### PR TITLE
PATH Dressup BUGFIX Sim fail no TOOL FreeCAD Breakdown

### DIFF
--- a/src/Mod/Path/PathScripts/PathDressupLeadInOut.py
+++ b/src/Mod/Path/PathScripts/PathDressupLeadInOut.py
@@ -52,6 +52,7 @@ class ObjectDressup:
 
     def __init__(self, obj):
         self.obj = obj
+        obj.addProperty("App::PropertyLink", "ToolController", "Path", QtCore.QT_TRANSLATE_NOOP("App::Property", "The tool controller that will be used to calculate the path"))
         obj.addProperty("App::PropertyLink", "Base",  "Path", QtCore.QT_TRANSLATE_NOOP("App::Property", "The base path to modify"))
         obj.addProperty("App::PropertyBool", "LeadIn", "Path", QtCore.QT_TRANSLATE_NOOP("App::Property", "Calculate roll-on to path"))
         obj.addProperty("App::PropertyBool", "LeadOut", "Path", QtCore.QT_TRANSLATE_NOOP("App::Property", "Calculate roll-off from path"))
@@ -81,6 +82,7 @@ class ObjectDressup:
         obj.StyleOn = 'Arc'
         obj.StyleOff = 'Arc'
         obj.RadiusCenter = 'Radius'
+        obj.ToolController = obj.Base.ToolController
 
     def execute(self, obj):
         if not obj.Base:


### PR DESCRIPTION
Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
Hi  Tests of my Dressup show that the SIMUlation Fails without propper ToolManagment
So i added its own ToolController and Loaded the BASE toolcontroler to it
THIS is a BUGFIX for my own Dressup committed by Sliptronic on my advice
im fully reponsable on this and the only one to blame
im very old and not that expirianced in git 
@sliptonic  Bugfix and @shaise For the Sim Bugfix as No tool is initializised in SIM
SORRY FOR The MESSUP on deleting my git account early as it has not been merged 
