### PR TITLE
Spreadsheet: Fix for issue #3225.

### DIFF
--- a/src/App/Document.cpp
+++ b/src/App/Document.cpp
@@ -2027,7 +2027,7 @@ std::vector<App::DocumentObject*> Document::getDependencyList(const std::vector<
  * @param paths Map with current and new names
  */
 
-void Document::renameObjectIdentifiers(const std::map<App::ObjectIdentifier, App::ObjectIdentifier> &paths)
+void Document::renameObjectIdentifiers(const std::map<App::ObjectIdentifier, App::ObjectIdentifier> &paths, const std::function<bool(const App::DocumentObject*)> & selector)
 {
     std::map<App::ObjectIdentifier, App::ObjectIdentifier> extendedPaths;
 
@@ -2038,7 +2038,8 @@ void Document::renameObjectIdentifiers(const std::map<App::ObjectIdentifier, App
     }
 
     for (std::vector<DocumentObject*>::iterator it = d->objectArray.begin(); it != d->objectArray.end(); ++it)
-        (*it)->renameObjectIdentifiers(extendedPaths);
+        if (selector(*it))
+            (*it)->renameObjectIdentifiers(extendedPaths);
 }
 
 #ifdef USE_OLD_DAG

--- a/src/App/Document.h
+++ b/src/App/Document.h
@@ -35,6 +35,7 @@
 #include <map>
 #include <vector>
 #include <stack>
+#include <functional>
 
 #include <boost/signals.hpp>
 
@@ -338,7 +339,7 @@ public:
     //@}
 
     /// Function called to signal that an object identifier has been renamed
-    void renameObjectIdentifiers(const std::map<App::ObjectIdentifier, App::ObjectIdentifier> & paths);
+    void renameObjectIdentifiers(const std::map<App::ObjectIdentifier, App::ObjectIdentifier> & paths, const std::function<bool(const App::DocumentObject*)> &selector = [](const App::DocumentObject *) { return true; });
 
     virtual PyObject *getPyObject(void);
 

--- a/src/Mod/Spreadsheet/App/PropertySheet.cpp
+++ b/src/Mod/Spreadsheet/App/PropertySheet.cpp
@@ -678,7 +678,8 @@ void PropertySheet::insertRows(int row, int count)
             moveCell(*i, CellAddress(i->row() + count, i->col()), renames);
     }
 
-    owner->getDocument()->renameObjectIdentifiers(renames);
+    const App::DocumentObject * docObj = static_cast<const App::DocumentObject*>(getContainer());
+    owner->getDocument()->renameObjectIdentifiers(renames, [docObj](const App::DocumentObject * obj) { return obj != docObj; });
 }
 
 /**
@@ -728,7 +729,8 @@ void PropertySheet::removeRows(int row, int count)
             moveCell(*i, CellAddress(i->row() - count, i->col()), renames);
     }
 
-    owner->getDocument()->renameObjectIdentifiers(renames);
+    const App::DocumentObject * docObj = static_cast<const App::DocumentObject*>(getContainer());
+    owner->getDocument()->renameObjectIdentifiers(renames, [docObj](const App::DocumentObject * obj) { return obj != docObj; });
 }
 
 void PropertySheet::insertColumns(int col, int count)
@@ -764,7 +766,8 @@ void PropertySheet::insertColumns(int col, int count)
             moveCell(*i, CellAddress(i->row(), i->col() + count), renames);
     }
 
-    owner->getDocument()->renameObjectIdentifiers(renames);
+    const App::DocumentObject * docObj = static_cast<const App::DocumentObject*>(getContainer());
+    owner->getDocument()->renameObjectIdentifiers(renames, [docObj](const App::DocumentObject * obj) { return obj != docObj; });
 }
 
 /**
@@ -814,7 +817,8 @@ void PropertySheet::removeColumns(int col, int count)
             moveCell(*i, CellAddress(i->row(), i->col() - count), renames);
     }
 
-    owner->getDocument()->renameObjectIdentifiers(renames);
+    const App::DocumentObject * docObj = static_cast<const App::DocumentObject*>(getContainer());
+    owner->getDocument()->renameObjectIdentifiers(renames, [docObj](const App::DocumentObject * obj) { return obj != docObj; } );
 }
 
 unsigned int PropertySheet::getMemSize() const

--- a/src/Mod/Spreadsheet/TestSpreadsheet.py
+++ b/src/Mod/Spreadsheet/TestSpreadsheet.py
@@ -660,6 +660,14 @@ class SpreadsheetCases(unittest.TestCase):
         sheet.insertRows('2', 1)
         self.assertEqual(sheet.getContents("B1"),"=B3")
 
+    def testIssue3225(self):
+        """ Inserting rows -- check renaming of internal cells """
+        sheet = self.doc.addObject('Spreadsheet::Sheet','Spreadsheet')
+        sheet.set('B2', '25')
+        sheet.set('B3', '=B2')
+        sheet.insertRows('2', 1)
+        self.assertEqual(sheet.getContents("B4"),"=B3")
+
     def testRenameAlias(self):
         """ Test renaming of alias1 to alias2 in a spreadsheet """
         sheet = self.doc.addObject('Spreadsheet::Sheet','Spreadsheet')


### PR DESCRIPTION
Done by adding a selector function to Document::renameObjectIdentifiers(...) to ensure
that the Spreadsheet document object is not rewritten twice.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [x] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR once it is merged.

---
