### PR TITLE
[For v0.18] mesh: py: add functions to get mesh as a numpy-array

### DIFF
--- a/src/Mod/Mesh/App/MeshPy.xml
+++ b/src/Mod/Mesh/App/MeshPy.xml
@@ -518,6 +518,24 @@ for p in mesh.Facets:
 			</Documentation>
 			<Parameter Name="Volume" Type="Float" />
 		</Attribute>
+		<Attribute Name="npFacetsPoints" ReadOnly="true">
+			<Documentation>
+				<UserDocu>Return a f x 3 x 3 numpy array representing all triangles</UserDocu>
+			</Documentation>
+			<Parameter Name="npFacetsPoints" Type="Object" />
+		</Attribute>
+		<Attribute Name="npPoints" ReadOnly="true">
+			<Documentation>
+				<UserDocu>Return a v x 3 array including all vertices.</UserDocu>
+			</Documentation>
+			<Parameter Name="npPoints" Type="Object" />
+		</Attribute>
+		<Attribute Name="npFacets" ReadOnly="true">
+			<Documentation>
+				<UserDocu>Return a f x 3 array including all facets indices.</UserDocu>
+			</Documentation>
+			<Parameter Name="npFacets" Type="Object" />
+		</Attribute>
 		<ClassDeclarations>private:
     friend class PropertyMeshKernel;
     class PropertyMeshKernel* parentProperty;

--- a/src/Mod/Mesh/App/MeshPyImp.cpp
+++ b/src/Mod/Mesh/App/MeshPyImp.cpp
@@ -47,6 +47,10 @@
 
 #include <boost/algorithm/string.hpp>
 
+#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+#include "numpy/arrayobject.h"
+
+
 using namespace Mesh;
 
 
@@ -1885,4 +1889,63 @@ Py::Tuple MeshPy::getTopology(void) const
     return tuple;
 }
 
+Py::Object MeshPy::getnpFacetsPoints() const
+{
+    MeshObject* mesh = getMeshObjectPtr();
+    
+    _import_array();
+
+    long dims[] = {(long) mesh->countFacets(), 3, 3};
+    PyObject* np_array = PyArray_SimpleNew(3, dims, NPY_FLOAT64);
+    double *arr = (double*) PyArray_DATA((PyArrayObject*) np_array);
+    long i = 0;
+    for (MeshObject::const_facet_iterator it = mesh->facets_begin(); it != mesh->facets_end(); ++it) {
+	for (int j = 0; j < 3; j++)
+	    {
+		MeshPoint pnt = mesh->getPoint(it->PIndex[j]);
+		arr[i] = pnt.x; i++;
+		arr[i] = pnt.y; i++;
+		arr[i] = pnt.z; i++;
+	    }
+    }
+
+    return  Py::Object (np_array);
+}
+
+Py::Object MeshPy::getnpPoints() const
+{
+    MeshObject* mesh = getMeshObjectPtr();
+    
+    _import_array();
+
+    long dims[] = {(long) mesh->countPoints(), 3};
+    PyObject* np_array = PyArray_SimpleNew(2, dims, NPY_FLOAT64);
+    double *arr = (double*) PyArray_DATA((PyArrayObject*) np_array);
+    long i = 0;
+    for (MeshObject::const_point_iterator it = mesh->points_begin(); it != mesh->points_end(); ++it) {
+	arr[i] = it->x; i++;
+	arr[i] = it->y; i++;
+	arr[i] = it->z; i++;
+    }
+    return Py::Object (np_array);
+}
+
+Py::Object MeshPy::getnpFacets() const
+{
+    MeshObject* mesh = getMeshObjectPtr();
+    
+    _import_array();
+
+    long dims[] = {(long) mesh->countFacets(), 3};
+    PyObject* np_array = PyArray_SimpleNew(2, dims, NPY_LONG);
+    long *arr = (long*) PyArray_DATA((PyArrayObject*) np_array);
+    long i = 0;
+    for (MeshObject::const_facet_iterator it = mesh->facets_begin(); it != mesh->facets_end(); ++it) {
+	for (int j = 0; j < 3; j++)
+	    {
+		arr[i] = it->PIndex[j]; i++;
+	    }
+    }
+    return Py::Object (np_array);
+}
 


### PR DESCRIPTION
asserts triangular mesh!
- mesh.npFacets [f x 3]
- mesh.npPoints [p x 3]
- mesh.npFacetsPoints [f x 3 x 3]

to test:
```
import time
import numpy as np
import FreeCAD as App
import Part, Mesh, MeshPart

doc = App.newDocument()
doc.addObject("Part::Sphere","Sphere")
doc.ActiveObject.Label = "Sphere"
doc.recompute()

mesh = doc.addObject("Mesh::Feature","Mesh")
mesh.Mesh = MeshPart.meshFromShape(Shape=doc.getObject("Sphere").Shape,
                                   LinearDeflection=0.1,
                                   AngularDeflection=0.025,
                                   Relative=False)
t0 = time.time()
pts = mesh.Mesh.npFacetsPoints
print('using c++ directly: {}s'.format(time.time() - t0))

t0 = time.time()
ind = mesh.Mesh.npFacets
verts = mesh.Mesh.npPoints
pts = verts[ind]
print('using vertices + facets from c++: {}s'.format(time.time() - t0))

```

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
