### PR TITLE
fix run-test failing due to locale

### DIFF
--- a/src/Mod/Path/PathTests/PathTestUtils.py
+++ b/src/Mod/Path/PathTests/PathTestUtils.py
@@ -127,3 +127,8 @@ class PathTestBase(unittest.TestCase):
         self.assertRoughly(c1.Parameters.get('I', 0), c2.Parameters.get('I', 0))
         self.assertRoughly(c1.Parameters.get('J', 0), c2.Parameters.get('J', 0))
         self.assertRoughly(c1.Parameters.get('K', 0), c2.Parameters.get('K', 0))
+
+    def assertEqualLocale(self,s1,s2):
+        """Verify that the 2 strings are equivalent, but converts eventual , into . for the first string that may be affected by locale."""
+        self.assertEqual(s1.replace(",","."), s2)
+		

--- a/src/Mod/Path/PathTests/TestPathSetupSheet.py
+++ b/src/Mod/Path/PathTests/TestPathSetupSheet.py
@@ -53,11 +53,11 @@ class TestPathSetupSheet(PathTestBase):
 
         attrs = ss.templateAttributes(True, True)
 
-        self.assertEqual(attrs[PathSetupSheet.Template.HorizRapid], '0.00 mm/s')
-        self.assertEqual(attrs[PathSetupSheet.Template.VertRapid], '0.00 mm/s')
-        self.assertEqual(attrs[PathSetupSheet.Template.SafeHeightOffset], '3.00 mm')
+        self.assertEqualLocale(attrs[PathSetupSheet.Template.HorizRapid], '0.00 mm/s')
+        self.assertEqualLocale(attrs[PathSetupSheet.Template.VertRapid], '0.00 mm/s')
+        self.assertEqualLocale(attrs[PathSetupSheet.Template.SafeHeightOffset], '3.00 mm')
         self.assertEqual(attrs[PathSetupSheet.Template.SafeHeightExpression], 'StartDepth+SetupSheet.SafeHeightOffset')
-        self.assertEqual(attrs[PathSetupSheet.Template.ClearanceHeightOffset], '5.00 mm')
+        self.assertEqualLocale(attrs[PathSetupSheet.Template.ClearanceHeightOffset], '5.00 mm')
         self.assertEqual(attrs[PathSetupSheet.Template.ClearanceHeightExpression], 'StartDepth+SetupSheet.ClearanceHeightOffset')
 
     def test01(self):


### PR DESCRIPTION
Very minor problem. Test of sheets is impacted by the locale. The decimal separator may be , instead of .

An assertEqualLocale function has been added to replace , by . in the values impacted by the locale with before comparison with the expected string containing a . as decimal separator.

Works fine

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR once it is merged.

---
