### PR TITLE
Add lib64 to python path

### DIFF
--- a/src/App/FreeCADInit.py
+++ b/src/App/FreeCADInit.py
@@ -47,6 +47,8 @@ def InitApplications():
 	BinDir = os.path.realpath(BinDir)
 	LibDir = FreeCAD.getHomePath()+'lib'
 	LibDir = os.path.realpath(LibDir)
+	Lib64Dir = FreeCAD.getHomePath()+'lib64'
+	Lib64Dir = os.path.realpath(Lib64Dir)
 	AddPath = FreeCAD.ConfigGet("AdditionalModulePaths").split(";")
 	HomeMod = FreeCAD.ConfigGet("UserAppData")+"Mod"
 	HomeMod = os.path.realpath(HomeMod)
@@ -102,6 +104,7 @@ def InitApplications():
 			else:
 				Log('Init:      Initializing ' + Dir + '(Init.py not found)... ignore\n')
 	sys.path.insert(0,LibDir)
+	sys.path.insert(0,Lib64Dir)
 	sys.path.insert(0,ModDir)
 	Log("Using "+ModDir+" as module path!\n")
 	# new paths must be prepended to avoid to load a wrong version of a library


### PR DESCRIPTION
On certain distributions the library directories are called "lib64" on
amd64 machines.