### PR TITLE
Add cmake checks for BUILD_GUI to some modules

### DIFF
--- a/src/Mod/Arch/CMakeLists.txt
+++ b/src/Mod/Arch/CMakeLists.txt
@@ -1,4 +1,6 @@
-PYSIDE_WRAP_RC(Arch_QRC_SRCS Resources/Arch.qrc)
+IF (BUILD_GUI)
+    PYSIDE_WRAP_RC(Arch_QRC_SRCS Resources/Arch.qrc)
+ENDIF (BUILD_GUI)
 
 SET(Arch_SRCS
     Init.py
@@ -53,10 +55,12 @@ fc_target_copy_resource(Arch
     ${Arch_presets}
 )
 
-fc_target_copy_resource(Arch
-    ${CMAKE_CURRENT_BINARY_DIR}
-    ${CMAKE_BINARY_DIR}/Mod/Arch
-    Arch_rc.py)
+IF (BUILD_GUI)
+    fc_target_copy_resource(Arch
+        ${CMAKE_CURRENT_BINARY_DIR}
+        ${CMAKE_BINARY_DIR}/Mod/Arch
+        Arch_rc.py)
+ENDIF (BUILD_GUI)
 
 INSTALL(
     FILES

--- a/src/Mod/Draft/CMakeLists.txt
+++ b/src/Mod/Draft/CMakeLists.txt
@@ -1,6 +1,8 @@
 add_subdirectory(App)
 
-PYSIDE_WRAP_RC(Draft_QRC_SRCS Resources/Draft.qrc)
+IF (BUILD_GUI)
+    PYSIDE_WRAP_RC(Draft_QRC_SRCS Resources/Draft.qrc)
+ENDIF (BUILD_GUI)
 
 SET(Draft_SRCS
     Init.py
@@ -28,10 +30,12 @@ ADD_CUSTOM_TARGET(Draft ALL
 
 fc_copy_sources(Draft "${CMAKE_BINARY_DIR}/Mod/Draft" ${Draft_SRCS})
 
-fc_target_copy_resource(Draft
-    ${CMAKE_CURRENT_BINARY_DIR}
-    ${CMAKE_BINARY_DIR}/Mod/Draft
-    Draft_rc.py)
+IF (BUILD_GUI)
+    fc_target_copy_resource(Draft
+        ${CMAKE_CURRENT_BINARY_DIR}
+        ${CMAKE_BINARY_DIR}/Mod/Draft
+        Draft_rc.py)
+ENDIF (BUILD_GUI)
 
 INSTALL(
     FILES

--- a/src/Mod/Material/CMakeLists.txt
+++ b/src/Mod/Material/CMakeLists.txt
@@ -1,4 +1,6 @@
-PYSIDE_WRAP_RC(Material_QRC_SRCS Resources/Material.qrc)
+IF (BUILD_GUI)
+    PYSIDE_WRAP_RC(Material_QRC_SRCS Resources/Material.qrc)
+ENDIF (BUILD_GUI)
 
 SET(Material_SRCS
     Init.py
@@ -34,10 +36,12 @@ fc_target_copy_resource(Material
     ${CMAKE_BINARY_DIR}/Mod/Material
     ${Material_SRCS})
 
-fc_target_copy_resource(Material
-    ${CMAKE_CURRENT_BINARY_DIR}
-    ${CMAKE_BINARY_DIR}/Mod/Material
-    Material_rc.py)
+IF (BUILD_GUI)
+    fc_target_copy_resource(Material
+        ${CMAKE_CURRENT_BINARY_DIR}
+        ${CMAKE_BINARY_DIR}/Mod/Material
+        Material_rc.py)
+ENDIF (BUILD_GUI)
 
 ADD_CUSTOM_TARGET(MaterialLib ALL
     SOURCES ${MaterialLib_Files}

--- a/src/Mod/OpenSCAD/CMakeLists.txt
+++ b/src/Mod/OpenSCAD/CMakeLists.txt
@@ -1,4 +1,6 @@
-PYSIDE_WRAP_RC(OpenSCAD_QRC_SRCS Resources/OpenSCAD.qrc)
+IF (BUILD_GUI)
+    PYSIDE_WRAP_RC(OpenSCAD_QRC_SRCS Resources/OpenSCAD.qrc)
+ENDIF (BUILD_GUI)
 
 SET(OpenSCAD_SRCS
         Init.py
@@ -32,10 +34,12 @@ ADD_CUSTOM_TARGET(OpenSCAD ALL
 
 fc_copy_sources(OpenSCAD "${CMAKE_BINARY_DIR}/Mod/OpenSCAD" ${all_files})
 
-fc_target_copy_resource(OpenSCAD
-    ${CMAKE_CURRENT_BINARY_DIR}
-    ${CMAKE_BINARY_DIR}/Mod/OpenSCAD
-    OpenSCAD_rc.py)
+IF (BUILD_GUI)
+    fc_target_copy_resource(OpenSCAD
+        ${CMAKE_CURRENT_BINARY_DIR}
+        ${CMAKE_BINARY_DIR}/Mod/OpenSCAD
+        OpenSCAD_rc.py)
+ENDIF (BUILD_GUI)
 
 INSTALL(
     FILES

--- a/src/Mod/Plot/CMakeLists.txt
+++ b/src/Mod/Plot/CMakeLists.txt
@@ -1,4 +1,6 @@
-PYSIDE_WRAP_RC(Plot_QRC_SRCS resources/Plot.qrc)
+IF (BUILD_GUI)
+    PYSIDE_WRAP_RC(Plot_QRC_SRCS resources/Plot.qrc)
+ENDIF (BUILD_GUI)
 
 SET(PlotMain_SRCS
 	Plot.py
@@ -56,10 +58,12 @@ ADD_CUSTOM_TARGET(Plot ALL
 
 fc_copy_sources(Plot "${CMAKE_BINARY_DIR}/Mod/Plot" ${all_files})
 
-fc_target_copy_resource(Plot
-    ${CMAKE_CURRENT_BINARY_DIR}
-    ${CMAKE_BINARY_DIR}/Mod/Plot
-    Plot_rc.py)
+IF (BUILD_GUI)
+    fc_target_copy_resource(Plot
+        ${CMAKE_CURRENT_BINARY_DIR}
+        ${CMAKE_BINARY_DIR}/Mod/Plot
+        Plot_rc.py)
+ENDIF (BUILD_GUI)
 
 INSTALL(
     FILES

--- a/src/Mod/Ship/CMakeLists.txt
+++ b/src/Mod/Ship/CMakeLists.txt
@@ -1,4 +1,6 @@
-PYSIDE_WRAP_RC(Ship_QRC_SRCS resources/Ship.qrc)
+IF(BUILD_GUI)
+    PYSIDE_WRAP_RC(Ship_QRC_SRCS resources/Ship.qrc)
+ENDIF(BUILD_GUI)
 
 SET(ShipMain_SRCS
     InitGui.py
@@ -116,10 +118,12 @@ ADD_CUSTOM_TARGET(Ship ALL
 
 fc_copy_sources(Ship "${CMAKE_BINARY_DIR}/Mod/Ship" ${all_files})
 
-fc_target_copy_resource(Ship
-    ${CMAKE_CURRENT_BINARY_DIR}
-    ${CMAKE_BINARY_DIR}/Mod/Ship
-    Ship_rc.py)
+IF(BUILD_GUI)
+    fc_target_copy_resource(Ship
+        ${CMAKE_CURRENT_BINARY_DIR}
+        ${CMAKE_BINARY_DIR}/Mod/Ship
+        Ship_rc.py)
+ENDIF(BUILD_GUI)
 
 INSTALL(
     FILES


### PR DESCRIPTION
Allows for building with BUILD_GUI=0.  Tested on Mac only, but looks reasonably safe :).