### PR TITLE
Packaging: macOS relocation of libraries without children

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -144,7 +144,7 @@ before_install:
        fi
 
        export CMAKE_ARGS="${CMAKE_OPTS} -DFREECAD_USE_EXTERNAL_KDL=ON -DFREECAD_USE_EXTERNAL_PIVY=ON -DFREECAD_CREATE_MAC_APP=ON"
-       export INSTALLED_APP_PATH="/usr/local/FreeCAD.app/Contents/bin/FreeCAD"
+       export INSTALLED_APP_PATH="/usr/local/FreeCAD.app/Contents/MacOS/FreeCAD"
        ;;
 
    *)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -196,7 +196,7 @@ if(APPLE)
             ${CMAKE_INSTALL_PREFIX}/${PACKAGE_NAME}.app/Contents)
         set(CMAKE_INSTALL_LIBDIR ${CMAKE_INSTALL_PREFIX}/lib)
     endif(FREECAD_CREATE_MAC_APP)
-    set(CMAKE_MACOSX_RPATH 1)
+    set(CMAKE_MACOSX_RPATH TRUE)
 endif(APPLE)
 
 OPTION(BUILD_FEM "Build the FreeCAD FEM module" ON)

--- a/src/MacAppBundle/FreeCAD.app/Contents/MacOS/FreeCAD
+++ b/src/MacAppBundle/FreeCAD.app/Contents/MacOS/FreeCAD
@@ -1,1 +1,0 @@
-../bin/FreeCAD

--- a/src/MacAppBundle/FreeCAD.app/Contents/bin/FreeCAD
+++ b/src/MacAppBundle/FreeCAD.app/Contents/bin/FreeCAD
@@ -1,0 +1,1 @@
+../MacOS/FreeCAD

--- a/src/Main/CMakeLists.txt
+++ b/src/Main/CMakeLists.txt
@@ -49,11 +49,16 @@ if(BUILD_GUI)
             RUNTIME DESTINATION bin
             LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         )
-    else(WIN32)
+    elseif(APPLE)
+        INSTALL(TARGETS FreeCADMain
+	    RUNTIME DESTINATION MacOS
+            LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        )
+    else()
         INSTALL(TARGETS FreeCADMain 
             RUNTIME DESTINATION bin
         )
-    endif(WIN32)
+    endif()
 endif(BUILD_GUI)
 ######################## FreeCADMainCmd ########################
 


### PR DESCRIPTION
  * macOS install path must be <bundle>/MacOS in order for
    QLibrary to find qt.conf to set the correct bundle paths
  * Refactored to add an explicit graph traversal to set the
    dynamic loader id to handle the case where a bundled
    resource does not have any children
  * Fixed the case where rpaths were not removed from
    libraries without children
  * Improved diagnostics when bundling fail to finds
    a dependent library in the search path

Mantis: #0002886
Refs: #535