### PR TITLE
Create Macro dir for AddonManager if nonexistent

### DIFF
--- a/src/Mod/AddonManager/AddonManager.py
+++ b/src/Mod/AddonManager/AddonManager.py
@@ -205,6 +205,8 @@ class AddonsInstaller(QtGui.QDialog):
             self.install_worker.start()
         elif self.tabWidget.currentIndex() == 1:
             macropath = FreeCAD.ParamGet('User parameter:BaseApp/Preferences/Macro').GetString("MacroPath",os.path.join(FreeCAD.ConfigGet("UserAppData"),"Macro"))
+            if not os.path.isdir(macropath):
+                os.makedirs(macropath)
             macro = self.macros[self.listMacros.currentRow()]
             if len(macro) < 5:
                 self.labelDescription.setText(QtGui.QApplication.translate("AddonsInstaller", "Unable to install", None, QtGui.QApplication.UnicodeUTF8))


### PR DESCRIPTION
This commit implements the directory-existence-check already used for
the Mod folder when AddonManager attempts to install something into it
and is associated with bug #00029998

---
Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [OK] Branch rebased on latest master `git pull --rebase upstream master`
- [OK] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [OK] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [OK] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR once it is merged.

---
