### PR TITLE
Fix Crash in DrawViewDraft/DrawViewArch

### DIFF
--- a/src/Mod/TechDraw/App/DrawViewArch.cpp
+++ b/src/Mod/TechDraw/App/DrawViewArch.cpp
@@ -140,3 +140,72 @@ std::string DrawViewArch::getSVGTail(void)
     std::string tail = "\\n</svg>";
     return tail;
 }
+
+//DVA is still Source PropertyLink so needs different logic vs DV::Restore
+void DrawViewArch::Restore(Base::XMLReader &reader)
+{
+// this is temporary code for backwards compat (within v0.17).  can probably be deleted once there are no development
+// fcstd files with old property types in use. 
+    reader.readElement("Properties");
+    int Cnt = reader.getAttributeAsInteger("Count");
+
+    for (int i=0 ;i<Cnt ;i++) {
+        reader.readElement("Property");
+        const char* PropName = reader.getAttribute("name");
+        const char* TypeName = reader.getAttribute("type");
+        App::Property* schemaProp = getPropertyByName(PropName);
+        try {
+            if(schemaProp){
+                if (strcmp(schemaProp->getTypeId().getName(), TypeName) == 0){        //if the property type in obj == type in schema
+                    schemaProp->Restore(reader);                                      //nothing special to do
+                } else if (strcmp(PropName, "Source") == 0) {
+                    App::PropertyLinkGlobal glink;
+                    App::PropertyLink link;
+                    if (strcmp(glink.getTypeId().getName(),TypeName) == 0) {            //property in file is plg
+                        glink.setContainer(this);
+                        glink.Restore(reader);
+                        if (glink.getValue() != nullptr) {
+                            static_cast<App::PropertyLink*>(schemaProp)->setScope(App::LinkScope::Global);
+                            static_cast<App::PropertyLink*>(schemaProp)->setValue(glink.getValue());
+                        }
+                    } else if (strcmp(link.getTypeId().getName(),TypeName) == 0) {            //property in file is pl
+                        link.setContainer(this);
+                        link.Restore(reader);
+                        if (link.getValue() != nullptr) {
+                            static_cast<App::PropertyLink*>(schemaProp)->setScope(App::LinkScope::Global);
+                            static_cast<App::PropertyLink*>(schemaProp)->setValue(link.getValue());
+                        }
+                    
+                    } else {
+                        // has Source prop isn't PropertyLink or PropertyLinkGlobal! 
+                        Base::Console().Log("DrawViewArch::Restore - old Document Source is weird: %s\n", TypeName);
+                        // no idea
+                    }
+                } else {
+                    Base::Console().Log("DrawViewArch::Restore - old Document has unknown Property\n");
+                }
+            }
+        }
+        catch (const Base::XMLParseException&) {
+            throw; // re-throw
+        }
+        catch (const Base::Exception &e) {
+            Base::Console().Error("%s\n", e.what());
+        }
+        catch (const std::exception &e) {
+            Base::Console().Error("%s\n", e.what());
+        }
+        catch (const char* e) {
+            Base::Console().Error("%s\n", e);
+        }
+#ifndef FC_DEBUG
+        catch (...) {
+            Base::Console().Error("PropertyContainer::Restore: Unknown C++ exception thrown");
+        }
+#endif
+
+        reader.readEndElement("Property");
+    }
+    reader.readEndElement("Properties");
+
+}

--- a/src/Mod/TechDraw/App/DrawViewArch.h
+++ b/src/Mod/TechDraw/App/DrawViewArch.h
@@ -60,6 +60,8 @@ public:
     virtual const char* getViewProviderName(void) const {
         return "TechDrawGui::ViewProviderArch";
     }
+    void Restore(Base::XMLReader &reader) override;
+
 
 protected:
     virtual void onChanged(const App::Property* prop);

--- a/src/Mod/TechDraw/App/DrawViewDraft.cpp
+++ b/src/Mod/TechDraw/App/DrawViewDraft.cpp
@@ -143,6 +143,75 @@ std::string DrawViewDraft::getSVGTail(void)
     return tail;
 }
 
+//DVD is still compatible with old Source PropertyLink so doesn't need DV::Restore logic
+void DrawViewDraft::Restore(Base::XMLReader &reader)
+{
+// this is temporary code for backwards compat (within v0.17).  can probably be deleted once there are no development
+// fcstd files with old property types in use. 
+    reader.readElement("Properties");
+    int Cnt = reader.getAttributeAsInteger("Count");
+
+    for (int i=0 ;i<Cnt ;i++) {
+        reader.readElement("Property");
+        const char* PropName = reader.getAttribute("name");
+        const char* TypeName = reader.getAttribute("type");
+        App::Property* schemaProp = getPropertyByName(PropName);
+        try {
+            if(schemaProp){
+                if (strcmp(schemaProp->getTypeId().getName(), TypeName) == 0){        //if the property type in obj == type in schema
+                    schemaProp->Restore(reader);                                      //nothing special to do
+                } else if (strcmp(PropName, "Source") == 0) {
+                    App::PropertyLinkGlobal glink;
+                    App::PropertyLink link;
+                    if (strcmp(glink.getTypeId().getName(),TypeName) == 0) {            //property in file is plg
+                        glink.setContainer(this);
+                        glink.Restore(reader);
+                        if (glink.getValue() != nullptr) {
+                            static_cast<App::PropertyLink*>(schemaProp)->setScope(App::LinkScope::Global);
+                            static_cast<App::PropertyLink*>(schemaProp)->setValue(glink.getValue());
+                        }
+                    } else if (strcmp(link.getTypeId().getName(),TypeName) == 0) {            //property in file is pl
+                        link.setContainer(this);
+                        link.Restore(reader);
+                        if (link.getValue() != nullptr) {
+                            static_cast<App::PropertyLink*>(schemaProp)->setScope(App::LinkScope::Global);
+                            static_cast<App::PropertyLink*>(schemaProp)->setValue(link.getValue());
+                        }
+                    
+                    } else {
+                        // has Source prop isn't PropertyLink or PropertyLinkGlobal! 
+                        Base::Console().Log("DrawViewDraft::Restore - old Document Source is weird: %s\n", TypeName);
+                        // no idea
+                    }
+                } else {
+                    Base::Console().Log("DrawViewDraft::Restore - old Document has unknown Property\n");
+                }
+            }
+        }
+        catch (const Base::XMLParseException&) {
+            throw; // re-throw
+        }
+        catch (const Base::Exception &e) {
+            Base::Console().Error("%s\n", e.what());
+        }
+        catch (const std::exception &e) {
+            Base::Console().Error("%s\n", e.what());
+        }
+        catch (const char* e) {
+            Base::Console().Error("%s\n", e);
+        }
+#ifndef FC_DEBUG
+        catch (...) {
+            Base::Console().Error("PropertyContainer::Restore: Unknown C++ exception thrown");
+        }
+#endif
+
+        reader.readEndElement("Property");
+    }
+    reader.readEndElement("Properties");
+
+}
+
 // Python Drawing feature ---------------------------------------------------------
 
 namespace App {

--- a/src/Mod/TechDraw/App/DrawViewDraft.h
+++ b/src/Mod/TechDraw/App/DrawViewDraft.h
@@ -61,6 +61,8 @@ public:
     virtual const char* getViewProviderName(void) const {
         return "TechDrawGui::ViewProviderDraft";
     }
+    void Restore(Base::XMLReader &reader) override;
+
 
 protected:
     virtual void onChanged(const App::Property* prop);


### PR DESCRIPTION
Special handling for DrawViewDraft/DrawViewArch was omitted from commit 98be3a3f.  This PR corrects that omission .  Please merge. 

Thanks,
wf

- when restoring DVD/DVA from old files, convert Source from
  PropertyLinkGlobal to PropertyLink with Scope = Global. Note
  subtle difference from Restore method in DrawView - PropertyLink
  vs PropertyLinkList.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
