### PR TITLE
Fix building with GCC and Qt5

### DIFF
--- a/src/Mod/Path/App/CMakeLists.txt
+++ b/src/Mod/Path/App/CMakeLists.txt
@@ -2,6 +2,9 @@ if(MSVC)
     add_definitions(-DHAVE_ACOSH -DHAVE_ASINH -DHAVE_ATANH)
 else(MSVC)
     add_definitions(-DHAVE_LIMITS_H -DHAVE_CONFIG_H)
+    if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+        add_definitions(-fext-numeric-literals) #fix for gcc and qt5
+    endif()
 endif(MSVC)
 
 


### PR DESCRIPTION
Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [x] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR once it is merged.

---
Hi.
This fixes:
```
error: unable to find numeric literal operator ‘operator""Q’
```

error while building with GCC and Qt5.

Cheers,
Mateusz