### PR TITLE
ArchPanel: Fixed wire transformation for scales other than 1.

### DIFF
--- a/src/Mod/Arch/ArchPanel.py
+++ b/src/Mod/Arch/ArchPanel.py
@@ -1043,16 +1043,16 @@ class PanelSheet(Draft._DraftObject):
                     w = p.Proxy.getWires(p)
                     if w[0]:
                         w = w[0]
+                        w.scale(obj.Scale, FreeCAD.Vector())
                         if transform:
                             w.Placement = obj.Placement.multiply(w.Placement)
-                        w.scale(obj.Scale, FreeCAD.Vector())
                         outp.append(w)
             if not ispanel:
                 if p.isDerivedFrom("Part::Feature"):
                     for w in p.Shape.Wires:
+                        w.scale(obj.Scale, FreeCAD.Vector())
                         if transform:
                             w.Placement = obj.Placement.multiply(w.Placement)
-                        w.scale(obj.Scale, FreeCAD.Vector())
                         outp.append(w)
         return outp
 
@@ -1068,9 +1068,9 @@ class PanelSheet(Draft._DraftObject):
                     w = p.Proxy.getWires(p)
                     if w[1]:
                         w = w[1]
+                        w.scale(obj.Scale, FreeCAD.Vector())
                         if transform:
                             w.Placement = obj.Placement.multiply(w.Placement)
-                        w.scale(obj.Scale, FreeCAD.Vector())
                         outp.append(w)
         return outp
 
@@ -1088,15 +1088,15 @@ class PanelSheet(Draft._DraftObject):
                     w = p.Proxy.getWires(p)
                     if w[2]:
                         w = w[2]
+                        w.scale(obj.Scale, FreeCAD.Vector())
                         if transform:
                             w.Placement = obj.Placement.multiply(w.Placement)
-                        w.scale(obj.Scale, FreeCAD.Vector())
                         outp.append(w)
         if self.sheettag is not None:
             w = self.sheettag.copy()
+            w.scale(obj.Scale, FreeCAD.Vector())
             if transform:
                 w.Placement = obj.Placement.multiply(w.Placement)
-            w.scale(obj.Scale, FreeCAD.Vector())
             outp.append(w)
 
         return outp


### PR DESCRIPTION
When I added the scaling I added it after the placement transformation - which causes the PanelSheet placement to get scaled as well - which is not correct.