### PR TITLE
Fix issue with working directory.

### DIFF
--- a/src/Gui/FileDialog.cpp
+++ b/src/Gui/FileDialog.cpp
@@ -386,7 +386,7 @@ void FileDialog::setWorkingDirectory(const QString& dir)
     QString dirName = dir;
     if (!dir.isEmpty()) {
         QFileInfo info(dir);
-        if (info.isFile())
+        if (!info.exists() || info.isFile())
             dirName = info.absolutePath();
         else
             dirName = info.absoluteFilePath();


### PR DESCRIPTION
Hi.
This fixes an issue with setting the FileDialog's working directory after first save. If you try to open a file next you get this error message (xxx is a folder but a file was expected):

![image](https://user-images.githubusercontent.com/72836/32698989-b7416d26-c7ae-11e7-9edf-7dd46556dc98.png)

Qt5, native dialogs, KDE Plasma

Cheers,
Mateusz

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)

And please remember to update the Wiki with the features added or changed once this PR once it is merged.

---
