### PR TITLE
Properly fix the Tetrahedron node ordering with VTK. This was reporte…

### DIFF
--- a/src/3rdParty/salomesmesh/inc/SMDSAbs_ElementType.hxx
+++ b/src/3rdParty/salomesmesh/inc/SMDSAbs_ElementType.hxx
@@ -30,7 +30,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 /// Type (node, edge, face or volume) of elements
 ///////////////////////////////////////////////////////////////////////////////
-enum SMDSAbs_ElementType
+enum SMDSAbs_ElementType : unsigned long
   {
     SMDSAbs_All,
     SMDSAbs_Node,
@@ -43,7 +43,7 @@ enum SMDSAbs_ElementType
   };
 
 /*! enumeration for element geometry type */
-enum SMDSAbs_GeometryType
+enum SMDSAbs_GeometryType : unsigned long
   {
     // 0D element
     SMDSGeom_POINT,
@@ -67,7 +67,8 @@ enum SMDSAbs_GeometryType
   };
 
 
-enum SMDSAbs_ElementOrder {
+enum SMDSAbs_ElementOrder : unsigned long
+{
   ORDER_ANY,          /*! entities of any order */
   ORDER_LINEAR,       /*! entities of 1st order */
   ORDER_QUADRATIC     /*! entities of 2nd order */
@@ -76,7 +77,8 @@ enum SMDSAbs_ElementOrder {
 /*!
  * Enumeration of entity type used in mesh info array
  */
-enum SMDSAbs_EntityType {
+enum SMDSAbs_EntityType : unsigned long
+{
   SMDSEntity_Node,
   SMDSEntity_0D,
   SMDSEntity_Edge,

--- a/src/3rdParty/salomesmesh/src/SMDS/SMDS_VtkCellIterator.cpp
+++ b/src/3rdParty/salomesmesh/src/SMDS/SMDS_VtkCellIterator.cpp
@@ -63,7 +63,7 @@ SMDS_VtkCellIteratorToUNV::SMDS_VtkCellIteratorToUNV(SMDS_Mesh* mesh, int vtkCel
   _mesh = mesh;
   _cellId = vtkCellId;
   _index = 0;
-  // _type = aType;
+  _type = aType;
   //MESSAGE("SMDS_VtkCellInterlacedIterator (UNV)" << _type);
 
   _vtkIdList = vtkIdList::New();
@@ -72,7 +72,6 @@ SMDS_VtkCellIteratorToUNV::SMDS_VtkCellIteratorToUNV(SMDS_Mesh* mesh, int vtkCel
   grid->GetCellPoints((vtkIdType)_cellId, (vtkIdType&)_nbNodes, pts);
   _vtkIdList->SetNumberOfIds(_nbNodes);
   const int *ids = 0;
-  _type = aType;
   switch (_type)
   {
   case SMDSEntity_Quad_Edge:


### PR DESCRIPTION
…d into

PR #203 back this summer 2016. A memory overwrite is happening if the enum are not
properly sized