### PR TITLE
Move Dxf functions to Mod/Import Ph3

### DIFF
--- a/src/Mod/Draft/App/AppDraftUtilsPy.cpp
+++ b/src/Mod/Draft/App/AppDraftUtilsPy.cpp
@@ -56,6 +56,7 @@ public:
 private:
     Py::Object readDXF(const Py::Tuple& args)
     {
+        Base::Console().Warning("DraftUtils.readDXF is deprecated. Use Import.readDxf instead.\n");
         char* Name;
         const char* DocName=0;
         bool IgnoreErrors=true;

--- a/src/Mod/Draft/importDXF.py
+++ b/src/Mod/Draft/importDXF.py
@@ -1570,8 +1570,8 @@ def open(filename):
         doc = FreeCAD.newDocument(docname)
         doc.Label = decodeName(docname)
         FreeCAD.setActiveDocument(doc.Name)
-        import DraftUtils
-        DraftUtils.readDXF(filename)
+        import Import
+        Import.readDXF(filename)
 
 def insert(filename,docname):
     "called when freecad imports a file"
@@ -1597,8 +1597,8 @@ def insert(filename,docname):
         else:
             errorDXFLib(gui)
     else:
-        import DraftUtils
-        DraftUtils.readDXF(filename)
+        import Import
+        Import.readDXF(filename)
 
 def getShapes(filename):
     "reads a dxf file and returns a list of shapes from its contents"


### PR DESCRIPTION
This PR is the last of a series that will:
* move c++ dxf import functions *from Draft to Import
* implement c++ dxf export functions
* add functions to TechDraw to export Dxf versions of Pages & Views
* change Draft importDXF to use Mod/Import version of the importer.

Please merge.
Thanks,
wf


Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
