### PR TITLE
Gui: do not round pre-select coord display

### DIFF
--- a/src/Gui/SoFCUnifiedSelection.cpp
+++ b/src/Gui/SoFCUnifiedSelection.cpp
@@ -67,7 +67,6 @@
 #include <QtOpenGL.h>
 
 #include <Base/Console.h>
-#include <Base/UnitsApi.h>
 #include <App/Application.h>
 #include <App/Document.h>
 #include <Gui/Document.h>
@@ -371,13 +370,12 @@ SoFCUnifiedSelection::handleEvent(SoHandleEventAction * action)
 
                 this->preSelection = 1;
                 static char buf[513];
-                int p = Base::UnitsApi::getDecimals();
-                snprintf(buf,512,"Preselected: %s.%s.%s (%.*g,%.*g,%.*g)",documentName.c_str()
+                snprintf(buf,512,"Preselected: %s.%s.%s (%g, %g, %g)",documentName.c_str()
                                            ,objectName.c_str()
                                            ,subElementName.c_str()
-                                           ,p,pp->getPoint()[0]
-                                           ,p,pp->getPoint()[1]
-                                           ,p,pp->getPoint()[2]);
+                                           ,pp->getPoint()[0]
+                                           ,pp->getPoint()[1]
+                                           ,pp->getPoint()[2]);
 
                 getMainWindow()->showMessage(QString::fromLatin1(buf));
 
@@ -474,13 +472,12 @@ SoFCUnifiedSelection::handleEvent(SoHandleEventAction * action)
                         if (ok)
                             type = SoSelectionElementAction::Append;
                         if (mymode == OFF) {
-                            int p = Base::UnitsApi::getDecimals();
-                            snprintf(buf,512,"Selected: %s.%s.%s (%.*g,%.*g,%.*g)",documentName.c_str()
+                            snprintf(buf,512,"Selected: %s.%s.%s (%g, %g, %g)",documentName.c_str()
                                                        ,objectName.c_str()
                                                        ,subElementName.c_str()
-                                                       ,p,pp->getPoint()[0]
-                                                       ,p,pp->getPoint()[1]
-                                                       ,p,pp->getPoint()[2]);
+                                                       ,pp->getPoint()[0]
+                                                       ,pp->getPoint()[1]
+                                                       ,pp->getPoint()[2]);
 
                             getMainWindow()->showMessage(QString::fromLatin1(buf));
                         }
@@ -513,13 +510,12 @@ SoFCUnifiedSelection::handleEvent(SoHandleEventAction * action)
                     }
 
                     if (mymode == OFF) {
-                        int p = Base::UnitsApi::getDecimals();
-                        snprintf(buf,512,"Selected: %s.%s.%s (%.*g,%.*g,%.*g)",documentName.c_str()
+                        snprintf(buf,512,"Selected: %s.%s.%s (%g, %g, %g)",documentName.c_str()
                                                    ,objectName.c_str()
                                                    ,subElementName.c_str()
-                                                   ,p,pp->getPoint()[0]
-                                                   ,p,pp->getPoint()[1]
-                                                   ,p,pp->getPoint()[2]);
+                                                   ,pp->getPoint()[0]
+                                                   ,pp->getPoint()[1]
+                                                   ,pp->getPoint()[2]);
 
                         getMainWindow()->showMessage(QString::fromLatin1(buf));
                     }


### PR DESCRIPTION
In a recent patch I submit (f852e6b789feb295b7ac8ff5a29d8466fca7929d), the coordinate of pre-selection is rounded to user set decimals, which I now find may cause problem. Because the user set decimals is usually short, and thus the displayed coordinate may differ quite lot to the actual one. Besides, now the preselect display area is widen, there is room to spare. So I simply changed to just use %g. 