### PR TITLE
Gui: Better visualization of the Active Object

### DIFF
--- a/src/Gui/ActiveObjectList.h
+++ b/src/Gui/ActiveObjectList.h
@@ -55,7 +55,7 @@ namespace Gui
 			std::map<std::string, App::DocumentObject*>::const_iterator pos = _ObjectMap.find(name);
 			return  pos == _ObjectMap.end() ? 0 : dynamic_cast<_T>(pos->second);
 		}
-		void setObject(App::DocumentObject*, const char*, const Gui::HighlightMode& m = Gui::LightBlue);
+		void setObject(App::DocumentObject*, const char*, const Gui::HighlightMode& m = Gui::UnderlinedBoldLightBlue);
 		bool hasObject(const char*)const;
                 void objectDeleted(const ViewProviderDocumentObject& viewProviderIn);
 	protected:

--- a/src/Gui/Tree.cpp
+++ b/src/Gui/Tree.cpp
@@ -1265,8 +1265,17 @@ void DocumentItem::slotActiveObject(const Gui::ViewProviderDocumentObject& obj)
 
 void DocumentItem::slotHighlightObject (const Gui::ViewProviderDocumentObject& obj, const Gui::HighlightMode& high, bool set)
 {
+
     FOREACH_ITEM(item,obj)
         QFont f = item->font(0);
+
+        auto lightblue = [&item, &set](){
+            if (set)
+                item->setBackgroundColor(0,QColor(230,230,255));
+            else
+                item->setData(0, Qt::BackgroundColorRole,QVariant());
+        };
+
         switch (high) {
         case Gui::Bold: f.setBold(set);             break;
         case Gui::Italic: f.setItalic(set);         break;
@@ -1279,10 +1288,12 @@ void DocumentItem::slotHighlightObject (const Gui::ViewProviderDocumentObject& o
                 item->setData(0, Qt::BackgroundColorRole,QVariant());
             break;
         case Gui::LightBlue:
-            if (set)
-                item->setBackgroundColor(0,QColor(230,230,255));
-            else
-                item->setData(0, Qt::BackgroundColorRole,QVariant());
+            lightblue();
+            break;
+        case Gui::UnderlinedBoldLightBlue:
+            f.setBold(set);
+            f.setUnderline(set);
+            lightblue();
             break;
         default:
             break;

--- a/src/Gui/Tree.h
+++ b/src/Gui/Tree.h
@@ -42,12 +42,13 @@ typedef std::shared_ptr<DocumentObjectItems> DocumentObjectItemsPtr;
 class DocumentItem;
 
 /// highlight modes for the tree items
-enum HighlightMode {    Underlined,
-                        Italic    ,
-                        Overlined ,
-                        Bold      ,
-                        Blue      ,
-                        LightBlue
+enum HighlightMode {    Underlined              = 0x1,
+                        Italic                  = 0x2,
+                        Overlined               = 0x4,
+                        Bold                    = 0x8,
+                        Blue                    = 0x10,
+                        LightBlue               = 0x20,
+                        UnderlinedBoldLightBlue = LightBlue | Bold | Underlined
 };
 
 /// highlight modes for the tree items


### PR DESCRIPTION
==============================================

Underlined bold lightblue active objects

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
