### PR TITLE
Fixing Plot module for weird matplotlib version

### DIFF
--- a/src/Mod/Plot/Plot.py
+++ b/src/Mod/Plot/Plot.py
@@ -25,7 +25,7 @@ import FreeCAD
 
 import PySide
 from PySide import QtCore, QtGui
-from distutils.version import StrictVersion as V
+from distutils.version import LooseVersion as V
 
 try:
     import matplotlib


### PR DESCRIPTION
matplotlib guys love using version numbers like 1.1.1rc, which is breaking the Plot module. Moving to a LooseVersion checking system should fix the problem.

Related with that:
http://forum.freecadweb.org/viewtopic.php?f=8&t=15351&p=122079&hilit=invalid+version#p122079