### PR TITLE
TechDraw Add LineGroups for Default Weights

### DIFF
--- a/src/Mod/TechDraw/App/CMakeLists.txt
+++ b/src/Mod/TechDraw/App/CMakeLists.txt
@@ -104,6 +104,8 @@ SET(TechDraw_SRCS
     EdgeWalker.h
     DrawProjectSplit.cpp
     DrawProjectSplit.h
+    LineGroup.cpp
+    LineGroup.h
 )
 
 SET(Geometry_SRCS
@@ -162,6 +164,10 @@ SET(TechDraw_PATFile
     PAT/FCPAT.pat
 )
 
+SET(TechDraw_LineGroupFile
+    LineGroup/LineGroup.csv
+)
+
 if(MSVC)
     #add_definitions(-D_PreComp_)
     #GET_MSVC_PRECOMPILED_SOURCE("PreCompiled.cpp" TechDrawCPP_SRCS ${TechDraw_SRCS} ${Draw_SRCS} )
@@ -191,6 +197,11 @@ fc_target_copy_resource(TechDraw
     ${CMAKE_SOURCE_DIR}/src/Mod/TechDraw
     ${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_DATADIR}/Mod/TechDraw
     ${TechDraw_PATFile})
+
+fc_target_copy_resource(TechDraw
+    ${CMAKE_SOURCE_DIR}/src/Mod/TechDraw
+    ${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_DATADIR}/Mod/TechDraw
+    ${TechDraw_LineGroupFile})
 
 SET_BIN_DIR(TechDraw TechDraw /Mod/TechDraw)
 SET_PYTHON_PREFIX_SUFFIX(TechDraw)

--- a/src/Mod/TechDraw/App/DrawViewDimension.cpp
+++ b/src/Mod/TechDraw/App/DrawViewDimension.cpp
@@ -51,6 +51,7 @@
 #include "DrawViewPart.h"
 #include "DrawViewDimension.h"
 #include "DrawUtil.h"
+#include "LineGroup.h"
 
 
 #include <Mod/TechDraw/App/DrawViewDimensionPy.h>  // generated from DrawViewDimensionPy.xml
@@ -91,7 +92,7 @@ DrawViewDimension::DrawViewDimension(void)
     std::string fontName = hGrp->GetASCII("LabelFont", "Sans");
     hGrp = App::GetApplication().GetUserParameter()
                                          .GetGroup("BaseApp")->GetGroup("Preferences")->GetGroup("Mod/TechDraw/Dimensions");
-    double fontSize = hGrp->GetFloat("FontSize", 4.0);
+    double fontSize = hGrp->GetFloat("FontSize", 3.5);
 
     ADD_PROPERTY_TYPE(References2D,(0,0),"",(App::PropertyType)(App::Prop_None),"Projected Geometry References");
     ADD_PROPERTY_TYPE(References3D,(0,0),"",(App::PropertyType)(App::Prop_None),"3D Geometry References");
@@ -99,7 +100,12 @@ DrawViewDimension::DrawViewDimension(void)
     ADD_PROPERTY_TYPE(Fontsize,(fontSize)    ,"Format",(App::PropertyType)(App::Prop_None),"Dimension text size in mm");
     ADD_PROPERTY_TYPE(FormatSpec,(getDefaultFormatSpec().c_str()) ,
                   "Format",(App::PropertyType)(App::Prop_None),"Dimension Format");
-    ADD_PROPERTY_TYPE(LineWidth,(0.5)    ,"Format",(App::PropertyType)(App::Prop_None),"Dimension line weight");
+
+    hGrp = App::GetApplication().GetUserParameter().GetGroup("BaseApp")->GetGroup("Preferences")->GetGroup("Mod/TechDraw/Decorations");
+    std::string lgName = hGrp->GetASCII("LineGroup","FC 0.70mm");
+    auto lg = LineGroup::lineGroupFactory(lgName);
+    double weight = lg->getWeight("Graphic");
+    ADD_PROPERTY_TYPE(LineWidth,(weight)    ,"Format",(App::PropertyType)(App::Prop_None),"Dimension line weight");
     //ADD_PROPERTY_TYPE(CentreLines,(0) ,"Format",(App::PropertyType)(App::Prop_None),"Arc Dimension Center Mark");
 
     Type.setEnums(TypeEnums);                                          //dimension type: length, radius etc

--- a/src/Mod/TechDraw/App/DrawViewPart.h
+++ b/src/Mod/TechDraw/App/DrawViewPart.h
@@ -98,6 +98,7 @@ public:
     App::PropertyFloat  LineWidth;
     App::PropertyFloat  HiddenWidth;
     App::PropertyFloat  IsoWidth;
+    App::PropertyFloat  ExtraWidth;
     App::PropertyBool   ArcCenterMarks;
     App::PropertyFloat  CenterScale;
     App::PropertyBool   HorizCenterLine;

--- a/src/Mod/TechDraw/App/LineGroup.cpp
+++ b/src/Mod/TechDraw/App/LineGroup.cpp
@@ -1,0 +1,196 @@
+/***************************************************************************
+ *   Copyright (c) 2017 Wandererfan <wandererfan@gmail.com>                *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "PreCompiled.h"
+
+#ifndef _PreComp_
+#include <sstream>
+#include <iomanip>
+#include <stdexcept>
+#endif
+
+#include <App/Application.h>
+#include <Base/Console.h>
+#include <Base/Parameter.h>
+
+#include "LineGroup.h"
+
+using namespace TechDraw;
+
+LineGroup::LineGroup()
+{
+    init();
+}
+
+LineGroup::LineGroup(std::string groupName)
+{
+    init();
+    m_name = groupName;
+}
+
+
+LineGroup::~LineGroup()
+{
+}
+
+void LineGroup::init(void)
+{
+    m_name    = "";
+    m_thin    = 0.0;
+    m_graphic = 0.0;
+    m_thick   = 0.0;
+    m_extra   = 0.0;
+}
+
+double LineGroup::getWeight(std::string s)
+{
+    double result = 0.55;
+    if (s == "Thin") {
+       result = m_thin;
+    } else if (s == "Graphic") {
+       result = m_graphic;
+    } else if (s == "Thick") {
+       result = m_thick;
+    } else if (s == "Extra") {
+       result = m_extra;
+    }
+    return result;
+}
+
+void LineGroup::setWeight(std::string s, double weight)
+{
+    if (s == "Thin") {
+       m_thin = weight;
+    } else if (s == "Graphic") {
+       m_graphic = weight;
+    } else if (s == "Thick") {
+       m_thick = weight;
+    } else if (s == "Extra") {
+       m_extra = weight;
+    }
+}
+
+void LineGroup::dump(char* title)
+{
+    Base::Console().Message( "DUMP: %s\n",title);
+    Base::Console().Message( "Name: %s\n", m_name.c_str());
+    Base::Console().Message( "Thin: %.3f\n", m_thin);
+    Base::Console().Message( "Graphic: %.3f\n",m_graphic);
+    Base::Console().Message( "Thick: %.3f\n",m_thick);
+    Base::Console().Message( "Extra: %.3f\n",m_extra);
+}
+
+//static support function: split comma separated string of values into vector of numbers
+std::vector<double> LineGroup::split(std::string line)
+{
+    std::vector<double>   result;
+    std::stringstream     lineStream(line);
+    std::string           cell;
+    bool nameCell = true;
+
+    while(std::getline(lineStream,cell, ','))
+    {
+        if (nameCell) {
+            nameCell = false;
+            continue;
+        }
+        try {
+            result.push_back(std::stod(cell));
+        }
+        catch (const std::invalid_argument& ia) {
+            Base::Console().Warning("Invalid number in cell: %s (%s) \n",cell.c_str(),ia.what());
+            result.push_back(0.0);
+        }
+    }
+    return result;
+}
+
+//static support function: find group defn in file
+std::string LineGroup::getRecordFromFile(std::string parmFile, std::string groupName)
+{
+    std::string record;
+    std::string lineSpec;
+    std::ifstream inFile;
+    inFile.open (parmFile, std::ifstream::in);
+    if(!inFile.is_open()) {
+        Base::Console().Message( "Cannot open input file: %s\n",parmFile.c_str());
+        return record;
+    }
+
+    bool groupFound = false;
+    while ( inFile.good() ){
+         std::string line;
+         std::getline(inFile,line);
+         std::string nameTag = line.substr(0,1);
+         std::string foundName;
+         unsigned long int commaPos;
+         if ((nameTag == ";")  ||
+             (nameTag == " ")  ||
+             (line.empty()) )  {           //is cr/lf empty?
+             continue;
+         } else if (nameTag == "*") {
+             commaPos = line.find(",",1);
+             if (commaPos != std::string::npos) {
+                  foundName = line.substr(1,commaPos-1);
+             } else {
+                  foundName = line.substr(1);
+             }
+             if (foundName == groupName) {
+                 //this is our group
+                 record = line;
+                 groupFound = true;
+                 break;
+             }
+        }
+    }  //endwhile
+    if (!groupFound) {
+        Base::Console().Message("LineGroup - group: %s is not found\n", groupName.c_str());
+    }
+    return record;
+}
+
+//static LineGroup maker
+LineGroup* LineGroup::lineGroupFactory(std::string groupName)
+{
+    LineGroup* lg = new LineGroup(groupName);
+
+    Base::Reference<ParameterGrp> hGrp = App::GetApplication().GetUserParameter()
+        .GetGroup("BaseApp")->GetGroup("Preferences")->GetGroup("Mod/TechDraw/Files");
+
+    std::string defaultDir = App::Application::getResourceDir() + "Mod/TechDraw/LineGroup/";
+    std::string defaultFileName = defaultDir + "LineGroup.csv";
+    
+    std::string lgFileName = hGrp->GetASCII("LineGroupFile",defaultFileName.c_str());
+
+    std::string lgRecord = LineGroup::getRecordFromFile(lgFileName, groupName);
+
+    std::vector<double> values = LineGroup::split(lgRecord);
+    if (values.size() < 4) {
+        Base::Console().Message( "LineGroup::invalid entry in %s\n",groupName.c_str() );
+    } else {
+        lg->setWeight("Thin",values[0]);
+        lg->setWeight("Graphic",values[1]);
+        lg->setWeight("Thick",values[2]);
+        lg->setWeight("Extra",values[3]);
+    }
+    return lg;
+}

--- a/src/Mod/TechDraw/App/LineGroup.h
+++ b/src/Mod/TechDraw/App/LineGroup.h
@@ -1,0 +1,67 @@
+/***************************************************************************
+ *   Copyright (c) 2017 Wandererfan <wandererfan@gmail.com>                *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+ 
+//! LineGroup - Classes related to processing LineGroup definition CSV files
+
+#ifndef _TechDraw_LINEGROUP_H_
+#define _TechDraw_LINEGROUP_H_
+
+#include <iostream>
+#include <sstream>
+#include <fstream>
+#include <string>
+
+namespace TechDraw
+{
+
+class TechDrawExport LineGroup
+{
+public: 
+    LineGroup();
+    LineGroup(std::string groupName);
+    ~LineGroup();
+    double getWeight(std::string s);
+    void setWeight(std::string s, double weight);
+//    void setWeight(const char* s, double weight);
+    void dump(char* title);
+
+    //static support function: split comma separated string of values into vector of numbers
+    static std::vector<double> split(std::string line);
+
+    //static support function: find group defn in file
+    static std::string getRecordFromFile(std::string parmFile, std::string groupName);
+
+    //static LineGroup maker
+    static LineGroup* lineGroupFactory(std::string groupName);
+
+protected:
+    void init(void);
+
+    std::string m_name;
+    double      m_thin;
+    double      m_graphic;
+    double      m_thick;
+    double      m_extra;
+};
+
+}
+#endif

--- a/src/Mod/TechDraw/Gui/DlgPrefsTechDraw2.ui
+++ b/src/Mod/TechDraw/Gui/DlgPrefsTechDraw2.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>521</width>
-    <height>554</height>
+    <height>587</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -94,7 +94,7 @@
            <number>1</number>
           </property>
           <property name="value">
-           <double>4.000000000000000</double>
+           <double>3.500000000000000</double>
           </property>
           <property name="prefEntry" stdset="0">
            <cstring>FontSize</cstring>
@@ -254,7 +254,7 @@
            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
           </property>
           <property name="value">
-           <double>5.000000000000000</double>
+           <double>3.500000000000000</double>
           </property>
           <property name="prefEntry" stdset="0">
            <cstring>ArrowSize</cstring>
@@ -290,7 +290,7 @@
      <layout class="QGridLayout" name="gridLayout_3">
       <item row="0" column="0">
        <layout class="QGridLayout" name="gridLayout_2" columnstretch="1,0,0">
-        <item row="0" column="2">
+        <item row="1" column="2">
          <widget class="Gui::PrefComboBox" name="pcbMatting">
           <property name="prefEntry" stdset="0">
            <cstring>MattingStyle</cstring>
@@ -310,28 +310,28 @@
           </item>
          </widget>
         </item>
-        <item row="3" column="0">
+        <item row="4" column="0">
          <widget class="QLabel" name="label_6">
           <property name="text">
            <string>Section Line Style</string>
           </property>
          </widget>
         </item>
-        <item row="1" column="0">
+        <item row="2" column="0">
          <widget class="QLabel" name="label_4">
           <property name="text">
            <string>Center Line Style</string>
           </property>
          </widget>
         </item>
-        <item row="0" column="0">
+        <item row="1" column="0">
          <widget class="QLabel" name="label">
           <property name="text">
            <string>Matting Style</string>
           </property>
          </widget>
         </item>
-        <item row="2" column="2">
+        <item row="3" column="2">
          <widget class="Gui::PrefColorButton" name="colCenterLine">
           <property name="color">
            <color>
@@ -348,7 +348,7 @@
           </property>
          </widget>
         </item>
-        <item row="1" column="2">
+        <item row="2" column="2">
          <widget class="Gui::PrefComboBox" name="pcbCenterStyle">
           <property name="currentIndex">
            <number>2</number>
@@ -391,7 +391,7 @@
           </item>
          </widget>
         </item>
-        <item row="3" column="2">
+        <item row="4" column="2">
          <widget class="Gui::PrefComboBox" name="pcbSectionStyle">
           <property name="currentIndex">
            <number>2</number>
@@ -434,21 +434,21 @@
           </item>
          </widget>
         </item>
-        <item row="2" column="0">
+        <item row="3" column="0">
          <widget class="QLabel" name="label_5">
           <property name="text">
            <string>Center Line Color</string>
           </property>
          </widget>
         </item>
-        <item row="4" column="0">
+        <item row="5" column="0">
          <widget class="QLabel" name="label_7">
           <property name="text">
            <string>Section Line Color</string>
           </property>
          </widget>
         </item>
-        <item row="4" column="2">
+        <item row="5" column="2">
          <widget class="Gui::PrefColorButton" name="colSectionLine">
           <property name="color">
            <color>
@@ -465,7 +465,7 @@
           </property>
          </widget>
         </item>
-        <item row="1" column="1">
+        <item row="2" column="1">
          <spacer name="horizontalSpacer_2">
           <property name="orientation">
            <enum>Qt::Horizontal</enum>
@@ -478,7 +478,7 @@
           </property>
          </spacer>
         </item>
-        <item row="5" column="0">
+        <item row="6" column="0">
          <widget class="QLabel" name="label_10">
           <property name="toolTip">
            <string>Default weight for GeomHatch lines</string>
@@ -488,7 +488,7 @@
           </property>
          </widget>
         </item>
-        <item row="5" column="2">
+        <item row="6" column="2">
          <widget class="Gui::PrefDoubleSpinBox" name="doubleSpinBox">
           <property name="alignment">
            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -501,6 +501,26 @@
           </property>
           <property name="prefPath" stdset="0">
            <cstring>Mod/TechDraw/PAT</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="0">
+         <widget class="QLabel" name="label_13">
+          <property name="text">
+           <string>Line Group </string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="2">
+         <widget class="Gui::PrefLineEdit" name="leLineGroup">
+          <property name="text">
+           <string>FC 0.70mm</string>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>LineGroup</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>/Mod/TechDraw/Decorations</cstring>
           </property>
          </widget>
         </item>

--- a/src/Mod/TechDraw/Gui/DlgPrefsTechDraw2Imp.cpp
+++ b/src/Mod/TechDraw/Gui/DlgPrefsTechDraw2Imp.cpp
@@ -56,6 +56,7 @@ void DlgPrefsTechDraw2Imp::saveSettings()
     cbGlobalDecimals->onSave();
     sbAltDecimals->onSave();
     dsbArrowSize->onSave();
+    leLineGroup->onSave();
 }
 
 void DlgPrefsTechDraw2Imp::loadSettings()
@@ -73,6 +74,7 @@ void DlgPrefsTechDraw2Imp::loadSettings()
     cbGlobalDecimals->onRestore();
     sbAltDecimals->onRestore();
     dsbArrowSize->onRestore();
+    leLineGroup->onRestore();
 }
 
 /**

--- a/src/Mod/TechDraw/Gui/QGIViewPart.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewPart.cpp
@@ -642,7 +642,7 @@ void QGIViewPart::drawSectionLine(TechDraw::DrawViewSection* viewSection, bool b
             yVal = sectionSpan / 2.0;
         }
         sectionLine->setBounds(-xVal,-yVal,xVal,yVal);
-        sectionLine->setWidth(Rez::guiX(viewPart->LineWidth.getValue()));          //TODO: add fudge to make sectionLine thinner than reg lines?
+        sectionLine->setWidth(Rez::guiX(viewPart->IsoWidth.getValue()));
         sectionLine->setFont(m_font,Rez::guiX(6.0));
         sectionLine->setZValue(ZVALUE::SECTIONLINE);
         sectionLine->setRotation(viewPart->Rotation.getValue());
@@ -673,7 +673,7 @@ void QGIViewPart::drawCenterLines(bool b)
             xVal = sectionSpan / 2.0;
             yVal = 0.0;
             centerLine->setBounds(-xVal,-yVal,xVal,yVal);
-            //centerLine->setWidth(viewPart->LineWidth.getValue());
+            centerLine->setWidth(Rez::guiX(viewPart->IsoWidth.getValue()));
             centerLine->setZValue(ZVALUE::SECTIONLINE);
             centerLine->setRotation(viewPart->Rotation.getValue());
             centerLine->draw();
@@ -686,7 +686,7 @@ void QGIViewPart::drawCenterLines(bool b)
             xVal = 0.0;
             yVal = sectionSpan / 2.0;
             centerLine->setBounds(-xVal,-yVal,xVal,yVal);
-            //centerLine->setWidth(viewPart->LineWidth.getValue());
+            centerLine->setWidth(Rez::guiX(viewPart->IsoWidth.getValue()));
             centerLine->setZValue(ZVALUE::SECTIONLINE);
             centerLine->setRotation(viewPart->Rotation.getValue());
             centerLine->draw();
@@ -714,7 +714,7 @@ void QGIViewPart::drawHighlight(TechDraw::DrawViewDetail* viewDetail, bool b)
         Base::Vector3d center = viewDetail->AnchorPoint.getValue() * viewPart->getScale();
         double radius = viewDetail->Radius.getValue() * viewPart->getScale();
         highlight->setBounds(center.x - radius, center.y + radius,center.x + radius, center.y - radius);
-        highlight->setWidth(Rez::guiX(viewPart->LineWidth.getValue()));
+        highlight->setWidth(Rez::guiX(viewPart->IsoWidth.getValue()));
         highlight->setFont(m_font,Rez::guiX(6.0));
         highlight->setZValue(ZVALUE::HIGHLIGHT);
         highlight->draw();

--- a/src/Mod/TechDraw/LineGroup/LineGroup.csv
+++ b/src/Mod/TechDraw/LineGroup/LineGroup.csv
@@ -1,0 +1,15 @@
+;FreeCAD LineGroup Definitions
+;Format: *GroupName,thin,graphic,thick,extra
+;thin: hidden lines
+;graphic: dimensions, centerlines
+;thick: visible lines
+;extra: not implemented
+
+*FC 0.25mm,0.13,0.18,0.25,0.50
+*FC 0.35mm,0.18,0.25,0.35,0.70
+*FC 0.50mm,0.25,0.35,0.50,1.0
+*FC 0.70mm,0.35,0.50,0.70,1.4
+*FC 1.00mm,0.50,0.70,1.00,2.00
+
+
+


### PR DESCRIPTION
This PR addresses the setting of default values for line weights in TechDraw.  These were previously hard coded.  Please merge. 

Thanks,
wf

- Add ability to control default weight for visible,
  hidden and decorative lines from a configuration
  file. Different sets of defaults can be specified as
  a preference.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR once it is merged.

---
