### PR TITLE
Fix FindNETGEN.cmake to properly set netgen search path to HOMEBREW_P…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -142,9 +142,6 @@ before_install:
        #Remove GDAL if installed because it results in non-existent dependent library exceptions
        if [ -e /usr/local/lib/libgdal.1.dylib ]; then brew unlink gdal; fi
 
-       #Remove conflicting nglib formula that confuses cmake
-       rm $(brew --repository homebrew/science)/nglib.rb
-
        export CMAKE_ARGS="${CMAKE_OPTS} -DFREECAD_USE_EXTERNAL_KDL=ON -DFREECAD_CREATE_MAC_APP=ON"
        export INSTALLED_APP_PATH="/usr/local/FreeCAD.app/Contents/bin/FreeCAD"
        ;;

--- a/cMake/FindNETGEN.cmake
+++ b/cMake/FindNETGEN.cmake
@@ -18,7 +18,7 @@ IF(DEFINED MACPORTS_PREFIX OR DEFINED HOMEBREW_PREFIX)
     # We haven't supported Netgen prior to 5.3.1 on MacOS, and the current
     # plan is for the next Netgen version to be 6.1 (currently unreleased).
     IF(DEFINED HOMEBREW_PREFIX)
-        EXEC_PROGRAM(brew ARGS --prefix nglib OUTPUT_VARIABLE NGLIB_PREFIX)
+        SET(NGLIB_PREFIX ${HOMEBREW_PREFIX})
     ELSE(DEFINED HOMEBREW_PREFIX)
         SET(NGLIB_PREFIX ${MACPORTS_PREFIX})
     ENDIF(DEFINED HOMEBREW_PREFIX)


### PR DESCRIPTION
…REFIX, when using homebrew, instead of the netgen cellar

The cmake file FindNETGEN.cmake improperly set the search patch on macOS when using HOMEBREW....  It was incorrectly set to the cellar path instead of HOMEBREW_PREFIX.  

Forum pull request post - http://forum.freecadweb.org/viewtopic.php?f=17&t=17892