### PR TITLE
Attacher11 - numerous changes to datum feature attachment

### DIFF
--- a/src/App/ObjectIdentifier.h
+++ b/src/App/ObjectIdentifier.h
@@ -267,7 +267,7 @@ protected:
 
 };
 
-std::size_t hash_value(const App::ObjectIdentifier & path);
+std::size_t AppExport hash_value(const App::ObjectIdentifier & path);
 
 }
 

--- a/src/Mod/Part/App/AttachableObject.cpp
+++ b/src/Mod/Part/App/AttachableObject.cpp
@@ -109,30 +109,31 @@ void setReadonlyness(App::Property &prop, bool on)
 void AttachableObject::onChanged(const App::Property* prop)
 {
     if(! this->isRestoring()){
-        bool bAttached = false;
-        try{
-            if ((prop == &Support
-                 || prop == &MapMode
-                 || prop == &MapPathParameter
-                 || prop == &MapReversed
-                 || prop == &superPlacement)){
+        if ((prop == &Support
+             || prop == &MapMode
+             || prop == &MapPathParameter
+             || prop == &MapReversed
+             || prop == &superPlacement)){
 
+            bool bAttached = false;
+            try{
                 bAttached = positionBySupport();
+            } catch (Base::Exception &e) {
+                this->setError();
+                Base::Console().Error("PositionBySupport: %s",e.what());
+                //set error message - how?
+            } catch (Standard_Failure &e){
+                this->setError();
+                Base::Console().Error("PositionBySupport: %s",e.GetMessageString());
             }
-        } catch (Base::Exception &e) {
-            this->setError();
-            Base::Console().Error("PositionBySupport: %s",e.what());
-            //set error message - how?
-        } catch (Standard_Failure &e){
-            this->setError();
-            Base::Console().Error("PositionBySupport: %s",e.GetMessageString());
+
+            eMapMode mmode = eMapMode(this->MapMode.getValue());
+            setReadonlyness(this->superPlacement, !bAttached);
+            setReadonlyness(this->Placement, bAttached && mmode != mmTranslate); //for mmTranslate, orientation should remain editable even when attached.
         }
 
-        eMapMode mmode = eMapMode(this->MapMode.getValue());
-        setReadonlyness(this->superPlacement, !bAttached);
-        setReadonlyness(this->Placement, bAttached && mmode != mmTranslate); //for mmTranslate, orientation should remain editable even when attached.
-
     }
+
     Part::Feature::onChanged(prop);
 }
 

--- a/src/Mod/Part/App/AttachableObject.h
+++ b/src/Mod/Part/App/AttachableObject.h
@@ -84,9 +84,10 @@ public:
     App::PropertyFloat MapPathParameter;
 
     /** calculate and update the Placement property based on the Support, and
-      * mode. Can throw FreeCAD and OCC exceptions.
+      * mode. Can throw FreeCAD and OCC exceptions. Returns true if attached,
+      * false if not, throws if attachment failed.
       */
-    virtual void positionBySupport(void);
+    virtual bool positionBySupport(void);
 
     virtual bool isTouched_Mapping()
     {return true; /*support.isTouched isn't true when linked objects are changed... why?..*/};

--- a/src/Mod/Part/App/Attacher.cpp
+++ b/src/Mod/Part/App/Attacher.cpp
@@ -247,7 +247,8 @@ Base::Placement AttachEngine::placementFactory(const gp_Dir &ZAxis,
 
 eMapMode AttachEngine::listMapModes(eSuggestResult& msg,
                                     std::vector<eMapMode>* allApplicableModes,
-                                    std::set<eRefType>* nextRefTypeHint) const
+                                    std::set<eRefType>* nextRefTypeHint,
+                                    std::set<eMapMode>* reachableModes) const
 {
     //replace a pointer with a valid reference, to avoid checks for zero pointer everywhere
     std::vector<eMapMode> buf;
@@ -262,6 +263,12 @@ eMapMode AttachEngine::listMapModes(eSuggestResult& msg,
         nextRefTypeHint = &buf2;
     std::set<eRefType> &hints = *nextRefTypeHint;
     hints.clear();
+
+    std::set<eMapMode> buf3;
+    if (reachableModes == 0)
+        reachableModes = &buf3;
+    std::set<eMapMode> &mlist_reachable = *reachableModes;
+    mlist_reachable.clear();
 
 
     std::vector<App::GeoFeature*> parts;
@@ -305,8 +312,10 @@ eMapMode AttachEngine::listMapModes(eSuggestResult& msg,
                 }
             }
 
-            if (score > 0  &&  str.size() > typeStr.size())
+            if (score > 0  &&  str.size() > typeStr.size()){
                 hints.insert(str[typeStr.size()]);
+                reachableModes->insert(eMapMode(iMode));
+            }
 
             //size check is last, because we needed to collect hints
             if (str.size() != typeStr.size())

--- a/src/Mod/Part/App/Attacher.h
+++ b/src/Mod/Part/App/Attacher.h
@@ -216,10 +216,13 @@ public: //methods
      * right type.
      *
      * @param nextRefTypeHint (output). A hint of what can be added to references.
+     *
+     * @param reachableModes (output). List of modes that can be reached by selecing more references.
      */
     virtual eMapMode listMapModes(eSuggestResult &msg,
                                   std::vector<eMapMode>* allApplicableModes = 0,
-                                  std::set<eRefType>* nextRefTypeHint = 0) const;
+                                  std::set<eRefType>* nextRefTypeHint = 0,
+                                  std::set<eMapMode> *reachableModes = 0) const;
 
     /**
      * @brief getHint function returns a set of types that user can add to

--- a/src/Mod/Part/App/Attacher.h
+++ b/src/Mod/Part/App/Attacher.h
@@ -39,6 +39,7 @@
 #include "PartFeature.h"
 
 #include <gp_Vec.hxx>
+#include <GProp_GProps.hxx>
 
 namespace Attacher
 {
@@ -303,6 +304,8 @@ public://helper functions that may be useful outside of the class
      * @return returns a string that identifies the attachment mode in enum property.
      */
     static std::string getModeName(eMapMode mmode);
+
+    static GProp_GProps getInertialPropsOfShape(const std::vector<const TopoDS_Shape*> &shapes);
 
 
 public: //enums

--- a/src/Mod/Part/App/Attacher.h
+++ b/src/Mod/Part/App/Attacher.h
@@ -92,6 +92,13 @@ enum eMapMode {
     mm0Vertex,
     mm0ProximityPoint1,
     mm0ProximityPoint2,
+
+    mm1AxisInertia1,
+    mm1AxisInertia2,
+    mm1AxisInertia3,
+
+    mmInertialCS,
+
     mmDummy_NumberOfModes//a value useful to check the validity of mode value
 };//see also eMapModeStrings[] definition in .cpp
 

--- a/src/Mod/Part/App/Attacher.h
+++ b/src/Mod/Part/App/Attacher.h
@@ -144,6 +144,10 @@ enum eRefType {
 class PartExport AttachEngine : public Base::BaseClass
 {
     TYPESYSTEM_HEADER();
+public: //typedefs
+    typedef std::vector<eRefType> refTypeString; //a sequence of ref types, according to Support contents for example
+    typedef std::vector<refTypeString> refTypeStringList; //a set of type strings, defines which selection sets are supported by a certain mode
+
 public: //methods
     AttachEngine();
     virtual void setUp(const App::PropertyLinkSubList &references,
@@ -217,12 +221,16 @@ public: //methods
      *
      * @param nextRefTypeHint (output). A hint of what can be added to references.
      *
-     * @param reachableModes (output). List of modes that can be reached by selecing more references.
+     * @param reachableModes (output). List of modes that can be reached by
+     * selecing more references. Is a map, where key is the mode that can be
+     * reached and value is a list of reference sequences that can be added to
+     * reach the mode (stuff already linked is omitted from these lists; only
+     * extra links needed are listed)
      */
     virtual eMapMode listMapModes(eSuggestResult &msg,
                                   std::vector<eMapMode>* allApplicableModes = 0,
                                   std::set<eRefType>* nextRefTypeHint = 0,
-                                  std::set<eMapMode> *reachableModes = 0) const;
+                                  std::map<eMapMode, refTypeStringList> *reachableModes = 0) const;
 
     /**
      * @brief getHint function returns a set of types that user can add to
@@ -317,8 +325,6 @@ public: //members
      */
     std::vector<bool> modeEnabled;
 
-    typedef std::vector<eRefType> refTypeString; //a sequence of ref types, according to Support contents for example
-    typedef std::vector<refTypeString> refTypeStringList; //a set of type strings, defines which selection sets are supported by a certain mode
     std::vector<refTypeStringList> modeRefTypes; //a complete data structure, containing info on which modes support what selection
 
 protected:

--- a/src/Mod/Part/App/Part2DObjectPy.xml
+++ b/src/Mod/Part/App/Part2DObjectPy.xml
@@ -15,7 +15,9 @@
     </Documentation>
     <Methode Name="positionBySupport">
       <Documentation>
-        <UserDocu>Reposition object based on Support, MapMode and MapPathParameter properties.</UserDocu>
+        <UserDocu>positionBySupport(): Reposition object based on Support, MapMode and MapPathParameter properties.
+Returns True if attachment calculation was successful, false if object is not attached and Placement wasn't updated,
+and raises an exception if attachment calculation fails.</UserDocu>
       </Documentation>
     </Methode>
   </PythonExport>

--- a/src/Mod/Part/App/Part2DObjectPyImp.cpp
+++ b/src/Mod/Part/App/Part2DObjectPyImp.cpp
@@ -20,8 +20,9 @@ PyObject* Part2DObjectPy::positionBySupport(PyObject *args)
 {
     if (!PyArg_ParseTuple(args, ""))
         return 0;
+    bool bAttached = false;
     try{
-        this->getPart2DObjectPtr()->positionBySupport();
+        bAttached = this->getPart2DObjectPtr()->positionBySupport();
     } catch (Standard_Failure) {
         Handle_Standard_Failure e = Standard_Failure::Caught();
         PyErr_SetString(PartExceptionOCCError, e->GetMessageString());
@@ -30,8 +31,7 @@ PyObject* Part2DObjectPy::positionBySupport(PyObject *args)
         PyErr_SetString(Base::BaseExceptionFreeCADError, e.what());
         return NULL;
     }
-    Py_INCREF(Py_None);
-    return Py_None;
+    return Py::new_reference_to(Py::Boolean(bAttached));
 }
 
 

--- a/src/Mod/Part/Gui/AttacherTexts.cpp
+++ b/src/Mod/Part/Gui/AttacherTexts.cpp
@@ -313,9 +313,9 @@ QString getShapeTypeText(eRefType type)
 
 QStringList getRefListForMode(AttachEngine &attacher, eMapMode mmode)
 {
-    AttachEngine::refTypeStringList list = attacher.modeRefTypes[mmode];
+    refTypeStringList list = attacher.modeRefTypes[mmode];
     QStringList strlist;
-    for(AttachEngine::refTypeString &rts : list){
+    for(refTypeString &rts : list){
         QStringList buf;
         for(eRefType rt : rts){
             buf.append(getShapeTypeText(rt));

--- a/src/Mod/Part/Gui/AttacherTexts.cpp
+++ b/src/Mod/Part/Gui/AttacherTexts.cpp
@@ -142,7 +142,7 @@ TextSet getUIStrings(Base::Type attacherType, eMapMode mmode)
                               qApp->translate("Attacher2D", "Align plane to pass through three vertices.","AttachmentPlane mode tooltip"));
         case mmThreePointsNormal:
             return TwoStrings(qApp->translate("Attacher2D", "Normal to 3 points","AttachmentPlane mode caption"),
-                              qApp->translate("Attacher2D", "Plane will pass through first to vertices, and perpendicular to plane that passes through three vertices.","AttachmentPlane mode tooltip"));
+                              qApp->translate("Attacher2D", "Plane will pass through first two vertices, and perpendicular to plane that passes through three vertices.","AttachmentPlane mode tooltip"));
         case mmFolding:
             return TwoStrings(qApp->translate("Attacher2D", "Folding","AttachmentPlane mode caption"),
                               qApp->translate("Attacher2D", "Specialty mode for folding polyhedra. Select 4 edges in order: foldable edge, fold line, other fold line, other foldable edge. Plane will be aligned to folding the first edge.","AttachmentPlane mode tooltip"));

--- a/src/Mod/Part/Gui/AttacherTexts.cpp
+++ b/src/Mod/Part/Gui/AttacherTexts.cpp
@@ -229,7 +229,7 @@ TextSet getUIStrings(Base::Type attacherType, eMapMode mmode)
                               qApp->translate("Attacher0D", "Center of osculating circle of an edge. Optinal vertex link defines where.","AttachmentPoint mode tooltip"));
         case mm0CenterOfMass:
             return TwoStrings(qApp->translate("Attacher0D", "Center of mass","AttachmentPoint mode caption"),
-                              qApp->translate("Attacher0D", "Not implemented","AttachmentPoint mode tooltip"));
+                              qApp->translate("Attacher0D", "Center of mass of all references (equal densities are assumed).","AttachmentPoint mode tooltip"));
         case mm0Intersection:
             return TwoStrings(qApp->translate("Attacher0D", "Intersection","AttachmentPoint mode caption"),
                               qApp->translate("Attacher0D", "Not implemented","AttachmentPoint mode tooltip"));

--- a/src/Mod/Part/Gui/AttacherTexts.cpp
+++ b/src/Mod/Part/Gui/AttacherTexts.cpp
@@ -92,6 +92,9 @@ TextSet getUIStrings(Base::Type attacherType, eMapMode mmode)
         case mmFolding:
             return TwoStrings(qApp->translate("Attacher3D", "Folding","Attachment3D mode caption"),
                               qApp->translate("Attacher3D", "Specialty mode for folding polyhedra. Select 4 edges in order: foldable edge, fold line, other fold line, other foldable edge. XY plane will be aligned to folding the first edge.","Attachment3D mode tooltip"));
+        case mmInertialCS:
+            return TwoStrings(qApp->translate("Attacher3D", "Inertial CS","Attachment3D mode caption"),
+                              qApp->translate("Attacher3D", "Inertial coordinate system, constructed on principal axes of inertia and center of mass.","Attachment3D mode tooltip"));
         default:
             break;
         }
@@ -146,6 +149,9 @@ TextSet getUIStrings(Base::Type attacherType, eMapMode mmode)
         case mmFolding:
             return TwoStrings(qApp->translate("Attacher2D", "Folding","AttachmentPlane mode caption"),
                               qApp->translate("Attacher2D", "Specialty mode for folding polyhedra. Select 4 edges in order: foldable edge, fold line, other fold line, other foldable edge. Plane will be aligned to folding the first edge.","AttachmentPlane mode tooltip"));
+        case mmInertialCS:
+            return TwoStrings(qApp->translate("Attacher2D", "Inertia 2-3","AttachmentPlane mode caption"),
+                              qApp->translate("Attacher2D", "Plane constructed on second and third principal axes of inertia (passes through center of mass).","AttachmentPlane mode tooltip"));
         default:
             break;
         }
@@ -203,6 +209,15 @@ TextSet getUIStrings(Base::Type attacherType, eMapMode mmode)
         case mm1Proximity:
             return TwoStrings(qApp->translate("Attacher1D", "Proximity line","AttachmentLine mode caption"),
                               qApp->translate("Attacher1D", "Line that spans the shortest distance between shapes.","AttachmentLine mode tooltip"));
+        case mm1AxisInertia1:
+            return TwoStrings(qApp->translate("Attacher1D", "1st principal axis","AttachmentLine mode caption"),
+                              qApp->translate("Attacher1D", "Line follows first principal axis of inertia.","AttachmentLine mode tooltip"));
+        case mm1AxisInertia2:
+            return TwoStrings(qApp->translate("Attacher1D", "2nd principal axis","AttachmentLine mode caption"),
+                              qApp->translate("Attacher1D", "Line follows second principal axis of inertia.","AttachmentLine mode tooltip"));
+        case mm1AxisInertia3:
+            return TwoStrings(qApp->translate("Attacher1D", "3rd principal axis","AttachmentLine mode caption"),
+                              qApp->translate("Attacher1D", "Line follows third principal axis of inertia.","AttachmentLine mode tooltip"));
         default:
             break;
         }

--- a/src/Mod/PartDesign/Gui/Command.cpp
+++ b/src/Mod/PartDesign/Gui/Command.cpp
@@ -114,12 +114,12 @@ void UnifiedDatumCommand(Gui::Command &cmd, Base::Type type, std::string name)
             if (support.getSize() > 0) {
                 Part::AttachableObject* pcDatum = static_cast<Part::AttachableObject*>(cmd.getDocument()->getObject(FeatName.c_str()));
                 pcDatum->attacher().references.Paste(support);
-                eSuggestResult msg;
-                eMapMode suggMode = pcDatum->attacher().listMapModes(msg);
-                if (msg == srOK) {
+                SuggestResult sugr;
+                pcDatum->attacher().suggestMapModes(sugr);
+                if (sugr.message == Attacher::SuggestResult::srOK) {
                     //fits some mode. Populate support property.
                     cmd.doCommand(Gui::Command::Doc,"App.activeDocument().%s.Support = %s",FeatName.c_str(),support.getPyReprString().c_str());
-                    cmd.doCommand(Gui::Command::Doc,"App.activeDocument().%s.MapMode = '%s'",FeatName.c_str(),AttachEngine::eMapModeStrings[suggMode]);
+                    cmd.doCommand(Gui::Command::Doc,"App.activeDocument().%s.MapMode = '%s'",FeatName.c_str(),AttachEngine::getModeName(sugr.bestFitMode).c_str());
                 } else {
                     QMessageBox::information(Gui::getMainWindow(),QObject::tr("Invalid selection"), QObject::tr("There are no attachment modes that fit seleted objects. Select something else."));
                 }

--- a/src/Mod/PartDesign/Gui/Command.cpp
+++ b/src/Mod/PartDesign/Gui/Command.cpp
@@ -423,7 +423,7 @@ void CmdPartDesignNewSketch::activated(int iMsg)
         openCommand("Create a Sketch on Face");
         doCommand(Doc,"App.activeDocument().addObject('Sketcher::SketchObject','%s')",FeatName.c_str());
         doCommand(Doc,"App.activeDocument().%s.Support = %s",FeatName.c_str(),supportString.c_str());
-        doCommand(Doc,"App.activeDocument().%s.MapMode = '%s'",FeatName.c_str(),Attacher::AttachEngine::eMapModeStrings[Attacher::mmFlatFace]);
+        doCommand(Doc,"App.activeDocument().%s.MapMode = '%s'",FeatName.c_str(),Attacher::AttachEngine::getModeName(Attacher::mmFlatFace).c_str());
         doCommand(Doc,"App.activeDocument().%s.addFeature(App.activeDocument().%s)",
                        pcActiveBody->getNameInDocument(), FeatName.c_str());
         doCommand(Gui,"App.activeDocument().recompute()");  // recompute the sketch placement based on its support
@@ -511,7 +511,7 @@ void CmdPartDesignNewSketch::activated(int iMsg)
             Gui::Command::openCommand("Create a new Sketch");
             Gui::Command::doCommand(Doc,"App.activeDocument().addObject('Sketcher::SketchObject','%s')",FeatName.c_str());
             Gui::Command::doCommand(Doc,"App.activeDocument().%s.Support = %s",FeatName.c_str(),supportString.c_str());
-            Gui::Command::doCommand(Doc,"App.activeDocument().%s.MapMode = '%s'",FeatName.c_str(),Attacher::AttachEngine::eMapModeStrings[Attacher::mmFlatFace]);
+            Gui::Command::doCommand(Doc,"App.activeDocument().%s.MapMode = '%s'",FeatName.c_str(),Attacher::AttachEngine::getModeName(Attacher::mmFlatFace).c_str());
             Gui::Command::updateActive(); // Make sure the Support's Placement property is updated
             Gui::Command::doCommand(Doc,"App.activeDocument().%s.addFeature(App.activeDocument().%s)",
                         pcActiveBody->getNameInDocument(), FeatName.c_str());

--- a/src/Mod/PartDesign/Gui/TaskDatumParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskDatumParameters.cpp
@@ -951,7 +951,7 @@ bool TaskDlgDatumParameters::accept()
         //here it is assumed that the support was already assigned, it just outputs a dummy Python command to the console
         Gui::Command::doCommand(Gui::Command::Doc,"App.ActiveDocument.%s.Support = %s", name.c_str(), pcDatum->Support.getPyReprString().c_str());
 
-        Gui::Command::doCommand(Gui::Command::Doc,"App.ActiveDocument.%s.MapMode = '%s'", name.c_str(), AttachEngine::eMapModeStrings[parameter->getActiveMapMode()]);
+        Gui::Command::doCommand(Gui::Command::Doc,"App.ActiveDocument.%s.MapMode = '%s'", name.c_str(), AttachEngine::getModeName(parameter->getActiveMapMode()).c_str());
 
         Gui::Command::doCommand(Gui::Command::Doc,"App.ActiveDocument.recompute()");
         if (!DatumView->getObject()->isValid())

--- a/src/Mod/PartDesign/Gui/TaskDatumParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskDatumParameters.cpp
@@ -675,9 +675,16 @@ void TaskDatumParameters::updateListOfModes(eMapMode curMode)
     //obtain list of available modes:
     Part::Datum* pcDatum = static_cast<Part::Datum*>(DatumView->getObject());
     eMapMode suggMode = mmDeactivated;
+    std::set<eMapMode> reachableModes;
+    int lastValidModeItemIndex = mmDummy_NumberOfModes;
     if (pcDatum->Support.getSize() > 0){
         eSuggestResult msg;
-        suggMode = pcDatum->attacher().listMapModes(msg, &modesInList);
+        suggMode = pcDatum->attacher().listMapModes(msg, &modesInList, 0, &reachableModes);
+        //add reachable modes to the list, too, but gray them out (using lastValidModeItemIndex, later)
+        lastValidModeItemIndex = modesInList.size()-1;
+        for(eMapMode m: reachableModes){
+            modesInList.push_back(m);
+        }
     } else {
         //no references - display all modes
         modesInList.clear();
@@ -702,13 +709,17 @@ void TaskDatumParameters::updateListOfModes(eMapMode curMode)
                              AttacherGui::getRefListForMode(pcDatum->attacher(),mmode).join(QString::fromLatin1("\n")));
             if (mmode == curMode)
                 iSelect = ui->listOfModes->item(i);
-            if (mmode == suggMode){
-                //make it bold
+            if (i > lastValidModeItemIndex){
+                //potential mode - can be reached by selecting more stuff
+                item->setFlags(item->flags() & ~(Qt::ItemFlag::ItemIsEnabled | Qt::ItemFlag::ItemIsSelectable));
+            } else if (mmode == suggMode){
+                //suggested mode - make bold
                 assert (item);
                 QFont fnt = item->font();
                 fnt.setBold(true);
                 item->setFont(fnt);
             }
+
         }
     }
     //restore selection

--- a/src/Mod/PartDesign/Gui/TaskDatumParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskDatumParameters.cpp
@@ -307,9 +307,9 @@ bool TaskDatumParameters::updatePreview()
 {
     Part::Datum* pcDatum = static_cast<Part::Datum*>(DatumView->getObject());
     QString errMessage;
-    bool attached;
+    bool attached = false;
     try{
-        pcDatum->positionBySupport();
+        attached = pcDatum->positionBySupport();
     } catch (Base::Exception &err){
         errMessage = QString::fromLatin1(err.what());
     } catch (Standard_Failure &err){
@@ -320,17 +320,14 @@ bool TaskDatumParameters::updatePreview()
     if (errMessage.length()>0){
         ui->message->setText(tr("Attachment mode failed: %1").arg(errMessage));
         ui->message->setStyleSheet(QString::fromLatin1("QLabel{color: red;}"));
-        attached = false;
     } else {
-        if (pcDatum->MapMode.getValue() == mmDeactivated){
+        if (!attached){
             ui->message->setText(tr("Not attached"));
             ui->message->setStyleSheet(QString());
-            attached = false;
         } else {
             std::vector<QString> strs = AttacherGui::getUIStrings(pcDatum->attacher().getTypeId(),eMapMode(pcDatum->MapMode.getValue()));
             ui->message->setText(tr("Attached with mode %1").arg(strs[0]));
             ui->message->setStyleSheet(QString::fromLatin1("QLabel{color: green;}"));
-            attached = true;
         }
     }
     QString splmLabelText = attached ? tr("Extra placement:") : tr("Extra placement (inactive - not attached):");

--- a/src/Mod/PartDesign/Gui/TaskDatumParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskDatumParameters.h
@@ -54,10 +54,6 @@ public:
     TaskDatumParameters(ViewProviderDatum *DatumView,QWidget *parent = 0);
     ~TaskDatumParameters();
 
-    double getOffset(void) const;
-    double getOffset2(void) const;
-    double getOffset3(void) const;
-    double getAngle(void) const;
     bool   getFlip(void) const;
 
     /**
@@ -70,10 +66,13 @@ public:
     const bool isCompleted() const { return completed; }
 
 private Q_SLOTS:
-    void onOffsetChanged(double);
-    void onOffset2Changed(double);
-    void onOffset3Changed(double);
-    void onAngleChanged(double);
+    void onSuperplacementChanged(double, int idx);
+    void onSuperplacementXChanged(double);
+    void onSuperplacementYChanged(double);
+    void onSuperplacementZChanged(double);
+    void onSuperplacementYawChanged(double);
+    void onSuperplacementPitchChanged(double);
+    void onSuperplacementRollChanged(double);
     void onCheckFlip(bool);
     void onRefName1(const QString& text);
     void onRefName2(const QString& text);
@@ -92,7 +91,7 @@ private:
     void resetViewMode();
     void objectDeleted(const Gui::ViewProviderDocumentObject&);
     void onSelectionChanged(const Gui::SelectionChanges& msg);
-    void updateUI();
+    void updateReferencesUI();
 
     /**
      * @brief updatePreview: calculate attachment, update 3d view, update status message
@@ -105,6 +104,7 @@ private:
     void onButtonRef(const bool checked, unsigned idx);
     void onRefName(const QString& text, unsigned idx);
     void updateRefButton(int idx);
+    void updateSuperplacementUI();
 
     /**
      * @brief updateListOfModes Fills the mode list with modes that apply to

--- a/src/Mod/PartDesign/Gui/TaskDatumParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskDatumParameters.h
@@ -98,6 +98,7 @@ private:
     QLineEdit* getLine(unsigned idx);
     void onButtonRef(const bool checked, unsigned idx);
     void onRefName(const QString& text, unsigned idx);
+    void updateRefButton(int idx);
 
     /**
      * @brief updateListOfModes Fills the mode list with modes that apply to
@@ -114,9 +115,10 @@ private:
     ViewProviderDatum *DatumView;
 
     // TODO fix documentation here (2015-11-10, Fat-Zer)
-    int iActiveRef; //what reference is being picked in 3d view now? -1 means no one, 0-2 means a reference is being picked.
+    int iActiveRef; //what reference is being picked in 3d view now? -1 means no one, 0-3 means a reference is being picked.
     bool autoNext;//if we should automatically switch to next reference (true after dialog launch, false afterwards)
     std::vector<Attacher::eMapMode> modesInList; //this list is synchronous to what is populated into listOfModes widget.
+    Attacher::SuggestResult lastSuggestResult;
     bool completed;
 
     typedef boost::BOOST_SIGNALS_NAMESPACE::connection Connection;

--- a/src/Mod/PartDesign/Gui/TaskDatumParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskDatumParameters.h
@@ -92,7 +92,13 @@ private:
     void resetViewMode();
     void objectDeleted(const Gui::ViewProviderDocumentObject&);
     void onSelectionChanged(const Gui::SelectionChanges& msg);
-    void updateUI(std::string message = std::string(), bool isWarning = false);
+    void updateUI();
+
+    /**
+     * @brief updatePreview: calculate attachment, update 3d view, update status message
+     * @return true if attachment calculation was successful, false otherwise
+     */
+    bool updatePreview();
 
     void makeRefStrings(std::vector<QString>& refstrings, std::vector<std::string>& refnames);
     QLineEdit* getLine(unsigned idx);

--- a/src/Mod/PartDesign/Gui/TaskDatumParameters.ui
+++ b/src/Mod/PartDesign/Gui/TaskDatumParameters.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>272</width>
-    <height>560</height>
+    <height>583</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -110,27 +110,37 @@
     </widget>
    </item>
    <item>
+    <widget class="QLabel" name="label_superplacement">
+     <property name="toolTip">
+      <string>Mirror of superPlacement property. Extra placement is expressed in local space of object being attached.</string>
+     </property>
+     <property name="text">
+      <string>Extra placement:</string>
+     </property>
+    </widget>
+   </item>
+   <item>
     <layout class="QHBoxLayout" name="horizontalLayout_4">
      <item>
       <widget class="QLabel" name="labelOffset">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
        <property name="text">
-        <string>OffsetZ</string>
+        <string>X</string>
        </property>
       </widget>
      </item>
      <item>
-      <widget class="QDoubleSpinBox" name="spinOffset">
-       <property name="minimum">
-        <double>-999999999.000000000000000</double>
-       </property>
-       <property name="maximum">
-        <double>999999999.000000000000000</double>
-       </property>
-       <property name="singleStep">
-        <double>1.000000000000000</double>
-       </property>
-       <property name="value">
-        <double>0.000000000000000</double>
+      <widget class="Gui::PrefQuantitySpinBox" name="superplacementX" native="true">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
        </property>
       </widget>
      </item>
@@ -140,24 +150,24 @@
     <layout class="QHBoxLayout" name="horizontalLayout_9">
      <item>
       <widget class="QLabel" name="labelOffset2">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
        <property name="text">
-        <string>OffsetY</string>
+        <string>Y</string>
        </property>
       </widget>
      </item>
      <item>
-      <widget class="QDoubleSpinBox" name="spinOffset2">
-       <property name="minimum">
-        <double>-999999999.000000000000000</double>
-       </property>
-       <property name="maximum">
-        <double>999999999.000000000000000</double>
-       </property>
-       <property name="singleStep">
-        <double>1.000000000000000</double>
-       </property>
-       <property name="value">
-        <double>0.000000000000000</double>
+      <widget class="Gui::PrefQuantitySpinBox" name="superplacementY" native="true">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
        </property>
       </widget>
      </item>
@@ -167,23 +177,62 @@
     <layout class="QHBoxLayout" name="horizontalLayout_8">
      <item>
       <widget class="QLabel" name="labelOffset3">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
        <property name="text">
-        <string>OffsetX</string>
+        <string>Z</string>
        </property>
       </widget>
      </item>
      <item>
-      <widget class="QDoubleSpinBox" name="spinOffset3">
-       <property name="minimum">
-        <double>-999999999.000000000000000</double>
+      <widget class="Gui::PrefQuantitySpinBox" name="superplacementZ" native="true">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
        </property>
-       <property name="maximum">
-        <double>999999999.000000000000000</double>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_2_yaw">
+     <item>
+      <widget class="QLabel" name="labelYaw">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
        </property>
-       <property name="singleStep">
-        <double>1.000000000000000</double>
+       <property name="text">
+        <string>Yaw</string>
        </property>
-       <property name="value">
+      </widget>
+     </item>
+     <item>
+      <widget class="Gui::QuantitySpinBox" name="superplacementYaw" native="true">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="unit" stdset="0">
+        <string notr="true">deg</string>
+       </property>
+       <property name="minimum" stdset="0">
+        <double>-360.000000000000000</double>
+       </property>
+       <property name="maximum" stdset="0">
+        <double>360.000000000000000</double>
+       </property>
+       <property name="value" stdset="0">
         <double>0.000000000000000</double>
        </property>
       </widget>
@@ -191,26 +240,77 @@
     </layout>
    </item>
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_2">
+    <layout class="QHBoxLayout" name="horizontalLayout_2_pitch">
      <item>
-      <widget class="QLabel" name="labelAngle">
+      <widget class="QLabel" name="labelPitch">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
        <property name="text">
-        <string>RotateXY</string>
+        <string>Pitch</string>
        </property>
       </widget>
      </item>
      <item>
-      <widget class="QDoubleSpinBox" name="spinAngle">
-       <property name="minimum">
+      <widget class="Gui::QuantitySpinBox" name="superplacementPitch" native="true">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="unit" stdset="0">
+        <string notr="true">deg</string>
+       </property>
+       <property name="minimum" stdset="0">
         <double>-360.000000000000000</double>
        </property>
-       <property name="maximum">
+       <property name="maximum" stdset="0">
         <double>360.000000000000000</double>
        </property>
-       <property name="singleStep">
-        <double>1.000000000000000</double>
+       <property name="value" stdset="0">
+        <double>0.000000000000000</double>
        </property>
-       <property name="value">
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_2_roll">
+     <item>
+      <widget class="QLabel" name="labelRoll">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Roll</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="Gui::QuantitySpinBox" name="superplacementRoll" native="true">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="unit" stdset="0">
+        <string notr="true">deg</string>
+       </property>
+       <property name="minimum" stdset="0">
+        <double>-360.000000000000000</double>
+       </property>
+       <property name="maximum" stdset="0">
+        <double>360.000000000000000</double>
+       </property>
+       <property name="value" stdset="0">
         <double>0.000000000000000</double>
        </property>
       </widget>
@@ -226,6 +326,18 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>Gui::QuantitySpinBox</class>
+   <extends>QWidget</extends>
+   <header location="global">Gui/QuantitySpinBox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>Gui::PrefQuantitySpinBox</class>
+   <extends>QWidget</extends>
+   <header>Gui/PrefWidgets.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/src/Mod/PartDesign/Gui/Utils.cpp
+++ b/src/Mod/PartDesign/Gui/Utils.cpp
@@ -196,7 +196,7 @@ void fixSketchSupport (Sketcher::SketchObject* sketch)
         Gui::Command::doCommand(Gui::Command::Doc,"App.activeDocument().%s.MapReversed = %s",
                 sketch->getNameInDocument(), reverseSketch ? "True" : "False");
         Gui::Command::doCommand(Gui::Command::Doc,"App.activeDocument().%s.MapMode = '%s'",
-                sketch->getNameInDocument(), Attacher::AttachEngine::eMapModeStrings[Attacher::mmFlatFace]);
+                sketch->getNameInDocument(), Attacher::AttachEngine::getModeName(Attacher::mmFlatFace).c_str());
 
     } else {
         // Offset to base plane
@@ -213,7 +213,7 @@ void fixSketchSupport (Sketcher::SketchObject* sketch)
         Gui::Command::doCommand(Gui::Command::Doc,"App.activeDocument().%s.Support = %s",
                 Datum.c_str(), refStr.toStdString().c_str());
         Gui::Command::doCommand(Gui::Command::Doc,"App.activeDocument().%s.MapMode = '%s'",
-                Datum.c_str(), AttachEngine::eMapModeStrings[Attacher::mmFlatFace]);
+                Datum.c_str(), AttachEngine::getModeName(Attacher::mmFlatFace).c_str());
         Gui::Command::doCommand(Gui::Command::Doc,"App.activeDocument().%s.superPlacement.Base.z = %f",
                 Datum.c_str(), offset);
         Gui::Command::doCommand(Gui::Command::Doc,
@@ -225,7 +225,7 @@ void fixSketchSupport (Sketcher::SketchObject* sketch)
         Gui::Command::doCommand(Gui::Command::Doc,"App.activeDocument().%s.MapReversed = %s",
                 sketch->getNameInDocument(), reverseSketch ? "True" : "False");
         Gui::Command::doCommand(Gui::Command::Doc,"App.activeDocument().%s.MapMode = '%s'",
-                sketch->getNameInDocument(),Attacher::AttachEngine::eMapModeStrings[Attacher::mmFlatFace]);
+                sketch->getNameInDocument(),Attacher::AttachEngine::getModeName(Attacher::mmFlatFace).c_str());
     }
 }
 

--- a/src/Mod/Sketcher/Gui/Command.cpp
+++ b/src/Mod/Sketcher/Gui/Command.cpp
@@ -79,14 +79,14 @@ namespace SketcherGui {
     };
 
 
-    Attacher::eMapMode SuggestAutoMapMode(Attacher::eSuggestResult* pMsgId = 0,
+    Attacher::eMapMode SuggestAutoMapMode(Attacher::SuggestResult::eSuggestResult* pMsgId = 0,
                                       QString* message = 0,
                                       std::vector<Attacher::eMapMode>* allmodes = 0){
         //convert pointers into valid references, to avoid checking for null pointers everywhere
-        Attacher::eSuggestResult buf;
+        Attacher::SuggestResult::eSuggestResult buf;
         if (pMsgId == 0)
             pMsgId = &buf;
-        Attacher::eSuggestResult &msg = *pMsgId;
+        Attacher::SuggestResult::eSuggestResult &msg = *pMsgId;
         QString buf2;
         if (message == 0)
             message = &buf2;
@@ -95,23 +95,26 @@ namespace SketcherGui {
         App::PropertyLinkSubList tmpSupport;
         Gui::Selection().getAsPropertyLinkSubList(tmpSupport);
 
+        Attacher::SuggestResult sugr;
         AttachEngine3D eng;
         eng.setUp(tmpSupport);
-        Attacher::eMapMode ret;
-        ret = eng.listMapModes(msg, allmodes);
+        eng.suggestMapModes(sugr);
+        if (allmodes)
+            *allmodes = sugr.allApplicableModes;
+        msg = sugr.message;
         switch(msg){
-            case Attacher::srOK:
+            case Attacher::SuggestResult::srOK:
             break;
-            case Attacher::srNoModesFit:
+            case Attacher::SuggestResult::srNoModesFit:
                 msg_str = QObject::tr("There are no modes that accept the selected set of subelements");
             break;
-            case Attacher::srLinkBroken:
+            case Attacher::SuggestResult::srLinkBroken:
                 msg_str = QObject::tr("Broken link to support subelements");
             break;
-            case Attacher::srUnexpectedError:
+            case Attacher::SuggestResult::srUnexpectedError:
                 msg_str = QObject::tr("Unexpected error");
             break;
-            case Attacher::srIncompatibleGeometry:
+            case Attacher::SuggestResult::srIncompatibleGeometry:
                 if(tmpSupport.getSubValues()[0].substr(0,4) == std::string("Face"))
                     msg_str = QObject::tr("Face is non-planar");
                 else
@@ -122,7 +125,7 @@ namespace SketcherGui {
                 assert(0/*no message for eSuggestResult enum item*/);
         }
 
-        return ret;
+        return sugr.bestFitMode;
     }
 } //namespace SketcherGui
 
@@ -147,13 +150,13 @@ void CmdSketcherNewSketch::activated(int iMsg)
     Attacher::eMapMode mapmode = Attacher::mmDeactivated;
     bool bAttach = false;
     if (Gui::Selection().hasSelection()){
-        Attacher::eSuggestResult msgid = Attacher::srOK;
+        Attacher::SuggestResult::eSuggestResult msgid = Attacher::SuggestResult::srOK;
         QString msg_str;
         std::vector<Attacher::eMapMode> validModes;
         mapmode = SuggestAutoMapMode(&msgid, &msg_str, &validModes);
-        if (msgid == Attacher::srOK)
+        if (msgid == Attacher::SuggestResult::srOK)
             bAttach = true;
-        if (msgid != Attacher::srOK && msgid != Attacher::srNoModesFit){
+        if (msgid != Attacher::SuggestResult::srOK && msgid != Attacher::SuggestResult::srNoModesFit){
             QMessageBox::warning(Gui::getMainWindow(),
                 QObject::tr("Sketch mapping"),
                 QObject::tr("Can't map the skecth to selected object. %1.").arg(msg_str));
@@ -166,7 +169,7 @@ void CmdSketcherNewSketch::activated(int iMsg)
             items.push_back(QObject::tr("Don't attach"));
             int iSugg = 0;//index of the auto-suggested mode in the list of valid modes
             for (size_t i = 0  ;  i < validModes.size()  ;  ++i){
-                items.push_back(QString::fromLatin1(AttachEngine::eMapModeStrings[validModes[i]]));
+                items.push_back(QString::fromLatin1(AttachEngine::getModeName(validModes[i]).c_str()));
                 if (validModes[i] == mapmode)
                     iSugg = items.size()-1;
             }
@@ -447,7 +450,7 @@ void CmdSketcherMapSketch::activated(int iMsg)
         std::vector<Attacher::eMapMode> validModes;
 
         //check that selection is valid for at least some mapping mode.
-        Attacher::eSuggestResult msgid = Attacher::srOK;
+        Attacher::SuggestResult::eSuggestResult msgid = Attacher::SuggestResult::srOK;
         suggMapMode = SuggestAutoMapMode(&msgid, &msg_str, &validModes);
 
         App::Document* doc = App::GetApplication().getActiveDocument();

--- a/src/Mod/Sketcher/Gui/Command.cpp
+++ b/src/Mod/Sketcher/Gui/Command.cpp
@@ -204,7 +204,7 @@ void CmdSketcherNewSketch::activated(int iMsg)
         openCommand("Create a Sketch on Face");
         doCommand(Doc,"App.activeDocument().addObject('Sketcher::SketchObject','%s')",FeatName.c_str());
         if (mapmode >= 0 && mapmode < Attacher::mmDummy_NumberOfModes)
-            doCommand(Gui,"App.activeDocument().%s.MapMode = \"%s\"",FeatName.c_str(),AttachEngine::eMapModeStrings[mapmode]);
+            doCommand(Gui,"App.activeDocument().%s.MapMode = \"%s\"",FeatName.c_str(),AttachEngine::getModeName(mapmode).c_str());
         else
             assert(0 /* mapmode index out of range */);
         doCommand(Gui,"App.activeDocument().%s.Support = %s",FeatName.c_str(),supportString.c_str());
@@ -256,7 +256,7 @@ void CmdSketcherNewSketch::activated(int iMsg)
         openCommand("Create a new Sketch");
         doCommand(Doc,"App.activeDocument().addObject('Sketcher::SketchObject','%s')",FeatName.c_str());
         doCommand(Doc,"App.activeDocument().%s.Placement = App.Placement(App.Vector(%f,%f,%f),App.Rotation(%f,%f,%f,%f))",FeatName.c_str(),p.x,p.y,p.z,r[0],r[1],r[2],r[3]);
-        doCommand(Doc,"App.activeDocument().%s.MapMode = \"%s\"",FeatName.c_str(),AttachEngine::eMapModeStrings[int(Attacher::mmDeactivated)]);
+        doCommand(Doc,"App.activeDocument().%s.MapMode = \"%s\"",FeatName.c_str(),AttachEngine::getModeName(Attacher::mmDeactivated).c_str());
         doCommand(Gui,"Gui.activeDocument().activeView().setCamera('%s')",camstring.c_str());
         doCommand(Gui,"Gui.activeDocument().setEdit('%s')",FeatName.c_str());
     }
@@ -517,7 +517,7 @@ void CmdSketcherMapSketch::activated(int iMsg)
         int iSugg = 0;//index of the auto-suggested mode in the list of valid modes
         int iCurr = 0;//index of current mode in the list of valid modes
         for (size_t i = 0  ;  i < validModes.size()  ;  ++i){
-            items.push_back(QString::fromLatin1(AttachEngine::eMapModeStrings[validModes[i]]));
+            items.push_back(QString::fromLatin1(AttachEngine::getModeName(validModes[i]).c_str()));
             if (validModes[i] == curMapMode) {
                 iCurr = items.size() - 1;
                 items.back().append(bCurIncompatible?
@@ -564,12 +564,12 @@ void CmdSketcherMapSketch::activated(int iMsg)
             std::string supportString = support.getPyReprString();
 
             openCommand("Attach Sketch");
-            doCommand(Gui,"App.activeDocument().%s.MapMode = \"%s\"",featName.c_str(),AttachEngine::eMapModeStrings[suggMapMode]);
+            doCommand(Gui,"App.activeDocument().%s.MapMode = \"%s\"",featName.c_str(),AttachEngine::getModeName(suggMapMode).c_str());
             doCommand(Gui,"App.activeDocument().%s.Support = %s",featName.c_str(),supportString.c_str());
             commitCommand();
         } else {
             openCommand("Detach Sketch");
-            doCommand(Gui,"App.activeDocument().%s.MapMode = \"%s\"",featName.c_str(),AttachEngine::eMapModeStrings[suggMapMode]);
+            doCommand(Gui,"App.activeDocument().%s.MapMode = \"%s\"",featName.c_str(),AttachEngine::getModeName(suggMapMode).c_str());
             doCommand(Gui,"App.activeDocument().%s.Support = None",featName.c_str());
             commitCommand();
         }


### PR DESCRIPTION
* display attachment modes that can accept or need more references, together with hints
* change the way reference selection buttons behave (they now reflect the geometry type, and say "Selecting..." when reference is being selected in 3d view.
* expose full superPlacement instead of a limited set of offsets in UI
* add inertial attachment modes (center of mass, and principal axes)
* make read-onlyness of Placement and superPlacement in property editor
* other changes, mostly internal. See commits.