### PR TITLE
str(Sketcher.Constraint('Radius', 1, 2)) should not return "<Constraint '?'>"

### DIFF
--- a/src/Mod/Sketcher/App/ConstraintPyImp.cpp
+++ b/src/Mod/Sketcher/App/ConstraintPyImp.cpp
@@ -484,6 +484,7 @@ std::string ConstraintPy::representation(void) const
         case Coincident         : result << "'Coincident'>";break;
         case Horizontal         : result << "'Horizontal' (" << getConstraintPtr()->First << ")>";break;
         case Vertical           : result << "'Vertical' (" << getConstraintPtr()->First << ")>";break;
+        case Radius             : result << "'Radius'>";break;
         case Parallel           : result << "'Parallel'>";break;
         case Tangent            :
             if (this->getConstraintPtr()->Third == Constraint::GeoUndef)


### PR DESCRIPTION
`str(Sketcher.Constraint('Radius', 1, 2))` should not return `"<Constraint '?'>"`, it should return `"<Constraint 'Radius'>"`

Note: I haven't tested this PR (yet).