### PR TITLE
py3: part-design: involute-gear

### DIFF
--- a/src/Mod/PartDesign/InitGui.py
+++ b/src/Mod/PartDesign/InitGui.py
@@ -37,28 +37,28 @@ class PartDesignWorkbench ( Workbench ):
         self.__class__.ToolTip = "Part Design workbench"
 
     def Initialize(self):
-            # load the module
+        # load the module
+        try:
+            from WizardShaft import WizardShaft
+        except ImportError:
+            print("Wizard shaft module cannot be loaded")
             try:
-                from WizardShaft import WizardShaft
-            except ImportError:
-                print("Wizard shaft module cannot be loaded")
-                try:
-                    from FeatureHole import HoleGui
-                except:
-                    pass
+                from FeatureHole import HoleGui
+            except:
+                pass
 
-            import PartDesignGui
-            import PartDesign
-            try:
-                import InvoluteGearFeature
-            except ImportError:
-                print("Involute gear module cannot be loaded")
-                #try:
-                #    from FeatureHole import HoleGui
-                #except:
-                #    pass
+        import PartDesignGui
+        import PartDesign
+        try:
+            import InvoluteGearFeature
+        except ImportError:
+            print("Involute gear module cannot be loaded")
+            #try:
+            #    from FeatureHole import HoleGui
+            #except:
+            #    pass
 
     def GetClassName(self):
-            return "PartDesignGui::Workbench"
+        return "PartDesignGui::Workbench"
 
 Gui.addWorkbench(PartDesignWorkbench())

--- a/src/Mod/PartDesign/fcgear/fcgear.py
+++ b/src/Mod/PartDesign/fcgear/fcgear.py
@@ -19,8 +19,7 @@ from math import cos, sin, pi, acos, asin, atan, sqrt
 
 import FreeCAD, Part
 from FreeCAD import Base, Console
-import involute
-reload(involute)
+from . import involute
 rotate = involute.rotate
 
 

--- a/src/Mod/PartDesign/fcgear/involute.py
+++ b/src/Mod/PartDesign/fcgear/involute.py
@@ -24,6 +24,11 @@
 
 from math import cos, sin, pi, acos, asin, atan, sqrt
 
+import sys
+if sys.version_info.major >= 3:
+    xrange = range
+
+
 def CreateExternalGear(w, m, Z, phi, split=True):
     """
     Create an external gear


### PR DESCRIPTION
this PR makes the involute-gear from part-design work with python3.

---
Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR once it is merged.

---
