### PR TITLE
[For v0.18] App: fix py return of propertyLinkSubList

### DIFF
--- a/src/App/PropertyLinks.cpp
+++ b/src/App/PropertyLinks.cpp
@@ -894,24 +894,15 @@ std::vector<PropertyLinkSubList::SubSet> PropertyLinkSubList::getSubListValues()
     if (_lValueList.size() != _lSubList.size())
         throw Base::ValueError("PropertyLinkSubList::getSubListValues: size of subelements list != size of objects list");
 
-    std::map<App::DocumentObject*, std::vector<std::string> > tmp;
     for (std::size_t i = 0; i < _lValueList.size(); i++) {
         App::DocumentObject* link = _lValueList[i];
         std::string sub = _lSubList[i];
-        if (tmp.find(link) == tmp.end()) {
-            // make sure to keep the same order as in '_lValueList'
-            PropertyLinkSubList::SubSet item;
-            item.first = link;
-            values.push_back(item);
+        if (values.size() == 0 || values.back().first != link){
+            //new object started, start a new subset.
+            values.push_back(SubSet(link, std::vector<std::string>()));
         }
-
-        tmp[link].push_back(sub);
+        values.back().second.push_back(sub);
     }
-
-    for (std::vector<PropertyLinkSubList::SubSet>::iterator it = values.begin(); it != values.end(); ++it) {
-        it->second = tmp[it->first];
-    }
-
     return values;
 }
 


### PR DESCRIPTION
fixes [#0002602](https://freecadweb.org/tracker/view.php?id=2602)

Now, it won't bunch up same object entries if they are not adjacent. I.e., same object  can appear twice and more, for example:
[(object1, ('Edge2', 'Edge3')), (object2, ('Edge1',)), (object1, ('Edge4', 'Edge5'))]

Complete bunching causes information loss, and it's impossible to fix the bug with keeping the bunching complete.
