### PR TITLE
Fix Linux icon install locations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,21 +112,19 @@ endif()
 
 if(WIN32)
     SET(CMAKE_INSTALL_PREFIX ${CMAKE_BINARY_DIR}/install CACHE PATH "Installation root directory")
+    SET(CMAKE_INSTALL_DATADIR data CACHE PATH "Output directory for data and resource files")
+    SET(CMAKE_INSTALL_DOCDIR doc CACHE PATH "Output directory for documentation and license files")
+    SET(CMAKE_INSTALL_LIBDIR lib CACHE PATH "Output directory for libraries")
 else(WIN32)
     SET(CMAKE_INSTALL_PREFIX "/usr/lib${LIB_SUFFIX}/freecad" CACHE PATH "Installation root directory")
+    SET(CMAKE_INSTALL_DATAROOTDIR "/usr/share" CACHE PATH "Read-only architecture-independent data root (share)")
+    SET(CMAKE_INSTALL_DATADIR "${CMAKE_INSTALL_DATAROOTDIR}/freecad" CACHE PATH "Output directory for data and resource files")
+    SET(CMAKE_INSTALL_DOCDIR "${CMAKE_INSTALL_DATAROOTDIR}/doc/freecad" CACHE PATH "Output directory for documentation and license files")
+    # Don't set it without manual adaption of LibDir variable in src/App/FreeCADInit.py
+    SET(CMAKE_INSTALL_LIBDIR "${CMAKE_INSTALL_PREFIX}/lib" CACHE PATH "Output directory for libraries" FORCE)
 endif(WIN32)
 
-SET(CMAKE_INSTALL_DATADIR data CACHE PATH "Output directory for data and resource files")
 SET(CMAKE_INSTALL_INCLUDEDIR include CACHE PATH "Output directory for header files")
-SET(CMAKE_INSTALL_DOCDIR doc CACHE PATH "Output directory for documentation and license files")
-# Don't set it without manual adaption of LibDir variable in src/App/FreeCADInit.py
-SET(CMAKE_INSTALL_LIBDIR lib CACHE PATH "Output directory for libraries")
-
-if(NOT WIN32)
-    if(NOT IS_ABSOLUTE ${CMAKE_INSTALL_LIBDIR})
-	    SET(CMAKE_INSTALL_LIBDIR "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")
-    endif(NOT IS_ABSOLUTE ${CMAKE_INSTALL_LIBDIR})
-endif(NOT WIN32)
 
 SET(PYCXX_INCLUDE_DIR
     "${CMAKE_SOURCE_DIR}/src" CACHE PATH

--- a/src/Gui/CMakeLists.txt
+++ b/src/Gui/CMakeLists.txt
@@ -1200,14 +1200,11 @@ else(WIN32)
     INSTALL(TARGETS FreeCADGui
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     )
-    INSTALL(FILES Icons/freecad.xpm
-        Icons/freecad-icon-16.png
-        Icons/freecad-icon-32.png
-        Icons/freecad-icon-48.png
-        Icons/freecad-icon-64.png
-        Icons/freecad.svg
-        Icons/freecad-doc.png
-        DESTINATION ${CMAKE_INSTALL_DATADIR}
-    )
+    INSTALL(FILES Icons/freecad-icon-16.png DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor/16x16/apps RENAME freecad.png)
+    INSTALL(FILES Icons/freecad-icon-32.png DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor/32x32/apps RENAME freecad.png)
+    INSTALL(FILES Icons/freecad-icon-48.png DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor/48x48/apps RENAME freecad.png)
+    INSTALL(FILES Icons/freecad-icon-64.png DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor/64x64/apps RENAME freecad.png)
+    INSTALL(FILES Icons/freecad.svg DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor/scalable/apps)
+    INSTALL(FILES Icons/freecad.xpm DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/pixmaps)
+    INSTALL(FILES Icons/freecad-doc.svg DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor/scalable/mimetypes RENAME application-x-extension-fcstd.svg)
 endif(WIN32)
-


### PR DESCRIPTION
This is an initial stab at trying to fix the CMake files to install all FreeCAD's files to the correct locations on Linux. This PR only concerns the icons as shown in a DE and file manager.

I'd like to get some feedback on this and see if this causes issues for other operating systems and distros. Judging by the Debian specific files in `./package` I'd expect some things need to change for that as well. I did use the daily PPA's debs to compare if the files ended up in the same location and they do :) So I'd expect any "custom" work for Debian packaging could be removed as well.

I ran into this issue when trying to fix the [live/git ebuild for Gentoo](https://github.com/gentoo/gentoo/blob/master/media-gfx/freecad/freecad-9999.ebuild), which had some older workarounds to fix various issues which were now failing. I'd prefer to fix them here instead of every distro having to fix them separately :)

What I did was introduce some new variables mimicking CMake's GNUInstallDirs and make use of these variables to install the icon files to the correct location. The locations for icons are standardized, though info is a bit hard to find. The basic spec can be found here https://standards.freedesktop.org/icon-theme-spec/icon-theme-spec-latest.html.
The icons are now working as they should on Gentoo.

Also, there is a lot more needed to fix the whole CMake setup. Main issues being:
- The misuse of `CMAKE_INSTALL_PREFIX` to set the full path for where the libs should live. `CMAKE_INSTALL_PREFIX` is to let users pass a prefix like `~/` or `/usr/local` to install everything in a prefix. This will mean adding the correct location to all files that are being installed, which now depend on the implicit path as defined by the prefix. This ties in to the following point because that provides variables for the relevant paths.
- Custom definitions of default CMAKE variables as defined in [GNUInstallDirs](https://cmake.org/cmake/help/v3.0/module/GNUInstallDirs.html). These should be replaced by including GNUInstallDirs and getting rid of the custom variables
- Non-lib files being installed to `/usr/lib*`, tied to some hardcoded dependencies, see http://forum.freecadweb.org/viewtopic.php?f=4&t=12890


I can work on fixing these in follow up PRs if there's interest