### PR TITLE
PropertyContainer: fix false hit when searching property

### DIFF
--- a/src/App/PropertyContainer.cpp
+++ b/src/App/PropertyContainer.cpp
@@ -321,6 +321,7 @@ void PropertyData::addProperty(OffsetBase offsetBase,const char* PropName, Prope
     PropertySpec temp;
     temp.Name   = PropName;
     temp.Offset = offsetBase.getOffsetTo(Prop);
+    assert(temp.Offset>=0);
     temp.Group  = PropertyGroup;
     temp.Type   = Type;
     temp.Docu   = PropertyDocu;
@@ -343,6 +344,8 @@ const PropertyData::PropertySpec *PropertyData::findProperty(OffsetBase offsetBa
 const PropertyData::PropertySpec *PropertyData::findProperty(OffsetBase offsetBase,const Property* prop) const
 {
   const int diff = offsetBase.getOffsetTo(prop);
+  if(diff<0)
+      return 0;
 
   for (vector<PropertyData::PropertySpec>::const_iterator It = propertyData.begin(); It != propertyData.end(); ++It)
     if(diff == It->Offset)

--- a/src/App/PropertyContainer.h
+++ b/src/App/PropertyContainer.h
@@ -25,6 +25,7 @@
 #define APP_PROPERTYCONTAINER_H
 
 #include <map>
+#include <climits>
 #include <Base/Persistence.h>
 
 namespace Base {
@@ -69,7 +70,11 @@ struct AppExport PropertyData
       OffsetBase(const App::Extension* container) : m_container(container) {};
       
       short int getOffsetTo(const App::Property* prop) const {
-            return (short) ((char*)prop - (char*)m_container);
+            auto *pt = (const char*)prop;
+            auto *base = (const char *)m_container;
+            if(pt<base || pt>base+SHRT_MAX)
+                return -1;
+            return (short) (pt-base);
       };
       char* getOffset() const {return (char*) m_container;};
       


### PR DESCRIPTION
PropertyContainer uses a static member of type PropertyData to register static properties. PropertyData uses a short variable to record the offset of the property against its container.

Because of possible 'short' truncation, when searching of property that in fact is from another container, we must check if the pointer is within boundary. Otherwise, truncation will result in effectively random
number, and possibly causing a false hit. The problem shows up as occasional failure on document restore. 