### PR TITLE
[Testing] test if boost 1.67 also affects macOS builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -596,7 +596,7 @@ endif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     find_package(Boost ${BOOST_MIN_VERSION}
         COMPONENTS filesystem program_options regex signals system thread REQUIRED)
 
-    if(UNIX AND NOT APPLE)
+    if(UNIX OR APPLE)
         # Boost.Thread 1.67+ headers reference pthread_condattr_*
         list(APPEND Boost_LIBRARIES pthread)
     endif()


### PR DESCRIPTION
Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
