### PR TITLE
replaced str() objects with unicode() objects

### DIFF
--- a/src/Mod/Ship/Instance.py
+++ b/src/Mod/Ship/Instance.py
@@ -41,7 +41,7 @@ class Ship:
         solids -- Set of solids which will compound the ship hull.
         """
         # Add an unique property to identify the Ship instances
-        tooltip = str(QtGui.QApplication.translate(
+        tooltip = unicode(QtGui.QApplication.translate(
             "Ship",
             "True if it is a valid ship instance, False otherwise",
             None,
@@ -51,7 +51,7 @@ class Ship:
                         "Ship",
                         tooltip).IsShip = True
         # Add the main dimensions
-        tooltip = str(QtGui.QApplication.translate(
+        tooltip = unicode(QtGui.QApplication.translate(
             "Ship",
             "Ship length [m]",
             None,
@@ -60,7 +60,7 @@ class Ship:
                         "Length",
                         "Ship",
                         tooltip).Length = 0.0
-        tooltip = str(QtGui.QApplication.translate(
+        tooltip = unicode(QtGui.QApplication.translate(
             "Ship",
             "Ship breadth [m]",
             None,
@@ -69,7 +69,7 @@ class Ship:
                         "Breadth",
                         "Ship",
                         tooltip).Breadth = 0.0
-        tooltip = str(QtGui.QApplication.translate(
+        tooltip = unicode(QtGui.QApplication.translate(
             "Ship",
             "Ship draft [m]",
             None,
@@ -80,7 +80,7 @@ class Ship:
                         tooltip).Draft = 0.0
         # Add the subshapes
         obj.Shape = Part.makeCompound(solids)
-        tooltip = str(QtGui.QApplication.translate(
+        tooltip = unicode(QtGui.QApplication.translate(
             "Ship",
             "Set of external faces of the ship hull",
             None,
@@ -89,7 +89,7 @@ class Ship:
                         "ExternalFaces",
                         "Ship",
                         tooltip)
-        tooltip = str(QtGui.QApplication.translate(
+        tooltip = unicode(QtGui.QApplication.translate(
             "Ship",
             "Set of weight instances",
             None,
@@ -98,7 +98,7 @@ class Ship:
                         "Weights",
                         "Ship",
                         tooltip).Weights = []
-        tooltip = str(QtGui.QApplication.translate(
+        tooltip = unicode(QtGui.QApplication.translate(
             "Ship",
             "Set of tank instances",
             None,
@@ -107,7 +107,7 @@ class Ship:
                         "Tanks",
                         "Ship",
                         tooltip).Tanks = []
-        tooltip = str(QtGui.QApplication.translate(
+        tooltip = unicode(QtGui.QApplication.translate(
             "Ship",
             "Set of load conditions",
             None,


### PR DESCRIPTION
replaced str() with unicode() to respect QtGui.QApplication.UnicodeUTF8 and to prevent:

```
File "/usr/lib64/freecad-9999/Mod/Ship/Instance.py", line 48, in __init__
    QtGui.QApplication.UnicodeUTF8))
<type 'exceptions.UnicodeEncodeError'>: 'ascii' codec can't encode character u'\xfc' in position 20: ordinal not in range(128)
```