### PR TITLE
TextDocument with full size editor (QPlainTextEdit)

### DIFF
--- a/src/App/Application.cpp
+++ b/src/App/Application.cpp
@@ -106,6 +106,7 @@
 #include "OriginFeature.h"
 #include "Origin.h"
 #include "MaterialObject.h"
+#include "TextDocument.h"
 #include "Expression.h"
 #include "Transactions.h"
 #include <App/MaterialPy.h>
@@ -1301,6 +1302,7 @@ void Application::initTypes(void)
     App ::MeasureDistance           ::init();
     App ::MaterialObject            ::init();
     App ::MaterialObjectPython      ::init();
+    App ::TextDocument              ::init();
     App ::Placement                 ::init();
     App ::OriginFeature             ::init();
     App ::Plane                     ::init();

--- a/src/App/CMakeLists.txt
+++ b/src/App/CMakeLists.txt
@@ -150,6 +150,7 @@ SET(Document_CPP_SRCS
     VRMLObject.cpp
     MaterialObject.cpp
     MergeDocuments.cpp
+    TextDocument.cpp
 )
 
 SET(Document_HPP_SRCS
@@ -187,6 +188,7 @@ SET(Document_HPP_SRCS
     VRMLObject.h
     MaterialObject.h
     MergeDocuments.h
+    TextDocument.h
 )
 SET(Document_SRCS
     ${Document_CPP_SRCS}

--- a/src/App/TextDocument.cpp
+++ b/src/App/TextDocument.cpp
@@ -1,0 +1,63 @@
+/***************************************************************************
+ *   Copyright (c) 2017 Markus Hovorka <m.hovorka@live.de>                 *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+
+#include "PreCompiled.h"
+
+#include <string>
+#include <fstream>
+#include <boost/signals2.hpp>
+
+#include "DocumentObject.h"
+#include "TextDocument.h"
+
+
+using namespace App;
+
+PROPERTY_SOURCE(App::TextDocument, App::DocumentObject)
+
+TextDocument::TextDocument()
+{
+    ADD_PROPERTY_TYPE(
+            Text, (""), 0, App::Prop_Hidden,
+            "Content of the document.");
+    ADD_PROPERTY_TYPE(
+            ReadOnly, (false), 0, App::Prop_None,
+            "Defines whether the content can be edited.");
+}
+
+void TextDocument::onChanged(const Property* prop)
+{
+    if (prop == &Text)
+        textChanged();
+    DocumentObject::onChanged(prop);
+}
+
+const char* TextDocument::getViewProviderName() const
+{
+    return "Gui::ViewProviderTextDocument";
+}
+
+boost::signals2::connection TextDocument::connect(const TextSlot &sub)
+{
+    return textChanged.connect(sub);
+}

--- a/src/App/TextDocument.h
+++ b/src/App/TextDocument.h
@@ -1,0 +1,61 @@
+/***************************************************************************
+ *   Copyright (c) 2017 Markus Hovorka <m.hovorka@live.de>                 *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+
+#ifndef APP_TEXTDOCUMENT_H
+#define APP_TEXTDOCUMENT_H
+
+
+#include <string>
+#include <boost/signals2.hpp>
+
+#include "DocumentObject.h"
+#include "PropertyStandard.h"
+
+
+namespace App
+{
+
+class AppExport TextDocument : public App::DocumentObject {
+    PROPERTY_HEADER(App::TextDocument);
+public:
+    using TextSignal = boost::signals2::signal<void ()>;
+    using TextSlot = TextSignal::slot_type;
+
+    PropertyString Text;
+    PropertyBool ReadOnly;
+
+    TextDocument();
+    ~TextDocument() {};
+
+    void onChanged(const Property* prop);
+    const char* getViewProviderName() const;
+
+    boost::signals2::connection connect(const TextSlot &sub);
+private:
+    TextSignal textChanged;
+};
+
+}
+
+
+#endif

--- a/src/Gui/Application.cpp
+++ b/src/Gui/Application.cpp
@@ -115,6 +115,7 @@
 #include "ViewProviderPart.h"
 #include "ViewProviderOrigin.h"
 #include "ViewProviderMaterialObject.h"
+#include "ViewProviderTextDocument.h"
 #include "ViewProviderGroupExtension.h"
 
 #include "Language/Translator.h"
@@ -1547,6 +1548,7 @@ void Application::initTypes(void)
     Gui::ViewProviderOrigin                     ::init();
     Gui::ViewProviderMaterialObject             ::init();
     Gui::ViewProviderMaterialObjectPython       ::init();
+    Gui::ViewProviderTextDocument               ::init();
 
     // Workbench
     Gui::Workbench                              ::init();

--- a/src/Gui/CMakeLists.txt
+++ b/src/Gui/CMakeLists.txt
@@ -242,6 +242,7 @@ set(Gui_MOC_HDRS
     DockWindowManager.h
     DocumentRecovery.h
     EditorView.h
+    TextDocumentEditorView.h
     ExpressionCompleter.h
     DlgExpressionInput.h
     FileDialog.h
@@ -631,6 +632,7 @@ SOURCE_GROUP("Dock Windows" FILES ${Dock_Windows_SRCS})
 SET(Editor_CPP_SRCS
     CallTips.cpp
     EditorView.cpp
+    TextDocumentEditorView.cpp
     PythonConsole.cpp
     PythonConsolePy.cpp
     PythonDebugger.cpp
@@ -641,6 +643,7 @@ SET(Editor_CPP_SRCS
 SET(Editor_HPP_SRCS
     CallTips.h
     EditorView.h
+    TextDocumentEditorView.h
     PythonConsole.h
     PythonConsolePy.h
     PythonDebugger.h
@@ -896,6 +899,7 @@ SET(Viewprovider_CPP_SRCS
     ViewProviderPart.cpp
     ViewProviderOrigin.cpp
     ViewProviderMaterialObject.cpp
+    ViewProviderTextDocument.cpp
 )
 SET(Viewprovider_SRCS
     ${Viewprovider_CPP_SRCS}
@@ -924,6 +928,7 @@ SET(Viewprovider_SRCS
     ViewProviderPart.h
     ViewProviderOrigin.h
     ViewProviderMaterialObject.h
+    ViewProviderTextDocument.h
 )
 SOURCE_GROUP("View3D\\Viewprovider" FILES ${Viewprovider_SRCS})
 

--- a/src/Gui/Icons/TextDocument.svg
+++ b/src/Gui/Icons/TextDocument.svg
@@ -1,0 +1,230 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   id="svg4198"
+   height="48px"
+   width="48px"
+   sodipodi:docname="TextDocument.svg"
+   inkscape:version="0.92.1 r">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="956"
+     inkscape:window-height="1115"
+     id="namedview4578"
+     showgrid="false"
+     inkscape:zoom="6.9532167"
+     inkscape:cx="26.229423"
+     inkscape:cy="5.7122022"
+     inkscape:window-x="2880"
+     inkscape:window-y="83"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g12863" />
+  <defs
+     id="defs4200">
+    <linearGradient
+       id="linearGradient15218">
+      <stop
+         id="stop15220"
+         offset="0.0000000"
+         style="stop-color:#f0f0ef;stop-opacity:1.0000000;" />
+      <stop
+         style="stop-color:#e8e8e8;stop-opacity:1;"
+         offset="0.59928656"
+         id="stop2269" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0.82758623"
+         id="stop2267" />
+      <stop
+         id="stop15222"
+         offset="1.0000000"
+         style="stop-color:#d8d8d3;stop-opacity:1.0000000;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2259">
+      <stop
+         id="stop2261"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="stop2263"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2224">
+      <stop
+         id="stop2226"
+         offset="0"
+         style="stop-color:#7c7c7c;stop-opacity:1;" />
+      <stop
+         id="stop2228"
+         offset="1"
+         style="stop-color:#b8b8b8;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(6.161836,4.033411)"
+       gradientUnits="userSpaceOnUse"
+       y2="37.770721"
+       x2="33.664921"
+       y1="40.458221"
+       x1="35.996582"
+       id="linearGradient2230"
+       xlink:href="#linearGradient2224" />
+    <linearGradient
+       id="linearGradient2251">
+      <stop
+         id="stop2253"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="stop2255"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(6.161836,3.658411)"
+       gradientUnits="userSpaceOnUse"
+       y2="38.070381"
+       x2="34.170048"
+       y1="36.921333"
+       x1="33.396004"
+       id="linearGradient2257"
+       xlink:href="#linearGradient2251" />
+    <linearGradient
+       y2="42.007351"
+       x2="30.811172"
+       y1="26.696676"
+       x1="26.076092"
+       gradientTransform="matrix(0.999421,0,0,1,5.991319,4.033411)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13651"
+       xlink:href="#linearGradient2259" />
+    <linearGradient
+       y2="39.498238"
+       x2="35.785294"
+       y1="18.992140"
+       x1="22.308331"
+       gradientTransform="matrix(1.067236,0,0,0.989276,4.391684,4.035227)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient13653"
+       xlink:href="#linearGradient15218" />
+  </defs>
+  <metadata
+     id="metadata4203">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+        <dc:date>2005-10-15</dc:date>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>Andreas Nilsson</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:subject>
+          <rdf:Bag>
+            <rdf:li>edit</rdf:li>
+            <rdf:li>copy</rdf:li>
+          </rdf:Bag>
+        </dc:subject>
+        <cc:license
+           rdf:resource="http://creativecommons.org/licenses/by-sa/2.0/" />
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title>Jakub Steiner</dc:title>
+          </cc:Agent>
+        </dc:contributor>
+      </cc:Work>
+      <cc:License
+         rdf:about="http://creativecommons.org/licenses/by-sa/2.0/">
+        <cc:permits
+           rdf:resource="http://web.resource.org/cc/Reproduction" />
+        <cc:permits
+           rdf:resource="http://web.resource.org/cc/Distribution" />
+        <cc:requires
+           rdf:resource="http://web.resource.org/cc/Notice" />
+        <cc:requires
+           rdf:resource="http://web.resource.org/cc/Attribution" />
+        <cc:permits
+           rdf:resource="http://web.resource.org/cc/DerivativeWorks" />
+        <cc:requires
+           rdf:resource="http://web.resource.org/cc/ShareAlike" />
+      </cc:License>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1">
+    <g
+       transform="matrix(1.1249531,0,0,1.1249531,-9.7587421,-8.0938643)"
+       id="g12863">
+      <path
+         id="rect12413"
+         d="m 15.072946,10.500852 h 29.856385 c 0.31574,0 0.569926,0.253093 0.569926,0.567472 v 27.167362 c 0,2.476452 -6.87981,8.303087 -9.267932,8.303087 H 15.072946 c -0.31574,0 -0.569926,-0.253092 -0.569926,-0.567473 V 11.068324 c 0,-0.314379 0.254186,-0.567472 0.569926,-0.567472 z"
+         style="fill:url(#linearGradient13653);fill-opacity:1;fill-rule:evenodd;stroke:#888a85;stroke-width:1.00000024;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1" />
+      <rect
+         style="opacity:1;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient13651);stroke-width:1.00000083;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="rect15244"
+         width="28.997349"
+         height="34.040764"
+         x="15.502951"
+         y="11.5"
+         rx="0.0000000"
+         ry="0.0000000" />
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:url(#linearGradient2230);fill-opacity:1;fill-rule:evenodd;stroke:#868a84;stroke-width:1.00000024;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none"
+         d="m 36.220918,46.536966 c 2.030418,0.329898 9.588793,-4.529929 9.284411,-8.497844 -1.563262,2.423097 -4.758522,1.286738 -8.86728,1.445748 0,0 0.395369,6.552096 -0.417131,7.052096 z"
+         id="path2210" />
+      <path
+         id="path2247"
+         d="m 37.671355,44.345464 c 1.369779,-0.683829 4.428249,-2.146465 5.72763,-4.027469 -1.596094,0.680055 -2.94781,0.209496 -5.702334,0.190405 0,0 0.162322,3.062094 -0.0253,3.837064 z"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.36931817;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient2257);stroke-width:0.99999982;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none" />
+      <rect
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.82;fill:#888a85;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none"
+         id="rect2271"
+         width="21"
+         height="2"
+         x="20"
+         y="19.033415" />
+      <rect
+         y="23.033415"
+         x="20"
+         height="2"
+         width="19.992233"
+         id="rect2273"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.82;fill:#888a85;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none" />
+      <rect
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.82;fill:#888a85;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none"
+         id="rect2275"
+         width="17.976702"
+         height="2"
+         x="20"
+         y="27.033415" />
+      <rect
+         y="31.033415"
+         x="20"
+         height="2"
+         width="21"
+         id="rect2277"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.82;fill:#888a85;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none" />
+    </g>
+  </g>
+</svg>

--- a/src/Gui/Icons/resource.qrc
+++ b/src/Gui/Icons/resource.qrc
@@ -11,6 +11,7 @@
         <file>freecad.svg</file>
         <file>freecad-doc.png</file>
         <file>bulb.svg</file>
+        <file>TextDocument.svg</file>
         <file>button_down.svg</file>
         <file>button_left.svg</file>
         <file>button_right.svg</file>

--- a/src/Gui/TextDocumentEditorView.cpp
+++ b/src/Gui/TextDocumentEditorView.cpp
@@ -1,0 +1,168 @@
+/***************************************************************************
+ *   Copyright (c) 2017 Markus Hovorka <m.hovorka@live.de>                 *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+
+#include "PreCompiled.h"
+
+#include <iostream>
+#include <boost/bind.hpp>
+#include <boost/signals2.hpp>
+#include <QString>
+#include <QMessageBox>
+#include <QPushButton>
+
+#include <App/TextDocument.h>
+#include <Gui/Document.h>
+#include <Gui/Application.h>
+#include <Gui/MainWindow.h>
+
+#include "TextDocumentEditorView.h"
+
+
+using namespace Gui;
+
+TextDocumentEditorView::TextDocumentEditorView(
+        App::TextDocument* txtDoc, QPlainTextEdit* e,
+        QWidget* parent)
+    : MDIView(
+            Application::Instance->getDocument(txtDoc->getDocument()),
+            parent),
+    editor {e}, textDocument {txtDoc}
+{
+    setupEditor();
+    setupConnection();
+    setCentralWidget(editor);
+}
+
+TextDocumentEditorView::~TextDocumentEditorView()
+{
+    textConnection.disconnect();
+}
+
+bool TextDocumentEditorView::event(QEvent *event)
+{
+    if (event->type() == QEvent::Show && sourceModified) {
+        refresh();
+        sourceModified = false;
+    }
+    return MDIView::event(event);
+}
+
+void TextDocumentEditorView::setupEditor()
+{
+    connect(getEditor()->document(), SIGNAL(modificationChanged(bool)),
+            this, SLOT(setWindowModified(bool)));
+    getEditor()->setReadOnly(textDocument->ReadOnly.getValue());
+    setWindowTitle(QString::fromLatin1(textDocument->Label.getValue())
+            + QString::fromLatin1("[*]"));
+    getEditor()->setPlainText(
+            QString::fromUtf8(textDocument->Text.getValue()));
+}
+
+void TextDocumentEditorView::setupConnection()
+{
+    textConnection = textDocument->connect(
+            boost::bind(&TextDocumentEditorView::sourceChanged, this));
+}
+
+void TextDocumentEditorView::sourceChanged()
+{
+    if (getMainWindow()->activeWindow() == this) {
+        refresh();
+        sourceModified = false;
+    } else {
+        sourceModified = true;
+    }
+}
+
+void TextDocumentEditorView::refresh()
+{
+    QString text = QString::fromStdString(
+            textDocument->Text.getStrValue());
+    if (isEditorModified()) {
+        QMessageBox msgBox {this};
+        msgBox.setWindowTitle(QString::fromUtf8("Text updated"));
+        msgBox.setIcon(QMessageBox::Question);
+        msgBox.setText(QString::fromUtf8(
+                    "The text of the underlying object has changed. "
+                    "Discard changes and reload the text from the object?"));
+        QPushButton* yesBtt = msgBox.addButton(
+                QString::fromUtf8("Yes, reload."), QMessageBox::YesRole);
+        QPushButton* noBtt = msgBox.addButton(
+                QString::fromUtf8("No"), QMessageBox::NoRole);
+        msgBox.exec();
+        if (msgBox.clickedButton() == noBtt)
+            return;
+    }
+    getEditor()->setPlainText(text);
+}
+
+bool TextDocumentEditorView::onMsg(const char* msg, const char**)
+{
+    if (strcmp(msg,"Save") == 0) {
+        saveToObject();
+        return true;
+    }
+    return false;
+}
+
+bool TextDocumentEditorView::isEditorModified() const
+{
+    return getEditor()->document()->isModified();
+}
+
+bool TextDocumentEditorView::onHasMsg(const char* msg) const
+{
+    if (strcmp(msg,"Save") == 0)
+        return isEditorModified();
+    return false;
+}
+
+bool TextDocumentEditorView::canClose()
+{
+    if (!getEditor()->document()->isModified())
+        return true;
+
+    this->setFocus();
+
+    QString question {
+        tr("The document has been modified.\n"
+                "Do you want to save your changes?")};
+    auto reply = QMessageBox::question(
+            this, tr("Unsaved document"), question,
+            QMessageBox::Yes|QMessageBox::Default, QMessageBox::No,
+            QMessageBox::Cancel|QMessageBox::Escape);
+    if (reply == QMessageBox::Yes)
+        saveToObject();
+    return reply != QMessageBox::Cancel;
+}
+
+void TextDocumentEditorView::saveToObject()
+{
+    boost::signals2::shared_connection_block textBlock {textConnection};
+    textDocument->Text.setValue(
+            getEditor()->document()->toPlainText().toStdString());
+    getEditor()->document()->setModified(false);
+}
+
+
+#include "moc_TextDocumentEditorView.cpp"

--- a/src/Gui/TextDocumentEditorView.h
+++ b/src/Gui/TextDocumentEditorView.h
@@ -1,0 +1,71 @@
+/***************************************************************************
+ *   Copyright (c) 2017 Markus Hovorka <m.hovorka@live.de>                 *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+
+#ifndef GUI_TEXTDOCUMENTEDITORVIEW_H
+#define GUI_TEXTDOCUMENTEDITORVIEW_H
+
+#include "PreCompiled.h"
+
+#include <string>
+#include <boost/signals2.hpp>
+#include <QPlainTextEdit>
+
+#include <App/TextDocument.h>
+#include <Gui/MDIView.h>
+#include <Gui/Window.h>
+
+
+namespace Gui {
+
+class GuiExport TextDocumentEditorView : public MDIView {
+    Q_OBJECT
+public:
+    TextDocumentEditorView(
+            App::TextDocument* textDocument,
+            QPlainTextEdit* editor, QWidget* parent);
+    ~TextDocumentEditorView();
+    const char *getName() const { return "TextDocumentEditorView"; }
+    bool onMsg(const char* msg, const char**);
+    bool onHasMsg(const char* msg) const;
+    bool canClose() override;
+
+    bool event(QEvent *event);
+
+    QPlainTextEdit* getEditor() const { return editor; }
+    App::TextDocument* getTextObject() const { return textDocument; }
+private:
+    void setupEditor();
+    void setupConnection();
+    void saveToObject();
+    void sourceChanged();
+    void refresh();
+    bool isEditorModified() const;
+    QPlainTextEdit *const editor;
+    App::TextDocument *const textDocument;
+    boost::signals2::connection textConnection;
+    bool sourceModified = false;
+};
+
+}
+
+#endif

--- a/src/Gui/ViewProviderTextDocument.cpp
+++ b/src/Gui/ViewProviderTextDocument.cpp
@@ -1,0 +1,72 @@
+/***************************************************************************
+ *   Copyright (c) 2017 Markus Hovorka <m.hovorka@live.de>                 *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+
+#include "PreCompiled.h"
+
+#ifndef _PreComp_
+#include <QPlainTextEdit>
+#endif
+
+#include <Base/Type.h>
+#include <Gui/ViewProviderDocumentObject.h>
+#include <Gui/TextDocumentEditorView.h>
+#include <Gui/MainWindow.h>
+#include <Gui/Document.h>
+
+#include "ViewProviderTextDocument.h"
+
+
+using namespace Gui;
+
+PROPERTY_SOURCE(Gui::ViewProviderTextDocument, Gui::ViewProviderDocumentObject)
+
+ViewProviderTextDocument::ViewProviderTextDocument()
+{
+    sPixmap = "TextDocument";
+}
+
+bool ViewProviderTextDocument::doubleClicked()
+{
+    if (!activateView()) {
+        auto* editorWidget = new QPlainTextEdit {};
+        getMainWindow()->addWindow(
+            new TextDocumentEditorView {
+                static_cast<App::TextDocument*>(getObject()),
+                editorWidget, getMainWindow()});
+    }
+    return true;
+}
+
+bool ViewProviderTextDocument::activateView() const
+{
+    auto views = getDocument()->getMDIViewsOfType(
+            TextDocumentEditorView::getClassTypeId());
+    for (auto v : views) {
+        auto textView = static_cast<TextDocumentEditorView *>(v);
+        if (textView->getTextObject() == getObject()) {
+            getMainWindow()->setActiveWindow(textView);
+            return true;
+        }
+    }
+    return false;
+}

--- a/src/Gui/ViewProviderTextDocument.h
+++ b/src/Gui/ViewProviderTextDocument.h
@@ -1,0 +1,49 @@
+/***************************************************************************
+ *   Copyright (c) 2017 Markus Hovorka <m.hovorka@live.de>                 *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+
+#ifndef GUI_ViewProviderTextDocument_H
+#define GUI_ViewProviderTextDocument_H
+
+
+#include "PreCompiled.h"
+#include "ViewProviderDocumentObject.h"
+
+
+namespace Gui {
+
+class GuiExport ViewProviderTextDocument : public ViewProviderDocumentObject {
+    PROPERTY_HEADER(Gui::ViewProviderTextDocument);
+public:
+    ViewProviderTextDocument();
+    ~ViewProviderTextDocument() {}
+
+    bool doubleClicked();
+    bool isShow() const { return true; }
+private:
+    bool activateView() const;
+};
+
+}
+
+#endif
+


### PR DESCRIPTION
A new document object App::TextDocument. It has a property Text which
holds the text of the document as a string. This commit also contains a
full size editor based on QPlainTextEdit. It can only be used by the
TextDocument and has a read only mode invoked for read only documents
(ReadOnly property set to true). The editor is invoked by a double
click on the TextDocument.

This TextDocument is a prerequisite of the soon to be merged elmer support
for the FEM WB.