### PR TITLE
Part 2D offset

### DIFF
--- a/src/Mod/Part/App/AppPart.cpp
+++ b/src/Mod/Part/App/AppPart.cpp
@@ -49,6 +49,7 @@
 #include "FeatureFillet.h"
 #include "FeatureMirroring.h"
 #include "FeatureRevolution.h"
+#include "FeatureOffset.h"
 #include "PartFeatures.h"
 #include "BodyBase.h"
 #include "PrimitiveFeature.h"

--- a/src/Mod/Part/App/AppPart.cpp
+++ b/src/Mod/Part/App/AppPart.cpp
@@ -301,6 +301,7 @@ PyMODINIT_FUNC initPart()
     Part::Loft                  ::init();
     Part::Sweep                 ::init();
     Part::Offset                ::init();
+    Part::Offset2D              ::init();
     Part::Thickness             ::init();
 
     // Geometry types

--- a/src/Mod/Part/App/CMakeLists.txt
+++ b/src/Mod/Part/App/CMakeLists.txt
@@ -124,6 +124,8 @@ SET(Features_SRCS
     FeatureMirroring.h
     FeatureRevolution.cpp
     FeatureRevolution.h
+    FeatureOffset.cpp
+    FeatureOffset.h
     PartFeatures.cpp
     PartFeatures.h
     PartFeature.cpp

--- a/src/Mod/Part/App/FeatureOffset.cpp
+++ b/src/Mod/Part/App/FeatureOffset.cpp
@@ -93,3 +93,52 @@ App::DocumentObjectExecReturn *Offset::execute(void)
 }
 
 
+//-------------------------------------------------------------------------------------------------------
+
+
+PROPERTY_SOURCE(Part::Offset2D, Part::Offset)
+
+Offset2D::Offset2D()
+{
+    this->SelfIntersection.setStatus(App::Property::Status::Hidden, true);
+    this->Mode.setValue(1); //switch to Pipe mode by default, because skin mode does not function properly on closed profiles.
+}
+
+Offset2D::~Offset2D()
+{
+
+}
+
+short Offset2D::mustExecute() const
+{
+    if (Source.isTouched())
+        return 1;
+    if (Value.isTouched())
+        return 1;
+    if (Mode.isTouched())
+        return 1;
+    if (Join.isTouched())
+        return 1;
+    if (Fill.isTouched())
+        return 1;
+    if (Intersection.isTouched())
+        return 1;
+    return 0;
+}
+
+App::DocumentObjectExecReturn *Offset2D::execute(void)
+{
+    App::DocumentObject* source = Source.getValue();
+    if (!(source && source->getTypeId().isDerivedFrom(Part::Feature::getClassTypeId())))
+        return new App::DocumentObjectExecReturn("No source shape linked.");
+    double offset = Value.getValue();
+    short mode = (short)Mode.getValue();
+    short join = (short)Join.getValue();
+    bool fill = Fill.getValue();
+    bool inter = Intersection.getValue();
+    if (mode == 2)
+        return new App::DocumentObjectExecReturn("Mode 'Recto-Verso' is not supported for 2D offset.");
+    const TopoShape& shape = static_cast<Part::Feature*>(source)->Shape.getShape();
+    this->Shape.setValue(shape.makeOffset2D(offset, join, fill, mode == 0, inter));
+    return App::DocumentObject::StdReturn;
+}

--- a/src/Mod/Part/App/FeatureOffset.cpp
+++ b/src/Mod/Part/App/FeatureOffset.cpp
@@ -1,0 +1,95 @@
+/***************************************************************************
+ *   Copyright (c) 2016 Victor Titov (DeepSOIC)      <vv.titov@gmail.com>  *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+#include "PreCompiled.h"
+#ifndef _PreComp_
+# include <Precision.hxx>
+#endif
+
+
+#include "FeatureOffset.h"
+
+
+using namespace Part;
+
+const char* Part::Offset::ModeEnums[]= {"Skin","Pipe", "RectoVerso",NULL};
+const char* Part::Offset::JoinEnums[]= {"Arc","Tangent", "Intersection",NULL};
+
+PROPERTY_SOURCE(Part::Offset, Part::Feature)
+
+Offset::Offset()
+{
+    ADD_PROPERTY_TYPE(Source,(0),"Offset",App::Prop_None,"Source shape");
+    ADD_PROPERTY_TYPE(Value,(1.0),"Offset",App::Prop_None,"Offset value");
+    ADD_PROPERTY_TYPE(Mode,(long(0)),"Offset",App::Prop_None,"Mode");
+    Mode.setEnums(ModeEnums);
+    ADD_PROPERTY_TYPE(Join,(long(0)),"Offset",App::Prop_None,"Join type");
+    Join.setEnums(JoinEnums);
+    ADD_PROPERTY_TYPE(Intersection,(false),"Offset",App::Prop_None,"Intersection");
+    ADD_PROPERTY_TYPE(SelfIntersection,(false),"Offset",App::Prop_None,"Self Intersection");
+    ADD_PROPERTY_TYPE(Fill,(false),"Offset",App::Prop_None,"Fill offset");
+}
+
+Offset::~Offset()
+{
+
+}
+
+short Offset::mustExecute() const
+{
+    if (Source.isTouched())
+        return 1;
+    if (Value.isTouched())
+        return 1;
+    if (Mode.isTouched())
+        return 1;
+    if (Join.isTouched())
+        return 1;
+    if (Intersection.isTouched())
+        return 1;
+    if (SelfIntersection.isTouched())
+        return 1;
+    if (Fill.isTouched())
+        return 1;
+    return 0;
+}
+
+App::DocumentObjectExecReturn *Offset::execute(void)
+{
+    App::DocumentObject* source = Source.getValue();
+    if (!(source && source->getTypeId().isDerivedFrom(Part::Feature::getClassTypeId())))
+        return new App::DocumentObjectExecReturn("No source shape linked.");
+    double offset = Value.getValue();
+    double tol = Precision::Confusion();
+    bool inter = Intersection.getValue();
+    bool self = SelfIntersection.getValue();
+    short mode = (short)Mode.getValue();
+    short join = (short)Join.getValue();
+    bool fill = Fill.getValue();
+    const TopoShape& shape = static_cast<Part::Feature*>(source)->Shape.getShape();
+    if (fabs(offset) > 2*tol)
+        this->Shape.setValue(shape.makeOffsetShape(offset, tol, inter, self, mode, join, fill));
+    else
+        this->Shape.setValue(shape);
+    return App::DocumentObject::StdReturn;
+}
+
+

--- a/src/Mod/Part/App/FeatureOffset.h
+++ b/src/Mod/Part/App/FeatureOffset.h
@@ -61,5 +61,23 @@ private:
     static const char* JoinEnums[];
 };
 
+class PartExport Offset2D : public Offset
+{
+    PROPERTY_HEADER(Part::Offset2D);
+public:
+    Offset2D();
+    ~Offset2D();
+
+    /** @name methods override feature */
+    //@{
+    /// recalculate the feature
+    virtual App::DocumentObjectExecReturn *execute(void) override;
+    virtual short mustExecute() const override;
+    virtual const char* getViewProviderName(void) const override {
+        return "PartGui::ViewProviderOffset2D";
+    }
+    //@}
+};
+
 }
 #endif // PART_FEATUREOFFSET_H

--- a/src/Mod/Part/App/FeatureOffset.h
+++ b/src/Mod/Part/App/FeatureOffset.h
@@ -1,0 +1,65 @@
+/***************************************************************************
+ *   Copyright (c) 2016 Victor Titov (DeepSOIC)      <vv.titov@gmail.com>  *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef PART_FEATUREOFFSET_H
+#define PART_FEATUREOFFSET_H
+
+#include <App/PropertyStandard.h>
+#include <App/PropertyUnits.h>
+#include <Mod/Part/App/PartFeature.h>
+
+namespace Part
+{
+
+class PartExport Offset : public Part::Feature
+{
+    PROPERTY_HEADER(Part::Offset);
+
+public:
+    Offset();
+    ~Offset();
+
+    App::PropertyLink  Source;
+    App::PropertyFloat Value;
+    App::PropertyEnumeration Mode;
+    App::PropertyEnumeration Join;
+    App::PropertyBool Intersection;
+    App::PropertyBool SelfIntersection;
+    App::PropertyBool Fill;
+
+    /** @name methods override feature */
+    //@{
+    /// recalculate the feature
+    virtual App::DocumentObjectExecReturn *execute(void) override;
+    virtual short mustExecute() const override;
+    virtual const char* getViewProviderName(void) const override {
+        return "PartGui::ViewProviderOffset";
+    }
+    //@}
+
+private:
+    static const char* ModeEnums[];
+    static const char* JoinEnums[];
+};
+
+}
+#endif // PART_FEATUREOFFSET_H

--- a/src/Mod/Part/App/PartFeatures.cpp
+++ b/src/Mod/Part/App/PartFeatures.cpp
@@ -476,69 +476,6 @@ App::DocumentObjectExecReturn *Sweep::execute(void)
 
 // ----------------------------------------------------------------------------
 
-const char* Part::Offset::ModeEnums[]= {"Skin","Pipe", "RectoVerso",NULL};
-const char* Part::Offset::JoinEnums[]= {"Arc","Tangent", "Intersection",NULL};
-
-PROPERTY_SOURCE(Part::Offset, Part::Feature)
-
-Offset::Offset()
-{
-    ADD_PROPERTY_TYPE(Source,(0),"Offset",App::Prop_None,"Source shape");
-    ADD_PROPERTY_TYPE(Value,(1.0),"Offset",App::Prop_None,"Offset value");
-    ADD_PROPERTY_TYPE(Mode,(long(0)),"Offset",App::Prop_None,"Mode");
-    Mode.setEnums(ModeEnums);
-    ADD_PROPERTY_TYPE(Join,(long(0)),"Offset",App::Prop_None,"Join type");
-    Join.setEnums(JoinEnums);
-    ADD_PROPERTY_TYPE(Intersection,(false),"Offset",App::Prop_None,"Intersection");
-    ADD_PROPERTY_TYPE(SelfIntersection,(false),"Offset",App::Prop_None,"Self Intersection");
-    ADD_PROPERTY_TYPE(Fill,(false),"Offset",App::Prop_None,"Fill offset");
-}
-
-Offset::~Offset()
-{
-}
-
-short Offset::mustExecute() const
-{
-    if (Source.isTouched())
-        return 1;
-    if (Value.isTouched())
-        return 1;
-    if (Mode.isTouched())
-        return 1;
-    if (Join.isTouched())
-        return 1;
-    if (Intersection.isTouched())
-        return 1;
-    if (SelfIntersection.isTouched())
-        return 1;
-    if (Fill.isTouched())
-        return 1;
-    return 0;
-}
-
-App::DocumentObjectExecReturn *Offset::execute(void)
-{
-    App::DocumentObject* source = Source.getValue();
-    if (!(source && source->getTypeId().isDerivedFrom(Part::Feature::getClassTypeId())))
-        return new App::DocumentObjectExecReturn("No source shape linked.");
-    double offset = Value.getValue();
-    double tol = Precision::Confusion();
-    bool inter = Intersection.getValue();
-    bool self = SelfIntersection.getValue();
-    short mode = (short)Mode.getValue();
-    short join = (short)Join.getValue();
-    bool fill = Fill.getValue();
-    const TopoShape& shape = static_cast<Part::Feature*>(source)->Shape.getShape();
-    if (fabs(offset) > 2*tol)
-        this->Shape.setValue(shape.makeOffsetShape(offset, tol, inter, self, mode, join, fill));
-    else
-        this->Shape.setValue(shape);
-    return App::DocumentObject::StdReturn;
-}
-
-// ----------------------------------------------------------------------------
-
 const char* Part::Thickness::ModeEnums[]= {"Skin","Pipe", "RectoVerso",NULL};
 const char* Part::Thickness::JoinEnums[]= {"Arc","Tangent", "Intersection",NULL};
 

--- a/src/Mod/Part/App/PartFeatures.h
+++ b/src/Mod/Part/App/PartFeatures.h
@@ -115,37 +115,6 @@ private:
     static const char* TransitionEnums[];
 };
 
-class Offset : public Part::Feature
-{
-    PROPERTY_HEADER(Part::Offset);
-
-public:
-    Offset();
-    ~Offset();
-
-    App::PropertyLink  Source;
-    App::PropertyFloat Value;
-    App::PropertyEnumeration Mode;
-    App::PropertyEnumeration Join;
-    App::PropertyBool Intersection;
-    App::PropertyBool SelfIntersection;
-    App::PropertyBool Fill;
-
-    /** @name methods override feature */
-    //@{
-    /// recalculate the feature
-    App::DocumentObjectExecReturn *execute(void);
-    short mustExecute() const;
-    const char* getViewProviderName(void) const {
-        return "PartGui::ViewProviderOffset";
-    }
-    //@}
-
-private:
-    static const char* ModeEnums[];
-    static const char* JoinEnums[];
-};
-
 class Thickness : public Part::Feature
 {
     PROPERTY_HEADER(Part::Thickness);

--- a/src/Mod/Part/App/TopoShape.h
+++ b/src/Mod/Part/App/TopoShape.h
@@ -207,6 +207,8 @@ public:
     TopoDS_Shape makeOffsetShape(double offset, double tol,
         bool intersection = false, bool selfInter = false,
         short offsetMode = 0, short join = 0, bool fill = false) const;
+    TopoDS_Shape makeOffset2D(double offset, short joinType = 0,
+        bool fill = false, bool allowOpenResult = false, bool intersection = false) const;
     TopoDS_Shape makeThickSolid(const TopTools_ListOfShape& remFace,
         double offset, double tol,
         bool intersection = false, bool selfInter = false,

--- a/src/Mod/Part/App/TopoShapePy.xml
+++ b/src/Mod/Part/App/TopoShapePy.xml
@@ -305,7 +305,56 @@ the hollowed solid, their thickness defined at the time of construction.</UserDo
     </Methode>
     <Methode Name="makeOffsetShape" Const="true"  Keyword="true">
       <Documentation> 
-        <UserDocu>Offset a given shape</UserDocu>
+        <UserDocu>makeOffsetShape(offset, tolerance, inter = False, self_inter = False,
+offsetMode = 0, join = 0, fill = False): makes an offset shape (3d offsetting).
+The function supports keyword arguments.
+
+* offset: distance to expand the shape by. Negative value will shrink the
+shape.
+
+* tolerance: precision of approximation.
+
+* inter: (parameter to OCC routine; not implemented)
+
+* self_inter: (parameter to OCC routine; not implemented)
+
+* offsetMode: 0 = skin; 1 = pipe; 2 = recto-verso
+
+* join: method of offsetting non-tangent joints. 0 = arcs, 1 = tangent, 2 =
+intersection
+
+* fill: if true, offsetting a shell is to yeild a solid
+
+Returns: result of offsetting.</UserDocu>
+      </Documentation>
+    </Methode>
+    <Methode Name="makeOffset2D" Const="true"  Keyword="true">
+      <Documentation>
+      <UserDocu>makeOffset2D(offset, join = 0, fill = False, openResult = false, intersection =
+false): makes an offset shape (2d offsetting). The function supports keyword
+arguments. Input shape (self) can be edge, wire, face, or a compound of those.
+
+* offset: distance to expand the shape by. Negative value will shrink the
+shape.
+
+* join: method of offsetting non-tangent joints. 0 = arcs, 1 = tangent, 2 =
+intersection
+
+* fill: if true, the output is a face filling the space covered by offset. If
+false, the output is a wire.
+
+* openResult: affects the way open wires are processed. If False, an open wire
+is made. If True, a closed wire is made from a double-sided offset, with rounds
+around open vertices.
+
+* intersection: affects the way compounds are processed. If False, all children
+are offset independently. If True, and children are edges/wires, the children
+are offset in a collective manner. If compounding is nested, collectiveness
+does not spread across compounds (only direct children of a compound are taken
+collectively).
+
+Returns: result of offsetting (wire or face or compound of those). Compounding
+structure follows that of source shape.</UserDocu>
       </Documentation>
     </Methode>
     <Methode Name="reverse">

--- a/src/Mod/Part/App/TopoShapePyImp.cpp
+++ b/src/Mod/Part/App/TopoShapePyImp.cpp
@@ -1453,6 +1453,32 @@ PyObject* TopoShapePy::makeOffsetShape(PyObject *args, PyObject *keywds)
     }
 }
 
+PyObject* TopoShapePy::makeOffset2D(PyObject *args, PyObject *keywds)
+{
+    static char *kwlist[] = {"offset", "join", "fill", "openResult", "intersection", NULL};
+    double offset;
+    PyObject* fill = Py_False;
+    PyObject* openResult = Py_False;
+    PyObject* inter = Py_False;
+    short join = 0;
+    if (!PyArg_ParseTupleAndKeywords(args, keywds, "d|hO!O!O!", kwlist,
+        &offset,
+        &join,
+        &(PyBool_Type), &fill,
+        &(PyBool_Type), &openResult,
+        &(PyBool_Type), &inter))
+        return 0;
+
+    try {
+        TopoDS_Shape resultShape = this->getTopoShapePtr()->makeOffset2D(offset, join,
+            PyObject_IsTrue(fill) ? true : false,
+            PyObject_IsTrue(openResult) ? true : false,
+            PyObject_IsTrue(inter) ? true : false);
+        return new_reference_to(shape2pyshape(resultShape));
+    }
+    PY_CATCH_OCC;
+}
+
 PyObject*  TopoShapePy::reverse(PyObject *args)
 {
     if (!PyArg_ParseTuple(args, ""))

--- a/src/Mod/Part/App/TopoShapeWirePy.xml
+++ b/src/Mod/Part/App/TopoShapeWirePy.xml
@@ -16,7 +16,7 @@
     </Documentation>
 	  <Methode Name="makeOffset" Const="true">
 		  <Documentation>
-			  <UserDocu>Offset the shape by a given ammount</UserDocu>
+              <UserDocu>Offset the shape by a given amount. DEPRECATED - use makeOffset2D instead.</UserDocu>
 		  </Documentation>
 	  </Methode>
 		<Methode Name="add">

--- a/src/Mod/Part/Gui/AppPartGui.cpp
+++ b/src/Mod/Part/Gui/AppPartGui.cpp
@@ -150,6 +150,7 @@ PyMODINIT_FUNC initPartGui()
     PartGui::ViewProviderLoft               ::init();
     PartGui::ViewProviderSweep              ::init();
     PartGui::ViewProviderOffset             ::init();
+    PartGui::ViewProviderOffset2D           ::init();
     PartGui::ViewProviderThickness          ::init();
     PartGui::ViewProviderCustom             ::init();
     PartGui::ViewProviderCustomPython       ::init();

--- a/src/Mod/Part/Gui/Resources/Part.qrc
+++ b/src/Mod/Part/Gui/Resources/Part.qrc
@@ -23,6 +23,7 @@
         <file>icons/Part_Mirror.svg</file>
         <file>icons/Part_MirrorPNG.png</file>
         <file>icons/Part_Offset.svg</file>
+        <file>icons/Part_Offset2D.svg</file>
         <file>icons/Part_Revolve.svg</file>
         <file>icons/Part_RuledSurface.svg</file>
         <file>icons/Part_Section.svg</file>

--- a/src/Mod/Part/Gui/Resources/icons/Part_Offset2D.svg
+++ b/src/Mod/Part/Gui/Resources/icons/Part_Offset2D.svg
@@ -1,0 +1,135 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="64px"
+   height="64px"
+   id="svg3136"
+   sodipodi:version="0.32"
+   inkscape:version="0.48.2 r9819"
+   sodipodi:docname="Draft_Offset.not.svg.zip"
+   inkscape:output_extension="org.inkscape.output.svg.inkscape"
+   version="1.1">
+  <defs
+     id="defs3138">
+    <linearGradient
+       id="linearGradient3841">
+      <stop
+         style="stop-color:#0619c0;stop-opacity:1;"
+         offset="0"
+         id="stop3843" />
+      <stop
+         style="stop-color:#379cfb;stop-opacity:1;"
+         offset="1"
+         id="stop3845" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3841"
+       id="linearGradient4235"
+       x1="8"
+       y1="31.75"
+       x2="52"
+       y2="31.75"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3841"
+       id="linearGradient4243"
+       x1="19.25"
+       y1="31.75"
+       x2="37"
+       y2="31.75"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3841"
+       id="linearGradient4246"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.1390891,0,0,0.1390891,-116.65366,-325.33528)"
+       x1="844.9165"
+       y1="2560.25"
+       x2="1270.7085"
+       y2="2560.25" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="2.8284271"
+     inkscape:cx="27.631036"
+     inkscape:cy="28.001052"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     inkscape:document-units="px"
+     inkscape:grid-bbox="true"
+     inkscape:window-width="1280"
+     inkscape:window-height="941"
+     inkscape:window-x="0"
+     inkscape:window-y="30"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:window-maximized="1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4167" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata3141">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer">
+    <path
+       id="path4210"
+       style="opacity:0.6;fill:none;stroke:#000000;stroke-width:7;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       d="m 31,43 c 4.14214,0 7.5,-3.357865 7.5,-7.5 l 0,-10 -12.5,0 -6.25,6.25 M 8.5,20.500001 18.5,10.5 l 35,0 0,25 C 53.5,47.926406 43.426408,58 31,58"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="csccccccsc" />
+    <path
+       id="path4173"
+       style="color:#000000;fill:none;stroke:#000000;stroke-width:7;stroke-linecap:butt;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       d="m 7,18.000001 10,-10.0000012 35,0 L 52,33 C 52,45.426406 41.926408,55.5 29.5,55.5"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       id="path4198"
+       style="fill:none;stroke:#000000;stroke-width:7;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       d="m 29.5,40.5 c 4.14214,0 7.5,-3.357865 7.5,-7.5 l 0,-10 -12.5,0 -6.25,6.25"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
+       d="m 29.5,40.5 c 4.14214,0 7.5,-3.357865 7.5,-7.5 l 0,-10 -12.5,0 -6.25,6.25"
+       style="fill:none;stroke:url(#linearGradient4243);stroke-width:4;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+       id="path4217" />
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
+       d="m 7,18.000001 10,-10.0000012 35,0 L 52,33 C 52,45.426406 41.926408,55.5 29.5,55.5"
+       style="color:#000000;fill:none;stroke:url(#linearGradient4235);stroke-width:4;stroke-linecap:square;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="path4219" />
+  </g>
+</svg>

--- a/src/Mod/Part/Gui/TaskOffset.cpp
+++ b/src/Mod/Part/Gui/TaskOffset.cpp
@@ -45,7 +45,7 @@
 #include <App/Application.h>
 #include <App/Document.h>
 #include <App/DocumentObject.h>
-#include <Mod/Part/App/PartFeatures.h>
+#include <Mod/Part/App/FeatureOffset.h>
 
 
 using namespace PartGui;

--- a/src/Mod/Part/Gui/TaskOffset.cpp
+++ b/src/Mod/Part/Gui/TaskOffset.cpp
@@ -76,8 +76,44 @@ OffsetWidget::OffsetWidget(Part::Offset* offset, QWidget* parent)
     d->ui.spinOffset->setUnit(Base::Unit::Length);
     d->ui.spinOffset->setRange(-INT_MAX, INT_MAX);
     d->ui.spinOffset->setSingleStep(0.1);
-    d->ui.spinOffset->setValue(d->offset->Value.getValue());
     d->ui.facesButton->hide();
+
+    bool is_2d = d->offset->isDerivedFrom(Part::Offset2D::getClassTypeId());
+    d->ui.selfIntersection->setVisible(!is_2d);
+    if(is_2d)
+        d->ui.modeType->removeItem(2);//remove Recto-Verso mode, not supported by 2d offset
+
+    //block signals to fill values read out from feature...
+    bool block = true;
+    d->ui.fillOffset->blockSignals(block);
+    d->ui.intersection->blockSignals(block);
+    d->ui.selfIntersection->blockSignals(block);
+    d->ui.modeType->blockSignals(block);
+    d->ui.joinType->blockSignals(block);
+    d->ui.spinOffset->blockSignals(block);
+
+    //read values from feature
+    d->ui.spinOffset->setValue(d->offset->Value.getValue());
+    d->ui.fillOffset->setChecked(offset->Fill.getValue());
+    d->ui.intersection->setChecked(offset->Intersection.getValue());
+    d->ui.selfIntersection->setChecked(offset->SelfIntersection.getValue());
+    long mode = offset->Mode.getValue();
+    if (mode >= 0 && mode < d->ui.modeType->count())
+        d->ui.modeType->setCurrentIndex(mode);
+    long join = offset->Join.getValue();
+    if (join >= 0 && join < d->ui.joinType->count())
+        d->ui.joinType->setCurrentIndex(join);
+
+    //unblock signals
+    block = false;
+    d->ui.fillOffset->blockSignals(block);
+    d->ui.intersection->blockSignals(block);
+    d->ui.selfIntersection->blockSignals(block);
+    d->ui.modeType->blockSignals(block);
+    d->ui.joinType->blockSignals(block);
+    d->ui.spinOffset->blockSignals(block);
+
+    d->ui.spinOffset->bind(d->offset->Value);
 }
 
 OffsetWidget::~OffsetWidget()
@@ -147,6 +183,7 @@ bool OffsetWidget::accept()
         double offsetValue = d->ui.spinOffset->value().getValue();
         Gui::Command::doCommand(Gui::Command::Doc,"App.ActiveDocument.%s.Value = %f",
             name.c_str(),offsetValue);
+        d->ui.spinOffset->apply();
         Gui::Command::doCommand(Gui::Command::Doc,"App.ActiveDocument.%s.Mode = %i",
             name.c_str(),d->ui.modeType->currentIndex());
         Gui::Command::doCommand(Gui::Command::Doc,"App.ActiveDocument.%s.Join = %i",

--- a/src/Mod/Part/Gui/ViewProviderMirror.cpp
+++ b/src/Mod/Part/Gui/ViewProviderMirror.cpp
@@ -45,6 +45,7 @@
 #include <Mod/Part/App/FeatureFillet.h>
 #include <Mod/Part/App/FeatureChamfer.h>
 #include <Mod/Part/App/FeatureRevolution.h>
+#include <Mod/Part/App/FeatureOffset.h>
 #include <Mod/Part/App/PartFeatures.h>
 #include <Gui/Application.h>
 #include <Gui/Control.h>

--- a/src/Mod/Part/Gui/ViewProviderMirror.cpp
+++ b/src/Mod/Part/Gui/ViewProviderMirror.cpp
@@ -583,6 +583,11 @@ bool ViewProviderOffset::onDelete(const std::vector<std::string> &)
 
 // ---------------------------------------
 
+PROPERTY_SOURCE(PartGui::ViewProviderOffset2D, PartGui::ViewProviderOffset)
+
+
+// ---------------------------------------
+
 PROPERTY_SOURCE(PartGui::ViewProviderThickness, PartGui::ViewProviderPart)
 
 ViewProviderThickness::ViewProviderThickness()

--- a/src/Mod/Part/Gui/ViewProviderMirror.h
+++ b/src/Mod/Part/Gui/ViewProviderMirror.h
@@ -163,6 +163,16 @@ protected:
     virtual void unsetEdit(int ModNum);
 };
 
+class ViewProviderOffset2D : public ViewProviderOffset
+{
+    PROPERTY_HEADER(PartGui::ViewProviderOffset2D);
+
+public:
+    ViewProviderOffset2D(){
+        sPixmap = "Part_Offset2D";
+    }
+};
+
 class ViewProviderThickness : public ViewProviderPart
 {
     PROPERTY_HEADER(PartGui::ViewProviderThickness);

--- a/src/Mod/Part/Gui/Workbench.cpp
+++ b/src/Mod/Part/Gui/Workbench.cpp
@@ -86,7 +86,7 @@ Gui::MenuItem* Workbench::setupMenuBar() const
           << "Part_CrossSections" << "Part_Compound" << "Part_MakeFace" << "Part_Extrude"
           << "Part_Revolve" << "Part_Mirror" << "Part_Fillet" << "Part_Chamfer"
           << "Part_RuledSurface" << "Part_Loft" << "Part_Sweep"
-          << "Part_Offset" << "Part_Thickness" << "Separator" << "Part_EditAttachment";
+          << "Part_Offset" << "Part_Offset2D" << "Part_Thickness" << "Separator" << "Part_EditAttachment";
 
     Gui::MenuItem* measure = new Gui::MenuItem;
     root->insertItem(item,measure);
@@ -122,7 +122,7 @@ Gui::ToolBarItem* Workbench::setupToolBars() const
     tool->setCommand("Part tools");
     *tool << "Part_Extrude" << "Part_Revolve" << "Part_Mirror" << "Part_Fillet"
           << "Part_Chamfer" << "Part_RuledSurface" << "Part_Loft" << "Part_Sweep"
-          << "Part_Offset" << "Part_Thickness";
+          << "Part_CompOffset" << "Part_Thickness";
 
     Gui::ToolBarItem* boolop = new Gui::ToolBarItem(root);
     boolop->setCommand("Boolean");


### PR DESCRIPTION
New feature of Part workbench: 2D offset.
2D offset offsets planar wires. It is powered by OCC's BRepOffsetAPI_MakeOffset.
Main capabilities:
* offsetting open and closed wires. Two offsetting modes for open wires: pipe and skin. 
* supports compounds. Two ways of treatment: independent or collective, controlled by 'Intersection' checkbox/property. On the screenshot, collective offset mode is presented.
* partial support for filling offset

Planned for future (not implemented yet):
* offsetting planar faces
* fill offset support for collective offset of compounds of wires

Py method Part.Wire.makeOffset was upgraded to support the same parameters as the feature does, and moved to become a member of Part.Shape (because it now applies to not only wires, but also compounds, and planned to support faces).

![offset-collective](https://cloud.githubusercontent.com/assets/8940427/18187264/2d9af1a2-70b9-11e6-9962-f3a431aba6ac.png)

Forum threads:
[Make Part Offset support wires](http://forum.freecadweb.org/viewtopic.php?f=8&t=17174)