### PR TITLE
Gui: increase pre-select information display

### DIFF
--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -277,10 +277,10 @@ MainWindow::MainWindow(QWidget * parent, Qt::WindowFlags f)
     // labels and progressbar
     d->status = new StatusBarObserver();
     d->actionLabel = new QLabel(statusBar());
-    d->actionLabel->setMinimumWidth(120);
+    // d->actionLabel->setMinimumWidth(120);
     d->sizeLabel = new QLabel(tr("Dimension"), statusBar());
     d->sizeLabel->setMinimumWidth(120);
-    statusBar()->addWidget(d->actionLabel, 0);
+    statusBar()->addWidget(d->actionLabel, 1);
     QProgressBar* progressBar = Gui::Sequencer::instance()->getProgressBar(statusBar());
     statusBar()->addPermanentWidget(progressBar, 0);
     statusBar()->addPermanentWidget(d->sizeLabel, 0);
@@ -1550,7 +1550,7 @@ void MainWindow::changeEvent(QEvent *e)
 void MainWindow::showMessage (const QString& message, int timeout)
 {
     QFontMetrics fm(statusBar()->font());
-    QString msg = fm.elidedText(message, Qt::ElideMiddle, this->width()/2);
+    QString msg = fm.elidedText(message, Qt::ElideMiddle, this->d->actionLabel->width());
 #if QT_VERSION <= 0x040600
     this->statusBar()->showMessage(msg, timeout);
 #else

--- a/src/Gui/SoFCUnifiedSelection.cpp
+++ b/src/Gui/SoFCUnifiedSelection.cpp
@@ -66,6 +66,7 @@
 #include <Inventor/SoPickedPoint.h>
 
 #include <Base/Console.h>
+#include <Base/UnitsApi.h>
 #include <App/Application.h>
 #include <App/Document.h>
 #include <Gui/Document.h>
@@ -366,12 +367,13 @@ SoFCUnifiedSelection::handleEvent(SoHandleEventAction * action)
 
                 this->preSelection = 1;
                 static char buf[513];
-                snprintf(buf,512,"Preselected: %s.%s.%s (%f,%f,%f)",documentName.c_str()
+                int p = Base::UnitsApi::getDecimals();
+                snprintf(buf,512,"Preselected: %s.%s.%s (%.*g,%.*g,%.*g)",documentName.c_str()
                                            ,objectName.c_str()
                                            ,subElementName.c_str()
-                                           ,pp->getPoint()[0]
-                                           ,pp->getPoint()[1]
-                                           ,pp->getPoint()[2]);
+                                           ,p,pp->getPoint()[0]
+                                           ,p,pp->getPoint()[1]
+                                           ,p,pp->getPoint()[2]);
 
                 getMainWindow()->showMessage(QString::fromLatin1(buf));
 
@@ -468,12 +470,13 @@ SoFCUnifiedSelection::handleEvent(SoHandleEventAction * action)
                         if (ok)
                             type = SoSelectionElementAction::Append;
                         if (mymode == OFF) {
-                            snprintf(buf,512,"Selected: %s.%s.%s (%f,%f,%f)",documentName.c_str()
+                            int p = Base::UnitsApi::getDecimals();
+                            snprintf(buf,512,"Selected: %s.%s.%s (%.*g,%.*g,%.*g)",documentName.c_str()
                                                        ,objectName.c_str()
                                                        ,subElementName.c_str()
-                                                       ,pp->getPoint()[0]
-                                                       ,pp->getPoint()[1]
-                                                       ,pp->getPoint()[2]);
+                                                       ,p,pp->getPoint()[0]
+                                                       ,p,pp->getPoint()[1]
+                                                       ,p,pp->getPoint()[2]);
 
                             getMainWindow()->showMessage(QString::fromLatin1(buf));
                         }
@@ -506,12 +509,13 @@ SoFCUnifiedSelection::handleEvent(SoHandleEventAction * action)
                     }
 
                     if (mymode == OFF) {
-                        snprintf(buf,512,"Selected: %s.%s.%s (%f,%f,%f)",documentName.c_str()
+                        int p = Base::UnitsApi::getDecimals();
+                        snprintf(buf,512,"Selected: %s.%s.%s (%.*g,%.*g,%.*g)",documentName.c_str()
                                                    ,objectName.c_str()
                                                    ,subElementName.c_str()
-                                                   ,pp->getPoint()[0]
-                                                   ,pp->getPoint()[1]
-                                                   ,pp->getPoint()[2]);
+                                                   ,p,pp->getPoint()[0]
+                                                   ,p,pp->getPoint()[1]
+                                                   ,p,pp->getPoint()[2]);
 
                         getMainWindow()->showMessage(QString::fromLatin1(buf));
                     }


### PR DESCRIPTION
The pre-select sub-element string may be clipped depending on the main window size. Currently it is hardcoded to be clipped to half the main window size. This patch increased sub-element display width by increasing MainWindow::showMessage text width and shortening pre-select coordinate information.