### PR TITLE
TD Bug Fixes

### DIFF
--- a/src/Mod/TechDraw/Gui/DrawGuiUtil.cpp
+++ b/src/Mod/TechDraw/Gui/DrawGuiUtil.cpp
@@ -32,6 +32,7 @@
 # include <QStringList>
 # include <QRegExp>
 # include <QMessageBox>
+#include <QRectF>
 
 #endif
 
@@ -140,4 +141,22 @@ bool DrawGuiUtil::needView(Gui::Command* cmd, bool partOnly)
         }
     }
     return haveView;
+}
+
+void DrawGuiUtil::dumpRectF(const char* text, const QRectF& r)
+{
+    Base::Console().Message("DUMP - dumpRectF - %s\n",text);
+    double left = r.left();
+    double right = r.right();
+    double top = r.top();
+    double bottom = r.bottom();
+    Base::Console().Message("Extents: L: %.3f, R: %.3f, T: %.3f, B: %.3f\n",left,right,top,bottom);
+    Base::Console().Message("Size: W: %.3f H: %.3f\n",r.width(),r.height());
+    Base::Console().Message("Centre: (%.3f, %.3f)\n",r.center().x(),r.center().y());
+}
+
+void DrawGuiUtil::dumpPointF(const char* text, const QPointF& p)
+{
+    Base::Console().Message("DUMP - dumpPointF - %s\n",text);
+    Base::Console().Message("Point: (%.3f, %.3f)\n",p.x(),p.y());
 }

--- a/src/Mod/TechDraw/Gui/DrawGuiUtil.h
+++ b/src/Mod/TechDraw/Gui/DrawGuiUtil.h
@@ -24,6 +24,15 @@
 #define _DrawGuiUtil_h_
 
 #include <string>
+#include <QRectF>
+#include <QPointF>
+
+namespace TechDraw {
+class DrawPage;
+}
+namespace Gui {
+class Command;
+}
 
 namespace TechDrawGui
 {
@@ -34,6 +43,8 @@ class TechDrawGuiExport DrawGuiUtil {
     static TechDraw::DrawPage* findPage(Gui::Command* cmd);
     static bool needPage(Gui::Command* cmd);
     static bool needView(Gui::Command* cmd, bool partOnly = true);
+    static void dumpRectF(const char* text, const QRectF& r);
+    static void dumpPointF(const char* text, const QPointF& p);
 };
 
 } //end namespace TechDrawGui

--- a/src/Mod/TechDraw/Gui/MDIViewPage.cpp
+++ b/src/Mod/TechDraw/Gui/MDIViewPage.cpp
@@ -385,7 +385,7 @@ void MDIViewPage::updateDrawing(bool forceUpdate)
 
     // if dv doesn't have a graphic, make one
     for (auto& dv: pChildren) {
-        if (dv->isDeleting()) {
+        if (dv->isRemoving()) {
             continue;
         }
         QGIView* qv = m_view->findQViewForDocObj(dv);
@@ -1063,7 +1063,7 @@ void MDIViewPage::selectionChanged()
             }
         } else {
             TechDraw::DrawView *viewObj = itemView->getViewObject();
-            if (viewObj && !viewObj->isDeleting()) {
+            if (viewObj && !viewObj->isRemoving()) {
                 std::string doc_name = viewObj->getDocument()->getName();
                 std::string obj_name = viewObj->getNameInDocument();
 

--- a/src/Mod/TechDraw/Gui/MDIViewPage.cpp
+++ b/src/Mod/TechDraw/Gui/MDIViewPage.cpp
@@ -385,6 +385,9 @@ void MDIViewPage::updateDrawing(bool forceUpdate)
 
     // if dv doesn't have a graphic, make one
     for (auto& dv: pChildren) {
+        if (dv->isDeleting()) {
+            continue;
+        }
         QGIView* qv = m_view->findQViewForDocObj(dv);
         if (qv == nullptr) {
             attachView(dv);
@@ -1059,19 +1062,17 @@ void MDIViewPage::selectionChanged()
                 static_cast<void> (Gui::Selection().addSelection(dimObj->getDocument()->getName(),dimObj->getNameInDocument()));
             }
         } else {
-
             TechDraw::DrawView *viewObj = itemView->getViewObject();
+            if (viewObj && !viewObj->isDeleting()) {
+                std::string doc_name = viewObj->getDocument()->getName();
+                std::string obj_name = viewObj->getNameInDocument();
 
-            std::string doc_name = viewObj->getDocument()->getName();
-            std::string obj_name = viewObj->getNameInDocument();
-
-            Gui::Selection().addSelection(doc_name.c_str(), obj_name.c_str());
-            showStatusMsg(doc_name.c_str(),
-                          obj_name.c_str(),
-                          "");
-
+                Gui::Selection().addSelection(doc_name.c_str(), obj_name.c_str());
+                showStatusMsg(doc_name.c_str(),
+                              obj_name.c_str(),
+                              "");
+            }
         }
-
     }
 
     blockConnection(saveBlock);

--- a/src/Mod/TechDraw/Gui/QGCustomSvg.cpp
+++ b/src/Mod/TechDraw/Gui/QGCustomSvg.cpp
@@ -51,26 +51,17 @@ QGCustomSvg::~QGCustomSvg()
 
 void QGCustomSvg::centerAt(QPointF centerPos)
 {
-    if (group()) { 
-        QRectF box = group()->boundingRect();
-        double width = box.width();
-        double height = box.height();
-        double newX = centerPos.x() - width/2.;
-        double newY = centerPos.y() - height/2.;
-        setPos(newX,newY);
-    }
+    centerAt(centerPos.x(),centerPos.y());
 }
 
 void QGCustomSvg::centerAt(double cX, double cY)
 {
-    if (group()) {
-        QRectF box = group()->boundingRect();
-        double width = box.width();
-        double height = box.height();
-        double newX = cX - width/2.;
-        double newY = cY - height/2.;
-        setPos(newX,newY);
-    }
+    QRectF box = boundingRect();
+    double width = box.width();
+    double height = box.height();
+    double newX = (cX - width/2.) * scale();
+    double newY = (cY - height/2.) * scale();
+    setPos(newX,newY);
 }
 
 bool QGCustomSvg::load(QByteArray *svgBytes)
@@ -87,12 +78,14 @@ QRectF QGCustomSvg::boundingRect() const
     double w = box.width();
     double h = box.height();
     QRectF newRect(0,0,w,h);
-    return newRect.adjusted(-1.,-1.,1.,1.);
+    return newRect;
 }
 
 void QGCustomSvg::paint ( QPainter * painter, const QStyleOptionGraphicsItem * option, QWidget * widget) {
     QStyleOptionGraphicsItem myOption(*option);
     myOption.state &= ~QStyle::State_Selected;
+
+    //painter->drawRect(boundingRect());          //good for debugging
 
     QGraphicsSvgItem::paint (painter, &myOption, widget);
 }

--- a/src/Mod/TechDraw/Gui/QGIView.cpp
+++ b/src/Mod/TechDraw/Gui/QGIView.cpp
@@ -376,6 +376,8 @@ void QGIView::drawBorder()
     double labelWidth = m_label->boundingRect().width();
     double labelHeight = (1 - labelCaptionFudge) * m_label->boundingRect().height();
 
+    QBrush b(Qt::NoBrush);
+    m_border->setBrush(b);
     m_decorPen.setColor(m_colCurrent);
     m_border->setPen(m_decorPen);
 

--- a/src/Mod/TechDraw/Gui/QGIViewSymbol.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewSymbol.cpp
@@ -107,9 +107,7 @@ void QGIViewSymbol::draw()
     }
 
     drawSvg();
-    if (borderVisible) {
-        drawBorder();
-    }
+    QGIView::draw();
 }
 
 void QGIViewSymbol::drawSvg()

--- a/src/Mod/TechDraw/Gui/ViewProviderViewSection.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderViewSection.cpp
@@ -68,7 +68,7 @@ ViewProviderViewSection::~ViewProviderViewSection()
 void ViewProviderViewSection::attach(App::DocumentObject *pcFeat)
 {
     // call parent attach method
-    ViewProviderDocumentObject::attach(pcFeat);
+    ViewProviderViewPart::attach(pcFeat);
 }
 
 void ViewProviderViewSection::setDisplayMode(const char* ModeName)


### PR DESCRIPTION
Some fixes to irritating issues.  Please merge.

Thanks,
wf

    Change 5d6b03eff to use isRemoving
    - DocumentObject::isDeleting was renamed to
      DocumentObject::isRemoving

    Fix Symbol fail to paint
    - calls ViewProviderDocumentObject, but should call
      ViewProviderViewPart in order to receive repaint
      signals.

    Fix crash due to QGraphicsScene update while View.isDeleting()

    Make View backgrounds transparent
    - makes it easier to stack views

    Fix Symbol based View positioning
    - Symbol uses TopLeft corner as position, should be center
      of view

    Add debug utils for QRectF/QPointF

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR once it is merged.

---
