### PR TITLE
Correct Handling of Extensions as View Source

### DIFF
--- a/src/Mod/TechDraw/App/DrawViewMulti.cpp
+++ b/src/Mod/TechDraw/App/DrawViewMulti.cpp
@@ -119,40 +119,6 @@ void DrawViewMulti::onChanged(const App::Property* prop)
     DrawViewPart::onChanged(prop);
 }
 
-TopoDS_Shape DrawViewMulti::getSourceShape(void) const
-{
-    TopoDS_Shape result;
-    const std::vector<App::DocumentObject*>& links = Sources.getValues();
-    if (links.empty())  {
-        Base::Console().Log("DVM::execute - No Sources - creation? - %s\n",getNameInDocument());
-    } else {
-        BRep_Builder builder;
-        TopoDS_Compound comp;
-        builder.MakeCompound(comp);
-        for (auto& l:links) {
-            if (l->isDerivedFrom(Part::Feature::getClassTypeId())){
-                const Part::TopoShape &partTopo = static_cast<Part::Feature*>(l)->Shape.getShape();
-                if (partTopo.isNull()) {
-                    continue;    //has no shape
-                }
-                BRepBuilderAPI_Copy BuilderCopy(partTopo.getShape());
-                TopoDS_Shape shape = BuilderCopy.Shape();
-                builder.Add(comp, shape);
-            } else if (l->getTypeId().isDerivedFrom(App::Part::getClassTypeId())) {
-                TopoDS_Shape s = getShapeFromPart(static_cast<App::Part*>(l));
-                if (s.IsNull()) {
-                    continue;
-                }
-                BRepBuilderAPI_Copy BuilderCopy(s);
-                TopoDS_Shape shape = BuilderCopy.Shape();
-                builder.Add(comp, shape);
-            }
-        }        
-        result = comp;
-    }
-    return result;
-}
-
 App::DocumentObjectExecReturn *DrawViewMulti::execute(void)
 {
     if (!keepUpdated()) {

--- a/src/Mod/TechDraw/App/DrawViewMulti.h
+++ b/src/Mod/TechDraw/App/DrawViewMulti.h
@@ -67,8 +67,6 @@ public:
     virtual void onChanged(const App::Property* prop) override;
     //@}
 
-    virtual TopoDS_Shape getSourceShape(void) const override; 
-
     /// returns the type name of the ViewProvider
     virtual const char* getViewProviderName(void) const override {
         return "TechDrawGui::ViewProviderViewPart";

--- a/src/Mod/TechDraw/App/DrawViewPart.h
+++ b/src/Mod/TechDraw/App/DrawViewPart.h
@@ -165,7 +165,7 @@ public:
     gp_Pln getProjPlane(void) const;
     virtual std::vector<TopoDS_Wire> getWireForFace(int idx) const;
     virtual TopoDS_Shape getSourceShape(void) const; 
-    virtual TopoDS_Shape getShapeFromPart(App::Part* ap) const;
+    virtual std::vector<TopoDS_Shape> getShapesFromObject(App::DocumentObject* docObj) const; 
     virtual TopoDS_Shape getSourceShapeFused(void) const; 
 
 protected:

--- a/src/Mod/TechDraw/Gui/Command.cpp
+++ b/src/Mod/TechDraw/Gui/Command.cpp
@@ -485,57 +485,57 @@ bool CmdTechDrawProjGroup::isActive(void)
 }
 
 //===========================================================================
-// TechDraw_NewMulti
+// TechDraw_NewMulti  **deprecated**
 //===========================================================================
 
-DEF_STD_CMD_A(CmdTechDrawNewMulti);
+//DEF_STD_CMD_A(CmdTechDrawNewMulti);
 
-CmdTechDrawNewMulti::CmdTechDrawNewMulti()
-  : Command("TechDraw_NewMulti")
-{
-    sAppModule      = "TechDraw";
-    sGroup          = QT_TR_NOOP("TechDraw");
-    sMenuText       = QT_TR_NOOP("Insert multi-part view in drawing");
-    sToolTipText    = QT_TR_NOOP("Insert a new View of a multiple Parts in the active drawing");
-    sWhatsThis      = "TechDraw_NewMulti";
-    sStatusTip      = sToolTipText;
-    sPixmap         = "actions/techdraw-multiview";
-}
+//CmdTechDrawNewMulti::CmdTechDrawNewMulti()
+//  : Command("TechDraw_NewMulti")
+//{
+//    sAppModule      = "TechDraw";
+//    sGroup          = QT_TR_NOOP("TechDraw");
+//    sMenuText       = QT_TR_NOOP("Insert multi-part view in drawing");
+//    sToolTipText    = QT_TR_NOOP("Insert a new View of a multiple Parts in the active drawing");
+//    sWhatsThis      = "TechDraw_NewMulti";
+//    sStatusTip      = sToolTipText;
+//    sPixmap         = "actions/techdraw-multiview";
+//}
 
-void CmdTechDrawNewMulti::activated(int iMsg)
-{
-    Q_UNUSED(iMsg);
-    TechDraw::DrawPage* page = DrawGuiUtil::findPage(this);
-    if (!page) {
-        return;
-    }
+//void CmdTechDrawNewMulti::activated(int iMsg)
+//{
+//    Q_UNUSED(iMsg);
+//    TechDraw::DrawPage* page = DrawGuiUtil::findPage(this);
+//    if (!page) {
+//        return;
+//    }
 
-    std::vector<App::DocumentObject*> shapes = getSelection().getObjectsOfType(App::DocumentObject::getClassTypeId());
-    if (shapes.empty()) {
-        QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-            QObject::tr("Can not make a MultiView from this selection."));
-        return;
-    }
+//    std::vector<App::DocumentObject*> shapes = getSelection().getObjectsOfType(App::DocumentObject::getClassTypeId());
+//    if (shapes.empty()) {
+//        QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
+//            QObject::tr("Can not make a MultiView from this selection."));
+//        return;
+//    }
 
-    std::string PageName = page->getNameInDocument();
+//    std::string PageName = page->getNameInDocument();
 
-    Gui::WaitCursor wc;
+//    Gui::WaitCursor wc;
 
-    openCommand("Create view");
-    std::string FeatName = getUniqueObjectName("MultiView");
-    doCommand(Doc,"App.activeDocument().addObject('TechDraw::DrawViewMulti','%s')",FeatName.c_str());
-    App::DocumentObject *docObj = getDocument()->getObject(FeatName.c_str());
-    auto multiView( static_cast<TechDraw::DrawViewMulti *>(docObj) );
-    multiView->Sources.setValues(shapes);
-    doCommand(Doc,"App.activeDocument().%s.addView(App.activeDocument().%s)",PageName.c_str(),FeatName.c_str());
-    updateActive();
-    commitCommand();
-}
+//    openCommand("Create view");
+//    std::string FeatName = getUniqueObjectName("MultiView");
+//    doCommand(Doc,"App.activeDocument().addObject('TechDraw::DrawViewMulti','%s')",FeatName.c_str());
+//    App::DocumentObject *docObj = getDocument()->getObject(FeatName.c_str());
+//    auto multiView( static_cast<TechDraw::DrawViewMulti *>(docObj) );
+//    multiView->Sources.setValues(shapes);
+//    doCommand(Doc,"App.activeDocument().%s.addView(App.activeDocument().%s)",PageName.c_str(),FeatName.c_str());
+//    updateActive();
+//    commitCommand();
+//}
 
-bool CmdTechDrawNewMulti::isActive(void)
-{
-    return DrawGuiUtil::needPage(this);
-}
+//bool CmdTechDrawNewMulti::isActive(void)
+//{
+//    return DrawGuiUtil::needPage(this);
+//}
 
 //===========================================================================
 // TechDraw_Annotation
@@ -1054,7 +1054,7 @@ void CreateTechDrawCommands(void)
     rcCmdMgr.addCommand(new CmdTechDrawNewView());
     rcCmdMgr.addCommand(new CmdTechDrawNewViewSection());
     rcCmdMgr.addCommand(new CmdTechDrawNewViewDetail());
-    rcCmdMgr.addCommand(new CmdTechDrawNewMulti());
+//    rcCmdMgr.addCommand(new CmdTechDrawNewMulti());          //deprecated
     rcCmdMgr.addCommand(new CmdTechDrawProjGroup());
     rcCmdMgr.addCommand(new CmdTechDrawAnnotation());
     rcCmdMgr.addCommand(new CmdTechDrawClip());

--- a/src/Mod/TechDraw/Gui/Command.cpp
+++ b/src/Mod/TechDraw/Gui/Command.cpp
@@ -34,7 +34,6 @@
 #include <App/Document.h>
 #include <App/DocumentObject.h>
 #include <App/FeaturePython.h>
-#include <App/Part.h>
 #include <App/PropertyGeo.h>
 #include <Base/Console.h>
 #include <Base/Exception.h>
@@ -254,25 +253,16 @@ void CmdTechDrawNewView::activated(int iMsg)
         return;
     }
 
-    std::vector<App::DocumentObject*> shapes = getSelection().getObjectsOfType(Part::Feature::getClassTypeId());
-    std::vector<App::DocumentObject*> parts = getSelection().getObjectsOfType(App::Part::getClassTypeId());
-    if ((shapes.empty()) && 
-        (parts.empty())) {
+    std::vector<App::DocumentObject*> shapes = getSelection().getObjectsOfType(App::DocumentObject::getClassTypeId());
+    if (shapes.empty()) {
         QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-            QObject::tr("Select at least 1 object with a Shape."));
+            QObject::tr("Can not make a View from this selection"));
         return;
     }
     
-    if (!parts.empty()) {
-        shapes.insert(shapes.end(),parts.begin(),parts.end());
-    }
-
     std::string PageName = page->getNameInDocument();
 
     Gui::WaitCursor wc;
-    const auto selectedProjections( getSelection().getObjectsOfType(TechDraw::DrawView::getClassTypeId()) );
-
-
     openCommand("Create view");
     std::string FeatName = getUniqueObjectName("View");
     doCommand(Doc,"App.activeDocument().addObject('TechDraw::DrawViewPart','%s')",FeatName.c_str());
@@ -457,22 +447,10 @@ void CmdTechDrawProjGroup::activated(int iMsg)
     }
 
     std::vector<App::DocumentObject*> shapes = getSelection().getObjectsOfType(Part::Feature::getClassTypeId());
-//    if (shapes.size() != 1) {
-//        QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-//            QObject::tr("Select exactly 1 Part object."));
-//        return;
-//    }
-
-    std::vector<App::DocumentObject*> parts = getSelection().getObjectsOfType(App::Part::getClassTypeId());
-    if ((shapes.empty()) && 
-        (parts.empty())) {
+    if (shapes.empty())  {
         QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-            QObject::tr("Select at least 1 object with a Shape."));
+            QObject::tr("Can not make a ProjectionGroup from this selection."));
         return;
-    }
-
-    if (!parts.empty()) {
-        shapes.insert(shapes.end(),parts.begin(),parts.end());
     }
 
     std::string PageName = page->getNameInDocument();
@@ -481,11 +459,9 @@ void CmdTechDrawProjGroup::activated(int iMsg)
 
     openCommand("Create Projection Group");
     std::string multiViewName = getUniqueObjectName("ProjGroup");
-    std::string SourceName = (*shapes.begin())->getNameInDocument();
     doCommand(Doc,"App.activeDocument().addObject('TechDraw::DrawProjGroup','%s')",multiViewName.c_str());
     doCommand(Doc,"App.activeDocument().%s.addView(App.activeDocument().%s)",PageName.c_str(),multiViewName.c_str());
 
-//    doCommand(Doc,"App.activeDocument().%s.Source = App.activeDocument().%s",multiViewName.c_str(),SourceName.c_str());
     App::DocumentObject *docObj = getDocument()->getObject(multiViewName.c_str());
     auto multiView( static_cast<TechDraw::DrawProjGroup *>(docObj) );
     multiView->Source.setValues(shapes);
@@ -534,22 +510,11 @@ void CmdTechDrawNewMulti::activated(int iMsg)
         return;
     }
 
-    std::vector<App::DocumentObject*> shapes = getSelection().getObjectsOfType(Part::Feature::getClassTypeId());
-//    if (shapes.empty()) {
-//        QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-//            QObject::tr("Select at least 1 Part object."));
-//        return;
-//    }
-    std::vector<App::DocumentObject*> parts = getSelection().getObjectsOfType(App::Part::getClassTypeId());
-    if ((shapes.empty()) && 
-        (parts.empty())) {
+    std::vector<App::DocumentObject*> shapes = getSelection().getObjectsOfType(App::DocumentObject::getClassTypeId());
+    if (shapes.empty()) {
         QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-            QObject::tr("Select at least 1 object with a Shape."));
+            QObject::tr("Can not make a MultiView from this selection."));
         return;
-    }
-    
-    if (!parts.empty()) {
-        shapes.insert(shapes.end(),parts.begin(),parts.end());
     }
 
     std::string PageName = page->getNameInDocument();

--- a/src/Mod/TechDraw/Gui/Workbench.cpp
+++ b/src/Mod/TechDraw/Gui/Workbench.cpp
@@ -55,7 +55,7 @@ Gui::MenuItem* Workbench::setupMenuBar() const
     *draw << "TechDraw_NewPageDef";
     *draw << "TechDraw_NewPage";
     *draw << "TechDraw_NewView";
-    *draw << "TechDraw_NewMulti";
+//    *draw << "TechDraw_NewMulti";     //deprecated
     *draw << "TechDraw_ProjGroup";
     *draw << "TechDraw_NewViewSection";
     *draw << "TechDraw_NewViewDetail";
@@ -85,7 +85,7 @@ Gui::ToolBarItem* Workbench::setupToolBars() const
     Gui::ToolBarItem *views = new Gui::ToolBarItem(root);
     views->setCommand("TechDraw Views");
     *views << "TechDraw_NewView";
-    *views << "TechDraw_NewMulti";
+//    *views << "TechDraw_NewMulti";    //deprecated
     *views << "TechDraw_ProjGroup";
     *views << "TechDraw_NewViewSection";
     *views << "TechDraw_NewViewDetail";
@@ -137,7 +137,7 @@ Gui::ToolBarItem* Workbench::setupCommandBars() const
     Gui::ToolBarItem *views = new Gui::ToolBarItem(root);
     views->setCommand("Views");
     *views << "TechDraw_NewView";
-    *views << "TechDraw_NewMulti";
+//    *views << "TechDraw_NewMulti";    //deprecated
     *views << "TechDraw_ProjGroup";
     *views << "TechDraw_NewViewSection";
     *views << "TechDraw_NewViewDetail";


### PR DESCRIPTION
This PR corrects the handling of GroupExtenstions as Source for Views.  It also removes deprecated command NewViewMult.  Please merge.

Thanks,
wf

Allow GroupExtension as Source for Views
    - DrawViewPart had special case logic for App::Part.
      It now handles DocumentObjectGroup and any other
      GroupExtensions as Source.





Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
