### PR TITLE
py3: Fem: PyGui: use relative imports for PyGui

### DIFF
--- a/src/Mod/Fem/PyGui/_CommandFemAnalysis.py
+++ b/src/Mod/Fem/PyGui/_CommandFemAnalysis.py
@@ -28,7 +28,7 @@ __url__ = "http://www.freecadweb.org"
 #  \ingroup FEM
 
 import FreeCAD
-from FemCommands import FemCommands
+from .FemCommands import FemCommands
 import FreeCADGui
 from PySide import QtCore
 

--- a/src/Mod/Fem/PyGui/_CommandFemConstraintSelfWeight.py
+++ b/src/Mod/Fem/PyGui/_CommandFemConstraintSelfWeight.py
@@ -28,7 +28,7 @@ __url__ = "http://www.freecadweb.org"
 #  \ingroup FEM
 
 import FreeCAD
-from FemCommands import FemCommands
+from .FemCommands import FemCommands
 import FreeCADGui
 from PySide import QtCore
 

--- a/src/Mod/Fem/PyGui/_CommandFemElementFluid1D.py
+++ b/src/Mod/Fem/PyGui/_CommandFemElementFluid1D.py
@@ -29,7 +29,7 @@ __url__ = "http://www.freecadweb.org"
 #  \ingroup FEM
 
 import FreeCAD
-from FemCommands import FemCommands
+from .FemCommands import FemCommands
 import FreeCADGui
 from PySide import QtCore
 

--- a/src/Mod/Fem/PyGui/_CommandFemElementGeometry1D.py
+++ b/src/Mod/Fem/PyGui/_CommandFemElementGeometry1D.py
@@ -28,7 +28,7 @@ __url__ = "http://www.freecadweb.org"
 #  \ingroup FEM
 
 import FreeCAD
-from FemCommands import FemCommands
+from .FemCommands import FemCommands
 import FreeCADGui
 from PySide import QtCore
 

--- a/src/Mod/Fem/PyGui/_CommandFemElementGeometry2D.py
+++ b/src/Mod/Fem/PyGui/_CommandFemElementGeometry2D.py
@@ -28,7 +28,7 @@ __url__ = "http://www.freecadweb.org"
 #  \ingroup FEM
 
 import FreeCAD
-from FemCommands import FemCommands
+from .FemCommands import FemCommands
 import FreeCADGui
 from PySide import QtCore
 

--- a/src/Mod/Fem/PyGui/_CommandFemMaterialFluid.py
+++ b/src/Mod/Fem/PyGui/_CommandFemMaterialFluid.py
@@ -28,7 +28,7 @@ __url__ = "http://www.freecadweb.org"
 #  \ingroup FEM
 
 import FreeCAD
-from FemCommands import FemCommands
+from .FemCommands import FemCommands
 import FreeCADGui
 import FemGui
 from PySide import QtCore

--- a/src/Mod/Fem/PyGui/_CommandFemMaterialMechanicalNonlinear.py
+++ b/src/Mod/Fem/PyGui/_CommandFemMaterialMechanicalNonlinear.py
@@ -28,7 +28,7 @@ __url__ = "http://www.freecadweb.org"
 #  \ingroup FEM
 
 import FreeCAD
-from FemCommands import FemCommands
+from .FemCommands import FemCommands
 import FreeCADGui
 import FemGui
 from PySide import QtCore

--- a/src/Mod/Fem/PyGui/_CommandFemMaterialSolid.py
+++ b/src/Mod/Fem/PyGui/_CommandFemMaterialSolid.py
@@ -28,7 +28,7 @@ __url__ = "http://www.freecadweb.org"
 #  \ingroup FEM
 
 import FreeCAD
-from FemCommands import FemCommands
+from .FemCommands import FemCommands
 import FreeCADGui
 import FemGui
 from PySide import QtCore

--- a/src/Mod/Fem/PyGui/_CommandFemMesh2Mesh.py
+++ b/src/Mod/Fem/PyGui/_CommandFemMesh2Mesh.py
@@ -28,7 +28,7 @@ __url__ = "http://www.freecadweb.org"
 #  \ingroup FEM
 
 import FreeCAD
-from FemCommands import FemCommands
+from .FemCommands import FemCommands
 
 import FreeCADGui
 from PySide import QtCore

--- a/src/Mod/Fem/PyGui/_CommandFemMeshClear.py
+++ b/src/Mod/Fem/PyGui/_CommandFemMeshClear.py
@@ -28,7 +28,7 @@ __url__ = "http://www.freecadweb.org"
 #  \ingroup FEM
 
 import FreeCAD
-from FemCommands import FemCommands
+from .FemCommands import FemCommands
 import FreeCADGui
 from PySide import QtCore
 

--- a/src/Mod/Fem/PyGui/_CommandFemMeshGmshFromShape.py
+++ b/src/Mod/Fem/PyGui/_CommandFemMeshGmshFromShape.py
@@ -28,7 +28,7 @@ __url__ = "http://www.freecadweb.org"
 #  \ingroup FEM
 
 import FreeCAD
-from FemCommands import FemCommands
+from .FemCommands import FemCommands
 import FreeCADGui
 import FemGui
 from PySide import QtCore

--- a/src/Mod/Fem/PyGui/_CommandFemMeshGroup.py
+++ b/src/Mod/Fem/PyGui/_CommandFemMeshGroup.py
@@ -28,7 +28,7 @@ __url__ = "http://www.freecadweb.org"
 #  \ingroup FEM
 
 import FreeCAD
-from FemCommands import FemCommands
+from .FemCommands import FemCommands
 import FreeCADGui
 from PySide import QtCore
 

--- a/src/Mod/Fem/PyGui/_CommandFemMeshNetgenFromShape.py
+++ b/src/Mod/Fem/PyGui/_CommandFemMeshNetgenFromShape.py
@@ -28,7 +28,7 @@ __url__ = "http://www.freecadweb.org"
 #  \ingroup FEM
 
 import FreeCAD
-from FemCommands import FemCommands
+from .FemCommands import FemCommands
 import FreeCADGui
 import FemGui
 from PySide import QtCore

--- a/src/Mod/Fem/PyGui/_CommandFemMeshPrintInfo.py
+++ b/src/Mod/Fem/PyGui/_CommandFemMeshPrintInfo.py
@@ -28,7 +28,7 @@ __url__ = "http://www.freecadweb.org"
 #  \ingroup FEM
 
 import FreeCAD
-from FemCommands import FemCommands
+from .FemCommands import FemCommands
 import FreeCADGui
 from PySide import QtCore
 

--- a/src/Mod/Fem/PyGui/_CommandFemMeshRegion.py
+++ b/src/Mod/Fem/PyGui/_CommandFemMeshRegion.py
@@ -28,7 +28,7 @@ __url__ = "http://www.freecadweb.org"
 #  \ingroup FEM
 
 import FreeCAD
-from FemCommands import FemCommands
+from .FemCommands import FemCommands
 import FreeCADGui
 from PySide import QtCore
 

--- a/src/Mod/Fem/PyGui/_CommandFemResultShow.py
+++ b/src/Mod/Fem/PyGui/_CommandFemResultShow.py
@@ -28,7 +28,7 @@ __url__ = "http://www.freecadweb.org"
 #  \ingroup FEM
 #  \brief FreeCAD Command show results for FEM workbench
 
-from FemCommands import FemCommands
+from .FemCommands import FemCommands
 import FreeCADGui
 from PySide import QtCore
 

--- a/src/Mod/Fem/PyGui/_CommandFemResultsPurge.py
+++ b/src/Mod/Fem/PyGui/_CommandFemResultsPurge.py
@@ -27,7 +27,7 @@ __url__ = "http://www.freecadweb.org"
 ## @package CommandFemResultsPurge
 #  \ingroup FEM
 
-from FemCommands import FemCommands
+from .FemCommands import FemCommands
 import FemTools
 import FreeCADGui
 from PySide import QtCore

--- a/src/Mod/Fem/PyGui/_CommandFemSolverCalculix.py
+++ b/src/Mod/Fem/PyGui/_CommandFemSolverCalculix.py
@@ -28,7 +28,7 @@ __url__ = "http://www.freecadweb.org"
 #  \ingroup FEM
 
 import FreeCAD
-from FemCommands import FemCommands
+from .FemCommands import FemCommands
 import FreeCADGui
 import FemGui
 from PySide import QtCore

--- a/src/Mod/Fem/PyGui/_CommandFemSolverControl.py
+++ b/src/Mod/Fem/PyGui/_CommandFemSolverControl.py
@@ -27,7 +27,7 @@ __url__ = "http://www.freecadweb.org"
 ## @package CommandFemSolverControl
 #  \ingroup FEM
 
-from FemCommands import FemCommands
+from .FemCommands import FemCommands
 import FreeCADGui
 from PySide import QtCore
 

--- a/src/Mod/Fem/PyGui/_CommandFemSolverRun.py
+++ b/src/Mod/Fem/PyGui/_CommandFemSolverRun.py
@@ -27,7 +27,7 @@ __url__ = "http://www.freecadweb.org"
 ## @package CommandFemSolverRun
 #  \ingroup FEM
 
-from FemCommands import FemCommands
+from .FemCommands import FemCommands
 import FreeCADGui
 from PySide import QtCore, QtGui
 

--- a/src/Mod/Fem/PyGui/_CommandFemSolverZ88.py
+++ b/src/Mod/Fem/PyGui/_CommandFemSolverZ88.py
@@ -28,7 +28,7 @@ __url__ = "http://www.freecadweb.org"
 #  \ingroup FEM
 
 import FreeCAD
-from FemCommands import FemCommands
+from .FemCommands import FemCommands
 import FreeCADGui
 from PySide import QtCore
 


### PR DESCRIPTION
I wanted to wait with this, but I think there won't be a better solution for imports available soon. So this fixes some issues with the imports for the FEM-workbench in python3.