### PR TITLE
PATH: change holding tags to not generate the PATH each time a new tag is added or one is modified

### DIFF
--- a/src/App/Document.cpp
+++ b/src/App/Document.cpp
@@ -2107,6 +2107,7 @@ int Document::recompute()
 
     for (std::list<Vertex>::reverse_iterator i = make_order.rbegin();i != make_order.rend(); ++i) {
         DocumentObject* Cur = d->vertexMap[*i];
+        if (!Cur || !isIn(Cur)) continue;
 
         if (recomputeList.find(Cur) != recomputeList.end() ||
                 Cur->ExpressionEngine.depsAreTouched()) {

--- a/src/Mod/Path/CMakeLists.txt
+++ b/src/Mod/Path/CMakeLists.txt
@@ -29,6 +29,8 @@ SET(PathScripts_SRCS
     PathScripts/PathDressupDragknife.py
     PathScripts/PathDressupHoldingTags.py
     PathScripts/PathDressupRampEntry.py
+    PathScripts/PathDressupTag.py
+    PathScripts/PathDressupTagGui.py
     PathScripts/PathDressupTagPreferences.py
     PathScripts/PathDrilling.py
     PathScripts/PathEngrave.py

--- a/src/Mod/Path/CMakeLists.txt
+++ b/src/Mod/Path/CMakeLists.txt
@@ -29,6 +29,7 @@ SET(PathScripts_SRCS
     PathScripts/PathDressupDragknife.py
     PathScripts/PathDressupHoldingTags.py
     PathScripts/PathDressupRampEntry.py
+    PathScripts/PathDressupTagPreferences.py
     PathScripts/PathDrilling.py
     PathScripts/PathEngrave.py
     PathScripts/PathFacePocket.py

--- a/src/Mod/Path/InitGui.py
+++ b/src/Mod/Path/InitGui.py
@@ -143,7 +143,7 @@ class PathWorkbench (Workbench):
                 selectedName = FreeCADGui.Selection.getSelection()[0].Name
                 if "Job" in selectedName:
                     self.appendContextMenu("", ["Path_ExportTemplate"])
-                if "Profile" in selectedName or "Contour" in selectedName:
+                if "Profile" in selectedName or "Contour" in selectedName or "Dressup" in selectedName:
                     #self.appendContextMenu("", ["Set_StartPoint"])
                     #self.appendContextMenu("", ["Set_EndPoint"])
                     for cmd in self.dressupcmds:

--- a/src/Mod/Path/InitGui.py
+++ b/src/Mod/Path/InitGui.py
@@ -51,7 +51,6 @@ class PathWorkbench (Workbench):
         from PathScripts import PathDressup
         from PathScripts import PathDressupDogbone
         from PathScripts import PathDressupDragknife
-        from PathScripts import PathDressupHoldingTags
         from PathScripts import PathDressupRampEntry
         from PathScripts import PathDressupTagGui
         from PathScripts import PathDrilling
@@ -87,7 +86,7 @@ class PathWorkbench (Workbench):
         twodopcmdlist = ["Path_Contour", "Path_Profile", "Path_Profile_Edges", "Path_Pocket", "Path_Drilling", "Path_Engrave", "Path_MillFace", "Path_Helix"]
         threedopcmdlist = ["Path_Surfacing"]
         modcmdlist = ["Path_Copy", "Path_CompoundExtended", "Path_Array", "Path_SimpleCopy" ]
-        dressupcmdlist = ["PathDressup_Dogbone", "PathDressup_DragKnife", "PathDressup_HoldingTags", "PathDressup_Tag", "PathDressup_RampEntry"]
+        dressupcmdlist = ["PathDressup_Dogbone", "PathDressup_DragKnife", "PathDressup_Tag", "PathDressup_RampEntry"]
         extracmdlist = ["Path_SelectLoop", "Path_Shape", "Path_Area", "Path_Area_Workplane", "Path_Stock"]
         #modcmdmore = ["Path_Hop",]
         #remotecmdlist = ["Path_Remote"]
@@ -145,7 +144,6 @@ class PathWorkbench (Workbench):
                 if "Job" in selectedName:
                     self.appendContextMenu("", ["Path_ExportTemplate"])
                 if "Profile" in selectedName or "Contour" in selectedName:
-                    #self.appendContextMenu("", ["Add_Tag"])
                     #self.appendContextMenu("", ["Set_StartPoint"])
                     #self.appendContextMenu("", ["Set_EndPoint"])
                     for cmd in self.dressupcmds:

--- a/src/Mod/Path/InitGui.py
+++ b/src/Mod/Path/InitGui.py
@@ -53,6 +53,7 @@ class PathWorkbench (Workbench):
         from PathScripts import PathDressupDragknife
         from PathScripts import PathDressupHoldingTags
         from PathScripts import PathDressupRampEntry
+        from PathScripts import PathDressupTagGui
         from PathScripts import PathDrilling
         from PathScripts import PathEngrave
         from PathScripts import PathFacePocket
@@ -86,7 +87,7 @@ class PathWorkbench (Workbench):
         twodopcmdlist = ["Path_Contour", "Path_Profile", "Path_Profile_Edges", "Path_Pocket", "Path_Drilling", "Path_Engrave", "Path_MillFace", "Path_Helix"]
         threedopcmdlist = ["Path_Surfacing"]
         modcmdlist = ["Path_Copy", "Path_CompoundExtended", "Path_Array", "Path_SimpleCopy" ]
-        dressupcmdlist = ["PathDressup_Dogbone", "PathDressup_DragKnife", "PathDressup_HoldingTags", "PathDressup_RampEntry"]
+        dressupcmdlist = ["PathDressup_Dogbone", "PathDressup_DragKnife", "PathDressup_HoldingTags", "PathDressup_Tag", "PathDressup_RampEntry"]
         extracmdlist = ["Path_SelectLoop", "Path_Shape", "Path_Area", "Path_Area_Workplane", "Path_Stock"]
         #modcmdmore = ["Path_Hop",]
         #remotecmdlist = ["Path_Remote"]

--- a/src/Mod/Path/PathScripts/PathDressupDogbone.py
+++ b/src/Mod/Path/PathScripts/PathDressupDogbone.py
@@ -982,7 +982,8 @@ class ViewProviderDressup:
     def onDelete(self, arg1=None, arg2=None):
         '''this makes sure that the base operation is added back to the project and visible'''
         FreeCADGui.ActiveDocument.getObject(arg1.Object.Base.Name).Visibility = True
-        PathUtils.addToJob(arg1.Object.Base)
+        job = PathUtils.findParentJob(arg1.Object)
+        PathUtils.addObjectToJob(arg1.Object.Base, job)
         arg1.Object.Base = None
         return True
 

--- a/src/Mod/Path/PathScripts/PathDressupHoldingTags.py
+++ b/src/Mod/Path/PathScripts/PathDressupHoldingTags.py
@@ -27,13 +27,13 @@ import Draft
 import DraftGeomUtils
 import Path
 import PathScripts.PathLog as PathLog
-import PathScripts.PathPreferencesPathDressup as PathPreferencesPathDressup
 import Part
 import copy
 import math
 
 from PathScripts import PathUtils
 from PathScripts.PathGeom import PathGeom
+from PathScripts.PathDressupTagPreferences import HoldingTagPreferences
 from PathScripts.PathPreferences import PathPreferences
 from PathScripts.PathUtils import waiting_effects
 from PySide import QtCore
@@ -94,69 +94,6 @@ def debugCone(vector, r1, r2, height, label, color = None):
         if color:
             obj.ViewObject.ShapeColor = color
 
-
-class HoldingTagsPreferences:
-    DefaultHoldingTagWidth   = 'DefaultHoldingTagWidth'
-    DefaultHoldingTagHeight  = 'DefaultHoldingTagHeight'
-    DefaultHoldingTagAngle   = 'DefaultHoldingTagAngle'
-    DefaultHoldingTagRadius  = 'DefaultHoldingTagRadius'
-    DefaultHoldingTagCount   = 'DefaultHoldingTagCount'
-
-    @classmethod
-    def defaultWidth(cls, ifNotSet):
-        value = PathPreferences.preferences().GetFloat(cls.DefaultHoldingTagWidth, ifNotSet)
-        if value == 0.0:
-            return ifNotSet
-        return value
-
-    @classmethod
-    def defaultHeight(cls, ifNotSet):
-        value = PathPreferences.preferences().GetFloat(cls.DefaultHoldingTagHeight, ifNotSet)
-        if value == 0.0:
-            return ifNotSet
-        return value
-
-    @classmethod
-    def defaultAngle(cls, ifNotSet = 45.0):
-        value = PathPreferences.preferences().GetFloat(cls.DefaultHoldingTagAngle, ifNotSet)
-        if value < 10.0:
-            return ifNotSet
-        return value
-
-    @classmethod
-    def defaultCount(cls, ifNotSet = 4):
-        value = PathPreferences.preferences().GetUnsigned(cls.DefaultHoldingTagCount, ifNotSet)
-        if value < 2:
-            return float(ifNotSet)
-        return float(value)
-
-    @classmethod
-    def defaultRadius(cls, ifNotSet = 0.0):
-        return PathPreferences.preferences().GetFloat(cls.DefaultHoldingTagRadius, ifNotSet)
-
-
-    def __init__(self):
-        self.form = FreeCADGui.PySideUic.loadUi(":/preferences/PathDressupHoldingTags.ui")
-        self.label = translate("PathDressup_HoldingTags", 'Holding Tags')
-
-    def loadSettings(self):
-        self.form.ifWidth.setText(FreeCAD.Units.Quantity(self.defaultWidth(0), FreeCAD.Units.Length).UserString)
-        self.form.ifHeight.setText(FreeCAD.Units.Quantity(self.defaultHeight(0), FreeCAD.Units.Length).UserString)
-        self.form.dsbAngle.setValue(self.defaultAngle())
-        self.form.ifRadius.setText(FreeCAD.Units.Quantity(self.defaultRadius(), FreeCAD.Units.Length).UserString)
-        self.form.sbCount.setValue(self.defaultCount())
-
-    def saveSettings(self):
-        pref = PathPreferences.preferences()
-        pref.SetFloat(self.DefaultHoldingTagWidth, FreeCAD.Units.Quantity(self.form.ifWidth.text()).Value)
-        pref.SetFloat(self.DefaultHoldingTagHeight, FreeCAD.Units.Quantity(self.form.ifHeight.text()).Value)
-        pref.SetFloat(self.DefaultHoldingTagAngle, self.form.dsbAngle.value())
-        pref.SetFloat(self.DefaultHoldingTagRadius, FreeCAD.Units.Quantity(self.form.ifRadius.text()))
-        pref.SetUnsigned(self.DefaultHoldingTagCount, self.form.sbCount.value())
-
-    @classmethod
-    def preferencesPage(cls):
-        return HoldingTagsPreferences()
 
 class Tag:
     def __init__(self, id, x, y, width, height, angle, radius, enabled=True):
@@ -685,20 +622,20 @@ class PathData:
             pathHeight = (self.obj.Base.StartDepth - self.obj.Base.FinalDepth).Value
         else:
             pathHeight = self.maxZ - self.minZ
-        height = HoldingTagsPreferences.defaultHeight(pathHeight / 2)
+        height = HoldingTagPreferences.defaultHeight(pathHeight / 2)
         if height > pathHeight:
             return pathHeight
         return height
 
     def defaultTagWidth(self):
         width = self.shortestAndLongestPathEdge()[1].Length / 10
-        return HoldingTagsPreferences.defaultWidth(width)
+        return HoldingTagPreferences.defaultWidth(width)
 
     def defaultTagAngle(self):
-        return HoldingTagsPreferences.defaultAngle()
+        return HoldingTagPreferences.defaultAngle()
 
     def defaultTagRadius(self):
-        return HoldingTagsPreferences.defaultRadius()
+        return HoldingTagPreferences.defaultRadius()
 
     def sortedTags(self, tags):
         ordered = []
@@ -988,7 +925,7 @@ class ObjectDressup:
             obj.Width  = self.pathData.defaultTagWidth()
             obj.Angle  = self.pathData.defaultTagAngle()
             obj.Radius = self.pathData.defaultTagRadius()
-            count = HoldingTagsPreferences.defaultCount()
+            count = HoldingTagPreferences.defaultCount()
             self.generateTags(obj, count)
         return self.pathData
 
@@ -1010,12 +947,6 @@ class ObjectDressup:
         if not hasattr(self, 'pathData'):
             self.setup(obj)
         return self.pathData.pointIsOnPath(point)
-
-    @classmethod
-    def preferencesPage(cls):
-        return HoldingTagsPreferences()
-
-PathPreferencesPathDressup.RegisterDressup(ObjectDressup)
 
 class TaskPanel:
     DataX = QtCore.Qt.ItemDataRole.UserRole

--- a/src/Mod/Path/PathScripts/PathDressupRampEntry.py
+++ b/src/Mod/Path/PathScripts/PathDressupRampEntry.py
@@ -563,7 +563,8 @@ class ViewProviderDressup:
         PathLog.debug("Deleting Dressup")
         '''this makes sure that the base operation is added back to the project and visible'''
         FreeCADGui.ActiveDocument.getObject(arg1.Object.Base.Name).Visibility = True
-        PathUtils.addToJob(arg1.Object.Base)
+        job = PathUtils.findParentJob(self.obj)
+        PathUtils.addObjectToJob(arg1.Object.Base, job)
         arg1.Object.Base = None
         return True
 

--- a/src/Mod/Path/PathScripts/PathDressupTag.py
+++ b/src/Mod/Path/PathScripts/PathDressupTag.py
@@ -1,0 +1,199 @@
+# -*- coding: utf-8 -*-
+
+# ***************************************************************************
+# *                                                                         *
+# *   Copyright (c) 2017 sliptonic <shopinthewoods@gmail.com>               *
+# *                                                                         *
+# *   This program is free software; you can redistribute it and/or modify  *
+# *   it under the terms of the GNU Lesser General Public License (LGPL)    *
+# *   as published by the Free Software Foundation; either version 2 of     *
+# *   the License, or (at your option) any later version.                   *
+# *   for detail see the LICENCE text file.                                 *
+# *                                                                         *
+# *   This program is distributed in the hope that it will be useful,       *
+# *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+# *   GNU Library General Public License for more details.                  *
+# *                                                                         *
+# *   You should have received a copy of the GNU Library General Public     *
+# *   License along with this program; if not, write to the Free Software   *
+# *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
+# *   USA                                                                   *
+# *                                                                         *
+# ***************************************************************************
+import FreeCAD
+import Part
+import Path
+import PathScripts.PathLog as PathLog
+import PathScripts.PathPreferencesPathDressup as PathPreferencesPathDressup
+import math
+import sys
+
+from PathScripts.PathDressupTagPreferences import HoldingTagPreferences
+from PathScripts.PathGeom import PathGeom
+from PySide import QtCore
+
+PathLog.setLevel(PathLog.Level.DEBUG, PathLog.thisModule())
+PathLog.trackModule()
+
+# Qt tanslation handling
+def translate(context, text, disambig=None):
+    return QtCore.QCoreApplication.translate(context, text, disambig)
+
+class TagSolid:
+    def __init__(self, proxy, z, R):
+        self.proxy = proxy
+        self.z = z
+        self.toolRadius = R
+        self.angle = math.fabs(proxy.obj.Angle)
+        self.width = math.fabs(proxy.obj.Width)
+        self.height = math.fabs(proxy.obj.Height)
+        self.radius = math.fabs(proxy.obj.Radius)
+        self.actualHeight = self.height
+        self.fullWidth = 2 * self.toolRadius + self.width
+
+        r1 = self.fullWidth / 2
+        self.r1 = r1
+        self.r2 = r1
+        height = self.actualHeight * 1.01
+        radius = 0
+        if self.angle == 90 and height > 0:
+            # cylinder
+            self.solid = Part.makeCylinder(r1, height)
+            radius = min(min(self.radius, r1), self.height)
+            PathLog.debug("Part.makeCylinder(%f, %f)" % (r1, height))
+        elif self.angle > 0.0 and height > 0.0:
+            # cone
+            rad = math.radians(self.angle)
+            tangens = math.tan(rad)
+            dr = height / tangens
+            if dr < r1:
+                # with top
+                r2 = r1 - dr
+                s = height / math.sin(rad)
+                radius = min(r2, s) * math.tan((math.pi - rad)/2) * 0.95
+            else:
+                # triangular
+                r2 = 0
+                height = r1 * tangens * 1.01
+                self.actualHeight = height
+            self.r2 = r2
+            PathLog.debug("Part.makeCone(r1=%.2f, r2=%.2f, h=%.2f)" % (r1, r2, height))
+            self.solid = Part.makeCone(r1, r2, height)
+        else:
+            # degenerated case - no tag
+            PathLog.debug("Part.makeSphere(%.2f)" % (r1 / 10000))
+            self.solid = Part.makeSphere(r1 / 10000)
+
+        radius = min(self.radius, radius)
+        self.realRadius = radius
+        if radius != 0:
+            PathLog.debug("makeFillet(%.4f)" % radius)
+            self.solid = self.solid.makeFillet(radius, [self.solid.Edges[0]])
+
+        #lastly determine the center of the model, we want to make sure the seam of
+        # the tag solid points away (in the hopes it doesn't coincide with a path)
+        self.baseCenter = FreeCAD.Vector((proxy.ptMin.x+proxy.ptMax.x)/2, (proxy.ptMin.y+proxy.ptMax.y)/2, 0)
+
+    def cloneAt(self, pos):
+        clone = self.solid.copy()
+        pos.z = 0
+        angle = -PathGeom.getAngle(pos - self.baseCenter) * 180 / math.pi
+        clone.rotate(FreeCAD.Vector(0,0,0), FreeCAD.Vector(0,0,1), angle)
+        pos.z = self.z - self.actualHeight * 0.01
+        clone.translate(pos)
+        return clone
+
+
+class ObjectDressup(QtCore.QObject):
+    changed = QtCore.Signal()
+    def __init__(self, obj):
+        obj.Proxy = self
+        self.obj = obj
+        obj.addProperty('App::PropertyLink', 'Base','Base', QtCore.QT_TRANSLATE_NOOP('PathDressup_Tag', 'The base path to modify'))
+        obj.addProperty('App::PropertyLength', 'Width', 'Tag', QtCore.QT_TRANSLATE_NOOP('PathDressup_Tag', 'Width of tags.'))
+        obj.addProperty('App::PropertyLength', 'Height', 'Tag', QtCore.QT_TRANSLATE_NOOP('PathDressup_Tag', 'Height of tags.'))
+        obj.addProperty('App::PropertyAngle', 'Angle', 'Tag', QtCore.QT_TRANSLATE_NOOP('PathDressup_Tag', 'Angle of tag plunge and ascent.'))
+        obj.addProperty('App::PropertyLength', 'Radius', 'Tag', QtCore.QT_TRANSLATE_NOOP('PathDressup_Tag', 'Radius of the fillet for the tag.'))
+        obj.addProperty('App::PropertyVectorList', 'Positions', 'Tag', QtCore.QT_TRANSLATE_NOOP('PathDressup_Tag', 'Locations of insterted holding tags'))
+        obj.addProperty('App::PropertyIntegerList', 'Disabled', 'Tag', QtCore.QT_TRANSLATE_NOOP('PathDressup_Tag', 'Ids of disabled holding tags'))
+        obj.addProperty('App::PropertyInteger', 'SegmentationFactor', 'Tag', QtCore.QT_TRANSLATE_NOOP('PathDressup_Tag', 'Factor determining the # segments used to approximate rounded tags.'))
+        obj.addProperty('App::PropertyLink', 'Debug', 'Debug', QtCore.QT_TRANSLATE_NOOP('PathDressup_Tag', 'Some elements for debugging'))
+        if PathLog.getLevel(PathLog.thisModule()) != PathLog.Level.DEBUG:
+            obj.setEditorMode('Debug', 2) # hide
+        dbg = obj.Document.addObject('App::DocumentObjectGroup', 'TagDebug')
+        obj.Debug = dbg
+        self.solids = []
+        super(ObjectDressup, self).__init__()
+
+    def __getstate__(self):
+        return None
+
+    def __setstate__(self, state):
+        return None
+
+    def assignDefaultValues(self):
+        self.obj.Width  = HoldingTagPreferences.defaultWidth(self.toolRadius() * 2)
+        self.obj.Height = HoldingTagPreferences.defaultHeight(self.toolRadius())
+        self.obj.Angle  = HoldingTagPreferences.defaultAngle()
+        self.obj.Radius = HoldingTagPreferences.defaultRadius()
+
+    def execute(self, obj):
+        PathLog.track()
+        if not obj.Base:
+            PathLog.error(translate('PathDressup_Tag', 'No Base object found.'))
+            return
+        if not obj.Base.isDerivedFrom('Path::Feature'):
+            PathLog.error(translate('PathDressup_Tag', 'Base is not a Path::Feature object.'))
+            return
+        if not obj.Base.Path:
+            PathLog.error(translate('PathDressup_Tag', 'Base doesn\'t have a Path to dress-up.'))
+            return
+        if not obj.Base.Path.Commands:
+            PathLog.error(translate('PathDressup_Tag', 'Base Path is empty.'))
+            return
+
+        self.obj = obj;
+
+        minZ =  sys.maxint
+        minX = minZ
+        minY = minZ
+
+        maxZ = -sys.maxint
+        maxX = maxZ
+        maxY = maxZ
+
+        # the assumption is that all helixes are in the xy-plane - in other words there is no
+        # intermittent point of a command that has a lower/higer Z-position than the start and
+        # and end positions of a command.
+        lastPt = FreeCAD.Vector(0, 0, 0)
+        for cmd in obj.Base.Path.Commands:
+            pt = PathGeom.commandEndPoint(cmd, lastPt)
+            if lastPt.x != pt.x:
+                maxX = max(pt.x, maxX)
+                minX = min(pt.x, minX)
+            if lastPt.y != pt.y:
+                maxY = max(pt.y, maxY)
+                minY = min(pt.y, minY)
+            if lastPt.z != pt.z:
+                maxZ = max(pt.z, maxZ)
+                minZ = min(pt.z, minZ)
+            lastPt = pt
+        PathLog.debug("bb = (%.2f, %.2f, %.2f) ... (%.2f, %.2f, %.2f)" % (minX, minY, minZ, maxX, maxY, maxZ))
+        self.ptMin = FreeCAD.Vector(minX, minY, minZ)
+        self.ptMax = FreeCAD.Vector(maxX, maxY, maxZ)
+        self.masterSolid = TagSolid(self, minZ, self.toolRadius())
+        self.solids = [self.masterSolid.cloneAt(pos) for pos in self.obj.Positions]
+        self.changed.emit()
+        PathLog.track()
+
+    def toolRadius(self):
+        return self.obj.Base.ToolController.Tool.Diameter / 2.0
+
+    def addTagsToDocuemnt(self):
+        for i, solid in enumerate(self.solids):
+            obj = FreeCAD.ActiveDocument.addObject('Part::Compound', "tag_%02d" % i)
+            obj.Shape = solid
+
+
+PathLog.notice('Loading PathDressupTag... done\n')

--- a/src/Mod/Path/PathScripts/PathDressupTag.py
+++ b/src/Mod/Path/PathScripts/PathDressupTag.py
@@ -108,10 +108,10 @@ class TagSolid:
         return clone
 
 
-class ObjectDressup(QtCore.QObject):
-    changed = QtCore.Signal()
+class ObjectDressup:
 
     def __init__(self, obj, base):
+
         obj.addProperty('App::PropertyLink', 'Base','Base', QtCore.QT_TRANSLATE_NOOP('PathDressup_Tag', 'The base path to modify'))
         obj.addProperty('App::PropertyLength', 'Width', 'Tag', QtCore.QT_TRANSLATE_NOOP('PathDressup_Tag', 'Width of tags.'))
         obj.addProperty('App::PropertyLength', 'Height', 'Tag', QtCore.QT_TRANSLATE_NOOP('PathDressup_Tag', 'Height of tags.'))
@@ -120,19 +120,12 @@ class ObjectDressup(QtCore.QObject):
         obj.addProperty('App::PropertyVectorList', 'Positions', 'Tag', QtCore.QT_TRANSLATE_NOOP('PathDressup_Tag', 'Locations of insterted holding tags'))
         obj.addProperty('App::PropertyIntegerList', 'Disabled', 'Tag', QtCore.QT_TRANSLATE_NOOP('PathDressup_Tag', 'Ids of disabled holding tags'))
         obj.addProperty('App::PropertyInteger', 'SegmentationFactor', 'Tag', QtCore.QT_TRANSLATE_NOOP('PathDressup_Tag', 'Factor determining the # segments used to approximate rounded tags.'))
-        obj.addProperty('App::PropertyLink', 'Debug', 'Debug', QtCore.QT_TRANSLATE_NOOP('PathDressup_Tag', 'Some elements for debugging'))
 
         obj.Proxy = self
         obj.Base = base
 
-        if PathLog.getLevel(PathLog.thisModule()) != PathLog.Level.DEBUG:
-            obj.setEditorMode('Debug', 2) # hide
-        dbg = obj.Document.addObject('App::DocumentObjectGroup', 'TagDebug')
-        obj.Debug = dbg
-
         self.obj = obj
         self.solids = []
-        super(ObjectDressup, self).__init__()
 
     def __getstate__(self):
         return None
@@ -196,7 +189,7 @@ class ObjectDressup(QtCore.QObject):
         self.wire, rapid = PathGeom.wireForPath(obj.Base.Path)
         self.edges = self.wire.Edges
 
-        maxTagZ = minZ + obj.Height
+        maxTagZ = minZ + obj.Height.Value
 
         lastX = 0
         lastY = 0
@@ -214,7 +207,6 @@ class ObjectDressup(QtCore.QObject):
                 commands.append(cmd)
 
         obj.Path = obj.Base.Path
-        self.changed.emit()
 
         PathLog.track()
 

--- a/src/Mod/Path/PathScripts/PathDressupTagGui.py
+++ b/src/Mod/Path/PathScripts/PathDressupTagGui.py
@@ -518,10 +518,11 @@ class PathDressupTagViewProvider:
 
     def onDelete(self, arg1=None, arg2=None):
         PathLog.track()
-        '''this makes sure that the base operation is added back to the project and visible'''
+        '''this makes sure that the base operation is added back to the job and visible'''
         if self.obj.Base.ViewObject:
             self.obj.Base.ViewObject.Visibility = True
-        PathUtils.addToJob(arg1.Object.Base)
+        job = PathUtils.findParentJob(self.obj)
+        PathUtils.addObjectToJob(arg1.Object.Base, job)
         #if self.debugDisplay():
         #    self.vobj.Debug.removeObjectsFromDocument()
         #    self.vobj.Debug.Document.removeObject(self.vobj.Debug.Name)

--- a/src/Mod/Path/PathScripts/PathDressupTagGui.py
+++ b/src/Mod/Path/PathScripts/PathDressupTagGui.py
@@ -26,7 +26,8 @@ import FreeCAD
 import FreeCADGui
 import Path
 import PathScripts
-import PathScripts.PathDressupTag as PathDressupTag
+#import PathScripts.PathDressupTag as PathDressupTag
+import PathScripts.PathDressupHoldingTags as PathDressupTag
 import PathScripts.PathLog as PathLog
 import PathScripts.PathUtils as PathUtils
 
@@ -35,12 +36,15 @@ from PathScripts.PathPreferences import PathPreferences
 from PySide import QtCore, QtGui
 from pivy import coin
 
-PathLog.setLevel(PathLog.Level.DEBUG, PathLog.thisModule())
-PathLog.trackModule()
+PathLog.setLevel(PathLog.Level.INFO, PathLog.thisModule())
+#PathLog.trackModule()
 
 # Qt tanslation handling
 def translate(context, text, disambig=None):
     return QtCore.QCoreApplication.translate(context, text, disambig)
+
+def addDebugDisplay():
+    return PathLog.getLevel(PathLog.thisModule()) == PathLog.Level.DEBUG
 
 class PathDressupTagTaskPanel:
     DataX  = QtCore.Qt.ItemDataRole.UserRole
@@ -455,6 +459,17 @@ class PathDressupTagViewProvider:
         self.vobj = vobj
         self.panel = None
 
+        self.debugDisplay()
+
+    def debugDisplay(self):
+        #if False and addDebugDisplay():
+        #    if not hasattr(self.vobj, 'Debug'):
+        #        self.vobj.addProperty('App::PropertyLink', 'Debug', 'Debug', QtCore.QT_TRANSLATE_NOOP('PathDressup_TagGui', 'Some elements for debugging'))
+        #        dbg = self.vobj.Object.Document.addObject('App::DocumentObjectGroup', 'TagDebug')
+        #        self.vobj.Debug = dbg
+        #    return True
+        return False
+
     def __getstate__(self):
         return None
     def __setstate__(self, state):
@@ -475,6 +490,7 @@ class PathDressupTagViewProvider:
     def attach(self, vobj):
         PathLog.track()
         self.setupColors()
+        self.vobj = vobj
         self.obj = vobj.Object
         self.tags = []
         self.switch = coin.SoSwitch()
@@ -487,10 +503,8 @@ class PathDressupTagViewProvider:
                     i.Group = [o for o in i.Group if o.Name != self.obj.Base.Name]
             if self.obj.Base.ViewObject:
                 self.obj.Base.ViewObject.Visibility = False
-            if PathLog.getLevel(PathLog.thisModule()) != PathLog.Level.DEBUG and self.obj.Debug.ViewObject:
-                self.obj.Debug.ViewObject.Visibility = False
-
-        self.obj.Proxy.changed.connect(self.onModelChanged)
+            #if self.debugDisplay() and self.vobj.Debug.ViewObject:
+            #    self.vobj.Debug.ViewObject.Visibility = False
 
     def turnMarkerDisplayOn(self, display):
         sw = coin.SO_SWITCH_ALL if display else coin.SO_SWITCH_NONE
@@ -498,7 +512,9 @@ class PathDressupTagViewProvider:
 
     def claimChildren(self):
         PathLog.track()
-        return [self.obj.Base, self.obj.Debug]
+        #if self.debugDisplay():
+        #    return [self.obj.Base, self.vobj.Debug]
+        return [self.obj.Base]
 
     def onDelete(self, arg1=None, arg2=None):
         PathLog.track()
@@ -506,9 +522,10 @@ class PathDressupTagViewProvider:
         if self.obj.Base.ViewObject:
             self.obj.Base.ViewObject.Visibility = True
         PathUtils.addToJob(arg1.Object.Base)
-        self.obj.Debug.removeObjectsFromDocument()
-        self.obj.Debug.Document.removeObject(self.obj.Debug.Name)
-        self.obj.Debug = None
+        #if self.debugDisplay():
+        #    self.vobj.Debug.removeObjectsFromDocument()
+        #    self.vobj.Debug.Document.removeObject(self.vobj.Debug.Name)
+        #    self.vobj.Debug = None
         return True
 
     def updatePositions(self, positions, disabled):
@@ -529,15 +546,16 @@ class PathDressupTagViewProvider:
 
     def onModelChanged(self):
         PathLog.track()
-        self.obj.Debug.removeObjectsFromDocument()
-        for solid in self.obj.Proxy.solids:
-            tag = self.obj.Document.addObject('Part::Feature', 'tag')
-            tag.Shape = solid
-            if tag.ViewObject and self.obj.Debug.ViewObject:
-                tag.ViewObject.Visibility = self.obj.Debug.ViewObject.Visibility
-                tag.ViewObject.Transparency = 80
-            self.obj.Debug.addObject(tag)
-            tag.purgeTouched()
+        #if self.debugDisplay():
+        #    self.vobj.Debug.removeObjectsFromDocument()
+        #    for solid in self.obj.Proxy.solids:
+        #        tag = self.obj.Document.addObject('Part::Feature', 'tag')
+        #        tag.Shape = solid
+        #        if tag.ViewObject and self.vobj.Debug.ViewObject:
+        #            tag.ViewObject.Visibility = self.vobj.Debug.ViewObject.Visibility
+        #            tag.ViewObject.Transparency = 80
+        #        self.vobj.Debug.addObject(tag)
+        #    tag.purgeTouched()
 
     def setEdit(self, vobj, mode=0):
         panel = PathDressupTagTaskPanel(vobj.Object, self)

--- a/src/Mod/Path/PathScripts/PathDressupTagGui.py
+++ b/src/Mod/Path/PathScripts/PathDressupTagGui.py
@@ -21,6 +21,7 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
+import Draft
 import FreeCAD
 import FreeCADGui
 import Path
@@ -29,8 +30,9 @@ import PathScripts.PathDressupTag as PathDressupTag
 import PathScripts.PathLog as PathLog
 import PathScripts.PathUtils as PathUtils
 
+from PathScripts.PathGeom import PathGeom
 from PathScripts.PathPreferences import PathPreferences
-from PySide import QtCore
+from PySide import QtCore, QtGui
 from pivy import coin
 
 PathLog.setLevel(PathLog.Level.DEBUG, PathLog.thisModule())
@@ -39,6 +41,357 @@ PathLog.trackModule()
 # Qt tanslation handling
 def translate(context, text, disambig=None):
     return QtCore.QCoreApplication.translate(context, text, disambig)
+
+class PathDressupTagTaskPanel:
+    DataX  = QtCore.Qt.ItemDataRole.UserRole
+    DataY  = QtCore.Qt.ItemDataRole.UserRole + 1
+    DataZ  = QtCore.Qt.ItemDataRole.UserRole + 2
+    DataID = QtCore.Qt.ItemDataRole.UserRole + 3
+
+    def __init__(self, obj, viewProvider, jvoVisibility=None):
+        self.obj = obj
+        self.obj.Proxy.obj = obj
+        self.viewProvider = viewProvider
+        self.form = QtGui.QWidget()
+        self.formTags  = FreeCADGui.PySideUic.loadUi(":/panels/HoldingTagsEdit.ui")
+        self.formPoint = FreeCADGui.PySideUic.loadUi(":/panels/PointEdit.ui")
+        self.layout = QtGui.QVBoxLayout(self.form)
+        #self.form.setGeometry(self.formTags.geometry())
+        self.form.setWindowTitle(self.formTags.windowTitle())
+        self.form.setSizePolicy(self.formTags.sizePolicy())
+        self.formTags.setParent(self.form)
+        self.formPoint.setParent(self.form)
+        self.layout.addWidget(self.formTags)
+        self.layout.addWidget(self.formPoint)
+        self.formPoint.hide()
+        self.jvo = PathUtils.findParentJob(obj).ViewObject
+        if jvoVisibility is None:
+            FreeCAD.ActiveDocument.openTransaction(translate("PathDressup_HoldingTags", "Edit HoldingTags Dress-up"))
+            self.jvoVisible = self.jvo.isVisible()
+            if self.jvoVisible:
+                self.jvo.hide()
+        else:
+            self.jvoVisible = jvoVisibility
+        self.pt = FreeCAD.Vector(0, 0, 0)
+
+        closeButton = self.formPoint.buttonBox.button(QtGui.QDialogButtonBox.StandardButton.Close)
+        closeButton.setText(translate("PathDressup_HoldingTags", "Done"))
+
+        self.isDirty = True
+
+    def getStandardButtons(self):
+        return int(QtGui.QDialogButtonBox.Ok | QtGui.QDialogButtonBox.Apply | QtGui.QDialogButtonBox.Cancel)
+
+    def clicked(self, button):
+        if button == QtGui.QDialogButtonBox.Apply:
+            self.getFields()
+            self.obj.Proxy.execute(self.obj)
+            self.isDirty = False
+
+    def addEscapeShortcut(self):
+        # The only way I could get to intercept the escape key, or really any key was
+        # by creating an action with a shortcut .....
+        self.escape = QtGui.QAction(self.formPoint)
+        self.escape.setText('Done')
+        self.escape.setShortcut(QtGui.QKeySequence.fromString('Esc'))
+        QtCore.QObject.connect(self.escape, QtCore.SIGNAL('triggered()'), self.pointDone)
+        self.formPoint.addAction(self.escape)
+
+    def removeEscapeShortcut(self):
+        if self.escape:
+            self.formPoint.removeAction(self.escape)
+            self.escape = None
+
+    def modifyStandardButtons(self, buttonBox):
+        self.buttonBox = buttonBox
+
+    def abort(self):
+        FreeCAD.ActiveDocument.abortTransaction()
+        self.cleanup(False)
+
+    def reject(self):
+        FreeCAD.ActiveDocument.abortTransaction()
+        self.cleanup(True)
+
+    def accept(self):
+        FreeCAD.ActiveDocument.commitTransaction()
+        self.cleanup(True)
+        if self.isDirty:
+            self.getFields()
+            FreeCAD.ActiveDocument.recompute()
+
+    def cleanup(self, gui):
+        self.removeGlobalCallbacks()
+        self.viewProvider.clearTaskPanel()
+        if gui:
+            FreeCADGui.ActiveDocument.resetEdit()
+            FreeCADGui.Control.closeDialog()
+            FreeCAD.ActiveDocument.recompute()
+            if self.jvoVisible:
+                self.jvo.show()
+
+    def getTags(self, includeCurrent):
+        tags = []
+        index = self.formTags.lwTags.currentRow()
+        for i in range(0, self.formTags.lwTags.count()):
+            item = self.formTags.lwTags.item(i)
+            enabled = item.checkState() == QtCore.Qt.CheckState.Checked
+            x = item.data(self.DataX)
+            y = item.data(self.DataY)
+            #print("(%.2f, %.2f) i=%d/%s" % (x, y, i, index))
+            if includeCurrent or i != index:
+                tags.append((x, y, enabled))
+        return tags
+
+    def getTagParameters(self):
+        self.obj.Width  = FreeCAD.Units.Quantity(self.formTags.ifWidth.text()).Value
+        self.obj.Height = FreeCAD.Units.Quantity(self.formTags.ifHeight.text()).Value
+        self.obj.Angle  = self.formTags.dsbAngle.value()
+        self.obj.Radius = FreeCAD.Units.Quantity(self.formTags.ifRadius.text()).Value
+
+    def getFields(self):
+        self.getTagParameters()
+        tags = self.getTags(True)
+        self.obj.Proxy.setXyEnabled(tags)
+        self.isDirty = True
+
+    def updateTagsView(self):
+        PathLog.track()
+        self.formTags.lwTags.blockSignals(True)
+        self.formTags.lwTags.clear()
+        for i, pos in enumerate(self.Positions):
+            lbl = "%d: (%.2f, %.2f)" % (i, pos.x, pos.y)
+            item = QtGui.QListWidgetItem(lbl)
+            item.setData(self.DataX, pos.x)
+            item.setData(self.DataY, pos.y)
+            item.setData(self.DataZ, pos.z)
+            item.setData(self.DataID, i)
+            if i in self.Disabled:
+                item.setCheckState(QtCore.Qt.CheckState.Unchecked)
+            else:
+                item.setCheckState(QtCore.Qt.CheckState.Checked)
+            flags = QtCore.Qt.ItemFlag.ItemIsSelectable
+            flags |= QtCore.Qt.ItemFlag.ItemIsEnabled
+            flags |= QtCore.Qt.ItemFlag.ItemIsUserCheckable
+            item.setFlags(flags)
+            self.formTags.lwTags.addItem(item)
+        self.formTags.lwTags.blockSignals(False)
+        self.whenTagSelectionChanged()
+        self.viewProvider.updatePositions(self.Positions, self.Disabled)
+
+    def generateNewTags(self):
+        count = self.formTags.sbCount.value()
+        if not self.obj.Proxy.generateTags(self.obj, count):
+            self.obj.Proxy.execute(self.obj)
+
+        self.updateTagsView()
+        #if PathLog.getLevel(LOG_MODULE) == PathLog.Level.DEBUG:
+        #    # this causes a big of an echo and a double click on the spin buttons, don't know why though
+        #    FreeCAD.ActiveDocument.recompute()
+
+
+    def updateModel(self):
+        self.getFields()
+        self.updateTagsView()
+        self.isDirty = True
+        #FreeCAD.ActiveDocument.recompute()
+
+    def whenCountChanged(self):
+        count = self.formTags.sbCount.value()
+        self.formTags.pbGenerate.setEnabled(count)
+
+    def selectTagWithId(self, index):
+        PathLog.track(index)
+        self.formTags.lwTags.setCurrentRow(index)
+
+    def whenTagSelectionChanged(self):
+        index = self.formTags.lwTags.currentRow()
+        count = self.formTags.lwTags.count()
+        self.formTags.pbDelete.setEnabled(index != -1 and count > 2)
+        self.formTags.pbEdit.setEnabled(index != -1)
+        self.viewProvider.selectTag(index)
+
+    def whenTagsViewChanged(self):
+        self.updateTagsViewWith(self.getTags(True))
+
+    def updateTagsViewWith(self, tags):
+        self.tags = tags
+        self.Positions = [FreeCAD.Vector(t[0], t[1], 0) for t in self.tags]
+        self.Disabled = [i for (i,t) in enumerate(self.tags) if not t[2]]
+        self.updateTagsView()
+
+    def deleteSelectedTag(self):
+        self.updateTagsViewWith(self.getTags(False))
+
+    def addNewTagAt(self, point, obj):
+        if point and obj and self.obj.Proxy.pointIsOnPath(self.obj, point):
+            PathLog.info("addNewTagAt(%.2f, %.2f)" % (point.x, point.y))
+            self.Positions.append(FreeCAD.Vector(point.x, point.y, 0))
+            self.updateTagsView()
+        else:
+            print("ignore new tag at %s" % (point))
+
+    def addNewTag(self):
+        self.tags = self.getTags(True)
+        self.getPoint(self.addNewTagAt)
+
+    def editTagAt(self, point, obj):
+        if point and obj and (obj or point != FreeCAD.Vector()) and self.obj.Proxy.pointIsOnPath(self.obj, point):
+            tags = []
+            for i, (x, y, enabled) in enumerate(self.tags):
+                if i == self.editItem:
+                    tags.append((point.x, point.y, enabled))
+                else:
+                    tags.append((x, y, enabled))
+            self.updateTagsViewWith(tags)
+
+    def editTag(self, item):
+        if item:
+            self.tags = self.getTags(True)
+            self.editItem = item.data(self.DataID)
+            x = item.data(self.DataX)
+            y = item.data(self.DataY)
+            z = item.data(self.DataZ)
+            self.getPoint(self.editTagAt, FreeCAD.Vector(x, y, z))
+
+    def editSelectedTag(self):
+        self.editTag(self.formTags.lwTags.currentItem())
+
+    def removeGlobalCallbacks(self):
+        if hasattr(self, 'view') and self.view:
+            if self.pointCbClick:
+                self.view.removeEventCallbackPivy(coin.SoMouseButtonEvent.getClassTypeId(), self.pointCbClick)
+                self.pointCbClick = None
+            if self.pointCbMove:
+                self.view.removeEventCallbackPivy(coin.SoLocation2Event.getClassTypeId(), self.pointCbMove)
+                self.pointCbMove = None
+            self.view = None
+
+    def getPoint(self, whenDone, start=None):
+
+        def displayPoint(p):
+            self.formPoint.ifValueX.setText(FreeCAD.Units.Quantity(p.x, FreeCAD.Units.Length).UserString)
+            self.formPoint.ifValueY.setText(FreeCAD.Units.Quantity(p.y, FreeCAD.Units.Length).UserString)
+            self.formPoint.ifValueZ.setText(FreeCAD.Units.Quantity(p.z, FreeCAD.Units.Length).UserString)
+            self.formPoint.ifValueX.setFocus()
+            self.formPoint.ifValueX.selectAll()
+
+        def mouseMove(cb):
+            event = cb.getEvent()
+            pos = event.getPosition()
+            cntrl = event.wasCtrlDown()
+            shift = event.wasShiftDown()
+            self.pt = FreeCADGui.Snapper.snap(pos, lastpoint=start, active=cntrl, constrain=shift)
+            plane = FreeCAD.DraftWorkingPlane
+            p = plane.getLocalCoords(self.pt)
+            displayPoint(p)
+
+        def click(cb):
+            event = cb.getEvent()
+            if event.getButton() == 1 and event.getState() == coin.SoMouseButtonEvent.DOWN:
+                accept()
+
+        def accept():
+            if start:
+                self.pointAccept()
+            else:
+                self.pointAcceptAndContinue()
+
+        def cancel():
+            self.pointCancel()
+
+        self.pointWhenDone = whenDone
+        self.formTags.hide()
+        self.formPoint.show()
+        self.addEscapeShortcut()
+        if start:
+            displayPoint(start)
+        else:
+            displayPoint(FreeCAD.Vector(0,0,0))
+
+        self.view = Draft.get3DView()
+        self.pointCbClick = self.view.addEventCallbackPivy(coin.SoMouseButtonEvent.getClassTypeId(), click)
+        self.pointCbMove = self.view.addEventCallbackPivy(coin.SoLocation2Event.getClassTypeId(), mouseMove)
+
+        self.buttonBox.setEnabled(False)
+
+    def setupSpinBox(self, widget, val, decimals = 2):
+        if decimals:
+            widget.setDecimals(decimals)
+        widget.setValue(val)
+
+    def setFields(self):
+        self.updateTagsView()
+        self.formTags.sbCount.setValue(len(self.Positions))
+        self.formTags.ifHeight.setText(FreeCAD.Units.Quantity(self.obj.Height, FreeCAD.Units.Length).UserString)
+        self.formTags.ifWidth.setText(FreeCAD.Units.Quantity(self.obj.Width, FreeCAD.Units.Length).UserString)
+        self.formTags.dsbAngle.setValue(self.obj.Angle)
+        self.formTags.ifRadius.setText(FreeCAD.Units.Quantity(self.obj.Radius, FreeCAD.Units.Length).UserString)
+
+    def setupUi(self):
+        self.Positions = self.obj.Positions
+        self.Disabled  = self.obj.Disabled
+
+        self.setFields()
+        self.whenCountChanged()
+
+        if self.obj.Proxy.supportsTagGeneration(self.obj):
+            self.formTags.sbCount.valueChanged.connect(self.whenCountChanged)
+            self.formTags.pbGenerate.clicked.connect(self.generateNewTags)
+        else:
+            self.formTags.cbTagGeneration.setEnabled(False)
+
+        self.formTags.lwTags.itemChanged.connect(self.whenTagsViewChanged)
+        self.formTags.lwTags.itemSelectionChanged.connect(self.whenTagSelectionChanged)
+        self.formTags.lwTags.itemActivated.connect(self.editTag)
+
+        self.formTags.pbDelete.clicked.connect(self.deleteSelectedTag)
+        self.formTags.pbEdit.clicked.connect(self.editSelectedTag)
+        self.formTags.pbAdd.clicked.connect(self.addNewTag)
+
+        self.formPoint.buttonBox.accepted.connect(self.pointAccept)
+        self.formPoint.buttonBox.rejected.connect(self.pointReject)
+
+        self.formPoint.ifValueX.editingFinished.connect(self.updatePoint)
+        self.formPoint.ifValueY.editingFinished.connect(self.updatePoint)
+        self.formPoint.ifValueZ.editingFinished.connect(self.updatePoint)
+
+        self.viewProvider.turnMarkerDisplayOn(True)
+
+    def pointFinish(self, ok, cleanup = True):
+        obj = FreeCADGui.Snapper.lastSnappedObject
+
+        if cleanup:
+            self.removeGlobalCallbacks();
+            FreeCADGui.Snapper.off()
+            self.buttonBox.setEnabled(True)
+            self.removeEscapeShortcut()
+            self.formPoint.hide()
+            self.formTags.show()
+            self.formTags.setFocus()
+
+        if ok:
+            self.pointWhenDone(self.pt, obj)
+        else:
+            self.pointWhenDone(None, None)
+
+    def pointDone(self):
+        self.pointFinish(False)
+
+    def pointReject(self):
+        self.pointFinish(False)
+
+    def pointAccept(self):
+        self.pointFinish(True)
+
+    def pointAcceptAndContinue(self):
+        self.pointFinish(True, False)
+
+    def updatePoint(self):
+        x = FreeCAD.Units.Quantity(self.formPoint.ifValueX.text()).Value
+        y = FreeCAD.Units.Quantity(self.formPoint.ifValueY.text()).Value
+        z = FreeCAD.Units.Quantity(self.formPoint.ifValueZ.text()).Value
+        self.pt = FreeCAD.Vector(x, y, z)
 
 class HoldingTagMarker:
     def __init__(self, point, colors):
@@ -111,10 +464,7 @@ class PathDressupTagViewProvider:
                 if hasattr(i, 'Group') and self.obj.Base.Name in [o.Name for o in i.Group]:
                     i.Group = [o for o in i.Group if o.Name != self.obj.Base.Name]
             if self.obj.Base.ViewObject:
-                PathLog.info("Setting visibility for %s" % (self.obj.Base.Name))
                 self.obj.Base.ViewObject.Visibility = False
-            else:
-                PathLog.info("Ignoring visibility")
             if PathLog.getLevel(PathLog.thisModule()) != PathLog.Level.DEBUG and self.obj.Debug.ViewObject:
                 self.obj.Debug.ViewObject.Visibility = False
 
@@ -139,18 +489,21 @@ class PathDressupTagViewProvider:
         self.obj.Debug = None
         return True
 
+    def updatePositions(self, positions, disabled):
+        for tag in self.tags:
+            self.switch.removeChild(tag.sep)
+        tags = []
+        for i, p in enumerate(positions):
+            tag = HoldingTagMarker(p, self.colors)
+            tag.setEnabled(not i in disabled)
+            tags.append(tag)
+            self.switch.addChild(tag.sep)
+        self.tags = tags
+
     def updateData(self, obj, propName):
         PathLog.track(propName)
         if 'Disabled' == propName:
-            for tag in self.tags:
-                self.switch.removeChild(tag.sep)
-            tags = []
-            for i, p in enumerate(obj.Positions):
-                tag = HoldingTagMarker(p, self.colors)
-                tag.setEnabled(not i in obj.Disabled)
-                tags.append(tag)
-                self.switch.addChild(tag.sep)
-            self.tags = tags
+            self.updatePositions(obj.Positions, obj.Disabled)
 
     def onModelChanged(self):
         PathLog.track()
@@ -164,27 +517,57 @@ class PathDressupTagViewProvider:
             self.obj.Debug.addObject(tag)
             tag.purgeTouched()
 
+    def setEdit(self, vobj, mode=0):
+        panel = PathDressupTagTaskPanel(vobj.Object, self)
+        self.setupTaskPanel(panel)
+        return True
+
+    def unsetEdit(self, vobj, mode):
+        if hasattr(self, 'panel') and self.panel:
+            self.panel.abort()
+
+    def setupTaskPanel(self, panel):
+        self.panel = panel
+        FreeCADGui.Control.closeDialog()
+        FreeCADGui.Control.showDialog(panel)
+        panel.setupUi()
+        FreeCADGui.Selection.addSelectionGate(self)
+        FreeCADGui.Selection.addObserver(self)
+
+    def clearTaskPanel(self):
+        self.panel = None
+        FreeCADGui.Selection.removeSelectionGate()
+        FreeCADGui.Selection.removeObserver(self)
+        self.turnMarkerDisplayOn(False)
+
+    # SelectionObserver interface
+
     def selectTag(self, index):
         PathLog.track(index)
         for i, tag in enumerate(self.tags):
             tag.setSelected(i == index)
 
-    def tagAtPoint(self, point):
-        p = FreeCAD.Vector(point[0], point[1], point[2])
+    def tagAtPoint(self, point, matchZ):
+        x = point[0]
+        y = point[1]
+        z = point[2]
+        if self.tags and not matchZ:
+            z = self.tags[0].point.z
+        p = FreeCAD.Vector(x, y, z)
         for i, tag in enumerate(self.tags):
-            if PathGeom.pointsCoincide(p, tag.point, tag.sphere.radius.getValue() * 1.1):
+            if PathGeom.pointsCoincide(p, tag.point, tag.sphere.radius.getValue() * 1.3):
                 return i
         return -1
 
-    # SelectionObserver interface
     def allow(self, doc, obj, sub):
         if obj == self.obj:
             return True
         return False
 
     def addSelection(self, doc, obj, sub, point):
-        i = self.tagAtPoint(point)
+        PathLog.track(doc, obj, sub, point)
         if self.panel:
+            i = self.tagAtPoint(point, sub is None)
             self.panel.selectTagWithId(i)
         FreeCADGui.updateGui()
 
@@ -193,8 +576,11 @@ def Create(baseObject, name='DressupTag'):
     Create(basePath, name = 'DressupTag') ... create tag dressup object for the given base path.
     Use this command only iff the UI is up - for batch processing see PathDressupTag.Create
     '''
+    FreeCAD.ActiveDocument.openTransaction(translate("PathDressup_Tag", "Create a Tag dressup"))
     obj = PathDressupTag.Create(baseObject, name)
     vp = PathDressupTagViewProvider(obj.ViewObject)
+    FreeCAD.ActiveDocument.commitTransaction()
+    obj.ViewObject.startEditing()
     return obj
 
 class CommandPathDressupTag:

--- a/src/Mod/Path/PathScripts/PathDressupTagGui.py
+++ b/src/Mod/Path/PathScripts/PathDressupTagGui.py
@@ -1,0 +1,232 @@
+# -*- coding: utf-8 -*-
+
+# ***************************************************************************
+# *                                                                         *
+# *   Copyright (c) 2017 sliptonic <shopinthewoods@gmail.com>               *
+# *                                                                         *
+# *   This program is free software; you can redistribute it and/or modify  *
+# *   it under the terms of the GNU Lesser General Public License (LGPL)    *
+# *   as published by the Free Software Foundation; either version 2 of     *
+# *   the License, or (at your option) any later version.                   *
+# *   for detail see the LICENCE text file.                                 *
+# *                                                                         *
+# *   This program is distributed in the hope that it will be useful,       *
+# *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+# *   GNU Library General Public License for more details.                  *
+# *                                                                         *
+# *   You should have received a copy of the GNU Library General Public     *
+# *   License along with this program; if not, write to the Free Software   *
+# *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
+# *   USA                                                                   *
+# *                                                                         *
+# ***************************************************************************
+import FreeCAD
+import FreeCADGui
+import PathScripts.PathLog as PathLog
+import PathScripts.PathUtils as PathUtils
+
+from PathScripts.PathPreferences import PathPreferences
+from PySide import QtCore
+from pivy import coin
+
+PathLog.setLevel(PathLog.Level.DEBUG, PathLog.thisModule())
+PathLog.trackModule()
+
+# Qt tanslation handling
+def translate(context, text, disambig=None):
+    return QtCore.QCoreApplication.translate(context, text, disambig)
+
+class HoldingTagMarker:
+    def __init__(self, point, colors):
+        self.point = point
+        self.color = colors
+        self.sep = coin.SoSeparator()
+        self.pos = coin.SoTranslation()
+        self.pos.translation = (point.x, point.y, point.z)
+        self.sphere = coin.SoSphere()
+        self.scale = coin.SoType.fromName('SoShapeScale').createInstance()
+        self.scale.setPart('shape', self.sphere)
+        self.scale.scaleFactor.setValue(7)
+        self.material = coin.SoMaterial()
+        self.sep.addChild(self.pos)
+        self.sep.addChild(self.material)
+        self.sep.addChild(self.scale)
+        self.enabled = True
+        self.selected = False
+
+    def setSelected(self, select):
+        self.selected = select
+        self.sphere.radius = 1.5 if select else 1.0
+        self.setEnabled(self.enabled)
+
+    def setEnabled(self, enabled):
+        self.enabled = enabled
+        if enabled:
+            self.material.diffuseColor = self.color[0] if not self.selected else self.color[2]
+            self.material.transparency = 0.0
+        else:
+            self.material.diffuseColor = self.color[1] if not self.selected else self.color[2]
+            self.material.transparency = 0.6
+
+class PathDressupTagViewProvider:
+
+    def __init__(self, vobj):
+        PathLog.track()
+        vobj.Proxy = self
+        self.vobj = vobj
+        self.panel = None
+
+    def setupColors(self):
+        def colorForColorValue(val):
+            v = [((val >> n) & 0xff) / 255. for n in [24, 16, 8, 0]]
+            return coin.SbColor(v[0], v[1], v[2])
+
+        pref = PathPreferences.preferences()
+        #                                                      R         G          B          A
+        npc = pref.GetUnsigned('DefaultPathMarkerColor',    (( 85*256 + 255)*256 +   0)*256 + 255)
+        hpc = pref.GetUnsigned('DefaultHighlightPathColor', ((255*256 + 125)*256 +   0)*256 + 255)
+        dpc = pref.GetUnsigned('DefaultDisabledPathColor',  ((205*256 + 205)*256 + 205)*256 + 154)
+        self.colors = [colorForColorValue(npc), colorForColorValue(dpc), colorForColorValue(hpc)]
+
+    def attach(self, vobj):
+        PathLog.track()
+        self.setupColors()
+        self.obj = vobj.Object
+        self.tags = []
+        self.switch = coin.SoSwitch()
+        vobj.RootNode.addChild(self.switch)
+        self.turnMarkerDisplayOn(False)
+
+        if self.obj and self.obj.Base:
+            for i in self.obj.Base.InList:
+                if hasattr(i, 'Group') and self.obj.Base.Name in [o.Name for o in i.Group]:
+                    i.Group = [o for o in i.Group if o.Name != self.obj.Base.Name]
+            if self.obj.Base.ViewObject:
+                PathLog.info("Setting visibility for %s" % (self.obj.Base.Name))
+                self.obj.Base.ViewObject.Visibility = False
+            else:
+                PathLog.info("Ignoring visibility")
+            if PathLog.getLevel(PathLog.thisModule()) != PathLog.Level.DEBUG and self.obj.Debug.ViewObject:
+                self.obj.Debug.ViewObject.Visibility = False
+
+        self.obj.Proxy.changed.connect(self.onModelChanged)
+
+    def turnMarkerDisplayOn(self, display):
+        sw = coin.SO_SWITCH_ALL if display else coin.SO_SWITCH_NONE
+        self.switch.whichChild = sw
+
+    def claimChildren(self):
+        PathLog.track()
+        return [self.obj.Base, self.obj.Debug]
+
+    def onDelete(self, arg1=None, arg2=None):
+        PathLog.track()
+        '''this makes sure that the base operation is added back to the project and visible'''
+        if self.obj.Base.ViewObject:
+            self.obj.Base.ViewObject.Visibility = True
+        PathUtils.addToJob(arg1.Object.Base)
+        self.obj.Debug.removeObjectsFromDocument()
+        self.obj.Debug.Document.removeObject(self.obj.Debug.Name)
+        self.obj.Debug = None
+        return True
+
+    def updateData(self, obj, propName):
+        PathLog.track(propName)
+        if 'Disabled' == propName:
+            for tag in self.tags:
+                self.switch.removeChild(tag.sep)
+            tags = []
+            for i, p in enumerate(obj.Positions):
+                tag = HoldingTagMarker(p, self.colors)
+                tag.setEnabled(not i in obj.Disabled)
+                tags.append(tag)
+                self.switch.addChild(tag.sep)
+            self.tags = tags
+
+    def onModelChanged(self):
+        PathLog.track()
+        self.obj.Debug.removeObjectsFromDocument()
+        for solid in self.obj.Proxy.solids:
+            tag = self.obj.Document.addObject('Part::Feature', 'tag')
+            tag.Shape = solid
+            if tag.ViewObject and self.obj.Debug.ViewObject:
+                tag.ViewObject.Visibility = self.obj.Debug.ViewObject.Visibility
+                tag.ViewObject.Transparency = 80
+            self.obj.Debug.addObject(tag)
+            tag.purgeTouched()
+
+    def selectTag(self, index):
+        PathLog.track(index)
+        for i, tag in enumerate(self.tags):
+            tag.setSelected(i == index)
+
+    def tagAtPoint(self, point):
+        p = FreeCAD.Vector(point[0], point[1], point[2])
+        for i, tag in enumerate(self.tags):
+            if PathGeom.pointsCoincide(p, tag.point, tag.sphere.radius.getValue() * 1.1):
+                return i
+        return -1
+
+    # SelectionObserver interface
+    def allow(self, doc, obj, sub):
+        if obj == self.obj:
+            return True
+        return False
+
+    def addSelection(self, doc, obj, sub, point):
+        i = self.tagAtPoint(point)
+        if self.panel:
+            self.panel.selectTagWithId(i)
+        FreeCADGui.updateGui()
+
+class CommandPathDressupTag:
+
+    def GetResources(self):
+        return {'Pixmap': 'Path-Dressup',
+                'MenuText': QtCore.QT_TRANSLATE_NOOP('PathDressup_Tag', 'Tag Dress-up'),
+                'ToolTip': QtCore.QT_TRANSLATE_NOOP('PathDressup_Tag', 'Creates a Tag Dress-up object from a selected path')}
+
+    def IsActive(self):
+        if FreeCAD.ActiveDocument is not None:
+            for o in FreeCAD.ActiveDocument.Objects:
+                if o.Name[:3] == 'Job':
+                        return True
+        return False
+
+    def Activated(self):
+
+        # check that the selection contains exactly what we want
+        selection = FreeCADGui.Selection.getSelection()
+        if len(selection) != 1:
+            PathLog.error(translate('PathDressup_Tag', 'Please select one path object\n'))
+            return
+        baseObject = selection[0]
+        if not baseObject.isDerivedFrom('Path::Feature'):
+            PathLog.error(translate('PathDressup_Tag', 'The selected object is not a path\n'))
+            return
+        if baseObject.isDerivedFrom('Path::FeatureCompoundPython'):
+            PathLog.error(translate('PathDressup_Tag', 'Please select a Profile object'))
+            return
+
+        # everything ok!
+        FreeCAD.ActiveDocument.openTransaction(translate('PathDressup_Tag', 'Create Tag Dress-up'))
+        FreeCADGui.addModule('PathScripts.PathDressupTag')
+        FreeCADGui.addModule('PathScripts.PathDressupTagGui')
+        FreeCADGui.addModule('PathScripts.PathUtils')
+        FreeCADGui.doCommand('obj = FreeCAD.ActiveDocument.addObject("Path::FeaturePython", "TagDressup")')
+        FreeCADGui.doCommand('dbo = PathScripts.PathDressupTag.ObjectDressup(obj)')
+        FreeCADGui.doCommand('obj.Base = FreeCAD.ActiveDocument.' + selection[0].Name)
+        FreeCADGui.doCommand('PathScripts.PathDressupTagGui.PathDressupTagViewProvider(obj.ViewObject)')
+        FreeCADGui.doCommand('PathScripts.PathUtils.addToJob(obj)')
+        FreeCADGui.doCommand('dbo.assignDefaultValues()')
+        FreeCADGui.doCommand('obj.Positions = [App.Vector(-10, -10, 0), App.Vector(10, 10, 0)]')
+        FreeCADGui.doCommand('dbo.execute(obj)')
+        FreeCAD.ActiveDocument.commitTransaction()
+        FreeCAD.ActiveDocument.recompute()
+
+if FreeCAD.GuiUp:
+    # register the FreeCAD command
+    FreeCADGui.addCommand('PathDressup_Tag', CommandPathDressupTag())
+
+PathLog.notice('Loading PathDressupTagGui... done\n')

--- a/src/Mod/Path/PathScripts/PathDressupTagGui.py
+++ b/src/Mod/Path/PathScripts/PathDressupTagGui.py
@@ -143,17 +143,39 @@ class PathDressupTagTaskPanel:
                 tags.append((x, y, enabled))
         return tags
 
-    def getTagParameters(self):
-        self.obj.Width  = FreeCAD.Units.Quantity(self.formTags.ifWidth.text()).Value
-        self.obj.Height = FreeCAD.Units.Quantity(self.formTags.ifHeight.text()).Value
-        self.obj.Angle  = self.formTags.dsbAngle.value()
-        self.obj.Radius = FreeCAD.Units.Quantity(self.formTags.ifRadius.text()).Value
-
     def getFields(self):
-        self.getTagParameters()
+        width  = FreeCAD.Units.Quantity(self.formTags.ifWidth.text()).Value
+        height = FreeCAD.Units.Quantity(self.formTags.ifHeight.text()).Value
+        angle  = self.formTags.dsbAngle.value()
+        radius = FreeCAD.Units.Quantity(self.formTags.ifRadius.text()).Value
+
         tags = self.getTags(True)
-        self.obj.Proxy.setXyEnabled(tags)
-        self.isDirty = True
+        positions = []
+        disabled = []
+        for i, (x, y, enabled) in enumerate(tags):
+            positions.append(FreeCAD.Vector(x, y, 0))
+            if not enabled:
+                disabled.append(i)
+
+        if width != self.obj.Width:
+            self.obj.Width = width
+            self.isDirty = True
+        if height != self.obj.Height:
+            self.obj.Height = height
+            self.isDirty = True
+        if angle != self.obj.Angle:
+            self.obj.Angle = angle
+            self.isDirty = True
+        if radius != self.obj.Radius:
+            self.obj.Radius = radius
+            self.isDirty = True
+        if positions != self.obj.Positions:
+            self.obj.Positions = positions
+            self.isDirty = True
+        if disabled != self.obj.Disabled:
+            self.obj.Disabled = disabled
+            self.isDirty = True
+
 
     def updateTagsView(self):
         PathLog.track()

--- a/src/Mod/Path/PathScripts/PathDressupTagPreferences.py
+++ b/src/Mod/Path/PathScripts/PathDressupTagPreferences.py
@@ -1,0 +1,99 @@
+# -*- coding: utf-8 -*-
+
+# ***************************************************************************
+# *                                                                         *
+# *   Copyright (c) 2017 sliptonic <shopinthewoods@gmail.com>               *
+# *                                                                         *
+# *   This program is free software; you can redistribute it and/or modify  *
+# *   it under the terms of the GNU Lesser General Public License (LGPL)    *
+# *   as published by the Free Software Foundation; either version 2 of     *
+# *   the License, or (at your option) any later version.                   *
+# *   for detail see the LICENCE text file.                                 *
+# *                                                                         *
+# *   This program is distributed in the hope that it will be useful,       *
+# *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+# *   GNU Library General Public License for more details.                  *
+# *                                                                         *
+# *   You should have received a copy of the GNU Library General Public     *
+# *   License along with this program; if not, write to the Free Software   *
+# *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
+# *   USA                                                                   *
+# *                                                                         *
+# ***************************************************************************
+
+import FreeCAD
+import FreeCADGui
+import PathScripts.PathPreferencesPathDressup as PathPreferencesPathDressup
+
+from PathScripts.PathPreferences import PathPreferences
+from PySide import QtCore
+
+# Qt tanslation handling
+def translate(context, text, disambig=None):
+    return QtCore.QCoreApplication.translate(context, text, disambig)
+
+class HoldingTagPreferences:
+    DefaultHoldingTagWidth   = 'DefaultHoldingTagWidth'
+    DefaultHoldingTagHeight  = 'DefaultHoldingTagHeight'
+    DefaultHoldingTagAngle   = 'DefaultHoldingTagAngle'
+    DefaultHoldingTagRadius  = 'DefaultHoldingTagRadius'
+    DefaultHoldingTagCount   = 'DefaultHoldingTagCount'
+
+    @classmethod
+    def defaultWidth(cls, ifNotSet):
+        value = PathPreferences.preferences().GetFloat(cls.DefaultHoldingTagWidth, ifNotSet)
+        if value == 0.0:
+            return ifNotSet
+        return value
+
+    @classmethod
+    def defaultHeight(cls, ifNotSet):
+        value = PathPreferences.preferences().GetFloat(cls.DefaultHoldingTagHeight, ifNotSet)
+        if value == 0.0:
+            return ifNotSet
+        return value
+
+    @classmethod
+    def defaultAngle(cls, ifNotSet = 45.0):
+        value = PathPreferences.preferences().GetFloat(cls.DefaultHoldingTagAngle, ifNotSet)
+        if value < 10.0:
+            return ifNotSet
+        return value
+
+    @classmethod
+    def defaultCount(cls, ifNotSet = 4):
+        value = PathPreferences.preferences().GetUnsigned(cls.DefaultHoldingTagCount, ifNotSet)
+        if value < 2:
+            return float(ifNotSet)
+        return float(value)
+
+    @classmethod
+    def defaultRadius(cls, ifNotSet = 0.0):
+        return PathPreferences.preferences().GetFloat(cls.DefaultHoldingTagRadius, ifNotSet)
+
+
+    def __init__(self):
+        self.form = FreeCADGui.PySideUic.loadUi(":/preferences/PathDressupHoldingTags.ui")
+        self.label = translate("PathDressup_HoldingTag", 'Holding Tag')
+
+    def loadSettings(self):
+        self.form.ifWidth.setText(FreeCAD.Units.Quantity(self.defaultWidth(0), FreeCAD.Units.Length).UserString)
+        self.form.ifHeight.setText(FreeCAD.Units.Quantity(self.defaultHeight(0), FreeCAD.Units.Length).UserString)
+        self.form.dsbAngle.setValue(self.defaultAngle())
+        self.form.ifRadius.setText(FreeCAD.Units.Quantity(self.defaultRadius(), FreeCAD.Units.Length).UserString)
+        self.form.sbCount.setValue(self.defaultCount())
+
+    def saveSettings(self):
+        pref = PathPreferences.preferences()
+        pref.SetFloat(self.DefaultHoldingTagWidth, FreeCAD.Units.Quantity(self.form.ifWidth.text()).Value)
+        pref.SetFloat(self.DefaultHoldingTagHeight, FreeCAD.Units.Quantity(self.form.ifHeight.text()).Value)
+        pref.SetFloat(self.DefaultHoldingTagAngle, self.form.dsbAngle.value())
+        pref.SetFloat(self.DefaultHoldingTagRadius, FreeCAD.Units.Quantity(self.form.ifRadius.text()))
+        pref.SetUnsigned(self.DefaultHoldingTagCount, self.form.sbCount.value())
+
+    @classmethod
+    def preferencesPage(cls):
+        return HoldingTagPreferences()
+
+PathPreferencesPathDressup.RegisterDressup(HoldingTagPreferences)

--- a/src/Mod/Path/PathScripts/PathUtils.py
+++ b/src/Mod/Path/PathScripts/PathUtils.py
@@ -24,15 +24,16 @@
 '''PathUtils -common functions used in PathScripts for filterig, sorting, and generating gcode toolpath data '''
 import FreeCAD
 import FreeCADGui
-import Part
 import math
-from DraftGeomUtils import geomType
-import PathScripts
-from PathScripts import PathJob
 import numpy
-from PathScripts import PathLog
-from FreeCAD import Vector
+import Part
 import Path
+import PathScripts
+
+from DraftGeomUtils import geomType
+from FreeCAD import Vector
+from PathScripts import PathJob
+from PathScripts import PathLog
 from PySide import QtCore
 from PySide import QtGui
 
@@ -455,13 +456,12 @@ def addToJob(obj, jobname=None):
         if len(jobs) == 1:
             job = jobs[0]
         else:
-            FreeCAD.Console.PrintError("Didn't find the job")
+            PathLog.error("Job %s does not exist" % jobname)
             return None
     else:
         jobs = GetJobs()
         if len(jobs) == 0:
             job = PathJob.CommandJob.Create()
-
         elif len(jobs) == 1:
             job = jobs[0]
         else:
@@ -735,15 +735,6 @@ def guessDepths(objshape, subs=None):
             final = fbb.ZMin
 
     return depth_params(clearance, safe, start, 1.0, 0.0, final, user_depths=None, equalstep=False)
-
-def drillTipLength(tool):
-    """returns the length of the drillbit tip.
-"""
-    if tool.CuttingEdgeAngle == 0.0 or tool.Diameter == 0.0:
-        return 0.0
-    else:
-        theta = math.radians(tool.CuttingEdgeAngle)
-        return (tool.Diameter/2) / math.tan(theta)
 
 
 class depth_params:

--- a/src/Mod/Path/PathScripts/PathUtils.py
+++ b/src/Mod/Path/PathScripts/PathUtils.py
@@ -446,6 +446,15 @@ def addObjectToJob(obj, job):
     job.Group = g
     return job
 
+def addObjectToJob(obj, job):
+    '''
+    addObjectToJob(obj, job) ... adds object to given job.
+    '''
+    g = job.Group
+    g.append(obj)
+    job.Group = g
+    return job
+
 def addToJob(obj, jobname=None):
     '''adds a path object to a job
     obj = obj
@@ -456,12 +465,13 @@ def addToJob(obj, jobname=None):
         if len(jobs) == 1:
             job = jobs[0]
         else:
-            PathLog.error("Job %s does not exist" % jobname)
+            FreeCAD.Console.PrintError("Didn't find the job")
             return None
     else:
         jobs = GetJobs()
         if len(jobs) == 0:
             job = PathJob.CommandJob.Create()
+
         elif len(jobs) == 1:
             job = jobs[0]
         else:
@@ -479,7 +489,6 @@ def addToJob(obj, jobname=None):
     if obj:
         addObjectToJob(obj, job)
     return job
-
 
 def rapid(x=None, y=None, z=None):
     """ Returns gcode string to perform a rapid move."""

--- a/src/Mod/Path/PathScripts/PathUtils.py
+++ b/src/Mod/Path/PathScripts/PathUtils.py
@@ -745,6 +745,13 @@ def guessDepths(objshape, subs=None):
 
     return depth_params(clearance, safe, start, 1.0, 0.0, final, user_depths=None, equalstep=False)
 
+def drillTipLength(tool):
+    """returns the length of the drillbit tip."""
+    if tool.CuttingEdgeAngle == 0.0 or tool.Diameter == 0.0:
+        return 0.0
+    else:
+        theta = math.radians(tool.CuttingEdgeAngle)
+        return (tool.Diameter/2) / math.tan(theta) 
 
 class depth_params:
     '''calculates the intermediate depth values for various operations given the starting, ending, and stepdown parameters


### PR DESCRIPTION
Currently adding tags is a painful exercise because each addition causes a complete recompute of the new path. The more tags there are, the longer it'll take.

With this change the UI lets the user add tags and they are just visualized, but not actually generated. Only if the user presses OK or Apply is the actual path recomputed.