### PR TITLE
TravisCI spellcheck [DO NOT MERGE]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -226,12 +226,19 @@ before_install:
   esac
 
 install:
+# Download codespell to test PR for spelling mistakes
+  - pip3 install --user --upgrade git+https://github.com/lucasdemarchi/codespell.git
+
 ####
 #  Build FreeCAD with cmake options set above for each platform
 ##
   - mkdir build && cd build && cmake ${CMAKE_ARGS} -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} ../
 
 script:
+# Run codepsell to test PR for spelling mistakes. 
+# Spelling mistakes _will not_ fail the build but instead return results via PR comment thread 
+  - ./spellcheck_code.sh 
+
 ####
 #  Install FreeCAD and run unit tests.  Test failures will fail the build
 ##

--- a/.travis.yml
+++ b/.travis.yml
@@ -86,6 +86,7 @@ notifications:
 before_install:
 # Download codespell to test PR for spelling mistakes
 - pip install --user --upgrade git+https://github.com/lucasdemarchi/codespell.git
+- source ${TRAVIS_BUILD_DIR}/spellcheck_code.sh
 - eval "$(curl -fsSL "https://raw.githubusercontent.com/${OSX_PORTS_CACHE}/v${FREECAD_RELEASE}/travis-helpers.sh")"
 - |
   case "${TRAVIS_OS_NAME}" in
@@ -236,7 +237,7 @@ install:
 script:
 # Run codepsell to test PR for spelling mistakes. 
 # Spelling mistakes _will not_ fail the build but instead return results via PR comment thread 
-  - ./spellcheck_code.sh 
+  - source ${TRAVIS_BUILD_DIR}/spellcheck_code.sh
 
 ####
 #  Install FreeCAD and run unit tests.  Test failures will fail the build

--- a/.travis.yml
+++ b/.travis.yml
@@ -85,7 +85,7 @@ notifications:
 
 before_install:
 # Download codespell to test PR for spelling mistakes
-  - pip install --user --upgrade git+https://github.com/lucasdemarchi/codespell.git
+- pip install --user --upgrade git+https://github.com/lucasdemarchi/codespell.git
 - eval "$(curl -fsSL "https://raw.githubusercontent.com/${OSX_PORTS_CACHE}/v${FREECAD_RELEASE}/travis-helpers.sh")"
 - |
   case "${TRAVIS_OS_NAME}" in

--- a/.travis.yml
+++ b/.travis.yml
@@ -84,6 +84,8 @@ notifications:
     on_start:   change
 
 before_install:
+# Download codespell to test PR for spelling mistakes
+  - pip install --user --upgrade git+https://github.com/lucasdemarchi/codespell.git
 - eval "$(curl -fsSL "https://raw.githubusercontent.com/${OSX_PORTS_CACHE}/v${FREECAD_RELEASE}/travis-helpers.sh")"
 - |
   case "${TRAVIS_OS_NAME}" in
@@ -226,9 +228,6 @@ before_install:
   esac
 
 install:
-# Download codespell to test PR for spelling mistakes
-  - pip3 install --user --upgrade git+https://github.com/lucasdemarchi/codespell.git
-
 ####
 #  Build FreeCAD with cmake options set above for each platform
 ##

--- a/spellcheck_code.sh
+++ b/spellcheck_code.sh
@@ -27,7 +27,7 @@ echo "$TEXT_CONTENT"
 
 # Download FreeCAD's codespell whitelist in to ./fc-word-whitelist.txt
 echo -e "$BLUE>> Downloading whitelist files:$NC"
-curl -Os https://gist.githubusercontent.com/luzpaz/7ac1bf4412b9c1e5acde715ef9cb612c/raw/fc-word-whitelist.txt`
+curl -Os https://gist.githubusercontent.com/luzpaz/7ac1bf4412b9c1e5acde715ef9cb612c/raw/fc-word-whitelist.txt
 
 # Run codespell 
 echo -e "$BLUE>> Run codespell:$NC"
@@ -43,4 +43,6 @@ curl -i -H "Authorization: token $GH_TOKEN" \
     https://api.github.com/repos/FreeCAD/FreeCAD/issues/$TRAVIS_PULL_REQUEST/comments
 
 # Clean up
-rm ./fc-word-whitelist.txt codespell_results.txt
+# rm ./fc-word-whitelist.txt codespell_results.txt
+
+exit 0;

--- a/spellcheck_code.sh
+++ b/spellcheck_code.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Inspired from https://blog.eleven-labs.com/en/how-to-check-the-spelling-of-your-docs-from-travis-ci/
+# Tips:
+# 1. use "exit 0;" to not interrupt build process
+# 2. Needs a token as an ENV variable that is hidden (DONE: $GH_TOKEN)
+# 3. requires apt package: codespell (we want to install the most up to date codespell) 
+#    pip install --user --upgrade git+https://github.com/lucasdemarchi/codespell.git
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+BLUE='\033[0;36m'
+NC='\033[0m' # No Color
+
+CODESPELL_SKIPS="*.po,*.ts,./.git,./src/3rdParty,./src/zipios++,./src/CXX"
+
+# Round up all changed content
+CHANGED_FILES=($(git diff --name-only $TRAVIS_COMMIT_RANGE))
+
+echo -e "$BLUE>> Following files were changed in this pull request (commit range: $TRAVIS_COMMIT_RANGE):$NC"
+echo "$CHANGED_FILES"
+
+# cat all files that changed
+TEXT_CONTENT=`cat $(echo "$CHANGED_FILES")`
+
+echo -e "$BLUE>> Text content that will be checked:$NC"
+echo "$TEXT_CONTENT"
+
+# Download FreeCAD's codespell whitelist in to ./fc-word-whitelist.txt
+echo -e "$BLUE>> Downloading whitelist files:$NC"
+curl -Os https://gist.githubusercontent.com/luzpaz/7ac1bf4412b9c1e5acde715ef9cb612c/raw/fc-word-whitelist.txt`
+
+# Run codespell 
+echo -e "$BLUE>> Run codespell:$NC"
+codespell -d -q 3 -S "$CODESPELL_SKIPS" -I ./fc-word-whitelist.txt | tee codespell_results.txt
+
+CODESPELL_RESULTS=`cat codespell_results.txt`
+
+# Send results back to the PR comment
+echo -e "$BLUE>> Sending results in a comment on the Github pull request #$TRAVIS_PULL_REQUEST:$NC"
+curl -i -H "Authorization: token $GH_TOKEN" \
+    -H "Content-Type: application/json" \
+    -X POST -d "{\"body\":\"$CODESPELL_RESULTS\"}" \
+    https://api.github.com/repos/FreeCAD/FreeCAD/issues/$TRAVIS_PULL_REQUEST/comments
+
+# Clean up
+rm ./fc-word-whitelist.txt codespell_results.txt

--- a/spellcheck_code.sh
+++ b/spellcheck_code.sh
@@ -3,21 +3,26 @@
 # Tips:
 # 1. use "exit 0;" to not interrupt build process
 # 2. Needs a token as an ENV variable that is hidden (DONE: $GH_TOKEN)
-# 3. requires apt package: codespell (we want to install the most up to date codespell) 
-#    pip install --user --upgrade git+https://github.com/lucasdemarchi/codespell.git
+# 3. requires most up to date codespell: pip install --user --upgrade git+https://github.com/lucasdemarchi/codespell.git
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 BLUE='\033[0;36m'
 NC='\033[0m' # No Color
 
-CODESPELL_SKIPS="*.po,*.ts,./.git,./src/3rdParty,./src/zipios++,./src/CXX"
+TRANSLATION_FILES="*.po,*.ts"
+3RDPARTY_FILES="./src/3rdParty,./src/zipios++,./src/CXX"
+MISC_FILES="./git,./src/Mod/Assembly/App/opendcm,./src/Mod/Cam/App"
+
+# CODESPELL_SKIPS="*.po,*.ts,./.git,./src/3rdParty,./src/zipios++,./src/CXX,./src/Mod/Assembly/App/opendcm,./src/Mod/Cam/App"
+CODESPELL_SKIPS="$TRANSLATION_FILES,$3RDPARTY_FILES,$MISC_FILES"
 
 # Round up all changed content
 CHANGED_FILES=($(git diff --name-only $TRAVIS_COMMIT_RANGE))
 
+# Show File names that changed
 echo -e "$BLUE>> Following files were changed in this pull request (commit range: $TRAVIS_COMMIT_RANGE):$NC"
-echo "$CHANGED_FILES"
+echo -e "$GREEN\n$CHANGED_FILES\n$NC"
 
 # cat all files that changed
 TEXT_CONTENT=`cat $(echo "$CHANGED_FILES")`

--- a/spellcheck_code.sh
+++ b/spellcheck_code.sh
@@ -6,23 +6,28 @@
 # 2. Needs a repo_public token as an ENV variable that is hidden
 # 3. requires most up to date codespell: pip install --user --upgrade git+https://github.com/lucasdemarchi/codespell.git
 
+INTRO="Hi! I'm an automated TravisCI build script bot that reports PR typos. 
+If your PR has typos the build will continue neverthless, *but* 
+we ask you to please provide a follow-up fix. FYI sometimes I report false positives.
+"
+
 # For colorizing output. When using them, we need to terminate with $NC to reset back to default 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 BLUE='\033[0;36m'
 NC='\033[0m' # No Color
 
-# Categorized files/directories that we want codespell to skip 
+# Categorized FreeCAD files/dirs that we want codespell to skip 
 TRANSLATION_FILES="*.po,*.ts"
 THIRDRDPARTY_FILES="./src/3rdParty,./src/zipios++,./src/CXX"
 MISC_FILES="./git,./src/Mod/Assembly/App/opendcm,./src/Mod/Cam/App"
 
-# Output what files/directories we will be skipping
+# Output what FreeCAD files/dirs we will be skipping
 echo -e "$BLUE>> Skipping all translation files: $TRANSLATION_FILES $NC\n"
 echo -e "$BLUE>> Skipping all 3 party directories: $THIRDPARTY_FILES $NC\n"
 echo -e "$BLUE>> Skipping all misc. directories: $MISC_FILES $NC\n"
 
-# consolidate skipped file/directories in to 1 variable
+# consolidate skipped file/dirs all in to 1 variable
 CODESPELL_SKIPS="$TRANSLATION_FILES,$THIRDPARTY_FILES,$MISC_FILES"
 
 # Round up all changed content
@@ -51,9 +56,9 @@ CODESPELL_RESULTS=`cat codespell_results.txt`
 
 # Send results back to the PR comment
 echo -e "$BLUE>> Sending results in a comment on the Github pull request #$TRAVIS_PULL_REQUEST:$NC"
-curl -i -H "Authorization: token $GH_TOKEN" \
+curl -i -H "Authorization: token ${GH_TOKEN}" \
     -H "Content-Type: application/json" \
-    -X POST -d "{\"body\":\"$CODESPELL_RESULTS\"}" \
+    -X POST -d "{\"body\":\"$INTRO\"\"$CODESPELL_RESULTS\"}" \
     https://api.github.com/repos/FreeCAD/FreeCAD/issues/$TRAVIS_PULL_REQUEST/comments
 
 # Clean up

--- a/spellcheck_code.sh
+++ b/spellcheck_code.sh
@@ -19,7 +19,7 @@ NC='\033[0m' # No Color
 
 # Categorized FreeCAD files/dirs that we want codespell to skip 
 TRANSLATION_FILES="*.po,*.ts"
-THIRDRDPARTY_FILES="./src/3rdParty,./src/zipios++,./src/CXX"
+THIRDPARTY_FILES="./src/3rdParty,./src/zipios++,./src/CXX"
 MISC_FILES="./git,./src/Mod/Assembly/App/opendcm,./src/Mod/Cam/App"
 
 # Output what FreeCAD files/dirs we will be skipping
@@ -28,7 +28,7 @@ echo -e "$BLUE>> Skipping all 3 party directories: $THIRDPARTY_FILES $NC\n"
 echo -e "$BLUE>> Skipping all misc. directories: $MISC_FILES $NC\n"
 
 # consolidate skipped file/dirs all in to 1 variable
-CODESPELL_SKIPS="$TRANSLATION_FILES,$THIRDPARTY_FILES,$MISC_FILES"
+CODESPELL_SKIPS="\"${TRANSLATION_FILES},${THIRDPARTY_FILES},${MISC_FILES}\""
 
 # Round up all changed content
 CHANGED_FILES=($(git diff --name-only $TRAVIS_COMMIT_RANGE))
@@ -45,11 +45,11 @@ echo -e "$BLUE>> Text content that will be checked:$NC"
 echo -e "$GREEN\n$TEXT_CONTENT\n$NC"
 
 # Download FreeCAD's codespell whitelist in to ./fc-word-whitelist.txt
-echo -e "$BLUE>> Downloading whitelist files:$NC"
+echo -e "$BLUE>> Downloading FreeCAD whitelist $NC"
 curl -Os https://gist.githubusercontent.com/luzpaz/7ac1bf4412b9c1e5acde715ef9cb612c/raw/fc-word-whitelist.txt
 
 # Run codespell and output results to stdout as well as in to a file
-echo -e "$BLUE>> Run codespell:$NC"
+echo -e "$BLUE>> Run codespell -d -q 3 -S "$CODESPELL_SKIPS" -I ./fc-word-whitelist.txt:$NC"
 codespell -d -q 3 -S "$CODESPELL_SKIPS" -I ./fc-word-whitelist.txt | tee codespell_results.txt
 
 CODESPELL_RESULTS=`cat codespell_results.txt`

--- a/spellcheck_code.sh
+++ b/spellcheck_code.sh
@@ -1,21 +1,29 @@
 #!/bin/bash
+# Script that runs codespell (a typo finder) called from FreeCAD TravisCI to test incoming PRs
 # Inspired from https://blog.eleven-labs.com/en/how-to-check-the-spelling-of-your-docs-from-travis-ci/
 # Tips:
 # 1. use "exit 0;" to not interrupt build process
-# 2. Needs a token as an ENV variable that is hidden (DONE: $GH_TOKEN)
+# 2. Needs a repo_public token as an ENV variable that is hidden
 # 3. requires most up to date codespell: pip install --user --upgrade git+https://github.com/lucasdemarchi/codespell.git
 
+# For colorizing output. When using them, we need to terminate with $NC to reset back to default 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 BLUE='\033[0;36m'
 NC='\033[0m' # No Color
 
+# Categorized files/directories that we want codespell to skip 
 TRANSLATION_FILES="*.po,*.ts"
-3RDPARTY_FILES="./src/3rdParty,./src/zipios++,./src/CXX"
+THIRDRDPARTY_FILES="./src/3rdParty,./src/zipios++,./src/CXX"
 MISC_FILES="./git,./src/Mod/Assembly/App/opendcm,./src/Mod/Cam/App"
 
-# CODESPELL_SKIPS="*.po,*.ts,./.git,./src/3rdParty,./src/zipios++,./src/CXX,./src/Mod/Assembly/App/opendcm,./src/Mod/Cam/App"
-CODESPELL_SKIPS="$TRANSLATION_FILES,$3RDPARTY_FILES,$MISC_FILES"
+# Output what files/directories we will be skipping
+echo -e "$BLUE>> Skipping all translation files: $TRANSLATION_FILES $NC\n"
+echo -e "$BLUE>> Skipping all 3 party directories: $THIRDPARTY_FILES $NC\n"
+echo -e "$BLUE>> Skipping all misc. directories: $MISC_FILES $NC\n"
+
+# consolidate skipped file/directories in to 1 variable
+CODESPELL_SKIPS="$TRANSLATION_FILES,$THIRDPARTY_FILES,$MISC_FILES"
 
 # Round up all changed content
 CHANGED_FILES=($(git diff --name-only $TRAVIS_COMMIT_RANGE))
@@ -27,14 +35,15 @@ echo -e "$GREEN\n$CHANGED_FILES\n$NC"
 # cat all files that changed
 TEXT_CONTENT=`cat $(echo "$CHANGED_FILES")`
 
+# Optionally output all the text in the PRs that is subject to be checked. 
 echo -e "$BLUE>> Text content that will be checked:$NC"
-echo "$TEXT_CONTENT"
+echo -e "$GREEN\n$TEXT_CONTENT\n$NC"
 
 # Download FreeCAD's codespell whitelist in to ./fc-word-whitelist.txt
 echo -e "$BLUE>> Downloading whitelist files:$NC"
 curl -Os https://gist.githubusercontent.com/luzpaz/7ac1bf4412b9c1e5acde715ef9cb612c/raw/fc-word-whitelist.txt
 
-# Run codespell 
+# Run codespell and output results to stdout as well as in to a file
 echo -e "$BLUE>> Run codespell:$NC"
 codespell -d -q 3 -S "$CODESPELL_SKIPS" -I ./fc-word-whitelist.txt | tee codespell_results.txt
 


### PR DESCRIPTION
This PR checks the possibility of integrating a spell checker in the PR process that does not fail the build if typos are found but instead returns the results to the comment thread of said PR. 

This PR is not ready to be merged.

Forum thread: https://forum.freecadweb.org/viewtopic.php?f=8&t=24908

**EDIT:**
Example output looks like:
```
[beast@beast FreeCAD]$ codespell -d -q 3 --skip="*.po,*.ts,./.git,./src/3rdParty,./src/zipios++,./src/CXX,./src/Mod/Assembly/App/opendcm,./src/Mod/Cam/App" --ignore-words=../fc-word-whitelist.txt
./src/Doc/FreeCAD.uml:1910: Persistance  ==> Persistence
./src/Doc/FreeCAD.uml:3184: Persistance  ==> Persistence
./src/Mod/Fem/FemMeshTools.py:676: ans  ==> and
./src/Mod/Fem/FemMeshTools.py:735: retrive  ==> retrieve
./src/Mod/Fem/FemMeshTools.py:735: elments  ==> elements
./src/Mod/Fem/FemMeshTools.py:783: lokale  ==> locale
./src/Mod/Fem/ObjectsFem.py:252: regon  ==> region
./src/Mod/Fem/ObjectsFem.py:275: regon  ==> region
./src/Mod/Fem/FemInputWriterCcx.py:384: retriving  ==> retrieving
./src/Mod/Fem/FemInputWriterCcx.py:877: elment  ==> element
./src/Mod/Fem/PyObjects/_FemMeshGmsh.py:46: inflatoin  ==> inflation
./src/Mod/Fem/PyObjects/_FemMeshGmsh.py:87: Gemetrical  ==> Geometrical
./src/Gui/Stylesheets/Dark-green.qss:74: Reseting  ==> Resetting
./src/Gui/Stylesheets/Dark-blue.qss:74: Reseting  ==> Resetting
./src/Gui/Stylesheets/Light-blue.qss:74: Reseting  ==> Resetting
./src/Gui/Stylesheets/Dark-orange.qss:74: Reseting  ==> Resetting
./src/Gui/Stylesheets/Light-orange.qss:74: Reseting  ==> Resetting
./src/Gui/Stylesheets/Light-green.qss:74: Reseting  ==> Resetting
```
False positives are whitelisted. The current whitelist can be found at:
https://gist.githubusercontent.com/luzpaz/7ac1bf4412b9c1e5acde715ef9cb612c/raw/fc-word-whitelist.txt