### PR TITLE
Fixes #2682

### DIFF
--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -4138,12 +4138,17 @@ void SketchObject::validateExternalLinks(void)
         const App::DocumentObject *Obj=Objects[i];
         const std::string SubElement=SubElements[i];
 
-        const Part::Feature *refObj=static_cast<const Part::Feature*>(Obj);
-        const Part::TopoShape& refShape=refObj->Shape.getShape();
-        
         TopoDS_Shape refSubShape;
         try {
-            refSubShape = refShape.getSubShape(SubElement.c_str());
+            if (Obj->getTypeId().isDerivedFrom(Part::Datum::getClassTypeId())) {
+                const Part::Datum* datum = static_cast<const Part::Datum*>(Obj);
+                refSubShape = datum->getShape();
+            }
+            else {
+                const Part::Feature *refObj=static_cast<const Part::Feature*>(Obj);
+                const Part::TopoShape& refShape=refObj->Shape.getShape();
+                refSubShape = refShape.getSubShape(SubElement.c_str());
+            }
         }
         catch (Standard_Failure) {
             rebuild = true ;
@@ -4185,7 +4190,6 @@ void SketchObject::validateExternalLinks(void)
         rebuildVertexIndex();
         solve(true); // we have to update this sketch and everything depending on it.
     }
-    
 }
 
 void SketchObject::rebuildExternalGeometry(void)


### PR DESCRIPTION
Modifying a check in SketchObject::validateExternalLinks() for datums.
Hopefully will not cause trouble.
There is still a problem where if the check fails, all constraints will
be lost!

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [x] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR once it is merged.

---
