### PR TITLE
workaround for netgen to use latest netgen/master

### DIFF
--- a/cMake/FindNETGEN.cmake
+++ b/cMake/FindNETGEN.cmake
@@ -107,13 +107,19 @@ ELSE()
     file(STRINGS ${NETGEN_DIR_include}/mydefs.hpp NETGEN_VERSION
         REGEX "#define PACKAGE_VERSION.*"
     )
-    string(REGEX MATCHALL "[0-9]+" NETGEN_VERSION ${NETGEN_VERSION})
-    list(LENGTH NETGEN_VERSION NETGEN_VERSION_COUNT)
-    list(GET NETGEN_VERSION 0 NETGEN_VERSION_MAJOR)
-    if(NETGEN_VERSION_COUNT GREATER 1)
-        list(GET NETGEN_VERSION 1 NETGEN_VERSION_MINOR)
-    else()
-        set(NETGEN_VERSION_MINOR 0)
+    if (NETGEN_VERSION)
+	string(REGEX MATCHALL "[0-9]+" NETGEN_VERSION ${NETGEN_VERSION})
+	list(LENGTH NETGEN_VERSION NETGEN_VERSION_COUNT)
+	list(GET NETGEN_VERSION 0 NETGEN_VERSION_MAJOR)
+	if(NETGEN_VERSION_COUNT GREATER 1)
+	    list(GET NETGEN_VERSION 1 NETGEN_VERSION_MINOR)
+	else()
+	    set(NETGEN_VERSION_MINOR 0)
+	endif()
+    else()  # workaround for netgen 6.2 and newer. currently there is no easy way to detect the version
+	    # better use "find_package(netgen CONFIG REQUIRED)"
+	set(NETGEN_VERSION_MAJOR 6)
+	set(NETGEN_VERSION_MINOR 2)
     endif()
 ENDIF()
 


### PR DESCRIPTION
Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
