### PR TITLE
PathGui: ViewProviderPath fix and improvements

### DIFF
--- a/src/Mod/Path/Gui/ViewProviderPath.cpp
+++ b/src/Mod/Path/Gui/ViewProviderPath.cpp
@@ -238,7 +238,7 @@ std::string ViewProviderPath::getElement(const SoDetail* detail) const
             const Toolpath &tp = pcPathObj->Path.getValue();
             if(index<(int)tp.getSize()) {
                 std::stringstream str;
-                str << index+1 << " " << tp.getCommand(index).toGCode(3,false);
+                str << index+1 << " " << tp.getCommand(index).toGCode(6,false);
                 pt0Index = line_detail->getPoint0()->getCoordinateIndex();
                 if(pt0Index<0 || pt0Index>=pcLineCoords->point.getNum())
                     pt0Index = -1;

--- a/src/Mod/Path/Gui/ViewProviderPath.cpp
+++ b/src/Mod/Path/Gui/ViewProviderPath.cpp
@@ -195,8 +195,8 @@ void ViewProviderPath::attach(App::DocumentObject *pcObj)
     pcMarkerSwitch->addChild(markersep);
 
     SoSeparator* pcPathRoot = new SoSeparator();
-    pcPathRoot->addChild(linesep);
     pcPathRoot->addChild(pcMarkerSwitch);
+    pcPathRoot->addChild(linesep);
     pcPathRoot->addChild(pcArrowSwitch);
 
     addDisplayMaskMode(pcPathRoot, "Waypoints");

--- a/src/Mod/Path/Gui/ViewProviderPath.cpp
+++ b/src/Mod/Path/Gui/ViewProviderPath.cpp
@@ -34,7 +34,7 @@
 # include <Inventor/nodes/SoCoordinate3.h>
 # include <Inventor/nodes/SoDrawStyle.h>
 # include <Inventor/nodes/SoIndexedLineSet.h>
-# include <Inventor/nodes/SoMarkerSet.h>
+# include <Inventor/nodes/SoPointSet.h>
 # include <Inventor/nodes/SoShapeHints.h>
 # include <Inventor/details/SoLineDetail.h>
 # include <Inventor/nodes/SoSwitch.h>
@@ -90,6 +90,8 @@ ViewProviderPath::ViewProviderPath()
     ADD_PROPERTY_TYPE(NormalColor,(lr,lg,lb),"Path",App::Prop_None,"The color of the feed rate moves");
     ADD_PROPERTY_TYPE(MarkerColor,(mr,mg,mb),"Path",App::Prop_None,"The color of the markers");
     ADD_PROPERTY_TYPE(LineWidth,(lwidth),"Path",App::Prop_None,"The line width of this path");
+    int markerSize = hGrp->GetInt("DefaultPathMarkerSize",4);
+    ADD_PROPERTY_TYPE(MarkerSize,(markerSize),"Path",App::Prop_None,"The point size of the markers");
     ADD_PROPERTY_TYPE(ShowNodes,(false),"Path",App::Prop_None,"Turns the display of nodes on/off");
 
 
@@ -114,6 +116,11 @@ ViewProviderPath::ViewProviderPath()
 
     pcMarkerCoords = new SoCoordinate3();
     pcMarkerCoords->ref();
+
+    pcMarkerStyle = new SoDrawStyle();
+    pcMarkerStyle->ref();
+    pcMarkerStyle->style = SoDrawStyle::POINTS;
+    pcMarkerStyle->pointSize = MarkerSize.getValue();
 
     pcDrawStyle = new SoDrawStyle();
     pcDrawStyle->ref();
@@ -169,6 +176,7 @@ ViewProviderPath::~ViewProviderPath()
     pcMarkerCoords->unref();
     pcMarkerSwitch->unref();
     pcDrawStyle->unref();
+    pcMarkerStyle->unref();
     pcLines->unref();
     pcLineColor->unref();
     pcMatBind->unref();
@@ -190,10 +198,10 @@ void ViewProviderPath::attach(App::DocumentObject *pcObj)
 
     // Draw markers
     SoSeparator* markersep = new SoSeparator;
-    SoMarkerSet* marker = new SoMarkerSet;
-    marker->markerIndex=SoMarkerSet::PLUS_7_7;
+    SoPointSet* marker = new SoPointSet;
     markersep->addChild(pcMarkerColor);
     markersep->addChild(pcMarkerCoords);
+    markersep->addChild(pcMarkerStyle);
     markersep->addChild(marker);
     pcMarkerSwitch->addChild(markersep);
 
@@ -288,6 +296,8 @@ void ViewProviderPath::onChanged(const App::Property* prop)
 
     if (prop == &LineWidth) {
         pcDrawStyle->lineWidth = LineWidth.getValue();
+    } else if (prop == &MarkerSize) {
+        pcMarkerStyle->pointSize = MarkerSize.getValue();
     } else if (prop == &NormalColor) {
         if (colorindex.size() > 0 && coordStart>=0 && coordStart<(int)colorindex.size()) {
             const App::Color& c = NormalColor.getValue();

--- a/src/Mod/Path/Gui/ViewProviderPath.cpp
+++ b/src/Mod/Path/Gui/ViewProviderPath.cpp
@@ -158,6 +158,9 @@ ViewProviderPath::ViewProviderPath()
 
     NormalColor.touch();
     MarkerColor.touch();
+
+    DisplayMode.setStatus(App::Property::Status::Hidden, true);
+    SelectionStyle.setValue(1);
 }
 
 ViewProviderPath::~ViewProviderPath()
@@ -634,7 +637,7 @@ void ViewProviderPath::recomputeBoundingBox()
     Path::Feature* pcPathObj = static_cast<Path::Feature*>(pcObject);
     Base::Placement pl = *(&pcPathObj->Placement.getValue());
     Base::Vector3d pt;
-    for (int i=0;i<pcLineCoords->point.getNum();i++) {
+    for (int i=1;i<pcLineCoords->point.getNum();i++) {
         pt.x = pcLineCoords->point[i].getValue()[0];
         pt.y = pcLineCoords->point[i].getValue()[1];
         pt.z = pcLineCoords->point[i].getValue()[2];

--- a/src/Mod/Path/Gui/ViewProviderPath.cpp
+++ b/src/Mod/Path/Gui/ViewProviderPath.cpp
@@ -258,20 +258,25 @@ SoDetail* ViewProviderPath::getDetail(const char* subelement) const
 }
 
 void ViewProviderPath::onSelectionChanged(const Gui::SelectionChanges& msg) {
-    if(msg.Type == Gui::SelectionChanges::SetPreselect &&
-       msg.pSubName && pt0Index >= 0 &&
-       strcmp(msg.pDocName,getObject()->getDocument()->getName())==0 &&
-       strcmp(msg.pObjectName,getObject()->getNameInDocument())==0)
-    {
-        Path::Feature* pcPathObj = static_cast<Path::Feature*>(pcObject);
-        Base::Vector3d pt = pcPathObj->Placement.getValue().inverse().toMatrix()*
-                                Base::Vector3d(msg.x,msg.y,msg.z);
-        const SbVec3f &ptTo = *pcLineCoords->point.getValues(pt0Index);
-        SbVec3f ptFrom(pt.x,pt.y,pt.z);
-        if(ptFrom != ptTo) {
-            pcArrowTransform->pointAt(ptFrom,ptTo);
-            pcArrowSwitch->whichChild = 0;
-            return;
+    if(msg.Type == Gui::SelectionChanges::SetPreselect && msg.pSubName && 
+       pt0Index >= 0 && getObject() && getObject()->getDocument())
+    { 
+        const char *docName = getObject()->getDocument()->getName();
+        const char *objName = getObject()->getNameInDocument();
+        if(docName && objName && 
+           strcmp(msg.pDocName,docName)==0 &&
+           strcmp(msg.pObjectName,objName)==0)
+        {
+            Path::Feature* pcPathObj = static_cast<Path::Feature*>(pcObject);
+            Base::Vector3d pt = pcPathObj->Placement.getValue().inverse().toMatrix()*
+                                    Base::Vector3d(msg.x,msg.y,msg.z);
+            const SbVec3f &ptTo = *pcLineCoords->point.getValues(pt0Index);
+            SbVec3f ptFrom(pt.x,pt.y,pt.z);
+            if(ptFrom != ptTo) {
+                pcArrowTransform->pointAt(ptFrom,ptTo);
+                pcArrowSwitch->whichChild = 0;
+                return;
+            }
         }
     }
     pcArrowSwitch->whichChild = -1;

--- a/src/Mod/Path/Gui/ViewProviderPath.h
+++ b/src/Mod/Path/Gui/ViewProviderPath.h
@@ -58,6 +58,7 @@ public:
     App::PropertyInteger LineWidth;
     App::PropertyColor   NormalColor;
     App::PropertyColor   MarkerColor;
+    App::PropertyInteger MarkerSize;
     App::PropertyBool    ShowNodes;
     App::PropertyVector  StartPosition;
 
@@ -89,6 +90,7 @@ protected:
     SoCoordinate3         * pcLineCoords;
     SoCoordinate3         * pcMarkerCoords;
     SoDrawStyle           * pcDrawStyle;
+    SoDrawStyle           * pcMarkerStyle;
     PartGui::SoBrepEdgeSet         * pcLines;
     SoMaterial            * pcLineColor;
     SoBaseColor           * pcMarkerColor;


### PR DESCRIPTION
- Selection style default to bounding box
- Fixed potential crash when Path object is deleted
- Speed up marker display by replacing SoMarkerSet with SoPointSet