### PR TITLE
PartDesign: fix #0002758 Datum point moves to (0,0,0) when reopening the file

### DIFF
--- a/src/Mod/PartDesign/App/DatumPoint.cpp
+++ b/src/Mod/PartDesign/App/DatumPoint.cpp
@@ -80,12 +80,7 @@ PROPERTY_SOURCE(PartDesign::Point, Part::Datum)
 Point::Point()
 {    
     this->setAttacher(new AttachEnginePoint);
-    // Create a shape, which will be used by the Sketcher. Them main function is to avoid a dependency of
-    // Sketcher on the PartDesign module
-    BRepBuilderAPI_MakeVertex builder(gp_Pnt(0,0,0));
-    if (!builder.IsDone())
-        return;
-    Shape.setValue(builder.Shape());
+    this->makeShape();
 }
 
 Point::~Point()
@@ -94,7 +89,32 @@ Point::~Point()
 
 void Point::onChanged(const App::Property* prop)
 {
-    Part::Datum::onChanged(prop);
+    if(prop == &(this->Shape)){
+        //fix for #0002758 Datum point moves to (0,0,0) when reopening the file.
+        //bypass Part::Feature's onChanged, which may alter Placement property to match shape's placement.
+        //This is to prevent loss of correct Placement when restoring Shape from file.
+        App::GeoFeature::onChanged(prop);
+        return;
+    }
+    Superclass::onChanged(prop);
+}
+
+void Point::Restore(Base::XMLReader& r)
+{
+    Superclass::Restore(r);
+    //fix for #0002758 Datum point moves to (0,0,0) when reopening the file.
+    //recreate shape, as the restored one has old Placement burned into it.
+    this->makeShape();
+}
+
+void Point::makeShape()
+{
+    // Create a shape, which will be used by Sketcher, attachables, and whatever. Them main function is to avoid a dependency of
+    // Sketcher on the PartDesign module
+    BRepBuilderAPI_MakeVertex builder(gp_Pnt(0,0,0));
+    if (!builder.IsDone())
+        return;
+    Shape.setValue(builder.Shape());
 }
 
 Base::Vector3d Point::getPoint()

--- a/src/Mod/PartDesign/App/DatumPoint.h
+++ b/src/Mod/PartDesign/App/DatumPoint.h
@@ -46,8 +46,13 @@ public:
 
     Base::Vector3d getPoint();
 
+    typedef Part::Datum Superclass;
+
 protected:
     virtual void onChanged(const App::Property* prop);
+    virtual void Restore(Base::XMLReader& r);
+private:
+    void makeShape();
 };
 
 } //namespace PartDesign


### PR DESCRIPTION
OCC has a peculiarity, that when saving single vertexes, it burns in placement into vertex coordinates. In loaded shape, Placement is zero. This caused datum point placement reset to zero, and its shape had nonzero  coordinates.

This fix keeps placement property from resetting, and reconstructs a new vertex upon load

[#0002758](https://www.freecadweb.org/tracker/view.php?id=2758)
see also:
https://forum.freecadweb.org/viewtopic.php?f=3&t=27811
https://forum.freecadweb.org/viewtopic.php?f=8&t=17630