### PR TITLE
ViewProviderPage Fixes

### DIFF
--- a/src/Mod/TechDraw/Gui/ViewProviderPage.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderPage.cpp
@@ -119,6 +119,8 @@ void ViewProviderPage::show(void)
     showMDIViewPage();
 }
 
+//this "hide" is only used for Visibility property toggle
+//not when Page tab is closed.
 void ViewProviderPage::hide(void)
 {
     if (!m_mdiView.isNull()) {                                //m_mdiView is a QPointer
@@ -169,18 +171,11 @@ void ViewProviderPage::updateData(const App::Property* prop)
 
 bool ViewProviderPage::onDelete(const std::vector<std::string> &items)
 {
+    bool rc = ViewProviderDocumentObject::onDelete(items);
     if (!m_mdiView.isNull()) {
-        Gui::getMainWindow()->removeWindow(m_mdiView);
-//        Gui::getMainWindow()->activatePreviousWindow();   //changed for consistency. see comment in hide() above. 
-                                                            //note: doesn't fix problem here.
-                                                            //3d view is still not maximized after page is deleted.
-        m_mdiView->deleteLater(); // Delete the drawing m_mdiView;
-    } else {
-        // MDIViewPage is not displayed yet so don't try to delete it!
-        Base::Console().Log("INFO - ViewProviderPage::onDelete - Page object deleted when viewer not displayed\n");
+        m_mdiView->deleteSelf();
     }
-    Gui::Selection().clearSelection();
-    return ViewProviderDocumentObject::onDelete(items);
+    return rc;
 }
 
 void ViewProviderPage::setupContextMenu(QMenu* menu, QObject* receiver, const char* member)


### PR DESCRIPTION
This PR addresses some shortcomings in TechDrawGui::ViewProviderPage.  
- a problem affecting the 3D window on close of TechDraw tab was [https://forum.freecadweb.org/viewtopic.php?f=3&t=22797&p=182614#p182614](fixed previously), but the problem remained when the DrawViewPage itself was deleted. This is now fixed.
- VPP also contained redundant code for updating tab text on change of Label property. This has been removed.
- a context menu item to allow toggling of the Page KeepUpdated property was also added.  
Please merge.
Thanks,
wf

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
