### PR TITLE
Fix crash when deleting View with Dimensions

### DIFF
--- a/src/Mod/TechDraw/App/DrawViewPart.cpp
+++ b/src/Mod/TechDraw/App/DrawViewPart.cpp
@@ -522,11 +522,14 @@ std::vector<TechDraw::DrawGeomHatch*> DrawViewPart::getGeomHatches() const
     return result;
 }
 
+//return *unique* list of Dimensions which reference this DVP
 std::vector<TechDraw::DrawViewDimension*> DrawViewPart::getDimensions() const
 {
     std::vector<TechDraw::DrawViewDimension*> result;
     std::vector<App::DocumentObject*> children = getInList();
-    for (std::vector<App::DocumentObject*>::iterator it = children.begin(); it != children.end(); ++it) {
+    std::sort(children.begin(),children.end(),std::less<App::DocumentObject*>());
+    std::vector<App::DocumentObject*>::iterator newEnd = std::unique(children.begin(),children.end());
+    for (std::vector<App::DocumentObject*>::iterator it = children.begin(); it != newEnd; ++it) {
         if ((*it)->getTypeId().isDerivedFrom(DrawViewDimension::getClassTypeId())) {
             TechDraw::DrawViewDimension* dim = dynamic_cast<TechDraw::DrawViewDimension*>(*it);
             result.push_back(dim);


### PR DESCRIPTION
This PR correct issue reported here; [FreeCAD Crash upon Deleting Projection Group](https://www.forum.freecadweb.org/viewtopic.php?f=35&t=26273&sid=8b6915219372c2f389d0bba275016794).  

- if a Dimension has multiple references to a
  DrawViewPart (ex vertex-vertex) the Dimension
  will appear twice in the DVP's InList.  This
  commit ensures that the Dimension is only
  deleted once when deleting the DVP.

Please merge. 

Thanks,
wf

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
