### PR TITLE
Override warning cleanup

### DIFF
--- a/src/3rdParty/salomesmesh/inc/SMESH_MeshVSLink.hxx
+++ b/src/3rdParty/salomesmesh/inc/SMESH_MeshVSLink.hxx
@@ -105,32 +105,32 @@ class SMESH_MeshVSLink : public MeshVS_DataSource3D {
 	//! by co-ordinates. For element this method must return all its nodes co-ordinates in the strict order: X, Y, Z and <br>
 	//! with nodes order is the same as in wire bounding the face or link. NbNodes is number of nodes of element. <br>
 	//! It is recommended to return 1 for node. Type is an element type. <br>
-	Standard_EXPORT   Standard_Boolean GetGeom(const Standard_Integer ID,const Standard_Boolean IsElement,TColStd_Array1OfReal& Coords,Standard_Integer& NbNodes,MeshVS_EntityType& Type) const;
+	Standard_EXPORT   Standard_Boolean GetGeom(const Standard_Integer ID,const Standard_Boolean IsElement,TColStd_Array1OfReal& Coords,Standard_Integer& NbNodes,MeshVS_EntityType& Type) const override;
 
-	Standard_EXPORT   Standard_Boolean Get3DGeom(const Standard_Integer ID,Standard_Integer& NbNodes,Handle(MeshVS_HArray1OfSequenceOfInteger)& Data) const;
+	Standard_EXPORT   Standard_Boolean Get3DGeom(const Standard_Integer ID,Standard_Integer& NbNodes,Handle(MeshVS_HArray1OfSequenceOfInteger)& Data) const override;
 
 	//! This method is similar to GetGeom, but returns only element or node type. This method is provided for <br>
 	//! a fine performance. <br>
-	Standard_EXPORT   Standard_Boolean GetGeomType(const Standard_Integer ID,const Standard_Boolean IsElement,MeshVS_EntityType& Type) const;
+	Standard_EXPORT   Standard_Boolean GetGeomType(const Standard_Integer ID,const Standard_Boolean IsElement,MeshVS_EntityType& Type) const override;
 
 	//! This method returns by number an address of any entity which represents element or node data structure. <br>
-	Standard_EXPORT   Standard_Address GetAddr(const Standard_Integer ID,const Standard_Boolean IsElement) const;
+	Standard_EXPORT   Standard_Address GetAddr(const Standard_Integer ID,const Standard_Boolean IsElement) const override;
 
 	//! This method returns information about what node this element consist of. <br>
-	Standard_EXPORT /*virtual*/  Standard_Boolean GetNodesByElement(const Standard_Integer ID,TColStd_Array1OfInteger& NodeIDs,Standard_Integer& NbNodes) const;
+	Standard_EXPORT /*virtual*/  Standard_Boolean GetNodesByElement(const Standard_Integer ID,TColStd_Array1OfInteger& NodeIDs,Standard_Integer& NbNodes) const override;
 
 	//! This method returns map of all nodes the object consist of. <br>
-	Standard_EXPORT  const TColStd_PackedMapOfInteger& GetAllNodes() const;
+	Standard_EXPORT  const TColStd_PackedMapOfInteger& GetAllNodes() const override;
 
 	//! This method returns map of all elements the object consist of. <br>
-	Standard_EXPORT  const TColStd_PackedMapOfInteger& GetAllElements() const;
+	Standard_EXPORT  const TColStd_PackedMapOfInteger& GetAllElements() const override;
 
 	//! This method calculates normal of face, which is using for correct reflection presentation. <br>
 	//! There is default method, for advance reflection this method can be redefined. <br>
-	Standard_EXPORT Standard_Boolean GetNormal(const Standard_Integer Id,const Standard_Integer Max,Standard_Real& nx,Standard_Real& ny,Standard_Real& nz) const;
+	Standard_EXPORT Standard_Boolean GetNormal(const Standard_Integer Id,const Standard_Integer Max,Standard_Real& nx,Standard_Real& ny,Standard_Real& nz) const override;
 
 	//! This method returns map of all groups the object contains. <br>
-	Standard_EXPORT void GetAllGroups(TColStd_PackedMapOfInteger& Ids) const;
+	Standard_EXPORT void GetAllGroups(TColStd_PackedMapOfInteger& Ids) const override;
 
 	// Type management
 	//

--- a/src/App/Extension.h
+++ b/src/App/Extension.h
@@ -43,6 +43,16 @@ public: \
   static void *create(void);\
 private: \
   static Base::Type classTypeId
+
+/// Like EXTENSION_TYPESYSTEM_HEADER, with getExtensionTypeId declared override
+#define EXTENSION_TYPESYSTEM_HEADER_WITH_OVERRIDE() \
+public: \
+  static Base::Type getExtensionClassTypeId(void); \
+  virtual Base::Type getExtensionTypeId(void) const override; \
+  static void init(void);\
+  static void *create(void);\
+private: \
+  static Base::Type classTypeId
     
 /// define to implement a subclass of Base::BaseClass
 #define EXTENSION_TYPESYSTEM_SOURCE_P(_class_) \
@@ -81,6 +91,15 @@ template<> void * _class_::create(void){\
 protected: \
   static const App::PropertyData * extensionGetPropertyDataPtr(void); \
   virtual const App::PropertyData &extensionGetPropertyData(void) const; \
+private: \
+  static App::PropertyData propertyData
+
+/// Like EXTENSION_PROPERTY_HEADER, but with override declarations.
+#define EXTENSION_PROPERTY_HEADER_WITH_OVERRIDE(_class_) \
+  EXTENSION_TYPESYSTEM_HEADER_WITH_OVERRIDE(); \
+protected: \
+  static const App::PropertyData * extensionGetPropertyDataPtr(void); \
+  virtual const App::PropertyData &extensionGetPropertyData(void) const override; \
 private: \
   static App::PropertyData propertyData
 

--- a/src/App/ExtensionContainer.h
+++ b/src/App/ExtensionContainer.h
@@ -114,7 +114,7 @@ namespace App {
 class AppExport ExtensionContainer : public App::PropertyContainer
 {
 
-    TYPESYSTEM_HEADER();
+    TYPESYSTEM_HEADER_WITH_OVERRIDE();
 
 public:
     
@@ -177,10 +177,10 @@ public:
     virtual const char* getPropertyDocumentation(const char *name) const override;
     //@}
     
-    virtual void onChanged(const Property*);
+    virtual void onChanged(const Property*) override;
     
-    virtual void Save(Base::Writer& writer) const;
-    virtual void Restore(Base::XMLReader& reader);
+    virtual void Save(Base::Writer& writer) const override;
+    virtual void Restore(Base::XMLReader& reader) override;
     
     //those methods save/restore the dynamic extenions without handling properties, which is something
     //done by the default Save/Restore methods.

--- a/src/App/OriginGroupExtension.h
+++ b/src/App/OriginGroupExtension.h
@@ -34,7 +34,7 @@ class Origin;
  */
 class AppExport OriginGroupExtension : public App::GeoFeatureGroupExtension
 {
-    EXTENSION_PROPERTY_HEADER(App::OriginGroupExtension);
+    EXTENSION_PROPERTY_HEADER_WITH_OVERRIDE(App::OriginGroupExtension);
     
 public:
     OriginGroupExtension ();
@@ -66,7 +66,7 @@ public:
     //changes all links of obj to a origin to point to this groupes origin
     void relinkToOrigin(App::DocumentObject* obj);
     
-    virtual void addObject(DocumentObject* obj);
+    virtual void addObject(DocumentObject* obj) override;
 
 protected:
     /// Checks integrity of the Origin

--- a/src/App/PropertyContainer.h
+++ b/src/App/PropertyContainer.h
@@ -230,6 +230,14 @@ protected: \
 private: \
   static App::PropertyData propertyData 
 
+/// Like PROPERTY_HEADER, but with overridden methods declared as such
+#define PROPERTY_HEADER_WITH_OVERRIDE(_class_) \
+  TYPESYSTEM_HEADER_WITH_OVERRIDE(); \
+protected: \
+  static const App::PropertyData * getPropertyDataPtr(void); \
+  virtual const App::PropertyData &getPropertyData(void) const override; \
+private: \
+  static App::PropertyData propertyData 
 /// 
 #define PROPERTY_SOURCE(_class_, _parentclass_) \
 TYPESYSTEM_SOURCE_P(_class_);\

--- a/src/Base/BaseClass.h
+++ b/src/Base/BaseClass.h
@@ -41,6 +41,15 @@ private: \
   static Base::Type classTypeId
 
 
+/// Like TYPESYSTEM_HEADER, but declare getTypeId as 'override'
+#define TYPESYSTEM_HEADER_WITH_OVERRIDE() \
+public: \
+  static Base::Type getClassTypeId(void); \
+  virtual Base::Type getTypeId(void) const override; \
+  static void init(void);\
+  static void *create(void);\
+private: \
+  static Base::Type classTypeId
 
 
 /// define to implement a  subclass of Base::BaseClass

--- a/src/Gui/ViewProviderGeoFeatureGroupExtension.h
+++ b/src/Gui/ViewProviderGeoFeatureGroupExtension.h
@@ -34,7 +34,7 @@ namespace Gui
 
 class GuiExport ViewProviderGeoFeatureGroupExtension : public ViewProviderGroupExtension
 {
-    EXTENSION_PROPERTY_HEADER(Gui::ViewProviderGeoFeatureGroupExtension);
+    EXTENSION_PROPERTY_HEADER_WITH_OVERRIDE(Gui::ViewProviderGeoFeatureGroupExtension);
 
 public:
     /// Constructor
@@ -58,8 +58,8 @@ public:
 
     virtual void extensionUpdateData(const App::Property*) override;
     
-    virtual void extensionDropObject(App::DocumentObject*);
-    virtual void extensionDragObject(App::DocumentObject*);
+    virtual void extensionDropObject(App::DocumentObject*) override;
+    virtual void extensionDragObject(App::DocumentObject*) override;
     
 protected:
     SoGroup *pcGroupChildren;

--- a/src/Gui/ViewProviderGroupExtension.h
+++ b/src/Gui/ViewProviderGroupExtension.h
@@ -32,7 +32,7 @@ namespace Gui
 
 class GuiExport ViewProviderGroupExtension : public ViewProviderExtension
 {
-    EXTENSION_PROPERTY_HEADER(Gui::ViewProviderGroupExtension);
+    EXTENSION_PROPERTY_HEADER_WITH_OVERRIDE(Gui::ViewProviderGroupExtension);
 
 public:
     /// Constructor

--- a/src/Gui/ViewProviderOriginGroupExtension.h
+++ b/src/Gui/ViewProviderOriginGroupExtension.h
@@ -33,7 +33,7 @@ namespace Gui
 
 class GuiExport ViewProviderOriginGroupExtension : public ViewProviderGeoFeatureGroupExtension
 {
-    EXTENSION_PROPERTY_HEADER(Gui::ViewProviderOriginGroupExtension);
+    EXTENSION_PROPERTY_HEADER_WITH_OVERRIDE(Gui::ViewProviderOriginGroupExtension);
 
 public:
     /// Constructor
@@ -47,7 +47,7 @@ public:
     virtual void extensionUpdateData(const App::Property* prop) override;
 
     virtual void extensionDragObject(App::DocumentObject*) override;
-    virtual void extensionDropObject(App::DocumentObject*);
+    virtual void extensionDropObject(App::DocumentObject*) override;
     
     void updateOriginSize();
 

--- a/src/Mod/Part/App/FaceMaker.h
+++ b/src/Mod/Part/App/FaceMaker.h
@@ -132,7 +132,7 @@ public:
  */
 class PartExport FaceMakerSimple : public FaceMakerPublic
 {
-    TYPESYSTEM_HEADER();
+    TYPESYSTEM_HEADER_WITH_OVERRIDE();
 public:
     virtual std::string getUserFriendlyName() const override;
     virtual std::string getBriefExplanation() const override;

--- a/src/Mod/Part/App/FaceMakerBullseye.h
+++ b/src/Mod/Part/App/FaceMakerBullseye.h
@@ -44,7 +44,7 @@ namespace Part
  */
 class PartExport FaceMakerBullseye: public FaceMakerPublic
 {
-    TYPESYSTEM_HEADER();
+    TYPESYSTEM_HEADER_WITH_OVERRIDE();
 public:
     FaceMakerBullseye()
         :planeSupplied(false){}

--- a/src/Mod/Part/App/FaceMakerCheese.h
+++ b/src/Mod/Part/App/FaceMakerCheese.h
@@ -41,7 +41,7 @@ namespace Part
  */
 class PartExport FaceMakerCheese: public FaceMakerPublic
 {
-    TYPESYSTEM_HEADER();
+    TYPESYSTEM_HEADER_WITH_OVERRIDE();
 public:
     virtual std::string getUserFriendlyName() const override;
     virtual std::string getBriefExplanation() const override;

--- a/src/Mod/Part/App/FeatureExtrusion.h
+++ b/src/Mod/Part/App/FeatureExtrusion.h
@@ -35,7 +35,7 @@ namespace Part
 
 class PartExport Extrusion : public Part::Feature
 {
-    PROPERTY_HEADER(Part::Extrusion);
+    PROPERTY_HEADER_WITH_OVERRIDE(Part::Extrusion);
 
 public:
     Extrusion();
@@ -73,10 +73,10 @@ public:
     /** @name methods override feature */
     //@{
     /// recalculate the feature
-    App::DocumentObjectExecReturn *execute(void);
-    short mustExecute() const;
+    App::DocumentObjectExecReturn *execute(void) override;
+    short mustExecute() const override;
     /// returns the type name of the view provider
-    const char* getViewProviderName(void) const {
+    const char* getViewProviderName(void) const override {
         return "PartGui::ViewProviderExtrusion";
     }
     //@}
@@ -135,7 +135,7 @@ protected:
  */
 class FaceMakerExtrusion: public FaceMakerCheese
 {
-    TYPESYSTEM_HEADER();
+    TYPESYSTEM_HEADER_WITH_OVERRIDE();
 public:
     virtual std::string getUserFriendlyName() const override;
     virtual std::string getBriefExplanation() const override;

--- a/src/Mod/Part/App/FeatureFace.h
+++ b/src/Mod/Part/App/FeatureFace.h
@@ -31,7 +31,7 @@ namespace Part
 
 class PartExport Face : public Part::Feature
 {
-    PROPERTY_HEADER(Part::Face);
+    PROPERTY_HEADER_WITH_OVERRIDE(Part::Face);
 
 public:
     Face();
@@ -42,10 +42,10 @@ public:
     /** @name methods override feature */
     //@{
     /// recalculate the feature
-    App::DocumentObjectExecReturn *execute(void);
-    short mustExecute() const;
+    App::DocumentObjectExecReturn *execute(void) override;
+    short mustExecute() const override;
     /// returns the type name of the ViewProvider
-    const char* getViewProviderName(void) const {
+    const char* getViewProviderName(void) const override {
         return "PartGui::ViewProviderFace";
     }
     void setupObject() override;

--- a/src/Mod/Part/App/FeatureOffset.h
+++ b/src/Mod/Part/App/FeatureOffset.h
@@ -32,7 +32,7 @@ namespace Part
 
 class PartExport Offset : public Part::Feature
 {
-    PROPERTY_HEADER(Part::Offset);
+    PROPERTY_HEADER_WITH_OVERRIDE(Part::Offset);
 
 public:
     Offset();
@@ -63,7 +63,7 @@ private:
 
 class PartExport Offset2D : public Offset
 {
-    PROPERTY_HEADER(Part::Offset2D);
+    PROPERTY_HEADER_WITH_OVERRIDE(Part::Offset2D);
 public:
     Offset2D();
     ~Offset2D();

--- a/src/Mod/Part/App/FeatureRevolution.h
+++ b/src/Mod/Part/App/FeatureRevolution.h
@@ -33,7 +33,7 @@ namespace Part
 
 class PartExport Revolution : public Part::Feature
 {
-    PROPERTY_HEADER(Part::Revolution);
+    PROPERTY_HEADER_WITH_OVERRIDE(Part::Revolution);
 
 public:
     Revolution();
@@ -50,13 +50,13 @@ public:
     /** @name methods override feature */
     //@{
     /// recalculate the feature
-    App::DocumentObjectExecReturn *execute(void);
-    short mustExecute() const;
+    App::DocumentObjectExecReturn *execute(void) override;
+    short mustExecute() const override;
 
     void onChanged(const App::Property* prop) override;
 
     /// returns the type name of the view provider
-    const char* getViewProviderName(void) const {
+    const char* getViewProviderName(void) const override{
         return "PartGui::ViewProviderRevolution";
     }
     //@}
@@ -82,7 +82,7 @@ private:
     static App::PropertyFloatConstraint::Constraints angleRangeU;
 
 protected:
-    virtual void setupObject();
+    virtual void setupObject() override;
 };
 
 } //namespace Part

--- a/src/Mod/Part/Gui/TaskAttacher.h
+++ b/src/Mod/Part/Gui/TaskAttacher.h
@@ -87,7 +87,7 @@ private Q_SLOTS:
     void visibilityAutomation(bool opening_not_closing);
 
 protected:
-    void changeEvent(QEvent *e);
+    void changeEvent(QEvent *e) override;
 private:
     void objectDeleted(const Gui::ViewProviderDocumentObject&);
     void onSelectionChanged(const Gui::SelectionChanges& msg) override;

--- a/src/Mod/PartDesign/App/Body.h
+++ b/src/Mod/PartDesign/App/Body.h
@@ -40,7 +40,7 @@ class Feature;
 
 class PartDesignExport Body : public Part::BodyBase
 {
-    PROPERTY_HEADER(PartDesign::Body);
+    PROPERTY_HEADER_WITH_OVERRIDE(PartDesign::Body);
 
 public:
 
@@ -52,11 +52,11 @@ public:
     /** @name methods override feature */
     //@{
     /// recalculate the feature
-    App::DocumentObjectExecReturn *execute(void);
-    short mustExecute() const;
+    App::DocumentObjectExecReturn *execute(void) override;
+    short mustExecute() const override;
 
     /// returns the type name of the view provider
-    const char* getViewProviderName(void) const {
+    const char* getViewProviderName(void) const override {
         return "PartDesignGui::ViewProviderBody";
     }
     //@}
@@ -107,7 +107,7 @@ public:
       * all features derived from PartDesign::Feature and Part::Datum and sketches
       */
     static bool isAllowed(const App::DocumentObject* f);
-    virtual bool allowObject(DocumentObject* f) {return isAllowed(f);};
+    virtual bool allowObject(DocumentObject* f) override {return isAllowed(f);};
 
     /**
      * Return the body which this feature belongs too, or NULL
@@ -115,14 +115,14 @@ public:
      */
     static Body *findBodyOf(const App::DocumentObject* feature);
 
-    PyObject *getPyObject(void);
+    PyObject *getPyObject(void) override;
 
 
 protected:
-    virtual void onSettingDocument();
+    virtual void onSettingDocument() override;
 
     /// Adjusts the first solid's feature's base on on BaseFeature getting setted
-    virtual void onChanged (const App::Property* prop);
+    virtual void onChanged (const App::Property* prop) override;
 
     /**
       * Return the solid feature before the given feature, or before the Tip feature
@@ -137,9 +137,9 @@ protected:
     App::DocumentObject *getNextSolidFeature(App::DocumentObject* start = NULL);
 
     /// Creates the corresponding Origin object
-    virtual void setupObject ();
+    virtual void setupObject () override;
     /// Removes all planes and axis if they are still linked to the document
-    virtual void unsetupObject ();
+    virtual void unsetupObject () override;
 
 private:
     boost::signals::scoped_connection connection;

--- a/src/Mod/TechDraw/App/DrawProjGroup.h
+++ b/src/Mod/TechDraw/App/DrawProjGroup.h
@@ -47,7 +47,7 @@ class Cube;
  */
 class TechDrawExport DrawProjGroup : public TechDraw::DrawViewCollection
 {
-    PROPERTY_HEADER(TechDraw::DrawProjGroup);
+    PROPERTY_HEADER_WITH_OVERRIDE(TechDraw::DrawProjGroup);
 
 public:
     /// Constructor
@@ -66,7 +66,7 @@ public:
 
     Base::BoundBox3d getBoundingBox() const;
     double calculateAutomaticScale() const;
-    virtual QRectF getRect(void) const;
+    virtual QRectF getRect(void) const override;
     virtual bool checkFit(TechDraw::DrawPage* p) const override;
     /// Check if container has a view of a specific type
     bool hasProjection(const char *viewProjType) const;
@@ -91,20 +91,20 @@ public:
     bool distributeProjections(void);
     void resetPositions(void);
 
-    short mustExecute() const;
+    short mustExecute() const override;
     /** @name methods overide Feature */
     //@{
     /// recalculate the Feature
-    virtual void onDocumentRestored();
-    virtual App::DocumentObjectExecReturn *execute(void);
+    virtual void onDocumentRestored() override;
+    virtual App::DocumentObjectExecReturn *execute(void) override;
     //@}
 
     /// returns the type name of the ViewProvider
-    virtual const char* getViewProviderName(void) const {
+    virtual const char* getViewProviderName(void) const override {
         return "TechDrawGui::ViewProviderProjGroup";
     }
     //return PyObject as DrawProjGroupPy
-    virtual PyObject *getPyObject(void);
+    virtual PyObject *getPyObject(void) override;
 
     /// Determines either "First Angle" or "Third Angle".
     App::Enumeration usedProjectionType(void);
@@ -132,7 +132,7 @@ public:
     void dumpISO(char * title);
 
 protected:
-    void onChanged(const App::Property* prop);
+    void onChanged(const App::Property* prop) override;
 
     //! Moves anchor view to keep our bounding box centre on the origin
     void moveToCentre();

--- a/src/Mod/TechDraw/App/DrawProjGroupItem.h
+++ b/src/Mod/TechDraw/App/DrawProjGroupItem.h
@@ -48,7 +48,7 @@ class DrawProjGroup;
 
 class TechDrawExport DrawProjGroupItem : public TechDraw::DrawViewPart
 {
-    PROPERTY_HEADER(TechDraw::DrawProjGroupItem);
+    PROPERTY_HEADER_WITH_OVERRIDE(TechDraw::DrawProjGroupItem);
 
 public:
     /// Constructor
@@ -58,26 +58,26 @@ public:
     App::PropertyEnumeration Type;
     App::PropertyVector      RotationVector;
 
-    short mustExecute() const;
-    virtual void onDocumentRestored();
-    virtual void unsetupObject();
+    short mustExecute() const override;
+    virtual void onDocumentRestored() override;
+    virtual void unsetupObject() override;
 
     DrawProjGroup* getGroup(void) const;
     double getRotateAngle();
 
     /// returns the type name of the ViewProvider
-    virtual const char* getViewProviderName(void) const {
+    virtual const char* getViewProviderName(void) const override {
         return "TechDrawGui::ViewProviderProjGroupItem";
     }
     //return PyObject as DrawProjGroupItemPy
-    virtual PyObject *getPyObject(void);
+    virtual PyObject *getPyObject(void) override;
 
     virtual gp_Ax2 getViewAxis(const Base::Vector3d& pt,
                                const Base::Vector3d& direction, 
                                const bool flip=true) const override;
 
 protected:
-    void onChanged(const App::Property* prop);
+    void onChanged(const App::Property* prop) override;
 
 private:
     static const char* TypeEnums[];

--- a/src/Mod/TechDraw/App/DrawViewSymbol.h
+++ b/src/Mod/TechDraw/App/DrawViewSymbol.h
@@ -37,7 +37,7 @@ class DrawPage;
 
 class TechDrawExport DrawViewSymbol : public TechDraw::DrawView
 {
-    PROPERTY_HEADER(TechDraw::DrawViewSymbol);
+    PROPERTY_HEADER_WITH_OVERRIDE(TechDraw::DrawViewSymbol);
 
 public:
     /// Constructor
@@ -50,19 +50,19 @@ public:
     /** @name methods overide Feature */
     //@{
     /// recalculate the Feature
-    virtual App::DocumentObjectExecReturn *execute(void);
+    virtual App::DocumentObjectExecReturn *execute(void) override;
     //@}
 
     /// returns the type name of the ViewProvider
-    virtual const char* getViewProviderName(void) const {
+    virtual const char* getViewProviderName(void) const override {
         return "TechDrawGui::ViewProviderSymbol";
     }
-    virtual QRectF getRect() const;
+    virtual QRectF getRect() const override;
     virtual bool checkFit(TechDraw::DrawPage* p) const override;
 
 
 protected:
-    virtual void onChanged(const App::Property* prop);
+    virtual void onChanged(const App::Property* prop) override;
     Base::BoundBox3d bbox;
 };
 

--- a/src/Mod/TechDraw/Gui/QGIViewDimension.h
+++ b/src/Mod/TechDraw/Gui/QGIViewDimension.h
@@ -94,12 +94,14 @@ public:
     ~QGIViewDimension() = default;
 
     void setViewPartFeature(TechDraw::DrawViewDimension *obj);
-    int type() const { return Type;}
+    int type() const override { return Type;}
 
-    virtual void drawBorder();
+    virtual void drawBorder() override;
     virtual void updateView(bool update = false) override;
-    virtual void paint(QPainter * painter, const QStyleOptionGraphicsItem * option, QWidget * widget = 0 );
-    virtual QColor getNormalColor(void);
+    virtual void paint( QPainter * painter,
+                        const QStyleOptionGraphicsItem * option,
+                        QWidget * widget = 0 ) override;
+    virtual QColor getNormalColor(void) override;
 
 public Q_SLOTS:
     void datumLabelDragged(void);
@@ -109,8 +111,9 @@ public Q_SLOTS:
     void updateDim(void);
 
 protected:
-    void draw();
-    virtual QVariant itemChange(GraphicsItemChange change, const QVariant &value);
+    void draw() override;
+    virtual QVariant itemChange( GraphicsItemChange change,
+                                 const QVariant &value ) override;
     virtual void setSvgPens(void);
     virtual void setPens(void);
 


### PR DESCRIPTION
This gets rid of ~5k warnings when building on MacOS.