### PR TITLE
PartDesign: Fix bug of mirror transformation of multiple features

### DIFF
--- a/src/Mod/PartDesign/App/Body.h
+++ b/src/Mod/PartDesign/App/Body.h
@@ -84,6 +84,8 @@ public:
      */
     void insertObject(App::DocumentObject* feature, App::DocumentObject* target, bool after=false);
 
+    void setBaseProperty(App::DocumentObject* feature);
+    
     /// Remove the feature from the body
     virtual std::vector<DocumentObject*> removeObject(DocumentObject* obj) override;
 

--- a/src/Mod/PartDesign/App/FeatureTransformed.cpp
+++ b/src/Mod/PartDesign/App/FeatureTransformed.cpp
@@ -44,6 +44,7 @@
 #include "FeatureLinearPattern.h"
 #include "FeaturePolarPattern.h"
 #include "FeatureSketchBased.h"
+#include "Body.h"
 
 #include <Base/Console.h>
 #include <Base/Exception.h>
@@ -193,8 +194,18 @@ App::DocumentObjectExecReturn *Transformed::execute(void)
     rejected.clear();
 
     std::vector<App::DocumentObject*> originals = Originals.getValues();
-    if (originals.empty()) // typically InsideMultiTransform
+    if (originals.empty()) {// typically InsideMultiTransform
         return App::DocumentObject::StdReturn;
+    }
+    else {
+        if(!this->BaseFeature.getValue()) {
+            auto body = getFeatureBody();
+
+            if(body) {
+                body->setBaseProperty(this);
+            }
+        }
+    }
 
     this->positionBySupport();
 


### PR DESCRIPTION
fixes #3317

This code ensures that an individual transformation or a multi-transformation have a proper
base feature and next feature.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [x] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
