### PR TITLE
Don't manage button arrow

### DIFF
--- a/src/Mod/Tux/NavigationIndicatorGui.py
+++ b/src/Mod/Tux/NavigationIndicatorGui.py
@@ -321,11 +321,9 @@ def onCompact():
     """Enable or disable compact mode."""
     if aCompact.isChecked():
         indicator.setToolButtonStyle(QtCore.Qt.ToolButtonIconOnly)
-        indicator.setStyleSheet("QToolButton::menu-indicator {image: none}")
         p.SetBool("Compact", 1)
     else:
         indicator.setToolButtonStyle(QtCore.Qt.ToolButtonTextBesideIcon)
-        indicator.setStyleSheet("QToolButton::menu-indicator {}")
         p.SetBool("Compact", 0)
 
 


### PR DESCRIPTION
On Windows it can result in undesired styling (reported by saso). Decision to show/hide the arrow if left to the user/stylesheet.