### PR TITLE
TechDraw Fix accented characters within SVG symbol

### DIFF
--- a/src/Mod/TechDraw/App/DrawUtil.cpp
+++ b/src/Mod/TechDraw/App/DrawUtil.cpp
@@ -236,7 +236,7 @@ QString DrawUtil::qbaToDebug(const QByteArray & line)
 
     for ( int i=0 ; i < line.size() ; i++ ){
         c = line[i];
-        if ( c >= 0x20 and c <= 126 ) {
+        if (( c >= 0x20) && (c <= 126) ) {
             s.append(QChar::fromLatin1(c));
         } else {
             s.append(QString::fromUtf8("<%1>").arg(c, 2, 16, QChar::fromLatin1('0')));

--- a/src/Mod/TechDraw/App/DrawUtil.cpp
+++ b/src/Mod/TechDraw/App/DrawUtil.cpp
@@ -32,6 +32,7 @@
 # include <QString>
 # include <QStringList>
 # include <QRegExp>
+#include <QChar>
 
 
 #include <BRep_Tool.hxx>
@@ -227,4 +228,21 @@ const char* DrawUtil::printBool(bool b)
 {
     return (b ? "True" : "False");
 }
+
+QString DrawUtil::qbaToDebug(const QByteArray & line)
+{
+    QString s;
+    uchar c;
+
+    for ( int i=0 ; i < line.size() ; i++ ){
+        c = line[i];
+        if ( c >= 0x20 and c <= 126 ) {
+            s.append(QChar::fromLatin1(c));
+        } else {
+            s.append(QString::fromUtf8("<%1>").arg(c, 2, 16, QChar::fromLatin1('0')));
+        }
+    }
+    return s;
+}
+
 //==================================

--- a/src/Mod/TechDraw/App/DrawUtil.h
+++ b/src/Mod/TechDraw/App/DrawUtil.h
@@ -24,6 +24,9 @@
 #define _DrawUtil_h_
 
 #include <string>
+
+#include <QString>
+#include <QByteArray>
 #include <TopoDS.hxx>
 #include <TopoDS_Vertex.hxx>
 #include <TopoDS_Edge.hxx>
@@ -51,6 +54,7 @@ class TechDrawExport DrawUtil {
         static void countWires(const char* label, const TopoDS_Shape& s);
         static void countEdges(const char* label, const TopoDS_Shape& s);
         static const char* printBool(bool b);
+        static QString qbaToDebug(const QByteArray& line);
 };
 
 } //end namespace TechDraw

--- a/src/Mod/TechDraw/Gui/QGIViewSymbol.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewSymbol.cpp
@@ -123,18 +123,16 @@ void QGIViewSymbol::drawSvg()
 
     m_svgItem->setScale(viewSymbol->Scale.getValue());
 
-    QString qs(QString::fromUtf8(viewSymbol->Symbol.getValue()));
-    symbolToSvg(qs);
+    QByteArray qba(viewSymbol->Symbol.getValue(),strlen(viewSymbol->Symbol.getValue()));
+    symbolToSvg(qba);
 }
 
-void QGIViewSymbol::symbolToSvg(QString qs)
+void QGIViewSymbol::symbolToSvg(QByteArray qba)
 {
-    if (qs.isEmpty()) {
+    if (qba.isEmpty()) {
         return;
     }
 
-    QByteArray qba;
-    qba.append(qs);
     prepareGeometryChange();
     if (!m_svgItem->load(&qba)) {
         Base::Console().Error("Error - Could not load Symbol into SVG renderer for %s\n", getViewObject()->getNameInDocument());

--- a/src/Mod/TechDraw/Gui/QGIViewSymbol.h
+++ b/src/Mod/TechDraw/Gui/QGIViewSymbol.h
@@ -57,7 +57,7 @@ public:
 
 protected:
     virtual void drawSvg();
-    void symbolToSvg(QString qs);
+    void symbolToSvg(QByteArray qba);
     QVariant itemChange(GraphicsItemChange change, const QVariant &value) override;
 
     QGCustomSvg *m_svgItem;


### PR DESCRIPTION
Small fix for error in conversion from char* to QString to QByteArray.  