### PR TITLE
3 point arc

### DIFF
--- a/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp
+++ b/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp
@@ -1411,7 +1411,7 @@ public:
 
             sketchgui->drawEdit(EditCurve);
             if (seekAutoConstraint(sugConstr3, onSketchPos, Base::Vector2D(0.0,0.0),
-                                   AutoConstraint::TargetType::CURVE)) {
+                                   AutoConstraint::CURVE)) {
                 renderSuggestConstraintsCursor(sugConstr3);
                 return;
             }


### PR DESCRIPTION
This fixes the 3 point arc tool so the 3rd point can auto-snap to either "tangent" or to "point on object".  The original tool is from this link.

I rebased to master tip.  Was it necessary to go to tip? Rebasing probably threw off anyone tracking my branch.

http://freecadweb.org/tracker/view.php?id=1475
