### PR TITLE
Fix rendering of Unit::ThermalConductivity

### DIFF
--- a/src/Base/UnitsSchemaInternal.cpp
+++ b/src/Base/UnitsSchemaInternal.cpp
@@ -114,7 +114,7 @@ QString UnitsSchemaInternal::schemaTranslate(const Quantity &quant, double &fact
         }
     }
     else if (unit == Unit::ThermalConductivity) {
-        if (UnitValue < 1000) {
+        if (UnitValue > 1000000) {
             unitString = QString::fromLatin1("W/mm/K");
             factor = 1000000.0;
         }

--- a/src/Base/UnitsSchemaMKS.cpp
+++ b/src/Base/UnitsSchemaMKS.cpp
@@ -143,7 +143,7 @@ QString UnitsSchemaMKS::schemaTranslate(const Quantity &quant, double &factor, Q
         }
     }
     else if (unit == Unit::ThermalConductivity) {
-        if (UnitValue < 1000) {
+        if (UnitValue > 1000000) {
             unitString = QString::fromLatin1("W/mm/K");
             factor = 1000000.0;
         }


### PR DESCRIPTION
The old behaviour was:
```
>>> Quantity('0.9 W/m/K').UserString
u'0.00 W/mm/K'
>>> Quantity('1.1 W/m/K').UserString
u'1.10 W/m/K'
>>> Quantity('1100 W/m/K').UserString
u'1100.00 W/m/K'
```

The new behaviour is:
```
>>> Quantity('0.9 W/m/K').UserString
u'0.90 W/m/K'
>>> Quantity('1.1 W/m/K').UserString
u'1.10 W/m/K'
>>> Quantity('1100 W/m/K').UserString
u'1.10 W/mm/K'
```

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
  There is one failure, but it is the same before and after the change, so doesn't look like a regression to me.
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [not applicable] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR once it is merged.

---
