### PR TITLE
FEM: Fenics: issue #3038: fixes missing isatty() function in Python wrapper classes for stderr and stdout

### DIFF
--- a/src/Gui/PythonConsolePy.cpp
+++ b/src/Gui/PythonConsolePy.cpp
@@ -46,6 +46,7 @@ void PythonStdout::init_type()
     behaviors().supportRepr();
     add_varargs_method("write",&PythonStdout::write,"write()");
     add_varargs_method("flush",&PythonStdout::flush,"flush()");
+    add_noargs_method("isatty",&PythonStdout::isatty,"isatty()");
 }
 
 PythonStdout::PythonStdout(PythonConsole *pc)
@@ -113,6 +114,11 @@ Py::Object PythonStdout::flush(const Py::Tuple&)
     return Py::None();
 }
 
+Py::Object PythonStdout::isatty()
+{
+    return Py::False();
+}
+
 // -------------------------------------------------------------------------
 
 void PythonStderr::init_type()
@@ -123,6 +129,7 @@ void PythonStderr::init_type()
     behaviors().supportRepr();
     add_varargs_method("write",&PythonStderr::write,"write()");
     add_varargs_method("flush",&PythonStderr::flush,"flush()");
+    add_noargs_method("isatty",&PythonStderr::isatty,"isatty()");
 }
 
 PythonStderr::PythonStderr(PythonConsole *pc)
@@ -190,6 +197,11 @@ Py::Object PythonStderr::flush(const Py::Tuple&)
     return Py::None();
 }
 
+Py::Object PythonStderr::isatty()
+{
+    return Py::False();
+}
+
 // -------------------------------------------------------------------------
 
 void OutputStdout::init_type()
@@ -200,6 +212,7 @@ void OutputStdout::init_type()
     behaviors().supportRepr();
     add_varargs_method("write",&OutputStdout::write,"write()");
     add_varargs_method("flush",&OutputStdout::flush,"flush()");
+    add_noargs_method("isatty",&OutputStdout::isatty,"isatty()");
 }
 
 OutputStdout::OutputStdout()
@@ -264,6 +277,12 @@ Py::Object OutputStdout::flush(const Py::Tuple&)
     return Py::None();
 }
 
+Py::Object OutputStdout::isatty()
+{
+    return Py::False();
+}
+
+
 // -------------------------------------------------------------------------
 
 void OutputStderr::init_type()
@@ -274,6 +293,7 @@ void OutputStderr::init_type()
     behaviors().supportRepr();
     add_varargs_method("write",&OutputStderr::write,"write()");
     add_varargs_method("flush",&OutputStderr::flush,"flush()");
+    add_noargs_method("isatty",&OutputStderr::isatty,"isatty()");
 }
 
 OutputStderr::OutputStderr()
@@ -337,6 +357,12 @@ Py::Object OutputStderr::flush(const Py::Tuple&)
 {
     return Py::None();
 }
+
+Py::Object OutputStderr::isatty()
+{
+    return Py::False();
+}
+
 
 // -------------------------------------------------------------------------
 

--- a/src/Gui/PythonConsolePy.h
+++ b/src/Gui/PythonConsolePy.h
@@ -54,6 +54,7 @@ public:
     Py::Object repr();
     Py::Object write(const Py::Tuple&);
     Py::Object flush(const Py::Tuple&);
+    Py::Object isatty();
 };
 
 /**
@@ -79,6 +80,7 @@ public:
     Py::Object repr();
     Py::Object write(const Py::Tuple&);
     Py::Object flush(const Py::Tuple&);
+    Py::Object isatty();
 };
 
 /**
@@ -101,6 +103,7 @@ public:
     Py::Object repr();
     Py::Object write(const Py::Tuple&);
     Py::Object flush(const Py::Tuple&);
+    Py::Object isatty();
 };
 
 /**
@@ -123,6 +126,7 @@ public:
     Py::Object repr();
     Py::Object write(const Py::Tuple&);
     Py::Object flush(const Py::Tuple&);
+    Py::Object isatty();
 };
 
 /**


### PR DESCRIPTION
* Implemented missing isatty() function into Python wrapper classes for out and err streams
* Now it is possible to perform `import fenics` in a macro

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [X] Branch rebased on latest master `git pull --rebase upstream master`
- [X] Unit tests confirmed to pass by run ning `./bin/FreeCAD --run-test 0`
- [X] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [X] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR once it is merged.

---
