### PR TITLE
Fix Draft Workbench with python3

### DIFF
--- a/src/Mod/Arch/ArchWall.py
+++ b/src/Mod/Arch/ArchWall.py
@@ -611,9 +611,9 @@ class _Wall(ArchComponent.Component):
         if hasattr(obj,"MakeBlocks"):
             fvol = obj.BlockLength.Value * obj.BlockHeight.Value * obj.Width.Value
             if fvol:
-                print "base volume:",fvol
+                print("base volume:",fvol)
                 for s in base.Solids:
-                    print abs(s.Volume - fvol)
+                    print(abs(s.Volume - fvol))
                 ents = [s for s in base.Solids if abs(s.Volume - fvol) < 1]
                 obj.CountEntire = len(ents)
                 obj.CountBroken = len(base.Solids) - len(ents)

--- a/src/Mod/Draft/Draft.py
+++ b/src/Mod/Draft/Draft.py
@@ -6133,8 +6133,10 @@ class _ShapeString(_DraftObject):
             ff8 = obj.FontFile.encode('utf8')                  # 1947 accents in filepath
                                                                # TODO: change for Py3?? bytes?
                                                                # Part.makeWireString uses FontFile as char* string
-#            CharList = Part.makeWireString(obj.String,obj.FontFile,obj.Size,obj.Tracking)
-            CharList = Part.makeWireString(obj.String,ff8,obj.Size,obj.Tracking)
+            if sys.version_info.major < 3:
+                CharList = Part.makeWireString(obj.String,ff8,obj.Size,obj.Tracking)
+            else:
+                CharList = Part.makeWireString(obj.String,obj.FontFile,obj.Size,obj.Tracking)
             if len(CharList) == 0:
                 msg(translate("draft","ShapeString: string has no wires\n"), 'warning')
                 return
@@ -6142,8 +6144,7 @@ class _ShapeString(_DraftObject):
 
             # test a simple letter to know if we have a sticky font or not
             sticky = False
-#            testWire = Part.makeWireString("L",obj.FontFile,obj.Size,obj.Tracking)[0][0]
-            testWire = Part.makeWireString("L",ff8,obj.Size,obj.Tracking)[0][0]
+            testWire = Part.makeWireString("L",obj.FontFile,obj.Size,obj.Tracking)[0][0]
             if testWire.isClosed:
                 try:
                     testFace = Part.Face(testWire)

--- a/src/Mod/Draft/Draft.py
+++ b/src/Mod/Draft/Draft.py
@@ -6144,7 +6144,10 @@ class _ShapeString(_DraftObject):
 
             # test a simple letter to know if we have a sticky font or not
             sticky = False
-            testWire = Part.makeWireString("L",obj.FontFile,obj.Size,obj.Tracking)[0][0]
+            if sys.version_info.major < 3:
+                testWire = Part.makeWireString("L",ff8,obj.Size,obj.Tracking)[0][0]
+            else:
+                testWire = Part.makeWireString("L",obj.FontFile,obj.Size,obj.Tracking)[0][0]
             if testWire.isClosed:
                 try:
                     testFace = Part.Face(testWire)

--- a/src/Mod/Draft/DraftTools.py
+++ b/src/Mod/Draft/DraftTools.py
@@ -2204,7 +2204,7 @@ class ShapeString(Creator):
         #print("debug: D_T ShapeString.createObject type(self.SString): "  str(type(self.SString)))
 
         dquote = '"'
-        if type(self.SString) == unicode: # Python3: no more unicode
+        if sys.version_info.major < 3: # Python3: no more unicode
             String  = 'u' + dquote + self.SString.encode('unicode_escape') + dquote
         else:
             String  = dquote + self.SString + dquote


### PR DESCRIPTION
This is fixes loading the Draftworkbench when using python3. As used in openSUSE packages here:

 https://build.opensuse.org/package/show/science/FreeCAD

I have to admit that the test suite is still not fully succeeding on python3 here, but the issues should be independent of this change. I did also not test a python2 build...