### PR TITLE
PATH: Feature/Stock - first steps in supporting Stock

### DIFF
--- a/src/Mod/Path/CMakeLists.txt
+++ b/src/Mod/Path/CMakeLists.txt
@@ -45,6 +45,7 @@ SET(PathScripts_SRCS
     PathScripts/PathHop.py
     PathScripts/PathInspect.py
     PathScripts/PathJob.py
+    PathScripts/PathJobCmd.py
     PathScripts/PathJobGui.py
     PathScripts/PathLog.py
     PathScripts/PathMillFace.py

--- a/src/Mod/Path/CMakeLists.txt
+++ b/src/Mod/Path/CMakeLists.txt
@@ -118,6 +118,7 @@ SET(PathTests_SRCS
     PathTests/TestPathGeom.py
     PathTests/TestPathLog.py
     PathTests/TestPathPost.py
+    PathTests/TestPathStock.py
     PathTests/TestPathUtil.py
 )
 

--- a/src/Mod/Path/CMakeLists.txt
+++ b/src/Mod/Path/CMakeLists.txt
@@ -45,6 +45,7 @@ SET(PathScripts_SRCS
     PathScripts/PathHop.py
     PathScripts/PathInspect.py
     PathScripts/PathJob.py
+    PathScripts/PathJobGui.py
     PathScripts/PathLog.py
     PathScripts/PathMillFace.py
     PathScripts/PathMillFaceGui.py

--- a/src/Mod/Path/CMakeLists.txt
+++ b/src/Mod/Path/CMakeLists.txt
@@ -43,6 +43,7 @@ SET(PathScripts_SRCS
     PathScripts/PathHelix.py
     PathScripts/PathHelixGui.py
     PathScripts/PathHop.py
+    PathScripts/PathIconViewProvider.py
     PathScripts/PathInspect.py
     PathScripts/PathJob.py
     PathScripts/PathJobCmd.py

--- a/src/Mod/Path/Gui/Resources/Path.qrc
+++ b/src/Mod/Path/Gui/Resources/Path.qrc
@@ -54,6 +54,7 @@
         <file>panels/DlgJobChooser.ui</file>
         <file>panels/DlgJobCreate.ui</file>
         <file>panels/DlgSelectPostProcessor.ui</file>
+        <file>panels/DlgToolControllerEdit.ui</file>
         <file>panels/DlgToolCopy.ui</file>
         <file>panels/DlgTCChooser.ui</file>
         <file>panels/DogboneEdit.ui</file>

--- a/src/Mod/Path/Gui/Resources/Path.qrc
+++ b/src/Mod/Path/Gui/Resources/Path.qrc
@@ -53,6 +53,7 @@
         <file>icons/preferences-path.svg</file>
         <file>panels/DlgJobChooser.ui</file>
         <file>panels/DlgJobCreate.ui</file>
+        <file>panels/DlgJobTemplateExport.ui</file>
         <file>panels/DlgSelectPostProcessor.ui</file>
         <file>panels/DlgToolControllerEdit.ui</file>
         <file>panels/DlgToolCopy.ui</file>

--- a/src/Mod/Path/Gui/Resources/Path.qrc
+++ b/src/Mod/Path/Gui/Resources/Path.qrc
@@ -69,6 +69,7 @@
         <file>panels/PageOpHelixEdit.ui</file>
         <file>panels/PageOpPocketFullEdit.ui</file>
         <file>panels/PageOpProfileFullEdit.ui</file>
+        <file>panels/PathEdit.ui</file>
         <file>panels/PointEdit.ui</file>
         <file>panels/SurfaceEdit.ui</file>
         <file>panels/ToolControl.ui</file>

--- a/src/Mod/Path/Gui/Resources/panels/DlgJobCreate.ui
+++ b/src/Mod/Path/Gui/Resources/panels/DlgJobCreate.ui
@@ -6,65 +6,52 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>400</width>
-    <height>208</height>
+    <width>365</width>
+    <height>147</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Dialog</string>
   </property>
-  <layout class="QFormLayout" name="formLayout">
-   <property name="fieldGrowthPolicy">
-    <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
-   </property>
-   <item row="1" column="0">
-    <widget class="QLabel" name="label_4">
-     <property name="text">
-      <string>Base Model </string>
-     </property>
+  <layout class="QVBoxLayout" name="verticalLayout_2">
+   <item>
+    <widget class="QWidget" name="widget_4" native="true">
+     <layout class="QGridLayout" name="gridLayout_2">
+      <item row="1" column="1">
+       <widget class="QComboBox" name="cbTemplate">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Select a template to be used for the job.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;In case there are no templates you can create one through the popup menu of an existing job. Name the file job_*.xml and place it in the macro or the path directory (see preferences) in order to be selectable from this list.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Note that the result is a plain xml file and can be edited by hand. Any properties not specified in the template will be set to their default value.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_4">
+        <property name="text">
+         <string>Base Model </string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label">
+        <property name="text">
+         <string>Template</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QComboBox" name="cbModel"/>
+      </item>
+     </layout>
     </widget>
    </item>
-   <item row="1" column="1">
-    <widget class="QComboBox" name="cbModel"/>
-   </item>
-   <item row="2" column="0">
-    <widget class="QLabel" name="label">
-     <property name="text">
-      <string>Template</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="1">
-    <widget class="QComboBox" name="cbTemplate">
-     <property name="enabled">
-      <bool>true</bool>
-     </property>
-     <property name="toolTip">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Select a template to be used for the job.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;In case there are no templates you can create one through the popup menu of an existing job. Name the file job_*.xml and place it in the macro or the path directory (see preferences) in order to be selectable from this list.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Note that the result is a plain xml file and can be edited by hand. Any properties not specified in the template will be set to their default value.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="0">
-    <widget class="QLabel" name="label_2">
-     <property name="text">
-      <string>Stock</string>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="1">
-    <widget class="QComboBox" name="cbStock">
-     <property name="enabled">
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="autoFillBackground">
       <bool>false</bool>
      </property>
-     <item>
-      <property name="text">
-       <string>coming soon</string>
-      </property>
-     </item>
-    </widget>
-   </item>
-   <item row="7" column="1">
-    <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
      </property>

--- a/src/Mod/Path/Gui/Resources/panels/DlgJobTemplateExport.ui
+++ b/src/Mod/Path/Gui/Resources/panels/DlgJobTemplateExport.ui
@@ -1,0 +1,193 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Dialog</class>
+ <widget class="QDialog" name="Dialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>422</width>
+    <height>432</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Job Template Export</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QGroupBox" name="postProcessingGroup">
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If enabled include all post processing settings in the template.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="title">
+      <string>Post Processing</string>
+     </property>
+     <property name="checkable">
+      <bool>true</bool>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_2">
+      <item>
+       <widget class="QLineEdit" name="postProcessingHint">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="focusPolicy">
+         <enum>Qt::NoFocus</enum>
+        </property>
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Hint about the current post processing configuration.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="stockGroup">
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If enabled the creation of stock is included in the template. If a template does not include a stock definition the default stock creation algorithm will be used (creation from the Base object's bound box).&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;This option is most useful if stock is a box or cylinder, or if the machine has a standard placement for machining.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Note that this option is disabled if a stock object from an existing solid is used in the job - they cannot be stored in a template.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="title">
+      <string>Stock</string>
+     </property>
+     <property name="checkable">
+      <bool>true</bool>
+     </property>
+     <layout class="QGridLayout" name="gridLayout">
+      <item row="0" column="0">
+       <widget class="QCheckBox" name="stockExtent">
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If enabled the current size settings for the stock object are included in the template.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;For Box and Cylinder stocks this means the actual size of the stock solid being created.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;For stock from the Base object's bound box it means the extra material in all directions. A stock object created from such a template will get its basic size from the new job's Base object and apply the stored extra settings.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="text">
+         <string>Extent</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QCheckBox" name="stockPlacement">
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If enabled the current placement of the stock solid is stored in the template.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="text">
+         <string>Placement</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QLineEdit" name="stockExtentHint">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="focusPolicy">
+         <enum>Qt::NoFocus</enum>
+        </property>
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Hint about the current stock extent setting.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QLineEdit" name="stockPlacementHint">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="focusPolicy">
+         <enum>Qt::NoFocus</enum>
+        </property>
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Hint about the current stock placement.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="toolsGroup">
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If enabled tool controller definitions are stored in the template.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="title">
+      <string>Tools</string>
+     </property>
+     <property name="checkable">
+      <bool>true</bool>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_3">
+      <item>
+       <widget class="QListWidget" name="toolsList">
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Check all tool controllers which should be included in the template.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <tabstops>
+  <tabstop>postProcessingGroup</tabstop>
+  <tabstop>stockGroup</tabstop>
+  <tabstop>stockExtent</tabstop>
+  <tabstop>stockPlacement</tabstop>
+  <tabstop>toolsGroup</tabstop>
+  <tabstop>toolsList</tabstop>
+  <tabstop>buttonBox</tabstop>
+  <tabstop>stockExtentHint</tabstop>
+  <tabstop>stockPlacementHint</tabstop>
+  <tabstop>postProcessingHint</tabstop>
+ </tabstops>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>Dialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>Dialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/src/Mod/Path/Gui/Resources/panels/DlgToolControllerEdit.ui
+++ b/src/Mod/Path/Gui/Resources/panels/DlgToolControllerEdit.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Dialog</string>
+   <string>Tool Controller Editor</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>

--- a/src/Mod/Path/Gui/Resources/panels/DlgToolControllerEdit.ui
+++ b/src/Mod/Path/Gui/Resources/panels/DlgToolControllerEdit.ui
@@ -1,0 +1,534 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Dialog</class>
+ <widget class="QDialog" name="Dialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>492</width>
+    <height>648</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Dialog</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QToolBox" name="toolBox">
+     <widget class="QWidget" name="toolBoxPage1" native="true">
+      <attribute name="label">
+       <string>Controller</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_2">
+       <item>
+        <widget class="QGroupBox" name="groupBox_4">
+         <property name="title">
+          <string>Controller Name /  Tool Number</string>
+         </property>
+         <layout class="QHBoxLayout" name="horizontalLayout">
+          <item>
+           <widget class="QLineEdit" name="tcName">
+            <property name="readOnly">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QSpinBox" name="tcNumber"/>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QFrame" name="frame">
+         <property name="frameShape">
+          <enum>QFrame::StyledPanel</enum>
+         </property>
+         <property name="frameShadow">
+          <enum>QFrame::Raised</enum>
+         </property>
+         <layout class="QFormLayout" name="formLayout">
+          <item row="0" column="0">
+           <widget class="QLabel" name="label">
+            <property name="text">
+             <string>Horiz. Feed</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="label_2">
+            <property name="text">
+             <string>Vert. Feed</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="label_5">
+            <property name="text">
+             <string>Horiz Rapid</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="label_4">
+            <property name="text">
+             <string>Vert Rapid</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="Gui::InputField" name="horizFeed">
+            <property name="minimum" stdset="0">
+             <double>0.000000000000000</double>
+            </property>
+            <property name="unit" stdset="0">
+             <string notr="true">mm/s</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="Gui::InputField" name="vertFeed">
+            <property name="minimum" stdset="0">
+             <double>0.000000000000000</double>
+            </property>
+            <property name="unit" stdset="0">
+             <string notr="true">mm/s</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="Gui::InputField" name="horizRapid">
+            <property name="minimum" stdset="0">
+             <double>0.000000000000000</double>
+            </property>
+            <property name="unit" stdset="0">
+             <string notr="true">mm/s</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <widget class="Gui::InputField" name="vertRapid">
+            <property name="minimum" stdset="0">
+             <double>0.000000000000000</double>
+            </property>
+            <property name="unit" stdset="0">
+             <string notr="true">mm/s</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="groupBox_3">
+         <property name="title">
+          <string>Spindle</string>
+         </property>
+         <layout class="QFormLayout" name="formLayout_2">
+          <property name="fieldGrowthPolicy">
+           <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+          </property>
+          <item row="0" column="1">
+           <widget class="QComboBox" name="spindleDirection">
+            <item>
+             <property name="text">
+              <string>Forward</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Reverse</string>
+             </property>
+            </item>
+           </widget>
+          </item>
+          <item row="0" column="0">
+           <widget class="QDoubleSpinBox" name="spindleSpeed">
+            <property name="minimum">
+             <double>0.000000000000000</double>
+            </property>
+            <property name="maximum">
+             <double>100000.000000000000000</double>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="toolBoxPage2" native="true">
+      <attribute name="label">
+       <string>Tool</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_3">
+       <item>
+        <widget class="QGroupBox" name="groupBox_2">
+         <property name="title">
+          <string>Tool Properties</string>
+         </property>
+         <layout class="QFormLayout" name="formLayout_3">
+          <property name="fieldGrowthPolicy">
+           <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+          </property>
+          <item row="0" column="0">
+           <widget class="QLabel" name="label_3">
+            <property name="text">
+             <string>Name</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QLineEdit" name="toolName">
+            <property name="maxLength">
+             <number>50</number>
+            </property>
+            <property name="placeholderText">
+             <string>Display Name</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="label_6">
+            <property name="text">
+             <string>Type</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QComboBox" name="toolType">
+            <property name="currentIndex">
+             <number>6</number>
+            </property>
+            <item>
+             <property name="text">
+              <string>Drill</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>CenterDrill</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>CounterSink</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>CounterBore</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Reamer</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Tap</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>EndMill</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>SlotCutter</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>BallEndMill</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>ChamferMill</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>CornerRound</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Engraver</string>
+             </property>
+            </item>
+           </widget>
+          </item>
+          <item row="4" column="0">
+           <widget class="QLabel" name="label_7">
+            <property name="text">
+             <string>Material</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="1">
+           <widget class="QComboBox" name="toolMaterial">
+            <item>
+             <property name="text">
+              <string>HighSpeedSteel</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>HighCarbonSteel</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>CastAlloy</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Carbide</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Ceramics</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Diamond</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Sialon</string>
+             </property>
+            </item>
+           </widget>
+          </item>
+          <item row="6" column="0">
+           <widget class="QLabel" name="label_8">
+            <property name="text">
+             <string>Diameter</string>
+            </property>
+           </widget>
+          </item>
+          <item row="8" column="0">
+           <widget class="QLabel" name="label_9">
+            <property name="text">
+             <string>Length Offset</string>
+            </property>
+           </widget>
+          </item>
+          <item row="12" column="0">
+           <widget class="QLabel" name="label_10">
+            <property name="text">
+             <string>Flat Radius</string>
+            </property>
+           </widget>
+          </item>
+          <item row="14" column="0">
+           <widget class="QLabel" name="label_11">
+            <property name="text">
+             <string>Corner Radius</string>
+            </property>
+           </widget>
+          </item>
+          <item row="16" column="0">
+           <widget class="QLabel" name="label_12">
+            <property name="text">
+             <string>Cutting Edge Angle</string>
+            </property>
+           </widget>
+          </item>
+          <item row="18" column="0">
+           <widget class="QLabel" name="label_13">
+            <property name="text">
+             <string>Cutting Edge Height</string>
+            </property>
+           </widget>
+          </item>
+          <item row="6" column="1">
+           <widget class="Gui::InputField" name="toolDiameter">
+            <property name="text">
+             <string>0 mm</string>
+            </property>
+            <property name="singleStep" stdset="0">
+             <double>0.125000000000000</double>
+            </property>
+            <property name="maximum" stdset="0">
+             <double>100.000000000000000</double>
+            </property>
+            <property name="minimum" stdset="0">
+             <double>0.000000000000000</double>
+            </property>
+            <property name="unit" stdset="0">
+             <string notr="true">mm</string>
+            </property>
+           </widget>
+          </item>
+          <item row="8" column="1">
+           <widget class="Gui::InputField" name="toolLengthOffset">
+            <property name="text">
+             <string>0 mm</string>
+            </property>
+            <property name="maximum" stdset="0">
+             <double>100.000000000000000</double>
+            </property>
+            <property name="minimum" stdset="0">
+             <double>0.000000000000000</double>
+            </property>
+            <property name="unit" stdset="0">
+             <string notr="true">mm</string>
+            </property>
+           </widget>
+          </item>
+          <item row="12" column="1">
+           <widget class="Gui::InputField" name="toolFlatRadius">
+            <property name="text">
+             <string>0 mm</string>
+            </property>
+            <property name="maximum" stdset="0">
+             <double>100.000000000000000</double>
+            </property>
+            <property name="minimum" stdset="0">
+             <double>0.000000000000000</double>
+            </property>
+            <property name="unit" stdset="0">
+             <string notr="true">mm</string>
+            </property>
+           </widget>
+          </item>
+          <item row="14" column="1">
+           <widget class="Gui::InputField" name="toolCornerRadius">
+            <property name="text">
+             <string>0 mm</string>
+            </property>
+            <property name="maximum" stdset="0">
+             <double>100.000000000000000</double>
+            </property>
+            <property name="minimum" stdset="0">
+             <double>0.000000000000000</double>
+            </property>
+            <property name="unit" stdset="0">
+             <string notr="true">mm</string>
+            </property>
+           </widget>
+          </item>
+          <item row="18" column="1">
+           <widget class="Gui::InputField" name="toolCuttingEdgeHeight">
+            <property name="text">
+             <string>0 mm</string>
+            </property>
+            <property name="maximum" stdset="0">
+             <double>100.000000000000000</double>
+            </property>
+            <property name="minimum" stdset="0">
+             <double>0.000000000000000</double>
+            </property>
+            <property name="unit" stdset="0">
+             <string notr="true">mm</string>
+            </property>
+           </widget>
+          </item>
+          <item row="16" column="1">
+           <widget class="Gui::InputField" name="toolCuttingEdgeAngle">
+            <property name="unit" stdset="0">
+             <string notr="true">°</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="label_14">
+         <property name="frameShape">
+          <enum>QFrame::WinPanel</enum>
+         </property>
+         <property name="text">
+          <string>Any modifications only affect this ToolController!</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>Gui::InputField</class>
+   <extends>QLineEdit</extends>
+   <header>Gui/InputField.h</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>Dialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>Dialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/src/Mod/Path/Gui/Resources/panels/PathEdit.ui
+++ b/src/Mod/Path/Gui/Resources/panels/PathEdit.ui
@@ -612,6 +612,45 @@
    <header>Gui/InputField.h</header>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>jobLabel</tabstop>
+  <tabstop>jobModel</tabstop>
+  <tabstop>jobDescription</tabstop>
+  <tabstop>postProcessorOutputFile</tabstop>
+  <tabstop>postProcessorSetOutputFile</tabstop>
+  <tabstop>postProcessor</tabstop>
+  <tabstop>postProcessorArguments</tabstop>
+  <tabstop>stock</tabstop>
+  <tabstop>stockExisting</tabstop>
+  <tabstop>stockExtXneg</tabstop>
+  <tabstop>stockExtXpos</tabstop>
+  <tabstop>stockExtYneg</tabstop>
+  <tabstop>stockExtYpos</tabstop>
+  <tabstop>stockExtZneg</tabstop>
+  <tabstop>stockExtZpos</tabstop>
+  <tabstop>stockCylinderRadius</tabstop>
+  <tabstop>stockCylinderHeight</tabstop>
+  <tabstop>stockBoxLength</tabstop>
+  <tabstop>stockBoxWidth</tabstop>
+  <tabstop>stockBoxHeight</tabstop>
+  <tabstop>orientXAxis</tabstop>
+  <tabstop>orientYAxis</tabstop>
+  <tabstop>orientZAxis</tabstop>
+  <tabstop>setOrigin</tabstop>
+  <tabstop>moveToOrigin</tabstop>
+  <tabstop>centerInStock</tabstop>
+  <tabstop>centerInStockXY</tabstop>
+  <tabstop>toolControllerList</tabstop>
+  <tabstop>toolControllerEdit</tabstop>
+  <tabstop>toolControllerAdd</tabstop>
+  <tabstop>toolControllerDelete</tabstop>
+  <tabstop>activeToolController</tabstop>
+  <tabstop>operationsList</tabstop>
+  <tabstop>operationDelete</tabstop>
+  <tabstop>operationEdit</tabstop>
+  <tabstop>operationUp</tabstop>
+  <tabstop>operationDown</tabstop>
+ </tabstops>
  <resources>
   <include location="../../../../../Gui/Icons/resource.qrc"/>
  </resources>

--- a/src/Mod/Path/Gui/Resources/panels/PathEdit.ui
+++ b/src/Mod/Path/Gui/Resources/panels/PathEdit.ui
@@ -642,10 +642,13 @@
          </widget>
         </item>
         <item>
-         <widget class="QWidget" name="widget_5" native="true">
+         <widget class="QWidget" name="operationModify" native="true">
           <layout class="QHBoxLayout" name="horizontalLayout_3">
            <item>
             <widget class="QPushButton" name="operationEdit">
+             <property name="enabled">
+              <bool>false</bool>
+             </property>
              <property name="text">
               <string>Edit</string>
              </property>

--- a/src/Mod/Path/Gui/Resources/panels/PathEdit.ui
+++ b/src/Mod/Path/Gui/Resources/panels/PathEdit.ui
@@ -14,7 +14,7 @@
    <string>Job Edit</string>
   </property>
   <property name="currentIndex">
-   <number>2</number>
+   <number>3</number>
   </property>
   <widget class="QWidget" name="tabGeneral">
    <attribute name="title">
@@ -82,6 +82,14 @@
        </layout>
       </widget>
       <widget class="QWidget" name="pagePostProcessor">
+       <property name="geometry">
+        <rect>
+         <x>0</x>
+         <y>0</y>
+         <width>233</width>
+         <height>135</height>
+        </rect>
+       </property>
        <attribute name="label">
         <string>Post Processing</string>
        </attribute>
@@ -618,7 +626,8 @@
                  <string>...</string>
                 </property>
                 <property name="icon">
-                 <iconset theme="go-up"/>
+                 <iconset resource="../../../../../Gui/Icons/resource.qrc">
+                  <normaloff>:/icons/button_up.svg</normaloff>:/icons/button_up.svg</iconset>
                 </property>
                </widget>
               </item>
@@ -628,7 +637,8 @@
                  <string>...</string>
                 </property>
                 <property name="icon">
-                 <iconset theme="go-down"/>
+                 <iconset resource="../../../../../Gui/Icons/resource.qrc">
+                  <normaloff>:/icons/button_down.svg</normaloff>:/icons/button_down.svg</iconset>
                 </property>
                </widget>
               </item>
@@ -908,6 +918,8 @@
   <tabstop>defaultMillingOp</tabstop>
   <tabstop>defaultToolCompensation</tabstop>
  </tabstops>
- <resources/>
+ <resources>
+  <include location="../../../../../Gui/Icons/resource.qrc"/>
+ </resources>
  <connections/>
 </ui>

--- a/src/Mod/Path/Gui/Resources/panels/PathEdit.ui
+++ b/src/Mod/Path/Gui/Resources/panels/PathEdit.ui
@@ -14,7 +14,7 @@
    <string>Job Edit</string>
   </property>
   <property name="currentIndex">
-   <number>1</number>
+   <number>3</number>
   </property>
   <widget class="QWidget" name="tabGeneral">
    <attribute name="title">
@@ -59,13 +59,6 @@
           </property>
          </widget>
         </item>
-        <item row="1" column="1">
-         <widget class="QLineEdit" name="infoModel">
-          <property name="enabled">
-           <bool>false</bool>
-          </property>
-         </widget>
-        </item>
         <item row="2" column="0">
          <widget class="QLabel" name="label_8">
           <property name="enabled">
@@ -82,6 +75,9 @@
            <bool>false</bool>
           </property>
          </widget>
+        </item>
+        <item row="1" column="1">
+         <widget class="QComboBox" name="infoModel"/>
         </item>
        </layout>
       </widget>
@@ -222,7 +218,7 @@
        <bool>true</bool>
       </property>
       <property name="currentIndex">
-       <number>0</number>
+       <number>1</number>
       </property>
       <widget class="QWidget" name="page_3">
        <property name="geometry">
@@ -434,7 +430,7 @@
          </spacer>
         </item>
         <item row="0" column="2">
-         <widget class="QToolButton" name="postProcessorOutputFile_2">
+         <widget class="QToolButton" name="postProcessorSetOutputFile">
           <property name="text">
            <string>...</string>
           </property>
@@ -636,7 +632,11 @@
          <widget class="QWidget" name="widget" native="true">
           <layout class="QHBoxLayout" name="horizontalLayout_4">
            <item>
-            <widget class="QListWidget" name="operationsList"/>
+            <widget class="QListWidget" name="operationsList">
+             <property name="dragDropMode">
+              <enum>QAbstractItemView::InternalMove</enum>
+             </property>
+            </widget>
            </item>
           </layout>
          </widget>

--- a/src/Mod/Path/Gui/Resources/panels/PathEdit.ui
+++ b/src/Mod/Path/Gui/Resources/panels/PathEdit.ui
@@ -14,7 +14,7 @@
    <string>Job Edit</string>
   </property>
   <property name="currentIndex">
-   <number>2</number>
+   <number>1</number>
   </property>
   <widget class="QWidget" name="tabGeneral">
    <attribute name="title">
@@ -86,8 +86,8 @@
         <rect>
          <x>0</x>
          <y>0</y>
-         <width>378</width>
-         <height>477</height>
+         <width>294</width>
+         <height>309</height>
         </rect>
        </property>
        <attribute name="label">
@@ -378,8 +378,8 @@
         <rect>
          <x>0</x>
          <y>0</y>
-         <width>378</width>
-         <height>403</height>
+         <width>233</width>
+         <height>135</height>
         </rect>
        </property>
        <attribute name="label">
@@ -619,8 +619,8 @@
         <rect>
          <x>0</x>
          <y>0</y>
-         <width>378</width>
-         <height>477</height>
+         <width>255</width>
+         <height>234</height>
         </rect>
        </property>
        <attribute name="label">

--- a/src/Mod/Path/Gui/Resources/panels/PathEdit.ui
+++ b/src/Mod/Path/Gui/Resources/panels/PathEdit.ui
@@ -31,8 +31,8 @@
         <rect>
          <x>0</x>
          <y>0</y>
-         <width>378</width>
-         <height>477</height>
+         <width>242</width>
+         <height>129</height>
         </rect>
        </property>
        <attribute name="label">
@@ -292,7 +292,7 @@
          </widget>
         </item>
         <item>
-         <widget class="QGroupBox" name="groupBox_4">
+         <widget class="QGroupBox" name="orientGroup">
           <property name="title">
            <string>Orientation</string>
           </property>
@@ -322,7 +322,7 @@
          </widget>
         </item>
         <item>
-         <widget class="QGroupBox" name="groupBox_9">
+         <widget class="QGroupBox" name="alignGroup">
           <property name="title">
            <string>Alignment</string>
           </property>
@@ -515,8 +515,8 @@
         <rect>
          <x>0</x>
          <y>0</y>
-         <width>378</width>
-         <height>514</height>
+         <width>312</width>
+         <height>159</height>
         </rect>
        </property>
        <attribute name="label">
@@ -690,7 +690,7 @@
          <x>0</x>
          <y>0</y>
          <width>395</width>
-         <height>462</height>
+         <height>430</height>
         </rect>
        </property>
        <attribute name="label">

--- a/src/Mod/Path/Gui/Resources/panels/PathEdit.ui
+++ b/src/Mod/Path/Gui/Resources/panels/PathEdit.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>400</width>
-    <height>608</height>
+    <height>924</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -24,7 +24,7 @@
     <item>
      <widget class="QToolBox" name="tbGeneral">
       <property name="currentIndex">
-       <number>0</number>
+       <number>1</number>
       </property>
       <widget class="QWidget" name="page">
        <property name="geometry">
@@ -226,67 +226,184 @@
          <x>0</x>
          <y>0</y>
          <width>378</width>
-         <height>403</height>
+         <height>719</height>
         </rect>
        </property>
        <attribute name="label">
         <string>Layout</string>
        </attribute>
-       <layout class="QVBoxLayout" name="verticalLayout_5">
+       <layout class="QVBoxLayout" name="verticalLayout_7">
         <item>
          <widget class="QGroupBox" name="stockGroup">
           <property name="title">
            <string>Stock</string>
           </property>
-          <layout class="QGridLayout" name="gridLayout_8">
-           <item row="1" column="1">
-            <widget class="QLabel" name="stockExtXLabel">
-             <property name="text">
-              <string>Ext. X</string>
+          <layout class="QVBoxLayout" name="verticalLayout_5">
+           <property name="spacing">
+            <number>0</number>
+           </property>
+           <item>
+            <widget class="QComboBox" name="stock">
+             <property name="currentIndex">
+              <number>2</number>
              </property>
+             <item>
+              <property name="text">
+               <string>Create Box</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>Create Cylinder</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>Extend Base Bound Box</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>Use Existing</string>
+              </property>
+             </item>
             </widget>
            </item>
-           <item row="2" column="1">
-            <widget class="QLabel" name="stockExtYLabel">
-             <property name="text">
-              <string>Ext. Y</string>
+           <item>
+            <spacer name="horizontalSpacer">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
              </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>6</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+           <item>
+            <widget class="QFrame" name="stockFromExisting">
+             <layout class="QGridLayout" name="gridLayout_8">
+              <item row="0" column="1">
+               <widget class="QComboBox" name="stockExisting"/>
+              </item>
+             </layout>
             </widget>
            </item>
-           <item row="1" column="4">
-            <widget class="Gui::InputField" name="stockExtXPlus">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
+           <item>
+            <widget class="QFrame" name="stockFromBase">
+             <layout class="QGridLayout" name="gridLayout_9">
+              <item row="1" column="3">
+               <widget class="Gui::InputField" name="stockExtYpos"/>
+              </item>
+              <item row="0" column="1">
+               <widget class="QLabel" name="stockExtXLabel">
+                <property name="text">
+                 <string>Ext. X</string>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="3">
+               <widget class="Gui::InputField" name="stockExtXpos">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="1">
+               <widget class="QLabel" name="stockExtYLabel">
+                <property name="text">
+                 <string>Ext. Y</string>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="2">
+               <widget class="Gui::InputField" name="stockExtXneg"/>
+              </item>
+              <item row="2" column="1">
+               <widget class="QLabel" name="stockExtZLabel">
+                <property name="text">
+                 <string>Ext. Z</string>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="2">
+               <widget class="Gui::InputField" name="stockExtZneg"/>
+              </item>
+              <item row="2" column="3">
+               <widget class="Gui::InputField" name="stockExtZpos"/>
+              </item>
+              <item row="1" column="2">
+               <widget class="Gui::InputField" name="stockExtYneg"/>
+              </item>
+             </layout>
             </widget>
            </item>
-           <item row="1" column="3">
-            <widget class="Gui::InputField" name="stockExtXMinus"/>
-           </item>
-           <item row="3" column="1">
-            <widget class="QLabel" name="stockExtZLabel">
-             <property name="text">
-              <string>Ext. Z</string>
-             </property>
+           <item>
+            <widget class="QFrame" name="stockCreateCylinder">
+             <layout class="QGridLayout" name="gridLayout_10">
+              <item row="0" column="2">
+               <widget class="Gui::InputField" name="stockCylinderRadius"/>
+              </item>
+              <item row="1" column="2">
+               <widget class="Gui::InputField" name="stockCylinderHeight"/>
+              </item>
+              <item row="0" column="1">
+               <widget class="QLabel" name="stockCylinderRadiusLabel">
+                <property name="text">
+                 <string>Radius</string>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="1">
+               <widget class="QLabel" name="stockCylinderHeightLabel">
+                <property name="text">
+                 <string>Height</string>
+                </property>
+               </widget>
+              </item>
+             </layout>
             </widget>
            </item>
-           <item row="3" column="3">
-            <widget class="Gui::InputField" name="stockExtZMinus"/>
-           </item>
-           <item row="2" column="3">
-            <widget class="Gui::InputField" name="stockExtYMinus"/>
-           </item>
-           <item row="2" column="4">
-            <widget class="Gui::InputField" name="stockExtYPlus"/>
-           </item>
-           <item row="3" column="4">
-            <widget class="Gui::InputField" name="stockExtZPlus"/>
-           </item>
-           <item row="0" column="1" colspan="4">
-            <widget class="QComboBox" name="comboBox"/>
+           <item>
+            <widget class="QFrame" name="stockCreateBox">
+             <layout class="QGridLayout" name="gridLayout_11">
+              <item row="0" column="1">
+               <widget class="QLabel" name="stockBoxLengthLabel">
+                <property name="text">
+                 <string>Length</string>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="1">
+               <widget class="QLabel" name="stockBoxWidthLabel">
+                <property name="text">
+                 <string>Width</string>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="2">
+               <widget class="Gui::InputField" name="stockBoxLength"/>
+              </item>
+              <item row="2" column="2">
+               <widget class="Gui::InputField" name="stockBoxHeight"/>
+              </item>
+              <item row="1" column="2">
+               <widget class="Gui::InputField" name="stockBoxWidth"/>
+              </item>
+              <item row="2" column="1">
+               <widget class="QLabel" name="stockBoxHeightLabel">
+                <property name="text">
+                 <string>Height</string>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </widget>
            </item>
           </layout>
          </widget>
@@ -612,7 +729,7 @@
     <item>
      <widget class="QToolBox" name="toolBox_2">
       <property name="currentIndex">
-       <number>1</number>
+       <number>0</number>
       </property>
       <widget class="QWidget" name="page_9">
        <property name="geometry">
@@ -862,6 +979,63 @@
    <header>Gui/InputField.h</header>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>infoLabel</tabstop>
+  <tabstop>infoModel</tabstop>
+  <tabstop>infoMaterial</tabstop>
+  <tabstop>stock</tabstop>
+  <tabstop>stockExisting</tabstop>
+  <tabstop>stockExtXneg</tabstop>
+  <tabstop>stockExtXpos</tabstop>
+  <tabstop>stockExtYneg</tabstop>
+  <tabstop>stockExtYpos</tabstop>
+  <tabstop>stockExtZneg</tabstop>
+  <tabstop>stockExtZpos</tabstop>
+  <tabstop>stockCylinderRadius</tabstop>
+  <tabstop>stockCylinderHeight</tabstop>
+  <tabstop>stockBoxLength</tabstop>
+  <tabstop>stockBoxWidth</tabstop>
+  <tabstop>stockBoxHeight</tabstop>
+  <tabstop>orientXAxis</tabstop>
+  <tabstop>orientYAxis</tabstop>
+  <tabstop>orientZAxis</tabstop>
+  <tabstop>setOrigin</tabstop>
+  <tabstop>moveToOrigin</tabstop>
+  <tabstop>centerInStock</tabstop>
+  <tabstop>centerInStockXY</tabstop>
+  <tabstop>postProcessorOutputFile</tabstop>
+  <tabstop>postProcessorSetOutputFile</tabstop>
+  <tabstop>postProcessor</tabstop>
+  <tabstop>postProcessorArguments</tabstop>
+  <tabstop>templateDefaultValues</tabstop>
+  <tabstop>templatePostProcessor</tabstop>
+  <tabstop>buttonBox</tabstop>
+  <tabstop>templateGeneral</tabstop>
+  <tabstop>templateMaterial</tabstop>
+  <tabstop>templateSetup</tabstop>
+  <tabstop>templateStock</tabstop>
+  <tabstop>templateOperations</tabstop>
+  <tabstop>templateTools</tabstop>
+  <tabstop>toolControllerList</tabstop>
+  <tabstop>toolControllerEdit</tabstop>
+  <tabstop>toolControllerAdd</tabstop>
+  <tabstop>toolControllerDelete</tabstop>
+  <tabstop>activeToolController</tabstop>
+  <tabstop>operationsList</tabstop>
+  <tabstop>operationEdit</tabstop>
+  <tabstop>operationDelete</tabstop>
+  <tabstop>groupBox_5</tabstop>
+  <tabstop>defaultSafeHeight</tabstop>
+  <tabstop>defaultClearanceHeight</tabstop>
+  <tabstop>groupBox_6</tabstop>
+  <tabstop>defaultStepDown</tabstop>
+  <tabstop>groupBox</tabstop>
+  <tabstop>lineEdit</tabstop>
+  <tabstop>lineEdit_2</tabstop>
+  <tabstop>groupBox_7</tabstop>
+  <tabstop>defaultMillingOp</tabstop>
+  <tabstop>defaultToolCompensation</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/src/Mod/Path/Gui/Resources/panels/PathEdit.ui
+++ b/src/Mod/Path/Gui/Resources/panels/PathEdit.ui
@@ -86,8 +86,8 @@
         <rect>
          <x>0</x>
          <y>0</y>
-         <width>378</width>
-         <height>477</height>
+         <width>294</width>
+         <height>309</height>
         </rect>
        </property>
        <attribute name="label">
@@ -225,8 +225,8 @@
         <rect>
          <x>0</x>
          <y>0</y>
-         <width>378</width>
-         <height>403</height>
+         <width>368</width>
+         <height>399</height>
         </rect>
        </property>
        <attribute name="label">
@@ -443,8 +443,8 @@
         <rect>
          <x>0</x>
          <y>0</y>
-         <width>378</width>
-         <height>403</height>
+         <width>142</width>
+         <height>41</height>
         </rect>
        </property>
        <attribute name="label">
@@ -468,8 +468,8 @@
         <rect>
          <x>0</x>
          <y>0</y>
-         <width>378</width>
-         <height>403</height>
+         <width>142</width>
+         <height>41</height>
         </rect>
        </property>
        <attribute name="label">
@@ -532,12 +532,18 @@
           </column>
           <column>
            <property name="text">
-            <string>H-Feed</string>
+            <string>Feed</string>
+           </property>
+           <property name="icon">
+            <iconset theme="object-flip-horizontal"/>
            </property>
           </column>
           <column>
            <property name="text">
-            <string>V-Feed</string>
+            <string>Feed</string>
+           </property>
+           <property name="icon">
+            <iconset theme="object-flip-vertical"/>
            </property>
           </column>
           <column>
@@ -744,15 +750,15 @@
            <item row="0" column="1">
             <widget class="Gui::InputField" name="defaultSafeHeight"/>
            </item>
+           <item row="1" column="1">
+            <widget class="Gui::InputField" name="defaultClearanceHeight"/>
+           </item>
            <item row="1" column="0">
             <widget class="QLabel" name="label_15">
              <property name="text">
               <string>Clearance</string>
              </property>
             </widget>
-           </item>
-           <item row="1" column="1">
-            <widget class="Gui::InputField" name="defaultClearanceHeight"/>
            </item>
           </layout>
          </widget>
@@ -780,6 +786,46 @@
             <widget class="Gui::InputField" name="defaultStepDown"/>
            </item>
           </layout>
+         </widget>
+        </item>
+        <item>
+         <widget class="QGroupBox" name="groupBox">
+          <property name="title">
+           <string>Rapid Speed</string>
+          </property>
+          <property name="checkable">
+           <bool>true</bool>
+          </property>
+          <property name="checked">
+           <bool>false</bool>
+          </property>
+          <layout class="QFormLayout" name="formLayout">
+           <item row="0" column="0">
+            <widget class="QLabel" name="label_3">
+             <property name="text">
+              <string>Horizontal</string>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="1">
+            <widget class="Gui::InputField" name="lineEdit"/>
+           </item>
+           <item row="1" column="1">
+            <widget class="Gui::InputField" name="lineEdit_2"/>
+           </item>
+           <item row="1" column="0">
+            <widget class="QLabel" name="label_4">
+             <property name="text">
+              <string>Vertical</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+          <zorder>label_15</zorder>
+          <zorder>label_3</zorder>
+          <zorder>lineEdit</zorder>
+          <zorder>lineEdit_2</zorder>
+          <zorder>label_4</zorder>
          </widget>
         </item>
         <item>

--- a/src/Mod/Path/Gui/Resources/panels/PathEdit.ui
+++ b/src/Mod/Path/Gui/Resources/panels/PathEdit.ui
@@ -1,0 +1,811 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>PathEdit</class>
+ <widget class="QTabWidget" name="PathEdit">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>608</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Job Edit</string>
+  </property>
+  <property name="currentIndex">
+   <number>1</number>
+  </property>
+  <widget class="QWidget" name="tabGeneral">
+   <attribute name="title">
+    <string>General</string>
+   </attribute>
+   <layout class="QVBoxLayout" name="verticalLayout">
+    <item>
+     <widget class="QToolBox" name="tbGeneral">
+      <property name="currentIndex">
+       <number>0</number>
+      </property>
+      <widget class="QWidget" name="page">
+       <property name="geometry">
+        <rect>
+         <x>0</x>
+         <y>0</y>
+         <width>378</width>
+         <height>477</height>
+        </rect>
+       </property>
+       <attribute name="label">
+        <string>Info</string>
+       </attribute>
+       <layout class="QFormLayout" name="formLayout_2">
+        <property name="fieldGrowthPolicy">
+         <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+        </property>
+        <item row="0" column="0">
+         <widget class="QLabel" name="label">
+          <property name="text">
+           <string>Label</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1">
+         <widget class="QLineEdit" name="infoLabel"/>
+        </item>
+        <item row="1" column="0">
+         <widget class="QLabel" name="label_2">
+          <property name="text">
+           <string>Model</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="1">
+         <widget class="QLineEdit" name="infoModel">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="0">
+         <widget class="QLabel" name="label_8">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+          <property name="text">
+           <string>Material      </string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="1">
+         <widget class="QComboBox" name="infoMaterial">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </widget>
+      <widget class="QWidget" name="page_2">
+       <property name="geometry">
+        <rect>
+         <x>0</x>
+         <y>0</y>
+         <width>378</width>
+         <height>477</height>
+        </rect>
+       </property>
+       <attribute name="label">
+        <string>Template</string>
+       </attribute>
+       <layout class="QVBoxLayout" name="verticalLayout_2">
+        <item>
+         <widget class="QGroupBox" name="templateGeneral">
+          <property name="title">
+           <string>General</string>
+          </property>
+          <property name="checkable">
+           <bool>true</bool>
+          </property>
+          <layout class="QGridLayout" name="gridLayout_7">
+           <item row="0" column="1">
+            <widget class="QCheckBox" name="templateMaterial">
+             <property name="text">
+              <string>Material</string>
+             </property>
+             <property name="checked">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </item>
+        <item>
+         <widget class="QGroupBox" name="templateSetup">
+          <property name="title">
+           <string>Setup</string>
+          </property>
+          <property name="checkable">
+           <bool>true</bool>
+          </property>
+          <layout class="QGridLayout" name="gridLayout_3">
+           <item row="0" column="0">
+            <widget class="QCheckBox" name="templateStock">
+             <property name="text">
+              <string>Stock</string>
+             </property>
+             <property name="checked">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="1">
+            <widget class="QCheckBox" name="templatePostProcessor">
+             <property name="text">
+              <string>Post Processor</string>
+             </property>
+             <property name="checked">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </item>
+        <item>
+         <widget class="QGroupBox" name="templateTools">
+          <property name="title">
+           <string>Tools</string>
+          </property>
+          <property name="checkable">
+           <bool>true</bool>
+          </property>
+          <layout class="QVBoxLayout" name="verticalLayout_3"/>
+         </widget>
+        </item>
+        <item>
+         <widget class="QGroupBox" name="templateOperations">
+          <property name="title">
+           <string>Operations</string>
+          </property>
+          <property name="checkable">
+           <bool>true</bool>
+          </property>
+          <layout class="QVBoxLayout" name="verticalLayout_4">
+           <item>
+            <widget class="QCheckBox" name="templateDefaultValues">
+             <property name="text">
+              <string>Default Values</string>
+             </property>
+             <property name="checked">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </item>
+        <item>
+         <widget class="QDialogButtonBox" name="buttonBox">
+          <property name="standardButtons">
+           <set>QDialogButtonBox::Save</set>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="verticalSpacer_4">
+          <property name="orientation">
+           <enum>Qt::Vertical</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>20</width>
+            <height>40</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
+      </widget>
+     </widget>
+    </item>
+   </layout>
+  </widget>
+  <widget class="QWidget" name="tabSetup">
+   <attribute name="title">
+    <string>Setup</string>
+   </attribute>
+   <layout class="QVBoxLayout" name="verticalLayout_6">
+    <item>
+     <widget class="QToolBox" name="tbSetup">
+      <property name="enabled">
+       <bool>true</bool>
+      </property>
+      <property name="currentIndex">
+       <number>0</number>
+      </property>
+      <widget class="QWidget" name="page_3">
+       <property name="geometry">
+        <rect>
+         <x>0</x>
+         <y>0</y>
+         <width>378</width>
+         <height>403</height>
+        </rect>
+       </property>
+       <attribute name="label">
+        <string>Layout</string>
+       </attribute>
+       <layout class="QVBoxLayout" name="verticalLayout_5">
+        <item>
+         <widget class="QGroupBox" name="groupBox_10">
+          <property name="title">
+           <string>Stock</string>
+          </property>
+          <layout class="QGridLayout" name="gridLayout_8">
+           <item row="1" column="1">
+            <widget class="QLabel" name="stockExtXLabel">
+             <property name="text">
+              <string>Ext. X</string>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="1">
+            <widget class="QLabel" name="stockExtYLabel">
+             <property name="text">
+              <string>Ext. Y</string>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="4">
+            <widget class="Gui::InputField" name="stockExtXPlus">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="3">
+            <widget class="Gui::InputField" name="stockExtXMinus"/>
+           </item>
+           <item row="3" column="1">
+            <widget class="QLabel" name="stockExtZLabel">
+             <property name="text">
+              <string>Ext. Z</string>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="3">
+            <widget class="Gui::InputField" name="stockExtZMinus"/>
+           </item>
+           <item row="2" column="3">
+            <widget class="Gui::InputField" name="stockExtYMinus"/>
+           </item>
+           <item row="2" column="4">
+            <widget class="Gui::InputField" name="stockExtYPlus"/>
+           </item>
+           <item row="3" column="4">
+            <widget class="Gui::InputField" name="stockExtZPlus"/>
+           </item>
+           <item row="0" column="1" colspan="4">
+            <widget class="QComboBox" name="comboBox"/>
+           </item>
+          </layout>
+         </widget>
+        </item>
+        <item>
+         <widget class="QGroupBox" name="groupBox_4">
+          <property name="title">
+           <string>Orientation</string>
+          </property>
+          <layout class="QHBoxLayout" name="horizontalLayout">
+           <item>
+            <widget class="QPushButton" name="orientXAxis">
+             <property name="text">
+              <string>X-Axis</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QPushButton" name="orientYAxis">
+             <property name="text">
+              <string>Y-Axis</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QPushButton" name="orientZAxis">
+             <property name="text">
+              <string>Z-Axis</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </item>
+        <item>
+         <widget class="QGroupBox" name="groupBox_9">
+          <property name="title">
+           <string>Alignment</string>
+          </property>
+          <layout class="QGridLayout" name="gridLayout_2">
+           <item row="1" column="0">
+            <widget class="QPushButton" name="setOrigin">
+             <property name="text">
+              <string>Set Origin</string>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="1">
+            <widget class="QPushButton" name="moveToOrigin">
+             <property name="text">
+              <string>Move to Origin</string>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="0">
+            <widget class="QPushButton" name="centerInStock">
+             <property name="text">
+              <string>Center in Stock</string>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="1">
+            <widget class="QPushButton" name="centerInStockXY">
+             <property name="text">
+              <string>XY in Stock</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </item>
+        <item>
+         <spacer name="verticalSpacer_2">
+          <property name="orientation">
+           <enum>Qt::Vertical</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>20</width>
+            <height>40</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
+      </widget>
+      <widget class="QWidget" name="page_6">
+       <property name="geometry">
+        <rect>
+         <x>0</x>
+         <y>0</y>
+         <width>378</width>
+         <height>403</height>
+        </rect>
+       </property>
+       <attribute name="label">
+        <string>Post Processor</string>
+       </attribute>
+       <layout class="QGridLayout" name="gridLayout">
+        <item row="1" column="1" colspan="2">
+         <widget class="QComboBox" name="postProcessor"/>
+        </item>
+        <item row="1" column="0">
+         <widget class="QLabel" name="label_10">
+          <property name="text">
+           <string>Processor</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="0">
+         <widget class="QLabel" name="label_9">
+          <property name="text">
+           <string>Output File</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1">
+         <widget class="QLineEdit" name="postProcessorOutputFile"/>
+        </item>
+        <item row="2" column="1" colspan="2">
+         <widget class="QLineEdit" name="postProcessorArguments"/>
+        </item>
+        <item row="2" column="0">
+         <widget class="QLabel" name="label_11">
+          <property name="text">
+           <string>Arguments</string>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="0">
+         <spacer name="verticalSpacer">
+          <property name="orientation">
+           <enum>Qt::Vertical</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>20</width>
+            <height>40</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item row="0" column="2">
+         <widget class="QToolButton" name="postProcessorOutputFile_2">
+          <property name="text">
+           <string>...</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </widget>
+      <widget class="QWidget" name="page_4">
+       <property name="geometry">
+        <rect>
+         <x>0</x>
+         <y>0</y>
+         <width>378</width>
+         <height>403</height>
+        </rect>
+       </property>
+       <attribute name="label">
+        <string>Fixtures</string>
+       </attribute>
+       <layout class="QVBoxLayout" name="verticalLayout_12">
+        <item alignment="Qt::AlignHCenter|Qt::AlignVCenter">
+         <widget class="QLabel" name="label_12">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+          <property name="text">
+           <string>Coming Soon</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </widget>
+      <widget class="QWidget" name="page_5">
+       <property name="geometry">
+        <rect>
+         <x>0</x>
+         <y>0</y>
+         <width>378</width>
+         <height>403</height>
+        </rect>
+       </property>
+       <attribute name="label">
+        <string>Vise</string>
+       </attribute>
+       <layout class="QVBoxLayout" name="verticalLayout_13">
+        <item alignment="Qt::AlignHCenter|Qt::AlignVCenter">
+         <widget class="QLabel" name="label_13">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+          <property name="text">
+           <string>Coming Soon</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </widget>
+     </widget>
+    </item>
+   </layout>
+  </widget>
+  <widget class="QWidget" name="tab">
+   <attribute name="title">
+    <string>Tools</string>
+   </attribute>
+   <layout class="QVBoxLayout" name="verticalLayout_8">
+    <item>
+     <widget class="QToolBox" name="toolBox">
+      <property name="currentIndex">
+       <number>0</number>
+      </property>
+      <widget class="QWidget" name="page_7">
+       <property name="geometry">
+        <rect>
+         <x>0</x>
+         <y>0</y>
+         <width>378</width>
+         <height>514</height>
+        </rect>
+       </property>
+       <attribute name="label">
+        <string>Tool Controller</string>
+       </attribute>
+       <layout class="QVBoxLayout" name="verticalLayout_9">
+        <item>
+         <widget class="QTableWidget" name="toolControllerTable">
+          <attribute name="horizontalHeaderDefaultSectionSize">
+           <number>71</number>
+          </attribute>
+          <column>
+           <property name="text">
+            <string>Name</string>
+           </property>
+          </column>
+          <column>
+           <property name="text">
+            <string>Tool</string>
+           </property>
+          </column>
+          <column>
+           <property name="text">
+            <string>H-Feed</string>
+           </property>
+          </column>
+          <column>
+           <property name="text">
+            <string>V-Feed</string>
+           </property>
+          </column>
+          <column>
+           <property name="text">
+            <string>Spindle</string>
+           </property>
+          </column>
+         </widget>
+        </item>
+        <item>
+         <widget class="QWidget" name="widget_4" native="true">
+          <layout class="QHBoxLayout" name="horizontalLayout_2">
+           <item>
+            <widget class="QPushButton" name="toolEdit">
+             <property name="enabled">
+              <bool>false</bool>
+             </property>
+             <property name="text">
+              <string>Edit</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QPushButton" name="toolAdd">
+             <property name="text">
+              <string>Add</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QPushButton" name="toolRemove">
+             <property name="enabled">
+              <bool>false</bool>
+             </property>
+             <property name="text">
+              <string>Remove</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </item>
+       </layout>
+      </widget>
+     </widget>
+    </item>
+   </layout>
+  </widget>
+  <widget class="QWidget" name="tab_2">
+   <attribute name="title">
+    <string>Workplan</string>
+   </attribute>
+   <layout class="QVBoxLayout" name="verticalLayout_10">
+    <item>
+     <widget class="QToolBox" name="toolBox_2">
+      <property name="currentIndex">
+       <number>0</number>
+      </property>
+      <widget class="QWidget" name="page_9">
+       <property name="geometry">
+        <rect>
+         <x>0</x>
+         <y>0</y>
+         <width>378</width>
+         <height>477</height>
+        </rect>
+       </property>
+       <attribute name="label">
+        <string>Operations</string>
+       </attribute>
+       <layout class="QVBoxLayout" name="verticalLayout_11">
+        <item>
+         <widget class="QWidget" name="widget_3" native="true">
+          <layout class="QFormLayout" name="formLayout_3">
+           <property name="fieldGrowthPolicy">
+            <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+           </property>
+           <item row="0" column="0">
+            <widget class="QLabel" name="label_18">
+             <property name="text">
+              <string>Active Tool </string>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="1">
+            <widget class="QComboBox" name="activeToolController"/>
+           </item>
+          </layout>
+         </widget>
+        </item>
+        <item>
+         <widget class="QWidget" name="widget" native="true">
+          <layout class="QHBoxLayout" name="horizontalLayout_4">
+           <item>
+            <widget class="QListWidget" name="operationsList"/>
+           </item>
+          </layout>
+         </widget>
+        </item>
+        <item>
+         <widget class="QWidget" name="widget_5" native="true">
+          <layout class="QHBoxLayout" name="horizontalLayout_3">
+           <item>
+            <widget class="QPushButton" name="operationEdit">
+             <property name="text">
+              <string>Edit</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QPushButton" name="operationDelete">
+             <property name="text">
+              <string>Delete</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </item>
+       </layout>
+      </widget>
+      <widget class="QWidget" name="page_10">
+       <property name="geometry">
+        <rect>
+         <x>0</x>
+         <y>0</y>
+         <width>395</width>
+         <height>462</height>
+        </rect>
+       </property>
+       <attribute name="label">
+        <string>Default Values</string>
+       </attribute>
+       <layout class="QVBoxLayout" name="verticalLayout_14">
+        <item>
+         <widget class="QGroupBox" name="groupBox_7">
+          <property name="title">
+           <string>Operation</string>
+          </property>
+          <property name="checkable">
+           <bool>true</bool>
+          </property>
+          <property name="checked">
+           <bool>false</bool>
+          </property>
+          <layout class="QGridLayout" name="gridLayout_6">
+           <item row="0" column="0">
+            <widget class="QLabel" name="label_17">
+             <property name="text">
+              <string>Milling</string>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="1">
+            <widget class="QComboBox" name="defaultMillingOp">
+             <item>
+              <property name="text">
+               <string>conventional</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>climb</string>
+              </property>
+             </item>
+            </widget>
+           </item>
+           <item row="1" column="0">
+            <widget class="QCheckBox" name="defaultToolCompensation">
+             <property name="text">
+              <string>Tool Compensated</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </item>
+        <item>
+         <widget class="QGroupBox" name="groupBox_5">
+          <property name="title">
+           <string>Heights</string>
+          </property>
+          <property name="checkable">
+           <bool>true</bool>
+          </property>
+          <property name="checked">
+           <bool>false</bool>
+          </property>
+          <layout class="QGridLayout" name="gridLayout_4">
+           <item row="0" column="0">
+            <widget class="QLabel" name="label_14">
+             <property name="text">
+              <string>Safe</string>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="1">
+            <widget class="Gui::InputField" name="defaultSafeHeight"/>
+           </item>
+           <item row="1" column="0">
+            <widget class="QLabel" name="label_15">
+             <property name="text">
+              <string>Clearance</string>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="1">
+            <widget class="Gui::InputField" name="defaultClearanceHeight"/>
+           </item>
+          </layout>
+         </widget>
+        </item>
+        <item>
+         <widget class="QGroupBox" name="groupBox_6">
+          <property name="title">
+           <string>Depths</string>
+          </property>
+          <property name="checkable">
+           <bool>true</bool>
+          </property>
+          <property name="checked">
+           <bool>false</bool>
+          </property>
+          <layout class="QGridLayout" name="gridLayout_5">
+           <item row="0" column="0">
+            <widget class="QLabel" name="label_16">
+             <property name="text">
+              <string>Step Down</string>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="1">
+            <widget class="Gui::InputField" name="defaultStepDown"/>
+           </item>
+          </layout>
+         </widget>
+        </item>
+        <item>
+         <spacer name="verticalSpacer_3">
+          <property name="orientation">
+           <enum>Qt::Vertical</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>20</width>
+            <height>40</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
+      </widget>
+     </widget>
+    </item>
+   </layout>
+  </widget>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>Gui::InputField</class>
+   <extends>QLineEdit</extends>
+   <header>Gui/InputField.h</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/Mod/Path/Gui/Resources/panels/PathEdit.ui
+++ b/src/Mod/Path/Gui/Resources/panels/PathEdit.ui
@@ -14,7 +14,7 @@
    <string>Job Edit</string>
   </property>
   <property name="currentIndex">
-   <number>3</number>
+   <number>2</number>
   </property>
   <widget class="QWidget" name="tabGeneral">
    <attribute name="title">
@@ -516,9 +516,9 @@
        </attribute>
        <layout class="QVBoxLayout" name="verticalLayout_9">
         <item>
-         <widget class="QTableWidget" name="toolControllerTable">
-          <attribute name="horizontalHeaderDefaultSectionSize">
-           <number>71</number>
+         <widget class="QTableWidget" name="toolControllerList">
+          <attribute name="verticalHeaderVisible">
+           <bool>false</bool>
           </attribute>
           <column>
            <property name="text">
@@ -527,7 +527,7 @@
           </column>
           <column>
            <property name="text">
-            <string>Tool</string>
+            <string>Nr.</string>
            </property>
           </column>
           <column>
@@ -551,7 +551,7 @@
          <widget class="QWidget" name="widget_4" native="true">
           <layout class="QHBoxLayout" name="horizontalLayout_2">
            <item>
-            <widget class="QPushButton" name="toolEdit">
+            <widget class="QPushButton" name="toolControllerEdit">
              <property name="enabled">
               <bool>false</bool>
              </property>
@@ -561,14 +561,14 @@
             </widget>
            </item>
            <item>
-            <widget class="QPushButton" name="toolAdd">
+            <widget class="QPushButton" name="toolControllerAdd">
              <property name="text">
               <string>Add</string>
              </property>
             </widget>
            </item>
            <item>
-            <widget class="QPushButton" name="toolRemove">
+            <widget class="QPushButton" name="toolControllerDelete">
              <property name="enabled">
               <bool>false</bool>
              </property>

--- a/src/Mod/Path/Gui/Resources/panels/PathEdit.ui
+++ b/src/Mod/Path/Gui/Resources/panels/PathEdit.ui
@@ -573,7 +573,7 @@
        </attribute>
        <layout class="QVBoxLayout" name="verticalLayout_11">
         <item>
-         <widget class="QWidget" name="widget_3" native="true">
+         <widget class="QWidget" name="activeToolGroup" native="true">
           <layout class="QFormLayout" name="formLayout_3">
            <property name="fieldGrowthPolicy">
             <enum>QFormLayout::AllNonFixedFieldsGrow</enum>

--- a/src/Mod/Path/Gui/Resources/panels/PathEdit.ui
+++ b/src/Mod/Path/Gui/Resources/panels/PathEdit.ui
@@ -264,7 +264,7 @@
              </item>
              <item>
               <property name="text">
-               <string>Use Existing</string>
+               <string>Use Existing Solid</string>
               </property>
              </item>
             </widget>

--- a/src/Mod/Path/Gui/Resources/panels/PathEdit.ui
+++ b/src/Mod/Path/Gui/Resources/panels/PathEdit.ui
@@ -14,147 +14,120 @@
    <string>Job Edit</string>
   </property>
   <property name="currentIndex">
-   <number>3</number>
+   <number>4</number>
   </property>
   <widget class="QWidget" name="tabGeneral">
    <attribute name="title">
     <string>General</string>
    </attribute>
-   <layout class="QVBoxLayout" name="verticalLayout">
-    <item>
-     <widget class="QToolBox" name="tbGeneral">
-      <property name="currentIndex">
-       <number>0</number>
+   <layout class="QGridLayout" name="gridLayout_3">
+    <item row="2" column="1">
+     <widget class="QComboBox" name="jobModel"/>
+    </item>
+    <item row="0" column="0">
+     <widget class="QLabel" name="label">
+      <property name="text">
+       <string>Label</string>
       </property>
-      <widget class="QWidget" name="pageInfo">
-       <property name="geometry">
-        <rect>
-         <x>0</x>
-         <y>0</y>
-         <width>378</width>
-         <height>793</height>
-        </rect>
-       </property>
-       <attribute name="label">
-        <string>Info</string>
-       </attribute>
-       <layout class="QFormLayout" name="formLayout_2">
-        <property name="fieldGrowthPolicy">
-         <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
-        </property>
-        <item row="0" column="0">
-         <widget class="QLabel" name="label">
-          <property name="text">
-           <string>Label</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="1">
-         <widget class="QLineEdit" name="infoLabel"/>
-        </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="label_2">
-          <property name="text">
-           <string>Model</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="0">
-         <widget class="QLabel" name="label_8">
-          <property name="enabled">
-           <bool>false</bool>
-          </property>
-          <property name="text">
-           <string>Material      </string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="1">
-         <widget class="QComboBox" name="infoMaterial">
-          <property name="enabled">
-           <bool>false</bool>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="1">
-         <widget class="QComboBox" name="infoModel"/>
-        </item>
-       </layout>
-      </widget>
-      <widget class="QWidget" name="pagePostProcessor">
-       <property name="geometry">
-        <rect>
-         <x>0</x>
-         <y>0</y>
-         <width>233</width>
-         <height>135</height>
-        </rect>
-       </property>
-       <attribute name="label">
-        <string>Post Processing</string>
-       </attribute>
-       <layout class="QGridLayout" name="gridLayout_16">
-        <item row="0" column="0">
-         <widget class="QLabel" name="label_9">
-          <property name="text">
-           <string>Output File</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="1">
-         <widget class="QLineEdit" name="postProcessorOutputFile">
-          <property name="toolTip">
-           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enter a path and optionally file name (see below) to be used as the default for the post processor export.&lt;/p&gt;&lt;p&gt;The following substitutions are performed before the name is resolved at the time of the post processing:&lt;/p&gt;&lt;p&gt;%D ... directory of the active document&lt;br/&gt;%d ... name of the active document (with extension)&lt;br/&gt;%M ... user macro directory&lt;br/&gt;%j ... name of the active Job object&lt;/p&gt;&lt;p&gt;The following example store all files with the same name as the document the directory /home/freecad (please remove quotes):&lt;/p&gt;&lt;p&gt;&amp;quot;/home/cnc/%d.g-code&amp;quot;&lt;/p&gt;&lt;p&gt;See the file save policy below on how to deal with name conflicts.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="2">
-         <widget class="QToolButton" name="postProcessorSetOutputFile">
-          <property name="text">
-           <string>...</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="label_10">
-          <property name="text">
-           <string>Processor</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="1" colspan="2">
-         <widget class="QComboBox" name="postProcessor"/>
-        </item>
-        <item row="2" column="0">
-         <widget class="QLabel" name="label_11">
-          <property name="text">
-           <string>Arguments</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="1" colspan="2">
-         <widget class="QLineEdit" name="postProcessorArguments">
-          <property name="toolTip">
-           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Optional arguments passed to the Post Processor. The arguments are specific for each Post Processor, please see it's documentation for details.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="0">
-         <spacer name="verticalSpacer">
-          <property name="orientation">
-           <enum>Qt::Vertical</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>20</width>
-            <height>655</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-       </layout>
-      </widget>
      </widget>
+    </item>
+    <item row="2" column="0">
+     <widget class="QLabel" name="label_2">
+      <property name="text">
+       <string>Model</string>
+      </property>
+     </widget>
+    </item>
+    <item row="0" column="1">
+     <widget class="QLineEdit" name="jobLabel"/>
+    </item>
+    <item row="4" column="0">
+     <spacer name="verticalSpacer_4">
+      <property name="orientation">
+       <enum>Qt::Vertical</enum>
+      </property>
+      <property name="sizeHint" stdset="0">
+       <size>
+        <width>20</width>
+        <height>40</height>
+       </size>
+      </property>
+     </spacer>
+    </item>
+    <item row="3" column="0">
+     <widget class="QLabel" name="label_5">
+      <property name="text">
+       <string>Description</string>
+      </property>
+     </widget>
+    </item>
+    <item row="3" column="1">
+     <widget class="QPlainTextEdit" name="jobDescription"/>
+    </item>
+   </layout>
+  </widget>
+  <widget class="QWidget" name="tabOutput">
+   <attribute name="title">
+    <string>Output</string>
+   </attribute>
+   <layout class="QGridLayout" name="gridLayout">
+    <item row="0" column="0">
+     <widget class="QLabel" name="label_9">
+      <property name="text">
+       <string>Output File</string>
+      </property>
+     </widget>
+    </item>
+    <item row="0" column="1">
+     <widget class="QLineEdit" name="postProcessorOutputFile">
+      <property name="toolTip">
+       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enter a path and optionally file name (see below) to be used as the default for the post processor export.&lt;/p&gt;&lt;p&gt;The following substitutions are performed before the name is resolved at the time of the post processing:&lt;/p&gt;&lt;p&gt;%D ... directory of the active document&lt;br/&gt;%d ... name of the active document (with extension)&lt;br/&gt;%M ... user macro directory&lt;br/&gt;%j ... name of the active Job object&lt;/p&gt;&lt;p&gt;The following example store all files with the same name as the document the directory /home/freecad (please remove quotes):&lt;/p&gt;&lt;p&gt;&amp;quot;/home/cnc/%d.g-code&amp;quot;&lt;/p&gt;&lt;p&gt;See the file save policy below on how to deal with name conflicts.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+      </property>
+     </widget>
+    </item>
+    <item row="0" column="2">
+     <widget class="QToolButton" name="postProcessorSetOutputFile">
+      <property name="text">
+       <string>...</string>
+      </property>
+     </widget>
+    </item>
+    <item row="1" column="0">
+     <widget class="QLabel" name="label_10">
+      <property name="text">
+       <string>Processor</string>
+      </property>
+     </widget>
+    </item>
+    <item row="1" column="1" colspan="2">
+     <widget class="QComboBox" name="postProcessor"/>
+    </item>
+    <item row="2" column="0">
+     <widget class="QLabel" name="label_11">
+      <property name="text">
+       <string>Arguments</string>
+      </property>
+     </widget>
+    </item>
+    <item row="2" column="1" colspan="2">
+     <widget class="QLineEdit" name="postProcessorArguments">
+      <property name="toolTip">
+       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Optional arguments passed to the Post Processor. The arguments are specific for each Post Processor, please see it's documentation for details.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+      </property>
+     </widget>
+    </item>
+    <item row="3" column="0">
+     <spacer name="verticalSpacer">
+      <property name="orientation">
+       <enum>Qt::Vertical</enum>
+      </property>
+      <property name="sizeHint" stdset="0">
+       <size>
+        <width>20</width>
+        <height>747</height>
+       </size>
+      </property>
+     </spacer>
     </item>
    </layout>
   </widget>
@@ -162,286 +135,261 @@
    <attribute name="title">
     <string>Setup</string>
    </attribute>
-   <layout class="QVBoxLayout" name="verticalLayout_6">
+   <layout class="QVBoxLayout" name="verticalLayout">
     <item>
-     <widget class="QToolBox" name="tbSetup">
-      <property name="enabled">
-       <bool>true</bool>
+     <widget class="QGroupBox" name="stockGroup">
+      <property name="title">
+       <string>Stock</string>
       </property>
-      <property name="currentIndex">
-       <number>0</number>
-      </property>
-      <widget class="QWidget" name="pageLayout">
-       <property name="geometry">
-        <rect>
-         <x>0</x>
-         <y>0</y>
-         <width>378</width>
-         <height>830</height>
-        </rect>
+      <layout class="QVBoxLayout" name="verticalLayout_5">
+       <property name="spacing">
+        <number>0</number>
        </property>
-       <attribute name="label">
-        <string>Layout</string>
-       </attribute>
-       <layout class="QVBoxLayout" name="verticalLayout_7">
-        <item>
-         <widget class="QGroupBox" name="stockGroup">
-          <property name="title">
-           <string>Stock</string>
+       <item>
+        <widget class="QComboBox" name="stock">
+         <property name="currentIndex">
+          <number>2</number>
+         </property>
+         <item>
+          <property name="text">
+           <string>Create Box</string>
           </property>
-          <layout class="QVBoxLayout" name="verticalLayout_5">
-           <property name="spacing">
-            <number>0</number>
-           </property>
-           <item>
-            <widget class="QComboBox" name="stock">
-             <property name="currentIndex">
-              <number>2</number>
-             </property>
-             <item>
-              <property name="text">
-               <string>Create Box</string>
-              </property>
-             </item>
-             <item>
-              <property name="text">
-               <string>Create Cylinder</string>
-              </property>
-             </item>
-             <item>
-              <property name="text">
-               <string>Extend Base Bound Box</string>
-              </property>
-             </item>
-             <item>
-              <property name="text">
-               <string>Use Existing Solid</string>
-              </property>
-             </item>
-            </widget>
-           </item>
-           <item>
-            <spacer name="horizontalSpacer">
-             <property name="orientation">
-              <enum>Qt::Horizontal</enum>
-             </property>
-             <property name="sizeHint" stdset="0">
-              <size>
-               <width>40</width>
-               <height>6</height>
-              </size>
-             </property>
-            </spacer>
-           </item>
-           <item>
-            <widget class="QFrame" name="stockFromExisting">
-             <layout class="QGridLayout" name="gridLayout_8">
-              <item row="0" column="1">
-               <widget class="QComboBox" name="stockExisting"/>
-              </item>
-             </layout>
-            </widget>
-           </item>
-           <item>
-            <widget class="QFrame" name="stockFromBase">
-             <layout class="QGridLayout" name="gridLayout_9">
-              <item row="1" column="3">
-               <widget class="Gui::InputField" name="stockExtYpos"/>
-              </item>
-              <item row="0" column="1">
-               <widget class="QLabel" name="stockExtXLabel">
-                <property name="text">
-                 <string>Ext. X</string>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="3">
-               <widget class="Gui::InputField" name="stockExtXpos">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="1">
-               <widget class="QLabel" name="stockExtYLabel">
-                <property name="text">
-                 <string>Ext. Y</string>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="2">
-               <widget class="Gui::InputField" name="stockExtXneg"/>
-              </item>
-              <item row="2" column="1">
-               <widget class="QLabel" name="stockExtZLabel">
-                <property name="text">
-                 <string>Ext. Z</string>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="2">
-               <widget class="Gui::InputField" name="stockExtZneg"/>
-              </item>
-              <item row="2" column="3">
-               <widget class="Gui::InputField" name="stockExtZpos"/>
-              </item>
-              <item row="1" column="2">
-               <widget class="Gui::InputField" name="stockExtYneg"/>
-              </item>
-             </layout>
-            </widget>
-           </item>
-           <item>
-            <widget class="QFrame" name="stockCreateCylinder">
-             <layout class="QGridLayout" name="gridLayout_10">
-              <item row="0" column="2">
-               <widget class="Gui::InputField" name="stockCylinderRadius"/>
-              </item>
-              <item row="1" column="2">
-               <widget class="Gui::InputField" name="stockCylinderHeight"/>
-              </item>
-              <item row="0" column="1">
-               <widget class="QLabel" name="stockCylinderRadiusLabel">
-                <property name="text">
-                 <string>Radius</string>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="1">
-               <widget class="QLabel" name="stockCylinderHeightLabel">
-                <property name="text">
-                 <string>Height</string>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </widget>
-           </item>
-           <item>
-            <widget class="QFrame" name="stockCreateBox">
-             <layout class="QGridLayout" name="gridLayout_11">
-              <item row="0" column="1">
-               <widget class="QLabel" name="stockBoxLengthLabel">
-                <property name="text">
-                 <string>Length</string>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="1">
-               <widget class="QLabel" name="stockBoxWidthLabel">
-                <property name="text">
-                 <string>Width</string>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="2">
-               <widget class="Gui::InputField" name="stockBoxLength"/>
-              </item>
-              <item row="2" column="2">
-               <widget class="Gui::InputField" name="stockBoxHeight"/>
-              </item>
-              <item row="1" column="2">
-               <widget class="Gui::InputField" name="stockBoxWidth"/>
-              </item>
-              <item row="2" column="1">
-               <widget class="QLabel" name="stockBoxHeightLabel">
-                <property name="text">
-                 <string>Height</string>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </widget>
-           </item>
-          </layout>
-         </widget>
-        </item>
-        <item>
-         <widget class="QGroupBox" name="orientGroup">
-          <property name="title">
-           <string>Orientation</string>
+         </item>
+         <item>
+          <property name="text">
+           <string>Create Cylinder</string>
           </property>
-          <layout class="QHBoxLayout" name="horizontalLayout">
-           <item>
-            <widget class="QPushButton" name="orientXAxis">
-             <property name="text">
-              <string>X-Axis</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QPushButton" name="orientYAxis">
-             <property name="text">
-              <string>Y-Axis</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QPushButton" name="orientZAxis">
-             <property name="text">
-              <string>Z-Axis</string>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </widget>
-        </item>
-        <item>
-         <widget class="QGroupBox" name="alignGroup">
-          <property name="title">
-           <string>Alignment</string>
+         </item>
+         <item>
+          <property name="text">
+           <string>Extend Base Bound Box</string>
           </property>
-          <layout class="QGridLayout" name="gridLayout_2">
-           <item row="1" column="0">
-            <widget class="QPushButton" name="setOrigin">
-             <property name="text">
-              <string>Set Origin</string>
-             </property>
-            </widget>
-           </item>
-           <item row="1" column="1">
-            <widget class="QPushButton" name="moveToOrigin">
-             <property name="text">
-              <string>Move to Origin</string>
-             </property>
-            </widget>
-           </item>
-           <item row="2" column="0">
-            <widget class="QPushButton" name="centerInStock">
-             <property name="text">
-              <string>Center in Stock</string>
-             </property>
-            </widget>
-           </item>
-           <item row="2" column="1">
-            <widget class="QPushButton" name="centerInStockXY">
-             <property name="text">
-              <string>XY in Stock</string>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </widget>
-        </item>
-        <item>
-         <spacer name="verticalSpacer_2">
-          <property name="orientation">
-           <enum>Qt::Vertical</enum>
+         </item>
+         <item>
+          <property name="text">
+           <string>Use Existing Solid</string>
           </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>20</width>
-            <height>40</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-       </layout>
-      </widget>
+         </item>
+        </widget>
+       </item>
+       <item>
+        <spacer name="horizontalSpacer">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>6</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="QFrame" name="stockFromExisting">
+         <layout class="QGridLayout" name="gridLayout_8">
+          <item row="0" column="1">
+           <widget class="QComboBox" name="stockExisting"/>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QFrame" name="stockFromBase">
+         <layout class="QGridLayout" name="gridLayout_9">
+          <item row="1" column="3">
+           <widget class="Gui::InputField" name="stockExtYpos"/>
+          </item>
+          <item row="0" column="1">
+           <widget class="QLabel" name="stockExtXLabel">
+            <property name="text">
+             <string>Ext. X</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="3">
+           <widget class="Gui::InputField" name="stockExtXpos">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QLabel" name="stockExtYLabel">
+            <property name="text">
+             <string>Ext. Y</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="2">
+           <widget class="Gui::InputField" name="stockExtXneg"/>
+          </item>
+          <item row="2" column="1">
+           <widget class="QLabel" name="stockExtZLabel">
+            <property name="text">
+             <string>Ext. Z</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="2">
+           <widget class="Gui::InputField" name="stockExtZneg"/>
+          </item>
+          <item row="2" column="3">
+           <widget class="Gui::InputField" name="stockExtZpos"/>
+          </item>
+          <item row="1" column="2">
+           <widget class="Gui::InputField" name="stockExtYneg"/>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QFrame" name="stockCreateCylinder">
+         <layout class="QGridLayout" name="gridLayout_10">
+          <item row="0" column="2">
+           <widget class="Gui::InputField" name="stockCylinderRadius"/>
+          </item>
+          <item row="1" column="2">
+           <widget class="Gui::InputField" name="stockCylinderHeight"/>
+          </item>
+          <item row="0" column="1">
+           <widget class="QLabel" name="stockCylinderRadiusLabel">
+            <property name="text">
+             <string>Radius</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QLabel" name="stockCylinderHeightLabel">
+            <property name="text">
+             <string>Height</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QFrame" name="stockCreateBox">
+         <layout class="QGridLayout" name="gridLayout_11">
+          <item row="0" column="1">
+           <widget class="QLabel" name="stockBoxLengthLabel">
+            <property name="text">
+             <string>Length</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QLabel" name="stockBoxWidthLabel">
+            <property name="text">
+             <string>Width</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="2">
+           <widget class="Gui::InputField" name="stockBoxLength"/>
+          </item>
+          <item row="2" column="2">
+           <widget class="Gui::InputField" name="stockBoxHeight"/>
+          </item>
+          <item row="1" column="2">
+           <widget class="Gui::InputField" name="stockBoxWidth"/>
+          </item>
+          <item row="2" column="1">
+           <widget class="QLabel" name="stockBoxHeightLabel">
+            <property name="text">
+             <string>Height</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+      </layout>
      </widget>
+    </item>
+    <item>
+     <widget class="QGroupBox" name="orientGroup">
+      <property name="title">
+       <string>Orientation</string>
+      </property>
+      <layout class="QHBoxLayout" name="horizontalLayout">
+       <item>
+        <widget class="QPushButton" name="orientXAxis">
+         <property name="text">
+          <string>X-Axis</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="orientYAxis">
+         <property name="text">
+          <string>Y-Axis</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="orientZAxis">
+         <property name="text">
+          <string>Z-Axis</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </item>
+    <item>
+     <widget class="QGroupBox" name="alignGroup">
+      <property name="title">
+       <string>Alignment</string>
+      </property>
+      <layout class="QGridLayout" name="gridLayout_2">
+       <item row="1" column="0">
+        <widget class="QPushButton" name="setOrigin">
+         <property name="text">
+          <string>Set Origin</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="1">
+        <widget class="QPushButton" name="moveToOrigin">
+         <property name="text">
+          <string>Move to Origin</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="0">
+        <widget class="QPushButton" name="centerInStock">
+         <property name="text">
+          <string>Center in Stock</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="1">
+        <widget class="QPushButton" name="centerInStockXY">
+         <property name="text">
+          <string>XY in Stock</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </item>
+    <item>
+     <spacer name="verticalSpacer_2">
+      <property name="orientation">
+       <enum>Qt::Vertical</enum>
+      </property>
+      <property name="sizeHint" stdset="0">
+       <size>
+        <width>20</width>
+        <height>195</height>
+       </size>
+      </property>
+     </spacer>
     </item>
    </layout>
   </widget>
@@ -449,102 +397,80 @@
    <attribute name="title">
     <string>Tools</string>
    </attribute>
-   <layout class="QVBoxLayout" name="verticalLayout_8">
+   <layout class="QVBoxLayout" name="verticalLayout_3">
     <item>
-     <widget class="QToolBox" name="tbTools">
-      <property name="currentIndex">
-       <number>0</number>
-      </property>
-      <widget class="QWidget" name="pageToolController">
-       <property name="geometry">
-        <rect>
-         <x>0</x>
-         <y>0</y>
-         <width>378</width>
-         <height>830</height>
-        </rect>
+     <widget class="QTableWidget" name="toolControllerList">
+      <attribute name="verticalHeaderVisible">
+       <bool>false</bool>
+      </attribute>
+      <column>
+       <property name="text">
+        <string>Name</string>
        </property>
-       <attribute name="label">
-        <string>Tool Controller</string>
-       </attribute>
-       <layout class="QVBoxLayout" name="verticalLayout_9">
-        <item>
-         <widget class="QTableWidget" name="toolControllerList">
-          <attribute name="verticalHeaderVisible">
-           <bool>false</bool>
-          </attribute>
-          <column>
-           <property name="text">
-            <string>Name</string>
-           </property>
-          </column>
-          <column>
-           <property name="text">
-            <string>Nr.</string>
-           </property>
-          </column>
-          <column>
-           <property name="text">
-            <string>Feed</string>
-           </property>
-           <property name="icon">
-            <iconset theme="object-flip-horizontal">
-             <normaloff/>
-            </iconset>
-           </property>
-          </column>
-          <column>
-           <property name="text">
-            <string>Feed</string>
-           </property>
-           <property name="icon">
-            <iconset theme="object-flip-vertical">
-             <normaloff/>
-            </iconset>
-           </property>
-          </column>
-          <column>
-           <property name="text">
-            <string>Spindle</string>
-           </property>
-          </column>
-         </widget>
-        </item>
-        <item>
-         <widget class="QWidget" name="widget_4" native="true">
-          <layout class="QHBoxLayout" name="horizontalLayout_2">
-           <item>
-            <widget class="QPushButton" name="toolControllerEdit">
-             <property name="enabled">
-              <bool>false</bool>
-             </property>
-             <property name="text">
-              <string>Edit</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QPushButton" name="toolControllerAdd">
-             <property name="text">
-              <string>Add</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QPushButton" name="toolControllerDelete">
-             <property name="enabled">
-              <bool>false</bool>
-             </property>
-             <property name="text">
-              <string>Remove</string>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </widget>
-        </item>
-       </layout>
-      </widget>
+      </column>
+      <column>
+       <property name="text">
+        <string>Nr.</string>
+       </property>
+      </column>
+      <column>
+       <property name="text">
+        <string>Feed</string>
+       </property>
+       <property name="icon">
+        <iconset theme="object-flip-horizontal">
+         <normaloff/>
+        </iconset>
+       </property>
+      </column>
+      <column>
+       <property name="text">
+        <string>Feed</string>
+       </property>
+       <property name="icon">
+        <iconset theme="object-flip-vertical">
+         <normaloff/>
+        </iconset>
+       </property>
+      </column>
+      <column>
+       <property name="text">
+        <string>Spindle</string>
+       </property>
+      </column>
+     </widget>
+    </item>
+    <item>
+     <widget class="QWidget" name="widget_4" native="true">
+      <layout class="QHBoxLayout" name="horizontalLayout_2">
+       <item>
+        <widget class="QPushButton" name="toolControllerEdit">
+         <property name="enabled">
+          <bool>false</bool>
+         </property>
+         <property name="text">
+          <string>Edit</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="toolControllerAdd">
+         <property name="text">
+          <string>Add</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="toolControllerDelete">
+         <property name="enabled">
+          <bool>false</bool>
+         </property>
+         <property name="text">
+          <string>Remove</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
      </widget>
     </item>
    </layout>
@@ -553,315 +479,127 @@
    <attribute name="title">
     <string>Workplan</string>
    </attribute>
-   <layout class="QVBoxLayout" name="verticalLayout_10">
+   <layout class="QVBoxLayout" name="verticalLayout_4">
     <item>
-     <widget class="QToolBox" name="tbWorkplan">
-      <property name="currentIndex">
-       <number>0</number>
-      </property>
-      <widget class="QWidget" name="pageOperations">
-       <property name="geometry">
-        <rect>
-         <x>0</x>
-         <y>0</y>
-         <width>378</width>
-         <height>793</height>
-        </rect>
+     <widget class="QWidget" name="activeToolGroup" native="true">
+      <layout class="QFormLayout" name="formLayout_3">
+       <property name="fieldGrowthPolicy">
+        <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
        </property>
-       <attribute name="label">
-        <string>Operations</string>
-       </attribute>
-       <layout class="QVBoxLayout" name="verticalLayout_11">
-        <item>
-         <widget class="QWidget" name="activeToolGroup" native="true">
-          <layout class="QFormLayout" name="formLayout_3">
-           <property name="fieldGrowthPolicy">
-            <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
-           </property>
-           <item row="0" column="0">
-            <widget class="QLabel" name="label_18">
-             <property name="text">
-              <string>Active Tool </string>
-             </property>
-            </widget>
-           </item>
-           <item row="0" column="1">
-            <widget class="QComboBox" name="activeToolController"/>
-           </item>
-          </layout>
-         </widget>
-        </item>
-        <item>
-         <widget class="QWidget" name="widget" native="true">
-          <layout class="QHBoxLayout" name="horizontalLayout_4">
-           <item>
-            <widget class="QListWidget" name="operationsList">
-             <property name="dragDropMode">
-              <enum>QAbstractItemView::InternalMove</enum>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QWidget" name="operationMove" native="true">
-             <layout class="QVBoxLayout" name="verticalLayout_2">
-              <property name="margin">
-               <number>0</number>
-              </property>
-              <item>
-               <spacer name="verticalSpacer_6">
-                <property name="orientation">
-                 <enum>Qt::Vertical</enum>
-                </property>
-                <property name="sizeHint" stdset="0">
-                 <size>
-                  <width>20</width>
-                  <height>40</height>
-                 </size>
-                </property>
-               </spacer>
-              </item>
-              <item>
-               <widget class="QToolButton" name="operationUp">
-                <property name="text">
-                 <string>...</string>
-                </property>
-                <property name="icon">
-                 <iconset resource="../../../../../Gui/Icons/resource.qrc">
-                  <normaloff>:/icons/button_up.svg</normaloff>:/icons/button_up.svg</iconset>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <widget class="QToolButton" name="operationDown">
-                <property name="text">
-                 <string>...</string>
-                </property>
-                <property name="icon">
-                 <iconset resource="../../../../../Gui/Icons/resource.qrc">
-                  <normaloff>:/icons/button_down.svg</normaloff>:/icons/button_down.svg</iconset>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <spacer name="verticalSpacer_7">
-                <property name="orientation">
-                 <enum>Qt::Vertical</enum>
-                </property>
-                <property name="sizeHint" stdset="0">
-                 <size>
-                  <width>20</width>
-                  <height>40</height>
-                 </size>
-                </property>
-               </spacer>
-              </item>
-             </layout>
-            </widget>
-           </item>
-          </layout>
-         </widget>
-        </item>
-        <item>
-         <widget class="QWidget" name="operationModify" native="true">
-          <layout class="QHBoxLayout" name="horizontalLayout_3">
-           <item>
-            <widget class="QPushButton" name="operationEdit">
-             <property name="text">
-              <string>Edit</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <spacer name="horizontalSpacer_3">
-             <property name="orientation">
-              <enum>Qt::Horizontal</enum>
-             </property>
-             <property name="sizeHint" stdset="0">
-              <size>
-               <width>40</width>
-               <height>20</height>
-              </size>
-             </property>
-            </spacer>
-           </item>
-           <item>
-            <widget class="QPushButton" name="operationDelete">
-             <property name="text">
-              <string>Delete</string>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </widget>
-        </item>
-       </layout>
-      </widget>
-      <widget class="QWidget" name="pageDefaultValues">
-       <property name="geometry">
-        <rect>
-         <x>0</x>
-         <y>0</y>
-         <width>395</width>
-         <height>778</height>
-        </rect>
-       </property>
-       <attribute name="label">
-        <string>Default Values</string>
-       </attribute>
-       <layout class="QVBoxLayout" name="verticalLayout_14">
-        <item>
-         <widget class="QGroupBox" name="groupBox_5">
-          <property name="title">
-           <string>Heights</string>
+       <item row="0" column="0">
+        <widget class="QLabel" name="label_18">
+         <property name="text">
+          <string>Active Tool </string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="1">
+        <widget class="QComboBox" name="activeToolController"/>
+       </item>
+      </layout>
+     </widget>
+    </item>
+    <item>
+     <widget class="QWidget" name="widget" native="true">
+      <layout class="QHBoxLayout" name="horizontalLayout_4">
+       <item>
+        <widget class="QListWidget" name="operationsList">
+         <property name="dragDropMode">
+          <enum>QAbstractItemView::InternalMove</enum>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QWidget" name="operationMove" native="true">
+         <layout class="QVBoxLayout" name="verticalLayout_2">
+          <property name="margin">
+           <number>0</number>
           </property>
-          <property name="checkable">
-           <bool>true</bool>
-          </property>
-          <property name="checked">
-           <bool>false</bool>
-          </property>
-          <layout class="QGridLayout" name="gridLayout_4">
-           <item row="0" column="0">
-            <widget class="QLabel" name="label_14">
-             <property name="text">
-              <string>Safe</string>
-             </property>
-            </widget>
-           </item>
-           <item row="0" column="1">
-            <widget class="Gui::InputField" name="defaultSafeHeight"/>
-           </item>
-           <item row="1" column="1">
-            <widget class="Gui::InputField" name="defaultClearanceHeight"/>
-           </item>
-           <item row="1" column="0">
-            <widget class="QLabel" name="label_15">
-             <property name="text">
-              <string>Clearance</string>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </widget>
-        </item>
-        <item>
-         <widget class="QGroupBox" name="groupBox_6">
-          <property name="title">
-           <string>Depths</string>
-          </property>
-          <property name="checkable">
-           <bool>true</bool>
-          </property>
-          <property name="checked">
-           <bool>false</bool>
-          </property>
-          <layout class="QGridLayout" name="gridLayout_5">
-           <item row="0" column="0">
-            <widget class="QLabel" name="label_16">
-             <property name="text">
-              <string>Step Down</string>
-             </property>
-            </widget>
-           </item>
-           <item row="0" column="1">
-            <widget class="Gui::InputField" name="defaultStepDown"/>
-           </item>
-          </layout>
-         </widget>
-        </item>
-        <item>
-         <widget class="QGroupBox" name="groupBox">
-          <property name="title">
-           <string>Rapid Speed</string>
-          </property>
-          <property name="checkable">
-           <bool>true</bool>
-          </property>
-          <property name="checked">
-           <bool>false</bool>
-          </property>
-          <layout class="QFormLayout" name="formLayout">
-           <item row="0" column="0">
-            <widget class="QLabel" name="label_3">
-             <property name="text">
-              <string>Horizontal</string>
-             </property>
-            </widget>
-           </item>
-           <item row="0" column="1">
-            <widget class="Gui::InputField" name="lineEdit"/>
-           </item>
-           <item row="1" column="1">
-            <widget class="Gui::InputField" name="lineEdit_2"/>
-           </item>
-           <item row="1" column="0">
-            <widget class="QLabel" name="label_4">
-             <property name="text">
-              <string>Vertical</string>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </widget>
-        </item>
-        <item>
-         <widget class="QGroupBox" name="groupBox_7">
-          <property name="title">
-           <string>Operation</string>
-          </property>
-          <property name="checkable">
-           <bool>true</bool>
-          </property>
-          <property name="checked">
-           <bool>false</bool>
-          </property>
-          <layout class="QGridLayout" name="gridLayout_6">
-           <item row="0" column="0">
-            <widget class="QLabel" name="label_17">
-             <property name="text">
-              <string>Milling</string>
-             </property>
-            </widget>
-           </item>
-           <item row="0" column="1">
-            <widget class="QComboBox" name="defaultMillingOp">
-             <item>
-              <property name="text">
-               <string>conventional</string>
-              </property>
-             </item>
-             <item>
-              <property name="text">
-               <string>climb</string>
-              </property>
-             </item>
-            </widget>
-           </item>
-           <item row="1" column="0">
-            <widget class="QCheckBox" name="defaultToolCompensation">
-             <property name="text">
-              <string>Tool Compensated</string>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </widget>
-        </item>
-        <item>
-         <spacer name="verticalSpacer_3">
-          <property name="orientation">
-           <enum>Qt::Vertical</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>20</width>
-            <height>40</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-       </layout>
-      </widget>
+          <item>
+           <spacer name="verticalSpacer_6">
+            <property name="orientation">
+             <enum>Qt::Vertical</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>20</width>
+              <height>40</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item>
+           <widget class="QToolButton" name="operationUp">
+            <property name="text">
+             <string>...</string>
+            </property>
+            <property name="icon">
+             <iconset resource="../../../../../Gui/Icons/resource.qrc">
+              <normaloff>:/icons/button_up.svg</normaloff>:/icons/button_up.svg</iconset>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QToolButton" name="operationDown">
+            <property name="text">
+             <string>...</string>
+            </property>
+            <property name="icon">
+             <iconset resource="../../../../../Gui/Icons/resource.qrc">
+              <normaloff>:/icons/button_down.svg</normaloff>:/icons/button_down.svg</iconset>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <spacer name="verticalSpacer_7">
+            <property name="orientation">
+             <enum>Qt::Vertical</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>20</width>
+              <height>40</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+         </layout>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </item>
+    <item>
+     <widget class="QWidget" name="operationModify" native="true">
+      <layout class="QHBoxLayout" name="horizontalLayout_3">
+       <item>
+        <widget class="QPushButton" name="operationEdit">
+         <property name="text">
+          <string>Edit</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="horizontalSpacer_3">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="QPushButton" name="operationDelete">
+         <property name="text">
+          <string>Delete</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
      </widget>
     </item>
    </layout>
@@ -874,50 +612,6 @@
    <header>Gui/InputField.h</header>
   </customwidget>
  </customwidgets>
- <tabstops>
-  <tabstop>infoLabel</tabstop>
-  <tabstop>infoModel</tabstop>
-  <tabstop>infoMaterial</tabstop>
-  <tabstop>stock</tabstop>
-  <tabstop>stockExisting</tabstop>
-  <tabstop>stockExtXneg</tabstop>
-  <tabstop>stockExtXpos</tabstop>
-  <tabstop>stockExtYneg</tabstop>
-  <tabstop>stockExtYpos</tabstop>
-  <tabstop>stockExtZneg</tabstop>
-  <tabstop>stockExtZpos</tabstop>
-  <tabstop>stockCylinderRadius</tabstop>
-  <tabstop>stockCylinderHeight</tabstop>
-  <tabstop>stockBoxLength</tabstop>
-  <tabstop>stockBoxWidth</tabstop>
-  <tabstop>stockBoxHeight</tabstop>
-  <tabstop>orientXAxis</tabstop>
-  <tabstop>orientYAxis</tabstop>
-  <tabstop>orientZAxis</tabstop>
-  <tabstop>setOrigin</tabstop>
-  <tabstop>moveToOrigin</tabstop>
-  <tabstop>centerInStock</tabstop>
-  <tabstop>centerInStockXY</tabstop>
-  <tabstop>toolControllerList</tabstop>
-  <tabstop>toolControllerEdit</tabstop>
-  <tabstop>toolControllerAdd</tabstop>
-  <tabstop>toolControllerDelete</tabstop>
-  <tabstop>activeToolController</tabstop>
-  <tabstop>operationsList</tabstop>
-  <tabstop>operationEdit</tabstop>
-  <tabstop>operationDelete</tabstop>
-  <tabstop>groupBox_5</tabstop>
-  <tabstop>defaultSafeHeight</tabstop>
-  <tabstop>defaultClearanceHeight</tabstop>
-  <tabstop>groupBox_6</tabstop>
-  <tabstop>defaultStepDown</tabstop>
-  <tabstop>groupBox</tabstop>
-  <tabstop>lineEdit</tabstop>
-  <tabstop>lineEdit_2</tabstop>
-  <tabstop>groupBox_7</tabstop>
-  <tabstop>defaultMillingOp</tabstop>
-  <tabstop>defaultToolCompensation</tabstop>
- </tabstops>
  <resources>
   <include location="../../../../../Gui/Icons/resource.qrc"/>
  </resources>

--- a/src/Mod/Path/Gui/Resources/panels/PathEdit.ui
+++ b/src/Mod/Path/Gui/Resources/panels/PathEdit.ui
@@ -86,8 +86,8 @@
         <rect>
          <x>0</x>
          <y>0</y>
-         <width>294</width>
-         <height>309</height>
+         <width>378</width>
+         <height>477</height>
         </rect>
        </property>
        <attribute name="label">
@@ -218,15 +218,15 @@
        <bool>true</bool>
       </property>
       <property name="currentIndex">
-       <number>1</number>
+       <number>0</number>
       </property>
       <widget class="QWidget" name="page_3">
        <property name="geometry">
         <rect>
          <x>0</x>
          <y>0</y>
-         <width>368</width>
-         <height>399</height>
+         <width>378</width>
+         <height>403</height>
         </rect>
        </property>
        <attribute name="label">
@@ -234,7 +234,7 @@
        </attribute>
        <layout class="QVBoxLayout" name="verticalLayout_5">
         <item>
-         <widget class="QGroupBox" name="groupBox_10">
+         <widget class="QGroupBox" name="stockGroup">
           <property name="title">
            <string>Stock</string>
           </property>
@@ -404,10 +404,18 @@
          </widget>
         </item>
         <item row="0" column="1">
-         <widget class="QLineEdit" name="postProcessorOutputFile"/>
+         <widget class="QLineEdit" name="postProcessorOutputFile">
+          <property name="toolTip">
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enter a path and optionally file name (see below) to be used as the default for the post processor export.&lt;/p&gt;&lt;p&gt;The following substitutions are performed before the name is resolved at the time of the post processing:&lt;/p&gt;&lt;p&gt;%D ... directory of the active document&lt;br/&gt;%d ... name of the active document (with extension)&lt;br/&gt;%M ... user macro directory&lt;br/&gt;%j ... name of the active Job object&lt;/p&gt;&lt;p&gt;The following example store all files with the same name as the document the directory /home/freecad (please remove quotes):&lt;/p&gt;&lt;p&gt;&amp;quot;/home/cnc/%d.g-code&amp;quot;&lt;/p&gt;&lt;p&gt;See the file save policy below on how to deal with name conflicts.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
+         </widget>
         </item>
         <item row="2" column="1" colspan="2">
-         <widget class="QLineEdit" name="postProcessorArguments"/>
+         <widget class="QLineEdit" name="postProcessorArguments">
+          <property name="toolTip">
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Optional arguments passed to the Post Processor. The arguments are specific for each Post Processor, please see it's documentation for details.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
+         </widget>
         </item>
         <item row="2" column="0">
          <widget class="QLabel" name="label_11">
@@ -535,7 +543,9 @@
             <string>Feed</string>
            </property>
            <property name="icon">
-            <iconset theme="object-flip-horizontal"/>
+            <iconset theme="object-flip-horizontal">
+             <normaloff/>
+            </iconset>
            </property>
           </column>
           <column>
@@ -543,7 +553,9 @@
             <string>Feed</string>
            </property>
            <property name="icon">
-            <iconset theme="object-flip-vertical"/>
+            <iconset theme="object-flip-vertical">
+             <normaloff/>
+            </iconset>
            </property>
           </column>
           <column>
@@ -600,7 +612,7 @@
     <item>
      <widget class="QToolBox" name="toolBox_2">
       <property name="currentIndex">
-       <number>0</number>
+       <number>1</number>
       </property>
       <widget class="QWidget" name="page_9">
        <property name="geometry">
@@ -685,49 +697,6 @@
         <string>Default Values</string>
        </attribute>
        <layout class="QVBoxLayout" name="verticalLayout_14">
-        <item>
-         <widget class="QGroupBox" name="groupBox_7">
-          <property name="title">
-           <string>Operation</string>
-          </property>
-          <property name="checkable">
-           <bool>true</bool>
-          </property>
-          <property name="checked">
-           <bool>false</bool>
-          </property>
-          <layout class="QGridLayout" name="gridLayout_6">
-           <item row="0" column="0">
-            <widget class="QLabel" name="label_17">
-             <property name="text">
-              <string>Milling</string>
-             </property>
-            </widget>
-           </item>
-           <item row="0" column="1">
-            <widget class="QComboBox" name="defaultMillingOp">
-             <item>
-              <property name="text">
-               <string>conventional</string>
-              </property>
-             </item>
-             <item>
-              <property name="text">
-               <string>climb</string>
-              </property>
-             </item>
-            </widget>
-           </item>
-           <item row="1" column="0">
-            <widget class="QCheckBox" name="defaultToolCompensation">
-             <property name="text">
-              <string>Tool Compensated</string>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </widget>
-        </item>
         <item>
          <widget class="QGroupBox" name="groupBox_5">
           <property name="title">
@@ -821,11 +790,49 @@
             </widget>
            </item>
           </layout>
-          <zorder>label_15</zorder>
-          <zorder>label_3</zorder>
-          <zorder>lineEdit</zorder>
-          <zorder>lineEdit_2</zorder>
-          <zorder>label_4</zorder>
+         </widget>
+        </item>
+        <item>
+         <widget class="QGroupBox" name="groupBox_7">
+          <property name="title">
+           <string>Operation</string>
+          </property>
+          <property name="checkable">
+           <bool>true</bool>
+          </property>
+          <property name="checked">
+           <bool>false</bool>
+          </property>
+          <layout class="QGridLayout" name="gridLayout_6">
+           <item row="0" column="0">
+            <widget class="QLabel" name="label_17">
+             <property name="text">
+              <string>Milling</string>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="1">
+            <widget class="QComboBox" name="defaultMillingOp">
+             <item>
+              <property name="text">
+               <string>conventional</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>climb</string>
+              </property>
+             </item>
+            </widget>
+           </item>
+           <item row="1" column="0">
+            <widget class="QCheckBox" name="defaultToolCompensation">
+             <property name="text">
+              <string>Tool Compensated</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
          </widget>
         </item>
         <item>

--- a/src/Mod/Path/Gui/Resources/panels/PathEdit.ui
+++ b/src/Mod/Path/Gui/Resources/panels/PathEdit.ui
@@ -14,7 +14,7 @@
    <string>Job Edit</string>
   </property>
   <property name="currentIndex">
-   <number>1</number>
+   <number>2</number>
   </property>
   <widget class="QWidget" name="tabGeneral">
    <attribute name="title">
@@ -24,15 +24,15 @@
     <item>
      <widget class="QToolBox" name="tbGeneral">
       <property name="currentIndex">
-       <number>1</number>
+       <number>0</number>
       </property>
-      <widget class="QWidget" name="page">
+      <widget class="QWidget" name="pageInfo">
        <property name="geometry">
         <rect>
          <x>0</x>
          <y>0</y>
-         <width>242</width>
-         <height>129</height>
+         <width>378</width>
+         <height>793</height>
         </rect>
        </property>
        <attribute name="label">
@@ -81,122 +81,65 @@
         </item>
        </layout>
       </widget>
-      <widget class="QWidget" name="page_2">
-       <property name="geometry">
-        <rect>
-         <x>0</x>
-         <y>0</y>
-         <width>294</width>
-         <height>309</height>
-        </rect>
-       </property>
+      <widget class="QWidget" name="pagePostProcessor">
        <attribute name="label">
-        <string>Template</string>
+        <string>Post Processing</string>
        </attribute>
-       <layout class="QVBoxLayout" name="verticalLayout_2">
-        <item>
-         <widget class="QGroupBox" name="templateGeneral">
-          <property name="title">
-           <string>General</string>
-          </property>
-          <property name="checkable">
-           <bool>true</bool>
-          </property>
-          <layout class="QGridLayout" name="gridLayout_7">
-           <item row="0" column="1">
-            <widget class="QCheckBox" name="templateMaterial">
-             <property name="text">
-              <string>Material</string>
-             </property>
-             <property name="checked">
-              <bool>true</bool>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </widget>
-        </item>
-        <item>
-         <widget class="QGroupBox" name="templateSetup">
-          <property name="title">
-           <string>Setup</string>
-          </property>
-          <property name="checkable">
-           <bool>true</bool>
-          </property>
-          <layout class="QGridLayout" name="gridLayout_3">
-           <item row="0" column="0">
-            <widget class="QCheckBox" name="templateStock">
-             <property name="text">
-              <string>Stock</string>
-             </property>
-             <property name="checked">
-              <bool>true</bool>
-             </property>
-            </widget>
-           </item>
-           <item row="0" column="1">
-            <widget class="QCheckBox" name="templatePostProcessor">
-             <property name="text">
-              <string>Post Processor</string>
-             </property>
-             <property name="checked">
-              <bool>true</bool>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </widget>
-        </item>
-        <item>
-         <widget class="QGroupBox" name="templateTools">
-          <property name="title">
-           <string>Tools</string>
-          </property>
-          <property name="checkable">
-           <bool>true</bool>
-          </property>
-          <layout class="QVBoxLayout" name="verticalLayout_3"/>
-         </widget>
-        </item>
-        <item>
-         <widget class="QGroupBox" name="templateOperations">
-          <property name="title">
-           <string>Operations</string>
-          </property>
-          <property name="checkable">
-           <bool>true</bool>
-          </property>
-          <layout class="QVBoxLayout" name="verticalLayout_4">
-           <item>
-            <widget class="QCheckBox" name="templateDefaultValues">
-             <property name="text">
-              <string>Default Values</string>
-             </property>
-             <property name="checked">
-              <bool>true</bool>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </widget>
-        </item>
-        <item>
-         <widget class="QDialogButtonBox" name="buttonBox">
-          <property name="standardButtons">
-           <set>QDialogButtonBox::Save</set>
+       <layout class="QGridLayout" name="gridLayout_16">
+        <item row="0" column="0">
+         <widget class="QLabel" name="label_9">
+          <property name="text">
+           <string>Output File</string>
           </property>
          </widget>
         </item>
-        <item>
-         <spacer name="verticalSpacer_4">
+        <item row="0" column="1">
+         <widget class="QLineEdit" name="postProcessorOutputFile">
+          <property name="toolTip">
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enter a path and optionally file name (see below) to be used as the default for the post processor export.&lt;/p&gt;&lt;p&gt;The following substitutions are performed before the name is resolved at the time of the post processing:&lt;/p&gt;&lt;p&gt;%D ... directory of the active document&lt;br/&gt;%d ... name of the active document (with extension)&lt;br/&gt;%M ... user macro directory&lt;br/&gt;%j ... name of the active Job object&lt;/p&gt;&lt;p&gt;The following example store all files with the same name as the document the directory /home/freecad (please remove quotes):&lt;/p&gt;&lt;p&gt;&amp;quot;/home/cnc/%d.g-code&amp;quot;&lt;/p&gt;&lt;p&gt;See the file save policy below on how to deal with name conflicts.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="2">
+         <widget class="QToolButton" name="postProcessorSetOutputFile">
+          <property name="text">
+           <string>...</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="0">
+         <widget class="QLabel" name="label_10">
+          <property name="text">
+           <string>Processor</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="1" colspan="2">
+         <widget class="QComboBox" name="postProcessor"/>
+        </item>
+        <item row="2" column="0">
+         <widget class="QLabel" name="label_11">
+          <property name="text">
+           <string>Arguments</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="1" colspan="2">
+         <widget class="QLineEdit" name="postProcessorArguments">
+          <property name="toolTip">
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Optional arguments passed to the Post Processor. The arguments are specific for each Post Processor, please see it's documentation for details.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="0">
+         <spacer name="verticalSpacer">
           <property name="orientation">
            <enum>Qt::Vertical</enum>
           </property>
           <property name="sizeHint" stdset="0">
            <size>
             <width>20</width>
-            <height>40</height>
+            <height>655</height>
            </size>
           </property>
          </spacer>
@@ -220,13 +163,13 @@
       <property name="currentIndex">
        <number>0</number>
       </property>
-      <widget class="QWidget" name="page_3">
+      <widget class="QWidget" name="pageLayout">
        <property name="geometry">
         <rect>
          <x>0</x>
          <y>0</y>
          <width>378</width>
-         <height>719</height>
+         <height>830</height>
         </rect>
        </property>
        <attribute name="label">
@@ -490,150 +433,27 @@
         </item>
        </layout>
       </widget>
-      <widget class="QWidget" name="page_6">
-       <property name="geometry">
-        <rect>
-         <x>0</x>
-         <y>0</y>
-         <width>233</width>
-         <height>135</height>
-        </rect>
-       </property>
-       <attribute name="label">
-        <string>Post Processor</string>
-       </attribute>
-       <layout class="QGridLayout" name="gridLayout">
-        <item row="1" column="1" colspan="2">
-         <widget class="QComboBox" name="postProcessor"/>
-        </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="label_10">
-          <property name="text">
-           <string>Processor</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="0">
-         <widget class="QLabel" name="label_9">
-          <property name="text">
-           <string>Output File</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="1">
-         <widget class="QLineEdit" name="postProcessorOutputFile">
-          <property name="toolTip">
-           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enter a path and optionally file name (see below) to be used as the default for the post processor export.&lt;/p&gt;&lt;p&gt;The following substitutions are performed before the name is resolved at the time of the post processing:&lt;/p&gt;&lt;p&gt;%D ... directory of the active document&lt;br/&gt;%d ... name of the active document (with extension)&lt;br/&gt;%M ... user macro directory&lt;br/&gt;%j ... name of the active Job object&lt;/p&gt;&lt;p&gt;The following example store all files with the same name as the document the directory /home/freecad (please remove quotes):&lt;/p&gt;&lt;p&gt;&amp;quot;/home/cnc/%d.g-code&amp;quot;&lt;/p&gt;&lt;p&gt;See the file save policy below on how to deal with name conflicts.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="1" colspan="2">
-         <widget class="QLineEdit" name="postProcessorArguments">
-          <property name="toolTip">
-           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Optional arguments passed to the Post Processor. The arguments are specific for each Post Processor, please see it's documentation for details.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="0">
-         <widget class="QLabel" name="label_11">
-          <property name="text">
-           <string>Arguments</string>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="0">
-         <spacer name="verticalSpacer">
-          <property name="orientation">
-           <enum>Qt::Vertical</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>20</width>
-            <height>40</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item row="0" column="2">
-         <widget class="QToolButton" name="postProcessorSetOutputFile">
-          <property name="text">
-           <string>...</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </widget>
-      <widget class="QWidget" name="page_4">
-       <property name="geometry">
-        <rect>
-         <x>0</x>
-         <y>0</y>
-         <width>142</width>
-         <height>41</height>
-        </rect>
-       </property>
-       <attribute name="label">
-        <string>Fixtures</string>
-       </attribute>
-       <layout class="QVBoxLayout" name="verticalLayout_12">
-        <item alignment="Qt::AlignHCenter|Qt::AlignVCenter">
-         <widget class="QLabel" name="label_12">
-          <property name="enabled">
-           <bool>false</bool>
-          </property>
-          <property name="text">
-           <string>Coming Soon</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </widget>
-      <widget class="QWidget" name="page_5">
-       <property name="geometry">
-        <rect>
-         <x>0</x>
-         <y>0</y>
-         <width>142</width>
-         <height>41</height>
-        </rect>
-       </property>
-       <attribute name="label">
-        <string>Vise</string>
-       </attribute>
-       <layout class="QVBoxLayout" name="verticalLayout_13">
-        <item alignment="Qt::AlignHCenter|Qt::AlignVCenter">
-         <widget class="QLabel" name="label_13">
-          <property name="enabled">
-           <bool>false</bool>
-          </property>
-          <property name="text">
-           <string>Coming Soon</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </widget>
      </widget>
     </item>
    </layout>
   </widget>
-  <widget class="QWidget" name="tab">
+  <widget class="QWidget" name="tabTools">
    <attribute name="title">
     <string>Tools</string>
    </attribute>
    <layout class="QVBoxLayout" name="verticalLayout_8">
     <item>
-     <widget class="QToolBox" name="toolBox">
+     <widget class="QToolBox" name="tbTools">
       <property name="currentIndex">
        <number>0</number>
       </property>
-      <widget class="QWidget" name="page_7">
+      <widget class="QWidget" name="pageToolController">
        <property name="geometry">
         <rect>
          <x>0</x>
          <y>0</y>
-         <width>312</width>
-         <height>159</height>
+         <width>378</width>
+         <height>830</height>
         </rect>
        </property>
        <attribute name="label">
@@ -721,23 +541,23 @@
     </item>
    </layout>
   </widget>
-  <widget class="QWidget" name="tab_2">
+  <widget class="QWidget" name="tabWorkplan">
    <attribute name="title">
     <string>Workplan</string>
    </attribute>
    <layout class="QVBoxLayout" name="verticalLayout_10">
     <item>
-     <widget class="QToolBox" name="toolBox_2">
+     <widget class="QToolBox" name="tbWorkplan">
       <property name="currentIndex">
        <number>0</number>
       </property>
-      <widget class="QWidget" name="page_9">
+      <widget class="QWidget" name="pageOperations">
        <property name="geometry">
         <rect>
          <x>0</x>
          <y>0</y>
-         <width>255</width>
-         <height>234</height>
+         <width>378</width>
+         <height>793</height>
         </rect>
        </property>
        <attribute name="label">
@@ -773,6 +593,61 @@
              </property>
             </widget>
            </item>
+           <item>
+            <widget class="QWidget" name="operationMove" native="true">
+             <layout class="QVBoxLayout" name="verticalLayout_2">
+              <property name="margin">
+               <number>0</number>
+              </property>
+              <item>
+               <spacer name="verticalSpacer_6">
+                <property name="orientation">
+                 <enum>Qt::Vertical</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>20</width>
+                  <height>40</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+              <item>
+               <widget class="QToolButton" name="operationUp">
+                <property name="text">
+                 <string>...</string>
+                </property>
+                <property name="icon">
+                 <iconset theme="go-up"/>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QToolButton" name="operationDown">
+                <property name="text">
+                 <string>...</string>
+                </property>
+                <property name="icon">
+                 <iconset theme="go-down"/>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <spacer name="verticalSpacer_7">
+                <property name="orientation">
+                 <enum>Qt::Vertical</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>20</width>
+                  <height>40</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+             </layout>
+            </widget>
+           </item>
           </layout>
          </widget>
         </item>
@@ -781,13 +656,23 @@
           <layout class="QHBoxLayout" name="horizontalLayout_3">
            <item>
             <widget class="QPushButton" name="operationEdit">
-             <property name="enabled">
-              <bool>false</bool>
-             </property>
              <property name="text">
               <string>Edit</string>
              </property>
             </widget>
+           </item>
+           <item>
+            <spacer name="horizontalSpacer_3">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
            </item>
            <item>
             <widget class="QPushButton" name="operationDelete">
@@ -801,13 +686,13 @@
         </item>
        </layout>
       </widget>
-      <widget class="QWidget" name="page_10">
+      <widget class="QWidget" name="pageDefaultValues">
        <property name="geometry">
         <rect>
          <x>0</x>
          <y>0</y>
          <width>395</width>
-         <height>430</height>
+         <height>778</height>
         </rect>
        </property>
        <attribute name="label">
@@ -1003,19 +888,6 @@
   <tabstop>moveToOrigin</tabstop>
   <tabstop>centerInStock</tabstop>
   <tabstop>centerInStockXY</tabstop>
-  <tabstop>postProcessorOutputFile</tabstop>
-  <tabstop>postProcessorSetOutputFile</tabstop>
-  <tabstop>postProcessor</tabstop>
-  <tabstop>postProcessorArguments</tabstop>
-  <tabstop>templateDefaultValues</tabstop>
-  <tabstop>templatePostProcessor</tabstop>
-  <tabstop>buttonBox</tabstop>
-  <tabstop>templateGeneral</tabstop>
-  <tabstop>templateMaterial</tabstop>
-  <tabstop>templateSetup</tabstop>
-  <tabstop>templateStock</tabstop>
-  <tabstop>templateOperations</tabstop>
-  <tabstop>templateTools</tabstop>
   <tabstop>toolControllerList</tabstop>
   <tabstop>toolControllerEdit</tabstop>
   <tabstop>toolControllerAdd</tabstop>

--- a/src/Mod/Path/Gui/Resources/panels/ToolEdit.ui
+++ b/src/Mod/Path/Gui/Resources/panels/ToolEdit.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>361</width>
-    <height>450</height>
+    <width>422</width>
+    <height>498</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -207,13 +207,13 @@
         <property name="text">
          <string>0 mm</string>
         </property>
-        <property name="singleStep">
+        <property name="singleStep" stdset="0">
          <double>0.125000000000000</double>
         </property>
-        <property name="maximum">
+        <property name="maximum" stdset="0">
          <double>100.000000000000000</double>
         </property>
-        <property name="minimum">
+        <property name="minimum" stdset="0">
          <double>0.000000000000000</double>
         </property>
         <property name="unit" stdset="0">
@@ -226,10 +226,10 @@
         <property name="text">
          <string>0 mm</string>
         </property>
-        <property name="maximum">
+        <property name="maximum" stdset="0">
          <double>100.000000000000000</double>
         </property>
-        <property name="minimum">
+        <property name="minimum" stdset="0">
          <double>0.000000000000000</double>
         </property>
         <property name="unit" stdset="0">
@@ -242,10 +242,10 @@
         <property name="text">
          <string>0 mm</string>
         </property>
-        <property name="maximum">
+        <property name="maximum" stdset="0">
          <double>100.000000000000000</double>
         </property>
-        <property name="minimum">
+        <property name="minimum" stdset="0">
          <double>0.000000000000000</double>
         </property>
         <property name="unit" stdset="0">
@@ -258,10 +258,10 @@
         <property name="text">
          <string>0 mm</string>
         </property>
-        <property name="maximum">
+        <property name="maximum" stdset="0">
          <double>100.000000000000000</double>
         </property>
-        <property name="minimum">
+        <property name="minimum" stdset="0">
          <double>0.000000000000000</double>
         </property>
         <property name="unit" stdset="0">
@@ -274,10 +274,10 @@
         <property name="text">
          <string>0 mm</string>
         </property>
-        <property name="maximum">
+        <property name="maximum" stdset="0">
          <double>100.000000000000000</double>
         </property>
-        <property name="minimum">
+        <property name="minimum" stdset="0">
          <double>0.000000000000000</double>
         </property>
         <property name="unit" stdset="0">
@@ -314,6 +314,18 @@
    <header>Gui/InputField.h</header>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>NameField</tabstop>
+  <tabstop>TypeField</tabstop>
+  <tabstop>MaterialField</tabstop>
+  <tabstop>DiameterField</tabstop>
+  <tabstop>LengthOffsetField</tabstop>
+  <tabstop>FlatRadiusField</tabstop>
+  <tabstop>CornerRadiusField</tabstop>
+  <tabstop>CuttingEdgeAngleField</tabstop>
+  <tabstop>CuttingEdgeHeightField</tabstop>
+  <tabstop>buttonBox</tabstop>
+ </tabstops>
  <resources/>
  <connections>
   <connection>

--- a/src/Mod/Path/InitGui.py
+++ b/src/Mod/Path/InitGui.py
@@ -58,7 +58,7 @@ class PathWorkbench (Workbench):
         from PathScripts import PathHelixGui
         from PathScripts import PathHop
         from PathScripts import PathInspect
-        from PathScripts import PathJob
+        from PathScripts import PathJobGui
         from PathScripts import PathMillFaceGui
         from PathScripts import PathPlane
         from PathScripts import PathPocketGui

--- a/src/Mod/Path/InitGui.py
+++ b/src/Mod/Path/InitGui.py
@@ -141,15 +141,17 @@ class PathWorkbench (Workbench):
                 selectedName = obj.Name
                 if "Job" in selectedName:
                     self.appendContextMenu("", ["Path_ExportTemplate"])
+                if "Remote" in selectedName:
+                    self.appendContextMenu("", ["Refresh_Path"])
+            if isinstance (obj.Proxy, PathScripts.PathOp.ObjectOp):
+                self.appendContextMenu("", ["Path_OperationCopy"])
+            if obj.isDerivedFrom("Path::Feature"):
                 if "Profile" in selectedName or "Contour" in selectedName or "Dressup" in selectedName:
+                    self.appendContextMenu("", "Separator")
                     #self.appendContextMenu("", ["Set_StartPoint"])
                     #self.appendContextMenu("", ["Set_EndPoint"])
                     for cmd in self.dressupcmds:
                         self.appendContextMenu("", [cmd])
-                if "Remote" in selectedName:
-                    self.appendContextMenu("", ["Refresh_Path"])
-            if isinstance (obj.Proxy, PathScripts.PathOp.ObjectOp):
-                self.appendContextMenu("", ["Path_CloneOperation"])
 
 Gui.addWorkbench(PathWorkbench())
 

--- a/src/Mod/Path/InitGui.py
+++ b/src/Mod/Path/InitGui.py
@@ -68,7 +68,6 @@ class PathWorkbench (Workbench):
         from PathScripts import PathProfileFacesGui
         from PathScripts import PathSanity
         from PathScripts import PathSimpleCopy
-        from PathScripts import PathStock
         from PathScripts import PathStop
         from PathScripts import PathSurface
         from PathScripts import PathToolController
@@ -84,7 +83,7 @@ class PathWorkbench (Workbench):
         threedopcmdlist = ["Path_Surfacing"]
         modcmdlist = ["Path_OperationCopy", "Path_Array", "Path_SimpleCopy" ]
         dressupcmdlist = ["PathDressup_Dogbone", "PathDressup_DragKnife", "PathDressup_Tag", "PathDressup_RampEntry"]
-        extracmdlist = ["Path_SelectLoop", "Path_Shape", "Path_Area", "Path_Area_Workplane", "Path_Stock"]
+        extracmdlist = ["Path_SelectLoop", "Path_Shape", "Path_Area", "Path_Area_Workplane"]
         #modcmdmore = ["Path_Hop",]
         #remotecmdlist = ["Path_Remote"]
 

--- a/src/Mod/Path/InitGui.py
+++ b/src/Mod/Path/InitGui.py
@@ -58,7 +58,7 @@ class PathWorkbench (Workbench):
         from PathScripts import PathHelixGui
         from PathScripts import PathHop
         from PathScripts import PathInspect
-        from PathScripts import PathJobGui
+        from PathScripts import PathJobCmd
         from PathScripts import PathMillFaceGui
         from PathScripts import PathPlane
         from PathScripts import PathPocketGui

--- a/src/Mod/Path/PathScripts/PathAreaOp.py
+++ b/src/Mod/Path/PathScripts/PathAreaOp.py
@@ -132,7 +132,7 @@ class ObjectOp(PathOp.ObjectOp):
                             obj.Side = "Inside"
 
                 except Exception as e:
-                    PathLog.error(translate("PatArea", "Error in calculating depths: %s" % e))
+                    PathLog.error(translate("PatArea", "Error in calculating depths: %s") % e)
                     obj.StartDepth = 5.0
                     obj.ClearanceHeight = 10.0
                     obj.SafeHeight = 8.0

--- a/src/Mod/Path/PathScripts/PathDressupDogbone.py
+++ b/src/Mod/Path/PathScripts/PathDressupDogbone.py
@@ -985,7 +985,7 @@ class ViewProviderDressup:
         '''this makes sure that the base operation is added back to the project and visible'''
         FreeCADGui.ActiveDocument.getObject(arg1.Object.Base.Name).Visibility = True
         job = PathUtils.findParentJob(arg1.Object)
-        job.addOperation(arg1.Object.Base)
+        job.Proxy.addOperation(arg1.Object.Base)
         arg1.Object.Base = None
         return True
 

--- a/src/Mod/Path/PathScripts/PathDressupDogbone.py
+++ b/src/Mod/Path/PathScripts/PathDressupDogbone.py
@@ -996,7 +996,7 @@ def Create(base, name = 'DogboneDressup'):
     obj = FreeCAD.ActiveDocument.addObject('Path::FeaturePython', 'DogboneDressup')
     dbo = ObjectDressup(obj, base)
     job = PathUtils.findParentJob(base)
-    job.addOperation(obj)
+    job.Proxy.addOperation(obj)
 
     if FreeCAD.GuiUp:
         ViewProviderDressup(obj.ViewObject)
@@ -1004,7 +1004,6 @@ def Create(base, name = 'DogboneDressup'):
 
     obj.ToolController = base.ToolController
     dbo.setup(obj, True)
-
     return obj
 
 class CommandDressupDogbone:

--- a/src/Mod/Path/PathScripts/PathDressupDogbone.py
+++ b/src/Mod/Path/PathScripts/PathDressupDogbone.py
@@ -985,7 +985,7 @@ class ViewProviderDressup:
         '''this makes sure that the base operation is added back to the project and visible'''
         FreeCADGui.ActiveDocument.getObject(arg1.Object.Base.Name).Visibility = True
         job = PathUtils.findParentJob(arg1.Object)
-        PathUtils.addObjectToJob(arg1.Object.Base, job)
+        job.addOperation(arg1.Object.Base)
         arg1.Object.Base = None
         return True
 
@@ -996,7 +996,7 @@ def Create(base, name = 'DogboneDressup'):
     obj = FreeCAD.ActiveDocument.addObject('Path::FeaturePython', 'DogboneDressup')
     dbo = ObjectDressup(obj, base)
     job = PathUtils.findParentJob(base)
-    PathUtils.addObjectToJob(obj, job)
+    job.addOperation(obj)
 
     if FreeCAD.GuiUp:
         ViewProviderDressup(obj.ViewObject)

--- a/src/Mod/Path/PathScripts/PathDressupDragknife.py
+++ b/src/Mod/Path/PathScripts/PathDressupDragknife.py
@@ -429,8 +429,16 @@ class ViewProviderDressup:
 
     def attach(self, vobj):
         self.Object = vobj.Object
-        return
-
+        if self.Object and self.Object.Base:
+            for i in self.Object.Base.InList:
+                if hasattr(i, "Group"):
+                    group = i.Group
+                    for g in group:
+                        if g.Name == self.Object.Base.Name:
+                            group.remove(g)
+                    i.Group = group
+                    print(i.Group)
+            #FreeCADGui.ActiveDocument.getObject(obj.Base.Name).Visibility = False
 
     def unsetEdit(self, vobj, mode=0):
         return False
@@ -439,15 +447,6 @@ class ViewProviderDressup:
         return True
 
     def claimChildren(self):
-        for i in self.Object.Base.InList:
-            if hasattr(i, "Group"):
-                group = i.Group
-                for g in group:
-                    if g.Name == self.Object.Base.Name:
-                        group.remove(g)
-                i.Group = group
-                print(i.Group)
-        #FreeCADGui.ActiveDocument.getObject(obj.Base.Name).Visibility = False
         return [self.Object.Base]
 
     def __getstate__(self):
@@ -458,7 +457,7 @@ class ViewProviderDressup:
 
     def onDelete(self, arg1=None, arg2=None):
         FreeCADGui.ActiveDocument.getObject(arg1.Object.Base.Name).Visibility = True
-        PathUtils.addToProject(arg1.Object.Base)
+        PathUtils.addToJob(arg1.Object.Base)
         arg1.Object.Base = None
         return True
 

--- a/src/Mod/Path/PathScripts/PathDressupHoldingTags.py
+++ b/src/Mod/Path/PathScripts/PathDressupHoldingTags.py
@@ -968,7 +968,7 @@ def Create(baseObject, name = 'DressupTag'):
     obj = FreeCAD.ActiveDocument.addObject("Path::FeaturePython", "TagDressup")
     dbo = ObjectTagDressup(obj, baseObject)
     job = PathUtils.findParentJob(baseObject)
-    job.addOperation(obj)
+    job.Proxy.addOperation(obj)
     dbo.setup(obj, True)
     return obj
 

--- a/src/Mod/Path/PathScripts/PathDressupHoldingTags.py
+++ b/src/Mod/Path/PathScripts/PathDressupHoldingTags.py
@@ -968,7 +968,7 @@ def Create(baseObject, name = 'DressupTag'):
     obj = FreeCAD.ActiveDocument.addObject("Path::FeaturePython", "TagDressup")
     dbo = ObjectTagDressup(obj, baseObject)
     job = PathUtils.findParentJob(baseObject)
-    PathUtils.addObjectToJob(obj, job)
+    job.addOperation(obj)
     dbo.setup(obj, True)
     return obj
 

--- a/src/Mod/Path/PathScripts/PathDressupRampEntry.py
+++ b/src/Mod/Path/PathScripts/PathDressupRampEntry.py
@@ -563,7 +563,7 @@ class ViewProviderDressup:
         '''this makes sure that the base operation is added back to the project and visible'''
         FreeCADGui.ActiveDocument.getObject(arg1.Object.Base.Name).Visibility = True
         job = PathUtils.findParentJob(self.obj)
-        job.addOperation(arg1.Object.Base)
+        job.Proxy.addOperation(arg1.Object.Base)
         arg1.Object.Base = None
         return True
 

--- a/src/Mod/Path/PathScripts/PathDressupRampEntry.py
+++ b/src/Mod/Path/PathScripts/PathDressupRampEntry.py
@@ -563,7 +563,7 @@ class ViewProviderDressup:
         '''this makes sure that the base operation is added back to the project and visible'''
         FreeCADGui.ActiveDocument.getObject(arg1.Object.Base.Name).Visibility = True
         job = PathUtils.findParentJob(self.obj)
-        PathUtils.addObjectToJob(arg1.Object.Base, job)
+        job.addOperation(arg1.Object.Base)
         arg1.Object.Base = None
         return True
 

--- a/src/Mod/Path/PathScripts/PathDressupTag.py
+++ b/src/Mod/Path/PathScripts/PathDressupTag.py
@@ -242,7 +242,7 @@ def Create(baseObject, name = 'DressupTag'):
     obj = FreeCAD.ActiveDocument.addObject("Path::FeaturePython", "TagDressup")
     dbo = ObjectDressup(obj, baseObject)
     job = PathUtils.findParentJob(baseObject)
-    PathUtils.addObjectToJob(obj, job)
+    job.adddOperation(obj)
     dbo.assignDefaultValues()
     return obj
 

--- a/src/Mod/Path/PathScripts/PathDressupTagGui.py
+++ b/src/Mod/Path/PathScripts/PathDressupTagGui.py
@@ -522,7 +522,8 @@ class PathDressupTagViewProvider:
         if self.obj.Base.ViewObject:
             self.obj.Base.ViewObject.Visibility = True
         job = PathUtils.findParentJob(self.obj)
-        PathUtils.addObjectToJob(arg1.Object.Base, job)
+        job.addOperation(arg1.Object.Base)
+        arg1.Object.Base = None
         #if self.debugDisplay():
         #    self.vobj.Debug.removeObjectsFromDocument()
         #    self.vobj.Debug.Document.removeObject(self.vobj.Debug.Name)

--- a/src/Mod/Path/PathScripts/PathDressupTagGui.py
+++ b/src/Mod/Path/PathScripts/PathDressupTagGui.py
@@ -522,7 +522,7 @@ class PathDressupTagViewProvider:
         if self.obj.Base.ViewObject:
             self.obj.Base.ViewObject.Visibility = True
         job = PathUtils.findParentJob(self.obj)
-        job.addOperation(arg1.Object.Base)
+        job.Proxy.addOperation(arg1.Object.Base)
         arg1.Object.Base = None
         #if self.debugDisplay():
         #    self.vobj.Debug.removeObjectsFromDocument()

--- a/src/Mod/Path/PathScripts/PathIconViewProvider.py
+++ b/src/Mod/Path/PathScripts/PathIconViewProvider.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+
+# ***************************************************************************
+# *                                                                         *
+# *   Copyright (c) 2017 sliptonic <shopinthewoods@gmail.com>               *
+# *                                                                         *
+# *   This program is free software; you can redistribute it and/or modify  *
+# *   it under the terms of the GNU Lesser General Public License (LGPL)    *
+# *   as published by the Free Software Foundation; either version 2 of     *
+# *   the License, or (at your option) any later version.                   *
+# *   for detail see the LICENCE text file.                                 *
+# *                                                                         *
+# *   This program is distributed in the hope that it will be useful,       *
+# *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+# *   GNU Library General Public License for more details.                  *
+# *                                                                         *
+# *   You should have received a copy of the GNU Library General Public     *
+# *   License along with this program; if not, write to the Free Software   *
+# *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
+# *   USA                                                                   *
+# *                                                                         *
+# ***************************************************************************
+
+__title__ = "Path Icon ViewProvider"
+__author__ = "sliptonic (Brad Collette)"
+__url__ = "http://www.freecadweb.org"
+__doc__ = "ViewProvider who's main and only task is to assign an icon."
+
+class ViewProvider(object):
+    '''Generic view provider to assign an icon.'''
+
+    def __init__(self, vobj, icon):
+        self.icon = icon
+        vobj.Proxy = self
+
+    def attach(self, vobj):
+        self.vobj = vobj
+        self.obj = vobj.Object
+
+    def __getstate__(self):
+        return {'icon': self.icon }
+
+    def __setstate__(self, state):
+        self.icon = state['icon']
+
+    def getIcon(self):
+        return ":/icons/Path-{}.svg".format(self.icon)
+

--- a/src/Mod/Path/PathScripts/PathJob.py
+++ b/src/Mod/Path/PathScripts/PathJob.py
@@ -103,6 +103,11 @@ class ObjectJob:
         FreeCAD.ActiveDocument.removeObject(obj.Operations.Name)
         obj.Operations = None
 
+    def onChanged(self, obj, prop):
+        if prop == "PostProcessor" and obj.PostProcessor:
+            processor = PostProcessor.load(obj.PostProcessor)
+            self.tooltip = processor.tooltip
+            self.tooltipArgs = processor.tooltipArgs
 
     def assignTemplate(self, obj, template):
         '''assignTemplate(obj, template) ... extract the properties from the given template file and assign to receiver.

--- a/src/Mod/Path/PathScripts/PathJob.py
+++ b/src/Mod/Path/PathScripts/PathJob.py
@@ -97,15 +97,23 @@ class ObjectJob:
         self.assignTemplate(obj, template)
 
     def onDelete(self, obj, arg2=None):
-        PathLog.track(obj, arg2)
+        '''Called by the view provider, there doesn't seem to be a callback on the obj itself.'''
+        PathLog.track(obj.Label, arg2)
+        doc = obj.Document
         for tc in obj.ToolController:
-            FreeCAD.ActiveDocument.removeObject(tc.Name)
+            doc.removeObject(tc.Name)
         obj.ToolController = []
-        for op in obj.Operations.Group:
-            FreeCAD.ActiveDocument.removeObject(op.Name)
+        while obj.Operations.Group:
+            doc.removeObject(obj.Operations.Group[0].Name)
         obj.Operations.Group = []
-        FreeCAD.ActiveDocument.removeObject(obj.Operations.Name)
+        doc.removeObject(obj.Operations.Name)
         obj.Operations = None
+        if obj.Base:
+            doc.removeObject(obj.Base.Name)
+            obj.Base = None
+        if obj.Stock:
+            doc.removeObject(obj.Stock.Name)
+            obj.Stock = None
 
     def isResourceClone(self, obj, propName, resourceName):
         if hasattr(obj, propName):

--- a/src/Mod/Path/PathScripts/PathJob.py
+++ b/src/Mod/Path/PathScripts/PathJob.py
@@ -34,7 +34,7 @@ from PathScripts.PathPreferences import PathPreferences
 from PathScripts.PathPostProcessor import PostProcessor
 from PySide import QtCore
 
-if True:
+if False:
     PathLog.setLevel(PathLog.Level.DEBUG, PathLog.thisModule())
     PathLog.trackModule(PathLog.thisModule())
 else:
@@ -120,6 +120,8 @@ class ObjectJob:
                 clone.Label = name
                 clone.addProperty('App::PropertyString', 'PathResource')
                 clone.PathResource = name
+                if clone.ViewObject:
+                    clone.ViewObject.Visibility = False
                 setattr(obj, name, clone)
 
     def onBeforeChange(self, obj, prop):

--- a/src/Mod/Path/PathScripts/PathJob.py
+++ b/src/Mod/Path/PathScripts/PathJob.py
@@ -23,31 +23,21 @@
 # ***************************************************************************
 
 import ArchPanel
-import Draft
 import FreeCAD
-import Path
 import PathScripts.PathLog as PathLog
 import PathScripts.PathToolController as PathToolController
 import PathScripts.PathUtil as PathUtil
-import glob
 import xml.etree.ElementTree as xml
-import os
-import sys
 
-from PySide import QtCore, QtGui
-from PathScripts.PathPostProcessor import PostProcessor
 from PathScripts.PathPreferences import PathPreferences
+from PathScripts.PathPostProcessor import PostProcessor
+from PySide import QtCore
 
-# xrange is not available in python3
-if sys.version_info.major >= 3:
-    xrange = range
-
-PathLog.setLevel(PathLog.Level.INFO, PathLog.thisModule())
-#PathLog.trackModule()
-
-FreeCADGui = None
-if FreeCAD.GuiUp:
-    import FreeCADGui
+if True:
+    PathLog.setLevel(PathLog.Level.DEBUG, PathLog.thisModule())
+    PathLog.trackModule()
+else:
+    PathLog.setLevel(PathLog.Level.INFO, PathLog.thisModule())
 
 """Path Job object and FreeCAD command"""
 
@@ -65,15 +55,24 @@ class JobTemplate:
     Description = 'desc'
     ToolController = 'ToolController'
 
-class ObjectPathJob:
+class ObjectJob:
 
     def __init__(self, obj, base, template = None):
         self.obj = obj
         obj.addProperty("App::PropertyFile", "PostProcessorOutputFile", "Output", QtCore.QT_TRANSLATE_NOOP("App::Property","The NC output file for this project"))
-        obj.PostProcessorOutputFile = PathPreferences.defaultOutputFile()
-        obj.setEditorMode("PostProcessorOutputFile", 0)  # set to default mode
-
         obj.addProperty("App::PropertyEnumeration", "PostProcessor", "Output", QtCore.QT_TRANSLATE_NOOP("App::Property","Select the Post Processor"))
+        obj.addProperty("App::PropertyString", "PostProcessorArgs", "Output", QtCore.QT_TRANSLATE_NOOP("App::Property", "Arguments for the Post Processor (specific to the script)"))
+
+        obj.addProperty("App::PropertyString", "Description", "Path", QtCore.QT_TRANSLATE_NOOP("App::Property","An optional description for this job"))
+        obj.addProperty("App::PropertyDistance", "GeometryTolerance", "Geometry", QtCore.QT_TRANSLATE_NOOP("App::Property", "For computing Paths; smaller increases accuracy, but slows down computation"))
+
+        obj.addProperty("App::PropertyLink", "Base", "Base", QtCore.QT_TRANSLATE_NOOP("PathJob", "The base object for all operations"))
+        obj.addProperty("App::PropertyLink", "Stock", "Base", QtCore.QT_TRANSLATE_NOOP("PathJob", "Solid object to be used as stock."))
+        obj.addProperty("App::PropertyLink", "Operations", "Base", QtCore.QT_TRANSLATE_NOOP("PathJob", "Compound path of all operations in the order they are processed."))
+        obj.addProperty("App::PropertyLinkList", "ToolController", "Base", QtCore.QT_TRANSLATE_NOOP("PathJob", "Collection of tool controllers available for this job."))
+
+        obj.PostProcessorOutputFile = PathPreferences.defaultOutputFile()
+        #obj.setEditorMode("PostProcessorOutputFile", 0)  # set to default mode
         obj.PostProcessor = postProcessors = PathPreferences.allEnabledPostProcessors()
         defaultPostProcessor = PathPreferences.defaultPostProcessor()
         # Check to see if default post processor hasn't been 'lost' (This can happen when Macro dir has changed)
@@ -81,26 +80,34 @@ class ObjectPathJob:
             obj.PostProcessor = defaultPostProcessor
         else:
             obj.PostProcessor = postProcessors[0]
-        obj.addProperty("App::PropertyString", "PostProcessorArgs", "Output", QtCore.QT_TRANSLATE_NOOP("App::Property", "Arguments for the Post Processor (specific to the script)"))
         obj.PostProcessorArgs = PathPreferences.defaultPostProcessorArgs()
-
-        obj.addProperty("App::PropertyString", "Description", "Path", QtCore.QT_TRANSLATE_NOOP("App::Property","An optional description for this job"))
-        obj.addProperty("App::PropertyDistance", "GeometryTolerance", "Geometry",
-                QtCore.QT_TRANSLATE_NOOP("App::Property", "For computing Paths; smaller increases accuracy, but slows down computation"))
         obj.GeometryTolerance = PathPreferences.defaultGeometryTolerance()
 
-        obj.addProperty("App::PropertyLink", "Base", "Base", "The base object for all operations")
-        obj.Base = base
+        ops = FreeCAD.ActiveDocument.addObject("Path::FeatureCompoundPython", "Operations")
+        obj.Operations = ops
+        obj.setEditorMode('Operations', 2) # hide
+        obj.setEditorMode('Placement', 2)
 
+        obj.Base = base
         obj.Proxy = self
 
-        if FreeCAD.GuiUp:
-            ViewProviderJob(obj.ViewObject)
         self.assignTemplate(obj, template)
+
+    def onDelete(self, obj, arg2=None):
+        for tc in obj.ToolController:
+            FreeCAD.ActiveDocument.removeObject(tc.Name)
+        obj.ToolController = []
+        for op in obj.Operations.Group:
+            FreeCAD.ActiveDocument.removeObject(op.Name)
+        obj.Operations.Group = []
+        FreeCAD.ActiveDocument.removeObject(obj.Operations.Name)
+        obj.Operations = None
+
 
     def assignTemplate(self, obj, template):
         '''assignTemplate(obj, template) ... extract the properties from the given template file and assign to receiver.
         This will also create any TCs stored in the template.'''
+        tcs = []
         if template:
             tree = xml.parse(template)
             for job in tree.getroot().iter(JobTemplate.Job):
@@ -117,9 +124,11 @@ class ObjectPathJob:
                 if job.get(JobTemplate.Description):
                     obj.Description = job.get(JobTemplate.Description)
             for tc in tree.getroot().iter(JobTemplate.ToolController):
-                PathToolController.CommandPathToolController.FromTemplate(obj, tc)
+                tcs.append(PathToolController.CommandPathToolController.FromTemplate(tc))
         else:
-            PathToolController.CommandPathToolController.Create(obj.Name)
+            tcs.append(PathToolController.CommandPathToolController.Create(obj.Name))
+        PathLog.debug("setting tool controllers (%d)" % len(tcs))
+        obj.ToolController = tcs
 
     def templateAttrs(self, obj):
         '''templateAttrs(obj) ... answer a dictionary with all properties of the receiver that should be stored in a template file.'''
@@ -140,27 +149,14 @@ class ObjectPathJob:
     def __setstate__(self, state):
         return None
 
-    def onChanged(self, obj, prop):
-        mode = 2
-        obj.setEditorMode('Placement', mode)
-
-        if prop == "PostProcessor" and obj.PostProcessor:
-            processor = PostProcessor.load(obj.PostProcessor)
-            self.tooltip = processor.tooltip
-            self.tooltipArgs = processor.tooltipArgs
-
     def execute(self, obj):
-        cmds = []
-        for child in obj.Group:
-            if child.isDerivedFrom("Path::Feature"):
-                if obj.UsePlacements:
-                    for c in child.Path.Commands:
-                        cmds.append(c.transform(child.Placement))
-                else:
-                    cmds.extend(child.Path.Commands)
-        if cmds:
-            path = Path.Path(cmds)
-            obj.Path = path
+        obj.Path = obj.Operations.Path
+
+    def addOperation(self, op):
+        group = self.obj.Operations.Group
+        if op not in group:
+            group.append(op)
+            self.obj.Operations.Group = group
 
     @classmethod
     def baseCandidates(cls):
@@ -172,328 +168,8 @@ class ObjectPathJob:
         '''Answer true if the given object can be used as a Base for a job.'''
         return PathUtil.isValidBaseObject(obj) or (hasattr(obj, 'Proxy') and isinstance(obj.Proxy, ArchPanel.PanelSheet))
 
+def Create(name, base, template = None):
+    obj = FreeCAD.ActiveDocument.addObject("Path::FeaturePython", name)
+    proxy = ObjectJob(obj, base, template)
+    return obj
 
-class ViewProviderJob:
-
-    def __init__(self, vobj):
-        vobj.Proxy = self
-        mode = 2
-        vobj.setEditorMode('BoundingBox', mode)
-        vobj.setEditorMode('DisplayMode', mode)
-        vobj.setEditorMode('Selectable', mode)
-        vobj.setEditorMode('ShapeColor', mode)
-        vobj.setEditorMode('Transparency', mode)
-        self.taskPanel = None
-
-    def __getstate__(self):  # mandatory
-        return None
-
-    def __setstate__(self, state):  # mandatory
-        return None
-
-    def deleteObjectsOnReject(self):
-        return hasattr(self, 'deleteOnReject') and self.deleteOnReject
-
-    def setEdit(self, vobj, mode=0):
-        FreeCADGui.Control.closeDialog()
-        self.taskPanel = TaskPanel(vobj, self.deleteObjectsOnReject())
-        FreeCADGui.Control.showDialog(self.taskPanel)
-        self.taskPanel.setupUi()
-        self.deleteOnReject = False
-        return True
-
-    def unsetEdit(self, vobj, mode):
-        if self.taskPanel:
-            self.taskPanel.reject()
-
-    def resetTaskPanel(self):
-        self.taskPanel = None
-
-    def getIcon(self):
-        return ":/icons/Path-Job.svg"
-
-    def onChanged(self, vobj, prop):
-        mode = 2
-        vobj.setEditorMode('BoundingBox', mode)
-        vobj.setEditorMode('DisplayMode', mode)
-        vobj.setEditorMode('Selectable', mode)
-        vobj.setEditorMode('ShapeColor', mode)
-        vobj.setEditorMode('Transparency', mode)
-
-
-class TaskPanel:
-    def __init__(self, vobj, deleteOnReject):
-        FreeCAD.ActiveDocument.openTransaction(translate("Path_Job", "Edit Job"))
-        self.vobj = vobj
-        self.obj = vobj.Object
-        self.deleteOnReject = deleteOnReject
-        self.form = FreeCADGui.PySideUic.loadUi(":/panels/JobEdit.ui")
-        #self.form = FreeCADGui.PySideUic.loadUi(FreeCAD.getHomePath() + "Mod/Path/JobEdit.ui")
-
-        currentPostProcessor = self.obj.PostProcessor
-        postProcessors = PathPreferences.allEnabledPostProcessors(['', currentPostProcessor])
-        for post in postProcessors:
-            self.form.cboPostProcessor.addItem(post)
-        # update the enumeration values, just to make sure all selections are valid
-        self.obj.PostProcessor = postProcessors
-        self.obj.PostProcessor = currentPostProcessor
-
-        for o in ObjectPathJob.baseCandidates():
-            self.form.cboBaseObject.addItem(o.Label, o)
-
-
-        self.postProcessorDefaultTooltip = self.form.cboPostProcessor.toolTip()
-        self.postProcessorArgsDefaultTooltip = self.form.cboPostProcessorArgs.toolTip()
-
-    def accept(self):
-        PathLog.debug('accept')
-        self.getFields()
-        FreeCAD.ActiveDocument.commitTransaction()
-        self.vobj.Proxy.resetTaskPanel()
-        FreeCADGui.ActiveDocument.resetEdit()
-        FreeCADGui.Control.closeDialog()
-        FreeCAD.ActiveDocument.recompute()
-
-    def reject(self):
-        PathLog.debug('reject')
-        FreeCADGui.Control.closeDialog()
-        FreeCAD.ActiveDocument.abortTransaction()
-        if self.deleteOnReject:
-            PathLog.info("Uncreate Job")
-            FreeCAD.ActiveDocument.openTransaction(translate("Path_Job", "Uncreate Job"))
-            for child in self.obj.Group:
-                FreeCAD.ActiveDocument.removeObject(child.Name)
-            FreeCAD.ActiveDocument.removeObject(self.obj.Name)
-            FreeCAD.ActiveDocument.commitTransaction()
-        FreeCAD.ActiveDocument.recompute()
-        self.vobj.Proxy.resetTaskPanel()
-        return True
-
-    def updateTooltips(self):
-        if hasattr(self.obj, "Proxy") and hasattr(self.obj.Proxy, "tooltip") and self.obj.Proxy.tooltip:
-            self.form.cboPostProcessor.setToolTip(self.obj.Proxy.tooltip)
-            if hasattr(self.obj.Proxy, "tooltipArgs") and self.obj.Proxy.tooltipArgs:
-                self.form.cboPostProcessorArgs.setToolTip(self.obj.Proxy.tooltipArgs)
-            else:
-                self.form.cboPostProcessorArgs.setToolTip(self.postProcessorArgsDefaultTooltip)
-        else:
-            self.form.cboPostProcessor.setToolTip(self.postProcessorDefaultTooltip)
-            self.form.cboPostProcessorArgs.setToolTip(self.postProcessorArgsDefaultTooltip)
-
-    def getFields(self):
-        '''sets properties in the object to match the form'''
-        if self.obj:
-            self.obj.PostProcessor = str(self.form.cboPostProcessor.currentText())
-            self.obj.PostProcessorArgs = str(self.form.cboPostProcessorArgs.displayText())
-            self.obj.Label = str(self.form.leLabel.text())
-            self.obj.PostProcessorOutputFile = str(self.form.leOutputFile.text())
-
-            oldlist = self.obj.Group
-            newlist = []
-
-            for index in xrange(self.form.PathsList.count()):
-                item = self.form.PathsList.item(index)
-                for olditem in oldlist:
-                    if olditem.Label == item.text():
-                        newlist.append(olditem)
-            self.obj.Group = newlist
-
-            selObj = self.form.cboBaseObject.itemData(self.form.cboBaseObject.currentIndex())
-            if self.form.chkCreateClone.isChecked():
-                selObj = Draft.clone(selObj)
-            self.obj.Base = selObj
-
-            self.updateTooltips()
-
-        self.obj.Proxy.execute(self.obj)
-
-    def selectComboBoxText(self, widget, text):
-        index = widget.findText(text, QtCore.Qt.MatchFixedString)
-        if index >= 0:
-            widget.blockSignals(True)
-            widget.setCurrentIndex(index)
-            widget.blockSignals(False)
-
-    def setFields(self):
-        '''sets fields in the form to match the object'''
-
-        self.form.leLabel.setText(self.obj.Label)
-        self.form.leOutputFile.setText(self.obj.PostProcessorOutputFile)
-
-        self.selectComboBoxText(self.form.cboPostProcessor, self.obj.PostProcessor)
-        self.form.cboPostProcessorArgs.setText(self.obj.PostProcessorArgs)
-        self.obj.Proxy.onChanged(self.obj, "PostProcessor")
-        self.updateTooltips()
-
-        self.form.PathsList.clear()
-        for child in self.obj.Group:
-            self.form.PathsList.addItem(child.Label)
-
-        baseindex = -1
-        if self.obj.Base:
-            baseindex = self.form.cboBaseObject.findText(self.obj.Base.Label, QtCore.Qt.MatchFixedString)
-        else:
-            for o in FreeCADGui.Selection.getCompleteSelection():
-                baseindex = self.form.cboBaseObject.findText(o.Label, QtCore.Qt.MatchFixedString)
-        if baseindex >= 0:
-            self.form.cboBaseObject.setCurrentIndex(baseindex)
-
-
-    def open(self):
-        pass
-
-    def setFile(self):
-        filename = QtGui.QFileDialog.getSaveFileName(self.form, translate("Path_Job", "Select Output File"), None, translate("Path_Job", "All Files (*.*)"))
-        if filename and filename[0]:
-            self.obj.PostProcessorOutputFile = str(filename[0])
-            self.setFields()
-
-    def setupUi(self):
-        # Connect Signals and Slots
-        self.form.cboPostProcessor.currentIndexChanged.connect(self.getFields)
-        self.form.cboPostProcessorArgs.editingFinished.connect(self.getFields)
-        self.form.leOutputFile.editingFinished.connect(self.getFields)
-        self.form.leLabel.editingFinished.connect(self.getFields)
-        self.form.btnSelectFile.clicked.connect(self.setFile)
-        self.form.PathsList.indexesMoved.connect(self.getFields)
-        self.form.cboBaseObject.currentIndexChanged.connect(self.getFields)
-
-        self.setFields()
-
-class DlgJobCreate:
-
-    def __init__(self, parent=None):
-        self.dialog = FreeCADGui.PySideUic.loadUi(":/panels/DlgJobCreate.ui")
-        sel = FreeCADGui.Selection.getSelection()
-        if sel:
-            selected = sel[0].Label
-        else:
-            selected = None
-        index = 0
-        for base in ObjectPathJob.baseCandidates():
-            if base.Label == selected:
-                index = self.dialog.cbModel.count()
-            self.dialog.cbModel.addItem(base.Label)
-        self.dialog.cbModel.setCurrentIndex(index)
-
-        templateFiles = []
-        for path in PathPreferences.searchPaths():
-            templateFiles.extend(self.templateFilesIn(path))
-
-        template = {}
-        for tFile in templateFiles:
-            name = os.path.split(os.path.splitext(tFile)[0])[1][4:]
-            if name in template:
-                basename = name
-                i = 0
-                while name in template:
-                    i = i + 1
-                    name = basename + " (%s)" % i
-            PathLog.track(name, tFile)
-            template[name] = tFile
-        selectTemplate = PathPreferences.defaultJobTemplate()
-        index = 0
-        self.dialog.cbTemplate.addItem('<none>', '')
-        for name in sorted(template.keys()):
-            if template[name] == selectTemplate:
-                index = self.dialog.cbTemplate.count()
-            self.dialog.cbTemplate.addItem(name, template[name])
-        self.dialog.cbTemplate.setCurrentIndex(index)
-
-    def templateFilesIn(self, path):
-        '''templateFilesIn(path) ... answer all file in the given directory which fit the job template naming convention.
-        PathJob template files are name job_*.xml'''
-        PathLog.track(path)
-        return glob.glob(path + '/job_*.xml')
-
-    def getModel(self):
-        '''answer the base model selected for the job'''
-        label = self.dialog.cbModel.currentText()
-        return filter(lambda obj: obj.Label == label, FreeCAD.ActiveDocument.Objects)[0]
-
-    def getTemplate(self):
-        '''answer the file name of the template to be assigned'''
-        return self.dialog.cbTemplate.itemData(self.dialog.cbTemplate.currentIndex())
-
-    def exec_(self):
-        return self.dialog.exec_()
-
-class CommandJobCreate:
-    '''
-    Command used to creat a command.
-    When activated the command opens a dialog allowing the user to select a base object (has to be a solid)
-    and a template to be used for the initial creation.
-    '''
-
-    def GetResources(self):
-        return {'Pixmap': 'Path-Job',
-                'MenuText': QtCore.QT_TRANSLATE_NOOP("Path_Job", "Job"),
-                'Accel': "P, J",
-                'ToolTip': QtCore.QT_TRANSLATE_NOOP("Path_Job", "Creates a Path Job object")}
-
-    def IsActive(self):
-        return FreeCAD.ActiveDocument is not None
-
-    def Activated(self):
-        dialog = DlgJobCreate()
-        if dialog.exec_() == 1:
-            self.Execute(dialog.getModel(), dialog.getTemplate())
-            FreeCAD.ActiveDocument.recompute()
-
-    @classmethod
-    def Execute(cls, base, template):
-        FreeCADGui.addModule('PathScripts.PathJob')
-        FreeCAD.ActiveDocument.openTransaction(translate("Path_Job", "Create Job"))
-        try:
-            FreeCADGui.doCommand('App.ActiveDocument.addObject("Path::FeatureCompoundPython", "Job")')
-            if template:
-                template = "'%s'" % template
-            else:
-                template = 'None'
-            FreeCADGui.doCommand('PathScripts.PathJob.ObjectPathJob(App.ActiveDocument.ActiveObject, App.ActiveDocument.%s, %s)' % (base.Name, template))
-            FreeCAD.ActiveDocument.commitTransaction()
-        except:
-            PathLog.error(sys.exc_info())
-            FreeCAD.ActiveDocument.abortTransaction()
-
-class CommandJobExportTemplate:
-    '''
-    Command to export a template of a given job.
-    Opens a dialog to select the file to store the template in. If the template is stored in Path's
-    file path (see preferences) and named in accordance with job_*.xml it will automatically be found
-    on Job creation and be available for selection.
-    '''
-
-    def GetResources(self):
-        return {'Pixmap': 'Path-Job',
-                'MenuText': QtCore.QT_TRANSLATE_NOOP("Path_Job", "Export Template"),
-                'ToolTip': QtCore.QT_TRANSLATE_NOOP("Path_Job", "Exports Path Job as a template to be used for other jobs")}
-
-    def IsActive(self):
-        return FreeCAD.ActiveDocument is not None
-
-    def Activated(self):
-        job = FreeCADGui.Selection.getSelection()[0]
-        foo = QtGui.QFileDialog.getSaveFileName(QtGui.qApp.activeWindow(),
-                "Path - Job Template",
-                PathPreferences.filePath(),
-                "job_*.xml")[0]
-        if foo: 
-            self.Execute(job, foo)
-
-    @classmethod
-    def Execute(cls, job, path):
-        root = xml.Element('PathJobTemplate')
-        xml.SubElement(root, JobTemplate.Job, job.Proxy.templateAttrs(job))
-        for obj in job.Group:
-            if hasattr(obj, 'Tool') and hasattr(obj, 'SpindleDir'):
-                tc = xml.SubElement(root, JobTemplate.ToolController, obj.Proxy.templateAttrs(obj))
-                tc.append(xml.fromstring(obj.Tool.Content))
-        xml.ElementTree(root).write(path)
-
-if FreeCAD.GuiUp:
-    # register the FreeCAD command
-    FreeCADGui.addCommand('Path_Job', CommandJobCreate())
-    FreeCADGui.addCommand('Path_ExportTemplate', CommandJobExportTemplate())
-
-FreeCAD.Console.PrintLog("Loading PathJob... done\n")

--- a/src/Mod/Path/PathScripts/PathJob.py
+++ b/src/Mod/Path/PathScripts/PathJob.py
@@ -152,6 +152,10 @@ class ObjectJob:
         return None
 
     def __setstate__(self, state):
+        for obj in FreeCAD.ActiveDocument.Objects:
+            if hasattr(obj, 'Proxy') and obj.Proxy == self:
+                self.obj = obj
+                break
         return None
 
     def execute(self, obj):

--- a/src/Mod/Path/PathScripts/PathJob.py
+++ b/src/Mod/Path/PathScripts/PathJob.py
@@ -178,7 +178,7 @@ class ObjectJob:
             for stock in tree.getroot().iter(JobTemplate.Stock):
                 obj.Stock = PathStock.CreateFromTemplate(self, stock)
         else:
-            tcs.append(PathToolController.Create(obj.Name))
+            tcs.append(PathToolController.Create())
         PathLog.debug("setting tool controllers (%d)" % len(tcs))
         obj.ToolController = tcs
 

--- a/src/Mod/Path/PathScripts/PathJob.py
+++ b/src/Mod/Path/PathScripts/PathJob.py
@@ -221,6 +221,20 @@ class ObjectJob:
             group.append(tc)
             self.obj.ToolController = group
 
+    def allOperations(self):
+        ops = []
+        def collectBaseOps(op):
+            if op.TypeId == 'Path::FeaturePython':
+                ops.append(op)
+                if hasattr(op, 'Base'):
+                    collectBaseOps(op.Base)
+            if op.TypeId == 'Path::FeatureCompoundPython':
+                ops.append(op)
+                for sub in op.Group:
+                    collectBaseOps(sub)
+        for op in self.obj.Operations.Group:
+            collectBaseOps(op)
+        return ops
 
     @classmethod
     def baseCandidates(cls):

--- a/src/Mod/Path/PathScripts/PathJob.py
+++ b/src/Mod/Path/PathScripts/PathJob.py
@@ -35,7 +35,7 @@ from PySide import QtCore
 
 if True:
     PathLog.setLevel(PathLog.Level.DEBUG, PathLog.thisModule())
-    PathLog.trackModule()
+    PathLog.trackModule(PathLog.thisModule())
 else:
     PathLog.setLevel(PathLog.Level.INFO, PathLog.thisModule())
 
@@ -94,6 +94,7 @@ class ObjectJob:
         self.assignTemplate(obj, template)
 
     def onDelete(self, obj, arg2=None):
+        PathLog.track(obj, arg2)
         for tc in obj.ToolController:
             FreeCAD.ActiveDocument.removeObject(tc.Name)
         obj.ToolController = []
@@ -129,9 +130,9 @@ class ObjectJob:
                 if job.get(JobTemplate.Description):
                     obj.Description = job.get(JobTemplate.Description)
             for tc in tree.getroot().iter(JobTemplate.ToolController):
-                tcs.append(PathToolController.CommandPathToolController.FromTemplate(tc))
+                tcs.append(PathToolController.FromTemplate(tc))
         else:
-            tcs.append(PathToolController.CommandPathToolController.Create(obj.Name))
+            tcs.append(PathToolController.Create(obj.Name))
         PathLog.debug("setting tool controllers (%d)" % len(tcs))
         obj.ToolController = tcs
 
@@ -166,6 +167,14 @@ class ObjectJob:
         if op not in group:
             group.append(op)
             self.obj.Operations.Group = group
+
+    def addToolController(self, tc):
+        group = self.obj.ToolController
+        PathLog.info("addToolController(%s): %s" % (tc.Label, [t.Label for t in group]))
+        if tc.Name not in [str(t.Name) for t in group]:
+            group.append(tc)
+            self.obj.ToolController = group
+
 
     @classmethod
     def baseCandidates(cls):

--- a/src/Mod/Path/PathScripts/PathJob.py
+++ b/src/Mod/Path/PathScripts/PathJob.py
@@ -58,6 +58,7 @@ class JobTemplate:
     GeometryTolerance = 'tol'
     Description = 'desc'
     ToolController = 'ToolController'
+    Stock = 'Stock'
 
 def isResourceClone(obj, propName, resourceName):
     '''isResourceClone(obj, propName, resourceName) ... Return True if the given property of obj is a clone of type resourceName.'''
@@ -174,6 +175,8 @@ class ObjectJob:
                     obj.Description = job.get(JobTemplate.Description)
             for tc in tree.getroot().iter(JobTemplate.ToolController):
                 tcs.append(PathToolController.FromTemplate(tc))
+            for stock in tree.getroot().iter(JobTemplate.Stock):
+                obj.Stock = PathStock.CreateFromTemplate(self, stock)
         else:
             tcs.append(PathToolController.Create(obj.Name))
         PathLog.debug("setting tool controllers (%d)" % len(tcs))

--- a/src/Mod/Path/PathScripts/PathJobCmd.py
+++ b/src/Mod/Path/PathScripts/PathJobCmd.py
@@ -1,0 +1,170 @@
+# -*- coding: utf-8 -*-
+
+# ***************************************************************************
+# *                                                                         *
+# *   Copyright (c) 2017 sliptonic <shopinthewoods@gmail.com>               *
+# *                                                                         *
+# *   This program is free software; you can redistribute it and/or modify  *
+# *   it under the terms of the GNU Lesser General Public License (LGPL)    *
+# *   as published by the Free Software Foundation; either version 2 of     *
+# *   the License, or (at your option) any later version.                   *
+# *   for detail see the LICENCE text file.                                 *
+# *                                                                         *
+# *   This program is distributed in the hope that it will be useful,       *
+# *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+# *   GNU Library General Public License for more details.                  *
+# *                                                                         *
+# *   You should have received a copy of the GNU Library General Public     *
+# *   License along with this program; if not, write to the Free Software   *
+# *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
+# *   USA                                                                   *
+# *                                                                         *
+# ***************************************************************************
+
+import FreeCAD
+import FreeCADGui
+import PathScripts.PathJob as PathJob
+import PathScripts.PathLog as PathLog
+import glob
+import os
+import xml.etree.ElementTree as xml
+
+from PathScripts.PathPreferences import PathPreferences
+from PySide import QtCore, QtGui
+
+# Qt tanslation handling
+def translate(context, text, disambig=None):
+    return QtCore.QCoreApplication.translate(context, text, disambig)
+
+class DlgJobCreate:
+
+    def __init__(self, parent=None):
+        self.dialog = FreeCADGui.PySideUic.loadUi(":/panels/DlgJobCreate.ui")
+        sel = FreeCADGui.Selection.getSelection()
+        if sel:
+            selected = sel[0].Label
+        else:
+            selected = None
+        index = 0
+        for base in PathJob.ObjectJob.baseCandidates():
+            if base.Label == selected:
+                index = self.dialog.cbModel.count()
+            self.dialog.cbModel.addItem(base.Label)
+        self.dialog.cbModel.setCurrentIndex(index)
+
+        templateFiles = []
+        for path in PathPreferences.searchPaths():
+            templateFiles.extend(self.templateFilesIn(path))
+
+        template = {}
+        for tFile in templateFiles:
+            name = os.path.split(os.path.splitext(tFile)[0])[1][4:]
+            if name in template:
+                basename = name
+                i = 0
+                while name in template:
+                    i = i + 1
+                    name = basename + " (%s)" % i
+            PathLog.track(name, tFile)
+            template[name] = tFile
+        selectTemplate = PathPreferences.defaultJobTemplate()
+        index = 0
+        self.dialog.cbTemplate.addItem('<none>', '')
+        for name in sorted(template.keys()):
+            if template[name] == selectTemplate:
+                index = self.dialog.cbTemplate.count()
+            self.dialog.cbTemplate.addItem(name, template[name])
+        self.dialog.cbTemplate.setCurrentIndex(index)
+
+    def templateFilesIn(self, path):
+        '''templateFilesIn(path) ... answer all file in the given directory which fit the job template naming convention.
+        PathJob template files are name job_*.xml'''
+        PathLog.track(path)
+        return glob.glob(path + '/job_*.xml')
+
+    def getModel(self):
+        '''answer the base model selected for the job'''
+        label = self.dialog.cbModel.currentText()
+        return filter(lambda obj: obj.Label == label, FreeCAD.ActiveDocument.Objects)[0]
+
+    def getTemplate(self):
+        '''answer the file name of the template to be assigned'''
+        return self.dialog.cbTemplate.itemData(self.dialog.cbTemplate.currentIndex())
+
+    def exec_(self):
+        return self.dialog.exec_()
+
+class CommandJobCreate:
+    '''
+    Command used to creat a command.
+    When activated the command opens a dialog allowing the user to select a base object (has to be a solid)
+    and a template to be used for the initial creation.
+    '''
+
+    def GetResources(self):
+        return {'Pixmap': 'Path-Job',
+                'MenuText': QtCore.QT_TRANSLATE_NOOP("Path_Job", "Job"),
+                'Accel': "P, J",
+                'ToolTip': QtCore.QT_TRANSLATE_NOOP("Path_Job", "Creates a Path Job object")}
+
+    def IsActive(self):
+        return FreeCAD.ActiveDocument is not None
+
+    def Activated(self):
+        dialog = DlgJobCreate()
+        if dialog.exec_() == 1:
+            self.Execute(dialog.getModel(), dialog.getTemplate())
+            FreeCAD.ActiveDocument.recompute()
+
+    @classmethod
+    def Execute(cls, base, template):
+        FreeCADGui.addModule('PathScripts.PathJobGui')
+        if template:
+            template = "'%s'" % template
+        else:
+            template = 'None'
+        FreeCADGui.doCommand('PathScripts.PathJobGui.Create(App.ActiveDocument.%s, %s)' % (base.Name, template))
+
+class CommandJobExportTemplate:
+    '''
+    Command to export a template of a given job.
+    Opens a dialog to select the file to store the template in. If the template is stored in Path's
+    file path (see preferences) and named in accordance with job_*.xml it will automatically be found
+    on Job creation and be available for selection.
+    '''
+
+    def GetResources(self):
+        return {'Pixmap': 'Path-Job',
+                'MenuText': QtCore.QT_TRANSLATE_NOOP("Path_Job", "Export Template"),
+                'ToolTip': QtCore.QT_TRANSLATE_NOOP("Path_Job", "Exports Path Job as a template to be used for other jobs")}
+
+    def IsActive(self):
+        return FreeCAD.ActiveDocument is not None
+
+    def Activated(self):
+        job = FreeCADGui.Selection.getSelection()[0]
+        foo = QtGui.QFileDialog.getSaveFileName(QtGui.qApp.activeWindow(),
+                "Path - Job Template",
+                PathPreferences.filePath(),
+                "job_*.xml")[0]
+        if foo: 
+            self.Execute(job, foo)
+
+    @classmethod
+    def Execute(cls, job, path):
+        root = xml.Element('PathJobTemplate')
+        xml.SubElement(root, JobTemplate.Job, job.Proxy.templateAttrs(job))
+        for obj in job.Group:
+            if hasattr(obj, 'Tool') and hasattr(obj, 'SpindleDir'):
+                tc = xml.SubElement(root, JobTemplate.ToolController, obj.Proxy.templateAttrs(obj))
+                tc.append(xml.fromstring(obj.Tool.Content))
+        xml.ElementTree(root).write(path)
+
+if FreeCAD.GuiUp:
+    # register the FreeCAD command
+    FreeCADGui.addCommand('Path_Job', CommandJobCreate())
+    FreeCADGui.addCommand('Path_ExportTemplate', CommandJobExportTemplate())
+
+FreeCAD.Console.PrintLog("Loading PathJobGui... done\n")
+

--- a/src/Mod/Path/PathScripts/PathJobGui.py
+++ b/src/Mod/Path/PathScripts/PathJobGui.py
@@ -512,7 +512,7 @@ class TaskPanel:
             if self.obj.Proxy.baseObject(self.obj) != selObj:
                 self.baseObjectRestoreVisibility(self.obj)
                 self.obj.Document.removeObject(self.obj.Base.Name)
-                self.obj.Proxy.createResourceClone(self.obj, selObj, 'Base')
+                self.obj.Base = PathJob.createResourceClone(self.obj, selObj, 'Base', 'Base')
                 self.baseObjectSaveVisibility(self.obj)
 
             self.updateTooltips()
@@ -885,10 +885,10 @@ class TaskPanel:
             self.form.centerInStock.setEnabled(True)
             self.form.centerInStockXY.setEnabled(True)
         else:
-            if len(sel) == 1:
-                PathLog.info("sel = %s / %s" % (sel[0].Object.Label, self.obj.Base.Label))
+            if len(sel) == 1 and self.obj.Base:
+                PathLog.debug("sel = %s / %s" % (sel[0].Object.Label, self.obj.Base.Label))
             else:
-                PathLog.info("sel len = %d" % len(sel))
+                PathLog.debug("sel len = %d" % len(sel))
             self.form.centerInStock.setEnabled(False)
             self.form.centerInStockXY.setEnabled(False)
 

--- a/src/Mod/Path/PathScripts/PathJobGui.py
+++ b/src/Mod/Path/PathScripts/PathJobGui.py
@@ -96,6 +96,10 @@ class TaskPanel:
         self.deleteOnReject = deleteOnReject
         self.form = FreeCADGui.PySideUic.loadUi(":/panels/PathEdit.ui")
 
+        vUnit = FreeCAD.Units.Quantity(1, FreeCAD.Units.Velocity).getUserPreferred()[2]
+        self.form.toolControllerList.horizontalHeaderItem(1).setText('#')
+        self.form.toolControllerList.horizontalHeaderItem(2).setText(vUnit)
+        self.form.toolControllerList.horizontalHeaderItem(3).setText(vUnit)
         self.form.toolControllerList.horizontalHeader().setResizeMode(0, QtGui.QHeaderView.Stretch)
         self.form.toolControllerList.resizeColumnsToContents()
 
@@ -109,7 +113,6 @@ class TaskPanel:
 
         for o in PathJob.ObjectJob.baseCandidates():
             self.form.infoModel.addItem(o.Label, o)
-
 
         self.postProcessorDefaultTooltip = self.form.postProcessor.toolTip()
         self.postProcessorArgsDefaultTooltip = self.form.postProcessorArguments.toolTip()

--- a/src/Mod/Path/PathScripts/PathJobGui.py
+++ b/src/Mod/Path/PathScripts/PathJobGui.py
@@ -435,22 +435,31 @@ class TaskPanel:
             FreeCADGui.Selection.addSelection(selObject, selFeature)
 
     def alignSetOrigin(self):
-        pass
+        (obj, by) = self.alignMoveToOrigin()
+        if obj == self.obj.Base and self.obj.Stock:
+            Draft.move(self.obj.Stock, by)
+        if obj == self.obj.Stock and self.obj.Base:
+            Draft.move(self.obj.Base, by)
+        placement = FreeCADGui.ActiveDocument.ActiveView.viewPosition()
+        placement.Base = placement.Base + by
+        FreeCADGui.ActiveDocument.ActiveView.viewPosition(placement, 0)
 
     def alignMoveToOrigin(self):
         selObject = None
         selFeature = None
+        p = None
         for sel in FreeCADGui.Selection.getSelectionEx():
             selObject = sel.Object
             for feature in sel.SubElementNames:
                 selFeature = feature
                 sub = sel.Object.Shape.getElement(feature)
                 if 'Vertex' == sub.ShapeType:
-                    p = sub.Point
-                    Draft.move(sel.Object, FreeCAD.Vector() - p)
+                    p = FreeCAD.Vector() - sub.Point
+                    Draft.move(sel.Object, p)
         if selObject and selFeature:
             FreeCADGui.Selection.clearSelection()
             FreeCADGui.Selection.addSelection(selObject, selFeature)
+        return (selObject, p)
 
     def updateSelection(self):
         sel = FreeCADGui.Selection.getSelectionEx()

--- a/src/Mod/Path/PathScripts/PathJobGui.py
+++ b/src/Mod/Path/PathScripts/PathJobGui.py
@@ -195,16 +195,29 @@ class TaskPanel:
             self.form.infoModel.setCurrentIndex(baseindex)
 
 
-    def open(self):
-        pass
-
     def setPostProcessorOutputFile(self):
         filename = QtGui.QFileDialog.getSaveFileName(self.form, translate("Path_Job", "Select Output File"), None, translate("Path_Job", "All Files (*.*)"))
         if filename and filename[0]:
             self.obj.PostProcessorOutputFile = str(filename[0])
             self.setFields()
 
+    def operationSelect(self):
+        if self.form.operationsList.selectedItems():
+            self.form.operationModify.setEnabled(True)
+        else:
+            self.form.operationModify.setEnabled(False)
+
+    def operationDelete(self):
+        for item in self.form.operationsList.selectedItems():
+            obj = item.data(self.DataObject)
+            if obj.ViewObject and hasattr(obj.ViewObject, 'Proxy') and hasattr(obj.ViewObject.Proxy, 'onDelete'):
+                obj.ViewObject.Proxy.onDelete(obj.ViewObject, None)
+            FreeCAD.ActiveDocument.removeObject(obj.Name)
+        self.setFields()
+
     def setupUi(self):
+        self.setFields()
+
         # Info
         self.form.infoLabel.editingFinished.connect(self.getFields)
         self.form.infoModel.currentIndexChanged.connect(self.getFields)
@@ -215,9 +228,11 @@ class TaskPanel:
         self.form.postProcessorOutputFile.editingFinished.connect(self.getFields)
         self.form.postProcessorSetOutputFile.clicked.connect(self.setPostProcessorOutputFile)
 
+        self.form.operationsList.itemSelectionChanged.connect(self.operationSelect)
         self.form.operationsList.indexesMoved.connect(self.getFields)
+        self.form.operationDelete.clicked.connect(self.operationDelete)
 
-        self.setFields()
+        self.operationSelect()
 
 def Create(base, template=None):
     '''Create(base, template) ... creates a job instance for the given base object

--- a/src/Mod/Path/PathScripts/PathJobGui.py
+++ b/src/Mod/Path/PathScripts/PathJobGui.py
@@ -177,6 +177,9 @@ class TaskPanel:
             widget.blockSignals(False)
 
     def updateToolController(self):
+        tcRow = self.form.toolControllerList.currentRow()
+        tcCol = self.form.toolControllerList.currentColumn()
+
         self.form.toolControllerList.blockSignals(True)
         self.form.toolControllerList.clearContents()
         self.form.toolControllerList.setRowCount(0)
@@ -224,6 +227,8 @@ class TaskPanel:
 
         if index != -1:
             self.form.activeToolController.setCurrentIndex(index)
+        if tcRow != -1 and tcCol != -1:
+            self.form.toolControllerList.setCurrentCell(tcRow, tcCol)
 
         self.form.activeToolController.blockSignals(False)
         self.form.toolControllerList.blockSignals(False)
@@ -302,7 +307,12 @@ class TaskPanel:
         self.form.toolControllerDelete.setEnabled(delete)
 
     def toolControllerEdit(self):
-        pass
+        for item in self.form.toolControllerList.selectedItems():
+            tc = item.data(self.DataObject)
+            dlg = PathToolController.DlgToolControllerEdit(tc)
+            dlg.exec_()
+        self.setFields()
+        self.toolControllerSelect()
 
     def toolControllerAdd(self):
         PathToolLibraryManager.CommandToolLibraryEdit().edit(self.obj, self.updateToolController)

--- a/src/Mod/Path/PathScripts/PathJobGui.py
+++ b/src/Mod/Path/PathScripts/PathJobGui.py
@@ -83,6 +83,10 @@ class ViewProvider:
     def claimChildren(self):
         children = self.obj.ToolController
         children.append(self.obj.Operations)
+        if self.obj.Base:
+            children.append(self.obj.Base)
+        if self.obj.Stock:
+            children.append(self.obj.Stock)
         return children
 
 class TaskPanel:

--- a/src/Mod/Path/PathScripts/PathJobGui.py
+++ b/src/Mod/Path/PathScripts/PathJobGui.py
@@ -1,0 +1,373 @@
+# -*- coding: utf-8 -*-
+
+# ***************************************************************************
+# *                                                                         *
+# *   Copyright (c) 2017 sliptonic <shopinthewoods@gmail.com>               *
+# *                                                                         *
+# *   This program is free software; you can redistribute it and/or modify  *
+# *   it under the terms of the GNU Lesser General Public License (LGPL)    *
+# *   as published by the Free Software Foundation; either version 2 of     *
+# *   the License, or (at your option) any later version.                   *
+# *   for detail see the LICENCE text file.                                 *
+# *                                                                         *
+# *   This program is distributed in the hope that it will be useful,       *
+# *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+# *   GNU Library General Public License for more details.                  *
+# *                                                                         *
+# *   You should have received a copy of the GNU Library General Public     *
+# *   License along with this program; if not, write to the Free Software   *
+# *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
+# *   USA                                                                   *
+# *                                                                         *
+# ***************************************************************************
+
+import FreeCAD
+import FreeCADGui
+import PathScripts.PathJob as PathJob
+import PathScripts.PathLog as PathLog
+import PathScripts.PathToolController as PathToolController
+
+import glob
+import os
+import sys
+import xml.etree.ElementTree as xml
+
+from PathScripts.PathPreferences import PathPreferences
+from PySide import QtCore, QtGui
+
+# Qt tanslation handling
+def translate(context, text, disambig=None):
+    return QtCore.QCoreApplication.translate(context, text, disambig)
+
+class ViewProvider:
+
+    def __init__(self, vobj):
+        vobj.Proxy = self
+        mode = 2
+        vobj.setEditorMode('BoundingBox', mode)
+        vobj.setEditorMode('DisplayMode', mode)
+        vobj.setEditorMode('Selectable', mode)
+        vobj.setEditorMode('ShapeColor', mode)
+        vobj.setEditorMode('Transparency', mode)
+        self.taskPanel = None
+
+    def attach(self, vobj):
+        self.vobj = vobj
+        self.obj = vobj.Object
+
+    def __getstate__(self):  # mandatory
+        return None
+
+    def __setstate__(self, state):  # mandatory
+        return None
+
+    def deleteObjectsOnReject(self):
+        return hasattr(self, 'deleteOnReject') and self.deleteOnReject
+
+    def setEdit(self, vobj, mode=0):
+        FreeCADGui.Control.closeDialog()
+        self.taskPanel = TaskPanel(vobj, self.deleteObjectsOnReject())
+        FreeCADGui.Control.showDialog(self.taskPanel)
+        self.taskPanel.setupUi()
+        self.deleteOnReject = False
+        return True
+
+    def unsetEdit(self, vobj, mode):
+        if self.taskPanel:
+            self.taskPanel.reject()
+
+    def resetTaskPanel(self):
+        self.taskPanel = None
+
+    def getIcon(self):
+        return ":/icons/Path-Job.svg"
+
+    def onChanged(self, vobj, prop):
+        mode = 2
+        vobj.setEditorMode('BoundingBox', mode)
+        vobj.setEditorMode('DisplayMode', mode)
+        vobj.setEditorMode('Selectable', mode)
+        vobj.setEditorMode('ShapeColor', mode)
+        vobj.setEditorMode('Transparency', mode)
+
+    def claimChildren(self):
+        children = self.obj.ToolController
+        children.append(self.obj.Operations)
+        return children
+
+class TaskPanel:
+    def __init__(self, vobj, deleteOnReject):
+        FreeCAD.ActiveDocument.openTransaction(translate("Path_Job", "Edit Job"))
+        self.vobj = vobj
+        self.obj = vobj.Object
+        self.deleteOnReject = deleteOnReject
+        self.form = FreeCADGui.PySideUic.loadUi(":/panels/PathEdit.ui")
+
+        currentPostProcessor = self.obj.PostProcessor
+        postProcessors = PathPreferences.allEnabledPostProcessors(['', currentPostProcessor])
+        for post in postProcessors:
+            self.form.postProcessor.addItem(post)
+        # update the enumeration values, just to make sure all selections are valid
+        self.obj.PostProcessor = postProcessors
+        self.obj.PostProcessor = currentPostProcessor
+
+        for o in PathJob.ObjectJob.baseCandidates():
+            self.form.infoModel.addItem(o.Label, o)
+
+
+        self.postProcessorDefaultTooltip = self.form.postProcessor.toolTip()
+        self.postProcessorArgsDefaultTooltip = self.form.postProcessorArguments.toolTip()
+
+    def accept(self):
+        PathLog.debug('accept')
+        self.getFields()
+        FreeCAD.ActiveDocument.commitTransaction()
+        self.vobj.Proxy.resetTaskPanel()
+        FreeCADGui.ActiveDocument.resetEdit()
+        FreeCADGui.Control.closeDialog()
+        FreeCAD.ActiveDocument.recompute()
+
+    def reject(self):
+        PathLog.debug('reject')
+        FreeCADGui.Control.closeDialog()
+        FreeCAD.ActiveDocument.abortTransaction()
+        if self.deleteOnReject:
+            PathLog.info("Uncreate Job")
+            FreeCAD.ActiveDocument.openTransaction(translate("Path_Job", "Uncreate Job"))
+            FreeCAD.ActiveDocument.removeObject(self.obj.Name)
+            FreeCAD.ActiveDocument.commitTransaction()
+        FreeCAD.ActiveDocument.recompute()
+        self.vobj.Proxy.resetTaskPanel()
+        return True
+
+    def updateTooltips(self):
+        if hasattr(self.obj, "Proxy") and hasattr(self.obj.Proxy, "tooltip") and self.obj.Proxy.tooltip:
+            self.form.postProcessor.setToolTip(self.obj.Proxy.tooltip)
+            if hasattr(self.obj.Proxy, "tooltipArgs") and self.obj.Proxy.tooltipArgs:
+                self.form.postProcessorArguments.setToolTip(self.obj.Proxy.tooltipArgs)
+            else:
+                self.form.postProcessorArguments.setToolTip(self.postProcessorArgsDefaultTooltip)
+        else:
+            self.form.postProcessor.setToolTip(self.postProcessorDefaultTooltip)
+            self.form.postProcessorArguments.setToolTip(self.postProcessorArgsDefaultTooltip)
+
+    def getFields(self):
+        '''sets properties in the object to match the form'''
+        if self.obj:
+            self.obj.PostProcessor = str(self.form.postProcessor.currentText())
+            self.obj.PostProcessorArgs = str(self.form.postProcessorArguments.displayText())
+            self.obj.PostProcessorOutputFile = str(self.form.postProcessorOutputFile.text())
+
+            self.obj.Label = str(self.form.infoLabel.text())
+            self.obj.Group = [self.form.operationsList.item(i).data() for i in range(self.form.operationsList.count())]
+
+            selObj = self.form.infoModel.itemData(self.form.infoModel.currentIndex())
+            #if self.form.chkCreateClone.isChecked():
+            #    selObj = Draft.clone(selObj)
+            self.obj.Base = selObj
+
+            self.updateTooltips()
+
+        self.obj.Proxy.execute(self.obj)
+
+    def selectComboBoxText(self, widget, text):
+        index = widget.findText(text, QtCore.Qt.MatchFixedString)
+        if index >= 0:
+            widget.blockSignals(True)
+            widget.setCurrentIndex(index)
+            widget.blockSignals(False)
+
+    def setFields(self):
+        '''sets fields in the form to match the object'''
+
+        self.form.infoLabel.setText(self.obj.Label)
+        self.form.postProcessorOutputFile.setText(self.obj.PostProcessorOutputFile)
+
+        self.selectComboBoxText(self.form.postProcessor, self.obj.PostProcessor)
+        self.form.postProcessorArguments.setText(self.obj.PostProcessorArgs)
+        self.obj.Proxy.onChanged(self.obj, "PostProcessor")
+        self.updateTooltips()
+
+        self.form.operationsList.clear()
+        for child in self.obj.Group:
+            item = QtGui.QListWidgetItem(child.Label)
+            item.setData(self.DataObject, child)
+            self.form.operationsList.addItem(item)
+
+        baseindex = -1
+        if self.obj.Base:
+            baseindex = self.form.infoModel.findText(self.obj.Base.Label, QtCore.Qt.MatchFixedString)
+        else:
+            for o in FreeCADGui.Selection.getCompleteSelection():
+                baseindex = self.form.infoModel.findText(o.Label, QtCore.Qt.MatchFixedString)
+        if baseindex >= 0:
+            self.form.infoModel.setCurrentIndex(baseindex)
+
+
+    def open(self):
+        pass
+
+    def setPostProcessorOutputFile(self):
+        filename = QtGui.QFileDialog.getSaveFileName(self.form, translate("Path_Job", "Select Output File"), None, translate("Path_Job", "All Files (*.*)"))
+        if filename and filename[0]:
+            self.obj.PostProcessorOutputFile = str(filename[0])
+            self.setFields()
+
+    def setupUi(self):
+        # Info
+        self.form.infoLabel.editingFinished.connect(self.getFields)
+        self.form.infoModel.currentIndexChanged.connect(self.getFields)
+
+        # Post Processor
+        self.form.postProcessor.currentIndexChanged.connect(self.getFields)
+        self.form.postProcessorArguments.editingFinished.connect(self.getFields)
+        self.form.postProcessorOutputFile.editingFinished.connect(self.getFields)
+        self.form.postProcessorSetOutputFile.clicked.connect(self.setPostProcessorOutputFile)
+
+        self.form.operationsList.indexesMoved.connect(self.getFields)
+
+        self.setFields()
+
+class DlgJobCreate:
+
+    def __init__(self, parent=None):
+        self.dialog = FreeCADGui.PySideUic.loadUi(":/panels/DlgJobCreate.ui")
+        sel = FreeCADGui.Selection.getSelection()
+        if sel:
+            selected = sel[0].Label
+        else:
+            selected = None
+        index = 0
+        for base in PathJob.ObjectJob.baseCandidates():
+            if base.Label == selected:
+                index = self.dialog.cbModel.count()
+            self.dialog.cbModel.addItem(base.Label)
+        self.dialog.cbModel.setCurrentIndex(index)
+
+        templateFiles = []
+        for path in PathPreferences.searchPaths():
+            templateFiles.extend(self.templateFilesIn(path))
+
+        template = {}
+        for tFile in templateFiles:
+            name = os.path.split(os.path.splitext(tFile)[0])[1][4:]
+            if name in template:
+                basename = name
+                i = 0
+                while name in template:
+                    i = i + 1
+                    name = basename + " (%s)" % i
+            PathLog.track(name, tFile)
+            template[name] = tFile
+        selectTemplate = PathPreferences.defaultJobTemplate()
+        index = 0
+        self.dialog.cbTemplate.addItem('<none>', '')
+        for name in sorted(template.keys()):
+            if template[name] == selectTemplate:
+                index = self.dialog.cbTemplate.count()
+            self.dialog.cbTemplate.addItem(name, template[name])
+        self.dialog.cbTemplate.setCurrentIndex(index)
+
+    def templateFilesIn(self, path):
+        '''templateFilesIn(path) ... answer all file in the given directory which fit the job template naming convention.
+        PathJob template files are name job_*.xml'''
+        PathLog.track(path)
+        return glob.glob(path + '/job_*.xml')
+
+    def getModel(self):
+        '''answer the base model selected for the job'''
+        label = self.dialog.cbModel.currentText()
+        return filter(lambda obj: obj.Label == label, FreeCAD.ActiveDocument.Objects)[0]
+
+    def getTemplate(self):
+        '''answer the file name of the template to be assigned'''
+        return self.dialog.cbTemplate.itemData(self.dialog.cbTemplate.currentIndex())
+
+    def exec_(self):
+        return self.dialog.exec_()
+
+def Create(base, template):
+    FreeCADGui.addModule('PathScripts.PathJob')
+    FreeCAD.ActiveDocument.openTransaction(translate("Path_Job", "Create Job"))
+    #try:
+    obj = PathJob.Create('Job', base, template)
+    ViewProvider(obj.ViewObject)
+    FreeCAD.ActiveDocument.commitTransaction()
+    #except:
+    #    PathLog.error(sys.exc_info())
+    #    FreeCAD.ActiveDocument.abortTransaction()
+
+class CommandJobCreate:
+    '''
+    Command used to creat a command.
+    When activated the command opens a dialog allowing the user to select a base object (has to be a solid)
+    and a template to be used for the initial creation.
+    '''
+
+    def GetResources(self):
+        return {'Pixmap': 'Path-Job',
+                'MenuText': QtCore.QT_TRANSLATE_NOOP("Path_Job", "Job"),
+                'Accel': "P, J",
+                'ToolTip': QtCore.QT_TRANSLATE_NOOP("Path_Job", "Creates a Path Job object")}
+
+    def IsActive(self):
+        return FreeCAD.ActiveDocument is not None
+
+    def Activated(self):
+        dialog = DlgJobCreate()
+        if dialog.exec_() == 1:
+            self.Execute(dialog.getModel(), dialog.getTemplate())
+            FreeCAD.ActiveDocument.recompute()
+
+    @classmethod
+    def Execute(cls, base, template):
+        FreeCADGui.addModule('PathScripts.PathJobGui')
+        if template:
+            template = "'%s'" % template
+        else:
+            template = 'None'
+        FreeCADGui.doCommand('PathScripts.PathJobGui.Create(App.ActiveDocument.%s, %s)' % (base.Name, template))
+
+class CommandJobExportTemplate:
+    '''
+    Command to export a template of a given job.
+    Opens a dialog to select the file to store the template in. If the template is stored in Path's
+    file path (see preferences) and named in accordance with job_*.xml it will automatically be found
+    on Job creation and be available for selection.
+    '''
+
+    def GetResources(self):
+        return {'Pixmap': 'Path-Job',
+                'MenuText': QtCore.QT_TRANSLATE_NOOP("Path_Job", "Export Template"),
+                'ToolTip': QtCore.QT_TRANSLATE_NOOP("Path_Job", "Exports Path Job as a template to be used for other jobs")}
+
+    def IsActive(self):
+        return FreeCAD.ActiveDocument is not None
+
+    def Activated(self):
+        job = FreeCADGui.Selection.getSelection()[0]
+        foo = QtGui.QFileDialog.getSaveFileName(QtGui.qApp.activeWindow(),
+                "Path - Job Template",
+                PathPreferences.filePath(),
+                "job_*.xml")[0]
+        if foo: 
+            self.Execute(job, foo)
+
+    @classmethod
+    def Execute(cls, job, path):
+        root = xml.Element('PathJobTemplate')
+        xml.SubElement(root, JobTemplate.Job, job.Proxy.templateAttrs(job))
+        for obj in job.Group:
+            if hasattr(obj, 'Tool') and hasattr(obj, 'SpindleDir'):
+                tc = xml.SubElement(root, JobTemplate.ToolController, obj.Proxy.templateAttrs(obj))
+                tc.append(xml.fromstring(obj.Tool.Content))
+        xml.ElementTree(root).write(path)
+
+if FreeCAD.GuiUp:
+    # register the FreeCAD command
+    FreeCADGui.addCommand('Path_Job', CommandJobCreate())
+    FreeCADGui.addCommand('Path_ExportTemplate', CommandJobExportTemplate())
+
+FreeCAD.Console.PrintLog("Loading PathJob... done\n")
+

--- a/src/Mod/Path/PathScripts/PathJobGui.py
+++ b/src/Mod/Path/PathScripts/PathJobGui.py
@@ -46,16 +46,16 @@ class ViewProvider:
         vobj.setEditorMode('Selectable', mode)
         vobj.setEditorMode('ShapeColor', mode)
         vobj.setEditorMode('Transparency', mode)
-        self.taskPanel = None
 
     def attach(self, vobj):
         self.vobj = vobj
         self.obj = vobj.Object
+        self.taskPanel = None
 
-    def __getstate__(self):  # mandatory
+    def __getstate__(self):
         return None
 
-    def __setstate__(self, state):  # mandatory
+    def __setstate__(self, state):
         return None
 
     def deleteObjectsOnReject(self):
@@ -79,20 +79,14 @@ class ViewProvider:
     def getIcon(self):
         return ":/icons/Path-Job.svg"
 
-    def onChanged(self, vobj, prop):
-        mode = 2
-        vobj.setEditorMode('BoundingBox', mode)
-        vobj.setEditorMode('DisplayMode', mode)
-        vobj.setEditorMode('Selectable', mode)
-        vobj.setEditorMode('ShapeColor', mode)
-        vobj.setEditorMode('Transparency', mode)
-
     def claimChildren(self):
         children = self.obj.ToolController
         children.append(self.obj.Operations)
         return children
 
 class TaskPanel:
+    DataObject = QtCore.Qt.ItemDataRole.UserRole
+
     def __init__(self, vobj, deleteOnReject):
         FreeCAD.ActiveDocument.openTransaction(translate("Path_Job", "Edit Job"))
         self.vobj = vobj
@@ -156,7 +150,7 @@ class TaskPanel:
             self.obj.PostProcessorOutputFile = str(self.form.postProcessorOutputFile.text())
 
             self.obj.Label = str(self.form.infoLabel.text())
-            self.obj.Group = [self.form.operationsList.item(i).data() for i in range(self.form.operationsList.count())]
+            self.obj.Operations.Group = [self.form.operationsList.item(i).data(self.DataObject) for i in range(self.form.operationsList.count())]
 
             selObj = self.form.infoModel.itemData(self.form.infoModel.currentIndex())
             #if self.form.chkCreateClone.isChecked():
@@ -182,11 +176,11 @@ class TaskPanel:
 
         self.selectComboBoxText(self.form.postProcessor, self.obj.PostProcessor)
         self.form.postProcessorArguments.setText(self.obj.PostProcessorArgs)
-        self.obj.Proxy.onChanged(self.obj, "PostProcessor")
+        #self.obj.Proxy.onChanged(self.obj, "PostProcessor")
         self.updateTooltips()
 
         self.form.operationsList.clear()
-        for child in self.obj.Group:
+        for child in self.obj.Operations.Group:
             item = QtGui.QListWidgetItem(child.Label)
             item.setData(self.DataObject, child)
             self.form.operationsList.addItem(item)

--- a/src/Mod/Path/PathScripts/PathJobGui.py
+++ b/src/Mod/Path/PathScripts/PathJobGui.py
@@ -436,8 +436,21 @@ class TaskPanel:
 
     def alignSetOrigin(self):
         pass
+
     def alignMoveToOrigin(self):
-        pass
+        selObject = None
+        selFeature = None
+        for sel in FreeCADGui.Selection.getSelectionEx():
+            selObject = sel.Object
+            for feature in sel.SubElementNames:
+                selFeature = feature
+                sub = sel.Object.Shape.getElement(feature)
+                if 'Vertex' == sub.ShapeType:
+                    p = sub.Point
+                    Draft.move(sel.Object, FreeCAD.Vector() - p)
+        if selObject and selFeature:
+            FreeCADGui.Selection.clearSelection()
+            FreeCADGui.Selection.addSelection(selObject, selFeature)
 
     def updateSelection(self):
         sel = FreeCADGui.Selection.getSelectionEx()

--- a/src/Mod/Path/PathScripts/PathJobGui.py
+++ b/src/Mod/Path/PathScripts/PathJobGui.py
@@ -319,7 +319,7 @@ class StockFromExistingEdit(StockEdit):
             if stock:
                 stock = PathJob.createResourceClone(obj, stock, 'Stock', 'Stock')
                 stock.ViewObject.Visibility = True
-                PathStock.SetupStockObject(stock, False)
+                PathStock.SetupStockObject(stock, PathStock.StockType.Unknown)
                 stock.Proxy.execute(stock)
                 self.setStock(obj, stock)
 

--- a/src/Mod/Path/PathScripts/PathJobGui.py
+++ b/src/Mod/Path/PathScripts/PathJobGui.py
@@ -246,12 +246,12 @@ class StockFromBaseBoundBoxEdit(StockEdit):
         self.checkXpos()
         self.checkYpos()
         self.checkZpos()
-        self.form.stockExtXneg.editingFinished.connect(self.updateXpos)
-        self.form.stockExtYneg.editingFinished.connect(self.updateYpos)
-        self.form.stockExtZneg.editingFinished.connect(self.updateZpos)
-        self.form.stockExtXpos.editingFinished.connect(self.checkXpos)
-        self.form.stockExtYpos.editingFinished.connect(self.checkYpos)
-        self.form.stockExtZpos.editingFinished.connect(self.checkZpos)
+        self.form.stockExtXneg.textChanged.connect(self.updateXpos)
+        self.form.stockExtYneg.textChanged.connect(self.updateYpos)
+        self.form.stockExtZneg.textChanged.connect(self.updateZpos)
+        self.form.stockExtXpos.textChanged.connect(self.checkXpos)
+        self.form.stockExtYpos.textChanged.connect(self.checkYpos)
+        self.form.stockExtZpos.textChanged.connect(self.checkZpos)
 
     def checkXpos(self):
         self.trackXpos = self.form.stockExtXneg.text() == self.form.stockExtXpos.text()
@@ -309,9 +309,9 @@ class StockCreateBoxEdit(StockEdit):
 
     def setupUi(self, obj):
         self.setFields(obj)
-        self.form.stockBoxLength.editingFinished.connect(lambda: self.getFields(obj, ['length']))
-        self.form.stockBoxWidth.editingFinished.connect(lambda:  self.getFields(obj, ['width']))
-        self.form.stockBoxHeight.editingFinished.connect(lambda: self.getFields(obj, ['height']))
+        self.form.stockBoxLength.textChanged.connect(lambda: self.getFields(obj, ['length']))
+        self.form.stockBoxWidth.textChanged.connect(lambda:  self.getFields(obj, ['width']))
+        self.form.stockBoxHeight.textChanged.connect(lambda: self.getFields(obj, ['height']))
 
 class StockCreateCylinderEdit(StockEdit):
     Index = 1
@@ -337,8 +337,8 @@ class StockCreateCylinderEdit(StockEdit):
 
     def setupUi(self, obj):
         self.setFields(obj)
-        self.form.stockCylinderRadius.editingFinished.connect(lambda: self.getFields(obj, ['radius']))
-        self.form.stockCylinderHeight.editingFinished.connect(lambda: self.getFields(obj, ['height']))
+        self.form.stockCylinderRadius.textChanged.connect(lambda: self.getFields(obj, ['radius']))
+        self.form.stockCylinderHeight.textChanged.connect(lambda: self.getFields(obj, ['height']))
 
 class StockFromExistingEdit(StockEdit):
     Index = 3

--- a/src/Mod/Path/PathScripts/PathJobGui.py
+++ b/src/Mod/Path/PathScripts/PathJobGui.py
@@ -302,17 +302,17 @@ class StockFromExistingEdit(StockEdit):
                 self.setStock(obj, stock)
 
     def setFields(self, obj):
+        self.form.stockExisting.clear()
+
         candidates = [o for o in obj.Document.Objects if PathUtil.isSolid(o)]
-        candidates.remove(obj.Base)
-        if PathJob.isResourceClone(obj, 'Stock', 'Stock'):
-            candidates.remove(obj.Stock)
+        candidates.remove(obj.Base)  # always a resource clone
+        candidates.remove(obj.Stock) # regardless, what stock is/was, it's not a valid choice
         stockName = obj.Stock.Label if obj.Stock else None
 
-        self.form.stockExisting.clear()
         index = -1
-        for i, c in enumerate(candidates):
-            self.form.stockExisting.addItem(c.Label, c)
-            if c.Label == stockName:
+        for i, o in enumerate(sorted(candidates, key=lambda c: c.Label)):
+            self.form.stockExisting.addItem(o.Label, o)
+            if o.Label == stockName:
                 index = i
         self.form.stockExisting.setCurrentIndex(index if index != -1 else 0)
 

--- a/src/Mod/Path/PathScripts/PathJobGui.py
+++ b/src/Mod/Path/PathScripts/PathJobGui.py
@@ -565,8 +565,13 @@ class TaskPanel:
     def operationSelect(self):
         if self.form.operationsList.selectedItems():
             self.form.operationModify.setEnabled(True)
+            self.form.operationMove.setEnabled(True)
+            row = self.form.operationsList.currentRow()
+            self.form.operationUp.setEnabled(row > 0)
+            self.form.operationDown.setEnabled(row < self.form.operationsList.count() - 1)
         else:
             self.form.operationModify.setEnabled(False)
+            self.form.operationMove.setEnabled(False)
 
     def objectDelete(self, widget):
         for item in widget.selectedItems():
@@ -578,6 +583,22 @@ class TaskPanel:
 
     def operationDelete(self):
         self.objectDelete(self.form.operationsList)
+
+    def operationMoveUp(self):
+        row = self.form.operationsList.currentRow()
+        if row > 0:
+            item = self.form.operationsList.takeItem(row)
+            self.form.operationsList.insertItem(row-1, item)
+            self.form.operationsList.setCurrentRow(row-1)
+            self.getFields()
+
+    def operationMoveDown(self):
+        row = self.form.operationsList.currentRow()
+        if row < self.form.operationsList.count() - 1:
+            item = self.form.operationsList.takeItem(row)
+            self.form.operationsList.insertItem(row+1, item)
+            self.form.operationsList.setCurrentRow(row+1)
+            self.getFields()
 
     def toolControllerSelect(self):
         def canDeleteTC(tc):
@@ -828,10 +849,15 @@ class TaskPanel:
         self.form.postProcessorOutputFile.editingFinished.connect(self.getFields)
         self.form.postProcessorSetOutputFile.clicked.connect(self.setPostProcessorOutputFile)
 
+        # Workplan
         self.form.operationsList.itemSelectionChanged.connect(self.operationSelect)
         self.form.operationsList.indexesMoved.connect(self.getFields)
         self.form.operationDelete.clicked.connect(self.operationDelete)
+        self.form.operationUp.clicked.connect(self.operationMoveUp)
+        self.form.operationDown.clicked.connect(self.operationMoveDown)
+        self.form.operationEdit.hide() # not supported yet
 
+        # Tool controller
         self.form.toolControllerList.itemSelectionChanged.connect(self.toolControllerSelect)
         self.form.toolControllerList.itemChanged.connect(self.toolControllerChanged)
         self.form.toolControllerEdit.clicked.connect(self.toolControllerEdit)

--- a/src/Mod/Path/PathScripts/PathJobGui.py
+++ b/src/Mod/Path/PathScripts/PathJobGui.py
@@ -27,11 +27,7 @@ import FreeCADGui
 import PathScripts.PathJob as PathJob
 import PathScripts.PathLog as PathLog
 import PathScripts.PathToolController as PathToolController
-
-import glob
-import os
 import sys
-import xml.etree.ElementTree as xml
 
 from PathScripts.PathPreferences import PathPreferences
 from PySide import QtCore, QtGui
@@ -229,145 +225,16 @@ class TaskPanel:
 
         self.setFields()
 
-class DlgJobCreate:
-
-    def __init__(self, parent=None):
-        self.dialog = FreeCADGui.PySideUic.loadUi(":/panels/DlgJobCreate.ui")
-        sel = FreeCADGui.Selection.getSelection()
-        if sel:
-            selected = sel[0].Label
-        else:
-            selected = None
-        index = 0
-        for base in PathJob.ObjectJob.baseCandidates():
-            if base.Label == selected:
-                index = self.dialog.cbModel.count()
-            self.dialog.cbModel.addItem(base.Label)
-        self.dialog.cbModel.setCurrentIndex(index)
-
-        templateFiles = []
-        for path in PathPreferences.searchPaths():
-            templateFiles.extend(self.templateFilesIn(path))
-
-        template = {}
-        for tFile in templateFiles:
-            name = os.path.split(os.path.splitext(tFile)[0])[1][4:]
-            if name in template:
-                basename = name
-                i = 0
-                while name in template:
-                    i = i + 1
-                    name = basename + " (%s)" % i
-            PathLog.track(name, tFile)
-            template[name] = tFile
-        selectTemplate = PathPreferences.defaultJobTemplate()
-        index = 0
-        self.dialog.cbTemplate.addItem('<none>', '')
-        for name in sorted(template.keys()):
-            if template[name] == selectTemplate:
-                index = self.dialog.cbTemplate.count()
-            self.dialog.cbTemplate.addItem(name, template[name])
-        self.dialog.cbTemplate.setCurrentIndex(index)
-
-    def templateFilesIn(self, path):
-        '''templateFilesIn(path) ... answer all file in the given directory which fit the job template naming convention.
-        PathJob template files are name job_*.xml'''
-        PathLog.track(path)
-        return glob.glob(path + '/job_*.xml')
-
-    def getModel(self):
-        '''answer the base model selected for the job'''
-        label = self.dialog.cbModel.currentText()
-        return filter(lambda obj: obj.Label == label, FreeCAD.ActiveDocument.Objects)[0]
-
-    def getTemplate(self):
-        '''answer the file name of the template to be assigned'''
-        return self.dialog.cbTemplate.itemData(self.dialog.cbTemplate.currentIndex())
-
-    def exec_(self):
-        return self.dialog.exec_()
-
-def Create(base, template):
+def Create(base, template=None):
+    '''Create(base, template) ... creates a job instance for the given base object
+    using template to configure it.'''
     FreeCADGui.addModule('PathScripts.PathJob')
     FreeCAD.ActiveDocument.openTransaction(translate("Path_Job", "Create Job"))
-    #try:
-    obj = PathJob.Create('Job', base, template)
-    ViewProvider(obj.ViewObject)
-    FreeCAD.ActiveDocument.commitTransaction()
-    #except:
-    #    PathLog.error(sys.exc_info())
-    #    FreeCAD.ActiveDocument.abortTransaction()
-
-class CommandJobCreate:
-    '''
-    Command used to creat a command.
-    When activated the command opens a dialog allowing the user to select a base object (has to be a solid)
-    and a template to be used for the initial creation.
-    '''
-
-    def GetResources(self):
-        return {'Pixmap': 'Path-Job',
-                'MenuText': QtCore.QT_TRANSLATE_NOOP("Path_Job", "Job"),
-                'Accel': "P, J",
-                'ToolTip': QtCore.QT_TRANSLATE_NOOP("Path_Job", "Creates a Path Job object")}
-
-    def IsActive(self):
-        return FreeCAD.ActiveDocument is not None
-
-    def Activated(self):
-        dialog = DlgJobCreate()
-        if dialog.exec_() == 1:
-            self.Execute(dialog.getModel(), dialog.getTemplate())
-            FreeCAD.ActiveDocument.recompute()
-
-    @classmethod
-    def Execute(cls, base, template):
-        FreeCADGui.addModule('PathScripts.PathJobGui')
-        if template:
-            template = "'%s'" % template
-        else:
-            template = 'None'
-        FreeCADGui.doCommand('PathScripts.PathJobGui.Create(App.ActiveDocument.%s, %s)' % (base.Name, template))
-
-class CommandJobExportTemplate:
-    '''
-    Command to export a template of a given job.
-    Opens a dialog to select the file to store the template in. If the template is stored in Path's
-    file path (see preferences) and named in accordance with job_*.xml it will automatically be found
-    on Job creation and be available for selection.
-    '''
-
-    def GetResources(self):
-        return {'Pixmap': 'Path-Job',
-                'MenuText': QtCore.QT_TRANSLATE_NOOP("Path_Job", "Export Template"),
-                'ToolTip': QtCore.QT_TRANSLATE_NOOP("Path_Job", "Exports Path Job as a template to be used for other jobs")}
-
-    def IsActive(self):
-        return FreeCAD.ActiveDocument is not None
-
-    def Activated(self):
-        job = FreeCADGui.Selection.getSelection()[0]
-        foo = QtGui.QFileDialog.getSaveFileName(QtGui.qApp.activeWindow(),
-                "Path - Job Template",
-                PathPreferences.filePath(),
-                "job_*.xml")[0]
-        if foo: 
-            self.Execute(job, foo)
-
-    @classmethod
-    def Execute(cls, job, path):
-        root = xml.Element('PathJobTemplate')
-        xml.SubElement(root, JobTemplate.Job, job.Proxy.templateAttrs(job))
-        for obj in job.Group:
-            if hasattr(obj, 'Tool') and hasattr(obj, 'SpindleDir'):
-                tc = xml.SubElement(root, JobTemplate.ToolController, obj.Proxy.templateAttrs(obj))
-                tc.append(xml.fromstring(obj.Tool.Content))
-        xml.ElementTree(root).write(path)
-
-if FreeCAD.GuiUp:
-    # register the FreeCAD command
-    FreeCADGui.addCommand('Path_Job', CommandJobCreate())
-    FreeCADGui.addCommand('Path_ExportTemplate', CommandJobExportTemplate())
-
-FreeCAD.Console.PrintLog("Loading PathJob... done\n")
+    try:
+        obj = PathJob.Create('Job', base, template)
+        ViewProvider(obj.ViewObject)
+        FreeCAD.ActiveDocument.commitTransaction()
+    except:
+        PathLog.error(sys.exc_info())
+        FreeCAD.ActiveDocument.abortTransaction()
 

--- a/src/Mod/Path/PathScripts/PathJobGui.py
+++ b/src/Mod/Path/PathScripts/PathJobGui.py
@@ -877,7 +877,11 @@ class TaskPanel:
         self.form.operationDelete.clicked.connect(self.operationDelete)
         self.form.operationUp.clicked.connect(self.operationMoveUp)
         self.form.operationDown.clicked.connect(self.operationMoveDown)
+
         self.form.operationEdit.hide() # not supported yet
+        self.form.activeToolGroup.hide() # not supported yet
+        self.form.tbWorkplan.widget(1).hide() # default values not supported yet
+        self.form.tbWorkplan.removeItem(1) # default values not supported yet
 
         # Tool controller
         self.form.toolControllerList.itemSelectionChanged.connect(self.toolControllerSelect)

--- a/src/Mod/Path/PathScripts/PathJobGui.py
+++ b/src/Mod/Path/PathScripts/PathJobGui.py
@@ -99,6 +99,11 @@ class ViewProvider:
             children.append(self.obj.Stock)
         return children
 
+    def onDelete(self, vobj, arg2=None):
+        PathLog.track(vobj.Object.Label, arg2)
+        self.obj.Proxy.onDelete(self.obj, arg2)
+        return True
+
 class TaskPanel:
     DataObject = QtCore.Qt.ItemDataRole.UserRole
     DataProperty = QtCore.Qt.ItemDataRole.UserRole + 1

--- a/src/Mod/Path/PathScripts/PathJobGui.py
+++ b/src/Mod/Path/PathScripts/PathJobGui.py
@@ -113,6 +113,10 @@ class StockEdit(object):
         self.form = form
         self.setupUi(obj)
 
+    @classmethod
+    def IsStock(cls, obj):
+        return PathStock.StockType.FromStock(obj.Stock) == cls.StockType
+
     def activate(self, obj, select = False):
         PathLog.track(obj.Label, select)
         def showHide(widget, activeWidget):
@@ -139,11 +143,7 @@ class StockEdit(object):
 
 class StockFromBaseBoundBoxEdit(StockEdit):
     Index = 2
-    StockType = 'FromBase'
-
-    @classmethod
-    def IsStock(cls, obj):
-        return hasattr(obj.Stock, 'ExtXneg') and hasattr(obj.Stock, 'ExtZpos')
+    StockType = PathStock.StockType.FromBase
 
     def editorFrame(self):
         return self.form.stockFromBase
@@ -219,11 +219,7 @@ class StockFromBaseBoundBoxEdit(StockEdit):
 
 class StockCreateBoxEdit(StockEdit):
     Index = 0
-    StockType = 'CreateBox'
-
-    @classmethod
-    def IsStock(cls, obj):
-        return hasattr(obj.Stock, 'Length') and hasattr(obj.Stock, 'Width') and hasattr(obj.Stock, 'Height') and not StockFromBaseBoundBoxEdit.IsStock(obj)
+    StockType = PathStock.StockType.CreateBox
 
     def editorFrame(self):
         return self.form.stockCreateBox
@@ -254,10 +250,7 @@ class StockCreateBoxEdit(StockEdit):
 
 class StockCreateCylinderEdit(StockEdit):
     Index = 1
-
-    @classmethod
-    def IsStock(cls, obj):
-        return hasattr(obj.Stock, 'Radius') and hasattr(obj.Stock, 'Height')
+    StockType = PathStock.StockType.CreateCylinder
 
     def editorFrame(self):
         return self.form.stockCreateCylinder
@@ -284,9 +277,7 @@ class StockCreateCylinderEdit(StockEdit):
 
 class StockFromExistingEdit(StockEdit):
     Index = 3
-
-    def IsStock(cls, obj):
-        return PathJob.isResourceClone(obj, 'Stock', 'Stock')
+    StockType = PathStock.StockType.Unknown
 
     def editorFrame(self):
         return self.form.stockFromExisting

--- a/src/Mod/Path/PathScripts/PathJobGui.py
+++ b/src/Mod/Path/PathScripts/PathJobGui.py
@@ -45,7 +45,7 @@ from pivy import coin
 def translate(context, text, disambig=None):
     return QtCore.QCoreApplication.translate(context, text, disambig)
 
-if True:
+if False:
     PathLog.setLevel(PathLog.Level.DEBUG, PathLog.thisModule())
     PathLog.trackModule(PathLog.thisModule())
 else:

--- a/src/Mod/Path/PathScripts/PathPost.py
+++ b/src/Mod/Path/PathScripts/PathPost.py
@@ -225,7 +225,7 @@ class CommandPathPost:
             targetlist = []
             for o in FreeCAD.ActiveDocument.Objects:
                 if hasattr(o, "Proxy"):
-                    if isinstance(o.Proxy, PathJob.ObjectPathJob):
+                    if isinstance(o.Proxy, PathJob.ObjectJob):
                         targetlist.append(o.Label)
             PathLog.debug("Possible post objects: {}".format(targetlist))
             if len(targetlist) > 1:
@@ -246,14 +246,13 @@ class CommandPathPost:
         # Then post-the ordered list
         postlist = []
         currTool = None
-        for obj in job.Group:
+        for obj in job.Operations.Group:
             PathLog.debug("obj: {}".format(obj.Name))
-            if not isinstance(obj.Proxy, PathToolController.ToolController):
-                tc = PathUtil.toolControllerForOp(obj)
-                if tc is not None:
-                    if tc.ToolNumber != currTool:
-                        postlist.append(tc)
-                postlist.append(obj)
+            tc = PathUtil.toolControllerForOp(obj)
+            if tc is not None:
+                if tc.ToolNumber != currTool:
+                    postlist.append(tc)
+            postlist.append(obj)
 
         fail = True
         rc = ''

--- a/src/Mod/Path/PathScripts/PathStock.py
+++ b/src/Mod/Path/PathScripts/PathStock.py
@@ -82,7 +82,9 @@ def SetupStockObject(obj, addVPProxy):
 
 def CreateFromBase(job):
     obj = FreeCAD.ActiveDocument.addObject('Part::FeaturePython', 'Stock')
-    proxy = StockFromBase(obj, job.Base)
+    # don't want to use the resrouce clone - we want the real object so 
+    # Base and Stock can be placed independently
+    proxy = StockFromBase(obj, job.Proxy.baseObject(job))
     SetupStockObject(obj, True)
     proxy.execute(obj)
     obj.purgeTouched()

--- a/src/Mod/Path/PathScripts/PathStock.py
+++ b/src/Mod/Path/PathScripts/PathStock.py
@@ -23,7 +23,6 @@
 '''used to create material stock around a machined part- for visualization '''
 
 import FreeCAD
-import FreeCADGui
 import Part
 import PathIconViewProvider
 
@@ -127,64 +126,5 @@ def CreateCylinder(job, radius=None, height=None, at=None):
         obj.Placement = FreeCAD.Placement(origin, FreeCAD.Vector(), 0)
     SetupStockObject(obj, False)
     return obj
-
-
-class _ViewProviderStock:
-
-    def __init__(self, obj):  # mandatory
-        #        obj.addProperty("App::PropertyFloat","SomePropertyName","PropertyGroup","Description of this property")
-        obj.Proxy = self
-
-    def __getstate__(self):  # mandatory
-        return None
-
-    def __setstate__(self, state):  # mandatory
-        return None
-
-    def getIcon(self):  # optional
-        return ":/icons/Path-Stock.svg"
-
-    def attach(self, vobj):  # optional
-        self.Object = vobj.Object
-
-
-class CommandPathStock:
-
-    def GetResources(self):
-        return {'Pixmap': 'Path-Stock',
-                'MenuText': QtCore.QT_TRANSLATE_NOOP("PathStock", "Stock"),
-                'ToolTip': QtCore.QT_TRANSLATE_NOOP("PathStock", "Creates a 3D object to represent raw stock to mill the part out of")}
-
-    def IsActive(self):
-        return FreeCAD.ActiveDocument is not None
-
-    def Activated(self):
-        FreeCAD.ActiveDocument.openTransaction(translate("Path_Stock", "Creates a 3D object to represent raw stock to mill the part out of"))
-        FreeCADGui.addModule("PathScripts.PathStock")
-        snippet = '''
-import FreeCADGui
-if len(FreeCADGui.Selection.getSelection())>0:
-    sel=FreeCADGui.Selection.getSelection()
-    o = sel[0]
-    if "Shape" in o.PropertiesList:
-        obj =FreeCAD.ActiveDocument.addObject('Part::FeaturePython',sel[0].Name+('_Stock'))
-        PathScripts.PathStock.Stock(obj)
-        PathScripts.PathStock._ViewProviderStock(obj.ViewObject)
-        PathScripts.PathUtils.addToJob(obj)
-        baseobj = sel[0]
-        obj.Base = baseobj
-        FreeCADGui.ActiveDocument.getObject(sel[0].Name+("_Stock")).ShapeColor = (0.3333,0.6667,1.0000)
-        FreeCADGui.ActiveDocument.getObject(sel[0].Name+("_Stock")).Transparency = 75
-        FreeCAD.ActiveDocument.recompute()
-    else:
-        FreeCAD.Console.PrintMessage("Select a Solid object and try again.\\n")
-else:
-    FreeCAD.Console.PrintMessage("Select the object you want to show stock for and try again.\\n")
-        '''
-        FreeCADGui.doCommand(snippet)
-
-if FreeCAD.GuiUp:
-    # register the FreeCAD command
-    FreeCADGui.addCommand('Path_Stock', CommandPathStock())
 
 FreeCAD.Console.PrintLog("Loading PathStock... done\n")

--- a/src/Mod/Path/PathScripts/PathStock.py
+++ b/src/Mod/Path/PathScripts/PathStock.py
@@ -80,6 +80,10 @@ class StockFromBase:
 
         obj.Shape = Part.makeBox(self.length, self.width, self.height, self.origin)
 
+    def onChanged(self, obj, prop):
+        if prop in ['ExtXneg', 'ExtXpos', 'ExtYneg', 'ExtYpos', 'ExtZneg', 'ExtZpos'] and not 'Restore' in obj.State:
+            self.execute(obj)
+
 def SetupStockObject(obj, addVPProxy):
     if FreeCAD.GuiUp and obj.ViewObject:
         if addVPProxy:

--- a/src/Mod/Path/PathScripts/PathStock.py
+++ b/src/Mod/Path/PathScripts/PathStock.py
@@ -24,23 +24,36 @@
 
 import FreeCAD
 import FreeCADGui
-from FreeCAD import Vector
-from PySide import QtCore, QtGui
 import Part
+import PathIconViewProvider
+
+from PySide import QtCore
 
 # Qt tanslation handling
 def translate(context, text, disambig=None):
     return QtCore.QCoreApplication.translate(context, text, disambig)
 
 
-class Stock:
+class StockFromBase:
 
-    def __init__(self, obj):
+    def __init__(self, obj, base):
         "Make stock"
-        obj.addProperty("App::PropertyFloat","Length_Allowance","Stock",QtCore.QT_TRANSLATE_NOOP("App::Property","extra allowance from part width")).Length_Allowance = 1.0
-        obj.addProperty("App::PropertyFloat","Width_Allowance","Stock",QtCore.QT_TRANSLATE_NOOP("App::Property","extra allowance from part width")).Width_Allowance = 1.0
-        obj.addProperty("App::PropertyFloat","Height_Allowance","Stock",QtCore.QT_TRANSLATE_NOOP("App::Property","extra allowance from part width")).Height_Allowance = 1.0
-        obj.addProperty("App::PropertyLink","Base","Base",QtCore.QT_TRANSLATE_NOOP("App::Property","The base object this represents"))
+        obj.addProperty("App::PropertyLink", "Base", "Base", QtCore.QT_TRANSLATE_NOOP("PathStock", "The base object this stock is derived from"))
+        obj.addProperty("App::PropertyLength", "ExtXneg", "Stock", QtCore.QT_TRANSLATE_NOOP("PathStock", "Extra allowance from part bound box in negative X direction"))
+        obj.addProperty("App::PropertyLength", "ExtXpos", "Stock", QtCore.QT_TRANSLATE_NOOP("PathStock", "Extra allowance from part bound box in positive X direction"))
+        obj.addProperty("App::PropertyLength", "ExtYneg", "Stock", QtCore.QT_TRANSLATE_NOOP("PathStock", "Extra allowance from part bound box in negative Y direction"))
+        obj.addProperty("App::PropertyLength", "ExtYpos", "Stock", QtCore.QT_TRANSLATE_NOOP("PathStock", "Extra allowance from part bound box in positive Y direction"))
+        obj.addProperty("App::PropertyLength", "ExtZneg", "Stock", QtCore.QT_TRANSLATE_NOOP("PathStock", "Extra allowance from part bound box in negative Z direction"))
+        obj.addProperty("App::PropertyLength", "ExtZpos", "Stock", QtCore.QT_TRANSLATE_NOOP("PathStock", "Extra allowance from part bound box in positive Z direction"))
+
+        obj.Base = base
+        obj.ExtXneg= 1.0
+        obj.ExtXpos= 1.0
+        obj.ExtYneg= 1.0
+        obj.ExtYpos= 1.0
+        obj.ExtZneg= 1.0
+        obj.ExtZpos= 1.0
+
         obj.Proxy = self
 
     def __getstate__(self):
@@ -50,23 +63,70 @@ class Stock:
         return None
 
     def execute(self, obj):
-        self.Xmin = obj.Base.Shape.BoundBox.XMin
-        self.Xmax = obj.Base.Shape.BoundBox.XMax
+        bb = obj.Base.Shape.BoundBox
 
-        self.Ymin = obj.Base.Shape.BoundBox.YMin
-        self.Ymax = obj.Base.Shape.BoundBox.YMax
+        origin = FreeCAD.Vector(bb.XMin, bb.YMin, bb.ZMin)
+        self.origin = origin - FreeCAD.Vector(obj.ExtXneg.Value, obj.ExtYneg.Value, obj.ExtZneg.Value)
 
-        self.Zmin = obj.Base.Shape.BoundBox.ZMin
-        self.Zmax = obj.Base.Shape.BoundBox.ZMax
+        self.length = bb.XLength + obj.ExtXneg.Value + obj.ExtXpos.Value
+        self.width  = bb.YLength + obj.ExtYneg.Value + obj.ExtYpos.Value
+        self.height = bb.ZLength + obj.ExtZneg.Value + obj.ExtZpos.Value
 
-        self.length = self.Xmax - self.Xmin + obj.Length_Allowance * 2.0
-        self.width = self.Ymax - self.Ymin + obj.Width_Allowance * 2.0
-        self.height = self.Zmax - self.Zmin + obj.Height_Allowance * 2.0
-        self.pnt = Vector(self.Xmin - obj.Length_Allowance, self.Ymin -
-                          obj.Width_Allowance, self.Zmin - obj.Height_Allowance)
+        obj.Shape = Part.makeBox(self.length, self.width, self.height, self.origin)
 
-        obj.Shape = Part.makeBox(
-            self.length, self.width, self.height, self.pnt)
+def SetupStockObject(obj, addVPProxy):
+    if FreeCAD.GuiUp and obj.ViewObject:
+        if addVPProxy:
+            PathIconViewProvider.ViewProvider(obj.ViewObject, 'Stock')
+        obj.ViewObject.Transparency = 90
+        obj.ViewObject.DisplayMode = 'Wireframe'
+
+def CreateFromBase(job):
+    obj = FreeCAD.ActiveDocument.addObject('Part::FeaturePython', 'Stock')
+    proxy = StockFromBase(obj, job.Base)
+    SetupStockObject(obj, True)
+    proxy.execute(obj)
+    obj.purgeTouched()
+    return obj
+
+def CreateBox(job, extent=None, at=None):
+    obj = FreeCAD.ActiveDocument.addObject('Part::Box', 'Stock')
+    if extent:
+        obj.Length = extent.x
+        obj.Width  = extent.y
+        obj.Height = extent.z
+    elif job.Base:
+        bb = job.Base.Shape.BoundBox
+        obj.Length = bb.XLength
+        obj.Width  = bb.YLength
+        obj.Height = bb.ZLength
+    if at:
+        obj.Placement = FreeCAD.Placement(at, FreeCAD.Vector(), 0)
+    else:
+        bb = job.Base.Shape.BoundBox
+        origin = FreeCAD.Vector(bb.XMin, bb.YMin, bb.ZMin)
+        obj.Placement = FreeCAD.Placement(origin, FreeCAD.Vector(), 0)
+    SetupStockObject(obj, False)
+    return obj
+
+def CreateCylinder(job, radius=None, height=None, at=None):
+    obj = FreeCAD.ActiveDocument.addObject('Part::Cylinder', 'Stock')
+    if radius:
+        obj.Radius = radius
+    if height:
+        obj.Height = height
+    elif job.Base:
+        bb = job.Base.Shape.BoundBox
+        obj.Radius = max(bb.XLength, bb.YLength) * 0.7072 # 1/sqrt(2)
+        obj.Height = bb.ZLength
+    if at:
+        obj.Placement = FreeCAD.Placement(at, FreeCAD.Vector(), 0)
+    else:
+        bb = job.Base.Shape.BoundBox
+        origin = FreeCAD.Vector((bb.XMin + bb.XMax)/2, (bb.YMin + bb.YMax)/2, bb.ZMin)
+        obj.Placement = FreeCAD.Placement(origin, FreeCAD.Vector(), 0)
+    SetupStockObject(obj, False)
+    return obj
 
 
 class _ViewProviderStock:

--- a/src/Mod/Path/PathScripts/PathStock.py
+++ b/src/Mod/Path/PathScripts/PathStock.py
@@ -96,9 +96,9 @@ def CreateBox(job, extent=None, at=None):
         obj.Height = extent.z
     elif job.Base:
         bb = job.Base.Shape.BoundBox
-        obj.Length = bb.XLength
-        obj.Width  = bb.YLength
-        obj.Height = bb.ZLength
+        obj.Length = max(bb.XLength, 1)
+        obj.Width  = max(bb.YLength, 1)
+        obj.Height = max(bb.ZLength, 1)
     if at:
         obj.Placement = FreeCAD.Placement(at, FreeCAD.Vector(), 0)
     else:
@@ -117,7 +117,7 @@ def CreateCylinder(job, radius=None, height=None, at=None):
     elif job.Base:
         bb = job.Base.Shape.BoundBox
         obj.Radius = max(bb.XLength, bb.YLength) * 0.7072 # 1/sqrt(2)
-        obj.Height = bb.ZLength
+        obj.Height = max(bb.ZLength, 1)
     if at:
         obj.Placement = FreeCAD.Placement(at, FreeCAD.Vector(), 0)
     else:

--- a/src/Mod/Path/PathScripts/PathToolController.py
+++ b/src/Mod/Path/PathScripts/PathToolController.py
@@ -136,18 +136,6 @@ class ToolController:
         if obj.ViewObject:
             obj.ViewObject.Visibility = True
 
-    def onChanged(self, obj, prop):
-        PathLog.track('prop: {}  state: {}'.format(prop, obj.State))
-
-        if 'Path' == prop and 'Restore' not in obj.State:
-            PathLog.warning('Markus you gotta do something about TC changes')
-        #    PathLog.debug("--- dirty deeds")
-        #    job = PathScripts.PathUtils.findParentJob(obj)
-        #    if job is not None:
-        #        for g in job.Group:
-        #            if not(isinstance(g.Proxy, PathScripts.PathToolController.ToolController)):
-        #                g.touch()
-
     def getTool(self, obj):
         '''returns the tool associated with this tool controller'''
         PathLog.track()
@@ -395,9 +383,6 @@ class TaskPanel:
         length = tool.CuttingEdgeHeight
         t = Part.makeCylinder(radius, length)
         self.toolrep.Shape = t
-
-    def getStandardButtons(self):
-        return int(QtGui.QDialogButtonBox.Ok)
 
     def edit(self, item, column):
         if not self.updating:

--- a/src/Mod/Path/PathScripts/PathToolController.py
+++ b/src/Mod/Path/PathScripts/PathToolController.py
@@ -35,7 +35,7 @@ import xml.etree.ElementTree as xml
 from FreeCAD import Units
 from PySide import QtCore, QtGui
 
-if True:
+if False:
     PathLog.setLevel(PathLog.Level.DEBUG, PathLog.thisModule())
     PathLog.trackModule(PathLog.thisModule())
 else:
@@ -190,8 +190,7 @@ class ViewProvider:
     def setEdit(self, vobj, mode):
         # this is executed when the object is double-clicked in the tree
         FreeCADGui.Control.closeDialog()
-        taskd = TaskPanel()
-        taskd.obj = vobj.Object
+        taskd = TaskPanel(vobj.Object)
         FreeCADGui.Control.showDialog(taskd)
         taskd.setupUi()
 
@@ -252,109 +251,13 @@ class CommandPathToolController:
         PathLog.track()
         Create()
 
-class TaskPanel:
-    def __init__(self):
-        self.form = FreeCADGui.PySideUic.loadUi(":/panels/ToolControl.ui")
-        #self.form = FreeCADGui.PySideUic.loadUi(FreeCAD.getHomePath() + "Mod/Path/ToolControl.ui")
-        self.editform = FreeCADGui.PySideUic.loadUi(":/panels/ToolEdit.ui")
+class ToolControllerEditor:
 
-        self.updating = False
-        self.toolrep = None
-
-    def accept(self):
-        self.getFields()
-
-        FreeCADGui.ActiveDocument.resetEdit()
-        FreeCADGui.Control.closeDialog()
-        if self.toolrep is not None:
-            FreeCAD.ActiveDocument.removeObject(self.toolrep.Name)
-        FreeCAD.ActiveDocument.recompute()
-        FreeCADGui.Selection.removeObserver(self.s)
-
-    def reject(self):
-        FreeCADGui.Control.closeDialog()
-        if self.toolrep is not None:
-            FreeCAD.ActiveDocument.removeObject(self.toolrep.Name)
-        FreeCAD.ActiveDocument.recompute()
-        FreeCADGui.Selection.removeObserver(self.s)
-
-    def getFields(self):
-        if self.obj:
-            if hasattr(self.obj, "Label"):
-                self.obj.Label = self.form.tcoName.text()
-            if hasattr(self.obj, "VertFeed"):
-                self.obj.VertFeed = self.form.vertFeed.text()
-            if hasattr(self.obj, "HorizFeed"):
-                self.obj.HorizFeed = self.form.horizFeed.text()
-            if hasattr(self.obj, "VertRapid"):
-                self.obj.VertRapid = self.form.vertRapid.text()
-            if hasattr(self.obj, "HorizRapid"):
-                self.obj.HorizRapid = self.form.horizRapid.text()
-            if hasattr(self.obj, "ToolNumber"):
-                self.obj.ToolNumber = self.form.uiToolNum.value()
-            if hasattr(self.obj, "SpindleSpeed"):
-                self.obj.SpindleSpeed = self.form.spindleSpeed.value()
-            if hasattr(self.obj, "SpindleDir"):
-                self.obj.SpindleDir = str(self.form.cboSpindleDirection.currentText())
-
-        self.obj.Proxy.execute(self.obj)
-
-    def setFields(self):
-        self.form.tcoName.setText(self.obj.Label)
-        self.form.uiToolNum.setValue(self.obj.ToolNumber)
-        self.form.vertFeed.setText(self.obj.VertFeed.UserString)
-        self.form.horizFeed.setText(self.obj.HorizFeed.UserString)
-        self.form.vertRapid.setText(self.obj.VertRapid.UserString)
-        self.form.horizRapid.setText(self.obj.HorizRapid.UserString)
-
-        self.form.spindleSpeed.setValue(self.obj.SpindleSpeed)
-
-        index = self.form.cboSpindleDirection.findText(self.obj.SpindleDir, QtCore.Qt.MatchFixedString)
-        if index >= 0:
-            self.form.cboSpindleDirection.setCurrentIndex(index)
-
-        try:
-            tool = self.obj.Tool
-            self.form.txtToolType.setText(tool.ToolType)
-            self.form.txtToolMaterial.setText(tool.Material)
-            diam = Units.Quantity(tool.Diameter, FreeCAD.Units.Length)
-            self.form.txtToolDiameter.setText(diam.getUserPreferred()[0])
-            self.form.txtToolName.setText(tool.Name)
-        except:
-            self.form.txtToolType.setText("UNDEFINED")
-            self.form.txtToolMaterial.setText("UNDEFINED")
-            self.form.txtToolDiameter.setText("UNDEFINED")
-
-        radius = tool.Diameter / 2
-        length = tool.CuttingEdgeHeight
-        t = Part.makeCylinder(radius, length)
-        self.toolrep.Shape = t
-
-    def open(self):
-        self.s = SelObserver()
-        # install the function mode resident
-        FreeCADGui.Selection.addObserver(self.s)
-
-    def getStandardButtons(self):
-        return int(QtGui.QDialogButtonBox.Ok)
-
-    def edit(self, item, column):
-        if not self.updating:
-            self.resetObject()
-
-    def resetObject(self, remove=None):
-        "transfers the values from the widget to the object"
-        FreeCAD.ActiveDocument.recompute()
-
-    def setupUi(self):
-        self.form.tcoName.editingFinished.connect(self.getFields)
-        self.form.cmdEditLocal.clicked.connect(self.editTool)
-
-        t = Part.makeCylinder(1, 1)
-        self.toolrep = FreeCAD.ActiveDocument.addObject("Part::Feature", "tool")
-        self.toolrep.Shape = t
-
-        self.setFields()
+    def __init__(self, obj, asDialog):
+        self.form = FreeCADGui.PySideUic.loadUi(":/panels/DlgToolControllerEdit.ui")
+        if not asDialog:
+            self.form.buttonBox.hide()
+        self.obj = obj
 
     def getType(self, tooltype):
         "gets a combobox index number for a given type or viceversa"
@@ -381,44 +284,134 @@ class TaskPanel:
         else:
             return matslist[material]
 
-    def editTool(self):
-        toolnum = self.obj.ToolNumber
+    def updateUi(self):
+        PathLog.info("updateUI")
+        tc = self.obj
+        self.form.tcName.setText(tc.Label)
+        self.form.tcNumber.setValue(tc.ToolNumber)
+        self.form.horizFeed.setText(tc.HorizFeed.UserString)
+        self.form.vertFeed.setText(tc.VertFeed.UserString)
+        self.form.horizRapid.setText(tc.HorizRapid.UserString)
+        self.form.vertRapid.setText(tc.VertRapid.UserString)
+        self.form.spindleSpeed.setValue(tc.SpindleSpeed)
+        index = self.form.spindleDirection.findText(tc.SpindleDir, QtCore.Qt.MatchFixedString)
+        if index >= 0:
+            self.form.spindleDirection.setCurrentIndex(index)
+
+        self.form.toolName.setText(tc.Tool.Name)
+        self.form.toolType.setCurrentIndex(self.getType(tc.Tool.ToolType))
+        self.form.toolMaterial.setCurrentIndex(self.getMaterial(tc.Tool.Material))
+        self.form.toolDiameter.setText(FreeCAD.Units.Quantity(tc.Tool.Diameter, FreeCAD.Units.Length).UserString)
+        self.form.toolLengthOffset.setText(FreeCAD.Units.Quantity(tc.Tool.LengthOffset, FreeCAD.Units.Length).UserString)
+        self.form.toolFlatRadius.setText(FreeCAD.Units.Quantity(tc.Tool.FlatRadius, FreeCAD.Units.Length).UserString)
+        self.form.toolCornerRadius.setText(FreeCAD.Units.Quantity(tc.Tool.CornerRadius, FreeCAD.Units.Length).UserString)
+        self.form.toolCuttingEdgeAngle.setText(FreeCAD.Units.Quantity(tc.Tool.CuttingEdgeAngle, FreeCAD.Units.Angle).UserString)
+        self.form.toolCuttingEdgeHeight.setText(FreeCAD.Units.Quantity(tc.Tool.CuttingEdgeHeight, FreeCAD.Units.Length).UserString)
+
+    def updateToolController(self):
+        PathLog.info("updateToolController")
+        tc = self.obj
+        try:
+            tc.Label = self.form.tcName.text()
+            tc.ToolNumber = self.form.tcNumber.value()
+            tc.HorizFeed = self.form.horizFeed.text()
+            tc.VertFeed = self.form.vertFeed.text()
+            tc.HorizRapid = self.form.horizRapid.text()
+            tc.VertRapid = self.form.vertRapid.text()
+            tc.SpindleSpeed = self.form.spindleSpeed.value()
+            tc.SpindleDir = self.form.spindleDirection.currentText()
+
+            tc.Tool.Name = str(self.form.toolName.text())
+            tc.Tool.ToolType = self.getType(self.form.toolType.currentIndex())
+            tc.Tool.Material = self.getMaterial(self.form.toolMaterial.currentIndex())
+            tc.Tool.Diameter = FreeCAD.Units.parseQuantity(self.form.toolDiameter.text())
+            tc.Tool.LengthOffset = FreeCAD.Units.parseQuantity(self.form.toolLengthOffset.text())
+            tc.Tool.FlatRadius = FreeCAD.Units.parseQuantity(self.form.toolFlatRadius.text())
+            tc.Tool.CornerRadius = FreeCAD.Units.parseQuantity(self.form.toolCornerRadius.text())
+            tc.Tool.CuttingEdgeAngle = FreeCAD.Units.Quantity(self.form.toolCuttingEdgeAngle.text())
+            tc.Tool.CuttingEdgeHeight = FreeCAD.Units.parseQuantity(self.form.toolCuttingEdgeHeight.text())
+        except Exception as e:
+            PathLog.error(translate("PathToolController", "Error updating TC: %s") % e)
+
+
+    def refresh(self):
+        self.form.blockSignals(True)
+        self.updateToolController()
+        self.updateUi()
+        self.form.blockSignals(False)
+
+    def setupUi(self):
+        self.form.tcName.editingFinished.connect(self.refresh)
+        self.form.horizFeed.editingFinished.connect(self.refresh)
+        self.form.vertFeed.editingFinished.connect(self.refresh)
+        self.form.horizRapid.editingFinished.connect(self.refresh)
+        self.form.vertRapid.editingFinished.connect(self.refresh)
+
+        self.form.toolName.editingFinished.connect(self.refresh)
+        self.form.toolDiameter.editingFinished.connect(self.refresh)
+        self.form.toolLengthOffset.editingFinished.connect(self.refresh)
+        self.form.toolFlatRadius.editingFinished.connect(self.refresh)
+        self.form.toolCornerRadius.editingFinished.connect(self.refresh)
+        self.form.toolCuttingEdgeAngle.editingFinished.connect(self.refresh)
+        self.form.toolCuttingEdgeHeight.editingFinished.connect(self.refresh)
+
+class TaskPanel:
+
+    def __init__(self, obj):
+        self.editor = ToolControllerEditor(obj, False)
+        self.form = self.editor.form
+        self.updating = False
+        self.toolrep = None
+        self.obj = obj
+
+    def accept(self):
+        self.getFields()
+
+        FreeCADGui.ActiveDocument.resetEdit()
+        FreeCADGui.Control.closeDialog()
+        if self.toolrep is not None:
+            FreeCAD.ActiveDocument.removeObject(self.toolrep.Name)
+        FreeCAD.ActiveDocument.recompute()
+
+    def reject(self):
+        FreeCADGui.Control.closeDialog()
+        if self.toolrep is not None:
+            FreeCAD.ActiveDocument.removeObject(self.toolrep.Name)
+        FreeCAD.ActiveDocument.recompute()
+
+    def getFields(self):
+        self.editor.updateToolController()
+        self.obj.Proxy.execute(self.obj)
+
+    def setFields(self):
+        self.editor.updateUi()
+
         tool = self.obj.Tool
-        editform = FreeCADGui.PySideUic.loadUi(":/panels/ToolEdit.ui")
+        radius = tool.Diameter / 2
+        length = tool.CuttingEdgeHeight
+        t = Part.makeCylinder(radius, length)
+        self.toolrep.Shape = t
 
-        editform.NameField.setText(tool.Name)
-        editform.TypeField.setCurrentIndex(self.getType(tool.ToolType))
-        editform.MaterialField.setCurrentIndex(self.getMaterial(tool.Material))
-        editform.DiameterField.setText(FreeCAD.Units.Quantity(tool.Diameter, FreeCAD.Units.Length).UserString)
-        editform.LengthOffsetField.setText(FreeCAD.Units.Quantity(tool.LengthOffset, FreeCAD.Units.Length).UserString)
-        editform.FlatRadiusField.setText(FreeCAD.Units.Quantity(tool.FlatRadius, FreeCAD.Units.Length).UserString)
-        editform.CornerRadiusField.setText(FreeCAD.Units.Quantity(tool.CornerRadius, FreeCAD.Units.Length).UserString)
-        editform.CuttingEdgeAngleField.setText(FreeCAD.Units.Quantity(tool.CuttingEdgeAngle, FreeCAD.Units.Angle).UserString)
-        editform.CuttingEdgeHeightField.setText(FreeCAD.Units.Quantity(tool.CuttingEdgeHeight, FreeCAD.Units.Length).UserString)
+    def getStandardButtons(self):
+        return int(QtGui.QDialogButtonBox.Ok)
 
-        r = editform.exec_()
-        if r:
-            if editform.NameField.text():
-                tool.Name = str(editform.NameField.text()) #FIXME: not unicode safe!
-            tool.ToolType = self.getType(editform.TypeField.currentIndex())
-            tool.Material = self.getMaterial(editform.MaterialField.currentIndex())
-            tool.Diameter = FreeCAD.Units.parseQuantity(editform.DiameterField.text())
-            tool.LengthOffset = FreeCAD.Units.parseQuantity(editform.LengthOffsetField.text())
-            tool.FlatRadius = FreeCAD.Units.parseQuantity(editform.FlatRadiusField.text())
-            tool.CornerRadius = FreeCAD.Units.parseQuantity(editform.CornerRadiusField.text())
-            tool.CuttingEdgeAngle = FreeCAD.Units.Quantity(editform.CuttingEdgeAngleField.text())
-            tool.CuttingEdgeHeight = FreeCAD.Units.parseQuantity(editform.CuttingEdgeHeightField.text())
-            self.obj.Tool = tool
-            self.setFields()
+    def edit(self, item, column):
+        if not self.updating:
+            self.resetObject()
+
+    def resetObject(self, remove=None):
+        "transfers the values from the widget to the object"
+        FreeCAD.ActiveDocument.recompute()
+
+    def setupUi(self):
+        t = Part.makeCylinder(1, 1)
+        self.toolrep = FreeCAD.ActiveDocument.addObject("Part::Feature", "tool")
+        self.toolrep.Shape = t
+
+        self.setFields()
+        self.editor.setupUi()
 
 
-
-class SelObserver:
-    def __init__(self):
-        pass
-
-    def __del__(self):
-        pass
 
 if FreeCAD.GuiUp:
     # register the FreeCAD command

--- a/src/Mod/Path/PathScripts/PathToolController.py
+++ b/src/Mod/Path/PathScripts/PathToolController.py
@@ -150,7 +150,7 @@ class ToolController:
         return obj.Tool
 
 
-class _ViewProviderToolController:
+class ViewProvider:
 
     def __init__(self, vobj):
         vobj.Proxy = self
@@ -203,6 +203,37 @@ class _ViewProviderToolController:
         # this is executed when the user cancels or terminates edit mode
         return False
 
+def Create(name = 'Default Tool', tool=None, toolNumber=1, assignViewProvider=True):
+    PathLog.track(tool, toolNumber)
+
+    obj = FreeCAD.ActiveDocument.addObject("Path::FeaturePython", name)
+    ToolController(obj)
+    if assignViewProvider:
+        ViewProvider(obj.ViewObject)
+
+    if tool is None:
+        tool = Path.Tool()
+        tool.Diameter = 5.0
+        tool.Name = "Default Tool"
+        tool.CuttingEdgeHeight = 15.0
+        tool.ToolType = "EndMill"
+        tool.Material = "HighSpeedSteel"
+    obj.Tool = tool
+    obj.ToolNumber = toolNumber
+    return obj
+
+def FromTemplate(template, assignViewProvider=True):
+    PathLog.track()
+
+    obj = FreeCAD.ActiveDocument.addObject("Path::FeaturePython", template.get(ToolControllerTemplate.Label))
+    tc  = ToolController(obj)
+    if assignViewProvider:
+        ViewProvider(obj.ViewObject)
+
+    tc.assignTemplate(obj, template)
+
+    return obj
+
 
 class CommandPathToolController:
     def GetResources(self):
@@ -219,41 +250,7 @@ class CommandPathToolController:
 
     def Activated(self):
         PathLog.track()
-        self.Create()
-
-    @staticmethod
-    def Create(assignViewProvider=True, tool=None, toolNumber=1):
-        PathLog.track("tool: {} with toolNumber: {}".format(tool, toolNumber))
-
-        obj = FreeCAD.ActiveDocument.addObject("Path::FeaturePython", "Default Tool")
-        PathScripts.PathToolController.ToolController(obj)
-        if FreeCAD.GuiUp and assignViewProvider:
-            PathScripts.PathToolController._ViewProviderToolController(obj.ViewObject)
-
-        if tool is None:
-            tool = Path.Tool()
-            tool.Diameter = 5.0
-            tool.Name = "Default Tool"
-            tool.CuttingEdgeHeight = 15.0
-            tool.ToolType = "EndMill"
-            tool.Material = "HighSpeedSteel"
-        obj.Tool = tool
-        obj.ToolNumber = toolNumber
-        return obj
-
-    @staticmethod
-    def FromTemplate(template, assignViewProvider=True):
-        PathLog.track()
-
-        obj = FreeCAD.ActiveDocument.addObject("Path::FeaturePython", template.get(ToolControllerTemplate.Label))
-        tc  = PathScripts.PathToolController.ToolController(obj)
-        if assignViewProvider:
-            PathScripts.PathToolController._ViewProviderToolController(obj.ViewObject)
-
-        tc.assignTemplate(obj, template)
-
-        return obj
-
+        Create()
 
 class TaskPanel:
     def __init__(self):

--- a/src/Mod/Path/PathScripts/PathToolController.py
+++ b/src/Mod/Path/PathScripts/PathToolController.py
@@ -35,7 +35,7 @@ import xml.etree.ElementTree as xml
 from FreeCAD import Units
 from PySide import QtCore, QtGui
 
-if False:
+if True:
     PathLog.setLevel(PathLog.Level.DEBUG, PathLog.thisModule())
     PathLog.trackModule(PathLog.thisModule())
 else:
@@ -78,6 +78,7 @@ class ToolController:
 
     def assignTemplate(self, obj, template):
         '''assignTemplate(obj, xmlItem) ... extract properties from xmlItem and assign to receiver.'''
+        PathLog.track(obj.Label, template)
         if template.get(ToolControllerTemplate.VertFeed):
             obj.VertFeed = template.get(ToolControllerTemplate.VertFeed)
         if template.get(ToolControllerTemplate.HorizFeed):
@@ -135,12 +136,13 @@ class ToolController:
         PathLog.track('prop: {}  state: {}'.format(prop, obj.State))
 
         if 'Path' == prop and 'Restore' not in obj.State:
-            PathLog.debug("--- dirty deeds")
-            job = PathScripts.PathUtils.findParentJob(obj)
-            if job is not None:
-                for g in job.Group:
-                    if not(isinstance(g.Proxy, PathScripts.PathToolController.ToolController)):
-                        g.touch()
+            PathLog.warning('Markus you gotta do something about TC changes')
+        #    PathLog.debug("--- dirty deeds")
+        #    job = PathScripts.PathUtils.findParentJob(obj)
+        #    if job is not None:
+        #        for g in job.Group:
+        #            if not(isinstance(g.Proxy, PathScripts.PathToolController.ToolController)):
+        #                g.touch()
 
     def getTool(self, obj):
         '''returns the tool associated with this tool controller'''
@@ -219,19 +221,8 @@ class CommandPathToolController:
         PathLog.track()
         self.Create()
 
-#         FreeCAD.ActiveDocument.openTransaction(translate("Path_ToolController", "Create Tool Controller Object"))
-
-#         obj = FreeCAD.ActiveDocument.addObject("Path::FeaturePython", "TC")
-#         PathScripts.PathToolController.ToolController(obj)
-#         PathScripts.PathToolController._ViewProviderToolController(obj.ViewObject)
-
-#         PathUtils.addToJob(obj)
-
-#         FreeCAD.ActiveDocument.commitTransaction()
-#         FreeCAD.ActiveDocument.recompute()
-
     @staticmethod
-    def Create(jobname=None, assignViewProvider=True, tool=None, toolNumber=1):
+    def Create(assignViewProvider=True, tool=None, toolNumber=1):
         PathLog.track("tool: {} with toolNumber: {}".format(tool, toolNumber))
 
         obj = FreeCAD.ActiveDocument.addObject("Path::FeaturePython", "Default Tool")
@@ -248,10 +239,10 @@ class CommandPathToolController:
             tool.Material = "HighSpeedSteel"
         obj.Tool = tool
         obj.ToolNumber = toolNumber
-        PathScripts.PathUtils.addToJob(obj, jobname)
+        return obj
 
     @staticmethod
-    def FromTemplate(job, template, assignViewProvider=True):
+    def FromTemplate(template, assignViewProvider=True):
         PathLog.track()
 
         obj = FreeCAD.ActiveDocument.addObject("Path::FeaturePython", template.get(ToolControllerTemplate.Label))
@@ -261,7 +252,7 @@ class CommandPathToolController:
 
         tc.assignTemplate(obj, template)
 
-        PathScripts.PathUtils.addToJob(obj, job.Name)
+        return obj
 
 
 class TaskPanel:

--- a/src/Mod/Path/PathScripts/PathToolController.py
+++ b/src/Mod/Path/PathScripts/PathToolController.py
@@ -176,7 +176,7 @@ class ViewProvider:
         return None
 
     def getIcon(self):
-        return ":/icons/Path-LengthOffset.svg"
+        return ":/icons/Path-ToolController.svg"
 
     def onChanged(self, vobj, prop):
         mode = 2

--- a/src/Mod/Path/PathScripts/PathToolController.py
+++ b/src/Mod/Path/PathScripts/PathToolController.py
@@ -208,7 +208,7 @@ def Create(name = 'Default Tool', tool=None, toolNumber=1, assignViewProvider=Tr
 
     obj = FreeCAD.ActiveDocument.addObject("Path::FeaturePython", name)
     ToolController(obj)
-    if assignViewProvider:
+    if FreeCAD.GuiUp and assignViewProvider:
         ViewProvider(obj.ViewObject)
 
     if tool is None:
@@ -227,7 +227,7 @@ def FromTemplate(template, assignViewProvider=True):
 
     obj = FreeCAD.ActiveDocument.addObject("Path::FeaturePython", template.get(ToolControllerTemplate.Label))
     tc  = ToolController(obj)
-    if assignViewProvider:
+    if FreeCAD.GuiUp and assignViewProvider:
         ViewProvider(obj.ViewObject)
 
     tc.assignTemplate(obj, template)

--- a/src/Mod/Path/PathScripts/PathToolController.py
+++ b/src/Mod/Path/PathScripts/PathToolController.py
@@ -210,6 +210,7 @@ def Create(name = 'Default Tool', tool=None, toolNumber=1, assignViewProvider=Tr
     PathLog.track(tool, toolNumber)
 
     obj = FreeCAD.ActiveDocument.addObject("Path::FeaturePython", name)
+    obj.Label = name
     ToolController(obj)
     if FreeCAD.GuiUp and assignViewProvider:
         ViewProvider(obj.ViewObject)

--- a/src/Mod/Path/PathScripts/PathToolLibraryManager.py
+++ b/src/Mod/Path/PathScripts/PathToolLibraryManager.py
@@ -159,7 +159,7 @@ class ToolLibraryManager():
         # Get ToolTables from any open CNC jobs
         for o in FreeCAD.ActiveDocument.Objects:
             if hasattr(o, "Proxy"):
-                if isinstance(o.Proxy, PathScripts.PathJob.ObjectPathJob):
+                if isinstance(o.Proxy, PathScripts.PathJob.ObjectJob):
                     tablelist.append(o.Label)
         return tablelist
 
@@ -546,7 +546,7 @@ class EditorPanel():
             tool = self.TLM.getTool(currList, int(toolnum))
             PathLog.debug('tool: {}, toolnum: {}'.format(tool, toolnum))
             for job in FreeCAD.ActiveDocument.findObjects("Path::Feature"):
-                if isinstance(job.Proxy, PathScripts.PathJob.ObjectPathJob) and job.Label == targetlist:
+                if isinstance(job.Proxy, PathScripts.PathJob.ObjectJob) and job.Label == targetlist:
 
                     label = "T{}: {}".format(toolnum, tool.Name)
                     obj = FreeCAD.ActiveDocument.addObject("Path::FeaturePython",label)

--- a/src/Mod/Path/PathScripts/PathUtil.py
+++ b/src/Mod/Path/PathScripts/PathUtil.py
@@ -37,9 +37,9 @@ import PathScripts.PathLog as PathLog
 PathLog.setLevel(PathLog.Level.INFO, PathLog.thisModule())
 
 NotValidBaseTypeIds = ['Sketcher::SketchObject']
-def isValidBaseObject(obj):
-    '''isSolid(obj) ... returns true if an object represents a solid.'''
 
+def isValidBaseObject(obj):
+    '''isValidBaseObject(obj) ... returns true if the object can be used as a base for a job.'''
     if not hasattr(obj, 'Shape'):
         return False
     if obj.TypeId in NotValidBaseTypeIds:
@@ -48,9 +48,23 @@ def isValidBaseObject(obj):
         return False
     return True
 
+def isSolid(obj):
+    '''isSolid(obj) ... return True if the object is a valid solid.'''
+    if hasattr(obj, 'Tip'):
+        return isSolid(obj.Tip)
+    if hasattr(obj, 'Shape'):
+        if obj.Shape.ShapeType == 'Solid' and obj.Shape.isClosed():
+            return True
+        if obj.Shape.ShapeType == 'Compound':
+            if hasattr(obj, 'Base') and hasattr(obj, 'Tool'):
+                return isSolid(obj.Base) and isSolid(obj.Tool)
+    return False
+
 def toolControllerForOp(op):
     if hasattr(op, 'ToolController'):
         return op.ToolController
     if hasattr(op, 'Base'):
         return toolControllerForOp(op.Base)
     return None
+
+

--- a/src/Mod/Path/PathScripts/PathUtils.py
+++ b/src/Mod/Path/PathScripts/PathUtils.py
@@ -355,18 +355,14 @@ def changeTool(obj, job):
 
 def getToolControllers(obj):
     '''returns all the tool controllers'''
-    controllers = []
     try:
-        parent = findParentJob(obj)
+        job = findParentJob(obj)
     except:
-        parent = None
+        job = None
 
-    if parent is not None and hasattr(parent, 'Group'):
-        sibs = parent.Group
-        for g in sibs:
-            if isinstance(g.Proxy, PathScripts.PathToolController.ToolController):
-                controllers.append(g)
-    return controllers
+    if job:
+        return job.ToolController
+    return []
 
 
 def findToolController(obj, name=None):
@@ -417,7 +413,7 @@ def findParentJob(obj):
     '''retrieves a parent job object for an operation or other Path object'''
     PathLog.track()
     for i in obj.InList:
-        if isinstance(i.Proxy, PathScripts.PathJob.ObjectPathJob):
+        if isinstance(i.Proxy, PathScripts.PathJob.ObjectJob):
             return i
         if i.TypeId == "Path::FeaturePython" or i.TypeId == "Path::FeatureCompoundPython":
             grandParent = findParentJob(i)
@@ -431,32 +427,13 @@ def GetJobs(jobname=None):
     PathLog.track()
     jobs = []
     for o in FreeCAD.ActiveDocument.Objects:
-        if "Proxy" in o.PropertiesList:
-            if isinstance(o.Proxy, PathJob.ObjectPathJob):
-                if jobname is not None:
-                    if o.Name == jobname:
-                        jobs.append(o)
-                else:
+        if hasattr(o, 'Proxy') and isinstance(o.Proxy, PathJob.ObjectJob):
+            if jobname is not None:
+                if o.Name == jobname:
                     jobs.append(o)
+            else:
+                jobs.append(o)
     return jobs
-
-def addObjectToJob(obj, job):
-    '''
-    addObjectToJob(obj, job) ... adds object to given job.
-    '''
-    g = job.Group
-    g.append(obj)
-    job.Group = g
-    return job
-
-def addObjectToJob(obj, job):
-    '''
-    addObjectToJob(obj, job) ... adds object to given job.
-    '''
-    g = job.Group
-    g.append(obj)
-    job.Group = g
-    return job
 
 def addToJob(obj, jobname=None):
     '''adds a path object to a job
@@ -490,7 +467,7 @@ def addToJob(obj, jobname=None):
                 job = [i for i in jobs if i.Label == form.cboProject.currentText()][0]
 
     if obj:
-        addObjectToJob(obj, job)
+        job.Proxy.addOperation(obj)
     return job
 
 def rapid(x=None, y=None, z=None):

--- a/src/Mod/Path/PathScripts/post/centroid_post.py
+++ b/src/Mod/Path/PathScripts/post/centroid_post.py
@@ -153,7 +153,7 @@ def export(objectslist, filename, argstring):
     global UNITS
     global UNIT_FORMAT
 
-    # ISJOB = (len(objectslist) == 1) and isinstance(objectslist[0].Proxy, PathScripts.PathJob.ObjectPathJob)
+    # ISJOB = (len(objectslist) == 1) and isinstance(objectslist[0].Proxy, PathScripts.PathJob.ObjectJob)
     # print("isjob: {} {}".format(ISJOB, len(objectslist)))
 
     # if len(objectslist) > 1:

--- a/src/Mod/Path/PathTests/PathTestUtils.py
+++ b/src/Mod/Path/PathTests/PathTestUtils.py
@@ -43,6 +43,12 @@ class PathTestBase(unittest.TestCase):
         self.assertRoughly(pt1.y, pt2.y)
         self.assertRoughly(pt1.z, pt2.z)
 
+    def assertPlacement(self, p1, p2):
+        """Verify that two placements are roughly identical."""
+        self.assertCoincide(p1.Base, p2.Base)
+        self.assertCoincide(p1.Rotation.Axis, p2.Rotation.Axis)
+        self.assertRoughly(p1.Rotation.Angle, p2.Rotation.Angle)
+
     def assertLine(self, edge, pt1, pt2):
         """Verify that edge is a line from pt1 to pt2."""
         # Depending on the setting of LineOld ....

--- a/src/Mod/Path/PathTests/TestPathDressupDogbone.py
+++ b/src/Mod/Path/PathTests/TestPathDressupDogbone.py
@@ -112,8 +112,7 @@ class TestDressupDogbone(PathTestBase):
             if f.Surface.Axis == FreeCAD.Vector(0,0,1) and f.Orientation == 'Forward':
                 break
 
-        job = doc.addObject("Path::FeatureCompoundPython", "Job")
-        PathJob.ObjectPathJob(job, cut, None)
+        job = PathJob.Create('Job', cut, None)
 
         profile = PathProfileFaces.Create('Profile Faces')
         profile.Base = (cut, face)

--- a/src/Mod/Path/PathTests/TestPathStock.py
+++ b/src/Mod/Path/PathTests/TestPathStock.py
@@ -1,0 +1,206 @@
+# -*- coding: utf-8 -*-
+
+# ***************************************************************************
+# *                                                                         *
+# *   Copyright (c) 2017 sliptonic <shopinthewoods@gmail.com>               *
+# *                                                                         *
+# *   This program is free software; you can redistribute it and/or modify  *
+# *   it under the terms of the GNU Lesser General Public License (LGPL)    *
+# *   as published by the Free Software Foundation; either version 2 of     *
+# *   the License, or (at your option) any later version.                   *
+# *   for detail see the LICENCE text file.                                 *
+# *                                                                         *
+# *   This program is distributed in the hope that it will be useful,       *
+# *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+# *   GNU Library General Public License for more details.                  *
+# *                                                                         *
+# *   You should have received a copy of the GNU Library General Public     *
+# *   License along with this program; if not, write to the Free Software   *
+# *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
+# *   USA                                                                   *
+# *                                                                         *
+# ***************************************************************************
+
+import FreeCAD
+import Part
+import Path
+import PathScripts.PathStock as PathStock
+
+from PathTests.PathTestUtils import PathTestBase
+
+class FakeJobProxy:
+    def baseObject(self, obj):
+        return obj.Base
+
+R = 223.606798
+
+
+class TestPathStock(PathTestBase):
+
+    def setUp(self):
+        self.doc = FreeCAD.newDocument("TestPathStock")
+        self.base = self.doc.addObject('Part::Box', 'Box')
+        self.base.Length = 100
+        self.base.Width  = 200
+        self.base.Height = 300
+        self.job = self.doc.addObject('App::FeaturePython', 'Job')
+        self.job.addProperty('App::PropertyLink', 'Base')
+        self.job.Base = self.base
+        self.job.addProperty('App::PropertyLink', 'Proxy')
+        self.job.Proxy = FakeJobProxy()
+
+    def tearDown(self):
+        FreeCAD.closeDocument("TestPathStock")
+
+    def test00(self):
+        '''Test CreateBox'''
+
+        stock = PathStock.CreateBox(self.job)
+        self.assertTrue(hasattr(stock, 'Length'))
+        self.assertTrue(hasattr(stock, 'Width'))
+        self.assertTrue(hasattr(stock, 'Height'))
+        self.assertEqual(100, stock.Length)
+        self.assertEqual(200, stock.Width)
+        self.assertEqual(300, stock.Height)
+
+        extent = FreeCAD.Vector(17, 13, 77)
+        stock = PathStock.CreateBox(self.job, extent)
+        self.assertEqual(17, stock.Length)
+        self.assertEqual(13, stock.Width)
+        self.assertEqual(77, stock.Height)
+
+        placement = FreeCAD.Placement(FreeCAD.Vector(-3, 88, 4), FreeCAD.Vector(0, 0, 1), 180)
+        stock = PathStock.CreateBox(self.job, extent, placement)
+        self.assertEqual(17, stock.Length)
+        self.assertEqual(13, stock.Width)
+        self.assertEqual(77, stock.Height)
+        self.assertPlacement(placement, stock.Placement)
+
+    def test01(self):
+        '''Test CreateCylinder'''
+
+        stock = PathStock.CreateCylinder(self.job)
+        self.assertTrue(hasattr(stock, 'Radius'))
+        self.assertTrue(hasattr(stock, 'Height'))
+        self.assertRoughly(R, stock.Radius.Value)
+        self.assertEqual(300, stock.Height)
+
+        stock = PathStock.CreateCylinder(self.job, 37, 24)
+        self.assertEqual(37, stock.Radius)
+        self.assertEqual(24, stock.Height)
+
+        placement = FreeCAD.Placement(FreeCAD.Vector(3, 8, -4), FreeCAD.Vector(0, 0, 1), -90)
+        stock = PathStock.CreateCylinder(self.job, 1, 88, placement)
+        self.assertEqual(1, stock.Radius)
+        self.assertEqual(88, stock.Height)
+        self.assertPlacement(placement, stock.Placement)
+
+
+    def test10(self):
+        '''Verify FromTemplate box creation.'''
+
+        extent = FreeCAD.Vector(17, 13, 77)
+        placement = FreeCAD.Placement(FreeCAD.Vector(3, 8, -4), FreeCAD.Vector(0, 0, 1), -90)
+        orig = PathStock.CreateBox(self.job, extent, placement)
+
+        # collect full template
+        template = PathStock.TemplateAttributes(orig)
+        stock = PathStock.CreateFromTemplate(self.job, template)
+
+        self.assertEqual(PathStock.StockType.CreateBox, PathStock.StockType.FromStock(stock))
+        self.assertEqual(orig.Length, stock.Length)
+        self.assertEqual(orig.Width,  stock.Width)
+        self.assertEqual(orig.Height, stock.Height)
+        self.assertPlacement(orig.Placement, stock.Placement)
+
+        # don't store extent in template
+        template = PathStock.TemplateAttributes(orig, False, True)
+        stock = PathStock.CreateFromTemplate(self.job, template)
+
+        self.assertEqual(PathStock.StockType.CreateBox, PathStock.StockType.FromStock(stock))
+        self.assertEqual(100, stock.Length)
+        self.assertEqual(200,  stock.Width)
+        self.assertEqual(300, stock.Height)
+        self.assertPlacement(orig.Placement, stock.Placement)
+
+        # don't store placement in template
+        template = PathStock.TemplateAttributes(orig, True, False)
+        stock = PathStock.CreateFromTemplate(self.job, template)
+
+        self.assertEqual(PathStock.StockType.CreateBox, PathStock.StockType.FromStock(stock))
+        self.assertEqual(orig.Length, stock.Length)
+        self.assertEqual(orig.Width,  stock.Width)
+        self.assertEqual(orig.Height, stock.Height)
+        self.assertPlacement(FreeCAD.Placement(), stock.Placement)
+
+    def test11(self):
+        '''Verify FromTemplate cylinder creation.'''
+        radius = 7
+        height = 12
+        placement = FreeCAD.Placement(FreeCAD.Vector(99, 88, 77), FreeCAD.Vector(1, 1, 1), 123)
+        orig = PathStock.CreateCylinder(self.job, radius, height, placement)
+
+        # full template
+        template = PathStock.TemplateAttributes(orig)
+        stock = PathStock.CreateFromTemplate(self.job, template)
+
+        self.assertEqual(PathStock.StockType.CreateCylinder, PathStock.StockType.FromStock(stock))
+        self.assertEqual(orig.Radius, stock.Radius)
+        self.assertEqual(orig.Height, stock.Height)
+        self.assertPlacement(orig.Placement, stock.Placement)
+
+        # no extent in template
+        template = PathStock.TemplateAttributes(orig, False, True)
+        stock = PathStock.CreateFromTemplate(self.job, template)
+
+        self.assertEqual(PathStock.StockType.CreateCylinder, PathStock.StockType.FromStock(stock))
+        self.assertRoughly(R, stock.Radius.Value)
+        self.assertEqual(300, stock.Height)
+        self.assertPlacement(orig.Placement, stock.Placement)
+
+        # no placement template - and no base
+        template = PathStock.TemplateAttributes(orig, True, False)
+        stock = PathStock.CreateFromTemplate(None, template)
+
+        self.assertEqual(PathStock.StockType.CreateCylinder, PathStock.StockType.FromStock(stock))
+        self.assertEqual(orig.Radius, stock.Radius)
+        self.assertEqual(orig.Height, stock.Height)
+        self.assertPlacement(FreeCAD.Placement(), stock.Placement)
+
+        # no placement template - but base
+        template = PathStock.TemplateAttributes(orig, True, False)
+        stock = PathStock.CreateFromTemplate(self.job, template)
+
+        self.assertEqual(PathStock.StockType.CreateCylinder, PathStock.StockType.FromStock(stock))
+        self.assertEqual(orig.Radius, stock.Radius)
+        self.assertEqual(orig.Height, stock.Height)
+        self.assertPlacement(FreeCAD.Placement(FreeCAD.Vector(50, 100, 0), FreeCAD.Rotation()), stock.Placement)
+
+    def test12(self):
+        '''Verify FromTemplate from Base creation.'''
+        neg = FreeCAD.Vector(1,2,3)
+        pos = FreeCAD.Vector(9,8,7)
+        orig = PathStock.CreateFromBase(self.job, neg, pos)
+
+        # Make sure we have a different base object for the creation
+        self.base.Length = 11
+        self.base.Width  = 12
+        self.base.Height = 13
+
+        # full template
+        template = PathStock.TemplateAttributes(orig)
+        stock = PathStock.CreateFromTemplate(self.job, template)
+        self.assertEqual(PathStock.StockType.FromBase, PathStock.StockType.FromStock(stock))
+        self.assertEqual(orig.ExtXneg, stock.ExtXneg)
+        self.assertEqual(orig.ExtXpos, stock.ExtXpos)
+        self.assertEqual(orig.ExtYneg, stock.ExtYneg)
+        self.assertEqual(orig.ExtYpos, stock.ExtYpos)
+        self.assertEqual(orig.ExtZneg, stock.ExtZneg)
+        self.assertEqual(orig.ExtZpos, stock.ExtZpos)
+
+        bb = stock.Shape.BoundBox
+        self.assertEqual(neg.x + pos.x + 11, bb.XLength)
+        self.assertEqual(neg.y + pos.y + 12, bb.YLength)
+        self.assertEqual(neg.z + pos.z + 13, bb.ZLength)
+

--- a/src/Mod/Path/PathTests/TestPathStock.py
+++ b/src/Mod/Path/PathTests/TestPathStock.py
@@ -33,7 +33,7 @@ class FakeJobProxy:
     def baseObject(self, obj):
         return obj.Base
 
-R = 223.606798
+R = 223.606798 / 2
 
 
 class TestPathStock(PathTestBase):

--- a/src/Mod/Path/TestPathApp.py
+++ b/src/Mod/Path/TestPathApp.py
@@ -32,4 +32,4 @@ from PathTests.TestPathUtil  import TestPathUtil
 from PathTests.TestPathDepthParams        import depthTestCases
 from PathTests.TestPathDressupHoldingTags import TestHoldingTags
 from PathTests.TestPathDressupDogbone import TestDressupDogbone
-
+from PathTests.TestPathStock import TestPathStock


### PR DESCRIPTION
Adds the first support for Base object alignment and Stock to PathJob.

Job references the Base object through a clone, allowing independent placement for machining, and different placements for the same Base object in different jobs. Creates a stock object from different sources and provides tools for simple placement of stock and base object.

New TaskPanel for Job that should make it easier to edit a Job and get to a valid output that can be processed by a machine.

JobTemplate also has support for stock allowing the definition of a standard machine setup minimizing design placement and thickness mistakes (not that any of those ever happened to me...)