### PR TITLE
GUI: Do not overwrite tooltips for InputFields.

### DIFF
--- a/src/Gui/InputField.cpp
+++ b/src/Gui/InputField.cpp
@@ -254,7 +254,6 @@ void InputField::newInput(const QString & text)
     }
     catch(Base::Exception &e){
         ErrorText = e.what();
-        this->setToolTip(QString::fromLatin1(ErrorText.c_str()));
         QPixmap pixmap = getValidationIcon(":/icons/button_invalid.svg", QSize(sizeHint().height(),sizeHint().height()));
         iconLabel->setPixmap(pixmap);
         parseError(QString::fromLatin1(ErrorText.c_str()));
@@ -267,7 +266,6 @@ void InputField::newInput(const QString & text)
 
     // check if unit fits!
     if(!actUnit.isEmpty() && !res.getUnit().isEmpty() && actUnit != res.getUnit()){
-        this->setToolTip(QString::fromLatin1("Wrong unit"));
         QPixmap pixmap = getValidationIcon(":/icons/button_invalid.svg", QSize(sizeHint().height(),sizeHint().height()));
         iconLabel->setPixmap(pixmap);
         parseError(QString::fromLatin1("Wrong unit"));
@@ -278,19 +276,14 @@ void InputField::newInput(const QString & text)
 
     QPixmap pixmap = getValidationIcon(":/icons/button_valid.svg", QSize(sizeHint().height(),sizeHint().height()));
     iconLabel->setPixmap(pixmap);
-    ErrorText = "";
     validInput = true;
 
     if (res.getValue() > Maximum){
         res.setValue(Maximum);
-        ErrorText = "Maximum reached";
     }
     if (res.getValue() < Minimum){
         res.setValue(Minimum);
-        ErrorText = "Minimum reached";
     }
-
-    this->setToolTip(QString::fromLatin1(ErrorText.c_str()));
 
     double dFactor;
     res.getUserString(dFactor,actUnitStr);


### PR DESCRIPTION
InputField currently uses the tooltip of it's underlying widget for error reporting - clearing the tooltip if there is not error. This is not intuitive behaviour of a standard widget and renders any tooltip assigned to the widget useless.

This patch removes the code to overwrite the tooltip and thereby makes assigned tooltips to InputFields pop up again - as they do for all other widgets.