### PR TITLE
Click confusion - setting to set pick radius, to make selecting stuff easier

### DIFF
--- a/src/Gui/DlgSettingsViewColor.cpp
+++ b/src/Gui/DlgSettingsViewColor.cpp
@@ -66,6 +66,7 @@ void DlgSettingsViewColor::saveSettings()
     checkBoxSelection->onSave();
     HighlightColor->onSave();
     SelectionColor->onSave();
+    spinPickRadius->onSave();
 }
 
 void DlgSettingsViewColor::loadSettings()
@@ -81,6 +82,7 @@ void DlgSettingsViewColor::loadSettings()
     checkBoxSelection->onRestore();
     HighlightColor->onRestore();
     SelectionColor->onRestore();
+    spinPickRadius->onRestore();
 }
 
 /**

--- a/src/Gui/DlgSettingsViewColor.ui
+++ b/src/Gui/DlgSettingsViewColor.ui
@@ -14,7 +14,16 @@
    <string>Colors</string>
   </property>
   <layout class="QGridLayout">
-   <property name="margin">
+   <property name="leftMargin">
+    <number>9</number>
+   </property>
+   <property name="topMargin">
+    <number>9</number>
+   </property>
+   <property name="rightMargin">
+    <number>9</number>
+   </property>
+   <property name="bottomMargin">
     <number>9</number>
    </property>
    <property name="spacing">
@@ -26,7 +35,16 @@
       <string>Selection</string>
      </property>
      <layout class="QGridLayout">
-      <property name="margin">
+      <property name="leftMargin">
+       <number>9</number>
+      </property>
+      <property name="topMargin">
+       <number>9</number>
+      </property>
+      <property name="rightMargin">
+       <number>9</number>
+      </property>
+      <property name="bottomMargin">
        <number>9</number>
       </property>
       <property name="spacing">
@@ -47,7 +65,16 @@
       </item>
       <item row="0" column="0">
        <layout class="QGridLayout" name="_3">
-        <property name="margin">
+        <property name="leftMargin">
+         <number>0</number>
+        </property>
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <property name="rightMargin">
+         <number>0</number>
+        </property>
+        <property name="bottomMargin">
          <number>0</number>
         </property>
         <property name="spacing">
@@ -61,7 +88,7 @@
           <property name="text">
            <string/>
           </property>
-          <property name="color">
+          <property name="color" stdset="0">
            <color>
             <red>28</red>
             <green>173</green>
@@ -70,22 +97,6 @@
           </property>
           <property name="prefEntry" stdset="0">
            <cstring>SelectionColor</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>View</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="0">
-         <widget class="Gui::PrefCheckBox" name="checkBoxSelection">
-          <property name="text">
-           <string>Enable selection highlighting</string>
-          </property>
-          <property name="checked">
-           <bool>true</bool>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>EnableSelection</cstring>
           </property>
           <property name="prefPath" stdset="0">
            <cstring>View</cstring>
@@ -128,7 +139,7 @@
           <property name="text">
            <string/>
           </property>
-          <property name="color">
+          <property name="color" stdset="0">
            <color>
             <red>225</red>
             <green>225</green>
@@ -143,6 +154,57 @@
           </property>
          </widget>
         </item>
+        <item row="1" column="0">
+         <widget class="Gui::PrefCheckBox" name="checkBoxSelection">
+          <property name="text">
+           <string>Enable selection highlighting</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>EnableSelection</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>View</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="0">
+         <widget class="QLabel" name="label">
+          <property name="text">
+           <string>Pick radius (px):</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="1">
+         <widget class="Gui::PrefDoubleSpinBox" name="spinPickRadius">
+          <property name="toolTip">
+           <string>Sets the area of confusion for picking elements in 3D view. Larger value make it easier to pick stuff, but will make some small features impossible to select.</string>
+          </property>
+          <property name="inputMethodHints">
+           <set>Qt::ImhPreferNumbers</set>
+          </property>
+          <property name="decimals">
+           <number>1</number>
+          </property>
+          <property name="minimum">
+           <double>0.500000000000000</double>
+          </property>
+          <property name="maximum">
+           <double>200.000000000000000</double>
+          </property>
+          <property name="value">
+           <double>5.000000000000000</double>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <string>PickRadius</string>
+          </property>
+          <property name="prefPath" stdset="0">
+           <string>View</string>
+          </property>
+         </widget>
+        </item>
        </layout>
       </item>
      </layout>
@@ -154,7 +216,16 @@
       <string>Background color</string>
      </property>
      <layout class="QGridLayout">
-      <property name="margin">
+      <property name="leftMargin">
+       <number>9</number>
+      </property>
+      <property name="topMargin">
+       <number>9</number>
+      </property>
+      <property name="rightMargin">
+       <number>9</number>
+      </property>
+      <property name="bottomMargin">
        <number>9</number>
       </property>
       <property name="spacing">
@@ -175,7 +246,16 @@
       </item>
       <item row="0" column="0">
        <layout class="QGridLayout" name="_4">
-        <property name="margin">
+        <property name="leftMargin">
+         <number>0</number>
+        </property>
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <property name="rightMargin">
+         <number>0</number>
+        </property>
+        <property name="bottomMargin">
          <number>0</number>
         </property>
         <property name="spacing">
@@ -211,7 +291,7 @@
           <property name="text">
            <string/>
           </property>
-          <property name="color">
+          <property name="color" stdset="0">
            <color>
             <red>20</red>
             <green>20</green>
@@ -244,7 +324,7 @@
           <property name="text">
            <string/>
           </property>
-          <property name="color">
+          <property name="color" stdset="0">
            <color>
             <red>151</red>
             <green>151</green>
@@ -267,7 +347,7 @@
           <property name="text">
            <string/>
           </property>
-          <property name="color">
+          <property name="color" stdset="0">
            <color>
             <red>111</red>
             <green>111</green>
@@ -303,7 +383,7 @@
           <property name="text">
            <string/>
           </property>
-          <property name="color">
+          <property name="color" stdset="0">
            <color>
             <red>51</red>
             <green>51</green>
@@ -378,12 +458,18 @@
    <extends>QCheckBox</extends>
    <header>Gui/PrefWidgets.h</header>
   </customwidget>
+  <customwidget>
+   <class>Gui::PrefDoubleSpinBox</class>
+   <extends>QDoubleSpinBox</extends>
+   <header>Gui/PrefWidgets.h</header>
+  </customwidget>
  </customwidgets>
  <tabstops>
   <tabstop>checkBoxPreselection</tabstop>
-  <tabstop>checkBoxSelection</tabstop>
   <tabstop>HighlightColor</tabstop>
+  <tabstop>checkBoxSelection</tabstop>
   <tabstop>SelectionColor</tabstop>
+  <tabstop>spinPickRadius</tabstop>
   <tabstop>radioButtonSimple</tabstop>
   <tabstop>SelectionColor_Background</tabstop>
   <tabstop>radioButtonGradient</tabstop>

--- a/src/Gui/NavigationStyle.cpp
+++ b/src/Gui/NavigationStyle.cpp
@@ -309,7 +309,7 @@ SbBool NavigationStyle::lookAtPoint(const SbVec2s screenpos)
 
     SoRayPickAction rpaction(viewer->getSoRenderManager()->getViewportRegion());
     rpaction.setPoint(screenpos);
-    rpaction.setRadius(2);
+    rpaction.setRadius(viewer->getPickRadius());
     rpaction.apply(viewer->getSoRenderManager()->getSceneGraph());
 
     SoPickedPoint * picked = rpaction.getPickedPoint();
@@ -994,7 +994,7 @@ void NavigationStyle::saveCursorPosition(const SoEvent * const ev)
     if (PRIVATE(this)->dragAtCursor) {
         SoRayPickAction rpaction(viewer->getSoRenderManager()->getViewportRegion());
         rpaction.setPoint(this->localPos);
-        rpaction.setRadius(2);
+        rpaction.setRadius(viewer->getPickRadius());
         rpaction.apply(viewer->getSoRenderManager()->getSceneGraph());
 
         SoPickedPoint * picked = rpaction.getPickedPoint();
@@ -1058,6 +1058,7 @@ SbBool NavigationStyle::handleEventInForeground(const SoEvent* const e)
 {
     SoHandleEventAction action(viewer->getSoRenderManager()->getViewportRegion());
     action.setEvent(e);
+    action.setPickRadius(viewer->getPickRadius());
     action.apply(viewer->foregroundroot);
     return action.isHandled();
 }

--- a/src/Gui/Quarter/SoQTQuarterAdaptor.cpp
+++ b/src/Gui/Quarter/SoQTQuarterAdaptor.cpp
@@ -29,6 +29,7 @@
 #include <Inventor/actions/SoSearchAction.h>
 #include <Inventor/actions/SoRayPickAction.h>
 #include <Inventor/actions/SoGetBoundingBoxAction.h>
+#include <Inventor/actions/SoHandleEventAction.h>
 #include <Inventor/SoPickedPoint.h>
 #include <Inventor/SbLine.h>
 #include <Inventor/SbPlane.h>
@@ -163,6 +164,7 @@ void SIM::Coin3D::Quarter::SoQTQuarterAdaptor::init()
     m_inseekmode = false;
     m_storedcamera = 0;
     m_viewingflag = false;
+    pickRadius = 5.0;
 
     m_seeksensor = new SoTimerSensor(SoQTQuarterAdaptor::seeksensorCB, (void*)this);
     getSoEventManager()->setNavigationState(SoEventManager::NO_NAVIGATION);
@@ -378,12 +380,24 @@ SbBool SIM::Coin3D::Quarter::SoQTQuarterAdaptor::isSeekValuePercentage(void) con
     return m_seekdistanceabs ? false : true;
 }
 
+void SIM::Coin3D::Quarter::SoQTQuarterAdaptor::setPickRadius(float pickRadius)
+{
+    this->pickRadius = pickRadius;
+    SoEventManager* evm = this->getSoEventManager();
+    if (evm){
+        SoHandleEventAction* a = evm->getHandleEventAction();
+        if (a){
+            a->setPickRadius(pickRadius);
+        }
+    }
+}
+
 SbBool SIM::Coin3D::Quarter::SoQTQuarterAdaptor::seekToPoint(const SbVec2s screenpos)
 {
 
     SoRayPickAction rpaction(getSoRenderManager()->getViewportRegion());
     rpaction.setPoint(screenpos);
-    rpaction.setRadius(2);
+    rpaction.setRadius(pickRadius);
     rpaction.apply(getSoRenderManager()->getSceneGraph());
 
     SoPickedPoint* picked = rpaction.getPickedPoint();

--- a/src/Gui/Quarter/SoQTQuarterAdaptor.h
+++ b/src/Gui/Quarter/SoQTQuarterAdaptor.h
@@ -85,6 +85,9 @@ public:
     void setSeekValueAsPercentage(const SbBool on);
     SbBool isSeekValuePercentage(void) const;
 
+    virtual float getPickRadius(void) const {return this->pickRadius;};
+    virtual void setPickRadius(float pickRadius);
+
     virtual void saveHomePosition(void);
     virtual void resetToHomePosition(void);
 
@@ -120,6 +123,7 @@ private:
     SbBool m_seekdistanceabs;
     SoSearchAction searchaction;
     SoGetMatrixAction matrixaction;
+    float pickRadius;
     // Home position storage.
     SoNode * m_storedcamera;
     

--- a/src/Gui/View3DInventor.cpp
+++ b/src/Gui/View3DInventor.cpp
@@ -192,6 +192,7 @@ View3DInventor::View3DInventor(Gui::Document* pcDocument, QWidget* parent,
     OnChange(*hGrp,"DimensionsVisible");
     OnChange(*hGrp,"Dimensions3dVisible");
     OnChange(*hGrp,"DimensionsDeltaVisible");
+    OnChange(*hGrp,"PickRadius");
 
     stopSpinTimer = new QTimer(this);
     connect(stopSpinTimer, SIGNAL(timeout()), this, SLOT(stopAnimating()));
@@ -395,6 +396,10 @@ void View3DInventor::OnChange(ParameterGrp::SubjectType &rCaller,ParameterGrp::M
       else
         _viewer->turnDeltaDimensionsOff();
     } 
+    else if (strcmp(Reason, "PickRadius") == 0)
+    {
+        _viewer->setPickRadius(rGrp.GetFloat("PickRadius", 5.0f));
+    }
     else{
         unsigned long col1 = rGrp.GetUnsigned("BackgroundColor",3940932863UL);
         unsigned long col2 = rGrp.GetUnsigned("BackgroundColor2",859006463UL); // default color (dark blue)

--- a/src/Gui/View3DViewerPy.cpp
+++ b/src/Gui/View3DViewerPy.cpp
@@ -71,6 +71,10 @@ void View3DInventorViewerPy::init_type()
     add_varargs_method("setFocalDistance",&View3DInventorViewerPy::setFocalDistance,"setFocalDistance(float) -> None\n");
     add_varargs_method("getFocalDistance",&View3DInventorViewerPy::getFocalDistance,"getFocalDistance() -> float\n");
     add_varargs_method("getPoint", &View3DInventorViewerPy::getPoint, "getPoint(x, y) -> Base::Vector(x,y,z)");
+    add_varargs_method("getPickRadius", &View3DInventorViewerPy::getPickRadius,
+        "getPickRadius(): returns radius of confusion in pixels for picking objects on screen (selection).");
+    add_varargs_method("setPickRadius", &View3DInventorViewerPy::setPickRadius,
+        "setPickRadius(new_radius): sets radius of confusion in pixels for picking objects on screen (selection).");
 }
 
 View3DInventorViewerPy::View3DInventorViewerPy(View3DInventorViewer *vi)
@@ -314,5 +318,39 @@ Py::Object View3DInventorViewerPy::getPoint(const Py::Tuple& args)
     }
     catch (const Py::Exception&) {
         throw;
+    }
+}
+
+Py::Object View3DInventorViewerPy::getPickRadius(const Py::Tuple& args)
+{
+    if (!PyArg_ParseTuple(args.ptr(), ""))
+        throw Py::Exception();
+
+    double d = _viewer->getPickRadius();
+    return Py::Float(d);
+}
+
+Py::Object View3DInventorViewerPy::setPickRadius(const Py::Tuple& args)
+{
+    float r = 0.0;
+    if (!PyArg_ParseTuple(args.ptr(), "f", &r)) {
+        throw Py::Exception();
+    }
+
+    if (r < 0.001){
+        throw Py::ValueError(std::string("Pick radius is zero or negative; positive number is required."));
+    }
+    try {
+        _viewer->setPickRadius(r);
+        return Py::None();
+    }
+    catch (const Base::Exception& e) {
+        throw Py::Exception(e.what());
+    }
+    catch (const std::exception& e) {
+        throw Py::Exception(e.what());
+    }
+    catch(...) {
+        throw Py::Exception("Unknown C++ exception");
     }
 }

--- a/src/Gui/View3DViewerPy.h
+++ b/src/Gui/View3DViewerPy.h
@@ -62,6 +62,8 @@ public:
     Py::Object setFocalDistance(const Py::Tuple& args);
     Py::Object getFocalDistance(const Py::Tuple& args);
     Py::Object getPoint(const Py::Tuple& args);
+    Py::Object getPickRadius(const Py::Tuple& args);
+    Py::Object setPickRadius(const Py::Tuple& args);
 
 
 

--- a/src/Gui/ViewProvider.cpp
+++ b/src/Gui/ViewProvider.cpp
@@ -416,6 +416,7 @@ SoPickedPoint* ViewProvider::getPointOnRay(const SbVec2s& pos, const View3DInven
     //get the picked point
     SoRayPickAction rp(viewer->getSoRenderManager()->getViewportRegion());
     rp.setPoint(pos);
+    rp.setRadius(viewer->getPickRadius());
     rp.apply(root);
     root->unref();
     trans->unref();
@@ -452,6 +453,7 @@ SoPickedPoint* ViewProvider::getPointOnRay(const SbVec3f& pos,const SbVec3f& dir
     //get the picked point
     SoRayPickAction rp(viewer->getSoRenderManager()->getViewportRegion());
     rp.setRay(pos,dir);
+    rp.setRadius(viewer->getPickRadius());
     rp.apply(root);
     root->unref();
     trans->unref();

--- a/src/Gui/ViewProviderGeometryObject.cpp
+++ b/src/Gui/ViewProviderGeometryObject.cpp
@@ -371,6 +371,7 @@ SoPickedPointList ViewProviderGeometryObject::getPickedPoints(const SbVec2s& pos
 
     SoRayPickAction rp(viewer.getSoRenderManager()->getViewportRegion());
     rp.setPickAll(pickAll);
+    rp.setRadius(viewer.getPickRadius());
     rp.setPoint(pos);
     rp.apply(root);
     root->unref();
@@ -389,6 +390,7 @@ SoPickedPoint* ViewProviderGeometryObject::getPickedPoint(const SbVec2s& pos, co
 
     SoRayPickAction rp(viewer.getSoRenderManager()->getViewportRegion());
     rp.setPoint(pos);
+    rp.setRadius(viewer.getPickRadius());
     rp.apply(root);
     root->unref();
 

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -277,8 +277,8 @@ ViewProviderSketch::ViewProviderSketch()
 
     zCross=0.001f;
     zLines=0.005f;
-    zConstr=0.006f; // constraint not construction
-    zHighLine=0.007f;
+    zConstr=0.007f; // constraint not construction
+    zHighLine=0.006f;
     zPoints=0.008f;
     zHighlight=0.009f;
     zText=0.011f;


### PR DESCRIPTION
asked for in 
http://forum.freecadweb.org/viewtopic.php?f=8&t=16251
I also recall older threads about it.
I want it especially, because things are almost impossible to select on touchscreen.
Bug that I found: http://www.freecadweb.org/tracker/view.php?id=1203

![selection pick radius](https://cloud.githubusercontent.com/assets/8940427/16249381/657645a2-3826-11e6-9319-b58d9731f8f3.png)

Pull-request thread:
http://forum.freecadweb.org/viewtopic.php?f=17&t=16275
