### PR TITLE
Add ctags tag files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ install_manifest.txt
 OpenSCAD_rc.py
 .subuser-dev
 /\.idea/
+.tags
+tags


### PR DESCRIPTION
This is to support usage of https://en.wikipedia.org/wiki/Ctags for FreeCAD.