### PR TITLE
Path: replace "Cutting Edge Angle" with "Point/Tip Angle", fixes issue 3338

### DIFF
--- a/src/Mod/Path/Gui/Resources/panels/DlgToolControllerEdit.ui
+++ b/src/Mod/Path/Gui/Resources/panels/DlgToolControllerEdit.ui
@@ -423,7 +423,7 @@
           <item row="16" column="0">
            <widget class="QLabel" name="label_12">
             <property name="text">
-             <string>Cutting Edge Angle</string>
+             <string>Point/Tip Angle</string>
             </property>
            </widget>
           </item>
@@ -576,11 +576,14 @@
             <property name="unit" stdset="0">
              <string notr="true">°</string>
             </property>
+            <property name="text">
+             <string>180 °</string>
+            </property>
             <property name="minimum">
              <double>0.000000000000000</double>
             </property>
             <property name="maximum">
-             <double>90.000000000000000</double>
+             <double>180.000000000000000</double>
             </property>
            </widget>
           </item>

--- a/src/Mod/Path/Gui/Resources/panels/ToolEdit.ui
+++ b/src/Mod/Path/Gui/Resources/panels/ToolEdit.ui
@@ -52,7 +52,6 @@
         <property name="currentIndex">
          <number>0</number>
         </property>
-
        </widget>
       </item>
       <item row="4" column="0">
@@ -63,9 +62,7 @@
        </widget>
       </item>
       <item row="4" column="1">
-       <widget class="QComboBox" name="MaterialField">
-        
-       </widget>
+       <widget class="QComboBox" name="MaterialField"/>
       </item>
       <item row="6" column="0">
        <widget class="QLabel" name="label_4">
@@ -98,7 +95,7 @@
       <item row="16" column="0">
        <widget class="QLabel" name="label_9">
         <property name="text">
-         <string>Cutting Edge Angle</string>
+         <string>Point/Tip Angle</string>
         </property>
        </widget>
       </item>
@@ -194,8 +191,11 @@
       </item>
       <item row="16" column="1">
        <widget class="Gui::InputField" name="CuttingEdgeAngleField">
+        <property name="text">
+         <string>180 °</string>
+        </property>
         <property name="maximum">
-         <double>90.000000000000000</double>
+         <double>180.000000000000000</double>
         </property>
         <property name="minimum">
          <double>0.000000000000000</double>

--- a/src/Mod/Path/PathScripts/PathUtils.py
+++ b/src/Mod/Path/PathScripts/PathUtils.py
@@ -781,14 +781,14 @@ def guessDepths(objshape, subs=None):
 
 def drillTipLength(tool):
     """returns the length of the drillbit tip."""
-    if tool.CuttingEdgeAngle == 0.0 or tool.Diameter == 0.0:
+    if tool.CuttingEdgeAngle == 180 or tool.CuttingEdgeAngle == 0.0 or tool.Diameter == 0.0:
         return 0.0
     else:
-        if tool.CuttingEdgeAngle < 0 or tool.CuttingEdgeAngle >= 90:
-            PathLog.error(translate("Path", "Invalid Cutting Edge Angle %.2f, must be <90° and >=0°") % tool.CuttingEdgeAngle)
+        if tool.CuttingEdgeAngle <= 0 or tool.CuttingEdgeAngle >= 180:
+            PathLog.error(translate("Path", "Invalid Cutting Edge Angle %.2f, must be >0° and <=180°") % tool.CuttingEdgeAngle)
             return 0.0
         theta = math.radians(tool.CuttingEdgeAngle)
-        length = (tool.Diameter/2) / math.tan(theta) 
+        length = (tool.Diameter/2) / math.tan(theta/2) 
         if length < 0:
             PathLog.error(translate("Path", "Cutting Edge Angle (%.2f) results in negative tool tip length") % tool.CuttingEdgeAngle)
             return 0.0


### PR DESCRIPTION
Changed Cutting Edge Angle to be the full bit angle and renamed label.

https://www.freecadweb.org/tracker/view.php?id=3338



Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
