### PR TITLE
1659: Ignore space navigator events when FreeCAD is not the active window

### DIFF
--- a/src/Gui/GuiApplicationNativeEventAware.cpp
+++ b/src/Gui/GuiApplicationNativeEventAware.cpp
@@ -100,6 +100,9 @@ void Gui::GUIApplicationNativeEventAware::initSpaceball(QMainWindow *window)
 
 bool Gui::GUIApplicationNativeEventAware::processSpaceballEvent(QObject *object, QEvent *event)
 {
+    if (!activeWindow())
+        return true;
+
     QApplication::notify(object, event);
     if (event->type() == Spaceball::MotionEvent::MotionEventType)
     {


### PR DESCRIPTION
Check whether the freecad window is active before relaying the space navigator events.
