### PR TITLE
TechDraw Perspective View Option

### DIFF
--- a/src/Mod/TechDraw/App/DrawHatch.cpp
+++ b/src/Mod/TechDraw/App/DrawHatch.cpp
@@ -109,8 +109,7 @@ App::DocumentObjectExecReturn *DrawHatch::execute(void)
 {
     DrawViewPart* parent = getSourceView();
     if (parent) {
-        parent->touch();
-        parent->recomputeFeature();
+        parent->requestPaint();
     }
     return App::DocumentObject::StdReturn;
 }

--- a/src/Mod/TechDraw/App/DrawViewPart.cpp
+++ b/src/Mod/TechDraw/App/DrawViewPart.cpp
@@ -120,10 +120,16 @@ DrawViewPart::DrawViewPart(void) : geometryObject(0)
     static const char *lgroup = "Lines";
     static const char *sgroup = "Show";
     nowUnsetting = false;
+    Base::Reference<ParameterGrp> hGrp = App::GetApplication().GetUserParameter().GetGroup("BaseApp")->
+                                                               GetGroup("Preferences")->GetGroup("Mod/TechDraw/General");
+    double defDist = hGrp->GetFloat("FocusDistance",100.0);
+
 
     //properties that affect Geometry
     ADD_PROPERTY_TYPE(Source ,(0),group,App::Prop_None,"3D Shape to view");
     ADD_PROPERTY_TYPE(Direction ,(0,0,1.0)    ,group,App::Prop_None,"Projection direction. The direction you are looking from.");
+    ADD_PROPERTY_TYPE(Perspective ,(false),group,App::Prop_None,"Perspective(true) or Orthographic(false) projection");
+    ADD_PROPERTY_TYPE(Focus,(defDist),group,App::Prop_None,"Perspective view focus distance");
 
     //properties that affect Appearance
     //visible outline
@@ -137,8 +143,8 @@ DrawViewPart::DrawViewPart(void) : geometryObject(0)
     ADD_PROPERTY_TYPE(IsoCount ,(0),sgroup,App::Prop_None,"Number of isoparameters");
     
     //default line weights
-    Base::Reference<ParameterGrp> hGrp = App::GetApplication().GetUserParameter()
-        .GetGroup("BaseApp")->GetGroup("Preferences")->GetGroup("Mod/TechDraw/Decorations");
+    hGrp = App::GetApplication().GetUserParameter().GetGroup("BaseApp")->
+                                                    GetGroup("Preferences")->GetGroup("Mod/TechDraw/Decorations");
     std::string lgName = hGrp->GetASCII("LineGroup","FC 0.70mm");
     auto lg = LineGroup::lineGroupFactory(lgName);
     double weight = lg->getWeight("Thick");
@@ -283,6 +289,8 @@ TechDrawGeometry::GeometryObject* DrawViewPart::buildGeometryObject(TopoDS_Shape
 {
     TechDrawGeometry::GeometryObject* go = new TechDrawGeometry::GeometryObject(getNameInDocument(), this);
     go->setIsoCount(IsoCount.getValue());
+    go->isPerspective(Perspective.getValue());
+    go->setFocus(Focus.getValue());
 
     Base::Vector3d baseProjDir = Direction.getValue();
     saveParamSpace(baseProjDir);

--- a/src/Mod/TechDraw/App/DrawViewPart.h
+++ b/src/Mod/TechDraw/App/DrawViewPart.h
@@ -32,6 +32,7 @@
 #include <App/DocumentObject.h>
 #include <App/PropertyLinks.h>
 #include <App/PropertyStandard.h>
+#include <App/PropertyUnits.h>
 #include <App/FeaturePython.h>
 
 #include <Base/BoundBox.h>
@@ -82,7 +83,10 @@ public:
     virtual ~DrawViewPart();
 
     App::PropertyLinkGlobal   Source;                                        //Part Feature
-    App::PropertyVector Direction;  //TODO: Rename to YAxisDirection or whatever this actually is  (ProjectionDirection)
+    App::PropertyVector       Direction;  //TODO: Rename to YAxisDirection or whatever this actually is  (ProjectionDirection)
+    App::PropertyBool         Perspective;
+    App::PropertyDistance     Focus;
+
     App::PropertyBool   SeamVisible;
     App::PropertyBool   SmoothVisible;
     //App::PropertyBool   OutlinesVisible;

--- a/src/Mod/TechDraw/App/GeometryObject.cpp
+++ b/src/Mod/TechDraw/App/GeometryObject.cpp
@@ -81,7 +81,9 @@ struct EdgePoints {
 GeometryObject::GeometryObject(const string& parent, TechDraw::DrawView* parentObj) :
     m_parentName(parent),
     m_parent(parentObj),
-    m_isoCount(0)
+    m_isoCount(0),
+    m_isPersp(false),
+    m_focus(100.0)
 {
 }
 
@@ -158,8 +160,14 @@ void GeometryObject::projectShape(const TopoDS_Shape& input,
     try {
         brep_hlr = new HLRBRep_Algo();
         brep_hlr->Add(input, m_isoCount);
-        HLRAlgo_Projector projector( viewAxis );
-        brep_hlr->Projector(projector);
+        if (m_isPersp) {
+            double fLength = std::max(Precision::Confusion(),m_focus);
+            HLRAlgo_Projector projector( viewAxis, fLength );
+            brep_hlr->Projector(projector);
+        } else {
+            HLRAlgo_Projector projector( viewAxis );
+            brep_hlr->Projector(projector);
+        }
         brep_hlr->Update();
         brep_hlr->Hide();                           //XXXX: what happens if we don't call Hide()?? and only look at VCompound?
                                                     // WF: you get back all the edges in the shape, but very fast!!

--- a/src/Mod/TechDraw/App/GeometryObject.h
+++ b/src/Mod/TechDraw/App/GeometryObject.h
@@ -98,6 +98,10 @@ public:
     void clearFaceGeom();
     void setIsoCount(int i) { m_isoCount = i; }
     void setParentName(std::string n);                          //for debug messages
+    void isPerspective(bool b) { m_isPersp = b; }
+    bool isPerspective(void) { return m_isPersp; }
+    void setFocus(double f) { m_focus = f; }
+    double getFocus(void) { return m_focus; }
     void pruneVertexGeom(Base::Vector3d center, double radius);
 
     TopoDS_Shape getVisHard(void)    { return visHard; }
@@ -144,6 +148,8 @@ protected:
     std::string m_parentName;
     TechDraw::DrawView* m_parent;
     int m_isoCount;
+    bool m_isPersp;
+    double m_focus;
 };
 
 } //namespace TechDrawGeometry

--- a/src/Mod/TechDraw/Gui/QGIFace.cpp
+++ b/src/Mod/TechDraw/Gui/QGIFace.cpp
@@ -76,7 +76,7 @@ QGIFace::QGIFace(int index) :
     m_segCount = 0;
     setFillMode(NoFill);
     isHatched(false);
-    setFlag(QGraphicsItem::ItemClipsChildrenToShape,false);
+    setFlag(QGraphicsItem::ItemClipsChildrenToShape,true);
 
     //setStyle(Qt::NoPen);    //don't draw face lines, just fill for debugging
     setStyle(Qt::DashLine);


### PR DESCRIPTION
This PR adds an option to DrawViewPart to allow Perspective or Orthogonal projections.  It also fixes a "still touched after recompute" bug in DrawHatch.  Please merge.

Thanks,
wf

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR once it is merged.

---
