### PR TITLE
Misc source comment typos

### DIFF
--- a/src/Mod/Cam/App/Approx.cpp
+++ b/src/Mod/Cam/App/Approx.cpp
@@ -1447,7 +1447,7 @@ double Approximate::Reparam()
 
 /*! \brief Extend the Nurb
 
-    Once error is computed and the generated nurb is stil not satisfactory (i.e max_err > tolerance), this function will extend
+ Once error is computed and the generated nurb is still not satisfactory (i.e max_err > tolerance), this function will extend
  the given Nurb by extending the Knot vectors by 2 and, because the degree is held constant, the control points
 */
 void Approximate::ExtendNurb(double c2, int h)
@@ -1466,9 +1466,9 @@ void Approximate::ExtendNurb(double c2, int h)
 
 /*! \brief Reorder the neighbour list
 
-  This function will reorder the list in one-direction. Clockwise or counter clockwise is depending on the
-  facet list and will not be checked by this function. (i.e the third vertex i.e vertex in first facet that
-  is not the CurIndex or the first neighbour in pnt[Ok, I am also lost with this..., just debug and step to see what I mean...])
+ This function will reorder the list in one-direction. Clockwise or counter clockwise is dependent on the
+ facet list and will not be checked by this function. (i.e the third vertex i.e vertex in first facet that
+ is not the CurIndex or the first neighbour in pnt[Ok, I am also lost with this... just debug and step to see what I mean...])
 */
 void Approximate::ReorderNeighbourList(std::set<unsigned long> &pnt,
                                        std::set<unsigned long> &face, std::vector<unsigned long> &nei, unsigned long CurInd)

--- a/src/Mod/Draft/DraftTools.py
+++ b/src/Mod/Draft/DraftTools.py
@@ -4316,7 +4316,7 @@ class Edit(Modifier):
                     changep = point +2
                 elif point == len(pts)-1 and self.obj.Closed: #last pole
                     # if the curve is closed the last pole has the last
-                    # index in the poits lists
+                    # index in the points lists
                     knot = 0
                     keepp = point
                     changep = 1

--- a/src/Mod/Fem/Gui/ViewProviderFemPostFunction.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemPostFunction.cpp
@@ -157,7 +157,7 @@ ViewProviderFemPostFunction::~ViewProviderFemPostFunction()
     m_geometrySeperator->unref();
     m_manip->unref();
     m_scale->unref();
-    //transfom us unrefed when it is replaced by the dragger
+    //transform is unref'd when it is replaced by the dragger
 }
 
 void ViewProviderFemPostFunction::attach(App::DocumentObject *pcObj)

--- a/src/Mod/PartDesign/Gui/CommandBody.cpp
+++ b/src/Mod/PartDesign/Gui/CommandBody.cpp
@@ -708,7 +708,7 @@ void CmdPartDesignMoveFeature::activated(int iMsg)
         return;
     }
 
-    // Collect dependenies of the selected features
+    // Collect dependencies of the selected features
     std::vector<App::DocumentObject*> dependencies = PartDesignGui::collectMovableDependencies(features);
     if (!dependencies.empty())
         features.insert(std::end(features), std::begin(dependencies), std::end(dependencies));


### PR DESCRIPTION
Found via `codespell -q 3 --skip="*.po,*.ts,./.git,./src/3rdParty,./src/CXX,./src/zipios++,./src/Mod/Assembly/App/opendcm" -I ~/Projects/fc-word-whitelist.txt`  
Whitelist consists of:
```
aline
alledges
als
ang
behaviour
bloaded
calculater
cancelled
cancelling
cas
centimetre
childs
colour
colours
doubleclick
dum
eiter
elemente
freez
iff
indicies
initialisation
initialise
initialised
initialises
kilometre
lod
mantatory
methode
metres
millimetre
modell
nd
normaly
nto
oder
ot
pres
que
recurrance
rougly
seperator
serie
strack
substraction
te
thru
vertexes
whitespaces
```