### PR TITLE
Fix macOS button layout in property editor

### DIFF
--- a/src/Gui/FileDialog.cpp
+++ b/src/Gui/FileDialog.cpp
@@ -36,6 +36,7 @@
 # include <QRadioButton>
 # include <QStyle>
 # include <QUrl>
+# include <QResizeEvent>
 #endif
 
 #include <Base/Parameter.h>
@@ -589,7 +590,7 @@ FileChooser::FileChooser ( QWidget * parent )
 {
     QHBoxLayout *layout = new QHBoxLayout( this );
     layout->setMargin( 0 );
-    layout->setSpacing( 6 );
+    layout->setSpacing( 2 );
 
     lineEdit = new QLineEdit ( this );
     completer = new QCompleter ( this );
@@ -607,7 +608,11 @@ FileChooser::FileChooser ( QWidget * parent )
     connect(lineEdit, SIGNAL(editingFinished()), this, SLOT(editingFinished()));
 
     button = new QPushButton(QLatin1String("..."), this);
-    button->setFixedWidth(2*button->fontMetrics().width(QLatin1String(" ... ")));
+
+#if defined (Q_OS_MAC)
+    button->setAttribute(Qt::WA_LayoutUsesWidgetRect); // layout size from QMacStyle was not correct
+#endif
+
     layout->addWidget(button);
 
     connect( button, SIGNAL(clicked()), this, SLOT(chooseFile()));
@@ -617,6 +622,12 @@ FileChooser::FileChooser ( QWidget * parent )
 
 FileChooser::~FileChooser()
 {
+}
+
+void FileChooser::resizeEvent(QResizeEvent* e)
+{
+    button->setFixedWidth(e->size().height());
+    button->setFixedHeight(e->size().height());
 }
 
 /**

--- a/src/Gui/FileDialog.h
+++ b/src/Gui/FileDialog.h
@@ -183,6 +183,9 @@ private Q_SLOTS:
     void chooseFile();
     void editingFinished();
 
+protected:
+    void resizeEvent(QResizeEvent*);
+
 private:
     QLineEdit *lineEdit;
     QCompleter *completer;

--- a/src/Gui/Widgets.cpp
+++ b/src/Gui/Widgets.cpp
@@ -867,6 +867,9 @@ LabelButton::LabelButton (QWidget * parent)
     layout->addWidget(label);
 
     button = new QPushButton(QLatin1String("..."), this);
+#if defined (Q_OS_MAC)
+    button->setAttribute(Qt::WA_LayoutUsesWidgetRect); // layout size from QMacStyle was not correct
+#endif
     layout->addWidget(button);
 
     connect(button, SIGNAL(clicked()), this, SLOT(browse()));
@@ -880,6 +883,7 @@ LabelButton::~LabelButton()
 void LabelButton::resizeEvent(QResizeEvent* e)
 {
     button->setFixedWidth(e->size().height());
+    button->setFixedHeight(e->size().height());
 }
 
 QLabel *LabelButton::getLabel() const
@@ -1298,7 +1302,9 @@ LabelEditor::LabelEditor (QWidget * parent)
             this, SLOT(validateText(const QString &)));
 
     button = new QPushButton(QLatin1String("..."), this);
-    button->setFixedWidth(2*button->fontMetrics().width(QLatin1String(" ... ")));
+#if defined (Q_OS_MAC)
+    button->setAttribute(Qt::WA_LayoutUsesWidgetRect); // layout size from QMacStyle was not correct
+#endif
     layout->addWidget(button);
 
     connect(button, SIGNAL(clicked()), this, SLOT(changeText()));
@@ -1308,6 +1314,12 @@ LabelEditor::LabelEditor (QWidget * parent)
 
 LabelEditor::~LabelEditor()
 {
+}
+
+void LabelEditor::resizeEvent(QResizeEvent* e)
+{
+    button->setFixedWidth(e->size().height());
+    button->setFixedHeight(e->size().height());
 }
 
 QString LabelEditor::text() const

--- a/src/Gui/Widgets.h
+++ b/src/Gui/Widgets.h
@@ -437,6 +437,9 @@ Q_SIGNALS:
 private Q_SLOTS:
     void changeText();
 
+protected:
+    void resizeEvent(QResizeEvent*);
+
 private:
     InputType type;
     QString plainText;

--- a/src/Gui/propertyeditor/PropertyItem.cpp
+++ b/src/Gui/propertyeditor/PropertyItem.cpp
@@ -3382,6 +3382,9 @@ LinkLabel::LinkLabel (QWidget * parent) : QWidget(parent)
     layout->addWidget(label);
 
     editButton = new QPushButton(QLatin1String("..."), this);
+#if defined (Q_OS_MAC)
+    editButton->setAttribute(Qt::WA_LayoutUsesWidgetRect); // layout size from QMacStyle was not correct
+#endif
     editButton->setToolTip(tr("Change the linked object"));
     layout->addWidget(editButton);
     
@@ -3440,6 +3443,7 @@ void LinkLabel::onEditClicked ()
 void LinkLabel::resizeEvent(QResizeEvent* e)
 {
     editButton->setFixedWidth(e->size().height());
+    editButton->setFixedHeight(e->size().height());
 }
 
 


### PR DESCRIPTION
The size of the "..." button calculated by QMacStyle was not correct,
causing other widgets in the layout to be clipped.

Also, set the size of all "..." buttons the same way.

See https://www.forum.freecadweb.org/viewtopic.php?f=3&t=24590 for an example.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR once it is merged.

---
