### PR TITLE
PATH: change external file formats to JSON 

### DIFF
--- a/src/Mod/Path/App/ToolPy.xml
+++ b/src/Mod/Path/App/ToolPy.xml
@@ -86,9 +86,9 @@ HighCarbonToolSteel CastAlloy, Ceramics, Diamond, Sialon or Undefined</UserDocu>
                 <UserDocu>returns a copy of this tool</UserDocu>
             </Documentation>
         </Methode>
-        <Methode Name="fromTemplate">
+        <Methode Name="setFromTemplate">
             <Documentation>
-                <UserDocu>fromTemplate(xmlString|dictionary) ... fills receiver with values from the template string or dictionary</UserDocu>
+                <UserDocu>setFromTemplate(xmlString|dictionary) ... fills receiver with values from the template string or dictionary</UserDocu>
             </Documentation>
         </Methode>
         <Methode Name="templateAttrs">

--- a/src/Mod/Path/App/ToolPy.xml
+++ b/src/Mod/Path/App/ToolPy.xml
@@ -88,7 +88,12 @@ HighCarbonToolSteel CastAlloy, Ceramics, Diamond, Sialon or Undefined</UserDocu>
         </Methode>
         <Methode Name="fromTemplate">
             <Documentation>
-                <UserDocu>fromTemplate(xmlString) ... fills receiver with values from the template string</UserDocu>
+                <UserDocu>fromTemplate(xmlString|dictionary) ... fills receiver with values from the template string or dictionary</UserDocu>
+            </Documentation>
+        </Methode>
+        <Methode Name="templateAttrs">
+            <Documentation>
+                <UserDocu>templateAttrs() ... returns a dictionary with all attributes</UserDocu>
             </Documentation>
         </Methode>
         <!--<ClassDeclarations>

--- a/src/Mod/Path/App/Tooltable.cpp
+++ b/src/Mod/Path/App/Tooltable.cpp
@@ -89,52 +89,10 @@ void Tool::Save (Writer &writer) const
                     << "flat=\"" <<  FlatRadius << "\" "
                     << "corner=\"" << CornerRadius << "\" "
                     << "angle=\"" << CuttingEdgeAngle << "\" "
-                    << "height=\"" << CuttingEdgeHeight << "\" ";
-                    
-    if(Type == Tool::ENDMILL)
-        writer.Stream() << " type=\"EndMill\" ";
-    else if(Type == Tool::DRILL)
-        writer.Stream() << " type=\"Drill\" ";
-    else if(Type == Tool::CENTERDRILL)
-        writer.Stream() << " type=\"CenterDrill\" ";
-    else if(Type == Tool::COUNTERSINK)
-        writer.Stream() << " type=\"CounterSink\" ";
-    else if(Type == Tool::COUNTERBORE)
-        writer.Stream() << " type=\"CounterBore\" ";
-    else if(Type == Tool::REAMER)
-        writer.Stream() << " type=\"Reamer\" ";
-    else if(Type == Tool::TAP)
-        writer.Stream() << " type=\"Tap\" ";
-    else if(Type == Tool::SLOTCUTTER)
-        writer.Stream() << " type=\"SlotCutter\" ";
-    else if(Type == Tool::BALLENDMILL)
-        writer.Stream() << " type=\"BallEndMill\" ";
-    else if(Type == Tool::CHAMFERMILL)
-        writer.Stream() << " type=\"ChamferMill\" ";
-    else if(Type == Tool::CORNERROUND)
-        writer.Stream() << " type=\"CornerRound\" ";
-    else if(Type == Tool::ENGRAVER)
-        writer.Stream() << " type=\"Engraver\" ";
-    else
-        writer.Stream() << " type=\"Undefined\" ";
-        
-    if(Material == Tool::CARBIDE)
-        writer.Stream() << " mat=\"Carbide\" /> ";
-    else if(Material == Tool::HIGHSPEEDSTEEL)
-        writer.Stream() << " mat=\"HighSpeedSteel\" /> ";
-    else if(Material == Tool::HIGHCARBONTOOLSTEEL)
-        writer.Stream() << " mat=\"HighCarbonToolSteel\" /> ";
-    else if(Material == Tool::CASTALLOY)
-        writer.Stream() << " mat=\"CastAlloy\" /> ";
-    else if(Material == Tool::CERAMICS)
-        writer.Stream() << " mat=\"Ceramics\" /> ";
-    else if(Material == Tool::DIAMOND)
-        writer.Stream() << " mat=\"Diamond\" /> ";
-    else if(Material == Tool::SIALON)
-        writer.Stream() << " mat=\"Sialon\" /> ";
-    else
-        writer.Stream() << " mat=\"Undefined\" /> ";
-    writer.Stream()<< std::endl;
+                    << "height=\"" << CuttingEdgeHeight << "\" "
+                    << "type=\"" << TypeName(Type) << "\" "
+                    << "mat=\"" << MaterialName(Material) << "\" "
+                    << "/>" << std::endl;
 }
 
 void Tool::Restore(XMLReader &reader)
@@ -195,7 +153,60 @@ void Tool::Restore(XMLReader &reader)
         Material = Tool::MATUNDEFINED;
 }
 
+const char* Tool::TypeName(Tool::ToolType typ) {
+    switch (typ) {
+      case Tool::DRILL:
+        return "Drill";
+      case Tool::CENTERDRILL:
+        return "CenterDrill";
+      case Tool::COUNTERSINK:
+        return "CounterSink";
+      case Tool::COUNTERBORE:
+        return "CounterBore";
+      case Tool::REAMER:
+        return "Reamer";
+      case Tool::TAP:
+        return "Tap";
+      case Tool::ENDMILL:
+        return "EndMill";
+      case Tool::SLOTCUTTER:
+        return "SlotCutter";
+      case Tool::BALLENDMILL:
+        return "BallEndMill";
+      case Tool::CHAMFERMILL:
+        return "ChamferMill";
+      case Tool::CORNERROUND:
+        return "CornerRound";
+      case Tool::ENGRAVER:
+        return "Engraver";
+      case Tool::UNDEFINED:
+        return "Undefined";
+    }
+    return "Undefined";
+}
 
+const char* Tool::MaterialName(Tool::ToolMaterial mat)
+{
+  switch (mat) {
+    case Tool::HIGHSPEEDSTEEL:
+        return "HighSpeedSteel";
+    case Tool::CARBIDE:
+        return "Carbide";
+    case Tool::HIGHCARBONTOOLSTEEL:
+        return "HighCarbonToolSteel";
+    case Tool::CASTALLOY:
+        return "CastAlloy";
+    case Tool::CERAMICS:
+        return "Ceramics";
+    case Tool::DIAMOND:
+        return "Diamond";
+    case Tool::SIALON:
+        return "Sialon";
+    case Tool::MATUNDEFINED:
+        return "Undefined";
+  }
+  return "Undefined";
+}
 
 // TOOLTABLE
 

--- a/src/Mod/Path/App/Tooltable.h
+++ b/src/Mod/Path/App/Tooltable.h
@@ -92,6 +92,8 @@ namespace Path
         double CuttingEdgeAngle;
         double CuttingEdgeHeight;
         
+        static const char* TypeName(ToolType typ);
+        static const char* MaterialName(ToolMaterial mat);
     };
     
     /** The representation of a table of tools */

--- a/src/Mod/Path/App/TooltablePy.xml
+++ b/src/Mod/Path/App/TooltablePy.xml
@@ -52,5 +52,15 @@ deletes the tool found at the given position</UserDocu>
         <!--<ClassDeclarations>
             bool touched;
         </ClassDeclarations>-->
+        <Methode Name="setFromTemplate">
+            <Documentation>
+                <UserDocu>setFromTemplate(dict) ... restores receiver from given template attribute dictionary</UserDocu>
+            </Documentation>
+        </Methode>
+        <Methode Name="templateAttrs">
+            <Documentation>
+                <UserDocu>templateAttrs() ... returns a dictionary representing the receivers attributes for a template</UserDocu>
+            </Documentation>
+        </Methode>
     </PythonExport>
 </GenerateModel>

--- a/src/Mod/Path/App/TooltablePyImp.cpp
+++ b/src/Mod/Path/App/TooltablePyImp.cpp
@@ -67,8 +67,9 @@ int ToolPy::PyInit(PyObject* args, PyObject* kwd)
     PyObject *cor = 0;
     PyObject *ang = 0;
     PyObject *hei = 0;
+    int version = 1;
 
-    static char *kwlist[] = {"name", "tooltype", "material", "diameter", "lengthOffset", "flatRadius", "cornerRadius", "cuttingEdgeAngle", "cuttingEdgeHeight" ,NULL};
+    static char *kwlist[] = {"name", "tooltype", "material", "diameter", "lengthOffset", "flatRadius", "cornerRadius", "cuttingEdgeAngle", "cuttingEdgeHeight" , "version", NULL};
 
     PyObject *dict = 0;
     if (!kwd && (PyObject_TypeCheck(args, &PyDict_Type) || PyArg_ParseTuple(args, "O!", &PyDict_Type, &dict))) {
@@ -76,7 +77,7 @@ int ToolPy::PyInit(PyObject* args, PyObject* kwd)
         if (PyObject_TypeCheck(args, &PyDict_Type)) {
           dict = args;
         }
-        if (!PyArg_ParseTupleAndKeywords(arg, dict, "|sssOOOOOO", kwlist, &name, &type, &mat, &dia, &len, &fla, &cor, &ang, &hei)) {
+        if (!PyArg_ParseTupleAndKeywords(arg, dict, "|sssOOOOOOi", kwlist, &name, &type, &mat, &dia, &len, &fla, &cor, &ang, &hei, &version)) {
             return -1;
         }
     } else {
@@ -84,6 +85,11 @@ int ToolPy::PyInit(PyObject* args, PyObject* kwd)
         if (!PyArg_ParseTupleAndKeywords(args, kwd, "|sssOOOOOO", kwlist, &name, &type, &mat, &dia, &len, &fla, &cor, &ang, &hei)) {
             return -1;
         }
+    }
+
+    if (1 != version) {
+        PyErr_SetString(PyExc_TypeError, "Unsupported Tool template version");
+        return -1;
     }
 
     getToolPtr()->Name = name;
@@ -338,6 +344,7 @@ PyObject* ToolPy::templateAttrs(PyObject * args)
 {
     if (!args || PyArg_ParseTuple(args, "")) {
         PyObject *dict = PyDict_New();
+        PyDict_SetItemString(dict, "version", PYINT_FROMLONG(1));
         PyDict_SetItemString(dict, "name", PYSTRING_FROMSTRING(getToolPtr()->Name.c_str()));
         PyDict_SetItemString(dict, "tooltype",PYSTRING_FROMSTRING(Tool::TypeName(getToolPtr()->Type)));
         PyDict_SetItemString(dict, "material", PYSTRING_FROMSTRING(Tool::MaterialName(getToolPtr()->Material)));

--- a/src/Mod/Path/App/TooltablePyImp.cpp
+++ b/src/Mod/Path/App/TooltablePyImp.cpp
@@ -288,7 +288,7 @@ PyObject* ToolPy::copy(PyObject * args)
 }
 
 
-PyObject* ToolPy::fromTemplate(PyObject * args)
+PyObject* ToolPy::setFromTemplate(PyObject * args)
 {
     char *pstr = 0;
     PyObject *dict = 0;

--- a/src/Mod/Path/CMakeLists.txt
+++ b/src/Mod/Path/CMakeLists.txt
@@ -121,6 +121,7 @@ SET(PathTests_SRCS
     PathTests/TestPathPost.py
     PathTests/TestPathStock.py
     PathTests/TestPathTool.py
+    PathTests/TestPathToolController.py
     PathTests/TestPathTooltable.py
     PathTests/TestPathUtil.py
 )

--- a/src/Mod/Path/CMakeLists.txt
+++ b/src/Mod/Path/CMakeLists.txt
@@ -120,6 +120,7 @@ SET(PathTests_SRCS
     PathTests/TestPathLog.py
     PathTests/TestPathPost.py
     PathTests/TestPathStock.py
+    PathTests/TestPathTool.py
     PathTests/TestPathUtil.py
 )
 

--- a/src/Mod/Path/CMakeLists.txt
+++ b/src/Mod/Path/CMakeLists.txt
@@ -121,6 +121,7 @@ SET(PathTests_SRCS
     PathTests/TestPathPost.py
     PathTests/TestPathStock.py
     PathTests/TestPathTool.py
+    PathTests/TestPathTooltable.py
     PathTests/TestPathUtil.py
 )
 

--- a/src/Mod/Path/PathScripts/PathJob.py
+++ b/src/Mod/Path/PathScripts/PathJob.py
@@ -115,7 +115,7 @@ class ObjectJob:
         obj.Base = createResourceClone(obj, base, 'Base', 'BaseGeometry')
         obj.Proxy = self
 
-        self.assignTemplate(obj, template)
+        self.setFromTemplate(obj, template)
         if not obj.Stock:
             obj.Stock = PathStock.CreateFromBase(obj)
         if obj.Stock.ViewObject:
@@ -165,8 +165,8 @@ class ObjectJob:
             return obj.Base.Objects[0]
         return obj.Base
 
-    def assignTemplate(self, obj, template):
-        '''assignTemplate(obj, template) ... extract the properties from the given template file and assign to receiver.
+    def setFromTemplate(self, obj, template):
+        '''setFromTemplate(obj, template) ... extract the properties from the given template file and assign to receiver.
         This will also create any TCs stored in the template.'''
         tcs = []
         if template:

--- a/src/Mod/Path/PathScripts/PathJobGui.py
+++ b/src/Mod/Path/PathScripts/PathJobGui.py
@@ -202,7 +202,7 @@ class StockEdit(object):
             obj.Document.removeObject(self.obj.Stock.Name)
         obj.Stock = stock
         if stock.ViewObject and stock.ViewObject.Proxy:
-            stock.ViewObject.Proxy.onEdit(OpenCloseResourceEditor)
+            stock.ViewObject.Proxy.onEdit(_OpenCloseResourceEditor)
 
     def setLengthField(self, widget, prop):
         widget.setText(FreeCAD.Units.Quantity(prop.Value, FreeCAD.Units.Length).UserString)

--- a/src/Mod/Path/PathScripts/PathJobGui.py
+++ b/src/Mod/Path/PathScripts/PathJobGui.py
@@ -291,15 +291,18 @@ class StockCreateBoxEdit(StockEdit):
         return self.form.stockCreateBox
 
     def getFields(self, obj, fields = ['length', 'widht', 'height']):
-        if self.IsStock(obj):
-            if 'length' in fields:
-                obj.Stock.Length = FreeCAD.Units.Quantity(self.form.stockBoxLength.text())
-            if 'width' in fields:
-                obj.Stock.Width  = FreeCAD.Units.Quantity(self.form.stockBoxWidth.text())
-            if 'height' in fields:
-                obj.Stock.Height = FreeCAD.Units.Quantity(self.form.stockBoxHeight.text())
-        else:
-            PathLog.error(translate('PathJob', 'Stock not a box!'))
+        try:
+            if self.IsStock(obj):
+                if 'length' in fields:
+                    obj.Stock.Length = FreeCAD.Units.Quantity(self.form.stockBoxLength.text())
+                if 'width' in fields:
+                    obj.Stock.Width  = FreeCAD.Units.Quantity(self.form.stockBoxWidth.text())
+                if 'height' in fields:
+                    obj.Stock.Height = FreeCAD.Units.Quantity(self.form.stockBoxHeight.text())
+            else:
+                PathLog.error(translate('PathJob', 'Stock not a box!'))
+        except:
+            pass
 
     def setFields(self, obj):
         if not self.IsStock(obj):
@@ -322,13 +325,16 @@ class StockCreateCylinderEdit(StockEdit):
         return self.form.stockCreateCylinder
 
     def getFields(self, obj, fields = ['radius', 'height']):
-        if self.IsStock(obj):
-            if 'radius' in fields:
-                obj.Stock.Radius = FreeCAD.Units.Quantity(self.form.stockCylinderRadius.text())
-            if 'height' in fields:
-                obj.Stock.Height = FreeCAD.Units.Quantity(self.form.stockCylinderHeight.text())
-        else:
-            PathLog.error(translate('PathJob', 'Stock not a cylinder!'))
+        try:
+            if self.IsStock(obj):
+                if 'radius' in fields:
+                    obj.Stock.Radius = FreeCAD.Units.Quantity(self.form.stockCylinderRadius.text())
+                if 'height' in fields:
+                    obj.Stock.Height = FreeCAD.Units.Quantity(self.form.stockCylinderHeight.text())
+            else:
+                PathLog.error(translate('PathJob', 'Stock not a cylinder!'))
+        except:
+            pass
 
     def setFields(self, obj):
         if not self.IsStock(obj):

--- a/src/Mod/Path/PathScripts/PathStock.py
+++ b/src/Mod/Path/PathScripts/PathStock.py
@@ -258,14 +258,14 @@ def TemplateAttributes(stock, includeExtent=True, includePlacement=True):
 
         if includePlacement:
             pos = stock.Placement.Base
-            attrs['posX'] = ("%f" % pos.x)
-            attrs['posY'] = ("%f" % pos.y)
-            attrs['posZ'] = ("%f" % pos.z)
+            attrs['posX'] = pos.x
+            attrs['posY'] = pos.y
+            attrs['posZ'] = pos.z
             rot = stock.Placement.Rotation
-            attrs['rotX'] = ("%f" % rot.Q[0])
-            attrs['rotY'] = ("%f" % rot.Q[1])
-            attrs['rotZ'] = ("%f" % rot.Q[2])
-            attrs['rotW'] = ("%f" % rot.Q[3])
+            attrs['rotX'] = rot.Q[0]
+            attrs['rotY'] = rot.Q[1]
+            attrs['rotZ'] = rot.Q[2]
+            attrs['rotW'] = rot.Q[3]
 
     return attrs
 

--- a/src/Mod/Path/PathScripts/PathStock.py
+++ b/src/Mod/Path/PathScripts/PathStock.py
@@ -253,6 +253,7 @@ def CreateCylinder(job, radius=None, height=None, placement=None):
 def TemplateAttributes(stock, includeExtent=True, includePlacement=True):
     attrs = {}
     if stock:
+        attrs['version'] = 1
         stockType = StockType.FromStock(stock)
         attrs['create'] = stockType
 
@@ -286,62 +287,65 @@ def TemplateAttributes(stock, includeExtent=True, includePlacement=True):
     return attrs
 
 def CreateFromTemplate(job, template):
-    stockType = template.get('create')
-    if stockType:
-        placement = None
-        posX = template.get('posX')
-        posY = template.get('posY')
-        posZ = template.get('posZ')
-        rotX = template.get('rotX')
-        rotY = template.get('rotY')
-        rotZ = template.get('rotZ')
-        rotW = template.get('rotW')
-        if posX is not None and posY is not None and posZ is not None and rotX is not None and rotY is not None and rotZ is not None and rotW is not None:
-            pos = FreeCAD.Vector(float(posX), float(posY), float(posZ)) 
-            rot = FreeCAD.Rotation(float(rotX), float(rotY), float(rotZ), float(rotW))
-            placement = FreeCAD.Placement(pos, rot)
-        elif posX is not None or posY is not None or posZ is not None or rotX is not None or rotY is not None or rotZ is not None or rotW is not None:
-            PathLog.warning(translate('PathStock', 'Corrupted or incomplete placement information in template - ignoring'))
+    if template.get('version') and 1 == int(template['version']):
+        stockType = template.get('create')
+        if stockType:
+            placement = None
+            posX = template.get('posX')
+            posY = template.get('posY')
+            posZ = template.get('posZ')
+            rotX = template.get('rotX')
+            rotY = template.get('rotY')
+            rotZ = template.get('rotZ')
+            rotW = template.get('rotW')
+            if posX is not None and posY is not None and posZ is not None and rotX is not None and rotY is not None and rotZ is not None and rotW is not None:
+                pos = FreeCAD.Vector(float(posX), float(posY), float(posZ)) 
+                rot = FreeCAD.Rotation(float(rotX), float(rotY), float(rotZ), float(rotW))
+                placement = FreeCAD.Placement(pos, rot)
+            elif posX is not None or posY is not None or posZ is not None or rotX is not None or rotY is not None or rotZ is not None or rotW is not None:
+                PathLog.warning(translate('PathStock', 'Corrupted or incomplete placement information in template - ignoring'))
 
-        if stockType == StockType.FromBase:
-            xneg = template.get('xneg')
-            xpos = template.get('xpos')
-            yneg = template.get('yneg')
-            ypos = template.get('ypos')
-            zneg = template.get('zneg')
-            zpos = template.get('zpos')
-            neg = None
-            pos = None
-            if xneg is not None and xpos is not None and yneg is not None and ypos is not None and zneg is not None and zpos is not None:
-                neg = FreeCAD.Vector(FreeCAD.Units.Quantity(xneg).Value, FreeCAD.Units.Quantity(yneg).Value, FreeCAD.Units.Quantity(zneg).Value)
-                pos = FreeCAD.Vector(FreeCAD.Units.Quantity(xpos).Value, FreeCAD.Units.Quantity(ypos).Value, FreeCAD.Units.Quantity(zpos).Value)
-            elif xneg is not None or xpos is not None or yneg is not None or ypos is not None or zneg is not None or zpos is not None:
-                PathLog.error(translate('PathStock', 'Corrupted or incomplete specification for creating stock from base - ignoring extent'))
-            return CreateFromBase(job, neg, pos, placement)
+            if stockType == StockType.FromBase:
+                xneg = template.get('xneg')
+                xpos = template.get('xpos')
+                yneg = template.get('yneg')
+                ypos = template.get('ypos')
+                zneg = template.get('zneg')
+                zpos = template.get('zpos')
+                neg = None
+                pos = None
+                if xneg is not None and xpos is not None and yneg is not None and ypos is not None and zneg is not None and zpos is not None:
+                    neg = FreeCAD.Vector(FreeCAD.Units.Quantity(xneg).Value, FreeCAD.Units.Quantity(yneg).Value, FreeCAD.Units.Quantity(zneg).Value)
+                    pos = FreeCAD.Vector(FreeCAD.Units.Quantity(xpos).Value, FreeCAD.Units.Quantity(ypos).Value, FreeCAD.Units.Quantity(zpos).Value)
+                elif xneg is not None or xpos is not None or yneg is not None or ypos is not None or zneg is not None or zpos is not None:
+                    PathLog.error(translate('PathStock', 'Corrupted or incomplete specification for creating stock from base - ignoring extent'))
+                return CreateFromBase(job, neg, pos, placement)
 
-        if stockType == StockType.CreateBox:
-            length = template.get('length')
-            width  = template.get('width')
-            height = template.get('height')
-            extent = None
-            if length is not None and width is not None and height is not None:
-                extent = FreeCAD.Vector(FreeCAD.Units.Quantity(length).Value, FreeCAD.Units.Quantity(width).Value, FreeCAD.Units.Quantity(height).Value)
-            elif length is not None or width is not None or height is not None:
-                PathLog.error(translate('PathStock', 'Corrupted or incomplete size for creating a stock box - ignoring size'))
-            return CreateBox(job, extent, placement)
+            if stockType == StockType.CreateBox:
+                length = template.get('length')
+                width  = template.get('width')
+                height = template.get('height')
+                extent = None
+                if length is not None and width is not None and height is not None:
+                    extent = FreeCAD.Vector(FreeCAD.Units.Quantity(length).Value, FreeCAD.Units.Quantity(width).Value, FreeCAD.Units.Quantity(height).Value)
+                elif length is not None or width is not None or height is not None:
+                    PathLog.error(translate('PathStock', 'Corrupted or incomplete size for creating a stock box - ignoring size'))
+                return CreateBox(job, extent, placement)
 
-        if stockType == StockType.CreateCylinder:
-            radius = template.get('radius')
-            height = template.get('height')
-            if radius is not None and height is not None:
-                pass
-            elif radius is not None or height is not None:
-                radius = None
-                height = None
-                PathLog.error(translate('PathStock', 'Corrupted or incomplete size for creating a stock cylinder - ignoring size'))
-            return CreateCylinder(job, radius, height, placement)
+            if stockType == StockType.CreateCylinder:
+                radius = template.get('radius')
+                height = template.get('height')
+                if radius is not None and height is not None:
+                    pass
+                elif radius is not None or height is not None:
+                    radius = None
+                    height = None
+                    PathLog.error(translate('PathStock', 'Corrupted or incomplete size for creating a stock cylinder - ignoring size'))
+                return CreateCylinder(job, radius, height, placement)
 
-        PathLog.error(translate('PathStock', 'Unsupported stock type named %s'), stockType)
+            PathLog.error(translate('PathStock', 'Unsupported stock type named %s'), stockType)
+        else:
+            PathLog.error(translate('PathStock', 'Unsupported PathStock template version %s'), template.get('version'))
         return None
 
 

--- a/src/Mod/Path/PathScripts/PathStock.py
+++ b/src/Mod/Path/PathScripts/PathStock.py
@@ -112,6 +112,8 @@ class StockFromBase:
 
 
 class StockCreateBox:
+    MinExtent = 0.001
+
     def __init__(self, obj):
         obj.addProperty('App::PropertyLength', 'Length', 'Stock', QtCore.QT_TRANSLATE_NOOP("PathStock", "Length of this stock box"))
         obj.addProperty('App::PropertyLength', 'Width', 'Stock', QtCore.QT_TRANSLATE_NOOP("PathStock", "Width of this stock box"))
@@ -129,6 +131,13 @@ class StockCreateBox:
         return None
 
     def execute(self, obj):
+        if obj.Length < self.MinExtent:
+            obj.Length = self.MinExtent
+        if obj.Width < self.MinExtent:
+            obj.Width = self.MinExtent
+        if obj.Height < self.MinExtent:
+            obj.Height = self.MinExtent
+
         shape = Part.makeBox(obj.Length, obj.Width, obj.Height)
         shape.Placement = obj.Placement
         obj.Shape = shape
@@ -138,6 +147,8 @@ class StockCreateBox:
             self.execute(obj)
 
 class StockCreateCylinder:
+    MinExtent = 0.001
+
     def __init__(self, obj):
         obj.addProperty('App::PropertyLength', 'Radius', 'Stock', QtCore.QT_TRANSLATE_NOOP("PathStock", "Radius of this stock cylinder"))
         obj.addProperty('App::PropertyLength', 'Height', 'Stock', QtCore.QT_TRANSLATE_NOOP("PathStock", "Height of this stock cylinder"))
@@ -153,6 +164,11 @@ class StockCreateCylinder:
         return None
 
     def execute(self, obj):
+        if obj.Radius < self.MinExtent:
+            obj.Radius = self.MinExtent
+        if obj.Height < self.MinExtent:
+            obj.Height = self.MinExtent
+
         shape = Part.makeCylinder(obj.Radius, obj.Height)
         shape.Placement = obj.Placement
         obj.Shape = shape

--- a/src/Mod/Path/PathScripts/PathToolController.py
+++ b/src/Mod/Path/PathScripts/PathToolController.py
@@ -99,7 +99,7 @@ class ToolController:
 
         for t in template.iter(ToolControllerTemplate.Tool):
             tool = Path.Tool()
-            tool.fromTemplate(xml.tostring(t))
+            tool.setFromTemplate(xml.tostring(t))
             obj.Tool = tool
 
     def templateAttrs(self, obj):

--- a/src/Mod/Path/PathScripts/PathToolController.py
+++ b/src/Mod/Path/PathScripts/PathToolController.py
@@ -57,6 +57,7 @@ class ToolControllerTemplate:
     SpindleSpeed = 'speed'
     SpindleDir   = 'dir'
     Tool         = 'tool'
+    Version      = 'version'
 
 class ToolController:
     def __init__(self, obj, tool=1):
@@ -80,34 +81,32 @@ class ToolController:
     def setFromTemplate(self, obj, template):
         '''setFromTemplate(obj, xmlItem) ... extract properties from xmlItem and assign to receiver.'''
         PathLog.track(obj.Name, template)
-        if template.get(ToolControllerTemplate.Label):
-            obj.Label = template.get(ToolControllerTemplate.Label)
-        if template.get(ToolControllerTemplate.VertFeed):
-            obj.VertFeed = template.get(ToolControllerTemplate.VertFeed)
-        if template.get(ToolControllerTemplate.HorizFeed):
-            obj.HorizFeed = template.get(ToolControllerTemplate.HorizFeed)
-        if template.get(ToolControllerTemplate.VertRapid):
-            obj.VertRapid = template.get(ToolControllerTemplate.VertRapid)
-        if template.get(ToolControllerTemplate.HorizRapid):
-            obj.HorizRapid = template.get(ToolControllerTemplate.HorizRapid)
-        if template.get(ToolControllerTemplate.SpindleSpeed):
-            obj.SpindleSpeed = float(template.get(ToolControllerTemplate.SpindleSpeed))
-        if template.get(ToolControllerTemplate.SpindleDir):
-            obj.SpindleDir = template.get(ToolControllerTemplate.SpindleDir)
-        if template.get(ToolControllerTemplate.ToolNumber):
-            obj.ToolNumber = int(template.get(ToolControllerTemplate.ToolNumber))
-
-        if hasattr(template, 'iter'):
-            for t in template.iter(ToolControllerTemplate.Tool):
-                tool = Path.Tool()
-                tool.setFromTemplate(xml.tostring(t))
-                obj.Tool = tool
-        elif template.get(ToolControllerTemplate.Tool):
-            obj.Tool.setFromTemplate(template.get(ToolControllerTemplate.Tool))
+        if template.get(ToolControllerTemplate.Version) and 1 == int(template.get(ToolControllerTemplate.Version)):
+            if template.get(ToolControllerTemplate.Label):
+                obj.Label = template.get(ToolControllerTemplate.Label)
+            if template.get(ToolControllerTemplate.VertFeed):
+                obj.VertFeed = template.get(ToolControllerTemplate.VertFeed)
+            if template.get(ToolControllerTemplate.HorizFeed):
+                obj.HorizFeed = template.get(ToolControllerTemplate.HorizFeed)
+            if template.get(ToolControllerTemplate.VertRapid):
+                obj.VertRapid = template.get(ToolControllerTemplate.VertRapid)
+            if template.get(ToolControllerTemplate.HorizRapid):
+                obj.HorizRapid = template.get(ToolControllerTemplate.HorizRapid)
+            if template.get(ToolControllerTemplate.SpindleSpeed):
+                obj.SpindleSpeed = float(template.get(ToolControllerTemplate.SpindleSpeed))
+            if template.get(ToolControllerTemplate.SpindleDir):
+                obj.SpindleDir = template.get(ToolControllerTemplate.SpindleDir)
+            if template.get(ToolControllerTemplate.ToolNumber):
+                obj.ToolNumber = int(template.get(ToolControllerTemplate.ToolNumber))
+            if template.get(ToolControllerTemplate.Tool):
+                obj.Tool.setFromTemplate(template.get(ToolControllerTemplate.Tool))
+        else:
+            PathLog.error(translate('PathToolController', "Unsupported PathToolController template version %s") % template.get(ToolControllerTemplate.Version))
 
     def templateAttrs(self, obj):
         '''templateAttrs(obj) ... answer a dictionary with all properties that should be stored for a template.'''
         attrs = {}
+        attrs[ToolControllerTemplate.Version]      = 1
         attrs[ToolControllerTemplate.Name]         = obj.Name
         attrs[ToolControllerTemplate.Label]        = obj.Label
         attrs[ToolControllerTemplate.ToolNumber]   = obj.ToolNumber

--- a/src/Mod/Path/PathScripts/PathToolLibraryManager.py
+++ b/src/Mod/Path/PathScripts/PathToolLibraryManager.py
@@ -148,6 +148,9 @@ class ToolLibraryManager():
     TooltableTypeHeekscad = translate("TooltableEditor", "HeeksCAD tooltable (*.tooltable)")
     TooltableTypeLinuxCNC = translate("TooltableEditor", "LinuxCNC tooltable (*.tbl)")
 
+    PreferenceMainLibraryXML = "ToolLibrary"
+    PreferenceMainLibraryJSON = "ToolLibrary-Main"
+
     def __init__(self):
         self.prefs = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/Path")
         return
@@ -171,7 +174,7 @@ class ToolLibraryManager():
     def saveMainLibrary(self, tooltable):
         '''Persists the permanent library to FreeCAD user preferences'''
         tmpstring = json.dumps(self.templateAttrs(tooltable))
-        self.prefs.SetString("ToolLibrary", tmpstring)
+        self.prefs.SetString(self.PreferenceMainLibraryJSON, tmpstring)
         return True
 
     def getLists(self):
@@ -190,7 +193,9 @@ class ToolLibraryManager():
     def _findList(self, listname):
         tt = None
         if listname == "<Main>":
-            tmpstring = self.prefs.GetString("ToolLibrary", "")
+            tmpstring = self.prefs.GetString(self.PreferenceMainLibraryJSON, "")
+            if not tmpstring:
+                tmpstring = self.prefs.GetString(self.PreferenceMainLibraryXML, "")
             if tmpstring:
                 if tmpstring[0] == '{':
                     tt = self.tooltableFromAttrs(json.loads(tmpstring))

--- a/src/Mod/Path/PathTests/TestPathTool.py
+++ b/src/Mod/Path/PathTests/TestPathTool.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+
+# ***************************************************************************
+# *                                                                         *
+# *   Copyright (c) 2017 sliptonic <shopinthewoods@gmail.com>               *
+# *                                                                         *
+# *   This program is free software; you can redistribute it and/or modify  *
+# *   it under the terms of the GNU Lesser General Public License (LGPL)    *
+# *   as published by the Free Software Foundation; either version 2 of     *
+# *   the License, or (at your option) any later version.                   *
+# *   for detail see the LICENCE text file.                                 *
+# *                                                                         *
+# *   This program is distributed in the hope that it will be useful,       *
+# *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+# *   GNU Library General Public License for more details.                  *
+# *                                                                         *
+# *   You should have received a copy of the GNU Library General Public     *
+# *   License along with this program; if not, write to the Free Software   *
+# *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
+# *   USA                                                                   *
+# *                                                                         *
+# ***************************************************************************
+
+import FreeCAD
+import Path
+
+from PathTests.PathTestUtils import PathTestBase
+
+class TestPathTool(PathTestBase):
+
+    def test00(self):
+        '''Verify templateAttrs'''
+
+        name = 'tool 1'
+        mat  = 'Carbide'
+        typ  = 'EndMill'
+        dia    = 1.7
+        flat   = 7.2
+        offset = 3.2
+        corner = 4
+        height = 45.3
+        angle  = 118
+
+        tool = Path.Tool()
+        tool.Name = name
+        tool.ToolType = typ
+        tool.Material = mat
+        tool.Diameter = dia
+        tool.LengthOffset = offset
+        tool.FlatRadius = flat
+        tool.CornerRadius = corner
+        tool.CuttingEdgeAngle = angle
+        tool.CuttingEdgeHeight = height
+
+        attrs = tool.templateAttrs()
+        self.assertEqual(attrs['name'], name)
+        self.assertEqual(attrs['diameter'], dia)
+        self.assertEqual(attrs['material'], mat)
+        self.assertEqual(attrs['tooltype'], typ)
+        self.assertEqual(attrs['lengthOffset'], offset)
+        self.assertEqual(attrs['flatRadius'], flat)
+        self.assertEqual(attrs['cornerRadius'], corner)
+        self.assertEqual(attrs['cuttingEdgeAngle'], angle)
+        self.assertEqual(attrs['cuttingEdgeHeight'], height)
+        return tool
+
+
+    def test01(self):
+        '''Verify template roundtrip'''
+
+        t0 = self.test00()
+        t1 = Path.Tool()
+        t1.fromTemplate(t0.templateAttrs())
+
+        self.assertEqual(t0.Name, t1.Name)
+        self.assertEqual(t0.ToolType, t1.ToolType)
+        self.assertEqual(t0.Material, t1.Material)
+        self.assertEqual(t0.Diameter, t1.Diameter)
+        self.assertEqual(t0.LengthOffset, t1.LengthOffset)
+        self.assertEqual(t0.FlatRadius, t1.FlatRadius)
+        self.assertEqual(t0.CornerRadius, t1.CornerRadius)
+        self.assertEqual(t0.CuttingEdgeAngle, t1.CuttingEdgeAngle)
+        self.assertEqual(t0.CuttingEdgeHeight, t1.CuttingEdgeHeight)
+

--- a/src/Mod/Path/PathTests/TestPathTool.py
+++ b/src/Mod/Path/PathTests/TestPathTool.py
@@ -83,3 +83,19 @@ class TestPathTool(PathTestBase):
         self.assertEqual(t0.CuttingEdgeAngle, t1.CuttingEdgeAngle)
         self.assertEqual(t0.CuttingEdgeHeight, t1.CuttingEdgeHeight)
 
+    def test02(self):
+        '''Verify template dictionary construction'''
+
+        t0 = self.test00()
+        t1 = Path.Tool(t0.templateAttrs())
+
+        self.assertEqual(t0.Name, t1.Name)
+        self.assertEqual(t0.ToolType, t1.ToolType)
+        self.assertEqual(t0.Material, t1.Material)
+        self.assertEqual(t0.Diameter, t1.Diameter)
+        self.assertEqual(t0.LengthOffset, t1.LengthOffset)
+        self.assertEqual(t0.FlatRadius, t1.FlatRadius)
+        self.assertEqual(t0.CornerRadius, t1.CornerRadius)
+        self.assertEqual(t0.CuttingEdgeAngle, t1.CuttingEdgeAngle)
+        self.assertEqual(t0.CuttingEdgeHeight, t1.CuttingEdgeHeight)
+

--- a/src/Mod/Path/PathTests/TestPathTool.py
+++ b/src/Mod/Path/PathTests/TestPathTool.py
@@ -71,7 +71,7 @@ class TestPathTool(PathTestBase):
 
         t0 = self.test00()
         t1 = Path.Tool()
-        t1.fromTemplate(t0.templateAttrs())
+        t1.setFromTemplate(t0.templateAttrs())
 
         self.assertEqual(t0.Name, t1.Name)
         self.assertEqual(t0.ToolType, t1.ToolType)

--- a/src/Mod/Path/PathTests/TestPathToolController.py
+++ b/src/Mod/Path/PathTests/TestPathToolController.py
@@ -1,0 +1,87 @@
+# -*- coding: utf-8 -*-
+
+# ***************************************************************************
+# *                                                                         *
+# *   Copyright (c) 2017 sliptonic <shopinthewoods@gmail.com>               *
+# *                                                                         *
+# *   This program is free software; you can redistribute it and/or modify  *
+# *   it under the terms of the GNU Lesser General Public License (LGPL)    *
+# *   as published by the Free Software Foundation; either version 2 of     *
+# *   the License, or (at your option) any later version.                   *
+# *   for detail see the LICENCE text file.                                 *
+# *                                                                         *
+# *   This program is distributed in the hope that it will be useful,       *
+# *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+# *   GNU Library General Public License for more details.                  *
+# *                                                                         *
+# *   You should have received a copy of the GNU Library General Public     *
+# *   License along with this program; if not, write to the Free Software   *
+# *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
+# *   USA                                                                   *
+# *                                                                         *
+# ***************************************************************************
+
+import FreeCAD
+import Path
+import PathScripts.PathToolController as PathToolController
+
+from PathTests.PathTestUtils import PathTestBase
+
+class TestPathToolController(PathTestBase):
+
+    def setUp(self):
+        self.doc = FreeCAD.newDocument("TestPathToolController")
+
+    def tearDown(self):
+        FreeCAD.closeDocument(self.doc.Name)
+
+    def createTool(self, name='t1', diameter=1.75):
+        return Path.Tool(name=name, diameter=diameter)
+
+    def test00(self):
+        '''Verify ToolController templateAttrs'''
+        t  = self.createTool('T1')
+        tc = PathToolController.Create('TC0', t)
+
+        tc.Label = 'ToolController'
+        tc.ToolNumber = 7
+        tc.VertFeed = '3 in/s'
+        tc.HorizFeed = '10 mm/s'
+        tc.VertRapid = 40
+        tc.HorizRapid = 28
+        tc.SpindleDir = 'Reverse'
+        tc.SpindleSpeed = 12000
+
+        attrs = tc.Proxy.templateAttrs(tc)
+
+        self.assertEqual(attrs['name'], 'TC0')
+        self.assertEqual(attrs['label'], 'ToolController')
+        self.assertEqual(attrs['nr'], 7)
+        self.assertEqual(attrs['vfeed'], '76.2 mm/s')
+        self.assertEqual(attrs['hfeed'], '10 mm/s')
+        self.assertEqual(attrs['vrapid'], '40 mm/s')
+        self.assertEqual(attrs['hrapid'], '28 mm/s')
+        self.assertEqual(attrs['dir'], 'Reverse')
+        self.assertEqual(attrs['speed'], 12000)
+        self.assertEqual(attrs['tool'], t.templateAttrs())
+
+        return tc
+
+    def test01(self):
+        '''Verify ToolController template roundtrip.'''
+
+        tc0 = self.test00()
+        tc1 = PathToolController.FromTemplate(tc0.Proxy.templateAttrs(tc0))
+
+        self.assertNotEqual(tc0.Name, tc1.Name)
+        self.assertNotEqual(tc0.Label, tc1.Label)
+        self.assertEqual(tc0.ToolNumber, tc1.ToolNumber)
+        self.assertRoughly(tc0.VertFeed, tc1.VertFeed)
+        self.assertRoughly(tc0.HorizFeed, tc1.HorizFeed)
+        self.assertRoughly(tc0.VertRapid, tc1.VertRapid)
+        self.assertRoughly(tc0.HorizRapid, tc1.HorizRapid)
+        self.assertEqual(tc0.SpindleDir, tc1.SpindleDir)
+        self.assertRoughly(tc0.SpindleSpeed, tc1.SpindleSpeed)
+        self.assertEqual(tc0.Tool.Name, tc1.Tool.Name)
+        self.assertRoughly(tc0.Tool.Diameter, tc1.Tool.Diameter)

--- a/src/Mod/Path/PathTests/TestPathTooltable.py
+++ b/src/Mod/Path/PathTests/TestPathTooltable.py
@@ -2,7 +2,7 @@
 
 # ***************************************************************************
 # *                                                                         *
-# *   Copyright (c) 2016 sliptonic <shopinthewoods@gmail.com>               *
+# *   Copyright (c) 2017 sliptonic <shopinthewoods@gmail.com>               *
 # *                                                                         *
 # *   This program is free software; you can redistribute it and/or modify  *
 # *   it under the terms of the GNU Lesser General Public License (LGPL)    *
@@ -22,16 +22,52 @@
 # *                                                                         *
 # ***************************************************************************
 
-import TestApp
+import FreeCAD
+import Path
 
-from PathTests.TestPathLog   import TestPathLog
-from PathTests.TestPathCore  import TestPathCore
-#from PathTests.TestPathPost  import PathPostTestCases
-from PathTests.TestPathGeom  import TestPathGeom
-from PathTests.TestPathUtil  import TestPathUtil
-from PathTests.TestPathDepthParams        import depthTestCases
-from PathTests.TestPathDressupHoldingTags import TestHoldingTags
-from PathTests.TestPathDressupDogbone import TestDressupDogbone
-from PathTests.TestPathStock import TestPathStock
-from PathTests.TestPathTool import TestPathTool
-from PathTests.TestPathTooltable import TestPathTooltable
+from PathTests.PathTestUtils import PathTestBase
+
+class TestPathTooltable(PathTestBase):
+
+    def test00(self):
+        '''Verify templateAttrs'''
+
+        t = Path.Tool(name='t', diameter=1.2)
+        u = Path.Tool(name='u', diameter=3.4)
+        v = Path.Tool(name='v', diameter=5.6)
+
+        tt = Path.Tooltable()
+        tt.setTool(3, t)
+        tt.setTool(1, u)
+        tt.addTools(v)
+
+        attrs = tt.templateAttrs()
+        self.assertEqual(3, len(attrs))
+        self.assertTrue(1 in attrs)
+        self.assertFalse(2 in attrs)
+        self.assertTrue(3 in attrs)
+        self.assertTrue(4 in attrs)
+
+        self.assertEqual(attrs[1]['name'], 'u')
+        self.assertEqual(attrs[1]['diameter'], 3.4)
+        self.assertEqual(attrs[3]['name'], 't')
+        self.assertEqual(attrs[3]['diameter'], 1.2)
+        self.assertEqual(attrs[4]['name'], 'v')
+        self.assertEqual(attrs[4]['diameter'], 5.6)
+        return tt
+
+    def test01(self):
+        '''Verify setFromTemplate roundtrip.'''
+        tt = self.test00()
+        uu = Path.Tooltable()
+        uu.setFromTemplate(tt.templateAttrs())
+
+        self.assertEqual(tt.Content, uu.Content)
+
+
+    def test02(self):
+        '''Verify template constructor.'''
+        tt = self.test00()
+        uu = Path.Tooltable(tt.templateAttrs())
+        self.assertEqual(tt.Content, uu.Content)
+

--- a/src/Mod/Path/TestPathApp.py
+++ b/src/Mod/Path/TestPathApp.py
@@ -33,3 +33,4 @@ from PathTests.TestPathDepthParams        import depthTestCases
 from PathTests.TestPathDressupHoldingTags import TestHoldingTags
 from PathTests.TestPathDressupDogbone import TestDressupDogbone
 from PathTests.TestPathStock import TestPathStock
+from PathTests.TestPathTool import TestPathTool

--- a/src/Mod/Path/TestPathApp.py
+++ b/src/Mod/Path/TestPathApp.py
@@ -24,15 +24,15 @@
 
 import TestApp
 
-#from PathTests.TestPathLog   import TestPathLog
-#from PathTests.TestPathCore  import TestPathCore
-##from PathTests.TestPathPost  import PathPostTestCases
-#from PathTests.TestPathGeom  import TestPathGeom
-#from PathTests.TestPathUtil  import TestPathUtil
-#from PathTests.TestPathDepthParams        import depthTestCases
-#from PathTests.TestPathDressupHoldingTags import TestHoldingTags
-#from PathTests.TestPathDressupDogbone import TestDressupDogbone
-#from PathTests.TestPathStock import TestPathStock
-#from PathTests.TestPathTool import TestPathTool
-#from PathTests.TestPathTooltable import TestPathTooltable
+from PathTests.TestPathLog   import TestPathLog
+from PathTests.TestPathCore  import TestPathCore
+#from PathTests.TestPathPost  import PathPostTestCases
+from PathTests.TestPathGeom  import TestPathGeom
+from PathTests.TestPathUtil  import TestPathUtil
+from PathTests.TestPathDepthParams        import depthTestCases
+from PathTests.TestPathDressupHoldingTags import TestHoldingTags
+from PathTests.TestPathDressupDogbone import TestDressupDogbone
+from PathTests.TestPathStock import TestPathStock
+from PathTests.TestPathTool import TestPathTool
+from PathTests.TestPathTooltable import TestPathTooltable
 from PathTests.TestPathToolController import TestPathToolController

--- a/src/Mod/Path/TestPathApp.py
+++ b/src/Mod/Path/TestPathApp.py
@@ -24,14 +24,15 @@
 
 import TestApp
 
-from PathTests.TestPathLog   import TestPathLog
-from PathTests.TestPathCore  import TestPathCore
-#from PathTests.TestPathPost  import PathPostTestCases
-from PathTests.TestPathGeom  import TestPathGeom
-from PathTests.TestPathUtil  import TestPathUtil
-from PathTests.TestPathDepthParams        import depthTestCases
-from PathTests.TestPathDressupHoldingTags import TestHoldingTags
-from PathTests.TestPathDressupDogbone import TestDressupDogbone
-from PathTests.TestPathStock import TestPathStock
-from PathTests.TestPathTool import TestPathTool
-from PathTests.TestPathTooltable import TestPathTooltable
+#from PathTests.TestPathLog   import TestPathLog
+#from PathTests.TestPathCore  import TestPathCore
+##from PathTests.TestPathPost  import PathPostTestCases
+#from PathTests.TestPathGeom  import TestPathGeom
+#from PathTests.TestPathUtil  import TestPathUtil
+#from PathTests.TestPathDepthParams        import depthTestCases
+#from PathTests.TestPathDressupHoldingTags import TestHoldingTags
+#from PathTests.TestPathDressupDogbone import TestDressupDogbone
+#from PathTests.TestPathStock import TestPathStock
+#from PathTests.TestPathTool import TestPathTool
+#from PathTests.TestPathTooltable import TestPathTooltable
+from PathTests.TestPathToolController import TestPathToolController


### PR DESCRIPTION
The discussions in 2 threads uncovered a lingering conflict due to Python and libcoin both using libexpat. The version mismatch results in a segfault of FC and we have no control over the build of those components in (who knows how many) OSs and distros out there.

Therefore we decided to prevent usage of XML in Path and replace it with a JSON format.

https://forum.freecadweb.org/viewtopic.php?f=15&t=23380
https://forum.freecadweb.org/viewtopic.php?f=10&t=24268