### PR TITLE
Draft: UI Grammar fixes

### DIFF
--- a/src/Mod/Draft/Resources/ui/preferences-draft.ui
+++ b/src/Mod/Draft/Resources/ui/preferences-draft.ui
@@ -300,7 +300,7 @@ Values with differences below this value will be treated as same.</string>
         <item>
          <widget class="Gui::PrefCheckBox" name="gui::prefcheckbox_6">
           <property name="toolTip">
-           <string>If this is checked, objects will appear as filled as default. Otherwise, they will appear as wireframe</string>
+           <string>If this is checked, objects will appear as filled by default. Otherwise, they will appear as wireframe</string>
           </property>
           <property name="text">
            <string>Fill objects with faces whenever possible</string>

--- a/src/Mod/Draft/Resources/ui/preferences-dxf.ui
+++ b/src/Mod/Draft/Resources/ui/preferences-dxf.ui
@@ -310,7 +310,7 @@ Ex: for files in millimeters: 1, in centimeters: 10, in meters: 1000, in inches:
         <item>
          <widget class="Gui::PrefCheckBox" name="gui::prefcheckbox_9">
           <property name="toolTip">
-           <string>If checked, freecad will try to joint coincident objects into wires. Beware, this can take a while...</string>
+           <string>If checked, FreeCAD will try to join coincident objects into wires. Beware, this can take a while...</string>
           </property>
           <property name="text">
            <string>Join geometry</string>


### PR DESCRIPTION
In preferences-dxf.ui I think the intention was to write `join` and not `joint`. @wmayer please confirm, thanks!