### PR TITLE
Path: Bugfix/path pocket cleanup

### DIFF
--- a/src/Mod/Path/PathScripts/PathAreaOp.py
+++ b/src/Mod/Path/PathScripts/PathAreaOp.py
@@ -104,7 +104,7 @@ class ObjectOp(PathOp.ObjectOp):
 
         if PathOp.FeatureBaseGeometry & self.opFeatures(obj):
             if prop == 'Base' and len(obj.Base) == 1:
-                PathLog.info("opOnChanged(%s, %s)" % (obj.Label, prop))
+                PathLog.debug("opOnChanged(%s, %s)" % (obj.Label, prop))
                 try:
                     (base, sub) = obj.Base[0]
                     bb = base.Shape.BoundBox  # parent boundbox
@@ -146,7 +146,7 @@ class ObjectOp(PathOp.ObjectOp):
         The base implementation sets the depths and heights based on the
         areaOpShapeForDepths() return value.
         Do not overwrite, overwrite areaOpSetDefaultValues(obj) instead.'''
-        PathLog.info("opSetDefaultValues(%s)" % (obj.Label))
+        PathLog.debug("opSetDefaultValues(%s)" % (obj.Label))
         if PathOp.FeatureDepths & self.opFeatures(obj):
             try:
                 shape = self.areaOpShapeForDepths(obj)

--- a/src/Mod/Path/PathScripts/PathOp.py
+++ b/src/Mod/Path/PathScripts/PathOp.py
@@ -51,6 +51,7 @@ FeatureHeights      = 0x0004     # ClearanceHeight, SafeHeight
 FeatureStartPoint   = 0x0008     # StartPoint
 FeatureFinishDepth  = 0x0010     # FinishDepth
 FeatureStepDown     = 0x0020     # StepDown
+FeatureNoFinalDepth = 0x0040     # edit or not edit FinalDepth
 FeatureBaseVertexes = 0x0100     # Base
 FeatureBaseEdges    = 0x0200     # Base
 FeatureBaseFaces    = 0x0400     # Base
@@ -75,6 +76,7 @@ class ObjectOp(object):
         FeatureStartPoint    ... Supports setting a start point
         FeatureFinishDepth   ... Operation supports a finish depth
         FeatureStepDown      ... Support for step down
+        FeatureNoFinalDepth  ... Disable support for final depth modifications
         FeatureBaseVertexes  ... Base geometry support for vertexes
         FeatureBaseEdges     ... Base geometry support for edges
         FeatureBaseFaces     ... Base geometry support for faces
@@ -113,6 +115,8 @@ class ObjectOp(object):
         if FeatureDepths & features:
             obj.addProperty("App::PropertyDistance", "StartDepth", "Depth", QtCore.QT_TRANSLATE_NOOP("App::Property", "Starting Depth of Tool- first cut depth in Z"))
             obj.addProperty("App::PropertyDistance", "FinalDepth", "Depth", QtCore.QT_TRANSLATE_NOOP("App::Property", "Final Depth of Tool- lowest value in Z"))
+            if FeatureNoFinalDepth & features:
+                obj.setEditorMode('FinalDepth', 2) # hide
 
         if FeatureStepDown & features:
             obj.addProperty("App::PropertyDistance", "StepDown", "Depth", QtCore.QT_TRANSLATE_NOOP("App::Property", "Incremental Step Down of Tool"))

--- a/src/Mod/Path/PathScripts/PathOpGui.py
+++ b/src/Mod/Path/PathScripts/PathOpGui.py
@@ -544,6 +544,11 @@ class TaskPanelDepthsPage(TaskPanelPage):
     def getForm(self):
         return FreeCADGui.PySideUic.loadUi(":/panels/PageDepthsEdit.ui")
     def initPage(self, obj):
+        if PathOp.FeatureNoFinalDepth & self.features:
+            self.form.finalDepth.hide()
+            self.form.finalDepthLabel.hide()
+            self.form.finalDepthSet.hide()
+
         if not PathOp.FeatureStepDown & self.features:
             self.form.stepDown.hide()
             self.form.stepDownLabel.hide()
@@ -555,14 +560,16 @@ class TaskPanelDepthsPage(TaskPanelPage):
         return translate("PathOp", "Depths")
     def getFields(self, obj):
         self.updateInputField(obj, 'StartDepth', self.form.startDepth)
-        self.updateInputField(obj, 'FinalDepth', self.form.finalDepth)
+        if not PathOp.FeatureNoFinalDepth & self.features:
+            self.updateInputField(obj, 'FinalDepth', self.form.finalDepth)
         if PathOp.FeatureStepDown & self.features:
             self.updateInputField(obj, 'StepDown', self.form.stepDown)
         if PathOp.FeatureFinishDepth & self.features:
             self.updateInputField(obj, 'FinishDepth', self.form.finishDepth)
     def setFields(self, obj):
         self.form.startDepth.setText(FreeCAD.Units.Quantity(obj.StartDepth.Value, FreeCAD.Units.Length).UserString)
-        self.form.finalDepth.setText(FreeCAD.Units.Quantity(obj.FinalDepth.Value, FreeCAD.Units.Length).UserString)
+        if not PathOp.FeatureNoFinalDepth & self.features:
+            self.form.finalDepth.setText(FreeCAD.Units.Quantity(obj.FinalDepth.Value, FreeCAD.Units.Length).UserString)
         if PathOp.FeatureStepDown & self.features:
             self.form.stepDown.setText(FreeCAD.Units.Quantity(obj.StepDown.Value, FreeCAD.Units.Length).UserString)
         if PathOp.FeatureFinishDepth & self.features:
@@ -571,7 +578,8 @@ class TaskPanelDepthsPage(TaskPanelPage):
     def getSignalsForUpdate(self, obj):
         signals = []
         signals.append(self.form.startDepth.editingFinished)
-        signals.append(self.form.finalDepth.editingFinished)
+        if not PathOp.FeatureNoFinalDepth & self.features:
+            signals.append(self.form.finalDepth.editingFinished)
         if PathOp.FeatureStepDown & self.features:
             signals.append(self.form.stepDown.editingFinished)
         if PathOp.FeatureFinishDepth & self.features:
@@ -579,7 +587,8 @@ class TaskPanelDepthsPage(TaskPanelPage):
         return signals
     def registerSignalHandlers(self, obj):
         self.form.startDepthSet.clicked.connect(lambda: self.depthSet(obj, self.form.startDepth))
-        self.form.finalDepthSet.clicked.connect(lambda: self.depthSet(obj, self.form.finalDepth))
+        if not PathOp.FeatureNoFinalDepth & self.features:
+            self.form.finalDepthSet.clicked.connect(lambda: self.depthSet(obj, self.form.finalDepth))
     def pageUpdateData(self, obj, prop):
         if prop in ['StartDepth', 'FinalDepth', 'StepDown', 'FinishDepth']:
             self.setFields(obj)
@@ -592,6 +601,7 @@ class TaskPanelDepthsPage(TaskPanelPage):
             self.getFields(obj)
         else:
             PathLog.info("depthSet(-)")
+
     def selectionZLevel(self, sel):
         if len(sel) == 1 and len(sel[0].SubObjects) == 1:
             sub = sel[0].SubObjects[0]

--- a/src/Mod/Path/PathScripts/PathPocketBase.py
+++ b/src/Mod/Path/PathScripts/PathPocketBase.py
@@ -48,7 +48,10 @@ class ObjectPocket(PathAreaOp.ObjectOp):
 
     def areaOpFeatures(self, obj):
         '''areaOpFeatures(obj) ... Pockets have a FinishDepth and work on Faces'''
-        return PathOp.FeatureBaseFaces | PathOp.FeatureFinishDepth
+        return PathOp.FeatureBaseFaces | PathOp.FeatureFinishDepth | self.pocketOpFeatures(obj)
+
+    def pocketOpFeatures(self, obj):
+        return 0
 
     def initAreaOp(self, obj):
         '''initAreaOp(obj) ... create pocket specific properties.

--- a/src/Mod/Path/PathScripts/PathPocketBaseGui.py
+++ b/src/Mod/Path/PathScripts/PathPocketBaseGui.py
@@ -60,11 +60,12 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
         '''getForm() ... returns UI, adapted to the resutls from pocketFeatures()'''
         form = FreeCADGui.PySideUic.loadUi(":/panels/PageOpPocketFullEdit.ui")
 
-        if FeatureFacing & self.pocketFeatures():
+        if not FeatureFacing & self.pocketFeatures():
+            form.facingWidget.hide()
+
+        if FeaturePocket & self.pocketFeatures():
             form.extraOffsetLabel.setText(translate("PathPocket", "Pass Extension"))
             form.extraOffset.setToolTip(translate("PathPocket", "The distance the facing operation will extend beyond the boundary shape."))
-        else:
-            form.facingWidget.hide()
 
         if True:
             # currently doesn't have an effect


### PR DESCRIPTION
Fixes tessellation issue for some removal shapes.
Correctly calculates FinalDepth and hides it from user (is not settable by user)