### PR TITLE
refuse to create partdesign objects if no active body in document

### DIFF
--- a/src/Mod/PartDesign/Gui/Command.cpp
+++ b/src/Mod/PartDesign/Gui/Command.cpp
@@ -870,9 +870,7 @@ CmdPartDesignPad::CmdPartDesignPad()
 
 void CmdPartDesignPad::activated(int iMsg)
 {
-	App::Document *doc = getDocument();
-	PartDesign::Body *pcActiveBody = PartDesignGui::getBody(
-		/*messageIfNot = */ PartDesignGui::assureModernWorkflow(doc));
+	PartDesign::Body *pcActiveBody = PartDesignGui::getBody(/*messageIfNot = */ true);
 
 	// No PartDesign feature without Body past FreeCAD 0.13
 	if (!pcActiveBody)
@@ -927,14 +925,11 @@ CmdPartDesignPocket::CmdPartDesignPocket()
 
 void CmdPartDesignPocket::activated(int iMsg)
 {
-	App::Document *doc = getDocument();
-	PartDesign::Body *pcActiveBody = PartDesignGui::getBody(
-		/*messageIfNot = */ PartDesignGui::assureModernWorkflow(doc));
+	PartDesign::Body *pcActiveBody = PartDesignGui::getBody(/*messageIfNot = */ true);
 
 	// No PartDesign feature without Body past FreeCAD 0.13
 	if (!pcActiveBody)
 		return;
-
     Gui::Command* cmd = this;
     auto worker = [cmd](Part::Feature* sketch, std::string FeatName) {
 
@@ -972,9 +967,7 @@ CmdPartDesignRevolution::CmdPartDesignRevolution()
 
 void CmdPartDesignRevolution::activated(int iMsg)
 {
-	App::Document *doc = getDocument();
-	PartDesign::Body *pcActiveBody = PartDesignGui::getBody(
-		/*messageIfNot = */ PartDesignGui::assureModernWorkflow(doc));
+	PartDesign::Body *pcActiveBody = PartDesignGui::getBody(/*messageIfNot = */ true);
 
 	// No PartDesign feature without Body past FreeCAD 0.13
 	if (!pcActiveBody)
@@ -1023,9 +1016,7 @@ CmdPartDesignGroove::CmdPartDesignGroove()
 
 void CmdPartDesignGroove::activated(int iMsg)
 {
-	App::Document *doc = getDocument();
-	PartDesign::Body *pcActiveBody = PartDesignGui::getBody(
-		/*messageIfNot = */ PartDesignGui::assureModernWorkflow(doc));
+	PartDesign::Body *pcActiveBody = PartDesignGui::getBody(/*messageIfNot = */ true);
 
 	// No PartDesign feature without Body past FreeCAD 0.13
 	if (!pcActiveBody)
@@ -1074,9 +1065,7 @@ CmdPartDesignAdditivePipe::CmdPartDesignAdditivePipe()
 
 void CmdPartDesignAdditivePipe::activated(int iMsg)
 {
-	App::Document *doc = getDocument();
-	PartDesign::Body *pcActiveBody = PartDesignGui::getBody(
-		/*messageIfNot = */ PartDesignGui::assureModernWorkflow(doc));
+	PartDesign::Body *pcActiveBody = PartDesignGui::getBody(/*messageIfNot = */ true);
 
 	// No PartDesign feature without Body past FreeCAD 0.13
 	if (!pcActiveBody)
@@ -1122,9 +1111,7 @@ CmdPartDesignSubtractivePipe::CmdPartDesignSubtractivePipe()
 
 void CmdPartDesignSubtractivePipe::activated(int iMsg)
 {
-	App::Document *doc = getDocument();
-	PartDesign::Body *pcActiveBody = PartDesignGui::getBody(
-		/*messageIfNot = */ PartDesignGui::assureModernWorkflow(doc));
+	PartDesign::Body *pcActiveBody = PartDesignGui::getBody(/*messageIfNot = */ true);
 
 	// No PartDesign feature without Body past FreeCAD 0.13
 	if (!pcActiveBody)
@@ -1170,9 +1157,7 @@ CmdPartDesignAdditiveLoft::CmdPartDesignAdditiveLoft()
 
 void CmdPartDesignAdditiveLoft::activated(int iMsg)
 {
-	App::Document *doc = getDocument();
-	PartDesign::Body *pcActiveBody = PartDesignGui::getBody(
-		/*messageIfNot = */ PartDesignGui::assureModernWorkflow(doc));
+	PartDesign::Body *pcActiveBody = PartDesignGui::getBody(/*messageIfNot = */ true);
 
 	// No PartDesign feature without Body past FreeCAD 0.13
 	if (!pcActiveBody)
@@ -1218,12 +1203,10 @@ CmdPartDesignSubtractiveLoft::CmdPartDesignSubtractiveLoft()
 
 void CmdPartDesignSubtractiveLoft::activated(int iMsg)
 {
-	App::Document *doc = getDocument();
-	PartDesign::Body *pcActiveBody = PartDesignGui::getBody(
-		/*messageIfNot = */ PartDesignGui::assureModernWorkflow(doc));
-
+	PartDesign::Body *pcActiveBody = PartDesignGui::getBody(/*messageIfNot = */ true);
+	
 	// No PartDesign feature without Body past FreeCAD 0.13
-	if (!pcActiveBody)
+	if (!pcActiveBody) 
 		return;
 
     Gui::Command* cmd = this;

--- a/src/Mod/PartDesign/Gui/Command.cpp
+++ b/src/Mod/PartDesign/Gui/Command.cpp
@@ -870,6 +870,14 @@ CmdPartDesignPad::CmdPartDesignPad()
 
 void CmdPartDesignPad::activated(int iMsg)
 {
+	App::Document *doc = getDocument();
+	PartDesign::Body *pcActiveBody = PartDesignGui::getBody(
+		/*messageIfNot = */ PartDesignGui::assureModernWorkflow(doc));
+
+	// No PartDesign feature without Body past FreeCAD 0.13
+	if (!pcActiveBody)
+		return;
+
     Gui::Command* cmd = this;
     auto worker = [cmd](Part::Feature* profile, std::string FeatName) {
 
@@ -919,6 +927,14 @@ CmdPartDesignPocket::CmdPartDesignPocket()
 
 void CmdPartDesignPocket::activated(int iMsg)
 {
+	App::Document *doc = getDocument();
+	PartDesign::Body *pcActiveBody = PartDesignGui::getBody(
+		/*messageIfNot = */ PartDesignGui::assureModernWorkflow(doc));
+
+	// No PartDesign feature without Body past FreeCAD 0.13
+	if (!pcActiveBody)
+		return;
+
     Gui::Command* cmd = this;
     auto worker = [cmd](Part::Feature* sketch, std::string FeatName) {
 
@@ -956,6 +972,14 @@ CmdPartDesignRevolution::CmdPartDesignRevolution()
 
 void CmdPartDesignRevolution::activated(int iMsg)
 {
+	App::Document *doc = getDocument();
+	PartDesign::Body *pcActiveBody = PartDesignGui::getBody(
+		/*messageIfNot = */ PartDesignGui::assureModernWorkflow(doc));
+
+	// No PartDesign feature without Body past FreeCAD 0.13
+	if (!pcActiveBody)
+		return;
+
     Gui::Command* cmd = this;
     auto worker = [cmd](Part::Feature* sketch, std::string FeatName) {
 
@@ -999,6 +1023,14 @@ CmdPartDesignGroove::CmdPartDesignGroove()
 
 void CmdPartDesignGroove::activated(int iMsg)
 {
+	App::Document *doc = getDocument();
+	PartDesign::Body *pcActiveBody = PartDesignGui::getBody(
+		/*messageIfNot = */ PartDesignGui::assureModernWorkflow(doc));
+
+	// No PartDesign feature without Body past FreeCAD 0.13
+	if (!pcActiveBody)
+		return;
+
     Gui::Command* cmd = this;
     auto worker = [cmd](Part::Feature* sketch, std::string FeatName) {
 
@@ -1042,6 +1074,14 @@ CmdPartDesignAdditivePipe::CmdPartDesignAdditivePipe()
 
 void CmdPartDesignAdditivePipe::activated(int iMsg)
 {
+	App::Document *doc = getDocument();
+	PartDesign::Body *pcActiveBody = PartDesignGui::getBody(
+		/*messageIfNot = */ PartDesignGui::assureModernWorkflow(doc));
+
+	// No PartDesign feature without Body past FreeCAD 0.13
+	if (!pcActiveBody)
+		return;
+
     Gui::Command* cmd = this;
     auto worker = [cmd](Part::Feature* sketch, std::string FeatName) {
 
@@ -1082,6 +1122,14 @@ CmdPartDesignSubtractivePipe::CmdPartDesignSubtractivePipe()
 
 void CmdPartDesignSubtractivePipe::activated(int iMsg)
 {
+	App::Document *doc = getDocument();
+	PartDesign::Body *pcActiveBody = PartDesignGui::getBody(
+		/*messageIfNot = */ PartDesignGui::assureModernWorkflow(doc));
+
+	// No PartDesign feature without Body past FreeCAD 0.13
+	if (!pcActiveBody)
+		return;
+
     Gui::Command* cmd = this;
     auto worker = [cmd](Part::Feature* sketch, std::string FeatName) {
 
@@ -1122,6 +1170,14 @@ CmdPartDesignAdditiveLoft::CmdPartDesignAdditiveLoft()
 
 void CmdPartDesignAdditiveLoft::activated(int iMsg)
 {
+	App::Document *doc = getDocument();
+	PartDesign::Body *pcActiveBody = PartDesignGui::getBody(
+		/*messageIfNot = */ PartDesignGui::assureModernWorkflow(doc));
+
+	// No PartDesign feature without Body past FreeCAD 0.13
+	if (!pcActiveBody)
+		return;
+
     Gui::Command* cmd = this;
     auto worker = [cmd](Part::Feature* sketch, std::string FeatName) {
 
@@ -1162,6 +1218,14 @@ CmdPartDesignSubtractiveLoft::CmdPartDesignSubtractiveLoft()
 
 void CmdPartDesignSubtractiveLoft::activated(int iMsg)
 {
+	App::Document *doc = getDocument();
+	PartDesign::Body *pcActiveBody = PartDesignGui::getBody(
+		/*messageIfNot = */ PartDesignGui::assureModernWorkflow(doc));
+
+	// No PartDesign feature without Body past FreeCAD 0.13
+	if (!pcActiveBody)
+		return;
+
     Gui::Command* cmd = this;
     auto worker = [cmd](Part::Feature* sketch, std::string FeatName) {
 

--- a/src/Mod/PartDesign/Gui/Command.cpp
+++ b/src/Mod/PartDesign/Gui/Command.cpp
@@ -870,10 +870,12 @@ CmdPartDesignPad::CmdPartDesignPad()
 
 void CmdPartDesignPad::activated(int iMsg)
 {
-	PartDesign::Body *pcActiveBody = PartDesignGui::getBody(/*messageIfNot = */ true);
+	App::Document *doc = getDocument();
+	PartDesign::Body *pcActiveBody = PartDesignGui::getBody(
+		/*messageIfNot = */ PartDesignGui::assureModernWorkflow(doc));
 
-	// No PartDesign feature without Body past FreeCAD 0.13
-	if (!pcActiveBody)
+	// No PartDesign feature without Body past FreeCAD 0.16
+	if (!pcActiveBody && PartDesignGui::isModernWorkflow(doc))
 		return;
 
     Gui::Command* cmd = this;
@@ -925,11 +927,14 @@ CmdPartDesignPocket::CmdPartDesignPocket()
 
 void CmdPartDesignPocket::activated(int iMsg)
 {
-	PartDesign::Body *pcActiveBody = PartDesignGui::getBody(/*messageIfNot = */ true);
+	App::Document *doc = getDocument();
+	PartDesign::Body *pcActiveBody = PartDesignGui::getBody(
+		/*messageIfNot = */ PartDesignGui::assureModernWorkflow(doc));
 
-	// No PartDesign feature without Body past FreeCAD 0.13
-	if (!pcActiveBody)
+	// No PartDesign feature without Body past FreeCAD 0.16
+	if (!pcActiveBody && PartDesignGui::isModernWorkflow(doc))
 		return;
+
     Gui::Command* cmd = this;
     auto worker = [cmd](Part::Feature* sketch, std::string FeatName) {
 
@@ -967,10 +972,12 @@ CmdPartDesignRevolution::CmdPartDesignRevolution()
 
 void CmdPartDesignRevolution::activated(int iMsg)
 {
-	PartDesign::Body *pcActiveBody = PartDesignGui::getBody(/*messageIfNot = */ true);
+	App::Document *doc = getDocument();
+	PartDesign::Body *pcActiveBody = PartDesignGui::getBody(
+		/*messageIfNot = */ PartDesignGui::assureModernWorkflow(doc));
 
-	// No PartDesign feature without Body past FreeCAD 0.13
-	if (!pcActiveBody)
+	// No PartDesign feature without Body past FreeCAD 0.16
+	if (!pcActiveBody && PartDesignGui::isModernWorkflow(doc))
 		return;
 
     Gui::Command* cmd = this;
@@ -1016,10 +1023,11 @@ CmdPartDesignGroove::CmdPartDesignGroove()
 
 void CmdPartDesignGroove::activated(int iMsg)
 {
-	PartDesign::Body *pcActiveBody = PartDesignGui::getBody(/*messageIfNot = */ true);
+	App::Document *doc = getDocument();
+	PartDesign::Body *pcActiveBody = PartDesignGui::getBody(
+		/*messageIfNot = */ PartDesignGui::assureModernWorkflow(doc));
 
-	// No PartDesign feature without Body past FreeCAD 0.13
-	if (!pcActiveBody)
+	if (!pcActiveBody && PartDesignGui::isModernWorkflow(doc))
 		return;
 
     Gui::Command* cmd = this;


### PR DESCRIPTION
One more try to fix the bug http://freecadweb.org/tracker/view.php?id=2533
Fixes following commands: Add/Sub. Lofts, Add./Sub. Pipes, Pad/Pocket, Revolution/Groove