### PR TITLE
Color for arch drawing view

### DIFF
--- a/src/Mod/Arch/ArchSectionPlane.py
+++ b/src/Mod/Arch/ArchSectionPlane.py
@@ -254,7 +254,7 @@ def getSVG(section, renderMode="Wireframe", allOn=False, showHidden=False, scale
         if not techdraw:
             svg += '<g transform="scale(1,-1)">'
         for d in drafts:
-            svg += Draft.getSVG(d, scale=scale, linewidth=symbolLineWidth,
+            svg += Draft.getSVG(d, scale=scale, linewidth=svgSymbolLineWidth,
                                 fontsize=fontsize, direction=direction, color=lineColor,
                                 techdraw=techdraw, rotation=rotation)
         if not techdraw:
@@ -267,7 +267,7 @@ def getSVG(section, renderMode="Wireframe", allOn=False, showHidden=False, scale
         if not techdraw:
             svg += '<g transform="scale(1,-1)">'
         for s in spaces:
-            svg += Draft.getSVG(s, scale=scale, linewidth=symbolLineWidth,
+            svg += Draft.getSVG(s, scale=scale, linewidth=svgSymbolLineWidth,
                                 fontsize=fontsize, direction=direction, color=lineColor,
                                 techdraw=techdraw, rotation=rotation)
         if not techdraw:
@@ -297,7 +297,8 @@ def getSVG(section, renderMode="Wireframe", allOn=False, showHidden=False, scale
             if not techdraw:
                 svg += '<g transform="scale(1,-1)">'
             for s in sh:
-                svg += Draft.getSVG(s, scale=scale, linewidth=symbolLineWidth,
+                svg += Draft.getSVG(s, scale=scale, 
+                                    linewidth=svgSymbolLineWidth,
                                     fontsize=fontsize, fillstyle="none",
                                     direction=direction, color=lineColor,
                                     techdraw=techdraw, rotation=rotation)

--- a/src/Mod/Arch/ArchSectionPlane.py
+++ b/src/Mod/Arch/ArchSectionPlane.py
@@ -196,21 +196,21 @@ def getSVG(section,allOn=False,renderMode="Wireframe",showHidden=False,showFill=
         shapes,hshapes,sshapes,cutface,cutvolume,invcutvolume = getCutShapes(objs,section,showHidden)
         if shapes:
             baseshape = Part.makeCompound(shapes)
-            svgf = Drawing.projectToSVG(baseshape,direction)
-            if svgf:
-                svgf = svgf.replace('stroke-width="0.35"','stroke-width="LWPlaceholder"')
-                svgf = svgf.replace('stroke-width="1"','stroke-width="LWPlaceholder"')
-                svgf = svgf.replace('stroke-width:0.01','stroke-width:LWPlaceholder')
-                svg += svgf
+            style = {'stroke-width': 'LWPlaceholder'}
+            svgf = Drawing.projectToSVG(
+                baseshape, direction,
+                hStyle=style, h0Style=style, h1Style=style,
+                vStyle=style, v0Style=style, v1Style=style)
+            svg += svgf
         if hshapes:
             hshapes = Part.makeCompound(hshapes)
-            svgh = Drawing.projectToSVG(hshapes,direction)
-            if svgh:
-                svgh = svgh.replace('stroke-width="0.35"','stroke-width="LWPlaceholder"')
-                svgh = svgh.replace('stroke-width="1"','stroke-width="LWPlaceholder"')
-                svgh = svgh.replace('stroke-width:0.01','stroke-width:LWPlaceholder')
-                svgh = svgh.replace('fill="none"','fill="none"\nstroke-dasharray="DAPlaceholder"')
-                svg += svgh
+            style = {'stroke-width': 'LWPlaceholder',
+                     'stroke-dasharray': 'DAPlaceholder'}
+            svgh = Drawing.projectToSVG(
+                hshapes, direction,
+                hStyle=style, h0Style=style, h1Style=style,
+                vStyle=style, v0Style=style, v1Style=style)
+            svg += svgh
         if sshapes:
             svgs = ""
             if showFill:
@@ -224,14 +224,12 @@ def getSVG(section,allOn=False,renderMode="Wireframe",showHidden=False,showFill=
                         svgs += f
                 svgs += "</g>\n"
             sshapes = Part.makeCompound(sshapes)
-            svgs += Drawing.projectToSVG(sshapes,direction)
-            if svgs:
-                svgs = svgs.replace('stroke-width="0.35"','stroke-width="SWPlaceholder"')
-                svgs = svgs.replace('stroke-width="1"','stroke-width="SWPlaceholder"')
-                svgs = svgs.replace('stroke-width:0.01','stroke-width:SWPlaceholder')
-                svgs = svgs.replace('stroke-width="0.35 px"','stroke-width="SWPlaceholder"')
-                svgs = svgs.replace('stroke-width:0.35','stroke-width:SWPlaceholder')
-                svg += svgs
+            style = {'stroke-width': 'SWPlaceholder'}
+            svgs += Drawing.projectToSVG(
+                sshapes, direction,
+                hStyle=style, h0Style=style, h1Style=style,
+                vStyle=style, v0Style=style, v1Style=style)
+            svg += svgs
     scaledlinewidth = linewidth/scale
     st = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/Arch").GetFloat("CutLineThickness",2)
     yt = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/Arch").GetFloat("SymbolLineThickness",0.6)

--- a/src/Mod/Arch/ArchSectionPlane.py
+++ b/src/Mod/Arch/ArchSectionPlane.py
@@ -216,7 +216,7 @@ def getSVG(section, renderMode="Wireframe", allOn=False, showHidden=False, scale
             baseshape = Part.makeCompound(shapes)
             style = {'stroke':       Draft.getrgb(lineColor),
                      'stroke-width': svgLineWidth}
-            svg = Drawing.projectToSVG(
+            svg += Drawing.projectToSVG(
                 baseshape, direction,
                 hStyle=style, h0Style=style, h1Style=style,
                 vStyle=style, v0Style=style, v1Style=style)
@@ -225,7 +225,7 @@ def getSVG(section, renderMode="Wireframe", allOn=False, showHidden=False, scale
             style = {'stroke':           Draft.getrgb(lineColor),
                      'stroke-width':     svgLineWidth,
                      'stroke-dasharray': svgHiddenPattern}
-            svg = Drawing.projectToSVG(
+            svg += Drawing.projectToSVG(
                 hshapes, direction,
                 hStyle=style, h0Style=style, h1Style=style,
                 vStyle=style, v0Style=style, v1Style=style)
@@ -235,9 +235,9 @@ def getSVG(section, renderMode="Wireframe", allOn=False, showHidden=False, scale
                 svg += '<g transform="rotate(180)">\n'
                 for s in sshapes:
                     if s.Edges:
-                        #svg = Draft.getSVG(s,direction=direction.negative(),linewidth=0,fillstyle="sectionfill",color=(0,0,0))
+                        #svg += Draft.getSVG(s,direction=direction.negative(),linewidth=0,fillstyle="sectionfill",color=(0,0,0))
                         # temporarily disabling fill patterns
-                        svg = Draft.getSVG(s, direction=direction.negative(),
+                        svg += Draft.getSVG(s, direction=direction.negative(),
                                            linewidth=0,
                                            fillstyle=Draft.getrgb(fillColor),
                                            color=lineColor)

--- a/src/Mod/Drawing/App/FeatureViewPart.cpp
+++ b/src/Mod/Drawing/App/FeatureViewPart.cpp
@@ -120,7 +120,13 @@ App::DocumentObjectExecReturn *FeatureViewPart::execute(void)
         ProjectionAlgos::ExtractionType type = ProjectionAlgos::Plain;
         if (hidden) type = (ProjectionAlgos::ExtractionType)(type|ProjectionAlgos::WithHidden);
         if (smooth) type = (ProjectionAlgos::ExtractionType)(type|ProjectionAlgos::WithSmooth);
-        result << Alg.getSVG(type, this->LineWidth.getValue() / this->Scale.getValue(), this->Tolerance.getValue(), this->HiddenWidth.getValue() / this->Scale.getValue());
+	ProjectionAlgos::XmlAttributes visible_style = { 
+	  {"stroke_width", to_string(this->LineWidth.getValue() / this->Scale.getValue())}
+	};
+	ProjectionAlgos::XmlAttributes hidden_style = {
+	  {"stroke_width", to_string(this->HiddenWidth.getValue() / this->Scale.getValue()) }
+	};
+        result << Alg.getSVG(type, this->Tolerance.getValue(), visible_style, visible_style, visible_style, hidden_style, hidden_style, hidden_style);
 
         result << "</g>" << endl;
 

--- a/src/Mod/Drawing/App/ProjectionAlgos.h
+++ b/src/Mod/Drawing/App/ProjectionAlgos.h
@@ -43,15 +43,21 @@ public:
     virtual ~ProjectionAlgos();
 
     void execute(void);
-//    static TopoDS_Shape invertY(const TopoDS_Shape&);
 
     enum ExtractionType {
         Plain = 0,
         WithHidden = 1,
         WithSmooth = 2
     };
+    typedef std::map<std::string,std::string> XmlAttributes;
 
-    std::string getSVG(ExtractionType type, double scale=0.35, double tolerance=0.05, double hiddenscale=0.15);
+    std::string getSVG(ExtractionType type, double tolerance=0.05,
+                       XmlAttributes V_style=XmlAttributes(),
+                       XmlAttributes V0_style=XmlAttributes(),
+                       XmlAttributes V1_style=XmlAttributes(),
+                       XmlAttributes H_style=XmlAttributes(),
+                       XmlAttributes H0_style=XmlAttributes(),
+                       XmlAttributes H1_style=XmlAttributes());
     std::string getDXF(ExtractionType type, double scale, double tolerance);//added by Dan Falck 2011/09/25
 
 


### PR DESCRIPTION
This feature adds two properties to ArchDrawingView: LineColor and FillColor (see attached screen shot). Thus it completes for ArchDrawingView what is already available for Draft's Shape2DView.

To realize this feature, ProjectionAlgos is extended to make the SVG styling accessible on the interface. User code can provide SVG attributes (key-value pairs) for each kind of line (V, V0, V1, H, H0, H1).

### Design decisions

- ProjectionAlgos: Offer style parameters for each kind of line. Alternatively: Maybe two kinds (e.g. V0 and V1 as well as H0 and H1) could be grouped to use only one set of style attributes.
- AppDrawingPy: Use keyed arguments on the Python interface of projectToSVG. There are too many arguments now.
- AppDrawingPy/ProjectionAlgos: Move the default values into one single module: ProjectionAlgos. Thus remove some defaults from AppDrawingPy.
- ArchSectionPlane: Add the new properties to objects from old files with onDocumentRestored (see https://forum.freecadweb.org/viewtopic.php?f=10&t=21891)
- ArchSectionPlane: Remove the placeholders from getSVG. With the changes to ProjectionAlgos, they are not necessary anymore.
- In the consequence, the following interface break: ArchSectionPlane::getSVG, AppDrawingPy - Module::projectToSVG, projectionAlgos::getSVG.

### Further notes

- I had to update FeatureViewPart to use the new interface of ProjectionAlgos. Did I do it right?
- Can someone review the code again to see whether I did break something?
- I tried to clean up some things. But I am very open to adjust the style if wanted.
- This is my first pull request to this project. Do not hesitate to push me that the pull request complies with your needs.


---

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [X] Branch rebased on latest master `git pull --rebase upstream master`
- [X] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [X] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR once it is merged.

---

![color_for_section_view](https://cloud.githubusercontent.com/assets/636024/25156450/ec45d3b6-249a-11e7-9b39-9cb84a7aaa4f.png)
