### PR TITLE
DlgCustomizeSpNavSettings.ui: remove trailing whitespace from menu label

### DIFF
--- a/src/Gui/DlgCustomizeSpNavSettings.ui
+++ b/src/Gui/DlgCustomizeSpNavSettings.ui
@@ -19,7 +19,7 @@
      <item>
       <widget class="QLabel" name="labelSlow">
        <property name="text">
-        <string>Global Sensitivity:  </string>
+        <string>Global Sensitivity:</string>
        </property>
       </widget>
      </item>


### PR DESCRIPTION
Crowdin complained about whitespace in this string. So I removed it. Though I haven't built this to test it. I did look at it in Qt Designer, and here is what I saw (sans whitespace):
![image](https://user-images.githubusercontent.com/4140247/32755438-5264337a-c8a3-11e7-83f9-aca7c3e4d7c0.png)

which looks fine to me. Thoughts?