### PR TITLE
20170402 path add geom tolerance

### DIFF
--- a/src/Mod/Path/Gui/Resources/preferences/PathJob.ui
+++ b/src/Mod/Path/Gui/Resources/preferences/PathJob.ui
@@ -7,19 +7,13 @@
     <x>0</x>
     <y>0</y>
     <width>503</width>
-    <height>526</height>
+    <height>557</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Job Preferences</string>
   </property>
   <layout class="QVBoxLayout">
-   <property name="spacing">
-    <number>6</number>
-   </property>
-   <property name="margin">
-    <number>9</number>
-   </property>
    <item>
     <widget class="QGroupBox" name="groupBox_2">
      <property name="sizePolicy">
@@ -199,6 +193,35 @@
         <property name="prefPath" stdset="0">
          <cstring>Mod/Path</cstring>
         </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="groupBox_3">
+     <property name="title">
+      <string>Geometry</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout">
+      <item row="0" column="0">
+       <widget class="QWidget" name="widget_5" native="true">
+        <layout class="QHBoxLayout" name="horizontalLayout">
+         <item>
+          <widget class="QLabel" name="label_6">
+           <property name="text">
+            <string>Default Geometry Tolerance</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="Gui::InputField" name="geometryTolerance">
+           <property name="toolTip">
+            <string>Default value for new Jobs, used for computing Paths.  Smaller increases accuracy, but slows down computation</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
        </widget>
       </item>
      </layout>

--- a/src/Mod/Path/PathScripts/PathJob.py
+++ b/src/Mod/Path/PathScripts/PathJob.py
@@ -72,6 +72,10 @@ class ObjectPathJob:
         obj.addProperty("App::PropertyEnumeration", "MachineUnits", "Output", QtCore.QT_TRANSLATE_NOOP("App::Property","Units that the machine works in, ie Metric or Inch"))
         obj.MachineUnits = ['Metric', 'Inch']
 
+        obj.addProperty("App::PropertyDistance", "GeometryTolerance", "Geometry",
+                QtCore.QT_TRANSLATE_NOOP("App::Property", "For computing Paths; smaller increases accuracy, but slows down computation"))
+        obj.GeometryTolerance = PathPreferences.defaultGeometryTolerance()
+
         obj.addProperty("App::PropertyDistance", "X_Max", "Limits", QtCore.QT_TRANSLATE_NOOP("App::Property","The Maximum distance in X the machine can travel"))
         obj.addProperty("App::PropertyDistance", "Y_Max", "Limits", QtCore.QT_TRANSLATE_NOOP("App::Property","The Maximum distance in X the machine can travel"))
         obj.addProperty("App::PropertyDistance", "Z_Max", "Limits", QtCore.QT_TRANSLATE_NOOP("App::Property","The Maximum distance in X the machine can travel"))

--- a/src/Mod/Path/PathScripts/PathPreferences.py
+++ b/src/Mod/Path/PathScripts/PathPreferences.py
@@ -30,6 +30,8 @@ class PathPreferences:
     PostProcessorDefault     = "PostProcessorDefault"
     PostProcessorDefaultArgs = "PostProcessorDefaultArgs"
     PostProcessorBlacklist   = "PostProcessorBlacklist"
+    # Linear tolerance to use when generating Paths, eg when tesselating geometry
+    GeometryTolerance  = "GeometryTolerance"
 
     @classmethod
     def preferences(cls):
@@ -71,6 +73,10 @@ class PathPreferences:
         return pref.GetString(cls.PostProcessorDefaultArgs, "")
 
     @classmethod
+    def defaultGeometryTolerance(cls):
+        return cls.preferences().GetFloat(cls.GeometryTolerance, 0.01)
+
+    @classmethod
     def postProcessorBlacklist(cls):
         pref = cls.preferences()
         blacklist = pref.GetString(cls.PostProcessorBlacklist, "")
@@ -79,11 +85,12 @@ class PathPreferences:
         return eval(blacklist)
 
     @classmethod
-    def savePostProcessorDefaults(cls, processor, args, blacklist):
+    def savePostProcessorDefaults(cls, processor, args, blacklist, geometryTolerance):
         pref = cls.preferences()
         pref.SetString(cls.PostProcessorDefault, processor)
         pref.SetString(cls.PostProcessorDefaultArgs, args)
         pref.SetString(cls.PostProcessorBlacklist, "%s" % (blacklist))
+        pref.SetFloat(cls.GeometryTolerance, geometryTolerance)
 
 
     DefaultOutputFile = "DefaultOutputFile"

--- a/src/Mod/Path/PathScripts/PathPreferencesPathJob.py
+++ b/src/Mod/Path/PathScripts/PathPreferencesPathJob.py
@@ -24,6 +24,7 @@
 
 import FreeCAD
 import FreeCADGui
+from FreeCAD import Units
 from PySide import QtCore, QtGui
 from PathScripts.PathPreferences import PathPreferences
 from PathScripts.PathPostProcessor import PostProcessor
@@ -45,7 +46,8 @@ class JobPreferencesPage:
             item = self.form.postProcessorList.item(i)
             if item.checkState() == QtCore.Qt.CheckState.Unchecked:
                 blacklist.append(item.text())
-        PathPreferences.savePostProcessorDefaults(processor, args, blacklist)
+        geometryTolerance = Units.Quantity(self.form.geometryTolerance.text())
+        PathPreferences.savePostProcessorDefaults(processor, args, blacklist, geometryTolerance)
 
         path = str(self.form.leOutputFile.text())
         policy = str(self.form.cboOutputPolicy.currentText())
@@ -92,6 +94,10 @@ class JobPreferencesPage:
         self.verifyAndUpdateDefaultPostProcessorWith(PathPreferences.defaultPostProcessor())
 
         self.form.defaultPostProcessorArgs.setText(PathPreferences.defaultPostProcessorArgs())
+
+        geomTol = Units.Quantity(PathPreferences.defaultGeometryTolerance(), Units.Length)
+        self.form.geometryTolerance.setText(geomTol.UserString)
+
         self.form.leOutputFile.setText(PathPreferences.defaultOutputFile())
         self.selectComboEntry(self.form.cboOutputPolicy, PathPreferences.defaultOutputPolicy())
 

--- a/src/Mod/Path/PathScripts/PathSurface.py
+++ b/src/Mod/Path/PathScripts/PathSurface.py
@@ -306,8 +306,15 @@ class ObjectSurface:
             mesh = mesh.Mesh
             bb = mesh.BoundBox
         else:
-            bb = mesh.Shape.BoundBox
+            # try/except is for Path Jobs created before GeometryTolerance
+            try:
+                deflection = parentJob.GeometryTolerance
+            except AttributeError:
+                from PathScripts.PathPreferences import PathPreferences
+                deflection = PathPreferences.defaultGeometryTolerance()
+
             mesh = MeshPart.meshFromShape(mesh.Shape, MaxLength=2)
+            bb = mesh.Shape.BoundBox
 
         s = ocl.STLSurf()
         for f in mesh.Facets:

--- a/src/Mod/Path/PathScripts/PathSurface.py
+++ b/src/Mod/Path/PathScripts/PathSurface.py
@@ -304,7 +304,6 @@ class ObjectSurface:
 
         if mesh.TypeId.startswith('Mesh'):
             mesh = mesh.Mesh
-            bb = mesh.BoundBox
         else:
             # try/except is for Path Jobs created before GeometryTolerance
             try:
@@ -313,8 +312,9 @@ class ObjectSurface:
                 from PathScripts.PathPreferences import PathPreferences
                 deflection = PathPreferences.defaultGeometryTolerance()
 
-            mesh = MeshPart.meshFromShape(mesh.Shape, MaxLength=2)
-            bb = mesh.Shape.BoundBox
+            mesh = MeshPart.meshFromShape(mesh.Shape, Deflection = deflection)
+
+        bb = mesh.BoundBox
 
         s = ocl.STLSurf()
         for f in mesh.Facets:


### PR DESCRIPTION
This adds a parameter to Path Job objects for the geometry tolerance, and uses it in the surfacing operations.  The main benefit of this approach is a significant speedup for similar accuracy.

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [nothing new broken] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [n/a] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR once it is merged.

---

