### PR TITLE
[For v0.18] Sketcher: v0.18 external geometry interoperability

### DIFF
--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -6136,6 +6136,8 @@ void SketchObject::handleChangedPropertyType( Base::XMLReader &reader,
         v.Restore(reader);
         
         ExternalGeometry.setValues(v.getValues(),v.getSubValues());
+        
+        Base::Console().Error("The file was saved with a new version of FreeCAD. The defining status of External Geometry will be lost.\n");
     }
 }
 

--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -6125,6 +6125,20 @@ void SketchObject::setExpression(const App::ObjectIdentifier &path, boost::share
         solve();
 }
 
+void SketchObject::handleChangedPropertyType( Base::XMLReader &reader,
+                                              const char * TypeName,
+                                              App::Property * prop)
+{
+    // forward compatibility to v0.18
+    if (prop == &ExternalGeometry && strcmp(TypeName, "Sketcher::PropertyExternalGeometryList") == 0) {
+        App::PropertyLinkSubList v;
+        v.setContainer(this);
+        v.Restore(reader);
+        
+        ExternalGeometry.setValues(v.getValues(),v.getSubValues());
+    }
+}
+
 
 // Python Sketcher feature ---------------------------------------------------------
 

--- a/src/Mod/Sketcher/App/SketchObject.h
+++ b/src/Mod/Sketcher/App/SketchObject.h
@@ -349,6 +349,9 @@ public:
     bool isExternalAllowed(App::Document *pDoc, App::DocumentObject *pObj, eReasonList* rsn = 0) const;
     
     bool isCarbonCopyAllowed(App::Document *pDoc, App::DocumentObject *pObj, bool & xinv, bool & yinv, eReasonList* rsn = 0) const;
+    
+    // handle change of type of properties
+    void handleChangedPropertyType(Base::XMLReader &reader, const char * TypeName, App::Property * prop);
 
 protected:
     /// get called by the container when a property has changed


### PR DESCRIPTION
This commit is for future v0.18 compatibility, so that if a file saved with v0.18 will be opened in v0.17, the external geometry won't be lost.

why?
I intend to support defining external geometry in v0.18. For that I change a property type. If that new functionality is included in v0.18, a file saved with v0.18 and opened in v0.17 will miss all the external geometry because of the change in type of the property. This code allows for a string check with a class non-existing in v0.17, and planned for v0.18, providing means for reading from a v0.18 file the information that is relevant for v0.17. The defining state would still be lost anyway, but this can be fixed by a simple "retrace" of the geometry. The impact of losing all the external links is huge.

alternatives?
1. Merge the defining external geometry work (https://forum.freecadweb.org/viewtopic.php?f=10&t=27780#p224659). But that is a new feature, not a bug fix, and it may require some code review. As everything it may introduce new bugs. Probably merging that would be hasty ATM.
2. Do nothing. Then if the defining branch is merged into v0.18, opening in v0.17 a file saved with v0.18 will lost all external geometry in the sketches.

impact?
I think there is no negative impact in merging this. If then v0.18 goes in another direction this code is harmless.

If you need further discussion:
https://forum.freecadweb.org/viewtopic.php?f=10&t=27780#p224659


