### PR TITLE
Path: Add PathDressupRampEntry.py to CMakeList

### DIFF
--- a/src/Mod/Path/CMakeLists.txt
+++ b/src/Mod/Path/CMakeLists.txt
@@ -29,6 +29,7 @@ SET(PathScripts_SRCS
     PathScripts/PathDressupDogbone.py
     PathScripts/PathDressupDragknife.py
     PathScripts/PathDressupHoldingTags.py
+    PathScripts/PathDressupRampEntry.py
     PathScripts/PathDrilling.py
     PathScripts/PathEngrave.py
     PathScripts/PathFacePocket.py
@@ -141,4 +142,3 @@ INSTALL(
     DESTINATION
         Mod/Path/PathTests
 )
-

--- a/src/Mod/Path/PathScripts/PathDressupRampEntry.py
+++ b/src/Mod/Path/PathScripts/PathDressupRampEntry.py
@@ -604,7 +604,7 @@ class CommandPathDressupRampEntry:
 
         # everything ok!
         FreeCAD.ActiveDocument.openTransaction(translate("Create RampEntry Dress-up"))
-        FreeCADGui.addModule("PathScripts.PathDressUpRampEntry")
+        FreeCADGui.addModule("PathScripts.PathDressupRampEntry")
         FreeCADGui.addModule("PathScripts.PathUtils")
         FreeCADGui.doCommand('obj = FreeCAD.ActiveDocument.addObject("Path::FeaturePython", "RampEntryDressup")')
         FreeCADGui.doCommand('dbo = PathScripts.PathDressupRampEntry.ObjectDressup(obj)')


### PR DESCRIPTION
Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR once it is merged.

---
The initial PR for PathDressupRampEntry did not modify the CMakeLists.txt as supposed.