### PR TITLE
Crowdin: Removing whitespace from widgets

### DIFF
--- a/src/Mod/Arch/Resources/ui/preferences-ifc.ui
+++ b/src/Mod/Arch/Resources/ui/preferences-ifc.ui
@@ -333,7 +333,7 @@
         <item>
          <widget class="QLabel" name="label_4">
           <property name="text">
-           <string>Exclude list: </string>
+           <string>Exclude list:</string>
           </property>
          </widget>
         </item>

--- a/src/Mod/Arch/importJSON.py
+++ b/src/Mod/Arch/importJSON.py
@@ -55,7 +55,7 @@ def export(exportList, filename):
 
     # Success
     FreeCAD.Console.PrintMessage(
-        translate("Arch", "successfully written ") + filename + "\n")
+        translate("Arch", "successfully written") + ' ' + filename + "\n")
 
 
 def getObjectData(obj):

--- a/src/Mod/Arch/importOBJ.py
+++ b/src/Mod/Arch/importOBJ.py
@@ -208,7 +208,7 @@ def export(exportList,filename):
                     done.append(mat.Name)
         outfile.write("# Material Count: " + str(len(materials)))
         outfile.close()
-        FreeCAD.Console.PrintMessage(translate("Arch","successfully written ") + filenamemtl + "\n")
+        FreeCAD.Console.PrintMessage(translate("Arch","successfully written") + ' ' + filenamemtl + "\n")
 
 
 def decode(name):
@@ -286,7 +286,7 @@ def insert(filename,docname):
                 material = line[7:]
         if activeobject:
             makeMesh(doc,activeobject,verts,facets,material,colortable)
-    FreeCAD.Console.PrintMessage(translate("Arch","successfully imported ")+filename+"\n")
+    FreeCAD.Console.PrintMessage(translate("Arch","Successfully imported") + ' ' + filename + "\n")
     return doc
 
 def makeMesh(doc,activeobject,verts,facets,material,colortable):

--- a/src/Mod/Arch/importWebGL.py
+++ b/src/Mod/Arch/importWebGL.py
@@ -26,7 +26,7 @@
 options: importWebGL.wireframeStyle = "faceloop" (can also be "multimaterial" or None)
 importWebGL.template = a complete html file, where $CameraData is a placeholder for the 
 FreeCAD camera, and $ObjectsData a placeholder for the FreeCAD objects.
-importWebGL.linewidth = an integer, specifyig the width of lines in "faceloop" mode"""
+importWebGL.linewidth = an integer, specifying the width of lines in "faceloop" mode"""
 
 import FreeCAD,Draft,Part,DraftGeomUtils
 
@@ -48,7 +48,7 @@ else:
 #  exported objects in WebGL format and a simple three.js-based viewer.
 
 tab = "                " # the tab size
-wireframeStyle = "faceloop" # this can be "faceloop", "multimaterial" or None
+wireframeStyle = "faceloop" # this can be "faceloop", "multimaterial", or None
 cameraPosition = None # set this to a tuple to change, for ex. (0,0,0)
 linewidth = 1
 template = """<!DOCTYPE html>
@@ -120,13 +120,13 @@ if open.__module__ in ['__builtin__','io']:
     pythonopen = open
     
 def export(exportList,filename):
-    "exports the given objects to a .html file"
+    "exports the given objects to an .html file"
 
     html = getHTML(exportList)
     outfile = pythonopen(filename,"wb")
     outfile.write(html)
     outfile.close()
-    FreeCAD.Console.PrintMessage(translate("Arch","successfully written ", utf8_decode=True)+filename+"\n")
+    FreeCAD.Console.PrintMessage(translate("Arch","Successfully written", utf8_decode=True) + ' ' + filename + "\n")
     
 def getHTML(objectsList):
     "returns the complete HTML code of a viewer for the given objects"
@@ -159,8 +159,8 @@ def getCameraData():
     return result
     
 def getObjectData(obj,wireframeMode=wireframeStyle):
-    """returns the geometry data of an object as three.js snippet. wireframeMode
-    can be multimaterial, faceloop or None"""
+    """returns the geometry data of an object as three.js snippet. 
+    wireframeMode can be multimaterial, faceloop, or None"""
     
     result = ""
     wires = []

--- a/src/Mod/Draft/Resources/ui/preferences-dxf.ui
+++ b/src/Mod/Draft/Resources/ui/preferences-dxf.ui
@@ -462,7 +462,7 @@ Ex: for files in millimeters: 1, in centimeters: 10, in meters: 1000, in inches:
         <item>
          <widget class="QLabel" name="label_7">
           <property name="text">
-           <string>Max Spline Segment: </string>
+           <string>Max Spline Segment:</string>
           </property>
           <property name="alignment">
            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>

--- a/src/Mod/Drawing/Gui/TaskOrthoViews.ui
+++ b/src/Mod/Drawing/Gui/TaskOrthoViews.ui
@@ -513,7 +513,7 @@
             <bool>false</bool>
            </property>
            <property name="text">
-            <string>Spacing dx / dy   </string>
+            <string>Spacing dx / dy</string>
            </property>
            <property name="margin">
             <number>2</number>
@@ -584,14 +584,14 @@
          <item row="2" column="0">
           <widget class="QLabel" name="label_9">
            <property name="text">
-            <string> Axis out and right</string>
+            <string>Axis out and right</string>
            </property>
           </widget>
          </item>
          <item row="3" column="0">
           <widget class="QLabel" name="label_11">
            <property name="text">
-            <string> Vertical tilt</string>
+            <string>Vertical tilt</string>
            </property>
           </widget>
          </item>


### PR DESCRIPTION
Modified the code so that the whitespace was hardcoded since translators on Crowdin weren't adding the whitespace. Please review if correct. 
+ found some other typos/grammar issues along the way. 
CC @yorikvanhavre