### PR TITLE
Leverage ccache to reduce build times (both locally and on Travis-ci)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,10 +23,14 @@ env:
   matrix:
     - CMAKE_OPTS="-DBUILD_FEM_NETGEN=ON"
 
+cache:
+    - ccache
+
 language: cpp
 
 compiler:
    - clang
+   - gcc
 
 python: 2.7
 
@@ -36,6 +40,11 @@ os:
 
 dist: trusty
 sudo: required
+
+matrix:
+   exclude:
+     - os: osx
+       compiler: gcc
 
 git:
   depth: 1500
@@ -93,16 +102,24 @@ before_install:
                                swig                             \
                                libvtk6-dev                      \
                                libmed-dev                       \
-                               libmedc-dev                      
-                               
+                               libmedc-dev			\
+                               asciidoc
+
        #Patch the system - there is a bug related to invalid location of libs on ubuntu 12.04
        sudo ln -s /usr/lib/x86_64-linux-gnu/ /usr/lib/i386-linux-gnu
        sudo find /usr/lib -name libpq.so -exec ln -s {} /usr/lib/libpq.so ';'
        export DISPLAY=:99.0
        sh -e /etc/init.d/xvfb start
 
-       CMAKE_ARGS="${CMAKE_OPTS} -DPYTHON_EXECUTABLE=/usr/bin/python"
-       INSTALLED_APP_PATH="/usr/local/bin/FreeCAD"
+       #Install ccache to reduce successive build times (use 3.2.5+ to avoid spurious warnings)
+       curl -L -o ccache.tgz "https://codeload.github.com/ccache/ccache/tar.gz/v3.2.5"
+       tar xvzf ccache.tgz && rm ccache.tgz && cd ccache-*
+       ./autogen.sh && ./configure CC=gcc && sudo make install
+       cd ..
+
+       export CCACHE_CPP2=YES
+       export CMAKE_ARGS="${CMAKE_OPTS} -DPYTHON_EXECUTABLE=/usr/bin/python"
+       export INSTALLED_APP_PATH="/usr/local/bin/FreeCAD"
        ;;
 
    "osx")
@@ -123,7 +140,8 @@ before_install:
                     orocos-kdl                  \
                     hdf5                        \
                     homebrew/science/oce        \
-                    homebrew/python/matplotlib
+                    homebrew/python/matplotlib  \
+                    ccache
        brew install homebrew/science/nglib --with-oce
        brew install sanelson/freecad/coin --without-framework --without-soqt
        brew install sanelson/freecad/pivy --HEAD
@@ -140,8 +158,8 @@ before_install:
        #Remove GDAL if installed because it results in non-existent dependent library exceptions
        if [ -e /usr/local/lib/libgdal.1.dylib ]; then brew unlink gdal; fi
 
-       CMAKE_ARGS="${CMAKE_OPTS} -DFREECAD_USE_EXTERNAL_KDL=ON -DFREECAD_CREATE_MAC_APP=ON"
-       INSTALLED_APP_PATH="/usr/local/FreeCAD.app/Contents/bin/FreeCAD"
+       export CMAKE_ARGS="${CMAKE_OPTS} -DFREECAD_USE_EXTERNAL_KDL=ON -DFREECAD_CREATE_MAC_APP=ON"
+       export INSTALLED_APP_PATH="/usr/local/FreeCAD.app/Contents/bin/FreeCAD"
        ;;
 
    *)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,11 @@ if(COMMAND cmake_policy)
     endif(POLICY CMP0045)
 endif(COMMAND cmake_policy)
 
+find_program(CCACHE_PROGRAM ccache)  #This check should occur before project()
+if(CCACHE_PROGRAM)
+    set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "${CCACHE_PROGRAM}")
+endif()
+
 # include local  modules
 include(AddFileDependencies)
 include(cMake/FreeCadMacros.cmake)


### PR DESCRIPTION
This pull request enables [ccache](https://ccache.samba.org) for travis and local builds greatly reducing successive build times to less than 12 minutes once the cache is primed.  In addition, the great folks over at Travis have increased the time limit on the FreeCAD repo to 90 minutes allowing enough time to prime the cache for GCC builds so this pull request also re-enables GCC builds.  Developers can reap the benefits by installing [ccache](https://ccache.samba.org) on their local system.  ccache will provide significant benefits, especially for developers who switch between git branches and suffer long rebuilds as a consequence.

**Results without caching (building the initial cache)**
<img width="1263" alt="screen shot 2016-07-04 at 5 03 53 pm" src="https://cloud.githubusercontent.com/assets/6841373/16571330/f4608a92-420e-11e6-8c12-7c86d27fdaa5.png">

**Results with caching (after that cache has been primed)**
<img width="1256" alt="screen shot 2016-07-04 at 5 21 11 pm" src="https://cloud.githubusercontent.com/assets/6841373/16571332/f8e584f0-420e-11e6-9fc3-3fd642732cc3.png">
