### PR TITLE
Body extension

### DIFF
--- a/src/App/DocumentObjectExtension.cpp
+++ b/src/App/DocumentObjectExtension.cpp
@@ -37,7 +37,7 @@ EXTENSION_PROPERTY_SOURCE(App::DocumentObjectExtension, App::Extension)
 
 DocumentObjectExtension::DocumentObjectExtension() 
 {
-    initExtension(App::DocumentObjectExtension::getExtensionClassTypeId());
+    initExtensionType(App::DocumentObjectExtension::getExtensionClassTypeId());
 }
 
 DocumentObjectExtension::~DocumentObjectExtension()

--- a/src/App/Extension.cpp
+++ b/src/App/Extension.cpp
@@ -71,7 +71,7 @@ Extension::~Extension()
     }
 }
 
-void Extension::initExtension(Base::Type type) {
+void Extension::initExtensionType(Base::Type type) {
 
     m_extensionType = type;
     if(m_extensionType.isBad())

--- a/src/App/Extension.h
+++ b/src/App/Extension.h
@@ -215,7 +215,7 @@ public:
     Extension();
     virtual ~Extension();
 
-    void initExtension(App::ExtensionContainer* obj);
+    virtual void initExtension(App::ExtensionContainer* obj);
     
     App::ExtensionContainer*       getExtendedContainer() {return m_base;}
     const App::ExtensionContainer* getExtendedContainer() const {return m_base;}
@@ -272,7 +272,7 @@ protected:
     friend class App::ExtensionContainer;
 
 protected:     
-    void initExtension(Base::Type type);
+    void initExtensionType(Base::Type type);
     bool m_isPythonExtension = false;
     Py::Object ExtensionPythonObject;
   
@@ -309,7 +309,7 @@ public:
     
     ExtensionPythonT() {
         ExtensionT::m_isPythonExtension = true;
-        ExtensionT::initExtension(ExtensionPythonT::getExtensionClassTypeId());
+        ExtensionT::initExtensionType(ExtensionPythonT::getExtensionClassTypeId());
         
         EXTENSION_ADD_PROPERTY(ExtensionProxy,(Py::Object()));
     }

--- a/src/App/GeoFeatureGroupExtension.cpp
+++ b/src/App/GeoFeatureGroupExtension.cpp
@@ -57,7 +57,7 @@ void GeoFeatureGroupExtension::initExtension(ExtensionContainer* obj) {
     if(!obj->isDerivedFrom(App::GeoFeature::getClassTypeId()))
         throw Base::Exception("GeoFeatureGroupExtension can only be applied to GeoFeatures");
         
-    App::Extension::initExtension(obj);
+    App::GroupExtension::initExtension(obj);
 }
 
 PropertyPlacement& GeoFeatureGroupExtension::placement() {
@@ -143,9 +143,9 @@ bool GeoFeatureGroupExtension::geoHasObject (const DocumentObject* obj) const {
 DocumentObject* GeoFeatureGroupExtension::getGroupOfObject(const DocumentObject* obj, bool indirect)
 {
     const Document* doc = obj->getDocument();
-    std::vector<DocumentObject*> grps = doc->getObjectsOfType(GeoFeatureGroupExtension::getExtensionClassTypeId());
+    std::vector<DocumentObject*> grps = doc->getObjectsWithExtension(GeoFeatureGroupExtension::getExtensionClassTypeId());
     for (std::vector<DocumentObject*>::const_iterator it = grps.begin(); it != grps.end(); ++it) {
-        GeoFeatureGroupExtension* grp = (GeoFeatureGroupExtension*)(*it);
+        GeoFeatureGroupExtension* grp = (*it)->getExtensionByType<GeoFeatureGroupExtension>();
         if ( indirect ) {
             if (grp->geoHasObject(obj)) {
                 return dynamic_cast<App::DocumentObject*>(grp);

--- a/src/App/GeoFeatureGroupExtension.cpp
+++ b/src/App/GeoFeatureGroupExtension.cpp
@@ -45,21 +45,36 @@ EXTENSION_PROPERTY_SOURCE(App::GeoFeatureGroupExtension, App::GroupExtension)
 
 GeoFeatureGroupExtension::GeoFeatureGroupExtension(void)
 {
-    initExtension(GeoFeatureGroupExtension::getExtensionClassTypeId());
-    
-    EXTENSION_ADD_PROPERTY(Placement,(Base::Placement()));
+    initExtensionType(GeoFeatureGroupExtension::getExtensionClassTypeId());
 }
 
 GeoFeatureGroupExtension::~GeoFeatureGroupExtension(void)
 {
 }
 
+void GeoFeatureGroupExtension::initExtension(ExtensionContainer* obj) {
+    
+    if(!obj->isDerivedFrom(App::GeoFeature::getClassTypeId()))
+        throw Base::Exception("GeoFeatureGroupExtension can only be applied to GeoFeatures");
+        
+    App::Extension::initExtension(obj);
+}
+
+PropertyPlacement& GeoFeatureGroupExtension::placement() {
+
+    if(!getExtendedContainer())
+        throw Base::Exception("GeoFeatureGroupExtension was not applied to GeoFeature");
+    
+    return static_cast<App::GeoFeature*>(getExtendedContainer())->Placement;
+}
+
+
 void GeoFeatureGroupExtension::transformPlacement(const Base::Placement &transform)
 {
     // NOTE: Keep in sync with APP::GeoFeature
-    Base::Placement plm = this->Placement.getValue();
+    Base::Placement plm = this->placement().getValue();
     plm = transform * plm;
-    this->Placement.setValue(plm);
+    this->placement().setValue(plm);
 }
 
 std::vector<App::DocumentObject*> GeoFeatureGroupExtension::getGeoSubObjects () const {

--- a/src/App/GeoFeatureGroupExtension.h
+++ b/src/App/GeoFeatureGroupExtension.h
@@ -41,7 +41,9 @@ class AppExport GeoFeatureGroupExtension : public App::GroupExtension
     EXTENSION_PROPERTY_HEADER(App::GeoFeatureGroupExtension);
 
 public:
-    PropertyPlacement Placement;
+    PropertyPlacement& placement();
+    
+    virtual void initExtension(ExtensionContainer* obj);
 
     /**
      * @brief transformPlacement applies transform to placement of this shape.

--- a/src/App/GeoFeatureGroupExtension.h
+++ b/src/App/GeoFeatureGroupExtension.h
@@ -73,7 +73,8 @@ public:
 
     /// Returns true if the given DocumentObject is DocumentObjectGroup but not GeoFeatureGroup
     static bool isNonGeoGroup(const DocumentObject* obj) {
-        return obj->hasExtension(GroupExtension::getExtensionClassTypeId());
+        return obj->hasExtension(GroupExtension::getExtensionClassTypeId()) & 
+               !obj->hasExtension(GeoFeatureGroupExtension::getExtensionClassTypeId());
     }
 };
 

--- a/src/App/GroupExtension.cpp
+++ b/src/App/GroupExtension.cpp
@@ -63,6 +63,11 @@ void GroupExtension::addObject(DocumentObject* obj)
     if(!allowObject(obj))
         return;
     
+    //only one group per object
+    auto *group = App::GroupExtension::getGroupOfObject(obj);
+    if(group && group != getExtendedObject())
+        group->getExtensionByType<App::GroupExtension>()->removeObject(obj);
+    
     if (!hasObject(obj)) {
         std::vector<DocumentObject*> grp = Group.getValues();
         grp.push_back(obj);
@@ -180,9 +185,9 @@ int GroupExtension::countObjectsOfType(const Base::Type& typeId) const
 DocumentObject* GroupExtension::getGroupOfObject(const DocumentObject* obj)
 {
     const Document* doc = obj->getDocument();
-    std::vector<DocumentObject*> grps = doc->getObjectsOfType(GroupExtension::getExtensionClassTypeId());
+    std::vector<DocumentObject*> grps = doc->getObjectsWithExtension(GroupExtension::getExtensionClassTypeId());
     for (std::vector<DocumentObject*>::const_iterator it = grps.begin(); it != grps.end(); ++it) {
-        GroupExtension* grp = (GroupExtension*)(*it);
+        GroupExtension* grp = (*it)->getExtensionByType<GroupExtension>();
         if (grp->hasObject(obj))
             return *it;
     }

--- a/src/App/GroupExtension.cpp
+++ b/src/App/GroupExtension.cpp
@@ -38,7 +38,7 @@ EXTENSION_PROPERTY_SOURCE(App::GroupExtension, App::DocumentObjectExtension)
 
 GroupExtension::GroupExtension()
 {
-    initExtension(GroupExtension::getExtensionClassTypeId());
+    initExtensionType(GroupExtension::getExtensionClassTypeId());
     
     EXTENSION_ADD_PROPERTY_TYPE(Group,(0),"Base",(App::PropertyType)(Prop_Output),"List of referenced objects");
 }

--- a/src/App/GroupExtension.h
+++ b/src/App/GroupExtension.h
@@ -49,20 +49,20 @@ public:
     /** Adds an object of \a sType with \a pObjectName to the document this group belongs to and
      * append it to this group as well.
      */
-    DocumentObject *addObject(const char* sType, const char* pObjectName);
+    virtual DocumentObject *addObject(const char* sType, const char* pObjectName);
     /* Adds the object \a obj to this group.
      */
-    void addObject(DocumentObject* obj);
+    virtual void addObject(DocumentObject* obj);
     /*override this function if you want only special objects
      */
     virtual bool allowObject(DocumentObject* ) {return true;};
     
     /** Removes an object from this group.
      */
-    void removeObject(DocumentObject* obj);
+    virtual void removeObject(DocumentObject* obj);
     /** Removes all children objects from this group and the document.
      */
-    void removeObjectsFromDocument();
+    virtual void removeObjectsFromDocument();
     /** Returns the object of this group with \a Name. If the group doesn't have such an object 0 is returned.
      * @note This method might return 0 even if the document this group belongs to contains an object with this name.
      */

--- a/src/App/OriginGroupExtension.cpp
+++ b/src/App/OriginGroupExtension.cpp
@@ -39,7 +39,7 @@ EXTENSION_PROPERTY_SOURCE(App::OriginGroupExtension, App::GeoFeatureGroupExtensi
 
 OriginGroupExtension::OriginGroupExtension () {
     
-    initExtension(OriginGroupExtension::getExtensionClassTypeId());
+    initExtensionType(OriginGroupExtension::getExtensionClassTypeId());
     
     EXTENSION_ADD_PROPERTY_TYPE ( Origin, (0), 0, App::Prop_Hidden, "Origin linked to the group" );
 }

--- a/src/App/OriginGroupExtension.cpp
+++ b/src/App/OriginGroupExtension.cpp
@@ -129,6 +129,69 @@ void OriginGroupExtension::onExtendedUnsetupObject () {
     GeoFeatureGroupExtension::onExtendedUnsetupObject ();
 }
 
+void OriginGroupExtension::relinkToOrigin(App::DocumentObject* obj)
+{
+    //we get all links and replace the origin objects if needed (subnames need not to change, they
+    //would stay the same)
+    std::vector< App::DocumentObject* > result;
+    std::vector<App::Property*> list;
+    obj->getPropertyList(list);
+    for(App::Property* prop : list) {
+        if(prop->getTypeId().isDerivedFrom(App::PropertyLink::getClassTypeId())) {
+            
+            auto p = static_cast<App::PropertyLink*>(prop);
+            if(!p->getValue() || !p->getValue()->isDerivedFrom(App::OriginFeature::getClassTypeId()))
+                continue;
+        
+            p->setValue(getOrigin()->getOriginFeature(static_cast<OriginFeature*>(p->getValue())->Role.getValue()));
+        }            
+        else if(prop->getTypeId().isDerivedFrom(App::PropertyLinkList::getClassTypeId())) {
+            auto p = static_cast<App::PropertyLinkList*>(prop);
+            auto vec = p->getValues();
+            std::vector<App::DocumentObject*> result;
+            bool changed = false;
+            for(App::DocumentObject* o : vec) {
+                if(!o || !o->isDerivedFrom(App::OriginFeature::getClassTypeId()))
+                    result.push_back(o);
+                else {
+                    result.push_back(getOrigin()->getOriginFeature(static_cast<OriginFeature*>(o)->Role.getValue()));
+                    changed = true;
+                }
+            }
+            if(changed)
+                static_cast<App::PropertyLinkList*>(prop)->setValues(result);
+        }
+        else if(prop->getTypeId().isDerivedFrom(App::PropertyLinkSub::getClassTypeId())) {
+            auto p = static_cast<App::PropertyLinkSub*>(prop);
+            if(!p->getValue() || !p->getValue()->isDerivedFrom(App::OriginFeature::getClassTypeId()))
+                continue;
+        
+            p->setValue(getOrigin()->getOriginFeature(static_cast<OriginFeature*>(p->getValue())->Role.getValue()));
+        }
+        else if(prop->getTypeId().isDerivedFrom(App::PropertyLinkSubList::getClassTypeId())) {
+            auto p = static_cast<App::PropertyLinkList*>(prop);
+            auto vec = p->getValues();
+            std::vector<App::DocumentObject*> result;
+            bool changed = false;
+            for(App::DocumentObject* o : vec) {
+                if(!o || !o->isDerivedFrom(App::OriginFeature::getClassTypeId()))
+                    result.push_back(o);
+                else {
+                    result.push_back(getOrigin()->getOriginFeature(static_cast<OriginFeature*>(o)->Role.getValue()));
+                    changed = true;
+                }
+            }
+            if(changed)
+                static_cast<App::PropertyLinkList*>(prop)->setValues(result);
+        }
+    }
+}
+
+void OriginGroupExtension::addObject(DocumentObject* obj) {
+    relinkToOrigin(obj);
+    App::GeoFeatureGroupExtension::addObject(obj);
+}
+
 
 // Python feature ---------------------------------------------------------
 

--- a/src/App/OriginGroupExtension.h
+++ b/src/App/OriginGroupExtension.h
@@ -62,6 +62,11 @@ public:
     
     /// Origin linked to the group
     PropertyLink Origin;
+    
+    //changes all links of obj to a origin to point to this groupes origin
+    void relinkToOrigin(App::DocumentObject* obj);
+    
+    virtual void addObject(DocumentObject* obj);
 
 protected:
     /// Checks integrity of the Origin

--- a/src/App/Part.cpp
+++ b/src/App/Part.cpp
@@ -35,7 +35,7 @@
 using namespace App;
 
 
-PROPERTY_SOURCE_WITH_EXTENSIONS(App::Part, App::DocumentObject)
+PROPERTY_SOURCE_WITH_EXTENSIONS(App::Part, App::GeoFeature)
 
 
 //===========================================================================

--- a/src/App/Part.h
+++ b/src/App/Part.h
@@ -35,7 +35,7 @@ namespace App
 
 /** Base class of all geometric document objects.
  */
-class AppExport Part : public App::DocumentObject, public App::OriginGroupExtension
+class AppExport Part : public App::GeoFeature, public App::OriginGroupExtension
 {
     PROPERTY_HEADER_WITH_EXTENSIONS(App::Part);
 

--- a/src/Gui/ViewProviderExtension.cpp
+++ b/src/Gui/ViewProviderExtension.cpp
@@ -37,7 +37,7 @@ EXTENSION_PROPERTY_SOURCE(Gui::ViewProviderExtension, App::Extension)
 
 ViewProviderExtension::ViewProviderExtension() 
 {
-    initExtension(Gui::ViewProviderExtension::getExtensionClassTypeId());
+    initExtensionType(Gui::ViewProviderExtension::getExtensionClassTypeId());
 }
 
 ViewProviderExtension::~ViewProviderExtension()

--- a/src/Gui/ViewProviderExtension.h
+++ b/src/Gui/ViewProviderExtension.h
@@ -97,7 +97,7 @@ public:
     
     ViewProviderExtensionPythonT() {
         ExtensionT::m_isPythonExtension = true;
-        ExtensionT::initExtension(ViewProviderExtensionPythonT::getExtensionClassTypeId());
+        ExtensionT::initExtensionType(ViewProviderExtensionPythonT::getExtensionClassTypeId());
         
         EXTENSION_ADD_PROPERTY(ExtensionProxy,(Py::Object()));
     }

--- a/src/Gui/ViewProviderGeoFeatureGroupExtension.cpp
+++ b/src/Gui/ViewProviderGeoFeatureGroupExtension.cpp
@@ -38,7 +38,7 @@ EXTENSION_PROPERTY_SOURCE(Gui::ViewProviderGeoFeatureGroupExtension, Gui::ViewPr
 
 ViewProviderGeoFeatureGroupExtension::ViewProviderGeoFeatureGroupExtension()
 {
-    initExtension(ViewProviderGeoFeatureGroupExtension::getExtensionClassTypeId());
+    initExtensionType(ViewProviderGeoFeatureGroupExtension::getExtensionClassTypeId());
     
     pcGroupChildren = new SoGroup();
     pcGroupChildren->ref();
@@ -84,8 +84,8 @@ std::vector<std::string> ViewProviderGeoFeatureGroupExtension::extensionGetDispl
 void ViewProviderGeoFeatureGroupExtension::extensionUpdateData(const App::Property* prop)
 {
     auto obj = getExtendedViewProvider()->getObject()->getExtensionByType<App::GeoFeatureGroupExtension>();
-    if (obj && prop == &obj->Placement) {
-        getExtendedViewProvider()->setTransformation ( obj->Placement.getValue().toMatrix() );
+    if (obj && prop == &obj->placement()) {
+        getExtendedViewProvider()->setTransformation ( obj->placement().getValue().toMatrix() );
     } else {
         ViewProviderGroupExtension::extensionUpdateData ( prop );
     }

--- a/src/Gui/ViewProviderGeoFeatureGroupExtension.cpp
+++ b/src/Gui/ViewProviderGeoFeatureGroupExtension.cpp
@@ -29,6 +29,9 @@
 #endif
 
 #include "ViewProviderGeoFeatureGroupExtension.h"
+#include "Command.h"
+#include "Application.h"
+#include "Document.h"
 #include <App/GeoFeatureGroupExtension.h>
 #include <Inventor/nodes/SoGroup.h>
 
@@ -90,6 +93,89 @@ void ViewProviderGeoFeatureGroupExtension::extensionUpdateData(const App::Proper
         ViewProviderGroupExtension::extensionUpdateData ( prop );
     }
 }
+
+std::vector< App::DocumentObject* > ViewProviderGeoFeatureGroupExtension::getLinkedObjects(App::DocumentObject* obj) {
+
+    if(!obj)
+        return std::vector< App::DocumentObject* >();
+    
+    //we get all linked objects, and that recursively
+    std::vector< App::DocumentObject* > result;
+    std::vector<App::Property*> list;
+    obj->getPropertyList(list);
+    for(App::Property* prop : list) {
+        if(prop->getTypeId().isDerivedFrom(App::PropertyLink::getClassTypeId()))
+            result.push_back(static_cast<App::PropertyLink*>(prop)->getValue());
+        else if(prop->getTypeId().isDerivedFrom(App::PropertyLinkList::getClassTypeId())) {
+            auto vec = static_cast<App::PropertyLinkList*>(prop)->getValues();
+            result.insert(result.end(), vec.begin(), vec.end());
+        }
+        else if(prop->getTypeId().isDerivedFrom(App::PropertyLinkSub::getClassTypeId()))
+            result.push_back(static_cast<App::PropertyLinkSub*>(prop)->getValue());
+        else if(prop->getTypeId().isDerivedFrom(App::PropertyLinkSubList::getClassTypeId())) {
+            auto vec = static_cast<App::PropertyLinkList*>(prop)->getValues();
+            result.insert(result.end(), vec.begin(), vec.end());
+        }
+    }
+    
+    //clear all null objects
+    result.erase(std::remove(result.begin(), result.end(), nullptr), result.end());
+    
+    //collect all dependencies of those objects
+    for(App::DocumentObject *obj : result) {
+        auto vec = getLinkedObjects(obj);
+        result.insert(result.end(), vec.begin(), vec.end());
+    }
+    
+    return result;
+}
+
+void ViewProviderGeoFeatureGroupExtension::extensionDropObject(App::DocumentObject* obj) {
+    
+    // Open command
+    App::DocumentObject* grp = static_cast<App::DocumentObject*>(getExtendedViewProvider()->getObject());
+    App::Document* doc = grp->getDocument();
+    Gui::Document* gui = Gui::Application::Instance->getDocument(doc);
+    gui->openCommand("Move object");
+    
+    //links between different CS are not allowed, hence we need to ensure if all dependencies are in 
+    //the same geofeaturegroup
+    auto vec = getLinkedObjects(obj);
+    
+    //remove all objects already in the correct group
+    vec.erase(std::remove_if(vec.begin(), vec.end(), [this](App::DocumentObject* o){    
+        return App::GroupExtension::getGroupOfObject(o) == this->getExtendedViewProvider()->getObject();
+    }), vec.end());
+
+    vec.push_back(obj);
+    
+    for(App::DocumentObject* o : vec) {       
+        // build Python command for execution
+        QString cmd;
+        cmd = QString::fromLatin1("App.getDocument(\"%1\").getObject(\"%2\").addObject("
+                            "App.getDocument(\"%1\").getObject(\"%3\"))")
+                            .arg(QString::fromLatin1(doc->getName()))
+                            .arg(QString::fromLatin1(grp->getNameInDocument()))
+                            .arg(QString::fromLatin1(o->getNameInDocument()));
+
+        Gui::Command::doCommand(Gui::Command::App, cmd.toUtf8());
+    }
+    gui->commitCommand();
+}
+
+
+void ViewProviderGeoFeatureGroupExtension::extensionDragObject(App::DocumentObject* obj) {
+    //links between different coordinate systems are not allowed, hence draging one object also needs
+    //to drag out all dependend objects
+    auto vec = getLinkedObjects(obj);
+       
+    //add this object
+    vec.push_back(obj);
+    
+    for(App::DocumentObject* obj : vec)
+        ViewProviderGroupExtension::extensionDragObject(obj);
+}
+
 
 
 namespace Gui {

--- a/src/Gui/ViewProviderGeoFeatureGroupExtension.h
+++ b/src/Gui/ViewProviderGeoFeatureGroupExtension.h
@@ -58,8 +58,13 @@ public:
 
     virtual void extensionUpdateData(const App::Property*) override;
     
+    virtual void extensionDropObject(App::DocumentObject*);
+    virtual void extensionDragObject(App::DocumentObject*);
+    
 protected:
     SoGroup *pcGroupChildren;
+    
+    std::vector<App::DocumentObject*> getLinkedObjects(App::DocumentObject* obj);    
 };
 
 typedef ViewProviderExtensionPythonT<Gui::ViewProviderGeoFeatureGroupExtension> ViewProviderGeoFeatureGroupExtensionPython;

--- a/src/Gui/ViewProviderGroupExtension.cpp
+++ b/src/Gui/ViewProviderGroupExtension.cpp
@@ -45,7 +45,7 @@ EXTENSION_PROPERTY_SOURCE(Gui::ViewProviderGroupExtension, Gui::ViewProviderExte
 
 ViewProviderGroupExtension::ViewProviderGroupExtension()  : visible(false)
 {
-    initExtension(ViewProviderGroupExtension::getExtensionClassTypeId());
+    initExtensionType(ViewProviderGroupExtension::getExtensionClassTypeId());
 }
 
 ViewProviderGroupExtension::~ViewProviderGroupExtension()

--- a/src/Gui/ViewProviderOriginGroupExtension.cpp
+++ b/src/Gui/ViewProviderOriginGroupExtension.cpp
@@ -34,6 +34,7 @@
 #include "ViewProviderOrigin.h"
 #include "View3DInventorViewer.h"
 #include "View3DInventor.h"
+#include "Command.h"
 #include <App/OriginGroupExtension.h>
 #include <App/Document.h>
 #include <App/Origin.h>
@@ -194,6 +195,63 @@ void ViewProviderOriginGroupExtension::updateOriginSize () {
     }
 
     vpOrigin->Size.setValue ( size * 1.3 );
+}
+
+void ViewProviderOriginGroupExtension::extensionDragObject(App::DocumentObject* obj) {
+    
+    //links between different coordinate systems are not allowed, hence draging one object also needs
+    //to drag out all dependend objects
+    auto vec = getLinkedObjects(obj);
+       
+    //remove all origin objects
+    vec.erase(std::remove_if(vec.begin(), vec.end(), [this](App::DocumentObject* o) {
+        return o->isDerivedFrom(App::OriginFeature::getClassTypeId());}), vec.end());
+    
+    //add the original object
+    vec.push_back(obj);
+    
+    for(App::DocumentObject* obj : vec)
+        ViewProviderGroupExtension::extensionDragObject(obj);
+}
+
+void ViewProviderOriginGroupExtension::extensionDropObject(App::DocumentObject* obj) {
+    
+    // Open command
+    App::DocumentObject* grp = static_cast<App::DocumentObject*>(getExtendedViewProvider()->getObject());
+    App::Document* doc = grp->getDocument();
+    Gui::Document* gui = Gui::Application::Instance->getDocument(doc);
+    gui->openCommand("Move object");
+    
+    //links between different CS are not allowed, hence we need to enure if all dependencies are in 
+    //the same geofeaturegroup
+    auto vec = getLinkedObjects(obj);
+
+    //remove all origin objects
+    vec.erase(std::remove_if(vec.begin(), vec.end(), [](App::DocumentObject* o) {
+        return o->isDerivedFrom(App::OriginFeature::getClassTypeId());}), vec.end());
+
+    //remove all objects already in the correct group
+    vec.erase(std::remove_if(vec.begin(), vec.end(), [this](App::DocumentObject* o){    
+        return App::GroupExtension::getGroupOfObject(o) == this->getExtendedViewProvider()->getObject();
+    }), vec.end());
+
+    //add the original object
+    vec.push_back(obj);
+    
+    for(App::DocumentObject* o : vec) {
+        
+        // build Python command for execution
+        QString cmd;
+        cmd = QString::fromLatin1("App.getDocument(\"%1\").getObject(\"%2\").addObject("
+                            "App.getDocument(\"%1\").getObject(\"%3\"))")
+                            .arg(QString::fromLatin1(doc->getName()))
+                            .arg(QString::fromLatin1(grp->getNameInDocument()))
+                            .arg(QString::fromLatin1(o->getNameInDocument()));
+
+        Gui::Command::doCommand(Gui::Command::App, cmd.toUtf8());
+    }
+    gui->commitCommand();
+    
 }
 
 

--- a/src/Gui/ViewProviderOriginGroupExtension.cpp
+++ b/src/Gui/ViewProviderOriginGroupExtension.cpp
@@ -48,7 +48,7 @@ EXTENSION_PROPERTY_SOURCE(Gui::ViewProviderOriginGroupExtension, Gui::ViewProvid
 
 ViewProviderOriginGroupExtension::ViewProviderOriginGroupExtension()
 {
-    initExtension(ViewProviderOriginGroupExtension::getExtensionClassTypeId());
+    initExtensionType(ViewProviderOriginGroupExtension::getExtensionClassTypeId());
 }
 
 ViewProviderOriginGroupExtension::~ViewProviderOriginGroupExtension()

--- a/src/Gui/ViewProviderOriginGroupExtension.h
+++ b/src/Gui/ViewProviderOriginGroupExtension.h
@@ -46,6 +46,9 @@ public:
     virtual void extensionAttach(App::DocumentObject *pcObject) override;
     virtual void extensionUpdateData(const App::Property* prop) override;
 
+    virtual void extensionDragObject(App::DocumentObject*) override;
+    virtual void extensionDropObject(App::DocumentObject*);
+    
     void updateOriginSize();
 
 protected:

--- a/src/Mod/Part/App/AttachExtension.cpp
+++ b/src/Mod/Part/App/AttachExtension.cpp
@@ -59,7 +59,7 @@ AttachExtension::AttachExtension()
     EXTENSION_ADD_PROPERTY_TYPE(superPlacement, (Base::Placement()), "Attachment", App::Prop_None, "Extra placement to apply in addition to attachment (in local coordinates)");
 
     setAttacher(new AttachEngine3D);//default attacher
-    initExtension(AttachExtension::getExtensionClassTypeId());
+    initExtensionType(AttachExtension::getExtensionClassTypeId());
 }
 
 AttachExtension::~AttachExtension()

--- a/src/Mod/Part/App/BodyBase.cpp
+++ b/src/Mod/Part/App/BodyBase.cpp
@@ -35,19 +35,12 @@
 namespace Part {
 
 
-PROPERTY_SOURCE(Part::BodyBase, Part::Feature)
+PROPERTY_SOURCE_WITH_EXTENSIONS(Part::BodyBase, Part::Feature)
 
 BodyBase::BodyBase()
 {
-    ADD_PROPERTY(Model       , (0) );
     ADD_PROPERTY(Tip         , (0) );
     ADD_PROPERTY(BaseFeature , (0) );
-}
-
-bool BodyBase::hasFeature(const App::DocumentObject* f) const
-{
-    const std::vector<App::DocumentObject*> &features = Model.getValues();
-    return f == BaseFeature.getValue() || std::find(features.begin(), features.end(), f) != features.end();
 }
 
 BodyBase* BodyBase::findBodyOf(const App::DocumentObject* f)
@@ -57,7 +50,7 @@ BodyBase* BodyBase::findBodyOf(const App::DocumentObject* f)
         std::vector<App::DocumentObject*> bodies = doc->getObjectsOfType(BodyBase::getClassTypeId());
         for (std::vector<App::DocumentObject*>::const_iterator b = bodies.begin(); b != bodies.end(); b++) {
             BodyBase* body = static_cast<BodyBase*>(*b);
-            if (body->hasFeature(f))
+            if (body->hasObject(f))
                 return body;
         }
     }
@@ -73,10 +66,10 @@ bool BodyBase::isAfter(const App::DocumentObject *feature, const App::DocumentOb
     }
 
     if (!target || target == BaseFeature.getValue() ) {
-        return hasFeature (feature);
+        return hasObject (feature);
     }
 
-    const std::vector<App::DocumentObject *> & features = Model.getValues();
+    const std::vector<App::DocumentObject *> & features = Group.getValues();
     auto featureIt = std::find(features.begin(), features.end(), feature);
     auto targetIt = std::find(features.begin(), features.end(), target);
 

--- a/src/Mod/Part/App/BodyBase.cpp
+++ b/src/Mod/Part/App/BodyBase.cpp
@@ -41,6 +41,8 @@ BodyBase::BodyBase()
 {
     ADD_PROPERTY(Tip         , (0) );
     ADD_PROPERTY(BaseFeature , (0) );
+    
+    App::OriginGroupExtension::initExtension(this);
 }
 
 BodyBase* BodyBase::findBodyOf(const App::DocumentObject* f)

--- a/src/Mod/Part/App/BodyBase.h
+++ b/src/Mod/Part/App/BodyBase.h
@@ -25,6 +25,7 @@
 #define PART_BodyBase_H
 
 #include <App/PropertyStandard.h>
+#include <App/OriginGroupExtension.h>
 #include <Mod/Part/App/PartFeature.h>
 
 
@@ -36,19 +37,16 @@ namespace Part
  * in edit or active on a workbench, the body shows only the
  * resulting shape to the outside (Tip link).
  */
-class PartExport BodyBase : public Part::Feature
+class PartExport BodyBase : public Part::Feature, public App::OriginGroupExtension
 {
-    PROPERTY_HEADER(Part::BodyBase);
+    PROPERTY_HEADER_WITH_EXTENSIONS(Part::BodyBase);
 
 public:
     BodyBase();
 
-    /// The list of features
-    App::PropertyLinkList   Model;
-
     /**
      * The final feature of the body it is associated with.
-     * Note: tip may either point to the BaseFeature or to some feature inside the Model list.
+     * Note: tip may either point to the BaseFeature or to some feature inside the Group list.
      *       in case it points to the model the PartDesign::Body guaranties that it is a solid.
      */
     App::PropertyLink       Tip;
@@ -59,22 +57,15 @@ public:
      */
     App::PropertyLink BaseFeature;
 
-    /// Returns all Model objects prepanded by BaseFeature (if any)
+    /// Returns all Group objects prepanded by BaseFeature (if any)
     std::vector<App::DocumentObject *> getFullModel () {
         std::vector<App::DocumentObject *> rv;
         if ( BaseFeature.getValue () ) {
             rv.push_back ( BaseFeature.getValue () );
         }
-        std::copy ( Model.getValues ().begin (), Model.getValues ().end (), std::back_inserter (rv) );
+        std::copy ( Group.getValues ().begin (), Group.getValues ().end (), std::back_inserter (rv) );
         return rv;
     }
-
-    // These methods are located here to avoid a dependency of ViewProviderSketchObject on PartDesign
-    /// Remove the feature from the body
-    virtual void removeFeature(App::DocumentObject*){}
-
-    /// Return true if the feature belongs to this body or either the body is based on the feature
-    bool hasFeature(const App::DocumentObject *f) const;
 
     /// Return true if the feature belongs to the body and is located after the target
     bool isAfter(const App::DocumentObject *feature, const App::DocumentObject *target) const;

--- a/src/Mod/PartDesign/App/Body.cpp
+++ b/src/Mod/PartDesign/App/Body.cpp
@@ -60,15 +60,15 @@ Body::Body() {
 
 /*
 // Note: The following code will catch Python Document::removeObject() modifications. If the object removed is
-// a member of the Body::Model, then it will be automatically removed from the Model property which triggers the
+// a member of the Body::Group, then it will be automatically removed from the Group property which triggers the
 // following two methods
 // But since we require the Python user to call both Document::addObject() and Body::addFeature(), we should
 // also require calling both Document::removeObject and Body::removeFeature() in order to be consistent
 void Body::onBeforeChange(const App::Property *prop)
 {
     // Remember the feature before the current Tip. If the Tip is already at the first feature, remember the next feature
-    if (prop == &Model) {
-        std::vector<App::DocumentObject*> features = Model.getValues();
+    if (prop == &Group) {
+        std::vector<App::DocumentObject*> features = Group.getValues();
         if (features.empty()) {
             rememberTip = NULL;
         } else {
@@ -91,8 +91,8 @@ void Body::onBeforeChange(const App::Property *prop)
 
 void Body::onChanged(const App::Property *prop)
 {
-    if (prop == &Model) {
-        std::vector<App::DocumentObject*> features = Model.getValues();
+    if (prop == &Group) {
+        std::vector<App::DocumentObject*> features = Group.getValues();
         if (features.empty()) {
             Tip.setValue(NULL);
         } else {
@@ -119,7 +119,7 @@ short Body::mustExecute() const
 
 App::DocumentObject* Body::getPrevFeature(App::DocumentObject *start) const
 {
-    std::vector<App::DocumentObject*> features = Model.getValues();
+    std::vector<App::DocumentObject*> features = Group.getValues();
     if (features.empty()) return NULL;
     App::DocumentObject* st = (start == NULL ? Tip.getValue() : start);
     if (st == NULL)
@@ -146,9 +146,9 @@ App::DocumentObject* Body::getPrevSolidFeature(App::DocumentObject *start)
         return nullptr;
     }
 
-    assert ( hasFeature ( start ) );
+    assert ( hasObject ( start ) );
 
-    const std::vector<App::DocumentObject*> & features = Model.getValues();
+    const std::vector<App::DocumentObject*> & features = Group.getValues();
 
     auto startIt = std::find ( features.rbegin(), features.rend(), start );
     assert ( startIt != features.rend() );
@@ -173,9 +173,9 @@ App::DocumentObject* Body::getNextSolidFeature(App::DocumentObject *start)
         return nullptr;
     }
 
-    assert ( hasFeature ( start ) );
+    assert ( hasObject ( start ) );
 
-    const std::vector<App::DocumentObject*> & features = Model.getValues();
+    const std::vector<App::DocumentObject*> & features = Group.getValues();
     std::vector<App::DocumentObject*>::const_iterator startIt;
 
     if ( start == baseFeature ) {
@@ -264,9 +264,12 @@ Body* Body::findBodyOf(const App::DocumentObject* feature)
 }
 
 
-void Body::addFeature(App::DocumentObject *feature)
+void Body::addObject(App::DocumentObject *feature)
 {
-    insertFeature (feature, getNextSolidFeature (), /*after = */ false);
+    if(!isAllowed(feature))
+        throw Base::Exception("Body: object is not allowed");
+    
+    insertObject (feature, getNextSolidFeature (), /*after = */ false);
     // Move the Tip if we added a solid
     if (isSolidFeature(feature)) {
         Tip.setValue (feature);
@@ -274,7 +277,7 @@ void Body::addFeature(App::DocumentObject *feature)
 }
 
 
-void Body::insertFeature(App::DocumentObject* feature, App::DocumentObject* target, bool after)
+void Body::insertObject(App::DocumentObject* feature, App::DocumentObject* target, bool after)
 {
     if (target) {
         if (target == BaseFeature.getValue()) {
@@ -284,13 +287,13 @@ void Body::insertFeature(App::DocumentObject* feature, App::DocumentObject* targ
             } else {
                 throw Base::Exception("Body: impossible to insert before the base object");
             }
-        } else if (!hasFeature (target)) {
+        } else if (!hasObject (target)) {
             // Check if the target feature belongs to the body
             throw Base::Exception("Body: the feature we should insert relative to is not part of that body");
         }
     }
 
-    std::vector<App::DocumentObject*> model = Model.getValues();
+    std::vector<App::DocumentObject*> model = Group.getValues();
     std::vector<App::DocumentObject*>::iterator insertInto;
 
     // Find out the position there to insert the feature
@@ -313,7 +316,7 @@ void Body::insertFeature(App::DocumentObject* feature, App::DocumentObject* targ
     // Insert the new feature after the given
     model.insert (insertInto, feature);
 
-    Model.setValues (model);
+    Group.setValues (model);
 
     // Set the BaseFeature property
     if (Body::isSolidFeature(feature)) {
@@ -333,7 +336,7 @@ void Body::insertFeature(App::DocumentObject* feature, App::DocumentObject* targ
 }
 
 
-void Body::removeFeature(App::DocumentObject* feature)
+void Body::removeObject(App::DocumentObject* feature)
 {
     App::DocumentObject* nextSolidFeature = getNextSolidFeature(feature);
     App::DocumentObject* prevSolidFeature = getPrevSolidFeature(feature);
@@ -348,7 +351,7 @@ void Body::removeFeature(App::DocumentObject* feature)
         }
     }
 
-    std::vector<App::DocumentObject*> model = Model.getValues();
+    std::vector<App::DocumentObject*> model = Group.getValues();
     std::vector<App::DocumentObject*>::iterator it = std::find(model.begin(), model.end(), feature);
 
     // Adjust Tip feature if it is pointing to the deleted object
@@ -360,9 +363,9 @@ void Body::removeFeature(App::DocumentObject* feature)
         }
     }
 
-    // Erase feature from Model
+    // Erase feature from Group
     model.erase(it);
-    Model.setValues(model);
+    Group.setValues(model);
 }
 
 
@@ -372,8 +375,8 @@ App::DocumentObjectExecReturn *Body::execute(void)
     Base::Console().Error("Body '%s':\n", getNameInDocument());
     App::DocumentObject* tip = Tip.getValue();
     Base::Console().Error("   Tip: %s\n", (tip == NULL) ? "None" : tip->getNameInDocument());
-    std::vector<App::DocumentObject*> model = Model.getValues();
-    Base::Console().Error("   Model:\n");
+    std::vector<App::DocumentObject*> model = Group.getValues();
+    Base::Console().Error("   Group:\n");
     for (std::vector<App::DocumentObject*>::const_iterator m = model.begin(); m != model.end(); m++) {
         if (*m == NULL) continue;
         Base::Console().Error("      %s", (*m)->getNameInDocument());
@@ -422,14 +425,6 @@ void Body::onSettingDocument() {
     Part::BodyBase::onSettingDocument();
 }
 
-void Body::removeModelFromDocument() {
-    //delete all child objects if needed
-    std::set<DocumentObject*> grp ( Model.getValues().begin (), Model.getValues().end() );
-    for (auto obj : grp) {
-        this->getDocument()->remObject(obj->getNameInDocument());
-    }
-}
-
 void Body::onChanged (const App::Property* prop) {
     if ( prop == &BaseFeature ) {
         App::DocumentObject *baseFeature = BaseFeature.getValue();
@@ -441,24 +436,6 @@ void Body::onChanged (const App::Property* prop) {
     }
 
     Part::BodyBase::onChanged ( prop );
-}
-
-App::Origin *Body::getOrigin () const {
-    App::DocumentObject *originObj = Origin.getValue ();
-
-    if ( !originObj ) {
-        std::stringstream err;
-        err << "Can't find Origin for \"" << getNameInDocument () << "\"";
-        throw Base::Exception ( err.str().c_str () );
-
-    } else if (! originObj->isDerivedFrom ( App::Origin::getClassTypeId() ) ) {
-        std::stringstream err;
-        err << "Bad object \"" << originObj->getNameInDocument () << "\"(" << originObj->getTypeId().getName()
-            << ") linked to the Origin of \"" << getNameInDocument () << "\"";
-        throw Base::Exception ( err.str().c_str () );
-    } else {
-            return static_cast<App::Origin *> ( originObj );
-    }
 }
 
 void Body::setupObject () {

--- a/src/Mod/PartDesign/App/Body.cpp
+++ b/src/Mod/PartDesign/App/Body.cpp
@@ -62,7 +62,7 @@ Body::Body() {
 // Note: The following code will catch Python Document::removeObject() modifications. If the object removed is
 // a member of the Body::Group, then it will be automatically removed from the Group property which triggers the
 // following two methods
-// But since we require the Python user to call both Document::addObject() and Body::addFeature(), we should
+// But since we require the Python user to call both Document::addObject() and Body::addObject(), we should
 // also require calling both Document::removeObject and Body::removeFeature() in order to be consistent
 void Body::onBeforeChange(const App::Property *prop)
 {

--- a/src/Mod/PartDesign/App/Body.cpp
+++ b/src/Mod/PartDesign/App/Body.cpp
@@ -439,26 +439,10 @@ void Body::onChanged (const App::Property* prop) {
 }
 
 void Body::setupObject () {
-    // NOTE: the code shared with App::OriginGroup
-    App::Document *doc = getDocument ();
-
-    std::string objName = std::string ( getNameInDocument() ).append ( "Origin" );
-
-    App::DocumentObject *originObj = doc->addObject ( "App::Origin", objName.c_str () );
-
-    assert ( originObj && originObj->isDerivedFrom ( App::Origin::getClassTypeId () ) );
-    Origin.setValue ( originObj );
-
     Part::BodyBase::setupObject ();
 }
 
 void Body::unsetupObject () {
-    App::DocumentObject *origin = Origin.getValue ();
-
-    if (origin && !origin->isDeleting ()) {
-        origin->getDocument ()->remObject (origin->getNameInDocument());
-    }
-
     Part::BodyBase::unsetupObject ();
 }
 

--- a/src/Mod/PartDesign/App/Body.h
+++ b/src/Mod/PartDesign/App/Body.h
@@ -68,7 +68,7 @@ public:
      * Add the feature into the body at the current insert point.
      * The insertion poin is the before next solid after the Tip feature
      */
-    void addFeature(App::DocumentObject* feature);
+    virtual void addObject(App::DocumentObject*) override;
 
     /**
      * Insert the feature into the body after the given feature.
@@ -81,13 +81,10 @@ public:
      *
      * @note the methode doesn't modifies the Tip unlike addFeature()
      */
-    void insertFeature(App::DocumentObject* feature, App::DocumentObject* target, bool after=false);
+    void insertObject(App::DocumentObject* feature, App::DocumentObject* target, bool after=false);
 
     /// Remove the feature from the body
-    void removeFeature(App::DocumentObject* feature);
-
-    /// Delets all the objects linked to the model.
-    void removeModelFromDocument();
+    virtual void removeObject(DocumentObject* obj) override;
 
     /**
      * Checks if the given document object lays after the current insert point
@@ -110,6 +107,7 @@ public:
       * all features derived from PartDesign::Feature and Part::Datum and sketches
       */
     static bool isAllowed(const App::DocumentObject* f);
+    virtual bool allowObject(DocumentObject* f) {return isAllowed(f);};
 
     /**
      * Return the body which this feature belongs too, or NULL
@@ -117,13 +115,8 @@ public:
      */
     static Body *findBodyOf(const App::DocumentObject* feature);
 
-    /// Returns the origin link or throws an exception
-    App::Origin *getOrigin () const;
-
     PyObject *getPyObject(void);
 
-    /// Origin linked to the property, please use getOrigin () to access it
-    App::PropertyLink Origin;
 
 protected:
     virtual void onSettingDocument();

--- a/src/Mod/PartDesign/App/Body.h
+++ b/src/Mod/PartDesign/App/Body.h
@@ -79,7 +79,7 @@ public:
      *                 and into the begin if where is InsertAfter.
      * @param after    if true insert the feature after the target. Default is false.
      *
-     * @note the methode doesn't modifies the Tip unlike addFeature()
+     * @note the methode doesn't modifies the Tip unlike addObject()
      */
     void insertObject(App::DocumentObject* feature, App::DocumentObject* target, bool after=false);
 

--- a/src/Mod/PartDesign/App/BodyPy.xml
+++ b/src/Mod/PartDesign/App/BodyPy.xml
@@ -13,14 +13,9 @@
       <Author Licence="LGPL" Name="Juergen Riegel" EMail="FreeCAD@juergen-riegel.net" />
       <UserDocu>PartDesign body class</UserDocu>
     </Documentation>
-    <Methode Name="addFeature">
+    <Methode Name="insertObject">
             <Documentation>
-                    <UserDocu>addFeature(feat) - Add the given feature after the current Tip feature</UserDocu>
-            </Documentation>
-    </Methode>
-    <Methode Name="insertFeature">
-            <Documentation>
-                    <UserDocu>insertFeatureAfter(feature, target, after=False)
+                    <UserDocu>insertObject(feature, target, after=False)
                         Insert the feature into the body after the given feature.
 
                         @param feature  The feature to insert into the body
@@ -29,18 +24,8 @@
                           and into the begin if where is InsertAfter.
                         @param after    if true insert the feature after the target. Default is false.
 
-                        @note the methode doesn't modifies the Tip unlike addFeature()
+                        @note the methode doesn't modifies the Tip unlike addObject()
                     </UserDocu>
-            </Documentation>
-    </Methode>
-    <Methode Name="removeFeature">
-            <Documentation>
-                    <UserDocu>removeFeature(feat) - Remove the given feature from the Body</UserDocu>
-            </Documentation>
-    </Methode>
-    <Methode Name="removeModelFromDocument">
-            <Documentation>
-                <UserDocu>Delets all the objects linked to the model.</UserDocu>
             </Documentation>
     </Methode>
   </PythonExport>

--- a/src/Mod/PartDesign/App/BodyPyImp.cpp
+++ b/src/Mod/PartDesign/App/BodyPyImp.cpp
@@ -68,7 +68,7 @@ PyObject* BodyPy::addFeature(PyObject *args)
     Body* body = this->getBodyPtr();
 
     try {
-        body->addFeature(feature);
+        body->addObject(feature);
     } catch (Base::Exception& e) {
         PyErr_SetString(PyExc_SystemError, e.what());
         return 0;
@@ -107,7 +107,7 @@ PyObject* BodyPy::insertFeature(PyObject *args)
     Body* body = this->getBodyPtr();
 
     try {
-        body->insertFeature(feature, target, after);
+        body->insertObject(feature, target, after);
     } catch (Base::Exception& e) {
         PyErr_SetString(PyExc_SystemError, e.what());
         return 0;
@@ -126,7 +126,7 @@ PyObject* BodyPy::removeFeature(PyObject *args)
     Body* body = this->getBodyPtr();
 
     try {
-        body->removeFeature(feature);
+        body->removeObject(feature);
     } catch (Base::Exception& e) {
         PyErr_SetString(PyExc_SystemError, e.what());
         return 0;
@@ -140,7 +140,7 @@ PyObject*  BodyPy::removeModelFromDocument(PyObject *args)
     if (!PyArg_ParseTuple(args, ""))
         return 0;
 
-    getBodyPtr()->removeModelFromDocument();
+    getBodyPtr()->removeObjectsFromDocument();
     Py_Return;
 }
 

--- a/src/Mod/PartDesign/App/BodyPyImp.cpp
+++ b/src/Mod/PartDesign/App/BodyPyImp.cpp
@@ -52,32 +52,7 @@ int BodyPy::setCustomAttributes(const char* /*attr*/, PyObject* /*obj*/)
     return 0;
 }
 
-PyObject* BodyPy::addFeature(PyObject *args)
-{
-    PyObject* featurePy;
-    if (!PyArg_ParseTuple(args, "O!", &(App::DocumentObjectPy::Type), &featurePy))
-        return 0;
-
-    App::DocumentObject* feature = static_cast<App::DocumentObjectPy*>(featurePy)->getDocumentObjectPtr();
-
-    if (!Body::isAllowed(feature)) {
-        PyErr_SetString(PyExc_SystemError, "Only PartDesign features, datum features and sketches can be inserted into a Body");
-        return 0;
-    }
-
-    Body* body = this->getBodyPtr();
-
-    try {
-        body->addObject(feature);
-    } catch (Base::Exception& e) {
-        PyErr_SetString(PyExc_SystemError, e.what());
-        return 0;
-    }
-
-    Py_Return;
-}
-
-PyObject* BodyPy::insertFeature(PyObject *args)
+PyObject* BodyPy::insertObject(PyObject *args)
 {
     PyObject* featurePy;
     PyObject* targetPy;
@@ -115,32 +90,3 @@ PyObject* BodyPy::insertFeature(PyObject *args)
 
     Py_Return;
 }
-
-PyObject* BodyPy::removeFeature(PyObject *args)
-{
-    PyObject* featurePy;
-    if (!PyArg_ParseTuple(args, "O!", &(App::DocumentObjectPy::Type), &featurePy))
-        return 0;
-
-    App::DocumentObject* feature = static_cast<App::DocumentObjectPy*>(featurePy)->getDocumentObjectPtr();
-    Body* body = this->getBodyPtr();
-
-    try {
-        body->removeObject(feature);
-    } catch (Base::Exception& e) {
-        PyErr_SetString(PyExc_SystemError, e.what());
-        return 0;
-    }
-
-    Py_Return;
-}
-
-PyObject*  BodyPy::removeModelFromDocument(PyObject *args)
-{
-    if (!PyArg_ParseTuple(args, ""))
-        return 0;
-
-    getBodyPtr()->removeObjectsFromDocument();
-    Py_Return;
-}
-

--- a/src/Mod/PartDesign/FeatureHole/TaskHole.py
+++ b/src/Mod/PartDesign/FeatureHole/TaskHole.py
@@ -54,18 +54,18 @@ class TaskHole:
             sketch = groove.Sketch
             plane = sketch.Support[0]
             axis = plane.References[0][0]     
-            body.removeFeature(self.feature)
+            body.removeObject(self.feature)
             document.removeObject(self.feature.Name)                      
-            body.removeFeature(groove)
+            body.removeObject(groove)
             document.removeObject(groove.Name)
-            body.removeFeature(sketch)
+            body.removeObject(sketch)
             try:
                 document.removeObject(sketch.Name)      
             except:
                 pass # This always throws an exception: "Sketch support has been deleted" from SketchObject::execute()
-            body.removeFeature(plane)
+            body.removeObject(plane)
             document.removeObject(plane.Name)
-            body.removeFeature(axis)
+            body.removeObject(axis)
             document.removeObject(axis.Name)            
         FreeCADGui.ActiveDocument.resetEdit()
         FreeCADGui.Control.closeDialog(self)

--- a/src/Mod/PartDesign/Gui/Command.cpp
+++ b/src/Mod/PartDesign/Gui/Command.cpp
@@ -385,7 +385,7 @@ void CmdPartDesignNewSketch::activated(int iMsg)
             supportString = std::string("(App.activeDocument().") + obj->getNameInDocument() + ", '')";
         }
 
-        if (!pcActiveBody->hasFeature(obj)) {
+        if (!pcActiveBody->hasObject(obj)) {
             if ( !obj->isDerivedFrom ( App::Plane::getClassTypeId() ) )  {
                 // TODO check here if the plane associated with right part/body (2015-09-01, Fat-Zer)
 
@@ -409,7 +409,7 @@ void CmdPartDesignNewSketch::activated(int iMsg)
                     auto copy = PartDesignGui::TaskFeaturePick::makeCopy(obj, sub, dlg.radioIndependent->isChecked());
 
                     if(pcActiveBody)
-                        pcActiveBody->addFeature(copy);
+                        pcActiveBody->addObject(copy);
                     else if (pcActivePart)
                         pcActivePart->addObject(copy);
 
@@ -466,7 +466,7 @@ void CmdPartDesignNewSketch::activated(int iMsg)
         for (auto plane: datumPlanes) {
             planes.push_back ( plane );
             // Check whether this plane belongs to the active body
-            if ( pcActiveBody && pcActiveBody->hasFeature(plane) ) {
+            if ( pcActiveBody && pcActiveBody->hasObject(plane) ) {
                 if ( !pcActiveBody->isAfterInsertPoint ( plane ) ) {
                     validPlanes++;
                     status.push_back(PartDesignGui::TaskFeaturePick::validFeature);
@@ -640,7 +640,7 @@ unsigned validateSketches(std::vector<App::DocumentObject*>& sketches,
                 status.push_back(PartDesignGui::TaskFeaturePick::otherPart);
                 continue;
             }
-        } else if (!pcActiveBody->hasFeature(*s)) {
+        } else if (!pcActiveBody->hasObject(*s)) {
             // Check whether this plane belongs to a body of the same part
             PartDesign::Body* b = PartDesign::Body::findBodyOf(*s);
             if(!b)
@@ -807,7 +807,7 @@ void prepareProfileBased(Gui::Command* cmd, const std::string& which,
                 auto copy = PartDesignGui::TaskFeaturePick::makeCopy(sketches[0], "", dlg.radioIndependent->isChecked());
                 auto oBody = PartDesignGui::getBodyFor(sketches[0], false);
                 if(oBody)
-                    pcActiveBody->addFeature(copy);
+                    pcActiveBody->addObject(copy);
                 else
                     pcActivePart->addObject(copy);
 

--- a/src/Mod/PartDesign/Gui/Command.cpp
+++ b/src/Mod/PartDesign/Gui/Command.cpp
@@ -125,7 +125,7 @@ void UnifiedDatumCommand(Gui::Command &cmd, Base::Type type, std::string name)
                 }
             }
             if (pcActiveBody) {
-                cmd.doCommand(Gui::Command::Doc,"App.activeDocument().%s.addFeature(App.activeDocument().%s)",
+                cmd.doCommand(Gui::Command::Doc,"App.activeDocument().%s.addObject(App.activeDocument().%s)",
                                pcActiveBody->getNameInDocument(), FeatName.c_str());
             }
             cmd.doCommand(Gui::Command::Doc,"App.activeDocument().recompute()");  // recompute the feature based on its references
@@ -278,7 +278,7 @@ void CmdPartDesignShapeBinder::activated(int iMsg)
             doCommand(Gui::Command::Doc,"App.activeDocument().%s.Support = %s",
                     FeatName.c_str(), support.getPyReprString().c_str());
         }
-        doCommand(Gui::Command::Doc,"App.activeDocument().%s.addFeature(App.activeDocument().%s)",
+        doCommand(Gui::Command::Doc,"App.activeDocument().%s.addObject(App.activeDocument().%s)",
                 pcActiveBody->getNameInDocument(), FeatName.c_str());
         doCommand(Gui::Command::Doc,"App.activeDocument().recompute()");  // recompute the feature based on its references
         doCommand(Gui::Command::Gui,"Gui.activeDocument().setEdit('%s')",FeatName.c_str());
@@ -429,7 +429,7 @@ void CmdPartDesignNewSketch::activated(int iMsg)
         doCommand(Doc,"App.activeDocument().addObject('Sketcher::SketchObject','%s')",FeatName.c_str());
         doCommand(Doc,"App.activeDocument().%s.Support = %s",FeatName.c_str(),supportString.c_str());
         doCommand(Doc,"App.activeDocument().%s.MapMode = '%s'",FeatName.c_str(),Attacher::AttachEngine::getModeName(Attacher::mmFlatFace).c_str());
-        doCommand(Doc,"App.activeDocument().%s.addFeature(App.activeDocument().%s)",
+        doCommand(Doc,"App.activeDocument().%s.addObject(App.activeDocument().%s)",
                        pcActiveBody->getNameInDocument(), FeatName.c_str());
         doCommand(Gui,"App.activeDocument().recompute()");  // recompute the sketch placement based on its support
         //doCommand(Gui,"Gui.activeDocument().activeView().setCamera('%s')",cam.c_str());
@@ -521,7 +521,7 @@ void CmdPartDesignNewSketch::activated(int iMsg)
             Gui::Command::doCommand(Doc,"App.activeDocument().%s.Support = %s",FeatName.c_str(),supportString.c_str());
             Gui::Command::doCommand(Doc,"App.activeDocument().%s.MapMode = '%s'",FeatName.c_str(),Attacher::AttachEngine::getModeName(Attacher::mmFlatFace).c_str());
             Gui::Command::updateActive(); // Make sure the Support's Placement property is updated
-            Gui::Command::doCommand(Doc,"App.activeDocument().%s.addFeature(App.activeDocument().%s)",
+            Gui::Command::doCommand(Doc,"App.activeDocument().%s.addObject(App.activeDocument().%s)",
                         pcActiveBody->getNameInDocument(), FeatName.c_str());
             //doCommand(Gui,"Gui.activeDocument().activeView().setCamera('%s')",cam.c_str());
             Gui::Command::doCommand(Gui,"Gui.activeDocument().setEdit('%s')",FeatName.c_str());
@@ -584,13 +584,13 @@ void finishFeature(const Gui::Command* cmd, const std::string& FeatName,
         App::DocumentObject* lastSolidFeature = pcActiveBody->Tip.getValue();
         if (!prevSolidFeature || prevSolidFeature == lastSolidFeature) {
             // If the previous feature not given or is the Tip add Feature after it.
-            cmd->doCommand(cmd->Doc,"App.activeDocument().%s.addFeature(App.activeDocument().%s)",
+            cmd->doCommand(cmd->Doc,"App.activeDocument().%s.addObject(App.activeDocument().%s)",
                     pcActiveBody->getNameInDocument(), FeatName.c_str());
             prevSolidFeature = lastSolidFeature;
         } else {
             // Insert the feature into the body after the given one.
             cmd->doCommand(cmd->Doc,
-                    "App.activeDocument().%s.insertFeature(App.activeDocument().%s, App.activeDocument().%s, True)",
+                    "App.activeDocument().%s.insertObject(App.activeDocument().%s, App.activeDocument().%s, True)",
                     pcActiveBody->getNameInDocument(), FeatName.c_str(), prevSolidFeature->getNameInDocument());
         }
     }
@@ -1855,7 +1855,7 @@ void CmdPartDesignMultiTransform::activated(int iMsg)
 
         // Remove the Transformed feature from the Body
         if(pcActiveBody)
-            doCommand(Doc, "App.activeDocument().%s.removeFeature(App.activeDocument().%s)",
+            doCommand(Doc, "App.activeDocument().%s.removeObject(App.activeDocument().%s)",
                       pcActiveBody->getNameInDocument(), trFeat->getNameInDocument());
 
         // Create a MultiTransform feature and move the Transformed feature inside it

--- a/src/Mod/PartDesign/Gui/CommandBody.cpp
+++ b/src/Mod/PartDesign/Gui/CommandBody.cpp
@@ -742,7 +742,7 @@ void CmdPartDesignMoveFeatureInTree::activated(int iMsg)
     if ( body ) {
         bodyBase= body->BaseFeature.getValue();
         for ( auto feat: features ) {
-            if ( !body->hasFeature ( feat ) ) {
+            if ( !body->hasObject ( feat ) ) {
                 allFeaturesFromSameBody = false;
                 break;
             }
@@ -760,7 +760,7 @@ void CmdPartDesignMoveFeatureInTree::activated(int iMsg)
     }
 
     // Create a list of all features in this body
-    const std::vector<App::DocumentObject*> & model = body->Model.getValues();
+    const std::vector<App::DocumentObject*> & model = body->Group.getValues();
 
     // Ask user to select the target feature
     bool ok;

--- a/src/Mod/PartDesign/Gui/CommandBody.cpp
+++ b/src/Mod/PartDesign/Gui/CommandBody.cpp
@@ -401,7 +401,7 @@ void CmdPartDesignMigrate::activated(int iMsg)
                 PartDesign::ProfileBased *sketchBased = static_cast<PartDesign::ProfileBased *> ( feature );
                 Part::Part2DObject *sketch = sketchBased->getVerifiedSketch( /*silent =*/ true);
                 if ( sketch ) {
-                    doCommand ( Doc,"App.activeDocument().%s.addFeature(App.activeDocument().%s)",
+                    doCommand ( Doc,"App.activeDocument().%s.addObject(App.activeDocument().%s)",
                             bodyName.c_str (), sketch->getNameInDocument() );
 
                     if ( sketch->isDerivedFrom ( Sketcher::SketchObject::getClassTypeId() ) ) {
@@ -419,7 +419,7 @@ void CmdPartDesignMigrate::activated(int iMsg)
                     }
                 }
             }
-            doCommand ( Doc,"App.activeDocument().%s.addFeature(App.activeDocument().%s)",
+            doCommand ( Doc,"App.activeDocument().%s.addObject(App.activeDocument().%s)",
                     bodyName.c_str (), feature->getNameInDocument() );
 
             PartDesignGui::relinkToBody ( feature );
@@ -552,7 +552,7 @@ void CmdPartDesignDuplicateSelection::activated(int iMsg)
 
         for (auto feature : newFeatures) {
             if (PartDesign::Body::isAllowed(feature)) {
-                doCommand(Doc,"App.activeDocument().%s.addFeature(App.activeDocument().%s)",
+                doCommand(Doc,"App.activeDocument().%s.addObject(App.activeDocument().%s)",
                           pcActiveBody->getNameInDocument(), feature->getNameInDocument());
                 doCommand(Gui,"Gui.activeDocument().hide(\"%s\")", feature->getNameInDocument());
             }
@@ -658,14 +658,14 @@ void CmdPartDesignMoveFeature::activated(int iMsg)
         // Remove from the source body if the feature belonged to a body
         if (source) {
             featureWasTip = (source->Tip.getValue() == feat);
-            doCommand(Doc,"App.activeDocument().%s.removeFeature(App.activeDocument().%s)",
+            doCommand(Doc,"App.activeDocument().%s.removeObject(App.activeDocument().%s)",
                       source->getNameInDocument(), (feat)->getNameInDocument());
         }
 
         App::DocumentObject* targetOldTip = target->Tip.getValue();
 
         // Add to target body (always at the Tip)
-        doCommand(Doc,"App.activeDocument().%s.addFeature(App.activeDocument().%s)",
+        doCommand(Doc,"App.activeDocument().%s.addObject(App.activeDocument().%s)",
                       target->getNameInDocument(), (feat)->getNameInDocument());
         // Recompute to update the shape
         doCommand(Gui,"App.activeDocument().recompute()");
@@ -798,9 +798,9 @@ void CmdPartDesignMoveFeatureInTree::activated(int iMsg)
         // Remove and re-insert the feature to/from the Body
         // TODO if tip was moved the new position of tip is quite undetermined (2015-08-07, Fat-Zer)
         // TODO warn the user if we are moving an object to some place before the object's link (2015-08-07, Fat-Zer)
-        doCommand ( Doc,"App.activeDocument().%s.removeFeature(App.activeDocument().%s)",
+        doCommand ( Doc,"App.activeDocument().%s.removeObject(App.activeDocument().%s)",
                 body->getNameInDocument(), feat->getNameInDocument() );
-        doCommand ( Doc, "App.activeDocument().%s.insertFeature(App.activeDocument().%s, %s, True)",
+        doCommand ( Doc, "App.activeDocument().%s.insertObject(App.activeDocument().%s, %s, True)",
                 body->getNameInDocument(), feat->getNameInDocument(), targetStr.c_str () );
     }
 

--- a/src/Mod/PartDesign/Gui/CommandPrimitive.cpp
+++ b/src/Mod/PartDesign/Gui/CommandPrimitive.cpp
@@ -133,7 +133,7 @@ void CmdPrimtiveCompAdditive::activated(int iMsg)
     }
 
 
-    Gui::Command::doCommand(Doc,"App.ActiveDocument.%s.addFeature(App.activeDocument().%s)"
+    Gui::Command::doCommand(Doc,"App.ActiveDocument.%s.addObject(App.activeDocument().%s)"
                     ,pcActiveBody->getNameInDocument(), FeatName.c_str());
     Gui::Command::updateActive();
 
@@ -322,7 +322,7 @@ void CmdPrimtiveCompSubtractive::activated(int iMsg)
             FeatName.c_str());
     }
 
-    Gui::Command::doCommand(Doc,"App.ActiveDocument.%s.addFeature(App.activeDocument().%s)"
+    Gui::Command::doCommand(Doc,"App.ActiveDocument.%s.addObject(App.activeDocument().%s)"
                     ,pcActiveBody->getNameInDocument(), FeatName.c_str());
     Gui::Command::updateActive();
 

--- a/src/Mod/PartDesign/Gui/ReferenceSelection.cpp
+++ b/src/Mod/PartDesign/Gui/ReferenceSelection.cpp
@@ -115,7 +115,7 @@ bool ReferenceSelection::allow(App::Document* pDoc, App::DocumentObject* pObj, c
 
         if (!body) { // Allow selecting Part::Datum features from the active Body
             return false;
-        } else if (!allowOtherBody && !body->hasFeature(pObj)) {
+        } else if (!allowOtherBody && !body->hasObject(pObj)) {
             return false;
         }
 
@@ -229,7 +229,7 @@ void getReferencedSelection(const App::DocumentObject* thisObj, const Gui::Selec
 
                     auto copy = PartDesignGui::TaskFeaturePick::makeCopy(selObj, subname, dlg.radioIndependent->isChecked());
                     if(selBody)
-                        body->addFeature(copy);
+                        body->addObject(copy);
                     else
                         pcActivePart->addObject(copy);
 

--- a/src/Mod/PartDesign/Gui/TaskDatumParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskDatumParameters.cpp
@@ -136,7 +136,7 @@ bool TaskDlgDatumParameters::accept() {
     //the user has to decide which option we should take if external references are used
     bool ext = false;
     for(App::DocumentObject* obj : pcDatum->Support.getValues()) {
-        if(!pcActiveBody->hasFeature(obj) && !pcActiveBody->getOrigin()->hasObject(obj))
+        if(!pcActiveBody->hasObject(obj) && !pcActiveBody->getOrigin()->hasObject(obj))
             ext = true;
     }
     if(ext) {
@@ -155,7 +155,7 @@ bool TaskDlgDatumParameters::accept() {
             int index = 0;
             for(App::DocumentObject* obj : pcDatum->Support.getValues()) {
 
-                if(!pcActiveBody->hasFeature(obj) && !pcActiveBody->getOrigin()->hasObject(obj)) {
+                if(!pcActiveBody->hasObject(obj) && !pcActiveBody->getOrigin()->hasObject(obj)) {
                     objs.push_back(PartDesignGui::TaskFeaturePick::makeCopy(obj, subs[index], dlg.radioIndependent->isChecked()));
                     copies.push_back(objs.back());
                     subs[index] = "";
@@ -176,7 +176,7 @@ bool TaskDlgDatumParameters::accept() {
     //we need to add the copied features to the body after the command action, as otherwise freecad crashs unexplainable
     for(auto obj : copies) {
         if(pcActiveBody)
-            pcActiveBody->addFeature(obj);
+            pcActiveBody->addObject(obj);
         else if (pcActivePart)
             pcActivePart->addObject(obj);
     }

--- a/src/Mod/PartDesign/Gui/TaskFeaturePick.cpp
+++ b/src/Mod/PartDesign/Gui/TaskFeaturePick.cpp
@@ -235,17 +235,17 @@ std::vector<App::DocumentObject*> TaskFeaturePick::buildFeatures()
                     auto copy = makeCopy(obj, "", ui->radioIndependent->isChecked());
 
                     if (*st == otherBody) {
-                        activeBody->addFeature(copy);
+                        activeBody->addObject(copy);
                     }
                     else if (*st == otherPart) {
                         auto oBody = PartDesignGui::getBodyFor(obj, false);
                         if (!oBody)
                             activePart->addObject(copy);
                         else
-                            activeBody->addFeature(copy);
+                            activeBody->addObject(copy);
                     }
                     else if (*st == notInBody) {
-                        activeBody->addFeature(copy);
+                        activeBody->addObject(copy);
                         // doesn't supposed to get here anything but sketch but to be on the safe side better to check
                         if (copy->getTypeId().isDerivedFrom(Sketcher::SketchObject::getClassTypeId())) {
                             Sketcher::SketchObject *sketch = static_cast<Sketcher::SketchObject*>(copy);

--- a/src/Mod/PartDesign/Gui/TaskPipeParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskPipeParameters.cpp
@@ -720,13 +720,13 @@ bool TaskDlgPipeParameters::accept()
     std::vector<App::DocumentObject*> copies;
 
     bool ext = false;
-    if(!pcActiveBody->hasFeature(pcPipe->Spine.getValue()) && !pcActiveBody->getOrigin()->hasObject(pcPipe->Spine.getValue()))
+    if(!pcActiveBody->hasObject(pcPipe->Spine.getValue()) && !pcActiveBody->getOrigin()->hasObject(pcPipe->Spine.getValue()))
         ext = true;
-    else if(!pcActiveBody->hasFeature(pcPipe->AuxillerySpine.getValue()) && !pcActiveBody->getOrigin()->hasObject(pcPipe->AuxillerySpine.getValue()))
+    else if(!pcActiveBody->hasObject(pcPipe->AuxillerySpine.getValue()) && !pcActiveBody->getOrigin()->hasObject(pcPipe->AuxillerySpine.getValue()))
             ext = true;
     else {
         for(App::DocumentObject* obj : pcPipe->Sections.getValues()) {
-            if(!pcActiveBody->hasFeature(obj) && !pcActiveBody->getOrigin()->hasObject(obj))
+            if(!pcActiveBody->hasObject(obj) && !pcActiveBody->getOrigin()->hasObject(obj))
                 ext = true;
         }
     }
@@ -741,12 +741,12 @@ bool TaskDlgPipeParameters::accept()
             return false;
         else if(!dlg.radioXRef->isChecked()) {
 
-            if(!pcActiveBody->hasFeature(pcPipe->Spine.getValue()) && !pcActiveBody->getOrigin()->hasObject(pcPipe->Spine.getValue())) {
+            if(!pcActiveBody->hasObject(pcPipe->Spine.getValue()) && !pcActiveBody->getOrigin()->hasObject(pcPipe->Spine.getValue())) {
                 pcPipe->Spine.setValue(PartDesignGui::TaskFeaturePick::makeCopy(pcPipe->Spine.getValue(), "", dlg.radioIndependent->isChecked()),
                                         pcPipe->Spine.getSubValues());
                 copies.push_back(pcPipe->Spine.getValue());
             }
-            else if(!pcActiveBody->hasFeature(pcPipe->AuxillerySpine.getValue()) && !pcActiveBody->getOrigin()->hasObject(pcPipe->AuxillerySpine.getValue())){
+            else if(!pcActiveBody->hasObject(pcPipe->AuxillerySpine.getValue()) && !pcActiveBody->getOrigin()->hasObject(pcPipe->AuxillerySpine.getValue())){
                 pcPipe->AuxillerySpine.setValue(PartDesignGui::TaskFeaturePick::makeCopy(pcPipe->AuxillerySpine.getValue(), "", dlg.radioIndependent->isChecked()),
                                         pcPipe->AuxillerySpine.getSubValues());
                 copies.push_back(pcPipe->AuxillerySpine.getValue());
@@ -756,7 +756,7 @@ bool TaskDlgPipeParameters::accept()
             int index = 0;
             for(App::DocumentObject* obj : pcPipe->Sections.getValues()) {
 
-                if(!pcActiveBody->hasFeature(obj) && !pcActiveBody->getOrigin()->hasObject(obj)) {
+                if(!pcActiveBody->hasObject(obj) && !pcActiveBody->getOrigin()->hasObject(obj)) {
                     objs.push_back(PartDesignGui::TaskFeaturePick::makeCopy(obj, "", dlg.radioIndependent->isChecked()));
                     copies.push_back(objs.back());
                 }
@@ -781,7 +781,7 @@ bool TaskDlgPipeParameters::accept()
         for(auto obj : copies) {
             //Dead code: pcActiveBody was previously used without checking for null, so it won't be null here either.
             //if(pcActiveBody)
-            pcActiveBody->addFeature(obj);
+            pcActiveBody->addObject(obj);
             //else if (pcActivePart)
             //    pcActivePart->addObject(obj);
         }

--- a/src/Mod/PartDesign/Gui/TaskPrimitiveParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskPrimitiveParameters.cpp
@@ -36,13 +36,16 @@
 #include "ViewProviderDatumCS.h"
 #include <Mod/PartDesign/App/FeaturePrimitive.h>
 #include <Mod/PartDesign/App/DatumCS.h>
+#include <Mod/PartDesign/App/Body.h>
 #include <Mod/Part/App/DatumFeature.h>
 #include <Gui/Application.h>
 #include <Gui/Document.h>
 #include <Gui/Command.h>
 #include <Gui/BitmapFactory.h>
+#include <Gui/ViewProviderOrigin.h>
 #include <Base/Interpreter.h>
 #include <Base/Console.h>
+#include <App/Origin.h>
 #include <boost/bind.hpp>
 
 using namespace PartDesignGui;
@@ -217,6 +220,19 @@ TaskBoxPrimitives::TaskBoxPrimitives(ViewProviderPrimitive* vp, QWidget* parent)
         if(i != index)
             ui.widgetStack->widget(i)->setSizePolicy(QSizePolicy(QSizePolicy::Ignored, QSizePolicy::Ignored));
     }
+    
+    //show the parts coordinate system axis for selection
+    PartDesign::Body * body = PartDesign::Body::findBodyOf(vp->getObject());
+    if(body) {
+        try {
+            App::Origin *origin = body->getOrigin();
+            Gui::ViewProviderOrigin* vpOrigin;
+            vpOrigin = static_cast<Gui::ViewProviderOrigin*>(Gui::Application::Instance->getViewProvider(origin));
+            vpOrigin->setTemporaryVisibility(true, true);
+        } catch (const Base::Exception &ex) {
+            Base::Console().Error ("%s\n", ex.what () );
+        }
+    }
 }
 
 /*  
@@ -224,6 +240,18 @@ TaskBoxPrimitives::TaskBoxPrimitives(ViewProviderPrimitive* vp, QWidget* parent)
  */
 TaskBoxPrimitives::~TaskBoxPrimitives()
 {
+    //hide the parts coordinate system axis for selection
+    PartDesign::Body * body = PartDesign::Body::findBodyOf ( vp->getObject() );
+    if(body) {
+        try {
+            App::Origin *origin = body->getOrigin();
+            Gui::ViewProviderOrigin* vpOrigin;
+            vpOrigin = static_cast<Gui::ViewProviderOrigin*>(Gui::Application::Instance->getViewProvider(origin));
+            vpOrigin->resetTemporaryVisibility();
+        } catch (const Base::Exception &ex) {
+            Base::Console().Error ("%s\n", ex.what () );
+        }
+    }
 }
 
 void TaskBoxPrimitives::onBoxHeightChanged(double v) {

--- a/src/Mod/PartDesign/Gui/TaskSketchBasedParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskSketchBasedParameters.cpp
@@ -147,7 +147,7 @@ const QByteArray TaskSketchBasedParameters::onFaceName(const QString& text)
         // everything is OK (we assume a Part can only have exactly 3 App::Plane objects located at the base of the feature tree)
         return QByteArray();
     } else if (obj->getTypeId().isDerivedFrom(Part::Datum::getClassTypeId())) {
-        if (!activeBody->hasFeature(obj))
+        if (!activeBody->hasObject(obj))
             return QByteArray();
         return QByteArray();
     } else {

--- a/src/Mod/PartDesign/Gui/Utils.cpp
+++ b/src/Mod/PartDesign/Gui/Utils.cpp
@@ -88,7 +88,7 @@ PartDesign::Body *getBodyFor(const App::DocumentObject* obj, bool messageIfNot)
         return nullptr;
 
     PartDesign::Body * rv = getBody( /*messageIfNot =*/ false);
-    if(rv && rv->hasFeature(obj))
+    if(rv && rv->hasObject(obj))
         return rv;
 
     rv = PartDesign::Body::findBodyOf(obj);

--- a/src/Mod/PartDesign/Gui/Utils.cpp
+++ b/src/Mod/PartDesign/Gui/Utils.cpp
@@ -221,7 +221,7 @@ void fixSketchSupport (Sketcher::SketchObject* sketch)
         Gui::Command::doCommand(Gui::Command::Doc,"App.activeDocument().%s.superPlacement.Base.z = %f",
                 Datum.c_str(), offset);
         Gui::Command::doCommand(Gui::Command::Doc,
-                "App.activeDocument().%s.insertFeature(App.activeDocument().%s, App.activeDocument().%s)",
+                "App.activeDocument().%s.insertObject(App.activeDocument().%s, App.activeDocument().%s)",
                 body->getNameInDocument(), Datum.c_str(), sketch->getNameInDocument());
         Gui::Command::doCommand(Gui::Command::Doc,
                 "App.activeDocument().%s.Support = (App.activeDocument().%s,[''])",

--- a/src/Mod/PartDesign/Gui/ViewProvider.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProvider.cpp
@@ -179,7 +179,7 @@ void ViewProvider::onChanged(const App::Property* prop) {
         if(body) {
             
             //hide all features in the body other than this object
-            for(App::DocumentObject* obj : body->Model.getValues()) {
+            for(App::DocumentObject* obj : body->Group.getValues()) {
              
                 if(obj->isDerivedFrom(PartDesign::Feature::getClassTypeId()) && obj != getObject()) {
                    Gui::ViewProvider* vp = Gui::Application::Instance->activeDocument()->getViewProvider(obj);

--- a/src/Mod/PartDesign/Gui/ViewProviderBody.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderBody.cpp
@@ -183,7 +183,7 @@ bool ViewProviderBody::doubleClicked(void)
 std::vector<App::DocumentObject*> ViewProviderBody::claimChildren(void)const
 {
     PartDesign::Body* body= static_cast<PartDesign::Body*> ( getObject () );
-    const std::vector<App::DocumentObject*> &model = body->Model.getValues ();
+    const std::vector<App::DocumentObject*> &model = body->Group.getValues ();
     std::set<App::DocumentObject*> outSet; //< set of objects not to claim (childrens of childrens)
 
     // search for objects handled (claimed) by the features
@@ -220,7 +220,7 @@ std::vector<App::DocumentObject*> ViewProviderBody::claimChildren3D(void)const
 {
     PartDesign::Body* body = static_cast<PartDesign::Body*>(getObject());
 
-    const std::vector<App::DocumentObject*> & features = body->Model.getValues();
+    const std::vector<App::DocumentObject*> & features = body->Group.getValues();
 
     std::vector<App::DocumentObject*> rv;
 
@@ -248,7 +248,7 @@ std::vector<App::DocumentObject*> ViewProviderBody::claimChildren3D(void)const
 //    bool active = body->IsActive.getValue();
 //    //Base::Console().Error("Body is %s\n", active ? "active" : "inactive");
 //    ActiveGuiDoc->signalHighlightObject(*this, Gui::Blue, active);
-//    std::vector<App::DocumentObject*> features = body->Model.getValues();
+//    std::vector<App::DocumentObject*> features = body->Group.getValues();
 //    bool highlight = true;
 //    App::DocumentObject* tip = body->Tip.getValue();
 //    for (std::vector<App::DocumentObject*>::const_iterator f = features.begin(); f != features.end(); f++) {
@@ -264,7 +264,7 @@ std::vector<App::DocumentObject*> ViewProviderBody::claimChildren3D(void)const
 bool ViewProviderBody::onDelete ( const std::vector<std::string> &) {
     // TODO May be do it conditionally? (2015-09-05, Fat-Zer)
     Gui::Command::doCommand(Gui::Command::Doc,
-            "App.getDocument(\"%s\").getObject(\"%s\").removeModelFromDocument()"
+            "App.getDocument(\"%s\").getObject(\"%s\").removeGroupFromDocument()"
             ,getObject()->getDocument()->getName(), getObject()->getNameInDocument());
     return true;
 }
@@ -273,7 +273,7 @@ void ViewProviderBody::updateData(const App::Property* prop)
 {
     PartDesign::Body* body = static_cast<PartDesign::Body*>(getObject());
 
-    if (prop == &body->Model || prop == &body->BaseFeature) {
+    if (prop == &body->Group || prop == &body->BaseFeature) {
         // update sizes of origins and datums
         updateOriginDatumSize ();
         //ensure all model features are in visual body mode
@@ -298,7 +298,7 @@ void ViewProviderBody::slotChangedObjectApp ( const App::DocumentObject& obj, co
     }
 
     PartDesign::Body *body = static_cast<PartDesign::Body*> ( getObject() );
-    if ( body && body->hasFeature (&obj ) ) {
+    if ( body && body->hasObject (&obj ) ) {
         updateOriginDatumSize ();
     }
 }
@@ -320,7 +320,7 @@ void ViewProviderBody::slotChangedObjectGui (
     PartDesign::Body *body = static_cast<PartDesign::Body*> ( getObject() );
     App::DocumentObject *obj = vp.getObject ();
 
-    if ( body && obj && body->hasFeature ( obj ) ) {
+    if ( body && obj && body->hasObject ( obj ) ) {
         updateOriginDatumSize ();
     }
 }
@@ -436,7 +436,7 @@ void ViewProviderBody::unifyVisualProperty(const App::Property* prop) {
     Gui::Document *gdoc = Gui::Application::Instance->getDocument ( pcObject->getDocument() ) ;
        
     PartDesign::Body *body = static_cast<PartDesign::Body *> ( getObject() );
-    auto features = body->Model.getValues();
+    auto features = body->Group.getValues();
     for(auto feature : features) {
         
         if(!feature->isDerivedFrom(PartDesign::Feature::getClassTypeId()))
@@ -453,7 +453,7 @@ void ViewProviderBody::setVisualBodyMode(bool bodymode) {
     Gui::Document *gdoc = Gui::Application::Instance->getDocument ( pcObject->getDocument() ) ;
        
     PartDesign::Body *body = static_cast<PartDesign::Body *> ( getObject() );
-    auto features = body->Model.getValues();
+    auto features = body->Group.getValues();
     for(auto feature : features) {
         
         if(!feature->isDerivedFrom(PartDesign::Feature::getClassTypeId()))

--- a/src/Mod/PartDesign/Gui/ViewProviderBody.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderBody.cpp
@@ -283,7 +283,7 @@ std::vector<App::DocumentObject*> ViewProviderBody::claimChildren3D(void)const
 bool ViewProviderBody::onDelete ( const std::vector<std::string> &) {
     // TODO May be do it conditionally? (2015-09-05, Fat-Zer)
     Gui::Command::doCommand(Gui::Command::Doc,
-            "App.getDocument(\"%s\").getObject(\"%s\").removeGroupFromDocument()"
+            "App.getDocument(\"%s\").getObject(\"%s\").removeObjectsFromDocument()"
             ,getObject()->getDocument()->getName(), getObject()->getNameInDocument());
     return true;
 }

--- a/src/Mod/PartDesign/Gui/ViewProviderBody.h
+++ b/src/Mod/PartDesign/Gui/ViewProviderBody.h
@@ -25,6 +25,7 @@
 #define PARTGUI_ViewProviderBody_H
 
 #include <Mod/Part/Gui/ViewProvider.h>
+#include <Gui/ViewProviderOriginGroupExtension.h>
 #include <QCoreApplication>
 
 class SoGroup;
@@ -39,10 +40,10 @@ namespace PartDesignGui {
  *  If the Body is not active it shows only the result shape (tip).
  * \author jriegel
  */
-class PartDesignGuiExport ViewProviderBody : public PartGui::ViewProviderPart
+class PartDesignGuiExport ViewProviderBody : public PartGui::ViewProviderPart, public Gui::ViewProviderOriginGroupExtension
 {
     Q_DECLARE_TR_FUNCTIONS(PartDesignGui::ViewProviderBody)
-    PROPERTY_HEADER(PartDesignGui::ViewProviderBody);
+    PROPERTY_HEADER_WITH_EXTENSIONS(PartDesignGui::ViewProviderBody);
 
 public:
     /// constructor
@@ -59,8 +60,9 @@ public:
     virtual std::vector<App::DocumentObject*> claimChildren(void)const;
 
     // returns the root node where the children gets collected(3D)
-    virtual SoGroup* getChildRoot(void) const {return pcBodyChildren;}
     virtual std::vector<App::DocumentObject*> claimChildren3D(void)const;
+
+    virtual std::vector< std::string > getDisplayModes(void) const;
     virtual void setDisplayMode(const char* ModeName);
     virtual void setOverrideMode(const std::string& mode);
 
@@ -89,9 +91,6 @@ protected:
     /// Set Feature viewprovider into visual body mode
     void setVisualBodyMode(bool bodymode);
 private:
-    /// group used to store children collected by claimChildren3D() in the through (edit) mode.
-    SoGroup *pcBodyChildren;
-
     static const char* BodyModeEnum[];
 
     boost::signals::connection connectChangedObjectApp;

--- a/src/Mod/PartDesign/Gui/Workbench.cpp
+++ b/src/Mod/PartDesign/Gui/Workbench.cpp
@@ -193,7 +193,7 @@ void Workbench::setupContextMenu(const char* recipient, Gui::MenuItem* item) con
                         }
                         // if all at lest one selected feature doesn't belongs to the same body
                         // disable the menu entry
-                        if ( addMoveFeatureInTree && !body->hasFeature ( sel.pObject ) ) {
+                        if ( addMoveFeatureInTree && !body->hasObject ( sel.pObject ) ) {
                             addMoveFeatureInTree = false;
                         }
 

--- a/src/Mod/PartDesign/Gui/Workbench.cpp
+++ b/src/Mod/PartDesign/Gui/Workbench.cpp
@@ -151,7 +151,7 @@ void Workbench::slotNewObject(const App::DocumentObject& obj)
     if ((obj.getDocument() == ActiveAppDoc) && (ActivePartObject != NULL)) {
         // Add the new object to the active Body
         // Note: Will this break Undo? But how else can we catch Edit->Duplicate selection?
-        Gui::Command::doCommand(Gui::Command::Doc,"App.activeDocument().%s.addFeature(App.activeDocument().%s)",
+        Gui::Command::doCommand(Gui::Command::Doc,"App.activeDocument().%s.addObject(App.activeDocument().%s)",
                                 ActivePartObject->getNameInDocument(), obj.getNameInDocument());
     }
 }

--- a/src/Mod/PartDesign/TestPartDesignGui.py
+++ b/src/Mod/PartDesign/TestPartDesignGui.py
@@ -72,14 +72,14 @@ class PartDesignGuiTestCases(unittest.TestCase):
         self.BoxObj.Length=10.0
         self.BoxObj.Width=10.0
         self.BoxObj.Height=10.0
-        self.BodySource.addFeature(self.BoxObj)
+        self.BodySource.addObject(self.BoxObj)
 
         App.ActiveDocument.recompute()
 
         self.Sketch = self.Doc.addObject('Sketcher::SketchObject','Sketch')
         self.Sketch.Support = (self.BoxObj, ('Face3',))
         self.Sketch.MapMode = 'FlatFace'
-        self.BodySource.addFeature(self.Sketch)
+        self.BodySource.addObject(self.Sketch)
 
         geoList = []
         geoList.append(Part.LineSegment(App.Vector(2.0,8.0,0),App.Vector(8.0,8.0,0)))
@@ -108,7 +108,7 @@ class PartDesignGuiTestCases(unittest.TestCase):
         self.Pad.Midplane = 0
         self.Pad.Offset = 0.000000
 
-        self.BodySource.addFeature(self.Pad)
+        self.BodySource.addObject(self.Pad)
 
         self.Doc.recompute()
         Gui.SendMsgToActiveView("ViewFit")
@@ -131,7 +131,7 @@ class PartDesignGuiTestCases(unittest.TestCase):
         self.Sketch = self.Doc.addObject('Sketcher::SketchObject','Sketch')
         self.Sketch.Support = (self.Doc.XY_Plane, [''])
         self.Sketch.MapMode = 'FlatFace'
-        self.BodySource.addFeature(self.Sketch)
+        self.BodySource.addObject(self.Sketch)
 
         geoList = []
         geoList.append(Part.LineSegment(App.Vector(-10.000000,10.000000,0),App.Vector(10.000000,10.000000,0)))
@@ -160,7 +160,7 @@ class PartDesignGuiTestCases(unittest.TestCase):
         self.Pad.Midplane = 0
         self.Pad.Offset = 0.000000
 
-        self.BodySource.addFeature(self.Pad)
+        self.BodySource.addObject(self.Pad)
 
         self.Doc.recompute()
         Gui.SendMsgToActiveView("ViewFit")

--- a/src/Mod/PartDesign/TestPartDesignGui.py
+++ b/src/Mod/PartDesign/TestPartDesignGui.py
@@ -120,8 +120,8 @@ class PartDesignGuiTestCases(unittest.TestCase):
         QtCore.QTimer.singleShot(500, cobj)
         Gui.runCommand('PartDesign_MoveFeature')
         #assert depenedencies of the Sketch
-        self.assertEqual(len(self.BodySource.Model), 3, "Source body feature count is wrong")
-        self.assertEqual(len(self.BodyTarget.Model), 0, "Target body feature count is wrong")
+        self.assertEqual(len(self.BodySource.Group), 3, "Source body feature count is wrong")
+        self.assertEqual(len(self.BodyTarget.Group), 0, "Target body feature count is wrong")
 
     def testMoveSingleFeature(self):
         FreeCAD.Console.PrintMessage('Testing moving one feature from one body to another\n')
@@ -176,8 +176,8 @@ class PartDesignGuiTestCases(unittest.TestCase):
         
         self.assertFalse(self.Sketch.Support[0][0] in self.BodySource.Origin.OriginFeatures)
         self.assertTrue(self.Sketch.Support[0][0] in self.BodyTarget.Origin.OriginFeatures)
-        self.assertEqual(len(self.BodySource.Model), 0, "Source body feature count is wrong")
-        self.assertEqual(len(self.BodyTarget.Model), 2, "Target body feature count is wrong")
+        self.assertEqual(len(self.BodySource.Group), 0, "Source body feature count is wrong")
+        self.assertEqual(len(self.BodyTarget.Group), 2, "Target body feature count is wrong")
 
     def tearDown(self):
         FreeCAD.closeDocument("SketchGuiTest")


### PR DESCRIPTION
The Body is portet to use Extensions. Hence it is now recognized as a geofeature group and handled as any other local coordinate system. 
Note that this breaks 0.17 file compatibility. Having no backward compatibility is intended, as this happen only for 0.17 files which are created with a development versions. When loading an old file the features will not be within the body anymore. This can be fixed by editing the xml files or drag&drop the features back in.
