### PR TITLE
Color Preferences

### DIFF
--- a/src/Mod/TechDraw/App/DrawViewPart.cpp
+++ b/src/Mod/TechDraw/App/DrawViewPart.cpp
@@ -245,7 +245,9 @@ void DrawViewPart::extractFaces()
     std::vector<TechDrawGeometry::BaseGeom*>::const_iterator itEdge = goEdges.begin();
     std::vector<TopoDS_Edge> origEdges;
     for (;itEdge != goEdges.end(); itEdge++) {
-        origEdges.push_back((*itEdge)->occEdge);
+        if ((*itEdge)->visible) {                        //don't make invisible faces!
+            origEdges.push_back((*itEdge)->occEdge);
+        }
     }
 
     std::vector<TopoDS_Edge> faceEdges = origEdges;
@@ -659,10 +661,22 @@ bool DrawViewPart::hasGeometry(void) const
 
 Base::Vector3d DrawViewPart::getValidXDir() const
 {
+    Base::Vector3d X(1.0,0.0,0.0);
+    Base::Vector3d Y(1.0,0.0,0.0);
     Base::Vector3d xDir = XAxisDirection.getValue();
-    if (xDir.Length() == 0) {
+    if (xDir.Length() < Precision::Confusion()) {
         Base::Console().Warning("XAxisDirection has zero length - using (1,0,0)\n");
-        xDir = Base::Vector3d(1.0,0.0,0.0);
+        xDir = X;
+    }
+    Base::Vector3d viewDir = Direction.getValue();
+    if ((xDir - viewDir).Length() < Precision::Confusion()) {
+        if (xDir == X) {
+            xDir = Y;
+        }else{
+            xDir = X;
+        }
+        Base::Console().Warning("XAxisDirection cannot equal Direction - using (%.3f,%.3f%.3f)\n",
+                                 xDir.x,xDir.y,xDir.z);
     }
     return xDir;
 }

--- a/src/Mod/TechDraw/Gui/DlgPrefsTechDraw.ui
+++ b/src/Mod/TechDraw/Gui/DlgPrefsTechDraw.ui
@@ -197,12 +197,20 @@
      </item>
      <item row="1" column="1">
       <widget class="Gui::PrefComboBox" name="cb_HidLine">
+       <property name="currentIndex">
+        <number>1</number>
+       </property>
        <property name="prefEntry" stdset="0">
         <cstring>HiddenLine</cstring>
        </property>
        <property name="prefPath" stdset="0">
         <cstring>Mod/TechDraw</cstring>
        </property>
+       <item>
+        <property name="text">
+         <string>NeverShow</string>
+        </property>
+       </item>
        <item>
         <property name="text">
          <string>Solid</string>

--- a/src/Mod/TechDraw/Gui/QGCustomText.cpp
+++ b/src/Mod/TechDraw/Gui/QGCustomText.cpp
@@ -104,3 +104,34 @@ void QGCustomText::paint ( QPainter * painter, const QStyleOptionGraphicsItem * 
 
     QGraphicsTextItem::paint (painter, &myOption, widget);
 }
+
+QColor QGCustomText::getNormalColor()
+{
+    Base::Reference<ParameterGrp> hGrp = getParmGroup();
+    App::Color fcColor;
+    fcColor.setPackedValue(hGrp->GetUnsigned("NormalColor", 0x00000000));
+    return fcColor.asValue<QColor>();
+}
+
+QColor QGCustomText::getPreColor()
+{
+    Base::Reference<ParameterGrp> hGrp = getParmGroup();
+    App::Color fcColor;
+    fcColor.setPackedValue(hGrp->GetUnsigned("PreSelectColor", 0xFFFF0000));
+    return fcColor.asValue<QColor>();
+}
+
+QColor QGCustomText::getSelectColor()
+{
+    Base::Reference<ParameterGrp> hGrp = getParmGroup();
+    App::Color fcColor;
+    fcColor.setPackedValue(hGrp->GetUnsigned("SelectColor", 0x00FF0000));
+    return fcColor.asValue<QColor>();
+}
+
+Base::Reference<ParameterGrp> QGCustomText::getParmGroup()
+{
+    Base::Reference<ParameterGrp> hGrp = App::GetApplication().GetUserParameter()
+        .GetGroup("BaseApp")->GetGroup("Preferences")->GetGroup("Mod/TechDraw/Colors");
+    return hGrp;
+}

--- a/src/Mod/TechDraw/Gui/QGCustomText.h
+++ b/src/Mod/TechDraw/Gui/QGCustomText.h
@@ -49,6 +49,10 @@ public:
     virtual void centerAt(double cX, double cY);
 
 protected:
+    QColor getNormalColor(void);
+    QColor getPreColor(void);
+    QColor getSelectColor(void);
+    Base::Reference<ParameterGrp> getParmGroup(void);
 
 private:
 
@@ -57,4 +61,3 @@ private:
 } // namespace MDIViewPageGui
 
 #endif // DRAWINGGUI_QGCUSTOMTEXT_H
-

--- a/src/Mod/TechDraw/Gui/QGIEdge.cpp
+++ b/src/Mod/TechDraw/Gui/QGIEdge.cpp
@@ -43,27 +43,13 @@
 using namespace TechDrawGui;
 
 QGIEdge::QGIEdge(int index) :
-    projIndex(index)
+    projIndex(index),
+    isCosmetic(false),
+    isHiddenEdge(false),
+    isSmoothEdge(false),
+    strokeWidth(1.0)
 {
-    strokeWidth = 1.;
-
-    isCosmetic    = false;
     m_pen.setCosmetic(isCosmetic);
-    isHiddenEdge = false;
-    isSmoothEdge = false;
-
-    Base::Reference<ParameterGrp> hGrp = App::GetApplication().GetUserParameter()
-        .GetGroup("BaseApp")->GetGroup("Preferences")->GetGroup("Mod/TechDraw/Colors");
-    m_defNormal = m_colNormal;
-    App::Color fcColor;
-    fcColor.setPackedValue(hGrp->GetUnsigned("HiddenColor", 0x08080800));
-    m_colHid = fcColor.asValue<QColor>();
-
-    hGrp = App::GetApplication().GetUserParameter().GetGroup("BaseApp")->GetGroup("Preferences")->GetGroup("Mod/TechDraw");
-    m_styleHid = static_cast<Qt::PenStyle> (hGrp->GetInt("HiddenLine",2));
-
-    //m_pen.setStyle(Qt::SolidLine);
-    //m_pen.setCapStyle(Qt::RoundCap);
 }
 
 QRectF QGIEdge::boundingRect() const
@@ -96,13 +82,36 @@ void QGIEdge::setStrokeWidth(float width) {
 void QGIEdge::setHiddenEdge(bool b) {
     isHiddenEdge = b;
     if (b) {
-        m_pen.setStyle(m_styleHid);
-        m_colNormal = m_colHid;
+        m_styleCurrent = getHiddenStyle();
     } else {
-        m_pen.setStyle(Qt::SolidLine);
-        m_colNormal = m_defNormal;
+        m_styleCurrent = Qt::SolidLine;
     }
     update();
+}
+
+void QGIEdge::setPrettyNormal() {
+    if (isHiddenEdge) {
+        m_colCurrent = getHiddenColor();
+    } else {
+        m_colCurrent = getNormalColor();
+    }
+    update();
+}
+
+QColor QGIEdge::getHiddenColor()
+{
+    Base::Reference<ParameterGrp> hGrp = App::GetApplication().GetUserParameter()
+        .GetGroup("BaseApp")->GetGroup("Preferences")->GetGroup("Mod/TechDraw/Colors");
+    App::Color fcColor = App::Color((uint32_t) hGrp->GetUnsigned("HiddenColor", 0x08080800));
+    return fcColor.asValue<QColor>();
+}
+
+Qt::PenStyle QGIEdge::getHiddenStyle()
+{
+    Base::Reference<ParameterGrp> hGrp = App::GetApplication().GetUserParameter().GetGroup("BaseApp")->
+                                         GetGroup("Preferences")->GetGroup("Mod/TechDraw");
+    Qt::PenStyle hidStyle = static_cast<Qt::PenStyle> (hGrp->GetInt("HiddenLine",2));
+    return hidStyle;
 }
 
 void QGIEdge::paint ( QPainter * painter, const QStyleOptionGraphicsItem * option, QWidget * widget) {

--- a/src/Mod/TechDraw/Gui/QGIEdge.h
+++ b/src/Mod/TechDraw/Gui/QGIEdge.h
@@ -49,6 +49,7 @@ public:
     bool getHiddenEdge() { return(isHiddenEdge); }
     void setSmoothEdge(bool b) { isSmoothEdge = b; }
     bool getSmoothEdge() { return(isSmoothEdge); }
+    virtual void setPrettyNormal();
 
 protected:
     int projIndex;                                                     //index of edge in Projection. must exist.
@@ -56,12 +57,11 @@ protected:
     bool isCosmetic;
     bool isHiddenEdge;
     bool isSmoothEdge;
+    QColor getHiddenColor();
+    Qt::PenStyle getHiddenStyle();
 
 private:
     float strokeWidth;
-    QColor m_colHid;
-    QColor m_defNormal;
-    Qt::PenStyle m_styleHid;
 };
 
 }

--- a/src/Mod/TechDraw/Gui/QGIFace.cpp
+++ b/src/Mod/TechDraw/Gui/QGIFace.cpp
@@ -61,7 +61,7 @@ QGIFace::QGIFace(int index) :
     setFlag(QGraphicsItem::ItemClipsChildrenToShape,true);
     //setFiltersChildEvents(true);
 
-    m_pen.setCosmetic(true);
+    m_styleCurrent = Qt::NoPen;    //don't draw face lines, just fill
 
     m_styleNormal = m_styleDef;
     m_colNormalFill = m_colDefFill;
@@ -88,13 +88,13 @@ void QGIFace::setPrettyNormal() {
 
 void QGIFace::setPrettyPre() {
     m_fillStyle = m_styleSelect;
-    m_fillColor = m_colPre;
+    m_fillColor = getPreColor();
     QGIPrimPath::setPrettyPre();
 }
 
 void QGIFace::setPrettySel() {
     m_fillStyle = m_styleSelect;
-    m_fillColor = m_colSel;
+    m_fillColor = getSelectColor();
     QGIPrimPath::setPrettySel();
 }
 

--- a/src/Mod/TechDraw/Gui/QGIPrimPath.cpp
+++ b/src/Mod/TechDraw/Gui/QGIPrimPath.cpp
@@ -34,7 +34,6 @@
 #include <App/Application.h>
 #include <App/Material.h>
 #include <Base/Console.h>
-#include <Base/Parameter.h>
 
 #include "QGIPrimPath.h"
 #include "QGIView.h"
@@ -51,21 +50,11 @@ QGIPrimPath::QGIPrimPath()
     setAcceptHoverEvents(true);
 
     isHighlighted = false;
-
-    Base::Reference<ParameterGrp> hGrp = App::GetApplication().GetUserParameter()
-        .GetGroup("BaseApp")->GetGroup("Preferences")->GetGroup("Mod/TechDraw/Colors");
-    App::Color fcColor;
-    fcColor.setPackedValue(hGrp->GetUnsigned("NormalColor", 0x00000000));
-    m_colNormal = fcColor.asValue<QColor>();
-    fcColor.setPackedValue(hGrp->GetUnsigned("SelectColor", 0x00FF0000));
-    m_colSel = fcColor.asValue<QColor>();
-    fcColor.setPackedValue(hGrp->GetUnsigned("PreSelectColor", 0xFFFF0000));
-    m_colPre = fcColor.asValue<QColor>();
-
     setPrettyNormal();
 
-    m_pen.setColor(m_colNormal);
-    m_pen.setStyle(Qt::SolidLine);
+    m_colCurrent = getNormalColor();
+    m_styleCurrent = Qt::SolidLine;
+    m_pen.setStyle(m_styleCurrent);
     m_pen.setCapStyle(Qt::RoundCap);
 }
 
@@ -110,17 +99,17 @@ void QGIPrimPath::setHighlighted(bool b)
 }
 
 void QGIPrimPath::setPrettyNormal() {
-    m_colCurrent = m_colNormal;
+    m_colCurrent = getNormalColor();
     update();
 }
 
 void QGIPrimPath::setPrettyPre() {
-    m_colCurrent = m_colPre;
+    m_colCurrent = getPreColor();
     update();
 }
 
 void QGIPrimPath::setPrettySel() {
-    m_colCurrent = m_colSel;
+    m_colCurrent = getSelectColor();
     update();
 }
 
@@ -129,6 +118,38 @@ void QGIPrimPath::paint ( QPainter * painter, const QStyleOptionGraphicsItem * o
     myOption.state &= ~QStyle::State_Selected;
 
     m_pen.setColor(m_colCurrent);
+    m_pen.setStyle(m_styleCurrent);
     setPen(m_pen);
     QGraphicsPathItem::paint (painter, &myOption, widget);
+}
+
+QColor QGIPrimPath::getNormalColor()
+{
+    Base::Reference<ParameterGrp> hGrp = getParmGroup();
+    App::Color fcColor;
+    fcColor.setPackedValue(hGrp->GetUnsigned("NormalColor", 0x00000000));
+    return fcColor.asValue<QColor>();
+}
+
+QColor QGIPrimPath::getPreColor()
+{
+    Base::Reference<ParameterGrp> hGrp = getParmGroup();
+    App::Color fcColor;
+    fcColor.setPackedValue(hGrp->GetUnsigned("PreSelectColor", 0xFFFF0000));
+    return fcColor.asValue<QColor>();
+}
+
+QColor QGIPrimPath::getSelectColor()
+{
+    Base::Reference<ParameterGrp> hGrp = getParmGroup();
+    App::Color fcColor;
+    fcColor.setPackedValue(hGrp->GetUnsigned("SelectColor", 0x00FF0000));
+    return fcColor.asValue<QColor>();
+}
+
+Base::Reference<ParameterGrp> QGIPrimPath::getParmGroup()
+{
+    Base::Reference<ParameterGrp> hGrp = App::GetApplication().GetUserParameter()
+        .GetGroup("BaseApp")->GetGroup("Preferences")->GetGroup("Mod/TechDraw/Colors");
+    return hGrp;
 }

--- a/src/Mod/TechDraw/Gui/QGIPrimPath.cpp
+++ b/src/Mod/TechDraw/Gui/QGIPrimPath.cpp
@@ -54,11 +54,12 @@ QGIPrimPath::QGIPrimPath()
 
     Base::Reference<ParameterGrp> hGrp = App::GetApplication().GetUserParameter()
         .GetGroup("BaseApp")->GetGroup("Preferences")->GetGroup("Mod/TechDraw/Colors");
-    App::Color fcColor = App::Color((uint32_t) hGrp->GetUnsigned("NormalColor", 0x00000000));
+    App::Color fcColor;
+    fcColor.setPackedValue(hGrp->GetUnsigned("NormalColor", 0x00000000));
     m_colNormal = fcColor.asValue<QColor>();
-    fcColor.setPackedValue(hGrp->GetUnsigned("SelectColor", 0x0000FF00));
+    fcColor.setPackedValue(hGrp->GetUnsigned("SelectColor", 0x00FF0000));
     m_colSel = fcColor.asValue<QColor>();
-    fcColor.setPackedValue(hGrp->GetUnsigned("PreSelectColor", 0x00080800));
+    fcColor.setPackedValue(hGrp->GetUnsigned("PreSelectColor", 0xFFFF0000));
     m_colPre = fcColor.asValue<QColor>();
 
     setPrettyNormal();

--- a/src/Mod/TechDraw/Gui/QGIPrimPath.h
+++ b/src/Mod/TechDraw/Gui/QGIPrimPath.h
@@ -23,12 +23,14 @@
 #ifndef DRAWINGGUI_QGIPRIMPATH_H
 #define DRAWINGGUI_QGIPRIMPATH_H
 
-# include <QGraphicsItem>
+#include <QGraphicsItem>
 
 QT_BEGIN_NAMESPACE
 class QPainter;
 class QStyleOptionGraphicsItem;
 QT_END_NAMESPACE
+
+#include <Base/Parameter.h>
 
 namespace TechDrawGui
 {
@@ -54,12 +56,15 @@ protected:
     void hoverLeaveEvent(QGraphicsSceneHoverEvent *event);
     QVariant itemChange(GraphicsItemChange change, const QVariant &value);
 
+    QColor getNormalColor(void);
+    QColor getPreColor(void);
+    QColor getSelectColor(void);
+    Base::Reference<ParameterGrp> getParmGroup(void);
+
     bool isHighlighted;
     QPen m_pen;
     QColor m_colCurrent;
-    QColor m_colNormal;
-    QColor m_colPre;
-    QColor m_colSel;
+    Qt::PenStyle m_styleCurrent;
 
 private:
 

--- a/src/Mod/TechDraw/Gui/QGIView.cpp
+++ b/src/Mod/TechDraw/Gui/QGIView.cpp
@@ -77,11 +77,12 @@ QGIView::QGIView()
 
     Base::Reference<ParameterGrp> hGrp = App::GetApplication().GetUserParameter()
         .GetGroup("BaseApp")->GetGroup("Preferences")->GetGroup("Mod/TechDraw/Colors");
-    App::Color fcColor = App::Color((uint32_t) hGrp->GetUnsigned("NormalColor", 0x00000000));
+    App::Color fcColor;
+    fcColor.setPackedValue(hGrp->GetUnsigned("NormalColor", 0x00000000));
     m_colNormal = fcColor.asValue<QColor>();
-    fcColor.setPackedValue(hGrp->GetUnsigned("SelectColor", 0x0000FF00));
+    fcColor.setPackedValue(hGrp->GetUnsigned("SelectColor", 0x00FF00000));
     m_colSel = fcColor.asValue<QColor>();
-    fcColor.setPackedValue(hGrp->GetUnsigned("PreSelectColor", 0x00080800));
+    fcColor.setPackedValue(hGrp->GetUnsigned("PreSelectColor", 0xFFFF0000));
     m_colPre = fcColor.asValue<QColor>();
 
     m_colCurrent = m_colNormal;

--- a/src/Mod/TechDraw/Gui/QGIView.h
+++ b/src/Mod/TechDraw/Gui/QGIView.h
@@ -24,10 +24,11 @@
 #define DRAWINGGUI_QGRAPHICSITEMVIEW_H
 
 #include <QGraphicsItemGroup>
-#include <QObject>
 #include <QPen>
 #include <QFont>
+
 #include <App/PropertyLinks.h>
+#include <Base/Parameter.h>
 
 #include <Mod/TechDraw/App/DrawView.h>
 
@@ -87,6 +88,12 @@ protected:
     virtual void hoverEnterEvent(QGraphicsSceneHoverEvent *event);
     virtual void hoverLeaveEvent(QGraphicsSceneHoverEvent *event);
     virtual QRectF customChildrenBoundingRect(void);
+
+    QColor getNormalColor(void);
+    QColor getPreColor(void);
+    QColor getSelectColor(void);
+    QString getPrefFont(void);
+    Base::Reference<ParameterGrp> getParmGroupCol(void);
 
     TechDraw::DrawView *viewObj;
     std::string viewName;

--- a/src/Mod/TechDraw/Gui/QGIViewDimension.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewDimension.cpp
@@ -88,15 +88,6 @@ QGIDatumLabel::QGIDatumLabel(int ref, QGraphicsScene *scene  ) : reference(ref)
     setFlag(ItemIsMovable, true);
     setFlag(ItemIsSelectable, true);
     setAcceptHoverEvents(true);
-
-    Base::Reference<ParameterGrp> hGrp = App::GetApplication().GetUserParameter()
-        .GetGroup("BaseApp")->GetGroup("Preferences")->GetGroup("Mod/TechDraw/Colors");
-    App::Color fcColor = App::Color((uint32_t) hGrp->GetUnsigned("NormalColor", 0x00000000));
-    m_colNormal = fcColor.asValue<QColor>();
-    fcColor.setPackedValue(hGrp->GetUnsigned("SelectColor", 0x0000FF00));
-    m_colSel = fcColor.asValue<QColor>();
-    fcColor.setPackedValue(hGrp->GetUnsigned("PreSelectColor", 0x00080800));
-    m_colPre = fcColor.asValue<QColor>();
 }
 
 QVariant QGIDatumLabel::itemChange(GraphicsItemChange change, const QVariant &value)
@@ -104,10 +95,10 @@ QVariant QGIDatumLabel::itemChange(GraphicsItemChange change, const QVariant &va
     if (change == ItemSelectedHasChanged && scene()) {
         if(isSelected()) {
             Q_EMIT selected(true);
-            setDefaultTextColor(m_colSel);
+            setDefaultTextColor(getSelectColor());
         } else {
             Q_EMIT selected(false);
-            setDefaultTextColor(m_colNormal);
+            setDefaultTextColor(getNormalColor());
         }
         update();
     } else if(change == ItemPositionHasChanged && scene()) {
@@ -134,7 +125,7 @@ void QGIDatumLabel::setLabelCenter()
 void QGIDatumLabel::hoverEnterEvent(QGraphicsSceneHoverEvent *event)
 {
     Q_EMIT hover(true);
-    setDefaultTextColor(m_colPre);
+    setDefaultTextColor(getPreColor());
     update();
 }
 
@@ -145,7 +136,7 @@ void QGIDatumLabel::hoverLeaveEvent(QGraphicsSceneHoverEvent *event)
 
     Q_EMIT hover(false);
     if(!isSelected() && !view->isSelected()) {
-        setDefaultTextColor(m_colNormal);
+        setDefaultTextColor(getNormalColor());
         update();
     }
 }
@@ -192,15 +183,6 @@ QGIViewDimension::QGIViewDimension() :
 
     pen.setCosmetic(true);
     pen.setWidthF(1.);
-
-    Base::Reference<ParameterGrp> hGrp = App::GetApplication().GetUserParameter()
-        .GetGroup("BaseApp")->GetGroup("Preferences")->GetGroup("Mod/TechDraw/Colors");
-    App::Color fcColor = App::Color((uint32_t) hGrp->GetUnsigned("NormalColor", 0x00000000));
-    m_colNormal = fcColor.asValue<QColor>();
-    fcColor.setPackedValue(hGrp->GetUnsigned("SelectColor", 0x0000FF00));
-    m_colSel = fcColor.asValue<QColor>();
-    fcColor.setPackedValue(hGrp->GetUnsigned("PreSelectColor", 0x00080800));
-    m_colPre = fcColor.asValue<QColor>();
 
     addToGroup(arrows);
     addToGroup(datumLabel);
@@ -332,11 +314,11 @@ void QGIViewDimension::draw()
 
     // Crude method of determining state [TODO] improve
     if(isSelected()) {
-        pen.setColor(m_colSel);
+        pen.setColor(getSelectColor());
     } else if (hasHover) {
-        pen.setColor(m_colPre);
+        pen.setColor(getPreColor());
     } else {
-        pen.setColor(m_colNormal);
+        pen.setColor(getNormalColor());
     }
 
     QString labelText = lbl->toPlainText();

--- a/src/Mod/TechDraw/Gui/QGIViewDimension.h
+++ b/src/Mod/TechDraw/Gui/QGIViewDimension.h
@@ -119,9 +119,6 @@ protected:
     std::vector<QGraphicsItem*> arw;                                  //arrowheads
     std::vector<TechDrawGeometry::BaseGeom *> projGeom;
     QPen pen;
-    QColor m_colNormal;
-    QColor m_colPre;
-    QColor m_colSel;
 };
 
 } // namespace MDIViewPageGui

--- a/src/Mod/TechDraw/Gui/QGIViewPart.h
+++ b/src/Mod/TechDraw/Gui/QGIViewPart.h
@@ -26,9 +26,9 @@
 #include <QObject>
 #include <QPainter>
 
-#include "QGIView.h"
+#include <Base/Parameter.h>
 #include <Mod/TechDraw/App/Geometry.h>
-
+#include "QGIView.h"
 
 namespace TechDraw {
 class DrawViewPart;
@@ -85,8 +85,6 @@ protected:
 
     TechDraw::DrawHatch* faceIsHatched(int i,std::vector<TechDraw::DrawHatch*> hatchObjs) const;
     void dumpPath(const char* text,QPainterPath path);
-
-    QColor m_colHid;
 
 private:
     QList<QGraphicsItem*> deleteItems;


### PR DESCRIPTION
Get color/line style preferences at time of use instead of at object creation. 
Don't use invisible lines to make selectable faces.
Error message when project Direction == XAxisDirection.