### PR TITLE
Capitalize beginning of tooltips + Typos

### DIFF
--- a/src/Base/Sequencer.cpp
+++ b/src/Base/Sequencer.cpp
@@ -63,7 +63,7 @@ namespace Base {
 
     /**
      * The _instances member just stores the pointer of the
-     * all instanciated SequencerBase objects.
+     * all instantiated SequencerBase objects.
      */
     std::vector<SequencerBase*> SequencerP::_instances;
     SequencerLauncher* SequencerP::_topLauncher = 0;

--- a/src/Gui/DlgSettingsDocument.ui
+++ b/src/Gui/DlgSettingsDocument.ui
@@ -527,7 +527,7 @@
       <item row="3" column="1" colspan="2">
        <widget class="Gui::PrefLineEdit" name="prefLicenseUrl">
         <property name="toolTip">
-         <string>An URL where the user can find more details about the license</string>
+         <string>A URL where the user can find more details about the license</string>
         </property>
         <property name="text">
          <string notr="true">http://en.wikipedia.org/wiki/All_rights_reserved</string>

--- a/src/Gui/Document.cpp
+++ b/src/Gui/Document.cpp
@@ -1455,7 +1455,7 @@ std::vector<std::string> Document::getRedoVector(void) const
     return getDocument()->getAvailableRedoNames();
 }
 
-/// Will UNDO  one or more steps
+/// Will UNDO one or more steps
 void Document::undo(int iSteps)
 {
     for (int i=0;i<iSteps;i++) {
@@ -1463,7 +1463,7 @@ void Document::undo(int iSteps)
     }
 }
 
-/// Will REDO  one or more steps
+/// Will REDO one or more steps
 void Document::redo(int iSteps)
 {
     for (int i=0;i<iSteps;i++) {
@@ -1517,7 +1517,7 @@ void Document::handleChildren3D(ViewProvider* viewProvider)
     } 
     
     //find all unclaimed viewproviders and add them back to the document (this happens if a 
-    //viewprovider has been claimed before, but the object droped it. 
+    //viewprovider has been claimed before, but the object dropped it. 
     if(rebuild) {
         auto vpmap = d->_ViewProviderMap;
         for( auto& pair  : d->_ViewProviderMap ) {

--- a/src/Mod/Arch/Resources/ui/ArchMaterial.ui
+++ b/src/Mod/Arch/Resources/ui/ArchMaterial.ui
@@ -205,7 +205,7 @@
         </sizepolicy>
        </property>
        <property name="toolTip">
-        <string>An URL describing this material</string>
+        <string>A URL describing this material</string>
        </property>
       </widget>
      </item>

--- a/src/Mod/Arch/Resources/ui/preferences-arch.ui
+++ b/src/Mod/Arch/Resources/ui/preferences-arch.ui
@@ -510,7 +510,7 @@
         <item>
          <widget class="Gui::PrefCheckBox" name="checkBox_3">
           <property name="toolTip">
-           <string>if this is checked, the &quot;open BimServer in browser&quot; button will open the Bim Server interface in an external browser instead of the FreeCAD web workbench</string>
+           <string>If this is checked, the &quot;open BimServer in browser&quot; button will open the Bim Server interface in an external browser instead of the FreeCAD web workbench</string>
           </property>
           <property name="text">
            <string>Open in external browser</string>

--- a/src/Mod/Cam/App/SpringbackCorrection.cpp
+++ b/src/Mod/Cam/App/SpringbackCorrection.cpp
@@ -278,7 +278,7 @@ bool SpringbackCorrection::CalcCurv()
 
 
 
-        FacePntVector.resize(innerpoints);  // stores inner-points and sourrounding edges-distances
+        FacePntVector.resize(innerpoints);  // stores inner-points and surrounding edges-distances
 
         // explores the edges of the face ----------------------
         for (aExpEdge.Init(aFace,TopAbs_EDGE);aExpEdge.More();aExpEdge.Next())

--- a/src/Mod/Cam/App/SpringbackCorrection.h
+++ b/src/Mod/Cam/App/SpringbackCorrection.h
@@ -82,9 +82,9 @@ struct MeshPnt
 /** @brief a struct for computing the maximum and minimum curvature-radius
            of a single mesh-point
     @param pnt        mesh-point
-    @param distances  distance-vector to all sourrounding edges
-    @param MinEdgeOff minimum curvature-radii of sourrounding edges
-    @param MaxEdgeOff maximum curvature-radii of sourrounding edges
+    @param distances  distance-vector to all surrounding edges
+    @param MinEdgeOff minimum curvature-radii of surrounding edges
+    @param MaxEdgeOff maximum curvature-radii of surrounding edges
 */
 struct FacePnt
 {

--- a/src/Mod/Draft/Resources/ui/preferences-draftsnap.ui
+++ b/src/Mod/Draft/Resources/ui/preferences-draftsnap.ui
@@ -444,7 +444,7 @@
         <item>
          <widget class="Gui::PrefSpinBox" name="spinBox">
           <property name="toolTip">
-           <string>the number of horizontal or vertical lines of the grid</string>
+           <string>The number of horizontal or vertical lines of the grid</string>
           </property>
           <property name="alignment">
            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>

--- a/src/Mod/Draft/Resources/ui/preferences-draftvisual.ui
+++ b/src/Mod/Draft/Resources/ui/preferences-draftvisual.ui
@@ -51,7 +51,7 @@
         <item>
          <widget class="Gui::PrefColorButton" name="gui::prefcolorbutton">
           <property name="toolTip">
-           <string>the default color for new objects</string>
+           <string>The default color for new objects</string>
           </property>
           <property name="color">
            <color>
@@ -95,7 +95,7 @@
         <item>
          <widget class="Gui::PrefSpinBox" name="gui::prefspinbox">
           <property name="toolTip">
-           <string>the default linewidth for new objects</string>
+           <string>The default linewidth for new objects</string>
           </property>
           <property name="value">
            <number>2</number>
@@ -168,7 +168,7 @@
         <item>
          <widget class="Gui::PrefColorButton" name="gui::prefcolorbutton_2">
           <property name="toolTip">
-           <string>the default color for snap symbols</string>
+           <string>The default color for snap symbols</string>
           </property>
           <property name="color">
            <color>
@@ -192,7 +192,7 @@
         <item>
          <widget class="Gui::PrefCheckBox" name="gui::prefcheckbox">
           <property name="toolTip">
-           <string>check this if you want to use the color/linewidth from the toolbar as default</string>
+           <string>Check this if you want to use the color/linewidth from the toolbar as default</string>
           </property>
           <property name="text">
            <string>Save current color and linewidth across sessions</string>
@@ -212,7 +212,7 @@
         <item>
          <widget class="Gui::PrefCheckBox" name="gui::prefcheckbox_11">
           <property name="toolTip">
-           <string>if checked, a widget indicating the current working plane orientation appears during drawing operations</string>
+           <string>If checked, a widget indicating the current working plane orientation appears during drawing operations</string>
           </property>
           <property name="text">
            <string>Show Working Plane tracker</string>
@@ -387,7 +387,7 @@
         <item>
          <widget class="Gui::PrefLineEdit" name="lineEdit">
           <property name="toolTip">
-           <string>A SVG linestyle definition</string>
+           <string>An SVG linestyle definition</string>
           </property>
           <property name="text">
            <string>0.09,0.05</string>
@@ -430,7 +430,7 @@
         <item>
          <widget class="Gui::PrefLineEdit" name="lineEdit_2">
           <property name="toolTip">
-           <string>A SVG linestyle definition</string>
+           <string>An SVG linestyle definition</string>
           </property>
           <property name="text">
            <string>0.09,0.05,0.02,0.05</string>
@@ -473,7 +473,7 @@
         <item>
          <widget class="Gui::PrefLineEdit" name="lineEdit_3">
           <property name="toolTip">
-           <string>A SVG linestyle definition</string>
+           <string>An SVG linestyle definition</string>
           </property>
           <property name="text">
            <string>0.02,0.02</string>

--- a/src/Mod/Draft/Resources/ui/preferences-dxf.ui
+++ b/src/Mod/Draft/Resources/ui/preferences-dxf.ui
@@ -112,7 +112,7 @@
         <item>
          <widget class="Gui::PrefCheckBox" name="gui::prefcheckbox_2">
           <property name="toolTip">
-           <string>if this is unchecked, texts/mtexts won't be imported</string>
+           <string>If this is unchecked, texts/mtexts won't be imported</string>
           </property>
           <property name="text">
            <string>texts and dimensions</string>
@@ -141,7 +141,7 @@
         <item>
          <widget class="Gui::PrefCheckBox" name="gui::prefcheckbox_3">
           <property name="toolTip">
-           <string>if this is checked, paper space objects will be imported too</string>
+           <string>If this is checked, paper space objects will be imported too</string>
           </property>
           <property name="text">
            <string>layouts</string>
@@ -330,7 +330,7 @@ Ex: for files in millimeters: 1, in centimeters: 10, in meters: 1000, in inches:
         <item>
          <widget class="Gui::PrefCheckBox" name="gui::prefcheckbox_5">
           <property name="toolTip">
-           <string>if this is checked, objects from the same layers will be joined into Draft Blocks, turning the display faster, but making them less easily editable</string>
+           <string>If this is checked, objects from the same layers will be joined into Draft Blocks, turning the display faster, but making them less easily editable</string>
           </property>
           <property name="text">
            <string>Group layers into blocks</string>

--- a/src/Mod/Import/App/SCL/SimpleReader.py
+++ b/src/Mod/Import/App/SCL/SimpleReader.py
@@ -33,7 +33,7 @@
 
 Reads a given STEP file. Maps the entities and instantiate the
 corresponding classes.
-In addition it writes out a graphwiz file with the entity graph.
+In addition it writes out a graphviz file with the entity graph.
 """
 
 import Part21,sys
@@ -91,7 +91,7 @@ class SimpleParser:
             self._writeGraphVizEdge( i,self._p21loader._instances_definition[i][1],gvFile)
         gvFile.write('}\n')
 
-    def instaciate(self):
+    def instantiate(self):
         """Instantiate the python class from the entities"""
         import inspect
         # load the needed schema module
@@ -166,6 +166,6 @@ class SimpleParser:
 if __name__ == "__main__":
     sys.path.append('..') # path where config_control_design.py is found
     parser = SimpleReader("Aufspannung.stp") # simple test file
-    #parser.instaciate()
+    #parser.instantiate()
     parser.writeGraphViz('TestGrap.gv')
     #dot.exe -Tsvg -o Test.svg e:\fem-dev\src\Mod\Import\App\SCL\TestGrap-geo.gv

--- a/src/Mod/Mesh/Gui/ViewProvider.cpp
+++ b/src/Mod/Mesh/Gui/ViewProvider.cpp
@@ -332,7 +332,7 @@ ViewProviderMesh::~ViewProviderMesh()
 
 void ViewProviderMesh::onChanged(const App::Property* prop)
 {
-    // we gonna change the number of colors to one
+    // we're going to change the number of colors to one
     if (prop == &ShapeColor || prop == &ShapeMaterial) {
         pcMatBinding->value = SoMaterialBinding::OVERALL;
     }

--- a/src/Mod/OpenSCAD/Resources/ui/openscadprefs-base.ui
+++ b/src/Mod/OpenSCAD/Resources/ui/openscadprefs-base.ui
@@ -202,7 +202,7 @@
         <item>
          <widget class="QLabel" name="label_3">
           <property name="toolTip">
-           <string>minimum angle for a fragment</string>
+           <string>Minimum angle for a fragment</string>
           </property>
           <property name="text">
            <string>angular (fa)</string>
@@ -212,7 +212,7 @@
         <item>
          <widget class="Gui::PrefDoubleSpinBox" name="doubleSpinBox_2">
           <property name="toolTip">
-           <string>minimum angle for a fragment</string>
+           <string>Minimum angle for a fragment</string>
           </property>
           <property name="suffix">
            <string>°</string>
@@ -244,7 +244,7 @@
         <item>
          <widget class="QLabel" name="label_4">
           <property name="toolTip">
-           <string>minimum size of a fragment</string>
+           <string>Minimum size of a fragment</string>
           </property>
           <property name="text">
            <string>size (fs)</string>
@@ -269,7 +269,7 @@
            </size>
           </property>
           <property name="toolTip">
-           <string>minimum size of a fragment</string>
+           <string>Minimum size of a fragment</string>
           </property>
           <property name="alignment">
            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>

--- a/src/Mod/Path/Gui/Resources/panels/PageBaseHoleGeometryEdit.ui
+++ b/src/Mod/Path/Gui/Resources/panels/PageBaseHoleGeometryEdit.ui
@@ -19,7 +19,7 @@
      <item row="0" column="0" colspan="3">
       <widget class="QTableWidget" name="baseList">
        <property name="toolTip">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Table of hole features and the determined radius of the associated hole.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;You can add feature for processing by selecting them and then pressing Add. If a feature is accidentally added to the list it can be removed through Remove and will no longer be processed.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Reset deletes all current items from the list and fills the list with all circular holes elegible for the operation from the model. You can again refine the list afterwards by enabling/disabling, removing and adding features.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Table of hole features and the determined radius of the associated hole.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;You can add feature for processing by selecting them and then pressing Add. If a feature is accidentally added to the list it can be removed through Remove and will no longer be processed.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Reset deletes all current items from the list and fills the list with all circular holes eligible for the operation from the model. You can again refine the list afterwards by enabling/disabling, removing and adding features.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
        </property>
        <attribute name="horizontalHeaderStretchLastSection">
         <bool>true</bool>
@@ -39,7 +39,7 @@
      <item row="1" column="2">
       <widget class="QPushButton" name="resetBase">
        <property name="toolTip">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Remove all list items and fill list with all elegible features from the job's base object.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Remove all list items and fill list with all eligible features from the job's base object.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
        </property>
        <property name="text">
         <string>Reset</string>

--- a/src/Mod/Path/Gui/Resources/panels/PageOpProfileFullEdit.ui
+++ b/src/Mod/Path/Gui/Resources/panels/PageOpProfileFullEdit.ui
@@ -160,7 +160,7 @@
       <item row="2" column="1">
        <widget class="QCheckBox" name="processPerimeter">
         <property name="toolTip">
-         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Check if this profile operation should also process the outside primeter of the base geomtry shapes.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Check if this profile operation should also process the outside perimeter of the base geomtry shapes.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
         </property>
         <property name="text">
          <string>Process Perimeter</string>

--- a/src/Mod/Sketcher/Gui/SketchRectangularArrayDialog.ui
+++ b/src/Mod/Sketcher/Gui/SketchRectangularArrayDialog.ui
@@ -90,7 +90,7 @@
    <item>
     <widget class="Gui::PrefCheckBox" name="ConstraintSeparationCheckBox">
      <property name="toolTip">
-      <string>if selected, each element in the array is constraint with respect to the others using construction lines</string>
+      <string>If selected, each element in the array is constraint with respect to the others using construction lines</string>
      </property>
      <property name="layoutDirection">
       <enum>Qt::LeftToRight</enum>

--- a/src/Mod/Sketcher/Gui/TaskSketcherSolverAdvanced.ui
+++ b/src/Mod/Sketcher/Gui/TaskSketcherSolverAdvanced.ui
@@ -554,7 +554,7 @@
         <string>Degree of verbosity of the debug output to the console</string>
        </property>
        <property name="text">
-        <string>Console  Debug mode:</string>
+        <string>Console Debug mode:</string>
        </property>
       </widget>
      </item>


### PR DESCRIPTION
Capitalized all remaining uncapitalized tooltips. 
+ Fixed typo in instantiate() function. Shouldn't have any repercussions on the code, AFAICT. 
+ other typos