### PR TITLE
PathProfile.py: Fix non-GUI usage

### DIFF
--- a/src/Mod/Path/PathScripts/PathProfile.py
+++ b/src/Mod/Path/PathScripts/PathProfile.py
@@ -33,6 +33,14 @@ if FreeCAD.GuiUp:
     import FreeCADGui
     from PySide import QtCore, QtGui
     from DraftTools import translate
+    # Qt tanslation handling
+    try:
+        _encoding = QtGui.QApplication.UnicodeUTF8
+        def translate(context, text, disambig=None):
+            return QtGui.QApplication.translate(context, text, disambig, _encoding)
+    except AttributeError:
+        def translate(context, text, disambig=None):
+            return QtGui.QApplication.translate(context, text, disambig)
 else:
     def translate(ctxt, txt):
         return txt
@@ -42,16 +50,6 @@ __author__ = "sliptonic (Brad Collette)"
 __url__ = "http://www.freecadweb.org"
 
 """Path Profile object and FreeCAD command"""
-
-# Qt tanslation handling
-try:
-    _encoding = QtGui.QApplication.UnicodeUTF8
-    def translate(context, text, disambig=None):
-        return QtGui.QApplication.translate(context, text, disambig, _encoding)
-except AttributeError:
-    def translate(context, text, disambig=None):
-        return QtGui.QApplication.translate(context, text, disambig)
-
 
 class ObjectProfile:
 


### PR DESCRIPTION
The call to QtGui.QApplication.translate is not possible and necessary
without a GUI