### PR TITLE
Crowdin: removal of apostrophes for translation clarrity

### DIFF
--- a/src/Gui/Action.cpp
+++ b/src/Gui/Action.cpp
@@ -543,7 +543,7 @@ void WorkbenchGroup::setWorkbenchData(int i, const QString& wb)
     workbenches[i]->setIcon(px);
     workbenches[i]->setText(name);
     workbenches[i]->setToolTip(tip);
-    workbenches[i]->setStatusTip(tr("Select the '%1' workbench").arg(name));
+    workbenches[i]->setStatusTip(tr("Select the %1 workbench").arg(name));
     workbenches[i]->setVisible(true);
     if (i < 9)
         workbenches[i]->setShortcut(QKeySequence(QString::fromUtf8("W,%1").arg(i+1)));
@@ -607,7 +607,7 @@ void WorkbenchGroup::slotAddWorkbench(const char* name)
             (*it)->setObjectName(wb);
             (*it)->setText(text);
             (*it)->setToolTip(tip);
-            (*it)->setStatusTip(tr("Select the '%1' workbench").arg(wb));
+            (*it)->setStatusTip(tr("Select the %1 workbench").arg(wb));
             (*it)->setVisible(true); // do this at last
             break;
         }
@@ -720,7 +720,7 @@ void RecentFilesAction::activateFile(int id)
     QString filename = files[id];
     QFileInfo fi(filename);
     if (!fi.exists() || !fi.isFile()) {
-        QMessageBox::critical(getMainWindow(), tr("File not found"), tr("The file '%1' cannot be opened.").arg(filename));
+        QMessageBox::critical(getMainWindow(), tr("File not found"), tr("The file %1 cannot be opened.").arg(filename));
         files.removeAll(filename);
         setFiles(files);
     }

--- a/src/Gui/Command.cpp
+++ b/src/Gui/Command.cpp
@@ -761,7 +761,7 @@ void MacroCommand::activated(int iMsg)
     if (!fi.exists()) {
         QMessageBox::critical(Gui::getMainWindow(),
             qApp->translate("Gui::MacroCommand", "Macro file doesn't exist"),
-            qApp->translate("Gui::MacroCommand", "No such macro file: '%1'").arg(fi.absoluteFilePath()));
+            qApp->translate("Gui::MacroCommand", "No such macro file: %1").arg(fi.absoluteFilePath()));
     }
     else {
         Application::Instance->macroManager()->run(MacroManager::File, fi.filePath().toUtf8());

--- a/src/Gui/CommandView.cpp
+++ b/src/Gui/CommandView.cpp
@@ -370,7 +370,7 @@ void StdCmdFreezeViews::onRestoreViews()
     QFile file(fn);
     if (!file.open(QFile::ReadOnly)) {
         QMessageBox::critical(getMainWindow(), QObject::tr("Restore views"),
-            QObject::tr("Cannot open file '%1'.").arg(fn));
+            QObject::tr("Can not open file %1.").arg(fn));
         return;
     }
 

--- a/src/Gui/DlgActionsImp.cpp
+++ b/src/Gui/DlgActionsImp.cpp
@@ -203,7 +203,7 @@ void DlgCustomActionsImp::on_actionListWidget_itemActivated(QTreeWidgetItem *ite
         if (!bFound)
         {
             QMessageBox::critical(this, tr("Macro not found"), 
-                    tr("Sorry, couldn't find macro file '%1'.").arg(scriptName));
+                    tr("Sorry, could not find macro file %1.").arg(scriptName));
         }
 
         // fill up labels with the command's data

--- a/src/Gui/View3DInventor.cpp
+++ b/src/Gui/View3DInventor.cpp
@@ -535,7 +535,7 @@ void View3DInventor::print(QPrinter* printer)
     if (!p.isActive() && !printer->outputFileName().isEmpty()) {
         qApp->setOverrideCursor(Qt::ArrowCursor);
         QMessageBox::critical(this, tr("Opening file failed"),
-            tr("Can't open file '%1' for writing.").arg(printer->outputFileName()));
+            tr("Can not open file %1 for writing.").arg(printer->outputFileName()));
         qApp->restoreOverrideCursor();
         return;
     }

--- a/src/Mod/Drawing/Gui/DrawingView.cpp
+++ b/src/Mod/Drawing/Gui/DrawingView.cpp
@@ -595,7 +595,7 @@ void DrawingView::print(QPrinter* printer)
     if (!p.isActive() && !printer->outputFileName().isEmpty()) {
         qApp->setOverrideCursor(Qt::ArrowCursor);
         QMessageBox::critical(this, tr("Opening file failed"),
-            tr("Can't open file '%1' for writing.").arg(printer->outputFileName()));
+            tr("Can not open file %1 for writing.").arg(printer->outputFileName()));
         qApp->restoreOverrideCursor();
         return;
     }

--- a/src/Mod/TechDraw/Gui/MDIViewPage.cpp
+++ b/src/Mod/TechDraw/Gui/MDIViewPage.cpp
@@ -673,7 +673,7 @@ void MDIViewPage::print(QPrinter* printer)
     if (!p.isActive() && !printer->outputFileName().isEmpty()) {
         qApp->setOverrideCursor(Qt::ArrowCursor);
         QMessageBox::critical(this, tr("Opening file failed"),
-            tr("Can't open file %1 for writing.").arg(printer->outputFileName()));
+            tr("Can not open file %1 for writing.").arg(printer->outputFileName()));
         qApp->restoreOverrideCursor();
         return;
     }


### PR DESCRIPTION
qtranslate interprets apostrophes as unicode and can be unclear for translators that the string contains an apostrophe. This PR removes them.