### PR TITLE
Add an update timer to the progress bar set to 500ms

### DIFF
--- a/src/Gui/ProgressBar.cpp
+++ b/src/Gui/ProgressBar.cpp
@@ -215,11 +215,14 @@ void Sequencer::setValue(int step)
                 showRemainingTime();
         }
         else {
-            d->bar->setValue(step);
-            if (d->bar->isVisible())
-                showRemainingTime();
-            d->bar->resetObserveEventFilter();
-            qApp->processEvents();
+	    int elapsed = d->progressTime.restart();
+	    if (elapsed > 500) {
+	            d->bar->setValue(step);
+	            if (d->bar->isVisible())
+	                showRemainingTime();
+	            d->bar->resetObserveEventFilter();
+	            qApp->processEvents();
+	    }
         }
     }
 }


### PR DESCRIPTION
Add an update timer to the progress bar set to 500ms instead of nothing. STEP Reader is updating the progress bar every time a new Shape is decoded/transferred and loaded, which is a huge amount of "interrupt" and slow down drastically the global performance. With this patch the STEP file transfer is running at the same speed than CAD Assistant or even faster with a parallel OCCT branch used.