### PR TITLE
Fix some GCC 7 warnings:

### DIFF
--- a/src/3rdParty/salomesmesh/inc/NETGENPlugin_SimpleHypothesis_2D.hxx
+++ b/src/3rdParty/salomesmesh/inc/NETGENPlugin_SimpleHypothesis_2D.hxx
@@ -45,7 +45,7 @@ public:
   /*!
    * Sets <number of segments> value
    */
-  void SetNumberOfSegments(int nb) throw (SALOME_Exception);
+  void SetNumberOfSegments(int nb);
   /*!
    * Returns <number of segments> value.
    * Can be zero in case if LocalLength() has been set
@@ -55,7 +55,7 @@ public:
   /*!
    * Sets <segment length> value
    */
-  void SetLocalLength(double segmentLength) throw (SALOME_Exception);
+  void SetLocalLength(double segmentLength);
   /*!
    * Returns <segment length> value.
    * Can be zero in case if NumberOfSegments() has been set

--- a/src/3rdParty/salomesmesh/inc/SMDS_Mesh.hxx
+++ b/src/3rdParty/salomesmesh/inc/SMDS_Mesh.hxx
@@ -695,7 +695,7 @@ public:
     * \param doNotRaise - if true, suppres exception, just return free memory size
     * \retval int - amount of available memory in MB or negative number in failure case
    */
-  static int CheckMemory(const bool doNotRaise=false) throw (std::bad_alloc);
+  static int CheckMemory(const bool doNotRaise=false);
 
   int MaxNodeID() const;
   int MinNodeID() const;

--- a/src/3rdParty/salomesmesh/inc/SMESH_Gen.hxx
+++ b/src/3rdParty/salomesmesh/inc/SMESH_Gen.hxx
@@ -63,8 +63,7 @@ public:
  
   static SMESH_Gen* get();
 
-  SMESH_Mesh* CreateMesh(int theStudyId, bool theIsEmbeddedMode)
-    throw(SALOME_Exception);
+  SMESH_Mesh* CreateMesh(int theStudyId, bool theIsEmbeddedMode);
 
   /*!
    * \brief Computes aMesh on aShape 

--- a/src/3rdParty/salomesmesh/inc/SMESH_Mesh.hxx
+++ b/src/3rdParty/salomesmesh/inc/SMESH_Mesh.hxx
@@ -131,16 +131,13 @@ class SMESH_EXPORT SMESH_Mesh
                                   bool        theMakeRequiredGroups = true );
 
   SMESH_Hypothesis::Hypothesis_Status
-  AddHypothesis(const TopoDS_Shape & aSubShape, int anHypId, std::string* error=0)
-    throw(SALOME_Exception);
+  AddHypothesis(const TopoDS_Shape & aSubShape, int anHypId, std::string* error=0);
   
   SMESH_Hypothesis::Hypothesis_Status
-  RemoveHypothesis(const TopoDS_Shape & aSubShape, int anHypId)
-    throw(SALOME_Exception);
+  RemoveHypothesis(const TopoDS_Shape & aSubShape, int anHypId);
   
   const std::list <const SMESHDS_Hypothesis * >&
-  GetHypothesisList(const TopoDS_Shape & aSubShape) const
-    throw(SALOME_Exception);
+  GetHypothesisList(const TopoDS_Shape & aSubShape) const;
 
   const SMESH_Hypothesis * GetHypothesis(const TopoDS_Shape &    aSubShape,
                                          const SMESH_HypoFilter& aFilter,
@@ -166,9 +163,9 @@ class SMESH_EXPORT SMESH_Mesh
 
   SMESH_Hypothesis * GetHypothesis(const int aHypID) const;
 
-  const std::list<SMESHDS_Command*> & GetLog() throw(SALOME_Exception);
+  const std::list<SMESHDS_Command*> & GetLog();
   
-  void ClearLog() throw(SALOME_Exception);
+  void ClearLog();
   
   int GetId() const          { return _id; }
   
@@ -182,19 +179,15 @@ class SMESH_EXPORT SMESH_Mesh
   
   SMESH_Gen *GetGen()        { return _gen; }
 
-  SMESH_subMesh *GetSubMesh(const TopoDS_Shape & aSubShape)
-    throw(SALOME_Exception);
+  SMESH_subMesh *GetSubMesh(const TopoDS_Shape & aSubShape);
   
-  SMESH_subMesh *GetSubMeshContaining(const TopoDS_Shape & aSubShape) const
-    throw(SALOME_Exception);
+  SMESH_subMesh *GetSubMeshContaining(const TopoDS_Shape & aSubShape) const;
   
-  SMESH_subMesh *GetSubMeshContaining(const int aShapeID) const
-    throw(SALOME_Exception);
+  SMESH_subMesh *GetSubMeshContaining(const int aShapeID) const;
   /*!
    * \brief Return submeshes of groups containing the given subshape
    */
-  std::list<SMESH_subMesh*> GetGroupSubMeshesContaining(const TopoDS_Shape & shape) const
-    throw(SALOME_Exception);
+  std::list<SMESH_subMesh*> GetGroupSubMeshesContaining(const TopoDS_Shape & shape) const;
   /*!
    * \brief Say all submeshes that theChangedHyp has been modified
    */
@@ -219,9 +212,9 @@ class SMESH_EXPORT SMESH_Mesh
    */
   const TopTools_ListOfShape& GetAncestors(const TopoDS_Shape& theSubShape) const;
 
-  void SetAutoColor(bool theAutoColor) throw(SALOME_Exception);
+  void SetAutoColor(bool theAutoColor);
 
-  bool GetAutoColor() throw(SALOME_Exception);
+  bool GetAutoColor();
 
   /*!
    * \brief Set the flag meaning that the mesh has been edited "manually".
@@ -255,16 +248,15 @@ class SMESH_EXPORT SMESH_Mesh
                  int                 theVersion = 0,
                  const SMESHDS_Mesh* theMeshPart = 0,
                  bool                theAutoDimension = false,
-                 bool                theAddODOnVertices = false)
-    throw(SALOME_Exception);
+                 bool                theAddODOnVertices = false);
 
   void ExportDAT(const char *        file,
-                 const SMESHDS_Mesh* meshPart = 0) throw(SALOME_Exception);
+                 const SMESHDS_Mesh* meshPart = 0);
   void ExportUNV(const char *        file,
-                 const SMESHDS_Mesh* meshPart = 0) throw(SALOME_Exception);
+                 const SMESHDS_Mesh* meshPart = 0);
   void ExportSTL(const char *        file,
                  const bool          isascii,
-                 const SMESHDS_Mesh* meshPart = 0) throw(SALOME_Exception);
+                 const SMESHDS_Mesh* meshPart = 0);
   void ExportCGNS(const char *        file,
                   const SMESHDS_Mesh* mesh,
                   const char *        meshName = 0);
@@ -273,33 +265,33 @@ class SMESH_EXPORT SMESH_Mesh
                  bool                withRequiredGroups = true );
   void ExportSAUV(const char *file, 
                   const char* theMeshName = NULL, 
-                  bool theAutoGroups = true) throw(SALOME_Exception);
+                  bool theAutoGroups = true);
 
   double GetComputeProgress() const;
   
-  int NbNodes() const throw(SALOME_Exception);
-  int Nb0DElements() const throw(SALOME_Exception);
-  int NbBalls() const throw(SALOME_Exception);
+  int NbNodes() const;
+  int Nb0DElements() const;
+  int NbBalls() const;
   
-  int NbEdges(SMDSAbs_ElementOrder order = ORDER_ANY) const throw(SALOME_Exception);
+  int NbEdges(SMDSAbs_ElementOrder order = ORDER_ANY) const;
   
-  int NbFaces(SMDSAbs_ElementOrder order = ORDER_ANY) const throw(SALOME_Exception);
-  int NbTriangles(SMDSAbs_ElementOrder order = ORDER_ANY) const throw(SALOME_Exception);
-  int NbQuadrangles(SMDSAbs_ElementOrder order = ORDER_ANY) const throw(SALOME_Exception);
-  int NbBiQuadQuadrangles() const throw(SALOME_Exception);
-  int NbBiQuadTriangles() const throw(SALOME_Exception);
-  int NbPolygons(SMDSAbs_ElementOrder order = ORDER_ANY) const throw(SALOME_Exception);
+  int NbFaces(SMDSAbs_ElementOrder order = ORDER_ANY) const;
+  int NbTriangles(SMDSAbs_ElementOrder order = ORDER_ANY) const;
+  int NbQuadrangles(SMDSAbs_ElementOrder order = ORDER_ANY) const;
+  int NbBiQuadQuadrangles() const;
+  int NbBiQuadTriangles() const;
+  int NbPolygons(SMDSAbs_ElementOrder order = ORDER_ANY) const;
   
-  int NbVolumes(SMDSAbs_ElementOrder order = ORDER_ANY) const throw(SALOME_Exception);
-  int NbTetras(SMDSAbs_ElementOrder order = ORDER_ANY) const throw(SALOME_Exception);
-  int NbHexas(SMDSAbs_ElementOrder order = ORDER_ANY) const throw(SALOME_Exception);
-  int NbTriQuadraticHexas() const throw(SALOME_Exception);
-  int NbPyramids(SMDSAbs_ElementOrder order = ORDER_ANY) const throw(SALOME_Exception);
-  int NbPrisms(SMDSAbs_ElementOrder order = ORDER_ANY) const throw(SALOME_Exception);
-  int NbHexagonalPrisms() const throw(SALOME_Exception);
-  int NbPolyhedrons() const throw(SALOME_Exception);
+  int NbVolumes(SMDSAbs_ElementOrder order = ORDER_ANY) const;
+  int NbTetras(SMDSAbs_ElementOrder order = ORDER_ANY) const;
+  int NbHexas(SMDSAbs_ElementOrder order = ORDER_ANY) const;
+  int NbTriQuadraticHexas() const;
+  int NbPyramids(SMDSAbs_ElementOrder order = ORDER_ANY) const;
+  int NbPrisms(SMDSAbs_ElementOrder order = ORDER_ANY) const;
+  int NbHexagonalPrisms() const;
+  int NbPolyhedrons() const;
   
-  int NbSubMesh() const throw(SALOME_Exception);
+  int NbSubMesh() const;
   
   int NbGroup() const { return _mapGroup.size(); }
 
@@ -311,7 +303,7 @@ class SMESH_EXPORT SMESH_Mesh
                          const TopoDS_Shape&       theShape=TopoDS_Shape(),
                          const SMESH_PredicatePtr& thePredicate=SMESH_PredicatePtr());
 
-  SMESH_Group* AddGroup (SMESHDS_GroupBase* groupDS) throw(SALOME_Exception);
+  SMESH_Group* AddGroup (SMESHDS_GroupBase* groupDS);
 
   typedef boost::shared_ptr< SMDS_Iterator<SMESH_Group*> > GroupIteratorPtr;
   GroupIteratorPtr GetGroups() const;

--- a/src/3rdParty/salomesmesh/inc/StdMeshers_Adaptive1D.hxx
+++ b/src/3rdParty/salomesmesh/inc/StdMeshers_Adaptive1D.hxx
@@ -43,20 +43,20 @@ class STDMESHERS_EXPORT StdMeshers_Adaptive1D : public SMESH_Hypothesis
   /*!
    * Sets minimal allowed segment length
    */
-  void SetMinSize( double minSegLen ) throw (SALOME_Exception);
+  void SetMinSize( double minSegLen );
   double GetMinSize() const { return myMinSize; }
 
   /*!
    * Sets maximal allowed segment length
    */
-  void SetMaxSize( double maxSegLen ) throw (SALOME_Exception);
+  void SetMaxSize( double maxSegLen );
   double GetMaxSize() const { return myMaxSize; }
 
   /*!
    * Sets <deflection> parameter value, 
    * i.e. a maximal allowed distance between a segment and an edge.
    */
-  void SetDeflection(double value) throw(SALOME_Exception);
+  void SetDeflection(double value);
   double GetDeflection() const { return myDeflection; }
   
   virtual std::ostream & SaveTo(std::ostream & save);

--- a/src/3rdParty/salomesmesh/inc/StdMeshers_Arithmetic1D.hxx
+++ b/src/3rdParty/salomesmesh/inc/StdMeshers_Arithmetic1D.hxx
@@ -44,7 +44,7 @@ public:
   StdMeshers_Arithmetic1D(int hypId, int studyId, SMESH_Gen* gen);
   virtual ~StdMeshers_Arithmetic1D();
 
-  void SetLength(double length, bool isStartLength) throw(SALOME_Exception);
+  void SetLength(double length, bool isStartLength);
 
   double GetLength(bool isStartLength) const;
 

--- a/src/3rdParty/salomesmesh/inc/StdMeshers_AutomaticLength.hxx
+++ b/src/3rdParty/salomesmesh/inc/StdMeshers_AutomaticLength.hxx
@@ -55,14 +55,12 @@ public:
   /*!
    * \brief Computes segment for a given edge
    */
-  double GetLength(const SMESH_Mesh* aMesh, const TopoDS_Shape& anEdge)
-    throw(SALOME_Exception);
+  double GetLength(const SMESH_Mesh* aMesh, const TopoDS_Shape& anEdge);
 
   /*!
    * \brief Computes segment length for an edge of given length
    */
-  double GetLength(const SMESH_Mesh* aMesh, const double edgeLength)
-    throw(SALOME_Exception);
+  double GetLength(const SMESH_Mesh* aMesh, const double edgeLength);
 
   /*!
    * \brief Set Fineness
@@ -74,8 +72,7 @@ public:
    * The "Initial Number of Elements on the Shortest Edge" (S0)
    * is divided by (0.5 + 4.5 x theFineness)
    */
-  void SetFineness(double theFineness)
-    throw(SALOME_Exception);
+  void SetFineness(double theFineness);
 
   /*!
    * \brief Return mesh Fineness

--- a/src/3rdParty/salomesmesh/inc/StdMeshers_CartesianParameters3D.hxx
+++ b/src/3rdParty/salomesmesh/inc/StdMeshers_CartesianParameters3D.hxx
@@ -54,11 +54,11 @@ public:
   /*!
    * Sets coordinates of node positions along an axis (countered from 0)
    */
-  void SetGrid(std::vector<double>& xNodes, int axis) throw ( SALOME_Exception );
+  void SetGrid(std::vector<double>& xNodes, int axis);
   /*!
    * Return coordinates of node positions along the three axes
    */
-  void GetGrid(std::vector<double>& xNodes, int axis) const throw ( SALOME_Exception );
+  void GetGrid(std::vector<double>& xNodes, int axis) const;
 
   /*!
    * \brief Set grid spacing along the three axes
@@ -70,13 +70,13 @@ public:
    */
   void SetGridSpacing(std::vector<std::string>& spaceFunctions,
                       std::vector<double>&      internalPoints,
-                      const int                 axis) throw ( SALOME_Exception );
+                      const int                 axis);
 
   void GetGridSpacing(std::vector<std::string>& spaceFunctions,
                       std::vector<double>&      internalPoints,
-                      const int                 axis) const throw ( SALOME_Exception );
+                      const int                 axis) const;
 
-  bool IsGridBySpacing(const int axis) const throw ( SALOME_Exception );
+  bool IsGridBySpacing(const int axis) const;
 
   /*!
    * Set/unset a fixed point, at which a node will be created provided that grid
@@ -99,7 +99,7 @@ public:
                                  std::vector<double>&      points,
                                  std::vector<double>&      coords,
                                  const std::string&        axis,
-                                 const double*             xForced=0) throw (SALOME_Exception);
+                                 const double*             xForced=0);
   /*!
    * Return coordinates of node positions along the three axes.
    * If the grid is defined by spacing functions, the coordinates are computed
@@ -107,12 +107,12 @@ public:
   void GetCoordinates(std::vector<double>& xNodes,
                       std::vector<double>& yNodes,
                       std::vector<double>& zNodes,
-                      const Bnd_Box&       bndBox) const throw ( SALOME_Exception );
+                      const Bnd_Box&       bndBox) const;
 
   /*!
    * \brief Set custom direction of axes
    */
-  void SetAxisDirs(const double* the9DirComps) throw ( SALOME_Exception );
+  void SetAxisDirs(const double* the9DirComps);
   const double* GetAxisDirs() const { return _axisDirs; }
   /*!
    * \brief Returns axes at which number of hexahedra is maximal
@@ -125,7 +125,7 @@ public:
    * hexahedron by geometry boundary is considered small and is removed if
    * it's size is \athreshold times less than the size of the initial hexahedron.
    */
-  void SetSizeThreshold(const double threshold) throw ( SALOME_Exception );
+  void SetSizeThreshold(const double threshold);
   /*!
    * \brief Return size threshold
    */

--- a/src/3rdParty/salomesmesh/inc/StdMeshers_Deflection1D.hxx
+++ b/src/3rdParty/salomesmesh/inc/StdMeshers_Deflection1D.hxx
@@ -38,7 +38,7 @@ class STDMESHERS_EXPORT StdMeshers_Deflection1D:public SMESH_Hypothesis
   StdMeshers_Deflection1D(int hypId, int studyId, SMESH_Gen * gen);
   virtual ~ StdMeshers_Deflection1D();
 
-  void SetDeflection(double value) throw(SALOME_Exception);
+  void SetDeflection(double value);
 
   double GetDeflection() const;
   

--- a/src/3rdParty/salomesmesh/inc/StdMeshers_FixedPoints1D.hxx
+++ b/src/3rdParty/salomesmesh/inc/StdMeshers_FixedPoints1D.hxx
@@ -41,11 +41,9 @@ public:
   StdMeshers_FixedPoints1D(int hypId, int studyId, SMESH_Gen* gen);
   virtual ~StdMeshers_FixedPoints1D();
 
-  void SetPoints(std::vector<double>& listParams)
-    throw(SALOME_Exception);
+  void SetPoints(std::vector<double>& listParams);
 
-  void SetNbSegments(std::vector<int>& listNbSeg) 
-    throw(SALOME_Exception);
+  void SetNbSegments(std::vector<int>& listNbSeg);
 
   const std::vector<double>& GetPoints() const { return _params; }
 

--- a/src/3rdParty/salomesmesh/inc/StdMeshers_Geometric1D.hxx
+++ b/src/3rdParty/salomesmesh/inc/StdMeshers_Geometric1D.hxx
@@ -37,8 +37,8 @@ class STDMESHERS_EXPORT StdMeshers_Geometric1D: public StdMeshers_Reversible1D
 public:
   StdMeshers_Geometric1D(int hypId, int studyId, SMESH_Gen* gen);
 
-  void SetStartLength(double length) throw(SALOME_Exception);
-  void SetCommonRatio(double factor) throw(SALOME_Exception);
+  void SetStartLength(double length);
+  void SetCommonRatio(double factor);
 
   double GetStartLength() const;
   double GetCommonRatio() const;

--- a/src/3rdParty/salomesmesh/inc/StdMeshers_LayerDistribution.hxx
+++ b/src/3rdParty/salomesmesh/inc/StdMeshers_LayerDistribution.hxx
@@ -59,8 +59,7 @@ public:
    * \brief Sets  1D hypothesis specifying distribution of layers
     * \param hyp1D - 1D hypothesis
    */
-  void SetLayerDistribution(SMESH_Hypothesis* hyp1D)
-    throw ( SALOME_Exception );
+  void SetLayerDistribution(SMESH_Hypothesis* hyp1D);
 
   /*!
    * \brief Returns 1D hypothesis specifying distribution of layers

--- a/src/3rdParty/salomesmesh/inc/StdMeshers_LengthFromEdges.hxx
+++ b/src/3rdParty/salomesmesh/inc/StdMeshers_LengthFromEdges.hxx
@@ -41,8 +41,7 @@ public:
   StdMeshers_LengthFromEdges(int hypId, int studyId, SMESH_Gen* gen);
   virtual ~StdMeshers_LengthFromEdges();
 
-  void SetMode(int mode)
-    throw (SALOME_Exception);
+  void SetMode(int mode);
 
   int GetMode();
 

--- a/src/3rdParty/salomesmesh/inc/StdMeshers_LocalLength.hxx
+++ b/src/3rdParty/salomesmesh/inc/StdMeshers_LocalLength.hxx
@@ -40,8 +40,8 @@ class STDMESHERS_EXPORT StdMeshers_LocalLength: public SMESH_Hypothesis
   StdMeshers_LocalLength(int hypId, int studyId, SMESH_Gen * gen);
   virtual ~ StdMeshers_LocalLength();
 
-  void SetLength(double length) throw(SALOME_Exception);
-  void SetPrecision(double precision) throw(SALOME_Exception);
+  void SetLength(double length);
+  void SetPrecision(double precision);
 
   double GetLength() const;
   double GetPrecision() const;

--- a/src/3rdParty/salomesmesh/inc/StdMeshers_MaxElementArea.hxx
+++ b/src/3rdParty/salomesmesh/inc/StdMeshers_MaxElementArea.hxx
@@ -40,7 +40,7 @@ public:
   StdMeshers_MaxElementArea(int hypId, int studyId, SMESH_Gen * gen);
   virtual ~ StdMeshers_MaxElementArea();
 
-  void SetMaxArea(double maxArea) throw(SALOME_Exception);
+  void SetMaxArea(double maxArea);
 
   double GetMaxArea() const;
 

--- a/src/3rdParty/salomesmesh/inc/StdMeshers_MaxElementVolume.hxx
+++ b/src/3rdParty/salomesmesh/inc/StdMeshers_MaxElementVolume.hxx
@@ -41,8 +41,7 @@ public:
   StdMeshers_MaxElementVolume(int hypId, int studyId, SMESH_Gen* gen);
   virtual ~StdMeshers_MaxElementVolume();
 
-  void SetMaxVolume(double maxVolume)
-    throw (SALOME_Exception);
+  void SetMaxVolume(double maxVolume);
 
   double GetMaxVolume() const;
 

--- a/src/3rdParty/salomesmesh/inc/StdMeshers_MaxLength.hxx
+++ b/src/3rdParty/salomesmesh/inc/StdMeshers_MaxLength.hxx
@@ -35,7 +35,7 @@ class STDMESHERS_EXPORT StdMeshers_MaxLength: public SMESH_Hypothesis
   StdMeshers_MaxLength(int hypId, int studyId, SMESH_Gen * gen);
   virtual ~ StdMeshers_MaxLength();
 
-  void SetLength(double length) throw(SALOME_Exception);
+  void SetLength(double length);
   double GetLength() const;
 
   bool HavePreestimatedLength() const  { return _preestimated > 0.; }

--- a/src/3rdParty/salomesmesh/inc/StdMeshers_NumberOfLayers.hxx
+++ b/src/3rdParty/salomesmesh/inc/StdMeshers_NumberOfLayers.hxx
@@ -54,7 +54,7 @@ public:
   virtual ~StdMeshers_NumberOfLayers();
 
   // Sets <number of segments> parameter value
-  void SetNumberOfLayers(int numberOfLayers) throw ( SALOME_Exception );
+  void SetNumberOfLayers(int numberOfLayers);
 
   // Returns <number of layers> parameter value
   int GetNumberOfLayers() const;

--- a/src/3rdParty/salomesmesh/inc/StdMeshers_NumberOfSegments.hxx
+++ b/src/3rdParty/salomesmesh/inc/StdMeshers_NumberOfSegments.hxx
@@ -49,15 +49,14 @@ public:
   virtual ~StdMeshers_NumberOfSegments();
 
   // Builds point distribution according to passed function
-  const std::vector<double>& BuildDistributionExpr( const char*, int, int ) throw ( SALOME_Exception );
-  const std::vector<double>& BuildDistributionTab( const std::vector<double>&, int, int ) throw ( SALOME_Exception );
+  const std::vector<double>& BuildDistributionExpr( const char*, int, int );
+  const std::vector<double>& BuildDistributionTab( const std::vector<double>&, int, int );
 
   /*!
    * \brief Set the number of segments
     * \param segmentsNumber - must be greater than zero
    */
-  void SetNumberOfSegments(int segmentsNumber)
-    throw (SALOME_Exception);
+  void SetNumberOfSegments(int segmentsNumber);
 
   /*!
    * \brief Get the number of segments
@@ -78,8 +77,7 @@ public:
   /*!
    * \brief Set distribution type
    */
-  void SetDistrType(DistrType typ)
-    throw (SALOME_Exception);
+  void SetDistrType(DistrType typ);
 
   /*!
    * \brief Get distribution type
@@ -93,16 +91,14 @@ public:
    * Throws SALOME_Exception if distribution type is not DT_Scale,
    * or scaleFactor is not a positive value different from 1
    */
-  virtual void SetScaleFactor(double scaleFactor)
-    throw (SALOME_Exception);
+  virtual void SetScaleFactor(double scaleFactor);
 
   /*!
    * \brief Get scale factor for scale distribution
    * 
    * Throws SALOME_Exception if distribution type is not DT_Scale
    */
-  double GetScaleFactor() const
-    throw (SALOME_Exception);
+  double GetScaleFactor() const;
 
   /*!
    * \brief Set table function for distribution DT_TabFunc
@@ -113,16 +109,14 @@ public:
    * 
    * Throws SALOME_Exception if distribution type is not DT_TabFunc
    */
-  void SetTableFunction(const std::vector<double>& table)
-    throw (SALOME_Exception);
+  void SetTableFunction(const std::vector<double>& table);
 
   /*!
    * \brief Get table function for distribution DT_TabFunc
    * 
    * Throws SALOME_Exception if distribution type is not DT_TabFunc
    */
-  const std::vector<double>& GetTableFunction() const
-    throw (SALOME_Exception);
+  const std::vector<double>& GetTableFunction() const;
 
   /*!
    * \brief Set expression function for distribution DT_ExprFunc
@@ -131,16 +125,14 @@ public:
    * 
    * Throws SALOME_Exception if distribution type is not DT_ExprFunc
    */
-  void SetExpressionFunction( const char* expr)
-    throw (SALOME_Exception);
+  void SetExpressionFunction( const char* expr);
 
   /*!
    * \brief Get expression function for distribution DT_ExprFunc
    * 
    * Throws SALOME_Exception if distribution type is not DT_ExprFunc
    */
-  const char* GetExpressionFunction() const
-    throw (SALOME_Exception);
+  const char* GetExpressionFunction() const;
 
   /*!
    * \brief Checks validity of  the expression of the function f(t), e.g. "sin(t)".
@@ -148,8 +140,7 @@ public:
    *  \param convMode - 0 for "Exponent mode", 1 for "Cut negative mode"
    */
   static std::string CheckExpressionFunction( const std::string& expr,
-                                              const int          convMode)
-    throw (SALOME_Exception);
+                                              const int          convMode);
 
   /*!
    * \brief Set conversion mode. When it is 0, it means "exponent mode":
@@ -160,16 +151,14 @@ public:
    * 
    * Throws SALOME_Exception if distribution type is not functional
    */
-  void SetConversionMode( int conv )
-    throw (SALOME_Exception);
+  void SetConversionMode( int conv );
 
   /*!
    * \brief Returns conversion mode
    * 
    * Throws SALOME_Exception if distribution type is not functional
    */
-  int ConversionMode() const
-    throw (SALOME_Exception);
+  int ConversionMode() const;
 
   void SetReversedEdges( std::vector<int>& ids);
 

--- a/src/3rdParty/salomesmesh/inc/StdMeshers_ProjectionSource1D.hxx
+++ b/src/3rdParty/salomesmesh/inc/StdMeshers_ProjectionSource1D.hxx
@@ -56,8 +56,7 @@ public:
   /*!
    * Sets source <edge> to take a mesh pattern from
    */
-  void SetSourceEdge(const TopoDS_Shape& edge)
-    throw ( SALOME_Exception );
+  void SetSourceEdge(const TopoDS_Shape& edge);
 
   /*!
    * Returns the source edge or a group containing edges
@@ -85,8 +84,7 @@ public:
    * This parameter is optional
    */
   void SetVertexAssociation(const TopoDS_Shape& sourceVertex,
-                            const TopoDS_Shape& targetVertex)
-    throw ( SALOME_Exception );
+                            const TopoDS_Shape& targetVertex);
 
   /*!
    * Returns the vertex associated with the target vertex.

--- a/src/3rdParty/salomesmesh/inc/StdMeshers_ProjectionSource2D.hxx
+++ b/src/3rdParty/salomesmesh/inc/StdMeshers_ProjectionSource2D.hxx
@@ -56,8 +56,7 @@ public:
   /*!
    * Sets a source <face> to take a mesh pattern from
    */
-  void SetSourceFace(const TopoDS_Shape& face)
-    throw ( SALOME_Exception );
+  void SetSourceFace(const TopoDS_Shape& face);
 
   /*!
    * Returns the source face or a group containing faces
@@ -88,22 +87,21 @@ public:
   void SetVertexAssociation(const TopoDS_Shape& sourceVertex1,
                             const TopoDS_Shape& sourceVertex2,
                             const TopoDS_Shape& targetVertex1,
-                            const TopoDS_Shape& targetVertex2)
-    throw ( SALOME_Exception );
+                            const TopoDS_Shape& targetVertex2);
 
   /*!
    * Returns the <i>-th source vertex associated with the <i>-th target vertex.
    * Result may be nil if association not set.
    * Valid indices are 1 and 2
    */
-  TopoDS_Vertex GetSourceVertex(int i) const throw ( SALOME_Exception );
+  TopoDS_Vertex GetSourceVertex(int i) const;
 
   /*!
    * Returns the <i>-th target vertex associated with the <i>-th source vertex.
    * Result may be nil if association not set.
    * Valid indices are 1 and 2
    */
-  TopoDS_Vertex GetTargetVertex(int i) const throw ( SALOME_Exception );
+  TopoDS_Vertex GetTargetVertex(int i) const;
 
   /*!
    * \brief Test if vertex association defined

--- a/src/3rdParty/salomesmesh/inc/StdMeshers_ProjectionSource3D.hxx
+++ b/src/3rdParty/salomesmesh/inc/StdMeshers_ProjectionSource3D.hxx
@@ -56,8 +56,7 @@ public:
   /*!
    * Sets a source <shape> to take a mesh pattern from
    */
-  void SetSource3DShape(const TopoDS_Shape& shape)
-    throw ( SALOME_Exception );
+  void SetSource3DShape(const TopoDS_Shape& shape);
 
   /*!
    * Returns the source shape
@@ -82,20 +81,19 @@ public:
   void SetVertexAssociation(const TopoDS_Shape& sourceVertex1,
                             const TopoDS_Shape& sourceVertex2,
                             const TopoDS_Shape& targetVertex1,
-                            const TopoDS_Shape& targetVertex2)
-    throw ( SALOME_Exception );
+                            const TopoDS_Shape& targetVertex2);
 
   /*!
    * Returns the <i>-th source vertex associated with the <i>-th target vertex.
    * Result may be nil if association not set.
    */
-  TopoDS_Vertex GetSourceVertex(int i) const throw ( SALOME_Exception );
+  TopoDS_Vertex GetSourceVertex(int i) const;
 
   /*!
    * Returns the <i>-th target vertex associated with the <i>-th source vertex.
    * Result may be nil if association not set.
    */
-  TopoDS_Vertex GetTargetVertex(int i) const throw ( SALOME_Exception );
+  TopoDS_Vertex GetTargetVertex(int i) const;
 
   /*!
    * \brief Test if vertex association defined

--- a/src/3rdParty/salomesmesh/inc/StdMeshers_SegmentLengthAroundVertex.hxx
+++ b/src/3rdParty/salomesmesh/inc/StdMeshers_SegmentLengthAroundVertex.hxx
@@ -43,7 +43,7 @@ class STDMESHERS_EXPORT StdMeshers_SegmentLengthAroundVertex:public SMESH_Hypoth
   StdMeshers_SegmentLengthAroundVertex(int hypId, int studyId, SMESH_Gen * gen);
   virtual ~ StdMeshers_SegmentLengthAroundVertex();
 
-  void SetLength(double length) throw(SALOME_Exception);
+  void SetLength(double length);
 
   double GetLength() const;
 

--- a/src/3rdParty/salomesmesh/inc/StdMeshers_StartEndLength.hxx
+++ b/src/3rdParty/salomesmesh/inc/StdMeshers_StartEndLength.hxx
@@ -40,7 +40,7 @@ class STDMESHERS_EXPORT StdMeshers_StartEndLength:public SMESH_Hypothesis
   StdMeshers_StartEndLength(int hypId, int studyId, SMESH_Gen * gen);
   virtual ~ StdMeshers_StartEndLength();
 
-  void SetLength(double length, bool isStartLength) throw(SALOME_Exception);
+  void SetLength(double length, bool isStartLength);
 
   double GetLength(bool isStartLength) const;
 

--- a/src/3rdParty/salomesmesh/src/NETGENPlugin/NETGENPlugin_SimpleHypothesis_2D.cpp
+++ b/src/3rdParty/salomesmesh/src/NETGENPlugin/NETGENPlugin_SimpleHypothesis_2D.cpp
@@ -59,7 +59,7 @@ NETGENPlugin_SimpleHypothesis_2D::NETGENPlugin_SimpleHypothesis_2D (int         
  *  
  */
 //=============================================================================
-void NETGENPlugin_SimpleHypothesis_2D::SetNumberOfSegments(int nb) throw (SALOME_Exception)
+void NETGENPlugin_SimpleHypothesis_2D::SetNumberOfSegments(int nb)
 {
   if ( nb < 1 )
     throw SALOME_Exception("Number of segments must be positive");
@@ -77,7 +77,6 @@ void NETGENPlugin_SimpleHypothesis_2D::SetNumberOfSegments(int nb) throw (SALOME
  */
 //=============================================================================
 void NETGENPlugin_SimpleHypothesis_2D::SetLocalLength(double segmentLength)
-  throw (SALOME_Exception)
 {
   if ( segmentLength < DBL_MIN )
     throw SALOME_Exception("segment length must be more than zero");

--- a/src/3rdParty/salomesmesh/src/SMDS/SMDS_Mesh.cpp
+++ b/src/3rdParty/salomesmesh/src/SMDS/SMDS_Mesh.cpp
@@ -78,7 +78,7 @@ int SMDS_Mesh::chunkSize = 1024;
  */
 //================================================================================
 
-int SMDS_Mesh::CheckMemory(const bool doNotRaise) throw (std::bad_alloc)
+int SMDS_Mesh::CheckMemory(const bool doNotRaise)
 {
 #if 0
 #if (defined(__MACH__) && defined(__APPLE__))

--- a/src/3rdParty/salomesmesh/src/SMDS/SMDS_VolumeTool.cpp
+++ b/src/3rdParty/salomesmesh/src/SMDS/SMDS_VolumeTool.cpp
@@ -1468,9 +1468,13 @@ bool SMDS_VolumeTool::IsLinked (const int theNode1Index,
     {
       switch ( minInd ) {
       case 0: if( maxInd==4 ||  maxInd==6 ||  maxInd==7 ) return true;
+          /* FALLTHRU */
       case 1: if( maxInd==4 ||  maxInd==5 ||  maxInd==8 ) return true;
+          /* FALLTHRU */
       case 2: if( maxInd==5 ||  maxInd==6 ||  maxInd==9 ) return true;
+          /* FALLTHRU */
       case 3: if( maxInd==7 ||  maxInd==8 ||  maxInd==9 ) return true;
+          /* FALLTHRU */
       default:;
       }
       break;
@@ -1479,13 +1483,21 @@ bool SMDS_VolumeTool::IsLinked (const int theNode1Index,
     {
       switch ( minInd ) {
       case 0: if( maxInd==8 ||  maxInd==11 ||  maxInd==16 ) return true;
+          /* FALLTHRU */
       case 1: if( maxInd==8 ||  maxInd==9 ||  maxInd==17 ) return true;
+          /* FALLTHRU */
       case 2: if( maxInd==9 ||  maxInd==10 ||  maxInd==18 ) return true;
+          /* FALLTHRU */
       case 3: if( maxInd==10 ||  maxInd==11 ||  maxInd==19 ) return true;
+          /* FALLTHRU */
       case 4: if( maxInd==12 ||  maxInd==15 ||  maxInd==16 ) return true;
+          /* FALLTHRU */
       case 5: if( maxInd==12 ||  maxInd==13 ||  maxInd==17 ) return true;
+          /* FALLTHRU */
       case 6: if( maxInd==13 ||  maxInd==14 ||  maxInd==18 ) return true;
+          /* FALLTHRU */
       case 7: if( maxInd==14 ||  maxInd==15 ||  maxInd==19 ) return true;
+          /* FALLTHRU */
       default:;
       }
       break;
@@ -1494,9 +1506,13 @@ bool SMDS_VolumeTool::IsLinked (const int theNode1Index,
     {
       switch ( minInd ) {
       case 0: if( maxInd==5 ||  maxInd==8 ||  maxInd==9 ) return true;
+          /* FALLTHRU */
       case 1: if( maxInd==5 ||  maxInd==6 ||  maxInd==10 ) return true;
+          /* FALLTHRU */
       case 2: if( maxInd==6 ||  maxInd==7 ||  maxInd==11 ) return true;
+          /* FALLTHRU */
       case 3: if( maxInd==7 ||  maxInd==8 ||  maxInd==12 ) return true;
+          /* FALLTHRU */
       case 4: if( maxInd==9 ||  maxInd==10 ||  maxInd==11 ||  maxInd==12 ) return true;
       default:;
       }
@@ -1506,11 +1522,17 @@ bool SMDS_VolumeTool::IsLinked (const int theNode1Index,
     {
       switch ( minInd ) {
       case 0: if( maxInd==6 ||  maxInd==8 ||  maxInd==12 ) return true;
+          /* FALLTHRU */
       case 1: if( maxInd==6 ||  maxInd==7 ||  maxInd==13 ) return true;
+          /* FALLTHRU */
       case 2: if( maxInd==7 ||  maxInd==8 ||  maxInd==14 ) return true;
+          /* FALLTHRU */
       case 3: if( maxInd==9 ||  maxInd==11 ||  maxInd==12 ) return true;
+          /* FALLTHRU */
       case 4: if( maxInd==9 ||  maxInd==10 ||  maxInd==13 ) return true;
+          /* FALLTHRU */
       case 5: if( maxInd==10 ||  maxInd==11 ||  maxInd==14 ) return true;
+          /* FALLTHRU */
       default:;
       }
       break;

--- a/src/3rdParty/salomesmesh/src/SMESH/MED_Structures.cpp
+++ b/src/3rdParty/salomesmesh/src/SMESH/MED_Structures.cpp
@@ -663,8 +663,10 @@ TGrilleInfo
     switch(aDim){
     case 3:
       aCoord[2] = myCoord[aDim*theId+2];
+      /* FALLTHRU */
     case 2:
       aCoord[1] = myCoord[aDim*theId+1];
+      /* FALLTHRU */
     case 1:{
       aCoord[0] = myCoord[aDim*theId];
       break;

--- a/src/3rdParty/salomesmesh/src/SMESH/SMESH_Gen.cpp
+++ b/src/3rdParty/salomesmesh/src/SMESH/SMESH_Gen.cpp
@@ -109,7 +109,6 @@ SMESH_Gen::~SMESH_Gen()
 //=============================================================================
 
 SMESH_Mesh* SMESH_Gen::CreateMesh(int theStudyId, bool theIsEmbeddedMode)
-  throw(SALOME_Exception)
 {
   Unexpect aCatch(SalomeException);
   MESSAGE("SMESH_Gen::CreateMesh");

--- a/src/3rdParty/salomesmesh/src/SMESH/SMESH_Mesh.cpp
+++ b/src/3rdParty/salomesmesh/src/SMESH/SMESH_Mesh.cpp
@@ -670,7 +670,7 @@ SMESH_ComputeErrorPtr SMESH_Mesh::GMFToMesh(const char* theFileName,
 SMESH_Hypothesis::Hypothesis_Status
 SMESH_Mesh::AddHypothesis(const TopoDS_Shape & aSubShape,
                           int                  anHypId,
-                          std::string*         anError  ) throw(SALOME_Exception)
+                          std::string*         anError  )
 {
   Unexpect aCatch(SalomeException);
   if(MYDEBUG) MESSAGE("SMESH_Mesh::AddHypothesis");
@@ -764,7 +764,7 @@ SMESH_Mesh::AddHypothesis(const TopoDS_Shape & aSubShape,
 
 SMESH_Hypothesis::Hypothesis_Status
   SMESH_Mesh::RemoveHypothesis(const TopoDS_Shape & aSubShape,
-                               int anHypId)throw(SALOME_Exception)
+                               int anHypId)
 {
   Unexpect aCatch(SalomeException);
   if(MYDEBUG) MESSAGE("SMESH_Mesh::RemoveHypothesis");
@@ -836,7 +836,6 @@ SMESH_Hypothesis::Hypothesis_Status
 
 const list<const SMESHDS_Hypothesis*>&
 SMESH_Mesh::GetHypothesisList(const TopoDS_Shape & aSubShape) const
-  throw(SALOME_Exception)
 {
   return _myMeshDS->GetHypothesis(aSubShape);
 }
@@ -1045,7 +1044,7 @@ SMESH_Hypothesis * SMESH_Mesh::GetHypothesis(const int anHypId) const
  */
 //=============================================================================
 
-const list<SMESHDS_Command*> & SMESH_Mesh::GetLog() throw(SALOME_Exception)
+const list<SMESHDS_Command*> & SMESH_Mesh::GetLog()
 {
   Unexpect aCatch(SalomeException);
   if(MYDEBUG) MESSAGE("SMESH_Mesh::GetLog");
@@ -1057,7 +1056,7 @@ const list<SMESHDS_Command*> & SMESH_Mesh::GetLog() throw(SALOME_Exception)
  * 
  */
 //=============================================================================
-void SMESH_Mesh::ClearLog() throw(SALOME_Exception)
+void SMESH_Mesh::ClearLog()
 {
   Unexpect aCatch(SalomeException);
   if(MYDEBUG) MESSAGE("SMESH_Mesh::ClearLog");
@@ -1071,7 +1070,6 @@ void SMESH_Mesh::ClearLog() throw(SALOME_Exception)
 //=============================================================================
 
 SMESH_subMesh *SMESH_Mesh::GetSubMesh(const TopoDS_Shape & aSubShape)
-  throw(SALOME_Exception)
 {
   int index = _myMeshDS->ShapeToIndex(aSubShape);
   if ( !index && aSubShape.IsNull() )
@@ -1123,7 +1121,6 @@ SMESH_subMesh *SMESH_Mesh::GetSubMesh(const TopoDS_Shape & aSubShape)
 //=============================================================================
 
 SMESH_subMesh *SMESH_Mesh::GetSubMeshContaining(const TopoDS_Shape & aSubShape) const
-  throw(SALOME_Exception)
 {
   int index = _myMeshDS->ShapeToIndex(aSubShape);
   return GetSubMeshContaining( index );
@@ -1137,7 +1134,6 @@ SMESH_subMesh *SMESH_Mesh::GetSubMeshContaining(const TopoDS_Shape & aSubShape) 
 //=============================================================================
 
 SMESH_subMesh *SMESH_Mesh::GetSubMeshContaining(const int aShapeID) const
-throw(SALOME_Exception)
 {
   SMESH_subMesh *aSubMesh = _subMeshHolder->Get( aShapeID );
 
@@ -1152,7 +1148,6 @@ throw(SALOME_Exception)
 
 list<SMESH_subMesh*>
 SMESH_Mesh::GetGroupSubMeshesContaining(const TopoDS_Shape & aSubShape) const
-  throw(SALOME_Exception)
 {
   list<SMESH_subMesh*> found;
 
@@ -1321,13 +1316,13 @@ void SMESH_Mesh::NotifySubMeshesHypothesisModification(const SMESH_Hypothesis* h
  *  Auto color functionality
  */
 //=============================================================================
-void SMESH_Mesh::SetAutoColor(bool theAutoColor) throw(SALOME_Exception)
+void SMESH_Mesh::SetAutoColor(bool theAutoColor)
 {
   Unexpect aCatch(SalomeException);
   _isAutoColor = theAutoColor;
 }
 
-bool SMESH_Mesh::GetAutoColor() throw(SALOME_Exception)
+bool SMESH_Mesh::GetAutoColor()
 {
   Unexpect aCatch(SalomeException);
   return _isAutoColor;
@@ -1435,7 +1430,6 @@ void SMESH_Mesh::ExportMED(const char *        file,
                            const SMESHDS_Mesh* meshPart,
                            bool                theAutoDimension,
                            bool                theAddODOnVertices)
-  throw(SALOME_Exception)
 {
   SMESH_TRY;
 
@@ -1498,7 +1492,6 @@ void SMESH_Mesh::ExportMED(const char *        file,
 void SMESH_Mesh::ExportSAUV(const char *file, 
                             const char* theMeshName, 
                             bool theAutoGroups)
-  throw(SALOME_Exception)
 {
   std::string medfilename(file);
   medfilename += ".med";
@@ -1540,7 +1533,7 @@ void SMESH_Mesh::ExportSAUV(const char *file,
 //================================================================================
 
 void SMESH_Mesh::ExportDAT(const char *        file,
-                           const SMESHDS_Mesh* meshPart) throw(SALOME_Exception)
+                           const SMESHDS_Mesh* meshPart)
 {
   Unexpect aCatch(SalomeException);
   DriverDAT_W_SMDS_Mesh myWriter;
@@ -1557,7 +1550,7 @@ void SMESH_Mesh::ExportDAT(const char *        file,
 //================================================================================
 
 void SMESH_Mesh::ExportUNV(const char *        file,
-                           const SMESHDS_Mesh* meshPart) throw(SALOME_Exception)
+                           const SMESHDS_Mesh* meshPart)
 {
   Unexpect aCatch(SalomeException);
   DriverUNV_W_SMDS_Mesh myWriter;
@@ -1589,7 +1582,7 @@ void SMESH_Mesh::ExportUNV(const char *        file,
 
 void SMESH_Mesh::ExportSTL(const char *        file,
                            const bool          isascii,
-                           const SMESHDS_Mesh* meshPart) throw(SALOME_Exception)
+                           const SMESHDS_Mesh* meshPart)
 {
   Unexpect aCatch(SalomeException);
   DriverSTL_W_SMDS_Mesh myWriter;
@@ -1722,7 +1715,7 @@ double SMESH_Mesh::GetComputeProgress() const
  */
 //================================================================================
 
-int SMESH_Mesh::NbNodes() const throw(SALOME_Exception)
+int SMESH_Mesh::NbNodes() const
 {
   Unexpect aCatch(SalomeException);
   return _myMeshDS->NbNodes();
@@ -1734,7 +1727,7 @@ int SMESH_Mesh::NbNodes() const throw(SALOME_Exception)
  */
 //================================================================================
 
-int SMESH_Mesh::Nb0DElements() const throw(SALOME_Exception)
+int SMESH_Mesh::Nb0DElements() const
 {
   Unexpect aCatch(SalomeException);
   return _myMeshDS->GetMeshInfo().Nb0DElements();
@@ -1746,7 +1739,7 @@ int SMESH_Mesh::Nb0DElements() const throw(SALOME_Exception)
  */
 //================================================================================
 
-int SMESH_Mesh::NbEdges(SMDSAbs_ElementOrder order) const throw(SALOME_Exception)
+int SMESH_Mesh::NbEdges(SMDSAbs_ElementOrder order) const
 {
   Unexpect aCatch(SalomeException);
   return _myMeshDS->GetMeshInfo().NbEdges(order);
@@ -1758,7 +1751,7 @@ int SMESH_Mesh::NbEdges(SMDSAbs_ElementOrder order) const throw(SALOME_Exception
  */
 //================================================================================
 
-int SMESH_Mesh::NbFaces(SMDSAbs_ElementOrder order) const throw(SALOME_Exception)
+int SMESH_Mesh::NbFaces(SMDSAbs_ElementOrder order) const
 {
   Unexpect aCatch(SalomeException);
   return _myMeshDS->GetMeshInfo().NbFaces(order);
@@ -1770,7 +1763,7 @@ int SMESH_Mesh::NbFaces(SMDSAbs_ElementOrder order) const throw(SALOME_Exception
  */
 //================================================================================
 
-int SMESH_Mesh::NbTriangles(SMDSAbs_ElementOrder order) const throw(SALOME_Exception)
+int SMESH_Mesh::NbTriangles(SMDSAbs_ElementOrder order) const
 {
   Unexpect aCatch(SalomeException);
   return _myMeshDS->GetMeshInfo().NbTriangles(order);
@@ -1782,7 +1775,7 @@ int SMESH_Mesh::NbTriangles(SMDSAbs_ElementOrder order) const throw(SALOME_Excep
  */
 //================================================================================
 
-int SMESH_Mesh::NbBiQuadTriangles() const throw(SALOME_Exception)
+int SMESH_Mesh::NbBiQuadTriangles() const
 {
   Unexpect aCatch(SalomeException);
   return _myMeshDS->GetMeshInfo().NbBiQuadTriangles();
@@ -1794,7 +1787,7 @@ int SMESH_Mesh::NbBiQuadTriangles() const throw(SALOME_Exception)
  */
 //================================================================================
 
-int SMESH_Mesh::NbQuadrangles(SMDSAbs_ElementOrder order) const throw(SALOME_Exception)
+int SMESH_Mesh::NbQuadrangles(SMDSAbs_ElementOrder order) const
 {
   Unexpect aCatch(SalomeException);
   return _myMeshDS->GetMeshInfo().NbQuadrangles(order);
@@ -1806,7 +1799,7 @@ int SMESH_Mesh::NbQuadrangles(SMDSAbs_ElementOrder order) const throw(SALOME_Exc
  */
 //================================================================================
 
-int SMESH_Mesh::NbBiQuadQuadrangles() const throw(SALOME_Exception)
+int SMESH_Mesh::NbBiQuadQuadrangles() const
 {
   Unexpect aCatch(SalomeException);
   return _myMeshDS->GetMeshInfo().NbBiQuadQuadrangles();
@@ -1818,7 +1811,7 @@ int SMESH_Mesh::NbBiQuadQuadrangles() const throw(SALOME_Exception)
  */
 //================================================================================
 
-int SMESH_Mesh::NbPolygons(SMDSAbs_ElementOrder order) const throw(SALOME_Exception)
+int SMESH_Mesh::NbPolygons(SMDSAbs_ElementOrder order) const
 {
   Unexpect aCatch(SalomeException);
   return _myMeshDS->GetMeshInfo().NbPolygons(order);
@@ -1830,7 +1823,7 @@ int SMESH_Mesh::NbPolygons(SMDSAbs_ElementOrder order) const throw(SALOME_Except
  */
 //================================================================================
 
-int SMESH_Mesh::NbVolumes(SMDSAbs_ElementOrder order) const throw(SALOME_Exception)
+int SMESH_Mesh::NbVolumes(SMDSAbs_ElementOrder order) const
 {
   Unexpect aCatch(SalomeException);
   return _myMeshDS->GetMeshInfo().NbVolumes(order);
@@ -1842,7 +1835,7 @@ int SMESH_Mesh::NbVolumes(SMDSAbs_ElementOrder order) const throw(SALOME_Excepti
  */
 //================================================================================
 
-int SMESH_Mesh::NbTetras(SMDSAbs_ElementOrder order) const throw(SALOME_Exception)
+int SMESH_Mesh::NbTetras(SMDSAbs_ElementOrder order) const
 {
   Unexpect aCatch(SalomeException);
   return _myMeshDS->GetMeshInfo().NbTetras(order);
@@ -1854,7 +1847,7 @@ int SMESH_Mesh::NbTetras(SMDSAbs_ElementOrder order) const throw(SALOME_Exceptio
  */
 //================================================================================
 
-int SMESH_Mesh::NbHexas(SMDSAbs_ElementOrder order) const throw(SALOME_Exception)
+int SMESH_Mesh::NbHexas(SMDSAbs_ElementOrder order) const
 {
   Unexpect aCatch(SalomeException);
   return _myMeshDS->GetMeshInfo().NbHexas(order);
@@ -1866,7 +1859,7 @@ int SMESH_Mesh::NbHexas(SMDSAbs_ElementOrder order) const throw(SALOME_Exception
  */
 //================================================================================
 
-int SMESH_Mesh::NbTriQuadraticHexas() const throw(SALOME_Exception)
+int SMESH_Mesh::NbTriQuadraticHexas() const
 {
   Unexpect aCatch(SalomeException);
   return _myMeshDS->GetMeshInfo().NbTriQuadHexas();
@@ -1878,7 +1871,7 @@ int SMESH_Mesh::NbTriQuadraticHexas() const throw(SALOME_Exception)
  */
 //================================================================================
 
-int SMESH_Mesh::NbPyramids(SMDSAbs_ElementOrder order) const throw(SALOME_Exception)
+int SMESH_Mesh::NbPyramids(SMDSAbs_ElementOrder order) const
 {
   Unexpect aCatch(SalomeException);
   return _myMeshDS->GetMeshInfo().NbPyramids(order);
@@ -1890,7 +1883,7 @@ int SMESH_Mesh::NbPyramids(SMDSAbs_ElementOrder order) const throw(SALOME_Except
  */
 //================================================================================
 
-int SMESH_Mesh::NbPrisms(SMDSAbs_ElementOrder order) const throw(SALOME_Exception)
+int SMESH_Mesh::NbPrisms(SMDSAbs_ElementOrder order) const
 {
   Unexpect aCatch(SalomeException);
   return _myMeshDS->GetMeshInfo().NbPrisms(order);
@@ -1902,7 +1895,7 @@ int SMESH_Mesh::NbPrisms(SMDSAbs_ElementOrder order) const throw(SALOME_Exceptio
  */
 //================================================================================
 
-int SMESH_Mesh::NbHexagonalPrisms() const throw(SALOME_Exception)
+int SMESH_Mesh::NbHexagonalPrisms() const
 {
   Unexpect aCatch(SalomeException);
   return _myMeshDS->GetMeshInfo().NbHexPrisms();
@@ -1914,7 +1907,7 @@ int SMESH_Mesh::NbHexagonalPrisms() const throw(SALOME_Exception)
  */
 //================================================================================
 
-int SMESH_Mesh::NbPolyhedrons() const throw(SALOME_Exception)
+int SMESH_Mesh::NbPolyhedrons() const
 {
   Unexpect aCatch(SalomeException);
   return _myMeshDS->GetMeshInfo().NbPolyhedrons();
@@ -1926,7 +1919,7 @@ int SMESH_Mesh::NbPolyhedrons() const throw(SALOME_Exception)
  */
 //================================================================================
 
-int SMESH_Mesh::NbBalls() const throw(SALOME_Exception)
+int SMESH_Mesh::NbBalls() const
 {
   Unexpect aCatch(SalomeException);
   return _myMeshDS->GetMeshInfo().NbBalls();
@@ -1938,7 +1931,7 @@ int SMESH_Mesh::NbBalls() const throw(SALOME_Exception)
  */
 //================================================================================
 
-int SMESH_Mesh::NbSubMesh() const throw(SALOME_Exception)
+int SMESH_Mesh::NbSubMesh() const
 {
   Unexpect aCatch(SalomeException);
   return _myMeshDS->NbSubMesh();
@@ -2006,7 +1999,7 @@ SMESH_Group* SMESH_Mesh::AddGroup (const SMDSAbs_ElementType theType,
  */
 //================================================================================
 
-SMESH_Group* SMESH_Mesh::AddGroup (SMESHDS_GroupBase* groupDS) throw(SALOME_Exception)
+SMESH_Group* SMESH_Mesh::AddGroup (SMESHDS_GroupBase* groupDS)
 {
   if ( !groupDS ) 
     throw SALOME_Exception(LOCALIZED ("SMESH_Mesh::AddGroup(): NULL SMESHDS_GroupBase"));

--- a/src/3rdParty/salomesmesh/src/SMESH/SMESH_Pattern.cpp
+++ b/src/3rdParty/salomesmesh/src/SMESH/SMESH_Pattern.cpp
@@ -178,6 +178,7 @@ int readLine (list <const char*> & theFields,
     case '+':
     case '.':
       isNumber = true;
+      /* FALLTHRU */
     default: // data
       isNumber = isNumber || ( *theLineBeg >= '0' && *theLineBeg <= '9' );
       if ( isNumber ) {
@@ -4249,11 +4250,13 @@ void SMESH_Pattern::createElements(SMESH_Mesh*                            theMes
           elem = aMeshDS->AddFace (nodes[0], nodes[1], nodes[2], nodes[3],
                                    nodes[4], nodes[5] ); break;
         } // else do not break but create a polygon
+        /* FALLTHRU */
       case 8:
         if ( !onMeshElements ) {// create a quadratic face
           elem = aMeshDS->AddFace (nodes[0], nodes[1], nodes[2], nodes[3],
                                    nodes[4], nodes[5], nodes[6], nodes[7] ); break;
         } // else do not break but create a polygon
+        /* FALLTHRU */
       default:
         elem = aMeshDS->AddPolygonalFace( nodes );
       }

--- a/src/3rdParty/salomesmesh/src/SMESH/SMESH_subMesh.cpp
+++ b/src/3rdParty/salomesmesh/src/SMESH/SMESH_subMesh.cpp
@@ -1420,6 +1420,7 @@ bool SMESH_subMesh::ComputeStateEngine(int event)
     case SUBMESH_LOADED:
       loadDependentMeshes();
       ComputeSubMeshStateEngine( SUBMESH_LOADED );
+      /* FALLTHRU */
       //break;
     case CHECK_COMPUTE_STATE:
       if ( IsMeshComputed() )
@@ -1662,6 +1663,7 @@ bool SMESH_subMesh::ComputeStateEngine(int event)
     case SUBMESH_LOADED:
       loadDependentMeshes();
       ComputeSubMeshStateEngine( SUBMESH_LOADED );
+      /* FALLTHRU */
       //break;
     case CHECK_COMPUTE_STATE:
       if ( IsMeshComputed() )

--- a/src/3rdParty/salomesmesh/src/StdMeshers/StdMeshers_Adaptive1D.cpp
+++ b/src/3rdParty/salomesmesh/src/StdMeshers/StdMeshers_Adaptive1D.cpp
@@ -937,7 +937,6 @@ StdMeshers_Adaptive1D::~StdMeshers_Adaptive1D()
 //function : SetDeflection
 //purpose  : 
 void StdMeshers_Adaptive1D::SetDeflection(double value)
-  throw(SALOME_Exception)
 {
   if (value <= std::numeric_limits<double>::min() )
     throw SALOME_Exception("Deflection must be greater that zero");
@@ -951,7 +950,6 @@ void StdMeshers_Adaptive1D::SetDeflection(double value)
 //function : SetMinSize
 //purpose  : Sets minimal allowed segment length
 void StdMeshers_Adaptive1D::SetMinSize(double minSize)
-  throw(SALOME_Exception)
 {
   if (minSize <= std::numeric_limits<double>::min() )
     throw SALOME_Exception("Min size must be greater that zero");
@@ -966,7 +964,6 @@ void StdMeshers_Adaptive1D::SetMinSize(double minSize)
 //function : SetMaxSize
 //purpose  : Sets maximal allowed segment length
 void StdMeshers_Adaptive1D::SetMaxSize(double maxSize)
-  throw(SALOME_Exception)
 {
   if (maxSize <= std::numeric_limits<double>::min() )
     throw SALOME_Exception("Max size must be greater that zero");

--- a/src/3rdParty/salomesmesh/src/StdMeshers/StdMeshers_Arithmetic1D.cpp
+++ b/src/3rdParty/salomesmesh/src/StdMeshers/StdMeshers_Arithmetic1D.cpp
@@ -74,7 +74,6 @@ StdMeshers_Arithmetic1D::~StdMeshers_Arithmetic1D()
 //=============================================================================
 
 void StdMeshers_Arithmetic1D::SetLength(double length, bool isStartLength)
-     throw(SALOME_Exception)
 {
   if ( (isStartLength ? _begLength : _endLength) != length ) {
     if (length <= 0)

--- a/src/3rdParty/salomesmesh/src/StdMeshers/StdMeshers_AutomaticLength.cpp
+++ b/src/3rdParty/salomesmesh/src/StdMeshers/StdMeshers_AutomaticLength.cpp
@@ -84,7 +84,6 @@ const double theCoarseConst = 0.5;
 const double theFineConst   = 4.5;
 
 void StdMeshers_AutomaticLength::SetFineness(double theFineness)
-  throw(SALOME_Exception)
 {
   if ( theFineness < 0.0 || theFineness > 1.0 )
     throw SALOME_Exception(LOCALIZED("theFineness is out of range [0.0-1.0]"));
@@ -239,7 +238,6 @@ namespace {
 
 double StdMeshers_AutomaticLength::GetLength(const SMESH_Mesh* theMesh,
                                              const double      theEdgeLength)
-  throw(SALOME_Exception)
 {
   if ( !theMesh ) throw SALOME_Exception(LOCALIZED("NULL Mesh"));
 
@@ -261,7 +259,6 @@ double StdMeshers_AutomaticLength::GetLength(const SMESH_Mesh* theMesh,
 
 double StdMeshers_AutomaticLength::GetLength(const SMESH_Mesh*   theMesh,
                                              const TopoDS_Shape& anEdge)
-  throw(SALOME_Exception)
 {
   if ( !theMesh ) throw SALOME_Exception(LOCALIZED("NULL Mesh"));
 

--- a/src/3rdParty/salomesmesh/src/StdMeshers/StdMeshers_CartesianParameters3D.cpp
+++ b/src/3rdParty/salomesmesh/src/StdMeshers/StdMeshers_CartesianParameters3D.cpp
@@ -131,7 +131,6 @@ namespace
   void checkGridSpacing(std::vector<std::string>& spaceFunctions,
                         std::vector<double>&      internalPoints,
                         const std::string&        axis)
-    throw ( SALOME_Exception )
   {
     if ( spaceFunctions.empty() )
       throw SALOME_Exception(SMESH_Comment("Empty space function for ") << axis );
@@ -168,7 +167,6 @@ namespace
 //=======================================================================
 
 void StdMeshers_CartesianParameters3D::SetGrid(std::vector<double>& coords, int axis)
-  throw ( SALOME_Exception )
 {
   checkAxis( axis );
 
@@ -196,7 +194,6 @@ void StdMeshers_CartesianParameters3D::SetGrid(std::vector<double>& coords, int 
 void StdMeshers_CartesianParameters3D::SetGridSpacing(std::vector<string>& xSpaceFuns,
                                                       std::vector<double>& xInternalPoints,
                                                       const int            axis)
-  throw ( SALOME_Exception )
 {
   checkAxis( axis );
 
@@ -250,7 +247,6 @@ bool StdMeshers_CartesianParameters3D::GetFixedPoint(double p[3]) const
 //=======================================================================
 
 void StdMeshers_CartesianParameters3D::SetSizeThreshold(const double threshold)
-  throw ( SALOME_Exception )
 {
   if ( threshold <= 1.0 )
     throw SALOME_Exception(LOCALIZED("threshold must be > 1.0"));
@@ -270,7 +266,6 @@ void StdMeshers_CartesianParameters3D::SetSizeThreshold(const double threshold)
 void StdMeshers_CartesianParameters3D::GetGridSpacing(std::vector<std::string>& spaceFunctions,
                                                       std::vector<double>&      internalPoints,
                                                       const int                 axis) const
-  throw ( SALOME_Exception )
 {
   if ( !IsGridBySpacing(axis) )
     throw SALOME_Exception(LOCALIZED("The grid is defined by coordinates and not by spacing"));
@@ -284,7 +279,6 @@ void StdMeshers_CartesianParameters3D::GetGridSpacing(std::vector<std::string>& 
 //=======================================================================
 
 bool StdMeshers_CartesianParameters3D::IsGridBySpacing(const int axis) const
-  throw ( SALOME_Exception )
 {
   checkAxis(axis);
   return !_spaceFunctions[axis].empty();
@@ -303,7 +297,6 @@ void StdMeshers_CartesianParameters3D::ComputeCoordinates(const double    x0,
                                                           vector<double>& coords,
                                                           const string&   axis,
                                                           const double*   xForced )
-  throw ( SALOME_Exception )
 {
   checkGridSpacing( theSpaceFuns, thePoints, axis );
 
@@ -402,7 +395,6 @@ void StdMeshers_CartesianParameters3D::GetCoordinates(std::vector<double>& xNode
                                                       std::vector<double>& yNodes,
                                                       std::vector<double>& zNodes,
                                                       const Bnd_Box&       bndBox) const
-  throw ( SALOME_Exception )
 {
   double x0,y0,z0, x1,y1,z1;
   if ( IsGridBySpacing(0) || IsGridBySpacing(1) || IsGridBySpacing(2))
@@ -654,7 +646,6 @@ ComputeOptimalAxesDirs(const TopoDS_Shape& shape,
 //=======================================================================
 
 void StdMeshers_CartesianParameters3D::SetAxisDirs(const double* the9DirComps)
-  throw ( SALOME_Exception )
 {
   gp_Vec x( the9DirComps[0],
             the9DirComps[1],
@@ -696,7 +687,6 @@ void StdMeshers_CartesianParameters3D::SetAxisDirs(const double* the9DirComps)
 //=======================================================================
 
 void StdMeshers_CartesianParameters3D::GetGrid(std::vector<double>& coords, int axis) const
-  throw ( SALOME_Exception )
 {
   if ( IsGridBySpacing(axis) )
     throw SALOME_Exception(LOCALIZED("The grid is defined by spacing and not by coordinates"));

--- a/src/3rdParty/salomesmesh/src/StdMeshers/StdMeshers_Deflection1D.cpp
+++ b/src/3rdParty/salomesmesh/src/StdMeshers/StdMeshers_Deflection1D.cpp
@@ -76,7 +76,6 @@ StdMeshers_Deflection1D::~StdMeshers_Deflection1D()
 //=============================================================================
 
 void StdMeshers_Deflection1D::SetDeflection(double value)
-     throw(SALOME_Exception)
 {
   if (_value != value) {
     if (value <= 0.)

--- a/src/3rdParty/salomesmesh/src/StdMeshers/StdMeshers_FixedPoints1D.cpp
+++ b/src/3rdParty/salomesmesh/src/StdMeshers/StdMeshers_FixedPoints1D.cpp
@@ -72,7 +72,6 @@ StdMeshers_FixedPoints1D::~StdMeshers_FixedPoints1D()
 //=============================================================================
 
 void StdMeshers_FixedPoints1D::SetPoints(std::vector<double>& listParams)
-                              throw(SALOME_Exception)
 {
   _params = listParams;
   NotifySubMeshesHypothesisModification();
@@ -85,7 +84,6 @@ void StdMeshers_FixedPoints1D::SetPoints(std::vector<double>& listParams)
 //=============================================================================
 
 void StdMeshers_FixedPoints1D::SetNbSegments(std::vector<int>& listNbSeg) 
-                              throw(SALOME_Exception)
 {
   _nbsegs = listNbSeg;
   NotifySubMeshesHypothesisModification();

--- a/src/3rdParty/salomesmesh/src/StdMeshers/StdMeshers_Geometric1D.cpp
+++ b/src/3rdParty/salomesmesh/src/StdMeshers/StdMeshers_Geometric1D.cpp
@@ -57,7 +57,6 @@ StdMeshers_Geometric1D::StdMeshers_Geometric1D(int hypId, int studyId, SMESH_Gen
 //=============================================================================
 
 void StdMeshers_Geometric1D::SetStartLength(double length)
-  throw(SALOME_Exception)
 {
   if ( _begLength != length )
   {
@@ -75,7 +74,6 @@ void StdMeshers_Geometric1D::SetStartLength(double length)
 //=============================================================================
 
 void StdMeshers_Geometric1D::SetCommonRatio(double factor)
-  throw(SALOME_Exception)
 {
   if ( _ratio != factor )
   {

--- a/src/3rdParty/salomesmesh/src/StdMeshers/StdMeshers_Import_1D.cpp
+++ b/src/3rdParty/salomesmesh/src/StdMeshers/StdMeshers_Import_1D.cpp
@@ -188,6 +188,7 @@ namespace // INTERNAL STUFF
         case TopAbs_EDGE:
           if ( SMESH_Algo::isDegenerated( TopoDS::Edge( sm->GetSubShape() )))
             continue;
+          /* FALLTHRU */
         case TopAbs_FACE:
           _subM.insert( sm );
           if ( !sm->IsEmpty() )

--- a/src/3rdParty/salomesmesh/src/StdMeshers/StdMeshers_LayerDistribution.cpp
+++ b/src/3rdParty/salomesmesh/src/StdMeshers/StdMeshers_LayerDistribution.cpp
@@ -70,7 +70,6 @@ StdMeshers_LayerDistribution::~StdMeshers_LayerDistribution()
 //=============================================================================
 
 void StdMeshers_LayerDistribution::SetLayerDistribution(SMESH_Hypothesis* hyp1D)
-  throw ( SALOME_Exception )
 {
   if ( myHyp != hyp1D ) {
     if ( myHyp && hyp1D->GetDim() != 1 )

--- a/src/3rdParty/salomesmesh/src/StdMeshers/StdMeshers_LengthFromEdges.cpp
+++ b/src/3rdParty/salomesmesh/src/StdMeshers/StdMeshers_LengthFromEdges.cpp
@@ -63,7 +63,6 @@ StdMeshers_LengthFromEdges::~StdMeshers_LengthFromEdges()
 //=============================================================================
 
 void StdMeshers_LengthFromEdges::SetMode(int mode)
-  throw (SALOME_Exception)
 {
   int oldMode = _mode;
   if (mode <= 0) 

--- a/src/3rdParty/salomesmesh/src/StdMeshers/StdMeshers_LocalLength.cpp
+++ b/src/3rdParty/salomesmesh/src/StdMeshers/StdMeshers_LocalLength.cpp
@@ -77,7 +77,7 @@ StdMeshers_LocalLength::~StdMeshers_LocalLength()
  */
 //=============================================================================
 
-void StdMeshers_LocalLength::SetLength(double length) throw(SALOME_Exception)
+void StdMeshers_LocalLength::SetLength(double length)
 {
   double oldLength = _length;
   if (length <= 0)
@@ -104,7 +104,7 @@ double StdMeshers_LocalLength::GetLength() const
  *  
  */
 //=============================================================================
-void StdMeshers_LocalLength::SetPrecision (double thePrecision) throw(SALOME_Exception)
+void StdMeshers_LocalLength::SetPrecision (double thePrecision)
 {
   double oldPrecision = _precision;
   if (_precision < 0)

--- a/src/3rdParty/salomesmesh/src/StdMeshers/StdMeshers_MaxElementArea.cpp
+++ b/src/3rdParty/salomesmesh/src/StdMeshers/StdMeshers_MaxElementArea.cpp
@@ -71,7 +71,6 @@ StdMeshers_MaxElementArea::~StdMeshers_MaxElementArea()
 //=============================================================================
 
 void StdMeshers_MaxElementArea::SetMaxArea(double maxArea)
-  throw (SALOME_Exception)
 {
   double oldArea = _maxArea;
   if (maxArea <= 0) 

--- a/src/3rdParty/salomesmesh/src/StdMeshers/StdMeshers_MaxElementVolume.cpp
+++ b/src/3rdParty/salomesmesh/src/StdMeshers/StdMeshers_MaxElementVolume.cpp
@@ -73,7 +73,6 @@ StdMeshers_MaxElementVolume::~StdMeshers_MaxElementVolume()
 //=============================================================================
 
 void StdMeshers_MaxElementVolume::SetMaxVolume(double maxVolume)
-  throw (SALOME_Exception)
 {
   double oldVolume = _maxVolume;
   if (maxVolume <= 0) 

--- a/src/3rdParty/salomesmesh/src/StdMeshers/StdMeshers_MaxLength.cpp
+++ b/src/3rdParty/salomesmesh/src/StdMeshers/StdMeshers_MaxLength.cpp
@@ -73,7 +73,7 @@ StdMeshers_MaxLength::~StdMeshers_MaxLength()
  */
 //=============================================================================
 
-void StdMeshers_MaxLength::SetLength(double length) throw(SALOME_Exception)
+void StdMeshers_MaxLength::SetLength(double length)
 {
   if (length <= 0)
     throw SALOME_Exception(LOCALIZED("length must be positive"));

--- a/src/3rdParty/salomesmesh/src/StdMeshers/StdMeshers_NumberOfLayers.cpp
+++ b/src/3rdParty/salomesmesh/src/StdMeshers/StdMeshers_NumberOfLayers.cpp
@@ -73,7 +73,6 @@ StdMeshers_NumberOfLayers::~StdMeshers_NumberOfLayers()
 //=============================================================================
 
 void StdMeshers_NumberOfLayers::SetNumberOfLayers(int numberOfLayers)
-  throw ( SALOME_Exception )
 {
   if ( _nbLayers != numberOfLayers ) {
     if ( numberOfLayers <= 0 )

--- a/src/3rdParty/salomesmesh/src/StdMeshers/StdMeshers_NumberOfSegments.cpp
+++ b/src/3rdParty/salomesmesh/src/StdMeshers/StdMeshers_NumberOfSegments.cpp
@@ -94,7 +94,6 @@ StdMeshers_NumberOfSegments::~StdMeshers_NumberOfSegments()
 //=============================================================================
 const vector<double>&
 StdMeshers_NumberOfSegments::BuildDistributionExpr( const char* expr,int nbSeg,int conv )
-  throw ( SALOME_Exception )
 {
   if( !buildDistribution( TCollection_AsciiString( ( Standard_CString )expr ), conv, 0.0, 1.0, nbSeg, _distr, 1E-4 ) )
     _distr.resize( 0 );
@@ -105,7 +104,6 @@ const vector<double>&
 StdMeshers_NumberOfSegments::BuildDistributionTab( const vector<double>& tab,
                                                    int nbSeg,
                                                    int conv )
-  throw ( SALOME_Exception )
 {
   if( !buildDistribution( tab, conv, 0.0, 1.0, nbSeg, _distr, 1E-4 ) )
     _distr.resize( 0 );
@@ -119,7 +117,6 @@ StdMeshers_NumberOfSegments::BuildDistributionTab( const vector<double>& tab,
 //=============================================================================
 
 void StdMeshers_NumberOfSegments::SetNumberOfSegments(int segmentsNumber)
-throw(SALOME_Exception)
 {
   int oldNumberOfSegments = _numberOfSegments;
   if (segmentsNumber <= 0)
@@ -148,7 +145,6 @@ int StdMeshers_NumberOfSegments::GetNumberOfSegments() const
 //================================================================================
 
 void StdMeshers_NumberOfSegments::SetDistrType(DistrType typ)
-  throw(SALOME_Exception)
 {
   if (typ < DT_Regular || typ > DT_ExprFunc)
     throw SALOME_Exception(LOCALIZED("distribution type is out of range"));
@@ -178,7 +174,6 @@ StdMeshers_NumberOfSegments::DistrType StdMeshers_NumberOfSegments::GetDistrType
 //================================================================================
 
 void StdMeshers_NumberOfSegments::SetScaleFactor(double scaleFactor)
-  throw(SALOME_Exception)
 {
   if (_distrType != DT_Scale)
     _distrType = DT_Scale;
@@ -202,7 +197,6 @@ void StdMeshers_NumberOfSegments::SetScaleFactor(double scaleFactor)
 //================================================================================
 
 double StdMeshers_NumberOfSegments::GetScaleFactor() const
-  throw(SALOME_Exception)
 {
   if (_distrType != DT_Scale)
     throw SALOME_Exception(LOCALIZED("not a scale distribution"));
@@ -216,7 +210,6 @@ double StdMeshers_NumberOfSegments::GetScaleFactor() const
 //================================================================================
 
 void StdMeshers_NumberOfSegments::SetTableFunction(const vector<double>& table)
-  throw(SALOME_Exception)
 {
   if (_distrType != DT_TabFunc)
     _distrType = DT_TabFunc;
@@ -282,7 +275,6 @@ void StdMeshers_NumberOfSegments::SetTableFunction(const vector<double>& table)
 //================================================================================
 
 const vector<double>& StdMeshers_NumberOfSegments::GetTableFunction() const
-  throw(SALOME_Exception)
 {
   if (_distrType != DT_TabFunc)
     throw SALOME_Exception(LOCALIZED("not a table function distribution"));
@@ -388,7 +380,6 @@ bool process( const TCollection_AsciiString& str, int convMode,
 //================================================================================
 
 void StdMeshers_NumberOfSegments::SetExpressionFunction(const char* expr)
-  throw(SALOME_Exception)
 {
   if (_distrType != DT_ExprFunc)
     _distrType = DT_ExprFunc;
@@ -411,7 +402,6 @@ void StdMeshers_NumberOfSegments::SetExpressionFunction(const char* expr)
 std::string
 StdMeshers_NumberOfSegments::CheckExpressionFunction( const std::string& expr,
                                                       const int          convMode)
-    throw (SALOME_Exception)
 {
   // remove white spaces
   TCollection_AsciiString str((Standard_CString)expr.c_str());
@@ -451,7 +441,6 @@ StdMeshers_NumberOfSegments::CheckExpressionFunction( const std::string& expr,
 //================================================================================
 
 const char* StdMeshers_NumberOfSegments::GetExpressionFunction() const
-  throw(SALOME_Exception)
 {
   if (_distrType != DT_ExprFunc)
     throw SALOME_Exception(LOCALIZED("not an expression function distribution"));
@@ -465,7 +454,6 @@ const char* StdMeshers_NumberOfSegments::GetExpressionFunction() const
 //================================================================================
 
 void StdMeshers_NumberOfSegments::SetConversionMode( int conv )
-  throw(SALOME_Exception)
 {
 //   if (_distrType != DT_TabFunc && _distrType != DT_ExprFunc)
 //     throw SALOME_Exception(LOCALIZED("not a functional distribution"));
@@ -484,7 +472,6 @@ void StdMeshers_NumberOfSegments::SetConversionMode( int conv )
 //================================================================================
 
 int StdMeshers_NumberOfSegments::ConversionMode() const
-  throw(SALOME_Exception)
 {
 //   if (_distrType != DT_TabFunc && _distrType != DT_ExprFunc)
 //     throw SALOME_Exception(LOCALIZED("not a functional distribution"));

--- a/src/3rdParty/salomesmesh/src/StdMeshers/StdMeshers_ProjectionSource1D.cpp
+++ b/src/3rdParty/salomesmesh/src/StdMeshers/StdMeshers_ProjectionSource1D.cpp
@@ -73,7 +73,6 @@ StdMeshers_ProjectionSource1D::~StdMeshers_ProjectionSource1D()
 //=============================================================================
 
 void StdMeshers_ProjectionSource1D::SetSourceEdge(const TopoDS_Shape& edge)
-  throw ( SALOME_Exception )
 {
   if ( edge.IsNull() )
     throw SALOME_Exception(LOCALIZED("Null edge is not allowed"));
@@ -98,7 +97,6 @@ void StdMeshers_ProjectionSource1D::SetSourceEdge(const TopoDS_Shape& edge)
 
 void StdMeshers_ProjectionSource1D::SetVertexAssociation(const TopoDS_Shape& sourceVertex,
                                                          const TopoDS_Shape& targetVertex)
-  throw ( SALOME_Exception )
 {
   if ( sourceVertex.IsNull() != targetVertex.IsNull() )
     throw SALOME_Exception(LOCALIZED("Two or none vertices must be provided"));

--- a/src/3rdParty/salomesmesh/src/StdMeshers/StdMeshers_ProjectionSource2D.cpp
+++ b/src/3rdParty/salomesmesh/src/StdMeshers/StdMeshers_ProjectionSource2D.cpp
@@ -74,7 +74,6 @@ StdMeshers_ProjectionSource2D::~StdMeshers_ProjectionSource2D()
 //=============================================================================
 
 void StdMeshers_ProjectionSource2D::SetSourceFace(const TopoDS_Shape& Face)
-  throw ( SALOME_Exception )
 {
   if ( Face.IsNull() )
     throw SALOME_Exception(LOCALIZED("Null Face is not allowed"));
@@ -102,7 +101,6 @@ void StdMeshers_ProjectionSource2D::SetVertexAssociation(const TopoDS_Shape& sou
                                                          const TopoDS_Shape& sourceVertex2,
                                                          const TopoDS_Shape& targetVertex1,
                                                          const TopoDS_Shape& targetVertex2)
-  throw ( SALOME_Exception )
 {
   if ( sourceVertex1.IsNull() != targetVertex1.IsNull() ||
        sourceVertex2.IsNull() != targetVertex2.IsNull() )
@@ -174,7 +172,6 @@ TopoDS_Shape StdMeshers_ProjectionSource2D::GetSourceFace() const
 //=============================================================================
 
 TopoDS_Vertex StdMeshers_ProjectionSource2D::GetSourceVertex(int i) const
-  throw ( SALOME_Exception )
 {
   if ( i == 1 )
     return _sourceVertex1;
@@ -192,7 +189,6 @@ TopoDS_Vertex StdMeshers_ProjectionSource2D::GetSourceVertex(int i) const
 //=============================================================================
 
 TopoDS_Vertex StdMeshers_ProjectionSource2D::GetTargetVertex(int i) const
-  throw ( SALOME_Exception )
 {
   if ( i == 1 )
     return _targetVertex1;

--- a/src/3rdParty/salomesmesh/src/StdMeshers/StdMeshers_ProjectionSource3D.cpp
+++ b/src/3rdParty/salomesmesh/src/StdMeshers/StdMeshers_ProjectionSource3D.cpp
@@ -71,7 +71,6 @@ StdMeshers_ProjectionSource3D::~StdMeshers_ProjectionSource3D()
 //=============================================================================
 
 void StdMeshers_ProjectionSource3D::SetSource3DShape(const TopoDS_Shape& Shape)
-  throw ( SALOME_Exception )
 {
   if ( Shape.IsNull() )
     throw SALOME_Exception(LOCALIZED("Null Shape is not allowed"));
@@ -99,7 +98,6 @@ void StdMeshers_ProjectionSource3D::SetVertexAssociation(const TopoDS_Shape& sou
                                                          const TopoDS_Shape& sourceVertex2,
                                                          const TopoDS_Shape& targetVertex1,
                                                          const TopoDS_Shape& targetVertex2)
-  throw ( SALOME_Exception )
 {
   if ( sourceVertex1.IsNull() != targetVertex1.IsNull() ||
        sourceVertex2.IsNull() != targetVertex2.IsNull() ||
@@ -161,7 +159,6 @@ TopoDS_Shape StdMeshers_ProjectionSource3D::GetSource3DShape() const
 //=============================================================================
 
 TopoDS_Vertex StdMeshers_ProjectionSource3D::GetSourceVertex(int i) const
-  throw ( SALOME_Exception )
 {
   if ( i == 1 )
     return _sourceVertex1;
@@ -179,7 +176,6 @@ TopoDS_Vertex StdMeshers_ProjectionSource3D::GetSourceVertex(int i) const
 //=============================================================================
 
 TopoDS_Vertex StdMeshers_ProjectionSource3D::GetTargetVertex(int i) const
-  throw ( SALOME_Exception )
 {
   if ( i == 1 )
     return _targetVertex1;

--- a/src/3rdParty/salomesmesh/src/StdMeshers/StdMeshers_Propagation.cpp
+++ b/src/3rdParty/salomesmesh/src/StdMeshers/StdMeshers_Propagation.cpp
@@ -589,6 +589,7 @@ namespace {
           clearPropagationChain( subMesh );
         }
         // return; -- hyp is modified any way
+        /* FALLTHRU */
       default:
         //case SMESH_subMesh::MODIF_HYP: // hyp modif
         // clear mesh in a chain

--- a/src/3rdParty/salomesmesh/src/StdMeshers/StdMeshers_SegmentLengthAroundVertex.cpp
+++ b/src/3rdParty/salomesmesh/src/StdMeshers/StdMeshers_SegmentLengthAroundVertex.cpp
@@ -74,7 +74,7 @@ StdMeshers_SegmentLengthAroundVertex::~StdMeshers_SegmentLengthAroundVertex()
  */
 //=============================================================================
 
-void StdMeshers_SegmentLengthAroundVertex::SetLength(double length) throw(SALOME_Exception)
+void StdMeshers_SegmentLengthAroundVertex::SetLength(double length)
 {
   if (length <= 0)
     throw SALOME_Exception(LOCALIZED("length must be positive"));

--- a/src/3rdParty/salomesmesh/src/StdMeshers/StdMeshers_StartEndLength.cpp
+++ b/src/3rdParty/salomesmesh/src/StdMeshers/StdMeshers_StartEndLength.cpp
@@ -75,7 +75,6 @@ StdMeshers_StartEndLength::~StdMeshers_StartEndLength()
 //=============================================================================
 
 void StdMeshers_StartEndLength::SetLength(double length, bool isStartLength)
-     throw(SALOME_Exception)
 {
   if ( (isStartLength ? _begLength : _endLength) != length ) {
     if (length <= 0)

--- a/src/Gui/GestureNavigationStyle.cpp
+++ b/src/Gui/GestureNavigationStyle.cpp
@@ -581,6 +581,7 @@ SbBool GestureNavigationStyle::processSoEvent(const SoEvent * const ev)
             }
         }
     } ; //not end of SEEK_WAIT_MODE. Fall through by design!!!
+        /* FALLTHRU */
     case NavigationStyle::SPINNING:
     case NavigationStyle::SEEK_MODE: {
         //animation modes

--- a/src/Gui/MayaGestureNavigationStyle.cpp
+++ b/src/Gui/MayaGestureNavigationStyle.cpp
@@ -586,6 +586,7 @@ SbBool MayaGestureNavigationStyle::processSoEvent(const SoEvent * const ev)
             }
         }
     } ; //not end of SEEK_WAIT_MODE. Fall through by design!!!
+        /* FALLTHRU */
     case NavigationStyle::SPINNING:
     case NavigationStyle::SEEK_MODE: {
         //animation modes

--- a/src/Mod/Path/App/Area.cpp
+++ b/src/Mod/Path/App/Area.cpp
@@ -356,8 +356,9 @@ void Area::addWire(CArea &area, const TopoDS_Wire& wire,
                             Point(center.X(),center.Y())));
                 break;
             }
-            //fall through
-        } default: {
+        }
+            /* FALLTHRU */
+        default: {
             // Discretize all other type of curves
             GCPnts_QuasiUniformDeflection discretizer(curve, deflection,
                     curve.FirstParameter(), curve.LastParameter());
@@ -3272,9 +3273,9 @@ void Area::toPath(Toolpath &path, const std::list<TopoDS_Shape> &shapes,
                     AREA_WARN("arc plane not aligned, force discretization");
                 }
                 AREA_TRACE("arc discretize " << AREA_XYZ(dir));
-                //fall through
-
-            } default: {
+            }
+                /* FALLTHRU */
+            default: {
                 // Discretize all other type of curves
                 GCPnts_QuasiUniformDeflection discretizer(curve, deflection,
                         curve.FirstParameter(), curve.LastParameter());

--- a/src/Mod/Points/App/PointsAlgos.cpp
+++ b/src/Mod/Points/App/PointsAlgos.cpp
@@ -339,14 +339,69 @@ lzfDecompress (const void *const in_data,  unsigned int in_len,
       }
       switch (ctrl)
       {
-        case 32: *op++ = *ip++; case 31: *op++ = *ip++; case 30: *op++ = *ip++; case 29: *op++ = *ip++;
-        case 28: *op++ = *ip++; case 27: *op++ = *ip++; case 26: *op++ = *ip++; case 25: *op++ = *ip++;
-        case 24: *op++ = *ip++; case 23: *op++ = *ip++; case 22: *op++ = *ip++; case 21: *op++ = *ip++;
-        case 20: *op++ = *ip++; case 19: *op++ = *ip++; case 18: *op++ = *ip++; case 17: *op++ = *ip++;
-        case 16: *op++ = *ip++; case 15: *op++ = *ip++; case 14: *op++ = *ip++; case 13: *op++ = *ip++;
-        case 12: *op++ = *ip++; case 11: *op++ = *ip++; case 10: *op++ = *ip++; case  9: *op++ = *ip++;
-        case  8: *op++ = *ip++; case  7: *op++ = *ip++; case  6: *op++ = *ip++; case  5: *op++ = *ip++;
-        case  4: *op++ = *ip++; case  3: *op++ = *ip++; case  2: *op++ = *ip++; case  1: *op++ = *ip++;
+      case 32: *op++ = *ip++;
+          /* FALLTHRU */
+      case 31: *op++ = *ip++;
+          /* FALLTHRU */
+      case 30: *op++ = *ip++;
+          /* FALLTHRU */
+      case 29: *op++ = *ip++;
+          /* FALLTHRU */
+      case 28: *op++ = *ip++;
+          /* FALLTHRU */
+      case 27: *op++ = *ip++;
+          /* FALLTHRU */
+      case 26: *op++ = *ip++;
+          /* FALLTHRU */
+      case 25: *op++ = *ip++;
+          /* FALLTHRU */
+      case 24: *op++ = *ip++;
+          /* FALLTHRU */
+      case 23: *op++ = *ip++;
+          /* FALLTHRU */
+      case 22: *op++ = *ip++;
+          /* FALLTHRU */
+      case 21: *op++ = *ip++;
+          /* FALLTHRU */
+      case 20: *op++ = *ip++;
+          /* FALLTHRU */
+      case 19: *op++ = *ip++;
+          /* FALLTHRU */
+      case 18: *op++ = *ip++;
+          /* FALLTHRU */
+      case 17: *op++ = *ip++;
+          /* FALLTHRU */
+      case 16: *op++ = *ip++;
+          /* FALLTHRU */
+      case 15: *op++ = *ip++;
+          /* FALLTHRU */
+      case 14: *op++ = *ip++;
+          /* FALLTHRU */
+      case 13: *op++ = *ip++;
+          /* FALLTHRU */
+      case 12: *op++ = *ip++;
+          /* FALLTHRU */
+      case 11: *op++ = *ip++;
+          /* FALLTHRU */
+      case 10: *op++ = *ip++;
+          /* FALLTHRU */
+      case  9: *op++ = *ip++;
+          /* FALLTHRU */
+      case  8: *op++ = *ip++;
+          /* FALLTHRU */
+      case  7: *op++ = *ip++;
+          /* FALLTHRU */
+      case  6: *op++ = *ip++;
+          /* FALLTHRU */
+      case  5: *op++ = *ip++;
+          /* FALLTHRU */
+      case  4: *op++ = *ip++;
+          /* FALLTHRU */
+      case  3: *op++ = *ip++;
+          /* FALLTHRU */
+      case  2: *op++ = *ip++;
+          /* FALLTHRU */
+      case  1: *op++ = *ip++;
       }
     }
     // Back reference
@@ -409,14 +464,23 @@ lzfDecompress (const void *const in_data,  unsigned int in_len,
           break;
         }
         case 9: *op++ = *ref++;
+          /* FALLTHRU */
         case 8: *op++ = *ref++;
+          /* FALLTHRU */
         case 7: *op++ = *ref++;
+          /* FALLTHRU */
         case 6: *op++ = *ref++;
+          /* FALLTHRU */
         case 5: *op++ = *ref++;
+          /* FALLTHRU */
         case 4: *op++ = *ref++;
+          /* FALLTHRU */
         case 3: *op++ = *ref++;
+          /* FALLTHRU */
         case 2: *op++ = *ref++;
+          /* FALLTHRU */
         case 1: *op++ = *ref++;
+          /* FALLTHRU */
         case 0: *op++ = *ref++; // two octets more
                 *op++ = *ref++;
       }

--- a/src/Mod/Sandbox/Gui/Overlay.cpp
+++ b/src/Mod/Sandbox/Gui/Overlay.cpp
@@ -624,6 +624,7 @@ int DrawingPlane::keyboardEvent(const SoKeyboardEvent * const)
 
 void DrawingPlane::drawLineTo(const QPoint &endPoint)
 {
+    Q_UNUSED(endPoint);
     return;
 #if !defined(HAVE_QT5_OPENGL)
     QPainter painter(fbo);


### PR DESCRIPTION
* dynamic exception specifications are deprecated [-Wdeprecated]
* this statement may fall through [-Wimplicit-fallthrough=]

With clean build it shows about 800 of them :/

Cheers,
Mateusz

---
Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR once it is merged.

---
