### PR TITLE
misc. typo fixes

### DIFF
--- a/src/Mod/Fem/FemMeshTools.py
+++ b/src/Mod/Fem/FemMeshTools.py
@@ -1146,7 +1146,7 @@ def get_anlysis_empty_references_group_elements(group_elements, aAnalysis, aShap
                     FreeCAD.Console.PrintError('Problem in get_anlysis_empty_references_group_elements, we seams to have two or more materials with empty referneces')
                     return {}
             elif hasattr(m, "References") and m.References:
-                # ShapeType ot the group elements, strip the number of the first group element
+                # ShapeType of the group elements, strip the number of the first group element
                 # http://stackoverflow.com/questions/12851791/removing-numbers-from-string
                 group_shape_type = ''.join(i for i in group_elements[m.Name][0] if not i.isdigit())
                 if not material_shape_type:

--- a/src/Mod/Fem/FemToolsCcx.py
+++ b/src/Mod/Fem/FemToolsCcx.py
@@ -103,7 +103,7 @@ class FemToolsCcx(FemTools.FemTools):
             print("Unexpected error when writing CalculiX input file:", sys.exc_info()[0])
             raise
 
-    ## Sets CalculiX ccx binary path and velidates if the binary can be executed
+    ## Sets CalculiX ccx binary path and validates if the binary can be executed
     #  @param self The python object self
     #  @ccx_binary path to ccx binary, default is guessed: "bin/ccx" windows, "ccx" for other systems
     #  @ccx_binary_sig expected output form ccx when run empty. Default value is "CalculiX.exe -i jobname"

--- a/src/Mod/Path/PathScripts/post/grbl_post.py
+++ b/src/Mod/Path/PathScripts/post/grbl_post.py
@@ -91,7 +91,7 @@ def export(objectslist,filename,args):
     gcode = ""
 
     #Find the machine.
-    #The user my have overriden post processor defaults in the GUI.  Make sure we're using the current values in the Machine Def.
+    #The user my have overridden post processor defaults in the GUI.  Make sure we're using the current values in the Machine Def.
     myMachine = None
     for pathobj in objectslist:
         if hasattr(pathobj,"Group"): #We have a compound or project.


### PR DESCRIPTION
fixed typos in FEM and Path WBs
@berndhahnebach can you double check the FEM typos
@sliptonic ditto for Path  
 Edit: Sorry for forgetting to add `[skip ci]` to commit messages 