### PR TITLE
fix doxygen typo introduced to DraftVecUtils.py

### DIFF
--- a/src/Mod/Draft/DraftVecUtils.py
+++ b/src/Mod/Draft/DraftVecUtils.py
@@ -29,7 +29,7 @@ __url__ = ["http://www.freecadweb.org"]
 
 ## \defgroup DRAFTVECUTILS DraftVecUtils
 #  \ingroup DRAFT
-#  \brief Vector math utilities use in Draft workbench
+#  \brief Vector math utilities used in Draft workbench
 #
 # Vector math utilities
 


### PR DESCRIPTION
typo from previous commit 019b0e2529d2a6127e67500b049b3a604c3ff6fc