### PR TITLE
Draft: Fix module loading in non-GUI mode

### DIFF
--- a/src/Mod/Draft/Draft.py
+++ b/src/Mod/Draft/Draft.py
@@ -47,11 +47,11 @@ __url__ = "http://www.freecadweb.org"
 
 '''The Draft module offers a range of tools to create and manipulate basic 2D objects'''
 
-import FreeCAD, math, sys, os, DraftVecUtils, Draft_rc
+import FreeCAD, math, sys, os, DraftVecUtils, Draft_rc, WorkingPlane
 from FreeCAD import Vector
 
 if FreeCAD.GuiUp:
-    import FreeCADGui, WorkingPlane
+    import FreeCADGui
     from PySide import QtCore
     from PySide.QtCore import QT_TRANSLATE_NOOP
     gui = True


### PR DESCRIPTION
The WorkingPlane module is used in getSVG and getDXF, so we need to
import it unconditionally.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)

And please remember to update the Wiki with the features added or changed once this PR once it is merged.

---
