### PR TITLE
Update Draft.py - Fixed problem with Draft.makePoint

### DIFF
--- a/src/Mod/Draft/Draft.py
+++ b/src/Mod/Draft/Draft.py
@@ -2903,9 +2903,12 @@ def makePoint(X=0, Y=0, Z=0,color=None,name = "Point", point_size= 5):
     obj.Z = Z
     if gui:
         _ViewProviderPoint(obj.ViewObject)
-        if not color:
+        if hasattr(FreeCADGui,"draftToolBar"):
             color = FreeCADGui.draftToolBar.getDefaultColor('ui')
-        obj.ViewObject.PointColor = (float(color[0]), float(color[1]), float(color[2]))
+        else:
+            pc = getParam("color",255)>>8
+            color = (float(pc/255.0),float(pc/255.0),float(pc/255.0))
+        obj.ViewObject.PointColor = color
         obj.ViewObject.PointSize = point_size
         obj.ViewObject.Visibility = True
     select(obj)


### PR DESCRIPTION
Sry, I'm not fit with github.

1. Restart FreeCAD
2. Create new doc
3. Test an example from wiki:

`import Draft`
`Draft.makePoint(6,4,2)`

> Traceback (most recent call last):
  File "<input>", line 1, in <module>
  File ".../FreeCAD/freecad/Mod/Draft/Draft.py", line 2907, in makePoint
    color = FreeCADGui.draftToolBar.getDefaultColor('ui')
AttributeError: 'module' object has no attribute 'draftToolBar'


