### PR TITLE
Install macOS bundle executables into MacOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -880,15 +880,21 @@ endif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
                                                             "from PySide2.QtWidgets import *\n")
         file(WRITE ${CMAKE_BINARY_DIR}/bin/PySide/QtSvg.py  "from PySide2.QtSvg import *\n")
 
-        INSTALL(
-            FILES
-                ${CMAKE_BINARY_DIR}/bin/PySide/__init__.py
-                ${CMAKE_BINARY_DIR}/bin/PySide/QtCore.py
-                ${CMAKE_BINARY_DIR}/bin/PySide/QtGui.py
-                ${CMAKE_BINARY_DIR}/bin/PySide/QtSvg.py
-            DESTINATION
-                bin/PySide
-        )
+	if(APPLE)
+	    INSTALL(
+	        DIRECTORY	
+                    ${CMAKE_BINARY_DIR}/bin/PySide
+		DESTINATION
+                    MacOS
+            )
+	else()
+            INSTALL(
+	        DIRECTORY	
+                    ${CMAKE_BINARY_DIR}/bin/PySide
+                DESTINATION
+                    bin
+            )
+	endif()
     else()
         # set(PYTHON_SUFFIX -python${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR})
         SET(PYTHON_SUFFIX -python2.7) # for shiboken

--- a/src/MacAppBundle/FreeCAD.app/Contents/MacOS/PySide
+++ b/src/MacAppBundle/FreeCAD.app/Contents/MacOS/PySide
@@ -1,1 +1,0 @@
-../bin/PySide

--- a/src/MacAppBundle/FreeCAD.app/Contents/bin/FreeCAD
+++ b/src/MacAppBundle/FreeCAD.app/Contents/bin/FreeCAD
@@ -1,1 +1,0 @@
-../MacOS/FreeCAD

--- a/src/Main/CMakeLists.txt
+++ b/src/Main/CMakeLists.txt
@@ -94,11 +94,16 @@ if(WIN32)
         RUNTIME DESTINATION bin
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     )
-else(WIN32)
+elseif(APPLE)
+    INSTALL(TARGETS FreeCADMainCmd
+        RUNTIME DESTINATION MacOS
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    )
+else()
     INSTALL(TARGETS FreeCADMainCmd 
         RUNTIME DESTINATION bin
     )
-endif(WIN32)
+endif()
 
 ######################## FreeCADMainPy ########################
 

--- a/src/Tools/MakeMacBundleRelocatable.py
+++ b/src/Tools/MakeMacBundleRelocatable.py
@@ -359,7 +359,7 @@ def main():
     path = sys.argv[1]
     bundle_path = os.path.abspath(os.path.join(path, "Contents"))
     graph = DepsGraph()
-    dir_filter = ["bin", "lib", "Mod", "Mod/PartDesign",
+    dir_filter = ["MacOS", "lib", "Mod", 
                   "lib/python2.7/site-packages",
                   "lib/python2.7/lib-dynload"]
     search_paths = [bundle_path + "/lib"] + sys.argv[2:]


### PR DESCRIPTION
  * Previously, the macOS bundle executables were installed into
    bin which does not adhere to Apple guidelines and causes
    issues with certain frameworks like Qt.  The install has
    been refactored to install the executables into MacOS

Fixes #2928