### PR TITLE
Sketcher minifeatures

### DIFF
--- a/src/Mod/Sketcher/Gui/TaskSketcherConstrains.h
+++ b/src/Mod/Sketcher/Gui/TaskSketcherConstrains.h
@@ -84,6 +84,7 @@ public Q_SLOTS:
     void on_listWidgetConstraints_itemChanged(QListWidgetItem * item);
     void on_listWidgetConstraints_updateDrivingStatus(QListWidgetItem *item, bool status);
     void on_listWidgetConstraints_emitCenterSelectedItems(void);
+    void on_filterInternalAlignment_stateChanged(int state);
 
 protected:
     void changeEvent(QEvent *e);

--- a/src/Mod/Sketcher/Gui/TaskSketcherConstrains.ui
+++ b/src/Mod/Sketcher/Gui/TaskSketcherConstrains.ui
@@ -58,6 +58,22 @@
     </layout>
    </item>
    <item>
+    <widget class="Gui::PrefCheckBox" name="filterInternalAlignment">
+     <property name="text">
+      <string>Hide Internal Aligment</string>
+     </property>
+     <property name="checked">
+      <bool>true</bool>
+     </property>
+     <property name="prefEntry" stdset="0">
+      <cstring>HideInternalAlignment</cstring>
+     </property>
+     <property name="prefPath" stdset="0">
+      <cstring>Mod/Sketcher</cstring>
+     </property>
+    </widget>
+   </item>
+   <item>
     <widget class="ConstraintView" name="listWidgetConstraints">
      <property name="modelColumn">
       <number>0</number>
@@ -71,6 +87,11 @@
    <class>ConstraintView</class>
    <extends>QListWidget</extends>
    <header location="global">QListWidget</header>
+  </customwidget>
+  <customwidget>
+   <class>Gui::PrefCheckBox</class>
+   <extends>QCheckBox</extends>
+   <header>Gui/PrefWidgets.h</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/src/Mod/Sketcher/Gui/TaskSketcherElements.cpp
+++ b/src/Mod/Sketcher/Gui/TaskSketcherElements.cpp
@@ -686,7 +686,8 @@ void TaskSketcherElements::slotElementsChanged(void)
     
     int i=1;
     for(std::vector< Part::Geometry * >::const_iterator it= vals.begin();it!=vals.end();++it,++i){
-      Base::Type type = (*it)->getTypeId();      
+      Base::Type type = (*it)->getTypeId();
+      bool construction = (*it)->Construction;
       
       ui->listWidgetElements->addItem(new ElementItem(
         (type == Part::GeomPoint::getClassTypeId()          && element==1) ? Sketcher_Element_Point_StartingPoint :
@@ -721,31 +722,40 @@ void TaskSketcherElements::slotElementsChanged(void)
                                                                 (tr("Point") + QString::fromLatin1("(Edge%1)").arg(i)):
                                                                 (QString::fromLatin1("%1-").arg(i)+tr("Point")))         :
         type == Part::GeomLineSegment::getClassTypeId()     ? ( isNamingBoxChecked ?
-                                                                (tr("Line") + QString::fromLatin1("(Edge%1)").arg(i)):
+                                                                (tr("Line") + QString::fromLatin1("(Edge%1)").arg(i)) + 
+                                                                (construction?(QString::fromLatin1("-")+tr("Construction")):QString::fromLatin1("")):
                                                                 (QString::fromLatin1("%1-").arg(i)+tr("Line")))         :
         type == Part::GeomArcOfCircle::getClassTypeId()     ? ( isNamingBoxChecked ?
-                                                                (tr("Arc") + QString::fromLatin1("(Edge%1)").arg(i)):
+                                                                (tr("Arc") + QString::fromLatin1("(Edge%1)").arg(i)) +
+                                                                (construction?(QString::fromLatin1("-")+tr("Construction")):QString::fromLatin1("")):
                                                                 (QString::fromLatin1("%1-").arg(i)+tr("Arc")))         :
         type == Part::GeomCircle::getClassTypeId()          ? ( isNamingBoxChecked ?
-                                                                (tr("Circle") + QString::fromLatin1("(Edge%1)").arg(i)):
+                                                                (tr("Circle") + QString::fromLatin1("(Edge%1)").arg(i)) +
+                                                                (construction?(QString::fromLatin1("-")+tr("Construction")):QString::fromLatin1("")):
                                                                 (QString::fromLatin1("%1-").arg(i)+tr("Circle")))         :
         type == Part::GeomEllipse::getClassTypeId()         ? ( isNamingBoxChecked ? 
-                                                                (tr("Ellipse") + QString::fromLatin1("(Edge%1)").arg(i)):
+                                                                (tr("Ellipse") + QString::fromLatin1("(Edge%1)").arg(i)) +
+                                                                (construction?(QString::fromLatin1("-")+tr("Construction")):QString::fromLatin1("")):
                                                                 (QString::fromLatin1("%1-").arg(i)+tr("Ellipse")))   :
         type == Part::GeomArcOfEllipse::getClassTypeId()    ? ( isNamingBoxChecked ? 
-                                                                (tr("Elliptical Arc") + QString::fromLatin1("(Edge%1)").arg(i)):
+                                                                (tr("Elliptical Arc") + QString::fromLatin1("(Edge%1)").arg(i)) +
+                                                                (construction?(QString::fromLatin1("-")+tr("Construction")):QString::fromLatin1("")):
                                                                 (QString::fromLatin1("%1-").arg(i)+tr("Elliptical Arc")))   :
         type == Part::GeomArcOfHyperbola::getClassTypeId()    ? ( isNamingBoxChecked ? 
-                                                                (tr("Hyperbolic Arc") + QString::fromLatin1("(Edge%1)").arg(i)):
+                                                                (tr("Hyperbolic Arc") + QString::fromLatin1("(Edge%1)").arg(i)) +
+                                                                (construction?(QString::fromLatin1("-")+tr("Construction")):QString::fromLatin1("")):
                                                                 (QString::fromLatin1("%1-").arg(i)+tr("Hyperbolic Arc")))   :
         type == Part::GeomArcOfParabola::getClassTypeId()    ? ( isNamingBoxChecked ? 
-                                                                (tr("Parabolic Arc") + QString::fromLatin1("(Edge%1)").arg(i)):
+                                                                (tr("Parabolic Arc") + QString::fromLatin1("(Edge%1)").arg(i)) +
+                                                                (construction?(QString::fromLatin1("-")+tr("Construction")):QString::fromLatin1("")):
                                                                 (QString::fromLatin1("%1-").arg(i)+tr("Parabolic Arc")))   :
         type == Part::GeomBSplineCurve::getClassTypeId()    ? ( isNamingBoxChecked ? 
-                                                                (tr("BSpline") + QString::fromLatin1("(Edge%1)").arg(i)):
+                                                                (tr("BSpline") + QString::fromLatin1("(Edge%1)").arg(i)) +
+                                                                (construction?(QString::fromLatin1("-")+tr("Construction")):QString::fromLatin1("")):
                                                                 (QString::fromLatin1("%1-").arg(i)+tr("BSpline")))   :
         ( isNamingBoxChecked ?
-          (tr("Other") + QString::fromLatin1("(Edge%1)").arg(i)):
+          (tr("Other") + QString::fromLatin1("(Edge%1)").arg(i)) +
+          (construction?(QString::fromLatin1("-")+tr("Construction")):QString::fromLatin1("")):
           (QString::fromLatin1("%1-").arg(i)+tr("Other"))),
         i-1,
         sketchView->getSketchObject()->getVertexIndexGeoPos(i-1,Sketcher::start),

--- a/src/Mod/Sketcher/Gui/TaskSketcherGeneral.cpp
+++ b/src/Mod/Sketcher/Gui/TaskSketcherGeneral.cpp
@@ -54,6 +54,8 @@ SketcherGeneralWidget::SketcherGeneralWidget(QWidget *parent)
             this, SLOT(setGridSize(double)));
     connect(ui->checkBoxAutoconstraints, SIGNAL(stateChanged(int)),
             this, SIGNAL(emitToggleAutoconstraints(int)));
+    connect(ui->renderingOrder->model(), SIGNAL(layoutChanged()),
+            this, SLOT(renderOrderChanged()));
 }
 
 SketcherGeneralWidget::~SketcherGeneralWidget()
@@ -71,6 +73,8 @@ void SketcherGeneralWidget::saveSettings()
 
     hGrp->SetBool("GridSnap", ui->checkBoxGridSnap->isChecked());
     hGrp->SetBool("AutoConstraints", ui->checkBoxAutoconstraints->isChecked());
+    
+    //not necessary to save renderOrder, as it is already stored in renderOrderChanged on every change.
 }
 
 void SketcherGeneralWidget::loadSettings()
@@ -82,6 +86,28 @@ void SketcherGeneralWidget::loadSettings()
     ui->gridSize->setToLastUsedValue();
     ui->checkBoxGridSnap->setChecked(hGrp->GetBool("GridSnap", ui->checkBoxGridSnap->isChecked()));
     ui->checkBoxAutoconstraints->setChecked(hGrp->GetBool("AutoConstraints", ui->checkBoxAutoconstraints->isChecked()));
+    
+    ParameterGrp::handle hGrpp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Mod/Sketcher");
+    
+    // 1->Normal Geometry, 2->Construction, 3->External
+    int topid = hGrpp->GetInt("TopRenderGeometryId",1);
+    int midid = hGrpp->GetInt("MidRenderGeometryId",2);
+    int lowid = hGrpp->GetInt("LowRenderGeometryId",3);
+    
+    QListWidgetItem *newItem = new QListWidgetItem;
+    newItem->setData(Qt::UserRole, QVariant(topid));
+    newItem->setText( topid==1?tr("Normal Geometry"):topid==2?tr("Construction Geometry"):tr("External Geometry"));
+    ui->renderingOrder->insertItem(0,newItem);
+    
+    newItem = new QListWidgetItem;
+    newItem->setData(Qt::UserRole, QVariant(midid));
+    newItem->setText(midid==1?tr("Normal Geometry"):midid==2?tr("Construction Geometry"):tr("External Geometry"));
+    ui->renderingOrder->insertItem(1,newItem);
+    
+    newItem = new QListWidgetItem;
+    newItem->setData(Qt::UserRole, QVariant(lowid));
+    newItem->setText(lowid==1?tr("Normal Geometry"):lowid==2?tr("Construction Geometry"):tr("External Geometry"));
+    ui->renderingOrder->insertItem(2,newItem);
 }
 
 void SketcherGeneralWidget::toggleGridView(bool on)
@@ -115,6 +141,20 @@ void SketcherGeneralWidget::changeEvent(QEvent *e)
     }
 }
 
+void SketcherGeneralWidget::renderOrderChanged()
+{
+    int topid = ui->renderingOrder->item(0)->data(Qt::UserRole).toInt();
+    int midid = ui->renderingOrder->item(1)->data(Qt::UserRole).toInt();
+    int lowid = ui->renderingOrder->item(2)->data(Qt::UserRole).toInt();
+    
+    ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Mod/Sketcher");
+    hGrp->SetInt("TopRenderGeometryId",topid);
+    hGrp->SetInt("MidRenderGeometryId",midid);
+    hGrp->SetInt("LowRenderGeometryId",lowid);
+    
+    emitrenderOrderChanged();
+}
+
 // ----------------------------------------------------------------------------
 
 TaskSketcherGeneral::TaskSketcherGeneral(ViewProviderSketch *sketchView)
@@ -144,6 +184,11 @@ TaskSketcherGeneral::TaskSketcherGeneral(ViewProviderSketch *sketchView)
         widget, SIGNAL(emitToggleAutoconstraints(int)),
         this  , SLOT  (toggleAutoconstraints(int))
        );
+    
+    QObject::connect(
+        widget, SIGNAL(emitrenderOrderChanged()),
+                     this  , SLOT  (renderOrderChanged())
+    );
     
 
     Gui::Selection().Attach(this);
@@ -191,5 +236,10 @@ void TaskSketcherGeneral::OnChange(Gui::SelectionSingleton::SubjectType &rCaller
     //}
 }
 /// @endcond DOXERR
+
+void TaskSketcherGeneral::renderOrderChanged()
+{
+    sketchView->updateColor();
+}
 
 #include "moc_TaskSketcherGeneral.cpp"

--- a/src/Mod/Sketcher/Gui/TaskSketcherGeneral.h
+++ b/src/Mod/Sketcher/Gui/TaskSketcherGeneral.h
@@ -55,11 +55,13 @@ Q_SIGNALS:
     void emitToggleGridSnap(int);
     void emitSetGridSize(double);
     void emitToggleAutoconstraints(int);
+    void emitrenderOrderChanged();
 
 public Q_SLOTS:
     void toggleGridView(bool on);
     void setGridSize(double val);
     void toggleGridSnap(int state);
+    void renderOrderChanged();
 
 protected:
     void changeEvent(QEvent *e);
@@ -88,6 +90,7 @@ public Q_SLOTS:
     void setGridSize(double val);
     void toggleGridSnap(int state);
     void toggleAutoconstraints(int state);
+    void renderOrderChanged();
 
 private:
     ViewProviderSketch *sketchView;

--- a/src/Mod/Sketcher/Gui/TaskSketcherGeneral.ui
+++ b/src/Mod/Sketcher/Gui/TaskSketcherGeneral.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>153</width>
-    <height>115</height>
+    <width>194</width>
+    <height>228</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -34,26 +34,26 @@
       </widget>
      </item>
      <item>
-       <widget class="Gui::PrefQuantitySpinBox" name="gridSize">
-         <property name="unit" stdset="0">
-           <string notr="true">mm</string>
-         </property>
-         <property name="decimals" stdset="0">
-           <number>3</number>
-         </property>
-         <property name="maximum" stdset="0">
-           <double>99999999.0</double>
-         </property>
-         <property name="minimum" stdset="0">
-           <double>0.001</double>
-         </property>
-         <property name="singleStep" stdset="0">
-           <double>1.000000000000000</double>
-         </property>
-         <property name="value" stdset="0">
-           <double>0.0000001</double>
-         </property>
-       </widget>
+      <widget class="Gui::PrefQuantitySpinBox" name="gridSize" native="true">
+       <property name="unit" stdset="0">
+        <string notr="true">mm</string>
+       </property>
+       <property name="decimals" stdset="0">
+        <number>3</number>
+       </property>
+       <property name="maximum" stdset="0">
+        <double>99999999.000000000000000</double>
+       </property>
+       <property name="minimum" stdset="0">
+        <double>0.001000000000000</double>
+       </property>
+       <property name="singleStep" stdset="0">
+        <double>1.000000000000000</double>
+       </property>
+       <property name="value" stdset="0">
+        <double>0.000000100000000</double>
+       </property>
+      </widget>
      </item>
     </layout>
    </item>
@@ -80,16 +80,35 @@
      </property>
     </widget>
    </item>
+   <item>
+    <widget class="QLabel" name="label_2">
+     <property name="text">
+      <string>Rendering order:</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QListWidget" name="renderingOrder">
+     <property name="dragEnabled">
+      <bool>true</bool>
+     </property>
+     <property name="dragDropMode">
+      <enum>QAbstractItemView::InternalMove</enum>
+     </property>
+     <property name="sortingEnabled">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>Gui::PrefQuantitySpinBox</class>
+   <extends>QWidget</extends>
+   <header>Gui/PrefWidgets.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
-  <customwidgets>
-    <customwidget>
-      <class>Gui::PrefQuantitySpinBox</class>
-      <extends>QWidget</extends>
-      <header>Gui/PrefWidgets.h</header>
-    </customwidget>
-  </customwidgets>
-
-  <connections/>
+ <connections/>
 </ui>

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -2462,7 +2462,7 @@ void ViewProviderSketch::updateColor(void)
     // 1->Normal Geometry, 2->Construction, 3->External
     int topid = hGrpp->GetInt("TopRenderGeometryId",1);
     int midid = hGrpp->GetInt("MidRenderGeometryId",2);
-    int lowid = hGrpp->GetInt("LowRenderGeometryId",3);
+    //int lowid = hGrpp->GetInt("LowRenderGeometryId",3);
     
     float zNormLine = (topid==1?zHighLines:midid==1?zMidLines:zLowLines);
     float zConstrLine = (topid==2?zHighLines:midid==2?zMidLines:zLowLines);

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.h
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.h
@@ -386,7 +386,7 @@ protected:
     static SbVec2s newCursorPos;
 
     float zCross;
-    float zLines;
+    //float zLines;
     float zPoints;
     float zConstr;
     float zHighlight;
@@ -394,6 +394,9 @@ protected:
     float zEdit;
     float zHighLine;
     float zInfo;
+    float zLowLines;
+    float zMidLines;
+    float zHighLines;
 
     // reference coordinates for relative operations
     double xInit,yInit;


### PR DESCRIPTION
Three mini-features:
https://forum.freecadweb.org/viewtopic.php?f=10&t=21878

1. Allow to hide Internal Alignment Constraints (See Constraints Widget)
2. Allow to recognise construction geometry (See Elements Widget)
3. Allow to select line rendering order (See Editor Widget)
