### PR TITLE
TechDraw: small corrections for line sizes

### DIFF
--- a/src/Mod/TechDraw/Gui/QGIViewPart.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewPart.cpp
@@ -742,6 +742,7 @@ void QGIViewPart::drawHighlight(TechDraw::DrawViewDetail* viewDetail, bool b)
     }
 
     if (b) {
+        double fontSize = getPrefFontSize();
         QGIHighlight* highlight = new QGIHighlight();
         addToGroup(highlight);
         highlight->setPos(0.0,0.0);   //sb setPos(center.x,center.y)?
@@ -750,7 +751,7 @@ void QGIViewPart::drawHighlight(TechDraw::DrawViewDetail* viewDetail, bool b)
         double radius = viewDetail->Radius.getValue() * viewPart->getScale();
         highlight->setBounds(center.x - radius, center.y + radius,center.x + radius, center.y - radius);
         highlight->setWidth(Rez::guiX(vp->IsoWidth.getValue()));
-        highlight->setFont(m_font,Rez::guiX(6.0));
+        highlight->setFont(m_font, fontSize);
         highlight->setZValue(ZVALUE::HIGHLIGHT);
         highlight->draw();
     }
@@ -1003,12 +1004,4 @@ bool QGIViewPart::getFaceEdgesPref(void)
         .GetGroup("BaseApp")->GetGroup("Preferences")->GetGroup("Mod/TechDraw/General");
     result = hGrp->GetBool("DrawFaceEdges", 0l);
     return result;
-}
-
-double QGIViewPart::getPrefFontSize()
-{
-    Base::Reference<ParameterGrp> hGrp = App::GetApplication().GetUserParameter().
-                                         GetGroup("BaseApp")->GetGroup("Preferences")->GetGroup("Mod/TechDraw/Labels");
-    double fontSize = hGrp->GetFloat("LabelSize", 5.0);
-    return Rez::guiX(fontSize);
 }

--- a/src/Mod/TechDraw/Gui/QGIViewPart.h
+++ b/src/Mod/TechDraw/Gui/QGIViewPart.h
@@ -100,7 +100,6 @@ protected:
     void removePrimitives(void);
     void removeDecorations(void);
     bool getFaceEdgesPref(void);
-    double getPrefFontSize(void);
 
 private:
     QList<QGraphicsItem*> deleteItems;

--- a/src/Mod/TechDraw/Gui/ViewProviderDimension.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderDimension.cpp
@@ -67,7 +67,7 @@ ViewProviderDimension::ViewProviderDimension()
     hGrp = App::GetApplication().GetUserParameter().GetGroup("BaseApp")->GetGroup("Preferences")->GetGroup("Mod/TechDraw/Decorations");
     std::string lgName = hGrp->GetASCII("LineGroup","FC 0.70mm");
     auto lg = TechDraw::LineGroup::lineGroupFactory(lgName);
-    double weight = lg->getWeight("Graphic");
+    double weight = lg->getWeight("Thin");
     ADD_PROPERTY_TYPE(LineWidth,(weight)    ,group,(App::PropertyType)(App::Prop_None),"Dimension line weight");
 
     hGrp = App::GetApplication().GetUserParameter()

--- a/src/Mod/TechDraw/LineGroup/LineGroup.csv
+++ b/src/Mod/TechDraw/LineGroup/LineGroup.csv
@@ -1,15 +1,41 @@
 ;FreeCAD LineGroup Definitions
-;Format: *GroupName,thin,graphic,thick,extra
-;thin: hidden lines
-;graphic: dimensions, centerlines
-;thick: visible lines
+;follows the specifications from DIN EN ISO 128-20
+;which defines 5 different base types of lines
+;in two different thicknesses:
+; * 01: full line, freehand line / zickzack line
+: * 02: dash line
+; * 04: dash-dot line
+; * 05: dash-dot-dot line
+; type .1: thin
+; type .2: thick
+;for example: 04.1 is a thin dash-dot line
+;
+;The size of the lines can be computed by this rule:
+;l = linegroup
+;thick = 1 * l
+;thin = 1/2 * l
+;graphic = 5/7 * l
+;extra = 2 * l
+;
+;Linegroup 0.50 and 0.70 shall be used preferable,
+;where 0.50 shall be used for A4 to A2 and
+;0.70 shall be used for A1 and A0
+;
+;FreeCAD applies these thicknesses:
+;thin: hidden lines, dimensions, centerlines
+;graphic: graphical symbols, text
+;thick: visible lines, section lines
 ;extra: not implemented
+;
+;Format of this file: *GroupName,thin,graphic,thick,extra
 
 *FC 0.25mm,0.13,0.18,0.25,0.50
 *FC 0.35mm,0.18,0.25,0.35,0.70
 *FC 0.50mm,0.25,0.35,0.50,1.0
 *FC 0.70mm,0.35,0.50,0.70,1.4
 *FC 1.00mm,0.50,0.70,1.00,2.00
+*FC 1.40mm,0.70,1.00,1.40,2.80
+*FC 2.00mm,1.00,1.40,2.00,4.00
 
 
 


### PR DESCRIPTION
changeing the line weight for dimensions to a thin line
and get the font size for detail view labels from the configuration
rather than using a hardcoded value.
Also removing a duplicate method, as it is already implemend in the
parent class.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
