### PR TITLE
Fix typo in AddonManager

### DIFF
--- a/src/Mod/AddonManager/AddonManager.py
+++ b/src/Mod/AddonManager/AddonManager.py
@@ -944,7 +944,7 @@ class InstallWorker(QtCore.QThread):
                         os.makedirs(macro_dir)
                     for f in os.listdir(clonedir):
                         if f.lower().endswith(".fcmacro"):
-                            symlink(os.path.join(clonedir, f), os.path.joint(macro_dir, f))
+                            symlink(os.path.join(clonedir, f), os.path.join(macro_dir, f))
                             FreeCAD.ParamGet('User parameter:Plugins/'+self.repos[idx][0]).SetString("destination",clonedir)
                             answer += translate("AddonsInstaller", "A macro has been installed and is available the Macros menu") + ": <b>"
                             answer += f + "</b>"


### PR DESCRIPTION
AddonManager has a typo which generates this error: 
Traceback (most recent call last):
  File "/usr/lib/freecad-daily/Mod/AddonManager/AddonManager.py", line 947, in run
    symlink(os.path.join(clonedir, f), os.path.joint(macro_dir, f))
AttributeError: 'module' object has no attribute 'joint'

This PR corrects the typo.  Please merge. 
Thanks,
wf

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
