### PR TITLE
Path: Using UserString for comparison instead of the actual value to avoid …

### DIFF
--- a/src/Mod/Path/PathTests/TestPathSetupSheet.py
+++ b/src/Mod/Path/PathTests/TestPathSetupSheet.py
@@ -79,12 +79,14 @@ class TestPathSetupSheet(PathTestBase):
         o2.Proxy.setFromTemplate(o1.Proxy.templateAttributes())
         self.doc.recompute()
 
+        # Need to compare the UserString's due to rounding errors depending on the
+        # user's unit settings - should have no impact on the validity
 
-        self.assertRoughly(o1.VertRapid, o2.VertRapid)
-        self.assertRoughly(o1.HorizRapid, o2.HorizRapid)
-        self.assertRoughly(o1.SafeHeightOffset, o2.SafeHeightOffset)
+        self.assertEqual(o1.VertRapid.UserString, o2.VertRapid.UserString)
+        self.assertEqual(o1.HorizRapid.UserString, o2.HorizRapid.UserString)
+        self.assertEqual(o1.SafeHeightOffset.UserString, o2.SafeHeightOffset.UserString)
         self.assertEqual(o1.SafeHeightExpression, o2.SafeHeightExpression)
-        self.assertRoughly(o1.ClearanceHeightOffset, o2.ClearanceHeightOffset)
+        self.assertEqual(o1.ClearanceHeightOffset.UserString, o2.ClearanceHeightOffset.UserString)
         self.assertEqual(o1.ClearanceHeightExpression, o2.ClearanceHeightExpression)
         self.assertEqual(o1.StartDepthExpression, o2.StartDepthExpression)
         self.assertEqual(o1.FinalDepthExpression, o2.FinalDepthExpression)


### PR DESCRIPTION
…rounding errors depending on the unit-system used.

See: https://forum.freecadweb.org/viewtopic.php?f=15&t=27648


Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
