### PR TITLE
Better handle non-ascii characters

### DIFF
--- a/src/Tools/fcinfo
+++ b/src/Tools/fcinfo
@@ -86,7 +86,7 @@ class FreeCADFileHandler(xml.sax.ContentHandler):
             items = self.contents.items()
             items.sort()
             for key,val in items:
-                print ("   " + key + " : " + val)
+                print ("   " + key.encode("utf-8").strip() + " : " + val.encode("utf-8").strip())
             self.contents = {}
             print ("   Objects: ("+self.count+")")
             


### PR DESCRIPTION
This prevents the following error when using fcinfo as diff driver for WebTools Git:
(...)
  File "/usr/local/bin/fcinfo", line 89, in startElement
    print ("   " + key + " : " + val)
UnicodeEncodeError: 'ascii' codec can't encode character u'\xe1' in position 17: ordinal not in range(128)
fatal: unable to read files to diff

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
