### PR TITLE
[For v0.17.1] Fix #3401 Warning on multiple solids in PD

### DIFF
--- a/src/Mod/PartDesign/App/Feature.cpp
+++ b/src/Mod/PartDesign/App/Feature.cpp
@@ -79,6 +79,21 @@ TopoDS_Shape Feature::getSolid(const TopoDS_Shape& shape)
     return TopoDS_Shape();
 }
 
+int Feature::countSolids(const TopoDS_Shape& shape, TopAbs_ShapeEnum type)
+{
+    int result = 0;
+    if (shape.IsNull())
+        return result;
+    TopExp_Explorer xp;
+    xp.Init(shape,type);
+    for (; xp.More(); xp.Next()) {
+        result++;
+    }
+    return result;
+}
+
+
+
 const gp_Pnt Feature::getPointFromFace(const TopoDS_Face& f)
 {
     if (!f.Infinite()) {

--- a/src/Mod/PartDesign/App/Feature.h
+++ b/src/Mod/PartDesign/App/Feature.h
@@ -83,6 +83,7 @@ protected:
      * Get a solid of the given shape. If no solid is found an exception is raised.
      */
     static TopoDS_Shape getSolid(const TopoDS_Shape&);    
+    static int countSolids(const TopoDS_Shape&, TopAbs_ShapeEnum type = TopAbs_SOLID );    
 
     /// Grab any point from the given face
     static const gp_Pnt getPointFromFace(const TopoDS_Face& f);    

--- a/src/Mod/PartDesign/App/FeatureBoolean.cpp
+++ b/src/Mod/PartDesign/App/FeatureBoolean.cpp
@@ -142,6 +142,11 @@ App::DocumentObjectExecReturn *Boolean::execute(void)
         result = boolOp; // Use result of this operation for fuse/cut of next body
     }
 
+    int solidCount = countSolids(result);
+    if (solidCount > 1) {
+        return new App::DocumentObjectExecReturn("Boolean: Result has multiple solids. Check parameters.");
+    }
+
     this->Shape.setValue(getSolid(result));
     return App::DocumentObject::StdReturn;
 }

--- a/src/Mod/PartDesign/App/FeatureBoolean.cpp
+++ b/src/Mod/PartDesign/App/FeatureBoolean.cpp
@@ -144,7 +144,7 @@ App::DocumentObjectExecReturn *Boolean::execute(void)
 
     int solidCount = countSolids(result);
     if (solidCount > 1) {
-        return new App::DocumentObjectExecReturn("Boolean: Result has multiple solids. Check parameters.");
+        return new App::DocumentObjectExecReturn("Boolean: Result has multiple solids. This is not supported at this time.");
     }
 
     this->Shape.setValue(getSolid(result));

--- a/src/Mod/PartDesign/App/FeatureChamfer.cpp
+++ b/src/Mod/PartDesign/App/FeatureChamfer.cpp
@@ -127,7 +127,7 @@ App::DocumentObjectExecReturn *Chamfer::execute(void)
         }
         int solidCount = countSolids(shape);
         if (solidCount > 1) {
-            return new App::DocumentObjectExecReturn("Chamfer: Result has multiple solids. Check parameters.");
+            return new App::DocumentObjectExecReturn("Chamfer: Result has multiple solids. This is not supported at this time.");
         }
 
         this->Shape.setValue(getSolid(shape));

--- a/src/Mod/PartDesign/App/FeatureChamfer.cpp
+++ b/src/Mod/PartDesign/App/FeatureChamfer.cpp
@@ -125,6 +125,10 @@ App::DocumentObjectExecReturn *Chamfer::execute(void)
                 return new App::DocumentObjectExecReturn("Resulting shape is invalid");
             }
         }
+        int solidCount = countSolids(shape);
+        if (solidCount > 1) {
+            return new App::DocumentObjectExecReturn("Chamfer: Result has multiple solids. Check parameters.");
+        }
 
         this->Shape.setValue(getSolid(shape));
         return App::DocumentObject::StdReturn;

--- a/src/Mod/PartDesign/App/FeatureDraft.cpp
+++ b/src/Mod/PartDesign/App/FeatureDraft.cpp
@@ -304,6 +304,11 @@ App::DocumentObjectExecReturn *Draft::execute(void)
         if (shape.IsNull())
             return new App::DocumentObjectExecReturn("Resulting shape is null");
 
+        int solidCount = countSolids(shape);
+        if (solidCount > 1) {
+            return new App::DocumentObjectExecReturn("Fuse: Result has multiple solids. Check parameters.");
+        }
+
         this->Shape.setValue(getSolid(shape));
         return App::DocumentObject::StdReturn;
     }

--- a/src/Mod/PartDesign/App/FeatureDraft.cpp
+++ b/src/Mod/PartDesign/App/FeatureDraft.cpp
@@ -306,7 +306,7 @@ App::DocumentObjectExecReturn *Draft::execute(void)
 
         int solidCount = countSolids(shape);
         if (solidCount > 1) {
-            return new App::DocumentObjectExecReturn("Fuse: Result has multiple solids. Check parameters.");
+            return new App::DocumentObjectExecReturn("Fuse: Result has multiple solids. This is not supported at this time.");
         }
 
         this->Shape.setValue(getSolid(shape));

--- a/src/Mod/PartDesign/App/FeatureFillet.cpp
+++ b/src/Mod/PartDesign/App/FeatureFillet.cpp
@@ -118,6 +118,11 @@ App::DocumentObjectExecReturn *Fillet::execute(void)
             }
         }
 
+        int solidCount = countSolids(shape);
+        if (solidCount > 1) {
+            return new App::DocumentObjectExecReturn("Fillet: Result has multiple solids. Check parameters.");
+        }
+
         this->Shape.setValue(getSolid(shape));
         return App::DocumentObject::StdReturn;
     }

--- a/src/Mod/PartDesign/App/FeatureFillet.cpp
+++ b/src/Mod/PartDesign/App/FeatureFillet.cpp
@@ -120,7 +120,7 @@ App::DocumentObjectExecReturn *Fillet::execute(void)
 
         int solidCount = countSolids(shape);
         if (solidCount > 1) {
-            return new App::DocumentObjectExecReturn("Fillet: Result has multiple solids. Check parameters.");
+            return new App::DocumentObjectExecReturn("Fillet: Result has multiple solids. This is not supported at this time.");
         }
 
         this->Shape.setValue(getSolid(shape));

--- a/src/Mod/PartDesign/App/FeatureGroove.cpp
+++ b/src/Mod/PartDesign/App/FeatureGroove.cpp
@@ -156,6 +156,11 @@ App::DocumentObjectExecReturn *Groove::execute(void)
             if (solRes.IsNull())
                 return new App::DocumentObjectExecReturn("Resulting shape is not a solid");
 
+            int solidCount = countSolids(result);
+            if (solidCount > 1) {
+                return new App::DocumentObjectExecReturn("Groove: Result has multiple solids. Check parameters.");
+            }
+
             solRes = refineShapeIfActive(solRes);
             this->Shape.setValue(getSolid(solRes));
         }

--- a/src/Mod/PartDesign/App/FeatureGroove.cpp
+++ b/src/Mod/PartDesign/App/FeatureGroove.cpp
@@ -158,7 +158,7 @@ App::DocumentObjectExecReturn *Groove::execute(void)
 
             int solidCount = countSolids(result);
             if (solidCount > 1) {
-                return new App::DocumentObjectExecReturn("Groove: Result has multiple solids. Check parameters.");
+                return new App::DocumentObjectExecReturn("Groove: Result has multiple solids. This is not supported at this time.");
             }
 
             solRes = refineShapeIfActive(solRes);

--- a/src/Mod/PartDesign/App/FeatureHole.cpp
+++ b/src/Mod/PartDesign/App/FeatureHole.cpp
@@ -1256,6 +1256,12 @@ App::DocumentObjectExecReturn *Hole::execute(void)
         this->AddSubShape.setValue( holes );
 
         remapSupportShape(base);
+
+        int solidCount = countSolids(base);
+        if (solidCount > 1) {
+            return new App::DocumentObjectExecReturn("Hole: Result has multiple solids. Check parameters.");
+        }
+
         this->Shape.setValue(base);
 
         return App::DocumentObject::StdReturn;

--- a/src/Mod/PartDesign/App/FeatureHole.cpp
+++ b/src/Mod/PartDesign/App/FeatureHole.cpp
@@ -1259,7 +1259,7 @@ App::DocumentObjectExecReturn *Hole::execute(void)
 
         int solidCount = countSolids(base);
         if (solidCount > 1) {
-            return new App::DocumentObjectExecReturn("Hole: Result has multiple solids. Check parameters.");
+            return new App::DocumentObjectExecReturn("Hole: Result has multiple solids. This is not supported at this time.");
         }
 
         this->Shape.setValue(base);

--- a/src/Mod/PartDesign/App/FeatureLoft.cpp
+++ b/src/Mod/PartDesign/App/FeatureLoft.cpp
@@ -193,6 +193,10 @@ App::DocumentObjectExecReturn *Loft::execute(void)
             // lets check if the result is a solid
             if (boolOp.IsNull())
                 return new App::DocumentObjectExecReturn("Loft: Resulting shape is not a solid");
+            int solidCount = countSolids(boolOp);
+            if (solidCount > 1) {
+                return new App::DocumentObjectExecReturn("Loft: Result has multiple solids. Check parameters.");
+            }
             
             boolOp = refineShapeIfActive(boolOp);
             Shape.setValue(getSolid(boolOp));
@@ -207,6 +211,10 @@ App::DocumentObjectExecReturn *Loft::execute(void)
             // lets check if the result is a solid
             if (boolOp.IsNull())
                 return new App::DocumentObjectExecReturn("Loft: Resulting shape is not a solid");
+            int solidCount = countSolids(boolOp);
+            if (solidCount > 1) {
+                return new App::DocumentObjectExecReturn("Loft: Result has multiple solids. Check parameters.");
+            }
             
             boolOp = refineShapeIfActive(boolOp);
             Shape.setValue(getSolid(boolOp));

--- a/src/Mod/PartDesign/App/FeatureLoft.cpp
+++ b/src/Mod/PartDesign/App/FeatureLoft.cpp
@@ -195,7 +195,7 @@ App::DocumentObjectExecReturn *Loft::execute(void)
                 return new App::DocumentObjectExecReturn("Loft: Resulting shape is not a solid");
             int solidCount = countSolids(boolOp);
             if (solidCount > 1) {
-                return new App::DocumentObjectExecReturn("Loft: Result has multiple solids. Check parameters.");
+                return new App::DocumentObjectExecReturn("Loft: Result has multiple solids. This is not supported at this time.");
             }
             
             boolOp = refineShapeIfActive(boolOp);
@@ -213,7 +213,7 @@ App::DocumentObjectExecReturn *Loft::execute(void)
                 return new App::DocumentObjectExecReturn("Loft: Resulting shape is not a solid");
             int solidCount = countSolids(boolOp);
             if (solidCount > 1) {
-                return new App::DocumentObjectExecReturn("Loft: Result has multiple solids. Check parameters.");
+                return new App::DocumentObjectExecReturn("Loft: Result has multiple solids. This is not supported at this time.");
             }
             
             boolOp = refineShapeIfActive(boolOp);

--- a/src/Mod/PartDesign/App/FeaturePad.cpp
+++ b/src/Mod/PartDesign/App/FeaturePad.cpp
@@ -225,10 +225,21 @@ App::DocumentObjectExecReturn *Pad::execute(void)
             // lets check if the result is a solid
             if (solRes.IsNull())
                 return new App::DocumentObjectExecReturn("Pad: Resulting shape is not a solid");
+
+            int solidCount = countSolids(result);
+            if (solidCount > 1) {
+                return new App::DocumentObjectExecReturn("Pad: Result has multiple solids. Check parameters.");
+            }
+
             solRes = refineShapeIfActive(solRes);
             this->Shape.setValue(getSolid(solRes));
         } else {
-            this->Shape.setValue(getSolid(prism));
+            int solidCount = countSolids(prism);
+            if (solidCount > 1) {
+                return new App::DocumentObjectExecReturn("Pad: Result has multiple solids. Check parameters.");
+            }
+
+           this->Shape.setValue(getSolid(prism));
         }
 
         return App::DocumentObject::StdReturn;

--- a/src/Mod/PartDesign/App/FeaturePad.cpp
+++ b/src/Mod/PartDesign/App/FeaturePad.cpp
@@ -228,7 +228,7 @@ App::DocumentObjectExecReturn *Pad::execute(void)
 
             int solidCount = countSolids(result);
             if (solidCount > 1) {
-                return new App::DocumentObjectExecReturn("Pad: Result has multiple solids. Check parameters.");
+                return new App::DocumentObjectExecReturn("Pad: Result has multiple solids. This is not supported at this time.");
             }
 
             solRes = refineShapeIfActive(solRes);
@@ -236,7 +236,7 @@ App::DocumentObjectExecReturn *Pad::execute(void)
         } else {
             int solidCount = countSolids(prism);
             if (solidCount > 1) {
-                return new App::DocumentObjectExecReturn("Pad: Result has multiple solids. Check parameters.");
+                return new App::DocumentObjectExecReturn("Pad: Result has multiple solids. This is not supported at this time.");
             }
 
            this->Shape.setValue(getSolid(prism));

--- a/src/Mod/PartDesign/App/FeaturePipe.cpp
+++ b/src/Mod/PartDesign/App/FeaturePipe.cpp
@@ -316,7 +316,7 @@ App::DocumentObjectExecReturn *Pipe::execute(void)
 
             int solidCount = countSolids(boolOp);
             if (solidCount > 1) {
-                return new App::DocumentObjectExecReturn("Pipe: Result has multiple solids. Check parameters.");
+                return new App::DocumentObjectExecReturn("Pipe: Result has multiple solids. This is not supported at this time.");
             }
 
             boolOp = refineShapeIfActive(boolOp);
@@ -335,7 +335,7 @@ App::DocumentObjectExecReturn *Pipe::execute(void)
 
             int solidCount = countSolids(boolOp);
             if (solidCount > 1) {
-                return new App::DocumentObjectExecReturn("Pipe: Result has multiple solids. Check parameters.");
+                return new App::DocumentObjectExecReturn("Pipe: Result has multiple solids. This is not supported at this time.");
             }
 
             boolOp = refineShapeIfActive(boolOp);

--- a/src/Mod/PartDesign/App/FeaturePipe.cpp
+++ b/src/Mod/PartDesign/App/FeaturePipe.cpp
@@ -314,6 +314,11 @@ App::DocumentObjectExecReturn *Pipe::execute(void)
             if (boolOp.IsNull())
                 return new App::DocumentObjectExecReturn("Resulting shape is not a solid");
 
+            int solidCount = countSolids(boolOp);
+            if (solidCount > 1) {
+                return new App::DocumentObjectExecReturn("Pipe: Result has multiple solids. Check parameters.");
+            }
+
             boolOp = refineShapeIfActive(boolOp);
             Shape.setValue(getSolid(boolOp));
         }
@@ -327,6 +332,11 @@ App::DocumentObjectExecReturn *Pipe::execute(void)
             // lets check if the result is a solid
             if (boolOp.IsNull())
                 return new App::DocumentObjectExecReturn("Resulting shape is not a solid");
+
+            int solidCount = countSolids(boolOp);
+            if (solidCount > 1) {
+                return new App::DocumentObjectExecReturn("Pipe: Result has multiple solids. Check parameters.");
+            }
 
             boolOp = refineShapeIfActive(boolOp);
             Shape.setValue(getSolid(boolOp));

--- a/src/Mod/PartDesign/App/FeaturePocket.cpp
+++ b/src/Mod/PartDesign/App/FeaturePocket.cpp
@@ -43,6 +43,7 @@
 # include <BRepAlgoAPI_Common.hxx>
 #endif
 
+#include <Base/Console.h>
 #include <Base/Exception.h>
 #include <Base/Placement.h>
 #include <App/Document.h>
@@ -181,6 +182,12 @@ App::DocumentObjectExecReturn *Pocket::execute(void)
             // FIXME: In some cases this affects the Shape property: It is set to the same shape as the SubShape!!!!
             TopoDS_Shape result = refineShapeIfActive(mkCut.Shape());
             this->AddSubShape.setValue(result);
+
+            int prismCount = countSolids(prism);
+            if (prismCount > 1) {
+                return new App::DocumentObjectExecReturn("Pocket: Result has multiple solids. Check parameters.");
+            }
+
             this->Shape.setValue(getSolid(prism));
         } else {
             TopoDS_Shape prism;
@@ -203,6 +210,12 @@ App::DocumentObjectExecReturn *Pocket::execute(void)
             TopoDS_Shape solRes = this->getSolid(result);
             if (solRes.IsNull())
                 return new App::DocumentObjectExecReturn("Pocket: Resulting shape is not a solid");
+
+            int solidCount = countSolids(result);
+            if (solidCount > 1) {
+                return new App::DocumentObjectExecReturn("Pocket: Result has multiple solids. Check parameters.");
+
+            }
             solRes = refineShapeIfActive(solRes);
             remapSupportShape(solRes);
             this->Shape.setValue(getSolid(solRes));

--- a/src/Mod/PartDesign/App/FeaturePocket.cpp
+++ b/src/Mod/PartDesign/App/FeaturePocket.cpp
@@ -185,7 +185,7 @@ App::DocumentObjectExecReturn *Pocket::execute(void)
 
             int prismCount = countSolids(prism);
             if (prismCount > 1) {
-                return new App::DocumentObjectExecReturn("Pocket: Result has multiple solids. Check parameters.");
+                return new App::DocumentObjectExecReturn("Pocket: Result has multiple solids. This is not supported at this time.");
             }
 
             this->Shape.setValue(getSolid(prism));
@@ -213,7 +213,7 @@ App::DocumentObjectExecReturn *Pocket::execute(void)
 
             int solidCount = countSolids(result);
             if (solidCount > 1) {
-                return new App::DocumentObjectExecReturn("Pocket: Result has multiple solids. Check parameters.");
+                return new App::DocumentObjectExecReturn("Pocket: Result has multiple solids. This is not supported at this time.");
 
             }
             solRes = refineShapeIfActive(solRes);

--- a/src/Mod/PartDesign/App/FeaturePrimitive.cpp
+++ b/src/Mod/PartDesign/App/FeaturePrimitive.cpp
@@ -124,7 +124,12 @@ App::DocumentObjectExecReturn* FeaturePrimitive::execute(const TopoDS_Shape& pri
             // lets check if the result is a solid
             if (boolOp.IsNull())
                 return new App::DocumentObjectExecReturn("Resulting shape is not a solid");
-            
+
+            int solidCount = countSolids(boolOp);
+            if (solidCount > 1) {
+                return new App::DocumentObjectExecReturn("Additive: Result has multiple solids. Check parameters.");
+            }
+
             boolOp = refineShapeIfActive(boolOp);
             Shape.setValue(getSolid(boolOp));
             AddSubShape.setValue(primitiveShape);
@@ -139,6 +144,11 @@ App::DocumentObjectExecReturn* FeaturePrimitive::execute(const TopoDS_Shape& pri
             // lets check if the result is a solid
             if (boolOp.IsNull())
                 return new App::DocumentObjectExecReturn("Resulting shape is not a solid");
+
+            int solidCount = countSolids(boolOp);
+            if (solidCount > 1) {
+                return new App::DocumentObjectExecReturn("Subtractive: Result has multiple solids. Check parameters.");
+            }
             
             boolOp = refineShapeIfActive(boolOp);
             Shape.setValue(getSolid(boolOp));

--- a/src/Mod/PartDesign/App/FeaturePrimitive.cpp
+++ b/src/Mod/PartDesign/App/FeaturePrimitive.cpp
@@ -127,7 +127,7 @@ App::DocumentObjectExecReturn* FeaturePrimitive::execute(const TopoDS_Shape& pri
 
             int solidCount = countSolids(boolOp);
             if (solidCount > 1) {
-                return new App::DocumentObjectExecReturn("Additive: Result has multiple solids. Check parameters.");
+                return new App::DocumentObjectExecReturn("Additive: Result has multiple solids. This is not supported at this time.");
             }
 
             boolOp = refineShapeIfActive(boolOp);
@@ -147,7 +147,7 @@ App::DocumentObjectExecReturn* FeaturePrimitive::execute(const TopoDS_Shape& pri
 
             int solidCount = countSolids(boolOp);
             if (solidCount > 1) {
-                return new App::DocumentObjectExecReturn("Subtractive: Result has multiple solids. Check parameters.");
+                return new App::DocumentObjectExecReturn("Subtractive: Result has multiple solids. This is not supported at this time.");
             }
             
             boolOp = refineShapeIfActive(boolOp);

--- a/src/Mod/PartDesign/App/FeatureTransformed.cpp
+++ b/src/Mod/PartDesign/App/FeatureTransformed.cpp
@@ -331,6 +331,7 @@ App::DocumentObjectExecReturn *Transformed::execute(void)
                         // lets check if the result is a solid
                         if (current.IsNull())
                             return new App::DocumentObjectExecReturn("Resulting shape is not a solid", *o);
+
                         /*std::vector<TopoDS_Shape>::const_iterator individualIt;
                         for (individualIt = individualTools.begin(); individualIt != individualTools.end(); ++individualIt)
                         {
@@ -377,6 +378,11 @@ App::DocumentObjectExecReturn *Transformed::execute(void)
     for (rej_it_map::const_iterator it = nointersect_trsfms.begin(); it != nointersect_trsfms.end(); ++it)
         for (trsf_it::const_iterator it2 = it->second.begin(); it2 != it->second.end(); ++it2)
             rejected[it->first].push_back(**it2);
+
+    int solidCount = countSolids(support);
+    if (solidCount > 1) {
+        return new App::DocumentObjectExecReturn("Transformed: Result has multiple solids. Check parameters.");
+    }
 
     this->Shape.setValue(getSolid(support));
 

--- a/src/Mod/PartDesign/App/FeatureTransformed.cpp
+++ b/src/Mod/PartDesign/App/FeatureTransformed.cpp
@@ -381,7 +381,7 @@ App::DocumentObjectExecReturn *Transformed::execute(void)
 
     int solidCount = countSolids(support);
     if (solidCount > 1) {
-        return new App::DocumentObjectExecReturn("Transformed: Result has multiple solids. Check parameters.");
+        return new App::DocumentObjectExecReturn("Transformed: Result has multiple solids. This is not supported at this time.");
     }
 
     this->Shape.setValue(getSolid(support));

--- a/src/Mod/PartDesign/PartDesignTests/TestPocket.py
+++ b/src/Mod/PartDesign/PartDesignTests/TestPocket.py
@@ -76,14 +76,14 @@ class TestPocket(unittest.TestCase):
         self.PocketSketch1.MapMode = 'FlatFace'
         self.PocketSketch1.Support = (self.Doc.XZ_Plane, [''])
         self.Doc.recompute()
-        TestSketcherApp.CreateRectangleSketch(self.PocketSketch1, (2.5, -1), (5, 1))
+        TestSketcherApp.CreateRectangleSketch(self.PocketSketch1, (2.5, -0.75), (5, 0.50))
         self.Doc.recompute()
         self.Pocket001 = self.Doc.addObject("PartDesign::Pocket", "Pocket001")
         self.Body.addObject(self.Pocket001)
         self.Pocket001.Profile = self.PocketSketch1
         self.Pocket001.Type = 1
         self.Doc.recompute()
-        self.assertAlmostEqual(self.Pocket001.Shape.Volume, 25.0)
+        self.assertAlmostEqual(self.Pocket001.Shape.Volume, 62.5)
 
     def testPocketToFirstCase(self):
         self.Body = self.Doc.addObject('PartDesign::Body','Body')


### PR DESCRIPTION
This PR displays a message when the result of an operation in Part Design would result in multiple solids within the Body.   Please merge when convenient.  Thanks,

- PartDesign only uses the first result shape
  of an operation and discards the rest without
  warning. 

- this also fixes #1707

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
