### PR TITLE
Misc. code comment typo fixes 

### DIFF
--- a/src/Gui/NavigationStyle.h
+++ b/src/Gui/NavigationStyle.h
@@ -100,7 +100,7 @@ public:
 
     enum RotationCenterMode {
         ScenePointAtCursor,     /**< Find the point in the scene at the cursor position. If there is no point then the focal plane is used */
-        FocalPointAtCursor      /**< Find the point on the focal plane at the cursor postion. */
+        FocalPointAtCursor      /**< Find the point on the focal plane at the cursor position. */
     };
 
 public:

--- a/src/Mod/Arch/importIFC.py
+++ b/src/Mod/Arch/importIFC.py
@@ -1512,7 +1512,7 @@ def export(exportList,filename):
             groups[obj.Name] = [o.Name for o in obj.Group]
             continue
         if (Draft.getType(obj) == "BuildingPart") and hasattr(obj,"IfcRole") and (obj.IfcRole == "Undefined"):
-            ifctype = "IfcBuildingStorey" # export BuildingParts as Storeys if their type wasn't explicitely set
+            ifctype = "IfcBuildingStorey" # export BuildingParts as Storeys if their type wasn't explicitly set
         if (Draft.getType(obj) == "BuildingPart") and hasattr(obj,"IfcRole") and (obj.IfcRole == "Building"):
             ifctype = "IfcBuilding"
 

--- a/src/Mod/Path/App/Area.cpp
+++ b/src/Mod/Path/App/Area.cpp
@@ -755,7 +755,7 @@ struct WireJoiner {
         }
     }
 
-    // split any edges that are intersected by othe edge's end point in the middle
+    // split any edges that are intersected by other edge's end point in the middle
     void splitEdges() {
 #if (BOOST_VERSION < 105500)
         throw Base::RuntimeError("Module must be built with boost version >= 1.55");

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -2771,7 +2771,7 @@ QString ViewProviderSketch::getPresentationString(const Constraint *constraint)
     {
         // Only hide the default length unit. Right now there is not an easy way
         // to get that from the Unit system so we have to manually add it here.
-        // Hopfully this can be added in the future so this code won't have to
+        // Hopefully this can be added in the future so this code won't have to
         // be updated if a new units schema is added.
         unitSys = Base::UnitsApi::getSchema();
 

--- a/src/Mod/TechDraw/Gui/QGIViewDimension.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewDimension.cpp
@@ -433,7 +433,7 @@ void QGIViewDimension::draw()
         margin = Rez::guiX(2.f);
         float scaler = 1.;
 
-        //intersection of extention lines and dimension line
+        //intersection of extension lines and dimension line
         Base::Vector3d startIntercept = DrawUtil::Intersect2d(startDist, dirExt,
                                                            fauxCenter,dirDim);
         Base::Vector3d endIntercept = DrawUtil::Intersect2d(endDist, dirExt,


### PR DESCRIPTION
Found via `codespell -q 3 -I ../fc-word-whitelist.txt --skip="*.ts,*.po,./src/3rdParty,./src/Mod/Assembly/App/opendcm,./.git,./src/zipios++"`