### PR TITLE
PartDesign: #2683 add Refine property

### DIFF
--- a/src/Mod/Part/App/FeaturePartBoolean.cpp
+++ b/src/Mod/Part/App/FeaturePartBoolean.cpp
@@ -47,6 +47,13 @@ Boolean::Boolean(void)
     ADD_PROPERTY_TYPE(History,(ShapeHistory()), "Boolean", (App::PropertyType)
         (App::Prop_Output|App::Prop_Transient|App::Prop_Hidden), "Shape history");
     History.setSize(0);
+
+    ADD_PROPERTY_TYPE(Refine,(0),"Boolean",(App::PropertyType)(App::Prop_None),"Refine shape (clean up redundant edges) after this boolean operation");
+
+    //init Refine property
+    Base::Reference<ParameterGrp> hGrp = App::GetApplication().GetUserParameter()
+        .GetGroup("BaseApp")->GetGroup("Preferences")->GetGroup("Mod/Part/Boolean");
+    this->Refine.setValue(hGrp->GetBool("RefineModel", false));
 }
 
 short Boolean::mustExecute() const
@@ -102,7 +109,7 @@ App::DocumentObjectExecReturn *Boolean::execute(void)
         history.push_back(buildHistory(*mkBool.get(), TopAbs_FACE, resShape, BaseShape));
         history.push_back(buildHistory(*mkBool.get(), TopAbs_FACE, resShape, ToolShape));
 
-        if (hGrp->GetBool("RefineModel", false)) {
+        if (this->Refine.getValue()) {
             try {
                 TopoDS_Shape oldShape = resShape;
                 BRepBuilderAPI_RefineModel mkRefine(oldShape);

--- a/src/Mod/Part/App/FeaturePartBoolean.h
+++ b/src/Mod/Part/App/FeaturePartBoolean.h
@@ -42,6 +42,7 @@ public:
     App::PropertyLink Base;
     App::PropertyLink Tool;
     PropertyShapeHistory History;
+    App::PropertyBool Refine;
 
     /** @name methods override Feature */
     //@{

--- a/src/Mod/Part/App/FeaturePartCommon.cpp
+++ b/src/Mod/Part/App/FeaturePartCommon.cpp
@@ -66,6 +66,13 @@ MultiCommon::MultiCommon(void)
     ADD_PROPERTY_TYPE(History,(ShapeHistory()), "Boolean", (App::PropertyType)
         (App::Prop_Output|App::Prop_Transient|App::Prop_Hidden), "Shape history");
     History.setSize(0);
+
+    ADD_PROPERTY_TYPE(Refine,(0),"Boolean",(App::PropertyType)(App::Prop_None),"Refine shape (clean up redundant edges) after this boolean operation");
+
+    //init Refine property
+    Base::Reference<ParameterGrp> hGrp = App::GetApplication().GetUserParameter()
+        .GetGroup("BaseApp")->GetGroup("Preferences")->GetGroup("Mod/Part/Boolean");
+    this->Refine.setValue(hGrp->GetBool("RefineModel", false));
 }
 
 short MultiCommon::mustExecute() const
@@ -145,7 +152,7 @@ App::DocumentObjectExecReturn *MultiCommon::execute(void)
                      return new App::DocumentObjectExecReturn("Resulting shape is invalid");
                  }
             }
-            if (hGrp->GetBool("RefineModel", false)) {
+            if (this->Refine.getValue()) {
                 try {
                     TopoDS_Shape oldShape = resShape;
                     BRepBuilderAPI_RefineModel mkRefine(oldShape);

--- a/src/Mod/Part/App/FeaturePartCommon.h
+++ b/src/Mod/Part/App/FeaturePartCommon.h
@@ -54,6 +54,7 @@ public:
 
     App::PropertyLinkList Shapes;
     PropertyShapeHistory History;
+    App::PropertyBool Refine;
 
     /** @name methods override feature */
     //@{

--- a/src/Mod/Part/App/FeaturePartFuse.cpp
+++ b/src/Mod/Part/App/FeaturePartFuse.cpp
@@ -65,6 +65,14 @@ MultiFuse::MultiFuse(void)
     ADD_PROPERTY_TYPE(History,(ShapeHistory()), "Boolean", (App::PropertyType)
         (App::Prop_Output|App::Prop_Transient|App::Prop_Hidden), "Shape history");
     History.setSize(0);
+
+    ADD_PROPERTY_TYPE(Refine,(0),"Boolean",(App::PropertyType)(App::Prop_None),"Refine shape (clean up redundant edges) after this boolean operation");
+
+    //init Refine property
+    Base::Reference<ParameterGrp> hGrp = App::GetApplication().GetUserParameter()
+        .GetGroup("BaseApp")->GetGroup("Preferences")->GetGroup("Mod/Part/Boolean");
+    this->Refine.setValue(hGrp->GetBool("RefineModel", false));
+
 }
 
 short MultiFuse::mustExecute() const
@@ -169,7 +177,7 @@ App::DocumentObjectExecReturn *MultiFuse::execute(void)
                     return new App::DocumentObjectExecReturn("Resulting shape is invalid");
                 }
             }
-            if (hGrp->GetBool("RefineModel", false)) {
+            if (this->Refine.getValue()) {
                 try {
                     TopoDS_Shape oldShape = resShape;
                     BRepBuilderAPI_RefineModel mkRefine(oldShape);

--- a/src/Mod/Part/App/FeaturePartFuse.h
+++ b/src/Mod/Part/App/FeaturePartFuse.h
@@ -55,6 +55,7 @@ public:
 
     App::PropertyLinkList Shapes;
     PropertyShapeHistory History;
+    App::PropertyBool Refine;
 
     /** @name methods override feature */
     //@{

--- a/src/Mod/PartDesign/App/FeatureSketchBased.cpp
+++ b/src/Mod/PartDesign/App/FeatureSketchBased.cpp
@@ -92,6 +92,12 @@ ProfileBased::ProfileBased()
     ADD_PROPERTY_TYPE(Midplane,(0),"SketchBased", App::Prop_None, "Extrude symmetric to sketch face");
     ADD_PROPERTY_TYPE(Reversed, (0),"SketchBased", App::Prop_None, "Reverse extrusion direction");
     ADD_PROPERTY_TYPE(UpToFace,(0),"SketchBased",(App::PropertyType)(App::Prop_None),"Face where feature will end");
+    ADD_PROPERTY_TYPE(Refine,(0),"SketchBased",(App::PropertyType)(App::Prop_None),"Refine shape (clean up redundant edges) after adding/subtracting");
+
+    //init Refine property
+    Base::Reference<ParameterGrp> hGrp = App::GetApplication().GetUserParameter()
+        .GetGroup("BaseApp")->GetGroup("Preferences")->GetGroup("Mod/PartDesign");
+    this->Refine.setValue(hGrp->GetBool("RefineModel", false));
 }
 
 short ProfileBased::mustExecute() const
@@ -1039,9 +1045,7 @@ void ProfileBased::getAxis(const App::DocumentObject *pcReferenceAxis, const std
 
 TopoDS_Shape ProfileBased::refineShapeIfActive(const TopoDS_Shape& oldShape) const
 {
-    Base::Reference<ParameterGrp> hGrp = App::GetApplication().GetUserParameter()
-        .GetGroup("BaseApp")->GetGroup("Preferences")->GetGroup("Mod/PartDesign");
-    if (hGrp->GetBool("RefineModel", false)) {
+    if (this->Refine.getValue()) {
         try {
             Part::BRepBuilderAPI_RefineModel mkRefine(oldShape);
             TopoDS_Shape resShape = mkRefine.Shape();

--- a/src/Mod/PartDesign/App/FeatureSketchBased.h
+++ b/src/Mod/PartDesign/App/FeatureSketchBased.h
@@ -54,6 +54,8 @@ public:
     /// Face to extrude up to
     App::PropertyLinkSub UpToFace;
 
+    App::PropertyBool Refine;
+
     short mustExecute() const;
 
     /** calculates and updates the Placement property based on the features

--- a/src/Mod/PartDesign/App/FeatureTransformed.cpp
+++ b/src/Mod/PartDesign/App/FeatureTransformed.cpp
@@ -63,6 +63,13 @@ Transformed::Transformed()
     ADD_PROPERTY(Originals,(0));
     Originals.setSize(0);
     Placement.setStatus(App::Property::ReadOnly, true);
+
+    ADD_PROPERTY_TYPE(Refine,(0),"SketchBased",(App::PropertyType)(App::Prop_None),"Refine shape (clean up redundant edges) after adding/subtracting");
+
+    //init Refine property
+    Base::Reference<ParameterGrp> hGrp = App::GetApplication().GetUserParameter()
+        .GetGroup("BaseApp")->GetGroup("Preferences")->GetGroup("Mod/PartDesign");
+    this->Refine.setValue(hGrp->GetBool("RefineModel", false));
 }
 
 void Transformed::positionBySupport(void)
@@ -374,9 +381,7 @@ App::DocumentObjectExecReturn *Transformed::execute(void)
 
 TopoDS_Shape Transformed::refineShapeIfActive(const TopoDS_Shape& oldShape) const
 {
-    Base::Reference<ParameterGrp> hGrp = App::GetApplication().GetUserParameter()
-        .GetGroup("BaseApp")->GetGroup("Preferences")->GetGroup("Mod/PartDesign");
-    if (hGrp->GetBool("RefineModel", false)) {
+    if (this->Refine.getValue()) {
         try {
             Part::BRepBuilderAPI_RefineModel mkRefine(oldShape);
             TopoDS_Shape resShape = mkRefine.Shape();

--- a/src/Mod/PartDesign/App/FeatureTransformed.h
+++ b/src/Mod/PartDesign/App/FeatureTransformed.h
@@ -49,6 +49,8 @@ public:
       */
     App::PropertyLinkList Originals;
 
+    App::PropertyBool Refine;
+
     /**
      * Returns the BaseFeature property's object(if any) otherwise return first original,
      *         which serves as "Support" for old style workflows


### PR DESCRIPTION
resolves [#2683](https://www.freecadweb.org/tracker/view.php?id=2683)

Adds Refine property to sketch-based and transformation features [edit]and to Part BOPs[/edit]. The
property is initialized according to preferences, and can be altered in
property editor on per-feature basis.

see also https://forum.freecadweb.org/viewtopic.php?f=19&t=22895