### PR TITLE
Fix image installation for Start WB

### DIFF
--- a/src/Mod/Start/CMakeLists.txt
+++ b/src/Mod/Start/CMakeLists.txt
@@ -23,21 +23,7 @@ if(BUILD_GUI)
         LoadFemExample3D.py
         Mesh.py
         PartDesign.py
-        images/Background.jpg
-        images/FreeCAD.png
-        images/PartDesign.png
-        images/ArchDesign.png
-        images/Mesh.png
-        images/Complete.png
-        images/PartDesignExample.png
-        images/ArchExample.png
-        images/web.png
-        images/blank.png
-        images/freecad-doc.png
-        images/complete.jpg
         Ship.py
-        images/Ship.png
-        images/ShipExample.png
         StartPage.css
         StartPage.js
         StartPage.html

--- a/src/Mod/Start/StartPage/CMakeLists.txt
+++ b/src/Mod/Start/StartPage/CMakeLists.txt
@@ -6,3 +6,7 @@ INSTALL(FILES ${StartPage_Scripts}
 INSTALL(FILES ${StartPage_Resources}
     DESTINATION ${CMAKE_INSTALL_DATADIR}/Mod/Start/StartPage
 )
+
+INSTALL(DIRECTORY images/ 
+    DESTINATION ${CMAKE_INSTALL_DATADIR}/Mod/Start/StartPage/images
+)


### PR DESCRIPTION
In, e.g. the Ubuntu daily PPA, images are being installed directly into `${CMAKE_INSTALL_DATADIR}/Mod/Start/StartPage` rather than in the images sub-folder, and are not being found by the Start WB which expects them to be in that images folder. This PR fixes that.