### PR TITLE
Fix PartDesign::Mirrored

### DIFF
--- a/src/Mod/Part/App/TopoShape.cpp
+++ b/src/Mod/Part/App/TopoShape.cpp
@@ -372,20 +372,19 @@ void TopoShape::convertToMatrix(const gp_Trsf& trsf, Base::Matrix4D& mtrx)
 #if OCC_VERSION_HEX >= 0x070000
     gp_Mat m = trsf.VectorialPart();
     gp_XYZ p = trsf.TranslationPart();
-    Standard_Real scale = trsf.ScaleFactor();
 
     // set Rotation matrix
-    mtrx[0][0] = scale * m(1,1);
-    mtrx[0][1] = scale * m(1,2);
-    mtrx[0][2] = scale * m(1,3);
+    mtrx[0][0] = m(1,1);
+    mtrx[0][1] = m(1,2);
+    mtrx[0][2] = m(1,3);
 
-    mtrx[1][0] = scale * m(2,1);
-    mtrx[1][1] = scale * m(2,2);
-    mtrx[1][2] = scale * m(2,3);
+    mtrx[1][0] = m(2,1);
+    mtrx[1][1] = m(2,2);
+    mtrx[1][2] = m(2,3);
 
-    mtrx[2][0] = scale * m(3,1);
-    mtrx[2][1] = scale * m(3,2);
-    mtrx[2][2] = scale * m(3,3);
+    mtrx[2][0] = m(3,1);
+    mtrx[2][1] = m(3,2);
+    mtrx[2][2] = m(3,3);
 
     // set pos vector
     mtrx[0][3] = p.X();

--- a/src/Mod/PartDesign/App/FeatureTransformed.cpp
+++ b/src/Mod/PartDesign/App/FeatureTransformed.cpp
@@ -364,6 +364,11 @@ App::DocumentObjectExecReturn *Transformed::execute(void)
             rejected[it->first].push_back(**it2);
 
     this->Shape.setValue(getSolid(support));
+
+    if (rejected.size() > 0) {
+        return new App::DocumentObjectExecReturn("Transformation failed");
+    }
+
     return App::DocumentObject::StdReturn;
 }
 

--- a/src/Mod/PartDesign/Gui/ViewProviderTransformed.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderTransformed.cpp
@@ -78,7 +78,7 @@ bool ViewProviderTransformed::setEdit(int ModNum)
     rejectedPickStyle->style = SoPickStyle::UNPICKABLE;
 
     SoShapeHints* rejectedHints = new SoShapeHints();
-    rejectedHints->vertexOrdering = SoShapeHints::COUNTERCLOCKWISE;
+    rejectedHints->vertexOrdering = SoShapeHints::UNKNOWN_ORDERING;
     rejectedHints->shapeType = SoShapeHints::UNKNOWN_SHAPE_TYPE;
 
     SoMaterialBinding* rejectedBind = new SoMaterialBinding();

--- a/src/Mod/PartDesign/TestPartDesignApp.py
+++ b/src/Mod/PartDesign/TestPartDesignApp.py
@@ -147,6 +147,28 @@ class PartDesignMirroredTestCases(unittest.TestCase):
         self.Doc.recompute()
         self.failUnless(self.Mirrored.Shape.Volume == 1.9999999999999993)
 
+    def testMirroredPrimitiveCase(self):
+        """
+        Tests the same mirroring scenario as in the sketch case,
+        but is designed to ensure the same end result occurs with
+        a different base object.
+        """
+        self.Body = self.Doc.addObject('PartDesign::Body','Body')
+
+        self.Box = self.Doc.addObject('PartDesign::AdditiveBox','Box')
+        self.Box.Length=1
+        self.Box.Width=1
+        self.Box.Height=1
+        self.Body.addObject(self.Box)
+        self.Doc.recompute()
+
+        self.Mirrored = self.Doc.addObject("PartDesign::Mirrored", "Mirrored")
+        self.Mirrored.Originals = [self.Box]
+        self.Mirrored.MirrorPlane = (self.Doc.XY_Plane, [""])
+        self.Body.addObject(self.Mirrored)
+        self.Doc.recompute()
+        self.failUnless(self.Mirrored.Shape.Volume == 1.9999999999999993)
+
     def testMirroredOffsetFailureCase(self):
         self.Body = self.Doc.addObject('PartDesign::Body','Body')
         self.Rect = self.Doc.addObject('Sketcher::SketchObject','Rect')


### PR DESCRIPTION
Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [X] Branch rebased on latest master `git pull --rebase upstream master`
- [X] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [X] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR once it is merged.

---

Commits fix PartDesign::Mirrored behavior and add two unit tests for it. More detailed explanation available at https://kkremitzki.github.io/blog/gsoc-week-1-recap/