### PR TITLE
Make linuxcnc_post use the job unit system and output <unit>/min

### DIFF
--- a/src/Mod/Path/PathScripts/linuxcnc_post.py
+++ b/src/Mod/Path/PathScripts/linuxcnc_post.py
@@ -44,6 +44,7 @@ import FreeCAD
 from FreeCAD import Units
 import datetime
 from PathScripts import PostUtils
+from PathScripts import PathUtils
 
 now = datetime.datetime.now()
 
@@ -61,7 +62,7 @@ LINENR = 100  # line number starting value
 
 # These globals will be reflected in the Machine configuration of the project
 UNITS = "G21"  # G21 for metric, G20 for us standard
-UNIT_FORMAT = 'in/min'
+UNIT_FORMAT = 'mm/min'
 MACHINE_NAME = "LinuxCNC"
 CORNER_MIN = {'x': 0, 'y': 0, 'z': 0}
 CORNER_MAX = {'x': 500, 'y': 300, 'z': 300}
@@ -118,6 +119,8 @@ def processArguments(argstring):
 def export(objectslist, filename, argstring):
     processArguments(argstring)
     global UNITS
+    global UNIT_FORMAT
+
     for obj in objectslist:
         if not hasattr(obj, "Path"):
             print("the object " + obj.Name + " is not a path. Please select only path and Compounds.")
@@ -131,13 +134,18 @@ def export(objectslist, filename, argstring):
     # sure we're using the current values in the Machine Def.
     myMachine = None
     for pathobj in objectslist:
-        if hasattr(pathobj,"MachineName"):
-            myMachine = pathobj.MachineName
-        if hasattr(pathobj, "MachineUnits"):
-            if pathobj.MachineUnits == "Metric":
+        job = PathUtils.findParentJob(pathobj)
+
+        if hasattr(job,"MachineName"):
+            myMachine = job.MachineName
+        if hasattr(job, "MachineUnits"):
+            if job.MachineUnits == "Metric":
                UNITS = "G21"
+               UNIT_FORMAT = 'mm/min'
             else:
                UNITS = "G20"
+               UNIT_FORMAT = 'in/min'
+
     if myMachine is None:
         print("No machine found in this selection")
 

--- a/src/Mod/Path/PathScripts/linuxcnc_post.py
+++ b/src/Mod/Path/PathScripts/linuxcnc_post.py
@@ -129,26 +129,6 @@ def export(objectslist, filename, argstring):
     print("postprocessing...")
     gcode = ""
 
-    # Find the machine.
-    # The user my have overridden post processor defaults in the GUI.  Make
-    # sure we're using the current values in the Machine Def.
-    myMachine = None
-    for pathobj in objectslist:
-        job = PathUtils.findParentJob(pathobj)
-
-        if hasattr(job,"MachineName"):
-            myMachine = job.MachineName
-        if hasattr(job, "MachineUnits"):
-            if job.MachineUnits == "Metric":
-               UNITS = "G21"
-               UNIT_FORMAT = 'mm/min'
-            else:
-               UNITS = "G20"
-               UNIT_FORMAT = 'in/min'
-
-    if myMachine is None:
-        print("No machine found in this selection")
-
     # write header
     if OUTPUT_HEADER:
         gcode += linenumber() + "(Exported by FreeCAD)\n"
@@ -164,9 +144,26 @@ def export(objectslist, filename, argstring):
 
     for obj in objectslist:
 
+        # fetch machine details
+        job = PathUtils.findParentJob(obj)
+
+        myMachine = 'not set'
+
+        if hasattr(job,"MachineName"):
+            myMachine = job.MachineName
+
+        if hasattr(job, "MachineUnits"):
+            if job.MachineUnits == "Metric":
+               UNITS = "G21"
+               UNIT_FORMAT = 'mm/min'
+            else:
+               UNITS = "G20"
+               UNIT_FORMAT = 'in/min'
+
         # do the pre_op
         if OUTPUT_COMMENTS:
-            gcode += linenumber() + "(begin operation: " + obj.Label + ")\n"
+            gcode += linenumber() + "(begin operation: %s)\n" % obj.Label
+            gcode += linenumber() + "(machine: %s, %s)\n" % (myMachine, UNIT_FORMAT)
         for line in PRE_OPERATION.splitlines(True):
             gcode += linenumber() + line
 
@@ -174,7 +171,7 @@ def export(objectslist, filename, argstring):
 
         # do the post_op
         if OUTPUT_COMMENTS:
-            gcode += linenumber() + "(finish operation: " + obj.Label + ")\n"
+            gcode += linenumber() + "(finish operation: %s)\n" % obj.Label
         for line in POST_OPERATION.splitlines(True):
             gcode += linenumber() + line
 


### PR DESCRIPTION
Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [OK] Branch rebased on latest master `git pull --rebase upstream master`
- [N/A] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [OK] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [N/A] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR once it is merged.

---
The linuxcnc post-processor outputs wrong speeds due to hardcoded `in/min` unit sistem; this PR makes it use the job unit system and output `unit/min`, since most (all?) machines expect it