### PR TITLE
[0.20] History storage framework  and options for select methods in TopoShapePy

### DIFF
--- a/src/Mod/Part/App/CMakeLists.txt
+++ b/src/Mod/Part/App/CMakeLists.txt
@@ -344,6 +344,8 @@ SET(Part_SRCS
     ProgressIndicator.h
     TopoShape.cpp
     TopoShape.h
+    TopoHistory.cpp
+    TopoHistory.h
     edgecluster.cpp
     edgecluster.h
     modelRefine.cpp

--- a/src/Mod/Part/App/CMakeLists.txt
+++ b/src/Mod/Part/App/CMakeLists.txt
@@ -74,6 +74,7 @@ generate_from_xml(PartFeaturePy)
 generate_from_xml(AttachExtensionPy)
 generate_from_xml(Part2DObjectPy)
 generate_from_xml(AttachEnginePy)
+generate_from_xml(TopoHistoryPy)
 generate_from_xml(TopoShapePy)
 generate_from_xml(TopoShapeCompoundPy)
 generate_from_xml(TopoShapeCompSolidPy)
@@ -255,6 +256,8 @@ SET(Python_SRCS
     Part2DObjectPyImp.cpp
     AttachEnginePy.xml
     AttachEnginePyImp.cpp
+    TopoHistoryPy.xml
+    TopoHistoryPyImp.cpp
     TopoShapePy.xml
     TopoShapePyImp.cpp
     TopoShapeCompSolidPy.xml

--- a/src/Mod/Part/App/FeaturePartBoolean.cpp
+++ b/src/Mod/Part/App/FeaturePartBoolean.cpp
@@ -80,7 +80,7 @@ App::DocumentObjectExecReturn *Boolean::execute(void)
         if (ToolShape.IsNull())
             throw Base::Exception("Tool shape is null");
 
-        std::unique_ptr<BRepAlgoAPI_BooleanOperation> mkBool(makeOperation(BaseShape, ToolShape));
+        std::shared_ptr<BRepAlgoAPI_BooleanOperation> mkBool(makeOperation(BaseShape, ToolShape));
         if (!mkBool->IsDone()) {
             return new App::DocumentObjectExecReturn("Boolean operation failed");
         }
@@ -99,8 +99,8 @@ App::DocumentObjectExecReturn *Boolean::execute(void)
         }
 
         std::vector<ShapeHistory> history;
-        history.push_back(buildHistory(*mkBool.get(), TopAbs_FACE, resShape, BaseShape));
-        history.push_back(buildHistory(*mkBool.get(), TopAbs_FACE, resShape, ToolShape));
+        history.push_back(buildHistory(*mkBool, TopAbs_FACE, resShape, BaseShape));
+        history.push_back(buildHistory(*mkBool, TopAbs_FACE, resShape, ToolShape));
 
         if (hGrp->GetBool("RefineModel", false)) {
             try {
@@ -116,7 +116,11 @@ App::DocumentObjectExecReturn *Boolean::execute(void)
             }
         }
 
-        this->Shape.setValue(resShape);
+        TopoShape resTopoShape(resShape);
+        // TODO: Add keepHistory Property to Part::Feature
+//        resTopoShape.history.modShapeMaker = mkBool;
+
+        this->Shape.setValue(resTopoShape);
         this->History.setValues(history);
         return App::DocumentObject::StdReturn;
     }

--- a/src/Mod/Part/App/PropertyTopoShape.cpp
+++ b/src/Mod/Part/App/PropertyTopoShape.cpp
@@ -144,39 +144,39 @@ PyObject *PropertyPartShape::getPyObject(void)
     Base::PyObjectBase* prop;
     const TopoDS_Shape& sh = _Shape.getShape();
     if (sh.IsNull()) {
-        prop = new TopoShapePy(new TopoShape(sh));
+        prop = new TopoShapePy(new TopoShape(_Shape));
     }
     else {
         TopAbs_ShapeEnum type = sh.ShapeType();
         switch (type)
         {
         case TopAbs_COMPOUND:
-            prop = new TopoShapeCompoundPy(new TopoShape(sh));
+            prop = new TopoShapeCompoundPy(new TopoShape(_Shape));
             break;
         case TopAbs_COMPSOLID:
-            prop = new TopoShapeCompSolidPy(new TopoShape(sh));
+            prop = new TopoShapeCompSolidPy(new TopoShape(_Shape));
             break;
         case TopAbs_SOLID:
-            prop = new TopoShapeSolidPy(new TopoShape(sh));
+            prop = new TopoShapeSolidPy(new TopoShape(_Shape));
             break;
         case TopAbs_SHELL:
-            prop = new TopoShapeShellPy(new TopoShape(sh));
+            prop = new TopoShapeShellPy(new TopoShape(_Shape));
             break;
         case TopAbs_FACE:
-            prop = new TopoShapeFacePy(new TopoShape(sh));
+            prop = new TopoShapeFacePy(new TopoShape(_Shape));
             break;
         case TopAbs_WIRE:
-            prop = new TopoShapeWirePy(new TopoShape(sh));
+            prop = new TopoShapeWirePy(new TopoShape(_Shape));
             break;
         case TopAbs_EDGE:
-            prop = new TopoShapeEdgePy(new TopoShape(sh));
+            prop = new TopoShapeEdgePy(new TopoShape(_Shape));
             break;
         case TopAbs_VERTEX:
-            prop = new TopoShapeVertexPy(new TopoShape(sh));
+            prop = new TopoShapeVertexPy(new TopoShape(_Shape));
             break;
         case TopAbs_SHAPE:
         default:
-            prop = new TopoShapePy(new TopoShape(sh));
+            prop = new TopoShapePy(new TopoShape(_Shape));
             break;
         }
     }

--- a/src/Mod/Part/App/TopoHistory.cpp
+++ b/src/Mod/Part/App/TopoHistory.cpp
@@ -1,0 +1,65 @@
+/***************************************************************************
+ *   Copyright (c) Ajinkya Dahale       (ajinkyadahale@gmail.com) 2017     *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "PreCompiled.h"
+
+#include <TopTools_ListOfShape.hxx>
+
+#include "TopoHistory.h"
+#include "TopoShape.h"
+
+using namespace Part;
+
+TYPESYSTEM_SOURCE(Part::TopoHistory, Base::BaseClass);
+
+TopoHistory::TopoHistory()
+{
+
+}
+
+TopTools_ListOfShape TopoHistory::modified(const TopoShape &oldShape)
+{
+    if (this->modShapeMaker.get()) {
+        TopoDS_Shape _shape = oldShape.getShape();
+        return this->modShapeMaker->Modified(_shape);
+    }
+    return TopTools_ListOfShape();
+}
+
+TopTools_ListOfShape TopoHistory::generated(const TopoShape &oldShape)
+{
+    if (this->modShapeMaker.get()) {
+        TopoDS_Shape _shape = oldShape.getShape();
+        return this->modShapeMaker->Generated(_shape);
+    }
+    return TopTools_ListOfShape();
+}
+
+
+bool TopoHistory::isDeleted(const TopoShape &oldShape)
+{
+    if (this->modShapeMaker.get()) {
+        TopoDS_Shape _shape = oldShape.getShape();
+        return this->modShapeMaker->IsDeleted(_shape);
+    }
+    return false;
+}

--- a/src/Mod/Part/App/TopoHistory.cpp
+++ b/src/Mod/Part/App/TopoHistory.cpp
@@ -33,7 +33,18 @@ TYPESYSTEM_SOURCE(Part::TopoHistory, Base::BaseClass);
 
 TopoHistory::TopoHistory()
 {
+}
 
+TopoHistory::TopoHistory(const TopoHistory &history)
+    : modShapeMaker(history.modShapeMaker)
+{
+}
+
+void TopoHistory::operator =(const TopoHistory &history)
+{
+    if (this != &history) {
+        this->modShapeMaker = history.modShapeMaker;
+    }
 }
 
 TopTools_ListOfShape TopoHistory::modified(const TopoShape &oldShape)

--- a/src/Mod/Part/App/TopoHistory.cpp
+++ b/src/Mod/Part/App/TopoHistory.cpp
@@ -23,6 +23,8 @@
 #include "PreCompiled.h"
 
 #include <TopTools_ListOfShape.hxx>
+#include <TopTools_ListIteratorOfListOfShape.hxx>
+#include <Standard_Failure.hxx>
 
 #include "TopoHistory.h"
 #include "TopoShape.h"
@@ -47,22 +49,34 @@ void TopoHistory::operator =(const TopoHistory &history)
     }
 }
 
-TopTools_ListOfShape TopoHistory::modified(const TopoShape &oldShape)
+std::vector<TopoShape> TopoHistory::modified(const TopoShape &oldShape)
 {
+    std::vector<TopoShape> newShapes;
     if (this->shapeMaker.get()) {
         TopoDS_Shape _shape = oldShape.getShape();
-        return this->shapeMaker->Modified(_shape);
+        const TopTools_ListOfShape& _newShapes = this->shapeMaker->Modified(_shape);
+        for(TopTools_ListIteratorOfListOfShape it(_newShapes); it.More(); it.Next()){
+            newShapes.push_back(TopoShape(it.Value()));
+        }
+        return newShapes;
     }
-    return TopTools_ListOfShape();
+    Standard_Failure::Raise("History is empty");
+    return newShapes; // just to silence compiler warning
 }
 
-TopTools_ListOfShape TopoHistory::generated(const TopoShape &oldShape)
+std::vector<TopoShape> TopoHistory::generated(const TopoShape &oldShape)
 {
+    std::vector<TopoShape> newShapes;
     if (this->shapeMaker.get()) {
         TopoDS_Shape _shape = oldShape.getShape();
-        return this->shapeMaker->Generated(_shape);
+        const TopTools_ListOfShape& _newShapes = this->shapeMaker->Modified(_shape);
+        for(TopTools_ListIteratorOfListOfShape it(_newShapes); it.More(); it.Next()){
+            newShapes.push_back(TopoShape(it.Value()));
+        }
+        return newShapes;
     }
-    return TopTools_ListOfShape();
+    Standard_Failure::Raise("History is empty");
+    return newShapes; // just to silence compiler warning
 }
 
 
@@ -72,5 +86,6 @@ bool TopoHistory::isDeleted(const TopoShape &oldShape)
         TopoDS_Shape _shape = oldShape.getShape();
         return this->shapeMaker->IsDeleted(_shape);
     }
-    return false;
+    Standard_Failure::Raise("History is empty");
+    return false; // just to silence compiler warning
 }

--- a/src/Mod/Part/App/TopoHistory.cpp
+++ b/src/Mod/Part/App/TopoHistory.cpp
@@ -36,31 +36,31 @@ TopoHistory::TopoHistory()
 }
 
 TopoHistory::TopoHistory(const TopoHistory &history)
-    : modShapeMaker(history.modShapeMaker)
+    : shapeMaker(history.shapeMaker)
 {
 }
 
 void TopoHistory::operator =(const TopoHistory &history)
 {
     if (this != &history) {
-        this->modShapeMaker = history.modShapeMaker;
+        this->shapeMaker = history.shapeMaker;
     }
 }
 
 TopTools_ListOfShape TopoHistory::modified(const TopoShape &oldShape)
 {
-    if (this->modShapeMaker.get()) {
+    if (this->shapeMaker.get()) {
         TopoDS_Shape _shape = oldShape.getShape();
-        return this->modShapeMaker->Modified(_shape);
+        return this->shapeMaker->Modified(_shape);
     }
     return TopTools_ListOfShape();
 }
 
 TopTools_ListOfShape TopoHistory::generated(const TopoShape &oldShape)
 {
-    if (this->modShapeMaker.get()) {
+    if (this->shapeMaker.get()) {
         TopoDS_Shape _shape = oldShape.getShape();
-        return this->modShapeMaker->Generated(_shape);
+        return this->shapeMaker->Generated(_shape);
     }
     return TopTools_ListOfShape();
 }
@@ -68,9 +68,9 @@ TopTools_ListOfShape TopoHistory::generated(const TopoShape &oldShape)
 
 bool TopoHistory::isDeleted(const TopoShape &oldShape)
 {
-    if (this->modShapeMaker.get()) {
+    if (this->shapeMaker.get()) {
         TopoDS_Shape _shape = oldShape.getShape();
-        return this->modShapeMaker->IsDeleted(_shape);
+        return this->shapeMaker->IsDeleted(_shape);
     }
     return false;
 }

--- a/src/Mod/Part/App/TopoHistory.cpp
+++ b/src/Mod/Part/App/TopoHistory.cpp
@@ -69,7 +69,7 @@ std::vector<TopoShape> TopoHistory::generated(const TopoShape &oldShape)
     std::vector<TopoShape> newShapes;
     if (this->shapeMaker.get()) {
         TopoDS_Shape _shape = oldShape.getShape();
-        const TopTools_ListOfShape& _newShapes = this->shapeMaker->Modified(_shape);
+        const TopTools_ListOfShape& _newShapes = this->shapeMaker->Generated(_shape);
         for(TopTools_ListIteratorOfListOfShape it(_newShapes); it.More(); it.Next()){
             newShapes.push_back(TopoShape(it.Value()));
         }

--- a/src/Mod/Part/App/TopoHistory.h
+++ b/src/Mod/Part/App/TopoHistory.h
@@ -50,6 +50,9 @@ class PartExport TopoHistory : public Base::BaseClass
 
 public:
     TopoHistory();
+    TopoHistory(const TopoHistory&);
+
+    void operator = (const TopoHistory&);
 
     TopTools_ListOfShape modified(const TopoShape&);
     TopTools_ListOfShape generated(const TopoShape&);

--- a/src/Mod/Part/App/TopoHistory.h
+++ b/src/Mod/Part/App/TopoHistory.h
@@ -1,0 +1,64 @@
+/***************************************************************************
+ *   Copyright (c) Ajinkya Dahale       (ajinkyadahale@gmail.com) 2017     *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef TOPOHISTORY_H
+#define TOPOHISTORY_H
+
+#include <iostream>
+#include <memory>
+#include <BRepBuilderAPI_MakeShape.hxx>
+
+#include <Base/BaseClass.h>
+
+namespace Part {
+
+class TopoShape;
+
+/**
+ * @brief The TopoHistory class
+ *
+ * Describes how a newer shape is developed from an older shape. Specifically,
+ * tells which sub-shape in the old shape is deleted, or which generated/was
+ * modified to which sub-shape(s) in the new shape.
+ *
+ * TODO: This class or, one of it's subclasses, might also be used to store
+ * a "para-history" between two shapes generated with slightly different
+ * methods (like with a different pad length somewhere in their history).
+ */
+class PartExport TopoHistory : public Base::BaseClass
+{
+    TYPESYSTEM_HEADER();
+
+public:
+    TopoHistory();
+
+    TopTools_ListOfShape modified(const TopoShape&);
+    TopTools_ListOfShape generated(const TopoShape&);
+    bool isDeleted(const TopoShape &);
+
+    std::shared_ptr<BRepBuilderAPI_MakeShape> modShapeMaker;
+
+};
+
+}
+
+#endif // TOPOHISTORY_H

--- a/src/Mod/Part/App/TopoHistory.h
+++ b/src/Mod/Part/App/TopoHistory.h
@@ -58,7 +58,7 @@ public:
     TopTools_ListOfShape generated(const TopoShape&);
     bool isDeleted(const TopoShape &);
 
-    std::shared_ptr<BRepBuilderAPI_MakeShape> modShapeMaker;
+    std::shared_ptr<BRepBuilderAPI_MakeShape> shapeMaker;
 
 };
 

--- a/src/Mod/Part/App/TopoHistory.h
+++ b/src/Mod/Part/App/TopoHistory.h
@@ -54,12 +54,11 @@ public:
 
     void operator = (const TopoHistory&);
 
-    TopTools_ListOfShape modified(const TopoShape&);
-    TopTools_ListOfShape generated(const TopoShape&);
+    std::vector<TopoShape> modified(const TopoShape&);
+    std::vector<TopoShape> generated(const TopoShape&);
     bool isDeleted(const TopoShape &);
 
     std::shared_ptr<BRepBuilderAPI_MakeShape> shapeMaker;
-
 };
 
 }

--- a/src/Mod/Part/App/TopoHistoryPy.xml
+++ b/src/Mod/Part/App/TopoHistoryPy.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<GenerateModel xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="generateMetaModel_Module.xsd">
+  <PythonExport
+      Father="BaseClassPy" 
+      Name="TopoHistoryPy" 
+      Twin="TopoHistory" 
+      TwinPointer="TopoHistory" 
+      Include="Mod/Part/App/TopoHistory.h" 
+      FatherInclude="Base/BaseClassPy.h" 
+      Namespace="Part" 
+      Constructor="true"
+      Delete="true"
+      FatherNamespace="Base">
+    <Documentation>
+      <Author Licence="LGPL" Name="Ajinkya Dahale" EMail="ajinkyadahale@gmail.com" />
+      <UserDocu>TopoHistory describes how a newer shape is developed from an older
+      shape</UserDocu>
+    </Documentation>
+    
+    <Methode Name="modified" Const="true">
+      <Documentation>
+        <UserDocu>Returns the sub-shapes within this shape that were modified from the
+argument while building this shape.</UserDocu>
+      </Documentation>
+    </Methode>
+    <Methode Name="generated" Const="true">
+      <Documentation>
+        <UserDocu>Returns the sub-shapes within this shape that were generated from the
+argument while building this shape.</UserDocu>
+      </Documentation>
+    </Methode>
+    <Methode Name="isDeleted">
+      <Documentation>
+        <UserDocu>Returns if the argument was deleted while building this shape.</UserDocu>
+      </Documentation>
+    </Methode>
+    
+  </PythonExport>
+</GenerateModel>

--- a/src/Mod/Part/App/TopoHistoryPyImp.cpp
+++ b/src/Mod/Part/App/TopoHistoryPyImp.cpp
@@ -1,0 +1,153 @@
+/***************************************************************************
+ *   Copyright (c) Ajinkya Dahale       (ajinkyadahale@gmail.com) 2008     *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+
+#include "PreCompiled.h"
+#ifndef _PreComp_
+#include <TopTools_ListOfShape.hxx>
+#include <TopTools_ListIteratorOfListOfShape.hxx>
+#endif //_PreComp_
+
+#include "TopoHistory.h"
+#include <Mod/Part/App/TopoHistoryPy.h>
+#include <Mod/Part/App/TopoHistoryPy.cpp>
+#include "TopoShape.h"
+#include <Mod/Part/App/TopoShapePy.h>
+
+#include "OCCError.h"
+
+using namespace Part;
+
+namespace Part
+{
+PartExport Py::Object shape2pyshape(const TopoDS_Shape &shape);
+}
+
+// returns a string which represents the object e.g. when printed in python
+std::string TopoHistoryPy::representation(void) const
+{
+    std::stringstream str;
+    str << "<History object at " << getTopoHistoryPtr() << ">";
+
+    return str.str();
+}
+
+PyObject* TopoHistoryPy::PyMake(_typeobject *, PyObject *, PyObject *)
+{
+    // create a new instance of TopoHistoryPy and the Twin object
+    return new TopoHistoryPy(new TopoHistory);
+}
+
+int TopoHistoryPy::PyInit(PyObject* /*args*/, PyObject* /*k*/)
+{
+    return -1;
+}
+
+PyObject* TopoHistoryPy::modified(PyObject *args)
+{
+    PyObject *pcObj;
+    if (PyArg_ParseTuple(args, "O!", &(TopoShapePy::Type), &pcObj)) {
+        TopoShape* shape = static_cast<TopoShapePy*>(pcObj)->getTopoShapePtr();
+        try {
+            Py::List resShapesPy;
+            TopTools_ListOfShape newShapes = this->getTopoHistoryPtr()->modified(*shape);
+            for(TopTools_ListIteratorOfListOfShape it(newShapes); it.More(); it.Next()){
+                resShapesPy.append(shape2pyshape(it.Value()));
+            }
+            return Py::new_reference_to(resShapesPy);
+        }
+        catch (Standard_Failure) {
+            Handle(Standard_Failure) e = Standard_Failure::Caught();
+            PyErr_SetString(PartExceptionOCCError, e->GetMessageString());
+            return NULL;
+        }
+        catch (const std::exception& e) {
+            PyErr_SetString(PartExceptionOCCError, e.what());
+            return NULL;
+        }
+    }
+
+    PyErr_SetString(PyExc_TypeError, "shape or sequence of shape expected");
+    return 0;
+}
+
+PyObject*  TopoHistoryPy::generated(PyObject *args)
+{
+    PyObject *pcObj;
+    if (PyArg_ParseTuple(args, "O!", &(TopoShapePy::Type), &pcObj)) {
+        TopoShape* shape = static_cast<TopoShapePy*>(pcObj)->getTopoShapePtr();
+        try {
+            Py::List resShapesPy;
+            TopTools_ListOfShape newShapes = this->getTopoHistoryPtr()->generated(*shape);
+            for(TopTools_ListIteratorOfListOfShape it(newShapes); it.More(); it.Next()){
+                resShapesPy.append(shape2pyshape(it.Value()));
+            }
+            return Py::new_reference_to(resShapesPy);
+        }
+        catch (Standard_Failure) {
+            Handle(Standard_Failure) e = Standard_Failure::Caught();
+            PyErr_SetString(PartExceptionOCCError, e->GetMessageString());
+            return NULL;
+        }
+        catch (const std::exception& e) {
+            PyErr_SetString(PartExceptionOCCError, e.what());
+            return NULL;
+        }
+    }
+
+    PyErr_SetString(PyExc_TypeError, "shape or sequence of shape expected");
+    return 0;
+}
+
+PyObject*  TopoHistoryPy::isDeleted(PyObject *args)
+{
+    PyObject *pcObj;
+    if (PyArg_ParseTuple(args, "O!", &(TopoShapePy::Type), &pcObj)) {
+        TopoShape* shape = static_cast<TopoShapePy*>(pcObj)->getTopoShapePtr();
+        try {
+            bool _isDeleted = this->getTopoHistoryPtr()->isDeleted(*shape);
+            return Py_BuildValue("O", (_isDeleted ? Py_True : Py_False));
+        }
+        catch (Standard_Failure) {
+            Handle(Standard_Failure) e = Standard_Failure::Caught();
+            PyErr_SetString(PartExceptionOCCError, e->GetMessageString());
+            return NULL;
+        }
+        catch (const std::exception& e) {
+            PyErr_SetString(PartExceptionOCCError, e.what());
+            return NULL;
+        }
+    }
+
+    PyErr_SetString(PyExc_TypeError, "shape or sequence of shape expected");
+    return 0;
+}
+
+PyObject* TopoHistoryPy::getCustomAttributes(const char* /*attr*/) const
+{
+    return 0;
+}
+
+int TopoHistoryPy::setCustomAttributes(const char* /*attr*/, PyObject* /*obj*/)
+{
+    return 0;
+}

--- a/src/Mod/Part/App/TopoHistoryPyImp.cpp
+++ b/src/Mod/Part/App/TopoHistoryPyImp.cpp
@@ -69,9 +69,10 @@ PyObject* TopoHistoryPy::modified(PyObject *args)
         TopoShape* shape = static_cast<TopoShapePy*>(pcObj)->getTopoShapePtr();
         try {
             Py::List resShapesPy;
-            TopTools_ListOfShape newShapes = this->getTopoHistoryPtr()->modified(*shape);
-            for(TopTools_ListIteratorOfListOfShape it(newShapes); it.More(); it.Next()){
-                resShapesPy.append(shape2pyshape(it.Value()));
+            std::vector<TopoShape> newShapes = this->getTopoHistoryPtr()->modified(*shape);
+            for(std::vector<TopoShape>::iterator it = newShapes.begin();
+                it != newShapes.end(); ++it){
+                resShapesPy.append(Py::asObject(it->getPyObject()));
             }
             return Py::new_reference_to(resShapesPy);
         }
@@ -97,9 +98,10 @@ PyObject*  TopoHistoryPy::generated(PyObject *args)
         TopoShape* shape = static_cast<TopoShapePy*>(pcObj)->getTopoShapePtr();
         try {
             Py::List resShapesPy;
-            TopTools_ListOfShape newShapes = this->getTopoHistoryPtr()->generated(*shape);
-            for(TopTools_ListIteratorOfListOfShape it(newShapes); it.More(); it.Next()){
-                resShapesPy.append(shape2pyshape(it.Value()));
+            std::vector<TopoShape> newShapes = this->getTopoHistoryPtr()->generated(*shape);
+            for(std::vector<TopoShape>::iterator it = newShapes.begin();
+                it != newShapes.end(); ++it){
+                resShapesPy.append(Py::asObject(it->getPyObject()));
             }
             return Py::new_reference_to(resShapesPy);
         }

--- a/src/Mod/Part/App/TopoShape.cpp
+++ b/src/Mod/Part/App/TopoShape.cpp
@@ -248,7 +248,7 @@ TopoShape::TopoShape(const TopoDS_Shape& shape)
 }
 
 TopoShape::TopoShape(const TopoShape& shape)
-  : _Shape(shape._Shape)
+  : history(shape.history), _Shape(shape._Shape)
 {
 }
 
@@ -404,6 +404,7 @@ PyObject * TopoShape::getPySubShape(const char* Type) const
 void TopoShape::operator = (const TopoShape& sh)
 {
     if (this != &sh) {
+        this->history = sh.history;
         this->_Shape = sh._Shape;
     }
 }

--- a/src/Mod/Part/App/TopoShape.cpp
+++ b/src/Mod/Part/App/TopoShape.cpp
@@ -398,7 +398,6 @@ PyObject * TopoShape::getPySubShape(const char* Type) const
         return new TopoShapeVertexPy(new TopoShape(Shape));
     else 
         return 0;
-
 }
 
 void TopoShape::operator = (const TopoShape& sh)
@@ -1457,6 +1456,20 @@ TopoDS_Shape TopoShape::cut(TopoDS_Shape shape) const
     return mkCut.Shape();
 }
 
+TopoShape TopoShape::cut(const TopoShape &shape, bool withHistory) const
+{
+    if (this->_Shape.IsNull())
+        Standard_Failure::Raise("Base shape is null");
+    if (shape.getShape().IsNull())
+        Standard_Failure::Raise("Tool shape is null");
+    std::shared_ptr<BRepAlgoAPI_Cut> mkCut(new BRepAlgoAPI_Cut(this->_Shape, shape.getShape()));
+    TopoShape resShape(mkCut->Shape());
+    if (withHistory) {
+        resShape.history.modShapeMaker = mkCut;
+    }
+    return resShape;
+}
+
 TopoDS_Shape TopoShape::cut(const std::vector<TopoDS_Shape>& shapes, Standard_Real tolerance) const
 {
     if (this->_Shape.IsNull())
@@ -1503,6 +1516,20 @@ TopoDS_Shape TopoShape::common(TopoDS_Shape shape) const
     return mkCommon.Shape();
 }
 
+TopoShape TopoShape::common(const TopoShape &shape, bool withHistory) const
+{
+    if (this->_Shape.IsNull())
+        Standard_Failure::Raise("Base shape is null");
+    if (shape.getShape().IsNull())
+        Standard_Failure::Raise("Tool shape is null");
+    std::shared_ptr<BRepAlgoAPI_Common> mkCommon(new BRepAlgoAPI_Common(this->_Shape, shape.getShape()));
+    TopoShape resShape(mkCommon->Shape());
+    if (withHistory) {
+        resShape.history.modShapeMaker = mkCommon;
+    }
+    return resShape;
+}
+
 TopoDS_Shape TopoShape::common(const std::vector<TopoDS_Shape>& shapes, Standard_Real tolerance) const
 {
     if (this->_Shape.IsNull())
@@ -1547,6 +1574,20 @@ TopoDS_Shape TopoShape::fuse(TopoDS_Shape shape) const
         Standard_Failure::Raise("Tool shape is null");
     BRepAlgoAPI_Fuse mkFuse(this->_Shape, shape);
     return mkFuse.Shape();
+}
+
+TopoShape TopoShape::fuse(const TopoShape &shape, bool withHistory) const
+{
+    if (this->_Shape.IsNull())
+        Standard_Failure::Raise("Base shape is null");
+    if (shape.getShape().IsNull())
+        Standard_Failure::Raise("Tool shape is null");
+    std::shared_ptr<BRepAlgoAPI_Fuse> mkFuse(new BRepAlgoAPI_Fuse(this->_Shape, shape.getShape()));
+    TopoShape resShape(mkFuse->Shape());
+    if (withHistory) {
+        resShape.history.modShapeMaker = mkFuse;
+    }
+    return resShape;
 }
 
 TopoDS_Shape TopoShape::fuse(const std::vector<TopoDS_Shape>& shapes, Standard_Real tolerance) const
@@ -1616,6 +1657,20 @@ TopoDS_Shape TopoShape::section(TopoDS_Shape shape) const
         Standard_Failure::Raise("Tool shape is null");
     BRepAlgoAPI_Section mkSection(this->_Shape, shape);
     return mkSection.Shape();
+}
+
+TopoShape TopoShape::section(const TopoShape &shape, bool withHistory) const
+{
+    if (this->_Shape.IsNull())
+        Standard_Failure::Raise("Base shape is null");
+    if (shape.getShape().IsNull())
+        Standard_Failure::Raise("Tool shape is null");
+    std::shared_ptr<BRepAlgoAPI_Section> mkSection(new BRepAlgoAPI_Section(this->_Shape, shape.getShape()));
+    TopoShape resShape(mkSection->Shape());
+    if (withHistory) {
+        resShape.history.modShapeMaker = mkSection;
+    }
+    return resShape;
 }
 
 TopoDS_Shape TopoShape::section(const std::vector<TopoDS_Shape>& shapes, Standard_Real tolerance) const

--- a/src/Mod/Part/App/TopoShape.cpp
+++ b/src/Mod/Part/App/TopoShape.cpp
@@ -185,6 +185,11 @@
 #include "TopoShapeFacePy.h"
 #include "TopoShapeEdgePy.h"
 #include "TopoShapeVertexPy.h"
+#include "TopoShapeCompoundPy.h"
+#include "TopoShapeCompSolidPy.h"
+#include "TopoShapeSolidPy.h"
+#include "TopoShapeShellPy.h"
+#include "TopoShapeWirePy.h"
 #include "ProgressIndicator.h"
 #include "modelRefine.h"
 #include "Tools.h"
@@ -245,6 +250,53 @@ TopoShape::TopoShape(const TopoDS_Shape& shape)
 TopoShape::TopoShape(const TopoShape& shape)
   : _Shape(shape._Shape)
 {
+}
+
+PyObject* TopoShape::getPyObject()
+{
+    PyObject* ret = 0;
+    if (!_Shape.IsNull()) {
+        TopAbs_ShapeEnum type = _Shape.ShapeType();
+        switch (type)
+        {
+        case TopAbs_COMPOUND:
+            ret = new TopoShapeCompoundPy(new TopoShape(*this));
+            break;
+        case TopAbs_COMPSOLID:
+            ret = new TopoShapeCompSolidPy(new TopoShape(*this));
+            break;
+        case TopAbs_SOLID:
+            ret = new TopoShapeSolidPy(new TopoShape(*this));
+            break;
+        case TopAbs_SHELL:
+            ret = new TopoShapeShellPy(new TopoShape(*this));
+            break;
+        case TopAbs_FACE:
+            ret = new TopoShapeFacePy(new TopoShape(*this));
+            break;
+        case TopAbs_WIRE:
+            ret = new TopoShapeWirePy(new TopoShape(*this));
+            break;
+        case TopAbs_EDGE:
+            ret = new TopoShapeEdgePy(new TopoShape(*this));
+            break;
+        case TopAbs_VERTEX:
+            ret = new TopoShapeVertexPy(new TopoShape(*this));
+            break;
+        case TopAbs_SHAPE:
+            ret = new TopoShapePy(new TopoShape(*this));
+            break;
+        default:
+            //shouldn't happen
+            ret = new TopoShapePy(new TopoShape(*this));
+            break;
+        }
+    } else {
+        ret = new TopoShapePy(new TopoShape(*this));
+    }
+    assert(ret);
+
+    return ret;
 }
 
 std::vector<const char*> TopoShape::getElementTypes(void) const

--- a/src/Mod/Part/App/TopoShape.cpp
+++ b/src/Mod/Part/App/TopoShape.cpp
@@ -1465,7 +1465,7 @@ TopoShape TopoShape::cut(const TopoShape &shape, bool withHistory) const
     std::shared_ptr<BRepAlgoAPI_Cut> mkCut(new BRepAlgoAPI_Cut(this->_Shape, shape.getShape()));
     TopoShape resShape(mkCut->Shape());
     if (withHistory) {
-        resShape.history.modShapeMaker = mkCut;
+        resShape.history.shapeMaker = mkCut;
     }
     return resShape;
 }
@@ -1525,7 +1525,7 @@ TopoShape TopoShape::common(const TopoShape &shape, bool withHistory) const
     std::shared_ptr<BRepAlgoAPI_Common> mkCommon(new BRepAlgoAPI_Common(this->_Shape, shape.getShape()));
     TopoShape resShape(mkCommon->Shape());
     if (withHistory) {
-        resShape.history.modShapeMaker = mkCommon;
+        resShape.history.shapeMaker = mkCommon;
     }
     return resShape;
 }
@@ -1585,7 +1585,7 @@ TopoShape TopoShape::fuse(const TopoShape &shape, bool withHistory) const
     std::shared_ptr<BRepAlgoAPI_Fuse> mkFuse(new BRepAlgoAPI_Fuse(this->_Shape, shape.getShape()));
     TopoShape resShape(mkFuse->Shape());
     if (withHistory) {
-        resShape.history.modShapeMaker = mkFuse;
+        resShape.history.shapeMaker = mkFuse;
     }
     return resShape;
 }
@@ -1668,7 +1668,7 @@ TopoShape TopoShape::section(const TopoShape &shape, bool withHistory) const
     std::shared_ptr<BRepAlgoAPI_Section> mkSection(new BRepAlgoAPI_Section(this->_Shape, shape.getShape()));
     TopoShape resShape(mkSection->Shape());
     if (withHistory) {
-        resShape.history.modShapeMaker = mkSection;
+        resShape.history.shapeMaker = mkSection;
     }
     return resShape;
 }
@@ -2275,7 +2275,7 @@ TopoShape TopoShape::makePrism(const gp_Vec& vec, bool withHistory) const
             mkPrism(new BRepPrimAPI_MakePrism(this->_Shape, vec));
     TopoShape resShape(mkPrism->Shape());
     if (withHistory) {
-        resShape.history.modShapeMaker = mkPrism;
+        resShape.history.shapeMaker = mkPrism;
     }
     return resShape;
 }
@@ -2794,7 +2794,7 @@ TopoShape TopoShape::mirror(const gp_Ax2& ax2, bool withHistory) const
             mkTrf(new BRepBuilderAPI_Transform(this->_Shape, mat));
     TopoShape resShape(mkTrf->Shape());
     if (withHistory) {
-        resShape.history.modShapeMaker = mkTrf;
+        resShape.history.shapeMaker = mkTrf;
     }
     return resShape;
 }

--- a/src/Mod/Part/App/TopoShape.cpp
+++ b/src/Mod/Part/App/TopoShape.cpp
@@ -2268,11 +2268,16 @@ TopoDS_Shape TopoShape::makeLoft(const TopTools_ListOfShape& profiles,
     return aGenerator.Shape();
 }
 
-TopoDS_Shape TopoShape::makePrism(const gp_Vec& vec) const
+TopoShape TopoShape::makePrism(const gp_Vec& vec, bool withHistory) const
 {
     if (this->_Shape.IsNull()) Standard_Failure::Raise("cannot sweep empty shape");
-    BRepPrimAPI_MakePrism mkPrism(this->_Shape, vec);
-    return mkPrism.Shape();
+    std::shared_ptr<BRepPrimAPI_MakePrism>
+            mkPrism(new BRepPrimAPI_MakePrism(this->_Shape, vec));
+    TopoShape resShape(mkPrism->Shape());
+    if (withHistory) {
+        resShape.history.modShapeMaker = mkPrism;
+    }
+    return resShape;
 }
 
 TopoDS_Shape TopoShape::revolve(const gp_Ax1& axis, double d, Standard_Boolean isSolid) const
@@ -2781,12 +2786,17 @@ void TopoShape::transformShape(const Base::Matrix4D& rclTrf, bool copy)
     this->_Shape = mkTrf.Shape();
 }
 
-TopoDS_Shape TopoShape::mirror(const gp_Ax2& ax2) const
+TopoShape TopoShape::mirror(const gp_Ax2& ax2, bool withHistory) const
 {
     gp_Trsf mat;
     mat.SetMirror(ax2);
-    BRepBuilderAPI_Transform mkTrf(this->_Shape, mat);
-    return mkTrf.Shape();
+    std::shared_ptr<BRepBuilderAPI_Transform>
+            mkTrf(new BRepBuilderAPI_Transform(this->_Shape, mat));
+    TopoShape resShape(mkTrf->Shape());
+    if (withHistory) {
+        resShape.history.modShapeMaker = mkTrf;
+    }
+    return resShape;
 }
 
 TopoDS_Shape TopoShape::toNurbs() const

--- a/src/Mod/Part/App/TopoShape.h
+++ b/src/Mod/Part/App/TopoShape.h
@@ -30,6 +30,8 @@
 #include <TopTools_ListOfShape.hxx>
 #include <App/ComplexGeoData.h>
 
+#include "TopoHistory.h"
+
 class gp_Ax1;
 class gp_Ax2;
 class gp_Vec;
@@ -249,6 +251,7 @@ public:
                   const std::vector<Facet> &faces, float Accuracy=1.0e-06);
     //@}
 
+    TopoHistory history;
 private:
     TopoDS_Shape _Shape;
 };

--- a/src/Mod/Part/App/TopoShape.h
+++ b/src/Mod/Part/App/TopoShape.h
@@ -76,6 +76,7 @@ public:
     }
 
     void operator = (const TopoShape&);
+    operator TopoDS_Shape() const {return _Shape;}
 
     /** @name Placement control */
     //@{
@@ -202,7 +203,7 @@ public:
     TopoDS_Shape makePipe(const TopoDS_Shape& profile) const;
     TopoDS_Shape makePipeShell(const TopTools_ListOfShape& profiles, const Standard_Boolean make_solid,
         const Standard_Boolean isFrenet = Standard_False, int transition=0) const;
-    TopoDS_Shape makePrism(const gp_Vec&) const;
+    TopoShape makePrism(const gp_Vec&, bool withHistory = true) const;
     ///revolve shape. Note: isSolid is deprecated (instead, use some Part::FaceMaker to make a face, first).
     TopoDS_Shape revolve(const gp_Ax1&, double d, Standard_Boolean isSolid=Standard_False) const;
     TopoDS_Shape makeSweep(const TopoDS_Shape& profile, double, int) const;
@@ -233,7 +234,7 @@ public:
     void transformGeometry(const Base::Matrix4D &rclMat);
     TopoDS_Shape transformGShape(const Base::Matrix4D&) const;
     void transformShape(const Base::Matrix4D&, bool copy);
-    TopoDS_Shape mirror(const gp_Ax2&) const;
+    TopoShape mirror(const gp_Ax2&, bool withHistory=false) const;
     TopoDS_Shape toNurbs() const;
     TopoDS_Shape replaceShape(const std::vector< std::pair<TopoDS_Shape,TopoDS_Shape> >& s) const;
     TopoDS_Shape removeShape(const std::vector<TopoDS_Shape>& s) const;

--- a/src/Mod/Part/App/TopoShape.h
+++ b/src/Mod/Part/App/TopoShape.h
@@ -63,6 +63,8 @@ public:
     TopoShape(const TopoShape&);
     ~TopoShape();
 
+    PyObject* getPyObject();
+
     inline void setShape(const TopoDS_Shape& shape) {
         this->_Shape = shape;
     }

--- a/src/Mod/Part/App/TopoShape.h
+++ b/src/Mod/Part/App/TopoShape.h
@@ -167,6 +167,10 @@ public:
     TopoDS_Shape oldFuse(TopoDS_Shape) const;
     TopoDS_Shape section(TopoDS_Shape) const;
     TopoDS_Shape section(const std::vector<TopoDS_Shape>&, Standard_Real tolerance = 0.0) const;
+    TopoShape cut(const TopoShape&, bool withHistory = true) const;
+    TopoShape common(const TopoShape&, bool withHistory = true) const;
+    TopoShape fuse(const TopoShape&, bool withHistory = true) const;
+    TopoShape section(const TopoShape&, bool withHistory = true) const;
     std::list<TopoDS_Wire> slice(const Base::Vector3d&, double) const;
     TopoDS_Compound slices(const Base::Vector3d&, const std::vector<double>&) const;
     /**
@@ -252,6 +256,7 @@ public:
     //@}
 
     TopoHistory history;
+
 private:
     TopoDS_Shape _Shape;
 };

--- a/src/Mod/Part/App/TopoShapePy.xml
+++ b/src/Mod/Part/App/TopoShapePy.xml
@@ -90,7 +90,15 @@ Sub-elements such as vertices, edges or faces are accessible as:
     </Methode>
     <Methode Name="extrude" Const="true" Keyword="true">
       <Documentation>
-        <UserDocu>Extrude the shape along a direction.</UserDocu>
+        <UserDocu>Extrude the shape along a direction.
+extrude(vec, [withHistory=False]) -> Shape
+
+Parameters:
+vec: Vector object indicating direnction and length of extrusion
+withHistory: True if history is needed to be stored, false otherwise. Be aware
+that storing history is extremely memory intensive. Currently only supported if
+tools is a single Shape, otherwise ignored.
+</UserDocu>
       </Documentation>
     </Methode>
     <Methode Name="revolve" Const="true">
@@ -140,12 +148,18 @@ This is a more detailed check as done in isValid().</UserDocu>
     </Methode>
     <Methode Name="fuse" Const="true" Keyword="true">
       <Documentation>
-        <UserDocu>Union of this and a given (list of) topo shape.
-fuse(tool) -> Shape
-  or
-fuse((tool1,tool2,...),[tolerance=0.0]) -> Shape
+        <UserDocu>Union of this and a given (list of) toposhape(s). History
+storage supported (with single tool only). Be aware that storing history is
+extremely memory intensive.
+fuse(tools, [tolerance=0.0, withHistory=False]) -> Shape
 
-Union of this and a given list of topo shapes.
+Parameters:
+tools: can either be a single Shape or a sequence of shapes (OCCT >= 6.9.0)
+tolerance: global tolerance for fuzzy Boolean operations (ignored if tools is a
+single shape)
+withHistory: True if history is needed to be stored, false otherwise. Be aware
+that storing history is extremely memory intensive. Currently only supported if
+tools is a single Shape, otherwise ignored.
 
 Supports (OCCT 6.9.0 and above):
 - Fuzzy Boolean operations (global tolerance for a Boolean operation)
@@ -177,12 +191,16 @@ Deprecated: use fuse() instead.</UserDocu>
     </Methode>
     <Methode Name="common" Const="true" Keyword="true">
       <Documentation>
-        <UserDocu>Intersection of this and a given (list of) topo shape.
-common(tool) -> Shape
-  or
-common((tool1,tool2,...),[tolerance=0.0]) -> Shape
+        <UserDocu>Intersection of this and a given (list of) topo shape(s).
+common(tools, [tolerance=0.0, withHistory=False]) -> Shape
 
-Intersection of this and a given list of topo shapes.
+Parameters:
+tools: can either be a single Shape or a sequence of shapes (OCCT >= 6.9.0)
+tolerance: global tolerance for fuzzy Boolean operations (ignored if tools is a
+single shape)
+withHistory: True if history is needed to be stored, false otherwise. Be aware
+that storing history is extremely memory intensive. Currently only supported if
+tools is a single Shape, otherwise ignored.
 
 Supports:
 - Fuzzy Boolean operations (global tolerance for a Boolean operation)
@@ -194,10 +212,16 @@ OCC 6.9.0 or later is required.</UserDocu>
     </Methode>
     <Methode Name="section" Const="true" Keyword="true">
       <Documentation>
-        <UserDocu>Section of this with a given (list of) topo shape.
-section(tool) -> Shape
-  or
-section((tool1,tool2,...),[tolerance=0.0]) -> Shape
+        <UserDocu>Section of this with a given (list of) topo shape(s).
+section(tools, [tolerance=0.0, withHistory=False]) -> Shape
+
+Parameters:
+tools: can either be a single Shape or a sequence of shapes (OCCT >= 6.9.0)
+tolerance: global tolerance for fuzzy Boolean operations (ignored if tools is a
+single shape)
+withHistory: True if history is needed to be stored, false otherwise. Be aware
+that storing history is extremely memory intensive. Currently only supported if
+tools is a single Shape, otherwise ignored.
 
 Section of this and a given list of topo shapes.
 
@@ -221,12 +245,16 @@ OCC 6.9.0 or later is required.</UserDocu>
     </Methode>
     <Methode Name="cut" Const="true" Keyword="true">
       <Documentation>
-        <UserDocu>Difference of this and a given (list of) topo shape
-cut(tool) -> Shape
-  or
-cut((tool1,tool2,...),[tolerance=0.0]) -> Shape
+        <UserDocu>Difference of this and a given (list of) topo shape(s).
+cut((tools, [tolerance=0.0, withHistory=False]) -> Shape
 
-Substraction of this and a given list of topo shapes.
+Parameters:
+tools: can either be a single Shape or a sequence of shapes (OCCT >= 6.9.0)
+tolerance: global tolerance for fuzzy Boolean operations (ignored if tools is a
+single shape)
+withHistory: True if history is needed to be stored, false otherwise. Be aware
+that storing history is extremely memory intensive. Currently only supported if
+tools is a single Shape, otherwise ignored.
 
 Supports:
 - Fuzzy Boolean operations (global tolerance for a Boolean operation)
@@ -298,7 +326,16 @@ For a sub-shape of this shape get its ancestors of a type.
     <Methode Name="mirror" Const="true" Keyword="true">
       <Documentation>
         <UserDocu>Mirror this shape on a given plane.
-The plane is given with its base point and its normal direction.</UserDocu>
+The plane is given with its base point and its normal direction.
+mirror(base, norm, [withHistory=False]) -> Shape
+
+Parameters:
+base: Vector indicating base point of reflection plane
+norm: Vector indicating normal direction of reflection plane
+withHistory: True if history is needed to be stored, false otherwise. Be aware
+that storing history is extremely memory intensive. Currently only supported if
+tools is a single Shape, otherwise ignored.
+</UserDocu>
       </Documentation>
     </Methode>
     <Methode Name="transformGeometry" Const="true">
@@ -358,11 +395,14 @@ transformShape(Matrix,[boolean copy=False]) -> None</UserDocu>
     <Methode Name="makeFillet2" Const="true" Keyword="true">
       <Documentation>
         <UserDocu>Make fillet: alternate version with history.
+makeFillet2(radius, edges, [withHistory=False]) -> Shape
+
 Parameters:
 radius: single number or a tuple of two numbers.
 edges: sequence of edges to be filleted.
-withHistory: True if history is needed to be stored, false otherwise.
-</UserDocu>
+withHistory: True if history is needed to be stored, false otherwise. Be aware
+that storing history is extremely memory intensive. Currently only supported if
+tools is a single Shape, otherwise ignored.</UserDocu>
       </Documentation>
     </Methode>
     <Methode Name="makeChamfer" Const="true">
@@ -373,10 +413,14 @@ withHistory: True if history is needed to be stored, false otherwise.
     <Methode Name="makeChamfer2" Const="true" Keyword="true">
       <Documentation>
         <UserDocu>Make chamfer: alternate version with history.
+makeChamfer2(radius, edges, [withHistory=False]) -> Shape
+
 Parameters:
 radius: single number or a tuple of two numbers.
 edges: sequence of edges to be filleted.
-withHistory: True if history is needed to be stored, false otherwise.</UserDocu>
+withHistory: True if history is needed to be stored, false otherwise. Be aware
+that storing history is extremely memory intensive. Currently only supported if
+tools is a single Shape, otherwise ignored.</UserDocu>
       </Documentation>
     </Methode>
     <Methode Name="makeThickness" Const="true">

--- a/src/Mod/Part/App/TopoShapePy.xml
+++ b/src/Mod/Part/App/TopoShapePy.xml
@@ -88,7 +88,7 @@ Sub-elements such as vertices, edges or faces are accessible as:
         <UserDocu>Load the shape from a string that keeps the content in BREP format.</UserDocu>
       </Documentation>
     </Methode>
-    <Methode Name="extrude" Const="true">
+    <Methode Name="extrude" Const="true" Keyword="true">
       <Documentation>
         <UserDocu>Extrude the shape along a direction.</UserDocu>
       </Documentation>
@@ -295,7 +295,7 @@ For a sub-shape of this shape get its ancestors of a type.
         <UserDocu>Removes internal wires (also holes) from the shape.</UserDocu>
       </Documentation>
     </Methode>
-    <Methode Name="mirror" Const="true">
+    <Methode Name="mirror" Const="true" Keyword="true">
       <Documentation>
         <UserDocu>Mirror this shape on a given plane.
 The plane is given with its base point and its normal direction.</UserDocu>

--- a/src/Mod/Part/App/TopoShapePy.xml
+++ b/src/Mod/Part/App/TopoShapePy.xml
@@ -704,6 +704,12 @@ infos contains additional info on the solutions. It is a list of tuples:
       </Documentation>
       <Parameter Name="ShapeType" Type="String"/>
     </Attribute>
+    <Attribute Name="History" ReadOnly="true">
+      <Documentation>
+        <UserDocu>Returns the history of the shape, if stored.</UserDocu>
+      </Documentation>
+      <Parameter Name="History" Type="Object" />
+    </Attribute>
     <Attribute Name="Orientation" ReadOnly="false">
       <Documentation>
         <UserDocu>Returns the orientation of the shape.</UserDocu>

--- a/src/Mod/Part/App/TopoShapePy.xml
+++ b/src/Mod/Part/App/TopoShapePy.xml
@@ -355,9 +355,28 @@ transformShape(Matrix,[boolean copy=False]) -> None</UserDocu>
         <UserDocu>Make fillet.</UserDocu>
       </Documentation>
     </Methode>
+    <Methode Name="makeFillet2" Const="true" Keyword="true">
+      <Documentation>
+        <UserDocu>Make fillet: alternate version with history.
+Parameters:
+radius: single number or a tuple of two numbers.
+edges: sequence of edges to be filleted.
+withHistory: True if history is needed to be stored, false otherwise.
+</UserDocu>
+      </Documentation>
+    </Methode>
     <Methode Name="makeChamfer" Const="true">
       <Documentation>
         <UserDocu>Make chamfer.</UserDocu>
+      </Documentation>
+    </Methode>
+    <Methode Name="makeChamfer2" Const="true" Keyword="true">
+      <Documentation>
+        <UserDocu>Make chamfer: alternate version with history.
+Parameters:
+radius: single number or a tuple of two numbers.
+edges: sequence of edges to be filleted.
+withHistory: True if history is needed to be stored, false otherwise.</UserDocu>
       </Documentation>
     </Methode>
     <Methode Name="makeThickness" Const="true">

--- a/src/Mod/Part/App/TopoShapePy.xml
+++ b/src/Mod/Part/App/TopoShapePy.xml
@@ -138,7 +138,7 @@ Part.show(r)
 This is a more detailed check as done in isValid().</UserDocu>
       </Documentation>
     </Methode>
-    <Methode Name="fuse" Const="true">
+    <Methode Name="fuse" Const="true" Keyword="true">
       <Documentation>
         <UserDocu>Union of this and a given (list of) topo shape.
 fuse(tool) -> Shape
@@ -175,7 +175,7 @@ Deprecated: use fuse() instead.</UserDocu>
         <UserDocu>Union of this and a given topo shape (old algorithm).</UserDocu>
       </Documentation>
     </Methode>
-    <Methode Name="common" Const="true">
+    <Methode Name="common" Const="true" Keyword="true">
       <Documentation>
         <UserDocu>Intersection of this and a given (list of) topo shape.
 common(tool) -> Shape
@@ -192,7 +192,7 @@ Supports:
 OCC 6.9.0 or later is required.</UserDocu>
       </Documentation>
     </Methode>
-    <Methode Name="section" Const="true">
+    <Methode Name="section" Const="true" Keyword="true">
       <Documentation>
         <UserDocu>Section of this with a given (list of) topo shape.
 section(tool) -> Shape
@@ -219,7 +219,7 @@ OCC 6.9.0 or later is required.</UserDocu>
         <UserDocu>Make single slice of this shape.</UserDocu>
       </Documentation>
     </Methode>
-    <Methode Name="cut" Const="true">
+    <Methode Name="cut" Const="true" Keyword="true">
       <Documentation>
         <UserDocu>Difference of this and a given (list of) topo shape
 cut(tool) -> Shape

--- a/src/Mod/Part/App/TopoShapePyImp.cpp
+++ b/src/Mod/Part/App/TopoShapePyImp.cpp
@@ -74,6 +74,7 @@
 #include "TopoShape.h"
 #include <Mod/Part/App/TopoShapePy.h>
 #include <Mod/Part/App/TopoShapePy.cpp>
+#include <Mod/Part/App/TopoHistoryPy.h>
 
 #include "OCCError.h"
 #include <Mod/Part/App/GeometryPy.h>
@@ -2679,6 +2680,11 @@ Py::String TopoShapePy::getShapeType(void) const
     }
 
     return Py::String(name);
+}
+
+Py::Object TopoShapePy::getHistory(void) const
+{
+    return Py::asObject(new TopoHistoryPy(new TopoHistory(this->getTopoShapePtr()->history)));
 }
 
 Py::String TopoShapePy::getOrientation(void) const

--- a/src/Mod/Part/App/TopoShapePyImp.cpp
+++ b/src/Mod/Part/App/TopoShapePyImp.cpp
@@ -760,15 +760,22 @@ PyObject*  TopoShapePy::check(PyObject *args)
     Py_Return; 
 }
 
-PyObject*  TopoShapePy::fuse(PyObject *args)
+PyObject*  TopoShapePy::fuse(PyObject *args, PyObject *keywds)
 {
+    static char *kwlist[] = {"tools", "tolerance", "withHistory", NULL};
     PyObject *pcObj;
-    if (PyArg_ParseTuple(args, "O!", &(TopoShapePy::Type), &pcObj)) {
-        TopoDS_Shape shape = static_cast<TopoShapePy*>(pcObj)->getTopoShapePtr()->getShape();
+    double tolerance = 0.0;
+    PyObject *withHistory = Py_False;
+    if (PyArg_ParseTupleAndKeywords(args, keywds, "O!|dO!", kwlist,
+                                    &(TopoShapePy::Type), &pcObj,
+                                    &tolerance,
+                                    &(PyBool_Type), &withHistory)) {
+        TopoShape* shape = static_cast<TopoShapePy*>(pcObj)->getTopoShapePtr();
         try {
             // Let's call algorithm computing a fuse operation:
-            TopoDS_Shape fusShape = this->getTopoShapePtr()->fuse(shape);
-            return new TopoShapePy(new TopoShape(fusShape));
+            TopoShape fusShape = this->getTopoShapePtr()
+                    ->fuse(*shape, PyObject_IsTrue(withHistory)?true:false);
+            return fusShape.getPyObject();//new TopoShapePy(new TopoShape(fusShape));
         }
         catch (Standard_Failure) {
             Handle(Standard_Failure) e = Standard_Failure::Caught();
@@ -782,8 +789,11 @@ PyObject*  TopoShapePy::fuse(PyObject *args)
     }
 
     PyErr_Clear();
-    double tolerance = 0.0;
-    if (PyArg_ParseTuple(args, "O|d", &pcObj, &tolerance)) {
+    tolerance = 0.0;
+    withHistory = Py_False;
+    if (PyArg_ParseTupleAndKeywords(args, keywds, "O|dO!", kwlist,
+                                    &pcObj, &tolerance,
+                                    &(PyBool_Type), &withHistory)) {
         std::vector<TopoDS_Shape> shapeVec;
         Py::Sequence shapeSeq(pcObj);
         for (Py::Sequence::iterator it = shapeSeq.begin(); it != shapeSeq.end(); ++it) {
@@ -794,7 +804,7 @@ PyObject*  TopoShapePy::fuse(PyObject *args)
             else {
                 PyErr_SetString(PyExc_TypeError, "non-shape object in sequence");
                 return 0;
-           }
+            }
         }
         try {
             TopoDS_Shape multiFusedShape = this->getTopoShapePtr()->fuse(shapeVec,tolerance);
@@ -871,15 +881,22 @@ PyObject*  TopoShapePy::oldFuse(PyObject *args)
     }
 }
 
-PyObject*  TopoShapePy::common(PyObject *args)
+PyObject*  TopoShapePy::common(PyObject *args, PyObject *keywds)
 {
+    static char *kwlist[] = {"tools", "tolerance", "withHistory", NULL};
     PyObject *pcObj;
-    if (PyArg_ParseTuple(args, "O!", &(TopoShapePy::Type), &pcObj)) {
-        TopoDS_Shape shape = static_cast<TopoShapePy*>(pcObj)->getTopoShapePtr()->getShape();
+    double tolerance = 0.0;
+    PyObject *withHistory = Py_False;
+    if (PyArg_ParseTupleAndKeywords(args, keywds, "O!|dO!", kwlist,
+                                    &(TopoShapePy::Type), &pcObj,
+                                    &tolerance,
+                                    &(PyBool_Type), &withHistory)) {
+        TopoShape* shape = static_cast<TopoShapePy*>(pcObj)->getTopoShapePtr();
         try {
             // Let's call algorithm computing a common operation:
-            TopoDS_Shape comShape = this->getTopoShapePtr()->common(shape);
-            return new TopoShapePy(new TopoShape(comShape));
+            TopoShape comShape = this->getTopoShapePtr()
+                    ->common(*shape, PyObject_IsTrue(withHistory)?true:false);
+            return comShape.getPyObject();
         }
         catch (Standard_Failure) {
             Handle(Standard_Failure) e = Standard_Failure::Caught();
@@ -893,8 +910,11 @@ PyObject*  TopoShapePy::common(PyObject *args)
     }
 
     PyErr_Clear();
-    double tolerance = 0.0;
-    if (PyArg_ParseTuple(args, "O|d", &pcObj, &tolerance)) {
+    tolerance = 0.0;
+    withHistory = Py_False;
+    if (PyArg_ParseTupleAndKeywords(args, keywds, "O|dO!", kwlist,
+                                    &pcObj, &tolerance,
+                                    &(PyBool_Type), &withHistory)) {
         std::vector<TopoDS_Shape> shapeVec;
         Py::Sequence shapeSeq(pcObj);
         for (Py::Sequence::iterator it = shapeSeq.begin(); it != shapeSeq.end(); ++it) {
@@ -926,15 +946,22 @@ PyObject*  TopoShapePy::common(PyObject *args)
     return 0;
 }
 
-PyObject*  TopoShapePy::section(PyObject *args)
+PyObject*  TopoShapePy::section(PyObject *args, PyObject *keywds)
 {
+    static char *kwlist[] = {"tools", "tolerance", "withHistory", NULL};
     PyObject *pcObj;
-    if (PyArg_ParseTuple(args, "O!", &(TopoShapePy::Type), &pcObj)) {
-        TopoDS_Shape shape = static_cast<TopoShapePy*>(pcObj)->getTopoShapePtr()->getShape();
+    double tolerance = 0.0;
+    PyObject *withHistory = Py_False;
+    if (PyArg_ParseTupleAndKeywords(args, keywds, "O!|dO!", kwlist,
+                                    &(TopoShapePy::Type), &pcObj,
+                                    &tolerance,
+                                    &(PyBool_Type), &withHistory)) {
+        TopoShape* shape = static_cast<TopoShapePy*>(pcObj)->getTopoShapePtr();
         try {
             // Let's call algorithm computing a section operation:
-            TopoDS_Shape secShape = this->getTopoShapePtr()->section(shape);
-            return new TopoShapePy(new TopoShape(secShape));
+            TopoShape secShape = this->getTopoShapePtr()
+                    ->section(*shape, PyObject_IsTrue(withHistory)?true:false);
+            return secShape.getPyObject();
         }
         catch (Standard_Failure) {
             Handle(Standard_Failure) e = Standard_Failure::Caught();
@@ -948,8 +975,11 @@ PyObject*  TopoShapePy::section(PyObject *args)
     }
 
     PyErr_Clear();
-    double tolerance = 0.0;
-    if (PyArg_ParseTuple(args, "O|d", &pcObj, &tolerance)) {
+    tolerance = 0.0;
+    withHistory = Py_False;
+    if (PyArg_ParseTupleAndKeywords(args, keywds, "O|dO!", kwlist,
+                                    &pcObj, &tolerance,
+                                    &(PyBool_Type), &withHistory)) {
         std::vector<TopoDS_Shape> shapeVec;
         Py::Sequence shapeSeq(pcObj);
         for (Py::Sequence::iterator it = shapeSeq.begin(); it != shapeSeq.end(); ++it) {
@@ -1036,15 +1066,22 @@ PyObject*  TopoShapePy::slices(PyObject *args)
     }
 }
 
-PyObject*  TopoShapePy::cut(PyObject *args)
+PyObject*  TopoShapePy::cut(PyObject *args, PyObject *keywds)
 {
+    static char *kwlist[] = {"tools", "tolerance", "withHistory", NULL};
     PyObject *pcObj;
-    if (PyArg_ParseTuple(args, "O!", &(TopoShapePy::Type), &pcObj)) {
-        TopoDS_Shape shape = static_cast<TopoShapePy*>(pcObj)->getTopoShapePtr()->getShape();
+    double tolerance = 0.0;
+    PyObject *withHistory = Py_False;
+    if (PyArg_ParseTupleAndKeywords(args, keywds, "O!|dO!", kwlist,
+                                    &(TopoShapePy::Type), &pcObj,
+                                    &tolerance,
+                                    &(PyBool_Type), &withHistory)) {
+        TopoShape* shape = static_cast<TopoShapePy*>(pcObj)->getTopoShapePtr();
         try {
             // Let's call algorithm computing a cut operation:
-            TopoDS_Shape cutShape = this->getTopoShapePtr()->cut(shape);
-            return new TopoShapePy(new TopoShape(cutShape));
+            TopoShape cutShape = this->getTopoShapePtr()
+                    ->cut(*shape, PyObject_IsTrue(withHistory)?true:false);
+            return cutShape.getPyObject();
         }
         catch (Standard_Failure) {
             Handle(Standard_Failure) e = Standard_Failure::Caught();
@@ -1058,8 +1095,11 @@ PyObject*  TopoShapePy::cut(PyObject *args)
     }
 
     PyErr_Clear();
-    double tolerance = 0.0;
-    if (PyArg_ParseTuple(args, "O|d", &pcObj, &tolerance)) {
+    tolerance = 0.0;
+    withHistory = Py_False;
+    if (PyArg_ParseTupleAndKeywords(args, keywds, "O|dO!", kwlist,
+                                    &pcObj, &tolerance,
+                                    &(PyBool_Type), &withHistory)) {
         std::vector<TopoDS_Shape> shapeVec;
         Py::Sequence shapeSeq(pcObj);
         for (Py::Sequence::iterator it = shapeSeq.begin(); it != shapeSeq.end(); ++it) {


### PR DESCRIPTION
Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [X] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [X] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR once it is merged.

---

Some testing required. Works well enough for my test cases, but they are fairly naive. 

Supported methods (all booleans, `extrude`, `mirror`, `makeFillet2`, `makeChamfer2`) now come with an optional `withHistory` parameter that can be set to `True` if you want to store history. The development of the sub-shapes from the sub-shapes of the base(s) can be studied by using `shapeName.History.modified`, `shapeName.History.generated`, `shapeName.History.isDeleted`. 
