### PR TITLE
Build FreeCAD for OS X with OCCT7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -129,7 +129,9 @@ before_install:
             cacheContext=$(create_helper_context repo=${OSX_PORTS_CACHE} auth_token=${GH_TOKEN} release=${FREECAD_RELEASE})
             prime_local_ports_cache $cacheContext
        fi
-       brew install eigen                       \
+       brew install cmake                       \
+                    ccache                      \
+                    eigen                       \
                     freetype                    \
                     qt                          \
                     python                      \
@@ -137,16 +139,17 @@ before_install:
                     pyside                      \
                     pyside-tools                \
                     xerces-c                    \
-                    orocos-kdl                  \
-                    hdf5                        \
-                    homebrew/science/oce        \
-                    homebrew/python/matplotlib  \
-                    ccache
-       brew install homebrew/science/nglib --with-oce
+                    homebrew/science/orocos-kdl \
+                    homebrew/python/matplotlib
        brew install sanelson/freecad/coin --without-framework --without-soqt
        brew install sanelson/freecad/pivy --HEAD
        brew install bblacey/taps/med-file --without-python
-       travis_wait 30 brew install vtk --without-python
+
+       #Install ports bottled with FreeCAD specific options and hosted on FreeCAD-ports-cache
+       brew untap homebrew/science && brew tap bblacey/science
+       brew install --force-bottle vtk --without-python
+       brew install --force-bottle opencascade --without-extras
+       brew install --force-bottle nglib --with-opencascade
 
        #Install the 3DConnexion frameworks
        if [ ! -d /Library/Frameworks/3DconnexionClient.framework ]; then


### PR DESCRIPTION
Given the inevitable migration to OCCT 7.0 in FreeCAD 0.17, there is benefit of defaulting to OCCT 7.0 on at least one of our platforms at this point in the development cycle to cover a broader regression suite (clang, GCC, OCCT6.x and OCCT7).  Furthermore, OCCT7 is a very straight-forward integration into the OS X FreeCAD product dependencies (e.g. the [FreeCAD-ports-cache](https://github.com/FreeCAD/FreeCAD-ports-cache) has already been updated accordingly), resolves some long-standing issues on OS X that we have had to previously work-around and is "development" qualified through active use by a number of prominent OS X users over the past several weeks.

Representative [build](https://travis-ci.org/bblacey/FreeCAD-MacOS-CI/jobs/142896695):
```
OS: Mac OS X
Word size of OS: 64-bit
Word size of FreeCAD: 64-bit
Version: 0.17.7824 (Git)
Build type: Release
Branch: (detached from e0f8acd)
Hash: e0f8acd26755ba7969293390ee53f2c9801ad419
Python version: 2.7.11
Qt version: 4.8.7
Coin version: 3.1.3
OCC version: 7.0.0
```

**Note:**  I purposefully updated the FreeCAD-ports-cache with the OCCT 7.0 dependencies so this pull-request will build successfully before and after merge into master.