### PR TITLE
PartDesign: Highlight body tip

### DIFF
--- a/src/Mod/PartDesign/Gui/ViewProvider.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProvider.cpp
@@ -25,6 +25,7 @@
 
 #ifndef _PreComp_
 # include <QMessageBox>
+# include <QApplication>
 #include <Inventor/nodes/SoSwitch.h>
 #endif
 
@@ -33,6 +34,7 @@
 #include <Gui/Control.h>
 #include <Gui/Application.h>
 #include <Gui/Document.h>
+#include <Gui/BitmapFactory.h>
 #include <Base/Exception.h>
 #include <Mod/PartDesign/App/Body.h>
 #include <Mod/PartDesign/App/Feature.h>
@@ -48,7 +50,7 @@ using namespace PartDesignGui;
 PROPERTY_SOURCE(PartDesignGui::ViewProvider, PartGui::ViewProviderPart)
 
 ViewProvider::ViewProvider()
-    :oldWb(""), oldTip(NULL)
+:oldWb(""), oldTip(NULL), isSetTipIcon(false)
 {
 }
 
@@ -199,6 +201,51 @@ void ViewProvider::onChanged(const App::Property* prop) {
     PartGui::ViewProviderPartExt::onChanged(prop);
 }
 
+void ViewProvider::setTipIcon(bool onoff) {
+    isSetTipIcon = onoff;
+    
+    signalChangeIcon();
+}
+
+QIcon ViewProvider::getIcon(void) const
+{
+    return mergeTip(Gui::BitmapFactory().pixmap(sPixmap));
+}
+
+QIcon ViewProvider::mergeTip(QIcon orig) const
+{
+    if(isSetTipIcon) {
+        QPixmap px;
+        
+        static const char * const feature_error_xpm[]={
+            "9 9 3 1",
+            ". c None",
+            "# c #00ff00",
+            "a c #ffffff",
+            "...###...",
+            ".##aaa##.",
+            ".##aaa##.",
+            "###aaa###",
+            "##aaaaa##",
+            "##aaaaa##",
+            ".##aaa##.",
+            ".##aaa##.",
+            "...###..."};
+        px = QPixmap(feature_error_xpm);
+
+        QIcon icon_mod;
+
+        int w = QApplication::style()->pixelMetric(QStyle::PM_ListViewIconSize);
+
+        icon_mod.addPixmap(Gui::BitmapFactory().merge(orig.pixmap(w, w, QIcon::Normal, QIcon::Off),
+                                                    px,Gui::BitmapFactoryInst::BottomRight), QIcon::Normal, QIcon::Off);
+        icon_mod.addPixmap(Gui::BitmapFactory().merge(orig.pixmap(w, w, QIcon::Normal, QIcon::On ),
+                                                    px,Gui::BitmapFactoryInst::BottomRight), QIcon::Normal, QIcon::Off);
+        return icon_mod;
+    }
+    else
+        return orig;
+}
 
 bool ViewProvider::onDelete(const std::vector<std::string> &)
 {

--- a/src/Mod/PartDesign/Gui/ViewProvider.h
+++ b/src/Mod/PartDesign/Gui/ViewProvider.h
@@ -49,6 +49,10 @@ public:
     virtual bool doubleClicked(void);
     void updateData(const App::Property*);
     void onChanged(const App::Property* prop);
+    
+    virtual QIcon getIcon(void) const;
+    
+    void setTipIcon(bool onoff);
 
     //body mode means that the object is part of a body and that the body is used to set the 
     //visual properties, not the features. Hence setting body mode to true will hide most 
@@ -71,6 +75,8 @@ protected:
     virtual void unsetEdit(int ModNum);
 
     virtual bool onDelete(const std::vector<std::string> &);
+    
+    virtual QIcon mergeTip(QIcon orig) const;
 
     /**
      * Returns a newly create dialog for the part to be placed in the task view
@@ -80,6 +86,7 @@ protected:
 
     std::string oldWb;
     App::DocumentObject* oldTip;
+    bool isSetTipIcon;
 };
 
 typedef Gui::ViewProviderPythonFeatureT<ViewProvider> ViewProviderPython;

--- a/src/Mod/PartDesign/Gui/ViewProviderBody.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderBody.cpp
@@ -225,6 +225,21 @@ void ViewProviderBody::updateData(const App::Property* prop)
         //ensure all model features are in visual body mode
         setVisualBodyMode(true);
     } 
+    
+    if (prop == &body->Tip) {
+        // We changed Tip
+        App::DocumentObject* tip = body->Tip.getValue();
+
+        auto features = body->Group.getValues();
+
+        // restore icons
+        for ( auto feature : features) {
+            Gui::ViewProvider* vp = Gui::Application::Instance->activeDocument()->getViewProvider(feature);
+            if(vp->isDerivedFrom(PartDesignGui::ViewProvider::getClassTypeId())) {
+                static_cast<PartDesignGui::ViewProvider*>(vp)->setTipIcon(feature == tip);
+            }
+        }
+    }
 
     PartGui::ViewProviderPart::updateData(prop);
 }

--- a/src/Mod/PartDesign/Gui/ViewProviderPrimitive.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderPrimitive.cpp
@@ -167,5 +167,5 @@ QIcon ViewProviderPrimitive::getIcon(void) const {
     }
 
     str += QString::fromLatin1(".svg");
-    return Gui::BitmapFactory().pixmap(str.toStdString().c_str());
+    return mergeTip(Gui::BitmapFactory().pixmap(str.toStdString().c_str()));
 }


### PR DESCRIPTION
==============================

It generates a small green icon on the treeview for those features being the tip of the body.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
