### PR TITLE
Icon sizes Preferences update

### DIFF
--- a/src/Gui/DlgGeneralImp.cpp
+++ b/src/Gui/DlgGeneralImp.cpp
@@ -244,7 +244,11 @@ void DlgGeneralImp::loadSettings()
     this->toolbarIconSize->addItem(tr("Large (%1px)").arg(32), QVariant((int)32));
     this->toolbarIconSize->addItem(tr("Extra large (%1px)").arg(48), QVariant((int)48));
     index = this->toolbarIconSize->findData(QVariant(current));
-    if (index > -1) this->toolbarIconSize->setCurrentIndex(index);
+    if (index < 0) {
+        this->toolbarIconSize->addItem(tr("Custom (%1px)").arg(current), QVariant((int)current));
+        index = this->toolbarIconSize->findData(QVariant(current));
+    } 
+    this->toolbarIconSize->setCurrentIndex(index);
 
     hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/MainWindow");
     this->tiledBackground->setChecked(hGrp->GetBool("TiledBackground", false));

--- a/src/Gui/DlgGeneralImp.cpp
+++ b/src/Gui/DlgGeneralImp.cpp
@@ -239,10 +239,10 @@ void DlgGeneralImp::loadSettings()
     }
 
     int current = getMainWindow()->iconSize().width();
-    this->toolbarIconSize->addItem(tr("Small (%1)").arg(16), QVariant((int)16));
-    this->toolbarIconSize->addItem(tr("Medium (%1)").arg(24), QVariant((int)24));
-    this->toolbarIconSize->addItem(tr("Large (%1)").arg(32), QVariant((int)32));
-    this->toolbarIconSize->addItem(tr("Extra large (%1)").arg(48), QVariant((int)48));
+    this->toolbarIconSize->addItem(tr("Small (%1px)").arg(16), QVariant((int)16));
+    this->toolbarIconSize->addItem(tr("Medium (%1px)").arg(24), QVariant((int)24));
+    this->toolbarIconSize->addItem(tr("Large (%1px)").arg(32), QVariant((int)32));
+    this->toolbarIconSize->addItem(tr("Extra large (%1px)").arg(48), QVariant((int)48));
     index = this->toolbarIconSize->findData(QVariant(current));
     if (index > -1) this->toolbarIconSize->setCurrentIndex(index);
 

--- a/src/Gui/DlgGeneralImp.cpp
+++ b/src/Gui/DlgGeneralImp.cpp
@@ -238,12 +238,11 @@ void DlgGeneralImp::loadSettings()
         }
     }
 
-    int size = QApplication::style()->pixelMetric(QStyle::PM_ToolBarIconSize);
     int current = getMainWindow()->iconSize().width();
-    this->toolbarIconSize->addItem(tr("Default (%1 x %1)").arg(size), QVariant((int)size));
-    this->toolbarIconSize->addItem(tr("Small (%1 x %1)").arg(16), QVariant((int)16));
-    this->toolbarIconSize->addItem(tr("Large (%1 x %1)").arg(32), QVariant((int)32));
-    this->toolbarIconSize->addItem(tr("Extra large (%1 x %1)").arg(48), QVariant((int)48));
+    this->toolbarIconSize->addItem(tr("Small (%1)").arg(16), QVariant((int)16));
+    this->toolbarIconSize->addItem(tr("Medium (%1)").arg(24), QVariant((int)24));
+    this->toolbarIconSize->addItem(tr("Large (%1)").arg(32), QVariant((int)32));
+    this->toolbarIconSize->addItem(tr("Extra large (%1)").arg(48), QVariant((int)48));
     index = this->toolbarIconSize->findData(QVariant(current));
     if (index > -1) this->toolbarIconSize->setCurrentIndex(index);
 


### PR DESCRIPTION
This PR fixes an issue with the icon size preferences where the default was set in such a way as to make 24px not available on some systems.

[Full discussion on the forum](https://forum.freecadweb.org/viewtopic.php?f=34&t=20207&p=157078#p157078)

[Forum Pull Request](https://forum.freecadweb.org/viewtopic.php?f=17&t=20373)

Key functioning:

> If you change the icon size in the property editor, you need to restart FreeCAD for it to be applied, as before. From that point on it appears in the icon size dropdown.
> 
> If in the preferences panel you change the icon size to a 'standard' size, your custom size remains available in the dropdown, until you exit the panel, at which point, only the standard sizes are available.