### PR TITLE
PATH: Set DocumentObject's Restore flag while restoring the Path property

### DIFF
--- a/src/Mod/Path/App/PropertyPath.cpp
+++ b/src/Mod/Path/App/PropertyPath.cpp
@@ -28,6 +28,8 @@
 #endif
 
 
+#include <App/DocumentObject.h>
+#include <App/PropertyContainer.h>
 #include <Base/Console.h>
 #include <Base/Writer.h>
 #include <Base/Reader.h>
@@ -124,9 +126,23 @@ void PropertyPath::SaveDocFile (Base::Writer &) const
 
 void PropertyPath::RestoreDocFile(Base::Reader &reader)
 {
+    App::PropertyContainer *container = getContainer();
+    App::DocumentObject *obj = 0;
+    if (container->isDerivedFrom(App::DocumentObject::getClassTypeId())) {
+        obj = static_cast<App::DocumentObject*>(container);
+    }
+
+    if (obj) {
+        obj->setStatus(App::ObjectStatus::Restore, true);
+    }
+
     aboutToSetValue();
     _Path.RestoreDocFile(reader);
     hasSetValue();
+
+    if (obj) {
+        obj->setStatus(App::ObjectStatus::Restore, false);
+    }
 }
 
 

--- a/src/Mod/Path/PathScripts/PathToolController.py
+++ b/src/Mod/Path/PathScripts/PathToolController.py
@@ -134,8 +134,8 @@ class ToolController:
     def onChanged(self, obj, prop):
         PathLog.track('prop: {}  state: {}'.format(prop, obj.State))
 
-
-        if 'Restore' not in obj.State:
+        if 'Path' == prop and 'Restore' not in obj.State:
+            PathLog.debug("--- dirty deeds")
             job = PathScripts.PathUtils.findParentJob(obj)
             if job is not None:
                 for g in job.Group:


### PR DESCRIPTION
Currently when a file with Path objects is loaded the document needs to be recomputed because some Path objects restore into a dirty state. This patch fixes this behaviour and the document is clean when opened.