### PR TITLE
MacOSX: When using Qt4 installed by MacPorts, give the cmake finder a…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -636,6 +636,13 @@ endif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 
 # sets ${QT_LIBRARIES}
 
+    # If using MacPorts, help the Qt4 finder.
+    if(MACPORTS_PREFIX)
+        if(NOT QT_QMAKE_EXECUTABLE)
+            set(QT_QMAKE_EXECUTABLE ${MACPORTS_PREFIX}/libexec/qt4/bin/qmake)
+        endif()
+    endif()
+
     SET(QT_MIN_VERSION 4.5.0)
     set(QT_USE_QTNETWORK TRUE)
     set(QT_USE_QTXML TRUE)


### PR DESCRIPTION
As the commit comment says, if using Qt4 installed by MacPorts, the cmake Qt4 finder _needs_ this help in order to find Qt4 (have a look at the source code of the Qt4 finder shipped with cmake). The path for QTDIR is the standard installation path for MacPorts, not 100% reliable (user might have customized MacPorts) but a lot better than just failing :-)