### PR TITLE
Fix compilation with GCC 8

### DIFF
--- a/src/3rdParty/salomesmesh/inc/SMESH_Algo.hxx
+++ b/src/3rdParty/salomesmesh/inc/SMESH_Algo.hxx
@@ -30,6 +30,7 @@
 
 #include "SMESH_SMESH.hxx"
 
+#include "SMDS_MeshNode.hxx"
 #include "SMDSAbs_ElementType.hxx"
 #include "SMESH_Comment.hxx"
 #include "SMESH_ComputeError.hxx"
@@ -45,7 +46,6 @@
 #include <map>
 #include <set>
 
-class SMDS_MeshNode;
 class SMESHDS_Mesh;
 class SMESHDS_SubMesh;
 class SMESH_Gen;


### PR DESCRIPTION
GCC 8 added some asserts in the STL such that having just this forward declaration isn't enough to compile SMESH anymore. Add this missing include.