### PR TITLE
Increased travis git clone depth to fix version count mechanism

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ matrix:
        compiler: gcc
 
 git:
-  depth: 800
+  depth: 1500
 
 notifications:
   email:


### PR DESCRIPTION
It seems the prolific development efforts by many in the community have exceeded the clone depth of 800 causing erroneous revision counts for build tagging.  Increased the depth from 800 to 1500 at the cost of about 15 seconds to the overall build time.