### PR TITLE
osx conda config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -200,6 +200,7 @@ OPTION(FREECAD_USE_EXTERNAL_KDL "Use system installed orocos-kdl instead of the 
 OPTION(FREECAD_USE_FREETYPE "Builds the features using FreeType libs" ON)
 OPTION(FREECAD_BUILD_DEBIAN "Prepare for a build of a Debian package" OFF)
 OPTION(BUILD_WITH_CONDA "Set ON if you build freecad with conda" OFF)
+OPTION(OCCT_CMAKE_FALLBACK "disable usage of occt-config files" OFF)
 if (WIN32 OR APPLE)
     OPTION(FREECAD_USE_QT_FILEDIALOG "Use Qt's file dialog instead of the native one." OFF)
 else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -199,6 +199,7 @@ OPTION(FREECAD_USE_EXTERNAL_SMESH "Use system installed smesh instead of the bun
 OPTION(FREECAD_USE_EXTERNAL_KDL "Use system installed orocos-kdl instead of the bundled." OFF)
 OPTION(FREECAD_USE_FREETYPE "Builds the features using FreeType libs" ON)
 OPTION(FREECAD_BUILD_DEBIAN "Prepare for a build of a Debian package" OFF)
+OPTION(BUILD_WITH_CONDA "Set ON if you build freecad with conda" OFF)
 if (WIN32 OR APPLE)
     OPTION(FREECAD_USE_QT_FILEDIALOG "Use Qt's file dialog instead of the native one." OFF)
 else()
@@ -453,7 +454,7 @@ if(NOT FREECAD_LIBPACK_USE OR FREECAD_LIBPACK_CHECKFILE_CLBUNDLER)
 set(Python_ADDITIONAL_VERSIONS "2.7")
 
 # For building on OS X
-if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin" AND NOT BUILD_WITH_CONDA)
 
     # If the user doesn't tell us which package manager they're using
     if(NOT DEFINED MACPORTS_PREFIX AND NOT DEFINED HOMEBREW_PREFIX)
@@ -563,7 +564,7 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     endif(NOT DEFINED PYTHON_LIBRARY)
 
 
-endif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+endif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin" AND NOT BUILD_WITH_CONDA)
 
     find_package(PythonInterp REQUIRED)
     set(Python_ADDITIONAL_VERSIONS ${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR})

--- a/cMake/FindOpenCasCade.cmake
+++ b/cMake/FindOpenCasCade.cmake
@@ -35,7 +35,9 @@ if(OCE_FOUND)
   #set(OCC_LIBRARY_DIR ${OCE_LIBRARY_DIR})
 else(OCE_FOUND) #look for OpenCASCADE
   # we first try to find opencascade directly:
-  find_package(OpenCASCADE CONFIG QUIET)
+  if(NOT OCCT_CMAKE_FALLBACK)
+    find_package(OpenCASCADE CONFIG QUIET)
+  endif(NOT OCCT_CMAKE_FALLBACK)
   if(OpenCASCADE_FOUND)
     set(OCC_FOUND ${OpenCASCADE_FOUND})
     set(OCC_INCLUDE_DIR ${OpenCASCADE_INCLUDE_DIR})

--- a/src/Main/MainPy.cpp
+++ b/src/Main/MainPy.cpp
@@ -61,7 +61,7 @@ BOOL APIENTRY DllMain(HANDLE hModule, DWORD  ul_reason_for_call, LPVOID lpReserv
         // This name is preliminary, we pass it to Application::init() in initFreeCAD()
         // which does the rest.
         char  szFileName [MAX_PATH];
-        GetModuleFileName((HMODULE)hModule, szFileName, MAX_PATH-1);
+        GetModuleFileNameA((HMODULE)hModule, szFileName, MAX_PATH-1);
         App::Application::Config()["AppHomePath"] = szFileName;
     }
     break;
@@ -98,7 +98,7 @@ PyMOD_INIT_FUNC(FreeCAD)
 #elif defined(FC_OS_CYGWIN)
     HMODULE hModule = GetModuleHandle("FreeCAD.dll");
     char szFileName [MAX_PATH];
-    GetModuleFileName(hModule, szFileName, MAX_PATH-1);
+    GetModuleFileNameA(hModule, szFileName, MAX_PATH-1);
     argv[0] = (char*)malloc(MAX_PATH);
     strncpy(argv[0],szFileName,MAX_PATH);
     argv[0][MAX_PATH-1] = '\0'; // ensure null termination


### PR DESCRIPTION
- conda osx: some small cmake changes to use the default configuration and not special brew, mac-ports config.
- cmake occt: fallback: https://forum.freecadweb.org/viewtopic.php?f=4&t=29009
- windows character conversation problem: https://forum.freecadweb.org/viewtopic.php?f=4&t=29014

not yet tested at all platforms. 