### PR TITLE
Fix #3525 Handle Global Position

### DIFF
--- a/src/Mod/TechDraw/App/DrawViewPart.cpp
+++ b/src/Mod/TechDraw/App/DrawViewPart.cpp
@@ -86,6 +86,7 @@
 #include <Base/FileInfo.h>
 #include <Base/Parameter.h>
 #include <Mod/Part/App/PartFeature.h>
+#include <Mod/Part/App/TopoShape.h>
 
 #include "DrawUtil.h"
 #include "DrawViewSection.h"
@@ -193,7 +194,10 @@ std::vector<TopoDS_Shape> DrawViewPart::getShapesFromObject(App::DocumentObject*
     std::vector<TopoDS_Shape> result;
     App::GroupExtension* gex = dynamic_cast<App::GroupExtension*>(docObj);
     if (docObj->getTypeId().isDerivedFrom(Part::Feature::getClassTypeId())) {
-        result.push_back(static_cast<Part::Feature*>(docObj)->Shape.getShape().getShape());
+        Part::Feature* pf = static_cast<Part::Feature*>(docObj);
+        Part::TopoShape ts = pf->Shape.getShape();
+        ts.setPlacement(pf->globalPlacement());
+        result.push_back(ts.getShape());
     } else if (gex != nullptr) {
         std::vector<App::DocumentObject*> objs = gex->Group.getValues();
         std::vector<TopoDS_Shape> shapes;
@@ -219,7 +223,7 @@ TopoDS_Shape DrawViewPart::getSourceShapeFused(void) const
             BRepAlgoAPI_Fuse mkFuse(fusedShape, aChild);
             // Let's check if the fusion has been successful
             if (!mkFuse.IsDone()) {
-                Base::Console().Error("DVp - Fusion failed\n");
+                Base::Console().Error("DVp - Fusion failed - %s\n",getNameInDocument());
                 return baseShape;
             }
             fusedShape = mkFuse.Shape();


### PR DESCRIPTION
This PR corrects [bug 3525](https://www.freecadweb.org/tracker/view.php?id=3525).  Please merge.  
Thanks, 
wf

- DVP was not taking container's Placement into
  account when drawing objects.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
