### PR TITLE
Gui: added bbox selection style to GeometryObject

### DIFF
--- a/src/Gui/SoFCUnifiedSelection.cpp
+++ b/src/Gui/SoFCUnifiedSelection.cpp
@@ -79,6 +79,7 @@
 #include "SoFCInteractiveElement.h"
 #include "SoFCSelectionAction.h"
 #include "ViewProviderDocumentObject.h"
+#include "ViewProviderGeometryObject.h"
 
 using namespace Gui;
 
@@ -295,13 +296,18 @@ void SoFCUnifiedSelection::doAction(SoAction *action)
                 vps = this->pcDocument->getViewProvidersOfType(ViewProviderDocumentObject::getClassTypeId());
             for (std::vector<ViewProvider*>::iterator it = vps.begin(); it != vps.end(); ++it) {
                 ViewProviderDocumentObject* vpd = static_cast<ViewProviderDocumentObject*>(*it);
+                bool selected = Selection().isSelected(vpd->getObject()) && vpd->isSelectable();
                 if (vpd->useNewSelectionModel()) {
-                    if (Selection().isSelected(vpd->getObject()) && vpd->isSelectable()) {
+                    if(vpd->isDerivedFrom(ViewProviderGeometryObject::getClassTypeId()) &&
+                       static_cast<ViewProviderGeometryObject*>(vpd)->SelectionStyle.getValue()==1)
+                    {
+                        static_cast<ViewProviderGeometryObject*>(vpd)->showBoundingBox(selected);
+                    }else if(selected){
                         SoSelectionElementAction action(SoSelectionElementAction::All);
                         action.setColor(this->colorSelection.getValue());
                         action.apply(vpd->getRoot());
                     }
-                    else {
+                    if(!selected){
                         SoSelectionElementAction action(SoSelectionElementAction::None);
                         action.setColor(this->colorSelection.getValue());
                         action.apply(vpd->getRoot());

--- a/src/Gui/SoFCUnifiedSelection.h
+++ b/src/Gui/SoFCUnifiedSelection.h
@@ -91,6 +91,8 @@ public:
     //virtual void GLRenderInPath(SoGLRenderAction * action);
     //static  void turnOffCurrentHighlight(SoGLRenderAction * action);
 
+    bool checkSelectionStyle(int type, ViewProvider *vp);
+
     friend class View3DInventorViewer;
 protected:
     virtual ~SoFCUnifiedSelection();

--- a/src/Gui/ViewProviderGeometryObject.cpp
+++ b/src/Gui/ViewProviderGeometryObject.cpp
@@ -151,7 +151,7 @@ void ViewProviderGeometryObject::onChanged(const App::Property* prop)
         pcShapeMaterial->transparency.setValue(Mat.transparency);
     }
     else if (prop == &BoundingBox || prop == &SelectionStyle) {
-        if(SelectionStyle.getValue()!=0)
+        if(SelectionStyle.getValue()==0)
             showBoundingBox( BoundingBox.getValue() );
     }
 
@@ -437,7 +437,7 @@ void ViewProviderGeometryObject::showBoundingBox(bool show)
 
         // add to the highlight node
         pcBoundSwitch->addChild(pBoundingSep);
-        pcRoot->addChild(pcBoundSwitch);
+        pcRoot->insertChild(pcBoundSwitch,pcRoot->findChild(pcModeSwitch));
     }
 
     if (pcBoundSwitch) {

--- a/src/Gui/ViewProviderGeometryObject.cpp
+++ b/src/Gui/ViewProviderGeometryObject.cpp
@@ -88,6 +88,10 @@ ViewProviderGeometryObject::ViewProviderGeometryObject() : pcBoundSwitch(0)
     ADD_PROPERTY(BoundingBox,(false));
     ADD_PROPERTY(Selectable,(true));
 
+    ADD_PROPERTY(SelectionStyle,((long)0));
+    static const char *SelectionStyleEnum[] = {"Shape","BoundBox",0};
+    SelectionStyle.setEnums(SelectionStyleEnum);
+
     bool enableSel = hGrp->GetBool("EnableSelection", true);
     Selectable.setValue(enableSel);
 
@@ -146,8 +150,9 @@ void ViewProviderGeometryObject::onChanged(const App::Property* prop)
         pcShapeMaterial->shininess.setValue(Mat.shininess);
         pcShapeMaterial->transparency.setValue(Mat.transparency);
     }
-    else if (prop == &BoundingBox) {
-        showBoundingBox( BoundingBox.getValue() );
+    else if (prop == &BoundingBox || prop == &SelectionStyle) {
+        if(SelectionStyle.getValue()!=0)
+            showBoundingBox( BoundingBox.getValue() );
     }
 
     ViewProviderDocumentObject::onChanged(prop);

--- a/src/Gui/ViewProviderGeometryObject.cpp
+++ b/src/Gui/ViewProviderGeometryObject.cpp
@@ -74,7 +74,7 @@ PROPERTY_SOURCE(Gui::ViewProviderGeometryObject, Gui::ViewProviderDocumentObject
 
 const App::PropertyIntegerConstraint::Constraints intPercent = {0,100,1};
 
-ViewProviderGeometryObject::ViewProviderGeometryObject() : pcBoundSwitch(0)
+ViewProviderGeometryObject::ViewProviderGeometryObject() : pcBoundSwitch(0),pcBoundColor(0)
 {
     ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/View");
     unsigned long shcol = hGrp->GetUnsigned("DefaultShapeColor",3435973887UL); // light gray (204,204,204)
@@ -151,7 +151,8 @@ void ViewProviderGeometryObject::onChanged(const App::Property* prop)
         pcShapeMaterial->transparency.setValue(Mat.transparency);
     }
     else if (prop == &BoundingBox || prop == &SelectionStyle) {
-        if(SelectionStyle.getValue()==0)
+        applyBoundColor();
+        if(SelectionStyle.getValue()==0 || !Selectable.getValue())
             showBoundingBox( BoundingBox.getValue() );
     }
 
@@ -414,21 +415,32 @@ SoPickedPoint* ViewProviderGeometryObject::getPickedPoint(const SbVec2s& pos, co
     return (pick ? new SoPickedPoint(*pick) : 0);
 }
 
+void ViewProviderGeometryObject::applyBoundColor() {
+    if(!pcBoundColor) return;
+    ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/View");
+    unsigned long bbcol;
+    if(SelectionStyle.getValue() == 0 || !Selectable.getValue() || !hGrp->GetBool("EnableSelection", true))
+        bbcol = hGrp->GetUnsigned("BoundingBoxColor",4294967295UL); // white (255,255,255)
+    else
+        bbcol = hGrp->GetUnsigned("SelectionColor",0x00CD00UL); // rgb(0,205,0)
+
+    float r,g,b;
+    r = ((bbcol >> 24) & 0xff) / 255.0; g = ((bbcol >> 16) & 0xff) / 255.0; b = ((bbcol >> 8) & 0xff) / 255.0;
+    pcBoundColor->rgb.setValue(r, g, b);
+}
+
 void ViewProviderGeometryObject::showBoundingBox(bool show)
 {
     if (!pcBoundSwitch && show) {
-        ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/View");
-        unsigned long bbcol = hGrp->GetUnsigned("BoundingBoxColor",4294967295UL); // white (255,255,255)
-        float r,g,b;
-        r = ((bbcol >> 24) & 0xff) / 255.0; g = ((bbcol >> 16) & 0xff) / 255.0; b = ((bbcol >> 8) & 0xff) / 255.0;
         pcBoundSwitch = new SoSwitch();
         SoSeparator* pBoundingSep = new SoSeparator();
         SoDrawStyle* lineStyle = new SoDrawStyle;
         lineStyle->lineWidth = 2.0f;
         pBoundingSep->addChild(lineStyle);
-        SoBaseColor* color = new SoBaseColor();
-        color->rgb.setValue(r, g, b);
-        pBoundingSep->addChild(color);
+
+        pcBoundColor = new SoBaseColor();
+        pBoundingSep->addChild(pcBoundColor);
+        applyBoundColor();
 
         pBoundingSep->addChild(new SoResetTransform());
         pBoundingSep->addChild(pcBoundingBox);
@@ -447,6 +459,12 @@ void ViewProviderGeometryObject::showBoundingBox(bool show)
 
 void ViewProviderGeometryObject::setSelectable(bool selectable)
 {
+    if(SelectionStyle.getValue()) {
+        applyBoundColor();
+        if(!selectable) 
+            showBoundingBox(false);
+    }
+
     SoSearchAction sa;
     sa.setInterest(SoSearchAction::ALL);
     sa.setSearchingAll(TRUE);

--- a/src/Gui/ViewProviderGeometryObject.h
+++ b/src/Gui/ViewProviderGeometryObject.h
@@ -64,6 +64,7 @@ public:
     App::PropertyMaterial ShapeMaterial;
     App::PropertyBool BoundingBox;
     App::PropertyBool Selectable;
+    App::PropertyEnumeration SelectionStyle;
 
     /**
      * Attaches the document object to this view provider.
@@ -93,6 +94,9 @@ public:
     
     /*! synchronize From FC placement to Coin placement*/
     static void updateTransform(const Base::Placement &from, SoTransform *to);
+    
+    void showBoundingBox(bool);
+
 protected:
     bool setEdit(int ModNum);
     void unsetEdit(int ModNum);
@@ -102,7 +106,6 @@ protected:
     SoFCCSysDragger *csysDragger = nullptr;
 
 protected:
-    void showBoundingBox(bool);
     /// get called by the container whenever a property has been changed
     void onChanged(const App::Property* prop);
     void setSelectable(bool Selectable=true);

--- a/src/Gui/ViewProviderGeometryObject.h
+++ b/src/Gui/ViewProviderGeometryObject.h
@@ -33,6 +33,7 @@ class SoSensor;
 class SoDragger;
 class SbVec2s;
 class SoTransform;
+class SoBaseColor;
 
 namespace Base { class Placement;}
 
@@ -109,6 +110,7 @@ protected:
     /// get called by the container whenever a property has been changed
     void onChanged(const App::Property* prop);
     void setSelectable(bool Selectable=true);
+    void applyBoundColor();
 
 private:
     static void dragStartCallback(void * data, SoDragger * d);
@@ -120,6 +122,7 @@ protected:
     SoMaterial       * pcShapeMaterial;
     SoFCBoundingBox  * pcBoundingBox;
     SoSwitch         * pcBoundSwitch;
+    SoBaseColor      * pcBoundColor;
 };
 
 } // namespace Gui


### PR DESCRIPTION
Whole object selection for complex shapes causes significant delay. This patch added a new selection style, which shows a bounding box instead of highlighting the whole object.

A new property 'SelectionStyle' is added to ViewProviderGeometryObject to control selection style per object.