### PR TITLE
Sketcher: Fixing Polyline Arc Endpoint autoconstraints

### DIFF
--- a/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp
+++ b/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp
@@ -1216,7 +1216,9 @@ public:
                 virtualsugConstr1 = sugConstr2; // these are the initial constraints for the next iteration.
 
                 if (sugConstr2.size() > 0) {
-                    createAutoConstraints(sugConstr2, getHighestCurveIndex(), Sketcher::end);
+                    createAutoConstraints(sugConstr2, getHighestCurveIndex(), 
+                                          (SegmentMode == SEGMENT_MODE_Arc && startAngle > endAngle) ?
+                                            Sketcher::start : Sketcher::end);
                     sugConstr2.clear();
                 }
 


### PR DESCRIPTION

======================================================

fixes #3091

https://forum.freecadweb.org/viewtopic.php?f=8&t=23044
https://freecadweb.org/tracker/view.php?id=3091

Autoconstraints did not check whether the arc was CW or CCW, as such the autoconstraint on the second position was sometimes assigned to the start point.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ y] Branch rebased on latest master `git pull --rebase upstream master`
- [ n] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [y ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ y] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
