### PR TITLE
Path: Add ToolController to PathArray, PathCopy and PathCompound. Improve PathArray

### DIFF
--- a/src/Mod/Path/PathScripts/PathArray.py
+++ b/src/Mod/Path/PathScripts/PathArray.py
@@ -42,6 +42,9 @@ class ObjectArray:
                         "Path", "The spacing between the array copies")
         obj.addProperty("App::PropertyInteger", "Copies",
                         "Path", "The number of copies")
+
+        obj.addProperty("App::PropertyLink", "ToolController", "Path", QtCore.QT_TRANSLATE_NOOP("App::Property", "The tool controller that will be used to calculate the path"))
+
         obj.Proxy = self
 
     def __getstate__(self):
@@ -56,6 +59,10 @@ class ObjectArray:
                 return
             if not obj.Base.Path:
                 return
+            if not obj.Base.ToolController:
+                return
+
+            obj.ToolController = obj.Base.ToolController
 
             # build copies
             basepath = obj.Base.Path

--- a/src/Mod/Path/PathScripts/PathCompoundExtended.py
+++ b/src/Mod/Path/PathScripts/PathCompoundExtended.py
@@ -41,6 +41,7 @@ class ObjectCompoundExtended:
 #        obj.addProperty("App::PropertyFloat", "SpindleSpeed", "Path",QtCore.QT_TRANSLATE_NOOP("App::Property","The spindle speed, in revolutions per minute, of the tool used in these compounded operations"))
         obj.addProperty("App::PropertyLength","SafeHeight",   "Path",QtCore.QT_TRANSLATE_NOOP("App::Property","The safe height for this operation"))
         obj.addProperty("App::PropertyLength","RetractHeight","Path",QtCore.QT_TRANSLATE_NOOP("App::Property","The retract height, above top surface of part, between compounded operations inside clamping area"))
+        obj.addProperty("App::PropertyLink", "ToolController", "Path", QtCore.QT_TRANSLATE_NOOP("App::Property", "The tool controller that will be used to calculate the path"))
         obj.Proxy = self
 
     def __getstate__(self):
@@ -114,12 +115,14 @@ import PathScripts
 from PathScripts import PathUtils
 incl = []
 prjexists = False
+tc = None
 sel = FreeCADGui.Selection.getSelection()
 for s in sel:
     if s.isDerivedFrom("Path::Feature"):
         incl.append(s)
 
 obj = FreeCAD.ActiveDocument.addObject("Path::FeatureCompoundPython","Compound")
+
 PathScripts.PathCompoundExtended.ObjectCompoundExtended(obj)
 PathScripts.PathCompoundExtended.ViewProviderCompoundExtended(obj.ViewObject)
 project = PathUtils.addToJob(obj)
@@ -130,10 +133,15 @@ if incl:
     g = obj.Group
     for child in incl:
         p.remove(child)
-        children.append(FreeCAD.ActiveDocument.getObject(child.Name))
+        childobj = FreeCAD.ActiveDocument.getObject(child.Name)
+        if hasattr(childobj, 'ToolController'):
+            tc = childobj.ToolController
+        children.append(childobj)
+
     project.Group = p
     g.append(children)
     obj.Group = children
+    obj.ToolController = tc
 '''
         FreeCADGui.doCommand(snippet)
         FreeCAD.ActiveDocument.commitTransaction()

--- a/src/Mod/Path/PathScripts/PathCopy.py
+++ b/src/Mod/Path/PathScripts/PathCopy.py
@@ -35,8 +35,9 @@ def translate(context, text, disambig=None):
 
 class ObjectPathCopy:
 
-    def __init__(self,obj):
-        obj.addProperty("App::PropertyLink","Base","Path",QtCore.QT_TRANSLATE_NOOP("App::Property","The path to be copied"))
+    def __init__(self, obj):
+        obj.addProperty("App::PropertyLink", "Base", "Path", QtCore.QT_TRANSLATE_NOOP("App::Property", "The path to be copied"))
+        obj.addProperty("App::PropertyLink", "ToolController", "Path", QtCore.QT_TRANSLATE_NOOP("App::Property", "The tool controller that will be used to calculate the path"))
         obj.Proxy = self
 
     def __getstate__(self):
@@ -47,6 +48,8 @@ class ObjectPathCopy:
 
     def execute(self, obj):
         if obj.Base:
+            if hasattr(obj.Base, 'ToolController'):
+                obj.ToolController = obj.Base.ToolController
             if obj.Base.Path:
                 obj.Path = obj.Base.Path.copy()
 
@@ -113,6 +116,8 @@ if selGood:
     PathScripts.PathCopy.ObjectPathCopy(obj)
     PathScripts.PathCopy.ViewProviderPathCopy(obj.ViewObject)
     obj.Base = FreeCAD.ActiveDocument.getObject(selection[0].Name)
+    if hasattr(obj.Base, 'ToolController'):
+        obj.ToolController = obj.Base.ToolController
 
 g = proj.Group
 g.append(obj)


### PR DESCRIPTION
Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR once it is merged.

---

Fixes the incompatibility with ToolController for PathArray, PathCopy and PathCompound.

New features for PathArray. You can create 2-dimensional arrays and Polar (circular) arrays.

Forum thread: https://forum.freecadweb.org/viewtopic.php?f=15&t=22770&sid=6b81e1f0c479f00ac91dd3100d712196