### PR TITLE
Change name prefix in the VRML exporter

### DIFF
--- a/src/Gui/SoFCDB.cpp
+++ b/src/Gui/SoFCDB.cpp
@@ -26,6 +26,7 @@
 # include <Inventor/actions/SoToVRML2Action.h>
 # include <Inventor/VRMLnodes/SoVRMLGroup.h>
 # include <Inventor/VRMLnodes/SoVRMLParent.h>
+# include <Inventor/SbString.h>
 #endif
 
 #include <Base/FileInfo.h>
@@ -217,6 +218,7 @@ bool Gui::SoFCDB::writeToVRML(SoNode* node, const char* filename, bool binary)
     SoToVRML2Action tovrml2;
     tovrml2.apply(node);
     SoVRMLGroup* vrmlRoot = tovrml2.getVRML2SceneGraph();
+    vrmlRoot->setInstancePrefix(SbString("o"));
     vrmlRoot->ref();
     std::string buffer = SoFCDB::writeNodesToString(vrmlRoot);
     vrmlRoot->unref(); // release the memory as soon as possible


### PR DESCRIPTION
I filed this bug earlier and decided to dive in to try and fix it: http://www.freecadweb.org/tracker/view.php?id=2390

This pull request does it. I changed the name prefix from Coin3D's default (+, which isn't allowed in the VRML standards) to a lower case o. This only changes the name of DEF blocks in vrml files which shouldn't affect anything else.

I tried exporting and importing VRML files and everything looked good.