### PR TITLE
Fix Bad View Position on Add to Clip

### DIFF
--- a/src/Mod/TechDraw/App/DrawViewClip.cpp
+++ b/src/Mod/TechDraw/App/DrawViewClip.cpp
@@ -25,15 +25,10 @@
 #include "PreCompiled.h"
 
 #ifndef _PreComp_
-# include <sstream>
+
 #endif
 
-
-#include <Base/Exception.h>
 #include <Base/Console.h>
-#include <Base/FileInfo.h>
-#include <App/Application.h>
-#include <iostream>
 
 #include "DrawViewClip.h"
 #include "DrawPage.h"
@@ -55,8 +50,8 @@ DrawViewClip::DrawViewClip(void)
     static const char *group = "Clip Group";
     //App::PropertyType hidden = (App::PropertyType)(App::Prop_Hidden);
 
-    ADD_PROPERTY_TYPE(Height     ,(10),group,App::Prop_None,"The height of the view area of this clip");
-    ADD_PROPERTY_TYPE(Width      ,(10),group,App::Prop_None,"The width of the view area of this clip");
+    ADD_PROPERTY_TYPE(Height     ,(100),group,App::Prop_None,"The height of the view area of this clip");
+    ADD_PROPERTY_TYPE(Width      ,(100),group,App::Prop_None,"The width of the view area of this clip");
     ADD_PROPERTY_TYPE(ShowFrame  ,(0) ,group,App::Prop_None,"Specifies if the clip frame appears on the page or not");
     ADD_PROPERTY_TYPE(ShowLabels ,(0) ,group,App::Prop_None,"Specifies if View labels appear within the clip area");
     ADD_PROPERTY_TYPE(Views      ,(0) ,group,App::Prop_None,"The Views in this Clip group");
@@ -83,7 +78,10 @@ void DrawViewClip::addView(DrawView *view)
     std::vector<App::DocumentObject *> newViews(currViews);
     newViews.push_back(view);
     Views.setValues(newViews);
-    Views.touch();
+    view->X.setValue(Width.getValue()/2.0);
+    view->Y.setValue(Height.getValue()/2.0);
+    auto page = findParentPage();             //get Page to release child relationship in tree
+    page->Views.touch();
 }
 
 void DrawViewClip::removeView(DrawView *view)
@@ -98,7 +96,6 @@ void DrawViewClip::removeView(DrawView *view)
         }
     }
     Views.setValues(newViews);
-    touch();
 }
 
 App::DocumentObjectExecReturn *DrawViewClip::execute(void)
@@ -111,7 +108,7 @@ App::DocumentObjectExecReturn *DrawViewClip::execute(void)
     for (std::vector<App::DocumentObject*>::iterator it = children.begin(); it != children.end(); ++it) {
         if ((*it)->getTypeId().isDerivedFrom(DrawView::getClassTypeId())) {
             TechDraw::DrawView *view = static_cast<TechDraw::DrawView *>(*it);
-            view->touch();
+            view->requestPaint();
         }
     }
 

--- a/src/Mod/TechDraw/App/DrawViewClip.h
+++ b/src/Mod/TechDraw/App/DrawViewClip.h
@@ -29,6 +29,7 @@
 #include <App/DocumentObjectGroup.h>
 #include <App/PropertyLinks.h>
 #include <App/PropertyStandard.h>
+#include <App/PropertyUnits.h>
 #include <App/FeaturePython.h>
 
 #include "DrawView.h"
@@ -45,8 +46,8 @@ public:
     DrawViewClip(void);
     virtual ~DrawViewClip();
 
-    App::PropertyFloat Width;
-    App::PropertyFloat Height;
+    App::PropertyLength Width;
+    App::PropertyLength Height;
     App::PropertyBool ShowFrame;
     App::PropertyBool ShowLabels;
     App::PropertyLinkList Views;

--- a/src/Mod/TechDraw/Gui/QGIViewClip.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewClip.cpp
@@ -23,22 +23,9 @@
 
 #include "PreCompiled.h"
 #ifndef _PreComp_
-#include <cmath>
-#include <QGraphicsScene>
-#include <QMouseEvent>
-#include <QGraphicsSceneHoverEvent>
-#include <QGraphicsItem>
-#include <QStyleOptionGraphicsItem>
-#include <QGraphicsTextItem>
-#include <QPainterPathStroker>
-#include <QPainter>
-#include <QString>
-#include <QTextOption>
-#include <sstream>
 #include <algorithm>    // std::find
+#include <QGraphicsScene>
 #endif
-
-#include <qmath.h>
 
 #include <App/Application.h>
 #include <App/Material.h>
@@ -90,7 +77,8 @@ void QGIViewClip::updateView(bool update)
         viewClip->isTouched() ||
         viewClip->Height.isTouched() ||
         viewClip->Width.isTouched() ||
-        viewClip->ShowFrame.isTouched()) {
+        viewClip->ShowFrame.isTouched() ||
+        viewClip->Views.isTouched() ) {
 
         draw();
     }

--- a/src/Mod/TechDraw/Gui/ViewProviderViewClip.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderViewClip.cpp
@@ -63,7 +63,8 @@ void ViewProviderViewClip::updateData(const App::Property* prop)
     if (prop == &(getViewObject()->Height)      ||
         prop == &(getViewObject()->Width)       ||
         prop == &(getViewObject()->ShowFrame)   ||
-        prop == &(getViewObject()->ShowLabels) ) {
+        prop == &(getViewObject()->ShowLabels)  ||
+        prop == &(getViewObject()->Views) ) {
         // redraw QGIVP
         QGIView* qgiv = getQView();
         if (qgiv) {


### PR DESCRIPTION
This PR fixes an error in the positioning of a View when added to a Clip group.  Please merge. 

Thanks,
wf


Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
