### PR TITLE
Add Transparent background to Save picture options

### DIFF
--- a/src/Gui/DlgSettingsImage.ui
+++ b/src/Gui/DlgSettingsImage.ui
@@ -61,6 +61,11 @@
           <string>Black</string>
          </property>
         </item>
+        <item>
+         <property name="text" >
+          <string>Transparent</string>
+         </property>
+        </item>
        </widget>
       </item>
      </layout>


### PR DESCRIPTION
Transparent background was already in the code of Tools -> Save Picture,
but the entry was missing in the dropdown of the UI.