### PR TITLE
Find Coin3 header files on Fedora.

### DIFF
--- a/cMake/FindCoin3D.cmake
+++ b/cMake/FindCoin3D.cmake
@@ -71,6 +71,7 @@ ELSE (WIN32)
    ELSE(APPLE)
 
   FIND_PATH(COIN3D_INCLUDE_DIR Inventor/So.h
+    /usr/include/Coin3
     /usr/include
     /usr/local/include
   )


### PR DESCRIPTION
This is necessary to build on Fedora 20.  I put complete instructions at http://blog.marcus-brinkmann.de/2014/02/22/compiling-freecad-on-fedora-20/
