### PR TITLE
Fix Path Keep View and Sim in Sync,typo Linuxcnc_post

### DIFF
--- a/src/Mod/Path/PathScripts/PathSimulatorGui.py
+++ b/src/Mod/Path/PathScripts/PathSimulatorGui.py
@@ -186,10 +186,10 @@ class PathSimulation:
                 (pathSolid, self.curpos) = self.GetPathSolid(self.tool, cmd, self.curpos)
         if cmd.Name in ['G81', 'G82', 'G83']:
             if self.firstDrill:
-                extendcommand = Path.Command('G1', {"X": 0.0, "Y": 0.0, "Z": cmd.r})
+                extendcommand = Path.Command('G0', {"X": 0.0, "Y": 0.0, "Z": cmd.r})
                 self.curpos = self.RapidMove(extendcommand, self.curpos)
                 self.firstDrill = False
-            extendcommand = Path.Command('G1', {"X": cmd.x, "Y": cmd.y, "Z": cmd.r})
+            extendcommand = Path.Command('G0', {"X": cmd.x, "Y": cmd.y, "Z": cmd.r})
             self.curpos = self.RapidMove(extendcommand, self.curpos)
             extendcommand = Path.Command('G1', {"X": cmd.x, "Y": cmd.y, "Z": cmd.z})
             self.curpos = self.RapidMove(extendcommand, self.curpos)
@@ -242,9 +242,9 @@ class PathSimulation:
         if cmd.Name in ['G81', 'G82', 'G83']:
             extendcommands = []
             if self.firstDrill:
-                extendcommands.append(Path.Command('G1', {"X": 0.0, "Y": 0.0, "Z": cmd.r}))
+                extendcommands.append(Path.Command('G0', {"X": 0.0, "Y": 0.0, "Z": cmd.r}))
                 self.firstDrill = False
-            extendcommands.append(Path.Command('G1', {"X": cmd.x, "Y": cmd.y, "Z": cmd.r}))
+            extendcommands.append(Path.Command('G0', {"X": cmd.x, "Y": cmd.y, "Z": cmd.r}))
             extendcommands.append(Path.Command('G1', {"X": cmd.x, "Y": cmd.y, "Z": cmd.z}))
             extendcommands.append(Path.Command('G1', {"X": cmd.x, "Y": cmd.y, "Z": cmd.r}))
             for ecmd in extendcommands:

--- a/src/Mod/Path/PathScripts/post/linuxcnc_post.py
+++ b/src/Mod/Path/PathScripts/post/linuxcnc_post.py
@@ -272,7 +272,7 @@ def parse(pathobj):
     params = ['X', 'Y', 'Z', 'A', 'B', 'C', 'I', 'J', 'F', 'S', 'T', 'Q', 'R', 'L', 'H', 'D', 'P']
     # keep track for no doubles
     currLocation = {}
-    firstmove = Path.Command("G0", {"X": -1, "Y": -1, "Z": -1, "F": -1})
+    firstmove = Path.Command("G0", {"X": -1, "Y": -1, "Z": -1, "F": 0.0})
     currLocation.update(firstmove.Parameters)
 
     if hasattr(pathobj, "Group"):  # We have a compound or project.
@@ -306,8 +306,11 @@ def parse(pathobj):
                     if param == 'F' and (currLocation[param] == c.Parameters[param] and OUTPUT_DOUBLES):
                         if c.Name not in ["G0", "G00"]:  # linuxcnc doesn't use rapid speeds
                             speed = Units.Quantity(c.Parameters['F'], FreeCAD.Units.Velocity)
-                            outstring.append(
+                            if speed.getValueAs(UNIT_SPEED_FORMAT) > 0.0:
+                                outstring.append(
                                 param + format(float(speed.getValueAs(UNIT_SPEED_FORMAT)), precision_string))
+                        else:
+                            continue
                     elif param == 'T':
                         outstring.append(param + str(int(c.Parameters['T'])))
                     elif param == 'H':

--- a/src/Mod/Path/PathSimulator/App/PathSim.cpp
+++ b/src/Mod/Path/PathSimulator/App/PathSim.cpp
@@ -50,7 +50,7 @@ PathSim::PathSim()
 PathSim::~PathSim()
 {
 	if (m_stock != nullptr)
-		delete m_stock;
+	    delete m_stock;
 	if (m_tool != nullptr)
 		delete m_tool;
 }
@@ -79,6 +79,13 @@ void PathSim::SetCurrentTool(Tool * tool)
 
 	case Tool::UNDEFINED:
 	case Tool::DRILL:
+		tp = cSimTool::CHAMFER;
+		angle = tool->CuttingEdgeAngle;
+        if (angle > 180) 
+        {
+            angle = 180;
+        }
+		break;
 	case Tool::CENTERDRILL:
 	case Tool::COUNTERSINK:
 	case Tool::COUNTERBORE:
@@ -88,12 +95,18 @@ void PathSim::SetCurrentTool(Tool * tool)
 	case Tool::SLOTCUTTER:
 	case Tool::CORNERROUND:
 	case Tool::ENGRAVER:
-		break; // quiet warnings
+		tp = cSimTool::CHAMFER;
+		angle = tool->CuttingEdgeAngle;
+        if (angle > 180) 
+        {
+            angle = 180;
+        }
+		break;
 
+		break; // quiet warnings
 	}
 	m_tool = new cSimTool(tp, tool->Diameter / 2.0, angle);
 }
-
 
 Base::Placement * PathSim::ApplyCommand(Base::Placement * pos, Command * cmd)
 {
@@ -102,7 +115,7 @@ Base::Placement * PathSim::ApplyCommand(Base::Placement * pos, Command * cmd)
 	toPos.UpdateCmd(*cmd);
 	if (cmd->Name == "G0" || cmd->Name == "G1")
 	{
-		m_stock->ApplyLinearTool(fromPos, toPos, *m_tool);
+        m_stock->ApplyLinearTool(fromPos, toPos, *m_tool);
 	}
 	else if (cmd->Name == "G2")
 	{
@@ -116,6 +129,7 @@ Base::Placement * PathSim::ApplyCommand(Base::Placement * pos, Command * cmd)
 		Point3D cent(vcent);
 		m_stock->ApplyCircularTool(fromPos, toPos, cent, *m_tool, true);
 	}
+
 	Base::Placement *plc = new Base::Placement();
 	Vector3d vec(toPos.x, toPos.y, toPos.z);
 	plc->setPosition(vec);


### PR DESCRIPTION
Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
The commit is about changes to keep Path Creater View and Simulation View in Sync on viewing 
rapid and feed lines in color  
and adding different Shapes of tools in the CPP file 
also a need of Startcommand without Feedrate to the Post as EMC Linuxcnc  dont like this 
AS a FIX to sliptonics push of my already pushed files 
