### PR TITLE
Fix CmdTechDrawProjGroup Selection Criteria

### DIFF
--- a/src/Mod/TechDraw/Gui/Command.cpp
+++ b/src/Mod/TechDraw/Gui/Command.cpp
@@ -33,8 +33,10 @@
 #include <App/Application.h>
 #include <App/Document.h>
 #include <App/DocumentObject.h>
+#include <App/DocumentObjectGroup.h>
 #include <App/FeaturePython.h>
 #include <App/PropertyGeo.h>
+#include <App/GeoFeature.h>
 #include <Base/Console.h>
 #include <Base/Exception.h>
 #include <Base/Parameter.h>
@@ -253,11 +255,16 @@ void CmdTechDrawNewView::activated(int iMsg)
         return;
     }
 
-    std::vector<App::DocumentObject*> shapes = getSelection().getObjectsOfType(App::DocumentObject::getClassTypeId());
-    if (shapes.empty()) {
+    std::vector<App::DocumentObject*> shapes = getSelection().getObjectsOfType(App::GeoFeature::getClassTypeId());
+    std::vector<App::DocumentObject*> groups = getSelection().getObjectsOfType(App::DocumentObjectGroup::getClassTypeId());
+    if ((shapes.empty()) &&
+        (groups.empty())) {
         QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
             QObject::tr("Can not make a View from this selection"));
         return;
+    }
+    if (!groups.empty()) {
+        shapes.insert(shapes.end(),groups.begin(),groups.end());
     }
     
     std::string PageName = page->getNameInDocument();
@@ -446,11 +453,16 @@ void CmdTechDrawProjGroup::activated(int iMsg)
         return;
     }
 
-    std::vector<App::DocumentObject*> shapes = getSelection().getObjectsOfType(Part::Feature::getClassTypeId());
-    if (shapes.empty())  {
+    std::vector<App::DocumentObject*> shapes = getSelection().getObjectsOfType(App::GeoFeature::getClassTypeId());
+    std::vector<App::DocumentObject*> groups = getSelection().getObjectsOfType(App::DocumentObjectGroup::getClassTypeId());
+    if ((shapes.empty()) &&
+        (groups.empty())) {
         QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Wrong selection"),
-            QObject::tr("Can not make a ProjectionGroup from this selection."));
+            QObject::tr("Can not make a ProjectionGroup from this selection"));
         return;
+    }
+    if (!groups.empty()) {
+        shapes.insert(shapes.end(),groups.begin(),groups.end());
     }
 
     std::string PageName = page->getNameInDocument();


### PR DESCRIPTION
This PR fixes a problem in the NewProjectionGroup command that restricted selection to Part::Feature.  Please merge.
Thanks,
wf

- CmdTechDrawProjGroup was not allowing Body or
  App::Part to be selected as Source for new
  ProjectionGroup even though DPG handles
  both.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
