### PR TITLE
Move Graphics Properties to Gui Side

### DIFF
--- a/src/Mod/TechDraw/App/AppTechDrawPy.cpp
+++ b/src/Mod/TechDraw/App/AppTechDrawPy.cpp
@@ -57,6 +57,7 @@
 #include "DrawViewPartPy.h"
 #include "GeometryObject.h"
 #include "EdgeWalker.h"
+#include "DrawUtil.h"
 
 
 namespace TechDraw {
@@ -380,7 +381,8 @@ private:
                 TechDrawGeometry::GeometryObject* go = dvp->getGeometryObject();
                 //visible group begin "<g ... >"
                 ss << grpHead1;
-                double thick = dvp->LineWidth.getValue();
+//                double thick = dvp->LineWidth.getValue();
+                double thick = DrawUtil::getDefaultLineWeight("Thick");
                 ss << thick;
                 ss << grpHead2;
                 TopoDS_Shape s = go->getVisHard();
@@ -403,7 +405,8 @@ private:
                      dvp->SeamHidden.getValue() ) {
                     //hidden group begin
                     ss << grpHead1;
-                    thick = dvp->HiddenWidth.getValue();
+//                    thick = dvp->HiddenWidth.getValue();
+                    thick = DrawUtil::getDefaultLineWeight("Thin");
                     ss << thick;
                     ss << grpHead2;
                     if (dvp->HardHidden.getValue()) {

--- a/src/Mod/TechDraw/App/DrawHatch.cpp
+++ b/src/Mod/TechDraw/App/DrawHatch.cpp
@@ -50,30 +50,20 @@
 using namespace TechDraw;
 using namespace std;
 
-App::PropertyFloatConstraint::Constraints DrawHatch::scaleRange = {Precision::Confusion(),
-                                                                  std::numeric_limits<double>::max(),
-                                                                  pow(10,- Base::UnitsApi::getDecimals())};
-
 PROPERTY_SOURCE(TechDraw::DrawHatch, App::DocumentObject)
 
 
 DrawHatch::DrawHatch(void)
 {
     static const char *vgroup = "Hatch";
-    Base::Reference<ParameterGrp> hGrp = App::GetApplication().GetUserParameter()
-        .GetGroup("BaseApp")->GetGroup("Preferences")->GetGroup("Mod/TechDraw/Colors");
-    App::Color fcColor;
-    fcColor.setPackedValue(hGrp->GetUnsigned("Hatch", 0x00FF0000));
 
     ADD_PROPERTY_TYPE(DirProjection ,(0,0,1.0)    ,vgroup,App::Prop_None,"Projection direction when Hatch was defined");     //sb RO?
     ADD_PROPERTY_TYPE(Source,(0),vgroup,(App::PropertyType)(App::Prop_None),"The View + Face to be hatched");
     ADD_PROPERTY_TYPE(HatchPattern ,(""),vgroup,App::Prop_None,"The hatch pattern file for this area");
-    ADD_PROPERTY_TYPE(HatchColor,(fcColor),vgroup,App::Prop_None,"The color of the hatch pattern");
-    ADD_PROPERTY_TYPE(HatchScale,(1.0),vgroup,App::Prop_None,"Hatch pattern size adjustment");
-    HatchScale.setConstraints(&scaleRange);
+
     DirProjection.setStatus(App::Property::ReadOnly,true);
 
-    hGrp = App::GetApplication().GetUserParameter()
+    Base::Reference<ParameterGrp> hGrp = App::GetApplication().GetUserParameter()
         .GetGroup("BaseApp")->GetGroup("Preferences")->GetGroup("Mod/TechDraw/Files");
 
     std::string defaultDir = App::Application::getResourceDir() + "Mod/Drawing/patterns/";
@@ -94,10 +84,8 @@ DrawHatch::~DrawHatch()
 
 void DrawHatch::onChanged(const App::Property* prop)
 {
-    if (prop == &Source         ||
-        prop == &HatchPattern  ||              //sb VP property?
-        prop == &HatchScale  ||
-        prop == &HatchColor) {
+    if ((prop == &Source)         ||
+        (prop == &HatchPattern)) {
         if (!isRestoring()) {
               DrawHatch::execute();
           }

--- a/src/Mod/TechDraw/App/DrawHatch.h
+++ b/src/Mod/TechDraw/App/DrawHatch.h
@@ -43,10 +43,6 @@ public:
     App::PropertyVector      DirProjection;                            //Source is only valid for original projection?
     App::PropertyLinkSub     Source;                                   //the dvp & face this hatch belongs to
     App::PropertyFile        HatchPattern;
-    App::PropertyColor       HatchColor;
-    App::PropertyFloatConstraint HatchScale;
-
-    //short mustExecute() const;
 
     virtual App::DocumentObjectExecReturn *execute(void);
 
@@ -62,7 +58,6 @@ protected:
     void onChanged(const App::Property* prop);
 
 private:
-    static App::PropertyFloatConstraint::Constraints scaleRange;
 
 };
 

--- a/src/Mod/TechDraw/App/DrawUtil.cpp
+++ b/src/Mod/TechDraw/App/DrawUtil.cpp
@@ -425,6 +425,17 @@ double DrawUtil::sensibleScale(double working_scale)
     return result;
 }
 
+double DrawUtil::getDefaultLineWeight(std::string lineType)
+{
+    Base::Reference<ParameterGrp> hGrp = App::GetApplication().GetUserParameter().GetGroup("BaseApp")->
+                                                    GetGroup("Preferences")->GetGroup("Mod/TechDraw/Decorations");
+    std::string lgName = hGrp->GetASCII("LineGroup","FC 0.70mm");
+    auto lg = LineGroup::lineGroupFactory(lgName);
+    
+    double weight = lg->getWeight(lineType);
+    return weight;
+}
+
 //============================
 // various debugging routines.
 void DrawUtil::dumpVertexes(const char* text, const TopoDS_Shape& s)

--- a/src/Mod/TechDraw/App/DrawUtil.h
+++ b/src/Mod/TechDraw/App/DrawUtil.h
@@ -40,6 +40,8 @@
 #include <Base/Vector3D.h>
 #include <Base/Matrix.h>
 
+#include "LineGroup.h"
+
 #define VERTEXTOLERANCE (2.0 * Precision::Confusion())
 
 namespace TechDraw
@@ -72,6 +74,7 @@ class TechDrawExport DrawUtil {
                                         Base::Vector3d axis,
                                         Base::Vector3d org = Base::Vector3d(0.0,0.0,0.0));
         static Base::Vector3d closestBasis(Base::Vector3d v);
+        static double getDefaultLineWeight(std::string s);
 
 
 

--- a/src/Mod/TechDraw/App/DrawView.cpp
+++ b/src/Mod/TechDraw/App/DrawView.cpp
@@ -84,9 +84,7 @@ DrawView::DrawView(void)
     ADD_PROPERTY_TYPE(Scale ,(1.0),group,App::Prop_None,"Scale factor of the view");
     Scale.setConstraints(&scaleRange);
 
-    ADD_PROPERTY_TYPE(KeepLabel ,(false),fgroup,App::Prop_None,"Keep Label on Page even if toggled off");
     ADD_PROPERTY_TYPE(Caption ,(""),fgroup,App::Prop_None,"Short text about the view");
-
 }
 
 DrawView::~DrawView()

--- a/src/Mod/TechDraw/App/DrawView.cpp
+++ b/src/Mod/TechDraw/App/DrawView.cpp
@@ -71,8 +71,7 @@ DrawView::DrawView(void)
   : autoPos(true),
     mouseMove(false)
 {
-    static const char *group = "BaseView";
-    static const char *fgroup = "Format";
+    static const char *group = "Base";
 
     ADD_PROPERTY_TYPE(X ,(0),group,App::Prop_None,"X position of the view on the page in modelling units (mm)");
     ADD_PROPERTY_TYPE(Y ,(0),group,App::Prop_None,"Y position of the view on the page in modelling units (mm)");
@@ -84,7 +83,7 @@ DrawView::DrawView(void)
     ADD_PROPERTY_TYPE(Scale ,(1.0),group,App::Prop_None,"Scale factor of the view");
     Scale.setConstraints(&scaleRange);
 
-    ADD_PROPERTY_TYPE(Caption ,(""),fgroup,App::Prop_None,"Short text about the view");
+    ADD_PROPERTY_TYPE(Caption ,(""),group,App::Prop_None,"Short text about the view");
 }
 
 DrawView::~DrawView()

--- a/src/Mod/TechDraw/App/DrawView.h
+++ b/src/Mod/TechDraw/App/DrawView.h
@@ -55,7 +55,6 @@ public:
 
     App::PropertyEnumeration ScaleType;
     App::PropertyFloat Rotation;
-    App::PropertyBool  KeepLabel;
     App::PropertyString Caption;
 
     /** @name methods override Feature */

--- a/src/Mod/TechDraw/App/DrawViewDimension.cpp
+++ b/src/Mod/TechDraw/App/DrawViewDimension.cpp
@@ -87,29 +87,12 @@ enum RefType{
 
 DrawViewDimension::DrawViewDimension(void)
 {
-    Base::Reference<ParameterGrp> hGrp = App::GetApplication().GetUserParameter()
-                                         .GetGroup("BaseApp")->GetGroup("Preferences")->GetGroup("Mod/TechDraw/Labels");
-    std::string fontName = hGrp->GetASCII("LabelFont", "osifont");
-    hGrp = App::GetApplication().GetUserParameter()
-                                         .GetGroup("BaseApp")->GetGroup("Preferences")->GetGroup("Mod/TechDraw/Dimensions");
-    double fontSize = hGrp->GetFloat("FontSize", 3.5);
-
     ADD_PROPERTY_TYPE(References2D,(0,0),"",(App::PropertyType)(App::Prop_None),"Projected Geometry References");
     References2D.setScope(App::LinkScope::Global);
     ADD_PROPERTY_TYPE(References3D,(0,0),"",(App::PropertyType)(App::Prop_None),"3D Geometry References");
     References3D.setScope(App::LinkScope::Global);
-    ADD_PROPERTY_TYPE(Font ,(fontName.c_str()),"Format",App::Prop_None, "The name of the font to use");
-    ADD_PROPERTY_TYPE(Fontsize,(fontSize)    ,"Format",(App::PropertyType)(App::Prop_None),"Dimension text size in mm");
     ADD_PROPERTY_TYPE(FormatSpec,(getDefaultFormatSpec().c_str()) ,
                   "Format",(App::PropertyType)(App::Prop_None),"Dimension Format");
-
-    hGrp = App::GetApplication().GetUserParameter().GetGroup("BaseApp")->GetGroup("Preferences")->GetGroup("Mod/TechDraw/Decorations");
-    std::string lgName = hGrp->GetASCII("LineGroup","FC 0.70mm");
-    auto lg = LineGroup::lineGroupFactory(lgName);
-    double weight = lg->getWeight("Graphic");
-    delete lg;   //Coverity CID 169507
-    ADD_PROPERTY_TYPE(LineWidth,(weight)    ,"Format",(App::PropertyType)(App::Prop_None),"Dimension line weight");
-    //ADD_PROPERTY_TYPE(CentreLines,(0) ,"Format",(App::PropertyType)(App::Prop_None),"Arc Dimension Center Mark");
 
     Type.setEnums(TypeEnums);                                          //dimension type: length, radius etc
     ADD_PROPERTY(Type,((long)0));
@@ -178,6 +161,7 @@ short DrawViewDimension::mustExecute() const
     if (!isRestoring()) {
         result =  (References2D.isTouched() ||
                   Type.isTouched() ||
+                  FormatSpec.isTouched() ||
                   MeasureType.isTouched());
     }
     if (result) {

--- a/src/Mod/TechDraw/App/DrawViewDimension.h
+++ b/src/Mod/TechDraw/App/DrawViewDimension.h
@@ -57,13 +57,7 @@ public:
     App::PropertyLinkSubList       References2D;                       //Points to Projection SubFeatures
     App::PropertyLinkSubList       References3D;                       //Points to 3D Geometry SubFeatures
     App::PropertyEnumeration       Type;                               //DistanceX,DistanceY,Diameter, etc
-
-    /// Properties for Visualisation
-    App::PropertyFont  Font;
-    App::PropertyFloat   Fontsize;
-    App::PropertyString  FormatSpec;
-    App::PropertyFloat   LineWidth;
-    //App::PropertyBool    CentreLines;
+    App::PropertyString            FormatSpec;
 
     short mustExecute() const;
     bool has2DReferences(void) const;

--- a/src/Mod/TechDraw/App/DrawViewPart.cpp
+++ b/src/Mod/TechDraw/App/DrawViewPart.cpp
@@ -118,14 +118,12 @@ PROPERTY_SOURCE(TechDraw::DrawViewPart, TechDraw::DrawView)
 DrawViewPart::DrawViewPart(void) : geometryObject(0)
 {
     static const char *group = "Projection";
-    static const char *fgroup = "Format";
-    static const char *lgroup = "Lines";
-    static const char *sgroup = "Show";
+    static const char *sgroup = "HLR Parameters";
     nowUnsetting = false;
+
     Base::Reference<ParameterGrp> hGrp = App::GetApplication().GetUserParameter().GetGroup("BaseApp")->
                                                                GetGroup("Preferences")->GetGroup("Mod/TechDraw/General");
     double defDist = hGrp->GetFloat("FocusDistance",100.0);
-    bool coarseView = hGrp->GetBool("CoarseView", false);
 
     //properties that affect Geometry
     ADD_PROPERTY_TYPE(Source ,(0),group,App::Prop_None,"3D Shape to view");
@@ -134,7 +132,8 @@ DrawViewPart::DrawViewPart(void) : geometryObject(0)
     ADD_PROPERTY_TYPE(Perspective ,(false),group,App::Prop_None,"Perspective(true) or Orthographic(false) projection");
     ADD_PROPERTY_TYPE(Focus,(defDist),group,App::Prop_None,"Perspective view focus distance");
 
-    //properties that affect Appearance
+    //properties that control HLR algoaffect Appearance
+    bool coarseView = hGrp->GetBool("CoarseView", false);
     ADD_PROPERTY_TYPE(CoarseView, (coarseView), sgroup, App::Prop_None, "Coarse View on/off");
     //visible outline
     ADD_PROPERTY_TYPE(SmoothVisible ,(false),sgroup,App::Prop_None,"Visible Smooth lines on/off");
@@ -145,33 +144,9 @@ DrawViewPart::DrawViewPart(void) : geometryObject(0)
     ADD_PROPERTY_TYPE(SeamHidden ,(false),sgroup,App::Prop_None,"Hidden Seam lines on/off");
     ADD_PROPERTY_TYPE(IsoHidden ,(false),sgroup,App::Prop_None,"Hidden Iso u,v lines on/off");
     ADD_PROPERTY_TYPE(IsoCount ,(0),sgroup,App::Prop_None,"Number of isoparameters");
-    
-    //default line weights
-    hGrp = App::GetApplication().GetUserParameter().GetGroup("BaseApp")->
-                                                    GetGroup("Preferences")->GetGroup("Mod/TechDraw/Decorations");
-    std::string lgName = hGrp->GetASCII("LineGroup","FC 0.70mm");
-    auto lg = LineGroup::lineGroupFactory(lgName);
-    double weight = lg->getWeight("Thick");
-    ADD_PROPERTY_TYPE(LineWidth,(weight),lgroup,App::Prop_None,"The thickness of visible lines");
-    weight = lg->getWeight("Thin");
-    ADD_PROPERTY_TYPE(HiddenWidth,(weight),lgroup,App::Prop_None,"The thickness of hidden lines, if enabled");
-    weight = lg->getWeight("Graphic");
-    ADD_PROPERTY_TYPE(IsoWidth,(weight),lgroup,App::Prop_None,"The thickness of isoparameter/center/section lines, if enabled");
-    weight = lg->getWeight("Extra");
-    ADD_PROPERTY_TYPE(ExtraWidth,(weight),lgroup,App::Prop_None,"The thickness of LineGroup Extra lines, if enabled");
-
-    ADD_PROPERTY_TYPE(HorizCenterLine ,(false),lgroup,App::Prop_None,"Show a horizontal centerline through view");
-    ADD_PROPERTY_TYPE(VertCenterLine ,(false),lgroup,App::Prop_None,"Show a vertical centerline through view");
-
-    ADD_PROPERTY_TYPE(ArcCenterMarks ,(true),sgroup,App::Prop_None,"Center marks on/off");
-    ADD_PROPERTY_TYPE(CenterScale,(2.0),fgroup,App::Prop_None,"Center mark size adjustment, if enabled");
-
-    //properties that affect Section Line
-    ADD_PROPERTY_TYPE(ShowSectionLine ,(true)    ,sgroup,App::Prop_None,"Show/hide section line if applicable");
 
     geometryObject = nullptr;
     getRunControl();
-    delete lg;
 }
 
 DrawViewPart::~DrawViewPart()
@@ -306,7 +281,18 @@ short DrawViewPart::mustExecute() const
         result  =  (Direction.isTouched()  ||
                     Source.isTouched()  ||
                     Scale.isTouched() ||
-                    ScaleType.isTouched());
+                    ScaleType.isTouched() ||
+                    Perspective.isTouched() ||
+                    Focus.isTouched() ||
+                    SmoothVisible.isTouched() ||
+                    SeamVisible.isTouched() ||
+                    IsoVisible.isTouched() ||
+                    HardHidden.isTouched() ||
+                    SmoothHidden.isTouched() ||
+                    SeamHidden.isTouched() ||
+                    IsoHidden.isTouched() ||
+                    IsoCount.isTouched() ||
+                    CoarseView.isTouched());
     }
 
     if (result) {

--- a/src/Mod/TechDraw/App/DrawViewPart.h
+++ b/src/Mod/TechDraw/App/DrawViewPart.h
@@ -100,17 +100,6 @@ public:
     App::PropertyBool   IsoHidden;
     App::PropertyInteger  IsoCount;
 
-    App::PropertyFloat  LineWidth;
-    App::PropertyFloat  HiddenWidth;
-    App::PropertyFloat  IsoWidth;
-    App::PropertyFloat  ExtraWidth;
-    App::PropertyBool   ArcCenterMarks;
-    App::PropertyFloat  CenterScale;
-    App::PropertyBool   HorizCenterLine;
-    App::PropertyBool   VertCenterLine;
-    App::PropertyBool   ShowSectionLine;
-
-
     std::vector<TechDraw::DrawHatch*> getHatches(void) const;
     std::vector<TechDraw::DrawGeomHatch*> getGeomHatches(void) const;
     std::vector<TechDraw::DrawViewDimension*> getDimensions() const;

--- a/src/Mod/TechDraw/App/DrawViewSection.cpp
+++ b/src/Mod/TechDraw/App/DrawViewSection.cpp
@@ -104,8 +104,7 @@ PROPERTY_SOURCE(TechDraw::DrawViewSection, TechDraw::DrawViewPart)
 DrawViewSection::DrawViewSection()
 {
     static const char *sgroup = "Section";
-    static const char *fgroup = "Format";
-    //static const char *lgroup = "Line";
+    static const char *fgroup = "Cut Surface Format";
 
 
     ADD_PROPERTY_TYPE(SectionSymbol ,("A"),sgroup,App::Prop_None,"The identifier for this section");
@@ -118,14 +117,6 @@ DrawViewSection::DrawViewSection()
     ADD_PROPERTY_TYPE(FileHatchPattern ,(""),fgroup,App::Prop_None,"The hatch pattern file for the cut surface");
     ADD_PROPERTY_TYPE(NameGeomPattern ,(""),fgroup,App::Prop_None,"The pattern name for geometric hatching");
     ADD_PROPERTY_TYPE(HatchScale,(1.0),fgroup,App::Prop_None,"Hatch pattern size adjustment");
-
-//    ADD_PROPERTY_TYPE(ShowCutSurface ,(true),fgroup,App::Prop_None,"Show/hide the cut surface");
-//    ADD_PROPERTY_TYPE(CutSurfaceColor,(0.0,0.0,0.0),fgroup,App::Prop_None,"The color to shade the cut surface");
-//    ADD_PROPERTY_TYPE(HatchCutSurface ,(false),fgroup,App::Prop_None,"Hatch the cut surface");
-//    ADD_PROPERTY_TYPE(FileHatchPattern ,(""),fgroup,App::Prop_None,"The hatch pattern file for the cut surface");
-//    ADD_PROPERTY_TYPE(NameGeomPattern ,(""),fgroup,App::Prop_None,"The pattern name for geometric hatching");
-//    ADD_PROPERTY_TYPE(HatchColor,(0.0,0.0,0.0),fgroup,App::Prop_None,"The color of the hatch pattern");
-    
 
     getParameters();
 

--- a/src/Mod/TechDraw/Gui/DlgPrefsTechDraw2.ui
+++ b/src/Mod/TechDraw/Gui/DlgPrefsTechDraw2.ui
@@ -266,19 +266,6 @@
         </item>
        </layout>
       </item>
-      <item row="1" column="0">
-       <spacer name="verticalSpacer">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>20</width>
-          <height>40</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
      </layout>
     </widget>
    </item>
@@ -477,32 +464,6 @@
            </size>
           </property>
          </spacer>
-        </item>
-        <item row="6" column="0">
-         <widget class="QLabel" name="label_10">
-          <property name="toolTip">
-           <string>Default weight for GeomHatch lines</string>
-          </property>
-          <property name="text">
-           <string>Hatch Weight</string>
-          </property>
-         </widget>
-        </item>
-        <item row="6" column="2">
-         <widget class="Gui::PrefDoubleSpinBox" name="doubleSpinBox">
-          <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-          </property>
-          <property name="value">
-           <double>1.000000000000000</double>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>GeomWeight</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/TechDraw/PAT</cstring>
-          </property>
-         </widget>
         </item>
         <item row="0" column="0">
          <widget class="QLabel" name="label_13">

--- a/src/Mod/TechDraw/Gui/QGIView.cpp
+++ b/src/Mod/TechDraw/Gui/QGIView.cpp
@@ -59,6 +59,7 @@
 #include "QGICaption.h"
 #include "QGCustomClip.h"
 #include "QGIViewClip.h"
+#include "ViewProviderDrawingView.h"
 
 #include <Mod/TechDraw/App/DrawViewClip.h>
 #include <Mod/TechDraw/App/DrawProjGroup.h>
@@ -354,7 +355,8 @@ void QGIView::drawCaption()
     QPointF displayCenter = displayArea.center();
     m_caption->setX(displayCenter.x() - captionArea.width()/2.);
     double labelHeight = (1 - labelCaptionFudge) * m_label->boundingRect().height();
-    if (borderVisible || viewObj->KeepLabel.getValue()) {            //place below label if label visible
+    auto vp = static_cast<ViewProviderDrawingView*>(getViewProvider(getViewObject()));
+    if (borderVisible || vp->KeepLabel.getValue()) {            //place below label if label visible
         m_caption->setY(displayArea.bottom() + labelHeight);
     } else {
         m_caption->setY(displayArea.bottom() + labelCaptionFudge * getPrefFontSize());
@@ -366,7 +368,8 @@ void QGIView::drawBorder()
 {
     drawCaption();
     //show neither
-    if (!borderVisible && !viewObj->KeepLabel.getValue()) {
+    auto vp = static_cast<ViewProviderDrawingView*>(getViewProvider(getViewObject()));
+    if (!borderVisible && !vp->KeepLabel.getValue()) {
          m_label->hide();
          m_border->hide();
         return;

--- a/src/Mod/TechDraw/Gui/QGIViewPart.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewPart.cpp
@@ -70,6 +70,7 @@
 #include "QGIMatting.h"
 #include "QGIViewPart.h"
 #include "ViewProviderGeomHatch.h"
+#include "ViewProviderHatch.h"
 
 using namespace TechDrawGui;
 using namespace TechDrawGeometry;
@@ -412,8 +413,12 @@ void QGIViewPart::drawViewPart()
                     newFace->isHatched(true);
                     newFace->setFillMode(QGIFace::FromFile);
                     newFace->setHatchFile(fHatch->HatchPattern.getValue());
-                    newFace->setHatchScale(fHatch->HatchScale.getValue());
-                    newFace->setHatchColor(fHatch->HatchColor.getValue());
+                    Gui::ViewProvider* gvp = QGIView::getViewProvider(fHatch);
+                    ViewProviderHatch* hatchVp = dynamic_cast<ViewProviderHatch*>(gvp);
+                    if (hatchVp != nullptr) {
+                        newFace->setHatchScale(hatchVp->HatchScale.getValue());
+                        newFace->setHatchColor(hatchVp->HatchColor.getValue());
+                    }
                 }
             } 
             bool drawEdges = getFaceEdgesPref();

--- a/src/Mod/TechDraw/Gui/ViewProviderDimension.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderDimension.cpp
@@ -35,8 +35,9 @@
 #include <App/Application.h>
 #include <App/Document.h>
 #include <App/DocumentObject.h>
-#include <Gui/SoFCSelection.h>
-#include <Gui/Selection.h>
+
+#include <Mod/TechDraw/App/LineGroup.h>
+
 
 #include "ViewProviderDimension.h"
 
@@ -50,6 +51,31 @@ PROPERTY_SOURCE(TechDrawGui::ViewProviderDimension, TechDrawGui::ViewProviderDra
 ViewProviderDimension::ViewProviderDimension()
 {
     sPixmap = "TechDraw_Dimension";
+
+    static const char *group = "Dim Format";
+
+    Base::Reference<ParameterGrp> hGrp = App::GetApplication().GetUserParameter()
+                                         .GetGroup("BaseApp")->GetGroup("Preferences")->GetGroup("Mod/TechDraw/Labels");
+    std::string fontName = hGrp->GetASCII("LabelFont", "osifont");
+    hGrp = App::GetApplication().GetUserParameter()
+                                         .GetGroup("BaseApp")->GetGroup("Preferences")->GetGroup("Mod/TechDraw/Dimensions");
+    double fontSize = hGrp->GetFloat("FontSize", 3.5);
+
+    ADD_PROPERTY_TYPE(Font ,(fontName.c_str()),group,App::Prop_None, "The name of the font to use");
+    ADD_PROPERTY_TYPE(Fontsize,(fontSize)    ,group,(App::PropertyType)(App::Prop_None),"Dimension text size in mm");
+
+    hGrp = App::GetApplication().GetUserParameter().GetGroup("BaseApp")->GetGroup("Preferences")->GetGroup("Mod/TechDraw/Decorations");
+    std::string lgName = hGrp->GetASCII("LineGroup","FC 0.70mm");
+    auto lg = TechDraw::LineGroup::lineGroupFactory(lgName);
+    double weight = lg->getWeight("Graphic");
+    ADD_PROPERTY_TYPE(LineWidth,(weight)    ,group,(App::PropertyType)(App::Prop_None),"Dimension line weight");
+
+    hGrp = App::GetApplication().GetUserParameter()
+                                        .GetGroup("BaseApp")->GetGroup("Preferences")->GetGroup("Mod/TechDraw/Dimensions");
+    App::Color fcColor;
+    fcColor.setPackedValue(hGrp->GetUnsigned("Color", 0x00000000));
+    ADD_PROPERTY_TYPE(Color,(fcColor),group,App::Prop_None,"The color of the Dimension");
+
 }
 
 ViewProviderDimension::~ViewProviderDimension()
@@ -91,6 +117,19 @@ void ViewProviderDimension::updateData(const App::Property* p)
         }
     }
     ViewProviderDrawingView::updateData(p);
+}
+
+void ViewProviderDimension::onChanged(const App::Property* p)
+{
+    if ((p == &Font)  ||
+        (p == &Fontsize) ||
+        (p == &LineWidth) ) {
+        QGIView* qgiv = getQView();
+        if (qgiv) {
+            qgiv->updateView(true);
+        }
+    }
+    Gui::ViewProviderDocumentObject::onChanged(p);
 }
 
 TechDraw::DrawViewDimension* ViewProviderDimension::getViewObject() const

--- a/src/Mod/TechDraw/Gui/ViewProviderDimension.h
+++ b/src/Mod/TechDraw/Gui/ViewProviderDimension.h
@@ -42,6 +42,11 @@ public:
     /// destructor
     virtual ~ViewProviderDimension();
 
+    App::PropertyFont    Font;
+    App::PropertyFloat   Fontsize;
+    App::PropertyFloat   LineWidth;
+    App::PropertyColor   Color;
+
 
     virtual void attach(App::DocumentObject *);
     virtual void setDisplayMode(const char* ModeName);
@@ -49,6 +54,7 @@ public:
     /// returns a list of all possible modes
     virtual std::vector<std::string> getDisplayModes(void) const;
     virtual void updateData(const App::Property*);
+    virtual void onChanged(const App::Property* p);
 
     virtual TechDraw::DrawViewDimension* getViewObject() const;
 };

--- a/src/Mod/TechDraw/Gui/ViewProviderDrawingView.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderDrawingView.cpp
@@ -61,11 +61,13 @@ PROPERTY_SOURCE(TechDrawGui::ViewProviderDrawingView, Gui::ViewProviderDocumentO
 ViewProviderDrawingView::ViewProviderDrawingView()
 {
     sPixmap = "TechDraw_Tree_View";
+    static const char *group = "Base";
+
+    ADD_PROPERTY_TYPE(KeepLabel ,(false),group,App::Prop_None,"Keep Label on Page even if toggled off");
 
     // Do not show in property editor   why? wf
     DisplayMode.setStatus(App::Property::ReadOnly,true);
     m_docReady = true;
-    
 }
 
 ViewProviderDrawingView::~ViewProviderDrawingView()
@@ -110,7 +112,13 @@ void ViewProviderDrawingView::onChanged(const App::Property *prop)
         } else {
             hide();
         }
+    } else if (prop == &KeepLabel) {
+        QGIView* qgiv = getQView();
+        if (qgiv) {
+            qgiv->updateView(true);
+        }
     }
+
     Gui::ViewProviderDocumentObject::onChanged(prop);
 }
 

--- a/src/Mod/TechDraw/Gui/ViewProviderDrawingView.h
+++ b/src/Mod/TechDraw/Gui/ViewProviderDrawingView.h
@@ -49,6 +49,7 @@ public:
     /// destructor
     virtual ~ViewProviderDrawingView();
 
+    App::PropertyBool  KeepLabel;
 
     virtual void attach(App::DocumentObject *);
     virtual void setDisplayMode(const char* ModeName);

--- a/src/Mod/TechDraw/Gui/ViewProviderGeomHatch.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderGeomHatch.cpp
@@ -52,6 +52,8 @@
 #include <Mod/TechDraw/App/DrawGeomHatch.h>
 #include <Mod/TechDraw/App/DrawViewPart.h>
 #include <Mod/TechDraw/App/DrawView.h>
+#include <Mod/TechDraw/App/LineGroup.h>
+
 #include "TaskGeomHatch.h"
 #include "ViewProviderDrawingView.h"
 #include "ViewProviderGeomHatch.h"
@@ -65,12 +67,12 @@ PROPERTY_SOURCE(TechDrawGui::ViewProviderGeomHatch, Gui::ViewProviderDocumentObj
 
 ViewProviderGeomHatch::ViewProviderGeomHatch()
 {
-    static const char *vgroup = "Format";
-
     sPixmap = "actions/techdraw-geomhatch";
 
+    static const char *vgroup = "GeomHatch";
+
     ADD_PROPERTY_TYPE(ColorPattern,(0),vgroup,App::Prop_None,"The color of the pattern");
-    ADD_PROPERTY_TYPE(WeightPattern,(0.1),vgroup,App::Prop_None,"GeomHatch pattern line thickness");
+    ADD_PROPERTY_TYPE(WeightPattern,(0),vgroup,App::Prop_None,"GeomHatch pattern line thickness");
 
     getParameters();
 
@@ -138,9 +140,20 @@ bool ViewProviderGeomHatch::doubleClicked(void)
 }
 
 //for VP properties - but each letter/digit in property editor triggers this!
-void ViewProviderGeomHatch::onChanged(const App::Property* prop)
+void ViewProviderGeomHatch::onChanged(const App::Property* p)
 {
-    Gui::ViewProviderDocumentObject::onChanged(prop);
+    if ((p == &WeightPattern)  ||
+        (p == &ColorPattern) ) {
+        auto gHatch = getViewObject();
+        if (gHatch != nullptr) {
+            TechDraw::DrawViewPart* parent = gHatch->getSourceView();
+            if (parent) {
+                parent->requestPaint();
+            }
+        }
+    }
+
+    Gui::ViewProviderDocumentObject::onChanged(p);
 }
 
 //for feature properties - but each letter/digit in property editor triggers this!
@@ -174,13 +187,14 @@ void ViewProviderGeomHatch::getParameters(void)
     Base::Reference<ParameterGrp> hGrp = App::GetApplication().GetUserParameter()
         .GetGroup("BaseApp")->GetGroup("Preferences")->GetGroup("Mod/TechDraw/Colors");
     App::Color fcColor;
-    fcColor.setPackedValue(hGrp->GetUnsigned("GeomHatch", 0x00000000));
+    fcColor.setPackedValue(hGrp->GetUnsigned("Hatch", 0x00FF0000));
     ColorPattern.setValue(fcColor);
-   
-    hGrp = App::GetApplication().GetUserParameter()
-        .GetGroup("BaseApp")->GetGroup("Preferences")->GetGroup("Mod/TechDraw/PAT"); 
-    double lineWeight = hGrp->GetFloat("GeomWeight",0.1);
-    WeightPattern.setValue(lineWeight);
+
+    hGrp = App::GetApplication().GetUserParameter().GetGroup("BaseApp")->GetGroup("Preferences")->GetGroup("Mod/TechDraw/Decorations");
+    std::string lgName = hGrp->GetASCII("LineGroup","FC 0.70mm");
+    auto lg = TechDraw::LineGroup::lineGroupFactory(lgName);
+    double weight = lg->getWeight("Graphic");
+    WeightPattern.setValue(weight);
 }
 
 TechDraw::DrawGeomHatch* ViewProviderGeomHatch::getViewObject() const

--- a/src/Mod/TechDraw/Gui/ViewProviderHatch.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderHatch.cpp
@@ -25,23 +25,32 @@
 #include "PreCompiled.h"
 
 #ifndef _PreComp_
+#include <Precision.hxx>
+
 #endif
 
 /// Here the FreeCAD includes sorted by Base,App,Gui......
 #include <Base/Console.h>
 #include <Base/Parameter.h>
-#include <Base/Exception.h>
-#include <Base/Sequencer.h>
+//#include <Base/Exception.h>
+//#include <Base/Sequencer.h>
+#include <Base/UnitsApi.h>
 #include <App/Application.h>
 #include <App/Document.h>
 #include <App/DocumentObject.h>
-#include <Gui/SoFCSelection.h>
-#include <Gui/Selection.h>
+//#include <Gui/SoFCSelection.h>
+//#include <Gui/Selection.h>
 
 #include <Mod/TechDraw/App/DrawHatch.h>
+#include <Mod/TechDraw/App/DrawViewPart.h>
 #include "ViewProviderHatch.h"
 
 using namespace TechDrawGui;
+
+App::PropertyFloatConstraint::Constraints ViewProviderHatch::scaleRange = {Precision::Confusion(),
+                                                                  std::numeric_limits<double>::max(),
+                                                                  pow(10,- Base::UnitsApi::getDecimals())};
+
 
 PROPERTY_SOURCE(TechDrawGui::ViewProviderHatch, Gui::ViewProviderDocumentObject)
 
@@ -51,6 +60,16 @@ PROPERTY_SOURCE(TechDrawGui::ViewProviderHatch, Gui::ViewProviderDocumentObject)
 ViewProviderHatch::ViewProviderHatch()
 {
     sPixmap = "TechDraw_Tree_Hatch";
+
+    static const char *vgroup = "Hatch";
+    Base::Reference<ParameterGrp> hGrp = App::GetApplication().GetUserParameter()
+        .GetGroup("BaseApp")->GetGroup("Preferences")->GetGroup("Mod/TechDraw/Colors");
+    App::Color fcColor;
+    fcColor.setPackedValue(hGrp->GetUnsigned("Hatch", 0x00FF0000));
+
+    ADD_PROPERTY_TYPE(HatchColor,(fcColor),vgroup,App::Prop_None,"The color of the hatch pattern");
+    ADD_PROPERTY_TYPE(HatchScale,(1.0),vgroup,App::Prop_None,"Hatch pattern size adjustment");
+    HatchScale.setConstraints(&scaleRange);
 }
 
 ViewProviderHatch::~ViewProviderHatch()
@@ -76,6 +95,16 @@ std::vector<std::string> ViewProviderHatch::getDisplayModes(void) const
     return StrList;
 }
 
+void ViewProviderHatch::onChanged(const App::Property* prop)
+{
+    if ((prop == &HatchScale) ||
+        (prop == &HatchColor)) {
+        TechDraw::DrawViewPart* parent = getViewObject()->getSourceView();
+        if (parent) {
+            parent->requestPaint();
+        }
+    }
+}
 void ViewProviderHatch::updateData(const App::Property* prop)
 {
     Gui::ViewProviderDocumentObject::updateData(prop);

--- a/src/Mod/TechDraw/Gui/ViewProviderHatch.h
+++ b/src/Mod/TechDraw/Gui/ViewProviderHatch.h
@@ -25,7 +25,7 @@
 #ifndef DRAWINGGUI_VIEWPROVIDERHATCH_H
 #define DRAWINGGUI_VIEWPROVIDERHATCH_H
 
-#include <Gui/ViewProviderFeature.h>
+#include <Gui/ViewProviderDocumentObject.h>
 
 namespace TechDraw{
     class DrawHatch;
@@ -44,15 +44,22 @@ public:
     /// destructor
     virtual ~ViewProviderHatch();
 
+    App::PropertyColor       HatchColor;
+    App::PropertyFloatConstraint HatchScale;
 
     virtual void attach(App::DocumentObject *);
     virtual void setDisplayMode(const char* ModeName);
     virtual bool useNewSelectionModel(void) const {return false;}
     /// returns a list of all possible modes
     virtual std::vector<std::string> getDisplayModes(void) const;
+    virtual void onChanged(const App::Property* prop);
     virtual void updateData(const App::Property*);
 
     TechDraw::DrawHatch* getViewObject() const;
+    
+private:
+    static App::PropertyFloatConstraint::Constraints scaleRange;
+
 };
 
 } // namespace TechDrawGui

--- a/src/Mod/TechDraw/Gui/ViewProviderViewPart.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderViewPart.cpp
@@ -40,6 +40,7 @@
 #include <Mod/TechDraw/App/DrawViewMulti.h>
 #include <Mod/TechDraw/App/DrawHatch.h>
 #include <Mod/TechDraw/App/DrawGeomHatch.h>
+#include <Mod/TechDraw/App/LineGroup.h>
 
 #include<Mod/TechDraw/App/DrawPage.h>
 #include "ViewProviderViewPart.h"
@@ -54,6 +55,32 @@ PROPERTY_SOURCE(TechDrawGui::ViewProviderViewPart, TechDrawGui::ViewProviderDraw
 ViewProviderViewPart::ViewProviderViewPart()
 {
     sPixmap = "TechDraw_Tree_View";
+
+    static const char *group = "Lines";
+    static const char *dgroup = "Decoration";
+
+    //default line weights
+    Base::Reference<ParameterGrp> hGrp = App::GetApplication().GetUserParameter().GetGroup("BaseApp")->
+                                                    GetGroup("Preferences")->GetGroup("Mod/TechDraw/Decorations");
+    std::string lgName = hGrp->GetASCII("LineGroup","FC 0.70mm");
+    auto lg = TechDraw::LineGroup::lineGroupFactory(lgName);
+    double weight = lg->getWeight("Thick");
+    ADD_PROPERTY_TYPE(LineWidth,(weight),group,App::Prop_None,"The thickness of visible lines");
+    weight = lg->getWeight("Thin");
+    ADD_PROPERTY_TYPE(HiddenWidth,(weight),group,App::Prop_None,"The thickness of hidden lines, if enabled");
+    weight = lg->getWeight("Graphic");
+    ADD_PROPERTY_TYPE(IsoWidth,(weight),group,App::Prop_None,"The thickness of isoparameter/center/section lines, if enabled");
+    weight = lg->getWeight("Extra");
+    ADD_PROPERTY_TYPE(ExtraWidth,(weight),group,App::Prop_None,"The thickness of LineGroup Extra lines, if enabled");
+
+    //decorations
+    ADD_PROPERTY_TYPE(HorizCenterLine ,(false),dgroup,App::Prop_None,"Show a horizontal centerline through view");
+    ADD_PROPERTY_TYPE(VertCenterLine ,(false),dgroup,App::Prop_None,"Show a vertical centerline through view");
+    ADD_PROPERTY_TYPE(ArcCenterMarks ,(true),dgroup,App::Prop_None,"Center marks on/off");
+    ADD_PROPERTY_TYPE(CenterScale,(2.0),dgroup,App::Prop_None,"Center mark size adjustment, if enabled");
+
+    //properties that affect Section Line
+    ADD_PROPERTY_TYPE(ShowSectionLine ,(true)    ,dgroup,App::Prop_None,"Show/hide section line if applicable");
 }
 
 ViewProviderViewPart::~ViewProviderViewPart()
@@ -63,13 +90,21 @@ ViewProviderViewPart::~ViewProviderViewPart()
 
 void ViewProviderViewPart::updateData(const App::Property* prop)
 {
-    if (prop == &(getViewObject()->LineWidth)   ||
-        prop == &(getViewObject()->HiddenWidth) ||
-        prop == &(getViewObject()->ArcCenterMarks) ||
-        prop == &(getViewObject()->CenterScale) ||
-        prop == &(getViewObject()->ShowSectionLine)  ||
-        prop == &(getViewObject()->HorizCenterLine)  ||
-        prop == &(getViewObject()->VertCenterLine) ) {
+
+    ViewProviderDrawingView::updateData(prop);
+}
+
+void ViewProviderViewPart::onChanged(const App::Property* prop)
+{
+    if (prop == &(LineWidth)   ||
+        prop == &(HiddenWidth) ||
+        prop == &(IsoWidth) ||
+        prop == &(ExtraWidth) ||
+        prop == &(ArcCenterMarks) ||
+        prop == &(CenterScale) ||
+        prop == &(ShowSectionLine)  ||
+        prop == &(HorizCenterLine)  ||
+        prop == &(VertCenterLine) ) {
         // redraw QGIVP
         QGIView* qgiv = getQView();
         if (qgiv) {
@@ -77,12 +112,6 @@ void ViewProviderViewPart::updateData(const App::Property* prop)
         }
      }
 
-
-    ViewProviderDrawingView::updateData(prop);
-}
-
-void ViewProviderViewPart::onChanged(const App::Property* prop)
-{
     ViewProviderDrawingView::onChanged(prop);
 }
 
@@ -94,8 +123,6 @@ void ViewProviderViewPart::attach(App::DocumentObject *pcFeat)
         sPixmap = "TechDraw_Tree_Multi";
     }
 
-    // call parent attach method
-//    ViewProviderDocumentObject::attach(pcFeat);
     ViewProviderDrawingView::attach(pcFeat);
 }
 

--- a/src/Mod/TechDraw/Gui/ViewProviderViewPart.h
+++ b/src/Mod/TechDraw/Gui/ViewProviderViewPart.h
@@ -24,6 +24,10 @@
 #ifndef DRAWINGGUI_VIEWPROVIDERVIEWPART_H
 #define DRAWINGGUI_VIEWPROVIDERVIEWPART_H
 
+#include <App/PropertyLinks.h>
+#include <App/PropertyStandard.h>
+#include <App/PropertyUnits.h>
+
 #include "ViewProviderDrawingView.h"
 #include <Mod/TechDraw/App/DrawView.h>
 #include <Mod/TechDraw/App/DrawViewPart.h>
@@ -39,6 +43,16 @@ public:
     ViewProviderViewPart();
     /// destructor
     virtual ~ViewProviderViewPart();
+
+    App::PropertyFloat  LineWidth;
+    App::PropertyFloat  HiddenWidth;
+    App::PropertyFloat  IsoWidth;
+    App::PropertyFloat  ExtraWidth;
+    App::PropertyBool   ArcCenterMarks;
+    App::PropertyFloat  CenterScale;
+    App::PropertyBool   HorizCenterLine;
+    App::PropertyBool   VertCenterLine;
+    App::PropertyBool   ShowSectionLine;
 
     virtual void attach(App::DocumentObject *);
     virtual void setDisplayMode(const char* ModeName);

--- a/src/Mod/TechDraw/Gui/ViewProviderViewSection.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderViewSection.cpp
@@ -48,8 +48,8 @@ PROPERTY_SOURCE(TechDrawGui::ViewProviderViewSection, TechDrawGui::ViewProviderV
 
 ViewProviderViewSection::ViewProviderViewSection()
 {
-    static const char *sgroup = "Surface";
-    static const char *hgroup = "Hatch";
+    static const char *sgroup = "Cut Surface";
+    static const char *hgroup = "Surface Hatch";
     sPixmap = "TechDraw_Tree_Section";
     ADD_PROPERTY_TYPE(ShowCutSurface ,(true),sgroup,App::Prop_None,"Show/hide the cut surface");
     ADD_PROPERTY_TYPE(CutSurfaceColor,(0.0,0.0,0.0),sgroup,App::Prop_None,"The color to shade the cut surface");


### PR DESCRIPTION
This PR moves Properties that do not affect the generation of Drawing geometry from TechDraw/App to TechDraw/Gui.  Changes to these properties can just be redrawn, they do not require a recompute of the Features.  Please merge.

Thanks,
wf


Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
