### PR TITLE
20170406 text output

### DIFF
--- a/src/Base/Console.cpp
+++ b/src/Base/Console.cpp
@@ -27,7 +27,7 @@
 #ifndef _PreComp_
 # include <time.h>
 # include <stdio.h>
-# if defined (FC_OS_WIN32)
+# if defined(FC_OS_WIN32)
 #  include <io.h>
 #  include <windows.h>
 # elif defined(FC_OS_LINUX) || defined(FC_OS_MACOSX)
@@ -635,11 +635,11 @@ void ConsoleObserverFile::Log    (const char *sLog)
 }
 
 
-ConsoleObserverStd::ConsoleObserverStd():
+ConsoleObserverStd::ConsoleObserverStd() :
 #   if defined(FC_OS_WIN32)
     useColorStderr( true )
 #   elif defined(FC_OS_LINUX) || defined(FC_OS_MACOSX)
-    useColorStderr( isatty(STDOUT_FILENO) )
+    useColorStderr( isatty(STDERR_FILENO) )
 #   endif
 {
     bLog = false;
@@ -658,20 +658,19 @@ void ConsoleObserverStd::Warning(const char *sWarn)
 {
     if (useColorStderr) {
 #   if defined(FC_OS_WIN32)
-        ::SetConsoleTextAttribute(::GetStdHandle(STD_OUTPUT_HANDLE), FOREGROUND_GREEN| FOREGROUND_BLUE);
+        ::SetConsoleTextAttribute(::GetStdHandle(STD_ERROR_HANDLE), FOREGROUND_GREEN| FOREGROUND_BLUE);
 #   elif defined(FC_OS_LINUX) || defined(FC_OS_MACOSX)
-        printf("\033[1;33m");
+        fprintf(stderr, "\033[1;33m");
 #   endif
     }
 
-    printf("%s",sWarn);
+    fprintf(stderr, "%s", sWarn);
 
     if (useColorStderr) {
 #   if defined(FC_OS_WIN32)
-        ::SetConsoleTextAttribute(::GetStdHandle(STD_OUTPUT_HANDLE),FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE );
+        ::SetConsoleTextAttribute(::GetStdHandle(STD_ERROR_HANDLE),FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE );
 #   elif defined(FC_OS_LINUX) || defined(FC_OS_MACOSX)
-        printf("\033[0m");
-        fflush(stdout);
+        fprintf(stderr, "\033[0m");
 #   endif
     }
 }
@@ -680,20 +679,19 @@ void ConsoleObserverStd::Error  (const char *sErr)
 {
     if (useColorStderr) {
 #   if defined(FC_OS_WIN32)
-        ::SetConsoleTextAttribute(::GetStdHandle(STD_OUTPUT_HANDLE), FOREGROUND_RED|FOREGROUND_INTENSITY );
+        ::SetConsoleTextAttribute(::GetStdHandle(STD_ERROR_HANDLE), FOREGROUND_RED|FOREGROUND_INTENSITY );
 #   elif defined(FC_OS_LINUX) || defined(FC_OS_MACOSX)
-        printf("\033[1;31m");
+        fprintf(stderr, "\033[1;31m");
 #   endif
     }
 
-    printf("%s",sErr);
+    fprintf(stderr, "%s", sErr);
 
     if (useColorStderr) {
 #   if defined(FC_OS_WIN32)
-        ::SetConsoleTextAttribute(::GetStdHandle(STD_OUTPUT_HANDLE),FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE );
+        ::SetConsoleTextAttribute(::GetStdHandle(STD_ERROR_HANDLE),FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE );
 #   elif defined(FC_OS_LINUX) || defined(FC_OS_MACOSX)
-        printf("\033[0m");
-        fflush(stdout);
+        fprintf(stderr, "\033[0m");
 #   endif
     }
 }
@@ -702,20 +700,19 @@ void ConsoleObserverStd::Log    (const char *sErr)
 {
     if (useColorStderr) {
 #   if defined(FC_OS_WIN32)
-        ::SetConsoleTextAttribute(::GetStdHandle(STD_OUTPUT_HANDLE), FOREGROUND_RED |FOREGROUND_GREEN);
+        ::SetConsoleTextAttribute(::GetStdHandle(STD_ERROR_HANDLE), FOREGROUND_RED |FOREGROUND_GREEN);
 #   elif defined(FC_OS_LINUX) || defined(FC_OS_MACOSX)
-        printf("\033[1;36m");
+        fprintf(stderr, "\033[1;36m");
 #   endif
     }
 
-    printf("%s",sErr);
+    fprintf(stderr, "%s", sErr);
 
     if (useColorStderr) {
 #   if defined(FC_OS_WIN32)
-        ::SetConsoleTextAttribute(::GetStdHandle(STD_OUTPUT_HANDLE),FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE );
+        ::SetConsoleTextAttribute(::GetStdHandle(STD_ERROR_HANDLE),FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE );
 #   elif defined(FC_OS_LINUX) || defined(FC_OS_MACOSX)
-        printf("\033[0m");
-        fflush(stdout);
+        fprintf(stderr, "\033[0m");
 #   endif
     }
 }

--- a/src/Base/Console.cpp
+++ b/src/Base/Console.cpp
@@ -27,9 +27,11 @@
 #ifndef _PreComp_
 # include <time.h>
 # include <stdio.h>
-# ifdef FC_OS_WIN32
-# include <io.h>
-# include <windows.h>
+# if defined (FC_OS_WIN32)
+#  include <io.h>
+#  include <windows.h>
+# elif defined(FC_OS_LINUX) || defined(FC_OS_MACOSX)
+#  include <unistd.h>
 # endif
 # include "fcntl.h"
 #endif
@@ -633,7 +635,12 @@ void ConsoleObserverFile::Log    (const char *sLog)
 }
 
 
-ConsoleObserverStd::ConsoleObserverStd()
+ConsoleObserverStd::ConsoleObserverStd():
+#   if defined(FC_OS_WIN32)
+    useColorStderr( true )
+#   elif defined(FC_OS_LINUX) || defined(FC_OS_MACOSX)
+    useColorStderr( isatty(STDOUT_FILENO) )
+#   endif
 {
     bLog = false;
 }
@@ -649,50 +656,68 @@ void ConsoleObserverStd::Message(const char *sMsg)
 
 void ConsoleObserverStd::Warning(const char *sWarn)
 {
+    if (useColorStderr) {
 #   if defined(FC_OS_WIN32)
-    ::SetConsoleTextAttribute(::GetStdHandle(STD_OUTPUT_HANDLE), FOREGROUND_GREEN| FOREGROUND_BLUE);
+        ::SetConsoleTextAttribute(::GetStdHandle(STD_OUTPUT_HANDLE), FOREGROUND_GREEN| FOREGROUND_BLUE);
 #   elif defined(FC_OS_LINUX) || defined(FC_OS_MACOSX)
-    printf("\033[1;33m");
+        printf("\033[1;33m");
 #   endif
+    }
+
     printf("%s",sWarn);
+
+    if (useColorStderr) {
 #   if defined(FC_OS_WIN32)
-    ::SetConsoleTextAttribute(::GetStdHandle(STD_OUTPUT_HANDLE),FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE );
+        ::SetConsoleTextAttribute(::GetStdHandle(STD_OUTPUT_HANDLE),FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE );
 #   elif defined(FC_OS_LINUX) || defined(FC_OS_MACOSX)
-    printf("\033[0m");
-    fflush(stdout);
+        printf("\033[0m");
+        fflush(stdout);
 #   endif
+    }
 }
 
 void ConsoleObserverStd::Error  (const char *sErr)
 {
+    if (useColorStderr) {
 #   if defined(FC_OS_WIN32)
-    ::SetConsoleTextAttribute(::GetStdHandle(STD_OUTPUT_HANDLE), FOREGROUND_RED|FOREGROUND_INTENSITY );
+        ::SetConsoleTextAttribute(::GetStdHandle(STD_OUTPUT_HANDLE), FOREGROUND_RED|FOREGROUND_INTENSITY );
 #   elif defined(FC_OS_LINUX) || defined(FC_OS_MACOSX)
-    printf("\033[1;31m");
+        printf("\033[1;31m");
 #   endif
+    }
+
     printf("%s",sErr);
+
+    if (useColorStderr) {
 #   if defined(FC_OS_WIN32)
-    ::SetConsoleTextAttribute(::GetStdHandle(STD_OUTPUT_HANDLE),FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE );
+        ::SetConsoleTextAttribute(::GetStdHandle(STD_OUTPUT_HANDLE),FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE );
 #   elif defined(FC_OS_LINUX) || defined(FC_OS_MACOSX)
-    printf("\033[0m");
-    fflush(stdout);
+        printf("\033[0m");
+        fflush(stdout);
 #   endif
+    }
 }
 
 void ConsoleObserverStd::Log    (const char *sErr)
 {
+    if (useColorStderr) {
 #   if defined(FC_OS_WIN32)
-    ::SetConsoleTextAttribute(::GetStdHandle(STD_OUTPUT_HANDLE), FOREGROUND_RED |FOREGROUND_GREEN);
+        ::SetConsoleTextAttribute(::GetStdHandle(STD_OUTPUT_HANDLE), FOREGROUND_RED |FOREGROUND_GREEN);
 #   elif defined(FC_OS_LINUX) || defined(FC_OS_MACOSX)
-    printf("\033[1;36m");
+        printf("\033[1;36m");
 #   endif
+    }
+
     printf("%s",sErr);
+
+    if (useColorStderr) {
 #   if defined(FC_OS_WIN32)
-    ::SetConsoleTextAttribute(::GetStdHandle(STD_OUTPUT_HANDLE),FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE );
+        ::SetConsoleTextAttribute(::GetStdHandle(STD_OUTPUT_HANDLE),FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE );
 #   elif defined(FC_OS_LINUX) || defined(FC_OS_MACOSX)
-    printf("\033[0m");
-    fflush(stdout);
+        printf("\033[0m");
+        fflush(stdout);
 #   endif
+    }
 }
 
 RedirectStdOutput::RedirectStdOutput() 

--- a/src/Base/Console.cpp
+++ b/src/Base/Console.cpp
@@ -651,13 +651,13 @@ void ConsoleObserverStd::Warning(const char *sWarn)
 {
 #   if defined(FC_OS_WIN32)
     ::SetConsoleTextAttribute(::GetStdHandle(STD_OUTPUT_HANDLE), FOREGROUND_GREEN| FOREGROUND_BLUE);
-#   elif defined(FC_OS_LINUX)
+#   elif defined(FC_OS_LINUX) || defined(FC_OS_MACOSX)
     printf("\033[1;33m");
 #   endif
     printf("%s",sWarn);
 #   if defined(FC_OS_WIN32)
     ::SetConsoleTextAttribute(::GetStdHandle(STD_OUTPUT_HANDLE),FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE );
-#   elif defined(FC_OS_LINUX)
+#   elif defined(FC_OS_LINUX) || defined(FC_OS_MACOSX)
     printf("\033[0m");
     fflush(stdout);
 #   endif
@@ -667,13 +667,13 @@ void ConsoleObserverStd::Error  (const char *sErr)
 {
 #   if defined(FC_OS_WIN32)
     ::SetConsoleTextAttribute(::GetStdHandle(STD_OUTPUT_HANDLE), FOREGROUND_RED|FOREGROUND_INTENSITY );
-#   elif defined(FC_OS_LINUX)
+#   elif defined(FC_OS_LINUX) || defined(FC_OS_MACOSX)
     printf("\033[1;31m");
 #   endif
     printf("%s",sErr);
 #   if defined(FC_OS_WIN32)
     ::SetConsoleTextAttribute(::GetStdHandle(STD_OUTPUT_HANDLE),FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE );
-#   elif defined(FC_OS_LINUX)
+#   elif defined(FC_OS_LINUX) || defined(FC_OS_MACOSX)
     printf("\033[0m");
     fflush(stdout);
 #   endif
@@ -683,13 +683,13 @@ void ConsoleObserverStd::Log    (const char *sErr)
 {
 #   if defined(FC_OS_WIN32)
     ::SetConsoleTextAttribute(::GetStdHandle(STD_OUTPUT_HANDLE), FOREGROUND_RED |FOREGROUND_GREEN);
-#   elif defined(FC_OS_LINUX)
+#   elif defined(FC_OS_LINUX) || defined(FC_OS_MACOSX)
     printf("\033[1;36m");
 #   endif
     printf("%s",sErr);
 #   if defined(FC_OS_WIN32)
     ::SetConsoleTextAttribute(::GetStdHandle(STD_OUTPUT_HANDLE),FOREGROUND_RED | FOREGROUND_GREEN | FOREGROUND_BLUE );
-#   elif defined(FC_OS_LINUX)
+#   elif defined(FC_OS_LINUX) || defined(FC_OS_MACOSX)
     printf("\033[0m");
     fflush(stdout);
 #   endif

--- a/src/Base/Console.h
+++ b/src/Base/Console.h
@@ -129,10 +129,10 @@ public:
     };
 
     enum FreeCAD_ConsoleMsgType { 
-        MsgType_Txt = 1, 
-        MsgType_Log = 2,
-        MsgType_Wrn = 4, 
-        MsgType_Err = 8 
+        MsgType_Txt = 1,
+        MsgType_Log = 2, // ConsoleObserverStd sends this and higher to stderr
+        MsgType_Wrn = 4,
+        MsgType_Err = 8
     } ;
 
     /// Change mode

--- a/src/Base/Console.h
+++ b/src/Base/Console.h
@@ -130,7 +130,7 @@ public:
 
     enum FreeCAD_ConsoleMsgType { 
         MsgType_Txt = 1, 
-        MsgType_Log = 2, 
+        MsgType_Log = 2,
         MsgType_Wrn = 4, 
         MsgType_Err = 8 
     } ;
@@ -226,6 +226,8 @@ public:
     virtual void Error  (const char *sErr); 
     virtual void Log    (const char *sErr); 
     const char* Name(void){return "Console";}
+protected:
+    bool useColorStderr;
 };
 
 class BaseExport RedirectStdOutput : public std::streambuf


### PR DESCRIPTION
This has a few related changes to the text output from the FreeCAD executable:
 * Output types other than Message go to stderr instead of stdout.  This conforms better with convention, and allows for detection of errors when piping stdout to some other process for example.
 * MacOS gets colour output like Linux.
 * On Linux and MacOS, only add colour codes to output when it's going to a TTY.  This prevents the colour codes from being written to files for instance, where they just make a mess.

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit messages are [well-written](https://chris.beams.io/posts/git-commit/)
- [x] Commit messages include `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR once it is merged.

---
