### PR TITLE
Use Font Selector Widget for Preferences

### DIFF
--- a/src/Gui/PrefWidgets.cpp
+++ b/src/Gui/PrefWidgets.cpp
@@ -640,4 +640,45 @@ void PrefQuantitySpinBox::setHistorySize(int i)
     d->historySize = i;
 }
 
+// --------------------------------------------------------------------
+
+PrefFontBox::PrefFontBox ( QWidget * parent )
+  : QFontComboBox(parent), PrefWidget()
+{
+}
+
+PrefFontBox::~PrefFontBox()
+{
+}
+
+void PrefFontBox::restorePreferences()
+{
+  if ( getWindowParameter().isNull() )
+  {
+    Console().Warning("Cannot restore!\n");
+    return;
+  }
+
+  QFont currFont = currentFont();                         //QFont from selector widget
+  QString currName = currFont.family();
+  
+  std::string prefName = getWindowParameter()->GetASCII(entryName(), currName.toUtf8());  //font name from cfg file
+
+  currFont.setFamily(QString::fromStdString(prefName));
+  setCurrentFont(currFont);                               //set selector widget to name from cfg file
+}
+
+void PrefFontBox::savePreferences()
+{
+  if (getWindowParameter().isNull())
+  {
+    Console().Warning("Cannot save!\n");
+    return;
+  }
+
+  QFont currFont = currentFont();
+  QString currName = currFont.family();
+  getWindowParameter()->SetASCII( entryName() , currName.toUtf8() );
+}
+
 #include "moc_PrefWidgets.cpp"

--- a/src/Gui/PrefWidgets.h
+++ b/src/Gui/PrefWidgets.h
@@ -27,6 +27,8 @@
 #include <QCheckBox>
 #include <QComboBox>
 #include <QRadioButton>
+#include <QFontComboBox>
+#include <QFont>
 #include <Base/Parameter.h>
 #include "Widgets.h"
 #include "Window.h"
@@ -320,6 +322,26 @@ private:
     QScopedPointer<PrefQuantitySpinBoxPrivate> d_ptr;
     Q_DISABLE_COPY(PrefQuantitySpinBox)
     Q_DECLARE_PRIVATE(PrefQuantitySpinBox)
+};
+
+/** The PrefFontBox class.
+ * \author wandererfan
+ */
+class GuiExport PrefFontBox : public QFontComboBox, public PrefWidget
+{
+  Q_OBJECT
+
+  Q_PROPERTY( QByteArray prefEntry READ entryName     WRITE setEntryName     )
+  Q_PROPERTY( QByteArray prefPath  READ paramGrpPath  WRITE setParamGrpPath  )
+
+public:
+  PrefFontBox ( QWidget * parent = 0 );
+  virtual ~PrefFontBox();
+
+protected:
+  // restore from/save to parameters
+  void restorePreferences();
+  void savePreferences();
 };
 
 } // namespace Gui

--- a/src/Mod/TechDraw/Gui/DlgPrefsTechDraw.ui
+++ b/src/Mod/TechDraw/Gui/DlgPrefsTechDraw.ui
@@ -159,29 +159,6 @@
           </property>
          </widget>
         </item>
-        <item row="5" column="0">
-         <widget class="QLabel" name="lbl_TemplateDot">
-          <property name="text">
-           <string>Template Dot Size</string>
-          </property>
-         </widget>
-        </item>
-        <item row="5" column="1">
-         <widget class="Gui::PrefDoubleSpinBox" name="dsb_TemplateDot">
-          <property name="toolTip">
-           <string>EditableText Dot Size in mm</string>
-          </property>
-          <property name="value">
-           <double>3.000000000000000</double>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>TemplateDotSize</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>/Mod/TechDraw/General</cstring>
-          </property>
-         </widget>
-        </item>
        </layout>
       </item>
       <item>
@@ -603,7 +580,23 @@
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_4">
       <item>
-       <layout class="QGridLayout" name="gridLayout_2" columnstretch="1,0,0">
+       <layout class="QGridLayout" name="gridLayout_2" rowstretch="0,0,0" columnstretch="0,0,0">
+        <item row="0" column="1">
+         <spacer name="horizontalSpacer_2">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeType">
+           <enum>QSizePolicy::Preferred</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
         <item row="1" column="2">
          <widget class="Gui::PrefDoubleSpinBox" name="dsb_LabelSize">
           <property name="toolTip">
@@ -623,39 +616,10 @@
           </property>
          </widget>
         </item>
-        <item row="0" column="1">
-         <spacer name="horizontalSpacer_2">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeType">
-           <enum>QSizePolicy::Fixed</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
         <item row="0" column="0">
          <widget class="QLabel" name="lbl_LabelFont">
           <property name="text">
            <string>Label Font</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="2">
-         <widget class="Gui::PrefLineEdit" name="le_LabelFont">
-          <property name="text">
-           <string>osifont</string>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>LabelFont</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/TechDraw/Labels</cstring>
           </property>
          </widget>
         </item>
@@ -665,6 +629,73 @@
            <string>Label Size</string>
           </property>
          </widget>
+        </item>
+        <item row="0" column="2">
+         <widget class="Gui::PrefFontBox" name="pfb_LabelFont">
+          <property name="toolTip">
+           <string>Font for View Labels</string>
+          </property>
+          <property name="currentFont">
+           <font>
+            <family>osifont</family>
+           </font>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>LabelFont</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>/Mod/TechDraw/Labels</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="0">
+         <widget class="QLabel" name="lbl_TemplateDot">
+          <property name="text">
+           <string>Template Dot Size</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="2">
+         <widget class="Gui::PrefDoubleSpinBox" name="dsb_TemplateDot">
+          <property name="toolTip">
+           <string>EditableText Dot Size in mm</string>
+          </property>
+          <property name="value">
+           <double>3.000000000000000</double>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>TemplateDotSize</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>/Mod/TechDraw/General</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="1">
+         <spacer name="horizontalSpacer_6">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item row="2" column="1">
+         <spacer name="horizontalSpacer_7">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
         </item>
        </layout>
       </item>
@@ -738,6 +769,11 @@
   <customwidget>
    <class>Gui::PrefDoubleSpinBox</class>
    <extends>QDoubleSpinBox</extends>
+   <header>Gui/PrefWidgets.h</header>
+  </customwidget>
+  <customwidget>
+   <class>Gui::PrefFontBox</class>
+   <extends>QFontComboBox</extends>
    <header>Gui/PrefWidgets.h</header>
   </customwidget>
  </customwidgets>

--- a/src/Mod/TechDraw/Gui/DlgPrefsTechDrawImp.cpp
+++ b/src/Mod/TechDraw/Gui/DlgPrefsTechDrawImp.cpp
@@ -58,7 +58,7 @@ void DlgPrefsTechDrawImp::saveSettings()
     pcb_Background->onSave();
     pcb_Hatch->onSave();
 
-    le_LabelFont->onSave();
+    pfb_LabelFont->onSave();
     dsb_LabelSize->onSave();
 
     pfc_DefTemp->onSave();
@@ -85,7 +85,7 @@ void DlgPrefsTechDrawImp::loadSettings()
     pcb_Background->onRestore();
     pcb_Hatch->onRestore();
 
-    le_LabelFont->onRestore();
+    pfb_LabelFont->onRestore();
     dsb_LabelSize->onRestore();
 
     pfc_DefTemp->onRestore();

--- a/src/Tools/plugins/widget/customwidgets.cpp
+++ b/src/Tools/plugins/widget/customwidgets.cpp
@@ -1224,3 +1224,35 @@ void PrefSlider::setParamGrpPath ( const QByteArray& name )
 {
     m_sPrefGrp = name;
 }
+
+// --------------------------------------------------------------------
+
+PrefFontBox::PrefFontBox ( QWidget * parent )
+  : QFontComboBox(parent)
+{
+}
+
+PrefFontBox::~PrefFontBox()
+{
+}
+
+QByteArray PrefFontBox::entryName () const
+{
+    return m_sPrefName;
+}
+
+QByteArray PrefFontBox::paramGrpPath () const
+{
+    return m_sPrefGrp;
+}
+
+void PrefFontBox::setEntryName ( const QByteArray& name )
+{
+    m_sPrefName = name;
+}
+
+void PrefFontBox::setParamGrpPath ( const QByteArray& name )
+{
+    m_sPrefGrp = name;
+}
+

--- a/src/Tools/plugins/widget/customwidgets.h
+++ b/src/Tools/plugins/widget/customwidgets.h
@@ -38,6 +38,7 @@
 #include <QGroupBox>
 #include <QGridLayout>
 #include <QTreeWidget>
+#include <QFontComboBox>
 
 namespace Base {
     class Quantity{};
@@ -581,6 +582,28 @@ private:
     QByteArray m_sPrefGrp;
 };
 
+// ------------------------------------------------------------------------------
+
+class PrefFontBox : public QFontComboBox
+{
+    Q_OBJECT
+
+    Q_PROPERTY( QByteArray prefEntry READ entryName     WRITE setEntryName     )
+    Q_PROPERTY( QByteArray prefPath  READ paramGrpPath  WRITE setParamGrpPath  )
+
+public:
+    PrefFontBox ( QWidget * parent = 0 );
+    virtual ~PrefFontBox();
+
+    QByteArray entryName    () const;
+    QByteArray paramGrpPath () const;
+    void  setEntryName     ( const QByteArray& name );
+    void  setParamGrpPath  ( const QByteArray& name );
+
+private:
+    QByteArray m_sPrefName;
+    QByteArray m_sPrefGrp;
+};
 } // namespace Gui
 
 #endif // GUI_CUSTOMWIDGETS_H

--- a/src/Tools/plugins/widget/plugin.cpp
+++ b/src/Tools/plugins/widget/plugin.cpp
@@ -1372,6 +1372,87 @@ public:
     }
 };
 
+
+/* XPM */
+static const char *fontbox_pixmap[]={
+"22 22 6 1",
+"a c #000000",
+"# c #000080",
+"b c #008080",
+"c c #808080",
+"d c #c0c0c0",
+". c #ffffff",
+"...#aaaaaaaaaaaaaa#...",
+".baccccccccccccccccab.",
+".acccddddddddddddddca.",
+"#ccd.................a",
+"acc..................a",
+"acd..................a",
+"acd..................a",
+"acd. ................a",
+"acd..................a",
+"acd..................a",
+"acd..................a",
+"acd..................a",
+"acd..................a",
+"acd..................a",
+"acd..................a",
+"acd..................a",
+"acd..................a",
+"acd..................a",
+"#cd..................#",
+".ac................da.",
+".badd............dda#.",
+"...#aaaaaaaaaaaaaa#..."};
+
+class PrefFontBoxPlugin : public QDesignerCustomWidgetInterface
+{
+    Q_INTERFACES(QDesignerCustomWidgetInterface)
+public:
+    PrefFontBoxPlugin()
+    {
+    }
+    QWidget *createWidget(QWidget *parent)
+    {
+        return new Gui::PrefFontBox(parent);
+    }
+    QString group() const
+    {
+        return QLatin1String("Preference Widgets");
+    }
+    QIcon icon() const
+    {
+        return QIcon( QPixmap( fontbox_pixmap ) );
+    }
+    QString includeFile() const
+    {
+        return QLatin1String("Gui/PrefWidgets.h");
+    }
+    QString toolTip() const
+    {
+        return QLatin1String("Font Box");
+    }
+    QString whatsThis() const
+    {
+        return QLatin1String("Font box widget (spin button).");
+    }
+    bool isContainer() const
+    {
+        return false;
+    }
+    QString domXml() const
+    {
+        return "<ui language=\"c++\">\n"
+               " <widget class=\"Gui::PrefFontBox\" name=\"fontBox\">\n"
+               " </widget>\n"
+               "</ui>";
+    }
+    QString name() const
+    {
+        return QLatin1String("Gui::PrefFontBox");
+    }
+};
+
 /* XPM */
 /*
 static char *listbox_pixmap[]={
@@ -1432,6 +1513,7 @@ QList<QDesignerCustomWidgetInterface *> CustomWidgetPlugin::customWidgets () con
     cw.append(new PrefComboBoxPlugin);
     cw.append(new PrefLineEditPlugin);
     cw.append(new PrefDoubleSpinBoxPlugin);
+    cw.append(new PrefFontBoxPlugin);
     return cw;
 }
 


### PR DESCRIPTION
Please merge this PR.  It has 2 parts: 
1) it adds an additional custom widget to the FreeCAD Designer plugin library using QFontComboBox as a base,
2) it modifies page 1 of TechDraw preferences to use the new widget instead of the PrefLineEdit used before. 
Thanks,
wf

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
