### PR TITLE
Fixes #3252 - obsolete FC links in package/debian FC man pages

### DIFF
--- a/package/debian/diff/freecad_gutsy.diff
+++ b/package/debian/diff/freecad_gutsy.diff
@@ -502,9 +502,9 @@
 +\fB\-P, \-\-python\-path\fR \fIarg\fR
 +Additional Python path.
 +.SH SEE ALSO
-+To get more information about \fBFreeCAD\fR, please visit \fIhttp://juergen\-riegel.net/FreeCAD/Docu/index.php/Main_Page\fR
++To get more information about \fBFreeCAD\fR, please visit \fIhttps://freecadweb.org/wiki\fR
 +.SH BUGS
-+To report a bug, please visit \fIhttp://free-cad.sf.net/\fR
++To report a bug, please visit \fIhttps://freecadweb.org/tracker/\fR
 +.SH AUTHOR
 +This manual page was written by Werner Mayer.
 --- freecad-0.7.2008.orig/debian/rules

--- a/package/debian/diff/freecad_hardy.diff
+++ b/package/debian/diff/freecad_hardy.diff
@@ -231,9 +231,9 @@
 +\fB\-P, \-\-python\-path\fR \fIarg\fR
 +Additional Python path.
 +.SH SEE ALSO
-+To get more information about \fBFreeCAD\fR, please visit \fIhttp://juergen\-riegel.net/FreeCAD/Docu/index.php/Main_Page\fR
++To get more information about \fBFreeCAD\fR, please visit \fIhttps://freecadweb.org/wiki\fR
 +.SH BUGS
-+To report a bug, please visit \fIhttp://free-cad.sf.net/\fR
++To report a bug, please visit \fIhttps://freecadweb.org/tracker/\fR
 +.SH AUTHOR
 +This manual page was written by Werner Mayer.
 --- freecad-0.8.2237.orig/debian/rules

--- a/package/debian/diff/freecad_intrepid.diff
+++ b/package/debian/diff/freecad_intrepid.diff
@@ -759,9 +759,9 @@
 +\fB\-P, \-\-python\-path\fR \fIarg\fR
 +Additional Python path.
 +.SH SEE ALSO
-+To get more information about \fBFreeCAD\fR, please visit \fIhttp://juergen\-riegel.net/FreeCAD/Docu/index.php/Main_Page\fR
++To get more information about \fBFreeCAD\fR, please visit \fIhttps://freecadweb.org/wiki\fR
 +.SH BUGS
-+To report a bug, please visit \fIhttp://free-cad.sf.net/\fR
++To report a bug, please visit \fIhttps://freecadweb.org/tracker/\fR
 +.SH AUTHOR
 +This manual page was written by Werner Mayer.
 --- freecad-0.8.2237.orig/debian/rules

--- a/package/debian/diff/freecad_jaunty.diff
+++ b/package/debian/diff/freecad_jaunty.diff
@@ -736,9 +736,9 @@
 +\fB\-P, \-\-python\-path\fR \fIarg\fR
 +Additional Python path.
 +.SH SEE ALSO
-+To get more information about \fBFreeCAD\fR, please visit \fIhttp://juergen\-riegel.net/FreeCAD/Docu/index.php/Main_Page\fR
++To get more information about \fBFreeCAD\fR, please visit \fIhttps://freecadweb.org/wiki\fR
 +.SH BUGS
-+To report a bug, please visit \fIhttp://free-cad.sf.net/\fR
++To report a bug, please visit \fIhttps://freecadweb.org/tracker/\fR
 +.SH AUTHOR
 +This manual page was written by Werner Mayer.
 --- freecad-0.8.2237.orig/debian/rules

--- a/package/debian/diff/freecad_karmic.diff
+++ b/package/debian/diff/freecad_karmic.diff
@@ -485,9 +485,9 @@
 +\fB\-P, \-\-python\-path\fR \fIarg\fR
 +Additional Python path.
 +.SH SEE ALSO
-+To get more information about \fBFreeCAD\fR, please visit \fIhttp://juergen\-riegel.net/FreeCAD/Docu/index.php/Main_Page\fR
++To get more information about \fBFreeCAD\fR, please visit \fIhttps://freecadweb.org/wiki\fR
 +.SH BUGS
-+To report a bug, please visit \fIhttp://free-cad.sf.net/\fR
++To report a bug, please visit \fIhttps://freecadweb.org/tracker/\fR
 +.SH AUTHOR
 +This manual page was written by Werner Mayer.
 --- freecad-0.9.2646.orig/debian/changelog

--- a/package/debian/diff/freecad_lucid.diff
+++ b/package/debian/diff/freecad_lucid.diff
@@ -316,9 +316,9 @@
 +\fB\-P, \-\-python\-path\fR \fIarg\fR
 +Additional Python path.
 +.SH SEE ALSO
-+To get more information about \fBFreeCAD\fR, please visit \fIhttp://juergen\-riegel.net/FreeCAD/Docu/index.php/Main_Page\fR
++To get more information about \fBFreeCAD\fR, please visit \fIhttps://freecadweb.org/wiki\fR
 +.SH BUGS
-+To report a bug, please visit \fIhttp://free-cad.sf.net/\fR
++To report a bug, please visit \fIhttps://freecadweb.org/tracker/\fR
 +.SH AUTHOR
 +This manual page was written by Werner Mayer.
 --- freecad-0.11.4446.orig/debian/rules

--- a/package/debian/diff/freecad_maverick.diff
+++ b/package/debian/diff/freecad_maverick.diff
@@ -248,9 +248,9 @@
 +\fB\-P, \-\-python\-path\fR \fIarg\fR
 +Additional Python path.
 +.SH SEE ALSO
-+To get more information about \fBFreeCAD\fR, please visit \fIhttp://juergen\-riegel.net/FreeCAD/Docu/index.php/Main_Page\fR
++To get more information about \fBFreeCAD\fR, please visit \fIhttps://freecadweb.org/wiki\fR
 +.SH BUGS
-+To report a bug, please visit \fIhttp://free-cad.sf.net/\fR
++To report a bug, please visit \fIhttps://freecadweb.org/tracker/\fR
 +.SH AUTHOR
 +This manual page was written by Werner Mayer.
 --- freecad-0.11.3729.orig/debian/rules

--- a/package/debian/diff/freecad_natty.diff
+++ b/package/debian/diff/freecad_natty.diff
@@ -371,9 +371,9 @@
 +\fB\-P, \-\-python\-path\fR \fIarg\fR
 +Additional Python path.
 +.SH SEE ALSO
-+To get more information about \fBFreeCAD\fR, please visit \fIhttp://juergen\-riegel.net/FreeCAD/Docu/index.php/Main_Page\fR
++To get more information about \fBFreeCAD\fR, please visit \fIhttps://freecadweb.org/wiki\fR
 +.SH BUGS
-+To report a bug, please visit \fIhttp://free-cad.sf.net/\fR
++To report a bug, please visit \fIhttps://freecadweb.org/tracker/\fR
 +.SH AUTHOR
 +This manual page was written by Werner Mayer.
 --- freecad-0.12.4484.orig/debian/rules

--- a/package/debian/diff/freecad_precise.diff
+++ b/package/debian/diff/freecad_precise.diff
@@ -353,9 +353,9 @@
 +\fB\-P, \-\-python\-path\fR \fIarg\fR
 +Additional Python path.
 +.SH SEE ALSO
-+To get more information about \fBFreeCAD\fR, please visit \fIhttp://juergen\-riegel.net/FreeCAD/Docu/index.php/Main_Page\fR
++To get more information about \fBFreeCAD\fR, please visit \fIhttps://freecadweb.org/wiki\fR
 +.SH BUGS
-+To report a bug, please visit \fIhttp://free-cad.sf.net/\fR
++To report a bug, please visit \fIhttps://freecadweb.org/tracker/\fR
 +.SH AUTHOR
 +This manual page was written by Werner Mayer.
 --- freecad-0.13.orig/debian/rules

--- a/package/debian/diff/freecad_testing.diff
+++ b/package/debian/diff/freecad_testing.diff
@@ -512,9 +512,9 @@
 +\fB\-P, \-\-python\-path\fR \fIarg\fR
 +Additional Python path.
 +.SH SEE ALSO
-+To get more information about \fBFreeCAD\fR, please visit \fIhttp://juergen\-riegel.net/FreeCAD/Docu/index.php/Main_Page\fR
++To get more information about \fBFreeCAD\fR, please visit \fIhttps://freecadweb.org/wiki\fR
 +.SH BUGS
-+To report a bug, please visit \fIhttp://free-cad.sf.net/\fR
++To report a bug, please visit \fIhttps://freecadweb.org/tracker/\fR
 +.SH AUTHOR
 +This manual page was written by Werner Mayer.
 --- freecad-0.9.2646.orig/debian/watch


### PR DESCRIPTION
See https://freecadweb.org/tracker/view.php?id=3253
More work will need to be done to get the man page updated with more current relevant info.