### PR TITLE
Adding a 20mm border for A4 landscape template

### DIFF
--- a/src/Mod/TechDraw/Templates/A4_Landscape_ISO7200TD.svg
+++ b/src/Mod/TechDraw/Templates/A4_Landscape_ISO7200TD.svg
@@ -13,9 +13,9 @@
 			id="drawing-border"
 			style="fill:none;stroke:#000000;stroke-width:0.35;stroke-linecap:miter;stroke-miterlimit:4"
 			width="277"
-			height="190"
+			height="180"
 			x="10"
-			y="10" />
+			y="20" />
 			<!-- width-20, height-20 -->
 		<g
 			transform="translate(87,-65)">


### PR DESCRIPTION
A4 Landscape is a special template, as it is new in the standard.
We orient us on the A4 portrait template, where the border is on the
left side (e.g. long side). Thus it should be on top for the
landscape template.

See also forum discussion: https://forum.freecadweb.org/viewtopic.php?f=35&t=25256