### PR TITLE
build: Fix invalid path to Spreadsheet.qrc file

### DIFF
--- a/src/Mod/Spreadsheet/CMakeLists.txt
+++ b/src/Mod/Spreadsheet/CMakeLists.txt
@@ -1,4 +1,4 @@
-PYSIDE_WRAP_RC(Spreadsheet_QRC_SRCS Resources/Spreadsheet.qrc)
+PYSIDE_WRAP_RC(Spreadsheet_QRC_SRCS Gui/Resources/Spreadsheet.qrc)
 
 add_subdirectory(App)
 if(BUILD_GUI)


### PR DESCRIPTION
cmake complains that Spreadsheet.qrc file cannot be found.