### PR TITLE
Sketcher: Fix Polygon disappearing on creation with autoconstraints on

### DIFF
--- a/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp
+++ b/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp
@@ -7161,7 +7161,7 @@ public:
             setPositionText(onSketchPos, text);
 
             sketchgui->drawEdit(EditCurve);
-            if (seekAutoConstraint(sugConstr2, onSketchPos, dV)) {
+            if (seekAutoConstraint(sugConstr2, onSketchPos, Base::Vector2d(0.f,0.f))) {
                 renderSuggestConstraintsCursor(sugConstr2);
                 return;
             }


### PR DESCRIPTION
======================================================================

Fixes #3154

About the fix:
- If a non-zero vector is passed to seekAutoConstraint, it will suggest a vertical/horizontal constraint, which does not
make sense in the construction method.
- Passing a zero vector enables to treat it like a point, so for example point on object will be suggested, but not vertical/horizontal constraints.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [y ] Branch rebased on latest master `git pull --rebase upstream master`
- [n ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [y ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [y ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR once it is merged.

---
