### PR TITLE
Matplotlib navigation toolbar support

### DIFF
--- a/src/Mod/Plot/Plot.py
+++ b/src/Mod/Plot/Plot.py
@@ -337,6 +337,38 @@ def save(path, figsize=None, dpi=None):
     plt.update()
 
 
+def addNavigationToolbar():
+    """Add the matplotlib QT navigation toolbar to the plot.
+    """
+    plt = getPlot()
+    if not plt:
+        return
+    # Check that the navigation toolbar has not been already created
+    if plt.mpl_toolbar is not None:
+        return
+    # Create the navigation toolbar and add it
+    plt.mpl_toolbar = NavigationToolbar(plt.canvas, plt)
+    vbox = plt.layout()
+    vbox.addWidget(plt.mpl_toolbar)
+
+
+def delNavigationToolbar():
+    """Remove the matplotlib QT navigation toolbar from the plot.
+    """
+    plt = getPlot()
+    if not plt:
+        return
+    # Check that the navigation toolbar already exist
+    if plt.mpl_toolbar is None:
+        return
+    # Remove the widget from the layout
+    vbox = plt.layout()
+    vbox.removeWidget(plt.mpl_toolbar)
+    # Destroy the navigation toolbar
+    plt.mpl_toolbar.deleteLater()
+    plt.mpl_toolbar = None
+
+
 class Line():
     def __init__(self, axes, x, y, name):
         """Construct a new plot serie.
@@ -397,9 +429,12 @@ class Plot(PySide.QtGui.QWidget):
         self.axes.spines['top'].set_color('none')
         self.axes.yaxis.set_ticks_position('left')
         self.axes.spines['right'].set_color('none')
+        # Add the navigation toolbar by default
+        self.mpl_toolbar = NavigationToolbar(self.canvas, self)
         # Setup layout
         vbox = PySide.QtGui.QVBoxLayout()
         vbox.addWidget(self.canvas)
+        vbox.addWidget(self.mpl_toolbar)
         self.setLayout(vbox)
         # Active series
         self.series = []

--- a/src/Mod/Plot/Plot.py
+++ b/src/Mod/Plot/Plot.py
@@ -33,7 +33,7 @@ try:
     matplotlib.rcParams['backend.qt4']='PySide'
     import matplotlib.pyplot as plt
     from matplotlib.backends.backend_qt4agg import FigureCanvasQTAgg as FigureCanvas
-    if V(matplotlib.__version__) < V("1.5.0"):
+    if V(matplotlib.__version__) < V("1.4.0"):
        from matplotlib.backends.backend_qt4agg import NavigationToolbar2QTAgg as NavigationToolbar
     else:
        from matplotlib.backends.backend_qt4agg import NavigationToolbar2QT as NavigationToolbar


### PR DESCRIPTION
* Even though NavigationToolbar2QT is required for matplotlib >= 1.5, in matplotlib 1.4 a deprecation warning is shown. So the minimum version to import NavigationToolbar2QT instead of NavigationToolbar2QTAgg has been conveniently decreased
* I added the matplotlib navigation toolbar by default
* I implemented two methods to toogle it on/off

Related with this: http://forum.freecadweb.org/viewtopic.php?f=27&t=14024