### PR TITLE
Change read only files mode

### DIFF
--- a/src/Mod/AddonManager/AddonManager.py
+++ b/src/Mod/AddonManager/AddonManager.py
@@ -503,13 +503,16 @@ class CheckWBWorker(QtCore.QThread):
                             cw = bare_repo.config_writer()
                             cw.set('core', 'bare', False)
                             del cw
+                        bare_repo.git.clear_cache()
                         repo = git.Repo(clonedir)
                         repo.head.reset('--hard')
+                        repo.git.clear_cache()
                     gitrepo = git.Git(clonedir)
                     gitrepo.fetch()
                     if "git pull" in gitrepo.status():
                         self.mark.emit(repo[0])
                         upds.append(repo[0])
+                    gitrepo.clear_cache()
         self.progressbar_show.emit(False)
         if upds:
             self.info_label.emit(str(len(upds))+" "+translate("AddonsInstaller", "update(s) available")+": "+",".join(upds)+". "+translate("AddonsInstaller","Press the update button again to update them all at once."))
@@ -615,12 +618,15 @@ class ShowWorker(QtCore.QThread):
                                 cw = bare_repo.config_writer()
                                 cw.set('core', 'bare', False)
                                 del cw
+                            bare_repo.git.clear_cache()
                             repo = git.Repo(clonedir)
                             repo.head.reset('--hard')
+                            repo.git.clear_cache()
                         gitrepo = git.Git(clonedir)
                         gitrepo.fetch()
                         if "git pull" in gitrepo.status():
                             upd = True
+                        gitrepo.clear_cache()
             if upd:
                 message = "<strong>" + translate("AddonsInstaller", "An update is available for this addon.") + "</strong><br>" + desc + ' - <a href="' + self.repos[self.idx][1] + '"><span style="word-wrap: break-word;width:15em;text-decoration: underline; color:#0000ff;">' + self.repos[self.idx][1] + '</span></a>'
             else:
@@ -759,15 +765,19 @@ class InstallWorker(QtCore.QThread):
                             cw = bare_repo.config_writer()
                             cw.set('core', 'bare', False)
                             del cw
+                        bare_repo.git.clear_cache()
                         repo = git.Repo(clonedir)
                         repo.head.reset('--hard')
+                        repo.git.clear_cache()
                     repo = git.Git(clonedir)
                     answer = repo.pull()
+                    repo.clear_cache()
 
                     # Update the submodules for this repository
                     repo_sms = git.Repo(clonedir)
                     for submodule in repo_sms.submodules:
                         submodule.update(init=True, recursive=True)
+                    repo_sms.git.clear_cache()
                 else:
                     answer = self.download(self.repos[idx][1],clonedir)
             else:
@@ -781,6 +791,7 @@ class InstallWorker(QtCore.QThread):
                         # Make sure to clone all the submodules as well
                         if repo.submodules:
                             repo.submodule_update(recursive=True)
+                        repo.git.clear_cache()
                     else:
                         self.info_label.emit("Downloading module...")
                         self.download(self.repos[idx][1],clonedir)


### PR DESCRIPTION
When creating a git repository (GitPython) some read only files are created. On Windows removing the directory with read only files in it won't succeeded if write mode isn't set explicitly.

Forum discussion:

https://forum.freecadweb.org/viewtopic.php?f=10&t=27213
