### PR TITLE
Sketcher: Fix deleteall crash

### DIFF
--- a/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp
+++ b/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp
@@ -1966,6 +1966,8 @@ void CmdSketcherDeleteAllGeometry::activated(int iMsg)
                                     QMessageBox::Yes, QMessageBox::Cancel);
     // use an equality constraint
     if (ret == QMessageBox::Yes) {
+        getSelection().clearSelection();
+
         Gui::Document * doc= getActiveGuiDocument();
 
         SketcherGui::ViewProviderSketch* vp = static_cast<SketcherGui::ViewProviderSketch*>(doc->getInEdit());


### PR DESCRIPTION
Achtung!

This "fixes" this:
https://forum.freecadweb.org/viewtopic.php?f=9&t=29192#p238347

But:
I think this might mask another bug. When closing the sketch without this "patch" it crashes only if there was a selection. So the fact that something was selected that was in the meantime deleted crashes FreeCAD.

I do not know if it is the responsibility of the module to remove the selection or not, but being the consequence a crash, maybe you want to do another kind of change.