### PR TITLE
python3: ConfigParser -> RawConfigParser

### DIFF
--- a/src/Mod/Material/Material.py
+++ b/src/Mod/Material/Material.py
@@ -56,7 +56,7 @@ def importFCMat(fileName):
     except ImportError:
         import configparser
 
-    Config = configparser.ConfigParser()
+    Config = configparser.RawConfigParser()
     Config.optionxform = str
     Config.read(fileName)
     dict1 = {}
@@ -75,7 +75,7 @@ def exportFCMat(fileName,matDict):
     except ImportError:
         import configparser
     import string
-    Config = configparser.ConfigParser()
+    Config = configparser.RawConfigParser()
 
     # create groups
     for x in matDict.keys():


### PR DESCRIPTION
"%"-symbol makes problems with python3
not tested with python2, but I hope it's covered by the tests.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
