### PR TITLE
Sketcher: Bug fix - prevent inter part/body links

### DIFF
--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -2194,6 +2194,8 @@ bool SketchObject::isCarbonCopyAllowed(App::Document *pDoc, App::DocumentObject 
         return false;
     }
     
+    SketchObject * psObj = static_cast<SketchObject *>(pObj);
+    
     // Sketches outside of the Document are NOT allowed
     if (this->getDocument() != pDoc){
         if (rsn)
@@ -2222,10 +2224,17 @@ bool SketchObject::isCarbonCopyAllowed(App::Document *pDoc, App::DocumentObject 
     App::Part* part_obj = App::Part::getPartOfObject(pObj);
     if (part_this == part_obj){ //either in the same part, or in the root of document
         if (body_this != NULL) {
-            if ((body_this != body_obj) && !this->allowOtherBody) {
-                if (rsn)
-                    *rsn = rlOtherBody;
-                return false;
+            if (body_this != body_obj) {
+                if (!this->allowOtherBody) {
+                    if (rsn)
+                        *rsn = rlOtherBody;
+                    return false;
+                }
+                else if (psObj->getExternalGeometryCount()>2){ // if the original sketch has external geometry AND it is not in this body prevent link
+                    if (rsn)
+                        *rsn = rlOtherBodyWithLinks;
+                    return false;
+                }
             }
         }
     } else {
@@ -2235,7 +2244,7 @@ bool SketchObject::isCarbonCopyAllowed(App::Document *pDoc, App::DocumentObject 
         return false;
     }
     
-    SketchObject * psObj = static_cast<SketchObject *>(pObj);
+    
     
     const Rotation & srot = psObj->Placement.getValue().getRotation();
     const Rotation & lrot = this->Placement.getValue().getRotation();

--- a/src/Mod/Sketcher/App/SketchObject.h
+++ b/src/Mod/Sketcher/App/SketchObject.h
@@ -339,6 +339,7 @@ public:
         rlCircularReference,
         rlOtherPart,
         rlOtherBody,
+        rlOtherBodyWithLinks,   // for carbon copy
         rlNotASketch,           // for carbon copy
         rlNonParallel,          // for carbon copy
         rlAxesMisaligned,       // for carbon copy

--- a/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp
+++ b/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp
@@ -6611,6 +6611,9 @@ namespace SketcherGui {
                     case Sketcher::SketchObject::rlOtherBody:
                         this->notAllowedReason = QT_TR_NOOP("This object belongs to another body. Hold Ctrl to allow crossreferences.");
                         break;
+                    case Sketcher::SketchObject::rlOtherBodyWithLinks:
+                        this->notAllowedReason = QT_TR_NOOP("This object belongs to another body and it contains external geometry. Crossreference not allowed.");
+                        break;
                     case Sketcher::SketchObject::rlOtherPart:
                         this->notAllowedReason = QT_TR_NOOP("This object belongs to another part.");
                         break;


### PR DESCRIPTION
HAS IMPACT ON TRANSLATIONS.

With the support for external geometry during carbon copy, it was introduced a way for creating inter-part/inter-body links. See:
https://forum.freecadweb.org/viewtopic.php?f=10&t=27700&p=223736#p223736

This commit closes this door, while still allows carbon copy with external geometry support within the same body.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
