### PR TITLE
Part/PartDesign: make BodyBase more functional

### DIFF
--- a/src/Mod/Part/App/BodyBasePy.xml
+++ b/src/Mod/Part/App/BodyBasePy.xml
@@ -13,5 +13,20 @@
       <Author Licence="LGPL" Name="Juergen Riegel" EMail="FreeCAD@juergen-riegel.net" />
       <UserDocu>Base class of all Body objects</UserDocu>
     </Documentation>
+    <Methode Name="addFeature">
+    <Documentation>
+       <UserDocu>addFeature(feat) - Add the given feature to the Body.</UserDocu>
+    </Documentation>
+    </Methode>
+    <Methode Name="removeFeature">
+        <Documentation>
+            <UserDocu>removeFeature(feat) - Remove the given feature from the Body</UserDocu>
+        </Documentation>
+    </Methode>
+    <Methode Name="removeModelFromDocument">
+        <Documentation>
+            <UserDocu>Delets all the objects linked to the model.</UserDocu>
+        </Documentation>
+    </Methode>
   </PythonExport>
 </GenerateModel>

--- a/src/Mod/Part/App/BodyBasePyImp.cpp
+++ b/src/Mod/Part/App/BodyBasePyImp.cpp
@@ -34,7 +34,7 @@ using namespace Part;
 // returns a string which represents the object e.g. when printed in python
 std::string BodyBasePy::representation(void) const
 {
-    return std::string("<body object>");
+    return std::string("<BodyBase object>");
 }
 
 
@@ -47,5 +47,55 @@ int BodyBasePy::setCustomAttributes(const char* /*attr*/, PyObject* /*obj*/)
 {
     return 0; 
 }
+
+PyObject* BodyBasePy::addFeature(PyObject *args)
+{
+    PyObject* featurePy;
+    if (!PyArg_ParseTuple(args, "O!", &(App::DocumentObjectPy::Type), &featurePy))
+        return 0;
+
+    App::DocumentObject* feature = static_cast<App::DocumentObjectPy*>(featurePy)->getDocumentObjectPtr();
+
+    BodyBase* body = this->getBodyBasePtr();
+
+    try {
+        body->addFeature(feature);
+    } catch (Base::Exception& e) {
+        PyErr_SetString(PyExc_SystemError, e.what());
+        return 0;
+    }
+
+    Py_Return;
+}
+
+PyObject* BodyBasePy::removeFeature(PyObject *args)
+{
+    PyObject* featurePy;
+    if (!PyArg_ParseTuple(args, "O!", &(App::DocumentObjectPy::Type), &featurePy))
+        return 0;
+
+    App::DocumentObject* feature = static_cast<App::DocumentObjectPy*>(featurePy)->getDocumentObjectPtr();
+    BodyBase* body = this->getBodyBasePtr();
+
+    try {
+        body->removeFeature(feature);
+    } catch (Base::Exception& e) {
+        PyErr_SetString(PyExc_SystemError, e.what());
+        return 0;
+    }
+
+    Py_Return;
+}
+
+PyObject*  BodyBasePy::removeModelFromDocument(PyObject *args)
+{
+    if (!PyArg_ParseTuple(args, ""))
+        return 0;
+
+    getBodyBasePtr()->removeModelFromDocument();
+    Py_Return;
+}
+
+
 
 

--- a/src/Mod/Part/Gui/AppPartGui.cpp
+++ b/src/Mod/Part/Gui/AppPartGui.cpp
@@ -36,6 +36,7 @@
 #include "ViewProvider.h"
 #include "ViewProviderExt.h"
 #include "ViewProviderPython.h"
+#include "ViewProviderBodyBase.h"
 #include "ViewProviderBox.h"
 #include "ViewProviderCurveNet.h"
 #include "ViewProviderImport.h"
@@ -132,6 +133,7 @@ PyMODINIT_FUNC initPartGui()
     PartGui::SoFCControlPoints              ::initClass();
     PartGui::ViewProviderPartExt            ::init();
     PartGui::ViewProviderPart               ::init();
+    PartGui::ViewProviderBodyBase           ::init();
     PartGui::ViewProviderEllipsoid          ::init();
     PartGui::ViewProviderPython             ::init();
     PartGui::ViewProviderBox                ::init();

--- a/src/Mod/Part/Gui/CMakeLists.txt
+++ b/src/Mod/Part/Gui/CMakeLists.txt
@@ -148,6 +148,8 @@ SET(PartGui_SRCS
     ViewProvider.h
     ViewProviderExt.cpp
     ViewProviderExt.h
+    ViewProviderBodyBase.cpp
+    ViewProviderBodyBase.h
     ViewProviderReference.cpp
     ViewProviderReference.h
     ViewProviderBox.cpp

--- a/src/Mod/Part/Gui/Resources/Part.qrc
+++ b/src/Mod/Part/Gui/Resources/Part.qrc
@@ -6,6 +6,7 @@
         <file>icons/Part_Attachment.svg</file>
         <file>icons/Part_Booleans.svg</file>
         <file>icons/Part_Box.svg</file>
+        <file>icons/Part_Body_Tree.svg</file>
         <file>icons/Part_Chamfer.svg</file>
         <file>icons/Part_Common.svg</file>
         <file>icons/Part_Cone.svg</file>

--- a/src/Mod/Part/Gui/Resources/icons/Part_Body_Tree.svg
+++ b/src/Mod/Part/Gui/Resources/icons/Part_Body_Tree.svg
@@ -1,0 +1,624 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="64px"
+   height="64px"
+   id="svg2816"
+   version="1.1"
+   inkscape:version="0.48.3.1 r9886"
+   sodipodi:docname="PartDesign_Body_Tree.svg"
+   inkscape:export-filename="/home/user/Downloads/cad/mystuff/icons/assembly/Assembly body/PartDesign_Body2_containing_Part_box_32px.png"
+   inkscape:export-xdpi="45"
+   inkscape:export-ydpi="45">
+  <defs
+     id="defs2818">
+    <linearGradient
+       id="linearGradient3835">
+      <stop
+         id="stop3837"
+         offset="0"
+         style="stop-color:#ffed00;stop-opacity:1;" />
+      <stop
+         id="stop3839"
+         offset="1"
+         style="stop-color:#fbfaf7;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3669">
+      <stop
+         style="stop-color:#002795;stop-opacity:1;"
+         offset="0"
+         id="stop3671" />
+      <stop
+         style="stop-color:#71b2f8;stop-opacity:1;"
+         offset="1"
+         id="stop3673" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3602">
+      <stop
+         style="stop-color:#ff2600;stop-opacity:1;"
+         offset="0"
+         id="stop3604" />
+      <stop
+         style="stop-color:#ff5f00;stop-opacity:1;"
+         offset="1"
+         id="stop3606" />
+    </linearGradient>
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 32 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="64 : 32 : 1"
+       inkscape:persp3d-origin="32 : 21.333333 : 1"
+       id="perspective2824" />
+    <inkscape:perspective
+       id="perspective3618"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3602-7"
+       id="linearGradient3608-5"
+       x1="3.909091"
+       y1="14.363636"
+       x2="24.81818"
+       y2="14.363636"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3602-7">
+      <stop
+         style="stop-color:#c51900;stop-opacity:1;"
+         offset="0"
+         id="stop3604-1" />
+      <stop
+         style="stop-color:#ff5f00;stop-opacity:1;"
+         offset="1"
+         id="stop3606-3" />
+    </linearGradient>
+    <inkscape:perspective
+       id="perspective3677"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3602-5"
+       id="linearGradient3608-1"
+       x1="3.909091"
+       y1="14.363636"
+       x2="24.81818"
+       y2="14.363636"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3602-5">
+      <stop
+         style="stop-color:#c51900;stop-opacity:1;"
+         offset="0"
+         id="stop3604-9" />
+      <stop
+         style="stop-color:#ff5f00;stop-opacity:1;"
+         offset="1"
+         id="stop3606-9" />
+    </linearGradient>
+    <linearGradient
+       y2="14.363636"
+       x2="24.81818"
+       y1="14.363636"
+       x1="3.909091"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3686"
+       xlink:href="#linearGradient3602-5"
+       inkscape:collect="always" />
+    <inkscape:perspective
+       id="perspective3717"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3602-58"
+       id="linearGradient3608-8"
+       x1="3.909091"
+       y1="14.363636"
+       x2="24.81818"
+       y2="14.363636"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3602-58">
+      <stop
+         style="stop-color:#c51900;stop-opacity:1;"
+         offset="0"
+         id="stop3604-2" />
+      <stop
+         style="stop-color:#ff5f00;stop-opacity:1;"
+         offset="1"
+         id="stop3606-2" />
+    </linearGradient>
+    <linearGradient
+       y2="14.363636"
+       x2="24.81818"
+       y1="14.363636"
+       x1="3.909091"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3726"
+       xlink:href="#linearGradient3602-58"
+       inkscape:collect="always" />
+    <inkscape:perspective
+       id="perspective4410"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective4944"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective4966"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective5009"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective5165"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective7581"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective7606"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective7638"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective7660"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective7704"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective7730"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective7762"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective7783"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective7843"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective7881"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective7932"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective2866"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective2878"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <linearGradient
+       id="linearGradient3602-1">
+      <stop
+         style="stop-color:#ff2600;stop-opacity:1;"
+         offset="0"
+         id="stop3604-8" />
+      <stop
+         style="stop-color:#ff5f00;stop-opacity:1;"
+         offset="1"
+         id="stop3606-96" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3602-1"
+       id="linearGradient2875"
+       gradientUnits="userSpaceOnUse"
+       x1="3.909091"
+       y1="14.363636"
+       x2="24.81818"
+       y2="14.363636" />
+    <inkscape:perspective
+       id="perspective2885"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <linearGradient
+       id="linearGradient3602-1-5">
+      <stop
+         style="stop-color:#ff2600;stop-opacity:1;"
+         offset="0"
+         id="stop3604-8-3" />
+      <stop
+         style="stop-color:#ff5f00;stop-opacity:1;"
+         offset="1"
+         id="stop3606-96-8" />
+    </linearGradient>
+    <inkscape:perspective
+       id="perspective3720"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <linearGradient
+       id="linearGradient3602-1-8">
+      <stop
+         style="stop-color:#ff2600;stop-opacity:1;"
+         offset="0"
+         id="stop3604-8-5" />
+      <stop
+         style="stop-color:#ff5f00;stop-opacity:1;"
+         offset="1"
+         id="stop3606-96-2" />
+    </linearGradient>
+    <inkscape:perspective
+       id="perspective3822"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective3849"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective3879"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective2896"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective2925"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective2925-4"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective3726"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective3689"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <linearGradient
+       id="linearGradient3669-2">
+      <stop
+         style="stop-color:#af7d00;stop-opacity:1;"
+         offset="0"
+         id="stop3671-7" />
+      <stop
+         style="stop-color:#ffed00;stop-opacity:1;"
+         offset="1"
+         id="stop3673-5" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.73872768,0,0,1.3536788,-2.25,-1.9999999)"
+       y2="1.8468192"
+       x2="48.259949"
+       y1="33.61211"
+       x1="34.290413"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3698"
+       xlink:href="#linearGradient3669-2"
+       inkscape:collect="always" />
+    <inkscape:perspective
+       id="perspective3689-6"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3669-22"
+       id="linearGradient3675-0"
+       x1="34.290413"
+       y1="33.61211"
+       x2="48.259949"
+       y2="1.8468192"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3536788,0,0,0.73872768,1.1636018,4.5369967)" />
+    <linearGradient
+       id="linearGradient3669-22">
+      <stop
+         style="stop-color:#af7d00;stop-opacity:1;"
+         offset="0"
+         id="stop3671-8" />
+      <stop
+         style="stop-color:#ffed00;stop-opacity:1;"
+         offset="1"
+         id="stop3673-4" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.73872768,0,0,1.3536788,-2.25,-1.9999999)"
+       y2="1.8468192"
+       x2="48.259949"
+       y1="33.61211"
+       x1="34.290413"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3698-3"
+       xlink:href="#linearGradient3669-22"
+       inkscape:collect="always" />
+    <inkscape:perspective
+       id="perspective3689-1"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <linearGradient
+       id="linearGradient3669-0">
+      <stop
+         style="stop-color:#af7d00;stop-opacity:1;"
+         offset="0"
+         id="stop3671-9" />
+      <stop
+         style="stop-color:#ffed00;stop-opacity:1;"
+         offset="1"
+         id="stop3673-1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.73872768,0,0,1.3536788,-2.25,-1.9999999)"
+       y2="1.8468192"
+       x2="48.259949"
+       y1="33.61211"
+       x1="34.290413"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3698-9"
+       xlink:href="#linearGradient3669-0"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4032-0"
+       id="linearGradient3822"
+       x1="154.13527"
+       y1="33.267025"
+       x2="165.61629"
+       y2="46.429642"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient4032-0">
+      <stop
+         style="stop-color:#71b2f8;stop-opacity:1;"
+         offset="0"
+         id="stop4034-37" />
+      <stop
+         style="stop-color:#002795;stop-opacity:1;"
+         offset="1"
+         id="stop4036-1" />
+    </linearGradient>
+    <radialGradient
+       r="19.467436"
+       fy="90.193245"
+       fx="132.70454"
+       cy="90.193245"
+       cx="132.70454"
+       gradientTransform="matrix(-0.08162339,1.3949072,-1.1572569,-0.26963374,245.22773,-105.44363)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3294"
+       xlink:href="#linearGradient4032-0"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3979">
+      <stop
+         style="stop-color:#71b2f8;stop-opacity:1;"
+         offset="0"
+         id="stop3981" />
+      <stop
+         style="stop-color:#002795;stop-opacity:1;"
+         offset="1"
+         id="stop3983" />
+    </linearGradient>
+    <radialGradient
+       r="19.467436"
+       fy="90.193245"
+       fx="132.70454"
+       cy="90.193245"
+       cx="132.70454"
+       gradientTransform="matrix(-0.08162339,1.3949072,-1.1572569,-0.26963374,245.22773,-105.44363)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3989"
+       xlink:href="#linearGradient4032-0"
+       inkscape:collect="always" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="12.640625"
+     inkscape:cx="32"
+     inkscape:cy="32.039555"
+     inkscape:current-layer="text3796"
+     showgrid="true"
+     inkscape:document-units="px"
+     inkscape:grid-bbox="true"
+     inkscape:window-width="1280"
+     inkscape:window-height="964"
+     inkscape:window-x="-2"
+     inkscape:window-y="-3"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata2821">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer">
+    <g
+       transform="scale(0.73872768,1.3536788)"
+       style="font-size:54.21519089000000236px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;fill:#ff2600;fill-opacity:1;stroke:#731200;font-family:Arial;-inkscape-font-specification:Arial;color:#000000;fill-rule:nonzero;stroke-width:2.19132471;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="text3796">
+      <g
+         id="g3618"
+         transform="matrix(0.70424957,0,0,0.52904253,-67.469101,-5.2254527)"
+         style="stroke-width:3.60424328;stroke-miterlimit:4;stroke-dasharray:none">
+        <path
+           inkscape:connector-curvature="0"
+           style="fill:#002795;fill-opacity:1;fill-rule:evenodd;stroke:#000060;stroke-width:3.60424328;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+           d="m 159.20148,53.902086 0.0531,21.601247 28.10788,-18.367937 c 0.007,-7.189794 0.0871,-9.896215 0.34301,-15.38983 -11.14834,4.941559 -16.71411,6.819852 -28.65417,12.047404 z"
+           id="rect3522"
+           sodipodi:nodetypes="cccccc" />
+        <path
+           sodipodi:nodetypes="ccccc"
+           id="path4028"
+           d="m 158.84325,35.928521 -32.65667,12.650912 c 10.09805,2.701125 21.41071,4.571297 33.46959,7.463999 L 187.85895,41.84161 c -11.48557,-2.602446 -16.87245,-3.39987 -29.0157,-5.913089 z"
+           style="fill:url(#linearGradient3822);fill-opacity:1;fill-rule:evenodd;stroke:#000060;stroke-width:3.60424328;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+           inkscape:connector-curvature="0" />
+        <path
+           inkscape:connector-curvature="0"
+           style="fill:url(#radialGradient3989);fill-opacity:1;fill-rule:evenodd;stroke:#000060;stroke-width:3.60424328;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+           d="m 125.86685,49.047591 33.79357,6.737763 -0.61235,19.807358 c -11.9371,-2.437662 -20.99832,-4.146589 -32.8167,-7.32403 z"
+           id="rect3520"
+           sodipodi:nodetypes="ccccc" />
+      </g>
+      <path
+         style="fill:none;stroke:#000000;stroke-width:3.5;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         d="M 81.72839,30.058765 C 66.271056,35.234203 52.077202,39.729497 35.491834,44.637555 L 5.1820775,38.913765 5.245712,13.331373 C 25.783406,9.8291131 35.549448,8.0435188 52.963717,4.9636367 l 28.637992,4.7198738 z"
+         id="path2887"
+         sodipodi:nodetypes="ccccccc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="color:#000000;fill:none;stroke:#000000;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         d="M 5.3512873,13.100465 C 17.795485,15.59416 20.108978,16.11907 36.438801,19.304469 l -1.158913,25.632485"
+         id="path3677"
+         sodipodi:nodetypes="ccc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="color:#000000;fill:url(#linearGradient3675-0);fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         d="M 36.007716,19.342719 C 56.454307,15.18655 62.948369,13.772094 81.792199,9.7066249"
+         id="path3679"
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0" />
+    </g>
+  </g>
+</svg>

--- a/src/Mod/Part/Gui/ViewProviderBodyBase.cpp
+++ b/src/Mod/Part/Gui/ViewProviderBodyBase.cpp
@@ -1,0 +1,363 @@
+/***************************************************************************
+ *   Copyright (c) 2016 Victor Titov (DeepSOIC)       <vv.titov@gmail.com> *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "PreCompiled.h"
+
+#ifndef _PreComp_
+# include <boost/bind.hpp>
+# include <Inventor/nodes/SoSeparator.h>
+# include <Inventor/actions/SoGetBoundingBoxAction.h>
+# include <Precision.hxx>
+# include <QMenu>
+#endif
+
+#include <Base/Console.h>
+#include <App/Part.h>
+#include <App/Origin.h>
+#include <Gui/Command.h>
+#include <Gui/ActionFunction.h>
+#include <Gui/Document.h>
+#include <Gui/Application.h>
+#include <Gui/View3DInventor.h>
+#include <Gui/View3DInventorViewer.h>
+#include <Gui/ViewProviderOrigin.h>
+#include <Gui/ViewProviderOriginFeature.h>
+
+#include <Mod/Part/App/BodyBase.h>
+
+#include "ViewProviderBodyBase.h"
+#include <Gui/MDIView.h>
+
+using namespace PartGui;
+
+const char* PartGui::ViewProviderBodyBase::BodyModeEnum[] = {"Through","Tip",NULL};
+
+PROPERTY_SOURCE(PartGui::ViewProviderBodyBase,PartGui::ViewProviderPart)
+
+ViewProviderBodyBase::ViewProviderBodyBase()
+{
+    ADD_PROPERTY(DisplayModeBody,((long)0));
+    DisplayModeBody.setEnums(BodyModeEnum);
+
+    pcBodyChildren = new SoSeparator();
+    pcBodyChildren->ref();
+
+    sPixmap = "Part_Body_Tree.svg";
+}
+
+ViewProviderBodyBase::~ViewProviderBodyBase()
+{
+    pcBodyChildren->unref ();
+    connectChangedObjectApp.disconnect();
+    connectChangedObjectGui.disconnect();
+}
+
+void ViewProviderBodyBase::attach(App::DocumentObject *pcFeat)
+{
+    // call parent attach method
+    ViewProviderPart::attach(pcFeat);
+
+    addDisplayMaskMode(pcBodyChildren, "Through");
+    setDisplayMaskMode("Through");
+
+    App::Document *adoc  = pcObject->getDocument ();
+    Gui::Document *gdoc = Gui::Application::Instance->getDocument ( adoc ) ;
+
+    assert ( adoc );
+    assert ( gdoc );
+
+    connectChangedObjectApp = adoc->signalChangedObject.connect (
+            boost::bind ( &ViewProviderBodyBase::slotChangedObjectApp, this, _1, _2) );
+
+    connectChangedObjectGui = gdoc->signalChangedObject.connect (
+            boost::bind ( &ViewProviderBodyBase::slotChangedObjectGui, this, _1, _2) );
+}
+
+// TODO on activating the body switch to the "Through" mode (2015-09-05, Fat-Zer)
+// TODO differnt icon in tree if mode is Through (2015-09-05, Fat-Zer)
+// TODO drag&drop (2015-09-05, Fat-Zer)
+// TODO Add activate () call (2015-09-08, Fat-Zer)
+
+void ViewProviderBodyBase::setDisplayMode(const char* ModeName) {
+
+    //if we show "Through" we must avoid to set the display mask modes, as this would result
+    //in going into "tip" mode. When through is chosen the child features are displayed, and all
+    //we need to ensure is that the display mode change is propagated to them fro within the
+    //onChanged() method.
+    if(DisplayModeBody.getValue() == 1)
+        PartGui::ViewProviderPartExt::setDisplayMode(ModeName);
+}
+
+void ViewProviderBodyBase::setOverrideMode(const std::string& mode) {
+
+    //if we are in through mode, we need to ensure that the override mode is not set for the body
+    //(as this would result in "tip" mode), it is enough when the children are set to the correct
+    //override mode.
+
+    if(DisplayModeBody.getValue() != 0)
+        Gui::ViewProvider::setOverrideMode(mode);
+    else
+        overrideMode = mode;
+}
+
+void ViewProviderBodyBase::setupContextMenu(QMenu* menu, QObject* receiver, const char* member)
+{
+    Gui::ActionFunction* func = new Gui::ActionFunction(menu);
+    QAction* act = menu->addAction(tr("Toggle active body"));
+    func->trigger(act, boost::bind(&ViewProviderBodyBase::doubleClicked, this));
+}
+
+bool ViewProviderBodyBase::doubleClicked(void)
+{
+    //first, check if the body is already active.
+    App::DocumentObject* activeBody = nullptr;
+    Gui::MDIView* activeView = this->getActiveView();
+    if ( activeView ) {
+        activeBody = activeView->getActiveObject<App::DocumentObject*> (PDBODYKEY);
+    }
+
+    if (activeBody == this->getObject()){
+        //active body double-clicked. Deactivate.
+        Gui::Command::doCommand(Gui::Command::Gui,
+                "Gui.getDocument('%s').ActiveView.setActiveObject('%s', None)",
+                this->getObject()->getDocument()->getName(),
+                PDBODYKEY);
+    } else {
+        // set correct active objects
+        auto* part = App::Part::getPartOfObject ( getObject() );
+        if ( part && part != getActiveView()->getActiveObject<App::Part*> ( PARTKEY ) ) {
+            Gui::Command::doCommand(Gui::Command::Gui,
+                    "Gui.getDocument('%s').ActiveView.setActiveObject('%s', App.getDocument('%s').getObject('%s'))",
+                    part->getDocument()->getName(),
+                    PARTKEY,
+                    part->getDocument()->getName(),
+                    part->getNameInDocument());
+        }
+
+        Gui::Command::doCommand(Gui::Command::Gui,
+                "Gui.getDocument('%s').ActiveView.setActiveObject('%s', App.getDocument('%s').getObject('%s'))",
+                this->getObject()->getDocument()->getName(),
+                PDBODYKEY,
+                this->getObject()->getDocument()->getName(),
+                this->getObject()->getNameInDocument());
+    }
+
+    return true;
+}
+
+std::vector<App::DocumentObject*> ViewProviderBodyBase::claimChildren(void)const
+{
+    Part::BodyBase* body = static_cast<Part::BodyBase*> ( getObject () );
+    const std::vector<App::DocumentObject*> &model = body->Model.getValues ();
+    std::set<App::DocumentObject*> outSet; //< set of objects not to claim (childrens of childrens)
+
+    // search for objects handled (claimed) by the features
+    for( auto obj: model){
+        if (!obj) { continue; }
+        Gui::ViewProvider* vp = Gui::Application::Instance->getViewProvider ( obj );
+        if (!vp) { continue; }
+
+        auto children = vp->claimChildren();
+        std::remove_copy ( children.begin (), children.end (), std::inserter (outSet, outSet.begin () ), nullptr);
+    }
+
+    // remove the otherwise handled objects, preserving their order so the order in the TreeWidget is correct
+    std::vector<App::DocumentObject*> Result;
+
+    if (body->Origin.getValue()) { // Claim for the Origin
+        Result.push_back (body->Origin.getValue());
+    }
+
+    // claim for rest content not claimed by any other features
+    std::remove_copy_if (model.begin(), model.end(), std::back_inserter (Result),
+            [outSet] (App::DocumentObject* obj) {
+                return outSet.find (obj) != outSet.end();
+            } );
+
+    return Result;
+}
+
+std::vector<App::DocumentObject*> ViewProviderBodyBase::claimChildren3D(void)const
+{
+    Part::BodyBase* body = static_cast<Part::BodyBase*>(getObject());
+
+    const std::vector<App::DocumentObject*> & features = body->Model.getValues();
+
+    std::vector<App::DocumentObject*> rv;
+
+    if ( body->Origin.getValue() ) { // Add origin
+        rv.push_back (body->Origin.getValue());
+    }
+
+    // Add all other stuff
+    std::copy (features.begin(), features.end(), std::back_inserter (rv) );
+
+    return rv;
+}
+
+bool ViewProviderBodyBase::onDelete ( const std::vector<std::string> &) {
+    // TODO May be do it conditionally? (2015-09-05, Fat-Zer)
+    Gui::Command::doCommand(Gui::Command::Doc,
+            "App.getDocument(\"%s\").getObject(\"%s\").removeModelFromDocument()"
+            ,getObject()->getDocument()->getName(), getObject()->getNameInDocument());
+    return true;
+}
+
+void ViewProviderBodyBase::updateData(const App::Property* prop)
+{
+    Part::BodyBase* body = static_cast<Part::BodyBase*>(getObject());
+
+    if (prop == &body->Model) {
+        // update sizes of origins and datums
+        updateOriginDatumSize ();
+    }
+
+    PartGui::ViewProviderPart::updateData(prop);
+}
+
+void ViewProviderBodyBase::slotChangedObjectApp ( const App::DocumentObject& obj, const App::Property& prop ) {
+
+    if (!obj.isDerivedFrom ( Part::Feature::getClassTypeId () ) ||
+        obj.isDerivedFrom ( Part::BodyBase::getClassTypeId () )    ) { // we are intrested only in Part::Features and not in bodies
+        return;
+    }
+
+    const Part::Feature* feat = static_cast <const Part::Feature*>(&obj);
+
+    if ( &feat->Shape != &prop && &feat->Placement != &prop) { // react only on changes in shapes and placement
+        return;
+    }
+
+    Part::BodyBase* body = static_cast<Part::BodyBase*> ( getObject() );
+    if ( body && body->hasFeature (&obj ) ) {
+        updateOriginDatumSize ();
+    }
+}
+
+
+void ViewProviderBodyBase::slotChangedObjectGui (
+        const Gui::ViewProviderDocumentObject& vp, const App::Property& prop )
+{
+    if (&vp.Visibility != &prop) { // react only on visability changes
+        return;
+    }
+
+    if ( !vp.isDerivedFrom ( Gui::ViewProviderOrigin::getClassTypeId () ) &&
+         !vp.isDerivedFrom ( Gui::ViewProviderOriginFeature::getClassTypeId () ) ) {
+        // Ignore origins to avoid infinite recursion (not likely in a well-formed document,
+        //          but may happen in documents designed in old versions of assembly branch )
+        return;
+    }
+
+    Part::BodyBase* body = static_cast<Part::BodyBase*> ( getObject() );
+    App::DocumentObject* obj = vp.getObject ();
+
+    if ( body && obj && body->hasFeature ( obj ) ) {
+        updateOriginDatumSize ();
+    }
+}
+
+void ViewProviderBodyBase::updateOriginDatumSize ()
+{
+    Part::BodyBase* body = static_cast<Part::BodyBase*> ( getObject() );
+
+    //compute bounding box of contained features (bb_cumu)
+    std::vector<App::DocumentObject*> features = body->getFullModel();
+    Base::BoundBox3d bb_cumu;
+    for(App::DocumentObject* obj: features){
+        if (obj && obj->isDerivedFrom(Part::Feature::getClassTypeId())){
+            Part::Feature &feat = *(static_cast<Part::Feature*>(obj));
+            Base::BoundBox3d bb = feat.Shape.getBoundingBox();
+            if(bb.IsValid() && bb.CalcDiagonalLength() < Precision::Infinite()){
+                bb_cumu.Add(bb);
+            }
+        }
+    }
+    if (! bb_cumu.IsValid() || bb_cumu.CalcDiagonalLength() < Precision::Confusion()){
+        bb_cumu.Add(Base::Vector3d(1.0,1.0,1.0));
+        bb_cumu.Add(Base::Vector3d(-1.0,-1.0,-1.0));
+    }
+    assert(bb_cumu.CalcDiagonalLength() >= Precision::Confusion());
+
+
+    //calculate size of origin.
+    Base::Vector3d size;
+    size.x = std::max(fabs(bb_cumu.MaxX), fabs(bb_cumu.MinX));
+    size.y = std::max(fabs(bb_cumu.MaxY), fabs(bb_cumu.MinY));
+    size.z = std::max(fabs(bb_cumu.MaxZ), fabs(bb_cumu.MinZ));
+    //make sure size isn't squeezed too much in some direction
+    double diag = size.Length();
+    if (size.x < diag*0.2)
+        size.x = diag*0.2;
+    if (size.y < diag*0.2)
+        size.y = diag*0.2;
+    if (size.z < diag*0.2)
+        size.z = diag*0.2;
+
+    //obtain pointer to origin viewprovider
+    Gui::ViewProviderOrigin* vpOrigin = 0;
+    try {
+        App::Origin* origin = body->getOrigin ();
+        assert (origin);
+
+        Gui::ViewProvider *vp = Gui::Application::Instance->getViewProvider(origin);
+        if (!vp) {
+            throw Base::Exception ("No view provider linked to the Origin");
+        }
+        assert ( vp->isDerivedFrom ( Gui::ViewProviderOrigin::getClassTypeId () ) );
+        vpOrigin = static_cast <Gui::ViewProviderOrigin *> ( vp );
+    } catch (const Base::Exception &ex) {
+        Base::Console().Error ("%s\n", ex.what() );
+        return;
+    }
+
+    //update it!
+    vpOrigin->Size.setValue(size*1.2);
+}
+
+void ViewProviderBodyBase::onChanged(const App::Property* prop) {
+
+    if(prop == &DisplayModeBody) {
+
+        if ( DisplayModeBody.getValue() == 0 )  {
+            //if we are in an override mode we need to make sure to come out, because
+            //otherwise the maskmode is blocked and won't go into "through"
+            if(getOverrideMode() != "As Is") {
+                auto mode = getOverrideMode();
+                ViewProvider::setOverrideMode("As Is");
+                overrideMode = mode;
+            }
+            setDisplayMaskMode("Through");
+        }
+        else {
+            if(getOverrideMode() == "As Is")
+                setDisplayMaskMode(DisplayMode.getValueAsString());
+            else {
+                Base::Console().Message("Set override mode: %s\n", getOverrideMode().c_str());
+                setDisplayMaskMode(getOverrideMode().c_str());
+            }
+        }
+    }
+
+    PartGui::ViewProviderPartExt::onChanged(prop);
+}
+

--- a/src/Mod/Part/Gui/ViewProviderBodyBase.h
+++ b/src/Mod/Part/Gui/ViewProviderBodyBase.h
@@ -1,0 +1,95 @@
+/***************************************************************************
+ *   Copyright (c) 2016 Victor Titov (DeepSOIC)       <vv.titov@gmail.com> *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef PARTGUI_ViewProviderBodyBase_H
+#define PARTGUI_ViewProviderBodyBase_H
+
+#include "ViewProvider.h"
+#include <QCoreApplication>
+
+class SoGroup;
+class SoSeparator;
+class SbBox3f;
+class SoGetBoundingBoxAction;
+namespace PartGui {
+
+/** ViewProvider of the BodyBase feature
+ *  This class manage the visual apperance of the features in the
+ *  Body feature. That mean while editing all visible features are shown.
+ *  If the Body is not active it shows only the result shape (tip).
+ * \author jriegel
+ */
+class PartGuiExport ViewProviderBodyBase : public ViewProviderPart
+{
+    Q_DECLARE_TR_FUNCTIONS(PartDesignGui::ViewProviderBody)
+    PROPERTY_HEADER(PartGui::ViewProviderBodyBase);
+
+public:
+    ViewProviderBodyBase();
+    virtual ~ViewProviderBodyBase();
+
+    App::PropertyEnumeration DisplayModeBody;
+
+    virtual void attach(App::DocumentObject *);
+
+    virtual bool doubleClicked(void);
+    virtual void setupContextMenu(QMenu* menu, QObject* receiver, const char* member);
+
+    virtual std::vector<App::DocumentObject*> claimChildren(void)const;
+
+    // returns the root node where the children gets collected(3D)
+    virtual SoGroup* getChildRoot(void) const {return pcBodyChildren;}
+
+    virtual std::vector<App::DocumentObject*> claimChildren3D(void)const;
+
+    virtual void setDisplayMode(const char* ModeName);
+    virtual void setOverrideMode(const std::string& mode);
+
+    virtual bool onDelete(const std::vector<std::string> &);
+
+    /// Update the children's highlighting when triggered
+    virtual void updateData(const App::Property* prop);
+
+    virtual void onChanged(const App::Property* prop);
+
+    /// Update the sizes of origin
+    virtual void updateOriginDatumSize ();
+
+protected:
+    void slotChangedObjectApp ( const App::DocumentObject& obj, const App::Property& prop );
+    void slotChangedObjectGui ( const Gui::ViewProviderDocumentObject& obj, const App::Property& prop );
+
+protected:
+    /// group used to store children collected by claimChildren3D() in the through (edit) mode.
+    SoGroup *pcBodyChildren;
+
+    static const char* BodyModeEnum[];
+
+private:
+    boost::signals::connection connectChangedObjectApp;
+    boost::signals::connection connectChangedObjectGui;
+};
+
+} // namespace PartGui
+
+
+#endif // PARTGUI_ViewProviderBodyBase_H

--- a/src/Mod/PartDesign/App/BodyPy.xml
+++ b/src/Mod/PartDesign/App/BodyPy.xml
@@ -33,15 +33,5 @@
                     </UserDocu>
             </Documentation>
     </Methode>
-    <Methode Name="removeFeature">
-            <Documentation>
-                    <UserDocu>removeFeature(feat) - Remove the given feature from the Body</UserDocu>
-            </Documentation>
-    </Methode>
-    <Methode Name="removeModelFromDocument">
-            <Documentation>
-                <UserDocu>Delets all the objects linked to the model.</UserDocu>
-            </Documentation>
-    </Methode>
   </PythonExport>
 </GenerateModel>

--- a/src/Mod/PartDesign/App/BodyPyImp.cpp
+++ b/src/Mod/PartDesign/App/BodyPyImp.cpp
@@ -116,31 +116,3 @@ PyObject* BodyPy::insertFeature(PyObject *args)
     Py_Return;
 }
 
-PyObject* BodyPy::removeFeature(PyObject *args)
-{
-    PyObject* featurePy;
-    if (!PyArg_ParseTuple(args, "O!", &(App::DocumentObjectPy::Type), &featurePy))
-        return 0;
-
-    App::DocumentObject* feature = static_cast<App::DocumentObjectPy*>(featurePy)->getDocumentObjectPtr();
-    Body* body = this->getBodyPtr();
-
-    try {
-        body->removeFeature(feature);
-    } catch (Base::Exception& e) {
-        PyErr_SetString(PyExc_SystemError, e.what());
-        return 0;
-    }
-
-    Py_Return;
-}
-
-PyObject*  BodyPy::removeModelFromDocument(PyObject *args)
-{
-    if (!PyArg_ParseTuple(args, ""))
-        return 0;
-
-    getBodyPtr()->removeModelFromDocument();
-    Py_Return;
-}
-

--- a/src/Mod/PartDesign/Gui/ViewProviderBody.h
+++ b/src/Mod/PartDesign/Gui/ViewProviderBody.h
@@ -25,7 +25,7 @@
 #define PARTGUI_ViewProviderBody_H
 
 #include <Mod/Part/Gui/ViewProvider.h>
-#include <QCoreApplication>
+#include <Mod/Part/Gui/ViewProviderBodyBase.h>
 
 class SoGroup;
 class SoSeparator;
@@ -39,9 +39,8 @@ namespace PartDesignGui {
  *  If the Body is not active it shows only the result shape (tip).
  * \author jriegel
  */
-class PartDesignGuiExport ViewProviderBody : public PartGui::ViewProviderPart
+class PartDesignGuiExport ViewProviderBody : public PartGui::ViewProviderBodyBase
 {
-    Q_DECLARE_TR_FUNCTIONS(PartDesignGui::ViewProviderBody)
     PROPERTY_HEADER(PartDesignGui::ViewProviderBody);
 
 public:
@@ -49,22 +48,15 @@ public:
     ViewProviderBody();
     /// destructor
     virtual ~ViewProviderBody();
-
-    App::PropertyEnumeration DisplayModeBody;
     
     virtual void attach(App::DocumentObject *);
 
     virtual bool doubleClicked(void);
-    virtual void setupContextMenu(QMenu* menu, QObject* receiver, const char* member);
+
     virtual std::vector<App::DocumentObject*> claimChildren(void)const;
 
     // returns the root node where the children gets collected(3D)
-    virtual SoGroup* getChildRoot(void) const {return pcBodyChildren;}
     virtual std::vector<App::DocumentObject*> claimChildren3D(void)const;
-    virtual void setDisplayMode(const char* ModeName);
-    virtual void setOverrideMode(const std::string& mode);
-
-    virtual bool onDelete(const std::vector<std::string> &);
 
     /// Update the children's highlighting when triggered
     virtual void updateData(const App::Property* prop);
@@ -74,28 +66,18 @@ public:
     /// Update the sizes of origin and datums
     void updateOriginDatumSize ();
     
-    /**
-     * Return the bounding box of visible features
-     * @note datums are counted as their base point only
-     */
-    SbBox3f getBoundBox ();
+    // /**
+    // * Return the bounding box of visible features
+    // * @note datums are counted as their base point only
+    // */
+    //SbBox3f getBoundBox ();
 
 protected:
-    void slotChangedObjectApp ( const App::DocumentObject& obj, const App::Property& prop );
-    void slotChangedObjectGui ( const Gui::ViewProviderDocumentObject& obj, const App::Property& prop );
 
     /// Copy over all visual properties to the child features
     void unifyVisualProperty(const App::Property* prop);
     /// Set Feature viewprovider into visual body mode
     void setVisualBodyMode(bool bodymode);
-private:
-    /// group used to store children collected by claimChildren3D() in the through (edit) mode.
-    SoGroup *pcBodyChildren;
-
-    static const char* BodyModeEnum[];
-
-    boost::signals::connection connectChangedObjectApp;
-    boost::signals::connection connectChangedObjectGui;
 };
 
 


### PR DESCRIPTION
This is a first step to introducing Bodies to Part workbench (and consequently, to Draft, Lattice, and whatever workbench related to Part::Features)

Offloaded some functionality that might be common to all kinds of
potential Body features to BodyBase. Includes:
* ViewProvider for BodyBase, supporting "Tip" and "Through" display
modes, as well as updating size of origin features, and double-click
activation
* addObject, removeObject, removeModelFromDocument, Origin creation and
deletion, etc.
* execute (merely returns shape of Tip feature)

Moved a couple of PartDesign::Body specific methods and properties from
BodyBase to Body:
* property BaseFeature
* isAfter method
* getFullModel method implementation

From now on, one can drop a Part::BodyBase object, and that object is functional. The management of it doesn't exist in Part Workbench, but Part-o-magic will make it tick =)