### PR TITLE
Workaround Qt 5 macOS menu bug

### DIFF
--- a/src/Gui/MenuManager.cpp
+++ b/src/Gui/MenuManager.cpp
@@ -191,7 +191,11 @@ void MenuManager::setup(MenuItem* menuItems) const
         return; // empty menu bar
 
     QMenuBar* menuBar = getMainWindow()->menuBar();
-    //menuBar->setUpdatesEnabled(false);
+
+#ifdef FC_OS_MACOSX
+    // Unknown Qt macOS bug observed with Qt >= 5.9.4 causes random crashes when viewing reused top level menus.
+    menuBar->clear();
+#endif
 
     QList<MenuItem*> items = menuItems->getItems();
     QList<QAction*> actions = menuBar->actions();


### PR DESCRIPTION
With Qt => 5.9, it would randomly crash when opening a menu after changing workbenches.
Evidently it is a Qt macOS bug related to removing actions from menus.
Recreating the menus everytime avoids the issue.

This is essential for 0.17 release.
