### PR TITLE
Support for running specific unit tests with --run-test

### DIFF
--- a/src/App/Application.cpp
+++ b/src/App/Application.cpp
@@ -1024,7 +1024,7 @@ void my_trans_func( unsigned int code, EXCEPTION_POINTERS* pExp )
 
    //switch (code)
    //{
-   //    case FLT_DIVIDE_BY_ZERO : 
+   //    case FLT_DIVIDE_BY_ZERO :
    //       //throw CMyFunkyDivideByZeroException(code, pExp);
    //       throw Base::Exception("Devision by zero!");
    //    break;
@@ -1145,7 +1145,7 @@ void Application::initTypes(void)
     App ::GeoFeatureGroupExtensionPython::init();
     App ::OriginGroupExtension          ::init();
     App ::OriginGroupExtensionPython    ::init();
-    
+
     // Document classes
     App ::TransactionalObject       ::init();
     App ::DocumentObject            ::init();
@@ -1675,7 +1675,7 @@ void Application::ParseOptions(int ac, char ** av)
     ("log-file", value<string>(), "Unlike to --write-log this allows to log to an arbitrary file")
     ("user-cfg,u", value<string>(),"User config file to load/save user settings")
     ("system-cfg,s", value<string>(),"Systen config file to load/save system settings")
-    ("run-test,t",   value<int>()   ,"Test level")
+    ("run-test,t",   value<string>()   ,"Test case - or 0 for all")
     ("module-path,M", value< vector<string> >()->composing(),"Additional module paths")
     ("python-path,P", value< vector<string> >()->composing(),"Additional python paths")
     ("single-instance", "Allow to run a single instance of the application")
@@ -1884,21 +1884,14 @@ void Application::ParseOptions(int ac, char ** av)
     }
 
     if (vm.count("run-test")) {
-        int level = vm["run-test"].as<int>();
-        switch (level) {
-        case '0':
-            // test script level 0
-            mConfig["RunMode"] = "Internal";
-            mConfig["ScriptFileName"] = "FreeCADTest";
-            //sScriptName = FreeCADTest;
-            break;
-        default:
-            //default testing level 0
-            mConfig["RunMode"] = "Internal";
-            mConfig["ScriptFileName"] = "FreeCADTest";
-            //sScriptName = FreeCADTest;
-            break;
-        };
+       string testCase = vm["run-test"].as<string>();
+        if ( "0" == testCase) {
+            testCase = "TestApp.All";
+        }
+        mConfig["TestCase"] = testCase;
+        mConfig["RunMode"] = "Internal";
+        mConfig["ScriptFileName"] = "FreeCADTest";
+        //sScriptName = FreeCADTest;
     }
 
     if (vm.count("single-instance")) {
@@ -2161,7 +2154,7 @@ std::string Application::FindHomePath(const char* sCall)
         // path. In the worst case we simply get q wrong path and FreeCAD is not
         // able to load its modules.
         char resolved[PATH_MAX];
-#if defined(FC_OS_BSD) 
+#if defined(FC_OS_BSD)
         int mib[4];
         mib[0] = CTL_KERN;
         mib[1] = KERN_PROC;

--- a/src/App/FreeCADTest.py
+++ b/src/App/FreeCADTest.py
@@ -1,7 +1,7 @@
-# FreeCAD test module  
+# FreeCAD test module
 # (c) 2002 Juergen Riegel
 #
-# Testing the function of the base system and run 
+# Testing the function of the base system and run
 # (if existing) the test function of the modules
 #
 
@@ -34,7 +34,9 @@ Log ("FreeCAD test running...\n\n")
 
 import TestApp, sys
 
-testResult = TestApp.TestText("TestApp.All")
+testCase = FreeCAD.ConfigGet("TestCase")
+
+testResult = TestApp.TestText(testCase)
 
 Log ("FreeCAD test done\n")
 


### PR DESCRIPTION
Currently --run-test takes and mandates an integer argument. However the argument itself has no influence on the operation.

This change allows the user to specify a specific test case they want to run, or, in order to not break existing jarvis/jenkins jobs, '0' which will still result in all unit test being executed.

Examples:
"FreeCADCmd -t 0"                              .... run all unit tests
"FreeCADCmd --run-test TestApp.All"  .... identical to above, runs all unit tests
"FreeCADCmd --run-test TestTechDrawApp" ... runs only the TechDraw unit tests

The intent is to make it more attractive to develop and run automated unit tests - during development and before submission.