### PR TITLE
Fix #2802 for multitransform and other PD tools

### DIFF
--- a/src/Mod/PartDesign/Gui/Command.cpp
+++ b/src/Mod/PartDesign/Gui/Command.cpp
@@ -1275,7 +1275,6 @@ bool dressupGetSelected(Gui::Command* cmd, const std::string& which,
         return false;
 
     std::vector<Gui::SelectionObject> selection = cmd->getSelection().getSelectionEx();
-    selection = cmd->getSelection().getSelectionEx();
 
     if (selection.size() == 0) {
         QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
@@ -1284,6 +1283,11 @@ bool dressupGetSelected(Gui::Command* cmd, const std::string& which,
     } else if (selection.size() != 1) {
         QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
             QObject::tr("Select an edge, face or body from a single body."));
+        return false;
+    }
+    else if (pcActiveBody != PartDesignGui::getBodyFor(selection[0].getObject(), false)) {
+        QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Selection is not in Active Body"),
+            QObject::tr("Select an edge, face or body from an active body."));
         return false;
     }
 

--- a/src/Mod/PartDesign/Gui/Command.cpp
+++ b/src/Mod/PartDesign/Gui/Command.cpp
@@ -1264,12 +1264,14 @@ bool CmdPartDesignSubtractiveLoft::isActive(void)
 bool dressupGetSelected(Gui::Command* cmd, const std::string& which,
         Gui::SelectionObject &selected)
 {
-    App::Document *doc = cmd->getDocument();
-    PartDesign::Body *pcActiveBody = PartDesignGui::getBody(
-        /*messageIfNot = */ PartDesignGui::assureModernWorkflow(doc));
-
     // No PartDesign feature without Body past FreeCAD 0.16
-    if (!pcActiveBody && PartDesignGui::isModernWorkflow(doc))
+    App::Document *doc = cmd->getDocument();
+    if (!PartDesignGui::assureModernWorkflow(doc))
+        return false;
+
+    PartDesign::Body *pcActiveBody = PartDesignGui::getBody(true);
+
+    if (!pcActiveBody)
         return false;
 
     std::vector<Gui::SelectionObject> selection = cmd->getSelection().getSelectionEx();
@@ -1620,13 +1622,15 @@ CmdPartDesignMirrored::CmdPartDesignMirrored()
 void CmdPartDesignMirrored::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
-		App::Document *doc = getDocument();
-		PartDesign::Body *pcActiveBody = PartDesignGui::getBody(
-			/*messageIfNot = */ PartDesignGui::assureModernWorkflow(doc));
+    // No PartDesign feature without Body past FreeCAD 0.16
+    App::Document *doc = getDocument();
+    if (!PartDesignGui::assureModernWorkflow(doc))
+        return;
 
-		// No PartDesign feature without Body past FreeCAD 0.16
-		if (!pcActiveBody && PartDesignGui::isModernWorkflow(doc))
-			return;
+	PartDesign::Body *pcActiveBody = PartDesignGui::getBody(true);
+
+	if (!pcActiveBody)
+		return;
 
     Gui::Command* cmd = this;
     auto worker = [this, cmd](std::string FeatName, std::vector<App::DocumentObject*> features) {
@@ -1682,13 +1686,15 @@ CmdPartDesignLinearPattern::CmdPartDesignLinearPattern()
 void CmdPartDesignLinearPattern::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
-		App::Document *doc = getDocument();
-		PartDesign::Body *pcActiveBody = PartDesignGui::getBody(
-			/*messageIfNot = */ PartDesignGui::assureModernWorkflow(doc));
+    // No PartDesign feature without Body past FreeCAD 0.16
+    App::Document *doc = getDocument();
+    if (!PartDesignGui::assureModernWorkflow(doc))
+        return;
 
-		// No PartDesign feature without Body past FreeCAD 0.16
-		if (!pcActiveBody && PartDesignGui::isModernWorkflow(doc))
-			return;
+    PartDesign::Body *pcActiveBody = PartDesignGui::getBody(true);
+
+    if (!pcActiveBody)
+        return;
 
     Gui::Command* cmd = this;
     auto worker = [this, cmd](std::string FeatName, std::vector<App::DocumentObject*> features) {
@@ -1746,13 +1752,15 @@ CmdPartDesignPolarPattern::CmdPartDesignPolarPattern()
 void CmdPartDesignPolarPattern::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
-		App::Document *doc = getDocument();
-		PartDesign::Body *pcActiveBody = PartDesignGui::getBody(
-			/*messageIfNot = */ PartDesignGui::assureModernWorkflow(doc));
+    // No PartDesign feature without Body past FreeCAD 0.16
+    App::Document *doc = getDocument();
+    if (!PartDesignGui::assureModernWorkflow(doc))
+        return;
 
-		// No PartDesign feature without Body past FreeCAD 0.16
-		if (!pcActiveBody && PartDesignGui::isModernWorkflow(doc))
-			return;
+    PartDesign::Body *pcActiveBody = PartDesignGui::getBody(true);
+
+    if (!pcActiveBody)
+        return;
 
     Gui::Command* cmd = this;
     auto worker = [this, cmd](std::string FeatName, std::vector<App::DocumentObject*> features) {

--- a/src/Mod/PartDesign/Gui/Command.cpp
+++ b/src/Mod/PartDesign/Gui/Command.cpp
@@ -1612,6 +1612,14 @@ CmdPartDesignMirrored::CmdPartDesignMirrored()
 void CmdPartDesignMirrored::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
+		App::Document *doc = getDocument();
+		PartDesign::Body *pcActiveBody = PartDesignGui::getBody(
+			/*messageIfNot = */ PartDesignGui::assureModernWorkflow(doc));
+
+		// No PartDesign feature without Body past FreeCAD 0.16
+		if (!pcActiveBody && PartDesignGui::isModernWorkflow(doc))
+			return;
+
     Gui::Command* cmd = this;
     auto worker = [this, cmd](std::string FeatName, std::vector<App::DocumentObject*> features) {
 
@@ -1666,6 +1674,14 @@ CmdPartDesignLinearPattern::CmdPartDesignLinearPattern()
 void CmdPartDesignLinearPattern::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
+		App::Document *doc = getDocument();
+		PartDesign::Body *pcActiveBody = PartDesignGui::getBody(
+			/*messageIfNot = */ PartDesignGui::assureModernWorkflow(doc));
+
+		// No PartDesign feature without Body past FreeCAD 0.16
+		if (!pcActiveBody && PartDesignGui::isModernWorkflow(doc))
+			return;
+
     Gui::Command* cmd = this;
     auto worker = [this, cmd](std::string FeatName, std::vector<App::DocumentObject*> features) {
 
@@ -1722,6 +1738,14 @@ CmdPartDesignPolarPattern::CmdPartDesignPolarPattern()
 void CmdPartDesignPolarPattern::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
+		App::Document *doc = getDocument();
+		PartDesign::Body *pcActiveBody = PartDesignGui::getBody(
+			/*messageIfNot = */ PartDesignGui::assureModernWorkflow(doc));
+
+		// No PartDesign feature without Body past FreeCAD 0.16
+		if (!pcActiveBody && PartDesignGui::isModernWorkflow(doc))
+			return;
+
     Gui::Command* cmd = this;
     auto worker = [this, cmd](std::string FeatName, std::vector<App::DocumentObject*> features) {
 
@@ -1819,8 +1843,13 @@ CmdPartDesignMultiTransform::CmdPartDesignMultiTransform()
 void CmdPartDesignMultiTransform::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
-    PartDesign::Body *pcActiveBody = PartDesignGui::getBody(/*messageIfNot = */false);
-    //if (!pcActiveBody) return;
+		App::Document *doc = getDocument();
+		PartDesign::Body *pcActiveBody = PartDesignGui::getBody(
+			/*messageIfNot = */ PartDesignGui::assureModernWorkflow(doc));
+
+		// No PartDesign feature without Body past FreeCAD 0.16
+		if (!pcActiveBody && PartDesignGui::isModernWorkflow(doc))
+			return;
 
     std::vector<App::DocumentObject*> features;
 

--- a/src/Mod/PartDesign/Gui/Command.cpp
+++ b/src/Mod/PartDesign/Gui/Command.cpp
@@ -884,11 +884,12 @@ void CmdPartDesignPad::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
     App::Document *doc = getDocument();
-    PartDesign::Body *pcActiveBody = PartDesignGui::getBody(
-        /*messageIfNot = */ PartDesignGui::assureModernWorkflow(doc));
+    if (!PartDesignGui::assureModernWorkflow(doc))
+        return;
 
-    // No PartDesign feature without Body past FreeCAD 0.16
-    if (!pcActiveBody && PartDesignGui::isModernWorkflow(doc))
+    PartDesign::Body *pcActiveBody = PartDesignGui::getBody(true);
+
+    if (!pcActiveBody)
         return;
 
     Gui::Command* cmd = this;
@@ -942,11 +943,12 @@ void CmdPartDesignPocket::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
     App::Document *doc = getDocument();
-    PartDesign::Body *pcActiveBody = PartDesignGui::getBody(
-        /*messageIfNot = */ PartDesignGui::assureModernWorkflow(doc));
+    if (!PartDesignGui::assureModernWorkflow(doc))
+        return;
 
-    // No PartDesign feature without Body past FreeCAD 0.16
-    if (!pcActiveBody && PartDesignGui::isModernWorkflow(doc))
+    PartDesign::Body *pcActiveBody = PartDesignGui::getBody(true);
+
+    if (!pcActiveBody)
         return;
 
     Gui::Command* cmd = this;
@@ -988,11 +990,12 @@ void CmdPartDesignRevolution::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
     App::Document *doc = getDocument();
-    PartDesign::Body *pcActiveBody = PartDesignGui::getBody(
-        /*messageIfNot = */ PartDesignGui::assureModernWorkflow(doc));
+    if (!PartDesignGui::assureModernWorkflow(doc))
+        return;
 
-    // No PartDesign feature without Body past FreeCAD 0.16
-    if (!pcActiveBody && PartDesignGui::isModernWorkflow(doc))
+    PartDesign::Body *pcActiveBody = PartDesignGui::getBody(true);
+
+    if (!pcActiveBody)
         return;
 
     Gui::Command* cmd = this;
@@ -1040,10 +1043,12 @@ void CmdPartDesignGroove::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
     App::Document *doc = getDocument();
-    PartDesign::Body *pcActiveBody = PartDesignGui::getBody(
-        /*messageIfNot = */ PartDesignGui::assureModernWorkflow(doc));
+    if (!PartDesignGui::assureModernWorkflow(doc))
+        return;
 
-    if (!pcActiveBody && PartDesignGui::isModernWorkflow(doc))
+    PartDesign::Body *pcActiveBody = PartDesignGui::getBody(true);
+
+    if (!pcActiveBody)
         return;
 
     Gui::Command* cmd = this;
@@ -1090,9 +1095,12 @@ CmdPartDesignAdditivePipe::CmdPartDesignAdditivePipe()
 void CmdPartDesignAdditivePipe::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
-    PartDesign::Body *pcActiveBody = PartDesignGui::getBody(/*messageIfNot = */ true);
+    App::Document *doc = getDocument();
+    if (!PartDesignGui::assureModernWorkflow(doc))
+        return;
 
-    // No PartDesign feature without Body past FreeCAD 0.13
+    PartDesign::Body *pcActiveBody = PartDesignGui::getBody(true);
+
     if (!pcActiveBody)
         return;
 
@@ -1137,9 +1145,12 @@ CmdPartDesignSubtractivePipe::CmdPartDesignSubtractivePipe()
 void CmdPartDesignSubtractivePipe::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
-    PartDesign::Body *pcActiveBody = PartDesignGui::getBody(/*messageIfNot = */ true);
+    App::Document *doc = getDocument();
+    if (!PartDesignGui::assureModernWorkflow(doc))
+        return;
 
-    // No PartDesign feature without Body past FreeCAD 0.13
+    PartDesign::Body *pcActiveBody = PartDesignGui::getBody(true);
+
     if (!pcActiveBody)
         return;
 
@@ -1184,9 +1195,12 @@ CmdPartDesignAdditiveLoft::CmdPartDesignAdditiveLoft()
 void CmdPartDesignAdditiveLoft::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
-    PartDesign::Body *pcActiveBody = PartDesignGui::getBody(/*messageIfNot = */ true);
+    App::Document *doc = getDocument();
+    if (!PartDesignGui::assureModernWorkflow(doc))
+        return;
 
-    // No PartDesign feature without Body past FreeCAD 0.13
+    PartDesign::Body *pcActiveBody = PartDesignGui::getBody(true);
+
     if (!pcActiveBody)
         return;
 
@@ -1231,9 +1245,12 @@ CmdPartDesignSubtractiveLoft::CmdPartDesignSubtractiveLoft()
 void CmdPartDesignSubtractiveLoft::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
-    PartDesign::Body *pcActiveBody = PartDesignGui::getBody(/*messageIfNot = */ true);
+    App::Document *doc = getDocument();
+    if (!PartDesignGui::assureModernWorkflow(doc))
+        return;
 
-    // No PartDesign feature without Body past FreeCAD 0.13
+    PartDesign::Body *pcActiveBody = PartDesignGui::getBody(true);
+
     if (!pcActiveBody)
         return;
 
@@ -1596,7 +1613,18 @@ void prepareTransformed(Gui::Command* cmd, const std::string& which,
             return;
         }
     }
+    else if (features.size() > 1) {
+        QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Multiple Features Selected"),
+            QObject::tr("Please select only one subtractive or additive feature first."));
+        return;
+    }
     else {
+        PartDesign::Body *pcActiveBody = PartDesignGui::getBody(true);
+        if (pcActiveBody != PartDesignGui::getBodyFor(features[0], false)) {
+            QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Selection is not in Active Body"),
+                QObject::tr("Please select only one subtractive or additive feature in an active body."));
+            return;
+        }
         worker(features);
     }
 }

--- a/src/Mod/PartDesign/Gui/Command.cpp
+++ b/src/Mod/PartDesign/Gui/Command.cpp
@@ -1264,6 +1264,14 @@ bool CmdPartDesignSubtractiveLoft::isActive(void)
 bool dressupGetSelected(Gui::Command* cmd, const std::string& which,
         Gui::SelectionObject &selected)
 {
+    App::Document *doc = cmd->getDocument();
+    PartDesign::Body *pcActiveBody = PartDesignGui::getBody(
+        /*messageIfNot = */ PartDesignGui::assureModernWorkflow(doc));
+
+    // No PartDesign feature without Body past FreeCAD 0.16
+    if (!pcActiveBody && PartDesignGui::isModernWorkflow(doc))
+        return false;
+
     std::vector<Gui::SelectionObject> selection = cmd->getSelection().getSelectionEx();
     selection = cmd->getSelection().getSelectionEx();
 

--- a/src/Mod/PartDesign/Gui/CommandPrimitive.cpp
+++ b/src/Mod/PartDesign/Gui/CommandPrimitive.cpp
@@ -40,6 +40,7 @@
 #include <Base/Console.h>
 
 #include "Utils.h"
+#include "WorkflowManager.h"
 
 using namespace std;
 
@@ -59,9 +60,14 @@ CmdPrimtiveCompAdditive::CmdPrimtiveCompAdditive()
 
 void CmdPrimtiveCompAdditive::activated(int iMsg)
 {
+    App::Document *doc = getDocument();
+    if (!PartDesignGui::assureModernWorkflow(doc))
+        return;
 
-    PartDesign::Body *pcActiveBody = PartDesignGui::getBody(/*messageIfNot = */true);
-    if (!pcActiveBody) return;
+    PartDesign::Body *pcActiveBody = PartDesignGui::getBody(true);
+
+    if (!pcActiveBody)
+        return;
 
     Gui::ActionGroup* pcAction = qobject_cast<Gui::ActionGroup*>(_pcAction);
     pcAction->setIcon(pcAction->actions().at(iMsg)->icon());
@@ -241,8 +247,14 @@ CmdPrimtiveCompSubtractive::CmdPrimtiveCompSubtractive()
 
 void CmdPrimtiveCompSubtractive::activated(int iMsg)
 {
-    PartDesign::Body *pcActiveBody = PartDesignGui::getBody(/*messageIfNot = */true);
-    if (!pcActiveBody) return;
+    App::Document *doc = getDocument();
+    if (!PartDesignGui::assureModernWorkflow(doc))
+        return;
+
+    PartDesign::Body *pcActiveBody = PartDesignGui::getBody(true);
+
+    if (!pcActiveBody)
+        return;
 
     Gui::ActionGroup* pcAction = qobject_cast<Gui::ActionGroup*>(_pcAction);
     pcAction->setIcon(pcAction->actions().at(iMsg)->icon());

--- a/src/Mod/PartDesign/Gui/WorkflowManager.cpp
+++ b/src/Mod/PartDesign/Gui/WorkflowManager.cpp
@@ -175,7 +175,7 @@ Workflow WorkflowManager::determinWorkflow( App::Document *doc) {
             Gui::Application::Instance->commandManager().runCommandByName("PartDesign_Migrate");
             rv = Workflow::Modern;
         } else if ( msgBox.clickedButton() == manuallyBtn ) {
-            rv = Workflow::Modern;
+            rv = Workflow::Undetermined;
         } else {
             rv = Workflow::Legacy;
         }


### PR DESCRIPTION
This should fix applying transform or dressup features to the objects outside the body.

Following checks are added
1. All the primitive, profile based, transform and dressup features are checking if document is in modern workflow and do not apply if it is not modern.
2. Workflow stays Undetermined if user presses Migrate Manually button.
3. Transform and Dressup features are only applied to a **single** selected object and only if the object is in active body.

Discussion currently is in PD Development branch - [What should happen when features is about to be applied outside the body?](http://forum.freecadweb.org/viewtopic.php?f=19&t=20938)
