### PR TITLE
Fix Detail View Orientation

### DIFF
--- a/src/Mod/TechDraw/App/GeometryObject.cpp
+++ b/src/Mod/TechDraw/App/GeometryObject.cpp
@@ -695,3 +695,22 @@ TopoDS_Shape TechDrawGeometry::scaleShape(const TopoDS_Shape &input,
     }
     return transShape;
 }
+
+//!moves a shape
+TopoDS_Shape TechDrawGeometry::moveShape(const TopoDS_Shape &input,
+                                         const Base::Vector3d& motion)
+{
+    TopoDS_Shape transShape;
+    try {
+        gp_Trsf xlate;
+        xlate.SetTranslation(gp_Vec(motion.x,motion.y,motion.z));
+
+        BRepBuilderAPI_Transform mkTrf(input, xlate);
+        transShape = mkTrf.Shape();
+    }
+    catch (...) {
+        Base::Console().Log("GeometryObject::moveShape - move failed.\n");
+        return transShape;
+    }
+    return transShape;
+}

--- a/src/Mod/TechDraw/App/GeometryObject.h
+++ b/src/Mod/TechDraw/App/GeometryObject.h
@@ -59,6 +59,8 @@ TopoDS_Shape TechDrawExport scaleShape(const TopoDS_Shape &input,
 TopoDS_Shape TechDrawExport rotateShape(const TopoDS_Shape &input,
                              gp_Ax2& viewAxis,
                              double rotAngle);
+TopoDS_Shape TechDrawExport moveShape(const TopoDS_Shape &input,
+                                      const Base::Vector3d& motion);
 
 
 //! Returns the centroid of shape, as viewed according to direction


### PR DESCRIPTION
Detail Views were not honoring the rotation of the BaseView.  This PR corrects this.  Please merge.
Thanks,
wf

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
