### PR TITLE
Fix window symbol rendering

### DIFF
--- a/src/Mod/Arch/ArchWindow.py
+++ b/src/Mod/Arch/ArchWindow.py
@@ -697,6 +697,13 @@ class _Window(ArchComponent.Component):
     def execute(self,obj):
         
         if self.clone(obj):
+            clonedProxy = obj.CloneOf.Proxy
+            if not (hasattr(clonedProxy, "sshapes") and hasattr(clonedProxy, "vshapes")):
+                clonedProxy.execute(obj.CloneOf)
+            self.sshapes = clonedProxy.sshapes
+            self.vshapes = clonedProxy.vshapes
+            if hasattr(clonedProxy, "boxes"):
+                self.boxes = clonedProxy.boxes
             return
         
         import Part,DraftGeomUtils,math

--- a/src/Mod/Draft/Draft.py
+++ b/src/Mod/Draft/Draft.py
@@ -1,4 +1,4 @@
-# -*- coding: utf8 -*-
+# -*- coding: utf-8 -*-
 
 #***************************************************************************
 #*                                                                         *
@@ -1891,7 +1891,7 @@ def getSVG(obj,scale=1,linewidth=0.35,fontsize=12,fillstyle="shape color",direct
             svg += 'id="%s" ' % pathname
         svg += ' d="'
         if not wires:
-            egroups = (Part.__sortEdges__(edges),)
+            egroups = Part.sortEdges(edges)
         else:
             egroups = []
             for w in wires:


### PR DESCRIPTION
Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR once it is merged.

---

Rendering of windows in SVG showed some problems:

* Clones of windows do not show the opening symbols in SVG (but in the normal 3D view, everything is fine)
* If a window has two components with opening symbols, only one is shown.

The attached file
[TestWindow.fcstd.zip](https://github.com/FreeCAD/FreeCAD/files/1029487/TestWindow.fcstd.zip) shows both bugs. It contains clones and one two-sided window.

The git log messages explain the fixes. Please check, whether my chosen way of fixing was right.

