### PR TITLE
Path: Allow removing of all base objects in Circular hole tools

### DIFF
--- a/src/Mod/Path/PathScripts/PathCircularHoleBase.py
+++ b/src/Mod/Path/PathScripts/PathCircularHoleBase.py
@@ -39,15 +39,18 @@ __author__ = "sliptonic (Brad Collette)"
 __url__ = "http://www.freecadweb.org"
 __doc__ = "Base class an implementation for operations on circular holes."
 
+
 # Qt tanslation handling
 def translate(context, text, disambig=None):
     return QtCore.QCoreApplication.translate(context, text, disambig)
+
 
 if False:
     PathLog.setLevel(PathLog.Level.DEBUG, PathLog.thisModule())
     PathLog.trackModule(PathLog.thisModule())
 else:
     PathLog.setLevel(PathLog.Level.INFO, PathLog.thisModule())
+
 
 class ObjectOp(PathOp.ObjectOp):
     '''Base class for proxy objects of all operations on circular holes.'''
@@ -155,23 +158,7 @@ class ObjectOp(PathOp.ObjectOp):
                 return len(obj.Locations) != 0
             return False
 
-        if len(obj.Base) == 0 and not haveLocations(self, obj):
-            features = []
-            if self.baseIsArchPanel(obj, self.baseobject):
-                holeshapes = self.baseobject.Proxy.getHoles(self.baseobject, transform=True)
-                tooldiameter = obj.ToolController.Proxy.getTool(obj.ToolController).Diameter
-                for holeNr, hole in enumerate(holeshapes):
-                    PathLog.debug('Entering new HoleShape')
-                    for wireNr, wire in enumerate(hole.Wires):
-                        PathLog.debug('Entering new Wire')
-                        for edgeNr, edge in enumerate(wire.Edges):
-                            if PathUtils.isDrillable(self.baseobject, edge, tooldiameter):
-                                PathLog.debug('Found drillable hole edges: {}'.format(edge))
-                                features.append((self.baseobject, "%d.%d.%d" % (holeNr, wireNr, edgeNr)))
-            else:
-                features = self.findHoles(obj, self.baseobject)
-            obj.Base = features
-            obj.Disabled = []
+        # if len(obj.Base) == 0 and not haveLocations(self, obj):
 
         holes = []
 
@@ -194,6 +181,24 @@ class ObjectOp(PathOp.ObjectOp):
         Note that for Vertexes, non-circular Edges and Locations r=0.
         Must be overwritten by subclasses.'''
         pass
+
+    def findAllHoles(self, obj):
+        features = []
+        if self.baseIsArchPanel(obj, self.baseobject):
+            holeshapes = self.baseobject.Proxy.getHoles(self.baseobject, transform=True)
+            tooldiameter = obj.ToolController.Proxy.getTool(obj.ToolController).Diameter
+            for holeNr, hole in enumerate(holeshapes):
+                PathLog.debug('Entering new HoleShape')
+                for wireNr, wire in enumerate(hole.Wires):
+                    PathLog.debug('Entering new Wire')
+                    for edgeNr, edge in enumerate(wire.Edges):
+                        if PathUtils.isDrillable(self.baseobject, edge, tooldiameter):
+                            PathLog.debug('Found drillable hole edges: {}'.format(edge))
+                            features.append((self.baseobject, "%d.%d.%d" % (holeNr, wireNr, edgeNr)))
+        else:
+            features = self.findHoles(obj, self.baseobject)
+        obj.Base = features
+        obj.Disabled = []
 
     def findHoles(self, obj, baseobject):
         '''findHoles(obj, baseobject) ... inspect baseobject and identify all features that resemble a straight cricular hole.'''

--- a/src/Mod/Path/PathScripts/PathCircularHoleBaseGui.py
+++ b/src/Mod/Path/PathScripts/PathCircularHoleBaseGui.py
@@ -165,6 +165,7 @@ class TaskPanelHoleGeometryPage(PathOpGui.TaskPanelBaseGeometryPage):
         '''resetBase() ... push button callback'''
         self.obj.Base = []
         self.obj.Disabled = []
+        self.obj.Proxy.findAllHoles(self.obj)
 
         self.obj.Proxy.execute(self.obj)
         FreeCAD.ActiveDocument.recompute()
@@ -180,4 +181,3 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
     def taskPanelBaseGeometryPage(self, obj, features):
         '''taskPanelBaseGeometryPage(obj, features) ... Return circular hole specific page controller for Base Geometry.'''
         return TaskPanelHoleGeometryPage(obj, features)
-

--- a/src/Mod/Path/PathScripts/PathDrilling.py
+++ b/src/Mod/Path/PathScripts/PathDrilling.py
@@ -124,4 +124,5 @@ def Create(name):
     '''Create(name) ... Creates and returns a Drilling operation.'''
     obj = FreeCAD.ActiveDocument.addObject("Path::FeaturePython", name)
     proxy = ObjectDrilling(obj)
+    proxy.findAllHoles(obj)
     return obj

--- a/src/Mod/Path/PathScripts/PathHelix.py
+++ b/src/Mod/Path/PathScripts/PathHelix.py
@@ -45,7 +45,7 @@ class ObjectHelix(PathCircularHoleBase.ObjectOp):
 
     def circularHoleFeatures(self, obj):
         '''circularHoleFeatures(obj) ... enable features supported by Helix.'''
-        return PathOp.FeatureStepDown | PathOp.FeatureBaseEdges | PathOp.FeatureBaseFaces | PathOp.FeatureBasePanels 
+        return PathOp.FeatureStepDown | PathOp.FeatureBaseEdges | PathOp.FeatureBaseFaces | PathOp.FeatureBasePanels
 
     def initCircularHoleOperation(self, obj):
         '''initCircularHoleOperation(obj) ... create helix specific properties.'''
@@ -197,4 +197,5 @@ def Create(name):
     '''Create(name) ... Creates and returns a Helix operation.'''
     obj = FreeCAD.ActiveDocument.addObject("Path::FeaturePython", name)
     proxy = ObjectHelix(obj)
+    proxy.findAllHoles(obj)
     return obj


### PR DESCRIPTION
It was impossible to remove all drilling features from the list of base objects, as the empty list invoked the automatic search of the drillable holes. Now the automatic search is called only when the operation is created or "Reset" -button is pressed.

Forum thread: https://forum.freecadweb.org/viewtopic.php?f=15&t=24881&start=10

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR once it is merged.

---
