### PR TITLE
Fix painting of detail highlight

### DIFF
--- a/src/Mod/TechDraw/App/DrawViewDetail.cpp
+++ b/src/Mod/TechDraw/App/DrawViewDetail.cpp
@@ -103,7 +103,7 @@ DrawViewDetail::DrawViewDetail()
     ADD_PROPERTY_TYPE(Reference ,("1"),dgroup,App::Prop_None,"An identifier for this detail");
 
     getParameters();
-    m_fudge = 1.1;
+    m_fudge = 1.01;
 }
 
 DrawViewDetail::~DrawViewDetail()
@@ -274,6 +274,7 @@ App::DocumentObjectExecReturn *DrawViewDetail::execute(void)
     }
 
     requestPaint();
+    dvp->requestPaint();
 
     return App::DocumentObject::StdReturn;
 }

--- a/src/Mod/TechDraw/Gui/QGIMatting.cpp
+++ b/src/Mod/TechDraw/Gui/QGIMatting.cpp
@@ -79,7 +79,7 @@ QGIMatting::QGIMatting() :
 void QGIMatting::draw()
 {
     prepareGeometryChange();
-    double radiusFudge = 1.15;                    //keep slightly larger than fudge in App/DVDetail to prevent bleed through
+    double radiusFudge = 1.1;                    //keep slightly larger than fudge in App/DVDetail to prevent bleed through
     double outerRadius = m_radius * radiusFudge;
     m_width = outerRadius;
     m_height = outerRadius;


### PR DESCRIPTION
This PR addresses a small error in TechDraw DrawViewDetail/DrawViewPart updating. Please merge.
Thanks,
wf

- painting of the detail highlight in the base
  view was being delayed until the base view
  was updated. It is now drawn when detail
  changes.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
