### PR TITLE
Flexible global marker size

### DIFF
--- a/src/Gui/Application.h
+++ b/src/Gui/Application.h
@@ -246,6 +246,8 @@ public:
 
     PYFUNCDEF_S(sCreateViewer);
 
+    PYFUNCDEF_S(sGetMarkerIndex);
+
     static PyMethodDef    Methods[]; 
 
 private:

--- a/src/Gui/ApplicationPy.cpp
+++ b/src/Gui/ApplicationPy.cpp
@@ -63,6 +63,7 @@
 #include <Base/Interpreter.h>
 #include <Base/Console.h>
 #include <CXX/Objects.hxx>
+#include <Inventor/MarkerBitmaps.h>
 
 using namespace Gui;
 
@@ -181,6 +182,9 @@ PyMethodDef Application::Methods[] = {
   {"createViewer",               (PyCFunction) Application::sCreateViewer,1,
    "createViewer([int]) -> View3DInventor/SplitView3DInventor\n\n"
    "shows and returns a viewer. If the integer argument is given and > 1: -> splitViewer"},
+
+  {"getMarkerIndex", (PyCFunction) Application::sGetMarkerIndex, 1,
+   "Get marker index according to marker size setting"},
 
   {NULL, NULL, 0, NULL}		/* Sentinel */
 };
@@ -1223,4 +1227,28 @@ PyObject* Application::sCreateViewer(PyObject * /*self*/, PyObject *args,PyObjec
         }
     }
     return Py_None;
+}
+
+PyObject* Application::sGetMarkerIndex(PyObject * /*self*/, PyObject *args, PyObject * /*kwd*/)
+{
+    char *pstr=0;
+    if (!PyArg_ParseTuple(args, "s", &pstr))
+        return NULL;
+
+    PY_TRY {
+        ParameterGrp::handle const hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/View");
+
+        if (strcmp(pstr, "square") == 0)
+            return Py_BuildValue("i", Gui::Inventor::MarkerBitmaps::getMarkerIndex("DIAMOND_FILLED", hGrp->GetInt("MarkerSize", 9)));
+        else if (strcmp(pstr, "cross") == 0)
+            return Py_BuildValue("i", Gui::Inventor::MarkerBitmaps::getMarkerIndex("CROSS", hGrp->GetInt("MarkerSize", 9)));
+        else if (strcmp(pstr, "empty") == 0)
+            return Py_BuildValue("i", Gui::Inventor::MarkerBitmaps::getMarkerIndex("SQUARE_LINE", hGrp->GetInt("MarkerSize", 9)));
+        else if (strcmp(pstr, "quad") == 0)
+            return Py_BuildValue("i", Gui::Inventor::MarkerBitmaps::getMarkerIndex("SQUARE_FILLED", hGrp->GetInt("MarkerSize", 9)));
+        else if (strcmp(pstr, "circle") == 0)
+            return Py_BuildValue("i", Gui::Inventor::MarkerBitmaps::getMarkerIndex("CIRCLE_LINE", hGrp->GetInt("MarkerSize", 9)));
+        else
+            return Py_BuildValue("i", Gui::Inventor::MarkerBitmaps::getMarkerIndex("CIRCLE_FILLED", hGrp->GetInt("MarkerSize", 9)));
+    }PY_CATCH;
 }

--- a/src/Gui/DlgSettings3DView.ui
+++ b/src/Gui/DlgSettings3DView.ui
@@ -324,6 +324,26 @@
        </widget>
       </item>
       <item>
+       <layout class="QHBoxLayout">
+        <property name="spacing">
+         <number>6</number>
+        </property>
+        <property name="margin">
+         <number>0</number>
+        </property>
+        <item>
+         <widget class="QLabel" name="markerSizeLabel">
+          <property name="text">
+           <string>Marker size:</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QComboBox" name="boxMarkerSize"/>
+        </item>
+       </layout>
+      </item>
+      <item>
        <widget class="Line" name="line1">
         <property name="frameShape">
          <enum>QFrame::HLine</enum>

--- a/src/Gui/DlgSettings3DViewImp.cpp
+++ b/src/Gui/DlgSettings3DViewImp.cpp
@@ -83,6 +83,9 @@ void DlgSettings3DViewImp::saveSettings()
     index = this->naviCubeCorner->currentIndex();
     hGrp->SetInt("CornerNaviCube", index);
 
+    QVariant const &vBoxMarkerSize = this->boxMarkerSize->itemData(this->boxMarkerSize->currentIndex());
+    hGrp->SetInt("MarkerSize", vBoxMarkerSize.toInt());
+
     checkBoxZoomAtCursor->onSave();
     checkBoxInvertZoom->onSave();
     spinBoxZoomStep->onSave();
@@ -135,6 +138,17 @@ void DlgSettings3DViewImp::loadSettings()
 
     index = hGrp->GetInt("CornerNaviCube", 1);
     naviCubeCorner->setCurrentIndex(index);
+
+    int const current = hGrp->GetInt("MarkerSize", 9L);
+    this->boxMarkerSize->addItem(tr("5px"), QVariant(5));
+    this->boxMarkerSize->addItem(tr("7px"), QVariant(7));
+    this->boxMarkerSize->addItem(tr("9px"), QVariant(9));
+    this->boxMarkerSize->addItem(tr("11px"), QVariant(11));
+    this->boxMarkerSize->addItem(tr("13px"), QVariant(13));
+    this->boxMarkerSize->addItem(tr("15px"), QVariant(15));
+    index = this->boxMarkerSize->findData(QVariant(current));
+    if (index < 0) index = 2;
+    this->boxMarkerSize->setCurrentIndex(index);
 }
 
 void DlgSettings3DViewImp::on_mouseButton_clicked()

--- a/src/Gui/Inventor/MarkerBitmaps.cpp
+++ b/src/Gui/Inventor/MarkerBitmaps.cpp
@@ -58,10 +58,290 @@ def makeIcon(s):
   print (ba.data())
 */
 
+//DIAMOND_FILLED_11_11
+const int DIAMOND_FILLED11_WIDTH = 11;
+const int DIAMOND_FILLED11_HEIGHT = 11;
+const char diamondFilled11_marker[DIAMOND_FILLED11_WIDTH * DIAMOND_FILLED11_HEIGHT + 1] = {
+"           "
+"     xx    "
+"    xxxx   "
+"   xxxxxx  "
+"  xxxxxxxx "
+" xxxxxxxxxx"
+" xxxxxxxxxx"
+"  xxxxxxxx "
+"   xxxxxx  "
+"    xxxx   "
+"     xx    "};
+
+
+//DIAMOND_FILLED_13_13
+const int DIAMOND_FILLED13_WIDTH = 13;
+const int DIAMOND_FILLED13_HEIGHT = 13;
+const char diamondFilled13_marker[DIAMOND_FILLED13_WIDTH * DIAMOND_FILLED13_HEIGHT + 1] = {
+"             "
+"      xx     "
+"     xxxx    "
+"    xxxxxx   "
+"   xxxxxxxx  "
+"  xxxxxxxxxx "
+" xxxxxxxxxxxx"
+" xxxxxxxxxxxx"
+"  xxxxxxxxxx "
+"   xxxxxxxx  "
+"    xxxxxx   "
+"     xxxx    "
+"      xx     "};
+
+
+//DIAMOND_FILLED_15_15
+const int DIAMOND_FILLED15_WIDTH = 15;
+const int DIAMOND_FILLED15_HEIGHT = 15;
+const char diamondFilled15_marker[DIAMOND_FILLED15_WIDTH * DIAMOND_FILLED15_HEIGHT + 1] = {
+"               "
+"       xx      "
+"      xxxx     "
+"     xxxxxx    "
+"    xxxxxxxx   "
+"   xxxxxxxxxx  "
+"  xxxxxxxxxxxx "
+" xxxxxxxxxxxxxx"
+" xxxxxxxxxxxxxx"
+"  xxxxxxxxxxxx "
+"   xxxxxxxxxx  "
+"    xxxxxxxx   "
+"     xxxxxx    "
+"      xxxx     "
+"       xx      "};
+
+//CROSS_11_11
+const int CROSS11_WIDTH = 11;
+const int CROSS11_HEIGHT = 11;
+const char cross11_marker[CROSS11_WIDTH * CROSS11_HEIGHT + 1] = {
+"           "
+" xx      xx"
+"  xx    xx "
+"   xx  xx  "
+"    xxxx   "
+"     xx    "
+"     xx    "
+"    xxxx   "
+"   xx  xx  "
+"  xx    xx "
+" xx      xx"};
+
+
+//CROSS_13_13
+const int CROSS13_WIDTH = 13;
+const int CROSS13_HEIGHT = 13;
+const char cross13_marker[CROSS13_WIDTH * CROSS13_HEIGHT + 1] = {
+"             "
+" xx        xx"
+"  xx      xx "
+"   xx    xx  "
+"    xx  xx   "
+"     xxxx    "
+"      xx     "
+"      xx     "
+"     xxxx    "
+"    xx  xx   "
+"   xx    xx  "
+"  xx      xx "
+" xx        xx"};
+
+
+//CROSS_15_15
+const int CROSS15_WIDTH = 15;
+const int CROSS15_HEIGHT = 15;
+const char cross15_marker[CROSS15_WIDTH * CROSS15_HEIGHT + 1] = {
+"               "
+" xx          xx"
+"  xx        xx "
+"   xx      xx  "
+"    xx    xx   "
+"     xx  xx    "
+"      xxxx     "
+"       xx      "
+"       xx      "
+"      xxxx     "
+"     xx  xx    "
+"    xx    xx   "
+"   xx      xx  "
+"  xx        xx "
+" xx          xx"};
+
+//SQUARE_LINE_11_11
+const int SQUARE_LINE11_WIDTH = 11;
+const int SQUARE_LINE11_HEIGHT = 11;
+const char squareLine11_marker[SQUARE_LINE11_WIDTH * SQUARE_LINE11_HEIGHT + 1] = {
+"           "
+" xxxxxxxxxx"
+" xxxxxxxxxx"
+" xx      xx"
+" xx      xx"
+" xx      xx"
+" xx      xx"
+" xx      xx"
+" xx      xx"
+" xxxxxxxxxx"
+" xxxxxxxxxx"};
+
+
+//SQUARE_LINE_13_13
+const int SQUARE_LINE13_WIDTH = 13;
+const int SQUARE_LINE13_HEIGHT = 13;
+const char squareLine13_marker[SQUARE_LINE13_WIDTH * SQUARE_LINE13_HEIGHT + 1] = {
+"             "
+" xxxxxxxxxxxx"
+" xxxxxxxxxxxx"
+" xx        xx"
+" xx        xx"
+" xx        xx"
+" xx        xx"
+" xx        xx"
+" xx        xx"
+" xx        xx"
+" xx        xx"
+" xxxxxxxxxxxx"
+" xxxxxxxxxxxx"};
+
+
+//SQUARE_LINE_15_15
+const int SQUARE_LINE15_WIDTH = 15;
+const int SQUARE_LINE15_HEIGHT = 15;
+const char squareLine15_marker[SQUARE_LINE15_WIDTH * SQUARE_LINE15_HEIGHT + 1] = {
+"               "
+" xxxxxxxxxxxxxx"
+" xxxxxxxxxxxxxx"
+" xx          xx"
+" xx          xx"
+" xx          xx"
+" xx          xx"
+" xx          xx"
+" xx          xx"
+" xx          xx"
+" xx          xx"
+" xx          xx"
+" xx          xx"
+" xxxxxxxxxxxxxx"
+" xxxxxxxxxxxxxx"};
+
+//SQUARE_FILLED_11_11
+const int SQUARE_FILLED11_WIDTH = 11;
+const int SQUARE_FILLED11_HEIGHT = 11;
+const char squareFilled11_marker[SQUARE_FILLED11_WIDTH * SQUARE_FILLED11_HEIGHT + 1] = {
+"           "
+" xxxxxxxxxx"
+" xxxxxxxxxx"
+" xxxxxxxxxx"
+" xxxxxxxxxx"
+" xxxxxxxxxx"
+" xxxxxxxxxx"
+" xxxxxxxxxx"
+" xxxxxxxxxx"
+" xxxxxxxxxx"
+" xxxxxxxxxx"};
+
+
+//SQUARE_FILLED_13_13
+const int SQUARE_FILLED13_WIDTH = 13;
+const int SQUARE_FILLED13_HEIGHT = 13;
+const char squareFilled13_marker[SQUARE_FILLED13_WIDTH * SQUARE_FILLED13_HEIGHT + 1] = {
+"             "
+" xxxxxxxxxxxx"
+" xxxxxxxxxxxx"
+" xxxxxxxxxxxx"
+" xxxxxxxxxxxx"
+" xxxxxxxxxxxx"
+" xxxxxxxxxxxx"
+" xxxxxxxxxxxx"
+" xxxxxxxxxxxx"
+" xxxxxxxxxxxx"
+" xxxxxxxxxxxx"
+" xxxxxxxxxxxx"
+" xxxxxxxxxxxx"};
+
+
+//SQUARE_FILLED_15_15
+const int SQUARE_FILLED15_WIDTH = 15;
+const int SQUARE_FILLED15_HEIGHT = 15;
+const char squareFilled15_marker[SQUARE_FILLED15_WIDTH * SQUARE_FILLED15_HEIGHT + 1] = {
+"               "
+" xxxxxxxxxxxxxx"
+" xxxxxxxxxxxxxx"
+" xxxxxxxxxxxxxx"
+" xxxxxxxxxxxxxx"
+" xxxxxxxxxxxxxx"
+" xxxxxxxxxxxxxx"
+" xxxxxxxxxxxxxx"
+" xxxxxxxxxxxxxx"
+" xxxxxxxxxxxxxx"
+" xxxxxxxxxxxxxx"
+" xxxxxxxxxxxxxx"
+" xxxxxxxxxxxxxx"
+" xxxxxxxxxxxxxx"
+" xxxxxxxxxxxxxx"};
+
+//CIRCLE_LINE_11_11
+const int CIRCLE_LINE11_WIDTH = 11;
+const int CIRCLE_LINE11_HEIGHT = 11;
+const char circleLine11_marker[CIRCLE_LINE11_WIDTH * CIRCLE_LINE11_HEIGHT + 1] = {
+"           "
+"   xxxxxx  "
+"  xxxxxxxx "
+"  xx    xx "
+" xx      xx"
+" xx      xx"
+" xx      xx"
+" xx      xx"
+"  xx    xx "
+"  xxxxxxxx "
+"   xxxxxx  "};
+
+
+//CIRCLE_LINE_13_13
+const int CIRCLE_LINE13_WIDTH = 13;
+const int CIRCLE_LINE13_HEIGHT = 13;
+const char circleLine13_marker[CIRCLE_LINE13_WIDTH * CIRCLE_LINE13_HEIGHT + 1] = {
+"             "
+"    xxxxxx   "
+"   xxxxxxxx  "
+"  xx      xx "
+" xx        xx"
+" xx        xx"
+" xx        xx"
+" xx        xx"
+" xx        xx"
+" xx        xx"
+"  xx      xx "
+"   xxxxxxxx  "
+"    xxxxxx   "};
+
+
+//CIRCLE_LINE_15_15
+const int CIRCLE_LINE15_WIDTH = 15;
+const int CIRCLE_LINE15_HEIGHT = 15;
+const char circleLine15_marker[CIRCLE_LINE15_WIDTH * CIRCLE_LINE15_HEIGHT + 1] = {
+"               "
+"     xxxxxx    "
+"   xxxxxxxxxx  "
+"  xx        xx "
+"  xx        xx "
+" xx          xx"
+" xx          xx"
+" xx          xx"
+" xx          xx"
+" xx          xx"
+" xx          xx"
+"  xx        xx "
+"   xx      xxxx"
+"   xxxxxxxxxx  "
+"     xxxxxx    "};
+
 //CIRCLE_FILLED_11_11
-const int CIRCLE11_WIDTH = 11;
-const int CIRCLE11_HEIGHT = 11;
-const char circle11_marker[CIRCLE11_WIDTH * CIRCLE11_HEIGHT + 1] = {
+const int CIRCLE_FILLED11_WIDTH = 11;
+const int CIRCLE_FILLED11_HEIGHT = 11;
+const char circleFilled11_marker[CIRCLE_FILLED11_WIDTH * CIRCLE_FILLED11_HEIGHT + 1] = {
 "           "
 "   xxxxxx  "
 "  xxxxxxxx "
@@ -76,9 +356,9 @@ const char circle11_marker[CIRCLE11_WIDTH * CIRCLE11_HEIGHT + 1] = {
 
 
 //CIRCLE_FILLED_13_13
-const int CIRCLE13_WIDTH = 13;
-const int CIRCLE13_HEIGHT = 13;
-const char circle13_marker[CIRCLE13_WIDTH * CIRCLE13_HEIGHT + 1] = {
+const int CIRCLE_FILLED13_WIDTH = 13;
+const int CIRCLE_FILLED13_HEIGHT = 13;
+const char circleFilled13_marker[CIRCLE_FILLED13_WIDTH * CIRCLE_FILLED13_HEIGHT + 1] = {
 "             "
 "    xxxxxx   "
 "   xxxxxxxx  "
@@ -95,9 +375,9 @@ const char circle13_marker[CIRCLE13_WIDTH * CIRCLE13_HEIGHT + 1] = {
 
 
 //CIRCLE_FILLED_15_15
-const int CIRCLE15_WIDTH = 15;
-const int CIRCLE15_HEIGHT = 15;
-const char circle15_marker[CIRCLE15_WIDTH * CIRCLE15_HEIGHT + 1] = {
+const int CIRCLE_FILLED15_WIDTH = 15;
+const int CIRCLE_FILLED15_HEIGHT = 15;
+const char circleFilled15_marker[CIRCLE_FILLED15_WIDTH * CIRCLE_FILLED15_HEIGHT + 1] = {
 "               "
 "     xxxxxx    "
 "   xxxxxxxxxx  "
@@ -119,9 +399,54 @@ std::map<MarkerBitmaps::Marker, int> MarkerBitmaps::markerIndex;
 void
 MarkerBitmaps::initClass()
 {
-    createBitmap("CIRCLE_FILLED", 11, 11, 11, circle11_marker);
-    createBitmap("CIRCLE_FILLED", 13, 13, 13, circle13_marker);
-    createBitmap("CIRCLE_FILLED", 15, 15, 15, circle15_marker);
+    createBitmap("DIAMOND_FILLED", 11, 11, 11, diamondFilled11_marker);
+    createBitmap("DIAMOND_FILLED", 13, 13, 13, diamondFilled13_marker);
+    createBitmap("DIAMOND_FILLED", 15, 15, 15, diamondFilled15_marker);
+
+    // the built-in bitmaps of Coin
+    markerIndex [std::make_pair("DIAMOND_FILLED", 9)] = SoMarkerSet::DIAMOND_FILLED_9_9;
+    markerIndex [std::make_pair("DIAMOND_FILLED", 7)] = SoMarkerSet::DIAMOND_FILLED_7_7;
+    markerIndex [std::make_pair("DIAMOND_FILLED", 5)] = SoMarkerSet::DIAMOND_FILLED_5_5;
+
+    createBitmap("CROSS", 11, 11, 11, cross11_marker);
+    createBitmap("CROSS", 13, 13, 13, cross13_marker);
+    createBitmap("CROSS", 15, 15, 15, cross15_marker);
+
+    // the built-in bitmaps of Coin
+    markerIndex [std::make_pair("CROSS", 9)] = SoMarkerSet::CROSS_9_9;
+    markerIndex [std::make_pair("CROSS", 7)] = SoMarkerSet::CROSS_7_7;
+    markerIndex [std::make_pair("CROSS", 5)] = SoMarkerSet::CROSS_5_5;
+
+    createBitmap("SQUARE_LINE", 11, 11, 11, squareLine11_marker);
+    createBitmap("SQUARE_LINE", 13, 13, 13, squareLine13_marker);
+    createBitmap("SQUARE_LINE", 15, 15, 15, squareLine15_marker);
+
+    // the built-in bitmaps of Coin
+    markerIndex [std::make_pair("SQUARE_LINE", 9)] = SoMarkerSet::SQUARE_LINE_9_9;
+    markerIndex [std::make_pair("SQUARE_LINE", 7)] = SoMarkerSet::SQUARE_LINE_7_7;
+    markerIndex [std::make_pair("SQUARE_LINE", 5)] = SoMarkerSet::SQUARE_LINE_5_5;
+
+    createBitmap("SQUARE_FILLED", 11, 11, 11, squareFilled11_marker);
+    createBitmap("SQUARE_FILLED", 13, 13, 13, squareFilled13_marker);
+    createBitmap("SQUARE_FILLED", 15, 15, 15, squareFilled15_marker);
+
+    // the built-in bitmaps of Coin
+    markerIndex [std::make_pair("SQUARE_FILLED", 9)] = SoMarkerSet::SQUARE_FILLED_9_9;
+    markerIndex [std::make_pair("SQUARE_FILLED", 7)] = SoMarkerSet::SQUARE_FILLED_7_7;
+    markerIndex [std::make_pair("SQUARE_FILLED", 5)] = SoMarkerSet::SQUARE_FILLED_5_5;
+
+    createBitmap("CIRCLE_LINE", 11, 11, 11, circleLine11_marker);
+    createBitmap("CIRCLE_LINE", 13, 13, 13, circleLine13_marker);
+    createBitmap("CIRCLE_LINE", 15, 15, 15, circleLine15_marker);
+
+    // the built-in bitmaps of Coin
+    markerIndex [std::make_pair("CIRCLE_LINE", 9)] = SoMarkerSet::CIRCLE_LINE_9_9;
+    markerIndex [std::make_pair("CIRCLE_LINE", 7)] = SoMarkerSet::CIRCLE_LINE_7_7;
+    markerIndex [std::make_pair("CIRCLE_LINE", 5)] = SoMarkerSet::CIRCLE_LINE_5_5;
+
+    createBitmap("CIRCLE_FILLED", 11, 11, 11, circleFilled11_marker);
+    createBitmap("CIRCLE_FILLED", 13, 13, 13, circleFilled13_marker);
+    createBitmap("CIRCLE_FILLED", 15, 15, 15, circleFilled15_marker);
 
     // the built-in bitmaps of Coin
     markerIndex [std::make_pair("CIRCLE_FILLED", 9)] = SoMarkerSet::CIRCLE_FILLED_9_9;

--- a/src/Mod/Draft/DraftTrackers.py
+++ b/src/Mod/Draft/DraftTrackers.py
@@ -116,7 +116,7 @@ class snapTracker(Tracker):
         color = coin.SoBaseColor()
         color.rgb = FreeCADGui.draftToolBar.getDefaultColor("snap")
         self.marker = coin.SoMarkerSet() # this is the marker symbol
-        self.marker.markerIndex = coin.SoMarkerSet.CIRCLE_FILLED_9_9
+        self.marker.markerIndex = FreeCADGui.getMarkerIndex("")
         self.coords = coin.SoCoordinate3() # this is the coordinate
         self.coords.point.setValue((0,0,0))
         node = coin.SoAnnotation()
@@ -126,18 +126,7 @@ class snapTracker(Tracker):
         Tracker.__init__(self,children=[node],name="snapTracker")
 
     def setMarker(self,style):
-        if (style == "square"):
-            self.marker.markerIndex = coin.SoMarkerSet.DIAMOND_FILLED_9_9
-        elif (style == "circle"):
-            self.marker.markerIndex = coin.SoMarkerSet.CIRCLE_LINE_9_9
-        elif (style == "quad"):
-            self.marker.markerIndex = coin.SoMarkerSet.SQUARE_FILLED_9_9
-        elif (style == "empty"):
-            self.marker.markerIndex = coin.SoMarkerSet.SQUARE_LINE_9_9
-        elif (style == "cross"):
-            self.marker.markerIndex = coin.SoMarkerSet.CROSS_9_9
-        else:
-            self.marker.markerIndex = coin.SoMarkerSet.CIRCLE_FILLED_9_9
+        self.marker.markerIndex = FreeCADGui.getMarkerIndex(style)
 
     def setCoords(self,point):
         self.coords.point.setValue((point.x,point.y,point.z))


### PR DESCRIPTION
Implemented a global setting for marker size, and implemented support of it currently for snapping in "Draft" workbench. In future this setting can be used for other markers too, to be able to set them all to comfortable size by just one global setting.
    
Before that (e.g. on MacBook Pro) it was very hard to see the microscopic selection-circle completely hidden behind much bigger cursor arrow when trying to snap e.g. a line to some vertex. Now this setting can be used for such displays to increase the marker size and make it clearly visible behind the cursor.

The already existing "sketcher marker size" property is intended to be used for sketcher only, so it's not suitable for global setup of all the markers' sizes uniformly...

![1](https://user-images.githubusercontent.com/3421219/42256049-f5e99826-7fa2-11e8-9590-2e8a46f0c584.png)

This is how it looks currently (before this change) on MacBook Pro. The cursor is substituted by screen-grabbing app to standard "arrow", but the original "cross-shaped" FreeCAD cursor obscures the selected vertex much more: actually the "snap-selected" dot is completely invisible when the FreeCADs cross-cursor is close to it...

![6](https://user-images.githubusercontent.com/3421219/42260136-5a8889e0-7fb7-11e8-86ac-595ec9ae8364.png)


Just for comparison of different sizes after this change (but these shots are made on Windows machine).
7px markers (smallest possible currently is 5px):

![2](https://user-images.githubusercontent.com/3421219/42256053-fac18b2e-7fa2-11e8-87e8-017a4f833267.png)

![3](https://user-images.githubusercontent.com/3421219/42256058-fea447ae-7fa2-11e8-9afc-4cfb62cd8bb7.png)

15px markers:

![4](https://user-images.githubusercontent.com/3421219/42256062-01f2d236-7fa3-11e8-85b1-cec4f486daa5.png)

![5](https://user-images.githubusercontent.com/3421219/42256065-0457083a-7fa3-11e8-8b6d-c4be4822576e.png)

Can be easily extended to have any other marker sizes...
