### PR TITLE
Improved macOS CI builds (declarative dependencies, robust ports-cach…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,30 +24,26 @@ env:
     - CMAKE_OPTS="-DBUILD_FEM_NETGEN=ON"
 
 cache:
-    - ccache
+    ccache: true
 
 language: cpp
-
-compiler:
-   - clang
-   - gcc
-
 python: 2.7
-
-os:
-   - linux
-   - osx
-
+os: linux
 dist: trusty
 sudo: required
+compiler:
+    - clang
+    - gcc
 
+# Inject osx build into matrix - needed to specify image/dist
 matrix:
-   exclude:
-     - os: osx
-       compiler: gcc
+    include:
+      - os: osx
+        osx_image: xcode6.4
+        compiler: clang
 
 git:
-  depth: 1500
+  depth: 5000
 
 notifications:
   email:
@@ -124,42 +120,30 @@ before_install:
 
    "osx")
        brew update >/dev/null
+       xcodebuild -version -sdk
+       brew --config
        if [ "${OSX_PORTS_CACHE}X" != "X" ]; then
             brew install jq
             cacheContext=$(create_helper_context repo=${OSX_PORTS_CACHE} auth_token=${GH_TOKEN} release=${FREECAD_RELEASE})
             prime_local_ports_cache $cacheContext
        fi
-       brew install cmake                       \
-                    ccache                      \
-                    eigen                       \
-                    freetype                    \
-                    qt                          \
-                    python                      \
-                    boost-python                \
-                    pyside                      \
-                    pyside-tools                \
-                    xerces-c                    \
-                    homebrew/science/orocos-kdl \
-                    homebrew/python/matplotlib
-       brew install sanelson/freecad/coin --without-framework --without-soqt
-       brew install sanelson/freecad/pivy --HEAD
-       brew install bblacey/taps/med-file --without-python
 
-       #Install ports bottled with FreeCAD specific options and hosted on FreeCAD-ports-cache
-       brew untap homebrew/science && brew tap bblacey/science
-       brew install --force-bottle vtk --without-python
-       brew install --force-bottle opencascade --without-extras
-       brew install --force-bottle nglib --with-opencascade
+       brew tap FreeCAD/freecad
+       brew install --verbose --only-dependencies freecad --with-freecad-bottles
+       brew install --verbose --only-dependencies freecad --with-freecad-bottles #Ensure all dependencies are satisfied
 
        #Install the 3DConnexion frameworks
        if [ ! -d /Library/Frameworks/3DconnexionClient.framework ]; then
-          curl -o /tmp/3dFW.dmg -L 'http://www.3dconnexion.com/index.php?eID=sdl&ext=tx_iccsoftware&oid=a273bdbc-c289-e10d-816b-567043331c9e&filename=3DxWareMac_v10-2-5_r2142.dmg'
+          curl -o /tmp/3dFW.dmg -L 'http://www.3dconnexion.com/index.php?eID=sdl&ext=tx_iccsoftware&oid=a273bdbc-c289-e10d-816b-567043331c9e&filename=3DxWareMac_v10-4-1_r2428.dmg'
           hdiutil attach -readonly /tmp/3dFW.dmg
           sudo installer -package /Volumes/3Dconnexion\ Software/Install\ 3Dconnexion\ software.pkg -target /
        fi
 
        #Remove GDAL if installed because it results in non-existent dependent library exceptions
        if [ -e /usr/local/lib/libgdal.1.dylib ]; then brew unlink gdal; fi
+
+       #Remove conflicting nglib formula that confuses cmake
+       rm $(brew --repository homebrew/science)/nglib.rb
 
        export CMAKE_ARGS="${CMAKE_OPTS} -DFREECAD_USE_EXTERNAL_KDL=ON -DFREECAD_CREATE_MAC_APP=ON"
        export INSTALLED_APP_PATH="/usr/local/FreeCAD.app/Contents/bin/FreeCAD"
@@ -197,7 +181,9 @@ after_success:
 ##
 - |
   if [ "${TRAVIS_OS_NAME}" == "osx" -a "${TRAVIS_PULL_REQUEST}" == "false" ]; then
-     brew install jq node && npm install -g appdmg
+     brew ls --versions jq || brew install jq
+     brew uninstall node && brew install node
+     npm install -g appdmg
      export VSN=$(python ${TRAVIS_BUILD_DIR}/src/Tools/ArchiveNameFromVersionHeader.py ${TRAVIS_BUILD_DIR}/build/src/Build/Version.h)
      export DEPLOYMENT_ARCHIVE=${VSN}.dmg
      appdmg ${TRAVIS_BUILD_DIR}/src/MacAppBundle/DiskImage/layout.json "${DEPLOYMENT_ARCHIVE}"


### PR DESCRIPTION
…e, custom bottles, ports upgrade)

  - Ports dependencies are now declared in FreeCAD formula hosted at FreeCAD/homebrew-freecad/freecad
  - Ports-cache will match on the homebrew major.minor sub-version to increase cache hits during CI builds
  - FreeCAD-specific bottles deployed to FreeCAD/homebrew-freecad (micro-caches)
  - Travis builds request Xcode6.4 on macOS 10.10 dist (10.9 dist is deprecated and will be removed from Travis on 10/31)
  - Salome Med-File and 3DxWare drivers upgraded

Additional details of broader macOS initiative in forum post http://forum.freecadweb.org/viewtopic.php?f=10&t=17832

Forum Pull Request - http://forum.freecadweb.org/viewtopic.php?f=17&t=17842