### PR TITLE
Part Extrude improvements

### DIFF
--- a/src/Mod/Part/App/FeatureExtrusion.cpp
+++ b/src/Mod/Part/App/FeatureExtrusion.cpp
@@ -27,9 +27,11 @@
 # include <Bnd_Box.hxx>
 # include <BRepBndLib.hxx>
 # include <gp_Pln.hxx>
+# include <gp_Lin.hxx>
 # include <gp_Trsf.hxx>
 # include <BRep_Tool.hxx>
 # include <BRepAdaptor_Surface.hxx>
+# include <BRepAdaptor_Curve.hxx>
 # include <BRepCheck_Analyzer.hxx>
 # include <BRepOffsetAPI_MakeOffset.hxx>
 # include <BRepBuilderAPI_Copy.hxx>
@@ -50,12 +52,15 @@
 # include <TopExp.hxx>
 # include <TopExp_Explorer.hxx>
 # include <TopTools_IndexedMapOfShape.hxx>
+# include <ShapeExtend_Explorer.hxx>
+# include <BRepLib_FindSurface.hxx>
 #endif
 
 
 #include "FeatureExtrusion.h"
 #include <Base/Tools.h>
 #include <Base/Exception.h>
+#include "Part2DObject.h"
 
 
 using namespace Part;
@@ -63,22 +68,281 @@ using namespace Part;
 
 PROPERTY_SOURCE(Part::Extrusion, Part::Feature)
 
+const char* Extrusion::eDirModeStrings[]= {
+    "Custom",
+    "Edge",
+    "Normal",
+    NULL};
+
 Extrusion::Extrusion()
 {
-    ADD_PROPERTY(Base,(0));
-    ADD_PROPERTY(Dir,(Base::Vector3d(0.0,0.0,1.0)));
-    ADD_PROPERTY(Solid,(false));
-    ADD_PROPERTY(TaperAngle,(0.0));
+    ADD_PROPERTY_TYPE(Base,(0), "Extrude", App::Prop_None, "Shape to extrude");
+    ADD_PROPERTY_TYPE(Dir,(Base::Vector3d(0.0,0.0,1.0)), "Extrude", App::Prop_None, "Direction of extrusion (also magnitude, if both lengths are zero).");
+    ADD_PROPERTY_TYPE(DirMode, (dmCustom), "Extrude", App::Prop_None, "Sets, how Dir is updated.");
+    DirMode.setEnums(eDirModeStrings);
+    ADD_PROPERTY_TYPE(DirLink,(nullptr), "Extrude", App::Prop_None, "Link to edge defining extrusion direction.");
+    ADD_PROPERTY_TYPE(LengthFwd,(0.0), "Extrude", App::Prop_None, "Length of extrusion along direction. If both LengthFwd and LengthRev are zero, magnitude of Dir is used.");
+    ADD_PROPERTY_TYPE(LengthRev,(0.0), "Extrude", App::Prop_None, "Length of additional extrusion, against direction.");
+    ADD_PROPERTY_TYPE(Solid,(false), "Extrude", App::Prop_None, "If true, extruding a wire yeilds a solid. If false, a shell.");
+    ADD_PROPERTY_TYPE(Reversed,(false), "Extrude", App::Prop_None, "Set to true to swap the direction of extrusion.");
+    ADD_PROPERTY_TYPE(Symmetric,(false), "Extrude", App::Prop_None, "If true, extrusion is done in both directions to a total of LengthFwd. LengthRev is ignored.");
+    ADD_PROPERTY_TYPE(TaperAngle,(0.0), "Extrude", App::Prop_None, "Sets the angle of slope (draft) to apply to the sides. The angle is for outward taper; negative value yeilds inward tapering.");
+    ADD_PROPERTY_TYPE(TaperAngleRev,(0.0), "Extrude", App::Prop_None, "Taper angle of reverse part of extrusion.");
 }
 
 short Extrusion::mustExecute() const
 {
     if (Base.isTouched() ||
         Dir.isTouched() ||
+        DirMode.isTouched() ||
+        DirLink.isTouched() ||
+        LengthFwd.isTouched() ||
+        LengthRev.isTouched() ||
         Solid.isTouched() ||
-        TaperAngle.isTouched())
+        Reversed.isTouched() ||
+        Symmetric.isTouched() ||
+        TaperAngle.isTouched() ||
+        TaperAngleRev.isTouched())
         return 1;
     return 0;
+}
+
+bool Extrusion::fetchAxisLink(const App::PropertyLinkSub& axisLink, Base::Vector3d& basepoint, Base::Vector3d& dir)
+{
+    if (!axisLink.getValue())
+        return false;
+
+    if (!axisLink.getValue()->isDerivedFrom(Part::Feature::getClassTypeId()))
+        throw Base::TypeError("AxisLink has no OCC shape");
+
+    Part::Feature* linked = static_cast<Part::Feature*>(axisLink.getValue());
+
+    TopoDS_Shape axEdge;
+    if (axisLink.getSubValues().size() > 0  &&  axisLink.getSubValues()[0].length() > 0){
+        axEdge = linked->Shape.getShape().getSubShape(axisLink.getSubValues()[0].c_str());
+    } else {
+        axEdge = linked->Shape.getValue();
+    }
+
+    if (axEdge.IsNull())
+        throw Base::ValueError("DirLink shape is null");
+    if (axEdge.ShapeType() != TopAbs_EDGE)
+        throw Base::TypeError("DirLink shape is not an edge");
+
+    BRepAdaptor_Curve crv(TopoDS::Edge(axEdge));
+    gp_Pnt startpoint;
+    gp_Pnt endpoint;
+    if (crv.GetType() == GeomAbs_Line){
+        startpoint = crv.Value(crv.FirstParameter());
+        endpoint = crv.Value(crv.LastParameter());
+        if (axEdge.Orientation() == TopAbs_REVERSED)
+            std::swap(startpoint, endpoint);
+    } else {
+        throw Base::TypeError("DirLink edge is not a line.");
+    }
+    basepoint.Set(startpoint.X(), startpoint.Y(), startpoint.Z());
+    gp_Vec vec = gp_Vec(startpoint, endpoint);
+    dir.Set(vec.X(), vec.Y(), vec.Z());
+    return true;
+}
+
+Extrusion::ExtrusionParameters Extrusion::computeFinalParameters()
+{
+    Extrusion::ExtrusionParameters result;
+    Base::Vector3d dir;
+    switch(this->DirMode.getValue()){
+        case dmCustom:
+            dir = this->Dir.getValue();
+        break;
+        case dmEdge:{
+            bool fetched;
+            Base::Vector3d base;
+            fetched = fetchAxisLink(this->DirLink, base, dir);
+            if (! fetched)
+                throw Base::Exception("DirMode is set to use edge, but no edge is linked.");
+            this->Dir.setValue(dir);
+        }break;
+        case dmNormal:
+            dir = calculateShapeNormal(this->Base);
+            this->Dir.setValue(dir);
+        break;
+        default:
+            throw Base::ValueError("Unexpected enum value");
+    }
+    if(dir.Length() < Precision::Confusion())
+        throw Base::ValueError("Direction is zero-length");
+    result.dir = gp_Dir(dir.x, dir.y, dir.z);
+    if (this->Reversed.getValue())
+        result.dir.Reverse();
+
+    result.lengthFwd = this->LengthFwd.getValue();
+    result.lengthRev = this->LengthRev.getValue();
+    if(fabs(result.lengthFwd) < Precision::Confusion()
+            && fabs(result.lengthRev) < Precision::Confusion() ){
+        result.lengthFwd = dir.Length();
+    }
+
+    if (this->Symmetric.getValue()){
+        result.lengthRev = result.lengthFwd * 0.5;
+        result.lengthFwd = result.lengthFwd * 0.5;
+    }
+
+    if (fabs(result.lengthFwd + result.lengthRev) < Precision::Confusion())
+        throw Base::ValueError("Total length of extrusion is zero.");
+
+    result.solid = this->Solid.getValue();
+
+    result.taperAngleFwd = this->TaperAngle.getValue() * M_PI / 180.0;
+    if (fabs(result.taperAngleFwd) > M_PI * 0.5 - Precision::Angular() )
+        throw Base::ValueError("Magnitude of taper angle matches or exceeds 90 degrees. That is too much.");
+    result.taperAngleRev = this->TaperAngleRev.getValue() * M_PI / 180.0;
+    if (fabs(result.taperAngleRev) > M_PI * 0.5 - Precision::Angular() )
+        throw Base::ValueError("Magnitude of taper angle matches or exceeds 90 degrees. That is too much.");
+
+    return result;
+}
+
+Base::Vector3d Extrusion::calculateShapeNormal(const App::PropertyLink& shapeLink)
+{
+    if (!shapeLink.getValue())
+        throw Base::Exception("calculateShapeNormal: link is empty");
+    const App::DocumentObject* docobj = shapeLink.getValue();
+
+    //special case for sketches and the like: no matter what shape they have, use their local Z axis.
+    if (docobj->isDerivedFrom(Part::Part2DObject::getClassTypeId())){
+        const Part::Part2DObject* p2do = static_cast<const Part::Part2DObject*>(docobj);
+        Base::Vector3d OZ (0.0, 0.0, 1.0);
+        Base::Vector3d result;
+        p2do->Placement.getValue().getRotation().multVec(OZ, result);
+        return result;
+    }
+
+    //extract the shape
+    if (! docobj->isDerivedFrom(Part::Feature::getClassTypeId()))
+        throw Base::TypeError("Linked object doesn't have shape.");
+
+    const TopoShape &tsh = static_cast<const Part::Feature*>(docobj)->Shape.getShape();
+    TopoDS_Shape sh = tsh.getShape();
+    if (sh.IsNull())
+        throw Base::Exception("calculateShapeNormal: link points to a valid object, but its shape is null.");
+
+    //find plane
+    BRepLib_FindSurface planeFinder(sh, -1, /*OnlyPlane=*/true);
+    if (! planeFinder.Found())
+        throw Base::ValueError("Can't find normal direction, because the shape is not on a plane.");
+
+    //find plane normal and return result.
+    GeomAdaptor_Surface surf(planeFinder.Surface());
+    gp_Dir normal = surf.Plane().Axis().Direction();
+
+    //now se know the plane. But if there are faces, the
+    //plane normal direction is not dependent on face orientation (because findPlane only uses egdes).
+    //let's fix that.
+    TopExp_Explorer ex(sh, TopAbs_FACE);
+    if(ex.More()) {
+        BRepAdaptor_Surface surf(TopoDS::Face(ex.Current()));
+        normal = surf.Plane().Axis().Direction();
+        if (ex.Current().Orientation() == TopAbs_REVERSED){
+            normal.Reverse();
+        }
+    }
+
+    return Base::Vector3d(normal.X(), normal.Y(), normal.Z());
+}
+
+TopoShape Extrusion::extrudeShape(const TopoShape source, Extrusion::ExtrusionParameters params)
+{
+    TopoDS_Shape result;
+    gp_Vec vec = gp_Vec(params.dir).Multiplied(params.lengthFwd+params.lengthRev);//total vector of extrusion
+
+    if (std::fabs(params.taperAngleFwd) >= Precision::Angular() ||
+        std::fabs(params.taperAngleRev) >= Precision::Angular() ) {
+        //Tapered extrusion!
+#if defined(__GNUC__) && defined (FC_OS_LINUX)
+        Base::SignalException se;
+#endif
+        TopoDS_Shape myShape = source.getShape();
+        if (myShape.IsNull())
+            Standard_Failure::Raise("Cannot extrude empty shape");
+        // #0000910: Circles Extrude Only Surfaces, thus use BRepBuilderAPI_Copy
+        myShape = BRepBuilderAPI_Copy(myShape).Shape();
+
+        std::list<TopoDS_Shape> drafts;
+        makeDraft(params, myShape, drafts);
+        if (drafts.empty()) {
+            Standard_Failure::Raise("Drafting shape failed");
+        }
+        else if (drafts.size() == 1) {
+            result = drafts.front();
+        }
+        else {
+            TopoDS_Compound comp;
+            BRep_Builder builder;
+            builder.MakeCompound(comp);
+            for (std::list<TopoDS_Shape>::iterator it = drafts.begin(); it != drafts.end(); ++it)
+                builder.Add(comp, *it);
+            result = comp;
+        }
+    }
+    else {
+        //Regular (non-tapered) extrusion!
+        TopoDS_Shape myShape = source.getShape();
+        if (myShape.IsNull())
+            Standard_Failure::Raise("Cannot extrude empty shape");
+
+        // #0000910: Circles Extrude Only Surfaces, thus use BRepBuilderAPI_Copy
+        myShape = BRepBuilderAPI_Copy(myShape).Shape();
+
+        //apply reverse part of extrusion by shifting the source shape
+        if (fabs(params.lengthRev)>Precision::Confusion() ){
+            gp_Trsf mov;
+            mov.SetTranslation(gp_Vec(params.dir)*(-params.lengthRev));
+            TopLoc_Location loc(mov);
+            myShape.Move(loc);
+        }
+
+        //make faces from wires
+        if (params.solid && myShape.ShapeType() != TopAbs_FACE) {
+            std::vector<TopoDS_Wire> wires;
+            TopTools_IndexedMapOfShape mapOfWires;
+            TopExp::MapShapes(myShape, TopAbs_WIRE, mapOfWires);
+
+            // if there are no wires then check also for edges
+            if (mapOfWires.IsEmpty()) {
+                TopTools_IndexedMapOfShape mapOfEdges;
+                TopExp::MapShapes(myShape, TopAbs_EDGE, mapOfEdges);
+                for (int i=1; i<=mapOfEdges.Extent(); i++) {
+                    BRepBuilderAPI_MakeWire mkWire(TopoDS::Edge(mapOfEdges.FindKey(i)));
+                    wires.push_back(mkWire.Wire());
+                }
+            }
+            else {
+                wires.reserve(mapOfWires.Extent());
+                for (int i=1; i<=mapOfWires.Extent(); i++) {
+                    wires.push_back(TopoDS::Wire(mapOfWires.FindKey(i)));
+                }
+            }
+
+            if (!wires.empty()) {
+                try {
+                    TopoDS_Shape res = makeFace(wires);
+                    if (!res.IsNull())
+                        myShape = res;
+                }
+                catch (...) {
+                }
+            }
+        }
+
+        //extrude!
+        BRepPrimAPI_MakePrism mkPrism(myShape, vec);
+        result = mkPrism.Shape();
+    }
+
+    if (result.IsNull())
+        throw Base::Exception("Result of extrusion is null shape.");
+    return TopoShape(result);
+
 }
 
 App::DocumentObjectExecReturn *Extrusion::execute(void)
@@ -90,84 +354,10 @@ App::DocumentObjectExecReturn *Extrusion::execute(void)
         return new App::DocumentObjectExecReturn("Linked object is not a Part object");
     Part::Feature *base = static_cast<Part::Feature*>(Base.getValue());
 
-    Base::Vector3d v = Dir.getValue();
-    gp_Vec vec(v.x,v.y,v.z);
-    double taperAngle = TaperAngle.getValue();
-    bool makeSolid = Solid.getValue();
-
     try {
-        if (std::fabs(taperAngle) >= Precision::Confusion()) {
-#if defined(__GNUC__) && defined (FC_OS_LINUX)
-            Base::SignalException se;
-#endif
-            double distance = std::tan(Base::toRadians(taperAngle)) * vec.Magnitude();
-            TopoDS_Shape myShape = base->Shape.getValue();
-            if (myShape.IsNull())
-                Standard_Failure::Raise("Cannot extrude empty shape");
-            // #0000910: Circles Extrude Only Surfaces, thus use BRepBuilderAPI_Copy
-            myShape = BRepBuilderAPI_Copy(myShape).Shape();
-
-            std::list<TopoDS_Shape> drafts;
-            makeDraft(distance, vec, makeSolid, myShape, drafts);
-            if (drafts.empty()) {
-                Standard_Failure::Raise("Drafting shape failed");
-            }
-            else if (drafts.size() == 1) {
-                this->Shape.setValue(drafts.front());
-            }
-            else {
-                TopoDS_Compound comp;
-                BRep_Builder builder;
-                builder.MakeCompound(comp);
-                for (std::list<TopoDS_Shape>::iterator it = drafts.begin(); it != drafts.end(); ++it)
-                    builder.Add(comp, *it);
-                this->Shape.setValue(comp);
-            }
-        }
-        else {
-            // Now, let's get the TopoDS_Shape
-            TopoDS_Shape myShape = base->Shape.getValue();
-            if (myShape.IsNull())
-                Standard_Failure::Raise("Cannot extrude empty shape");
-            // #0000910: Circles Extrude Only Surfaces, thus use BRepBuilderAPI_Copy
-            myShape = BRepBuilderAPI_Copy(myShape).Shape();
-            if (makeSolid && myShape.ShapeType() != TopAbs_FACE) {
-                std::vector<TopoDS_Wire> wires;
-                TopTools_IndexedMapOfShape mapOfWires;
-                TopExp::MapShapes(myShape, TopAbs_WIRE, mapOfWires);
-
-                // if there are no wires then check also for edges
-                if (mapOfWires.IsEmpty()) {
-                    TopTools_IndexedMapOfShape mapOfEdges;
-                    TopExp::MapShapes(myShape, TopAbs_EDGE, mapOfEdges);
-                    for (int i=1; i<=mapOfEdges.Extent(); i++) {
-                        BRepBuilderAPI_MakeWire mkWire(TopoDS::Edge(mapOfEdges.FindKey(i)));
-                        wires.push_back(mkWire.Wire());
-                    }
-                }
-                else {
-                    wires.reserve(mapOfWires.Extent());
-                    for (int i=1; i<=mapOfWires.Extent(); i++) {
-                        wires.push_back(TopoDS::Wire(mapOfWires.FindKey(i)));
-                    }
-                }
-
-                if (!wires.empty()) {
-                    try {
-                        TopoDS_Shape res = makeFace(wires);
-                        if (!res.IsNull())
-                            myShape = res;
-                    }
-                    catch (...) {
-                    }
-                }
-            }
-            BRepPrimAPI_MakePrism mkPrism(myShape, vec);
-            TopoDS_Shape swept = mkPrism.Shape();
-            if (swept.IsNull())
-                return new App::DocumentObjectExecReturn("Resulting shape is null");
-            this->Shape.setValue(swept);
-        }
+        Extrusion::ExtrusionParameters params = computeFinalParameters();
+        TopoShape result = extrudeShape(base->Shape.getShape(),params);
+        this->Shape.setValue(result);
         return App::DocumentObject::StdReturn;
     }
     catch (Standard_Failure) {
@@ -176,9 +366,19 @@ App::DocumentObjectExecReturn *Extrusion::execute(void)
     }
 }
 
-void Extrusion::makeDraft(double distance, const gp_Vec& vec, bool makeSolid, const TopoDS_Shape& shape, std::list<TopoDS_Shape>& drafts) const
+void Extrusion::makeDraft(ExtrusionParameters params, const TopoDS_Shape& shape, std::list<TopoDS_Shape>& drafts)
 {
-    std::list<TopoDS_Wire> wire_list;
+    double distanceFwd = tan(params.taperAngleFwd)*params.lengthFwd;
+    double distanceRev = tan(params.taperAngleRev)*params.lengthRev;
+
+    gp_Vec vecFwd = gp_Vec(params.dir)*params.lengthFwd;
+    gp_Vec vecRev = gp_Vec(params.dir.Reversed())*params.lengthRev;
+
+    bool bFwd = fabs(params.lengthFwd) > Precision::Confusion();
+    bool bRev = fabs(params.lengthRev) > Precision::Confusion();
+    bool bMid = !bFwd || !bRev || params.lengthFwd*params.lengthRev > 0.0; //include the source shape as loft section?
+
+    TopoDS_Wire sourceWire;
     if (shape.IsNull())
         Standard_Failure::Raise("Not a valid shape");
     if (shape.ShapeType() == TopAbs_WIRE) {
@@ -187,49 +387,119 @@ void Extrusion::makeDraft(double distance, const gp_Vec& vec, bool makeSolid, co
         aFix.FixReorder();
         aFix.FixConnected();
         aFix.FixClosed();
-        wire_list.push_back(aFix.Wire());
+        sourceWire = aFix.Wire();
     }
     else if (shape.ShapeType() == TopAbs_FACE) {
         TopoDS_Wire outerWire = ShapeAnalysis::OuterWire(TopoDS::Face(shape));
-        wire_list.push_back(outerWire);
+        sourceWire = outerWire;
     }
     else if (shape.ShapeType() == TopAbs_COMPOUND) {
         TopoDS_Iterator it(shape);
         for (; it.More(); it.Next()) {
-            makeDraft(distance, vec, makeSolid, it.Value(), drafts);
+            makeDraft(params, it.Value(), drafts);
         }
     }
     else {
         Standard_Failure::Raise("Only a wire or a face is supported");
     }
 
-    if (!wire_list.empty()) {
-        BRepOffsetAPI_MakeOffset mkOffset;
+    if (!sourceWire.IsNull()) {
+        std::list<TopoDS_Wire> list_of_sections;
+
+        //first. add wire for reversed part of extrusion
+        if (bRev){
+            gp_Vec translation = vecRev;
+            double offset = distanceRev;
+
+            BRepOffsetAPI_MakeOffset mkOffset;
 #if OCC_VERSION_HEX >= 0x060800
-        mkOffset.Init(GeomAbs_Arc);
+            mkOffset.Init(GeomAbs_Arc);
 #endif
-        mkOffset.AddWire(wire_list.front());
-        mkOffset.Perform(distance);
+#if OCC_VERSION_HEX >= 0x070000
+            mkOffset.Init(GeomAbs_Intersection);
+#endif
+            gp_Trsf mat;
+            mat.SetTranslation(translation);
+            TopLoc_Location loc(mat);
+            TopoDS_Wire movedSourceWire = TopoDS::Wire(sourceWire.Moved(loc));
 
-        gp_Trsf mat;
-        mat.SetTranslation(vec);
-        BRepBuilderAPI_Transform mkTransform(mkOffset.Shape(),mat);
-        if (mkTransform.Shape().IsNull())
-            Standard_Failure::Raise("Tapered shape is empty");
-        TopAbs_ShapeEnum type = mkTransform.Shape().ShapeType();
-        if (type == TopAbs_WIRE) {
-            wire_list.push_back(TopoDS::Wire(mkTransform.Shape()));
-        }
-        else if (type == TopAbs_EDGE) {
-            BRepBuilderAPI_MakeWire mkWire(TopoDS::Edge(mkTransform.Shape()));
-            wire_list.push_back(mkWire.Wire());
-        }
-        else {
-            Standard_Failure::Raise("Tapered shape type is not supported");
+            TopoDS_Shape offsetShape;
+            if (fabs(offset)>Precision::Confusion()){
+                mkOffset.AddWire(movedSourceWire);
+                mkOffset.Perform(offset);
+
+                offsetShape = mkOffset.Shape();
+            } else {
+                //stupid OCC doesn't understand, what to do when offset value is zero =/
+                offsetShape = movedSourceWire;
+            }
+
+            if (offsetShape.IsNull())
+                Standard_Failure::Raise("Tapered shape is empty");
+            TopAbs_ShapeEnum type = offsetShape.ShapeType();
+            if (type == TopAbs_WIRE) {
+                list_of_sections.push_back(TopoDS::Wire(offsetShape));
+            }
+            else if (type == TopAbs_EDGE) {
+                BRepBuilderAPI_MakeWire mkWire(TopoDS::Edge(offsetShape));
+                list_of_sections.push_back(mkWire.Wire());
+            }
+            else {
+                Standard_Failure::Raise("Tapered shape type is not supported");
+            }
         }
 
-        BRepOffsetAPI_ThruSections mkGenerator(makeSolid ? Standard_True : Standard_False, Standard_False);
-        for (std::list<TopoDS_Wire>::const_iterator it = wire_list.begin(); it != wire_list.end(); ++it) {
+        //next. Add source wire as middle section. Order is important.
+        if (bMid){
+            list_of_sections.push_back(sourceWire);
+        }
+
+        //finally. Forward extrusion offset wire.
+        if (bFwd){
+            gp_Vec translation = vecFwd;
+            double offset = distanceFwd;
+
+            BRepOffsetAPI_MakeOffset mkOffset;
+#if OCC_VERSION_HEX >= 0x060800
+            mkOffset.Init(GeomAbs_Arc);
+#endif
+#if OCC_VERSION_HEX >= 0x070000
+            mkOffset.Init(GeomAbs_Intersection);
+#endif
+            gp_Trsf mat;
+            mat.SetTranslation(translation);
+            TopLoc_Location loc(mat);
+            TopoDS_Wire movedSourceWire = TopoDS::Wire(sourceWire.Moved(loc));
+
+            TopoDS_Shape offsetShape;
+            if (fabs(offset)>Precision::Confusion()){
+                mkOffset.AddWire(movedSourceWire);
+                mkOffset.Perform(offset);
+
+                offsetShape = mkOffset.Shape();
+            } else {
+                //stupid OCC doesn't understand, what to do when offset value is zero =/
+                offsetShape = movedSourceWire;
+            }
+
+            if (offsetShape.IsNull())
+                Standard_Failure::Raise("Tapered shape is empty");
+            TopAbs_ShapeEnum type = offsetShape.ShapeType();
+            if (type == TopAbs_WIRE) {
+                list_of_sections.push_back(TopoDS::Wire(offsetShape));
+            }
+            else if (type == TopAbs_EDGE) {
+                BRepBuilderAPI_MakeWire mkWire(TopoDS::Edge(offsetShape));
+                list_of_sections.push_back(mkWire.Wire());
+            }
+            else {
+                Standard_Failure::Raise("Tapered shape type is not supported");
+            }
+        }
+
+        //make loft
+        BRepOffsetAPI_ThruSections mkGenerator(params.solid ? Standard_True : Standard_False, /*ruled=*/Standard_True);
+        for (std::list<TopoDS_Wire>::const_iterator it = list_of_sections.begin(); it != list_of_sections.end(); ++it) {
             const TopoDS_Wire &wire = *it;
             mkGenerator.AddWire(wire);
         }
@@ -241,12 +511,16 @@ void Extrusion::makeDraft(double distance, const gp_Vec& vec, bool makeSolid, co
             mkGenerator.Build();
             drafts.push_back(mkGenerator.Shape());
         }
+        catch (Standard_Failure &){
+            throw;
+        }
         catch (...) {
+            throw Base::Exception("Unknown exception from BRepOffsetAPI_ThruSections");
         }
     }
 }
 
-TopoDS_Face Extrusion::validateFace(const TopoDS_Face& face) const
+TopoDS_Face Extrusion::validateFace(const TopoDS_Face& face)
 {
     BRepCheck_Analyzer aChecker(face);
     if (!aChecker.IsValid()) {
@@ -311,7 +585,7 @@ public:
     }
 };
 
-bool Extrusion::isInside(const TopoDS_Wire& wire1, const TopoDS_Wire& wire2) const
+bool Extrusion::isInside(const TopoDS_Wire& wire1, const TopoDS_Wire& wire2)
 {
     Bnd_Box box1;
     BRepBndLib::Add(wire1, box1);
@@ -352,7 +626,7 @@ bool Extrusion::isInside(const TopoDS_Wire& wire1, const TopoDS_Wire& wire2) con
     return false;
 }
 
-TopoDS_Shape Extrusion::makeFace(std::list<TopoDS_Wire>& wires) const
+TopoDS_Shape Extrusion::makeFace(std::list<TopoDS_Wire>& wires)
 {
     BRepBuilderAPI_MakeFace mkFace(wires.front());
     const TopoDS_Face& face = mkFace.Face();
@@ -384,7 +658,7 @@ TopoDS_Shape Extrusion::makeFace(std::list<TopoDS_Wire>& wires) const
     return validateFace(mkFace.Face());
 }
 
-TopoDS_Shape Extrusion::makeFace(const std::vector<TopoDS_Wire>& w) const
+TopoDS_Shape Extrusion::makeFace(const std::vector<TopoDS_Wire>& w)
 {
     if (w.empty())
         return TopoDS_Shape();

--- a/src/Mod/Part/App/FeatureExtrusion.h
+++ b/src/Mod/Part/App/FeatureExtrusion.h
@@ -32,7 +32,7 @@
 namespace Part
 {
 
-class Extrusion : public Part::Feature
+class PartExport Extrusion : public Part::Feature
 {
     PROPERTY_HEADER(Part::Extrusion);
 
@@ -41,8 +41,31 @@ public:
 
     App::PropertyLink Base;
     App::PropertyVector Dir;
+    App::PropertyEnumeration DirMode;
+    App::PropertyLinkSub DirLink;
+    App::PropertyDistance LengthFwd;
+    App::PropertyDistance LengthRev;
     App::PropertyBool Solid;
+    App::PropertyBool Reversed;
+    App::PropertyBool Symmetric;
     App::PropertyAngle TaperAngle;
+    App::PropertyAngle TaperAngleRev;
+
+
+    /**
+     * @brief The ExtrusionParameters struct is supposed to be filled with final
+     * extrusion parameters, after resolving links, applying mode logic,
+     * reversing, etc., and be passed to extrudeShape.
+     */
+    struct ExtrusionParameters {
+        gp_Dir dir;
+        double lengthFwd;
+        double lengthRev;
+        bool solid;
+        double taperAngleFwd; //in radians
+        double taperAngleRev;
+        ExtrusionParameters(): lengthFwd(0), lengthRev(0), solid(false), taperAngleFwd(0), taperAngleRev(0) {}// constructor to keep garbage out
+    };
 
     /** @name methods override feature */
     //@{
@@ -55,12 +78,51 @@ public:
     }
     //@}
 
+    /**
+     * @brief extrudeShape powers the extrusion feature.
+     * @param source: the shape to be extruded
+     * @param params: extrusion parameters
+     * @return result of extrusion
+     */
+    static TopoShape extrudeShape(TopoShape source, ExtrusionParameters params);
+
+    /**
+     * @brief fetchAxisLink: read AxisLink to obtain the direction and
+     * length. Note: this routine is re-used in Extrude dialog, hence it
+     * is static.
+     * @param axisLink (input): the link
+     * @param basepoint (output): starting point of edge. Not used by extrude as of now.
+     * @param dir (output): direction of axis, with magnitude (length)
+     * @return true if link was fetched. false if link was empty. Throws if the
+     * link is wrong.
+     */
+    static bool fetchAxisLink(const App::PropertyLinkSub& axisLink,
+                              Base::Vector3d &basepoint,
+                              Base::Vector3d &dir);
+
+    /**
+     * @brief computeFinalParameters: applies mode logic and fetches links, to
+     * compute the actual parameters of extrusion. Dir property is updated in
+     * the process, hence the function is non-const.
+     */
+    ExtrusionParameters computeFinalParameters();
+
+    static Base::Vector3d calculateShapeNormal(const App::PropertyLink &shapeLink);
+
+public: //mode enumerations
+    enum eDirMode{
+        dmCustom,
+        dmEdge,
+        dmNormal
+    };
+    static const char* eDirModeStrings[];
+
 private:
-    bool isInside(const TopoDS_Wire&, const TopoDS_Wire&) const;
-    TopoDS_Face validateFace(const TopoDS_Face&) const;
-    TopoDS_Shape makeFace(const std::vector<TopoDS_Wire>&) const;
-    TopoDS_Shape makeFace(std::list<TopoDS_Wire>&) const; // for internal use only
-    void makeDraft(double, const gp_Vec&, bool, const TopoDS_Shape&, std::list<TopoDS_Shape>&) const;
+    static bool isInside(const TopoDS_Wire&, const TopoDS_Wire&);
+    static TopoDS_Face validateFace(const TopoDS_Face&);
+    static TopoDS_Shape makeFace(const std::vector<TopoDS_Wire>&);
+    static TopoDS_Shape makeFace(std::list<TopoDS_Wire>&); // for internal use only
+    static void makeDraft(ExtrusionParameters params, const TopoDS_Shape&, std::list<TopoDS_Shape>&);
 
 private:
     class Wire_Compare;

--- a/src/Mod/Part/App/FeatureRevolution.cpp
+++ b/src/Mod/Part/App/FeatureRevolution.cpp
@@ -106,8 +106,9 @@ bool Revolution::fetchAxisLink(const App::PropertyLinkSub &axisLink,
     BRepAdaptor_Curve crv(TopoDS::Edge(axEdge));
     gp_Pnt base;
     gp_Dir occdir;
+    bool reversed = axEdge.Orientation() == TopAbs_REVERSED;
     if (crv.GetType() == GeomAbs_Line){
-        base = crv.Value(crv.FirstParameter());
+        base = crv.Value(reversed ? crv.FirstParameter() : crv.LastParameter());
         occdir = crv.Line().Direction();
     } else if (crv.GetType() == GeomAbs_Circle) {
         base = crv.Circle().Axis().Location();
@@ -116,6 +117,8 @@ bool Revolution::fetchAxisLink(const App::PropertyLinkSub &axisLink,
     } else {
         throw Base::TypeError("AxisLink edge is neither line nor arc of circle.");
     }
+    if (reversed)
+        occdir.Reverse();
     center.Set(base.X(), base.Y(),base.Z());
     dir.Set(occdir.X(), occdir.Y(), occdir.Z());
     return true;

--- a/src/Mod/Part/Gui/DlgExtrusion.cpp
+++ b/src/Mod/Part/Gui/DlgExtrusion.cpp
@@ -24,12 +24,16 @@
 #include "PreCompiled.h"
 #ifndef _PreComp_
 # include <BRepAdaptor_Surface.hxx>
+# include <BRepAdaptor_Curve.hxx>
 # include <BRepLProp_SLProps.hxx>
 # include <BRepGProp_Face.hxx>
+# include <BRep_Tool.hxx>
 # include <Precision.hxx>
 # include <TopoDS.hxx>
 # include <TopoDS_Face.hxx>
 # include <TopExp_Explorer.hxx>
+# include <ShapeExtend_Explorer.hxx>
+# include <TopTools_HSequenceOfShape.hxx>
 # include <QMessageBox>
 # include <Inventor/system/inttypes.h>
 #endif
@@ -39,6 +43,7 @@
 #include "../App/PartFeature.h"
 #include <Base/Console.h>
 #include <Base/UnitsApi.h>
+#include <Base/Interpreter.h>
 #include <App/Application.h>
 #include <App/Document.h>
 #include <App/DocumentObject.h>
@@ -52,23 +57,71 @@
 
 using namespace PartGui;
 
+class DlgExtrusion::EdgeSelection : public Gui::SelectionFilterGate
+{
+public:
+    bool canSelect;
+
+    EdgeSelection()
+        : Gui::SelectionFilterGate((Gui::SelectionFilter*)0)
+    {
+        canSelect = false;
+    }
+    bool allow(App::Document* pDoc, App::DocumentObject* pObj, const char* sSubName)
+    {
+        this->canSelect = false;
+        if (!pObj->isDerivedFrom(Part::Feature::getClassTypeId()))
+            return false;
+        if (!sSubName || sSubName[0] == '\0')
+            return false;
+        std::string element(sSubName);
+        if (element.substr(0,4) != "Edge")
+            return false;
+        Part::Feature* fea = static_cast<Part::Feature*>(pObj);
+        try {
+            TopoDS_Shape sub = fea->Shape.getShape().getSubShape(sSubName);
+            if (!sub.IsNull() && sub.ShapeType() == TopAbs_EDGE) {
+                const TopoDS_Edge& edge = TopoDS::Edge(sub);
+                BRepAdaptor_Curve adapt(edge);
+                if (adapt.GetType() == GeomAbs_Line) {
+                    this->canSelect = true;
+                    return true;
+                }
+            }
+        }
+        catch (...) {
+        }
+
+        return false;
+    }
+};
+
 DlgExtrusion::DlgExtrusion(QWidget* parent, Qt::WindowFlags fl)
-  : QDialog(parent, fl), ui(new Ui_DlgExtrusion)
+  : QDialog(parent, fl), ui(new Ui_DlgExtrusion), filter(nullptr)
 {
     ui->setupUi(this);
     ui->statusLabel->clear();
-    ui->labelNormal->hide();
-    ui->viewButton->hide();
     ui->dirX->setDecimals(Base::UnitsApi::getDecimals());
     ui->dirY->setDecimals(Base::UnitsApi::getDecimals());
     ui->dirZ->setDecimals(Base::UnitsApi::getDecimals());
-    ui->dirLen->setUnit(Base::Unit::Length);
-    ui->taperAngle->setUnit(Base::Unit::Angle);
-    ui->dirLen->setMinimumWidth(55); // needed to show all digits
+    ui->spinLenFwd->setUnit(Base::Unit::Length);
+    ui->spinLenFwd->setValue(10.0);
+    ui->spinLenRev->setUnit(Base::Unit::Length);
+    ui->spinTaperAngle->setUnit(Base::Unit::Angle);
+    ui->spinTaperAngle->setUnit(Base::Unit::Angle);
     findShapes();
 
     Gui::ItemViewSelection sel(ui->treeWidget);
     sel.applyFrom(Gui::Selection().getObjectsOfType(Part::Feature::getClassTypeId()));
+
+    this->on_DirMode_changed();
+    ui->spinLenFwd->selectAll();
+    // Make sure that the spin box has the focus to get key events
+    // Calling setFocus() directly doesn't work because the spin box is not
+    // yet visible.
+    QMetaObject::invokeMethod(ui->spinLenFwd, "setFocus", Qt::QueuedConnection);
+
+    this->autoSolid();
 }
 
 /*  
@@ -86,6 +139,198 @@ void DlgExtrusion::changeEvent(QEvent *e)
         ui->retranslateUi(this);
     }
     QDialog::changeEvent(e);
+}
+
+void DlgExtrusion::on_rbDirModeCustom_toggled(bool on)
+{
+    if(on) //this check prevents dual fire of dirmode changed - on radio buttons, one will come on, and other will come off, causing two events.
+        this->on_DirMode_changed();
+}
+
+void DlgExtrusion::on_rbDirModeEdge_toggled(bool on)
+{
+    if(on)
+        this->on_DirMode_changed();
+}
+
+void DlgExtrusion::on_rbDirModeNormal_toggled(bool on)
+{
+    if(on)
+        this->on_DirMode_changed();
+}
+
+void DlgExtrusion::on_btnSelectEdge_clicked()
+{
+    if (!filter) {
+        filter = new EdgeSelection();
+        Gui::Selection().addSelectionGate(filter);
+        ui->btnSelectEdge->setText(tr("Selecting..."));
+
+        //visibility automation
+        try{
+            QString code = QString::fromLatin1(
+                        "import TempoVis\n"
+                        "tv = TempoVis.TempoVis(App.ActiveDocument)\n"
+                        "tv.hide([%1])"
+                        );
+            std::vector<App::DocumentObject*>sources = getShapesToExtrude();
+            QString features_to_hide;
+            for (App::DocumentObject* obj: sources){
+                if (!obj)
+                    continue;
+                features_to_hide.append(QString::fromLatin1("App.ActiveDocument."));
+                features_to_hide.append(QString::fromLatin1(obj->getNameInDocument()));
+                features_to_hide.append(QString::fromLatin1(", \n"));
+            }
+            QByteArray code_2 = code.arg(features_to_hide).toLatin1();
+            Base::Interpreter().runString(code_2.constData());
+        } catch (Base::PyException &e){
+            e.ReportException();
+        }
+    } else {
+        Gui::Selection().rmvSelectionGate();
+        filter = nullptr;
+        ui->btnSelectEdge->setText(tr("Select"));
+
+        //visibility automation
+        try{
+            Base::Interpreter().runString("del(tv)");
+        } catch (Base::PyException &e){
+            e.ReportException();
+        }
+    }
+}
+
+void DlgExtrusion::on_btnX_clicked()
+{
+    Base::Vector3d axis(1.0, 0.0, 0.0);
+    if ((getDir() - axis).Length() < 1e-7)
+        axis = axis * (-1);
+    setDirMode(Part::Extrusion::dmCustom);
+    setDir(axis);
+}
+
+void DlgExtrusion::on_btnY_clicked()
+{
+    Base::Vector3d axis(0.0, 1.0, 0.0);
+    if ((getDir() - axis).Length() < 1e-7)
+        axis = axis * (-1);
+    setDirMode(Part::Extrusion::dmCustom);
+    setDir(axis);
+}
+
+void DlgExtrusion::on_btnZ_clicked()
+{
+    Base::Vector3d axis(0.0, 0.0, 1.0);
+    if ((getDir() - axis).Length() < 1e-7)
+        axis = axis * (-1);
+    setDirMode(Part::Extrusion::dmCustom);
+    setDir(axis);
+}
+
+void DlgExtrusion::on_chkSymmetric_toggled(bool on)
+{
+    ui->spinLenRev->setEnabled(!on);
+}
+
+void DlgExtrusion::on_txtLink_textChanged(QString)
+{
+    this->fetchDir();
+}
+
+void DlgExtrusion::on_DirMode_changed()
+{
+    Part::Extrusion::eDirMode dirMode = this->getDirMode();
+    ui->dirX->setEnabled(dirMode == Part::Extrusion::dmCustom);
+    ui->dirY->setEnabled(dirMode == Part::Extrusion::dmCustom);
+    ui->dirZ->setEnabled(dirMode == Part::Extrusion::dmCustom);
+    ui->txtLink->setEnabled(dirMode == Part::Extrusion::dmEdge);
+    this->fetchDir();
+}
+
+void DlgExtrusion::onSelectionChanged(const Gui::SelectionChanges& msg)
+{
+    if (msg.Type == Gui::SelectionChanges::AddSelection) {
+        if (filter && filter->canSelect) {
+            this->setAxisLink(msg.pObjectName, msg.pSubName);
+            this->setDirMode(Part::Extrusion::dmEdge);
+        }
+    }
+}
+
+App::DocumentObject& DlgExtrusion::getShapeToExtrude() const
+{
+    std::vector<App::DocumentObject*> objs = this->getShapesToExtrude();
+    if (objs.size() == 0)
+        throw Base::Exception("No shapes selected");
+    return *(objs[0]);
+}
+
+void DlgExtrusion::fetchDir()
+{
+    bool lengths_are_at_defaults =
+            (fabs(ui->spinLenFwd->value().getValue() - 10.0) < 1e-7)
+            && (fabs(ui->spinLenRev->value().getValue() - 0.0) < 1e-7);
+    bool lengths_are_zero =
+            (fabs(ui->spinLenFwd->value().getValue() - 0.0) < 1e-7)
+            && (fabs(ui->spinLenRev->value().getValue() - 0.0) < 1e-7);
+
+    try{
+        Base::Vector3d pos, dir;
+        bool fetched = false;
+        bool dir_has_valid_magnitude = false;
+        if(this->getDirMode() == Part::Extrusion::dmEdge){
+            App::PropertyLinkSub lnk; this->getAxisLink(lnk);
+            fetched = Part::Extrusion::fetchAxisLink(lnk, pos, dir);
+            dir_has_valid_magnitude = fetched;
+        } else if (this->getDirMode() == Part::Extrusion::dmNormal){
+            App::PropertyLink lnk;
+            lnk.setValue(&this->getShapeToExtrude());
+            dir = Part::Extrusion::calculateShapeNormal(lnk);
+            fetched = true;
+        }
+        if (dir_has_valid_magnitude && lengths_are_at_defaults){
+            ui->spinLenFwd->setValue(0);
+        } else if (!dir_has_valid_magnitude && lengths_are_zero){
+            ui->spinLenFwd->setValue(1.0);
+        }
+        if (fetched){
+            this->setDir(dir);
+        }
+    } catch (Base::Exception &){
+
+    } catch (...){
+
+    }
+}
+
+void DlgExtrusion::autoSolid()
+{
+    try{
+        App::DocumentObject &dobj = this->getShapeToExtrude();
+        if (dobj.isDerivedFrom(Part::Feature::getClassTypeId())){
+            Part::Feature &feature = static_cast<Part::Feature&>(dobj);
+            TopoDS_Shape sh = feature.Shape.getValue();
+            if (sh.IsNull())
+                return;
+            ShapeExtend_Explorer xp;
+            Handle_TopTools_HSequenceOfShape leaves = xp.SeqFromCompound(sh, /*recursive= */Standard_True);
+            int cntClosedWires = 0;
+            for(int i = 0   ;   i < leaves->Length()   ;   i++){
+                const TopoDS_Shape &leaf = leaves->Value(i+1);
+                if (leaf.IsNull())
+                    return;
+                if (leaf.ShapeType() == TopAbs_WIRE || leaf.ShapeType() == TopAbs_EDGE){
+                    if (BRep_Tool::IsClosed(leaf)){
+                        cntClosedWires++;
+                    }
+                }
+            }
+            ui->chkSolid->setChecked( cntClosedWires == leaves->Length() );
+        }
+    } catch(...){
+
+    }
 }
 
 void DlgExtrusion::findShapes()
@@ -139,133 +384,317 @@ bool DlgExtrusion::canExtrude(const TopoDS_Shape& shape) const
 
 void DlgExtrusion::accept()
 {
-    apply();
-    QDialog::accept();
+    try{
+        apply();
+        QDialog::accept();
+    } catch (Base::AbortException){
+
+    };
 }
 
 void DlgExtrusion::apply()
 {
-    if (ui->treeWidget->selectedItems().isEmpty()) {
-        QMessageBox::critical(this, windowTitle(), 
-            tr("Select a shape for extrusion, first."));
-        return;
-    }
+    try{
+        if (!validate())
+            throw Base::AbortException();
 
-    Gui::WaitCursor wc;
-    App::Document* activeDoc = App::GetApplication().getDocument(this->document.c_str());
-    if (!activeDoc) {
-        QMessageBox::critical(this, windowTitle(), 
-            tr("The document '%1' doesn't exist.").arg(QString::fromUtf8(this->label.c_str())));
-        return;
-    }
-    activeDoc->openTransaction("Extrude");
+        if (filter) //if still selecting edge - stop. This is important for visibility automation.
+            this->on_btnSelectEdge_clicked();
 
-    Base::Reference<ParameterGrp> hGrp = App::GetApplication().GetUserParameter()
-        .GetGroup("BaseApp")->GetGroup("Preferences")->GetGroup("Mod/Part");
-    bool addBaseName = hGrp->GetBool("AddBaseObjectName", false);
-
-    QString shape, type, name, label;
-    QList<QTreeWidgetItem *> items = ui->treeWidget->selectedItems();
-    for (QList<QTreeWidgetItem *>::iterator it = items.begin(); it != items.end(); ++it) {
-        shape = (*it)->data(0, Qt::UserRole).toString();
-        type = QString::fromLatin1("Part::Extrusion");
-        if (addBaseName) {
-            QString baseName = QString::fromLatin1("Extrude_%1").arg(shape);
-            label = QString::fromLatin1("%1_Extrude").arg((*it)->text(0));
-            name = QString::fromLatin1(activeDoc->getUniqueObjectName((const char*)baseName.toLatin1()).c_str());
+        Gui::WaitCursor wc;
+        App::Document* activeDoc = App::GetApplication().getDocument(this->document.c_str());
+        if (!activeDoc) {
+            QMessageBox::critical(this, windowTitle(),
+                tr("The document '%1' doesn't exist.").arg(QString::fromUtf8(this->label.c_str())));
+            return;
         }
-        else {
-            name = QString::fromLatin1(activeDoc->getUniqueObjectName("Extrude").c_str());
-            label = name;
-        }
+        activeDoc->openTransaction("Extrude");
 
-        double dirX = ui->dirX->value();
-        double dirY = ui->dirY->value();
-        double dirZ = ui->dirZ->value();
-        double len = ui->dirLen->value().getValue();
-        double angle = ui->taperAngle->value().getValue();
-        bool makeSolid = ui->makeSolid->isChecked();
+        Base::Reference<ParameterGrp> hGrp = App::GetApplication().GetUserParameter()
+            .GetGroup("BaseApp")->GetGroup("Preferences")->GetGroup("Mod/Part");
+        bool addBaseName = hGrp->GetBool("AddBaseObjectName", false);
 
-        // inspect geometry
-        App::DocumentObject* obj = activeDoc->getObject((const char*)shape.toLatin1());
-        if (!obj || !obj->isDerivedFrom(Part::Feature::getClassTypeId())) continue;
-        Part::Feature* fea = static_cast<Part::Feature*>(obj);
-        const TopoDS_Shape& data = fea->Shape.getValue();
-        if (data.IsNull()) continue;
+        std::vector<App::DocumentObject*> objects = this->getShapesToExtrude();
+        for (App::DocumentObject* sourceObj: objects) {
+            assert(sourceObj);
 
-        // check for planes
-        if (ui->checkNormal->isChecked() && data.ShapeType() == TopAbs_FACE) {
-            BRepAdaptor_Surface adapt(TopoDS::Face(data));
-            if (adapt.GetType() == GeomAbs_Plane) {
-                double u = 0.5*(adapt.FirstUParameter() + adapt.LastUParameter());
-                double v = 0.5*(adapt.FirstVParameter() + adapt.LastVParameter());
-                BRepLProp_SLProps prop(adapt,u,v,1,Precision::Confusion());
-                if (prop.IsNormalDefined()) {
-                    gp_Pnt pnt; gp_Vec vec;
-                    // handles the orientation state of the shape
-                    BRepGProp_Face(TopoDS::Face(data)).Normal(u,v,pnt,vec);
-                    dirX = vec.X();
-                    dirY = vec.Y();
-                    dirZ = vec.Z();
-                }
+            if (!sourceObj->isDerivedFrom(Part::Feature::getClassTypeId())){
+                std::stringstream errmsg;
+                errmsg << "Object " << sourceObj->getNameInDocument() << " is not Part object (has no OCC shape). Can't extrude it.\n";
+                Base::Console().Error(errmsg.str().c_str());
+                continue;
             }
+
+            std::string name;
+            name = sourceObj->getDocument()->getUniqueObjectName("Extrude").c_str();
+            if (addBaseName) {
+                //FIXME: implement
+                //QString baseName = QString::fromLatin1("Extrude_%1").arg(sourceObjectName);
+                //label = QString::fromLatin1("%1_Extrude").arg((*it)->text(0));
+            }
+
+            Gui::Command::doCommand(Gui::Command::Doc, "f = FreeCAD.getDocument('%s').addObject('Part::Extrusion', '%s')", sourceObj->getDocument()->getName(), name.c_str());
+
+            this->writeParametersToFeature(*(sourceObj->getDocument()->getObject(name.c_str())), sourceObj);
+
+            std::string sourceObjectName = sourceObj->getNameInDocument();
+            Gui::Command::copyVisual(name.c_str(), "ShapeColor", sourceObjectName.c_str());
+            Gui::Command::copyVisual(name.c_str(), "LineColor", sourceObjectName.c_str());
+            Gui::Command::copyVisual(name.c_str(), "PointColor", sourceObjectName.c_str());
+
+            Gui::Command::doCommand(Gui::Command::Gui,"f.Base.ViewObject.hide()");
         }
 
-        QString code = QString::fromLatin1(
-            "FreeCAD.getDocument(\"%1\").addObject(\"%2\",\"%3\")\n"
-            "FreeCAD.getDocument(\"%1\").%3.Base = FreeCAD.getDocument(\"%1\").%4\n"
-            "FreeCAD.getDocument(\"%1\").%3.Dir = (%5,%6,%7)\n"
-            "FreeCAD.getDocument(\"%1\").%3.Solid = (%8)\n"
-            "FreeCAD.getDocument(\"%1\").%3.TaperAngle = (%9)\n"
-            "FreeCADGui.getDocument(\"%1\").%4.Visibility = False\n"
-            "FreeCAD.getDocument(\"%1\").%3.Label = '%10'\n")
-            .arg(QString::fromLatin1(this->document.c_str()))
-            .arg(type).arg(name).arg(shape)
-            .arg(dirX*len)
-            .arg(dirY*len)
-            .arg(dirZ*len)
-            .arg(makeSolid ? QLatin1String("True") : QLatin1String("False"))
-            .arg(angle)
-            .arg(label);
-        Gui::Application::Instance->runPythonCode((const char*)code.toLatin1());
-        QByteArray to = name.toLatin1();
-        QByteArray from = shape.toLatin1();
-        Gui::Command::copyVisual(to, "ShapeColor", from);
-        Gui::Command::copyVisual(to, "LineColor", from);
-        Gui::Command::copyVisual(to, "PointColor", from);
+        activeDoc->commitTransaction();
+        Gui::Command::updateActive();
     }
-
-    activeDoc->commitTransaction();
-    try {
-        ui->statusLabel->clear();
-        activeDoc->recompute();
-        ui->statusLabel->setText(QString::fromLatin1
-            ("<span style=\" color:#55aa00;\">%1</span>").arg(tr("Succeeded")));
+    catch (Base::AbortException){
+        throw;
     }
-    catch (const std::exception& e) {
-        ui->statusLabel->setText(QString::fromLatin1
-            ("<span style=\" color:#ff0000;\">%1</span>").arg(tr("Failed")));
-        Base::Console().Error("%s\n", e.what());
+    catch (Base::Exception &err){
+        QMessageBox::critical(this, windowTitle(),
+            tr("Creating Extrusion failed.\n\n%1").arg(QString::fromUtf8(err.what())));
+        return;
     }
-    catch (const Base::Exception& e) {
-        ui->statusLabel->setText(QString::fromLatin1
-            ("<span style=\" color:#ff0000;\">%1</span>").arg(tr("Failed")));
-        Base::Console().Error("%s\n", e.what());
-    }
-    catch (...) {
-        ui->statusLabel->setText(QString::fromLatin1
-            ("<span style=\" color:#ff0000;\">%1</span>").arg(tr("Failed")));
-        Base::Console().Error("General error in extrusion\n");
+    catch(...) {
+        QMessageBox::critical(this, windowTitle(),
+            tr("Creating Extrusion failed.\n\n%1").arg(QString::fromUtf8("Unknown error")));
+        return;
     }
 }
 
-void DlgExtrusion::on_checkNormal_toggled(bool b)
+Base::Vector3d DlgExtrusion::getDir() const
 {
-    //ui->dirX->setDisabled(b);
-    //ui->dirY->setDisabled(b);
-    //ui->dirZ->setDisabled(b);
-    ui->labelNormal->setVisible(b);
+    return Base::Vector3d(
+                ui->dirX->value(),
+                ui->dirY->value(),
+                ui->dirZ->value());
 }
+
+void DlgExtrusion::setDir(Base::Vector3d newDir)
+{
+    ui->dirX->setValue(newDir.x);
+    ui->dirY->setValue(newDir.y);
+    ui->dirZ->setValue(newDir.z);
+}
+
+Part::Extrusion::eDirMode DlgExtrusion::getDirMode() const
+{
+    if(ui->rbDirModeCustom->isChecked())
+        return Part::Extrusion::dmCustom;
+    if(ui->rbDirModeEdge->isChecked())
+        return Part::Extrusion::dmEdge;
+    if(ui->rbDirModeNormal->isChecked())
+        return Part::Extrusion::dmNormal;
+
+    //we shouldn't get here...
+    return Part::Extrusion::dmCustom;
+}
+
+void DlgExtrusion::setDirMode(Part::Extrusion::eDirMode newMode)
+{
+    ui->rbDirModeCustom->blockSignals(true);
+    ui->rbDirModeEdge->blockSignals(true);
+    ui->rbDirModeNormal->blockSignals(true);
+
+    ui->rbDirModeCustom->setChecked(newMode == Part::Extrusion::dmCustom);
+    ui->rbDirModeEdge->setChecked(newMode == Part::Extrusion::dmEdge);
+    ui->rbDirModeNormal->setChecked(newMode == Part::Extrusion::dmNormal);
+
+    ui->rbDirModeCustom->blockSignals(false);
+    ui->rbDirModeEdge->blockSignals(false);
+    ui->rbDirModeNormal->blockSignals(false);
+    this->on_DirMode_changed();
+}
+
+void DlgExtrusion::getAxisLink(App::PropertyLinkSub& lnk) const
+{
+    QString text = ui->txtLink->text();
+
+    if (text.length() == 0) {
+        lnk.setValue(nullptr);
+    } else {
+        QStringList parts = text.split(QChar::fromLatin1(':'));
+        App::DocumentObject* obj = App::GetApplication().getActiveDocument()->getObject(parts[0].toLatin1());
+        if(!obj){
+            throw Base::ValueError(tr("Object not found: %1").arg(parts[0]).toUtf8().constData());
+        }
+        lnk.setValue(obj);
+        if (parts.size() == 1) {
+            return;
+        } else if (parts.size() == 2) {
+            std::vector<std::string> subs;
+            subs.push_back(std::string(parts[1].toLatin1().constData()));
+            lnk.setValue(obj,subs);
+        }
+    }
+
+}
+
+void DlgExtrusion::setAxisLink(const App::PropertyLinkSub& lnk)
+{
+    if (!lnk.getValue()){
+        ui->txtLink->clear();
+        return;
+    }
+    if (lnk.getSubValues().size() == 1){
+        this->setAxisLink(lnk.getValue()->getNameInDocument(), lnk.getSubValues()[0].c_str());
+    } else {
+        this->setAxisLink(lnk.getValue()->getNameInDocument(), "");
+    }
+}
+
+void DlgExtrusion::setAxisLink(const char* objname, const char* subname)
+{
+    if(objname && strlen(objname) > 0){
+        QString txt = QString::fromLatin1(objname);
+        if (subname && strlen(subname) > 0){
+            txt = txt + QString::fromLatin1(":") + QString::fromLatin1(subname);
+        }
+        ui->txtLink->setText(txt);
+    } else {
+        ui->txtLink->clear();
+    }
+}
+
+std::vector<App::DocumentObject*> DlgExtrusion::getShapesToExtrude() const
+{
+    QList<QTreeWidgetItem *> items = ui->treeWidget->selectedItems();
+    App::Document* doc = App::GetApplication().getDocument(this->document.c_str());
+    if (!doc)
+        throw Base::Exception("Document lost");
+
+    std::vector<App::DocumentObject*> objects;
+    for(size_t i = 0  ;  i < items.size()  ;  i++){
+        App::DocumentObject* obj = doc->getObject(items[i]->data(0, Qt::UserRole).toString().toLatin1());
+        if (!obj)
+            throw Base::Exception("Object not found");
+        objects.push_back(obj);
+    }
+    return objects;
+}
+
+bool DlgExtrusion::validate()
+{
+    //check source shapes
+    if (ui->treeWidget->selectedItems().isEmpty()) {
+        QMessageBox::critical(this, windowTitle(),
+            tr("No shapes selected for extrusion. Select some, first."));
+        return false;
+    }
+
+    //check axis link
+    QString errmsg;
+    bool hasValidAxisLink = false;
+    try{
+        App::PropertyLinkSub lnk;
+        this->getAxisLink(lnk);
+        Base::Vector3d dir, base;
+        hasValidAxisLink = Part::Extrusion::fetchAxisLink(lnk, base, dir);
+    } catch(Base::Exception &err) {
+        errmsg = QString::fromUtf8(err.what());
+    } catch(Standard_Failure &err) {
+        errmsg = QString::fromLocal8Bit(err.GetMessageString());
+    } catch(...) {
+        errmsg = QString::fromUtf8("Unknown error");
+    }
+    if (this->getDirMode() == Part::Extrusion::dmEdge && !hasValidAxisLink){
+        if (errmsg.length() > 0)
+            QMessageBox::critical(this, windowTitle(), tr("Revolution axis link is invalid.\n\n%1").arg(errmsg));
+        else
+            QMessageBox::critical(this, windowTitle(), tr("Direction mode is to use an edge, but no edge is linked."));
+        ui->txtLink->setFocus();
+        return false;
+    } else if (this->getDirMode() != Part::Extrusion::dmEdge && !hasValidAxisLink){
+        //axis link is invalid, but it is not required by the mode. We shouldn't complain it's invalid then...
+        ui->txtLink->clear();
+    }
+
+    //check normal
+    if (this->getDirMode() == Part::Extrusion::dmNormal){
+        errmsg.clear();
+        try {
+            App::PropertyLink lnk;
+            lnk.setValue(&this->getShapeToExtrude()); //simplified - check only for the first shape.
+            Part::Extrusion::calculateShapeNormal(lnk);
+        } catch(Base::Exception &err) {
+            errmsg = QString::fromUtf8(err.what());
+        } catch(Standard_Failure &err) {
+            errmsg = QString::fromLocal8Bit(err.GetMessageString());
+        } catch(...) {
+            errmsg = QString::fromUtf8("Unknown error");
+        }
+        if (errmsg.length() > 0){
+            QMessageBox::critical(this, windowTitle(), tr("Can't determine normal vector of shape to be extruded. Please use other mode. \n\n(%1)").arg(errmsg));
+            ui->rbDirModeNormal->setFocus();
+            return false;
+        }
+    }
+
+    //check axis dir
+    if (this->getDirMode() == Part::Extrusion::dmCustom){
+        if(this->getDir().Length() < Precision::Confusion()){
+            QMessageBox::critical(this, windowTitle(),
+                tr("Extrusion direction is zero-length. It must be non-zero."));
+            ui->dirX->setFocus();
+            return false;
+        }
+    }
+
+    //check lengths
+    if (!ui->chkSymmetric->isChecked()
+            && fabs(ui->spinLenFwd->value().getValue() + ui->spinLenRev->value().getValue()) < Precision::Confusion()
+            && ! (fabs(ui->spinLenFwd->value().getValue() - ui->spinLenRev->value().getValue()) < Precision::Confusion())){
+        QMessageBox::critical(this, windowTitle(),
+            tr("Total extrusion length is zero (length1 == -length2). It must be nonzero."));
+        ui->spinLenFwd->setFocus();
+        return false;
+    }
+
+    return true;
+}
+
+void DlgExtrusion::writeParametersToFeature(App::DocumentObject &feature, App::DocumentObject* base) const
+{
+    Gui::Command::doCommand(Gui::Command::Doc,"f = App.getDocument('%s').getObject('%s')", feature.getDocument()->getName(), feature.getNameInDocument());
+
+    if (base)
+        Gui::Command::doCommand(Gui::Command::Doc,"f.Base = App.getDocument('%s').getObject('%s')", base->getDocument()->getName(), base->getNameInDocument());
+
+    Part::Extrusion::eDirMode dirMode = this->getDirMode();
+    const char* modestr = Part::Extrusion::eDirModeStrings[dirMode];
+    Gui::Command::doCommand(Gui::Command::Doc,"f.DirMode = \"%s\"", modestr);
+
+    if (dirMode == Part::Extrusion::dmCustom){
+        Base::Vector3d dir = this->getDir();
+        Gui::Command::doCommand(Gui::Command::Doc, "f.Dir = App.Vector(%.15f, %.15f, %.15f)", dir.x, dir.y, dir.z);
+    }
+
+    App::PropertyLinkSub lnk;
+    this->getAxisLink(lnk);
+    std::stringstream linkstr;
+    if(lnk.getValue() == nullptr){
+        linkstr << "None";
+    } else {
+        linkstr << "(App.getDocument(\"" << lnk.getValue()->getDocument()->getName() <<"\")." << lnk.getValue()->getNameInDocument();
+        linkstr << ", [";
+        for (const std::string &str: lnk.getSubValues()){
+            linkstr << "\"" << str << "\"";
+        }
+        linkstr << "])";
+    }
+    Gui::Command::doCommand(Gui::Command::Doc,"f.DirLink = %s", linkstr.str().c_str());
+
+    Gui::Command::doCommand(Gui::Command::Doc,"f.LengthFwd = %.15f", ui->spinLenFwd->value().getValue());
+    Gui::Command::doCommand(Gui::Command::Doc,"f.LengthRev = %.15f", ui->spinLenRev->value().getValue());
+
+    Gui::Command::doCommand(Gui::Command::Doc,"f.Solid = %s", ui->chkSolid->isChecked() ? "True" : "False");
+    Gui::Command::doCommand(Gui::Command::Doc,"f.Reversed = %s", ui->chkReversed->isChecked() ? "True" : "False");
+    Gui::Command::doCommand(Gui::Command::Doc,"f.Symmetric = %s", ui->chkSymmetric->isChecked() ? "True" : "False");
+    Gui::Command::doCommand(Gui::Command::Doc,"f.TaperAngle = %.15f", ui->spinTaperAngle->value().getValue());
+    Gui::Command::doCommand(Gui::Command::Doc,"f.TaperAngleRev = %.15f", ui->spinTaperAngleRev->value().getValue());
+}
+
 
 // ---------------------------------------
 
@@ -298,7 +727,11 @@ bool TaskExtrusion::reject()
 void TaskExtrusion::clicked(int id)
 {
     if (id == QDialogButtonBox::Apply) {
-        widget->apply();
+        try{
+            widget->apply();
+        } catch (Base::AbortException){
+
+        };
     }
 }
 

--- a/src/Mod/Part/Gui/DlgExtrusion.h
+++ b/src/Mod/Part/Gui/DlgExtrusion.h
@@ -27,12 +27,14 @@
 #include <Gui/TaskView/TaskView.h>
 #include <string>
 
+#include <Mod/Part/App/FeatureExtrusion.h>
+
 class TopoDS_Shape;
 
 namespace PartGui {
 
 class Ui_DlgExtrusion;
-class DlgExtrusion : public QDialog
+class DlgExtrusion : public QDialog, public Gui::SelectionObserver
 {
     Q_OBJECT
 
@@ -42,17 +44,55 @@ public:
     void accept();
     void apply();
 
+    Base::Vector3d getDir() const;
+    void setDir(Base::Vector3d newDir);
+
+    Part::Extrusion::eDirMode getDirMode() const;
+    void setDirMode(Part::Extrusion::eDirMode newMode);
+
+    void getAxisLink(App::PropertyLinkSub &lnk) const;
+    void setAxisLink(const App::PropertyLinkSub &lnk);
+    void setAxisLink(const char* objname, const char* subname);
+
+    std::vector<App::DocumentObject*> getShapesToExtrude() const;
+
+    bool validate();
+
+    void writeParametersToFeature(App::DocumentObject& feature, App::DocumentObject* base) const;
+
 protected:
     void findShapes();
     bool canExtrude(const TopoDS_Shape&) const;
     void changeEvent(QEvent *e);
 
 private Q_SLOTS:
-    void on_checkNormal_toggled(bool);
+    void on_rbDirModeCustom_toggled(bool on);
+    void on_rbDirModeEdge_toggled(bool on);
+    void on_rbDirModeNormal_toggled(bool on);
+    void on_btnSelectEdge_clicked();
+    void on_btnX_clicked();
+    void on_btnY_clicked();
+    void on_btnZ_clicked();
+    void on_chkSymmetric_toggled(bool on);
+    void on_txtLink_textChanged(QString);
+
+private:
+    ///updates enabling of controls
+    void on_DirMode_changed();
+    void onSelectionChanged(const Gui::SelectionChanges& msg);
+    ///returns link to any of selected source shapes. Throws if nothing is selected for extrusion.
+    App::DocumentObject& getShapeToExtrude() const;
+    ///if dirMode is not custom, it tries to compute the actual extrusion direction. Also, it does some auto-magic manipulation of length value.
+    void fetchDir();
+
+    ///automatically checks Solid checkbox depending on input shape
+    void autoSolid();
 
 private:
     Ui_DlgExtrusion* ui;
     std::string document, label;
+    class EdgeSelection;
+    EdgeSelection* filter;
 };
 
 class TaskExtrusion : public Gui::TaskView::TaskDialog

--- a/src/Mod/Part/Gui/DlgExtrusion.ui
+++ b/src/Mod/Part/Gui/DlgExtrusion.ui
@@ -6,15 +6,15 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>260</width>
-    <height>545</height>
+    <width>343</width>
+    <height>798</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Extrude</string>
   </property>
-  <layout class="QGridLayout" name="gridLayout_3">
-   <item row="0" column="0">
+  <layout class="QVBoxLayout" name="verticalLayout_2">
+   <item>
     <widget class="QGroupBox" name="groupBox_2">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
@@ -26,52 +26,70 @@
       <string>Direction</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_2">
-      <item row="1" column="0">
-       <widget class="QCheckBox" name="checkNormal">
+      <item row="4" column="2">
+       <widget class="QCheckBox" name="chkReversed">
+        <property name="toolTip">
+         <string>If checked, direction of extrusion is reversed.</string>
+        </property>
+        <property name="text">
+         <string>Reversed</string>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="0">
+       <widget class="QRadioButton" name="rbDirModeCustom">
+        <property name="toolTip">
+         <string>Specify direction manually using X,Y,Z values.</string>
+        </property>
+        <property name="text">
+         <string>Custom direction:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QRadioButton" name="rbDirModeNormal">
+        <property name="toolTip">
+         <string>Extrude perpendicularly to plane of input shape.</string>
+        </property>
         <property name="text">
          <string>Along normal</string>
         </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
        </widget>
       </item>
-      <item row="1" column="1">
-       <widget class="QPushButton" name="viewButton">
+      <item row="5" column="2">
+       <widget class="QPushButton" name="btnSelectEdge">
+        <property name="toolTip">
+         <string>Click to start selecting an edge in 3d view.</string>
+        </property>
         <property name="text">
-         <string>3D view</string>
+         <string>Select</string>
         </property>
        </widget>
       </item>
-      <item row="1" column="2">
-       <spacer name="horizontalSpacer">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>43</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
+      <item row="5" column="0">
+       <widget class="QLineEdit" name="txtLink"/>
       </item>
-      <item row="2" column="0" colspan="3">
-       <widget class="QLabel" name="labelNormal">
+      <item row="4" column="0">
+       <widget class="QRadioButton" name="rbDirModeEdge">
+        <property name="toolTip">
+         <string>Set direction to match a direction of straight edge. Hint: to account for length of the edge too, set both lengths to zero.</string>
+        </property>
         <property name="text">
-         <string>Note:This option works for planes only</string>
+         <string>Along edge:</string>
         </property>
        </widget>
       </item>
-      <item row="0" column="0" colspan="3">
-       <layout class="QGridLayout" name="gridLayout">
-        <item row="0" column="0">
-         <widget class="QLabel" name="label_2">
-          <property name="text">
-           <string>X:</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-          </property>
-         </widget>
-        </item>
+      <item row="7" column="0" colspan="3">
+       <layout class="QFormLayout" name="formLayout">
+        <property name="labelAlignment">
+         <set>Qt::AlignCenter</set>
+        </property>
+        <property name="formAlignment">
+         <set>Qt::AlignCenter</set>
+        </property>
         <item row="0" column="1">
          <widget class="QDoubleSpinBox" name="dirX">
           <property name="sizePolicy">
@@ -81,20 +99,10 @@
            </sizepolicy>
           </property>
           <property name="minimum">
-           <double>-100.000000000000000</double>
+           <double>-2147480000.000000000000000</double>
           </property>
           <property name="maximum">
-           <double>100.000000000000000</double>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="label_3">
-          <property name="text">
-           <string>Y:</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           <double>2147480000.000000000000000</double>
           </property>
          </widget>
         </item>
@@ -107,20 +115,10 @@
            </sizepolicy>
           </property>
           <property name="minimum">
-           <double>-100.000000000000000</double>
+           <double>-2147480000.000000000000000</double>
           </property>
           <property name="maximum">
-           <double>100.000000000000000</double>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="0">
-         <widget class="QLabel" name="label_4">
-          <property name="text">
-           <string>Z:</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           <double>2147480000.000000000000000</double>
           </property>
          </widget>
         </item>
@@ -132,40 +130,11 @@
             <verstretch>0</verstretch>
            </sizepolicy>
           </property>
-          <property name="minimum">
-           <double>-100.000000000000000</double>
-          </property>
-          <property name="maximum">
-           <double>100.000000000000000</double>
-          </property>
-          <property name="value">
-           <double>1.000000000000000</double>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="0">
-         <widget class="QLabel" name="label_5">
-          <property name="text">
-           <string>Length:</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="1">
-         <widget class="Gui::QuantitySpinBox" name="dirLen">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="unit" stdset="0">
-           <string notr="true">mm</string>
+          <property name="keyboardTracking">
+           <bool>false</bool>
           </property>
           <property name="minimum">
-           <double>0.001000000000000</double>
+           <double>-2147480000.000000000000000</double>
           </property>
           <property name="maximum">
            <double>2147480000.000000000000000</double>
@@ -175,46 +144,207 @@
           </property>
          </widget>
         </item>
+        <item row="0" column="0">
+         <widget class="QPushButton" name="btnX">
+          <property name="toolTip">
+           <string/>
+          </property>
+          <property name="text">
+           <string>X:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="0">
+         <widget class="QPushButton" name="btnY">
+          <property name="text">
+           <string>Y:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="0">
+         <widget class="QPushButton" name="btnZ">
+          <property name="text">
+           <string>Z:</string>
+          </property>
+         </widget>
+        </item>
        </layout>
       </item>
      </layout>
     </widget>
    </item>
-   <item row="1" column="0">
-    <widget class="QCheckBox" name="makeSolid">
-     <property name="text">
-      <string>Create solid</string>
+   <item>
+    <widget class="QGroupBox" name="groupBox">
+     <property name="title">
+      <string>Length</string>
      </property>
+     <layout class="QVBoxLayout" name="verticalLayout">
+      <item>
+       <layout class="QFormLayout" name="formLayout_2">
+        <item row="0" column="0">
+         <widget class="QLabel" name="label_5">
+          <property name="text">
+           <string>Along</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="0">
+         <widget class="QLabel" name="label_6">
+          <property name="text">
+           <string>Against</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1">
+         <widget class="Gui::QuantitySpinBox" name="spinLenFwd" native="true">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="toolTip">
+           <string>Length to extrude along direction (can be negative). If both lengths are zero, magnitude of direction is used.</string>
+          </property>
+          <property name="unit" stdset="0">
+           <string notr="true">mm</string>
+          </property>
+          <property name="minimum" stdset="0">
+           <double>-2147480000.000000000000000</double>
+          </property>
+          <property name="maximum" stdset="0">
+           <double>2147480000.000000000000000</double>
+          </property>
+          <property name="value" stdset="0">
+           <double>10.000000000000000</double>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="1">
+         <widget class="Gui::QuantitySpinBox" name="spinLenRev" native="true">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="toolTip">
+           <string>Length to extrude against direction (can be negative).</string>
+          </property>
+          <property name="unit" stdset="0">
+           <string notr="true">mm</string>
+          </property>
+          <property name="minimum" stdset="0">
+           <double>-2147480000.000000000000000</double>
+          </property>
+          <property name="maximum" stdset="0">
+           <double>2147480000.000000000000000</double>
+          </property>
+          <property name="value" stdset="0">
+           <double>0.000000000000000</double>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="chkSymmetric">
+        <property name="toolTip">
+         <string>Distribute extrusion length equally to both sides.</string>
+        </property>
+        <property name="text">
+         <string>Symmetric</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
     </widget>
    </item>
-   <item row="2" column="0">
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <item>
+   <item>
+    <layout class="QFormLayout" name="formLayout_3">
+     <item row="0" column="0">
       <widget class="QLabel" name="label">
        <property name="text">
         <string>Taper outward angle</string>
        </property>
       </widget>
      </item>
-     <item>
-      <widget class="Gui::QuantitySpinBox" name="taperAngle">
+     <item row="0" column="1">
+      <widget class="Gui::QuantitySpinBox" name="spinTaperAngle" native="true">
+       <property name="toolTip">
+        <string>Apply slope (draft) to extrusion side faces.</string>
+       </property>
        <property name="unit" stdset="0">
         <string notr="true">deg</string>
        </property>
-       <property name="minimum">
-        <double>-180.000000000000000</double>
+       <property name="minimum" stdset="0">
+        <double>-89.999999000000003</double>
        </property>
-       <property name="maximum">
-        <double>180.000000000000000</double>
+       <property name="maximum" stdset="0">
+        <double>89.999999000000003</double>
        </property>
-       <property name="singleStep">
+       <property name="singleStep" stdset="0">
+        <double>5.000000000000000</double>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="Gui::QuantitySpinBox" name="spinTaperAngleRev" native="true">
+       <property name="toolTip">
+        <string>Apply slope (draft) to extrusion side faces.</string>
+       </property>
+       <property name="unit" stdset="0">
+        <string notr="true">deg</string>
+       </property>
+       <property name="minimum" stdset="0">
+        <double>-89.999999000000003</double>
+       </property>
+       <property name="maximum" stdset="0">
+        <double>89.999999000000003</double>
+       </property>
+       <property name="singleStep" stdset="0">
         <double>5.000000000000000</double>
        </property>
       </widget>
      </item>
     </layout>
    </item>
-   <item row="3" column="0">
+   <item>
+    <widget class="QCheckBox" name="chkSolid">
+     <property name="toolTip">
+      <string>If checked, extruding closed wires will give solids, not shells.</string>
+     </property>
+     <property name="text">
+      <string>Create solid</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="Line" name="line">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item>
     <widget class="QTreeWidget" name="treeWidget">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
@@ -238,7 +368,7 @@
      </column>
     </widget>
    </item>
-   <item row="4" column="0">
+   <item>
     <widget class="QLabel" name="statusLabel">
      <property name="text">
       <string notr="true">StatusLabel</string>
@@ -246,6 +376,12 @@
     </widget>
    </item>
   </layout>
+  <zorder>groupBox_2</zorder>
+  <zorder>chkSolid</zorder>
+  <zorder>treeWidget</zorder>
+  <zorder>statusLabel</zorder>
+  <zorder>groupBox</zorder>
+  <zorder>line</zorder>
  </widget>
  <customwidgets>
   <customwidget>
@@ -255,12 +391,25 @@
   </customwidget>
  </customwidgets>
  <tabstops>
-  <tabstop>treeWidget</tabstop>
+  <tabstop>rbDirModeNormal</tabstop>
+  <tabstop>rbDirModeEdge</tabstop>
+  <tabstop>chkReversed</tabstop>
+  <tabstop>txtLink</tabstop>
+  <tabstop>btnSelectEdge</tabstop>
+  <tabstop>rbDirModeCustom</tabstop>
+  <tabstop>btnX</tabstop>
   <tabstop>dirX</tabstop>
+  <tabstop>btnY</tabstop>
   <tabstop>dirY</tabstop>
+  <tabstop>btnZ</tabstop>
   <tabstop>dirZ</tabstop>
-  <tabstop>dirLen</tabstop>
-  <tabstop>checkNormal</tabstop>
+  <tabstop>spinLenFwd</tabstop>
+  <tabstop>spinLenRev</tabstop>
+  <tabstop>chkSymmetric</tabstop>
+  <tabstop>spinTaperAngle</tabstop>
+  <tabstop>spinTaperAngleRev</tabstop>
+  <tabstop>chkSolid</tabstop>
+  <tabstop>treeWidget</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/src/Mod/Part/Gui/DlgRevolution.h
+++ b/src/Mod/Part/Gui/DlgRevolution.h
@@ -50,6 +50,8 @@ public:
     void setAxisLink(const App::PropertyLinkSub &lnk);
     void setAxisLink(const char* objname, const char* subname);
 
+    std::vector<App::DocumentObject*> getShapesToRevolve() const;
+
     bool validate();
 
 protected:
@@ -65,6 +67,12 @@ private Q_SLOTS:
 private:
     void findShapes();
     void onSelectionChanged(const Gui::SelectionChanges& msg);
+
+    ///returns link to any of selected source shapes. Throws if nothing is selected for extrusion.
+    App::DocumentObject& getShapeToRevolve() const;
+
+    ///automatically checks Solid checkbox depending on input shape
+    void autoSolid();
 
 private:
     //typedef Gui::LocationInterfaceComp<Ui_DlgRevolution> Ui_RevolutionComp;


### PR DESCRIPTION
1. separated Dir into Dir + Length. Added second Length, acting similarly to PartDesign Pad's two lengths mode.
If Length is zero, the magnitude of Dir is to be used (for legacy). If Length is non-zero, only the direction of Dir is to be taken, but the magnitude is to be overridden by length. This should prove nice regarding expression support, as Length will have a unit.

2. added ability to use edge as direction and optionally magnitude, like Part Revolve now accepts edges for axis. Along normal was made parametric, and works on wires too.

3. Add 'Symmetric', and 'Reversed' options like PartDesign Pad has

4. Added second taper angle for second length

5. Redesigned task dialog to account for all this stuff.
![new_extrude_dialog_pr](https://cloud.githubusercontent.com/assets/8940427/17981038/fb5eb38c-6b12-11e6-8dfe-7aa630a87ac3.png)

Forum threads:
[Plans to improve Part Extrude](http://forum.freecadweb.org/viewtopic.php?f=8&t=17114)
[Pull-request forum thread](http://forum.freecadweb.org/viewtopic.php?f=17&t=17168)