### PR TITLE
PDN: Fix Revolution, Loft & Pipe claimChildren, auto-activate Body

### DIFF
--- a/src/Mod/PartDesign/App/FeatureRevolution.cpp
+++ b/src/Mod/PartDesign/App/FeatureRevolution.cpp
@@ -103,7 +103,11 @@ App::DocumentObjectExecReturn *Revolution::execute(void)
     }
 
     // update Axis from ReferenceAxis
-    updateAxis();
+    try {
+        updateAxis();
+    } catch (const Base::Exception& e) {
+        return new App::DocumentObjectExecReturn(e.what());
+    }
 
     // get revolve axis
     Base::Vector3d b = Base.getValue();

--- a/src/Mod/PartDesign/App/FeatureRevolution.cpp
+++ b/src/Mod/PartDesign/App/FeatureRevolution.cpp
@@ -37,6 +37,7 @@
 #endif
 
 #include <Base/Axis.h>
+#include <Base/Console.h>
 #include <Base/Exception.h>
 #include <Base/Placement.h>
 #include <Base/Tools.h>
@@ -186,7 +187,7 @@ bool Revolution::suggestReversed(void)
     try {
         updateAxis();
     } catch (const Base::Exception& e) {
-        return new App::DocumentObjectExecReturn(e.what());
+        return false;
     }
 
     return ProfileBased::getReversedAngle(Base.getValue(), Axis.getValue()) < 0.0;

--- a/src/Mod/PartDesign/App/FeatureRevolution.cpp
+++ b/src/Mod/PartDesign/App/FeatureRevolution.cpp
@@ -183,7 +183,12 @@ App::DocumentObjectExecReturn *Revolution::execute(void)
 
 bool Revolution::suggestReversed(void)
 {
-    updateAxis();
+    try {
+        updateAxis();
+    } catch (const Base::Exception& e) {
+        return new App::DocumentObjectExecReturn(e.what());
+    }
+
     return ProfileBased::getReversedAngle(Base.getValue(), Axis.getValue()) < 0.0;
 }
 

--- a/src/Mod/PartDesign/App/FeatureSketchBased.cpp
+++ b/src/Mod/PartDesign/App/FeatureSketchBased.cpp
@@ -971,19 +971,19 @@ void ProfileBased::getAxis(const App::DocumentObject *pcReferenceAxis, const std
         dir = line->getDirection();
 
         // Check that axis is perpendicular with sketch plane!
-        if (sketchplane.Axis().Direction().Angle(gp_Dir(dir.x, dir.y, dir.z))< Precision::Angular())
-             throw Base::Exception("Rotation axis must not be perpendicular with the sketch plane");
+        if (sketchplane.Axis().Direction().IsParallel(gp_Dir(dir.x, dir.y, dir.z), Precision::Angular()))
+            throw Base::Exception("Rotation axis must not be perpendicular with the sketch plane");
         return;
     }
 
     if (pcReferenceAxis->getTypeId().isDerivedFrom(App::Line::getClassTypeId())) {
         const App::Line* line = static_cast<const App::Line*>(pcReferenceAxis);
         base = Base::Vector3d(0,0,0);
-        line->Placement.getValue().multVec (Base::Vector3d (1,0,0), dir);
+        line->Placement.getValue().multVec(Base::Vector3d (1,0,0), dir);
 
         // Check that axis is perpendicular with sketch plane!
-        if (sketchplane.Axis().Direction().Angle(gp_Dir(dir.x, dir.y, dir.z)) < Precision::Angular())
-             throw Base::Exception("Rotation axis must not be perpendicular with the sketch plane");
+        if (sketchplane.Axis().Direction().IsParallel(gp_Dir(dir.x, dir.y, dir.z), Precision::Angular()))
+            throw Base::Exception("Rotation axis must not be perpendicular with the sketch plane");
         return;
     }
 
@@ -1008,7 +1008,7 @@ void ProfileBased::getAxis(const App::DocumentObject *pcReferenceAxis, const std
             dir = Base::Vector3d(d.X(), d.Y(), d.Z());
             // Check that axis is co-planar with sketch plane!
             // Check that axis is perpendicular with sketch plane!
-            if (sketchplane.Axis().Direction().Angle(d) < Precision::Angular())
+            if (sketchplane.Axis().Direction().IsParallel(d, Precision::Angular()))
                 throw Base::Exception("Rotation axis must not be perpendicular with the sketch plane");
             return;
         } else {

--- a/src/Mod/PartDesign/Gui/Utils.cpp
+++ b/src/Mod/PartDesign/Gui/Utils.cpp
@@ -63,15 +63,23 @@ PartDesign::Body *getBody(bool messageIfNot)
 {
     PartDesign::Body * activeBody = nullptr;
     Gui::MDIView *activeView = Gui::Application::Instance->activeView();
+    bool singleBodyDocument = activeView->getAppDocument()->
+        countObjectsOfType(PartDesign::Body::getClassTypeId()) == 1;
 
     if (activeView) {
         if ( PartDesignGui::assureModernWorkflow ( activeView->getAppDocument() ) ) {
             activeBody = activeView->getActiveObject<PartDesign::Body*>(PDBODYKEY);
 
+            if (!activeBody && singleBodyDocument) {
+                Gui::Command::doCommand( Gui::Command::Gui,
+                    "Gui.activeView().setActiveObject('pdbody',App.ActiveDocument.findObjects('PartDesign::Body')[0])");
+                activeBody = activeView->getActiveObject<PartDesign::Body*>(PDBODYKEY);
+                return activeBody;
+            }
             if (!activeBody && messageIfNot) {
                 QMessageBox::warning(Gui::getMainWindow(), QObject::tr("No active Body"),
                     QObject::tr("In order to use PartDesign you need an active Body object in the document. "
-                                "Please make one active (double click) or create one. If you have a legacy document "
+                                "Please make one active (double click) or create one.\n\nIf you have a legacy document "
                                 "with PartDesign objects without Body, use the transfer function in "
                                 "PartDesign to put them into a Body."
                                 ));

--- a/src/Mod/PartDesign/Gui/ViewProviderLoft.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderLoft.cpp
@@ -64,7 +64,7 @@ std::vector<App::DocumentObject*> ViewProviderLoft::claimChildren(void)const
         temp.push_back(sketch);
 
     for(App::DocumentObject* obj : pcLoft->Sections.getValues()) {
-        if (obj != NULL)
+        if (obj != NULL && obj->isDerivedFrom(Part::Part2DObject::getClassTypeId()))
             temp.push_back(obj);
     }
 

--- a/src/Mod/PartDesign/Gui/ViewProviderPipe.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderPipe.cpp
@@ -64,11 +64,11 @@ std::vector<App::DocumentObject*> ViewProviderPipe::claimChildren(void)const
         temp.push_back(sketch);
 
     App::DocumentObject* spine = pcPipe->Spine.getValue();
-    if (spine != NULL)
+    if (spine != NULL && spine->isDerivedFrom(Part::Part2DObject::getClassTypeId()))
         temp.push_back(spine);
 
     App::DocumentObject* auxspine = pcPipe->AuxillerySpine.getValue();
-    if (auxspine != NULL)
+    if (auxspine != NULL && auxspine->isDerivedFrom(Part::Part2DObject::getClassTypeId()))
         temp.push_back(auxspine);
 
     return temp;


### PR DESCRIPTION
Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [X] Branch rebased on latest master `git pull --rebase upstream master`
- [X] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [X] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [X] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR once it is merged.

---
Revolution was checking if the axis of revolution and sketch normal were 0 radians apart in space, which failed in the case they were pi radians apart, i.e. anti-parallel.

Loft & Pipe claimChildren amended to only pick up sketches.

Body auto-activated when tool is used in a document with only 1 body.