### PR TITLE
Fix typo

### DIFF
--- a/src/Mod/Draft/Draft.py
+++ b/src/Mod/Draft/Draft.py
@@ -6137,7 +6137,7 @@ class _PointArray(_DraftObject):
         if hasattr(obj.Base, 'Shape'):
             for pts in pls:
                 #print pts # inspect the objects
-                if hasattr(pts, 'X') and hasattr(pts, 'Y') and hasattr(pts, 'Y'):
+                if hasattr(pts, 'X') and hasattr(pts, 'Y') and hasattr(pts, 'Z'):
         	        nshape = obj.Base.Shape.copy()
         	        if hasattr(pts, 'Placement'):
         	            place = pts.Placement


### PR DESCRIPTION
I figure this should be Z instead of Y, but even if I'm wrong there's no reason to check for hasattr(pts,'Y') twice.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
