### PR TITLE
Performance improvements for exporting meshes to Collada format

### DIFF
--- a/src/Mod/Arch/importDAE.py
+++ b/src/Mod/Arch/importDAE.py
@@ -193,9 +193,7 @@ def export(exportList,filename,tessellation=1):
     objectslist = Draft.getGroupContents(exportList,walls=True,addgroups=True)
     objectslist = Arch.pruneIncluded(objectslist)
     for obj in objectslist:
-        vindex = []
-        nindex = []
-        findex = []
+        findex = numpy.array([])
         m = None
         if obj.isDerivedFrom("Part::Feature"):
             print("exporting object ",obj.Name, obj.Shape)
@@ -205,21 +203,29 @@ def export(exportList,filename,tessellation=1):
             m = obj.Mesh
         if m:
             Topology = m.Topology
+            Facets = m.Facets
 
             # vertex indices
-            for v in Topology[0]:
-                vindex.extend([v.x*scale,v.y*scale,v.z*scale])
+            vindex = numpy.empty(len(Topology[0]) * 3)
+            for i in xrange(len(Topology[0])):
+                v = Topology[0][i]
+                vindex[list(range(i*3, i*3+3))] = (v.x*scale,v.y*scale,v.z*scale)
+
             # normals
-            for f in m.Facets:
-                n = f.Normal
-                nindex.extend([n.x,n.y,n.z])
+            nindex = numpy.empty(len(Facets) * 3)
+            for i in xrange(len(Facets)):
+                n = Facets[i].Normal
+                nindex[list(range(i*3, i*3+3))] = (n.x,n.y,n.z)
+
             # face indices
+            findex = numpy.empty(len(Topology[1]) * 6, numpy.int64)
             for i in xrange(len(Topology[1])):
                 f = Topology[1][i]
-                findex.extend([f[0],i,f[1],i,f[2],i])
+                findex[list(range(i*6, i*6+6))] = (f[0],i,f[1],i,f[2],i)
+
         print(len(vindex), " vert indices, ", len(nindex), " norm indices, ", len(findex), " face indices.")
-        vert_src = collada.source.FloatSource("cubeverts-array"+str(objind), numpy.array(vindex), ('X', 'Y', 'Z'))
-        normal_src = collada.source.FloatSource("cubenormals-array"+str(objind), numpy.array(nindex), ('X', 'Y', 'Z'))
+        vert_src = collada.source.FloatSource("cubeverts-array"+str(objind), vindex, ('X', 'Y', 'Z'))
+        normal_src = collada.source.FloatSource("cubenormals-array"+str(objind), nindex, ('X', 'Y', 'Z'))
         geom = collada.geometry.Geometry(colmesh, "geometry"+str(objind), obj.Name, [vert_src, normal_src])
         input_list = collada.source.InputList()
         input_list.addInput(0, 'VERTEX', "#cubeverts-array"+str(objind))
@@ -254,7 +260,7 @@ def export(exportList,filename,tessellation=1):
                 colmesh.effects.append(effect)
                 colmesh.materials.append(defaultmat)
             matnode = collada.scene.MaterialNode(matref, defaultmat, inputs=[])
-        triset = geom.createTriangleSet(numpy.array(findex), input_list, matref)
+        triset = geom.createTriangleSet(findex, input_list, matref)
         geom.primitives.append(triset)
         colmesh.geometries.append(geom)
         geomnode = collada.scene.GeometryNode(geom, [matnode])

--- a/src/Mod/Arch/importDAE.py
+++ b/src/Mod/Arch/importDAE.py
@@ -204,16 +204,18 @@ def export(exportList,filename,tessellation=1):
             print("exporting object ",obj.Name, obj.Mesh)
             m = obj.Mesh
         if m:
+            Topology = m.Topology
+
             # vertex indices
-            for v in m.Topology[0]:
+            for v in Topology[0]:
                 vindex.extend([v.x*scale,v.y*scale,v.z*scale])
             # normals
             for f in m.Facets:
                 n = f.Normal
                 nindex.extend([n.x,n.y,n.z])
             # face indices
-            for i in xrange(len(m.Topology[1])):
-                f = m.Topology[1][i]
+            for i in xrange(len(Topology[1])):
+                f = Topology[1][i]
                 findex.extend([f[0],i,f[1],i,f[2],i])
         print(len(vindex), " vert indices, ", len(nindex), " norm indices, ", len(findex), " face indices.")
         vert_src = collada.source.FloatSource("cubeverts-array"+str(objind), numpy.array(vindex), ('X', 'Y', 'Z'))


### PR DESCRIPTION
As discussed in pycollada/pycollada#64, FreeCAD consumes an enormous amount of RAM when exporting meshes to Collada format.  The change committed for FreeCAD/FreeCAD#753 does not seem to have any noticeable impact on this problem.  The root cause of the issue is that accessing m.Topology is computationally expensive for non-trivial meshes since each call to MeshPy::getTopology() iterates over all Points and Facets.  Therefore the current implementation has O(n^2) performance - m.Topology is accessed once for each vertex and each face, which results in a multiple calls to MeshPy::getTopology(), which in turn iterate over all of the Points and Facets.

My solution is to take a temporary copy of the Topology and Facet objects so that there is only one call to MeshPy::getTopology() and MeshPy::getFacets() per mesh.  This should not result in any increase in memory consumption since these methods were already being called (sometimes thousands of times) in the previous implementation.  However I also took a suggestion from pycollada/pycollada#64 and made a change to use the numpy arrays directly in order to save the memory overhead of the temporary copy.

With my test case (~50000 point mesh) this change reduced the export time from approximately 1 hour (consuming nearly 100GB of RAM) to around 20 seconds (with no noticeable memory usage).