### PR TITLE
fix some compilation errors

### DIFF
--- a/src/3rdParty/salomesmesh/src/SMESH/MED_V2_2_Wrapper.cpp
+++ b/src/3rdParty/salomesmesh/src/SMESH/MED_V2_2_Wrapper.cpp
@@ -2152,7 +2152,7 @@ namespace MED
           med_int myNbComp = MEDfieldnComponentByName(anId,&aFieldName);
           char *cname=new char[myNbComp*MED_SNAME_SIZE+1];
           char *unitname=new char[myNbComp*MED_SNAME_SIZE+1];
-          TInt aNbStamps;
+          med_int aNbStamps;
           MEDfieldInfoByName(anId,
                              &aFieldName,
                              aMeshName,
@@ -2266,7 +2266,7 @@ namespace MED
       med_int aNbComp = MEDfieldnComponentByName(myFile->Id(), &aFieldName);
       char *aCompName = new char[aNbComp*MED_SNAME_SIZE+1];
       char *aCompUnit = new char[aNbComp*MED_SNAME_SIZE+1];
-      TInt aNbStamps;
+      med_int aNbStamps;
       MEDfieldInfoByName(myFile->Id(),
                          &aFieldName,
                          &aMeshName,


### PR DESCRIPTION
I had this error when compiling:

/home/jose/freecad/src/3rdParty/salomesmesh/src/SMESH/MED_V2_2_Wrapper.cpp: In member function ‘virtual MED::TInt MED::V2_2::TVWrapper::GetNbTimeStamps(const MED::TFieldInfo&, const TEntityInfo&, MED::EEntiteMaillage&, MED::TGeom2Size&, MED::TErr*)’:
/home/jose/freecad/src/3rdParty/salomesmesh/src/SMESH/MED_V2_2_Wrapper.cpp:2164:40: error: cannot convert ‘MED::TInt* {aka int*}’ to ‘med_int* {aka long int*}’ for argument ‘9’ to ‘med_err MEDfieldInfoByName(med_idt, const char*, char*, med_bool*, med_field_type*, char*, char*, char*, med_int*)’
                              &aNbStamps);
                                        ^
/home/jose/freecad/src/3rdParty/salomesmesh/src/SMESH/MED_V2_2_Wrapper.cpp: In member function ‘virtual void MED::V2_2::TVWrapper::GetTimeStampInfo(MED::TInt, MED::TTimeStampInfo&, MED::TErr*)’:
/home/jose/freecad/src/3rdParty/salomesmesh/src/SMESH/MED_V2_2_Wrapper.cpp:2278:36: error: cannot convert ‘MED::TInt* {aka int*}’ to ‘med_int* {aka long int*}’ for argument ‘9’ to ‘med_err MEDfieldInfoByName(med_idt, const char*, char*, med_bool*, med_field_type*, char*, char*, char*, med_int*)’
                          &aNbStamps);
                                    ^
make[2]: *** [src/3rdParty/salomesmesh/CMakeFiles/SMESH.dir/build.make:231: src/3rdParty/salomesmesh/CMakeFiles/SMESH.dir/src/SMESH/MED_V2_2_Wrapper.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:536: src/3rdParty/salomesmesh/CMakeFiles/SMESH.dir/all] Error 2
make: *** [Makefile:128: all] Error 2