### PR TITLE
More fixes around Python exit codes

### DIFF
--- a/src/Base/Interpreter.cpp
+++ b/src/Base/Interpreter.cpp
@@ -131,7 +131,7 @@ SystemExitException::SystemExitException()
 }
 
 SystemExitException::SystemExitException(const SystemExitException &inst)
-  : Exception(inst)
+  : Exception(inst), _exitCode(inst._exitCode)
 {
 }
 

--- a/src/Gui/GuiApplication.cpp
+++ b/src/Gui/GuiApplication.cpp
@@ -54,14 +54,13 @@
 
 #include <Base/Console.h>
 #include <Base/Exception.h>
-#include <Base/Interpreter.h>
 
 #include <App/Application.h>
 
 using namespace Gui;
 
-GUIApplication::GUIApplication(int & argc, char ** argv, int exitcode)
-    : GUIApplicationNativeEventAware(argc, argv), systemExit(exitcode)
+GUIApplication::GUIApplication(int & argc, char ** argv)
+    : GUIApplicationNativeEventAware(argc, argv)
 {
 }
 
@@ -82,8 +81,9 @@ bool GUIApplication::notify (QObject * receiver, QEvent * event)
         else
             return QApplication::notify(receiver, event);
     }
-    catch (const Base::SystemExitException&) {
-        qApp->exit(systemExit);
+    catch (const Base::SystemExitException &e) {
+        caughtException.reset(new Base::SystemExitException(e));
+        qApp->exit(e.getExitCode());
         return true;
     }
     catch (const Base::Exception& e) {
@@ -225,8 +225,8 @@ public:
     bool running;
 };
 
-GUISingleApplication::GUISingleApplication(int & argc, char ** argv, int exitcode)
-    : GUIApplication(argc, argv, exitcode),
+GUISingleApplication::GUISingleApplication(int & argc, char ** argv)
+    : GUIApplication(argc, argv),
       d_ptr(new Private(this))
 {
     d_ptr->setupConnection();

--- a/src/Gui/GuiApplication.h
+++ b/src/Gui/GuiApplication.h
@@ -25,7 +25,9 @@
 #define GUI_APPLICATION_H
 
 #include "GuiApplicationNativeEventAware.h"
+#include <Base/Interpreter.h> // For Base::SystemExitException
 #include <QList>
+#include <boost/shared_ptr.hpp>
 
 class QSessionManager;
 
@@ -39,7 +41,7 @@ class GUIApplication : public GUIApplicationNativeEventAware
     Q_OBJECT
 
 public:
-    explicit GUIApplication(int & argc, char ** argv, int exitcode);
+    explicit GUIApplication(int & argc, char ** argv);
     virtual ~GUIApplication();
 
     /**
@@ -49,11 +51,11 @@ public:
     bool notify (QObject * receiver, QEvent * event);
     void commitData(QSessionManager &manager);
 
+    /// Pointer to exceptions caught in Qt event handler
+    boost::shared_ptr<Base::SystemExitException> caughtException;
+
 protected:
     bool event(QEvent * event);
-
-private:
-    int systemExit;
 };
 
 class GUISingleApplication : public GUIApplication
@@ -61,7 +63,7 @@ class GUISingleApplication : public GUIApplication
     Q_OBJECT
 
 public:
-    explicit GUISingleApplication(int & argc, char ** argv, int exitcode);
+    explicit GUISingleApplication(int & argc, char ** argv);
     virtual ~GUISingleApplication();
 
     bool isRunning() const;

--- a/src/Main/MainCmd.cpp
+++ b/src/Main/MainCmd.cpp
@@ -125,8 +125,8 @@ int main( int argc, char ** argv )
     try {
         Application::runApplication();
     }
-    catch (const Base::SystemExitException&) {
-        exit(0);
+    catch (const Base::SystemExitException &e) {
+        exit(e.getExitCode());
     }
     catch (const Base::Exception& e) {
         e.ReportException();


### PR DESCRIPTION
Three fixes - let me know if it would be better to separate them:

1) In the GUI application - rather than a sentinel integer to detect SystemExitExceptions, this preserves a copy of the exception.  The old system was discarding exit codes from SystemExitExceptions (due to default constructor of SystemExitException being called in src/Gui/Application.cpp).

2) Fixes an omission from commit 9816e48b07 - need to copy _exitCode in SystemExitException copy constructor.

3) Updates commit 3cd752417b to use value from SystemExitException (sorry - I didn't update master before copy-and-pasting and so missed a recent change...)
