### PR TITLE
Attacher UX enhancements

### DIFF
--- a/src/App/PropertyStandard.cpp
+++ b/src/App/PropertyStandard.cpp
@@ -295,7 +295,7 @@ TYPESYSTEM_SOURCE(App::PropertyEnumeration, App::PropertyInteger);
 
 PropertyEnumeration::PropertyEnumeration()
 {
-
+    _editorTypeName = "Gui::PropertyEditor::PropertyEnumItem";
 }
 
 PropertyEnumeration::PropertyEnumeration(const App::Enumeration &e)

--- a/src/App/PropertyStandard.h
+++ b/src/App/PropertyStandard.h
@@ -187,7 +187,8 @@ public:
     const char ** getEnums(void) const;
     //@}
 
-    virtual const char * getEditorName(void) const { return "Gui::PropertyEditor::PropertyEnumItem"; }
+    const char* getEditorName(void) const { return _editorTypeName.c_str(); }
+    void setEditorName(const char* name) { _editorTypeName = name; } 
     
     virtual PyObject * getPyObject(void);
     virtual void setPyObject(PyObject *);
@@ -203,6 +204,7 @@ public:
 
 private:
     Enumeration _enum;
+    std::string _editorTypeName;
 };
 
 /** Constraint integer properties

--- a/src/Gui/Widgets.cpp
+++ b/src/Gui/Widgets.cpp
@@ -870,6 +870,7 @@ LabelButton::LabelButton (QWidget * parent)
     layout->addWidget(button);
 
     connect(button, SIGNAL(clicked()), this, SLOT(browse()));
+    connect(button, SIGNAL(clicked()), this, SIGNAL(buttonClicked()));
 }
 
 LabelButton::~LabelButton()
@@ -901,6 +902,15 @@ void LabelButton::setValue(const QVariant& val)
     _val = val;
     showValue(_val);
     valueChanged(_val);
+}
+
+void LabelButton::showValue(const QVariant& data)
+{
+    label->setText(data.toString());
+}
+
+void LabelButton::browse()
+{
 }
 
 // ----------------------------------------------------------------------

--- a/src/Gui/Widgets.h
+++ b/src/Gui/Widgets.h
@@ -298,14 +298,15 @@ public Q_SLOTS:
     void setValue(const QVariant&);
 
 protected:
-    virtual void showValue(const QVariant&) = 0;
+    virtual void showValue(const QVariant& data);
     void resizeEvent(QResizeEvent*);
 
 protected Q_SLOTS:
-    virtual void browse() = 0;
+    virtual void browse();
 
 Q_SIGNALS:
     void valueChanged(const QVariant &);
+    void buttonClicked();
 
 private:
     QLabel *label;

--- a/src/Mod/Part/App/AttachExtension.cpp
+++ b/src/Mod/Part/App/AttachExtension.cpp
@@ -48,6 +48,7 @@ AttachExtension::AttachExtension()
     EXTENSION_ADD_PROPERTY_TYPE(Support, (0,0), "Attachment",(App::PropertyType)(App::Prop_None),"Support of the 2D geometry");
 
     EXTENSION_ADD_PROPERTY_TYPE(MapMode, (mmDeactivated), "Attachment", App::Prop_None, "Mode of attachment to other object");
+    MapMode.setEditorName("PartGui::PropertyEnumAttacherItem");
     MapMode.setEnums(AttachEngine::eMapModeStrings);
     //a rough test if mode string list in Attacher.cpp is in sync with eMapMode enum.
     assert(MapMode.getEnumVector().size() == mmDummy_NumberOfModes);
@@ -57,6 +58,11 @@ AttachExtension::AttachExtension()
     EXTENSION_ADD_PROPERTY_TYPE(MapPathParameter, (0.0), "Attachment", App::Prop_None, "Sets point of curve to map the sketch to. 0..1 = start..end");
 
     EXTENSION_ADD_PROPERTY_TYPE(superPlacement, (Base::Placement()), "Attachment", App::Prop_None, "Extra placement to apply in addition to attachment (in local coordinates)");
+
+    // Only show these properties when applicable. Controlled by extensionOnChanged
+    this->MapPathParameter.setStatus(App::Property::Status::Hidden, true);
+    this->MapReversed.setStatus(App::Property::Status::Hidden, true);
+    this->superPlacement.setStatus(App::Property::Status::Hidden, true);
 
     setAttacher(new AttachEngine3D);//default attacher
     initExtensionType(AttachExtension::getExtensionClassTypeId());
@@ -172,8 +178,23 @@ void AttachExtension::extensionOnChanged(const App::Property* prop)
                 Base::Console().Error("PositionBySupport: %s",e.GetMessageString());
             }
 
+            // Hide properties when not applicable to reduce user confusion
+
             eMapMode mmode = eMapMode(this->MapMode.getValue());
-            this->superPlacement.setReadOnly(!bAttached);
+
+            bool modeIsPointOnCurve = mmode == mmNormalToPath ||
+                mmode == mmFrenetNB || mmode == mmFrenetTN || mmode == mmFrenetTB ||
+                mmode == mmRevolutionSection || mmode == mmConcentric;
+
+            // MapPathParameter is only used if there is a reference to one edge and not edge + vertex
+            bool hasOneRef = false;
+            if (_attacher && _attacher->references.getSubValues().size() == 1) {
+                hasOneRef = true;
+            }
+
+            this->MapPathParameter.setStatus(App::Property::Status::Hidden, !bAttached || !(modeIsPointOnCurve && hasOneRef));
+            this->MapReversed.setStatus(App::Property::Status::Hidden, !bAttached);
+            this->superPlacement.setStatus(App::Property::Status::Hidden, !bAttached);
             getPlacement().setReadOnly(bAttached && mmode != mmTranslate); //for mmTranslate, orientation should remain editable even when attached.
         }
 

--- a/src/Mod/Part/AttachmentEditor/TaskAttachmentEditor.py
+++ b/src/Mod/Part/AttachmentEditor/TaskAttachmentEditor.py
@@ -472,8 +472,11 @@ class AttachmentEditorTaskPanel(FrozenClass):
             list_widget = self.form.listOfModes
             list_widget.clear()
             sugr = self.last_sugr
+            # always have the option to choose Deactivated mode
+            valid_modes = ['Deactivated'] + sugr['allApplicableModes']
+            
             # add valid modes
-            for m in sugr['allApplicableModes']:
+            for m in valid_modes:
                 item = QtGui.QListWidgetItem()
                 txt = self.attacher.getModeInfo(m)['UserFriendlyName']
                 item.setText(txt)
@@ -521,8 +524,11 @@ class AttachmentEditorTaskPanel(FrozenClass):
                 for refstr in mi['ReferenceCombinations']:
                     refstr_userfriendly = [self.attacher.getRefTypeInfo(t)['UserFriendlyName'] for t in refstr]
                     cmb.append(u", ".join(refstr_userfriendly))
-                tip = _translate('AttachmentEditor',"{docu}\n\nReference combinations:\n{combinations}",None).format(docu=mi['BriefDocu'], combinations= u"\n".join(cmb) )
-
+                
+                tip = mi['BriefDocu']
+                if (m != 'Deactivated'):
+                    tip += _translate('AttachmentEditor', "\n\nReference combinations:\n", None) + u"\n".join(cmb)
+                
                 item.setToolTip(tip)
 
         finally:
@@ -587,8 +593,10 @@ class AttachmentEditorTaskPanel(FrozenClass):
         
         if new_plm is not None:
             self.form.groupBox_superplacement.setTitle(_translate('AttachmentEditor',"Extra placement:",None))
+            self.form.groupBox_superplacement.setEnabled(True)
         else:
             self.form.groupBox_superplacement.setTitle(_translate('AttachmentEditor',"Extra placement (inactive - not attached):",None))
+            self.form.groupBox_superplacement.setEnabled(False)
 
     def cleanUp(self):
         '''stuff that needs to be done when dialog is closed.'''

--- a/src/Mod/Part/Gui/AppPartGui.cpp
+++ b/src/Mod/Part/Gui/AppPartGui.cpp
@@ -29,6 +29,7 @@
 #include <Mod/Part/App/PropertyTopoShape.h>
 
 #include "AttacherTexts.h"
+#include "PropertyEnumAttacherItem.h"
 #include "SoBrepFaceSet.h"
 #include "SoBrepEdgeSet.h"
 #include "SoBrepPointSet.h"
@@ -139,6 +140,7 @@ PyMOD_INIT_FUNC(PartGui)
     Py_INCREF(pAttachEngineTextsModule);
     PyModule_AddObject(partGuiModule, "AttachEngineResources", pAttachEngineTextsModule);
 
+    PartGui::PropertyEnumAttacherItem       ::init();
     PartGui::SoBrepFaceSet                  ::initClass();
     PartGui::SoBrepEdgeSet                  ::initClass();
     PartGui::SoBrepPointSet                 ::initClass();

--- a/src/Mod/Part/Gui/AttacherTexts.cpp
+++ b/src/Mod/Part/Gui/AttacherTexts.cpp
@@ -48,7 +48,7 @@ TextSet getUIStrings(Base::Type attacherType, eMapMode mmode)
         switch (mmode){
         case mmDeactivated:
             return TwoStrings(qApp->translate("Attacher3D", "Deactivated","Attachment3D mode caption"),
-                              qApp->translate("Attacher3D", "Attachment is disabled. CS can be moved by editing Placement property.","Attachment3D mode tooltip"));
+                              qApp->translate("Attacher3D", "Attachment is disabled. Object can be moved by editing Placement property.","Attachment3D mode tooltip"));
         case mmTranslate:
             return TwoStrings(qApp->translate("Attacher3D", "Translate origin","Attachment3D mode caption"),
                               qApp->translate("Attacher3D", "Origin is aligned to match Vertex. Orientation is controlled by Placement property.","Attachment3D mode tooltip"));
@@ -123,7 +123,7 @@ TextSet getUIStrings(Base::Type attacherType, eMapMode mmode)
         switch (mmode){
         case mmDeactivated:
             return TwoStrings(qApp->translate("Attacher2D", "Deactivated","AttachmentPlane mode caption"),
-                              qApp->translate("Attacher2D", "Attachment is disabled. Plane can be moved by editing Placement property.","AttachmentPlane mode tooltip"));
+                              qApp->translate("Attacher2D", "Attachment is disabled. Object can be moved by editing Placement property.","AttachmentPlane mode tooltip"));
         case mmTranslate:
             return TwoStrings(qApp->translate("Attacher2D", "Translate origin","AttachmentPlane mode caption"),
                               qApp->translate("Attacher2D", "Origin is aligned to match Vertex. Orientation is controlled by Placement property.","AttachmentPlane mode tooltip"));

--- a/src/Mod/Part/Gui/CMakeLists.txt
+++ b/src/Mod/Part/Gui/CMakeLists.txt
@@ -53,6 +53,7 @@ set(PartGui_MOC_HDRS
     DlgSettings3DViewPartImp.h
     DlgSettingsGeneral.h
     DlgSettingsObjectColor.h
+    PropertyEnumAttacherItem.h
     TaskFaceColors.h
     TaskShapeBuilder.h
     TaskLoft.h
@@ -161,6 +162,8 @@ SET(PartGui_SRCS
     Resources/Part.qrc
     PreCompiled.cpp
     PreCompiled.h
+    PropertyEnumAttacherItem.cpp
+    PropertyEnumAttacherItem.h
     SoFCShapeObject.cpp
     SoFCShapeObject.h
     SoBrepEdgeSet.cpp

--- a/src/Mod/Part/Gui/PropertyEnumAttacherItem.cpp
+++ b/src/Mod/Part/Gui/PropertyEnumAttacherItem.cpp
@@ -1,0 +1,94 @@
+/***************************************************************************
+ *   Copyright (c) 2017 Peter Lama (peterldev94@gmail.com)                 *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+
+#include "PreCompiled.h"
+
+#include <Gui/Application.h>
+#include <Gui/Control.h>
+#include <Gui/ViewProviderDocumentObject.h>
+
+#include "PropertyEnumAttacherItem.h"
+
+using namespace PartGui;
+
+PROPERTYITEM_SOURCE(PartGui::PropertyEnumAttacherItem)
+
+PropertyEnumAttacherItem::PropertyEnumAttacherItem()
+{
+}
+
+QWidget* PropertyEnumAttacherItem::createEditor(QWidget* parent, const QObject* receiver, const char* method) const
+{
+    Gui::LabelButton* modeEditor = new Gui::LabelButton(parent);
+    QObject::connect(modeEditor, SIGNAL(valueChanged(const QVariant &)), receiver, method);
+    QObject::connect(modeEditor, SIGNAL(buttonClicked()), this, SLOT(openTask()));
+    modeEditor->setDisabled(isReadOnly());
+    return modeEditor;
+}
+
+void PropertyEnumAttacherItem::setEditorData(QWidget *editor, const QVariant& data) const
+{
+    Gui::LabelButton* modeEditor = qobject_cast<Gui::LabelButton*>(editor);
+    modeEditor->setValue(data);
+}
+
+QVariant PropertyEnumAttacherItem::editorData(QWidget *editor) const
+{
+    Gui::LabelButton* modeEditor = qobject_cast<Gui::LabelButton*>(editor);
+    return modeEditor->value();
+}
+
+void PropertyEnumAttacherItem::openTask()
+{
+    Gui::TaskView::TaskDialog* dlg = Gui::Control().activeDialog();
+    TaskDlgAttacher* task;
+    task = qobject_cast<TaskDlgAttacher*>(dlg);
+
+    if (dlg && !task) {
+        // there is already another task dialog which must be closed first
+        Gui::Control().showDialog(dlg);
+        return;
+    }
+    if (!task) {
+        const App::Property* prop = getFirstProperty();
+        if (prop) {
+            App::PropertyContainer* parent = prop->getContainer();
+
+            if (parent->getTypeId().isDerivedFrom(App::DocumentObject::getClassTypeId())) {
+                App::DocumentObject* obj = static_cast<App::DocumentObject*>(parent);
+                Gui::ViewProvider* view = Gui::Application::Instance->getViewProvider(obj);
+
+                if (view->getTypeId().isDerivedFrom(Gui::ViewProviderDocumentObject::getClassTypeId())) {
+                    task = new TaskDlgAttacher(static_cast<Gui::ViewProviderDocumentObject*>(view));
+                }
+            }
+        }
+        if (!task) {
+            return;
+        }
+    }
+    
+    Gui::Control().showDialog(task);
+}
+
+#include "moc_PropertyEnumAttacherItem.cpp"

--- a/src/Mod/Part/Gui/PropertyEnumAttacherItem.h
+++ b/src/Mod/Part/Gui/PropertyEnumAttacherItem.h
@@ -1,0 +1,56 @@
+/***************************************************************************
+ *   Copyright (c) 2017 Peter Lama (peterldev94@gmail.com)                 *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+
+#ifndef PART_PropertyEnumAttacherItem_H
+#define PART_PropertyEnumAttacherItem_H
+
+#include <Gui/propertyeditor/PropertyItem.h>
+#include "TaskAttacher.h"
+
+namespace PartGui
+{
+
+/**
+* Custom editor item for PropertyEnumeration to open Attacher task
+*/
+class PartGuiExport PropertyEnumAttacherItem: public Gui::PropertyEditor::PropertyEnumItem
+{
+    Q_OBJECT
+
+public:
+    PROPERTYITEM_HEADER
+
+    virtual QWidget* createEditor(QWidget* parent, const QObject* receiver, const char* method) const;
+    virtual void setEditorData(QWidget* editor, const QVariant& data) const;
+    virtual QVariant editorData(QWidget* editor) const;
+
+protected Q_SLOTS:
+    void openTask();
+
+protected:
+    PropertyEnumAttacherItem();
+};
+
+} // namespace PartGui
+
+#endif // PART_PropertyEnumAttacherItem_H

--- a/src/Mod/Part/Gui/TaskAttacher.h
+++ b/src/Mod/Part/Gui/TaskAttacher.h
@@ -108,12 +108,14 @@ private:
 
     /**
      * @brief updateListOfModes Fills the mode list with modes that apply to
-     * current set of references.
-     * @param curMode the mode to select in the list. If the mode isn't
-     * contained in the list, nothing is selected. If mmDeactivated is passed,
-     * currently selected mode is kept.
+     * current set of references. Maintains selection when possible.
      */
-    void updateListOfModes(Attacher::eMapMode curMode = Attacher::mmDeactivated);
+    void updateListOfModes();
+    
+    /**
+     * @brief selectMapMode Select the given mode in the list widget
+     */
+    void selectMapMode(Attacher::eMapMode mmode);
 
 protected:
     Gui::ViewProviderDocumentObject *ViewProvider;


### PR DESCRIPTION
- New editor for MapMode with button to open attacher dialog
- Fix superPlacement being disabled after first change
- Disable MapPathParameter and MapReversed properties when they don't apply
- Disable super placement ui in attacher dialog when mode is deactivated
- Always select used mode in mode list

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR once it is merged.

---
