### PR TITLE
Helical/linear ramp plunging

### DIFF
--- a/src/Mod/Draft/DraftGeomUtils.py
+++ b/src/Mod/Draft/DraftGeomUtils.py
@@ -2075,20 +2075,8 @@ def rebaseWire(wire,vidx):
     if vidx > len(wire.Vertexes):
         #print("Vertex index above maximum\n")
         return wire
-    basepoint = wire.Vertexes[vidx-1].Point
-    #wire = Part.__sortEdges__(wire)
-    edges = []
-    start = False
-    for i in range(len(wire.Edges)):
-        if wire.Edges[i].Vertexes[0].Point == basepoint:
-            start = True
-            edges.append(wire.Edges[i])
-        elif start:
-            edges.append(wire.Edges[i])
-    if len(edges) < len(wire.Edges):
-        f = len(wire.Edges) - len(edges)
-        edges.extend(wire.Edges[0:f])
-    return Part.Wire(edges)
+    #This can be done in one step
+    return Part.Wire(wire.Edges[vidx-1:] + wire.Edges[:vidx-1])
 
 
 # circle functions *********************************************************

--- a/src/Mod/Path/Gui/ViewProviderPath.cpp
+++ b/src/Mod/Path/Gui/ViewProviderPath.cpp
@@ -288,12 +288,14 @@ void ViewProviderPath::updateData(const App::Property* prop)
                 if (angle == 0)
                     angle = M_PI * 2;
                 int segments = 3/(deviation/angle); //we use a rather simple rule here, provisorily
+                double dZ = (next.z - last.z)/segments; //How far each sigment will helix in Z
                 for (int j = 1; j < segments; j++) {
                     //std::cout << "vector " << j << std::endl;
                     Base::Vector3d inter;
                     Base::Rotation rot(norm,(angle/segments)*j);
                     //std::cout << "angle " << (angle/segments)*j << std::endl;
                     rot.multVec((last - center),inter);
+                    inter.z = dZ * j; //Enable displaying helices
                     //std::cout << "result " << inter.x << " , " << inter.y << " , " << inter.z << std::endl;
                     points.push_back( center + inter);
                     colorindex.push_back(1);

--- a/src/Mod/Path/PathScripts/PathPocket.py
+++ b/src/Mod/Path/PathScripts/PathPocket.py
@@ -179,7 +179,7 @@ class ObjectPocket:
 #            print "finishDepth" + str(obj.FinishDepth)
 #            print "offsets:", len(offsets)
 
-            def prnt(vlu): return str(round(vlu, 4))
+            def prnt(vlu): return str("%.4f" % round(vlu, 4))
 
             for vpos in frange(obj.StartDepth, obj.FinalDepth, obj.StepDown, obj.FinishDepth):
 #                print "vpos: " + str(vpos)


### PR DESCRIPTION
Both features are basically functional, and I'm short on time these days to refine further. Overview of features:

-When possible, a helical plunge is attempted
-If helical plunging isn't possible, a linear ramp is attempted
-If a linear ramp fails, a straight plunge is performed (really shouldn't ever need to happen, but code for linear ramp could use some improvement)
-Minor cleanups to other parts of the code
-Both linear ramps and helical plunging are properly displayed in the GUI


Possible improvements:

-Code for determining when a helical plunge is possible seems to work OK, but could stand a more rigorous check for interior plunges
-Linear ramp code could stand improvement. It should basically always be possible to perform a linear ramp plunge, but my method of identifying a place in the workpiece to do it is less than ideal
-Plunging is attempted as close to the starting point of the clearing paths. Since the ordering of the clearing offsets really needs to be fixed, this may or may not work OK in the future.