### PR TITLE
Find Netgen/nglib on MacOS with MacPorts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -470,7 +470,8 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
         # Try to find Homebrew path
         find_program(HOMEBREW_EXECUTABLE brew)
         if(EXISTS ${HOMEBREW_EXECUTABLE})
-            set(HOMEBREW_PREFIX "/usr/local")
+            string(REPLACE "/bin/brew" ""
+                   HOMEBREW_PREFIX ${HOMEBREW_EXECUTABLE})
             message(STATUS "Detected Homebrew install at ${HOMEBREW_PREFIX}")
         endif()
 

--- a/cMake/FindNETGEN.cmake
+++ b/cMake/FindNETGEN.cmake
@@ -1,23 +1,52 @@
 # Try to find nglib/netgen
+# 
+# Optional input NETGENDATA is path to the netgen libsrc source tree - this is
+# required due to some headers not being installed by netgen.
+#
 # Once done this will define
 #
 # NGLIB_INCLUDE_DIR   - where the nglib include directory can be found
 # NGLIB_LIBRARIES     - Link this to use nglib
 # NETGEN_INCLUDE_DIRS - where the netgen include directories can be found
+# NETGEN_DEFINITIONS  - C++ compiler defines required to use netgen/nglib
 #
 # See also: http://git.salome-platform.org/gitweb/?p=NETGENPLUGIN_SRC.git;a=summary
 
-# nglib
-FIND_PATH(NGLIB_INCLUDE_DIR nglib.h /usr/include)
-FIND_LIBRARY(NGLIB_LIBRARIES nglib /usr/lib /usr/local/lib)
+SET(NETGEN_DEFINITIONS -DNO_PARALLEL_THREADS -DOCCGEOMETRY)
 
-# netgen headers
-SET(NETGEN_INCLUDE_DIRS)
-SET(NETGEN_INCLUDE_DIRS ${NETGEN_INCLUDE_DIRS} -DNO_PARALLEL_THREADS -DOCCGEOMETRY)
+IF(DEFINED MACPORTS_PREFIX OR DEFINED HOMEBREW_PREFIX)
+    # We haven't supported Netgen prior to 5.3.1 on MacOS, and the current
+    # plan is for the next Netgen version to be 6.1 (currently unreleased).
+    LIST( APPEND NETGEN_DEFINITIONS -DNETGEN_V5 )
 
-if(NOT NETGENDATA)
-    SET(NETGENDATA /usr/share/netgen/libsrc)
-endif()
+    IF(DEFINED HOMEBREW_PREFIX)
+        EXEC_PROGRAM(brew ARGS --prefix nglib OUTPUT_VARIABLE NGLIB_PREFIX)
+    ELSE(DEFINED HOMEBREW_PREFIX)
+        SET(NGLIB_PREFIX ${MACPORTS_PREFIX})
+    ENDIF(DEFINED HOMEBREW_PREFIX)
+
+    FIND_PATH(NGLIB_INCLUDE_DIR nglib.h ${NGLIB_PREFIX}/include)
+
+    FIND_LIBRARY(NGLIB_LIBNGLIB nglib ${NGLIB_PREFIX}/lib)
+    FIND_LIBRARY(NGLIB_LIBMESH mesh ${NGLIB_PREFIX}/lib)
+    FIND_LIBRARY(NGLIB_LIBOCC occ ${NGLIB_PREFIX}/lib)
+    FIND_LIBRARY(NGLIB_LIBINTERFACE interface ${NGLIB_PREFIX}/lib)
+    SET(NGLIB_LIBRARIES ${NGLIB_LIBNGLIB} ${NGLIB_LIBMESH}
+                        ${NGLIB_LIBOCC} ${NGLIB_LIBINTERFACE})
+
+    IF(NOT NETGENDATA)
+        SET(NETGENDATA ${NGLIB_PREFIX}/include/netgen)
+    ENDIF(NOT NETGENDATA)
+
+ELSE(DEFINED MACPORTS_PREFIX OR DEFINED HOMEBREW_PREFIX)
+    FIND_PATH(NGLIB_INCLUDE_DIR nglib.h /usr/include)
+    FIND_LIBRARY(NGLIB_LIBRARIES nglib /usr/lib /usr/local/lib)
+
+    IF(NOT NETGENDATA)
+        SET(NETGENDATA /usr/share/netgen/libsrc)
+    ENDIF(NOT NETGENDATA)
+
+ENDIF(DEFINED MACPORTS_PREFIX OR DEFINED HOMEBREW_PREFIX)
 
 FIND_PATH(NETGEN_DIR_csg csg.hpp PATHS ${NETGENDATA}/csg)
 FIND_PATH(NETGEN_DIR_gen array.hpp PATHS ${NETGENDATA}/general)
@@ -28,12 +57,8 @@ FIND_PATH(NETGEN_DIR_mesh meshing.hpp PATHS ${NETGENDATA}/meshing)
 FIND_PATH(NETGEN_DIR_occ occgeom.hpp PATHS ${NETGENDATA}/occ)
 FIND_PATH(NETGEN_DIR_stlgeom stlgeom.hpp PATHS ${NETGENDATA}/stlgeom)
 
-SET(NETGEN_INCLUDE_DIRS ${NETGEN_INCLUDE_DIRS} ${NETGEN_DIR_csg})
-SET(NETGEN_INCLUDE_DIRS ${NETGEN_INCLUDE_DIRS} ${NETGEN_DIR_gen})
-SET(NETGEN_INCLUDE_DIRS ${NETGEN_INCLUDE_DIRS} ${NETGEN_DIR_geom2d})
-SET(NETGEN_INCLUDE_DIRS ${NETGEN_INCLUDE_DIRS} ${NETGEN_DIR_gprim})
-SET(NETGEN_INCLUDE_DIRS ${NETGEN_INCLUDE_DIRS} ${NETGEN_DIR_la})
-SET(NETGEN_INCLUDE_DIRS ${NETGEN_INCLUDE_DIRS} ${NETGEN_DIR_mesh})
-SET(NETGEN_INCLUDE_DIRS ${NETGEN_INCLUDE_DIRS} ${NETGEN_DIR_occ})
-SET(NETGEN_INCLUDE_DIRS ${NETGEN_INCLUDE_DIRS} ${NETGEN_DIR_stlgeom})
+LIST( APPEND NETGEN_INCLUDE_DIRS
+      ${NETGEN_DIR_csg} ${NETGEN_DIR_gen} ${NETGEN_DIR_geom2d} 
+      ${NETGEN_DIR_gprim} ${NETGEN_DIR_la} ${NETGEN_DIR_mesh}
+      ${NETGEN_DIR_occ} ${NETGEN_DIR_stlgeom} )
 

--- a/src/3rdParty/salomesmesh/CMakeLists.txt
+++ b/src/3rdParty/salomesmesh/CMakeLists.txt
@@ -38,34 +38,34 @@ include_directories(
 link_directories(${OCC_LIBRARY_DIR})
 
 if(MSVC)
-	if(BUILD_FEM_NETGEN)
-		set(SMESH_LIBS
-			debug     MSVCRTD.LIB
-			debug     MSVCPRTD.LIB
-			optimized MSVCRT.LIB
-			optimized MSVCPRT.LIB
-			Rpcrt4.lib
-			${NGLIB_LIBRARIES}
-			${NGLIB_DEBUG_LIBRARIES}
-			${OCC_LIBRARIES}
-			${OCC_DEBUG_LIBRARIES}
-			${OCC_OCAF_DEBUG_LIBRARIES}
-			${OCC_OCAF_LIBRARIES}
-		)
-	else(BUILD_FEM_NETGEN)
-		set(SMESH_LIBS
-			debug     MSVCRTD.LIB
-			debug     MSVCPRTD.LIB
-			optimized MSVCRT.LIB
-			optimized MSVCPRT.LIB
-			Rpcrt4.lib
-			${OCC_LIBRARIES}
-			${OCC_DEBUG_LIBRARIES}
-			${OCC_OCAF_DEBUG_LIBRARIES}
-			${OCC_OCAF_LIBRARIES}
-		)
-	endif(BUILD_FEM_NETGEN)
-	
+    if(BUILD_FEM_NETGEN)
+        set(SMESH_LIBS
+            debug     MSVCRTD.LIB
+            debug     MSVCPRTD.LIB
+            optimized MSVCRT.LIB
+            optimized MSVCPRT.LIB
+            Rpcrt4.lib
+            ${NGLIB_LIBRARIES}
+            ${NGLIB_DEBUG_LIBRARIES}
+            ${OCC_LIBRARIES}
+            ${OCC_DEBUG_LIBRARIES}
+            ${OCC_OCAF_DEBUG_LIBRARIES}
+            ${OCC_OCAF_LIBRARIES}
+        )
+        ADD_DEFINITIONS(${NETGEN_DEFINITIONS})
+    else(BUILD_FEM_NETGEN)
+        set(SMESH_LIBS
+            debug     MSVCRTD.LIB
+            debug     MSVCPRTD.LIB
+            optimized MSVCRT.LIB
+            optimized MSVCPRT.LIB
+            Rpcrt4.lib
+            ${OCC_LIBRARIES}
+            ${OCC_DEBUG_LIBRARIES}
+            ${OCC_OCAF_DEBUG_LIBRARIES}
+            ${OCC_OCAF_LIBRARIES}
+        )
+    endif(BUILD_FEM_NETGEN)
 else(MSVC)
     if(BUILD_FEM_NETGEN)
         set(SMESH_LIBS
@@ -73,6 +73,7 @@ else(MSVC)
             ${OCC_LIBRARIES}
             ${OCC_OCAF_LIBRARIES}
         )
+        ADD_DEFINITIONS(${NETGEN_DEFINITIONS})
     else(BUILD_FEM_NETGEN)
         set(SMESH_LIBS
             ${OCC_LIBRARIES}

--- a/src/3rdParty/salomesmesh/src/NETGENPlugin/NETGENPlugin_NETGEN_2D_ONLY.cpp
+++ b/src/3rdParty/salomesmesh/src/NETGENPlugin/NETGENPlugin_NETGEN_2D_ONLY.cpp
@@ -57,7 +57,9 @@
 namespace nglib {
 #include <nglib.h>
 }
-#define OCCGEOMETRY
+#ifndef OCCGEOMETRY
+    #define OCCGEOMETRY
+#endif // #ifndef OCCGEOMETRY
 #include <occgeom.hpp>
 #include <meshing.hpp>
 //#include <meshtype.hpp>

--- a/src/Mod/Fem/App/CMakeLists.txt
+++ b/src/Mod/Fem/App/CMakeLists.txt
@@ -5,7 +5,7 @@ else(MSVC)
 endif(MSVC)
 
 if(BUILD_FEM_NETGEN)
-    add_definitions(-DFCWithNetgen)
+    add_definitions(-DFCWithNetgen ${NETGEN_DEFINITIONS})
 endif(BUILD_FEM_NETGEN)
 
 


### PR DESCRIPTION
This should allow for building in netgen support on Macs using MacPorts, assuming the ticket at https://trac.macports.org/ticket/50687 is accepted.  It's not intended to change any behaviour unless MACPORTS_PREFIX is defined.

@peterl94  - Let me know if you run into problems making up a Homebrew recipe.  I ended up making the MacPorts port just copy the entire libsrc directory to the MacPorts equivalent of /share/netgen/libsrc .