### PR TITLE
PathUtils findParentJob fixed to work from within a PathCompound

### DIFF
--- a/src/Mod/Path/PathScripts/PathUtils.py
+++ b/src/Mod/Path/PathScripts/PathUtils.py
@@ -569,7 +569,7 @@ def findParentJob(obj):
     for i in obj.InList:
         if isinstance(i.Proxy, PathScripts.PathJob.ObjectPathJob):
             return i
-        if i.TypeId == "Path::FeaturePython":
+        if i.TypeId == "Path::FeaturePython" or i.TypeId == "Path::FeatureCompoundPython":
             grandParent = findParentJob(i)
             if grandParent is not None:
                 return grandParent


### PR DESCRIPTION
Discussed at https://forum.freecadweb.org/viewtopic.php?f=15&t=20475

Bugfix to make Paths inside a PathCompound to get calculated without errors