### PR TITLE
Path: Bugfix/tags snapper fix

### DIFF
--- a/src/Mod/Draft/DraftSnap.py
+++ b/src/Mod/Draft/DraftSnap.py
@@ -987,7 +987,8 @@ class Snapper:
         self.radius = 0
         self.setCursor()
         if hideSnapBar or Draft.getParam("hideSnapBar",False):
-            self.toolbar.hide()
+            if hasattr(self,"toolbar") and self.toolbar:
+                self.toolbar.hide()
         self.mask = None
         self.lastArchPoint = None
         self.selectMode = False

--- a/src/Mod/Path/Gui/Resources/panels/HoldingTagsEdit.ui
+++ b/src/Mod/Path/Gui/Resources/panels/HoldingTagsEdit.ui
@@ -34,7 +34,7 @@
         <x>0</x>
         <y>0</y>
         <width>381</width>
-        <height>528</height>
+        <height>533</height>
        </rect>
       </property>
       <attribute name="label">
@@ -126,7 +126,7 @@
         </widget>
        </item>
        <item>
-        <widget class="QWidget" name="widget" native="true">
+        <widget class="QWidget" name="removeEditAddGroup" native="true">
          <layout class="QGridLayout" name="gridLayout">
           <item row="1" column="0">
            <widget class="QPushButton" name="pbDelete">

--- a/src/Mod/Path/Gui/Resources/panels/HoldingTagsEdit.ui
+++ b/src/Mod/Path/Gui/Resources/panels/HoldingTagsEdit.ui
@@ -15,187 +15,156 @@
   </property>
   <layout class="QGridLayout" name="gridLayout_2">
    <item row="2" column="0">
-    <widget class="QToolBox" name="toolBox">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
+    <widget class="QWidget" name="removeEditAddGroup" native="true">
+     <layout class="QGridLayout" name="gridLayout">
+      <item row="1" column="2">
+       <widget class="QPushButton" name="pbAdd">
+        <property name="text">
+         <string>Add...</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QPushButton" name="pbDelete">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="text">
+         <string>Delete</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QPushButton" name="pbEdit">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="text">
+         <string>Edit...</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0" colspan="3">
+       <widget class="QGroupBox" name="cbTagGeneration">
+        <property name="title">
+         <string>Auto Generate</string>
+        </property>
+        <layout class="QGridLayout" name="gridLayout_3">
+         <item row="1" column="1">
+          <widget class="QSpinBox" name="sbCount">
+           <property name="minimum">
+            <number>2</number>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <widget class="QPushButton" name="pbGenerate">
+           <property name="enabled">
+            <bool>false</bool>
+           </property>
+           <property name="text">
+            <string>Replace All</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="label">
+           <property name="text">
+            <string>Number of Tags</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QListWidget" name="lwTags">
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;List of current tags. Edit coordinates by double click or Edit button.&lt;/p&gt;&lt;p&gt;Tags are automatically disabled if they overlap with the previous tag, or don't lie on the base wire.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
-     <property name="frameShape">
-      <enum>QFrame::NoFrame</enum>
-     </property>
-     <property name="currentIndex">
-      <number>0</number>
-     </property>
-     <widget class="QWidget" name="tbpTags">
-      <property name="geometry">
-       <rect>
-        <x>0</x>
-        <y>0</y>
-        <width>381</width>
-        <height>533</height>
-       </rect>
+    </widget>
+   </item>
+   <item row="0" column="0">
+    <widget class="QWidget" name="parameterGroup" native="true">
+     <layout class="QFormLayout">
+      <property name="fieldGrowthPolicy">
+       <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
       </property>
-      <attribute name="label">
-       <string>Tags</string>
-      </attribute>
-      <layout class="QVBoxLayout" name="verticalLayout">
-       <item>
-        <widget class="QWidget" name="widget_2" native="true">
-         <layout class="QFormLayout">
-          <property name="fieldGrowthPolicy">
-           <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
-          </property>
-          <item row="0" column="0">
-           <widget class="QLabel" name="label_2">
-            <property name="text">
-             <string>Width</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="label_3">
-            <property name="text">
-             <string>Height</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="0">
-           <widget class="QLabel" name="label_4">
-            <property name="text">
-             <string>Angle            </string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="1">
-           <widget class="Gui::InputField" name="ifWidth">
-            <property name="toolTip">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Width of the resulting holding tag.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="1">
-           <widget class="Gui::InputField" name="ifHeight">
-            <property name="toolTip">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Height of holding tag.&lt;/p&gt;&lt;p&gt;Note that resulting tag might be smaller if the tag's width and angle result in a triangular shape.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="1">
-           <widget class="QDoubleSpinBox" name="dsbAngle">
-            <property name="toolTip">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Plunge angle for ascent and descent of holding tag.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-            </property>
-            <property name="minimum">
-             <double>5.000000000000000</double>
-            </property>
-            <property name="maximum">
-             <double>90.000000000000000</double>
-            </property>
-            <property name="singleStep">
-             <double>15.000000000000000</double>
-            </property>
-            <property name="value">
-             <double>45.000000000000000</double>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="0">
-           <widget class="QLabel" name="label_5">
-            <property name="text">
-             <string>Radius</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="1">
-           <widget class="Gui::InputField" name="ifRadius">
-            <property name="toolTip">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Radius of the fillet at the top.&lt;/p&gt;&lt;p&gt;If the radius is too big for the tag shape it gets reduced to the maximum possible radius - resulting in a spherical shape.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item>
-        <widget class="QListWidget" name="lwTags">
-         <property name="toolTip">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;List of current tags. Edit coordinates by double click or Edit button.&lt;/p&gt;&lt;p&gt;Tags are automatically disabled if they overlap with the previous tag, or don't lie on the base wire.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QWidget" name="removeEditAddGroup" native="true">
-         <layout class="QGridLayout" name="gridLayout">
-          <item row="1" column="0">
-           <widget class="QPushButton" name="pbDelete">
-            <property name="enabled">
-             <bool>false</bool>
-            </property>
-            <property name="text">
-             <string>Delete</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="2">
-           <widget class="QPushButton" name="pbAdd">
-            <property name="text">
-             <string>Add...</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="1">
-           <widget class="QPushButton" name="pbEdit">
-            <property name="enabled">
-             <bool>false</bool>
-            </property>
-            <property name="text">
-             <string>Edit...</string>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item>
-        <widget class="QGroupBox" name="cbTagGeneration">
-         <property name="title">
-          <string>Auto Generate</string>
-         </property>
-         <layout class="QGridLayout" name="gridLayout_3">
-          <item row="1" column="1">
-           <widget class="QSpinBox" name="sbCount">
-            <property name="minimum">
-             <number>2</number>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="1">
-           <widget class="QPushButton" name="pbGenerate">
-            <property name="enabled">
-             <bool>false</bool>
-            </property>
-            <property name="text">
-             <string>Replace All</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="label">
-            <property name="text">
-             <string>Number of Tags</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignCenter</set>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
-      </layout>
-     </widget>
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_2">
+        <property name="text">
+         <string>Width</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_3">
+        <property name="text">
+         <string>Height</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="label_4">
+        <property name="text">
+         <string>Angle            </string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="Gui::InputField" name="ifWidth">
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Width of the resulting holding tag.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="Gui::InputField" name="ifHeight">
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Height of holding tag.&lt;/p&gt;&lt;p&gt;Note that resulting tag might be smaller if the tag's width and angle result in a triangular shape.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QDoubleSpinBox" name="dsbAngle">
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Plunge angle for ascent and descent of holding tag.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="minimum">
+         <double>5.000000000000000</double>
+        </property>
+        <property name="maximum">
+         <double>90.000000000000000</double>
+        </property>
+        <property name="singleStep">
+         <double>15.000000000000000</double>
+        </property>
+        <property name="value">
+         <double>45.000000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="label_5">
+        <property name="text">
+         <string>Radius</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="Gui::InputField" name="ifRadius">
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Radius of the fillet at the top.&lt;/p&gt;&lt;p&gt;If the radius is too big for the tag shape it gets reduced to the maximum possible radius - resulting in a spherical shape.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
     </widget>
    </item>
   </layout>

--- a/src/Mod/Path/PathScripts/PathDressupHoldingTags.py
+++ b/src/Mod/Path/PathScripts/PathDressupHoldingTags.py
@@ -795,7 +795,7 @@ class ObjectTagDressup:
             zVal2 = zVal2 and round(zVal2, 8)
 
             if cmd.Name in ['G1', 'G2', 'G3', 'G01', 'G02', 'G03']:
-                if zVal is not None and zVal2 != zVal:
+                if False and zVal is not None and zVal2 != zVal:
                     params['F'] = vertFeed
                 else:
                     params['F'] = horizFeed

--- a/src/Mod/Path/PathScripts/PathDressupHoldingTags.py
+++ b/src/Mod/Path/PathScripts/PathDressupHoldingTags.py
@@ -653,7 +653,7 @@ class PathData:
 
     def pointIsOnPath(self, p):
         v = Part.Vertex(FreeCAD.Vector(p.x, p.y, self.minZ))
-        PathLog.info("pt = (%f, %f, %f)" % (v.X, v.Y, v.Z))
+        PathLog.debug("pt = (%f, %f, %f)" % (v.X, v.Y, v.Z))
         for e in self.bottomEdges:
             indent = "{} ".format(e.distToShape(v)[0])
             debugEdge(e, indent, True)

--- a/src/Mod/Path/PathScripts/PathDressupHoldingTags.py
+++ b/src/Mod/Path/PathScripts/PathDressupHoldingTags.py
@@ -42,8 +42,11 @@ from PySide import QtCore
 
 """Holding Tags Dressup object and FreeCAD command"""
 
-PathLog.setLevel(PathLog.Level.INFO, PathLog.thisModule())
-#PathLog.trackModule()
+if False:
+    PathLog.setLevel(PathLog.Level.DEBUG, PathLog.thisModule())
+    PathLog.trackModule()
+else:
+    PathLog.setLevel(PathLog.Level.INFO, PathLog.thisModule())
 
 # Qt tanslation handling
 def translate(context, text, disambig=None):
@@ -643,14 +646,18 @@ class PathData:
                 ordered.append(t)
         # disable all tags that are not on the base wire.
         for tag in tags:
-            PathLog.notice("Tag #%d not on base wire - disabling\n" % len(ordered))
+            PathLog.info("Tag #%d (%.2f, %.2f) not on base wire - disabling\n" % (len(ordered), tag.x, tag.y))
             tag.enabled = False
             ordered.append(tag)
         return ordered
 
     def pointIsOnPath(self, p):
-        for e in self.edges:
-            if DraftGeomUtils.isPtOnEdge(p, e):
+        v = Part.Vertex(FreeCAD.Vector(p.x, p.y, self.minZ))
+        PathLog.info("pt = (%f, %f, %f)" % (v.X, v.Y, v.Z))
+        for e in self.bottomEdges:
+            indent = "{} ".format(e.distToShape(v)[0])
+            debugEdge(e, indent, True)
+            if PathGeom.isRoughly(v.distToShape(e)[0], 0.0, 1.0):
                 return True
         return False
 
@@ -823,7 +830,7 @@ class ObjectTagDressup:
             if tag.enabled:
                 if prev:
                     if prev.solid.common(tag.solid).Faces:
-                        PathLog.notice("Tag #%d intersects with previous tag - disabling\n" % i)
+                        PathLog.info("Tag #%d intersects with previous tag - disabling\n" % i)
                         PathLog.debug("this tag = %d [%s]" % (i, tag.solid.BoundBox))
                         tag.enabled = False
                 elif self.pathData.edges:
@@ -831,7 +838,7 @@ class ObjectTagDressup:
                     p0 = e.valueAt(e.FirstParameter)
                     p1 = e.valueAt(e.LastParameter)
                     if tag.solid.isInside(p0, PathGeom.Tolerance, True) or tag.solid.isInside(p1, PathGeom.Tolerance, True):
-                        PathLog.notice("Tag #%d intersects with starting point - disabling\n" % i)
+                        PathLog.info("Tag #%d intersects with starting point - disabling\n" % i)
                         tag.enabled = False
 
             if tag.enabled:

--- a/src/Mod/Path/PathScripts/PathDressupTagGui.py
+++ b/src/Mod/Path/PathScripts/PathDressupTagGui.py
@@ -255,7 +255,7 @@ class PathDressupTagTaskPanel:
             self.Positions.append(FreeCAD.Vector(point.x, point.y, 0))
             self.updateTagsView()
         else:
-            print("ignore new tag at %s" % (point))
+            print("ignore new tag at %s (obj=%s, on-path=%d" % (point, obj, 0))
 
     def addNewTag(self):
         self.tags = self.getTags(True)
@@ -310,6 +310,8 @@ class PathDressupTagTaskPanel:
             self.pt = FreeCADGui.Snapper.snap(pos, lastpoint=start, active=cntrl, constrain=shift)
             plane = FreeCAD.DraftWorkingPlane
             p = plane.getLocalCoords(self.pt)
+            v = pos.getValue()
+            PathLog.info("mouseMove(%s, %s, %s)" % (self.view.getPoint(v[0], v[1]), self.pt, p))
             displayPoint(p)
 
         def click(cb):

--- a/src/Mod/Path/PathScripts/PathDressupTagGui.py
+++ b/src/Mod/Path/PathScripts/PathDressupTagGui.py
@@ -58,7 +58,7 @@ class PathDressupTagTaskPanel:
         self.obj.Proxy.obj = obj
         self.viewProvider = viewProvider
         self.form  = FreeCADGui.PySideUic.loadUi(":/panels/HoldingTagsEdit.ui")
-        self.getPoint = PathGetPoint.TaskPanel(self.form.removeEditAddGroup)
+        self.getPoint = PathGetPoint.TaskPanel(self.form.removeEditAddGroup, True)
         self.jvo = PathUtils.findParentJob(obj).ViewObject
         if jvoVisibility is None:
             FreeCAD.ActiveDocument.openTransaction(translate("PathDressup_HoldingTags", "Edit HoldingTags Dress-up"))

--- a/src/Mod/Path/PathScripts/PathGetPoint.py
+++ b/src/Mod/Path/PathScripts/PathGetPoint.py
@@ -104,8 +104,11 @@ class TaskPanel:
             event = cb.getEvent()
             pos = event.getPosition()
             if self.onPath:
+                # There should not be a dependency from Draft->Path, so handle Path "snapping"
+                # directly, at least for now. Simple enough because there isn't really any
+                # "snapping" going on other than what getObjectInfo() provides.
                 screenpos = tuple(pos.getValue())
-                snapInfo = Draft.get3DView().getObjectInfo((screenpos[0],screenpos[1]))
+                snapInfo = Draft.get3DView().getObjectInfo(screenpos)
                 if snapInfo:
                     obj = FreeCAD.ActiveDocument.getObject(snapInfo['Object'])
                     if hasattr(obj, 'Path'):
@@ -114,6 +117,7 @@ class TaskPanel:
                     else:
                         self.obj = None
             else:
+                # Snapper handles regular objects just fine
                 cntrl = event.wasCtrlDown()
                 shift = event.wasShiftDown()
                 self.pt = FreeCADGui.Snapper.snap(pos, lastpoint=start, active=cntrl, constrain=shift)

--- a/src/Mod/Path/PathScripts/PathGetPoint.py
+++ b/src/Mod/Path/PathScripts/PathGetPoint.py
@@ -25,6 +25,7 @@
 import Draft
 import FreeCAD
 import FreeCADGui
+import PathScripts.PathLog as PathLog
 
 from PySide import QtCore, QtGui
 from pivy import coin
@@ -34,6 +35,8 @@ __author__ = "sliptonic (Brad Collette)"
 __url__ = "http://www.freecadweb.org"
 __doc__ = "Helper class to use FreeCADGUi.Snapper to let the user enter arbitray points while the task panel is active."
 
+PathLog.setLevel(PathLog.Level.INFO, PathLog.thisModule())
+
 class TaskPanel:
     '''Use an instance of this class in another TaskPanel to invoke the snapper.
     Create the instance in the TaskPanel's constructors and invoke getPoint(whenDone, start) whenever a new point is
@@ -41,7 +44,7 @@ class TaskPanel:
     provided in the constructor.
     The (only) public API function other than the constructor is getPoint(whenDone, start).
     '''
-    def __init__(self, form):
+    def __init__(self, form, onPath=False):
         '''__init___(form) ... form will be replaced by PointEdit.ui while the Snapper is active.'''
         self.formOrig = form
         self.formPoint = FreeCADGui.PySideUic.loadUi(":/panels/PointEdit.ui")
@@ -52,6 +55,8 @@ class TaskPanel:
 
         self.setupUi()
         self.buttonBox = None
+        self.onPath = onPath
+        self.obj = None
 
     def setupUi(self):
         '''setupUi() ... internal function - do not call.'''
@@ -95,19 +100,34 @@ class TaskPanel:
             self.formPoint.ifValueX.selectAll()
 
         def mouseMove(cb):
+            p = None
             event = cb.getEvent()
             pos = event.getPosition()
-            cntrl = event.wasCtrlDown()
-            shift = event.wasShiftDown()
-            self.pt = FreeCADGui.Snapper.snap(pos, lastpoint=start, active=cntrl, constrain=shift)
-            plane = FreeCAD.DraftWorkingPlane
-            p = plane.getLocalCoords(self.pt)
-            displayPoint(p)
+            if self.onPath:
+                screenpos = tuple(pos.getValue())
+                snapInfo = Draft.get3DView().getObjectInfo((screenpos[0],screenpos[1]))
+                if snapInfo:
+                    obj = FreeCAD.ActiveDocument.getObject(snapInfo['Object'])
+                    if hasattr(obj, 'Path'):
+                        self.obj = obj
+                        p = FreeCAD.Vector(snapInfo['x'], snapInfo['y'], snapInfo['z'])
+                    else:
+                        self.obj = None
+            else:
+                cntrl = event.wasCtrlDown()
+                shift = event.wasShiftDown()
+                self.pt = FreeCADGui.Snapper.snap(pos, lastpoint=start, active=cntrl, constrain=shift)
+                plane = FreeCAD.DraftWorkingPlane
+                p = plane.getLocalCoords(self.pt)
+                self.obj = FreeCADGui.Snapper.lastSnappedObject
+            if p:
+                displayPoint(p)
 
         def click(cb):
             event = cb.getEvent()
             if event.getButton() == 1 and event.getState() == coin.SoMouseButtonEvent.DOWN:
-                accept()
+                if self.obj:
+                    accept()
 
         def accept():
             if start:
@@ -137,7 +157,6 @@ class TaskPanel:
 
     def pointFinish(self, ok, cleanup = True):
         '''pointFinish(ok, cleanup=True) ... internal function - do not call.'''
-        obj = FreeCADGui.Snapper.lastSnappedObject
 
         if cleanup:
             self.removeGlobalCallbacks()
@@ -150,7 +169,7 @@ class TaskPanel:
             self.formOrig.setFocus()
 
         if ok:
-            self.pointWhenDone(self.pt, obj)
+            self.pointWhenDone(self.pt, self.obj)
         else:
             self.pointWhenDone(None, None)
 


### PR DESCRIPTION
It wasn't possible to add new or edit existing holding tags anymore by using Snapper. This change modifies the interaction and lets the user interact with the tags again.