### PR TITLE
Fillet Feature: Return if radius <= 0

### DIFF
--- a/src/Mod/PartDesign/App/FeatureFillet.cpp
+++ b/src/Mod/PartDesign/App/FeatureFillet.cpp
@@ -78,6 +78,9 @@ App::DocumentObjectExecReturn *Fillet::execute(void)
         return new App::DocumentObjectExecReturn("Fillet not possible on selected shapes");
     
     double radius = Radius.getValue();
+    
+    if(radius <= 0)
+        return new App::DocumentObjectExecReturn("Fillet radius must be greater than zero");
 
     this->positionByBaseFeature();
 


### PR DESCRIPTION

- Saves time as no result can be provided in that range.
- (Sometimes) FC hangs with radius == 0.