### PR TITLE
Unpickable support for TempoVis

### DIFF
--- a/src/Mod/Part/AttachmentEditor/TaskAttachmentEditor.py
+++ b/src/Mod/Part/AttachmentEditor/TaskAttachmentEditor.py
@@ -291,6 +291,8 @@ class AttachmentEditorTaskPanel(FrozenClass):
         if self.tv: # tv will still be None if Show module is unavailable
             self.tv.hide_all_dependent(self.obj)
             self.tv.show(self.obj)
+            self.tv.setUnpickable(self.obj)
+            self.tv.modifyVPProperty(self.obj, "Transparency", 70)
             self.tv.show([obj for (obj,subname) in self.attacher.References])
     
     # task dialog handling

--- a/src/Mod/Show/DepGraphTools.py
+++ b/src/Mod/Show/DepGraphTools.py
@@ -74,7 +74,7 @@ def isContainer(obj):
     
     if obj.isDerivedFrom("App::DocumentObjectGroup"):
         return True
-    if obj.isDerivedFrom("PartDesign::Body"):
+    if obj.isDerivedFrom("Part::BodyBase"):
         return True
     if obj.isDerivedFrom("App::Origin"):
         return True


### PR DESCRIPTION
* added new method "setUnpickable" to TempoVis. It makes specified objects transparent to clicks, which is very useful for attachment dialog.
* use "setUnpickable" in Part Attachment Editor + make object being attached transparent
* small tweak to Body container detection in TempoVis (test for deriving from Part::BodyBase instead of PartDesign::Body)

The last point is for myself, as I use my custom branch of FreeCAD where there is another kind of Body container. It doesn't change the behavior of master FreeCAD.

--inspired by http://forum.freecadweb.org/viewtopic.php?f=22&t=17684