### PR TITLE
Path: Fixed QtGui import.

### DIFF
--- a/src/Mod/Path/PathScripts/PathDressupHoldingTags.py
+++ b/src/Mod/Path/PathScripts/PathDressupHoldingTags.py
@@ -49,7 +49,7 @@ LOG_MODULE = 'PathDressupHoldingTags'
 
 if FreeCAD.GuiUp:
     from pivy import coin
-    from PySide import QtCore
+    from PySide import QtGui
 
 def debugEdge(edge, prefix, force = False):
     if force or PathLog.getLevel(LOG_MODULE) == PathLog.Level.DEBUG:


### PR DESCRIPTION
In the refactoring frenzy of fixing up the unit tests so they run in all environments I included QtCore twice, instead of QtGui.