### PR TITLE
Fix 2628 Quantity::getUserString Fixed Precision

### DIFF
--- a/src/Base/UnitsSchemaCentimeters.cpp
+++ b/src/Base/UnitsSchemaCentimeters.cpp
@@ -27,6 +27,7 @@
 #endif
 
 #include <QString>
+#include <QLocale>
 #include "Exception.h"
 #include "UnitsApi.h"
 #include "UnitsSchemaCentimeters.h"
@@ -55,5 +56,9 @@ QString UnitsSchemaCentimeters::schemaTranslate(Base::Quantity quant,double &fac
         unitString = quant.getUnit().getString();
         factor = 1.0;
     }
-    return QString::fromUtf8("%L1 %2").arg(quant.getValue() / factor).arg(unitString);
+    //return QString::fromUtf8("%L1 %2").arg(quant.getValue() / factor).arg(unitString);
+    QLocale Lc = QLocale::system();
+    Lc.setNumberOptions(Lc.OmitGroupSeparator | Lc.RejectGroupSeparator);
+    QString Ln = Lc.toString((quant.getValue() / factor), 'f', Base::UnitsApi::getDecimals());
+    return QString::fromUtf8("%1 %2").arg(Ln).arg(unitString);
 }

--- a/src/Base/UnitsSchemaImperial1.cpp
+++ b/src/Base/UnitsSchemaImperial1.cpp
@@ -42,20 +42,20 @@ using namespace Base;
 
 //void UnitsSchemaImperial1::setSchemaUnits(void){
 //    // here you could change the constances used by the parser (defined in Quantity.cpp)
-//    Quantity::Inch =  Quantity (25.4          ,Unit(1));             
-//    Quantity::Foot =  Quantity (304.8         ,Unit(1));             
-//    Quantity::Thou =  Quantity (0.0254        ,Unit(1));             
-//    Quantity::Yard =  Quantity (914.4         ,Unit(1)); 
-//    Quantity::Mile =  Quantity (1609344.0     ,Unit(1)); 
+//    Quantity::Inch =  Quantity (25.4          ,Unit(1));
+//    Quantity::Foot =  Quantity (304.8         ,Unit(1));
+//    Quantity::Thou =  Quantity (0.0254        ,Unit(1));
+//    Quantity::Yard =  Quantity (914.4         ,Unit(1));
+//    Quantity::Mile =  Quantity (1609344.0     ,Unit(1));
 //}
 //
 //void UnitsSchemaImperial1::resetSchemaUnits(void){
 //    // set units to US customary / Imperial units
-//    Quantity::Inch =  Quantity (25.4          ,Unit(1));             
-//    Quantity::Foot =  Quantity (304.8         ,Unit(1));             
-//    Quantity::Thou =  Quantity (0.0254        ,Unit(1));             
-//    Quantity::Yard =  Quantity (914.4         ,Unit(1)); 
-//    Quantity::Mile =  Quantity (1609344.0     ,Unit(1)); 
+//    Quantity::Inch =  Quantity (25.4          ,Unit(1));
+//    Quantity::Foot =  Quantity (304.8         ,Unit(1));
+//    Quantity::Thou =  Quantity (0.0254        ,Unit(1));
+//    Quantity::Yard =  Quantity (914.4         ,Unit(1));
+//    Quantity::Mile =  Quantity (1609344.0     ,Unit(1));
 //}
 
 QString UnitsSchemaImperial1::schemaTranslate(Base::Quantity quant,double &factor,QString &unitString)
@@ -63,7 +63,7 @@ QString UnitsSchemaImperial1::schemaTranslate(Base::Quantity quant,double &facto
     double UnitValue = std::abs(quant.getValue());
     Unit unit = quant.getUnit();
     // for imperial user/programmer mind; UnitValue is in internal system, that means
-    // mm/kg/s. And all combined units have to be calculated from there! 
+    // mm/kg/s. And all combined units have to be calculated from there!
 
     // now do special treatment on all cases seems necessary:
     if(unit == Unit::Length){  // Length handling ============================
@@ -73,7 +73,7 @@ QString UnitsSchemaImperial1::schemaTranslate(Base::Quantity quant,double &facto
         }else if(UnitValue < 2.54){ // smaller then 0.1 inch -> Thou (mil)
             unitString = QString::fromLatin1("thou");
             factor = 0.0254;
-        }else if(UnitValue < 304.8){ 
+        }else if(UnitValue < 304.8){
             unitString = QString::fromLatin1("\"");
             factor = 25.4;
         }else if(UnitValue < 914.4){
@@ -85,7 +85,7 @@ QString UnitsSchemaImperial1::schemaTranslate(Base::Quantity quant,double &facto
         }else if(UnitValue < 1609344000.0 ){
             unitString = QString::fromLatin1("mi");
             factor = 1609344.0;
-        }else{ // bigger then 1000 mi -> scientific notation 
+        }else{ // bigger then 1000 mi -> scientific notation
             unitString = QString::fromLatin1("in");
             factor = 25.4;
         }
@@ -111,7 +111,7 @@ QString UnitsSchemaImperial1::schemaTranslate(Base::Quantity quant,double &facto
         }else if(UnitValue < 145038){
             unitString = QString::fromLatin1("ksi");
             factor = 145.038;
-        }else{ // bigger then 1000 ksi -> psi + scientific notation 
+        }else{ // bigger then 1000 ksi -> psi + scientific notation
             unitString = QString::fromLatin1("psi");
             factor = 0.145038;
         }
@@ -120,7 +120,11 @@ QString UnitsSchemaImperial1::schemaTranslate(Base::Quantity quant,double &facto
         unitString = quant.getUnit().getString();
         factor = 1.0;
     }
-    return QString::fromLatin1("%L1 %2").arg(quant.getValue() / factor).arg(unitString);
+    //return QString::fromLatin1("%L1 %2").arg(quant.getValue() / factor).arg(unitString);
+    QLocale Lc = QLocale::system();
+    Lc.setNumberOptions(Lc.OmitGroupSeparator | Lc.RejectGroupSeparator);
+    QString Ln = Lc.toString((quant.getValue() / factor), 'f', Base::UnitsApi::getDecimals());
+    return QString::fromUtf8("%1 %2").arg(Ln).arg(unitString);
 }
 
 
@@ -131,7 +135,7 @@ QString UnitsSchemaImperialDecimal::schemaTranslate(Base::Quantity quant,double 
     double UnitValue = std::abs(quant.getValue());
     Unit unit = quant.getUnit();
     // for imperial user/programmer mind; UnitValue is in internal system, that means
-    // mm/kg/s. And all combined units have to be calculated from there! 
+    // mm/kg/s. And all combined units have to be calculated from there!
 
     // now do special treatment on all cases seems necessary:
     if(unit == Unit::Length){  // Length handling ============================
@@ -141,7 +145,7 @@ QString UnitsSchemaImperialDecimal::schemaTranslate(Base::Quantity quant,double 
         //}else if(UnitValue < 2.54){ // smaller then 0.1 inch -> Thou (mil)
         //    unitString = QString::fromLatin1("thou");
         //    factor = 0.0254;
-        }else{ // bigger then 1000 mi -> scientific notation 
+        }else{ // bigger then 1000 mi -> scientific notation
             unitString = QString::fromLatin1("in");
             factor = 25.4;
         }
@@ -167,7 +171,7 @@ QString UnitsSchemaImperialDecimal::schemaTranslate(Base::Quantity quant,double 
         //}else if(UnitValue < 145038){
         //    unitString = QString::fromLatin1("ksi");
         //    factor = 145.038;
-        }else{ // bigger then 1000 ksi -> psi + scientific notation 
+        }else{ // bigger then 1000 ksi -> psi + scientific notation
             unitString = QString::fromLatin1("psi");
             factor = 0.145038;
         }
@@ -176,11 +180,11 @@ QString UnitsSchemaImperialDecimal::schemaTranslate(Base::Quantity quant,double 
         unitString = quant.getUnit().getString();
         factor = 1.0;
     }
+    //return QString::fromLatin1("%L1 %2").arg(quant.getValue() / factor).arg(unitString);
     QLocale Lc = QLocale::system();
     Lc.setNumberOptions(Lc.OmitGroupSeparator | Lc.RejectGroupSeparator);
-    QString Ln = Lc.toString(quant.getValue() / factor);
-    return QString::fromLatin1("%1 %2").arg(Ln).arg(unitString);
-    //return QString::fromLatin1("%L1 %2").arg(quant.getValue() / factor).arg(unitString);
+    QString Ln = Lc.toString((quant.getValue() / factor), 'f', Base::UnitsApi::getDecimals());
+    return QString::fromUtf8("%1 %2").arg(Ln).arg(unitString);
 }
 
 
@@ -252,6 +256,6 @@ QString UnitsSchemaImperialBuilding::schemaTranslate(Base::Quantity quant,double
     }
     QLocale Lc = QLocale::system();
     Lc.setNumberOptions(Lc.OmitGroupSeparator | Lc.RejectGroupSeparator);
-    QString Ln = Lc.toString(quant.getValue() / factor);
-    return QString::fromLatin1("%1 %2").arg(Ln).arg(unitString);
+    QString Ln = Lc.toString((quant.getValue() / factor), 'f', Base::UnitsApi::getDecimals());
+    return QString::fromUtf8("%1 %2").arg(Ln).arg(unitString);
 }

--- a/src/Base/UnitsSchemaInternal.cpp
+++ b/src/Base/UnitsSchemaInternal.cpp
@@ -27,6 +27,7 @@
 #endif
 
 #include <QString>
+#include <QLocale>
 #include "Exception.h"
 #include "UnitsApi.h"
 #include "UnitsSchemaInternal.h"
@@ -61,7 +62,7 @@ QString UnitsSchemaInternal::schemaTranslate(Base::Quantity quant,double &factor
         }else if(UnitValue < 100000000000.0 ){
             unitString = QString::fromLatin1("km");
             factor = 1000000.0;
-        }else{ // bigger then 1000 km -> scientific notation 
+        }else{ // bigger then 1000 km -> scientific notation
             unitString = QString::fromLatin1("mm");
             factor = 1.0;
         }
@@ -104,7 +105,7 @@ QString UnitsSchemaInternal::schemaTranslate(Base::Quantity quant,double &factor
         }else if(UnitValue < 10000000000.0){
             unitString = QString::fromLatin1("GPa");
             factor = 1000000.0;
-        }else{ // bigger -> scientific notation 
+        }else{ // bigger -> scientific notation
             unitString = QString::fromLatin1("Pa");
             factor = 1.0;
         }
@@ -113,6 +114,9 @@ QString UnitsSchemaInternal::schemaTranslate(Base::Quantity quant,double &factor
         unitString = quant.getUnit().getString();
         factor = 1.0;
     }
-    return QString::fromUtf8("%L1 %2").arg(quant.getValue() / factor).arg(unitString);
+    //return QString::fromUtf8("%L1 %2").arg(quant.getValue() / factor).arg(unitString);
+    QLocale Lc = QLocale::system();
+    Lc.setNumberOptions(Lc.OmitGroupSeparator | Lc.RejectGroupSeparator);
+    QString Ln = Lc.toString((quant.getValue() / factor), 'f', Base::UnitsApi::getDecimals());
+    return QString::fromUtf8("%1 %2").arg(Ln).arg(unitString);
 }
-

--- a/src/Base/UnitsSchemaMKS.cpp
+++ b/src/Base/UnitsSchemaMKS.cpp
@@ -27,6 +27,7 @@
 #endif
 
 #include <QString>
+#include <QLocale>
 #include "Exception.h"
 #include "UnitsApi.h"
 #include "UnitsSchemaMKS.h"
@@ -60,7 +61,7 @@ QString UnitsSchemaMKS::schemaTranslate(Base::Quantity quant,double &factor,QStr
         }else if(UnitValue < 100000000000.0 ){
             unitString = QString::fromLatin1("km");
             factor = 1000000.0;
-        }else{ // bigger then 1000 km -> scientific notation 
+        }else{ // bigger then 1000 km -> scientific notation
             unitString = QString::fromLatin1("mm");
             factor = 1.0;
         }
@@ -104,7 +105,7 @@ QString UnitsSchemaMKS::schemaTranslate(Base::Quantity quant,double &factor,QStr
         }else if(UnitValue < 10000000000.0){
             unitString = QString::fromLatin1("GPa");
             factor = 1000000.0;
-        }else{ // bigger then 1000 GPa -> scientific notation 
+        }else{ // bigger then 1000 GPa -> scientific notation
             unitString = QString::fromLatin1("Pa");
             factor = 1.0;
         }
@@ -113,5 +114,9 @@ QString UnitsSchemaMKS::schemaTranslate(Base::Quantity quant,double &factor,QStr
         unitString = quant.getUnit().getString();
         factor = 1.0;
     }
-	return QString::fromUtf8("%L1 %2").arg(quant.getValue() / factor).arg(unitString);
+	//return QString::fromUtf8("%L1 %2").arg(quant.getValue() / factor).arg(unitString);
+    QLocale Lc = QLocale::system();
+    Lc.setNumberOptions(Lc.OmitGroupSeparator | Lc.RejectGroupSeparator);
+    QString Ln = Lc.toString((quant.getValue() / factor), 'f', Base::UnitsApi::getDecimals());
+    return QString::fromUtf8("%1 %2").arg(Ln).arg(unitString);
 }


### PR DESCRIPTION
Quantity::getUserString always receives 6 digits of precision from UnitsSchema*::schemaTranslate().  This change uses Base::UnitsApi::getDecimals() value for precision in schemaTranslate.

