### PR TITLE
Optionally generate FEM mesh on OK

### DIFF
--- a/src/Mod/Fem/Gui/DlgSettingsFemGeneral.ui
+++ b/src/Mod/Fem/Gui/DlgSettingsFemGeneral.ui
@@ -202,6 +202,34 @@
       </widget>
      </item>
      <item>
+      <widget class="QGroupBox" name="gb_meshes">
+       <property name="title">
+        <string>Meshes</string>
+       </property>
+       <layout class="QVBoxLayout" name="verticalLayout_5">
+        <item>
+         <widget class="Gui::PrefCheckBox" name="cb_no_calc_mesh_on_ok">
+          <property name="enabled">
+           <bool>true</bool>
+          </property>
+          <property name="text">
+           <string>Store parameters without calculating mesh on OK</string>
+          </property>
+          <property name="checked">
+           <bool>false</bool>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>NoCalcMeshOnOk</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/Fem/General</cstring>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </widget>
+     </item>
+     <item>
       <widget class="QGroupBox" name="gb_results">
        <property name="title">
         <string>Results</string>

--- a/src/Mod/Fem/Gui/DlgSettingsFemGeneralImp.cpp
+++ b/src/Mod/Fem/Gui/DlgSettingsFemGeneralImp.cpp
@@ -46,6 +46,8 @@ void DlgSettingsFemGeneralImp::saveSettings()
 {
     fc_analysis_working_directory->onSave();
 
+    cb_no_calc_mesh_on_ok->onSave();
+
     cb_use_built_in_materials->onSave();
     cb_use_mat_from_config_dir->onSave();
     cb_use_mat_from_custom_dir->onSave();
@@ -59,6 +61,8 @@ void DlgSettingsFemGeneralImp::saveSettings()
 void DlgSettingsFemGeneralImp::loadSettings()
 {
     fc_analysis_working_directory->onRestore();
+
+    cb_no_calc_mesh_on_ok->onRestore();
 
     cb_use_built_in_materials->onRestore();
     cb_use_mat_from_config_dir->onRestore();

--- a/src/Mod/Fem/PyGui/TaskPanelFemMeshGmsh.ui
+++ b/src/Mod/Fem/PyGui/TaskPanelFemMeshGmsh.ui
@@ -129,6 +129,16 @@
           </property>
          </widget>
         </item>
+        <item row="4" column="0">
+         <widget class="QCheckBox" name="cb_no_mesh_calc">
+          <property name="text">
+           <string>Store parameters without calculating mesh on OK</string>
+          </property>
+          <property name="checked">
+           <bool>false</bool>
+          </property>
+         </widget>
+        </item>
        </layout>
       </item>
      </layout>


### PR DESCRIPTION
This PR adds the following:
- An option in Preferences > FEM > General > Meshes: "Store parameters without calculating mesh on OK" (this can later be implemented for netgen, etc, and doesnt seem worth implementing on the per-mesher level)
- A one-time dialog box on clicking OK that gives the option of setting the preference above
- A checkbox in the GMSH parameters that defaults to the value of the preference, but can be selected/unselected as needed

Hopefully this meets everyone's needs for usability.

---
Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ok] Branch rebased on latest master `git pull --rebase upstream master`
- [ok] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ok] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ok] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR once it is merged.

---
