### PR TITLE
Management of Rotations (direction and angles) 

### DIFF
--- a/src/App/PropertyGeo.cpp
+++ b/src/App/PropertyGeo.cpp
@@ -744,10 +744,18 @@ void PropertyPlacement::Save (Base::Writer &writer) const
     writer.Stream() << " Px=\"" <<  _cPos.getPosition().x 
                     << "\" Py=\"" <<  _cPos.getPosition().y
                     << "\" Pz=\"" <<  _cPos.getPosition().z << "\"";
+
     writer.Stream() << " Q0=\"" <<  _cPos.getRotation()[0]
                     << "\" Q1=\"" <<  _cPos.getRotation()[1]
                     << "\" Q2=\"" <<  _cPos.getRotation()[2]
                     << "\" Q3=\"" <<  _cPos.getRotation()[3] << "\"";
+	Vector3d axis;
+	double rfAngle;
+	_cPos.getRotation().getValue(axis, rfAngle);
+    writer.Stream() << " A=\"" <<  rfAngle
+                    << "\" Ox=\"" <<  axis.x
+                    << "\" Oy=\"" <<  axis.y
+                    << "\" Oz=\"" <<  axis.z << "\"";
     writer.Stream() <<"/>" << endl;
 }
 
@@ -757,13 +765,25 @@ void PropertyPlacement::Restore(Base::XMLReader &reader)
     reader.readElement("PropertyPlacement");
     // get the value of my Attribute
     aboutToSetValue();
-    _cPos = Base::Placement(Vector3d(reader.getAttributeAsFloat("Px"),
+	if (reader.hasAttribute("A")) {
+		_cPos = Base::Placement(Vector3d(reader.getAttributeAsFloat("Px"),
+                                     reader.getAttributeAsFloat("Py"),
+                                     reader.getAttributeAsFloat("Pz")),
+                            Rotation(
+                                     Vector3d(reader.getAttributeAsFloat("Ox"),
+											  reader.getAttributeAsFloat("Oy"),
+											  reader.getAttributeAsFloat("Oz")),
+									  reader.getAttributeAsFloat("A")));
+	} else {
+		_cPos = Base::Placement(Vector3d(reader.getAttributeAsFloat("Px"),
                                      reader.getAttributeAsFloat("Py"),
                                      reader.getAttributeAsFloat("Pz")),
                             Rotation(reader.getAttributeAsFloat("Q0"),
                                      reader.getAttributeAsFloat("Q1"),
                                      reader.getAttributeAsFloat("Q2"),
                                      reader.getAttributeAsFloat("Q3")));
+	
+	}
     hasSetValue();
 }
 

--- a/src/Base/Rotation.cpp
+++ b/src/Base/Rotation.cpp
@@ -116,9 +116,11 @@ void Rotation::evaluateVector () {
         double rfAngle = double(acos(this->quat[3])) * 2.0;
         double scale = (double)sin(rfAngle / 2.0);
         // Get a normalized vector 
-        this->_axis.x = this->quat[0] / scale;
-        this->_axis.y = this->quat[1] / scale;
-        this->_axis.z = this->quat[2] / scale;
+		double l = this->_axis.Length();
+		if (l < Base::Vector3d::epsilon()) l = 1;
+        this->_axis.x = this->quat[0] * l / scale;
+        this->_axis.y = this->quat[1] * l / scale;
+        this->_axis.z = this->quat[2] * l / scale;
 		
 		_angle=double(acos(this->quat[3])) * 2.0;
 		if (_angle>=D_PI) {
@@ -147,6 +149,12 @@ void Rotation::getValue(Vector3d & axis, double & rfAngle) const
 	axis.x = _axis.x;
 	axis.y = _axis.y;
 	axis.z = _axis.z;
+}
+
+void Rotation::getValueNormalized(Vector3d & axis, double & rfAngle) const
+{
+	getValue(axis, rfAngle);
+	axis.Normalize();
 }
 
 /**
@@ -236,13 +244,16 @@ void Rotation::setValue(const Vector3d & axis, const double fAngle)
     norm.Normalize();
 	double l = norm.Length();
 	if (l>0.5) {
-		this->_axis = norm;
+		this->_axis = axis;
+	} else {
+		norm = _axis;
+		norm.Normalize();
 	}
 
     double scale = (double)sin(theAngle/2.0);
-    this->quat[0] = this->_axis.x * scale;
-    this->quat[1] = this->_axis.y * scale;
-    this->quat[2] = this->_axis.z * scale;
+    this->quat[0] = norm.x * scale;
+    this->quat[1] = norm.y * scale;
+    this->quat[2] = norm.z * scale;
 }
 
 void Rotation::setValue(const Vector3d & rotateFrom, const Vector3d & rotateTo)

--- a/src/Base/Rotation.h
+++ b/src/Base/Rotation.h
@@ -103,9 +103,12 @@ public:
     static Rotation makeRotationByAxes(Vector3d xdir, Vector3d ydir, Vector3d zdir, const char* priorityOrder = "ZXY");
 
 
+void evaluateVector ();
 private:
     void normalize();
     double quat[4];
+	Vector3d _axis; // the axis kept not to lose direction when angle is 0
+	double _angle; // this angle to keep the angle chozen by the user
 };
 
 }

--- a/src/Base/Rotation.h
+++ b/src/Base/Rotation.h
@@ -51,6 +51,8 @@ public:
     void getValue(double & q0, double & q1, double & q2, double & q3) const;
     void setValue(const double q0, const double q1, const double q2, const double q3);
     void getValue(Vector3d & axis, double & rfAngle) const;
+    void getValueNormalized(Vector3d & axis, double & rfAngle) const;
+
     void getValue(Matrix4D & matrix) const;
     void setValue(const double q[4]);
     void setValue(const Matrix4D& matrix);

--- a/src/Mod/Path/PathScripts/PathStock.py
+++ b/src/Mod/Path/PathScripts/PathStock.py
@@ -303,6 +303,10 @@ def TemplateAttributes(stock, includeExtent=True, includePlacement=True):
             attrs['rotY'] = rot.Q[1]
             attrs['rotZ'] = rot.Q[2]
             attrs['rotW'] = rot.Q[3]
+            attrs['oX'] = rot.Axis.x
+            attrs['oY'] = rot.Axis.y
+            attrs['oZ'] = rot.Axis.z
+            attrs['angle'] = rot.Angle*180.0/math.pi
 
     return attrs
 
@@ -318,13 +322,23 @@ def CreateFromTemplate(job, template):
             rotY = template.get('rotY')
             rotZ = template.get('rotZ')
             rotW = template.get('rotW')
-            if posX is not None and posY is not None and posZ is not None and rotX is not None and rotY is not None and rotZ is not None and rotW is not None:
+            oX = template.get('oX')
+            oY = template.get('oY')
+            oZ = template.get('oZ')
+            angle = template.get('angle')
+            if posX is not None and posY is not None and posZ is not None :
                 pos = FreeCAD.Vector(float(posX), float(posY), float(posZ)) 
-                rot = FreeCAD.Rotation(float(rotX), float(rotY), float(rotZ), float(rotW))
-                placement = FreeCAD.Placement(pos, rot)
-            elif posX is not None or posY is not None or posZ is not None or rotX is not None or rotY is not None or rotZ is not None or rotW is not None:
+                if oX is not None and oY is not None and oZ is not None and angle is not None :
+                    placement = FreeCAD.Placement(FreeCAD.Vector(posX, posY, posZ), FreeCAD.Vector(oX, oY, oZ), angle)
+                elif rotX is not None and rotY is not None and rotZ is not None and rotW is not None:
+                    pos = FreeCAD.Vector(float(posX), float(posY), float(posZ)) 
+                    rot = FreeCAD.Rotation(float(rotX), float(rotY), float(rotZ), float(rotW))
+                    placement = FreeCAD.Placement(pos, rot)
+                else:
+                    PathLog.warning(translate('PathStock', 'Corrupted or incomplete placement information in template - ignoring'))
+            else:
                 PathLog.warning(translate('PathStock', 'Corrupted or incomplete placement information in template - ignoring'))
-
+			
             if stockType == StockType.FromBase:
                 xneg = template.get('xneg')
                 xpos = template.get('xpos')

--- a/src/Mod/Test/Document.py
+++ b/src/Mod/Test/Document.py
@@ -23,6 +23,7 @@
 #***************************************************************************/
 
 import FreeCAD, os, unittest, tempfile
+import math
 
 
 #---------------------------------------------------------------------------
@@ -1262,18 +1263,24 @@ class DocumentExpressionCases(unittest.TestCase):
     self.Obj1 = self.Doc.addObject("App::FeatureTest","Test")
     self.Obj2 = self.Doc.addObject("App::FeatureTest","Test")
 
+  def assertAlmostEqual (self, v1, v2) :
+    if (math.fabs(v2-v1) > 1E-12) :
+      self.assertEqual(v1,v2)
+
+			
   def testExpression(self):
     # set the object twice to test that the backlinks are removed when overwriting the expression
     self.Obj2.setExpression('Placement.Rotation.Angle', u'%s.Placement.Rotation.Angle' % self.Obj1.Name)
     self.Obj2.setExpression('Placement.Rotation.Angle', u'%s.Placement.Rotation.Angle' % self.Obj1.Name)
     self.Obj1.Placement = FreeCAD.Placement(FreeCAD.Vector(0,0,0),FreeCAD.Rotation(FreeCAD.Vector(0,0,1),10))
     self.Doc.recompute()
-    self.assertEqual(self.Obj1.Placement.Rotation.Angle, self.Obj2.Placement.Rotation.Angle)
+    self.assertAlmostEqual(self.Obj1.Placement.Rotation.Angle, self.Obj2.Placement.Rotation.Angle)
+	
     # clear the expression
     self.Obj2.setExpression('Placement.Rotation.Angle', None)
-    self.assertEqual(self.Obj1.Placement.Rotation.Angle, self.Obj2.Placement.Rotation.Angle)
+    self.assertAlmostEqual(self.Obj1.Placement.Rotation.Angle, self.Obj2.Placement.Rotation.Angle)
     self.Doc.recompute()
-    self.assertEqual(self.Obj1.Placement.Rotation.Angle, self.Obj2.Placement.Rotation.Angle)
+    self.assertAlmostEqual(self.Obj1.Placement.Rotation.Angle, self.Obj2.Placement.Rotation.Angle)
     # touch the objects to perform a recompute
     self.Obj1.Placement = self.Obj1.Placement
     self.Obj2.Placement = self.Obj2.Placement


### PR DESCRIPTION
See Forum :
https://forum.freecadweb.org/viewtopic.php?t=23563
and
https://forum.freecadweb.org/viewtopic.php?f=10&t=24662

This change keep track and the direction and the angle that has been set by the user, whatever the value of the angle is given. The quaternon is also evalutated for any calcuation based on them.
When seting a Rotation with the quaternion, the angle chosen is the one in ]-180, 180] what is more convienent in most cases than [0, 360[.

This allow to use angles in formulas without modulos,  if -5 * 2 is equivalent to 355 * 2, 
-5 /2 is definitively not the same as 355 /2!


Explanation:
Rotation:
-	Add a private attribute Vector to store the direction of the rotation, and manage not to erase this direction when the angle id 0.
-	Add a private attribute to store the angle as defined (no modulo etc)
-	Keep the quaternion for calculations 

PropertyGeo:
-	Saves the rotation with angle and direction instead of saving the quaternion.
-	Attribute name chosen: Ox, Oy and Oz for the coordinates of the axis and A for the angle in radians. This has to be validated.
-	Backward compatibility with the saved files with quaternion (test presence of A to determine which of  the Quaternion (old way) or the direction and angle is stored (new way). New files can be opened by old FreeCAD and vice-versa.

The only side effect I can imagine is that it was possible to set a vector to 0, 0, 0 if the angle was not 0, what is somehow non sense. Now when setting to 0, 0 0 the last not null vector is kept. The vector can not be null any longer.


Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0` (see comment)
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [x] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR once it is merged.

---
