### PR TITLE
Add C++ implementation of Part.sortEdges

### DIFF
--- a/src/Mod/Draft/DraftGeomUtils.py
+++ b/src/Mod/Draft/DraftGeomUtils.py
@@ -870,8 +870,10 @@ def flattenWire(wire):
     w = Part.makePolygon(verts)
     return w
 
-
 def findWires(edgeslist):
+    return [ Part.Wire(e) for e in Part.sortEdges(edgeslist)]
+    
+def findWiresOld2(edgeslist):
     '''finds connected wires in the given list of edges'''
 
     def touches(e1,e2):


### PR DESCRIPTION
Unlike `Part.__sortEdges__` which only return a list of connected edges, and discard the rest. `Part.sortEdges` return a list of list of connected edges, which includes all input edges. Also change `DraftGeomUtils.findWires` to make use of Part.sortEdges