### PR TITLE
Fix Exception when Source Shape IsNull

### DIFF
--- a/src/Mod/TechDraw/App/DrawViewPart.cpp
+++ b/src/Mod/TechDraw/App/DrawViewPart.cpp
@@ -195,15 +195,20 @@ TopoDS_Shape DrawViewPart::getSourceShape(void) const
         BRep_Builder builder;
         TopoDS_Compound comp;
         builder.MakeCompound(comp);
+        bool found = false;
         for (auto& s:sourceShapes) {
             if (s.IsNull()) {
                 continue;    //has no shape
             }
+            found = true;
             BRepBuilderAPI_Copy BuilderCopy(s);
             TopoDS_Shape shape = BuilderCopy.Shape();
             builder.Add(comp, shape);
-        }        
-        result = comp;
+        }
+        //it appears that an empty compound is !IsNull(), so we need to check if we added anything to the compound.
+        if (found) {
+            result = comp;
+        }
     }
     return result;
 }


### PR DESCRIPTION
This PR addresses a rare situation where an Exception is raised due to the only Source object having a null shape.  This does not seem to happen in the Gui, but it is possible in a script. 

Please merge. 

Thanks,
wf


Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
