### PR TITLE
fix #0002662 - crash when create ShapeBinder with origin selected

### DIFF
--- a/src/Mod/PartDesign/App/ShapeBinder.cpp
+++ b/src/Mod/PartDesign/App/ShapeBinder.cpp
@@ -89,7 +89,7 @@ void ShapeBinder::getFilteredReferences(App::PropertyLinkSubList* prop, Part::Fe
 
     //we only allow one part feature, so get the first one we find
     size_t index = 0;
-    while(!objs[index]->isDerivedFrom(Part::Feature::getClassTypeId()) && index < objs.size())
+    while(index < objs.size() && !objs[index]->isDerivedFrom(Part::Feature::getClassTypeId()))
         index++;
 
     //do we have any part feature?

--- a/src/Mod/PartDesign/Gui/TaskShapeBinder.cpp
+++ b/src/Mod/PartDesign/Gui/TaskShapeBinder.cpp
@@ -317,35 +317,13 @@ bool TaskDlgShapeBinder::accept()
     return true;
 }
 
-//bool TaskDlgShapeBinder::reject()
-//{
-//    // get the support and Sketch
-//    PartDesign::Pipe* pcPipe = static_cast<PartDesign::Pipe*>(PipeView->getObject()); 
-//    Sketcher::SketchObject *pcSketch = 0;
-//    App::DocumentObject    *pcSupport = 0;
-//    if (pcPipe->Sketch.getValue()) {
-//        pcSketch = static_cast<Sketcher::SketchObject*>(pcPipe->Sketch.getValue()); 
-//        pcSupport = pcSketch->Support.getValue();
-//    }
-//
-//    // roll back the done things
-//    Gui::Command::abortCommand();
-//    Gui::Command::doCommand(Gui::Command::Gui,"Gui.activeDocument().resetEdit()");
-//    
-//    // if abort command deleted the object the support is visible again
-//    if (!Gui::Application::Instance->getViewProvider(pcPipe)) {
-//        if (pcSketch && Gui::Application::Instance->getViewProvider(pcSketch))
-//            Gui::Application::Instance->getViewProvider(pcSketch)->show();
-//        if (pcSupport && Gui::Application::Instance->getViewProvider(pcSupport))
-//            Gui::Application::Instance->getViewProvider(pcSupport)->show();
-//    }
-//
-//    //Gui::Command::doCommand(Gui::Command::Doc,"App.ActiveDocument.recompute()");
-//    //Gui::Command::commitCommand();
-//
-//    return true;
-//}
-
-
+bool TaskDlgShapeBinder::reject()
+{
+  // roll back the done things
+  Gui::Command::abortCommand();
+  Gui::Command::doCommand(Gui::Command::Gui, "Gui.activeDocument().resetEdit()");
+  Gui::Command::doCommand(Gui::Command::Doc, "App.ActiveDocument.recompute()");
+  return true;
+}
 
 #include "moc_TaskShapeBinder.cpp"

--- a/src/Mod/PartDesign/Gui/TaskShapeBinder.h
+++ b/src/Mod/PartDesign/Gui/TaskShapeBinder.h
@@ -94,7 +94,7 @@ public:
     /// is called by the framework if the dialog is accepted (Ok)
     virtual bool accept();
     /// is called by the framework if the dialog is rejected (Cancel)
-    //virtual bool reject();
+    virtual bool reject();
 
 protected:
     TaskShapeBinder  *parameter;


### PR DESCRIPTION
Hi,

This should fix the issue #0002662. Also I've added reject handler so that pressing Cancel in taskdialog cancels ShapeBinder modifications and resets EditMode.

[Forum link](http://forum.freecadweb.org/viewtopic.php?f=17&t=18860)

Thanks for review!
Sergo.