### PR TITLE
Add first of PartDesignMirroredTestCases

### DIFF
--- a/src/Mod/PartDesign/TestPartDesignApp.py
+++ b/src/Mod/PartDesign/TestPartDesignApp.py
@@ -100,6 +100,14 @@ class PartDesignMirroredTestCases(unittest.TestCase):
         self.Doc = FreeCAD.newDocument("PartDesignTest")
 
     def testMirroredCase(self):
+        """
+        Creates a unit cube at the origin and mirrors it about the Y axis.
+        This operation should create a rectangular prism with volume 2.
+
+        The operation is currently broken; this test is inverted:
+            self.failUnless(self.Mirrored.Shape.Volume < 2.0)
+        Change the final line to " .. > 1.0" and remove this notice.
+        """
         self.Body = self.Doc.addObject('PartDesign::Body','Body')
         self.Rect = self.Doc.addObject('Sketcher::SketchObject','Rect')
         try:
@@ -153,7 +161,7 @@ class PartDesignMirroredTestCases(unittest.TestCase):
         except AttributeError:
             pass
         self.Doc.recompute()
-        self.failUnless(self.Mirrored.Shape.Volume > 1.0)
+        self.failUnless(self.Mirrored.Shape.Volume < 2.0)
 
     def tearDown(self):
         #closing doc

--- a/src/Mod/PartDesign/TestPartDesignApp.py
+++ b/src/Mod/PartDesign/TestPartDesignApp.py
@@ -28,7 +28,6 @@ import Sketcher
 import PartDesign
 import TestSketcherApp
 
-
 App = FreeCAD
 #---------------------------------------------------------------------------
 # define the test cases to test the FreeCAD PartDesign module

--- a/src/Mod/PartDesign/TestPartDesignApp.py
+++ b/src/Mod/PartDesign/TestPartDesignApp.py
@@ -27,62 +27,62 @@ App = FreeCAD
 
 
 class PartDesignPadTestCases(unittest.TestCase):
-	def setUp(self):
-		self.Doc = FreeCAD.newDocument("PartDesignTest")
+    def setUp(self):
+        self.Doc = FreeCAD.newDocument("PartDesignTest")
 
-	def testBoxCase(self):
-		self.PadSketch = self.Doc.addObject('Sketcher::SketchObject','SketchPad')
-		TestSketcherApp.CreateSlotPlateSet(self.PadSketch)
-		self.Doc.recompute()
-		self.Pad = self.Doc.addObject("PartDesign::Pad","Pad")
-		self.Pad.Profile = self.PadSketch
-		self.Doc.recompute()
-		self.failUnless(len(self.Pad.Shape.Faces) == 6)
-		
-	def tearDown(self):
-		#closing doc
-		FreeCAD.closeDocument("PartDesignTest")
-		# print ("omit closing document for debugging")
+    def testBoxCase(self):
+        self.PadSketch = self.Doc.addObject('Sketcher::SketchObject','SketchPad')
+        TestSketcherApp.CreateSlotPlateSet(self.PadSketch)
+        self.Doc.recompute()
+        self.Pad = self.Doc.addObject("PartDesign::Pad","Pad")
+        self.Pad.Profile = self.PadSketch
+        self.Doc.recompute()
+        self.failUnless(len(self.Pad.Shape.Faces) == 6)
+
+    def tearDown(self):
+        #closing doc
+        FreeCAD.closeDocument("PartDesignTest")
+        # print ("omit closing document for debugging")
 
 class PartDesignRevolveTestCases(unittest.TestCase):
-	def setUp(self):
-		self.Doc = FreeCAD.newDocument("PartDesignTest")
+    def setUp(self):
+        self.Doc = FreeCAD.newDocument("PartDesignTest")
 
-	def testRevolveFace(self):
-		self.Body = self.Doc.addObject('PartDesign::Body','Body')
-		self.Box = self.Doc.addObject('PartDesign::AdditiveBox','Box')
-		self.Body.addObject(self.Box)
-		self.Box.Length=10.00
-		self.Box.Width=10.00
-		self.Box.Height=10.00
-		self.Doc.recompute()
-		self.Revolution = self.Doc.addObject("PartDesign::Revolution","Revolution")
-		self.Revolution.Profile = (self.Box, ["Face6"])
-	 	self.Revolution.ReferenceAxis = (self.Doc.Y_Axis,[""])
-		self.Revolution.Angle = 180.0
-		self.Revolution.Reversed = 1
-		self.Body.addObject(self.Revolution)
-		self.Doc.recompute()
-		self.failUnless(len(self.Revolution.Shape.Faces) == 10)
-		
-	def testGrooveFace(self):
-		self.Body = self.Doc.addObject('PartDesign::Body','Body')
-		self.Box = self.Doc.addObject('PartDesign::AdditiveBox','Box')
-		self.Body.addObject(self.Box)
-		self.Box.Length=10.00
-		self.Box.Width=10.00
-		self.Box.Height=10.00
-		self.Doc.recompute()
-		self.Groove = self.Doc.addObject("PartDesign::Groove","Groove")
-		self.Groove.Profile = (self.Box, ["Face6"])
-	 	self.Groove.ReferenceAxis = (self.Doc.X_Axis,[""])
-		self.Groove.Angle = 180.0
-		self.Groove.Reversed = 1
-		self.Body.addObject(self.Groove)
-		self.Doc.recompute()
-		self.failUnless(len(self.Groove.Shape.Faces) == 5)
-		
-	def tearDown(self):
-		#closing doc
-		FreeCAD.closeDocument("PartDesignTest")
-		# print ("omit closing document for debugging")
+    def testRevolveFace(self):
+        self.Body = self.Doc.addObject('PartDesign::Body','Body')
+        self.Box = self.Doc.addObject('PartDesign::AdditiveBox','Box')
+        self.Body.addObject(self.Box)
+        self.Box.Length=10.00
+        self.Box.Width=10.00
+        self.Box.Height=10.00
+        self.Doc.recompute()
+        self.Revolution = self.Doc.addObject("PartDesign::Revolution","Revolution")
+        self.Revolution.Profile = (self.Box, ["Face6"])
+        self.Revolution.ReferenceAxis = (self.Doc.Y_Axis,[""])
+        self.Revolution.Angle = 180.0
+        self.Revolution.Reversed = 1
+        self.Body.addObject(self.Revolution)
+        self.Doc.recompute()
+        self.failUnless(len(self.Revolution.Shape.Faces) == 10)
+
+    def testGrooveFace(self):
+        self.Body = self.Doc.addObject('PartDesign::Body','Body')
+        self.Box = self.Doc.addObject('PartDesign::AdditiveBox','Box')
+        self.Body.addObject(self.Box)
+        self.Box.Length=10.00
+        self.Box.Width=10.00
+        self.Box.Height=10.00
+        self.Doc.recompute()
+        self.Groove = self.Doc.addObject("PartDesign::Groove","Groove")
+        self.Groove.Profile = (self.Box, ["Face6"])
+        self.Groove.ReferenceAxis = (self.Doc.X_Axis,[""])
+        self.Groove.Angle = 180.0
+        self.Groove.Reversed = 1
+        self.Body.addObject(self.Groove)
+        self.Doc.recompute()
+        self.failUnless(len(self.Groove.Shape.Faces) == 5)
+
+    def tearDown(self):
+        #closing doc
+        FreeCAD.closeDocument("PartDesignTest")
+        # print ("omit closing document for debugging")

--- a/src/Mod/PartDesign/TestPartDesignApp.py
+++ b/src/Mod/PartDesign/TestPartDesignApp.py
@@ -28,9 +28,10 @@ import Sketcher
 import PartDesign
 import TestSketcherApp
 
+
 App = FreeCAD
 #---------------------------------------------------------------------------
-# define the test cases to test the FreeCAD Sketcher module
+# define the test cases to test the FreeCAD PartDesign module
 #---------------------------------------------------------------------------
 
 


### PR DESCRIPTION
Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [X] Branch rebased on latest master `git pull --rebase upstream master`
- [X] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [X] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [x] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR once it is merged.

---

This is an inverted test case for [bug 0003006](https://freecadweb.org/tracker/view.php?id=3006). From the docstring:

Creates a unit cube at the origin and mirrors it about the Y axis.
This operation should create a rectangular prism with volume 2.

The operation is currently broken; this test is inverted:
`self.failUnless(self.Mirrored.Shape.Volume < 2.0)`
Change the final line to " .. > 1.0" and remove this notice.
