### PR TITLE
Added App::PropertyPrecision

### DIFF
--- a/src/App/Application.cpp
+++ b/src/App/Application.cpp
@@ -1177,6 +1177,7 @@ void Application::initTypes(void)
     App ::PropertyFloat             ::init();
     App ::PropertyFloatList         ::init();
     App ::PropertyFloatConstraint   ::init();
+    App ::PropertyPrecision         ::init();
     App ::PropertyQuantity          ::init();
     App ::PropertyQuantityConstraint::init();
     App ::PropertyAngle             ::init();

--- a/src/App/PropertyStandard.cpp
+++ b/src/App/PropertyStandard.cpp
@@ -1097,6 +1097,27 @@ void PropertyFloatConstraint::setPyObject(PyObject *value)
     }
 }
 
+//**************************************************************************
+// PropertyPrecision
+//++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+TYPESYSTEM_SOURCE(App::PropertyPrecision, App::PropertyFloatConstraint);
+
+//**************************************************************************
+// Construction/Destruction
+//
+const PropertyFloatConstraint::Constraints PrecisionStandard = {0.0,DBL_MAX,0.001};
+
+PropertyPrecision::PropertyPrecision()
+{
+    setConstraints(&PrecisionStandard);
+}
+
+PropertyPrecision::~PropertyPrecision()
+{
+
+}
+
 
 //**************************************************************************
 // PropertyFloatList

--- a/src/App/PropertyStandard.h
+++ b/src/App/PropertyStandard.h
@@ -518,6 +518,23 @@ protected:
     const Constraints* _ConstStruct;
 };
 
+
+/** Precision properties
+ * This property fulfills the need of a floating value with many decimal points,
+ * e.g. for holding values like Precision::Confusion(). The value has a default
+ * constraint for non-negative, but can be overidden
+ */
+class AppExport PropertyPrecision: public PropertyFloatConstraint
+{
+    TYPESYSTEM_HEADER();
+public:
+    PropertyPrecision(void);
+    virtual ~PropertyPrecision();
+    virtual const char* getEditorName(void) const
+    { return "Gui::PropertyEditor::PropertyPrecisionItem"; }
+};
+
+
 class AppExport PropertyFloatList: public PropertyLists
 {
     TYPESYSTEM_HEADER();

--- a/src/Gui/SoFCDB.cpp
+++ b/src/Gui/SoFCDB.cpp
@@ -128,6 +128,7 @@ void Gui::SoFCDB::init()
     PropertyFloatItem               ::init();
     PropertyUnitItem                ::init();
     PropertyFloatConstraintItem     ::init();
+    PropertyPrecisionItem           ::init();
     PropertyUnitConstraintItem      ::init();
     PropertyAngleItem               ::init();
     PropertyBoolItem                ::init();

--- a/src/Gui/propertyeditor/PropertyItem.cpp
+++ b/src/Gui/propertyeditor/PropertyItem.cpp
@@ -1019,6 +1019,15 @@ QVariant PropertyFloatConstraintItem::editorData(QWidget *editor) const
 
 // --------------------------------------------------------------------
 
+PROPERTYITEM_SOURCE(Gui::PropertyEditor::PropertyPrecisionItem)
+
+PropertyPrecisionItem::PropertyPrecisionItem()
+{
+    setDecimals(16);
+}
+
+// --------------------------------------------------------------------
+
 PROPERTYITEM_SOURCE(Gui::PropertyEditor::PropertyAngleItem)
 
 PropertyAngleItem::PropertyAngleItem()

--- a/src/Gui/propertyeditor/PropertyItem.h
+++ b/src/Gui/propertyeditor/PropertyItem.h
@@ -350,6 +350,16 @@ protected:
 };
 
 /**
+ * Change a floating point number with many decimal points (hard coded as 16)
+ */
+class GuiExport PropertyPrecisionItem: public PropertyFloatConstraintItem
+{
+    PROPERTYITEM_HEADER
+protected:
+    PropertyPrecisionItem();
+};
+
+/**
  * Change a floating point number.
  * \author Werner Mayer
  */


### PR DESCRIPTION
The purpose of this property and the associated GUI property item is to properly display floating point value with many decimal points, such as Precision::Confusion()