### PR TITLE
Path: add plunge angle feature for PathProfile

### DIFF
--- a/src/Mod/Path/Gui/Resources/panels/ProfileEdit.ui
+++ b/src/Mod/Path/Gui/Resources/panels/ProfileEdit.ui
@@ -435,6 +435,16 @@
           <item row="2" column="1">
            <widget class="QDoubleSpinBox" name="rollRadius"/>
           </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="label_13">
+            <property name="text">
+             <string>Plunge Angle</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <widget class="QDoubleSpinBox" name="plungeAngle"/>
+          </item>
          </layout>
         </widget>
        </item>

--- a/src/Mod/Path/PathScripts/PathProfile.py
+++ b/src/Mod/Path/PathScripts/PathProfile.py
@@ -100,6 +100,7 @@ class ObjectProfile:
         obj.addProperty("App::PropertyDistance", "RollRadius", "Profile", "Radius at start and end")
         obj.addProperty("App::PropertyDistance", "OffsetExtra", "Profile", "Extra value to stay away from final profile- good for roughing toolpath")
         obj.addProperty("App::PropertyLength", "SegLen", "Profile", "Tesselation  value for tool paths made from beziers, bsplines, and ellipses")
+        obj.addProperty("App::PropertyAngle", "PlungeAngle", "Profile", "Plunge angle with which the tool enters the work piece. Straight down is 90 degrees, if set small enough or zero the tool will descent exactly one layer depth down per turn")
 
         obj.addProperty("App::PropertyVectorList", "locs", "Tags", "List of holding tag locations")
 
@@ -185,7 +186,7 @@ class ObjectProfile:
                 wire, obj.Side, self.radius, clockwise,
                 obj.ClearanceHeight.Value, obj.StepDown, obj.StartDepth.Value,
                 obj.FinalDepth.Value, FirstEdge, PathClosed, obj.SegLen.Value,
-                self.vertFeed, self.horizFeed)
+                self.vertFeed, self.horizFeed, PlungeAngle=obj.PlungeAngle.Value)
 
         return output
 
@@ -468,6 +469,7 @@ class CommandPathProfile:
         FreeCADGui.doCommand('obj.OffsetExtra = 0.0')
         FreeCADGui.doCommand('obj.Direction = "CW"')
         FreeCADGui.doCommand('obj.UseComp = False')
+        FreeCADGui.doCommand('obj.PlungeAngle = 90.0')
         FreeCADGui.doCommand('PathScripts.PathUtils.addToProject(obj)')
 
         FreeCAD.ActiveDocument.commitTransaction()
@@ -511,6 +513,8 @@ class TaskPanel:
                 self.obj.SegLen = self.form.segLen.value()
             if hasattr(self.obj, "RollRadius"):
                 self.obj.RollRadius = self.form.rollRadius.value()
+            if hasattr(self.obj, "PlungeAngle"):
+                self.obj.PlungeAngle = str(self.form.plungeAngle.value())
             if hasattr(self.obj, "UseComp"):
                 self.obj.UseComp = self.form.useCompensation.isChecked()
             if hasattr(self.obj, "UseStartPoint"):
@@ -525,7 +529,7 @@ class TaskPanel:
                 self.obj.Direction = str(self.form.direction.currentText())
         self.obj.Proxy.execute(self.obj)
 
-    def setFields(self): 
+    def setFields(self):
         self.form.startDepth.setText(str(self.obj.StartDepth.Value))
         self.form.finalDepth.setText(str(self.obj.FinalDepth.Value))
         self.form.safeHeight.setText(str(self.obj.SafeHeight.Value))
@@ -534,6 +538,7 @@ class TaskPanel:
         self.form.extraOffset.setValue(self.obj.OffsetExtra.Value)
         self.form.segLen.setValue(self.obj.SegLen.Value)
         self.form.rollRadius.setValue(self.obj.RollRadius.Value)
+        self.form.plungeAngle.setValue(self.obj.PlungeAngle.Value)
         self.form.useCompensation.setChecked(self.obj.UseComp)
         self.form.useStartPoint.setChecked(self.obj.UseStartPoint)
         self.form.useEndPoint.setChecked(self.obj.UseEndPoint)


### PR DESCRIPTION
This adds a new capability to the PathProfile CNC command:

With the new property "PlungeAngle", one can specify the inclination of
a ramp into the material, instead of plunging the tool straight down. The
original behaviour and default is set to 90.0 degrees. A value of zero
makes the tool descent exactly one layer depth down per turn.

See also the discussion at http://forum.freecadweb.org/viewtopic.php?f=15&t=16107
