### PR TITLE
Exit application with non-zero general error status code if an except…

### DIFF
--- a/src/Main/MainCmd.cpp
+++ b/src/Main/MainCmd.cpp
@@ -130,9 +130,11 @@ int main( int argc, char ** argv )
     }
     catch (const Base::Exception& e) {
         e.ReportException();
+        exit(1);
     }
     catch (...) {
         Console().Error("Application unexpectedly terminated\n");
+        exit(1);
     }
 
     // Destruction phase ===========================================================

--- a/src/Main/MainGui.cpp
+++ b/src/Main/MainGui.cpp
@@ -241,9 +241,11 @@ int main( int argc, char ** argv )
     }
     catch (const Base::Exception& e) {
         e.ReportException();
+        exit(1);
     }
     catch (...) {
         Base::Console().Error("Application unexpectedly terminated\n");
+        exit(1);
     }
 
     std::cout.rdbuf(oldcout);


### PR DESCRIPTION
Recently, we had an occurrence of an exception being raised that [was not trapped during continuous integration](http://forum.freecadweb.org/viewtopic.php?f=10&t=17818)...  This pull request prevents a recurrence by setting the application exit code to a general error if an exception is raised and not properly caught before propagating to the main() so to speak.

Forum post - http://forum.freecadweb.org/viewtopic.php?f=17&t=17878