### PR TITLE
Path: Feature/support part as base object

### DIFF
--- a/src/Mod/Path/PathScripts/PathCircularHoleBase.py
+++ b/src/Mod/Path/PathScripts/PathCircularHoleBase.py
@@ -25,6 +25,7 @@
 import ArchPanel
 import FreeCAD
 import DraftGeomUtils
+import Part
 import PathScripts.PathLog as PathLog
 import PathScripts.PathOp as PathOp
 import PathScripts.PathUtils as PathUtils
@@ -45,6 +46,8 @@ def translate(context, text, disambig=None):
 if False:
     PathLog.setLevel(PathLog.Level.DEBUG, PathLog.thisModule())
     PathLog.trackModule(PathLog.thisModule())
+else:
+    PathLog.setLevel(PathLog.Level.INFO, PathLog.thisModule())
 
 class ObjectOp(PathOp.ObjectOp):
     '''Base class for proxy objects of all operations on circular holes.'''
@@ -95,6 +98,9 @@ class ObjectOp(PathOp.ObjectOp):
         shape = base.Shape.getElement(sub)
         if shape.ShapeType == 'Vertex':
             return 0
+
+        if shape.ShapeType == 'Edge' and type(shape.Curve) == Part.Circle:
+            return shape.Curve.Radius * 2
 
         # for all other shapes the diameter is just the dimension in X
         return shape.BoundBox.XLength

--- a/src/Mod/Path/PathScripts/PathCircularHoleBaseGui.py
+++ b/src/Mod/Path/PathScripts/PathCircularHoleBaseGui.py
@@ -34,7 +34,7 @@ __author__ = "sliptonic (Brad Collette)"
 __url__ = "http://www.freecadweb.org"
 __doc__ = "Implementation of circular hole specific base geometry page controller."
 
-if True:
+if False:
     PathLog.setLevel(PathLog.Level.DEBUG, PathLog.thisModule())
     PathLog.trackModule(PathLog.thisModule())
 else:

--- a/src/Mod/Path/PathScripts/PathHelix.py
+++ b/src/Mod/Path/PathScripts/PathHelix.py
@@ -80,7 +80,7 @@ class ObjectHelix(PathCircularHoleBase.ObjectOp):
         from numpy import ceil, linspace
 
         if (obj.StartDepth.Value <= obj.FinalDepth.Value):
-            return
+            return ""
 
         out = "(helix_cut <{0}, {1}>, {2})".format(x0, y0,
                     ", ".join(map(str, (r_out, r_in, dr, obj.StartDepth.Value, obj.FinalDepth.Value, obj.StepDown.Value, obj.SafeHeight.Value,

--- a/src/Mod/Path/PathScripts/PathUtil.py
+++ b/src/Mod/Path/PathScripts/PathUtil.py
@@ -40,6 +40,11 @@ NotValidBaseTypeIds = ['Sketcher::SketchObject']
 
 def isValidBaseObject(obj):
     '''isValidBaseObject(obj) ... returns true if the object can be used as a base for a job.'''
+    if hasattr(obj, 'getParentGeoFeatureGroup') and obj.getParentGeoFeatureGroup():
+        # Can't link to anything inside a geo feature group anymore
+        return False
+    if hasattr(obj, 'TypeId') and 'App::Part' == obj.TypeId:
+        return obj.Group and any(hasattr(o, 'Shape') for o in obj.Group)
     if not hasattr(obj, 'Shape'):
         return False
     if obj.TypeId in NotValidBaseTypeIds:
@@ -58,6 +63,10 @@ def isSolid(obj):
         if obj.Shape.ShapeType == 'Compound':
             if hasattr(obj, 'Base') and hasattr(obj, 'Tool'):
                 return isSolid(obj.Base) and isSolid(obj.Tool)
+    if hasattr(obj, 'TypeId') and 'App::Part' == obj.TypeId:
+        if not obj.Group or any(hasattr(o, 'Shape') and not isSolid(o) for o in obj.Group):
+            return False
+        return True
     return False
 
 def toolControllerForOp(op):

--- a/src/Mod/Path/PathTests/TestPathUtil.py
+++ b/src/Mod/Path/PathTests/TestPathUtil.py
@@ -84,9 +84,36 @@ class TestPathUtil(PathTestBase):
         body.addObject(pad)
         pad.Profile = sketch
         self.doc.recompute()
-        # the body and the pad are solids
-        self.assertTrue(PathUtil.isValidBaseObject(pad))
+
+        # the body is a solid
         self.assertTrue(PathUtil.isValidBaseObject(body))
-        # however, the sketch is no
+
+        # the pad inside the body cannot be used due to the linking constraints
+        self.assertFalse(PathUtil.isValidBaseObject(pad))
+
+        # the sketch is no good neither
         self.assertFalse(PathUtil.isValidBaseObject(sketch))
+
+    def test04(self):
+        '''Check that Part is handled correctly.'''
+        part = self.doc.addObject('App::Part', 'Part')
+
+        # an empty part is not a valid base object
+        self.assertFalse(PathUtil.isValidBaseObject(part))
+
+        # a none empty part where none of the objects has a shape is no good neither
+        fp = self.doc.addObject('App::FeaturePython', 'Feature')
+        part.addObject(fp)
+        self.assertFalse(PathUtil.isValidBaseObject(part))
+
+        # create an valid base object
+        box = self.doc.addObject("Part::Box","Box")
+        self.assertTrue(PathUtil.isValidBaseObject(box))
+
+        # a part with at least one valid object is valid
+        part.addObject(box)
+        self.assertTrue(PathUtil.isValidBaseObject(part))
+
+        # however, the object itself is no longer valid
+        self.assertFalse(PathUtil.isValidBaseObject(box))
 


### PR DESCRIPTION
This PR allows 'App::Part' objects to be used as base and/or stock objects for a job. It also prevents creation of a job for objects which rely inside a body or part, following the new link restrictions.