### PR TITLE
Path: Ensure loop detection logic ignores tree selections.

### DIFF
--- a/src/Mod/Path/PathCommands.py
+++ b/src/Mod/Path/PathCommands.py
@@ -107,9 +107,9 @@ class _CommandSelectLoop:
             if names[0][0:4] == 'Face' and horizontalFaceLoop(obj, sub, names):
                 return True
             return False
-        if len(sel.SubElementNames) == 1 and horizontalEdgeLoop(obj, sub):
+        if len(names) == 1 and horizontalEdgeLoop(obj, sub):
             return True
-        if names[1][0:4] != 'Edge':
+        if len(names) == 1 or names[1][0:4] != 'Edge':
             return False
         return True
 

--- a/src/Mod/Path/PathCommands.py
+++ b/src/Mod/Path/PathCommands.py
@@ -68,7 +68,10 @@ class _CommandSelectLoop:
                 return self.active
             self.obj = sel.Object
             self.sub = sel.SubElementNames
-            self.active = self.formsPartOfALoop(sel.Object, sel.SubObjects[0], sel.SubElementNames)
+            if sel.SubObjects:
+                self.active = self.formsPartOfALoop(sel.Object, sel.SubObjects[0], sel.SubElementNames)
+            else:
+                self.active = False
             return self.active
         except Exception as exc:
             PathLog.error(exc)


### PR DESCRIPTION
When selecting an item in the tree the loop detection logic gets triggered and references sub-objects without checking if they exist - resulting in an error.