### PR TITLE
Restore QTabWidget shape style in PropertyView.cpp to default style.

### DIFF
--- a/src/Gui/CombiView.cpp
+++ b/src/Gui/CombiView.cpp
@@ -57,7 +57,6 @@ CombiView::CombiView(Gui::Document* pcDocument, QWidget *parent)
     tabs = new QTabWidget ();
     tabs->setObjectName(QString::fromUtf8("combiTab"));
     tabs->setTabPosition(QTabWidget::North);
-    //tabs->setTabShape(QTabWidget::Triangular);
     pLayout->addWidget( tabs, 0, 0 );
 
     // splitter between tree and property view

--- a/src/Gui/PropertyView.cpp
+++ b/src/Gui/PropertyView.cpp
@@ -70,7 +70,6 @@ PropertyView::PropertyView(QWidget *parent)
     tabs = new QTabWidget (this);
     tabs->setObjectName(QString::fromUtf8("propertyTab"));
     tabs->setTabPosition(QTabWidget::South);
-    tabs->setTabShape(QTabWidget::Triangular);
     pLayout->addWidget(tabs, 0, 0);
 
     propertyEditorView = new Gui::PropertyEditor::PropertyEditor();


### PR DESCRIPTION
QTabWidget::Triangular is used only in src/Gui/PropertyView.cpp. It looks like it was planned to be used in src/Gui/CombiView.cpp too, but the code was commented out. 

It's a simple modification, but IMHO, it looks better now. 

Before:
![freecad_tabs_before](https://cloud.githubusercontent.com/assets/735338/22290914/4ff34cd6-e2e2-11e6-813f-86764ba1f21f.png)

After:
![freecad_tabs_after](https://cloud.githubusercontent.com/assets/735338/22290915/4ff49a00-e2e2-11e6-8667-3d7bacf6a341.png)

