### PR TITLE
Draft snap and stylesheet improvements

### DIFF
--- a/src/Gui/Stylesheets/Dark-blue.qss
+++ b/src/Gui/Stylesheets/Dark-blue.qss
@@ -1885,20 +1885,20 @@ QToolBar > QToolButton:pressed {
 }
 
 /* ToolBar menu buttons (buttons with drop-down menu) */
-QToolBar > QToolButton#qt_toolbutton_menubutton {
+QToolButton#qt_toolbutton_menubutton {
     padding-right: 20px; /* Hack to add more width to buttons with menu */
     border: 1px solid transparent;
     border-radius: 3px;
 }
 
-QToolBar > QToolButton#qt_toolbutton_menubutton:hover,
-QToolBar > QToolButton#qt_toolbutton_menubutton:pressed,
-QToolBar > QToolButton#qt_toolbutton_menubutton:open {
+QToolButton#qt_toolbutton_menubutton:hover,
+QToolButton#qt_toolbutton_menubutton:pressed,
+QToolButton#qt_toolbutton_menubutton:open {
     border: 1px solid #7cabf9;
 }
 
 QToolBar QToolButton::menu-button,
-QToolBar > QToolButton#qt_toolbutton_menubutton::menu-button {
+QToolButton#qt_toolbutton_menubutton::menu-button {
     border: none;
     border-top-right-radius: 3px;
     border-bottom-right-radius: 3px;
@@ -1907,9 +1907,9 @@ QToolBar > QToolButton#qt_toolbutton_menubutton::menu-button {
     background-color: transparent;
 }
 
-QToolBar > QToolButton#qt_toolbutton_menubutton::menu-button:hover,
-QToolBar > QToolButton#qt_toolbutton_menubutton::menu-button:pressed,
-QToolBar > QToolButton#qt_toolbutton_menubutton::menu-button:open {
+QToolButton#qt_toolbutton_menubutton::menu-button:hover,
+QToolButton#qt_toolbutton_menubutton::menu-button:pressed,
+QToolButton#qt_toolbutton_menubutton::menu-button:open {
     background-color: qlineargradient(spread:pad, x1:1, y1:0.8, x2:1, y2:0, stop:0 #5e90fa, stop:1 #7cabf9);
 }
 

--- a/src/Gui/Stylesheets/Dark-green.qss
+++ b/src/Gui/Stylesheets/Dark-green.qss
@@ -1885,20 +1885,20 @@ QToolBar > QToolButton:pressed {
 }
 
 /* ToolBar menu buttons (buttons with drop-down menu) */
-QToolBar > QToolButton#qt_toolbutton_menubutton {
+QToolButton#qt_toolbutton_menubutton {
     padding-right: 20px; /* Hack to add more width to buttons with menu */
     border: 1px solid transparent;
     border-radius: 3px;
 }
 
-QToolBar > QToolButton#qt_toolbutton_menubutton:hover,
-QToolBar > QToolButton#qt_toolbutton_menubutton:pressed,
-QToolBar > QToolButton#qt_toolbutton_menubutton:open {
+QToolButton#qt_toolbutton_menubutton:hover,
+QToolButton#qt_toolbutton_menubutton:pressed,
+QToolButton#qt_toolbutton_menubutton:open {
     border: 1px solid #a5c61a;
 }
 
 QToolBar QToolButton::menu-button,
-QToolBar > QToolButton#qt_toolbutton_menubutton::menu-button {
+QToolButton#qt_toolbutton_menubutton::menu-button {
     border: none;
     border-top-right-radius: 3px;
     border-bottom-right-radius: 3px;
@@ -1907,9 +1907,9 @@ QToolBar > QToolButton#qt_toolbutton_menubutton::menu-button {
     background-color: transparent;
 }
 
-QToolBar > QToolButton#qt_toolbutton_menubutton::menu-button:hover,
-QToolBar > QToolButton#qt_toolbutton_menubutton::menu-button:pressed,
-QToolBar > QToolButton#qt_toolbutton_menubutton::menu-button:open {
+QToolButton#qt_toolbutton_menubutton::menu-button:hover,
+QToolButton#qt_toolbutton_menubutton::menu-button:pressed,
+QToolButton#qt_toolbutton_menubutton::menu-button:open {
     background-color: qlineargradient(spread:pad, x1:1, y1:0.8, x2:1, y2:0, stop:0 #94b30f, stop:1 #a5c61a);
 }
 

--- a/src/Gui/Stylesheets/Dark-orange.qss
+++ b/src/Gui/Stylesheets/Dark-orange.qss
@@ -1885,20 +1885,20 @@ QToolBar > QToolButton:pressed {
 }
 
 /* ToolBar menu buttons (buttons with drop-down menu) */
-QToolBar > QToolButton#qt_toolbutton_menubutton {
+QToolButton#qt_toolbutton_menubutton {
     padding-right: 20px; /* Hack to add more width to buttons with menu */
     border: 1px solid transparent;
     border-radius: 3px;
 }
 
-QToolBar > QToolButton#qt_toolbutton_menubutton:hover,
-QToolBar > QToolButton#qt_toolbutton_menubutton:pressed,
-QToolBar > QToolButton#qt_toolbutton_menubutton:open {
+QToolButton#qt_toolbutton_menubutton:hover,
+QToolButton#qt_toolbutton_menubutton:pressed,
+QToolButton#qt_toolbutton_menubutton:open {
     border: 1px solid #e3b64d;
 }
 
 QToolBar QToolButton::menu-button,
-QToolBar > QToolButton#qt_toolbutton_menubutton::menu-button {
+QToolButton#qt_toolbutton_menubutton::menu-button {
     border: none;
     border-top-right-radius: 3px;
     border-bottom-right-radius: 3px;
@@ -1907,9 +1907,9 @@ QToolBar > QToolButton#qt_toolbutton_menubutton::menu-button {
     background-color: transparent;
 }
 
-QToolBar > QToolButton#qt_toolbutton_menubutton::menu-button:hover,
-QToolBar > QToolButton#qt_toolbutton_menubutton::menu-button:pressed,
-QToolBar > QToolButton#qt_toolbutton_menubutton::menu-button:open {
+QToolButton#qt_toolbutton_menubutton::menu-button:hover,
+QToolButton#qt_toolbutton_menubutton::menu-button:pressed,
+QToolButton#qt_toolbutton_menubutton::menu-button:open {
     background-color: qlineargradient(spread:pad, x1:1, y1:0.8, x2:1, y2:0, stop:0 #daa116, stop:1 #e3b64d);
 }
 

--- a/src/Gui/Stylesheets/Light-blue.qss
+++ b/src/Gui/Stylesheets/Light-blue.qss
@@ -1882,20 +1882,20 @@ QToolBar > QToolButton:pressed {
 }
 
 /* ToolBar menu buttons (buttons with drop-down menu) */
-QToolBar > QToolButton#qt_toolbutton_menubutton {
+QToolButton#qt_toolbutton_menubutton {
     padding-right: 20px; /* Hack to add more width to buttons with menu */
     border: 1px solid transparent;
     border-radius: 3px;
 }
 
-QToolBar > QToolButton#qt_toolbutton_menubutton:hover,
-QToolBar > QToolButton#qt_toolbutton_menubutton:pressed,
-QToolBar > QToolButton#qt_toolbutton_menubutton:open {
+QToolButton#qt_toolbutton_menubutton:hover,
+QToolButton#qt_toolbutton_menubutton:pressed,
+QToolButton#qt_toolbutton_menubutton:open {
     border: 1px solid #7cabf9;
 }
 
 QToolBar QToolButton::menu-button,
-QToolBar > QToolButton#qt_toolbutton_menubutton::menu-button {
+QToolButton#qt_toolbutton_menubutton::menu-button {
     border: none;
     border-top-right-radius: 3px;
     border-bottom-right-radius: 3px;
@@ -1904,9 +1904,9 @@ QToolBar > QToolButton#qt_toolbutton_menubutton::menu-button {
     background-color: transparent;
 }
 
-QToolBar > QToolButton#qt_toolbutton_menubutton::menu-button:hover,
-QToolBar > QToolButton#qt_toolbutton_menubutton::menu-button:pressed,
-QToolBar > QToolButton#qt_toolbutton_menubutton::menu-button:open {
+QToolButton#qt_toolbutton_menubutton::menu-button:hover,
+QToolButton#qt_toolbutton_menubutton::menu-button:pressed,
+QToolButton#qt_toolbutton_menubutton::menu-button:open {
     background-color: qlineargradient(spread:pad, x1:1, y1:0.8, x2:1, y2:0, stop:0 #5e90fa, stop:1 #7cabf9);
 }
 

--- a/src/Gui/Stylesheets/Light-green.qss
+++ b/src/Gui/Stylesheets/Light-green.qss
@@ -1882,20 +1882,20 @@ QToolBar > QToolButton:pressed {
 }
 
 /* ToolBar menu buttons (buttons with drop-down menu) */
-QToolBar > QToolButton#qt_toolbutton_menubutton {
+QToolButton#qt_toolbutton_menubutton {
     padding-right: 20px; /* Hack to add more width to buttons with menu */
     border: 1px solid transparent;
     border-radius: 3px;
 }
 
-QToolBar > QToolButton#qt_toolbutton_menubutton:hover,
-QToolBar > QToolButton#qt_toolbutton_menubutton:pressed,
-QToolBar > QToolButton#qt_toolbutton_menubutton:open {
+QToolButton#qt_toolbutton_menubutton:hover,
+QToolButton#qt_toolbutton_menubutton:pressed,
+QToolButton#qt_toolbutton_menubutton:open {
     border: 1px solid #a5c61a;
 }
 
 QToolBar QToolButton::menu-button,
-QToolBar > QToolButton#qt_toolbutton_menubutton::menu-button {
+QToolButton#qt_toolbutton_menubutton::menu-button {
     border: none;
     border-top-right-radius: 3px;
     border-bottom-right-radius: 3px;
@@ -1904,9 +1904,9 @@ QToolBar > QToolButton#qt_toolbutton_menubutton::menu-button {
     background-color: transparent;
 }
 
-QToolBar > QToolButton#qt_toolbutton_menubutton::menu-button:hover,
-QToolBar > QToolButton#qt_toolbutton_menubutton::menu-button:pressed,
-QToolBar > QToolButton#qt_toolbutton_menubutton::menu-button:open {
+QToolButton#qt_toolbutton_menubutton::menu-button:hover,
+QToolButton#qt_toolbutton_menubutton::menu-button:pressed,
+QToolButton#qt_toolbutton_menubutton::menu-button:open {
     background-color: qlineargradient(spread:pad, x1:1, y1:0.8, x2:1, y2:0, stop:0 #94b30f, stop:1 #a5c61a);
 }
 

--- a/src/Gui/Stylesheets/Light-orange.qss
+++ b/src/Gui/Stylesheets/Light-orange.qss
@@ -1882,20 +1882,20 @@ QToolBar > QToolButton:pressed {
 }
 
 /* ToolBar menu buttons (buttons with drop-down menu) */
-QToolBar > QToolButton#qt_toolbutton_menubutton {
+QToolButton#qt_toolbutton_menubutton {
     padding-right: 20px; /* Hack to add more width to buttons with menu */
     border: 1px solid transparent;
     border-radius: 3px;
 }
 
-QToolBar > QToolButton#qt_toolbutton_menubutton:hover,
-QToolBar > QToolButton#qt_toolbutton_menubutton:pressed,
-QToolBar > QToolButton#qt_toolbutton_menubutton:open {
+QToolButton#qt_toolbutton_menubutton:hover,
+QToolButton#qt_toolbutton_menubutton:pressed,
+QToolButton#qt_toolbutton_menubutton:open {
     border: 1px solid #e3b64d;
 }
 
 QToolBar QToolButton::menu-button,
-QToolBar > QToolButton#qt_toolbutton_menubutton::menu-button {
+QToolButton#qt_toolbutton_menubutton::menu-button {
     border: none;
     border-top-right-radius: 3px;
     border-bottom-right-radius: 3px;
@@ -1904,9 +1904,9 @@ QToolBar > QToolButton#qt_toolbutton_menubutton::menu-button {
     background-color: transparent;
 }
 
-QToolBar > QToolButton#qt_toolbutton_menubutton::menu-button:hover,
-QToolBar > QToolButton#qt_toolbutton_menubutton::menu-button:pressed,
-QToolBar > QToolButton#qt_toolbutton_menubutton::menu-button:open {
+QQToolButton#qt_toolbutton_menubutton::menu-button:hover,
+QToolButton#qt_toolbutton_menubutton::menu-button:pressed,
+QToolButton#qt_toolbutton_menubutton::menu-button:open {
     background-color: qlineargradient(spread:pad, x1:1, y1:0.8, x2:1, y2:0, stop:0 #daa116, stop:1 #e3b64d);
 }
 

--- a/src/Gui/Stylesheets/Light-orange.qss
+++ b/src/Gui/Stylesheets/Light-orange.qss
@@ -1904,7 +1904,7 @@ QToolButton#qt_toolbutton_menubutton::menu-button {
     background-color: transparent;
 }
 
-QQToolButton#qt_toolbutton_menubutton::menu-button:hover,
+QToolButton#qt_toolbutton_menubutton::menu-button:hover,
 QToolButton#qt_toolbutton_menubutton::menu-button:pressed,
 QToolButton#qt_toolbutton_menubutton::menu-button:open {
     background-color: qlineargradient(spread:pad, x1:1, y1:0.8, x2:1, y2:0, stop:0 #daa116, stop:1 #e3b64d);

--- a/src/Mod/Draft/DraftSnap.py
+++ b/src/Mod/Draft/DraftSnap.py
@@ -1177,12 +1177,14 @@ class Snapper:
 
     def makeSnapToolBar(self):
         "builds the Snap toolbar"
-        self.toolbar = QtGui.QToolBar(None)
+        mw = FreeCADGui.getMainWindow()
+        self.toolbar = QtGui.QToolBar(mw)
+        mw.addToolBar(QtCore.Qt.TopToolBarArea, self.toolbar)
         self.toolbar.setObjectName("Draft Snap")
         self.toolbar.setWindowTitle(QtCore.QCoreApplication.translate("Workbench", "Draft Snap"))
         self.toolbarButtons = []
         # grid button
-        self.gridbutton = QtGui.QAction(None)
+        self.gridbutton = QtGui.QAction(mw)
         self.gridbutton.setIcon(QtGui.QIcon(":/icons/Draft_Grid.svg"))
         self.gridbutton.setText(QtCore.QCoreApplication.translate("Draft_ToggleGrid","Grid"))
         self.gridbutton.setToolTip(QtCore.QCoreApplication.translate("Draft_ToggleGrid","Toggles the Draft grid On/Off"))
@@ -1191,7 +1193,7 @@ class Snapper:
         QtCore.QObject.connect(self.gridbutton,QtCore.SIGNAL("triggered()"),self.toggleGrid)
         self.toolbar.addAction(self.gridbutton)
         # master button
-        self.masterbutton = QtGui.QAction(None)
+        self.masterbutton = QtGui.QAction(mw)
         self.masterbutton.setIcon(QtGui.QIcon(":/icons/Snap_Lock.svg"))
         self.masterbutton.setText(QtCore.QCoreApplication.translate("Draft_Snap_Lock","Lock"))
         self.masterbutton.setToolTip(QtCore.QCoreApplication.translate("Draft_Snap_Lock","Toggle On/Off"))
@@ -1203,7 +1205,7 @@ class Snapper:
         self.toolbar.addAction(self.masterbutton)
         for c,i in self.cursors.items():
             if i:
-                b = QtGui.QAction(None)
+                b = QtGui.QAction(mw)
                 b.setIcon(QtGui.QIcon(i))
                 if c == "passive":
                     b.setText(QtCore.QCoreApplication.translate("Draft_Snap_Near","Nearest"))
@@ -1220,7 +1222,7 @@ class Snapper:
                 QtCore.QObject.connect(b,QtCore.SIGNAL("toggled(bool)"),self.saveSnapModes)
         # adding non-snap button
         for n in ["Dimensions","WorkingPlane"]:
-            b = QtGui.QAction(None)
+            b = QtGui.QAction(mw)
             b.setIcon(QtGui.QIcon(":/icons/Snap_"+n+".svg"))
             b.setText(QtCore.QCoreApplication.translate("Draft_Snap_"+n,n))
             b.setToolTip(QtCore.QCoreApplication.translate("Draft_Snap_"+n,n))


### PR DESCRIPTION
- Stylesheets general button with menu support
- Improved reusability of snap toolbar commands.
- Ability to change draft snap toolbar icon size from preferences. Without the need to restart FreeCAD after.

Forum discussion:

https://forum.freecadweb.org/viewtopic.php?f=8&t=13509&p=208740#p208740