### PR TITLE
Fix #3367: view/data pane is unselected if hatch type is changed

### DIFF
--- a/src/Mod/TechDraw/App/CMakeLists.txt
+++ b/src/Mod/TechDraw/App/CMakeLists.txt
@@ -42,6 +42,7 @@ generate_from_xml(DrawGeomHatchPy)
 generate_from_xml(DrawViewCollectionPy)
 generate_from_xml(DrawProjGroupPy)
 generate_from_xml(DrawProjGroupItemPy)
+generate_from_xml(DrawViewAnnotationPy)
 
 SET(Draw_SRCS
     DrawPage.cpp
@@ -143,7 +144,9 @@ SET(Python_SRCS
     DrawProjGroupPy.xml
     DrawProjGroupPyImp.cpp
     DrawProjGroupItemPy.xml
-    DrawProjGroupItemPyImp.cpp)
+    DrawProjGroupItemPyImp.cpp
+    DrawViewAnnotationPy.xml
+    DrawViewAnnotationPyImp.cpp)
 
 SOURCE_GROUP("Mod" FILES ${TechDraw_SRCS})
 SOURCE_GROUP("Features" FILES ${Draw_SRCS})

--- a/src/Mod/TechDraw/App/DrawPage.h
+++ b/src/Mod/TechDraw/App/DrawPage.h
@@ -88,6 +88,7 @@ public:
     const char* getPageOrientation() const;
     bool isUnsetting(void) { return nowUnsetting; }
     void requestPaint(void);
+    std::vector<App::DocumentObject*> getAllViews(void) ;
 
 
 protected:

--- a/src/Mod/TechDraw/App/DrawPagePy.xml
+++ b/src/Mod/TechDraw/App/DrawPagePy.xml
@@ -23,6 +23,11 @@
         <UserDocu>removeView(DrawView) - Remove a View to this Page</UserDocu>
       </Documentation>
     </Methode>
+    <Methode Name="getAllViews">
+      <Documentation>
+        <UserDocu>getAllViews() - returns a list of all the views on page including Views inside Collections</UserDocu>
+      </Documentation>
+    </Methode>
     <Methode Name="getPageWidth">
       <Documentation>
         <UserDocu>Return the width of this page</UserDocu>

--- a/src/Mod/TechDraw/App/DrawPagePyImp.cpp
+++ b/src/Mod/TechDraw/App/DrawPagePyImp.cpp
@@ -6,9 +6,15 @@
 
 #include "DrawPage.h"
 #include "DrawView.h"
+#include "DrawViewPart.h"
+#include "DrawProjGroup.h"
+#include "DrawProjGroupItem.h"
 
 // inclusion of the generated files
 #include <Mod/TechDraw/App/DrawViewPy.h>
+#include <Mod/TechDraw/App/DrawViewPartPy.h>
+#include <Mod/TechDraw/App/DrawProjGroupItemPy.h>
+#include <Mod/TechDraw/App/DrawViewAnnotationPy.h>
 #include <Mod/TechDraw/App/DrawPagePy.h>
 #include <Mod/TechDraw/App/DrawPagePy.cpp>
 
@@ -70,6 +76,30 @@ PyObject* DrawPagePy::removeView(PyObject* args)
 #endif
 }
 
+PyObject* DrawPagePy::getAllViews(PyObject* args)
+{
+    (void) args;
+    DrawPage* page = getDrawPagePtr();
+    std::vector<App::DocumentObject*> allViews = page->getAllViews();
+
+    PyObject* ret = PyList_New(0);
+    for (auto&v: allViews) {
+        if (v->isDerivedFrom(TechDraw::DrawProjGroupItem::getClassTypeId())) {
+            TechDraw::DrawProjGroupItem* dpgi = static_cast<TechDraw::DrawProjGroupItem*>(v);
+            PyList_Append(ret,new TechDraw::DrawProjGroupItemPy(dpgi));   //is this legit? or need to make new copy of dv?
+        } else if (v->isDerivedFrom(TechDraw::DrawViewPart::getClassTypeId())) {
+            TechDraw::DrawViewPart* dvp = static_cast<TechDraw::DrawViewPart*>(v);
+            PyList_Append(ret,new TechDraw::DrawViewPartPy(dvp));
+        } else if (v->isDerivedFrom(TechDraw::DrawViewAnnotation::getClassTypeId())) {
+            TechDraw::DrawViewAnnotation* dva = static_cast<TechDraw::DrawViewAnnotation*>(v);
+            PyList_Append(ret,new TechDraw::DrawViewAnnotationPy(dva));
+        } else {
+            TechDraw::DrawView* dv = static_cast<TechDraw::DrawView*>(v);
+            PyList_Append(ret,new TechDraw::DrawViewPy(dv));
+        }
+    }
+    return ret;
+}
 
 //    double getPageWidth() const;
 PyObject* DrawPagePy::getPageWidth(PyObject *)

--- a/src/Mod/TechDraw/App/DrawUtil.cpp
+++ b/src/Mod/TechDraw/App/DrawUtil.cpp
@@ -433,6 +433,7 @@ double DrawUtil::getDefaultLineWeight(std::string lineType)
     auto lg = LineGroup::lineGroupFactory(lgName);
     
     double weight = lg->getWeight(lineType);
+    delete lg;                                    //Coverity CID 174671
     return weight;
 }
 

--- a/src/Mod/TechDraw/App/DrawViewAnnotationPy.xml
+++ b/src/Mod/TechDraw/App/DrawViewAnnotationPy.xml
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<GenerateModel xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="generateMetaModel_Module.xsd">
+  <PythonExport
+    Father="DrawViewPy"
+    Name="DrawViewAnnotationPy"
+    Twin="DrawViewAnnotation"
+    TwinPointer="DrawViewAnnotation"
+    Include="Mod/TechDraw/App/DrawViewAnnotation.h"
+    Namespace="TechDraw"
+    FatherInclude="Mod/TechDraw/App/DrawViewPy.h"
+    FatherNamespace="TechDraw">
+    <Documentation>
+      <Author Licence="LGPL" Name="WandererFan" EMail="wandererfan@gmail.com" />
+      <UserDocu>Feature for creating and manipulating Technical Drawing Annotation Views</UserDocu>
+    </Documentation>
+   <CustomAttributes />
+  </PythonExport>
+</GenerateModel>

--- a/src/Mod/TechDraw/App/DrawViewAnnotationPyImp.cpp
+++ b/src/Mod/TechDraw/App/DrawViewAnnotationPyImp.cpp
@@ -1,0 +1,58 @@
+/***************************************************************************
+ *   Copyright (c) 2018 WandererFan   (wandererfan@gmail.com)              *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+
+#include "PreCompiled.h"
+
+#ifndef _PreComp_
+# include <sstream>
+#endif
+
+#include <App/DocumentObject.h>
+#include <Base/Console.h>
+
+#include "DrawPage.h"
+#include "DrawView.h"
+#include "DrawViewAnnotation.h"
+
+// inclusion of the generated files
+#include <Mod/TechDraw/App/DrawViewPy.h>
+#include <Mod/TechDraw/App/DrawViewAnnotationPy.h>
+#include <Mod/TechDraw/App/DrawViewAnnotationPy.cpp>
+
+using namespace TechDraw;
+
+// returns a string which represents the object e.g. when printed in python
+std::string DrawViewAnnotationPy::representation(void) const
+{
+    return std::string("<DrawViewAnnotation object>");
+}
+
+PyObject *DrawViewAnnotationPy::getCustomAttributes(const char* ) const
+{
+    return 0;
+}
+
+int DrawViewAnnotationPy::setCustomAttributes(const char* , PyObject *)
+{
+    return 0;
+}

--- a/src/Mod/TechDraw/Gui/DrawGuiUtil.cpp
+++ b/src/Mod/TechDraw/Gui/DrawGuiUtil.cpp
@@ -75,18 +75,8 @@ using namespace TechDrawGui;
 //find a page in Selection, Document or CurrentWindow.
 TechDraw::DrawPage* DrawGuiUtil::findPage(Gui::Command* cmd)
 {
-    TechDraw::DrawPage* page = nullptr;
+    TechDraw::DrawPage* page;
     bool warn = true;
-
-    //default to currently displayed DrawPage is there is one
-    Gui::MainWindow* w = Gui::getMainWindow();
-    Gui::MDIView* mv = w->activeWindow();
-    MDIViewPage* mvp = dynamic_cast<MDIViewPage*>(mv);
-    if (mvp) {
-        QString windowTitle = mvp->windowTitle();
-        QGVPage* qp = mvp->getQGVPage();
-        page = qp->getDrawPage();
-    }
 
     //check Selection and/or Document for a DrawPage
     std::vector<App::DocumentObject*> selPages = cmd->getSelection().getObjectsOfType(TechDraw::DrawPage::getClassTypeId());
@@ -112,6 +102,18 @@ TechDraw::DrawPage* DrawGuiUtil::findPage(Gui::Command* cmd)
         warn = false;
     } else {                                                           //use only page in selection
         page = static_cast<TechDraw::DrawPage*>(selPages.front());
+    }
+
+    //default to currently displayed DrawPage is there is one         //code moved Coverity CID 174668
+    if (page == nullptr) {
+        Gui::MainWindow* w = Gui::getMainWindow();
+        Gui::MDIView* mv = w->activeWindow();
+        MDIViewPage* mvp = dynamic_cast<MDIViewPage*>(mv);
+        if (mvp) {
+            QString windowTitle = mvp->windowTitle();
+            QGVPage* qp = mvp->getQGVPage();
+            page = qp->getDrawPage();
+        }
     }
 
     if ((page == nullptr) && 

--- a/src/Mod/TechDraw/Gui/MDIViewPage.h
+++ b/src/Mod/TechDraw/Gui/MDIViewPage.h
@@ -55,11 +55,13 @@ public:
     MDIViewPage(ViewProviderPage *page, Gui::Document* doc, QWidget* parent = 0);
     virtual ~MDIViewPage();
 
-    /// Observer message from the Selection
+    /// Observer message from the Tree Selection mechanism
     void onSelectionChanged(const Gui::SelectionChanges& msg);
     void preSelectionChanged(const QPoint &pos);
-    void selectFeature(App::DocumentObject *obj, bool state);
-    void clearSelection();
+
+    /// QGraphicsScene seletion routines
+    void selectQGIView(App::DocumentObject *obj, bool state);
+    void clearSceneSelection();
     void blockSelection(bool isBlocked);
 
     void attachTemplate(TechDraw::DrawTemplate *obj);
@@ -100,7 +102,7 @@ public Q_SLOTS:
     void setRenderer(QAction *action);
     void viewAll();
     void saveSVG(void);
-    void selectionChanged();
+    void sceneSelectionChanged();
 
 protected:
     void findMissingViews( const std::vector<App::DocumentObject*> &list, std::vector<App::DocumentObject*> &missing);
@@ -120,6 +122,9 @@ protected:
 
     typedef boost::BOOST_SIGNALS_NAMESPACE::connection Connection;
     Connection connectDeletedObject;
+
+    bool compareSelections(std::vector<Gui::SelectionObject>& treeSel,QList<QGraphicsItem*>& sceneSel);
+    void setTreeToSceneSelect(void);
 
 private:
     QAction *m_nativeAction;

--- a/src/Mod/TechDraw/Gui/QGICenterLine.cpp
+++ b/src/Mod/TechDraw/Gui/QGICenterLine.cpp
@@ -44,6 +44,7 @@ QGICenterLine::QGICenterLine()
     setWidth(0.0);
     setStyle(getCenterStyle());
     setColor(getCenterColor());
+    m_isintersection = false;              //Coverity CID 174669
 }
 
 void QGICenterLine::draw()

--- a/src/Mod/TechDraw/Gui/QGIView.cpp
+++ b/src/Mod/TechDraw/Gui/QGIView.cpp
@@ -60,6 +60,7 @@
 #include "QGCustomClip.h"
 #include "QGIViewClip.h"
 #include "ViewProviderDrawingView.h"
+#include "MDIViewPage.h"
 
 #include <Mod/TechDraw/App/DrawViewClip.h>
 #include <Mod/TechDraw/App/DrawProjGroup.h>
@@ -296,6 +297,11 @@ const char * QGIView::getViewName() const
 {
     return viewName.c_str();
 }
+const std::string QGIView::getViewNameAsString() const
+{
+    return viewName;
+}
+
 
 TechDraw::DrawView * QGIView::getViewObject() const
 {
@@ -481,6 +487,22 @@ Gui::ViewProvider* QGIView::getViewProvider(App::DocumentObject* obj)
     return result;
 }
 
+MDIViewPage* QGIView::getMDIViewPage(void) const
+{
+    MDIViewPage* result = nullptr;
+    QGraphicsScene* s = scene();
+    QObject* parent = nullptr;
+    if (s != nullptr) {
+        parent = s->parent();
+    }
+    if (parent != nullptr) {
+        MDIViewPage* mdi = dynamic_cast<MDIViewPage*>(parent);
+        if (mdi != nullptr) {
+            result = mdi;
+        }
+    }
+    return result;
+}
 
 QColor QGIView::getNormalColor()
 {

--- a/src/Mod/TechDraw/Gui/QGIView.h
+++ b/src/Mod/TechDraw/Gui/QGIView.h
@@ -46,6 +46,7 @@ class QGCustomBorder;
 class QGCustomLabel;
 class QGCustomText;
 class QGICaption;
+class MDIViewPage;
 
 class TechDrawGuiExport  QGIView : public QGraphicsItemGroup
 {
@@ -61,7 +62,8 @@ public:
                         const QStyleOptionGraphicsItem *option,
                         QWidget *widget = nullptr ) override;
 
-    const char * getViewName() const;
+    const char *      getViewName() const;
+    const std::string getViewNameAsString() const;
     void setViewFeature(TechDraw::DrawView *obj);
     TechDraw::DrawView * getViewObject() const;
 
@@ -92,6 +94,7 @@ public:
     virtual QColor getSelectColor(void);
     
     static Gui::ViewProvider* getViewProvider(App::DocumentObject* obj);
+    MDIViewPage* getMDIViewPage(void) const;
 
 protected:
     QGIView* getQGIVByName(std::string name);

--- a/src/Mod/TechDraw/Gui/QGVPage.cpp
+++ b/src/Mod/TechDraw/Gui/QGVPage.cpp
@@ -38,10 +38,12 @@
 #endif
 
 #include <App/Application.h>
+#include <App/Document.h>
 #include <App/Material.h>
 #include <Base/Console.h>
 #include <Base/Stream.h>
 #include <Gui/FileDialog.h>
+#include <Gui/Selection.h>
 #include <Gui/WaitCursor.h>
 
 #include <Mod/TechDraw/App/Geometry.h>

--- a/src/Mod/TechDraw/Gui/ViewProviderDimension.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderDimension.cpp
@@ -68,6 +68,7 @@ ViewProviderDimension::ViewProviderDimension()
     std::string lgName = hGrp->GetASCII("LineGroup","FC 0.70mm");
     auto lg = TechDraw::LineGroup::lineGroupFactory(lgName);
     double weight = lg->getWeight("Thin");
+    delete lg;                                   //Coverity CID 174670
     ADD_PROPERTY_TYPE(LineWidth,(weight)    ,group,(App::PropertyType)(App::Prop_None),"Dimension line weight");
 
     hGrp = App::GetApplication().GetUserParameter()

--- a/src/Mod/TechDraw/Gui/ViewProviderGeomHatch.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderGeomHatch.cpp
@@ -194,6 +194,7 @@ void ViewProviderGeomHatch::getParameters(void)
     std::string lgName = hGrp->GetASCII("LineGroup","FC 0.70mm");
     auto lg = TechDraw::LineGroup::lineGroupFactory(lgName);
     double weight = lg->getWeight("Graphic");
+    delete lg;                                                    //Coverity CID 174667
     WeightPattern.setValue(weight);
 }
 

--- a/src/Mod/TechDraw/Gui/ViewProviderPage.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderPage.cpp
@@ -37,8 +37,6 @@
 /// Here the FreeCAD includes sorted by Base,App,Gui......
 #include <Base/Console.h>
 #include <Base/Parameter.h>
-#include <Base/Exception.h>
-#include <Base/Sequencer.h>
 
 #include <App/Application.h>
 #include <App/Document.h>
@@ -46,15 +44,9 @@
 
 #include <Gui/Application.h>
 #include <Gui/BitmapFactory.h>
-#include <Gui/Command.h>
-#include <Gui/Control.h>
 #include <Gui/Document.h>
 #include <Gui/MainWindow.h>
-#include <Gui/Selection.h>
-#include <Gui/ViewProvider.h>
 #include <Gui/ViewProviderDocumentObject.h>
-#include <Gui/ViewProviderDocumentObjectGroup.h>
-
 
 #include "MDIViewPage.h"
 #include "ViewProviderPage.h"
@@ -291,50 +283,6 @@ MDIViewPage* ViewProviderPage::getMDIViewPage()
     }
 }
 
-void ViewProviderPage::onSelectionChanged(const Gui::SelectionChanges& msg)
-{
-    if(!m_mdiView.isNull()) {
-        if(msg.Type == Gui::SelectionChanges::SetSelection) {
-            m_mdiView->clearSelection();
-            std::vector<Gui::SelectionSingleton::SelObj> objs = Gui::Selection().getSelection(msg.pDocName);
-
-            for (std::vector<Gui::SelectionSingleton::SelObj>::iterator it = objs.begin(); it != objs.end(); ++it) {
-                Gui::SelectionSingleton::SelObj selObj = *it;
-                if(selObj.pObject == getDrawPage())
-                    continue;
-
-                std::string str = msg.pSubName;
-                // If it's a subfeature, don't select feature
-                if (!str.empty()) {
-                    if (TechDraw::DrawUtil::getGeomTypeFromName(str) == "Face" ||
-                        TechDraw::DrawUtil::getGeomTypeFromName(str) == "Edge" ||
-                        TechDraw::DrawUtil::getGeomTypeFromName(str) == "Vertex") {
-                        // TODO implement me   wf: don't think this is ever executed
-                    }
-                } else {
-                        m_mdiView->selectFeature(selObj.pObject, true);
-                }
-            }
-        } else {
-            bool selectState = (msg.Type == Gui::SelectionChanges::AddSelection) ? true : false;
-            Gui::Document* doc = Gui::Application::Instance->getDocument(pcObject->getDocument());
-            App::DocumentObject *obj = doc->getDocument()->getObject(msg.pObjectName);
-            if(obj) {
-                std::string str = msg.pSubName;
-                // If it's a subfeature, don't select feature
-                if (!str.empty()) {
-                    if (TechDraw::DrawUtil::getGeomTypeFromName(str) == "Face" ||
-                        TechDraw::DrawUtil::getGeomTypeFromName(str) == "Edge" ||
-                        TechDraw::DrawUtil::getGeomTypeFromName(str) == "Vertex") {
-                        // TODO implement me
-                    } else {
-                        m_mdiView->selectFeature(obj, selectState);
-                    }
-                }
-            }
-        }  //else (Gui::SelectionChanges::SetPreselect)
-    }
-}
 
 void ViewProviderPage::onChanged(const App::Property *prop)
 {

--- a/src/Mod/TechDraw/Gui/ViewProviderPage.h
+++ b/src/Mod/TechDraw/Gui/ViewProviderPage.h
@@ -26,9 +26,7 @@
 #define DRAWINGGUI_VIEWPROVIDERPAGE_H
 
 #include <QPointer>
-#include <Gui/ViewProviderFeature.h>
-#include <Gui/ViewProviderDocumentObjectGroup.h>
-#include <Gui/Selection.h>
+#include <Gui/ViewProviderDocumentObject.h>
 
 namespace TechDraw{
     class DrawPage;
@@ -38,8 +36,7 @@ namespace TechDrawGui {
 
 class MDIViewPage;
 
-class TechDrawGuiExport ViewProviderPage : public Gui::ViewProviderDocumentObject,
-                                                 public Gui::SelectionObserver
+class TechDrawGuiExport ViewProviderPage : public Gui::ViewProviderDocumentObject
 {
     PROPERTY_HEADER(TechDrawGui::ViewProviderPage);
 
@@ -48,10 +45,6 @@ public:
     ViewProviderPage();
     /// destructor
     virtual ~ViewProviderPage();
-
-    //App::PropertyFloat         HintScale;
-    //App::PropertyFloat         HintOffsetX;
-    //App::PropertyFloat         HintOffsetY;
 
     virtual void attach(App::DocumentObject *);
     virtual void setDisplayMode(const char* ModeName);
@@ -63,8 +56,6 @@ public:
     /// Shows the view provider
     virtual void show(void);
     virtual bool isShow(void) const;
-
-    void onSelectionChanged(const Gui::SelectionChanges& msg);
 
     /// Claim all the views for the page
     std::vector<App::DocumentObject*> claimChildren(void) const;

--- a/src/Mod/TechDraw/Gui/ViewProviderViewPart.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderViewPart.cpp
@@ -76,6 +76,7 @@ ViewProviderViewPart::ViewProviderViewPart()
 
     weight = lg->getWeight("Extra");
     ADD_PROPERTY_TYPE(ExtraWidth,(weight),group,App::Prop_None,"The thickness of LineGroup Extra lines, if enabled");
+    delete lg;                            //Coverity CID 174664
 
     //decorations
     ADD_PROPERTY_TYPE(HorizCenterLine ,(false),dgroup,App::Prop_None,"Show a horizontal centerline through view");


### PR DESCRIPTION
This PR fixes Mantis issue #3367 which involved a problem with object selection in the Tree when a sub-object was already selected in the QGraphicsScene.

It also includes Coverity fixes and implements some missing Python functions.

Please merge. 


Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
