### PR TITLE
 Prevent Loop in BRepBuilderAPI_Transform

### DIFF
--- a/src/Mod/TechDraw/App/DrawProjGroup.cpp
+++ b/src/Mod/TechDraw/App/DrawProjGroup.cpp
@@ -246,6 +246,9 @@ double DrawProjGroup::calculateAutomaticScale() const
     arrangeViewPointers(viewPtrs);
     double width, height;
     minimumBbViews(viewPtrs, width, height);                               //get 1:1 bbxs
+                                            // if Page.keepUpdated is false, and DrawViews have never been executed,
+                                            // bb's will be 0x0 and this routine will return 0!!!
+                                            // if we return 1.0, AutoScale will sort itself out once bb's are non-zero.
     double bbFudge = 1.2;
     width *= bbFudge;
     height *= bbFudge;
@@ -269,6 +272,10 @@ double DrawProjGroup::calculateAutomaticScale() const
     double scaleFudge = 0.80;
     float working_scale = scaleFudge * std::min(scale_x, scale_y);
     double result = DrawUtil::sensibleScale(working_scale);
+    if (!(result > 0.0)) {
+        Base::Console().Log("DPG - %s - bad scale found (%.3f) using 1.0\n",getNameInDocument(),result);
+        result = 1.0;
+    }
     return result;
 }
 

--- a/src/Mod/TechDraw/App/DrawProjGroupItem.cpp
+++ b/src/Mod/TechDraw/App/DrawProjGroupItem.cpp
@@ -183,6 +183,10 @@ double DrawProjGroupItem::getScale(void) const
     auto pgroup = getPGroup();
     if (pgroup != nullptr) {
         result = pgroup->Scale.getValue();
+        if (!(result > 0.0)) {
+            Base::Console().Log("DPGI - %s - bad scale found (%.3f) using 1.0\n",getNameInDocument(),Scale.getValue());
+            result = 1.0;                                   //kludgy protective fix. autoscale sometimes serves up 0.0!
+        }
     }
     return result;
 }

--- a/src/Mod/TechDraw/App/DrawUtil.cpp
+++ b/src/Mod/TechDraw/App/DrawUtil.cpp
@@ -400,6 +400,9 @@ Base::Vector3d  DrawUtil::closestBasis(Base::Vector3d v)
 double DrawUtil::sensibleScale(double working_scale)
 {
     double result = 1.0;
+    if (!(working_scale > 0.0)) {
+        return result;
+    }
     //which gives the largest scale for which the min_space requirements can be met, but we want a 'sensible' scale, rather than 0.28457239...
     //eg if working_scale = 0.115, then we want to use 0.1, similarly 7.65 -> 5, and 76.5 -> 50
 

--- a/src/Mod/TechDraw/App/DrawView.cpp
+++ b/src/Mod/TechDraw/App/DrawView.cpp
@@ -249,6 +249,10 @@ void DrawView::setPosition(double x, double y)
 double DrawView::getScale(void) const
 {
     auto result = Scale.getValue();
+    if (!(result > 0.0)) {
+        result = 1.0;
+        Base::Console().Log("DrawView - %s - bad scale found (%.3f) using 1.0\n",getNameInDocument(),Scale.getValue());
+    }
     return result;
 }
 

--- a/src/Mod/TechDraw/App/GeometryObject.cpp
+++ b/src/Mod/TechDraw/App/GeometryObject.cpp
@@ -626,12 +626,16 @@ TopoDS_Shape TechDrawGeometry::mirrorShape(const TopoDS_Shape &input,
     if (input.IsNull()) {
         return transShape;
     }
-    
     try {
         // Make tempTransform scale the object around it's centre point and
         // mirror about the Y axis
         gp_Trsf tempTransform;
-        tempTransform.SetScale(inputCenter, scale);
+        //BRepBuilderAPI_Transform will loop forever if asked to use 0.0 as scale
+        if (!(scale > 0.0)) {
+            tempTransform.SetScale(inputCenter, 1.0);
+        } else {
+            tempTransform.SetScale(inputCenter, scale);
+        }
         gp_Trsf mirrorTransform;
         mirrorTransform.SetMirror( gp_Ax2(inputCenter, gp_Dir(0, -1, 0)) );
         tempTransform.Multiply(mirrorTransform);

--- a/src/Mod/TechDraw/Gui/QGIViewDimension.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewDimension.cpp
@@ -290,6 +290,7 @@ void QGIViewDimension::draw()
         return;
     }
     
+    datumLabel->show();
     show();
 
     TechDraw::DrawViewDimension *dim = dynamic_cast<TechDraw::DrawViewDimension *>(getViewObject());


### PR DESCRIPTION
This PR corrects a problem where BRepBuilderAPI_Transform was called with scale = zero, causing infinite loop.  It also fixes a problem with Dimension text display.  Please merge. 

Thanks,
wf

- if a scale transform with scale = 0 is passed to
  BRepBuilderAPI_Transform, it will loop forever.
  If Page.keepUpdated is false, and Views have not yet
  been executed (ex at load time), Views will have a
  0.0 x 0.0 bbox and if Autoscale is true, a scale of
  0.0 will be used in fit-to-page.

- if keepUpdated is off, Dimension text never
  gets shown.


Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
