### PR TITLE
Unbreak build against Boost 1.67

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -596,6 +596,11 @@ endif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     find_package(Boost ${BOOST_MIN_VERSION}
         COMPONENTS filesystem program_options regex signals system thread REQUIRED)
 
+    if(UNIX AND NOT APPLE)
+        # Boost.Thread 1.67+ headers reference pthread_condattr_*
+        list(APPEND Boost_LIBRARIES pthread)
+    endif()
+
     IF(NOT Boost_FOUND)
         MESSAGE(FATAL_ERROR "========================================\n"
                             "boost not found, install the components:\n"


### PR DESCRIPTION
Regressed by https://github.com/boostorg/thread/commit/1e84b978b2bb. Found [downstream](https://reviews.freebsd.org/D15030) ([error log](http://package23.nyi.freebsd.org/data/111i386-default-PR227427/2018-04-16_14h20m42s/logs/errors/FreeCAD-0.17.12018_2.log)).

```c++
$ cat foo.cc
#include <boost/thread.hpp>

void foo() {}

int main()
{
  boost::thread thr(foo);
  return 0;
}

$ clang++ -fuse-ld=lld foo.cc -I/usr/local/include -L/usr/local/lib/ -lboost_thread -lboost_system
/usr/bin/ld.lld: error: undefined symbol: pthread_condattr_init
>>> referenced by foo.cc
>>>               /tmp/foo-060c75.o:(boost::pthread::cond_init(pthread_cond*&))

/usr/bin/ld.lld: error: undefined symbol: pthread_condattr_setclock
>>> referenced by foo.cc
>>>               /tmp/foo-060c75.o:(boost::pthread::cond_init(pthread_cond*&))

/usr/bin/ld.lld: error: undefined symbol: pthread_condattr_destroy
>>> referenced by foo.cc
>>>               /tmp/foo-060c75.o:(boost::pthread::cond_init(pthread_cond*&))
```
