### PR TITLE
TechDraw: Tidy, and fix Qt5 template text edition

### DIFF
--- a/src/Mod/TechDraw/Gui/DlgTemplateField.cpp
+++ b/src/Mod/TechDraw/Gui/DlgTemplateField.cpp
@@ -23,20 +23,15 @@
 
 #include "PreCompiled.h"
 #include <Base/Console.h>
-
 #include "DlgTemplateField.h"
 
 using namespace TechDrawGui;
 
-DlgTemplateField::DlgTemplateField( QWidget* parent )
+DlgTemplateField::DlgTemplateField( QWidget *parent /* = nullptr */ ) :
+    QDialog(parent)
 {
-    Q_UNUSED(parent);
     setupUi(this);
     leInput->setFocus();
-}
-
-DlgTemplateField::~DlgTemplateField()
-{
 }
 
 void DlgTemplateField::changeEvent(QEvent *e)

--- a/src/Mod/TechDraw/Gui/DlgTemplateField.h
+++ b/src/Mod/TechDraw/Gui/DlgTemplateField.h
@@ -36,8 +36,8 @@ class DlgTemplateField : public QDialog, public Ui_dlgTemplateField
     Q_OBJECT
 
 public:
-    DlgTemplateField( QWidget* parent = 0 );
-    ~DlgTemplateField();
+    DlgTemplateField( QWidget *parent = nullptr );
+    virtual ~DlgTemplateField() = default;
 
     void setFieldName(std::string name);
     void setFieldContent(std::string content);

--- a/src/Mod/TechDraw/Gui/QGISVGTemplate.cpp
+++ b/src/Mod/TechDraw/Gui/QGISVGTemplate.cpp
@@ -47,9 +47,8 @@
 
 using namespace TechDrawGui;
 
-QGISVGTemplate::QGISVGTemplate(QGraphicsScene *scene, QWidget* srWidget)
+QGISVGTemplate::QGISVGTemplate(QGraphicsScene *scene)
     : QGITemplate(scene),
-      qgview(srWidget),
       firstTime(true)
 {
 
@@ -188,7 +187,6 @@ void QGISVGTemplate::createClickHandles(void)
 
             QString xStr = QString::fromStdString(xMatch[1].str());
             QString yStr = QString::fromStdString(yMatch[1].str());
-            QString editableName = QString::fromStdString(nameMatch[1].str());
 
             double x = Rez::guiX(xStr.toDouble());
             double y = Rez::guiX(yStr.toDouble());
@@ -200,8 +198,9 @@ void QGISVGTemplate::createClickHandles(void)
             double width = editClickBoxSize;
             double height = editClickBoxSize;
 
-            TemplateTextField *item = new TemplateTextField(this, tmplte, nameMatch[1].str(), qgview);
+            auto item( new TemplateTextField(this, tmplte, nameMatch[1].str()) );
             float pad = 1;
+
             item->setRect(x - pad, Rez::guiX(-tmplte->getHeight()) + y - height - pad,
                           width + 2 * pad, height + 2 * pad);
 

--- a/src/Mod/TechDraw/Gui/QGISVGTemplate.h
+++ b/src/Mod/TechDraw/Gui/QGISVGTemplate.h
@@ -43,8 +43,8 @@ class TechDrawGuiExport QGISVGTemplate : public QGITemplate
     Q_OBJECT
 
 public:
-    QGISVGTemplate(QGraphicsScene *, QWidget* srWidget=0);
-    ~QGISVGTemplate();
+    QGISVGTemplate(QGraphicsScene *scene);
+    virtual ~QGISVGTemplate();
 
     enum {Type = QGraphicsItem::UserType + 153};
     int type() const { return Type; }
@@ -56,7 +56,6 @@ protected:
     void openFile(const QFile &file);
     void load (const QString & fileName);
     void createClickHandles(void);
-    QWidget* qgview;                                  //for parenting dlgTemplateField
 
 protected:
     bool firstTime;

--- a/src/Mod/TechDraw/Gui/QGVPage.cpp
+++ b/src/Mod/TechDraw/Gui/QGVPage.cpp
@@ -466,11 +466,9 @@ void QGVPage::setPageTemplate(TechDraw::DrawTemplate *obj)
     removeTemplate();
 
     if(obj->isDerivedFrom(TechDraw::DrawParametricTemplate::getClassTypeId())) {
-        QGIDrawingTemplate *qTempItem = new QGIDrawingTemplate(scene());
-        pageTemplate = qTempItem;
+        pageTemplate = new QGIDrawingTemplate(scene());
     } else if(obj->isDerivedFrom(TechDraw::DrawSVGTemplate::getClassTypeId())) {
-        QGISVGTemplate *qTempItem = new QGISVGTemplate(scene(),this);
-        pageTemplate = qTempItem;
+        pageTemplate = new QGISVGTemplate(scene());
     }
     pageTemplate->setTemplate(obj);
     pageTemplate->updateView();

--- a/src/Mod/TechDraw/Gui/QGVPage.h
+++ b/src/Mod/TechDraw/Gui/QGVPage.h
@@ -56,7 +56,7 @@ public:
     enum RendererType { Native, OpenGL, Image };
 
     QGVPage(ViewProviderPage *vp, QGraphicsScene* s, QWidget *parent = 0);
-    ~QGVPage();
+    virtual ~QGVPage();
 
     void setRenderer(RendererType type = Native);
     void drawBackground(QPainter *p, const QRectF &rect);

--- a/src/Mod/TechDraw/Gui/TemplateTextField.h
+++ b/src/Mod/TechDraw/Gui/TemplateTextField.h
@@ -23,47 +23,41 @@
 #ifndef DRAWINGGUI_TEMPLATETEXTFIELD_H
 #define DRAWINGGUI_TEMPLATETEXTFIELD_H
 
-//TODO Precompiled header
-
 #include <QGraphicsRectItem>
 
-
-#include <Mod/TechDraw/App/DrawTemplate.h>
+#include "Mod/TechDraw/App/DrawTemplate.h"
 
 namespace TechDrawGui
 {
-class DlgTemplateField;
     /// QGraphicsRectItem-derived class for the text fields in title blocks
     /*!
-     * This essentially just a way for us to make a rectangular area which
-     * will give us a text editing dialog when clicked so that an appropriate
-     * Property in the Drawing's template can be modified.
-     * Dear English, I'm sorry.
+     * Makes an area on the drawing that's clickable, so appropriate
+     * Properties of the template can be modified.
      */
 class TechDrawGuiExport TemplateTextField : public QGraphicsRectItem
 {
     public:
-        TemplateTextField(QGraphicsItem*parent,
+        TemplateTextField(QGraphicsItem *parent,
                           TechDraw::DrawTemplate *myTmplte,
-                          const std::string &myFieldName,
-                          QWidget* upperWidget=0);
+                          const std::string &myFieldName);
 
-        ~TemplateTextField();
+        virtual ~TemplateTextField() = default;
 
         enum {Type = QGraphicsItem::UserType + 160};
         int type() const { return Type;}
-
 
         /// Returns the field name that this TemplateTextField represents
         std::string fieldName() const { return fieldNameStr; }
 
     protected:
-        void execDialog(void);
-        DlgTemplateField* ui;
-        virtual void mousePressEvent(QGraphicsSceneMouseEvent *event);
         TechDraw::DrawTemplate *tmplte;
         std::string fieldNameStr;
-        QWidget* dlgOwner;
+
+        /// Need this to properly handle mouse release
+        virtual void mousePressEvent(QGraphicsSceneMouseEvent *event);
+
+        /// Trigger the dialog for editing template text
+        virtual void mouseReleaseEvent(QGraphicsSceneMouseEvent *event);
 };
 }   // namespace TechDrawGui
 


### PR DESCRIPTION
This fixes an issue with TechDraw and Qt5 discussed in https://forum.freecadweb.org/viewtopic.php?f=35&t=21894

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [x] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR once it is merged.

---
