### PR TITLE
Allow progress meter to finish. http instead of https for github.com

### DIFF
--- a/src/Mod/Start/StartPage/StartPage.py
+++ b/src/Mod/Start/StartPage/StartPage.py
@@ -186,7 +186,7 @@ page = """
             // load latest news
             ddiv = document.getElementById("news");
             ddiv.innerHTML = "Connecting...";
-            var tobj=new JSONscriptRequest('https://api.github.com/repos/FreeCAD/FreeCAD/commits?callback=showTweets');
+            var tobj=new JSONscriptRequest('http://api.github.com/repos/FreeCAD/FreeCAD/commits?callback=showTweets');
             tobj.buildScriptTag(); // Build the script tag
             tobj.addScriptTag(); // Execute (add) the script tag
             ddiv.innerHTML = "Downloading latest news...";


### PR DESCRIPTION
This is only a partial solution as the commits are still not loaded on the StartPage but at least the progress meter doesn't hang. I tried allowing FreeCAD through the firewall and disable the firewall with no difference.