### PR TITLE
Part Design: Keep body transparency when adding a new feature

### DIFF
--- a/src/Mod/PartDesign/Gui/Command.cpp
+++ b/src/Mod/PartDesign/Gui/Command.cpp
@@ -672,6 +672,7 @@ void finishFeature(const Gui::Command* cmd, const std::string& FeatName,
         cmd->copyVisual(FeatName.c_str(), "ShapeColor", pcActiveBody->getNameInDocument());
         cmd->copyVisual(FeatName.c_str(), "LineColor", pcActiveBody->getNameInDocument());
         cmd->copyVisual(FeatName.c_str(), "PointColor", pcActiveBody->getNameInDocument());
+        cmd->copyVisual(FeatName.c_str(), "Transparency", pcActiveBody->getNameInDocument());
     }
 }
 


### PR DESCRIPTION
My first PD commit. A very simple one. Yet, it is possible that I got it wrong. Thread:
https://forum.freecadweb.org/viewtopic.php?f=10&t=21765#p169354

=============================================================

Prior this commit, if a body has transparency (let's say 55%) and a new feature is added, the transparency is lost until you update it again in the body.

This prevents to actually see through while editing the feature (e.g. while setting the length of a pad) and is very annoying as the user
is required to go back to the body properties, where the old value (e.g. 55%) would still be there and change it to another value (56%) to effect it.

---
