### PR TITLE
TechDraw: new center/section draw style

### DIFF
--- a/src/Mod/TechDraw/App/CMakeLists.txt
+++ b/src/Mod/TechDraw/App/CMakeLists.txt
@@ -158,6 +158,12 @@ SET(TechDraw_Templates
     Templates/A4_LandscapeTD.svg
     Templates/A4_Landscape_ISO7200TD.svg
     Templates/A4_Portrait_ISO7200TD.svg
+    Templates/A0_Landscape_blank.svg
+    Templates/A1_Landscape_blank.svg
+    Templates/A2_Landscape_blank.svg
+    Templates/A3_Landscape_blank.svg
+    Templates/A4_Landscape_blank.svg
+    Templates/A4_Portrait_blank.svg
 )
 
 SET(TechDraw_PATFile

--- a/src/Mod/TechDraw/Gui/QGICenterLine.cpp
+++ b/src/Mod/TechDraw/Gui/QGICenterLine.cpp
@@ -26,6 +26,8 @@
 #include <QStyleOptionGraphicsItem>
 #endif
 
+#include <cmath>
+
 #include <App/Application.h>
 #include <App/Material.h>
 #include <Base/Console.h>
@@ -70,7 +72,7 @@ QColor QGICenterLine::getCenterColor()
 {
     Base::Reference<ParameterGrp> hGrp = App::GetApplication().GetUserParameter()
         .GetGroup("BaseApp")->GetGroup("Preferences")->GetGroup("Mod/TechDraw/Decorations");
-    App::Color fcColor = App::Color((uint32_t) hGrp->GetUnsigned("CenterColor", 0x08080800));
+    App::Color fcColor = App::Color((uint32_t) hGrp->GetUnsigned("CenterColor", 0x00000000));
     return fcColor.asValue<QColor>();
 }
 
@@ -78,7 +80,7 @@ Qt::PenStyle QGICenterLine::getCenterStyle()
 {
     Base::Reference<ParameterGrp> hGrp = App::GetApplication().GetUserParameter().GetGroup("BaseApp")->
                                          GetGroup("Preferences")->GetGroup("Mod/TechDraw/Decorations");
-    Qt::PenStyle centerStyle = static_cast<Qt::PenStyle> (hGrp->GetInt("CenterLine",3));
+    Qt::PenStyle centerStyle = static_cast<Qt::PenStyle> (hGrp->GetInt("CenterLine", 4));
     return centerStyle;
 }
 
@@ -90,10 +92,48 @@ void QGICenterLine::paint ( QPainter * painter, const QStyleOptionGraphicsItem *
     QGIDecoration::paint (painter, &myOption, widget);
 }
 
+void QGICenterLine::setIntersection(bool isIntersecting) {
+    /**
+     * Set the intersection style for the centerline.
+     * If isIntersecting is set to true, the middle of the centerline
+     * will be the middle of a dash - therefore if two lines intersect, they
+     * will form a cross.
+     * If isIntersecting is set to false, the middle of the centerline will be a
+     * dot.
+     */
+    m_isintersection = isIntersecting;
+}
+
 void QGICenterLine::setTools()
 {
+    if (m_styleCurrent == Qt::DashDotLine) {
+        QVector<qreal> dashes;
+        qreal space = 4;  // in unit width
+        qreal dash = 16;
+        // dot must be really small when using CapStyle RoundCap but > 0
+        // for CapStyle FlatCap you would need to set it to 1
+        qreal dot = 0.000001;
+
+        dashes << dot << space << dash << space;
+        qreal dashlen = dot + 2 * space + dash;
+        qreal l_len = sqrt(pow(m_start.x() - m_end.x(), 2) + pow(m_start.y() - m_end.y(), 2)) / 2.0;
+        // convert from pixelunits to width units
+        l_len = l_len / m_width;
+        // note that the additional length using RoundCap or SquareCap does not
+        // count here!
+        if (m_isintersection) {
+            m_pen.setDashOffset(dashlen - fmod(l_len, dashlen) + space + dash / 2);
+        } else {
+            m_pen.setDashOffset(dashlen - fmod(l_len, dashlen));
+        }
+
+        m_pen.setDashPattern(dashes);
+    }
+    else {
+        m_pen.setStyle(m_styleCurrent);
+    }
+    m_pen.setCapStyle(Qt::RoundCap);
     m_pen.setWidthF(m_width);
     m_pen.setColor(m_colCurrent);
-    m_pen.setStyle(m_styleCurrent);
     m_line->setPen(m_pen);
 }

--- a/src/Mod/TechDraw/Gui/QGICenterLine.h
+++ b/src/Mod/TechDraw/Gui/QGICenterLine.h
@@ -48,6 +48,8 @@ public:
     void setBounds(double x1,double y1,double x2,double y2);
     virtual void draw();
 
+    void setIntersection(bool isIntersecting);
+
 protected:
     QColor getCenterColor();
     Qt::PenStyle getCenterStyle();
@@ -58,6 +60,7 @@ private:
     QGraphicsPathItem* m_line;           //primpath?
     QPointF            m_start;
     QPointF            m_end;
+    bool               m_isintersection;
 };
 
 }

--- a/src/Mod/TechDraw/Gui/QGISectionLine.cpp
+++ b/src/Mod/TechDraw/Gui/QGISectionLine.cpp
@@ -119,7 +119,7 @@ void QGISectionLine::makeSymbols()
 {
     QPointF extLineStart,extLineEnd;
     QPointF offset(m_arrowDir.x,-m_arrowDir.y);
-    offset = 2.0 * m_extLen * offset;
+    offset = 1.5 * m_extLen * offset;
     extLineStart = m_start + offset;
     extLineEnd = m_end + offset;
 
@@ -173,7 +173,7 @@ QColor QGISectionLine::getSectionColor()
 {
     Base::Reference<ParameterGrp> hGrp = App::GetApplication().GetUserParameter()
         .GetGroup("BaseApp")->GetGroup("Preferences")->GetGroup("Mod/TechDraw/Colors");
-    App::Color fcColor = App::Color((uint32_t) hGrp->GetUnsigned("SectionColor", 0x08080800));
+    App::Color fcColor = App::Color((uint32_t) hGrp->GetUnsigned("SectionColor", 0x00000000));
     return fcColor.asValue<QColor>();
 }
 
@@ -181,7 +181,7 @@ Qt::PenStyle QGISectionLine::getSectionStyle()
 {
     Base::Reference<ParameterGrp> hGrp = App::GetApplication().GetUserParameter().GetGroup("BaseApp")->
                                          GetGroup("Preferences")->GetGroup("Mod/TechDraw");
-    Qt::PenStyle sectStyle = static_cast<Qt::PenStyle> (hGrp->GetInt("SectionLine",2));
+    Qt::PenStyle sectStyle = static_cast<Qt::PenStyle> (hGrp->GetInt("SectionLine", 4));
     return sectStyle;
 }
 
@@ -195,9 +195,32 @@ void QGISectionLine::paint ( QPainter * painter, const QStyleOptionGraphicsItem 
 
 void QGISectionLine::setTools()
 {
+    // Use our own style
+    if (m_styleCurrent == Qt::DashDotLine) {
+        QVector<qreal> dashes;
+        // the stroke width is double the one of center lines, but we like to
+        // have the same spacing. thus these values must be half as large
+        qreal space = 2;  // in unit r_width
+        qreal dash = 8;
+        // dot must be really small when using CapStyle RoundCap but > 0
+        // for CapStyle FlatCap you would need to set it to 1
+        qreal dot = 0.000001;
+
+        dashes << dot << space << dash << space;
+
+        // TODO for fancyness: calculate the offset so both arrows start with a
+        // dash!
+
+        m_pen.setDashPattern(dashes);
+
+        m_pen.setDashOffset(2);
+    }
+    else {
+        m_pen.setStyle(m_styleCurrent);
+    }
     m_pen.setWidthF(m_width);
     m_pen.setColor(m_colCurrent);
-    m_pen.setStyle(m_styleCurrent);
+    m_pen.setCapStyle(Qt::RoundCap);
     m_brush.setStyle(m_brushCurrent);
     m_brush.setColor(m_colCurrent);
 

--- a/src/Mod/TechDraw/Gui/QGIViewPart.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewPart.cpp
@@ -654,6 +654,7 @@ void QGIViewPart::drawSectionLine(TechDraw::DrawViewSection* viewSection, bool b
         double sectionSpan;
         double sectionFudge = Rez::guiX(10.0);
         double xVal, yVal;
+        double fontSize = getPrefFontSize();
         if (horiz)  {
             sectionSpan = m_border->rect().width() + sectionFudge;
             xVal = sectionSpan / 2.0;
@@ -664,8 +665,8 @@ void QGIViewPart::drawSectionLine(TechDraw::DrawViewSection* viewSection, bool b
             yVal = sectionSpan / 2.0;
         }
         sectionLine->setBounds(-xVal,-yVal,xVal,yVal);
-        sectionLine->setWidth(Rez::guiX(vp->IsoWidth.getValue()));
-        sectionLine->setFont(m_font,Rez::guiX(6.0));
+        sectionLine->setWidth(Rez::guiX(vp->LineWidth.getValue()));
+        sectionLine->setFont(m_font, fontSize);
         sectionLine->setZValue(ZVALUE::SECTIONLINE);
         sectionLine->setRotation(viewPart->Rotation.getValue());
         sectionLine->draw();
@@ -690,7 +691,7 @@ void QGIViewPart::drawCenterLines(bool b)
 
         QGICenterLine* centerLine;
         double sectionSpan;
-        double sectionFudge = 10.0;
+        double sectionFudge = Rez::guiX(10.0);
         double xVal, yVal;
         if (horiz)  {
             centerLine = new QGICenterLine();
@@ -699,8 +700,9 @@ void QGIViewPart::drawCenterLines(bool b)
             sectionSpan = m_border->rect().width() + sectionFudge;
             xVal = sectionSpan / 2.0;
             yVal = 0.0;
+            centerLine->setIntersection(horiz && vert);
             centerLine->setBounds(-xVal,-yVal,xVal,yVal);
-            centerLine->setWidth(Rez::guiX(vp->IsoWidth.getValue()));
+            centerLine->setWidth(Rez::guiX(vp->HiddenWidth.getValue()));
             centerLine->setZValue(ZVALUE::SECTIONLINE);
             centerLine->setRotation(viewPart->Rotation.getValue());
             centerLine->draw();
@@ -712,8 +714,9 @@ void QGIViewPart::drawCenterLines(bool b)
             sectionSpan = (m_border->rect().height() - m_label->boundingRect().height()) + sectionFudge;
             xVal = 0.0;
             yVal = sectionSpan / 2.0;
+            centerLine->setIntersection(horiz && vert);
             centerLine->setBounds(-xVal,-yVal,xVal,yVal);
-            centerLine->setWidth(Rez::guiX(vp->IsoWidth.getValue()));
+            centerLine->setWidth(Rez::guiX(vp->HiddenWidth.getValue()));
             centerLine->setZValue(ZVALUE::SECTIONLINE);
             centerLine->setRotation(viewPart->Rotation.getValue());
             centerLine->draw();
@@ -1000,4 +1003,12 @@ bool QGIViewPart::getFaceEdgesPref(void)
         .GetGroup("BaseApp")->GetGroup("Preferences")->GetGroup("Mod/TechDraw/General");
     result = hGrp->GetBool("DrawFaceEdges", 0l);
     return result;
+}
+
+double QGIViewPart::getPrefFontSize()
+{
+    Base::Reference<ParameterGrp> hGrp = App::GetApplication().GetUserParameter().
+                                         GetGroup("BaseApp")->GetGroup("Preferences")->GetGroup("Mod/TechDraw/Labels");
+    double fontSize = hGrp->GetFloat("LabelSize", 5.0);
+    return Rez::guiX(fontSize);
 }

--- a/src/Mod/TechDraw/Gui/QGIViewPart.h
+++ b/src/Mod/TechDraw/Gui/QGIViewPart.h
@@ -100,6 +100,7 @@ protected:
     void removePrimitives(void);
     void removeDecorations(void);
     bool getFaceEdgesPref(void);
+    double getPrefFontSize(void);
 
 private:
     QList<QGraphicsItem*> deleteItems;

--- a/src/Mod/TechDraw/Gui/ViewProviderViewPart.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderViewPart.cpp
@@ -64,12 +64,16 @@ ViewProviderViewPart::ViewProviderViewPart()
                                                     GetGroup("Preferences")->GetGroup("Mod/TechDraw/Decorations");
     std::string lgName = hGrp->GetASCII("LineGroup","FC 0.70mm");
     auto lg = TechDraw::LineGroup::lineGroupFactory(lgName);
+
     double weight = lg->getWeight("Thick");
-    ADD_PROPERTY_TYPE(LineWidth,(weight),group,App::Prop_None,"The thickness of visible lines");
+    ADD_PROPERTY_TYPE(LineWidth,(weight),group,App::Prop_None,"The thickness of visible lines (line groups xx.2");
+
     weight = lg->getWeight("Thin");
-    ADD_PROPERTY_TYPE(HiddenWidth,(weight),group,App::Prop_None,"The thickness of hidden lines, if enabled");
+    ADD_PROPERTY_TYPE(HiddenWidth,(weight),group,App::Prop_None,"The thickness of hidden lines, if enabled (line groups xx.1)");
+
     weight = lg->getWeight("Graphic");
-    ADD_PROPERTY_TYPE(IsoWidth,(weight),group,App::Prop_None,"The thickness of isoparameter/center/section lines, if enabled");
+    ADD_PROPERTY_TYPE(IsoWidth,(weight),group,App::Prop_None,"The thickness of isoparameter lines, if enabled");
+
     weight = lg->getWeight("Extra");
     ADD_PROPERTY_TYPE(ExtraWidth,(weight),group,App::Prop_None,"The thickness of LineGroup Extra lines, if enabled");
 

--- a/src/Mod/TechDraw/Templates/A0_Landscape_blank.svg
+++ b/src/Mod/TechDraw/Templates/A0_Landscape_blank.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+
+<svg
+	xmlns="http://www.w3.org/2000/svg" version="1.1"
+	xmlns:freecad="http://www.freecadweb.org/wiki/index.php?title=Svg_Namespace"
+	width="1189mm"
+	height="841mm"
+	viewBox="0 0 1189 841">
+</svg>

--- a/src/Mod/TechDraw/Templates/A1_Landscape_blank.svg
+++ b/src/Mod/TechDraw/Templates/A1_Landscape_blank.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+
+<svg
+	xmlns="http://www.w3.org/2000/svg" version="1.1"
+	xmlns:freecad="http://www.freecadweb.org/wiki/index.php?title=Svg_Namespace"
+	width="841mm"
+	height="594mm"
+	viewBox="0 0 841 594">
+</svg>

--- a/src/Mod/TechDraw/Templates/A2_Landscape_blank.svg
+++ b/src/Mod/TechDraw/Templates/A2_Landscape_blank.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+
+<svg
+	xmlns="http://www.w3.org/2000/svg" version="1.1"
+	xmlns:freecad="http://www.freecadweb.org/wiki/index.php?title=Svg_Namespace"
+	width="594mm"
+	height="420mm"
+	viewBox="0 0 594 420">
+</svg>

--- a/src/Mod/TechDraw/Templates/A3_Landscape_blank.svg
+++ b/src/Mod/TechDraw/Templates/A3_Landscape_blank.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+
+<svg
+	xmlns="http://www.w3.org/2000/svg" version="1.1"
+	xmlns:freecad="http://www.freecadweb.org/wiki/index.php?title=Svg_Namespace"
+	width="420mm"
+	height="297mm"
+	viewBox="0 0 420 297">
+</svg>

--- a/src/Mod/TechDraw/Templates/A4_Landscape_blank.svg
+++ b/src/Mod/TechDraw/Templates/A4_Landscape_blank.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+
+<svg
+	xmlns="http://www.w3.org/2000/svg" version="1.1"
+	xmlns:freecad="http://www.freecadweb.org/wiki/index.php?title=Svg_Namespace"
+	width="297mm"
+	height="210mm"
+	viewBox="0 0 297 210">
+</svg>

--- a/src/Mod/TechDraw/Templates/A4_Portrait_blank.svg
+++ b/src/Mod/TechDraw/Templates/A4_Portrait_blank.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+
+<svg
+	xmlns="http://www.w3.org/2000/svg" version="1.1"
+	xmlns:freecad="http://www.freecadweb.org/wiki/index.php?title=Svg_Namespace"
+	width="210mm"
+	height="297mm"
+	viewBox="0 0 210 297">
+</svg>


### PR DESCRIPTION
using custom QT pen styles, the center and section lines look much
better.
With some math we are also able to control the middle position, thus
the centerlines will always look good, regardless of the size of an
object.

Also getting the section label size from the settings, so the font
size is controllable and not hardcoded.

Bonus: adding blank templates for the common paper sizes (as the
        Drawing WB has them)

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
there are some FEM tests failing for me, but they fail for me also in master...
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists
see discussion https://forum.freecadweb.org/viewtopic.php?f=35&t=27019

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
