### PR TITLE
BOPTools imporvements

### DIFF
--- a/src/Mod/Part/BOPTools/JoinFeatures.py
+++ b/src/Mod/Part/BOPTools/JoinFeatures.py
@@ -170,6 +170,22 @@ class ViewProviderConnect:
             FreeCAD.Console.PrintError("Error in onDelete: " + str(err))
         return True
 
+    def canDragObjects(self):
+        return True
+    def canDropObjects(self):
+        return True
+    def canDragObject(self, dragged_object):
+        return True
+    def canDropObject(self, incoming_object):
+        return hasattr(incoming_object, 'Shape')
+    def dragObject(self, selfvp, dragged_object):
+        objs = self.Object.Objects
+        objs.remove(dragged_object)
+        self.Object.Objects = objs
+    def dropObject(self, selfvp, incoming_object):
+        self.Object.Objects = self.Object.Objects + [incoming_object]
+
+
 class CommandConnect:
     "Command to create Connect feature"
     def GetResources(self):

--- a/src/Mod/Part/BOPTools/ShapeMerge.py
+++ b/src/Mod/Part/BOPTools/ShapeMerge.py
@@ -157,7 +157,7 @@ def mergeWires(list_of_edges_wires, flag_single = False, split_connections = [])
         return Part.Wire(edges)
     else:
         groups = splitIntoGroupsBySharing(edges, lambda sh: sh.Vertexes, split_connections)
-        return Part.makeCompound([Part.Wire(Part.getSortedClusters(group)[0]) for group in groups])
+        return Part.makeCompound([Part.Wire(Part.sortEdges(group)[0]) for group in groups])
 
 def mergeVertices(list_of_vertices, flag_single = False, split_connections = []):
     # no comprehensive support, just following the footprint of other mergeXXX()

--- a/src/Mod/Part/BOPTools/SplitFeatures.py
+++ b/src/Mod/Part/BOPTools/SplitFeatures.py
@@ -122,6 +122,21 @@ class ViewProviderBooleanFragments:
             FreeCAD.Console.PrintError("Error in onDelete: " + str(err))
         return True
 
+    def canDragObjects(self):
+        return True
+    def canDropObjects(self):
+        return True
+    def canDragObject(self, dragged_object):
+        return True
+    def canDropObject(self, incoming_object):
+        return hasattr(incoming_object, 'Shape')
+    def dragObject(self, selfvp, dragged_object):
+        objs = self.Object.Objects
+        objs.remove(dragged_object)
+        self.Object.Objects = objs
+    def dropObject(self, selfvp, incoming_object):
+        self.Object.Objects = self.Object.Objects + [incoming_object]
+
 def cmdCreateBooleanFragmentsFeature(name, mode):
     """cmdCreateBooleanFragmentsFeature(name, mode): implementation of GUI command to create
     BooleanFragments feature (GFA). Mode can be "Standard", "Split", or "CompSolid"."""
@@ -376,6 +391,21 @@ class ViewProviderXOR:
         except Exception as err:
             FreeCAD.Console.PrintError("Error in onDelete: " + str(err))
         return True
+
+    def canDragObjects(self):
+        return True
+    def canDropObjects(self):
+        return True
+    def canDragObject(self, dragged_object):
+        return True
+    def canDropObject(self, incoming_object):
+        return hasattr(incoming_object, 'Shape')
+    def dragObject(self, selfvp, dragged_object):
+        objs = self.Object.Objects
+        objs.remove(dragged_object)
+        self.Object.Objects = objs
+    def dropObject(self, selfvp, incoming_object):
+        self.Object.Objects = self.Object.Objects + [incoming_object]
 
 def cmdCreateXORFeature(name):
     """cmdCreateXORFeature(name): implementation of GUI command to create


### PR DESCRIPTION
* made Connect, BooleanFragments and XOR features support drag-and-drop in model tree like Part Fuse does. Requested by @HoWil  here: https://forum.freecadweb.org/viewtopic.php?f=3&t=21292
* fix wire stitching routine by using Part.sortEdges instead of Part.getSortedClusters. Fixes wrong result of Connect when connecting wires. See also https://forum.freecadweb.org/viewtopic.php?t=16985

PR thread: https://forum.freecadweb.org/viewtopic.php?f=17&t=21306