### PR TITLE
Enable building the KDL libray with clang

### DIFF
--- a/src/Mod/Robot/App/CMakeLists.txt
+++ b/src/Mod/Robot/App/CMakeLists.txt
@@ -95,6 +95,7 @@ if (FREECAD_USE_EXTERNAL_KDL)
 
 else(FREECAD_USE_EXTERNAL_KDL)
   # here we use the internal supplied kdl
+  add_definitions(-DKDL_USE_NEW_TREE_INTERFACE=1)
   FILE( GLOB KDL_SRCS kdl_cp/[^.]*.cpp )
   FILE( GLOB KDL_HPPS kdl_cp/[^.]*.hpp kdl_cp/[^.]*.inl)
 


### PR DESCRIPTION
This fix makes clang happy when building the KDL library shipped with FreeCAD. This also means:
- We can build the Robot workbench on MacOSX (tested)
- On macosx, the default cmake configuration (issuing just "cmake ..") will finally work, no need to exclude parts from the build.