### PR TITLE
Path: Feature/engrave

### DIFF
--- a/src/Mod/Path/PathScripts/PathEngrave.py
+++ b/src/Mod/Path/PathScripts/PathEngrave.py
@@ -106,7 +106,9 @@ class ObjectEngrave(PathOp.ObjectOp):
             elif obj.Base:
                 wires = []
                 for base, subs in obj.Base:
-                    edges = [base.Shape.getElement(sub) for sub in subs]
+                    edges = []
+                    for sub in subs:
+                        edges.extend(base.Shape.getElement(sub).Edges)
                     wires.extend(TechDraw.edgeWalker(edges))
                 output += self.buildpathocc(obj, wires, zValues)
                 self.wires = wires
@@ -124,8 +126,8 @@ class ObjectEngrave(PathOp.ObjectOp):
             self.commandlist.append(Path.Command('G0', {'Z': obj.ClearanceHeight.Value, 'F': self.vertRapid}))
 
         except Exception as e:
-            #PathLog.error("Exception: %s" % e)
-            #traceback.print_exc()
+            PathLog.error("Exception: %s" % e)
+            traceback.print_exc()
             PathLog.error(translate("Path", "The Job Base Object has no engraveable element.  Engraving operation will produce no output."))
 
     def buildpathocc(self, obj, wires, zValues):

--- a/src/Mod/Path/PathScripts/PathEngrave.py
+++ b/src/Mod/Path/PathScripts/PathEngrave.py
@@ -30,6 +30,8 @@ import Path
 import PathScripts.PathLog as PathLog
 import PathScripts.PathOp as PathOp
 import PathScripts.PathUtils as PathUtils
+import TechDraw
+import traceback
 
 from PySide import QtCore
 
@@ -100,6 +102,13 @@ class ObjectEngrave(PathOp.ObjectOp):
                     output += self.buildpathocc(obj, tagWires, zValues)
                     wires.extend(tagWires)
                 self.wires = wires
+            elif obj.Base:
+                wires = []
+                for base, subs in obj.Base:
+                    edges = [base.Shape.getElement(sub) for sub in subs]
+                    wires.extend(TechDraw.edgeWalker(edges))
+                output += self.buildpathocc(obj, wires, zValues)
+                self.wires = wires
             else:
                 raise ValueError('Unknown baseobject type for engraving')
 
@@ -108,6 +117,7 @@ class ObjectEngrave(PathOp.ObjectOp):
 
         except Exception as e:
             #PathLog.error("Exception: %s" % e)
+            #traceback.print_exc()
             PathLog.error(translate("Path", "The Job Base Object has no engraveable element.  Engraving operation will produce no output."))
 
     def buildpathocc(self, obj, wires, zValues):

--- a/src/Mod/Path/PathScripts/PathEngrave.py
+++ b/src/Mod/Path/PathScripts/PathEngrave.py
@@ -57,7 +57,8 @@ class ObjectEngrave(PathOp.ObjectOp):
 
     def initOperation(self, obj):
         '''initOperation(obj) ... create engraving specific properties.'''
-        obj.addProperty("App::PropertyInteger", "StartVertex", "Path", QtCore.QT_TRANSLATE_NOOP("App::Property", "The vertex index to start the path from"))
+        obj.addProperty("App::PropertyInteger", "StartVertex", "Path", QtCore.QT_TRANSLATE_NOOP("PathEngrave", "The vertex index to start the path from"))
+        obj.addProperty("App::PropertyLinkList", "BaseShapes", "Path", QtCore.QT_TRANSLATE_NOOP("PathEngrave", "Additional base objects to be engraved"))
 
     def opExecute(self, obj):
         '''opExecute(obj) ... process engraving operation'''
@@ -109,9 +110,16 @@ class ObjectEngrave(PathOp.ObjectOp):
                     wires.extend(TechDraw.edgeWalker(edges))
                 output += self.buildpathocc(obj, wires, zValues)
                 self.wires = wires
-            else:
+            elif not obj.BaseShapes:
+                PathLog.info("base object: %s" % (obj.Base))
                 raise ValueError('Unknown baseobject type for engraving')
 
+            if obj.BaseShapes:
+                wires = []
+                for shape in obj.BaseShapes:
+                    output += self.buildpathocc(obj, shape.Shape.Wires, zValues)
+                    wires.extend(shape.Shape.Wires)
+                self.wires = wires
             output += "G0 Z" + PathUtils.fmt(obj.ClearanceHeight.Value) + "F " + PathUtils.fmt(self.vertRapid) + "\n"
             self.commandlist.append(Path.Command('G0', {'Z': obj.ClearanceHeight.Value, 'F': self.vertRapid}))
 

--- a/src/Mod/Path/PathScripts/PathEngraveGui.py
+++ b/src/Mod/Path/PathScripts/PathEngraveGui.py
@@ -61,8 +61,12 @@ class TaskPanelBaseGeometryPage(PathOpGui.TaskPanelBaseGeometryPage):
             if sel.Object.isDerivedFrom('Part::Part2DObject'):
                 if sel.HasSubObjects:
                     for sub in sel.SubElementNames:
-                        self.obj.Proxy.addBase(self.obj, sel.Object, sub)
+                        if 'Vertex' in sub:
+                            PathLog.info(translate("Path", "Ignoring vertex"))
+                        else:
+                            self.obj.Proxy.addBase(self.obj, sel.Object, sub)
                 else:
+                    self.obj.Base = [p for p,el in self.obj.Base if p != sel.Object]
                     shapes.append(sel.Object)
                     self.obj.BaseShapes = shapes
                 added = True

--- a/src/Mod/Path/PathScripts/PathEngraveGui.py
+++ b/src/Mod/Path/PathScripts/PathEngraveGui.py
@@ -66,7 +66,7 @@ class TaskPanelBaseGeometryPage(PathOpGui.TaskPanelBaseGeometryPage):
                         else:
                             self.obj.Proxy.addBase(self.obj, sel.Object, sub)
                 else:
-                    self.obj.Base = [p for p,el in self.obj.Base if p != sel.Object]
+                    self.obj.Base = [(p,el) for p,el in self.obj.Base if p != sel.Object]
                     shapes.append(sel.Object)
                     self.obj.BaseShapes = shapes
                 added = True
@@ -92,7 +92,7 @@ class TaskPanelBaseGeometryPage(PathOpGui.TaskPanelBaseGeometryPage):
         for i in range(self.form.baseList.count()):
             item = self.form.baseList.item(i)
             obj = item.data(self.super().DataObject)
-            sub = itme.data(self.super().DataObjectSub)
+            sub = item.data(self.super().DataObjectSub)
             if not sub:
                 shapes.append(obj)
         PathLog.debug("Setting new base shapes: %s -> %s" % (self.obj.BaseShapes, shapes))

--- a/src/Mod/Path/PathScripts/PathEngraveGui.py
+++ b/src/Mod/Path/PathScripts/PathEngraveGui.py
@@ -52,17 +52,25 @@ class TaskPanelBaseGeometryPage(PathOpGui.TaskPanelBaseGeometryPage):
         return super(TaskPanelBaseGeometryPage, self)
 
     def addBaseGeometry(self, selection):
-        if 1 == len(selection) and selection[0].Object.isDerivedFrom('Part::Part2DObject'):
-            sel = selection[0]
-            if sel.HasSubObjects:
-                for sub in sel.SubElementNames:
-                    self.obj.Proxy.addBase(self.obj, sel.Object, sub)
+        added = False
+        shapes = self.obj.BaseShapes
+        for sel in selection:
+            if sel.Object in shapes:
+                PathLog.notice((translate("Path", "Base shape %s already in the list")+"\n") % (sel.Object.Label))
+                continue
+            if sel.Object.isDerivedFrom('Part::Part2DObject'):
+                if sel.HasSubObjects:
+                    for sub in sel.SubElementNames:
+                        self.obj.Proxy.addBase(self.obj, sel.Object, sub)
+                else:
+                    shapes.append(sel.Object)
+                    self.obj.BaseShapes = shapes
+                added = True
             else:
-                shapes = self.obj.BaseShapes
-                shapes.append(sel.Object)
-                self.obj.BaseShapes = shapes
-            return True
-        return self.super().addBaseGeometry(selection)
+                base = self.super().addBaseGeometry(selection)
+                added = added or base
+
+        return added
 
     def setFields(self, obj):
         self.super().setFields(obj)

--- a/src/Mod/Path/PathScripts/PathOp.py
+++ b/src/Mod/Path/PathScripts/PathOp.py
@@ -427,7 +427,7 @@ class ObjectOp(object):
         return result
 
     def addBase(self, obj, base, sub):
-        PathLog.track()
+        PathLog.track(obj, base, sub)
         base = PathUtil.getPublicObject(base)
 
         if self._setBaseAndStock(obj):
@@ -436,10 +436,11 @@ class ObjectOp(object):
             baselist = obj.Base
             if baselist is None:
                 baselist = []
-            item = (base, sub)
-            if item in baselist:
-                PathLog.notice(translate("Path", "This object already in the list")+"\n")
-            else:
-                baselist.append(item)
-                obj.Base = baselist
+            for p, el in baselist:
+                if p == base and sub in el:
+                    PathLog.notice((translate("Path", "Base object %s.%s already in the list")+"\n") % (base.Label, sub))
+                    return
+
+            baselist.append((base, sub))
+            obj.Base = baselist
 

--- a/src/Mod/Path/PathScripts/PathOpGui.py
+++ b/src/Mod/Path/PathScripts/PathOpGui.py
@@ -427,8 +427,9 @@ class TaskPanelBaseGeometryPage(TaskPanelPage):
             item = self.form.baseList.item(i)
             obj = item.data(self.DataObject)
             sub = str(item.data(self.DataObjectSub))
-            base = (obj, sub)
-            newlist.append(base)
+            if sub:
+                base = (obj, sub)
+                newlist.append(base)
         PathLog.debug("Setting new base: %s -> %s" % (self.obj.Base, newlist))
         self.obj.Base = newlist
 

--- a/src/Mod/Path/PathScripts/PathOpGui.py
+++ b/src/Mod/Path/PathScripts/PathOpGui.py
@@ -675,9 +675,9 @@ class TaskPanelDepthsPage(TaskPanelPage):
     def selectionZLevel(self, sel):
         if len(sel) == 1 and len(sel[0].SubObjects) == 1:
             sub = sel[0].SubObjects[0]
+            if 'Vertex' == sub.ShapeType:
+                return sub.Z
             if PathGeom.isHorizontal(sub):
-                if 'Vertex' == sub.ShapeType:
-                    return sub.Z
                 if 'Edge' == sub.ShapeType:
                     return sub.Vertexes[0].Z
                 if 'Face' == sub.ShapeType:

--- a/src/Mod/Path/PathScripts/PathSelection.py
+++ b/src/Mod/Path/PathScripts/PathSelection.py
@@ -50,7 +50,7 @@ class ENGRAVEGate:
         except:
             return False
 
-        if shape.BoundBox.ZLength == 0.0 and len(obj.Wires) > 0:
+        if shape.BoundBox.ZLength == 0.0 and len(shape.Wires) > 0:
             return True
 
         if shape.ShapeType == 'Edge':

--- a/src/Mod/Path/PathScripts/PathSelection.py
+++ b/src/Mod/Path/PathScripts/PathSelection.py
@@ -27,6 +27,7 @@ import FreeCAD
 import FreeCADGui
 import PathScripts.PathLog as PathLog
 import PathScripts.PathUtils as PathUtils
+import math
 
 if False:
     PathLog.setLevel(PathLog.Level.DEBUG, PathLog.thisModule())
@@ -50,7 +51,7 @@ class ENGRAVEGate:
         except:
             return False
 
-        if shape.BoundBox.ZLength == 0.0 and len(shape.Wires) > 0:
+        if math.fabs(shape.Volume) < 1e-9 and len(shape.Wires) > 0:
             return True
 
         if shape.ShapeType == 'Edge':

--- a/src/Mod/Path/PathScripts/PathSelection.py
+++ b/src/Mod/Path/PathScripts/PathSelection.py
@@ -45,16 +45,23 @@ class MESHGate:
 
 class ENGRAVEGate:
     def allow(self, doc, obj, sub):
-        engraveable = False
-        if hasattr(obj, "Shape"):
-            if obj.Shape.BoundBox.ZLength == 0.0:
-                try:
-                    obj = obj.Shape
-                except:
-                    return False
-                if len(obj.Wires) > 0:
-                    engraveable = True
-        return engraveable
+        try:
+            shape = obj.Shape
+        except:
+            return False
+
+        if shape.BoundBox.ZLength == 0.0 and len(obj.Wires) > 0:
+            return True
+
+        if shape.ShapeType == 'Edge':
+            return True
+
+        if sub:
+            subShape = shape.getElement(sub)
+            if subShape.ShapeType == 'Edge':
+                return True
+
+        return False
 
 
 class DRILLGate:

--- a/src/Mod/Path/PathScripts/PathStock.py
+++ b/src/Mod/Path/PathScripts/PathStock.py
@@ -79,7 +79,7 @@ def shapeBoundBox(obj):
 
 class StockFromBase:
 
-    def __init__(self, obj, base, placement):
+    def __init__(self, obj, base):
         "Make stock"
         obj.addProperty("App::PropertyLink", "Base", "Base", QtCore.QT_TRANSLATE_NOOP("PathStock", "The base object this stock is derived from"))
         obj.addProperty("App::PropertyLength", "ExtXneg", "Stock", QtCore.QT_TRANSLATE_NOOP("PathStock", "Extra allowance from part bound box in negative X direction"))
@@ -97,11 +97,6 @@ class StockFromBase:
         obj.ExtZneg= 1.0
         obj.ExtZpos= 1.0
 
-        dPos = placement.Base - base.Placement.Base
-        dRot = placement.Rotation.multiply(base.Placement.Rotation.inverted())
-        dPlacement = FreeCAD.Placement(dPos, dRot)
-        PathLog.debug("%s - %s: %s" % (placement, base.Placement, dPlacement))
-        obj.Placement = dPlacement
         obj.Proxy = self
 
     def __getstate__(self):
@@ -208,10 +203,9 @@ def SetupStockObject(obj, stockType):
         obj.ViewObject.DisplayMode = 'Wireframe'
 
 def CreateFromBase(job, neg=None, pos=None, placement=None):
+    base = job.Base if job and hasattr(job, 'Base') else None
     obj = FreeCAD.ActiveDocument.addObject('Part::FeaturePython', 'Stock')
-    # don't want to use the resrouce clone - we want the real object so 
-    # Base and Stock can be placed independently
-    proxy = StockFromBase(obj, job.Proxy.baseObject(job), job.Base.Placement)
+    proxy = StockFromBase(obj, base)
     if neg:
         obj.ExtXneg = neg.x
         obj.ExtYneg = neg.y


### PR DESCRIPTION
Better integration of the Engrave op:
* Allow engrave of shapestring as part of an existing job (no need to create a specific job for engraving only - although still supported)
* engraving of entire shapestring, or individual letters and/or edges of it
* if shapestring is attached to the base model the placement is recalculated to match the job's setup
* support for individual edges of the base model, don't need to form closed wires (but can)