### PR TITLE
Fix layout issue in DraftGui's _inputfield.

### DIFF
--- a/src/Mod/Draft/DraftGui.py
+++ b/src/Mod/Draft/DraftGui.py
@@ -334,13 +334,14 @@ class DraftToolBar:
         return lineedit
 
     def _inputfield (self,name, layout, hide=True, width=None):
-        p = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/General")
-        bsize = p.GetInt("ToolbarIconSize",24)-2
         inputfield = self.uiloader.createWidget("Gui::InputField")
         inputfield.setObjectName(name)
         if hide: inputfield.hide()
-        if not width: width = 800
-        inputfield.setMaximumSize(QtCore.QSize(width,bsize))
+        if not width:
+            sizePolicy = QtGui.QSizePolicy(QtGui.QSizePolicy.Expanding, QtGui.QSizePolicy.Preferred)
+            inputfield.setSizePolicy(sizePolicy)
+        else:
+            inputfield.setMaximumWidth(width)
         layout.addWidget(inputfield)
         return inputfield
 


### PR DESCRIPTION
Hi. With Qt5 build there is a severe layout issue in Draft's task panel. It is also available with Qt4 but not as visible. The problem is when the preference setting ToolbarIconSize is set to ~ < 31 (can't remember exactly). Below is a screenshot with ToolbarIconSize set to 16.

![layout-issue-before-qt5](https://cloud.githubusercontent.com/assets/72836/22172977/3bcff8e2-dfb5-11e6-9533-c6efd1324477.png)

Cheers,
Mateusz

P.S. Another idea to fix this could be changing the Gui::Inputfield widget to honor the ToolbarIconSize setting.