### PR TITLE
py3: boost: some diff for the cmake of libarea to work with boost1.64…

### DIFF
--- a/src/Mod/Path/libarea/CMakeLists.txt
+++ b/src/Mod/Path/libarea/CMakeLists.txt
@@ -12,7 +12,15 @@ include_directories(${PYTHON_INCLUDE_DIRS})
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
 if(NOT FREECAD_LIBPACK_USE OR FREECAD_LIBPACK_CHECKFILE_CLBUNDLER)
-    find_package( Boost COMPONENTS python REQUIRED)  # find BOOST and boost-python
+    if(NOT PYTHON_VERSION_MAJOR LESS 3)
+        find_package( Boost COMPONENTS python3)
+        if (NOT Boost_PYTHON3_FOUND)
+            find_package( Boost COMPONENTS python REQUIRED)
+        endif()
+    else()
+        find_package( Boost COMPONENTS python REQUIRED)  # find BOOST and boost-python
+    endif()
+
     if(Boost_FOUND)
         include_directories(${Boost_INCLUDE_DIRS})
         MESSAGE(STATUS "found Boost: " ${Boost_LIB_VERSION})


### PR DESCRIPTION
with boost 1.64 the names of python bindings for py2 and py3 differs. So we have to find python3 explicitly.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR once it is merged.

---
