### PR TITLE
[path] Remove duplicate first drill job in PathHelix

### DIFF
--- a/src/Mod/Path/PathScripts/PathHelix.py
+++ b/src/Mod/Path/PathScripts/PathHelix.py
@@ -320,6 +320,7 @@ class ObjectPathHelix(object):
         zero = {'xc': 0, 'yc': 0}
 
         out.append(find_closest(jobs, zero, sqdist))
+        jobs.remove(out[-1])
 
         while jobs:
             closest = find_closest(jobs, out[-1], sqdist)


### PR DESCRIPTION
Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [OK] Branch rebased on latest master `git pull --rebase upstream master`
- [N/A] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [OK] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [N/A] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR once it is merged.

---
the recent job sorting addition to PathHelix doubles the first drill job, this PR fixes the issue.