### PR TITLE
Cleanup Application after failed document open.

### DIFF
--- a/src/App/Application.cpp
+++ b/src/App/Application.cpp
@@ -444,7 +444,24 @@ Document* Application::openDocument(const char * FileName)
     newDoc->FileName.setValue(File.filePath());
 
     // read the document
-    newDoc->restore();
+    try {
+        newDoc->restore();
+    } catch (...) {
+        for (std::map<std::string, Document *>::iterator it = DocMap.begin();
+             it != DocMap.end(); ++it) {
+            if (it->second == newDoc) {
+                DocMap.erase(it);
+                break;
+            }
+        }
+
+        if (newDoc == _pActiveDoc)
+            setActiveDocument(static_cast<Document *>(0));
+
+        delete newDoc;
+
+        throw;
+    }
 
     return newDoc;
 }


### PR DESCRIPTION
This evening I happened to notice that when Application::openDocument() fails, it leaves some stale state.  Here's a little fix - no worries if this goes in before/after 0.16.