### PR TITLE
Reset depth_params index when starting a new iterator.

### DIFF
--- a/src/Mod/Path/PathScripts/PathUtils.py
+++ b/src/Mod/Path/PathScripts/PathUtils.py
@@ -763,6 +763,7 @@ class depth_params:
         self.index = 0
 
     def __iter__(self):
+        self.index = 0
         return self
 
     def __next__(self):


### PR DESCRIPTION
Reset index in depth_params when starting a new iterator.
Otherwise, when a profile consists of multiple cuts (example: profile outline+circles+holes) only the first one
will respect the requested depths.



