### PR TITLE
correct spelling StanardHypotheses to StandardHypotheses

### DIFF
--- a/src/Mod/Fem/App/FemMesh.cpp
+++ b/src/Mod/Fem/App/FemMesh.cpp
@@ -332,7 +332,7 @@ void FemMesh::addHypothesis(const TopoDS_Shape & aSubShape, SMESH_HypothesisPtr 
     hypoth.push_back(ptr);
 }
 
-void FemMesh::setStanardHypotheses()
+void FemMesh::setStandardHypotheses()
 {
     if (!hypoth.empty())
         return;

--- a/src/Mod/Fem/App/FemMesh.h
+++ b/src/Mod/Fem/App/FemMesh.h
@@ -62,7 +62,7 @@ public:
     SMESH_Mesh* getSMesh();
     static SMESH_Gen * getGenerator();
     void addHypothesis(const TopoDS_Shape & aSubShape, SMESH_HypothesisPtr hyp);
-    void setStanardHypotheses();
+    void setStandardHypotheses();
     void compute();
 
     // from base class

--- a/src/Mod/Fem/App/FemMeshPy.xml
+++ b/src/Mod/Fem/App/FemMeshPy.xml
@@ -29,7 +29,7 @@
                 <UserDocu>Add hypothesis</UserDocu>
             </Documentation>
         </Methode>
-        <Methode Name="setStanardHypotheses">
+        <Methode Name="setStandardHypotheses">
             <Documentation>
                 <UserDocu>Set some standard hypotheses for the whole shape</UserDocu>
             </Documentation>

--- a/src/Mod/Fem/App/FemMeshPyImp.cpp
+++ b/src/Mod/Fem/App/FemMeshPyImp.cpp
@@ -152,13 +152,13 @@ PyObject* FemMeshPy::addHypothesis(PyObject *args)
     Py_Return;
 }
 
-PyObject* FemMeshPy::setStanardHypotheses(PyObject *args)
+PyObject* FemMeshPy::setStandardHypotheses(PyObject *args)
 {
     if (!PyArg_ParseTuple(args, ""))
         return 0;
 
     try {
-        getFemMeshPtr()->setStanardHypotheses();
+        getFemMeshPtr()->setStandardHypotheses();
     }
     catch (const std::exception& e) {
         PyErr_SetString(Base::BaseExceptionFreeCADError, e.what());


### PR DESCRIPTION
`grep -R 'StanardHypotheses' ./`
output:
```
./App/FemMesh.cpp:void FemMesh::setStanardHypotheses()
./App/FemMesh.h:    void setStanardHypotheses();
./App/FemMeshPyImp.cpp:PyObject* FemMeshPy::setStanardHypotheses(PyObject *args)
./App/FemMeshPyImp.cpp:        getFemMeshPtr()->setStanardHypotheses();
./App/FemMeshPy.xml:        <Methode Name="setStanardHypotheses">
```
replace a string in all files in a folder, including subfolders
```
grep -rl StanardHypotheses ./ | xargs sed -i 's/StanardHypotheses/StandardHypotheses/g'
```

check the result of replacement: 
There should be no output: `grep -R 'StanardHypotheses' ./`
Then again: `grep -R 'StandardHypotheses' ./`, should match the file and lines number found in step 1

compiling pass, and this method is not called by other files, other modules. It is safe to apply this fix. 
 `grep -R 'StandardHypotheses' ../`   it is shown this method is not used by other module