### PR TITLE
DocumentObject storage including Error and Touch flags, fixes #2156

### DIFF
--- a/src/App/Document.cpp
+++ b/src/App/Document.cpp
@@ -1259,8 +1259,10 @@ void Document::writeObjects(const std::vector<App::DocumentObject*>& obj,
     std::vector<DocumentObject*>::const_iterator it;
     for (it = obj.begin(); it != obj.end(); ++it) {
         writer.Stream() << writer.ind() << "<Object "
-        << "type=\"" << (*it)->getTypeId().getName() << "\" "
-        << "name=\"" << (*it)->getNameInDocument()       << "\" "
+        << "type=\"" << (*it)->getTypeId().getName()        << "\" "
+        << "name=\"" << (*it)->getNameInDocument()          << "\" "
+        << "isTouch=\"" << (*it)->testStatus(App::Touch)    << "\" "
+        << "isError=\"" << (*it)->testStatus(App::Error)    << "\" "
         << "/>" << endl;
     }
 
@@ -1312,6 +1314,12 @@ Document::readObjects(Base::XMLReader& reader)
                 // use this name for the later access because an object with
                 // the given name may already exist
                 reader.addName(name.c_str(), obj->getNameInDocument());
+
+                // restore touch/error status flags
+                if(reader.hasAttribute("isTouch"))
+                    obj->setStatus(App::Touch, (bool) reader.getAttributeAsInteger("isTouch"));
+                if(reader.hasAttribute("isError"))
+                    obj->setStatus(App::Error, (bool) reader.getAttributeAsInteger("isError"));
             }
         }
         catch (const Base::Exception& e) {


### PR DESCRIPTION
Bug including a file to reproduce:
https://www.freecadweb.org/tracker/view.php?id=2156

Just enter a sketch, close and save the file and it will look like this:

```
   <Objects Count="2">   
        <Object type="Sketcher::SketchObject" name="Sketch" isTouch="0" isError="1" />   
        <Object type="Sketcher::SketchObject" name="Sketch001" isTouch="0" isError="1" />   
    </Objects>   
```
Close the file, open it again and the error flags will directly appear.
