### PR TITLE
Prevent Hatch Export to SVG

### DIFF
--- a/src/Mod/TechDraw/Gui/MDIViewPage.cpp
+++ b/src/Mod/TechDraw/Gui/MDIViewPage.cpp
@@ -744,7 +744,7 @@ void MDIViewPage::print(QPrinter* printer)
     static_cast<void> (blockConnection(true)); // avoid to be notified by itself
     Gui::Selection().clearSelection();
 
-    m_view->toggleEdit(false);
+    m_view->toggleMarkers(false);
     m_view->scene()->update();
 
     Gui::Selection().clearSelection();
@@ -752,7 +752,7 @@ void MDIViewPage::print(QPrinter* printer)
     m_view->scene()->render(&p, rect);
 
     // Reset
-    m_view->toggleEdit(true);
+    m_view->toggleMarkers(true);
 }
 
 
@@ -812,7 +812,7 @@ QPrinter::PageSize MDIViewPage::getPageSize(int w, int h) const
 void MDIViewPage::setFrameState(bool state)
 {
     m_frameState = state;
-    m_view->toggleEdit(state);
+    m_view->toggleMarkers(state);
     m_view->scene()->update();
 }
 

--- a/src/Mod/TechDraw/Gui/QGIFace.cpp
+++ b/src/Mod/TechDraw/Gui/QGIFace.cpp
@@ -175,6 +175,17 @@ void QGIFace::setHatchColor(std::string c)
     m_svgCol = c;
 }
 
+//QtSvg does not handle clipping, so we must be able to turn the hatching on/off
+void QGIFace::toggleSvg(bool b)
+{
+    if (b) {
+        m_rect->show();
+    } else {
+        m_rect->hide();
+    }
+    update();
+}
+
 QRectF QGIFace::boundingRect() const
 {
     return shape().controlPointRect();

--- a/src/Mod/TechDraw/Gui/QGIFace.h
+++ b/src/Mod/TechDraw/Gui/QGIFace.h
@@ -65,6 +65,7 @@ public:
     void setPath(const QPainterPath & path);
     void buildHatch(void);
     void setHatchColor(std::string c);
+    void toggleSvg(bool b);
 
 protected:
     bool load(QByteArray *svgBytes);

--- a/src/Mod/TechDraw/Gui/QGITemplate.h
+++ b/src/Mod/TechDraw/Gui/QGITemplate.h
@@ -57,6 +57,7 @@ public:
     inline qreal getY() { return y() * -1; }
 
     virtual void updateView(bool update = false);
+    std::vector<TemplateTextField *> getTestFields(void) { return textFields; };
 
     virtual void draw() = 0;
 

--- a/src/Mod/TechDraw/Gui/QGIView.cpp
+++ b/src/Mod/TechDraw/Gui/QGIView.cpp
@@ -79,8 +79,8 @@ QGIView::QGIView()
     m_colCurrent = getNormalColor();
     m_pen.setColor(m_colCurrent);
 
+    //Border/Label styling
     m_font.setPointSize(5.0);     //scene units (mm), not points
-
     m_decorPen.setStyle(Qt::DashLine);
     m_decorPen.setWidth(0); // 0 => 1px "cosmetic pen"
 

--- a/src/Mod/TechDraw/Gui/QGIViewPart.h
+++ b/src/Mod/TechDraw/Gui/QGIViewPart.h
@@ -85,6 +85,7 @@ protected:
 
     TechDraw::DrawHatch* faceIsHatched(int i,std::vector<TechDraw::DrawHatch*> hatchObjs) const;
     void dumpPath(const char* text,QPainterPath path);
+    void removePrimitives(void);
 
 private:
     QList<QGraphicsItem*> deleteItems;

--- a/src/Mod/TechDraw/Gui/QGVPage.h
+++ b/src/Mod/TechDraw/Gui/QGVPage.h
@@ -85,7 +85,8 @@ public:
 
     TechDraw::DrawPage * getDrawPage();
 
-    void toggleEdit(bool enable);
+    void toggleMarkers(bool enable);
+    void toggleHatch(bool enable);
 
     /// Renders the page to SVG with filename.
     void saveSvg(QString filename);


### PR DESCRIPTION
1) QtSvg does not support clipping, so Hatch areas are mis-drawn on export. This change turns off the Hatch on SvgExport, then turns it back on.
2) Ensure delete of old QGraphicsItems in QGIViewPart