### PR TITLE
A generic constraint mode framework and a few constraints converted to use it

### DIFF
--- a/src/Mod/Sketcher/Gui/CommandConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/CommandConstraints.cpp
@@ -859,7 +859,7 @@ public:
 
     virtual bool pressButton(Base::Vector2d /*onSketchPos*/)
     {
-        return false;
+        return true;
     }
 
     virtual bool releaseButton(Base::Vector2d onSketchPos)
@@ -934,7 +934,7 @@ public:
                         selSeq.clear();
                         resetOngoingSequences();
 
-                        return false;
+                        return true;
                     }
                     _tempOnSequences->insert(*token);
                     allowedSelTypes = allowedSelTypes | (cmd->allowedSelSequences).at(*token).at(seqIndex+1);
@@ -947,7 +947,7 @@ public:
             selFilterGate->setAllowedSelTypes(allowedSelTypes);
         }
 
-        return false;
+        return true;
     }
 
 protected:

--- a/src/Mod/Sketcher/Gui/CommandConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/CommandConstraints.cpp
@@ -739,6 +739,23 @@ int SketchSelection::setUp(void)
 
 /* Constrain commands =======================================================*/
 
+class CmdSketcherConstraint : public Gui::Command
+{
+public:
+    CmdSketcherConstraint();
+    virtual ~CmdSketcherConstraint(){}
+    virtual const char* className() const
+    { return "CmdSketcherConstraint"; }
+
+protected:
+    virtual void applyConstraint();
+    virtual void activated(int iMsg);
+    virtual bool isActive(void)
+    { return isCreateGeoActive(getActiveGuiDocument()); }
+};
+
+// ======================================================================================
+
 namespace SketcherGui {
     class HoriVertConstraintSelection : public Gui::SelectionFilterGate
     {
@@ -974,7 +991,7 @@ bool CmdSketcherConstrainHorizontal::isActive(void)
     return isCreateGeoActive( getActiveGuiDocument() );
 }
 
-// ======================================================================================
+// ============================================================================
 
 static const char *cursor_createvertconstraint[]={
 "32 32 3 1",
@@ -1698,6 +1715,7 @@ bool CmdSketcherConstrainCoincident::isActive(void)
     return isCreateGeoActive( getActiveGuiDocument() );
 }
 
+// ======================================================================================
 
 DEF_STD_CMD_AU(CmdSketcherConstrainDistance);
 
@@ -1880,6 +1898,7 @@ bool CmdSketcherConstrainDistance::isActive(void)
     return isCreateConstraintActive( getActiveGuiDocument() );
 }
 
+// ======================================================================================
 
 DEF_STD_CMD_A(CmdSketcherConstrainPointOnObject);
 
@@ -1977,6 +1996,8 @@ bool CmdSketcherConstrainPointOnObject::isActive(void)
 {
     return isCreateConstraintActive( getActiveGuiDocument() );
 }
+
+// ======================================================================================
 
 DEF_STD_CMD_AU(CmdSketcherConstrainDistanceX);
 
@@ -2136,6 +2157,7 @@ bool CmdSketcherConstrainDistanceX::isActive(void)
     return isCreateConstraintActive( getActiveGuiDocument() );
 }
 
+// ======================================================================================
 
 DEF_STD_CMD_AU(CmdSketcherConstrainDistanceY);
 
@@ -2294,6 +2316,7 @@ bool CmdSketcherConstrainDistanceY::isActive(void)
     return isCreateConstraintActive( getActiveGuiDocument() );
 }
 
+//=================================================================================
 
 DEF_STD_CMD_A(CmdSketcherConstrainParallel);
 
@@ -2394,6 +2417,7 @@ bool CmdSketcherConstrainParallel::isActive(void)
     return isCreateConstraintActive( getActiveGuiDocument() );
 }
 
+// ======================================================================================
 
 DEF_STD_CMD_A(CmdSketcherConstrainPerpendicular);
 
@@ -2778,6 +2802,7 @@ bool CmdSketcherConstrainPerpendicular::isActive(void)
     return isCreateConstraintActive( getActiveGuiDocument() );
 }
 
+// ======================================================================================
 
 DEF_STD_CMD_A(CmdSketcherConstrainTangent);
 
@@ -3121,6 +3146,7 @@ bool CmdSketcherConstrainTangent::isActive(void)
     return isCreateConstraintActive( getActiveGuiDocument() );
 }
 
+// ======================================================================================
 
 DEF_STD_CMD_AU(CmdSketcherConstrainRadius);
 
@@ -3445,6 +3471,8 @@ bool CmdSketcherConstrainRadius::isActive(void)
     return isCreateConstraintActive( getActiveGuiDocument() );
 }
 
+// ======================================================================================
+
 DEF_STD_CMD_AU(CmdSketcherConstrainAngle);
 
 CmdSketcherConstrainAngle::CmdSketcherConstrainAngle()
@@ -3741,6 +3769,8 @@ bool CmdSketcherConstrainAngle::isActive(void)
     return isCreateConstraintActive( getActiveGuiDocument() );
 }
 
+// ======================================================================================
+
 DEF_STD_CMD_A(CmdSketcherConstrainEqual);
 
 CmdSketcherConstrainEqual::CmdSketcherConstrainEqual()
@@ -3868,6 +3898,7 @@ bool CmdSketcherConstrainEqual::isActive(void)
     return isCreateConstraintActive( getActiveGuiDocument() );
 }
 
+// ======================================================================================
 
 DEF_STD_CMD_A(CmdSketcherConstrainSymmetric);
 
@@ -4040,6 +4071,8 @@ bool CmdSketcherConstrainSymmetric::isActive(void)
     return isCreateConstraintActive( getActiveGuiDocument() );
 }
 
+// ======================================================================================
+
 DEF_STD_CMD_A(CmdSketcherConstrainSnellsLaw);
 
 CmdSketcherConstrainSnellsLaw::CmdSketcherConstrainSnellsLaw()
@@ -4197,6 +4230,7 @@ bool CmdSketcherConstrainSnellsLaw::isActive(void)
     return isCreateConstraintActive( getActiveGuiDocument() );
 }
 
+// ======================================================================================
 
 DEF_STD_CMD_A(CmdSketcherConstrainInternalAlignment);
 
@@ -4621,6 +4655,7 @@ bool CmdSketcherConstrainInternalAlignment::isActive(void)
     return isCreateConstraintActive( getActiveGuiDocument() );
 }
 
+// ======================================================================================
 /*** Creation Mode / Toggle to or from Reference ***/
 DEF_STD_CMD_A(CmdSketcherToggleDrivingConstraint);
 
@@ -4743,7 +4778,7 @@ void CmdSketcherToggleDrivingConstraint::activated(int iMsg)
 
 bool CmdSketcherToggleDrivingConstraint::isActive(void)
 {
-    return isCreateConstraintActive( getActiveGuiDocument() );
+    return isCreateGeoActive( getActiveGuiDocument() );
 }
 
 void CreateSketcherCommandsConstraints(void)

--- a/src/Mod/Sketcher/Gui/CommandConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/CommandConstraints.cpp
@@ -780,7 +780,7 @@ namespace SketcherGui {
                     (allowedSelTypes & SketcherGui::SelVertex && element.substr(0,6) == "Vertex") ||
                     (allowedSelTypes & SketcherGui::SelEdge && element.substr(0,4) == "Edge") ||
                     (allowedSelTypes & SketcherGui::SelHAxis && element.substr(0,6) == "H_Axis") ||
-                    (allowedSelTypes & SketcherGui::SelVAxis && element.substr(0,6) == "H_Axis") ||
+                    (allowedSelTypes & SketcherGui::SelVAxis && element.substr(0,6) == "V_Axis") ||
                     (allowedSelTypes & SketcherGui::SelExternalEdge && element.substr(0,12) == "ExternalEdge"))
                 return true;
 
@@ -1743,6 +1743,46 @@ bool CmdSketcherConstrainDistance::isActive(void)
 
 // ======================================================================================
 
+/* XPM */
+static char * cursor_createpointonobj[] = {
+"32 32 3 1",
+" 	c None",
+".	c #FFFFFF",
+"+	c #FF0000",
+"      .                         ",
+"      .                     ++++",
+"      .                   ++++++",
+"      .                +++++++  ",
+"      .              ++++++     ",
+"                   ++++++       ",
+".....   .....     +++++         ",
+"                +++++           ",
+"      .    +++ ++++             ",
+"      .  +++++++++              ",
+"      .  ++++++++               ",
+"      . +++++++++               ",
+"      . +++++++++               ",
+"        +++++++++               ",
+"         +++++++                ",
+"        ++++++++                ",
+"       +++++++                  ",
+"       +++                      ",
+"      +++                       ",
+"     +++                        ",
+"     +++                        ",
+"    +++                         ",
+"    +++                         ",
+"   +++                          ",
+"   +++                          ",
+"   ++                           ",
+"  +++                           ",
+"  ++                            ",
+" +++                            ",
+" +++                            ",
+" ++                             ",
+" ++                             "};
+
+
 DEF_STD_CMD_A(CmdSketcherConstrainPointOnObject);
 
 CmdSketcherConstrainPointOnObject::CmdSketcherConstrainPointOnObject()
@@ -2161,10 +2201,61 @@ bool CmdSketcherConstrainDistanceY::isActive(void)
 
 //=================================================================================
 
-DEF_STD_CMD_A(CmdSketcherConstrainParallel);
+/* XPM */
+static const char *cursor_createparallel[]={
+"32 32 3 1",
+"  c None",
+". c #FFFFFF",
+"+ c #FF0000",
+"      .                         ",
+"      .                         ",
+"      .                         ",
+"      .                         ",
+"      .                         ",
+"                                ",
+".....   .....                   ",
+"                                ",
+"      .                         ",
+"      .                         ",
+"      .         +         +     ",
+"      .        ++        ++     ",
+"      .        +         +      ",
+"              ++        ++      ",
+"              +         +       ",
+"             ++        ++       ",
+"             +         +        ",
+"            ++        ++        ",
+"            +         +         ",
+"           ++        ++         ",
+"           +         +          ",
+"          ++        ++          ",
+"          +         +           ",
+"         ++        ++           ",
+"         +         +            ",
+"        ++        ++            ",
+"        +         +             ",
+"       ++        ++             ",
+"       +         +              ",
+"                                ",
+"                                ",
+"                                "};
+
+//DEF_STD_CMD_A(CmdSketcherConstrainParallel);
+
+class CmdSketcherConstrainParallel : public CmdSketcherConstraint
+{
+public:
+    CmdSketcherConstrainParallel();
+    virtual ~CmdSketcherConstrainParallel(){}
+    virtual const char* className() const
+    { return "CmdSketcherConstrainParallel"; }
+protected:
+//    virtual void activated(int iMsg);
+    virtual void applyConstraint(std::vector<SelIdPair> &selSeq, int seqIndex);
+};
 
 CmdSketcherConstrainParallel::CmdSketcherConstrainParallel()
-    :Command("Sketcher_ConstrainParallel")
+    :CmdSketcherConstraint("Sketcher_ConstrainParallel")
 {
     sAppModule      = "Sketcher";
     sGroup          = QT_TR_NOOP("Sketcher");
@@ -2175,90 +2266,134 @@ CmdSketcherConstrainParallel::CmdSketcherConstrainParallel()
     sPixmap         = "Constraint_Parallel";
     sAccel          = "SHIFT+P";
     eType           = ForEdit;
+
+    // TODO: Also needed: ExternalEdges
+    allowedSelSequences = {{SelEdge, SelEdge},
+                           {SelEdge, SelHAxis}, {SelEdge, SelVAxis},
+                           {SelHAxis, SelEdge}, {SelVAxis, SelEdge}};
+    constraintCursor = cursor_createparallel;
 }
 
-void CmdSketcherConstrainParallel::activated(int iMsg)
+//void CmdSketcherConstrainParallel::activated(int iMsg)
+//{
+//    Q_UNUSED(iMsg);
+//    // get the selection
+//    std::vector<Gui::SelectionObject> selection = getSelection().getSelectionEx();
+
+//    // only one sketch with its subelements are allowed to be selected
+//    if (selection.size() != 1) {
+//        QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
+//            QObject::tr("Select two or more lines from the sketch."));
+//        return;
+//    }
+
+//    // get the needed lists and objects
+//    const std::vector<std::string> &SubNames = selection[0].getSubNames();
+//    Sketcher::SketchObject* Obj = static_cast<Sketcher::SketchObject*>(selection[0].getObject());
+
+//    // go through the selected subelements
+
+//    if (SubNames.size() < 2) {
+//        QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
+//            QObject::tr("Select at least two lines from the sketch."));
+//        return;
+//    }
+
+//    std::vector<int> ids;
+//    bool hasAlreadyExternal=false;
+//    for (std::vector<std::string>::const_iterator it=SubNames.begin();it!=SubNames.end();++it) {
+
+//        int GeoId;
+//        Sketcher::PointPos PosId;
+//        getIdsFromName(*it, Obj, GeoId, PosId);
+
+//        if (!isEdge(GeoId,PosId)) {
+//            QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
+//                                 QObject::tr("Select a valid line"));
+//            return;
+//        }
+//        else if (GeoId < 0) {
+//            if (hasAlreadyExternal) {
+//                showNoConstraintBetweenExternal();
+//                return;
+//            }
+//            else
+//                hasAlreadyExternal = true;
+//        }
+
+//        // Check that the curve is a line segment
+//        const Part::Geometry *geo = Obj->getGeometry(GeoId);
+//        if (geo->getTypeId() != Part::GeomLineSegment::getClassTypeId()) {
+//            QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
+//                                QObject::tr("The selected edge is not a valid line"));
+//            return;
+//        }
+//        ids.push_back(GeoId);
+//    }
+
+//    // undo command open
+//    openCommand("add parallel constraint");
+//    for (int i=0; i < int(ids.size()-1); i++) {
+//        Gui::Command::doCommand(
+//            Doc,"App.ActiveDocument.%s.addConstraint(Sketcher.Constraint('Parallel',%d,%d)) ",
+//            selection[0].getFeatName(),ids[i],ids[i+1]);
+//    }
+//    // finish the transaction and update
+//    commitCommand();
+    
+//    ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Mod/Sketcher");
+//    bool autoRecompute = hGrp->GetBool("AutoRecompute",false);
+
+//    if(autoRecompute)
+//        Gui::Command::updateActive();
+
+
+//    // clear the selection (convenience)
+//    getSelection().clearSelection();
+//}
+
+void CmdSketcherConstrainParallel::applyConstraint(std::vector<SelIdPair> &selSeq, int seqIndex)
 {
-    Q_UNUSED(iMsg);
-    // get the selection
-    std::vector<Gui::SelectionObject> selection = getSelection().getSelectionEx();
+    switch (seqIndex) {
+    case 0: // {SelEdge, SelEdge}
+    case 1: // {SelEdge, SelHAxis}
+    case 2: // {SelEdge, SelVAxis}
+    case 3: // {SelHAxis, SelEdge}
+    case 4: // {SelVAxis, SelEdge}
+        // TODO: create the constraint
+        SketcherGui::ViewProviderSketch* sketchgui = static_cast<SketcherGui::ViewProviderSketch*>(getActiveGuiDocument()->getInEdit());
+        Sketcher::SketchObject* Obj = sketchgui->getSketchObject();
 
-    // only one sketch with its subelements are allowed to be selected
-    if (selection.size() != 1) {
-        QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-            QObject::tr("Select two or more lines from the sketch."));
-        return;
-    }
+        int GeoId1 = selSeq.at(0).GeoId, GeoId2 = selSeq.at(1).GeoId;
 
-    // get the needed lists and objects
-    const std::vector<std::string> &SubNames = selection[0].getSubNames();
-    Sketcher::SketchObject* Obj = static_cast<Sketcher::SketchObject*>(selection[0].getObject());
-
-    // go through the selected subelements
-
-    if (SubNames.size() < 2) {
-        QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-            QObject::tr("Select at least two lines from the sketch."));
-        return;
-    }
-
-    std::vector<int> ids;
-    bool hasAlreadyExternal=false;
-    for (std::vector<std::string>::const_iterator it=SubNames.begin();it!=SubNames.end();++it) {
-
-        int GeoId;
-        Sketcher::PointPos PosId;
-        getIdsFromName(*it, Obj, GeoId, PosId);
-
-        if (!isEdge(GeoId,PosId)) {
-            QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-                                 QObject::tr("Select a valid line"));
-            return;
-        }
-        else if (GeoId < 0) {
-            if (hasAlreadyExternal) {
-                showNoConstraintBetweenExternal();
-                return;
-            }
-            else
-                hasAlreadyExternal = true;
-        }
-
-        // Check that the curve is a line segment
-        const Part::Geometry *geo = Obj->getGeometry(GeoId);
-        if (geo->getTypeId() != Part::GeomLineSegment::getClassTypeId()) {
+        // Check that the curves are line segments
+        if (    Obj->getGeometry(GeoId1)->getTypeId() != Part::GeomLineSegment::getClassTypeId() ||
+                Obj->getGeometry(GeoId2)->getTypeId() != Part::GeomLineSegment::getClassTypeId()) {
             QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
                                 QObject::tr("The selected edge is not a valid line"));
             return;
         }
-        ids.push_back(GeoId);
-    }
 
-    // undo command open
-    openCommand("add parallel constraint");
-    for (int i=0; i < int(ids.size()-1); i++) {
+        // undo command open
+        openCommand("add parallel constraint");
         Gui::Command::doCommand(
-            Doc,"App.ActiveDocument.%s.addConstraint(Sketcher.Constraint('Parallel',%d,%d)) ",
-            selection[0].getFeatName(),ids[i],ids[i+1]);
+            Doc, "App.ActiveDocument.%s.addConstraint(Sketcher.Constraint('Parallel',%d,%d)) ",
+            sketchgui->getObject()->getNameInDocument(), GeoId1, GeoId2);
+        // finish the transaction and update
+        commitCommand();
+
+        ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Mod/Sketcher");
+        bool autoRecompute = hGrp->GetBool("AutoRecompute",false);
+
+        if(autoRecompute)
+            Gui::Command::updateActive();
     }
-    // finish the transaction and update
-    commitCommand();
-    
-    ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Mod/Sketcher");
-    bool autoRecompute = hGrp->GetBool("AutoRecompute",false);
-
-    if(autoRecompute)
-        Gui::Command::updateActive();
-
-
-    // clear the selection (convenience)
-    getSelection().clearSelection();
 }
 
-bool CmdSketcherConstrainParallel::isActive(void)
-{
-    return isCreateConstraintActive( getActiveGuiDocument() );
-}
+//bool CmdSketcherConstrainParallel::isActive(void)
+//{
+//    return isCreateConstraintActive( getActiveGuiDocument() );
+//}
 
 // ======================================================================================
 


### PR DESCRIPTION
When in constraint mode, selection is addtitive and a bit rough around the edges (you cannot un-select part of the already selected, you have to restart by clicking on empty space). Some issues regarding the coincident constraint earlier have been addressed.

The elements are selectable in predefined orders, for e.g. on point-on-object, if you select a vertex first, next HAS to be a curve and vice versa.