### PR TITLE
Added color prefs to sketcher create commands

### DIFF
--- a/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp
+++ b/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp
@@ -61,6 +61,7 @@
 #include <Gui/ToolBarManager.h>
 
 #include "GeometryCreationMode.h"
+#include <stdlib.h>
 
 using namespace std;
 using namespace SketcherGui;
@@ -226,10 +227,14 @@ void removeRedundantHorizontalVertical(Sketcher::SketchObject* psketch,
 
 /* Sketch commands =======================================================*/
 
+static const char cursor_crosshair_color_fmt[] = "+ c #%06lX";
+
+static char cursor_crosshair_color[11];
+
 /* XPM */
 static const char *cursor_createline[]={
 "32 32 3 1",
-"+ c white",
+cursor_crosshair_color,
 "# c red",
 ". c None",
 "......+.........................",
@@ -279,6 +284,14 @@ public:
 
     virtual void activated(ViewProviderSketch *)
     {
+	unsigned long color = 0xFFFFFF; // white
+	ParameterGrp::handle hGrp = \
+	    App::GetApplication().GetParameterGroupByPath\
+	    ("User parameter:BaseApp/Preferences/View");
+	color = hGrp->GetUnsigned("CreateCrosshairColor", color);
+	// from rgba to rgb
+	color = (color >> 8) & 0xFFFFFF;
+	sprintf(cursor_crosshair_color, cursor_crosshair_color_fmt, color);
         setCursor(QPixmap(cursor_createline),7,7);
     }
 
@@ -436,7 +449,7 @@ bool CmdSketcherCreateLine::isActive(void)
 /* XPM */
 static const char *cursor_createbox[]={
 "32 32 3 1",
-"+ c white",
+cursor_crosshair_color,
 "# c red",
 ". c None",
 "......+.........................",
@@ -486,6 +499,14 @@ public:
 
     virtual void activated(ViewProviderSketch *)
     {
+	unsigned long color = 0xFFFFFF; // white
+	ParameterGrp::handle hGrp = \
+	    App::GetApplication().GetParameterGroupByPath\
+	    ("User parameter:BaseApp/Preferences/View");
+	color = hGrp->GetUnsigned("CreateCrosshairColor", color);
+	// from rgba to rgb
+	color = (color >> 8) & 0xFFFFFF;
+	sprintf(cursor_crosshair_color, cursor_crosshair_color_fmt, color);
         setCursor(QPixmap(cursor_createbox),7,7);
     }
 
@@ -674,7 +695,7 @@ bool CmdSketcherCreateRectangle::isActive(void)
 /* XPM */
 static const char *cursor_createlineset[]={
 "32 32 3 1",
-"+ c white",
+cursor_crosshair_color,
 "# c red",
 ". c None",
 "......+.........................",
@@ -830,6 +851,14 @@ public:
 
     virtual void activated(ViewProviderSketch *)
     {
+	unsigned long color = 0xFFFFFF; // white
+	ParameterGrp::handle hGrp = \
+	    App::GetApplication().GetParameterGroupByPath\
+	    ("User parameter:BaseApp/Preferences/View");
+	color = hGrp->GetUnsigned("CreateCrosshairColor", color);
+	// from rgba to rgb
+	color = (color >> 8) & 0xFFFFFF;
+	sprintf(cursor_crosshair_color, cursor_crosshair_color_fmt, color);
         setCursor(QPixmap(cursor_createlineset),7,7);
     }
 
@@ -1365,7 +1394,7 @@ bool CmdSketcherCreatePolyline::isActive(void)
 /* XPM */
 static const char *cursor_createarc[]={
 "32 32 3 1",
-"+ c white",
+cursor_crosshair_color,
 "# c red",
 ". c None",
 "......+...........###...........",
@@ -1424,6 +1453,14 @@ public:
 
     virtual void activated(ViewProviderSketch *)
     {
+	unsigned long color = 0xFFFFFF; // white
+	ParameterGrp::handle hGrp = \
+	    App::GetApplication().GetParameterGroupByPath\
+	    ("User parameter:BaseApp/Preferences/View");
+	color = hGrp->GetUnsigned("CreateCrosshairColor", color);
+	// from rgba to rgb
+	color = (color >> 8) & 0xFFFFFF;
+	sprintf(cursor_crosshair_color, cursor_crosshair_color_fmt, color);
         setCursor(QPixmap(cursor_createarc),7,7);
     }
 
@@ -1636,7 +1673,7 @@ bool CmdSketcherCreateArc::isActive(void)
 /* XPM */
 static const char *cursor_create3pointarc[]={
 "32 32 3 1",
-"+ c white",
+cursor_crosshair_color,
 "# c red",
 ". c None",
 "......+...........###...........",
@@ -1694,6 +1731,14 @@ public:
 
     virtual void activated(ViewProviderSketch *)
     {
+	unsigned long color = 0xFFFFFF; // white
+	ParameterGrp::handle hGrp = \
+	    App::GetApplication().GetParameterGroupByPath\
+	    ("User parameter:BaseApp/Preferences/View");
+	color = hGrp->GetUnsigned("CreateCrosshairColor", color);
+	// from rgba to rgb
+	color = (color >> 8) & 0xFFFFFF;
+	sprintf(cursor_crosshair_color, cursor_crosshair_color_fmt, color);
         setCursor(QPixmap(cursor_create3pointarc),7,7);
     }
 
@@ -2047,7 +2092,7 @@ bool CmdSketcherCompCreateArc::isActive(void)
 /* XPM */
 static const char *cursor_createcircle[]={
 "32 32 3 1",
-"+ c white",
+cursor_crosshair_color,
 "# c red",
 ". c None",
 "......+.........................",
@@ -2097,6 +2142,14 @@ public:
 
     virtual void activated(ViewProviderSketch *)
     {
+	unsigned long color = 0xFFFFFF; // white
+	ParameterGrp::handle hGrp = \
+	    App::GetApplication().GetParameterGroupByPath\
+	    ("User parameter:BaseApp/Preferences/View");
+	color = hGrp->GetUnsigned("CreateCrosshairColor", color);
+	// from rgba to rgb
+	color = (color >> 8) & 0xFFFFFF;
+	sprintf(cursor_crosshair_color, cursor_crosshair_color_fmt, color);
         setCursor(QPixmap(cursor_createcircle),7,7);
     }
 
@@ -2249,7 +2302,7 @@ bool CmdSketcherCreateCircle::isActive(void)
  */
 static const char *cursor_createellipse[]={
 "32 32 3 1",
-"+ c white",
+cursor_crosshair_color,
 "# c red",
 ". c None",
 "......+.........................",
@@ -2357,6 +2410,14 @@ public:
      */
     virtual void activated(ViewProviderSketch *)
     {
+	unsigned long color = 0xFFFFFF; // white
+	ParameterGrp::handle hGrp = \
+	    App::GetApplication().GetParameterGroupByPath\
+	    ("User parameter:BaseApp/Preferences/View");
+	color = hGrp->GetUnsigned("CreateCrosshairColor", color);
+	// from rgba to rgb
+	color = (color >> 8) & 0xFFFFFF;
+	sprintf(cursor_crosshair_color, cursor_crosshair_color_fmt, color);
         setCursor(QPixmap(cursor_createellipse),7,7);
         if (constrMethod == 0) {
             method = CENTER_PERIAPSIS_B;
@@ -3116,7 +3177,7 @@ bool CmdSketcherCreateEllipseBy3Points::isActive(void)
 /* XPM */
 static const char *cursor_createarcofellipse[]={
 "32 32 3 1",
-"+ c white",
+cursor_crosshair_color,
 "# c red",
 ". c None",
 "......+.........................",
@@ -3173,6 +3234,14 @@ public:
 
     virtual void activated(ViewProviderSketch *)
     {
+	unsigned long color = 0xFFFFFF; // white
+	ParameterGrp::handle hGrp = \
+	    App::GetApplication().GetParameterGroupByPath\
+	    ("User parameter:BaseApp/Preferences/View");
+	color = hGrp->GetUnsigned("CreateCrosshairColor", color);
+	// from rgba to rgb
+	color = (color >> 8) & 0xFFFFFF;
+	sprintf(cursor_crosshair_color, cursor_crosshair_color_fmt, color);
         setCursor(QPixmap(cursor_createarcofellipse),7,7);
     }
 
@@ -3488,7 +3557,7 @@ bool CmdSketcherCreateArcOfEllipse::isActive(void)
 /* XPM */
 static const char *cursor_createarcofhyperbola[]={
 "32 32 3 1",
-"+ c white",
+cursor_crosshair_color,
 "# c red",
 ". c None",
 "......+.........................",
@@ -3546,6 +3615,14 @@ public:
 
     virtual void activated(ViewProviderSketch * /*sketchgui*/)
     {
+	unsigned long color = 0xFFFFFF; // white
+	ParameterGrp::handle hGrp = \
+	    App::GetApplication().GetParameterGroupByPath\
+	    ("User parameter:BaseApp/Preferences/View");
+	color = hGrp->GetUnsigned("CreateCrosshairColor", color);
+	// from rgba to rgb
+	color = (color >> 8) & 0xFFFFFF;
+	sprintf(cursor_crosshair_color, cursor_crosshair_color_fmt, color);
         setCursor(QPixmap(cursor_createarcofhyperbola),7,7);
     }
 
@@ -3870,7 +3947,7 @@ bool CmdSketcherCreateArcOfHyperbola::isActive(void)
 /* XPM */
 static const char *cursor_createarcofparabola[]={
 "32 32 3 1",
-"+ c white",
+cursor_crosshair_color,
 "# c red",
 ". c None",
 "......+.........................",
@@ -3930,6 +4007,14 @@ public:
 
     virtual void activated(ViewProviderSketch * /*sketchgui*/)
     {
+	unsigned long color = 0xFFFFFF; // white
+	ParameterGrp::handle hGrp = \
+	    App::GetApplication().GetParameterGroupByPath\
+	    ("User parameter:BaseApp/Preferences/View");
+	color = hGrp->GetUnsigned("CreateCrosshairColor", color);
+	// from rgba to rgb
+	color = (color >> 8) & 0xFFFFFF;
+	sprintf(cursor_crosshair_color, cursor_crosshair_color_fmt, color);
         setCursor(QPixmap(cursor_createarcofparabola),7,7);
     }
 
@@ -4362,7 +4447,7 @@ bool CmdSketcherCompCreateConic::isActive(void)
 /* XPM */
 static const char *cursor_createbspline[]={
 "32 32 3 1",
-"+ c white",
+cursor_crosshair_color,
 "# c red",
 ". c None",
 "......+.........................",
@@ -4423,6 +4508,14 @@ public:
 
     virtual void activated(ViewProviderSketch *)
     {
+	unsigned long color = 0xFFFFFF; // white
+	ParameterGrp::handle hGrp = \
+	    App::GetApplication().GetParameterGroupByPath\
+	    ("User parameter:BaseApp/Preferences/View");
+	color = hGrp->GetUnsigned("CreateCrosshairColor", color);
+	// from rgba to rgb
+	color = (color >> 8) & 0xFFFFFF;
+	sprintf(cursor_crosshair_color, cursor_crosshair_color_fmt, color);
         setCursor(QPixmap(cursor_createbspline),7,7);
     }
 
@@ -4941,7 +5034,7 @@ bool CmdSketcherCompCreateBSpline::isActive(void)
 /* XPM */
 static const char *cursor_create3pointcircle[]={
 "32 32 3 1",
-"+ c white",
+cursor_crosshair_color,
 "# c red",
 ". c None",
 "......+.........................",
@@ -4993,6 +5086,14 @@ public:
 
     virtual void activated(ViewProviderSketch *)
     {
+	unsigned long color = 0xFFFFFF; // white
+	ParameterGrp::handle hGrp = \
+	    App::GetApplication().GetParameterGroupByPath\
+	    ("User parameter:BaseApp/Preferences/View");
+	color = hGrp->GetUnsigned("CreateCrosshairColor", color);
+	// from rgba to rgb
+	color = (color >> 8) & 0xFFFFFF;
+	sprintf(cursor_crosshair_color, cursor_crosshair_color_fmt, color);
         setCursor(QPixmap(cursor_create3pointcircle),7,7);
     }
 
@@ -5293,7 +5394,7 @@ bool CmdSketcherCompCreateCircle::isActive(void)
 /* XPM */
 static const char *cursor_createpoint[]={
 "32 32 3 1",
-"+ c white",
+cursor_crosshair_color,
 "# c red",
 ". c None",
 "......+.........................",
@@ -5337,6 +5438,14 @@ public:
 
     virtual void activated(ViewProviderSketch *)
     {
+	unsigned long color = 0xFFFFFF; // white
+	ParameterGrp::handle hGrp = \
+	    App::GetApplication().GetParameterGroupByPath\
+	    ("User parameter:BaseApp/Preferences/View");
+	color = hGrp->GetUnsigned("CreateCrosshairColor", color);
+	// from rgba to rgb
+	color = (color >> 8) & 0xFFFFFF;
+	sprintf(cursor_crosshair_color, cursor_crosshair_color_fmt, color);
         setCursor(QPixmap(cursor_createpoint),7,7);
     }
 
@@ -5539,7 +5648,7 @@ namespace SketcherGui {
 /* XPM */
 static const char *cursor_createfillet[]={
 "32 32 3 1",
-"+ c white",
+cursor_crosshair_color,
 "* c red",
 ". c None",
 "......+.........................",
@@ -5592,6 +5701,14 @@ public:
     {
         Gui::Selection().rmvSelectionGate();
         Gui::Selection().addSelectionGate(new FilletSelection(sketchgui->getObject()));
+	unsigned long color = 0xFFFFFF; // white
+	ParameterGrp::handle hGrp = \
+	    App::GetApplication().GetParameterGroupByPath\
+	    ("User parameter:BaseApp/Preferences/View");
+	color = hGrp->GetUnsigned("CreateCrosshairColor", color);
+	// from rgba to rgb
+	color = (color >> 8) & 0xFFFFFF;
+	sprintf(cursor_crosshair_color, cursor_crosshair_color_fmt, color);
         setCursor(QPixmap(cursor_createfillet),7,7);
     }
 
@@ -5819,7 +5936,7 @@ namespace SketcherGui {
 /* XPM */
 static const char *cursor_trimming[]={
 "32 32 3 1",
-"+ c white",
+cursor_crosshair_color,
 "* c red",
 ". c None",
 "......+.........................",
@@ -5869,6 +5986,14 @@ public:
         Gui::Selection().clearSelection();
         Gui::Selection().rmvSelectionGate();
         Gui::Selection().addSelectionGate(new TrimmingSelection(sketchgui->getObject()));
+	unsigned long color = 0xFFFFFF; // white
+	ParameterGrp::handle hGrp = \
+	    App::GetApplication().GetParameterGroupByPath\
+	    ("User parameter:BaseApp/Preferences/View");
+	color = hGrp->GetUnsigned("CreateCrosshairColor", color);
+	// from rgba to rgb
+	color = (color >> 8) & 0xFFFFFF;
+	sprintf(cursor_crosshair_color, cursor_crosshair_color_fmt, color);
         setCursor(QPixmap(cursor_trimming),7,7);
     }
 
@@ -5986,7 +6111,7 @@ namespace SketcherGui {
 /* XPM */
 static const char *cursor_extension[]={
 "32 32 3 1",
-"+ c white",
+cursor_crosshair_color,
 "* c red",
 ". c None",
 "......+.........................",
@@ -6049,6 +6174,14 @@ public:
         Gui::Selection().rmvSelectionGate();
         filterGate = new ExtendSelection(sketchgui->getObject());
         Gui::Selection().addSelectionGate(filterGate);
+	unsigned long color = 0xFFFFFF; // white
+	ParameterGrp::handle hGrp = \
+	    App::GetApplication().GetParameterGroupByPath\
+	    ("User parameter:BaseApp/Preferences/View");
+	color = hGrp->GetUnsigned("CreateCrosshairColor", color);
+	// from rgba to rgb
+	color = (color >> 8) & 0xFFFFFF;
+	sprintf(cursor_crosshair_color, cursor_crosshair_color_fmt, color);
         setCursor(QPixmap(cursor_extension),7,7);
     }
 
@@ -6360,7 +6493,7 @@ namespace SketcherGui {
 /* XPM */
 static const char *cursor_external[]={
 "32 32 3 1",
-"+ c white",
+cursor_crosshair_color,
 "* c red",
 ". c None",
 "......+.........................",
@@ -6418,6 +6551,14 @@ public:
         Gui::Selection().clearSelection();
         Gui::Selection().rmvSelectionGate();
         Gui::Selection().addSelectionGate(new ExternalSelection(sketchgui->getObject()));
+	unsigned long color = 0xFFFFFF; // white
+	ParameterGrp::handle hGrp = \
+	    App::GetApplication().GetParameterGroupByPath\
+	    ("User parameter:BaseApp/Preferences/View");
+	color = hGrp->GetUnsigned("CreateCrosshairColor", color);
+	// from rgba to rgb
+	color = (color >> 8) & 0xFFFFFF;
+	sprintf(cursor_crosshair_color, cursor_crosshair_color_fmt, color);
         setCursor(QPixmap(cursor_external),7,7);
     }
 
@@ -6580,7 +6721,7 @@ namespace SketcherGui {
 /* XPM */
 static const char *cursor_carboncopy[]={
     "32 32 3 1",
-    "+ c white",
+    cursor_crosshair_color,
     "* c red",
     ". c None",
     "......+.........................",
@@ -6638,6 +6779,14 @@ static const char *cursor_carboncopy[]={
             Gui::Selection().clearSelection();
             Gui::Selection().rmvSelectionGate();
             Gui::Selection().addSelectionGate(new CarbonCopySelection(sketchgui->getObject()));
+	    unsigned long color = 0xFFFFFF; // white
+	    ParameterGrp::handle hGrp =				\
+		App::GetApplication().GetParameterGroupByPath	\
+		("User parameter:BaseApp/Preferences/View");
+	    color = hGrp->GetUnsigned("CreateCrosshairColor", color);
+	    // from rgba to rgb
+	    color = (color >> 8) & 0xFFFFFF;
+	    sprintf(cursor_crosshair_color, cursor_crosshair_color_fmt, color);
             setCursor(QPixmap(cursor_carboncopy),7,7);
         }
         
@@ -6752,7 +6901,7 @@ static const char *cursor_carboncopy[]={
 /* XPM */
 static const char *cursor_creatslot[]={
 "32 32 3 1",
-"+ c white",
+cursor_crosshair_color,
 "# c red",
 ". c None",
 "......+.........................",
@@ -6807,6 +6956,14 @@ public:
 
     virtual void activated(ViewProviderSketch *)
     {
+	unsigned long color = 0xFFFFFF; // white
+	ParameterGrp::handle hGrp = \
+	    App::GetApplication().GetParameterGroupByPath\
+	    ("User parameter:BaseApp/Preferences/View");
+	color = hGrp->GetUnsigned("CreateCrosshairColor", color);
+	// from rgba to rgb
+	color = (color >> 8) & 0xFFFFFF;
+	sprintf(cursor_crosshair_color, cursor_crosshair_color_fmt, color);
         setCursor(QPixmap(cursor_creatslot),7,7);
     }
 
@@ -7031,7 +7188,7 @@ bool CmdSketcherCreateSlot::isActive(void)
 /* XPM */
 static const char *cursor_createregularpolygon[]={
 "32 32 3 1",
-"+ c white",
+cursor_crosshair_color,
 "# c red",
 ". c None",
 "......+.........................",
@@ -7089,6 +7246,14 @@ public:
 
     virtual void activated(ViewProviderSketch *)
     {
+	unsigned long color = 0xFFFFFF; // white
+	ParameterGrp::handle hGrp = \
+	    App::GetApplication().GetParameterGroupByPath\
+	    ("User parameter:BaseApp/Preferences/View");
+	color = hGrp->GetUnsigned("CreateCrosshairColor", color);
+	// from rgba to rgb
+	color = (color >> 8) & 0xFFFFFF;
+	sprintf(cursor_crosshair_color, cursor_crosshair_color_fmt, color);
         setCursor(QPixmap(cursor_createregularpolygon),7,7);
     }
 

--- a/src/Mod/Sketcher/Gui/SketcherSettings.cpp
+++ b/src/Mod/Sketcher/Gui/SketcherSettings.cpp
@@ -236,6 +236,8 @@ void SketcherSettingsColors::saveSettings()
     ui->DefaultSketcherLineWidth->onSave();
 
     ui->CursorTextColor->onSave();
+    ui->CreateCrosshairColor->onSave();
+    ui->CreateLineColor->onSave();
 }
 
 void SketcherSettingsColors::loadSettings()
@@ -258,6 +260,8 @@ void SketcherSettingsColors::loadSettings()
     ui->DefaultSketcherLineWidth->onRestore();
 
     ui->CursorTextColor->onRestore();
+    ui->CreateCrosshairColor->onRestore();
+    ui->CreateLineColor->onRestore();
 }
 
 /**

--- a/src/Mod/Sketcher/Gui/SketcherSettingsColors.ui
+++ b/src/Mod/Sketcher/Gui/SketcherSettingsColors.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>438</width>
-    <height>474</height>
+    <height>529</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -19,469 +19,525 @@
      <property name="title">
       <string>Sketcher colors</string>
      </property>
-     <layout class="QHBoxLayout" name="horizontalLayout_2">
-      <item>
-       <layout class="QGridLayout" name="gridLayout_2">
-        <item row="0" column="0">
-         <widget class="QLabel" name="label_17">
-          <property name="minimumSize">
-           <size>
-            <width>182</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>Default edge color</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="1">
-         <widget class="Gui::PrefColorButton" name="SketchEdgeColor">
-          <property name="toolTip">
-           <string>The color of edges being edited</string>
-          </property>
-          <property name="color">
-           <color>
-            <red>255</red>
-            <green>255</green>
-            <blue>255</blue>
-           </color>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>SketchEdgeColor</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>View</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="label_18">
-          <property name="minimumSize">
-           <size>
-            <width>182</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>Default vertex color</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="1">
-         <widget class="Gui::PrefColorButton" name="SketchVertexColor">
-          <property name="toolTip">
-           <string>The color of vertices being edited</string>
-          </property>
-          <property name="color">
-           <color>
-            <red>255</red>
-            <green>255</green>
-            <blue>255</blue>
-           </color>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>SketchVertexColor</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>View</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="0">
-         <widget class="QLabel" name="label">
-          <property name="minimumSize">
-           <size>
-            <width>182</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>Edit edge color</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="1">
-         <widget class="Gui::PrefColorButton" name="EditedEdgeColor">
-          <property name="toolTip">
-           <string>The color of edges being edited</string>
-          </property>
-          <property name="color">
-           <color>
-            <red>255</red>
-            <green>255</green>
-            <blue>255</blue>
-           </color>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>EditedEdgeColor</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>View</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="0">
-         <widget class="QLabel" name="label_2">
-          <property name="minimumSize">
-           <size>
-            <width>182</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>Edit vertex color</string>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="1">
-         <widget class="Gui::PrefColorButton" name="EditedVertexColor">
-          <property name="toolTip">
-           <string>The color of vertices being edited</string>
-          </property>
-          <property name="color">
-           <color>
-            <red>255</red>
-            <green>38</green>
-            <blue>0</blue>
-           </color>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>EditedVertexColor</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>View</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="0">
-         <widget class="QLabel" name="label_3">
-          <property name="minimumSize">
-           <size>
-            <width>182</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>Construction geometry</string>
-          </property>
-         </widget>
-        </item>
-        <item row="9" column="1">
-         <widget class="Gui::PrefColorButton" name="DatumColor">
-          <property name="toolTip">
-           <string>The color of the datum portion of a driving constraint</string>
-          </property>
-          <property name="color">
-           <color>
-            <red>255</red>
-            <green>38</green>
-            <blue>0</blue>
-           </color>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>ConstrainedDimColor</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>View</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="1">
-         <widget class="Gui::PrefColorButton" name="ConstructionColor">
-          <property name="toolTip">
-           <string>The color of construction geometry in edit mode</string>
-          </property>
-          <property name="color">
-           <color>
-            <red>0</red>
-            <green>0</green>
-            <blue>220</blue>
-           </color>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>ConstructionColor</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>View</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="5" column="0">
-         <widget class="QLabel" name="label_20">
-          <property name="minimumSize">
-           <size>
-            <width>182</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>External geometry</string>
-          </property>
-         </widget>
-        </item>
-        <item row="5" column="1">
-         <widget class="Gui::PrefColorButton" name="ExternalColor">
-          <property name="toolTip">
-           <string>The color of external geometry in edit mode</string>
-          </property>
-          <property name="color">
-           <color>
-            <red>204</red>
-            <green>51</green>
-            <blue>115</blue>
-           </color>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>ExternalColor</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>View</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="6" column="0">
-         <widget class="QLabel" name="label_4">
-          <property name="minimumSize">
-           <size>
-            <width>182</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>Fully constrained geometry</string>
-          </property>
-         </widget>
-        </item>
-        <item row="7" column="0">
-         <widget class="QLabel" name="label_14">
-          <property name="minimumSize">
-           <size>
-            <width>182</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>Constraint color</string>
-          </property>
-         </widget>
-        </item>
-        <item row="6" column="1">
-         <widget class="Gui::PrefColorButton" name="FullyConstrainedColor">
-          <property name="toolTip">
-           <string>The color of fully constrained geometry in edit mode</string>
-          </property>
-          <property name="color">
-           <color>
-            <red>0</red>
-            <green>255</green>
-            <blue>0</blue>
-           </color>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>FullyConstrainedColor</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>View</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="9" column="0">
-         <widget class="QLabel" name="label_15">
-          <property name="minimumSize">
-           <size>
-            <width>182</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>Datum color</string>
-          </property>
-         </widget>
-        </item>
-        <item row="10" column="0">
-         <widget class="QLabel" name="label_16">
-          <property name="minimumSize">
-           <size>
-            <width>182</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>Datum text size</string>
-          </property>
-         </widget>
-        </item>
-        <item row="11" column="0">
-         <widget class="QLabel" name="label_12">
-          <property name="minimumSize">
-           <size>
-            <width>182</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>Default vertex size</string>
-          </property>
-         </widget>
-        </item>
-        <item row="10" column="1">
-         <widget class="Gui::PrefSpinBox" name="SketcherDatumWidth">
-          <property name="toolTip">
-           <string>The default line thickness for new shapes</string>
-          </property>
-          <property name="suffix">
-           <string>px</string>
-          </property>
-          <property name="maximum">
-           <number>9</number>
-          </property>
-          <property name="value">
-           <number>2</number>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>DefaultSketcherVertexWidth</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>View</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="12" column="0">
-         <widget class="QLabel" name="label_13">
-          <property name="minimumSize">
-           <size>
-            <width>182</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>Default line width</string>
-          </property>
-         </widget>
-        </item>
-        <item row="11" column="1">
-         <widget class="Gui::PrefSpinBox" name="DefaultSketcherVertexWidth">
-          <property name="toolTip">
-           <string>The default line thickness for new shapes</string>
-          </property>
-          <property name="suffix">
-           <string>px</string>
-          </property>
-          <property name="maximum">
-           <number>9</number>
-          </property>
-          <property name="value">
-           <number>2</number>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>DefaultSketcherVertexWidth</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>View</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="13" column="0">
-         <widget class="QLabel" name="label_5">
-          <property name="minimumSize">
-           <size>
-            <width>182</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>Cursor text color</string>
-          </property>
-         </widget>
-        </item>
-        <item row="13" column="1">
-         <widget class="Gui::PrefColorButton" name="CursorTextColor">
-          <property name="color">
-           <color>
-            <red>0</red>
-            <green>0</green>
-            <blue>255</blue>
-           </color>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>CursorTextColor</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>View</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="12" column="1">
-         <widget class="Gui::PrefSpinBox" name="DefaultSketcherLineWidth">
-          <property name="toolTip">
-           <string>The default line thickness for new shapes</string>
-          </property>
-          <property name="suffix">
-           <string>px</string>
-          </property>
-          <property name="maximum">
-           <number>9</number>
-          </property>
-          <property name="value">
-           <number>2</number>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>DefaultShapeLineWidth</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>View</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="8" column="0">
-         <widget class="QLabel" name="label_8">
-          <property name="text">
-           <string>Reference Constraint color</string>
-          </property>
-         </widget>
-        </item>
-        <item row="7" column="1">
-         <widget class="Gui::PrefColorButton" name="ConstrainedColor">
-          <property name="toolTip">
-           <string>The color of driving constraints in edit mode</string>
-          </property>
-          <property name="color">
-           <color>
-            <red>255</red>
-            <green>38</green>
-            <blue>0</blue>
-           </color>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>ConstrainedIcoColor</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>View</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="8" column="1">
-         <widget class="Gui::PrefColorButton" name="NonDrivingConstraintColor">
-          <property name="toolTip">
-           <string>The color of reference constrains and datum in edit mode</string>
-          </property>
-          <property name="color">
-           <color>
-            <red>0</red>
-            <green>38</green>
-            <blue>255</blue>
-           </color>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>NonDrivingConstrDimColor</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>View</cstring>
-          </property>
-         </widget>
-        </item>
-       </layout>
+     <layout class="QGridLayout" name="gridLayout_2">
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_17">
+        <property name="minimumSize">
+         <size>
+          <width>182</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>Default edge color</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="Gui::PrefColorButton" name="SketchEdgeColor">
+        <property name="toolTip">
+         <string>The color of edges being edited</string>
+        </property>
+        <property name="color" stdset="0">
+         <color>
+          <red>255</red>
+          <green>255</green>
+          <blue>255</blue>
+         </color>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>SketchEdgeColor</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>View</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_18">
+        <property name="minimumSize">
+         <size>
+          <width>182</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>Default vertex color</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="Gui::PrefColorButton" name="SketchVertexColor">
+        <property name="toolTip">
+         <string>The color of vertices being edited</string>
+        </property>
+        <property name="color" stdset="0">
+         <color>
+          <red>255</red>
+          <green>255</green>
+          <blue>255</blue>
+         </color>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>SketchVertexColor</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>View</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="label">
+        <property name="minimumSize">
+         <size>
+          <width>182</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>Edit edge color</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="Gui::PrefColorButton" name="EditedEdgeColor">
+        <property name="toolTip">
+         <string>The color of edges being edited</string>
+        </property>
+        <property name="color" stdset="0">
+         <color>
+          <red>255</red>
+          <green>255</green>
+          <blue>255</blue>
+         </color>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>EditedEdgeColor</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>View</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="label_2">
+        <property name="minimumSize">
+         <size>
+          <width>182</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>Edit vertex color</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="Gui::PrefColorButton" name="EditedVertexColor">
+        <property name="toolTip">
+         <string>The color of vertices being edited</string>
+        </property>
+        <property name="color" stdset="0">
+         <color>
+          <red>255</red>
+          <green>38</green>
+          <blue>0</blue>
+         </color>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>EditedVertexColor</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>View</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0">
+       <widget class="QLabel" name="label_3">
+        <property name="minimumSize">
+         <size>
+          <width>182</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>Construction geometry</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="1">
+       <widget class="Gui::PrefColorButton" name="ConstructionColor">
+        <property name="toolTip">
+         <string>The color of construction geometry in edit mode</string>
+        </property>
+        <property name="color" stdset="0">
+         <color>
+          <red>0</red>
+          <green>0</green>
+          <blue>220</blue>
+         </color>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>ConstructionColor</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>View</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="0">
+       <widget class="QLabel" name="label_20">
+        <property name="minimumSize">
+         <size>
+          <width>182</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>External geometry</string>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="1">
+       <widget class="Gui::PrefColorButton" name="ExternalColor">
+        <property name="toolTip">
+         <string>The color of external geometry in edit mode</string>
+        </property>
+        <property name="color" stdset="0">
+         <color>
+          <red>204</red>
+          <green>51</green>
+          <blue>115</blue>
+         </color>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>ExternalColor</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>View</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="0">
+       <widget class="QLabel" name="label_4">
+        <property name="minimumSize">
+         <size>
+          <width>182</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>Fully constrained geometry</string>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="1">
+       <widget class="Gui::PrefColorButton" name="FullyConstrainedColor">
+        <property name="toolTip">
+         <string>The color of fully constrained geometry in edit mode</string>
+        </property>
+        <property name="color" stdset="0">
+         <color>
+          <red>0</red>
+          <green>255</green>
+          <blue>0</blue>
+         </color>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>FullyConstrainedColor</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>View</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="0">
+       <widget class="QLabel" name="label_14">
+        <property name="minimumSize">
+         <size>
+          <width>182</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>Constraint color</string>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="1">
+       <widget class="Gui::PrefColorButton" name="ConstrainedColor">
+        <property name="toolTip">
+         <string>The color of driving constraints in edit mode</string>
+        </property>
+        <property name="color" stdset="0">
+         <color>
+          <red>255</red>
+          <green>38</green>
+          <blue>0</blue>
+         </color>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>ConstrainedIcoColor</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>View</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="8" column="0">
+       <widget class="QLabel" name="label_8">
+        <property name="text">
+         <string>Reference Constraint color</string>
+        </property>
+       </widget>
+      </item>
+      <item row="8" column="1">
+       <widget class="Gui::PrefColorButton" name="NonDrivingConstraintColor">
+        <property name="toolTip">
+         <string>The color of reference constrains and datum in edit mode</string>
+        </property>
+        <property name="color" stdset="0">
+         <color>
+          <red>0</red>
+          <green>38</green>
+          <blue>255</blue>
+         </color>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>NonDrivingConstrDimColor</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>View</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="9" column="0">
+       <widget class="QLabel" name="label_15">
+        <property name="minimumSize">
+         <size>
+          <width>182</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>Datum color</string>
+        </property>
+       </widget>
+      </item>
+      <item row="9" column="1">
+       <widget class="Gui::PrefColorButton" name="DatumColor">
+        <property name="toolTip">
+         <string>The color of the datum portion of a driving constraint</string>
+        </property>
+        <property name="color" stdset="0">
+         <color>
+          <red>255</red>
+          <green>38</green>
+          <blue>0</blue>
+         </color>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>ConstrainedDimColor</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>View</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="10" column="0">
+       <widget class="QLabel" name="label_16">
+        <property name="minimumSize">
+         <size>
+          <width>182</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>Datum text size</string>
+        </property>
+       </widget>
+      </item>
+      <item row="10" column="1">
+       <widget class="Gui::PrefSpinBox" name="SketcherDatumWidth">
+        <property name="toolTip">
+         <string>The default line thickness for new shapes</string>
+        </property>
+        <property name="suffix">
+         <string>px</string>
+        </property>
+        <property name="maximum">
+         <number>9</number>
+        </property>
+        <property name="value">
+         <number>2</number>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>DefaultSketcherVertexWidth</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>View</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="11" column="0">
+       <widget class="QLabel" name="label_12">
+        <property name="minimumSize">
+         <size>
+          <width>182</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>Default vertex size</string>
+        </property>
+       </widget>
+      </item>
+      <item row="11" column="1">
+       <widget class="Gui::PrefSpinBox" name="DefaultSketcherVertexWidth">
+        <property name="toolTip">
+         <string>The default line thickness for new shapes</string>
+        </property>
+        <property name="suffix">
+         <string>px</string>
+        </property>
+        <property name="maximum">
+         <number>9</number>
+        </property>
+        <property name="value">
+         <number>2</number>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>DefaultSketcherVertexWidth</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>View</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="12" column="0">
+       <widget class="QLabel" name="label_13">
+        <property name="minimumSize">
+         <size>
+          <width>182</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>Default line width</string>
+        </property>
+       </widget>
+      </item>
+      <item row="12" column="1">
+       <widget class="Gui::PrefSpinBox" name="DefaultSketcherLineWidth">
+        <property name="toolTip">
+         <string>The default line thickness for new shapes</string>
+        </property>
+        <property name="suffix">
+         <string>px</string>
+        </property>
+        <property name="maximum">
+         <number>9</number>
+        </property>
+        <property name="value">
+         <number>2</number>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>DefaultShapeLineWidth</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>View</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="13" column="0">
+       <widget class="QLabel" name="label_5">
+        <property name="minimumSize">
+         <size>
+          <width>182</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>Cursor text color</string>
+        </property>
+       </widget>
+      </item>
+      <item row="13" column="1">
+       <widget class="Gui::PrefColorButton" name="CursorTextColor">
+        <property name="color" stdset="0">
+         <color>
+          <red>0</red>
+          <green>0</green>
+          <blue>255</blue>
+         </color>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>CursorTextColor</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>View</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="14" column="0">
+       <widget class="QLabel" name="label_6">
+        <property name="minimumSize">
+         <size>
+          <width>182</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>Create crosshair color</string>
+        </property>
+       </widget>
+      </item>
+      <item row="14" column="1">
+       <widget class="Gui::PrefColorButton" name="CreateCrosshairColor">
+        <property name="color" stdset="0">
+         <color>
+          <red>255</red>
+          <green>255</green>
+          <blue>255</blue>
+         </color>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>CreateCrosshairColor</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>View</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="15" column="0">
+       <widget class="QLabel" name="label_7">
+        <property name="minimumSize">
+         <size>
+          <width>182</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>Create line color</string>
+        </property>
+       </widget>
+      </item>
+      <item row="15" column="1">
+       <widget class="Gui::PrefColorButton" name="CreateLineColor">
+        <property name="color" stdset="0">
+         <color>
+          <red>204</red>
+          <green>204</green>
+          <blue>204</blue>
+         </color>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>CreateLineColor</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>View</cstring>
+        </property>
+       </widget>
       </item>
      </layout>
     </widget>

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -145,6 +145,7 @@ SbColor ViewProviderSketch::InformationColor            (0.0f,1.0f,0.0f);     //
 SbColor ViewProviderSketch::PreselectColor              (0.88f,0.88f,0.0f);   // #E1E100 -> (225,225,  0)
 SbColor ViewProviderSketch::SelectColor                 (0.11f,0.68f,0.11f);  // #1CAD1C -> ( 28,173, 28)
 SbColor ViewProviderSketch::PreselectSelectedColor      (0.36f,0.48f,0.11f);  // #5D7B1C -> ( 93,123, 28)
+SbColor ViewProviderSketch::CreateCurveColor            (0.8f,0.8f,0.8f);     // #CCCCCC -> (204,204,204)
 // Variables for holding previous click
 SbTime  ViewProviderSketch::prvClickTime;
 SbVec2s ViewProviderSketch::prvClickPos;
@@ -5019,12 +5020,19 @@ void ViewProviderSketch::drawEdit(const std::vector<Base::Vector2d> &EditCurve)
 
     edit->EditCurveSet->numVertices.setNum(1);
     edit->EditCurvesCoordinate->point.setNum(EditCurve.size());
+    edit->EditCurvesMaterials->diffuseColor.setNum(EditCurve.size());
     SbVec3f *verts = edit->EditCurvesCoordinate->point.startEditing();
     int32_t *index = edit->EditCurveSet->numVertices.startEditing();
+    SbColor *color = edit->EditCurvesMaterials->diffuseColor.startEditing();
 
     int i=0; // setting up the line set
-    for (std::vector<Base::Vector2d>::const_iterator it = EditCurve.begin(); it != EditCurve.end(); ++it,i++)
+    for (std::vector<Base::Vector2d>::const_iterator it = EditCurve.begin();
+	 it != EditCurve.end();
+	 ++it,i++)
+    {
         verts[i].setValue(it->x,it->y,zEdit);
+	color[i] = CreateCurveColor;
+    }
 
     index[0] = EditCurve.size();
     edit->EditCurvesCoordinate->point.finishEditing();
@@ -5180,6 +5188,10 @@ bool ViewProviderSketch::setEdit(int ModNum)
     color = (unsigned long)(CurveColor.getPackedValue());
     color = hGrp->GetUnsigned("EditedEdgeColor", color);
     CurveColor.setPackedValue((uint32_t)color, transparency);
+    // set the create line (curve) color
+    color = (unsigned long)(CreateCurveColor.getPackedValue());
+    color = hGrp->GetUnsigned("CreateLineColor", color);
+    CreateCurveColor.setPackedValue((uint32_t)color, transparency);
     // set the construction curve color
     color = (unsigned long)(CurveDraftColor.getPackedValue());
     color = hGrp->GetUnsigned("ConstructionColor", color);

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.h
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.h
@@ -364,6 +364,7 @@ protected:
     // colors
     static SbColor VertexColor;
     static SbColor CurveColor;
+    static SbColor CreateCurveColor;
     static SbColor CurveDraftColor;
     static SbColor CurveExternalColor;
     static SbColor CrossColorV;


### PR DESCRIPTION
Create geometry commands in sketcher now have configurable crosshair color
and editCurve color.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR once it is merged.

---
