### PR TITLE
PartDesign: fix non-selectable datum features

### DIFF
--- a/src/Mod/PartDesign/Gui/TaskDatumParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskDatumParameters.cpp
@@ -77,6 +77,9 @@ TaskDatumParameters::TaskDatumParameters(ViewProviderDatum *ViewProvider,QWidget
 
 TaskDatumParameters::~TaskDatumParameters()
 {
+    if(this->ViewProvider && this->ViewProvider->isDerivedFrom(ViewProviderDatum::getClassTypeId()))
+        static_cast<ViewProviderDatum*>(this->ViewProvider)->setPickable(true);
+    Gui::Selection().rmvSelectionGate();
 }
 
 
@@ -100,8 +103,6 @@ TaskDlgDatumParameters::~TaskDlgDatumParameters()
 
 bool TaskDlgDatumParameters::reject() {
     
-    Gui::Selection().rmvSelectionGate();
-    static_cast<ViewProviderDatum*>(ViewProvider)->setPickable(true);
     return PartGui::TaskDlgAttacher::reject();
 }
 


### PR DESCRIPTION
Fixes that newly created datum planes and other datum features were not selectable in 3d view. Probably, also fixes removal of selection gate, which may have caused other bugs.

see https://forum.freecadweb.org/viewtopic.php?f=3&t=21269 for more on the bug.

pull-request forum thread: https://forum.freecadweb.org/viewtopic.php?f=17&t=21284