### PR TITLE
path: Correct feedrate unit in linuxcnc post processor

### DIFF
--- a/src/Mod/Path/PathScripts/PathProfile.py
+++ b/src/Mod/Path/PathScripts/PathProfile.py
@@ -241,7 +241,7 @@ print "y - " + str(point.y)
 
         output += "(" + obj.Label + ")"
         if obj.UseComp:
-            output += "(Compensated Tool Path. Diameter: " + str(self.radius * 2) + ")"
+            output += "(Compensated Tool Path. Diameter: " + str(tool.Diameter) + ")"
         else:
             output += "(Uncompensated Tool Path)"
 

--- a/src/Mod/Path/PathScripts/PathProfile.py
+++ b/src/Mod/Path/PathScripts/PathProfile.py
@@ -241,7 +241,7 @@ print "y - " + str(point.y)
 
         output += "(" + obj.Label + ")"
         if obj.UseComp:
-            output += "(Compensated Tool Path. Diameter: " + str(tool.Diameter) + ")"
+            output += "(Compensated Tool Path. Diameter: " + str(self.radius * 2) + ")"
         else:
             output += "(Uncompensated Tool Path)"
 

--- a/src/Mod/Path/PathScripts/linuxcnc_post.py
+++ b/src/Mod/Path/PathScripts/linuxcnc_post.py
@@ -61,7 +61,7 @@ LINENR = 100  # line number starting value
 
 # These globals will be reflected in the Machine configuration of the project
 UNITS = "G21"  # G21 for metric, G20 for us standard
-UNIT_FORMAT = 'in/min'
+UNIT_FORMAT = 'mm/s'
 MACHINE_NAME = "LinuxCNC"
 CORNER_MIN = {'x': 0, 'y': 0, 'z': 0}
 CORNER_MAX = {'x': 500, 'y': 300, 'z': 300}


### PR DESCRIPTION
Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [OK ] Branch rebased on latest master `git pull --rebase upstream master`
- [ N/A] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ OK] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ N/A] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR once it is merged.

---
The unit format is wrong for linuxcnc post processor, thanks to dlhenke who gave the solution on freecad forum.