### PR TITLE
Matrix 0.17 Improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,28 +16,35 @@
 ##
 env:
   global:
-   - FREECAD_RELEASE="0.17"
-   - DEPLOY_RELEASE=${DEPLOY_RELEASE:-$FREECAD_RELEASE}
-   - CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE:-Release}
-   - OSX_PORTS_CACHE=${OSX_PORTS_CACHE:-FreeCAD/FreeCAD-ports-cache}
+    - FREECAD_RELEASE="0.17"
+    - DEPLOY_RELEASE=${DEPLOY_RELEASE:-$FREECAD_RELEASE}
+    - CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE:-Release}
+    - OSX_PORTS_CACHE=${OSX_PORTS_CACHE:-FreeCAD/FreeCAD-ports-cache}
+  matrix:
+    - CMAKE_OPTS="-DBUILD_FEM_NETGEN=ON"
 
 language: cpp
 
+compiler:
+   - clang
+   - gcc
+
+python: 2.7
+
+os:
+   - linux
+   - osx
+
+dist: trusty
+sudo: required
+
 matrix:
-   include:
-     - os: linux
-       dist: trusty
-       sudo: required
-       compiler: clang
-     - os: osx
-       osx_image: beta-xcode6.2
-       compiler: clang
    exclude:
-     - os: linux
-       dist: precise
+     - os: osx
+       compiler: gcc
 
 git:
-  depth: 200
+  depth: 800
 
 before_install:
 - eval "$(curl -fsSL "https://raw.githubusercontent.com/${OSX_PORTS_CACHE}/v${FREECAD_RELEASE}/travis-helpers.sh")"
@@ -72,6 +79,8 @@ before_install:
                                libxmu6                          \
                                libxmuu-dev                      \
                                libxmuu1                         \
+                               netgen                           \
+                               netgen-headers                   \
                                oce-draw                         \
                                pyside-tools                     \
                                python-dev                       \
@@ -82,16 +91,12 @@ before_install:
                                shiboken                         \
                                swig
 
-       #Temporary hack - remove older Python (find a supported way to do this)
-       sudo rm -rf /opt/python/2.6.9
-       sudo rm -rf /opt/python/2.7.10
-
        #Patch the system - there is a bug related to invalid location of libs on ubuntu 12.04
        sudo ln -s /usr/lib/x86_64-linux-gnu/ /usr/lib/i386-linux-gnu
        export DISPLAY=:99.0
        sh -e /etc/init.d/xvfb start
 
-       CMAKE_ARGS=""
+       CMAKE_ARGS="${CMAKE_OPTS} -DPYTHON_EXECUTABLE=/usr/bin/python"
        INSTALLED_APP_PATH="/usr/local/bin/FreeCAD"
        ;;
 
@@ -127,7 +132,7 @@ before_install:
        #Remove GDAL if installed because it results in non-existent dependent library exceptions
        if [ -e /usr/local/lib/libgdal.1.dylib ]; then brew unlink gdal; fi
 
-       CMAKE_ARGS="-DFREECAD_USE_EXTERNAL_KDL=ON -DBUILD_FEM_NETGEN=ON -DFREECAD_CREATE_MAC_APP=ON"
+       CMAKE_ARGS="${CMAKE_OPTS} -DFREECAD_USE_EXTERNAL_KDL=ON -DFREECAD_CREATE_MAC_APP=ON"
        INSTALLED_APP_PATH="/usr/local/FreeCAD.app/Contents/bin/FreeCAD"
        ;;
 
@@ -164,7 +169,7 @@ after_success:
 - |
   if [ "${TRAVIS_OS_NAME}" == "osx" -a "${TRAVIS_PULL_REQUEST}" == "false" ]; then
      brew install jq node && npm install -g appdmg
-     export VSN=$(python ${TRAVIS_BUILD_DIR}/src/Tools/ArchiveNameFromVersionHeader.py ${TRAVIS_BUILD_DIR}/build/src/Build/Version.h --git-SHA=$(git ls-remote origin master))
+     export VSN=$(python ${TRAVIS_BUILD_DIR}/src/Tools/ArchiveNameFromVersionHeader.py ${TRAVIS_BUILD_DIR}/build/src/Build/Version.h)
      export DEPLOYMENT_ARCHIVE=${VSN}.dmg
      appdmg ${TRAVIS_BUILD_DIR}/src/MacAppBundle/DiskImage/layout.json "${DEPLOYMENT_ARCHIVE}"
      deployContext=$(create_helper_context repo=${TRAVIS_REPO_SLUG} auth_token=${GH_TOKEN} release=${DEPLOY_RELEASE})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,41 +44,42 @@ else(WIN32)
     set(PLATFORM_MK mkdir -p)
 endif(WIN32)
 
+if (${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
+    set(CMAKE_COMPILER_IS_CLANGXX TRUE)
+endif (${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
+
 # ================================================================================
 
 # Issues with boost::any on older versions with C++11 enabled.
 set(BOOST_MIN_VERSION 1.55)
+IF(CMAKE_COMPILER_IS_GNUCXX AND CMAKE_COMPILER_VERSION VERSION_LESS 4.7)
+   UNSET(BOOST_MIN_VERSION) # For Ubuntu 12.04
+ENDIF(CMAKE_COMPILER_IS_GNUCXX AND CMAKE_COMPILER_VERSION VERSION_LESS 4.7)
 
-if (${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
-    set(CMAKE_COMPILER_IS_CLANGXX TRUE)
-    # make this an option because for older compilers C++11 doesn't work properly.
+# Enabled C++11 for Freecad 0.17 and later
+IF(FREECAD_VERSION VERSION_GREATER 0.16)
     OPTION(BUILD_ENABLE_CXX11 "Enable C++11 support." ON)
-    if (BUILD_ENABLE_CXX11)
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
-    endif(BUILD_ENABLE_CXX11)
-endif (${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
+    IF(CMAKE_COMPILER_IS_GNUCXX AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.7)
+        MESSAGE(FATAL_ERROR "FreeCAD 0.17 and later requires C++11.  G++ must be 4.7 or later")
+    ELSEIF(CMAKE_COMPILER_IS_CLANGXX AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 3.3)
+        MESSAGE(FATAL_ERROR "FreeCAD 0.17 and later requires C++11.  Clang must be 3.3 or later")
+    ENDIF()
+ENDIF(FREECAD_VERSION VERSION_GREATER 0.16)
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANGXX)
     include(cMake/ConfigureChecks.cmake)
     configure_file(config.h.cmake ${CMAKE_CURRENT_BINARY_DIR}/config.h)
     add_definitions(-DHAVE_CONFIG_H)
-    set(CMAKE_CXX_FLAGS "-Wall -Wno-deprecated -Wno-write-strings -std=c++11 ${CMAKE_CXX_FLAGS}")
+    if(BUILD_ENABLE_CXX11)
+       set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+    endif(BUILD_ENABLE_CXX11)
+    set(CMAKE_CXX_FLAGS "-Wall -Wno-deprecated -Wno-write-strings ${CMAKE_CXX_FLAGS}")
     INCLUDE_DIRECTORIES(${CMAKE_CURRENT_BINARY_DIR})
     # get linker errors as soon as possible and not at runtime e.g. for modules
     if(UNIX)
     #    SET(CMAKE_SHARED_LINKER_FLAGS "-Wl,--no-undefined")
     endif(UNIX)
 endif(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANGXX)
-
-IF(CMAKE_COMPILER_IS_GNUCXX)
-    EXECUTE_PROCESS( COMMAND ${CMAKE_C_COMPILER} -dumpversion
-                     OUTPUT_VARIABLE GCC_VERSION )
-    IF(GCC_VERSION VERSION_GREATER 4.7 OR GCC_VERSION VERSION_EQUAL 4.7)
-        SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
-    ELSE(GCC_VERSION VERSION_GREATER 4.7 OR GCC_VERSION VERSION_EQUAL 4.7)
-        UNSET(BOOST_MIN_VERSION) # For Ubuntu 12.04
-    ENDIF(GCC_VERSION VERSION_GREATER 4.7 OR GCC_VERSION VERSION_EQUAL 4.7)
-ENDIF()
 
 # ================================================================================
 # Output directories for install target


### PR DESCRIPTION
This pull request builds upon the initial FreeCAD 0.17 build matrix pull by increasing the build coverage to include BUILD_FEM_NETGEN for Linux and including GCC for Linux.  The .travis.yml has been refactored for improved readability and to enable testing of alternative versions of Python when the time comes.  In addition, it includes a commit that refactors CMakeLists.txt to require and set c++11 for FreeCAD 0.17 and later and verifies the compilers being used support C+11.  While refactoring cmake, I intentionally preserved what appears to be deprecated logic because this cmake project file won't be used for any versions earlier than FreeCAD 0.17.  Let me know if you want to remove the deprecated logic (i.e. unsetting boost minimum on Linux 12.04 - everyone should be building on Linux 14.04/Trusty and later).

Forum post: http://forum.freecadweb.org/viewtopic.php?f=17&t=15278

