### PR TITLE
Attacher fixes and UI improvements

### DIFF
--- a/src/Mod/Part/App/AppPart.cpp
+++ b/src/Mod/Part/App/AppPart.cpp
@@ -93,6 +93,8 @@
 #include "PartFeaturePy.h"
 #include "PropertyGeometryList.h"
 #include "DatumFeature.h"
+#include "Attacher.h"
+#include "AttachableObject.h"
 
 namespace Part {
 extern PyObject* initModule();
@@ -219,6 +221,12 @@ PyMODINIT_FUNC initPart()
     Part::PropertyShapeHistory  ::init();
     Part::PropertyFilletEdges   ::init();
 
+    Attacher::AttachEngine        ::init();
+    Attacher::AttachEngine3D      ::init();
+    Attacher::AttachEnginePlane   ::init();
+    Attacher::AttachEngineLine    ::init();
+    Attacher::AttachEnginePoint   ::init();
+
     Part::Feature               ::init();
     Part::FeatureExt            ::init();
     Part::AttachableObject      ::init();
@@ -264,6 +272,7 @@ PyMODINIT_FUNC initPart()
     Part::Helix                 ::init();
     Part::Spiral                ::init();
     Part::Wedge                 ::init();
+
     Part::Part2DObject          ::init();
     Part::Part2DObjectPython    ::init();
     Part::Face                  ::init();

--- a/src/Mod/Part/App/Attacher.cpp
+++ b/src/Mod/Part/App/Attacher.cpp
@@ -1509,6 +1509,7 @@ Base::Placement AttachEngineLine::calculateAttachedPlacement(Base::Placement ori
         AttachEngine3D attacher3D;
         attacher3D.setUp(*this);
         attacher3D.mapMode = mmode;
+        attacher3D.superPlacement = Base::Placement(); //superplacement is applied separately here, afterwards. So we are resetting it in sub-attacher to avoid applying it twice!
         plm = attacher3D.calculateAttachedPlacement(origPlacement);
         plm *= presuperPlacement;
     }
@@ -1677,6 +1678,7 @@ Base::Placement AttachEnginePoint::calculateAttachedPlacement(Base::Placement or
         AttachEngine3D attacher3D;
         attacher3D.setUp(*this);
         attacher3D.mapMode = mmode;
+        attacher3D.superPlacement = Base::Placement(); //superplacement is applied separately here, afterwards. So we are resetting it in sub-attacher to avoid applying it twice!
         plm = attacher3D.calculateAttachedPlacement(origPlacement);
     }
     plm *= this->superPlacement;

--- a/src/Mod/Part/App/Attacher.cpp
+++ b/src/Mod/Part/App/Attacher.cpp
@@ -549,6 +549,13 @@ int AttachEngine::isShapeOfType(eRefType shapeType, eRefType requirement)
     return -1;
 }
 
+std::string AttachEngine::getModeName(eMapMode mmode)
+{
+    if(mmode < 0 || mmode >= mmDummy_NumberOfModes)
+        throw Base::Exception("AttachEngine::getModeName: Attachment Mode index is out of range");
+    return std::string(AttachEngine::eMapModeStrings[mmode]);
+}
+
 /*!
  * \brief AttachEngine3D::readLinks
  * \param parts

--- a/src/Mod/Part/App/Attacher.cpp
+++ b/src/Mod/Part/App/Attacher.cpp
@@ -59,6 +59,7 @@
 using namespace Part;
 using namespace Attacher;
 
+//These strings are for mode list enum property.
 const char* AttachEngine::eMapModeStrings[]= {
     "Deactivated",
     "Translate",
@@ -1251,6 +1252,35 @@ double AttachEngine3D::calculateFoldAngle(gp_Vec axA, gp_Vec axB, gp_Vec edA, gp
     return acos(cos_unfold);
 }
 
+
+//=================================================================================
+
+TYPESYSTEM_SOURCE(Attacher::AttachEnginePlane, Attacher::AttachEngine);
+
+AttachEnginePlane::AttachEnginePlane()
+{
+    //re-used 3d modes: all of Attacher3d
+    AttachEngine3D attacher3D;
+    this->modeRefTypes = attacher3D.modeRefTypes;
+    this->EnableAllSupportedModes();
+}
+
+AttachEnginePlane *AttachEnginePlane::copy() const
+{
+    AttachEnginePlane* p = new AttachEnginePlane;
+    p->setUp(*this);
+    return p;
+}
+
+Base::Placement AttachEnginePlane::calculateAttachedPlacement(Base::Placement origPlacement) const
+{
+    //re-use Attacher3d
+    Base::Placement plm;
+    AttachEngine3D attacher3D;
+    attacher3D.setUp(*this);
+    plm = attacher3D.calculateAttachedPlacement(origPlacement);
+    return plm;
+}
 
 //=================================================================================
 

--- a/src/Mod/Part/App/Attacher.h
+++ b/src/Mod/Part/App/Attacher.h
@@ -360,17 +360,15 @@ private:
     double calculateFoldAngle(gp_Vec axA, gp_Vec axB, gp_Vec edA, gp_Vec edB) const;
 };
 
-typedef AttachEngine3D AttachEnginePlane ;//no separate class for planes, for now. Can be added later, if required.
-/*
-class AttachEngine2D : public AttachEngine
+//attacher specialized for datum planes
+class PartExport AttachEnginePlane : public AttachEngine
 {
+    TYPESYSTEM_HEADER();
+public:
     AttachEnginePlane();
-    virtual AttachEnginePlane* copy() const {return new AttachEnginePlane(*this);}
-    virtual Base::Placement calculateAttachedPlacement(void) const;
-    virtual eMapMode listMapModes(eSuggestResult &msg, std::vector<eMapMode>* allmodes = 0, std::vector<QString>* nextRefTypeHint = 0) const;
-    ~AttachEnginePlane(){};
+    virtual AttachEnginePlane* copy() const;
+    virtual Base::Placement calculateAttachedPlacement(Base::Placement origPlacement) const;
 };
-*/
 
 //attacher specialized for datum lines
 class PartExport AttachEngineLine : public AttachEngine

--- a/src/Mod/Part/App/Attacher.h
+++ b/src/Mod/Part/App/Attacher.h
@@ -286,6 +286,13 @@ public://helper functions that may be useful outside of the class
      */
     static int isShapeOfType(eRefType shapeType, eRefType requirement);
 
+    /**
+     * @brief getModeName
+     * @param mmode
+     * @return returns a string that identifies the attachment mode in enum property.
+     */
+    static std::string getModeName(eMapMode mmode);
+
 
 public: //enums
     static const char* eMapModeStrings[];

--- a/src/Mod/Part/App/Attacher.h
+++ b/src/Mod/Part/App/Attacher.h
@@ -104,7 +104,7 @@ enum eSuggestResult{
 
 /**
  * @brief The eRefType enum lists the types of references. If adding one, see
- * also AttachEngine::getShapeType(), AttachEngine::downgradeType(), TaskDatumParameters.cpp/getShTypeText()
+ * also AttachEngine::getShapeType(), AttachEngine::downgradeType(), AttacherTexts.cpp/getShTypeText()
  */
 enum eRefType {
     //topo             //ranks: (number of times the type is downgradable)

--- a/src/Mod/Part/App/Attacher.h
+++ b/src/Mod/Part/App/Attacher.h
@@ -38,8 +38,6 @@
 
 #include "PartFeature.h"
 
-#include <QString>
-
 #include <gp_Vec.hxx>
 
 namespace Attacher

--- a/src/Mod/Part/Gui/AttacherTexts.cpp
+++ b/src/Mod/Part/Gui/AttacherTexts.cpp
@@ -1,0 +1,345 @@
+/***************************************************************************
+ *   Copyright (c) Victor Titov (DeepSOIC)                                 *
+ *                                           (vv.titov@gmail.com) 2016     *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+#include "PreCompiled.h"
+#ifndef _PreComp_
+# include <QObject>
+#endif
+#include "AttacherTexts.h"
+
+using namespace Attacher;
+
+namespace AttacherGui {
+
+TextSet TwoStrings(QString str1, QString str2)
+{
+    std::vector<QString> v;
+    v.resize(2);
+    v[0] = str1;
+    v[1] = str2;
+    return v;
+}
+
+AttacherGui::TextSet AttacherGui::getUIStrings(Base::Type attacherType, Attacher::eMapMode mmode)
+{
+    if (attacherType.isDerivedFrom(Attacher::AttachEngine3D::getClassTypeId())){
+        //---- coordinate system attacher ----
+        switch (mmode){
+        case mmDeactivated:
+            return TwoStrings(QObject::tr("Deactivated","Attachment3D mode caption"),
+                              QObject::tr("Attachment is disabled. CS can be moved by editing Placement property.","Attachment3D mode tooltip"));
+        break;
+        case mmTranslate:
+            return TwoStrings(QObject::tr("Translate origin","Attachment3D mode caption"),
+                              QObject::tr("Origin is aligned to match Vertex. Orientation is controlled by Placement property.","Attachment3D mode tooltip"));
+        break;
+        case mmObjectXY:
+            return TwoStrings(QObject::tr("Object's  X Y Z","Attachment3D mode caption"),
+                              QObject::tr("Placement is made equal to Placement of linked object.","Attachment3D mode tooltip"));
+        break;
+        case mmObjectXZ:
+            return TwoStrings(QObject::tr("Object's  X Z-Y","Attachment3D mode caption"),
+                              QObject::tr("X', Y', Z' axes are matched with object's local X, Z, -Y, respectively.","Attachment3D mode tooltip"));
+        break;
+        case mmObjectYZ:
+            return TwoStrings(QObject::tr("Object's  Y Z X","Attachment3D mode caption"),
+                              QObject::tr("X', Y', Z' axes are matched with object's local Y, Z, X, respectively.","Attachment3D mode tooltip"));
+        break;
+        case mmFlatFace:
+            return TwoStrings(QObject::tr("XY on plane","Attachment3D mode caption"),
+                              QObject::tr("X' Y' plane is aligned to coincide planar face.","Attachment3D mode tooltip"));
+        break;
+        case mmTangentPlane:
+            return TwoStrings(QObject::tr("XY tangent to surface","Attachment3D mode caption"),
+                              QObject::tr("X' Y' plane is made tangent to surface at vertex.","Attachment3D mode tooltip"));
+        break;
+        case mmNormalToPath:
+            return TwoStrings(QObject::tr("Z tangent to edge","Attachment3D mode caption"),
+                              QObject::tr("Z' axis is aligned to be tangent to edge. Optional vertex link defines where.","Attachment3D mode tooltip"));
+        break;
+        case mmFrenetNB:
+            return TwoStrings(QObject::tr("Frenet NBT","Attachment3D mode caption"),
+                              QObject::tr("Align to Frenet-Serret coordinate system of curved edge. Optional vertex link defines where.","Attachment3D mode tooltip"));
+        break;
+        case mmFrenetTN:
+            return TwoStrings(QObject::tr("Frenet TNB","Attachment3D mode caption"),
+                              QObject::tr("Align to Frenet-Serret coordinate system of curved edge. Optional vertex link defines where.","Attachment3D mode tooltip"));
+        break;
+        case mmFrenetTB:
+            return TwoStrings(QObject::tr("Frenet TBN","Attachment3D mode caption"),
+                              QObject::tr("Align to Frenet-Serret coordinate system of curved edge. Optional vertex link defines where.","Attachment3D mode tooltip"));
+        break;
+        case mmConcentric:
+            return TwoStrings(QObject::tr("Concentric","Attachment3D mode caption"),
+                              QObject::tr("Align XY plane to osculating circle of an edge. Optional vertex link defines where.","Attachment3D mode tooltip"));
+        break;
+        case mmRevolutionSection:
+            return TwoStrings(QObject::tr("Revolution Section","Attachment3D mode caption"),
+                              QObject::tr("Align Y' axis to match axis of osculating circle of an edge. Optional vertex link defines where.","Attachment3D mode tooltip"));
+        break;
+        case mmThreePointsPlane:
+            return TwoStrings(QObject::tr("XY plane by 3 points","Attachment3D mode caption"),
+                              QObject::tr("Align XY plane to pass through three vertices.","Attachment3D mode tooltip"));
+        break;
+        case mmThreePointsNormal:
+            return TwoStrings(QObject::tr("XZ plane by 3 points","Attachment3D mode caption"),
+                              QObject::tr("Align XZ plane to pass through 3 points; X axis will pass through two first points.","Attachment3D mode tooltip"));
+        break;
+        case mmFolding:
+            return TwoStrings(QObject::tr("Folding","Attachment3D mode caption"),
+                              QObject::tr("Specialty mode for folding polyhedra. Select 4 edges in order: foldable edge, fold line, other fold line, other foldable edge. XY plane will be aligned to folding the first edge.","Attachment3D mode tooltip"));
+        break;
+        }
+    } else if (attacherType.isDerivedFrom(Attacher::AttachEnginePlane::getClassTypeId())){
+        //---- Plane/sketch attacher ----
+        switch (mmode){
+        case mmDeactivated:
+            return TwoStrings(QObject::tr("Deactivated","AttachmentPlane mode caption"),
+                              QObject::tr("Attachment is disabled. Plane can be moved by editing Placement property.","AttachmentPlane mode tooltip"));
+        break;
+        case mmTranslate:
+            return TwoStrings(QObject::tr("Translate origin","AttachmentPlane mode caption"),
+                              QObject::tr("Origin is aligned to match Vertex. Orientation is controlled by Placement property.","AttachmentPlane mode tooltip"));
+        break;
+        case mmObjectXY:
+            return TwoStrings(QObject::tr("Object's XY","AttachmentPlane mode caption"),
+                              QObject::tr("Plane is aligned to XY local plane of linked object.","AttachmentPlane mode tooltip"));
+        break;
+        case mmObjectXZ:
+            return TwoStrings(QObject::tr("Object's XZ","AttachmentPlane mode caption"),
+                              QObject::tr("Plane is aligned to XZ local plane of linked object.","AttachmentPlane mode tooltip"));
+        break;
+        case mmObjectYZ:
+            return TwoStrings(QObject::tr("Object's  YZ","AttachmentPlane mode caption"),
+                              QObject::tr("Plane is aligned to YZ local plane of linked object.","AttachmentPlane mode tooltip"));
+        break;
+        case mmFlatFace:
+            return TwoStrings(QObject::tr("Plane face","AttachmentPlane mode caption"),
+                              QObject::tr("Plane is aligned to coincide planar face.","AttachmentPlane mode tooltip"));
+        break;
+        case mmTangentPlane:
+            return TwoStrings(QObject::tr("Tangent to surface","AttachmentPlane mode caption"),
+                              QObject::tr("Plane is made tangent to surface at vertex.","AttachmentPlane mode tooltip"));
+        break;
+        case mmNormalToPath:
+            return TwoStrings(QObject::tr("Normal to edge","AttachmentPlane mode caption"),
+                              QObject::tr("Plane is made tangent to edge. Optional vertex link defines where.","AttachmentPlane mode tooltip"));
+        break;
+        case mmFrenetNB:
+            return TwoStrings(QObject::tr("Frenet NB","AttachmentPlane mode caption"),
+                              QObject::tr("Align to Frenet-Serret coordinate system of curved edge. Optional vertex link defines where.","AttachmentPlane mode tooltip"));
+        break;
+        case mmFrenetTN:
+            return TwoStrings(QObject::tr("Frenet TN","AttachmentPlane mode caption"),
+                              QObject::tr("Align to Frenet-Serret coordinate system of curved edge. Optional vertex link defines where.","AttachmentPlane mode tooltip"));
+        break;
+        case mmFrenetTB:
+            return TwoStrings(QObject::tr("Frenet TB","AttachmentPlane mode caption"),
+                              QObject::tr("Align to Frenet-Serret coordinate system of curved edge. Optional vertex link defines where.","AttachmentPlane mode tooltip"));
+        break;
+        case mmConcentric:
+            return TwoStrings(QObject::tr("Concentric","AttachmentPlane mode caption"),
+                              QObject::tr("Align to plane to osculating circle of an edge. Origin is aligned to point of curvature. Optional vertex link defines where.","AttachmentPlane mode tooltip"));
+        break;
+        case mmRevolutionSection:
+            return TwoStrings(QObject::tr("Revolution Section","AttachmentPlane mode caption"),
+                              QObject::tr("Plane is prependicular to edge, and Y axis is matched with axis of osculating circle. Optional vertex link defines where.","AttachmentPlane mode tooltip"));
+        break;
+        case mmThreePointsPlane:
+            return TwoStrings(QObject::tr("Plane by 3 points","AttachmentPlane mode caption"),
+                              QObject::tr("Align plane to pass through three vertices.","AttachmentPlane mode tooltip"));
+        break;
+        case mmThreePointsNormal:
+            return TwoStrings(QObject::tr("Normal to 3 points","AttachmentPlane mode caption"),
+                              QObject::tr("Plane will pass through first to vertices, and perpendicular to plane that passes through three vertices.","AttachmentPlane mode tooltip"));
+        break;
+        case mmFolding:
+            return TwoStrings(QObject::tr("Folding","AttachmentPlane mode caption"),
+                              QObject::tr("Specialty mode for folding polyhedra. Select 4 edges in order: foldable edge, fold line, other fold line, other foldable edge. Plane will be aligned to folding the first edge.","AttachmentPlane mode tooltip"));
+        break;
+        }
+    } else if (attacherType.isDerivedFrom(Attacher::AttachEngineLine::getClassTypeId())){
+        //---- Line attacher ----
+        switch (mmode){
+        case mmDeactivated:
+            return TwoStrings(QObject::tr("Deactivated","AttachmentLine mode caption"),
+                              QObject::tr("Attachment is disabled. Line can be moved by editing Placement property.","AttachmentLine mode tooltip"));
+        break;
+        case mm1AxisX:
+            return TwoStrings(QObject::tr("Object's X","AttachmentLine mode caption"),
+                              QObject::tr("Line is aligned along local X axis of object. Works on objects with placements, and ellipse/parabola/hyperbola edges.","AttachmentLine mode tooltip"));
+        break;
+        case mm1AxisY:
+            return TwoStrings(QObject::tr("Object's Y","AttachmentLine mode caption"),
+                              QObject::tr("Line is aligned along local Y axis of object. Works on objects with placements, and ellipse/parabola/hyperbola edges.","AttachmentLine mode tooltip"));
+        break;
+        case mm1AxisZ:
+            return TwoStrings(QObject::tr("Object's Z","AttachmentLine mode caption"),
+                              QObject::tr("Line is aligned along local X axis of object. Works on objects with placements, and ellipse/parabola/hyperbola edges.","AttachmentLine mode tooltip"));
+        break;
+        case mm1AxisCurv:
+            return TwoStrings(QObject::tr("Axis of curvature","AttachmentLine mode caption"),
+                              QObject::tr("Line that is an axis of osculating circle of curved edge. Optional vertex defines where.","AttachmentLine mode tooltip"));
+        break;
+        case mm1Directrix1:
+            return TwoStrings(QObject::tr("Directrix1","AttachmentLine mode caption"),
+                              QObject::tr("Directrix line for ellipse, parabola, hyperbola.","AttachmentLine mode tooltip"));
+        break;
+        case mm1Directrix2:
+            return TwoStrings(QObject::tr("Directrix2","AttachmentLine mode caption"),
+                              QObject::tr("Second directrix line for ellipse and hyperbola.","AttachmentLine mode tooltip"));
+        break;
+        case mm1Asymptote1:
+            return TwoStrings(QObject::tr("Asymptote1","AttachmentLine mode caption"),
+                              QObject::tr("Asymptote of a hyperbola.","AttachmentLine mode tooltip"));
+        break;
+        case mm1Asymptote2:
+            return TwoStrings(QObject::tr("Asymptote2","AttachmentLine mode caption"),
+                              QObject::tr("Second asymptote of hyperbola.","AttachmentLine mode tooltip"));
+        break;
+        case mm1Tangent:
+            return TwoStrings(QObject::tr("Tangent","AttachmentLine mode caption"),
+                              QObject::tr("Line tangent to an edge. Optional vertex link defines where.","AttachmentLine mode tooltip"));
+        break;
+        case mm1Normal:
+            return TwoStrings(QObject::tr("Normal","AttachmentLine mode caption"),
+                              QObject::tr("Align to N vector of Frenet-Serret coordinate system of curved edge. Optional vertex link defines where.","AttachmentLine mode tooltip"));
+        break;
+        case mm1Binormal:
+            return TwoStrings(QObject::tr("Binormal","AttachmentLine mode caption"),
+                              QObject::tr("Align to B vector of Frenet-Serret coordinate system of curved edge. Optional vertex link defines where.","AttachmentLine mode tooltip"));
+        break;
+        case mm1TangentU:
+            return TwoStrings(QObject::tr("Tangent to surface (U)","AttachmentLine mode caption"),
+                              QObject::tr("Tangent to surface, along U parameter. Vertex link defines where.","AttachmentLine mode tooltip"));
+        break;
+        case mm1TangentV:
+            return TwoStrings(QObject::tr("Tangent to surface (V)","AttachmentLine mode caption"),
+                              QObject::tr("Tangent to surface, along U parameter. Vertex link defines where.","AttachmentLine mode tooltip"));
+        break;
+        case mm1TwoPoints:
+            return TwoStrings(QObject::tr("Through two points","AttachmentLine mode caption"),
+                              QObject::tr("Line that passes through two vertices.","AttachmentLine mode tooltip"));
+        break;
+        case mm1Intersection:
+            return TwoStrings(QObject::tr("Intersection","AttachmentLine mode caption"),
+                              QObject::tr("Not implemented.","AttachmentLine mode tooltip"));
+        break;
+        case mm1Proximity:
+            return TwoStrings(QObject::tr("Proximity line","AttachmentLine mode caption"),
+                              QObject::tr("Line that spans the shortest distance between shapes.","AttachmentLine mode tooltip"));
+        break;
+        }
+    } else if (attacherType.isDerivedFrom(Attacher::AttachEnginePoint::getClassTypeId())){
+        //---- Point attacher ----
+        switch (mmode){
+        case mmDeactivated:
+            return TwoStrings(QObject::tr("Deactivated","AttachmentPoint mode caption"),
+                              QObject::tr("Attachment is disabled. Point can be moved by editing Placement property.","AttachmentPoint mode tooltip"));
+        break;
+        case mm0Origin:
+            return TwoStrings(QObject::tr("Object's origin","AttachmentPoint mode caption"),
+                              QObject::tr("Point is put at object's Placement.Position. Works on objects with placements, and ellipse/parabola/hyperbola edges.","AttachmentPoint mode tooltip"));
+        break;
+        case mm0Focus1:
+            return TwoStrings(QObject::tr("Focus1","AttachmentPoint mode caption"),
+                              QObject::tr("Focus of ellipse, parabola, hyperbola.","AttachmentPoint mode tooltip"));
+        break;
+        case mm0Focus2:
+            return TwoStrings(QObject::tr("Focus2","AttachmentPoint mode caption"),
+                              QObject::tr("Second focus of ellipse and hyperbola.","AttachmentPoint mode tooltip"));
+        break;
+        case mm0OnEdge:
+            return TwoStrings(QObject::tr("On edge","AttachmentPoint mode caption"),
+                              QObject::tr("Point is put on edge, MapPathParametr controls where. Additionally, vertex can be linked in for making a projection.","AttachmentPoint mode tooltip"));
+        break;
+        case mm0CenterOfCurvature:
+            return TwoStrings(QObject::tr("Center of curvature","AttachmentPoint mode caption"),
+                              QObject::tr("Center of osculating circle of an edge. Optinal vertex link defines where.","AttachmentPoint mode tooltip"));
+        break;
+        case mm0CenterOfMass:
+            return TwoStrings(QObject::tr("Center of mass","AttachmentPoint mode caption"),
+                              QObject::tr("Not implemented","AttachmentPoint mode tooltip"));
+        break;
+        case mm0Intersection:
+            return TwoStrings(QObject::tr("Intersection","AttachmentPoint mode caption"),
+                              QObject::tr("Not implemented","AttachmentPoint mode tooltip"));
+        break;
+        case mm0Vertex:
+            return TwoStrings(QObject::tr("Vertex","AttachmentPoint mode caption"),
+                              QObject::tr("Put Datum point coincident with another vertex.","AttachmentPoint mode tooltip"));
+        break;
+        case mm0ProximityPoint1:
+            return TwoStrings(QObject::tr("Proximity point 1","AttachmentPoint mode caption"),
+                              QObject::tr("Point on first reference that is closest to second reference.","AttachmentPoint mode tooltip"));
+        break;
+        case mm0ProximityPoint2:
+            return TwoStrings(QObject::tr("Proximity point 2","AttachmentPoint mode caption"),
+                              QObject::tr("Point on second reference that is closest to first reference.","AttachmentPoint mode tooltip"));
+        break;
+        }
+    }
+
+    assert("No user-friendly string defined for this attachment mode."=="");
+    return TwoStrings(QString::fromLatin1(Attacher::AttachEngine::getModeName(mmode).c_str()),QString());
+}
+
+
+QString getShapeTypeText(eRefType type)
+{
+    //get rid of flags in type
+    type = eRefType(type & (rtFlagHasPlacement - 1));
+
+    const char* eRefTypeStrings[] = {
+        QT_TR_NOOP("Any"),
+        QT_TR_NOOP("Vertex"),
+        QT_TR_NOOP("Edge"),
+        QT_TR_NOOP("Face"),
+
+        QT_TR_NOOP("Line"),
+        QT_TR_NOOP("Curve"),
+        QT_TR_NOOP("Circle"),
+        QT_TR_NOOP("Conic"),
+        QT_TR_NOOP("Ellipse"),
+        QT_TR_NOOP("Parabola"),
+        QT_TR_NOOP("Hyperbola"),
+
+        QT_TR_NOOP("Plane"),
+        QT_TR_NOOP("Sphere"),
+        QT_TR_NOOP("Revolve"),
+        QT_TR_NOOP("Cylinder"),
+        QT_TR_NOOP("Torus"),
+        QT_TR_NOOP("Cone"),
+        //
+        QT_TR_NOOP("Object"),
+        QT_TR_NOOP("Solid"),
+        QT_TR_NOOP("Wire"),
+        NULL
+    };
+
+    if (type >= 0 && type < rtDummy_numberOfShapeTypes)
+        if (eRefTypeStrings[int(type)])
+            return QObject::tr(eRefTypeStrings[int(type)]);
+    throw Base::Exception("getShTypeText: type value is wrong, or a string is missing in the list");
+}
+
+} //namespace AttacherGui

--- a/src/Mod/Part/Gui/AttacherTexts.cpp
+++ b/src/Mod/Part/Gui/AttacherTexts.cpp
@@ -342,4 +342,18 @@ QString getShapeTypeText(eRefType type)
     throw Base::Exception("getShTypeText: type value is wrong, or a string is missing in the list");
 }
 
+QStringList getRefListForMode(AttachEngine &attacher, eMapMode mmode)
+{
+    AttachEngine::refTypeStringList list = attacher.modeRefTypes[mmode];
+    QStringList strlist;
+    for(AttachEngine::refTypeString &rts : list){
+        QStringList buf;
+        for(eRefType rt : rts){
+            buf.append(getShapeTypeText(rt));
+        }
+        strlist.append(buf.join(QString::fromLatin1(", ")));
+    }
+    return strlist;
+}
+
 } //namespace AttacherGui

--- a/src/Mod/Part/Gui/AttacherTexts.cpp
+++ b/src/Mod/Part/Gui/AttacherTexts.cpp
@@ -22,7 +22,7 @@
  ***************************************************************************/
 #include "PreCompiled.h"
 #ifndef _PreComp_
-# include <QObject>
+# include <QApplication>
 #endif
 #include "AttacherTexts.h"
 
@@ -45,256 +45,256 @@ AttacherGui::TextSet AttacherGui::getUIStrings(Base::Type attacherType, Attacher
         //---- coordinate system attacher ----
         switch (mmode){
         case mmDeactivated:
-            return TwoStrings(QObject::tr("Deactivated","Attachment3D mode caption"),
-                              QObject::tr("Attachment is disabled. CS can be moved by editing Placement property.","Attachment3D mode tooltip"));
+            return TwoStrings(qApp->translate("Attacher3D", "Deactivated","Attachment3D mode caption"),
+                              qApp->translate("Attacher3D", "Attachment is disabled. CS can be moved by editing Placement property.","Attachment3D mode tooltip"));
         break;
         case mmTranslate:
-            return TwoStrings(QObject::tr("Translate origin","Attachment3D mode caption"),
-                              QObject::tr("Origin is aligned to match Vertex. Orientation is controlled by Placement property.","Attachment3D mode tooltip"));
+            return TwoStrings(qApp->translate("Attacher3D", "Translate origin","Attachment3D mode caption"),
+                              qApp->translate("Attacher3D", "Origin is aligned to match Vertex. Orientation is controlled by Placement property.","Attachment3D mode tooltip"));
         break;
         case mmObjectXY:
-            return TwoStrings(QObject::tr("Object's  X Y Z","Attachment3D mode caption"),
-                              QObject::tr("Placement is made equal to Placement of linked object.","Attachment3D mode tooltip"));
+            return TwoStrings(qApp->translate("Attacher3D", "Object's  X Y Z","Attachment3D mode caption"),
+                              qApp->translate("Attacher3D", "Placement is made equal to Placement of linked object.","Attachment3D mode tooltip"));
         break;
         case mmObjectXZ:
-            return TwoStrings(QObject::tr("Object's  X Z-Y","Attachment3D mode caption"),
-                              QObject::tr("X', Y', Z' axes are matched with object's local X, Z, -Y, respectively.","Attachment3D mode tooltip"));
+            return TwoStrings(qApp->translate("Attacher3D", "Object's  X Z-Y","Attachment3D mode caption"),
+                              qApp->translate("Attacher3D", "X', Y', Z' axes are matched with object's local X, Z, -Y, respectively.","Attachment3D mode tooltip"));
         break;
         case mmObjectYZ:
-            return TwoStrings(QObject::tr("Object's  Y Z X","Attachment3D mode caption"),
-                              QObject::tr("X', Y', Z' axes are matched with object's local Y, Z, X, respectively.","Attachment3D mode tooltip"));
+            return TwoStrings(qApp->translate("Attacher3D", "Object's  Y Z X","Attachment3D mode caption"),
+                              qApp->translate("Attacher3D", "X', Y', Z' axes are matched with object's local Y, Z, X, respectively.","Attachment3D mode tooltip"));
         break;
         case mmFlatFace:
-            return TwoStrings(QObject::tr("XY on plane","Attachment3D mode caption"),
-                              QObject::tr("X' Y' plane is aligned to coincide planar face.","Attachment3D mode tooltip"));
+            return TwoStrings(qApp->translate("Attacher3D", "XY on plane","Attachment3D mode caption"),
+                              qApp->translate("Attacher3D", "X' Y' plane is aligned to coincide planar face.","Attachment3D mode tooltip"));
         break;
         case mmTangentPlane:
-            return TwoStrings(QObject::tr("XY tangent to surface","Attachment3D mode caption"),
-                              QObject::tr("X' Y' plane is made tangent to surface at vertex.","Attachment3D mode tooltip"));
+            return TwoStrings(qApp->translate("Attacher3D", "XY tangent to surface","Attachment3D mode caption"),
+                              qApp->translate("Attacher3D", "X' Y' plane is made tangent to surface at vertex.","Attachment3D mode tooltip"));
         break;
         case mmNormalToPath:
-            return TwoStrings(QObject::tr("Z tangent to edge","Attachment3D mode caption"),
-                              QObject::tr("Z' axis is aligned to be tangent to edge. Optional vertex link defines where.","Attachment3D mode tooltip"));
+            return TwoStrings(qApp->translate("Attacher3D", "Z tangent to edge","Attachment3D mode caption"),
+                              qApp->translate("Attacher3D", "Z' axis is aligned to be tangent to edge. Optional vertex link defines where.","Attachment3D mode tooltip"));
         break;
         case mmFrenetNB:
-            return TwoStrings(QObject::tr("Frenet NBT","Attachment3D mode caption"),
-                              QObject::tr("Align to Frenet-Serret coordinate system of curved edge. Optional vertex link defines where.","Attachment3D mode tooltip"));
+            return TwoStrings(qApp->translate("Attacher3D", "Frenet NBT","Attachment3D mode caption"),
+                              qApp->translate("Attacher3D", "Align to Frenet-Serret coordinate system of curved edge. Optional vertex link defines where.","Attachment3D mode tooltip"));
         break;
         case mmFrenetTN:
-            return TwoStrings(QObject::tr("Frenet TNB","Attachment3D mode caption"),
-                              QObject::tr("Align to Frenet-Serret coordinate system of curved edge. Optional vertex link defines where.","Attachment3D mode tooltip"));
+            return TwoStrings(qApp->translate("Attacher3D", "Frenet TNB","Attachment3D mode caption"),
+                              qApp->translate("Attacher3D", "Align to Frenet-Serret coordinate system of curved edge. Optional vertex link defines where.","Attachment3D mode tooltip"));
         break;
         case mmFrenetTB:
-            return TwoStrings(QObject::tr("Frenet TBN","Attachment3D mode caption"),
-                              QObject::tr("Align to Frenet-Serret coordinate system of curved edge. Optional vertex link defines where.","Attachment3D mode tooltip"));
+            return TwoStrings(qApp->translate("Attacher3D", "Frenet TBN","Attachment3D mode caption"),
+                              qApp->translate("Attacher3D", "Align to Frenet-Serret coordinate system of curved edge. Optional vertex link defines where.","Attachment3D mode tooltip"));
         break;
         case mmConcentric:
-            return TwoStrings(QObject::tr("Concentric","Attachment3D mode caption"),
-                              QObject::tr("Align XY plane to osculating circle of an edge. Optional vertex link defines where.","Attachment3D mode tooltip"));
+            return TwoStrings(qApp->translate("Attacher3D", "Concentric","Attachment3D mode caption"),
+                              qApp->translate("Attacher3D", "Align XY plane to osculating circle of an edge. Optional vertex link defines where.","Attachment3D mode tooltip"));
         break;
         case mmRevolutionSection:
-            return TwoStrings(QObject::tr("Revolution Section","Attachment3D mode caption"),
-                              QObject::tr("Align Y' axis to match axis of osculating circle of an edge. Optional vertex link defines where.","Attachment3D mode tooltip"));
+            return TwoStrings(qApp->translate("Attacher3D", "Revolution Section","Attachment3D mode caption"),
+                              qApp->translate("Attacher3D", "Align Y' axis to match axis of osculating circle of an edge. Optional vertex link defines where.","Attachment3D mode tooltip"));
         break;
         case mmThreePointsPlane:
-            return TwoStrings(QObject::tr("XY plane by 3 points","Attachment3D mode caption"),
-                              QObject::tr("Align XY plane to pass through three vertices.","Attachment3D mode tooltip"));
+            return TwoStrings(qApp->translate("Attacher3D", "XY plane by 3 points","Attachment3D mode caption"),
+                              qApp->translate("Attacher3D", "Align XY plane to pass through three vertices.","Attachment3D mode tooltip"));
         break;
         case mmThreePointsNormal:
-            return TwoStrings(QObject::tr("XZ plane by 3 points","Attachment3D mode caption"),
-                              QObject::tr("Align XZ plane to pass through 3 points; X axis will pass through two first points.","Attachment3D mode tooltip"));
+            return TwoStrings(qApp->translate("Attacher3D", "XZ plane by 3 points","Attachment3D mode caption"),
+                              qApp->translate("Attacher3D", "Align XZ plane to pass through 3 points; X axis will pass through two first points.","Attachment3D mode tooltip"));
         break;
         case mmFolding:
-            return TwoStrings(QObject::tr("Folding","Attachment3D mode caption"),
-                              QObject::tr("Specialty mode for folding polyhedra. Select 4 edges in order: foldable edge, fold line, other fold line, other foldable edge. XY plane will be aligned to folding the first edge.","Attachment3D mode tooltip"));
+            return TwoStrings(qApp->translate("Attacher3D", "Folding","Attachment3D mode caption"),
+                              qApp->translate("Attacher3D", "Specialty mode for folding polyhedra. Select 4 edges in order: foldable edge, fold line, other fold line, other foldable edge. XY plane will be aligned to folding the first edge.","Attachment3D mode tooltip"));
         break;
         }
     } else if (attacherType.isDerivedFrom(Attacher::AttachEnginePlane::getClassTypeId())){
         //---- Plane/sketch attacher ----
         switch (mmode){
         case mmDeactivated:
-            return TwoStrings(QObject::tr("Deactivated","AttachmentPlane mode caption"),
-                              QObject::tr("Attachment is disabled. Plane can be moved by editing Placement property.","AttachmentPlane mode tooltip"));
+            return TwoStrings(qApp->translate("Attacher2D", "Deactivated","AttachmentPlane mode caption"),
+                              qApp->translate("Attacher2D", "Attachment is disabled. Plane can be moved by editing Placement property.","AttachmentPlane mode tooltip"));
         break;
         case mmTranslate:
-            return TwoStrings(QObject::tr("Translate origin","AttachmentPlane mode caption"),
-                              QObject::tr("Origin is aligned to match Vertex. Orientation is controlled by Placement property.","AttachmentPlane mode tooltip"));
+            return TwoStrings(qApp->translate("Attacher2D", "Translate origin","AttachmentPlane mode caption"),
+                              qApp->translate("Attacher2D", "Origin is aligned to match Vertex. Orientation is controlled by Placement property.","AttachmentPlane mode tooltip"));
         break;
         case mmObjectXY:
-            return TwoStrings(QObject::tr("Object's XY","AttachmentPlane mode caption"),
-                              QObject::tr("Plane is aligned to XY local plane of linked object.","AttachmentPlane mode tooltip"));
+            return TwoStrings(qApp->translate("Attacher2D", "Object's XY","AttachmentPlane mode caption"),
+                              qApp->translate("Attacher2D", "Plane is aligned to XY local plane of linked object.","AttachmentPlane mode tooltip"));
         break;
         case mmObjectXZ:
-            return TwoStrings(QObject::tr("Object's XZ","AttachmentPlane mode caption"),
-                              QObject::tr("Plane is aligned to XZ local plane of linked object.","AttachmentPlane mode tooltip"));
+            return TwoStrings(qApp->translate("Attacher2D", "Object's XZ","AttachmentPlane mode caption"),
+                              qApp->translate("Attacher2D", "Plane is aligned to XZ local plane of linked object.","AttachmentPlane mode tooltip"));
         break;
         case mmObjectYZ:
-            return TwoStrings(QObject::tr("Object's  YZ","AttachmentPlane mode caption"),
-                              QObject::tr("Plane is aligned to YZ local plane of linked object.","AttachmentPlane mode tooltip"));
+            return TwoStrings(qApp->translate("Attacher2D", "Object's  YZ","AttachmentPlane mode caption"),
+                              qApp->translate("Attacher2D", "Plane is aligned to YZ local plane of linked object.","AttachmentPlane mode tooltip"));
         break;
         case mmFlatFace:
-            return TwoStrings(QObject::tr("Plane face","AttachmentPlane mode caption"),
-                              QObject::tr("Plane is aligned to coincide planar face.","AttachmentPlane mode tooltip"));
+            return TwoStrings(qApp->translate("Attacher2D", "Plane face","AttachmentPlane mode caption"),
+                              qApp->translate("Attacher2D", "Plane is aligned to coincide planar face.","AttachmentPlane mode tooltip"));
         break;
         case mmTangentPlane:
-            return TwoStrings(QObject::tr("Tangent to surface","AttachmentPlane mode caption"),
-                              QObject::tr("Plane is made tangent to surface at vertex.","AttachmentPlane mode tooltip"));
+            return TwoStrings(qApp->translate("Attacher2D", "Tangent to surface","AttachmentPlane mode caption"),
+                              qApp->translate("Attacher2D", "Plane is made tangent to surface at vertex.","AttachmentPlane mode tooltip"));
         break;
         case mmNormalToPath:
-            return TwoStrings(QObject::tr("Normal to edge","AttachmentPlane mode caption"),
-                              QObject::tr("Plane is made tangent to edge. Optional vertex link defines where.","AttachmentPlane mode tooltip"));
+            return TwoStrings(qApp->translate("Attacher2D", "Normal to edge","AttachmentPlane mode caption"),
+                              qApp->translate("Attacher2D", "Plane is made tangent to edge. Optional vertex link defines where.","AttachmentPlane mode tooltip"));
         break;
         case mmFrenetNB:
-            return TwoStrings(QObject::tr("Frenet NB","AttachmentPlane mode caption"),
-                              QObject::tr("Align to Frenet-Serret coordinate system of curved edge. Optional vertex link defines where.","AttachmentPlane mode tooltip"));
+            return TwoStrings(qApp->translate("Attacher2D", "Frenet NB","AttachmentPlane mode caption"),
+                              qApp->translate("Attacher2D", "Align to Frenet-Serret coordinate system of curved edge. Optional vertex link defines where.","AttachmentPlane mode tooltip"));
         break;
         case mmFrenetTN:
-            return TwoStrings(QObject::tr("Frenet TN","AttachmentPlane mode caption"),
-                              QObject::tr("Align to Frenet-Serret coordinate system of curved edge. Optional vertex link defines where.","AttachmentPlane mode tooltip"));
+            return TwoStrings(qApp->translate("Attacher2D", "Frenet TN","AttachmentPlane mode caption"),
+                              qApp->translate("Attacher2D", "Align to Frenet-Serret coordinate system of curved edge. Optional vertex link defines where.","AttachmentPlane mode tooltip"));
         break;
         case mmFrenetTB:
-            return TwoStrings(QObject::tr("Frenet TB","AttachmentPlane mode caption"),
-                              QObject::tr("Align to Frenet-Serret coordinate system of curved edge. Optional vertex link defines where.","AttachmentPlane mode tooltip"));
+            return TwoStrings(qApp->translate("Attacher2D", "Frenet TB","AttachmentPlane mode caption"),
+                              qApp->translate("Attacher2D", "Align to Frenet-Serret coordinate system of curved edge. Optional vertex link defines where.","AttachmentPlane mode tooltip"));
         break;
         case mmConcentric:
-            return TwoStrings(QObject::tr("Concentric","AttachmentPlane mode caption"),
-                              QObject::tr("Align to plane to osculating circle of an edge. Origin is aligned to point of curvature. Optional vertex link defines where.","AttachmentPlane mode tooltip"));
+            return TwoStrings(qApp->translate("Attacher2D", "Concentric","AttachmentPlane mode caption"),
+                              qApp->translate("Attacher2D", "Align to plane to osculating circle of an edge. Origin is aligned to point of curvature. Optional vertex link defines where.","AttachmentPlane mode tooltip"));
         break;
         case mmRevolutionSection:
-            return TwoStrings(QObject::tr("Revolution Section","AttachmentPlane mode caption"),
-                              QObject::tr("Plane is prependicular to edge, and Y axis is matched with axis of osculating circle. Optional vertex link defines where.","AttachmentPlane mode tooltip"));
+            return TwoStrings(qApp->translate("Attacher2D", "Revolution Section","AttachmentPlane mode caption"),
+                              qApp->translate("Attacher2D", "Plane is prependicular to edge, and Y axis is matched with axis of osculating circle. Optional vertex link defines where.","AttachmentPlane mode tooltip"));
         break;
         case mmThreePointsPlane:
-            return TwoStrings(QObject::tr("Plane by 3 points","AttachmentPlane mode caption"),
-                              QObject::tr("Align plane to pass through three vertices.","AttachmentPlane mode tooltip"));
+            return TwoStrings(qApp->translate("Attacher2D", "Plane by 3 points","AttachmentPlane mode caption"),
+                              qApp->translate("Attacher2D", "Align plane to pass through three vertices.","AttachmentPlane mode tooltip"));
         break;
         case mmThreePointsNormal:
-            return TwoStrings(QObject::tr("Normal to 3 points","AttachmentPlane mode caption"),
-                              QObject::tr("Plane will pass through first to vertices, and perpendicular to plane that passes through three vertices.","AttachmentPlane mode tooltip"));
+            return TwoStrings(qApp->translate("Attacher2D", "Normal to 3 points","AttachmentPlane mode caption"),
+                              qApp->translate("Attacher2D", "Plane will pass through first to vertices, and perpendicular to plane that passes through three vertices.","AttachmentPlane mode tooltip"));
         break;
         case mmFolding:
-            return TwoStrings(QObject::tr("Folding","AttachmentPlane mode caption"),
-                              QObject::tr("Specialty mode for folding polyhedra. Select 4 edges in order: foldable edge, fold line, other fold line, other foldable edge. Plane will be aligned to folding the first edge.","AttachmentPlane mode tooltip"));
+            return TwoStrings(qApp->translate("Attacher2D", "Folding","AttachmentPlane mode caption"),
+                              qApp->translate("Attacher2D", "Specialty mode for folding polyhedra. Select 4 edges in order: foldable edge, fold line, other fold line, other foldable edge. Plane will be aligned to folding the first edge.","AttachmentPlane mode tooltip"));
         break;
         }
     } else if (attacherType.isDerivedFrom(Attacher::AttachEngineLine::getClassTypeId())){
         //---- Line attacher ----
         switch (mmode){
         case mmDeactivated:
-            return TwoStrings(QObject::tr("Deactivated","AttachmentLine mode caption"),
-                              QObject::tr("Attachment is disabled. Line can be moved by editing Placement property.","AttachmentLine mode tooltip"));
+            return TwoStrings(qApp->translate("Attacher1D", "Deactivated","AttachmentLine mode caption"),
+                              qApp->translate("Attacher1D", "Attachment is disabled. Line can be moved by editing Placement property.","AttachmentLine mode tooltip"));
         break;
         case mm1AxisX:
-            return TwoStrings(QObject::tr("Object's X","AttachmentLine mode caption"),
-                              QObject::tr("Line is aligned along local X axis of object. Works on objects with placements, and ellipse/parabola/hyperbola edges.","AttachmentLine mode tooltip"));
+            return TwoStrings(qApp->translate("Attacher1D", "Object's X","AttachmentLine mode caption"),
+                              qApp->translate("Attacher1D", "Line is aligned along local X axis of object. Works on objects with placements, and ellipse/parabola/hyperbola edges.","AttachmentLine mode tooltip"));
         break;
         case mm1AxisY:
-            return TwoStrings(QObject::tr("Object's Y","AttachmentLine mode caption"),
-                              QObject::tr("Line is aligned along local Y axis of object. Works on objects with placements, and ellipse/parabola/hyperbola edges.","AttachmentLine mode tooltip"));
+            return TwoStrings(qApp->translate("Attacher1D", "Object's Y","AttachmentLine mode caption"),
+                              qApp->translate("Attacher1D", "Line is aligned along local Y axis of object. Works on objects with placements, and ellipse/parabola/hyperbola edges.","AttachmentLine mode tooltip"));
         break;
         case mm1AxisZ:
-            return TwoStrings(QObject::tr("Object's Z","AttachmentLine mode caption"),
-                              QObject::tr("Line is aligned along local X axis of object. Works on objects with placements, and ellipse/parabola/hyperbola edges.","AttachmentLine mode tooltip"));
+            return TwoStrings(qApp->translate("Attacher1D", "Object's Z","AttachmentLine mode caption"),
+                              qApp->translate("Attacher1D", "Line is aligned along local X axis of object. Works on objects with placements, and ellipse/parabola/hyperbola edges.","AttachmentLine mode tooltip"));
         break;
         case mm1AxisCurv:
-            return TwoStrings(QObject::tr("Axis of curvature","AttachmentLine mode caption"),
-                              QObject::tr("Line that is an axis of osculating circle of curved edge. Optional vertex defines where.","AttachmentLine mode tooltip"));
+            return TwoStrings(qApp->translate("Attacher1D", "Axis of curvature","AttachmentLine mode caption"),
+                              qApp->translate("Attacher1D", "Line that is an axis of osculating circle of curved edge. Optional vertex defines where.","AttachmentLine mode tooltip"));
         break;
         case mm1Directrix1:
-            return TwoStrings(QObject::tr("Directrix1","AttachmentLine mode caption"),
-                              QObject::tr("Directrix line for ellipse, parabola, hyperbola.","AttachmentLine mode tooltip"));
+            return TwoStrings(qApp->translate("Attacher1D", "Directrix1","AttachmentLine mode caption"),
+                              qApp->translate("Attacher1D", "Directrix line for ellipse, parabola, hyperbola.","AttachmentLine mode tooltip"));
         break;
         case mm1Directrix2:
-            return TwoStrings(QObject::tr("Directrix2","AttachmentLine mode caption"),
-                              QObject::tr("Second directrix line for ellipse and hyperbola.","AttachmentLine mode tooltip"));
+            return TwoStrings(qApp->translate("Attacher1D", "Directrix2","AttachmentLine mode caption"),
+                              qApp->translate("Attacher1D", "Second directrix line for ellipse and hyperbola.","AttachmentLine mode tooltip"));
         break;
         case mm1Asymptote1:
-            return TwoStrings(QObject::tr("Asymptote1","AttachmentLine mode caption"),
-                              QObject::tr("Asymptote of a hyperbola.","AttachmentLine mode tooltip"));
+            return TwoStrings(qApp->translate("Attacher1D", "Asymptote1","AttachmentLine mode caption"),
+                              qApp->translate("Attacher1D", "Asymptote of a hyperbola.","AttachmentLine mode tooltip"));
         break;
         case mm1Asymptote2:
-            return TwoStrings(QObject::tr("Asymptote2","AttachmentLine mode caption"),
-                              QObject::tr("Second asymptote of hyperbola.","AttachmentLine mode tooltip"));
+            return TwoStrings(qApp->translate("Attacher1D", "Asymptote2","AttachmentLine mode caption"),
+                              qApp->translate("Attacher1D", "Second asymptote of hyperbola.","AttachmentLine mode tooltip"));
         break;
         case mm1Tangent:
-            return TwoStrings(QObject::tr("Tangent","AttachmentLine mode caption"),
-                              QObject::tr("Line tangent to an edge. Optional vertex link defines where.","AttachmentLine mode tooltip"));
+            return TwoStrings(qApp->translate("Attacher1D", "Tangent","AttachmentLine mode caption"),
+                              qApp->translate("Attacher1D", "Line tangent to an edge. Optional vertex link defines where.","AttachmentLine mode tooltip"));
         break;
         case mm1Normal:
-            return TwoStrings(QObject::tr("Normal","AttachmentLine mode caption"),
-                              QObject::tr("Align to N vector of Frenet-Serret coordinate system of curved edge. Optional vertex link defines where.","AttachmentLine mode tooltip"));
+            return TwoStrings(qApp->translate("Attacher1D", "Normal","AttachmentLine mode caption"),
+                              qApp->translate("Attacher1D", "Align to N vector of Frenet-Serret coordinate system of curved edge. Optional vertex link defines where.","AttachmentLine mode tooltip"));
         break;
         case mm1Binormal:
-            return TwoStrings(QObject::tr("Binormal","AttachmentLine mode caption"),
-                              QObject::tr("Align to B vector of Frenet-Serret coordinate system of curved edge. Optional vertex link defines where.","AttachmentLine mode tooltip"));
+            return TwoStrings(qApp->translate("Attacher1D", "Binormal","AttachmentLine mode caption"),
+                              qApp->translate("Attacher1D", "Align to B vector of Frenet-Serret coordinate system of curved edge. Optional vertex link defines where.","AttachmentLine mode tooltip"));
         break;
         case mm1TangentU:
-            return TwoStrings(QObject::tr("Tangent to surface (U)","AttachmentLine mode caption"),
-                              QObject::tr("Tangent to surface, along U parameter. Vertex link defines where.","AttachmentLine mode tooltip"));
+            return TwoStrings(qApp->translate("Attacher1D", "Tangent to surface (U)","AttachmentLine mode caption"),
+                              qApp->translate("Attacher1D", "Tangent to surface, along U parameter. Vertex link defines where.","AttachmentLine mode tooltip"));
         break;
         case mm1TangentV:
-            return TwoStrings(QObject::tr("Tangent to surface (V)","AttachmentLine mode caption"),
-                              QObject::tr("Tangent to surface, along U parameter. Vertex link defines where.","AttachmentLine mode tooltip"));
+            return TwoStrings(qApp->translate("Attacher1D", "Tangent to surface (V)","AttachmentLine mode caption"),
+                              qApp->translate("Attacher1D", "Tangent to surface, along U parameter. Vertex link defines where.","AttachmentLine mode tooltip"));
         break;
         case mm1TwoPoints:
-            return TwoStrings(QObject::tr("Through two points","AttachmentLine mode caption"),
-                              QObject::tr("Line that passes through two vertices.","AttachmentLine mode tooltip"));
+            return TwoStrings(qApp->translate("Attacher1D", "Through two points","AttachmentLine mode caption"),
+                              qApp->translate("Attacher1D", "Line that passes through two vertices.","AttachmentLine mode tooltip"));
         break;
         case mm1Intersection:
-            return TwoStrings(QObject::tr("Intersection","AttachmentLine mode caption"),
-                              QObject::tr("Not implemented.","AttachmentLine mode tooltip"));
+            return TwoStrings(qApp->translate("Attacher1D", "Intersection","AttachmentLine mode caption"),
+                              qApp->translate("Attacher1D", "Not implemented.","AttachmentLine mode tooltip"));
         break;
         case mm1Proximity:
-            return TwoStrings(QObject::tr("Proximity line","AttachmentLine mode caption"),
-                              QObject::tr("Line that spans the shortest distance between shapes.","AttachmentLine mode tooltip"));
+            return TwoStrings(qApp->translate("Attacher1D", "Proximity line","AttachmentLine mode caption"),
+                              qApp->translate("Attacher1D", "Line that spans the shortest distance between shapes.","AttachmentLine mode tooltip"));
         break;
         }
     } else if (attacherType.isDerivedFrom(Attacher::AttachEnginePoint::getClassTypeId())){
         //---- Point attacher ----
         switch (mmode){
         case mmDeactivated:
-            return TwoStrings(QObject::tr("Deactivated","AttachmentPoint mode caption"),
-                              QObject::tr("Attachment is disabled. Point can be moved by editing Placement property.","AttachmentPoint mode tooltip"));
+            return TwoStrings(qApp->translate("Attacher0D", "Deactivated","AttachmentPoint mode caption"),
+                              qApp->translate("Attacher0D", "Attachment is disabled. Point can be moved by editing Placement property.","AttachmentPoint mode tooltip"));
         break;
         case mm0Origin:
-            return TwoStrings(QObject::tr("Object's origin","AttachmentPoint mode caption"),
-                              QObject::tr("Point is put at object's Placement.Position. Works on objects with placements, and ellipse/parabola/hyperbola edges.","AttachmentPoint mode tooltip"));
+            return TwoStrings(qApp->translate("Attacher0D", "Object's origin","AttachmentPoint mode caption"),
+                              qApp->translate("Attacher0D", "Point is put at object's Placement.Position. Works on objects with placements, and ellipse/parabola/hyperbola edges.","AttachmentPoint mode tooltip"));
         break;
         case mm0Focus1:
-            return TwoStrings(QObject::tr("Focus1","AttachmentPoint mode caption"),
-                              QObject::tr("Focus of ellipse, parabola, hyperbola.","AttachmentPoint mode tooltip"));
+            return TwoStrings(qApp->translate("Attacher0D", "Focus1","AttachmentPoint mode caption"),
+                              qApp->translate("Attacher0D", "Focus of ellipse, parabola, hyperbola.","AttachmentPoint mode tooltip"));
         break;
         case mm0Focus2:
-            return TwoStrings(QObject::tr("Focus2","AttachmentPoint mode caption"),
-                              QObject::tr("Second focus of ellipse and hyperbola.","AttachmentPoint mode tooltip"));
+            return TwoStrings(qApp->translate("Attacher0D", "Focus2","AttachmentPoint mode caption"),
+                              qApp->translate("Attacher0D", "Second focus of ellipse and hyperbola.","AttachmentPoint mode tooltip"));
         break;
         case mm0OnEdge:
-            return TwoStrings(QObject::tr("On edge","AttachmentPoint mode caption"),
-                              QObject::tr("Point is put on edge, MapPathParametr controls where. Additionally, vertex can be linked in for making a projection.","AttachmentPoint mode tooltip"));
+            return TwoStrings(qApp->translate("Attacher0D", "On edge","AttachmentPoint mode caption"),
+                              qApp->translate("Attacher0D", "Point is put on edge, MapPathParametr controls where. Additionally, vertex can be linked in for making a projection.","AttachmentPoint mode tooltip"));
         break;
         case mm0CenterOfCurvature:
-            return TwoStrings(QObject::tr("Center of curvature","AttachmentPoint mode caption"),
-                              QObject::tr("Center of osculating circle of an edge. Optinal vertex link defines where.","AttachmentPoint mode tooltip"));
+            return TwoStrings(qApp->translate("Attacher0D", "Center of curvature","AttachmentPoint mode caption"),
+                              qApp->translate("Attacher0D", "Center of osculating circle of an edge. Optinal vertex link defines where.","AttachmentPoint mode tooltip"));
         break;
         case mm0CenterOfMass:
-            return TwoStrings(QObject::tr("Center of mass","AttachmentPoint mode caption"),
-                              QObject::tr("Not implemented","AttachmentPoint mode tooltip"));
+            return TwoStrings(qApp->translate("Attacher0D", "Center of mass","AttachmentPoint mode caption"),
+                              qApp->translate("Attacher0D", "Not implemented","AttachmentPoint mode tooltip"));
         break;
         case mm0Intersection:
-            return TwoStrings(QObject::tr("Intersection","AttachmentPoint mode caption"),
-                              QObject::tr("Not implemented","AttachmentPoint mode tooltip"));
+            return TwoStrings(qApp->translate("Attacher0D", "Intersection","AttachmentPoint mode caption"),
+                              qApp->translate("Attacher0D", "Not implemented","AttachmentPoint mode tooltip"));
         break;
         case mm0Vertex:
-            return TwoStrings(QObject::tr("Vertex","AttachmentPoint mode caption"),
-                              QObject::tr("Put Datum point coincident with another vertex.","AttachmentPoint mode tooltip"));
+            return TwoStrings(qApp->translate("Attacher0D", "Vertex","AttachmentPoint mode caption"),
+                              qApp->translate("Attacher0D", "Put Datum point coincident with another vertex.","AttachmentPoint mode tooltip"));
         break;
         case mm0ProximityPoint1:
-            return TwoStrings(QObject::tr("Proximity point 1","AttachmentPoint mode caption"),
-                              QObject::tr("Point on first reference that is closest to second reference.","AttachmentPoint mode tooltip"));
+            return TwoStrings(qApp->translate("Attacher0D", "Proximity point 1","AttachmentPoint mode caption"),
+                              qApp->translate("Attacher0D", "Point on first reference that is closest to second reference.","AttachmentPoint mode tooltip"));
         break;
         case mm0ProximityPoint2:
-            return TwoStrings(QObject::tr("Proximity point 2","AttachmentPoint mode caption"),
-                              QObject::tr("Point on second reference that is closest to first reference.","AttachmentPoint mode tooltip"));
+            return TwoStrings(qApp->translate("Attacher0D", "Proximity point 2","AttachmentPoint mode caption"),
+                              qApp->translate("Attacher0D", "Point on second reference that is closest to first reference.","AttachmentPoint mode tooltip"));
         break;
         }
     }
@@ -303,42 +303,48 @@ AttacherGui::TextSet AttacherGui::getUIStrings(Base::Type attacherType, Attacher
     return TwoStrings(QString::fromLatin1(Attacher::AttachEngine::getModeName(mmode).c_str()),QString());
 }
 
+//Note: this list must be in sync with eRefType enum
+static struct { const char *txt; const char *comment; } eRefTypeStrings[] = {
+    QT_TRANSLATE_NOOP3("Attacher", "Any", "Attacher reference type"),
+    QT_TRANSLATE_NOOP3("Attacher", "Vertex", "Attacher reference type"),
+    QT_TRANSLATE_NOOP3("Attacher", "Edge", "Attacher reference type"),
+    QT_TRANSLATE_NOOP3("Attacher", "Face", "Attacher reference type"),
+
+    QT_TRANSLATE_NOOP3("Attacher", "Line", "Attacher reference type"),
+    QT_TRANSLATE_NOOP3("Attacher", "Curve", "Attacher reference type"),
+    QT_TRANSLATE_NOOP3("Attacher", "Circle", "Attacher reference type"),
+    QT_TRANSLATE_NOOP3("Attacher", "Conic", "Attacher reference type"),
+    QT_TRANSLATE_NOOP3("Attacher", "Ellipse", "Attacher reference type"),
+    QT_TRANSLATE_NOOP3("Attacher", "Parabola", "Attacher reference type"),
+    QT_TRANSLATE_NOOP3("Attacher", "Hyperbola", "Attacher reference type"),
+
+    QT_TRANSLATE_NOOP3("Attacher", "Plane", "Attacher reference type"),
+    QT_TRANSLATE_NOOP3("Attacher", "Sphere", "Attacher reference type"),
+    QT_TRANSLATE_NOOP3("Attacher", "Revolve", "Attacher reference type"),
+    QT_TRANSLATE_NOOP3("Attacher", "Cylinder", "Attacher reference type"),
+    QT_TRANSLATE_NOOP3("Attacher", "Torus", "Attacher reference type"),
+    QT_TRANSLATE_NOOP3("Attacher", "Cone", "Attacher reference type"),
+
+    QT_TRANSLATE_NOOP3("Attacher", "Object", "Attacher reference type"),
+    QT_TRANSLATE_NOOP3("Attacher", "Solid", "Attacher reference type"),
+    QT_TRANSLATE_NOOP3("Attacher", "Wire", "Attacher reference type"),
+    {nullptr, nullptr},
+    {nullptr, nullptr},
+    {nullptr, nullptr}
+};
+
 
 QString getShapeTypeText(eRefType type)
 {
     //get rid of flags in type
     type = eRefType(type & (rtFlagHasPlacement - 1));
 
-    const char* eRefTypeStrings[] = {
-        QT_TR_NOOP("Any"),
-        QT_TR_NOOP("Vertex"),
-        QT_TR_NOOP("Edge"),
-        QT_TR_NOOP("Face"),
+    if (type >= 0 && type < rtDummy_numberOfShapeTypes){
+        if (eRefTypeStrings[int(type)].txt){
+            return qApp->translate("Attacher", eRefTypeStrings[int(type)].txt, eRefTypeStrings[int(type)].comment);
+        }
+    }
 
-        QT_TR_NOOP("Line"),
-        QT_TR_NOOP("Curve"),
-        QT_TR_NOOP("Circle"),
-        QT_TR_NOOP("Conic"),
-        QT_TR_NOOP("Ellipse"),
-        QT_TR_NOOP("Parabola"),
-        QT_TR_NOOP("Hyperbola"),
-
-        QT_TR_NOOP("Plane"),
-        QT_TR_NOOP("Sphere"),
-        QT_TR_NOOP("Revolve"),
-        QT_TR_NOOP("Cylinder"),
-        QT_TR_NOOP("Torus"),
-        QT_TR_NOOP("Cone"),
-        //
-        QT_TR_NOOP("Object"),
-        QT_TR_NOOP("Solid"),
-        QT_TR_NOOP("Wire"),
-        NULL
-    };
-
-    if (type >= 0 && type < rtDummy_numberOfShapeTypes)
-        if (eRefTypeStrings[int(type)])
-            return QObject::tr(eRefTypeStrings[int(type)]);
     throw Base::Exception("getShTypeText: type value is wrong, or a string is missing in the list");
 }
 

--- a/src/Mod/Part/Gui/AttacherTexts.cpp
+++ b/src/Mod/Part/Gui/AttacherTexts.cpp
@@ -39,9 +39,9 @@ TextSet TwoStrings(QString str1, QString str2)
     return v;
 }
 
-AttacherGui::TextSet AttacherGui::getUIStrings(Base::Type attacherType, Attacher::eMapMode mmode)
+TextSet getUIStrings(Base::Type attacherType, eMapMode mmode)
 {
-    if (attacherType.isDerivedFrom(Attacher::AttachEngine3D::getClassTypeId())){
+    if (attacherType.isDerivedFrom(AttachEngine3D::getClassTypeId())){
         //---- coordinate system attacher ----
         switch (mmode){
         case mmDeactivated:
@@ -109,7 +109,7 @@ AttacherGui::TextSet AttacherGui::getUIStrings(Base::Type attacherType, Attacher
                               qApp->translate("Attacher3D", "Specialty mode for folding polyhedra. Select 4 edges in order: foldable edge, fold line, other fold line, other foldable edge. XY plane will be aligned to folding the first edge.","Attachment3D mode tooltip"));
         break;
         }
-    } else if (attacherType.isDerivedFrom(Attacher::AttachEnginePlane::getClassTypeId())){
+    } else if (attacherType.isDerivedFrom(AttachEnginePlane::getClassTypeId())){
         //---- Plane/sketch attacher ----
         switch (mmode){
         case mmDeactivated:
@@ -177,7 +177,7 @@ AttacherGui::TextSet AttacherGui::getUIStrings(Base::Type attacherType, Attacher
                               qApp->translate("Attacher2D", "Specialty mode for folding polyhedra. Select 4 edges in order: foldable edge, fold line, other fold line, other foldable edge. Plane will be aligned to folding the first edge.","AttachmentPlane mode tooltip"));
         break;
         }
-    } else if (attacherType.isDerivedFrom(Attacher::AttachEngineLine::getClassTypeId())){
+    } else if (attacherType.isDerivedFrom(AttachEngineLine::getClassTypeId())){
         //---- Line attacher ----
         switch (mmode){
         case mmDeactivated:
@@ -249,7 +249,7 @@ AttacherGui::TextSet AttacherGui::getUIStrings(Base::Type attacherType, Attacher
                               qApp->translate("Attacher1D", "Line that spans the shortest distance between shapes.","AttachmentLine mode tooltip"));
         break;
         }
-    } else if (attacherType.isDerivedFrom(Attacher::AttachEnginePoint::getClassTypeId())){
+    } else if (attacherType.isDerivedFrom(AttachEnginePoint::getClassTypeId())){
         //---- Point attacher ----
         switch (mmode){
         case mmDeactivated:
@@ -300,7 +300,7 @@ AttacherGui::TextSet AttacherGui::getUIStrings(Base::Type attacherType, Attacher
     }
 
     assert("No user-friendly string defined for this attachment mode."=="");
-    return TwoStrings(QString::fromLatin1(Attacher::AttachEngine::getModeName(mmode).c_str()),QString());
+    return TwoStrings(QString::fromLatin1(AttachEngine::getModeName(mmode).c_str()),QString());
 }
 
 //Note: this list must be in sync with eRefType enum

--- a/src/Mod/Part/Gui/AttacherTexts.h
+++ b/src/Mod/Part/Gui/AttacherTexts.h
@@ -1,0 +1,56 @@
+/***************************************************************************
+ *   Copyright (c) Victor Titov (DeepSOIC)                                 *
+ *                                           (vv.titov@gmail.com) 2016     *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+/**
+  * AttacherTexts.h, .cpp - files that contain user-friendly translatable names
+  * of attachment modes, as well as help texts, and the like.
+  */
+
+#ifndef PARTATTACHERTEXTS_H
+#define PARTATTACHERTEXTS_H
+
+
+#include <vector>
+#include <QString>
+#include <Mod/Part/App/Attacher.h>
+
+namespace AttacherGui {
+
+typedef std::vector<QString> TextSet;
+
+/**
+ * @brief getUIStrings
+ * @param attacherType
+ * @param mmode
+ * @return vector of two QStrings:
+ * first is the name of attachment mode. e.g. "Tangent to surface";
+ * second is tooltip-style explanation of the mode, like "Plane is tangent to a surface at vertex."
+ */
+TextSet PartGuiExport getUIStrings(Base::Type attacherType, Attacher::eMapMode mmode);
+
+
+QString PartGuiExport getShapeTypeText(Attacher::eRefType type);
+
+}
+
+#endif

--- a/src/Mod/Part/Gui/AttacherTexts.h
+++ b/src/Mod/Part/Gui/AttacherTexts.h
@@ -32,6 +32,7 @@
 
 #include <vector>
 #include <QString>
+#include <QStringList>
 #include <Mod/Part/App/Attacher.h>
 
 namespace AttacherGui {
@@ -50,6 +51,8 @@ TextSet PartGuiExport getUIStrings(Base::Type attacherType, Attacher::eMapMode m
 
 
 QString PartGuiExport getShapeTypeText(Attacher::eRefType type);
+
+QStringList PartGuiExport getRefListForMode(Attacher::AttachEngine &attacher, Attacher::eMapMode mmode);
 
 }
 

--- a/src/Mod/Part/Gui/CMakeLists.txt
+++ b/src/Mod/Part/Gui/CMakeLists.txt
@@ -83,6 +83,8 @@ SET(PartGui_SRCS
     ${PartGui_QRC_SRCS}
     ${PartGui_UIC_HDRS}
     AppPartGui.cpp
+    AttacherTexts.h
+    AttacherTexts.cpp
     Command.cpp
     CommandSimple.cpp
     CommandParametric.cpp

--- a/src/Mod/PartDesign/App/DatumPlane.cpp
+++ b/src/Mod/PartDesign/App/DatumPlane.cpp
@@ -40,7 +40,7 @@ PROPERTY_SOURCE(PartDesign::Plane, Part::Datum)
 
 Plane::Plane()
 {
-    this->setAttacher(new AttachEngine3D);
+    this->setAttacher(new AttachEnginePlane);
     // Create a shape, which will be used by the Sketcher. Them main function is to avoid a dependency of
     // Sketcher on the PartDesign module
     BRepBuilderAPI_MakeFace builder(gp_Pln(gp_Pnt(0,0,0), gp_Dir(0,0,1)));

--- a/src/Mod/PartDesign/Gui/TaskDatumParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskDatumParameters.cpp
@@ -49,6 +49,7 @@
 #include <Mod/Part/App/PrimitiveFeature.h>
 #include <Mod/Part/App/DatumFeature.h>
 #include <Mod/PartDesign/App/Body.h>
+#include <Mod/Part/Gui/AttacherTexts.h>
 
 #include "ReferenceSelection.h"
 #include "Utils.h"
@@ -232,50 +233,13 @@ TaskDatumParameters::TaskDatumParameters(ViewProviderDatum *DatumView,QWidget *p
     DatumView->setPickable(false);
 }
 
-QString getShTypeText(eRefType type)
-{
-    //get rid of flags in type
-    type = eRefType(type & (rtFlagHasPlacement - 1));
-
-    const char* eRefTypeStrings[] = {
-        QT_TR_NOOP("Any"),
-        QT_TR_NOOP("Vertex"),
-        QT_TR_NOOP("Edge"),
-        QT_TR_NOOP("Face"),
-
-        QT_TR_NOOP("Line"),
-        QT_TR_NOOP("Curve"),
-        QT_TR_NOOP("Circle"),
-        QT_TR_NOOP("Conic"),
-        QT_TR_NOOP("Ellipse"),
-        QT_TR_NOOP("Parabola"),
-        QT_TR_NOOP("Hyperbola"),
-
-        QT_TR_NOOP("Plane"),
-        QT_TR_NOOP("Sphere"),
-        QT_TR_NOOP("Revolve"),
-        QT_TR_NOOP("Cylinder"),
-        QT_TR_NOOP("Torus"),
-        QT_TR_NOOP("Cone"),
-        //
-        QT_TR_NOOP("Object"),
-        QT_TR_NOOP("Solid"),
-        QT_TR_NOOP("Wire"),
-        NULL
-    };
-
-    if (type >= 0 && type < rtDummy_numberOfShapeTypes)
-        if (eRefTypeStrings[int(type)])
-            return QObject::tr(eRefTypeStrings[int(type)]);
-    throw Base::Exception("getShTypeText: type value is wrong, or a string is missing in the list");
-}
 
 const QString makeHintText(std::set<eRefType> hint)
 {
     QString result;
     for (std::set<eRefType>::const_iterator t = hint.begin(); t != hint.end(); t++) {
         QString tText;
-        tText = getShTypeText(*t);
+        tText = AttacherGui::getShapeTypeText(*t);
         result += QString::fromLatin1(result.size() == 0 ? "" : "/") + tText;
     }
 
@@ -691,12 +655,14 @@ void TaskDatumParameters::updateListOfModes(eMapMode curMode)
     if (modesInList.size()>0) {
         for (size_t i = 0  ;  i < modesInList.size()  ;  ++i){
             eMapMode mmode = modesInList[i];
-            ui->listOfModes->addItem(QString::fromLatin1(AttachEngine::eMapModeStrings[mmode]));
+            std::vector<QString> mstr = AttacherGui::getUIStrings(pcDatum->attacher().getTypeId(),mmode);
+            ui->listOfModes->addItem(mstr[0]);
+            QListWidgetItem* item = ui->listOfModes->item(i);
+            item->setToolTip(mstr[1]);
             if (mmode == curMode)
                 iSelect = ui->listOfModes->item(i);
             if (mmode == suggMode){
                 //make it bold
-                QListWidgetItem* item = ui->listOfModes->item(i);
                 assert (item);
                 QFont fnt = item->font();
                 fnt.setBold(true);

--- a/src/Mod/PartDesign/Gui/TaskDatumParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskDatumParameters.cpp
@@ -658,7 +658,9 @@ void TaskDatumParameters::updateListOfModes(eMapMode curMode)
             std::vector<QString> mstr = AttacherGui::getUIStrings(pcDatum->attacher().getTypeId(),mmode);
             ui->listOfModes->addItem(mstr[0]);
             QListWidgetItem* item = ui->listOfModes->item(i);
-            item->setToolTip(mstr[1]);
+            item->setToolTip(mstr[1] + QString::fromLatin1("\n\n") +
+                             tr("Reference combinations:\n") +
+                             AttacherGui::getRefListForMode(pcDatum->attacher(),mmode).join(QString::fromLatin1("\n")));
             if (mmode == curMode)
                 iSelect = ui->listOfModes->item(i);
             if (mmode == suggMode){

--- a/src/Mod/PartDesign/Gui/TaskDatumParameters.ui
+++ b/src/Mod/PartDesign/Gui/TaskDatumParameters.ui
@@ -98,7 +98,7 @@
    <item>
     <widget class="QLabel" name="label">
      <property name="text">
-      <string>Available modes:</string>
+      <string>Attachment mode:</string>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
I'm repeating pull request after fixing attacher strings.

Fix: superPlacement was applied twice on some line and point attachment modes

UI:
* Mode names in datum tasks are now less programmerish. They have become easily changeable, and translatable. 
* Added tooltips to all modes, that explain the action with one sentence, and list accepted reference combinations.
