### PR TITLE
Give default values to cutting edge angle so simulations with work ev…

### DIFF
--- a/src/Mod/Path/PathScripts/PathSimulatorGui.py
+++ b/src/Mod/Path/PathScripts/PathSimulatorGui.py
@@ -6,6 +6,7 @@ import Mesh
 import PathSimulator
 import math
 from FreeCAD import Vector, Base
+import PathScripts.PathLog as PathLog
 from PathScripts.PathGeom import PathGeom
 
 _filePath = os.path.dirname(os.path.abspath(__file__))
@@ -382,6 +383,9 @@ class PathSimulation:
         yp = pos[1]
         zp = pos[2]
         h = tool.CuttingEdgeHeight
+        if h <= 0.0:#set default if user fails to avoit Freeze
+            h = 1.0
+            PathLog.error("SET Tool Length")
         # common to all tools
         vTR = Vector(xp + yf, yp - xf, zp + h)
         vTC = Vector(xp, yp, zp + h)

--- a/src/Mod/Path/PathSimulator/App/PathSim.cpp
+++ b/src/Mod/Path/PathSimulator/App/PathSim.cpp
@@ -87,11 +87,21 @@ void PathSim::SetCurrentTool(Tool * tool)
         }
 		break;
 	case Tool::CENTERDRILL:
+		tp = cSimTool::CHAMFER;
+		angle = tool->CuttingEdgeAngle;
+        if (angle > 180) 
+        {
+            angle = 180;
+        }
+		break;
 	case Tool::COUNTERSINK:
 	case Tool::COUNTERBORE:
 	case Tool::REAMER:
 	case Tool::TAP:
 	case Tool::ENDMILL:
+		tp = cSimTool::FLAT;
+		angle = 180;
+		break;
 	case Tool::SLOTCUTTER:
 	case Tool::CORNERROUND:
 	case Tool::ENGRAVER:
@@ -102,8 +112,10 @@ void PathSim::SetCurrentTool(Tool * tool)
             angle = 180;
         }
 		break;
-
-		break; // quiet warnings
+	default:
+		tp = cSimTool::FLAT;
+		angle = 180;
+		break;
 	}
 	m_tool = new cSimTool(tp, tool->Diameter / 2.0, angle);
 }


### PR DESCRIPTION
…en if user did not specify a valid cutting angle.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [X] Branch rebased on latest master `git pull --rebase upstream master`
- [X] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [X] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
This change was done by Lothar Sammel to give some default values for cutting edge angle of tools. This makes the simulation work even if the user did not supply valid values (and hence compatible with old files that used to work)