### PR TITLE
Path: Assign Contour label on restore fixes 2770

### DIFF
--- a/src/Mod/Path/App/Command.cpp
+++ b/src/Mod/Path/App/Command.cpp
@@ -131,9 +131,12 @@ std::string Command::toGCode (void) const
     std::stringstream str;
     str.precision(5);
     str << Name;
+    char v[60];
     for(std::map<std::string,double>::const_iterator i = Parameters.begin(); i != Parameters.end(); ++i) {
         std::string k = i->first;
-        std::string v = boost::lexical_cast<std::string>(i->second);
+        //std::string v = std::to_string(i->second);  // only 6 digits
+        snprintf(v, sizeof(v), "%.9f", i->second);
+        v[sizeof(v)-1] = '\0';
         str << " " << k << v;
     }
     return str.str();

--- a/src/Mod/Path/App/Command.cpp
+++ b/src/Mod/Path/App/Command.cpp
@@ -34,6 +34,7 @@
 #include <Base/Reader.h>
 #include <Base/Exception.h>
 #include "Command.h"
+#include <stdio.h>
 
 using namespace Base;
 using namespace Path;

--- a/src/Mod/Path/App/Command.cpp
+++ b/src/Mod/Path/App/Command.cpp
@@ -34,7 +34,6 @@
 #include <Base/Reader.h>
 #include <Base/Exception.h>
 #include "Command.h"
-#include <stdio.h>
 
 using namespace Base;
 using namespace Path;
@@ -132,12 +131,9 @@ std::string Command::toGCode (void) const
     std::stringstream str;
     str.precision(5);
     str << Name;
-    char v[60];
     for(std::map<std::string,double>::const_iterator i = Parameters.begin(); i != Parameters.end(); ++i) {
         std::string k = i->first;
-        //std::string v = std::to_string(i->second);  // only 6 digits
-        snprintf(v, sizeof(v), "%.9f", i->second);
-        v[sizeof(v)-1] = '\0';
+        std::string v = std::to_string(i->second);
         str << " " << k << v;
     }
     return str.str();

--- a/src/Mod/Path/PathScripts/PathContour.py
+++ b/src/Mod/Path/PathScripts/PathContour.py
@@ -120,9 +120,15 @@ class ObjectContour:
     def __setstate__(self, state):
         return None
 
+    def setLabel(self, obj):
+        if not obj.UserLabel:
+            obj.Label = obj.Name + " :" + obj.ToolDescription
+        else:
+            obj.Label = obj.UserLabel + " :" + obj.ToolDescription
+
     def onChanged(self, obj, prop):
         if prop == "UserLabel":
-            obj.Label = obj.UserLabel + " :" + obj.ToolDescription
+            self.setLabel(obj)
 
     def setDepths(proxy, obj):
         parentJob = PathUtils.findParentJob(obj)
@@ -231,10 +237,7 @@ class ObjectContour:
             obj.ToolNumber = toolLoad.ToolNumber
             obj.ToolDescription = toolLoad.Name
 
-        if obj.UserLabel == "":
-            obj.Label = obj.Name + " :" + obj.ToolDescription
-        else:
-            obj.Label = obj.UserLabel + " :" + obj.ToolDescription
+        self.setLabel(obj)
 
         output += "(" + obj.Label + ")"
         if not obj.UseComp:

--- a/src/Mod/Path/PathScripts/PathLoadTool.py
+++ b/src/Mod/Path/PathScripts/PathLoadTool.py
@@ -58,7 +58,6 @@ class LoadTool():
         obj.setEditorMode('Placement', mode)
 
     def execute(self, obj):
-
         tool = PathUtils.getTool(obj, obj.ToolNumber)
         if tool is not None:
             obj.Label = obj.Name + ": " + tool.Name
@@ -86,14 +85,12 @@ class LoadTool():
             obj.ViewObject.Visibility = True
 
     def onChanged(self, obj, prop):
-        mode = 2
-        obj.setEditorMode('Placement', mode)
-        # if prop == "ToolNumber":
-        job = PathUtils.findParentJob(obj)
-        if job is not None:
-            for g in job.Group:
-                if not(isinstance(g.Proxy, PathScripts.PathLoadTool.LoadTool)):
-                    g.touch()
+        if prop == "ToolNumber" and not 'Restore' in obj.State:
+            job = PathUtils.findParentJob(obj)
+            if job is not None:
+                for g in job.Group:
+                    if not(isinstance(g.Proxy, PathScripts.PathLoadTool.LoadTool)):
+                        g.touch()
 
 
 class _ViewProviderLoadTool:

--- a/src/Mod/Path/PathScripts/generic_post.py
+++ b/src/Mod/Path/PathScripts/generic_post.py
@@ -34,9 +34,10 @@ parameters, like e.g. suppress the units in the header and at every hop.
 '''
 
 # reload in python console:
-#   import maho_post
-#   reload(maho_post)
+#   import generic_post
+#   reload(generic_post)
 
+''' example post for Maho M 600E mill'''
 import FreeCAD
 import time
 import Path, PathScripts
@@ -195,7 +196,11 @@ def mkHeader(selection):
   now = time.strftime("%Y-%m-%d %H:%M")
   originfile = FreeCAD.ActiveDocument.FileName
   headerNoNumber = "%PM\n"     # this line gets no linenumber
-  headerNoNumber += "N9XXX (" + selection[0].Description + ", " + now + ")\n"  # this line gets no linenumber, it is already a specially numbered
+  if hasattr(selection[0],"Description"):
+     description = selection[0].Description
+  else:
+     description = ""
+  headerNoNumber += "N9XXX (" + description + ", " + now + ")\n"  # this line gets no linenumber, it is already a specially numbered
   header = ""
 #  header += "(Output Time:" + str(now) + ")\n"
   header += "(" + originfile + ")\n"
@@ -304,11 +309,12 @@ def export(selection,filename,argstring):
 
     gobjects = []
     for g in selection[0].Group:
-        gobjects.append(g)
+        if g.Name <>'Machine': #filtering out gcode home position from Machine object
+            gobjects.append(g)
 
     for obj in gobjects:
-        if hasattr(obj,'GComment'):
-          gcode += linenumberify('(' + obj.GComment + ')')
+        if hasattr(obj,'Comment'):
+          gcode += linenumberify('(' + obj.Comment + ')')
         for c in obj.Path.Commands:
             outstring = []
             command = c.Name


### PR DESCRIPTION
* consolidate contour label generation
* only touch dependent TC objects if the tool number changed;
* changed formatting of intermediate path representation to be valid g-code and not use exponents.

http://www.freecadweb.org/tracker/view.php?id=2770