### PR TITLE
TechDraw: Add option to use polygonal HLR algorithm

### DIFF
--- a/src/Mod/TechDraw/App/DrawProjectSplit.cpp
+++ b/src/Mod/TechDraw/App/DrawProjectSplit.cpp
@@ -129,8 +129,15 @@ TechDrawGeometry::GeometryObject* DrawProjectSplit::buildGeometryObject(TopoDS_S
 {
     TechDrawGeometry::GeometryObject* geometryObject = new TechDrawGeometry::GeometryObject("DrawProjectSplit",nullptr);
 
-    geometryObject->projectShape(shape,
-                                 viewAxis);
+    if (geometryObject->usePolygonHLR()){
+        geometryObject->projectShapeWithPolygonAlgo(shape,
+            viewAxis);
+    }
+    else{
+        geometryObject->projectShape(shape,
+            viewAxis);
+    }
+        
     geometryObject->extractGeometry(TechDrawGeometry::ecHARD,                   //always show the hard&outline visible lines
                                     true);
     geometryObject->extractGeometry(TechDrawGeometry::ecOUTLINE,

--- a/src/Mod/TechDraw/App/DrawViewPart.cpp
+++ b/src/Mod/TechDraw/App/DrawViewPart.cpp
@@ -125,7 +125,7 @@ DrawViewPart::DrawViewPart(void) : geometryObject(0)
     Base::Reference<ParameterGrp> hGrp = App::GetApplication().GetUserParameter().GetGroup("BaseApp")->
                                                                GetGroup("Preferences")->GetGroup("Mod/TechDraw/General");
     double defDist = hGrp->GetFloat("FocusDistance",100.0);
-
+    bool coarseView = hGrp->GetBool("CoarseView", false);
 
     //properties that affect Geometry
     ADD_PROPERTY_TYPE(Source ,(0),group,App::Prop_None,"3D Shape to view");
@@ -133,8 +133,9 @@ DrawViewPart::DrawViewPart(void) : geometryObject(0)
     ADD_PROPERTY_TYPE(Direction ,(0,0,1.0)    ,group,App::Prop_None,"Projection direction. The direction you are looking from.");
     ADD_PROPERTY_TYPE(Perspective ,(false),group,App::Prop_None,"Perspective(true) or Orthographic(false) projection");
     ADD_PROPERTY_TYPE(Focus,(defDist),group,App::Prop_None,"Perspective view focus distance");
-
+    
     //properties that affect Appearance
+    ADD_PROPERTY_TYPE(CoarseView, (coarseView), sgroup, App::Prop_None, "Coarse View on/off");
     //visible outline
     ADD_PROPERTY_TYPE(SmoothVisible ,(false),sgroup,App::Prop_None,"Visible Smooth lines on/off");
     ADD_PROPERTY_TYPE(SeamVisible ,(false),sgroup,App::Prop_None,"Visible Seam lines on/off");
@@ -278,7 +279,7 @@ App::DocumentObjectExecReturn *DrawViewPart::execute(void)
      geometryObject =  buildGeometryObject(mirroredShape,viewAxis);
 
 #if MOD_TECHDRAW_HANDLE_FACES
-    if (handleFaces()) {
+    if (handleFaces()&& (!geometryObject->usePolygonHLR())) {
         try {
             extractFaces();
         }
@@ -312,7 +313,7 @@ short DrawViewPart::mustExecute() const
 void DrawViewPart::onChanged(const App::Property* prop)
 {
     DrawView::onChanged(prop);
-
+    
 //TODO: when scale changes, any Dimensions for this View sb recalculated.  DVD should pick this up subject to topological naming issues.
 }
 
@@ -323,12 +324,19 @@ TechDrawGeometry::GeometryObject* DrawViewPart::buildGeometryObject(TopoDS_Shape
     go->setIsoCount(IsoCount.getValue());
     go->isPerspective(Perspective.getValue());
     go->setFocus(Focus.getValue());
+    go->usePolygonHLR(CoarseView.getValue());
 
     Base::Vector3d baseProjDir = Direction.getValue();
     saveParamSpace(baseProjDir);
 
-    go->projectShape(shape,
-                     viewAxis);
+    if (go->usePolygonHLR()){
+        go->projectShapeWithPolygonAlgo(shape,
+            viewAxis);
+    }
+    else{
+        go->projectShape(shape,
+            viewAxis);
+    }
     go->extractGeometry(TechDrawGeometry::ecHARD,                   //always show the hard&outline visible lines
                         true);
     go->extractGeometry(TechDrawGeometry::ecOUTLINE,

--- a/src/Mod/TechDraw/App/DrawViewPart.h
+++ b/src/Mod/TechDraw/App/DrawViewPart.h
@@ -87,6 +87,7 @@ public:
     App::PropertyBool         Perspective;
     App::PropertyDistance     Focus;
 
+    App::PropertyBool   CoarseView;
     App::PropertyBool   SeamVisible;
     App::PropertyBool   SmoothVisible;
     //App::PropertyBool   OutlinesVisible;

--- a/src/Mod/TechDraw/App/GeometryObject.cpp
+++ b/src/Mod/TechDraw/App/GeometryObject.cpp
@@ -43,6 +43,14 @@
 #include <HLRBRep_Algo.hxx>
 #include <HLRBRep_HLRToShape.hxx>
 #include <HLRAlgo_Projector.hxx>
+
+
+#include <BRepMesh_IncrementalMesh.hxx>
+#include <HLRBRep_PolyAlgo.hxx>
+#include <HLRBRep_PolyHLRToShape.hxx>
+#include <Poly_Triangulation.hxx>
+#include <TopLoc_Location.hxx>
+
 #include <TopoDS.hxx>
 #include <TopoDS_Shape.hxx>
 #include <TopoDS_Vertex.hxx>
@@ -83,7 +91,9 @@ GeometryObject::GeometryObject(const string& parent, TechDraw::DrawView* parentO
     m_parent(parentObj),
     m_isoCount(0),
     m_isPersp(false),
-    m_focus(100.0)
+    m_focus(100.0),
+    m_usePolygonHLR(false)
+
 {
 }
 
@@ -211,6 +221,76 @@ void GeometryObject::projectShape(const TopoDS_Shape& input,
     }
 
 }
+
+//!set up a hidden line remover and project a shape with it
+void GeometryObject::projectShapeWithPolygonAlgo(const TopoDS_Shape& input,
+    const gp_Ax2 viewAxis)
+{
+    // Clear previous Geometry
+    clear();
+
+    auto start = chrono::high_resolution_clock::now();
+
+    Handle(HLRBRep_PolyAlgo) brep_hlrPoly = NULL;
+    
+    try {
+        TopExp_Explorer faces(input, TopAbs_FACE);
+        for (int i = 1; faces.More(); faces.Next(), i++) {
+            const TopoDS_Face& f = TopoDS::Face(faces.Current());
+            if (!f.IsNull()) {
+                BRepMesh_IncrementalMesh(f, 0.10); //Poly Algo requires a mesh!
+            }
+        }
+        brep_hlrPoly = new HLRBRep_PolyAlgo();
+        brep_hlrPoly->Load(input);
+        if (m_isPersp) {
+            double fLength = std::max(Precision::Confusion(), m_focus);
+            HLRAlgo_Projector projector(viewAxis, fLength);
+            brep_hlrPoly->Projector(projector);
+        }
+        else { // non perspective
+            HLRAlgo_Projector projector(viewAxis);
+            brep_hlrPoly->Projector(projector);
+        }
+        brep_hlrPoly->Update();
+    }
+    catch (...) {
+        Standard_Failure::Raise("GeometryObject::projectShapeWithPolygonAlgo  - error occurred while projecting shape");
+    }
+    auto end = chrono::high_resolution_clock::now();
+    auto diff = end - start;
+    double diffOut = chrono::duration <double, milli>(diff).count();
+    Base::Console().Log("TIMING - %s GO spent: %.3f millisecs in HLRBRep_PolyAlgo & co\n", m_parentName.c_str(), diffOut);
+
+    try {
+        HLRBRep_PolyHLRToShape polyhlrToShape = HLRBRep_PolyHLRToShape();
+        polyhlrToShape.Update(brep_hlrPoly);
+
+        visHard = polyhlrToShape.VCompound();
+        visSmooth = polyhlrToShape.Rg1LineVCompound();
+        visSeam = polyhlrToShape.RgNLineVCompound();
+        visOutline = polyhlrToShape.OutLineVCompound();
+        hidHard = polyhlrToShape.HCompound();
+        hidSmooth = polyhlrToShape.Rg1LineHCompound();
+        hidSeam = polyhlrToShape.RgNLineHCompound();
+        hidOutline = polyhlrToShape.OutLineHCompound();
+        
+
+        //need these 3d curves to prevent "zero edges" later
+        BRepLib::BuildCurves3d(visHard);
+        BRepLib::BuildCurves3d(visSmooth);
+        BRepLib::BuildCurves3d(visSeam);
+        BRepLib::BuildCurves3d(visOutline);
+        BRepLib::BuildCurves3d(hidHard);
+        BRepLib::BuildCurves3d(hidSmooth);
+        BRepLib::BuildCurves3d(hidSeam);
+        BRepLib::BuildCurves3d(hidOutline);
+    }
+    catch (...) {
+        Standard_Failure::Raise("GeometryObject::projectShapeWithPolygonAlgo - error occurred while extracting edges");
+    }
+}
+
 
 //!add edges meeting filter criteria for category, visibility
 void GeometryObject::extractGeometry(edgeClass category, bool visible)

--- a/src/Mod/TechDraw/App/GeometryObject.h
+++ b/src/Mod/TechDraw/App/GeometryObject.h
@@ -91,8 +91,10 @@ public:
     const std::vector<Face *>     & getFaceGeometry() const { return faceGeom; };
 
     void projectShape(const TopoDS_Shape &input,
-                      const gp_Ax2 viewAxis);
-
+        const gp_Ax2 viewAxis);
+    void projectShapeWithPolygonAlgo(const TopoDS_Shape &input,
+        const gp_Ax2 viewAxis);
+    
     void extractGeometry(edgeClass category, bool visible);
     void addFaceGeom(Face * f);
     void clearFaceGeom();
@@ -100,6 +102,8 @@ public:
     void setParentName(std::string n);                          //for debug messages
     void isPerspective(bool b) { m_isPersp = b; }
     bool isPerspective(void) { return m_isPersp; }
+    void usePolygonHLR(bool b) { m_usePolygonHLR = b; }
+    bool usePolygonHLR(void) { return m_usePolygonHLR; }
     void setFocus(double f) { m_focus = f; }
     double getFocus(void) { return m_focus; }
     void pruneVertexGeom(Base::Vector3d center, double radius);
@@ -150,6 +154,7 @@ protected:
     int m_isoCount;
     bool m_isPersp;
     double m_focus;
+    bool m_usePolygonHLR;
 };
 
 } //namespace TechDrawGeometry

--- a/src/Mod/TechDraw/Gui/QGIViewPart.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewPart.cpp
@@ -477,6 +477,7 @@ void QGIViewPart::drawViewPart()
                                          GetGroup("Preferences")->GetGroup("Mod/TechDraw/General");
     double vertexScaleFactor = hGrp->GetFloat("VertexScale", 3.0);
 
+    bool usePolygonHLR = viewPart->CoarseView.getValue();
     const std::vector<TechDrawGeometry::Vertex *> &verts = viewPart->getVertexGeometry();
     std::vector<TechDrawGeometry::Vertex *>::const_iterator vert = verts.begin();
     bool showCenters = viewPart->ArcCenterMarks.getValue();
@@ -491,7 +492,7 @@ void QGIViewPart::drawViewPart()
                 cmItem->setSize( cAdjust * lineWidth * vertexScaleFactor);
                 cmItem->setZValue(ZVALUE::VERTEX);
             }
-        } else {
+        } else if(!usePolygonHLR){ //Disable dots WHEN usePolygonHLR
             QGIVertex *item = new QGIVertex(i);
             addToGroup(item);
             item->setPos(Rez::guiX((*vert)->pnt.x), Rez::guiX((*vert)->pnt.y));


### PR DESCRIPTION
Now on property panel there is option "Coarse View" which allows to set
selected drawing view's Hidden Line Removal to utilize polygonal algorithm.
This should be faster on same cases (complex models).

When this option is set for a view there is known limitation with dimensions not
working on this experimental mode. At least currently this is best utilized on
view with no dimensions.

Also the vertices' "black dots" are not drawn on this mode view to avoid
cluttering.  Face hilite is avoided, to gain speed. All curves are represented
by short linesegments in this mode.

Previously TechDraw always used OCC's exact HLR algorithm to generate views,
which produces good quality and continous shape lines but is sometimes
slower to generate than with polygonal approach.

Additionally now there is bool "CoarseView" Parameter Editor setting, if anyone
wants to set this as their default.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
This code is written according to WanderFan's suggestions. Hopefully this is useful...