### PR TITLE
Core: add properties "binding" and "expression" to QuantitySpinBox

### DIFF
--- a/src/Gui/ExpressionBinding.h
+++ b/src/Gui/ExpressionBinding.h
@@ -50,7 +50,7 @@ public:
 
     QPixmap getIcon(const char *name, const QSize &size) const;
    
-    //auto apply means that the python code is issues not only on aplly() but 
+    //auto apply means that the python code is issued not only on apply() but 
     //also on setExpression
     bool autoApply() const {return m_autoApply;};
     void setAutoApply(bool value) {m_autoApply = value;};

--- a/src/Gui/QuantitySpinBox.cpp
+++ b/src/Gui/QuantitySpinBox.cpp
@@ -315,16 +315,16 @@ void QuantitySpinBox::setBoundToByName(const QString &qstr)
                     path.setDocumentObjectName(objName, true);
                     bind(path);
                 } else {
-                    printf("%s.%s('%s', '%s'): no prop\n", __FILE__, __FUNCTION__, objName.c_str(), prpName.c_str());
+                    //printf("%s.%s('%s', '%s'): no prop\n", __FILE__, __FUNCTION__, objName.c_str(), prpName.c_str());
                 }
             } else {
-                printf("%s.%s('%s', '%s'): no obj\n", __FILE__, __FUNCTION__, objName.c_str(), prpName.c_str());
+                //printf("%s.%s('%s', '%s'): no obj\n", __FILE__, __FUNCTION__, objName.c_str(), prpName.c_str());
             }
         } else {
-            printf("%s.%s('%s', '%s'): no doc\n", __FILE__, __FUNCTION__, objName.c_str(), prpName.c_str());
+            //printf("%s.%s('%s', '%s'): no doc\n", __FILE__, __FUNCTION__, objName.c_str(), prpName.c_str());
         }
     } else {
-        printf("%s.%s(%s'): invalid name\n", __FILE__, __FUNCTION__, name.c_str());
+        //printf("%s.%s(%s'): invalid name\n", __FILE__, __FUNCTION__, name.c_str());
     }
 }
 

--- a/src/Gui/QuantitySpinBox.cpp
+++ b/src/Gui/QuantitySpinBox.cpp
@@ -328,8 +328,18 @@ void QuantitySpinBox::setBoundToByName(const QString &qstr)
     }
 }
 
-void Gui::QuantitySpinBox::onChange() {
-    
+QString Gui::QuantitySpinBox::expressionText() const
+{
+    Q_D(const QuantitySpinBox);
+    if (isBound()) {
+        return QString::fromStdString(getExpressionString());
+    }
+    return QString();
+}
+
+
+void Gui::QuantitySpinBox::onChange()
+{
     Q_ASSERT(isBound());
     
     if (getExpression()) {

--- a/src/Gui/QuantitySpinBox.h
+++ b/src/Gui/QuantitySpinBox.h
@@ -45,7 +45,8 @@ class GuiExport QuantitySpinBox : public QAbstractSpinBox, public ExpressionBind
     Q_PROPERTY(double singleStep READ singleStep WRITE setSingleStep)
     Q_PROPERTY(double rawValue READ rawValue WRITE setValue NOTIFY valueChanged)
     Q_PROPERTY(Base::Quantity value READ value WRITE setValue NOTIFY valueChanged USER true)
-    Q_PROPERTY(QString boundTo READ boundToName WRITE setBoundToByName)
+    Q_PROPERTY(QString binding READ boundToName WRITE setBoundToByName)
+    Q_PROPERTY(QString expression READ expressionText)
 
 public:
     using ExpressionBinding::apply;
@@ -94,6 +95,9 @@ public:
     QString boundToName() const;
     /// Sets the path of the bound property
     void setBoundToByName(const QString &path);
+
+    /// Gets the expression as a string
+    QString expressionText() const;
 
     /// Set the number portion selected
     void selectNumber();

--- a/src/Gui/QuantitySpinBox.h
+++ b/src/Gui/QuantitySpinBox.h
@@ -45,6 +45,7 @@ class GuiExport QuantitySpinBox : public QAbstractSpinBox, public ExpressionBind
     Q_PROPERTY(double singleStep READ singleStep WRITE setSingleStep)
     Q_PROPERTY(double rawValue READ rawValue WRITE setValue NOTIFY valueChanged)
     Q_PROPERTY(Base::Quantity value READ value WRITE setValue NOTIFY valueChanged USER true)
+    Q_PROPERTY(QString boundTo READ boundToName WRITE setBoundToByName)
 
 public:
     using ExpressionBinding::apply;
@@ -88,6 +89,11 @@ public:
     double maximum() const;
     /// Sets the value of the maximum property 
     void setMaximum(double max);
+
+    /// Gets the path of the bound property
+    QString boundToName() const;
+    /// Sets the path of the bound property
+    void setBoundToByName(const QString &path);
 
     /// Set the number portion selected
     void selectNumber();


### PR DESCRIPTION
This change makes it possible to use the QuantitySpinBox from Python and bind the spin box to a property. This makes it possible to support properties with expressions.