### PR TITLE
App::Document: fix breakDependency

### DIFF
--- a/src/App/Document.cpp
+++ b/src/App/Document.cpp
@@ -2683,15 +2683,14 @@ void Document::breakDependency(DocumentObject* pcObject, bool clear)
                     link->setValues(std::vector<DocumentObject*>());
                 }
                 else {
-                    // copy the list (not the objects)
-                    std::vector<DocumentObject*> linked = link->getValues();
-                    for (std::vector<DocumentObject*>::iterator fIt = linked.begin(); fIt != linked.end(); ++fIt) {
-                        if ((*fIt) == pcObject) {
-                            // reassign the the list without the object to be deleted
-                            linked.erase(fIt);
-                            link->setValues(linked);
-                            break;
+                    const auto &links = link->getValues();
+                    if (std::find(links.begin(), links.end(), pcObject) != links.end()) {
+                        std::vector<DocumentObject*> newLinks;
+                        for(auto obj : links) {
+                            if (obj != pcObject) 
+                                newLinks.push_back(obj);
                         }
+                        link->setValues(newLinks);
                     }
                 }
             }


### PR DESCRIPTION
Fixed breakDependency to handle repetitive entries inside PropertyLinkList, which may otherwise resulting a crash.

A more general question though, is that, shall we prohibit repetitive entries in PropertyLinkList altogether, by raising exception in its setValues()? One thing I know that, the tree view does not behave correctly if there are repetitive entries in claimChildren(), which usually comes from PropertyLinkList. 