### PR TITLE
Remove gcc from build matrix because it always times out on Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,6 @@ language: cpp
 
 compiler:
    - clang
-   - gcc
 
 python: 2.7
 
@@ -37,11 +36,6 @@ os:
 
 dist: trusty
 sudo: required
-
-matrix:
-   exclude:
-     - os: osx
-       compiler: gcc
 
 git:
   depth: 1500


### PR DESCRIPTION
The gcc builds routinely timeout on Travis-CI leading to numerous false-negatives and also wastes precious Travis-CI resources.  In order to be better Travis citizens and eliminate the false-negatives, I recommend that we disable gcc builds on Travis.