### PR TITLE
Typos: user-facing and trivial

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -558,8 +558,8 @@ Version: V0.1B117 Date: Sun Mar 20 14:06:55 2005 +++++++++++++++++++++++++++++++
   * Integration of latest Image module source
   * RFE 1159671 implemented (elements in alphabetic order)
   * Finishing drag&drop multiple files
-  * Finishing open from command line and droping on Programm icon
-  * solving load dependand modules
+  * Finishing open from command line and dropping on Program icon
+  * solving load dependent modules
   * more convenient Python console
   * Bug 1149706 fixed (Cannot load CAD curves)
   * RFE 1214187 implemented (Remove views from main window)

--- a/src/App/PropertyLinks.cpp
+++ b/src/App/PropertyLinks.cpp
@@ -74,7 +74,7 @@ PropertyLink::~PropertyLink()
     if (_pcLink && getContainer() && getContainer()->isDerivedFrom(App::DocumentObject::getClassTypeId())) {
         App::DocumentObject* parent = static_cast<DocumentObject*>(getContainer());
         // before accessing internals make sure the object is not about to be destroyed
-        // as otherwise the backlink contains dangling pointers
+        // otherwise the backlink contains dangling pointers
         if (!parent->testStatus(ObjectStatus::Destroy)) {
             if (_pcLink)
                 _pcLink->_removeBackLink(parent);
@@ -95,7 +95,7 @@ void PropertyLink::setValue(App::DocumentObject * lValue)
     if (getContainer() && getContainer()->isDerivedFrom(App::DocumentObject::getClassTypeId())) {
         App::DocumentObject* parent = static_cast<DocumentObject*>(getContainer());
         // before accessing internals make sure the object is not about to be destroyed
-        // as otherwise the backlink contains dangling pointers
+        // otherwise the backlink contains dangling pointers
         if (!parent->testStatus(ObjectStatus::Destroy)) {
             if (_pcLink)
                 _pcLink->_removeBackLink(parent);
@@ -222,7 +222,7 @@ PropertyLinkList::~PropertyLinkList()
     if (!_lValueList.empty() && getContainer() && getContainer()->isDerivedFrom(App::DocumentObject::getClassTypeId())) {
         App::DocumentObject* parent = static_cast<DocumentObject*>(getContainer());
         // before accessing internals make sure the object is not about to be destroyed
-        // as otherwise the backlink contains dangling pointers
+        // otherwise the backlink contains dangling pointers
         if (!parent->testStatus(ObjectStatus::Destroy)) {
             for(auto *obj : _lValueList)
                 obj->_removeBackLink(parent);
@@ -249,7 +249,7 @@ void PropertyLinkList::setValue(DocumentObject* lValue)
     if (getContainer() && getContainer()->isDerivedFrom(App::DocumentObject::getClassTypeId())) {
         App::DocumentObject* parent = static_cast<DocumentObject*>(getContainer());
         // before accessing internals make sure the object is not about to be destroyed
-        // as otherwise the backlink contains dangling pointers
+        // otherwise the backlink contains dangling pointers
         if (!parent->testStatus(ObjectStatus::Destroy)) {
             for(auto *obj : _lValueList)
                 obj->_removeBackLink(parent);
@@ -280,7 +280,7 @@ void PropertyLinkList::setValues(const std::vector<DocumentObject*>& lValue)
     if (getContainer() && getContainer()->isDerivedFrom(App::DocumentObject::getClassTypeId())) {
         App::DocumentObject* parent = static_cast<DocumentObject*>(getContainer());
         // before accessing internals make sure the object is not about to be destroyed
-        // as otherwise the backlink contains dangling pointers
+        // otherwise the backlink contains dangling pointers
         if (!parent->testStatus(ObjectStatus::Destroy)) {
             for(auto *obj : _lValueList)
                 obj->_removeBackLink(parent);
@@ -440,7 +440,7 @@ PropertyLinkSub::~PropertyLinkSub()
     if (_pcLinkSub && getContainer() && getContainer()->isDerivedFrom(App::DocumentObject::getClassTypeId())) {
         App::DocumentObject* parent = static_cast<DocumentObject*>(getContainer());
         // before accessing internals make sure the object is not about to be destroyed
-        // as otherwise the backlink contains dangling pointers
+        // otherwise the backlink contains dangling pointers
         if (!parent->testStatus(ObjectStatus::Destroy)) {
             if (_pcLinkSub)
                 _pcLinkSub->_removeBackLink(parent);
@@ -459,7 +459,7 @@ void PropertyLinkSub::setValue(App::DocumentObject * lValue, const std::vector<s
     if (getContainer() && getContainer()->isDerivedFrom(App::DocumentObject::getClassTypeId())) {
         App::DocumentObject* parent = static_cast<DocumentObject*>(getContainer());
         // before accessing internals make sure the object is not about to be destroyed
-        // as otherwise the backlink contains dangling pointers
+        // otherwise the backlink contains dangling pointers
         if (!parent->testStatus(ObjectStatus::Destroy)) {
             if (_pcLinkSub)
                 _pcLinkSub->_removeBackLink(parent);
@@ -649,7 +649,7 @@ PropertyLinkSubList::~PropertyLinkSubList()
     if (!_lValueList.empty() && getContainer() && getContainer()->isDerivedFrom(App::DocumentObject::getClassTypeId())) {
         App::DocumentObject* parent = static_cast<DocumentObject*>(getContainer());
         // before accessing internals make sure the object is not about to be destroyed
-        // as otherwise the backlink contains dangling pointers
+        // otherwise the backlink contains dangling pointers
         if (!parent->testStatus(ObjectStatus::Destroy)) {
             for(auto *obj : _lValueList)
                 obj->_removeBackLink(parent);
@@ -676,7 +676,7 @@ void PropertyLinkSubList::setValue(DocumentObject* lValue,const char* SubName)
     if (getContainer() && getContainer()->isDerivedFrom(App::DocumentObject::getClassTypeId())) {
         App::DocumentObject* parent = static_cast<DocumentObject*>(getContainer());
         // before accessing internals make sure the object is not about to be destroyed
-        // as otherwise the backlink contains dangling pointers
+        // otherwise the backlink contains dangling pointers
         if (!parent->testStatus(ObjectStatus::Destroy)) {
             for(auto *obj : _lValueList)
                 obj->_removeBackLink(parent);
@@ -712,7 +712,7 @@ void PropertyLinkSubList::setValues(const std::vector<DocumentObject*>& lValue,c
     if (getContainer() && getContainer()->isDerivedFrom(App::DocumentObject::getClassTypeId())) {
         App::DocumentObject* parent = static_cast<DocumentObject*>(getContainer());
         // before accessing internals make sure the object is not about to be destroyed
-        // as otherwise the backlink contains dangling pointers
+        // otherwise the backlink contains dangling pointers
         if (!parent->testStatus(ObjectStatus::Destroy)) {
             //_lValueList can contain items multiple times, but we trust the document
             //object to ensure that this works
@@ -746,7 +746,7 @@ void PropertyLinkSubList::setValues(const std::vector<DocumentObject*>& lValue,c
     if (getContainer() && getContainer()->isDerivedFrom(App::DocumentObject::getClassTypeId())) {
         App::DocumentObject* parent = static_cast<DocumentObject*>(getContainer());
         // before accessing internals make sure the object is not about to be destroyed
-        // as otherwise the backlink contains dangling pointers
+        // otherwise the backlink contains dangling pointers
         if (!parent->testStatus(ObjectStatus::Destroy)) {
             //_lValueList can contain items multiple times, but we trust the document
             //object to ensure that this works
@@ -774,7 +774,7 @@ void PropertyLinkSubList::setValue(DocumentObject* lValue, const std::vector<str
     if (getContainer() && getContainer()->isDerivedFrom(App::DocumentObject::getClassTypeId())) {
         App::DocumentObject* parent = static_cast<DocumentObject*>(getContainer());
         // before accessing internals make sure the object is not about to be destroyed
-        // as otherwise the backlink contains dangling pointers
+        // otherwise the backlink contains dangling pointers
         if (!parent->testStatus(ObjectStatus::Destroy)) {
             //_lValueList can contain items multiple times, but we trust the document
             //object to ensure that this works

--- a/src/Gui/CommandDoc.cpp
+++ b/src/Gui/CommandDoc.cpp
@@ -81,7 +81,7 @@ DEF_STD_CMD(StdCmdOpen);
 StdCmdOpen::StdCmdOpen()
   : Command("Std_Open")
 {
-    // seting the
+    // setting the
     sGroup        = QT_TR_NOOP("File");
     sMenuText     = QT_TR_NOOP("&Open...");
     sToolTipText  = QT_TR_NOOP("Open a document or import files");
@@ -163,7 +163,7 @@ DEF_STD_CMD_A(StdCmdImport);
 StdCmdImport::StdCmdImport()
   : Command("Std_Import")
 {
-    // seting the
+    // setting the
     sGroup        = QT_TR_NOOP("File");
     sMenuText     = QT_TR_NOOP("&Import...");
     sToolTipText  = QT_TR_NOOP("Import a file in the active document");
@@ -249,7 +249,7 @@ DEF_STD_CMD_A(StdCmdExport);
 StdCmdExport::StdCmdExport()
   : Command("Std_Export")
 {
-    // seting the
+    // setting the
     sGroup        = QT_TR_NOOP("File");
     sMenuText     = QT_TR_NOOP("&Export...");
     sToolTipText  = QT_TR_NOOP("Export an object in the active document");
@@ -367,7 +367,7 @@ DEF_STD_CMD_A(StdCmdExportGraphviz);
 StdCmdExportGraphviz::StdCmdExportGraphviz()
   : Command("Std_ExportGraphviz")
 {
-    // seting the
+    // setting the
     sGroup        = QT_TR_NOOP("Tools");
     sMenuText     = QT_TR_NOOP("Dependency graph...");
     sToolTipText  = QT_TR_NOOP("Show the dependency graph of the objects in the active document");
@@ -577,7 +577,7 @@ DEF_STD_CMD_A(StdCmdProjectInfo);
 StdCmdProjectInfo::StdCmdProjectInfo()
   :Command("Std_ProjectInfo")
 {
-  // seting the
+  // setting the
   sGroup        = QT_TR_NOOP("File");
   sMenuText     = QT_TR_NOOP("Project i&nformation...");
   sToolTipText  = QT_TR_NOOP("Show details of the currently active project");
@@ -609,7 +609,7 @@ DEF_STD_CMD_A(StdCmdProjectUtil);
 StdCmdProjectUtil::StdCmdProjectUtil()
   :Command("Std_ProjectUtil")
 {
-    // seting the
+    // setting the
     sGroup        = QT_TR_NOOP("Tools");
     sWhatsThis    = "Std_ProjectUtil";
     sMenuText     = QT_TR_NOOP("Project utility...");

--- a/src/Gui/CommandFeat.cpp
+++ b/src/Gui/CommandFeat.cpp
@@ -45,7 +45,7 @@ DEF_STD_CMD(StdCmdFeatRecompute);
 StdCmdFeatRecompute::StdCmdFeatRecompute()
   :Command("Std_Recompute")
 {
-    // seting the
+    // setting the
     sGroup        = QT_TR_NOOP("File");
     sMenuText     = QT_TR_NOOP("&Recompute");
     sToolTipText  = QT_TR_NOOP("Recompute feature or document");

--- a/src/Gui/CommandView.cpp
+++ b/src/Gui/CommandView.cpp
@@ -2679,7 +2679,7 @@ DEF_3DV_CMD(StdCmdSceneInspector)
 StdCmdSceneInspector::StdCmdSceneInspector()
   : Command("Std_SceneInspector")
 {
-    // seting the
+    // setting the
     sGroup        = QT_TR_NOOP("Tools");
     sMenuText     = QT_TR_NOOP("Scene inspector...");
     sToolTipText  = QT_TR_NOOP("Scene inspector");
@@ -2711,7 +2711,7 @@ DEF_STD_CMD_A(StdCmdTextureMapping)
 StdCmdTextureMapping::StdCmdTextureMapping()
   : Command("Std_TextureMapping")
 {
-    // seting the
+    // setting the
     sGroup        = QT_TR_NOOP("Tools");
     sMenuText     = QT_TR_NOOP("Texture mapping...");
     sToolTipText  = QT_TR_NOOP("Texture mapping");

--- a/src/Gui/TaskView/TaskSelectLinkProperty.h
+++ b/src/Gui/TaskView/TaskSelectLinkProperty.h
@@ -66,16 +66,16 @@ public:
     /// set the filter criterion (same as in constructor)
     bool setFilter(const char*);
 
-    /// set the TaskSelectLinkProperty active, means seting the selection and controls it
+    /// set the TaskSelectLinkProperty active, means setting the selection and control it
     void activate(void);
 
-    /// call this to accept the changes the user have made and put back to the Propterty (Ok)
+    /// call this to accept the changes the user has made and send back to the Propterty (Ok)
     bool accept(void);
-    /// This discard the changes of the user and leaf the Property untouched (Cancel)
+    /// This discards the changes of the user and leaves the Property untouched (Cancel)
     bool reject(void);
     /// send the selection to the Property for e.g. forced recomputation of a feature
     void sendSelection2Property(void);
-    /// checkes if the filter is current met
+    /// checks if the filter is currently met
     inline bool isSelectionValid(void) const {return Filter->match();}
 
 private Q_SLOTS:
@@ -101,7 +101,7 @@ private:
     // selection filter for the session 
     Gui::SelectionFilter *Filter;
 
-    // posible used propetry types, only one is used
+    // possible used property types, only one is used
     App::PropertyLinkSub  *LinkSub;
     App::PropertyLinkList *LinkList;
 

--- a/src/Mod/Assembly/App/Solver/Solver.h
+++ b/src/Mod/Assembly/App/Solver/Solver.h
@@ -354,7 +354,7 @@ struct placement_accessor {
     template<typename T>
     void finalize(T& t) {
         //need to do it at once as setting every value step by step would always normalize the rotation and
-        //therefor give a false value
+        //therefore give a false value
         Base::Rotation rot(q0,q1,q2,q3);
         t.setRotation(rot);
         t.setPosition(vec);

--- a/src/Mod/Draft/Draft.py
+++ b/src/Mod/Draft/Draft.py
@@ -5226,7 +5226,7 @@ class _BezCurve(_DraftObject):
 
     def _segpoleslst(self,fp):
         """split the points into segments"""
-        if not fp.Closed and len(fp.Points) >= 2: #allow lower degree segement
+        if not fp.Closed and len(fp.Points) >= 2: #allow lower degree segment
             poles=fp.Points[1:]
         elif fp.Closed and len(fp.Points) >= fp.Degree: #drawable
             #poles=fp.Points[1:(fp.Degree*(len(fp.Points)//fp.Degree))]+fp.Points[0:1]

--- a/src/Mod/Drawing/Gui/Command.cpp
+++ b/src/Mod/Drawing/Gui/Command.cpp
@@ -432,7 +432,7 @@ DEF_STD_CMD_A(CmdDrawingOpenBrowserView);
 CmdDrawingOpenBrowserView::CmdDrawingOpenBrowserView()
   : Command("Drawing_OpenBrowserView")
 {
-    // seting the
+    // setting the
     sGroup        = QT_TR_NOOP("Drawing");
     sMenuText     = QT_TR_NOOP("Open &browser view");
     sToolTipText  = QT_TR_NOOP("Opens the selected page in a browser view");
@@ -470,7 +470,7 @@ DEF_STD_CMD_A(CmdDrawingAnnotation);
 CmdDrawingAnnotation::CmdDrawingAnnotation()
   : Command("Drawing_Annotation")
 {
-    // seting the
+    // setting the
     sGroup        = QT_TR_NOOP("Drawing");
     sMenuText     = QT_TR_NOOP("&Annotation");
     sToolTipText  = QT_TR_NOOP("Inserts an Annotation view in the active drawing");
@@ -518,7 +518,7 @@ DEF_STD_CMD_A(CmdDrawingClip);
 CmdDrawingClip::CmdDrawingClip()
   : Command("Drawing_Clip")
 {
-    // seting the
+    // setting the
     sGroup        = QT_TR_NOOP("Drawing");
     sMenuText     = QT_TR_NOOP("&Clip");
     sToolTipText  = QT_TR_NOOP("Inserts a clip group in the active drawing");
@@ -563,7 +563,7 @@ DEF_STD_CMD_A(CmdDrawingSymbol);
 CmdDrawingSymbol::CmdDrawingSymbol()
   : Command("Drawing_Symbol")
 {
-    // seting the
+    // setting the
     sGroup        = QT_TR_NOOP("Drawing");
     sMenuText     = QT_TR_NOOP("&Symbol");
     sToolTipText  = QT_TR_NOOP("Inserts a symbol from a svg file in the active drawing");
@@ -619,7 +619,7 @@ DEF_STD_CMD_A(CmdDrawingExportPage);
 CmdDrawingExportPage::CmdDrawingExportPage()
   : Command("Drawing_ExportPage")
 {
-    // seting the
+    // setting the
     sGroup        = QT_TR_NOOP("File");
     sMenuText     = QT_TR_NOOP("&Export page...");
     sToolTipText  = QT_TR_NOOP("Export a page to an SVG file");
@@ -671,7 +671,7 @@ DEF_STD_CMD_A(CmdDrawingProjectShape);
 CmdDrawingProjectShape::CmdDrawingProjectShape()
   : Command("Drawing_ProjectShape")
 {
-    // seting the
+    // setting the
     sGroup        = QT_TR_NOOP("Drawing");
     sMenuText     = QT_TR_NOOP("Project shape...");
     sToolTipText  = QT_TR_NOOP("Project shape onto a user-defined plane");
@@ -707,7 +707,7 @@ DEF_STD_CMD_A(CmdDrawingDraftView);
 CmdDrawingDraftView::CmdDrawingDraftView()
   : Command("Drawing_DraftView")
 {
-    // seting the
+    // setting the
     sGroup        = QT_TR_NOOP("Drawing");
     sMenuText     = QT_TR_NOOP("&Draft View");
     sToolTipText  = QT_TR_NOOP("Inserts a Draft view of the selected object(s) in the active drawing");
@@ -738,7 +738,7 @@ DEF_STD_CMD_A(CmdDrawingSpreadsheetView);
 CmdDrawingSpreadsheetView::CmdDrawingSpreadsheetView()
   : Command("Drawing_SpreadsheetView")
 {
-    // seting the
+    // setting the
     sGroup        = QT_TR_NOOP("Drawing");
     sMenuText     = QT_TR_NOOP("&Spreadsheet View");
     sToolTipText  = QT_TR_NOOP("Inserts a view of a selected spreadsheet in the active drawing");

--- a/src/Mod/Import/App/SCL/SimpleDataTypes.py
+++ b/src/Mod/Import/App/SCL/SimpleDataTypes.py
@@ -185,7 +185,7 @@ class BINARY(str):
         self._fixed = fixed
         # Check implicit width
         if (width!=-1) and not fixed:
-            raise ValueError("The 'width' parameter is passed but 'fixed' is still false. Please explicitely set 'fixed' to True to avoid implicit declaration")
+            raise ValueError("The 'width' parameter is passed but 'fixed' is still false. Please explicitly set 'fixed' to True to avoid implicit declaration")
         # First check the string length if 'fixed' is set to True
         if fixed:
             if len(value) != width:

--- a/src/Mod/Inspection/Gui/ViewProviderInspection.cpp
+++ b/src/Mod/Inspection/Gui/ViewProviderInspection.cpp
@@ -141,7 +141,7 @@ void ViewProviderInspection::show(void)
 
 void ViewProviderInspection::attach(App::DocumentObject *pcFeat)
 {
-    // creats the standard viewing modes
+    // creates the standard viewing modes
     inherited::attach(pcFeat);
 
     SoShapeHints * flathints = new SoShapeHints;

--- a/src/Mod/Mesh/Gui/ViewProviderCurvature.cpp
+++ b/src/Mod/Mesh/Gui/ViewProviderCurvature.cpp
@@ -242,7 +242,7 @@ void ViewProviderMeshCurvature::slotChangedObject(const App::DocumentObject& Obj
 
 void ViewProviderMeshCurvature::attach(App::DocumentObject *pcFeat)
 {
-    // creats the standard viewing modes
+    // creates the standard viewing modes
     inherited::attach(pcFeat);
     attachDocument(pcFeat->getDocument());
 

--- a/src/Mod/Mesh/Gui/ViewProviderTransform.cpp
+++ b/src/Mod/Mesh/Gui/ViewProviderTransform.cpp
@@ -68,7 +68,7 @@ ViewProviderMeshTransform::~ViewProviderMeshTransform()
 
 void ViewProviderMeshTransform::attach(App::DocumentObject *pcFeat)
 {
-  // creats the standard viewing modes
+  // creates the standard viewing modes
   ViewProviderMesh::attach(pcFeat);
 
   SoSeparator* pcEditRoot = new SoSeparator();

--- a/src/Mod/Mesh/Gui/ViewProviderTransformDemolding.cpp
+++ b/src/Mod/Mesh/Gui/ViewProviderTransformDemolding.cpp
@@ -76,7 +76,7 @@ ViewProviderMeshTransformDemolding::~ViewProviderMeshTransformDemolding()
 
 void ViewProviderMeshTransformDemolding::attach(App::DocumentObject *pcFeat)
 {
-  // creats the satandard viewing modes
+  // creates the standard viewing modes
   ViewProviderMesh::attach(pcFeat);
 
   SoGroup* pcDemoldRoot = new SoGroup();

--- a/src/Mod/Part/App/TopoShapePy.xml
+++ b/src/Mod/Part/App/TopoShapePy.xml
@@ -312,7 +312,7 @@ The underlying geometry of the following shapes may change:
 
 For example, a circle may be transformed into an ellipse when
 applying an affinity transformation. It may also happen that
-the circle then is represented as a b-spline curve.
+the circle then is represented as a B-spline curve.
 
 The transformation is applied to:
 - all the curves which support edges of the shape, and
@@ -514,7 +514,7 @@ makePerspectiveProjection(shape, pnt)
     </Methode>
     <Methode Name="makeShapeFromMesh">
       <Documentation>
-        <UserDocu>Make a compund shape out of mesh data.
+        <UserDocu>Make a compound shape out of mesh data.
 Note: This should be used for rather small meshes only.</UserDocu>
       </Documentation>
     </Methode>
@@ -522,8 +522,8 @@ Note: This should be used for rather small meshes only.</UserDocu>
       <Documentation>
         <UserDocu>Conversion of the complete geometry of a shape into NURBS geometry.
 For example, all curves supporting edges of the basis shape are converted
-into BSpline curves, and all surfaces supporting its faces are converted
-into BSpline surfaces.</UserDocu>
+into B-spline curves, and all surfaces supporting its faces are converted
+into B-spline surfaces.</UserDocu>
       </Documentation>
     </Methode>
     <Methode Name="copy" Const="true">
@@ -534,7 +534,7 @@ into BSpline surfaces.</UserDocu>
     <Methode Name="cleaned" Const="true">
       <Documentation>
         <UserDocu>This creates a cleaned copy of the shape with the triangulation removed.
-This can be useful to reduce file size when exporting as a BRep file.
+This can be useful to reduce file size when exporting as a BREP file.
 Warning: Use the cleaned shape with care because certain algorithms may work incorrectly
 if the shape has no internal triangulation any more.
 </UserDocu>
@@ -754,7 +754,7 @@ infos contains additional info on the solutions. It is a list of tuples:
     </Attribute>
     <Attribute Name="Compounds" ReadOnly="true">
       <Documentation>
-        <UserDocu>List of coumpounds in this shape.</UserDocu>
+        <UserDocu>List of compounds in this shape.</UserDocu>
       </Documentation>
       <Parameter Name="Compounds" Type="List"/>
     </Attribute>

--- a/src/Mod/PartDesign/App/FeatureLoft.cpp
+++ b/src/Mod/PartDesign/App/FeatureLoft.cpp
@@ -139,7 +139,7 @@ App::DocumentObjectExecReturn *Loft::execute(void)
 
             mkTS.Build();
             if (!mkTS.IsDone())
-                return new App::DocumentObjectExecReturn("Loft could not be build");
+                return new App::DocumentObjectExecReturn("Loft could not be built");
             
             //build the shell use simulate to get the top and bottom wires in an easy way
             shells.push_back(mkTS.Shape());

--- a/src/Mod/Raytracing/Gui/Command.cpp
+++ b/src/Mod/Raytracing/Gui/Command.cpp
@@ -491,7 +491,7 @@ DEF_STD_CMD_A(CmdRaytracingExportProject);
 CmdRaytracingExportProject::CmdRaytracingExportProject()
   : Command("Raytracing_ExportProject")
 {
-    // seting the
+    // setting the
     sAppModule    = "Raytracing";
     sGroup        = QT_TR_NOOP("File");
     sMenuText     = QT_TR_NOOP("&Export project...");
@@ -798,7 +798,7 @@ DEF_STD_CMD_A(CmdRaytracingResetCamera);
 CmdRaytracingResetCamera::CmdRaytracingResetCamera()
   : Command("Raytracing_ResetCamera")
 {
-    // seting the
+    // setting the
     sAppModule    = "Raytracing";
     sGroup        = QT_TR_NOOP("Raytracing");
     sMenuText     = QT_TR_NOOP("&Reset Camera");

--- a/src/Mod/TechDraw/Gui/Command.cpp
+++ b/src/Mod/TechDraw/Gui/Command.cpp
@@ -637,7 +637,7 @@ DEF_STD_CMD_A(CmdTechDrawClip);
 CmdTechDrawClip::CmdTechDrawClip()
   : Command("TechDraw_Clip")
 {
-    // seting the
+    // setting the
     sGroup        = QT_TR_NOOP("TechDraw");
     sMenuText     = QT_TR_NOOP("&Clip");
     sToolTipText  = QT_TR_NOOP("Inserts a clip group in the active drawing");
@@ -999,7 +999,7 @@ DEF_STD_CMD_A(CmdTechDrawSpreadsheet);
 CmdTechDrawSpreadsheet::CmdTechDrawSpreadsheet()
   : Command("TechDraw_Spreadsheet")
 {
-    // seting the
+    // setting the
     sGroup        = QT_TR_NOOP("TechDraw");
     sMenuText     = QT_TR_NOOP("Spreadsheet");
     sToolTipText  = QT_TR_NOOP("Inserts a view of a selected spreadsheet into a drawing");

--- a/src/Tools/SubWCRev.py
+++ b/src/Tools/SubWCRev.py
@@ -276,7 +276,7 @@ class GitControl(VersionControl):
             else: # guess
                 self.branch = '(%s)' % \
                     os.popen("git describe --all --dirty").read().strip()
-        #if the branch name conainted any slashes but was not a remote
+        #if the branch name contained any slashes but was not a remote
         #there might be not result by now. Hence we assume origin
         if self.url == "Unknown":
             for i in info:

--- a/src/Tools/generateBase/generateMetaModel_Module.xsd
+++ b/src/Tools/generateBase/generateMetaModel_Module.xsd
@@ -1,11 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Mit XMLSpy v2006 rel. 3 U bearbeitet (http://www.altova.com) von Juergen Riegel (DCX) -->
-<!-- Mit XMLSpy v2006 rel. 3 U bearbeitet (http://www.altova.com) von Juergen Riegel (DCX) -->
-<!-- Mit XMLSpy v2006 rel. 3 U bearbeitet (http://www.altova.com) von Juergen Riegel (DCX) -->
-<!-- Mit XMLSpy v2006 rel. 3 U bearbeitet (http://www.altova.com) von Juergen Riegel (DCX) -->
-<!-- Mit XMLSpy v2006 rel. 3 U bearbeitet (http://www.altova.com) von Juergen Riegel (DCX) -->
-<!-- Mit XMLSpy v2006 rel. 3 U bearbeitet (http://www.altova.com) von juergen Riegel (DCX) -->
-<!-- Mit XMLSpy v2006 rel. 3 U bearbeitet (http://www.altova.com) von juergen Riegel (DCX) -->
 <!-- Mit XMLSpy v2006 rel. 3 U bearbeitet (http://www.altova.com) von juergen Riegel (DCX) -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="unqualified">
 	<xs:element name="GenerateModel">
@@ -98,7 +91,7 @@
 							<xs:element name="Property" minOccurs="0" maxOccurs="unbounded"/>
 							<xs:element name="Feature" minOccurs="0" maxOccurs="unbounded">
 								<xs:annotation>
-									<xs:documentation>Represent a Feature in the modue</xs:documentation>
+									<xs:documentation>Represent a Feature in the module</xs:documentation>
 								</xs:annotation>
 								<xs:complexType>
 									<xs:sequence>
@@ -115,7 +108,7 @@
 							</xs:element>
 							<xs:element name="DocObject" minOccurs="0" maxOccurs="unbounded">
 								<xs:annotation>
-									<xs:documentation>Represnts a Document Object in the module</xs:documentation>
+									<xs:documentation>Represents a Document Object in the module</xs:documentation>
 								</xs:annotation>
 								<xs:complexType>
 									<xs:sequence>
@@ -127,7 +120,7 @@
 							</xs:element>
 							<xs:element name="GuiCommand" minOccurs="0" maxOccurs="unbounded">
 								<xs:annotation>
-									<xs:documentation>Creats a GuiCommand in this module</xs:documentation>
+									<xs:documentation>Creates a GuiCommand in this module</xs:documentation>
 								</xs:annotation>
 							</xs:element>
 							<xs:element name="PreferencesPage" minOccurs="0" maxOccurs="unbounded"/>
@@ -140,7 +133,7 @@
 	</xs:element>
 	<xs:element name="Property">
 		<xs:annotation>
-			<xs:documentation> Defines a class property</xs:documentation>
+			<xs:documentation>Defines a class property</xs:documentation>
 		</xs:annotation>
 		<xs:complexType>
 			<xs:sequence>
@@ -172,7 +165,7 @@
 	</xs:element>
 	<xs:element name="ViewProvider">
 		<xs:annotation>
-			<xs:documentation>Defins a ViewProvider for a Object</xs:documentation>
+			<xs:documentation>Defines a ViewProvider for an Object</xs:documentation>
 		</xs:annotation>
 		<xs:complexType>
 			<xs:sequence>


### PR DESCRIPTION
Several typos and uniformity fixes.
Note: 
* `SCL/SimpleDataTypes.py` is an upstream stepcode file whose fix has been submitted upstream and accepted. (https://github.com/stepcode/stepcode/commit/132ad5ea1f63547b67a62ef2d9759284f001abb3#diff-72280addca9a0793520aab74a114b168R188)
* the header of `Tools/generateBase/generateMetaModel_Module.xsd` had redundant data. It has been removed. Please double check it.