### PR TITLE
Fixes #<0003159> ShapeBinder is part of solid

### DIFF
--- a/src/Mod/PartDesign/App/FeaturePad.cpp
+++ b/src/Mod/PartDesign/App/FeaturePad.cpp
@@ -50,6 +50,7 @@
 #include <Base/Console.h>
 #include <Base/Reader.h>
 #include <App/Document.h>
+#include <Mod/PartDesign/App/ShapeBinder.h>
 
 //#include "Body.h"
 #include "FeaturePad.h"
@@ -214,12 +215,20 @@ App::DocumentObjectExecReturn *Pad::execute(void)
         if (!base.IsNull()) {
 //             auto obj = getDocument()->addObject("Part::Feature", "prism");
 //             static_cast<Part::Feature*>(obj)->Shape.setValue(getSolid(prism));
-            // Let's call algorithm computing a fuse operation:
-            BRepAlgoAPI_Fuse mkFuse(base, prism);
-            // Let's check if the fusion has been successful
-            if (!mkFuse.IsDone())
-                return new App::DocumentObjectExecReturn("Pad: Fusion with base feature failed");
-            TopoDS_Shape result = mkFuse.Shape();
+			TopoDS_Shape result;
+			if (getBaseObject()->getTypeId().isDerivedFrom(PartDesign::ShapeBinder::getClassTypeId()))
+			{
+				result = prism;
+			}
+			else
+			{
+				// Let's call algorithm computing a fuse operation:
+				BRepAlgoAPI_Fuse mkFuse(base, prism);
+				// Let's check if the fusion has been successful
+				if (!mkFuse.IsDone())
+					return new App::DocumentObjectExecReturn("Pad: Fusion with base feature failed");
+				result = mkFuse.Shape();
+			}
             // we have to get the solids (fuse sometimes creates compounds)
             TopoDS_Shape solRes = this->getSolid(result);
             // lets check if the result is a solid


### PR DESCRIPTION
Avoid making a fuse of the underlying base shape and the newly create
prism if base is a ShapeBinder

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR once it is merged.

---
