### PR TITLE
py3: fix for translation in start wb

### DIFF
--- a/src/Mod/Start/StartPage/StartPage.py
+++ b/src/Mod/Start/StartPage/StartPage.py
@@ -40,25 +40,30 @@ def translate(context,text):
     # return str(QtGui.QApplication.translate(context, text, None, QtGui.QApplication.UnicodeUTF8).toUtf8())
     try:
         _encoding = QtGui.QApplication.UnicodeUTF8
-        u = QtGui.QApplication.translate(context, text, None, _encoding).encode("utf8")
+        u = QtGui.QApplication.translate(context, text, None, _encoding)
     except AttributeError:
-        u = QtGui.QApplication.translate(context, text, None).encode("utf8")
-        
-    s = cStringIO.StringIO()
-    for i in u:
-        if sys.version_info.major > 2: #below only works correctly in python3
-            if i == 39:
-                s.write("\\'")
-            else:
-                s.write(chr(i))
-        else:
-            if ord(i) == 39:
-                s.write(unicode("\\'"))
-            else:
-                s.write(unicode(i))
-    t = s.getvalue()
-    s.close()
-    return t
+        u = QtGui.QApplication.translate(context, text, None)
+
+    if sys.version_info.major < 3:
+        u = u.encode("utf8")
+
+    # s = cStringIO.StringIO()
+    # for i in u:
+    #     if sys.version_info.major > 2: #below only works correctly in python3
+    #         if i == 39:
+    #             s.write("\\'")
+    #         else:
+    #             s.write(chr(i))
+    #     else:
+    #         if ord(i) == 39:
+    #             s.write(unicode("\\'"))
+    #         else:
+    #             s.write(unicode(i))
+    # t = s.getvalue()
+    # s.close()
+    # return t
+    
+    return u.replace(chr(39), "\\'")
 
 # texts to be translated
 


### PR DESCRIPTION
please have a closer look at this, as it change the way the character is replaced. I am not aware why it was done with the cString library, so I may miss an important thing (windows, mac)? 
This was tested with python3 and python2 on linux and diffferent languages.