### PR TITLE
Set QComboBox icon size

### DIFF
--- a/src/Gui/Action.cpp
+++ b/src/Gui/Action.cpp
@@ -508,6 +508,7 @@ void WorkbenchGroup::addTo(QWidget *w)
     if (w->inherits("QToolBar")) {
         QToolBar* bar = qobject_cast<QToolBar*>(w);
         QComboBox* box = new WorkbenchComboBox(this, w);
+        box->setIconSize(QSize(16, 16));
         box->setToolTip(_action->toolTip());
         box->setStatusTip(_action->statusTip());
         box->setWhatsThis(_action->whatsThis());


### PR DESCRIPTION
Fix icon size in workbench switcher on Mac as discussed:

https://github.com/FreeCAD/FreeCAD/pull/102

P.S. On additional note if somebody is up to it i believe better approach would be to set icon size based on icon size value set in FreeCAD Preferences.