### PR TITLE
UI small fixes in different places

### DIFF
--- a/src/Gui/Document.cpp
+++ b/src/Gui/Document.cpp
@@ -1201,15 +1201,15 @@ bool Document::canClose ()
         box.setText(QObject::tr("Do you want to save your changes to document '%1' before closing?")
                     .arg(QString::fromUtf8(getDocument()->Label.getValue())));
         box.setInformativeText(QObject::tr("If you don't save, your changes will be lost."));
-        box.setStandardButtons(QMessageBox::Discard | QMessageBox::Cancel | QMessageBox::Save);
-        box.setDefaultButton(QMessageBox::Save);
+        box.setStandardButtons(QMessageBox::Yes | QMessageBox::No| QMessageBox::Cancel);
+        box.setDefaultButton(QMessageBox::Yes);
 
         switch (box.exec())
         {
-        case QMessageBox::Save:
+        case QMessageBox::Yes:
             ok = save();
             break;
-        case QMessageBox::Discard:
+        case QMessageBox::No:
             ok = true;
             break;
         case QMessageBox::Cancel:

--- a/src/Mod/PartDesign/Gui/CommandPrimitive.cpp
+++ b/src/Mod/PartDesign/Gui/CommandPrimitive.cpp
@@ -59,9 +59,11 @@ CmdPrimtiveCompAdditive::CmdPrimtiveCompAdditive()
 
 void CmdPrimtiveCompAdditive::activated(int iMsg)
 {
-
     PartDesign::Body *pcActiveBody = PartDesignGui::getBody(/*messageIfNot = */true);
     if (!pcActiveBody) return;
+
+	Gui::ActionGroup* pcAction = qobject_cast<Gui::ActionGroup*>(_pcAction);
+	pcAction->setIcon(pcAction->actions().at(iMsg)->icon());
 
     std::string FeatName;
     std::string CSName = getUniqueObjectName("CoordinateSystem");;
@@ -248,6 +250,9 @@ void CmdPrimtiveCompSubtractive::activated(int iMsg)
 {
     PartDesign::Body *pcActiveBody = PartDesignGui::getBody(/*messageIfNot = */true);
     if (!pcActiveBody) return;
+
+	Gui::ActionGroup* pcAction = qobject_cast<Gui::ActionGroup*>(_pcAction);
+	pcAction->setIcon(pcAction->actions().at(iMsg)->icon());
 
     //check if we already have a feature as subtractive ones work only if we have
     //something to subtract from.


### PR DESCRIPTION
I've tried to fix couple of annoying things in different places in UI.

1. It changes saving dialog box to Yes/No/Cancel buttons from Save/Discard/Cancel. Main reason is shortcuts that work with Yes/No/Cancel by default.

2. PartDesign primitive combo buttons do not remember the icon of last choice. I'm not sure if I have proper fix, but it works.

Discussion - http://forum.freecadweb.org/viewtopic.php?f=17&t=17109&p=134952#p134952

Thanks.