### PR TITLE
Added the Open CASCADE TKCDF library required to build SMESH with OCC…

### DIFF
--- a/cMake/FindOpenCasCade.cmake
+++ b/cMake/FindOpenCasCade.cmake
@@ -12,9 +12,9 @@ if(NOT DEFINED OCE_DIR)
   # Check for OSX needs to come first because UNIX evaluates to true on OSX
   if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     if(DEFINED MACPORTS_PREFIX)
-      find_package(OCE HINTS ${MACPORTS_PREFIX}/Library/Frameworks)
+      find_package(OCE QUIET HINTS ${MACPORTS_PREFIX}/Library/Frameworks)
     elseif(DEFINED HOMEBREW_PREFIX)
-      find_package(OCE HINTS ${HOMEBREW_PREFIX}/Cellar/oce/*)
+      find_package(OCE QUIET HINTS ${HOMEBREW_PREFIX}/Cellar/oce/*)
     endif()
   elseif(UNIX)
     set(OCE_DIR "/usr/local/share/cmake/")
@@ -112,6 +112,7 @@ if(OCC_FOUND)
     TKBin
     TKBool
     TKBO
+    TKCDF
     TKBRep
     TKTopAlgo
     TKGeomAlgo


### PR DESCRIPTION
The TKCDF library is required to build SMESH with OCCT7.  Within this change, I  have also 'quiet'ed the search for OCE because failure to locate OCE at that point in the search is non-fatal.  

This change is compatible with both OCCT6 and OCCT7.