### PR TITLE
Fixed paths for 3Dconnexion headers on Mac

### DIFF
--- a/src/Gui/CMakeLists.txt
+++ b/src/Gui/CMakeLists.txt
@@ -12,7 +12,8 @@ if (FREECAD_USE_3DCONNEXION)
     add_definitions(-D_USE_3DCONNEXION_SDK)
     if(APPLE)
         set(3DCONNEXION_LINKFLAGS "-F/Library/Frameworks -weak_framework 3DconnexionClient")
-        set(3DCONNEXION_INCLUDE_DIR ${3DCONNEXIONCLIENT_FRAMEWORK}/Headers )
+        set(3DCONNEXION_INCLUDE_DIR ${3DCONNEXIONCLIENT_FRAMEWORK}/Headers
+                                    ${3DCONNEXIONCLIENT_FRAMEWORK}/Headers/3DconnexionClient )
     endif(APPLE)
 endif(FREECAD_USE_3DCONNEXION)
 

--- a/src/Gui/GuiApplicationNativeEventAware.h
+++ b/src/Gui/GuiApplicationNativeEventAware.h
@@ -45,7 +45,7 @@ class QMainWindow;
 
 #ifdef Q_WS_MACX
 #include <IOKit/IOKitLib.h>
-#include <3DconnexionClient/ConnexionClientAPI.h>
+#include <ConnexionClientAPI.h>
 extern OSErr InstallConnexionHandlers(ConnexionMessageHandlerProc messageHandler, ConnexionAddedHandlerProc addedHandler, ConnexionRemovedHandlerProc removedHandler)
   __attribute__((weak_import));
 extern UInt16 RegisterConnexionClient(UInt32 signature, UInt8 *name, UInt16 mode, UInt32 mask) __attribute__((weak_import));


### PR DESCRIPTION
I'm not sure why, but on some Macs the 3Dconnexion headers are in a slightly different path from others.