### PR TITLE
flatmesh: missing include

### DIFF
--- a/src/Mod/MeshPart/App/MeshFlatteningLscmRelax.cpp
+++ b/src/Mod/MeshPart/App/MeshFlatteningLscmRelax.cpp
@@ -33,6 +33,7 @@
 #include <map>
 #include <vector>
 #include <tuple>
+#include <array>
 
 #ifndef M_PI
 #define M_PI    3.14159265358979323846f

--- a/src/Mod/MeshPart/Gui/MeshFlatteningCommand.py
+++ b/src/Mod/MeshPart/Gui/MeshFlatteningCommand.py
@@ -3,8 +3,6 @@ import FreeCAD as App
 import FreeCADGui as Gui
 import Part
 import numpy as np
-#from pivy import graphics as g
-#from pivy import coin
 
 class BaseCommand(object):
     def __init__(self):
@@ -82,5 +80,10 @@ class CreateFlatFace(BaseCommand):
         assert(isinstance(Gui.Selection.getSelectionEx()[0].SubObjects[0], Part.Face))
         return True
 
-Gui.addCommand('MeshPart_CreateFlatMesh', CreateFlatMesh())
-Gui.addCommand('MeshPart_CreateFlatFace', CreateFlatFace())
+try:
+    import flatmesh
+    Gui.addCommand('MeshPart_CreateFlatMesh', CreateFlatMesh())
+    Gui.addCommand('MeshPart_CreateFlatFace', CreateFlatFace())
+except ImportError:
+    App.Console.PrintLog("flatmesh-commands are not available")
+    App.Console.PrintLog("flatmesh needs pybind11 as build dependency")


### PR DESCRIPTION
- add a missing include
- don't show commands if no flatmesh is available