### PR TITLE
Fix compliation against shiboken2 head

### DIFF
--- a/src/Gui/WidgetFactory.cpp
+++ b/src/Gui/WidgetFactory.cpp
@@ -77,7 +77,6 @@ PyTypeObject** SbkPySide_QtGuiTypes=NULL;
 # include <basewrapper.h>
 # include <sbkconverter.h>
 # include <sbkmodule.h>
-# include <typeresolver.h>
 # include <shiboken.h>
 # ifdef HAVE_PYSIDE2
 # define HAVE_PYSIDE
@@ -114,40 +113,24 @@ PyTypeObject** SbkPySide2_QtWidgetsTypes=NULL;
 using namespace Gui;
 
 #if defined (HAVE_SHIBOKEN)
-namespace Shiboken {
-template<> struct Converter<Base::Quantity>
-{
-    static inline bool checkType(PyObject* pyObj) {
-        return PyObject_TypeCheck(pyObj, &(Base::QuantityPy::Type));
-    }
-    static inline bool isConvertible(PyObject* pyObj) {
-        return PyObject_TypeCheck(pyObj, &(Base::QuantityPy::Type));
-    }
-    static inline PyObject* toPython(void* cppobj) {
-        return toPython(*reinterpret_cast<Base::Quantity*>(cppobj));
-    }
-    static inline PyObject* toPython(Base::Quantity cpx) {
-        return new Base::QuantityPy(new Base::Quantity(cpx));
-    }
-    static inline Base::Quantity toCpp(PyObject* pyobj) {
-        Base::Quantity q = *static_cast<Base::QuantityPy*>(pyobj)->getQuantityPtr();
-        return q;
-    }
-};
+
+PyObject* toPythonFuncQuantityTyped(Base::Quantity cpx) {
+    return new Base::QuantityPy(new Base::Quantity(cpx));
 }
 
 PyObject* toPythonFuncQuantity(const void* cpp)
 {
-    return Shiboken::Converter<Base::Quantity>::toPython(const_cast<void*>(cpp));
+    return toPythonFuncQuantityTyped(*reinterpret_cast<const Base::Quantity*>(cpp));
 }
 
-void toCppPointerConvFuncQuantity(PyObject*,void*)
+void toCppPointerConvFuncQuantity(PyObject* pyobj,void* cpp)
 {
+   *((Base::Quantity*)cpp) = *static_cast<Base::QuantityPy*>(pyobj)->getQuantityPtr();
 }
 
 PythonToCppFunc toCppPointerCheckFuncQuantity(PyObject* obj)
 {
-    if (Shiboken::Converter<Base::Quantity>::isConvertible(obj))
+    if (PyObject_TypeCheck(obj, &(Base::QuantityPy::Type)))
         return toCppPointerConvFuncQuantity;
     else
         return 0;
@@ -297,7 +280,9 @@ QObject* PythonWrapper::toQObject(const Py::Object& pyobject)
 Py::Object PythonWrapper::fromQIcon(const QIcon* icon)
 {
 #if defined (HAVE_SHIBOKEN) && defined(HAVE_PYSIDE)
-    PyObject* pyobj = Shiboken::createWrapper<QIcon>(icon, true);
+    const char* typeName = typeid(icon).name();
+    PyObject* pyobj = Shiboken::Object::newObject(reinterpret_cast<SbkObjectType*>(Shiboken::SbkType<QIcon>()),
+                              const_cast<QIcon*>(icon), true, false, typeName);
     if (pyobj)
         return Py::asObject(pyobj);
 #else

--- a/src/Gui/WidgetFactory.cpp
+++ b/src/Gui/WidgetFactory.cpp
@@ -280,7 +280,7 @@ QObject* PythonWrapper::toQObject(const Py::Object& pyobject)
 Py::Object PythonWrapper::fromQIcon(const QIcon* icon)
 {
 #if defined (HAVE_SHIBOKEN) && defined(HAVE_PYSIDE)
-    const char* typeName = typeid(icon).name();
+    const char* typeName = typeid(*const_cast<QIcon*>(icon)).name();
     PyObject* pyobj = Shiboken::Object::newObject(reinterpret_cast<SbkObjectType*>(Shiboken::SbkType<QIcon>()),
                               const_cast<QIcon*>(icon), true, false, typeName);
     if (pyobj)


### PR DESCRIPTION
shiboken2 changed type conversion and removed a wrapper.
This just deleted the class definition that is not longer valid and inlines
code in a few places.

fixes #3287

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [X] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [X] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [X] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
