### PR TITLE
Detect OCCT at new Debian location

### DIFF
--- a/cMake/FindOpenCasCade.cmake
+++ b/cMake/FindOpenCasCade.cmake
@@ -68,6 +68,7 @@ else(OCE_FOUND) #look for OpenCASCADE
       endif(CYGWIN OR MINGW)
     else(WIN32)
       FIND_PATH(OCC_INCLUDE_DIR Standard_Version.hxx
+        /usr/include/occt
         /usr/include/opencascade
         /usr/local/include/opencascade
         /opt/opencascade/include


### PR DESCRIPTION
Now that OCCT is in Debian Testing we can expect future Debian & Ubuntu versions to have OCCT available at /usr/include/occt.
