### PR TITLE
Upgraded Plot module to comply with matplotlib 1.5.x API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,7 @@ before_install:
     - sudo apt-get install -y pyside-tools
     - sudo apt-get install -y python-dev
     - sudo apt-get install -y python-pyside
+    - sudo apt-get install -y python-matplotlib
     - sudo apt-get install -y qt4-dev-tools
     - sudo apt-get install -y qt4-qmake
     - sudo apt-get install -y shiboken

--- a/src/Mod/Plot/Plot.py
+++ b/src/Mod/Plot/Plot.py
@@ -25,6 +25,7 @@ import FreeCAD
 
 import PySide
 from PySide import QtCore, QtGui
+from distutils.version import StrictVersion as V
 
 try:
     import matplotlib
@@ -32,7 +33,11 @@ try:
     matplotlib.rcParams['backend.qt4']='PySide'
     import matplotlib.pyplot as plt
     from matplotlib.backends.backend_qt4agg import FigureCanvasQTAgg as FigureCanvas
-    from matplotlib.backends.backend_qt4agg import NavigationToolbar2QTAgg as NavigationToolbar
+    if V(matplotlib.__version__) < V("1.5.0"):
+       from matplotlib.backends.backend_qt4agg import NavigationToolbar2QTAgg as NavigationToolbar
+    else:
+       from matplotlib.backends.backend_qt4agg import NavigationToolbar2QT as NavigationToolbar
+
     from matplotlib.figure import Figure
 except ImportError:
     msg = PySide.QtGui.QApplication.translate(


### PR DESCRIPTION
Plot.py will check the version of matplotlib imported using the
distutils.version.StrictVersion class.  If the version is less
than 1.5.0, it will import the legacy gt4agg NavigationToolbar
from matplotlib, otherwise the 1.5.x version.

Resolves #2421