### PR TITLE
PartDesign: Add Body for new sketch/primitive when appropriate

### DIFF
--- a/src/Mod/PartDesign/Gui/CommandPrimitive.cpp
+++ b/src/Mod/PartDesign/Gui/CommandPrimitive.cpp
@@ -46,6 +46,21 @@ using namespace std;
 
 DEF_STD_CMD_ACL(CmdPrimtiveCompAdditive);
 
+static const char * primitiveIntToName(int id)
+{
+    switch(id) {
+        case 0:  return "Box";
+        case 1:  return "Cylinder";
+        case 2:  return "Sphere";
+        case 3:  return "Cone";
+        case 4:  return "Ellipsoid";
+        case 5:  return "Torus";
+        case 6:  return "Prism";
+        case 7:  return "Wedge";
+        default: return nullptr;
+    };
+};
+
 CmdPrimtiveCompAdditive::CmdPrimtiveCompAdditive()
   : Command("PartDesign_CompPrimitiveAdditive")
 {
@@ -72,72 +87,14 @@ void CmdPrimtiveCompAdditive::activated(int iMsg)
     Gui::ActionGroup* pcAction = qobject_cast<Gui::ActionGroup*>(_pcAction);
     pcAction->setIcon(pcAction->actions().at(iMsg)->icon());
 
-    std::string FeatName;
-    if(iMsg == 0) {
+    auto shapeType( primitiveIntToName(iMsg) );
+    auto FeatName( getUniqueObjectName(shapeType) );
 
-        FeatName = getUniqueObjectName("Box");
-
-        Gui::Command::openCommand("Make additive box");
-        Gui::Command::doCommand(Gui::Command::Doc,"App.ActiveDocument.addObject(\'PartDesign::AdditiveBox\',\'%s\')",
-            FeatName.c_str());
-    }
-    else if(iMsg == 1) {
-
-        FeatName = getUniqueObjectName("Cylinder");
-
-        Gui::Command::openCommand("Make additive cylinder");
-        Gui::Command::doCommand(Gui::Command::Doc,"App.ActiveDocument.addObject(\'PartDesign::AdditiveCylinder\',\'%s\')",
-            FeatName.c_str());
-    }
-    else if(iMsg == 2) {
-
-        FeatName = getUniqueObjectName("Sphere");
-
-        Gui::Command::openCommand("Make additive sphere");
-        Gui::Command::doCommand(Gui::Command::Doc,"App.ActiveDocument.addObject(\'PartDesign::AdditiveSphere\',\'%s\')",
-            FeatName.c_str());
-    }
-    else if(iMsg == 3) {
-
-        FeatName = getUniqueObjectName("Cone");
-
-        Gui::Command::openCommand("Make additive cone");
-        Gui::Command::doCommand(Gui::Command::Doc,"App.ActiveDocument.addObject(\'PartDesign::AdditiveCone\',\'%s\')",
-            FeatName.c_str());
-    }
-    else if(iMsg == 4) {
-
-        FeatName = getUniqueObjectName("Ellipsoid");
-
-        Gui::Command::openCommand("Make additive ellipsoid");
-        Gui::Command::doCommand(Gui::Command::Doc,"App.ActiveDocument.addObject(\'PartDesign::AdditiveEllipsoid\',\'%s\')",
-            FeatName.c_str());
-    }
-    else if(iMsg == 5) {
-
-        FeatName = getUniqueObjectName("Torus");
-
-        Gui::Command::openCommand("Make additive torus");
-        Gui::Command::doCommand(Gui::Command::Doc,"App.ActiveDocument.addObject(\'PartDesign::AdditiveTorus\',\'%s\')",
-            FeatName.c_str());
-    }
-    else if(iMsg == 6) {
-
-        FeatName = getUniqueObjectName("Prism");
-
-        Gui::Command::openCommand("Make additive prism");
-        Gui::Command::doCommand(Gui::Command::Doc,"App.ActiveDocument.addObject(\'PartDesign::AdditivePrism\',\'%s\')",
-            FeatName.c_str());
-    }
-    else if(iMsg == 7) {
-
-        FeatName = getUniqueObjectName("Wedge");
-
-        Gui::Command::openCommand("Make additive wedge");
-        Gui::Command::doCommand(Gui::Command::Doc,"App.ActiveDocument.addObject(\'PartDesign::AdditiveWedge\',\'%s\')",
-            FeatName.c_str());
-    }
-
+    Gui::Command::openCommand( (std::string("Make additive ") + shapeType).c_str() );
+    Gui::Command::doCommand(
+            Gui::Command::Doc,
+            "App.ActiveDocument.addObject(\'PartDesign::Additive%s\',\'%s\')",
+            shapeType, FeatName.c_str() );
 
     Gui::Command::doCommand(Doc,"App.ActiveDocument.%s.addObject(App.activeDocument().%s)"
                     ,pcActiveBody->getNameInDocument(), FeatName.c_str());
@@ -268,77 +225,20 @@ void CmdPrimtiveCompSubtractive::activated(int iMsg)
             return;
     }
 
-    std::string FeatName;
-    if(iMsg == 0) {
+    auto shapeType( primitiveIntToName(iMsg) );
+    auto FeatName( getUniqueObjectName(shapeType) );
 
-        FeatName = getUniqueObjectName("Box");
-
-        Gui::Command::openCommand("Make subtractive box");
-        Gui::Command::doCommand(Gui::Command::Doc,"App.ActiveDocument.addObject(\'PartDesign::SubtractiveBox\',\'%s\')",
-            FeatName.c_str());
-    }
-    else if(iMsg == 1) {
-
-        FeatName = getUniqueObjectName("Cylinder");
-
-        Gui::Command::openCommand("Make subtractive cylinder");
-        Gui::Command::doCommand(Gui::Command::Doc,"App.ActiveDocument.addObject(\'PartDesign::SubtractiveCylinder\',\'%s\')",
-            FeatName.c_str());
-    }
-    else if(iMsg == 2) {
-
-        FeatName = getUniqueObjectName("Sphere");
-
-        Gui::Command::openCommand("Make subtractive sphere");
-        Gui::Command::doCommand(Gui::Command::Doc,"App.ActiveDocument.addObject(\'PartDesign::SubtractiveSphere\',\'%s\')",
-            FeatName.c_str());
-    }
-    else if(iMsg == 3) {
-
-        FeatName = getUniqueObjectName("Cone");
-
-        Gui::Command::openCommand("Make subtractive cone");
-        Gui::Command::doCommand(Gui::Command::Doc,"App.ActiveDocument.addObject(\'PartDesign::SubtractiveCone\',\'%s\')",
-            FeatName.c_str());
-    }
-    else if(iMsg == 4) {
-
-        FeatName = getUniqueObjectName("Ellipsoid");
-
-        Gui::Command::openCommand("Make subtractive ellipsoid");
-        Gui::Command::doCommand(Gui::Command::Doc,"App.ActiveDocument.addObject(\'PartDesign::SubtractiveEllipsoid\',\'%s\')",
-            FeatName.c_str());
-    }
-    else if(iMsg == 5) {
-
-        FeatName = getUniqueObjectName("Torus");
-
-        Gui::Command::openCommand("Make subtractive torus");
-        Gui::Command::doCommand(Gui::Command::Doc,"App.ActiveDocument.addObject(\'PartDesign::SubtractiveTorus\',\'%s\')",
-            FeatName.c_str());
-    }
-    else if(iMsg == 6) {
-
-        FeatName = getUniqueObjectName("Prism");
-
-        Gui::Command::openCommand("Make subtractive prism");
-        Gui::Command::doCommand(Gui::Command::Doc,"App.ActiveDocument.addObject(\'PartDesign::SubtractivePrism\',\'%s\')",
-            FeatName.c_str());
-    }
-    else if(iMsg == 7) {
-
-        FeatName = getUniqueObjectName("Wedge");
-
-        Gui::Command::openCommand("Make subtractive wedge");
-        Gui::Command::doCommand(Gui::Command::Doc,"App.ActiveDocument.addObject(\'PartDesign::SubtractiveWedge\',\'%s\')",
-            FeatName.c_str());
-    }
+    Gui::Command::openCommand( (std::string("Make subtractive ") + shapeType).c_str() );
+    Gui::Command::doCommand(
+            Gui::Command::Doc,
+            "App.ActiveDocument.addObject(\'PartDesign::Subtractive%s\',\'%s\')",
+            shapeType, FeatName.c_str() );
 
     Gui::Command::doCommand(Doc,"App.ActiveDocument.%s.addObject(App.activeDocument().%s)"
                     ,pcActiveBody->getNameInDocument(), FeatName.c_str());
     Gui::Command::updateActive();
 
-    if (isActiveObjectValid() && (pcActiveBody != NULL)) {
+    if ( isActiveObjectValid() ) {
         // TODO  (2015-08-05, Fat-Zer)
         if (prevSolid) {
             doCommand(Gui,"Gui.activeDocument().hide(\"%s\")", prevSolid->getNameInDocument());

--- a/src/Mod/PartDesign/Gui/TaskFeaturePick.h
+++ b/src/Mod/PartDesign/Gui/TaskFeaturePick.h
@@ -90,10 +90,11 @@ class TaskDlgFeaturePick : public Gui::TaskView::TaskDialog
     Q_OBJECT
 
 public:
-    TaskDlgFeaturePick(std::vector<App::DocumentObject*> &objects, 
+    TaskDlgFeaturePick( std::vector<App::DocumentObject*> &objects,
                         const std::vector<TaskFeaturePick::featureStatus> &status,
                         boost::function<bool (std::vector<App::DocumentObject*>)> acceptfunc,
-                        boost::function<void (std::vector<App::DocumentObject*>)> workfunc);
+                        boost::function<void (std::vector<App::DocumentObject*>)> workfunc,
+                        boost::function<void (void)> abortfunc = NULL );
     ~TaskDlgFeaturePick();
 
 public:
@@ -120,6 +121,7 @@ protected:
     bool accepted;
     boost::function<bool (std::vector<App::DocumentObject*>)>  acceptFunction;
     boost::function<void (std::vector<App::DocumentObject*>)>  workFunction;
+    boost::function<void (void)> abortFunction;
 };
 
 }

--- a/src/Mod/PartDesign/Gui/Utils.cpp
+++ b/src/Mod/PartDesign/Gui/Utils.cpp
@@ -82,6 +82,30 @@ PartDesign::Body *getBody(bool messageIfNot)
     return activeBody;
 }
 
+void needActiveBodyError(void)
+{
+    QMessageBox::warning( Gui::getMainWindow(),
+        QObject::tr("Active Body Required"),
+        QObject::tr("To create a new PartDesign object, there must be "
+                    "an active Body object in the document. Please make "
+                    "one active (double click) or create a new Body.") );
+}
+
+PartDesign::Body * makeBody(App::Document *doc)
+{
+    // This is intended as a convenience when starting a new document.
+    auto bodyName( doc->getUniqueObjectName("Body") );
+    Gui::Command::doCommand( Gui::Command::Doc,
+                             "App.activeDocument().addObject('PartDesign::Body','%s')",
+                             bodyName.c_str() );
+    Gui::Command::doCommand( Gui::Command::Gui,
+                             "Gui.activeView().setActiveObject('%s', App.activeDocument().%s)",
+                             PDBODYKEY, bodyName.c_str() );
+
+    auto activeView( Gui::Application::Instance->activeView() );
+    return activeView->getActiveObject<PartDesign::Body*>(PDBODYKEY);
+}
+
 PartDesign::Body *getBodyFor(const App::DocumentObject* obj, bool messageIfNot)
 {
     if(!obj)

--- a/src/Mod/PartDesign/Gui/Utils.h
+++ b/src/Mod/PartDesign/Gui/Utils.h
@@ -32,6 +32,7 @@ namespace PartDesign {
 }
 
 namespace App {
+    class Document;
     class DocumentObject;
     class Part;
 }
@@ -44,6 +45,13 @@ namespace PartDesignGui {
 
 /// Return active body or show a warning message
 PartDesign::Body *getBody(bool messageIfNot);
+
+/// Display error when there are existing Body objects, but none are active
+void needActiveBodyError(void);
+
+/// Create a Body object in doc, set it active, and return pointer to it
+PartDesign::Body * makeBody(App::Document *doc);
+
 /**
  * Finds a body for the given feature. And shows a message if not found
  * Also unlike Body::findBodyFor it checks if the active body has the feature first.


### PR DESCRIPTION
From https://forum.freecadweb.org/viewtopic.php?f=19&t=21404 .  Automatically adds a new Body for newly created sketch or primitive shape when document doesn't already have any Body.

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [no additional failures] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [n/a] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR once it is merged.

---
