### PR TITLE
Arch: fix grammatical error

### DIFF
--- a/src/Mod/Arch/ArchEquipment.py
+++ b/src/Mod/Arch/ArchEquipment.py
@@ -48,7 +48,7 @@ else:
 #  \brief The Equipment object and tools
 #
 #  This module provides tools to build equipment objects.
-#  Equipments are used to represent furniture and all kinds of electrical
+#  Equipment is used to represent furniture and all kinds of electrical
 #  or hydraulic appliances in a building
 
 # presets

--- a/src/Mod/Arch/ArchSpace.py
+++ b/src/Mod/Arch/ArchSpace.py
@@ -258,8 +258,8 @@ class _Space(ArchComponent.Component):
         obj.addProperty("App::PropertyLink",       "Zone",          "Arch",QT_TRANSLATE_NOOP("App::Property","A zone this space is part of"))
         obj.addProperty("App::PropertyInteger",    "NumberOfPeople","Arch",QT_TRANSLATE_NOOP("App::Property","The number of people who typically occupy this space"))
         obj.addProperty("App::PropertyFloat",      "LightingPower", "Arch",QT_TRANSLATE_NOOP("App::Property","The electric power needed to light this space in Watts"))
-        obj.addProperty("App::PropertyFloat",      "EquipmentPower","Arch",QT_TRANSLATE_NOOP("App::Property","The electric power needed by the equipments of this space in Watts"))
-        obj.addProperty("App::PropertyBool",       "AutoPower",     "Arch",QT_TRANSLATE_NOOP("App::Property","If True, Equipment Power will be automatically filled by the equipments included in this space"))
+        obj.addProperty("App::PropertyFloat",      "EquipmentPower","Arch",QT_TRANSLATE_NOOP("App::Property","The electric power needed by the equipment of this space in Watts"))
+        obj.addProperty("App::PropertyBool",       "AutoPower",     "Arch",QT_TRANSLATE_NOOP("App::Property","If True, Equipment Power will be automatically filled by the equipment included in this space"))
         obj.addProperty("App::PropertyEnumeration","Conditioning",  "Arch",QT_TRANSLATE_NOOP("App::Property","The type of air conditioning of this space"))
         self.Type = "Space"
         obj.SpaceType = SpaceTypes

--- a/src/Mod/Arch/Resources/translations/Arch.ts
+++ b/src/Mod/Arch/Resources/translations/Arch.ts
@@ -834,12 +834,12 @@
     </message>
     <message>
         <location filename="ArchSpace.py" line="261"/>
-        <source>The electric power needed by the equipments of this space in Watts</source>
+        <source>The electric power needed by the equipment of this space in Watts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="ArchSpace.py" line="262"/>
-        <source>If True, Equipment Power will be automatically filled by the equipments included in this space</source>
+        <source>If True, Equipment Power will be automatically filled by the equipment included in this space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>


### PR DESCRIPTION
Changed `equipments` to `equipment`
@yorikvanhavre is this OK with you?