### PR TITLE
Fix "Unit overflow in pow()" error

### DIFF
--- a/src/Base/Unit.cpp
+++ b/src/Base/Unit.cpp
@@ -127,7 +127,7 @@ Unit::Unit(const QString& expr)
     }
 }
 
-Unit Unit::pow(char exp) const
+Unit Unit::pow(signed char exp) const
 {
     checkRange("pow()",
                (int32_t)Sig.Length * (int32_t)exp,

--- a/src/Base/Unit.h
+++ b/src/Base/Unit.h
@@ -79,7 +79,7 @@ public:
     bool operator ==(const Unit&) const;
     bool operator !=(const Unit&that) const {return !(*this == that);}
     Unit& operator =(const Unit&);
-    Unit pow(char exp)const;
+    Unit pow(signed char exp)const;
     //@}
     /// get the unit signature
     const UnitSignature & getSignature(void)const {return Sig;} 


### PR DESCRIPTION
During tests on Debian/Ubuntu :
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=836983 a problem was
found when raising a unit to a negative power on some architectures.
By default some architectures have "char" being
unsigned such as the ones listed here and others (
https://wiki.debian.org/ArchitectureSpecificsMemo ).
I just forced the sign-ness of pow()'s argument which fixes the issue.

F.
Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
