### PR TITLE
Relax regex for editable text in Template

### DIFF
--- a/src/Mod/TechDraw/App/DrawSVGTemplate.cpp
+++ b/src/Mod/TechDraw/App/DrawSVGTemplate.cpp
@@ -295,7 +295,7 @@ std::map<std::string, std::string> DrawSVGTemplate::getEditableTextsFromTemplate
         tfile.close();
         //this catches all the tags: <text ... </tspan></text>
         //keep tagRegex in sync with Gui/QGISVGTemplate.cpp
-        boost::regex tagRegex ("<text([^>]*freecad:editable=[^>]*)>[^<]*<tspan[^>]*>([^<]*)</tspan></text>");
+        boost::regex tagRegex ("<text([^>]*freecad:editable=[^>]*)>[^<]*<tspan[^>]*>([^<]*)</tspan>");
         boost::regex nameRegex("freecad:editable=\"(.*?)\"");
         boost::regex valueRegex("<tspan.*?>(.*?)</tspan>");
 


### PR DESCRIPTION
Please merge this minor fix. Thanks.

- the regex for finding editable text fields in
  the svg code of Templates was too strict and
  missed some fields if the svg had extra characters
  between </tspan> & </text>.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
