### PR TITLE
Exception improvements 7

### DIFF
--- a/src/App/Application.cpp
+++ b/src/App/Application.cpp
@@ -1162,6 +1162,33 @@ void Application::initTypes(void)
     Base::Type                      ::init();
     Base::BaseClass                 ::init();
     Base::Exception                 ::init();
+    Base::AbortException            ::init();
+    Base::XMLBaseException          ::init();
+    Base::XMLParseException         ::init();
+    Base::FileException             ::init();
+    Base::FileSystemError           ::init();
+    Base::BadFormatError            ::init();
+    Base::MemoryException           ::init();
+    Base::AccessViolation           ::init();
+    Base::AbnormalProgramTermination::init();
+    Base::UnknownProgramOption      ::init();
+    Base::ProgramInformation        ::init();
+    Base::TypeError                 ::init();
+    Base::ValueError                ::init();
+    Base::IndexError                ::init();
+    Base::AttributeError            ::init();
+    Base::RuntimeError              ::init();
+    Base::NotImplementedError       ::init();
+    Base::DivisionByZeroError       ::init();
+    Base::ReferencesError           ::init();
+    Base::ExpressionError           ::init();
+    Base::ParserError               ::init();
+    Base::UnicodeError              ::init();
+    Base::OverflowError             ::init();
+    Base::UnderflowError            ::init();
+    Base::UnitsMismatchError        ::init();
+    Base::CADKernelError            ::init();
+
     Base::Persistence               ::init();
 
     // Complex data classes

--- a/src/Base/Exception.cpp
+++ b/src/Base/Exception.cpp
@@ -80,7 +80,9 @@ void Exception::ReportException (void) const
         str+= " ";
     }
     
-    if(!_file.empty() && !_line.empty()) {
+    std::string _linestr = std::to_string(_line);
+    
+    if(!_file.empty() && !_linestr.empty()) {
         // strip absolute path
         std::size_t pos = _file.find("src");
         
@@ -88,7 +90,7 @@ void Exception::ReportException (void) const
             str+="in ";
             str+= _file.substr(pos);
             str+= ":";
-            str+=_line;
+            str+=_linestr;
         }
     }
 
@@ -213,7 +215,9 @@ void FileException::ReportException (void) const
         str+= " ";
     }
     
-    if(!_file.empty() && !_line.empty()) {
+    std::string _linestr = std::to_string(_line);
+    
+    if(!_file.empty() && !_linestr.empty()) {
         // strip absolute path
         std::size_t pos = _file.find("src");
         
@@ -221,7 +225,7 @@ void FileException::ReportException (void) const
             str+="in ";
             str+= _file.substr(pos);
             str+= ":";
-            str+=_line;
+            str+=_linestr;
         }
     }
     

--- a/src/Base/Exception.cpp
+++ b/src/Base/Exception.cpp
@@ -99,6 +99,8 @@ void Exception::ReportException (void) const
 
 // ---------------------------------------------------------
 
+TYPESYSTEM_SOURCE(Base::AbortException,Base::Exception);
+
 AbortException::AbortException(const char * sMessage)
   : Exception( sMessage )
 {
@@ -121,6 +123,13 @@ const char* AbortException::what() const throw()
 
 // ---------------------------------------------------------
 
+TYPESYSTEM_SOURCE(Base::XMLBaseException,Base::Exception);
+
+XMLBaseException::XMLBaseException()
+: Exception()
+{
+}
+
 XMLBaseException::XMLBaseException(const char * sMessage)
   : Exception(sMessage)
 {
@@ -137,6 +146,8 @@ XMLBaseException::XMLBaseException(const XMLBaseException &inst)
 }
 
 // ---------------------------------------------------------
+
+TYPESYSTEM_SOURCE(Base::XMLParseException,Base::Exception);
 
 XMLParseException::XMLParseException(const char * sMessage)
   : Exception(sMessage)
@@ -164,6 +175,8 @@ const char* XMLParseException::what() const throw()
 }
 
 // ---------------------------------------------------------
+
+TYPESYSTEM_SOURCE(Base::FileException,Base::Exception);
 
 FileException::FileException(const char * sMessage, const char * sFileName)
   : Exception( sMessage ),file(sFileName)
@@ -235,6 +248,13 @@ void FileException::ReportException (void) const
 
 // ---------------------------------------------------------
 
+TYPESYSTEM_SOURCE(Base::FileSystemError,Base::Exception);
+
+FileSystemError::FileSystemError()
+: Exception()
+{
+}
+
 FileSystemError::FileSystemError(const char * sMessage)
   : Exception(sMessage)
 {
@@ -252,6 +272,13 @@ FileSystemError::FileSystemError(const FileSystemError &inst)
 
 // ---------------------------------------------------------
 
+TYPESYSTEM_SOURCE(Base::BadFormatError,Base::Exception);
+
+BadFormatError::BadFormatError()
+: Exception()
+{
+}
+
 BadFormatError::BadFormatError(const char * sMessage)
   : Exception(sMessage)
 {
@@ -268,6 +295,8 @@ BadFormatError::BadFormatError(const BadFormatError &inst)
 }
 
 // ---------------------------------------------------------
+
+TYPESYSTEM_SOURCE(Base::MemoryException,Base::Exception);
 
 MemoryException::MemoryException()
 {
@@ -292,6 +321,7 @@ const char* MemoryException::what() const throw()
 #endif
 
 // ---------------------------------------------------------
+TYPESYSTEM_SOURCE(Base::AccessViolation,Base::Exception);
 
 AccessViolation::AccessViolation()
 {
@@ -314,6 +344,7 @@ AccessViolation::AccessViolation(const AccessViolation &inst)
 }
 
 // ---------------------------------------------------------
+TYPESYSTEM_SOURCE(Base::AbnormalProgramTermination,Base::Exception);
 
 AbnormalProgramTermination::AbnormalProgramTermination()
 {
@@ -336,6 +367,12 @@ AbnormalProgramTermination::AbnormalProgramTermination(const AbnormalProgramTerm
 }
 
 // ---------------------------------------------------------
+TYPESYSTEM_SOURCE(Base::UnknownProgramOption,Base::Exception);
+
+UnknownProgramOption::UnknownProgramOption()
+: Exception()
+{
+}
 
 UnknownProgramOption::UnknownProgramOption(const char * sMessage)
   : Exception(sMessage)
@@ -353,6 +390,12 @@ UnknownProgramOption::UnknownProgramOption(const UnknownProgramOption &inst)
 }
 
 // ---------------------------------------------------------
+TYPESYSTEM_SOURCE(Base::ProgramInformation,Base::Exception);
+
+ProgramInformation::ProgramInformation()
+: Exception()
+{
+}
 
 ProgramInformation::ProgramInformation(const char * sMessage)
   : Exception(sMessage)
@@ -370,6 +413,12 @@ ProgramInformation::ProgramInformation(const ProgramInformation &inst)
 }
 
 // ---------------------------------------------------------
+TYPESYSTEM_SOURCE(Base::TypeError,Base::Exception);
+
+TypeError::TypeError()
+: Exception()
+{
+}
 
 TypeError::TypeError(const char * sMessage)
   : Exception(sMessage)
@@ -387,6 +436,12 @@ TypeError::TypeError(const TypeError &inst)
 }
 
 // ---------------------------------------------------------
+TYPESYSTEM_SOURCE(Base::ValueError,Base::Exception);
+
+ValueError::ValueError()
+: Exception()
+{
+}
 
 ValueError::ValueError(const char * sMessage)
   : Exception(sMessage)
@@ -404,6 +459,12 @@ ValueError::ValueError(const ValueError &inst)
 }
 
 // ---------------------------------------------------------
+TYPESYSTEM_SOURCE(Base::IndexError,Base::Exception);
+
+IndexError::IndexError()
+: Exception()
+{
+}
 
 IndexError::IndexError(const char * sMessage)
   : Exception(sMessage)
@@ -421,6 +482,12 @@ IndexError::IndexError(const IndexError &inst)
 }
 
 // ---------------------------------------------------------
+TYPESYSTEM_SOURCE(Base::AttributeError,Base::Exception);
+
+AttributeError::AttributeError()
+: Exception()
+{
+}
 
 AttributeError::AttributeError(const char * sMessage)
   : Exception(sMessage)
@@ -438,6 +505,12 @@ AttributeError::AttributeError(const AttributeError &inst)
 }
 
 // ---------------------------------------------------------
+TYPESYSTEM_SOURCE(Base::RuntimeError,Base::Exception);
+
+RuntimeError::RuntimeError()
+: Exception()
+{
+}
 
 RuntimeError::RuntimeError(const char * sMessage)
   : Exception(sMessage)
@@ -455,6 +528,12 @@ RuntimeError::RuntimeError(const RuntimeError &inst)
 }
 
 // ---------------------------------------------------------
+TYPESYSTEM_SOURCE(Base::NotImplementedError,Base::Exception);
+
+NotImplementedError::NotImplementedError()
+: Exception()
+{
+}
 
 NotImplementedError::NotImplementedError(const char * sMessage)
   : Exception(sMessage)
@@ -472,6 +551,12 @@ NotImplementedError::NotImplementedError(const NotImplementedError &inst)
 }
 
 // ---------------------------------------------------------
+TYPESYSTEM_SOURCE(Base::DivisionByZeroError,Base::Exception);
+
+DivisionByZeroError::DivisionByZeroError()
+: Exception()
+{
+}
 
 DivisionByZeroError::DivisionByZeroError(const char * sMessage)
   : Exception(sMessage)
@@ -489,6 +574,12 @@ DivisionByZeroError::DivisionByZeroError(const DivisionByZeroError &inst)
 }
 
 // ---------------------------------------------------------
+TYPESYSTEM_SOURCE(Base::ReferencesError,Base::Exception);
+
+ReferencesError::ReferencesError()
+: Exception()
+{
+}
 
 ReferencesError::ReferencesError(const char * sMessage)
   : Exception(sMessage)
@@ -506,6 +597,12 @@ ReferencesError::ReferencesError(const ReferencesError &inst)
 }
 
 // ---------------------------------------------------------
+TYPESYSTEM_SOURCE(Base::ExpressionError,Base::Exception);
+
+ExpressionError::ExpressionError()
+: Exception()
+{
+}
 
 ExpressionError::ExpressionError(const char * sMessage)
   : Exception(sMessage)
@@ -523,6 +620,12 @@ ExpressionError::ExpressionError(const ExpressionError &inst)
 }
 
 // ---------------------------------------------------------
+TYPESYSTEM_SOURCE(Base::ParserError,Base::Exception);
+
+ParserError::ParserError()
+: Exception()
+{
+}
 
 ParserError::ParserError(const char * sMessage)
   : Exception(sMessage)
@@ -540,6 +643,12 @@ ParserError::ParserError(const ParserError &inst)
 }
 
 // ---------------------------------------------------------
+TYPESYSTEM_SOURCE(Base::UnicodeError,Base::Exception);
+
+UnicodeError::UnicodeError()
+: Exception()
+{
+}
 
 UnicodeError::UnicodeError(const char * sMessage)
   : Exception(sMessage)
@@ -557,6 +666,12 @@ UnicodeError::UnicodeError(const UnicodeError &inst)
 }
 
 // ---------------------------------------------------------
+TYPESYSTEM_SOURCE(Base::OverflowError,Base::Exception);
+
+OverflowError::OverflowError()
+: Exception()
+{
+}
 
 OverflowError::OverflowError(const char * sMessage)
   : Exception(sMessage)
@@ -574,6 +689,12 @@ OverflowError::OverflowError(const OverflowError &inst)
 }
 
 // ---------------------------------------------------------
+TYPESYSTEM_SOURCE(Base::UnderflowError,Base::Exception);
+
+UnderflowError::UnderflowError()
+: Exception()
+{
+}
 
 UnderflowError::UnderflowError(const char * sMessage)
   : Exception(sMessage)
@@ -591,6 +712,12 @@ UnderflowError::UnderflowError(const UnderflowError &inst)
 }
 
 // ---------------------------------------------------------
+TYPESYSTEM_SOURCE(Base::UnitsMismatchError,Base::Exception);
+
+UnitsMismatchError::UnitsMismatchError()
+: Exception()
+{
+}
 
 UnitsMismatchError::UnitsMismatchError(const char * sMessage)
   : Exception(sMessage)
@@ -608,7 +735,13 @@ UnitsMismatchError::UnitsMismatchError(const UnitsMismatchError &inst)
 }
 
 // ---------------------------------------------------------
- 
+TYPESYSTEM_SOURCE(Base::CADKernelError,Base::Exception);
+
+CADKernelError::CADKernelError()
+: Exception()
+{
+}
+
 CADKernelError::CADKernelError(const char * sMessage)
 : Exception(sMessage)
 {

--- a/src/Base/Exception.h
+++ b/src/Base/Exception.h
@@ -77,6 +77,9 @@ public:
   // what may differ from the message given by the user in
   // derived classes
   inline std::string getMessage() const;
+  inline std::string getFile() const;
+  inline int getLine() const;
+  inline std::string getFunction() const;
   
   /// setter methods for including debug information
   /// intended to use via macro for autofilling of debugging information
@@ -97,7 +100,7 @@ public: // FIXME: Remove the public keyword
 protected:
   std::string _sErrMsg;
   std::string _file;
-  std::string _line;
+  int _line;
   std::string _function;
 };
 
@@ -572,10 +575,25 @@ inline std::string Exception::getMessage() const
     return _sErrMsg;
 }
 
+inline std::string Exception::getFile() const
+{
+    return _file;
+}
+
+inline int Exception::getLine() const
+{
+    return _line;
+}
+
+inline std::string Exception::getFunction() const
+{
+    return _function;
+}
+
 inline void Exception::setDebugInformation(const std::string & file, const int line, const std::string & function)
 {
     _file = file;
-    _line = std::to_string(line);
+    _line = line;
     _function = function;
 }
 

--- a/src/Base/Exception.h
+++ b/src/Base/Exception.h
@@ -111,6 +111,7 @@ protected:
  */
 class BaseExport AbortException : public Exception
 {
+    TYPESYSTEM_HEADER();
 public:
   /// Construction
   AbortException(const char * sMessage);
@@ -131,8 +132,10 @@ public:
  */
 class BaseExport XMLBaseException : public Exception
 {
+    TYPESYSTEM_HEADER();
 public:
   /// Construction
+  XMLBaseException();
   XMLBaseException(const char * sMessage);
   XMLBaseException(const std::string& sMessage);
   /// Construction
@@ -148,6 +151,7 @@ public:
  */
 class BaseExport XMLParseException : public Exception
 {
+    TYPESYSTEM_HEADER();
 public:
   /// Construction
   XMLParseException(const char * sMessage);
@@ -170,6 +174,7 @@ public:
  */
 class BaseExport FileException : public Exception
 {
+    TYPESYSTEM_HEADER();
 public:
   /// With massage and file name
   FileException(const char * sMessage, const char * sFileName=0);
@@ -200,8 +205,10 @@ protected:
  */
 class BaseExport FileSystemError : public Exception
 {
+    TYPESYSTEM_HEADER();
 public:
   /// Construction
+  FileSystemError();
   FileSystemError(const char * sMessage);
   FileSystemError(const std::string& sMessage);
   /// Construction
@@ -216,8 +223,10 @@ public:
  */
 class BaseExport BadFormatError : public Exception
 {
+    TYPESYSTEM_HEADER();
 public:
   /// Construction
+  BadFormatError();
   BadFormatError(const char * sMessage);
   BadFormatError(const std::string& sMessage);
   /// Construction
@@ -237,6 +246,7 @@ class BaseExport MemoryException : public Exception, virtual public std::bad_all
 class BaseExport MemoryException : public Exception
 #endif
 {
+    TYPESYSTEM_HEADER();
 public:
   /// Construction
   MemoryException();
@@ -256,6 +266,7 @@ public:
  */
 class BaseExport AccessViolation : public Exception
 {
+    TYPESYSTEM_HEADER();
 public:
   /// Construction
   AccessViolation();
@@ -273,6 +284,7 @@ public:
  */
 class BaseExport AbnormalProgramTermination : public Exception
 {
+    TYPESYSTEM_HEADER();
 public:
   /// Construction
   AbnormalProgramTermination();
@@ -290,8 +302,10 @@ public:
  */
 class BaseExport UnknownProgramOption : public Exception
 {
+    TYPESYSTEM_HEADER();
 public:
   /// Construction
+  UnknownProgramOption();
   UnknownProgramOption(const char * sMessage);
   UnknownProgramOption(const std::string& sMessage);
   /// Construction
@@ -306,8 +320,10 @@ public:
  */
 class BaseExport ProgramInformation : public Exception
 {
+    TYPESYSTEM_HEADER();
 public:
   /// Construction
+  ProgramInformation();
   ProgramInformation(const char * sMessage);
   ProgramInformation(const std::string& sMessage);
   /// Construction
@@ -323,8 +339,10 @@ public:
  */
 class BaseExport TypeError : public Exception
 {
+    TYPESYSTEM_HEADER();
 public:
   /// Construction
+  TypeError();
   TypeError(const char * sMessage);
   TypeError(const std::string& sMessage);
   /// Construction
@@ -339,8 +357,10 @@ public:
  */
 class BaseExport ValueError : public Exception
 {
+    TYPESYSTEM_HEADER();
 public:
   /// Construction
+  ValueError();
   ValueError(const char * sMessage);
   ValueError(const std::string& sMessage);
   /// Construction
@@ -355,8 +375,10 @@ public:
  */
 class BaseExport IndexError : public Exception
 {
+    TYPESYSTEM_HEADER();
 public:
   /// Construction
+  IndexError();
   IndexError(const char * sMessage);
   IndexError(const std::string& sMessage);
   /// Construction
@@ -371,8 +393,10 @@ public:
  */
 class BaseExport AttributeError : public Exception
 {
+    TYPESYSTEM_HEADER();
 public:
   /// Construction
+  AttributeError();
   AttributeError(const char * sMessage);
   AttributeError(const std::string& sMessage);
   /// Construction
@@ -387,8 +411,10 @@ public:
  */
 class BaseExport RuntimeError : public Exception
 {
+    TYPESYSTEM_HEADER();
 public:
   /// Construction
+  RuntimeError();
   RuntimeError(const char * sMessage);
   RuntimeError(const std::string& sMessage);
   /// Construction
@@ -403,8 +429,10 @@ public:
  */
 class BaseExport NotImplementedError : public Exception
 {
+    TYPESYSTEM_HEADER();
 public:
   /// Construction
+  NotImplementedError();
   NotImplementedError(const char * sMessage);
   NotImplementedError(const std::string& sMessage);
   /// Construction
@@ -419,8 +447,10 @@ public:
  */
 class BaseExport DivisionByZeroError : public Exception
 {
+    TYPESYSTEM_HEADER();
 public:
   /// Construction
+  DivisionByZeroError();
   DivisionByZeroError(const char * sMessage);
   DivisionByZeroError(const std::string& sMessage);
   /// Construction
@@ -435,8 +465,10 @@ public:
  */
 class BaseExport ReferencesError : public Exception
 {
+    TYPESYSTEM_HEADER();
 public:
   /// Construction
+  ReferencesError();
   ReferencesError(const char * sMessage);
   ReferencesError(const std::string& sMessage);
   /// Construction
@@ -452,8 +484,10 @@ public:
  */
 class BaseExport ExpressionError : public Exception
 {
+    TYPESYSTEM_HEADER();
 public:
   /// Construction
+  ExpressionError();
   ExpressionError(const char * sMessage);
   ExpressionError(const std::string& sMessage);
   /// Construction
@@ -468,8 +502,10 @@ public:
  */
 class BaseExport ParserError : public Exception
 {
+    TYPESYSTEM_HEADER();
 public:
   /// Construction
+  ParserError();
   ParserError(const char * sMessage);
   ParserError(const std::string& sMessage);
   /// Construction
@@ -484,8 +520,10 @@ public:
  */
 class BaseExport UnicodeError : public Exception
 {
+    TYPESYSTEM_HEADER();
 public:
   /// Construction
+  UnicodeError();
   UnicodeError(const char * sMessage);
   UnicodeError(const std::string& sMessage);
   /// Construction
@@ -500,8 +538,10 @@ public:
  */
 class BaseExport OverflowError : public Exception
 {
+    TYPESYSTEM_HEADER();
 public:
   /// Construction
+  OverflowError();
   OverflowError(const char * sMessage);
   OverflowError(const std::string& sMessage);
   /// Construction
@@ -516,8 +556,10 @@ public:
  */
 class BaseExport UnderflowError : public Exception
 {
+    TYPESYSTEM_HEADER();
 public:
   /// Construction
+  UnderflowError();
   UnderflowError(const char * sMessage);
   UnderflowError(const std::string& sMessage);
   /// Construction
@@ -532,8 +574,10 @@ public:
  */
 class BaseExport UnitsMismatchError : public Exception
 {
+    TYPESYSTEM_HEADER();
 public:
   /// Construction
+  UnitsMismatchError();
   UnitsMismatchError(const char * sMessage);
   UnitsMismatchError(const std::string& sMessage);
   /// Construction
@@ -549,8 +593,10 @@ public:
  */
 class BaseExport CADKernelError : public Exception
 {
+    TYPESYSTEM_HEADER();
 public:
     /// Construction
+    CADKernelError();
     CADKernelError(const char * sMessage);
     CADKernelError(const std::string& sMessage);
     /// Construction

--- a/src/Base/Interpreter.h
+++ b/src/Base/Interpreter.h
@@ -72,10 +72,13 @@ public:
     const std::string &getStackTrace(void) const {return _stackTrace;}
     const std::string &getErrorType(void) const {return _errorType;}
     void ReportException (void) const;
+    
+    static void ThrowException();
 
 protected:
     std::string _stackTrace;
     std::string _errorType;
+    unsigned int _classindex;
 };
 
 /**

--- a/src/Base/PyTools.c
+++ b/src/Base/PyTools.c
@@ -17,7 +17,6 @@ is provided on an as is basis, without warranties of any kind.
 #include <compile.h>
 #include <eval.h>
 
-
 #if PY_VERSION_HEX <= 0x02050000
 #error "Use Python2.5.x or higher"
 #endif
@@ -214,10 +213,16 @@ FC_OS_LINUX: This is dangerous. How about PY_EXCEPT_MAX?
 */
 
 /* exception text is here after PP_Fetch_Error_Text call */
-char PP_last_error_type[MAX];           /* exception name text */
-char PP_last_error_info[MAX];           /* exception data text */
-char PP_last_error_trace[MAX];          /* exception traceback text */
-PyObject *PP_last_traceback = NULL;     /* saved exception traceback object */
+char PP_last_error_type[MAX];               /* exception name text */
+char PP_last_error_info[MAX];               /* exception data text */
+char PP_last_error_file[MAX];               /* exception file text */
+unsigned int PP_last_error_line;            /* exception line */
+unsigned int PP_last_error_classindex;      /* exception class type index (key of Base::Type) */
+char PP_last_error_function[MAX];           /* exception function text */
+char PP_last_error_message[MAX];            /* exception message text */
+char PP_last_error_trace[MAX];              /* exception traceback text */
+PyObject *PP_last_traceback = NULL;         /* saved exception traceback object */
+bool PP_last_error_isDictType = false;
 
 
 void PP_Fetch_Error_Text()
@@ -226,7 +231,7 @@ void PP_Fetch_Error_Text()
     //assert(PyErr_Occurred());
 
     char *tempstr;
-    PyObject *errobj, *errdata, *errtraceback, *pystring;
+    PyObject *errobj, *errdata, *errtraceback, *pystring, *pydictobject;
 
     /* get latest python exception information */
     /* this also clears the current exception  */
@@ -245,13 +250,45 @@ void PP_Fetch_Error_Text()
         strncpy(PP_last_error_type, PyString_AsString(pystring), MAX); /*Py->C*/
         PP_last_error_type[MAX-1] = '\0';
     }
-    else 
+    else
+    {
         strcpy(PP_last_error_type, "<unknown exception type>");
+    }
+    
     Py_XDECREF(pystring);
 
 
     pystring = NULL;
+    pydictobject = NULL;
     if (errdata != NULL &&
+        (PyDict_Check(errdata)) )                      /* str() increfs */
+    {
+        pystring = PyDict_GetItemString(errdata,"swhat");
+        strncpy(PP_last_error_info, PyString_AsString(pystring), MAX); /*Py->C*/
+        PP_last_error_info[MAX-1] = '\0';
+        
+        pystring = PyDict_GetItemString(errdata,"sfile");
+        strncpy(PP_last_error_file, PyString_AsString(pystring), MAX); /*Py->C*/
+        PP_last_error_file[MAX-1] = '\0';
+        
+        pystring = PyDict_GetItemString(errdata,"sfunction");
+        strncpy(PP_last_error_function, PyString_AsString(pystring), MAX); /*Py->C*/
+        PP_last_error_function[MAX-1] = '\0';
+        
+        pystring = PyDict_GetItemString(errdata,"sErrMsg");
+        strncpy(PP_last_error_message, PyString_AsString(pystring), MAX); /*Py->C*/
+        PP_last_error_message[MAX-1] = '\0';
+        
+        pystring = PyDict_GetItemString(errdata,"iline");
+        PP_last_error_line = PyInt_AsLong(pystring);
+        
+        pystring = PyDict_GetItemString(errdata,"classindex");
+        PP_last_error_classindex = PyInt_AsLong(pystring);
+        
+        PP_last_error_isDictType = true;
+        
+    }
+    else if (errdata != NULL &&
        (pystring = PyObject_Str(errdata)) != NULL &&     /* str(): increfs */
        (PyString_Check(pystring)) )
     {
@@ -260,7 +297,9 @@ void PP_Fetch_Error_Text()
     }
     else 
         strcpy(PP_last_error_info, "<unknown exception data>");
+    
     Py_XDECREF(pystring);
+    Py_XDECREF(pydictobject);
 
 
     /* convert traceback to string */ 

--- a/src/Base/PyTools.h
+++ b/src/Base/PyTools.h
@@ -73,6 +73,8 @@ extern "C" {             /* a C library, but callable from C++ */
 #	undef  _POSIX_C_SOURCE
 #endif // (re-)defined in pyconfig.h
 #include <Python.h>
+    
+#include <stdbool.h>
 
 extern int PP_RELOAD;    /* 1=reload py modules when attributes referenced */
 extern int PP_DEBUG;     /* 1=start debugger when string/function/member run */
@@ -179,6 +181,15 @@ extern void PP_Fetch_Error_Text();    /* fetch (and clear) exception */
 extern char PP_last_error_type[];     /* exception name text */
 extern char PP_last_error_info[];     /* exception data text */
 extern char PP_last_error_trace[];    /* exception traceback text */
+
+extern char PP_last_error_file[];               /* exception file text */
+extern unsigned int PP_last_error_line;            /* exception line */
+extern unsigned int PP_last_error_classindex;      /* exception class type index (key of Base::Type) */
+extern char PP_last_error_function[];           /* exception function text */
+extern char PP_last_error_message[];            /* exception message text */
+extern bool PP_last_error_isDictType;
+
+
 
 extern PyObject *PP_last_traceback;   /* saved exception traceback object */
 

--- a/src/Base/Type.h
+++ b/src/Base/Type.h
@@ -87,10 +87,13 @@ public:
   void *createInstance(void);
   /// creates a instance of the named type
   static void *createInstanceByName(const char* TypeName, bool bLoadModule=false);
+  /// creates a instance of the type with the given index key 
+  static void *createInstanceByKey(unsigned int key, bool bLoadModule=false);
 
   typedef void * (*instantiationMethod)(void);
 
   static Type fromName(const char *name);
+  static Type fromKey(unsigned int key);
   const char *getName(void) const;
   const Type getParent(void) const;
   bool isDerivedFrom(const Type type) const;
@@ -119,7 +122,7 @@ public:
 
 protected:
   static std::string getModuleName(const char* ClassName);
-
+  static std::string getModuleName(unsigned int key);
 
 private:
 

--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -4099,32 +4099,33 @@ bool SketchObject::modifyBSplineKnotMultiplicity(int GeoId, int knotIndex, int m
     #endif
     
     if (GeoId < 0 || GeoId > getHighestCurveIndex())
-        throw Base::ValueError("BSpline GeoId is out of bounds.");
+        //throw Base::ValueError("BSpline GeoId is out of bounds.");
+        THROWM(Base::ValueError,"BSpline GeoId is out of bounds.")
     
     if (multiplicityincr == 0) // no change in multiplicity
-        throw Base::ValueError("You are requesting no change in knot multiplicity.");
+        THROWM(Base::ValueError,"You are requesting no change in knot multiplicity.")
     
     const Part::Geometry *geo = getGeometry(GeoId);
     
     if(geo->getTypeId() != Part::GeomBSplineCurve::getClassTypeId())
-        throw Base::TypeError("The GeoId provided is not a B-spline curve");
+        THROWM(Base::TypeError,"The GeoId provided is not a B-spline curve");
     
     const Part::GeomBSplineCurve *bsp = static_cast<const Part::GeomBSplineCurve *>(geo);
     
     int degree = bsp->getDegree();
     
     if( knotIndex > bsp->countKnots() || knotIndex < 1 ) // knotindex in OCC 1 -> countKnots
-        throw Base::ValueError("The knot index is out of bounds. Note that in accordance with OCC notation, the first knot has index 1 and not zero.");
+        THROWM(Base::ValueError,"The knot index is out of bounds. Note that in accordance with OCC notation, the first knot has index 1 and not zero.");
 
     Part::GeomBSplineCurve *bspline;
 
     int curmult = bsp->getMultiplicity(knotIndex);
     
     if ( (curmult + multiplicityincr) > degree ) // zero is removing the knot, degree is just positional continuity
-        throw Base::ValueError("The multiplicity cannot be increased beyond the degree of the b-spline.");
+        THROWM(Base::ValueError,"The multiplicity cannot be increased beyond the degree of the b-spline.");
     
     if ( (curmult + multiplicityincr) < 0) // zero is removing the knot, degree is just positional continuity
-        throw Base::ValueError("The multiplicity cannot be decreased beyond zero.");
+        THROWM(Base::ValueError,"The multiplicity cannot be decreased beyond zero.");
     
     try {
 

--- a/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp
+++ b/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp
@@ -576,9 +576,14 @@ void CmdSketcherIncreaseKnotMultiplicity::activated(int iMsg)
                     // particularly B-spline GeoID might have changed.
 
                 }
+                catch (const Base::ValueError& e) {
+                    QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Error"),
+                                         QObject::tr(e.getMessage().c_str()));
+                    getSelection().clearSelection();
+                }                
                 catch (const Base::Exception& e) {
                     QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Error"),
-                                         QObject::tr(getStrippedPythonExceptionString(e).c_str()));
+                                         QObject::tr(e.getMessage().c_str()));
                     getSelection().clearSelection();
                 }
 

--- a/src/Tools/generateTemplates/templateClassPyExport.py
+++ b/src/Tools/generateTemplates/templateClassPyExport.py
@@ -494,12 +494,19 @@ PyObject * @self.export.Name@::staticCallback_@i.Name@ (PyObject *self, PyObject
     }
     catch(const Base::Exception& e) // catch the FreeCAD exceptions
     {
-        std::string str;
-        str += "FreeCAD exception thrown (";
-        str += e.what();
-        str += ")";
+        PyObject *edict = PyDict_New();
+
+        PyDict_SetItemString(edict, "classindex", PyInt_FromLong(e.getTypeId().getKey()));
+        PyDict_SetItemString(edict, "sErrMsg", PyString_FromString(e.getMessage().c_str()));
+        PyDict_SetItemString(edict, "sfile", PyString_FromString(e.getFile().c_str()));
+        PyDict_SetItemString(edict, "iline", PyInt_FromLong(e.getLine()));
+        PyDict_SetItemString(edict, "sfunction", PyString_FromString(e.getFunction().c_str()));
+        PyDict_SetItemString(edict, "swhat", PyString_FromString(e.what()));
+        
         e.ReportException();
-        PyErr_SetString(Base::BaseExceptionFreeCADError,str.c_str());
+        PyErr_SetObject(Base::BaseExceptionFreeCADError, edict);
+        Py_DECREF(edict);
+        
         return NULL;
     }
     catch(const boost::filesystem::filesystem_error& e) // catch boost filesystem exception
@@ -684,12 +691,18 @@ PyObject *@self.export.Name@::_getattr(char *attr)				// __getattr__ function: n
 #ifndef DONT_CATCH_CXX_EXCEPTIONS 
     catch(const Base::Exception& e) // catch the FreeCAD exceptions
     {
-        std::string str;
-        str += "FreeCAD exception thrown (";
-        str += e.what();
-        str += ")";
+        PyObject *edict = PyDict_New();
+
+        PyDict_SetItemString(edict, "classindex", PyInt_FromLong(e.getTypeId().getKey()));
+        PyDict_SetItemString(edict, "sErrMsg", PyString_FromString(e.getMessage().c_str()));
+        PyDict_SetItemString(edict, "sfile", PyString_FromString(e.getFile().c_str()));
+        PyDict_SetItemString(edict, "iline", PyInt_FromLong(e.getLine()));
+        PyDict_SetItemString(edict, "sfunction", PyString_FromString(e.getFunction().c_str()));
+        PyDict_SetItemString(edict, "swhat", PyString_FromString(e.what()));
+        
         e.ReportException();
-        PyErr_SetString(Base::BaseExceptionFreeCADError,str.c_str());
+        PyErr_SetObject(Base::BaseExceptionFreeCADError, edict);
+        Py_DECREF(edict);
         return NULL;
     }
     catch(const std::exception& e) // catch other c++ exceptions
@@ -715,12 +728,19 @@ PyObject *@self.export.Name@::_getattr(char *attr)				// __getattr__ function: n
 #else  // DONT_CATCH_CXX_EXCEPTIONS  
     catch(const Base::Exception& e) // catch the FreeCAD exceptions
     {
-        std::string str;
-        str += "FreeCAD exception thrown (";
-        str += e.what();
-        str += ")";
+        PyObject *edict = PyDict_New();
+
+        PyDict_SetItemString(edict, "classindex", PyInt_FromLong(e.getTypeId().getKey()));
+        PyDict_SetItemString(edict, "sErrMsg", PyString_FromString(e.getMessage().c_str()));
+        PyDict_SetItemString(edict, "sfile", PyString_FromString(e.getFile().c_str()));
+        PyDict_SetItemString(edict, "iline", PyInt_FromLong(e.getLine()));
+        PyDict_SetItemString(edict, "sfunction", PyString_FromString(e.getFunction().c_str()));
+        PyDict_SetItemString(edict, "swhat", PyString_FromString(e.what()));
+        
         e.ReportException();
-        PyErr_SetString(Base::BaseExceptionFreeCADError,str.c_str());
+        PyErr_SetObject(Base::BaseExceptionFreeCADError, edict);
+        Py_DECREF(edict);
+        
         return NULL;
     }
     catch(const Py::Exception&)
@@ -758,12 +778,19 @@ int @self.export.Name@::_setattr(char *attr, PyObject *value) // __setattr__ fun
 #ifndef DONT_CATCH_CXX_EXCEPTIONS 
     catch(const Base::Exception& e) // catch the FreeCAD exceptions
     {
-        std::string str;
-        str += "FreeCAD exception thrown (";
-        str += e.what();
-        str += ")";
+        PyObject *edict = PyDict_New();
+
+        PyDict_SetItemString(edict, "classindex", PyInt_FromLong(e.getTypeId().getKey()));
+        PyDict_SetItemString(edict, "sErrMsg", PyString_FromString(e.getMessage().c_str()));
+        PyDict_SetItemString(edict, "sfile", PyString_FromString(e.getFile().c_str()));
+        PyDict_SetItemString(edict, "iline", PyInt_FromLong(e.getLine()));
+        PyDict_SetItemString(edict, "sfunction", PyString_FromString(e.getFunction().c_str()));
+        PyDict_SetItemString(edict, "swhat", PyString_FromString(e.what()));
+        
         e.ReportException();
-        PyErr_SetString(Base::BaseExceptionFreeCADError,str.c_str());
+        PyErr_SetObject(Base::BaseExceptionFreeCADError, edict);
+        Py_DECREF(edict);
+        
         return -1;
     }
     catch(const std::exception& e) // catch other c++ exceptions
@@ -789,12 +816,18 @@ int @self.export.Name@::_setattr(char *attr, PyObject *value) // __setattr__ fun
 #else  // DONT_CATCH_CXX_EXCEPTIONS  
     catch(const Base::Exception& e) // catch the FreeCAD exceptions
     {
-        std::string str;
-        str += "FreeCAD exception thrown (";
-        str += e.what();
-        str += ")";
+        PyObject *edict = PyDict_New();
+
+        PyDict_SetItemString(edict, "classindex", PyInt_FromLong(e.getTypeId().getKey()));
+        PyDict_SetItemString(edict, "sErrMsg", PyString_FromString(e.getMessage().c_str()));
+        PyDict_SetItemString(edict, "sfile", PyString_FromString(e.getFile().c_str()));
+        PyDict_SetItemString(edict, "iline", PyInt_FromLong(e.getLine()));
+        PyDict_SetItemString(edict, "sfunction", PyString_FromString(e.getFunction().c_str()));
+        PyDict_SetItemString(edict, "swhat", PyString_FromString(e.what()));
+        
         e.ReportException();
-        PyErr_SetString(Base::BaseExceptionFreeCADError,str.c_str());
+        PyErr_SetObject(Base::BaseExceptionFreeCADError, edict);
+        Py_DECREF(edict);
         return -1;
     }
     catch(const Py::Exception&)


### PR DESCRIPTION
For building, review and comment.

This PR is a possible approach to convert Base::Exception derivatives into python (removing the str prefix) and after python, rethrowing the original derivative exception type. All debug information is tunneled through python.

It makes use of the PyErr_setObject instead of setString to pass a PyDict with the extra information.

It is is backwards compatible with setString (checks for dictionary, if not present it acts according to the legacy behaviour).
