### PR TITLE
* PDN: fixes #<0003161> "ShapeBinder not at expected place"

### DIFF
--- a/src/Mod/PartDesign/App/ShapeBinder.cpp
+++ b/src/Mod/PartDesign/App/ShapeBinder.cpp
@@ -67,8 +67,22 @@ App::DocumentObjectExecReturn* ShapeBinder::execute(void) {
         ShapeBinder::getFilteredReferences(&Support, obj, subs);
         //if we have a link we rebuild the shape, but we change nothing if we are a simple copy
         if(obj) {
-            Shape.setValue(ShapeBinder::buildShapeFromReferences(obj, subs).getShape());
-            Placement.setValue(obj->Placement.getValue());
+			TopoDS_Shape shape = ShapeBinder::buildShapeFromReferences(obj, subs).getShape();
+				
+			TopLoc_Location loc = shape.Location();
+			gp_Trsf trsf = loc.Transformation();
+			gp_XYZ transl = trsf.TranslationPart();
+			
+			gp_XYZ xyz_rot;
+			Standard_Real theAngle;
+			trsf.GetRotation(xyz_rot, theAngle);
+
+			Base::Vector3d vect_rot(xyz_rot.X(), xyz_rot.Y(), xyz_rot.Z());
+			Base::Rotation rot(vect_rot, theAngle);
+			Base::Placement place(Base::Vector3d(transl.X(), transl.Y(), transl.Z()), rot);
+			
+			Shape.setValue(shape);
+			Placement.setValue(place);
         }
     }
 


### PR DESCRIPTION
Instead of using the placement of the Part::Features the ShapeBinder
is based on, use the shapes location. The problem was, that when using
the placement of the feature, the ShapeBinder had a wrong translation
and rotation.

Discussed here "https://forum.freecadweb.org/viewtopic.php?f=3&t=23893&sid=3f16d093fcc7cc76188387dc84f46a0e&start=10"

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR once it is merged.

---
