### PR TITLE
Fix Drawing/TechDraw BSplines

### DIFF
--- a/src/Mod/Drawing/App/DrawingExport.cpp
+++ b/src/Mod/Drawing/App/DrawingExport.cpp
@@ -359,17 +359,18 @@ void SVGOutput::printBSpline(const BRepAdaptor_Curve& c, int id, std::ostream& o
 {
     try {
         std::stringstream str;
-        Handle(Geom_BSplineCurve) spline = c.BSpline();
-        if (spline->Degree() > 3 || spline->IsRational()) {
-            Standard_Real tol3D = 0.001;
-            Standard_Integer maxDegree = 3, maxSegment = 100;
-            Handle(BRepAdaptor_HCurve) hCurve = new BRepAdaptor_HCurve(c);
-            // approximate the curve using a tolerance
-            Approx_Curve3d approx(hCurve,tol3D,GeomAbs_C0,maxSegment,maxDegree);
-            if (approx.IsDone() && approx.HasResult()) {
-                // have the result
-                spline = approx.Curve();
-            }
+        Handle(Geom_BSplineCurve) spline;
+        Standard_Real tol3D = 0.001;
+        Standard_Integer maxDegree = 3, maxSegment = 100;
+        Handle(BRepAdaptor_HCurve) hCurve = new BRepAdaptor_HCurve(c);
+        // approximate the curve using a tolerance
+        Approx_Curve3d approx(hCurve,tol3D,GeomAbs_C0,maxSegment,maxDegree);
+        if (approx.IsDone() && approx.HasResult()) {
+            // have the result
+            spline = approx.Curve();
+        } else {
+            printGeneric(c, id, out);
+            return;
         }
 
         GeomConvert_BSplineCurveToBezierCurve crt(spline);
@@ -659,17 +660,18 @@ void DXFOutput::printBSpline(const BRepAdaptor_Curve& c, int id, std::ostream& o
 {
     try {
         std::stringstream str;
-        Handle(Geom_BSplineCurve) spline = c.BSpline();
-        if (spline->Degree() > 3 || spline->IsRational()) {
-            Standard_Real tol3D = 0.001;
-            Standard_Integer maxDegree = 3, maxSegment = 50;
-            Handle(BRepAdaptor_HCurve) hCurve = new BRepAdaptor_HCurve(c);
-            // approximate the curve using a tolerance
-            Approx_Curve3d approx(hCurve,tol3D,GeomAbs_C0,maxSegment,maxDegree);
-            if (approx.IsDone() && approx.HasResult()) {
-                // have the result
-                spline = approx.Curve();
-            }
+        Handle(Geom_BSplineCurve) spline;
+        Standard_Real tol3D = 0.001;
+        Standard_Integer maxDegree = 3, maxSegment = 50;
+        Handle(BRepAdaptor_HCurve) hCurve = new BRepAdaptor_HCurve(c);
+        // approximate the curve using a tolerance
+        Approx_Curve3d approx(hCurve,tol3D,GeomAbs_C0,maxSegment,maxDegree);
+        if (approx.IsDone() && approx.HasResult()) {
+            // have the result
+            spline = approx.Curve();
+        } else {
+            printGeneric(c, id, out);
+            return;
         }
 		
         //GeomConvert_BSplineCurveToBezierCurve crt(spline);


### PR DESCRIPTION
Please merge.
Thanks,
wf
[Forum discussion here](https://www.forum.freecadweb.org/viewtopic.php?f=3&t=23126)

In some cases the Geom_BSplineCurve returned by
BrepAdaptor_Curve.BSpline() does not have the
same endpoints as the original Edge and should
not be used in place of Approx_Curve3d.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ x] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR once it is merged.

---
