### PR TITLE
Add Approximation option to Part Section

### DIFF
--- a/src/Mod/Part/App/FeaturePartSection.cpp
+++ b/src/Mod/Part/App/FeaturePartSection.cpp
@@ -37,10 +37,27 @@ PROPERTY_SOURCE(Part::Section, Part::Boolean)
 
 Section::Section(void)
 {
+    ADD_PROPERTY_TYPE(Approximation,(false),"Section",App::Prop_None,"Approximate the output edges");
 }
 
-BRepAlgoAPI_BooleanOperation* Section::makeOperation(const TopoDS_Shape& base, const TopoDS_Shape& tool) const
+short Section::mustExecute() const
+{
+    if (Approximation.isTouched())
+        return 1;
+    return 0;
+}
+
+BRepAlgoAPI_BooleanOperation *Section::makeOperation(const TopoDS_Shape& base, const TopoDS_Shape& tool) const
 {
     // Let's call algorithm computing a section operation:
-    return new BRepAlgoAPI_Section(base, tool);
+    // return new BRepAlgoAPI_Section(base, tool);
+    bool approx = Approximation.getValue();
+    BRepAlgoAPI_Section* mkSection = new BRepAlgoAPI_Section();
+    mkSection->Init1(base);
+    mkSection->Init2(tool);
+    mkSection->Approximation(approx);
+    mkSection->Build();
+    if (!mkSection->IsDone())
+        throw Base::RuntimeError("Section failed");
+    return mkSection;
 }

--- a/src/Mod/Part/App/FeaturePartSection.h
+++ b/src/Mod/Part/App/FeaturePartSection.h
@@ -38,9 +38,12 @@ class Section : public Boolean
 public:
     Section();
 
+    App::PropertyBool Approximation;
+    
     /** @name methods override Feature */
     //@{
     /// recalculate the Feature
+    short mustExecute() const;
 protected:
     BRepAlgoAPI_BooleanOperation* makeOperation(const TopoDS_Shape&, const TopoDS_Shape&) const;
     //@}

--- a/src/Mod/Part/App/TopoShape.cpp
+++ b/src/Mod/Part/App/TopoShape.cpp
@@ -1637,17 +1637,23 @@ TopoDS_Shape TopoShape::oldFuse(TopoDS_Shape shape) const
 #endif
 }
 
-TopoDS_Shape TopoShape::section(TopoDS_Shape shape) const
+TopoDS_Shape TopoShape::section(TopoDS_Shape shape, const Standard_Boolean approximate) const
 {
     if (this->_Shape.IsNull())
         Standard_Failure::Raise("Base shape is null");
     if (shape.IsNull())
         Standard_Failure::Raise("Tool shape is null");
-    BRepAlgoAPI_Section mkSection(this->_Shape, shape);
+    BRepAlgoAPI_Section mkSection;
+    mkSection.Init1(this->_Shape);
+    mkSection.Init2(shape);
+    mkSection.Approximation(approximate);
+    mkSection.Build();
+    if (!mkSection.IsDone())
+        throw Base::RuntimeError("Section failed");
     return mkSection.Shape();
 }
 
-TopoDS_Shape TopoShape::section(const std::vector<TopoDS_Shape>& shapes, Standard_Real tolerance) const
+TopoDS_Shape TopoShape::section(const std::vector<TopoDS_Shape>& shapes, Standard_Real tolerance, const Standard_Boolean approximate) const
 {
     if (this->_Shape.IsNull())
         Standard_Failure::Raise("Base shape is null");
@@ -1658,6 +1664,7 @@ TopoDS_Shape TopoShape::section(const std::vector<TopoDS_Shape>& shapes, Standar
 #else
     BRepAlgoAPI_Section mkSection;
     mkSection.SetRunParallel(true);
+    mkSection.Approximation(approximate);
     TopTools_ListOfShape shapeArguments,shapeTools;
     shapeArguments.Append(this->_Shape);
     for (std::vector<TopoDS_Shape>::const_iterator it = shapes.begin(); it != shapes.end(); ++it) {

--- a/src/Mod/Part/App/TopoShape.h
+++ b/src/Mod/Part/App/TopoShape.h
@@ -165,8 +165,8 @@ public:
     TopoDS_Shape fuse(TopoDS_Shape) const;
     TopoDS_Shape fuse(const std::vector<TopoDS_Shape>&, Standard_Real tolerance = 0.0) const;
     TopoDS_Shape oldFuse(TopoDS_Shape) const;
-    TopoDS_Shape section(TopoDS_Shape) const;
-    TopoDS_Shape section(const std::vector<TopoDS_Shape>&, Standard_Real tolerance = 0.0) const;
+    TopoDS_Shape section(TopoDS_Shape, const Standard_Boolean approximate=Standard_False) const;
+    TopoDS_Shape section(const std::vector<TopoDS_Shape>&, Standard_Real tolerance = 0.0, const Standard_Boolean approximate=Standard_False) const;
     std::list<TopoDS_Wire> slice(const Base::Vector3d&, double) const;
     TopoDS_Compound slices(const Base::Vector3d&, const std::vector<double>&) const;
     /**

--- a/src/Mod/Part/App/TopoShapePy.xml
+++ b/src/Mod/Part/App/TopoShapePy.xml
@@ -197,9 +197,11 @@ OCC 6.9.0 or later is required.</UserDocu>
     <Methode Name="section" Const="true">
       <Documentation>
         <UserDocu>Section of this with a given (list of) topo shape.
-section(tool) -> Shape
+section(tool,[approximation=False]) -> Shape
   or
-section((tool1,tool2,...),[tolerance=0.0]) -> Shape
+section((tool1,tool2,...),[tolerance=0.0, approximation=False]) -> Shape
+
+If approximation is True, section edges are approximated to a C1-continuous BSpline curve.
 
 Section of this and a given list of topo shapes.
 

--- a/src/Mod/Part/App/TopoShapePyImp.cpp
+++ b/src/Mod/Part/App/TopoShapePyImp.cpp
@@ -911,11 +911,12 @@ PyObject*  TopoShapePy::common(PyObject *args)
 PyObject*  TopoShapePy::section(PyObject *args)
 {
     PyObject *pcObj;
-    if (PyArg_ParseTuple(args, "O!", &(TopoShapePy::Type), &pcObj)) {
+    PyObject *approx = Py_False;
+    if (PyArg_ParseTuple(args, "O!|O!", &(TopoShapePy::Type), &pcObj, &(PyBool_Type), &approx)) {
         TopoDS_Shape shape = static_cast<TopoShapePy*>(pcObj)->getTopoShapePtr()->getShape();
         try {
             // Let's call algorithm computing a section operation:
-            TopoDS_Shape secShape = this->getTopoShapePtr()->section(shape);
+            TopoDS_Shape secShape = this->getTopoShapePtr()->section(shape,PyObject_IsTrue(approx) ? true : false);
             return new TopoShapePy(new TopoShape(secShape));
         }
         catch (Standard_Failure& e) {
@@ -931,11 +932,11 @@ PyObject*  TopoShapePy::section(PyObject *args)
 
     PyErr_Clear();
     double tolerance = 0.0;
-    if (PyArg_ParseTuple(args, "O!d", &(TopoShapePy::Type), &pcObj, &tolerance)) {
+    if (PyArg_ParseTuple(args, "O!d|O!", &(TopoShapePy::Type), &pcObj, &tolerance, &(PyBool_Type), &approx)) {
         std::vector<TopoDS_Shape> shapeVec;
         shapeVec.push_back(static_cast<TopoShapePy*>(pcObj)->getTopoShapePtr()->getShape());
         try {
-            TopoDS_Shape sectionShape = this->getTopoShapePtr()->section(shapeVec,tolerance);
+            TopoDS_Shape sectionShape = this->getTopoShapePtr()->section(shapeVec,tolerance,PyObject_IsTrue(approx) ? true : false);
             return new TopoShapePy(new TopoShape(sectionShape));
         }
         catch (Standard_Failure& e) {
@@ -949,7 +950,7 @@ PyObject*  TopoShapePy::section(PyObject *args)
     }
 
     PyErr_Clear();
-    if (PyArg_ParseTuple(args, "O|d", &pcObj, &tolerance)) {
+    if (PyArg_ParseTuple(args, "O|dO!", &pcObj, &tolerance, &(PyBool_Type), &approx)) {
         std::vector<TopoDS_Shape> shapeVec;
         Py::Sequence shapeSeq(pcObj);
         for (Py::Sequence::iterator it = shapeSeq.begin(); it != shapeSeq.end(); ++it) {
@@ -963,7 +964,7 @@ PyObject*  TopoShapePy::section(PyObject *args)
            }
         }
         try {
-            TopoDS_Shape multiSectionShape = this->getTopoShapePtr()->section(shapeVec,tolerance);
+            TopoDS_Shape multiSectionShape = this->getTopoShapePtr()->section(shapeVec,tolerance,PyObject_IsTrue(approx) ? true : false);
             return new TopoShapePy(new TopoShape(multiSectionShape));
         }
         catch (Standard_Failure& e) {


### PR DESCRIPTION
In many situations, TopoShape.section() creates BSpline curves of degree 1, that are not very good sweep paths.
OCCT BRepAlgoAPI_Section that is used, offers an Approximation option, to convert these section curves to C1-continuous BSplines.
See this bad sweep path example : 
[https://forum.freecadweb.org/viewtopic.php?f=22&t=11705](https://forum.freecadweb.org/viewtopic.php?f=22&t=11705)

fixes #2187

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [x] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
