### PR TITLE
Comment set name of combiview tab 2

### DIFF
--- a/src/Gui/CombiView.cpp
+++ b/src/Gui/CombiView.cpp
@@ -126,7 +126,7 @@ void CombiView::changeEvent(QEvent *e)
     if (e->type() == QEvent::LanguageChange) {
         tabs->setTabText(0, trUtf8("Model"));
         tabs->setTabText(1, trUtf8("Tasks"));
-        tabs->setTabText(2, trUtf8("Project"));
+        //tabs->setTabText(2, trUtf8("Project"));
     }
 
     DockWindow::changeEvent(e);


### PR DESCRIPTION
Comment set name of combiview tab 2 

--> if some one adds a new tab this will always be overwritten by "Project" 
--> in line 83 the project widget is comment. So i think line 129 should also be comment

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ x] Branch rebased on latest master `git pull --rebase upstream master`
- [x ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR once it is merged.

---
