### PR TITLE
Fix duplicate about entries in mac app menu

### DIFF
--- a/src/Gui/CommandStd.cpp
+++ b/src/Gui/CommandStd.cpp
@@ -204,9 +204,13 @@ Action * StdCmdAbout::createAction(void)
     pcAction->setWhatsThis(QLatin1String(sWhatsThis));
     pcAction->setIcon(QApplication::windowIcon());
     pcAction->setShortcut(QString::fromLatin1(sAccel));
-    //Prevent Qt from using AboutRole -- fixes issue #0001485
+#if QT_VERSION > 0x050000
+    // Needs to have AboutRole set to avoid duplicates if adding the about action more than once on macOS
+    pcAction->setMenuRole(QAction::AboutRole);
+#else
+    // With Qt 4.8, having AboutRole set causes it to disappear when readding it: issue #0001485
     pcAction->setMenuRole(QAction::ApplicationSpecificRole);
-
+#endif
     return pcAction;
 }
 

--- a/src/Gui/MenuManager.cpp
+++ b/src/Gui/MenuManager.cpp
@@ -192,7 +192,7 @@ void MenuManager::setup(MenuItem* menuItems) const
 
     QMenuBar* menuBar = getMainWindow()->menuBar();
 
-#ifdef FC_OS_MACOSX
+#if defined(FC_OS_MACOSX) && QT_VERSION >= 0x050900
     // Unknown Qt macOS bug observed with Qt >= 5.9.4 causes random crashes when viewing reused top level menus.
     menuBar->clear();
 #endif


### PR DESCRIPTION
Clearing the menu bar does not remove the actions from the app menu,
but setting the action role allows Qt to take care of duplicates.