### PR TITLE
Fix #3419 Circles as Polygons

### DIFF
--- a/src/Mod/OpenSCAD/OpenSCADUtils.py
+++ b/src/Mod/OpenSCAD/OpenSCADUtils.py
@@ -479,15 +479,22 @@ def meshoponobjs(opname,inobjs):
 def process2D_ObjectsViaOpenSCADShape(ObjList,Operation,doc):
     import FreeCAD,importDXF
     import os,tempfile
+    # Mantis 3419
+    params = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/OpenSCAD")
+    fn  = params.GetInt('fnForImport',32)
+    fnStr = ",$fn=" + str(fn)
+    #
     dir1=tempfile.gettempdir()
     filenames = []
     for item in ObjList :
         outputfilename=os.path.join(dir1,'%s.dxf' % tempfilenamegen.next())
         importDXF.export([item],outputfilename,True,True)
         filenames.append(outputfilename)
-    dxfimports = ' '.join("import(file = \"%s\");" % \
+    # Mantis 3419
+    dxfimports = ' '.join("import(file = \"%s\" %s);" % \
         #filename \
-        os.path.split(filename)[1] for filename in filenames)
+        (os.path.split(filename)[1], fnStr) for filename in filenames)
+    #
     tmpfilename = callopenscadstring('%s(){%s}' % (Operation,dxfimports),'dxf')
     from OpenSCAD2Dgeom import importDXFface
     # TBD: assure the given doc is active


### PR DESCRIPTION
This PR corrects issue [#3419](https://www.freecadweb.org/tracker/view.php?id=3419).  Please merge. 
Thanks, wf.

- by default, OpenScad represents circles from
  dxf files as octogons.  This fix provides
  access to the OpenScad variable "$fn" which
  controls the number of polygon sides.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
