### PR TITLE
Fix duplicate objects during export and during copy

### DIFF
--- a/src/Gui/Application.cpp
+++ b/src/Gui/Application.cpp
@@ -606,10 +606,12 @@ void Application::exportTo(const char* FileName, const char* DocName, const char
             }
 
             std::stringstream str;
+			std::set<App::DocumentObject*> unique_objs;
             str << "__objs__=[]" << std::endl;
             for (std::vector<App::DocumentObject*>::iterator it = sel.begin(); it != sel.end(); ++it) {
-                str << "__objs__.append(FreeCAD.getDocument(\"" << DocName << "\").getObject(\""
-                    << (*it)->getNameInDocument() << "\"))" << std::endl;
+				if (unique_objs.insert(*it).second)
+					str << "__objs__.append(FreeCAD.getDocument(\"" << DocName << "\").getObject(\""
+						<< (*it)->getNameInDocument() << "\"))" << std::endl;
             }
 
             str << "import " << Module << std::endl;

--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -1318,10 +1318,12 @@ void MainWindow::dragEnterEvent (QDragEnterEvent * e)
 QMimeData * MainWindow::createMimeDataFromSelection () const
 {
     std::vector<SelectionSingleton::SelObj> selobj = Selection().getCompleteSelection();
+	std::set<App::DocumentObject*> unique_objs;
     std::map< App::Document*, std::vector<App::DocumentObject*> > objs;
     for (std::vector<SelectionSingleton::SelObj>::iterator it = selobj.begin(); it != selobj.end(); ++it) {
         if (it->pObject && it->pObject->getDocument()) {
-            objs[it->pObject->getDocument()].push_back(it->pObject);
+			if (unique_objs.insert(it->pObject).second)
+	            objs[it->pObject->getDocument()].push_back(it->pObject);
         }
     }
 


### PR DESCRIPTION
This branch fixes two very similar bugs:

1. Duplicate objects exported when several faces selected on one object
2. Duplicate objects pasted when object copied with several faces selected

Bugs were discussed here - http://forum.freecadweb.org/viewtopic.php?f=3&t=15994
Bug report - http://www.freecadweb.org/tracker/view.php?id=2578