### PR TITLE
Python home

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -932,29 +932,29 @@ endif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 
         find_package(PySide2Tools REQUIRED) # PySide2 utilities (pyside2-uic & pyside2-rcc)
 
-        file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/bin/PySide)
-        file(WRITE ${CMAKE_BINARY_DIR}/bin/PySide/__init__.py "# PySide wrapper\n")
-        file(WRITE ${CMAKE_BINARY_DIR}/bin/PySide/QtCore.py "from PySide2.QtCore import *\n\n"
+        file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/Ext/PySide)
+        file(WRITE ${CMAKE_BINARY_DIR}/Ext/PySide/__init__.py "# PySide wrapper\n")
+        file(WRITE ${CMAKE_BINARY_DIR}/Ext/PySide/QtCore.py "from PySide2.QtCore import *\n\n"
                                                             "#QCoreApplication.CodecForTr=0\n"
                                                             "#QCoreApplication.UnicodeUTF8=1\n")
-        file(WRITE ${CMAKE_BINARY_DIR}/bin/PySide/QtGui.py  "from PySide2.QtGui import *\n"
+        file(WRITE ${CMAKE_BINARY_DIR}/Ext/PySide/QtGui.py  "from PySide2.QtGui import *\n"
                                                             "from PySide2.QtWidgets import *\n"
                                                             "QHeaderView.setResizeMode = QHeaderView.setSectionResizeMode\n")
-        file(WRITE ${CMAKE_BINARY_DIR}/bin/PySide/QtSvg.py  "from PySide2.QtSvg import *\n")
+        file(WRITE ${CMAKE_BINARY_DIR}/Ext/PySide/QtSvg.py  "from PySide2.QtSvg import *\n")
 
 	if(APPLE)
 	    INSTALL(
 	        DIRECTORY	
-                    ${CMAKE_BINARY_DIR}/bin/PySide
+                    ${CMAKE_BINARY_DIR}/Ext/PySide
 		DESTINATION
                     MacOS
             )
 	else()
             INSTALL(
 	        DIRECTORY	
-                    ${CMAKE_BINARY_DIR}/bin/PySide
+                    ${CMAKE_BINARY_DIR}/Ext/PySide
                 DESTINATION
-                    bin
+                    Ext
             )
 	endif()
     else()

--- a/src/Main/MainGui.cpp
+++ b/src/Main/MainGui.cpp
@@ -109,7 +109,11 @@ int main( int argc, char ** argv )
     _putenv("PYTHONPATH=");
     // https://forum.freecadweb.org/viewtopic.php?f=4&t=18288
     // https://forum.freecadweb.org/viewtopic.php?f=3&t=20515
-    _putenv("PYTHONHOME=");
+    const char* fc_py_home = getenv("FC_PYTHONHOME");
+    if (fc_py_home)
+        _putenv_s("PYTHONHOME", fc_py_home);
+    else
+        _putenv("PYTHONHOME=");
 #endif
 
 #if defined (FC_OS_WIN32)


### PR DESCRIPTION
1. add option --python-home / -H <path_to_python_interpreter>
2. move pyside-abstraction-layer to Ext, as bin is not in sys.path for conda (and maybe other distros too...)