### PR TITLE
Bugfix/compile warnings

### DIFF
--- a/src/3rdParty/salomesmesh/src/DriverSTL/DriverSTL_W_SMDS_Mesh.cpp
+++ b/src/3rdParty/salomesmesh/src/DriverSTL/DriverSTL_W_SMDS_Mesh.cpp
@@ -291,7 +291,7 @@ namespace
     try {
       axes = gp_Ax2( p0, normal, v01 );
     }
-    catch ( Standard_Failure ) {
+    catch ( Standard_Failure &) {
       return false;
     }
     for ( size_t i = 0; i < nbNodes; ++i )

--- a/src/3rdParty/salomesmesh/src/SMESH/SMESH_Algo.cpp
+++ b/src/3rdParty/salomesmesh/src/SMESH/SMESH_Algo.cpp
@@ -522,7 +522,7 @@ GeomAbs_Shape SMESH_Algo::Continuity(TopoDS_Edge E1,
     OCC_CATCH_SIGNALS;
     return BRepLProp::Continuity(C1, C2, u1, u2, tol, angTol);
   }
-  catch (Standard_Failure) {
+  catch (Standard_Failure&) {
   }
   return GeomAbs_C0;
 }

--- a/src/3rdParty/salomesmesh/src/SMESH/SMESH_MeshAlgos.cpp
+++ b/src/3rdParty/salomesmesh/src/SMESH/SMESH_MeshAlgos.cpp
@@ -1371,7 +1371,7 @@ double SMESH_MeshAlgos::GetDistance( const SMDS_MeshFace* face,
   try {
     tgtCS = gp_Ax3( xyz[0], OZ, OX );
   }
-  catch ( Standard_Failure ) {
+  catch ( Standard_Failure &) {
     return badDistance;
   }
   trsf.SetTransformation( tgtCS );

--- a/src/3rdParty/salomesmesh/src/SMESH/SMESH_MeshEditor.cpp
+++ b/src/3rdParty/salomesmesh/src/SMESH/SMESH_MeshEditor.cpp
@@ -11178,7 +11178,7 @@ double SMESH_MeshEditor::OrientedAngle(const gp_Pnt& p0, const gp_Pnt& p1, const
   try {
     return n2.AngleWithRef(n1, vref);
   }
-  catch ( Standard_Failure ) {
+  catch ( Standard_Failure &) {
   }
   return Max( v1.Magnitude(), v2.Magnitude() );
 }

--- a/src/3rdParty/salomesmesh/src/SMESH/SMESH_MesherHelper.cpp
+++ b/src/3rdParty/salomesmesh/src/SMESH/SMESH_MesherHelper.cpp
@@ -4445,7 +4445,7 @@ namespace { // Structures used by FixQuadraticElements()
             if ( curvNorm * D2 > 0 )
               continue; // convex edge
           }
-          catch ( Standard_Failure )
+          catch ( Standard_Failure &)
           {
             continue;
           }
@@ -4558,7 +4558,7 @@ namespace { // Structures used by FixQuadraticElements()
             if ( concaveU || concaveV )
               concaveFaces.push_back( face );
           }
-          catch ( Standard_Failure )
+          catch ( Standard_Failure &)
           {
             concaveFaces.push_back( face );
           }
@@ -5081,7 +5081,7 @@ void SMESH_MesherHelper::FixQuadraticElements(SMESH_ComputeErrorPtr& compError,
               try {
                 gp_Vec x = x01.Normalized() + x12.Normalized();
                 trsf.SetTransformation( gp_Ax3( gp::Origin(), link1->Normal(), x), gp_Ax3() );
-              } catch ( Standard_Failure ) {
+              } catch ( Standard_Failure &) {
                 trsf.Invert();
               }
               move.Transform(trsf);

--- a/src/3rdParty/salomesmesh/src/SMESHDS/SMESHDS_Mesh.cpp
+++ b/src/3rdParty/salomesmesh/src/SMESHDS/SMESHDS_Mesh.cpp
@@ -1377,7 +1377,7 @@ const TopoDS_Shape& SMESHDS_Mesh::IndexToShape(int ShapeIndex) const
     if ( ShapeIndex > 0 )
       return myIndexToShape.FindKey(ShapeIndex);
   }
-  catch ( Standard_OutOfRange )
+  catch ( Standard_OutOfRange &)
   {
   }
   static TopoDS_Shape nullShape;

--- a/src/3rdParty/salomesmesh/src/StdMeshers/StdMeshers_CompositeHexa_3D.cpp
+++ b/src/3rdParty/salomesmesh/src/StdMeshers/StdMeshers_CompositeHexa_3D.cpp
@@ -1466,7 +1466,7 @@ bool _QuadFaceGrid::GetNormal( const TopoDS_Vertex& v, gp_Vec& n ) const
         n = d1u.Crossed( d1v );
         return true;
       }
-      catch (Standard_Failure) {
+      catch (Standard_Failure&) {
         return false;
       }
     }

--- a/src/3rdParty/salomesmesh/src/StdMeshers/StdMeshers_Distribution.cpp
+++ b/src/3rdParty/salomesmesh/src/StdMeshers/StdMeshers_Distribution.cpp
@@ -64,7 +64,7 @@ bool Function::value( const double, double& f ) const
       OCC_CATCH_SIGNALS;
 #endif
       f = pow( 10., f );
-    } catch(Standard_Failure) {
+    } catch(Standard_Failure&) {
       f = 0.0;
       ok = false;
     }
@@ -196,7 +196,7 @@ FunctionExpr::FunctionExpr( const char* str, const int conv )
 #endif
     myExpr = ExprIntrp_GenExp::Create();
     myExpr->Process( ( Standard_CString )str );
-  } catch(Standard_Failure) {
+  } catch(Standard_Failure&) {
     ok = false;
   }
 
@@ -230,7 +230,7 @@ bool FunctionExpr::value( const double t, double& f ) const
     OCC_CATCH_SIGNALS;
 #endif
     f = myExpr->Expression()->Evaluate( myVars, myValues );
-  } catch(Standard_Failure) {
+  } catch(Standard_Failure&) {
     f = 0.0;
     ok = false;
   }
@@ -250,7 +250,7 @@ double FunctionExpr::integral( const double a, const double b ) const
       ( *static_cast<math_Function*>( const_cast<FunctionExpr*> (this) ), a, b, 20 );
     if( _int.IsDone() )
       res = _int.Value();
-  } catch(Standard_Failure) {
+  } catch(Standard_Failure&) {
     res = 0.0;
     MESSAGE( "Exception in integral calculating" );
   }

--- a/src/3rdParty/salomesmesh/src/StdMeshers/StdMeshers_NumberOfSegments.cpp
+++ b/src/3rdParty/salomesmesh/src/StdMeshers/StdMeshers_NumberOfSegments.cpp
@@ -232,7 +232,7 @@ void StdMeshers_NumberOfSegments::SetTableFunction(const vector<double>& table)
         OCC_CATCH_SIGNALS;
 #endif
         val = pow( 10.0, val );
-      } catch(Standard_Failure) {
+      } catch(Standard_Failure&) {
         throw SALOME_Exception( LOCALIZED( "invalid value"));
         return;
       }
@@ -327,7 +327,7 @@ bool process( const TCollection_AsciiString& str, int convMode,
 #endif
     myExpr = ExprIntrp_GenExp::Create();
     myExpr->Process( str.ToCString() );
-  } catch(Standard_Failure) {
+  } catch(Standard_Failure&) {
     parsed_ok = false;
   }
 

--- a/src/App/ApplicationPy.cpp
+++ b/src/App/ApplicationPy.cpp
@@ -56,90 +56,90 @@ using namespace App;
 
 // Application Methods						// Methods structure
 PyMethodDef Application::Methods[] = {
-    {"ParamGet",       (PyCFunction) Application::sGetParam,       1,
+    {"ParamGet",       (PyCFunction) (void*)Application::sGetParam,       1,
      "Get parameters by path"},
-    {"saveParameter",  (PyCFunction) Application::sSaveParameter,  1,
+    {"saveParameter",  (PyCFunction) (void*)Application::sSaveParameter,  1,
      "saveParameter(config='User parameter') -> None\n"
      "Save parameter set to file. The default set is 'User parameter'"},
-    {"Version",        (PyCFunction) Application::sGetVersion,     1,
+    {"Version",        (PyCFunction) (void*)Application::sGetVersion,     1,
      "Print the version to the output."},
-    {"ConfigGet",      (PyCFunction) Application::sGetConfig,      1,
+    {"ConfigGet",      (PyCFunction) (void*)Application::sGetConfig,      1,
      "ConfigGet(string) -- Get the value for the given key."},
-    {"ConfigSet",      (PyCFunction) Application::sSetConfig,      1,
+    {"ConfigSet",      (PyCFunction) (void*)Application::sSetConfig,      1,
      "ConfigSet(string, string) -- Set the given key to the given value."},
-    {"ConfigDump",     (PyCFunction) Application::sDumpConfig,     1,
+    {"ConfigDump",     (PyCFunction) (void*)Application::sDumpConfig,     1,
      "Dump the configuration to the output."},
-    {"addImportType",  (PyCFunction) Application::sAddImportType,  1,
+    {"addImportType",  (PyCFunction) (void*)Application::sAddImportType,  1,
      "Register filetype for import"},
-    {"getImportType",  (PyCFunction) Application::sGetImportType,  1,
+    {"getImportType",  (PyCFunction) (void*)Application::sGetImportType,  1,
      "Get the name of the module that can import the filetype"},
-    {"EndingAdd",      (PyCFunction) Application::sAddImportType  ,1, // deprecated
+    {"EndingAdd",      (PyCFunction) (void*)Application::sAddImportType  ,1, // deprecated
      "deprecated -- use addImportType"},
-    {"EndingGet",      (PyCFunction) Application::sGetImportType  ,1, // deprecated
+    {"EndingGet",      (PyCFunction) (void*)Application::sGetImportType  ,1, // deprecated
      "deprecated -- use getImportType"},
-    {"addExportType",  (PyCFunction) Application::sAddExportType  ,1,
+    {"addExportType",  (PyCFunction) (void*)Application::sAddExportType  ,1,
      "Register filetype for export"},
-    {"getExportType",  (PyCFunction) Application::sGetExportType  ,1,
+    {"getExportType",  (PyCFunction) (void*)Application::sGetExportType  ,1,
      "Get the name of the module that can export the filetype"},
-    {"getResourceDir", (PyCFunction) Application::sGetResourceDir  ,1,
+    {"getResourceDir", (PyCFunction) (void*)Application::sGetResourceDir  ,1,
      "Get the root directory of all resources"},
-    {"getUserAppDataDir", (PyCFunction) Application::sGetUserAppDataDir  ,1,
+    {"getUserAppDataDir", (PyCFunction) (void*)Application::sGetUserAppDataDir  ,1,
      "Get the root directory of user settings"},
-    {"getUserMacroDir", (PyCFunction) Application::sGetUserMacroDir  ,1,
+    {"getUserMacroDir", (PyCFunction) (void*)Application::sGetUserMacroDir  ,1,
      "Get the directory of the user's macro directory"},
-    {"getHelpDir", (PyCFunction) Application::sGetHelpDir  ,1,
+    {"getHelpDir", (PyCFunction) (void*)Application::sGetHelpDir  ,1,
      "Get the directory of the documentation"},
-    {"getHomePath",    (PyCFunction) Application::sGetHomePath  ,1,
+    {"getHomePath",    (PyCFunction) (void*)Application::sGetHomePath  ,1,
      "Get the home path, i.e. the parent directory of the executable"},
 
-    {"loadFile",       (PyCFunction) Application::sLoadFile,   1,
+    {"loadFile",       (PyCFunction) (void*)Application::sLoadFile,   1,
      "loadFile(string=filename,[string=module]) -> None\n\n"
      "Loads an arbitrary file by delegating to the given Python module:\n"
      "* If no module is given it will be determined by the file extension.\n"
      "* If more than one module can load a file the first one one will be taken.\n"
      "* If no module exists to load the file an exception will be raised."},
-    {"open",   (PyCFunction) Application::sOpenDocument,   1,
+    {"open",   (PyCFunction) (void*)Application::sOpenDocument,   1,
      "See openDocument(string)"},
-    {"openDocument",   (PyCFunction) Application::sOpenDocument,   1,
+    {"openDocument",   (PyCFunction) (void*)Application::sOpenDocument,   1,
      "openDocument(string) -> object\n\n"
      "Create a document and load the project file into the document.\n"
      "The string argument must point to an existing file. If the file doesn't exist\n"
      "or the file cannot be loaded an I/O exception is thrown. In this case the\n"
      "document is kept alive."},
-//  {"saveDocument",   (PyCFunction) Application::sSaveDocument,   1,
+//  {"saveDocument",   (PyCFunction) (void*)Application::sSaveDocument,   1,
 //   "saveDocument(string) -- Save the document to a file."},
-//  {"saveDocumentAs", (PyCFunction) Application::sSaveDocumentAs, 1},
-    {"newDocument",    (PyCFunction) Application::sNewDocument,    1,
+//  {"saveDocumentAs", (PyCFunction) (void*)Application::sSaveDocumentAs, 1},
+    {"newDocument",    (PyCFunction) (void*)Application::sNewDocument,    1,
      "newDocument([string]) -> object\n\n"
      "Create a new document with a given name.\n"
      "The document name must be unique which\n"
      "is checked automatically."},
-    {"closeDocument",  (PyCFunction) Application::sCloseDocument,  1,
+    {"closeDocument",  (PyCFunction) (void*)Application::sCloseDocument,  1,
      "closeDocument(string) -> None\n\n"
      "Close the document with a given name."},
-    {"activeDocument", (PyCFunction) Application::sActiveDocument, 1,
+    {"activeDocument", (PyCFunction) (void*)Application::sActiveDocument, 1,
      "activeDocument() -> object or None\n\n"
      "Return the active document or None if there is no one."},
-    {"setActiveDocument",(PyCFunction) Application::sSetActiveDocument, 1,
+    {"setActiveDocument",(PyCFunction) (void*)Application::sSetActiveDocument, 1,
      "setActiveDocement(string) -> None\n\n"
      "Set the active document by its name."},
-    {"getDocument",    (PyCFunction) Application::sGetDocument,    1,
+    {"getDocument",    (PyCFunction) (void*)Application::sGetDocument,    1,
      "getDocument(string) -> object\n\n"
      "Get a document by its name or raise an exception\n"
      "if there is no document with the given name."},
-    {"listDocuments",  (PyCFunction) Application::sListDocuments  ,1,
+    {"listDocuments",  (PyCFunction) (void*)Application::sListDocuments  ,1,
      "listDocuments() -> list\n\n"
      "Return a list of names of all documents."},
-    {"addDocumentObserver",  (PyCFunction) Application::sAddDocObserver  ,1,
+    {"addDocumentObserver",  (PyCFunction) (void*)Application::sAddDocObserver  ,1,
      "addDocumentObserver() -> None\n\n"
      "Add an observer to get notified about changes on documents."},
-    {"removeDocumentObserver",  (PyCFunction) Application::sRemoveDocObserver  ,1,
+    {"removeDocumentObserver",  (PyCFunction) (void*)Application::sRemoveDocObserver  ,1,
      "removeDocumentObserver() -> None\n\n"
      "Remove an added document observer."},
-    {"setLogLevel",          (PyCFunction) Application::sSetLogLevel, 1,
+    {"setLogLevel",          (PyCFunction) (void*)Application::sSetLogLevel, 1,
      "setLogLevel(tag, level) -- Set the log level for a string tag.\n"
      "'level' can either be string 'Log', 'Msg', 'Wrn', 'Error', or an integer value"},
-    {"getLogLevel",          (PyCFunction) Application::sGetLogLevel, 1,
+    {"getLogLevel",          (PyCFunction) (void*)Application::sGetLogLevel, 1,
      "getLogLevel(tag) -- Get the log level of a string tag"},
 
     {NULL, NULL, 0, NULL}		/* Sentinel */

--- a/src/App/PropertyLinks.cpp
+++ b/src/App/PropertyLinks.cpp
@@ -958,7 +958,7 @@ void PropertyLinkSubList::setPyObject(PyObject *value)
         dummy.setPyObject(value);
         this->setValue(dummy.getValue(), dummy.getSubValues());
     }
-    catch (Base::TypeError) {
+    catch (Base::TypeError&) {
         if (PyTuple_Check(value) || PyList_Check(value)) {
             Py::Sequence list(value);
             Py::Sequence::size_type size = list.size();

--- a/src/Base/Console.cpp
+++ b/src/Base/Console.cpp
@@ -499,17 +499,17 @@ ConsoleSingleton & ConsoleSingleton::Instance(void)
 
 // ConsoleSingleton Methods						// Methods structure
 PyMethodDef ConsoleSingleton::Methods[] = {
-    {"PrintMessage",         (PyCFunction) ConsoleSingleton::sPyMessage, 1, 
+    {"PrintMessage",         (PyCFunction) (void*)ConsoleSingleton::sPyMessage, 1, 
      "PrintMessage(string) -- Print a message to the output"},
-    {"PrintLog",             (PyCFunction) ConsoleSingleton::sPyLog, 1,
+    {"PrintLog",             (PyCFunction) (void*)ConsoleSingleton::sPyLog, 1,
      "PrintLog(string) -- Print a log message to the output"},
-    {"PrintError"  ,         (PyCFunction) ConsoleSingleton::sPyError, 1,
+    {"PrintError"  ,         (PyCFunction) (void*)ConsoleSingleton::sPyError, 1,
      "PrintError(string) -- Print an error message to the output"},
-    {"PrintWarning",         (PyCFunction) ConsoleSingleton::sPyWarning, 1,
+    {"PrintWarning",         (PyCFunction) (void*)ConsoleSingleton::sPyWarning, 1,
      "PrintWarning -- Print a warning to the output"},
-    {"SetStatus",            (PyCFunction) ConsoleSingleton::sPySetStatus, 1,
+    {"SetStatus",            (PyCFunction) (void*)ConsoleSingleton::sPySetStatus, 1,
      "Set the status for either Log, Msg, Wrn or Error for an observer"},
-    {"GetStatus",            (PyCFunction) ConsoleSingleton::sPyGetStatus, 1,
+    {"GetStatus",            (PyCFunction) (void*)ConsoleSingleton::sPyGetStatus, 1,
      "Get the status for either Log, Msg, Wrn or Error for an observer"},
     {NULL, NULL, 0, NULL}		/* Sentinel */
 };

--- a/src/Base/UnitsApiPy.cpp
+++ b/src/Base/UnitsApiPy.cpp
@@ -43,7 +43,7 @@ using namespace Base;
 
 // UnitsApi Methods						// Methods structure
 PyMethodDef UnitsApi::Methods[] = {
-    //{"translateUnit",  (PyCFunction) UnitsApi::sTranslateUnit  ,1,
+    //{"translateUnit",  (PyCFunction) (void*)UnitsApi::sTranslateUnit  ,1,
     // "translateUnit(string) -> double\n\n"
     // "calculate a mathematical expression with units to a number. \n"
     // "can be used for simple unit translation like: \n"
@@ -51,7 +51,7 @@ PyMethodDef UnitsApi::Methods[] = {
     // " or for more complex espressions:\n"
     // " translateUnit('sin(pi)/50.0 m/s^2')\n"
     //},
-    //{"getWithPrefs",  (PyCFunction) UnitsApi::sGetWithPrefs  ,1,
+    //{"getWithPrefs",  (PyCFunction) (void*)UnitsApi::sGetWithPrefs  ,1,
     // "getWithPrefs(type,[string|float|int]) -> double\n\n"
     // "Translation to internal regarding user prefs \n"
     // " That means if no unit is issued the user prefs are in \n"
@@ -68,7 +68,7 @@ PyMethodDef UnitsApi::Methods[] = {
     // " Temperature \n"
 
     //},
-    {"parseQuantity",  (PyCFunction) UnitsApi::sParseQuantity  ,1,
+    {"parseQuantity",  (PyCFunction) (void*)UnitsApi::sParseQuantity  ,1,
      "parseQuantity(string) -> Base.Quantity()\n\n"
      "calculate a mathematical expression with units to a quantity object. \n"
      "can be used for simple unit translation like: \n"
@@ -76,15 +76,15 @@ PyMethodDef UnitsApi::Methods[] = {
      "or for more complex espressions:\n"
      "parseQuantity('sin(pi)/50.0 m/s^2')\n"
     },
-    {"listSchemas",  (PyCFunction) UnitsApi::sListSchemas  ,1,
+    {"listSchemas",  (PyCFunction) (void*)UnitsApi::sListSchemas  ,1,
      "listSchemas() -> a tuple of schemas\n\n"
      "listSchemas(int) -> description of the given schema\n\n"
     },
-    {"getSchema",  (PyCFunction) UnitsApi::sGetSchema  ,1,
+    {"getSchema",  (PyCFunction) (void*)UnitsApi::sGetSchema  ,1,
      "getSchema() -> int\n\n"
      "The int is the position of the tuple returned by listSchemas"
     },
-    {"schemaTranslate",  (PyCFunction) UnitsApi::sSchemaTranslate  ,1,
+    {"schemaTranslate",  (PyCFunction) (void*)UnitsApi::sSchemaTranslate  ,1,
      "schemaTranslate(Quantity, int) -> tuple\n\n"
      "Translate a quantity to a given schema"
     },

--- a/src/Base/swigpyrun_1.3.33.h
+++ b/src/Base/swigpyrun_1.3.33.h
@@ -1543,23 +1543,23 @@ PySwigObject_own(PyObject *v, PyObject *args)
 #ifdef METH_O
 static PyMethodDef
 swigobject_methods[] = {
-  {(char *)"disown",  (PyCFunction)PySwigObject_disown,  METH_NOARGS,  (char *)"releases ownership of the pointer"},
-  {(char *)"acquire", (PyCFunction)PySwigObject_acquire, METH_NOARGS,  (char *)"aquires ownership of the pointer"},
-  {(char *)"own",     (PyCFunction)PySwigObject_own,     METH_VARARGS, (char *)"returns/sets ownership of the pointer"},
-  {(char *)"append",  (PyCFunction)PySwigObject_append,  METH_O,       (char *)"appends another 'this' object"},
-  {(char *)"next",    (PyCFunction)PySwigObject_next,    METH_NOARGS,  (char *)"returns the next 'this' object"},
-  {(char *)"__repr__",(PyCFunction)PySwigObject_repr,    METH_NOARGS,  (char *)"returns object representation"},
+  {(char *)"disown",  (PyCFunction)(void*)PySwigObject_disown,  METH_NOARGS,  (char *)"releases ownership of the pointer"},
+  {(char *)"acquire", (PyCFunction)(void*)PySwigObject_acquire, METH_NOARGS,  (char *)"aquires ownership of the pointer"},
+  {(char *)"own",     (PyCFunction)(void*)PySwigObject_own,     METH_VARARGS, (char *)"returns/sets ownership of the pointer"},
+  {(char *)"append",  (PyCFunction)(void*)PySwigObject_append,  METH_O,       (char *)"appends another 'this' object"},
+  {(char *)"next",    (PyCFunction)(void*)PySwigObject_next,    METH_NOARGS,  (char *)"returns the next 'this' object"},
+  {(char *)"__repr__",(PyCFunction)(void*)PySwigObject_repr,    METH_NOARGS,  (char *)"returns object representation"},
   {0, 0, 0, 0}  
 };
 #else
 static PyMethodDef
 swigobject_methods[] = {
-  {(char *)"disown",  (PyCFunction)PySwigObject_disown,  METH_VARARGS,  (char *)"releases ownership of the pointer"},
-  {(char *)"acquire", (PyCFunction)PySwigObject_acquire, METH_VARARGS,  (char *)"aquires ownership of the pointer"},
-  {(char *)"own",     (PyCFunction)PySwigObject_own,     METH_VARARGS,  (char *)"returns/sets ownership of the pointer"},
-  {(char *)"append",  (PyCFunction)PySwigObject_append,  METH_VARARGS,  (char *)"appends another 'this' object"},
-  {(char *)"next",    (PyCFunction)PySwigObject_next,    METH_VARARGS,  (char *)"returns the next 'this' object"},
-  {(char *)"__repr__",(PyCFunction)PySwigObject_repr,   METH_VARARGS,  (char *)"returns object representation"},
+  {(char *)"disown",  (PyCFunction)(void*)PySwigObject_disown,  METH_VARARGS,  (char *)"releases ownership of the pointer"},
+  {(char *)"acquire", (PyCFunction)(void*)PySwigObject_acquire, METH_VARARGS,  (char *)"aquires ownership of the pointer"},
+  {(char *)"own",     (PyCFunction)(void*)PySwigObject_own,     METH_VARARGS,  (char *)"returns/sets ownership of the pointer"},
+  {(char *)"append",  (PyCFunction)(void*)PySwigObject_append,  METH_VARARGS,  (char *)"appends another 'this' object"},
+  {(char *)"next",    (PyCFunction)(void*)PySwigObject_next,    METH_VARARGS,  (char *)"returns the next 'this' object"},
+  {(char *)"__repr__",(PyCFunction)(void*)PySwigObject_repr,   METH_VARARGS,  (char *)"returns object representation"},
   {0, 0, 0, 0}  
 };
 #endif

--- a/src/Base/swigpyrun_1.3.36.h
+++ b/src/Base/swigpyrun_1.3.36.h
@@ -1551,23 +1551,23 @@ PySwigObject_own(PyObject *v, PyObject *args)
 #ifdef METH_O
 static PyMethodDef
 swigobject_methods[] = {
-  {(char *)"disown",  (PyCFunction)PySwigObject_disown,  METH_NOARGS,  (char *)"releases ownership of the pointer"},
-  {(char *)"acquire", (PyCFunction)PySwigObject_acquire, METH_NOARGS,  (char *)"aquires ownership of the pointer"},
-  {(char *)"own",     (PyCFunction)PySwigObject_own,     METH_VARARGS, (char *)"returns/sets ownership of the pointer"},
-  {(char *)"append",  (PyCFunction)PySwigObject_append,  METH_O,       (char *)"appends another 'this' object"},
-  {(char *)"next",    (PyCFunction)PySwigObject_next,    METH_NOARGS,  (char *)"returns the next 'this' object"},
-  {(char *)"__repr__",(PyCFunction)PySwigObject_repr,    METH_NOARGS,  (char *)"returns object representation"},
+  {(char *)"disown",  (PyCFunction)(void*)PySwigObject_disown,  METH_NOARGS,  (char *)"releases ownership of the pointer"},
+  {(char *)"acquire", (PyCFunction)(void*)PySwigObject_acquire, METH_NOARGS,  (char *)"aquires ownership of the pointer"},
+  {(char *)"own",     (PyCFunction)(void*)PySwigObject_own,     METH_VARARGS, (char *)"returns/sets ownership of the pointer"},
+  {(char *)"append",  (PyCFunction)(void*)PySwigObject_append,  METH_O,       (char *)"appends another 'this' object"},
+  {(char *)"next",    (PyCFunction)(void*)PySwigObject_next,    METH_NOARGS,  (char *)"returns the next 'this' object"},
+  {(char *)"__repr__",(PyCFunction)(void*)PySwigObject_repr,    METH_NOARGS,  (char *)"returns object representation"},
   {0, 0, 0, 0}  
 };
 #else
 static PyMethodDef
 swigobject_methods[] = {
-  {(char *)"disown",  (PyCFunction)PySwigObject_disown,  METH_VARARGS,  (char *)"releases ownership of the pointer"},
-  {(char *)"acquire", (PyCFunction)PySwigObject_acquire, METH_VARARGS,  (char *)"aquires ownership of the pointer"},
-  {(char *)"own",     (PyCFunction)PySwigObject_own,     METH_VARARGS,  (char *)"returns/sets ownership of the pointer"},
-  {(char *)"append",  (PyCFunction)PySwigObject_append,  METH_VARARGS,  (char *)"appends another 'this' object"},
-  {(char *)"next",    (PyCFunction)PySwigObject_next,    METH_VARARGS,  (char *)"returns the next 'this' object"},
-  {(char *)"__repr__",(PyCFunction)PySwigObject_repr,   METH_VARARGS,  (char *)"returns object representation"},
+  {(char *)"disown",  (PyCFunction)(void*)PySwigObject_disown,  METH_VARARGS,  (char *)"releases ownership of the pointer"},
+  {(char *)"acquire", (PyCFunction)(void*)PySwigObject_acquire, METH_VARARGS,  (char *)"aquires ownership of the pointer"},
+  {(char *)"own",     (PyCFunction)(void*)PySwigObject_own,     METH_VARARGS,  (char *)"returns/sets ownership of the pointer"},
+  {(char *)"append",  (PyCFunction)(void*)PySwigObject_append,  METH_VARARGS,  (char *)"appends another 'this' object"},
+  {(char *)"next",    (PyCFunction)(void*)PySwigObject_next,    METH_VARARGS,  (char *)"returns the next 'this' object"},
+  {(char *)"__repr__",(PyCFunction)(void*)PySwigObject_repr,   METH_VARARGS,  (char *)"returns object representation"},
   {0, 0, 0, 0}  
 };
 #endif

--- a/src/Base/swigpyrun_1.3.38.h
+++ b/src/Base/swigpyrun_1.3.38.h
@@ -1650,23 +1650,23 @@ SwigPyObject_own(PyObject *v, PyObject *args)
 #ifdef METH_O
 static PyMethodDef
 swigobject_methods[] = {
-  {(char *)"disown",  (PyCFunction)SwigPyObject_disown,  METH_NOARGS,  (char *)"releases ownership of the pointer"},
-  {(char *)"acquire", (PyCFunction)SwigPyObject_acquire, METH_NOARGS,  (char *)"aquires ownership of the pointer"},
-  {(char *)"own",     (PyCFunction)SwigPyObject_own,     METH_VARARGS, (char *)"returns/sets ownership of the pointer"},
-  {(char *)"append",  (PyCFunction)SwigPyObject_append,  METH_O,       (char *)"appends another 'this' object"},
-  {(char *)"next",    (PyCFunction)SwigPyObject_next,    METH_NOARGS,  (char *)"returns the next 'this' object"},
-  {(char *)"__repr__",(PyCFunction)SwigPyObject_repr,    METH_NOARGS,  (char *)"returns object representation"},
+  {(char *)"disown",  (PyCFunction)(void*)SwigPyObject_disown,  METH_NOARGS,  (char *)"releases ownership of the pointer"},
+  {(char *)"acquire", (PyCFunction)(void*)SwigPyObject_acquire, METH_NOARGS,  (char *)"aquires ownership of the pointer"},
+  {(char *)"own",     (PyCFunction)(void*)SwigPyObject_own,     METH_VARARGS, (char *)"returns/sets ownership of the pointer"},
+  {(char *)"append",  (PyCFunction)(void*)SwigPyObject_append,  METH_O,       (char *)"appends another 'this' object"},
+  {(char *)"next",    (PyCFunction)(void*)SwigPyObject_next,    METH_NOARGS,  (char *)"returns the next 'this' object"},
+  {(char *)"__repr__",(PyCFunction)(void*)SwigPyObject_repr,    METH_NOARGS,  (char *)"returns object representation"},
   {0, 0, 0, 0}  
 };
 #else
 static PyMethodDef
 swigobject_methods[] = {
-  {(char *)"disown",  (PyCFunction)SwigPyObject_disown,  METH_VARARGS,  (char *)"releases ownership of the pointer"},
-  {(char *)"acquire", (PyCFunction)SwigPyObject_acquire, METH_VARARGS,  (char *)"aquires ownership of the pointer"},
-  {(char *)"own",     (PyCFunction)SwigPyObject_own,     METH_VARARGS,  (char *)"returns/sets ownership of the pointer"},
-  {(char *)"append",  (PyCFunction)SwigPyObject_append,  METH_VARARGS,  (char *)"appends another 'this' object"},
-  {(char *)"next",    (PyCFunction)SwigPyObject_next,    METH_VARARGS,  (char *)"returns the next 'this' object"},
-  {(char *)"__repr__",(PyCFunction)SwigPyObject_repr,   METH_VARARGS,  (char *)"returns object representation"},
+  {(char *)"disown",  (PyCFunction)(void*)SwigPyObject_disown,  METH_VARARGS,  (char *)"releases ownership of the pointer"},
+  {(char *)"acquire", (PyCFunction)(void*)SwigPyObject_acquire, METH_VARARGS,  (char *)"aquires ownership of the pointer"},
+  {(char *)"own",     (PyCFunction)(void*)SwigPyObject_own,     METH_VARARGS,  (char *)"returns/sets ownership of the pointer"},
+  {(char *)"append",  (PyCFunction)(void*)SwigPyObject_append,  METH_VARARGS,  (char *)"appends another 'this' object"},
+  {(char *)"next",    (PyCFunction)(void*)SwigPyObject_next,    METH_VARARGS,  (char *)"returns the next 'this' object"},
+  {(char *)"__repr__",(PyCFunction)(void*)SwigPyObject_repr,   METH_VARARGS,  (char *)"returns object representation"},
   {0, 0, 0, 0}  
 };
 #endif

--- a/src/Base/swigpyrun_1.3.40.h
+++ b/src/Base/swigpyrun_1.3.40.h
@@ -1671,23 +1671,23 @@ SwigPyObject_own(PyObject *v, PyObject *args)
 #ifdef METH_O
 static PyMethodDef
 swigobject_methods[] = {
-  {(char *)"disown",  (PyCFunction)SwigPyObject_disown,  METH_NOARGS,  (char *)"releases ownership of the pointer"},
-  {(char *)"acquire", (PyCFunction)SwigPyObject_acquire, METH_NOARGS,  (char *)"aquires ownership of the pointer"},
-  {(char *)"own",     (PyCFunction)SwigPyObject_own,     METH_VARARGS, (char *)"returns/sets ownership of the pointer"},
-  {(char *)"append",  (PyCFunction)SwigPyObject_append,  METH_O,       (char *)"appends another 'this' object"},
-  {(char *)"next",    (PyCFunction)SwigPyObject_next,    METH_NOARGS,  (char *)"returns the next 'this' object"},
-  {(char *)"__repr__",(PyCFunction)SwigPyObject_repr,    METH_NOARGS,  (char *)"returns object representation"},
+  {(char *)"disown",  (PyCFunction)(void*)SwigPyObject_disown,  METH_NOARGS,  (char *)"releases ownership of the pointer"},
+  {(char *)"acquire", (PyCFunction)(void*)SwigPyObject_acquire, METH_NOARGS,  (char *)"aquires ownership of the pointer"},
+  {(char *)"own",     (PyCFunction)(void*)SwigPyObject_own,     METH_VARARGS, (char *)"returns/sets ownership of the pointer"},
+  {(char *)"append",  (PyCFunction)(void*)SwigPyObject_append,  METH_O,       (char *)"appends another 'this' object"},
+  {(char *)"next",    (PyCFunction)(void*)SwigPyObject_next,    METH_NOARGS,  (char *)"returns the next 'this' object"},
+  {(char *)"__repr__",(PyCFunction)(void*)SwigPyObject_repr,    METH_NOARGS,  (char *)"returns object representation"},
   {0, 0, 0, 0}  
 };
 #else
 static PyMethodDef
 swigobject_methods[] = {
-  {(char *)"disown",  (PyCFunction)SwigPyObject_disown,  METH_VARARGS,  (char *)"releases ownership of the pointer"},
-  {(char *)"acquire", (PyCFunction)SwigPyObject_acquire, METH_VARARGS,  (char *)"aquires ownership of the pointer"},
-  {(char *)"own",     (PyCFunction)SwigPyObject_own,     METH_VARARGS,  (char *)"returns/sets ownership of the pointer"},
-  {(char *)"append",  (PyCFunction)SwigPyObject_append,  METH_VARARGS,  (char *)"appends another 'this' object"},
-  {(char *)"next",    (PyCFunction)SwigPyObject_next,    METH_VARARGS,  (char *)"returns the next 'this' object"},
-  {(char *)"__repr__",(PyCFunction)SwigPyObject_repr,   METH_VARARGS,  (char *)"returns object representation"},
+  {(char *)"disown",  (PyCFunction)(void*)SwigPyObject_disown,  METH_VARARGS,  (char *)"releases ownership of the pointer"},
+  {(char *)"acquire", (PyCFunction)(void*)SwigPyObject_acquire, METH_VARARGS,  (char *)"aquires ownership of the pointer"},
+  {(char *)"own",     (PyCFunction)(void*)SwigPyObject_own,     METH_VARARGS,  (char *)"returns/sets ownership of the pointer"},
+  {(char *)"append",  (PyCFunction)(void*)SwigPyObject_append,  METH_VARARGS,  (char *)"appends another 'this' object"},
+  {(char *)"next",    (PyCFunction)(void*)SwigPyObject_next,    METH_VARARGS,  (char *)"returns the next 'this' object"},
+  {(char *)"__repr__",(PyCFunction)(void*)SwigPyObject_repr,   METH_VARARGS,  (char *)"returns object representation"},
   {0, 0, 0, 0}  
 };
 #endif

--- a/src/CXX/Python2/Extensions.hxx
+++ b/src/CXX/Python2/Extensions.hxx
@@ -159,7 +159,7 @@ namespace Py
         )
         {
             ext_meth_def.ml_name = const_cast<char *>( _name );
-            ext_meth_def.ml_meth = reinterpret_cast<method_varargs_call_handler_t>( _handler );
+            ext_meth_def.ml_meth = reinterpret_cast<method_varargs_call_handler_t>( (void*)_handler );
             ext_meth_def.ml_flags = METH_VARARGS|METH_KEYWORDS;
             ext_meth_def.ml_doc = const_cast<char *>( _doc );
 

--- a/src/CXX/Python3/Extensions.hxx
+++ b/src/CXX/Python3/Extensions.hxx
@@ -159,7 +159,7 @@ namespace Py
         )
         {
             ext_meth_def.ml_name = const_cast<char *>( _name );
-            ext_meth_def.ml_meth = reinterpret_cast<method_varargs_call_handler_t>( _handler );
+            ext_meth_def.ml_meth = reinterpret_cast<method_varargs_call_handler_t>( (void*) _handler );
             ext_meth_def.ml_flags = METH_VARARGS|METH_KEYWORDS;
             ext_meth_def.ml_doc = const_cast<char *>( _doc );
 

--- a/src/Gui/ApplicationPy.cpp
+++ b/src/Gui/ApplicationPy.cpp
@@ -69,121 +69,121 @@ using namespace Gui;
 
 // FCApplication Methods						// Methods structure
 PyMethodDef Application::Methods[] = {
-  {"activateWorkbench",(PyCFunction) Application::sActivateWorkbenchHandler,1,
+  {"activateWorkbench",(PyCFunction) (void*)Application::sActivateWorkbenchHandler,1,
    "activateWorkbench(string) -> None\n\n"
    "Activate the workbench by name"},
-  {"addWorkbench",     (PyCFunction) Application::sAddWorkbenchHandler,     1,
+  {"addWorkbench",     (PyCFunction) (void*)Application::sAddWorkbenchHandler,     1,
    "addWorkbench(string, object) -> None\n\n"
    "Add a workbench under a defined name."},
-  {"removeWorkbench",  (PyCFunction) Application::sRemoveWorkbenchHandler,  1,
+  {"removeWorkbench",  (PyCFunction) (void*)Application::sRemoveWorkbenchHandler,  1,
    "removeWorkbench(string) -> None\n\n"
    "Remove the workbench with name"},
-  {"getWorkbench",     (PyCFunction) Application::sGetWorkbenchHandler,     1,
+  {"getWorkbench",     (PyCFunction) (void*)Application::sGetWorkbenchHandler,     1,
    "getWorkbench(string) -> object\n\n"
    "Get the workbench by its name"},
-  {"listWorkbenches",   (PyCFunction) Application::sListWorkbenchHandlers,    1,
+  {"listWorkbenches",   (PyCFunction) (void*)Application::sListWorkbenchHandlers,    1,
    "listWorkbenches() -> list\n\n"
    "Show a list of all workbenches"},
-  {"activeWorkbench", (PyCFunction) Application::sActiveWorkbenchHandler,   1,
+  {"activeWorkbench", (PyCFunction) (void*)Application::sActiveWorkbenchHandler,   1,
    "activeWorkbench() -> object\n\n"
    "Return the active workbench object"},
-  {"addResourcePath",             (PyCFunction) Application::sAddResPath,      1,
+  {"addResourcePath",             (PyCFunction) (void*)Application::sAddResPath,      1,
    "addResourcePath(string) -> None\n\n"
    "Add a new path to the system where to find resource files\n"
    "like icons or localization files"},
-  {"addLanguagePath",             (PyCFunction) Application::sAddLangPath,      1,
+  {"addLanguagePath",             (PyCFunction) (void*)Application::sAddLangPath,      1,
    "addLanguagePath(string) -> None\n\n"
    "Add a new path to the system where to find language files"},
-  {"addIconPath",             (PyCFunction) Application::sAddIconPath,      1,
+  {"addIconPath",             (PyCFunction) (void*)Application::sAddIconPath,      1,
    "addIconPath(string) -> None\n\n"
    "Add a new path to the system where to find icon files"},
-  {"addIcon",                 (PyCFunction) Application::sAddIcon,          1,
+  {"addIcon",                 (PyCFunction) (void*)Application::sAddIcon,          1,
    "addIcon(string, string or list) -> None\n\n"
    "Add an icon as file name or in XPM format to the system"},
-  {"getMainWindow",           (PyCFunction) Application::sGetMainWindow,    1,
+  {"getMainWindow",           (PyCFunction) (void*)Application::sGetMainWindow,    1,
    "getMainWindow() -> QMainWindow\n\n"
    "Return the main window instance"},
-  {"updateGui",               (PyCFunction) Application::sUpdateGui,        1,
+  {"updateGui",               (PyCFunction) (void*)Application::sUpdateGui,        1,
    "updateGui() -> None\n\n"
    "Update the main window and all its windows"},
-  {"updateLocale",            (PyCFunction) Application::sUpdateLocale,     1,
+  {"updateLocale",            (PyCFunction) (void*)Application::sUpdateLocale,     1,
    "updateLocale() -> None\n\n"
    "Update the localization"},
-  {"getLocale",            (PyCFunction) Application::sGetLocale,     1,
+  {"getLocale",            (PyCFunction) (void*)Application::sGetLocale,     1,
    "getLocale() -> string\n\n"
    "Returns the locale currently used by FreeCAD"},
-  {"setLocale",            (PyCFunction) Application::sSetLocale,     1,
+  {"setLocale",            (PyCFunction) (void*)Application::sSetLocale,     1,
    "getLocale(string) -> None\n\n"
    "Sets the locale used by FreeCAD. You can set it by\n"
    "top-level domain (e.g. \"de\") or the language name (e.g. \"German\")"},
-  {"supportedLocales", (PyCFunction) Application::sSupportedLocales,     1,
+  {"supportedLocales", (PyCFunction) (void*)Application::sSupportedLocales,     1,
    "supportedLocales() -> dict\n\n"
    "Returns a dict of all supported languages/top-level domains"},
-  {"createDialog",            (PyCFunction) Application::sCreateDialog,     1,
+  {"createDialog",            (PyCFunction) (void*)Application::sCreateDialog,     1,
    "createDialog(string) -- Open a UI file"},
-  {"addPreferencePage",       (PyCFunction) Application::sAddPreferencePage,1,
+  {"addPreferencePage",       (PyCFunction) (void*)Application::sAddPreferencePage,1,
    "addPreferencePage(string,string) -- Add a UI form to the\n"
    "preferences dialog. The first argument specifies the file name"
    "and the second specifies the group name"},
-  {"addCommand",              (PyCFunction) Application::sAddCommand,       1,
+  {"addCommand",              (PyCFunction) (void*)Application::sAddCommand,       1,
    "addCommand(string, object) -> None\n\n"
    "Add a command object"},
-  {"runCommand",              (PyCFunction) Application::sRunCommand,       1,
+  {"runCommand",              (PyCFunction) (void*)Application::sRunCommand,       1,
    "runCommand(string) -> None\n\n"
    "Run command with name"},
-  {"listCommands",               (PyCFunction) Application::sListCommands,1,
+  {"listCommands",               (PyCFunction) (void*)Application::sListCommands,1,
    "listCommands() -> list of strings\n\n"
    "Returns a list of all commands known to FreeCAD."},
-  {"SendMsgToActiveView",     (PyCFunction) Application::sSendActiveView,   1,
+  {"SendMsgToActiveView",     (PyCFunction) (void*)Application::sSendActiveView,   1,
    "deprecated -- use class View"},
-  {"hide",                    (PyCFunction) Application::sHide,             1,
+  {"hide",                    (PyCFunction) (void*)Application::sHide,             1,
    "deprecated"},
-  {"show",                    (PyCFunction) Application::sShow,             1,
+  {"show",                    (PyCFunction) (void*)Application::sShow,             1,
    "deprecated"},
-  {"hideObject",              (PyCFunction) Application::sHideObject,       1,
+  {"hideObject",              (PyCFunction) (void*)Application::sHideObject,       1,
    "hideObject(object) -> None\n\n"
    "Hide the view provider to the given object"},
-  {"showObject",              (PyCFunction) Application::sShowObject,       1,
+  {"showObject",              (PyCFunction) (void*)Application::sShowObject,       1,
    "showObject(object) -> None\n\n"
    "Show the view provider to the given object"},
-  {"open",                    (PyCFunction) Application::sOpen,             1,
+  {"open",                    (PyCFunction) (void*)Application::sOpen,             1,
    "Open a macro, Inventor or VRML file"},
-  {"insert",                  (PyCFunction) Application::sInsert,           1,
+  {"insert",                  (PyCFunction) (void*)Application::sInsert,           1,
    "Open a macro, Inventor or VRML file"},
-  {"export",                  (PyCFunction) Application::sExport,           1,
+  {"export",                  (PyCFunction) (void*)Application::sExport,           1,
    "save scene to Inventor or VRML file"},
-  {"activeDocument",          (PyCFunction) Application::sActiveDocument,   1,
+  {"activeDocument",          (PyCFunction) (void*)Application::sActiveDocument,   1,
    "activeDocument() -> object or None\n\n"
    "Return the active document or None if no one exists"},
-  {"setActiveDocument",       (PyCFunction) Application::sSetActiveDocument,1,
+  {"setActiveDocument",       (PyCFunction) (void*)Application::sSetActiveDocument,1,
    "setActiveDocument(string or App.Document) -> None\n\n"
    "Activate the specified document"},
-  {"activeView", (PyCFunction)Application::sActiveView, 1,
+  {"activeView",              (PyCFunction) (void*)Application::sActiveView,       1,
    "activeView() -> object or None\n\n"
    "Return the active view of the active document or None if no one exists"},
-  {"getDocument",             (PyCFunction) Application::sGetDocument,      1,
+  {"getDocument",             (PyCFunction) (void*)Application::sGetDocument,      1,
    "getDocument(string) -> object\n\n"
    "Get a document by its name"},
-  {"doCommand",               (PyCFunction) Application::sDoCommand,        1,
+  {"doCommand",               (PyCFunction) (void*)Application::sDoCommand,        1,
    "doCommand(string) -> None\n\n"
    "Prints the given string in the python console and runs it"},
-  {"doCommandGui",               (PyCFunction) Application::sDoCommandGui,  1,
+  {"doCommandGui",               (PyCFunction) (void*)Application::sDoCommandGui,  1,
    "doCommandGui(string) -> None\n\n"
    "Prints the given string in the python console and runs it but doesn't record it in macros"},
-  {"addModule",               (PyCFunction) Application::sAddModule,        1,
+  {"addModule",               (PyCFunction) (void*)Application::sAddModule,        1,
    "addModule(string) -> None\n\n"
    "Prints the given module import only once in the macro recording"},
-  {"showDownloads",               (PyCFunction) Application::sShowDownloads,1,
+  {"showDownloads",               (PyCFunction) (void*)Application::sShowDownloads,1,
    "showDownloads() -> None\n\n"
    "Shows the downloads manager window"},
-  {"showPreferences",               (PyCFunction) Application::sShowPreferences,1,
+  {"showPreferences",               (PyCFunction) (void*)Application::sShowPreferences,1,
    "showPreferences([string,int]) -> None\n\n"
    "Shows the preferences window. If string and int are provided, the given page index in the given group is shown."},
-  {"createViewer",               (PyCFunction) Application::sCreateViewer,1,
+  {"createViewer",               (PyCFunction) (void*)Application::sCreateViewer,1,
    "createViewer([int]) -> View3DInventor/SplitView3DInventor\n\n"
    "shows and returns a viewer. If the integer argument is given and > 1: -> splitViewer"},
 
-  {"getMarkerIndex", (PyCFunction) Application::sGetMarkerIndex, 1,
+  {"getMarkerIndex", (PyCFunction) (void*)Application::sGetMarkerIndex, 1,
    "Get marker index according to marker size setting"},
 
   {NULL, NULL, 0, NULL}		/* Sentinel */

--- a/src/Gui/Selection.cpp
+++ b/src/Gui/Selection.cpp
@@ -1066,7 +1066,7 @@ PyMethodDef SelectionSingleton::Methods[] = {
     {NULL, NULL, 0, NULL}  /* Sentinel */
 };
 
-PyObject *SelectionSingleton::sAddSelection(PyObject * /*self*/, PyObject *args, PyObject * /*kwd*/)
+PyObject *SelectionSingleton::sAddSelection(PyObject * /*self*/, PyObject *args)
 {
     PyObject *object;
     char* subname=0;
@@ -1117,7 +1117,7 @@ PyObject *SelectionSingleton::sAddSelection(PyObject * /*self*/, PyObject *args,
     return 0;
 }
 
-PyObject *SelectionSingleton::sRemoveSelection(PyObject * /*self*/, PyObject *args, PyObject * /*kwd*/)
+PyObject *SelectionSingleton::sRemoveSelection(PyObject * /*self*/, PyObject *args)
 {
     PyObject *object;
     char* subname=0;
@@ -1138,7 +1138,7 @@ PyObject *SelectionSingleton::sRemoveSelection(PyObject * /*self*/, PyObject *ar
     Py_Return;
 }
 
-PyObject *SelectionSingleton::sClearSelection(PyObject * /*self*/, PyObject *args, PyObject * /*kwd*/)
+PyObject *SelectionSingleton::sClearSelection(PyObject * /*self*/, PyObject *args)
 {
     char *documentName=0;
     if (!PyArg_ParseTuple(args, "|s", &documentName))
@@ -1147,7 +1147,7 @@ PyObject *SelectionSingleton::sClearSelection(PyObject * /*self*/, PyObject *arg
     Py_Return;
 }
 
-PyObject *SelectionSingleton::sIsSelected(PyObject * /*self*/, PyObject *args, PyObject * /*kwd*/)
+PyObject *SelectionSingleton::sIsSelected(PyObject * /*self*/, PyObject *args)
 {
     PyObject *object;
     char* subname=0;
@@ -1159,7 +1159,7 @@ PyObject *SelectionSingleton::sIsSelected(PyObject * /*self*/, PyObject *args, P
     return Py_BuildValue("O", (ok ? Py_True : Py_False));
 }
 
-PyObject *SelectionSingleton::sCountObjectsOfType(PyObject * /*self*/, PyObject *args, PyObject * /*kwd*/)
+PyObject *SelectionSingleton::sCountObjectsOfType(PyObject * /*self*/, PyObject *args)
 {
     char* objecttype;
     char* document=0;
@@ -1174,7 +1174,7 @@ PyObject *SelectionSingleton::sCountObjectsOfType(PyObject * /*self*/, PyObject 
 #endif
 }
 
-PyObject *SelectionSingleton::sGetSelection(PyObject * /*self*/, PyObject *args, PyObject * /*kwd*/)
+PyObject *SelectionSingleton::sGetSelection(PyObject * /*self*/, PyObject *args)
 {
     char *documentName=0;
     if (!PyArg_ParseTuple(args, "|s", &documentName))
@@ -1195,7 +1195,7 @@ PyObject *SelectionSingleton::sGetSelection(PyObject * /*self*/, PyObject *args,
     }
 }
 
-PyObject *SelectionSingleton::sGetPreselection(PyObject * /*self*/, PyObject *args, PyObject * /*kwd*/)
+PyObject *SelectionSingleton::sGetPreselection(PyObject * /*self*/, PyObject *args)
 {
     if (!PyArg_ParseTuple(args, ""))
         return NULL;
@@ -1205,7 +1205,7 @@ PyObject *SelectionSingleton::sGetPreselection(PyObject * /*self*/, PyObject *ar
     return obj.getPyObject();
 }
 
-PyObject *SelectionSingleton::sRemPreselection(PyObject * /*self*/, PyObject *args, PyObject * /*kwd*/)
+PyObject *SelectionSingleton::sRemPreselection(PyObject * /*self*/, PyObject *args)
 {
     if (!PyArg_ParseTuple(args, ""))
         return NULL;
@@ -1214,7 +1214,7 @@ PyObject *SelectionSingleton::sRemPreselection(PyObject * /*self*/, PyObject *ar
     Py_Return;
 }
 
-PyObject *SelectionSingleton::sGetCompleteSelection(PyObject * /*self*/, PyObject *args, PyObject * /*kwd*/)
+PyObject *SelectionSingleton::sGetCompleteSelection(PyObject * /*self*/, PyObject *args)
 {
     if (!PyArg_ParseTuple(args, ""))
         return NULL;
@@ -1234,7 +1234,7 @@ PyObject *SelectionSingleton::sGetCompleteSelection(PyObject * /*self*/, PyObjec
     }
 }
 
-PyObject *SelectionSingleton::sGetSelectionEx(PyObject * /*self*/, PyObject *args, PyObject * /*kwd*/)
+PyObject *SelectionSingleton::sGetSelectionEx(PyObject * /*self*/, PyObject *args)
 {
     char *documentName=0;
     if (!PyArg_ParseTuple(args, "|s", &documentName))
@@ -1255,7 +1255,7 @@ PyObject *SelectionSingleton::sGetSelectionEx(PyObject * /*self*/, PyObject *arg
     }
 }
 
-PyObject *SelectionSingleton::sGetSelectionObject(PyObject * /*self*/, PyObject *args, PyObject * /*kwd*/)
+PyObject *SelectionSingleton::sGetSelectionObject(PyObject * /*self*/, PyObject *args)
 {
     char *docName, *objName, *subName;
     PyObject* tuple=0;
@@ -1290,7 +1290,7 @@ PyObject *SelectionSingleton::sGetSelectionObject(PyObject * /*self*/, PyObject 
     }
 }
 
-PyObject *SelectionSingleton::sAddSelObserver(PyObject * /*self*/, PyObject *args, PyObject * /*kwd*/)
+PyObject *SelectionSingleton::sAddSelObserver(PyObject * /*self*/, PyObject *args)
 {
     PyObject* o;
     if (!PyArg_ParseTuple(args, "O",&o))
@@ -1301,7 +1301,7 @@ PyObject *SelectionSingleton::sAddSelObserver(PyObject * /*self*/, PyObject *arg
     } PY_CATCH;
 }
 
-PyObject *SelectionSingleton::sRemSelObserver(PyObject * /*self*/, PyObject *args, PyObject * /*kwd*/)
+PyObject *SelectionSingleton::sRemSelObserver(PyObject * /*self*/, PyObject *args)
 {
     PyObject* o;
     if (!PyArg_ParseTuple(args, "O",&o))
@@ -1312,7 +1312,7 @@ PyObject *SelectionSingleton::sRemSelObserver(PyObject * /*self*/, PyObject *arg
     } PY_CATCH;
 }
 
-PyObject *SelectionSingleton::sAddSelectionGate(PyObject * /*self*/, PyObject *args, PyObject * /*kwd*/)
+PyObject *SelectionSingleton::sAddSelectionGate(PyObject * /*self*/, PyObject *args)
 {
     char* filter;
     if (PyArg_ParseTuple(args, "s",&filter)) {
@@ -1344,7 +1344,7 @@ PyObject *SelectionSingleton::sAddSelectionGate(PyObject * /*self*/, PyObject *a
     return 0;
 }
 
-PyObject *SelectionSingleton::sRemoveSelectionGate(PyObject * /*self*/, PyObject *args, PyObject * /*kwd*/)
+PyObject *SelectionSingleton::sRemoveSelectionGate(PyObject * /*self*/, PyObject *args)
 {
     if (!PyArg_ParseTuple(args, ""))
         return NULL;

--- a/src/Gui/Selection.h
+++ b/src/Gui/Selection.h
@@ -330,21 +330,21 @@ public:
     static PyMethodDef    Methods[];
 
 protected:
-    static PyObject *sAddSelection        (PyObject *self,PyObject *args,PyObject *kwd);
-    static PyObject *sRemoveSelection     (PyObject *self,PyObject *args,PyObject *kwd);
-    static PyObject *sClearSelection      (PyObject *self,PyObject *args,PyObject *kwd);
-    static PyObject *sIsSelected          (PyObject *self,PyObject *args,PyObject *kwd);
-    static PyObject *sCountObjectsOfType  (PyObject *self,PyObject *args,PyObject *kwd);
-    static PyObject *sGetSelection        (PyObject *self,PyObject *args,PyObject *kwd);
-    static PyObject *sGetPreselection     (PyObject *self,PyObject *args,PyObject *kwd);
-    static PyObject *sRemPreselection     (PyObject *self,PyObject *args,PyObject *kwd);
-    static PyObject *sGetCompleteSelection(PyObject *self,PyObject *args,PyObject *kwd);
-    static PyObject *sGetSelectionEx      (PyObject *self,PyObject *args,PyObject *kwd);
-    static PyObject *sGetSelectionObject  (PyObject *self,PyObject *args,PyObject *kwd);
-    static PyObject *sAddSelObserver      (PyObject *self,PyObject *args,PyObject *kwd);
-    static PyObject *sRemSelObserver      (PyObject *self,PyObject *args,PyObject *kwd);
-    static PyObject *sAddSelectionGate    (PyObject *self,PyObject *args,PyObject *kwd);
-    static PyObject *sRemoveSelectionGate (PyObject *self,PyObject *args,PyObject *kwd);
+    static PyObject *sAddSelection        (PyObject *self,PyObject *args);
+    static PyObject *sRemoveSelection     (PyObject *self,PyObject *args);
+    static PyObject *sClearSelection      (PyObject *self,PyObject *args);
+    static PyObject *sIsSelected          (PyObject *self,PyObject *args);
+    static PyObject *sCountObjectsOfType  (PyObject *self,PyObject *args);
+    static PyObject *sGetSelection        (PyObject *self,PyObject *args);
+    static PyObject *sGetPreselection     (PyObject *self,PyObject *args);
+    static PyObject *sRemPreselection     (PyObject *self,PyObject *args);
+    static PyObject *sGetCompleteSelection(PyObject *self,PyObject *args);
+    static PyObject *sGetSelectionEx      (PyObject *self,PyObject *args);
+    static PyObject *sGetSelectionObject  (PyObject *self,PyObject *args);
+    static PyObject *sAddSelObserver      (PyObject *self,PyObject *args);
+    static PyObject *sRemSelObserver      (PyObject *self,PyObject *args);
+    static PyObject *sAddSelectionGate    (PyObject *self,PyObject *args);
+    static PyObject *sRemoveSelectionGate (PyObject *self,PyObject *args);
 
 protected:
     /// Construction

--- a/src/Mod/Drawing/App/DrawingExport.cpp
+++ b/src/Mod/Drawing/App/DrawingExport.cpp
@@ -107,7 +107,7 @@ TopoDS_Edge DrawingOutput::asCircle(const BRepAdaptor_Curve& c) const
         center.ChangeCoord().Divide(3);
         curv /= 3;
     }
-    catch (Standard_Failure) {
+    catch (Standard_Failure&) {
         // if getting center of curvature fails, e.g.
         // for straight lines it raises LProp_NotDefined
         return TopoDS_Edge();
@@ -350,7 +350,7 @@ void SVGOutput::printBezier(const BRepAdaptor_Curve& c, int id, std::ostream& ou
         str << "\" />";
         out << str.str();
     }
-    catch (Standard_Failure) {
+    catch (Standard_Failure&) {
         printGeneric(c, id, out);
     }
 }
@@ -417,7 +417,7 @@ void SVGOutput::printBSpline(const BRepAdaptor_Curve& c, int id, std::ostream& o
         str << "\" />";
         out << str.str();
     }
-    catch (Standard_Failure) {
+    catch (Standard_Failure&) {
         printGeneric(c, id, out);
     }
 }
@@ -723,7 +723,7 @@ void DXFOutput::printBSpline(const BRepAdaptor_Curve& c, int id, std::ostream& o
         //str << "\" />";
         out << str.str();
     }
-    catch (Standard_Failure) {
+    catch (Standard_Failure&) {
         printGeneric(c, id, out);
     }
 }

--- a/src/Mod/Drawing/App/FeatureViewSpreadsheet.cpp
+++ b/src/Mod/Drawing/App/FeatureViewSpreadsheet.cpp
@@ -131,7 +131,7 @@ App::DocumentObjectExecReturn *FeatureViewSpreadsheet::execute(void)
                 }
             }
         }
-    } catch (std::exception) {
+    } catch (std::exception&) {
         return new App::DocumentObjectExecReturn("Invalid cell range");
     }
     

--- a/src/Mod/Drawing/Gui/TaskOrthoViews.cpp
+++ b/src/Mod/Drawing/Gui/TaskOrthoViews.cpp
@@ -107,7 +107,7 @@ void pagesize(string & page_template, int dims[4], int block[4])
                 break;
         }
     }
-    catch (Standard_Failure)
+    catch (Standard_Failure&)
     { }
 
 

--- a/src/Mod/Fem/App/FemConstraint.cpp
+++ b/src/Mod/Fem/App/FemConstraint.cpp
@@ -433,7 +433,7 @@ const Base::Vector3d Constraint::getDirection(const App::PropertyLinkSub &direct
     try {
         sh = shape.getSubShape(subName.c_str());
     }
-    catch (Standard_Failure) {
+    catch (Standard_Failure&) {
         std::stringstream str;
         str << "No such sub-element '" << subName << "'";
         throw Base::AttributeError(str.str());

--- a/src/Mod/Fem/App/FemTools.cpp
+++ b/src/Mod/Fem/App/FemTools.cpp
@@ -99,7 +99,7 @@ bool Fem::Tools::isPlanar(const TopoDS_Face& face)
 
             return true;
         }
-        catch (Standard_Failure) {
+        catch (Standard_Failure&) {
             return false;
         }
     }
@@ -131,7 +131,7 @@ bool Fem::Tools::isPlanar(const TopoDS_Face& face)
 
             return true;
         }
-        catch (Standard_Failure) {
+        catch (Standard_Failure&) {
             return false;
         }
     }
@@ -163,7 +163,7 @@ gp_XYZ Fem::Tools::getDirection(const TopoDS_Face& face)
             gp_Pln plane(p1, gp_Dir(vec3));
             dir = plane.Axis().Direction().XYZ();
         }
-        catch (Standard_Failure) {
+        catch (Standard_Failure&) {
         }
     }
     else if (surface.GetType() == GeomAbs_BezierSurface) {
@@ -182,7 +182,7 @@ gp_XYZ Fem::Tools::getDirection(const TopoDS_Face& face)
             gp_Pln plane(p1, gp_Dir(vec3));
             dir = plane.Axis().Direction().XYZ();
         }
-        catch (Standard_Failure) {
+        catch (Standard_Failure&) {
         }
     }
 
@@ -213,7 +213,7 @@ bool Fem::Tools::isLinear(const TopoDS_Edge& edge)
 
             return true;
         }
-        catch (Standard_Failure) {
+        catch (Standard_Failure&) {
             return false;
         }
     }
@@ -235,7 +235,7 @@ bool Fem::Tools::isLinear(const TopoDS_Edge& edge)
 
             return true;
         }
-        catch (Standard_Failure) {
+        catch (Standard_Failure&) {
             return false;
         }
     }
@@ -260,7 +260,7 @@ gp_XYZ Fem::Tools::getDirection(const TopoDS_Edge& edge)
             gp_Lin line(s1, gp_Dir(vec));
             dir = line.Direction().XYZ();
         }
-        catch (Standard_Failure) {
+        catch (Standard_Failure&) {
         }
     }
     else if (curve.GetType() == GeomAbs_BezierCurve) {
@@ -272,7 +272,7 @@ gp_XYZ Fem::Tools::getDirection(const TopoDS_Edge& edge)
             gp_Lin line(s1, gp_Dir(vec));
             dir = line.Direction().XYZ();
         }
-        catch (Standard_Failure) {
+        catch (Standard_Failure&) {
         }
     }
 

--- a/src/Mod/Part/App/AppPartPy.cpp
+++ b/src/Mod/Part/App/AppPartPy.cpp
@@ -845,7 +845,7 @@ private:
                 return Py::None(); //prevents compiler warning
             }
         }
-        catch (Standard_Failure err) {
+        catch (Standard_Failure& err) {
             std::stringstream errmsg;
             errmsg << "Creation of solid failed: " << err.GetMessageString();
             throw Py::Exception(PartExceptionOCCError, errmsg.str().c_str());
@@ -897,10 +897,10 @@ private:
             );
             return Py::asObject(new TopoShapeFacePy(new TopoShape((Face.Face()))));
         }
-        catch (Standard_DomainError) {
+        catch (Standard_DomainError&) {
             throw Py::Exception(PartExceptionOCCDomainError, "creation of plane failed");
         }
-        catch (Standard_Failure) {
+        catch (Standard_Failure&) {
             throw Py::Exception(PartExceptionOCCError, "creation of plane failed");
         }
     }
@@ -939,7 +939,7 @@ private:
             TopoDS_Shape ResultShape = mkBox.Shape();
             return Py::asObject(new TopoShapeSolidPy(new TopoShape(ResultShape)));
         }
-        catch (Standard_DomainError) {
+        catch (Standard_DomainError&) {
             throw Py::Exception(PartExceptionOCCDomainError, "creation of box failed");
         }
     }
@@ -989,7 +989,7 @@ private:
             mkSolid.Add(mkWedge.Shell());
             return Py::asObject(new TopoShapeSolidPy(new TopoShape(mkSolid.Solid())));
         }
-        catch (Standard_DomainError) {
+        catch (Standard_DomainError&) {
             throw Py::Exception(PartExceptionOCCDomainError, "creation of wedge failed");
         }
     }
@@ -1124,7 +1124,7 @@ private:
             TopoDS_Edge edge = aMakeEdge.Edge();
             return Py::asObject(new TopoShapeEdgePy(new TopoShape(edge)));
         }
-        catch (Standard_Failure) {
+        catch (Standard_Failure&) {
             throw Py::Exception(PartExceptionOCCError, "creation of circle failed");
         }
     }
@@ -1154,7 +1154,7 @@ private:
             TopoDS_Shape shape = mkSphere.Shape();
             return Py::asObject(new TopoShapeSolidPy(new TopoShape(shape)));
         }
-        catch (Standard_DomainError) {
+        catch (Standard_DomainError&) {
             throw Py::Exception(PartExceptionOCCDomainError, "creation of sphere failed");
         }
     }
@@ -1184,7 +1184,7 @@ private:
             TopoDS_Shape shape = mkCyl.Shape();
             return Py::asObject(new TopoShapeSolidPy(new TopoShape(shape)));
         }
-        catch (Standard_DomainError) {
+        catch (Standard_DomainError&) {
             throw Py::Exception(PartExceptionOCCDomainError, "creation of cylinder failed");
         }
     }
@@ -1214,7 +1214,7 @@ private:
             TopoDS_Shape shape = mkCone.Shape();
             return Py::asObject(new TopoShapeSolidPy(new TopoShape(shape)));
         }
-        catch (Standard_DomainError) {
+        catch (Standard_DomainError&) {
             throw Py::Exception(PartExceptionOCCDomainError, "creation of cone failed");
         }
     }
@@ -1244,7 +1244,7 @@ private:
             const TopoDS_Shape& shape = mkTorus.Shape();
             return Py::asObject(new TopoShapeSolidPy(new TopoShape(shape)));
         }
-        catch (Standard_DomainError) {
+        catch (Standard_DomainError&) {
             throw Py::Exception(PartExceptionOCCDomainError, "creation of torus failed");
         }
     }
@@ -1396,7 +1396,7 @@ private:
                 return Py::asObject(new TopoShapePy(new TopoShape(shape)));
             }
         }
-        catch (Standard_DomainError) {
+        catch (Standard_DomainError&) {
             throw Py::Exception(PartExceptionOCCDomainError, "creation of revolved shape failed");
         }
     }
@@ -1424,7 +1424,7 @@ private:
                 throw Py::Exception(PartExceptionOCCError, "curves must either be edges or wires");
             }
         }
-        catch (Standard_Failure) {
+        catch (Standard_Failure&) {
             throw Py::Exception(PartExceptionOCCError, "creation of ruled surface failed");
         }
     }
@@ -1712,7 +1712,7 @@ private:
                 CharList = FT2FC(unichars,pysize,dir,fontfile,height,track);
             }
         }
-        catch (Standard_DomainError) {                                      // Standard_DomainError is OCC error.
+        catch (Standard_DomainError&) {                                      // Standard_DomainError is OCC error.
             throw Py::Exception(PartExceptionOCCDomainError, "makeWireString failed - Standard_DomainError");
         }
         catch (std::runtime_error& e) {                                     // FT2 or FT2FC errors

--- a/src/Mod/Part/App/ArcOfConicPyImp.cpp
+++ b/src/Mod/Part/App/ArcOfConicPyImp.cpp
@@ -147,7 +147,7 @@ void  ArcOfConicPy::setAxis(Py::Object arg)
         axis.SetDirection(gp_Dir(val.x, val.y, val.z));
         conic->SetAxis(axis);
     }
-    catch (Standard_Failure) {
+    catch (Standard_Failure&) {
         throw Py::RuntimeError("cannot set axis");
     }
 }
@@ -187,7 +187,7 @@ void  ArcOfConicPy::setXAxis(Py::Object arg)
         pos.SetXDirection(gp_Dir(val.x, val.y, val.z));
         conic->SetPosition(pos);
     }
-    catch (Standard_Failure) {
+    catch (Standard_Failure&) {
         throw Py::RuntimeError("cannot set X axis");
     }
 }
@@ -227,7 +227,7 @@ void  ArcOfConicPy::setYAxis(Py::Object arg)
         pos.SetYDirection(gp_Dir(val.x, val.y, val.z));
         conic->SetPosition(pos);
     }
-    catch (Standard_Failure) {
+    catch (Standard_Failure&) {
         throw Py::RuntimeError("cannot set Y axis");
     }
 }

--- a/src/Mod/Part/App/AttachEnginePyImp.cpp
+++ b/src/Mod/Part/App/AttachEnginePyImp.cpp
@@ -408,7 +408,7 @@ PyObject* AttachEnginePy::calculateAttachedPlacement(PyObject* args)
         Base::Placement result;
         try{
             result = this->getAttachEnginePtr()->calculateAttachedPlacement(plm);
-        } catch (ExceptionCancel) {
+        } catch (ExceptionCancel&) {
             Py_IncRef(Py_None);
             return Py_None;
         }

--- a/src/Mod/Part/App/AttachExtension.cpp
+++ b/src/Mod/Part/App/AttachExtension.cpp
@@ -129,7 +129,7 @@ bool AttachExtension::positionBySupport()
             return false;
         getPlacement().setValue(_attacher->calculateAttachedPlacement(getPlacement().getValue()));
         return true;
-    } catch (ExceptionCancel) {
+    } catch (ExceptionCancel&) {
         //disabled, don't do anything
         return false;
     };

--- a/src/Mod/Part/App/AttachExtensionPyImp.cpp
+++ b/src/Mod/Part/App/AttachExtensionPyImp.cpp
@@ -57,7 +57,7 @@ Py::Object AttachExtensionPy::getAttacher(void) const
 {
     try {
         this->getAttachExtensionPtr()->attacher(); //throws if attacher is not set
-    } catch (Base::Exception) {
+    } catch (Base::Exception&) {
         return Py::None();
     }
 

--- a/src/Mod/Part/App/Attacher.cpp
+++ b/src/Mod/Part/App/Attacher.cpp
@@ -783,7 +783,7 @@ void AttachEngine::readLinks(const App::PropertyLinkSubList &references,
             if (sub[i].length()>0){
                 try{
                     storage.push_back(shape->getSubShape(sub[i].c_str()));
-                } catch (Standard_Failure){
+                } catch (Standard_Failure&){
                     throw Base::Exception("AttachEngine3D: subshape not found");
                 }
                 if(storage[storage.size()-1].IsNull())

--- a/src/Mod/Part/App/ConePyImp.cpp
+++ b/src/Mod/Part/App/ConePyImp.cpp
@@ -295,7 +295,7 @@ void ConePy::setAxis(Py::Object arg)
         axis.SetDirection(gp_Dir(dir_x, dir_y, dir_z));
         this_surf->SetAxis(axis);
     }
-    catch (Standard_Failure) {
+    catch (Standard_Failure&) {
         throw Py::RuntimeError("cannot set axis");
     }
 }

--- a/src/Mod/Part/App/ConicPyImp.cpp
+++ b/src/Mod/Part/App/ConicPyImp.cpp
@@ -150,7 +150,7 @@ void  ConicPy::setAxis(Py::Object arg)
         axis.SetDirection(gp_Dir(val.x, val.y, val.z));
         conic->SetAxis(axis);
     }
-    catch (Standard_Failure) {
+    catch (Standard_Failure&) {
         throw Py::RuntimeError("cannot set axis");
     }
 }
@@ -186,7 +186,7 @@ void  ConicPy::setXAxis(Py::Object arg)
         pos.SetXDirection(gp_Dir(val.x, val.y, val.z));
         conic->SetPosition(pos);
     }
-    catch (Standard_Failure) {
+    catch (Standard_Failure&) {
         throw Py::RuntimeError("cannot set X axis");
     }
 }
@@ -222,7 +222,7 @@ void  ConicPy::setYAxis(Py::Object arg)
         pos.SetYDirection(gp_Dir(val.x, val.y, val.z));
         conic->SetPosition(pos);
     }
-    catch (Standard_Failure) {
+    catch (Standard_Failure&) {
         throw Py::RuntimeError("cannot set Y axis");
     }
 }

--- a/src/Mod/Part/App/CylinderPyImp.cpp
+++ b/src/Mod/Part/App/CylinderPyImp.cpp
@@ -292,7 +292,7 @@ void CylinderPy::setAxis(Py::Object arg)
         axis.SetDirection(gp_Dir(dir_x, dir_y, dir_z));
         this_surf->SetAxis(axis);
     }
-    catch (Standard_Failure) {
+    catch (Standard_Failure&) {
         throw Py::RuntimeError("cannot set axis");
     }
 }

--- a/src/Mod/Part/App/FeaturePartBoolean.cpp
+++ b/src/Mod/Part/App/FeaturePartBoolean.cpp
@@ -118,7 +118,7 @@ App::DocumentObjectExecReturn *Boolean::execute(void)
                 history[0] = joinHistory(history[0], hist);
                 history[1] = joinHistory(history[1], hist);
             }
-            catch (Standard_Failure) {
+            catch (Standard_Failure&) {
                 // do nothing
             }
         }

--- a/src/Mod/Part/App/FeaturePartCommon.cpp
+++ b/src/Mod/Part/App/FeaturePartCommon.cpp
@@ -161,7 +161,7 @@ App::DocumentObjectExecReturn *MultiCommon::execute(void)
                     for (std::vector<ShapeHistory>::iterator jt = history.begin(); jt != history.end(); ++jt)
                         *jt = joinHistory(*jt, hist);
                 }
-                catch (Standard_Failure) {
+                catch (Standard_Failure&) {
                     // do nothing
                 }
             }

--- a/src/Mod/Part/App/FeaturePartFuse.cpp
+++ b/src/Mod/Part/App/FeaturePartFuse.cpp
@@ -186,7 +186,7 @@ App::DocumentObjectExecReturn *MultiFuse::execute(void)
                     for (std::vector<ShapeHistory>::iterator jt = history.begin(); jt != history.end(); ++jt)
                         *jt = joinHistory(*jt, hist);
                 }
-                catch (Standard_Failure) {
+                catch (Standard_Failure&) {
                     // do nothing
                 }
             }

--- a/src/Mod/Part/App/Geometry.cpp
+++ b/src/Mod/Part/App/Geometry.cpp
@@ -454,7 +454,7 @@ bool GeomCurve::closestParameter(const Base::Vector3d& point, double &u) const
             return true;
         }
     }
-    catch (StdFail_NotDone e) { // projection does not exist on trimmer curve, let's try basis curve
+    catch (StdFail_NotDone& e) { // projection does not exist on trimmer curve, let's try basis curve
         closestParameterToBasicCurve(point,u);
 
         if(abs(u-c->FirstParameter()) < abs(u-c->LastParameter()))

--- a/src/Mod/Part/App/PlanePyImp.cpp
+++ b/src/Mod/Part/App/PlanePyImp.cpp
@@ -250,7 +250,7 @@ void PlanePy::setAxis(Py::Object arg)
         axis.SetDirection(gp_Dir(dir_x, dir_y, dir_z));
         this_surf->SetAxis(axis);
     }
-    catch (Standard_Failure) {
+    catch (Standard_Failure&) {
         throw Py::RuntimeError("cannot set axis");
     }
 }

--- a/src/Mod/Part/App/PropertyTopoShape.cpp
+++ b/src/Mod/Part/App/PropertyTopoShape.cpp
@@ -126,7 +126,7 @@ Base::BoundBox3d PropertyPartShape::getBoundingBox() const
         box.MinZ = zMin;
         box.MaxZ = zMax;
     }
-    catch (Standard_Failure) {
+    catch (Standard_Failure&) {
     }
 
     return box;

--- a/src/Mod/Part/App/SpherePyImp.cpp
+++ b/src/Mod/Part/App/SpherePyImp.cpp
@@ -176,7 +176,7 @@ void SpherePy::setAxis(Py::Object arg)
         axis.SetDirection(gp_Dir(dir_x, dir_y, dir_z));
         this_surf->SetAxis(axis);
     }
-    catch (Standard_Failure) {
+    catch (Standard_Failure&) {
         throw Py::RuntimeError("cannot set axis");
     }
 }

--- a/src/Mod/Part/App/TopoShape.cpp
+++ b/src/Mod/Part/App/TopoShape.cpp
@@ -647,7 +647,7 @@ void TopoShape::importBinary(std::istream& str)
         this->_Shape.Location(theShapeSet.Locations().Location (locId));
         this->_Shape.Orientation (anOrient);
     }
-    catch (Standard_Failure) {
+    catch (Standard_Failure&) {
         throw Base::RuntimeError("Failed to read shape from binary stream");
     }
 }
@@ -960,7 +960,7 @@ Base::BoundBox3d TopoShape::getBoundBox(void) const
         box.MinZ = zMin;
         box.MaxZ = zMax;
     }
-    catch (Standard_Failure) {
+    catch (Standard_Failure&) {
     }
 
     return box;

--- a/src/Mod/Part/App/TopoShapePyImp.cpp
+++ b/src/Mod/Part/App/TopoShapePyImp.cpp
@@ -1892,7 +1892,7 @@ PyObject* TopoShapePy::project(PyObject *args)
             algo.Build();
             return new TopoShapePy(new TopoShape(algo.Projection()));
         }
-        catch (Standard_Failure) {
+        catch (Standard_Failure&) {
             PyErr_SetString(PartExceptionOCCError, "Failed to project shape");
             return NULL;
         }

--- a/src/Mod/Part/App/TopoShapeSolidPyImp.cpp
+++ b/src/Mod/Part/App/TopoShapeSolidPyImp.cpp
@@ -119,7 +119,7 @@ int TopoShapeSolidPy::PyInit(PyObject* args, PyObject* /*kwd*/)
         }
 
     }
-    catch (Standard_Failure err) {
+    catch (Standard_Failure& err) {
         std::stringstream errmsg;
         errmsg << "Creation of solid failed: " << err.GetMessageString();
         PyErr_SetString(PartExceptionOCCError, errmsg.str().c_str());

--- a/src/Mod/Part/App/TopoShapeWirePyImp.cpp
+++ b/src/Mod/Part/App/TopoShapeWirePyImp.cpp
@@ -348,7 +348,7 @@ PyObject* TopoShapeWirePy::approximate(PyObject *args)
             return 0;
         }
     }
-    catch (Standard_Failure) {
+    catch (Standard_Failure&) {
         PyErr_SetString(PartExceptionOCCError, "failed to approximate wire");
         return 0;
     }

--- a/src/Mod/Part/App/ToroidPyImp.cpp
+++ b/src/Mod/Part/App/ToroidPyImp.cpp
@@ -118,7 +118,7 @@ void ToroidPy::setMajorRadius(Py::Float arg)
             (getGeomToroidPtr()->handle());
         torus->SetMajorRadius((double)arg);
     }
-    catch (Standard_Failure) {
+    catch (Standard_Failure&) {
         throw Py::RuntimeError("Major radius must be positive and higher than minor radius");
     }
 }
@@ -137,7 +137,7 @@ void ToroidPy::setMinorRadius(Py::Float arg)
             (getGeomToroidPtr()->handle());
         torus->SetMinorRadius((double)arg);
     }
-    catch (Standard_Failure) {
+    catch (Standard_Failure&) {
         throw Py::RuntimeError("Minor radius must be positive and lower than major radius");
     }
 }
@@ -204,7 +204,7 @@ void ToroidPy::setAxis(Py::Object arg)
         axis.SetDirection(gp_Dir(dir_x, dir_y, dir_z));
         this_surf->SetAxis(axis);
     }
-    catch (Standard_Failure) {
+    catch (Standard_Failure&) {
         throw Py::RuntimeError("cannot set axis");
     }
 }

--- a/src/Mod/Part/App/modelRefine.cpp
+++ b/src/Mod/Part/App/modelRefine.cpp
@@ -1064,7 +1064,7 @@ bool FaceUniter::process()
             sew.Perform();
             try {
                 workShell = TopoDS::Shell(sew.SewedShape());
-            } catch (Standard_Failure) {
+            } catch (Standard_Failure&) {
                 return false;
             }
             // update the list of modifications

--- a/src/Mod/Part/Gui/AttacherTexts.cpp
+++ b/src/Mod/Part/Gui/AttacherTexts.cpp
@@ -369,7 +369,7 @@ QStringList getRefListForMode(AttachEngine &attacher, eMapMode mmode)
 
 // --------------------Py interface---------------------
 
-PyObject* AttacherGuiPy::sGetModeStrings(PyObject * /*self*/, PyObject *args, PyObject * /*kwd*/)
+PyObject* AttacherGuiPy::sGetModeStrings(PyObject * /*self*/, PyObject *args)
 {
     int modeIndex = 0;
     char* attacherType;
@@ -400,7 +400,7 @@ PyObject* AttacherGuiPy::sGetModeStrings(PyObject * /*self*/, PyObject *args, Py
     }
 }
 
-PyObject* AttacherGuiPy::sGetRefTypeUserFriendlyName(PyObject * /*self*/, PyObject *args, PyObject * /*kwd*/)
+PyObject* AttacherGuiPy::sGetRefTypeUserFriendlyName(PyObject * /*self*/, PyObject *args)
 {
     int refTypeIndex = 0;
     if (!PyArg_ParseTuple(args, "i", &refTypeIndex))

--- a/src/Mod/Part/Gui/AttacherTexts.h
+++ b/src/Mod/Part/Gui/AttacherTexts.h
@@ -61,8 +61,8 @@ QStringList PartGuiExport getRefListForMode(Attacher::AttachEngine &attacher, At
 class PartGuiExport AttacherGuiPy{
 public:
     static PyMethodDef    Methods[];
-    static PyObject* sGetModeStrings(PyObject * /*self*/, PyObject *args, PyObject * /*kwd*/);
-    static PyObject* sGetRefTypeUserFriendlyName(PyObject * /*self*/, PyObject *args, PyObject * /*kwd*/);
+    static PyObject* sGetModeStrings(PyObject * /*self*/, PyObject *args);
+    static PyObject* sGetRefTypeUserFriendlyName(PyObject * /*self*/, PyObject *args);
 };
 
 }

--- a/src/Mod/Part/Gui/DlgExtrusion.cpp
+++ b/src/Mod/Part/Gui/DlgExtrusion.cpp
@@ -393,7 +393,7 @@ void DlgExtrusion::accept()
     try{
         apply();
         QDialog::accept();
-    } catch (Base::AbortException){
+    } catch (Base::AbortException&){
 
     };
 }
@@ -454,7 +454,7 @@ void DlgExtrusion::apply()
         activeDoc->commitTransaction();
         Gui::Command::updateActive();
     }
-    catch (Base::AbortException){
+    catch (Base::AbortException&){
         throw;
     }
     catch (Base::Exception &err){
@@ -744,7 +744,7 @@ void TaskExtrusion::clicked(int id)
     if (id == QDialogButtonBox::Apply) {
         try{
             widget->apply();
-        } catch (Base::AbortException){
+        } catch (Base::AbortException&){
 
         };
     }

--- a/src/Mod/Part/Gui/DlgFilletEdges.cpp
+++ b/src/Mod/Part/Gui/DlgFilletEdges.cpp
@@ -453,7 +453,7 @@ void DlgFilletEdges::onSelectEdgesOfFace(const QString& subelement, int type)
                 }
             }
         }
-        catch (Standard_Failure) {
+        catch (Standard_Failure&) {
         }
     }
 }

--- a/src/Mod/PartDesign/App/FeaturePipe.cpp
+++ b/src/Mod/PartDesign/App/FeaturePipe.cpp
@@ -492,7 +492,7 @@ void Pipe::buildPipePath(const Part::TopoShape& shape, const std::vector< std::s
                 throw Base::Exception("Spine is neither an edge nor a wire.");
             }
         }
-        catch (Standard_Failure) {
+        catch (Standard_Failure&) {
             throw Base::Exception("Invalid spine.");
         }
     }

--- a/src/Mod/PartDesign/App/FeaturePrimitive.cpp
+++ b/src/Mod/PartDesign/App/FeaturePrimitive.cpp
@@ -80,7 +80,7 @@ TopoDS_Shape FeaturePrimitive::refineShapeIfActive(const TopoDS_Shape& oldShape)
             TopoDS_Shape resShape = mkRefine.Shape();
             return resShape;
         }
-        catch (Standard_Failure) {
+        catch (Standard_Failure&) {
             return oldShape;
         }
     }

--- a/src/Mod/PartDesign/App/FeatureSketchBased.cpp
+++ b/src/Mod/PartDesign/App/FeatureSketchBased.cpp
@@ -757,7 +757,7 @@ void ProfileBased::remapSupportShape(const TopoDS_Shape& newShape)
                 try {
                     element = shape.getSubShape(it->c_str());
                 }
-                catch (Standard_Failure) {
+                catch (Standard_Failure&) {
                     // This shape doesn't even exist, so no chance to do some tests
                     newSubValues.push_back(*it);
                     continue;
@@ -770,7 +770,7 @@ void ProfileBased::remapSupportShape(const TopoDS_Shape& newShape)
                         success = true;
                     }
                 }
-                catch (Standard_Failure) {
+                catch (Standard_Failure&) {
                 }
                 // try an exact matching
                 if (!success) {
@@ -1051,7 +1051,7 @@ TopoDS_Shape ProfileBased::refineShapeIfActive(const TopoDS_Shape& oldShape) con
             TopoDS_Shape resShape = mkRefine.Shape();
             return resShape;
         }
-        catch (Standard_Failure) {
+        catch (Standard_Failure&) {
             return oldShape;
         }
     }

--- a/src/Mod/PartDesign/App/FeatureTransformed.cpp
+++ b/src/Mod/PartDesign/App/FeatureTransformed.cpp
@@ -401,7 +401,7 @@ TopoDS_Shape Transformed::refineShapeIfActive(const TopoDS_Shape& oldShape) cons
             TopoDS_Shape resShape = mkRefine.Shape();
             return resShape;
         }
-        catch (Standard_Failure) {
+        catch (Standard_Failure&) {
             return oldShape;
         }
     }

--- a/src/Mod/PartDesign/Gui/ReferenceSelection.cpp
+++ b/src/Mod/PartDesign/Gui/ReferenceSelection.cpp
@@ -105,7 +105,7 @@ bool ReferenceSelection::allow(App::Document* pDoc, App::DocumentObject* pObj, c
                         return true;
                     }
                 }
-            } catch (const Base::Exception)
+            } catch (const Base::Exception&)
             { }
         }
         return false; // The Plane/Axis doesn't fits our needs

--- a/src/Mod/Path/App/AreaPyImp.cpp
+++ b/src/Mod/Path/App/AreaPyImp.cpp
@@ -148,7 +148,7 @@ static const PyMethodDef areaOverrides[] = {
         "of this Area is used if section mode is 'Workplane'.",
     },
     {
-        "setDefaultParams",(PyCFunction)areaSetParams, METH_VARARGS|METH_KEYWORDS|METH_STATIC,
+        "setDefaultParams",(PyCFunction)(void*)areaSetParams, METH_VARARGS|METH_KEYWORDS|METH_STATIC,
         "setDefaultParams(key=value...):\n"
         "Static method to set the default parameters of all following Path.Area, plus the following\n"
         "additional parameters.\n"
@@ -158,13 +158,13 @@ static const PyMethodDef areaOverrides[] = {
         "getDefaultParams(): Static method to return the current default parameters."
     },
     {
-        "abort",(PyCFunction)areaAbort, METH_VARARGS|METH_KEYWORDS|METH_STATIC,
+        "abort",(PyCFunction)(void*)areaAbort, METH_VARARGS|METH_KEYWORDS|METH_STATIC,
         "abort(aborting=True): Static method to abort any ongoing operation\n"
         "\nTo ensure no stray abortion is left in the previous operation, it is advised to manually clear\n"
         "the aborting flag by calling abort(False) before starting a new operation.",
     },
     {
-        "getParamsDesc",(PyCFunction)areaGetParamsDesc, METH_VARARGS|METH_KEYWORDS|METH_STATIC,
+        "getParamsDesc",(PyCFunction)(void*)areaGetParamsDesc, METH_VARARGS|METH_KEYWORDS|METH_STATIC,
         "getParamsDesc(as_string=False): Returns a list of supported parameters and their descriptions.\n"
         "\n* as_string: if False, then return a dictionary of documents of all supported parameters."
     },

--- a/src/Mod/Sketcher/App/Sketch.cpp
+++ b/src/Mod/Sketcher/App/Sketch.cpp
@@ -3048,7 +3048,7 @@ bool Sketch::updateGeometry()
                 #endif
 
             }
-        } catch (Base::Exception e) {
+        } catch (Base::Exception &e) {
             Base::Console().Error("Updating geometry: Error build geometry(%d): %s\n",
                                   i,e.what());
             return false;
@@ -3659,7 +3659,7 @@ bool Sketch::hasDependentParameters(int geoId, PointPos pos) const
     try {
         geoId = checkGeoId(geoId);
     }
-    catch (Base::Exception) {
+    catch (Base::Exception&) {
         return false;
     }
 

--- a/src/Mod/Sketcher/App/SketchAnalysis.cpp
+++ b/src/Mod/Sketcher/App/SketchAnalysis.cpp
@@ -337,7 +337,7 @@ void SketchAnalysis::analyseMissingPointOnPointCoincident(double angleprecision)
                 }
             
             }
-            catch(Base::Exception e) {
+            catch(Base::Exception &e) {
                 Base::Console().Warning("Point-On-Point Coincidence analysis: unable to obtain derivative. Detection ignored.\n");
                 continue;
             }
@@ -782,7 +782,7 @@ int SketchAnalysis::autoconstraint(double precision, double angleprecision, bool
         try {
             makeMissingEquality();
         }
-        catch(Base::RuntimeError e)
+        catch(Base::RuntimeError &e)
         {
             doc->abortTransaction();
             throw;

--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -4931,7 +4931,7 @@ void SketchObject::validateExternalLinks(void)
                 refSubShape = refShape.getSubShape(SubElement.c_str());
             }
         }
-        catch (Standard_Failure) {
+        catch (Standard_Failure&) {
             rebuild = true ;
             Objects.erase(Objects.begin()+i);
             SubElements.erase(SubElements.begin()+i);

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -3924,7 +3924,7 @@ void ViewProviderSketch::draw(bool temp /*=false*/, bool rebuildinformationlayer
             try {
                 spline->normalAt(paramlist[i],normallist[i]);
             }
-            catch(Base::Exception) {
+            catch(Base::Exception&) {
                 normallist[i] = Base::Vector3d(0,0,0);
             }
 
@@ -5126,7 +5126,7 @@ Restart:
                     break;
             }
 
-        } catch (Base::Exception e) {
+        } catch (Base::Exception &e) {
             Base::Console().Error("Exception during draw: %s\n", e.what());
         } catch (...){
             Base::Console().Error("Exception during draw: unknown\n");

--- a/src/Mod/Spreadsheet/App/Sheet.cpp
+++ b/src/Mod/Spreadsheet/App/Sheet.cpp
@@ -793,7 +793,7 @@ DocumentObjectExecReturn *Sheet::execute(void)
                 ++i;
             }
         }
-        catch (std::exception) {
+        catch (std::exception&) {
             // Cycle detected; flag all with errors
 
             std::map<CellAddress, Vertex>::const_iterator i = VertexList.begin();

--- a/src/Mod/Surface/App/FeatureGeomFillSurface.cpp
+++ b/src/Mod/Surface/App/FeatureGeomFillSurface.cpp
@@ -116,7 +116,7 @@ void ShapeValidator::checkAndAdd(const Part::TopoShape &ts, const char *subName,
             checkAndAdd(ts.getShape(), aWD);
         }
     }
-    catch (Standard_Failure) { // any OCC exception means an unappropriate shape in the selection
+    catch (Standard_Failure&) { // any OCC exception means an unappropriate shape in the selection
         Standard_Failure::Raise("Wrong shape type.\n");
     }
 }
@@ -160,11 +160,11 @@ App::DocumentObjectExecReturn *GeomFillSurface::execute(void)
 
         return App::DocumentObject::StdReturn;
     }
-    catch (Standard_ConstructionError) {
+    catch (Standard_ConstructionError&) {
         // message is in a Latin language, show a normal one
         return new App::DocumentObjectExecReturn("Curves are disjoint.");
     }
-    catch (StdFail_NotDone) {
+    catch (StdFail_NotDone&) {
         return new App::DocumentObjectExecReturn("A curve was not a B-spline and could not be converted into one.");
     }
     catch (Standard_Failure& e) {

--- a/src/Mod/TechDraw/App/DrawProjectSplit.cpp
+++ b/src/Mod/TechDraw/App/DrawProjectSplit.cpp
@@ -368,7 +368,7 @@ std::vector<TopoDS_Edge> DrawProjectSplit::split1Edge(TopoDS_Edge e, std::vector
                 result.push_back(e1);
             }
         }
-        catch (Standard_Failure) {
+        catch (Standard_Failure&) {
             Base::Console().Message("LOG - DPS::split1Edge failed building edge segment\n");
         }
     }

--- a/src/Mod/TechDraw/App/DrawViewSpreadsheet.cpp
+++ b/src/Mod/TechDraw/App/DrawViewSpreadsheet.cpp
@@ -203,7 +203,7 @@ std::string DrawViewSpreadsheet::getSheetImage(void)
                 break;
             }
         }
-    } catch (std::exception) {
+    } catch (std::exception&) {
         Base::Console().Error("Invalid cell range for %s\n",getNameInDocument());
         return result.str();
     }

--- a/src/Mod/TechDraw/App/Geometry.cpp
+++ b/src/Mod/TechDraw/App/Geometry.cpp
@@ -241,7 +241,7 @@ BaseGeom* BaseGeom::baseFactory(TopoDS_Edge edge)
             }
             break;
         }
-        catch (Standard_Failure) {
+        catch (Standard_Failure&) {
             if (bspline != nullptr) {
                 delete bspline;
                 bspline = nullptr;


### PR DESCRIPTION
gcc 8 introduced a bunch of new warnings which make the build really noisy - to the point where all relevant errors and warnings are hard to spot.

This change fixes the most notorious two warnings, catch of an exception by value and the incompatible pointer cast of python functions with and without keyword paramater.

<s>Also added an attribute for `case` fallthrough warnings in sketch - should be interesting to see how they fair with other compilers.</s> As it turns out all builds other than the clang have an issue with the `__attribute__`, removed that commit.

The changes go through the entire code base.