### PR TITLE
Catch exceptions in FreeCADCmd like FreeCAD

### DIFF
--- a/src/Main/MainCmd.cpp
+++ b/src/Main/MainCmd.cpp
@@ -122,8 +122,18 @@ int main( int argc, char ** argv )
     }
 
     // Run phase ===========================================================
-    Application::runApplication();
-
+    try {
+        Application::runApplication();
+    }
+    catch (const Base::SystemExitException&) {
+        exit(0);
+    }
+    catch (const Base::Exception& e) {
+        e.ReportException();
+    }
+    catch (...) {
+        Console().Error("Application unexpectedly terminated\n");
+    }
 
     // Destruction phase ===========================================================
     Console().Log("FreeCAD terminating...\n");


### PR DESCRIPTION
To reproduce, make a simple script/macro that hits an exit().  Run script via command line in FreeCAD, everything is fine.  Run it in FreeCADCmd and get an unhandled exception.