### PR TITLE
adding 'import sys' needed when opening a dxf file

### DIFF
--- a/src/Mod/Draft/importDXF.py
+++ b/src/Mod/Draft/importDXF.py
@@ -1547,10 +1547,10 @@ def open(filename):
     if dxfUseLegacyImporter:
         getDXFlibs()
         if dxfReader:
-            #workaround since newDocument currently can't handle unicode filenames
             docname = os.path.splitext(os.path.basename(filename))[0]
             if sys.version_info.major < 3:
                 if isinstance(docname,unicode): 
+                    #workaround since newDocument currently can't handle unicode filenames
                     docname = docname.encode(sys.getfilesystemencoding())
             doc = FreeCAD.newDocument(docname)
             doc.Label = decodeName(docname)

--- a/src/Mod/Draft/importDXF.py
+++ b/src/Mod/Draft/importDXF.py
@@ -1542,14 +1542,15 @@ def warn(dxfobject,num=None):
 
 def open(filename):
     "called when freecad opens a file."
+    import sys
     readPreferences()
     if dxfUseLegacyImporter:
         getDXFlibs()
         if dxfReader:
+            #workaround since newDocument currently can't handle unicode filenames
             docname = os.path.splitext(os.path.basename(filename))[0]
             if sys.version_info.major < 3:
                 if isinstance(docname,unicode): 
-                    import sys #workaround since newDocument currently can't handle unicode filenames
                     docname = docname.encode(sys.getfilesystemencoding())
             doc = FreeCAD.newDocument(docname)
             doc.Label = decodeName(docname)


### PR DESCRIPTION
This is fixing 'Open DXF' operation.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
