### PR TITLE
TreeView: fix children order when cyclic ref is found

### DIFF
--- a/src/Gui/Tree.cpp
+++ b/src/Gui/Tree.cpp
@@ -1149,6 +1149,7 @@ void DocumentItem::populateItem(DocumentObjectItem *item, bool refresh) {
                 Base::Console().Error("Gui::DocumentItem::populateItem(): Cyclic dependency in %s and %s\n",
                         item->object()->getObject()->Label.getValue(),
                         childItem->object()->getObject()->Label.getValue());
+                --i;
                 continue;
             }
             this->removeChild(childItem);


### PR DESCRIPTION
Fixed potential children order problem when a cyclic reference is detected.