### PR TITLE
fix object.getGlobalPlacement

### DIFF
--- a/src/App/GeoFeatureGroupExtension.cpp
+++ b/src/App/GeoFeatureGroupExtension.cpp
@@ -124,8 +124,10 @@ Base::Placement GeoFeatureGroupExtension::recursiveGroupPlacement(GeoFeatureGrou
     
     auto inList = group->getExtendedObject()->getInList();
     for(auto* link : inList) {
-        if(link->hasExtension(App::GeoFeatureGroupExtension::getExtensionClassTypeId()))
-            return recursiveGroupPlacement(link->getExtensionByType<GeoFeatureGroupExtension>()) * group->placement().getValue();
+        if(link->hasExtension(App::GeoFeatureGroupExtension::getExtensionClassTypeId())){
+            if (link->getExtensionByType<GeoFeatureGroupExtension>()->hasObject(group->getExtendedObject()))
+                return recursiveGroupPlacement(link->getExtensionByType<GeoFeatureGroupExtension>()) * group->placement().getValue();
+        }
     }
     
     return group->placement().getValue();


### PR DESCRIPTION
was confused by expressions in Placement of containers.
Fixes #3217 Sketcher not drawing at mouse position.

https://forum.freecadweb.org/viewtopic.php?f=3&t=24941&p=203740#p203740
