### PR TITLE
Enable boolean (BOA) multithreading

### DIFF
--- a/src/Mod/Part/App/CrossSection.cpp
+++ b/src/Mod/Part/App/CrossSection.cpp
@@ -76,6 +76,9 @@ std::list<TopoDS_Wire> CrossSection::slice(double d) const
 void CrossSection::sliceNonSolid(double d, const TopoDS_Shape& shape, std::list<TopoDS_Wire>& wires) const
 {
     BRepAlgoAPI_Section cs(shape, gp_Pln(a,b,c,-d));
+#if OCC_VERSION_HEX >= 0x060900
+    cs.SetRunParallel(true);
+#endif
     if (cs.IsDone()) {
         std::list<TopoDS_Edge> edges;
         TopExp_Explorer xp;
@@ -92,6 +95,9 @@ void CrossSection::sliceSolid(double d, const TopoDS_Shape& shape, std::list<Top
     BRepBuilderAPI_MakeFace mkFace(slicePlane);
     TopoDS_Face face = mkFace.Face();
     BRepAlgoAPI_Common mkInt(shape, face);
+#if OCC_VERSION_HEX >= 0x060900
+    mkInt.SetRunParallel(true);
+#endif
 
     if (mkInt.IsDone()) {
         // sort and repair the wires
@@ -114,7 +120,9 @@ void CrossSection::sliceSolid(double d, const TopoDS_Shape& shape, std::list<Top
     BRepPrimAPI_MakeHalfSpace mkSolid(face, refPoint);
     TopoDS_Solid solid = mkSolid.Solid();
     BRepAlgoAPI_Cut mkCut(shape, solid);
-
+#if OCC_VERSION_HEX >= 0x060900
+    mkCut.SetRunParallel(true);
+#endif
     if (mkCut.IsDone()) {
         TopTools_IndexedMapOfShape mapOfFaces;
         TopExp::MapShapes(mkCut.Shape(), TopAbs_FACE, mapOfFaces);

--- a/src/Mod/Part/App/FeaturePartCommon.cpp
+++ b/src/Mod/Part/App/FeaturePartCommon.cpp
@@ -111,6 +111,9 @@ App::DocumentObjectExecReturn *MultiCommon::execute(void)
             for (std::vector<TopoDS_Shape>::iterator it = s.begin()+1; it != s.end(); ++it) {
                 // Let's call algorithm computing a fuse operation:
                 BRepAlgoAPI_Common mkCommon(resShape, *it);
+#if OCC_VERSION_HEX >= 0x060900
+                mkCommon.SetRunParallel(true);
+#endif
                 // Let's check if the fusion has been successful
                 if (!mkCommon.IsDone()) 
                     throw Base::Exception("Intersection failed");

--- a/src/Mod/Part/App/FeaturePartFuse.cpp
+++ b/src/Mod/Part/App/FeaturePartFuse.cpp
@@ -145,6 +145,9 @@ App::DocumentObjectExecReturn *MultiFuse::execute(void)
             mkFuse.SetArguments(shapeArguments);
             mkFuse.SetTools(shapeTools);
             mkFuse.Build();
+# if OCC_VERSION_HEX >= 0x060900
+            mkFuse.SetRunParallel(true);
+# endif
             if (!mkFuse.IsDone())
                 throw Base::Exception("MultiFusion failed");
             TopoDS_Shape resShape = mkFuse.Shape();

--- a/src/Mod/Part/App/TopoShape.cpp
+++ b/src/Mod/Part/App/TopoShape.cpp
@@ -1280,6 +1280,9 @@ TopoDS_Shape TopoShape::cut(TopoDS_Shape shape) const
     if (shape.IsNull())
         Standard_Failure::Raise("Tool shape is null");
     BRepAlgoAPI_Cut mkCut(this->_Shape, shape);
+#if OCC_VERSION_HEX >= 0x060900
+    mkCut.SetRunParallel(true);
+#endif
     return mkCut.Shape();
 }
 
@@ -1290,6 +1293,9 @@ TopoDS_Shape TopoShape::common(TopoDS_Shape shape) const
     if (shape.IsNull())
         Standard_Failure::Raise("Tool shape is null");
     BRepAlgoAPI_Common mkCommon(this->_Shape, shape);
+#if OCC_VERSION_HEX >= 0x060900
+    mkCommon.SetRunParallel(true);
+#endif
     return mkCommon.Shape();
 }
 
@@ -1300,6 +1306,9 @@ TopoDS_Shape TopoShape::fuse(TopoDS_Shape shape) const
     if (shape.IsNull())
         Standard_Failure::Raise("Tool shape is null");
     BRepAlgoAPI_Fuse mkFuse(this->_Shape, shape);
+#if OCC_VERSION_HEX >= 0x060900
+    mkFuse.SetRunParallel(true);
+#endif
     return mkFuse.Shape();
 }
 
@@ -1325,6 +1334,9 @@ TopoDS_Shape TopoShape::multiFuse(const std::vector<TopoDS_Shape>& shapes, Stand
     }
 #else
     BRepAlgoAPI_Fuse mkFuse;
+# if OCC_VERSION_HEX >= 0x060900
+    mkFuse.SetRunParallel(true);
+# endif
     TopTools_ListOfShape shapeArguments,shapeTools;
     shapeArguments.Append(this->_Shape);
     for (std::vector<TopoDS_Shape>::const_iterator it = shapes.begin(); it != shapes.end(); ++it) {
@@ -1365,6 +1377,9 @@ TopoDS_Shape TopoShape::section(TopoDS_Shape shape) const
     if (shape.IsNull())
         Standard_Failure::Raise("Tool shape is null");
     BRepAlgoAPI_Section mkSection(this->_Shape, shape);
+# if OCC_VERSION_HEX >= 0x060900
+    mkSection.SetRunParallel(true);
+# endif
     return mkSection.Shape();
 }
 

--- a/src/Mod/PartDesign/App/FeatureBoolean.cpp
+++ b/src/Mod/PartDesign/App/FeatureBoolean.cpp
@@ -131,6 +131,9 @@ App::DocumentObjectExecReturn *Boolean::execute(void)
 
         if (type == "Fuse") {
             BRepAlgoAPI_Fuse mkFuse(result, shape);
+#if OCC_VERSION_HEX >= 0x060900
+            mkFuse.SetRunParallel(true);
+#endif
             if (!mkFuse.IsDone())
                 return new App::DocumentObjectExecReturn("Fusion of bodies failed", *b);
             // we have to get the solids (fuse sometimes creates compounds)
@@ -140,16 +143,25 @@ App::DocumentObjectExecReturn *Boolean::execute(void)
                 return new App::DocumentObjectExecReturn("Resulting shape is not a solid", *b);
         } else if (type == "Cut") {
             BRepAlgoAPI_Cut mkCut(result, shape);
+#if OCC_VERSION_HEX >= 0x060900
+            mkCut.SetRunParallel(true);
+#endif
             if (!mkCut.IsDone())
                 return new App::DocumentObjectExecReturn("Cut out of first body failed", *b);
             boolOp = mkCut.Shape();
         } else if (type == "Common") {
             BRepAlgoAPI_Common mkCommon(result, shape);
+#if OCC_VERSION_HEX >= 0x060900
+            mkCommon.SetRunParallel(true);
+#endif
             if (!mkCommon.IsDone())
                 return new App::DocumentObjectExecReturn("Common operation with first body failed", *b);
             boolOp = mkCommon.Shape();
         } else if (type == "Section") {
             BRepAlgoAPI_Section mkSection(result, shape);
+#if OCC_VERSION_HEX >= 0x060900
+            mkSection.SetRunParallel(true);
+#endif
             if (!mkSection.IsDone())
                 return new App::DocumentObjectExecReturn("Section out of first body failed", *b);
             // we have to get the solids

--- a/src/Mod/PartDesign/App/FeatureGroove.cpp
+++ b/src/Mod/PartDesign/App/FeatureGroove.cpp
@@ -147,6 +147,9 @@ App::DocumentObjectExecReturn *Groove::execute(void)
 
             // cut out groove to get one result object
             BRepAlgoAPI_Cut mkCut(base, result);
+#if OCC_VERSION_HEX >= 0x060900
+            mkCut.SetRunParallel(true);
+#endif
             // Let's check if the fusion has been successful
             if (!mkCut.IsDone())
                 throw Base::Exception("Cut out of base feature failed");

--- a/src/Mod/PartDesign/App/FeatureHole.cpp
+++ b/src/Mod/PartDesign/App/FeatureHole.cpp
@@ -145,6 +145,9 @@ App::DocumentObjectExecReturn *Hole::execute(void)
     //            return new App::DocumentObjectExecReturn("Support shape is not a solid");
     //        // Let's call algorithm computing a fuse operation:
     //        BRepAlgoAPI_Cut mkCut(support, PrismMaker.Shape());
+    //#if OCC_VERSION_HEX >= 0x060900
+    //        mkCut.SetRunParallel(true);
+    //#endif
     //        // Let's check if the fusion has been successful
     //        if (!mkCut.IsDone()) 
     //            return new App::DocumentObjectExecReturn("Cut with support failed");

--- a/src/Mod/PartDesign/App/FeatureLoft.cpp
+++ b/src/Mod/PartDesign/App/FeatureLoft.cpp
@@ -186,6 +186,9 @@ App::DocumentObjectExecReturn *Loft::execute(void)
         if(getAddSubType() == FeatureAddSub::Additive) {
                        
             BRepAlgoAPI_Fuse mkFuse(base, result);
+#if OCC_VERSION_HEX >= 0x060900
+            mkFuse.SetRunParallel(true);
+#endif
             if (!mkFuse.IsDone())
                 return new App::DocumentObjectExecReturn("Loft: Adding the loft failed");
             // we have to get the solids (fuse sometimes creates compounds)
@@ -200,6 +203,9 @@ App::DocumentObjectExecReturn *Loft::execute(void)
         else if(getAddSubType() == FeatureAddSub::Subtractive) {
             
             BRepAlgoAPI_Cut mkCut(base, result);
+#if OCC_VERSION_HEX >= 0x060900
+            mkCut.SetRunParallel(true);
+#endif
             if (!mkCut.IsDone())
                 return new App::DocumentObjectExecReturn("Loft: Subtracting the loft failed");
             // we have to get the solids (fuse sometimes creates compounds)

--- a/src/Mod/PartDesign/App/FeaturePad.cpp
+++ b/src/Mod/PartDesign/App/FeaturePad.cpp
@@ -216,6 +216,9 @@ App::DocumentObjectExecReturn *Pad::execute(void)
 //             static_cast<Part::Feature*>(obj)->Shape.setValue(getSolid(prism));
             // Let's call algorithm computing a fuse operation:
             BRepAlgoAPI_Fuse mkFuse(base, prism);
+#if OCC_VERSION_HEX >= 0x060900
+            mkFuse.SetRunParallel(true);
+#endif
             // Let's check if the fusion has been successful
             if (!mkFuse.IsDone())
                 return new App::DocumentObjectExecReturn("Pad: Fusion with base feature failed");

--- a/src/Mod/PartDesign/App/FeaturePipe.cpp
+++ b/src/Mod/PartDesign/App/FeaturePipe.cpp
@@ -293,6 +293,9 @@ App::DocumentObjectExecReturn *Pipe::execute(void)
         if(getAddSubType() == FeatureAddSub::Additive) {
                         
             BRepAlgoAPI_Fuse mkFuse(base, result);
+#if OCC_VERSION_HEX >= 0x060900
+            mkFuse.SetRunParallel(true);
+#endif
             if (!mkFuse.IsDone())
                 return new App::DocumentObjectExecReturn("Adding the pipe failed");
             // we have to get the solids (fuse sometimes creates compounds)
@@ -307,6 +310,9 @@ App::DocumentObjectExecReturn *Pipe::execute(void)
         else if(getAddSubType() == FeatureAddSub::Subtractive) {
             
             BRepAlgoAPI_Cut mkCut(base, result);
+#if OCC_VERSION_HEX >= 0x060900
+            mkCut.SetRunParallel(true);
+#endif
             if (!mkCut.IsDone())
                 return new App::DocumentObjectExecReturn("Subtracting the pipe failed");
             // we have to get the solids (fuse sometimes creates compounds)

--- a/src/Mod/PartDesign/App/FeaturePocket.cpp
+++ b/src/Mod/PartDesign/App/FeaturePocket.cpp
@@ -170,6 +170,9 @@ App::DocumentObjectExecReturn *Pocket::execute(void)
 
             // And the really expensive way to get the SubShape...
             BRepAlgoAPI_Cut mkCut(base, prism);
+#if OCC_VERSION_HEX >= 0x060900
+            mkCut.SetRunParallel(true);
+#endif
             if (!mkCut.IsDone())
                 return new App::DocumentObjectExecReturn("Pocket: Up to face: Could not get SubShape!");
             // FIXME: In some cases this affects the Shape property: It is set to the same shape as the SubShape!!!!
@@ -189,6 +192,9 @@ App::DocumentObjectExecReturn *Pocket::execute(void)
 
             // Cut the SubShape out of the base feature
             BRepAlgoAPI_Cut mkCut(base, prism);
+#if OCC_VERSION_HEX >= 0x060900
+            mkCut.SetRunParallel(true);
+#endif
             if (!mkCut.IsDone())
                 return new App::DocumentObjectExecReturn("Pocket: Cut out of base feature failed");
             TopoDS_Shape result = mkCut.Shape();

--- a/src/Mod/PartDesign/App/FeaturePrimitive.cpp
+++ b/src/Mod/PartDesign/App/FeaturePrimitive.cpp
@@ -113,6 +113,9 @@ App::DocumentObjectExecReturn* FeaturePrimitive::execute(const TopoDS_Shape& pri
         if(getAddSubType() == FeatureAddSub::Additive) {
             
             BRepAlgoAPI_Fuse mkFuse(base, primitiveShape);
+#if OCC_VERSION_HEX >= 0x060900
+            mkFuse.SetRunParallel(true);
+#endif
             if (!mkFuse.IsDone())
                 return new App::DocumentObjectExecReturn("Adding the primitive failed");
             // we have to get the solids (fuse sometimes creates compounds)
@@ -128,6 +131,9 @@ App::DocumentObjectExecReturn* FeaturePrimitive::execute(const TopoDS_Shape& pri
         else if(getAddSubType() == FeatureAddSub::Subtractive) {
             
             BRepAlgoAPI_Cut mkCut(base, primitiveShape);
+#if OCC_VERSION_HEX >= 0x060900
+            mkCut.SetRunParallel(true);
+#endif
             if (!mkCut.IsDone())
                 return new App::DocumentObjectExecReturn("Subtracting the primitive failed");
             // we have to get the solids (fuse sometimes creates compounds)

--- a/src/Mod/PartDesign/App/FeatureRevolution.cpp
+++ b/src/Mod/PartDesign/App/FeatureRevolution.cpp
@@ -150,6 +150,9 @@ App::DocumentObjectExecReturn *Revolution::execute(void)
             if (!base.IsNull()) {
                 // Let's call algorithm computing a fuse operation:
                 BRepAlgoAPI_Fuse mkFuse(base, result);
+#if OCC_VERSION_HEX >= 0x060900
+                mkFuse.SetRunParallel(true);
+#endif
                 // Let's check if the fusion has been successful
                 if (!mkFuse.IsDone())
                     throw Base::Exception("Fusion with base feature failed");

--- a/src/Mod/PartDesign/App/FeatureTransformed.cpp
+++ b/src/Mod/PartDesign/App/FeatureTransformed.cpp
@@ -315,6 +315,9 @@ App::DocumentObjectExecReturn *Transformed::execute(void)
 
         if (fuse) {
             BRepAlgoAPI_Fuse mkFuse(current, compoundTool);
+#if OCC_VERSION_HEX >= 0x060900
+            mkFuse.SetRunParallel(true);
+#endif
             if (!mkFuse.IsDone())
                 return new App::DocumentObjectExecReturn("Fusion with support failed", *o);
             // we have to get the solids (fuse sometimes creates compounds)
@@ -326,6 +329,9 @@ App::DocumentObjectExecReturn *Transformed::execute(void)
             for (individualIt = individualTools.begin(); individualIt != individualTools.end(); ++individualIt)
             {
               BRepAlgoAPI_Fuse mkFuse2(current, *individualIt);
+#if OCC_VERSION_HEX >= 0x060900
+              mkFuse2.SetRunParallel(true);
+#endif
               if (!mkFuse2.IsDone())
                   return new App::DocumentObjectExecReturn("Fusion with support failed", *o);
               // we have to get the solids (fuse sometimes creates compounds)
@@ -336,6 +342,9 @@ App::DocumentObjectExecReturn *Transformed::execute(void)
             }
         } else {
             BRepAlgoAPI_Cut mkCut(current, compoundTool);
+#if OCC_VERSION_HEX >= 0x060900
+            mkCut.SetRunParallel(true);
+#endif
             if (!mkCut.IsDone())
                 return new App::DocumentObjectExecReturn("Cut out of support failed", *o);
             current = mkCut.Shape();
@@ -343,6 +352,9 @@ App::DocumentObjectExecReturn *Transformed::execute(void)
             for (individualIt = individualTools.begin(); individualIt != individualTools.end(); ++individualIt)
             {
               BRepAlgoAPI_Cut mkCut2(current, *individualIt);
+#if OCC_VERSION_HEX >= 0x060900
+              mkCut2.SetRunParallel(true);
+#endif
               if (!mkCut2.IsDone())
                   return new App::DocumentObjectExecReturn("Cut out of support failed", *o);
               current = this->getSolid(mkCut2.Shape());

--- a/src/Mod/TechDraw/App/DrawViewSection.cpp
+++ b/src/Mod/TechDraw/App/DrawViewSection.cpp
@@ -192,6 +192,9 @@ App::DocumentObjectExecReturn *DrawViewSection::execute(void)
     TopoDS_Shape myShape = BuilderCopy.Shape();
 
     BRepAlgoAPI_Cut mkCut(myShape, prism);
+#if OCC_VERSION_HEX >= 0x060900
+    mkCut.SetRunParallel(true);
+#endif
     if (!mkCut.IsDone())
         return new App::DocumentObjectExecReturn("Section cut has failed");
 


### PR DESCRIPTION
Part:
- Boolean (Cut, Fuse, Common, Section) (not oldFuse)
- CrossSection (Cut, Common, Section)
- MultiFuse (Fuse)
- MultiCommon (Common)

PartDesign:
- Pad (Fuse)
- Pocket (Cut)
- Revolution (Fuse)
- Hole (Cut) (feature disabled)
- Groove (Cut)
- Loft (Cut, Fuse)
- Pipe (Cut, Fuse)
- Subtractive/Additive primitive (Cut, Fuse)
- Boolean (Cut, Fuse, Common, Section)
- Transformed (Cut, Fuse) (compound/individual)

TechDraw
- DrawViewSection (Cut)

Some command are affected indirectly. Like the Draft Array (Fuse property is using Part Fuse). OCC 6.9.0 or above is needed (or appropriate OCE counterpart in the future). TBB must be enabled when compiling OCC (OCE) or multithreding won't work.

Discussion:
http://forum.freecadweb.org/viewtopic.php?f=10&t=18179

Fixes:
http://www.freecadweb.org/tracker/view.php?id=2750
http://freecadweb.org/tracker/view.php?id=002334
