### PR TITLE
Part GeomBezierCurve implement Save() and Restore()

### DIFF
--- a/src/Mod/Part/App/Geometry.h
+++ b/src/Mod/Part/App/Geometry.h
@@ -193,8 +193,11 @@ class PartExport GeomBezierCurve : public GeomBoundedCurve
 public:
     GeomBezierCurve();
     GeomBezierCurve(const Handle(Geom_BezierCurve)&);
+    GeomBezierCurve(const std::vector<Base::Vector3d>&, const std::vector<double>&);
     virtual ~GeomBezierCurve();
     virtual Geometry *copy(void) const;
+    std::vector<Base::Vector3d> getPoles() const;
+    std::vector<double> getWeights() const;
 
     // Persistence implementer ---------------------
     virtual unsigned int getMemSize (void) const;


### PR DESCRIPTION
Hi,
Related topic : [https://forum.freecadweb.org/viewtopic.php?f=22&t=23095](https://forum.freecadweb.org/viewtopic.php?f=22&t=23095)
Trying to add a Part.BezierCurve into a PropertyGeometryList creates a crash.
This seems to be due to not implemented save / restore methods.
This PR adds the Save / Restore methods, and 3 others that were needed (a new constructor, getPoles and getWeights).
Thanks,


Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR once it is merged.

---
