### PR TITLE
Fix finding boost python

### DIFF
--- a/src/Mod/Path/libarea/CMakeLists.txt
+++ b/src/Mod/Path/libarea/CMakeLists.txt
@@ -16,13 +16,17 @@ OPTION(USE_BOOST_PYTHON "use BOOST_PYTHON, otherwise use PYBIND11" ON)
 
 if(USE_BOOST_PYTHON)
     if(NOT FREECAD_LIBPACK_USE OR FREECAD_LIBPACK_CHECKFILE_CLBUNDLER)
-        if(NOT PYTHON_VERSION_MAJOR LESS 3)
-            find_package( Boost COMPONENTS python3)
-            if (NOT Boost_PYTHON3_FOUND)
+        # boost-python >= 1.67 on some platforms has suffix
+        set(BOOST_PY_SUFFIX ${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR})
+
+        find_package( Boost COMPONENTS python${BOOST_PY_SUFFIX} )
+        if (NOT Boost_PYTHON${BOOST_PY_SUFFIX}_FOUND)
+            # try just the major version
+            find_package( Boost COMPONENTS python${PYTHON_VERSION_MAJOR} )
+            if (NOT Boost_PYTHON${PYTHON_VERSION_MAJOR}_FOUND)
+                # unversioned
                 find_package( Boost COMPONENTS python REQUIRED)
             endif()
-        else()
-            find_package( Boost COMPONENTS python REQUIRED)  # find BOOST and boost-python
         endif()
 
         if(Boost_FOUND)


### PR DESCRIPTION
Boost >= 1.67 requires a version suffix (on macOS at least)
