### PR TITLE
[0.17] Doc: cmake now joins parts of offline doc-Fixes

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,11 +1,3 @@
-# join offline doc parts
-if(WIN32)
-    EXECUTE_PROCESS(COMMAND powershell gc ${CMAKE_SOURCE_DIR}/src/Doc/freecad.qch.part* -Enc Byte -Read 1024 | sc ${CMAKE_BINARY_DIR}/src/Doc/freecad.qch -Enc Byte)
-	# gc is an alias for Get-Content, sc is an alias for Set-Content, -Read XXXX can be adjusted up for performance, if the user has insufficient RAM it might fail
-else(WIN32)
-    EXECUTE_PROCESS(COMMAND sh -c "cat ${CMAKE_SOURCE_DIR}/src/Doc/freecad.qch.part* >> ${CMAKE_BINARY_DIR}/src/Doc/freecad.qch" )
-endif(WIN32)
-
 add_subdirectory(Build)
 add_subdirectory(3rdParty)
 add_subdirectory(Base)
@@ -13,19 +5,32 @@ add_subdirectory(App)
 add_subdirectory(Main)
 add_subdirectory(Mod)
 add_subdirectory(Ext)
+add_subdirectory(Doc)
+
+configure_file(Doc/ThirdPartyLibraries.html
+    ${CMAKE_BINARY_DIR}/doc/ThirdPartyLibraries.html COPYONLY)
+
+
+
 if(BUILD_GUI)
     add_subdirectory(Gui)
     configure_file(Doc/freecad.qhc ${CMAKE_BINARY_DIR}/doc/freecad.qhc COPYONLY)
-    #configure_file(Doc/freecad.qch ${CMAKE_BINARY_DIR}/doc/freecad.qch COPYONLY)
+    #configure_file(${CMAKE_BINARY_DIR}/src/Doc/freecad.qch ${CMAKE_BINARY_DIR}/doc/freecad.qch COPYONLY)
+	# join offline doc parts
+    if(WIN32)
+        EXECUTE_PROCESS(COMMAND powershell gc ${CMAKE_SOURCE_DIR}/src/Doc/freecad.qch.part* -Enc Byte -Read 1024 | sc ${CMAKE_BINARY_DIR}/doc/freecad.qch -Enc Byte -Force)
+	    # gc is an alias for Get-Content, sc is an alias for Set-Content, 
+		#-Read XXXX can be adjusted up for performance, if the user has insufficient RAM it might fail
+    else(WIN32)
+        EXECUTE_PROCESS(COMMAND sh -c "cat ${CMAKE_SOURCE_DIR}/src/Doc/freecad.qch.part* >> ${CMAKE_BINARY_DIR}/doc/freecad.qch" )
+    endif(WIN32)
 endif(BUILD_GUI)
 
 if(BUILD_TEMPLATE)
     add_subdirectory(Tools/_TEMPLATE_)
 endif(BUILD_TEMPLATE)
 
-configure_file(Doc/ThirdPartyLibraries.html
-    ${CMAKE_BINARY_DIR}/doc/ThirdPartyLibraries.html COPYONLY)
-add_subdirectory(Doc)
+
 
 if(FREECAD_MAINTAINERS_BUILD AND WIN32)
     #add_subdirectory(WindowsInstaller)
@@ -33,7 +38,7 @@ endif(FREECAD_MAINTAINERS_BUILD AND WIN32)
 
 INSTALL(FILES
     Doc/freecad.qhc
-    ${CMAKE_BINARY_DIR}/src/Doc/freecad.qch
+    ${CMAKE_BINARY_DIR}/doc/freecad.qch
     Doc/ThirdPartyLibraries.html
     DESTINATION ${CMAKE_INSTALL_DOCDIR}
 )


### PR DESCRIPTION
Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x ] Branch re-based on latest master `git pull --rebase upstream master`
- [x ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [? ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [N/A ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---

Fixes Failed build on Travis: https://travis-ci.org/FreeCAD/FreeCAD/builds/355423073?utm_source=github_status&utm_medium=notification

Create destination directory for concatenated file prior to writing file.
Concatenates the offline doc and writes to Build/doc directory so it's available with an non-installed build.
Only concatenates the file if BUILD_GUI=TRUE 
