### PR TITLE
Expressions: Fixed issue #3128; mod(x;y) should support arbitrary uni…

### DIFF
--- a/src/App/Expression.cpp
+++ b/src/App/Expression.cpp
@@ -1007,9 +1007,7 @@ Expression * FunctionExpression::eval() const
     case MOD:
         if (v2 == 0)
             throw ExpressionError("Invalid second argument.");
-        if (!v2->getUnit().isEmpty())
-            throw ExpressionError("Second argument must have empty unit.");
-        unit = v1->getUnit();
+        unit = v1->getUnit() / v2->getUnit();
         break;
     case POW: {
         if (v2 == 0)

--- a/src/Mod/Spreadsheet/TestSpreadsheet.py
+++ b/src/Mod/Spreadsheet/TestSpreadsheet.py
@@ -300,7 +300,7 @@ class SpreadsheetCases(unittest.TestCase):
         self.assertMostlyEqual(sheet.A19, 3) # Mod
         self.assertMostlyEqual(sheet.B19, -3)
         self.assertMostlyEqual(sheet.C19, Units.Quantity('3 mm'))
-        self.assertEqual(sheet.D19, u'ERR: Second argument must have empty unit.')
+        self.assertEqual(sheet.D19, 3)
         self.assertMostlyEqual(sheet.A20, Units.Quantity('45 deg'))       # Atan2
         self.assertMostlyEqual(sheet.B20, Units.Quantity('-45 deg'))
         self.assertEqual(sheet.C20, u'ERR: Units must be equal')
@@ -774,6 +774,15 @@ class SpreadsheetCases(unittest.TestCase):
 
         # Close second document
         FreeCAD.closeDocument(doc2.Name)
+
+    def testIssue3128(self):
+        """ Regression test for issue 3128; mod should work with arbitrary units for both arguments """
+        sheet = self.doc.addObject('Spreadsheet::Sheet','Spreadsheet')
+        sheet.set('A1', '=mod(7mm;3mm)')
+        sheet.set('A2', '=mod(7kg;3mm)')
+        self.doc.recompute()
+        self.assertEqual(sheet.A1, Units.Quantity('1'))
+        self.assertEqual(sheet.A2, Units.Quantity('1 kg/mm'))
 
     def tearDown(self):
         #closing doc


### PR DESCRIPTION
…ts for both arguments.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [x] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR once it is merged.

---
