### PR TITLE
TechDraw MultiObject Views and Bug Fixes

### DIFF
--- a/src/Mod/Measure/App/Measurement.cpp
+++ b/src/Mod/Measure/App/Measurement.cpp
@@ -65,6 +65,7 @@ TYPESYSTEM_SOURCE(Measure::Measurement, Base::BaseClass)
 Measurement::Measurement()
 {
     measureType = Invalid;
+    References3D.setScope(App::LinkScope::Global);
 }
 
 Measurement::~Measurement()
@@ -229,6 +230,7 @@ TopoDS_Shape Measurement::getShape(App::DocumentObject *obj , const char *subNam
     }
 }
 
+//TODO:: add lengthX, lengthY (and lengthZ??) support
 // Methods for distances (edge length, two points, edge and a point
 double Measurement::length() const
 {

--- a/src/Mod/Measure/App/Measurement.h
+++ b/src/Mod/Measure/App/Measurement.h
@@ -48,7 +48,7 @@ class MeasureExport Measurement : public Base::BaseClass {
       TYPESYSTEM_HEADER();
 public:
 
-    App::PropertyLinkSubListGlobal References3D;
+    App::PropertyLinkSubList References3D;
 
 public:
     Measurement();

--- a/src/Mod/TechDraw/App/DrawPage.cpp
+++ b/src/Mod/TechDraw/App/DrawPage.cpp
@@ -272,22 +272,36 @@ int DrawPage::addView(App::DocumentObject *docObj)
     return Views.getSize();
 }
 
+//Note Views might be removed from document elsewhere so need to check if a View is still in Document here
 int DrawPage::removeView(App::DocumentObject *docObj)
 {
     if(!docObj->isDerivedFrom(TechDraw::DrawView::getClassTypeId()))
         return -1;
 
+    App::Document* doc = docObj->getDocument();
+    if (doc == nullptr) {
+        return -1;
+    }
+
+    const char* name = docObj->getNameInDocument();
+    if (!name) {
+         return -1;
+    }
     const std::vector<App::DocumentObject*> currViews = Views.getValues();
     std::vector<App::DocumentObject*> newViews;
     std::vector<App::DocumentObject*>::const_iterator it = currViews.begin();
     for (; it != currViews.end(); it++) {
-        std::string viewName = docObj->getNameInDocument();
+        App::Document* viewDoc = (*it)->getDocument();
+        if (viewDoc == nullptr) {
+            continue;
+        }
+
+        std::string viewName = name;
         if (viewName.compare((*it)->getNameInDocument()) != 0) {
             newViews.push_back((*it));
         }
     }
     Views.setValues(newViews);
-
     return Views.getSize();
 }
 

--- a/src/Mod/TechDraw/App/DrawProjGroup.cpp
+++ b/src/Mod/TechDraw/App/DrawProjGroup.cpp
@@ -64,6 +64,7 @@ DrawProjGroup::DrawProjGroup(void)
 
 
     ADD_PROPERTY_TYPE(Source    ,(0), group, App::Prop_None,"Shape to view");
+    Source.setScope(App::LinkScope::Global);
     ADD_PROPERTY_TYPE(Anchor, (0), group, App::Prop_None, "The root view to align projections with");
     ProjectionType.setEnums(ProjectionTypeEnums);
     ADD_PROPERTY(ProjectionType, ((long)0));
@@ -96,8 +97,8 @@ void DrawProjGroup::onChanged(const App::Property* prop)
     TechDraw::DrawPage *page = getPage();
     if (!isRestoring() && page) {
         if (prop == &Source) {
-            App::DocumentObject* sourceObj = Source.getValue();
-            if (sourceObj != nullptr) {
+            std::vector<App::DocumentObject*> sourceObjs = Source.getValues();
+            if (!sourceObjs.empty()) {
                 if (!hasAnchor()) {
                     // if we have a Source, but no Anchor, make an anchor
                     Anchor.setValue(addProjection("Front"));
@@ -142,12 +143,12 @@ App::DocumentObjectExecReturn *DrawProjGroup::execute(void)
         return DrawViewCollection::execute();
     }
 
-    App::DocumentObject* docObj = Source.getValue();
-    if (docObj == nullptr) {
+    std::vector<App::DocumentObject*> docObjs = Source.getValues();
+    if (docObjs.empty()) {
         return DrawViewCollection::execute();
     }
 
-    docObj = Anchor.getValue();
+    App::DocumentObject* docObj = Anchor.getValue();
     if (docObj == nullptr) {
         return DrawViewCollection::execute();
     }
@@ -380,7 +381,7 @@ App::DocumentObject * DrawProjGroup::addProjection(const char *viewProjType)
         auto docObj( getDocument()->addObject( "TechDraw::DrawProjGroupItem",     //add to Document
                                                FeatName.c_str() ) );
         view = static_cast<TechDraw::DrawProjGroupItem *>( docObj );
-        view->Source.setValue( Source.getValue() );
+        view->Source.setValues( Source.getValues() );
         if (ScaleType.isValue("Automatic")) {
             view->ScaleType.setValue("Custom");
         } else {
@@ -389,7 +390,7 @@ App::DocumentObject * DrawProjGroup::addProjection(const char *viewProjType)
         view->Scale.setValue( getScale() );
         view->Type.setValue( viewProjType );
         view->Label.setValue( viewProjType );
-        view->Source.setValue( Source.getValue() );
+        view->Source.setValues( Source.getValues() );
         view->Direction.setValue(m_cube->getViewDir(viewProjType));
         view->RotationVector.setValue(m_cube->getRotationDir(viewProjType));
         addView(view);         //from DrawViewCollection

--- a/src/Mod/TechDraw/App/DrawProjGroup.h
+++ b/src/Mod/TechDraw/App/DrawProjGroup.h
@@ -54,7 +54,7 @@ public:
     DrawProjGroup();
     ~DrawProjGroup();
 
-    App::PropertyLinkGlobal  Source;
+    App::PropertyLinkList  Source;
     App::PropertyEnumeration ProjectionType;
 
     App::PropertyBool AutoDistribute;

--- a/src/Mod/TechDraw/App/DrawView.cpp
+++ b/src/Mod/TechDraw/App/DrawView.cpp
@@ -253,6 +253,8 @@ double DrawView::getScale(void) const
 
 void DrawView::Restore(Base::XMLReader &reader)
 {
+// this is temporary code for backwards compat (within v0.17).  can probably be deleted once there are no development
+// fcstd files with old property types in use. 
     reader.readElement("Properties");
     int Cnt = reader.getAttributeAsInteger("Count");
 
@@ -268,7 +270,7 @@ void DrawView::Restore(Base::XMLReader &reader)
                 } else  {
                     if (strcmp(PropName, "Scale") == 0) {
                         if (schemaProp->isDerivedFrom(App::PropertyFloatConstraint::getClassTypeId())){  //right property type
-                            schemaProp->Restore(reader);                                                  //nothing special to do
+                            schemaProp->Restore(reader);                                                  //nothing special to do (redundant)
                         } else {                                                                //Scale, but not PropertyFloatConstraint
                             App::PropertyFloat tmp;
                             if (strcmp(tmp.getTypeId().getName(),TypeName)) {                   //property in file is Float
@@ -285,6 +287,29 @@ void DrawView::Restore(Base::XMLReader &reader)
                                 Base::Console().Log("DrawView::Restore - old Document Scale is Not Float!\n");
                                 // no idea
                             }
+                        }
+                    } else if (strcmp(PropName, "Source") == 0) {
+                        App::PropertyLinkGlobal glink;
+                        App::PropertyLink link;
+                        if (strcmp(glink.getTypeId().getName(),TypeName) == 0) {            //property in file is plg
+                            glink.setContainer(this);
+                            glink.Restore(reader);
+                            if (glink.getValue() != nullptr) {
+                                static_cast<App::PropertyLinkList*>(schemaProp)->setScope(App::LinkScope::Global);
+                                static_cast<App::PropertyLinkList*>(schemaProp)->setValue(glink.getValue());
+                            }
+                        } else if (strcmp(link.getTypeId().getName(),TypeName) == 0) {            //property in file is pl
+                            link.setContainer(this);
+                            link.Restore(reader);
+                            if (link.getValue() != nullptr) {
+                                static_cast<App::PropertyLinkList*>(schemaProp)->setScope(App::LinkScope::Global);
+                                static_cast<App::PropertyLinkList*>(schemaProp)->setValue(link.getValue());
+                            }
+                        
+                        } else {
+                            // has Source prop isn't PropertyLink or PropertyLinkGlobal! 
+                            Base::Console().Log("DrawView::Restore - old Document Source is weird: %s\n", TypeName);
+                            // no idea
                         }
                     } else {
                         Base::Console().Log("DrawView::Restore - old Document has unknown Property\n");

--- a/src/Mod/TechDraw/App/DrawViewArch.cpp
+++ b/src/Mod/TechDraw/App/DrawViewArch.cpp
@@ -55,6 +55,7 @@ DrawViewArch::DrawViewArch(void)
     static const char *group = "Arch view";
 
     ADD_PROPERTY_TYPE(Source ,(0),group,App::Prop_None,"Section Plane object for this view");
+    Source.setScope(App::LinkScope::Global);
     ADD_PROPERTY_TYPE(AllOn ,(false),group,App::Prop_None,"If hidden objects must be shown or not");
     RenderMode.setEnums(RenderModeEnums);
     ADD_PROPERTY_TYPE(RenderMode, ((long)0),group,App::Prop_None,"The render mode to use");

--- a/src/Mod/TechDraw/App/DrawViewArch.h
+++ b/src/Mod/TechDraw/App/DrawViewArch.h
@@ -42,7 +42,7 @@ public:
     DrawViewArch(void);
     virtual ~DrawViewArch();
 
-    App::PropertyLinkGlobal   Source;
+    App::PropertyLink         Source;
     App::PropertyBool         AllOn;
     App::PropertyEnumeration  RenderMode; // "Wireframe","Solid"
     App::PropertyBool         ShowHidden;

--- a/src/Mod/TechDraw/App/DrawViewDetail.cpp
+++ b/src/Mod/TechDraw/App/DrawViewDetail.cpp
@@ -150,27 +150,23 @@ App::DocumentObjectExecReturn *DrawViewDetail::execute(void)
         return App::DocumentObject::StdReturn;
     }
 
-    App::DocumentObject* link = Source.getValue();
-    App::DocumentObject* base = BaseView.getValue();
-    if (!link || !base)  {
-        Base::Console().Log("INFO - DVD::execute - No Source or Link - creation?\n");
+    App::DocumentObject* baseObj = BaseView.getValue();
+    if (!baseObj)  {
+        Base::Console().Log("INFO - DVD::execute - No BaseView - creation?\n");
         return DrawView::execute();
     }
 
-    if (!link->getTypeId().isDerivedFrom(Part::Feature::getClassTypeId()))
-        return new App::DocumentObjectExecReturn("Source object is not a Part object");
     DrawViewPart* dvp = nullptr;
-    if (!base->getTypeId().isDerivedFrom(TechDraw::DrawViewPart::getClassTypeId())) {
+    if (!baseObj->getTypeId().isDerivedFrom(TechDraw::DrawViewPart::getClassTypeId())) {
         return new App::DocumentObjectExecReturn("BaseView object is not a DrawViewPart object");
     } else {
-        dvp = static_cast<DrawViewPart*>(base);
+        dvp = static_cast<DrawViewPart*>(baseObj);
     }
 
-    //Base::Console().Message("TRACE - DVD::execute() - %s/%s\n",getNameInDocument(),Label.getValue());
-
-    const Part::TopoShape &partTopo = static_cast<Part::Feature*>(link)->Shape.getShape();
-    if (partTopo.getShape().IsNull())
-        return new App::DocumentObjectExecReturn("Linked shape object is empty");
+    TopoDS_Shape shape = dvp->getSourceShapeFused();
+    if (shape.IsNull()) {
+        return new App::DocumentObjectExecReturn("DVD - Linked shape object is invalid");
+    }
 
     Base::Vector3d anchor = AnchorPoint.getValue();    //this is a 2D point
     anchor = Base::Vector3d(anchor.x,anchor.y, 0.0);
@@ -179,15 +175,17 @@ App::DocumentObjectExecReturn *DrawViewDetail::execute(void)
     double scale = getScale();
     gp_Ax2 viewAxis = getViewAxis(Base::Vector3d(0.0,0.0,0.0), dirDetail, false);
 
-    Base::BoundBox3d bbxSource = partTopo.getBoundBox();
+    Bnd_Box bbxSource;
+    BRepBndLib::Add(shape, bbxSource);
+    bbxSource.SetGap(0.0);
+    double diag = sqrt(bbxSource.SquareExtent());
 
-    BRepBuilderAPI_Copy BuilderCopy(partTopo.getShape());
+    BRepBuilderAPI_Copy BuilderCopy(shape);
     TopoDS_Shape myShape = BuilderCopy.Shape();
 
     gp_Pnt gpCenter = TechDrawGeometry::findCentroid(myShape,
                                                      dirDetail);
     Base::Vector3d shapeCenter = Base::Vector3d(gpCenter.X(),gpCenter.Y(),gpCenter.Z());
-    double diag = bbxSource.CalcDiagonalLength();
     Base::Vector3d extentFar,extentNear;
     extentFar = shapeCenter + dirDetail * diag;
     extentNear = shapeCenter + dirDetail * diag * -1.0;

--- a/src/Mod/TechDraw/App/DrawViewDimension.cpp
+++ b/src/Mod/TechDraw/App/DrawViewDimension.cpp
@@ -95,7 +95,9 @@ DrawViewDimension::DrawViewDimension(void)
     double fontSize = hGrp->GetFloat("FontSize", 3.5);
 
     ADD_PROPERTY_TYPE(References2D,(0,0),"",(App::PropertyType)(App::Prop_None),"Projected Geometry References");
+    References2D.setScope(App::LinkScope::Global);
     ADD_PROPERTY_TYPE(References3D,(0,0),"",(App::PropertyType)(App::Prop_None),"3D Geometry References");
+    References3D.setScope(App::LinkScope::Global);
     ADD_PROPERTY_TYPE(Font ,(fontName.c_str()),"Format",App::Prop_None, "The name of the font to use");
     ADD_PROPERTY_TYPE(Fontsize,(fontSize)    ,"Format",(App::PropertyType)(App::Prop_None),"Dimension text size in mm");
     ADD_PROPERTY_TYPE(FormatSpec,(getDefaultFormatSpec().c_str()) ,

--- a/src/Mod/TechDraw/App/DrawViewDimension.cpp
+++ b/src/Mod/TechDraw/App/DrawViewDimension.cpp
@@ -105,6 +105,7 @@ DrawViewDimension::DrawViewDimension(void)
     std::string lgName = hGrp->GetASCII("LineGroup","FC 0.70mm");
     auto lg = LineGroup::lineGroupFactory(lgName);
     double weight = lg->getWeight("Graphic");
+    delete lg;   //Coverity CID 169507
     ADD_PROPERTY_TYPE(LineWidth,(weight)    ,"Format",(App::PropertyType)(App::Prop_None),"Dimension line weight");
     //ADD_PROPERTY_TYPE(CentreLines,(0) ,"Format",(App::PropertyType)(App::Prop_None),"Arc Dimension Center Mark");
 

--- a/src/Mod/TechDraw/App/DrawViewDimension.h
+++ b/src/Mod/TechDraw/App/DrawViewDimension.h
@@ -55,7 +55,7 @@ public:
 
     App::PropertyEnumeration       MeasureType;                        //True/Projected
     App::PropertyLinkSubList       References2D;                       //Points to Projection SubFeatures
-    App::PropertyLinkSubListGlobal References3D;                       //Points to 3D Geometry SubFeatures
+    App::PropertyLinkSubList       References3D;                       //Points to 3D Geometry SubFeatures
     App::PropertyEnumeration       Type;                               //DistanceX,DistanceY,Diameter, etc
 
     /// Properties for Visualisation

--- a/src/Mod/TechDraw/App/DrawViewDraft.cpp
+++ b/src/Mod/TechDraw/App/DrawViewDraft.cpp
@@ -52,6 +52,7 @@ DrawViewDraft::DrawViewDraft(void)
     static const char *group = "Draft view";
 
     ADD_PROPERTY_TYPE(Source ,(0),group,App::Prop_None,"Draft object for this view");
+    Source.setScope(App::LinkScope::Global);
     ADD_PROPERTY_TYPE(LineWidth,(0.35),group,App::Prop_None,"Line width of this view");
     ADD_PROPERTY_TYPE(FontSize,(12.0),group,App::Prop_None,"Text size for this view");
     ADD_PROPERTY_TYPE(Direction ,(0,0,1.0),group,App::Prop_None,"Projection direction. The direction you are looking from.");

--- a/src/Mod/TechDraw/App/DrawViewDraft.h
+++ b/src/Mod/TechDraw/App/DrawViewDraft.h
@@ -43,7 +43,7 @@ public:
     DrawViewDraft(void);
     virtual ~DrawViewDraft();
 
-    App::PropertyLinkGlobal   Source;
+    App::PropertyLink         Source;
     App::PropertyFloat        LineWidth;
     App::PropertyFloat        FontSize;
     App::PropertyVector       Direction;

--- a/src/Mod/TechDraw/App/DrawViewMulti.cpp
+++ b/src/Mod/TechDraw/App/DrawViewMulti.cpp
@@ -80,7 +80,7 @@ DrawViewMulti::DrawViewMulti()
 
     //properties that affect Geometry
     ADD_PROPERTY_TYPE(Sources ,(0),group,App::Prop_None,"3D Shapes to view");
-
+    Sources.setScope(App::LinkScope::Global);
     //Source is replaced by Sources in Multi
     Source.setStatus(App::Property::ReadOnly,true);
     Source.setStatus(App::Property::Hidden,true);

--- a/src/Mod/TechDraw/App/DrawViewMulti.h
+++ b/src/Mod/TechDraw/App/DrawViewMulti.h
@@ -56,8 +56,8 @@ public:
     /// Constructor
     DrawViewMulti(void);
     virtual ~DrawViewMulti();
-
-    App::PropertyLinkListGlobal Sources;
+  
+    App::PropertyLinkList    Sources;
 
     virtual short mustExecute() const override;
     /** @name methods override Feature */

--- a/src/Mod/TechDraw/App/DrawViewPart.cpp
+++ b/src/Mod/TechDraw/App/DrawViewPart.cpp
@@ -33,6 +33,7 @@
 #include <BRepAdaptor_Curve.hxx>
 #include <BRepBuilderAPI_MakeEdge.hxx>
 #include <BRepBuilderAPI_MakeWire.hxx>
+#include <BRepAlgoAPI_Fuse.hxx>
 #include <BRepLib.hxx>
 #include <BRepLProp_CurveTool.hxx>
 #include <BRepLProp_CLProps.hxx>
@@ -127,6 +128,7 @@ DrawViewPart::DrawViewPart(void) : geometryObject(0)
 
     //properties that affect Geometry
     ADD_PROPERTY_TYPE(Source ,(0),group,App::Prop_None,"3D Shape to view");
+    Source.setScope(App::LinkScope::Global);
     ADD_PROPERTY_TYPE(Direction ,(0,0,1.0)    ,group,App::Prop_None,"Projection direction. The direction you are looking from.");
     ADD_PROPERTY_TYPE(Perspective ,(false),group,App::Prop_None,"Perspective(true) or Orthographic(false) projection");
     ADD_PROPERTY_TYPE(Focus,(defDist),group,App::Prop_None,"Perspective view focus distance");
@@ -178,14 +180,33 @@ DrawViewPart::~DrawViewPart()
 TopoDS_Shape DrawViewPart::getSourceShape(void) const
 {
     TopoDS_Shape result;
-    App::DocumentObject *link = Source.getValue();
-    if (!link) {
-        Base::Console().Error("DVP - No Source object linked - %s\n",getNameInDocument());
-    } else if (link->getTypeId().isDerivedFrom(Part::Feature::getClassTypeId())) {
-        result = static_cast<Part::Feature*>(link)->Shape.getShape().getShape();
-    } else if (link->getTypeId().isDerivedFrom(App::Part::getClassTypeId())) {
-        result = getShapeFromPart(static_cast<App::Part*>(link));
-    } else {        Base::Console().Error("DVP - Can't handle this Source - %s\n",getNameInDocument());
+    const std::vector<App::DocumentObject*>& links = Source.getValues();
+    if (links.empty())  {
+        Base::Console().Log("DVP::getSourceShape - No Sources - creation? - %s\n",getNameInDocument());
+    } else {
+        BRep_Builder builder;
+        TopoDS_Compound comp;
+        builder.MakeCompound(comp);
+        for (auto& l:links) {
+            if (l->isDerivedFrom(Part::Feature::getClassTypeId())){
+                const Part::TopoShape &partTopo = static_cast<Part::Feature*>(l)->Shape.getShape();
+                if (partTopo.isNull()) {
+                    continue;    //has no shape
+                }
+                BRepBuilderAPI_Copy BuilderCopy(partTopo.getShape());
+                TopoDS_Shape shape = BuilderCopy.Shape();
+                builder.Add(comp, shape);
+            } else if (l->getTypeId().isDerivedFrom(App::Part::getClassTypeId())) {
+                TopoDS_Shape s = getShapeFromPart(static_cast<App::Part*>(l));
+                if (s.IsNull()) {
+                    continue;
+                }
+                BRepBuilderAPI_Copy BuilderCopy(s);
+                TopoDS_Shape shape = BuilderCopy.Shape();
+                builder.Add(comp, shape);
+            }
+        }        
+        result = comp;
     }
     return result;
 }
@@ -214,7 +235,25 @@ TopoDS_Shape DrawViewPart::getShapeFromPart(App::Part* ap) const
     return result;
 }
 
-
+TopoDS_Shape DrawViewPart::getSourceShapeFused(void) const
+{
+    TopoDS_Shape baseShape = getSourceShape();
+    TopoDS_Iterator it(baseShape);
+    TopoDS_Shape fusedShape = it.Value();
+    it.Next();
+    for (; it.More(); it.Next()) {
+        const TopoDS_Shape& aChild = it.Value();
+        BRepAlgoAPI_Fuse mkFuse(fusedShape, aChild);
+        // Let's check if the fusion has been successful
+        if (!mkFuse.IsDone()) {
+            Base::Console().Error("DVp - Fusion failed\n");
+            return baseShape;
+        }
+        fusedShape = mkFuse.Shape();
+    }
+    baseShape = fusedShape;
+    return baseShape;
+}
 
 App::DocumentObjectExecReturn *DrawViewPart::execute(void)
 {

--- a/src/Mod/TechDraw/App/DrawViewPart.h
+++ b/src/Mod/TechDraw/App/DrawViewPart.h
@@ -82,7 +82,7 @@ public:
     DrawViewPart(void);
     virtual ~DrawViewPart();
 
-    App::PropertyLinkGlobal   Source;                                        //Part Feature
+    App::PropertyLinkList     Source;
     App::PropertyVector       Direction;  //TODO: Rename to YAxisDirection or whatever this actually is  (ProjectionDirection)
     App::PropertyBool         Perspective;
     App::PropertyDistance     Focus;
@@ -166,7 +166,8 @@ public:
     virtual std::vector<TopoDS_Wire> getWireForFace(int idx) const;
     virtual TopoDS_Shape getSourceShape(void) const; 
     virtual TopoDS_Shape getShapeFromPart(App::Part* ap) const;
-    
+    virtual TopoDS_Shape getSourceShapeFused(void) const; 
+
 protected:
     TechDrawGeometry::GeometryObject *geometryObject;
     Base::BoundBox3d bbox;

--- a/src/Mod/TechDraw/App/DrawViewSection.cpp
+++ b/src/Mod/TechDraw/App/DrawViewSection.cpp
@@ -199,7 +199,7 @@ App::DocumentObjectExecReturn *DrawViewSection::execute(void)
     if (!base->getTypeId().isDerivedFrom(TechDraw::DrawViewPart::getClassTypeId()))
         return new App::DocumentObjectExecReturn("BaseView object is not a DrawViewPart object");
 
-    TopoDS_Shape baseShape = static_cast<TechDraw::DrawViewPart*>(base)->getSourceShape();
+    TopoDS_Shape baseShape = static_cast<TechDraw::DrawViewPart*>(base)->getSourceShapeFused();
     if (baseShape.IsNull()) {
         Base::Console().Log("DVS::execute - baseShape is Null\n");
     }
@@ -244,6 +244,7 @@ App::DocumentObjectExecReturn *DrawViewSection::execute(void)
     }
 
     TopoDS_Shape rawShape = mkCut.Shape();
+
     Bnd_Box testBox;
     BRepBndLib::Add(rawShape, testBox);
     testBox.SetGap(0.0);

--- a/src/Mod/TechDraw/App/DrawViewSection.cpp
+++ b/src/Mod/TechDraw/App/DrawViewSection.cpp
@@ -202,6 +202,7 @@ App::DocumentObjectExecReturn *DrawViewSection::execute(void)
     TopoDS_Shape baseShape = static_cast<TechDraw::DrawViewPart*>(base)->getSourceShapeFused();
     if (baseShape.IsNull()) {
         Base::Console().Log("DVS::execute - baseShape is Null\n");
+        return new App::DocumentObjectExecReturn("BaseView Source object is Null");
     }
 
     //is SectionOrigin valid?

--- a/src/Mod/TechDraw/App/LineGroup.cpp
+++ b/src/Mod/TechDraw/App/LineGroup.cpp
@@ -54,11 +54,11 @@ LineGroup::~LineGroup()
 
 void LineGroup::init(void)
 {
-    m_name    = "";
-    m_thin    = 0.0;
-    m_graphic = 0.0;
-    m_thick   = 0.0;
-    m_extra   = 0.0;
+    m_name    = "Default";
+    m_thin    = 0.35;
+    m_graphic = 0.50;
+    m_thick   = 0.70;
+    m_extra   = 1.40;
 }
 
 double LineGroup::getWeight(std::string s)
@@ -132,7 +132,7 @@ std::string LineGroup::getRecordFromFile(std::string parmFile, std::string group
     std::ifstream inFile;
     inFile.open (parmFile, std::ifstream::in);
     if(!inFile.is_open()) {
-        Base::Console().Message( "Cannot open input file: %s\n",parmFile.c_str());
+        Base::Console().Message( "Cannot open LineGroup file: %s\n",parmFile.c_str());
         return record;
     }
 

--- a/src/Mod/TechDraw/App/LineGroup.h
+++ b/src/Mod/TechDraw/App/LineGroup.h
@@ -43,6 +43,8 @@ public:
     void setWeight(std::string s, double weight);
 //    void setWeight(const char* s, double weight);
     void dump(char* title);
+    std::string getName(void) { return m_name; }
+    void setName(std::string s) { m_name = s; }
 
     //static support function: split comma separated string of values into vector of numbers
     static std::vector<double> split(std::string line);

--- a/src/Mod/TechDraw/CMakeLists.txt
+++ b/src/Mod/TechDraw/CMakeLists.txt
@@ -23,3 +23,21 @@ INSTALL(
     FILES_MATCHING
         PATTERN "*.svg*"
 )
+
+INSTALL(
+    DIRECTORY
+        PAT
+    DESTINATION
+        ${CMAKE_INSTALL_DATADIR}/Mod/TechDraw
+    FILES_MATCHING
+        PATTERN "*.pat*"
+)
+
+INSTALL(
+    DIRECTORY
+        LineGroup
+    DESTINATION
+        ${CMAKE_INSTALL_DATADIR}/Mod/TechDraw
+    FILES_MATCHING
+        PATTERN "*.csv*"
+)

--- a/src/Mod/TechDraw/Gui/DlgPrefsTechDraw.ui
+++ b/src/Mod/TechDraw/Gui/DlgPrefsTechDraw.ui
@@ -61,6 +61,9 @@
         </item>
         <item row="1" column="1">
          <widget class="Gui::PrefComboBox" name="cb_HidLine">
+          <property name="toolTip">
+           <string>Style for hidden lines</string>
+          </property>
           <property name="currentIndex">
            <number>1</number>
           </property>
@@ -104,6 +107,9 @@
         </item>
         <item row="2" column="0">
          <widget class="Gui::PrefCheckBox" name="cb_Faces">
+          <property name="toolTip">
+           <string>Perform/skip face processing</string>
+          </property>
           <property name="text">
            <string>Detect Faces</string>
           </property>
@@ -120,6 +126,9 @@
         </item>
         <item row="3" column="0">
          <widget class="Gui::PrefCheckBox" name="cb_SectionEdges">
+          <property name="toolTip">
+           <string>deugging option</string>
+          </property>
           <property name="text">
            <string>Show Section Edges</string>
           </property>
@@ -133,6 +142,9 @@
         </item>
         <item row="4" column="0">
          <widget class="Gui::PrefCheckBox" name="cb_PageUpdate">
+          <property name="toolTip">
+           <string>Update Pages as scheduled or skip</string>
+          </property>
           <property name="text">
            <string>Keep Pages Up to Date</string>
           </property>
@@ -156,6 +168,9 @@
         </item>
         <item row="5" column="1">
          <widget class="Gui::PrefDoubleSpinBox" name="dsb_TemplateDot">
+          <property name="toolTip">
+           <string>EditableText Dot Size in mm</string>
+          </property>
           <property name="value">
            <double>3.000000000000000</double>
           </property>
@@ -591,8 +606,14 @@
        <layout class="QGridLayout" name="gridLayout_2" columnstretch="1,0,0">
         <item row="1" column="2">
          <widget class="Gui::PrefDoubleSpinBox" name="dsb_LabelSize">
+          <property name="toolTip">
+           <string>Label height in millimeters</string>
+          </property>
           <property name="minimum">
            <double>0.100000000000000</double>
+          </property>
+          <property name="value">
+           <double>5.000000000000000</double>
           </property>
           <property name="prefEntry" stdset="0">
            <cstring>LabelSize</cstring>


### PR DESCRIPTION
This PR allows any View type to use multiple objects as a Source.  Previously only DrawViewMulti supported this.  It also fixes a problem with the install of LineGroup and PAT files and corrects 2 crash situations.  Please merge.

Thanks,
wf

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
