### PR TITLE
Misc. typo & whitespace fixes

### DIFF
--- a/src/Base/Parameter.cpp
+++ b/src/Base/Parameter.cpp
@@ -215,7 +215,7 @@ ParameterGrp::~ParameterGrp()
 
 void ParameterGrp::copyTo(Base::Reference<ParameterGrp> Grp)
 {
-    // delete previos content
+    // delete previous content
     Grp->Clear();
 
     // copy all

--- a/src/Gui/Splashscreen.cpp
+++ b/src/Gui/Splashscreen.cpp
@@ -187,8 +187,8 @@ SplashScreen::~SplashScreen()
     delete messages;
 }
 
-/** 
- * Draws the contents of the splash screen using painter \a painter. The default 
+/**
+ * Draws the contents of the splash screen using painter \a painter. The default
  * implementation draws the message passed by message().
  */
 void SplashScreen::drawContents ( QPainter * painter )
@@ -249,7 +249,7 @@ AboutDialog::AboutDialog(bool showLic, QWidget* parent)
 //    if (showLic) { // currently disabled. Additional license blocks are always shown.
         QString info(QLatin1String("SUCH DAMAGES.<hr/>"));
         // any additional piece of text to be added after the main license text goes below.
-        // Please set title in <h2> tags, license text in <p> tags 
+        // Please set title in <h2> tags, license text in <p> tags
         // and add an <hr/> tag at the end to nicely separate license blocks
 #ifdef _USE_3DCONNEXION_SDK
         info += QString::fromLatin1(
@@ -449,7 +449,7 @@ void AboutDialog::setupLabels()
     if (qApp->styleSheet().isEmpty()) {
         setStyleSheet(QString::fromLatin1("Gui--Dialog--AboutDialog QLabel {font-size: %1pt;}").arg(fontSize));
     }
-    
+
     QString exeName = qApp->applicationName();
     std::map<std::string, std::string>& config = App::Application::Config();
     std::map<std::string,std::string>::iterator it;
@@ -461,7 +461,7 @@ void AboutDialog::setupLabels()
     QString disda  = QString::fromLatin1(config["BuildRevisionDate"].c_str());
     QString mturl  = QString::fromLatin1(config["MaintainerUrl"].c_str());
 
-    // we use replace() to keep label formating, so a label with text "<b>Unknown</b>"
+    // we use replace() to keep label formatting, so a label with text "<b>Unknown</b>"
     // gets replaced to "<b>FreeCAD</b>", for example
 
     QString author = ui->labelAuthor->text();
@@ -490,7 +490,7 @@ void AboutDialog::setupLabels()
     platform.replace(QString::fromLatin1("Unknown"),
         QString::fromLatin1("%1-bit").arg(QSysInfo::WordSize));
     ui->labelBuildPlatform->setText(platform);
-    
+
     // branch name
     it = config.find("BuildRevisionBranch");
     if (it != config.end()) {

--- a/src/Mod/Image/Gui/Resources/icons/image-scale.svg
+++ b/src/Mod/Image/Gui/Resources/icons/image-scale.svg
@@ -342,7 +342,7 @@
             <rdf:li />
           </rdf:Bag>
         </dc:subject>
-        <dc:description>A small square in the bottom left corner of a large dotted box ith an arrow pointing from the top left corner of the inner box to the top left corner of the outer box</dc:description>
+        <dc:description>A small square in the bottom left corner of a large dotted box with an arrow pointing from the top left corner of the inner box to the top left corner of the outer box</dc:description>
       </cc:Work>
     </rdf:RDF>
   </metadata>

--- a/src/Mod/Import/App/dxf.cpp
+++ b/src/Mod/Import/App/dxf.cpp
@@ -25,7 +25,7 @@ CDxfWrite::CDxfWrite(const char* filepath)
         return;
     }
     m_ofs->imbue(std::locale("C"));
-    
+
     writeHeaderSection();
     writeTablesSection();
 
@@ -106,7 +106,7 @@ void CDxfWrite::WriteLWPolyLine(LWPolyDataOut pd, const char* layer_name)
         (*m_ofs) << p.x          << endl;
         (*m_ofs) << " 20"        << endl;
         (*m_ofs) << p.y          << endl;
-    } 
+    }
     for (auto& s: pd.StartWidth) {
         (*m_ofs) << " 40"        << endl;
         (*m_ofs) << s            << endl;    // Start Width
@@ -160,7 +160,7 @@ void CDxfWrite::WritePolyline(LWPolyDataOut pd, const char* layer_name)
         (*m_ofs) << p.y          << endl;
         (*m_ofs) << " 30"        << endl;
         (*m_ofs) << "0.0"        << endl;
-    } 
+    }
     (*m_ofs) << "  0"            << endl;
     (*m_ofs) << "SEQEND"         << endl;
     (*m_ofs) << "  8"            << endl;
@@ -287,13 +287,13 @@ void CDxfWrite::WriteSpline(SplineDataOut sd, const char* layer_name)
     //normal 210,220,230
     (*m_ofs) << " 70"          << endl;
     (*m_ofs) << sd.flag        << endl;      //flags
-    (*m_ofs) << " 71"          << endl; 
+    (*m_ofs) << " 71"          << endl;
     (*m_ofs) << sd.degree      << endl;
     (*m_ofs) << " 72"          << endl;
     (*m_ofs) << sd.knots       << endl;
     (*m_ofs) << " 73"          << endl;
     (*m_ofs) << sd.control_points   << endl;
-    (*m_ofs) << " 74"          << endl; 
+    (*m_ofs) << " 74"          << endl;
     (*m_ofs) << 0              << endl;
 
     (*m_ofs) << " 12"          << endl;
@@ -310,13 +310,13 @@ void CDxfWrite::WriteSpline(SplineDataOut sd, const char* layer_name)
     (*m_ofs) << sd.endtan.z    << endl;
 
     for (auto& k: sd.knot) {
-        (*m_ofs) << " 40"      << endl;  
-        (*m_ofs) << k          << endl;  
+        (*m_ofs) << " 40"      << endl;
+        (*m_ofs) << k          << endl;
     }
 
     for (auto& w : sd.weight) {
-        (*m_ofs) << " 41"      << endl;  
-        (*m_ofs) << w          << endl;  
+        (*m_ofs) << " 41"      << endl;
+        (*m_ofs) << w          << endl;
     }
 
     for (auto& c: sd.control) {
@@ -352,7 +352,7 @@ void CDxfWrite::WriteVertex(double x, double y, double z, const char* layer_name
 //    (*m_ofs) << "AcDbVertex"   << endl;
     (*m_ofs) << " 10"          << endl;
     (*m_ofs) << x              << endl;
-    (*m_ofs) << " 20"          << endl; 
+    (*m_ofs) << " 20"          << endl;
     (*m_ofs) << y              << endl;
     (*m_ofs) << " 30"          << endl;
     (*m_ofs) << z              << endl;
@@ -378,7 +378,7 @@ void CDxfWrite::WriteText(const char* text, const double* location1, const doubl
     (*m_ofs) << 0              << endl;     //thickness
     (*m_ofs) << " 10"          << endl;     //first alignment point
     (*m_ofs) << location1[0]   << endl;
-    (*m_ofs) << " 20"          << endl; 
+    (*m_ofs) << " 20"          << endl;
     (*m_ofs) << location1[1]   << endl;
     (*m_ofs) << " 30"          << endl;
     (*m_ofs) << location1[2]   << endl;
@@ -398,7 +398,7 @@ void CDxfWrite::WriteText(const char* text, const double* location1, const doubl
     (*m_ofs) << "0"            << endl;
     (*m_ofs) << " 11"          << endl;    //second alignment point
     (*m_ofs) << location2[0]   << endl;
-    (*m_ofs) << " 21"          << endl; 
+    (*m_ofs) << " 21"          << endl;
     (*m_ofs) << location2[1]   << endl;
     (*m_ofs) << " 31"          << endl;
     (*m_ofs) << location2[2]   << endl;
@@ -425,13 +425,13 @@ void CDxfWrite::WriteLinearDim(const double* textMidPoint, const double* lineDef
     (*m_ofs) << "*" << layer_name     << endl;     // blockName
     (*m_ofs) << " 10"          << endl;     //dimension line definition point
     (*m_ofs) << lineDefPoint[0]    << endl;
-    (*m_ofs) << " 20"          << endl; 
+    (*m_ofs) << " 20"          << endl;
     (*m_ofs) << lineDefPoint[1]    << endl;
     (*m_ofs) << " 30"          << endl;
     (*m_ofs) << lineDefPoint[2]    << endl;
     (*m_ofs) << " 11"          << endl;     //text mid point
     (*m_ofs) << textMidPoint[0]    << endl;
-    (*m_ofs) << " 21"          << endl; 
+    (*m_ofs) << " 21"          << endl;
     (*m_ofs) << textMidPoint[1]    << endl;
     (*m_ofs) << " 31"          << endl;
     (*m_ofs) << textMidPoint[2]    << endl;
@@ -440,7 +440,7 @@ void CDxfWrite::WriteLinearDim(const double* textMidPoint, const double* lineDef
 //    (*m_ofs) << " 71"          << endl;    // not R12
 //    (*m_ofs) << 1              << endl;    // attachPoint ??1 = topleft
     (*m_ofs) << "  1"          << endl;
-    (*m_ofs) << dimText        << endl;    
+    (*m_ofs) << dimText        << endl;
     (*m_ofs) << "  3"          << endl;
     (*m_ofs) << "STANDARD"     << endl;    //style
 //linear dims
@@ -448,13 +448,13 @@ void CDxfWrite::WriteLinearDim(const double* textMidPoint, const double* lineDef
 //    (*m_ofs) << "AcDbAlignedDimension"     << endl;
     (*m_ofs) << " 13"          << endl;
     (*m_ofs) << extLine1[0]    << endl;
-    (*m_ofs) << " 23"          << endl; 
+    (*m_ofs) << " 23"          << endl;
     (*m_ofs) << extLine1[1]    << endl;
     (*m_ofs) << " 33"          << endl;
     (*m_ofs) << extLine1[2]    << endl;
     (*m_ofs) << " 14"          << endl;
     (*m_ofs) << extLine2[0]    << endl;
-    (*m_ofs) << " 24"          << endl; 
+    (*m_ofs) << " 24"          << endl;
     (*m_ofs) << extLine2[1]    << endl;
     (*m_ofs) << " 34"          << endl;
     (*m_ofs) << extLine2[2]    << endl;
@@ -487,14 +487,14 @@ void CDxfWrite::WriteAngularDim(const double* textMidPoint, const double* lineDe
 
     (*m_ofs) << " 10"          << endl;
     (*m_ofs) << endExt2[0]     << endl;
-    (*m_ofs) << " 20"          << endl; 
+    (*m_ofs) << " 20"          << endl;
     (*m_ofs) << endExt2[1]     << endl;
     (*m_ofs) << " 30"          << endl;
     (*m_ofs) << endExt2[2]     << endl;
 
     (*m_ofs) << " 11"          << endl;
     (*m_ofs) << textMidPoint[0]  << endl;
-    (*m_ofs) << " 21"          << endl; 
+    (*m_ofs) << " 21"          << endl;
     (*m_ofs) << textMidPoint[1]  << endl;
     (*m_ofs) << " 31"          << endl;
     (*m_ofs) << textMidPoint[2]  << endl;
@@ -505,7 +505,7 @@ void CDxfWrite::WriteAngularDim(const double* textMidPoint, const double* lineDe
 //    (*m_ofs) << " 71"          << endl;    // not R12
 //    (*m_ofs) << 5              << endl;    // attachPoint 5 = middle
     (*m_ofs) << "  1"          << endl;
-    (*m_ofs) << dimText        << endl;    
+    (*m_ofs) << dimText        << endl;
     (*m_ofs) << "  3"          << endl;
     (*m_ofs) << "STANDARD"     << endl;    //style
 //angular dims
@@ -514,28 +514,28 @@ void CDxfWrite::WriteAngularDim(const double* textMidPoint, const double* lineDe
 
     (*m_ofs) << " 13"           << endl;
     (*m_ofs) << startExt1[0]    << endl;
-    (*m_ofs) << " 23"           << endl; 
+    (*m_ofs) << " 23"           << endl;
     (*m_ofs) << startExt1[1]    << endl;
     (*m_ofs) << " 33"           << endl;
     (*m_ofs) << startExt1[2]    << endl;
 
     (*m_ofs) << " 14"           << endl;
     (*m_ofs) << endExt1[0]      << endl;
-    (*m_ofs) << " 24"           << endl; 
+    (*m_ofs) << " 24"           << endl;
     (*m_ofs) << endExt1[1]      << endl;
     (*m_ofs) << " 34"           << endl;
     (*m_ofs) << endExt1[2]      << endl;
 
     (*m_ofs) << " 15"           << endl;
     (*m_ofs) << startExt2[0]    << endl;
-    (*m_ofs) << " 25"           << endl; 
+    (*m_ofs) << " 25"           << endl;
     (*m_ofs) << startExt2[1]    << endl;
     (*m_ofs) << " 35"           << endl;
     (*m_ofs) << startExt2[2]    << endl;
 
     (*m_ofs) << " 16"           << endl;
     (*m_ofs) << lineDefPoint[0] << endl;
-    (*m_ofs) << " 26"           << endl; 
+    (*m_ofs) << " 26"           << endl;
     (*m_ofs) << lineDefPoint[1] << endl;
     (*m_ofs) << " 36"           << endl;
     (*m_ofs) << lineDefPoint[2] << endl;
@@ -549,7 +549,7 @@ void CDxfWrite::WriteAngularDim(const double* textMidPoint, const double* lineDe
 //***************************
 //WriteRadialDim
 //added by Wandererfan 2018 (wandererfan@gmail.com) for FreeCAD project
-void CDxfWrite::WriteRadialDim(const double* centerPoint, const double* textMidPoint, 
+void CDxfWrite::WriteRadialDim(const double* centerPoint, const double* textMidPoint,
                          const double* arcPoint,
                          const char* dimText,
                          const char* layer_name)
@@ -566,13 +566,13 @@ void CDxfWrite::WriteRadialDim(const double* centerPoint, const double* textMidP
     (*m_ofs) << "*" << layer_name     << endl;     // blockName
     (*m_ofs) << " 10"          << endl;     // arc center point
     (*m_ofs) << centerPoint[0] << endl;
-    (*m_ofs) << " 20"          << endl; 
+    (*m_ofs) << " 20"          << endl;
     (*m_ofs) << centerPoint[1] << endl;
     (*m_ofs) << " 30"          << endl;
     (*m_ofs) << centerPoint[2] << endl;
     (*m_ofs) << " 11"          << endl;     //text mid point
     (*m_ofs) << textMidPoint[0]   << endl;
-    (*m_ofs) << " 21"          << endl; 
+    (*m_ofs) << " 21"          << endl;
     (*m_ofs) << textMidPoint[1]   << endl;
     (*m_ofs) << " 31"          << endl;
     (*m_ofs) << textMidPoint[2]   << endl;
@@ -581,7 +581,7 @@ void CDxfWrite::WriteRadialDim(const double* centerPoint, const double* textMidP
 //    (*m_ofs) << " 71"          << endl;    // not R12
 //    (*m_ofs) << 1              << endl;    // attachPoint 5 = middle center
     (*m_ofs) << "  1"          << endl;
-    (*m_ofs) << dimText        << endl;    
+    (*m_ofs) << dimText        << endl;
     (*m_ofs) << "  3"          << endl;
     (*m_ofs) << "STANDARD"     << endl;    //style
 //radial dims
@@ -589,7 +589,7 @@ void CDxfWrite::WriteRadialDim(const double* centerPoint, const double* textMidP
 //    (*m_ofs) << "AcDbRadialDimension"     << endl;
     (*m_ofs) << " 15"          << endl;
     (*m_ofs) << arcPoint[0]    << endl;
-    (*m_ofs) << " 25"          << endl; 
+    (*m_ofs) << " 25"          << endl;
     (*m_ofs) << arcPoint[1]    << endl;
     (*m_ofs) << " 35"          << endl;
     (*m_ofs) << arcPoint[2]    << endl;
@@ -603,7 +603,7 @@ void CDxfWrite::WriteRadialDim(const double* centerPoint, const double* textMidP
 //***************************
 //WriteDiametricDim
 //added by Wandererfan 2018 (wandererfan@gmail.com) for FreeCAD project
-void CDxfWrite::WriteDiametricDim(const double* textMidPoint, 
+void CDxfWrite::WriteDiametricDim(const double* textMidPoint,
                          const double* arcPoint1, const double* arcPoint2,
                          const char* dimText,
                          const char* layer_name)
@@ -620,13 +620,13 @@ void CDxfWrite::WriteDiametricDim(const double* textMidPoint,
     (*m_ofs) << "*" << layer_name     << endl;     // blockName
     (*m_ofs) << " 10"          << endl;
     (*m_ofs) << arcPoint1[0]   << endl;
-    (*m_ofs) << " 20"          << endl; 
+    (*m_ofs) << " 20"          << endl;
     (*m_ofs) << arcPoint1[1]   << endl;
     (*m_ofs) << " 30"          << endl;
     (*m_ofs) << arcPoint1[2]   << endl;
     (*m_ofs) << " 11"          << endl;     //text mid point
     (*m_ofs) << textMidPoint[0]   << endl;
-    (*m_ofs) << " 21"          << endl; 
+    (*m_ofs) << " 21"          << endl;
     (*m_ofs) << textMidPoint[1]   << endl;
     (*m_ofs) << " 31"          << endl;
     (*m_ofs) << textMidPoint[2]   << endl;
@@ -635,7 +635,7 @@ void CDxfWrite::WriteDiametricDim(const double* textMidPoint,
 //    (*m_ofs) << " 71"          << endl;    // not R12
 //    (*m_ofs) << 5              << endl;    // attachPoint 5 = middle center
     (*m_ofs) << "  1"          << endl;
-    (*m_ofs) << dimText        << endl;    
+    (*m_ofs) << dimText        << endl;
     (*m_ofs) << "  3"          << endl;
     (*m_ofs) << "STANDARD"     << endl;    //style
 //diametric dims
@@ -643,7 +643,7 @@ void CDxfWrite::WriteDiametricDim(const double* textMidPoint,
 //    (*m_ofs) << "AcDbDiametricDimension"     << endl;
     (*m_ofs) << " 15"          << endl;
     (*m_ofs) << arcPoint2[0]   << endl;
-    (*m_ofs) << " 25"          << endl; 
+    (*m_ofs) << " 25"          << endl;
     (*m_ofs) << arcPoint2[1]   << endl;
     (*m_ofs) << " 35"          << endl;
     (*m_ofs) << arcPoint2[2]   << endl;
@@ -667,7 +667,7 @@ void CDxfWrite::writeDimBlockPreamble(const char* layer_name)
     m_ssBlock << "*" << layer_name     << endl;     // blockName
     m_ssBlock << " 10"          << endl;
     m_ssBlock << 0.0            << endl;
-    m_ssBlock << " 20"          << endl; 
+    m_ssBlock << " 20"          << endl;
     m_ssBlock << 0.0            << endl;
     m_ssBlock << " 30"          << endl;
     m_ssBlock << 0.0            << endl;
@@ -762,7 +762,7 @@ void CDxfWrite::writeLinearDimBlock(const double* textMidPoint, const double* di
     m_ssBlock << "CONTINUOUS"   << endl;
     m_ssBlock << " 62"          << endl;
     m_ssBlock << "     0"       << endl;
-    
+
     m_ssBlock << " 10"          << endl;
     m_ssBlock << textMidPoint[0]     << endl;
     m_ssBlock << " 20"          << endl;
@@ -879,7 +879,7 @@ void CDxfWrite::writeAngularDimBlock(const double* textMidPoint, const double* l
     Base::Vector3d endOff(cos(endAngle - offset),sin(endAngle - offset),0.0);
     startAngle = startAngle * 180.0 / Pi;
     endAngle = endAngle * 180.0 / Pi;
-    
+
     Base::Vector3d linePt(lineDefPoint[0],lineDefPoint[1],lineDefPoint[2]);
     double radius = (e2S - linePt).Length();
 
@@ -932,9 +932,9 @@ void CDxfWrite::writeAngularDimBlock(const double* textMidPoint, const double* l
     Base::Vector3d endTan = e1S + (startOff * radius);
     Base::Vector3d startTan = e2S + (endOff * radius);
     Base::Vector3d tanP1 = (arrow1Start - startTan).Normalize();
-    Base::Vector3d perp1(-tanP1.y,tanP1.x,tanP1.z); 
+    Base::Vector3d perp1(-tanP1.y,tanP1.x,tanP1.z);
     Base::Vector3d tanP2 = (arrow2Start - endTan).Normalize();
-    Base::Vector3d perp2(-tanP2.y,tanP2.x,tanP2.z); 
+    Base::Vector3d perp2(-tanP2.y,tanP2.x,tanP2.z);
     double arrowLen = 5.0;                  //magic number
     double arrowWidth = arrowLen/6.0/2.0;   //magic number calc!
 
@@ -1013,7 +1013,7 @@ void CDxfWrite::writeAngularDimBlock(const double* textMidPoint, const double* l
 //***************************
 //writeRadialDimBlock
 //added by Wandererfan 2018 (wandererfan@gmail.com) for FreeCAD project
-void CDxfWrite::writeRadialDimBlock(const double* centerPoint, const double* textMidPoint, 
+void CDxfWrite::writeRadialDimBlock(const double* centerPoint, const double* textMidPoint,
                          const double* arcPoint, const char* dimText)
 {
     m_ssBlock << "  0"          << endl;
@@ -1108,7 +1108,7 @@ void CDxfWrite::writeRadialDimBlock(const double* centerPoint, const double* tex
 //***************************
 //writeDiametricDimBlock
 //added by Wandererfan 2018 (wandererfan@gmail.com) for FreeCAD project
-void CDxfWrite::writeDiametricDimBlock(const double* textMidPoint, 
+void CDxfWrite::writeDiametricDimBlock(const double* textMidPoint,
                          const double* arcPoint1, const double* arcPoint2,
                          const char* dimText)
 {
@@ -1240,7 +1240,7 @@ void CDxfWrite::writeDiametricDimBlock(const double* textMidPoint,
 void CDxfWrite::writeHeaderSection(void)
 {
     std::stringstream ss;
-    ss << "FreeCAD v" << FCVersionMajor << "." << FCVersionMinor << " " << FCRevision; 
+    ss << "FreeCAD v" << FCVersionMajor << "." << FCVersionMinor << " " << FCRevision;
 
     //header & version
     (*m_ofs) << "999"      << endl;
@@ -1311,7 +1311,7 @@ void CDxfWrite::writeHeaderSection(void)
     (*m_ofs) << "$DIMTAD"   << endl;
     (*m_ofs) << " 70"       << endl;
     (*m_ofs) << "1"         << endl;
-    
+
     (*m_ofs) << "  9"       << endl;
     (*m_ofs) << "$DIMASZ"   << endl;
     (*m_ofs) << " 40"       << endl;
@@ -1348,7 +1348,7 @@ void CDxfWrite::writeTablesSection(void)
     (*m_ofs) << "VPORT"    << endl;
     (*m_ofs) << " 70"      << endl;
     (*m_ofs) << "    0"    << endl;
-    
+
 //    (*m_ofs) << "100"      << endl;
 //    (*m_ofs) << "AcDbSymbolTableRecord"    << endl;
 //    (*m_ofs) << "100"      << endl;
@@ -1458,7 +1458,7 @@ void CDxfWrite::writeTablesSection(void)
     (*m_ofs) << " 40"      << endl;
     (*m_ofs) << "1"        << endl;
 
-//wf: don't know what these do, but seem to be neccessary for import to ACAD
+//wf: don't know what these do, but seem to be necessary for import to ACAD
     (*m_ofs) << " 41"      << endl;
     (*m_ofs) << "2.5"      << endl;
     (*m_ofs) << " 42"      << endl;
@@ -1811,7 +1811,7 @@ bool CDxfRead::ReadArc()
     double c[3]; // centre
     double z_extrusion_dir = 1.0;
     bool hidden = false;
-    
+
     while(!((*m_ifs).eof()))
     {
         get_line();
@@ -1888,9 +1888,9 @@ bool CDxfRead::ReadArc()
                 get_line();
                 break;
             case 230:
-                //Z extrusion direction for arc 
+                //Z extrusion direction for arc
                 get_line();
-                ss.str(m_str); ss >> z_extrusion_dir; if(ss.fail()) return false;                                
+                ss.str(m_str); ss >> z_extrusion_dir; if(ss.fail()) return false;
                 break;
 
             default:
@@ -2471,7 +2471,7 @@ bool CDxfRead::ReadLwPolyLine()
                 ss.str(m_str); ss >> y; y = mm(y); if(ss.fail()) return false;
                 y_found = true;
                 break;
-            case 38: 
+            case 38:
                 // elevation
                 get_line();
                 ss.str(m_str); ss >> z; z = mm(z); if(ss.fail()) return false;
@@ -2682,7 +2682,7 @@ void CDxfRead::OnReadArc(double start_angle, double end_angle, double radius, co
     temp[0] =-c[0];
     temp[1] =c[1];
     temp[2] =c[2];
-    
+
     e[0] = -(c[0] + radius * cos(start_angle * Pi/180));
     e[1] = (c[1] + radius * sin(start_angle * Pi/180));
     e[2] = c[2];
@@ -2740,12 +2740,12 @@ bool CDxfRead::ReadInsert()
         std::istringstream ss;
         ss.imbue(std::locale("C"));
         switch(n){
-            case 0: 
+            case 0:
                 // next item found
                 DerefACI();
                 OnReadInsert(c, s, name, rot * Pi/180);
                 return(true);
-            case 8: 
+            case 8:
                 // Layer name follows
                 get_line();
                 strcpy(m_layer_name, m_str);
@@ -2832,12 +2832,12 @@ bool CDxfRead::ReadDimension()
         std::istringstream ss;
         ss.imbue(std::locale("C"));
         switch(n){
-            case 0: 
+            case 0:
                 // next item found
                 DerefACI();
                 OnReadDimension(s, e, p, rot * Pi/180);
                 return(true);
-            case 8: 
+            case 8:
                 // Layer name follows
                 get_line();
                 strcpy(m_layer_name, m_str);
@@ -3082,7 +3082,7 @@ void CDxfRead::DoRead(const bool ignore_errors /* = false */ )
             }
             continue;
         } // End if - then
-        
+
         else if(!strcmp(m_str, "0"))
         {
             get_line();
@@ -3107,9 +3107,9 @@ void CDxfRead::DoRead(const bool ignore_errors /* = false */ )
                   printf("CDxfRead::DoRead() Failed to read layer\n");
                   //return; Some objects or tables can have "LAYER" as name...
                 }
-              continue;     
+              continue;
         }
-        
+
         else if (!strcmp( m_str, "BLOCK" )) {
             if(!ReadBlockInfo())
             {

--- a/src/Mod/Material/Material.py
+++ b/src/Mod/Material/Material.py
@@ -97,7 +97,7 @@ def exportFCMat(fileName, matDict):
 
 def getMaterialAttributeStructure(withSpaces=None):
     # material properties
-    # see the following resources in the FreeCAD wiki for more informations about the material specific properties:
+    # see the following resources in the FreeCAD wiki for more information about the material specific properties:
     # https://www.freecadweb.org/wiki/Material_data_model
     # https://www.freecadweb.org/wiki/Material
     materialPropertyGroups = (

--- a/src/Mod/Path/PathTests/TestPathGeom.py
+++ b/src/Mod/Path/PathTests/TestPathGeom.py
@@ -121,7 +121,7 @@ class TestPathGeom(PathTestBase):
 
         # bezier curves
         # ml: I know nothing about bezier curves, so this might be bollocks
-        # and now I disable the tests because they seem to fail on OCE 
+        # and now I disable the tests because they seem to fail on OCE
         #bezier = Part.BezierCurve()
         #bezier.setPoles([Vector(), Vector(1,1,0), Vector(2,1,0), Vector(2,2,0)])
         #self.assertTrue(PathGeom.isHorizontal(Part.Edge(bezier)))
@@ -249,7 +249,7 @@ class TestPathGeom(PathTestBase):
         self.assertCommandEqual(cmds(p1, p4, p3,  True), cmd('G2', p1, Vector(0, -10, 0)))
 
     def test41(self):
-        """Verify circle results in proper G2/G3 comamnds."""
+        """Verify circle results in proper G2/G3 commands."""
 
         def cmds(center, radius, up = True):
             norm = Vector(0, 0, 1) if up else Vector(0, 0, -1)
@@ -448,7 +448,3 @@ class TestPathGeom(PathTestBase):
 
         edge = Part.Edge(Part.BSplineCurve([Vector(-8,4,0), Vector(1,-5,0), Vector(5,11,0), Vector(12,-5,0)], weights=[2,3,5,7]))
         self.assertEdgeShapesMatch(edge, PathGeom.flipEdge(edge))
-
-
-
-

--- a/src/Mod/TechDraw/Gui/QGIViewDimension.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewDimension.cpp
@@ -308,7 +308,7 @@ void QGIViewDimension::draw()
     if (!isVisible()) {                                                //should this be controlled by parent ViewPart?
         return;
     }
-    
+
     datumLabel->show();
     show();
 
@@ -356,11 +356,11 @@ void QGIViewDimension::draw()
         // text to left of vertical dims
         // text above horizontal dims
         Base::Vector3d dirDist, normDist;               //direction/normal vectors of distance line
-        Base::Vector3d dirExt, normExt;                 
+        Base::Vector3d dirExt, normExt;
         Base::Vector3d dirDim, normDim;
         Base::Vector3d dirIso;
-        dirDist = vecDist; 
-        dirDist.Normalize();                
+        dirDist = vecDist;
+        dirDist.Normalize();
         normDist = Base::Vector3d (-dirDist.y,dirDist.x, 0);         //normal to distance direction
                                                                      //toward dimension line?
         if (strcmp(dimType, "Distance") == 0 ) {
@@ -368,11 +368,11 @@ void QGIViewDimension::draw()
             dirDim = dirDist;
             normDim = Base::Vector3d (-dirDist.y,dirDist.x, 0);
         } else if (strcmp(dimType, "DistanceX") == 0 ) {
-            //distance and dimension lines not (neccessarily) parallel
+            //distance and dimension lines not (necessarily) parallel
             dirDim = Base::Vector3d ( ((endDist.x - startDist.x >= FLT_EPSILON) ? 1 : -1) , 0, 0);
             normDim = Base::Vector3d (-dirDim.y,dirDim.x, 0);
         } else if (strcmp(dimType, "DistanceY") == 0 ) {
-            //distance and dimension lines not (neccessarily) parallel
+            //distance and dimension lines not (necessarily) parallel
             dirDim = Base::Vector3d (0, ((endDist.y - startDist.y >= FLT_EPSILON) ? 1 : -1) , 0);
             normDim = Base::Vector3d (-dirDim.y, dirDim.x, 0);
         }
@@ -384,7 +384,7 @@ void QGIViewDimension::draw()
             //is this dimension an iso dimension? ie points +/-isoX,+/-isoY,+/-isoZ
             dirIso = findIsoDir(dirDist);
             dirExt = findIsoExt(dirIso);
-        } 
+        }
         dirExt.Normalize();
         normExt = Base::Vector3d (-dirExt.y,dirExt.x, 0);         //normal to extension lines (req'd?)
 
@@ -419,7 +419,7 @@ void QGIViewDimension::draw()
         }
 
         // +/- pos of startDist vs endDist for vert/horiz Dims
-        // distStartDelta sb zero for normal dims 
+        // distStartDelta sb zero for normal dims
         float distStartDelta = vecDist.Dot(normDim);        // component of distance vector in dim line direction
         Base::Vector3d startDistAdj = startDist + normDim * distStartDelta;
         midDist = (startDistAdj + endDist) / 2.0;
@@ -486,7 +486,7 @@ void QGIViewDimension::draw()
             } else {
                 dim1Tail = dim1Tip - tailLength * dirDim;
                 dim2Tail = fauxCenter;
-            } 
+            }
         }
 
         // Extension lines
@@ -503,7 +503,7 @@ void QGIViewDimension::draw()
         path.moveTo(gap.x, gap.y);
         path.lineTo(extEndEnd.x, extEndEnd.y);
 
-        //Dimension lines (arrow shafts) 
+        //Dimension lines (arrow shafts)
         //TODO: line tip goes just a bit too far. overlaps the arrowhead's point.
         path.moveTo(dim1Tip.x, dim1Tip.y);
         path.lineTo(dim1Tail.x, dim1Tail.y);
@@ -534,7 +534,7 @@ void QGIViewDimension::draw()
 
         aHead1->setPos(dim1Tip.x, dim1Tip.y);
         aHead2->setPos(dim2Tip.x, dim2Tip.y);
-        
+
         aHead1->setDirMode(false);
         aHead2->setDirMode(false);
 
@@ -730,7 +730,7 @@ void QGIViewDimension::draw()
             dirDimLine = lblCenter - curveCenter;
             dirDimLine.Normalize();
 
-            Base::Vector3d labelEndDir(1.0,0.0,0.0);   
+            Base::Vector3d labelEndDir(1.0,0.0,0.0);
             if (lblCenter.x > pointOnCurve.x) {         //label is to right of point
                 labelEndDir = -1.0 * labelEndDir;
             }


### PR DESCRIPTION
Found via `codespell -q 3 -I ../fc-word-whitelist.txt --skip="*.ts,*.po,./src/3rdParty,./src/Mod/Assembly/App/opendcm,./.git,./src/zipios++"`