### PR TITLE
Private shape

### DIFF
--- a/src/Mod/Draft/App/DraftDxf.cpp
+++ b/src/Mod/Draft/App/DraftDxf.cpp
@@ -171,7 +171,7 @@ void DraftDxfRead::OnReadInsert(const double* point, const double* scale, const 
             builder.MakeCompound(comp);
             std::vector<Part::TopoShape*> v = i->second;
             for(std::vector<Part::TopoShape*>::const_iterator j = v.begin(); j != v.end(); ++j) { 
-                const TopoDS_Shape& sh = (*j)->_Shape;
+                const TopoDS_Shape& sh = (*j)->getShape();
                 if (!sh.IsNull())
                     builder.Add(comp, sh);
             }
@@ -266,7 +266,7 @@ void DraftDxfRead::AddGraphics() const
             std::vector<Part::TopoShape*> v = i->second;
             if(k.substr(0, 6) != "BLOCKS") {
                 for(std::vector<Part::TopoShape*>::const_iterator j = v.begin(); j != v.end(); ++j) { 
-                    const TopoDS_Shape& sh = (*j)->_Shape;
+                    const TopoDS_Shape& sh = (*j)->getShape();
                     if (!sh.IsNull())
                         builder.Add(comp, sh);
                 }

--- a/src/Mod/Drawing/App/AppDrawingPy.cpp
+++ b/src/Mod/Drawing/App/AppDrawingPy.cpp
@@ -119,7 +119,7 @@ private:
         if (pcObjDir)
             Vector = *static_cast<Base::VectorPy*>(pcObjDir)->getVectorPtr();
 
-        ProjectionAlgos Alg(pShape->getTopoShapePtr()->_Shape,Vector);
+        ProjectionAlgos Alg(pShape->getTopoShapePtr()->getShape(),Vector);
 
         Py::List list;
         list.append(Py::Object(new Part::TopoShapePy(new Part::TopoShape(Alg.V)) , true));
@@ -144,7 +144,7 @@ private:
         if (pcObjDir)
             Vector = *static_cast<Base::VectorPy*>(pcObjDir)->getVectorPtr();
 
-        ProjectionAlgos Alg(pShape->getTopoShapePtr()->_Shape,Vector);
+        ProjectionAlgos Alg(pShape->getTopoShapePtr()->getShape(),Vector);
 
         Py::List list;
         list.append(Py::Object(new TopoShapePy(new TopoShape(Alg.V)) , true));
@@ -177,7 +177,7 @@ private:
         Base::Vector3d Vector(0,0,1);
         if (pcObjDir)
             Vector = static_cast<Base::VectorPy*>(pcObjDir)->value();
-        ProjectionAlgos Alg(pShape->getTopoShapePtr()->_Shape,Vector);
+        ProjectionAlgos Alg(pShape->getTopoShapePtr()->getShape(),Vector);
 
         bool hidden = false;
         if (type && std::string(type) == "ShowHiddenLines")
@@ -203,7 +203,7 @@ private:
         Base::Vector3d Vector(0,0,1);
         if (pcObjDir)
             Vector = static_cast<Base::VectorPy*>(pcObjDir)->value();
-        ProjectionAlgos Alg(pShape->getTopoShapePtr()->_Shape,Vector);
+        ProjectionAlgos Alg(pShape->getTopoShapePtr()->getShape(),Vector);
 
         bool hidden = false;
         if (type && std::string(type) == "ShowHiddenLines")

--- a/src/Mod/Drawing/App/FeatureProjection.cpp
+++ b/src/Mod/Drawing/App/FeatureProjection.cpp
@@ -74,7 +74,7 @@ App::DocumentObjectExecReturn *FeatureProjection::execute(void)
         return new App::DocumentObjectExecReturn("No object linked");
     if (!link->getTypeId().isDerivedFrom(Part::Feature::getClassTypeId()))
         return new App::DocumentObjectExecReturn("Linked object is not a Part object");
-    const TopoDS_Shape& shape = static_cast<Part::Feature*>(link)->Shape.getShape()._Shape;
+    const TopoDS_Shape& shape = static_cast<Part::Feature*>(link)->Shape.getShape().getShape();
     if (shape.IsNull())
         return new App::DocumentObjectExecReturn("Linked shape object is empty");
 

--- a/src/Mod/Drawing/App/FeatureViewPart.cpp
+++ b/src/Mod/Drawing/App/FeatureViewPart.cpp
@@ -103,7 +103,7 @@ App::DocumentObjectExecReturn *FeatureViewPart::execute(void)
         return new App::DocumentObjectExecReturn("No object linked");
     if (!link->getTypeId().isDerivedFrom(Part::Feature::getClassTypeId()))
         return new App::DocumentObjectExecReturn("Linked object is not a Part object");
-    TopoDS_Shape shape = static_cast<Part::Feature*>(link)->Shape.getShape()._Shape;
+    TopoDS_Shape shape = static_cast<Part::Feature*>(link)->Shape.getShape().getShape();
     if (shape.IsNull())
         return new App::DocumentObjectExecReturn("Linked shape object is empty");
     Base::Vector3d Dir = Direction.getValue();

--- a/src/Mod/Drawing/Gui/AppDrawingGuiPy.cpp
+++ b/src/Mod/Drawing/Gui/AppDrawingGuiPy.cpp
@@ -181,7 +181,7 @@ private:
                                 if (!link->getTypeId().isDerivedFrom(Part::Feature::getClassTypeId())) {
                                     throw Py::TypeError("Linked object is not a Part object");
                                 }
-                                TopoDS_Shape shape = static_cast<Part::Feature*>(link)->Shape.getShape()._Shape;
+                                TopoDS_Shape shape = static_cast<Part::Feature*>(link)->Shape.getShape().getShape();
                                 if (!shape.IsNull()) {
                                     Base::Vector3d dir = view->Direction.getValue();
                                     bool hidden = view->ShowHiddenLines.getValue();

--- a/src/Mod/Fem/App/FemConstraint.cpp
+++ b/src/Mod/Fem/App/FemConstraint.cpp
@@ -120,7 +120,7 @@ void Constraint::onChanged(const App::Property* prop)
             App::DocumentObject* obj = Objects[i];
             Part::Feature* feat = static_cast<Part::Feature*>(obj);
             const Part::TopoShape& toposhape = feat->Shape.getShape();
-            if (!toposhape._Shape.IsNull()) {
+            if (!toposhape.getShape().IsNull()) {
                 sh = toposhape.getSubShape(SubElements[i].c_str());
 
                 if (sh.ShapeType() == TopAbs_FACE) {
@@ -175,7 +175,7 @@ const bool Constraint::getPoints(std::vector<Base::Vector3d> &points, std::vecto
             normals.push_back(NormalDirection.getValue());
             //OvG: Scale by whole object mass in case of a vertex
             GProp_GProps props;
-            BRepGProp::VolumeProperties(toposhape._Shape, props);
+            BRepGProp::VolumeProperties(toposhape.getShape(), props);
             double lx = props.Mass();
             *scale = this->calcDrawScaleFactor(sqrt(lx)*0.5); //OvG: setup draw scale for constraint
         } else if (sh.ShapeType() == TopAbs_EDGE) {

--- a/src/Mod/Fem/App/FemMeshPyImp.cpp
+++ b/src/Mod/Fem/App/FemMeshPyImp.cpp
@@ -111,7 +111,7 @@ PyObject* FemMeshPy::setShape(PyObject *args)
         return 0;
 
     try {
-        TopoDS_Shape shape = static_cast<Part::TopoShapePy*>(pcObj)->getTopoShapePtr()->_Shape;
+        TopoDS_Shape shape = static_cast<Part::TopoShapePy*>(pcObj)->getTopoShapePtr()->getShape();
         getFemMeshPtr()->getSMesh()->ShapeToMesh(shape);
     }
     catch (const std::exception& e) {
@@ -134,7 +134,7 @@ PyObject* FemMeshPy::addHypothesis(PyObject *args)
     if (shp == 0)
         shape = getFemMeshPtr()->getSMesh()->GetShapeToMesh();
     else
-        shape = static_cast<Part::TopoShapePy*>(shp)->getTopoShapePtr()->_Shape;
+        shape = static_cast<Part::TopoShapePy*>(shp)->getTopoShapePtr()->getShape();
 
     try {
         Py::Object obj(hyp);
@@ -583,7 +583,7 @@ PyObject* FemMeshPy::getFacesByFace(PyObject *args)
          return 0;
 
     try {
-        const TopoDS_Shape& sh = static_cast<Part::TopoShapeFacePy*>(pW)->getTopoShapePtr()->_Shape;
+        const TopoDS_Shape& sh = static_cast<Part::TopoShapeFacePy*>(pW)->getTopoShapePtr()->getShape();
         if (sh.IsNull()) {
             PyErr_SetString(Base::BaseExceptionFreeCADError, "Face is empty");
             return 0;
@@ -613,7 +613,7 @@ PyObject* FemMeshPy::getVolumesByFace(PyObject *args)
          return 0;
 
     try {
-        const TopoDS_Shape& sh = static_cast<Part::TopoShapeFacePy*>(pW)->getTopoShapePtr()->_Shape;
+        const TopoDS_Shape& sh = static_cast<Part::TopoShapeFacePy*>(pW)->getTopoShapePtr()->getShape();
         if (sh.IsNull()) {
             PyErr_SetString(Base::BaseExceptionFreeCADError, "Face is empty");
             return 0;
@@ -646,7 +646,7 @@ PyObject* FemMeshPy::getccxVolumesByFace(PyObject *args)
          return 0;
 
     try {
-        const TopoDS_Shape& sh = static_cast<Part::TopoShapeFacePy*>(pW)->getTopoShapePtr()->_Shape;
+        const TopoDS_Shape& sh = static_cast<Part::TopoShapeFacePy*>(pW)->getTopoShapePtr()->getShape();
         if (sh.IsNull()) {
             PyErr_SetString(Base::BaseExceptionFreeCADError, "Face is empty");
             return 0;
@@ -698,7 +698,7 @@ PyObject* FemMeshPy::getNodesBySolid(PyObject *args)
          return 0;
 
     try {
-        const TopoDS_Shape& sh = static_cast<Part::TopoShapeSolidPy*>(pW)->getTopoShapePtr()->_Shape;
+        const TopoDS_Shape& sh = static_cast<Part::TopoShapeSolidPy*>(pW)->getTopoShapePtr()->getShape();
         const TopoDS_Solid& fc = TopoDS::Solid(sh);
         if (sh.IsNull()) {
             PyErr_SetString(Base::BaseExceptionFreeCADError, "Solid is empty");
@@ -726,7 +726,7 @@ PyObject* FemMeshPy::getNodesByFace(PyObject *args)
          return 0;
 
     try {
-        const TopoDS_Shape& sh = static_cast<Part::TopoShapeFacePy*>(pW)->getTopoShapePtr()->_Shape;
+        const TopoDS_Shape& sh = static_cast<Part::TopoShapeFacePy*>(pW)->getTopoShapePtr()->getShape();
         const TopoDS_Face& fc = TopoDS::Face(sh);
         if (sh.IsNull()) {
             PyErr_SetString(Base::BaseExceptionFreeCADError, "Face is empty");
@@ -754,7 +754,7 @@ PyObject* FemMeshPy::getNodesByEdge(PyObject *args)
          return 0;
 
     try {
-        const TopoDS_Shape& sh = static_cast<Part::TopoShapeEdgePy*>(pW)->getTopoShapePtr()->_Shape;
+        const TopoDS_Shape& sh = static_cast<Part::TopoShapeEdgePy*>(pW)->getTopoShapePtr()->getShape();
         const TopoDS_Edge& fc = TopoDS::Edge(sh);
         if (sh.IsNull()) {
             PyErr_SetString(Base::BaseExceptionFreeCADError, "Edge is empty");
@@ -782,7 +782,7 @@ PyObject* FemMeshPy::getNodesByVertex(PyObject *args)
          return 0;
 
     try {
-        const TopoDS_Shape& sh = static_cast<Part::TopoShapeVertexPy*>(pW)->getTopoShapePtr()->_Shape;
+        const TopoDS_Shape& sh = static_cast<Part::TopoShapeVertexPy*>(pW)->getTopoShapePtr()->getShape();
         const TopoDS_Vertex& fc = TopoDS::Vertex(sh);
         if (sh.IsNull()) {
             PyErr_SetString(Base::BaseExceptionFreeCADError, "Vertex is empty");

--- a/src/Mod/Fem/App/HypothesisPy.cpp
+++ b/src/Mod/Fem/App/HypothesisPy.cpp
@@ -182,7 +182,7 @@ Py::Object SMESH_HypothesisPy<T>::setParametersByMesh(const Py::Tuple& args)
         &(Part::TopoShapePy::Type), &shape))
         throw Py::Exception();
     Fem::FemMesh* m = static_cast<Fem::FemMeshPy*>(mesh)->getFemMeshPtr();
-    const TopoDS_Shape& s = static_cast<Part::TopoShapePy*>(shape)->getTopoShapePtr()->_Shape;
+    const TopoDS_Shape& s = static_cast<Part::TopoShapePy*>(shape)->getTopoShapePtr()->getShape();
     return Py::Boolean(hypothesis<SMESH_Hypothesis>()->SetParametersByMesh(m->getSMesh(), s));
 }
 
@@ -299,7 +299,7 @@ Py::Object StdMeshers_AutomaticLengthPy::getLength(const Py::Tuple& args)
     }
     else {
         Py::TopoShape shape(shape_or_double);
-        const TopoDS_Shape& s = shape.extensionObject()->getTopoShapePtr()->_Shape;
+        const TopoDS_Shape& s = shape.extensionObject()->getTopoShapePtr()->getShape();
         return Py::Float(hypothesis<StdMeshers_AutomaticLength>()->GetLength(m->getSMesh(),s));
     }
 

--- a/src/Mod/Measure/App/Measurement.cpp
+++ b/src/Mod/Measure/App/Measurement.cpp
@@ -208,7 +208,7 @@ TopoDS_Shape Measurement::getShape(App::DocumentObject *obj , const char *subNam
 
     // Check if selecting whol object
     if(strcmp(subName, "") == 0) {
-        return refShape._Shape;
+        return refShape.getShape();
     } else {
 
         TopoDS_Shape refSubShape;

--- a/src/Mod/MeshPart/App/AppMeshPartPy.cpp
+++ b/src/Mod/MeshPart/App/AppMeshPartPy.cpp
@@ -134,7 +134,7 @@ private:
             poly.push_back(vec);
         }
 
-        TopoDS_Shape aShape = pcObject->getTopoShapePtr()->_Shape;
+        TopoDS_Shape aShape = pcObject->getTopoShapePtr()->getShape();
         // use the MeshAlgos 
         MeshPart::MeshAlgos::LoftOnCurve(M,aShape,poly,Base::Vector3f(x,y,z),size);
         return Py::asObject(new Mesh::MeshPy(new Mesh::MeshObject(M)));
@@ -182,7 +182,7 @@ private:
         double maxLength=0;
         if (PyArg_ParseTupleAndKeywords(args.ptr(), kwds.ptr(), "O!d", kwds_maxLength,
                                         &(Part::TopoShapePy::Type), &shape, &maxLength)) {
-            MeshPart::Mesher mesher(static_cast<Part::TopoShapePy*>(shape)->getTopoShapePtr()->_Shape);
+            MeshPart::Mesher mesher(static_cast<Part::TopoShapePy*>(shape)->getTopoShapePtr()->getShape());
             mesher.setMethod(MeshPart::Mesher::Mefisto);
             mesher.setMaxLength(maxLength);
             mesher.setRegular(true);
@@ -194,7 +194,7 @@ private:
         double maxArea=0;
         if (PyArg_ParseTupleAndKeywords(args.ptr(), kwds.ptr(), "O!d", kwds_maxArea,
                                         &(Part::TopoShapePy::Type), &shape, &maxArea)) {
-            MeshPart::Mesher mesher(static_cast<Part::TopoShapePy*>(shape)->getTopoShapePtr()->_Shape);
+            MeshPart::Mesher mesher(static_cast<Part::TopoShapePy*>(shape)->getTopoShapePtr()->getShape());
             mesher.setMethod(MeshPart::Mesher::Mefisto);
             mesher.setMaxArea(maxArea);
             mesher.setRegular(true);
@@ -206,7 +206,7 @@ private:
         double localLen=0;
         if (PyArg_ParseTupleAndKeywords(args.ptr(), kwds.ptr(), "O!d", kwds_localLen,
                                         &(Part::TopoShapePy::Type), &shape, &localLen)) {
-            MeshPart::Mesher mesher(static_cast<Part::TopoShapePy*>(shape)->getTopoShapePtr()->_Shape);
+            MeshPart::Mesher mesher(static_cast<Part::TopoShapePy*>(shape)->getTopoShapePtr()->getShape());
             mesher.setMethod(MeshPart::Mesher::Mefisto);
             mesher.setLocalLength(localLen);
             mesher.setRegular(true);
@@ -218,7 +218,7 @@ private:
         double deflection=0;
         if (PyArg_ParseTupleAndKeywords(args.ptr(), kwds.ptr(), "O!d", kwds_deflection,
                                         &(Part::TopoShapePy::Type), &shape, &deflection)) {
-            MeshPart::Mesher mesher(static_cast<Part::TopoShapePy*>(shape)->getTopoShapePtr()->_Shape);
+            MeshPart::Mesher mesher(static_cast<Part::TopoShapePy*>(shape)->getTopoShapePtr()->getShape());
             mesher.setMethod(MeshPart::Mesher::Mefisto);
             mesher.setDeflection(deflection);
             mesher.setRegular(true);
@@ -230,7 +230,7 @@ private:
         double minLen=0, maxLen=0;
         if (PyArg_ParseTupleAndKeywords(args.ptr(), kwds.ptr(), "O!dd", kwds_minmaxLen,
                                         &(Part::TopoShapePy::Type), &shape, &minLen, &maxLen)) {
-            MeshPart::Mesher mesher(static_cast<Part::TopoShapePy*>(shape)->getTopoShapePtr()->_Shape);
+            MeshPart::Mesher mesher(static_cast<Part::TopoShapePy*>(shape)->getTopoShapePtr()->getShape());
             mesher.setMethod(MeshPart::Mesher::Mefisto);
             mesher.setMinMaxLengths(minLen, maxLen);
             mesher.setRegular(true);
@@ -244,7 +244,7 @@ private:
         if (PyArg_ParseTupleAndKeywords(args.ptr(), kwds.ptr(), "O!i|iii", kwds_fineness,
                                         &(Part::TopoShapePy::Type), &shape, &fineness,
                                         &secondOrder, &optimize, &allowquad)) {
-            MeshPart::Mesher mesher(static_cast<Part::TopoShapePy*>(shape)->getTopoShapePtr()->_Shape);
+            MeshPart::Mesher mesher(static_cast<Part::TopoShapePy*>(shape)->getTopoShapePtr()->getShape());
             mesher.setMethod(MeshPart::Mesher::Netgen);
             mesher.setFineness(fineness);
             mesher.setSecondOrder(secondOrder > 0);
@@ -260,7 +260,7 @@ private:
                                         &(Part::TopoShapePy::Type), &shape,
                                         &growthRate, &nbSegPerEdge, &nbSegPerRadius,
                                         &secondOrder, &optimize, &allowquad)) {
-            MeshPart::Mesher mesher(static_cast<Part::TopoShapePy*>(shape)->getTopoShapePtr()->_Shape);
+            MeshPart::Mesher mesher(static_cast<Part::TopoShapePy*>(shape)->getTopoShapePtr()->getShape());
             mesher.setMethod(MeshPart::Mesher::Netgen);
             mesher.setGrowthRate(growthRate);
             mesher.setNbSegPerEdge(nbSegPerEdge);
@@ -274,7 +274,7 @@ private:
 
         PyErr_Clear();
         if (PyArg_ParseTuple(args.ptr(), "O!", &(Part::TopoShapePy::Type), &shape)) {
-            MeshPart::Mesher mesher(static_cast<Part::TopoShapePy*>(shape)->getTopoShapePtr()->_Shape);
+            MeshPart::Mesher mesher(static_cast<Part::TopoShapePy*>(shape)->getTopoShapePtr()->getShape());
 #if defined (HAVE_NETGEN)
             mesher.setMethod(MeshPart::Mesher::Netgen);
 #else

--- a/src/Mod/Part/App/AppPartPy.cpp
+++ b/src/Mod/Part/App/AppPartPy.cpp
@@ -556,7 +556,7 @@ private:
         Part::Feature *pcFeature = (Part::Feature *)pcDoc->addObject("Part::Feature", "Shape");
         // copy the data
         //TopoShape* shape = new MeshObject(*pShape->getTopoShapeObjectPtr());
-        pcFeature->Shape.setValue(pShape->getTopoShapePtr()->_Shape);
+        pcFeature->Shape.setValue(pShape->getTopoShapePtr()->getShape());
         pcDoc->recompute();
 
         return Py::None();
@@ -576,7 +576,7 @@ private:
             for (Py::Sequence::iterator it = list.begin(); it != list.end(); ++it) {
                 if (PyObject_TypeCheck((*it).ptr(), &(Part::TopoShapePy::Type))) {
                     const TopoDS_Shape& sh = static_cast<TopoShapePy*>((*it).ptr())->
-                        getTopoShapePtr()->_Shape;
+                        getTopoShapePtr()->getShape();
                     if (!sh.IsNull())
                         builder.Add(Comp, sh);
                 }
@@ -606,7 +606,7 @@ private:
             for (Py::Sequence::iterator it = list.begin(); it != list.end(); ++it) {
                 if (PyObject_TypeCheck((*it).ptr(), &(Part::TopoShapeFacePy::Type))) {
                     const TopoDS_Shape& sh = static_cast<TopoShapeFacePy*>((*it).ptr())->
-                        getTopoShapePtr()->_Shape;
+                        getTopoShapePtr()->getShape();
                     if (!sh.IsNull())
                         builder.Add(shell, sh);
                 }
@@ -639,7 +639,7 @@ private:
         try {
             if (surf) {
                 const TopoDS_Shape& face = static_cast<TopoShapeFacePy*>(surf)->
-                    getTopoShapePtr()->_Shape;
+                    getTopoShapePtr()->getShape();
                 if (!face.IsNull() && face.ShapeType() == TopAbs_FACE) {
                     builder.LoadInitSurface(TopoDS::Face(face));
                 }
@@ -649,7 +649,7 @@ private:
             for (Py::Sequence::iterator it = list.begin(); it != list.end(); ++it) {
                 if (PyObject_TypeCheck((*it).ptr(), &(Part::TopoShapePy::Type))) {
                     const TopoDS_Shape& sh = static_cast<TopoShapePy*>((*it).ptr())->
-                        getTopoShapePtr()->_Shape;
+                        getTopoShapePtr()->getShape();
                     if (!sh.IsNull()) {
                         if (sh.ShapeType() == TopAbs_EDGE) {
                             builder.Add(TopoDS::Edge(sh), GeomAbs_C0);
@@ -694,7 +694,7 @@ private:
 
         try {
             const TopoDS_Shape& shape = static_cast<TopoShapePy*>(obj)
-                ->getTopoShapePtr()->_Shape;
+                ->getTopoShapePtr()->getShape();
             //first, if we were given a compsolid, try making a solid out of it
             TopExp_Explorer CSExp (shape, TopAbs_COMPSOLID);
             TopoDS_CompSolid compsolid;
@@ -1226,7 +1226,7 @@ private:
                 &(Base::VectorPy::Type), &pDir)) {
                 throw Py::Exception();
             }
-            const TopoDS_Shape& shape = static_cast<TopoShapePy*>(pCrv)->getTopoShapePtr()->_Shape;
+            const TopoDS_Shape& shape = static_cast<TopoShapePy*>(pCrv)->getTopoShapePtr()->getShape();
             if (shape.IsNull()) {
                 throw Py::Exception(PartExceptionOCCError, "shape is empty");
             }
@@ -1297,8 +1297,8 @@ private:
                                             &(TopoShapePy::Type), &sh2))
             throw Py::Exception();
 
-        const TopoDS_Shape& shape1 = static_cast<TopoShapePy*>(sh1)->getTopoShapePtr()->_Shape;
-        const TopoDS_Shape& shape2 = static_cast<TopoShapePy*>(sh2)->getTopoShapePtr()->_Shape;
+        const TopoDS_Shape& shape1 = static_cast<TopoShapePy*>(sh1)->getTopoShapePtr()->getShape();
+        const TopoDS_Shape& shape2 = static_cast<TopoShapePy*>(sh2)->getTopoShapePtr()->getShape();
 
         try {
             if (shape1.ShapeType() == TopAbs_EDGE && shape2.ShapeType() == TopAbs_EDGE) {
@@ -1350,7 +1350,7 @@ private:
             cont = (int)GeomAbs_C0;
 
         try {
-            const TopoDS_Shape& path_shape = static_cast<TopoShapePy*>(pshape)->getTopoShapePtr()->_Shape;
+            const TopoDS_Shape& path_shape = static_cast<TopoShapePy*>(pshape)->getTopoShapePtr()->getShape();
             TopoShape myShape(path_shape);
             TopoDS_Shape face = myShape.makeTube(radius, tolerance, cont, maxdegree, maxsegment);
             return Py::asObject(new TopoShapeFacePy(new TopoShape(face)));
@@ -1373,8 +1373,8 @@ private:
             throw Py::Exception();
 
         try {
-            const TopoDS_Shape& path_shape = static_cast<TopoShapePy*>(path)->getTopoShapePtr()->_Shape;
-            const TopoDS_Shape& prof_shape = static_cast<TopoShapePy*>(profile)->getTopoShapePtr()->_Shape;
+            const TopoDS_Shape& path_shape = static_cast<TopoShapePy*>(path)->getTopoShapePtr()->getShape();
+            const TopoDS_Shape& prof_shape = static_cast<TopoShapePy*>(profile)->getTopoShapePtr()->getShape();
 
             TopoShape myShape(path_shape);
             TopoDS_Shape face = myShape.makeSweep(prof_shape, tolerance, fillMode);
@@ -1448,7 +1448,7 @@ private:
         for (Py::Sequence::iterator it = list.begin(); it != list.end(); ++it) {
             if (PyObject_TypeCheck((*it).ptr(), &(Part::TopoShapePy::Type))) {
                 const TopoDS_Shape& sh = static_cast<TopoShapePy*>((*it).ptr())->
-                    getTopoShapePtr()->_Shape;
+                    getTopoShapePtr()->getShape();
                 profiles.Append(sh);
             }
         }
@@ -1601,7 +1601,7 @@ private:
         PyObject *object;
         if (PyArg_ParseTuple(args.ptr(),"O!",&(Part::TopoShapePy::Type), &object)) {
             TopoShape* ptr = static_cast<TopoShapePy*>(object)->getTopoShapePtr();
-            TopoDS_Shape shape = ptr->_Shape;
+            TopoDS_Shape shape = ptr->getShape();
             if (!shape.IsNull()) {
                 TopAbs_ShapeEnum type = shape.ShapeType();
                 switch (type)
@@ -1647,7 +1647,7 @@ private:
         for (Py::Sequence::iterator it = list.begin(); it != list.end(); ++it) {
             PyObject* item = (*it).ptr();
             if (PyObject_TypeCheck(item, &(Part::TopoShapePy::Type))) {
-                const TopoDS_Shape& sh = static_cast<Part::TopoShapePy*>(item)->getTopoShapePtr()->_Shape;
+                const TopoDS_Shape& sh = static_cast<Part::TopoShapePy*>(item)->getTopoShapePtr()->getShape();
                 if (sh.ShapeType() == TopAbs_EDGE)
                     edges.push_back(TopoDS::Edge(sh));
                 else {
@@ -1685,7 +1685,7 @@ private:
         for (Py::Sequence::iterator it = list.begin(); it != list.end(); ++it) {
             PyObject* item = (*it).ptr();
             if (PyObject_TypeCheck(item, &(Part::TopoShapePy::Type))) {
-                const TopoDS_Shape& sh = static_cast<Part::TopoShapePy*>(item)->getTopoShapePtr()->_Shape;
+                const TopoDS_Shape& sh = static_cast<Part::TopoShapePy*>(item)->getTopoShapePtr()->getShape();
                 if (sh.ShapeType() == TopAbs_EDGE)
                     edges.push_back(TopoDS::Edge(sh));
                 else {
@@ -1713,7 +1713,7 @@ private:
 
         try {
             TopoDS_Shape* shape = new TopoDS_Shape();
-            (*shape) = static_cast<TopoShapePy*>(pcObj)->getTopoShapePtr()->_Shape;
+            (*shape) = static_cast<TopoShapePy*>(pcObj)->getTopoShapePtr()->getShape();
             PyObject* proxy = 0;
             proxy = Base::Interpreter().createSWIGPointerObj("OCC.TopoDS", "TopoDS_Shape *", (void*)shape, 1);
             return Py::asObject(proxy);
@@ -1733,7 +1733,7 @@ private:
             TopoShape* shape = new TopoShape();
             Base::Interpreter().convertSWIGPointerObj("OCC.TopoDS","TopoDS_Shape *", proxy, &ptr, 0);
             TopoDS_Shape* s = reinterpret_cast<TopoDS_Shape*>(ptr);
-            shape->_Shape = (*s);
+            shape->setShape((*s));
             return Py::asObject(new TopoShapePy(shape));
         }
         catch (const Base::Exception& e) {

--- a/src/Mod/Part/App/AttachEnginePyImp.cpp
+++ b/src/Mod/Part/App/AttachEnginePyImp.cpp
@@ -300,7 +300,7 @@ PyObject* AttachEnginePy::getRefTypeOfShape(PyObject* args)
         return NULL;
 
     try{
-        TopoDS_Shape shape = static_cast<Part::TopoShapePy*>(pcObj)->getTopoShapePtr()->_Shape;
+        TopoDS_Shape shape = static_cast<Part::TopoShapePy*>(pcObj)->getTopoShapePtr()->getShape();
         eRefType rt = AttachEngine::getShapeType(shape);
         return Py::new_reference_to(Py::String(AttachEngine::getRefTypeName(rt)));
     } ATTACHERPY_STDCATCH_METH;

--- a/src/Mod/Part/App/Attacher.cpp
+++ b/src/Mod/Part/App/Attacher.cpp
@@ -780,7 +780,8 @@ void AttachEngine::readLinks(const App::PropertyLinkSubList &references,
                     throw Base::Exception("AttachEngine3D: null subshape");
                 shapes[i] = &(storage[storage.size()-1]);
             } else {
-                shapes[i] = &(shape->_Shape);
+                TopoDS_Shape myShape = shape->getShape();
+                shapes[i] = &myShape;
             }
         } else if (  geof->isDerivedFrom(App::Plane::getClassTypeId())  ){
             //obtain Z axis and origin of placement

--- a/src/Mod/Part/App/BRepOffsetAPI_MakePipeShellPyImp.cpp
+++ b/src/Mod/Part/App/BRepOffsetAPI_MakePipeShellPyImp.cpp
@@ -49,7 +49,7 @@ PyObject *BRepOffsetAPI_MakePipeShellPy::PyMake(struct _typeobject *, PyObject *
     PyObject* obj;
     if (!PyArg_ParseTuple(args, "O!",&(TopoShapePy::Type),&obj))
         return 0;
-    const TopoDS_Shape& wire = static_cast<TopoShapePy*>(obj)->getTopoShapePtr()->_Shape;
+    const TopoDS_Shape& wire = static_cast<TopoShapePy*>(obj)->getTopoShapePtr()->getShape();
     if (!wire.IsNull() && wire.ShapeType() == TopAbs_WIRE) {
         return new BRepOffsetAPI_MakePipeShellPy(new BRepOffsetAPI_MakePipeShell(TopoDS::Wire(wire)));
     }
@@ -106,7 +106,7 @@ PyObject* BRepOffsetAPI_MakePipeShellPy::setSpineSupport(PyObject *args)
     PyObject *shape;
     if (!PyArg_ParseTuple(args, "O!",&Part::TopoShapePy::Type,&shape))
         return 0;
-    const TopoDS_Shape& s = static_cast<Part::TopoShapePy*>(shape)->getTopoShapePtr()->_Shape;
+    const TopoDS_Shape& s = static_cast<Part::TopoShapePy*>(shape)->getTopoShapePtr()->getShape();
     Standard_Boolean ok = this->getBRepOffsetAPI_MakePipeShellPtr()->SetMode(s);
     return Py::new_reference_to(Py::Boolean(ok ? true : false));
 }
@@ -119,7 +119,7 @@ PyObject* BRepOffsetAPI_MakePipeShellPy::setAuxiliarySpine(PyObject *args)
                                         ,&PyBool_Type,&curv
                                         ,&PyInt_Type,&keep))
         return 0;
-    const TopoDS_Shape& s = static_cast<Part::TopoShapePy*>(spine)->getTopoShapePtr()->_Shape;
+    const TopoDS_Shape& s = static_cast<Part::TopoShapePy*>(spine)->getTopoShapePtr()->getShape();
     if (s.IsNull() || s.ShapeType() != TopAbs_WIRE) {
         PyErr_SetString(PyExc_TypeError, "spine is not a wire");
         return 0;
@@ -148,7 +148,7 @@ PyObject* BRepOffsetAPI_MakePipeShellPy::setAuxiliarySpine(PyObject *args)
                                         ,&PyBool_Type,&curv
                                         ,&PyBool_Type,&keep))
         return 0;
-    const TopoDS_Shape& s = static_cast<Part::TopoShapePy*>(spine)->getTopoShapePtr()->_Shape;
+    const TopoDS_Shape& s = static_cast<Part::TopoShapePy*>(spine)->getTopoShapePtr()->getShape();
     if (s.IsNull() || s.ShapeType() != TopAbs_WIRE) {
         PyErr_SetString(PyExc_TypeError, "spine is not a wire");
         return 0;
@@ -169,7 +169,7 @@ PyObject* BRepOffsetAPI_MakePipeShellPy::add(PyObject *args)
                                          ,&PyBool_Type,&curv
                                          ,&PyBool_Type,&keep))
         return 0;
-    const TopoDS_Shape& s = static_cast<Part::TopoShapePy*>(prof)->getTopoShapePtr()->_Shape;
+    const TopoDS_Shape& s = static_cast<Part::TopoShapePy*>(prof)->getTopoShapePtr()->getShape();
     this->getBRepOffsetAPI_MakePipeShellPtr()->Add(s,
         PyObject_IsTrue(curv) ? Standard_True : Standard_False,
         PyObject_IsTrue(keep) ? Standard_True : Standard_False);
@@ -181,7 +181,7 @@ PyObject* BRepOffsetAPI_MakePipeShellPy::remove(PyObject *args)
     PyObject *prof;
     if (!PyArg_ParseTuple(args, "O!",&Part::TopoShapePy::Type,&prof))
         return 0;
-    const TopoDS_Shape& s = static_cast<Part::TopoShapePy*>(prof)->getTopoShapePtr()->_Shape;
+    const TopoDS_Shape& s = static_cast<Part::TopoShapePy*>(prof)->getTopoShapePtr()->getShape();
     this->getBRepOffsetAPI_MakePipeShellPtr()->Delete(s);
     Py_Return;
 }
@@ -247,7 +247,7 @@ PyObject* BRepOffsetAPI_MakePipeShellPy::generated(PyObject *args)
     PyObject *shape;
     if (!PyArg_ParseTuple(args, "O!",&Part::TopoShapePy::Type,&shape))
         return 0;
-    const TopoDS_Shape& s = static_cast<Part::TopoShapePy*>(shape)->getTopoShapePtr()->_Shape;
+    const TopoDS_Shape& s = static_cast<Part::TopoShapePy*>(shape)->getTopoShapePtr()->getShape();
     const TopTools_ListOfShape& list = this->getBRepOffsetAPI_MakePipeShellPtr()->Generated(s);
 
     Py::List shapes;

--- a/src/Mod/Part/App/DatumFeature.cpp
+++ b/src/Mod/Part/App/DatumFeature.cpp
@@ -54,7 +54,7 @@ TopoDS_Shape Datum::getShape() const
 {
     Part::TopoShape sh = Shape.getShape();
     sh.setPlacement(Placement.getValue());
-    return sh._Shape;
+    return sh.getShape();
 }
 
 Base::Vector3d Datum::getBasePoint () const {

--- a/src/Mod/Part/App/FeatureFace.cpp
+++ b/src/Mod/Part/App/FeatureFace.cpp
@@ -75,7 +75,7 @@ App::DocumentObjectExecReturn *Face::execute(void)
     for (std::vector<App::DocumentObject*>::iterator it = links.begin(); it != links.end(); ++it) {
         if (!(*it && (*it)->isDerivedFrom(Part::Part2DObject::getClassTypeId())))
             return new App::DocumentObjectExecReturn("Linked object is not a Sketch or Part2DObject");
-        TopoDS_Shape shape = static_cast<Part::Part2DObject*>(*it)->Shape.getShape()._Shape;
+        TopoDS_Shape shape = static_cast<Part::Part2DObject*>(*it)->Shape.getShape().getShape();
         if (shape.IsNull())
             return new App::DocumentObjectExecReturn("Linked shape object is empty");
 

--- a/src/Mod/Part/App/FeatureGeometrySet.cpp
+++ b/src/Mod/Part/App/FeatureGeometrySet.cpp
@@ -56,7 +56,7 @@ App::DocumentObjectExecReturn *FeatureGeometrySet::execute(void)
             result.setShape(sh);
         }
         else {
-            result._Shape = result.fuse(sh);
+            result.setShape(result.fuse(sh));
         }
     }
     

--- a/src/Mod/Part/App/FeatureGeometrySet.cpp
+++ b/src/Mod/Part/App/FeatureGeometrySet.cpp
@@ -53,7 +53,7 @@ App::DocumentObjectExecReturn *FeatureGeometrySet::execute(void)
         TopoDS_Shape sh = (*it)->toShape();
         if (first) {
             first = false;
-            result._Shape = sh;
+            result.setShape(sh);
         }
         else {
             result._Shape = result.fuse(sh);

--- a/src/Mod/Part/App/PartFeatures.cpp
+++ b/src/Mod/Part/App/PartFeatures.cpp
@@ -96,29 +96,29 @@ App::DocumentObjectExecReturn *RuledSurface::execute(void)
 
         TopoDS_Shape curve1;
         const Part::TopoShape& shape1 = static_cast<Part::Feature*>(c1)->Shape.getValue();
-        if (!shape1._Shape.IsNull()) {
+        if (!shape1.getShape().IsNull()) {
             if (!element1[0].empty()) {
                 curve1 = shape1.getSubShape(element1[0].c_str());
             }
             else {
-                if (shape1._Shape.ShapeType() == TopAbs_EDGE)
-                    curve1 = shape1._Shape;
-                else if (shape1._Shape.ShapeType() == TopAbs_WIRE)
-                    curve1 = shape1._Shape;
+                if (shape1.getShape().ShapeType() == TopAbs_EDGE)
+                    curve1 = shape1.getShape();
+                else if (shape1.getShape().ShapeType() == TopAbs_WIRE)
+                    curve1 = shape1.getShape();
             }
         }
 
         TopoDS_Shape curve2;
         const Part::TopoShape& shape2 = static_cast<Part::Feature*>(c2)->Shape.getValue();
-        if (!shape2._Shape.IsNull()) {
+        if (!shape2.getShape().IsNull()) {
             if (!element2[0].empty()) {
                 curve2 = shape2.getSubShape(element2[0].c_str());
             }
             else {
-                if (shape2._Shape.ShapeType() == TopAbs_EDGE)
-                    curve2 = shape2._Shape;
-                else if (shape2._Shape.ShapeType() == TopAbs_WIRE)
-                    curve2 = shape2._Shape;
+                if (shape2.getShape().ShapeType() == TopAbs_EDGE)
+                    curve2 = shape2.getShape();
+                else if (shape2.getShape().ShapeType() == TopAbs_WIRE)
+                    curve2 = shape2.getShape();
             }
         }
 
@@ -339,7 +339,7 @@ App::DocumentObjectExecReturn *Sweep::execute(void)
 
     TopoDS_Shape path;
     const Part::TopoShape& shape = static_cast<Part::Feature*>(spine)->Shape.getValue();
-    if (!shape._Shape.IsNull()) {
+    if (!shape.getShape().IsNull()) {
         try {
             if (!subedge.empty()) {
                 BRepBuilderAPI_MakeWire mkWire;
@@ -349,15 +349,15 @@ App::DocumentObjectExecReturn *Sweep::execute(void)
                 }
                 path = mkWire.Wire();
             }
-            else if (shape._Shape.ShapeType() == TopAbs_EDGE) {
-                path = shape._Shape;
+            else if (shape.getShape().ShapeType() == TopAbs_EDGE) {
+                path = shape.getShape();
             }
-            else if (shape._Shape.ShapeType() == TopAbs_WIRE) {
-                BRepBuilderAPI_MakeWire mkWire(TopoDS::Wire(shape._Shape));
+            else if (shape.getShape().ShapeType() == TopAbs_WIRE) {
+                BRepBuilderAPI_MakeWire mkWire(TopoDS::Wire(shape.getShape()));
                 path = mkWire.Wire();
             }
-            else if (shape._Shape.ShapeType() == TopAbs_COMPOUND) {
-                TopoDS_Iterator it(shape._Shape);
+            else if (shape.getShape().ShapeType() == TopAbs_COMPOUND) {
+                TopoDS_Iterator it(shape.getShape());
                 for (; it.More(); it.Next()) {
                     if (it.Value().IsNull())
                         return new App::DocumentObjectExecReturn("In valid element in spine.");
@@ -369,7 +369,7 @@ App::DocumentObjectExecReturn *Sweep::execute(void)
 
                 Handle(TopTools_HSequenceOfShape) hEdges = new TopTools_HSequenceOfShape();
                 Handle(TopTools_HSequenceOfShape) hWires = new TopTools_HSequenceOfShape();
-                for (TopExp_Explorer xp(shape._Shape, TopAbs_EDGE); xp.More(); xp.Next())
+                for (TopExp_Explorer xp(shape.getShape(), TopAbs_EDGE); xp.More(); xp.Next())
                     hEdges->Append(xp.Current());
 
                 ShapeAnalysis_FreeBounds::ConnectEdgesToWires(hEdges, Precision::Confusion(), Standard_True, hWires);
@@ -580,7 +580,7 @@ App::DocumentObjectExecReturn *Thickness::execute(void)
 
     int countSolids = 0;
     TopExp_Explorer xp;
-    xp.Init(shape._Shape,TopAbs_SOLID);
+    xp.Init(shape.getShape(),TopAbs_SOLID);
     for (;xp.More(); xp.Next()) {
         countSolids++;
     }

--- a/src/Mod/Part/App/PropertyTopoShape.cpp
+++ b/src/Mod/Part/App/PropertyTopoShape.cpp
@@ -96,7 +96,6 @@ void PropertyPartShape::setValue(const TopoDS_Shape& sh)
 
 const TopoDS_Shape& PropertyPartShape::getValue(void)const 
 {
-    _OCCShape = _Shape.getShape();
     return _OCCShape;
 }
 
@@ -282,7 +281,7 @@ void PropertyPartShape::SaveDocFile (Base::Writer &writer) const
 
     if (writer.getMode("BinaryBrep")) {
         TopoShape shape;
-        shape._Shape.setShape(myShape);
+        shape.setShape(myShape);
         shape.exportBinary(writer.Stream());
     }
     else {

--- a/src/Mod/Part/App/PropertyTopoShape.cpp
+++ b/src/Mod/Part/App/PropertyTopoShape.cpp
@@ -82,6 +82,7 @@ void PropertyPartShape::setValue(const TopoShape& sh)
 {
     aboutToSetValue();
     _Shape = sh;
+    _OCCShape = sh.getShape();
     hasSetValue();
 }
 
@@ -89,12 +90,14 @@ void PropertyPartShape::setValue(const TopoDS_Shape& sh)
 {
     aboutToSetValue();
     _Shape.setShape(sh);
+    _OCCShape = sh;
     hasSetValue();
 }
 
 const TopoDS_Shape& PropertyPartShape::getValue(void)const 
 {
-    return _Shape.getShape();
+    _OCCShape = _Shape.getShape();
+    return _OCCShape;
 }
 
 const TopoShape& PropertyPartShape::getShape() const

--- a/src/Mod/Part/App/PropertyTopoShape.cpp
+++ b/src/Mod/Part/App/PropertyTopoShape.cpp
@@ -88,13 +88,13 @@ void PropertyPartShape::setValue(const TopoShape& sh)
 void PropertyPartShape::setValue(const TopoDS_Shape& sh)
 {
     aboutToSetValue();
-    _Shape._Shape = sh;
+    _Shape.setShape(sh);
     hasSetValue();
 }
 
 const TopoDS_Shape& PropertyPartShape::getValue(void)const 
 {
-    return _Shape._Shape;
+    return _Shape.getShape();
 }
 
 const TopoShape& PropertyPartShape::getShape() const
@@ -110,12 +110,12 @@ const Data::ComplexGeoData* PropertyPartShape::getComplexData() const
 Base::BoundBox3d PropertyPartShape::getBoundingBox() const
 {
     Base::BoundBox3d box;
-    if (_Shape._Shape.IsNull())
+    if (_Shape.getShape().IsNull())
         return box;
     try {
         // If the shape is empty an exception may be thrown
         Bnd_Box bounds;
-        BRepBndLib::Add(_Shape._Shape, bounds);
+        BRepBndLib::Add(_Shape.getShape(), bounds);
         bounds.SetGap(0.0);
         Standard_Real xMin, yMin, zMin, xMax, yMax, zMax;
         bounds.Get(xMin, yMin, zMin, xMax, yMax, zMax);
@@ -143,7 +143,7 @@ void PropertyPartShape::transformGeometry(const Base::Matrix4D &rclTrf)
 PyObject *PropertyPartShape::getPyObject(void)
 {
     Base::PyObjectBase* prop;
-    const TopoDS_Shape& sh = _Shape._Shape;
+    const TopoDS_Shape& sh = _Shape.getShape();
     if (sh.IsNull()) {
         prop = new TopoShapePy(new TopoShape(sh));
     }
@@ -203,9 +203,9 @@ App::Property *PropertyPartShape::Copy(void) const
 {
     PropertyPartShape *prop = new PropertyPartShape();
     prop->_Shape = this->_Shape;
-    if (!_Shape._Shape.IsNull()) {
-        BRepBuilderAPI_Copy copy(_Shape._Shape);
-        prop->_Shape._Shape = copy.Shape();
+    if (!_Shape.getShape().IsNull()) {
+        BRepBuilderAPI_Copy copy(_Shape.getShape());
+        prop->_Shape.setShape(copy.Shape());
     }
 
     return prop;
@@ -269,17 +269,17 @@ void PropertyPartShape::SaveDocFile (Base::Writer &writer) const
 {
     // If the shape is empty we simply store nothing. The file size will be 0 which
     // can be checked when reading in the data.
-    if (_Shape._Shape.IsNull())
+    if (_Shape.getShape().IsNull())
         return;
     // NOTE: Cleaning the triangulation may cause problems on some algorithms like BOP
     // Before writing to the project we clean all triangulation data to save memory
-    BRepBuilderAPI_Copy copy(_Shape._Shape);
+    BRepBuilderAPI_Copy copy(_Shape.getShape());
     const TopoDS_Shape& myShape = copy.Shape();
     BRepTools::Clean(myShape); // remove triangulation
 
     if (writer.getMode("BinaryBrep")) {
         TopoShape shape;
-        shape._Shape = myShape;
+        shape._Shape.setShape(myShape);
         shape.exportBinary(writer.Stream());
     }
     else {

--- a/src/Mod/Part/App/PropertyTopoShape.h
+++ b/src/Mod/Part/App/PropertyTopoShape.h
@@ -93,6 +93,7 @@ public:
 
 private:
     TopoShape _Shape;
+    TopoDS_Shape _OCCShape;
 };
 
 struct PartExport ShapeHistory {

--- a/src/Mod/Part/App/TopoShape.cpp
+++ b/src/Mod/Part/App/TopoShape.cpp
@@ -234,6 +234,14 @@ TopoShape::TopoShape(const TopoShape& shape)
 {
 }
 
+void TopoShape::setShape(const TopoDS_Shape& shape){
+    this->_Shape = shape;
+}
+
+TopoDS_Shape TopoShape::getShape() const{
+    return this->_Shape;
+}
+
 std::vector<const char*> TopoShape::getElementTypes(void) const
 {
     std::vector<const char*> temp(3);

--- a/src/Mod/Part/App/TopoShape.h
+++ b/src/Mod/Part/App/TopoShape.h
@@ -63,6 +63,9 @@ public:
     TopoShape(const TopoShape&);
     ~TopoShape();
 
+    void setShape(const TopoDS_Shape& shape);
+    TopoDS_Shape getShape() const;
+
     void operator = (const TopoShape&);
 
     /** @name Placement control */
@@ -232,6 +235,7 @@ public:
                   const std::vector<Facet> &faces, float Accuracy=1.0e-06);
     //@}
 
+private:
     TopoDS_Shape _Shape;
 };
 

--- a/src/Mod/Part/App/TopoShapeCompSolidPyImp.cpp
+++ b/src/Mod/Part/App/TopoShapeCompSolidPyImp.cpp
@@ -104,6 +104,9 @@ PyObject*  TopoShapeCompSolidPy::add(PyObject *args)
         return 0;
     }
 
+    // TODO: Is this needed?
+    getTopoShapePtr()->setShape(comp);
+
     Py_Return;
 }
 

--- a/src/Mod/Part/App/TopoShapeCompSolidPyImp.cpp
+++ b/src/Mod/Part/App/TopoShapeCompSolidPyImp.cpp
@@ -65,7 +65,7 @@ int TopoShapeCompSolidPy::PyInit(PyObject* args, PyObject* /*kwd*/)
         for (Py::Sequence::iterator it = list.begin(); it != list.end(); ++it) {
             if (PyObject_TypeCheck((*it).ptr(), &(Part::TopoShapeSolidPy::Type))) {
                 const TopoDS_Shape& sh = static_cast<TopoShapePy*>((*it).ptr())->
-                    getTopoShapePtr()->_Shape;
+                    getTopoShapePtr()->getShape();
                 if (!sh.IsNull())
                     builder.Add(Comp, sh);
             }
@@ -77,7 +77,7 @@ int TopoShapeCompSolidPy::PyInit(PyObject* args, PyObject* /*kwd*/)
         return -1;
     }
 
-    getTopoShapePtr()->_Shape = Comp;
+    getTopoShapePtr()->setShape(Comp);
     return 0;
 }
 
@@ -88,11 +88,11 @@ PyObject*  TopoShapeCompSolidPy::add(PyObject *args)
         return NULL;
 
     BRep_Builder builder;
-    TopoDS_Shape& comp = getTopoShapePtr()->_Shape;
+    TopoDS_Shape comp = getTopoShapePtr()->getShape();
     
     try {
         const TopoDS_Shape& sh = static_cast<TopoShapePy*>(obj)->
-            getTopoShapePtr()->_Shape;
+            getTopoShapePtr()->getShape();
         if (!sh.IsNull())
             builder.Add(comp, sh);
         else

--- a/src/Mod/Part/App/TopoShapeCompoundPyImp.cpp
+++ b/src/Mod/Part/App/TopoShapeCompoundPyImp.cpp
@@ -105,6 +105,9 @@ PyObject*  TopoShapeCompoundPy::add(PyObject *args)
         PyErr_SetString(PartExceptionOCCError, e->GetMessageString());
         return 0;
     }
+    
+    // TODO: is this needed?
+    getTopoShapePtr()->setShape(comp);
 
     Py_Return;
 }

--- a/src/Mod/Part/App/TopoShapeCompoundPyImp.cpp
+++ b/src/Mod/Part/App/TopoShapeCompoundPyImp.cpp
@@ -69,7 +69,7 @@ int TopoShapeCompoundPy::PyInit(PyObject* args, PyObject* /*kwd*/)
         for (Py::Sequence::iterator it = list.begin(); it != list.end(); ++it) {
             if (PyObject_TypeCheck((*it).ptr(), &(Part::TopoShapePy::Type))) {
                 const TopoDS_Shape& sh = static_cast<TopoShapePy*>((*it).ptr())->
-                    getTopoShapePtr()->_Shape;
+                    getTopoShapePtr()->getShape();
                 if (!sh.IsNull())
                     builder.Add(Comp, sh);
             }
@@ -81,7 +81,7 @@ int TopoShapeCompoundPy::PyInit(PyObject* args, PyObject* /*kwd*/)
         return -1;
     }
 
-    getTopoShapePtr()->_Shape = Comp;
+    getTopoShapePtr()->setShape(Comp);
     return 0;
 }
 
@@ -92,11 +92,11 @@ PyObject*  TopoShapeCompoundPy::add(PyObject *args)
         return NULL;
 
     BRep_Builder builder;
-    TopoDS_Shape& comp = getTopoShapePtr()->_Shape;
+    TopoDS_Shape comp = getTopoShapePtr()->getShape();
     
     try {
         const TopoDS_Shape& sh = static_cast<TopoShapePy*>(obj)->
-            getTopoShapePtr()->_Shape;
+            getTopoShapePtr()->getShape();
         if (!sh.IsNull())
             builder.Add(comp, sh);
     }
@@ -117,7 +117,7 @@ PyObject* TopoShapeCompoundPy::connectEdgesToWires(PyObject *args)
         return 0;
 
     try {
-        const TopoDS_Shape& s = getTopoShapePtr()->_Shape;
+        const TopoDS_Shape& s = getTopoShapePtr()->getShape();
 
         Handle(TopTools_HSequenceOfShape) hEdges = new TopTools_HSequenceOfShape();
         Handle(TopTools_HSequenceOfShape) hWires = new TopTools_HSequenceOfShape();
@@ -135,7 +135,7 @@ PyObject* TopoShapeCompoundPy::connectEdgesToWires(PyObject *args)
             builder.Add(comp, hWires->Value(i));
         }
 
-        getTopoShapePtr()->_Shape = comp;
+        getTopoShapePtr()->setShape(comp);
         return new TopoShapeCompoundPy(new TopoShape(comp));
     }
     catch (Standard_Failure) {

--- a/src/Mod/Part/App/TopoShapeEdgePyImp.cpp
+++ b/src/Mod/Part/App/TopoShapeEdgePyImp.cpp
@@ -125,7 +125,7 @@ int TopoShapeEdgePy::PyInit(PyObject* args, PyObject* /*kwd*/)
 
         try {
             BRepBuilderAPI_MakeEdge mkEdge(curve, first, last);
-            getTopoShapePtr()->_Shape = mkEdge.Edge();
+            getTopoShapePtr()->setShape(mkEdge.Edge());
             return 0;
         }
         catch (Standard_Failure) {
@@ -138,8 +138,8 @@ int TopoShapeEdgePy::PyInit(PyObject* args, PyObject* /*kwd*/)
     PyErr_Clear();
     if (PyArg_ParseTuple(args, "O!", &(Part::TopoShapePy::Type), &pcObj)) {
         TopoShape* shape = static_cast<TopoShapePy*>(pcObj)->getTopoShapePtr();
-        if (shape && !shape->_Shape.IsNull() && shape->_Shape.ShapeType() == TopAbs_EDGE) {
-            this->getTopoShapePtr()->_Shape = shape->_Shape;
+        if (shape && !shape->getShape().IsNull() && shape->getShape().ShapeType() == TopAbs_EDGE) {
+            this->getTopoShapePtr()->setShape(shape->getShape());
             return 0;
         }
         else {
@@ -153,12 +153,12 @@ int TopoShapeEdgePy::PyInit(PyObject* args, PyObject* /*kwd*/)
                                        &(Part::TopoShapeVertexPy::Type), &pcObj2)) {
         TopoShape* shape1 = static_cast<TopoShapePy*>(pcObj)->getTopoShapePtr();
         TopoShape* shape2 = static_cast<TopoShapePy*>(pcObj2)->getTopoShapePtr();
-        const TopoDS_Vertex& v1 = TopoDS::Vertex(shape1->_Shape);
-        const TopoDS_Vertex& v2 = TopoDS::Vertex(shape2->_Shape);
+        const TopoDS_Vertex& v1 = TopoDS::Vertex(shape1->getShape());
+        const TopoDS_Vertex& v2 = TopoDS::Vertex(shape2->getShape());
 
         try {
             BRepBuilderAPI_MakeEdge mkEdge(v1, v2);
-            getTopoShapePtr()->_Shape = mkEdge.Edge();
+            getTopoShapePtr()->setShape(mkEdge.Edge());
             return 0;
         }
         catch (Standard_Failure) {
@@ -180,7 +180,7 @@ PyObject* TopoShapeEdgePy::getParameterByLength(PyObject *args)
     if (!PyArg_ParseTuple(args, "d",&u))
         return 0;
 
-    const TopoDS_Edge& e = TopoDS::Edge(getTopoShapePtr()->_Shape);
+    const TopoDS_Edge& e = TopoDS::Edge(getTopoShapePtr()->getShape());
     BRepAdaptor_Curve adapt(e);
 
     // transform value of [0,Length] to [First,Last]
@@ -207,7 +207,7 @@ PyObject* TopoShapeEdgePy::valueAt(PyObject *args)
     if (!PyArg_ParseTuple(args, "d",&u))
         return 0;
 
-    const TopoDS_Edge& e = TopoDS::Edge(getTopoShapePtr()->_Shape);
+    const TopoDS_Edge& e = TopoDS::Edge(getTopoShapePtr()->getShape());
     BRepAdaptor_Curve adapt(e);
 
     // Check now the orientation of the edge to make
@@ -226,11 +226,11 @@ PyObject* TopoShapeEdgePy::parameterAt(PyObject *args)
         return 0;
 
     try {
-        const TopoDS_Shape& v = static_cast<TopoShapePy*>(pnt)->getTopoShapePtr()->_Shape;
-        const TopoDS_Edge& e = TopoDS::Edge(getTopoShapePtr()->_Shape);
+        const TopoDS_Shape& v = static_cast<TopoShapePy*>(pnt)->getTopoShapePtr()->getShape();
+        const TopoDS_Edge& e = TopoDS::Edge(getTopoShapePtr()->getShape());
 
         if (face) {
-            const TopoDS_Shape& f = static_cast<TopoShapeFacePy*>(face)->getTopoShapePtr()->_Shape;
+            const TopoDS_Shape& f = static_cast<TopoShapeFacePy*>(face)->getTopoShapePtr()->getShape();
             Standard_Real par = BRep_Tool::Parameter(TopoDS::Vertex(v), e, TopoDS::Face(f));
             return PyFloat_FromDouble(par);
         }
@@ -252,7 +252,7 @@ PyObject* TopoShapeEdgePy::tangentAt(PyObject *args)
     if (!PyArg_ParseTuple(args, "d",&u))
         return 0;
 
-    const TopoDS_Edge& e = TopoDS::Edge(getTopoShapePtr()->_Shape);
+    const TopoDS_Edge& e = TopoDS::Edge(getTopoShapePtr()->getShape());
     BRepAdaptor_Curve adapt(e);
 
     BRepLProp_CLProps prop(adapt,u,2,Precision::Confusion());
@@ -273,7 +273,7 @@ PyObject* TopoShapeEdgePy::normalAt(PyObject *args)
     if (!PyArg_ParseTuple(args, "d",&u))
         return 0;
 
-    const TopoDS_Edge& e = TopoDS::Edge(getTopoShapePtr()->_Shape);
+    const TopoDS_Edge& e = TopoDS::Edge(getTopoShapePtr()->getShape());
     BRepAdaptor_Curve adapt(e);
 
     try {
@@ -295,7 +295,7 @@ PyObject* TopoShapeEdgePy::curvatureAt(PyObject *args)
     if (!PyArg_ParseTuple(args, "d",&u))
         return 0;
 
-    const TopoDS_Edge& e = TopoDS::Edge(getTopoShapePtr()->_Shape);
+    const TopoDS_Edge& e = TopoDS::Edge(getTopoShapePtr()->getShape());
     BRepAdaptor_Curve adapt(e);
 
     try {
@@ -316,7 +316,7 @@ PyObject* TopoShapeEdgePy::centerOfCurvatureAt(PyObject *args)
     if (!PyArg_ParseTuple(args, "d",&u))
         return 0;
 
-    const TopoDS_Edge& e = TopoDS::Edge(getTopoShapePtr()->_Shape);
+    const TopoDS_Edge& e = TopoDS::Edge(getTopoShapePtr()->getShape());
     BRepAdaptor_Curve adapt(e);
 
     try {
@@ -338,7 +338,7 @@ PyObject* TopoShapeEdgePy::derivative1At(PyObject *args)
     if (!PyArg_ParseTuple(args, "d",&u))
         return 0;
 
-    const TopoDS_Edge& e = TopoDS::Edge(getTopoShapePtr()->_Shape);
+    const TopoDS_Edge& e = TopoDS::Edge(getTopoShapePtr()->getShape());
     BRepAdaptor_Curve adapt(e);
 
     try {
@@ -359,7 +359,7 @@ PyObject* TopoShapeEdgePy::derivative2At(PyObject *args)
     if (!PyArg_ParseTuple(args, "d",&u))
         return 0;
 
-    const TopoDS_Edge& e = TopoDS::Edge(getTopoShapePtr()->_Shape);
+    const TopoDS_Edge& e = TopoDS::Edge(getTopoShapePtr()->getShape());
     BRepAdaptor_Curve adapt(e);
 
     try {
@@ -380,7 +380,7 @@ PyObject* TopoShapeEdgePy::derivative3At(PyObject *args)
     if (!PyArg_ParseTuple(args, "d",&u))
         return 0;
 
-    const TopoDS_Edge& e = TopoDS::Edge(getTopoShapePtr()->_Shape);
+    const TopoDS_Edge& e = TopoDS::Edge(getTopoShapePtr()->getShape());
     BRepAdaptor_Curve adapt(e);
 
     try {
@@ -398,7 +398,7 @@ PyObject* TopoShapeEdgePy::derivative3At(PyObject *args)
 PyObject* TopoShapeEdgePy::discretize(PyObject *args, PyObject *kwds)
 {
     try {
-        BRepAdaptor_Curve adapt(TopoDS::Edge(getTopoShapePtr()->_Shape));
+        BRepAdaptor_Curve adapt(TopoDS::Edge(getTopoShapePtr()->getShape()));
         bool uniformAbscissaPoints = false;
         bool uniformAbscissaDistance = false;
         int numPoints = -1;
@@ -568,7 +568,7 @@ PyObject* TopoShapeEdgePy::split(PyObject *args)
         return 0;
 
     try {
-        BRepAdaptor_Curve adapt(TopoDS::Edge(getTopoShapePtr()->_Shape));
+        BRepAdaptor_Curve adapt(TopoDS::Edge(getTopoShapePtr()->getShape()));
         Standard_Real f = adapt.FirstParameter();
         Standard_Real l = adapt.LastParameter();
 
@@ -636,8 +636,8 @@ PyObject* TopoShapeEdgePy::isSeam(PyObject *args)
         return 0;
 
     try {
-        const TopoDS_Edge& e = TopoDS::Edge(this->getTopoShapePtr()->_Shape);
-        const TopoDS_Face& f = TopoDS::Face(static_cast<TopoShapeFacePy*>(face)->getTopoShapePtr()->_Shape);
+        const TopoDS_Edge& e = TopoDS::Edge(this->getTopoShapePtr()->getShape());
+        const TopoDS_Face& f = TopoDS::Face(static_cast<TopoShapeFacePy*>(face)->getTopoShapePtr()->getShape());
 
         ShapeAnalysis_Edge sa;
         Standard_Boolean ok = sa.IsSeam(e, f);
@@ -656,7 +656,7 @@ PyObject* TopoShapeEdgePy::setTolerance(PyObject *args)
     if (!PyArg_ParseTuple(args, "d", &tol))
         return 0;
     BRep_Builder aBuilder;
-    const TopoDS_Edge& e = TopoDS::Edge(getTopoShapePtr()->_Shape);
+    const TopoDS_Edge& e = TopoDS::Edge(getTopoShapePtr()->getShape());
     aBuilder.UpdateEdge(e, tol);
     Py_Return;
 }
@@ -665,27 +665,27 @@ PyObject* TopoShapeEdgePy::setTolerance(PyObject *args)
 
 Py::Float TopoShapeEdgePy::getTolerance(void) const
 {
-    const TopoDS_Edge& e = TopoDS::Edge(getTopoShapePtr()->_Shape);
+    const TopoDS_Edge& e = TopoDS::Edge(getTopoShapePtr()->getShape());
     return Py::Float(BRep_Tool::Tolerance(e));
 }
 
 void TopoShapeEdgePy::setTolerance(Py::Float tol)
 {
     BRep_Builder aBuilder;
-    const TopoDS_Edge& e = TopoDS::Edge(getTopoShapePtr()->_Shape);
+    const TopoDS_Edge& e = TopoDS::Edge(getTopoShapePtr()->getShape());
     aBuilder.UpdateEdge(e, (double)tol);
 }
 
 Py::Float TopoShapeEdgePy::getLength(void) const
 {
-    const TopoDS_Edge& e = TopoDS::Edge(getTopoShapePtr()->_Shape);
+    const TopoDS_Edge& e = TopoDS::Edge(getTopoShapePtr()->getShape());
     BRepAdaptor_Curve adapt(e);
     return Py::Float(GCPnts_AbscissaPoint::Length(adapt));
 }
 
 Py::Object TopoShapeEdgePy::getCurve() const
 {
-    const TopoDS_Edge& e = TopoDS::Edge(getTopoShapePtr()->_Shape);
+    const TopoDS_Edge& e = TopoDS::Edge(getTopoShapePtr()->getShape());
     BRepAdaptor_Curve adapt(e);
     switch(adapt.GetType())
     {
@@ -753,7 +753,7 @@ Py::Object TopoShapeEdgePy::getCurve() const
 
 Py::Tuple TopoShapeEdgePy::getParameterRange(void) const
 {
-    const TopoDS_Edge& e = TopoDS::Edge(getTopoShapePtr()->_Shape);
+    const TopoDS_Edge& e = TopoDS::Edge(getTopoShapePtr()->getShape());
     BRepAdaptor_Curve adapt(e);
     double u = adapt.FirstParameter();
     double v = adapt.LastParameter();
@@ -766,7 +766,7 @@ Py::Tuple TopoShapeEdgePy::getParameterRange(void) const
 
 Py::Float TopoShapeEdgePy::getFirstParameter(void) const
 {
-    const TopoDS_Edge& e = TopoDS::Edge(getTopoShapePtr()->_Shape);
+    const TopoDS_Edge& e = TopoDS::Edge(getTopoShapePtr()->getShape());
     BRepAdaptor_Curve adapt(e);
     double t = adapt.FirstParameter();
     return Py::Float(t);
@@ -774,7 +774,7 @@ Py::Float TopoShapeEdgePy::getFirstParameter(void) const
 
 Py::Float TopoShapeEdgePy::getLastParameter(void) const
 {
-    const TopoDS_Edge& e = TopoDS::Edge(getTopoShapePtr()->_Shape);
+    const TopoDS_Edge& e = TopoDS::Edge(getTopoShapePtr()->getShape());
     BRepAdaptor_Curve adapt(e);
     double t = adapt.LastParameter();
     return Py::Float(t);
@@ -783,7 +783,7 @@ Py::Float TopoShapeEdgePy::getLastParameter(void) const
 Py::Object TopoShapeEdgePy::getMass(void) const
 {
     GProp_GProps props;
-    BRepGProp::LinearProperties(getTopoShapePtr()->_Shape, props);
+    BRepGProp::LinearProperties(getTopoShapePtr()->getShape(), props);
     double c = props.Mass();
     return Py::Float(c);
 }
@@ -791,7 +791,7 @@ Py::Object TopoShapeEdgePy::getMass(void) const
 Py::Object TopoShapeEdgePy::getCenterOfMass(void) const
 {
     GProp_GProps props;
-    BRepGProp::LinearProperties(getTopoShapePtr()->_Shape, props);
+    BRepGProp::LinearProperties(getTopoShapePtr()->getShape(), props);
     gp_Pnt c = props.CentreOfMass();
     return Py::Vector(Base::Vector3d(c.X(),c.Y(),c.Z()));
 }
@@ -799,7 +799,7 @@ Py::Object TopoShapeEdgePy::getCenterOfMass(void) const
 Py::Object TopoShapeEdgePy::getMatrixOfInertia(void) const
 {
     GProp_GProps props;
-    BRepGProp::LinearProperties(getTopoShapePtr()->_Shape, props);
+    BRepGProp::LinearProperties(getTopoShapePtr()->getShape(), props);
     gp_Mat m = props.MatrixOfInertia();
     Base::Matrix4D mat;
     for (int i=0; i<3; i++) {
@@ -813,7 +813,7 @@ Py::Object TopoShapeEdgePy::getMatrixOfInertia(void) const
 Py::Object TopoShapeEdgePy::getStaticMoments(void) const
 {
     GProp_GProps props;
-    BRepGProp::LinearProperties(getTopoShapePtr()->_Shape, props);
+    BRepGProp::LinearProperties(getTopoShapePtr()->getShape(), props);
     Standard_Real lx,ly,lz;
     props.StaticMoments(lx,ly,lz);
     Py::Tuple tuple(3);
@@ -826,7 +826,7 @@ Py::Object TopoShapeEdgePy::getStaticMoments(void) const
 Py::Dict TopoShapeEdgePy::getPrincipalProperties(void) const
 {
     GProp_GProps props;
-    BRepGProp::LinearProperties(getTopoShapePtr()->_Shape, props);
+    BRepGProp::LinearProperties(getTopoShapePtr()->getShape(), props);
     GProp_PrincipalProps pprops = props.PrincipalProperties();
 
     Py::Dict dict;
@@ -858,15 +858,15 @@ Py::Dict TopoShapeEdgePy::getPrincipalProperties(void) const
 
 Py::Boolean TopoShapeEdgePy::getClosed(void) const
 {
-    if (getTopoShapePtr()->_Shape.IsNull())
+    if (getTopoShapePtr()->getShape().IsNull())
         throw Py::Exception("Cannot determine the 'Closed'' flag of an empty shape");
-    Standard_Boolean ok = BRep_Tool::IsClosed(getTopoShapePtr()->_Shape);
+    Standard_Boolean ok = BRep_Tool::IsClosed(getTopoShapePtr()->getShape());
     return Py::Boolean(ok ? true : false);
 }
 
 Py::Boolean TopoShapeEdgePy::getDegenerated(void) const
 {
-    Standard_Boolean ok = BRep_Tool::Degenerated(TopoDS::Edge(getTopoShapePtr()->_Shape));
+    Standard_Boolean ok = BRep_Tool::Degenerated(TopoDS::Edge(getTopoShapePtr()->getShape()));
     return Py::Boolean(ok ? true : false);
 }
 

--- a/src/Mod/Part/App/TopoShapeFacePyImp.cpp
+++ b/src/Mod/Part/App/TopoShapeFacePyImp.cpp
@@ -112,7 +112,7 @@ int TopoShapeFacePy::PyInit(PyObject* args, PyObject* /*kwd*/)
     PyObject *pW;
     if (PyArg_ParseTuple(args, "O!", &(Part::TopoShapePy::Type), &pW)) {
         try {
-            const TopoDS_Shape& sh = static_cast<Part::TopoShapePy*>(pW)->getTopoShapePtr()->_Shape;
+            const TopoDS_Shape& sh = static_cast<Part::TopoShapePy*>(pW)->getTopoShapePtr()->getShape();
             if (sh.IsNull()) {
                 PyErr_SetString(PartExceptionOCCError, "cannot create face out of empty wire");
                 return -1;
@@ -124,11 +124,11 @@ int TopoShapeFacePy::PyInit(PyObject* args, PyObject* /*kwd*/)
                     PyErr_SetString(PartExceptionOCCError, "Failed to create face from wire");
                     return -1;
                 }
-                getTopoShapePtr()->_Shape = mkFace.Face();
+                getTopoShapePtr()->setShape(mkFace.Face());
                 return 0;
             }
             else if (sh.ShapeType() == TopAbs_FACE) {
-                getTopoShapePtr()->_Shape = sh;
+                getTopoShapePtr()->setShape(sh);
                 return 0;
             }
         }
@@ -160,7 +160,7 @@ int TopoShapeFacePy::PyInit(PyObject* args, PyObject* /*kwd*/)
                 for (Py::List::iterator it = list.begin(); it != list.end(); ++it) {
                     PyObject* item = (*it).ptr();
                     if (PyObject_TypeCheck(item, &(Part::TopoShapePy::Type))) {
-                        const TopoDS_Shape& sh = static_cast<Part::TopoShapePy*>(item)->getTopoShapePtr()->_Shape;
+                        const TopoDS_Shape& sh = static_cast<Part::TopoShapePy*>(item)->getTopoShapePtr()->getShape();
                         if (sh.ShapeType() == TopAbs_WIRE)
                             mkFace.Add(TopoDS::Wire(sh));
                         else {
@@ -175,7 +175,7 @@ int TopoShapeFacePy::PyInit(PyObject* args, PyObject* /*kwd*/)
                 }
             }
 
-            getTopoShapePtr()->_Shape = mkFace.Face();
+            getTopoShapePtr()->setShape(mkFace.Face());
             return 0;
         }
         catch (Standard_Failure) {
@@ -193,7 +193,7 @@ int TopoShapeFacePy::PyInit(PyObject* args, PyObject* /*kwd*/)
             for (Py::List::iterator it = list.begin(); it != list.end(); ++it) {
                 PyObject* item = (*it).ptr();
                 if (PyObject_TypeCheck(item, &(Part::TopoShapePy::Type))) {
-                    const TopoDS_Shape& sh = static_cast<Part::TopoShapePy*>(item)->getTopoShapePtr()->_Shape;
+                    const TopoDS_Shape& sh = static_cast<Part::TopoShapePy*>(item)->getTopoShapePtr()->getShape();
                     if (sh.ShapeType() == TopAbs_WIRE)
                         wires.push_back(TopoDS::Wire(sh));
                     else
@@ -231,7 +231,7 @@ int TopoShapeFacePy::PyInit(PyObject* args, PyObject* /*kwd*/)
                 }
                 for (std::vector<TopoDS_Wire>::iterator it = wires.begin()+1; it != wires.end(); ++it)
                     mkFace.Add(*it);
-                getTopoShapePtr()->_Shape = mkFace.Face();
+                getTopoShapePtr()->setShape(mkFace.Face());
                 return 0;
             }
             else {
@@ -254,7 +254,7 @@ PyObject* TopoShapeFacePy::makeOffset(PyObject *args)
     double dist;
     if (!PyArg_ParseTuple(args, "d",&dist))
         return 0;
-    const TopoDS_Face& f = TopoDS::Face(getTopoShapePtr()->_Shape);
+    const TopoDS_Face& f = TopoDS::Face(getTopoShapePtr()->getShape());
     BRepBuilderAPI_FindPlane findPlane(f);
     if (!findPlane.Found()) {
         PyErr_SetString(PartExceptionOCCError, "No planar face");
@@ -273,7 +273,7 @@ PyObject* TopoShapeFacePy::valueAt(PyObject *args)
     if (!PyArg_ParseTuple(args, "dd",&u,&v))
         return 0;
 
-    const TopoDS_Face& f = TopoDS::Face(getTopoShapePtr()->_Shape);
+    const TopoDS_Face& f = TopoDS::Face(getTopoShapePtr()->getShape());
 
     BRepAdaptor_Surface adapt(f);
     BRepLProp_SLProps prop(adapt,u,v,0,Precision::Confusion());
@@ -287,7 +287,7 @@ PyObject* TopoShapeFacePy::normalAt(PyObject *args)
     if (!PyArg_ParseTuple(args, "dd",&u,&v))
         return 0;
 
-    const TopoDS_Face& f = TopoDS::Face(getTopoShapePtr()->_Shape);
+    const TopoDS_Face& f = TopoDS::Face(getTopoShapePtr()->getShape());
     BRepAdaptor_Surface adapt(f);
 
     BRepLProp_SLProps prop(adapt,u,v,2,Precision::Confusion());
@@ -311,7 +311,7 @@ PyObject* TopoShapeFacePy::tangentAt(PyObject *args)
 
     gp_Dir dir;
     Py::Tuple tuple(2);
-    const TopoDS_Face& f = TopoDS::Face(getTopoShapePtr()->_Shape);
+    const TopoDS_Face& f = TopoDS::Face(getTopoShapePtr()->getShape());
     BRepAdaptor_Surface adapt(f);
 
     BRepLProp_SLProps prop(adapt,u,v,2,Precision::Confusion());
@@ -342,7 +342,7 @@ PyObject* TopoShapeFacePy::curvatureAt(PyObject *args)
         return 0;
 
     Py::Tuple tuple(2);
-    const TopoDS_Face& f = TopoDS::Face(getTopoShapePtr()->_Shape);
+    const TopoDS_Face& f = TopoDS::Face(getTopoShapePtr()->getShape());
     BRepAdaptor_Surface adapt(f);
 
     BRepLProp_SLProps prop(adapt,u,v,2,Precision::Confusion());
@@ -365,7 +365,7 @@ PyObject* TopoShapeFacePy::derivative1At(PyObject *args)
         return 0;
 
     Py::Tuple tuple(2);
-    const TopoDS_Face& f = TopoDS::Face(getTopoShapePtr()->_Shape);
+    const TopoDS_Face& f = TopoDS::Face(getTopoShapePtr()->getShape());
     BRepAdaptor_Surface adapt(f);
 
     try {
@@ -390,7 +390,7 @@ PyObject* TopoShapeFacePy::derivative2At(PyObject *args)
         return 0;
 
     Py::Tuple tuple(2);
-    const TopoDS_Face& f = TopoDS::Face(getTopoShapePtr()->_Shape);
+    const TopoDS_Face& f = TopoDS::Face(getTopoShapePtr()->getShape());
     BRepAdaptor_Surface adapt(f);
 
     try {
@@ -414,7 +414,7 @@ PyObject* TopoShapeFacePy::isPartOfDomain(PyObject *args)
     if (!PyArg_ParseTuple(args, "dd",&u,&v))
         return 0;
 
-    const TopoDS_Face& face = TopoDS::Face(getTopoShapePtr()->_Shape);
+    const TopoDS_Face& face = TopoDS::Face(getTopoShapePtr()->getShape());
 
     double tol;
     //double u1, u2, v1, v2, dialen;
@@ -443,7 +443,7 @@ PyObject* TopoShapeFacePy::makeHalfSpace(PyObject *args)
 
     try {
         Base::Vector3d pt = Py::Vector(pPnt,false).toVector();
-        BRepPrimAPI_MakeHalfSpace mkHS(TopoDS::Face(this->getTopoShapePtr()->_Shape), gp_Pnt(pt.x,pt.y,pt.z));
+        BRepPrimAPI_MakeHalfSpace mkHS(TopoDS::Face(this->getTopoShapePtr()->getShape()), gp_Pnt(pt.x,pt.y,pt.z));
         return new TopoShapeSolidPy(new TopoShape(mkHS.Solid()));
     }
     catch (Standard_Failure) {
@@ -459,7 +459,7 @@ PyObject* TopoShapeFacePy::validate(PyObject *args)
         return 0;
 
     try {
-        const TopoDS_Face& face = TopoDS::Face(getTopoShapePtr()->_Shape);
+        const TopoDS_Face& face = TopoDS::Face(getTopoShapePtr()->getShape());
         BRepCheck_Analyzer aChecker(face);
         if (!aChecker.IsValid()) {
             TopoDS_Wire outerwire = ShapeAnalysis::OuterWire(face);
@@ -490,10 +490,10 @@ PyObject* TopoShapeFacePy::validate(PyObject *args)
                 fix.Perform();
                 fix.FixWireTool()->Perform();
                 fix.FixFaceTool()->Perform();
-                getTopoShapePtr()->_Shape = fix.Shape();
+                getTopoShapePtr()->setShape(fix.Shape());
             }
             else {
-                getTopoShapePtr()->_Shape = mkFace.Face();
+                getTopoShapePtr()->setShape(mkFace.Face());
             }
         }
 
@@ -508,7 +508,7 @@ PyObject* TopoShapeFacePy::validate(PyObject *args)
 
 Py::Object TopoShapeFacePy::getSurface() const
 {
-    const TopoDS_Face& f = TopoDS::Face(getTopoShapePtr()->_Shape);
+    const TopoDS_Face& f = TopoDS::Face(getTopoShapePtr()->getShape());
     BRepAdaptor_Surface adapt(f);
     switch(adapt.GetType())
     {
@@ -623,27 +623,27 @@ PyObject* TopoShapeFacePy::setTolerance(PyObject *args)
     if (!PyArg_ParseTuple(args, "d", &tol))
         return 0;
     BRep_Builder aBuilder;
-    const TopoDS_Face& f = TopoDS::Face(getTopoShapePtr()->_Shape);
+    const TopoDS_Face& f = TopoDS::Face(getTopoShapePtr()->getShape());
     aBuilder.UpdateFace(f, tol);
     Py_Return;
 }
 
 Py::Float TopoShapeFacePy::getTolerance(void) const
 {
-    const TopoDS_Face& f = TopoDS::Face(getTopoShapePtr()->_Shape);
+    const TopoDS_Face& f = TopoDS::Face(getTopoShapePtr()->getShape());
     return Py::Float(BRep_Tool::Tolerance(f));
 }
 
 void TopoShapeFacePy::setTolerance(Py::Float tol)
 {
     BRep_Builder aBuilder;
-    const TopoDS_Face& f = TopoDS::Face(getTopoShapePtr()->_Shape);
+    const TopoDS_Face& f = TopoDS::Face(getTopoShapePtr()->getShape());
     aBuilder.UpdateFace(f, (double)tol);
 }
 
 Py::Tuple TopoShapeFacePy::getParameterRange(void) const
 {
-    const TopoDS_Face& f = TopoDS::Face(getTopoShapePtr()->_Shape);
+    const TopoDS_Face& f = TopoDS::Face(getTopoShapePtr()->getShape());
     BRepAdaptor_Surface adapt(f);
     double u1 = adapt.FirstUParameter();
     double u2 = adapt.LastUParameter();
@@ -675,7 +675,7 @@ Py::Object TopoShapeFacePy::getWire(void) const
 
 Py::Object TopoShapeFacePy::getOuterWire(void) const
 {
-    const TopoDS_Shape& clSh = getTopoShapePtr()->_Shape;
+    const TopoDS_Shape& clSh = getTopoShapePtr()->getShape();
     if (clSh.IsNull())
         throw Py::Exception("Null shape");
     if (clSh.ShapeType() == TopAbs_FACE) {
@@ -692,7 +692,7 @@ Py::Object TopoShapeFacePy::getOuterWire(void) const
 Py::Object TopoShapeFacePy::getMass(void) const
 {
     GProp_GProps props;
-    BRepGProp::SurfaceProperties(getTopoShapePtr()->_Shape, props);
+    BRepGProp::SurfaceProperties(getTopoShapePtr()->getShape(), props);
     double c = props.Mass();
     return Py::Float(c);
 }
@@ -700,7 +700,7 @@ Py::Object TopoShapeFacePy::getMass(void) const
 Py::Object TopoShapeFacePy::getCenterOfMass(void) const
 {
     GProp_GProps props;
-    BRepGProp::SurfaceProperties(getTopoShapePtr()->_Shape, props);
+    BRepGProp::SurfaceProperties(getTopoShapePtr()->getShape(), props);
     gp_Pnt c = props.CentreOfMass();
     return Py::Vector(Base::Vector3d(c.X(),c.Y(),c.Z()));
 }
@@ -708,7 +708,7 @@ Py::Object TopoShapeFacePy::getCenterOfMass(void) const
 Py::Object TopoShapeFacePy::getMatrixOfInertia(void) const
 {
     GProp_GProps props;
-    BRepGProp::SurfaceProperties(getTopoShapePtr()->_Shape, props);
+    BRepGProp::SurfaceProperties(getTopoShapePtr()->getShape(), props);
     gp_Mat m = props.MatrixOfInertia();
     Base::Matrix4D mat;
     for (int i=0; i<3; i++) {
@@ -722,7 +722,7 @@ Py::Object TopoShapeFacePy::getMatrixOfInertia(void) const
 Py::Object TopoShapeFacePy::getStaticMoments(void) const
 {
     GProp_GProps props;
-    BRepGProp::SurfaceProperties(getTopoShapePtr()->_Shape, props);
+    BRepGProp::SurfaceProperties(getTopoShapePtr()->getShape(), props);
     Standard_Real lx,ly,lz;
     props.StaticMoments(lx,ly,lz);
     Py::Tuple tuple(3);
@@ -735,7 +735,7 @@ Py::Object TopoShapeFacePy::getStaticMoments(void) const
 Py::Dict TopoShapeFacePy::getPrincipalProperties(void) const
 {
     GProp_GProps props;
-    BRepGProp::SurfaceProperties(getTopoShapePtr()->_Shape, props);
+    BRepGProp::SurfaceProperties(getTopoShapePtr()->getShape(), props);
     GProp_PrincipalProps pprops = props.PrincipalProperties();
 
     Py::Dict dict;

--- a/src/Mod/Part/App/TopoShapePyImp.cpp
+++ b/src/Mod/Part/App/TopoShapePyImp.cpp
@@ -2144,6 +2144,8 @@ void TopoShapePy::setOrientation(Py::String arg)
     }
 
     sh.Orientation(type);
+    // TODO: is this needed?
+    getTopoShapePtr()->setShape(sh);
 }
 
 Py::List TopoShapePy::getFaces(void) const

--- a/src/Mod/Part/App/TopoShapePyImp.cpp
+++ b/src/Mod/Part/App/TopoShapePyImp.cpp
@@ -135,10 +135,10 @@ int TopoShapePy::PyInit(PyObject* args, PyObject*)
                         getGeometryPtr()->toShape();
                     if (first) {
                         first = false;
-                        shape._Shape = sh;
+                        shape.setShape(sh);
                     }
                     else {
-                        shape._Shape = shape.fuse(sh);
+                        shape.setShape(shape.fuse(sh));
                     }
                 }
             }
@@ -149,7 +149,7 @@ int TopoShapePy::PyInit(PyObject* args, PyObject*)
             return -1;
         }
 
-        getTopoShapePtr()->_Shape = shape._Shape;
+        getTopoShapePtr()->setShape(shape.getShape());
     }
 
     return 0;
@@ -208,7 +208,7 @@ PyObject* TopoShapePy::copy(PyObject *args)
     if (!PyArg_ParseTuple(args, ""))
         return NULL;
 
-    const TopoDS_Shape& shape = this->getTopoShapePtr()->_Shape;
+    const TopoDS_Shape& shape = this->getTopoShapePtr()->getShape();
     PyTypeObject* type = this->GetType();
     PyObject* cpy = 0;
     // let the type object decide
@@ -221,7 +221,7 @@ PyObject* TopoShapePy::copy(PyObject *args)
 
     if (!shape.IsNull()) {
         BRepBuilderAPI_Copy c(shape);
-        static_cast<TopoShapePy*>(cpy)->getTopoShapePtr()->_Shape = c.Shape();
+        static_cast<TopoShapePy*>(cpy)->getTopoShapePtr()->setShape(c.Shape());
     }
     return cpy;
 }
@@ -231,7 +231,7 @@ PyObject* TopoShapePy::cleaned(PyObject *args)
     if (!PyArg_ParseTuple(args, ""))
         return NULL;
 
-    const TopoDS_Shape& shape = this->getTopoShapePtr()->_Shape;
+    const TopoDS_Shape& shape = this->getTopoShapePtr()->getShape();
     PyTypeObject* type = this->GetType();
     PyObject* cpy = 0;
     // let the type object decide
@@ -246,7 +246,7 @@ PyObject* TopoShapePy::cleaned(PyObject *args)
         BRepBuilderAPI_Copy c(shape);
         const TopoDS_Shape& copiedShape = c.Shape();
         BRepTools::Clean(copiedShape); // remove triangulation
-        static_cast<TopoShapePy*>(cpy)->getTopoShapePtr()->_Shape = c.Shape();
+        static_cast<TopoShapePy*>(cpy)->getTopoShapePtr()->setShape(c.Shape());
     }
     return cpy;
 }
@@ -265,14 +265,14 @@ PyObject* TopoShapePy::replaceShape(PyObject *args)
             Py::TopoShape sh1(tuple[0]);
             Py::TopoShape sh2(tuple[1]);
             shapes.push_back(std::make_pair(
-                sh1.extensionObject()->getTopoShapePtr()->_Shape,
-                sh2.extensionObject()->getTopoShapePtr()->_Shape)
+                sh1.extensionObject()->getTopoShapePtr()->getShape(),
+                sh2.extensionObject()->getTopoShapePtr()->getShape())
             );
         }
         PyTypeObject* type = this->GetType();
         PyObject* inst = type->tp_new(type, this, 0);
-        static_cast<TopoShapePy*>(inst)->getTopoShapePtr()->_Shape = 
-            this->getTopoShapePtr()->replaceShape(shapes);
+        static_cast<TopoShapePy*>(inst)->getTopoShapePtr()->setShape(
+            this->getTopoShapePtr()->replaceShape(shapes));
         return inst;
     }
     catch (const Py::Exception&) {
@@ -296,12 +296,12 @@ PyObject* TopoShapePy::removeShape(PyObject *args)
         for (Py::Sequence::iterator it = list.begin(); it != list.end(); ++it) {
             Py::TopoShape sh(*it);
             shapes.push_back(
-                sh.extensionObject()->getTopoShapePtr()->_Shape
+                sh.extensionObject()->getTopoShapePtr()->getShape()
             );
         }
         PyTypeObject* type = this->GetType();
         PyObject* inst = type->tp_new(type, this, 0);
-        static_cast<TopoShapePy*>(inst)->getTopoShapePtr()->_Shape = 
+        static_cast<TopoShapePy*>(inst)->getTopoShapePtr()->getShape() = 
             this->getTopoShapePtr()->removeShape(shapes);
         return inst;
     }
@@ -331,7 +331,7 @@ PyObject* TopoShapePy::writeInventor(PyObject * args)
         return NULL;
 
     std::stringstream result;
-    BRepMesh_IncrementalMesh(getTopoShapePtr()->_Shape,dev);
+    BRepMesh_IncrementalMesh(getTopoShapePtr()->getShape(),dev);
     if (mode == 0)
         getTopoShapePtr()->exportFaceSet(dev, angle, result);
     else if (mode == 1)
@@ -341,7 +341,7 @@ PyObject* TopoShapePy::writeInventor(PyObject * args)
         getTopoShapePtr()->exportLineSet(result);
     }
     // NOTE: Cleaning the triangulation may cause problems on some algorithms like BOP
-    //BRepTools::Clean(getTopoShapePtr()->_Shape); // remove triangulation
+    //BRepTools::Clean(getTopoShapePtr()->getShape()); // remove triangulation
     return Py::new_reference_to(Py::String(result.str()));
 }
 
@@ -679,7 +679,7 @@ PyObject* TopoShapePy::revolve(PyObject *args)
     double d=360;
     if (PyArg_ParseTuple(args, "O!O!|d", &(Base::VectorPy::Type), &pPos, &(Base::VectorPy::Type), &pDir,&d)) {
         try {
-            const TopoDS_Shape& input = this->getTopoShapePtr()->_Shape;
+            const TopoDS_Shape& input = this->getTopoShapePtr()->getShape();
             if (input.IsNull()) {
                 PyErr_SetString(PartExceptionOCCError, "empty shape cannot be revolved");
                 return 0;
@@ -743,7 +743,7 @@ PyObject*  TopoShapePy::check(PyObject *args)
 {
     if (!PyArg_ParseTuple(args, ""))
         return NULL;
-    if (!getTopoShapePtr()->_Shape.IsNull()) {
+    if (!getTopoShapePtr()->getShape().IsNull()) {
         std::stringstream str;
         if (!getTopoShapePtr()->analyze(str)) {
             PyErr_SetString(PyExc_StandardError, str.str().c_str());
@@ -760,7 +760,7 @@ PyObject*  TopoShapePy::fuse(PyObject *args)
     if (!PyArg_ParseTuple(args, "O!", &(TopoShapePy::Type), &pcObj))
         return NULL;
 
-    TopoDS_Shape shape = static_cast<TopoShapePy*>(pcObj)->getTopoShapePtr()->_Shape;
+    TopoDS_Shape shape = static_cast<TopoShapePy*>(pcObj)->getTopoShapePtr()->getShape();
     try {
         // Let's call algorithm computing a fuse operation:
         TopoDS_Shape fusShape = this->getTopoShapePtr()->fuse(shape);
@@ -788,7 +788,7 @@ PyObject*  TopoShapePy::multiFuse(PyObject *args)
     for (Py::Sequence::iterator it = shapeSeq.begin(); it != shapeSeq.end(); ++it) {
         PyObject* item = (*it).ptr();
         if (PyObject_TypeCheck(item, &(Part::TopoShapePy::Type))) {
-            shapeVec.push_back(static_cast<Part::TopoShapePy*>(item)->getTopoShapePtr()->_Shape);
+            shapeVec.push_back(static_cast<Part::TopoShapePy*>(item)->getTopoShapePtr()->getShape());
         }
         else {
             PyErr_SetString(PyExc_TypeError, "non-shape object in sequence");
@@ -816,7 +816,7 @@ PyObject*  TopoShapePy::oldFuse(PyObject *args)
     if (!PyArg_ParseTuple(args, "O!", &(TopoShapePy::Type), &pcObj))
         return NULL;
 
-    TopoDS_Shape shape = static_cast<TopoShapePy*>(pcObj)->getTopoShapePtr()->_Shape;
+    TopoDS_Shape shape = static_cast<TopoShapePy*>(pcObj)->getTopoShapePtr()->getShape();
     try {
         // Let's call algorithm computing a fuse operation:
         TopoDS_Shape fusShape = this->getTopoShapePtr()->oldFuse(shape);
@@ -839,7 +839,7 @@ PyObject*  TopoShapePy::common(PyObject *args)
     if (!PyArg_ParseTuple(args, "O!", &(TopoShapePy::Type), &pcObj))
         return NULL;
 
-    TopoDS_Shape shape = static_cast<TopoShapePy*>(pcObj)->getTopoShapePtr()->_Shape;
+    TopoDS_Shape shape = static_cast<TopoShapePy*>(pcObj)->getTopoShapePtr()->getShape();
     try {
         // Let's call algorithm computing a common operation:
         TopoDS_Shape comShape = this->getTopoShapePtr()->common(shape);
@@ -862,7 +862,7 @@ PyObject*  TopoShapePy::section(PyObject *args)
     if (!PyArg_ParseTuple(args, "O!", &(TopoShapePy::Type), &pcObj))
         return NULL;
 
-    TopoDS_Shape shape = static_cast<TopoShapePy*>(pcObj)->getTopoShapePtr()->_Shape;
+    TopoDS_Shape shape = static_cast<TopoShapePy*>(pcObj)->getTopoShapePtr()->getShape();
     try {
         // Let's call algorithm computing a section operation:
         TopoDS_Shape secShape = this->getTopoShapePtr()->section(shape);
@@ -940,7 +940,7 @@ PyObject*  TopoShapePy::cut(PyObject *args)
     if (!PyArg_ParseTuple(args, "O!", &(TopoShapePy::Type), &pcObj))
         return NULL;
 
-    TopoDS_Shape shape = static_cast<TopoShapePy*>(pcObj)->getTopoShapePtr()->_Shape;
+    TopoDS_Shape shape = static_cast<TopoShapePy*>(pcObj)->getTopoShapePtr()->getShape();
     try {
         // Let's call algorithm computing a cut operation:
         TopoDS_Shape cutShape = this->getTopoShapePtr()->cut(shape);
@@ -968,7 +968,7 @@ PyObject*  TopoShapePy::generalFuse(PyObject *args)
     for (Py::Sequence::iterator it = shapeSeq.begin(); it != shapeSeq.end(); ++it) {
         PyObject* item = (*it).ptr();
         if (PyObject_TypeCheck(item, &(Part::TopoShapePy::Type))) {
-            shapeVec.push_back(static_cast<Part::TopoShapePy*>(item)->getTopoShapePtr()->_Shape);
+            shapeVec.push_back(static_cast<Part::TopoShapePy*>(item)->getTopoShapePtr()->getShape());
         }
         else {
             PyErr_SetString(PyExc_TypeError, "non-shape object in sequence");
@@ -1030,7 +1030,7 @@ PyObject* TopoShapePy::childShapes(PyObject *args)
         return NULL;
 
     try {
-        TopoDS_Iterator it(getTopoShapePtr()->_Shape,
+        TopoDS_Iterator it(getTopoShapePtr()->getShape(),
             PyObject_IsTrue(cumOri) ? Standard_True : Standard_False,
             PyObject_IsTrue(cumLoc) ? Standard_True : Standard_False);
         Py::List list;
@@ -1184,7 +1184,7 @@ PyObject*  TopoShapePy::translate(PyObject *args)
     gp_Trsf mov;
     mov.SetTranslation(gp_Vec(vec.x,vec.y,vec.z));
     TopLoc_Location loc(mov);
-    getTopoShapePtr()->_Shape.Move(loc);
+    getTopoShapePtr()->getShape().Move(loc);
     Py_Return;
 }
 
@@ -1210,7 +1210,7 @@ PyObject*  TopoShapePy::rotate(PyObject *args)
         gp_Trsf mov;
         mov.SetRotation(axis, angle*(M_PI/180));
         TopLoc_Location loc(mov);
-        getTopoShapePtr()->_Shape.Move(loc);
+        getTopoShapePtr()->getShape().Move(loc);
         Py_Return;
     }
     catch (const Py::Exception&) {
@@ -1242,8 +1242,8 @@ PyObject*  TopoShapePy::scale(PyObject *args)
         scl.SetScale(pos, factor);
         BRepBuilderAPI_Transform BRepScale(scl);
         bool bCopy = true;
-        BRepScale.Perform(getTopoShapePtr()->_Shape,bCopy);
-        getTopoShapePtr()->_Shape = BRepScale.Shape();
+        BRepScale.Perform(getTopoShapePtr()->getShape(),bCopy);
+        getTopoShapePtr()->setShape(BRepScale.Shape());
         Py_Return;
     }
     catch (Standard_Failure) {
@@ -1260,12 +1260,12 @@ PyObject* TopoShapePy::makeFillet(PyObject *args)
     PyObject *obj;
     if (PyArg_ParseTuple(args, "ddO", &radius1, &radius2, &obj)) {
         try {
-            const TopoDS_Shape& shape = this->getTopoShapePtr()->_Shape;
+            const TopoDS_Shape& shape = this->getTopoShapePtr()->getShape();
             BRepFilletAPI_MakeFillet mkFillet(shape);
             Py::Sequence list(obj);
             for (Py::Sequence::iterator it = list.begin(); it != list.end(); ++it) {
                 if (PyObject_TypeCheck((*it).ptr(), &(Part::TopoShapePy::Type))) {
-                    const TopoDS_Shape& edge = static_cast<TopoShapePy*>((*it).ptr())->getTopoShapePtr()->_Shape;
+                    const TopoDS_Shape& edge = static_cast<TopoShapePy*>((*it).ptr())->getTopoShapePtr()->getShape();
                     if (edge.ShapeType() == TopAbs_EDGE) {
                         //Add edge to fillet algorithm
                         mkFillet.Add(radius1, radius2, TopoDS::Edge(edge));
@@ -1286,12 +1286,12 @@ PyObject* TopoShapePy::makeFillet(PyObject *args)
     double radius;
     if (PyArg_ParseTuple(args, "dO", &radius, &obj)) {
         try {
-            const TopoDS_Shape& shape = this->getTopoShapePtr()->_Shape;
+            const TopoDS_Shape& shape = this->getTopoShapePtr()->getShape();
             BRepFilletAPI_MakeFillet mkFillet(shape);
             Py::Sequence list(obj);
             for (Py::Sequence::iterator it = list.begin(); it != list.end(); ++it) {
                 if (PyObject_TypeCheck((*it).ptr(), &(Part::TopoShapePy::Type))) {
-                    const TopoDS_Shape& edge = static_cast<TopoShapePy*>((*it).ptr())->getTopoShapePtr()->_Shape;
+                    const TopoDS_Shape& edge = static_cast<TopoShapePy*>((*it).ptr())->getTopoShapePtr()->getShape();
                     if (edge.ShapeType() == TopAbs_EDGE) {
                         //Add edge to fillet algorithm
                         mkFillet.Add(radius, TopoDS::Edge(edge));
@@ -1320,7 +1320,7 @@ PyObject* TopoShapePy::makeChamfer(PyObject *args)
     PyObject *obj;
     if (PyArg_ParseTuple(args, "ddO", &radius1, &radius2, &obj)) {
         try {
-            const TopoDS_Shape& shape = this->getTopoShapePtr()->_Shape;
+            const TopoDS_Shape& shape = this->getTopoShapePtr()->getShape();
             BRepFilletAPI_MakeChamfer mkChamfer(shape);
             TopTools_IndexedMapOfShape mapOfEdges;
             TopTools_IndexedDataMapOfShapeListOfShape mapEdgeFace;
@@ -1329,7 +1329,7 @@ PyObject* TopoShapePy::makeChamfer(PyObject *args)
             Py::Sequence list(obj);
             for (Py::Sequence::iterator it = list.begin(); it != list.end(); ++it) {
                 if (PyObject_TypeCheck((*it).ptr(), &(Part::TopoShapePy::Type))) {
-                    const TopoDS_Shape& edge = static_cast<TopoShapePy*>((*it).ptr())->getTopoShapePtr()->_Shape;
+                    const TopoDS_Shape& edge = static_cast<TopoShapePy*>((*it).ptr())->getTopoShapePtr()->getShape();
                     if (edge.ShapeType() == TopAbs_EDGE) {
                         //Add edge to fillet algorithm
                         const TopoDS_Face& face = TopoDS::Face(mapEdgeFace.FindFromKey(edge).First());
@@ -1351,7 +1351,7 @@ PyObject* TopoShapePy::makeChamfer(PyObject *args)
     double radius;
     if (PyArg_ParseTuple(args, "dO", &radius, &obj)) {
         try {
-            const TopoDS_Shape& shape = this->getTopoShapePtr()->_Shape;
+            const TopoDS_Shape& shape = this->getTopoShapePtr()->getShape();
             BRepFilletAPI_MakeChamfer mkChamfer(shape);
             TopTools_IndexedMapOfShape mapOfEdges;
             TopTools_IndexedDataMapOfShapeListOfShape mapEdgeFace;
@@ -1360,7 +1360,7 @@ PyObject* TopoShapePy::makeChamfer(PyObject *args)
             Py::Sequence list(obj);
             for (Py::Sequence::iterator it = list.begin(); it != list.end(); ++it) {
                 if (PyObject_TypeCheck((*it).ptr(), &(Part::TopoShapePy::Type))) {
-                    const TopoDS_Shape& edge = static_cast<TopoShapePy*>((*it).ptr())->getTopoShapePtr()->_Shape;
+                    const TopoDS_Shape& edge = static_cast<TopoShapePy*>((*it).ptr())->getTopoShapePtr()->getShape();
                     if (edge.ShapeType() == TopAbs_EDGE) {
                         //Add edge to fillet algorithm
                         const TopoDS_Face& face = TopoDS::Face(mapEdgeFace.FindFromKey(edge).First());
@@ -1403,7 +1403,7 @@ PyObject* TopoShapePy::makeThickness(PyObject *args)
         Py::Sequence list(obj);
         for (Py::Sequence::iterator it = list.begin(); it != list.end(); ++it) {
             if (PyObject_TypeCheck((*it).ptr(), &(Part::TopoShapePy::Type))) {
-                const TopoDS_Shape& shape = static_cast<TopoShapePy*>((*it).ptr())->getTopoShapePtr()->_Shape;
+                const TopoDS_Shape& shape = static_cast<TopoShapePy*>((*it).ptr())->getTopoShapePtr()->getShape();
                 facesToRemove.Append(shape);
             }
         }
@@ -1454,7 +1454,7 @@ PyObject*  TopoShapePy::reverse(PyObject *args)
     if (!PyArg_ParseTuple(args, ""))
         return NULL;
 
-    getTopoShapePtr()->_Shape.Reverse();
+    getTopoShapePtr()->getShape().Reverse();
     Py_Return;
 }
 
@@ -1463,7 +1463,7 @@ PyObject*  TopoShapePy::complement(PyObject *args)
     if (!PyArg_ParseTuple(args, ""))
         return NULL;
 
-    getTopoShapePtr()->_Shape.Complement();
+    getTopoShapePtr()->getShape().Complement();
     Py_Return;
 }
 
@@ -1472,7 +1472,7 @@ PyObject*  TopoShapePy::nullify(PyObject *args)
     if (!PyArg_ParseTuple(args, ""))
         return NULL;
 
-    getTopoShapePtr()->_Shape.Nullify();
+    getTopoShapePtr()->getShape().Nullify();
     Py_Return;
 }
 
@@ -1489,7 +1489,7 @@ PyObject*  TopoShapePy::isClosed(PyObject *args)
     if (!PyArg_ParseTuple(args, ""))
         return NULL;
     try {
-        if (getTopoShapePtr()->_Shape.IsNull())
+        if (getTopoShapePtr()->getShape().IsNull())
             Standard_Failure::Raise("Cannot determine the 'Closed'' flag of an empty shape");
         return Py_BuildValue("O", (getTopoShapePtr()->isClosed() ? Py_True : Py_False));
     }
@@ -1505,8 +1505,8 @@ PyObject*  TopoShapePy::isEqual(PyObject *args)
     if (!PyArg_ParseTuple(args, "O!", &(TopoShapePy::Type), &pcObj))
         return NULL;
 
-    TopoDS_Shape shape = static_cast<TopoShapePy*>(pcObj)->getTopoShapePtr()->_Shape;
-    Standard_Boolean test = (getTopoShapePtr()->_Shape.IsEqual(shape));
+    TopoDS_Shape shape = static_cast<TopoShapePy*>(pcObj)->getTopoShapePtr()->getShape();
+    Standard_Boolean test = (getTopoShapePtr()->getShape().IsEqual(shape));
     return Py_BuildValue("O", (test ? Py_True : Py_False));
 }
 
@@ -1516,8 +1516,8 @@ PyObject*  TopoShapePy::isSame(PyObject *args)
     if (!PyArg_ParseTuple(args, "O!", &(TopoShapePy::Type), &pcObj))
         return NULL;
 
-    TopoDS_Shape shape = static_cast<TopoShapePy*>(pcObj)->getTopoShapePtr()->_Shape;
-    Standard_Boolean test = getTopoShapePtr()->_Shape.IsSame(shape);
+    TopoDS_Shape shape = static_cast<TopoShapePy*>(pcObj)->getTopoShapePtr()->getShape();
+    Standard_Boolean test = getTopoShapePtr()->getShape().IsSame(shape);
     return Py_BuildValue("O", (test ? Py_True : Py_False));
 }
 
@@ -1527,8 +1527,8 @@ PyObject*  TopoShapePy::isPartner(PyObject *args)
     if (!PyArg_ParseTuple(args, "O!", &(TopoShapePy::Type), &pcObj))
         return NULL;
 
-    TopoDS_Shape shape = static_cast<TopoShapePy*>(pcObj)->getTopoShapePtr()->_Shape;
-    Standard_Boolean test = getTopoShapePtr()->_Shape.IsPartner(shape);
+    TopoDS_Shape shape = static_cast<TopoShapePy*>(pcObj)->getTopoShapePtr()->getShape();
+    Standard_Boolean test = getTopoShapePtr()->getShape().IsPartner(shape);
     return Py_BuildValue("O", (test ? Py_True : Py_False));
 }
 
@@ -1564,7 +1564,7 @@ PyObject* TopoShapePy::hashCode(PyObject *args)
     int upper = IntegerLast();
     if (!PyArg_ParseTuple(args, "|i",&upper))
         return 0;
-    int hc = getTopoShapePtr()->_Shape.HashCode(upper);
+    int hc = getTopoShapePtr()->getShape().HashCode(upper);
     return Py_BuildValue("i", hc);
 }
 
@@ -1578,7 +1578,7 @@ PyObject* TopoShapePy::tessellate(PyObject *args)
         std::vector<Base::Vector3d> Points;
         std::vector<Data::ComplexGeoData::Facet> Facets;
         if (PyObject_IsTrue(ok))
-            BRepTools::Clean(getTopoShapePtr()->_Shape);
+            BRepTools::Clean(getTopoShapePtr()->getShape());
         getTopoShapePtr()->getFaces(Points, Facets,tolerance);
         Py::Tuple tuple(2);
         Py::List vertex;
@@ -1610,13 +1610,13 @@ PyObject* TopoShapePy::project(PyObject *args)
     PyObject *obj;
 
     BRepAlgo_NormalProjection algo;
-    algo.Init(this->getTopoShapePtr()->_Shape);
+    algo.Init(this->getTopoShapePtr()->getShape());
     if (PyArg_ParseTuple(args, "O", &obj)) {
         try {
             Py::Sequence list(obj);
             for (Py::Sequence::iterator it = list.begin(); it != list.end(); ++it) {
                 if (PyObject_TypeCheck((*it).ptr(), &(Part::TopoShapePy::Type))) {
-                    const TopoDS_Shape& shape = static_cast<TopoShapePy*>((*it).ptr())->getTopoShapePtr()->_Shape;
+                    const TopoDS_Shape& shape = static_cast<TopoShapePy*>((*it).ptr())->getTopoShapePtr()->getShape();
                     algo.Add(shape);
                 }
             }
@@ -1642,8 +1642,8 @@ PyObject* TopoShapePy::makeParallelProjection(PyObject *args)
     PyObject *pShape, *pDir;
     if (PyArg_ParseTuple(args, "O!O!", &(Part::TopoShapePy::Type), &pShape, &Base::VectorPy::Type, &pDir)) {
         try {
-            const TopoDS_Shape& shape = this->getTopoShapePtr()->_Shape;
-            const TopoDS_Shape& wire = static_cast<TopoShapePy*>(pShape)->getTopoShapePtr()->_Shape;
+            const TopoDS_Shape& shape = this->getTopoShapePtr()->getShape();
+            const TopoDS_Shape& wire = static_cast<TopoShapePy*>(pShape)->getTopoShapePtr()->getShape();
             Base::Vector3d vec = Py::Vector(pDir,false).toVector();
             BRepProj_Projection proj(wire, shape, gp_Dir(vec.x,vec.y,vec.z));
             TopoDS_Shape projected = proj.Shape();
@@ -1664,8 +1664,8 @@ PyObject* TopoShapePy::makePerspectiveProjection(PyObject *args)
     PyObject *pShape, *pDir;
     if (PyArg_ParseTuple(args, "O!O!", &(Part::TopoShapePy::Type), &pShape, &Base::VectorPy::Type, &pDir)) {
         try {
-            const TopoDS_Shape& shape = this->getTopoShapePtr()->_Shape;
-            const TopoDS_Shape& wire = static_cast<TopoShapePy*>(pShape)->getTopoShapePtr()->_Shape;
+            const TopoDS_Shape& shape = this->getTopoShapePtr()->getShape();
+            const TopoDS_Shape& wire = static_cast<TopoShapePy*>(pShape)->getTopoShapePtr()->getShape();
             Base::Vector3d vec = Py::Vector(pDir,false).toVector();
             BRepProj_Projection proj(wire, shape, gp_Pnt(vec.x,vec.y,vec.z));
             TopoDS_Shape projected = proj.Shape();
@@ -1742,7 +1742,7 @@ PyObject*  TopoShapePy::isInside(PyObject *args)
     if (!PyArg_ParseTuple(args, "O!dO!", &(Base::VectorPy::Type), &point, &tolerance,  &PyBool_Type, &checkFace))
         return NULL;
     try {
-        TopoDS_Shape shape = getTopoShapePtr()->_Shape;
+        TopoDS_Shape shape = getTopoShapePtr()->getShape();
         BRepClass3d_SolidClassifier solidClassifier(shape);
         Base::Vector3d pnt = static_cast<Base::VectorPy*>(point)->value();
         gp_Pnt vertex = gp_Pnt(pnt.x,pnt.y,pnt.z);
@@ -1843,8 +1843,8 @@ PyObject* TopoShapePy::proximity(PyObject *args)
     Standard_Real tol = Precision::Confusion();
     if (!PyArg_ParseTuple(args, "O!|d",&(TopoShapePy::Type), &ps2, &tol))
         return 0;
-    const TopoDS_Shape& s1 = getTopoShapePtr()->_Shape;
-    const TopoDS_Shape& s2 = static_cast<Part::TopoShapePy*>(ps2)->getTopoShapePtr()->_Shape;
+    const TopoDS_Shape& s1 = getTopoShapePtr()->getShape();
+    const TopoDS_Shape& s2 = static_cast<Part::TopoShapePy*>(ps2)->getTopoShapePtr()->getShape();
     if (s1.IsNull()) {
         PyErr_SetString(PyExc_ValueError, "proximity: Shape object is invalid");
         return 0;
@@ -1898,9 +1898,9 @@ PyObject* TopoShapePy::distToShape(PyObject *args)
     if (!PyArg_ParseTuple(args, "O!",&(TopoShapePy::Type), &ps2))
         return 0;
 
-    const TopoDS_Shape& s1 = getTopoShapePtr()->_Shape;
+    const TopoDS_Shape& s1 = getTopoShapePtr()->getShape();
     TopoShape* ts1 = getTopoShapePtr();
-    const TopoDS_Shape& s2 = static_cast<Part::TopoShapePy*>(ps2)->getTopoShapePtr()->_Shape;
+    const TopoDS_Shape& s2 = static_cast<Part::TopoShapePy*>(ps2)->getTopoShapePtr()->getShape();
     TopoShape* ts2 = static_cast<Part::TopoShapePy*>(ps2)->getTopoShapePtr();
 
     if (s2.IsNull()) {
@@ -2010,7 +2010,7 @@ PyObject* TopoShapePy::distToShape(PyObject *args)
 #if 0 // see ComplexGeoDataPy::Matrix which does the same
 Py::Object TopoShapePy::getLocation(void) const
 {
-    const TopLoc_Location& loc = getTopoShapePtr()->_Shape.Location();
+    const TopLoc_Location& loc = getTopoShapePtr()->getShape().Location();
     gp_Trsf trf = (gp_Trsf)loc;
     Base::Matrix4D mat;
     mat[0][0] = trf.Value(1,1);
@@ -2043,7 +2043,7 @@ void TopoShapePy::setLocation(Py::Object o)
         trf.SetRotation(gp_Ax1(gp_Pnt(), gp_Dir(axis.x, axis.y, axis.z)), angle);
         trf.SetTranslationPart(gp_Vec(mat[0][3],mat[1][3],mat[2][3]));
         TopLoc_Location loc(trf);
-        getTopoShapePtr()->_Shape.Location(loc);
+        getTopoShapePtr()->getShape().Location(loc);
     }
     else {
         std::string error = std::string("type must be 'Matrix', not ");
@@ -2055,7 +2055,7 @@ void TopoShapePy::setLocation(Py::Object o)
 
 Py::String TopoShapePy::getShapeType(void) const
 {
-    TopoDS_Shape sh = getTopoShapePtr()->_Shape;
+    TopoDS_Shape sh = getTopoShapePtr()->getShape();
     if (sh.IsNull())
         throw Py::Exception(Base::BaseExceptionFreeCADError, "cannot determine type of null shape");
     TopAbs_ShapeEnum type = sh.ShapeType();
@@ -2096,7 +2096,7 @@ Py::String TopoShapePy::getShapeType(void) const
 
 Py::String TopoShapePy::getOrientation(void) const
 {
-    TopoDS_Shape sh = getTopoShapePtr()->_Shape;
+    TopoDS_Shape sh = getTopoShapePtr()->getShape();
     if (sh.IsNull())
         throw Py::Exception(Base::BaseExceptionFreeCADError, "cannot determine orientation of null shape");
     TopAbs_Orientation type = sh.Orientation();
@@ -2122,7 +2122,7 @@ Py::String TopoShapePy::getOrientation(void) const
 
 void TopoShapePy::setOrientation(Py::String arg)
 {
-    TopoDS_Shape& sh = getTopoShapePtr()->_Shape;
+    TopoDS_Shape sh = getTopoShapePtr()->getShape();
     if (sh.IsNull())
         throw Py::Exception(Base::BaseExceptionFreeCADError, "cannot determine orientation of null shape");
     std::string name = (std::string)arg;
@@ -2151,7 +2151,7 @@ Py::List TopoShapePy::getFaces(void) const
     Py::List ret;
     TopTools_IndexedMapOfShape M;
 
-    TopExp_Explorer Ex(getTopoShapePtr()->_Shape,TopAbs_FACE);
+    TopExp_Explorer Ex(getTopoShapePtr()->getShape(),TopAbs_FACE);
     while (Ex.More()) 
     {
         M.Add(Ex.Current());
@@ -2172,7 +2172,7 @@ Py::List TopoShapePy::getVertexes(void) const
     Py::List ret;
     TopTools_IndexedMapOfShape M;
 
-    TopExp_Explorer Ex(getTopoShapePtr()->_Shape,TopAbs_VERTEX);
+    TopExp_Explorer Ex(getTopoShapePtr()->getShape(),TopAbs_VERTEX);
     while (Ex.More()) 
     {
         M.Add(Ex.Current());
@@ -2193,7 +2193,7 @@ Py::List TopoShapePy::getShells(void) const
     Py::List ret;
     TopTools_IndexedMapOfShape M;
 
-    TopExp_Explorer Ex(getTopoShapePtr()->_Shape,TopAbs_SHELL);
+    TopExp_Explorer Ex(getTopoShapePtr()->getShape(),TopAbs_SHELL);
     while (Ex.More()) 
     {
         M.Add(Ex.Current());
@@ -2214,7 +2214,7 @@ Py::List TopoShapePy::getSolids(void) const
     Py::List ret;
     TopTools_IndexedMapOfShape M;
 
-    TopExp_Explorer Ex(getTopoShapePtr()->_Shape,TopAbs_SOLID);
+    TopExp_Explorer Ex(getTopoShapePtr()->getShape(),TopAbs_SOLID);
     while (Ex.More()) 
     {
         M.Add(Ex.Current());
@@ -2235,7 +2235,7 @@ Py::List TopoShapePy::getCompSolids(void) const
     Py::List ret;
     TopTools_IndexedMapOfShape M;
 
-    TopExp_Explorer Ex(getTopoShapePtr()->_Shape,TopAbs_COMPSOLID);
+    TopExp_Explorer Ex(getTopoShapePtr()->getShape(),TopAbs_COMPSOLID);
     while (Ex.More()) 
     {
         M.Add(Ex.Current());
@@ -2256,7 +2256,7 @@ Py::List TopoShapePy::getEdges(void) const
     Py::List ret;
     TopTools_IndexedMapOfShape M;
 
-    TopExp_Explorer Ex(getTopoShapePtr()->_Shape,TopAbs_EDGE);
+    TopExp_Explorer Ex(getTopoShapePtr()->getShape(),TopAbs_EDGE);
     while (Ex.More()) 
     {
         M.Add(Ex.Current());
@@ -2277,7 +2277,7 @@ Py::List TopoShapePy::getWires(void) const
     Py::List ret;
     TopTools_IndexedMapOfShape M;
 
-    TopExp_Explorer Ex(getTopoShapePtr()->_Shape,TopAbs_WIRE);
+    TopExp_Explorer Ex(getTopoShapePtr()->getShape(),TopAbs_WIRE);
     while (Ex.More())
     {
         M.Add(Ex.Current());
@@ -2298,7 +2298,7 @@ Py::List TopoShapePy::getCompounds(void) const
     Py::List ret;
     TopTools_IndexedMapOfShape M;
 
-    TopExp_Explorer Ex(getTopoShapePtr()->_Shape,TopAbs_COMPOUND);
+    TopExp_Explorer Ex(getTopoShapePtr()->getShape(),TopAbs_COMPOUND);
     while (Ex.More())
     {
         M.Add(Ex.Current());
@@ -2316,7 +2316,7 @@ Py::List TopoShapePy::getCompounds(void) const
 
 Py::Float TopoShapePy::getLength(void) const
 {
-    const TopoDS_Shape& shape = getTopoShapePtr()->_Shape;
+    const TopoDS_Shape& shape = getTopoShapePtr()->getShape();
     if (shape.IsNull())
         throw Py::RuntimeError("shape is invalid");
     GProp_GProps props;
@@ -2326,7 +2326,7 @@ Py::Float TopoShapePy::getLength(void) const
 
 Py::Float TopoShapePy::getArea(void) const
 {
-    const TopoDS_Shape& shape = getTopoShapePtr()->_Shape;
+    const TopoDS_Shape& shape = getTopoShapePtr()->getShape();
     if (shape.IsNull())
         throw Py::RuntimeError("shape is invalid");
     GProp_GProps props;
@@ -2336,7 +2336,7 @@ Py::Float TopoShapePy::getArea(void) const
 
 Py::Float TopoShapePy::getVolume(void) const
 {
-    const TopoDS_Shape& shape = getTopoShapePtr()->_Shape;
+    const TopoDS_Shape& shape = getTopoShapePtr()->getShape();
     if (shape.IsNull())
         throw Py::RuntimeError("shape is invalid");
     GProp_GProps props;

--- a/src/Mod/Part/App/TopoShapeShellPyImp.cpp
+++ b/src/Mod/Part/App/TopoShapeShellPyImp.cpp
@@ -151,6 +151,8 @@ PyObject*  TopoShapeShellPy::add(PyObject *args)
         return 0;
     }
 
+    // TODO: is this needed?
+    getTopoShapePtr()->setShape(shell);
     Py_Return;
 }
 

--- a/src/Mod/Part/App/TopoShapeShellPyImp.cpp
+++ b/src/Mod/Part/App/TopoShapeShellPyImp.cpp
@@ -92,7 +92,7 @@ int TopoShapeShellPy::PyInit(PyObject* args, PyObject* /*kwd*/)
         for (Py::Sequence::iterator it = list.begin(); it != list.end(); ++it) {
             if (PyObject_TypeCheck((*it).ptr(), &(Part::TopoShapeFacePy::Type))) {
                 const TopoDS_Shape& sh = static_cast<TopoShapeFacePy*>((*it).ptr())->
-                    getTopoShapePtr()->_Shape;
+                    getTopoShapePtr()->getShape();
                 if (!sh.IsNull())
                     builder.Add(shell, sh);
             }
@@ -117,7 +117,7 @@ int TopoShapeShellPy::PyInit(PyObject* args, PyObject* /*kwd*/)
         return -1;
     }
 
-    getTopoShapePtr()->_Shape = shape;
+    getTopoShapePtr()->setShape(shape);
     return 0;
 }
 
@@ -128,17 +128,17 @@ PyObject*  TopoShapeShellPy::add(PyObject *args)
         return NULL;
 
     BRep_Builder builder;
-    TopoDS_Shape& shell = getTopoShapePtr()->_Shape;
+    TopoDS_Shape shell = getTopoShapePtr()->getShape();
     
     try {
         const TopoDS_Shape& sh = static_cast<TopoShapeFacePy*>(obj)->
-            getTopoShapePtr()->_Shape;
+            getTopoShapePtr()->getShape();
         if (!sh.IsNull()) {
             builder.Add(shell, sh);
             BRepCheck_Analyzer check(shell);
             if (!check.IsValid()) {
                 ShapeUpgrade_ShellSewing sewShell;
-                getTopoShapePtr()->_Shape = sewShell.ApplySewing(shell);
+                getTopoShapePtr()->setShape(sewShell.ApplySewing(shell));
             }
         }
         else {
@@ -159,11 +159,11 @@ PyObject*  TopoShapeShellPy::getFreeEdges(PyObject *args)
     if (!PyArg_ParseTuple(args, ""))
         return NULL;
     ShapeAnalysis_Shell as;
-    as.LoadShells(getTopoShapePtr()->_Shape);
+    as.LoadShells(getTopoShapePtr()->getShape());
 #if OCC_VERSION_HEX < 0x060500
-    as.CheckOrientedShells(getTopoShapePtr()->_Shape, Standard_True);
+    as.CheckOrientedShells(getTopoShapePtr()->getShape(), Standard_True);
 #else
-    as.CheckOrientedShells(getTopoShapePtr()->_Shape, Standard_True, Standard_True);
+    as.CheckOrientedShells(getTopoShapePtr()->getShape(), Standard_True, Standard_True);
 #endif
     TopoDS_Compound comp = as.FreeEdges();
     return new TopoShapeCompoundPy(new TopoShape(comp));
@@ -174,11 +174,11 @@ PyObject*  TopoShapeShellPy::getBadEdges(PyObject *args)
     if (!PyArg_ParseTuple(args, ""))
         return NULL;
     ShapeAnalysis_Shell as;
-    as.LoadShells(getTopoShapePtr()->_Shape);
+    as.LoadShells(getTopoShapePtr()->getShape());
 #if OCC_VERSION_HEX < 0x060500
-    as.CheckOrientedShells(getTopoShapePtr()->_Shape, Standard_True);
+    as.CheckOrientedShells(getTopoShapePtr()->getShape(), Standard_True);
 #else
-    as.CheckOrientedShells(getTopoShapePtr()->_Shape, Standard_True, Standard_True);
+    as.CheckOrientedShells(getTopoShapePtr()->getShape(), Standard_True, Standard_True);
 #endif
     TopoDS_Compound comp = as.BadEdges();
     return new TopoShapeCompoundPy(new TopoShape(comp));
@@ -192,7 +192,7 @@ PyObject* TopoShapeShellPy::makeHalfSpace(PyObject *args)
 
     try {
         Base::Vector3d pt = Py::Vector(pPnt,false).toVector();
-        BRepPrimAPI_MakeHalfSpace mkHS(TopoDS::Shell(this->getTopoShapePtr()->_Shape), gp_Pnt(pt.x,pt.y,pt.z));
+        BRepPrimAPI_MakeHalfSpace mkHS(TopoDS::Shell(this->getTopoShapePtr()->getShape()), gp_Pnt(pt.x,pt.y,pt.z));
         return new TopoShapeSolidPy(new TopoShape(mkHS.Solid()));
     }
     catch (Standard_Failure) {
@@ -205,7 +205,7 @@ PyObject* TopoShapeShellPy::makeHalfSpace(PyObject *args)
 Py::Object TopoShapeShellPy::getMass(void) const
 {
     GProp_GProps props;
-    BRepGProp::SurfaceProperties(getTopoShapePtr()->_Shape, props);
+    BRepGProp::SurfaceProperties(getTopoShapePtr()->getShape(), props);
     double c = props.Mass();
     return Py::Float(c);
 }
@@ -213,7 +213,7 @@ Py::Object TopoShapeShellPy::getMass(void) const
 Py::Object TopoShapeShellPy::getCenterOfMass(void) const
 {
     GProp_GProps props;
-    BRepGProp::SurfaceProperties(getTopoShapePtr()->_Shape, props);
+    BRepGProp::SurfaceProperties(getTopoShapePtr()->getShape(), props);
     gp_Pnt c = props.CentreOfMass();
     return Py::Vector(Base::Vector3d(c.X(),c.Y(),c.Z()));
 }
@@ -221,7 +221,7 @@ Py::Object TopoShapeShellPy::getCenterOfMass(void) const
 Py::Object TopoShapeShellPy::getMatrixOfInertia(void) const
 {
     GProp_GProps props;
-    BRepGProp::SurfaceProperties(getTopoShapePtr()->_Shape, props);
+    BRepGProp::SurfaceProperties(getTopoShapePtr()->getShape(), props);
     gp_Mat m = props.MatrixOfInertia();
     Base::Matrix4D mat;
     for (int i=0; i<3; i++) {
@@ -235,7 +235,7 @@ Py::Object TopoShapeShellPy::getMatrixOfInertia(void) const
 Py::Object TopoShapeShellPy::getStaticMoments(void) const
 {
     GProp_GProps props;
-    BRepGProp::SurfaceProperties(getTopoShapePtr()->_Shape, props);
+    BRepGProp::SurfaceProperties(getTopoShapePtr()->getShape(), props);
     Standard_Real lx,ly,lz;
     props.StaticMoments(lx,ly,lz);
     Py::Tuple tuple(3);
@@ -248,7 +248,7 @@ Py::Object TopoShapeShellPy::getStaticMoments(void) const
 Py::Dict TopoShapeShellPy::getPrincipalProperties(void) const
 {
     GProp_GProps props;
-    BRepGProp::SurfaceProperties(getTopoShapePtr()->_Shape, props);
+    BRepGProp::SurfaceProperties(getTopoShapePtr()->getShape(), props);
     GProp_PrincipalProps pprops = props.PrincipalProperties();
 
     Py::Dict dict;

--- a/src/Mod/Part/App/TopoShapeSolidPyImp.cpp
+++ b/src/Mod/Part/App/TopoShapeSolidPyImp.cpp
@@ -83,7 +83,7 @@ int TopoShapeSolidPy::PyInit(PyObject* args, PyObject* /*kwd*/)
 
     try {
         const TopoDS_Shape& shape = static_cast<TopoShapePy*>(obj)
-            ->getTopoShapePtr()->_Shape;
+            ->getTopoShapePtr()->getShape();
         //first, if we were given a compsolid, try making a solid out of it
         TopExp_Explorer CSExp (shape, TopAbs_COMPSOLID);
         TopoDS_CompSolid compsolid;
@@ -109,11 +109,11 @@ int TopoShapeSolidPy::PyInit(PyObject* args, PyObject* /*kwd*/)
 
             TopoDS_Solid solid = mkSolid.Solid();
             BRepLib::OrientClosedSolid(solid);
-            getTopoShapePtr()->_Shape = solid;
+            getTopoShapePtr()->setShape(solid);
         } else if (count == 1) {
             BRepBuilderAPI_MakeSolid mkSolid(compsolid);
             TopoDS_Solid solid = mkSolid.Solid();
-            getTopoShapePtr()->_Shape = solid;
+            getTopoShapePtr()->setShape(solid);
         } else if (count > 1) {
             Standard_Failure::Raise("Only one compsolid can be accepted. Provided shape has more than one compsolid.");
         }
@@ -132,7 +132,7 @@ int TopoShapeSolidPy::PyInit(PyObject* args, PyObject* /*kwd*/)
 Py::Object TopoShapeSolidPy::getMass(void) const
 {
     GProp_GProps props;
-    BRepGProp::VolumeProperties(getTopoShapePtr()->_Shape, props);
+    BRepGProp::VolumeProperties(getTopoShapePtr()->getShape(), props);
     double c = props.Mass();
     return Py::Float(c);
 }
@@ -140,7 +140,7 @@ Py::Object TopoShapeSolidPy::getMass(void) const
 Py::Object TopoShapeSolidPy::getCenterOfMass(void) const
 {
     GProp_GProps props;
-    BRepGProp::VolumeProperties(getTopoShapePtr()->_Shape, props);
+    BRepGProp::VolumeProperties(getTopoShapePtr()->getShape(), props);
     gp_Pnt c = props.CentreOfMass();
     return Py::Vector(Base::Vector3d(c.X(),c.Y(),c.Z()));
 }
@@ -148,7 +148,7 @@ Py::Object TopoShapeSolidPy::getCenterOfMass(void) const
 Py::Object TopoShapeSolidPy::getMatrixOfInertia(void) const
 {
     GProp_GProps props;
-    BRepGProp::VolumeProperties(getTopoShapePtr()->_Shape, props);
+    BRepGProp::VolumeProperties(getTopoShapePtr()->getShape(), props);
     gp_Mat m = props.MatrixOfInertia();
     Base::Matrix4D mat;
     for (int i=0; i<3; i++) {
@@ -162,7 +162,7 @@ Py::Object TopoShapeSolidPy::getMatrixOfInertia(void) const
 Py::Object TopoShapeSolidPy::getStaticMoments(void) const
 {
     GProp_GProps props;
-    BRepGProp::VolumeProperties(getTopoShapePtr()->_Shape, props);
+    BRepGProp::VolumeProperties(getTopoShapePtr()->getShape(), props);
     Standard_Real lx,ly,lz;
     props.StaticMoments(lx,ly,lz);
     Py::Tuple tuple(3);
@@ -175,7 +175,7 @@ Py::Object TopoShapeSolidPy::getStaticMoments(void) const
 Py::Dict TopoShapeSolidPy::getPrincipalProperties(void) const
 {
     GProp_GProps props;
-    BRepGProp::VolumeProperties(getTopoShapePtr()->_Shape, props);
+    BRepGProp::VolumeProperties(getTopoShapePtr()->getShape(), props);
     GProp_PrincipalProps pprops = props.PrincipalProperties();
 
     Py::Dict dict;
@@ -208,7 +208,7 @@ Py::Dict TopoShapeSolidPy::getPrincipalProperties(void) const
 Py::Object TopoShapeSolidPy::getOuterShell(void) const
 {
     TopoDS_Shell shell;
-    const TopoDS_Shape& shape = getTopoShapePtr()->_Shape;
+    const TopoDS_Shape& shape = getTopoShapePtr()->getShape();
     if (!shape.IsNull() && shape.ShapeType() == TopAbs_SOLID)
 #if OCC_VERSION_HEX >= 0x060600
         shell = BRepClass3d::OuterShell(TopoDS::Solid(shape));
@@ -229,7 +229,7 @@ PyObject* TopoShapeSolidPy::getMomentOfInertia(PyObject *args)
 
     try {
         GProp_GProps props;
-        BRepGProp::VolumeProperties(getTopoShapePtr()->_Shape, props);
+        BRepGProp::VolumeProperties(getTopoShapePtr()->getShape(), props);
         double r = props.MomentOfInertia(gp_Ax1(Base::convertTo<gp_Pnt>(pnt),
                                                 Base::convertTo<gp_Dir>(dir)));
         return PyFloat_FromDouble(r);
@@ -252,7 +252,7 @@ PyObject* TopoShapeSolidPy::getRadiusOfGyration(PyObject *args)
 
     try {
         GProp_GProps props;
-        BRepGProp::VolumeProperties(getTopoShapePtr()->_Shape, props);
+        BRepGProp::VolumeProperties(getTopoShapePtr()->getShape(), props);
         double r = props.RadiusOfGyration(gp_Ax1(Base::convertTo<gp_Pnt>(pnt),
                                                 Base::convertTo<gp_Dir>(dir)));
         return PyFloat_FromDouble(r);
@@ -269,7 +269,7 @@ PyObject* TopoShapeSolidPy::offsetFaces(PyObject *args)
     PyObject *obj;
     Standard_Real offset;
 
-    const TopoDS_Shape& shape = getTopoShapePtr()->_Shape;
+    const TopoDS_Shape& shape = getTopoShapePtr()->getShape();
     BRepOffset_MakeOffset builder;
     // Set here an offset value higher than the tolerance
     builder.Initialize(shape,1.0,Precision::Confusion(),BRepOffset_Skin,Standard_False,Standard_False,GeomAbs_Intersection);
@@ -287,7 +287,7 @@ PyObject* TopoShapeSolidPy::offsetFaces(PyObject *args)
         for (Py::Sequence::iterator it = list.begin(); it != list.end(); ++it) {
             if (PyObject_TypeCheck((*it).ptr(), &(Part::TopoShapePy::Type))) {
                 // set offset of the requested faces
-                const TopoDS_Shape& face = static_cast<TopoShapePy*>((*it).ptr())->getTopoShapePtr()->_Shape;
+                const TopoDS_Shape& face = static_cast<TopoShapePy*>((*it).ptr())->getTopoShapePtr()->getShape();
                 builder.SetOffsetOnFace(TopoDS::Face(face), offset);
             }
         }
@@ -300,7 +300,7 @@ PyObject* TopoShapeSolidPy::offsetFaces(PyObject *args)
         for (Py::Dict::iterator it = dict.begin(); it != dict.end(); ++it) {
             if (PyObject_TypeCheck((*it).first.ptr(), &(Part::TopoShapePy::Type))) {
                 // set offset of the requested faces
-                const TopoDS_Shape& face = static_cast<TopoShapePy*>((*it).first.ptr())->getTopoShapePtr()->_Shape;
+                const TopoDS_Shape& face = static_cast<TopoShapePy*>((*it).first.ptr())->getTopoShapePtr()->getShape();
                 Standard_Real value = (double)Py::Float((*it).second.ptr());
                 builder.SetOffsetOnFace(TopoDS::Face(face), value);
             }

--- a/src/Mod/Part/App/TopoShapeVertexPyImp.cpp
+++ b/src/Mod/Part/App/TopoShapeVertexPyImp.cpp
@@ -111,10 +111,10 @@ int TopoShapeVertexPy::PyInit(PyObject* args, PyObject* /*kwd*/)
         PyErr_Clear(); // set by PyArg_ParseTuple()
         if (PyArg_ParseTuple(args,"O!",&(Part::TopoShapePy::Type), &object)) {
             TopoShape* ptr = static_cast<TopoShapePy*>(object)->getTopoShapePtr();
-            TopoDS_Shape shape = ptr->_Shape;
+            TopoDS_Shape shape = ptr->getShape();
             if (!shape.IsNull() && shape.ShapeType() == TopAbs_VERTEX) {
                 TopoShapeVertexPy::PointerType vert = reinterpret_cast<TopoShapeVertexPy::PointerType>(_pcTwinPointer);
-                vert->_Shape = ptr->_Shape;
+                vert->setShape(ptr->getShape());
                 return 0;
             }
         }
@@ -127,7 +127,7 @@ int TopoShapeVertexPy::PyInit(PyObject* args, PyObject* /*kwd*/)
     TopoShapeVertexPy::PointerType ptr = reinterpret_cast<TopoShapeVertexPy::PointerType>(_pcTwinPointer);
     BRepBuilderAPI_MakeVertex aBuilder(gp_Pnt(x,y,z));
     TopoDS_Shape s = aBuilder.Vertex();
-    ptr->_Shape = s;
+    ptr->setShape(s);
 
     return 0;
 }
@@ -138,45 +138,45 @@ PyObject* TopoShapeVertexPy::setTolerance(PyObject *args)
     if (!PyArg_ParseTuple(args, "d", &tol))
         return 0;
     BRep_Builder aBuilder;
-    const TopoDS_Vertex& v = TopoDS::Vertex(getTopoShapePtr()->_Shape);
+    const TopoDS_Vertex& v = TopoDS::Vertex(getTopoShapePtr()->getShape());
     aBuilder.UpdateVertex(v, tol);
     Py_Return;
 }
 
 Py::Float TopoShapeVertexPy::getTolerance(void) const
 {
-    const TopoDS_Vertex& v = TopoDS::Vertex(getTopoShapePtr()->_Shape);
+    const TopoDS_Vertex& v = TopoDS::Vertex(getTopoShapePtr()->getShape());
     return Py::Float(BRep_Tool::Tolerance(v));
 }
 
 void TopoShapeVertexPy::setTolerance(Py::Float tol)
 {
     BRep_Builder aBuilder;
-    const TopoDS_Vertex& v = TopoDS::Vertex(getTopoShapePtr()->_Shape);
+    const TopoDS_Vertex& v = TopoDS::Vertex(getTopoShapePtr()->getShape());
     aBuilder.UpdateVertex(v, (double)tol);
 }
 
 Py::Float TopoShapeVertexPy::getX(void) const
 {
-    const TopoDS_Vertex& v = TopoDS::Vertex(getTopoShapePtr()->_Shape);
+    const TopoDS_Vertex& v = TopoDS::Vertex(getTopoShapePtr()->getShape());
     return Py::Float(BRep_Tool::Pnt(v).X());
 }
 
 Py::Float TopoShapeVertexPy::getY(void) const
 {
-    const TopoDS_Vertex& v = TopoDS::Vertex(getTopoShapePtr()->_Shape);
+    const TopoDS_Vertex& v = TopoDS::Vertex(getTopoShapePtr()->getShape());
     return Py::Float(BRep_Tool::Pnt(v).Y());
 }
 
 Py::Float TopoShapeVertexPy::getZ(void) const
 {
-    const TopoDS_Vertex& v = TopoDS::Vertex(getTopoShapePtr()->_Shape);
+    const TopoDS_Vertex& v = TopoDS::Vertex(getTopoShapePtr()->getShape());
     return Py::Float(BRep_Tool::Pnt(v).Z());
 }
 
 Py::Object TopoShapeVertexPy::getPoint(void) const
 {
-    const TopoDS_Vertex& v = TopoDS::Vertex(getTopoShapePtr()->_Shape);
+    const TopoDS_Vertex& v = TopoDS::Vertex(getTopoShapePtr()->getShape());
     gp_Pnt p = BRep_Tool::Pnt(v);
     return Py::Object(new Base::VectorPy(new Base::Vector3d(p.X(),p.Y(),p.Z())));
 }

--- a/src/Mod/Part/App/TopoShapeWirePyImp.cpp
+++ b/src/Mod/Part/App/TopoShapeWirePyImp.cpp
@@ -81,7 +81,7 @@ int TopoShapeWirePy::PyInit(PyObject* args, PyObject* /*kwd*/)
     PyObject *pcObj;
     if (PyArg_ParseTuple(args, "O!", &(Part::TopoShapePy::Type), &pcObj)) {
         BRepBuilderAPI_MakeWire mkWire;
-        const TopoDS_Shape& sh = static_cast<Part::TopoShapePy*>(pcObj)->getTopoShapePtr()->_Shape;
+        const TopoDS_Shape& sh = static_cast<Part::TopoShapePy*>(pcObj)->getTopoShapePtr()->getShape();
         if (sh.IsNull()) {
             PyErr_SetString(PyExc_TypeError, "given shape is invalid");
             return -1;
@@ -96,7 +96,7 @@ int TopoShapeWirePy::PyInit(PyObject* args, PyObject* /*kwd*/)
         }
 
         try {
-            getTopoShapePtr()->_Shape = mkWire.Wire();
+            getTopoShapePtr()->setShape(mkWire.Wire());
             return 0;
         }
         catch (Standard_Failure) {
@@ -118,7 +118,7 @@ int TopoShapeWirePy::PyInit(PyObject* args, PyObject* /*kwd*/)
         for (Py::Sequence::iterator it = list.begin(); it != list.end(); ++it) {
             PyObject* item = (*it).ptr();
             if (PyObject_TypeCheck(item, &(Part::TopoShapePy::Type))) {
-                const TopoDS_Shape& sh = static_cast<Part::TopoShapePy*>(item)->getTopoShapePtr()->_Shape;
+                const TopoDS_Shape& sh = static_cast<Part::TopoShapePy*>(item)->getTopoShapePtr()->getShape();
                 if (sh.IsNull()) {
                     PyErr_SetString(PyExc_TypeError, "given shape is invalid");
                     return -1;
@@ -139,7 +139,7 @@ int TopoShapeWirePy::PyInit(PyObject* args, PyObject* /*kwd*/)
         }
 
         try {
-            getTopoShapePtr()->_Shape = mkWire.Wire();
+            getTopoShapePtr()->setShape(mkWire.Wire());
             return 0;
         }
         catch (Standard_Failure) {
@@ -158,10 +158,10 @@ PyObject* TopoShapeWirePy::add(PyObject *args)
     PyObject* edge;
     if (!PyArg_ParseTuple(args, "O!",&(TopoShapePy::Type), &edge))
         return 0;
-    const TopoDS_Wire& w = TopoDS::Wire(getTopoShapePtr()->_Shape);
+    const TopoDS_Wire& w = TopoDS::Wire(getTopoShapePtr()->getShape());
     BRepBuilderAPI_MakeWire mkWire(w);
 
-    const TopoDS_Shape& sh = static_cast<Part::TopoShapePy*>(edge)->getTopoShapePtr()->_Shape;
+    const TopoDS_Shape& sh = static_cast<Part::TopoShapePy*>(edge)->getTopoShapePtr()->getShape();
     if (sh.IsNull()) {
         PyErr_SetString(PyExc_TypeError, "given shape is invalid");
         return 0;
@@ -176,7 +176,7 @@ PyObject* TopoShapeWirePy::add(PyObject *args)
     }
 
     try {
-        getTopoShapePtr()->_Shape = mkWire.Wire();
+        getTopoShapePtr()->setShape(mkWire.Wire());
         Py_Return;
     }
     catch (Standard_Failure) {
@@ -195,10 +195,10 @@ PyObject* TopoShapeWirePy::fixWire(PyObject *args)
 
     try {
         ShapeFix_Wire aFix;
-        const TopoDS_Wire& w = TopoDS::Wire(getTopoShapePtr()->_Shape);
+        const TopoDS_Wire& w = TopoDS::Wire(getTopoShapePtr()->getShape());
 
         if (face) {
-            const TopoDS_Face& f = TopoDS::Face(static_cast<TopoShapePy*>(face)->getTopoShapePtr()->_Shape);
+            const TopoDS_Face& f = TopoDS::Face(static_cast<TopoShapePy*>(face)->getTopoShapePtr()->getShape());
             aFix.Init(w, f, tol);
         }
         else {
@@ -209,7 +209,7 @@ PyObject* TopoShapeWirePy::fixWire(PyObject *args)
         aFix.FixReorder();
         aFix.FixConnected();
         aFix.FixClosed();
-        getTopoShapePtr()->_Shape = aFix.Wire();
+        getTopoShapePtr()->setShape(aFix.Wire());
 
         Py_Return;
     }
@@ -225,7 +225,7 @@ PyObject* TopoShapeWirePy::makeOffset(PyObject *args)
     double dist;
     if (!PyArg_ParseTuple(args, "d",&dist))
         return 0;
-    const TopoDS_Wire& w = TopoDS::Wire(getTopoShapePtr()->_Shape);
+    const TopoDS_Wire& w = TopoDS::Wire(getTopoShapePtr()->getShape());
     BRepBuilderAPI_FindPlane findPlane(w);
     if (!findPlane.Found()) {
         PyErr_SetString(PartExceptionOCCError, "No planar wire");
@@ -243,7 +243,7 @@ PyObject* TopoShapeWirePy::makePipe(PyObject *args)
     PyObject *pShape;
     if (PyArg_ParseTuple(args, "O!", &(Part::TopoShapePy::Type), &pShape)) {
         try {
-            TopoDS_Shape profile = static_cast<TopoShapePy*>(pShape)->getTopoShapePtr()->_Shape;
+            TopoDS_Shape profile = static_cast<TopoShapePy*>(pShape)->getTopoShapePtr()->getShape();
             TopoDS_Shape shape = this->getTopoShapePtr()->makePipe(profile);
             return new TopoShapePy(new TopoShape(shape));
         }
@@ -273,7 +273,7 @@ PyObject* TopoShapeWirePy::makePipeShell(PyObject *args)
             Py::Sequence list(obj);
             for (Py::Sequence::iterator it = list.begin(); it != list.end(); ++it) {
                 if (PyObject_TypeCheck((*it).ptr(), &(Part::TopoShapePy::Type))) {
-                    const TopoDS_Shape& shape = static_cast<TopoShapePy*>((*it).ptr())->getTopoShapePtr()->_Shape;
+                    const TopoDS_Shape& shape = static_cast<TopoShapePy*>((*it).ptr())->getTopoShapePtr()->getShape();
                     sections.Append(shape);
                 }
             }
@@ -300,11 +300,11 @@ PyObject* TopoShapeWirePy::makeHomogenousWires(PyObject *args)
         return 0;
     try {
         TopoDS_Wire o1, o2;
-        const TopoDS_Wire& w1 = TopoDS::Wire(getTopoShapePtr()->_Shape);
-        const TopoDS_Wire& w2 = TopoDS::Wire(static_cast<TopoShapePy*>(wire)->getTopoShapePtr()->_Shape);
+        const TopoDS_Wire& w1 = TopoDS::Wire(getTopoShapePtr()->getShape());
+        const TopoDS_Wire& w2 = TopoDS::Wire(static_cast<TopoShapePy*>(wire)->getTopoShapePtr()->getShape());
         ShapeAlgo_AlgoContainer shapeAlgo;
         if (shapeAlgo.HomoWires(w1,w2,o1,o2,Standard_True)) {
-            getTopoShapePtr()->_Shape = o1;
+            getTopoShapePtr()->setShape(o1);
             return new TopoShapeWirePy(new TopoShape(o2));
         }
         else {
@@ -327,7 +327,7 @@ PyObject* TopoShapeWirePy::approximate(PyObject *args)
     if (!PyArg_ParseTuple(args, "ddii",&tol2d,&tol3d,&maxseg,&maxdeg))
         return 0;
     try {
-        BRepAdaptor_CompCurve adapt(TopoDS::Wire(getTopoShapePtr()->_Shape));
+        BRepAdaptor_CompCurve adapt(TopoDS::Wire(getTopoShapePtr()->getShape()));
         Handle_Adaptor3d_HCurve hcurve = adapt.Trim(adapt.FirstParameter(),
                                                     adapt.LastParameter(),
                                                     tol2d);
@@ -349,7 +349,7 @@ PyObject* TopoShapeWirePy::approximate(PyObject *args)
 PyObject* TopoShapeWirePy::discretize(PyObject *args, PyObject *kwds)
 {
     try {
-        BRepAdaptor_CompCurve adapt(TopoDS::Wire(getTopoShapePtr()->_Shape));
+        BRepAdaptor_CompCurve adapt(TopoDS::Wire(getTopoShapePtr()->getShape()));
         bool uniformAbscissaPoints = false;
         bool uniformAbscissaDistance = false;
         int numPoints = -1;
@@ -515,7 +515,7 @@ PyObject* TopoShapeWirePy::discretize(PyObject *args, PyObject *kwds)
 Py::Object TopoShapeWirePy::getMass(void) const
 {
     GProp_GProps props;
-    BRepGProp::LinearProperties(getTopoShapePtr()->_Shape, props);
+    BRepGProp::LinearProperties(getTopoShapePtr()->getShape(), props);
     double c = props.Mass();
     return Py::Float(c);
 }
@@ -523,7 +523,7 @@ Py::Object TopoShapeWirePy::getMass(void) const
 Py::Object TopoShapeWirePy::getCenterOfMass(void) const
 {
     GProp_GProps props;
-    BRepGProp::LinearProperties(getTopoShapePtr()->_Shape, props);
+    BRepGProp::LinearProperties(getTopoShapePtr()->getShape(), props);
     gp_Pnt c = props.CentreOfMass();
     return Py::Vector(Base::Vector3d(c.X(),c.Y(),c.Z()));
 }
@@ -531,7 +531,7 @@ Py::Object TopoShapeWirePy::getCenterOfMass(void) const
 Py::Object TopoShapeWirePy::getMatrixOfInertia(void) const
 {
     GProp_GProps props;
-    BRepGProp::LinearProperties(getTopoShapePtr()->_Shape, props);
+    BRepGProp::LinearProperties(getTopoShapePtr()->getShape(), props);
     gp_Mat m = props.MatrixOfInertia();
     Base::Matrix4D mat;
     for (int i=0; i<3; i++) {
@@ -545,7 +545,7 @@ Py::Object TopoShapeWirePy::getMatrixOfInertia(void) const
 Py::Object TopoShapeWirePy::getStaticMoments(void) const
 {
     GProp_GProps props;
-    BRepGProp::LinearProperties(getTopoShapePtr()->_Shape, props);
+    BRepGProp::LinearProperties(getTopoShapePtr()->getShape(), props);
     Standard_Real lx,ly,lz;
     props.StaticMoments(lx,ly,lz);
     Py::Tuple tuple(3);
@@ -558,7 +558,7 @@ Py::Object TopoShapeWirePy::getStaticMoments(void) const
 Py::Dict TopoShapeWirePy::getPrincipalProperties(void) const
 {
     GProp_GProps props;
-    BRepGProp::LinearProperties(getTopoShapePtr()->_Shape, props);
+    BRepGProp::LinearProperties(getTopoShapePtr()->getShape(), props);
     GProp_PrincipalProps pprops = props.PrincipalProperties();
 
     Py::Dict dict;

--- a/src/Mod/Part/Gui/Command.cpp
+++ b/src/Mod/Part/Gui/Command.cpp
@@ -1722,9 +1722,9 @@ void CmdPartRuledSurface::activated(int iMsg)
         const Part::Feature* part1 = static_cast<const Part::Feature*>(result[0].getObject());
         const Part::Feature* part2 = static_cast<const Part::Feature*>(result[1].getObject());
         const Part::TopoShape& shape1 = part1->Shape.getValue();
-        curve1 = shape1._Shape;
+        curve1 = shape1.getShape();
         const Part::TopoShape& shape2 = part2->Shape.getValue();
-        curve2 = shape2._Shape;
+        curve2 = shape2.getShape();
         obj1 = part1->getNameInDocument();
         obj2 = part2->getNameInDocument();
 

--- a/src/Mod/Part/Gui/TaskSweep.cpp
+++ b/src/Mod/Part/Gui/TaskSweep.cpp
@@ -216,16 +216,16 @@ bool SweepWidget::isPathValid(const Gui::SelectionObject& sel) const
             return false;
         }
     }
-    else if (shape._Shape.ShapeType() == TopAbs_EDGE) {
-        pathShape = shape._Shape;
+    else if (shape.getShape().ShapeType() == TopAbs_EDGE) {
+        pathShape = shape.getShape();
     }
-    else if (shape._Shape.ShapeType() == TopAbs_WIRE) {
-        BRepBuilderAPI_MakeWire mkWire(TopoDS::Wire(shape._Shape));
+    else if (shape.getShape().ShapeType() == TopAbs_WIRE) {
+        BRepBuilderAPI_MakeWire mkWire(TopoDS::Wire(shape.getShape()));
         pathShape = mkWire.Wire();
     }
-    else if (shape._Shape.ShapeType() == TopAbs_COMPOUND) {
+    else if (shape.getShape().ShapeType() == TopAbs_COMPOUND) {
         try {
-            TopoDS_Iterator it(shape._Shape);
+            TopoDS_Iterator it(shape.getShape());
             for (; it.More(); it.Next()) {
                 if ((it.Value().ShapeType() != TopAbs_EDGE) &&
                     (it.Value().ShapeType() != TopAbs_WIRE)) {
@@ -234,7 +234,7 @@ bool SweepWidget::isPathValid(const Gui::SelectionObject& sel) const
             }
             Handle(TopTools_HSequenceOfShape) hEdges = new TopTools_HSequenceOfShape();
             Handle(TopTools_HSequenceOfShape) hWires = new TopTools_HSequenceOfShape();
-            for (TopExp_Explorer xp(shape._Shape, TopAbs_EDGE); xp.More(); xp.Next())
+            for (TopExp_Explorer xp(shape.getShape(), TopAbs_EDGE); xp.More(); xp.Next())
                 hEdges->Append(xp.Current());
 
             ShapeAnalysis_FreeBounds::ConnectEdgesToWires(hEdges, Precision::Confusion(), Standard_True, hWires);

--- a/src/Mod/PartDesign/App/Body.cpp
+++ b/src/Mod/PartDesign/App/Body.cpp
@@ -394,7 +394,7 @@ App::DocumentObjectExecReturn *Body::execute(void)
         // get the shape of the tip
         tipShape = static_cast<Part::Feature *>(tip)->Shape.getShape();
 
-        if ( tipShape._Shape.IsNull () ) {
+        if ( tipShape.getShape().IsNull () ) {
             return new App::DocumentObjectExecReturn ( "Tip shape is empty" );
         }
 

--- a/src/Mod/PartDesign/App/Feature.cpp
+++ b/src/Mod/PartDesign/App/Feature.cpp
@@ -131,7 +131,7 @@ const Part::TopoShape Feature::getBaseTopoShape() const {
     const Part::Feature* BaseObject = getBaseObject();
 
     const Part::TopoShape& result = BaseObject->Shape.getShape();
-    if (result._Shape.IsNull())
+    if (result.getShape().IsNull())
         throw Base::Exception("Base feature's TopoShape is invalid");
 
     return result;

--- a/src/Mod/PartDesign/App/FeatureBoolean.cpp
+++ b/src/Mod/PartDesign/App/FeatureBoolean.cpp
@@ -80,7 +80,7 @@ App::DocumentObjectExecReturn *Boolean::execute(void)
 
     // Get the base shape to operate on
     Part::TopoShape baseTopShape = baseFeature->Shape.getShape();
-    if (baseTopShape._Shape.IsNull())
+    if (baseTopShape.getShape().IsNull())
         return new App::DocumentObjectExecReturn("Cannot do boolean operation with invalid base shape");
       
     //get the body this boolean feature belongs to
@@ -100,7 +100,7 @@ App::DocumentObjectExecReturn *Boolean::execute(void)
     trf.SetTranslationPart(gp_Vec(place.getPosition().x,place.getPosition().y,place.getPosition().z));
     TopLoc_Location objLoc(trf);
 
-    TopoDS_Shape result = baseTopShape._Shape;
+    TopoDS_Shape result = baseTopShape.getShape();
     result.Move(objLoc);
 
     // Get the operation type

--- a/src/Mod/PartDesign/App/FeatureChamfer.cpp
+++ b/src/Mod/PartDesign/App/FeatureChamfer.cpp
@@ -88,12 +88,12 @@ App::DocumentObjectExecReturn *Chamfer::execute(void)
     Part::TopoShape baseShape(TopShape);
     baseShape.setTransform(Base::Matrix4D());
     try {
-        BRepFilletAPI_MakeChamfer mkChamfer(baseShape._Shape);
+        BRepFilletAPI_MakeChamfer mkChamfer(baseShape.getShape());
 
         TopTools_IndexedMapOfShape mapOfEdges;
         TopTools_IndexedDataMapOfShapeListOfShape mapEdgeFace;
-        TopExp::MapShapesAndAncestors(baseShape._Shape, TopAbs_EDGE, TopAbs_FACE, mapEdgeFace);
-        TopExp::MapShapes(baseShape._Shape, TopAbs_EDGE, mapOfEdges);
+        TopExp::MapShapesAndAncestors(baseShape.getShape(), TopAbs_EDGE, TopAbs_FACE, mapEdgeFace);
+        TopExp::MapShapes(baseShape.getShape(), TopAbs_EDGE, mapOfEdges);
 
         for (std::vector<std::string>::const_iterator it=SubNames.begin(); it != SubNames.end(); ++it) {
             TopoDS_Edge edge = TopoDS::Edge(baseShape.getSubShape(it->c_str()));
@@ -110,7 +110,7 @@ App::DocumentObjectExecReturn *Chamfer::execute(void)
             return new App::DocumentObjectExecReturn("Resulting shape is null");
 
         TopTools_ListOfShape aLarg;
-        aLarg.Append(baseShape._Shape);
+        aLarg.Append(baseShape.getShape());
         if (!BRepAlgo::IsValid(aLarg, shape, Standard_False, Standard_False)) {
             return new App::DocumentObjectExecReturn("Resulting shape is invalid");
         }

--- a/src/Mod/PartDesign/App/FeatureDraft.cpp
+++ b/src/Mod/PartDesign/App/FeatureDraft.cpp
@@ -273,7 +273,7 @@ App::DocumentObjectExecReturn *Draft::execute(void)
 
         do {
             success = true;
-            mkDraft.Init(baseShape._Shape);
+            mkDraft.Init(baseShape.getShape());
 
             for (std::vector<std::string>::iterator it=SubVals.begin(); it != SubVals.end(); ++it) {
                 TopoDS_Face face = TopoDS::Face(baseShape.getSubShape(it->c_str()));

--- a/src/Mod/PartDesign/App/FeatureDressUp.cpp
+++ b/src/Mod/PartDesign/App/FeatureDressUp.cpp
@@ -94,8 +94,8 @@ void DressUp::getContiniusEdges(Part::TopoShape TopShape, std::vector< std::stri
 
     TopTools_IndexedMapOfShape mapOfEdges;
     TopTools_IndexedDataMapOfShapeListOfShape mapEdgeFace;
-    TopExp::MapShapesAndAncestors(TopShape._Shape, TopAbs_EDGE, TopAbs_FACE, mapEdgeFace);
-    TopExp::MapShapes(TopShape._Shape, TopAbs_EDGE, mapOfEdges);
+    TopExp::MapShapesAndAncestors(TopShape.getShape(), TopAbs_EDGE, TopAbs_FACE, mapEdgeFace);
+    TopExp::MapShapes(TopShape.getShape(), TopAbs_EDGE, mapOfEdges);
 
     unsigned int i = 0;
     while(i < SubNames.size())

--- a/src/Mod/PartDesign/App/FeatureFillet.cpp
+++ b/src/Mod/PartDesign/App/FeatureFillet.cpp
@@ -85,7 +85,7 @@ App::DocumentObjectExecReturn *Fillet::execute(void)
     Part::TopoShape baseShape(TopShape);
     baseShape.setTransform(Base::Matrix4D());
     try {
-        BRepFilletAPI_MakeFillet mkFillet(baseShape._Shape);
+        BRepFilletAPI_MakeFillet mkFillet(baseShape.getShape());
 
         for (std::vector<std::string>::const_iterator it=SubNames.begin(); it != SubNames.end(); ++it) {
             TopoDS_Edge edge = TopoDS::Edge(baseShape.getSubShape(it->c_str()));
@@ -101,7 +101,7 @@ App::DocumentObjectExecReturn *Fillet::execute(void)
             return new App::DocumentObjectExecReturn("Resulting shape is null");
 
         TopTools_ListOfShape aLarg;
-        aLarg.Append(baseShape._Shape);
+        aLarg.Append(baseShape.getShape());
         if (!BRepAlgo::IsValid(aLarg, shape, Standard_False, Standard_False)) {
             return new App::DocumentObjectExecReturn("Resulting shape is invalid");
         }

--- a/src/Mod/PartDesign/App/FeatureMultiTransform.cpp
+++ b/src/Mod/PartDesign/App/FeatureMultiTransform.cpp
@@ -81,9 +81,9 @@ const std::list<gp_Trsf> MultiTransform::getTransformations(const std::vector<Ap
     if (originalFeature->getTypeId().isDerivedFrom(PartDesign::FeatureAddSub::getClassTypeId())) {
         PartDesign::FeatureAddSub* addFeature = static_cast<PartDesign::FeatureAddSub*>(originalFeature);
         if(addFeature->getAddSubType() == FeatureAddSub::Additive)
-            original = addFeature->AddSubShape.getShape()._Shape;
+            original = addFeature->AddSubShape.getShape().getShape();
         else 
-            original = addFeature->AddSubShape.getShape()._Shape;
+            original = addFeature->AddSubShape.getShape().getShape();
     }
 
     GProp_GProps props;

--- a/src/Mod/PartDesign/App/FeaturePipe.cpp
+++ b/src/Mod/PartDesign/App/FeaturePipe.cpp
@@ -376,8 +376,8 @@ void Pipe::getContiniusEdges(Part::TopoShape TopShape, std::vector< std::string 
     /*
     TopTools_IndexedMapOfShape mapOfEdges;
     TopTools_IndexedDataMapOfShapeListOfShape mapEdgeEdge;
-    TopExp::MapShapesAndAncestors(TopShape._Shape, TopAbs_EDGE, TopAbs_EDGE, mapEdgeEdge);
-    TopExp::MapShapes(TopShape._Shape, TopAbs_EDGE, mapOfEdges);
+    TopExp::MapShapesAndAncestors(TopShape.getShape(), TopAbs_EDGE, TopAbs_EDGE, mapEdgeEdge);
+    TopExp::MapShapes(TopShape.getShape(), TopAbs_EDGE, mapOfEdges);
 
     Base::Console().Message("Initial edges:\n");
     for(int i=0; i<SubNames.size(); ++i)
@@ -424,7 +424,7 @@ void Pipe::getContiniusEdges(Part::TopoShape TopShape, std::vector< std::string 
 
 void Pipe::buildPipePath(const Part::TopoShape& shape, const std::vector< std::string >& subedge, TopoDS_Shape& path) {
 
-    if (!shape._Shape.IsNull()) {
+    if (!shape.getShape().IsNull()) {
         try {
             if (!subedge.empty()) {
                 //if(SpineTangent.getValue())
@@ -437,15 +437,15 @@ void Pipe::buildPipePath(const Part::TopoShape& shape, const std::vector< std::s
                 }
                 path = mkWire.Wire();
             }
-            else if (shape._Shape.ShapeType() == TopAbs_EDGE) {
-                path = shape._Shape;
+            else if (shape.getShape().ShapeType() == TopAbs_EDGE) {
+                path = shape.getShape();
             }
-            else if (shape._Shape.ShapeType() == TopAbs_WIRE) {
-                BRepBuilderAPI_MakeWire mkWire(TopoDS::Wire(shape._Shape));
+            else if (shape.getShape().ShapeType() == TopAbs_WIRE) {
+                BRepBuilderAPI_MakeWire mkWire(TopoDS::Wire(shape.getShape()));
                 path = mkWire.Wire();
             }
-            else if (shape._Shape.ShapeType() == TopAbs_COMPOUND) {
-                TopoDS_Iterator it(shape._Shape);
+            else if (shape.getShape().ShapeType() == TopAbs_COMPOUND) {
+                TopoDS_Iterator it(shape.getShape());
                 for (; it.More(); it.Next()) {
                     if (it.Value().IsNull())
                         throw Base::Exception("In valid element in spine.");
@@ -457,7 +457,7 @@ void Pipe::buildPipePath(const Part::TopoShape& shape, const std::vector< std::s
 
                 Handle(TopTools_HSequenceOfShape) hEdges = new TopTools_HSequenceOfShape();
                 Handle(TopTools_HSequenceOfShape) hWires = new TopTools_HSequenceOfShape();
-                for (TopExp_Explorer xp(shape._Shape, TopAbs_EDGE); xp.More(); xp.Next())
+                for (TopExp_Explorer xp(shape.getShape(), TopAbs_EDGE); xp.More(); xp.Next())
                     hEdges->Append(xp.Current());
 
                 ShapeAnalysis_FreeBounds::ConnectEdgesToWires(hEdges, Precision::Confusion(), Standard_True, hWires);

--- a/src/Mod/PartDesign/App/FeatureScaled.cpp
+++ b/src/Mod/PartDesign/App/FeatureScaled.cpp
@@ -75,9 +75,9 @@ const std::list<gp_Trsf> Scaled::getTransformations(const std::vector<App::Docum
     if (originalFeature->getTypeId().isDerivedFrom(PartDesign::FeatureAddSub::getClassTypeId())) {
         PartDesign::FeatureAddSub* Feature = static_cast<PartDesign::FeatureAddSub*>(originalFeature);
         if(Feature->getAddSubType() == FeatureAddSub::Additive)
-            original = Feature->AddSubShape.getShape()._Shape;
+            original = Feature->AddSubShape.getShape().getShape();
         else
-            original = Feature->AddSubShape.getShape()._Shape;
+            original = Feature->AddSubShape.getShape().getShape();
     }
 
     GProp_GProps props;

--- a/src/Mod/PartDesign/App/FeatureSketchBased.cpp
+++ b/src/Mod/PartDesign/App/FeatureSketchBased.cpp
@@ -294,7 +294,7 @@ const TopoDS_Face ProfileBased::getSupportFace() const {
             assert(sub.size()==1);
             // get the selected sub shape (a Face)
             const Part::TopoShape &shape = part->Shape.getShape();
-            if (shape._Shape.IsNull())
+            if (shape.getShape().IsNull())
                 throw Base::Exception("Sketch support shape is empty!");
 
             TopoDS_Shape sh = shape.getSubShape(sub[0].c_str());
@@ -898,7 +898,7 @@ void ProfileBased::remapSupportShape(const TopoDS_Shape& newShape)
 
     // here we must reset the placement otherwise the geometric matching doesn't work
     Part::TopoShape shape = this->Shape.getValue();
-    shape._Shape.Location(TopLoc_Location());
+    shape.getShape().Location(TopLoc_Location());
 
     std::vector<App::DocumentObject*> refs = this->getInList();
     for (std::vector<App::DocumentObject*>::iterator it = refs.begin(); it != refs.end(); ++it) {

--- a/src/Mod/PartDesign/App/FeatureThickness.cpp
+++ b/src/Mod/PartDesign/App/FeatureThickness.cpp
@@ -87,6 +87,6 @@ App::DocumentObjectExecReturn *Thickness::execute(void)
     if (fabs(thickness) > 2*tol)
         this->Shape.setValue(getSolid(TopShape.makeThickSolid(closingFaces, thickness, tol, false, false, mode, join)));
     else
-        this->Shape.setValue(getSolid(TopShape._Shape));
+        this->Shape.setValue(getSolid(TopShape.getShape()));
     return App::DocumentObject::StdReturn;
 }

--- a/src/Mod/PartDesign/App/FeatureTransformed.cpp
+++ b/src/Mod/PartDesign/App/FeatureTransformed.cpp
@@ -220,13 +220,13 @@ App::DocumentObjectExecReturn *Transformed::execute(void)
     }
 
     const Part::TopoShape& supportTopShape = supportFeature->Shape.getShape();
-    if (supportTopShape._Shape.IsNull())
+    if (supportTopShape.getShape().IsNull())
         return new App::DocumentObjectExecReturn("Cannot transform invalid support shape");
 
     // create an untransformed copy of the support shape
     Part::TopoShape supportShape(supportTopShape);
     supportShape.setTransform(Base::Matrix4D());
-    TopoDS_Shape support = supportShape._Shape;
+    TopoDS_Shape support = supportShape.getShape();
 
     typedef std::set<std::vector<gp_Trsf>::const_iterator> trsf_it;
     typedef std::map<App::DocumentObject*,  trsf_it> rej_it_map;
@@ -245,7 +245,7 @@ App::DocumentObjectExecReturn *Transformed::execute(void)
 
         if ((*o)->getTypeId().isDerivedFrom(PartDesign::FeatureAddSub::getClassTypeId())) {
             PartDesign::FeatureAddSub* feature = static_cast<PartDesign::FeatureAddSub*>(*o);
-            shape = feature->AddSubShape.getShape()._Shape;
+            shape = feature->AddSubShape.getShape().getShape();
             if (shape.IsNull())
                 return new App::DocumentObjectExecReturn("Shape of additive feature is empty");
             

--- a/src/Mod/PartDesign/App/ShapeBinder.cpp
+++ b/src/Mod/PartDesign/App/ShapeBinder.cpp
@@ -67,7 +67,7 @@ App::DocumentObjectExecReturn* ShapeBinder::execute(void) {
         ShapeBinder::getFilteredReferences(&Support, obj, subs);
         //if we have a link we rebuild the shape, but we change nothing if we are a simple copy
         if(obj) {
-            Shape.setValue(ShapeBinder::buildShapeFromReferences(obj, subs)._Shape);
+            Shape.setValue(ShapeBinder::buildShapeFromReferences(obj, subs).getShape());
             Placement.setValue(obj->Placement.getValue());
         }
     }

--- a/src/Mod/PartDesign/Gui/Command.cpp
+++ b/src/Mod/PartDesign/Gui/Command.cpp
@@ -1272,7 +1272,7 @@ bool dressupGetSelected(Gui::Command* cmd, const std::string& which,
 
     const Part::TopoShape& TopShape = base->Shape.getShape();
 
-    if (TopShape._Shape.IsNull()){
+    if (TopShape.getShape().IsNull()){
         QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
             QObject::tr("Shape of the selected Part is empty"));
         return false;

--- a/src/Mod/PartDesign/Gui/ViewProviderTransformed.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderTransformed.cpp
@@ -179,7 +179,7 @@ void ViewProviderTransformed::recomputeFeature(void)
         TopoDS_Shape shape;
         if ((o->first)->getTypeId().isDerivedFrom(PartDesign::FeatureAddSub::getClassTypeId())) {
             PartDesign::FeatureAddSub* feature = static_cast<PartDesign::FeatureAddSub*>(o->first);
-            shape = feature->AddSubShape.getShape()._Shape;
+            shape = feature->AddSubShape.getShape().getShape();
         }
 
         if (shape.IsNull()) continue;

--- a/src/Mod/Raytracing/App/AppRaytracingPy.cpp
+++ b/src/Mod/Raytracing/App/AppRaytracingPy.cpp
@@ -101,7 +101,7 @@ private:
             throw Py::Exception();
 
         std::stringstream out;
-        TopoDS_Shape &aShape = static_cast<Part::TopoShapePy *>(ShapeObject)->getTopoShapePtr()->_Shape;
+        TopoDS_Shape aShape = static_cast<Part::TopoShapePy *>(ShapeObject)->getTopoShapePtr()->getShape();
 
         PovTools::writeShape(out,PartName,aShape,(float)0.1);
         // This must not be done in PovTools::writeShape!
@@ -124,7 +124,7 @@ private:
             throw Py::Exception();
 
         std::stringstream out;
-        TopoDS_Shape &aShape = static_cast<Part::TopoShapePy *>(ShapeObject)->getTopoShapePtr()->_Shape;
+        TopoDS_Shape aShape = static_cast<Part::TopoShapePy *>(ShapeObject)->getTopoShapePtr()->getShape();
 
         // write a material entry
         // This must not be done in PovTools::writeShape!
@@ -144,7 +144,7 @@ private:
             &(Part::TopoShapePy::Type), &ShapeObject)) 
             throw Py::Exception();
 
-        TopoDS_Shape &aShape = static_cast<Part::TopoShapePy *>(ShapeObject)->getTopoShapePtr()->_Shape;
+        TopoDS_Shape aShape = static_cast<Part::TopoShapePy *>(ShapeObject)->getTopoShapePtr()->getShape();
 
         PovTools::writeShape(FileName,PartName,aShape,(float)0.1);
 
@@ -174,7 +174,7 @@ private:
             &ShapeObject,&FileName,&Acur,&Length))
             throw Py::Exception();
 
-        TopoDS_Shape aShape = static_cast<Part::TopoShapePy *>(ShapeObject)->getTopoShapePtr()->_Shape;
+        TopoDS_Shape aShape = static_cast<Part::TopoShapePy *>(ShapeObject)->getTopoShapePtr()->getShape();
         PovTools::writeShapeCSV(FileName,aShape,Acur,Length);
         return Py::None();
     }

--- a/src/Mod/Raytracing/App/AppRaytracingPy.cpp
+++ b/src/Mod/Raytracing/App/AppRaytracingPy.cpp
@@ -112,6 +112,8 @@ private:
             << "      finish {StdFinish } //definition on top of the project" << endl
             << "  }" << endl
             << "}" << endl   ;
+        // TODO: is this needed?
+        static_cast<Part::TopoShapePy *>(ShapeObject)->getTopoShapePtr()->setShape(aShape);
         return Py::String(out.str());
     }
     Py::Object getPartAsLux(const Py::Tuple& args)
@@ -134,6 +136,8 @@ private:
         out << "    \"string type\" [\"matte\"]" << endl << endl;
 
         LuxTools::writeShape(out,PartName,aShape,(float)0.1);
+        // TODO: is this needed?
+        static_cast<Part::TopoShapePy *>(ShapeObject)->getTopoShapePtr()->setShape(aShape);
         return Py::String(out.str());
     }
     Py::Object writePartFile(const Py::Tuple& args)
@@ -148,6 +152,8 @@ private:
 
         PovTools::writeShape(FileName,PartName,aShape,(float)0.1);
 
+        // TODO: is this needed?
+        static_cast<Part::TopoShapePy *>(ShapeObject)->getTopoShapePtr()->setShape(aShape);
         return Py::None();
     }
     Py::Object writeDataFile(const Py::Tuple& args)
@@ -176,6 +182,8 @@ private:
 
         TopoDS_Shape aShape = static_cast<Part::TopoShapePy *>(ShapeObject)->getTopoShapePtr()->getShape();
         PovTools::writeShapeCSV(FileName,aShape,Acur,Length);
+        // TODO: is this needed?
+        static_cast<Part::TopoShapePy *>(ShapeObject)->getTopoShapePtr()->setShape(aShape);
         return Py::None();
     }
     Py::Object writeCameraFile(const Py::Tuple& args)

--- a/src/Mod/Raytracing/App/LuxFeature.cpp
+++ b/src/Mod/Raytracing/App/LuxFeature.cpp
@@ -60,7 +60,7 @@ App::DocumentObjectExecReturn *LuxFeature::execute(void)
         return new App::DocumentObjectExecReturn("No object linked");
     if (!link->getTypeId().isDerivedFrom(Part::Feature::getClassTypeId()))
         return new App::DocumentObjectExecReturn("Linked object is not a Part object");
-    TopoDS_Shape shape = static_cast<Part::Feature*>(link)->Shape.getShape()._Shape;
+    TopoDS_Shape shape = static_cast<Part::Feature*>(link)->Shape.getShape().getShape();
     std::string Name(std::string("Lux_")+static_cast<Part::Feature*>(link)->getNameInDocument());
     if (shape.IsNull())
         return new App::DocumentObjectExecReturn("Linked shape object is empty");

--- a/src/Mod/Raytracing/App/RayFeature.cpp
+++ b/src/Mod/Raytracing/App/RayFeature.cpp
@@ -60,7 +60,7 @@ App::DocumentObjectExecReturn *RayFeature::execute(void)
         return new App::DocumentObjectExecReturn("No object linked");
     if (!link->getTypeId().isDerivedFrom(Part::Feature::getClassTypeId()))
         return new App::DocumentObjectExecReturn("Linked object is not a Part object");
-    TopoDS_Shape shape = static_cast<Part::Feature*>(link)->Shape.getShape()._Shape;
+    TopoDS_Shape shape = static_cast<Part::Feature*>(link)->Shape.getShape().getShape();
     std::string Name(std::string("Pov_")+static_cast<Part::Feature*>(link)->getNameInDocument());
     if (shape.IsNull())
         return new App::DocumentObjectExecReturn("Linked shape object is empty");

--- a/src/Mod/Sketcher/App/Sketch.cpp
+++ b/src/Mod/Sketcher/App/Sketch.cpp
@@ -2508,9 +2508,9 @@ TopoShape Sketch::toShape(void) const
             TopoDS_Shape sh = it->geo->toShape();
             if (first) {
                 first = false;
-                result._Shape = sh;
+                result.setShape(sh);
             } else {
-                result._Shape = result.fuse(sh);
+                result.setShape(result.fuse(sh));
             }
         }
     }
@@ -2580,7 +2580,7 @@ TopoShape Sketch::toShape(void) const
         builder.MakeCompound(comp);
         for (std::list<TopoDS_Wire>::iterator wt = wires.begin(); wt != wires.end(); ++wt)
             builder.Add(comp, *wt);
-        result._Shape = comp;
+        result.setShape(comp);
     }
     // FIXME: if free edges are left over its probably better to
     // create a compound with the closed structures and let the

--- a/src/Mod/TechDraw/App/DrawViewPart.cpp
+++ b/src/Mod/TechDraw/App/DrawViewPart.cpp
@@ -124,7 +124,7 @@ App::DocumentObjectExecReturn *DrawViewPart::execute(void)
         return new App::DocumentObjectExecReturn("FVP - Linked object is not a Part object");
     }
 
-    TopoDS_Shape shape = static_cast<Part::Feature*>(link)->Shape.getShape()._Shape;
+    TopoDS_Shape shape = static_cast<Part::Feature*>(link)->Shape.getShape().getShape();
     if (shape.IsNull()) {
         return new App::DocumentObjectExecReturn("FVP - Linked shape object is empty");
     }

--- a/src/Mod/TechDraw/App/DrawViewSection.cpp
+++ b/src/Mod/TechDraw/App/DrawViewSection.cpp
@@ -121,7 +121,7 @@ App::DocumentObjectExecReturn *DrawViewSection::execute(void)
 
     const Part::TopoShape &partTopo = static_cast<Part::Feature*>(link)->Shape.getShape();
 
-    if (partTopo._Shape.IsNull())
+    if (partTopo.getShape().IsNull())
         return new App::DocumentObjectExecReturn("Linked shape object is empty");
 
     gp_Pln pln = getSectionPlane();
@@ -196,7 +196,7 @@ App::DocumentObjectExecReturn *DrawViewSection::execute(void)
     TopoDS_Shape prism = BRepPrimAPI_MakePrism(aProjFace, wMax * gp_Vec(pln.Axis().Direction()), 0, 1).Shape();
 
     // We need to copy the shape to not modify the BRepstructure
-    BRepBuilderAPI_Copy BuilderCopy(partTopo._Shape);
+    BRepBuilderAPI_Copy BuilderCopy(partTopo.getShape());
     TopoDS_Shape myShape = BuilderCopy.Shape();
 
     BRepAlgoAPI_Cut mkCut(myShape, prism);


### PR DESCRIPTION
This pull request changes `TopoShape::_Shape` to a private member variable, and adds access functions `TopoShape::getShape` and `TopoShape::setShape`. Most of the changes are trivial, switching to the use of the access functions rather than direct access to `TopoShape::_Shape`. The following are non-trivial changes:

1. `Part/App/Attacher.cpp:784` the original array took the address of `TopoShape::_Shape`, I have now created a copy of the `_Shape` and added that to the array
2. `PropertyPartShape::getValue` returns a `const TopoDS_Shape&`, which means I cannot return the private `TopoShape::_Shape`. Instead, I have added `PropertyPartShape::OCCShape` as a member variable, and I'm returning that instead