### PR TITLE
Fixes #3294 TechDraw: Prevent scale changing

### DIFF
--- a/src/Mod/TechDraw/Gui/TaskProjGroup.cpp
+++ b/src/Mod/TechDraw/Gui/TaskProjGroup.cpp
@@ -72,6 +72,16 @@ TaskProjGroup::TaskProjGroup(TechDraw::DrawProjGroup* featView, bool mode) :
 
     setFractionalScale(multiView->getScale());
     ui->cmbScaleType->setCurrentIndex(multiView->ScaleType.getValue());
+	
+	//Allow or prevent scale changing initially 
+	if (multiView->ScaleType.isValue("Custom"))	{
+		ui->sbScaleNum->setEnabled(true);
+		ui->sbScaleDen->setEnabled(true);
+	}
+	else {
+		ui->sbScaleNum->setEnabled(false);
+		ui->sbScaleDen->setEnabled(false);
+	}
 
     // Initially toggle view checkboxes if needed
     setupViewCheckboxes(true);
@@ -229,6 +239,10 @@ void TaskProjGroup::scaleTypeChanged(int index)
     if(blockUpdate)
         return;
 
+	//defaults to prevent scale changing 
+	ui->sbScaleNum->setEnabled(false);
+	ui->sbScaleDen->setEnabled(false);
+
     if(index == 0) {
         // Document Scale Type
         Gui::Command::doCommand(Gui::Command::Doc, "App.activeDocument().%s.ScaleType = '%s'", multiView->getNameInDocument()
@@ -241,6 +255,9 @@ void TaskProjGroup::scaleTypeChanged(int index)
         // Custom Scale Type
         Gui::Command::doCommand(Gui::Command::Doc, "App.activeDocument().%s.ScaleType = '%s'", multiView->getNameInDocument()
                                                                                              , "Custom");
+		ui->sbScaleNum->setEnabled(true);
+		ui->sbScaleDen->setEnabled(true);
+
         int a = ui->sbScaleNum->value();
         int b = ui->sbScaleDen->value();
         double scale = (double) a / (double) b;

--- a/src/Mod/TechDraw/Gui/TaskProjGroup.cpp
+++ b/src/Mod/TechDraw/Gui/TaskProjGroup.cpp
@@ -72,16 +72,16 @@ TaskProjGroup::TaskProjGroup(TechDraw::DrawProjGroup* featView, bool mode) :
 
     setFractionalScale(multiView->getScale());
     ui->cmbScaleType->setCurrentIndex(multiView->ScaleType.getValue());
-	
-	//Allow or prevent scale changing initially 
-	if (multiView->ScaleType.isValue("Custom"))	{
-		ui->sbScaleNum->setEnabled(true);
-		ui->sbScaleDen->setEnabled(true);
-	}
-	else {
-		ui->sbScaleNum->setEnabled(false);
-		ui->sbScaleDen->setEnabled(false);
-	}
+    
+    //Allow or prevent scale changing initially 
+    if (multiView->ScaleType.isValue("Custom"))	{
+        ui->sbScaleNum->setEnabled(true);
+        ui->sbScaleDen->setEnabled(true);
+    }
+    else {
+        ui->sbScaleNum->setEnabled(false);
+        ui->sbScaleDen->setEnabled(false);
+    }
 
     // Initially toggle view checkboxes if needed
     setupViewCheckboxes(true);
@@ -239,9 +239,9 @@ void TaskProjGroup::scaleTypeChanged(int index)
     if(blockUpdate)
         return;
 
-	//defaults to prevent scale changing 
-	ui->sbScaleNum->setEnabled(false);
-	ui->sbScaleDen->setEnabled(false);
+    //defaults to prevent scale changing 
+    ui->sbScaleNum->setEnabled(false);
+    ui->sbScaleDen->setEnabled(false);
 
     if(index == 0) {
         // Document Scale Type
@@ -255,8 +255,8 @@ void TaskProjGroup::scaleTypeChanged(int index)
         // Custom Scale Type
         Gui::Command::doCommand(Gui::Command::Doc, "App.activeDocument().%s.ScaleType = '%s'", multiView->getNameInDocument()
                                                                                              , "Custom");
-		ui->sbScaleNum->setEnabled(true);
-		ui->sbScaleDen->setEnabled(true);
+        ui->sbScaleNum->setEnabled(true);
+        ui->sbScaleDen->setEnabled(true);
 
         int a = ui->sbScaleNum->value();
         int b = ui->sbScaleDen->value();


### PR DESCRIPTION
Now scale number changing controls are disabled by default and enabled only in
Custom Scale mode.

Previously user was all time allowed to edit scale numerical values.
But this had effect on the size of generated views in drawing page only
when scale type was set to Custom.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
_______________________

Hi!

I am Tero K, and this is my first contribution to FC project. I hope the code and commits will be accepted, I had little trouble to get Git things properly done. Hopefully this can be merged to master, at least it says so on top of this PR submit page...

EDIT. Now I day later I understand that my code is not good. Perhaps I should refactor this functionality
on its own utility function, so code readability would be better????

  