### PR TITLE
support stepdown greater than total depth

### DIFF
--- a/src/Mod/Path/PathTests/TestPathDepthParams.py
+++ b/src/Mod/Path/PathTests/TestPathDepthParams.py
@@ -38,7 +38,7 @@ class depthTestCases(unittest.TestCase):
         final_depth = 0
         user_depths =  None
 
-        expected =[8,6,4,2,1,0]
+        expected =[9,7,5,3,1,0]
 
         d = PU.depth_params(clearance_height, rapid_safety_space, start_depth, step_down, z_finish_step, final_depth, user_depths)
         r = d.get_depths()
@@ -73,7 +73,7 @@ class depthTestCases(unittest.TestCase):
         final_depth = 10
         user_depths =  None
 
-        expected =[]
+        expected =[10]
 
         d = PU.depth_params(clearance_height, rapid_safety_space, start_depth, step_down, z_finish_step, final_depth, user_depths)
         r = d.get_depths()
@@ -109,7 +109,7 @@ class depthTestCases(unittest.TestCase):
         self.assertListEqual (r, expected)
 
     def test40(self):
-        '''Finish depth passed in.'''
+        '''Finish step passed in.'''
         clearance_height= 10
         rapid_safety_space = 5
 
@@ -119,7 +119,7 @@ class depthTestCases(unittest.TestCase):
         final_depth = -10
         user_depths =  None
 
-        expected =[-2, -4, -6, -8, -9, -10]
+        expected =[-1, -3, -5, -7, -9, -10]
 
         d = PU.depth_params(clearance_height, rapid_safety_space, start_depth, step_down, z_finish_step, final_depth, user_depths)
         r = d.get_depths()
@@ -156,6 +156,23 @@ class depthTestCases(unittest.TestCase):
         user_depths =  None
 
         expected =[7.0, 4.0, 1.0, 0]
+
+        d = PU.depth_params(clearance_height, rapid_safety_space, start_depth, step_down, z_finish_step, final_depth, user_depths)
+        r = d.get_depths(equalstep=True)
+        self.assertListEqual (r, expected)
+
+    def test70(self):
+        '''stepping down with stepdown greater than total depth'''
+        clearance_height= 10
+        rapid_safety_space = 5
+
+        start_depth = 10
+        step_down = 20
+        z_finish_step = 1
+        final_depth = 0
+        user_depths =  None
+
+        expected =[1.0, 0]
 
         d = PU.depth_params(clearance_height, rapid_safety_space, start_depth, step_down, z_finish_step, final_depth, user_depths)
         r = d.get_depths(equalstep=True)


### PR DESCRIPTION
The previous implementation created IndexError when step_down was greater than the total depth. This pull request tries to improve this point and also introduces a test for this.

There are two more things that differ from the old implementation:
* the partial layer is now at the very 'top' (was at the bottom, on top of the z_finish_step before)
* start_depth equal to finish_depth is accepted now and will produce one depth value at finish_depth