### PR TITLE
PartDesign: OnDelete basefeature fixing and visualization

### DIFF
--- a/src/Mod/PartDesign/Gui/ViewProvider.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProvider.cpp
@@ -36,6 +36,7 @@
 #include <Base/Exception.h>
 #include <Mod/PartDesign/App/Body.h>
 #include <Mod/PartDesign/App/Feature.h>
+#include <Mod/Sketcher/App/SketchObject.h>
 
 #include "TaskFeatureParameters.h"
 
@@ -202,26 +203,41 @@ void ViewProvider::onChanged(const App::Property* prop) {
 bool ViewProvider::onDelete(const std::vector<std::string> &)
 {
     PartDesign::Feature* feature = static_cast<PartDesign::Feature*>(getObject());
-    App::DocumentObject* previous = feature->getBaseObject(/* silent = */ true );
 
-    // Make the tip or the previous feature visiable again with preference to the previous one
-    // if the feature was visiable itself
-    if (isShow()) {
-        // TODO TaskDlgFeatureParameters::reject has the same code. May be this one is excess?
-        //      (2015-07-24, Fat-Zer)
-        if (previous && Gui::Application::Instance->getViewProvider(previous)) {
-            Gui::Application::Instance->getViewProvider(previous)->show();
-        } else {
-            // Body feature housekeeping
-            Part::BodyBase* body = PartDesign::Body::findBodyOf(getObject());
-            if (body != NULL) {
-                App::DocumentObject* tip = body->Tip.getValue();
-                if (tip && Gui::Application::Instance->getViewProvider(tip)) {
-                    Gui::Application::Instance->getViewProvider(tip)->show();
-                }
-            }
-        }
+    std::vector<App::DocumentObject*> inlinks = feature->getInList();
+
+    App::DocumentObject* previousfeat = feature->BaseFeature.getValue();
+
+    // Visibility - we want:
+    // 1. If the visible object is not the one being deleted, we leave that one visible.
+    // 2. If the visible object is the one being deleted, we make the previous object visible.
+    if (isShow() && previousfeat && Gui::Application::Instance->getViewProvider(previousfeat)) {
+        Gui::Application::Instance->getViewProvider(previousfeat)->show();
     }
+
+    // find surrounding features in the tree
+    Part::BodyBase* body = PartDesign::Body::findBodyOf(getObject());
+
+    if (body != NULL) {
+        // Deletion from the tree of a feature is handled by Document.removeObject, which has no clue
+        // about what a body is. Therefore, Bodies, although an "activable" container, know nothing 
+        // about what happens at Document level with the features they contain.
+        //
+        // The Deletion command StdCmdDelete::activated, however does notify the viewprovider corresponding
+        // to the feature (not body) of the imminent deletion (before actually doing it).
+        //
+        // Consequently, the only way of notifying a body of the imminent deletion of one of its features 
+        // so as to do the clean up required (moving basefeature references, tip management) is from the 
+        // viewprovider, so we call it here.
+        //
+        // fixes (#3084)
+
+        Gui::Command::doCommand ( Gui::Command::Doc,"App.activeDocument().%s.removeObject(App.activeDocument().%s)",
+                                body->getNameInDocument(), feature->getNameInDocument() );
+
+        return false; // no need for the document to delete the feature, we have just done it, see StdCmdDelete::activated
+    }
+
     return true;
 }
 

--- a/src/Mod/PartDesign/Gui/ViewProvider.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProvider.cpp
@@ -234,8 +234,6 @@ bool ViewProvider::onDelete(const std::vector<std::string> &)
 
         Gui::Command::doCommand ( Gui::Command::Doc,"App.activeDocument().%s.removeObject(App.activeDocument().%s)",
                                 body->getNameInDocument(), feature->getNameInDocument() );
-
-        return false; // no need for the document to delete the feature, we have just done it, see StdCmdDelete::activated
     }
 
     return true;


### PR DESCRIPTION

=========================================================

fixes #3084
fixes #3061 (at least what it is understood in the analysis as being a bug, the visualization left).

Basically when deleting a feature, if it is the base feature (feature with which it will merge or cutout), the dependent objects'
base feature is made to be the base feature of the object being deleted. This code pre-existed at body level, but was not being called (see below).

Additionally, if the visible object is not the one being deleted, we leave that one visible. If the visible object is the one
being deleted, we make the previous object visible.

Deletion from the tree of a feature is handled by Document.removeObject, which has no clue about what a body is. Therefore, Bodies, although an
"activable" container, know nothing about what happens at Document level with the features they contain.

The Deletion command StdCmdDelete::activated, however does notify the viewprovider corresponding to the feature (not body) of the imminent deletion
(before actually doing it). Consequently, the only way of notifying a body of the imminent deletion of one of its features so as to do the clean up
required (moving basefeature references, tip management) is from the viewprovider of the feature being deleted.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [x] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
