### PR TITLE
Various TechDraw Fixes

### DIFF
--- a/src/Mod/TechDraw/App/DrawPage.cpp
+++ b/src/Mod/TechDraw/App/DrawPage.cpp
@@ -237,11 +237,19 @@ int DrawPage::addView(App::DocumentObject *docObj)
     if(!docObj->isDerivedFrom(TechDraw::DrawView::getClassTypeId()))
         return -1;
 
+    //position all new views in center of Page (exceptDVDimension)
+    DrawView* view = dynamic_cast<DrawView*>(docObj);
+    if (!docObj->isDerivedFrom(TechDraw::DrawViewDimension::getClassTypeId())) {
+        view->X.setValue(getPageWidth()/2.0);
+        view->Y.setValue(getPageHeight()/2.0);
+    }
+
     const std::vector<App::DocumentObject *> currViews = Views.getValues();
     std::vector<App::DocumentObject *> newViews(currViews);
     newViews.push_back(docObj);
     Views.setValues(newViews);
     Views.touch();
+
     return Views.getSize();
 }
 

--- a/src/Mod/TechDraw/App/DrawParametricTemplate.h
+++ b/src/Mod/TechDraw/App/DrawParametricTemplate.h
@@ -33,11 +33,11 @@ namespace TechDrawGeometry
     class BaseGeom;
 }
 
+//TODO: DrawParametricTemplate class is obsolete
+
 namespace TechDraw
 {
 
-/** Base class of all View Features in the drawing module
- */
 class TechDrawExport DrawParametricTemplate: public TechDraw::DrawTemplate
 {
     PROPERTY_HEADER(TechDraw::DrawParametricTemplate);

--- a/src/Mod/TechDraw/App/DrawSVGTemplate.cpp
+++ b/src/Mod/TechDraw/App/DrawSVGTemplate.cpp
@@ -76,16 +76,6 @@ DrawSVGTemplate::~DrawSVGTemplate()
 {
 }
 
-/*
-std::string DrawSVGTemplate::getSvgIdForEditable(const std::string &editableName)
-{
-    if (editableSvgIds.count(editableName)) {
-        return editableSvgIds[editableName];
-    } else {
-        return "";
-    }
-}*/
-
 PyObject *DrawSVGTemplate::getPyObject(void)
 {
     if (PythonObject.is(Py::_None())) {

--- a/src/Mod/TechDraw/App/DrawSVGTemplate.h
+++ b/src/Mod/TechDraw/App/DrawSVGTemplate.h
@@ -33,14 +33,12 @@
 namespace TechDraw
 {
 
-/** Base class of all View Features in the drawing module
- */
 class TechDrawExport DrawSVGTemplate: public TechDraw::DrawTemplate
 {
     PROPERTY_HEADER(TechDraw::DrawSVGTemplate);
 
 public:
-    DrawSVGTemplate(); /// Constructor
+    DrawSVGTemplate();
     ~DrawSVGTemplate();
 
     App::PropertyFileIncluded PageResult;
@@ -59,13 +57,6 @@ public:
         return "TechDrawGui::ViewProviderTemplate";
     }
 
-    /// Returns the SVG ID for editable field with name editableName
-    /*!
-     * If editableName isn't known, returns an empty string
-     */
- //   std::string getSvgIdForEditable(const std::string &editableName);
-
-    // from base class
     virtual PyObject *getPyObject(void);
     virtual unsigned int getMemSize(void) const;
 

--- a/src/Mod/TechDraw/App/DrawTemplate.cpp
+++ b/src/Mod/TechDraw/App/DrawTemplate.cpp
@@ -62,7 +62,7 @@ DrawTemplate::DrawTemplate(void)
     // Physical Properties inherent to every template class
     ADD_PROPERTY_TYPE(Width,     (0),  group, (App::PropertyType)(App::Prop_None), "Width of page");
     ADD_PROPERTY_TYPE(Height,    (0),  group, (App::PropertyType)(App::Prop_None), "Height of page");
-    ADD_PROPERTY_TYPE(PaperSize, (""), group, (App::PropertyType)(App::Prop_None), "Paper Format");
+    //ADD_PROPERTY_TYPE(PaperSize, (""), group, (App::PropertyType)(App::Prop_None), "Paper Format");   //obs?
 
     ADD_PROPERTY_TYPE(EditableTexts, (), group, (App::PropertyType)(App::Prop_None),
                       "Editable strings in the template");

--- a/src/Mod/TechDraw/App/DrawTemplate.h
+++ b/src/Mod/TechDraw/App/DrawTemplate.h
@@ -47,7 +47,7 @@ public:
     App::PropertyLength Width;
     App::PropertyLength Height;
     App::PropertyEnumeration Orientation;
-    App::PropertyString PaperSize;
+    //App::PropertyString PaperSize;
 
     App::PropertyMap EditableTexts;
 

--- a/src/Mod/TechDraw/App/DrawView.cpp
+++ b/src/Mod/TechDraw/App/DrawView.cpp
@@ -58,9 +58,8 @@ const char* DrawView::ScaleTypeEnums[]= {"Document",
 
 PROPERTY_SOURCE(TechDraw::DrawView, App::DocumentObject)
 
-
-
 DrawView::DrawView(void)
+  : autoPos(true)
 {
     static const char *group = "Drawing view";
     ADD_PROPERTY_TYPE(X ,(0),group,App::Prop_None,"X position of the view on the page in modelling units (mm)");
@@ -73,8 +72,6 @@ DrawView::DrawView(void)
 
     if (isRestoring()) {
         autoPos = false;
-    } else {
-        autoPos = true;
     }
 }
 

--- a/src/Mod/TechDraw/Gui/Command.cpp
+++ b/src/Mod/TechDraw/Gui/Command.cpp
@@ -164,11 +164,8 @@ void CmdTechDrawNewPageDef::activated(int iMsg)
         Gui::WaitCursor wc;
         openCommand("Drawing create page");
         doCommand(Doc,"App.activeDocument().addObject('TechDraw::DrawPage','%s')",PageName.c_str());
-
-        // Create the Template Object to attach to the page
         doCommand(Doc,"App.activeDocument().addObject('TechDraw::DrawSVGTemplate','%s')",TemplateName.c_str());
 
-        //TODO: why is "Template" property set twice?
         doCommand(Doc,"App.activeDocument().%s.Template = '%s'",TemplateName.c_str(), templateFileName.toStdString().c_str());
         doCommand(Doc,"App.activeDocument().%s.Template = App.activeDocument().%s",PageName.c_str(),TemplateName.c_str());
 
@@ -307,16 +304,12 @@ void CmdTechDrawNewView::activated(int iMsg)
     Gui::WaitCursor wc;
     const std::vector<App::DocumentObject*> selectedProjections = getSelection().getObjectsOfType(TechDraw::DrawView::getClassTypeId());
 
-    float newX = 10.0;
-    float newY = 10.0;
     float newScale = 1.0;
     float newRotation = 0.0;
     Base::Vector3d newDirection(0.0, 0.0, 1.0);
     if (!selectedProjections.empty()) {
         const TechDraw::DrawView* const myView = dynamic_cast<TechDraw::DrawView*>(selectedProjections.front());
 
-        newX = myView->X.getValue();
-        newY = myView->Y.getValue();
         newScale = myView->Scale.getValue();
         newRotation = myView->Rotation.getValue();
 
@@ -335,8 +328,6 @@ void CmdTechDrawNewView::activated(int iMsg)
         doCommand(Doc,"App.activeDocument().addObject('TechDraw::DrawViewPart','%s')",FeatName.c_str());
         doCommand(Doc,"App.activeDocument().%s.Source = App.activeDocument().%s",FeatName.c_str(),(*it)->getNameInDocument());
         doCommand(Doc,"App.activeDocument().%s.Direction = (%e,%e,%e)",FeatName.c_str(), newDirection.x, newDirection.y, newDirection.z);
-        doCommand(Doc,"App.activeDocument().%s.X = %e",FeatName.c_str(), newX);
-        doCommand(Doc,"App.activeDocument().%s.Y = %e",FeatName.c_str(), newY);
         doCommand(Doc,"App.activeDocument().%s.Scale = %e",FeatName.c_str(), newScale);
         doCommand(Doc,"App.activeDocument().%s.Rotation = %e",FeatName.c_str(), newRotation);
         doCommand(Doc,"App.activeDocument().%s.addView(App.activeDocument().%s)",PageName.c_str(),FeatName.c_str());
@@ -390,10 +381,6 @@ void CmdTechDrawNewViewSection::activated(int iMsg)
         std::string FeatName = getUniqueObjectName("Section");
         doCommand(Doc,"App.activeDocument().addObject('TechDraw::DrawViewSection','%s')",FeatName.c_str());
         doCommand(Doc,"App.activeDocument().%s.Source = App.activeDocument().%s",FeatName.c_str(),(*it)->getNameInDocument());
-        doCommand(Doc,"App.activeDocument().%s.Direction = (0.0,0.0,1.0)",FeatName.c_str());
-        doCommand(Doc,"App.activeDocument().%s.X = 10.0",FeatName.c_str());
-        doCommand(Doc,"App.activeDocument().%s.Y = 10.0",FeatName.c_str());
-        doCommand(Doc,"App.activeDocument().%s.Scale = 1.0",FeatName.c_str());
         doCommand(Doc,"App.activeDocument().%s.addView(App.activeDocument().%s)",PageName.c_str(),FeatName.c_str());
     }
     updateActive();
@@ -446,9 +433,6 @@ void CmdTechDrawProjGroup::activated(int iMsg)
     std::string SourceName = (*shapes.begin())->getNameInDocument();
     doCommand(Doc,"App.activeDocument().addObject('TechDraw::DrawProjGroup','%s')",multiViewName.c_str());
     doCommand(Doc,"App.activeDocument().%s.Source = App.activeDocument().%s",multiViewName.c_str(),SourceName.c_str());
-    doCommand(Doc,"App.activeDocument().%s.X = %f",     multiViewName.c_str(), page->getPageWidth() / 2);
-    doCommand(Doc,"App.activeDocument().%s.Y = %f",     multiViewName.c_str(), page->getPageHeight() / 2);
-    doCommand(Doc,"App.activeDocument().%s.Scale = 1.0",multiViewName.c_str());
 
     App::DocumentObject *docObj = getDocument()->getObject(multiViewName.c_str());
     TechDraw::DrawProjGroup *multiView = dynamic_cast<TechDraw::DrawProjGroup *>(docObj);
@@ -506,8 +490,6 @@ void CmdTechDrawAnnotation::activated(int iMsg)
     std::string FeatName = getUniqueObjectName("Annotation");
     openCommand("Create Annotation");
     doCommand(Doc,"App.activeDocument().addObject('TechDraw::DrawViewAnnotation','%s')",FeatName.c_str());
-    doCommand(Doc,"App.activeDocument().%s.X = 10.0",FeatName.c_str());
-    doCommand(Doc,"App.activeDocument().%s.Y = 10.0",FeatName.c_str());
     doCommand(Doc,"App.activeDocument().%s.addView(App.activeDocument().%s)",PageName.c_str(),FeatName.c_str());
     updateActive();
     commitCommand();
@@ -748,8 +730,6 @@ void CmdTechDrawSymbol::activated(int iMsg)
         doCommand(Doc,"svg = f.read()");
         doCommand(Doc,"f.close()");
         doCommand(Doc,"App.activeDocument().addObject('TechDraw::DrawViewSymbol','%s')",FeatName.c_str());
-        doCommand(Doc,"App.activeDocument().%s.X = 10.0",FeatName.c_str());
-        doCommand(Doc,"App.activeDocument().%s.Y = 10.0",FeatName.c_str());
         doCommand(Doc,"App.activeDocument().%s.Symbol = svg",FeatName.c_str());
         doCommand(Doc,"App.activeDocument().%s.addView(App.activeDocument().%s)",PageName.c_str(),FeatName.c_str());
         updateActive();

--- a/src/Mod/TechDraw/Gui/QGIView.cpp
+++ b/src/Mod/TechDraw/Gui/QGIView.cpp
@@ -48,9 +48,6 @@
 #include <Gui/Selection.h>
 #include <Gui/Command.h>
 
-#include "QGCustomBorder.h"
-#include "QGCustomLabel.h"
-
 #include "QGIView.h"
 #include "QGCustomClip.h"
 #include "QGIViewClip.h"
@@ -82,11 +79,8 @@ QGIView::QGIView()
     m_decorPen.setStyle(Qt::DashLine);
     m_decorPen.setWidth(0); // 0 => 1px "cosmetic pen"
 
-    m_label = new QGCustomLabel();
-    addToGroup(m_label);
-
-    m_border = new QGCustomBorder();
-    addToGroup(m_border);
+    addToGroup(&m_label);
+    addToGroup(&m_border);
 
     isVisible(true);
 }
@@ -298,27 +292,27 @@ void QGIView::drawBorder()
 {
     prepareGeometryChange();
     if (!borderVisible) {
-         m_label->hide();
-         m_border->hide();
+         m_label.hide();
+         m_border.hide();
         return;
     }
 
     //double margin = 2.0;
-    m_label->hide();
-    m_border->hide();
+    m_label.hide();
+    m_border.hide();
 
-    m_label->setDefaultTextColor(m_colCurrent);
+    m_label.setDefaultTextColor(m_colCurrent);
     m_font.setFamily(getPrefFont());
-    m_label->setFont(m_font);
+    m_label.setFont(m_font);
     QString labelStr = QString::fromUtf8(getViewObject()->Label.getValue());
-    m_label->setPlainText(labelStr);
-    QRectF labelArea = m_label->boundingRect();
-    double labelWidth = m_label->boundingRect().width();
-    double labelHeight = m_label->boundingRect().height();
+    m_label.setPlainText(labelStr);
+    QRectF labelArea = m_label.boundingRect();
+    double labelWidth = m_label.boundingRect().width();
+    double labelHeight = m_label.boundingRect().height();
 
-    m_border->hide();
+    m_border.hide();
     m_decorPen.setColor(m_colCurrent);
-    m_border->setPen(m_decorPen);
+    m_border.setPen(m_decorPen);
 
     QRectF displayArea = customChildrenBoundingRect();
     double displayWidth = displayArea.width();
@@ -331,18 +325,18 @@ void QGIView::drawBorder()
     double frameHeight = labelHeight + displayHeight;
     QPointF displayCenter = displayArea.center();
 
-    m_label->setX(displayCenter.x() - labelArea.width()/2.);
-    m_label->setY(displayArea.bottom());
+    m_label.setX(displayCenter.x() - labelArea.width()/2.);
+    m_label.setY(displayArea.bottom());
 
     QRectF frameArea = QRectF(displayCenter.x() - frameWidth/2.,
                               displayArea.top(),
                               frameWidth,
                               frameHeight);
-    m_border->setRect(frameArea);
-    m_border->setPos(0.,0.);
+    m_border.setRect(frameArea);
+    m_border.setPos(0.,0.);
 
-    m_label->show();
-    m_border->show();
+    m_label.show();
+    m_border.show();
 }
 
 void QGIView::paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget)
@@ -371,7 +365,23 @@ QRectF QGIView::customChildrenBoundingRect() {
 
 QRectF QGIView::boundingRect() const
 {
-    return m_border->rect().adjusted(-2.,-2.,2.,2.);     //allow for border line width  //TODO: fiddle brect if border off?
+    return m_border.rect().adjusted(-2.,-2.,2.,2.);     //allow for border line width  //TODO: fiddle brect if border off?
+}
+
+QGIView* QGIView::getQGIVByName(std::string name)
+{
+    QList<QGraphicsItem*> qgItems = scene()->items();
+    QList<QGraphicsItem*>::iterator it = qgItems.begin();
+    for (; it != qgItems.end(); it++) {
+        QGIView* qv = dynamic_cast<QGIView*>((*it));
+        if (qv) {
+            const char* qvName = qv->getViewName();
+            if(name.compare(qvName) == 0) {
+                return (qv);
+            }
+        }
+    }
+    return 0;
 }
 
 QColor QGIView::getNormalColor()

--- a/src/Mod/TechDraw/Gui/QGIView.cpp
+++ b/src/Mod/TechDraw/Gui/QGIView.cpp
@@ -59,8 +59,6 @@
 
 using namespace TechDrawGui;
 
-void _debugRect(char* text, QRectF r);
-
 QGIView::QGIView()
     :QGraphicsItemGroup(),
      locked(false),
@@ -298,12 +296,14 @@ void QGIView::draw()
 
 void QGIView::drawBorder()
 {
+    prepareGeometryChange();
     if (!borderVisible) {
+         m_label->hide();
+         m_border->hide();
         return;
     }
 
     //double margin = 2.0;
-    prepareGeometryChange();
     m_label->hide();
     m_border->hide();
 
@@ -350,10 +350,6 @@ void QGIView::paint(QPainter *painter, const QStyleOptionGraphicsItem *option, Q
     QStyleOptionGraphicsItem myOption(*option);
     myOption.state &= ~QStyle::State_Selected;
 
-    if(!borderVisible){
-         m_label->hide();
-         m_border->hide();
-    }
     QGraphicsItemGroup::paint(painter, &myOption, widget);
 }
 
@@ -377,6 +373,7 @@ QRectF QGIView::boundingRect() const
 {
     return m_border->rect().adjusted(-2.,-2.,2.,2.);     //allow for border line width  //TODO: fiddle brect if border off?
 }
+
 QColor QGIView::getNormalColor()
 {
     Base::Reference<ParameterGrp> hGrp = getParmGroupCol();
@@ -419,7 +416,7 @@ QString QGIView::getPrefFont()
     return QString::fromStdString(fontName);
 }
 
-void _debugRect(char* text, QRectF r) {
-    Base::Console().Message("TRACE - %s - rect: (%.3f,%.3f) x (%.3f,%.3f)\n",text,
+void QGIView::dumpRect(char* text, QRectF r) {
+    Base::Console().Message("DUMP - %s - rect: (%.3f,%.3f) x (%.3f,%.3f)\n",text,
                             r.left(),r.top(),r.right(),r.bottom());
 }

--- a/src/Mod/TechDraw/Gui/QGIView.cpp
+++ b/src/Mod/TechDraw/Gui/QGIView.cpp
@@ -373,6 +373,10 @@ QRectF QGIView::customChildrenBoundingRect() {
     return result;
 }
 
+QRectF QGIView::boundingRect() const
+{
+    return m_border->rect().adjusted(-2.,-2.,2.,2.);     //allow for border line width  //TODO: fiddle brect if border off?
+}
 QColor QGIView::getNormalColor()
 {
     Base::Reference<ParameterGrp> hGrp = getParmGroupCol();

--- a/src/Mod/TechDraw/Gui/QGIView.h
+++ b/src/Mod/TechDraw/Gui/QGIView.h
@@ -31,6 +31,8 @@
 #include <Base/Parameter.h>
 
 #include <Mod/TechDraw/App/DrawView.h>
+#include "QGCustomBorder.h"
+#include "QGCustomLabel.h"
 
 QT_BEGIN_NAMESPACE
 class QGraphicsScene;
@@ -39,8 +41,6 @@ QT_END_NAMESPACE
 
 namespace TechDrawGui
 {
-class QGCustomBorder;
-class QGCustomLabel;
 
 class TechDrawGuiExport  QGIView : public QGraphicsItemGroup
 {
@@ -79,6 +79,7 @@ public:
     virtual void mouseReleaseEvent(QGraphicsSceneMouseEvent * event);
 
 protected:
+    QGIView* getQGIVByName(std::string name);
 
     virtual QVariant itemChange(GraphicsItemChange change, const QVariant &value);
     // Mouse handling
@@ -112,8 +113,8 @@ protected:
     QColor m_colPre;
     QColor m_colSel;
     QFont m_font;
-    QGCustomLabel* m_label;
-    QGCustomBorder* m_border;
+    QGCustomLabel m_label;
+    QGCustomBorder m_border;
     QPen m_decorPen;
 };
 

--- a/src/Mod/TechDraw/Gui/QGIView.h
+++ b/src/Mod/TechDraw/Gui/QGIView.h
@@ -75,7 +75,6 @@ public:
     virtual void updateView(bool update = false);
     virtual void paint(QPainter * painter, const QStyleOptionGraphicsItem * option, QWidget * widget = 0 );
     virtual QRectF boundingRect() const override;
-    //virtual QPainterPath shape(void) const;
 
     virtual void mouseReleaseEvent(QGraphicsSceneMouseEvent * event);
 
@@ -89,6 +88,7 @@ protected:
     virtual void hoverEnterEvent(QGraphicsSceneHoverEvent *event);
     virtual void hoverLeaveEvent(QGraphicsSceneHoverEvent *event);
     virtual QRectF customChildrenBoundingRect(void);
+    void dumpRect(char* text, QRectF r);
 
     QColor getNormalColor(void);
     QColor getPreColor(void);
@@ -117,6 +117,6 @@ protected:
     QPen m_decorPen;
 };
 
-} // namespace MDIViewPageGui
+} // namespace
 
 #endif // DRAWINGGUI_QGRAPHICSITEMVIEW_H

--- a/src/Mod/TechDraw/Gui/QGIView.h
+++ b/src/Mod/TechDraw/Gui/QGIView.h
@@ -74,6 +74,7 @@ public:
     virtual void toggleCache(bool state);
     virtual void updateView(bool update = false);
     virtual void paint(QPainter * painter, const QStyleOptionGraphicsItem * option, QWidget * widget = 0 );
+    virtual QRectF boundingRect() const override;
     //virtual QPainterPath shape(void) const;
 
     virtual void mouseReleaseEvent(QGraphicsSceneMouseEvent * event);

--- a/src/Mod/TechDraw/Gui/QGIViewAnnotation.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewAnnotation.cpp
@@ -163,8 +163,3 @@ void QGIViewAnnotation::drawAnnotation()
     m_textItem->setPos(0.,0.);
 }
 
-QRectF QGIViewAnnotation::boundingRect() const
-{
-    return childrenBoundingRect();
-}
-

--- a/src/Mod/TechDraw/Gui/QGIViewAnnotation.h
+++ b/src/Mod/TechDraw/Gui/QGIViewAnnotation.h
@@ -50,7 +50,6 @@ public:
     void setViewAnnoFeature(TechDraw::DrawViewAnnotation *obj);
 
     virtual void draw() override;
-    virtual QRectF boundingRect() const override;
 
 protected:
     void drawAnnotation();

--- a/src/Mod/TechDraw/Gui/QGIViewClip.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewClip.cpp
@@ -47,8 +47,6 @@
 
 #include <Mod/TechDraw/App/DrawViewClip.h>
 
-#include "QGCustomRect.h"
-#include "QGCustomClip.h"
 #include "QGIViewClip.h"
 
 using namespace TechDrawGui;
@@ -61,15 +59,13 @@ QGIViewClip::QGIViewClip()
     setFlag(QGraphicsItem::ItemIsSelectable, true);
     setFlag(QGraphicsItem::ItemIsMovable, true);
 
-    m_cliparea = new QGCustomClip();
-    addToGroup(m_cliparea);
-    m_cliparea->setPos(0.,0.);
-    m_cliparea->setRect(0.,0.,5.,5.);
+    addToGroup(&m_cliparea);
+    m_cliparea.setPos(0.,0.);
+    m_cliparea.setRect(0.,0.,5.,5.);
 
-    m_frame = new QGCustomRect();
-    addToGroup(m_frame);
-    m_frame->setPos(0.,0.);
-    m_frame->setRect(0.,0.,5.,5.);
+    addToGroup(&m_frame);
+    m_frame.setPos(0.,0.);
+    m_frame.setRect(0.,0.,5.,5.);
 }
 
 
@@ -120,15 +116,15 @@ void QGIViewClip::drawClip()
     double h = viewClip->Height.getValue();
     double w = viewClip->Width.getValue();
     QRectF r = QRectF(0,0,w,h);
-    m_frame->setRect(r);
-    m_frame->setPos(0.,0.);
+    m_frame.setRect(r);
+    m_frame.setPos(0.,0.);
     if (viewClip->ShowFrame.getValue()) {
-        m_frame->show();
+        m_frame.show();
     } else {
-        m_frame->hide();
+        m_frame.hide();
     }
 
-    m_cliparea->setRect(r.adjusted(-1,-1,1,1));                        //TODO: clip just outside frame or just inside??
+    m_cliparea.setRect(r.adjusted(-1,-1,1,1));                        //TODO: clip just outside frame or just inside??
 
     std::vector<std::string> childNames = viewClip->getChildViewNames();
     //for all child Views in Clip, add the graphics representation of the View to the Clip group
@@ -136,10 +132,10 @@ void QGIViewClip::drawClip()
         QGIView* qgiv = getQGIVByName((*it));
         if (qgiv) {
             //TODO: why is qgiv never already in a group?
-            if (qgiv->group() != m_cliparea) {
+            if (qgiv->group() != &m_cliparea) {
                 qgiv->hide();
                 scene()->removeItem(qgiv);
-                m_cliparea->addToGroup(qgiv);
+                m_cliparea.addToGroup(qgiv);
                 qgiv->isInnerView(true);
                 double x = qgiv->getViewObject()->X.getValue();
                 double y = qgiv->getViewObject()->Y.getValue();
@@ -157,14 +153,14 @@ void QGIViewClip::drawClip()
     }
 
     //for all graphic views in qgigroup, remove from qgigroup the ones that aren't in ViewClip
-    QList<QGraphicsItem*> qgItems = m_cliparea->childItems();
+    QList<QGraphicsItem*> qgItems = m_cliparea.childItems();
     QList<QGraphicsItem*>::iterator it = qgItems.begin();
     for (; it != qgItems.end(); it++) {
         QGIView* qv = dynamic_cast<QGIView*>((*it));
         if (qv) {
             std::string qvName = std::string(qv->getViewName());
             if (std::find(childNames.begin(),childNames.end(),qvName) == childNames.end()) {
-                m_cliparea->removeFromGroup(qv);
+                m_cliparea.removeFromGroup(qv);
                 removeFromGroup(qv);
                 qv->isInnerView(false);
                 qv->toggleBorder(true);
@@ -173,19 +169,4 @@ void QGIViewClip::drawClip()
     }
 }
 
-//TODO: at least move to QGIView
-QGIView* QGIViewClip::getQGIVByName(std::string name)  //should probably be method in MDIViewPage??  but qgiv can't get drawingView? or QGVPage!
-{
-    QList<QGraphicsItem*> qgItems = scene()->items();
-    QList<QGraphicsItem*>::iterator it = qgItems.begin();
-    for (; it != qgItems.end(); it++) {
-        QGIView* qv = dynamic_cast<QGIView*>((*it));
-        if (qv) {
-            const char* qvName = qv->getViewName();
-            if(name.compare(qvName) == 0) {
-                return (qv);
-            }
-        }
-    }
-    return 0;
-}
+

--- a/src/Mod/TechDraw/Gui/QGIViewClip.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewClip.cpp
@@ -138,6 +138,7 @@ void QGIViewClip::drawClip()
             //TODO: why is qgiv never already in a group?
             if (qgiv->group() != m_cliparea) {
                 qgiv->hide();
+                scene()->removeItem(qgiv);
                 m_cliparea->addToGroup(qgiv);
                 qgiv->isInnerView(true);
                 double x = qgiv->getViewObject()->X.getValue();
@@ -172,6 +173,7 @@ void QGIViewClip::drawClip()
     }
 }
 
+//TODO: at least move to QGIView
 QGIView* QGIViewClip::getQGIVByName(std::string name)  //should probably be method in MDIViewPage??  but qgiv can't get drawingView? or QGVPage!
 {
     QList<QGraphicsItem*> qgItems = scene()->items();

--- a/src/Mod/TechDraw/Gui/QGIViewClip.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewClip.cpp
@@ -187,8 +187,3 @@ QGIView* QGIViewClip::getQGIVByName(std::string name)  //should probably be meth
     }
     return 0;
 }
-
-QRectF QGIViewClip::boundingRect() const
-{
-    return childrenBoundingRect();
-}

--- a/src/Mod/TechDraw/Gui/QGIViewClip.h
+++ b/src/Mod/TechDraw/Gui/QGIViewClip.h
@@ -27,11 +27,11 @@
 #include <QPainter>
 
 #include "QGIView.h"
+#include "QGCustomRect.h"
+#include "QGCustomClip.h"
 
 namespace TechDrawGui
 {
-class QGCustomRect;
-class QGCustomClip;
 
 class TechDrawGuiExport QGIViewClip : public QGIView
 {
@@ -50,11 +50,10 @@ public:
 protected:
     void drawClip();
     virtual QVariant itemChange(GraphicsItemChange change, const QVariant &value) override;
-    QGIView* getQGIVByName(std::string name);
 
 private:
-    QGCustomRect* m_frame;
-    QGCustomClip* m_cliparea;
+    QGCustomRect m_frame;
+    QGCustomClip m_cliparea;
 
 };
 

--- a/src/Mod/TechDraw/Gui/QGIViewClip.h
+++ b/src/Mod/TechDraw/Gui/QGIViewClip.h
@@ -46,7 +46,6 @@ public:
     virtual void updateView(bool update = false) override;
 
     virtual void draw() override;
-    virtual QRectF boundingRect() const override;
 
 protected:
     void drawClip();

--- a/src/Mod/TechDraw/Gui/QGIViewPart.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewPart.cpp
@@ -575,12 +575,6 @@ TechDraw::DrawHatch* QGIViewPart::faceIsHatched(int i,std::vector<TechDraw::Draw
     return result;
 }
 
-QRectF QGIViewPart::boundingRect() const
-{
-    //return childrenBoundingRect().adjusted(-2.,-2.,2.,6.);             //just a bit bigger than the children need
-    return childrenBoundingRect();
-}
-
 void QGIViewPart::dumpPath(const char* text,QPainterPath path)
 {
         QPainterPath::Element elem;

--- a/src/Mod/TechDraw/Gui/QGIViewPart.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewPart.cpp
@@ -272,7 +272,6 @@ void QGIViewPart::updateView(bool update)
 void QGIViewPart::draw() {
     drawViewPart();
     drawBorder();
-    QGIView::draw();
 }
 
 void QGIViewPart::drawViewPart()
@@ -594,4 +593,9 @@ void QGIViewPart::dumpPath(const char* text,QPainterPath path)
             Base::Console().Message(">>>>> element %d: type:%d/%s pos(%.3f,%.3f) M:%d L:%d C:%d\n",iElem,
                                     elem.type,typeName,elem.x,elem.y,elem.isMoveTo(),elem.isLineTo(),elem.isCurveTo());
         }
+}
+
+QRectF QGIViewPart::boundingRect() const
+{
+    return childrenBoundingRect();
 }

--- a/src/Mod/TechDraw/Gui/QGIViewPart.h
+++ b/src/Mod/TechDraw/Gui/QGIViewPart.h
@@ -28,6 +28,7 @@
 
 #include <Base/Parameter.h>
 #include <Mod/TechDraw/App/Geometry.h>
+#include "QGCustomBorder.h"
 #include "QGIView.h"
 
 namespace TechDraw {
@@ -56,6 +57,7 @@ public:
     void setViewPartFeature(TechDraw::DrawViewPart *obj);
     virtual void updateView(bool update = false) override;
     void tidy();
+    virtual QRectF boundingRect() const override;
 
     virtual void draw() override;
 
@@ -90,6 +92,6 @@ private:
     QList<QGraphicsItem*> deleteItems;
 };
 
-} // namespace MDIViewPageGui
+} // namespace
 
 #endif // DRAWINGGUI_QGRAPHICSITEMVIEWPART_H

--- a/src/Mod/TechDraw/Gui/QGIViewPart.h
+++ b/src/Mod/TechDraw/Gui/QGIViewPart.h
@@ -58,7 +58,6 @@ public:
     void tidy();
 
     virtual void draw() override;
-    virtual QRectF boundingRect() const override;
 
 protected:
     /// Helper for pathArc()

--- a/src/Mod/TechDraw/Gui/QGIViewSymbol.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewSymbol.cpp
@@ -139,7 +139,3 @@ void QGIViewSymbol::symbolToSvg(QString qs)
     m_svgItem->setPos(0.,0.);
 }
 
-QRectF QGIViewSymbol::boundingRect() const
-{
-    return childrenBoundingRect();
-}

--- a/src/Mod/TechDraw/Gui/QGIViewSymbol.h
+++ b/src/Mod/TechDraw/Gui/QGIViewSymbol.h
@@ -54,7 +54,6 @@ public:
     void setViewSymbolFeature(TechDraw::DrawViewSymbol *obj);
 
     virtual void draw() override;
-    virtual QRectF boundingRect() const override;
 
 protected:
     virtual void drawSvg();


### PR DESCRIPTION
-  Refactor ViewClip method to base View
- Auto allocate member attributes
- Fix GH Issue 49 Clip artifact
- remove unneeded boundingRect methods 
- Remove obs property & code for template
- Simplify ClipMinus selection logic 
- Center new view on Page/ClipGroup