### PR TITLE
TechDraw - Outlines on Pocketed Solids

### DIFF
--- a/src/Mod/TechDraw/App/DrawProjectSplit.cpp
+++ b/src/Mod/TechDraw/App/DrawProjectSplit.cpp
@@ -479,7 +479,7 @@ std::string edgeSortItem::dump(void)
 /*static*/bool edgeSortItem::edgeLess(const edgeSortItem& e1, const edgeSortItem& e2)
 {
     bool result = false;
-    if (e1.start != e2.start) {
+    if ((e1.start - e2.start).Length() < Precision::Confusion()) {
         if ( DrawUtil::vectorLess(e1.start, e2.start)) {
             result = true;
         }
@@ -501,8 +501,11 @@ std::string edgeSortItem::dump(void)
 /*static*/bool edgeSortItem::edgeEqual(const edgeSortItem& e1, const edgeSortItem& e2)
 {
     bool result = false;
-    if ( (e1.start == e2.start) &&
-         (e1.end   == e2.end)   &&
+    double startDif = (e1.start - e2.start).Length();
+    double endDif   = (e1.end   - e2.end).Length();
+    
+    if ( (startDif < Precision::Confusion()) &&
+         (endDif   < Precision::Confusion())   &&
          (DrawUtil::fpCompare(e1.startAngle,e2.startAngle)) &&
          (DrawUtil::fpCompare(e1.endAngle,e2.endAngle)) ) {
         result = true;

--- a/src/Mod/TechDraw/App/DrawProjectSplit.cpp
+++ b/src/Mod/TechDraw/App/DrawProjectSplit.cpp
@@ -405,7 +405,6 @@ std::vector<splitPoint> DrawProjectSplit::sortSplits(std::vector<splitPoint>& s,
     return result;
 }
 
-
 std::vector<TopoDS_Edge> DrawProjectSplit::removeDuplicateEdges(std::vector<TopoDS_Edge>& inEdges)
 {
     std::vector<TopoDS_Edge> result;
@@ -446,7 +445,6 @@ std::vector<TopoDS_Edge> DrawProjectSplit::removeDuplicateEdges(std::vector<Topo
             Base::Console().Message("ERROR - DPS::removeDuplicateEdges - access: %d inEdges: %d\n",e.idx,inEdges.size());
         }
     }
-
     return result;
 }
 
@@ -479,7 +477,7 @@ std::string edgeSortItem::dump(void)
 /*static*/bool edgeSortItem::edgeLess(const edgeSortItem& e1, const edgeSortItem& e2)
 {
     bool result = false;
-    if ((e1.start - e2.start).Length() < Precision::Confusion()) {
+    if (!((e1.start - e2.start).Length() < Precision::Confusion())) {  //e1 != e2
         if ( DrawUtil::vectorLess(e1.start, e2.start)) {
             result = true;
         }
@@ -503,9 +501,8 @@ std::string edgeSortItem::dump(void)
     bool result = false;
     double startDif = (e1.start - e2.start).Length();
     double endDif   = (e1.end   - e2.end).Length();
-    
     if ( (startDif < Precision::Confusion()) &&
-         (endDif   < Precision::Confusion())   &&
+         (endDif   < Precision::Confusion()) &&
          (DrawUtil::fpCompare(e1.startAngle,e2.startAngle)) &&
          (DrawUtil::fpCompare(e1.endAngle,e2.endAngle)) ) {
         result = true;

--- a/src/Mod/TechDraw/App/DrawUtil.cpp
+++ b/src/Mod/TechDraw/App/DrawUtil.cpp
@@ -281,7 +281,7 @@ std::string DrawUtil::formatVector(const Base::Vector3d& v)
 bool DrawUtil::vectorLess(const Base::Vector3d& v1, const Base::Vector3d& v2)  
 {
     bool result = false;
-    if (v1 != v2) {
+    if ((v1 - v2).Length() > Precision::Confusion()) {      //ie v1 != v2
         if (!DrawUtil::fpCompare(v1.x,v2.x)) {
             result = v1.x < v2.x;
         } else if (!DrawUtil::fpCompare(v1.y,v2.y)) {


### PR DESCRIPTION
This PR solves a problem with incorrect shape outline calculations based on bounding boxes which cause errors with pocketed solids. 

Please merge.

Thanks.
