### PR TITLE
prevent cross geofeaturegroup links

### DIFF
--- a/src/App/Application.cpp
+++ b/src/App/Application.cpp
@@ -1250,9 +1250,17 @@ void Application::initTypes(void)
     App ::PropertyFont              ::init();
     App ::PropertyStringList        ::init();
     App ::PropertyLink              ::init();
+    App ::PropertyLinkChild         ::init();
+    App ::PropertyLinkGlobal        ::init();
     App ::PropertyLinkSub           ::init();
+    App ::PropertyLinkSubChild      ::init();
+    App ::PropertyLinkSubGlobal     ::init();
     App ::PropertyLinkList          ::init();
+    App ::PropertyLinkListChild     ::init();
+    App ::PropertyLinkListGlobal    ::init();
     App ::PropertyLinkSubList       ::init();
+    App ::PropertyLinkSubListChild  ::init();
+    App ::PropertyLinkSubListGlobal ::init();
     App ::PropertyMatrix            ::init();
     App ::PropertyVector            ::init();
     App ::PropertyVectorDistance    ::init();

--- a/src/App/CMakeLists.txt
+++ b/src/App/CMakeLists.txt
@@ -15,7 +15,7 @@ ENDIF(DOCDIR)
 add_definitions(-DBOOST_${Boost_VERSION})
 
 #if you want to use the old DAG structure uncomment this line
-add_definitions(-DUSE_OLD_DAG)
+#add_definitions(-DUSE_OLD_DAG)
 
 #write relevant cmake variables to a file for later access with python. Exportet are all variables 
 #starting with BUILD. As the variable only exists if the user set it to ON a dict is useless, we 

--- a/src/App/Document.cpp
+++ b/src/App/Document.cpp
@@ -258,6 +258,7 @@ void Document::exportGraphviz(std::ostream& out) const
             buildAdjacencyList();
             addEdges();
             markCycles();
+            markOutOfScopeLinks();
         }
 
         /**
@@ -663,6 +664,7 @@ void Document::exportGraphviz(std::ostream& out) const
                             edgeAttrMap[edge]["ltail"] = getClusterName(docObj);
                         if (GraphList[*It2])
                             edgeAttrMap[edge]["lhead"] = getClusterName(*It2);
+                        
                     }
                 }
 
@@ -766,6 +768,24 @@ void Document::exportGraphviz(std::ostream& out) const
             const boost::property_map<Graph, boost::edge_attribute_t>::type& edgeAttrMap = boost::get(boost::edge_attribute, DepList);
             for (auto ei = out_edges.begin(), ei_end = out_edges.end(); ei != ei_end; ++ei)
                 edgeAttrMap[ei->second]["color"] = "red";
+        }
+        
+        void markOutOfScopeLinks() {
+            
+            const boost::property_map<Graph, boost::edge_attribute_t>::type& edgeAttrMap = boost::get(boost::edge_attribute, DepList);
+
+            for( auto obj : objects) {            
+                       
+                std::vector<App::DocumentObject*> invalids;
+                GeoFeatureGroupExtension::getInvalidLinkObjects(obj, invalids);
+                //isLinkValid returns true for non-link properties
+                for(auto linkedObj : invalids) {
+    
+                    auto res = edge(GlobalVertexList[getId(obj)], GlobalVertexList[getId(linkedObj)], DepList);
+                    if(res.second)
+                        edgeAttrMap[res.first]["color"] = "red";
+                }
+            }                
         }
 
         const struct DocumentP* d;

--- a/src/App/Document.cpp
+++ b/src/App/Document.cpp
@@ -2790,7 +2790,7 @@ DocumentObject* Document::moveObject(DocumentObject* obj, bool recursive)
     std::map<std::string,App::Property*> props;
     obj->getPropertyMap(props);
     for (std::map<std::string,App::Property*>::iterator it = props.begin(); it != props.end(); ++it) {
-        if (it->second->getTypeId() == PropertyLink::getClassTypeId()) {
+        if (it->second->getTypeId().isDerivedFrom(PropertyLink::getClassTypeId())) {
             DocumentObject* link = static_cast<PropertyLink*>(it->second)->getValue();
             if (recursive) {
                 moveObject(link, recursive);
@@ -2800,7 +2800,7 @@ DocumentObject* Document::moveObject(DocumentObject* obj, bool recursive)
                 static_cast<PropertyLink*>(it->second)->setValue(0);
             }
         }
-        else if (it->second->getTypeId() == PropertyLinkList::getClassTypeId()) {
+        else if (it->second->getTypeId().isDerivedFrom(PropertyLinkList::getClassTypeId())) {
             std::vector<DocumentObject*> links = static_cast<PropertyLinkList*>(it->second)->getValues();
             if (recursive) {
                 for (std::vector<DocumentObject*>::iterator jt = links.begin(); jt != links.end(); ++jt)

--- a/src/App/Document.cpp
+++ b/src/App/Document.cpp
@@ -2186,8 +2186,14 @@ std::vector<App::DocumentObject*> Document::topologicalSort() const
     ret.reserve(d->objectArray.size());
     map < App::DocumentObject*,int > countMap;
 
-    for (auto objectIt : d->objectMap)
-        countMap[objectIt.second] = objectIt.second->getInList().size();
+    for (auto objectIt : d->objectMap) {
+        //we need inlist with unique entries
+        auto in = objectIt.second->getInList();
+        std::sort(in.begin(), in.end());
+        in.erase(std::unique(in.begin(), in.end()), in.end());
+        
+        countMap[objectIt.second] = in.size();
+    }
 
     auto rootObjeIt = find_if(countMap.begin(), countMap.end(), [](pair < App::DocumentObject*, int > count)->bool {
         return count.second == 0;
@@ -2201,7 +2207,7 @@ std::vector<App::DocumentObject*> Document::topologicalSort() const
     while (rootObjeIt != countMap.end()){
         rootObjeIt->second = rootObjeIt->second - 1;
         
-        //we need outlist with unique entries, as inlist also has unique entries
+        //we need outlist with unique entries
         auto out = rootObjeIt->first->getOutList();
         std::sort(out.begin(), out.end());
         out.erase(std::unique(out.begin(), out.end()), out.end());

--- a/src/App/Document.cpp
+++ b/src/App/Document.cpp
@@ -2164,7 +2164,6 @@ int Document::recompute()
                     inObjIt->touch();
             }
         }
-
     }
 #ifdef FC_DEBUG
     // check if all objects are recalculated which were thouched 

--- a/src/App/Document.cpp
+++ b/src/App/Document.cpp
@@ -2187,8 +2187,8 @@ std::vector<App::DocumentObject*> Document::topologicalSort() const
     ret.reserve(d->objectArray.size());
     map < App::DocumentObject*,int > countMap;
 
-    for (auto objectIt : d->objectArray)
-        countMap[objectIt] = objectIt->getInList().size();
+    for (auto objectIt : d->objectMap)
+        countMap[objectIt.second] = objectIt.second->getInList().size();
 
     auto rootObjeIt = find_if(countMap.begin(), countMap.end(), [](pair < App::DocumentObject*, int > count)->bool {
         return count.second == 0;
@@ -2201,7 +2201,13 @@ std::vector<App::DocumentObject*> Document::topologicalSort() const
 
     while (rootObjeIt != countMap.end()){
         rootObjeIt->second = rootObjeIt->second - 1;
-        for (auto outListIt : rootObjeIt->first->getOutList()){
+        
+        //we need outlist with unique entries, as inlist also has unique entries
+        auto out = rootObjeIt->first->getOutList();
+        std::sort(out.begin(), out.end());
+        out.erase(std::unique(out.begin(), out.end()), out.end());
+        
+        for (auto outListIt : out) {
             auto outListMapIt = countMap.find(outListIt);
             outListMapIt->second = outListMapIt->second - 1;
         }

--- a/src/App/DocumentObject.cpp
+++ b/src/App/DocumentObject.cpp
@@ -76,7 +76,7 @@ App::DocumentObjectExecReturn *DocumentObject::recompute(void)
 {
     //check if the links are valid before making the recompute
     if(!GeoFeatureGroupExtension::areLinksValid(this))
-        return new App::DocumentObjectExecReturn("Links between different GeoFeatureGroups are not valid", this);
+        return new App::DocumentObjectExecReturn("Links go out of the allowed scope", this);
 
     // set/unset the execution bit
     ObjectStatusLocker<ObjectStatus, DocumentObject> exe(App::Recompute, this);

--- a/src/App/DocumentObject.cpp
+++ b/src/App/DocumentObject.cpp
@@ -34,6 +34,7 @@
 #include "PropertyLinks.h"
 #include "PropertyExpressionEngine.h"
 #include "DocumentObjectExtension.h"
+#include "GeoFeatureGroupExtension.h"
 #include <App/DocumentObjectPy.h>
 #include <boost/signals/connection.hpp>
 #include <boost/bind.hpp>
@@ -73,6 +74,10 @@ DocumentObject::~DocumentObject(void)
 
 App::DocumentObjectExecReturn *DocumentObject::recompute(void)
 {
+    //check if the links are valid before making the recompute
+    if(!GeoFeatureGroupExtension::areLinksValid(this))
+        return new App::DocumentObjectExecReturn("Links between different GeoFeatureGroups are not valid", this);
+
     // set/unset the execution bit
     ObjectStatusLocker<ObjectStatus, DocumentObject> exe(App::Recompute, this);
     return this->execute();

--- a/src/App/DocumentObject.cpp
+++ b/src/App/DocumentObject.cpp
@@ -572,7 +572,11 @@ void DocumentObject::unsetupObject()
 void App::DocumentObject::_removeBackLink(DocumentObject* rmvObj)
 {
 #ifndef USE_OLD_DAG
-       _inList.erase(std::remove(_inList.begin(), _inList.end(), rmvObj), _inList.end());
+    //do not use erase-remove idom, as this erases ALL entries that match. we only want to remove a
+    //single one.
+    auto it = std::find(_inList.begin(), _inList.end(), rmvObj);
+    if(it != _inList.end())
+        _inList.erase(it);
 #else
     (void)rmvObj;
 #endif
@@ -581,8 +585,11 @@ void App::DocumentObject::_removeBackLink(DocumentObject* rmvObj)
 void App::DocumentObject::_addBackLink(DocumentObject* newObj)
 {
 #ifndef USE_OLD_DAG
-    if ( std::find(_inList.begin(), _inList.end(), newObj) == _inList.end() )
-       _inList.push_back(newObj);
+    //we need to add all links, even if they are available multiple times. The reason for this is the
+    //removal: If a link loses this object it removes the backlink. If we would have added it only once
+    //this removal would clear the object from the inlist, even though there may be other link properties 
+    //from this object that link to us.
+    _inList.push_back(newObj);
 #else
     (void)newObj;
 #endif //USE_OLD_DAG    

--- a/src/App/DocumentPy.xml
+++ b/src/App/DocumentPy.xml
@@ -151,7 +151,7 @@ Both parameters are optional.</UserDocu>
       </Documentation>
       <Parameter Name="Objects" Type="List" />
     </Attribute>
-    <Attribute Name="ToplogicalSortedObjects" ReadOnly="true">
+    <Attribute Name="TopologicalSortedObjects" ReadOnly="true">
       <Documentation>
         <UserDocu>The list of object of this document in topological sorted order</UserDocu>
       </Documentation>

--- a/src/App/DocumentPyImp.cpp
+++ b/src/App/DocumentPyImp.cpp
@@ -516,7 +516,7 @@ Py::List DocumentPy::getObjects(void) const
     return res;
 }
 
-Py::List DocumentPy::getToplogicalSortedObjects(void) const
+Py::List DocumentPy::getTopologicalSortedObjects(void) const
 {
     std::vector<DocumentObject*> objs = getDocumentPtr()->topologicalSort();
     Py::List res;

--- a/src/App/GeoFeatureGroupExtension.cpp
+++ b/src/App/GeoFeatureGroupExtension.cpp
@@ -360,7 +360,7 @@ bool GeoFeatureGroupExtension::areLinksValid(DocumentObject* obj) {
     
     //for links with scope SubGroup we need to check if all features are part of subgroups
     if(group) {
-        result = getScopedObjectsFromLinks(obj, LinkScope::SubGroup);
+        result = getScopedObjectsFromLinks(obj, LinkScope::Child);
         auto groupExt = group->getExtensionByType<App::GeoFeatureGroupExtension>();
         for(auto link : result) {
             if(!groupExt->hasObject(link, true))

--- a/src/App/GeoFeatureGroupExtension.cpp
+++ b/src/App/GeoFeatureGroupExtension.cpp
@@ -305,6 +305,20 @@ void GeoFeatureGroupExtension::getCSRelevantLinks(DocumentObject* obj, std::vect
     vec.erase(std::unique(vec.begin(), vec.end()), vec.end());
 }
 
+bool GeoFeatureGroupExtension::areLinksValid(DocumentObject* obj) {
+
+    //we get all linked objects. We can't use outList() as this includes the links from expressions
+    auto result = getObjectsFromLinks(obj);
+    
+    //no cross CS links.
+    auto group = obj->hasExtension(App::GeoFeatureGroupExtension::getExtensionClassTypeId()) ? obj : getGroupOfObject(obj);
+    for(auto link : result) {
+        if(getGroupOfObject(link) != group)
+            return false;
+    }
+    return true;
+}
+
 // Python feature ---------------------------------------------------------
 
 namespace App {

--- a/src/App/GeoFeatureGroupExtension.h
+++ b/src/App/GeoFeatureGroupExtension.h
@@ -68,6 +68,8 @@ public:
     /// Constructor
     GeoFeatureGroupExtension(void);
     virtual ~GeoFeatureGroupExtension();
+    
+    virtual void extensionOnChanged(const Property* p);
 
     /** Returns the geo feature group which contains this object.
      * In case this object is not part of any geoFeatureGroup 0 is returned.

--- a/src/App/GeoFeatureGroupExtension.h
+++ b/src/App/GeoFeatureGroupExtension.h
@@ -102,21 +102,30 @@ public:
     /// Collects GeoFeatureGroup relevant objects that are linked from the given one. That means all linked objects
     /// including their links (recursively) except GeoFeatureGroups, where the recursion stops. Expressions
     /// links are ignored. An exception is thrown when there are dependency loops.
-    static void getCSOutList(App::DocumentObject* obj, std::vector<App::DocumentObject*>& vec);
+    static void getCSOutList(const App::DocumentObject* obj, std::vector<App::DocumentObject*>& vec);
     /// Collects GeoFeatureGroup relevant objects that link to the given one. That means all objects
     /// including their parents (recursively) except GeoFeatureGroups, where the recursion stops. Expression 
     /// links are ignored. An exception is thrown when there are dependency loops.
-    static void getCSInList(App::DocumentObject* obj, std::vector<App::DocumentObject*>& vec);
+    static void getCSInList(const App::DocumentObject* obj, std::vector<App::DocumentObject*>& vec);
     /// Collects all links that are relevant for the coordinate system, meaning all recursive links to 
     /// obj and from obj excluding expressions and stopping the recursion at other geofeaturegroups. 
     /// The result is the combination of CSOutList and CSInList.
-    static void getCSRelevantLinks(App::DocumentObject* obj, std::vector<App::DocumentObject*>& vec);
+    static void getCSRelevantLinks(const App::DocumentObject* obj, std::vector<App::DocumentObject*>& vec);
     /// Checks if the links of the given object comply with all GeoFeatureGroup requrirements, that means
     /// if normal links are only withing the parent GeoFeatureGroup. 
-    static bool areLinksValid(App::DocumentObject* obj);
+    static bool areLinksValid(const App::DocumentObject* obj);
+    /// Checks if the given link complies with all GeoFeatureGroup requrirements, that means
+    /// if normal links are only withing the parent GeoFeatureGroup. 
+    static bool isLinkValid(App::Property* link);
+    //Returns all objects that are wrongly linked from this object, meaning which are out of scope of the 
+    //links of obj
+    static void getInvalidLinkObjects(const App::DocumentObject* obj, std::vector<App::DocumentObject*>& vec);
+    
 private:
     Base::Placement recursiveGroupPlacement(GeoFeatureGroupExtension* group);
-    static std::vector<App::DocumentObject*> getScopedObjectsFromLinks(App::DocumentObject*, LinkScope scope = LinkScope::Local);
+    static std::vector<App::DocumentObject*> getScopedObjectsFromLinks(const App::DocumentObject*, LinkScope scope = LinkScope::Local);
+    static std::vector<App::DocumentObject*> getScopedObjectsFromLink(App::Property*, LinkScope scope = LinkScope::Local);
+
 };
 
 typedef ExtensionPythonT<GroupExtensionPythonT<GeoFeatureGroupExtension>> GeoFeatureGroupExtensionPython;

--- a/src/App/GeoFeatureGroupExtension.h
+++ b/src/App/GeoFeatureGroupExtension.h
@@ -44,7 +44,7 @@ namespace App
  *   also be added to the GeoFeatureGroup
  * - Objects can be only in a single GeoFeatureGroup. It is not allowed to have a document object in 
  *   multiple GeoFeatureGroups
- * - PropertyLinks between different GeoFeatureGroups are forbidden. There are special link proeprties 
+ * - PropertyLinks between different GeoFeatureGroups are forbidden. There are special link properties 
  *   that allow such cross-CS links.
  * - Expressions can cross GeoFeatureGroup borders
  */
@@ -109,7 +109,9 @@ public:
     /// obj and from obj excluding expressions and stopping the recursion at other geofeaturegroups. 
     /// The result is the combination of CSOutList and CSInList.
     static void getCSRelevantLinks(App::DocumentObject* obj, std::vector<App::DocumentObject*>& vec);
-    
+    /// Checks if the links of the given object comply with all GeoFeatureGroup requrirements, that means
+    /// if normal links are only withing the parent GeoFeatureGroup. 
+    static bool areLinksValid(App::DocumentObject* obj);
 private:
     Base::Placement recursiveGroupPlacement(GeoFeatureGroupExtension* group);
     static std::vector<App::DocumentObject*> getObjectsFromLinks(App::DocumentObject*);

--- a/src/App/GeoFeatureGroupExtension.h
+++ b/src/App/GeoFeatureGroupExtension.h
@@ -116,7 +116,7 @@ public:
     static bool areLinksValid(App::DocumentObject* obj);
 private:
     Base::Placement recursiveGroupPlacement(GeoFeatureGroupExtension* group);
-    static std::vector<App::DocumentObject*> getObjectsFromLinks(App::DocumentObject*);
+    static std::vector<App::DocumentObject*> getScopedObjectsFromLinks(App::DocumentObject*, LinkScope scope = LinkScope::Local);
 };
 
 typedef ExtensionPythonT<GroupExtensionPythonT<GeoFeatureGroupExtension>> GeoFeatureGroupExtensionPython;

--- a/src/App/GroupExtension.cpp
+++ b/src/App/GroupExtension.cpp
@@ -272,7 +272,6 @@ void GroupExtension::extensionOnChanged(const Property* p) {
                     in != getExtendedObject()) {
                     error = true;
                     corrected.erase(std::remove(corrected.begin(), corrected.end(), obj), corrected.end());
-                    break;
                 }
             }
         }

--- a/src/App/PropertyLinks.cpp
+++ b/src/App/PropertyLinks.cpp
@@ -50,6 +50,8 @@ using namespace std;
 //++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 TYPESYSTEM_SOURCE(App::PropertyLink , App::Property)
+TYPESYSTEM_SOURCE(App::PropertyLinkChild , App::PropertyLink)
+TYPESYSTEM_SOURCE(App::PropertyLinkGlobal , App::PropertyLink)
 
 //**************************************************************************
 // Construction/Destruction
@@ -180,6 +182,8 @@ void PropertyLink::Paste(const Property &from)
 //++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 TYPESYSTEM_SOURCE(App::PropertyLinkList, App::PropertyLists)
+TYPESYSTEM_SOURCE(App::PropertyLinkListChild , App::PropertyLinkList)
+TYPESYSTEM_SOURCE(App::PropertyLinkListGlobal , App::PropertyLinkList)
 
 //**************************************************************************
 // Construction/Destruction
@@ -364,6 +368,8 @@ unsigned int PropertyLinkList::getMemSize(void) const
 //++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 TYPESYSTEM_SOURCE(App::PropertyLinkSub , App::Property)
+TYPESYSTEM_SOURCE(App::PropertyLinkSubChild , App::PropertyLinkSub)
+TYPESYSTEM_SOURCE(App::PropertyLinkSubGlobal , App::PropertyLinkSub)
 
 //**************************************************************************
 // Construction/Destruction
@@ -556,6 +562,8 @@ void PropertyLinkSub::Paste(const Property &from)
 //++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 TYPESYSTEM_SOURCE(App::PropertyLinkSubList , App::PropertyLists)
+TYPESYSTEM_SOURCE(App::PropertyLinkSubListChild , App::PropertyLinkSubList)
+TYPESYSTEM_SOURCE(App::PropertyLinkSubListGlobal , App::PropertyLinkSubList)
 
 //**************************************************************************
 // Construction/Destruction

--- a/src/App/PropertyLinks.cpp
+++ b/src/App/PropertyLinks.cpp
@@ -74,11 +74,13 @@ void PropertyLink::setValue(App::DocumentObject * lValue)
 {
     aboutToSetValue();
 #ifndef USE_OLD_DAG
-    // maintain the back link in the DocumentObject class
-    if(_pcLink)
-        _pcLink->_removeBackLink(static_cast<DocumentObject*>(getContainer()));
-    if(lValue)
-        lValue->_addBackLink(static_cast<DocumentObject*>(getContainer()));
+    // maintain the back link in the DocumentObject class if it is from a document object
+    if(getContainer() && getContainer()->isDerivedFrom(App::DocumentObject::getClassTypeId())) {
+        if(_pcLink)
+            _pcLink->_removeBackLink(static_cast<DocumentObject*>(getContainer()));
+        if(lValue)
+            lValue->_addBackLink(static_cast<DocumentObject*>(getContainer()));
+    }
 #endif
     _pcLink=lValue;
     hasSetValue();
@@ -207,10 +209,12 @@ void PropertyLinkList::setValue(DocumentObject* lValue)
 {
 #ifndef USE_OLD_DAG   
     //maintain the back link in the DocumentObject class
-    for(auto *obj : _lValueList)
-        obj->_removeBackLink(static_cast<DocumentObject*>(getContainer()));
-    if(lValue)
-        lValue->_addBackLink(static_cast<DocumentObject*>(getContainer()));
+    if(getContainer() && getContainer()->isDerivedFrom(App::DocumentObject::getClassTypeId())) {
+        for(auto *obj : _lValueList)
+            obj->_removeBackLink(static_cast<DocumentObject*>(getContainer()));
+        if(lValue)
+            lValue->_addBackLink(static_cast<DocumentObject*>(getContainer()));
+    }
 #endif
     
     if (lValue){
@@ -231,10 +235,12 @@ void PropertyLinkList::setValues(const std::vector<DocumentObject*>& lValue)
     aboutToSetValue();
 #ifndef USE_OLD_DAG
     //maintain the back link in the DocumentObject class
-    for(auto *obj : _lValueList)
-        obj->_removeBackLink(static_cast<DocumentObject*>(getContainer()));
-    for(auto *obj : lValue)
-        obj->_addBackLink(static_cast<DocumentObject*>(getContainer()));
+    if(getContainer() && getContainer()->isDerivedFrom(App::DocumentObject::getClassTypeId())) {
+        for(auto *obj : _lValueList)
+            obj->_removeBackLink(static_cast<DocumentObject*>(getContainer()));
+        for(auto *obj : lValue)
+            obj->_addBackLink(static_cast<DocumentObject*>(getContainer()));
+    }
 #endif
     _lValueList = lValue;
     hasSetValue();
@@ -382,10 +388,12 @@ void PropertyLinkSub::setValue(App::DocumentObject * lValue, const std::vector<s
 {
     aboutToSetValue();
 #ifndef USE_OLD_DAG
-    if (_pcLinkSub)
-        _pcLinkSub->_removeBackLink(static_cast<App::DocumentObject*>(getContainer()));
-    if (lValue)
-        lValue->_addBackLink(static_cast<App::DocumentObject*>(getContainer()));
+    if(getContainer() && getContainer()->isDerivedFrom(App::DocumentObject::getClassTypeId())) {
+        if (_pcLinkSub)
+            _pcLinkSub->_removeBackLink(static_cast<App::DocumentObject*>(getContainer()));
+        if (lValue)
+            lValue->_addBackLink(static_cast<App::DocumentObject*>(getContainer()));
+    }
 #endif
     _pcLinkSub=lValue;
     _cSubList = SubList;
@@ -578,10 +586,12 @@ void PropertyLinkSubList::setValue(DocumentObject* lValue,const char* SubName)
 {
 #ifndef USE_OLD_DAG
     //maintain backlinks
-    for(auto *obj : _lValueList)
-        obj->_removeBackLink(static_cast<DocumentObject*>(getContainer()));
-    if (lValue)
-        lValue->_addBackLink(static_cast<DocumentObject*>(getContainer()));
+    if(getContainer() && getContainer()->isDerivedFrom(App::DocumentObject::getClassTypeId())) {
+        for(auto *obj : _lValueList)
+            obj->_removeBackLink(static_cast<DocumentObject*>(getContainer()));
+        if (lValue)
+            lValue->_addBackLink(static_cast<DocumentObject*>(getContainer()));
+    }
 #endif
     
     if (lValue) {
@@ -606,15 +616,19 @@ void PropertyLinkSubList::setValues(const std::vector<DocumentObject*>& lValue,c
         throw Base::ValueError("PropertyLinkSubList::setValues: size of subelements list != size of objects list");
     
 #ifndef USE_OLD_DAG
-    //maintain backlinks. _lValueList can contain items multiple times, but we trust the document 
-    //object to ensure that this works
-    for(auto *obj : _lValueList)
-        obj->_removeBackLink(static_cast<DocumentObject*>(getContainer()));
-    
-    //maintain backlinks. lValue can contain items multiple times, but we trust the document 
-    //object to ensure that the backlink is only added once
-    for(auto *obj : lValue)
-        obj->_addBackLink(static_cast<DocumentObject*>(getContainer()));
+    //maintain backlinks. 
+    if(getContainer() && getContainer()->isDerivedFrom(App::DocumentObject::getClassTypeId())) {
+        
+        //_lValueList can contain items multiple times, but we trust the document 
+        //object to ensure that this works
+        for(auto *obj : _lValueList)
+            obj->_removeBackLink(static_cast<DocumentObject*>(getContainer()));
+        
+        //maintain backlinks. lValue can contain items multiple times, but we trust the document 
+        //object to ensure that the backlink is only added once
+        for(auto *obj : lValue)
+            obj->_addBackLink(static_cast<DocumentObject*>(getContainer()));
+    }
 #endif
     
     aboutToSetValue();
@@ -632,15 +646,19 @@ void PropertyLinkSubList::setValues(const std::vector<DocumentObject*>& lValue,c
         throw Base::ValueError("PropertyLinkSubList::setValues: size of subelements list != size of objects list");
     
 #ifndef USE_OLD_DAG
-    //maintain backlinks. _lValueList can contain items multiple times, but we trust the document 
-    //object to ensure that this works
-    for(auto *obj : _lValueList)
-        obj->_removeBackLink(static_cast<DocumentObject*>(getContainer()));
-    
-    //maintain backlinks. lValue can contain items multiple times, but we trust the document 
-    //object to ensure that the backlink is only added once
-    for(auto *obj : lValue)
-        obj->_addBackLink(static_cast<DocumentObject*>(getContainer()));
+    //maintain backlinks. 
+    if(getContainer() && getContainer()->isDerivedFrom(App::DocumentObject::getClassTypeId())) {
+        
+        //_lValueList can contain items multiple times, but we trust the document 
+        //object to ensure that this works
+        for(auto *obj : _lValueList)
+            obj->_removeBackLink(static_cast<DocumentObject*>(getContainer()));
+        
+        //maintain backlinks. lValue can contain items multiple times, but we trust the document 
+        //object to ensure that the backlink is only added once
+        for(auto *obj : lValue)
+            obj->_addBackLink(static_cast<DocumentObject*>(getContainer()));
+    }
 #endif
     
     aboutToSetValue();
@@ -651,16 +669,20 @@ void PropertyLinkSubList::setValues(const std::vector<DocumentObject*>& lValue,c
 
 void PropertyLinkSubList::setValue(DocumentObject* lValue, const std::vector<string> &SubList)
 {
-#ifndef USE_OLD_DAG    
-    //maintain backlinks. _lValueList can contain items multiple times, but we trust the document 
-    //object to ensure that this works
-    for(auto *obj : _lValueList)
-        obj->_removeBackLink(static_cast<DocumentObject*>(getContainer()));
-    
-    //maintain backlinks. lValue can contain items multiple times, but we trust the document 
-    //object to ensure that the backlink is only added once
-    if(lValue)
-        lValue->_addBackLink(static_cast<DocumentObject*>(getContainer()));
+#ifndef USE_OLD_DAG   
+    //maintain backlinks.
+    if(getContainer() && getContainer()->isDerivedFrom(App::DocumentObject::getClassTypeId())) {
+        
+        //_lValueList can contain items multiple times, but we trust the document 
+        //object to ensure that this works
+        for(auto *obj : _lValueList)
+            obj->_removeBackLink(static_cast<DocumentObject*>(getContainer()));
+        
+        //maintain backlinks. lValue can contain items multiple times, but we trust the document 
+        //object to ensure that the backlink is only added once
+        if(lValue)
+            lValue->_addBackLink(static_cast<DocumentObject*>(getContainer()));
+    }
 #endif
     
     aboutToSetValue();

--- a/src/App/PropertyLinks.h
+++ b/src/App/PropertyLinks.h
@@ -39,9 +39,19 @@ namespace App
 {
 class DocumentObject;
 
+enum class LinkScope {
+    Local,
+    SubGroup,
+    Global
+};
 
-/** the general Link Poperty
- *  Main Purpose of this property is to Link Objects and Feautures in a document.
+/** The general Link Property
+ *  Main Purpose of this property is to Link Objects and Feautures in a document. Like all links this 
+ *  property is scope aware, meaning it does define which objects are allowed to be linked depending 
+ *  of the GeoFeatureGroup where it is in. 
+ * 
+ *  @note Links that invalid in respect to the scope this property is set to are not rejected. They 
+ *        are only detected to be invalid and prevent the feature from recomputing.
  */
 class AppExport PropertyLink : public Property
 {
@@ -93,9 +103,23 @@ public:
     }
     virtual const char* getEditorName(void) const
     { return "Gui::PropertyEditor::PropertyLinkItem"; }
+    
+    /**
+     * @brief Set the links scope
+     * Allows to define what kind of links are allowed. Only in the Local GeoFeatureGroup, in this an 
+     * all SubGroups or to all object within the Glocal scope.
+     */
+    void setScope(LinkScope scope) {_pcScope = scope;};    
+    /**
+     * @brief Get the links scope
+     * Retreive what kind of links are allowed. Only in the Local GeoFeatureGroup, in this an 
+     * all SubGroups or to all object within the Glocal scope.
+     */
+    LinkScope getScope() {return _pcScope;};
 
 protected:
     App::DocumentObject *_pcLink;
+    LinkScope            _pcScope = LinkScope::Local;
 };
 
 class AppExport PropertyLinkList : public PropertyLists
@@ -148,8 +172,22 @@ public:
 
     virtual unsigned int getMemSize(void) const;
 
+    /**
+     * @brief Set the links scope
+     * Allows to define what kind of links are allowed. Only in the Local GeoFeatureGroup, in this an 
+     * all SubGroups or to all object within the Glocal scope.
+     */
+    void setScope(LinkScope scope) {_pcScope = scope;};    
+    /**
+     * @brief Get the links scope
+     * Retreive what kind of links are allowed. Only in the Local GeoFeatureGroup, in this an 
+     * all SubGroups or to all object within the Glocal scope.
+     */
+    LinkScope getScope() {return _pcScope;};
+    
 private:
     std::vector<DocumentObject*> _lValueList;
+    LinkScope                    _pcScope = LinkScope::Local;
 };
 
 /** the Link Poperty with sub elements
@@ -212,11 +250,24 @@ public:
     virtual unsigned int getMemSize (void) const{
         return sizeof(App::DocumentObject *);
     }
+    
+    /**
+     * @brief Set the links scope
+     * Allows to define what kind of links are allowed. Only in the Local GeoFeatureGroup, in this an 
+     * all SubGroups or to all object within the Glocal scope.
+     */
+    void setScope(LinkScope scope) {_pcScope = scope;};    
+    /**
+     * @brief Get the links scope
+     * Retreive what kind of links are allowed. Only in the Local GeoFeatureGroup, in this an 
+     * all SubGroups or to all object within the Glocal scope.
+     */
+    LinkScope getScope() {return _pcScope;};
 
 protected:
-    App::DocumentObject *_pcLinkSub;
+    App::DocumentObject*     _pcLinkSub;
     std::vector<std::string> _cSubList;
-
+    LinkScope                _pcScope = LinkScope::Local;
 };
 
 class AppExport PropertyLinkSubList: public PropertyLists
@@ -285,10 +336,24 @@ public:
 
     virtual unsigned int getMemSize (void) const;
 
+    /**
+     * @brief Set the links scope
+     * Allows to define what kind of links are allowed. Only in the Local GeoFeatureGroup, in this an 
+     * all SubGroups or to all object within the Glocal scope.
+     */
+    void setScope(LinkScope scope) {_pcScope = scope;};    
+    /**
+     * @brief Get the links scope
+     * Retreive what kind of links are allowed. Only in the Local GeoFeatureGroup, in this an 
+     * all SubGroups or to all object within the Glocal scope.
+     */
+    LinkScope getScope() {return _pcScope;};
+    
 private:
     //FIXME: Do not make two independent lists because this will lead to some inconsistencies!
     std::vector<DocumentObject*> _lValueList;
     std::vector<std::string>     _lSubList;
+    LinkScope                    _pcScope = LinkScope::Local;
 };
 
 } // namespace App

--- a/src/Gui/Application.cpp
+++ b/src/Gui/Application.cpp
@@ -649,6 +649,7 @@ void Application::createStandardOperations()
     Gui::CreateMacroCommands();
     Gui::CreateViewStdCommands();
     Gui::CreateWindowStdCommands();
+    Gui::CreateStructureCommands();
     Gui::CreateTestCommands();
 }
 

--- a/src/Gui/CMakeLists.txt
+++ b/src/Gui/CMakeLists.txt
@@ -397,6 +397,7 @@ SET(Command_CPP_SRCS
     CommandWindow.cpp
     CommandTest.cpp
     CommandView.cpp
+    CommandStructure.cpp
 )
 SET(Command_SRCS
     ${Command_CPP_SRCS}

--- a/src/Gui/Command.h
+++ b/src/Gui/Command.h
@@ -61,6 +61,7 @@ void CreateFeatCommands(void);
 void CreateMacroCommands(void);
 void CreateViewStdCommands(void);
 void CreateWindowStdCommands(void);
+void CreateStructureCommands(void);
 void CreateTestCommands(void);
 
 

--- a/src/Gui/CommandStructure.cpp
+++ b/src/Gui/CommandStructure.cpp
@@ -1,0 +1,124 @@
+/***************************************************************************
+ *   Copyright (c) 2017 Stefan Tröger <stefantroeger@gmx.net>              *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+
+#include "PreCompiled.h"
+#ifndef _PreComp_
+#include <QMessageBox>
+#endif
+
+#include "App/Part.h"
+#include "Command.h"
+#include "Application.h"
+#include "MDIView.h"
+
+
+using namespace Gui;
+
+//++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+//===========================================================================
+// Std_Part
+//===========================================================================
+DEF_STD_CMD_A(StdCmdPart);
+
+StdCmdPart::StdCmdPart()
+  : Command("Std_Part")
+{
+    sGroup        = QT_TR_NOOP("Structure");
+    sMenuText     = QT_TR_NOOP("Create part");
+    sToolTipText  = QT_TR_NOOP("Create a new part and make it active");
+    sWhatsThis    = sToolTipText;
+    sStatusTip    = sToolTipText;
+    sPixmap       = "Tree_Annotation";
+}
+
+void StdCmdPart::activated(int iMsg)
+{
+    Q_UNUSED(iMsg);
+
+    openCommand("Add a part");
+    std::string FeatName = getUniqueObjectName("Part");
+
+    std::string PartName;
+    PartName = getUniqueObjectName("Part");
+    doCommand(Doc,"App.activeDocument().Tip = App.activeDocument().addObject('App::Part','%s')",PartName.c_str());
+    // TODO We really must to set label ourselfs? (2015-08-17, Fat-Zer)
+    doCommand(Doc,"App.activeDocument().%s.Label = '%s'", PartName.c_str(),
+            QObject::tr(PartName.c_str()).toUtf8().data());
+    doCommand(Gui::Command::Gui, "Gui.activeView().setActiveObject('%s', App.activeDocument().%s)",
+            PARTKEY, PartName.c_str());
+
+    updateActive();
+}
+
+bool StdCmdPart::isActive(void)
+{
+    return hasActiveDocument();
+}
+
+//===========================================================================
+// Std_Group
+//===========================================================================
+DEF_STD_CMD_A(StdCmdGroup);
+
+StdCmdGroup::StdCmdGroup()
+  : Command("Std_Group")
+{
+    sGroup        = QT_TR_NOOP("Structure");
+    sMenuText     = QT_TR_NOOP("Create group");
+    sToolTipText  = QT_TR_NOOP("Create a new group for ordering objects");
+    sWhatsThis    = sToolTipText;
+    sStatusTip    = sToolTipText;
+    sPixmap       = "Tree_Annotation";
+}
+
+void StdCmdGroup::activated(int iMsg)
+{
+    Q_UNUSED(iMsg);
+
+    openCommand("Add a group");
+    std::string FeatName = getUniqueObjectName("Group");
+
+    std::string GroupName;
+    GroupName = getUniqueObjectName("Group");
+    doCommand(Doc,"App.activeDocument().Tip = App.activeDocument().addObject('App::DocumentObjectGroup','%s')",GroupName.c_str());
+    doCommand(Doc,"App.activeDocument().%s.Label = '%s'", GroupName.c_str(),
+            QObject::tr(GroupName.c_str()).toUtf8().data());
+}
+
+bool StdCmdGroup::isActive(void)
+{
+    return hasActiveDocument();
+}
+
+namespace Gui {
+
+void CreateStructureCommands(void)
+{
+    CommandManager &rcCmdMgr = Application::Instance->commandManager();
+
+    rcCmdMgr.addCommand(new StdCmdPart());
+    rcCmdMgr.addCommand(new StdCmdGroup());
+}
+
+} // namespace Gui

--- a/src/Gui/CommandStructure.cpp
+++ b/src/Gui/CommandStructure.cpp
@@ -49,7 +49,7 @@ StdCmdPart::StdCmdPart()
     sToolTipText  = QT_TR_NOOP("Create a new part and make it active");
     sWhatsThis    = sToolTipText;
     sStatusTip    = sToolTipText;
-    sPixmap       = "Tree_Annotation";
+    sPixmap       = "Geofeaturegroup.svg";
 }
 
 void StdCmdPart::activated(int iMsg)
@@ -89,7 +89,7 @@ StdCmdGroup::StdCmdGroup()
     sToolTipText  = QT_TR_NOOP("Create a new group for ordering objects");
     sWhatsThis    = sToolTipText;
     sStatusTip    = sToolTipText;
-    sPixmap       = "Tree_Annotation";
+    sPixmap       = "Group.svg";
 }
 
 void StdCmdGroup::activated(int iMsg)

--- a/src/Gui/Document.cpp
+++ b/src/Gui/Document.cpp
@@ -1473,6 +1473,7 @@ PyObject* Document::getPyObject(void)
 void Document::handleChildren3D(ViewProvider* viewProvider)
 {
     // check for children
+    bool rebuild = false;
     if (viewProvider && viewProvider->getChildRoot()) {
         std::vector<App::DocumentObject*> children = viewProvider->claimChildren3D();
         SoGroup* childGroup =  viewProvider->getChildRoot();
@@ -1480,6 +1481,7 @@ void Document::handleChildren3D(ViewProvider* viewProvider)
         // size not the same -> build up the list new
         if (childGroup->getNumChildren() != static_cast<int>(children.size())) {
 
+            rebuild = true;
             childGroup->removeAllChildren();
 
             for (std::vector<App::DocumentObject*>::iterator it=children.begin();it!=children.end();++it) {
@@ -1521,5 +1523,29 @@ void Document::handleChildren3D(ViewProvider* viewProvider)
                 }
             }
         }
+    }
+    
+    //find all unclaimed viewproviders and add them back to the document (this happens if a 
+    //viewprovider has been claimed before, but the object droped it. 
+    if(rebuild) {
+        auto vpmap = d->_ViewProviderMap;
+        for( auto& pair  : d->_ViewProviderMap ) {
+            auto claimed = pair.second->claimChildren3D();
+            for(auto obj : claimed) {
+                auto it = vpmap.find(obj);
+                if(it != vpmap.end())
+                    vpmap.erase(it);
+            }
+        }
+        for(auto& pair : vpmap) {
+            
+            // cycling to all views of the document to add the viewprovider to the viewer itself
+            for (std::list<Gui::BaseView*>::iterator vIt = d->baseViews.begin();vIt != d->baseViews.end();++vIt) {
+                View3DInventor *activeView = dynamic_cast<View3DInventor *>(*vIt);
+                if (activeView && !activeView->getViewer()->hasViewProvider(pair.second)) {
+                    activeView->getViewer()->addViewProvider(pair.second);
+                }
+            }   
+        }   
     }
 }

--- a/src/Gui/Icons/Geofeaturegroup.svg
+++ b/src/Gui/Icons/Geofeaturegroup.svg
@@ -1,0 +1,548 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="256"
+   width="256"
+   version="1.1"
+   id="svg4683"
+   sodipodi:docname="Geofeaturegroup.svg"
+   inkscape:version="0.91 r13725">
+  <metadata
+     id="metadata4689">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs4687">
+    <linearGradient
+       id="linearGradient3794"
+       inkscape:collect="always">
+      <stop
+         id="stop3796"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         id="stop3798"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3864">
+      <stop
+         style="stop-color:#71b2f8;stop-opacity:1;"
+         offset="0"
+         id="stop3866" />
+      <stop
+         style="stop-color:#002795;stop-opacity:1;"
+         offset="1"
+         id="stop3868" />
+    </linearGradient>
+    <inkscape:perspective
+       id="perspective2988"
+       inkscape:persp3d-origin="32 : 21.333333 : 1"
+       inkscape:vp_z="64 : 32 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 32 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="21.31134"
+       x2="17.328547"
+       y1="55.717518"
+       x1="22.116516"
+       id="linearGradient3773"
+       xlink:href="#linearGradient3767"
+       inkscape:collect="always"
+       gradientTransform="translate(0,-4)" />
+    <linearGradient
+       id="linearGradient3767"
+       inkscape:collect="always">
+      <stop
+         id="stop3769"
+         offset="0"
+         style="stop-color:#3465a4;stop-opacity:1" />
+      <stop
+         id="stop3771"
+         offset="1"
+         style="stop-color:#729fcf;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="21.83742"
+       x2="47.502235"
+       y1="51.179787"
+       x1="53.896763"
+       id="linearGradient3783"
+       xlink:href="#linearGradient3777"
+       inkscape:collect="always"
+       gradientTransform="translate(0,-4)" />
+    <linearGradient
+       id="linearGradient3777"
+       inkscape:collect="always">
+      <stop
+         id="stop3779"
+         offset="0"
+         style="stop-color:#204a87;stop-opacity:1" />
+      <stop
+         id="stop3781"
+         offset="1"
+         style="stop-color:#3465a4;stop-opacity:1" />
+    </linearGradient>
+    <radialGradient
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.93348213,-2.2905276e-8,0,0.28687573,0.06651751,32.090592)"
+       r="41"
+       fy="45"
+       fx="1"
+       cy="45"
+       cx="1"
+       id="radialGradient3800"
+       xlink:href="#linearGradient3794"
+       inkscape:collect="always" />
+    <radialGradient
+       gradientTransform="matrix(2.8492421,1.2585119,-0.4040415,0.9147407,-125.84131,-100.25805)"
+       r="19.467436"
+       fy="77.042847"
+       fx="84.883324"
+       cy="77.042847"
+       cx="84.883324"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3701"
+       xlink:href="#linearGradient3377"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3377">
+      <stop
+         style="stop-color:#faff2b;stop-opacity:1;"
+         offset="0"
+         id="stop3379" />
+      <stop
+         style="stop-color:#ffaa00;stop-opacity:1;"
+         offset="1"
+         id="stop3381" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(0.9818943,0.1894295,-0.4109427,2.1300924,40.163453,-121.11559)"
+       r="19.467436"
+       fy="94.369568"
+       fx="76.383331"
+       cy="94.369568"
+       cx="76.383331"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3699"
+       xlink:href="#linearGradient3377"
+       inkscape:collect="always" />
+    <inkscape:perspective
+       id="perspective2829"
+       inkscape:persp3d-origin="32 : 21.333333 : 1"
+       inkscape:vp_z="64 : 32 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 32 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <linearGradient
+       gradientTransform="translate(-62,-16)"
+       spreadMethod="reflect"
+       gradientUnits="userSpaceOnUse"
+       y2="35"
+       x2="85"
+       y1="35"
+       x1="110"
+       id="linearGradient3807-7"
+       xlink:href="#linearGradient3801-5"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3801-5"
+       inkscape:collect="always">
+      <stop
+         id="stop3803-3"
+         offset="0"
+         style="stop-color:#c4a000;stop-opacity:1" />
+      <stop
+         id="stop3805-5"
+         offset="1"
+         style="stop-color:#fce94f;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3836-0-6-92-4-0">
+      <stop
+         id="stop3838-2-7-06-8-6"
+         offset="0"
+         style="stop-color:#a40000;stop-opacity:1" />
+      <stop
+         id="stop3840-5-5-8-7-2"
+         offset="1"
+         style="stop-color:#ef2929;stop-opacity:1" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4067-6"
+       id="radialGradient4081-3"
+       cx="16.481266"
+       cy="23.519165"
+       fx="16.481266"
+       fy="23.519165"
+       r="6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.732702,3.0198439,-3.942036,3.2272068,142.91392,5.997893)" />
+    <linearGradient
+       id="linearGradient4067-6">
+      <stop
+         style="stop-color:#888a85;stop-opacity:1;"
+         offset="0"
+         id="stop4069-7" />
+      <stop
+         style="stop-color:#2e3436;stop-opacity:1;"
+         offset="1"
+         id="stop4071-5" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3972"
+       id="linearGradient4004"
+       x1="36.71875"
+       y1="35.688774"
+       x2="56"
+       y2="35.688774"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.7157585,0,0,2.7157585,-401.20082,21.075878)" />
+    <linearGradient
+       id="linearGradient3972">
+      <stop
+         id="stop3974"
+         offset="0"
+         style="stop-color:#8ae234;stop-opacity:1;" />
+      <stop
+         id="stop3976"
+         offset="1"
+         style="stop-color:#73d216;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(2.7440576,0,0,1.8860234,-564.00418,26.205109)"
+       inkscape:collect="always"
+       xlink:href="#linearGradient3972"
+       id="linearGradient3970"
+       x1="99.075409"
+       y1="16.470234"
+       x2="117.81521"
+       y2="15.97659"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3892"
+       id="linearGradient3908"
+       x1="34"
+       y1="18"
+       x2="57"
+       y2="24"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.7157585,0,0,2.7157585,-401.20082,21.075878)" />
+    <linearGradient
+       id="linearGradient3892">
+      <stop
+         style="stop-color:#8ae234;stop-opacity:1;"
+         offset="0"
+         id="stop3894" />
+      <stop
+         style="stop-color:#4e9a06;stop-opacity:1;"
+         offset="1"
+         id="stop3896" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1848"
+     inkscape:window-height="1043"
+     id="namedview4685"
+     showgrid="false"
+     inkscape:zoom="1.1835752"
+     inkscape:cx="-40.672897"
+     inkscape:cy="182.96519"
+     inkscape:window-x="72"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg4683" />
+  <radialGradient
+     id="a"
+     cx="-25"
+     cy="203.5"
+     gradientTransform="matrix(1,0,0,0.78571429,0,43.607143)"
+     gradientUnits="userSpaceOnUse"
+     r="35">
+    <stop
+       offset="0"
+       id="stop4660" />
+    <stop
+       offset="1"
+       stop-opacity="0"
+       id="stop4662" />
+  </radialGradient>
+  <g
+     transform="matrix(0.87508221,0,0,0.87508221,-362.5247,-868.64133)"
+     id="g4681">
+    <path
+       d="m 10,203.5 a 35,27.5 0 1 1 -70,0 35,27.5 0 1 1 70,0 z"
+       transform="matrix(5.0857143,0,0,1.0909091,255.14286,788.3622)"
+       id="path4665"
+       style="opacity:0.55;fill:url(#a)"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 0,832.59752 0,171.29388 256,0 0,-85.6468 -12.19048,-73.412 L 148,844.3622 l -12,-24 -123.80952,0 C 6.09524,820.3622 0,826.47984 0,832.59752 Z"
+       id="path4667"
+       inkscape:connector-curvature="0"
+       style="fill:#ef6c00" />
+    <path
+       d="m 20,852.36212 126.28571,0 0,47.52914 -126.28571,0 z"
+       id="path4669"
+       inkscape:connector-curvature="0"
+       style="fill:#fffdf0" />
+    <path
+       d="m 12.25,820.3622 c -6.09524,0 -12.25,6.13232 -12.25,12.25 l 0,8 c 0,-6.11768 6.15476,-12.25 12.25,-12.25 l 119.75,0 12,24 99.75,0.5 12.25,73.375 0,-8 -12.25,-73.375 -95.75,-0.5 -12,-24 z"
+       id="path4671"
+       inkscape:connector-curvature="0"
+       style="opacity:0.02999998" />
+    <path
+       d="m 256,857.0682 0,171.294 -256,0 0,-160 120,0 12,-24 111.80952,0.4704 c 6.09524,0 12.19048,6.118 12.19048,12.2356 z"
+       id="path4673"
+       inkscape:connector-curvature="0"
+       style="fill:#ffa726" />
+    <path
+       d="m 0,1020.3622 0,8 256,0 0,-8 z"
+       id="path4675"
+       inkscape:connector-curvature="0"
+       style="opacity:0.15" />
+    <path
+       d="m 134.09524,850.9506 -30.4762,18.3528 18.28572,0 z"
+       id="path4677"
+       inkscape:connector-curvature="0"
+       style="fill:none" />
+    <path
+       d="m 132,844.3622 -12,24 -120,0 0,8 124,0 12,-24 107.75,0.5 c 6.09524,0 12.25,6.1324 12.25,12.25 l 0,-8 c 0,-6.1176 -6.15476,-12.25 -12.25,-12.25 z"
+       id="path4679"
+       inkscape:connector-curvature="0"
+       style="opacity:0.02999998" />
+  </g>
+  <g
+     id="g4036-9-5"
+     transform="matrix(3.9446872,-2.7605595,4.3293163,3.0297297,-29.856469,72.292634)"
+     style="fill:#3465a4;stroke:#0b1521;stroke-width:1.75300193;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1">
+    <g
+       id="g4033-8-3"
+       transform="matrix(0.70857077,0.64561924,-0.7760537,0.70710678,30.848953,1.7173836)"
+       style="fill:#3465a4;stroke:#0b1521;stroke-width:1.75119007;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1">
+      <rect
+         style="fill:#3465a4;stroke:#0b1521;stroke-width:1.75119007;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect3261-1-56"
+         width="23"
+         height="6"
+         x="-25"
+         y="-38"
+         transform="scale(-1,-1)" />
+    </g>
+  </g>
+  <g
+     id="g4036-9"
+     transform="matrix(-2.7612809,-3.9436566,3.0305215,-4.3281852,36.008591,278.28315)"
+     style="fill:#cc0000;stroke:#280000;stroke-width:1.75300193;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1">
+    <g
+       id="g4033-8"
+       transform="matrix(0.70857077,0.64561924,-0.7760537,0.70710678,30.848953,1.7173836)"
+       style="fill:#cc0000;stroke:#280000;stroke-width:1.75119007;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1">
+      <rect
+         style="fill:#cc0000;stroke:#280000;stroke-width:1.75119007;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect3261-1"
+         width="23"
+         height="6"
+         x="-25"
+         y="-38"
+         transform="scale(-1,-1)" />
+    </g>
+  </g>
+  <path
+     style="fill:none;stroke:#ef2929;stroke-width:8.57048988;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 101.74791,133.72988 0,-119.971012"
+     id="path4083-0"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="cc" />
+  <path
+     style="fill:#73d216;stroke:#729fcf;stroke-width:8.57048988;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 114.73428,138.01456 120.00253,0"
+     id="path4083-0-29"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="cc" />
+  <g
+     id="g4036-9-3"
+     transform="matrix(3.8539874,-2.7605595,4.229773,3.0297297,-46.864179,116.89792)"
+     style="fill:#73d216;stroke:#172a04;stroke-width:1.77350962;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1">
+    <g
+       id="g4033-8-5"
+       transform="matrix(0.70857077,0.64561924,-0.7760537,0.70710678,30.848953,1.7173836)"
+       style="fill:#73d216;stroke:#172a04;stroke-width:1.77167654;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1">
+      <rect
+         style="fill:#73d216;stroke:#172a04;stroke-width:1.79764783;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect3261-1-6"
+         width="26.344721"
+         height="5.3929434"
+         x="12.011514"
+         y="-22.444706"
+         transform="matrix(-0.61733264,0.78670224,-0.61733264,-0.78670224,0,0)" />
+    </g>
+  </g>
+  <path
+     style="fill:none;stroke:#8ae234;stroke-width:8.57048988;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 16.594111,226.73239 82.72374,-82.655"
+     id="path4083-0-2"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="cc" />
+  <ellipse
+     style="fill:url(#radialGradient4081-3);fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:8.5704937"
+     id="path11841-1"
+     cx="106.03366"
+     cy="142.29953"
+     rx="21.429024"
+     ry="21.423424" />
+  <g
+     inkscape:label="Layer 1"
+     id="layer1"
+     transform="matrix(2.2725886,0,0,2.418458,4.7713937,47.993306)">
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
+       id="path2993"
+       d="M 3,13 37,19 61,11 31,7 Z"
+       style="fill:#729fcf;stroke:#0b1521;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path2995"
+       d="M 61,11 61,47 37,57 37,19 Z"
+       style="fill:url(#linearGradient3783);fill-opacity:1;stroke:#0b1521;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1" />
+    <path
+       style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3773);fill-opacity:1;fill-rule:evenodd;stroke:#0b1521;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       d="M 3,13 37,19 37,57 3,51 Z"
+       id="path3825"
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0" />
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
+       id="path3765"
+       d="m 5,15.42772 0.00867,33.919116 30.008671,5.268799 -0.0087,-33.933614 z"
+       style="fill:none;stroke:#729fcf;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
+       id="path3775"
+       d="m 39.01243,20.433833 -0.01226,33.535301 20.001105,-8.300993 3.6e-4,-31.867363 z"
+       style="fill:none;stroke:#3465a4;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+  </g>
+  <g
+     id="g4275"
+     transform="matrix(1.433359,0,0,1.9757465,604.40469,-7.1689356)">
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
+       id="path3890"
+       d="m -246.4026,40.086188 0,81.472752 c -21.90395,8.7208 -33.86771,6.28731 -62.46245,0 l 0,-81.472752 z"
+       style="fill:url(#linearGradient3908);fill-opacity:1;stroke:#172a04;stroke-width:5.43151712;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path3962"
+       d="m -251.83412,48.233464 0,70.609726"
+       style="fill:none;stroke:#73d216;stroke-width:5.43151712;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       sodipodi:open="true"
+       sodipodi:end="6.2816523"
+       sodipodi:start="0"
+       transform="matrix(0.99984252,0.0177464,-0.19808478,0.98018489,0,0)"
+       d="m -235.90103,49.780407 a 31.74497,9.9438305 0 0 1 -31.7328,9.94383 31.74497,9.9438305 0 0 1 -31.75713,-9.936208 31.74497,9.9438305 0 0 1 31.70846,-9.951446 31.74497,9.9438305 0 0 1 31.78144,9.92858"
+       sodipodi:ry="9.9438305"
+       sodipodi:rx="31.74497"
+       sodipodi:cy="49.780407"
+       sodipodi:cx="-267.646"
+       id="path3870-2"
+       style="fill:#73d216;stroke:url(#linearGradient3970);stroke-width:4.34565067;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       sodipodi:type="arc" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path3996"
+       d="m -246.4026,116.12743 c -23.54166,9.22746 -41.49842,5.99385 -59.74669,0"
+       style="fill:none;stroke:url(#linearGradient4004);stroke-width:5.43151712;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       id="path3890-6"
+       d="m -308.86505,121.55894 0,-81.472752 62.46245,0 0,81.472752"
+       style="fill:none;stroke:#172a04;stroke-width:5.43151712;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path3848-4"
+       d="m -268.12867,126.99046 -32.5891,-81.472755"
+       style="fill:none;stroke:#172a04;stroke-width:5.43151712;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       sodipodi:open="true"
+       sodipodi:end="6.2816523"
+       sodipodi:start="0"
+       transform="matrix(0.99984252,0.0177464,-0.19808478,0.98018489,0,0)"
+       d="m -236.97976,45.187111 a 31.74497,9.9438305 0 0 1 -31.73281,9.94383 31.74497,9.9438305 0 0 1 -31.75712,-9.936208 31.74497,9.9438305 0 0 1 31.70846,-9.951446 31.74497,9.9438305 0 0 1 31.78143,9.92858"
+       sodipodi:ry="9.9438305"
+       sodipodi:rx="31.74497"
+       sodipodi:cy="45.187111"
+       sodipodi:cx="-268.72473"
+       id="path3870"
+       style="fill:#8ae234;fill-opacity:1;stroke:#172a04;stroke-width:4.34565067;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       sodipodi:type="arc" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path3848-4-5"
+       d="m -268.12867,126.99046 0,-78.756996"
+       style="fill:none;stroke:#172a04;stroke-width:5.43151712;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path3848-4-8"
+       d="M -246.4026,99.832876 -268.12867,48.233464"
+       style="fill:none;stroke:#172a04;stroke-width:5.43151712;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path3848-4-8-1"
+       d="m -281.70746,31.938912 -19.01031,13.578793"
+       style="fill:none;stroke:#172a04;stroke-width:5.43151712;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path3848-4-8-7"
+       d="M -268.12867,50.949222 -278.9917,29.223154"
+       style="fill:none;stroke:#172a04;stroke-width:5.43151712;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path3848-4-8-4"
+       d="m -268.12867,50.949222 13.57879,-19.01031"
+       style="fill:none;stroke:#172a04;stroke-width:5.43151712;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+  </g>
+</svg>

--- a/src/Gui/Icons/Group.svg
+++ b/src/Gui/Icons/Group.svg
@@ -1,0 +1,548 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="256"
+   width="256"
+   version="1.1"
+   id="svg4683"
+   sodipodi:docname="Group.svg"
+   inkscape:version="0.91 r13725">
+  <metadata
+     id="metadata4689">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs4687">
+    <linearGradient
+       id="linearGradient3794"
+       inkscape:collect="always">
+      <stop
+         id="stop3796"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         id="stop3798"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3864">
+      <stop
+         style="stop-color:#71b2f8;stop-opacity:1;"
+         offset="0"
+         id="stop3866" />
+      <stop
+         style="stop-color:#002795;stop-opacity:1;"
+         offset="1"
+         id="stop3868" />
+    </linearGradient>
+    <inkscape:perspective
+       id="perspective2988"
+       inkscape:persp3d-origin="32 : 21.333333 : 1"
+       inkscape:vp_z="64 : 32 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 32 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="21.31134"
+       x2="17.328547"
+       y1="55.717518"
+       x1="22.116516"
+       id="linearGradient3773"
+       xlink:href="#linearGradient3767"
+       inkscape:collect="always"
+       gradientTransform="translate(0,-4)" />
+    <linearGradient
+       id="linearGradient3767"
+       inkscape:collect="always">
+      <stop
+         id="stop3769"
+         offset="0"
+         style="stop-color:#3465a4;stop-opacity:1" />
+      <stop
+         id="stop3771"
+         offset="1"
+         style="stop-color:#729fcf;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="21.83742"
+       x2="47.502235"
+       y1="51.179787"
+       x1="53.896763"
+       id="linearGradient3783"
+       xlink:href="#linearGradient3777"
+       inkscape:collect="always"
+       gradientTransform="translate(0,-4)" />
+    <linearGradient
+       id="linearGradient3777"
+       inkscape:collect="always">
+      <stop
+         id="stop3779"
+         offset="0"
+         style="stop-color:#204a87;stop-opacity:1" />
+      <stop
+         id="stop3781"
+         offset="1"
+         style="stop-color:#3465a4;stop-opacity:1" />
+    </linearGradient>
+    <radialGradient
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.93348213,-2.2905276e-8,0,0.28687573,0.06651751,32.090592)"
+       r="41"
+       fy="45"
+       fx="1"
+       cy="45"
+       cx="1"
+       id="radialGradient3800"
+       xlink:href="#linearGradient3794"
+       inkscape:collect="always" />
+    <radialGradient
+       gradientTransform="matrix(2.8492421,1.2585119,-0.4040415,0.9147407,-125.84131,-100.25805)"
+       r="19.467436"
+       fy="77.042847"
+       fx="84.883324"
+       cy="77.042847"
+       cx="84.883324"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3701"
+       xlink:href="#linearGradient3377"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3377">
+      <stop
+         style="stop-color:#faff2b;stop-opacity:1;"
+         offset="0"
+         id="stop3379" />
+      <stop
+         style="stop-color:#ffaa00;stop-opacity:1;"
+         offset="1"
+         id="stop3381" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(0.9818943,0.1894295,-0.4109427,2.1300924,40.163453,-121.11559)"
+       r="19.467436"
+       fy="94.369568"
+       fx="76.383331"
+       cy="94.369568"
+       cx="76.383331"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3699"
+       xlink:href="#linearGradient3377"
+       inkscape:collect="always" />
+    <inkscape:perspective
+       id="perspective2829"
+       inkscape:persp3d-origin="32 : 21.333333 : 1"
+       inkscape:vp_z="64 : 32 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 32 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <linearGradient
+       gradientTransform="translate(-62,-16)"
+       spreadMethod="reflect"
+       gradientUnits="userSpaceOnUse"
+       y2="35"
+       x2="85"
+       y1="35"
+       x1="110"
+       id="linearGradient3807-7"
+       xlink:href="#linearGradient3801-5"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3801-5"
+       inkscape:collect="always">
+      <stop
+         id="stop3803-3"
+         offset="0"
+         style="stop-color:#c4a000;stop-opacity:1" />
+      <stop
+         id="stop3805-5"
+         offset="1"
+         style="stop-color:#fce94f;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3836-0-6-92-4-0">
+      <stop
+         id="stop3838-2-7-06-8-6"
+         offset="0"
+         style="stop-color:#a40000;stop-opacity:1" />
+      <stop
+         id="stop3840-5-5-8-7-2"
+         offset="1"
+         style="stop-color:#ef2929;stop-opacity:1" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4067-6"
+       id="radialGradient4081-3"
+       cx="16.481266"
+       cy="23.519165"
+       fx="16.481266"
+       fy="23.519165"
+       r="6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.732702,3.0198439,-3.942036,3.2272068,-191.66558,-47.230664)" />
+    <linearGradient
+       id="linearGradient4067-6">
+      <stop
+         style="stop-color:#888a85;stop-opacity:1;"
+         offset="0"
+         id="stop4069-7" />
+      <stop
+         style="stop-color:#2e3436;stop-opacity:1;"
+         offset="1"
+         id="stop4071-5" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3972"
+       id="linearGradient4004"
+       x1="36.71875"
+       y1="35.688774"
+       x2="56"
+       y2="35.688774"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.7157585,0,0,2.7157585,-401.20082,21.075878)" />
+    <linearGradient
+       id="linearGradient3972">
+      <stop
+         id="stop3974"
+         offset="0"
+         style="stop-color:#8ae234;stop-opacity:1;" />
+      <stop
+         id="stop3976"
+         offset="1"
+         style="stop-color:#73d216;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(2.7440576,0,0,1.8860234,-564.00418,26.205109)"
+       inkscape:collect="always"
+       xlink:href="#linearGradient3972"
+       id="linearGradient3970"
+       x1="99.075409"
+       y1="16.470234"
+       x2="117.81521"
+       y2="15.97659"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3892"
+       id="linearGradient3908"
+       x1="34"
+       y1="18"
+       x2="57"
+       y2="24"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.7157585,0,0,2.7157585,-401.20082,21.075878)" />
+    <linearGradient
+       id="linearGradient3892">
+      <stop
+         style="stop-color:#8ae234;stop-opacity:1;"
+         offset="0"
+         id="stop3894" />
+      <stop
+         style="stop-color:#4e9a06;stop-opacity:1;"
+         offset="1"
+         id="stop3896" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1848"
+     inkscape:window-height="1043"
+     id="namedview4685"
+     showgrid="false"
+     inkscape:zoom="1.1835752"
+     inkscape:cx="-40.672897"
+     inkscape:cy="182.96519"
+     inkscape:window-x="72"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg4683" />
+  <radialGradient
+     id="a"
+     cx="-25"
+     cy="203.5"
+     gradientTransform="matrix(1,0,0,0.78571429,0,43.607143)"
+     gradientUnits="userSpaceOnUse"
+     r="35">
+    <stop
+       offset="0"
+       id="stop4660" />
+    <stop
+       offset="1"
+       stop-opacity="0"
+       id="stop4662" />
+  </radialGradient>
+  <g
+     transform="matrix(0.87508221,0,0,0.87508221,19.369072,-685.29852)"
+     id="g4681">
+    <path
+       d="m 10,203.5 a 35,27.5 0 1 1 -70,0 35,27.5 0 1 1 70,0 z"
+       transform="matrix(5.0857143,0,0,1.0909091,255.14286,788.3622)"
+       id="path4665"
+       style="opacity:0.55;fill:url(#a)"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 0,832.59752 0,171.29388 256,0 0,-85.6468 -12.19048,-73.412 L 148,844.3622 l -12,-24 -123.80952,0 C 6.09524,820.3622 0,826.47984 0,832.59752 Z"
+       id="path4667"
+       inkscape:connector-curvature="0"
+       style="fill:#ef6c00" />
+    <path
+       d="m 20,852.36212 126.28571,0 0,47.52914 -126.28571,0 z"
+       id="path4669"
+       inkscape:connector-curvature="0"
+       style="fill:#fffdf0" />
+    <path
+       d="m 12.25,820.3622 c -6.09524,0 -12.25,6.13232 -12.25,12.25 l 0,8 c 0,-6.11768 6.15476,-12.25 12.25,-12.25 l 119.75,0 12,24 99.75,0.5 12.25,73.375 0,-8 -12.25,-73.375 -95.75,-0.5 -12,-24 z"
+       id="path4671"
+       inkscape:connector-curvature="0"
+       style="opacity:0.02999998" />
+    <path
+       d="m 256,857.0682 0,171.294 -256,0 0,-160 120,0 12,-24 111.80952,0.4704 c 6.09524,0 12.19048,6.118 12.19048,12.2356 z"
+       id="path4673"
+       inkscape:connector-curvature="0"
+       style="fill:#ffa726" />
+    <path
+       d="m 0,1020.3622 0,8 256,0 0,-8 z"
+       id="path4675"
+       inkscape:connector-curvature="0"
+       style="opacity:0.15" />
+    <path
+       d="m 134.09524,850.9506 -30.4762,18.3528 18.28572,0 z"
+       id="path4677"
+       inkscape:connector-curvature="0"
+       style="fill:none" />
+    <path
+       d="m 132,844.3622 -12,24 -120,0 0,8 124,0 12,-24 107.75,0.5 c 6.09524,0 12.25,6.1324 12.25,12.25 l 0,-8 c 0,-6.1176 -6.15476,-12.25 -12.25,-12.25 z"
+       id="path4679"
+       inkscape:connector-curvature="0"
+       style="opacity:0.02999998" />
+  </g>
+  <g
+     id="g4036-9-5"
+     transform="matrix(3.9446872,-2.7605595,4.3293163,3.0297297,-364.43597,19.064077)"
+     style="fill:#3465a4;stroke:#0b1521;stroke-width:1.75300193;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1">
+    <g
+       id="g4033-8-3"
+       transform="matrix(0.70857077,0.64561924,-0.7760537,0.70710678,30.848953,1.7173836)"
+       style="fill:#3465a4;stroke:#0b1521;stroke-width:1.75119007;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1">
+      <rect
+         style="fill:#3465a4;stroke:#0b1521;stroke-width:1.75119007;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect3261-1-56"
+         width="23"
+         height="6"
+         x="-25"
+         y="-38"
+         transform="scale(-1,-1)" />
+    </g>
+  </g>
+  <g
+     id="g4036-9"
+     transform="matrix(-2.7612809,-3.9436566,3.0305215,-4.3281852,-298.57091,225.05459)"
+     style="fill:#cc0000;stroke:#280000;stroke-width:1.75300193;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1">
+    <g
+       id="g4033-8"
+       transform="matrix(0.70857077,0.64561924,-0.7760537,0.70710678,30.848953,1.7173836)"
+       style="fill:#cc0000;stroke:#280000;stroke-width:1.75119007;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1">
+      <rect
+         style="fill:#cc0000;stroke:#280000;stroke-width:1.75119007;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect3261-1"
+         width="23"
+         height="6"
+         x="-25"
+         y="-38"
+         transform="scale(-1,-1)" />
+    </g>
+  </g>
+  <path
+     style="fill:none;stroke:#ef2929;stroke-width:8.57048988;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m -232.83159,80.501322 0,-119.971011"
+     id="path4083-0"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="cc" />
+  <path
+     style="fill:#73d216;stroke:#729fcf;stroke-width:8.57048988;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m -219.84522,84.786002 120.002528,0"
+     id="path4083-0-29"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="cc" />
+  <g
+     id="g4036-9-3"
+     transform="matrix(3.8539874,-2.7605595,4.229773,3.0297297,-381.44368,63.669362)"
+     style="fill:#73d216;stroke:#172a04;stroke-width:1.77350962;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1">
+    <g
+       id="g4033-8-5"
+       transform="matrix(0.70857077,0.64561924,-0.7760537,0.70710678,30.848953,1.7173836)"
+       style="fill:#73d216;stroke:#172a04;stroke-width:1.77167654;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1">
+      <rect
+         style="fill:#73d216;stroke:#172a04;stroke-width:1.79764783;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect3261-1-6"
+         width="26.344721"
+         height="5.3929434"
+         x="12.011514"
+         y="-22.444706"
+         transform="matrix(-0.61733264,0.78670224,-0.61733264,-0.78670224,0,0)" />
+    </g>
+  </g>
+  <path
+     style="fill:none;stroke:#8ae234;stroke-width:8.57048988;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m -317.98539,173.50383 82.72374,-82.654998"
+     id="path4083-0-2"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="cc" />
+  <ellipse
+     style="fill:url(#radialGradient4081-3);fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:8.5704937"
+     id="path11841-1"
+     cx="-228.54584"
+     cy="89.070976"
+     rx="21.429024"
+     ry="21.423424" />
+  <g
+     inkscape:label="Layer 1"
+     id="layer1"
+     transform="matrix(2.0070729,0,0,2.0260939,-319.19936,27.597942)">
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
+       id="path2993"
+       d="M 3,13 37,19 61,11 31,7 Z"
+       style="fill:#729fcf;stroke:#0b1521;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path2995"
+       d="M 61,11 61,47 37,57 37,19 Z"
+       style="fill:url(#linearGradient3783);fill-opacity:1;stroke:#0b1521;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1" />
+    <path
+       style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3773);fill-opacity:1;fill-rule:evenodd;stroke:#0b1521;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       d="M 3,13 37,19 37,57 3,51 Z"
+       id="path3825"
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0" />
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
+       id="path3765"
+       d="m 5,15.42772 0.00867,33.919116 30.008671,5.268799 -0.0087,-33.933614 z"
+       style="fill:none;stroke:#729fcf;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
+       id="path3775"
+       d="m 39.01243,20.433833 -0.01226,33.535301 20.001105,-8.300993 3.6e-4,-31.867363 z"
+       style="fill:none;stroke:#3465a4;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+  </g>
+  <g
+     id="g4275"
+     transform="matrix(1.0660729,0,0,1.3533555,146.7629,-79.377444)">
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
+       id="path3890"
+       d="m -246.4026,40.086188 0,81.472752 c -21.90395,8.7208 -33.86771,6.28731 -62.46245,0 l 0,-81.472752 z"
+       style="fill:url(#linearGradient3908);fill-opacity:1;stroke:#172a04;stroke-width:5.43151712;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path3962"
+       d="m -251.83412,48.233464 0,70.609726"
+       style="fill:none;stroke:#73d216;stroke-width:5.43151712;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       sodipodi:open="true"
+       sodipodi:end="6.2816523"
+       sodipodi:start="0"
+       transform="matrix(0.99984252,0.0177464,-0.19808478,0.98018489,0,0)"
+       d="m -235.90103,49.780407 a 31.74497,9.9438305 0 0 1 -31.7328,9.94383 31.74497,9.9438305 0 0 1 -31.75713,-9.936208 31.74497,9.9438305 0 0 1 31.70846,-9.951446 31.74497,9.9438305 0 0 1 31.78144,9.92858"
+       sodipodi:ry="9.9438305"
+       sodipodi:rx="31.74497"
+       sodipodi:cy="49.780407"
+       sodipodi:cx="-267.646"
+       id="path3870-2"
+       style="fill:#73d216;stroke:url(#linearGradient3970);stroke-width:4.34565067;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       sodipodi:type="arc" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path3996"
+       d="m -246.4026,116.12743 c -23.54166,9.22746 -41.49842,5.99385 -59.74669,0"
+       style="fill:none;stroke:url(#linearGradient4004);stroke-width:5.43151712;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       id="path3890-6"
+       d="m -308.86505,121.55894 0,-81.472752 62.46245,0 0,81.472752"
+       style="fill:none;stroke:#172a04;stroke-width:5.43151712;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path3848-4"
+       d="m -268.12867,126.99046 -32.5891,-81.472755"
+       style="fill:none;stroke:#172a04;stroke-width:5.43151712;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       sodipodi:open="true"
+       sodipodi:end="6.2816523"
+       sodipodi:start="0"
+       transform="matrix(0.99984252,0.0177464,-0.19808478,0.98018489,0,0)"
+       d="m -236.97976,45.187111 a 31.74497,9.9438305 0 0 1 -31.73281,9.94383 31.74497,9.9438305 0 0 1 -31.75712,-9.936208 31.74497,9.9438305 0 0 1 31.70846,-9.951446 31.74497,9.9438305 0 0 1 31.78143,9.92858"
+       sodipodi:ry="9.9438305"
+       sodipodi:rx="31.74497"
+       sodipodi:cy="45.187111"
+       sodipodi:cx="-268.72473"
+       id="path3870"
+       style="fill:#8ae234;fill-opacity:1;stroke:#172a04;stroke-width:4.34565067;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       sodipodi:type="arc" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path3848-4-5"
+       d="m -268.12867,126.99046 0,-78.756996"
+       style="fill:none;stroke:#172a04;stroke-width:5.43151712;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path3848-4-8"
+       d="M -246.4026,99.832876 -268.12867,48.233464"
+       style="fill:none;stroke:#172a04;stroke-width:5.43151712;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path3848-4-8-1"
+       d="m -281.70746,31.938912 -19.01031,13.578793"
+       style="fill:none;stroke:#172a04;stroke-width:5.43151712;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path3848-4-8-7"
+       d="M -268.12867,50.949222 -278.9917,29.223154"
+       style="fill:none;stroke:#172a04;stroke-width:5.43151712;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path3848-4-8-4"
+       d="m -268.12867,50.949222 13.57879,-19.01031"
+       style="fill:none;stroke:#172a04;stroke-width:5.43151712;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+  </g>
+</svg>

--- a/src/Gui/Icons/resource.qrc
+++ b/src/Gui/Icons/resource.qrc
@@ -153,6 +153,8 @@
         <file>colors.svg</file>
         <file>px.svg</file>
         <file>AddonManager.svg</file>
+        <file>Group.svg</file>
+        <file>Geofeaturegroup.svg</file>
     </qresource>
     <!-- Alternative directory names for icons that should be loaded from a theme -->
     <!-- See also http://permalink.gmane.org/gmane.comp.lib.qt.general/26374 -->

--- a/src/Gui/Tree.cpp
+++ b/src/Gui/Tree.cpp
@@ -1161,7 +1161,7 @@ void DocumentItem::populateItem(DocumentObjectItem *item, bool refresh) {
             if(!createNewItem(*childItem->object(),item,i,it->second))
                 --i;
         }else {
-            if(item->isChildOfItem(childItem)) {
+            if(item==childItem || item->isChildOfItem(childItem)) {
                 Base::Console().Error("Gui::DocumentItem::populateItem(): Cyclic dependency in %s and %s\n",
                         item->object()->getObject()->Label.getValue(),
                         childItem->object()->getObject()->Label.getValue());

--- a/src/Gui/ViewProviderDocumentObjectGroup.cpp
+++ b/src/Gui/ViewProviderDocumentObjectGroup.cpp
@@ -59,6 +59,8 @@ ViewProviderDocumentObjectGroup::ViewProviderDocumentObjectGroup()
     setDefaultMode(SO_SWITCH_ALL);
 #endif
     ViewProviderGroupExtension::initExtension(this);
+    
+    sPixmap = "Group.svg";
 }
 
 ViewProviderDocumentObjectGroup::~ViewProviderDocumentObjectGroup()
@@ -92,19 +94,6 @@ void ViewProviderDocumentObjectGroup::getViewProviders(std::vector<ViewProviderD
                 vp.push_back((ViewProviderDocumentObject*)v);
         }
     }
-}
-
-/**
- * Returns the pixmap for the list item.
- */
-QIcon ViewProviderDocumentObjectGroup::getIcon() const
-{
-    QIcon groupIcon;
-    groupIcon.addPixmap(QApplication::style()->standardPixmap(QStyle::SP_DirClosedIcon),
-                        QIcon::Normal, QIcon::Off);
-    groupIcon.addPixmap(QApplication::style()->standardPixmap(QStyle::SP_DirOpenIcon),
-                        QIcon::Normal, QIcon::On);
-    return groupIcon;
 }
 
 

--- a/src/Gui/ViewProviderDocumentObjectGroup.h
+++ b/src/Gui/ViewProviderDocumentObjectGroup.h
@@ -42,7 +42,6 @@ public:
     /// destructor.
     virtual ~ViewProviderDocumentObjectGroup();
 
-    QIcon getIcon(void) const;
     /// returns a list of all possible modes
     std::vector<std::string> getDisplayModes(void) const;
     bool isShow(void) const;

--- a/src/Gui/ViewProviderGeoFeatureGroupExtension.cpp
+++ b/src/Gui/ViewProviderGeoFeatureGroupExtension.cpp
@@ -76,9 +76,13 @@ std::vector<App::DocumentObject*> ViewProviderGeoFeatureGroupExtension::extensio
         //object in the tree
         std::vector<App::DocumentObject*> claim;
         auto objs = ext->Group.getValues();
+        Base::Console().Message("Claim children GeoFatureGroup:\n");
+        
         for(auto obj : objs) {            
-            if(obj->getInList().size()<=1)
+            if(obj->getInList().size()<=1) {
+                Base::Console().Message("%s\n", obj->getNameInDocument());
                 claim.push_back(obj);
+            }
         }
         return claim;
     }

--- a/src/Gui/ViewProviderGeoFeatureGroupExtension.cpp
+++ b/src/Gui/ViewProviderGeoFeatureGroupExtension.cpp
@@ -33,7 +33,6 @@
 #include "Application.h"
 #include "Document.h"
 #include <App/GeoFeatureGroupExtension.h>
-#include <Base/Console.h>
 #include <Inventor/nodes/SoGroup.h>
 
 using namespace Gui;
@@ -76,13 +75,10 @@ std::vector<App::DocumentObject*> ViewProviderGeoFeatureGroupExtension::extensio
         //object in the tree
         std::vector<App::DocumentObject*> claim;
         auto objs = ext->Group.getValues();
-        Base::Console().Message("Claim children GeoFatureGroup:\n");
         
         for(auto obj : objs) {            
-            if(obj->getInList().size()<=1) {
-                Base::Console().Message("%s\n", obj->getNameInDocument());
+            if(obj->getInList().size()<=1)
                 claim.push_back(obj);
-            }
         }
         return claim;
     }

--- a/src/Gui/ViewProviderGroupExtension.cpp
+++ b/src/Gui/ViewProviderGroupExtension.cpp
@@ -111,6 +111,9 @@ void ViewProviderGroupExtension::extensionDropObject(App::DocumentObject* obj) {
 std::vector< App::DocumentObject* > ViewProviderGroupExtension::extensionClaimChildren(void) const {
 
     auto* group = getExtendedViewProvider()->getObject()->getExtensionByType<App::GroupExtension>();
+    Base::Console().Message("Claim children group:\n");
+    for(auto obj : group->Group.getValues())
+        Base::Console().Message("%s\n", obj->getNameInDocument());
     
     return std::vector<App::DocumentObject*>(group->Group.getValues());
 }

--- a/src/Gui/ViewProviderGroupExtension.cpp
+++ b/src/Gui/ViewProviderGroupExtension.cpp
@@ -110,11 +110,7 @@ void ViewProviderGroupExtension::extensionDropObject(App::DocumentObject* obj) {
 
 std::vector< App::DocumentObject* > ViewProviderGroupExtension::extensionClaimChildren(void) const {
 
-    auto* group = getExtendedViewProvider()->getObject()->getExtensionByType<App::GroupExtension>();
-    Base::Console().Message("Claim children group:\n");
-    for(auto obj : group->Group.getValues())
-        Base::Console().Message("%s\n", obj->getNameInDocument());
-    
+    auto* group = getExtendedViewProvider()->getObject()->getExtensionByType<App::GroupExtension>();    
     return std::vector<App::DocumentObject*>(group->Group.getValues());
 }
 

--- a/src/Gui/ViewProviderPart.cpp
+++ b/src/Gui/ViewProviderPart.cpp
@@ -52,6 +52,8 @@ PROPERTY_SOURCE_WITH_EXTENSIONS(Gui::ViewProviderPart, Gui::ViewProviderDocument
 ViewProviderPart::ViewProviderPart()
 { 
     initExtension(this);
+    
+    sPixmap = "Geofeaturegroup.svg";
 }
 
 ViewProviderPart::~ViewProviderPart()
@@ -94,20 +96,6 @@ bool ViewProviderPart::doubleClicked(void)
     }
 
     return true;
-}
-
-/**
- * Returns the pixmap for the list item.
- */
-QIcon ViewProviderPart::getIcon() const
-{
-    // TODO Make a nice icon for the part (2015-09-01, Fat-Zer)
-    QIcon groupIcon;
-    groupIcon.addPixmap(QApplication::style()->standardPixmap(QStyle::SP_DirClosedIcon),
-                        QIcon::Normal, QIcon::Off);
-    groupIcon.addPixmap(QApplication::style()->standardPixmap(QStyle::SP_DirOpenIcon),
-                        QIcon::Normal, QIcon::On);
-    return groupIcon;
 }
 
 // Python feature -----------------------------------------------------------------------

--- a/src/Gui/ViewProviderPart.h
+++ b/src/Gui/ViewProviderPart.h
@@ -42,8 +42,6 @@ public:
     /// destructor.
     virtual ~ViewProviderPart();
 
-    QIcon getIcon(void) const;
-
     virtual bool doubleClicked(void);
 protected:
     /// get called by the container whenever a property has been changed

--- a/src/Gui/Workbench.cpp
+++ b/src/Gui/Workbench.cpp
@@ -622,6 +622,12 @@ ToolBarItem* StdWorkbench::setupToolBars() const
     *view << "Std_ViewFitAll" << "Std_ViewFitSelection" << "Std_DrawStyle" << "Separator" << "Std_ViewAxo" << "Separator" << "Std_ViewFront"
           << "Std_ViewTop" << "Std_ViewRight" << "Separator" << "Std_ViewRear" << "Std_ViewBottom"
           << "Std_ViewLeft" << "Separator" << "Std_MeasureDistance" ;
+    
+    // Structure
+    ToolBarItem* structure = new ToolBarItem( root );
+    structure->setCommand("Structure");
+    *structure << "Std_Part";
+          
     return root;
 }
 

--- a/src/Gui/Workbench.cpp
+++ b/src/Gui/Workbench.cpp
@@ -626,7 +626,7 @@ ToolBarItem* StdWorkbench::setupToolBars() const
     // Structure
     ToolBarItem* structure = new ToolBarItem( root );
     structure->setCommand("Structure");
-    *structure << "Std_Part";
+    *structure << "Std_Part" << "Std_Group";
           
     return root;
 }

--- a/src/Mod/Inspection/Gui/ViewProviderInspection.cpp
+++ b/src/Mod/Inspection/Gui/ViewProviderInspection.cpp
@@ -184,7 +184,7 @@ void ViewProviderInspection::attach(App::DocumentObject *pcFeat)
 void ViewProviderInspection::updateData(const App::Property* prop)
 {
     // set to the expected size
-    if (prop->getTypeId() == App::PropertyLink::getClassTypeId()) {
+    if (prop->getTypeId().isDerivedFrom(App::PropertyLink::getClassTypeId())) {
         App::GeoFeature* object = static_cast<const App::PropertyLink*>(prop)->getValue<App::GeoFeature*>();
         if (object) {
             float accuracy=0;

--- a/src/Mod/Mesh/Gui/ViewProviderCurvature.cpp
+++ b/src/Mod/Mesh/Gui/ViewProviderCurvature.cpp
@@ -288,7 +288,7 @@ void ViewProviderMeshCurvature::attach(App::DocumentObject *pcFeat)
 void ViewProviderMeshCurvature::updateData(const App::Property* prop)
 {
     // set to the expected size
-    if (prop->getTypeId() == App::PropertyLink::getClassTypeId()) {
+    if (prop->getTypeId().isDerivedFrom(App::PropertyLink::getClassTypeId())) {
         Mesh::Feature* object = static_cast<const App::PropertyLink*>(prop)->getValue<Mesh::Feature*>();
         this->pcLinkRoot->removeAllChildren();
         if (object) {

--- a/src/Mod/Part/Gui/ViewProviderBoolean.cpp
+++ b/src/Mod/Part/Gui/ViewProviderBoolean.cpp
@@ -134,7 +134,7 @@ void ViewProviderBoolean::updateData(const App::Property* prop)
             }
         }
     }
-    else if (prop->getTypeId() == App::PropertyLink::getClassTypeId()) {
+    else if (prop->getTypeId().isDerivedFrom(App::PropertyLink::getClassTypeId())) {
         App::DocumentObject *pBase = static_cast<const App::PropertyLink*>(prop)->getValue();
         if (pBase)
             Gui::Application::Instance->hideViewProvider(pBase);
@@ -224,7 +224,7 @@ void ViewProviderMultiFuse::updateData(const App::Property* prop)
         if (setColor)
             this->DiffuseColor.setValues(colBool);
     }
-    else if (prop->getTypeId() == App::PropertyLinkList::getClassTypeId()) {
+    else if (prop->getTypeId().isDerivedFrom(App::PropertyLinkList::getClassTypeId())) {
         std::vector<App::DocumentObject*> pShapes = static_cast<const App::PropertyLinkList*>(prop)->getValues();
         for (std::vector<App::DocumentObject*>::iterator it = pShapes.begin(); it != pShapes.end(); ++it) {
             if (*it)
@@ -356,7 +356,7 @@ void ViewProviderMultiCommon::updateData(const App::Property* prop)
         if (setColor)
             this->DiffuseColor.setValues(colBool);
     }
-    else if (prop->getTypeId() == App::PropertyLinkList::getClassTypeId()) {
+    else if (prop->getTypeId().isDerivedFrom(App::PropertyLinkList::getClassTypeId())) {
         std::vector<App::DocumentObject*> pShapes = static_cast<const App::PropertyLinkList*>(prop)->getValues();
         for (std::vector<App::DocumentObject*>::iterator it = pShapes.begin(); it != pShapes.end(); ++it) {
             if (*it)

--- a/src/Mod/Part/Gui/ViewProviderCompound.cpp
+++ b/src/Mod/Part/Gui/ViewProviderCompound.cpp
@@ -110,7 +110,7 @@ void ViewProviderCompound::updateData(const App::Property* prop)
         if (setColor)
             this->DiffuseColor.setValues(compCol);
     }
-    else if (prop->getTypeId() == App::PropertyLinkList::getClassTypeId()) {
+    else if (prop->getTypeId().isDerivedFrom(App::PropertyLinkList::getClassTypeId())) {
         const std::vector<App::DocumentObject *>& pBases = static_cast<const App::PropertyLinkList*>(prop)->getValues();
         for (std::vector<App::DocumentObject *>::const_iterator it = pBases.begin(); it != pBases.end(); ++it) {
             if (*it) Gui::Application::Instance->hideViewProvider(*it);

--- a/src/Mod/PartDesign/App/ShapeBinder.h
+++ b/src/Mod/PartDesign/App/ShapeBinder.h
@@ -47,7 +47,7 @@ public:
     ShapeBinder();
     virtual ~ShapeBinder();
 
-    App::PropertyLinkSubList    Support;
+    App::PropertyLinkSubListGlobal    Support;
 
     static void getFilteredReferences(App::PropertyLinkSubList* prop, Part::Feature*& object, std::vector< std::string >& subobjects);
     static Part::TopoShape buildShapeFromReferences(Feature* obj, std::vector< std::string > subs);

--- a/src/Mod/PartDesign/Gui/CommandBody.cpp
+++ b/src/Mod/PartDesign/Gui/CommandBody.cpp
@@ -76,49 +76,6 @@ App::Part* assertActivePart () {
 } /* PartDesignGui */
 
 //===========================================================================
-// PartDesign_Part
-//===========================================================================
-DEF_STD_CMD_A(CmdPartDesignPart);
-
-CmdPartDesignPart::CmdPartDesignPart()
-  : Command("PartDesign_Part")
-{
-    sAppModule    = "PartDesign";
-    sGroup        = QT_TR_NOOP("PartDesign");
-    sMenuText     = QT_TR_NOOP("Create part");
-    sToolTipText  = QT_TR_NOOP("Create a new part and make it active");
-    sWhatsThis    = sToolTipText;
-    sStatusTip    = sToolTipText;
-    sPixmap       = "Tree_Annotation";
-}
-
-void CmdPartDesignPart::activated(int iMsg)
-{
-    Q_UNUSED(iMsg);
-    if ( !PartDesignGui::assureModernWorkflow( getDocument() ) )
-        return;
-
-    openCommand("Add a part");
-    std::string FeatName = getUniqueObjectName("Part");
-
-    std::string PartName;
-    PartName = getUniqueObjectName("Part");
-    doCommand(Doc,"App.activeDocument().Tip = App.activeDocument().addObject('App::Part','%s')",PartName.c_str());
-    // TODO We really must to set label ourselfs? (2015-08-17, Fat-Zer)
-    doCommand(Doc,"App.activeDocument().%s.Label = '%s'", PartName.c_str(),
-            QObject::tr(PartName.c_str()).toUtf8().data());
-    doCommand(Gui::Command::Gui, "Gui.activeView().setActiveObject('%s', App.activeDocument().%s)",
-            PARTKEY, PartName.c_str());
-
-    updateActive();
-}
-
-bool CmdPartDesignPart::isActive(void)
-{
-    return hasActiveDocument() && !PartDesignGui::isLegacyWorkflow ( getDocument () );
-}
-
-//===========================================================================
 // PartDesign_Body
 //===========================================================================
 DEF_STD_CMD_A(CmdPartDesignBody);
@@ -867,7 +824,6 @@ void CreatePartDesignBodyCommands(void)
 {
     Gui::CommandManager &rcCmdMgr = Gui::Application::Instance->commandManager();
 
-    rcCmdMgr.addCommand(new CmdPartDesignPart());
     rcCmdMgr.addCommand(new CmdPartDesignBody());
     rcCmdMgr.addCommand(new CmdPartDesignMigrate());
     rcCmdMgr.addCommand(new CmdPartDesignMoveTip());

--- a/src/Mod/PartDesign/Gui/TaskFeaturePick.cpp
+++ b/src/Mod/PartDesign/Gui/TaskFeaturePick.cpp
@@ -310,10 +310,10 @@ App::DocumentObject* TaskFeaturePick::makeCopy(App::DocumentObject* obj, std::st
 
             //independent copies don't have links and are not attached
             if(independent && (
-                prop->getTypeId() == App::PropertyLink::getClassTypeId() ||
-                prop->getTypeId() == App::PropertyLinkList::getClassTypeId() ||
-                prop->getTypeId() == App::PropertyLinkSub::getClassTypeId() ||
-                prop->getTypeId() == App::PropertyLinkSubList::getClassTypeId()||
+                prop->getTypeId().isDerivedFrom(App::PropertyLink::getClassTypeId()) ||
+                prop->getTypeId().isDerivedFrom(App::PropertyLinkList::getClassTypeId()) ||
+                prop->getTypeId().isDerivedFrom(App::PropertyLinkSub::getClassTypeId()) ||
+                prop->getTypeId().isDerivedFrom(App::PropertyLinkSubList::getClassTypeId())||
                 ( prop->getGroup() && strcmp(prop->getGroup(),"Attachment")==0) ))    {
 
                 ++it;

--- a/src/Mod/PartDesign/Gui/Workbench.cpp
+++ b/src/Mod/PartDesign/Gui/Workbench.cpp
@@ -341,7 +341,6 @@ void Workbench::activated()
 
     const char* NoSel[] = {
         "PartDesign_Body",
-        "PartDesign_Part",
         0};
     Watcher.push_back(new Gui::TaskView::TaskWatcherCommandsEmptySelection(
         NoSel,
@@ -436,8 +435,7 @@ Gui::MenuItem* Workbench::setupMenuBar() const
     Gui::MenuItem* part = new Gui::MenuItem;
     root->insertItem(item, part);
     part->setCommand("&Part Design");
-    *part << "PartDesign_Part"
-          << "PartDesign_Body"
+    *part << "PartDesign_Body"
           << "PartDesign_NewSketch"
           << "Sketcher_LeaveSketch"
           << "Sketcher_ViewSketch"
@@ -504,8 +502,7 @@ Gui::ToolBarItem* Workbench::setupToolBars() const
     Gui::ToolBarItem* root = StdWorkbench::setupToolBars();
     Gui::ToolBarItem* part = new Gui::ToolBarItem(root);
     part->setCommand("Part Design Helper");
-    *part << "PartDesign_Part"
-          << "PartDesign_Body"
+    *part << "PartDesign_Body"
           << "PartDesign_NewSketch"
           << "Sketcher_EditSketch"
           << "Sketcher_MapSketch"

--- a/src/Mod/Path/Gui/ViewProviderArea.cpp
+++ b/src/Mod/Path/Gui/ViewProviderArea.cpp
@@ -92,7 +92,7 @@ void ViewProviderArea::dropObject(App::DocumentObject* obj)
 void ViewProviderArea::updateData(const App::Property* prop)
 {
     PartGui::ViewProviderPart::updateData(prop);
-    if (prop->getTypeId() == App::PropertyLinkList::getClassTypeId()) {
+    if (prop->getTypeId().isDerivedFrom(App::PropertyLinkList::getClassTypeId())) {
         std::vector<App::DocumentObject*> pShapes = static_cast<const App::PropertyLinkList*>(prop)->getValues();
         for (std::vector<App::DocumentObject*>::iterator it = pShapes.begin(); it != pShapes.end(); ++it) {
             if (*it)
@@ -170,7 +170,7 @@ void ViewProviderAreaView::dropObject(App::DocumentObject* obj)
 void ViewProviderAreaView::updateData(const App::Property* prop)
 {
     PartGui::ViewProviderPlaneParametric::updateData(prop);
-    if (prop->getTypeId() == App::PropertyLink::getClassTypeId())
+    if (prop->getTypeId().isDerivedFrom(App::PropertyLink::getClassTypeId()))
         Gui::Application::Instance->hideViewProvider(
                 static_cast<const App::PropertyLink*>(prop)->getValue());
 }

--- a/src/Mod/Path/Gui/ViewProviderPathShape.cpp
+++ b/src/Mod/Path/Gui/ViewProviderPathShape.cpp
@@ -92,7 +92,7 @@ void ViewProviderPathShape::dropObject(App::DocumentObject* obj)
 void ViewProviderPathShape::updateData(const App::Property* prop)
 {
     PathGui::ViewProviderPath::updateData(prop);
-    if (prop->getTypeId() == App::PropertyLinkList::getClassTypeId()) {
+    if (prop->getTypeId().isDerivedFrom(App::PropertyLinkList::getClassTypeId())) {
         std::vector<App::DocumentObject*> pShapes = static_cast<const App::PropertyLinkList*>(prop)->getValues();
         for (std::vector<App::DocumentObject*>::iterator it = pShapes.begin(); it != pShapes.end(); ++it) {
             if (*it)

--- a/src/Mod/Test/Document.py
+++ b/src/Mod/Test/Document.py
@@ -887,17 +887,32 @@ class UndoRedoCases(unittest.TestCase):
     else:
         self.fail("No exception thrown when object is in multiple Groups")
    
-    #to test: try add obj to second group by .Group = []
-    grp = prt1.Group
-    grp.append(grp2)
-    
-    try:
-        prt1.Group=grp
-        self.Doc.recompute()
-    except:
-        pass
-    else:
-        self.fail("No exception at cross geofeaturegroup links") 
+    #cross linking between GeoFeatureGroups is not allowed
+    self.Doc.recompute()
+    box = self.Doc.addObject("Part::Box","Box")
+    cyl = self.Doc.addObject("Part::Cylinder","Cylinder")
+    fus = self.Doc.addObject("Part::MultiFuse","Fusion")
+    fus.Shapes = [cyl, box]
+    self.Doc.recompute()
+    self.failUnless(fus.State[0] == 'Up-to-date')
+    fus.Shapes = [] #remove all links as addObject would otherwise transfer all linked objects
+    prt1.addObject(cyl)
+    fus.Shapes = [cyl, box]
+    self.Doc.recompute()
+    self.failUnless(fus.State[0] == 'Invalid')
+    fus.Shapes = []
+    prt1.addObject(box)
+    fus.Shapes = [cyl, box]
+    self.Doc.recompute()
+    self.failUnless(fus.State[0] == 'Invalid')
+    fus.Shapes = []
+    prt1.addObject(fus)
+    fus.Shapes = [cyl, box]
+    self.Doc.recompute()
+    self.failUnless(fus.State[0] == 'Up-to-date')
+    prt2.addObject(box) #this time addObject should move all dependencies to the new part
+    self.Doc.recompute()
+    self.failUnless(fus.State[0] == 'Up-to-date')
 
   def tearDown(self):
     # closing doc

--- a/src/Mod/Test/Document.py
+++ b/src/Mod/Test/Document.py
@@ -290,11 +290,11 @@ class DocumentBasicCases(unittest.TestCase):
     self.failUnless(L7 in self.Doc.RootObjects)
     self.failUnless(L1 in self.Doc.RootObjects)
 
-    self.failUnless(len(self.Doc.Objects) == len(self.Doc.ToplogicalSortedObjects))
+    self.failUnless(len(self.Doc.Objects) == len(self.Doc.TopologicalSortedObjects))
 
     seqDic = {}
     i = 0
-    for obj in self.Doc.ToplogicalSortedObjects:
+    for obj in self.Doc.TopologicalSortedObjects:
         seqDic[obj] = i
         print(obj)
         i += 1
@@ -871,13 +871,13 @@ class UndoRedoCases(unittest.TestCase):
     grp = prt1.Group
     grp.append(grp2)
     
-    #to test: check if cross CS link works
-    #try:
-    #    prt1.Group=grp
-    #except:
-    #    pass
-    #else:
-    #    self.fail("No exception at cross geofeaturegroup links")
+    try:
+        prt1.Group=grp
+        self.Doc.recompute()
+    except:
+        pass
+    else:
+        self.fail("No exception at cross geofeaturegroup links")
     
     prt2.addObject(grp1)
     grp = grp1.Group

--- a/src/Mod/Test/Document.py
+++ b/src/Mod/Test/Document.py
@@ -866,19 +866,17 @@ class UndoRedoCases(unittest.TestCase):
     self.failUnless(prt1.hasObject(obj1)==False)
     self.failUnless(prt2.hasObject(grp2))
     self.failUnless(prt2.hasObject(obj1))
-       
-    #to test: try add obj to second group by .Group = []
-    grp = prt1.Group
-    grp.append(grp2)
-    
     try:
-        prt1.Group=grp
-        self.Doc.recompute()
+        grp = prt1.Group
+        grp.append(obj1)
+        prt1.Group = grp
     except:
-        pass
+        grp.remove(obj1)
+        self.failUnless(prt1.Group == grp)
     else:
-        self.fail("No exception at cross geofeaturegroup links")
-    
+        self.fail("No exception thrown when object is in multiple Groups")
+          
+    #it is not allowed to be in 2 Groups
     prt2.addObject(grp1)
     grp = grp1.Group
     grp.append(obj1)
@@ -889,7 +887,17 @@ class UndoRedoCases(unittest.TestCase):
     else:
         self.fail("No exception thrown when object is in multiple Groups")
    
-        
+    #to test: try add obj to second group by .Group = []
+    grp = prt1.Group
+    grp.append(grp2)
+    
+    try:
+        prt1.Group=grp
+        self.Doc.recompute()
+    except:
+        pass
+    else:
+        self.fail("No exception at cross geofeaturegroup links") 
 
   def tearDown(self):
     # closing doc

--- a/src/Mod/Test/Document.py
+++ b/src/Mod/Test/Document.py
@@ -264,80 +264,6 @@ class DocumentBasicCases(unittest.TestCase):
     self.Doc.removeObject(obj.Name)
     del obj
     
-  def testRecompute(self):
-      
-    # sequence to test recompute behaviour
-    #       L1---\    L7
-    #      /  \   \    |
-    #    L2   L3   \  L8
-    #   /  \ /  \  /
-    #  L4   L5   L6
-
-    L1 = self.Doc.addObject("App::FeatureTest","Label_1")
-    L2 = self.Doc.addObject("App::FeatureTest","Label_2")
-    L3 = self.Doc.addObject("App::FeatureTest","Label_3")
-    L4 = self.Doc.addObject("App::FeatureTest","Label_4")
-    L5 = self.Doc.addObject("App::FeatureTest","Label_5")
-    L6 = self.Doc.addObject("App::FeatureTest","Label_6")
-    L7 = self.Doc.addObject("App::FeatureTest","Label_7")
-    L8 = self.Doc.addObject("App::FeatureTest","Label_8")
-    L1.LinkList = [L2,L3,L6]
-    L2.Link = L4
-    L2.LinkList = [L5]
-    L3.LinkList = [L5,L6]
-    L7.Link = L8 #make second root
-
-    self.failUnless(L7 in self.Doc.RootObjects)
-    self.failUnless(L1 in self.Doc.RootObjects)
-
-    self.failUnless(len(self.Doc.Objects) == len(self.Doc.TopologicalSortedObjects))
-
-    seqDic = {}
-    i = 0
-    for obj in self.Doc.TopologicalSortedObjects:
-        seqDic[obj] = i
-        print(obj)
-        i += 1
-        
-    self.failUnless(seqDic[L2] > seqDic[L1])
-    self.failUnless(seqDic[L3] > seqDic[L1])
-    self.failUnless(seqDic[L5] > seqDic[L2])
-    self.failUnless(seqDic[L5] > seqDic[L3])
-    self.failUnless(seqDic[L5] > seqDic[L1])
-
-
-    self.failUnless((0, 0, 0, 0, 0, 0)==(L1.ExecCount,L2.ExecCount,L3.ExecCount,L4.ExecCount,L5.ExecCount,L6.ExecCount))
-    self.failUnless(self.Doc.recompute()==4)
-    self.failUnless((1, 1, 1, 0, 0, 0)==(L1.ExecCount,L2.ExecCount,L3.ExecCount,L4.ExecCount,L5.ExecCount,L6.ExecCount))
-    L5.touch()
-    self.failUnless((1, 1, 1, 0, 0, 0)==(L1.ExecCount,L2.ExecCount,L3.ExecCount,L4.ExecCount,L5.ExecCount,L6.ExecCount))
-    self.failUnless(self.Doc.recompute()==4)
-    self.failUnless((2, 2, 2, 0, 1, 0)==(L1.ExecCount,L2.ExecCount,L3.ExecCount,L4.ExecCount,L5.ExecCount,L6.ExecCount))
-    L4.touch()
-    self.failUnless(self.Doc.recompute()==3)
-    self.failUnless((3, 3, 2, 1, 1, 0)==(L1.ExecCount,L2.ExecCount,L3.ExecCount,L4.ExecCount,L5.ExecCount,L6.ExecCount))
-    L5.touch()
-    self.failUnless(self.Doc.recompute()==4)
-    self.failUnless((4, 4, 3, 1, 2, 0)==(L1.ExecCount,L2.ExecCount,L3.ExecCount,L4.ExecCount,L5.ExecCount,L6.ExecCount))
-    L6.touch()
-    self.failUnless(self.Doc.recompute()==3)
-    self.failUnless((5, 4, 4, 1, 2, 1)==(L1.ExecCount,L2.ExecCount,L3.ExecCount,L4.ExecCount,L5.ExecCount,L6.ExecCount))
-    L2.touch()
-    self.failUnless(self.Doc.recompute()==2)
-    self.failUnless((6, 5, 4, 1, 2, 1)==(L1.ExecCount,L2.ExecCount,L3.ExecCount,L4.ExecCount,L5.ExecCount,L6.ExecCount))
-    L1.touch()
-    self.failUnless(self.Doc.recompute()==1)
-    self.failUnless((7, 5, 4, 1, 2, 1)==(L1.ExecCount,L2.ExecCount,L3.ExecCount,L4.ExecCount,L5.ExecCount,L6.ExecCount))
-     
-    self.Doc.removeObject(L1.Name)
-    self.Doc.removeObject(L2.Name)
-    self.Doc.removeObject(L3.Name)
-    self.Doc.removeObject(L4.Name)
-    self.Doc.removeObject(L5.Name)
-    self.Doc.removeObject(L6.Name)
-    self.Doc.removeObject(L7.Name)
-    self.Doc.removeObject(L8.Name)
-    
   def testPropertyLink_Issue2902Part1(self):
     o1 = self.Doc.addObject("App::FeatureTest","test1")
     o2 = self.Doc.addObject("App::FeatureTest","test2")
@@ -528,6 +454,79 @@ class DocumentRecomputeCases(unittest.TestCase):
     self.L1.Link = self.L2
     self.L2.Link = self.L3
 
+  def testRecompute(self):
+      
+    # sequence to test recompute behaviour
+    #       L1---\    L7
+    #      /  \   \    |
+    #    L2   L3   \  L8
+    #   /  \ /  \  /
+    #  L4   L5   L6
+
+    L1 = self.Doc.addObject("App::FeatureTest","Label_1")
+    L2 = self.Doc.addObject("App::FeatureTest","Label_2")
+    L3 = self.Doc.addObject("App::FeatureTest","Label_3")
+    L4 = self.Doc.addObject("App::FeatureTest","Label_4")
+    L5 = self.Doc.addObject("App::FeatureTest","Label_5")
+    L6 = self.Doc.addObject("App::FeatureTest","Label_6")
+    L7 = self.Doc.addObject("App::FeatureTest","Label_7")
+    L8 = self.Doc.addObject("App::FeatureTest","Label_8")
+    L1.LinkList = [L2,L3,L6]
+    L2.Link = L4
+    L2.LinkList = [L5]
+    L3.LinkList = [L5,L6]
+    L7.Link = L8 #make second root
+
+    self.failUnless(L7 in self.Doc.RootObjects)
+    self.failUnless(L1 in self.Doc.RootObjects)
+
+    self.failUnless(len(self.Doc.Objects) == len(self.Doc.TopologicalSortedObjects))
+
+    seqDic = {}
+    i = 0
+    for obj in self.Doc.TopologicalSortedObjects:
+        seqDic[obj] = i
+        print(obj)
+        i += 1
+        
+    self.failUnless(seqDic[L2] > seqDic[L1])
+    self.failUnless(seqDic[L3] > seqDic[L1])
+    self.failUnless(seqDic[L5] > seqDic[L2])
+    self.failUnless(seqDic[L5] > seqDic[L3])
+    self.failUnless(seqDic[L5] > seqDic[L1])
+
+
+    self.failUnless((0, 0, 0, 0, 0, 0)==(L1.ExecCount,L2.ExecCount,L3.ExecCount,L4.ExecCount,L5.ExecCount,L6.ExecCount))
+    self.failUnless(self.Doc.recompute()==4)
+    self.failUnless((1, 1, 1, 0, 0, 0)==(L1.ExecCount,L2.ExecCount,L3.ExecCount,L4.ExecCount,L5.ExecCount,L6.ExecCount))
+    L5.touch()
+    self.failUnless((1, 1, 1, 0, 0, 0)==(L1.ExecCount,L2.ExecCount,L3.ExecCount,L4.ExecCount,L5.ExecCount,L6.ExecCount))
+    self.failUnless(self.Doc.recompute()==4)
+    self.failUnless((2, 2, 2, 0, 1, 0)==(L1.ExecCount,L2.ExecCount,L3.ExecCount,L4.ExecCount,L5.ExecCount,L6.ExecCount))
+    L4.touch()
+    self.failUnless(self.Doc.recompute()==3)
+    self.failUnless((3, 3, 2, 1, 1, 0)==(L1.ExecCount,L2.ExecCount,L3.ExecCount,L4.ExecCount,L5.ExecCount,L6.ExecCount))
+    L5.touch()
+    self.failUnless(self.Doc.recompute()==4)
+    self.failUnless((4, 4, 3, 1, 2, 0)==(L1.ExecCount,L2.ExecCount,L3.ExecCount,L4.ExecCount,L5.ExecCount,L6.ExecCount))
+    L6.touch()
+    self.failUnless(self.Doc.recompute()==3)
+    self.failUnless((5, 4, 4, 1, 2, 1)==(L1.ExecCount,L2.ExecCount,L3.ExecCount,L4.ExecCount,L5.ExecCount,L6.ExecCount))
+    L2.touch()
+    self.failUnless(self.Doc.recompute()==2)
+    self.failUnless((6, 5, 4, 1, 2, 1)==(L1.ExecCount,L2.ExecCount,L3.ExecCount,L4.ExecCount,L5.ExecCount,L6.ExecCount))
+    L1.touch()
+    self.failUnless(self.Doc.recompute()==1)
+    self.failUnless((7, 5, 4, 1, 2, 1)==(L1.ExecCount,L2.ExecCount,L3.ExecCount,L4.ExecCount,L5.ExecCount,L6.ExecCount))
+     
+    self.Doc.removeObject(L1.Name)
+    self.Doc.removeObject(L2.Name)
+    self.Doc.removeObject(L3.Name)
+    self.Doc.removeObject(L4.Name)
+    self.Doc.removeObject(L5.Name)
+    self.Doc.removeObject(L6.Name)
+    self.Doc.removeObject(L7.Name)
+    self.Doc.removeObject(L8.Name)
 
   def tearDown(self):
     #closing doc
@@ -758,6 +757,15 @@ class UndoRedoCases(unittest.TestCase):
     self.assertEqual(self.Doc.RedoNames,[])
     self.assertEqual(self.Doc.RedoCount,0)
 
+  def tearDown(self):
+    # closing doc
+    FreeCAD.closeDocument("UndoTest")
+
+class DocumentGroupCases(unittest.TestCase):
+    
+  def setUp(self):
+    self.Doc = FreeCAD.newDocument("GroupTests")
+
   def testGroup(self):
     # Add an object to the group
     L2 = self.Doc.addObject("App::FeatureTest","Label_2")
@@ -886,7 +894,7 @@ class UndoRedoCases(unittest.TestCase):
         pass
     else:
         self.fail("No exception thrown when object is in multiple Groups")
-   
+          
     #cross linking between GeoFeatureGroups is not allowed
     self.Doc.recompute()
     box = self.Doc.addObject("Part::Box","Box")
@@ -913,11 +921,18 @@ class UndoRedoCases(unittest.TestCase):
     prt2.addObject(box) #this time addObject should move all dependencies to the new part
     self.Doc.recompute()
     self.failUnless(fus.State[0] == 'Up-to-date')
+    
+    #grouping must be resilient against cyclic links and not crash: #issue 0002567
+    prt1.addObject(prt2)
+    grp = prt2.Group
+    grp.append(prt1)
+    prt2.Group = grp 
+    prt1.Group = [prt1]
+    prt2.Group = [prt2]
 
   def tearDown(self):
     # closing doc
-    FreeCAD.closeDocument("UndoTest")
-
+    FreeCAD.closeDocument("GroupTests")
 
 class DocumentPlatformCases(unittest.TestCase):
   def setUp(self):
@@ -981,6 +996,7 @@ class DocumentPlatformCases(unittest.TestCase):
   def tearDown(self):
     #closing doc
     FreeCAD.closeDocument("PlatformTests")
+    
 class DocumentFileIncludeCases(unittest.TestCase):
   def setUp(self):
     self.Doc = FreeCAD.newDocument("FileIncludeTests")


### PR DESCRIPTION
Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [x] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR once it is merged.

---


This pull request brings multiple enhancements to freecads groups:
- it fixes and enables the new backlink structures to improve performance for many group operations
- It makes link properties scoped, a link can now define where he is allowed to link in respect to geofeaturegroups (default is into the local group only)
- new link types for different scoped links to be used from python
- report error on wrong links during recompute
- New global toolbar for groups 
- numerous bug fixes for tree view and group handling