### PR TITLE
Minor bug in PartDesignGui::ViewProviderPipe

### DIFF
--- a/src/Mod/PartDesign/Gui/ViewProviderPipe.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderPipe.cpp
@@ -141,7 +141,7 @@ void ViewProviderPipe::highlightReferences(const bool on, bool auxillery)
 
             for (std::string e : edges) {
                 int idx = std::stoi(e.substr(4)) - 1;
-                assert ( idx > 0 );
+                assert ( idx >= 0 );
                 if ( idx < (ssize_t) colors.size() )
                     colors[idx] = App::Color(1.0,0.0,1.0); // magenta
             }


### PR DESCRIPTION
Assert excludes any "Edge1"