### PR TITLE
Path.Command: fix toGCode() bug introduced in 0e9c1c07

### DIFF
--- a/src/Mod/Path/App/AreaParams.h
+++ b/src/Mod/Path/App/AreaParams.h
@@ -90,7 +90,7 @@
     ((double,units,Unit,1.0,"Scaling factor for conversion to inch",App::PropertyFloat))\
     ((short,min_arc_points,MinArcPoints,4,"Minimum segments for arc discretization"))\
     ((short,max_arc_points,MaxArcPoints,100,"Maximum segments for arc discretization"))\
-    ((double,clipper_scale,ClipperScale,1e6,\
+    ((double,clipper_scale,ClipperScale,1e7,\
         "ClipperLib operate on intergers. This is the scale factor to convert\n"\
         "floating points.",App::PropertyFloat))
 

--- a/src/Mod/Path/App/Command.cpp
+++ b/src/Mod/Path/App/Command.cpp
@@ -103,22 +103,26 @@ std::string Command::toGCode (int precision, bool padzero) const
     std::stringstream str;
     str.fill('0');
     str << Name;
-    if(precision<=0) 
-        precision = 1;
-    double scale = std::pow(10.0,precision);
+    if(precision<0) 
+        precision = 0;
+    double scale = std::pow(10.0,precision+1);
     std::int64_t iscale = static_cast<std::int64_t>(scale)/10;
     for(std::map<std::string,double>::const_iterator i = Parameters.begin(); i != Parameters.end(); ++i) {
         if(i->first == "N") continue;
 
+        str << " " << i->first;
+
         std::int64_t v = static_cast<std::int64_t>(i->second*scale);
-        if(v>=0)
-            v+=5;
-        else
-            v-=5;
+        if(v<0) {
+            v = -v;
+            str << '-'; //shall we allow -0 ?
+        }
+        v+=5;
         v /= 10;
-        str << " " << i->first << (v/iscale);
-        if(precision==1) continue;
-        int width = precision-1;
+        str << (v/iscale);
+        if(!precision) continue;
+
+        int width = precision;
         std::int64_t digits = v%iscale;
         if(!padzero) {
             if(!digits) continue;


### PR DESCRIPTION
* output 6 digits instead of 5
* fixed negative value output
