### PR TITLE
Fix #3508 Missing Namespace in Templates

### DIFF
--- a/src/Mod/Drawing/Templates/A0_Landscape_plain.svg
+++ b/src/Mod/Drawing/Templates/A0_Landscape_plain.svg
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <svg xmlns="http://www.w3.org/2000/svg" version="1.1"
+    xmlns:freecad="http://www.freecadweb.org/wiki/index.php?title=Svg_Namespace"
 	width="1189mm"
 	height="841mm"
 	viewBox="0 0 1189 841">

--- a/src/Mod/Drawing/Templates/A0_Portrait_plain.svg
+++ b/src/Mod/Drawing/Templates/A0_Portrait_plain.svg
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <svg xmlns="http://www.w3.org/2000/svg" version="1.1"
+    xmlns:freecad="http://www.freecadweb.org/wiki/index.php?title=Svg_Namespace"
 	width="841mm"
 	height="1189mm"
 	viewBox="0 0 841 1189">

--- a/src/Mod/Drawing/Templates/A1_Landscape_plain.svg
+++ b/src/Mod/Drawing/Templates/A1_Landscape_plain.svg
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <svg xmlns="http://www.w3.org/2000/svg" version="1.1"
+    xmlns:freecad="http://www.freecadweb.org/wiki/index.php?title=Svg_Namespace"
 	width="841mm"
 	height="594mm"
 	viewBox="0 0 841 594">

--- a/src/Mod/Drawing/Templates/A1_Portrait_plain.svg
+++ b/src/Mod/Drawing/Templates/A1_Portrait_plain.svg
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <svg xmlns="http://www.w3.org/2000/svg" version="1.1"
+    xmlns:freecad="http://www.freecadweb.org/wiki/index.php?title=Svg_Namespace"
 	width="594mm"
 	height="841mm"
 	viewBox="0 0 594 841">

--- a/src/Mod/Drawing/Templates/A2_Landscape_plain.svg
+++ b/src/Mod/Drawing/Templates/A2_Landscape_plain.svg
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <svg xmlns="http://www.w3.org/2000/svg" version="1.1"
+    xmlns:freecad="http://www.freecadweb.org/wiki/index.php?title=Svg_Namespace"
 	width="594mm"
 	height="420mm"
 	viewBox="0 0 594 420">

--- a/src/Mod/Drawing/Templates/A2_Portrait_plain.svg
+++ b/src/Mod/Drawing/Templates/A2_Portrait_plain.svg
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <svg xmlns="http://www.w3.org/2000/svg" version="1.1"
+    xmlns:freecad="http://www.freecadweb.org/wiki/index.php?title=Svg_Namespace"
 	width="420mm"
 	height="594mm"
 	viewBox="0 0 420 594">

--- a/src/Mod/Drawing/Templates/A3_Landscape_plain.svg
+++ b/src/Mod/Drawing/Templates/A3_Landscape_plain.svg
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <svg xmlns="http://www.w3.org/2000/svg" version="1.1"
+    xmlns:freecad="http://www.freecadweb.org/wiki/index.php?title=Svg_Namespace"
 	width="420mm"
 	height="297mm"
 	viewBox="0 0 420 297">

--- a/src/Mod/Drawing/Templates/A3_Portrait_plain.svg
+++ b/src/Mod/Drawing/Templates/A3_Portrait_plain.svg
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <svg xmlns="http://www.w3.org/2000/svg" version="1.1"
+    xmlns:freecad="http://www.freecadweb.org/wiki/index.php?title=Svg_Namespace"
 	width="297mm"
 	height="420mm"
 	viewBox="0 0 297 420">

--- a/src/Mod/Drawing/Templates/A4_Landscape_plain.svg
+++ b/src/Mod/Drawing/Templates/A4_Landscape_plain.svg
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <svg xmlns="http://www.w3.org/2000/svg" version="1.1"
+    xmlns:freecad="http://www.freecadweb.org/wiki/index.php?title=Svg_Namespace"
 	width="297mm"
 	height="210mm"
 	viewBox="0 0 297 210">

--- a/src/Mod/Drawing/Templates/A4_Portrait_plain.svg
+++ b/src/Mod/Drawing/Templates/A4_Portrait_plain.svg
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <svg xmlns="http://www.w3.org/2000/svg" version="1.1"
+    xmlns:freecad="http://www.freecadweb.org/wiki/index.php?title=Svg_Namespace"
 	width="210mm"
 	height="297mm"
 	viewBox="0 0 210 297">


### PR DESCRIPTION
 [#3508](https://www.freecadweb.org/tracker/view.php?id=3508) The "plain" templates in Drawing module do not specify FreeCAD Svg namespace.   This PR corrects this.  Please merge. 
Thanks,
wf

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
