### PR TITLE
Exit with non-zero status when unit tests fail.

### DIFF
--- a/src/App/FreeCADTest.py
+++ b/src/App/FreeCADTest.py
@@ -32,9 +32,10 @@
 
 Log ("FreeCAD test running...\n\n")
 
-import TestApp;TestApp.TestText("TestApp.All")
+import TestApp, os
 
+testResult = TestApp.TestText("TestApp.All")
 
 Log ("FreeCAD test done\n")
 
-
+os._exit(0 if testResult.wasSuccessful() else 1)

--- a/src/Mod/Test/TestApp.py
+++ b/src/Mod/Test/TestApp.py
@@ -63,7 +63,7 @@ def All():
 def TestText(s):
     s = unittest.defaultTestLoader.loadTestsFromName(s)
     r = unittest.TextTestRunner(stream=sys.stdout, verbosity=2)
-    r.run(s)
+    return r.run(s)
 
 
 def Test(s):
@@ -72,7 +72,7 @@ def Test(s):
 
 def testAll():
     r = unittest.TextTestRunner(stream=sys.stdout, verbosity=2)
-    r.run(All())
+    return r.run(All())
 
 
 def testUnit():


### PR DESCRIPTION
1.  Enhanced TestApp.py to return the unittest TestResult object to the calling method
2.  FreeCADTest.py now checks the TestResult object.  If all tests pass, FreeCADTest.py exits with a 0 however if any tests fail, then it exits with 1.  FreeCADTest.py calls os._exit() with the exit code instead of sys.exit() because Base::Interpreter:SystemExitException intercepts sys.exit() calls and swallows the exit code so there is no way to propogate the non-zero code from the python test cases through the interpreter to the shell in the current call stack.
