### PR TITLE
Fix #2561 - crash while moving features

### DIFF
--- a/src/Mod/PartDesign/Gui/CommandBody.cpp
+++ b/src/Mod/PartDesign/Gui/CommandBody.cpp
@@ -587,6 +587,11 @@ void CmdPartDesignMoveFeature::activated(int iMsg)
     std::vector<App::DocumentObject*> features = getSelection().getObjectsOfType(Part::Feature::getClassTypeId());
     if (features.empty()) return;
 
+	// Collect dependenies of the selected features
+	std::vector<App::DocumentObject*> dependencies = PartDesignGui::collectDependencies(features);
+	if (!dependencies.empty())
+		features.insert(std::end(features), std::begin(dependencies), std::end(dependencies));
+
     // Create a list of all bodies in this part
     std::vector<App::DocumentObject*> bodies = getDocument()->getObjectsOfType(Part::BodyBase::getClassTypeId());
 
@@ -634,7 +639,8 @@ void CmdPartDesignMoveFeature::activated(int iMsg)
         // If we removed the tip of the source body, make the new tip visible
         if ( featureWasTip ) {
             App::DocumentObject * sourceNewTip = source->Tip.getValue();
-            doCommand(Gui,"Gui.activeDocument().show(\"%s\")", sourceNewTip->getNameInDocument());
+			if (sourceNewTip)
+				doCommand(Gui,"Gui.activeDocument().show(\"%s\")", sourceNewTip->getNameInDocument());
         }
 
         // Hide old tip and show new tip (the moved feature) of the target body

--- a/src/Mod/PartDesign/Gui/CommandBody.cpp
+++ b/src/Mod/PartDesign/Gui/CommandBody.cpp
@@ -592,7 +592,7 @@ void CmdPartDesignMoveFeature::activated(int iMsg)
 	{
 		//show messagebox and cancel
 		QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Features cannot be moved"),
-			QObject::tr("Some of the selected features has dependencies in the source body"));
+			QObject::tr("Some of the selected features have dependencies in the source body"));
 		return;
 	}
 

--- a/src/Mod/PartDesign/Gui/Utils.h
+++ b/src/Mod/PartDesign/Gui/Utils.h
@@ -64,6 +64,9 @@ bool isAnyNonPartDesignLinksTo ( PartDesign::Feature *feature, bool respectGroup
 /// Relink all nonPartDesign features to the body instead of the given partDesign Feature
 void relinkToBody ( PartDesign::Feature *feature );
 
+/// Collect all needed dependencies of the features during the move from one body to another
+std::vector<App::DocumentObject*> collectDependencies(std::vector<App::DocumentObject*>& features);
+
 } /* PartDesignGui */
 
 #endif /* end of include guard: UTILS_H_CS5LK2ZQ */

--- a/src/Mod/PartDesign/Gui/Utils.h
+++ b/src/Mod/PartDesign/Gui/Utils.h
@@ -64,8 +64,12 @@ bool isAnyNonPartDesignLinksTo ( PartDesign::Feature *feature, bool respectGroup
 /// Relink all nonPartDesign features to the body instead of the given partDesign Feature
 void relinkToBody ( PartDesign::Feature *feature );
 
-/// Collect all needed dependencies of the features during the move from one body to another
-std::vector<App::DocumentObject*> collectDependencies(std::vector<App::DocumentObject*>& features);
+/// Check if feature is dependent on anything except movable sketches and datums
+bool isFeatureMovable(App::DocumentObject* feature);
+/// Collect dependencies of the features during the move. Dependecies should only be dependent on origin
+std::vector<App::DocumentObject*> collectMovableDependencies(std::vector<App::DocumentObject*>& features);
+/// Relink sketches and datums to target body's origin
+void relinkToOrigin(App::DocumentObject* feature, PartDesign::Body* body);
 
 } /* PartDesignGui */
 

--- a/src/Mod/PartDesign/TestPartDesignGui.py
+++ b/src/Mod/PartDesign/TestPartDesignGui.py
@@ -33,12 +33,21 @@ from PySide import QtGui, QtCore
 from PySide.QtGui import QApplication
 
 #timer runs this class in order to access modal dialog
-class Callable:
+class CallableCheckWarning:
 	def __init__(self, test):
 		self.test = test
 	def __call__(self):
 		diag = QApplication.activeModalWidget()
 		self.test.assertIsNotNone(diag, "Input dialog box could not be found")
+		if (diag != None):
+			QtCore.QTimer.singleShot(0, diag, QtCore.SLOT('accept()'))
+
+class CallableComboBox:
+	def __init__(self, test):
+		self.test = test
+	def __call__(self):
+		diag = QApplication.activeModalWidget()
+		self.test.assertIsNotNone(diag, "Warning dialog box could not be found")
 		if (diag != None):
 			cbox = diag.findChild(QtGui.QComboBox)
 			self.test.assertIsNotNone(cbox, "ComboBox widget could not be found")
@@ -54,6 +63,70 @@ Gui = FreeCADGui
 class PartDesignGuiTestCases(unittest.TestCase):
 	def setUp(self):
 		self.Doc = FreeCAD.newDocument("SketchGuiTest")
+
+	def testRefuseToMoveSingleFeature(self):
+		FreeCAD.Console.PrintMessage('Testing moving one feature from one body to another\n')
+		self.BodySource = self.Doc.addObject('PartDesign::Body','Body')
+		Gui.activeView().setActiveObject('pdbody', self.BodySource)
+
+		self.BoxObj = self.Doc.addObject('PartDesign::AdditiveBox','Box')
+		self.BoxObj.Length=10.0
+		self.BoxObj.Width=10.0
+		self.BoxObj.Height=10.0
+		self.BodySource.addFeature(self.BoxObj)
+
+		self.BoxCoords = self.Doc.addObject('PartDesign::CoordinateSystem','CoordinateSystem')
+		self.BodySource.addFeature(self.BoxCoords)
+		self.BoxObj.CoordinateSystem=(self.BoxCoords)
+		App.ActiveDocument.recompute()
+		Gui.activeDocument().hide('CoordinateSystem')
+
+		self.Sketch = self.Doc.addObject('Sketcher::SketchObject','Sketch')
+		self.Sketch.Support = (self.BoxObj, ('Face3',))
+		self.Sketch.MapMode = 'FlatFace'
+		self.BodySource.addFeature(self.Sketch)
+
+		geoList = []
+		geoList.append(Part.Line(App.Vector(2.0,8.0,0),App.Vector(8.0,8.0,0)))
+		geoList.append(Part.Line(App.Vector(8.0,8.0,0),App.Vector(8.0,2.0,0)))
+		geoList.append(Part.Line(App.Vector(8.0,2.0,0),App.Vector(2.0,2.0,0)))
+		geoList.append(Part.Line(App.Vector(2.0,2.0,0),App.Vector(2.0,8.0,0)))
+		self.Sketch.addGeometry(geoList,False)
+		conList = []
+		conList.append(Sketcher.Constraint('Coincident',0,2,1,1))
+		conList.append(Sketcher.Constraint('Coincident',1,2,2,1))
+		conList.append(Sketcher.Constraint('Coincident',2,2,3,1))
+		conList.append(Sketcher.Constraint('Coincident',3,2,0,1))
+		conList.append(Sketcher.Constraint('Horizontal',0))
+		conList.append(Sketcher.Constraint('Horizontal',2))
+		conList.append(Sketcher.Constraint('Vertical',1))
+		conList.append(Sketcher.Constraint('Vertical',3))
+		self.Sketch.addConstraint(conList)
+
+		self.Pad = self.Doc.addObject("PartDesign::Pad","Pad")
+		self.Pad.Profile = self.Sketch
+		self.Pad.Length = 10.000000
+		self.Pad.Length2 = 100.000000
+		self.Pad.Type = 0
+		self.Pad.UpToFace = None
+		self.Pad.Reversed = 0
+		self.Pad.Midplane = 0
+		self.Pad.Offset = 0.000000
+
+		self.BodySource.addFeature(self.Pad)
+
+		self.Doc.recompute()
+		Gui.SendMsgToActiveView("ViewFit")
+
+		self.BodyTarget = self.Doc.addObject('PartDesign::Body','Body')
+		
+		Gui.Selection.addSelection(App.ActiveDocument.Pad)
+		cobj = CallableCheckWarning(self)
+		QtCore.QTimer.singleShot(500, cobj)
+		Gui.runCommand('PartDesign_MoveFeature')
+		#assert depenedencies of the Sketch
+		self.assertEqual(len(self.BodySource.Model), 4, "Source body feature count is wrong")
+		self.assertEqual(len(self.BodyTarget.Model), 0, "Target body feature count is wrong")
 
 	def testMoveSingleFeature(self):
 		FreeCAD.Console.PrintMessage('Testing moving one feature from one body to another\n')
@@ -100,9 +173,12 @@ class PartDesignGuiTestCases(unittest.TestCase):
 		self.BodyTarget = self.Doc.addObject('PartDesign::Body','Body')
 		
 		Gui.Selection.addSelection(App.ActiveDocument.Pad)
-		cobj = Callable(self)
+		cobj = CallableComboBox(self)
 		QtCore.QTimer.singleShot(500, cobj)
 		Gui.runCommand('PartDesign_MoveFeature')
+		#assert depenedencies of the Sketch
+		self.assertFalse(self.Sketch.Support[0][0] in self.BodySource.Origin.OriginFeatures)
+		self.assertTrue(self.Sketch.Support[0][0] in self.BodyTarget.Origin.OriginFeatures)
 		self.assertEqual(len(self.BodySource.Model), 0, "Source body feature count is wrong")
 		self.assertEqual(len(self.BodyTarget.Model), 2, "Target body feature count is wrong")
 

--- a/src/Mod/PartDesign/TestPartDesignGui.py
+++ b/src/Mod/PartDesign/TestPartDesignGui.py
@@ -1,4 +1,4 @@
-#   (c) Juergen Riegel (FreeCAD@juergen-riegel.net) 2011      LGPL        *
+﻿#   (c) Juergen Riegel (FreeCAD@juergen-riegel.net) 2011      LGPL        *
 #                                                                         *
 #   This file is part of the FreeCAD CAx development system.              *
 #                                                                         *
@@ -19,25 +19,107 @@
 #   USA                                                                   *
 #**************************************************************************
 
-import FreeCAD, FreeCADGui, os, sys, unittest, PartDesign, PartDesignGui
+import FreeCAD
+import FreeCADGui
+import os
+import sys
+import unittest
+import Sketcher
+import Part
+import PartDesign
+import PartDesignGui
 
+from PySide import QtGui, QtCore
+from PySide.QtGui import QApplication
 
+#timer runs this class in order to access modal dialog
+class Callable:
+	def __init__(self, test):
+		self.test = test
+	def __call__(self):
+		diag = QApplication.activeModalWidget()
+		self.test.assertIsNotNone(diag, "Input dialog box could not be found")
+		if (diag != None):
+			cbox = diag.findChild(QtGui.QComboBox)
+			self.test.assertIsNotNone(cbox, "ComboBox widget could not be found")
+			if (cbox != None):
+				cbox.setCurrentIndex(1)		
+				QtCore.QTimer.singleShot(0, diag, QtCore.SLOT('accept()'))
+
+App = FreeCAD
+Gui = FreeCADGui
 #---------------------------------------------------------------------------
 # define the test cases to test the FreeCAD PartDesign module
 #---------------------------------------------------------------------------
+class PartDesignGuiTestCases(unittest.TestCase):
+	def setUp(self):
+		self.Doc = FreeCAD.newDocument("SketchGuiTest")
 
+	def testMoveSingleFeature(self):
+		FreeCAD.Console.PrintMessage('Testing moving one feature from one body to another\n')
+		self.BodySource = self.Doc.addObject('PartDesign::Body','Body')
+		Gui.activeView().setActiveObject('pdbody', self.BodySource)
+
+		self.Sketch = self.Doc.addObject('Sketcher::SketchObject','Sketch')
+		self.Sketch.Support = (self.Doc.XY_Plane, [''])
+		self.Sketch.MapMode = 'FlatFace'
+		self.BodySource.addFeature(self.Sketch)
+
+		geoList = []
+		geoList.append(Part.Line(App.Vector(-10.000000,10.000000,0),App.Vector(10.000000,10.000000,0)))
+		geoList.append(Part.Line(App.Vector(10.000000,10.000000,0),App.Vector(10.000000,-10.000000,0)))
+		geoList.append(Part.Line(App.Vector(10.000000,-10.000000,0),App.Vector(-10.000000,-10.000000,0)))
+		geoList.append(Part.Line(App.Vector(-10.000000,-10.000000,0),App.Vector(-10.000000,10.000000,0)))
+		self.Sketch.addGeometry(geoList,False)
+		conList = []
+		conList.append(Sketcher.Constraint('Coincident',0,2,1,1))
+		conList.append(Sketcher.Constraint('Coincident',1,2,2,1))
+		conList.append(Sketcher.Constraint('Coincident',2,2,3,1))
+		conList.append(Sketcher.Constraint('Coincident',3,2,0,1))
+		conList.append(Sketcher.Constraint('Horizontal',0))
+		conList.append(Sketcher.Constraint('Horizontal',2))
+		conList.append(Sketcher.Constraint('Vertical',1))
+		conList.append(Sketcher.Constraint('Vertical',3))
+		self.Sketch.addConstraint(conList)
+
+		self.Pad = self.Doc.addObject("PartDesign::Pad","Pad")
+		self.Pad.Profile = self.Sketch
+		self.Pad.Length = 10.000000
+		self.Pad.Length2 = 100.000000
+		self.Pad.Type = 0
+		self.Pad.UpToFace = None
+		self.Pad.Reversed = 0
+		self.Pad.Midplane = 0
+		self.Pad.Offset = 0.000000
+
+		self.BodySource.addFeature(self.Pad)
+
+		self.Doc.recompute()
+		Gui.SendMsgToActiveView("ViewFit")
+
+		self.BodyTarget = self.Doc.addObject('PartDesign::Body','Body')
+		
+		Gui.Selection.addSelection(App.ActiveDocument.Pad)
+		cobj = Callable(self)
+		QtCore.QTimer.singleShot(500, cobj)
+		Gui.runCommand('PartDesign_MoveFeature')
+		self.assertEqual(len(self.BodySource.Model), 0, "Source body feature count is wrong")
+		self.assertEqual(len(self.BodyTarget.Model), 2, "Target body feature count is wrong")
+
+	def tearDown(self):
+		FreeCAD.closeDocument("SketchGuiTest")
 
 #class PartDesignGuiTestCases(unittest.TestCase):
-#	def setUp(self):
-#		self.Doc = FreeCAD.newDocument("SketchGuiTest")
+#   def setUp(self):
+#       self.Doc = FreeCAD.newDocument("SketchGuiTest")
 #
-#	def testBoxCase(self):
-#		self.Box = self.Doc.addObject('PartDesign::SketchObject','SketchBox')
-#		self.Box.addGeometry(Part.Line(App.Vector(-99.230339,36.960674,0),App.Vector(69.432587,36.960674,0)))
-#		self.Box.addGeometry(Part.Line(App.Vector(69.432587,36.960674,0),App.Vector(69.432587,-53.196629,0)))
-#		self.Box.addGeometry(Part.Line(App.Vector(69.432587,-53.196629,0),App.Vector(-99.230339,-53.196629,0)))
-#		self.Box.addGeometry(Part.Line(App.Vector(-99.230339,-53.196629,0),App.Vector(-99.230339,36.960674,0)))
-#		
-#	def tearDown(self):
-#		#closing doc
-#		FreeCAD.closeDocument("SketchGuiTest")
+#   def testBoxCase(self):
+#       self.Box = self.Doc.addObject('PartDesign::SketchObject','SketchBox')
+#       self.Box.addGeometry(Part.Line(App.Vector(-99.230339,36.960674,0),App.Vector(69.432587,36.960674,0)))
+#       self.Box.addGeometry(Part.Line(App.Vector(69.432587,36.960674,0),App.Vector(69.432587,-53.196629,0)))
+#       self.Box.addGeometry(Part.Line(App.Vector(69.432587,-53.196629,0),App.Vector(-99.230339,-53.196629,0)))
+#       self.Box.addGeometry(Part.Line(App.Vector(-99.230339,-53.196629,0),App.Vector(-99.230339,36.960674,0)))
+#       
+#   def tearDown(self):
+#       #closing doc
+#       FreeCAD.closeDocument("SketchGuiTest")

--- a/src/Mod/Test/TestGui.py
+++ b/src/Mod/Test/TestGui.py
@@ -1,4 +1,4 @@
-# FreeCAD Part module
+﻿# FreeCAD Part module
 # (c) 2001 Juergen Riegel
 #
 # Part design module
@@ -51,6 +51,7 @@ class TestCmd:
         QtUnitGui.addTest("TestSketcherApp")
         QtUnitGui.addTest("TestPartApp")
         QtUnitGui.addTest("TestPartDesignApp")
+        QtUnitGui.addTest("TestPartDesignGui")
         QtUnitGui.addTest("TestSpreadsheet")
         QtUnitGui.addTest("TestDraft")
         QtUnitGui.addTest("TestArch")


### PR DESCRIPTION
Hi,
this PR fixes the bug and also fixes moving sketches, profiles and other dependencies of the selected features.
It also adds a simple test which creates two bodies, adds Sketch and Pad to one body and then moves Pad to second body.

PR topic link on forum - http://forum.freecadweb.org/viewtopic.php?f=17&t=16939