### PR TITLE
path: fixing a broken import statement in python2

### DIFF
--- a/src/Mod/Path/PathScripts/PathToolController.py
+++ b/src/Mod/Path/PathScripts/PathToolController.py
@@ -23,13 +23,19 @@
 # ***************************************************************************
 ''' Tool Controller defines tool, spindle speed and feed rates for Path Operations '''
 
+import sys
 import FreeCAD
 import FreeCADGui
 import Part
 import Path
 import PathScripts
 import PathScripts.PathLog as PathLog
-from . import PathUtils
+if sys.version_info < (3, 0):
+    import PathUtils  # This doesn't work in python3, but as this import introduce a circular import
+                      # there is no alternitive.
+else:
+    from . import PathUtils
+
 import xml.etree.ElementTree as xml
 
 from FreeCAD import Units


### PR DESCRIPTION
`from . import module` does not allways work for python2 and python3. If it is part of a circular import this statement will not work with python2.

https://github.com/FreeCAD/FreeCAD/commit/4b2c5f51e4bc41d8e7e18db0641b3db668c4e807#commitcomment-22790155

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR once it is merged.

---
