### PR TITLE
Fix #2504 revolve groove

### DIFF
--- a/src/Mod/PartDesign/Gui/Command.cpp
+++ b/src/Mod/PartDesign/Gui/Command.cpp
@@ -738,14 +738,14 @@ void prepareProfileBased(Gui::Command* cmd, const std::string& which,
         func(static_cast<Part::Feature*>(feature), FeatName);
     };
     
-    //if a profie is selected we can make our life easy and fast
-    auto selection = cmd->getSelection().getSelectionEx();
+    //if a profile is selected we can make our life easy and fast
+    auto selection = cmd->getSelection().getSelectionEx(0, Part::Part2DObject::getClassTypeId());
     if (!selection.empty() && selection.front().hasSubNames()) {
         base_worker(selection.front().getObject(), selection.front().getSubNames().front());
         return;
     }
 
-    //no face profile was selected, do he extended sketch logic
+    //no face profile was selected, do the extended sketch logic
 
     bool bNoSketchWasSelected = false;
     // Get a valid sketch from the user

--- a/src/Mod/PartDesign/Gui/Command.cpp
+++ b/src/Mod/PartDesign/Gui/Command.cpp
@@ -724,7 +724,7 @@ void prepareProfileBased(Gui::Command* cmd, const std::string& which,
 
         Gui::Command::openCommand((std::string("Make ") + which).c_str());
         Gui::Command::doCommand(Gui::Command::Doc,"App.activeDocument().addObject(\"PartDesign::%s\",\"%s\")",
-                    which.c_str(), FeatName.c_str());
+            which.c_str(), FeatName.c_str());
         
         if (feature->isDerivedFrom(Part::Part2DObject::getClassTypeId())) {
             Gui::Command::doCommand(Gui::Command::Doc,"App.activeDocument().%s.Profile = App.activeDocument().%s",
@@ -739,7 +739,12 @@ void prepareProfileBased(Gui::Command* cmd, const std::string& which,
     };
     
     //if a profile is selected we can make our life easy and fast
-    auto selection = cmd->getSelection().getSelectionEx(0, Part::Part2DObject::getClassTypeId());
+    std::vector<Gui::SelectionObject> selection;
+    std::string cmdName = cmd->getName();
+    if (cmdName == "PartDesign_Revolution" || cmdName == "PartDesign_Groove")
+        selection = cmd->getSelection().getSelectionEx(0, Part::Part2DObject::getClassTypeId());
+    else
+        selection = cmd->getSelection().getSelectionEx();
     if (!selection.empty() && selection.front().hasSubNames()) {
         base_worker(selection.front().getObject(), selection.front().getSubNames().front());
         return;
@@ -774,7 +779,7 @@ void prepareProfileBased(Gui::Command* cmd, const std::string& which,
         return true;
     };
     
-    auto sketch_worker = [&](std::vector<App::DocumentObject*> features) {
+    auto sketch_worker = [&, base_worker](std::vector<App::DocumentObject*> features) {
         
         base_worker(features.front(), "");
     };


### PR DESCRIPTION
This is an attempt to fix bug [#2504](https://freecadweb.org/tracker/view.php?id=2504).
I've tried to stop Revolve and Groove from applying on faces. Now if Revolve or Groove is applied to selected face it doesn't result in an error.
[Forum thread](https://forum.freecadweb.org/viewtopic.php?f=19&t=21182)