### PR TITLE
TreeView: fix tree view performance

### DIFF
--- a/src/Gui/Tree.h
+++ b/src/Gui/Tree.h
@@ -162,7 +162,7 @@ protected:
     /** Adds a view provider to the document item.
      * If this view provider is already added nothing happens.
      */
-    void slotNewObject(DocumentObjectItem *parent, const Gui::ViewProviderDocumentObject&);
+    void slotNewObject(const Gui::ViewProviderDocumentObject&);
     /** Removes a view provider from the document item.
      * If this view provider is not added nothing happens.
      */
@@ -174,6 +174,10 @@ protected:
     void slotResetEdit       (const Gui::ViewProviderDocumentObject&);
     void slotHighlightObject (const Gui::ViewProviderDocumentObject&,const Gui::HighlightMode&,bool);
     void slotExpandObject    (const Gui::ViewProviderDocumentObject&,const Gui::TreeItemMode&);
+
+    bool createNewItem(const Gui::ViewProviderDocumentObject&, 
+                    QTreeWidgetItem *parent=0, int index=-1, 
+                    DocumentObjectItemsPtr ptrs = DocumentObjectItemsPtr());
         
 private:
     const Gui::Document* pDocument;
@@ -200,7 +204,7 @@ class DocumentObjectItem : public QTreeWidgetItem
 {
 public:
     DocumentObjectItem(Gui::ViewProviderDocumentObject* pcViewProvider, 
-                       QTreeWidgetItem * parent, DocumentObjectItemsPtr selves);
+                       DocumentObjectItemsPtr selves);
     ~DocumentObjectItem();
 
     Gui::ViewProviderDocumentObject* object() const;


### PR DESCRIPTION
It seems on some system calling QTreeWidgetItem::takeChildren and then addChild back is expensive. This fix avoids that but still keeps track of item order in claimed children.

Discussion starts here https://forum.freecadweb.org/viewtopic.php?f=27&t=21334&start=30#p168504