### PR TITLE
Qt5: Enabled HiDPI scaling and Use HiDPI Qt Pixmaps

### DIFF
--- a/src/Gui/Application.cpp
+++ b/src/Gui/Application.cpp
@@ -1518,6 +1518,14 @@ void Application::runApplication(void)
         return;
     }
 
+#if QT_VERSION >= 0x050600
+    //Enable automatic scaling based on pixel density fo display (added in Qt 5.6)
+    mainApp.setAttribute(Qt::AA_EnableHighDpiScaling);
+#endif
+#if QT_VERSION >= 0x050100
+    //Enable support for highres images (added in Qt 5.1, but off by default)
+    mainApp.setAttribute(Qt::AA_UseHighDpiPixmaps);
+#endif
     // set application icon and window title
     it = cfg.find("Application");
     if (it != cfg.end()) {


### PR DESCRIPTION
  * Enable HiDPI scaling on displays that support it
    on Qt 5.6 and later
  * Enable HiDPI Pixmaps on Qt 5.1 and later