### PR TITLE
Path: fix Path.Area accuracy setting - fixes issue 3449

### DIFF
--- a/src/Mod/Path/InitGui.py
+++ b/src/Mod/Path/InitGui.py
@@ -137,7 +137,9 @@ class PathWorkbench (Workbench):
 
         self.dressupcmds = dressupcmdlist
 
-        Path.Area.setDefaultParams(Accuracy = PathPreferences.defaultLibAreaCurveAccuracy())
+        curveAccuracy = PathPreferences.defaultLibAreaCurveAccuracy()
+        if curveAccuracy:
+            Path.Area.setDefaultParams(curveAccuracy)
 
         Log('Loading Path workbench... done\n')
 

--- a/src/Mod/Path/PathScripts/PathPreferencesPathJob.py
+++ b/src/Mod/Path/PathScripts/PathPreferencesPathJob.py
@@ -24,6 +24,7 @@
 
 import FreeCAD
 import FreeCADGui
+import Path
 import PathScripts.PathLog as PathLog
 import PathScripts.PathStock as PathStock
 import json
@@ -52,6 +53,9 @@ class JobPreferencesPage:
         geometryTolerance = Units.Quantity(self.form.geometryTolerance.text())
         curveAccuracy = Units.Quantity(self.form.curveAccuracy.text())
         PathPreferences.setJobDefaults(filePath, jobTemplate, geometryTolerance, curveAccuracy)
+
+        if curveAccuracy:
+            Path.Area.setDefaultParams(Accuracy = curveAccuracy)
 
         processor = str(self.form.defaultPostProcessor.currentText())
         args = str(self.form.defaultPostProcessorArgs.text())


### PR DESCRIPTION
Only setting Path.Area curve accuracy if it is not, and also set it when Preferences get saved.

https://www.freecadweb.org/tracker/view.php?id=3449