### PR TITLE
PartDesign: reverse XZ plane to match legacy orientations

### DIFF
--- a/src/App/Origin.cpp
+++ b/src/App/Origin.cpp
@@ -140,7 +140,7 @@ void Origin::setupObject () {
         {App::Line::getClassTypeId(), "Y_Axis", Base::Rotation ( Base::Vector3d (1,1,1), M_PI*2/3 ) },
         {App::Line::getClassTypeId(), "Z_Axis", Base::Rotation ( Base::Vector3d (1,1,1), M_PI*4/3 ) },
         {App::Plane::getClassTypeId (), "XY_Plane", Base::Rotation () },
-        {App::Plane::getClassTypeId (), "XZ_Plane", Base::Rotation ( Base::Vector3d (0,1,1), M_PI ), },
+        {App::Plane::getClassTypeId (), "XZ_Plane", Base::Rotation ( 1.0, 0.0, 0.0, 1.0 ), },
         {App::Plane::getClassTypeId (), "YZ_Plane", Base::Rotation ( Base::Vector3d (1,1,1), M_PI*2/3 ) },
     };
 


### PR DESCRIPTION
discussion in forum thread "ZX plane in PartDesign Next (instead of XZ)"
http://forum.freecadweb.org/viewtopic.php?f=8&t=15319