### PR TITLE
ports-cache timeout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -140,7 +140,7 @@ before_install:
        if [ "${OSX_PORTS_CACHE}X" != "X" ]; then
             brew install jq
             cacheContext=$(create_helper_context repo=${OSX_PORTS_CACHE} auth_token=${GH_TOKEN} release=${FREECAD_RELEASE})
-            prime_local_ports_cache $cacheContext
+            travis_wait prime_local_ports_cache $cacheContext
        fi
        brew update >/dev/null
        brew --config


### PR DESCRIPTION
  * Use travis_wait for prime_local_ports_cache to increase ports-cache
    time limit imposed when restoring a ports-cache