### PR TITLE
Sketcher: Fixes #3009 error with geompoints in sketcher

### DIFF
--- a/src/Mod/Sketcher/App/Sketch.cpp
+++ b/src/Mod/Sketcher/App/Sketch.cpp
@@ -3325,7 +3325,7 @@ TopoShape Sketch::toShape(void) const
 
     // collecting all (non constructive and non external) edges out of the sketch
     for (;it!=Geoms.end();++it) {
-        if (!it->external && !it->geo->Construction) {
+        if (!it->external && !it->geo->Construction && (it->type != Point)) {
             edge_list.push_back(TopoDS::Edge(it->geo->toShape()));
         }
     }


### PR DESCRIPTION
=======================================================

Introduction of construction points as fixed solver entities introduced this bug, as there was no specific code to check for points as they were by default construction.
