### PR TITLE
[Hold]Sketcher: disble hide dependent when auto recompute

### DIFF
--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -4530,7 +4530,7 @@ bool ViewProviderSketch::setEdit(int ModNum)
             QString cmdstr = QString::fromLatin1(
                         "ActiveSketch = App.ActiveDocument.getObject('{sketch_name}')\n"
                         "tv = Show.TempoVis(App.ActiveDocument)\n"
-                        "if ActiveSketch.ViewObject.HideDependent:\n"
+                        "if not App.ParamGet('User parameter:BaseApp/Preferences/Mod/Sketcher').GetBool('AutoRecompute') and ActiveSketch.ViewObject.HideDependent:\n"
                         "  tv.hide_all_dependent(ActiveSketch)\n"
                         "if ActiveSketch.ViewObject.ShowSupport:\n"
                         "  tv.show([ref[0] for ref in ActiveSketch.Support])\n"


### PR DESCRIPTION
When skecher auto recompute is enabled, user expects to see immediate changes on dependent object. This patch disables auto hide dependent feature when auto recompute is enabled.  