### PR TITLE
Edge.getParameterByLength fix

### DIFF
--- a/src/Mod/Part/App/TopoShapeEdgePy.xml
+++ b/src/Mod/Part/App/TopoShapeEdgePy.xml
@@ -16,18 +16,21 @@
     </Documentation>
 		<Methode Name="getParameterByLength" Const="true">
 			<Documentation>
-				<UserDocu>paramval = getParameterByLength(pos)
+				<UserDocu>paramval = getParameterByLength(pos, [tolerance = 1e-7])
 Get the value of the primary parameter at the given distance along the cartesian
-length of the curve.
+length of the edge.
 
 Args:
-    pos (float or int): The distance along the length of the curve at which to 
+    pos (float or int): The distance along the length of the edge at which to 
         determine the primary parameter value. See help for the FirstParameter or 
         LastParameter properties for more information on the primary parameter.
+        If the given value is positive, the distance from edge start is used.
+        If the given value is negative, the distance from edge end is used.
+    tol (float): Computing tolerance. Optional, defaults to 1e-7.
 
 Returns:
 
-    paramval (float): the value of the primary parameter defining the curve at the 
+    paramval (float): the value of the primary parameter defining the edge at the 
         given position along its cartesian length.
 </UserDocu>
 			</Documentation>

--- a/src/Mod/Part/App/TopoShapeEdgePyImp.cpp
+++ b/src/Mod/Part/App/TopoShapeEdgePyImp.cpp
@@ -187,7 +187,8 @@ int TopoShapeEdgePy::PyInit(PyObject* args, PyObject* /*kwd*/)
 PyObject* TopoShapeEdgePy::getParameterByLength(PyObject *args)
 {
     double u;
-    if (!PyArg_ParseTuple(args, "d",&u))
+    double t=Precision::Confusion();
+    if (!PyArg_ParseTuple(args, "d|d",&u,&t))
         return 0;
 
     const TopoDS_Edge& e = TopoDS::Edge(getTopoShapePtr()->getShape());
@@ -197,15 +198,17 @@ PyObject* TopoShapeEdgePy::getParameterByLength(PyObject *args)
     double first = BRepLProp_CurveTool::FirstParameter(adapt);
     double last = BRepLProp_CurveTool::LastParameter(adapt);
     if (!Precision::IsInfinite(first) && !Precision::IsInfinite(last)) {
-        double length = GCPnts_AbscissaPoint::Length(adapt);
+        double length = GCPnts_AbscissaPoint::Length(adapt,t);
 
-        if (u < 0 || u > length) {
+        if (u < -length || u > length) {
             PyErr_SetString(PyExc_ValueError, "value out of range");
             return 0;
         }
-
-        double stretch = (last - first) / length;
-        u = first + u*stretch;
+        if (u < 0)
+            u = length+u;
+        GCPnts_AbscissaPoint abscissaPoint(t,adapt,u,first);
+        double parm = abscissaPoint.Parameter();
+        return PyFloat_FromDouble(parm);
     }
 
     return PyFloat_FromDouble(u);


### PR DESCRIPTION
Edge.getParameterByLength() only worked on edges with curvilinear parametrization.
See this topic :
https://forum.freecadweb.org/viewtopic.php?style=4&f=22&t=20786
The commit also add the ability to supply a negative value, that will be considered as a distance from edge end.


Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
