### PR TITLE
Quantity formatting / units

### DIFF
--- a/src/Base/QuantityLexer.c
+++ b/src/Base/QuantityLexer.c
@@ -183,7 +183,7 @@ extern FILE *yyin, *yyout;
 	do \
 		{ \
 		/* Undo effects of setting up yytext. */ \
-        int yyless_macro_arg = (n); \
+        yy_size_t yyless_macro_arg = (n); \
         YY_LESS_LINENO(yyless_macro_arg);\
 		*yy_cp = (yy_hold_char); \
 		YY_RESTORE_YY_MORE_OFFSET \
@@ -211,7 +211,7 @@ struct yy_buffer_state
 	/* Number of characters read into yy_ch_buf, not including EOB
 	 * characters.
 	 */
-	int yy_n_chars;
+	yy_size_t yy_n_chars;
 
 	/* Whether we "own" the buffer - i.e., we know we created it,
 	 * and can realloc() it to grow it, and should free() it to
@@ -281,7 +281,7 @@ static YY_BUFFER_STATE * yy_buffer_stack = 0; /**< Stack as an array. */
 
 /* yy_hold_char holds the character lost when yytext is formed. */
 static char yy_hold_char;
-static int yy_n_chars;		/* number of characters read into yy_ch_buf */
+static yy_size_t yy_n_chars;		/* number of characters read into yy_ch_buf */
 yy_size_t yyleng;
 
 /* Points to current character in buffer. */
@@ -377,8 +377,8 @@ static void yy_fatal_error (yyconst char msg[]  );
 	*yy_cp = '\0'; \
 	(yy_c_buf_p) = yy_cp;
 
-#define YY_NUM_RULES 99
-#define YY_END_OF_BUFFER 100
+#define YY_NUM_RULES 100
+#define YY_END_OF_BUFFER 101
 /* This struct is not used in this scanner,
    but its presence is necessary. */
 struct yy_trans_info
@@ -386,28 +386,28 @@ struct yy_trans_info
 	flex_int32_t yy_verify;
 	flex_int32_t yy_nxt;
 	};
-static yyconst flex_int16_t yy_accept[189] =
+static yyconst flex_int16_t yy_accept[190] =
     {   0,
-        0,    0,    0,    0,  100,   98,    4,    5,   38,   40,
-        6,   98,    7,   98,   76,   27,   98,   98,   67,   31,
-       98,   51,   98,   98,   98,   65,    1,   98,   98,   98,
-       81,   98,   21,   26,   98,   98,   17,   15,   98,   98,
-       98,   98,   24,   23,   98,   98,   98,   98,    3,   99,
-        2,    5,   79,   77,   78,   76,   76,    0,   70,    0,
-       30,   53,    0,   68,   55,    0,   66,   71,    0,    0,
-        0,    0,   36,   13,    0,    0,    0,   14,    0,   39,
-        0,   37,   29,   52,    0,   22,   16,    0,   45,    0,
-       28,   32,   54,    0,   20,   44,   12,    0,    9,   47,
+        0,    0,    0,    0,  101,   99,    4,    5,   38,   40,
+        6,   99,    7,   99,   77,   76,   27,   99,   99,   67,
+       31,   99,   51,   99,   99,   99,   65,    1,   99,   99,
+       99,   82,   99,   21,   26,   99,   99,   17,   15,   99,
+       99,   99,   99,   24,   23,   99,   99,   99,   99,    3,
+      100,    2,    5,   80,   78,   79,   77,   77,    0,   70,
+        0,   30,   53,    0,   68,   55,    0,   66,   71,    0,
+        0,    0,    0,   36,   13,    0,    0,    0,   14,    0,
+       39,    0,   37,   29,   52,    0,   22,   16,    0,   45,
+        0,   28,   32,   54,    0,   20,   44,   12,    0,    9,
 
-       80,    0,    0,    0,    0,    0,   48,    0,    0,   34,
-        0,   18,   10,   43,   72,    0,    0,    0,    0,   78,
-        0,   76,    0,    0,   76,   58,   57,    0,   69,   88,
-        0,    0,    0,   86,   49,   73,   87,   75,   56,   64,
-       50,   46,   90,    0,   42,   25,   89,   35,   92,   63,
-       74,   93,    0,   95,    0,    0,   33,    0,   19,   11,
-        8,    0,   79,    0,   77,    0,   78,    0,   76,   59,
-       82,   83,   84,    0,    0,   94,   97,   96,   41,    0,
-        0,   85,   91,   60,   61,    0,   62,    0
+       47,   81,    0,    0,    0,    0,    0,   48,    0,    0,
+       34,    0,   18,   10,   43,   72,    0,    0,    0,    0,
+       79,    0,   77,    0,    0,   77,   58,   57,    0,   69,
+       89,    0,    0,    0,   87,   49,   73,   88,   75,   56,
+       64,   50,   46,   91,    0,   42,   25,   90,   35,   93,
+       63,   74,   94,    0,   96,    0,    0,   33,    0,   19,
+       11,    8,    0,   80,    0,   78,    0,   79,    0,   77,
+       59,   83,   84,   85,    0,    0,   95,   98,   97,   41,
+        0,    0,   86,   92,   60,   61,    0,   62,    0
     } ;
 
 static yyconst YY_CHAR yy_ec[256] =
@@ -452,99 +452,100 @@ static yyconst YY_CHAR yy_meta[59] =
         1,    1,    1,    1,    1,    1,    1,    1
     } ;
 
-static yyconst flex_uint16_t yy_base[190] =
+static yyconst flex_uint16_t yy_base[191] =
     {   0,
-        0,    0,   56,   57,  309,  310,  310,  305,  310,  310,
-      310,   50,  310,   54,   61,  310,  282,  283,  310,  310,
-       64,  265,  275,  261,  287,  255,  310,   46,   48,   49,
-      250,  252,  256,  310,  256,   76,   53,   86,  256,  243,
-       63,  265,   70,   67,   95,  261,   57,  239,  310,  310,
-      310,  288,  120,  127,  134,  144,  158,  167,  310,  261,
-      310,  310,  260,  310,  310,  243,  241,  310,  240,  243,
-      247,  254,  310,  310,  236,  234,  245,  310,  236,  310,
-      237,  310,  310,  310,  248,  310,  310,  239,   84,  240,
-      310,  310,  310,  232,  310,   63,  310,   88,  310,  310,
+        0,    0,   56,   57,  317,  318,  318,  313,  318,  318,
+      318,   50,  318,   54,   61,   69,  318,  290,  291,  318,
+      318,   73,  273,  283,  269,  295,  263,  318,   59,   59,
+       60,  258,  260,  264,  318,  264,   88,   62,   98,  264,
+      251,   70,  273,   77,   90,  107,  269,   42,  247,  318,
+      318,  318,  296,  132,  139,  146,  156,  170,  179,  318,
+      269,  318,  318,  268,  318,  318,  251,  249,  318,  248,
+      251,  255,  262,  318,  318,  244,  242,  253,  318,  244,
+      318,  245,  318,  318,  318,  256,  318,  318,  247,   36,
+      248,  318,  318,  318,  207,  318,   76,  318,   93,  318,
 
-      310,  224,  235,  239,  196,  191,  310,  186,  181,  310,
-      179,  310,  310,  310,  310,  162,  166,  176,  187,  192,
-      201,  205,  217,  151,  221,  310,  310,  166,  310,  310,
-      161,  154,  152,  310,  310,  310,  310,  310,  310,  310,
-      310,  310,  180,  139,  310,  310,  310,  310,  310,  310,
-      310,  137,  112,  118,  104,  105,  310,  107,  310,  310,
-      310,  228,  232,  236,  240,  244,  248,  252,  256,  310,
-      310,  310,  130,  131,   91,  310,  310,  310,  310,   84,
-       80,  310,  310,  310,  310,   36,  310,  310,   69
+      318,  318,  199,  202,  203,  192,  187,  318,  182,  177,
+      318,  165,  318,  318,  318,  318,  174,  151,  188,  199,
+      204,  213,  217,  229,  163,  233,  318,  318,  159,  318,
+      318,  150,  144,  130,  318,  318,  318,  318,  318,  318,
+      318,  318,  318,  154,  119,  318,  318,  318,  318,  318,
+      318,  318,  126,  114,  119,  106,  103,  318,   99,  318,
+      318,  318,  240,  244,  248,  252,  256,  260,  264,  268,
+      318,  318,  318,  126,  126,   91,  318,  318,  318,  318,
+       85,   84,  318,  318,  318,  318,   64,  318,  318,   86
     } ;
 
-static yyconst flex_int16_t yy_def[190] =
+static yyconst flex_int16_t yy_def[191] =
     {   0,
-      188,    1,  189,  189,  188,  188,  188,  188,  188,  188,
-      188,  188,  188,  188,  188,  188,  188,  188,  188,  188,
-      188,  188,  188,  188,  188,  188,  188,  188,  188,  188,
-      188,  188,  188,  188,  188,  188,  188,  188,  188,  188,
-      188,  188,  188,  188,  188,  188,  188,  188,  188,  188,
-      188,  188,  188,  188,  188,  188,  188,  188,  188,  188,
-      188,  188,  188,  188,  188,  188,  188,  188,  188,  188,
-      188,  188,  188,  188,  188,  188,  188,  188,  188,  188,
-      188,  188,  188,  188,  188,  188,  188,  188,  188,  188,
-      188,  188,  188,  188,  188,  188,  188,  188,  188,  188,
+      189,    1,  190,  190,  189,  189,  189,  189,  189,  189,
+      189,  189,  189,  189,  189,  189,  189,  189,  189,  189,
+      189,  189,  189,  189,  189,  189,  189,  189,  189,  189,
+      189,  189,  189,  189,  189,  189,  189,  189,  189,  189,
+      189,  189,  189,  189,  189,  189,  189,  189,  189,  189,
+      189,  189,  189,  189,  189,  189,  189,  189,  189,  189,
+      189,  189,  189,  189,  189,  189,  189,  189,  189,  189,
+      189,  189,  189,  189,  189,  189,  189,  189,  189,  189,
+      189,  189,  189,  189,  189,  189,  189,  189,  189,  189,
+      189,  189,  189,  189,  189,  189,  189,  189,  189,  189,
 
-      188,  188,  188,  188,  188,  188,  188,  188,  188,  188,
-      188,  188,  188,  188,  188,  188,  188,  188,  188,  188,
-      188,  188,  188,  188,  188,  188,  188,  188,  188,  188,
-      188,  188,  188,  188,  188,  188,  188,  188,  188,  188,
-      188,  188,  188,  188,  188,  188,  188,  188,  188,  188,
-      188,  188,  188,  188,  188,  188,  188,  188,  188,  188,
-      188,  188,  188,  188,  188,  188,  188,  188,  188,  188,
-      188,  188,  188,  188,  188,  188,  188,  188,  188,  188,
-      188,  188,  188,  188,  188,  188,  188,    0,  188
+      189,  189,  189,  189,  189,  189,  189,  189,  189,  189,
+      189,  189,  189,  189,  189,  189,  189,  189,  189,  189,
+      189,  189,  189,  189,  189,  189,  189,  189,  189,  189,
+      189,  189,  189,  189,  189,  189,  189,  189,  189,  189,
+      189,  189,  189,  189,  189,  189,  189,  189,  189,  189,
+      189,  189,  189,  189,  189,  189,  189,  189,  189,  189,
+      189,  189,  189,  189,  189,  189,  189,  189,  189,  189,
+      189,  189,  189,  189,  189,  189,  189,  189,  189,  189,
+      189,  189,  189,  189,  189,  189,  189,  189,    0,  189
     } ;
 
-static yyconst flex_uint16_t yy_nxt[369] =
+static yyconst flex_uint16_t yy_nxt[377] =
     {   0,
         6,    7,    8,    9,   10,   11,   11,   12,   13,   14,
-       15,   15,   15,   15,   16,   17,    6,   18,   19,   20,
-       21,   22,   23,   24,   25,   26,   27,    6,   28,    6,
-       29,   30,   31,   32,   33,   34,   35,   36,   37,   38,
-       39,   40,   41,    6,   42,   43,   44,   45,    6,    6,
-       46,    6,    6,    6,    6,    6,   47,   48,   50,   50,
-       53,   53,   53,   53,   54,   54,   54,   54,   55,   49,
-       56,   57,   57,   57,   57,   69,   70,   58,   61,   73,
-      187,   77,   89,   51,   51,   62,   63,   74,   78,   75,
-       83,   71,   72,   58,   90,  108,   76,   84,   85,  101,
+       15,   16,   15,   15,   17,   18,    6,   19,   20,   21,
+       22,   23,   24,   25,   26,   27,   28,    6,   29,    6,
+       30,   31,   32,   33,   34,   35,   36,   37,   38,   39,
+       40,   41,   42,    6,   43,   44,   45,   46,    6,    6,
+       47,    6,    6,    6,    6,    6,   48,   49,   51,   51,
+       54,   54,   54,   54,   55,   55,   55,   55,   56,  142,
+       57,   58,   58,   58,   58,  143,   56,   59,   57,   58,
+       58,   58,   58,   52,   52,   59,   50,   62,   70,   71,
+       74,   90,   78,   59,   63,   64,  116,  117,   75,   79,
 
-       91,  145,  109,  146,  102,   92,  105,   93,  103,   94,
-       86,  115,  116,  106,  110,   87,  107,  141,  111,  147,
-       95,   88,   96,  142,  186,   97,  148,   98,  185,  112,
-       53,   53,   53,   53,  113,  184,  118,   54,   54,   54,
-       54,  183,  182,  119,  120,  120,  120,  120,  181,  180,
-      121,  179,  118,  178,  122,  122,  122,  122,  177,  119,
-      123,  125,  125,  125,  125,   55,  121,   56,   57,   57,
-       57,   57,  176,  124,   58,  124,  123,  125,  125,  125,
-      125,  157,  162,  175,  162,  158,  163,  163,  163,  163,
-       58,  174,  173,  164,  172,  164,  159,  165,  165,  165,
+       76,   59,   84,   91,   72,   73,  102,   77,  188,   85,
+       86,  103,   92,  106,  146,  104,  147,   93,  109,   94,
+      107,   95,   87,  108,  148,  110,  111,   88,  187,  186,
+      112,  149,   96,   89,   97,  185,  184,   98,  183,   99,
+      182,  113,   54,   54,   54,   54,  114,  181,  119,   55,
+       55,   55,   55,  180,  179,  120,  121,  121,  121,  121,
+      178,  177,  122,  176,  119,  175,  123,  123,  123,  123,
+      174,  120,  124,  126,  126,  126,  126,   56,  122,   57,
+       58,   58,   58,   58,  173,  125,   59,  125,  124,  126,
+      126,  126,  126,  158,  163,  172,  163,  159,  164,  164,
 
-      165,  160,  120,  120,  120,  120,  171,  166,  121,  166,
-      170,  167,  167,  167,  167,  122,  122,  122,  122,  161,
-      156,  123,  155,  168,  121,  168,  154,  169,  169,  169,
-      169,  125,  125,  125,  125,  153,  152,  123,  163,  163,
-      163,  163,  163,  163,  163,  163,  165,  165,  165,  165,
-      165,  165,  165,  165,  167,  167,  167,  167,  167,  167,
-      167,  167,  169,  169,  169,  169,  169,  169,  169,  169,
-      151,  150,  149,  144,  143,  140,  139,  138,  137,  136,
-      135,  134,  133,  132,  131,  130,  129,  128,  127,  126,
-       52,  117,  114,  104,  100,   99,   82,   81,   80,   79,
+      164,  164,   59,  171,  162,  165,  157,  165,  160,  166,
+      166,  166,  166,  161,  121,  121,  121,  121,  156,  167,
+      122,  167,  155,  168,  168,  168,  168,  123,  123,  123,
+      123,  154,  153,  124,  152,  169,  122,  169,  151,  170,
+      170,  170,  170,  126,  126,  126,  126,  150,  145,  124,
+      164,  164,  164,  164,  164,  164,  164,  164,  166,  166,
+      166,  166,  166,  166,  166,  166,  168,  168,  168,  168,
+      168,  168,  168,  168,  170,  170,  170,  170,  170,  170,
+      170,  170,  144,  141,  140,  139,  138,  137,  136,  135,
+      134,  133,  132,  131,  130,  129,  128,  127,   53,  118,
 
-       68,   67,   66,   65,   64,   60,   59,   52,  188,    5,
-      188,  188,  188,  188,  188,  188,  188,  188,  188,  188,
-      188,  188,  188,  188,  188,  188,  188,  188,  188,  188,
-      188,  188,  188,  188,  188,  188,  188,  188,  188,  188,
-      188,  188,  188,  188,  188,  188,  188,  188,  188,  188,
-      188,  188,  188,  188,  188,  188,  188,  188,  188,  188,
-      188,  188,  188,  188,  188,  188,  188,  188
+      115,  105,  101,  100,   83,   82,   81,   80,   69,   68,
+       67,   66,   65,   61,   60,   53,  189,    5,  189,  189,
+      189,  189,  189,  189,  189,  189,  189,  189,  189,  189,
+      189,  189,  189,  189,  189,  189,  189,  189,  189,  189,
+      189,  189,  189,  189,  189,  189,  189,  189,  189,  189,
+      189,  189,  189,  189,  189,  189,  189,  189,  189,  189,
+      189,  189,  189,  189,  189,  189,  189,  189,  189,  189,
+      189,  189,  189,  189,  189,  189
     } ;
 
-static yyconst flex_int16_t yy_chk[369] =
+static yyconst flex_int16_t yy_chk[377] =
     {   0,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
@@ -552,40 +553,41 @@ static yyconst flex_int16_t yy_chk[369] =
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    1,    1,    3,    4,
-       12,   12,   12,   12,   14,   14,   14,   14,   15,  189,
-       15,   15,   15,   15,   15,   28,   28,   15,   21,   29,
-      186,   30,   37,    3,    4,   21,   21,   29,   30,   29,
-       36,   28,   28,   15,   37,   44,   29,   36,   36,   41,
+       12,   12,   12,   12,   14,   14,   14,   14,   15,   90,
+       15,   15,   15,   15,   15,   90,   16,   15,   16,   16,
+       16,   16,   16,    3,    4,   16,  190,   22,   29,   29,
+       30,   38,   31,   15,   22,   22,   48,   48,   30,   31,
 
-       38,   96,   44,   96,   41,   38,   43,   38,   41,   38,
-       36,   47,   47,   43,   45,   36,   43,   89,   45,   98,
-       38,   36,   38,   89,  181,   38,   98,   38,  180,   45,
-       53,   53,   53,   53,   45,  175,   53,   54,   54,   54,
-       54,  174,  173,   54,   55,   55,   55,   55,  158,  156,
-       55,  155,   53,  154,   56,   56,   56,   56,  153,   54,
-       56,  124,  124,  124,  124,   57,   55,   57,   57,   57,
-       57,   57,  152,   58,   57,   58,   56,   58,   58,   58,
-       58,  116,  118,  144,  118,  116,  118,  118,  118,  118,
-       57,  143,  133,  119,  132,  119,  116,  119,  119,  119,
+       30,   16,   37,   38,   29,   29,   42,   30,  187,   37,
+       37,   42,   39,   44,   97,   42,   97,   39,   45,   39,
+       44,   39,   37,   44,   99,   45,   46,   37,  182,  181,
+       46,   99,   39,   37,   39,  176,  175,   39,  174,   39,
+      159,   46,   54,   54,   54,   54,   46,  157,   54,   55,
+       55,   55,   55,  156,  155,   55,   56,   56,   56,   56,
+      154,  153,   56,  145,   54,  144,   57,   57,   57,   57,
+      134,   55,   57,  125,  125,  125,  125,   58,   56,   58,
+       58,   58,   58,   58,  133,   59,   58,   59,   57,   59,
+       59,   59,   59,  117,  119,  132,  119,  117,  119,  119,
 
-      119,  116,  120,  120,  120,  120,  131,  121,  120,  121,
-      128,  121,  121,  121,  121,  122,  122,  122,  122,  117,
-      111,  122,  109,  123,  120,  123,  108,  123,  123,  123,
-      123,  125,  125,  125,  125,  106,  105,  122,  162,  162,
-      162,  162,  163,  163,  163,  163,  164,  164,  164,  164,
-      165,  165,  165,  165,  166,  166,  166,  166,  167,  167,
-      167,  167,  168,  168,  168,  168,  169,  169,  169,  169,
-      104,  103,  102,   94,   90,   88,   85,   81,   79,   77,
-       76,   75,   72,   71,   70,   69,   67,   66,   63,   60,
-       52,   48,   46,   42,   40,   39,   35,   33,   32,   31,
+      119,  119,   58,  129,  118,  120,  112,  120,  117,  120,
+      120,  120,  120,  117,  121,  121,  121,  121,  110,  122,
+      121,  122,  109,  122,  122,  122,  122,  123,  123,  123,
+      123,  107,  106,  123,  105,  124,  121,  124,  104,  124,
+      124,  124,  124,  126,  126,  126,  126,  103,   95,  123,
+      163,  163,  163,  163,  164,  164,  164,  164,  165,  165,
+      165,  165,  166,  166,  166,  166,  167,  167,  167,  167,
+      168,  168,  168,  168,  169,  169,  169,  169,  170,  170,
+      170,  170,   91,   89,   86,   82,   80,   78,   77,   76,
+       73,   72,   71,   70,   68,   67,   64,   61,   53,   49,
 
-       26,   25,   24,   23,   22,   18,   17,    8,    5,  188,
-      188,  188,  188,  188,  188,  188,  188,  188,  188,  188,
-      188,  188,  188,  188,  188,  188,  188,  188,  188,  188,
-      188,  188,  188,  188,  188,  188,  188,  188,  188,  188,
-      188,  188,  188,  188,  188,  188,  188,  188,  188,  188,
-      188,  188,  188,  188,  188,  188,  188,  188,  188,  188,
-      188,  188,  188,  188,  188,  188,  188,  188
+       47,   43,   41,   40,   36,   34,   33,   32,   27,   26,
+       25,   24,   23,   19,   18,    8,    5,  189,  189,  189,
+      189,  189,  189,  189,  189,  189,  189,  189,  189,  189,
+      189,  189,  189,  189,  189,  189,  189,  189,  189,  189,
+      189,  189,  189,  189,  189,  189,  189,  189,  189,  189,
+      189,  189,  189,  189,  189,  189,  189,  189,  189,  189,
+      189,  189,  189,  189,  189,  189,  189,  189,  189,  189,
+      189,  189,  189,  189,  189,  189
     } ;
 
 static yy_state_type yy_last_accepting_state;
@@ -616,7 +618,7 @@ char *yytext;
 /* the manual says "somewhat more optimized" */
 /* no support for include files is planned */
 
-#line 620 "QuantityLexer.c"
+#line 622 "QuantityLexer.c"
 
 #define INITIAL 0
 #define C_COMMENT 1
@@ -836,7 +838,7 @@ YY_DECL
 #line 31 "QuantityParser.l"
 
 
-#line 840 "QuantityLexer.c"
+#line 842 "QuantityLexer.c"
 
 	while ( /*CONSTCOND*/1 )		/* loops until end-of-file is reached */
 		{
@@ -863,13 +865,13 @@ yy_match:
 			while ( yy_chk[yy_base[yy_current_state] + yy_c] != yy_current_state )
 				{
 				yy_current_state = (int) yy_def[yy_current_state];
-				if ( yy_current_state >= 189 )
+				if ( yy_current_state >= 190 )
 					yy_c = yy_meta[(unsigned int) yy_c];
 				}
 			yy_current_state = yy_nxt[yy_base[yy_current_state] + (unsigned int) yy_c];
 			++yy_cp;
 			}
-		while ( yy_current_state != 188 );
+		while ( yy_current_state != 189 );
 		yy_cp = (yy_last_accepting_cpos);
 		yy_current_state = (yy_last_accepting_state);
 
@@ -1268,7 +1270,7 @@ yylval = Quantity::Gon;                 return UNIT; // gon
 case 76:
 YY_RULE_SETUP
 #line 133 "QuantityParser.l"
-{  yylval = Quantity(num_change(yytext,'.',','));return NUM;  }
+yylval = Quantity(1.0);                 return ONE;
 	YY_BREAK
 case 77:
 YY_RULE_SETUP
@@ -1278,7 +1280,7 @@ YY_RULE_SETUP
 case 78:
 YY_RULE_SETUP
 #line 135 "QuantityParser.l"
-{  yylval = Quantity(num_change(yytext,',','.'));return NUM;  }
+{  yylval = Quantity(num_change(yytext,'.',','));return NUM;  }
 	YY_BREAK
 case 79:
 YY_RULE_SETUP
@@ -1287,105 +1289,110 @@ YY_RULE_SETUP
 	YY_BREAK
 case 80:
 YY_RULE_SETUP
-#line 139 "QuantityParser.l"
-{yylval = Quantity(M_PI)          ; return NUM;} // constant pi
+#line 137 "QuantityParser.l"
+{  yylval = Quantity(num_change(yytext,',','.'));return NUM;  }
 	YY_BREAK
 case 81:
 YY_RULE_SETUP
 #line 140 "QuantityParser.l"
-{yylval = Quantity(M_E)           ; return NUM;} // constant e
+{yylval = Quantity(M_PI)          ; return NUM;} // constant pi
 	YY_BREAK
 case 82:
 YY_RULE_SETUP
-#line 142 "QuantityParser.l"
-return ACOS;
+#line 141 "QuantityParser.l"
+{yylval = Quantity(M_E)           ; return NUM;} // constant e
 	YY_BREAK
 case 83:
 YY_RULE_SETUP
 #line 143 "QuantityParser.l"
-return ASIN;
+return ACOS;
 	YY_BREAK
 case 84:
 YY_RULE_SETUP
 #line 144 "QuantityParser.l"
-return ATAN;
+return ASIN;
 	YY_BREAK
 case 85:
 YY_RULE_SETUP
 #line 145 "QuantityParser.l"
-return ATAN2;
+return ATAN;
 	YY_BREAK
 case 86:
 YY_RULE_SETUP
 #line 146 "QuantityParser.l"
-return COS;
+return ATAN2;
 	YY_BREAK
 case 87:
 YY_RULE_SETUP
 #line 147 "QuantityParser.l"
-return EXP;
+return COS;
 	YY_BREAK
 case 88:
 YY_RULE_SETUP
 #line 148 "QuantityParser.l"
-return ABS;
+return EXP;
 	YY_BREAK
 case 89:
 YY_RULE_SETUP
 #line 149 "QuantityParser.l"
-return MOD;
+return ABS;
 	YY_BREAK
 case 90:
 YY_RULE_SETUP
 #line 150 "QuantityParser.l"
-return LOG;
+return MOD;
 	YY_BREAK
 case 91:
 YY_RULE_SETUP
 #line 151 "QuantityParser.l"
-return LOG10;
+return LOG;
 	YY_BREAK
 case 92:
 YY_RULE_SETUP
 #line 152 "QuantityParser.l"
-return POW;
+return LOG10;
 	YY_BREAK
 case 93:
 YY_RULE_SETUP
 #line 153 "QuantityParser.l"
-return SIN;
+return POW;
 	YY_BREAK
 case 94:
 YY_RULE_SETUP
 #line 154 "QuantityParser.l"
-return SINH;
+return SIN;
 	YY_BREAK
 case 95:
 YY_RULE_SETUP
 #line 155 "QuantityParser.l"
-return TAN;
+return SINH;
 	YY_BREAK
 case 96:
 YY_RULE_SETUP
 #line 156 "QuantityParser.l"
-return TANH;
+return TAN;
 	YY_BREAK
 case 97:
 YY_RULE_SETUP
 #line 157 "QuantityParser.l"
-return SQRT;
+return TANH;
 	YY_BREAK
 case 98:
 YY_RULE_SETUP
-#line 159 "QuantityParser.l"
-return *yytext;
+#line 158 "QuantityParser.l"
+return SQRT;
 	YY_BREAK
 case 99:
 YY_RULE_SETUP
 #line 160 "QuantityParser.l"
+return *yytext;
+	YY_BREAK
+case 100:
+YY_RULE_SETUP
+#line 161 "QuantityParser.l"
 ECHO;
 	YY_BREAK
-#line 1389 "QuantityLexer.c"
+#line 1396 "QuantityLexer.c"
 case YY_STATE_EOF(INITIAL):
 case YY_STATE_EOF(C_COMMENT):
 	yyterminate();
@@ -1574,7 +1581,7 @@ static int yy_get_next_buffer (void)
 
 	else
 		{
-			yy_size_t num_to_read =
+			int num_to_read =
 			YY_CURRENT_BUFFER_LVALUE->yy_buf_size - number_to_move - 1;
 
 		while ( num_to_read <= 0 )
@@ -1643,9 +1650,9 @@ static int yy_get_next_buffer (void)
 	else
 		ret_val = EOB_ACT_CONTINUE_SCAN;
 
-	if ((int) ((yy_n_chars) + number_to_move) > YY_CURRENT_BUFFER_LVALUE->yy_buf_size) {
+	if ((yy_size_t) ((yy_n_chars) + number_to_move) > YY_CURRENT_BUFFER_LVALUE->yy_buf_size) {
 		/* Extend the array by 50%, plus the number we really need. */
-		int new_size = (yy_n_chars) + number_to_move + ((yy_n_chars) >> 1);
+		yy_size_t new_size = (yy_n_chars) + number_to_move + ((yy_n_chars) >> 1);
 		YY_CURRENT_BUFFER_LVALUE->yy_ch_buf = (char *) yyrealloc((void *) YY_CURRENT_BUFFER_LVALUE->yy_ch_buf,new_size  );
 		if ( ! YY_CURRENT_BUFFER_LVALUE->yy_ch_buf )
 			YY_FATAL_ERROR( "out of dynamic memory in yy_get_next_buffer()" );
@@ -1680,7 +1687,7 @@ static int yy_get_next_buffer (void)
 		while ( yy_chk[yy_base[yy_current_state] + yy_c] != yy_current_state )
 			{
 			yy_current_state = (int) yy_def[yy_current_state];
-			if ( yy_current_state >= 189 )
+			if ( yy_current_state >= 190 )
 				yy_c = yy_meta[(unsigned int) yy_c];
 			}
 		yy_current_state = yy_nxt[yy_base[yy_current_state] + (unsigned int) yy_c];
@@ -1708,11 +1715,11 @@ static int yy_get_next_buffer (void)
 	while ( yy_chk[yy_base[yy_current_state] + yy_c] != yy_current_state )
 		{
 		yy_current_state = (int) yy_def[yy_current_state];
-		if ( yy_current_state >= 189 )
+		if ( yy_current_state >= 190 )
 			yy_c = yy_meta[(unsigned int) yy_c];
 		}
 	yy_current_state = yy_nxt[yy_base[yy_current_state] + (unsigned int) yy_c];
-	yy_is_jam = (yy_current_state == 188);
+	yy_is_jam = (yy_current_state == 189);
 
 		return yy_is_jam ? 0 : yy_current_state;
 }
@@ -2025,7 +2032,7 @@ static void yyensure_buffer_stack (void)
 		 * scanner will even need a stack. We use 2 instead of 1 to avoid an
 		 * immediate realloc on the next call.
          */
-		num_to_alloc = 1; /* After all that talk, this was set to 1 anyways... */
+      num_to_alloc = 1; /* After all that talk, this was set to 1 anyways... */
 		(yy_buffer_stack) = (struct yy_buffer_state**)yyalloc
 								(num_to_alloc * sizeof(struct yy_buffer_state*)
 								);
@@ -2161,7 +2168,7 @@ static void yy_fatal_error (yyconst char* msg )
 	do \
 		{ \
 		/* Undo effects of setting up yytext. */ \
-        int yyless_macro_arg = (n); \
+        yy_size_t yyless_macro_arg = (n); \
         YY_LESS_LINENO(yyless_macro_arg);\
 		yytext[yyleng] = (yy_hold_char); \
 		(yy_c_buf_p) = yytext + yyless_macro_arg; \
@@ -2351,4 +2358,4 @@ void yyfree (void * ptr )
 
 #define YYTABLES_NAME "yytables"
 
-#line 160 "QuantityParser.l"
+#line 161 "QuantityParser.l"

--- a/src/Base/QuantityParser.c
+++ b/src/Base/QuantityParser.c
@@ -1,8 +1,8 @@
-/* A Bison parser, made by GNU Bison 3.0.2.  */
+/* A Bison parser, made by GNU Bison 3.0.4.  */
 
 /* Bison implementation for Yacc-like parsers in C
 
-   Copyright (C) 1984, 1989-1990, 2000-2013 Free Software Foundation, Inc.
+   Copyright (C) 1984, 1989-1990, 2000-2015 Free Software Foundation, Inc.
 
    This program is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -44,7 +44,7 @@
 #define YYBISON 1
 
 /* Bison version.  */
-#define YYBISON_VERSION "3.0.2"
+#define YYBISON_VERSION "3.0.4"
 
 /* Skeleton name.  */
 #define YYSKELETON_NAME "yacc.c"
@@ -109,24 +109,26 @@ extern int yydebug;
   {
     UNIT = 258,
     NUM = 259,
-    MINUSSIGN = 260,
-    ACOS = 261,
-    ASIN = 262,
-    ATAN = 263,
-    ATAN2 = 264,
-    COS = 265,
-    EXP = 266,
-    ABS = 267,
-    MOD = 268,
-    LOG = 269,
-    LOG10 = 270,
-    POW = 271,
-    SIN = 272,
-    SINH = 273,
-    TAN = 274,
-    TANH = 275,
-    SQRT = 276,
-    NEG = 277
+    ONE = 260,
+    MINUSSIGN = 261,
+    ACOS = 262,
+    ASIN = 263,
+    ATAN = 264,
+    ATAN2 = 265,
+    COS = 266,
+    EXP = 267,
+    ABS = 268,
+    MOD = 269,
+    LOG = 270,
+    LOG10 = 271,
+    POW = 272,
+    SIN = 273,
+    SINH = 274,
+    TAN = 275,
+    TANH = 276,
+    SQRT = 277,
+    RECIPROCALSLASH = 278,
+    NEG = 279
   };
 #endif
 
@@ -146,7 +148,7 @@ int yyparse (void);
 
 /* Copy the second part of user declarations.  */
 
-#line 150 "QuantityParser.c" /* yacc.c:358  */
+#line 152 "QuantityParser.c" /* yacc.c:358  */
 
 #ifdef short
 # undef short
@@ -386,23 +388,23 @@ union yyalloc
 #endif /* !YYCOPY_NEEDED */
 
 /* YYFINAL -- State number of the termination state.  */
-#define YYFINAL  39
+#define YYFINAL  42
 /* YYLAST -- Last index in YYTABLE.  */
-#define YYLAST   200
+#define YYLAST   245
 
 /* YYNTOKENS -- Number of terminals.  */
-#define YYNTOKENS  29
+#define YYNTOKENS  31
 /* YYNNTS -- Number of nonterminals.  */
 #define YYNNTS  5
 /* YYNRULES -- Number of rules.  */
-#define YYNRULES  33
+#define YYNRULES  35
 /* YYNSTATES -- Number of states.  */
-#define YYNSTATES  88
+#define YYNSTATES  93
 
 /* YYTRANSLATE[YYX] -- Symbol number corresponding to YYX as returned
    by yylex, with out-of-bounds checking.  */
 #define YYUNDEFTOK  2
-#define YYMAXUTOK   277
+#define YYMAXUTOK   279
 
 #define YYTRANSLATE(YYX)                                                \
   ((unsigned int) (YYX) <= YYMAXUTOK ? yytranslate[YYX] : YYUNDEFTOK)
@@ -415,12 +417,12 @@ static const yytype_uint8 yytranslate[] =
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
-      27,    28,    23,    22,     2,     2,     2,    24,     2,     2,
+      29,    30,    25,    23,     2,     2,     2,    26,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
-       2,     2,     2,     2,    26,     2,     2,     2,     2,     2,
+       2,     2,     2,     2,    28,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
@@ -438,17 +440,17 @@ static const yytype_uint8 yytranslate[] =
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     1,     2,     3,     4,
        5,     6,     7,     8,     9,    10,    11,    12,    13,    14,
-      15,    16,    17,    18,    19,    20,    21,    25
+      15,    16,    17,    18,    19,    20,    21,    22,    24,    27
 };
 
 #if YYDEBUG
   /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
 static const yytype_uint8 yyrline[] =
 {
-       0,    33,    33,    34,    35,    36,    37,    39,    40,    41,
-      42,    43,    44,    45,    46,    47,    48,    49,    50,    51,
-      52,    53,    54,    55,    56,    57,    58,    59,    62,    63,
-      64,    65,    66,    68
+       0,    34,    34,    35,    36,    37,    38,    40,    41,    42,
+      43,    44,    45,    46,    47,    48,    49,    50,    51,    52,
+      53,    54,    55,    56,    57,    58,    59,    60,    61,    63,
+      64,    65,    66,    67,    68,    70
 };
 #endif
 
@@ -457,10 +459,11 @@ static const yytype_uint8 yyrline[] =
    First, the terminals, then, starting at YYNTOKENS, nonterminals.  */
 static const char *const yytname[] =
 {
-  "$end", "error", "$undefined", "UNIT", "NUM", "MINUSSIGN", "ACOS",
-  "ASIN", "ATAN", "ATAN2", "COS", "EXP", "ABS", "MOD", "LOG", "LOG10",
-  "POW", "SIN", "SINH", "TAN", "TANH", "SQRT", "'+'", "'*'", "'/'", "NEG",
-  "'^'", "'('", "')'", "$accept", "input", "num", "unit", "quantity", YY_NULLPTR
+  "$end", "error", "$undefined", "UNIT", "NUM", "ONE", "MINUSSIGN",
+  "ACOS", "ASIN", "ATAN", "ATAN2", "COS", "EXP", "ABS", "MOD", "LOG",
+  "LOG10", "POW", "SIN", "SINH", "TAN", "TANH", "SQRT", "'+'",
+  "RECIPROCALSLASH", "'*'", "'/'", "NEG", "'^'", "'('", "')'", "$accept",
+  "input", "num", "unit", "quantity", YY_NULLPTR
 };
 #endif
 
@@ -471,14 +474,15 @@ static const yytype_uint16 yytoknum[] =
 {
        0,   256,   257,   258,   259,   260,   261,   262,   263,   264,
      265,   266,   267,   268,   269,   270,   271,   272,   273,   274,
-     275,   276,    43,    42,    47,   277,    94,    40,    41
+     275,   276,   277,    43,   278,    42,    47,   279,    94,    40,
+      41
 };
 # endif
 
-#define YYPACT_NINF -19
+#define YYPACT_NINF -22
 
 #define yypact_value_is_default(Yystate) \
-  (!!((Yystate) == (-19)))
+  (!!((Yystate) == (-22)))
 
 #define YYTABLE_NINF -1
 
@@ -489,15 +493,16 @@ static const yytype_uint16 yytoknum[] =
      STATE-NUM.  */
 static const yytype_int16 yypact[] =
 {
-      49,   -19,   -19,    67,   -15,    -9,    13,    14,    22,    31,
-      35,    38,    56,    63,    64,    73,    78,    49,    10,    -2,
-     -10,    67,    67,    76,    67,    67,    67,    67,    67,    67,
-      67,    67,    67,    67,    67,    67,    67,    75,   -17,   -19,
-      67,    67,    67,    67,    67,    12,   -10,    12,    12,    67,
-      -2,   -19,    84,    91,    99,   106,   113,   121,   128,   135,
-     143,   150,   157,   165,   172,   -19,   -19,    69,    69,    76,
-      76,    76,    83,    83,   -18,   -19,   -19,   -19,   -19,   -19,
-     -19,   -19,   -19,   -19,   -19,   -19,   -19,   -19
+      53,   -22,   -22,   -22,    99,   -19,   -12,    -8,    -7,    -4,
+      -3,    -1,    13,    14,    15,    16,    24,    34,    53,    19,
+      73,   -14,    99,    -2,   -22,    99,    42,    99,    99,    99,
+      99,    99,    99,    99,    99,    99,    99,    99,    99,    99,
+      61,   -21,   -22,    51,    99,    99,    99,    99,    99,    -2,
+     -14,    -2,    -2,    99,    73,   -22,    52,   107,   116,   125,
+     134,   143,   152,   161,   170,   179,   188,   197,   206,   215,
+     -22,   -22,   -10,   -10,    42,    42,    42,    52,    52,   -15,
+     -22,   -22,   -22,   -22,   -22,   -22,   -22,   -22,   -22,   -22,
+     -22,   -22,   -22
 };
 
   /* YYDEFACT[STATE-NUM] -- Default reduction number in state STATE-NUM.
@@ -505,27 +510,28 @@ static const yytype_int16 yypact[] =
      means the default is an error.  */
 static const yytype_uint8 yydefact[] =
 {
-       2,    28,     7,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,     3,
-       4,     5,     0,    12,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,     1,
-       0,     0,     0,     0,     0,     0,    33,     0,     0,     0,
-       0,     6,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,    14,    32,     9,     8,    10,
-      11,    13,    29,    30,    31,    15,    16,    17,    27,    19,
-      18,    20,    21,    22,    23,    24,    25,    26
+       2,    29,     7,     8,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       3,     4,     5,     0,     8,     0,    13,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     1,     0,     0,     0,     0,     0,     0,     0,
+      35,     0,     0,     0,     0,     6,    30,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+      15,    34,    10,     9,    11,    12,    14,    31,    32,    33,
+      16,    17,    18,    28,    20,    19,    21,    22,    23,    24,
+      25,    26,    27
 };
 
   /* YYPGOTO[NTERM-NUM].  */
 static const yytype_int8 yypgoto[] =
 {
-     -19,   -19,     2,     0,    -4
+     -22,   -22,     2,     0,    59
 };
 
   /* YYDEFGOTO[NTERM-NUM].  */
 static const yytype_int8 yydefgoto[] =
 {
-      -1,    18,    37,    38,    21
+      -1,    19,    40,    41,    22
 };
 
   /* YYTABLE[YYPACT[STATE-NUM]] -- What to do in state STATE-NUM.  If
@@ -533,85 +539,94 @@ static const yytype_int8 yydefgoto[] =
      number is the opposite.  If YYTABLE_NINF, syntax error.  */
 static const yytype_uint8 yytable[] =
 {
-      20,     1,    19,    40,    41,    23,    47,    48,    44,    49,
-      39,    66,    24,    47,    48,     1,    49,    51,    25,    46,
-      41,    42,    43,    50,    44,    45,    52,    53,    54,    55,
-      56,    57,    58,    59,    60,    61,    62,    63,    64,    45,
-      26,    27,    67,    68,    69,    70,    71,    72,    73,    28,
-      46,    74,     1,     2,     3,     4,     5,     6,    29,     7,
-       8,     9,    30,    10,    11,    31,    12,    13,    14,    15,
-      16,     2,     3,     4,     5,     6,    17,     7,     8,     9,
-      40,    10,    11,    32,    12,    13,    14,    15,    16,    40,
-      33,    34,    42,    43,    22,    44,    40,    41,    42,    43,
-      35,    44,    44,    65,    40,    36,    41,    42,    43,    49,
-      44,    40,    75,    41,    42,    43,     0,    44,    40,    76,
-       0,    41,    42,    43,     0,    44,    40,    77,    41,    42,
-      43,     0,    44,    40,    78,    41,    42,    43,     0,    44,
-      40,    79,     0,    41,    42,    43,     0,    44,    40,    80,
-      41,    42,    43,     0,    44,    40,    81,    41,    42,    43,
-       0,    44,    40,    82,     0,    41,    42,    43,     0,    44,
-      40,    83,    41,    42,    43,     0,    44,    40,    84,    41,
-      42,    43,     0,    44,     0,    85,     0,    41,    42,    43,
-       0,    44,     0,    86,    41,    42,    43,     0,    44,     0,
-      87
+      21,     1,    20,    43,    51,    52,    26,    53,    45,    71,
+      27,    51,    52,    48,    53,    46,    47,    28,    48,    42,
+      50,    29,    30,    56,    54,    31,    32,    49,    33,    57,
+      58,    59,    60,    61,    62,    63,    64,    65,    66,    67,
+      68,    69,    34,    35,    36,    37,    72,    73,    74,    75,
+      76,    77,    78,    38,    50,    79,     1,     2,     3,     4,
+       5,     6,     7,    39,     8,     9,    10,    44,    11,    12,
+      48,    13,    14,    15,    16,    17,     1,    23,    43,    44,
+      53,    55,    18,     0,    45,     0,    46,    47,     0,    48,
+       0,    70,     0,     0,     0,     0,    45,     0,    46,    47,
+       0,    48,    49,     2,    24,     4,     5,     6,     7,     0,
+       8,     9,    10,    44,    11,    12,     0,    13,    14,    15,
+      16,    17,    44,     0,     0,     0,     0,     0,    25,     0,
+      45,    44,    46,    47,     0,    48,     0,    80,     0,    45,
+      44,    46,    47,     0,    48,     0,    81,     0,    45,    44,
+      46,    47,     0,    48,     0,    82,     0,    45,    44,    46,
+      47,     0,    48,     0,    83,     0,    45,    44,    46,    47,
+       0,    48,     0,    84,     0,    45,    44,    46,    47,     0,
+      48,     0,    85,     0,    45,    44,    46,    47,     0,    48,
+       0,    86,     0,    45,    44,    46,    47,     0,    48,     0,
+      87,     0,    45,    44,    46,    47,     0,    48,     0,    88,
+       0,    45,    44,    46,    47,     0,    48,     0,    89,     0,
+      45,    44,    46,    47,     0,    48,     0,    90,     0,    45,
+       0,    46,    47,     0,    48,     0,    91,     0,    45,     0,
+      46,    47,     0,    48,     0,    92
 };
 
 static const yytype_int8 yycheck[] =
 {
-       0,     3,     0,     5,    22,     3,    23,    24,    26,    26,
-       0,    28,    27,    23,    24,     3,    26,    21,    27,    19,
-      22,    23,    24,    21,    26,    27,    24,    25,    26,    27,
-      28,    29,    30,    31,    32,    33,    34,    35,    36,    27,
-      27,    27,    40,    41,    42,    43,    44,    47,    48,    27,
-      50,    49,     3,     4,     5,     6,     7,     8,    27,    10,
-      11,    12,    27,    14,    15,    27,    17,    18,    19,    20,
-      21,     4,     5,     6,     7,     8,    27,    10,    11,    12,
-       5,    14,    15,    27,    17,    18,    19,    20,    21,     5,
-      27,    27,    23,    24,    27,    26,     5,    22,    23,    24,
-      27,    26,    26,    28,     5,    27,    22,    23,    24,    26,
-      26,     5,    28,    22,    23,    24,    -1,    26,     5,    28,
-      -1,    22,    23,    24,    -1,    26,     5,    28,    22,    23,
-      24,    -1,    26,     5,    28,    22,    23,    24,    -1,    26,
-       5,    28,    -1,    22,    23,    24,    -1,    26,     5,    28,
-      22,    23,    24,    -1,    26,     5,    28,    22,    23,    24,
-      -1,    26,     5,    28,    -1,    22,    23,    24,    -1,    26,
-       5,    28,    22,    23,    24,    -1,    26,     5,    28,    22,
-      23,    24,    -1,    26,    -1,    28,    -1,    22,    23,    24,
-      -1,    26,    -1,    28,    22,    23,    24,    -1,    26,    -1,
-      28
+       0,     3,     0,     5,    25,    26,     4,    28,    23,    30,
+      29,    25,    26,    28,    28,    25,    26,    29,    28,     0,
+      20,    29,    29,    23,    22,    29,    29,    29,    29,    27,
+      28,    29,    30,    31,    32,    33,    34,    35,    36,    37,
+      38,    39,    29,    29,    29,    29,    44,    45,    46,    47,
+      48,    51,    52,    29,    54,    53,     3,     4,     5,     6,
+       7,     8,     9,    29,    11,    12,    13,     6,    15,    16,
+      28,    18,    19,    20,    21,    22,     3,    26,     5,     6,
+      28,    22,    29,    -1,    23,    -1,    25,    26,    -1,    28,
+      -1,    30,    -1,    -1,    -1,    -1,    23,    -1,    25,    26,
+      -1,    28,    29,     4,     5,     6,     7,     8,     9,    -1,
+      11,    12,    13,     6,    15,    16,    -1,    18,    19,    20,
+      21,    22,     6,    -1,    -1,    -1,    -1,    -1,    29,    -1,
+      23,     6,    25,    26,    -1,    28,    -1,    30,    -1,    23,
+       6,    25,    26,    -1,    28,    -1,    30,    -1,    23,     6,
+      25,    26,    -1,    28,    -1,    30,    -1,    23,     6,    25,
+      26,    -1,    28,    -1,    30,    -1,    23,     6,    25,    26,
+      -1,    28,    -1,    30,    -1,    23,     6,    25,    26,    -1,
+      28,    -1,    30,    -1,    23,     6,    25,    26,    -1,    28,
+      -1,    30,    -1,    23,     6,    25,    26,    -1,    28,    -1,
+      30,    -1,    23,     6,    25,    26,    -1,    28,    -1,    30,
+      -1,    23,     6,    25,    26,    -1,    28,    -1,    30,    -1,
+      23,     6,    25,    26,    -1,    28,    -1,    30,    -1,    23,
+      -1,    25,    26,    -1,    28,    -1,    30,    -1,    23,    -1,
+      25,    26,    -1,    28,    -1,    30
 };
 
   /* YYSTOS[STATE-NUM] -- The (internal number of the) accessing
      symbol of state STATE-NUM.  */
 static const yytype_uint8 yystos[] =
 {
-       0,     3,     4,     5,     6,     7,     8,    10,    11,    12,
-      14,    15,    17,    18,    19,    20,    21,    27,    30,    31,
-      32,    33,    27,    31,    27,    27,    27,    27,    27,    27,
-      27,    27,    27,    27,    27,    27,    27,    31,    32,     0,
-       5,    22,    23,    24,    26,    27,    32,    23,    24,    26,
-      31,    33,    31,    31,    31,    31,    31,    31,    31,    31,
-      31,    31,    31,    31,    31,    28,    28,    31,    31,    31,
-      31,    31,    32,    32,    31,    28,    28,    28,    28,    28,
-      28,    28,    28,    28,    28,    28,    28,    28
+       0,     3,     4,     5,     6,     7,     8,     9,    11,    12,
+      13,    15,    16,    18,    19,    20,    21,    22,    29,    32,
+      33,    34,    35,    26,     5,    29,    33,    29,    29,    29,
+      29,    29,    29,    29,    29,    29,    29,    29,    29,    29,
+      33,    34,     0,     5,     6,    23,    25,    26,    28,    29,
+      34,    25,    26,    28,    33,    35,    34,    33,    33,    33,
+      33,    33,    33,    33,    33,    33,    33,    33,    33,    33,
+      30,    30,    33,    33,    33,    33,    33,    34,    34,    33,
+      30,    30,    30,    30,    30,    30,    30,    30,    30,    30,
+      30,    30,    30
 };
 
   /* YYR1[YYN] -- Symbol number of symbol that rule YYN derives.  */
 static const yytype_uint8 yyr1[] =
 {
-       0,    29,    30,    30,    30,    30,    30,    31,    31,    31,
-      31,    31,    31,    31,    31,    31,    31,    31,    31,    31,
-      31,    31,    31,    31,    31,    31,    31,    31,    32,    32,
-      32,    32,    32,    33
+       0,    31,    32,    32,    32,    32,    32,    33,    33,    33,
+      33,    33,    33,    33,    33,    33,    33,    33,    33,    33,
+      33,    33,    33,    33,    33,    33,    33,    33,    33,    34,
+      34,    34,    34,    34,    34,    35
 };
 
   /* YYR2[YYN] -- Number of symbols on the right hand side of rule YYN.  */
 static const yytype_uint8 yyr2[] =
 {
-       0,     2,     0,     1,     1,     1,     2,     1,     3,     3,
-       3,     3,     2,     3,     3,     4,     4,     4,     4,     4,
-       4,     4,     4,     4,     4,     4,     4,     4,     1,     3,
-       3,     3,     3,     2
+       0,     2,     0,     1,     1,     1,     2,     1,     1,     3,
+       3,     3,     3,     2,     3,     3,     4,     4,     4,     4,
+       4,     4,     4,     4,     4,     4,     4,     4,     4,     1,
+       3,     3,     3,     3,     3,     2
 };
 
 
@@ -1288,199 +1303,211 @@ yyreduce:
   switch (yyn)
     {
         case 2:
-#line 33 "QuantityParser.y" /* yacc.c:1646  */
+#line 34 "QuantityParser.y" /* yacc.c:1646  */
     { QuantResult = Quantity(DOUBLE_MIN); /* empty input */ }
-#line 1294 "QuantityParser.c" /* yacc.c:1646  */
+#line 1309 "QuantityParser.c" /* yacc.c:1646  */
     break;
 
   case 3:
-#line 34 "QuantityParser.y" /* yacc.c:1646  */
+#line 35 "QuantityParser.y" /* yacc.c:1646  */
     { QuantResult = (yyvsp[0])     ;            }
-#line 1300 "QuantityParser.c" /* yacc.c:1646  */
+#line 1315 "QuantityParser.c" /* yacc.c:1646  */
     break;
 
   case 4:
-#line 35 "QuantityParser.y" /* yacc.c:1646  */
+#line 36 "QuantityParser.y" /* yacc.c:1646  */
     { QuantResult = (yyvsp[0])     ;            }
-#line 1306 "QuantityParser.c" /* yacc.c:1646  */
+#line 1321 "QuantityParser.c" /* yacc.c:1646  */
     break;
 
   case 5:
-#line 36 "QuantityParser.y" /* yacc.c:1646  */
+#line 37 "QuantityParser.y" /* yacc.c:1646  */
     { QuantResult = (yyvsp[0])     ;            }
-#line 1312 "QuantityParser.c" /* yacc.c:1646  */
+#line 1327 "QuantityParser.c" /* yacc.c:1646  */
     break;
 
   case 6:
-#line 37 "QuantityParser.y" /* yacc.c:1646  */
+#line 38 "QuantityParser.y" /* yacc.c:1646  */
     { QuantResult = (yyvsp[-1]) + (yyvsp[0]);            }
-#line 1318 "QuantityParser.c" /* yacc.c:1646  */
+#line 1333 "QuantityParser.c" /* yacc.c:1646  */
     break;
 
   case 7:
-#line 39 "QuantityParser.y" /* yacc.c:1646  */
+#line 40 "QuantityParser.y" /* yacc.c:1646  */
     { (yyval) = (yyvsp[0]);         	}
-#line 1324 "QuantityParser.c" /* yacc.c:1646  */
+#line 1339 "QuantityParser.c" /* yacc.c:1646  */
     break;
 
   case 8:
-#line 40 "QuantityParser.y" /* yacc.c:1646  */
-    { (yyval) = Quantity((yyvsp[-2]).getValue() + (yyvsp[0]).getValue());    	}
-#line 1330 "QuantityParser.c" /* yacc.c:1646  */
+#line 41 "QuantityParser.y" /* yacc.c:1646  */
+    { (yyval) = (yyvsp[0]);          }
+#line 1345 "QuantityParser.c" /* yacc.c:1646  */
     break;
 
   case 9:
-#line 41 "QuantityParser.y" /* yacc.c:1646  */
-    { (yyval) = Quantity((yyvsp[-2]).getValue() - (yyvsp[0]).getValue());    	}
-#line 1336 "QuantityParser.c" /* yacc.c:1646  */
+#line 42 "QuantityParser.y" /* yacc.c:1646  */
+    { (yyval) = Quantity((yyvsp[-2]).getValue() + (yyvsp[0]).getValue());    	}
+#line 1351 "QuantityParser.c" /* yacc.c:1646  */
     break;
 
   case 10:
-#line 42 "QuantityParser.y" /* yacc.c:1646  */
-    { (yyval) = Quantity((yyvsp[-2]).getValue() * (yyvsp[0]).getValue());    	}
-#line 1342 "QuantityParser.c" /* yacc.c:1646  */
+#line 43 "QuantityParser.y" /* yacc.c:1646  */
+    { (yyval) = Quantity((yyvsp[-2]).getValue() - (yyvsp[0]).getValue());    	}
+#line 1357 "QuantityParser.c" /* yacc.c:1646  */
     break;
 
   case 11:
-#line 43 "QuantityParser.y" /* yacc.c:1646  */
-    { (yyval) = Quantity((yyvsp[-2]).getValue() / (yyvsp[0]).getValue());    	}
-#line 1348 "QuantityParser.c" /* yacc.c:1646  */
+#line 44 "QuantityParser.y" /* yacc.c:1646  */
+    { (yyval) = Quantity((yyvsp[-2]).getValue() * (yyvsp[0]).getValue());    	}
+#line 1363 "QuantityParser.c" /* yacc.c:1646  */
     break;
 
   case 12:
-#line 44 "QuantityParser.y" /* yacc.c:1646  */
-    { (yyval) = Quantity(-(yyvsp[0]).getValue());        	}
-#line 1354 "QuantityParser.c" /* yacc.c:1646  */
+#line 45 "QuantityParser.y" /* yacc.c:1646  */
+    { (yyval) = Quantity((yyvsp[-2]).getValue() / (yyvsp[0]).getValue());    	}
+#line 1369 "QuantityParser.c" /* yacc.c:1646  */
     break;
 
   case 13:
-#line 45 "QuantityParser.y" /* yacc.c:1646  */
-    { (yyval) = Quantity(pow ((yyvsp[-2]).getValue(), (yyvsp[0]).getValue()));}
-#line 1360 "QuantityParser.c" /* yacc.c:1646  */
+#line 46 "QuantityParser.y" /* yacc.c:1646  */
+    { (yyval) = Quantity(-(yyvsp[0]).getValue());        	}
+#line 1375 "QuantityParser.c" /* yacc.c:1646  */
     break;
 
   case 14:
-#line 46 "QuantityParser.y" /* yacc.c:1646  */
-    { (yyval) = (yyvsp[-1]);         	}
-#line 1366 "QuantityParser.c" /* yacc.c:1646  */
+#line 47 "QuantityParser.y" /* yacc.c:1646  */
+    { (yyval) = Quantity(pow ((yyvsp[-2]).getValue(), (yyvsp[0]).getValue()));}
+#line 1381 "QuantityParser.c" /* yacc.c:1646  */
     break;
 
   case 15:
-#line 47 "QuantityParser.y" /* yacc.c:1646  */
-    { (yyval) = Quantity(acos((yyvsp[-1]).getValue()));   	}
-#line 1372 "QuantityParser.c" /* yacc.c:1646  */
+#line 48 "QuantityParser.y" /* yacc.c:1646  */
+    { (yyval) = (yyvsp[-1]);         	}
+#line 1387 "QuantityParser.c" /* yacc.c:1646  */
     break;
 
   case 16:
-#line 48 "QuantityParser.y" /* yacc.c:1646  */
-    { (yyval) = Quantity(asin((yyvsp[-1]).getValue()));   	}
-#line 1378 "QuantityParser.c" /* yacc.c:1646  */
+#line 49 "QuantityParser.y" /* yacc.c:1646  */
+    { (yyval) = Quantity(acos((yyvsp[-1]).getValue()));   	}
+#line 1393 "QuantityParser.c" /* yacc.c:1646  */
     break;
 
   case 17:
-#line 49 "QuantityParser.y" /* yacc.c:1646  */
-    { (yyval) = Quantity(atan((yyvsp[-1]).getValue()));   	}
-#line 1384 "QuantityParser.c" /* yacc.c:1646  */
+#line 50 "QuantityParser.y" /* yacc.c:1646  */
+    { (yyval) = Quantity(asin((yyvsp[-1]).getValue()));   	}
+#line 1399 "QuantityParser.c" /* yacc.c:1646  */
     break;
 
   case 18:
-#line 50 "QuantityParser.y" /* yacc.c:1646  */
-    { (yyval) = Quantity(fabs((yyvsp[-1]).getValue()));   	}
-#line 1390 "QuantityParser.c" /* yacc.c:1646  */
+#line 51 "QuantityParser.y" /* yacc.c:1646  */
+    { (yyval) = Quantity(atan((yyvsp[-1]).getValue()));   	}
+#line 1405 "QuantityParser.c" /* yacc.c:1646  */
     break;
 
   case 19:
-#line 51 "QuantityParser.y" /* yacc.c:1646  */
-    { (yyval) = Quantity(exp((yyvsp[-1]).getValue()));    	}
-#line 1396 "QuantityParser.c" /* yacc.c:1646  */
+#line 52 "QuantityParser.y" /* yacc.c:1646  */
+    { (yyval) = Quantity(fabs((yyvsp[-1]).getValue()));   	}
+#line 1411 "QuantityParser.c" /* yacc.c:1646  */
     break;
 
   case 20:
-#line 52 "QuantityParser.y" /* yacc.c:1646  */
-    { (yyval) = Quantity(log((yyvsp[-1]).getValue()));     }
-#line 1402 "QuantityParser.c" /* yacc.c:1646  */
+#line 53 "QuantityParser.y" /* yacc.c:1646  */
+    { (yyval) = Quantity(exp((yyvsp[-1]).getValue()));    	}
+#line 1417 "QuantityParser.c" /* yacc.c:1646  */
     break;
 
   case 21:
-#line 53 "QuantityParser.y" /* yacc.c:1646  */
-    { (yyval) = Quantity(log10((yyvsp[-1]).getValue()));   }
-#line 1408 "QuantityParser.c" /* yacc.c:1646  */
+#line 54 "QuantityParser.y" /* yacc.c:1646  */
+    { (yyval) = Quantity(log((yyvsp[-1]).getValue()));     }
+#line 1423 "QuantityParser.c" /* yacc.c:1646  */
     break;
 
   case 22:
-#line 54 "QuantityParser.y" /* yacc.c:1646  */
-    { (yyval) = Quantity(sin((yyvsp[-1]).getValue()));     }
-#line 1414 "QuantityParser.c" /* yacc.c:1646  */
+#line 55 "QuantityParser.y" /* yacc.c:1646  */
+    { (yyval) = Quantity(log10((yyvsp[-1]).getValue()));   }
+#line 1429 "QuantityParser.c" /* yacc.c:1646  */
     break;
 
   case 23:
-#line 55 "QuantityParser.y" /* yacc.c:1646  */
-    { (yyval) = Quantity(sinh((yyvsp[-1]).getValue()));    }
-#line 1420 "QuantityParser.c" /* yacc.c:1646  */
+#line 56 "QuantityParser.y" /* yacc.c:1646  */
+    { (yyval) = Quantity(sin((yyvsp[-1]).getValue()));     }
+#line 1435 "QuantityParser.c" /* yacc.c:1646  */
     break;
 
   case 24:
-#line 56 "QuantityParser.y" /* yacc.c:1646  */
-    { (yyval) = Quantity(tan((yyvsp[-1]).getValue()));     }
-#line 1426 "QuantityParser.c" /* yacc.c:1646  */
+#line 57 "QuantityParser.y" /* yacc.c:1646  */
+    { (yyval) = Quantity(sinh((yyvsp[-1]).getValue()));    }
+#line 1441 "QuantityParser.c" /* yacc.c:1646  */
     break;
 
   case 25:
-#line 57 "QuantityParser.y" /* yacc.c:1646  */
-    { (yyval) = Quantity(tanh((yyvsp[-1]).getValue()));    }
-#line 1432 "QuantityParser.c" /* yacc.c:1646  */
+#line 58 "QuantityParser.y" /* yacc.c:1646  */
+    { (yyval) = Quantity(tan((yyvsp[-1]).getValue()));     }
+#line 1447 "QuantityParser.c" /* yacc.c:1646  */
     break;
 
   case 26:
-#line 58 "QuantityParser.y" /* yacc.c:1646  */
-    { (yyval) = Quantity(sqrt((yyvsp[-1]).getValue()));    }
-#line 1438 "QuantityParser.c" /* yacc.c:1646  */
+#line 59 "QuantityParser.y" /* yacc.c:1646  */
+    { (yyval) = Quantity(tanh((yyvsp[-1]).getValue()));    }
+#line 1453 "QuantityParser.c" /* yacc.c:1646  */
     break;
 
   case 27:
-#line 59 "QuantityParser.y" /* yacc.c:1646  */
-    { (yyval) = Quantity(cos((yyvsp[-1]).getValue()));    }
-#line 1444 "QuantityParser.c" /* yacc.c:1646  */
+#line 60 "QuantityParser.y" /* yacc.c:1646  */
+    { (yyval) = Quantity(sqrt((yyvsp[-1]).getValue()));    }
+#line 1459 "QuantityParser.c" /* yacc.c:1646  */
     break;
 
   case 28:
-#line 62 "QuantityParser.y" /* yacc.c:1646  */
-    { (yyval) = (yyvsp[0]);         	                }
-#line 1450 "QuantityParser.c" /* yacc.c:1646  */
+#line 61 "QuantityParser.y" /* yacc.c:1646  */
+    { (yyval) = Quantity(cos((yyvsp[-1]).getValue()));    }
+#line 1465 "QuantityParser.c" /* yacc.c:1646  */
     break;
 
   case 29:
 #line 63 "QuantityParser.y" /* yacc.c:1646  */
-    { (yyval) = (yyvsp[-2]) * (yyvsp[0]);    	                }
-#line 1456 "QuantityParser.c" /* yacc.c:1646  */
+    { (yyval) = (yyvsp[0]);         	                }
+#line 1471 "QuantityParser.c" /* yacc.c:1646  */
     break;
 
   case 30:
 #line 64 "QuantityParser.y" /* yacc.c:1646  */
-    { (yyval) = (yyvsp[-2]) / (yyvsp[0]);    	                }
-#line 1462 "QuantityParser.c" /* yacc.c:1646  */
+    { (yyval) = Quantity(1.0)/(yyvsp[0]);     	    }
+#line 1477 "QuantityParser.c" /* yacc.c:1646  */
     break;
 
   case 31:
 #line 65 "QuantityParser.y" /* yacc.c:1646  */
-    { (yyval) = (yyvsp[-2]).pow ((yyvsp[0]));                 }
-#line 1468 "QuantityParser.c" /* yacc.c:1646  */
+    { (yyval) = (yyvsp[-2]) * (yyvsp[0]);    	                }
+#line 1483 "QuantityParser.c" /* yacc.c:1646  */
     break;
 
   case 32:
 #line 66 "QuantityParser.y" /* yacc.c:1646  */
-    { (yyval) = (yyvsp[-1]);                          }
-#line 1474 "QuantityParser.c" /* yacc.c:1646  */
+    { (yyval) = (yyvsp[-2]) / (yyvsp[0]);    	                }
+#line 1489 "QuantityParser.c" /* yacc.c:1646  */
     break;
 
   case 33:
+#line 67 "QuantityParser.y" /* yacc.c:1646  */
+    { (yyval) = (yyvsp[-2]).pow ((yyvsp[0]));                 }
+#line 1495 "QuantityParser.c" /* yacc.c:1646  */
+    break;
+
+  case 34:
 #line 68 "QuantityParser.y" /* yacc.c:1646  */
+    { (yyval) = (yyvsp[-1]);                          }
+#line 1501 "QuantityParser.c" /* yacc.c:1646  */
+    break;
+
+  case 35:
+#line 70 "QuantityParser.y" /* yacc.c:1646  */
     { (yyval) = (yyvsp[-1])*(yyvsp[0]);    	                }
-#line 1480 "QuantityParser.c" /* yacc.c:1646  */
+#line 1507 "QuantityParser.c" /* yacc.c:1646  */
     break;
 
 
-#line 1484 "QuantityParser.c" /* yacc.c:1646  */
+#line 1511 "QuantityParser.c" /* yacc.c:1646  */
       default: break;
     }
   /* User semantic actions sometimes alter yychar, and that requires
@@ -1708,5 +1735,5 @@ yyreturn:
 #endif
   return yyresult;
 }
-#line 72 "QuantityParser.y" /* yacc.c:1906  */
+#line 74 "QuantityParser.y" /* yacc.c:1906  */
 

--- a/src/Base/QuantityParser.l
+++ b/src/Base/QuantityParser.l
@@ -130,6 +130,7 @@ CGRP     '\,'[0-9][0-9][0-9]
 "rad"      yylval = Quantity::Radian;              return UNIT; // radian         
 "gon"      yylval = Quantity::Gon;                 return UNIT; // gon         
 
+"1"        yylval = Quantity(1.0);                 return ONE;
 {DIGIT}+"."?{DIGIT}*{EXPO}?                         {  yylval = Quantity(num_change(yytext,'.',','));return NUM;  }
 "."?{DIGIT}+{EXPO}?                                 {  yylval = Quantity(num_change(yytext,'.',','));return NUM;  }
 {DIGIT}+","?{DIGIT}*{EXPO}?                         {  yylval = Quantity(num_change(yytext,',','.'));return NUM;  }

--- a/src/Base/QuantityParser.y
+++ b/src/Base/QuantityParser.y
@@ -17,12 +17,13 @@
 %}
 
      /* Bison declarations.  */
-     %token UNIT NUM MINUSSIGN
+     %token UNIT ONE NUM MINUSSIGN
      %token ACOS ASIN ATAN ATAN2 COS EXP ABS MOD LOG LOG10 POW SIN SINH TAN TANH SQRT;
      %left MINUSSIGN '+'
      %left '*' '/'
      %left NEG     /* negation--unary minus */
      %right '^'    /* exponentiation */
+     %left ONE NUM
 
 
 
@@ -37,6 +38,7 @@
             |  quantity quantity            { QuantResult = $1 + $2;            }
  ;   
      num:      NUM                			{ $$ = $1;         	}
+             | ONE                			{ $$ = $1;         	}
              | num '+' num        			{ $$ = Quantity($1.getValue() + $3.getValue());    	}
              | num MINUSSIGN num      		{ $$ = Quantity($1.getValue() - $3.getValue());    	}
              | num '*' num        			{ $$ = Quantity($1.getValue() * $3.getValue());    	}
@@ -60,6 +62,7 @@
 ;            
 
     unit:       UNIT                        { $$ = $1;         	                }
+            |   ONE '/' unit                { $$ = Quantity(1.0)/$3;  	        }
             |   unit '*' unit        	    { $$ = $1 * $3;    	                }
             |   unit '/' unit        		{ $$ = $1 / $3;    	                }
             |   unit '^' num        	    { $$ = $1.pow ($3);                 }

--- a/src/Base/Unit.cpp
+++ b/src/Base/Unit.cpp
@@ -481,11 +481,13 @@ QString Unit::getTypeString(void) const
     if(*this == Unit::Force                       )       return QString::fromLatin1("Force"); else
     if(*this == Unit::Work                        )       return QString::fromLatin1("Work"); else
     if(*this == Unit::Power                       )       return QString::fromLatin1("Power"); else
+    if(*this == Unit::SpecificEnergy              )       return QString::fromLatin1("SpecificEnergy"); else
     if(*this == Unit::ThermalConductivity         )       return QString::fromLatin1("ThermalConductivity"); else
     if(*this == Unit::ThermalExpansionCoefficient )       return QString::fromLatin1("ThermalExpansionCoefficient"); else
     if(*this == Unit::SpecificHeat                )       return QString::fromLatin1("SpecificHeat"); else
     if(*this == Unit::ThermalTransferCoefficient  )       return QString::fromLatin1("ThermalTransferCoefficient"); else
     if(*this == Unit::HeatFlux                    )       return QString::fromLatin1("HeatFlux"); else
+    if(*this == Unit::DynamicViscosity            )       return QString::fromLatin1("DynamicViscosity"); else
     if(*this == Unit::KinematicViscosity          )       return QString::fromLatin1("KinematicViscosity"); else
 
     return QString();
@@ -515,9 +517,11 @@ Unit Unit::Force   (1,1,-2);
 Unit Unit::Work    (2,1,-2);
 Unit Unit::Power   (2,1,-3);
 
+Unit Unit::SpecificEnergy              (2,0,-2);
 Unit Unit::ThermalConductivity         (1,1,-3,0,-1);
 Unit Unit::ThermalExpansionCoefficient (0,0,0,0,-1);
 Unit Unit::SpecificHeat                (2,0,-2,0,-1);
 Unit Unit::ThermalTransferCoefficient  (0,1,-3,0,-1);
 Unit Unit::HeatFlux                    (0,1,-3,0,0);
+Unit Unit::DynamicViscosity            (-1,1,-1);  // SI unit: kg/m/s
 Unit Unit::KinematicViscosity          (2,0,-1);  // SI unit: m^2/s, https://en.wikipedia.org/wiki/Viscosity#Kinematic_viscosity

--- a/src/Base/Unit.h
+++ b/src/Base/Unit.h
@@ -116,11 +116,13 @@ public:
     static Unit Work;
     static Unit Power;
 
+    static Unit SpecificEnergy;
     static Unit ThermalConductivity;
     static Unit ThermalExpansionCoefficient;
     static Unit SpecificHeat;
     static Unit ThermalTransferCoefficient;
     static Unit HeatFlux;
+    static Unit DynamicViscosity;
     static Unit KinematicViscosity;
 
     //@}

--- a/src/Base/UnitsSchemaInternal.cpp
+++ b/src/Base/UnitsSchemaInternal.cpp
@@ -167,6 +167,10 @@ QString UnitsSchemaInternal::schemaTranslate(const Quantity &quant, double &fact
         unitString = QString::fromLatin1("W");
         factor = 1000000;
     }
+    else if (unit == Unit::SpecificEnergy) {
+        unitString = QString::fromLatin1("m^2/s^2");
+        factor = 1000000;
+    }
     else if (unit == Unit::HeatFlux) {
         unitString = QString::fromLatin1("W/m^2");
         factor = 1.0;
@@ -174,6 +178,10 @@ QString UnitsSchemaInternal::schemaTranslate(const Quantity &quant, double &fact
     else if (unit == Unit::Velocity) {
         unitString = QString::fromLatin1("mm/s");
         factor = 1.0;
+    }
+    else if (unit == Unit::DynamicViscosity) {
+        unitString = QString::fromLatin1("kg/(m*s)");
+        factor = 0.001;
     }
     else {
         // default action for all cases without special treatment:

--- a/src/Base/UnitsSchemaMKS.cpp
+++ b/src/Base/UnitsSchemaMKS.cpp
@@ -44,8 +44,8 @@ QString UnitsSchemaMKS::schemaTranslate(const Quantity &quant, double &factor, Q
     // now do special treatment on all cases seems necessary:
     if (unit == Unit::Length) {  // Length handling ============================
         if (UnitValue < 0.000000001) {// smaller then 0.001 nm -> scientific notation
-            unitString = QString::fromLatin1("mm");
-            factor = 1.0;
+            unitString = QString::fromLatin1("m");
+            factor = 1000.0;
         }
         else if(UnitValue < 0.001) {
             unitString = QString::fromLatin1("nm");
@@ -68,8 +68,8 @@ QString UnitsSchemaMKS::schemaTranslate(const Quantity &quant, double &factor, Q
             factor = 1000000.0;
         }
         else { // bigger then 1000 km -> scientific notation
-            unitString = QString::fromLatin1("mm");
-            factor = 1.0;
+            unitString = QString::fromLatin1("m");
+            factor = 1000.0;
         }
     }
     else if (unit == Unit::Area) {
@@ -91,6 +91,20 @@ QString UnitsSchemaMKS::schemaTranslate(const Quantity &quant, double &factor, Q
         // default action for all cases without special treatment:
         unitString = quant.getUnit().getString();
         factor = 1.0;
+    }
+    else if (unit == Unit::Density) {
+        if (UnitValue < 0.0001) {
+            unitString = QString::fromLatin1("kg/m^3");
+            factor = 0.000000001;
+        }
+        else if (UnitValue < 1.0) {
+            unitString = QString::fromLatin1("kg/cm^3");
+            factor = 0.001;
+        }
+        else {
+            unitString = QString::fromLatin1("kg/mm^3");
+            factor = 1.0;
+        }
     }
     else if (unit == Unit::Volume) {
         if (UnitValue < 1000000.0) {// smaller than 10 cubic cm
@@ -169,8 +183,8 @@ QString UnitsSchemaMKS::schemaTranslate(const Quantity &quant, double &factor, Q
         factor = 1.0;
     }
     else if (unit == Unit::Velocity) {
-        unitString = QString::fromLatin1("mm/s");
-        factor = 1.0;
+        unitString = QString::fromLatin1("m/s");
+        factor = 1000.0;
     }
     else if (unit == Unit::DynamicViscosity) {
         unitString = QString::fromLatin1("kg/(m*s)");

--- a/src/Base/UnitsSchemaMKS.cpp
+++ b/src/Base/UnitsSchemaMKS.cpp
@@ -160,6 +160,10 @@ QString UnitsSchemaMKS::schemaTranslate(const Quantity &quant, double &factor, Q
         unitString = QString::fromLatin1("W");
         factor = 1000000;
     }
+    else if (unit == Unit::SpecificEnergy) {
+        unitString = QString::fromLatin1("m^2/s^2");
+        factor = 1000000;
+    }
     else if (unit == Unit::HeatFlux) {
         unitString = QString::fromLatin1("W/m^2");
         factor = 1.0;
@@ -167,6 +171,10 @@ QString UnitsSchemaMKS::schemaTranslate(const Quantity &quant, double &factor, Q
     else if (unit == Unit::Velocity) {
         unitString = QString::fromLatin1("mm/s");
         factor = 1.0;
+    }
+    else if (unit == Unit::DynamicViscosity) {
+        unitString = QString::fromLatin1("kg/(m*s)");
+        factor = 0.001;
     }
     else {
         // default action for all cases without special treatment:

--- a/src/Gui/InputField.cpp
+++ b/src/Gui/InputField.cpp
@@ -295,6 +295,8 @@ void InputField::newInput(const QString & text)
     double dFactor;
     res.getUserString(dFactor,actUnitStr);
     actUnitValue = res.getValue()/dFactor;
+    // Preserve previous format
+    res.setFormat(this->actQuantity.getFormat());
     actQuantity = res;
 
     // signaling
@@ -446,6 +448,20 @@ const Base::Unit& InputField::getUnit() const
     return actUnit;
 }
 
+/// get stored, valid quantity as a string
+QString InputField::getQuantityString(void) const
+{
+    return actQuantity.getUserString();
+}
+
+/// set, validate and display quantity from a string. Must match existing units.
+void InputField::setQuantityString(const QString& text)
+{
+    // Input and then format the quantity
+    newInput(text);
+    updateText(actQuantity);
+}
+
 /// get the value of the singleStep property
 double InputField::singleStep(void)const
 {
@@ -506,6 +522,37 @@ QString InputField::getUnitText(void)
     return actUnitStr;
 }
 
+int InputField::getPrecision() const
+{
+    return this->actQuantity.getFormat().precision;
+}
+
+void InputField::setPrecision(const int precision)
+{
+    Base::QuantityFormat format = actQuantity.getFormat();
+    format.precision = precision;
+    actQuantity.setFormat(format);
+    updateText(actQuantity);
+}
+
+QString InputField::getFormat() const
+{
+    return QString(QChar::fromLatin1(actQuantity.getFormat().toFormat()));
+}
+
+void InputField::setFormat(const QString& format)
+{
+    Base::QuantityFormat f = this->actQuantity.getFormat();
+    if (format == QString::fromLatin1("f"))
+        f.format = Base::QuantityFormat::NumberFormat::Fixed;
+    else if (format == QString::fromLatin1("e"))
+        f.format = Base::QuantityFormat::NumberFormat::Scientific;
+    else
+        f.format = Base::QuantityFormat::NumberFormat::Default;
+    actQuantity.setFormat(f);
+    updateText(actQuantity);
+}
+
 // get the value of the minimum property
 int InputField::historySize(void)const
 {
@@ -529,6 +576,7 @@ void InputField::selectNumber(void)
     QChar d = locale().decimalPoint();
     QChar g = locale().groupSeparator();
     QChar n = locale().negativeSign();
+    QChar e = locale().exponential();
 
     for (QString::iterator it = str.begin(); it != str.end(); ++it) {
         if (it->isDigit())
@@ -538,6 +586,8 @@ void InputField::selectNumber(void)
         else if (*it == g)
             i++;
         else if (*it == n)
+            i++;
+        else if (*it == e && actQuantity.getFormat().format != Base::QuantityFormat::Fixed)
             i++;
         else // any non-number character
             break;

--- a/src/Gui/InputField.h
+++ b/src/Gui/InputField.h
@@ -68,7 +68,10 @@ class GuiExport InputField : public ExpressionLineEdit, public ExpressionBinding
     Q_PROPERTY(double minimum READ minimum WRITE setMinimum )
     Q_PROPERTY(int historySize READ historySize WRITE setHistorySize )
     Q_PROPERTY(QString unit READ getUnitText WRITE setUnitText )
+    Q_PROPERTY(int precision READ getPrecision WRITE setPrecision )
+    Q_PROPERTY(QString format READ getFormat WRITE setFormat )
     Q_PROPERTY(Base::Quantity quantity READ getQuantity WRITE setValue )
+    Q_PROPERTY(QString quantityString READ getQuantityString WRITE setQuantityString )
 
 
 public:
@@ -82,6 +85,12 @@ public:
 
     /// get the current value
     Base::Quantity getQuantity(void)const{return this->actQuantity;}
+
+    /// get stored, valid quantity as a string (user string - avoid storing)
+    QString getQuantityString(void) const;
+
+    /// set, validate and display quantity from a string. Must match existing units.
+    void setQuantityString(const QString& text);
 
     /// gives the current state of the user input, gives true if it is a valid input with correct quantity
     /// (shown by the green pixmap), returns false if the input is a unparsable string or has a wrong unit
@@ -119,6 +128,14 @@ public:
     void setUnitText(const QString&);
     /// get the unit as a string (can be used in the *.ui file)  
     QString getUnitText(void); 
+    /// get the value of the precision property
+    int getPrecision(void) const; 
+    /// set the value of the precision property (can be used in the *.ui file)  
+    void setPrecision(const int);
+    /// get the value of the format property: "f" (fixed), "e" (scientific), "g" (general)
+    QString getFormat(void) const; 
+    /// set the value of the format property (can be used in the *.ui file)  
+    void setFormat(const QString&);
     /// set the number portion selected (use after setValue()) 
     void selectNumber(void);
     /// input validation


### PR DESCRIPTION
This resolves the problem of numbers displayed in InputField widgets having to use the default fixed-precision formatting and the resultant truncation. From python I could not get around this issue, hence some additional properties have been added to InputField.

The issue was raised in the forum [here](https://forum.freecadweb.org/viewtopic.php?f=10&t=22732&sid=7d262875885a756746c76d3b29159bc5):
My initial attempt was to change the QuantityFormat member of the Quantity object stored by the InputField, but despite every effort I was unable to get the setProperty('quantity', ...) method on the InputField widget to work, even though I could retrieve the same property without a problem. (Possibly some subtle issue with PySide...who knows.) Therefore I added a new 'format' property to directly set the format to 'f', 'e', 'g', and this has the advantage or easy specification in the .ui file.

Also:
- Added a 'precision' property to change the number of decimal places from the default if wanted
- Added a 'quantityString' property to allow direct setting of the quantity in string representation so that a new value can be validated as if it were typed in, but also displayed correctly formatted. From python this couldn't be done without hiding and re-showing the widget after inputting a new value.
- Added two units needed for the CFD  workbench (DynamicViscosity, SpecificEnergy)
- Made some tweaks to the MKS units schema to favour the display of some common compound units using m rather than mm
- Modified the QuantityParser to accept 1/[unit] as a valid unit equivalent to [unit]^-1. This was a problem because the string representation of [unit]^-1 is outputted as 1/[unit] which is then not recognised, and so cannot be used in InputFields. 
e.g., before:
```
>>> import Units
>>> Units.Quantity('50 s^-1')
50 1/s
>>> Units.Quantity('50 1/s')
Traceback (most recent call last):
  File "<input>", line 1, in <module>
ValueError: syntax error
```
After:
```
>>> import Units
>>> Units.Quantity('50 s^-1')
50 1/s
>>> Units.Quantity('50 1/s')
50 1/s
```
Of course, the alternative would be to change the string representation to only output ...^-1 rather than 1/..., but it seems more consistent to accept 1/[unit]
