### PR TITLE
Implements more arguments to BSplineCurve.approximate

### DIFF
--- a/src/Mod/Part/App/BSplineCurvePy.xml
+++ b/src/Mod/Part/App/BSplineCurvePy.xml
@@ -293,12 +293,37 @@ from the knots table of this B-Spline curve.</UserDocu>
 				</UserDocu>
 			</Documentation>
 		</Methode>
-		<Methode Name="approximate">
+		<Methode Name="approximate" Keyword="true">
 			<Documentation>
 				<UserDocu>
-					approximate(list_of_points):
-
 					Replaces this B-Spline curve by approximating a set of points.
+					The function accepts keywords as arguments.
+
+					approximate2(Points = list_of_points) 
+
+					Optional arguments :
+
+					DegMin = integer (3) : Minimum degree of the curve.
+					DegMax = integer (8) : Maximum degree of the curve.
+					Tolerance = float (1e-3) : approximating tolerance.
+					Continuity = string ('C2') : Desired continuity of the curve.
+					Possible values : 'C0','G1','C1','G2','C2','C3','CN'
+
+					LengthWeight = float, CurvatureWeight = float, TorsionWeight = float
+					If one of these arguments is not null, the functions approximates the 
+					points using variational smoothing algorithm, which tries to minimize 
+					additional criterium: 
+					LengthWeight*CurveLength + CurvatureWeight*Curvature + TorsionWeight*Torsion
+					Continuity must be C0, C1 or C2, else defaults to C2.
+
+					Parameters = list of floats : knot sequence of the approximated points.
+					This argument is only used if the weights above are all null.
+
+					ParamType = string ('Uniform','Centripetal' or 'ChordLength')
+					Parameterization type. Only used if weights and Parameters above aren't specified.
+
+					Note : Continuity of the spline defaults to C2. However, it may not be applied if 
+					it conflicts with other parameters ( especially DegMax ).
 				</UserDocu>
 			</Documentation>
 		</Methode>


### PR DESCRIPTION
The function now uses keywords, and implements all the arguments available in OCC's GeomAPI_PointsToBSpline.