### PR TITLE
Path fixes

### DIFF
--- a/src/Base/UnitsSchemaCentimeters.cpp
+++ b/src/Base/UnitsSchemaCentimeters.cpp
@@ -62,6 +62,10 @@ QString UnitsSchemaCentimeters::schemaTranslate(const Base::Quantity& quant, dou
         unitString = QString::fromLatin1("W/m^2");
         factor = 1.0;
     }
+    else if (unit == Unit::Velocity) {
+        unitString = QString::fromLatin1("mm/min");
+        factor = 1.0/60;
+    }
     else {
         // default action for all cases without special treatment:
         unitString = quant.getUnit().getString();

--- a/src/Base/UnitsSchemaImperial1.cpp
+++ b/src/Base/UnitsSchemaImperial1.cpp
@@ -127,6 +127,10 @@ QString UnitsSchemaImperial1::schemaTranslate(const Quantity &quant, double &fac
             factor = 0.145038;
         }
     }
+    else if (unit == Unit::Velocity) {
+        unitString = QString::fromLatin1("in/min");
+        factor = 25.4/60;
+    }
     else{
         // default action for all cases without special treatment:
         unitString = quant.getUnit().getString();
@@ -187,6 +191,10 @@ QString UnitsSchemaImperialDecimal::schemaTranslate(const Base::Quantity& quant,
             unitString = QString::fromLatin1("psi");
             factor = 0.145038;
         }
+    }
+    else if (unit == Unit::Velocity) {
+        unitString = QString::fromLatin1("in/min");
+        factor = 25.4/60;
     }
     else {
         // default action for all cases without special treatment:
@@ -265,6 +273,10 @@ QString UnitsSchemaImperialBuilding::schemaTranslate(const Quantity &quant, doub
     else if (unit == Unit::Volume) {
         unitString = QString::fromLatin1("cuft");
         factor = 28316846.592;
+    }
+    else if (unit == Unit::Velocity) {
+        unitString = QString::fromLatin1("in/min");
+        factor = 25.4/60;
     }
     else {
         unitString = quant.getUnit().getString();

--- a/src/Base/UnitsSchemaInternal.cpp
+++ b/src/Base/UnitsSchemaInternal.cpp
@@ -163,6 +163,10 @@ QString UnitsSchemaInternal::schemaTranslate(const Quantity &quant, double &fact
         unitString = QString::fromLatin1("W/m^2");
         factor = 1.0;
     }
+    else if (unit == Unit::Velocity) {
+        unitString = QString::fromLatin1("mm/min");
+        factor = 1.0/60;
+    }
     else {
         // default action for all cases without special treatment:
         unitString = quant.getUnit().getString();

--- a/src/Base/UnitsSchemaMKS.cpp
+++ b/src/Base/UnitsSchemaMKS.cpp
@@ -164,6 +164,10 @@ QString UnitsSchemaMKS::schemaTranslate(const Quantity &quant, double &factor, Q
         unitString = QString::fromLatin1("W/m^2");
         factor = 1.0;
     }
+    else if (unit == Unit::Velocity) {
+        unitString = QString::fromLatin1("mm/min");
+        factor = 1.0/60;
+    }
     else {
         // default action for all cases without special treatment:
         unitString = quant.getUnit().getString();

--- a/src/Mod/Path/Gui/Resources/panels/ToolControl.ui
+++ b/src/Mod/Path/Gui/Resources/panels/ToolControl.ui
@@ -181,7 +181,14 @@
        </widget>
       </item>
       <item row="0" column="0">
-       <widget class="QDoubleSpinBox" name="spindleSpeed"/>
+       <widget class="QDoubleSpinBox" name="spindleSpeed">
+        <property name="minimum">
+         <double>0.000000000000000</double>
+        </property>
+        <property name="maximum">
+         <double>100000.000000000000000</double>
+        </property>
+       </widget>
       </item>
      </layout>
     </widget>

--- a/src/Mod/Path/PathScripts/PathToolLibraryManager.py
+++ b/src/Mod/Path/PathScripts/PathToolLibraryManager.py
@@ -192,19 +192,8 @@ class ToolLibraryManager():
         model.setHorizontalHeaderLabels(headers)
 
         def unitconv(ivalue):
-            parms = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Units")
-            digits = parms.GetContents()[1][2] #get user's number of digits of precision
-            if parms.GetContents()[0][2]==0:
-                suffix = 'mm'
-                conversion = 1.0
-            elif parms.GetContents()[0][2]==3:
-                suffix = 'in'
-                conversion = 25.4
-            else:
-                suffix = ''
-            val = FreeCAD.Units.parseQuantity(str(round(ivalue/conversion,digits))+suffix)
-            displayed_val = val.UserString #just the displayed value-not the internal one
-
+            val = FreeCAD.Units.Quantity(ivalue, FreeCAD.Units.Length)
+            displayed_val = val.UserString      #just the displayed value-not the internal one
             return displayed_val
 
         if tt:


### PR DESCRIPTION
Pull request addresses 3 issues:
## 0003088: ToolTable crashes after changing the units in the settings
commit fcb5667e35ceb83efe05da5e32a706687dd3920d
I chose to use the default unit conversion of the current schema. It may be a pain to see a "59.055 thou" tool but this is a common problem with UnitsSchema::schemaTranslate that do not allow customization for each use.

## 0003089: Spindle speed is limited to only 100 RPM
commit 8ed7e131808298fcea5c990798b519e3ddccc495
The default maximum of 99.99 is too small. I Just set the maximum to 100,000 RPM (Is that enough?)

## 0003090: There is no default Units schema translation for Unit::Velocity
commit ecc762c0ae03037af1e8a0a4fccd29ed6f863d44
IMHO this is only used for feed-rates in the Path module tool control. It is very important to me to use the same units that I use in G-CODE (mm/min).
It would be better if any property could override the default conversion of the current unit schema. Then one could use imperial units on drawings and still see mm/min on the feed-rates.
