### PR TITLE
Path: Bugfix/assert on op cancel

### DIFF
--- a/src/Mod/Path/PathScripts/PathJob.py
+++ b/src/Mod/Path/PathScripts/PathJob.py
@@ -234,14 +234,15 @@ class ObjectJob:
     def allOperations(self):
         ops = []
         def collectBaseOps(op):
-            if op.TypeId == 'Path::FeaturePython':
-                ops.append(op)
-                if hasattr(op, 'Base'):
-                    collectBaseOps(op.Base)
-            if op.TypeId == 'Path::FeatureCompoundPython':
-                ops.append(op)
-                for sub in op.Group:
-                    collectBaseOps(sub)
+            if hasattr(op, 'TypeId'):
+                if op.TypeId == 'Path::FeaturePython':
+                    ops.append(op)
+                    if hasattr(op, 'Base'):
+                        collectBaseOps(op.Base)
+                if op.TypeId == 'Path::FeatureCompoundPython':
+                    ops.append(op)
+                    for sub in op.Group:
+                        collectBaseOps(sub)
         for op in self.obj.Operations.Group:
             collectBaseOps(op)
         return ops

--- a/src/Mod/Path/PathScripts/PathJobGui.py
+++ b/src/Mod/Path/PathScripts/PathJobGui.py
@@ -478,8 +478,6 @@ class TaskPanel:
             if self.obj.ViewObject.Proxy.onDelete(self.obj.ViewObject, None):
                 FreeCAD.ActiveDocument.removeObject(self.obj.Name)
             FreeCAD.ActiveDocument.commitTransaction()
-        else:
-            PathLog.info("don't uncreate Job")
         self.cleanup(resetEdit)
         return True
 

--- a/src/Mod/Path/PathScripts/PathJobGui.py
+++ b/src/Mod/Path/PathScripts/PathJobGui.py
@@ -69,6 +69,7 @@ class ViewProvider:
         vobj.setEditorMode('Selectable', mode)
         vobj.setEditorMode('ShapeColor', mode)
         vobj.setEditorMode('Transparency', mode)
+        self.deleteOnReject = True
 
     def attach(self, vobj):
         self.vobj = vobj
@@ -458,6 +459,7 @@ class TaskPanel:
             self.baseObjectRestoreVisibility(self.obj)
         if self.obj.Stock and self.obj.Stock.ViewObject:
             self.obj.Stock.ViewObject.Visibility = self.stockVisibility
+        self.vobj.Proxy.resetTaskPanel()
 
     def accept(self, resetEdit=True):
         PathLog.track()
@@ -473,14 +475,16 @@ class TaskPanel:
         if self.deleteOnReject:
             PathLog.info("Uncreate Job")
             FreeCAD.ActiveDocument.openTransaction(translate("Path_Job", "Uncreate Job"))
-            FreeCAD.ActiveDocument.removeObject(self.obj.Name)
+            if self.obj.ViewObject.Proxy.onDelete(self.obj.ViewObject, None):
+                FreeCAD.ActiveDocument.removeObject(self.obj.Name)
             FreeCAD.ActiveDocument.commitTransaction()
+        else:
+            PathLog.info("don't uncreate Job")
         self.cleanup(resetEdit)
         return True
 
     def cleanup(self, resetEdit):
         PathLog.track()
-        self.vobj.Proxy.resetTaskPanel()
         FreeCADGui.Control.closeDialog()
         if resetEdit:
             FreeCADGui.ActiveDocument.resetEdit()

--- a/src/Mod/Path/PathScripts/PathOpGui.py
+++ b/src/Mod/Path/PathScripts/PathOpGui.py
@@ -721,10 +721,10 @@ class TaskPanel(object):
     def preCleanup(self):
         FreeCADGui.Selection.removeObserver(self)
         FreeCADGui.Selection.removeObserver(self.s)
+        self.obj.ViewObject.Proxy.clearTaskPanel()
 
     def cleanup(self, resetEdit):
         '''cleanup() ... implements common cleanup tasks.'''
-        self.obj.ViewObject.Proxy.clearTaskPanel()
         FreeCADGui.Control.closeDialog()
         if resetEdit:
             FreeCADGui.ActiveDocument.resetEdit()


### PR DESCRIPTION
cleanup internal state before removing object from document. Also fixed cancelling a job creation to remove the job and all dependent objects again.