### PR TITLE
#0002499

### DIFF
--- a/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp
+++ b/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp
@@ -1121,6 +1121,8 @@ static const char *cursor_createcopy[]={
                 unsetCursor();
                 resetPositionText();
                 
+                int currentgeoid = static_cast<Sketcher::SketchObject *>(sketchgui->getObject())->getHighestCurveIndex();
+                
                 Gui::Command::openCommand("Create copy of geometry");
                 
                 ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Mod/Sketcher");
@@ -1142,7 +1144,7 @@ static const char *cursor_createcopy[]={
                 
                 // add auto constraints for the destination copy
                 if (sugConstr1.size() > 0) {
-                    createAutoConstraints(sugConstr1, OriginGeoId+nElements, OriginPos);
+                    createAutoConstraints(sugConstr1, currentgeoid+nElements, OriginPos);
                     sugConstr1.clear();
                 }
                 


### PR DESCRIPTION
https://freecadweb.org/tracker/view.php?id=2499

The autoconstraint setting was wishful thinking. It would only work if the to be copied geometry comprised the last geometry element of the sketch.

