### PR TITLE
Path: holding tags arc generation - fixes Issue 2937

### DIFF
--- a/src/Mod/Path/PathScripts/PathDressupHoldingTags.py
+++ b/src/Mod/Path/PathScripts/PathDressupHoldingTags.py
@@ -44,8 +44,8 @@ def translate(text, context = "PathDressup_HoldingTags", disambig=None):
     return QtCore.QCoreApplication.translate(context, text, disambig)
 
 
-LOG_MODULE = 'PathDressupHoldingTags'
-#PathLog.setLevel(PathLog.Level.DEBUG, LOG_MODULE)
+LOG_MODULE = PathLog.thisModule()
+PathLog.setLevel(PathLog.Level.INFO, LOG_MODULE)
 
 if FreeCAD.GuiUp:
     from pivy import coin

--- a/src/Mod/Path/PathScripts/PathGeom.py
+++ b/src/Mod/Path/PathScripts/PathGeom.py
@@ -26,10 +26,13 @@ import FreeCAD
 import math
 import Part
 import Path
+import PathScripts.PathLog as PathLog
 
 from FreeCAD import Vector
 
 PathGeomTolerance = 0.000001
+
+#PathLog.setLevel(PathLog.Level.INFO, PathLog.thisModule())
 
 class Side:
     """Class to determine and define the side a Path is on, or Vectors are in relation to each other."""
@@ -222,7 +225,8 @@ class PathGeom:
             B = cls.xy(endPoint - center)
             d = -B.x * A.y + B.y * A.x
 
-            if d == 0:
+            if cls.isRoughly(d, 0, 0.005):
+                PathLog.info("Half circle arc at: (%.2f, %.2f, %.2f)" % (center.x, center.y, center.z))
                 # we're dealing with half a circle here
                 angle = cls.getAngle(A) + math.pi/2
                 if cmd.Name in cls.CmdMoveCW:
@@ -230,13 +234,15 @@ class PathGeom:
             else:
                 C = A + B
                 angle = cls.getAngle(C)
+                PathLog.info("Arc (%8f) at: (%.2f, %.2f, %.2f) -> angle=%f" % (d, center.x, center.y, center.z, angle / math.pi))
 
             R = A.Length
-            #print("arc: p1=(%.2f, %.2f) p2=(%.2f, %.2f) -> center=(%.2f, %.2f)" % (startPoint.x, startPoint.y, endPoint.x, endPoint.y, center.x, center.y))
-            #print("arc: A=(%.2f, %.2f) B=(%.2f, %.2f) -> d=%.2f" % (A.x, A.y, B.x, B.y, d))
-            #print("arc: R=%.2f angle=%.2f" % (R, angle/math.pi))
-            if startPoint.z == endPoint.z:
+            PathLog.debug("arc: p1=(%.2f, %.2f) p2=(%.2f, %.2f) -> center=(%.2f, %.2f)" % (startPoint.x, startPoint.y, endPoint.x, endPoint.y, center.x, center.y))
+            PathLog.debug("arc: A=(%.2f, %.2f) B=(%.2f, %.2f) -> d=%.2f" % (A.x, A.y, B.x, B.y, d))
+            PathLog.debug("arc: R=%.2f angle=%.2f" % (R, angle/math.pi))
+            if cls.isRoughly(startPoint.z, endPoint.z):
                 midPoint = center + Vector(math.cos(angle), math.sin(angle), 0) * R
+                PathLog.debug("arc: (%.2f, %.2f) -> (%.2f, %.2f) -> (%.2f, %.2f)" % (startPoint.x, startPoint.y, midPoint.x, midPoint.y, endPoint.x, endPoint.y))
                 return Part.Edge(Part.Arc(startPoint, midPoint, endPoint))
 
             # It's a Helix

--- a/src/Mod/Path/PathScripts/PathLog.py
+++ b/src/Mod/Path/PathScripts/PathLog.py
@@ -77,6 +77,10 @@ def getLevel(module = None):
         return _moduleLogLevel.get(module, _defaultLogLevel)
     return _defaultLogLevel
 
+def thisModule():
+    """returns the module id of the caller, can be used for setLevel, getLevel and trackModule."""
+    return _caller()[0]
+
 def _caller():
     """internal function to determine the calling module."""
     file, line, func, text = traceback.extract_stack(limit=3)[0]
@@ -160,5 +164,4 @@ def track(*args):
             print(message)
         return message
     return None
-
 

--- a/src/Mod/Path/PathTests/PathTestUtils.py
+++ b/src/Mod/Path/PathTests/PathTestUtils.py
@@ -110,3 +110,14 @@ class PathTestBase(unittest.TestCase):
         self.assertLine(hull, Vector(pt.x+r1, pt.y, pt.z), Vector(pt.x+r2, pt.y, pt.z+h))
         self.assertCircle(base, Vector(pt.x, pt.y, pt.z), r1)
 
+    def assertCommandEqual(self, c1, c2):
+        """Verify that the 2 commands are equivalent."""
+        self.assertEqual(c1.Name, c2.Name)
+
+        self.assertRoughly(c1.Parameters.get('X', 0), c2.Parameters.get('X', 0))
+        self.assertRoughly(c1.Parameters.get('Y', 0), c2.Parameters.get('Y', 0))
+        self.assertRoughly(c1.Parameters.get('Z', 0), c2.Parameters.get('Z', 0))
+
+        self.assertRoughly(c1.Parameters.get('I', 0), c2.Parameters.get('I', 0))
+        self.assertRoughly(c1.Parameters.get('J', 0), c2.Parameters.get('J', 0))
+        self.assertRoughly(c1.Parameters.get('K', 0), c2.Parameters.get('K', 0))

--- a/src/Mod/Path/PathTests/TestPathGeom.py
+++ b/src/Mod/Path/PathTests/TestPathGeom.py
@@ -122,6 +122,25 @@ class TestPathGeom(PathTestBase):
                     Path.Command('G3', {'X': p2.x, 'Y': p2.y, 'Z': p2.z, 'I': 1, 'J': 0, 'K': -1}), p1),
                 p1, Vector(-1/math.sqrt(2), -1/math.sqrt(2), 1), p2)
 
+    def test40(self):
+        """Verify arc results in proper G2/3 command."""
+        p1 = Vector(  0, -10, 0)
+        p2 = Vector(-10,   0, 0)
+        p3 = Vector(  0, +10, 0)
+        p4 = Vector(+10,   0, 0)
+
+        def cmds(pa, pb, pc, flip):
+            return PathGeom.cmdsForEdge(Part.Edge(Part.Arc(pa, pb, pc)), flip)[0]
+        def cmd(c, end, off):
+            return Path.Command(c, {'X': end.x, 'Y': end.y, 'Z': end.z, 'I': off.x, 'J': off.y, 'K': off.z})
+
+        self.assertCommandEqual(cmds(p1, p2, p3, False), cmd('G2', p3, Vector(0,  10, 0)))
+        self.assertCommandEqual(cmds(p1, p4, p3, False), cmd('G3', p3, Vector(0,  10, 0)))
+
+        self.assertCommandEqual(cmds(p1, p2, p3,  True), cmd('G3', p1, Vector(0, -10, 0)))
+        self.assertCommandEqual(cmds(p1, p4, p3,  True), cmd('G2', p1, Vector(0, -10, 0)))
+
+
     def test50(self):
         """Verify proper wire(s) aggregation from a Path."""
         commands = []


### PR DESCRIPTION
For posterity: the issue with the attached file (see mantis) was another float rounding problem, where a semi circle wasn't recognised as such.

However, holdingTagsCatastrophy from PathTorture revealed that there was another issue - converting an arc to its command did the wrong thing if the arc needed to be flipped.

https://www.freecadweb.org/tracker/view.php?id=2937