### PR TITLE
Fix typo in GmshTools

### DIFF
--- a/src/Mod/Fem/femmesh/gmshtools.py
+++ b/src/Mod/Fem/femmesh/gmshtools.py
@@ -93,7 +93,7 @@ class GmshTools():
 
         # Algorithm3D
         # known_mesh_algorithm_3D = ['Automatic', 'Delaunay', 'New Delaunay', 'Frontal', 'Frontal Delaunay', 'Frontal Hex', 'MMG3D', 'R-tree']
-        algo3D = self.mesh_obj.Algorithm2D
+        algo3D = self.mesh_obj.Algorithm3D
         if algo3D == 'Automatic':
             self.algorithm3D = '1'
         elif algo3D == 'Delaunay':


### PR DESCRIPTION
I think there is a mistake in GmshTools. The 3D algorithm is chosen based on the mesh_obj.Algorithm2D. Shouldn't it be mesh_obj.Algorithm3D?