### PR TITLE
python3: App/ Gui FreeCADInit.py + New style module

### DIFF
--- a/src/App/FreeCADInit.py
+++ b/src/App/FreeCADInit.py
@@ -33,10 +33,22 @@
 # imports the one and only
 import FreeCAD
 
+def removeFromPath(module_name):
+	import sys, os
+	paths = sys.path
+	for path in paths:
+		if module_name in path:
+			sys.path.remove(path)
+			return
+	else:
+		Wrn(module_name + " not found in sys.path\n")
+
+FreeCAD._newStyleModule = removeFromPath
+
 
 def InitApplications():
 	try:
-		import sys,os,traceback
+		import sys,os,traceback,io
 	except ImportError:
 		FreeCAD.Console.PrintError("\n\nSeems the python standard libs are not installed, bailing out!\n\n")
 		raise
@@ -279,7 +291,3 @@ del(InitApplications)
 del(test_ascii)
 
 Log ('Init: App::FreeCADInit.py done\n')
-
-
-
-

--- a/src/App/FreeCADInit.py
+++ b/src/App/FreeCADInit.py
@@ -86,9 +86,24 @@ def InitApplications():
 	# add also this path so that all modules search for libraries
 	# they depend on first here
 	PathExtension = BinDir + os.pathsep
+
 	# prepend all module paths to Python search path
 	Log('Init:   Searching for modules...\n')
-	FreeCAD.__path__ = list(ModDict.values())
+
+
+	# to have all the module-paths available in FreeCADGuiInit.py:
+	FreeCAD.__ModDirs__ = list(ModDict.values())
+
+	# this allows importing with:
+	# from FreeCAD.Module import package
+	FreeCAD.__path__ = [ModDir, Lib64Dir, LibDir]
+
+	# also add these directories to the sys.path to 
+	# not change the old behaviour. once we have moved to 
+	# proper python modules this can eventuelly be removed.
+	for path in FreeCAD.__path__[::-1]:
+		sys.path.insert(0, path)
+
 	for Dir in ModDict.values():
 		if ((Dir != '') & (Dir != 'CVS') & (Dir != '__init__.py')):
 			sys.path.insert(0,Dir)
@@ -105,13 +120,12 @@ def InitApplications():
 					Log(traceback.format_exc())
 					Log('-'*100+'\n')
 					Err('During initialization the error ' + str(inst) + ' occurred in ' + InstallFile + '\n')
+					Err('Please look into the log file for further information')
 				else:
 					Log('Init:      Initializing ' + Dir + '... done\n')
 			else:
 				Log('Init:      Initializing ' + Dir + '(Init.py not found)... ignore\n')
-	sys.path.insert(0,LibDir)
-	sys.path.insert(0,Lib64Dir)
-	sys.path.insert(0,ModDir)
+
 	Log("Using "+ModDir+" as module path!\n")
 	# new paths must be prepended to avoid to load a wrong version of a library
 	try:

--- a/src/App/FreeCADInit.py
+++ b/src/App/FreeCADInit.py
@@ -36,7 +36,7 @@ import FreeCAD
 
 def InitApplications():
 	try:
-		import sys,os,traceback,cStringIO
+		import sys,os,traceback,io
 	except ImportError:
 		FreeCAD.Console.PrintError("\n\nSeems the python standard libs are not installed, bailing out!\n\n")
 		raise
@@ -88,7 +88,7 @@ def InitApplications():
 	PathExtension = BinDir + os.pathsep
 	# prepend all module paths to Python search path
 	Log('Init:   Searching for modules...\n')
-	FreeCAD.__path__ = ModDict.values()
+	FreeCAD.__path__ = list(ModDict.values())
 	for Dir in ModDict.values():
 		if ((Dir != '') & (Dir != 'CVS') & (Dir != '__init__.py')):
 			sys.path.insert(0,Dir)
@@ -96,16 +96,15 @@ def InitApplications():
 			InstallFile = os.path.join(Dir,"Init.py")
 			if (os.path.exists(InstallFile)):
 				try:
-					#execfile(InstallFile)
-					exec open(InstallFile).read()
-				except Exception, inst:
+					# XXX: This looks scary securitywise...
+					with open(InstallFile) as f:
+						exec(f.read())
+				except Exception as inst:
 					Log('Init:      Initializing ' + Dir + '... failed\n')
 					Log('-'*100+'\n')
-					output=cStringIO.StringIO()
-					traceback.print_exc(file=output)
-					Log(output.getvalue())
+					Log(traceback.format_exc())
 					Log('-'*100+'\n')
-					Err('During initialization the error ' + str(inst).decode('ascii','replace') + ' occurred in ' + InstallFile + '\n')
+					Err('During initialization the error ' + str(inst) + ' occurred in ' + InstallFile + '\n')
 				else:
 					Log('Init:      Initializing ' + Dir + '... done\n')
 			else:

--- a/src/App/FreeCADInit.py
+++ b/src/App/FreeCADInit.py
@@ -34,6 +34,9 @@
 import FreeCAD
 
 def removeFromPath(module_name):
+	"""removes the module from the sys.path. The entry point for imports
+		will therfor always be FreeCAD.
+		eg.: from FreeCAD.Module.submodule import function"""
 	import sys, os
 	paths = sys.path
 	for path in paths:
@@ -43,7 +46,7 @@ def removeFromPath(module_name):
 	else:
 		Wrn(module_name + " not found in sys.path\n")
 
-FreeCAD._newStyleModule = removeFromPath
+FreeCAD._importFromFreeCAD = removeFromPath
 
 
 def InitApplications():
@@ -113,8 +116,7 @@ def InitApplications():
 	# also add these directories to the sys.path to 
 	# not change the old behaviour. once we have moved to 
 	# proper python modules this can eventuelly be removed.
-	for path in FreeCAD.__path__[::-1]:
-		sys.path.insert(0, path)
+	sys.path = [ModDir, Lib64Dir, LibDir] + sys.path
 
 	for Dir in ModDict.values():
 		if ((Dir != '') & (Dir != 'CVS') & (Dir != '__init__.py')):

--- a/src/App/FreeCADInit.py
+++ b/src/App/FreeCADInit.py
@@ -36,7 +36,7 @@ import FreeCAD
 
 def InitApplications():
 	try:
-		import sys,os,traceback,io
+		import sys,os,traceback
 	except ImportError:
 		FreeCAD.Console.PrintError("\n\nSeems the python standard libs are not installed, bailing out!\n\n")
 		raise
@@ -96,7 +96,7 @@ def InitApplications():
 
 	# this allows importing with:
 	# from FreeCAD.Module import package
-	FreeCAD.__path__ = [ModDir, Lib64Dir, LibDir]
+	FreeCAD.__path__ = [ModDir, Lib64Dir, LibDir, HomeMod]
 
 	# also add these directories to the sys.path to 
 	# not change the old behaviour. once we have moved to 
@@ -112,6 +112,7 @@ def InitApplications():
 			if (os.path.exists(InstallFile)):
 				try:
 					# XXX: This looks scary securitywise...
+
 					with open(InstallFile) as f:
 						exec(f.read())
 				except Exception as inst:

--- a/src/Gui/FreeCADGuiInit.py
+++ b/src/Gui/FreeCADGuiInit.py
@@ -98,7 +98,7 @@ class NoneWorkbench ( Workbench ):
 		return "Gui::NoneWorkbench"
 
 def InitApplications():
-	import sys,os,traceback,cStringIO
+	import sys,os,traceback
 	# Searching modules dirs +++++++++++++++++++++++++++++++++++++++++++++++++++
 	# (additional module paths are already cached)
 	ModDirs = FreeCAD.__path__
@@ -109,16 +109,16 @@ def InitApplications():
 			InstallFile = os.path.join(Dir,"InitGui.py")
 			if (os.path.exists(InstallFile)):
 				try:
-					#execfile(InstallFile)
-					exec open(InstallFile).read()
-				except Exception, inst:
+					# XXX: This looks scary securitywise...
+					with open(InstallFile) as f:
+						exec(f.read())
+				except Exception as inst:
 					Log('Init:      Initializing ' + Dir + '... failed\n')
 					Log('-'*100+'\n')
-					output=cStringIO.StringIO()
-					traceback.print_exc(file=output)
+					Log(traceback.format_exc())
 					Log(output.getvalue())
 					Log('-'*100+'\n')
-					Err('During initialization the error ' + str(inst).decode('ascii','replace') + ' occurred in ' + InstallFile + '\n')
+					Err('During initialization the error ' + str(inst) + ' occurred in ' + InstallFile + '\n')
 				else:
 					Log('Init:      Initializing ' + Dir + '... done\n')
 			else:

--- a/src/Gui/FreeCADGuiInit.py
+++ b/src/Gui/FreeCADGuiInit.py
@@ -101,7 +101,7 @@ def InitApplications():
 	import sys,os,traceback
 	# Searching modules dirs +++++++++++++++++++++++++++++++++++++++++++++++++++
 	# (additional module paths are already cached)
-	ModDirs = FreeCAD.__path__
+	ModDirs = FreeCAD.__ModDirs__
 	#print ModDirs
 	Log('Init:   Searching modules...\n')
 	for Dir in ModDirs:
@@ -116,9 +116,9 @@ def InitApplications():
 					Log('Init:      Initializing ' + Dir + '... failed\n')
 					Log('-'*100+'\n')
 					Log(traceback.format_exc())
-					Log(output.getvalue())
 					Log('-'*100+'\n')
 					Err('During initialization the error ' + str(inst) + ' occurred in ' + InstallFile + '\n')
+					Err('Please look into the log file for further information')
 				else:
 					Log('Init:      Initializing ' + Dir + '... done\n')
 			else:


### PR DESCRIPTION
first step towards new-style modules
- make FreeCADInit.py and FreeCADGuiInit.py python3 compatible
- use `FreeCAD.__ModDirs__` instead of `FreeCAD.__path__` for storing the module directory names
- set `FreeCAD.__path__` to ModDir, Lib64Dir, LibDir
- add ModDir, Lib64Dir, LibDir before the Modules get initialized. (This allows to import the a module from the Init.py via `__init__.py`
