### PR TITLE
Add Unit (Length) Aware Preferences Widget

### DIFF
--- a/src/Gui/PrefWidgets.cpp
+++ b/src/Gui/PrefWidgets.cpp
@@ -681,4 +681,41 @@ void PrefFontBox::savePreferences()
   getWindowParameter()->SetASCII( entryName() , currName.toUtf8() );
 }
 
+// --------------------------------------------------------------------
+
+PrefLengthSpinBox::PrefLengthSpinBox ( QWidget * parent )
+  : QuantitySpinBox(parent), PrefWidget()
+{
+}
+
+PrefLengthSpinBox::~PrefLengthSpinBox()
+{
+}
+
+void PrefLengthSpinBox::restorePreferences()
+{
+  if ( getWindowParameter().isNull() )
+  {
+    Console().Warning("Cannot restore!\n");
+    return;
+  }
+  setUnit(Base::Unit::Length);
+  double fVal = (double)getWindowParameter()->GetFloat( entryName() ,rawValue() );
+  //Base::Quantity q(fVal,unit());
+  setValue(fVal);
+}
+
+void PrefLengthSpinBox::savePreferences()
+{
+  if (getWindowParameter().isNull())
+  {
+    Console().Warning("Cannot save!\n");
+    return;
+  }
+
+  double q = rawValue();
+  getWindowParameter()->SetFloat( entryName(), q );
+}
+
+
 #include "moc_PrefWidgets.cpp"

--- a/src/Gui/PrefWidgets.h
+++ b/src/Gui/PrefWidgets.h
@@ -348,7 +348,7 @@ protected:
  * \author wandererfan
  * a simple Length aware spin box.  
  */
-class PrefLengthSpinBox : public QuantitySpinBox, public PrefWidget
+class GuiExport PrefLengthSpinBox : public QuantitySpinBox, public PrefWidget
 {
     Q_OBJECT
 

--- a/src/Gui/PrefWidgets.h
+++ b/src/Gui/PrefWidgets.h
@@ -344,6 +344,27 @@ protected:
   void savePreferences();
 };
 
+/** The PrefLengthSpinBox class.
+ * \author wandererfan
+ * a simple Length aware spin box.  
+ */
+class PrefLengthSpinBox : public QuantitySpinBox, public PrefWidget
+{
+    Q_OBJECT
+
+    Q_PROPERTY( QByteArray prefEntry READ entryName     WRITE setEntryName     )
+    Q_PROPERTY( QByteArray prefPath  READ paramGrpPath  WRITE setParamGrpPath  )
+
+public:
+    PrefLengthSpinBox ( QWidget * parent = 0 );
+    virtual ~PrefLengthSpinBox();
+
+protected:
+  // restore from/save to parameters
+  void restorePreferences();
+  void savePreferences();
+};
+
 } // namespace Gui
 
 #endif // GUI_PREFWIDGETS_H

--- a/src/Mod/TechDraw/Gui/DlgPrefsTechDraw.ui
+++ b/src/Mod/TechDraw/Gui/DlgPrefsTechDraw.ui
@@ -597,25 +597,6 @@
           </property>
          </spacer>
         </item>
-        <item row="1" column="2">
-         <widget class="Gui::PrefDoubleSpinBox" name="dsb_LabelSize">
-          <property name="toolTip">
-           <string>Label height in millimeters</string>
-          </property>
-          <property name="minimum">
-           <double>0.100000000000000</double>
-          </property>
-          <property name="value">
-           <double>5.000000000000000</double>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>LabelSize</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>/Mod/TechDraw/Labels</cstring>
-          </property>
-         </widget>
-        </item>
         <item row="0" column="0">
          <widget class="QLabel" name="lbl_LabelFont">
           <property name="text">
@@ -655,22 +636,6 @@
           </property>
          </widget>
         </item>
-        <item row="2" column="2">
-         <widget class="Gui::PrefDoubleSpinBox" name="dsb_TemplateDot">
-          <property name="toolTip">
-           <string>EditableText Dot Size in mm</string>
-          </property>
-          <property name="value">
-           <double>3.000000000000000</double>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>TemplateDotSize</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>/Mod/TechDraw/General</cstring>
-          </property>
-         </widget>
-        </item>
         <item row="1" column="1">
          <spacer name="horizontalSpacer_6">
           <property name="orientation">
@@ -696,6 +661,38 @@
            </size>
           </property>
          </spacer>
+        </item>
+        <item row="1" column="2">
+         <widget class="Gui::PrefLengthSpinBox" name="plsb_LabelSize">
+          <property name="toolTip">
+           <string>View Label size in units</string>
+          </property>
+          <property name="value">
+           <double>3.500000000000000</double>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>LabelSize</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>/Mod/TechDraw/Labels</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="2">
+         <widget class="Gui::PrefLengthSpinBox" name="plsb_TemplateDot">
+          <property name="toolTip">
+           <string>Green edit dot size in units</string>
+          </property>
+          <property name="value">
+           <double>3.000000000000000</double>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>TemplateDotSize</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>/Mod/TechDraw/General</cstring>
+          </property>
+         </widget>
         </item>
        </layout>
       </item>
@@ -737,6 +734,11 @@
    <header>Gui/FileDialog.h</header>
   </customwidget>
   <customwidget>
+   <class>Gui::QuantitySpinBox</class>
+   <extends>QWidget</extends>
+   <header>Gui/QuantitySpinBox.h</header>
+  </customwidget>
+  <customwidget>
    <class>Gui::ColorButton</class>
    <extends>QPushButton</extends>
    <header>Gui/Widgets.h</header>
@@ -767,13 +769,13 @@
    <header>Gui/PrefWidgets.h</header>
   </customwidget>
   <customwidget>
-   <class>Gui::PrefDoubleSpinBox</class>
-   <extends>QDoubleSpinBox</extends>
+   <class>Gui::PrefFontBox</class>
+   <extends>QFontComboBox</extends>
    <header>Gui/PrefWidgets.h</header>
   </customwidget>
   <customwidget>
-   <class>Gui::PrefFontBox</class>
-   <extends>QFontComboBox</extends>
+   <class>Gui::PrefLengthSpinBox</class>
+   <extends>Gui::QuantitySpinBox</extends>
    <header>Gui/PrefWidgets.h</header>
   </customwidget>
  </customwidgets>

--- a/src/Mod/TechDraw/Gui/DlgPrefsTechDraw2.ui
+++ b/src/Mod/TechDraw/Gui/DlgPrefsTechDraw2.ui
@@ -22,29 +22,6 @@
      <layout class="QGridLayout" name="gridLayout_4">
       <item row="0" column="0">
        <layout class="QGridLayout" name="gridLayout" columnstretch="1,0,0">
-        <item row="6" column="0">
-         <widget class="QLabel" name="label_9">
-          <property name="text">
-           <string>Arrow Style</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="2">
-         <widget class="Gui::PrefSpinBox" name="sbAltDecimals">
-          <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-          </property>
-          <property name="value">
-           <number>2</number>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>AltDecimals</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>/Mod/TechDraw/Dimensions</cstring>
-          </property>
-         </widget>
-        </item>
         <item row="0" column="0">
          <widget class="Gui::PrefCheckBox" name="cbShowUnits">
           <property name="text">
@@ -62,6 +39,23 @@
          <widget class="QLabel" name="label_3">
           <property name="text">
            <string>Color</string>
+          </property>
+         </widget>
+        </item>
+        <item row="4" column="2">
+         <widget class="Gui::PrefColorButton" name="colDimColor">
+          <property name="color">
+           <color>
+            <red>0</red>
+            <green>0</green>
+            <blue>0</blue>
+           </color>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>Color</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>/Mod/TechDraw/Dimensions</cstring>
           </property>
          </widget>
         </item>
@@ -85,39 +79,17 @@
           </property>
          </spacer>
         </item>
-        <item row="3" column="2">
-         <widget class="Gui::PrefDoubleSpinBox" name="dsbFontSize">
-          <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-          </property>
-          <property name="decimals">
-           <number>1</number>
-          </property>
-          <property name="value">
-           <double>3.500000000000000</double>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>FontSize</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>/Mod/TechDraw/Dimensions</cstring>
+        <item row="2" column="0">
+         <widget class="QLabel" name="label_11">
+          <property name="text">
+           <string>Alternate Decimals</string>
           </property>
          </widget>
         </item>
-        <item row="4" column="2">
-         <widget class="Gui::PrefColorButton" name="colDimColor">
-          <property name="color">
-           <color>
-            <red>0</red>
-            <green>0</green>
-            <blue>0</blue>
-           </color>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>Color</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>/Mod/TechDraw/Dimensions</cstring>
+        <item row="7" column="0">
+         <widget class="QLabel" name="label_12">
+          <property name="text">
+           <string>Arrow Size</string>
           </property>
          </widget>
         </item>
@@ -146,13 +118,6 @@
           </property>
           <property name="prefPath" stdset="0">
            <cstring>/Mod/TechDraw/Dimensions</cstring>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="0">
-         <widget class="QLabel" name="label_11">
-          <property name="text">
-           <string>Alternate Decimals</string>
           </property>
          </widget>
         </item>
@@ -241,17 +206,49 @@
           </item>
          </widget>
         </item>
-        <item row="7" column="0">
-         <widget class="QLabel" name="label_12">
+        <item row="6" column="0">
+         <widget class="QLabel" name="label_9">
           <property name="text">
-           <string>Arrow Size</string>
+           <string>Arrow Style</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="2">
+         <widget class="Gui::PrefSpinBox" name="sbAltDecimals">
+          <property name="alignment">
+           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          </property>
+          <property name="value">
+           <number>2</number>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>AltDecimals</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>/Mod/TechDraw/Dimensions</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="2">
+         <widget class="Gui::PrefLengthSpinBox" name="plsb_FontSize">
+          <property name="toolTip">
+           <string>Dimension font size in units</string>
+          </property>
+          <property name="value">
+           <double>3.500000000000000</double>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>FontSize</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>/Mod/TechDraw/Dimensions</cstring>
           </property>
          </widget>
         </item>
         <item row="7" column="2">
-         <widget class="Gui::PrefDoubleSpinBox" name="dsbArrowSize">
-          <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         <widget class="Gui::PrefLengthSpinBox" name="plsb_ArrowSize">
+          <property name="toolTip">
+           <string>Dimension arrowhead size in units</string>
           </property>
           <property name="value">
            <double>3.500000000000000</double>
@@ -507,6 +504,11 @@
  </widget>
  <customwidgets>
   <customwidget>
+   <class>Gui::QuantitySpinBox</class>
+   <extends>QWidget</extends>
+   <header>Gui/QuantitySpinBox.h</header>
+  </customwidget>
+  <customwidget>
    <class>Gui::ColorButton</class>
    <extends>QPushButton</extends>
    <header>Gui/Widgets.h</header>
@@ -537,8 +539,8 @@
    <header>Gui/PrefWidgets.h</header>
   </customwidget>
   <customwidget>
-   <class>Gui::PrefDoubleSpinBox</class>
-   <extends>QDoubleSpinBox</extends>
+   <class>Gui::PrefLengthSpinBox</class>
+   <extends>Gui::QuantitySpinBox</extends>
    <header>Gui/PrefWidgets.h</header>
   </customwidget>
  </customwidgets>

--- a/src/Mod/TechDraw/Gui/DlgPrefsTechDraw2Imp.cpp
+++ b/src/Mod/TechDraw/Gui/DlgPrefsTechDraw2Imp.cpp
@@ -44,7 +44,7 @@ DlgPrefsTechDraw2Imp::~DlgPrefsTechDraw2Imp()
 void DlgPrefsTechDraw2Imp::saveSettings()
 {
     cbShowUnits->onSave();
-    dsbFontSize->onSave();
+    plsb_FontSize->onSave();
     colDimColor->onSave();
     leDiameter->onSave();
     pcbMatting->onSave();
@@ -55,14 +55,14 @@ void DlgPrefsTechDraw2Imp::saveSettings()
     pcbArrow->onSave();
     cbGlobalDecimals->onSave();
     sbAltDecimals->onSave();
-    dsbArrowSize->onSave();
+    plsb_ArrowSize->onSave();
     leLineGroup->onSave();
 }
 
 void DlgPrefsTechDraw2Imp::loadSettings()
 {
     cbShowUnits->onRestore();
-    dsbFontSize->onRestore();
+    plsb_FontSize->onRestore();
     colDimColor->onRestore();
     leDiameter->onRestore();
     pcbMatting->onRestore();
@@ -73,7 +73,7 @@ void DlgPrefsTechDraw2Imp::loadSettings()
     pcbArrow->onRestore();
     cbGlobalDecimals->onRestore();
     sbAltDecimals->onRestore();
-    dsbArrowSize->onRestore();
+    plsb_ArrowSize->onRestore();
     leLineGroup->onRestore();
 }
 

--- a/src/Mod/TechDraw/Gui/DlgPrefsTechDrawImp.cpp
+++ b/src/Mod/TechDraw/Gui/DlgPrefsTechDrawImp.cpp
@@ -48,7 +48,6 @@ void DlgPrefsTechDrawImp::saveSettings()
     cb_Faces->onSave();
     cb_SectionEdges->onSave();
     cb_PageUpdate->onSave();
-    dsb_TemplateDot->onSave();
 
     pcb_Normal->onSave();
     pcb_Select->onSave();
@@ -59,7 +58,8 @@ void DlgPrefsTechDrawImp::saveSettings()
     pcb_Hatch->onSave();
 
     pfb_LabelFont->onSave();
-    dsb_LabelSize->onSave();
+    plsb_LabelSize->onSave();
+    plsb_TemplateDot->onSave();
 
     pfc_DefTemp->onSave();
     pfc_DefDir->onSave();
@@ -75,7 +75,6 @@ void DlgPrefsTechDrawImp::loadSettings()
     cb_Faces->onRestore();
     cb_SectionEdges->onRestore();
     cb_PageUpdate->onRestore();
-    dsb_TemplateDot->onRestore();
 
     pcb_Normal->onRestore();
     pcb_Select->onRestore();
@@ -86,7 +85,8 @@ void DlgPrefsTechDrawImp::loadSettings()
     pcb_Hatch->onRestore();
 
     pfb_LabelFont->onRestore();
-    dsb_LabelSize->onRestore();
+    plsb_LabelSize->onRestore();
+    plsb_TemplateDot->onRestore();
 
     pfc_DefTemp->onRestore();
     pfc_DefDir->onRestore();

--- a/src/Tools/plugins/widget/customwidgets.cpp
+++ b/src/Tools/plugins/widget/customwidgets.cpp
@@ -1256,3 +1256,34 @@ void PrefFontBox::setParamGrpPath ( const QByteArray& name )
     m_sPrefGrp = name;
 }
 
+// --------------------------------------------------------------------
+
+PrefLengthSpinBox::PrefLengthSpinBox ( QWidget * parent )
+  : QuantitySpinBox(parent)
+{
+}
+
+PrefLengthSpinBox::~PrefLengthSpinBox()
+{
+}
+
+QByteArray PrefLengthSpinBox::entryName () const
+{
+    return m_sPrefName;
+}
+
+QByteArray PrefLengthSpinBox::paramGrpPath () const
+{
+    return m_sPrefGrp;
+}
+
+void PrefLengthSpinBox::setEntryName ( const QByteArray& name )
+{
+    m_sPrefName = name;
+}
+
+void PrefLengthSpinBox::setParamGrpPath ( const QByteArray& name )
+{
+    m_sPrefGrp = name;
+}
+

--- a/src/Tools/plugins/widget/customwidgets.h
+++ b/src/Tools/plugins/widget/customwidgets.h
@@ -604,6 +604,32 @@ private:
     QByteArray m_sPrefName;
     QByteArray m_sPrefGrp;
 };
+
+
+// ------------------------------------------------------------------------------
+
+
+class PrefLengthSpinBox : public QuantitySpinBox
+{
+    Q_OBJECT
+
+    Q_PROPERTY( QByteArray prefEntry READ entryName     WRITE setEntryName     )
+    Q_PROPERTY( QByteArray prefPath  READ paramGrpPath  WRITE setParamGrpPath  )
+
+public:
+    PrefLengthSpinBox ( QWidget * parent = 0 );
+    virtual ~PrefLengthSpinBox();
+
+    QByteArray entryName    () const;
+    QByteArray paramGrpPath () const;
+    void  setEntryName     ( const QByteArray& name );
+    void  setParamGrpPath  ( const QByteArray& name );
+
+private:
+    QByteArray m_sPrefName;
+    QByteArray m_sPrefGrp;
+};
+
 } // namespace Gui
 
 #endif // GUI_CUSTOMWIDGETS_H

--- a/src/Tools/plugins/widget/plugin.cpp
+++ b/src/Tools/plugins/widget/plugin.cpp
@@ -1454,6 +1454,86 @@ public:
 };
 
 /* XPM */
+static const char *lengthspinbox_pixmap[]={
+"22 22 6 1",
+"a c #000000",
+"# c #000080",
+"b c #008080",
+"c c #808080",
+"d c #c0c0c0",
+". c #ffffff",
+"...#aaaaaaaaaaaaaa#...",
+".baccccccccccccccccab.",
+".acccddddddddddddddca.",
+"#ccd.................a",
+"acc..................a",
+"acd..................a",
+"acd..................a",
+"acd. ................a",
+"acd..................a",
+"acd..................a",
+"acd..................a",
+"acd..................a",
+"acd..................a",
+"acd..................a",
+"acd..................a",
+"acd..................a",
+"acd..................a",
+"acd..................a",
+"#cd..................#",
+".ac................da.",
+".badd............dda#.",
+"...#aaaaaaaaaaaaaa#..."};
+
+class PrefLengthSpinBoxPlugin : public QDesignerCustomWidgetInterface
+{
+    Q_INTERFACES(QDesignerCustomWidgetInterface)
+public:
+    PrefLengthSpinBoxPlugin()
+    {
+    }
+    QWidget *createWidget(QWidget *parent)
+    {
+        return new Gui::PrefLengthSpinBox(parent);
+    }
+    QString group() const
+    {
+        return QLatin1String("Preference Widgets");
+    }
+    QIcon icon() const
+    {
+        return QIcon( QPixmap( lengthspinbox_pixmap ) );
+    }
+    QString includeFile() const
+    {
+        return QLatin1String("Gui/PrefWidgets.h");
+    }
+    QString toolTip() const
+    {
+        return QLatin1String("Length Spinbox");
+    }
+    QString whatsThis() const
+    {
+        return QLatin1String("Length Spinbox widget.");
+    }
+    bool isContainer() const
+    {
+        return false;
+    }
+    QString domXml() const
+    {
+        return "<ui language=\"c++\">\n"
+               " <widget class=\"Gui::PrefLengthSpinBox\" name=\"lengthspinBox\">\n"
+               " </widget>\n"
+               "</ui>";
+    }
+    QString name() const
+    {
+        return QLatin1String("Gui::PrefLengthSpinBox");
+    }
+};
+
+/* XPM */
 /*
 static char *listbox_pixmap[]={
 "22 22 6 1",
@@ -1491,6 +1571,7 @@ CustomWidgetPlugin::CustomWidgetPlugin(QObject *parent)
 {
 }
 
+
 QList<QDesignerCustomWidgetInterface *> CustomWidgetPlugin::customWidgets () const
 {
     QList<QDesignerCustomWidgetInterface *> cw;
@@ -1514,6 +1595,8 @@ QList<QDesignerCustomWidgetInterface *> CustomWidgetPlugin::customWidgets () con
     cw.append(new PrefLineEditPlugin);
     cw.append(new PrefDoubleSpinBoxPlugin);
     cw.append(new PrefFontBoxPlugin);
+    cw.append(new PrefLengthSpinBoxPlugin);
+    
     return cw;
 }
 


### PR DESCRIPTION
This PR adds a Unit Aware (Length only) spinbox to the custom preference widget collection and modifies the TechDraw preference pages to use it.  NOTE: this PR affects Gui and Tools!
Please merge.
Thanks,
wf

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
