### PR TITLE
Fix preferences Python console bug

### DIFF
--- a/src/Gui/DlgGeneralImp.cpp
+++ b/src/Gui/DlgGeneralImp.cpp
@@ -128,8 +128,9 @@ void DlgGeneralImp::saveSettings()
     RecentFiles->onSave();
     SplashScreen->onSave();
     PythonWordWrap->onSave();
-
-    PythonConsole* pcPython = new PythonConsole(this);
+  
+    QWidget* pc = DockWindowManager::instance()->getDockWindow("Python console");
+    PythonConsole *pcPython = static_cast<PythonConsole*>(pc);
     bool pythonWordWrap = App::GetApplication().GetUserParameter().
         GetGroup("BaseApp")->GetGroup("Preferences")->GetGroup("General")->GetBool("PythonWordWrap", true);
 


### PR DESCRIPTION
This fixes a bug introduced by https://github.com/FreeCAD/FreeCAD/commit/f2467d70445aca19043d4dcba701badc18043f71

To reproduce, Edit > Preferences. Click a "General" tab besides "General" > "General", e.g. "General" > "Editor". Click "Apply". Tab back to "General" > "General". A small Python console will be present in the top left.