### PR TITLE
add MaxDegree setting to Part.Loft

### DIFF
--- a/src/Mod/Part/App/AppPartPy.cpp
+++ b/src/Mod/Part/App/AppPartPy.cpp
@@ -363,7 +363,7 @@ public:
             "makeSweepSurface(edge(path),edge(profile),[float]) -- Create a profile along a path."
         );
         add_varargs_method("makeLoft",&Module::makeLoft,
-            "makeLoft(list of wires,[solid=False,ruled=False,closed=False]) -- Create a loft shape."
+            "makeLoft(list of wires,[solid=False,ruled=False,closed=False,maxDegree=5]) -- Create a loft shape."
         );
         add_varargs_method("makeWireString",&Module::makeWireString,
             "makeWireString(string,fontdir,fontfile,height,[track]) -- Make list of wires in the form of a string's characters."
@@ -1517,10 +1517,12 @@ private:
         PyObject *psolid=Py_False;
         PyObject *pruled=Py_False;
         PyObject *pclosed=Py_False;
-        if (!PyArg_ParseTuple(args.ptr(), "O|O!O!O!", &pcObj,
+        int degMax = 5;
+        if (!PyArg_ParseTuple(args.ptr(), "O|O!O!O!i", &pcObj,
                                               &(PyBool_Type), &psolid,
                                               &(PyBool_Type), &pruled,
-                                              &(PyBool_Type), &pclosed)) {
+                                              &(PyBool_Type), &pclosed,
+                                              &degMax)) {
             throw Py::Exception();
         }
 
@@ -1539,7 +1541,7 @@ private:
         Standard_Boolean anIsSolid = PyObject_IsTrue(psolid) ? Standard_True : Standard_False;
         Standard_Boolean anIsRuled = PyObject_IsTrue(pruled) ? Standard_True : Standard_False;
         Standard_Boolean anIsClosed = PyObject_IsTrue(pclosed) ? Standard_True : Standard_False;
-        TopoDS_Shape aResult = myShape.makeLoft(profiles, anIsSolid, anIsRuled,anIsClosed);
+        TopoDS_Shape aResult = myShape.makeLoft(profiles, anIsSolid, anIsRuled, anIsClosed, degMax);
         return Py::asObject(new TopoShapePy(new TopoShape(aResult)));
 #endif
     }

--- a/src/Mod/Part/App/PartFeatures.cpp
+++ b/src/Mod/Part/App/PartFeatures.cpp
@@ -265,6 +265,7 @@ Loft::Loft()
     ADD_PROPERTY_TYPE(Solid,(false),"Loft",App::Prop_None,"Create solid");
     ADD_PROPERTY_TYPE(Ruled,(false),"Loft",App::Prop_None,"Ruled surface");
     ADD_PROPERTY_TYPE(Closed,(false),"Loft",App::Prop_None,"Close Last to First Profile");
+    ADD_PROPERTY_TYPE(MaxDegree,(5),"Loft",App::Prop_None,"Maximum Degree");
 }
 
 short Loft::mustExecute() const
@@ -276,6 +277,8 @@ short Loft::mustExecute() const
     if (Ruled.isTouched())
         return 1;
     if (Closed.isTouched())
+        return 1;
+    if (MaxDegree.isTouched())
         return 1;
     return 0;
 }
@@ -334,9 +337,10 @@ App::DocumentObjectExecReturn *Loft::execute(void)
         Standard_Boolean isSolid = Solid.getValue() ? Standard_True : Standard_False;
         Standard_Boolean isRuled = Ruled.getValue() ? Standard_True : Standard_False;
         Standard_Boolean isClosed = Closed.getValue() ? Standard_True : Standard_False;
+        int degMax = MaxDegree.getValue();
 
         TopoShape myShape;
-        this->Shape.setValue(myShape.makeLoft(profiles, isSolid, isRuled,isClosed));
+        this->Shape.setValue(myShape.makeLoft(profiles, isSolid, isRuled, isClosed, degMax));
         return App::DocumentObject::StdReturn;
     }
     catch (Standard_Failure& e) {

--- a/src/Mod/Part/App/PartFeatures.h
+++ b/src/Mod/Part/App/PartFeatures.h
@@ -73,6 +73,7 @@ public:
     App::PropertyBool Solid;
     App::PropertyBool Ruled;
     App::PropertyBool Closed;
+    App::PropertyInteger MaxDegree;
 
     /** @name methods override feature */
     //@{

--- a/src/Mod/Part/App/TopoShape.cpp
+++ b/src/Mod/Part/App/TopoShape.cpp
@@ -2089,10 +2089,12 @@ TopoDS_Shape TopoShape::makeThread(Standard_Real pitch,
 TopoDS_Shape TopoShape::makeLoft(const TopTools_ListOfShape& profiles, 
                                  Standard_Boolean isSolid,
                                  Standard_Boolean isRuled,
-                                 Standard_Boolean isClosed) const
+                                 Standard_Boolean isClosed,
+                                 Standard_Integer MaxDegree) const
 {
     // http://opencascade.blogspot.com/2010/01/surface-modeling-part5.html
     BRepOffsetAPI_ThruSections aGenerator (isSolid,isRuled);
+    aGenerator.SetMaxDegree(MaxDegree);
 
     TopTools_ListIteratorOfListOfShape it;
     int countShapes = 0;

--- a/src/Mod/Part/App/TopoShape.h
+++ b/src/Mod/Part/App/TopoShape.h
@@ -208,7 +208,7 @@ public:
     TopoDS_Shape makeThread(Standard_Real pitch, Standard_Real depth,
         Standard_Real height, Standard_Real radius) const;
     TopoDS_Shape makeLoft(const TopTools_ListOfShape& profiles, Standard_Boolean isSolid,
-        Standard_Boolean isRuled, Standard_Boolean isClosed = Standard_False) const;
+        Standard_Boolean isRuled, Standard_Boolean isClosed = Standard_False, Standard_Integer MaxDegree = 5) const;
     TopoDS_Shape makeOffsetShape(double offset, double tol,
         bool intersection = false, bool selfInter = false,
         short offsetMode = 0, short join = 0, bool fill = false) const;


### PR DESCRIPTION
Adds a MaxDegree setting to Part.Loft.
This can help in cases where a high degree leads to wrong surface.
Here is an [example](https://forum.freecadweb.org/viewtopic.php?f=3&t=23771)
The loft operation resulted in a self-intersecting surface of v-degree 6.
Setting the maxDegree to 5 or lower results in a good surface.
There is no control on the Min or Max value of the property.


Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR once it is merged.

---
