### PR TITLE
Fix Path Sim TOOLEndmill DefaultToolSET

### DIFF
--- a/src/Mod/Path/PathSimulator/App/PathSim.cpp
+++ b/src/Mod/Path/PathSimulator/App/PathSim.cpp
@@ -92,6 +92,9 @@ void PathSim::SetCurrentTool(Tool * tool)
 	case Tool::REAMER:
 	case Tool::TAP:
 	case Tool::ENDMILL:
+			tp = cSimTool::FLAT;
+			angle = 180;
+			break;
 	case Tool::SLOTCUTTER:
 	case Tool::CORNERROUND:
 	case Tool::ENGRAVER:
@@ -103,7 +106,11 @@ void PathSim::SetCurrentTool(Tool * tool)
         }
 		break;
 
-		break; // quiet warnings
+	default:
+			tp = cSimTool::FLAT;
+			angle = 180;
+			break;
+
 	}
 	m_tool = new cSimTool(tp, tool->Diameter / 2.0, angle);
 }


### PR DESCRIPTION
Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x ] Branch rebased on latest master `git pull --rebase upstream master`
- [x ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
AS a TEST Faild User reported i added a Default Tool
and Changed the CASE Switch to run Endmill Tool as a Regular Tool

REASON the SIM grabbed  the Tool-> CuttingEdgeAngle as given 0 HUMEN Reading
The Real Angel is 180  as SIM needs to Process 
