### PR TITLE
[For v0.18]Sync TechDraw Toolbars/Menu and WhatsThis/Wiki

### DIFF
--- a/src/Mod/TechDraw/Gui/Command.cpp
+++ b/src/Mod/TechDraw/Gui/Command.cpp
@@ -92,7 +92,7 @@ CmdTechDrawNewPageDef::CmdTechDrawNewPageDef()
     sGroup          = QT_TR_NOOP("TechDraw");
     sMenuText       = QT_TR_NOOP("Insert new default Page");
     sToolTipText    = QT_TR_NOOP("Insert new default Page");
-    sWhatsThis      = "TechDraw_NewPageDef";
+    sWhatsThis      = "TechDraw_New_Default";
     sStatusTip      = sToolTipText;
     sPixmap         = "actions/techdraw-new-default";
 }
@@ -162,7 +162,7 @@ CmdTechDrawNewPage::CmdTechDrawNewPage()
     sGroup          = QT_TR_NOOP("TechDraw");
     sMenuText       = QT_TR_NOOP("Insert new Page using Template");
     sToolTipText    = QT_TR_NOOP("Insert new Page using Template");
-    sWhatsThis      = "TechDraw_NewPage";
+    sWhatsThis      = "TechDraw_New_Pick";
     sStatusTip      = sToolTipText;
     sPixmap         = "actions/techdraw-new-pick";
 }
@@ -302,7 +302,7 @@ CmdTechDrawNewViewSection::CmdTechDrawNewViewSection()
     sGroup          = QT_TR_NOOP("TechDraw");
     sMenuText       = QT_TR_NOOP("Insert Section View in Page");
     sToolTipText    = QT_TR_NOOP("Insert Section View in Page");
-    sWhatsThis      = "TechDraw_NewViewSecton";
+    sWhatsThis      = "TechDraw_NewSection";
     sStatusTip      = sToolTipText;
     sPixmap         = "actions/techdraw-viewsection";
 }
@@ -371,7 +371,7 @@ CmdTechDrawNewViewDetail::CmdTechDrawNewViewDetail()
     sGroup          = QT_TR_NOOP("TechDraw");
     sMenuText       = QT_TR_NOOP("Insert Detail View");
     sToolTipText    = QT_TR_NOOP("Insert Detail View");
-    sWhatsThis      = "TechDraw_NewViewDetail";
+    sWhatsThis      = "TechDraw_NewDetail";
     sStatusTip      = sToolTipText;
     sPixmap         = "actions/techdraw-viewdetail";
 }
@@ -440,7 +440,7 @@ CmdTechDrawProjGroup::CmdTechDrawProjGroup()
     sGroup          = QT_TR_NOOP("TechDraw");
     sMenuText       = QT_TR_NOOP("Insert Projection Group");
     sToolTipText    = QT_TR_NOOP("Insert multiple linked views of drawable object(s)");
-    sWhatsThis      = "TechDraw_ProjGroup";
+    sWhatsThis      = "TechDraw_NewProjGroup";
     sStatusTip      = sToolTipText;
     sPixmap         = "actions/techdraw-projgroup";
 }
@@ -562,7 +562,7 @@ CmdTechDrawAnnotation::CmdTechDrawAnnotation()
     sGroup        = QT_TR_NOOP("TechDraw");
     sMenuText     = QT_TR_NOOP("Insert Annotation");
     sToolTipText  = QT_TR_NOOP("Insert Annotation");
-    sWhatsThis    = "TechDraw_Annotation";
+    sWhatsThis    = "TechDraw_NewAnnotation";
     sStatusTip    = sToolTipText;
     sPixmap       = "actions/techdraw-annotation";
 }
@@ -855,7 +855,7 @@ CmdTechDrawDraftView::CmdTechDrawDraftView()
     sGroup        = QT_TR_NOOP("TechDraw");
     sMenuText     = QT_TR_NOOP("Insert a DraftView");
     sToolTipText  = QT_TR_NOOP("Inserts a Draft WB object");
-    sWhatsThis    = "TechDraw_DraftView";
+    sWhatsThis    = "TechDraw_NewDraft";
     sStatusTip    = sToolTipText;
     sPixmap       = "actions/techdraw-draft-view";
 }
@@ -908,7 +908,7 @@ CmdTechDrawArchView::CmdTechDrawArchView()
     sGroup        = QT_TR_NOOP("TechDraw");
     sMenuText     = QT_TR_NOOP("Insert an ArchView");
     sToolTipText  = QT_TR_NOOP("Inserts a view of an Arch Section Plane");
-    sWhatsThis    = "TechDraw_ArchView";
+    sWhatsThis    = "TechDraw_NewArch";
     sStatusTip    = sToolTipText;
     sPixmap       = "actions/techdraw-arch-view";
 }
@@ -1024,7 +1024,7 @@ CmdTechDrawExportPage::CmdTechDrawExportPage()
     sGroup        = QT_TR_NOOP("File");
     sMenuText     = QT_TR_NOOP("Export page as SVG");
     sToolTipText  = QT_TR_NOOP("Export a page to an SVG file");
-    sWhatsThis    = "TechDraw_ExportPage";
+    sWhatsThis    = "TechDraw_SaveSVG";
     sStatusTip    = sToolTipText;
     sPixmap       = "actions/techdraw-saveSVG";
 }

--- a/src/Mod/TechDraw/Gui/Command.cpp
+++ b/src/Mod/TechDraw/Gui/Command.cpp
@@ -90,8 +90,8 @@ CmdTechDrawNewPageDef::CmdTechDrawNewPageDef()
 {
     sAppModule      = "TechDraw";
     sGroup          = QT_TR_NOOP("TechDraw");
-    sMenuText       = QT_TR_NOOP("Insert new default drawing page");
-    sToolTipText    = QT_TR_NOOP("Insert new default drawing page");
+    sMenuText       = QT_TR_NOOP("Insert new default Page");
+    sToolTipText    = QT_TR_NOOP("Insert new default Page");
     sWhatsThis      = "TechDraw_NewPageDef";
     sStatusTip      = sToolTipText;
     sPixmap         = "actions/techdraw-new-default";
@@ -160,8 +160,8 @@ CmdTechDrawNewPage::CmdTechDrawNewPage()
 {
     sAppModule      = "TechDraw";
     sGroup          = QT_TR_NOOP("TechDraw");
-    sMenuText       = QT_TR_NOOP("Insert new drawing page from template");
-    sToolTipText    = QT_TR_NOOP("Insert new drawing page from template");
+    sMenuText       = QT_TR_NOOP("Insert new Page using Template");
+    sToolTipText    = QT_TR_NOOP("Insert new Page using Template");
     sWhatsThis      = "TechDraw_NewPage";
     sStatusTip      = sToolTipText;
     sPixmap         = "actions/techdraw-new-pick";
@@ -240,8 +240,8 @@ CmdTechDrawNewView::CmdTechDrawNewView()
 {
     sAppModule      = "TechDraw";
     sGroup          = QT_TR_NOOP("TechDraw");
-    sMenuText       = QT_TR_NOOP("Insert view in drawing");
-    sToolTipText    = QT_TR_NOOP("Insert a new View of a Part in the active drawing");
+    sMenuText       = QT_TR_NOOP("Insert View in Page");
+    sToolTipText    = QT_TR_NOOP("Insert View in Page");
     sWhatsThis      = "TechDraw_NewView";
     sStatusTip      = sToolTipText;
     sPixmap         = "actions/techdraw-view";
@@ -300,8 +300,8 @@ CmdTechDrawNewViewSection::CmdTechDrawNewViewSection()
 {
     sAppModule      = "TechDraw";
     sGroup          = QT_TR_NOOP("TechDraw");
-    sMenuText       = QT_TR_NOOP("Insert section view in drawing");
-    sToolTipText    = QT_TR_NOOP("Insert a new Section View of a Part in the active drawing");
+    sMenuText       = QT_TR_NOOP("Insert Section View in Page");
+    sToolTipText    = QT_TR_NOOP("Insert Section View in Page");
     sWhatsThis      = "TechDraw_NewViewSecton";
     sStatusTip      = sToolTipText;
     sPixmap         = "actions/techdraw-viewsection";
@@ -369,8 +369,8 @@ CmdTechDrawNewViewDetail::CmdTechDrawNewViewDetail()
 {
     sAppModule      = "TechDraw";
     sGroup          = QT_TR_NOOP("TechDraw");
-    sMenuText       = QT_TR_NOOP("Insert detail view in drawing");
-    sToolTipText    = QT_TR_NOOP("Insert a new Detail View of a Part in the active drawing");
+    sMenuText       = QT_TR_NOOP("Insert Detail View");
+    sToolTipText    = QT_TR_NOOP("Insert Detail View");
     sWhatsThis      = "TechDraw_NewViewDetail";
     sStatusTip      = sToolTipText;
     sPixmap         = "actions/techdraw-viewdetail";
@@ -439,7 +439,7 @@ CmdTechDrawProjGroup::CmdTechDrawProjGroup()
     sAppModule      = "TechDraw";
     sGroup          = QT_TR_NOOP("TechDraw");
     sMenuText       = QT_TR_NOOP("Insert Projection Group");
-    sToolTipText    = QT_TR_NOOP("Insert multiple views of a single part into the active drawing");
+    sToolTipText    = QT_TR_NOOP("Insert multiple linked views of drawable object(s)");
     sWhatsThis      = "TechDraw_ProjGroup";
     sStatusTip      = sToolTipText;
     sPixmap         = "actions/techdraw-projgroup";
@@ -560,10 +560,10 @@ CmdTechDrawAnnotation::CmdTechDrawAnnotation()
 {
     // setting the Gui eye-candy
     sGroup        = QT_TR_NOOP("TechDraw");
-    sMenuText     = QT_TR_NOOP("&Annotation");
-    sToolTipText  = QT_TR_NOOP("Inserts an Annotation in the active drawing");
+    sMenuText     = QT_TR_NOOP("Insert Annotation");
+    sToolTipText  = QT_TR_NOOP("Insert Annotation");
     sWhatsThis    = "TechDraw_Annotation";
-    sStatusTip    = QT_TR_NOOP("Inserts an Annotation in the active drawing");
+    sStatusTip    = sToolTipText;
     sPixmap       = "actions/techdraw-annotation";
 }
 
@@ -601,10 +601,10 @@ CmdTechDrawClip::CmdTechDrawClip()
 {
     // setting the
     sGroup        = QT_TR_NOOP("TechDraw");
-    sMenuText     = QT_TR_NOOP("&Clip");
-    sToolTipText  = QT_TR_NOOP("Inserts a clip group in the active drawing");
+    sMenuText     = QT_TR_NOOP("Insert Clip group");
+    sToolTipText  = QT_TR_NOOP("Insert Clip group");
     sWhatsThis    = "TechDraw_Clip";
-    sStatusTip    = QT_TR_NOOP("Inserts a clip group in the active drawing");
+    sStatusTip    = sToolTipText;
     sPixmap       = "actions/techdraw-clip";
 }
 
@@ -640,10 +640,10 @@ CmdTechDrawClipPlus::CmdTechDrawClipPlus()
   : Command("TechDraw_ClipPlus")
 {
     sGroup        = QT_TR_NOOP("TechDraw");
-    sMenuText     = QT_TR_NOOP("&ClipPlus");
-    sToolTipText  = QT_TR_NOOP("Add a View to a clip group in the active drawing");
+    sMenuText     = QT_TR_NOOP("Add View to ClipGroup");
+    sToolTipText  = QT_TR_NOOP("Add a View to Clip group");
     sWhatsThis    = "TechDraw_ClipPlus";
-    sStatusTip    = QT_TR_NOOP("Adds a View into a clip group in the active drawing");
+    sStatusTip    = sToolTipText;
     sPixmap       = "actions/techdraw-clipplus";
 }
 
@@ -728,10 +728,10 @@ CmdTechDrawClipMinus::CmdTechDrawClipMinus()
   : Command("TechDraw_ClipMinus")
 {
     sGroup        = QT_TR_NOOP("TechDraw");
-    sMenuText     = QT_TR_NOOP("&ClipMinus");
-    sToolTipText  = QT_TR_NOOP("Remove a View from a clip group in the active drawing");
+    sMenuText     = QT_TR_NOOP("Remove View from ClipGroup");
+    sToolTipText  = QT_TR_NOOP("Remove a View from Clip group");
     sWhatsThis    = "TechDraw_ClipMinus";
-    sStatusTip    = QT_TR_NOOP("Remove a View from a clip group in the active drawing");
+    sStatusTip    = sToolTipText;
     sPixmap       = "actions/techdraw-clipminus";
 }
 
@@ -803,10 +803,10 @@ CmdTechDrawSymbol::CmdTechDrawSymbol()
 {
     // setting the Gui eye-candy
     sGroup        = QT_TR_NOOP("TechDraw");
-    sMenuText     = QT_TR_NOOP("Insert SVG &Symbol");
-    sToolTipText  = QT_TR_NOOP("Inserts a symbol from a svg file in the active drawing");
+    sMenuText     = QT_TR_NOOP("Insert SVG Symbol");
+    sToolTipText  = QT_TR_NOOP("Insert symbol from a svg file");
     sWhatsThis    = "TechDraw_Symbol";
-    sStatusTip    = QT_TR_NOOP("Inserts a symbol from a svg file in the active drawing");
+    sStatusTip    = sToolTipText;
     sPixmap       = "actions/techdraw-symbol";
 }
 
@@ -854,9 +854,9 @@ CmdTechDrawDraftView::CmdTechDrawDraftView()
     // setting the Gui eye-candy
     sGroup        = QT_TR_NOOP("TechDraw");
     sMenuText     = QT_TR_NOOP("Insert a DraftView");
-    sToolTipText  = QT_TR_NOOP("Inserts a Draft WB object into the active drawing");
+    sToolTipText  = QT_TR_NOOP("Inserts a Draft WB object");
     sWhatsThis    = "TechDraw_DraftView";
-    sStatusTip    = QT_TR_NOOP("Inserts a Draft WB object into the active drawing");
+    sStatusTip    = sToolTipText;
     sPixmap       = "actions/techdraw-draft-view";
 }
 
@@ -907,9 +907,9 @@ CmdTechDrawArchView::CmdTechDrawArchView()
     // setting the Gui eye-candy
     sGroup        = QT_TR_NOOP("TechDraw");
     sMenuText     = QT_TR_NOOP("Insert an ArchView");
-    sToolTipText  = QT_TR_NOOP("Inserts a view of an Arch Section Plane into the active drawing");
+    sToolTipText  = QT_TR_NOOP("Inserts a view of an Arch Section Plane");
     sWhatsThis    = "TechDraw_ArchView";
-    sStatusTip    = QT_TR_NOOP("Inserts a view of an Arch Section Plane into the active drawing");
+    sStatusTip    = sToolTipText;
     sPixmap       = "actions/techdraw-arch-view";
 }
 
@@ -963,10 +963,10 @@ CmdTechDrawSpreadsheet::CmdTechDrawSpreadsheet()
 {
     // setting the
     sGroup        = QT_TR_NOOP("TechDraw");
-    sMenuText     = QT_TR_NOOP("Spreadsheet");
-    sToolTipText  = QT_TR_NOOP("Inserts a view of a selected spreadsheet into a drawing");
+    sMenuText     = QT_TR_NOOP("Insert Spreadsheet view");
+    sToolTipText  = QT_TR_NOOP("Inserts a view of a selected spreadsheet");
     sWhatsThis    = "TechDraw_Spreadsheet";
-    sStatusTip    = QT_TR_NOOP("Inserts a view of a selected spreadsheet into a drawing");
+    sStatusTip    = sToolTipText;
     sPixmap       = "actions/techdraw-spreadsheet";
 }
 
@@ -1022,10 +1022,10 @@ CmdTechDrawExportPage::CmdTechDrawExportPage()
   : Command("TechDraw_ExportPage")
 {
     sGroup        = QT_TR_NOOP("File");
-    sMenuText     = QT_TR_NOOP("&Export page...");
+    sMenuText     = QT_TR_NOOP("Export page as SVG");
     sToolTipText  = QT_TR_NOOP("Export a page to an SVG file");
     sWhatsThis    = "TechDraw_ExportPage";
-    sStatusTip    = QT_TR_NOOP("Export a page to an SVG file");
+    sStatusTip    = sToolTipText;
     sPixmap       = "actions/techdraw-saveSVG";
 }
 

--- a/src/Mod/TechDraw/Gui/CommandCreateDims.cpp
+++ b/src/Mod/TechDraw/Gui/CommandCreateDims.cpp
@@ -238,7 +238,7 @@ CmdTechDrawNewRadiusDimension::CmdTechDrawNewRadiusDimension()
     sGroup          = QT_TR_NOOP("TechDraw");
     sMenuText       = QT_TR_NOOP("Insert a new radius dimension");
     sToolTipText    = QT_TR_NOOP("Insert a new radius dimension");
-    sWhatsThis      = "TechDraw_NewRadiusDimension";
+    sWhatsThis      = "TechDraw_Dimension_Radius";
     sStatusTip      = sToolTipText;
     sPixmap         = "TechDraw_Dimension_Radius";
 }
@@ -325,7 +325,7 @@ CmdTechDrawNewDiameterDimension::CmdTechDrawNewDiameterDimension()
     sGroup          = QT_TR_NOOP("TechDraw");
     sMenuText       = QT_TR_NOOP("Insert a new diameter dimension");
     sToolTipText    = QT_TR_NOOP("Insert a new diameter dimension feature");
-    sWhatsThis      = "TechDraw_NewDiameterDimension";
+    sWhatsThis      = "TechDraw_Dimension_Diameter";
     sStatusTip      = sToolTipText;
     sPixmap         = "TechDraw_Dimension_Diameter";
 }
@@ -412,7 +412,7 @@ CmdTechDrawNewLengthDimension::CmdTechDrawNewLengthDimension()
     sGroup          = QT_TR_NOOP("TechDraw");
     sMenuText       = QT_TR_NOOP("Insert a new length dimension");
     sToolTipText    = QT_TR_NOOP("Insert a new length dimension");
-    sWhatsThis      = "TechDraw_NewLengthDimension";
+    sWhatsThis      = "TechDraw_Dimension_Length";
     sStatusTip      = sToolTipText;
     sPixmap         = "TechDraw_Dimension_Length";
 }
@@ -520,7 +520,7 @@ CmdTechDrawNewDistanceXDimension::CmdTechDrawNewDistanceXDimension()
     sGroup          = QT_TR_NOOP("TechDraw");
     sMenuText       = QT_TR_NOOP("Insert a new horizontal dimension");
     sToolTipText    = QT_TR_NOOP("Insert a new horizontal distance dimension");
-    sWhatsThis      = "TechDraw_NewDistanceXDimension";
+    sWhatsThis      = "TechDraw_Dimension_Horizontal";
     sStatusTip      = sToolTipText;
     sPixmap         = "TechDraw_Dimension_Horizontal";
 }
@@ -628,7 +628,7 @@ CmdTechDrawNewDistanceYDimension::CmdTechDrawNewDistanceYDimension()
     sGroup          = QT_TR_NOOP("TechDraw");
     sMenuText       = QT_TR_NOOP("Insert a new vertical dimension");
     sToolTipText    = QT_TR_NOOP("Insert a new vertical distance dimension");
-    sWhatsThis      = "TechDraw_NewDistanceYDimension";
+    sWhatsThis      = "TechDraw_Dimension_Vertical";
     sStatusTip      = sToolTipText;
     sPixmap         = "TechDraw_Dimension_Vertical";
 }
@@ -735,7 +735,7 @@ CmdTechDrawNewAngleDimension::CmdTechDrawNewAngleDimension()
     sGroup          = QT_TR_NOOP("TechDraw");
     sMenuText       = QT_TR_NOOP("Insert a new angle dimension");
     sToolTipText    = QT_TR_NOOP("Insert a new angle dimension");
-    sWhatsThis      = "TechDraw_NewAngleDimension";
+    sWhatsThis      = "TechDraw_Dimension_Angle";
     sStatusTip      = sToolTipText;
     sPixmap         = "TechDraw_Dimension_Angle";
 }
@@ -824,7 +824,7 @@ CmdTechDrawLinkDimension::CmdTechDrawLinkDimension()
     sGroup          = QT_TR_NOOP("TechDraw");
     sMenuText       = QT_TR_NOOP("Link a dimension to 3D geometry");
     sToolTipText    = QT_TR_NOOP("Link a dimension to 3D geometry");
-    sWhatsThis      = "TechDraw_LinkDimension";
+    sWhatsThis      = "TechDraw_Dimension_Link";
     sStatusTip      = sToolTipText;
     sPixmap         = "TechDraw_Dimension_Link";
 }

--- a/src/Mod/TechDraw/Gui/CommandCreateDims.cpp
+++ b/src/Mod/TechDraw/Gui/CommandCreateDims.cpp
@@ -101,6 +101,8 @@ char* _edgeTypeToText(int e);
 // TechDraw_NewDimension
 //===========================================================================
 
+// this is deprecated. use individual add dimension commands.
+
 DEF_STD_CMD_A(CmdTechDrawNewDimension);
 
 CmdTechDrawNewDimension::CmdTechDrawNewDimension()
@@ -108,7 +110,7 @@ CmdTechDrawNewDimension::CmdTechDrawNewDimension()
 {
     sAppModule      = "TechDraw";
     sGroup          = QT_TR_NOOP("TechDraw");
-    sMenuText       = QT_TR_NOOP("Insert a dimension into the drawing");
+    sMenuText       = QT_TR_NOOP("Insert a dimension into a drawing");
     sToolTipText    = QT_TR_NOOP("Insert a new dimension");
     sWhatsThis      = "TechDraw_NewDimension";
     sStatusTip      = sToolTipText;
@@ -234,8 +236,8 @@ CmdTechDrawNewRadiusDimension::CmdTechDrawNewRadiusDimension()
 {
     sAppModule      = "TechDraw";
     sGroup          = QT_TR_NOOP("TechDraw");
-    sMenuText       = QT_TR_NOOP("Insert a new radius dimension into the drawing");
-    sToolTipText    = QT_TR_NOOP("Insert a new radius dimension feature for the selected view");
+    sMenuText       = QT_TR_NOOP("Insert a new radius dimension");
+    sToolTipText    = QT_TR_NOOP("Insert a new radius dimension");
     sWhatsThis      = "TechDraw_NewRadiusDimension";
     sStatusTip      = sToolTipText;
     sPixmap         = "TechDraw_Dimension_Radius";
@@ -321,8 +323,8 @@ CmdTechDrawNewDiameterDimension::CmdTechDrawNewDiameterDimension()
 {
     sAppModule      = "TechDraw";
     sGroup          = QT_TR_NOOP("TechDraw");
-    sMenuText       = QT_TR_NOOP("Insert a new diameter dimension into the drawing");
-    sToolTipText    = QT_TR_NOOP("Insert a new diameter dimension feature for the selected view");
+    sMenuText       = QT_TR_NOOP("Insert a new diameter dimension");
+    sToolTipText    = QT_TR_NOOP("Insert a new diameter dimension feature");
     sWhatsThis      = "TechDraw_NewDiameterDimension";
     sStatusTip      = sToolTipText;
     sPixmap         = "TechDraw_Dimension_Diameter";
@@ -408,7 +410,7 @@ CmdTechDrawNewLengthDimension::CmdTechDrawNewLengthDimension()
 {
     sAppModule      = "TechDraw";
     sGroup          = QT_TR_NOOP("TechDraw");
-    sMenuText       = QT_TR_NOOP("Insert a new length dimension into the drawing");
+    sMenuText       = QT_TR_NOOP("Insert a new length dimension");
     sToolTipText    = QT_TR_NOOP("Insert a new length dimension");
     sWhatsThis      = "TechDraw_NewLengthDimension";
     sStatusTip      = sToolTipText;
@@ -516,8 +518,8 @@ CmdTechDrawNewDistanceXDimension::CmdTechDrawNewDistanceXDimension()
 {
     sAppModule      = "TechDraw";
     sGroup          = QT_TR_NOOP("TechDraw");
-    sMenuText       = QT_TR_NOOP("Insert a new horizontal dimension into the drawing");
-    sToolTipText    = QT_TR_NOOP("Insert a new horizontal-distance dimension");
+    sMenuText       = QT_TR_NOOP("Insert a new horizontal dimension");
+    sToolTipText    = QT_TR_NOOP("Insert a new horizontal distance dimension");
     sWhatsThis      = "TechDraw_NewDistanceXDimension";
     sStatusTip      = sToolTipText;
     sPixmap         = "TechDraw_Dimension_Horizontal";
@@ -624,7 +626,7 @@ CmdTechDrawNewDistanceYDimension::CmdTechDrawNewDistanceYDimension()
 {
     sAppModule      = "TechDraw";
     sGroup          = QT_TR_NOOP("TechDraw");
-    sMenuText       = QT_TR_NOOP("Insert a new vertical dimension into the drawing");
+    sMenuText       = QT_TR_NOOP("Insert a new vertical dimension");
     sToolTipText    = QT_TR_NOOP("Insert a new vertical distance dimension");
     sWhatsThis      = "TechDraw_NewDistanceYDimension";
     sStatusTip      = sToolTipText;
@@ -731,7 +733,7 @@ CmdTechDrawNewAngleDimension::CmdTechDrawNewAngleDimension()
 {
     sAppModule      = "TechDraw";
     sGroup          = QT_TR_NOOP("TechDraw");
-    sMenuText       = QT_TR_NOOP("Insert a new angle dimension into the drawing");
+    sMenuText       = QT_TR_NOOP("Insert a new angle dimension");
     sToolTipText    = QT_TR_NOOP("Insert a new angle dimension");
     sWhatsThis      = "TechDraw_NewAngleDimension";
     sStatusTip      = sToolTipText;

--- a/src/Mod/TechDraw/Gui/CommandDecorate.cpp
+++ b/src/Mod/TechDraw/Gui/CommandDecorate.cpp
@@ -211,9 +211,9 @@ CmdTechDrawImage::CmdTechDrawImage()
     // setting the Gui eye-candy
     sGroup        = QT_TR_NOOP("TechDraw");
     sMenuText     = QT_TR_NOOP("Insert bitmap image");
-    sToolTipText  = QT_TR_NOOP("Inserts a bitmap from a file in the active drawing");
+    sToolTipText  = QT_TR_NOOP("Inserts a bitmap from a file into a Page");
     sWhatsThis    = "TechDraw_Image";
-    sStatusTip    = QT_TR_NOOP("Inserts a bitmap from a file in the active drawing");
+    sStatusTip    = QT_TR_NOOP("Inserts a bitmap from a file into a Page");
     sPixmap       = "actions/techdraw-image";
 }
 

--- a/src/Mod/TechDraw/Gui/CommandDecorate.cpp
+++ b/src/Mod/TechDraw/Gui/CommandDecorate.cpp
@@ -80,7 +80,7 @@ CmdTechDrawNewHatch::CmdTechDrawNewHatch()
     sGroup          = QT_TR_NOOP("TechDraw");
     sMenuText       = QT_TR_NOOP("Hatch a Face using image file");
     sToolTipText    = QT_TR_NOOP("Hatch a Face using image file");
-    sWhatsThis      = "TechDraw_NewHatch";
+    sWhatsThis      = "TechDraw_Hatch";
     sStatusTip      = sToolTipText;
     sPixmap         = "actions/techdraw-hatch";
 }
@@ -142,7 +142,7 @@ CmdTechDrawNewGeomHatch::CmdTechDrawNewGeomHatch()
     sGroup          = QT_TR_NOOP("TechDraw");
     sMenuText       = QT_TR_NOOP("Apply geometric hatch to a Face");
     sToolTipText    = QT_TR_NOOP("Apply geometric hatch to a Face");
-    sWhatsThis      = "TechDraw_NewGeomHatch";
+    sWhatsThis      = "TechDraw_GeomHatch";
     sStatusTip      = sToolTipText;
     sPixmap         = "actions/techdraw-geomhatch";
 }
@@ -264,7 +264,7 @@ CmdTechDrawToggleFrame::CmdTechDrawToggleFrame()
     sGroup          = QT_TR_NOOP("TechDraw");
     sMenuText       = QT_TR_NOOP("Turn View Frames on or off");
     sToolTipText    = QT_TR_NOOP("Turn View Frames on or off");
-    sWhatsThis      = "TechDraw_ToggleFrame";
+    sWhatsThis      = "TechDraw_Toggle";
     sStatusTip      = sToolTipText;
     sPixmap         = "actions/techdraw-toggleframe";
 }
@@ -311,7 +311,7 @@ CmdTechDrawRedrawPage::CmdTechDrawRedrawPage()
     sGroup          = QT_TR_NOOP("TechDraw");
     sMenuText       = QT_TR_NOOP("Redraw a page");
     sToolTipText    = QT_TR_NOOP("Redraw a page");
-    sWhatsThis      = "TechDraw_RedrawPage";
+    sWhatsThis      = "TechDraw_Redraw";
     sStatusTip      = sToolTipText;
     sPixmap         = "TechDraw_Tree_Page_Sync";
 }

--- a/src/Mod/TechDraw/Gui/Workbench.cpp
+++ b/src/Mod/TechDraw/Gui/Workbench.cpp
@@ -54,22 +54,38 @@ Gui::MenuItem* Workbench::setupMenuBar() const
     draw->setCommand("TechDraw");
     *draw << "TechDraw_NewPageDef";
     *draw << "TechDraw_NewPage";
+    *draw << "Separator";
     *draw << "TechDraw_NewView";
 //    *draw << "TechDraw_NewMulti";     //deprecated
     *draw << "TechDraw_ProjGroup";
     *draw << "TechDraw_NewViewSection";
     *draw << "TechDraw_NewViewDetail";
+    *draw << "Separator";
     *draw << "TechDraw_Annotation";
-    *draw << "TechDraw_Symbol";
+    *draw << "TechDraw_DraftView";
+    *draw << "TechDraw_ArchView";
     *draw << "TechDraw_Spreadsheet";
+    *draw << "Separator";
     *draw << "TechDraw_Clip";
     *draw << "TechDraw_ClipPlus";
     *draw << "TechDraw_ClipMinus";
-    *draw << "TechDraw_NewDimension";
-    *draw << "TechDraw_DraftView";
-    *draw << "TechDraw_ArchView";
+    *draw << "Separator";
+    *draw << "TechDraw_NewLengthDimension";
+    *draw << "TechDraw_NewDistanceXDimension";
+    *draw << "TechDraw_NewDistanceYDimension";
+    *draw << "TechDraw_NewRadiusDimension";
+    *draw << "TechDraw_NewDiameterDimension";
+    *draw << "TechDraw_NewAngleDimension";
+    *draw << "TechDraw_LinkDimension";
+    *draw << "Separator";
     *draw << "TechDraw_ExportPage";
+    *draw << "Separator";
+    *draw << "TechDraw_NewHatch";
+    *draw << "TechDraw_NewGeomHatch";
+    *draw << "TechDraw_Symbol";
     *draw << "TechDraw_Image";
+    *draw << "TechDraw_ToggleFrame";
+//    *decor << "TechDraw_RedrawPage";
 
     return root;
 }


### PR DESCRIPTION
This PR synchronizes the TechDraw Toolbars and the TechDraw Menu entries.  It also changes the "WhatsThis" test of TechDraw commands to match the corresponding Wiki page.  Please merge. 

Thanks,
wf

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
