### PR TITLE
TechDraw View Positioning and Dimension Value Format

### DIFF
--- a/src/Mod/TechDraw/App/DrawViewDetail.cpp
+++ b/src/Mod/TechDraw/App/DrawViewDetail.cpp
@@ -249,6 +249,11 @@ App::DocumentObjectExecReturn *DrawViewDetail::execute(void)
                                                     inputCenter,
                                                     scale);
         gp_Ax2 viewAxis = getViewAxis(Base::Vector3d(inputCenter.X(),inputCenter.Y(),inputCenter.Z()),Direction.getValue());
+        if (!DrawUtil::fpCompare(Rotation.getValue(),0.0)) {
+            mirroredShape = TechDrawGeometry::rotateShape(mirroredShape,
+                                                          viewAxis,
+                                                          Rotation.getValue());
+        }
         geometryObject = buildGeometryObject(mirroredShape,viewAxis);
         geometryObject->pruneVertexGeom(Base::Vector3d(0.0,0.0,0.0),Radius.getValue() * scale);      //remove vertices beyond clipradius
 

--- a/src/Mod/TechDraw/App/DrawViewDimension.cpp
+++ b/src/Mod/TechDraw/App/DrawViewDimension.cpp
@@ -225,7 +225,7 @@ std::string  DrawViewDimension::getFormatedValue()
     std::string prefixSym = getPrefix();                                  //get Radius/Diameter/... symbol
 
     //find the %x.y tag in FormatSpec
-    QRegExp rxFormat(QString::fromUtf8("%[0-9]*\\.[0-9]*[aefgAEFG]"));     //printf double format spec 
+    QRegExp rxFormat(QString::fromUtf8("%[0-9]*\\.*[0-9]*[aefgAEFG]"));     //printf double format spec 
     QString match;
     QString specVal = Base::Tools::fromStdString("%.2f");                    //sensible default
     pos = 0;

--- a/src/Mod/TechDraw/App/DrawViewDimension.cpp
+++ b/src/Mod/TechDraw/App/DrawViewDimension.cpp
@@ -209,12 +209,13 @@ std::string  DrawViewDimension::getFormatedValue()
     QString userStr = qVal.getUserString();                           //this handles mm to inch/km/parsec etc and decimal positions
                                                                       //but won't give more than Global_Decimals precision
                                                                       //really should be able to ask units for value in appropriate UoM!!
-    QRegExp rxUnits(QString::fromUtf8("\\D*$"));                      //any non digits at end of string
+    QRegExp rxUnits(QString::fromUtf8(" \\D*$"));                     //space + any non digits at end of string
 
     QString userVal = userStr;
     userVal.remove(rxUnits);                                           //getUserString(defaultDecimals) without units
-    double userValNum = userVal.toDouble();
 
+    QLocale loc;
+    double userValNum = loc.toDouble(userVal);
 
     QString userUnits;
     int pos = 0;
@@ -227,7 +228,7 @@ std::string  DrawViewDimension::getFormatedValue()
     //find the %x.y tag in FormatSpec
     QRegExp rxFormat(QString::fromUtf8("%[0-9]*\\.*[0-9]*[aefgAEFG]"));     //printf double format spec 
     QString match;
-    QString specVal = Base::Tools::fromStdString("%.2f");                    //sensible default
+    QString specVal = userVal;                                             //sensible default
     pos = 0;
     if ((pos = rxFormat.indexIn(specStr, 0)) != -1)  {
         match = rxFormat.cap(0);                                          //entire capture of rx
@@ -256,6 +257,11 @@ std::string  DrawViewDimension::getFormatedValue()
 
     repl = Base::Tools::fromStdString(getPrefix()) + repl;
     specStr.replace(match,repl);
+    //this next bit is so inelegant!!!
+    QChar dp = QChar::fromLatin1('.');
+    if (loc.decimalPoint() != dp) {
+        specStr.replace(dp,loc.decimalPoint());
+    }
 
     return specStr.toUtf8().constData();
 }

--- a/src/Mod/TechDraw/App/DrawViewMulti.cpp
+++ b/src/Mod/TechDraw/App/DrawViewMulti.cpp
@@ -61,6 +61,7 @@
 
 #include "Geometry.h"
 #include "GeometryObject.h"
+#include "DrawUtil.h"
 #include "DrawViewMulti.h"
 
 using namespace TechDraw;
@@ -179,6 +180,11 @@ App::DocumentObjectExecReturn *DrawViewMulti::execute(void)
                                                     inputCenter,
                                                     getScale());
         gp_Ax2 viewAxis = getViewAxis(Base::Vector3d(inputCenter.X(),inputCenter.Y(),inputCenter.Z()),Direction.getValue());
+        if (!DrawUtil::fpCompare(Rotation.getValue(),0.0)) {
+            mirroredShape = TechDrawGeometry::rotateShape(mirroredShape,
+                                                          viewAxis,
+                                                          Rotation.getValue());
+        }
         geometryObject = buildGeometryObject(mirroredShape,viewAxis);
 
 #if MOD_TECHDRAW_HANDLE_FACES

--- a/src/Mod/TechDraw/App/DrawViewPart.cpp
+++ b/src/Mod/TechDraw/App/DrawViewPart.cpp
@@ -218,6 +218,11 @@ App::DocumentObjectExecReturn *DrawViewPart::execute(void)
                                                   getScale());
 
      gp_Ax2 viewAxis = getViewAxis(shapeCentroid,Direction.getValue());
+     if (!DrawUtil::fpCompare(Rotation.getValue(),0.0)) {
+        mirroredShape = TechDrawGeometry::rotateShape(mirroredShape,
+                                                      viewAxis,
+                                                      Rotation.getValue());
+     }
      geometryObject =  buildGeometryObject(mirroredShape,viewAxis);
 
 #if MOD_TECHDRAW_HANDLE_FACES

--- a/src/Mod/TechDraw/App/DrawViewSection.cpp
+++ b/src/Mod/TechDraw/App/DrawViewSection.cpp
@@ -260,6 +260,11 @@ App::DocumentObjectExecReturn *DrawViewSection::execute(void)
                                                     inputCenter,
                                                     getScale());
         gp_Ax2 viewAxis = getViewAxis(Base::Vector3d(inputCenter.X(),inputCenter.Y(),inputCenter.Z()),Direction.getValue());
+        if (!DrawUtil::fpCompare(Rotation.getValue(),0.0)) {
+            mirroredShape = TechDrawGeometry::rotateShape(mirroredShape,
+                                                          viewAxis,
+                                                          Rotation.getValue());
+        }
         geometryObject = buildGeometryObject(mirroredShape,viewAxis);   //this is original shape after cut by section prism
 
 #if MOD_TECHDRAW_HANDLE_FACES
@@ -276,6 +281,12 @@ App::DocumentObjectExecReturn *DrawViewSection::execute(void)
         TopoDS_Shape mirroredSection = TechDrawGeometry::mirrorShape(sectionCompound,
                                                                      inputCenter,
                                                                      getScale());
+        gp_Ax2 viewAxis = getViewAxis(Base::Vector3d(inputCenter.X(),inputCenter.Y(),inputCenter.Z()),Direction.getValue());
+        if (!DrawUtil::fpCompare(Rotation.getValue(),0.0)) {
+            mirroredSection = TechDrawGeometry::rotateShape(mirroredSection,
+                                                            viewAxis,
+                                                            Rotation.getValue());
+        }
 
         sectionFaceWires.clear();
         TopoDS_Compound newFaces;

--- a/src/Mod/TechDraw/App/GeometryObject.cpp
+++ b/src/Mod/TechDraw/App/GeometryObject.cpp
@@ -561,6 +561,32 @@ TopoDS_Shape TechDrawGeometry::mirrorShape(const TopoDS_Shape &input,
     return transShape;
 }
 
+//!rotates a shape about a viewAxis
+TopoDS_Shape TechDrawGeometry::rotateShape(const TopoDS_Shape &input,
+                             gp_Ax2& viewAxis,
+                             double rotAngle)
+{
+    TopoDS_Shape transShape;
+    if (input.IsNull()) {
+        return transShape;
+    }
+
+    gp_Ax1 rotAxis = viewAxis.Axis();
+    double rotation = rotAngle * M_PI/180.0;
+
+    try {
+        gp_Trsf tempTransform;
+        tempTransform.SetRotation(rotAxis,rotation);
+        BRepBuilderAPI_Transform mkTrf(input, tempTransform);
+        transShape = mkTrf.Shape();
+    }
+    catch (...) {
+        Base::Console().Log("GeometryObject::rotateShape - rotate failed.\n");
+        return transShape;
+    }
+    return transShape;
+}
+
 //!scales a shape about a origin
 TopoDS_Shape TechDrawGeometry::scaleShape(const TopoDS_Shape &input,
                                           double scale)

--- a/src/Mod/TechDraw/App/GeometryObject.h
+++ b/src/Mod/TechDraw/App/GeometryObject.h
@@ -26,6 +26,7 @@
 #include <TopoDS_Shape.hxx>
 #include <TopoDS_Compound.hxx>
 #include <gp_Pnt.hxx>
+#include <gp_Ax2.hxx>
 
 #include <Base/Vector3D.h>
 #include <Base/BoundBox.h>
@@ -55,6 +56,10 @@ TopoDS_Shape TechDrawExport mirrorShape(const TopoDS_Shape &input,
                         double scale = 1.0);
 TopoDS_Shape TechDrawExport scaleShape(const TopoDS_Shape &input,
                                        double scale);
+TopoDS_Shape TechDrawExport rotateShape(const TopoDS_Shape &input,
+                             gp_Ax2& viewAxis,
+                             double rotAngle);
+
 
 //! Returns the centroid of shape, as viewed according to direction
 gp_Pnt TechDrawExport findCentroid(const TopoDS_Shape &shape,

--- a/src/Mod/TechDraw/Gui/CMakeLists.txt
+++ b/src/Mod/TechDraw/Gui/CMakeLists.txt
@@ -123,6 +123,8 @@ SET(TechDrawGuiView_SRCS
     QGCustomBorder.h
     QGCustomImage.cpp
     QGCustomImage.h
+    QGDisplayArea.cpp
+    QGDisplayArea.h
     QGIView.cpp
     QGIView.h
     QGIArrow.cpp

--- a/src/Mod/TechDraw/Gui/QGCustomClip.cpp
+++ b/src/Mod/TechDraw/Gui/QGCustomClip.cpp
@@ -35,7 +35,6 @@
 #include <Base/Console.h>
 #include <Base/Parameter.h>
 
-#include <qmath.h>
 #include "QGCustomClip.h"
 
 using namespace TechDrawGui;
@@ -53,12 +52,7 @@ QGCustomClip::QGCustomClip()
 
 void QGCustomClip::centerAt(QPointF centerPos)
 {
-    QRectF box = boundingRect();
-    double width = box.width();
-    double height = box.height();
-    double newX = centerPos.x() - width/2.;
-    double newY = centerPos.y() - height/2.;
-    setPos(newX,newY);
+    centerAt(centerPos.x(),centerPos.y());
 }
 
 void QGCustomClip::centerAt(double cX, double cY)
@@ -83,7 +77,6 @@ void QGCustomClip::setRect(double x, double y, double w, double h)
     setRect(r);
 }
 
-
 QRectF QGCustomClip::rect()
 {
     return m_rect;
@@ -92,6 +85,8 @@ QRectF QGCustomClip::rect()
 void QGCustomClip::paint ( QPainter * painter, const QStyleOptionGraphicsItem * option, QWidget * widget) {
     QStyleOptionGraphicsItem myOption(*option);
     myOption.state &= ~QStyle::State_Selected;
+
+//    painter->drawRect(boundingRect());          //good for debugging
 
     QGraphicsItemGroup::paint (painter, &myOption, widget);
 }

--- a/src/Mod/TechDraw/Gui/QGCustomImage.cpp
+++ b/src/Mod/TechDraw/Gui/QGCustomImage.cpp
@@ -31,6 +31,7 @@
 
 #include <QRectF>
 #include <QPixmap>
+
 #include "QGCustomImage.h"
 
 using namespace TechDrawGui;
@@ -55,20 +56,12 @@ void QGCustomImage::centerAt(QPointF centerPos)
 
 void QGCustomImage::centerAt(double cX, double cY)
 {
-//    QGraphicsItemGroup* g = group();
-//    if (g == nullptr) {
-//        return;
-//    }
-    QPointF parentPt(cX,cY);
-    QPointF myPt = mapFromParent(parentPt);
-
     QRectF br = boundingRect();
-    double width = br.width();
-    double height = br.height();
-    double newX = width/2.0;
-    double newY = height/2.0;
-    QPointF off(myPt.x() - newX,myPt.y() - newY);
-    setOffset(off);
+    double width = br.width() * scale();
+    double height = br.height() * scale();
+    double newX = cX - width/2.;
+    double newY = cY - height/2.;
+    setPos(newX, newY);
 }
 
 bool QGCustomImage::load(QString fileSpec)
@@ -76,9 +69,6 @@ bool QGCustomImage::load(QString fileSpec)
     bool success = true;
     QPixmap px(fileSpec);
     m_px = px;
-//    if (m_px.isNull()) {
-//        Base::Console().Message("TRACE - QGCustomImage::load - pixmap no good\n");
-//    }
     prepareGeometryChange();
     setPixmap(m_px);
     return(success);
@@ -88,5 +78,8 @@ void QGCustomImage::paint ( QPainter * painter, const QStyleOptionGraphicsItem *
     QStyleOptionGraphicsItem myOption(*option);
     myOption.state &= ~QStyle::State_Selected;
 
+    //painter->drawRect(boundingRect());          //good for debugging
+
     QGraphicsPixmapItem::paint (painter, &myOption, widget);
 }
+

--- a/src/Mod/TechDraw/Gui/QGCustomText.cpp
+++ b/src/Mod/TechDraw/Gui/QGCustomText.cpp
@@ -59,12 +59,13 @@ QGCustomText::QGCustomText()
 
 void QGCustomText::centerAt(QPointF centerPos)
 {
-    QRectF box = boundingRect();
-    double width = box.width();
-    double height = box.height();
-    double newX = centerPos.x() - width/2.;
-    double newY = centerPos.y() - height/2.;
-    setPos(newX,newY);
+      centerAt(centerPos.x(),centerPos.y());
+//    QRectF box = boundingRect();
+//    double width = box.width();
+//    double height = box.height();
+//    double newX = centerPos.x() - width/2.;
+//    double newY = centerPos.y() - height/2.;
+//    setPos(newX,newY);
 }
 
 void QGCustomText::centerAt(double cX, double cY)

--- a/src/Mod/TechDraw/Gui/QGDisplayArea.cpp
+++ b/src/Mod/TechDraw/Gui/QGDisplayArea.cpp
@@ -1,6 +1,5 @@
 /***************************************************************************
- *   Copyright (c) 2013 Luke Parry <l.parry@warwick.ac.uk>                 *
- *                 2014 wandererfan <WandererFan@gmail.com>                *
+ *   Copyright (c) 2017 WandererFan <wandererfan@gmail.com>                *
  *                                                                         *
  *   This file is part of the FreeCAD CAx development system.              *
  *                                                                         *
@@ -21,51 +20,62 @@
  *                                                                         *
  ***************************************************************************/
 
-#ifndef DRAWINGGUI_QGRAPHICSITEMVIEWSYMBOL_H
-#define DRAWINGGUI_QGRAPHICSITEMVIEWSYMBOL_H
-
-#include <QObject>
+#include "PreCompiled.h"
+#ifndef _PreComp_
+#include <assert.h>
+#include <QGraphicsScene>
+#include <QGraphicsSceneHoverEvent>
+#include <QMouseEvent>
 #include <QPainter>
-#include <QString>
-#include <QByteArray>
-#include <QSvgRenderer>
-#include <QGraphicsSvgItem>
+#include <QStyleOptionGraphicsItem>
+#endif
 
-#include "QGIView.h"
+#include <App/Application.h>
+#include <App/Material.h>
+#include <Base/Console.h>
+#include <Base/Parameter.h>
 
-namespace TechDraw {
-class DrawViewSymbol;
+#include "QGDisplayArea.h"
+
+using namespace TechDrawGui;
+
+QGDisplayArea::QGDisplayArea(void)
+{
+    setHandlesChildEvents(false);
+    setCacheMode(QGraphicsItem::NoCache);
+    setAcceptHoverEvents(false);
+    setFlag(QGraphicsItem::ItemIsSelectable, false);
+    setFlag(QGraphicsItem::ItemIsMovable, false);
+    setFlag(QGraphicsItem::ItemClipsChildrenToShape, false);
+    setFlag(QGraphicsItem::ItemSendsGeometryChanges, true);
 }
 
-namespace TechDrawGui
+void QGDisplayArea::centerAt(QPointF centerPos)
 {
-class QGCustomSvg;
-class QGDisplayArea;
+    centerAt(centerPos.x(),centerPos.y());
+}
 
-class TechDrawGuiExport QGIViewSymbol : public QGIView
+void QGDisplayArea::centerAt(double cX, double cY)
 {
-public:
-    QGIViewSymbol();
-    ~QGIViewSymbol();
+    QRectF box = boundingRect();
+    double width = box.width();
+    double height = box.height();
+    double newX = cX - width/2.;
+    double newY = cY - height/2.;
+    setPos(newX,newY);
+}
 
-    enum {Type = QGraphicsItem::UserType + 121};
-    int type() const override { return Type;}
+void QGDisplayArea::paint ( QPainter * painter, const QStyleOptionGraphicsItem * option, QWidget * widget) {
+    QStyleOptionGraphicsItem myOption(*option);
+    myOption.state &= ~QStyle::State_Selected;
 
-    virtual void updateView(bool update = false) override;
-    void setViewSymbolFeature(TechDraw::DrawViewSymbol *obj);
+    //painter->drawRect(boundingRect());          //good for debugging
 
-    virtual void draw() override;
-    virtual void rotateView(void) override;
+    QGraphicsItemGroup::paint (painter, &myOption, widget);
+}
 
+QRectF QGDisplayArea::boundingRect() const
+{
+    return childrenBoundingRect();
+}
 
-protected:
-    virtual void drawSvg();
-    void symbolToSvg(QByteArray qba);
-    QVariant itemChange(GraphicsItemChange change, const QVariant &value) override;
-
-    QGDisplayArea* m_displayArea;
-    QGCustomSvg *m_svgItem;
-};
-
-} // namespace
-#endif // DRAWINGGUI_QGRAPHICSITEMVIEWSYMBOL_H

--- a/src/Mod/TechDraw/Gui/QGDisplayArea.h
+++ b/src/Mod/TechDraw/Gui/QGDisplayArea.h
@@ -1,6 +1,5 @@
 /***************************************************************************
- *   Copyright (c) 2013 Luke Parry <l.parry@warwick.ac.uk>                 *
- *                 2014 wandererfan <WandererFan@gmail.com>                *
+ *   Copyright (c) 2017 WandererFan <wandererfan@gmail.com>                *
  *                                                                         *
  *   This file is part of the FreeCAD CAx development system.              *
  *                                                                         *
@@ -21,51 +20,42 @@
  *                                                                         *
  ***************************************************************************/
 
-#ifndef DRAWINGGUI_QGRAPHICSITEMVIEWSYMBOL_H
-#define DRAWINGGUI_QGRAPHICSITEMVIEWSYMBOL_H
+#ifndef DRAWINGGUI_QGDISPLAYAREA_H
+#define DRAWINGGUI_QGDISPLAYAREA_H
 
-#include <QObject>
-#include <QPainter>
-#include <QString>
-#include <QByteArray>
-#include <QSvgRenderer>
-#include <QGraphicsSvgItem>
+#include <QGraphicsItem>
+#include <QPointF>
+#include <QRectF>
 
-#include "QGIView.h"
-
-namespace TechDraw {
-class DrawViewSymbol;
-}
+QT_BEGIN_NAMESPACE
+class QPainter;
+class QStyleOptionGraphicsItem;
+QT_END_NAMESPACE
 
 namespace TechDrawGui
 {
-class QGCustomSvg;
-class QGDisplayArea;
 
-class TechDrawGuiExport QGIViewSymbol : public QGIView
+class TechDrawGuiExport QGDisplayArea : public QGraphicsItemGroup
 {
 public:
-    QGIViewSymbol();
-    ~QGIViewSymbol();
+    explicit QGDisplayArea(void);
+    ~QGDisplayArea() {}
 
-    enum {Type = QGraphicsItem::UserType + 121};
-    int type() const override { return Type;}
+    enum {Type = QGraphicsItem::UserType + 137};
+    int type() const { return Type;}
+    virtual QRectF boundingRect() const;
 
-    virtual void updateView(bool update = false) override;
-    void setViewSymbolFeature(TechDraw::DrawViewSymbol *obj);
-
-    virtual void draw() override;
-    virtual void rotateView(void) override;
-
+    void paint(QPainter * painter, const QStyleOptionGraphicsItem * option, QWidget * widget = 0 );
+    virtual void centerAt(QPointF centerPos);
+    virtual void centerAt(double cX, double cY);
 
 protected:
-    virtual void drawSvg();
-    void symbolToSvg(QByteArray qba);
-    QVariant itemChange(GraphicsItemChange change, const QVariant &value) override;
 
-    QGDisplayArea* m_displayArea;
-    QGCustomSvg *m_svgItem;
+private:
+
 };
 
-} // namespace
-#endif // DRAWINGGUI_QGRAPHICSITEMVIEWSYMBOL_H
+}
+
+#endif // DRAWINGGUI_QGDISPLAYAREA_H
+

--- a/src/Mod/TechDraw/Gui/QGIUserTypes.h
+++ b/src/Mod/TechDraw/Gui/QGIUserTypes.h
@@ -25,6 +25,7 @@ QGCustomClip: 132
 QGCustomRect: 133
 QGCustomLabel:135
 QGCustomBorder: 136
+QGDisplayArea: 137
 QGraphicsItemTemplate: 150
 QGraphicsItemDrawingTemplate: 151
 QGraphicsItemSVGTemplate: 153

--- a/src/Mod/TechDraw/Gui/QGIView.cpp
+++ b/src/Mod/TechDraw/Gui/QGIView.cpp
@@ -267,17 +267,23 @@ void QGIView::updateView(bool update)
 
     if (update ||
         getViewObject()->Rotation.isTouched() ) {
-        //NOTE: QPainterPaths have to be rotated individually. This transform handles Rotation for everything else.
-        //Scale is handled in GeometryObject for DVP & descendents
-        //Objects not descended from DVP must setScale for themselves
-        //note that setTransform(,,rotation,,) is not the same as setRotation!!!
-        double rot = getViewObject()->Rotation.getValue();
-        QPointF centre = boundingRect().center();
-        setTransform(QTransform().translate(centre.x(), centre.y()).rotate(-rot).translate(-centre.x(), -centre.y()));
+        rotateView();
     }
 
     if (update)
         QGraphicsItem::update();
+}
+
+//QGIVP derived classes do not need a rotate view method as rotation is handled on App side.
+void QGIView::rotateView(void)
+{
+//NOTE: QPainterPaths have to be rotated individually. This transform handles Rotation for everything else.
+//Scale is handled in GeometryObject for DVP & descendents
+//Objects not descended from DVP must setScale for themselves
+//note that setTransform(,,rotation,,) is not the same as setRotation!!!
+    double rot = getViewObject()->Rotation.getValue();
+    QPointF centre = boundingRect().center();
+    setTransform(QTransform().translate(centre.x(), centre.y()).rotate(-rot).translate(-centre.x(), -centre.y()));
 }
 
 const char * QGIView::getViewName() const

--- a/src/Mod/TechDraw/Gui/QGIView.h
+++ b/src/Mod/TechDraw/Gui/QGIView.h
@@ -73,6 +73,7 @@ public:
     virtual bool isVisible(void) {return m_visibility;};
     virtual void draw(void);
     virtual void drawCaption(void);
+    virtual void rotateView(void);
 
     /** Methods to ensure that Y-Coordinates are orientated correctly.
      * @{ */

--- a/src/Mod/TechDraw/Gui/QGIViewAnnotation.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewAnnotation.cpp
@@ -162,6 +162,15 @@ void QGIViewAnnotation::drawAnnotation()
     m_textItem->setTextWidth(Rez::guiX(viewAnno->MaxWidth.getValue()));
     QString qs = QString::fromUtf8(ss.str().c_str());
     m_textItem->setHtml(qs);
-    m_textItem->setPos(0.,0.);
+    m_textItem->centerAt(0.,0.);
 }
+
+void QGIViewAnnotation::rotateView(void)
+{
+    QRectF r = m_textItem->boundingRect();
+    m_textItem->setTransformOriginPoint(r.center());
+    double rot = getViewObject()->Rotation.getValue();
+    m_textItem->setRotation(-rot);
+}
+
 

--- a/src/Mod/TechDraw/Gui/QGIViewAnnotation.h
+++ b/src/Mod/TechDraw/Gui/QGIViewAnnotation.h
@@ -50,6 +50,7 @@ public:
     void setViewAnnoFeature(TechDraw::DrawViewAnnotation *obj);
 
     virtual void draw() override;
+    virtual void rotateView(void) override;
 
 protected:
     void drawAnnotation();

--- a/src/Mod/TechDraw/Gui/QGIViewImage.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewImage.cpp
@@ -61,13 +61,13 @@ QGIViewImage::QGIViewImage()
 
     m_cliparea = new QGCustomClip();
     addToGroup(m_cliparea);
-    m_cliparea->setPos(0.,0.);
     m_cliparea->setRect(0.,0.,5.,5.);
+    m_cliparea->centerAt(0.,0.);
 
     m_imageItem = new QGCustomImage();
     m_imageItem->setTransformationMode(Qt::SmoothTransformation);
     m_cliparea->addToGroup(m_imageItem);
-    m_imageItem->setPos(0.,0.);
+    m_imageItem->centerAt(0.,0.);
 }
 
 QGIViewImage::~QGIViewImage()
@@ -117,11 +117,10 @@ void QGIViewImage::draw()
     auto viewImage( dynamic_cast<TechDraw::DrawViewImage*>(getViewObject()) );
     if (!viewImage)
         return;
-    QRectF newRect(0.0,0.0,Rez::guiX(viewImage->Width.getValue()),Rez::guiX(viewImage->Height.getValue()));
-    double pad = Rez::guiX(1.0);
-    m_cliparea->setRect(newRect.adjusted(-pad,-pad,pad,pad));
-
+    QRectF newRect(0.0,0.0,viewImage->Width.getValue(),viewImage->Height.getValue());
+    m_cliparea->setRect(newRect);
     drawImage();
+    m_cliparea->centerAt(0.0,0.0);
     if (borderVisible) {
         drawBorder();
     }
@@ -144,6 +143,14 @@ void QGIViewImage::drawImage()
         m_imageItem->centerAt(midX,midY);
         m_imageItem->show();
     }
+}
+
+void QGIViewImage::rotateView(void)
+{
+    QRectF r = m_cliparea->boundingRect();
+    m_cliparea->setTransformOriginPoint(r.center());
+    double rot = getViewObject()->Rotation.getValue();
+    m_cliparea->setRotation(-rot);
 }
 
 

--- a/src/Mod/TechDraw/Gui/QGIViewImage.h
+++ b/src/Mod/TechDraw/Gui/QGIViewImage.h
@@ -51,6 +51,7 @@ public:
     void setViewImageFeature(TechDraw::DrawViewImage *obj);
 
     virtual void draw() override;
+    virtual void rotateView(void) override;
 
 protected:
     virtual void drawImage();

--- a/src/Mod/TechDraw/Gui/QGIViewPart.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewPart.cpp
@@ -147,6 +147,7 @@ QPainterPath QGIViewPart::drawPainterPath(TechDrawGeometry::BaseGeom *baseGeom) 
 
 QPainterPath QGIViewPart::geomToPainterPath(TechDrawGeometry::BaseGeom *baseGeom, double rot)
 {
+    Q_UNUSED(rot);
     QPainterPath path;
 
     switch(baseGeom->geomType) {
@@ -291,11 +292,12 @@ QPainterPath QGIViewPart::geomToPainterPath(TechDrawGeometry::BaseGeom *baseGeom
           break;
       }
 
-    if (rot != 0.0) {
-        QTransform t;
-        t.rotate(-rot);
-        path = t.map(path);
-    }
+//old rotate path logic. now done on App side.
+//    if (rot != 0.0) {
+//        QTransform t;
+//        t.rotate(-rot);
+//        path = t.map(path);
+//    }
 
     return path;
 }
@@ -643,7 +645,7 @@ void QGIViewPart::drawSectionLine(TechDraw::DrawViewSection* viewSection, bool b
         sectionLine->setWidth(Rez::guiX(viewPart->LineWidth.getValue()));          //TODO: add fudge to make sectionLine thinner than reg lines?
         sectionLine->setFont(m_font,Rez::guiX(6.0));
         sectionLine->setZValue(ZVALUE::SECTIONLINE);
-        sectionLine->setRotation(- viewPart->Rotation.getValue());
+        sectionLine->setRotation(viewPart->Rotation.getValue());
         sectionLine->draw();
     }
 }
@@ -673,7 +675,7 @@ void QGIViewPart::drawCenterLines(bool b)
             centerLine->setBounds(-xVal,-yVal,xVal,yVal);
             //centerLine->setWidth(viewPart->LineWidth.getValue());
             centerLine->setZValue(ZVALUE::SECTIONLINE);
-            centerLine->setRotation(- viewPart->Rotation.getValue());
+            centerLine->setRotation(viewPart->Rotation.getValue());
             centerLine->draw();
         }
         if (vert) {
@@ -686,7 +688,7 @@ void QGIViewPart::drawCenterLines(bool b)
             centerLine->setBounds(-xVal,-yVal,xVal,yVal);
             //centerLine->setWidth(viewPart->LineWidth.getValue());
             centerLine->setZValue(ZVALUE::SECTIONLINE);
-            centerLine->setRotation(- viewPart->Rotation.getValue());
+            centerLine->setRotation(viewPart->Rotation.getValue());
             centerLine->draw();
         }
     }
@@ -952,6 +954,11 @@ void QGIViewPart::dumpPath(const char* text,QPainterPath path)
 QRectF QGIViewPart::boundingRect() const
 {
     return childrenBoundingRect();
+}
+
+//QGIViewPart derived classes do not need a rotate view method as rotation is handled on App side.
+void QGIViewPart::rotateView(void)
+{
 }
 
 bool QGIViewPart::getFaceEdgesPref(void)

--- a/src/Mod/TechDraw/Gui/QGIViewPart.h
+++ b/src/Mod/TechDraw/Gui/QGIViewPart.h
@@ -67,6 +67,8 @@ public:
     bool showSection;
 
     virtual void draw() override;
+    virtual void rotateView(void) override;
+
 
     static QPainterPath geomToPainterPath(TechDrawGeometry::BaseGeom *baseGeom, double rotation = 0.0);
     /// Helper for pathArc()

--- a/src/Mod/TechDraw/Gui/QGIViewSymbol.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewSymbol.cpp
@@ -44,7 +44,9 @@
 #include <Mod/TechDraw/App/DrawViewSymbol.h>
 
 #include "QGCustomSvg.h"
+#include "QGDisplayArea.h"
 #include "QGIViewSymbol.h"
+#include "DrawGuiUtil.h"
 #include "Rez.h"
 
 using namespace TechDrawGui;
@@ -58,8 +60,12 @@ QGIViewSymbol::QGIViewSymbol()
     setFlag(QGraphicsItem::ItemIsSelectable, true);
     setFlag(QGraphicsItem::ItemSendsGeometryChanges, true);
 
+    m_displayArea = new QGDisplayArea();
+    addToGroup(m_displayArea);
+    m_displayArea->centerAt(0.,0.);
+
     m_svgItem = new QGCustomSvg();
-    addToGroup(m_svgItem);
+    m_displayArea->addToGroup(m_svgItem);
     m_svgItem->centerAt(0.,0.);
 }
 
@@ -126,6 +132,7 @@ void QGIViewSymbol::drawSvg()
 
     QByteArray qba(viewSymbol->Symbol.getValue(),strlen(viewSymbol->Symbol.getValue()));
     symbolToSvg(qba);
+    rotateView();
 }
 
 void QGIViewSymbol::symbolToSvg(QByteArray qba)
@@ -140,3 +147,12 @@ void QGIViewSymbol::symbolToSvg(QByteArray qba)
     }
     m_svgItem->centerAt(0.,0.);
 }
+
+void QGIViewSymbol::rotateView(void)
+{
+    QRectF r = m_displayArea->boundingRect();
+    m_displayArea->setTransformOriginPoint(r.center());
+    double rot = getViewObject()->Rotation.getValue();
+    m_displayArea->setRotation(-rot);
+}
+

--- a/src/Mod/TechDraw/Gui/TaskProjGroup.cpp
+++ b/src/Mod/TechDraw/Gui/TaskProjGroup.cpp
@@ -255,35 +255,79 @@ void TaskProjGroup::scaleTypeChanged(int index)
     Gui::Command::updateActive();
 }
 
-// ** David Eppstein / UC Irvine / 8 Aug 1993
-// Reworked 2015 IR to add the power of logarithms!
-void TaskProjGroup::nearestFraction(double val, int &n, int &d) const
+std::pair<int, int> TaskProjGroup::nearestFraction(const double val, const long int maxDenom) const
 {
-    int exponent = std::floor(std::log10(val));
-    if (exponent > 1 || exponent < -1) {
-        val *= std::pow(10, -exponent);
+/*
+** find rational approximation to given real number
+** David Eppstein / UC Irvine / 8 Aug 1993
+**
+** With corrections from Arno Formella, May 2008
+** and additional fiddles by WF 2017
+** usage: a.out r d
+**   r is real number to approx
+**   d is the maximum denominator allowed
+**
+** based on the theory of continued fractions
+** if x = a1 + 1/(a2 + 1/(a3 + 1/(a4 + ...)))
+** then best approximation is found by truncating this series
+** (with some adjustments in the last term).
+**
+** Note the fraction can be recovered as the first column of the matrix
+**  ( a1 1 ) ( a2 1 ) ( a3 1 ) ...
+**  ( 1  0 ) ( 1  0 ) ( 1  0 )
+** Instead of keeping the sequence of continued fraction terms,
+** we just keep the last partial product of these matrices.
+*/
+    std::pair<int, int> result;
+    long m[2][2];
+    long maxden = maxDenom;
+    long ai;
+    double x = val;
+    double startx = x;
+
+    /* initialize matrix */
+    m[0][0] = m[1][1] = 1;
+    m[0][1] = m[1][0] = 0;
+
+    /* loop finding terms until denom gets too big */
+    while (m[1][0] *  ( ai = (long)x ) + m[1][1] <= maxden) {
+        long t;
+        t = m[0][0] * ai + m[0][1];
+        m[0][1] = m[0][0];
+        m[0][0] = t;
+        t = m[1][0] * ai + m[1][1];
+        m[1][1] = m[1][0];
+        m[1][0] = t;
+        if(x == (double) ai)
+            break;     // AF: division by zero
+        x = 1/(x - (double) ai);
+        if(x > (double) std::numeric_limits<int>::max())
+            break;     // AF: representation failure
     }
 
-    n = 1;  // numerator
-    d = 1;  // denominator
-    double fraction = 1.0;                                                      //coverity 152005
-    //double m = fabs(fraction - val);
+    /* now remaining x is between 0 and 1/ai */
+    /* approx as either 0 or 1/m where m is max that will fit in maxden */
+    /* first try zero */
+    double error1 = startx - ((double) m[0][0] / (double) m[1][0]);
+    int n1 = m[0][0];
+    int d1 = m[1][0];
 
-    while (fabs(fraction - val) > 0.001) {
-        if (fraction < val) {
-            ++n;
-        } else {
-            ++d;
-            n = (int) round(val * d);
-        }
-        fraction = n / (double) d;
-    }
+    /* now try other possibility */
+    ai = (maxden - m[1][1]) / m[1][0];
+    m[0][0] = m[0][0] * ai + m[0][1];
+    m[1][0] = m[1][0] * ai + m[1][1];
+    double error2 = startx - ((double) m[0][0] / (double) m[1][0]);
+    int n2 = m[0][0];
+    int d2 = m[1][0];
 
-    if (exponent > 1) {
-            n *= std::pow(10, exponent);
-    } else if (exponent < -1) {
-            d *= std::pow(10, -exponent);
+    if (std::fabs(error1) <= std::fabs(error2)) {
+        result.first  = n1;
+        result.second = d1;
+    } else {
+        result.first  = n2;
+        result.second = d2;
     }
+    return result;
 }
 
 void TaskProjGroup::updateTask()
@@ -302,12 +346,11 @@ void TaskProjGroup::updateTask()
 void TaskProjGroup::setFractionalScale(double newScale)
 {
     blockUpdate = true;
-    int num, den;
 
-    nearestFraction(newScale, num, den);
+    std::pair<int, int> fraction = nearestFraction(newScale);
 
-    ui->sbScaleNum->setValue(num);
-    ui->sbScaleDen->setValue(den);
+    ui->sbScaleNum->setValue(fraction.first);
+    ui->sbScaleDen->setValue(fraction.second);
     blockUpdate = false;
 }
 

--- a/src/Mod/TechDraw/Gui/TaskProjGroup.h
+++ b/src/Mod/TechDraw/Gui/TaskProjGroup.h
@@ -63,8 +63,8 @@ public:
     virtual bool accept();
     virtual bool reject();
     void updateTask();
-    void nearestFraction(double val, int &a, int &b) const;
-    /// Sets the numerator and denominator widgets to match newScale
+    std::pair<int, int> nearestFraction(const double val, const long int maxDenom = 999) const;
+    // Sets the numerator and denominator widgets to match newScale
     void setFractionalScale(double newScale);
     void setCreateMode(bool b) { m_createMode = b;}
     bool getCreateMode() { return m_createMode; }


### PR DESCRIPTION
This PR addresses the following issues in TechDraw.  Please merge.
- make X,Y positioning consistent across all view types.
- rotate contents within View frames instead of rotating frames.
- fix conversion of decimal scale <-> ratio scale
- fix handling of "," decimal separator in Qt5

Thanks,
wf 


Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR once it is merged.

---
