### PR TITLE
py3: Fix raytracing render for python3

### DIFF
--- a/src/Mod/Raytracing/Gui/Command.cpp
+++ b/src/Mod/Raytracing/Gui/Command.cpp
@@ -647,7 +647,7 @@ void CmdRaytracingRender::activated(int)
             std::stringstream h;
             h << height;
             std::string par = hGrp->GetASCII("OutputParameters", "+P +A");
-            doCommand(Doc,"PageFile = open(App.activeDocument().%s.PageResult,'r')",Sel[0].getFeatName());
+            doCommand(Doc,"PageFile = open(App.activeDocument().%s.PageResult,'rb')",Sel[0].getFeatName());
             doCommand(Doc,"import os,subprocess,tempfile");
             doCommand(Doc,"fd, TempFile = tempfile.mkstemp(suffix='.pov')");
             doCommand(Doc,"f = open(TempFile,'wb')");
@@ -675,7 +675,7 @@ void CmdRaytracingRender::activated(int)
         }
 
         openCommand("Render project");
-        doCommand(Doc,"PageFile = open(App.activeDocument().%s.PageResult,'r')",Sel[0].getFeatName());
+        doCommand(Doc,"PageFile = open(App.activeDocument().%s.PageResult,'rb')",Sel[0].getFeatName());
         doCommand(Doc,"import subprocess,tempfile");
         doCommand(Doc,"TempFile = tempfile.mkstemp(suffix='.lxs')[1]");
         doCommand(Doc,"f = open(TempFile,'wb')");


### PR DESCRIPTION
Because temp file is open in the binary mode (wb) then it should also be read in the binary mode (rb). Otherwise its causing error with python3:
```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
<class 'TypeError'>: a bytes-like object is required, not 'str'
```
---

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
