### PR TITLE
Gui: Gesture: fix for conda

### DIFF
--- a/src/Gui/WinNativeGestureRecognizers.cpp
+++ b/src/Gui/WinNativeGestureRecognizers.cpp
@@ -40,12 +40,47 @@
 
 
 #include <qgesture.h>
-#include <private/qevent_p.h>
+
 #include <Base/Exception.h>
 
 QT_BEGIN_NAMESPACE
 
 #if !defined(QT_NO_NATIVE_GESTURES)
+
+//#include <private/qevent_p.h>
+//this include is not avalable on conda Qt, see https://forum.freecadweb.org/viewtopic.php?f=4&t=21405&p=167395#p167395
+//copy-pasted from this header:
+class QNativeGestureEvent : public QEvent
+{
+public:
+    enum Type {
+        None,
+        GestureBegin,
+        GestureEnd,
+        Pan,
+        Zoom,
+        Rotate,
+        Swipe
+    };
+
+    QNativeGestureEvent()
+        : QEvent(QEvent::NativeGesture), gestureType(None), percentage(0)
+#ifdef Q_WS_WIN
+        , sequenceId(0), argument(0)
+#endif
+    {
+    }
+
+    Type gestureType;
+    float percentage;
+    QPoint position;
+    float angle;
+#ifdef Q_WS_WIN
+    ulong sequenceId;
+    quint64 argument;
+#endif
+};
+
 
 QGesture* WinNativeGestureRecognizerPinch::create(QObject* target)
 {


### PR DESCRIPTION
@peterl94 said anaconda's Qt doesn't offer private headers. The
definitions used have almost no code associated with them, I simply
copied them to the cpp file.

See thread "ana(conda) windows packaging", starting from this post:
https://forum.freecadweb.org/viewtopic.php?f=4&t=21405&start=70#p167370
