### PR TITLE
Extended the global marker size usage for other modes

### DIFF
--- a/src/Gui/ApplicationPy.cpp
+++ b/src/Gui/ApplicationPy.cpp
@@ -1231,24 +1231,27 @@ PyObject* Application::sCreateViewer(PyObject * /*self*/, PyObject *args,PyObjec
 
 PyObject* Application::sGetMarkerIndex(PyObject * /*self*/, PyObject *args, PyObject * /*kwd*/)
 {
-    char *pstr=0;
-    if (!PyArg_ParseTuple(args, "s", &pstr))
+    char *pstr   = 0;
+    int  defSize = 9;
+    if (!PyArg_ParseTuple(args, "|si", &pstr, &defSize))
         return NULL;
 
     PY_TRY {
         ParameterGrp::handle const hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/View");
 
         if (strcmp(pstr, "square") == 0)
-            return Py_BuildValue("i", Gui::Inventor::MarkerBitmaps::getMarkerIndex("DIAMOND_FILLED", hGrp->GetInt("MarkerSize", 9)));
+            return Py_BuildValue("i", Gui::Inventor::MarkerBitmaps::getMarkerIndex("DIAMOND_FILLED", hGrp->GetInt("MarkerSize", defSize)));
         else if (strcmp(pstr, "cross") == 0)
-            return Py_BuildValue("i", Gui::Inventor::MarkerBitmaps::getMarkerIndex("CROSS", hGrp->GetInt("MarkerSize", 9)));
+            return Py_BuildValue("i", Gui::Inventor::MarkerBitmaps::getMarkerIndex("CROSS", hGrp->GetInt("MarkerSize", defSize)));
+        else if (strcmp(pstr, "plus") == 0)
+            return Py_BuildValue("i", Gui::Inventor::MarkerBitmaps::getMarkerIndex("PLUS", hGrp->GetInt("MarkerSize", defSize)));
         else if (strcmp(pstr, "empty") == 0)
-            return Py_BuildValue("i", Gui::Inventor::MarkerBitmaps::getMarkerIndex("SQUARE_LINE", hGrp->GetInt("MarkerSize", 9)));
+            return Py_BuildValue("i", Gui::Inventor::MarkerBitmaps::getMarkerIndex("SQUARE_LINE", hGrp->GetInt("MarkerSize", defSize)));
         else if (strcmp(pstr, "quad") == 0)
-            return Py_BuildValue("i", Gui::Inventor::MarkerBitmaps::getMarkerIndex("SQUARE_FILLED", hGrp->GetInt("MarkerSize", 9)));
+            return Py_BuildValue("i", Gui::Inventor::MarkerBitmaps::getMarkerIndex("SQUARE_FILLED", hGrp->GetInt("MarkerSize", defSize)));
         else if (strcmp(pstr, "circle") == 0)
-            return Py_BuildValue("i", Gui::Inventor::MarkerBitmaps::getMarkerIndex("CIRCLE_LINE", hGrp->GetInt("MarkerSize", 9)));
+            return Py_BuildValue("i", Gui::Inventor::MarkerBitmaps::getMarkerIndex("CIRCLE_LINE", hGrp->GetInt("MarkerSize", defSize)));
         else
-            return Py_BuildValue("i", Gui::Inventor::MarkerBitmaps::getMarkerIndex("CIRCLE_FILLED", hGrp->GetInt("MarkerSize", 9)));
+            return Py_BuildValue("i", Gui::Inventor::MarkerBitmaps::getMarkerIndex("CIRCLE_FILLED", hGrp->GetInt("MarkerSize", defSize)));
     }PY_CATCH;
 }

--- a/src/Gui/Inventor/MarkerBitmaps.cpp
+++ b/src/Gui/Inventor/MarkerBitmaps.cpp
@@ -170,6 +170,62 @@ const char cross15_marker[CROSS15_WIDTH * CROSS15_HEIGHT + 1] = {
 "  xx        xx "
 " xx          xx"};
 
+//PLUS_11_11
+const int PLUS11_WIDTH = 11;
+const int PLUS11_HEIGHT = 11;
+const char plus11_marker[PLUS11_WIDTH * PLUS11_HEIGHT + 1] = {
+    "           "
+    "     xx    "
+    "     xx    "
+    "     xx    "
+    "     xx    "
+    " xxxxxxxxxx"
+    " xxxxxxxxxx"
+    "     xx    "
+    "     xx    "
+    "     xx    "
+    "     xx    "};
+
+
+//PLUS_13_13
+const int PLUS13_WIDTH = 13;
+const int PLUS13_HEIGHT = 13;
+const char plus13_marker[PLUS13_WIDTH * PLUS13_HEIGHT + 1] = {
+    "             "
+    "      xx     "
+    "      xx     "
+    "      xx     "
+    "      xx     "
+    "      xx     "
+    " xxxxxxxxxxxx"
+    " xxxxxxxxxxxx"
+    "      xx     "
+    "      xx     "
+    "      xx     "
+    "      xx     "
+    "      xx     "};
+
+
+//PLUS_15_15
+const int PLUS15_WIDTH = 15;
+const int PLUS15_HEIGHT = 15;
+const char plus15_marker[PLUS15_WIDTH * PLUS15_HEIGHT + 1] = {
+    "               "
+    "       xx      "
+    "       xx      "
+    "       xx      "
+    "       xx      "
+    "       xx      "
+    "       xx      "
+    " xxxxxxxxxxxxxx"
+    " xxxxxxxxxxxxxx"
+    "       xx      "
+    "       xx      "
+    "       xx      "
+    "       xx      "
+    "       xx      "
+    "       xx      "};
+
 //SQUARE_LINE_11_11
 const int SQUARE_LINE11_WIDTH = 11;
 const int SQUARE_LINE11_HEIGHT = 11;
@@ -416,6 +472,15 @@ MarkerBitmaps::initClass()
     markerIndex [std::make_pair("CROSS", 9)] = SoMarkerSet::CROSS_9_9;
     markerIndex [std::make_pair("CROSS", 7)] = SoMarkerSet::CROSS_7_7;
     markerIndex [std::make_pair("CROSS", 5)] = SoMarkerSet::CROSS_5_5;
+
+    createBitmap("PLUS", 11, 11, 11, plus11_marker);
+    createBitmap("PLUS", 13, 13, 13, plus13_marker);
+    createBitmap("PLUS", 15, 15, 15, plus15_marker);
+
+    // the built-in bitmaps of Coin
+    markerIndex [std::make_pair("PLUS", 9)] = SoMarkerSet::PLUS_9_9;
+    markerIndex [std::make_pair("PLUS", 7)] = SoMarkerSet::PLUS_7_7;
+    markerIndex [std::make_pair("PLUS", 5)] = SoMarkerSet::PLUS_5_5;
 
     createBitmap("SQUARE_LINE", 11, 11, 11, squareLine11_marker);
     createBitmap("SQUARE_LINE", 13, 13, 13, squareLine13_marker);

--- a/src/Gui/ViewProviderMeasureDistance.cpp
+++ b/src/Gui/ViewProviderMeasureDistance.cpp
@@ -50,6 +50,7 @@
 #include <App/MeasureDistance.h>
 #include <Base/Console.h>
 #include <Base/Quantity.h>
+#include <Inventor/MarkerBitmaps.h>
 
 using namespace Gui;
 
@@ -168,7 +169,7 @@ void ViewProviderMeasureDistance::attach(App::DocumentObject* pcObject)
     lineSep->addChild(pCoords);
     lineSep->addChild(pLines);
     SoMarkerSet* points = new SoMarkerSet();
-    points->markerIndex = SoMarkerSet::CROSS_9_9;
+    points->markerIndex = Gui::Inventor::MarkerBitmaps::getMarkerIndex("CROSS", App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/View")->GetInt("MarkerSize", 9));
     points->numPoints=2;
     lineSep->addChild(points);
 
@@ -287,7 +288,7 @@ ViewProviderPointMarker::ViewProviderPointMarker()
     pCoords->ref();
     pCoords->point.setNum(0);
     pMarker = new SoMarkerSet();
-    pMarker->markerIndex = SoMarkerSet::CROSS_9_9;
+    pMarker->markerIndex = Gui::Inventor::MarkerBitmaps::getMarkerIndex("CROSS", App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/View")->GetInt("MarkerSize", 9));
     pMarker->numPoints=0;
     pMarker->ref();
 

--- a/src/Mod/Arch/ArchEquipment.py
+++ b/src/Mod/Arch/ArchEquipment.py
@@ -350,7 +350,7 @@ class _ViewProviderEquipment(ArchComponent.ViewProviderComponent):
         sep.addChild(self.coords)
         self.coords.point.deleteValues(0)
         symbol = coin.SoMarkerSet()
-        symbol.markerIndex = coin.SoMarkerSet.CIRCLE_FILLED_5_5
+        symbol.markerIndex = FreeCADGui.getMarkerIndex("", 5)
         sep.addChild(symbol)
         rn = vobj.RootNode
         rn.addChild(sep)

--- a/src/Mod/Draft/Draft.py
+++ b/src/Mod/Draft/Draft.py
@@ -285,7 +285,7 @@ def dimSymbol(symbol=None,invert=False):
         return coin.SoSphere()
     elif symbol == 1:
         marker = coin.SoMarkerSet()
-        marker.markerIndex = coin.SoMarkerSet.CIRCLE_LINE_9_9
+        marker.markerIndex = FreeCADGui.getMarkerIndex("circle", 9)
         return marker
     elif symbol == 2:
         marker = coin.SoSeparator()

--- a/src/Mod/Draft/DraftTrackers.py
+++ b/src/Mod/Draft/DraftTrackers.py
@@ -116,7 +116,7 @@ class snapTracker(Tracker):
         color = coin.SoBaseColor()
         color.rgb = FreeCADGui.draftToolBar.getDefaultColor("snap")
         self.marker = coin.SoMarkerSet() # this is the marker symbol
-        self.marker.markerIndex = FreeCADGui.getMarkerIndex("")
+        self.marker.markerIndex = FreeCADGui.getMarkerIndex("", 9)
         self.coords = coin.SoCoordinate3() # this is the coordinate
         self.coords.point.setValue((0,0,0))
         node = coin.SoAnnotation()
@@ -126,7 +126,7 @@ class snapTracker(Tracker):
         Tracker.__init__(self,children=[node],name="snapTracker")
 
     def setMarker(self,style):
-        self.marker.markerIndex = FreeCADGui.getMarkerIndex(style)
+        self.marker.markerIndex = FreeCADGui.getMarkerIndex(style, 9)
 
     def setCoords(self,point):
         self.coords.point.setValue((point.x,point.y,point.z))
@@ -654,7 +654,7 @@ class ghostTracker(Tracker):
 class editTracker(Tracker):
     "A node edit tracker"
     def __init__(self,pos=Vector(0,0,0),name="None",idx=0,objcol=None,\
-            marker=coin.SoMarkerSet.SQUARE_FILLED_9_9,inactive=False):
+            marker=FreeCADGui.getMarkerIndex("quad", 9),inactive=False):
         color = coin.SoBaseColor()
         if objcol:
             color.rgb = objcol[:3]

--- a/src/Mod/Fem/Gui/TaskPostBoxes.cpp
+++ b/src/Mod/Fem/Gui/TaskPostBoxes.cpp
@@ -66,6 +66,7 @@
 # include <Inventor/nodes/SoMarkerSet.h>
 # include <Inventor/nodes/SoDrawStyle.h>
 #include <Gui/View3DInventorViewer.h>
+#include <Gui/Inventor/MarkerBitmaps.h>
 #include <Base/Console.h>
 
 #include <App/PropertyGeo.h>
@@ -198,7 +199,7 @@ ViewProviderDataMarker::ViewProviderDataMarker()
     pCoords->ref();
     pCoords->point.setNum(0);
     pMarker = new SoMarkerSet();
-    pMarker->markerIndex = SoMarkerSet::CIRCLE_FILLED_9_9;
+    pMarker->markerIndex = Gui::Inventor::MarkerBitmaps::getMarkerIndex("CIRCLE_FILLED", App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/View")->GetInt("MarkerSize", 9));
     pMarker->numPoints=0;
     pMarker->ref();
 

--- a/src/Mod/Mesh/Gui/ViewProviderDefects.cpp
+++ b/src/Mod/Mesh/Gui/ViewProviderDefects.cpp
@@ -41,6 +41,7 @@
 #include <Base/Sequencer.h>
 #include <App/Application.h>
 #include <Gui/Selection.h>
+#include <Gui/Inventor/MarkerBitmaps.h>
 
 #include <Mod/Mesh/App/Core/Degeneration.h>
 #include <Mod/Mesh/App/Core/Evaluation.h>
@@ -134,7 +135,7 @@ void ViewProviderMeshOrientation::attach(App::DocumentObject* pcFeat)
     SoBaseColor * markcol = new SoBaseColor;
     markcol->rgb.setValue( 1.0f, 1.0f, 0.0f );
     SoMarkerSet* marker = new SoMarkerSet;
-    marker->markerIndex=SoMarkerSet::PLUS_7_7;
+    marker->markerIndex=Gui::Inventor::MarkerBitmaps::getMarkerIndex("PLUS", App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/View")->GetInt("MarkerSize", 7));
     linesep->addChild(markcol);
     linesep->addChild(marker);
 
@@ -201,7 +202,7 @@ void ViewProviderMeshNonManifolds::attach(App::DocumentObject* pcFeat)
     SoBaseColor * markcol = new SoBaseColor;
     markcol->rgb.setValue( 1.0f, 1.0f, 0.0f );
     SoMarkerSet* marker = new SoMarkerSet;
-    marker->markerIndex=SoMarkerSet::PLUS_7_7;
+    marker->markerIndex=Gui::Inventor::MarkerBitmaps::getMarkerIndex("PLUS", App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/View")->GetInt("MarkerSize", 7));
     linesep->addChild(markcol);
     linesep->addChild(marker);
 
@@ -266,7 +267,7 @@ void ViewProviderMeshNonManifoldPoints::attach(App::DocumentObject* pcFeat)
     SoBaseColor * markcol = new SoBaseColor;
     markcol->rgb.setValue( 1.0f, 1.0f, 0.0f );
     SoMarkerSet* marker = new SoMarkerSet;
-    marker->markerIndex=SoMarkerSet::PLUS_7_7;
+    marker->markerIndex=Gui::Inventor::MarkerBitmaps::getMarkerIndex("PLUS", App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/View")->GetInt("MarkerSize", 7));
     pointsep->addChild(markcol);
     pointsep->addChild(marker);
 
@@ -330,7 +331,7 @@ void ViewProviderMeshDuplicatedFaces::attach(App::DocumentObject* pcFeat)
     SoBaseColor * markcol = new SoBaseColor;
     markcol->rgb.setValue( 1.0f, 1.0f, 0.0f );
     SoMarkerSet* marker = new SoMarkerSet;
-    marker->markerIndex=SoMarkerSet::PLUS_7_7;
+    marker->markerIndex=Gui::Inventor::MarkerBitmaps::getMarkerIndex("PLUS", App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/View")->GetInt("MarkerSize", 7));
     linesep->addChild(markcol);
     linesep->addChild(marker);
 
@@ -395,7 +396,7 @@ void ViewProviderMeshDuplicatedPoints::attach(App::DocumentObject* pcFeat)
     SoBaseColor * markcol = new SoBaseColor;
     markcol->rgb.setValue( 1.0f, 1.0f, 0.0f );
     SoMarkerSet* marker = new SoMarkerSet;
-    marker->markerIndex=SoMarkerSet::PLUS_7_7;
+    marker->markerIndex=Gui::Inventor::MarkerBitmaps::getMarkerIndex("PLUS", App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/View")->GetInt("MarkerSize", 7));
     pointsep->addChild(markcol);
     pointsep->addChild(marker);
 
@@ -452,7 +453,7 @@ void ViewProviderMeshDegenerations::attach(App::DocumentObject* pcFeat)
     SoBaseColor * markcol = new SoBaseColor;
     markcol->rgb.setValue( 1.0f, 1.0f, 0.0f );
     SoMarkerSet* marker = new SoMarkerSet;
-    marker->markerIndex=SoMarkerSet::PLUS_7_7;
+    marker->markerIndex=Gui::Inventor::MarkerBitmaps::getMarkerIndex("PLUS", App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/View")->GetInt("MarkerSize", 7));
     linesep->addChild(markcol);
     linesep->addChild(marker);
 
@@ -558,7 +559,7 @@ void ViewProviderMeshIndices::attach(App::DocumentObject* pcFeat)
     SoBaseColor * markcol = new SoBaseColor;
     markcol->rgb.setValue( 1.0f, 1.0f, 0.0f );
     SoMarkerSet* marker = new SoMarkerSet;
-    marker->markerIndex=SoMarkerSet::PLUS_7_7;
+    marker->markerIndex=Gui::Inventor::MarkerBitmaps::getMarkerIndex("PLUS", App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/View")->GetInt("MarkerSize", 7));
     linesep->addChild(markcol);
     linesep->addChild(marker);
 
@@ -625,7 +626,7 @@ void ViewProviderMeshSelfIntersections::attach(App::DocumentObject* pcFeat)
     SoBaseColor * markcol = new SoBaseColor;
     markcol->rgb.setValue( 1.0f, 1.0f, 0.0f );
     SoMarkerSet* marker = new SoMarkerSet;
-    marker->markerIndex=SoMarkerSet::PLUS_7_7;
+    marker->markerIndex=Gui::Inventor::MarkerBitmaps::getMarkerIndex("PLUS", App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/View")->GetInt("MarkerSize", 7));
     linesep->addChild(markcol);
     linesep->addChild(marker);
 
@@ -705,7 +706,7 @@ void ViewProviderMeshFolds::attach(App::DocumentObject* pcFeat)
     SoBaseColor * markcol = new SoBaseColor;
     markcol->rgb.setValue( 1.0f, 1.0f, 0.0f );
     SoMarkerSet* marker = new SoMarkerSet;
-    marker->markerIndex=SoMarkerSet::PLUS_7_7;
+    marker->markerIndex=Gui::Inventor::MarkerBitmaps::getMarkerIndex("PLUS", App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/View")->GetInt("MarkerSize", 7));
     linesep->addChild(markcol);
     linesep->addChild(marker);
 

--- a/src/Mod/PartDesign/Gui/ViewProviderDatumPoint.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderDatumPoint.cpp
@@ -32,6 +32,8 @@
 #include "ViewProviderDatumPoint.h"
 // #include <Mod/Part/Gui/SoBrepPointSet.h>
 #include <Mod/PartDesign/App/DatumPoint.h>
+#include <Gui/Inventor/MarkerBitmaps.h>
+#include <App/Application.h>
 
 using namespace PartDesignGui;
 
@@ -65,7 +67,7 @@ void ViewProviderDatumPoint::attach ( App::DocumentObject *obj ) {
     SoMarkerSet* marker = new SoMarkerSet();
     marker->vertexProperty = vprop;
     marker->numPoints = 1;
-    marker->markerIndex = SoMarkerSet::DIAMOND_FILLED_9_9;
+    marker->markerIndex = Gui::Inventor::MarkerBitmaps::getMarkerIndex("DIAMOND_FILLED", App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/View")->GetInt("MarkerSize", 9));
 
     getShapeRoot ()->addChild(marker);
 }

--- a/src/Mod/Path/Gui/ViewProviderPath.cpp
+++ b/src/Mod/Path/Gui/ViewProviderPath.cpp
@@ -91,8 +91,6 @@ ViewProviderPath::ViewProviderPath()
     ADD_PROPERTY_TYPE(NormalColor,(lr,lg,lb),"Path",App::Prop_None,"The color of the feed rate moves");
     ADD_PROPERTY_TYPE(MarkerColor,(mr,mg,mb),"Path",App::Prop_None,"The color of the markers");
     ADD_PROPERTY_TYPE(LineWidth,(lwidth),"Path",App::Prop_None,"The line width of this path");
-    int markerSize = hGrp->GetInt("DefaultPathMarkerSize",4);
-    ADD_PROPERTY_TYPE(MarkerSize,(markerSize),"Path",App::Prop_None,"The point size of the markers");
     ADD_PROPERTY_TYPE(ShowNodes,(false),"Path",App::Prop_None,"Turns the display of nodes on/off");
 
 
@@ -121,7 +119,7 @@ ViewProviderPath::ViewProviderPath()
     pcMarkerStyle = new SoDrawStyle();
     pcMarkerStyle->ref();
     pcMarkerStyle->style = SoDrawStyle::POINTS;
-    pcMarkerStyle->pointSize = MarkerSize.getValue();
+    pcMarkerStyle->pointSize = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/View")->GetInt("MarkerSize", 4);
 
     pcDrawStyle = new SoDrawStyle();
     pcDrawStyle->ref();
@@ -305,8 +303,6 @@ void ViewProviderPath::onChanged(const App::Property* prop)
 
     if (prop == &LineWidth) {
         pcDrawStyle->lineWidth = LineWidth.getValue();
-    } else if (prop == &MarkerSize) {
-        pcMarkerStyle->pointSize = MarkerSize.getValue();
     } else if (prop == &NormalColor) {
         if (colorindex.size() > 0 && coordStart>=0 && coordStart<(int)colorindex.size()) {
             const App::Color& c = NormalColor.getValue();

--- a/src/Mod/Path/Gui/ViewProviderPath.h
+++ b/src/Mod/Path/Gui/ViewProviderPath.h
@@ -59,7 +59,6 @@ public:
     App::PropertyInteger LineWidth;
     App::PropertyColor   NormalColor;
     App::PropertyColor   MarkerColor;
-    App::PropertyInteger MarkerSize;
     App::PropertyBool    ShowNodes;
     App::PropertyVector  StartPosition;
 

--- a/src/Mod/Robot/Gui/ViewProviderTrajectory.cpp
+++ b/src/Mod/Robot/Gui/ViewProviderTrajectory.cpp
@@ -52,6 +52,8 @@
 #include <Base/FileInfo.h>
 #include <Base/Stream.h>
 #include <Base/Console.h>
+#include <App/Application.h>
+#include <Gui/Inventor/MarkerBitmaps.h>
 #include <sstream>
 using namespace Gui;
 using namespace RobotGui;
@@ -106,7 +108,7 @@ void ViewProviderTrajectory::attach(App::DocumentObject *pcObj)
     SoBaseColor * markcol = new SoBaseColor;
     markcol->rgb.setValue( 1.0f, 1.0f, 0.0f );
     SoMarkerSet* marker = new SoMarkerSet;
-    marker->markerIndex=SoMarkerSet::CROSS_5_5;
+    marker->markerIndex=Gui::Inventor::MarkerBitmaps::getMarkerIndex("CROSS", App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/View")->GetInt("MarkerSize", 5));
     linesep->addChild(markcol);
     linesep->addChild(marker);
 

--- a/src/Mod/Sketcher/Gui/SketcherSettings.cpp
+++ b/src/Mod/Sketcher/Gui/SketcherSettings.cpp
@@ -109,10 +109,6 @@ void SketcherSettings::saveSettings()
     ui->checkBoxNotifyConstraintSubstitutions->onSave();
     form->saveSettings();
 
-    ParameterGrp::handle hViewGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/View");
-    int markerSize = ui->EditSketcherMarkerSize->itemData(ui->EditSketcherMarkerSize->currentIndex()).toInt();
-    hViewGrp->SetInt("EditSketcherMarkerSize", markerSize);
-
     ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Mod/Part");
     QVariant data = ui->comboBox->itemData(ui->comboBox->currentIndex());
     int pattern = data.toInt();
@@ -135,16 +131,6 @@ void SketcherSettings::loadSettings()
     ui->checkBoxTVRestoreCamera->onRestore();
     ui->checkBoxNotifyConstraintSubstitutions->onRestore();
     form->loadSettings();
-
-    std::list<int> sizes = Gui::Inventor::MarkerBitmaps::getSupportedSizes("CIRCLE_FILLED");
-    for (std::list<int>::iterator it = sizes.begin(); it != sizes.end(); ++it)
-        ui->EditSketcherMarkerSize->addItem(tr("%1 px").arg(*it), *it);
-    ParameterGrp::handle hViewGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/View");
-    int markerSize = hViewGrp->GetInt("EditSketcherMarkerSize", 7);
-    int markerIndex = ui->EditSketcherMarkerSize->findData(QVariant(markerSize));
-    if (markerIndex < 0)
-        markerIndex = 1;
-    ui->EditSketcherMarkerSize->setCurrentIndex(markerIndex);
 
     ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Mod/Part");
     int pattern = hGrp->GetInt("GridLinePattern", 0x0f0f);

--- a/src/Mod/Sketcher/Gui/SketcherSettings.ui
+++ b/src/Mod/Sketcher/Gui/SketcherSettings.ui
@@ -55,27 +55,14 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="label_marker">
-        <property name="minimumSize">
-         <size>
-          <width>182</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="text">
-         <string>Marker size</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="1">
+      <item row="1" column="1">
        <widget class="QComboBox" name="comboBox">
         <property name="currentIndex">
          <number>-1</number>
         </property>
        </widget>
       </item>
-      <item row="4" column="0" colspan="2">
+      <item row="3" column="0" colspan="2">
        <widget class="Gui::PrefCheckBox" name="dialogOnDistanceConstraint">
         <property name="text">
          <string>Ask for value after creating a distance constraint</string>
@@ -91,17 +78,14 @@
         </property>
        </widget>
       </item>
-      <item row="2" column="0">
+      <item row="1" column="0">
        <widget class="QLabel" name="label_7">
         <property name="text">
          <string>Grid line pattern</string>
         </property>
        </widget>
       </item>
-      <item row="1" column="1">
-       <widget class="QComboBox" name="EditSketcherMarkerSize"/>
-      </item>
-      <item row="5" column="0" colspan="2">
+      <item row="4" column="0" colspan="2">
        <widget class="Gui::PrefCheckBox" name="continueMode">
         <property name="text">
          <string>Geometry Creation &quot;Continue Mode&quot;</string>
@@ -117,7 +101,7 @@
         </property>
        </widget>
       </item>
-      <item row="6" column="0" colspan="2">
+      <item row="5" column="0" colspan="2">
        <widget class="Gui::PrefCheckBox" name="constraintMode">
         <property name="text">
          <string>Constraint Creation &quot;Continue Mode&quot; (Experimental)</string>
@@ -133,7 +117,7 @@
         </property>
        </widget>
       </item>
-      <item row="7" column="0" colspan="2">
+      <item row="6" column="0" colspan="2">
        <widget class="QGroupBox" name="groupBox_3">
         <property name="enabled">
          <bool>true</bool>
@@ -280,7 +264,7 @@
         </layout>
        </widget>
       </item>
-      <item row="8" column="0" colspan="2">
+      <item row="7" column="0" colspan="2">
        <widget class="QGroupBox" name="groupBox_5">
         <property name="enabled">
          <bool>true</bool>
@@ -335,14 +319,14 @@
         </layout>
        </widget>
       </item>
-      <item row="3" column="0">
+      <item row="2" column="0">
        <widget class="QLabel" name="label_10">
         <property name="text">
          <string>Segments per geometry</string>
         </property>
        </widget>
       </item>
-      <item row="3" column="1">
+      <item row="2" column="1">
        <widget class="Gui::PrefSpinBox" name="SegmentsPerGeometry">
         <property name="minimum">
          <number>50</number>
@@ -424,7 +408,6 @@
  </customwidgets>
  <tabstops>
   <tabstop>EditSketcherFontSize</tabstop>
-  <tabstop>EditSketcherMarkerSize</tabstop>
   <tabstop>comboBox</tabstop>
   <tabstop>dialogOnDistanceConstraint</tabstop>
   <tabstop>continueMode</tabstop>

--- a/src/Mod/Sketcher/Gui/TaskSketcherValidation.cpp
+++ b/src/Mod/Sketcher/Gui/TaskSketcherValidation.cpp
@@ -57,6 +57,7 @@
 #include <Gui/Application.h>
 #include <Gui/ViewProvider.h>
 #include <Gui/WaitCursor.h>
+#include <Gui/Inventor/MarkerBitmaps.h>
 
 using namespace SketcherGui;
 using namespace Gui::TaskView;
@@ -545,7 +546,7 @@ void SketcherValidation::showPoints(const std::vector<Base::Vector3d>& pts)
     SoBaseColor * markcol = new SoBaseColor();
     markcol->rgb.setValue(1.0f, 1.0f, 0.0f);
     SoMarkerSet* marker = new SoMarkerSet();
-    marker->markerIndex=SoMarkerSet::PLUS_9_9;
+    marker->markerIndex=Gui::Inventor::MarkerBitmaps::getMarkerIndex("PLUS", App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/View")->GetInt("MarkerSize", 9));
     pointsep->addChild(markcol);
     pointsep->addChild(marker);
 

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -5336,7 +5336,7 @@ bool ViewProviderSketch::setEdit(int ModNum)
     edit = new EditData();
 
     ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/View");
-    edit->MarkerSize = hGrp->GetInt("EditSketcherMarkerSize", 7);
+    edit->MarkerSize = hGrp->GetInt("MarkerSize", 7);
 
     createEditInventorNodes();
 


### PR DESCRIPTION
Extended the global marker size usage for other modes' markers too.

Perhaps you might want to have some discussion regarding already existing marker size settings in Path and Sketcher...
In my opinion - the marker size must be uniform for any modes, so it's logical to have only one place to set the marker size and expect it to be sized uniformly throughout all the modes. Instead of going to each mode's setting separately and change for each of them one by one. But Path and Sketcher already have their own marker size setting at the time, so making them use the newly implemented global marker size slightly affects the backward compatibility... IMHO it's not a big deal for the software which is still in beta stage, especially taking into account the change is not invasive at all. But if you have different opinion about it - I've intentionally separated the Path and Sketcher changes into two different commits, so you can use cherry-pick if you like to leave each of them with their own setting for marker size...