### PR TITLE
py3: boost: some diff for the cmake of libarea to work with boost1.64

### DIFF
--- a/src/Mod/Path/libarea/CMakeLists.txt
+++ b/src/Mod/Path/libarea/CMakeLists.txt
@@ -12,7 +12,13 @@ include_directories(${PYTHON_INCLUDE_DIRS})
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
 if(NOT FREECAD_LIBPACK_USE OR FREECAD_LIBPACK_CHECKFILE_CLBUNDLER)
-    find_package( Boost COMPONENTS python REQUIRED)  # find BOOST and boost-python
+    set(Boost_FOUND False)
+    if (PYTHON_MAJOR_VERSION GREATER 2) # python3
+        find_package( Boost COMPONENTS python3)
+    endif()
+    if (NOT Boost_FOUND)
+        find_package( Boost COMPONENTS python REQUIRED)  # find BOOST and boost-python
+    endif()
     if(Boost_FOUND)
         include_directories(${Boost_INCLUDE_DIRS})
         MESSAGE(STATUS "found Boost: " ${Boost_LIB_VERSION})


### PR DESCRIPTION
This is only tested with conda and related to this issue: https://github.com/conda-forge/boost-feedstock/issues/38


Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR once it is merged.

---
