### PR TITLE
[PDN] Add Pad and Pocket tests

### DIFF
--- a/src/Mod/PartDesign/TestPartDesignApp.py
+++ b/src/Mod/PartDesign/TestPartDesignApp.py
@@ -377,6 +377,42 @@ class PartDesignPocketTestCases(unittest.TestCase):
         self.Doc.recompute()
         self.assertAlmostEqual(self.Pocket001.Shape.Volume, 62.5)
 
+    def testPocketToFaceCase(self):
+        self.Body = self.Doc.addObject('PartDesign::Body','Body')
+        self.PadSketch = self.Doc.addObject('Sketcher::SketchObject', 'PadSketch')
+        self.Body.addObject(self.PadSketch)
+        TestSketcherApp.CreateRectangleSketch(self.PadSketch, (0, 0), (10, 10), True)
+        self.Doc.recompute()
+        self.Pad = self.Doc.addObject("PartDesign::Pad", "Pad")
+        self.Body.addObject(self.Pad)
+        self.Pad.Profile = self.PadSketch
+        self.Pad.Length = 1
+        self.Pad.Reversed = 1
+        self.Doc.recompute()
+        self.PocketSketch = self.Doc.addObject('Sketcher::SketchObject', 'PocketSketch')
+        self.Body.addObject(self.PocketSketch)
+        TestSketcherApp.CreateRectangleSketch(self.PocketSketch, (2.5, 2.5), (5, 5), True)
+        self.Doc.recompute()
+        self.Pocket = self.Doc.addObject("PartDesign::Pocket", "Pocket")
+        self.Body.addObject(self.Pocket)
+        self.Pocket.Profile = self.PocketSketch
+        self.Pocket.Length = 1
+        self.Doc.recompute()
+        self.PocketSketch1 = self.Doc.addObject('Sketcher::SketchObject', 'PocketSketch')
+        self.Body.addObject(self.PocketSketch1)
+        self.PocketSketch1.MapMode = 'FlatFace'
+        self.PocketSketch1.Support = (App.ActiveDocument.XZ_Plane, [''])
+        self.Doc.recompute()
+        TestSketcherApp.CreateRectangleSketch(self.PocketSketch1, (0, -1), (10, 1))
+        self.Doc.recompute()
+        self.Pocket001 = self.Doc.addObject("PartDesign::Pocket", "Pocket001")
+        self.Body.addObject(self.Pocket001)
+        self.Pocket001.Profile = self.PocketSketch1
+        self.Pocket001.Type = 3
+        self.Pocket001.UpToFace = (self.Pocket, ["Face10"])
+        self.Doc.recompute()
+        self.assertAlmostEqual(self.Pocket001.Shape.Volume, 50.0)
+
     def tearDown(self):
         #closing doc
         FreeCAD.closeDocument("PartDesignTestPocket")

--- a/src/Mod/PartDesign/TestPartDesignApp.py
+++ b/src/Mod/PartDesign/TestPartDesignApp.py
@@ -45,7 +45,7 @@ class PartDesignPadTestCases(unittest.TestCase):
         self.Pad = self.Doc.addObject("PartDesign::Pad","Pad")
         self.Pad.Profile = self.PadSketch
         self.Doc.recompute()
-        self.failUnless(len(self.Pad.Shape.Faces) == 6)
+        self.assertEqual(len(self.Pad.Shape.Faces), 6)
 
     def testPadToFirstCase(self):
         self.Body = self.Doc.addObject('PartDesign::Body','Body')
@@ -73,7 +73,7 @@ class PartDesignPadTestCases(unittest.TestCase):
         self.Pad1.Type = 2
         self.Pad1.Reversed = 1
         self.Doc.recompute()
-        self.failUnless(self.Pad1.Shape.Volume == 1.9999999999999996)
+        self.assertAlmostEqual(self.Pad1.Shape.Volume, 2.0)
 
     def testPadtoLastCase(self):
         self.Body = self.Doc.addObject('PartDesign::Body','Body')
@@ -101,7 +101,7 @@ class PartDesignPadTestCases(unittest.TestCase):
         self.Pad1.Type = 1
         self.Pad1.Reversed = 1
         self.Doc.recompute()
-        self.failUnless(self.Pad1.Shape.Volume == 2.999999999999999)
+        self.assertAlmostEqual(self.Pad1.Shape.Volume, 3.0)
 
     def testPadToFaceCase(self):
         self.Body = self.Doc.addObject('PartDesign::Body','Body')
@@ -130,7 +130,7 @@ class PartDesignPadTestCases(unittest.TestCase):
         self.Pad1.UpToFace = (self.Pad, ["Face3"])
         self.Pad1.Reversed = 1
         self.Doc.recompute()
-        self.failUnless(self.Pad1.Shape.Volume == 1.9999999999999996)
+        self.assertAlmostEqual(self.Pad1.Shape.Volume, 2.0)
 
     def testPadTwoDimensionsCase(self):
         self.Body = self.Doc.addObject('PartDesign::Body','Body')
@@ -160,7 +160,7 @@ class PartDesignPadTestCases(unittest.TestCase):
         self.Pad1.Length2 = 1.0
         self.Pad1.Reversed = 1
         self.Doc.recompute()
-        self.failUnless(self.Pad1.Shape.Volume == 3.9999999999999996)
+        self.assertAlmostEqual(self.Pad1.Shape.Volume, 4.0)
 
     def tearDown(self):
         #closing doc
@@ -204,7 +204,7 @@ class PartDesignRevolveTestCases(unittest.TestCase):
         self.Groove.Reversed = 1
         self.Body.addObject(self.Groove)
         self.Doc.recompute()
-        self.failUnless(len(self.Groove.Shape.Faces) == 5)
+        self.assertEqual(len(self.Groove.Shape.Faces), 5)
 
     def tearDown(self):
         #closing doc
@@ -219,12 +219,6 @@ class PartDesignMirroredTestCases(unittest.TestCase):
         """
         Creates a unit cube cornered at the origin and mirrors it about the Y axis.
         This operation should create a rectangular prism with volume 2.0.
-
-        The precision is currently broken and the volume created
-        is 1.9999999999999993. so this test will fail if code is
-        introduced to change it. If you've submitted code which fixes
-        the precision and causes this bug to fail, please remove this
-        message and update this test as well as testMirroredPrimitiveCase.
         """
         self.Body = self.Doc.addObject('PartDesign::Body','Body')
         self.Rect = self.Doc.addObject('Sketcher::SketchObject','Rect')
@@ -326,7 +320,7 @@ class PartDesignMirroredTestCases(unittest.TestCase):
         self.Mirrored.MirrorPlane = (self.Rect, ["H_Axis"])
         self.Body.addObject(self.Mirrored)
         self.Doc.recompute()
-        self.failUnless(self.Mirrored.State == ["Invalid"])
+        self.assertEqual(self.Mirrored.State, ["Invalid"])
 
     def tearDown(self):
         #closing doc

--- a/src/Mod/PartDesign/TestPartDesignApp.py
+++ b/src/Mod/PartDesign/TestPartDesignApp.py
@@ -409,11 +409,13 @@ class PartDesignPocketTestCases(unittest.TestCase):
         self.Body.addObject(self.Pocket001)
         self.Pocket001.Profile = self.PocketSketch1
         self.Pocket001.Type = 3
-        self.Pocket001.UpToFace = (self.Pocket, ["Face10"])
-        self.Doc.recompute()
         # Handle face-naming inconsistency in OCC < 7
-        if 'Invalid' in self.Pocket001.State:
-            self.Pocket001.UpToFace = (self.Pocket, ["Face7"])
+        self.FaceNumber = 7
+        self.Pocket001.UpToFace = (self.Pocket, ["Face"+str(self.FaceNumber)])
+        self.Doc.recompute()
+        while (('Invalid' in self.Pocket001.State or round(self.Pocket001.Shape.Volume, 7) != 50.0) and self.FaceNumber < 11):
+            self.FaceNumber += 1
+            self.Pocket001.UpToFace = (self.Pocket, ["Face"+str(self.FaceNumber)])
             self.Doc.recompute()
         self.assertAlmostEqual(self.Pocket001.Shape.Volume, 50.0)
 

--- a/src/Mod/PartDesign/TestPartDesignApp.py
+++ b/src/Mod/PartDesign/TestPartDesignApp.py
@@ -223,27 +223,7 @@ class PartDesignMirroredTestCases(unittest.TestCase):
         self.Body = self.Doc.addObject('PartDesign::Body','Body')
         self.Rect = self.Doc.addObject('Sketcher::SketchObject','Rect')
         self.Body.addObject(self.Rect)
-        geoList = []
-        geoList.append(Part.LineSegment(App.Vector(0, 0, 0), App.Vector(1, 0, 0)))
-        geoList.append(Part.LineSegment(App.Vector(1, 0, 0), App.Vector(1, 1, 0)))
-        geoList.append(Part.LineSegment(App.Vector(1, 1, 0), App.Vector(0, 1, 0)))
-        geoList.append(Part.LineSegment(App.Vector(0, 1, 0), App.Vector(0, 0, 0)))
-        self.Rect.addGeometry(geoList,False)
-        conList = []
-        conList.append(Sketcher.Constraint('Coincident',0,2,1,1))
-        conList.append(Sketcher.Constraint('Coincident',1,2,2,1))
-        conList.append(Sketcher.Constraint('Coincident',2,2,3,1))
-        conList.append(Sketcher.Constraint('Coincident',3,2,0,1))
-        conList.append(Sketcher.Constraint('Horizontal',0))
-        conList.append(Sketcher.Constraint('Horizontal',2))
-        conList.append(Sketcher.Constraint('Vertical',1))
-        conList.append(Sketcher.Constraint('Vertical',3))
-        self.Rect.addConstraint(conList)
-        self.Rect.addConstraint(Sketcher.Constraint('Coincident',0,1,-1,1))
-        self.Rect.addConstraint(Sketcher.Constraint('DistanceX',0,1,0,2,1))
-        self.Rect.setDatum(9,App.Units.Quantity('1.0 mm'))
-        self.Rect.addConstraint(Sketcher.Constraint('DistanceY',3,2,3,1,1))
-        self.Rect.setDatum(10,App.Units.Quantity('1.0 mm'))
+        TestSketcherApp.CreateRectangleSketch(self.Rect, (0, 0), (1, 1), True)
         self.Doc.recompute()
         self.Pad = self.Doc.addObject("PartDesign::Pad","Pad")
         self.Pad.Profile = self.Rect
@@ -264,14 +244,12 @@ class PartDesignMirroredTestCases(unittest.TestCase):
         a different base object.
         """
         self.Body = self.Doc.addObject('PartDesign::Body','Body')
-
         self.Box = self.Doc.addObject('PartDesign::AdditiveBox','Box')
         self.Box.Length=1
         self.Box.Width=1
         self.Box.Height=1
         self.Body.addObject(self.Box)
         self.Doc.recompute()
-
         self.Mirrored = self.Doc.addObject("PartDesign::Mirrored", "Mirrored")
         self.Mirrored.Originals = [self.Box]
         self.Mirrored.MirrorPlane = (self.Doc.XY_Plane, [""])
@@ -283,38 +261,13 @@ class PartDesignMirroredTestCases(unittest.TestCase):
         self.Body = self.Doc.addObject('PartDesign::Body','Body')
         self.Rect = self.Doc.addObject('Sketcher::SketchObject','Rect')
         self.Body.addObject(self.Rect)
-        geoList = []
-        geoList.append(Part.LineSegment(App.Vector(0, 0, 0), App.Vector(1, 0, 0)))
-        geoList.append(Part.LineSegment(App.Vector(1, 0, 0), App.Vector(1, 1, 0)))
-        geoList.append(Part.LineSegment(App.Vector(1, 1, 0), App.Vector(0, 1, 0)))
-        geoList.append(Part.LineSegment(App.Vector(0, 1, 0), App.Vector(0, 0, 0)))
-        self.Rect.addGeometry(geoList,False)
-        conList = []
-
-        conList.append(Sketcher.Constraint('Coincident',0,2,1,1))
-        conList.append(Sketcher.Constraint('Coincident',1,2,2,1))
-        conList.append(Sketcher.Constraint('Coincident',2,2,3,1))
-        conList.append(Sketcher.Constraint('Coincident',3,2,0,1))
-        conList.append(Sketcher.Constraint('Horizontal',0))
-        conList.append(Sketcher.Constraint('Horizontal',2))
-        conList.append(Sketcher.Constraint('Vertical',1))
-        conList.append(Sketcher.Constraint('Vertical',3))
-        self.Rect.addConstraint(conList)
-
-        self.Rect.addConstraint(Sketcher.Constraint('PointOnObject',0,1,-2)) 
-        self.Rect.addConstraint(Sketcher.Constraint('Equal',3,0)) 
-        self.Rect.addConstraint(Sketcher.Constraint('DistanceX',0,1,0,2,1))
-        self.Rect.setDatum(10,App.Units.Quantity('1.0 mm'))
-        self.Rect.addConstraint(Sketcher.Constraint('DistanceY',-1,1,0,1,1)) 
-        self.Rect.setDatum(11,App.Units.Quantity('1.0 mm'))
+        TestSketcherApp.CreateRectangleSketch(self.Rect, (0, 1), (1, 1), True)
         self.Doc.recompute()
-
         self.Pad = self.Doc.addObject("PartDesign::Pad","Pad")
         self.Pad.Profile = self.Rect
         self.Pad.Length = 1
         self.Body.addObject(self.Pad)
         self.Doc.recompute()
-
         self.Mirrored = self.Doc.addObject("PartDesign::Mirrored","Mirrored")
         self.Mirrored.Originals = [self.Pad]
         self.Mirrored.MirrorPlane = (self.Rect, ["H_Axis"])
@@ -325,4 +278,106 @@ class PartDesignMirroredTestCases(unittest.TestCase):
     def tearDown(self):
         #closing doc
         FreeCAD.closeDocument("PartDesignTestMirrored")
+        #print ("omit closing document for debugging")
+
+class PartDesignPocketTestCases(unittest.TestCase):
+    def setUp(self):
+        self.Doc = FreeCAD.newDocument("PartDesignTestPocket")
+
+    def testPocketDimensionCase(self):
+        self.Body = self.Doc.addObject('PartDesign::Body','Body')
+        self.PadSketch = self.Doc.addObject('Sketcher::SketchObject', 'PadSketch')
+        self.Body.addObject(self.PadSketch)
+        TestSketcherApp.CreateRectangleSketch(self.PadSketch, (0, 0), (10, 10), True)
+        self.Doc.recompute()
+        self.Pad = self.Doc.addObject("PartDesign::Pad", "Pad")
+        self.Body.addObject(self.Pad)
+        self.Pad.Profile = self.PadSketch
+        self.Pad.Length = 1
+        self.Pad.Reversed = 1
+        self.Doc.recompute()
+        self.PocketSketch = self.Doc.addObject('Sketcher::SketchObject', 'PocketSketch')
+        self.Body.addObject(self.PocketSketch)
+        TestSketcherApp.CreateRectangleSketch(self.PocketSketch, (2.5, 2.5), (5, 5), True)
+        self.Doc.recompute()
+        self.Pocket = self.Doc.addObject("PartDesign::Pocket", "Pocket")
+        self.Body.addObject(self.Pocket)
+        self.Pocket.Profile = self.PocketSketch
+        self.Pocket.Length = 1
+        self.Doc.recompute()
+        self.assertAlmostEqual(self.Pocket.Shape.Volume, 75.0)
+
+    def testPocketThroughAllCase(self):
+        self.Body = self.Doc.addObject('PartDesign::Body','Body')
+        self.PadSketch = self.Doc.addObject('Sketcher::SketchObject', 'PadSketch')
+        self.Body.addObject(self.PadSketch)
+        TestSketcherApp.CreateRectangleSketch(self.PadSketch, (0, 0), (10, 10), True)
+        self.Doc.recompute()
+        self.Pad = self.Doc.addObject("PartDesign::Pad", "Pad")
+        self.Body.addObject(self.Pad)
+        self.Pad.Profile = self.PadSketch
+        self.Pad.Length = 1
+        self.Pad.Reversed = 1
+        self.Doc.recompute()
+        self.PocketSketch = self.Doc.addObject('Sketcher::SketchObject', 'PocketSketch')
+        self.Body.addObject(self.PocketSketch)
+        TestSketcherApp.CreateRectangleSketch(self.PocketSketch, (2.5, 2.5), (5, 5), True)
+        self.Doc.recompute()
+        self.Pocket = self.Doc.addObject("PartDesign::Pocket", "Pocket")
+        self.Body.addObject(self.Pocket)
+        self.Pocket.Profile = self.PocketSketch
+        self.Pocket.Length = 1
+        self.Doc.recompute()
+        self.PocketSketch1 = self.Doc.addObject('Sketcher::SketchObject', 'PocketSketch')
+        self.Body.addObject(self.PocketSketch1)
+        self.PocketSketch1.MapMode = 'FlatFace'
+        self.PocketSketch1.Support = (App.ActiveDocument.XZ_Plane, [''])
+        self.Doc.recompute()
+        TestSketcherApp.CreateRectangleSketch(self.PocketSketch1, (2.5, -1), (5, 1))
+        self.Doc.recompute()
+        self.Pocket001 = self.Doc.addObject("PartDesign::Pocket", "Pocket001")
+        self.Body.addObject(self.Pocket001)
+        self.Pocket001.Profile = self.PocketSketch1
+        self.Pocket001.Type = 1
+        self.Doc.recompute()
+        self.assertAlmostEqual(self.Pocket001.Shape.Volume, 25.0)
+
+    def testPocketToFirstCase(self):
+        self.Body = self.Doc.addObject('PartDesign::Body','Body')
+        self.PadSketch = self.Doc.addObject('Sketcher::SketchObject', 'PadSketch')
+        self.Body.addObject(self.PadSketch)
+        TestSketcherApp.CreateRectangleSketch(self.PadSketch, (0, 0), (10, 10), True)
+        self.Doc.recompute()
+        self.Pad = self.Doc.addObject("PartDesign::Pad", "Pad")
+        self.Body.addObject(self.Pad)
+        self.Pad.Profile = self.PadSketch
+        self.Pad.Length = 1
+        self.Pad.Reversed = 1
+        self.Doc.recompute()
+        self.PocketSketch = self.Doc.addObject('Sketcher::SketchObject', 'PocketSketch')
+        self.Body.addObject(self.PocketSketch)
+        TestSketcherApp.CreateRectangleSketch(self.PocketSketch, (2.5, 2.5), (5, 5), True)
+        self.Doc.recompute()
+        self.Pocket = self.Doc.addObject("PartDesign::Pocket", "Pocket")
+        self.Body.addObject(self.Pocket)
+        self.Pocket.Profile = self.PocketSketch
+        self.Pocket.Length = 1
+        self.Doc.recompute()
+        self.PocketSketch1 = self.Doc.addObject('Sketcher::SketchObject', 'PocketSketch')
+        self.Body.addObject(self.PocketSketch1)
+        self.PocketSketch1.MapMode = 'FlatFace'
+        self.PocketSketch1.Support = (App.ActiveDocument.XZ_Plane, [''])
+        self.Doc.recompute()
+        TestSketcherApp.CreateRectangleSketch(self.PocketSketch1, (2.5, -1), (5, 1))
+        self.Doc.recompute()
+        self.Pocket001 = self.Doc.addObject("PartDesign::Pocket", "Pocket001")
+        self.Body.addObject(self.Pocket001)
+        self.Pocket001.Profile = self.PocketSketch1
+        self.Pocket001.Type = 2
+        self.Doc.recompute()
+        self.assertAlmostEqual(self.Pocket001.Shape.Volume, 62.5)
+
+    def tearDown(self):
+        #closing doc
+        FreeCAD.closeDocument("PartDesignTestPocket")
         #print ("omit closing document for debugging")

--- a/src/Mod/PartDesign/TestPartDesignApp.py
+++ b/src/Mod/PartDesign/TestPartDesignApp.py
@@ -411,6 +411,10 @@ class PartDesignPocketTestCases(unittest.TestCase):
         self.Pocket001.Type = 3
         self.Pocket001.UpToFace = (self.Pocket, ["Face10"])
         self.Doc.recompute()
+        # Handle face-naming inconsistency in OCC < 7
+        if 'Invalid' in self.Pocket001.State:
+            self.Pocket001.UpToFace = (self.Pocket, ["Face7"])
+            self.Doc.recompute()
         self.assertAlmostEqual(self.Pocket001.Shape.Volume, 50.0)
 
     def tearDown(self):

--- a/src/Mod/PartDesign/TestPartDesignApp.py
+++ b/src/Mod/PartDesign/TestPartDesignApp.py
@@ -47,10 +47,125 @@ class PartDesignPadTestCases(unittest.TestCase):
         self.Doc.recompute()
         self.failUnless(len(self.Pad.Shape.Faces) == 6)
 
+    def testPadToFirstCase(self):
+        self.Body = self.Doc.addObject('PartDesign::Body','Body')
+        # Make first offset cube Pad
+        self.PadSketch = self.Doc.addObject('Sketcher::SketchObject', 'SketchPad')
+        self.Body.addObject(self.PadSketch)
+        TestSketcherApp.CreateRectangleSketch(self.PadSketch, (0, 1), (1, 1), True)
+        self.Doc.recompute()
+        self.Pad = self.Doc.addObject("PartDesign::Pad", "Pad")
+        self.Body.addObject(self.Pad)
+        self.Pad.Profile = self.PadSketch
+        self.Pad.Length = 1
+        self.Doc.recompute()
+        # Make second pad on different plane and pad to first
+        self.PadSketch1 = self.Doc.addObject('Sketcher::SketchObject', 'SketchPad1')
+        self.Body.addObject(self.PadSketch1)
+        self.PadSketch1.MapMode = 'FlatFace'
+        self.PadSketch1.Support = (App.ActiveDocument.XZ_Plane, [''])
+        self.Doc.recompute()
+        TestSketcherApp.CreateRectangleSketch(self.PadSketch1, (0, 0), (1, 1), True)
+        self.Doc.recompute()
+        self.Pad1 = self.Doc.addObject("PartDesign::Pad", "Pad1")
+        self.Body.addObject(self.Pad1)
+        self.Pad1.Profile = self.PadSketch1
+        self.Pad1.Type = 2
+        self.Pad1.Reversed = 1
+        self.Doc.recompute()
+        self.failUnless(self.Pad1.Shape.Volume == 1.9999999999999996)
+
+    def testPadtoLastCase(self):
+        self.Body = self.Doc.addObject('PartDesign::Body','Body')
+        # Make first offset cube Pad
+        self.PadSketch = self.Doc.addObject('Sketcher::SketchObject', 'SketchPad')
+        self.Body.addObject(self.PadSketch)
+        TestSketcherApp.CreateRectangleSketch(self.PadSketch, (0.5, 1), (0.5, 2))
+        self.Doc.recompute()
+        self.Pad = self.Doc.addObject("PartDesign::Pad", "Pad")
+        self.Body.addObject(self.Pad)
+        self.Pad.Profile = self.PadSketch
+        self.Pad.Length = 1
+        self.Doc.recompute()
+        # Make second pad on different plane and pad to first
+        self.PadSketch1 = self.Doc.addObject('Sketcher::SketchObject', 'SketchPad1')
+        self.Body.addObject(self.PadSketch1)
+        self.PadSketch1.MapMode = 'FlatFace'
+        self.PadSketch1.Support = (App.ActiveDocument.XZ_Plane, [''])
+        self.Doc.recompute()
+        TestSketcherApp.CreateRectangleSketch(self.PadSketch1, (0, 0), (1, 1), True)
+        self.Doc.recompute()
+        self.Pad1 = self.Doc.addObject("PartDesign::Pad", "Pad1")
+        self.Body.addObject(self.Pad1)
+        self.Pad1.Profile = self.PadSketch1
+        self.Pad1.Type = 1
+        self.Pad1.Reversed = 1
+        self.Doc.recompute()
+        self.failUnless(self.Pad1.Shape.Volume == 2.999999999999999)
+
+    def testPadToFaceCase(self):
+        self.Body = self.Doc.addObject('PartDesign::Body','Body')
+        # Make first offset cube Pad
+        self.PadSketch = self.Doc.addObject('Sketcher::SketchObject', 'SketchPad')
+        self.Body.addObject(self.PadSketch)
+        TestSketcherApp.CreateRectangleSketch(self.PadSketch, (0, 1), (1, 1), True)
+        self.Doc.recompute()
+        self.Pad = self.Doc.addObject("PartDesign::Pad", "Pad")
+        self.Body.addObject(self.Pad)
+        self.Pad.Profile = self.PadSketch
+        self.Pad.Length = 1
+        self.Doc.recompute()
+        # Make second pad on different plane and pad to face on first
+        self.PadSketch1 = self.Doc.addObject('Sketcher::SketchObject', 'SketchPad1')
+        self.Body.addObject(self.PadSketch1)
+        self.PadSketch1.MapMode = 'FlatFace'
+        self.PadSketch1.Support = (App.ActiveDocument.XZ_Plane, [''])
+        self.Doc.recompute()
+        TestSketcherApp.CreateRectangleSketch(self.PadSketch1, (0, 0), (1, 1), True)
+        self.Doc.recompute()
+        self.Pad1 = self.Doc.addObject("PartDesign::Pad", "Pad1")
+        self.Body.addObject(self.Pad1)
+        self.Pad1.Profile = self.PadSketch1
+        self.Pad1.Type = 3
+        self.Pad1.UpToFace = (self.Pad, ["Face3"])
+        self.Pad1.Reversed = 1
+        self.Doc.recompute()
+        self.failUnless(self.Pad1.Shape.Volume == 1.9999999999999996)
+
+    def testPadTwoDimensionsCase(self):
+        self.Body = self.Doc.addObject('PartDesign::Body','Body')
+        # Make first offset cube Pad
+        self.PadSketch = self.Doc.addObject('Sketcher::SketchObject', 'SketchPad')
+        self.Body.addObject(self.PadSketch)
+        TestSketcherApp.CreateRectangleSketch(self.PadSketch, (0, 1), (1, 1), True)
+        self.Doc.recompute()
+        self.Pad = self.Doc.addObject("PartDesign::Pad", "Pad")
+        self.Body.addObject(self.Pad)
+        self.Pad.Profile = self.PadSketch
+        self.Pad.Length = 1
+        self.Doc.recompute()
+        # Make second pad on different plane and pad to face on first
+        self.PadSketch1 = self.Doc.addObject('Sketcher::SketchObject', 'SketchPad1')
+        self.Body.addObject(self.PadSketch1)
+        self.PadSketch1.MapMode = 'FlatFace'
+        self.PadSketch1.Support = (App.ActiveDocument.XZ_Plane, [''])
+        self.Doc.recompute()
+        TestSketcherApp.CreateRectangleSketch(self.PadSketch1, (0, 0), (1, 1), True)
+        self.Doc.recompute()
+        self.Pad1 = self.Doc.addObject("PartDesign::Pad", "Pad1")
+        self.Body.addObject(self.Pad1)
+        self.Pad1.Profile = self.PadSketch1
+        self.Pad1.Type = 4
+        self.Pad1.Length = 2.0
+        self.Pad1.Length2 = 1.0
+        self.Pad1.Reversed = 1
+        self.Doc.recompute()
+        self.failUnless(self.Pad1.Shape.Volume == 3.9999999999999996)
+
     def tearDown(self):
         #closing doc
         FreeCAD.closeDocument("PartDesignTestPad")
-        # print ("omit closing document for debugging")
+        #print ("omit closing document for debugging")
 
 class PartDesignRevolveTestCases(unittest.TestCase):
     def setUp(self):

--- a/src/Mod/Sketcher/TestSketcherApp.py
+++ b/src/Mod/Sketcher/TestSketcherApp.py
@@ -23,6 +23,40 @@
 import FreeCAD, os, sys, unittest, Part, Sketcher
 App = FreeCAD
 
+def CreateRectangleSketch(SketchFeature, corner, lengths, square=False):
+    hmin, hmax = corner[0], corner[0] + lengths[0]
+    vmin, vmax = corner[1], corner[1] + lengths[1]
+
+    # add the geometry and grab the count offset
+    i = int(SketchFeature.GeometryCount)
+    SketchFeature.addGeometry(Part.LineSegment(FreeCAD.Vector(hmin,vmax),FreeCAD.Vector(hmax,vmax,0)))
+    SketchFeature.addGeometry(Part.LineSegment(FreeCAD.Vector(hmax,vmax,0),FreeCAD.Vector(hmax,vmin,0)))
+    SketchFeature.addGeometry(Part.LineSegment(FreeCAD.Vector(hmax,vmin,0),FreeCAD.Vector(hmin,vmin,0)))
+    SketchFeature.addGeometry(Part.LineSegment(FreeCAD.Vector(hmin,vmin,0),FreeCAD.Vector(hmin,vmax,0)))
+
+    # add the rectangular constraints
+    SketchFeature.addConstraint(Sketcher.Constraint('Coincident',i+0,2,i+1,1)) 
+    SketchFeature.addConstraint(Sketcher.Constraint('Coincident',i+1,2,i+2,1)) 
+    SketchFeature.addConstraint(Sketcher.Constraint('Coincident',i+2,2,i+3,1)) 
+    SketchFeature.addConstraint(Sketcher.Constraint('Coincident',i+3,2,i+0,1)) 
+    SketchFeature.addConstraint(Sketcher.Constraint('Horizontal',i+0)) 
+    SketchFeature.addConstraint(Sketcher.Constraint('Horizontal',i+2)) 
+    SketchFeature.addConstraint(Sketcher.Constraint('Vertical',i+1)) 
+    SketchFeature.addConstraint(Sketcher.Constraint('Vertical',i+3)) 
+
+    # Fix the bottom left corner of the rectangle
+    App.ActiveDocument.Sketch.addConstraint(Sketcher.Constraint('DistanceX',i+2,2,corner[0])) 
+    App.ActiveDocument.Sketch.addConstraint(Sketcher.Constraint('DistanceY',i+2,2,corner[1])) 
+
+    # add dimensions
+    if square:
+        # Make sure it's square
+        SketchFeature.addConstraint(Sketcher.Constraint('Equal',i+2,i+3)) 
+        SketchFeature.addConstraint(Sketcher.Constraint('Distance',i+0,hmax-hmin)) 
+    else:
+        SketchFeature.addConstraint(Sketcher.Constraint('Distance',i+1,vmax-vmin)) 
+        SketchFeature.addConstraint(Sketcher.Constraint('Distance',i+0,hmax-hmin)) 
+    
 def CreateBoxSketchSet(SketchFeature):
 	SketchFeature.addGeometry(Part.LineSegment(FreeCAD.Vector(-99.230339,36.960674,0),FreeCAD.Vector(69.432587,36.960674,0)))
 	SketchFeature.addGeometry(Part.LineSegment(FreeCAD.Vector(69.432587,36.960674,0),FreeCAD.Vector(69.432587,-53.196629,0)))

--- a/src/Mod/Sketcher/TestSketcherApp.py
+++ b/src/Mod/Sketcher/TestSketcherApp.py
@@ -45,8 +45,8 @@ def CreateRectangleSketch(SketchFeature, corner, lengths, square=False):
     SketchFeature.addConstraint(Sketcher.Constraint('Vertical',i+3)) 
 
     # Fix the bottom left corner of the rectangle
-    App.ActiveDocument.Sketch.addConstraint(Sketcher.Constraint('DistanceX',i+2,2,corner[0])) 
-    App.ActiveDocument.Sketch.addConstraint(Sketcher.Constraint('DistanceY',i+2,2,corner[1])) 
+    SketchFeature.addConstraint(Sketcher.Constraint('DistanceX',i+2,2,corner[0])) 
+    SketchFeature.addConstraint(Sketcher.Constraint('DistanceY',i+2,2,corner[1])) 
 
     # add dimensions
     if square:


### PR DESCRIPTION
Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [X] Branch rebased on latest master `git pull --rebase upstream master`
- [X] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [X] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [X] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR once it is merged.

---
This PR adds test cases for all the Pad and Pocket modes. It also adds a small helper function `TestSketcherApp.CreateRectangleSketch`.