### PR TITLE
MacOSX: Fetch and build MEDFile

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,8 @@ if(CCACHE_PROGRAM)
     set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "${CCACHE_PROGRAM}")
 endif()
 
+include(ExternalProject)
+
 # include local  modules
 include(AddFileDependencies)
 include(cMake/FreeCadMacros.cmake)
@@ -588,7 +590,34 @@ endif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
             else()
                 find_package(HDF5 REQUIRED)
             endif()
-            find_package(MEDFile REQUIRED)
+            if (APPLE)
+                # There is no MEDFile package for MacOSX, let's build it ourselves.
+                # Unfortunately it gets messy. A proper way would be to build all
+                # FreeCAD as a set of ExternalProjects or even better to use conan.io
+                # for all dependencies :-)
+                set(MEDFILE_INSTALL_DIR ${CMAKE_BINARY_DIR}/deps/src/MEDFile-install)
+                ExternalProject_Add(MEDFile
+                    PREFIX deps
+                    DOWNLOAD_NO_PROGRESS 1
+                    URL http://files.salome-platform.org/Salome/other/med-3.2.0.tar.gz
+                    URL_HASH MD5=eb61df92f0624feb6328f517cd756a23
+                    PATCH_COMMAND patch -p 1 < ${CMAKE_SOURCE_DIR}/cMake/medfile.patch
+                    CMAKE_ARGS
+                        -DCMAKE_INSTALL_PREFIX=${MEDFILE_INSTALL_DIR}
+                        -DMEDFILE_INSTALL_DOC=OFF
+                )
+                #
+                # Set MEDFILE_INCLUDE_DIRS and MEDFILE_LIBRARIES as if we were FindMEDFile.cmake
+                #
+                add_library(LIBMEDC SHARED IMPORTED)
+                set_target_properties(LIBMEDC PROPERTIES IMPORTED_LOCATION ${MEDFILE_INSTALL_DIR}/lib/libmedC.dylib)
+                # This dependency is needed to avoid breaking parallel builds.
+                add_dependencies(LIBMEDC MEDFile)
+                set(MEDFILE_INCLUDE_DIRS ${MEDFILE_INSTALL_DIR}/include)
+                set(MEDFILE_LIBRARIES LIBMEDC)
+            else()
+                find_package(MEDFile REQUIRED)
+            endif()
             set(SMESH_INCLUDE_DIR ${CMAKE_SOURCE_DIR}/src/3rdParty/salomesmesh/inc)
         else()
             find_package(SMESH)

--- a/cMake/medfile.patch
+++ b/cMake/medfile.patch
@@ -1,0 +1,36 @@
+diff -u -r med-3.2.0.orig/include/med_utils.h.in med-3.2.0/include/med_utils.h.in
+--- med-3.2.0.orig/include/med_utils.h.in
++++ med-3.2.0/include/med_utils.h.in
+@@ -251,7 +251,7 @@
+ 					fprintf(stderr,"%s = %llu\n",#entier,entier) ;\
+ 					fflush(stderr) ;\
+ 				}
+-# define ISCRUTE_id(entier) ISCRUTE_int(entier)
++# define ISCRUTE_id(entier) ISCRUTE_llong(entier)
+ # define RSCRUTE(reel)		{\
+ 					ICI ;\
+ 					fprintf(stderr,"%s = %f\n",#reel,reel) ;\
+diff -u -r med-3.2.0.orig/src/2.3.6/ci/MEDequivInfo.c med-3.2.0/src/2.3.6/ci/MEDequivInfo.c
+--- med-3.2.0.orig/src/2.3.6/ci/MEDequivInfo.c
++++ med-3.2.0/src/2.3.6/ci/MEDequivInfo.c
+@@ -24,7 +24,7 @@
+ #include <stdlib.h>
+ 
+ int
+-MEDequivInfo(int fid, char *maa, int ind, char *eq, char *des)
++MEDequivInfo(med_idt fid, char *maa, int ind, char *eq, char *des)
+ {
+   med_idt eqid;
+   med_err ret;
+diff -u -r med-3.2.0.orig/src/hdfi/_MEDselectAllEntitiesNoI.c med-3.2.0/src/hdfi/_MEDselectAllEntitiesNoI.c
+--- med-3.2.0.orig/src/hdfi/_MEDselectAllEntitiesNoI.c
++++ med-3.2.0/src/hdfi/_MEDselectAllEntitiesNoI.c
+@@ -65,7 +65,7 @@
+   if ( (_memspace[0] = H5Screate_simple (1, _memspacesize, NULL)) <0) {
+     MED_ERR_(_ret,MED_ERR_CREATE,MED_ERR_MEMSPACE,MED_ERR_SIZE_MSG);
+     ISCRUTE_size(*_memspacesize);
+-    ISCRUTE_int(_memspace[0]);
++    ISCRUTE_id(_memspace[0]);
+     goto ERROR;
+   }
+ 


### PR DESCRIPTION
MEDFile is not avaliable as a package on MacOSX, and the tarball doesn't build out of the box.
I wanted to have a solution that can help anybody on Mac, so I added to cmake the capability to fetch and build MEDFile, applying the needed patch (cMake/medfile.patch)

This commit allows to automatically fetch and build medifle on macos, so enabling all the FreeCAD features that depend on it.

The build of medfile is still full of scary warnings, but I think that the same warnings will be found on any 64-bit platform, not only mac.