### PR TITLE
Spreadsheet: Fixed issue #2894: Unit strings could be used as aliases.

### DIFF
--- a/src/App/Expression.cpp
+++ b/src/App/Expression.cpp
@@ -1934,3 +1934,16 @@ bool ExpressionParser::isTokenAnIndentifier(const std::string & str)
     else
         return false;
 }
+
+bool ExpressionParser::isTokenAUnit(const std::string & str)
+{
+    ExpressionParser::YY_BUFFER_STATE buf = ExpressionParser_scan_string(str.c_str());
+    int token = ExpressionParserlex();
+    int status = ExpressionParserlex();
+    ExpressionParser_delete_buffer(buf);
+
+    if (status == 0 && token == UNIT)
+        return true;
+    else
+        return false;
+}

--- a/src/App/Expression.h
+++ b/src/App/Expression.h
@@ -481,6 +481,7 @@ AppExport Expression * parse(const App::DocumentObject *owner, const char *buffe
 AppExport UnitExpression * parseUnit(const App::DocumentObject *owner, const char *buffer);
 AppExport ObjectIdentifier parsePath(const App::DocumentObject *owner, const char* buffer);
 AppExport bool isTokenAnIndentifier(const std::string & str);
+AppExport bool isTokenAUnit(const std::string & str);
 AppExport std::vector<boost::tuple<int, int, std::string> > tokenize(const std::string & str);
 
 /**

--- a/src/Mod/Spreadsheet/App/PropertySheet.cpp
+++ b/src/Mod/Spreadsheet/App/PropertySheet.cpp
@@ -149,6 +149,9 @@ bool PropertySheet::isValidAlias(const std::string &candidate)
     if (getValueFromAlias(candidate) != 0)
         return false;
 
+    if (ExpressionParser::isTokenAUnit(candidate))
+        return false;
+
     if (boost::regex_match(candidate.c_str(), cm, gen)) {
         static const boost::regex e("\\${0,1}([A-Z]{1,2})\\${0,1}([0-9]{1,5})");
 

--- a/src/Mod/Spreadsheet/TestSpreadsheet.py
+++ b/src/Mod/Spreadsheet/TestSpreadsheet.py
@@ -692,6 +692,16 @@ class SpreadsheetCases(unittest.TestCase):
         else:
             self.fail("A cell address was used as alias which shouldn't be allowed")
 
+    def testSetInvalidAlias2(self):
+        """ Try to use a unit (reserved word) as alias name """
+        sheet = self.doc.addObject("Spreadsheet::Sheet","Calc")
+        try:
+            sheet.setAlias("A1","mA")
+        except:
+            self.assertEqual(sheet.getAlias("A1"), None)
+        else:
+            self.fail("A unit (reserved word) was used as alias which shouldn't be allowed")
+
     def testPlacementName(self):
         """ Object name is equal to property name (bug #2389) """
         if not FreeCAD.GuiUp:


### PR DESCRIPTION
Fixed issue #2894: Unit strings could be used as aliases.