### PR TITLE
Fix part of #2504 - revolve and groove failed to apply to faces

### DIFF
--- a/src/App/OriginGroupExtension.cpp
+++ b/src/App/OriginGroupExtension.cpp
@@ -166,7 +166,8 @@ void OriginGroupExtension::relinkToOrigin(App::DocumentObject* obj)
             if(!p->getValue() || !p->getValue()->isDerivedFrom(App::OriginFeature::getClassTypeId()))
                 continue;
         
-            p->setValue(getOrigin()->getOriginFeature(static_cast<OriginFeature*>(p->getValue())->Role.getValue()));
+            std::vector<std::string> subValues = p->getSubValues();
+            p->setValue(getOrigin()->getOriginFeature(static_cast<OriginFeature*>(p->getValue())->Role.getValue()), subValues);
         }
         else if(prop->getTypeId().isDerivedFrom(App::PropertyLinkSubList::getClassTypeId())) {
             auto p = static_cast<App::PropertyLinkList*>(prop);

--- a/src/Mod/PartDesign/App/FeatureSketchBased.cpp
+++ b/src/Mod/PartDesign/App/FeatureSketchBased.cpp
@@ -912,7 +912,15 @@ void ProfileBased::getAxis(const App::DocumentObject *pcReferenceAxis, const std
     if (pcReferenceAxis == NULL)
         return;
 
-    Part::Part2DObject* sketch = getVerifiedSketch();
+    App::DocumentObject* profile = Profile.getValue();
+    Part::Part2DObject* sketch;
+    if (profile->getTypeId().isDerivedFrom(Part::Part2DObject::getClassTypeId())) {
+        sketch = getVerifiedSketch();
+    }
+    else if (profile->getTypeId().isDerivedFrom(Part::Feature::getClassTypeId())) {
+        sketch = static_cast<Part::Part2DObject*>(getVerifiedObject());
+    }
+
     Base::Placement SketchPlm = sketch->Placement.getValue();
     Base::Vector3d SketchPos = SketchPlm.getPosition();
     Base::Rotation SketchOrientation = SketchPlm.getRotation();
@@ -943,7 +951,8 @@ void ProfileBased::getAxis(const App::DocumentObject *pcReferenceAxis, const std
         return;
     }
 
-    if (pcReferenceAxis == sketch){
+    if (pcReferenceAxis == profile) {
+        //Part::Part2DObject* sketch = getVerifiedSketch();
         bool hasValidAxis=false;
         Base::Axis axis;
         if (subReferenceAxis[0] == "V_Axis") {

--- a/src/Mod/PartDesign/App/FeatureSketchBased.cpp
+++ b/src/Mod/PartDesign/App/FeatureSketchBased.cpp
@@ -914,19 +914,26 @@ void ProfileBased::getAxis(const App::DocumentObject *pcReferenceAxis, const std
 
     App::DocumentObject* profile = Profile.getValue();
     Part::Part2DObject* sketch;
+    gp_Pln sketchplane;
+    Base::Placement SketchPlm;
+
     if (profile->getTypeId().isDerivedFrom(Part::Part2DObject::getClassTypeId())) {
         sketch = getVerifiedSketch();
+        SketchPlm = sketch->Placement.getValue();
+        Base::Vector3d SketchPos = SketchPlm.getPosition();
+        Base::Rotation SketchOrientation = SketchPlm.getRotation();
+        Base::Vector3d SketchVector(0, 0, 1);
+        SketchOrientation.multVec(SketchVector, SketchVector);
+        sketchplane = gp_Pln(gp_Pnt(SketchPos.x, SketchPos.y, SketchPos.z), gp_Dir(SketchVector.x, SketchVector.y, SketchVector.z));
     }
     else if (profile->getTypeId().isDerivedFrom(Part::Feature::getClassTypeId())) {
-        sketch = static_cast<Part::Part2DObject*>(getVerifiedObject());
+        Base::Placement SketchPos = getVerifiedObject()->Placement.getValue();
+        Base::Vector3d  SketchVector = getProfileNormal();
+        TopoDS_Shape sketchshape = getVerifiedFace();
+        gp_XYZ facePos = sketchshape.Location().Transformation().TranslationPart();
+        //sketchshape.Location().Transformation().TranslationPart())
+        sketchplane = gp_Pln(gp_Pnt(SketchPos.getPosition().x, SketchPos.getPosition().y, SketchPos.getPosition().z), gp_Dir(SketchVector.x, SketchVector.y, SketchVector.z));
     }
-
-    Base::Placement SketchPlm = sketch->Placement.getValue();
-    Base::Vector3d SketchPos = SketchPlm.getPosition();
-    Base::Rotation SketchOrientation = SketchPlm.getRotation();
-    Base::Vector3d SketchVector(0,0,1);
-    SketchOrientation.multVec(SketchVector,SketchVector);
-    gp_Pln sketchplane(gp_Pnt(SketchPos.x, SketchPos.y, SketchPos.z), gp_Dir(SketchVector.x, SketchVector.y, SketchVector.z));
 
     // get reference axis
     if (pcReferenceAxis->getTypeId().isDerivedFrom(PartDesign::Line::getClassTypeId())) {

--- a/src/Mod/PartDesign/App/FeatureSketchBased.cpp
+++ b/src/Mod/PartDesign/App/FeatureSketchBased.cpp
@@ -1041,7 +1041,10 @@ Base::Vector3d ProfileBased::getProfileNormal() const {
     }
     else {
         TopoDS_Shape shape = getVerifiedFace(true);
-        if(shape.ShapeType() == TopAbs_FACE) {
+        if (shape == TopoDS_Shape())
+            return SketchVector;
+
+        if (shape.ShapeType() == TopAbs_FACE) {
             BRepAdaptor_Surface adapt(TopoDS::Face(shape));
             double u = adapt.FirstUParameter() + (adapt.LastUParameter() - adapt.FirstUParameter())/2.;
             double v = adapt.FirstVParameter() + (adapt.LastVParameter() - adapt.FirstVParameter())/2.;

--- a/src/Mod/PartDesign/Gui/Command.cpp
+++ b/src/Mod/PartDesign/Gui/Command.cpp
@@ -738,14 +738,14 @@ void prepareProfileBased(Gui::Command* cmd, const std::string& which,
         func(static_cast<Part::Feature*>(feature), FeatName);
     };
     
-    //if a profie is selected we can make our life easy and fast
-    auto selection = cmd->getSelection().getSelectionEx();
+    //if a profile is selected we can make our life easy and fast
+    auto selection = cmd->getSelection().getSelectionEx(0, Part::Part2DObject::getClassTypeId());
     if (!selection.empty() && selection.front().hasSubNames()) {
         base_worker(selection.front().getObject(), selection.front().getSubNames().front());
         return;
     }
 
-    //no face profile was selected, do he extended sketch logic
+    //no face profile was selected, do the extended sketch logic
 
     bool bNoSketchWasSelected = false;
     // Get a valid sketch from the user

--- a/src/Mod/PartDesign/Gui/Command.cpp
+++ b/src/Mod/PartDesign/Gui/Command.cpp
@@ -999,7 +999,7 @@ void CmdPartDesignRevolution::activated(int iMsg)
         return;
 
     Gui::Command* cmd = this;
-    auto worker = [this, cmd, pcActiveBody](Part::Feature* sketch, std::string FeatName) {
+    auto worker = [this, cmd, &pcActiveBody](Part::Feature* sketch, std::string FeatName) {
 
         if (FeatName.empty()) return;
 
@@ -1059,12 +1059,19 @@ void CmdPartDesignGroove::activated(int iMsg)
         return;
 
     Gui::Command* cmd = this;
-    auto worker = [this, cmd](Part::Feature* sketch, std::string FeatName) {
+    auto worker = [this, cmd, &pcActiveBody](Part::Feature* sketch, std::string FeatName) {
 
         if (FeatName.empty()) return;
 
-        Gui::Command::doCommand(Doc,"App.activeDocument().%s.ReferenceAxis = (App.activeDocument().%s,['V_Axis'])",
-                                                                             FeatName.c_str(), sketch->getNameInDocument());
+        if (sketch->isDerivedFrom(Part::Part2DObject::getClassTypeId())) {
+            Gui::Command::doCommand(Doc, "App.activeDocument().%s.ReferenceAxis = (App.activeDocument().%s,['V_Axis'])",
+                FeatName.c_str(), sketch->getNameInDocument());
+        }
+        else {
+            Gui::Command::doCommand(Doc, "App.activeDocument().%s.ReferenceAxis = (App.activeDocument().%s,[\"\"])",
+                FeatName.c_str(), pcActiveBody->getOrigin()->getY()->getNameInDocument());
+        }
+
         Gui::Command::doCommand(Doc,"App.activeDocument().%s.Angle = 360.0",FeatName.c_str());
         PartDesign::Groove* pcGroove = static_cast<PartDesign::Groove*>(cmd->getDocument()->getObject(FeatName.c_str()));
         if (pcGroove && pcGroove->suggestReversed())

--- a/src/Mod/PartDesign/Gui/Command.cpp
+++ b/src/Mod/PartDesign/Gui/Command.cpp
@@ -724,7 +724,7 @@ void prepareProfileBased(Gui::Command* cmd, const std::string& which,
 
         Gui::Command::openCommand((std::string("Make ") + which).c_str());
         Gui::Command::doCommand(Gui::Command::Doc,"App.activeDocument().addObject(\"PartDesign::%s\",\"%s\")",
-                    which.c_str(), FeatName.c_str());
+            which.c_str(), FeatName.c_str());
         
         if (feature->isDerivedFrom(Part::Part2DObject::getClassTypeId())) {
             Gui::Command::doCommand(Gui::Command::Doc,"App.activeDocument().%s.Profile = App.activeDocument().%s",
@@ -739,7 +739,12 @@ void prepareProfileBased(Gui::Command* cmd, const std::string& which,
     };
     
     //if a profile is selected we can make our life easy and fast
-    auto selection = cmd->getSelection().getSelectionEx(0, Part::Part2DObject::getClassTypeId());
+    std::vector<Gui::SelectionObject> selection;
+    std::string cmdName = cmd->getName();
+    if (cmdName == "PartDesign_Revolution" || cmdName == "PartDesign_Groove")
+        selection = cmd->getSelection().getSelectionEx(0, Part::Part2DObject::getClassTypeId());
+    else
+        selection = cmd->getSelection().getSelectionEx();
     if (!selection.empty() && selection.front().hasSubNames()) {
         base_worker(selection.front().getObject(), selection.front().getSubNames().front());
         return;
@@ -774,7 +779,7 @@ void prepareProfileBased(Gui::Command* cmd, const std::string& which,
         return true;
     };
     
-    auto sketch_worker = [&](std::vector<App::DocumentObject*> features) {
+    auto sketch_worker = [&, base_worker](std::vector<App::DocumentObject*> features) {
         
         base_worker(features.front(), "");
     };

--- a/src/Mod/PartDesign/TestPartDesignApp.py
+++ b/src/Mod/PartDesign/TestPartDesignApp.py
@@ -19,9 +19,8 @@
 #   USA                                                                   *
 #**************************************************************************
 
-import FreeCAD, FreeCADGui, os, sys, unittest, Sketcher, PartDesign, TestSketcherApp
+import FreeCAD, os, sys, unittest, Sketcher, PartDesign, TestSketcherApp
 App = FreeCAD
-Gui = FreeCADGui
 #---------------------------------------------------------------------------
 # define the test cases to test the FreeCAD Sketcher module
 #---------------------------------------------------------------------------
@@ -43,47 +42,47 @@ class PartDesignPadTestCases(unittest.TestCase):
 	def tearDown(self):
 		#closing doc
 		FreeCAD.closeDocument("PartDesignTest")
-		#print ("omit clos document for debuging")
+		# print ("omit clos document for debuging")
 
 class PartDesignRevolveTestCases(unittest.TestCase):
 	def setUp(self):
 		self.Doc = FreeCAD.newDocument("PartDesignTest")
 
 	def testRevolveFace(self):
-		self.Body1 = self.Doc.addObject('PartDesign::Body','Body')
-		self.Box1 = self.Doc.addObject('PartDesign::AdditiveBox','Box')
-		self.Body1.addObject(self.Box1)
-		self.Box1.Length=10.00
-		self.Box1.Width=10.00
-		self.Box1.Height=10.00
+		self.Body = self.Doc.addObject('PartDesign::Body','Body')
+		self.Box = self.Doc.addObject('PartDesign::AdditiveBox','Box')
+		self.Body.addObject(self.Box)
+		self.Box.Length=10.00
+		self.Box.Width=10.00
+		self.Box.Height=10.00
 		self.Doc.recompute()
 		self.Revolution = self.Doc.addObject("PartDesign::Revolution","Revolution")
-		self.Revolution.Profile = (self.Box1, ["Face6"])
+		self.Revolution.Profile = (self.Box, ["Face6"])
 	 	self.Revolution.ReferenceAxis = (self.Doc.Y_Axis,[""])
 		self.Revolution.Angle = 180.0
 		self.Revolution.Reversed = 1
-		self.Body1.addObject(self.Revolution)
+		self.Body.addObject(self.Revolution)
 		self.Doc.recompute()
 		self.failUnless(len(self.Revolution.Shape.Faces) == 10)
 		
 	def testGrooveFace(self):
-		self.Body2 = self.Doc.addObject('PartDesign::Body','Body')
-		self.Box2 = self.Doc.addObject('PartDesign::AdditiveBox','Box')
-		self.Body2.addObject(self.Box2)
-		self.Box2.Length=10.00
-		self.Box2.Width=10.00
-		self.Box2.Height=10.00
+		self.Body = self.Doc.addObject('PartDesign::Body','Body')
+		self.Box = self.Doc.addObject('PartDesign::AdditiveBox','Box')
+		self.Body.addObject(self.Box)
+		self.Box.Length=10.00
+		self.Box.Width=10.00
+		self.Box.Height=10.00
 		self.Doc.recompute()
 		self.Groove = self.Doc.addObject("PartDesign::Groove","Groove")
-		self.Groove.Profile = (self.Box2, ["Face6"])
+		self.Groove.Profile = (self.Box, ["Face6"])
 	 	self.Groove.ReferenceAxis = (self.Doc.X_Axis,[""])
 		self.Groove.Angle = 180.0
 		self.Groove.Reversed = 1
-		self.Body2.addObject(self.Groove)
+		self.Body.addObject(self.Groove)
 		self.Doc.recompute()
 		self.failUnless(len(self.Groove.Shape.Faces) == 5)
 		
 	def tearDown(self):
 		#closing doc
-		# FreeCAD.closeDocument("PartDesignTest")
-		print ("omit closing document for debugging")
+		FreeCAD.closeDocument("PartDesignTest")
+		# print ("omit closing document for debugging")

--- a/src/Mod/PartDesign/TestPartDesignApp.py
+++ b/src/Mod/PartDesign/TestPartDesignApp.py
@@ -19,9 +19,9 @@
 #   USA                                                                   *
 #**************************************************************************
 
-import FreeCAD, os, sys, unittest, Sketcher, PartDesign, TestSketcherApp
+import FreeCAD, FreeCADGui, os, sys, unittest, Sketcher, PartDesign, TestSketcherApp
 App = FreeCAD
-
+Gui = FreeCADGui
 #---------------------------------------------------------------------------
 # define the test cases to test the FreeCAD Sketcher module
 #---------------------------------------------------------------------------
@@ -44,3 +44,46 @@ class PartDesignPadTestCases(unittest.TestCase):
 		#closing doc
 		FreeCAD.closeDocument("PartDesignTest")
 		#print ("omit clos document for debuging")
+
+class PartDesignRevolveTestCases(unittest.TestCase):
+	def setUp(self):
+		self.Doc = FreeCAD.newDocument("PartDesignTest")
+
+	def testRevolveFace(self):
+		self.Body1 = self.Doc.addObject('PartDesign::Body','Body')
+		self.Box1 = self.Doc.addObject('PartDesign::AdditiveBox','Box')
+		self.Body1.addObject(self.Box1)
+		self.Box1.Length=10.00
+		self.Box1.Width=10.00
+		self.Box1.Height=10.00
+		self.Doc.recompute()
+		self.Revolution = self.Doc.addObject("PartDesign::Revolution","Revolution")
+		self.Revolution.Profile = (self.Box1, ["Face6"])
+	 	self.Revolution.ReferenceAxis = (self.Doc.Y_Axis,[""])
+		self.Revolution.Angle = 180.0
+		self.Revolution.Reversed = 1
+		self.Body1.addObject(self.Revolution)
+		self.Doc.recompute()
+		self.failUnless(len(self.Revolution.Shape.Faces) == 10)
+		
+	def testGrooveFace(self):
+		self.Body2 = self.Doc.addObject('PartDesign::Body','Body')
+		self.Box2 = self.Doc.addObject('PartDesign::AdditiveBox','Box')
+		self.Body2.addObject(self.Box2)
+		self.Box2.Length=10.00
+		self.Box2.Width=10.00
+		self.Box2.Height=10.00
+		self.Doc.recompute()
+		self.Groove = self.Doc.addObject("PartDesign::Groove","Groove")
+		self.Groove.Profile = (self.Box2, ["Face6"])
+	 	self.Groove.ReferenceAxis = (self.Doc.X_Axis,[""])
+		self.Groove.Angle = 180.0
+		self.Groove.Reversed = 1
+		self.Body2.addObject(self.Groove)
+		self.Doc.recompute()
+		self.failUnless(len(self.Groove.Shape.Faces) == 5)
+		
+	def tearDown(self):
+		#closing doc
+		# FreeCAD.closeDocument("PartDesignTest")
+		print ("omit closing document for debugging")


### PR DESCRIPTION
This should fix failing Revolve and Groove when applied to selected faces.

Discussion is [here](https://forum.freecadweb.org/viewtopic.php?f=19&t=21182).

Issue is [here](https://freecadweb.org/tracker/view.php?id=2504)

P.S. I did it again - closed and re-opened the same issue. Sorry, didn't want to have opened issue hanging around for long time. Should probably have it opened until resolved.