### PR TITLE
Attacher19: patch attachable objects in Draft to recompute properly; make Part primitives attachable.

### DIFF
--- a/src/Mod/Draft/Draft.py
+++ b/src/Mod/Draft/Draft.py
@@ -2469,7 +2469,7 @@ def clone(obj,delta=None):
         cl.CloneOf = base
         return cl
     else:
-        cl = FreeCAD.ActiveDocument.addObject("Part::FeaturePython","Clone")
+        cl = FreeCAD.ActiveDocument.addObject("Part::AttachableObjectPython","Clone")
         cl.Label = "Clone of " + obj[0].Label
     _Clone(cl)
     if gui:
@@ -4161,6 +4161,7 @@ class _Rectangle(_DraftObject):
                     shape = Part.Face(shape)
             obj.Shape = shape
             obj.Placement = plm
+        obj.positionBySupport()
 
 class _ViewProviderRectangle(_ViewProviderDraft):
     def __init__(self,vobj):
@@ -4192,6 +4193,7 @@ class _Circle(_DraftObject):
                 shape = Part.Face(shape)
         obj.Shape = shape
         obj.Placement = plm
+        obj.positionBySupport()
         
 class _Ellipse(_DraftObject):
     "The Circle object"
@@ -4228,6 +4230,7 @@ class _Ellipse(_DraftObject):
                     shape = Part.Face(shape)
             obj.Shape = shape
             obj.Placement = plm
+        obj.positionBySupport()
 
 class _Wire(_DraftObject):
     "The Wire object"
@@ -4349,6 +4352,7 @@ class _Wire(_DraftObject):
                 if hasattr(obj,"Length"):
                     obj.Length = shape.Length
         obj.Placement = plm
+        obj.positionBySupport()
         self.onChanged(obj,"Placement")
         
     def onChanged(self, obj, prop):
@@ -4511,6 +4515,8 @@ class _Polygon(_DraftObject):
                 shape = Part.Face(shape)
             obj.Shape = shape
             obj.Placement = plm
+        obj.positionBySupport()
+
 
 class _DrawingView(_DraftObject):
     "The Draft DrawingView object"
@@ -4612,6 +4618,7 @@ class _BSpline(_DraftObject):
                 spline.interpolate(obj.Points, False)
                 obj.Shape = spline.toShape()
             obj.Placement = plm
+        obj.positionBySupport()
 
 # for compatibility with older versions
 _ViewProviderBSpline = _ViewProviderWire
@@ -4639,6 +4646,7 @@ class _BezCurve(_DraftObject):
 
     def execute(self, fp):
         self.createGeometry(fp)
+        fp.positionBySupport()
 
     def _segpoleslst(self,fp):
         """split the points into segments"""
@@ -4760,6 +4768,7 @@ class _Block(_DraftObject):
             shape = Part.makeCompound(shps)
             obj.Shape = shape
         obj.Placement = plm
+        obj.positionBySupport()
 
 class _Shape2DView(_DraftObject):
     "The Shape2DView object"
@@ -4800,6 +4809,7 @@ class _Shape2DView(_DraftObject):
 
     def execute(self,obj):
         import DraftGeomUtils
+        obj.positionBySupport()
         pl = obj.Placement
         if obj.Base:
             if getType(obj.Base) == "SectionPlane":
@@ -5241,7 +5251,9 @@ class _Clone(_DraftObject):
             else:
                 obj.Shape = Part.makeCompound(shapes)
         obj.Placement = pl
-            
+        if hasattr(obj,"positionBySupport"):
+            obj.positionBySupport()
+    
     def getSubVolume(self,obj,placement=None):
         # this allows clones of arch windows to return a subvolume too
         if obj.Objects:
@@ -5339,6 +5351,7 @@ class _ShapeString(_DraftObject):
             obj.Shape = shape 
             if plm:                     
                 obj.Placement = plm
+        obj.positionBySupport()
 
     def makeFaces(self, wireChar):
         import Part

--- a/src/Mod/Part/App/AttachableObject.cpp
+++ b/src/Mod/Part/App/AttachableObject.cpp
@@ -58,7 +58,7 @@ AttachableObject::AttachableObject()
 
     ADD_PROPERTY_TYPE(superPlacement, (Base::Placement()), "Attachment", App::Prop_None, "Extra placement to apply in addition to attachment (in local coordinates)");
 
-    //setAttacher(new AttachEngine3D);//default attacher
+    setAttacher(new AttachEngine3D);//default attacher
 }
 
 AttachableObject::~AttachableObject()

--- a/src/Mod/Part/App/PrimitiveFeature.cpp
+++ b/src/Mod/Part/App/PrimitiveFeature.cpp
@@ -84,7 +84,7 @@ namespace Part {
 using namespace Part;
 
 
-PROPERTY_SOURCE_ABSTRACT(Part::Primitive, Part::Feature)
+PROPERTY_SOURCE_ABSTRACT(Part::Primitive, Part::AttachableObject)
 
 Primitive::Primitive(void) 
 {
@@ -169,7 +169,7 @@ void Primitive::onChanged(const App::Property* prop)
             }
         }
     }
-    Part::Feature::onChanged(prop);
+    Part::AttachableObject::onChanged(prop);
 }
 
 PROPERTY_SOURCE(Part::Vertex, Part::Primitive)
@@ -191,7 +191,7 @@ short Vertex::mustExecute() const
         Y.isTouched() ||
         Z.isTouched())
         return 1;
-    return Part::Feature::mustExecute();
+    return Part::AttachableObject::mustExecute();
 }
 
 App::DocumentObjectExecReturn *Vertex::execute(void)
@@ -205,7 +205,7 @@ App::DocumentObjectExecReturn *Vertex::execute(void)
     const TopoDS_Vertex& vertex = MakeVertex.Vertex();
     this->Shape.setValue(vertex);
 
-    return App::DocumentObject::StdReturn;
+    return AttachableObject::execute();
 }
 
 
@@ -221,7 +221,7 @@ void Vertex::onChanged(const App::Property* prop)
             }
         }
     }
-    Part::Feature::onChanged(prop);
+    Part::AttachableObject::onChanged(prop);
 }
 
 PROPERTY_SOURCE(Part::Line, Part::Primitive)
@@ -249,7 +249,7 @@ short Line::mustExecute() const
         Y2.isTouched() ||
         Z2.isTouched())
         return 1;
-    return Part::Feature::mustExecute();
+    return Part::AttachableObject::mustExecute();
 }
 
 App::DocumentObjectExecReturn *Line::execute(void)
@@ -270,7 +270,7 @@ App::DocumentObjectExecReturn *Line::execute(void)
     const TopoDS_Edge& edge = mkEdge.Edge();
     this->Shape.setValue(edge);
 
-    return App::DocumentObject::StdReturn;
+    return AttachableObject::execute();
 }
 
 void Line::onChanged(const App::Property* prop)
@@ -285,7 +285,7 @@ void Line::onChanged(const App::Property* prop)
             }
         }
     }
-    Part::Feature::onChanged(prop);
+    Part::AttachableObject::onChanged(prop);
 }
 
 PROPERTY_SOURCE(Part::Plane, Part::Primitive)
@@ -356,7 +356,7 @@ App::DocumentObjectExecReturn *Plane::execute(void)
     TopoDS_Shape ResultShape = mkFace.Shape();
     this->Shape.setValue(ResultShape);
 
-    return App::DocumentObject::StdReturn;
+    return AttachableObject::execute();
 }
 
 PROPERTY_SOURCE(Part::Sphere, Part::Primitive)
@@ -404,7 +404,7 @@ App::DocumentObjectExecReturn *Sphere::execute(void)
         return new App::DocumentObjectExecReturn(e->GetMessageString());
     }
 
-    return App::DocumentObject::StdReturn;
+    return AttachableObject::execute();
 }
 
 PROPERTY_SOURCE(Part::Ellipsoid, Part::Primitive)
@@ -486,7 +486,7 @@ App::DocumentObjectExecReturn *Ellipsoid::execute(void)
         return new App::DocumentObjectExecReturn(e->GetMessageString());
     }
 
-    return App::DocumentObject::StdReturn;
+    return AttachableObject::execute();
 }
 
 PROPERTY_SOURCE(Part::Cylinder, Part::Primitive)
@@ -529,7 +529,7 @@ App::DocumentObjectExecReturn *Cylinder::execute(void)
         return new App::DocumentObjectExecReturn(e->GetMessageString());
     }
 
-    return App::DocumentObject::StdReturn;
+    return AttachableObject::execute();
 }
 
 App::PropertyIntegerConstraint::Constraints Prism::polygonRange = {3,INT_MAX,1};
@@ -587,7 +587,7 @@ App::DocumentObjectExecReturn *Prism::execute(void)
         return new App::DocumentObjectExecReturn(e->GetMessageString());
     }
 
-    return App::DocumentObject::StdReturn;
+    return AttachableObject::execute();
 }
 
 App::PropertyIntegerConstraint::Constraints RegularPolygon::polygon = {3,INT_MAX,1};
@@ -639,7 +639,7 @@ App::DocumentObjectExecReturn *RegularPolygon::execute(void)
         return new App::DocumentObjectExecReturn(e->GetMessageString());
     }
 
-    return App::DocumentObject::StdReturn;
+    return AttachableObject::execute();
 }
 
 
@@ -689,7 +689,7 @@ App::DocumentObjectExecReturn *Cone::execute(void)
         return new App::DocumentObjectExecReturn(e->GetMessageString());
     }
 
-    return App::DocumentObject::StdReturn;
+    return AttachableObject::execute();
 }
 
 PROPERTY_SOURCE(Part::Torus, Part::Primitive)
@@ -761,7 +761,7 @@ App::DocumentObjectExecReturn *Torus::execute(void)
         return new App::DocumentObjectExecReturn(e->GetMessageString());
     }
 
-    return App::DocumentObject::StdReturn;
+    return AttachableObject::execute();
 }
 
 PROPERTY_SOURCE(Part::Helix, Part::Primitive)
@@ -798,7 +798,7 @@ void Helix::onChanged(const App::Property* prop)
             }
         }
     }
-    Part::Feature::onChanged(prop);
+    Part::AttachableObject::onChanged(prop);
 }
 
 short Helix::mustExecute() const
@@ -842,7 +842,7 @@ App::DocumentObjectExecReturn *Helix::execute(void)
         return new App::DocumentObjectExecReturn(e->GetMessageString());
     }
 
-    return App::DocumentObject::StdReturn;
+    return AttachableObject::execute();
 }
 
 PROPERTY_SOURCE(Part::Spiral, Part::Primitive)
@@ -869,7 +869,7 @@ void Spiral::onChanged(const App::Property* prop)
             }
         }
     }
-    Part::Feature::onChanged(prop);
+    Part::AttachableObject::onChanged(prop);
 }
 
 short Spiral::mustExecute() const
@@ -932,13 +932,17 @@ App::DocumentObjectExecReturn *Spiral::execute(void)
         );
         BRepProj_Projection proj(wire, mkFace.Face(), gp::DZ());
         this->Shape.setValue(proj.Shape());
+
+        AttachableObject::execute();
     }
     catch (Standard_Failure) {
         Handle_Standard_Failure e = Standard_Failure::Caught();
         return new App::DocumentObjectExecReturn(e->GetMessageString());
     }
 
-    return App::DocumentObject::StdReturn;
+
+
+    return AttachableObject::execute();
 }
 
 PROPERTY_SOURCE(Part::Wedge, Part::Primitive)
@@ -1023,7 +1027,7 @@ App::DocumentObjectExecReturn *Wedge::execute(void)
         return new App::DocumentObjectExecReturn(e->GetMessageString());
     }
 
-    return App::DocumentObject::StdReturn;
+    return AttachableObject::execute();
 }
 
 void Wedge::onChanged(const App::Property* prop)
@@ -1066,7 +1070,7 @@ short Ellipse::mustExecute() const
         MajorRadius.isTouched() ||
         MinorRadius.isTouched())
         return 1;
-    return Part::Feature::mustExecute();
+    return Part::AttachableObject::mustExecute();
 }
 
 App::DocumentObjectExecReturn *Ellipse::execute(void)
@@ -1080,7 +1084,7 @@ App::DocumentObjectExecReturn *Ellipse::execute(void)
     const TopoDS_Edge& edge = clMakeEdge.Edge();
     this->Shape.setValue(edge);
 
-    return App::DocumentObject::StdReturn;
+    return AttachableObject::execute();
 }
 
 void Ellipse::onChanged(const App::Property* prop)
@@ -1095,5 +1099,5 @@ void Ellipse::onChanged(const App::Property* prop)
             }
         }
     }
-    Part::Feature::onChanged(prop);
+    Part::AttachableObject::onChanged(prop);
 }

--- a/src/Mod/Part/App/PrimitiveFeature.h
+++ b/src/Mod/Part/App/PrimitiveFeature.h
@@ -26,11 +26,12 @@
 
 #include <App/PropertyUnits.h>
 #include "PartFeature.h"
+#include "AttachableObject.h"
 
 namespace Part
 {
 
-class PartExport Primitive : public Part::Feature
+class PartExport Primitive : public Part::AttachableObject
 {
     PROPERTY_HEADER(Part::Primitive);
 


### PR DESCRIPTION
The title says it all!