### PR TITLE
Part FaceMakers

### DIFF
--- a/src/Mod/Part/App/AppPart.cpp
+++ b/src/Mod/Part/App/AppPart.cpp
@@ -97,6 +97,9 @@
 #include "DatumFeature.h"
 #include "Attacher.h"
 #include "AttachableObject.h"
+#include "FaceMaker.h"
+#include "FaceMakerCheese.h"
+#include "FaceMakerBullseye.h"
 
 namespace Part {
 extern PyObject* initModule();
@@ -240,6 +243,13 @@ PyMODINIT_FUNC initPart()
     Part::PropertyGeometryList  ::init();
     Part::PropertyShapeHistory  ::init();
     Part::PropertyFilletEdges   ::init();
+
+    Part::FaceMaker             ::init();
+    Part::FaceMakerPublic       ::init();
+    Part::FaceMakerSimple       ::init();
+    Part::FaceMakerCheese       ::init();
+    Part::FaceMakerExtrusion    ::init();
+    Part::FaceMakerBullseye     ::init();
 
     Attacher::AttachEngine        ::init();
     Attacher::AttachEngine3D      ::init();

--- a/src/Mod/Part/App/AppPartPy.cpp
+++ b/src/Mod/Part/App/AppPartPy.cpp
@@ -124,6 +124,7 @@
 #include "ImportIges.h"
 #include "ImportStep.h"
 #include "edgecluster.h"
+#include "FaceMaker.h"
 
 #ifdef FCUseFreeType
 #  include "FT2FC.h"
@@ -251,6 +252,10 @@ public:
         );
         add_varargs_method("makeShell",&Module::makeShell,
             "makeShell(list) -- Create a shell out of a list of faces."
+        );
+        add_varargs_method("makeFace",&Module::makeFace,
+            "makeFace(list_of_shapes_or_compound, maker_class_name) -- Create a face (faces) using facemaker class.\n"
+            "maker_class_name is a string like 'Part::FaceMakerSimple'."
         );
         add_varargs_method("makeFilledFace",&Module::makeFilledFace,
             "makeFilledFace(list) -- Create a face out of a list of edges."
@@ -625,6 +630,67 @@ private:
         }
 
         return Py::asObject(new TopoShapeShellPy(new TopoShape(shape)));
+    }
+    Py::Object makeFace(const Py::Tuple& args)
+    {
+        try{
+
+            char* className = 0;
+            PyObject* pcPyShapeOrList = nullptr;
+            PyErr_Clear();
+            if (PyArg_ParseTuple(args.ptr(), "Os", &pcPyShapeOrList, &className)) {
+                std::unique_ptr<FaceMaker> fm_instance = Part::FaceMaker::ConstructFromType(className);
+                FaceMaker* fm = &(*fm_instance);
+
+                //dump all supplied shapes to facemaker, no matter what type (let facemaker decide).
+                if (PySequence_Check(pcPyShapeOrList)){
+                    Py::Sequence list(pcPyShapeOrList);
+                    for (Py::Sequence::iterator it = list.begin(); it != list.end(); ++it) {
+                        PyObject* item = (*it).ptr();
+                        if (PyObject_TypeCheck(item, &(Part::TopoShapePy::Type))) {
+                            const TopoDS_Shape& sh = static_cast<Part::TopoShapePy*>(item)->getTopoShapePtr()->getShape();
+                            fm->addShape(sh);
+                        } else {
+                            throw Py::Exception(PyExc_TypeError, "Object is not a shape.");
+                        }
+                    }
+                } else if (PyObject_TypeCheck(pcPyShapeOrList, &(Part::TopoShapePy::Type))) {
+                    const TopoDS_Shape& sh = static_cast<Part::TopoShapePy*>(pcPyShapeOrList)->getTopoShapePtr()->getShape();
+                    if (sh.IsNull())
+                        throw Base::Exception("Shape is null!");
+                    if (sh.ShapeType() == TopAbs_COMPOUND)
+                        fm->useCompound(TopoDS::Compound(sh));
+                    else
+                        fm->addShape(sh);
+                } else {
+                    throw Py::Exception(PyExc_TypeError, "First argument is neither a shape nor list of shapes.");
+                }
+
+                fm->Build();
+
+                if(fm->Shape().IsNull())
+                    return Py::asObject(new TopoShapePy(new TopoShape(fm->Shape())));
+
+                switch(fm->Shape().ShapeType()){
+                case TopAbs_FACE:
+                    return Py::asObject(new TopoShapeFacePy(new TopoShape(fm->Shape())));
+                break;
+                case TopAbs_COMPOUND:
+                    return Py::asObject(new TopoShapeCompoundPy(new TopoShape(fm->Shape())));
+                break;
+                default:
+                    return Py::asObject(new TopoShapePy(new TopoShape(fm->Shape())));
+                }
+            } ;
+
+            throw Py::Exception(Base::BaseExceptionFreeCADError, std::string("Argument type signature not recognized. Should be either (list, string), or (shape, string)"));
+
+        } catch (Standard_Failure) {
+            Handle_Standard_Failure e = Standard_Failure::Caught();
+            throw Py::Exception(PartExceptionOCCError, e->GetMessageString());
+        } catch (Base::Exception &e){
+            throw Py::Exception(Base::BaseExceptionFreeCADError, e.what());
+        }
     }
     Py::Object makeFilledFace(const Py::Tuple& args)
     {

--- a/src/Mod/Part/App/CMakeLists.txt
+++ b/src/Mod/Part/App/CMakeLists.txt
@@ -282,6 +282,8 @@ SET(Part_SRCS
     OCCError.h
     FT2FC.cpp
     FT2FC.h
+    FaceMaker.cpp
+    FaceMaker.h
 )
 
 SET(Part_Scripts

--- a/src/Mod/Part/App/CMakeLists.txt
+++ b/src/Mod/Part/App/CMakeLists.txt
@@ -284,6 +284,10 @@ SET(Part_SRCS
     FT2FC.h
     FaceMaker.cpp
     FaceMaker.h
+    FaceMakerCheese.cpp
+    FaceMakerCheese.h
+    FaceMakerBullseye.cpp
+    FaceMakerBullseye.h
 )
 
 SET(Part_Scripts

--- a/src/Mod/Part/App/FaceMaker.cpp
+++ b/src/Mod/Part/App/FaceMaker.cpp
@@ -1,0 +1,180 @@
+/***************************************************************************
+ *   Copyright (c) 2016 Victor Titov (DeepSOIC)      <vv.titov@gmail.com>  *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "PreCompiled.h"
+#ifndef _PreComp_
+# include <TopoDS.hxx>
+# include <TopoDS_Iterator.hxx>
+# include <BRep_Builder.hxx>
+# include <BRepBuilderAPI_MakeWire.hxx>
+# include <BRepBuilderAPI_MakeFace.hxx>
+# include <BRep_Tool.hxx>
+#endif
+
+#include "FaceMaker.h"
+
+#include <Base/Exception.h>
+#include <memory>
+
+#include <QtGlobal>
+
+TYPESYSTEM_SOURCE_ABSTRACT(Part::FaceMaker, Base::BaseClass);
+TYPESYSTEM_SOURCE_ABSTRACT(Part::FaceMakerPublic, Part::FaceMaker);
+
+void Part::FaceMaker::addWire(const TopoDS_Wire& w)
+{
+    this->addShape(w);
+}
+
+void Part::FaceMaker::addShape(const TopoDS_Shape& sh)
+{
+    if(sh.IsNull())
+        throw Base::ValueError("Input shape is null.");
+    switch(sh.ShapeType()){
+        case TopAbs_COMPOUND:
+            this->myCompounds.push_back(TopoDS::Compound(sh));
+        break;
+        case TopAbs_WIRE:
+            this->myWires.push_back(TopoDS::Wire(sh));
+        break;
+        case TopAbs_EDGE:
+            this->myWires.push_back(BRepBuilderAPI_MakeWire(TopoDS::Edge(sh)).Wire());
+        break;
+        default:
+            throw Base::TypeError("Shape must be a wire, edge or compound. Something else was supplied.");
+        break;
+    }
+    this->mySourceShapes.push_back(sh);
+}
+
+void Part::FaceMaker::useCompound(const TopoDS_Compound& comp)
+{
+    TopoDS_Iterator it(comp);
+    for(; it.More(); it.Next()){
+        this->addShape(it.Value());
+    }
+}
+
+const TopoDS_Face& Part::FaceMaker::Face()
+{
+    const TopoDS_Shape &sh = this->Shape();
+    if(sh.IsNull())
+        throw Base::Exception("Part::FaceMaker: result shape is null.");
+    if (sh.ShapeType() != TopAbs_FACE)
+        throw Base::TypeError("Part::FaceMaker: return shape is not a single face.");
+    return TopoDS::Face(sh);
+}
+
+void Part::FaceMaker::Build()
+{
+    this->NotDone();
+    this->myShapesToReturn.clear();
+    this->myGenerated.Clear();
+
+    this->Build_Essence();//adds stuff to myShapesToReturn
+
+    for(const TopoDS_Compound& cmp : this->myCompounds){
+        std::unique_ptr<FaceMaker> facemaker_instance = Part::FaceMaker::ConstructFromType(this->getTypeId());
+        FaceMaker* facemaker = &(*facemaker_instance); //handy to have plain pointer for intellisense to work =)
+
+        facemaker->useCompound(cmp);
+
+        facemaker->Build();
+        const TopoDS_Shape &subfaces = facemaker->Shape();
+        if (subfaces.IsNull())
+            continue;
+        if (subfaces.ShapeType() == TopAbs_COMPOUND){
+            this->myShapesToReturn.push_back(subfaces);
+        } else {
+            //result is not a compound (probably, a face)... but we want to follow compounding structure of input, so wrap it into compound.
+            TopoDS_Builder builder;
+            TopoDS_Compound cmp_res;
+            builder.MakeCompound(cmp_res);
+            builder.Add(cmp_res,subfaces);
+            this->myShapesToReturn.push_back(cmp_res);
+        }
+    }
+
+    if(this->myShapesToReturn.empty()){
+        //nothing to do, null shape will be returned.
+    } else if (this->myShapesToReturn.size() == 1){
+        this->myShape = this->myShapesToReturn[0];
+    } else {
+        TopoDS_Builder builder;
+        TopoDS_Compound cmp_res;
+        builder.MakeCompound(cmp_res);
+        for(TopoDS_Shape &sh: this->myShapesToReturn){
+            builder.Add(cmp_res,sh);
+        }
+        this->myShape = cmp_res;
+    }
+    this->Done();
+}
+
+std::unique_ptr<Part::FaceMaker> Part::FaceMaker::ConstructFromType(const char* className)
+{
+    Base::Type fmType = Base::Type::fromName(className);
+    if (fmType.isBad()){
+        std::stringstream ss;
+        ss << "Class '"<< className <<"' not found.";
+        throw Base::Exception(ss.str().c_str());
+    }
+    return Part::FaceMaker::ConstructFromType(fmType);
+}
+
+std::unique_ptr<Part::FaceMaker> Part::FaceMaker::ConstructFromType(Base::Type type)
+{
+    if (!type.isDerivedFrom(Part::FaceMaker::getClassTypeId())){
+        std::stringstream ss;
+        ss << "Class '" << type.getName() << "' is not derived from Part::FaceMaker.";
+        throw Base::TypeError(ss.str().c_str());
+    }
+    return std::unique_ptr<FaceMaker>(static_cast<Part::FaceMaker*>(type.createInstance()));
+}
+
+void Part::FaceMaker::throwNotImplemented()
+{
+    throw Base::NotImplementedError("Not implemente yet...");
+}
+
+
+//----------------------------------------------------------------------------------------
+
+TYPESYSTEM_SOURCE(Part::FaceMakerSimple, Part::FaceMakerPublic);
+
+
+std::string Part::FaceMakerSimple::getUserFriendlyName() const
+{
+    return std::string(QT_TRANSLATE_NOOP("Part_FaceMaker","Simple"));
+}
+
+std::string Part::FaceMakerSimple::getBriefExplanation() const
+{
+    return std::string(QT_TRANSLATE_NOOP("Part_FaceMaker","Makes separate plane face from every wire independently. No support for holes; wires can be on different planes."));
+}
+
+void Part::FaceMakerSimple::Build_Essence()
+{
+    for(TopoDS_Wire &w: myWires){
+        this->myShapesToReturn.push_back(BRepBuilderAPI_MakeFace(w).Shape());
+    }
+}

--- a/src/Mod/Part/App/FaceMaker.h
+++ b/src/Mod/Part/App/FaceMaker.h
@@ -1,0 +1,145 @@
+/***************************************************************************
+ *   Copyright (c) 2016 Victor Titov (DeepSOIC)      <vv.titov@gmail.com>  *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef PART_FACEMAKER_H
+#define PART_FACEMAKER_H
+
+#include <BRepBuilderAPI_MakeShape.hxx>
+#include <Base/BaseClass.h>
+#include <TopoDS_Wire.hxx>
+#include <TopoDS_Compound.hxx>
+#include <TopoDS_Face.hxx>
+
+#include <memory>
+
+namespace Part
+{
+
+/**
+ * @brief FaceMaker class is the base class for implementing various "smart"
+ * face making routines. This was created to address the problem of multiple
+ * private implementations of making faces with holes, which are quite complex.
+ * The two most important facemaking routines then was: one in Part Extrude,
+ * and one in PartDesign (there, it is used in every sketch-based feature).
+ * Plus, another one (new) was needed for filling 2D offset.
+ */
+class PartExport FaceMaker: public BRepBuilderAPI_MakeShape, public Base::BaseClass
+{
+    TYPESYSTEM_HEADER();
+
+public:
+    FaceMaker() {};
+    virtual ~FaceMaker() {};
+
+    virtual void addWire(const TopoDS_Wire& w);
+    /**
+     * @brief addShape: add another wire, edge, or compound. If compound is
+     * added, its internals will be treated as isolated from the rest, and the
+     * compounding structure of result will follow.
+     * @param sh
+     */
+    virtual void addShape(const TopoDS_Shape& sh);
+    /**
+     * @brief useCompound: add children of compound to the FaceMaker. Note that
+     * this is different from addShape(comp) - structure is lost. The compound
+     * is NOT expanded recursively.
+     * @param comp
+     */
+    virtual void useCompound(const TopoDS_Compound &comp);
+
+    /**
+     * @brief Face: returns the face (result). If result is not a single face,
+     * throws Base::TypeError. (hint: use .Shape() instead)
+     * @return
+     */
+    virtual const TopoDS_Face& Face();
+
+    virtual void Build();
+
+    //fails to compile, huh!
+    //virtual const TopTools_ListOfShape& Generated(const TopoDS_Shape &S) override {throwNotImplemented();}
+    //virtual const TopTools_ListOfShape& Modified(const TopoDS_Shape &S) override {throwNotImplemented();}
+    //virtual Standard_Boolean IsDeleted(const TopoDS_Shape &S) override {throwNotImplemented();}
+
+    static std::unique_ptr<FaceMaker> ConstructFromType(const char* className);
+    static std::unique_ptr<FaceMaker> ConstructFromType(Base::Type type);
+
+protected:
+    std::vector<TopoDS_Shape> mySourceShapes; //wire or compound
+    std::vector<TopoDS_Wire> myWires; //wires from mySourceShapes
+    std::vector<TopoDS_Compound> myCompounds; //compounds, for recursive processing
+    std::vector<TopoDS_Shape> myShapesToReturn;
+
+    /**
+     * @brief Build_Essence: build routine that can assume there is no nesting.
+     *
+     * Implementing instructions:
+     * Add new faces (or whatever) to myShapesToReturn. The rest is done by
+     * base class's Build(). Please ignore contents of myCompounds in
+     * implementation. If special handling of nesting is required, override
+     * whole Build().
+     */
+    virtual void Build_Essence() = 0;
+
+    static void throwNotImplemented();
+};
+
+/**
+ * @brief The FaceMakerPublic class: derive from it if you want the face maker to be listed in tools that allow choosing one.
+ */
+class PartExport FaceMakerPublic : public FaceMaker
+{
+    TYPESYSTEM_HEADER();
+public:
+    virtual std::string getUserFriendlyName() const = 0;
+    virtual std::string getBriefExplanation() const = 0;
+};
+
+
+
+/**
+ * @brief The FaceMakerSimple class: make plane faces from all closed wires
+ * supplied, ignoring overlaps.
+ *
+ * Strengths: can work with non-coplanar sets of wires. Will not make broken
+ * faces if wires overlap*.
+ *
+ * Limitations: can't make faces with holes (will generate overlapping faces
+ * instead). Can't make faces from nonplanar wires.
+ *
+ * * Compound of valid but overlapping faces is created. The compound is invalid
+ * for BOPs, but the faces themselves are valid, provided that the source wires
+ * are valid.
+ */
+class PartExport FaceMakerSimple : public FaceMakerPublic
+{
+    TYPESYSTEM_HEADER();
+public:
+    virtual std::string getUserFriendlyName() const override;
+    virtual std::string getBriefExplanation() const override;
+protected:
+    virtual void Build_Essence() override;
+};
+
+
+}//namespace Part
+#endif // PART_FACEMAKER_H

--- a/src/Mod/Part/App/FaceMakerBullseye.cpp
+++ b/src/Mod/Part/App/FaceMakerBullseye.cpp
@@ -1,0 +1,201 @@
+/***************************************************************************
+ *   Copyright (c) 2016 Victor Titov (DeepSOIC)      <vv.titov@gmail.com>  *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+
+#include "PreCompiled.h"
+#ifndef _PreComp_
+# include <Bnd_Box.hxx>
+# include <BRepBndLib.hxx>
+# include <BRep_Builder.hxx>
+# include <BRep_Tool.hxx>
+# include <BRepAdaptor_Surface.hxx>
+# include <BRepBuilderAPI_MakeFace.hxx>
+# include <BRepCheck_Analyzer.hxx>
+# include <BRepClass_FaceClassifier.hxx>
+# include <BRepLib_FindSurface.hxx>
+# include <Geom_Plane.hxx>
+# include <GeomAPI_ProjectPointOnSurf.hxx>
+# include <IntTools_FClass2d.hxx>
+# include <Precision.hxx>
+# include <ShapeAnalysis.hxx>
+# include <ShapeAnalysis_Surface.hxx>
+# include <ShapeExtend_Explorer.hxx>
+# include <ShapeFix_Shape.hxx>
+# include <ShapeFix_Wire.hxx>
+# include <TopoDS.hxx>
+# include <TopExp_Explorer.hxx>
+# include <TopTools_IndexedMapOfShape.hxx>
+# include <TopTools_HSequenceOfShape.hxx>
+#endif
+
+#include "FaceMakerBullseye.h"
+#include "FaceMakerCheese.h"
+
+#include <Base/Exception.h>
+
+#include <QtGlobal>
+
+using namespace Part;
+
+TYPESYSTEM_SOURCE(Part::FaceMakerBullseye, Part::FaceMakerPublic);
+
+void FaceMakerBullseye::setPlane(const gp_Pln &plane)
+{
+    this->myPlane = gp_Pln(plane);
+    this->planeSupplied = true;
+}
+
+std::string FaceMakerBullseye::getUserFriendlyName() const
+{
+    return std::string(QT_TRANSLATE_NOOP("Part_FaceMaker","Bull's-eye facemaker"));
+}
+
+std::string FaceMakerBullseye::getBriefExplanation() const
+{
+    return std::string(QT_TRANSLATE_NOOP("Part_FaceMaker","Supports making planar faces with holes with islands."));
+}
+
+void FaceMakerBullseye::Build_Essence()
+{
+    if(myWires.empty())
+        return;
+
+    //validity check
+    for(TopoDS_Wire &w : myWires){
+        if (!BRep_Tool::IsClosed(w))
+            throw Base::ValueError("Wire is not closed.");
+    }
+
+
+    //find plane (at the same time, test that all wires are on the same plane)
+    gp_Pln plane;
+    if(this->planeSupplied){
+        plane = this->myPlane;
+    } else {
+        TopoDS_Builder builder;
+        TopoDS_Compound comp;
+        builder.MakeCompound(comp);
+        for(TopoDS_Wire &w : myWires){
+            builder.Add(comp, w);
+        }
+        BRepLib_FindSurface planeFinder(comp,-1, /*OnlyPlane=*/Standard_True);
+        if (!planeFinder.Found())
+            throw Base::ValueError("Wires are not coplanar.");
+        plane = GeomAdaptor_Surface(planeFinder.Surface()).Plane();
+    }
+
+    //sort wires by length of diagonal of bounding box.
+    std::vector<TopoDS_Wire> wires = this->myWires;
+    std::stable_sort(wires.begin(), wires.end(), FaceMakerCheese::Wire_Compare());
+
+    //add wires one by one to current set of faces.
+    //We go from last to first, to make it so that outer wires come before inner wires.
+    std::vector< std::unique_ptr<FaceDriller> > faces;
+    for( int i = wires.size()-1   ;   i >= 0   ;   --i){
+        TopoDS_Wire &w = wires[i];
+
+        //test if this wire is on any of existing faces (if yes, it's a hole;
+        // if no, it's a beginning of a new face).
+        //Since we are assuming the wires do not intersect, testing if one vertex of wire is in a face is enough.
+        gp_Pnt p = BRep_Tool::Pnt(TopoDS::Vertex(TopExp_Explorer(w, TopAbs_VERTEX).Current()));
+        FaceDriller* foundFace = nullptr;
+        for(std::unique_ptr<FaceDriller> &ff : faces){
+            if(ff->hitTest(p)){
+                foundFace = &(*ff);
+                break;
+            }
+        }
+
+        if(foundFace){
+            //wire is on a face.
+            foundFace->addHole(w);
+        } else {
+            //wire is not on a face. Start a new face.
+            faces.push_back(std::unique_ptr<FaceDriller>(
+                                new FaceDriller(plane, w)
+                           ));
+        }
+    }
+
+    //and we are done!
+    for(std::unique_ptr<FaceDriller> &ff : faces){
+        this->myShapesToReturn.push_back(ff->Face());
+    }
+}
+
+
+FaceMakerBullseye::FaceDriller::FaceDriller(gp_Pln plane, TopoDS_Wire outerWire)
+{
+    this->myPlane = plane;
+    this->myFace = TopoDS_Face();
+
+    //Ensure correct orientation of the wire.
+    if (getWireDirection(myPlane, outerWire) < 0)
+        outerWire.Reverse();
+
+    myHPlane = new Geom_Plane(this->myPlane);
+    BRep_Builder builder;
+    builder.MakeFace(this->myFace, myHPlane, Precision::Confusion());
+    builder.Add(this->myFace, outerWire);
+}
+
+bool FaceMakerBullseye::FaceDriller::hitTest(gp_Pnt point) const
+{
+    double u,v;
+    GeomAPI_ProjectPointOnSurf(point, myHPlane).LowerDistanceParameters(u,v);
+    BRepClass_FaceClassifier cl(myFace, gp_Pnt2d(u,v), Precision::Confusion());
+    TopAbs_State ret = cl.State();
+    switch(ret){
+        case TopAbs_UNKNOWN:
+            throw Base::Exception("FaceMakerBullseye::FaceDriller::hitTest: result unknown.");
+        break;
+        default:
+            return ret == TopAbs_IN || ret == TopAbs_ON;
+    }
+
+}
+
+void FaceMakerBullseye::FaceDriller::addHole(TopoDS_Wire w)
+{
+    //Ensure correct orientation of the wire.
+    if (getWireDirection(myPlane, w) > 0) //if wire is CCW..
+        w.Reverse();   //.. we want CW!
+
+    BRep_Builder builder;
+    builder.Add(this->myFace, w);
+}
+
+int FaceMakerBullseye::FaceDriller::getWireDirection(const gp_Pln& plane, const TopoDS_Wire& wire)
+{
+    //make a test face
+    BRepBuilderAPI_MakeFace mkFace(wire, /*onlyplane=*/Standard_True);
+    TopoDS_Face tmpFace = mkFace.Face();
+    //compare face surface normal with our plane's one
+    BRepAdaptor_Surface surf(tmpFace);
+    bool normal_co = surf.Plane().Axis().Direction().Dot(plane.Axis().Direction()) > 0;
+
+    //unlikely, but just in case OCC decided to reverse our wire for the face...  take that into account!
+    TopoDS_Iterator it(tmpFace, /*CumOri=*/Standard_False);
+    normal_co ^= it.Value().Orientation() != wire.Orientation();
+
+    return normal_co ? 1 : -1;
+}

--- a/src/Mod/Part/App/FaceMakerBullseye.h
+++ b/src/Mod/Part/App/FaceMakerBullseye.h
@@ -1,0 +1,105 @@
+/***************************************************************************
+ *   Copyright (c) 2016 Victor Titov (DeepSOIC)      <vv.titov@gmail.com>  *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef PART_FACEMAKER_BULLSEYE_H
+#define PART_FACEMAKER_BULLSEYE_H
+
+#include "FaceMaker.h"
+#include <list>
+
+#include <Geom_Surface.hxx>
+#include <gp_Pln.hxx>
+
+namespace Part
+{
+
+
+/**
+ * @brief The FaceMakerBullseye class is a tool to make planar faces with holes,
+ * where there can be additional faces inside holes and they can have holes too
+ * and so on.
+ *
+ * Strengths: makes faces with holes with islands
+ *
+ * Weaknesses: faces of one compound must be on same plane. TBD
+ */
+class PartExport FaceMakerBullseye: public FaceMakerPublic
+{
+    TYPESYSTEM_HEADER();
+public:
+    FaceMakerBullseye()
+        :planeSupplied(false){}
+    /**
+     * @brief setPlane: sets the plane to use when making faces. This is
+     * optional. If the plane was set, it is not tested that the wires are
+     * planar or on the supplied plane, potentially speeding things up.
+     * @param plane FIXME: the plane is not propagated if processing compounds.
+     */
+    void setPlane(const gp_Pln& plane);
+
+    virtual std::string getUserFriendlyName() const override;
+    virtual std::string getBriefExplanation() const override;
+
+protected:
+    virtual void Build_Essence() override;
+
+protected:
+    gp_Pln myPlane; //externally supplied plane (if any)
+    bool planeSupplied;
+
+    /**
+     * @brief The FaceDriller class is similar to BRepBuilderAPI_MakeFace,
+     * except that it is tolerant to wire orientation (wires are oriented as
+     * needed automatically).
+     */
+    class FaceDriller
+    {
+    public:
+        FaceDriller(gp_Pln plane, TopoDS_Wire outerWire);
+
+        /**
+         * @brief hitTest: returns True if point is on the face
+         * @param point
+         */
+        bool hitTest(gp_Pnt point) const;
+
+        void addHole(TopoDS_Wire w);
+
+        TopoDS_Face Face() {return myFace;}
+    public:
+        /**
+         * @brief wireDirection: determines direction of wire with respect to
+         * myPlane.
+         * @param w
+         * @return  1 = CCW (suits as outer wire), -1 = CW (suits as hole)
+         */
+        static int getWireDirection(const gp_Pln &plane, const TopoDS_Wire &w);
+    private:
+        gp_Pln myPlane;
+        TopoDS_Face myFace;
+        Handle_Geom_Surface myHPlane;
+    };
+};
+
+
+}//namespace Part
+#endif // PART_FACEMAKER_BULLSEYE_H

--- a/src/Mod/Part/App/FaceMakerCheese.cpp
+++ b/src/Mod/Part/App/FaceMakerCheese.cpp
@@ -1,0 +1,264 @@
+/***************************************************************************
+ *   Copyright (c) 2016 Victor Titov (DeepSOIC)      <vv.titov@gmail.com>  *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+
+#include "PreCompiled.h"
+#ifndef _PreComp_
+# include <Bnd_Box.hxx>
+# include <BRepBndLib.hxx>
+# include <BRep_Builder.hxx>
+# include <BRep_Tool.hxx>
+# include <BRepAdaptor_Surface.hxx>
+# include <BRepCheck_Analyzer.hxx>
+# include <BRepBuilderAPI_MakeFace.hxx>
+# include <Geom_Plane.hxx>
+# include <gp_Pln.hxx>
+# include <IntTools_FClass2d.hxx>
+# include <Precision.hxx>
+# include <ShapeAnalysis.hxx>
+# include <ShapeAnalysis_Surface.hxx>
+# include <ShapeExtend_Explorer.hxx>
+# include <ShapeFix_Shape.hxx>
+# include <ShapeFix_Wire.hxx>
+# include <TopoDS.hxx>
+# include <TopExp_Explorer.hxx>
+# include <TopTools_IndexedMapOfShape.hxx>
+# include <TopTools_HSequenceOfShape.hxx>
+#endif
+
+#include "FaceMakerCheese.h"
+
+#include <QtGlobal>
+
+using namespace Part;
+
+TYPESYSTEM_SOURCE(Part::FaceMakerCheese, Part::FaceMakerPublic);
+
+
+TopoDS_Face FaceMakerCheese::validateFace(const TopoDS_Face& face)
+{
+    BRepCheck_Analyzer aChecker(face);
+    if (!aChecker.IsValid()) {
+        TopoDS_Wire outerwire = ShapeAnalysis::OuterWire(face);
+        TopTools_IndexedMapOfShape myMap;
+        myMap.Add(outerwire);
+
+        TopExp_Explorer xp(face,TopAbs_WIRE);
+        ShapeFix_Wire fix;
+        fix.SetFace(face);
+        fix.Load(outerwire);
+        fix.Perform();
+        BRepBuilderAPI_MakeFace mkFace(fix.WireAPIMake());
+        while (xp.More()) {
+            if (!myMap.Contains(xp.Current())) {
+                fix.Load(TopoDS::Wire(xp.Current()));
+                fix.Perform();
+                mkFace.Add(fix.WireAPIMake());
+            }
+            xp.Next();
+        }
+
+        aChecker.Init(mkFace.Face());
+        if (!aChecker.IsValid()) {
+            ShapeFix_Shape fix(mkFace.Face());
+            fix.SetPrecision(Precision::Confusion());
+            fix.SetMaxTolerance(Precision::Confusion());
+            fix.SetMaxTolerance(Precision::Confusion());
+            fix.Perform();
+            fix.FixWireTool()->Perform();
+            fix.FixFaceTool()->Perform();
+            TopoDS_Face fixedFace = TopoDS::Face(fix.Shape());
+            aChecker.Init(fixedFace);
+            if (!aChecker.IsValid())
+                Standard_Failure::Raise("Failed to validate broken face");
+            return fixedFace;
+        }
+        return mkFace.Face();
+    }
+
+    return face;
+}
+
+bool FaceMakerCheese::Wire_Compare::operator() (const TopoDS_Wire& w1, const TopoDS_Wire& w2)
+{
+    Bnd_Box box1, box2;
+    if (!w1.IsNull()) {
+        BRepBndLib::Add(w1, box1);
+        box1.SetGap(0.0);
+    }
+
+    if (!w2.IsNull()) {
+        BRepBndLib::Add(w2, box2);
+        box2.SetGap(0.0);
+    }
+
+    return box1.SquareExtent() < box2.SquareExtent();
+}
+
+bool FaceMakerCheese::isInside(const TopoDS_Wire& wire1, const TopoDS_Wire& wire2)
+{
+    Bnd_Box box1;
+    BRepBndLib::Add(wire1, box1);
+    box1.SetGap(0.0);
+
+    Bnd_Box box2;
+    BRepBndLib::Add(wire2, box2);
+    box2.SetGap(0.0);
+
+    if (box1.IsOut(box2))
+        return false;
+
+    double prec = Precision::Confusion();
+
+    BRepBuilderAPI_MakeFace mkFace(wire1);
+    if (!mkFace.IsDone())
+        Standard_Failure::Raise("Failed to create a face from wire in sketch");
+    TopoDS_Face face = validateFace(mkFace.Face());
+    BRepAdaptor_Surface adapt(face);
+    IntTools_FClass2d class2d(face, prec);
+    Handle_Geom_Surface surf = new Geom_Plane(adapt.Plane());
+    ShapeAnalysis_Surface as(surf);
+
+    TopExp_Explorer xp(wire2,TopAbs_VERTEX);
+    while (xp.More())  {
+        TopoDS_Vertex v = TopoDS::Vertex(xp.Current());
+        gp_Pnt p = BRep_Tool::Pnt(v);
+        gp_Pnt2d uv = as.ValueOfUV(p, prec);
+        if (class2d.Perform(uv) == TopAbs_IN)
+            return true;
+        // TODO: We can make a check to see if all points are inside or all outside
+        // because otherwise we have some intersections which is not allowed
+        else
+            return false;
+        //xp.Next();
+    }
+
+    return false;
+}
+
+TopoDS_Shape FaceMakerCheese::makeFace(std::list<TopoDS_Wire>& wires)
+{
+    BRepBuilderAPI_MakeFace mkFace(wires.front());
+    const TopoDS_Face& face = mkFace.Face();
+    if (face.IsNull())
+        return face;
+    gp_Dir axis(0,0,1);
+    BRepAdaptor_Surface adapt(face);
+    if (adapt.GetType() == GeomAbs_Plane) {
+        axis = adapt.Plane().Axis().Direction();
+    }
+
+    wires.pop_front();
+    for (std::list<TopoDS_Wire>::iterator it = wires.begin(); it != wires.end(); ++it) {
+        BRepBuilderAPI_MakeFace mkInnerFace(*it);
+        const TopoDS_Face& inner_face = mkInnerFace.Face();
+        if (inner_face.IsNull())
+            return inner_face; // failure
+        gp_Dir inner_axis(0,0,1);
+        BRepAdaptor_Surface adapt(inner_face);
+        if (adapt.GetType() == GeomAbs_Plane) {
+            inner_axis = adapt.Plane().Axis().Direction();
+        }
+        // It seems that orientation is always 'Forward' and we only have to reverse
+        // if the underlying plane have opposite normals.
+        if (axis.Dot(inner_axis) < 0)
+            it->Reverse();
+        mkFace.Add(*it);
+    }
+    return validateFace(mkFace.Face());
+}
+
+TopoDS_Shape FaceMakerCheese::makeFace(const std::vector<TopoDS_Wire>& w)
+{
+    if (w.empty())
+        return TopoDS_Shape();
+
+    //FIXME: Need a safe method to sort wire that the outermost one comes last
+    // Currently it's done with the diagonal lengths of the bounding boxes
+    std::vector<TopoDS_Wire> wires = w;
+    std::sort(wires.begin(), wires.end(), Wire_Compare());
+    std::list<TopoDS_Wire> wire_list;
+    wire_list.insert(wire_list.begin(), wires.rbegin(), wires.rend());
+
+    // separate the wires into several independent faces
+    std::list< std::list<TopoDS_Wire> > sep_wire_list;
+    while (!wire_list.empty()) {
+        std::list<TopoDS_Wire> sep_list;
+        TopoDS_Wire wire = wire_list.front();
+        wire_list.pop_front();
+        sep_list.push_back(wire);
+
+        std::list<TopoDS_Wire>::iterator it = wire_list.begin();
+        while (it != wire_list.end()) {
+            if (isInside(wire, *it)) {
+                sep_list.push_back(*it);
+                it = wire_list.erase(it);
+            }
+            else {
+                ++it;
+            }
+        }
+
+        sep_wire_list.push_back(sep_list);
+    }
+
+    if (sep_wire_list.size() == 1) {
+        std::list<TopoDS_Wire>& wires = sep_wire_list.front();
+        return makeFace(wires);
+    }
+    else if (sep_wire_list.size() > 1) {
+        TopoDS_Compound comp;
+        BRep_Builder builder;
+        builder.MakeCompound(comp);
+        for (std::list< std::list<TopoDS_Wire> >::iterator it = sep_wire_list.begin(); it != sep_wire_list.end(); ++it) {
+            TopoDS_Shape aFace = makeFace(*it);
+            if (!aFace.IsNull())
+                builder.Add(comp, aFace);
+        }
+
+        return comp;
+    }
+    else {
+        return TopoDS_Shape(); // error
+    }
+}
+
+
+std::string FaceMakerCheese::getUserFriendlyName() const
+{
+    return std::string(QT_TRANSLATE_NOOP("Part_FaceMaker","Cheese facemaker"));
+}
+
+std::string FaceMakerCheese::getBriefExplanation() const
+{
+    return std::string(QT_TRANSLATE_NOOP("Part_FaceMaker","Supports making planar faces with holes, but no islands inside holes."));
+}
+
+void FaceMakerCheese::Build_Essence()
+{
+    TopoDS_Shape faces = makeFace(this->myWires);
+    ShapeExtend_Explorer xp;
+    Handle_TopTools_HSequenceOfShape seq = xp.SeqFromCompound(faces, Standard_True);
+    for(int i = 0   ;   i < seq->Length()   ;   i++){
+        this->myShapesToReturn.push_back(seq->Value(i+1));
+    }
+}

--- a/src/Mod/Part/App/FaceMakerCheese.h
+++ b/src/Mod/Part/App/FaceMakerCheese.h
@@ -1,0 +1,73 @@
+/***************************************************************************
+ *   Copyright (c) 2016 Victor Titov (DeepSOIC)      <vv.titov@gmail.com>  *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef PART_FACEMAKER_CHEESE_H
+#define PART_FACEMAKER_CHEESE_H
+
+#include "FaceMaker.h"
+#include <list>
+#include <functional>
+
+namespace Part
+{
+
+
+/**
+ * @brief The FaceMakerCheese class is a legacy face maker that was extracted
+ * from Part Extrude. It is used by almost all PartDesign.
+ *
+ * Strengths: makes faces with holes
+ *
+ * Weaknesses: can't make islands in holes. All faces must be on same plane.
+ */
+class PartExport FaceMakerCheese: public FaceMakerPublic
+{
+    TYPESYSTEM_HEADER();
+public:
+    virtual std::string getUserFriendlyName() const override;
+    virtual std::string getBriefExplanation() const override;
+
+public: //in Extrusion, they used to be private. but they are also used by PartDesign, so made public.
+    /**
+     * @brief The Wire_Compare class is for sorting wires by bounding box diagonal length
+     */
+    class Wire_Compare : public std::binary_function<const TopoDS_Wire&,
+            const TopoDS_Wire&, bool>
+    {
+    public:
+        bool operator() (const TopoDS_Wire& w1, const TopoDS_Wire& w2);
+    };
+
+    static TopoDS_Shape makeFace(const std::vector<TopoDS_Wire>&);
+    static TopoDS_Face validateFace(const TopoDS_Face&);
+    static bool isInside(const TopoDS_Wire&, const TopoDS_Wire&);
+
+private:
+    static TopoDS_Shape makeFace(std::list<TopoDS_Wire>&); // for internal use only
+
+protected:
+    virtual void Build_Essence() override;
+};
+
+
+}//namespace Part
+#endif // PART_FACEMAKER_CHEESE_H

--- a/src/Mod/Part/App/FeatureExtrusion.cpp
+++ b/src/Mod/Part/App/FeatureExtrusion.cpp
@@ -24,35 +24,23 @@
 #include "PreCompiled.h"
 #ifndef _PreComp_
 # include <cmath>
-# include <Bnd_Box.hxx>
-# include <BRepBndLib.hxx>
 # include <gp_Pln.hxx>
-# include <gp_Lin.hxx>
 # include <gp_Trsf.hxx>
-# include <BRep_Tool.hxx>
 # include <BRepAdaptor_Surface.hxx>
 # include <BRepAdaptor_Curve.hxx>
-# include <BRepCheck_Analyzer.hxx>
 # include <BRepOffsetAPI_MakeOffset.hxx>
 # include <BRepBuilderAPI_Copy.hxx>
-# include <BRepBuilderAPI_MakeFace.hxx>
 # include <BRepBuilderAPI_MakeWire.hxx>
-# include <BRepBuilderAPI_Transform.hxx>
 # include <BRepOffsetAPI_ThruSections.hxx>
 # include <BRepPrimAPI_MakePrism.hxx>
-# include <Geom_Plane.hxx>
-# include <IntTools_FClass2d.hxx>
 # include <Precision.hxx>
 # include <ShapeAnalysis.hxx>
-# include <ShapeAnalysis_Surface.hxx>
-# include <ShapeFix_Shape.hxx>
 # include <ShapeFix_Wire.hxx>
 # include <TopoDS.hxx>
 # include <TopoDS_Iterator.hxx>
 # include <TopExp.hxx>
 # include <TopExp_Explorer.hxx>
 # include <TopTools_IndexedMapOfShape.hxx>
-# include <ShapeExtend_Explorer.hxx>
 # include <BRepLib_FindSurface.hxx>
 #endif
 
@@ -61,6 +49,7 @@
 #include <Base/Tools.h>
 #include <Base/Exception.h>
 #include "Part2DObject.h"
+
 
 
 using namespace Part;
@@ -88,6 +77,7 @@ Extrusion::Extrusion()
     ADD_PROPERTY_TYPE(Symmetric,(false), "Extrude", App::Prop_None, "If true, extrusion is done in both directions to a total of LengthFwd. LengthRev is ignored.");
     ADD_PROPERTY_TYPE(TaperAngle,(0.0), "Extrude", App::Prop_None, "Sets the angle of slope (draft) to apply to the sides. The angle is for outward taper; negative value yeilds inward tapering.");
     ADD_PROPERTY_TYPE(TaperAngleRev,(0.0), "Extrude", App::Prop_None, "Taper angle of reverse part of extrusion.");
+    ADD_PROPERTY_TYPE(FaceMakerClass,("Part::FaceMakerExtrusion"), "Extrude", App::Prop_None, "If Solid is true, this sets the facemaker class to use when converting wires to faces. Otherwise, ignored."); //default for old documents. See setupObject for default for new extrusions.
 }
 
 short Extrusion::mustExecute() const
@@ -102,7 +92,8 @@ short Extrusion::mustExecute() const
         Reversed.isTouched() ||
         Symmetric.isTouched() ||
         TaperAngle.isTouched() ||
-        TaperAngleRev.isTouched())
+        TaperAngleRev.isTouched() ||
+        FaceMakerClass.isTouched())
         return 1;
     return 0;
 }
@@ -198,6 +189,8 @@ Extrusion::ExtrusionParameters Extrusion::computeFinalParameters()
     result.taperAngleRev = this->TaperAngleRev.getValue() * M_PI / 180.0;
     if (fabs(result.taperAngleRev) > M_PI * 0.5 - Precision::Angular() )
         throw Base::ValueError("Magnitude of taper angle matches or exceeds 90 degrees. That is too much.");
+
+    result.faceMakerClass = this->FaceMakerClass.getValue();
 
     return result;
 }
@@ -302,35 +295,20 @@ TopoShape Extrusion::extrudeShape(const TopoShape source, Extrusion::ExtrusionPa
         }
 
         //make faces from wires
-        if (params.solid && myShape.ShapeType() != TopAbs_FACE) {
-            std::vector<TopoDS_Wire> wires;
-            TopTools_IndexedMapOfShape mapOfWires;
-            TopExp::MapShapes(myShape, TopAbs_WIRE, mapOfWires);
+        if (params.solid) {
+            if (myShape.ShapeType() == TopAbs_FACE && params.faceMakerClass == "Part::FaceMakerExtrusion"){
+                //legacy exclusion: ignore "solid" if extruding a face.
+            } else {
+                //new strict behavior. If solid==True => make faces from wires, and if myShape not wires - fail!
+                std::unique_ptr<FaceMaker> fm_instance = FaceMaker::ConstructFromType(params.faceMakerClass.c_str());
+                FaceMaker* mkFace = &(*(fm_instance));
 
-            // if there are no wires then check also for edges
-            if (mapOfWires.IsEmpty()) {
-                TopTools_IndexedMapOfShape mapOfEdges;
-                TopExp::MapShapes(myShape, TopAbs_EDGE, mapOfEdges);
-                for (int i=1; i<=mapOfEdges.Extent(); i++) {
-                    BRepBuilderAPI_MakeWire mkWire(TopoDS::Edge(mapOfEdges.FindKey(i)));
-                    wires.push_back(mkWire.Wire());
-                }
-            }
-            else {
-                wires.reserve(mapOfWires.Extent());
-                for (int i=1; i<=mapOfWires.Extent(); i++) {
-                    wires.push_back(TopoDS::Wire(mapOfWires.FindKey(i)));
-                }
-            }
-
-            if (!wires.empty()) {
-                try {
-                    TopoDS_Shape res = makeFace(wires);
-                    if (!res.IsNull())
-                        myShape = res;
-                }
-                catch (...) {
-                }
+                if(myShape.ShapeType() == TopAbs_COMPOUND)
+                    mkFace->useCompound(TopoDS::Compound(myShape));
+                else
+                    mkFace->addShape(myShape);
+                mkFace->Build();
+                myShape = mkFace->Shape();
             }
         }
 
@@ -520,195 +498,79 @@ void Extrusion::makeDraft(ExtrusionParameters params, const TopoDS_Shape& shape,
     }
 }
 
-TopoDS_Face Extrusion::validateFace(const TopoDS_Face& face)
+//----------------------------------------------------------------
+
+TYPESYSTEM_SOURCE(Part::FaceMakerExtrusion, Part::FaceMakerCheese);
+
+std::string FaceMakerExtrusion::getUserFriendlyName() const
 {
-    BRepCheck_Analyzer aChecker(face);
-    if (!aChecker.IsValid()) {
-        TopoDS_Wire outerwire = ShapeAnalysis::OuterWire(face);
-        TopTools_IndexedMapOfShape myMap;
-        myMap.Add(outerwire);
-
-        TopExp_Explorer xp(face,TopAbs_WIRE);
-        ShapeFix_Wire fix;
-        fix.SetFace(face);
-        fix.Load(outerwire);
-        fix.Perform();
-        BRepBuilderAPI_MakeFace mkFace(fix.WireAPIMake());
-        while (xp.More()) {
-            if (!myMap.Contains(xp.Current())) {
-                fix.Load(TopoDS::Wire(xp.Current()));
-                fix.Perform();
-                mkFace.Add(fix.WireAPIMake());
-            }
-            xp.Next();
-        }
-
-        aChecker.Init(mkFace.Face());
-        if (!aChecker.IsValid()) {
-            ShapeFix_Shape fix(mkFace.Face());
-            fix.SetPrecision(Precision::Confusion());
-            fix.SetMaxTolerance(Precision::Confusion());
-            fix.SetMaxTolerance(Precision::Confusion());
-            fix.Perform();
-            fix.FixWireTool()->Perform();
-            fix.FixFaceTool()->Perform();
-            TopoDS_Face fixedFace = TopoDS::Face(fix.Shape());
-            aChecker.Init(fixedFace);
-            if (!aChecker.IsValid())
-                Standard_Failure::Raise("Failed to validate broken face");
-            return fixedFace;
-        }
-        return mkFace.Face();
-    }
-
-    return face;
+    return std::string(QT_TRANSLATE_NOOP("Part_FaceMaker","Part Extrude facemaker"));
 }
 
-// sort bounding boxes according to diagonal length
-class Extrusion::Wire_Compare : public std::binary_function<const TopoDS_Wire&,
-                                                            const TopoDS_Wire&, bool> {
-public:
-    bool operator() (const TopoDS_Wire& w1, const TopoDS_Wire& w2)
-    {
-        Bnd_Box box1, box2;
-        if (!w1.IsNull()) {
-            BRepBndLib::Add(w1, box1);
-            box1.SetGap(0.0);
-        }
-
-        if (!w2.IsNull()) {
-            BRepBndLib::Add(w2, box2);
-            box2.SetGap(0.0);
-        }
-
-        return box1.SquareExtent() < box2.SquareExtent();
-    }
-};
-
-bool Extrusion::isInside(const TopoDS_Wire& wire1, const TopoDS_Wire& wire2)
+std::string FaceMakerExtrusion::getBriefExplanation() const
 {
-    Bnd_Box box1;
-    BRepBndLib::Add(wire1, box1);
-    box1.SetGap(0.0);
-
-    Bnd_Box box2;
-    BRepBndLib::Add(wire2, box2);
-    box2.SetGap(0.0);
-
-    if (box1.IsOut(box2))
-        return false;
-
-    double prec = Precision::Confusion();
-
-    BRepBuilderAPI_MakeFace mkFace(wire1);
-    if (!mkFace.IsDone())
-        Standard_Failure::Raise("Failed to create a face from wire in sketch");
-    TopoDS_Face face = validateFace(mkFace.Face());
-    BRepAdaptor_Surface adapt(face);
-    IntTools_FClass2d class2d(face, prec);
-    Handle_Geom_Surface surf = new Geom_Plane(adapt.Plane());
-    ShapeAnalysis_Surface as(surf);
-
-    TopExp_Explorer xp(wire2,TopAbs_VERTEX);
-    while (xp.More())  {
-        TopoDS_Vertex v = TopoDS::Vertex(xp.Current());
-        gp_Pnt p = BRep_Tool::Pnt(v);
-        gp_Pnt2d uv = as.ValueOfUV(p, prec);
-        if (class2d.Perform(uv) == TopAbs_IN)
-            return true;
-        // TODO: We can make a check to see if all points are inside or all outside
-        // because otherwise we have some intersections which is not allowed
-        else
-            return false;
-        //xp.Next();
-    }
-
-    return false;
+    return std::string(QT_TRANSLATE_NOOP("Part_FaceMaker","Supports making faces with holes, does not support nesting."));
 }
 
-TopoDS_Shape Extrusion::makeFace(std::list<TopoDS_Wire>& wires)
+void FaceMakerExtrusion::Build()
 {
-    BRepBuilderAPI_MakeFace mkFace(wires.front());
-    const TopoDS_Face& face = mkFace.Face();
-    if (face.IsNull())
-        return face;
-    gp_Dir axis(0,0,1);
-    BRepAdaptor_Surface adapt(face);
-    if (adapt.GetType() == GeomAbs_Plane) {
-        axis = adapt.Plane().Axis().Direction();
-    }
-
-    wires.pop_front();
-    for (std::list<TopoDS_Wire>::iterator it = wires.begin(); it != wires.end(); ++it) {
-        BRepBuilderAPI_MakeFace mkInnerFace(*it);
-        const TopoDS_Face& inner_face = mkInnerFace.Face();
-        if (inner_face.IsNull())
-            return inner_face; // failure
-        gp_Dir inner_axis(0,0,1);
-        BRepAdaptor_Surface adapt(inner_face);
-        if (adapt.GetType() == GeomAbs_Plane) {
-            inner_axis = adapt.Plane().Axis().Direction();
+    this->NotDone();
+    this->myGenerated.Clear();
+    this->myShapesToReturn.clear();
+    this->myShape = TopoDS_Shape();
+    TopoDS_Shape inputShape;
+    if (mySourceShapes.empty())
+        throw Base::Exception("No input shapes!");
+    if (mySourceShapes.size() == 1){
+        inputShape = mySourceShapes[0];
+    } else {
+        TopoDS_Builder builder;
+        TopoDS_Compound cmp;
+        builder.MakeCompound(cmp);
+        for (const TopoDS_Shape& sh: mySourceShapes){
+            builder.Add(cmp, sh);
         }
-        // It seems that orientation is always 'Forward' and we only have to reverse
-        // if the underlying plane have opposite normals.
-        if (axis.Dot(inner_axis) < 0)
-            it->Reverse();
-        mkFace.Add(*it);
+        inputShape = cmp;
     }
-    return validateFace(mkFace.Face());
-}
 
-TopoDS_Shape Extrusion::makeFace(const std::vector<TopoDS_Wire>& w)
-{
-    if (w.empty())
-        return TopoDS_Shape();
+    std::vector<TopoDS_Wire> wires;
+    TopTools_IndexedMapOfShape mapOfWires;
+    TopExp::MapShapes(inputShape, TopAbs_WIRE, mapOfWires);
 
-    //FIXME: Need a safe method to sort wire that the outermost one comes last
-    // Currently it's done with the diagonal lengths of the bounding boxes
-    std::vector<TopoDS_Wire> wires = w;
-    std::sort(wires.begin(), wires.end(), Wire_Compare());
-    std::list<TopoDS_Wire> wire_list;
-    wire_list.insert(wire_list.begin(), wires.rbegin(), wires.rend());
-
-    // separate the wires into several independent faces
-    std::list< std::list<TopoDS_Wire> > sep_wire_list;
-    while (!wire_list.empty()) {
-        std::list<TopoDS_Wire> sep_list;
-        TopoDS_Wire wire = wire_list.front();
-        wire_list.pop_front();
-        sep_list.push_back(wire);
-
-        std::list<TopoDS_Wire>::iterator it = wire_list.begin();
-        while (it != wire_list.end()) {
-            if (isInside(wire, *it)) {
-                sep_list.push_back(*it);
-                it = wire_list.erase(it);
-            }
-            else {
-                ++it;
-            }
+    // if there are no wires then check also for edges
+    if (mapOfWires.IsEmpty()) {
+        TopTools_IndexedMapOfShape mapOfEdges;
+        TopExp::MapShapes(inputShape, TopAbs_EDGE, mapOfEdges);
+        for (int i=1; i<=mapOfEdges.Extent(); i++) {
+            BRepBuilderAPI_MakeWire mkWire(TopoDS::Edge(mapOfEdges.FindKey(i)));
+            wires.push_back(mkWire.Wire());
         }
-
-        sep_wire_list.push_back(sep_list);
-    }
-
-    if (sep_wire_list.size() == 1) {
-        std::list<TopoDS_Wire>& wires = sep_wire_list.front();
-        return makeFace(wires);
-    }
-    else if (sep_wire_list.size() > 1) {
-        TopoDS_Compound comp;
-        BRep_Builder builder;
-        builder.MakeCompound(comp);
-        for (std::list< std::list<TopoDS_Wire> >::iterator it = sep_wire_list.begin(); it != sep_wire_list.end(); ++it) {
-            TopoDS_Shape aFace = makeFace(*it);
-            if (!aFace.IsNull())
-                builder.Add(comp, aFace);
-        }
-
-        return comp;
     }
     else {
-        return TopoDS_Shape(); // error
+        wires.reserve(mapOfWires.Extent());
+        for (int i=1; i<=mapOfWires.Extent(); i++) {
+            wires.push_back(TopoDS::Wire(mapOfWires.FindKey(i)));
+        }
     }
+
+    if (!wires.empty()) {
+        //try {
+            TopoDS_Shape res = FaceMakerCheese::makeFace(wires);
+            if (!res.IsNull())
+                this->myShape = res;
+        //}
+        //catch (...) {
+
+        //}
+    }
+
+    this->Done();
+
+}
+
+
+void Part::Extrusion::setupObject()
+{
+    Part::Feature::setupObject();
+    this->FaceMakerClass.setValue("Part::FaceMakerBullseye"); //default for newly created features
 }

--- a/src/Mod/Part/App/FeatureExtrusion.h
+++ b/src/Mod/Part/App/FeatureExtrusion.h
@@ -27,6 +27,7 @@
 #include <App/PropertyStandard.h>
 #include <App/PropertyUnits.h>
 #include "PartFeature.h"
+#include "FaceMakerCheese.h"
 #include <TopoDS_Face.hxx>
 
 namespace Part
@@ -50,6 +51,7 @@ public:
     App::PropertyBool Symmetric;
     App::PropertyAngle TaperAngle;
     App::PropertyAngle TaperAngleRev;
+    App::PropertyString FaceMakerClass;
 
 
     /**
@@ -64,6 +66,7 @@ public:
         bool solid;
         double taperAngleFwd; //in radians
         double taperAngleRev;
+        std::string faceMakerClass;
         ExtrusionParameters(): lengthFwd(0), lengthRev(0), solid(false), taperAngleFwd(0), taperAngleRev(0) {}// constructor to keep garbage out
     };
 
@@ -117,15 +120,29 @@ public: //mode enumerations
     };
     static const char* eDirModeStrings[];
 
-private:
-    static bool isInside(const TopoDS_Wire&, const TopoDS_Wire&);
-    static TopoDS_Face validateFace(const TopoDS_Face&);
-    static TopoDS_Shape makeFace(const std::vector<TopoDS_Wire>&);
-    static TopoDS_Shape makeFace(std::list<TopoDS_Wire>&); // for internal use only
+protected:
     static void makeDraft(ExtrusionParameters params, const TopoDS_Shape&, std::list<TopoDS_Shape>&);
 
-private:
-    class Wire_Compare;
+
+protected:
+    virtual void setupObject() override;
+};
+
+/**
+ * @brief FaceMakerExtrusion provides legacy compounding-structure-ignorant behavior of facemaker of Part Extrude.
+ * Strengths: makes faces with holes
+ * Weaknesses: can't make islands in holes. Ignores compounding nesting. All faces must be on same plane.
+ */
+class FaceMakerExtrusion: public FaceMakerCheese
+{
+    TYPESYSTEM_HEADER();
+public:
+    virtual std::string getUserFriendlyName() const override;
+    virtual std::string getBriefExplanation() const override;
+
+    virtual void Build() override;
+protected:
+    virtual void Build_Essence() override {};
 };
 
 } //namespace Part

--- a/src/Mod/Part/App/FeatureFace.cpp
+++ b/src/Mod/Part/App/FeatureFace.cpp
@@ -44,6 +44,7 @@
 #include <Base/Placement.h>
 
 #include "FeatureFace.h"
+#include "FaceMaker.h"
 #include <Mod/Part/App/Part2DObject.h>
 
 
@@ -55,14 +56,23 @@ PROPERTY_SOURCE(Part::Face, Part::Feature)
 Face::Face()
 {
     ADD_PROPERTY(Sources,(0));
+    ADD_PROPERTY(FaceMakerClass,("Part::FaceMakerCheese"));//default value here is for legacy documents. Default for new objects is set in setupObject.
     Sources.setSize(0);
 }
 
 short Face::mustExecute() const
 {
+    if (FaceMakerClass.isTouched())
+        return 1;
     if (Sources.isTouched())
         return 1;
     return Part::Feature::mustExecute();
+}
+
+void Face::setupObject()
+{
+    this->FaceMakerClass.setValue("Part::FaceMakerBullseye");
+    Feature::setupObject();
 }
 
 App::DocumentObjectExecReturn *Face::execute(void)
@@ -71,10 +81,12 @@ App::DocumentObjectExecReturn *Face::execute(void)
     if (links.empty())
         return new App::DocumentObjectExecReturn("No shapes linked");
 
-    std::vector<TopoDS_Wire> wires;
+    std::unique_ptr<FaceMaker> fm_instance = FaceMaker::ConstructFromType(this->FaceMakerClass.getValue());
+    FaceMaker* facemaker = &(*(fm_instance));
+
     for (std::vector<App::DocumentObject*>::iterator it = links.begin(); it != links.end(); ++it) {
-        if (!(*it && (*it)->isDerivedFrom(Part::Part2DObject::getClassTypeId())))
-            return new App::DocumentObjectExecReturn("Linked object is not a Sketch or Part2DObject");
+        if (!(*it && (*it)->isDerivedFrom(Part::Feature::getClassTypeId())))
+            return new App::DocumentObjectExecReturn("Linked object is not a Part object (has no Shape).");
         TopoDS_Shape shape = static_cast<Part::Part2DObject*>(*it)->Shape.getShape().getShape();
         if (shape.IsNull())
             return new App::DocumentObjectExecReturn("Linked shape object is empty");
@@ -82,139 +94,26 @@ App::DocumentObjectExecReturn *Face::execute(void)
         // this is a workaround for an obscure OCC bug which leads to empty tessellations
         // for some faces. Making an explicit copy of the linked shape seems to fix it.
         // The error only happens when re-computing the shape.
-        if (!this->Shape.getValue().IsNull()) {
+        /*if (!this->Shape.getValue().IsNull()) {
             BRepBuilderAPI_Copy copy(shape);
             shape = copy.Shape();
             if (shape.IsNull())
                 return new App::DocumentObjectExecReturn("Linked shape object is empty");
-        }
+        }*/
 
-        TopExp_Explorer ex;
-        for (ex.Init(shape, TopAbs_WIRE); ex.More(); ex.Next()) {
-            wires.push_back(TopoDS::Wire(ex.Current()));
-        }
+        if(links.size() == 1 && shape.ShapeType() == TopAbs_COMPOUND)
+            facemaker->useCompound(TopoDS::Compound(shape));
+        else
+            facemaker->addShape(shape);
     }
 
-    if (wires.empty()) // there can be several wires
-        return new App::DocumentObjectExecReturn("Linked shape object is not a wire");
+    facemaker->Build();
 
-    TopoDS_Shape aFace = makeFace(wires);
+    TopoDS_Shape aFace = facemaker->Shape();
     if (aFace.IsNull())
-        return new App::DocumentObjectExecReturn("Creating a face from sketch failed");
+        return new App::DocumentObjectExecReturn("Creating face failed (null shape result)");
     this->Shape.setValue(aFace);
 
     return App::DocumentObject::StdReturn;
-}
-
-// sort bounding boxes according to diagonal length
-class Face::Wire_Compare {
-public:
-    bool operator() (const TopoDS_Wire& w1, const TopoDS_Wire& w2)
-    {
-        Bnd_Box box1, box2;
-        if (!w1.IsNull()) {
-            BRepBndLib::Add(w1, box1);
-            box1.SetGap(0.0);
-        }
-
-        if (!w2.IsNull()) {
-            BRepBndLib::Add(w2, box2);
-            box2.SetGap(0.0);
-        }
-
-        return box1.SquareExtent() < box2.SquareExtent();
-    }
-};
-
-TopoDS_Shape Face::makeFace(std::list<TopoDS_Wire>& wires) const
-{
-    BRepBuilderAPI_MakeFace mkFace(wires.front());
-    const TopoDS_Face& face = mkFace.Face();
-    if (face.IsNull())
-        return face;
-    gp_Dir axis(0,0,1);
-    BRepAdaptor_Surface adapt(face);
-    if (adapt.GetType() == GeomAbs_Plane) {
-        axis = adapt.Plane().Axis().Direction();
-    }
-
-    wires.pop_front();
-    for (std::list<TopoDS_Wire>::iterator it = wires.begin(); it != wires.end(); ++it) {
-        BRepBuilderAPI_MakeFace mkInnerFace(*it);
-        const TopoDS_Face& inner_face = mkInnerFace.Face();
-        gp_Dir inner_axis(0,0,1);
-        BRepAdaptor_Surface adapt(inner_face);
-        if (adapt.GetType() == GeomAbs_Plane) {
-            inner_axis = adapt.Plane().Axis().Direction();
-        }
-        // It seems that orientation is always 'Forward' and we only have to reverse
-        // if the underlying plane have opposite normals. 
-        if (axis.Dot(inner_axis) < 0)
-            it->Reverse();
-        mkFace.Add(*it);
-    }
-    return mkFace.Face();
-}
-
-TopoDS_Shape Face::makeFace(const std::vector<TopoDS_Wire>& w) const
-{
-    if (w.empty())
-        return TopoDS_Shape();
-
-    //FIXME: Need a safe method to sort wire that the outermost one comes last
-    // Currently it's done with the diagonal lengths of the bounding boxes
-    std::vector<TopoDS_Wire> wires = w;
-    std::sort(wires.begin(), wires.end(), Wire_Compare());
-    std::list<TopoDS_Wire> wire_list;
-    wire_list.insert(wire_list.begin(), wires.rbegin(), wires.rend());
-
-    // separate the wires into several independent faces
-    std::list< std::list<TopoDS_Wire> > sep_wire_list;
-    while (!wire_list.empty()) {
-        std::list<TopoDS_Wire> sep_list;
-        TopoDS_Wire wire = wire_list.front();
-        wire_list.pop_front();
-        sep_list.push_back(wire);
-
-        Bnd_Box box;
-        BRepBndLib::Add(wire, box);
-        box.SetGap(0.0);
-
-        std::list<TopoDS_Wire>::iterator it = wire_list.begin();
-        while (it != wire_list.end()) {
-            Bnd_Box box2;
-            BRepBndLib::Add(*it, box2);
-            box2.SetGap(0.0);
-            if (!box.IsOut(box2)) {
-                sep_list.push_back(*it);
-                it = wire_list.erase(it);
-            }
-            else {
-                ++it;
-            }
-        }
-
-        sep_wire_list.push_back(sep_list);
-    }
-
-    if (sep_wire_list.size() == 1) {
-        std::list<TopoDS_Wire>& wires = sep_wire_list.front();
-        return makeFace(wires);
-    }
-    else if (sep_wire_list.size() > 1) {
-        TopoDS_Compound comp;
-        BRep_Builder builder;
-        builder.MakeCompound(comp);
-        for (std::list< std::list<TopoDS_Wire> >::iterator it = sep_wire_list.begin(); it != sep_wire_list.end(); ++it) {
-            TopoDS_Shape aFace = makeFace(*it);
-            if (!aFace.IsNull())
-                builder.Add(comp, aFace);
-        }
-
-        return comp;
-    }
-    else {
-        return TopoDS_Shape(); // error
-    }
 }
 

--- a/src/Mod/Part/App/FeatureFace.h
+++ b/src/Mod/Part/App/FeatureFace.h
@@ -37,6 +37,7 @@ public:
     Face();
 
     App::PropertyLinkList   Sources;
+    App::PropertyString FaceMakerClass;
 
     /** @name methods override feature */
     //@{
@@ -47,14 +48,8 @@ public:
     const char* getViewProviderName(void) const {
         return "PartGui::ViewProviderFace";
     }
+    void setupObject() override;
     //@}
-
-protected:
-    TopoDS_Shape makeFace(const std::vector<TopoDS_Wire>&) const;
-    TopoDS_Shape makeFace(std::list<TopoDS_Wire>&) const; // for internal use only
-
-private:
-    class Wire_Compare;
 };
 
 } //namespace Part

--- a/src/Mod/Part/App/FeatureRevolution.cpp
+++ b/src/Mod/Part/App/FeatureRevolution.cpp
@@ -35,6 +35,7 @@
 #include <Base/Tools.h>
 #include <Base/Exception.h>
 #include <App/Application.h>
+#include "FaceMaker.h"
 
 using namespace Part;
 
@@ -52,6 +53,7 @@ Revolution::Revolution()
     Angle.setConstraints(&angleRangeU);
     ADD_PROPERTY_TYPE(Symmetric,(false),"Revolve",App::Prop_None,"Extend revolution symmetrically from the profile.");
     ADD_PROPERTY_TYPE(Solid,(false),"Revolve",App::Prop_None,"Make revolution a solid if possible");
+    ADD_PROPERTY_TYPE(FaceMakerClass,(""),"Revolve",App::Prop_None,"Facemaker to use if Solid is true."); //default for old documents. For default for new objects, refer to setupObject().
 }
 
 short Revolution::mustExecute() const
@@ -62,7 +64,8 @@ short Revolution::mustExecute() const
         Source.isTouched() ||
         Solid.isTouched() ||
         AxisLink.isTouched() ||
-        Symmetric.isTouched())
+        Symmetric.isTouched() ||
+        FaceMakerClass.isTouched())
         return 1;
     return 0;
 }
@@ -165,6 +168,21 @@ App::DocumentObjectExecReturn *Revolution::execute(void)
 
         //do it!
         Standard_Boolean makeSolid = Solid.getValue() ? Standard_True : Standard_False;
+        if (makeSolid && strlen(this->FaceMakerClass.getValue())>0){
+            //new facemaking behavior: use facemaker class
+            std::unique_ptr<FaceMaker> fm_instance = FaceMaker::ConstructFromType(this->FaceMakerClass.getValue());
+            FaceMaker* mkFace = &(*(fm_instance));
+            TopoDS_Shape myShape = sourceShape.getShape();
+            if(myShape.ShapeType() == TopAbs_COMPOUND)
+                mkFace->useCompound(TopoDS::Compound(myShape));
+            else
+                mkFace->addShape(myShape);
+            mkFace->Build();
+            myShape = mkFace->Shape();
+            sourceShape = TopoShape(myShape);
+
+            makeSolid = Standard_False;//don't ask TopoShape::revolve to make solid, as we've made faces...
+        }
         TopoDS_Shape revolve = sourceShape.revolve(revAx, angle, makeSolid);
 
         if (revolve.IsNull())
@@ -176,4 +194,12 @@ App::DocumentObjectExecReturn *Revolution::execute(void)
         Handle_Standard_Failure e = Standard_Failure::Caught();
         return new App::DocumentObjectExecReturn(e->GetMessageString());
     }
+}
+
+
+
+void Part::Revolution::setupObject()
+{
+    Part::Feature::setupObject();
+    this->FaceMakerClass.setValue("Part::FaceMakerBullseye"); //default for newly created features
 }

--- a/src/Mod/Part/App/FeatureRevolution.h
+++ b/src/Mod/Part/App/FeatureRevolution.h
@@ -45,6 +45,7 @@ public:
     App::PropertyFloatConstraint Angle;
     App::PropertyBool Symmetric; //like "Midplane" in PartDesign
     App::PropertyBool Solid;
+    App::PropertyString FaceMakerClass;
 
     /** @name methods override feature */
     //@{
@@ -79,6 +80,9 @@ public:
 
 private:
     static App::PropertyFloatConstraint::Constraints angleRangeU;
+
+protected:
+    virtual void setupObject();
 };
 
 } //namespace Part

--- a/src/Mod/Part/App/TopoShape.h
+++ b/src/Mod/Part/App/TopoShape.h
@@ -191,6 +191,7 @@ public:
     TopoDS_Shape makePipeShell(const TopTools_ListOfShape& profiles, const Standard_Boolean make_solid,
         const Standard_Boolean isFrenet = Standard_False, int transition=0) const;
     TopoDS_Shape makePrism(const gp_Vec&) const;
+    ///revolve shape. Note: isSolid is deprecated (instead, use some Part::FaceMaker to make a face, first).
     TopoDS_Shape revolve(const gp_Ax1&, double d, Standard_Boolean isSolid=Standard_False) const;
     TopoDS_Shape makeSweep(const TopoDS_Shape& profile, double, int) const;
     TopoDS_Shape makeTube(double radius, double tol, int cont, int maxdeg, int maxsegm) const;

--- a/src/Mod/Part/App/TopoShapeFacePy.xml
+++ b/src/Mod/Part/App/TopoShapeFacePy.xml
@@ -16,7 +16,7 @@
 		</Documentation>
 		<Methode Name="makeOffset" Const="true">
 			<Documentation>
-				<UserDocu>Offset the shape by a given ammount</UserDocu>
+				<UserDocu>Offset the face by a given ammount. Returns Compound of Wires. Deprecated - use makeOffset2D instead.</UserDocu>
 			</Documentation>
 		</Methode>
 		<Methode Name="tangentAt" Const="true">

--- a/src/Mod/Part/Gui/Command.cpp
+++ b/src/Mod/Part/Gui/Command.cpp
@@ -1515,6 +1515,7 @@ void CmdPartOffset::activated(int iMsg)
     doCommand(Doc,"App.ActiveDocument.%s.Source = App.ActiveDocument.%s" ,offset.c_str(), shape->getNameInDocument());
     doCommand(Doc,"App.ActiveDocument.%s.Value = 1.0",offset.c_str());
     updateActive();
+    doCommand(Gui,"Gui.ActiveDocument.%s.DisplayMode = 'Wireframe'", shape->getNameInDocument());
     //if (isActiveObjectValid())
     //    doCommand(Gui,"Gui.ActiveDocument.hide(\"%s\")",shape->getNameInDocument());
     doCommand(Gui,"Gui.ActiveDocument.setEdit('%s')",offset.c_str());

--- a/src/Mod/Part/Gui/Command.cpp
+++ b/src/Mod/Part/Gui/Command.cpp
@@ -1208,8 +1208,8 @@ CmdPartMakeFace::CmdPartMakeFace()
 {
     sAppModule    = "Part";
     sGroup        = QT_TR_NOOP("Part");
-    sMenuText     = QT_TR_NOOP("Make face from sketch");
-    sToolTipText  = QT_TR_NOOP("Make face from selected sketches");
+    sMenuText     = QT_TR_NOOP("Make face from wires");
+    sToolTipText  = QT_TR_NOOP("Part_MakeFace: Make face from set of wires (e.g., from a sketch).");
     sWhatsThis    = "Part_MakeFace";
     sStatusTip    = sToolTipText;
 }
@@ -1217,7 +1217,7 @@ CmdPartMakeFace::CmdPartMakeFace()
 void CmdPartMakeFace::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
-    std::vector<Part::Part2DObject*> sketches = Gui::Selection().getObjectsOfType<Part::Part2DObject>();
+    std::vector<Part::Feature*> sketches = Gui::Selection().getObjectsOfType<Part::Feature>();
     openCommand("Make face");
 
     try {
@@ -1225,7 +1225,7 @@ void CmdPartMakeFace::activated(int iMsg)
         std::stringstream str;
         str << doc.getDocumentPython()
             << ".addObject(\"Part::Face\", \"Face\").Sources = (";
-        for (std::vector<Part::Part2DObject*>::iterator it = sketches.begin(); it != sketches.end(); ++it) {
+        for (std::vector<Part::Feature*>::iterator it = sketches.begin(); it != sketches.end(); ++it) {
             App::DocumentObjectT obj(*it);
             str << obj.getObjectPython() << ", ";
         }
@@ -1244,7 +1244,7 @@ void CmdPartMakeFace::activated(int iMsg)
 
 bool CmdPartMakeFace::isActive(void)
 {
-    return (Gui::Selection().countObjectsOfType(Part::Part2DObject::getClassTypeId()) > 0 &&
+    return (Gui::Selection().countObjectsOfType(Part::Feature::getClassTypeId()) > 0 &&
             !Gui::Control().activeDialog());
 }
 

--- a/src/Mod/PartDesign/App/FeatureLoft.cpp
+++ b/src/Mod/PartDesign/App/FeatureLoft.cpp
@@ -42,6 +42,7 @@
 #include <Base/Console.h>
 #include <Base/Reader.h>
 #include <App/Document.h>
+#include <Mod/Part/App/FaceMakerCheese.h>
 
 //#include "Body.h"
 #include "FeatureLoft.h"
@@ -151,7 +152,7 @@ App::DocumentObjectExecReturn *Loft::execute(void)
         for(std::vector<TopoDS_Wire>& wires : wiresections)
             backwires.push_back(wires.back());
         
-        TopoDS_Shape back = makeFace(backwires);
+        TopoDS_Shape back = Part::FaceMakerCheese::makeFace(backwires);
         
         BRepBuilderAPI_Sewing sewer;
         sewer.SetTolerance(Precision::Confusion());

--- a/src/Mod/PartDesign/App/FeaturePipe.cpp
+++ b/src/Mod/PartDesign/App/FeaturePipe.cpp
@@ -63,6 +63,7 @@
 #include <Base/Console.h>
 #include <Base/Reader.h>
 #include <App/Document.h>
+#include <Mod/Part/App/FaceMakerCheese.h>
 
 //#include "Body.h"
 #include "FeaturePipe.h"
@@ -256,8 +257,8 @@ App::DocumentObjectExecReturn *Pipe::execute(void)
         }
         
         //build the top and bottom face, sew the shell and build the final solid
-        TopoDS_Shape front = makeFace(frontwires);
-        TopoDS_Shape back  = makeFace(backwires);
+        TopoDS_Shape front = Part::FaceMakerCheese::makeFace(frontwires);
+        TopoDS_Shape back  = Part::FaceMakerCheese::makeFace(backwires);
         
         BRepBuilderAPI_Sewing sewer;
         sewer.SetTolerance(Precision::Confusion());

--- a/src/Mod/PartDesign/App/FeatureSketchBased.cpp
+++ b/src/Mod/PartDesign/App/FeatureSketchBased.cpp
@@ -77,6 +77,7 @@
 #include <App/OriginFeature.h>
 #include <App/Document.h>
 #include <Mod/Part/App/modelRefine.h>
+#include <Mod/Part/App/FaceMakerCheese.h>
 #include "FeatureSketchBased.h"
 #include "DatumPlane.h"
 #include "DatumLine.h"
@@ -203,7 +204,7 @@ TopoDS_Shape ProfileBased::getVerifiedFace(bool silent) const {
         if (result->getTypeId().isDerivedFrom(Part::Part2DObject::getClassTypeId())) {
             
             auto wires = getProfileWires();
-            return makeFace(wires);
+            return Part::FaceMakerCheese::makeFace(wires);
         }
         else if(result->getTypeId().isDerivedFrom(Part::Feature::getClassTypeId())) {
             if(Profile.getSubValues().empty())
@@ -373,195 +374,6 @@ void ProfileBased::onChanged(const App::Property* prop)
     FeatureAddSub::onChanged(prop);
 }
 
-bool ProfileBased::isInside(const TopoDS_Wire& wire1, const TopoDS_Wire& wire2) const
-{
-    Bnd_Box box1;
-    BRepBndLib::Add(wire1, box1);
-    box1.SetGap(0.0);
-
-    Bnd_Box box2;
-    BRepBndLib::Add(wire2, box2);
-    box2.SetGap(0.0);
-
-    if (box1.IsOut(box2))
-        return false;
-
-    double prec = Precision::Confusion();
-
-    BRepBuilderAPI_MakeFace mkFace(wire1);
-    if (!mkFace.IsDone())
-        Standard_Failure::Raise("Failed to create a face from wire in sketch");
-    TopoDS_Face face = validateFace(mkFace.Face());
-    BRepAdaptor_Surface adapt(face);
-    IntTools_FClass2d class2d(face, prec);
-    Handle_Geom_Surface surf = new Geom_Plane(adapt.Plane());
-    ShapeAnalysis_Surface as(surf);
-
-    TopExp_Explorer xp(wire2,TopAbs_VERTEX);
-    while (xp.More())  {
-        TopoDS_Vertex v = TopoDS::Vertex(xp.Current());
-        gp_Pnt p = BRep_Tool::Pnt(v);
-        gp_Pnt2d uv = as.ValueOfUV(p, prec);
-        if (class2d.Perform(uv) == TopAbs_IN)
-            return true;
-        // TODO: We can make a check to see if all points are inside or all outside
-        // because otherwise we have some intersections which is not allowed
-        else
-            return false;
-        xp.Next();
-    }
-
-    return false;
-}
-
-TopoDS_Face ProfileBased::validateFace(const TopoDS_Face& face) const
-{
-    BRepCheck_Analyzer aChecker(face);
-    if (!aChecker.IsValid()) {
-        TopoDS_Wire outerwire = ShapeAnalysis::OuterWire(face);
-        TopTools_IndexedMapOfShape myMap;
-        myMap.Add(outerwire);
-
-        TopExp_Explorer xp(face,TopAbs_WIRE);
-        ShapeFix_Wire fix;
-        fix.SetFace(face);
-        fix.Load(outerwire);
-        fix.Perform();
-        BRepBuilderAPI_MakeFace mkFace(fix.WireAPIMake());
-        while (xp.More()) {
-            if (!myMap.Contains(xp.Current())) {
-                fix.Load(TopoDS::Wire(xp.Current()));
-                fix.Perform();
-                mkFace.Add(fix.WireAPIMake());
-            }
-            xp.Next();
-        }
-
-        aChecker.Init(mkFace.Face());
-        if (!aChecker.IsValid()) {
-            ShapeFix_Shape fix(mkFace.Face());
-            fix.SetPrecision(Precision::Confusion());
-            fix.SetMaxTolerance(Precision::Confusion());
-            fix.SetMaxTolerance(Precision::Confusion());
-            fix.Perform();
-            fix.FixWireTool()->Perform();
-            fix.FixFaceTool()->Perform();
-            TopoDS_Face fixedFace = TopoDS::Face(fix.Shape());
-            aChecker.Init(fixedFace);
-            if (!aChecker.IsValid())
-                Standard_Failure::Raise("Failed to validate broken face");
-            return fixedFace;
-        }
-        return mkFace.Face();
-    }
-
-    return face;
-}
-
-TopoDS_Shape ProfileBased::makeFace(std::list<TopoDS_Wire>& wires) const
-{
-    BRepBuilderAPI_MakeFace mkFace(wires.front());
-    const TopoDS_Face& face = mkFace.Face();
-    if (face.IsNull())
-        return face;
-    gp_Dir axis(0,0,1);
-    BRepAdaptor_Surface adapt(face);
-    if (adapt.GetType() == GeomAbs_Plane) {
-        axis = adapt.Plane().Axis().Direction();
-    }
-
-    wires.pop_front();
-    for (std::list<TopoDS_Wire>::iterator it = wires.begin(); it != wires.end(); ++it) {
-        BRepBuilderAPI_MakeFace mkInnerFace(*it);
-        const TopoDS_Face& inner_face = mkInnerFace.Face();
-        if (inner_face.IsNull())
-            return inner_face; // failure
-        gp_Dir inner_axis(0,0,1);
-        BRepAdaptor_Surface adapt(inner_face);
-        if (adapt.GetType() == GeomAbs_Plane) {
-            inner_axis = adapt.Plane().Axis().Direction();
-        }
-        // It seems that orientation is always 'Forward' and we only have to reverse
-        // if the underlying plane have opposite normals.
-        if (axis.Dot(inner_axis) < 0)
-            it->Reverse();
-        mkFace.Add(*it);
-    }
-    return validateFace(mkFace.Face());
-}
-
-TopoDS_Shape ProfileBased::makeFace(const std::vector<TopoDS_Wire>& w) const
-{
-    if (w.empty())
-        return TopoDS_Shape();
-
-    //FIXME: Need a safe method to sort wire that the outermost one comes last
-    // Currently it's done with the diagonal lengths of the bounding boxes
-#if 1
-    std::vector<TopoDS_Wire> wires = w;
-    std::sort(wires.begin(), wires.end(), Wire_Compare());
-    std::list<TopoDS_Wire> wire_list;
-    wire_list.insert(wire_list.begin(), wires.rbegin(), wires.rend());
-#else
-    //bug #0001133: try alternative sort algorithm
-    std::list<TopoDS_Wire> unsorted_wire_list;
-    unsorted_wire_list.insert(unsorted_wire_list.begin(), w.begin(), w.end());
-    std::list<TopoDS_Wire> wire_list;
-    Wire_Compare wc;
-    while (!unsorted_wire_list.empty()) {
-        std::list<TopoDS_Wire>::iterator w_ref = unsorted_wire_list.begin();
-        std::list<TopoDS_Wire>::iterator w_it = unsorted_wire_list.begin();
-        for (++w_it; w_it != unsorted_wire_list.end(); ++w_it) {
-            if (wc(*w_ref, *w_it))
-                w_ref = w_it;
-        }
-        wire_list.push_back(*w_ref);
-        unsorted_wire_list.erase(w_ref);
-    }
-#endif
-
-    // separate the wires into several independent faces
-    std::list< std::list<TopoDS_Wire> > sep_wire_list;
-    while (!wire_list.empty()) {
-        std::list<TopoDS_Wire> sep_list;
-        TopoDS_Wire wire = wire_list.front();
-        wire_list.pop_front();
-        sep_list.push_back(wire);
-
-        std::list<TopoDS_Wire>::iterator it = wire_list.begin();
-        while (it != wire_list.end()) {
-            if (isInside(wire, *it)) {
-                sep_list.push_back(*it);
-                it = wire_list.erase(it);
-            }
-            else {
-                ++it;
-            }
-        }
-
-        sep_wire_list.push_back(sep_list);
-    }
-
-    if (sep_wire_list.size() == 1) {
-        std::list<TopoDS_Wire>& wires = sep_wire_list.front();
-        return makeFace(wires);
-    }
-    else if (sep_wire_list.size() > 1) {
-        TopoDS_Compound comp;
-        BRep_Builder builder;
-        builder.MakeCompound(comp);
-        for (std::list< std::list<TopoDS_Wire> >::iterator it = sep_wire_list.begin(); it != sep_wire_list.end(); ++it) {
-            TopoDS_Shape aFace = makeFace(*it);
-            if (!aFace.IsNull())
-                builder.Add(comp, aFace);
-        }
-
-        return comp;
-    }
-    else {
-        return TopoDS_Shape(); // error
-    }
-}
 
 void ProfileBased::getUpToFaceFromLinkSub(TopoDS_Face& upToFace,
                                          const App::PropertyLinkSub& refFace)

--- a/src/Mod/PartDesign/App/FeatureSketchBased.h
+++ b/src/Mod/PartDesign/App/FeatureSketchBased.h
@@ -151,14 +151,9 @@ protected:
     /// get Axis from ReferenceAxis
     void getAxis(const App::DocumentObject* pcReferenceAxis, const std::vector<std::string>& subReferenceAxis,
                  Base::Vector3d& base, Base::Vector3d& dir);
-    
-    TopoDS_Shape makeFace(const std::vector<TopoDS_Wire>&) const;
-    
+        
 private:
     void onChanged(const App::Property* prop);
-    TopoDS_Face validateFace(const TopoDS_Face&) const;
-    TopoDS_Shape makeFace(std::list<TopoDS_Wire>&) const; // for internal use only    
-    bool isInside(const TopoDS_Wire&, const TopoDS_Wire&) const;
     bool isParallelPlane(const TopoDS_Shape&, const TopoDS_Shape&) const;
     bool isEqualGeometry(const TopoDS_Shape&, const TopoDS_Shape&) const;
     bool isQuasiEqual(const TopoDS_Shape&, const TopoDS_Shape&) const;

--- a/src/Mod/PartDesign/App/PreCompiled.h
+++ b/src/Mod/PartDesign/App/PreCompiled.h
@@ -37,6 +37,13 @@
 # define MeshExport   
 #endif
 
+#ifdef _MSC_VER
+// disable warning triggered by use of Part::FaceMaker
+// see forum thread "Warning C4275 non-dll class used as base for dll class"
+// http://forum.freecadweb.org/viewtopic.php?f=10&t=17542
+#   pragma warning( disable : 4275)
+#endif
+
 #ifdef _PreComp_
 
 // standard


### PR DESCRIPTION
Summary.
From user side:
1. Part MakeFaceFromSketch, Part Extrude and Part Revolve now use the new "bullseye" facemaker by default. I have introduced a property "FaceMakerClass" to them, to handle legacy documents, as well as allow to alter the facemaker if necessary.
2. Part MakeFaceFromSketch now accepts any feature as input, not just sketches as it used to (and was renamed to "make face from wires" to reflect that).
3. Part 2D Offset now supports planar faces as input. I also implemented offset filling for collective offset (when "Intersection" ticked). Some orientations of faces generated by offset filling have changed, so some projects that relied on it might break (Part Extrude along normal).

From Python side:
1. Part.Shape.makeOffset2D has changed in the same way as Part 2D Offset feature (they are the same thing).
2. Part.Face() constructor now has argument footprints to accept a facemaker class name as string. 
3. I introduced Part.makeFace(shape_or_list_of_shapes, facemaker_class_name) method, for the cases where more than one face results (return type is then a Compound, not Face, so it can't be a constructor of Face).

From C++ side:
1. FaceMaker class introduced, to serve as base for facemaking routines.
2. Actual facemakers introduced: FaceMakerSimple, FaceMakerCheese (was part of Part Extrude), FaceMakerExtrusion (special for retaining legacy behavior of Part Extrude), FaceMakerBullseye (the new one!)
3. PartDesign facemaker was deleted, and relevant calls redirected to FaceMakerCheese functions. Hopefully I didn't break anything

![offset-face-example](https://cloud.githubusercontent.com/assets/8940427/18846913/14793308-8439-11e6-9437-eb7dd485b559.png)

(on picture: Part Offset2D applied to faces - this is achieved in just one step from [example project of Part Slice](http://www.freecadweb.org/wiki/index.php?title=Part_Slice#Example:_making_puzzle))

Things I thought of, but decided to leave for future:
* UI for selecting FaceMakerClass of Part Face
* Py API for getting list of facemakers. Maybe, Py binding of FaceMaker.
* Proper visibility automation for Part 2D Offset task dialog.
* More FaceMakers (e.g., non-planar, mosaic)
* Tests

Forum threads:
[General FaceMakers](http://forum.freecadweb.org/viewtopic.php?f=10&t=17528)
[BRepBuilderAPI_FindPlane vs BRepLib_FindSurface](http://forum.freecadweb.org/viewtopic.php?f=10&t=17592)
[Warning C4275 non-dll class used as base for dll class](http://forum.freecadweb.org/viewtopic.php?f=10&t=17542)
[PR #292 - FaceMakers](http://forum.freecadweb.org/viewtopic.php?f=17&t=17632)