### PR TITLE
PATH BUGFIX DressUP-LeadINOut-Line-Generation-SIMFix

### DIFF
--- a/src/Mod/Path/PathScripts/PathDressupLeadInOut.py
+++ b/src/Mod/Path/PathScripts/PathDressupLeadInOut.py
@@ -178,7 +178,7 @@ class ObjectDressup:
             arcmove = Path.Command(arcdir, {"X": p0.x, "Y": p0.y, "I": offsetvector.x, "J": offsetvector.y, "F": horizFeed})  # add G2/G3 move
             results.append(arcmove)
         elif obj.StyleOn == 'Tangent':
-            extendcommand = Path.Command('G1', {"X": p0.x, "Y": p0.y, "Z": p0.z, "F": horizFeed})
+            extendcommand = Path.Command('G1', {"X": p0.x, "Y": p0.y, "F": horizFeed})
             results.append(extendcommand)
         else:
             PathLog.notice(" CURRENT_IN Perp")
@@ -213,12 +213,12 @@ class ObjectDressup:
         else:
             leadend = p1.add(off_v)  # Dmode
         IJ = off_v  # .negative()
-        results.append(queue[1])
+        #results.append(queue[1])
         if obj.StyleOff == 'Arc':
             arcmove = Path.Command(arcdir, {"X": leadend.x, "Y": leadend.y, "I": IJ.x, "J": IJ.y, "F": horizFeed})  # add G2/G3 move
             results.append(arcmove)
         elif obj.StyleOff == 'Tangent':
-            extendcommand = Path.Command('G1', {"X": leadend.x, "Y": leadend.y, "Z": currLocation["Z"], "F": horizFeed})
+            extendcommand = Path.Command('G1', {"X": leadend.x, "Y": leadend.y, "F": horizFeed})
             results.append(extendcommand)
         else:
             PathLog.notice(" CURRENT_IN Perp")
@@ -262,7 +262,7 @@ class ObjectDressup:
                     if obj.LeadIn:
                         temp = self.getLeadStart(obj, queue, action)
                         newpath.extend(temp)
-                        newpath.append(curCommand)
+                        #newpath.append(curCommand)
                         action = 'none'
                         currLocation.update(curCommand.Parameters)
                     else:


### PR DESCRIPTION
Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x ] Branch rebased on latest master `git pull --rebase upstream master`
- [x ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
tis is a bugfix to User Forum Request 
as to many lines in view not representing the gcode 
and make SIM Fail 
NOW Clean View Clean SIM on Dressup lead in out  
@shaise  i did it myself 
@sliptonic  to be aproved by your tests 
