### PR TITLE
initial clean commit of adding CaeSolver and CaeAnalysis 

### DIFF
--- a/src/Mod/Fem/App/AppFem.cpp
+++ b/src/Mod/Fem/App/AppFem.cpp
@@ -52,6 +52,7 @@
 #include "FemConstraintPulley.h"
 
 #include "FemResultObject.h"
+#include "FemSolverObject.h"
 
 extern struct PyMethodDef Fem_methods[];
 
@@ -142,6 +143,8 @@ void AppFemExport initFem()
 
     Fem::FemResultObject            ::init();
     Fem::FemResultObjectPython      ::init();
+    Fem::FemSolverObject            ::init();
+    Fem::FemSolverObjectPython      ::init();
 }
 
 } // extern "C"

--- a/src/Mod/Fem/App/CMakeLists.txt
+++ b/src/Mod/Fem/App/CMakeLists.txt
@@ -110,6 +110,17 @@ SET(FemScripts_SRCS
     TaskPanelMechanicalAnalysis.ui
     TaskPanelMechanicalMaterial.ui
     TaskPanelShowDisplacement.ui
+
+    CaeAnalysis.py
+    CaeSolver.py
+    TaskPanelSolverControl.ui
+    CaeTools.py
+    FoamCfdSolver.py
+    ccxFemSolver.py
+    #FoamCaseWriter.py
+    CfdExample.py
+    _TaskPanelAnalysisControl.py
+    TaskPanelAnalysisControl.ui
 )
 #SOURCE_GROUP("Scripts" FILES ${FemScripts_SRCS})
 
@@ -141,6 +152,8 @@ SET(FemBase_SRCS
     FemMesh.h
     FemResultObject.cpp
     FemResultObject.h
+    FemSolverObject.cpp
+    FemSolverObject.h
     FemConstraint.cpp
     FemConstraint.h
     FemMeshProperty.cpp

--- a/src/Mod/Fem/App/FemSolverObject.cpp
+++ b/src/Mod/Fem/App/FemSolverObject.cpp
@@ -1,0 +1,97 @@
+/***************************************************************************
+ *   Copyright (c) 2013 J¨¹rgen Riegel (FreeCAD@juergen-riegel.net)        *
+ *   Copyright (c) 2015 Qingfeng Xia (FreeCAD@iesensor.com)                *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+
+#include "PreCompiled.h"
+
+#ifndef _PreComp_
+#endif
+
+#include "FemSolverObject.h"
+
+#include <Base/FileInfo.h>
+#include <App/FeaturePythonPyImp.h>
+#include <App/DocumentObjectPy.h>
+
+
+using namespace Fem;
+using namespace App;
+
+PROPERTY_SOURCE(Fem::FemSolverObject, App::DocumentObject)
+
+
+FemSolverObject::FemSolverObject()
+{
+
+    ADD_PROPERTY_TYPE(SolverName,("Calculix"), "Data",Prop_None,"Solver program name");
+    ADD_PROPERTY_TYPE(Category,("FEM"), "Data",Prop_None,"FEM, CFD ...");
+    ADD_PROPERTY_TYPE(Module,(""), "Data",Prop_None,"Python module name");
+    ADD_PROPERTY_TYPE(ExternalCaseEditor,(""), "Data",Prop_None,"External case editor programe");
+    ADD_PROPERTY_TYPE(ExternalResultViewer,(""), "Data",Prop_None,"External result viewer name");
+
+    ADD_PROPERTY_TYPE(AnalysisType,("Static"), "Solver",Prop_None,"Specific analysis type");
+    ADD_PROPERTY_TYPE(WorkingDir,(Base::FileInfo::getTempPath()), "Solver",Prop_None,"Solver working directory");
+    ADD_PROPERTY_TYPE(InputCaseName,("TestCase"), "Solver",Prop_None,"Solver input file without suffix");
+    ADD_PROPERTY_TYPE(Parallel,(false), "Solver",Prop_None,"Run solver in parallel like MPI");
+    ADD_PROPERTY_TYPE(ResultObtained,(false), "Solver",Prop_None,"if true, result has been obtained");
+}
+
+FemSolverObject::~FemSolverObject()
+{
+}
+
+short FemSolverObject::mustExecute(void) const
+{
+    return 0;
+}
+
+PyObject *FemSolverObject::getPyObject()
+{
+    if (PythonObject.is(Py::_None())){
+        // ref counter is set to 1
+        PythonObject = Py::Object(new DocumentObjectPy(this),true);
+    }
+    return Py::new_reference_to(PythonObject); 
+}
+
+// Python feature ---------------------------------------------------------
+
+namespace App {
+/// @cond DOXERR
+PROPERTY_SOURCE_TEMPLATE(Fem::FemSolverObjectPython, Fem::FemSolverObject)
+template<> const char* Fem::FemSolverObjectPython::getViewProviderName(void) const {
+    return "FemGui::ViewProviderSolverPython";
+}
+
+template<> PyObject* Fem::FemSolverObjectPython::getPyObject(void) {
+    if (PythonObject.is(Py::_None())) {
+        // ref counter is set to 1
+        PythonObject = Py::Object(new App::FeaturePythonPyT<App::DocumentObjectPy>(this),true);
+    }
+    return Py::new_reference_to(PythonObject);
+}
+
+// explicit template instantiation
+template class AppFemExport FeaturePythonT<Fem::FemSolverObject>;
+
+}

--- a/src/Mod/Fem/App/FemSolverObject.h
+++ b/src/Mod/Fem/App/FemSolverObject.h
@@ -1,0 +1,85 @@
+/***************************************************************************
+ *   Copyright (c) 2013 Jürgen Riegel (FreeCAD@juergen-riegel.net)         *
+ *   Copyright (c) 2015 Qingfeng Xia (FreeCAD@iesensor.com)                *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+
+#ifndef Fem_FemSolverObject_H
+#define Fem_FemSolverObject_H
+
+#include <App/DocumentObject.h>
+#include <App/PropertyUnits.h>
+#include <App/PropertyStandard.h>
+#include <App/FeaturePython.h>
+#include "FemSolverObject.h"
+
+namespace Fem
+{
+/// Father of all result data in a Fem Analysis
+class AppFemExport FemSolverObject : public App::DocumentObject
+{
+    PROPERTY_HEADER(Fem::FemSolverObject);
+
+public:
+    /// Constructor
+    FemSolverObject(void);
+    virtual ~FemSolverObject();
+
+    /// Solver name, unique to identify solver in registered_solver dict
+    App::PropertyString SolverName;
+    /// CAE category like FEM, all capitalised letters
+    App::PropertyString Category;
+    /// python module name
+    App::PropertyString Module;
+    /// Path or program name for external case editor, empty string means using FreeCAD to view
+    App::PropertyString ExternalCaseEditor;
+    /// Path to External Result Viewer like Paraview, empty string means using FreeCAD
+    App::PropertyString ExternalResultViewer;
+    
+    /// for FEM: Static, Frequency, etc
+    App::PropertyString AnalysisType;
+    /// Path of working dir for the solver
+    App::PropertyString WorkingDir;
+    /// name for the case file without suffix
+    App::PropertyString InputCaseName;
+    /// run parallel in MPI (message passing interface)/multiple cores or serial(single CPU)
+    App::PropertyBool Parallel;
+    /// result has been obtained, purge result may be needed for rerun
+    App::PropertyBool ResultObtained;
+
+    /// returns the type name of the ViewProvider
+    virtual const char* getViewProviderName(void) const {
+        return "FemGui::ViewProviderSolver";
+    }
+    virtual App::DocumentObjectExecReturn *execute(void) {
+        return App::DocumentObject::StdReturn;
+    }
+    virtual short mustExecute(void) const;
+    virtual PyObject *getPyObject(void);
+
+};
+
+typedef App::FeaturePythonT<FemSolverObject> FemSolverObjectPython;
+
+} //namespace Fem
+
+
+#endif // Fem_FemSolverObject_H

--- a/src/Mod/Fem/CMakeLists.txt
+++ b/src/Mod/Fem/CMakeLists.txt
@@ -61,6 +61,17 @@ INSTALL(
         _TaskPanelMechanicalMaterial.py
         TaskPanelMechanicalMaterial.ui
 
+	CaeAnalysis.py
+	CaeSolver.py
+	TaskPanelSolverControl.ui
+	CaeTools.py
+	FoamCfdSolver.py
+	ccxFemSolver.py
+	#FoamCaseWriter.py
+	CfdExample.py
+	_TaskPanelAnalysisControl.py
+	TaskPanelAnalysisControl.ui
+
     DESTINATION
         Mod/Fem
 )

--- a/src/Mod/Fem/CaeAnalysis.py
+++ b/src/Mod/Fem/CaeAnalysis.py
@@ -1,0 +1,239 @@
+#***************************************************************************
+#*                                                                         *
+#*   Copyright (c) 2015 - Qingfeng Xia <qingfeng.xia()eng.ox.ac.uk> *
+#*                                                                         *
+#*   This program is free software; you can redistribute it and/or modify  *
+#*   it under the terms of the GNU Lesser General Public License (LGPL)    *
+#*   as published by the Free Software Foundation; either version 2 of     *
+#*   the License, or (at your option) any later version.                   *
+#*   for detail see the LICENCE text file.                                 *
+#*                                                                         *
+#*   This program is distributed in the hope that it will be useful,       *
+#*   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+#*   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+#*   GNU Library General Public License for more details.                  *
+#*                                                                         *
+#*   You should have received a copy of the GNU Library General Public     *
+#*   License along with this program; if not, write to the Free Software   *
+#*   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
+#*   USA                                                                   *
+#*                                                                         *
+#***************************************************************************
+
+__title__ = "Command and Classes for New CAE Analysis"
+__author__ = "Qingfeng Xia"
+__url__ = "http://www.freecadweb.org"
+
+import FreeCAD
+from FemCommands import FemCommands
+
+if FreeCAD.GuiUp:
+    import FreeCADGui
+    import FemGui
+    from PySide import QtCore
+
+
+def makeMechanicalAnalysis(name):
+    '''makes a Fem MechAnalysis object'''
+    obj =  _CreateCaeAnalysis('Calculix', name)
+    obj.Type = "MechAnalysis"
+    return obj
+
+
+def _makeCaeAnalysis(name):
+    '''makeCaeAnalysis(name): makes a CAE Analysis object,
+    this is designed for internal usage only'''
+    obj = FreeCAD.ActiveDocument.addObject("Fem::FemAnalysisPython", name)
+    CaeAnalysis(obj)
+    if FreeCAD.GuiUp:
+        ViewProviderCaeAnalysis(obj.ViewObject)
+    #FreeCAD.ActiveDocument.recompute()
+    return obj
+
+
+class CaeAnalysis:
+    """The CaeAnalysis container object, serve CFD ,FEM, etc
+    This class should not have instance methods,
+    since document reload, this class's instance does not exist!
+    """
+    def __init__(self, obj):
+        self.Type = "CaeAnalysis"
+        self.Object = obj  # keep a ref to the DocObj for nonGui usage
+        obj.Proxy = self  # link between App::DocumentObject to  this object
+        obj.addProperty("App::PropertyString", "Category", "Analysis", "Cfd, Computional solid mechanics")
+        obj.addProperty("App::PropertyString", "SolverName", "Analysis", "External solver unique name")
+
+        # added from Oct 30, 2015, these properties should be added into FemSolverPython object: ccxFemSolver,
+        # FemTools.py  _AnalysisControlTaskPanel.py  also need change.
+        from FemTools import FemTools
+        fem_prefs = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/Fem")
+        obj.addProperty("App::PropertyEnumeration", "AnalysisType", "Fem", "Type of the analysis")
+        obj.AnalysisType = FemTools.known_analysis_types
+        analysis_type = fem_prefs.GetInt("AnalysisType", 0)
+        obj.AnalysisType = FemTools.known_analysis_types[analysis_type]
+        obj.addProperty("App::PropertyPath", "WorkingDir", "Fem", "Working directory for calculations")
+        obj.WorkingDir = fem_prefs.GetString("WorkingDir", "")
+
+        obj.addProperty("App::PropertyIntegerConstraint", "NumberOfEigenmodes", "Fem", "Number of modes for frequency calculations")
+        noe = fem_prefs.GetInt("NumberOfEigenmodes", 10)
+        obj.NumberOfEigenmodes = (noe, 1, 100, 1)
+
+        obj.addProperty("App::PropertyFloatConstraint", "EigenmodeLowLimit", "Fem", "Low frequency limit for eigenmode calculations")
+        #Not yet in prefs, so it will always default to 0.0
+        ell = fem_prefs.GetFloat("EigenmodeLowLimit", 0.0)
+        obj.EigenmodeLowLimit = (ell, 0.0, 1000000.0, 10000.0)
+
+        obj.addProperty("App::PropertyFloatConstraint", "EigenmodeHighLimit", "Fem", "High frequency limit for eigenmode calculations")
+        ehl = fem_prefs.GetFloat("EigenmodeHighLimit", 1000000.0)
+        obj.EigenmodeHighLimit = (ehl, 0.0, 1000000.0, 10000.0)
+
+    # following are the FeutureT standard methods
+    def execute(self, obj):
+        """updated Part should lead to recompute of mesh, if result_present"""
+        return
+
+    def onChanged(self, obj, prop):
+        """updated Part should lead to recompute of mesh"""
+        if prop in ["MaterialName"]:
+            return  # todo!
+
+    def __getstate__(self):
+        "store python attribute into FCStd file"
+        return self.Type
+
+    def __setstate__(self, state):
+        "restore python attribute from  FCStd file"
+        if state:
+            self.Type = state
+
+
+class ViewProviderCaeAnalysis:
+    """A View Provider for the CaeAnalysis container object
+    doubleClicked() should activate AnalysisControlTaskView
+    """
+    def __init__(self, vobj):
+        vobj.Proxy = self
+
+    def getIcon(self):
+        return ":/icons/fem-analysis.svg"
+
+    def setIcon(self,icon):
+        self.icon = icon
+
+    def attach(self, vobj):
+        self.ViewObject = vobj
+        self.Object = vobj.Object
+        self.bubbles = None
+
+    def updateData(self, obj, prop):
+        return
+
+    def onChanged(self, vobj, prop):
+        return
+
+    def doubleClicked(self, vobj):
+        if not FemGui.getActiveAnalysis() == self.Object:
+            if FreeCADGui.activeWorkbench().name() != 'FemWorkbench':
+                FreeCADGui.activateWorkbench("FemWorkbench")
+            FemGui.setActiveAnalysis(self.Object)
+            return True
+        else:
+            import _TaskPanelAnalysisControl
+            taskd = _TaskPanelAnalysisControl._TaskPanelAnalysisControl(self.Object)
+            FreeCADGui.Control.showDialog(taskd)
+        return True
+
+    def __getstate__(self):
+        return None
+
+    def __setstate__(self, state):
+        return None
+
+
+def _CreateCaeAnalysis(solverName, analysisName=None):
+        """ work for both Gui and nonGui mode"""
+        _analysisName = analysisName if analysisName else solverName + "Analysis"
+        if FreeCAD.GuiUp:
+            FreeCAD.ActiveDocument.openTransaction("Create Cae Analysis")
+            FreeCADGui.addModule("FemGui")
+            FreeCADGui.addModule("CaeAnalysis")
+            FreeCADGui.doCommand("CaeAnalysis._makeCaeAnalysis('{}')".format(_analysisName))
+            obj = FreeCAD.activeDocument().ActiveObject
+            FreeCADGui.doCommand("FemGui.setActiveAnalysis(App.activeDocument().ActiveObject)")
+            # create an solver and append into analysisObject
+            FreeCADGui.addModule("CaeSolver")
+            FreeCADGui.doCommand("CaeSolver.makeCaeSolver('{}')".format(solverName))
+            FreeCADGui.doCommand("FemGui.getActiveAnalysis().Member = FemGui.getActiveAnalysis().Member + [App.activeDocument().ActiveObject]")
+            sel = FreeCADGui.Selection.getSelection()
+            if (len(sel) == 1):
+                if(sel[0].isDerivedFrom("Fem::FemMeshObject")):
+                    FreeCADGui.doCommand("FemGui.getActiveAnalysis().ActiveObject.Member = FemGui.getActiveAnalysis().Member + [App.activeDocument()." + sel[0].Name + "]")
+                if(sel[0].isDerivedFrom("Part::Feature")):
+                    FreeCADGui.doCommand("App.activeDocument().addObject('Fem::FemMeshShapeNetgenObject', '" + sel[0].Name + "_Mesh')")
+                    FreeCADGui.doCommand("App.activeDocument().ActiveObject.Shape = App.activeDocument()." + sel[0].Name)
+                    FreeCADGui.doCommand("FemGui.getActiveAnalysis().Member = FemGui.getActiveAnalysis().Member + [App.activeDocument().ActiveObject]")
+                    #FreeCADGui.doCommand("Gui.activeDocument().hide('" + sel[0].Name + "')")
+                    #FreeCADGui.doCommand("App.activeDocument().ActiveObject.touch()")
+                    #FreeCADGui.doCommand("App.activeDocument().recompute()")
+                    FreeCADGui.doCommand("Gui.activeDocument().setEdit(App.ActiveDocument.ActiveObject.Name)")
+
+            #FreeCAD.ActiveDocument.commitTransaction()
+            FreeCADGui.Selection.clearSelection()
+        else:
+            import CaeAnalysis
+            obj = CaeAnalysis._makeCaeAnalysis(_analysisName)
+            import CaeSolver
+            sobj = CaeSolver.makeCaeSolver(solverName)
+            obj.Member = obj.Member + [sobj]
+        return obj
+
+
+class _CommandNewCfdAnalysis(FemCommands):
+    "the Cfd Analysis command definition"
+    def __init__(self):
+        super(_CommandNewCfdAnalysis, self).__init__()
+        self.resources = {'Pixmap': 'fem-cfd-analysis',
+                          'MenuText': QtCore.QT_TRANSLATE_NOOP("Fem_CfdAnalysis", "New CFD analysis"),
+                          'Accel': "N, A",  # conflict with mechanical analysis?
+                          'ToolTip': QtCore.QT_TRANSLATE_NOOP("Fem_CfdAnalysis", "Create a new computional fluid dynamics analysis")}
+        self.is_active = 'with_document'
+
+    def Activated(self):
+        _CreateCaeAnalysis('OpenFOAM')
+
+
+class _CommandNewMechAnalysis(FemCommands):
+    "the Mechancial FEM Analysis command definition"
+    def __init__(self):
+        super(_CommandNewMechAnalysis, self).__init__()
+        self.resources = {'Pixmap': 'fem-mech-analysis',
+                          'MenuText': QtCore.QT_TRANSLATE_NOOP("Fem_MechAnalysis", "New FEM Mechanical Analysis"),
+                          'Accel': "N, A",
+                          'ToolTip': QtCore.QT_TRANSLATE_NOOP("Fem_MechAnalysis", "Create a new Mechanical FEM Analysis")}
+        self.is_active = 'with_document'
+
+    def Activated(self):
+        _CreateCaeAnalysis('Calculix')
+
+
+class _CommandAnalysisControl(FemCommands):
+    "the Fem Analysis Job Control command definition"
+    def __init__(self):
+        super(_CommandAnalysisControl, self).__init__()
+        self.resources = {'Pixmap': 'fem-new-analysis',
+                          'MenuText': QtCore.QT_TRANSLATE_NOOP("Fem_AnalysisControl", "Start analysis"),
+                          'Accel': "S, C",
+                          'ToolTip': QtCore.QT_TRANSLATE_NOOP("Fem_AnalysisControl", "Dialog to start the calculation of the anlysis")}
+        self.is_active = 'with_analysis'
+
+    def Activated(self):
+        import _TaskPanelAnalysisControl
+        import FemGui
+        taskd = _TaskPanelAnalysisControl._TaskPanelAnalysisControl(FemGui.getActiveAnalysis())
+        taskd.update()
+        FreeCADGui.Control.showDialog(taskd)
+
+if FreeCAD.GuiUp:
+    FreeCADGui.addCommand('Fem_NewCfdAnalysis', _CommandNewCfdAnalysis())
+    FreeCADGui.addCommand('Fem_NewMechAnalysis', _CommandNewMechAnalysis())
+    FreeCADGui.addCommand('Fem_AnalysisControl', _CommandAnalysisControl())

--- a/src/Mod/Fem/CaeSolver.py
+++ b/src/Mod/Fem/CaeSolver.py
@@ -1,0 +1,118 @@
+#***************************************************************************
+#*                                                                         *
+#*   Copyright (c) 2015 - Qingfeng Xia @iesensor.com                 *
+#*                                                                         *
+#*   This program is free software; you can redistribute it and/or modify  *
+#*   it under the terms of the GNU Lesser General Public License (LGPL)    *
+#*   as published by the Free Software Foundation; either version 2 of     *
+#*   the License, or (at your option) any later version.                   *
+#*   for detail see the LICENCE text file.                                 *
+#*                                                                         *
+#*   This program is distributed in the hope that it will be useful,       *
+#*   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+#*   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+#*   GNU Library General Public License for more details.                  *
+#*                                                                         *
+#*   You should have received a copy of the GNU Library General Public     *
+#*   License along with this program; if not, write to the Free Software   *
+#*   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
+#*   USA                                                                   *
+#*                                                                         *
+#***************************************************************************
+
+import FreeCAD
+if FreeCAD.GuiUp:
+    import FemGui
+
+"""
+CaeSolver, implements a factory pattern to create concrete solver from name. 
+it should define and Abstract class CaeSolver , but it is Python there is no need declare a class doing nothing. 
+Concrete solver module should define  classes: CaeSover, ViewProviderCaeSolver, and SolverControlTaskPanel
+"""
+
+""" This list could be gen by python from preference page in the future,
+     each key has same name Property in Fem::FemSolverObjectPython
+"""
+REGISTERED_SOLVERS = {
+    "Calculix": {"SolverName": "Calculix", "Category": "FEM", "Module": "ccxFemSolver",
+                 "ExternalResultViewer": "", "ExternalCaseEditor": ""},
+    "OpenFOAM": {"SolverName": "OpenFOAM", "Category": "CFD", "Module": "FoamCfdSolver",
+                 "ExternalResultViewer": "paraFoam", "ExternalCaseEditor": ""}
+}
+
+
+def _setSolverInfo(solver_obj, solverInfo):
+    solver_obj.SolverName = solverInfo["SolverName"]
+    solver_obj.Category = solverInfo["Category"]
+    solver_obj.Module = solverInfo["Module"]
+    solver_obj.ExternalResultViewer = solverInfo["ExternalResultViewer"]
+    solver_obj.ExternalCaseEditor = solverInfo["ExternalCaseEditor"]
+
+
+def makeCaeSolver(solverName, analysis=None):
+    """CaeSolver Factory method, solverName string  "Calculix" "Openfoam"
+    """
+    if (solverName is not None) and solverName in REGISTERED_SOLVERS.keys():
+        solverInfo = REGISTERED_SOLVERS[solverName]
+        obj = _createCaeSolver(solverInfo, analysis)
+        _setSolverInfo(obj, solverInfo)
+    else:
+        raise Exception('Solver: {} is not registered or found'.format(solverName))
+
+
+def _createCaeSolver(solverInfo, analysis=None, solver_object=None):
+    if FreeCAD.GuiUp:
+        if (analysis is not None) and analysis.isDerivedFrom("Fem::FemAnalysisObject"):
+            _analysis = analysis
+        else:
+            _analysis = FemGui.getActiveAnalysis()
+    else:
+        if (analysis is not None) and  analysis.isDerivedFrom("Fem::FemAnalysisObject"):
+            _analysis = analysis
+        else:
+            raise Exception('Analysis obj is not the valid type of Fem::FemAnalysisObject')
+
+    if solver_object is None:
+        obj = FreeCAD.ActiveDocument.addObject("Fem::FemSolverObjectPython", solverInfo["SolverName"])
+        FreeCAD.Console.PrintMessage("Solver {} is created\n".format(solverInfo["SolverName"]))
+    else:
+        obj = solver_object
+
+    import importlib  # works for python 2.7 and 3.x
+    mod = importlib.import_module(solverInfo["Module"])
+    mod.CaeSolver(obj)
+    if FreeCAD.GuiUp:
+        mod.ViewProviderCaeSolver(obj.ViewObject)
+    _analysis.Member = _analysis.Member + [obj]
+
+    _analysis.Category = solverInfo["Category"]
+    _analysis.SolverName = solverInfo["SolverName"]
+
+    return obj
+
+"""
+# Currently, one analysis has only one solver, once analysis is created, solver is added auto
+class _CommandNewCaeSolver:
+    def GetResources(self):
+        return {'Pixmap': 'fem-solver',
+                'MenuText': QtCore.QT_TRANSLATE_NOOP("Fem_Solver", "Create solver"),
+                'Accel': "S, R",
+                'ToolTip': QtCore.QT_TRANSLATE_NOOP("Fem_Solver", "Create a solver object to an analysis")}
+
+    def Activated(self):
+        #
+        if not self.solver_object:
+            QtGui.QMessageBox.critical(None, "Missing prerequisite", "No solver is created in active Analysis")
+            return
+        # pop a dialog to select solver from combobox, not implemented yet! 
+        #_CreateCaeSolver(solverInfo)
+        #import _SolverControlTaskPanel
+        #taskd = _SolverControlTaskPanel._ResultControlTaskPanel()
+        #FreeCADGui.Control.showDialog(taskd)
+
+    def IsActive(self):
+        return FreeCADGui.ActiveDocument is not None and solver_present()
+
+if FreeCAD.GuiUp:
+    FreeCADGui.addCommand('Fem_CreateSolver', _CommandNewCaeSolver())
+"""

--- a/src/Mod/Fem/CaeTools.py
+++ b/src/Mod/Fem/CaeTools.py
@@ -1,6 +1,7 @@
 #***************************************************************************
 #*                                                                         *
-#*   Copyright (c) 2015 - Qingfeng Xia <qingfeng.xia()eng.ox.ac.uk> *
+#*   Copyright (c) 2015 - FreeCAD Developers                               *
+#*   Author (c) 2015 - Qingfeng Xia <qingfeng xia eng.ox.ac.uk>                    *
 #*                                                                         *
 #*   This program is free software; you can redistribute it and/or modify  *
 #*   it under the terms of the GNU Lesser General Public License (LGPL)    *
@@ -20,29 +21,42 @@
 #*                                                                         *
 #***************************************************************************
 
-"""API for compatibility
-import CaeAnalysis
-import FreeCAD
-
-def makeMechanicalAnalysis(name):
-    '''makes a Fem MechAnalysis object'''
-    obj = CaeAnalysis._CreateCaeAnalysis('Calculix', name)
+"""
+This file provides utility functions, not belong to any python class
+Since python object will not be saved, reference to python object's instance will fail!
 """
 
-import FreeCAD
 
-__title__ = "Mechanical Analysis managment"
-__author__ = "Juergen Riegel"
-__url__ = "http://www.freecadweb.org"
+def getMesh(analysis_object):
+    for i in analysis_object.Member:
+        if i.isDerivedFrom("Fem::FemMeshObject"):
+            return i
+    # python will return None by default, so check None outside
 
 
-def makeMechanicalAnalysis(name):
-    '''makeFemAnalysis(name): makes a Fem Analysis object'''
-    obj = FreeCAD.ActiveDocument.addObject("Fem::FemAnalysisPython", name)
-    import _FemAnalysis
-    _FemAnalysis._FemAnalysis(obj)
-    import _ViewProviderFemAnalysis
-    _ViewProviderFemAnalysis._ViewProviderFemAnalysis()
-    #FreeCAD.ActiveDocument.recompute()
-    return obj
+def getSolver(analysis_object):
+    for i in analysis_object.Member:
+        if i.isDerivedFrom("Fem::FemSolverObject"):
+            return i
+        print("Error: No solver object is found from this analysis_object")
 
+
+def getSolverPythonFromAnalysis(analysis_object):
+    solver = getSolver(analysis_object)
+    if solver is not None:
+        try:
+            pobj = solver.Proxy
+            return pobj
+        finally:
+            import CaeSolver
+            solverInfo = CaeSolver.REGISTERED_SOLVERS[solver.SolverName]
+            obj = CaeSolver._createCaeSolver(solverInfo, analysis_object, solver)
+            return obj.Proxy
+
+
+def getConstraintGroup(analysis_object):
+    group = []
+    for i in analysis_object.Member:
+        if i.isDerivedFrom("Fem::Constraint"):
+            group.append(i)
+    return group

--- a/src/Mod/Fem/CfdExample.py
+++ b/src/Mod/Fem/CfdExample.py
@@ -1,0 +1,78 @@
+#***************************************************************************
+#*                                                                         *
+#*   Copyright (c) 2015 - Qingfeng Xia @iesensor.com                 *
+#*                                                                         *
+#*   This program is free software; you can redistribute it and/or modify  *
+#*   it under the terms of the GNU Lesser General Public License (LGPL)    *
+#*   as published by the Free Software Foundation; either version 2 of     *
+#*   the License, or (at your option) any later version.                   *
+#*   for detail see the LICENCE text file.                                 *
+#*                                                                         *
+#*   This program is distributed in the hope that it will be useful,       *
+#*   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+#*   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+#*   GNU Library General Public License for more details.                  *
+#*                                                                         *
+#*   You should have received a copy of the GNU Library General Public     *
+#*   License along with this program; if not, write to the Free Software   *
+#*   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
+#*   USA                                                                   *
+#*                                                                         *
+#***************************************************************************
+
+App.newDocument("Unnamed")
+App.setActiveDocument("Unnamed")
+App.ActiveDocument=App.getDocument("Unnamed")
+Gui.ActiveDocument=Gui.getDocument("Unnamed")
+#
+Gui.activateWorkbench("PartWorkbench")
+App.ActiveDocument.addObject("Part::Cylinder","Cylinder")
+App.ActiveDocument.ActiveObject.Label = "Cylinder"
+App.ActiveDocument.recompute()
+Gui.SendMsgToActiveView("ViewFit")
+Gui.activateWorkbench("FemWorkbench")
+#
+App.activeDocument().addObject('Fem::FemMeshShapeNetgenObject', 'Cylinder_Mesh')
+App.activeDocument().ActiveObject.Shape = App.activeDocument().Cylinder
+Gui.activeDocument().setEdit(App.ActiveDocument.ActiveObject.Name)
+Gui.activeDocument().resetEdit()
+#
+import FemGui
+import CaeAnalysis
+import CaeSolver
+CaeAnalysis._makeCaeAnalysis("OpenFOAMAnalysis")
+FemGui.setActiveAnalysis(App.activeDocument().ActiveObject)
+CaeSolver.makeCaeSolver('OpenFOAM')
+#
+Gui.getDocument("Unnamed").getObject("Cylinder_Mesh").Visibility=False
+Gui.getDocument("Unnamed").getObject("Cylinder").Visibility=True
+#pressure inlet
+import MechanicalMaterial
+MechanicalMaterial.makeMechanicalMaterial('MechanicalMaterial')
+App.activeDocument().OpenFOAMAnalysis.Member = App.activeDocument().OpenFOAMAnalysis.Member + [App.ActiveDocument.ActiveObject]
+Gui.activeDocument().setEdit(App.ActiveDocument.ActiveObject.Name,0)
+#
+App.activeDocument().addObject("Fem::ConstraintPressure","FemConstraintPressure")
+App.activeDocument().FemConstraintPressure.Pressure = 0.0
+App.activeDocument().OpenFOAMAnalysis.Member = App.activeDocument().OpenFOAMAnalysis.Member + [App.activeDocument().FemConstraintPressure]
+App.ActiveDocument.recompute()
+Gui.activeDocument().setEdit('FemConstraintPressure')
+App.ActiveDocument.FemConstraintPressure.Pressure = 0.010000
+App.ActiveDocument.FemConstraintPressure.Reversed = False
+App.ActiveDocument.FemConstraintPressure.References = [(App.ActiveDocument.Cylinder,"Face3")]
+App.ActiveDocument.recompute()
+Gui.activeDocument().resetEdit()
+#pressure outlet
+App.activeDocument().addObject("Fem::ConstraintPressure","FemConstraintPressure001")
+App.activeDocument().FemConstraintPressure001.Pressure = 0.0
+App.activeDocument().OpenFOAMAnalysis.Member = App.activeDocument().OpenFOAMAnalysis.Member + [App.activeDocument().FemConstraintPressure001]
+App.ActiveDocument.recompute()
+Gui.activeDocument().setEdit('FemConstraintPressure001')
+App.ActiveDocument.FemConstraintPressure001.Pressure = 0.000010
+App.ActiveDocument.FemConstraintPressure001.Reversed = True
+App.ActiveDocument.FemConstraintPressure001.References = [(App.ActiveDocument.Cylinder,"Face2")]
+App.ActiveDocument.recompute()
+Gui.activeDocument().resetEdit()
+#
+
+

--- a/src/Mod/Fem/CfdTools.py
+++ b/src/Mod/Fem/CfdTools.py
@@ -1,0 +1,5 @@
+
+
+
+#once the saved document is loaded, python object is None, so new one such solver!
+    

--- a/src/Mod/Fem/FemCommands.py
+++ b/src/Mod/Fem/FemCommands.py
@@ -45,7 +45,7 @@ class FemCommands(object):
         def GetResources(self):
             return self.resources
 
-        def IsActive(self):
+        def IsActive(self): 
             if not self.is_active:
                 active = False
             elif self.is_active == 'with_document':

--- a/src/Mod/Fem/FemExample.py
+++ b/src/Mod/Fem/FemExample.py
@@ -1,13 +1,92 @@
-# Example hwo to use the basic fem classes. The Fem module is  dependend on Part but nor on other Modules.
-# So we need only:
-from Fem import *
-from Part import *
-from FreeCAD import *
+#***************************************************************************
+#*                                                                         *
+#*   Copyright (c) 2015 - FreeCAD Developers                               *
+#*   Author (c) 2015 - Qingfeng Xia <qingfeng xia eng.ox.ac.uk>                    *
+#*                                                                         *
+#*   This program is free software; you can redistribute it and/or modify  *
+#*   it under the terms of the GNU Lesser General Public License (LGPL)    *
+#*   as published by the Free Software Foundation; either version 2 of     *
+#*   the License, or (at your option) any later version.                   *
+#*   for detail see the LICENCE text file.                                 *
+#*                                                                         *
+#*   This program is distributed in the hope that it will be useful,       *
+#*   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+#*   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+#*   GNU Library General Public License for more details.                  *
+#*                                                                         *
+#*   You should have received a copy of the GNU Library General Public     *
+#*   License along with this program; if not, write to the Free Software   *
+#*   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
+#*   USA                                                                   *
+#*                                                                         *
+#***************************************************************************
 
-m = FemMesh()
-m.NodeCount
 
-b = makeBox(10,10,10)
-m.setShape(b)
+"""This file can be pasted into FemWorkbench's python console for testing
+Material and Mesh need redo in GUI to work, since GUI operation is not recorded fully
+"""
 
-m.NodeCount
+
+App.newDocument("Unnamed")
+App.setActiveDocument("Unnamed")
+App.ActiveDocument=App.getDocument("Unnamed")
+Gui.ActiveDocument=Gui.getDocument("Unnamed")
+
+# copy from this line, if you want to create both CFD and FEM analysise
+
+App.ActiveDocument.addObject("Part::Box","Box")
+App.ActiveDocument.ActiveObject.Label = "Cube"
+App.ActiveDocument.recompute()
+Gui.SendMsgToActiveView("ViewFit")
+#
+FreeCAD.getDocument("Unnamed").getObject("Box").Length = '20 mm'
+FreeCAD.getDocument("Unnamed").getObject("Box").Width = '20 mm'
+FreeCAD.getDocument("Unnamed").getObject("Box").Height = '20 mm'
+#
+Gui.activateWorkbench("FemWorkbench")
+import FemGui
+App.activeDocument().addObject('Fem::FemMeshShapeNetgenObject', 'Box_Mesh')
+App.activeDocument().ActiveObject.Shape = App.activeDocument().Box
+Gui.activeDocument().setEdit(App.ActiveDocument.ActiveObject.Name)
+Gui.activeDocument().resetEdit()
+#
+#import MechanicalAnalysis #deprecated
+#FemGui.setActiveAnalysis(MechanicalAnalysis.makeMechanicalAnalysis('MechanicalAnalysis'))
+import CaeAnalysis  #using NEW API for mech analysis
+FemGui.setActiveAnalysis(CaeAnalysis.makeMechanicalAnalysis('MechanicalAnalysis'))
+FemGui.getActiveAnalysis().Member = FemGui.getActiveAnalysis().Member + [App.activeDocument().Box_Mesh]
+
+import MechanicalMaterial
+MechanicalMaterial.makeMechanicalMaterial('MechanicalMaterial')
+App.activeDocument().MechanicalAnalysis.Member = App.activeDocument().MechanicalAnalysis.Member + [App.ActiveDocument.ActiveObject]
+Gui.activeDocument().setEdit(App.ActiveDocument.ActiveObject.Name,0)
+
+App.activeDocument().addObject("Fem::ConstraintFixed","FemConstraintFixed")
+App.activeDocument().MechanicalAnalysis.Member = App.activeDocument().MechanicalAnalysis.Member + [App.activeDocument().FemConstraintFixed]
+App.ActiveDocument.recompute()
+Gui.activeDocument().setEdit('FemConstraintFixed')
+App.ActiveDocument.FemConstraintFixed.References = [(App.ActiveDocument.Box,"Face6")]
+App.ActiveDocument.recompute()
+Gui.activeDocument().resetEdit()
+App.activeDocument().addObject("Fem::ConstraintForce","FemConstraintForce")
+App.activeDocument().FemConstraintForce.Force = 0.0
+App.activeDocument().MechanicalAnalysis.Member = App.activeDocument().MechanicalAnalysis.Member + [App.activeDocument().FemConstraintForce]
+App.ActiveDocument.recompute()
+Gui.activeDocument().setEdit('FemConstraintForce')
+App.ActiveDocument.FemConstraintForce.Force = 0.000000
+App.ActiveDocument.FemConstraintForce.Direction = None
+App.ActiveDocument.FemConstraintForce.Reversed = False
+App.ActiveDocument.FemConstraintForce.References = [(App.ActiveDocument.Box,"Face5")]
+App.ActiveDocument.recompute()
+App.ActiveDocument.FemConstraintForce.Force = 5000.000000
+App.ActiveDocument.FemConstraintForce.Direction = None
+App.ActiveDocument.FemConstraintForce.Reversed = False
+App.ActiveDocument.FemConstraintForce.References = [(App.ActiveDocument.Box,"Face4")]
+App.ActiveDocument.recompute()
+Gui.activeDocument().resetEdit()
+
+Gui.getDocument("Unnamed").getObject("Box_Mesh").Visibility=False
+Gui.getDocument("Unnamed").getObject("Box").Visibility=True
+#
+#need to select material, and refine mesh before solve, or you will got ERROR!!!
+#

--- a/src/Mod/Fem/FoamCaseWriter.py
+++ b/src/Mod/Fem/FoamCaseWriter.py
@@ -1,0 +1,197 @@
+# ***************************************************************************
+# *                                                                         *
+# *   Copyright (c) 2015 - Qingfeng Xia <qingfeng.xia eng ox ac uk>                 *       *
+# *                                                                         *
+# *   This program is free software; you can redistribute it and/or modify  *
+# *   it under the terms of the GNU Lesser General Public License (LGPL)    *
+# *   as published by the Free Software Foundation; either version 2 of     *
+# *   the License, or (at your option) any later version.                   *
+# *   for detail see the LICENCE text file.                                 *
+# *                                                                         *
+# *   This program is distributed in the hope that it will be useful,       *
+# *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+# *   GNU Library General Public License for more details.                  *
+# *                                                                         *
+# *   You should have received a copy of the GNU Library General Public     *
+# *   License along with this program; if not, write to the Free Software   *
+# *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
+# *   USA                                                                   *
+# *                                                                         *
+# ***************************************************************************
+
+import FreeCAD
+import os
+import sys
+import time
+
+__title__ = "FoamCaseWriter"
+__author__ = "Qingfeng Xia"
+__url__ = "http://www.freecadweb.org"
+
+import FreeCAD
+import os.path
+
+"""
+Mesh object can not update without click
+pyFoamClearCase.py
+SetField  BoxToFace BoundingBox  runApplication setFields
+"""
+
+#from pyfoam import
+from subprocess import Popen, PIPE, ProcessException
+
+
+def launch_cmdline(cmdline):
+    process = Popen([].append(cmdline), stdout=PIPE, stderr=PIPE)
+    stdout, stderr = process.communicate()
+    exitCode = process.returncode
+
+    if (exitCode == 0):
+        print stdout
+    else:
+        print stdout
+        print stderr
+        raise ProcessException(cmdline, exitCode)
+
+
+def write_bc_faces(unv_mesh_file, bc_id, bc_objects):
+    FreeCAD.Console.PrintMessage('write face_set or patches for boundary\n')
+    f = unv_mesh_file
+    facet_list = []
+    for fobj in bc_objects:
+        bc_obj = fobj['Object']
+        for o, e in bc_obj.References:
+            elem = o.Shape.getElement(e)
+            if elem.ShapeType == 'Face':  # CFD study heeds only 2D face boundary for 3D model, normally
+                ret = mesh_object.FemMesh.getVolumesByFace(elem)
+                # return a list of tuple (vol->GetID(), face->GetID())
+                facet_list.append([i[1] for i in ret])
+    nr_facets = len(facet_list)
+    f.writeline("{:>10d}         0         0         0         0         0         0{:>10d}".format(bc_id,  nr_facets))
+    f.writeline(bc_objects.Name)
+    for i in int(nr_facets/2):
+        f.write("         8{:>10d}         0         0         ".format(facet_list[2*i].id))
+        f.writeline("         8{:>10d}         0         0         ".format(facet_list[2*i+1].id))
+    if nr_facets%2:
+        f.writeline("         8{:>10d}         0         0         ".format(facet_list[-1].id))
+
+def set_bc_velocity(bc):
+    """ignored in phase I"""
+    pass
+
+
+def set_bc_pressure(bc):
+    """rev = -1 if prs_obj.Reversed else 1 #inlet and outlet"""
+    pass
+
+
+def set_bc_temperature(bc):
+    """ignored in phase I"""
+    pass
+
+
+def write_bc_wall(bc):
+    pass
+
+
+def create_empty_case(zipped_template_file,output_path):
+    """copy or command to generate an empty case folder structure"""
+    import zipfile
+    with zipfile.ZipFile(zipped_template_file, "r") as z:
+        z.extractall(output_path)
+    # remove old case and mesh? auto replace without warning
+
+
+def is_solid_mesh(fem_mesh):
+    if fem_mesh.VolumeCount > 0:  # solid mesh
+        return True
+
+
+class SolverCaseWriter:
+    """write_case() is the only public API
+    """
+    def __init__(self, analysis_obj):
+        """analysis_obj should contains all the information needed,
+        boundaryConditionList is a list of all boundary Conditions objects(FemConstraint)
+        """
+        self.analysis_obj = analysis_obj
+        self.solver_obj = CaeTools.getSolver(analysis_obj)
+        self.mesh_obj = CaeTools.getMesh(analysis_obj)
+        self.bc_group = CaeTools.getConstraintGroup(analysis_obj)
+        self.mesh_generatd = False
+
+    def write_case(self):
+        QApplication.setOverrideCursor(Qt.WaitCursor)
+        try:
+            create_empty_case(FreeCAD.getHomePath() + "/Mod/Fem/icoFoam_case_template.zip", self.working_dir+os.path.sep+self.solver_obj.InputCaseName)
+            self.write_mesh()
+            self.write_material()
+            self.write_boundary_condition()
+            # solver control: time,
+            self.write_solver_control()
+            self.write_time_control()
+        finally:
+            QApplication.restoreOverrideCursor()
+        FreeCAD.Console.PrintMessage("Sucessfully write {} case to folder".format(self.solver_object.Name, self.working_dir))
+
+    def write_bc_mesh(self, unv_mesh_file):
+        FreeCAD.Console.PrintMessage('write face_set or patches for boundary\n')
+        f=open(unv_mesh_file,'a')   # appending bc to the volume mesh, which contains node and element definition, ends with '-1' 
+        f.writeline("{:6d}".format(-1))  # start of a section 
+        f.writeline("{:6d}".format(2467))  # group section 
+        for bc_number, bc_obj in enumerate(self.bcgroup):
+            write_bc_faces(f, bc_number+1, bc_obj)
+        f.writeline("{:6d}".format(-1))  # end of a section 
+        f.writeline("{:6d}".format(-1))  # end of file
+        f.close()
+
+    def write_mesh(self, mesh_obj=None):
+        """This is FreeCAD specific code"""
+        if mesh_obj == None:
+            mesh_obj = self.mesh_obj
+        __objs__ = []
+        __objs__.append(mesh_obj)
+        import Fem
+        mesh_file_name = self.solver_obj.WorkingDir + os.path.sep + self.solver_obj.CaseInputFile + u".unv"
+        Fem.export(__objs__, mesh_file_name)
+        del __objs__
+
+        # repen this unv file and write the boundary faces
+        write_bc_mesh(self, mesh_file_name)
+
+        # convert from UNV to OpenFoam
+        cmdline="ideasUnvToFoam -case {}  {}".format(self.solver_obj.WorkingDir, self.solver_obj.CaseInputFile + u".unv")
+        # icoFoam -case WorkingDir/case_file_name
+        launch_cmdline(cmdline)
+        FreeCAD.Console.PrintMessage('mesh file {} converted\n'.format(mesh_file_name))
+        self.mesh_generatd = True
+
+    def write_material(self, material=None):
+        """Air, Water, CustomedFluid, first step, default to Air"""
+        pass
+
+    def write_boundary_condition(self, bcgroup):
+        """switch case to deal diff boundary condition, mapping FEM constrain to CFD boundary conditon
+        thermal BC must be defined, heat flux and or fixed temperature
+        volume force / load? 
+        """
+        for bc in bcgroup:
+            if bc.isDerivedFrom("Fem::FemConstraintPressure"):  # pressure inlet or outlet (revsered = True)
+                set_bc_pressure()
+            elif bc.isDerivedFrom("Fem::FemConstraintForce"):  # velocity
+                set_bc_velocity()
+            elif bc.isDerivedFrom("Fem::FemConstraintFixed"):  # wall
+                set_bc_wall()
+            else:
+                FreeCAD.Console.PrintMessage('boundary condition not supported yet\n')
+        # non-group boundary surface should be wall, print a warning msg
+
+    def write_solver_control(self):
+        """ 
+        """
+        pass
+
+    def write_time_control(self):
+        if self.solver_obj.Transient == False:
+            pass

--- a/src/Mod/Fem/FoamCfdSolver.py
+++ b/src/Mod/Fem/FoamCfdSolver.py
@@ -1,0 +1,163 @@
+#***************************************************************************
+#*                                                                         *
+#*   Copyright (c) 2015 - Qingfeng Xia <qingfeng.xia()eng.ox.ac.uk> *
+#*                                                                         *
+#*   This program is free software; you can redistribute it and/or modify  *
+#*   it under the terms of the GNU Lesser General Public License (LGPL)    *
+#*   as published by the Free Software Foundation; either version 2 of     *
+#*   the License, or (at your option) any later version.                   *
+#*   for detail see the LICENCE text file.                                 *
+#*                                                                         *
+#*   This program is distributed in the hope that it will be useful,       *
+#*   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+#*   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+#*   GNU Library General Public License for more details.                  *
+#*                                                                         *
+#*   You should have received a copy of the GNU Library General Public     *
+#*   License along with this program; if not, write to the Free Software   *
+#*   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
+#*   USA                                                                   *
+#*                                                                         *
+#***************************************************************************
+
+__title__ = "Command and Classes for New CAE Analysis"
+__author__ = "Qingfeng Xia"
+__url__ = "http://www.freecadweb.org"
+
+import os.path
+
+import FreeCAD
+if FreeCAD.GuiUp:
+    import FreeCADGui
+    from PySide import QtCore, QtGui
+
+
+TurbulenceModelList = ["Laminar", "KE", "KW", "LES"]
+AnalysisTypeList = []
+
+
+class CaeSolver():
+    """Fem::FemSolverObject 's Proxy python type
+    add solver specific properties, methods and bring up SolverControlTaskPanel.
+    After loaded from FCStd file, this python class is not instantiated.
+    use CaeTools.getSolverPythonFromAnalysis() to get/create such an instance.
+    """
+    def __init__(self, obj):
+        self.Type = "CfdSolver"
+        self.Object = obj  # keep a ref to the DocObj for nonGui usage
+        obj.Proxy = self  # link between App::DocumentObject to  this object
+
+        # general CFD properties, if there are not existant for newly create FemSolverObj, adProperty
+        if not "Compressible" in obj.PropertiesList:
+            # API: addProperty(self,type,name='',group='',doc='',attr=0,readonly=False,hidden=False)
+            obj.addProperty("App::PropertyEnumeration", "TurbulenceModel", "CFD",
+                            "Laminar,KE,KW,LES,")
+            obj.TurbulenceModel = TurbulenceModelList
+            obj.addProperty("App::PropertyBool", "Compressible", "CFD",
+                            "Compressible air or Incompressible like liquid")
+            obj.addProperty("App::PropertyBool", "ThermalAnalysisEnabled", "CFD",
+                             "calc heat transfering")
+            obj.addProperty("App::PropertyBool", "Transient", "CFD",
+                            "static or transient analysis")
+            # CurrentTime TimeStep StartTime, StopTime
+
+            # adding solver specific properties
+        # FemSolverObject standard properties should be set in _SetSolverInfo() of CaeSolver.py
+
+    ########## CaeSolver API #####################
+    def check_prerequisites(self, analysis_object):
+        return ""
+
+    def write_case(self, analysis_object=None):
+        if analysis_object is None and FreeCAD.GuiUp:
+            import FemGui
+            analysis_object = FemGui.getActiveAnalysis()
+        import FoamCaseWriter
+        writer = FoamCaseWriter.FoamCaseWriter(analysis_object)
+        writer.write_mesh()
+
+
+    def generate_cmdline(self):
+        return "icoFoam -help"  # try to use abs path for case name file/folder
+
+    def edit_case_externally(self):
+        case_path = self.Object.WorkingDir + os.path.sep + self.Object.InputCaseName
+        if FreeCAD.GuiUp:
+            QtGui.QDesktopServices.openUrl(QtCore.QUrl(case_path))
+
+    def view_result_externally(self):
+        return "paraFoam {}".format(self.Object.InputCaseName)
+
+    ############ standard FeutureT methods ##########
+    def execute(self, obj):
+        """"this method is executed on object creation and whenever the document is recomputed"
+        update Part or Mesh should NOT lead to recompution of the analysis automatically, time consuming"""
+        return
+
+    def onChanged(self, obj, prop):
+        return
+
+    def __getstate__(self):
+        return self.Type
+
+    def __setstate__(self, state):
+        if state:
+            self.Type = state
+
+
+# this class could be moved into CaeSolver, as it can be shared by any solver
+class ViewProviderCaeSolver:
+    """A View Provider for the Solver object, base class for all derived solver
+    derived solver should implement  a specific TaskPanel and set up solver and override setEdit()"""
+
+    def __init__(self, vobj):
+        vobj.Proxy = self
+
+    def getIcon(self):
+        """after load from FCStd file, self.icon does not exist, return constant path instead"""
+        return ":/icons/fem-solver.svg"
+
+    def attach(self, vobj):
+        self.ViewObject = vobj
+        self.Object = vobj.Object
+
+    def updateData(self, obj, prop):
+        return
+
+    def onChanged(self, vobj, prop):
+        return
+
+    def doubleClicked(self, vobj):
+        """after load from FCStd file, self.Object does not exist, use vobj.Object instead"""
+        # from solver_specific module import _SolverControlTaskPanel
+        taskd = _TaskPanelSolverControl(vobj.Object)
+        FreeCADGui.Control.showDialog(taskd)
+        return True
+
+    def setEdit(self, vobj, mode):
+        taskd = _TaskPanelSolverControl(vobj.Object)
+        FreeCADGui.Control.showDialog(taskd)
+        return True
+
+    def unsetEdit(self, vobj, mode):
+        #FreeCADGui.Control.closeDialog()
+        return
+
+    def __getstate__(self):
+        return None
+
+    def __setstate__(self, state):
+        return None
+
+
+class _TaskPanelSolverControl:
+    def __init__(self, solver_object):
+        self.form = FreeCADGui.PySideUic.loadUi(FreeCAD.getHomePath() + "Mod/Fem/TaskPanelSolverControl.ui")
+        #QtGui.QMessageBox.critical(None, "This task panel is not implement yet", "Please edit in property editor ")
+        pass
+
+    def accept(self):
+        return True
+
+    def reject(self):
+        return True

--- a/src/Mod/Fem/Gui/AppFemGui.cpp
+++ b/src/Mod/Fem/Gui/AppFemGui.cpp
@@ -37,6 +37,7 @@
 #include "ViewProviderFemMeshShape.h"
 #include "ViewProviderFemMeshShapeNetgen.h"
 #include "ViewProviderAnalysis.h"
+#include "ViewProviderSolver.h"
 #include "ViewProviderSetNodes.h"
 #include "ViewProviderSetElements.h"
 #include "ViewProviderSetFaces.h"
@@ -88,6 +89,8 @@ void FemGuiExport initFemGui()
     FemGui::ViewProviderFemMesh                ::init();
     FemGui::ViewProviderFemMeshShape           ::init();
     FemGui::ViewProviderFemMeshShapeNetgen     ::init();
+    FemGui::ViewProviderSolver                 ::init();
+    FemGui::ViewProviderSolverPython           ::init();
     FemGui::ViewProviderSetNodes               ::init();
     FemGui::ViewProviderSetElements            ::init();
     FemGui::ViewProviderSetFaces               ::init();

--- a/src/Mod/Fem/Gui/CMakeLists.txt
+++ b/src/Mod/Fem/Gui/CMakeLists.txt
@@ -116,6 +116,8 @@ SET(FemGui_SRCS_ViewProvider
     ViewProviderFemMeshShapeNetgen.h
     ViewProviderAnalysis.cpp
     ViewProviderAnalysis.h
+    ViewProviderSolver.cpp
+    ViewProviderSolver.h
     ViewProviderSetNodes.cpp
     ViewProviderSetNodes.h
     ViewProviderSetElements.cpp

--- a/src/Mod/Fem/Gui/Resources/Fem.qrc
+++ b/src/Mod/Fem/Gui/Resources/Fem.qrc
@@ -3,6 +3,9 @@
         <file>icons/fem-fem-mesh-from-shape.svg</file>
         <file>icons/fem-fem-mesh-create-node-by-poly.svg</file>
         <file>icons/fem-analysis.svg</file>
+        <file>icons/fem-cfd-analysis.svg</file>
+        <file>icons/fem-mech-analysis.svg</file>
+        <file>icons/fem-solver.svg</file>
         <file>icons/fem-constraint-force.svg</file>
         <file>icons/fem-constraint-fixed.svg</file>
         <file>icons/fem-constraint-pressure.svg</file>

--- a/src/Mod/Fem/Gui/Resources/icons/fem-cfd-analysis.svg
+++ b/src/Mod/Fem/Gui/Resources/icons/fem-cfd-analysis.svg
@@ -1,0 +1,135 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="64px"
+   height="64px"
+   id="svg2860"
+   sodipodi:version="0.32"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="fem-cfd-analysis.svg"
+   inkscape:output_extension="org.inkscape.output.svg.inkscape"
+   version="1.1">
+  <defs
+     id="defs2862">
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3377"
+       id="radialGradient3692"
+       cx="45.883327"
+       cy="28.869568"
+       fx="45.883327"
+       fy="28.869568"
+       r="19.467436"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3377"
+       id="radialGradient3703"
+       gradientUnits="userSpaceOnUse"
+       cx="135.38333"
+       cy="97.369568"
+       fx="135.38333"
+       fy="97.369568"
+       r="19.467436"
+       gradientTransform="matrix(0.97435,0.2250379,-0.4623105,2.0016728,48.487554,-127.99883)" />
+    <linearGradient
+       id="linearGradient3377">
+      <stop
+         id="stop3379"
+         offset="0"
+         style="stop-color:#faff2b;stop-opacity:1;" />
+      <stop
+         id="stop3381"
+         offset="1"
+         style="stop-color:#ffaa00;stop-opacity:1;" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3377"
+       id="radialGradient3705"
+       gradientUnits="userSpaceOnUse"
+       cx="148.88333"
+       cy="81.869568"
+       fx="148.88333"
+       fy="81.869568"
+       r="19.467436"
+       gradientTransform="matrix(1.3852588,-5.1367833e-2,3.7056289e-2,0.9993132,-60.392403,7.7040438)" />
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 32 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="64 : 32 : 1"
+       inkscape:persp3d-origin="32 : 21.333333 : 1"
+       id="perspective2868" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="5.5"
+     inkscape:cx="1.1818182"
+     inkscape:cy="29.272727"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:document-units="px"
+     inkscape:grid-bbox="true"
+     inkscape:window-width="1280"
+     inkscape:window-height="716"
+     inkscape:window-x="86"
+     inkscape:window-y="24"
+     inkscape:window-maximized="0" />
+  <metadata
+     id="metadata2865">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer">
+    <text
+       xml:space="preserve"
+       style="font-size:53.45185852px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ffff00;fill-opacity:1;stroke:#241c1c;stroke-width:2.22716069;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:4.1;font-family:DejaVu Serif;-inkscape-font-specification:DejaVu Serif"
+       x="11.120363"
+       y="42.796223"
+       id="text3014"
+       sodipodi:linespacing="125%"
+       transform="scale(1.0443878,0.95749872)"><tspan
+         sodipodi:role="line"
+         id="tspan3016"
+         x="11.120363"
+         y="42.796223"
+         style="stroke-width:2.22716069">A</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-size:21.82932663000000062px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#d40000;fill-opacity:1;stroke:none;font-family:Bitstream Vera Sans"
+       x="11.969317"
+       y="57.515423"
+       id="text2991"
+       sodipodi:linespacing="125%"
+       transform="scale(0.94671686,1.056282)"><tspan
+         sodipodi:role="line"
+         id="tspan2993"
+         x="11.969317"
+         y="57.515423">CFD</tspan></text>
+  </g>
+</svg>

--- a/src/Mod/Fem/Gui/Resources/icons/fem-mech-analysis.svg
+++ b/src/Mod/Fem/Gui/Resources/icons/fem-mech-analysis.svg
@@ -1,0 +1,136 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="64px"
+   height="64px"
+   id="svg2860"
+   sodipodi:version="0.32"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="fem-mech-analysis.svg"
+   inkscape:output_extension="org.inkscape.output.svg.inkscape"
+   version="1.1">
+  <defs
+     id="defs2862">
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3377"
+       id="radialGradient3692"
+       cx="45.883327"
+       cy="28.869568"
+       fx="45.883327"
+       fy="28.869568"
+       r="19.467436"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3377"
+       id="radialGradient3703"
+       gradientUnits="userSpaceOnUse"
+       cx="135.38333"
+       cy="97.369568"
+       fx="135.38333"
+       fy="97.369568"
+       r="19.467436"
+       gradientTransform="matrix(0.97435,0.2250379,-0.4623105,2.0016728,48.487554,-127.99883)" />
+    <linearGradient
+       id="linearGradient3377">
+      <stop
+         id="stop3379"
+         offset="0"
+         style="stop-color:#faff2b;stop-opacity:1;" />
+      <stop
+         id="stop3381"
+         offset="1"
+         style="stop-color:#ffaa00;stop-opacity:1;" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3377"
+       id="radialGradient3705"
+       gradientUnits="userSpaceOnUse"
+       cx="148.88333"
+       cy="81.869568"
+       fx="148.88333"
+       fy="81.869568"
+       r="19.467436"
+       gradientTransform="matrix(1.3852588,-5.1367833e-2,3.7056289e-2,0.9993132,-60.392403,7.7040438)" />
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 32 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="64 : 32 : 1"
+       inkscape:persp3d-origin="32 : 21.333333 : 1"
+       id="perspective2868" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="5.5"
+     inkscape:cx="1.1818182"
+     inkscape:cy="29.272727"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:document-units="px"
+     inkscape:grid-bbox="true"
+     inkscape:window-width="1280"
+     inkscape:window-height="716"
+     inkscape:window-x="86"
+     inkscape:window-y="24"
+     inkscape:window-maximized="0" />
+  <metadata
+     id="metadata2865">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer">
+    <text
+       xml:space="preserve"
+       style="font-size:55.07272339px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ffff00;fill-opacity:1;stroke:#241c1c;stroke-width:1.72102261;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:4.1;font-family:DejaVu Serif;-inkscape-font-specification:DejaVu Serif"
+       x="10.603539"
+       y="44.564304"
+       id="text3014"
+       sodipodi:linespacing="125%"
+       transform="scale(1.0589701,0.94431374)"><tspan
+         sodipodi:role="line"
+         id="tspan3016"
+         x="10.603539"
+         y="44.564304"
+         style="stroke-width:1.72102261">A</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-size:18.31701469px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Bitstream Vera Sans"
+       x="13.05022"
+       y="53.041969"
+       id="text2991"
+       sodipodi:linespacing="125%"
+       transform="scale(0.87526762,1.1425077)"><tspan
+         sodipodi:role="line"
+         id="tspan2993"
+         x="13.05022"
+         y="53.041969"
+         style="fill:#0000ff">Mech</tspan></text>
+  </g>
+</svg>

--- a/src/Mod/Fem/Gui/Resources/icons/fem-solver.svg
+++ b/src/Mod/Fem/Gui/Resources/icons/fem-solver.svg
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="64px"
+   height="64px"
+   id="svg2860"
+   sodipodi:version="0.32"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="fem-solver.svg"
+   inkscape:output_extension="org.inkscape.output.svg.inkscape"
+   version="1.1">
+  <defs
+     id="defs2862">
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3377"
+       id="radialGradient3692"
+       cx="45.883327"
+       cy="28.869568"
+       fx="45.883327"
+       fy="28.869568"
+       r="19.467436"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3377"
+       id="radialGradient3703"
+       gradientUnits="userSpaceOnUse"
+       cx="135.38333"
+       cy="97.369568"
+       fx="135.38333"
+       fy="97.369568"
+       r="19.467436"
+       gradientTransform="matrix(0.97435,0.2250379,-0.4623105,2.0016728,48.487554,-127.99883)" />
+    <linearGradient
+       id="linearGradient3377">
+      <stop
+         id="stop3379"
+         offset="0"
+         style="stop-color:#faff2b;stop-opacity:1;" />
+      <stop
+         id="stop3381"
+         offset="1"
+         style="stop-color:#ffaa00;stop-opacity:1;" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3377"
+       id="radialGradient3705"
+       gradientUnits="userSpaceOnUse"
+       cx="148.88333"
+       cy="81.869568"
+       fx="148.88333"
+       fy="81.869568"
+       r="19.467436"
+       gradientTransform="matrix(1.3852588,-5.1367833e-2,3.7056289e-2,0.9993132,-60.392403,7.7040438)" />
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 32 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="64 : 32 : 1"
+       inkscape:persp3d-origin="32 : 21.333333 : 1"
+       id="perspective2868" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="5.5"
+     inkscape:cx="29.130684"
+     inkscape:cy="35.583452"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:document-units="px"
+     inkscape:grid-bbox="true"
+     inkscape:window-width="1280"
+     inkscape:window-height="716"
+     inkscape:window-x="86"
+     inkscape:window-y="24"
+     inkscape:window-maximized="0" />
+  <metadata
+     id="metadata2865">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer">
+    <path
+       style="fill:#ff2a2a"
+       d="M 11.754126,56.082969 C 9.9807024,55.847848 7.7607179,54.945643 5.8002044,53.663287 l -0.5449363,-0.356437 0,-2.957551 c 0,-1.626652 0.021355,-2.957549 0.047474,-2.957549 0.026108,0 0.3435608,0.289788 0.7054508,0.643973 2.4045363,2.353345 4.8898276,3.462166 7.2798286,3.247919 2.641541,-0.236792 4.21308,-1.81833 4.901949,-4.93314 0.244882,-1.107266 0.264466,-1.32649 0.259815,-2.908519 -0.0064,-2.174628 -0.205953,-3.405591 -0.755837,-4.662261 -0.782638,-1.788591 -1.925146,-2.69149 -4.809582,-3.800905 C 9.1841388,33.555629 7.6097903,32.267557 6.4208943,29.690645 5.5505736,27.804241 5.1687266,25.584787 5.1687266,22.412526 c 0,-3.052144 0.3687842,-5.334077 1.1875098,-7.347975 C 7.68326,11.800342 9.7843097,10.044953 12.751845,9.7211365 14.762203,9.5017667 18.26241,10.50663 20.08962,11.827714 l 0.262376,0.189699 0,2.854983 0,2.854984 -0.349774,-0.333744 c -0.70581,-0.673464 -2.39694,-1.809398 -3.411502,-2.29151 -0.957699,-0.455093 -1.186272,-0.4953 -2.818311,-0.495763 -1.389134,-3.95e-4 -1.891293,0.06448 -2.304886,0.29778 -1.6915579,0.954172 -2.6569284,2.501128 -3.0302,4.855736 -0.1470268,0.927451 -0.1616274,3.31541 -0.025881,4.233836 0.2430549,1.644524 0.7350548,2.663733 1.6877046,3.496192 0.687143,0.600449 1.546576,1.032095 3.996191,2.00707 3.513965,1.398598 4.920908,2.609783 6.174398,5.315307 0.598145,1.29103 0.898516,2.323881 1.195778,4.111766 0.272711,1.64022 0.340722,4.936071 0.142737,6.916995 -0.544819,5.451141 -2.707706,8.890726 -6.221214,9.893445 -0.953042,0.271991 -2.842667,0.453248 -3.632902,0.348479 z"
+       id="path2995"
+       inkscape:connector-curvature="0" />
+    <text
+       xml:space="preserve"
+       style="font-size:55.9948082px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ff0000;fill-opacity:1;stroke:none;font-family:Bitstream Vera Sans"
+       x="28.894026"
+       y="41.966354"
+       id="text2992"
+       sodipodi:linespacing="125%"
+       transform="scale(0.79003371,1.2657688)"><tspan
+         sodipodi:role="line"
+         id="tspan2994"
+         x="28.894026"
+         y="41.966354"
+         style="font-size:19.59818268px;fill:#ff0000">olver</tspan></text>
+  </g>
+</svg>

--- a/src/Mod/Fem/Gui/ViewProviderAnalysis.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderAnalysis.cpp
@@ -37,6 +37,7 @@
 #include <Gui/ActionFunction.h>
 
 #include <Mod/Fem/App/FemAnalysis.h>
+#include <Mod/Fem/App/FemSolverObject.h>
 #include <Mod/Fem/App/FemMeshObject.h>
 #include <Mod/Fem/App/FemSetObject.h>
 #include <Mod/Fem/App/FemConstraint.h>
@@ -170,6 +171,8 @@ bool ViewProviderFemAnalysis::canDragObject(App::DocumentObject* obj) const
     if (!obj)
         return false;
     if (obj->getTypeId().isDerivedFrom(Fem::FemMeshObject::getClassTypeId()))
+        return true;
+    else if (obj->getTypeId().isDerivedFrom(Fem::FemSolverObject::getClassTypeId()))
         return true;
     else if (obj->getTypeId().isDerivedFrom(Fem::Constraint::getClassTypeId()))
         return true;

--- a/src/Mod/Fem/Gui/ViewProviderSolver.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderSolver.cpp
@@ -1,0 +1,69 @@
+/***************************************************************************
+ *   Copyright (c) 2013 Jürgen Riegel (FreeCAD@juergen-riegel.net)         *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+
+#include "PreCompiled.h"
+
+#ifndef _PreComp_
+# include <Standard_math.hxx>
+
+#endif
+
+#include "ViewProviderSolver.h"
+#include <Gui/Command.h>
+#include <Gui/Document.h>
+#include <Gui/Control.h>
+
+#include <Mod/Fem/App/FemAnalysis.h>
+
+#include "TaskDlgAnalysis.h"
+
+using namespace FemGui;
+
+
+
+PROPERTY_SOURCE(FemGui::ViewProviderSolver, Gui::ViewProviderDocumentObject)
+
+
+ViewProviderSolver::ViewProviderSolver()
+{
+  sPixmap = "fem-solver";
+
+}
+
+ViewProviderSolver::~ViewProviderSolver()
+{
+
+}
+
+
+
+// Python feature -----------------------------------------------------------------------
+
+namespace Gui {
+/// @cond DOXERR
+PROPERTY_SOURCE_TEMPLATE(FemGui::ViewProviderSolverPython, FemGui::ViewProviderSolver)
+/// @endcond
+
+// explicit template instantiation
+template class FemGuiExport ViewProviderPythonFeatureT<ViewProviderSolver>;
+}

--- a/src/Mod/Fem/Gui/ViewProviderSolver.h
+++ b/src/Mod/Fem/Gui/ViewProviderSolver.h
@@ -1,0 +1,65 @@
+/***************************************************************************
+ *   Copyright (c) 2013 Jürgen Riegel (FreeCAD@juergen-riegel.net)         *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+
+#ifndef FEM_ViewProviderSolver_H
+#define FEM_ViewProviderSolver_H
+
+#include <Gui/ViewProviderGeometryObject.h>
+#include <Gui/ViewProviderBuilder.h>
+#include <Gui/ViewProviderPythonFeature.h>
+
+class SoCoordinate3;
+class SoDrawStyle;  
+class SoIndexedFaceSet; 
+class SoIndexedLineSet; 
+class SoShapeHints;
+class SoMaterialBinding;
+
+namespace FemGui
+{
+
+
+
+class FemGuiExport ViewProviderSolver : public Gui::ViewProviderDocumentObject
+{
+    PROPERTY_HEADER(FemGui::ViewProviderSolver);
+
+public:
+    /// constructor
+    ViewProviderSolver();
+
+    /// destructor
+    ~ViewProviderSolver();
+
+    // shows solid in the tree
+    virtual bool isShow(void) const{return true;}
+protected:
+
+};
+
+typedef Gui::ViewProviderPythonFeatureT<ViewProviderSolver> ViewProviderSolverPython;
+
+} //namespace FemGui
+
+
+#endif // FEM_ViewProviderSolver_H

--- a/src/Mod/Fem/Gui/Workbench.cpp
+++ b/src/Mod/Fem/Gui/Workbench.cpp
@@ -55,7 +55,10 @@ Gui::ToolBarItem* Workbench::setupToolBars() const
     Gui::ToolBarItem* root = StdWorkbench::setupToolBars();
     Gui::ToolBarItem* fem = new Gui::ToolBarItem(root);
     fem->setCommand("FEM");
-    *fem << "Fem_NewMechanicalAnalysis"
+    //*fem << "Fem_NewMechanicalAnalysis"
+    *fem << "Fem_NewMechAnalysis"
+         << "Fem_NewCfdAnalysis"
+         //<< "Fem_CreateSolver"
          << "Fem_CreateFromShape"
          << "Fem_MechanicalMaterial"
          << "Fem_BeamSection"
@@ -70,7 +73,8 @@ Gui::ToolBarItem* Workbench::setupToolBars() const
          << "Fem_ConstraintGear"   
          << "Fem_ConstraintPulley"
          << "Separator"
-         << "Fem_MechanicalJobControl"
+         << "Fem_AnalysisControl"
+         //<< "Fem_MechanicalJobControl" // double click to activate task panel
          << "Fem_Quick_Analysis"
          << "Fem_PurgeResults"
          << "Fem_ShowResult";
@@ -85,6 +89,8 @@ Gui::MenuItem* Workbench::setupMenuBar() const
     root->insertItem(item, fem);
     fem->setCommand("&FEM");
     *fem << "Fem_NewMechanicalAnalysis"
+         << "Fem_NewCfdAnalysis"
+         //<< "Fem_CreateSolver"
          << "Fem_CreateFromShape"
          << "Fem_MechanicalMaterial"
          << "Fem_BeamSection"
@@ -99,7 +105,7 @@ Gui::MenuItem* Workbench::setupMenuBar() const
          << "Fem_ConstraintGear"   
          << "Fem_ConstraintPulley"
          << "Separator"
-         << "Fem_MechanicalJobControl"
+         << "Fem_AnalysisControl"
          << "Fem_Quick_Analysis"
          << "Fem_PurgeResults"
          << "Fem_ShowResult";

--- a/src/Mod/Fem/InitGui.py
+++ b/src/Mod/Fem/InitGui.py
@@ -54,6 +54,8 @@ class FemWorkbench (Workbench):
 
         import MechanicalAnalysis
 
+        import CaeAnalysis
+        
         import subprocess
         from platform import system
         ccx_path = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/Fem").GetString("ccxBinaryPath")

--- a/src/Mod/Fem/TaskPanelAnalysisControl.ui
+++ b/src/Mod/Fem/TaskPanelAnalysisControl.ui
@@ -1,0 +1,145 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>AnalysisControl</class>
+ <widget class="QWidget" name="AnalysisControl">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>329</width>
+    <height>458</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Mechanical analysis</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QGroupBox" name="gb_working_dir">
+     <property name="title">
+      <string>Working directory</string>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout_4">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="QLineEdit" name="le_working_dir">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="readOnly">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QToolButton" name="tb_choose_working_dir">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="text">
+         <string>...</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="gb_analysis_type">
+     <property name="title">
+      <string>Analysis type</string>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="Gui::PrefRadioButton" name="rb_static_analysis">
+        <property name="text">
+         <string>Static</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="Gui::PrefRadioButton" name="rb_frequency_analysis">
+        <property name="text">
+         <string>Frequency</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <layout class="QGridLayout" name="gl_actions">
+     <item row="0" column="0">
+      <widget class="QPushButton" name="pb_write_inp">
+       <property name="text">
+        <string>Write case input</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QPushButton" name="pb_edit_inp">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="text">
+        <string>Edit case input</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0" colspan="2">
+      <widget class="QPushButton" name="pb_run_solver">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="text">
+        <string>Run Solver</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QTextEdit" name="textEdit_Output">
+     <property name="lineWrapMode">
+      <enum>QTextEdit::NoWrap</enum>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="l_time">
+     <property name="font">
+      <font>
+       <pointsize>12</pointsize>
+      </font>
+     </property>
+     <property name="text">
+      <string>Time:</string>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>Gui::PrefRadioButton</class>
+   <extends>QRadioButton</extends>
+   <header>Gui/PrefWidgets.h</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/Mod/Fem/TaskPanelSolverControl.ui
+++ b/src/Mod/Fem/TaskPanelSolverControl.ui
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>TaskPanel</class>
+ <widget class="QWidget" name="TaskPanel">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>307</width>
+    <height>75</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="1" column="0" colspan="2">
+    <layout class="QVBoxLayout" name="verticalLayout_2">
+     <item>
+      <widget class="QLabel" name="label_2">
+       <property name="text">
+        <string>UI for advanced solver control</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>Use combiview to edit property</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/Mod/Fem/_CommandFemFromShape.py
+++ b/src/Mod/Fem/_CommandFemFromShape.py
@@ -43,7 +43,7 @@ class _CommandFemFromShape(FemCommands):
     def Activated(self):
         FreeCAD.ActiveDocument.openTransaction("Create FEM mesh")
         FreeCADGui.addModule("FemGui")
-        FreeCADGui.addModule("MechanicalAnalysis")
+        #FreeCADGui.addModule("MechanicalAnalysis")
         sel = FreeCADGui.Selection.getSelection()
         if (len(sel) == 1):
             if(sel[0].isDerivedFrom("Part::Feature")):

--- a/src/Mod/Fem/_TaskPanelAnalysisControl.py
+++ b/src/Mod/Fem/_TaskPanelAnalysisControl.py
@@ -1,0 +1,324 @@
+#***************************************************************************
+#*                                                                         *
+#*   Copyright (c) 2013-2015 - Juergen Riegel <FreeCAD@juergen-riegel.net> *
+#*                                                                         *
+#*   This program is free software; you can redistribute it and/or modify  *
+#*   it under the terms of the GNU Lesser General Public License (LGPL)    *
+#*   as published by the Free Software Foundation; either version 2 of     *
+#*   the License, or (at your option) any later version.                   *
+#*   for detail see the LICENCE text file.                                 *
+#*                                                                         *
+#*   This program is distributed in the hope that it will be useful,       *
+#*   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+#*   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+#*   GNU Library General Public License for more details.                  *
+#*                                                                         *
+#*   You should have received a copy of the GNU Library General Public     *
+#*   License along with this program; if not, write to the Free Software   *
+#*   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
+#*   USA                                                                   *
+#*                                                                         *
+#***************************************************************************
+
+__title__ = "Job Control Task Panel"
+__author__ = "Juergen Riegel"
+__url__ = "http://www.freecadweb.org"
+
+from FemTools import FemTools
+import FreeCAD
+import ccxFrdReader
+import os
+import os.path
+import time
+
+if FreeCAD.GuiUp:
+    import FreeCADGui
+    import FemGui
+    from PySide import QtCore
+    from PySide import QtGui
+    from PySide.QtCore import Qt
+    from PySide.QtGui import QApplication
+
+
+class _TaskPanelAnalysisControl:
+    def __init__(self, analysis_object):
+        self.form = FreeCADGui.PySideUic.loadUi(FreeCAD.getHomePath() + "Mod/Fem/TaskPanelAnalysisControl.ui")
+        self.fem_prefs = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/Fem")
+
+        self.analysis_object = analysis_object
+        import CaeTools
+        self.solver_object = CaeTools.getSolver(self.analysis_object)
+        # test if Proxy instance is not None and correct type, or create a new python instance
+        self.solver_python_object = CaeTools.getSolverPythonFromAnalysis(self.analysis_object)
+
+        self.SolverProcess = QtCore.QProcess()
+        self.Timer = QtCore.QTimer()
+        self.Timer.start(300)
+        
+        # update UI text according to solver info, replace sover with specific solver name
+
+        # consider: moved into FemSolverObject.Proxy class
+        if self.solver_object.SolverName == "Calculix":
+            ccx_binary = self.fem_prefs.GetString("ccxBinaryPath", "")
+            if ccx_binary:
+                self.CalculixBinary = ccx_binary
+                print ("Using ccx binary path from FEM preferences: {}".format(ccx_binary))
+            else:
+                from platform import system
+                if system() == 'Linux':
+                    self.CalculixBinary = 'ccx'
+                elif system() == 'Windows':
+                    self.CalculixBinary = FreeCAD.getHomePath() + 'bin/ccx.exe'
+                else:
+                    self.CalculixBinary = 'ccx'
+            self.fem_prefs = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/Fem")  # why twice? refresh?
+
+        self.fem_console_message = ''
+
+        # Connect Signals and Slots
+        QtCore.QObject.connect(self.form.tb_choose_working_dir, QtCore.SIGNAL("clicked()"), self.choose_working_dir)
+        QtCore.QObject.connect(self.form.pb_write_inp, QtCore.SIGNAL("clicked()"), self.write_input_file_handler)
+        QtCore.QObject.connect(self.form.pb_edit_inp, QtCore.SIGNAL("clicked()"), self.editSolverInputFile)
+        QtCore.QObject.connect(self.form.pb_run_solver, QtCore.SIGNAL("clicked()"), self.runSolverProcess)
+        # combobox is preferred
+        QtCore.QObject.connect(self.form.rb_static_analysis, QtCore.SIGNAL("clicked()"), self.select_static_analysis)
+        QtCore.QObject.connect(self.form.rb_frequency_analysis, QtCore.SIGNAL("clicked()"), self.select_frequency_analysis)
+
+        QtCore.QObject.connect(self.SolverProcess, QtCore.SIGNAL("started()"), self.solverProcessStarted)
+        QtCore.QObject.connect(self.SolverProcess, QtCore.SIGNAL("stateChanged(QProcess::ProcessState)"), self.solverProcessStateChanged)
+        QtCore.QObject.connect(self.SolverProcess, QtCore.SIGNAL("error(QProcess::ProcessError)"), self.solverProcessError)
+        QtCore.QObject.connect(self.SolverProcess, QtCore.SIGNAL("finished(int)"), self.solverProcessFinished)
+
+        QtCore.QObject.connect(self.Timer, QtCore.SIGNAL("timeout()"), self.updateText)
+        self.update()
+
+    def femConsoleMessage(self, message="", color="#000000"):
+        self.fem_console_message = self.fem_console_message + '<font color="#0000FF">{0:4.1f}:</font> <font color="{1}">{2}</font><br>'.\
+            format(time.time() - self.Start, color, message.encode('utf-8', 'replace'))
+        self.form.textEdit_Output.setText(self.fem_console_message)
+        self.form.textEdit_Output.moveCursor(QtGui.QTextCursor.End)
+
+    def printSolverProcessStdout(self):
+        out = self.SolverProcess.readAllStandardOutput()
+        if out.isEmpty():
+            self.femConsoleMessage("Solver stdout is empty", "#FF0000")
+        else:
+            try:
+                out = unicode(out, 'utf-8', 'replace')
+                rx = QtCore.QRegExp("\\*ERROR.*\\n\\n")  # this is solver specific feature
+                rx.setMinimal(True)
+                pos = rx.indexIn(out)
+                while not pos < 0:
+                    match = rx.cap(0)
+                    FreeCAD.Console.PrintError(match.strip().replace('\n', ' ') + '\n')
+                    pos = rx.indexIn(out, pos + 1)
+                out = os.linesep.join([s for s in out.splitlines() if s])
+                self.femConsoleMessage(out.replace('\n', '<br>'))
+            except UnicodeDecodeError:
+                self.femConsoleMessage("Error converting stdout from Solver", "#FF0000")
+
+    def updateText(self):
+        if(self.SolverProcess.state() == QtCore.QProcess.ProcessState.Running):
+            self.form.l_time.setText('Time: {0:4.1f}: '.format(time.time() - self.Start))
+
+    def solverProcessError(self, error):
+        print ("Error() {}".format(error))
+        self.femConsoleMessage("Solver execute error: {}".format(error), "#FF0000")
+
+    def solverProcessStarted(self):
+        print ("calculixStarted()")
+        print (self.SolverProcess.state())
+        self.form.pb_run_solver.setText("Break Solver process")
+
+    def solverProcessStateChanged(self, newState):
+        if (newState == QtCore.QProcess.ProcessState.Starting):
+            self.femConsoleMessage("Starting Solver...")
+        if (newState == QtCore.QProcess.ProcessState.Running):
+            self.femConsoleMessage("Solver is running...")
+        if (newState == QtCore.QProcess.ProcessState.NotRunning):
+            self.femConsoleMessage("Solver stopped.")
+
+    def solverProcessFinished(self, exitCode):
+        print ("Solver Process Finished() {}".format(exitCode))
+        print self.SolverProcess.state()
+
+        # Restore previous cwd
+        QtCore.QDir.setCurrent(self.cwd)
+
+        self.printSolverProcessStdout()
+        self.Timer.stop()
+        self.femConsoleMessage("External solver process is done!", "#00AA00")
+        self.form.pb_run_solver.setText("Re-run Solver")
+
+        if self.solver_object.SolverName == "Calculix":
+            self.femConsoleMessage("Loading result sets...")
+            self.form.l_time.setText('Time: {0:4.1f}: '.format(time.time() - self.Start))
+            fea = FemTools()
+            fea.reset_all()
+            frd_result_file = os.path.splitext(self.inp_file_name)[0] + '.frd'
+            if os.path.isfile(frd_result_file):
+                QApplication.setOverrideCursor(Qt.WaitCursor)
+                ccxFrdReader.importFrd(frd_result_file, FemGui.getActiveAnalysis())
+                self.femConsoleMessage("Loading results done!", "#00AA00")
+            else:
+                self.femConsoleMessage("Loading results failed! Results file doesn\'t exist", "#FF0000")
+            self.form.l_time.setText('Time: {0:4.1f}: '.format(time.time() - self.Start))
+        else:  # self.solver_object.SolverName == "OpenFOAM":
+            self.femConsoleMessage("Please use external view to view the result", "#00AA00")
+            self.solver_python_object.view_result_externally()
+        QApplication.restoreOverrideCursor()
+
+    def getStandardButtons(self):
+        return int(QtGui.QDialogButtonBox.Close)
+
+    def update(self):
+        'fills the widgets'
+        if self.solver_object.SolverName == "Calculix":
+            self.form.le_working_dir.setText(self.analysis_object.WorkingDir)  # need unification
+        else:
+            self.form.le_working_dir.setText(self.solver_object.WorkingDir)  # need unification
+        # to-do: should use combobox instead
+        if self.analysis_object.AnalysisType == 'static':
+            self.form.rb_static_analysis.setChecked(True)
+        elif self.analysis_object.AnalysisType == 'frequency':
+            self.form.rb_frequency_analysis.setChecked(True)
+        return
+
+    def accept(self):
+        FreeCADGui.Control.closeDialog()
+
+    def reject(self):
+        FreeCADGui.Control.closeDialog()
+
+    def choose_working_dir(self):
+        current_wd = self.setup_working_dir()
+        wd = QtGui.QFileDialog.getExistingDirectory(None,
+                                                    'Choose Solver working directory',
+                                                    current_wd)
+        if self.solver_object.SolverName == "Calculix":
+            info_obj = self.analysis_object
+        else:
+            info_obj = self.solver_object
+        if wd:
+            info_obj.WorkingDir = wd
+        else:
+            info_obj.WorkingDir = current_wd
+        self.form.le_working_dir.setText(info_obj.WorkingDir)
+
+    def write_input_file_handler(self):
+        QApplication.restoreOverrideCursor()
+        try:  # protect code from exception and freezing UI by waitCursor
+            if self.check_prerequisites_helper():
+                QApplication.setOverrideCursor(Qt.WaitCursor)
+                if self.solver_object.SolverName == "Calculix":
+                    self.inp_file_name = ""
+                    fea = FemTools()
+                    fea.set_analysis_type(self.analysis_object.AnalysisType)
+                    fea.update_objects()
+                    fea.write_inp_file()
+                    if fea.inp_file_name != "":
+                        self.inp_file_name = fea.inp_file_name
+                        self.femConsoleMessage("Write completed.")
+                        self.form.pb_edit_inp.setEnabled(True)
+                        self.form.pb_run_solver.setEnabled(True)
+                    else:
+                        self.femConsoleMessage("Write .inp file failed!", "#FF0000")
+                else:  # self.solver_object.SolverName == "OpenFOAM":
+                    self.femConsoleMessage("{} case writer is called".format(self.solver_object.SolverName))
+                    if self.solver_python_object.write_case(self.analysis_object):
+                        self.femConsoleMessage("Write {} case is completed.".format(self.solver_object.SolverName))
+                        self.form.pb_edit_inp.setEnabled(True)
+                        self.form.pb_run_solver.setEnabled(True)
+                    else:
+                        self.femConsoleMessage("Write .inp file failed!", "#FF0000")
+        finally:
+            QApplication.restoreOverrideCursor()
+
+    def check_prerequisites_helper(self):
+        self.Start = time.time()
+        self.femConsoleMessage("Check dependencies...")
+        self.form.l_time.setText('Time: {0:4.1f}: '.format(time.time() - self.Start))
+
+        if self.solver_object.SolverName == "Calculix":
+            fea = FemTools()
+            fea.update_objects()
+            message = fea.check_prerequisites()
+        else:
+            message = self.solver_python_object.check_prerequisites(self.analysis_object)
+        if message != "":
+            QtGui.QMessageBox.critical(None, "Missing prerequisit(s)", message)
+            return False
+        return True
+
+    def start_ext_editor(self, ext_editor_path, filename):
+        if not hasattr(self, "ext_editor_process"):
+            self.ext_editor_process = QtCore.QProcess()
+        if self.ext_editor_process.state() != QtCore.QProcess.Running:
+            self.ext_editor_process.start(ext_editor_path, [filename])
+
+    def editSolverInputFile(self):
+        if self.solver_object.SolverName == "Calculix":
+            print ('editCalculixInputFile {}'.format(self.inp_file_name))
+            if self.fem_prefs.GetBool("UseInternalEditor", True):
+                FemGui.open(self.inp_file_name)
+            else:
+                ext_editor_path = self.fem_prefs.GetString("ExternalEditorPath", "")
+                if ext_editor_path:
+                    self.start_ext_editor(ext_editor_path, self.inp_file_name)
+                else:
+                    print "External editor is not defined in FEM preferences. Falling back to internal editor"
+                    FemGui.open(self.inp_file_name)
+        else:
+            self.femConsoleMessage("Edit case input file in FreeCAD is not implemented!")
+            self.solver_python_object.edit_case_externally()
+
+    def runSolverProcess(self):
+        print ('run solver process')
+        self.Start = time.time()
+        self.femConsoleMessage("Run {}...".format(self.solver_object.SolverName))
+
+        if self.solver_object.SolverName == "Calculix":
+
+            self.femConsoleMessage("Solver binary: {}".format(self.CalculixBinary))
+            print('run Calculix at: ', self.CalculixBinary, ' with: ', os.path.splitext(self.inp_file_name)[0])
+            # change cwd because ccx may crash if directory has no write permission
+            # there is also a limit of the length of file names so jump to the document directory
+            self.cwd = QtCore.QDir.currentPath()
+            fi = QtCore.QFileInfo(self.inp_file_name)
+            QtCore.QDir.setCurrent(fi.path())
+            self.SolverProcess.start(self.CalculixBinary, ['-i', fi.baseName()])
+        else:  # self.solver_object.SolverName == "OpenFOAM":
+            self.femConsoleMessage("Run OpenFoam at {}".format(self.solver_object.WorkingDir))
+            self.cwd = QtCore.QDir.currentPath()
+            QtCore.QDir.setCurrent(self.solver_object.WorkingDir)
+            self.SolverProcess.start(self.solver_python_object.generate_cmdline())
+
+        QApplication.restoreOverrideCursor()
+
+    def select_analysis_type(self, analysis_type):
+        if self.analysis_object.AnalysisType != analysis_type:
+            self.analysis_object.AnalysisType = analysis_type
+            self.form.pb_edit_inp.setEnabled(False)
+            self.form.pb_run_solver.setEnabled(False)
+
+    def select_static_analysis(self):
+        self.select_analysis_type('static')
+
+    def select_frequency_analysis(self):
+        self.select_analysis_type('frequency')
+
+    # That function overlaps with FemTools setup_working_dir and needs to be removed when we migrate fully to FemTools
+    def setup_working_dir(self):
+        if self.solver_object.SolverName == "Calculix":
+            wd = self.analysis_object.WorkingDir
+        else:
+            wd = self.solver_object.WorkingDir
+        if not (os.path.isdir(wd)):
+            try:
+                os.makedirs(wd)
+            except:
+                print ("Dir \'{}\' from FEM preferences doesn't exist and cannot be created.".format(wd))
+                import tempfile
+                wd = tempfile.gettempdir()
+                print ("Dir \'{}\' will be used instead.".format(wd))
+        return wd

--- a/src/Mod/Fem/ccxFemSolver.py
+++ b/src/Mod/Fem/ccxFemSolver.py
@@ -1,0 +1,115 @@
+#***************************************************************************
+#*                                                                         *
+#*   Copyright (c) 2015 - FreeCAD Developers                               *
+#*   Author (c) 2015 - Qingfeng Xia <qingfeng xia eng.ox.ac.uk>                    *
+#*                                                                         *
+#*   This program is free software; you can redistribute it and/or modify  *
+#*   it under the terms of the GNU Lesser General Public License (LGPL)    *
+#*   as published by the Free Software Foundation; either version 2 of     *
+#*   the License, or (at your option) any later version.                   *
+#*   for detail see the LICENCE text file.                                 *
+#*                                                                         *
+#*   This program is distributed in the hope that it will be useful,       *
+#*   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+#*   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+#*   GNU Library General Public License for more details.                  *
+#*                                                                         *
+#*   You should have received a copy of the GNU Library General Public     *
+#*   License along with this program; if not, write to the Free Software   *
+#*   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
+#*   USA                                                                   *
+#*                                                                         *
+#***************************************************************************
+
+"""
+A dump class to let Calculix solver fit into the CaeSolver Framework
+Some of FemTools() information retrieval function could be moved in, if not all
+"""
+
+import FreeCAD
+if FreeCAD.GuiUp:
+    import FreeCADGui
+    from PySide import QtCore
+
+
+class CaeSolver():
+    """The Fem::FemSolver 's Proxy python type,
+    add solver specific properties, methods and bring up SolverControlTaskPanel.
+    After loaded from FCStd file, this python class is not instantiated.
+    use CaeTools.getSolverPythonFromAnalysis() to get/create such an instance.
+    """
+    def __init__(self, obj):
+        self.Type = "CaeAnalysis"
+        self.Object = obj  # keep a ref to the DocObj for nonGui usage
+        obj.Proxy = self  # link between App::DocumentObject to  this object
+
+    # following are the standard FeaturePython methods
+    def execute(self, obj):
+        return
+
+    def onChanged(self, obj, prop):
+        """updated Part should lead to recompution of the analysis # to-do """
+        return
+
+    def __getstate__(self):
+        return self.Type
+
+    def __setstate__(self, state):
+        if state:
+            self.Type = state
+
+
+class ViewProviderCaeSolver:
+    """A View Provider for the Solver object, base class for all derived solver
+    derived solver should implement  a specific TaskPanel and set up solver and override setEdit()
+    """
+    def __init__(self, vobj):
+        vobj.Proxy = self
+
+    def getIcon(self):
+        return ":/icons/fem-solver.svg"
+
+    def attach(self, vobj):
+        self.ViewObject = vobj
+        self.Object = vobj.Object
+
+    def updateData(self, obj, prop):
+        return
+
+    def onChanged(self, vobj, prop):
+        return
+
+    def doubleClicked(self, vobj):
+        # from import _SolverControlTaskPanel
+        taskd = _TaskPanelSolverControl(vobj.Object)
+        FreeCADGui.Control.showDialog(taskd)
+        return True
+
+    def setEdit(self, vobj, mode):
+        # import module if it is defined in another file
+        taskd = _TaskPanelSolverControl(vobj.Object)
+        FreeCADGui.Control.showDialog(taskd)
+        return True
+
+    def unsetEdit(self, vobj, mode):
+        #FreeCADGui.Control.closeDialog()
+        return
+
+    def __getstate__(self):
+        return None
+
+    def __setstate__(self, state):
+        return None
+
+
+class _TaskPanelSolverControl:
+    def __init__(self, solver_object):
+        self.form = FreeCADGui.PySideUic.loadUi(FreeCAD.getHomePath() + "Mod/Fem/TaskPanelSolverControl.ui")
+        #QtGui.QMessageBox.critical(None, "Not implement yet", "Please edit proper in property editor")
+        pass
+
+    def accept(self):
+        return True
+
+    def reject(self):
+        return True


### PR DESCRIPTION
Changelog for pull request
======================

I renamed original foamsolver -> foamsolver_dirty which is not properly rebased.  This is new foamsolver fork, which is rebased to Nov 10 master.  FoamCaseSolver.py is under heavy development, please ignore this file for PEP8. I am exhausted to merge manually each time Fem has some changes. 

In addition to C++ Fem::SolverObject, python side are added to extend FemSolverObject into Solver specific CaeSolver, like FoamCfdSolver.py ccxFemSolver.py. CaeSolver.py implements a factory pattern to make solver instance from string name.

CaeAnalysis.py: Extending FemAnalysisObject into CaeAnalysis. This module implements all functions in "MechanicalAnalysis.py, _ViewProviderFemAnalysis.py, _FemAnalysis.py, _CommandNewMechanicalAnalysis.py". These files are not removed to ease the merge conflict with official master, but their function/code is not used. These files should be deleted soon after this commit is accept.

_AnalysisControlTaskPanel.py is a super set of the existent_JobControlTaskPanel.py + future general CaeSolver control (retrieve information only from CaeSolver). This file is manually updated once _JobControlTaskPanel.py is updated, but I have no time to maintain this kind of merge/compatiblity any longer.

Multiple analysis can be saved into document and reloaded, but macro (FemExample.py) replay is not perfect, as MechanicalMaterial.py/ Meshing does not record GUI operation.

http://forum.freecadweb.org/viewtopic.php?f=18&t=13016&sid=58ff5c1ac03b66aac6e6dca069f19207

### Testing ###

I have tested on 2PC for the 1CFD + 2FEM analyses.
UnitTest passed, may fail in file comparison. 
FoamAnalysis will fail on your PC as you have not install OpenFoam, but it does not affect FreeCAD. 
quick test can be done by paste FemExample.py and make some adjustment on material. 
