### PR TITLE
TravisCI spellcheck

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -84,6 +84,9 @@ notifications:
     on_start:   change
 
 before_install:
+# Download codespell to test PR for spelling mistakes
+- pip install --user --upgrade git+https://github.com/lucasdemarchi/codespell.git
+- source ${TRAVIS_BUILD_DIR}/spellcheck_code.sh
 - eval "$(curl -fsSL "https://raw.githubusercontent.com/${OSX_PORTS_CACHE}/v${FREECAD_RELEASE}/travis-helpers.sh")"
 - |
   case "${TRAVIS_OS_NAME}" in
@@ -232,6 +235,10 @@ install:
   - mkdir build && cd build && cmake ${CMAKE_ARGS} -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} ../
 
 script:
+# Run codepsell to test PR for spelling mistakes. 
+# Spelling mistakes _will not_ fail the build but instead return results via PR comment thread 
+  - source ${TRAVIS_BUILD_DIR}/spellcheck_code.sh
+
 ####
 #  Install FreeCAD and run unit tests.  Test failures will fail the build
 ##

--- a/.travis.yml
+++ b/.travis.yml
@@ -235,10 +235,6 @@ install:
   - mkdir build && cd build && cmake ${CMAKE_ARGS} -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} ../
 
 script:
-# Run codepsell to test PR for spelling mistakes. 
-# Spelling mistakes _will not_ fail the build but instead return results via PR comment thread 
-  - source ${TRAVIS_BUILD_DIR}/spellcheck_code.sh
-
 ####
 #  Install FreeCAD and run unit tests.  Test failures will fail the build
 ##

--- a/.travis.yml
+++ b/.travis.yml
@@ -84,9 +84,12 @@ notifications:
     on_start:   change
 
 before_install:
-# Download codespell to test PR for spelling mistakes
-- pip install --user --upgrade git+https://github.com/lucasdemarchi/codespell.git
-- source ${TRAVIS_BUILD_DIR}/spellcheck_code.sh
+# Download codespell to test PR for spelling mistakes (linux only)
+- |
+  if [ "${TRAVIS_OS_NAME}" == "linux" ]; then
+     pip install --user --upgrade git+https://github.com/lucasdemarchi/codespell.git
+     source ${TRAVIS_BUILD_DIR}/spellcheck_code.sh
+  fi
 - eval "$(curl -fsSL "https://raw.githubusercontent.com/${OSX_PORTS_CACHE}/v${FREECAD_RELEASE}/travis-helpers.sh")"
 - |
   case "${TRAVIS_OS_NAME}" in

--- a/spellcheck_code.sh
+++ b/spellcheck_code.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# Script that runs codespell (a typo finder) called from FreeCAD TravisCI to test incoming PRs
+# Inspired from https://blog.eleven-labs.com/en/how-to-check-the-spelling-of-your-docs-from-travis-ci/
+# Tips:
+# 1. use "exit 0;" to not interrupt build process
+# 2. Needs a repo_public token as an ENV variable that is hidden
+# 3. requires most up to date codespell: pip install --user --upgrade git+https://github.com/lucasdemarchi/codespell.git
+
+
+# For colorizing output. When using them, we need to terminate with $NC to reset back to default 
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+BLUE='\033[0;36m'
+NC='\033[0m' # No Color
+
+# Categorized FreeCAD files/dirs that we want codespell to skip 
+TRANSLATION_FILES="*.po,*.ts"
+THIRDPARTY_FILES="./src/3rdParty,./src/zipios++,./src/CXX"
+MISC_FILES="./git,./src/Mod/Assembly/App/opendcm,./src/Mod/Cam/App"
+
+# Output what FreeCAD files/dirs we will be skipping
+echo -e "$BLUE>> Skipping all translation files: $TRANSLATION_FILES $NC\n"
+echo -e "$BLUE>> Skipping all 3 party directories: $THIRDPARTY_FILES $NC\n"
+echo -e "$BLUE>> Skipping all misc. directories: $MISC_FILES $NC\n"
+
+# consolidate skipped file/dirs all in to 1 variable
+CODESPELL_SKIPS="\"${TRANSLATION_FILES},${THIRDPARTY_FILES},${MISC_FILES}\""
+
+# Round up all changed content
+# TODO: Figure out how to make $CHANGED_FILES output a list of files separated by a space
+CHANGED_FILES=($(git diff --name-only $TRAVIS_COMMIT_RANGE))
+
+
+# Show File names that changed
+echo -e "$BLUE>> Following files were changed in this pull request (commit range: $TRAVIS_COMMIT_RANGE):$NC"
+echo -e "$GREEN\n$CHANGED_FILES\n$NC"
+
+# cat all files that changed
+TEXT_CONTENT=`cat $(echo "$CHANGED_FILES")`
+
+# Optionally output all the text in the PRs that is subject to be checked. 
+# echo -e "$BLUE>> Text content that will be checked:$NC"
+# echo -e "$GREEN\n$TEXT_CONTENT\n$NC"
+
+# Download FreeCAD's codespell whitelist in to ./fc-word-whitelist.txt
+echo -e "$BLUE>> Downloading FreeCAD whitelist $NC"
+curl -Os https://gist.githubusercontent.com/luzpaz/7ac1bf4412b9c1e5acde715ef9cb612c/raw/fc-word-whitelist.txt
+
+# Run codespell and output results to stdout as well as in to a file
+echo -e "$BLUE>> Run codespell -d -q 3 -S "$CODESPELL_SKIPS" -I ./fc-word-whitelist.txt:$NC"
+codespell -d -q 3 -S "$CODESPELL_SKIPS" -I ./fc-word-whitelist.txt 
+
+exit 0;

--- a/spellcheck_code.sh
+++ b/spellcheck_code.sh
@@ -27,7 +27,6 @@ echo -e "$BLUE>> Skipping all misc. directories: $MISC_FILES $NC\n"
 CODESPELL_SKIPS="\"${TRANSLATION_FILES},${THIRDPARTY_FILES},${MISC_FILES}\""
 
 # Round up all changed content
-# TODO: Figure out how to make $CHANGED_FILES output a list of files separated by a space
 CHANGED_FILES=($(git diff --name-only $TRAVIS_COMMIT_RANGE))
 
 
@@ -35,8 +34,9 @@ CHANGED_FILES=($(git diff --name-only $TRAVIS_COMMIT_RANGE))
 echo -e "$BLUE>> Following files were changed in this pull request (commit range: $TRAVIS_COMMIT_RANGE):$NC"
 echo -e "$GREEN\n$CHANGED_FILES\n$NC"
 
+
 # cat all files that changed
-TEXT_CONTENT=`cat $(echo "$CHANGED_FILES")`
+# TEXT_CONTENT=`cat $(echo "$CHANGED_FILES")`
 
 # Optionally output all the text in the PRs that is subject to be checked. 
 # echo -e "$BLUE>> Text content that will be checked:$NC"
@@ -48,6 +48,8 @@ curl -Os https://gist.githubusercontent.com/luzpaz/7ac1bf4412b9c1e5acde715ef9cb6
 
 # Run codespell and output results to stdout as well as in to a file
 echo -e "$BLUE>> Run codespell -d -q 3 -S "$CODESPELL_SKIPS" -I ./fc-word-whitelist.txt:$NC"
-codespell -d -q 3 -S "$CODESPELL_SKIPS" -I ./fc-word-whitelist.txt 
+# we need to sort the diffed file names in to a space delimited list so that we can pass it as parameters to codespell
+# hence the bash sorcery below 
+mapfile -t files < <(git diff --name-only $TRAVIS_COMMIT_RANGE); codespell -d -q 3 -S "$CODESPELL_SKIPS" -I ./fc-word-whitelist.txt  "${files[@]}"
 
-exit 0;
+# exit 0;


### PR DESCRIPTION
This PR integrates a spell checker in the PR process that does not fail the build if typos are found but instead returns the results to the ~PR comment thread~ TravisCI STDOUT for now. Later when we have a buildbot will we be able to return results to the PR comment thread. For now folks can look at the TravisCI logs.