### PR TITLE
AppVeyor builds fix

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,13 +29,13 @@ clone_depth: 1600
 #todo cleanup libpacks on the FreeCAD-ports-cache repo
 install:
   - cd C:\projects\freecad
+  - if [%ARCH%] == [Win64] (appveyor DownloadFile https://github.com/FreeCAD/FreeCAD-ports-cache/releases/download/v0.17/FreeCADLibs_11.5.1_x64_VC12.7z)
   - if [%ARCH%] == [Win64] (
-      powershell -Command "Start-FileDownload https://github.com/FreeCAD/FreeCAD-ports-cache/releases/download/v0.17/FreeCADLibs_11.5.1_x64_VC12.7z" &&
-      7z x FreeCADLibs_11.5.1_x64_VC12.7z > nul &&
+      powershell -Command 7z x FreeCADLibs_11.5.1_x64_VC12.7z > nul &&
       ren FreeCADLibs_11.5_x64_VC12 FreeCADLibs)
+  - if [%ARCH%] == [Win32] (appveyor DownloadFile https://github.com/FreeCAD/FreeCAD-ports-cache/releases/download/v0.17/FreeCADLibs_11.5.1_x86_VC12.7z)
   - if [%ARCH%] == [Win32] (
-      powershell -Command "Start-FileDownload https://github.com/FreeCAD/FreeCAD-ports-cache/releases/download/v0.17/FreeCADLibs_11.5.1_x86_VC12.7z" &&
-      7z x FreeCADLibs_11.5.1_x86_VC12.7z > nul &&
+      powershell -Command 7z x FreeCADLibs_11.5.1_x86_VC12.7z > nul &&
       ren FreeCADLibs_11.5_x86_VC12 FreeCADLibs)
   - dir
 


### PR DESCRIPTION
This fixes the failing AppVeyor builds. Reason was probably this update from GitHub https://github.com/blog/2507-weak-cryptographic-standards-removed