### PR TITLE
User-facing typo fixes

### DIFF
--- a/src/Gui/Command.cpp
+++ b/src/Gui/Command.cpp
@@ -84,7 +84,7 @@ using namespace Gui::DockWnd;
  *
  * \section wayout Way out
  * To solve these problems we have introduced the command framework to decouple QAction and MainWindow. The base classes of the framework are
- * \a Gui::CommandBase and \a Gui::Action that represent the link between Qt's QAction world and the FreeCAD's command  world. 
+ * \a Gui::CommandBase and \a Gui::Action that represent the link between Qt's QAction world and the FreeCAD's command world. 
  *
  * The Action class holds a pointer to QAction and CommandBase and acts as a mediator and -- to save memory -- that gets created 
  * (@ref Gui::CommandBase::createAction()) not before it is added (@ref Gui::Command::addTo()) to a menu or toolbar.

--- a/src/Gui/CommandView.cpp
+++ b/src/Gui/CommandView.cpp
@@ -1865,9 +1865,9 @@ StdCmdViewCreate::StdCmdViewCreate()
 {
     sGroup      = QT_TR_NOOP("Standard-View");
     sMenuText   = QT_TR_NOOP("Create new view");
-    sToolTipText= QT_TR_NOOP("Creates a new  view window for the active document");
+    sToolTipText= QT_TR_NOOP("Creates a new view window for the active document");
     sWhatsThis  = "Std_ViewCreate";
-    sStatusTip  = QT_TR_NOOP("Creates a new  view window for the active document");
+    sStatusTip  = QT_TR_NOOP("Creates a new view window for the active document");
     sPixmap     = "window-new";
     eType         = Alter3DView;
 }

--- a/src/Main/MainCmd.cpp
+++ b/src/Main/MainCmd.cpp
@@ -97,7 +97,7 @@ int main( int argc, char ** argv )
     catch (const Base::Exception& e) {
         std::string appName = App::Application::Config()["ExeName"];
         std::stringstream msg;
-        msg << "While initializing " << appName << " the  following exception occurred: '" << e.what() << "'\n\n";
+        msg << "While initializing " << appName << " the following exception occurred: '" << e.what() << "'\n\n";
         msg << "Python is searching for its runtime files in the following directories:\n" << Py_GetPath() << "\n\n";
         msg << "Python version information:\n" << Py_GetVersion() << "\n";
         const char* pythonhome = getenv("PYTHONHOME");

--- a/src/Main/MainGui.cpp
+++ b/src/Main/MainGui.cpp
@@ -202,7 +202,7 @@ int main( int argc, char ** argv )
         QApplication app(argc,argv);
         QString appName = QString::fromLatin1(App::Application::Config()["ExeName"].c_str());
         QString msg;
-        msg = QObject::tr("While initializing %1 the  following exception occurred: '%2'\n\n"
+        msg = QObject::tr("While initializing %1 the following exception occurred: '%2'\n\n"
                           "Python is searching for its files in the following directories:\n%3\n\n"
                           "Python version information:\n%4\n")
                           .arg(appName).arg(QString::fromUtf8(e.what()))

--- a/src/Main/MainPy.cpp
+++ b/src/Main/MainPy.cpp
@@ -215,7 +215,7 @@ PyMOD_INIT_FUNC(FreeCAD)
     catch (const Base::Exception& e) {
         std::string appName = App::Application::Config()["ExeName"];
         std::stringstream msg;
-        msg << "While initializing " << appName << " the  following exception occurred: '"
+        msg << "While initializing " << appName << " the following exception occurred: '"
             << e.what() << "'\n\n";
         msg << "\nPlease contact the application's support team for more information.\n\n";
         printf("Initialization of %s failed:\n%s", appName.c_str(), msg.str().c_str());

--- a/src/Mod/Cam/App/best_fit.h
+++ b/src/Mod/Cam/App/best_fit.h
@@ -59,7 +59,7 @@ public:
     /*! \brief Load the input-shapes. Must be called before running the main program
 
         \param InputMesh Input-mesh
-        \param CAD_Shape  Input-shape
+        \param CAD_Shape Input-shape
     */
     void Load(const MeshCore::MeshKernel &InputMesh, const TopoDS_Shape &CAD_Shape);
 

--- a/src/Mod/Drawing/Gui/DrawingView.cpp
+++ b/src/Mod/Drawing/Gui/DrawingView.cpp
@@ -567,7 +567,7 @@ void DrawingView::print(QPrinter* printer)
 
         if (doPrint && printer->orientation() != this->m_orientation) {
             int ret = QMessageBox::warning(this, tr("Different orientation"),
-                tr("The printer uses a different orientation  than the drawing.\n"
+                tr("The printer uses a different orientation than the drawing.\n"
                    "Do you want to continue?"),
                    QMessageBox::Yes | QMessageBox::No);
             if (ret != QMessageBox::Yes)


### PR DESCRIPTION
All user-facing strings that have double (consecutive) whitespace e.g. `\b  \b` (regex) have been removed. Inspired by the error message in https://forum.freecadweb.org/viewtopic.php?f=3&t=5899&p=200309#p200309