### PR TITLE
Remove warnings about Qt4 + OpenGL + MacOS issues

### DIFF
--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -469,57 +469,11 @@ void MainWindow::arrangeIcons()
 void MainWindow::tile()
 {
     d->mdiArea->tileSubWindows();
-
-// Warn about limitation in Qt4.8 involving multiple OpenGL widgets with Cocoa.
-#if defined(__APPLE__)
-    ParameterGrp::handle hGrp = App::GetApplication().GetUserParameter().
-        GetGroup("BaseApp")->GetGroup("Preferences")->GetGroup("MainWindow");
-
-    if(hGrp->GetBool("ShowAppleMdiWarning", true)) {
-        QMessageBox mb(this);
-        mb.setIcon(QMessageBox::Warning);
-        mb.setTextFormat(Qt::RichText);
-        mb.setText(tr("There is a rendering issue on MacOS."));
-        mb.setInformativeText(tr("See <a href=\"http://www.freecadweb.org/wiki/OpenGL_on_MacOS\"> the wiki</a> for more information"));
-
-        QAbstractButton *suppressBtn;
-        suppressBtn = mb.addButton(tr("Don't show again"), QMessageBox::DestructiveRole);
-        mb.addButton(QMessageBox::Ok);
-
-        mb.exec();
-        if(mb.clickedButton() == suppressBtn) {
-            hGrp->SetBool("ShowAppleMdiWarning", false);
-        }
-    }
-#endif // defined(__APPLE__)
 }
 
 void MainWindow::cascade()
 {
     d->mdiArea->cascadeSubWindows();
-
-// See above in MainWindow::tile()
-#if defined(__APPLE__)
-    ParameterGrp::handle hGrp = App::GetApplication().GetUserParameter().
-        GetGroup("BaseApp")->GetGroup("Preferences")->GetGroup("MainWindow");
-
-    if(hGrp->GetBool("ShowAppleMdiWarning", true)) {
-        QMessageBox mb(this);
-        mb.setIcon(QMessageBox::Warning);
-        mb.setTextFormat(Qt::RichText);
-        mb.setText(tr("There is a rendering issue on MacOS."));
-        mb.setInformativeText(tr("See <a href=\"http://www.freecadweb.org/wiki/OpenGL_on_MacOS\"> the wiki</a> for more information"));
-
-        QAbstractButton *suppressBtn;
-        suppressBtn = mb.addButton(tr("Don't show again"), QMessageBox::DestructiveRole);
-        mb.addButton(QMessageBox::Ok);
-
-        mb.exec();
-        if(mb.clickedButton() == suppressBtn) {
-            hGrp->SetBool("ShowAppleMdiWarning", false);
-        }
-    }
-#endif // defined(__APPLE__)
 }
 
 void MainWindow::closeActiveWindow ()


### PR DESCRIPTION
Now that Issue #1401 is resolved, remove the popup warning in the GUI.

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [already closed] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists
