### PR TITLE
Really use PySide2 tools for Qt5 build.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -367,14 +367,6 @@ if(FREECAD_LIBPACK_USE)
                 "==================================================\n")
     ENDIF(NOT SWIG_FOUND)
 
-# -------------------------------- Shiboken/PySide ------------------------
-
-    if(BUILD_QT5)
-        find_package(PySide2Tools REQUIRED) # PySide2 utilities (pyside2-uic & pyside2-rcc)
-    else()
-        find_package(PySideTools REQUIRED) # Pyside utilities (pyside-uic & pyside-rcc)
-    endif()
-
 # -------------------------------- Salome SMESH --------------------------
 
     if(NOT FREECAD_USE_EXTERNAL_SMESH)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -856,7 +856,7 @@ endif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
                                 "==================\n")
         endif(NOT PYSIDE_INCLUDE_DIR)
 
-        find_package(PySideTools REQUIRED) # PySide2 utilities (pyside-uic & pyside-rcc)
+        find_package(PySide2Tools REQUIRED) # PySide2 utilities (pyside2-uic & pyside2-rcc)
     else()
         # set(PYTHON_SUFFIX -python${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR})
         SET(PYTHON_SUFFIX -python2.7) # for shiboken


### PR DESCRIPTION
This fixes a crash when built with Qt5. Resources are generated by wrong version of tools.

Cheers,
Mateusz