### PR TITLE
Fix hidden click handles on Templates

### DIFF
--- a/src/Mod/TechDraw/Gui/QGISVGTemplate.cpp
+++ b/src/Mod/TechDraw/Gui/QGISVGTemplate.cpp
@@ -61,6 +61,10 @@ QGISVGTemplate::QGISVGTemplate(QGraphicsScene *scene)
     m_svgItem->setCacheMode(QGraphicsItem::NoCache);
 
     addToGroup(m_svgItem);
+
+    m_svgItem->setZValue(ZVALUE::SVGTEMPLATE);
+    setZValue(ZVALUE::SVGTEMPLATE);
+
 }
 
 QGISVGTemplate::~QGISVGTemplate()
@@ -197,6 +201,7 @@ void QGISVGTemplate::createClickHandles(void)
 
             double editClickBoxSize = Rez::guiX(dotSize);
             QColor editClickBoxColor = Qt::green;
+            editClickBoxColor.setAlpha(128);              //semi-transparent
 
             double width = editClickBoxSize;
             double height = editClickBoxSize;
@@ -206,7 +211,6 @@ void QGISVGTemplate::createClickHandles(void)
 
             item->setRect(x - pad, Rez::guiX(-tmplte->getHeight()) + y - height - pad,
                           width + 2 * pad, height + 2 * pad);
-
             QPen myPen;
             QBrush myBrush(editClickBoxColor,Qt::SolidPattern);
             myPen.setStyle(Qt::SolidLine);
@@ -215,14 +219,13 @@ void QGISVGTemplate::createClickHandles(void)
             item->setPen(myPen);
             item->setBrush(myBrush);
 
-            item->setZValue(ZVALUE::SVGTEMPLATE);
+            item->setZValue(ZVALUE::SVGTEMPLATE + 1);
             addToGroup(item);
             textFields.push_back(item);
         }
 
         begin = tagMatch[0].second;
     }
-
 }
 
 #include <Mod/TechDraw/Gui/moc_QGISVGTemplate.cpp>

--- a/src/Mod/TechDraw/Gui/TemplateTextField.cpp
+++ b/src/Mod/TechDraw/Gui/TemplateTextField.cpp
@@ -40,7 +40,9 @@ TemplateTextField::TemplateTextField(QGraphicsItem *parent,
     : QGraphicsRectItem(parent),
       tmplte(myTmplte),
       fieldNameStr(myFieldName)
-{ }
+{
+    setToolTip(QObject::tr("Click to update text"));
+ }
 
 void TemplateTextField::mousePressEvent(QGraphicsSceneMouseEvent *event)
 {


### PR DESCRIPTION
This PR addresses some problems with TechDraw templates.  Please merge.
Thanks,
wf

- on some Templates, the green click handles for
  editing text were being painted under the Template
  and were not visible.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
