### PR TITLE
TechDraw - fix Page position when Template size changes

### DIFF
--- a/src/Mod/TechDraw/Gui/MDIViewPage.cpp
+++ b/src/Mod/TechDraw/Gui/MDIViewPage.cpp
@@ -178,12 +178,8 @@ MDIViewPage::MDIViewPage(ViewProviderPage *pageVp, Gui::Document* doc, QWidget* 
     App::DocumentObject *obj = m_vpPage->getDrawPage()->Template.getValue();
     auto pageTemplate( dynamic_cast<TechDraw::DrawTemplate *>(obj) );
     if( pageTemplate ) {
-        //make sceneRect 1 pagesize bigger in every direction
-        double width  =  Rez::guiX(pageTemplate->Width.getValue());
-        double height =  Rez::guiX(pageTemplate->Height.getValue());
-        m_view->scene()->setSceneRect(QRectF(-width,-2.0 * height,3.0*width,3.0*height));
         attachTemplate(pageTemplate);
-        viewAll();
+        matchSceneRectToTemplate();
     }
 }
 
@@ -193,6 +189,18 @@ MDIViewPage::~MDIViewPage()
     connectDeletedObject.disconnect();
 }
 
+void MDIViewPage::matchSceneRectToTemplate(void)
+{
+    App::DocumentObject *obj = m_vpPage->getDrawPage()->Template.getValue();
+    auto pageTemplate( dynamic_cast<TechDraw::DrawTemplate *>(obj) );
+    if( pageTemplate ) {
+        //make sceneRect 1 pagesize bigger in every direction
+        double width  =  Rez::guiX(pageTemplate->Width.getValue());
+        double height =  Rez::guiX(pageTemplate->Height.getValue());
+        m_view->scene()->setSceneRect(QRectF(-width,-2.0 * height,3.0*width,3.0*height));
+        viewAll();
+    }
+}
 
 void MDIViewPage::setDimensionGroups(void)
 {

--- a/src/Mod/TechDraw/Gui/MDIViewPage.h
+++ b/src/Mod/TechDraw/Gui/MDIViewPage.h
@@ -65,6 +65,7 @@ public:
     void attachTemplate(TechDraw::DrawTemplate *obj);
     void updateTemplate(bool force = false);
     void updateDrawing(bool force = false);
+    void matchSceneRectToTemplate(void);
     
     bool onMsg(const char* pMsg,const char** ppReturn);
     bool onHasMsg(const char* pMsg) const;

--- a/src/Mod/TechDraw/Gui/ViewProviderPage.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderPage.cpp
@@ -153,6 +153,7 @@ void ViewProviderPage::updateData(const App::Property* prop)
     } else if (prop == &(getDrawPage()->Template)) {
        if(m_mdiView && 
           !getDrawPage()->isUnsetting()) {
+            m_mdiView->matchSceneRectToTemplate();
             m_mdiView->updateTemplate();
         }
     }


### PR DESCRIPTION
This PR fixes an issue in TechDraw where the Page is not redrawn correctly when the Template size is changed to a much larger one (ex A4 -> A0).  Please merge. 

Thanks,
wf

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR once it is merged.

---
