### PR TITLE
Path.Area: new feature and bug fixes

### DIFF
--- a/src/Mod/Path/App/Area.cpp
+++ b/src/Mod/Path/App/Area.cpp
@@ -1722,7 +1722,7 @@ TopoDS_Shape Area::makePocket(int index, PARAM_ARGS(PARAM_FARG,AREA_PARAMS_POCKE
     if(!done) {
         CAreaPocketParams params(
                 tool_radius,extra_offset,stepover,from_center,pm,angle);
-        CArea in(*myArea),out;
+        CArea in(*myArea);
         // MakePcoketToolPath internally uses libarea Offset which somehow demands
         // reorder before input, otherwise nothing is shown.
         in.Reorder();

--- a/src/Mod/Path/App/Area.cpp
+++ b/src/Mod/Path/App/Area.cpp
@@ -977,6 +977,7 @@ std::list<TopoDS_Wire> Area::project(const TopoDS_Shape &solid)
     area.myParams.Explode = false;
     area.myParams.FitArcs = false;
     area.myParams.Reorient = false;
+    area.myParams.Outline = false;
     area.myParams.Coplanar = CoplanarNone;
     area.add(joiner.comp, OperationUnion);
     TopoDS_Shape shape = area.getShape();
@@ -1356,6 +1357,19 @@ void Area::build() {
             area.add(joiner.comp,OperationCompound);
             area.build();
             myArea = std::move(area.myArea);
+        }
+
+        if(myParams.Outline) {
+            myArea->Reorder();
+            for(auto it=myArea->m_curves.begin(),itNext=it;
+                it!=myArea->m_curves.end();
+                it=itNext)
+            {
+                ++itNext;
+                auto &curve = *it;
+                if(curve.IsClosed() && curve.IsClockwise())
+                    myArea->m_curves.erase(it);
+            }
         }
 
         TIME_TRACE(t,"prepare");

--- a/src/Mod/Path/App/Area.cpp
+++ b/src/Mod/Path/App/Area.cpp
@@ -731,7 +731,14 @@ struct WireJoiner {
         std::map<int,TopoDS_Edge> edgesToVisit;
         int count = 0;
         for(const auto &info : edges) {
-            if(BRep_Tool::IsClosed(info.edge)){
+#if OCC_VERSION_HEX >= 0x070000
+            if(BRep_Tool::IsClosed(info.edge))
+#else
+            gp_Pnt p1,p2;
+            getEndPoints(info.edge,p1,p2);
+            if(p1.SquareDistance(p2)<Precision::SquareConfusion())
+#endif
+            {
                 builder.Add(comp,BRepBuilderAPI_MakeWire(info.edge).Wire());
                 ++count;
             }else

--- a/src/Mod/Path/App/Area.h
+++ b/src/Mod/Path/App/Area.h
@@ -446,7 +446,7 @@ public:
             const gp_Pnt *pstart=NULL, gp_Pnt *pend=NULL,
             PARAM_ARGS_DEF(PARAM_FARG,AREA_PARAMS_PATH));
 
-    static int getWireDirection(const TopoDS_Shape& wire, const gp_Pln *plane=0);
+    static void setWireOrientation(TopoDS_Wire& wire, const gp_Dir &dir, bool ccw);
 
     PARAM_ENUM_DECLARE(AREA_PARAMS_PATH)
 

--- a/src/Mod/Path/App/Area.h
+++ b/src/Mod/Path/App/Area.h
@@ -125,6 +125,7 @@ inline std::chrono::TIME_UNIT getDuration(TIME_POINT &t)
 
 class CArea;
 class CCurve;
+class Bnd_Box;
 
 namespace Path
 {
@@ -213,7 +214,8 @@ protected:
     bool myHaveFace;
     bool myHaveSolid;
     bool myShapeDone;
-    int mySkippedShapes;
+    bool myProjecting;
+    mutable int mySkippedShapes;
 
     static bool s_aborting;
     static AreaStaticParams s_params;
@@ -246,7 +248,7 @@ protected:
 
     TopoDS_Shape findPlane(const TopoDS_Shape &shape, gp_Trsf &trsf);
 
-    std::list<TopoDS_Wire> project(const TopoDS_Shape &solid);
+    std::list<Shape> getProjectedShapes(const gp_Trsf &trsf, bool inverse=true) const;
 
 public:
     /** Declare all parameters defined in #AREA_PARAMS_ALL as member variable */
@@ -279,7 +281,7 @@ public:
      * If no workplane is set using setPlane(), the active workplane is derived from
      * the added children shapes using the same algorithm empolyed by setPlane().
      */
-    TopoDS_Shape getPlane(gp_Trsf *trsf = NULL);
+    TopoDS_Shape getPlane(gp_Trsf *trsf=0);
 
     /** Add a child shape with given operation code 
      *
@@ -445,6 +447,8 @@ public:
     static void toPath(Toolpath &path, const std::list<TopoDS_Shape> &shapes,
             const gp_Pnt *pstart=NULL, gp_Pnt *pend=NULL,
             PARAM_ARGS_DEF(PARAM_FARG,AREA_PARAMS_PATH));
+
+    static int project(TopoDS_Shape &out, const TopoDS_Shape &in, const AreaParams *params=0);
 
     static void setWireOrientation(TopoDS_Wire& wire, const gp_Dir &dir, bool ccw);
 

--- a/src/Mod/Path/App/Area.h
+++ b/src/Mod/Path/App/Area.h
@@ -227,7 +227,7 @@ protected:
     void addToBuild(CArea &area, const TopoDS_Shape &shape);
 
     /** Called internally to obtain the combained children shapes */
-    TopoDS_Shape toShape(CArea &area, short fill);
+    TopoDS_Shape toShape(CArea &area, short fill, int reorient=0);
 
     /** Obtain a list of offseted areas
      *
@@ -299,7 +299,7 @@ public:
      * If more than one offset is requested, a compound shape is return
      * containing all offset shapes as wires regardless of \c Fill setting.
      */
-    TopoDS_Shape makeOffset(int index=-1, PARAM_ARGS_DEF(PARAM_FARG,AREA_PARAMS_OFFSET));
+    TopoDS_Shape makeOffset(int index=-1, PARAM_ARGS_DEF(PARAM_FARG,AREA_PARAMS_OFFSET), int reoirent=0);
 
     /** Make a pocket of the combined shape
      *
@@ -401,7 +401,7 @@ public:
      * its original position.
      * */
     static TopoDS_Shape toShape(const CArea &area, bool fill, 
-            const gp_Trsf *trsf=NULL);
+            const gp_Trsf *trsf=NULL, int reoirent=0);
 
     /** Convert a single curve into an OCC wire
      *
@@ -409,7 +409,7 @@ public:
      * \arg \c trsf: optional transform matrix to transform the shape back into
      * its original position.
      * */
-    static TopoDS_Wire toShape(const CCurve &curve, const gp_Trsf *trsf=NULL);
+    static TopoDS_Wire toShape(const CCurve &curve, const gp_Trsf *trsf=NULL, int reorient=0);
 
     /** Check if two OCC shape is coplanar */
     static bool isCoplanar(const TopoDS_Shape &s1, const TopoDS_Shape &s2);

--- a/src/Mod/Path/App/AreaParams.h
+++ b/src/Mod/Path/App/AreaParams.h
@@ -219,9 +219,9 @@
     ((double, retraction, Retraction, 0.0,"Tool retraction absolute coordinate along retraction axis",\
         App::PropertyLength))\
     ((enum, retract_axis, RetractAxis, 2,"Tool retraction axis",(X)(Y)(Z)))\
-    ((double, clearance, Clearance, 0.0,\
+    ((double, resume_height, ResumeHeight, 0.0,\
         "When return from last retraction, this gives the pause height relative to the Z\n"\
-        "value of the next move",App::PropertyLength))\
+        "value of the next move.", App::PropertyLength))\
     ((double,segmentation,Segmentation,0.0,\
         "Break long curves into segments of this length. One use case is for PCB autolevel,\n"\
         "so that more correction points can be inserted",App::PropertyLength)) \

--- a/src/Mod/Path/App/AreaParams.h
+++ b/src/Mod/Path/App/AreaParams.h
@@ -60,6 +60,8 @@
         "but 'Check' only gives warning.",(None)(Check)(Force)))\
     ((bool,reorient,Reorient,true,\
         "Re-orient closed wires in wire only shapes so that inner wires become holes."))\
+    ((bool,outline,Outline,false,\
+        "Remove all inner wires (holes) before output the final shape"))\
     ((bool,explode,Explode,false,\
         "If true, Area will explode the first shape into disconnected open edges, \n"\
         "with all curves discretized, so that later operations like 'Difference' \n"\

--- a/src/Mod/Path/App/AreaParams.h
+++ b/src/Mod/Path/App/AreaParams.h
@@ -190,6 +190,11 @@
         "arc encountered.",\
         (None)(Auto)(XY)(ZX)(YZ)(Variable)))
 
+#define AREA_PARAMS_ORIENTATION \
+    ((enum, orientation, Orientation, 0, "Enforce loop orientation\n"\
+        "'Normal' means CCW for outer wires when looking against the positive axis direction, \n"\
+        "and CW for inner wires. 'Reversed' means the other way round", (Normal)(Reversed)))
+
 /** Area wire sorting parameters */
 #define AREA_PARAMS_SORT \
     ((enum, sort_mode, SortMode, 1, "Wire sorting mode to optimize travel distance.\n"\
@@ -202,9 +207,7 @@
     ((double, abscissa, SortAbscissa, 3.0, "Controls vertex sampling on wire for nearest point searching\n"\
         "The sampling is dong using OCC GCPnts_UniformAbscissa",App::PropertyLength))\
     ((short, nearest_k, NearestK, 3, "Nearest k sampling vertices are considered during sorting"))\
-    ((enum, orientation, Orientation, 0, "Enforce loop orientation\n"\
-        "Note the CW/CCW here specifies the outer wire orientation. For inner wires (holes), the\n"\
-        "enforced orientation is reversed", (None)(CW)(CCW)))\
+    AREA_PARAMS_ORIENTATION \
     ((enum, direction, Direction, 0, "Enforce open path direction",\
         (None)(XPositive)(XNegative)(YPositive)(YNegative)(ZPositive)(ZNegative)))
        


### PR DESCRIPTION
Summary:

* Zigzag pocket mode fix
* Rapid path generation parameter `clearance` renamed to `resume_height`
* Fixed path orientation setting
* Fixed work plane surface normal problem on reversed face
* Added new parameter `Outline` to obtain face and/or solid shape outline.