### PR TITLE
Correct Scaling/boundingRect of Svg Symbols

### DIFF
--- a/src/Mod/TechDraw/Gui/QGCustomSvg.cpp
+++ b/src/Mod/TechDraw/Gui/QGCustomSvg.cpp
@@ -72,15 +72,6 @@ bool QGCustomSvg::load(QByteArray *svgBytes)
     return(success);
 }
 
-QRectF QGCustomSvg::boundingRect() const
-{
-    QRectF box = m_svgRender->viewBoxF();
-    double w = box.width();
-    double h = box.height();
-    QRectF newRect(0,0,w,h);
-    return newRect;
-}
-
 void QGCustomSvg::paint ( QPainter * painter, const QStyleOptionGraphicsItem * option, QWidget * widget) {
     QStyleOptionGraphicsItem myOption(*option);
     myOption.state &= ~QStyle::State_Selected;

--- a/src/Mod/TechDraw/Gui/QGCustomSvg.h
+++ b/src/Mod/TechDraw/Gui/QGCustomSvg.h
@@ -52,7 +52,6 @@ public:
     virtual void centerAt(QPointF centerPos);
     virtual void centerAt(double cX, double cY);
     virtual bool load(QByteArray *svgString);
-    virtual QRectF boundingRect(void) const override;
 
 protected:
     QSvgRenderer *m_svgRender;

--- a/src/Mod/TechDraw/Gui/QGIViewSymbol.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewSymbol.cpp
@@ -42,6 +42,8 @@
 #include <Base/Parameter.h>
 
 #include <Mod/TechDraw/App/DrawViewSymbol.h>
+#include <Mod/TechDraw/App/DrawViewDraft.h>
+#include <Mod/TechDraw/App/DrawViewArch.h>
 
 #include "QGCustomSvg.h"
 #include "QGDisplayArea.h"
@@ -123,11 +125,18 @@ void QGIViewSymbol::drawSvg()
         return;
     }
 
-//note: svg's are overscaled by (72 pixels(pts actually) /in)*(1 in/25.4 mm) = 2.834645669   (could be 96/25.4(CSS)? 110/25.4?)
-//due to 1 sceneUnit (1mm) = 1 pixel for some QtSvg functions
-
     double rezfactor = Rez::getRezFactor();
-    double scaling = viewSymbol->getScale() * rezfactor;
+    double scaling = viewSymbol->getScale();
+    double pxMm = 3.78;                 //96px/25.4mm ( CSS/SVG defined value of 96 pixels per inch)
+//    double pxMm = 3.54;                 //90px/25.4mm ( inkscape value version <= 0.91)
+                                        //some software uses different px/in, so symbol will need Scale adjusted.
+    //Arch/Draft views are in px and need to be scaled @ rezfactor px/mm to ensure proper representation
+    if (viewSymbol->isDerivedFrom(TechDraw::DrawViewArch::getClassTypeId()) ||
+        viewSymbol->isDerivedFrom(TechDraw::DrawViewDraft::getClassTypeId()) ) {
+        scaling = scaling * rezfactor;
+    } else { 
+        scaling = scaling * rezfactor / pxMm;
+    }
     m_svgItem->setScale(scaling);
 
     QByteArray qba(viewSymbol->Symbol.getValue(),strlen(viewSymbol->Symbol.getValue()));


### PR DESCRIPTION
This PR correct an error where some Svg Symbols were drawn incorrectly on the Page.  Please merge.

Thanks,
wf

- Svg symbols were over scale and reporting their
  boundingRect incorrectly.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
