### PR TITLE
Minor property editor UI fixes

### DIFF
--- a/src/Gui/propertyeditor/PropertyEditor.cpp
+++ b/src/Gui/propertyeditor/PropertyEditor.cpp
@@ -203,6 +203,10 @@ void PropertyEditor::setEditorMode(const QModelIndex & parent, int start, int en
         if (propItem && propItem->testStatus(App::Property::Hidden)) {
             setRowHidden (i, parent, true);
         }
+        if (propItem && propItem->isSeparator()) {
+            // Set group header rows to span all columns
+            setFirstColumnSpanned(i, parent, true);
+        }
     }
 }
 

--- a/src/Gui/propertyeditor/PropertyItemDelegate.cpp
+++ b/src/Gui/propertyeditor/PropertyItemDelegate.cpp
@@ -122,6 +122,8 @@ QWidget * PropertyItemDelegate::createEditor (QWidget * parent, const QStyleOpti
     if (!childItem)
         return 0;
     QWidget* editor = childItem->createEditor(parent, this, SLOT(valueChanged()));
+    if (editor) // Make sure the editor background is painted so the cell content doesn't show through
+        editor->setAutoFillBackground(true);
     if (editor && childItem->isReadOnly())
         editor->setDisabled(true);
     else if (editor && this->pressed)


### PR DESCRIPTION
A couple of minor tidy ups in the property editor UI:
 - Span property group headers across all cells to avoid text truncation
 - Render the background of property value editor widgets to avoid cell contents showing through the editor (at least in linux/kde dropboxes show the cell contents through the dropbox background)

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [x] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR once it is merged.

---
