### PR TITLE
Added OS X to Travis build configuration for unified Linux & OS X CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,67 +1,166 @@
+####
+#  Travis-CI configuration file for FreeCAD.
+#
+#  This build configuration will build and test FreeCAD on both Linux
+#  and Mac OS X.  For Mac OS X, this configuration will also package
+#  and deploy the build to GitHub provided the following prerequisites
+#  are satisfied:
+#
+#  GH_TOKEN is defined as a secure environment variable and contains a
+#           a valid GitHub OAUTH token with repo_deployment scope.
+#           NOTE: Define this env using the Travis-CI Repo Settings UI
+#
+#  FREECAD_RELEASE: A GitHub Release with this identifier exists in the
+#           repo.  The Travis job will deploy the OS X build to this
+#           GitHub release name as a release asset.
+##
+env:
+  global:
+   - FREECAD_RELEASE="0.16"
+   - DEPLOY_RELEASE=${DEPLOY_RELEASE:-$FREECAD_RELEASE}
+   - CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE:-Release}
+   - OSX_PORTS_CACHE=${OSX_PORTS_CACHE:-FreeCAD/FreeCAD-ports-cache}
+
+os:
+   - linux
+   - osx
+
+git:
+  depth: 800
+
 language: cpp
 
 before_install:
-    - sudo apt-get update -qq
-    - sudo apt-get install -y doxygen
-    - sudo apt-get install -y libboost-dev
-    - sudo apt-get install -y libboost-filesystem-dev
-    - sudo apt-get install -y libboost-program-options-dev
-    - sudo apt-get install -y libboost-python-dev
-    - sudo apt-get install -y libboost-regex-dev
-    - sudo apt-get install -y libboost-signals-dev
-    - sudo apt-get install -y libboost-system-dev
-    - sudo apt-get install -y libboost-thread-dev
-    - sudo apt-get install -y libcoin60
-    - sudo apt-get install -y libcoin60-dev
-    - sudo apt-get install -y libeigen3-dev
-    - sudo apt-get install -y liboce-foundation-dev
-    - sudo apt-get install -y liboce-foundation1
-    - sudo apt-get install -y liboce-modeling-dev
-    - sudo apt-get install -y liboce-modeling1
-    - sudo apt-get install -y liboce-ocaf-dev
-    - sudo apt-get install -y liboce-ocaf-lite-dev
-    - sudo apt-get install -y liboce-ocaf-lite1
-    - sudo apt-get install -y liboce-ocaf1
-    - sudo apt-get install -y liboce-visualization-dev
-    - sudo apt-get install -y liboce-visualization1
-    - sudo apt-get install -y libopencascade-modeling-6.5.0
-    - sudo apt-get install -y libpyside-dev
-    - sudo apt-get install -y libqtcore4
-    - sudo apt-get install -y libshiboken-dev
-    - sudo apt-get install -y libxerces-c-dev
-    - sudo apt-get install -y libxmu-dev
-    - sudo apt-get install -y libxmu-headers
-    - sudo apt-get install -y libxmu6
-    - sudo apt-get install -y libxmuu-dev
-    - sudo apt-get install -y libxmuu1
-    - sudo apt-get install -y oce-draw
-    - sudo apt-get install -y pyside-tools
-    - sudo apt-get install -y python-dev
-    - sudo apt-get install -y python-pyside
-    - sudo apt-get install -y python-matplotlib
-    - sudo apt-get install -y qt4-dev-tools
-    - sudo apt-get install -y qt4-qmake
-    - sudo apt-get install -y shiboken
-    - sudo apt-get install -y swig
-#Patch the system - there is a bug related to invalid location of libs on ubuntu 12.04
-    - sudo ln -s /usr/lib/x86_64-linux-gnu/ /usr/lib/i386-linux-gnu
-    - "export DISPLAY=:99.0"
-    - "sh -e /etc/init.d/xvfb start"
+- eval "$(curl -fsSL "https://raw.githubusercontent.com/${OSX_PORTS_CACHE}/v${FREECAD_RELEASE}/travis-helpers.sh")"
+- |
+  case "${TRAVIS_OS_NAME}" in
+
+   "linux")
+       sudo apt-get update -qq
+       sudo apt-get install -y doxygen                        \
+                               libboost-dev                   \
+                               libboost-filesystem-dev        \
+                               libboost-program-options-dev   \
+                               libboost-python-dev            \
+                               libboost-regex-dev             \
+                               libboost-signals-dev           \
+                               libboost-system-dev            \
+                               libboost-thread-dev            \
+                               libcoin60                      \
+                               libcoin60-dev                  \
+                               libeigen3-dev                  \
+                               liboce-foundation-dev          \
+                               liboce-foundation1             \
+                               liboce-modeling-dev            \
+                               liboce-modeling1               \
+                               liboce-ocaf-dev                \
+                               liboce-ocaf-lite-dev           \
+                               liboce-ocaf-lite1              \
+                               liboce-ocaf1                   \
+                               liboce-visualization-dev       \
+                               liboce-visualization1          \
+                               libopencascade-modeling-6.5.0  \
+                               libpyside-dev                  \
+                               libqtcore4                     \
+                               libshiboken-dev                \
+                               libxerces-c-dev                \
+                               libxmu-dev                     \
+                               libxmu-headers                 \
+                               libxmu6                        \
+                               libxmuu-dev                    \
+                               libxmuu1                       \
+                               oce-draw                       \
+                               pyside-tools                   \
+                               python-dev                     \
+                               python-pyside                  \
+                               python-matplotlib              \
+                               qt4-dev-tools                  \
+                               qt4-qmake                      \
+                               shiboken                       \
+                               swig
+
+       #Patch the system - there is a bug related to invalid location of libs on ubuntu 12.04
+       sudo ln -s /usr/lib/x86_64-linux-gnu/ /usr/lib/i386-linux-gnu
+       export DISPLAY=:99.0
+       sh -e /etc/init.d/xvfb start
+
+       CMAKE_ARGS=""
+       INSTALLED_APP_PATH="/usr/local/bin/FreeCAD"
+       ;;
+
+   "osx")
+       brew update >/dev/null
+       if [ "${OSX_PORTS_CACHE}X" != "X" ]; then
+            brew install jq
+            cacheContext=$(create_helper_context repo=${OSX_PORTS_CACHE} auth_token=${GH_TOKEN} release=${FREECAD_RELEASE})
+            prime_local_ports_cache $cacheContext
+       fi
+       brew install eigen                       \
+                    freetype                    \
+                    qt                          \
+                    python                      \
+                    boost-python                \
+                    pyside                      \
+                    pyside-tools                \
+                    xerces-c                    \
+                    orocos-kdl                  \
+                    homebrew/science/oce        \
+                    homebrew/python/matplotlib
+       brew install --with-oce homebrew/science/nglib
+       brew install --without-framework --without-soqt sanelson/freecad/coin
+       brew install --HEAD pivy
+
+       #Install the 3DConnexion frameworks
+       if [ ! -d /Library/Frameworks/3DconnexionClient.framework ]; then
+          curl -o /tmp/3dFW.dmg -L 'http://www.3dconnexion.com/index.php?eID=sdl&ext=tx_iccsoftware&oid=a273bdbc-c289-e10d-816b-567043331c9e&filename=3DxWareMac_v10-2-5_r2142.dmg'
+          hdiutil attach -readonly /tmp/3dFW.dmg
+          sudo installer -package /Volumes/3Dconnexion\ Software/Install\ 3Dconnexion\ software.pkg -target /
+       fi
+
+       #Remove GDAL if installed because it results in non-existent dependent library exceptions
+       if [ -e /usr/local/lib/libgdal.1.dylib ]; then brew unlink gdal; fi
+
+       CMAKE_ARGS="-DFREECAD_USE_EXTERNAL_KDL=ON -DBUILD_FEM_NETGEN=ON -DFREECAD_CREATE_MAC_APP=ON"
+       INSTALLED_APP_PATH="/usr/local/FreeCAD.app/Contents/bin/FreeCAD"
+       ;;
+
+   *)
+       echo "Invalid or unsupported operating system ${TRAVIS_OS_NAME}"
+       exit 1
+       ;;
+  esac
 
 install:
-    - mkdir build && cd build && cmake ../
+####
+#  Build FreeCAD with cmake options set above for each platform
+##
+  - mkdir build && cd build && cmake ${CMAKE_ARGS} -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} ../
 
 script:
-    - make -j2
-    - PYTHONPATH=$(pwd)/lib/ python -c "import sys, unittest, FreeCAD, TestApp; sys.exit(0 if unittest.TextTestRunner().run(TestApp.All()).wasSuccessful() else 1)"
-    - bin/FreeCAD --log-file /tmp/FreeCAD.log &
-    - sleep 10 && pkill FreeCAD
-    - cat /tmp/FreeCAD.log
-    - grep --file=../.log_errors /tmp/FreeCAD.log ; [ $? == 1 ] && echo "No errors from .log_errors file found in the log after start from build directory" || ( echo "Error from .log_errors found!" && false )
-    - sudo make install
-    - /usr/local/bin/FreeCAD --run-test 0
-    - /usr/local/bin/FreeCAD --log-file /tmp/FreeCAD_installed.log &
-    - sleep 10 && pkill FreeCAD
-    - cat /tmp/FreeCAD_installed.log
-    - grep --file=../.log_errors /tmp/FreeCAD_installed.log ; [ $? == 1 ] && echo "No errors from .log_errors file found in the log after start from /usr/local/bin" || ( echo "Error from .log_errors found!" && false )
+####
+#  Install FreeCAD and run unit tests.  Test failures will fail the build
+##
+  - sudo make -j2 install
+  - ${INSTALLED_APP_PATH} --run-test 0
+  - ${INSTALLED_APP_PATH} --log-file /tmp/FreeCAD_installed.log &
+  - sleep 10 && pkill FreeCAD
+  - cat /tmp/FreeCAD_installed.log
+  - grep --file=../.log_errors /tmp/FreeCAD_installed.log ; [ $? == 1 ] && echo "No errors from .log_errors file found in the log after start from /usr/local/bin" || ( echo "Error from .log_errors found!" && false )
 
+after_success:
+####
+#  Package and deploy the build to GitHub.  This will only run for builds on
+#  master (i.e. pull requests are only built and tested but not deployed).
+#
+#  GH_TOKEN must be set in order to deploy releases to GitHub
+##
+- |
+  if [ "${TRAVIS_OS_NAME}" == "osx" -a "${TRAVIS_PULL_REQUEST}" == "false" ]; then
+     brew install jq node && npm install -g appdmg
+     export VSN=$(python ${TRAVIS_BUILD_DIR}/src/Tools/ArchiveNameFromVersionHeader.py ${TRAVIS_BUILD_DIR}/build/src/Build/Version.h --git-SHA=$(git ls-remote origin master))
+     export DEPLOYMENT_ARCHIVE=${VSN}.dmg
+     appdmg ${TRAVIS_BUILD_DIR}/src/MacAppBundle/DiskImage/layout.json "${DEPLOYMENT_ARCHIVE}"
+     deployContext=$(create_helper_context repo=${TRAVIS_REPO_SLUG} auth_token=${GH_TOKEN} release=${DEPLOY_RELEASE})
+     gitHub_deploy_asset_to_release_named $deployContext ${DEPLOYMENT_ARCHIVE}
+     gitHub_prune_assets_for_release_named $deployContext "-OSX-" 3
+  fi

--- a/README.md
+++ b/README.md
@@ -37,6 +37,18 @@ software center application.
 
 Other options are described at http://www.freecadweb.org/wiki/index.php?title=Download
 
+Build Status <img src="https://cdn.travis-ci.org/images/travis-mascot-150-3791701416eeee8479e23fe4bb7edf4f.png" height="30"/>
+------------
+
+| Master | 0.16 |
+|:------:|:----:|
+|[![Master][freecad-master-status]][travis-branches]|[![0.16][freecad-0.16-status]][travis-branches]|
+
+[freecad-0.16-status]: https://travis-ci-org/FreeCAD/FreeCAD.svg?branch=0.16
+[freecad-master-status]: https://travis-ci.org/FreeCAD/FreeCAD.svg?branch=master
+[travis-branches]: https://travis-ci.org/FreeCAD/FreeCAD/branches
+[travis-builds]: https://travis-ci.org/FreeCAD/FreeCAD/builds
+
 Compiling
 ---------
 


### PR DESCRIPTION
This PR, enables simultaneous Linux and OS X builds using Travis-CI.  The build status will be presented on the FreeCAD home page and the OS X builds will be automatically deployed to the FreeCAD GitHub Releases section.

Developed in close communication with @sgrogan to ensure auto-deploying OS X builds will support the FreeCAD release management process.

Mantis issue: http://www.freecadweb.org/tracker/view.php?id=2414
FreeCAD Discussion:  http://forum.freecadweb.org/viewtopic.php?f=10&t=15064
Smoke Test Results on Travis-CI: https://travis-ci.org/bblacey/FreeCAD-MacOS-CI

Once this pull request is inspected and merged, I will configure Travis builds on the main repo.  