### PR TITLE
handle user cancel color dialog

### DIFF
--- a/src/Mod/Draft/DraftGui.py
+++ b/src/Mod/Draft/DraftGui.py
@@ -1314,9 +1314,9 @@ class DraftToolBar:
 
     def getcol(self):
         "opens a color picker dialog"
-	oldColor = self.color
+        oldColor = self.color
         self.color=QtGui.QColorDialog.getColor()
-	if not QtGui.QColor.isValid(self.color): #user canceled
+        if not QtGui.QColor.isValid(self.color): #user canceled
             self.color = oldColor
             return
         self.colorPix.fill(self.color)
@@ -1338,10 +1338,10 @@ class DraftToolBar:
 
     def getfacecol(self):
         "opens a color picker dialog"
-	oldColor = self.facecolor
+        oldColor = self.facecolor
         self.facecolor=QtGui.QColorDialog.getColor()
-	if not QtGui.QColor.isValid(self.facecolor): #user canceled
-	    self.facecolor = oldColor
+        if not QtGui.QColor.isValid(self.facecolor): #user canceled
+            self.facecolor = oldColor
             return
         self.facecolorPix.fill(self.facecolor)
         self.facecolorButton.setIcon(QtGui.QIcon(self.facecolorPix))

--- a/src/Mod/Draft/DraftGui.py
+++ b/src/Mod/Draft/DraftGui.py
@@ -1314,8 +1314,10 @@ class DraftToolBar:
 
     def getcol(self):
         "opens a color picker dialog"
+	oldColor = self.color
         self.color=QtGui.QColorDialog.getColor()
 	if not QtGui.QColor.isValid(self.color): #user canceled
+            self.color = oldColor
             return
         self.colorPix.fill(self.color)
         self.colorButton.setIcon(QtGui.QIcon(self.colorPix))
@@ -1336,8 +1338,10 @@ class DraftToolBar:
 
     def getfacecol(self):
         "opens a color picker dialog"
+	oldColor = self.facecolor
         self.facecolor=QtGui.QColorDialog.getColor()
 	if not QtGui.QColor.isValid(self.facecolor): #user canceled
+	    self.facecolor = oldColor
             return
         self.facecolorPix.fill(self.facecolor)
         self.facecolorButton.setIcon(QtGui.QIcon(self.facecolorPix))

--- a/src/Mod/Draft/DraftGui.py
+++ b/src/Mod/Draft/DraftGui.py
@@ -1315,6 +1315,8 @@ class DraftToolBar:
     def getcol(self):
         "opens a color picker dialog"
         self.color=QtGui.QColorDialog.getColor()
+	if not QtGui.QColor.isValid(self.color): #user canceled
+            return
         self.colorPix.fill(self.color)
         self.colorButton.setIcon(QtGui.QIcon(self.colorPix))
         if Draft.getParam("saveonexit",False):
@@ -1335,6 +1337,8 @@ class DraftToolBar:
     def getfacecol(self):
         "opens a color picker dialog"
         self.facecolor=QtGui.QColorDialog.getColor()
+	if not QtGui.QColor.isValid(self.facecolor): #user canceled
+            return
         self.facecolorPix.fill(self.facecolor)
         self.facecolorButton.setIcon(QtGui.QIcon(self.facecolorPix))
         r = float(self.facecolor.red()/255.0)


### PR DESCRIPTION
Currently, when user cancels line color or face color selection dialog current color gets changed to black, as opposed to retaining the status quo.  https://forum.freecadweb.org/viewtopic.php?f=3&t=29762

The fix is to test QColor.isValid(color), which returns false when the user cancels the QColor dialog.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
