### PR TITLE
Fix error caused by insufficient rights to create symlink under Windo…

### DIFF
--- a/src/Mod/AddonManager/AddonManager.py
+++ b/src/Mod/AddonManager/AddonManager.py
@@ -82,6 +82,10 @@ def symlink(source, link_name):
             csl.argtypes = (ctypes.c_wchar_p, ctypes.c_wchar_p, ctypes.c_uint32)
             csl.restype = ctypes.c_ubyte
             flags = 1 if os.path.isdir(source) else 0
+            # set the SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE flag
+            # (see https://blogs.windows.com/buildingapps/2016/12/02/symlinks-windows-10/#joC5tFKhdXs2gGml.97)
+            flags += 2
+
             if csl(link_name, source, flags) == 0:
                 raise ctypes.WinError()
 


### PR DESCRIPTION
…ws 10

On Windows 10, symlink creation is not allowed unless the process runs with elevated rights. 

As per https://blogs.windows.com/buildingapps/2016/12/02/symlinks-windows-10/#joC5tFKhdXs2gGml.97, starting with Windows 10 Insiders build 14972, symlinks can be created without needing to elevate the console as administrator.

To use this functionality, 0x2 needs to be set in the flags argument for the CreateSymbolicLinkW() call. See also https://github.com/FreeCAD/FreeCAD-addons/commit/e8838474846383caff216385c5a1ddf2c6a8774d .