### PR TITLE
Use unit conversion when changing FeedRates

### DIFF
--- a/src/Mod/Path/PathScripts/PathJobGui.py
+++ b/src/Mod/Path/PathScripts/PathJobGui.py
@@ -752,6 +752,18 @@ class TaskPanel:
             except:
                 pass
             item.setText("%s%g" % ('+' if tc.SpindleDir == 'Forward' else '-', tc.SpindleSpeed))
+        elif 'HorizFeed' == prop or 'VertFeed' == prop:
+            vUnit = FreeCAD.Units.Quantity(1, FreeCAD.Units.Velocity).getUserPreferred()[2]
+            try:
+                val = FreeCAD.Units.Quantity(item.text())
+                if FreeCAD.Units.Velocity == val.Unit:
+                    setattr(tc, prop, val)
+                elif FreeCAD.Units.Unit() == val.Unit:
+                    val = FreeCAD.Units.Quantity(item.text()+vUnit);
+                    setattr(tc, prop, val)
+            except:
+                pass
+            item.setText("%g" % getattr(tc, prop).getValueAs(vUnit))
         else:
             try:
                 val = FreeCAD.Units.Quantity(item.text())


### PR DESCRIPTION
Use unit conversion when changing FeedRates in the tools table of the job edit panel.

If the user enters a valid velocity quantity it will be used,
Otherwise if the user enters a unitless value the default velocity unit will be used,
Otherwise error.