### PR TITLE
Lock constraints can be applied without having to select first

### DIFF
--- a/src/Mod/Sketcher/Gui/CommandConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/CommandConstraints.cpp
@@ -33,6 +33,7 @@
 #include <Gui/Application.h>
 #include <Gui/Document.h>
 #include <Gui/Selection.h>
+#include <Gui/SelectionFilter.h>
 #include <Gui/Command.h>
 #include <Gui/MainWindow.h>
 #include <Gui/DlgEditFileIncludeProptertyExternal.h>
@@ -836,6 +837,29 @@ bool CmdSketcherConstrainVertical::isActive(void)
 
 // ======================================================================================
 
+namespace SketcherGui {
+    class LockSelection : public Gui::SelectionFilterGate
+    {
+        App::DocumentObject* object;
+    public:
+        LockSelection(App::DocumentObject* obj)
+            : Gui::SelectionFilterGate((Gui::SelectionFilter*)0), object(obj)
+        {}
+
+        bool allow(App::Document *pDoc, App::DocumentObject *pObj, const char *sSubName)
+        {
+            if (pObj != this->object)
+                return false;
+            if (!sSubName || sSubName[0] == '\0')
+                return false;
+            std::string element(sSubName);
+            if (element.substr(0,6) == "Vertex")
+                return true;
+            return false;
+        }
+    };
+}
+
 /* XPM */
 static const char *cursor_createlock[]={
 "32 32 3 1",
@@ -878,44 +902,102 @@ static const char *cursor_createlock[]={
 /**
  * @brief The DrawSketchHandlerLock class
  *
- * Hacking on the lines of the functions in CommandCreateGeo.cpp to make lock
+ * Hacking along the lines of the functions in CommandCreateGeo.cpp to make lock
  * constraints on the fly.
  */
 class DrawSketchHandlerLock: public DrawSketchHandler
 {
 public:
     DrawSketchHandlerLock() : selectionDone(false) {}
-    virtual ~DrawSketchHandlerLock() {}
+    virtual ~DrawSketchHandlerLock()
+    {
+        Gui::Selection().rmvSelectionGate();
+    }
 
     virtual void activated(ViewProviderSketch *)
     {
+        Gui::Selection().rmvSelectionGate();
+        Gui::Selection().addSelectionGate(new LockSelection(sketchgui->getObject()));
         setCursor(QPixmap(cursor_createlock),7,7);
     }
 
     virtual void mouseMove(Base::Vector2d onSketchPos)
     {
-        setPositionText(onSketchPos);
-        if (seekAutoConstraint(sugConstr, onSketchPos, Base::Vector2d(0.f,0.f))) {
-            renderSuggestConstraintsCursor(sugConstr);
+        // If preselection Point
+        //int preSelPnt = sketchgui->getPreselectPoint();
+        if (sketchgui->getPreselectPoint() != -1) {
+            setPositionText(onSketchPos);
             return;
         }
+        resetPositionText();
         applyCursor();
     }
 
     virtual bool pressButton(Base::Vector2d onSketchPos)
     {
-        EditPoint = onSketchPos;
-        selectionDone = true;
+        Q_UNUSED(onSketchPos);
+        // Get Preselection Point
+        int preSelPnt = sketchgui->getPreselectPoint();
+        if (preSelPnt != -1) {
+            pointGeoId = Constraint::GeoUndef;
+            pointPosId = Sketcher::none;
+            sketchgui->getSketchObject()->getGeoVertexIndex(preSelPnt, pointGeoId, pointPosId);
+            selectionDone = true;
+            return true;
+        }
         return true;
     }
 
     virtual bool releaseButton(Base::Vector2d onSketchPos) {
+        Q_UNUSED(onSketchPos);
+        if (selectionDone) {
+            unsetCursor();
+            resetPositionText();
+
+            Sketcher::SketchObject* Obj = static_cast<Sketcher::SketchObject*>(sketchgui->getObject());
+
+            Base::Vector3d pnt = Obj->getPoint(pointGeoId,pointPosId);
+
+            // undo command open
+            Gui::Command::openCommand("add fixed constraint");
+            Gui::Command::doCommand(
+                Gui::Command::Doc,"App.ActiveDocument.%s.addConstraint(Sketcher.Constraint('DistanceX',%d,%d,%f)) ",
+                sketchgui->getObject()->getNameInDocument(),pointGeoId,pointPosId,pnt.x);
+            Gui::Command::doCommand(
+                Gui::Command::Doc,"App.ActiveDocument.%s.addConstraint(Sketcher.Constraint('DistanceY',%d,%d,%f)) ",
+                sketchgui->getObject()->getNameInDocument(),pointGeoId,pointPosId,pnt.y);
+
+            if (pointGeoId <= Sketcher::GeoEnum::RefExt || constraintCreationMode==Reference) {
+                // it is a constraint on a external line, make it non-driving
+                const std::vector<Sketcher::Constraint *> &ConStr = Obj->Constraints.getValues();
+
+                Gui::Command::doCommand(Gui::Command::Doc,"App.ActiveDocument.%s.setDriving(%i,%s)",
+                sketchgui->getObject()->getNameInDocument(),ConStr.size()-2,"False");
+
+                Gui::Command::doCommand(Gui::Command::Doc,"App.ActiveDocument.%s.setDriving(%i,%s)",
+                sketchgui->getObject()->getNameInDocument(),ConStr.size()-1,"False");
+            }
+
+            // finish the transaction and update
+            Gui::Command::commitCommand();
+
+            ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Mod/Sketcher");
+            bool autoRecompute = hGrp->GetBool("AutoRecompute",false);
+
+            if(autoRecompute)
+                Gui::Command::updateActive();
+
+            // clear the selection (convenience)
+            Gui::Selection().clearSelection();
+
+        }
         return true;
     }
 
 protected:
     bool selectionDone;
-    Base::Vector2d EditPoint;
+    int pointGeoId;
+    Sketcher::PointPos pointPosId;
     std::vector<AutoConstraint> sugConstr;
 };
 

--- a/src/Mod/Sketcher/Gui/CommandConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/CommandConstraints.cpp
@@ -840,11 +840,11 @@ bool CmdSketcherConstrainVertical::isActive(void)
 // ======================================================================================
 
 namespace SketcherGui {
-    class LockSelection : public Gui::SelectionFilterGate
+    class LockConstraintSelection : public Gui::SelectionFilterGate
     {
         App::DocumentObject* object;
     public:
-        LockSelection(App::DocumentObject* obj)
+        LockConstraintSelection(App::DocumentObject* obj)
             : Gui::SelectionFilterGate((Gui::SelectionFilter*)0), object(obj)
         {}
 
@@ -919,7 +919,7 @@ public:
     virtual void activated(ViewProviderSketch *)
     {
         Gui::Selection().rmvSelectionGate();
-        Gui::Selection().addSelectionGate(new LockSelection(sketchgui->getObject()));
+        Gui::Selection().addSelectionGate(new LockConstraintSelection(sketchgui->getObject()));
         setCursor(QPixmap(cursor_createlock),7,7);
     }
 
@@ -927,12 +927,12 @@ public:
     {
         // If preselection Point
         //int preSelPnt = sketchgui->getPreselectPoint();
-        if (sketchgui->getPreselectPoint() != -1) {
-            setPositionText(onSketchPos);
-            return;
-        }
-        resetPositionText();
-        applyCursor();
+//        if (sketchgui->getPreselectPoint() != -1) {
+//            setPositionText(onSketchPos);
+//            return;
+//        }
+//        resetPositionText();
+//        applyCursor();
     }
 
     virtual bool pressButton(Base::Vector2d onSketchPos)
@@ -950,7 +950,8 @@ public:
         return true;
     }
 
-    virtual bool releaseButton(Base::Vector2d onSketchPos) {
+    virtual bool releaseButton(Base::Vector2d onSketchPos)
+    {
         Q_UNUSED(onSketchPos);
         if (selectionDone) {
             unsetCursor();
@@ -1111,6 +1112,147 @@ bool CmdSketcherConstrainLock::isActive(void)
     return isCreateGeoActive( getActiveGuiDocument() );
 }
 
+// ======================================================================================
+
+namespace SketcherGui {
+    class CoincidentConstraintSelection : public Gui::SelectionFilterGate
+    {
+        App::DocumentObject* object;
+    public:
+        CoincidentConstraintSelection(App::DocumentObject* obj)
+            : Gui::SelectionFilterGate((Gui::SelectionFilter*)0), object(obj)
+        {}
+
+        bool allow(App::Document *pDoc, App::DocumentObject *pObj, const char *sSubName)
+        {
+            if (pObj != this->object)
+                return false;
+            if (!sSubName || sSubName[0] == '\0')
+                return false;
+            std::string element(sSubName);
+            if (element.substr(0,6) == "Vertex" || element.substr(0,9) == "RootPoint")
+                return true;
+            return false;
+        }
+    };
+}
+
+/* XPM */
+static const char *cursor_createcoincident[]={
+"32 32 3 1",
+"+ c white",
+"# c red",
+". c None",
+"......+.........................",
+"......+.........................",
+"......+.........................",
+"......+.........................",
+"......+.........................",
+"................................",
+"+++++...+++++...................",
+"................................",
+"......+.........................",
+"......+.........................",
+"......+.........................",
+"......+.........................",
+"......+.........................",
+"................................",
+"................................",
+"................................",
+".................####...........",
+"................######..........",
+"...............########.........",
+"...............########.........",
+"...............########.........",
+"...............########.........",
+"................######..........",
+".................####...........",
+"................................",
+"................................",
+"................................",
+"................................",
+"................................",
+"................................",
+"................................",
+"................................"};
+
+class DrawSketchHandlerCoincident: public DrawSketchHandler
+{
+public:
+    DrawSketchHandlerCoincident()
+    {
+        GeoId1 = GeoId2 = Constraint::GeoUndef;
+        PosId1 = PosId2 = Sketcher::none;
+    }
+    virtual ~DrawSketchHandlerCoincident()
+    {
+        Gui::Selection().rmvSelectionGate();
+    }
+
+    virtual void activated(ViewProviderSketch *)
+    {
+        Gui::Selection().rmvSelectionGate();
+        Gui::Selection().addSelectionGate(new CoincidentConstraintSelection(sketchgui->getObject()));
+        setCursor(QPixmap(cursor_createcoincident), 7, 7);
+    }
+
+    virtual void mouseMove(Base::Vector2d onSketchPos) {Q_UNUSED(onSketchPos);}
+
+    virtual bool pressButton(Base::Vector2d onSketchPos)
+    {
+        Q_UNUSED(onSketchPos);
+        return true;
+    }
+
+    virtual bool releaseButton(Base::Vector2d onSketchPos)
+    {
+        Q_UNUSED(onSketchPos);
+        int VtId = sketchgui->getPreselectPoint();
+        if (VtId != -1) {
+            if (GeoId1 == Constraint::GeoUndef) {
+                sketchgui->getSketchObject()->getGeoVertexIndex(VtId,GeoId1,PosId1);
+                std::stringstream ss;
+                ss << "Vertex" << VtId + 1;
+                Gui::Selection().addSelection(sketchgui->getSketchObject()->getDocument()->getName(),
+                                              sketchgui->getSketchObject()->getNameInDocument(),
+                                              ss.str().c_str(),
+                                              onSketchPos.x,
+                                              onSketchPos.y,
+                                              0.f);
+            }
+            else {
+                sketchgui->getSketchObject()->getGeoVertexIndex(VtId,GeoId2,PosId2);
+
+                // Apply the constraint
+                Sketcher::SketchObject* Obj = static_cast<Sketcher::SketchObject*>(sketchgui->getObject());
+
+                // undo command open
+                Gui::Command::openCommand("add coincident constraint");
+
+                // check if this coincidence is already enforced (even indirectly)
+                bool constraintExists = Obj->arePointsCoincident(GeoId1,PosId1,GeoId2,PosId2);
+                if (!constraintExists && (GeoId1 != GeoId2)) {
+                    Gui::Command::doCommand(
+                        Gui::Command::Doc,"App.ActiveDocument.%s.addConstraint(Sketcher.Constraint('Coincident',%d,%d,%d,%d)) ",
+                        sketchgui->getObject()->getNameInDocument(),GeoId1,PosId1,GeoId2,PosId2);
+                    Gui::Command::commitCommand();
+                }
+                else {
+                    Gui::Command::abortCommand();
+                }
+            }
+        }
+        else {
+            GeoId1 = GeoId2 = Constraint::GeoUndef;
+            PosId1 = PosId2 = Sketcher::none;
+            Gui::Selection().clearSelection();
+        }
+        return true;
+    }
+protected:
+    int GeoId1, GeoId2;
+    Sketcher::PointPos PosId1, PosId2;
+};
 
 DEF_STD_CMD_A(CmdSketcherConstrainCoincident);
 
@@ -1131,13 +1273,15 @@ CmdSketcherConstrainCoincident::CmdSketcherConstrainCoincident()
 void CmdSketcherConstrainCoincident::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
+    ActivateHandler(getActiveGuiDocument(), new DrawSketchHandlerCoincident());
+
     // get the selection
     std::vector<Gui::SelectionObject> selection = getSelection().getSelectionEx();
 
     // only one sketch with its subelements are allowed to be selected
     if (selection.size() != 1) {
-        QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-            QObject::tr("Select vertexes from the sketch."));
+//        QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
+//            QObject::tr("Select vertexes from the sketch."));
         return;
     }
 
@@ -1201,7 +1345,8 @@ void CmdSketcherConstrainCoincident::activated(int iMsg)
 
 bool CmdSketcherConstrainCoincident::isActive(void)
 {
-    return isCreateConstraintActive( getActiveGuiDocument() );
+    //    return isCreateConstraintActive( getActiveGuiDocument() );
+    return isCreateGeoActive( getActiveGuiDocument() );
 }
 
 

--- a/src/Mod/Sketcher/Gui/CommandConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/CommandConstraints.cpp
@@ -1027,8 +1027,8 @@ void CmdSketcherConstrainLock::activated(int iMsg)
 
     // only one sketch with its subelements are allowed to be selected
     if (selection.size() != 1) {
-        QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-            QObject::tr("Select entities from the sketch."));
+//        QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
+//            QObject::tr("Select entities from the sketch."));
         return;
     }
 
@@ -1039,6 +1039,8 @@ void CmdSketcherConstrainLock::activated(int iMsg)
     if (SubNames.size() != 1) {
         QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
             QObject::tr("Select exactly one entity from the sketch."));
+        // clear the selection (convenience)
+        getSelection().clearSelection();
         return;
     }
 
@@ -1049,6 +1051,8 @@ void CmdSketcherConstrainLock::activated(int iMsg)
     if (isEdge(GeoId,PosId) || (GeoId < 0 && GeoId >= Sketcher::GeoEnum::VAxis)) {
         QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
             QObject::tr("Select one vertex from the sketch other than the origin."));
+        // clear the selection (convenience)
+        getSelection().clearSelection();
         return;
     }
 

--- a/src/Mod/Sketcher/Gui/CommandConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/CommandConstraints.cpp
@@ -44,6 +44,7 @@
 #include <Mod/Sketcher/App/Sketch.h>
 
 #include "ViewProviderSketch.h"
+#include "DrawSketchHandler.h"
 #include "ui_InsertDatum.h"
 #include "EditDatumDialog.h"
 #include "CommandConstraints.h"
@@ -62,6 +63,8 @@ namespace SketcherGui
 }
 
 ConstraintCreationMode constraintCreationMode=Driving;
+
+void ActivateHandler(Gui::Document *doc,DrawSketchHandler *handler);
 
 bool isCreateConstraintActive(Gui::Document *doc)
 {
@@ -831,6 +834,91 @@ bool CmdSketcherConstrainVertical::isActive(void)
 }
 
 
+// ======================================================================================
+
+/* XPM */
+static const char *cursor_createlock[]={
+"32 32 3 1",
+"+ c white",
+"# c red",
+". c None",
+"......+.........................",
+"......+.........................",
+"......+.........................",
+"......+.........................",
+"......+.........................",
+"................................",
+"+++++...+++++...................",
+"................................",
+"......+.........................",
+"......+.........................",
+"......+.........................",
+"......+.........................",
+"......+..........###............",
+"................######..........",
+"...............##....##.........",
+"..............##......##........",
+"..............##......##........",
+".............############.......",
+".............############.......",
+".............############.......",
+".............############.......",
+".............############.......",
+".............############.......",
+".............############.......",
+".............############.......",
+"................................",
+"................................",
+"................................",
+"................................",
+"................................",
+"................................",
+"................................"};
+
+/**
+ * @brief The DrawSketchHandlerLock class
+ *
+ * Hacking on the lines of the functions in CommandCreateGeo.cpp to make lock
+ * constraints on the fly.
+ */
+class DrawSketchHandlerLock: public DrawSketchHandler
+{
+public:
+    DrawSketchHandlerLock() : selectionDone(false) {}
+    virtual ~DrawSketchHandlerLock() {}
+
+    virtual void activated(ViewProviderSketch *)
+    {
+        setCursor(QPixmap(cursor_createlock),7,7);
+    }
+
+    virtual void mouseMove(Base::Vector2d onSketchPos)
+    {
+        setPositionText(onSketchPos);
+        if (seekAutoConstraint(sugConstr, onSketchPos, Base::Vector2d(0.f,0.f))) {
+            renderSuggestConstraintsCursor(sugConstr);
+            return;
+        }
+        applyCursor();
+    }
+
+    virtual bool pressButton(Base::Vector2d onSketchPos)
+    {
+        EditPoint = onSketchPos;
+        selectionDone = true;
+        return true;
+    }
+
+    virtual bool releaseButton(Base::Vector2d onSketchPos) {
+        return true;
+    }
+
+protected:
+    bool selectionDone;
+    Base::Vector2d EditPoint;
+    std::vector<AutoConstraint> sugConstr;
+};
+
 DEF_STD_CMD_AU(CmdSketcherConstrainLock);
 
 CmdSketcherConstrainLock::CmdSketcherConstrainLock()
@@ -849,6 +937,7 @@ CmdSketcherConstrainLock::CmdSketcherConstrainLock()
 void CmdSketcherConstrainLock::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
+    ActivateHandler(getActiveGuiDocument(), new DrawSketchHandlerLock());
     // get the selection
     std::vector<Gui::SelectionObject> selection = getSelection().getSelectionEx();
 
@@ -890,7 +979,8 @@ void CmdSketcherConstrainLock::activated(int iMsg)
         Doc,"App.ActiveDocument.%s.addConstraint(Sketcher.Constraint('DistanceY',%d,%d,%f)) ",
         selection[0].getFeatName(),GeoId,PosId,pnt.y);
 
-    if (GeoId <= Sketcher::GeoEnum::RefExt || constraintCreationMode==Reference) { // it is a constraint on a external line, make it non-driving
+    if (GeoId <= Sketcher::GeoEnum::RefExt || constraintCreationMode==Reference) {
+        // it is a constraint on a external line, make it non-driving
         const std::vector<Sketcher::Constraint *> &ConStr = Obj->Constraints.getValues();
         
         Gui::Command::doCommand(Doc,"App.ActiveDocument.%s.setDriving(%i,%s)",

--- a/src/Mod/Sketcher/Gui/CommandConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/CommandConstraints.cpp
@@ -67,6 +67,8 @@ ConstraintCreationMode constraintCreationMode=Driving;
 
 void ActivateHandler(Gui::Document *doc,DrawSketchHandler *handler);
 
+bool isCreateGeoActive(Gui::Document *doc);
+
 bool isCreateConstraintActive(Gui::Document *doc)
 {
     if (doc) {
@@ -1101,7 +1103,8 @@ void CmdSketcherConstrainLock::updateAction(int mode)
 
 bool CmdSketcherConstrainLock::isActive(void)
 {
-    return isCreateConstraintActive( getActiveGuiDocument() );
+    //    return isCreateConstraintActive( getActiveGuiDocument() );
+    return isCreateGeoActive( getActiveGuiDocument() );
 }
 
 

--- a/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp
+++ b/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp
@@ -4384,6 +4384,7 @@ public:
         }
         return true;
     }
+
 protected:
     bool selectionDone;
     Base::Vector2d EditPoint;

--- a/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp
+++ b/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp
@@ -4367,7 +4367,6 @@ public:
             else
                 static_cast<Sketcher::SketchObject *>(sketchgui->getObject())->solve();            
 
-            //ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Mod/Sketcher");
             bool continuousMode = hGrp->GetBool("ContinuousCreationMode",true);
             
             if(continuousMode){
@@ -4516,7 +4515,7 @@ namespace SketcherGui {
             return  false;
         }
     };
-};
+}
 
 
 /* XPM */

--- a/src/Mod/Sketcher/Gui/DrawSketchHandler.cpp
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandler.cpp
@@ -61,16 +61,9 @@ using namespace Sketcher;
 //**************************************************************************
 // Construction/Destruction
 
-DrawSketchHandler::DrawSketchHandler()
-        : sketchgui(0)
-{
+DrawSketchHandler::DrawSketchHandler() : sketchgui(0) {}
 
-}
-
-DrawSketchHandler::~DrawSketchHandler()
-{
-
-}
+DrawSketchHandler::~DrawSketchHandler() {}
 
 void DrawSketchHandler::quit(void)
 {


### PR DESCRIPTION
This set of commits is to make the lock constraint tool work like the geometry creation tools. This is more of a proof of concept along the lines of the discussion [here](http://forum.freecadweb.org/viewtopic.php?f=8&t=18175).