### PR TITLE
Fix macOS Qt4 build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -186,7 +186,9 @@ before_install:
 
           brew install --verbose --only-dependencies freecad --with-qt4 --with-packaging-utils
           brew install --verbose --only-dependencies freecad --with-qt4 --with-packaging-utils #Ensure all dependencies are satisfied
-
+          # qt4 bottle contains postgresql plugin even when --with-postgresql option is not specified
+          # and so postgresql dep is not installed. Delete it because the plugin is not included with qt5 bottle.
+          sudo rm -f /usr/local/lib/qt4/plugins/sqldrivers/libqsqlpsql.dylib
        elif [ "${QT}" == "Qt5" ]; then
           # Qt5: Replace Qt4 in ports-cache with Qt5, if necessary
           brew ls --versions cartr/qt4/qt > /dev/null && \

--- a/src/MacAppBundle/CMakeLists.txt
+++ b/src/MacAppBundle/CMakeLists.txt
@@ -50,7 +50,22 @@ if(BUILD_QT5)
   set(XCTEST_PATH "${XCODE_PATH}/Platforms/MacOSX.platform/Developer/Library/Frameworks/XCTest.framework/Versions/Current")
 endif(BUILD_QT5)
 
-install(DIRECTORY ${QT_PLUGINS_DIR}/ DESTINATION ${CMAKE_INSTALL_LIBDIR}/qtplugins )
+# Ensure the actual plugin files are installed instead of symlinks.
+file(GLOB _subdirs RELATIVE "${QT_PLUGINS_DIR}" "${QT_PLUGINS_DIR}/*")
+
+foreach(_subdir ${_subdirs})
+    if(IS_DIRECTORY "${QT_PLUGINS_DIR}/${_subdir}")
+        set(_resolved_files "")
+        file(GLOB _plugin_files RELATIVE "${QT_PLUGINS_DIR}/${_subdir}" "${QT_PLUGINS_DIR}/${_subdir}/*")
+
+        foreach(_plugin_file ${_plugin_files})
+            get_filename_component(_resolved_file "${QT_PLUGINS_DIR}/${_subdir}/${_plugin_file}" REALPATH)
+            list(APPEND _resolved_files ${_resolved_file})
+        endforeach()
+
+        install(FILES ${_resolved_files} DESTINATION "${CMAKE_INSTALL_LIBDIR}/qtplugins/${_subdir}")
+    endif()
+endforeach()
 
 #files installed by homebrew do not have write permission for regular user
 install(CODE "execute_process(COMMAND chmod -R a+w ${CMAKE_INSTALL_LIBDIR})")


### PR DESCRIPTION
- Dereference qt plugin symlinks
- Remove qt postgresql plugin because of missing dependency

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR once it is merged.

---
