### PR TITLE
draft: fix snapping with images

### DIFF
--- a/src/Mod/Draft/DraftSnap.py
+++ b/src/Mod/Draft/DraftSnap.py
@@ -237,7 +237,7 @@ class Snapper:
             point,eline = self.snapToPolar(point,lastpoint)
             point,eline = self.snapToExtensions(point,lastpoint,constrain,eline)
             
-        if not self.snapInfo:
+        if not self.snapInfo or "Component" not in self.snapInfo:
             # nothing has been snapped
             
             # check for grid snap and ext crossings


### PR DESCRIPTION
@yorik minimal fix. Somehow snapping was broken if an image was in the scene. I needed this recently. I guess the "Component" key is necessery for objects to work with the snapper...