### PR TITLE
Graphviz: adding wiki doc link to 'Graphviz not found' dialogue

### DIFF
--- a/src/Gui/GraphvizView.cpp
+++ b/src/Gui/GraphvizView.cpp
@@ -225,6 +225,7 @@ void GraphvizView::updateSvgItem(const App::Document &doc)
             int ret = QMessageBox::warning(Gui::getMainWindow(),
                                            qApp->translate("Std_ExportGraphviz","Graphviz not found"),
                                            qApp->translate("Std_ExportGraphviz","Graphviz couldn't be found on your system.\n"
+                                                           "Read more about this at https://www.freecadweb.org/wiki/Std_DependencyGraph\n"
                                                            "Do you want to specify its installation path if it's already installed?"),
                                            QMessageBox::Yes, QMessageBox::No);
             if (ret == QMessageBox::No) {


### PR DESCRIPTION
Will the dialogue automagically turn this in to a hyperlink or do i need to do some wizardry on it?
Ref: [Forum thread](https://forum.freecadweb.org/viewtopic.php?f=3&t=23506#p183152)