### PR TITLE
Typos and whitespace fixes

### DIFF
--- a/src/App/PropertyFile.cpp
+++ b/src/App/PropertyFile.cpp
@@ -438,7 +438,7 @@ void PropertyFileIncluded::Restore(Base::XMLReader &reader)
     if (reader.hasAttribute("file")) {
         string file (reader.getAttribute("file") );
         if (!file.empty()) {
-            // initate a file read
+            // initiate a file read
             reader.addFile(file.c_str(),this);
             // is in the document transient path
             aboutToSetValue();

--- a/src/App/PropertyGeo.cpp
+++ b/src/App/PropertyGeo.cpp
@@ -408,7 +408,7 @@ void PropertyVectorList::Restore(Base::XMLReader &reader)
     std::string file (reader.getAttribute("file") );
 
     if (!file.empty()) {
-        // initate a file read
+        // initiate a file read
         reader.addFile(file.c_str(),this);
     }
 }
@@ -907,7 +907,7 @@ void PropertyPlacementList::Restore(Base::XMLReader &reader)
     std::string file (reader.getAttribute("file") );
 
     if (!file.empty()) {
-        // initate a file read
+        // initiate a file read
         reader.addFile(file.c_str(),this);
     }
 }

--- a/src/App/PropertyStandard.cpp
+++ b/src/App/PropertyStandard.cpp
@@ -1370,7 +1370,7 @@ void PropertyFloatList::Restore(Base::XMLReader &reader)
     string file (reader.getAttribute("file") );
 
     if (!file.empty()) {
-        // initate a file read
+        // initiate a file read
         reader.addFile(file.c_str(),this);
     }
 }
@@ -2608,7 +2608,7 @@ void PropertyColorList::Restore(Base::XMLReader &reader)
         std::string file (reader.getAttribute("file"));
 
         if (!file.empty()) {
-            // initate a file read
+            // initiate a file read
             reader.addFile(file.c_str(),this);
         }
     }
@@ -2887,7 +2887,7 @@ void PropertyMaterialList::Restore(Base::XMLReader &reader)
         std::string file(reader.getAttribute("file"));
 
         if (!file.empty()) {
-            // initate a file read
+            // initiate a file read
             reader.addFile(file.c_str(), this);
         }
     }

--- a/src/Gui/ToolBarManager.cpp
+++ b/src/Gui/ToolBarManager.cpp
@@ -183,7 +183,7 @@ void ToolBarManager::setup(ToolBarItem* toolBarItems)
 
     int max_width = getMainWindow()->width();
     int top_width = 0;
-    
+
     ParameterGrp::handle hPref = App::GetApplication().GetUserParameter().GetGroup("BaseApp")
                                ->GetGroup("MainWindow")->GetGroup("Toolbars");
     QList<ToolBarItem*> items = toolBarItems->getItems();
@@ -272,8 +272,8 @@ void ToolBarManager::setup(ToolBarItem* item, QToolBar* toolbar) const
             // set the tool button user data
             if (action) action->setData(QString::fromLatin1((*it)->command().c_str()));
         } else {
-            // Note: For toolbars we do not remove and readd the actions
-            // because this causes flicker effects. So, it could happen that the order of 
+            // Note: For toolbars we do not remove and re-add the actions
+            // because this causes flicker effects. So, it could happen that the order of
             // buttons doesn't match with the order of commands in the workbench.
             int index = actions.indexOf(action);
             actions.removeAt(index);

--- a/src/Gui/View3DInventorViewer.cpp
+++ b/src/Gui/View3DInventorViewer.cpp
@@ -245,7 +245,7 @@ public:
         }
 #endif
 
-        // Bug #0000607: Some mices also support horizontal scrolling which however might
+        // Bug #0000607: Some mice also support horizontal scrolling which however might
         // lead to some unwanted zooming when pressing the MMB for panning.
         // Thus, we filter out horizontal scrolling.
         if (event->type() == QEvent::Wheel) {

--- a/src/Mod/Cam/doxygen_config
+++ b/src/Mod/Cam/doxygen_config
@@ -25,8 +25,8 @@ ABBREVIATE_BRIEF       = "The $name class" \
 ALWAYS_DETAILED_SEC    = NO
 INLINE_INHERITED_MEMB  = NO
 FULL_PATH_NAMES        = NO
-STRIP_FROM_PATH        = 
-STRIP_FROM_INC_PATH    = 
+STRIP_FROM_PATH        =
+STRIP_FROM_INC_PATH    =
 SHORT_NAMES            = NO
 JAVADOC_AUTOBRIEF      = NO
 QT_AUTOBRIEF           = NO
@@ -35,7 +35,7 @@ DETAILS_AT_TOP         = NO
 INHERIT_DOCS           = YES
 SEPARATE_MEMBER_PAGES  = NO
 TAB_SIZE               = 8
-ALIASES                = 
+ALIASES                =
 OPTIMIZE_OUTPUT_FOR_C  = NO
 OPTIMIZE_OUTPUT_JAVA   = NO
 OPTIMIZE_FOR_FORTRAN   = NO
@@ -73,13 +73,13 @@ GENERATE_TODOLIST      = YES
 GENERATE_TESTLIST      = YES
 GENERATE_BUGLIST       = YES
 GENERATE_DEPRECATEDLIST= YES
-ENABLED_SECTIONS       = 
+ENABLED_SECTIONS       =
 MAX_INITIALIZER_LINES  = 30
 SHOW_USED_FILES        = YES
 SHOW_DIRECTORIES       = NO
 SHOW_FILES             = YES
 SHOW_NAMESPACES        = YES
-FILE_VERSION_FILTER    = 
+FILE_VERSION_FILTER    =
 #---------------------------------------------------------------------------
 # configuration options related to warning and progress messages
 #---------------------------------------------------------------------------
@@ -89,7 +89,7 @@ WARN_IF_UNDOCUMENTED   = YES
 WARN_IF_DOC_ERROR      = YES
 WARN_NO_PARAMDOC       = NO
 WARN_FORMAT            = "$file:$line: $text"
-WARN_LOGFILE           = 
+WARN_LOGFILE           =
 #---------------------------------------------------------------------------
 # configuration options related to the input files
 #---------------------------------------------------------------------------
@@ -127,16 +127,16 @@ FILE_PATTERNS          = *.c \
                          *.vhd \
                          *.vhdl
 RECURSIVE              = YES
-EXCLUDE                = 
+EXCLUDE                =
 EXCLUDE_SYMLINKS       = NO
-EXCLUDE_PATTERNS       = 
-EXCLUDE_SYMBOLS        = 
-EXAMPLE_PATH           = 
+EXCLUDE_PATTERNS       =
+EXCLUDE_SYMBOLS        =
+EXAMPLE_PATH           =
 EXAMPLE_PATTERNS       = *
 EXAMPLE_RECURSIVE      = NO
-IMAGE_PATH             = 
-INPUT_FILTER           = 
-FILTER_PATTERNS        = 
+IMAGE_PATH             =
+INPUT_FILTER           =
+FILTER_PATTERNS        =
 FILTER_SOURCE_FILES    = NO
 #---------------------------------------------------------------------------
 # configuration options related to source browsing
@@ -154,26 +154,26 @@ VERBATIM_HEADERS       = YES
 #---------------------------------------------------------------------------
 ALPHABETICAL_INDEX     = NO
 COLS_IN_ALPHA_INDEX    = 5
-IGNORE_PREFIX          = 
+IGNORE_PREFIX          =
 #---------------------------------------------------------------------------
 # configuration options related to the HTML output
 #---------------------------------------------------------------------------
 GENERATE_HTML          = YES
 HTML_OUTPUT            = html
 HTML_FILE_EXTENSION    = .html
-HTML_HEADER            = 
-HTML_FOOTER            = 
-HTML_STYLESHEET        = 
+HTML_HEADER            =
+HTML_FOOTER            =
+HTML_STYLESHEET        =
 HTML_ALIGN_MEMBERS     = YES
 GENERATE_HTMLHELP      = NO
 GENERATE_DOCSET        = NO
 DOCSET_FEEDNAME        = "Doxygen generated docs"
 DOCSET_BUNDLE_ID       = org.doxygen.Project
 HTML_DYNAMIC_SECTIONS  = NO
-CHM_FILE               = 
-HHC_LOCATION           = 
+CHM_FILE               =
+HHC_LOCATION           =
 GENERATE_CHI           = NO
-CHM_INDEX_ENCODING     = 
+CHM_INDEX_ENCODING     =
 BINARY_TOC             = NO
 TOC_EXPAND             = NO
 DISABLE_INDEX          = NO
@@ -190,8 +190,8 @@ LATEX_CMD_NAME         = latex
 MAKEINDEX_CMD_NAME     = makeindex
 COMPACT_LATEX          = NO
 PAPER_TYPE             = a4wide
-EXTRA_PACKAGES         = 
-LATEX_HEADER           = 
+EXTRA_PACKAGES         =
+LATEX_HEADER           =
 PDF_HYPERLINKS         = YES
 USE_PDFLATEX           = YES
 LATEX_BATCHMODE        = NO
@@ -203,8 +203,8 @@ GENERATE_RTF           = NO
 RTF_OUTPUT             = rtf
 COMPACT_RTF            = NO
 RTF_HYPERLINKS         = NO
-RTF_STYLESHEET_FILE    = 
-RTF_EXTENSIONS_FILE    = 
+RTF_STYLESHEET_FILE    =
+RTF_EXTENSIONS_FILE    =
 #---------------------------------------------------------------------------
 # configuration options related to the man page output
 #---------------------------------------------------------------------------
@@ -217,8 +217,8 @@ MAN_LINKS              = NO
 #---------------------------------------------------------------------------
 GENERATE_XML           = NO
 XML_OUTPUT             = xml
-XML_SCHEMA             = 
-XML_DTD                = 
+XML_SCHEMA             =
+XML_DTD                =
 XML_PROGRAMLISTING     = YES
 #---------------------------------------------------------------------------
 # configuration options for the AutoGen Definitions output
@@ -230,36 +230,36 @@ GENERATE_AUTOGEN_DEF   = NO
 GENERATE_PERLMOD       = NO
 PERLMOD_LATEX          = NO
 PERLMOD_PRETTY         = YES
-PERLMOD_MAKEVAR_PREFIX = 
+PERLMOD_MAKEVAR_PREFIX =
 #---------------------------------------------------------------------------
-# Configuration options related to the preprocessor   
+# Configuration options related to the preprocessor
 #---------------------------------------------------------------------------
 ENABLE_PREPROCESSING   = YES
 MACRO_EXPANSION        = NO
 EXPAND_ONLY_PREDEF     = NO
 SEARCH_INCLUDES        = YES
-INCLUDE_PATH           = 
-INCLUDE_FILE_PATTERNS  = 
-PREDEFINED             = 
-EXPAND_AS_DEFINED      = 
+INCLUDE_PATH           =
+INCLUDE_FILE_PATTERNS  =
+PREDEFINED             =
+EXPAND_AS_DEFINED      =
 SKIP_FUNCTION_MACROS   = YES
 #---------------------------------------------------------------------------
-# Configuration::additions related to external references   
+# Configuration::additions related to external references
 #---------------------------------------------------------------------------
-TAGFILES               = 
-GENERATE_TAGFILE       = 
+TAGFILES               =
+GENERATE_TAGFILE       =
 ALLEXTERNALS           = NO
 EXTERNAL_GROUPS        = YES
 PERL_PATH              = /usr/bin/perl
 #---------------------------------------------------------------------------
-# Configuration options related to the dot tool   
+# Configuration options related to the dot tool
 #---------------------------------------------------------------------------
 CLASS_DIAGRAMS         = NO
-MSCGEN_PATH            = 
+MSCGEN_PATH            =
 HIDE_UNDOC_RELATIONS   = YES
 HAVE_DOT               = YES
 DOT_FONTNAME           = FreeSans
-DOT_FONTPATH           = 
+DOT_FONTPATH           =
 CLASS_GRAPH            = YES
 COLLABORATION_GRAPH    = YES
 GROUP_GRAPHS           = YES
@@ -273,7 +273,7 @@ GRAPHICAL_HIERARCHY    = YES
 DIRECTORY_GRAPH        = YES
 DOT_IMAGE_FORMAT       = png
 DOT_PATH               = "C:/Program Files/Graphviz2.16/bin"
-DOTFILE_DIRS           = 
+DOTFILE_DIRS           =
 DOT_GRAPH_MAX_NODES    = 50
 MAX_DOT_GRAPH_DEPTH    = 1000
 DOT_TRANSPARENT        = YES
@@ -281,6 +281,6 @@ DOT_MULTI_TARGETS      = NO
 GENERATE_LEGEND        = YES
 DOT_CLEANUP            = YES
 #---------------------------------------------------------------------------
-# Configuration::additions related to the search engine   
+# Configuration::additions related to the search engine
 #---------------------------------------------------------------------------
 SEARCHENGINE           = NO

--- a/src/Mod/Cam/doxygen_config
+++ b/src/Mod/Cam/doxygen_config
@@ -4,7 +4,7 @@
 # Project related configuration options
 #---------------------------------------------------------------------------
 DOXYFILE_ENCODING      = UTF-8
-PROJECT_NAME           = "FreeCAD CAM Modul"
+PROJECT_NAME           = "FreeCAD CAM Module"
 PROJECT_NUMBER         = 0.1
 OUTPUT_DIRECTORY       = Doc
 CREATE_SUBDIRS         = NO

--- a/src/Mod/Draft/DraftGui.py
+++ b/src/Mod/Draft/DraftGui.py
@@ -1585,7 +1585,7 @@ class DraftToolBar:
 
     def checkSpecialChars(self,txt):
         '''
-        checks for special characters in the entered coords that mut be
+        checks for special characters in the entered coords that must be
         treated as shortcuts
         '''
 

--- a/src/Mod/Fem/App/FemMesh.cpp
+++ b/src/Mod/Fem/App/FemMesh.cpp
@@ -1656,7 +1656,7 @@ void FemMesh::Restore(Base::XMLReader &reader)
     std::string file (reader.getAttribute("file") );
 
     if (!file.empty()) {
-        // initate a file read
+        // initiate a file read
         reader.addFile(file.c_str(),this);
     }
     if( reader.hasAttribute("a11")){

--- a/src/Mod/Fem/App/PropertyPostDataObject.cpp
+++ b/src/Mod/Fem/App/PropertyPostDataObject.cpp
@@ -235,7 +235,7 @@ void PropertyPostDataObject::Restore(Base::XMLReader &reader)
     std::string file (reader.getAttribute("file") );
 
     if (!file.empty()) {
-        // initate a file read
+        // initiate a file read
         reader.addFile(file.c_str(),this);
     }
 }

--- a/src/Mod/Inspection/App/InspectionFeature.cpp
+++ b/src/Mod/Inspection/App/InspectionFeature.cpp
@@ -591,7 +591,7 @@ void PropertyDistanceList::Restore(Base::XMLReader &reader)
     std::string file (reader.getAttribute("file") );
 
     if (!file.empty()) {
-        // initate a file read
+        // initiate a file read
         reader.addFile(file.c_str(),this);
     }
 }

--- a/src/Mod/Mesh/App/Core/Degeneration.h
+++ b/src/Mod/Mesh/App/Core/Degeneration.h
@@ -367,8 +367,8 @@ private:
 };
 
 /**
- * The MeshFixDeformedFacets class tries to fix deformed facets by swapping the commong edge with one of their neighbours.
- * @note Degenerated facets are also deformed facet but this algorithm tries to fix deformed facets that or not degenrated.
+ * The MeshFixDeformedFacets class tries to fix deformed facets by swapping the common edge with one of their neighbours.
+ * @note Degenerated facets are also deformed facet but this algorithm tries to fix deformed facets that or not degenerated.
  * The removal of degenerated facets is done by @ref MeshFixDegeneratedFacets.
  * @see MeshEvalDeformedFacets
  * @author Werner Mayer

--- a/src/Mod/Mesh/App/Core/Degeneration.h
+++ b/src/Mod/Mesh/App/Core/Degeneration.h
@@ -51,11 +51,11 @@ public:
    * Construction.
    */
   MeshEvalInvalids (const MeshKernel &rclM) : MeshEvaluation( rclM ) { }
-  /** 
+  /**
    * Destruction.
    */
   ~MeshEvalInvalids () { }
-  /** 
+  /**
    * Searches for as 'Invalid' marked points or facets.
    */
   bool Evaluate ();
@@ -77,11 +77,11 @@ public:
    * Construction.
    */
   MeshFixInvalids (MeshKernel &rclM) : MeshValidation( rclM ) { }
-  /** 
+  /**
    * Destruction.
    */
   ~MeshFixInvalids () { }
-  /** 
+  /**
    * Remove invalid elements.
    */
   bool Fixup ();
@@ -89,7 +89,7 @@ public:
 
 /**
  * The MeshEvalDuplicatePoints class searches for duplicated points.
- * A point is regarded as duplicated if the distances between x, y and z coordinates of two points is 
+ * A point is regarded as duplicated if the distances between x, y and z coordinates of two points is
  * less than an epsilon (defined by MeshDefinitions::_fMinPointDistanceD1, default value=1.0e-5f).
  * @see MeshFixDuplicatePoints
  * @see MeshEvalDegeneratedFacets
@@ -102,7 +102,7 @@ public:
    * Construction.
    */
   MeshEvalDuplicatePoints (const MeshKernel &rclM) : MeshEvaluation( rclM ) { }
-  /** 
+  /**
    * Destruction.
    */
   ~MeshEvalDuplicatePoints () { }
@@ -128,11 +128,11 @@ public:
    * Construction.
    */
   MeshFixDuplicatePoints (MeshKernel &rclM) : MeshValidation( rclM ) { }
-  /** 
+  /**
    * Destruction.
    */
   ~MeshFixDuplicatePoints () { }
-  /** 
+  /**
    * Merges duplicated points.
    */
   bool Fixup ();
@@ -150,7 +150,7 @@ public:
    * Construction.
    */
   MeshEvalNaNPoints (const MeshKernel &rclM) : MeshEvaluation( rclM ) { }
-  /** 
+  /**
    * Destruction.
    */
   ~MeshEvalNaNPoints () { }
@@ -176,11 +176,11 @@ public:
    * Construction.
    */
   MeshFixNaNPoints (MeshKernel &rclM) : MeshValidation( rclM ) { }
-  /** 
+  /**
    * Destruction.
    */
   ~MeshFixNaNPoints () { }
-  /** 
+  /**
    * Merges duplicated points.
    */
   bool Fixup ();
@@ -188,7 +188,7 @@ public:
 
 /**
  * The MeshEvalDuplicateFacets class searches for duplicated facets.
- * A facet is regarded as duplicated if all its point indices refer to the same location in the point array of the mesh kernel. 
+ * A facet is regarded as duplicated if all its point indices refer to the same location in the point array of the mesh kernel.
  * The actual geometric points are not taken into consideration.
  * @see MeshFixDuplicateFacets
  * @author Werner Mayer
@@ -200,11 +200,11 @@ public:
    * Construction.
    */
   MeshEvalDuplicateFacets (const MeshKernel &rclM) : MeshEvaluation( rclM ) { }
-  /** 
+  /**
    * Destruction.
    */
   ~MeshEvalDuplicateFacets () { }
-  /** 
+  /**
    * Searches for duplicated facets.
    */
   bool Evaluate ();
@@ -226,11 +226,11 @@ public:
    * Construction.
    */
   MeshFixDuplicateFacets (MeshKernel &rclM) : MeshValidation( rclM ) { }
-  /** 
+  /**
    * Destruction.
    */
   ~MeshFixDuplicateFacets () { }
-  /** 
+  /**
    * Removes duplicated facets.
    */
   bool Fixup ();
@@ -247,11 +247,11 @@ public:
    * Construction.
    */
   MeshEvalInternalFacets (const MeshKernel &rclM) : MeshEvaluation( rclM ) { }
-  /** 
+  /**
    * Destruction.
    */
   ~MeshEvalInternalFacets () { }
-  /** 
+  /**
    * Identify internal facets.
    */
   bool Evaluate ();
@@ -282,11 +282,11 @@ public:
    */
   MeshEvalDegeneratedFacets (const MeshKernel &rclM, float fEps)
       : MeshEvaluation(rclM), fEpsilon(fEps) {}
-  /** 
+  /**
    * Destruction.
    */
   ~MeshEvalDegeneratedFacets () { }
-  /** 
+  /**
    * Searches degenerated facets.
    */
   bool Evaluate ();
@@ -316,11 +316,11 @@ public:
    */
   MeshFixDegeneratedFacets (MeshKernel &rclM, float fEps)
       : MeshValidation(rclM), fEpsilon(fEps) { }
-  /** 
+  /**
    * Destruction.
    */
   ~MeshFixDegeneratedFacets () { }
-  /** 
+  /**
    * Removes degenerated facets.
    */
   bool Fixup ();
@@ -348,11 +348,11 @@ public:
    */
   MeshEvalDeformedFacets (const MeshKernel &rclM, float fMinAngle, float fMaxAngle)
       : MeshEvaluation(rclM), fMinAngle(fMinAngle), fMaxAngle(fMaxAngle) { }
-  /** 
+  /**
    * Destruction.
    */
   ~MeshEvalDeformedFacets () { }
-  /** 
+  /**
    * Searches deformed facets.
    */
   bool Evaluate ();
@@ -382,11 +382,11 @@ public:
   MeshFixDeformedFacets (MeshKernel &rclM, float fMinAngle, float fMaxAngle, float fSwapAngle, float fEps)
       : MeshValidation(rclM), fMinAngle(fMinAngle), fMaxAngle(fMaxAngle),
         fMaxSwapAngle(fSwapAngle), fEpsilon(fEps) { }
-  /** 
+  /**
    * Destruction.
    */
   ~MeshFixDeformedFacets () { }
-  /** 
+  /**
    * Removes deformed facets.
    */
   bool Fixup ();
@@ -523,11 +523,11 @@ public:
    * Construction.
    */
   MeshEvalRangeFacet (const MeshKernel &rclM) : MeshEvaluation( rclM ) { }
-  /** 
+  /**
    * Destruction.
    */
   ~MeshEvalRangeFacet () { }
-  /** 
+  /**
    * Searches for facets that has neighbour facet indices out of range.
    */
   bool Evaluate ();
@@ -537,7 +537,7 @@ public:
   std::vector<unsigned long> GetIndices() const;
 };
 
-/** 
+/**
  * The MeshFixRangeFacet class fixes facets with invalid neighbour indices.
  * @see MeshEvalRangeFacet
  * @author Werner Mayer
@@ -549,17 +549,17 @@ public:
    * Construction.
    */
   MeshFixRangeFacet (MeshKernel &rclM) : MeshValidation( rclM ) { }
-  /** 
+  /**
    * Destruction.
    */
   ~MeshFixRangeFacet () { }
-  /** 
+  /**
    * Fixes facets with neighbour indices out of range.
    */
   bool Fixup ();
 };
 
-/** 
+/**
  * The MeshEvalRangePoint class searches for facets that has point indices out of range.
  * @see MeshFixRangePoint
  * @author Werner Mayer
@@ -571,11 +571,11 @@ public:
    * Construction.
    */
   MeshEvalRangePoint (const MeshKernel &rclM) : MeshEvaluation( rclM ) { }
-  /** 
+  /**
    * Destruction.
    */
   ~MeshEvalRangePoint () { }
-  /** 
+  /**
    * Searches for facets that has point indices out of range.
    */
   bool Evaluate ();
@@ -597,7 +597,7 @@ public:
    * Construction.
    */
   MeshFixRangePoint (MeshKernel &rclM) : MeshValidation( rclM ) { }
-  /** 
+  /**
    * Destruction.
    */
   ~MeshFixRangePoint () { }
@@ -620,11 +620,11 @@ public:
    * Construction.
    */
   MeshEvalCorruptedFacets (const MeshKernel &rclM) : MeshEvaluation( rclM ) { }
-  /** 
+  /**
    * Destruction.
    */
   ~MeshEvalCorruptedFacets () { }
-  /** 
+  /**
    * Searches for corrupted facets.
    */
   bool Evaluate ();
@@ -647,11 +647,11 @@ public:
    * Construction.
    */
   MeshFixCorruptedFacets (MeshKernel &rclM) : MeshValidation( rclM ) { }
-  /** 
+  /**
    * Destruction.
    */
   ~MeshFixCorruptedFacets () { }
-  /** 
+  /**
    * Removes corrupted facets.
    */
   bool Fixup ();
@@ -659,4 +659,4 @@ public:
 
 } // namespace MeshCore
 
-#endif // MESH_DEGENERATION_H 
+#endif // MESH_DEGENERATION_H

--- a/src/Mod/Mesh/App/Core/TopoAlgorithm.h
+++ b/src/Mod/Mesh/App/Core/TopoAlgorithm.h
@@ -77,9 +77,9 @@ public:
                                  float fMaxAngle);
     /**
      * Swaps the common edge of two adjacent facets even if the operation might
-     * be illegal. To be sure that this operation is legal check either with
+     * be illegal. To be sure that this operation is legal, check either with
      * IsSwapEdgeLegal() or ShouldSwapEdge() before.
-     * An illegel swap edge operation can produce non-manifolds, degenrated
+     * An illegel swap edge operation can produce non-manifolds, degenerated
      * facets or it might create a fold on the surface, i.e. geometric overlaps
      * of several triangles. 
      */
@@ -200,7 +200,7 @@ public:
      */
     bool SnapVertex(unsigned long ulFacetPos, const Base::Vector3f& rP);
     /**
-     * Checks whether a swap edge operation is legel that is fulfilled if the
+     * Checks whether a swap edge operation is legal, that is fulfilled if the
      * two adjacent facets builds a convex polygon. If this operation is legal
      * true is returned, false is returned if this operation is illegal or if
      * \a ulFacetPos and \a ulNeighbour are not adjacent facets.

--- a/src/Mod/Mesh/App/MeshProperties.cpp
+++ b/src/Mod/Mesh/App/MeshProperties.cpp
@@ -146,7 +146,7 @@ void PropertyNormalList::Restore(Base::XMLReader &reader)
     std::string file (reader.getAttribute("file") );
 
     if (!file.empty()) {
-        // initate a file read
+        // initiate a file read
         reader.addFile(file.c_str(),this);
     }
 }
@@ -349,7 +349,7 @@ void PropertyCurvatureList::Restore(Base::XMLReader &reader)
     std::string file (reader.getAttribute("file") );
     
     if (!file.empty()) {
-        // initate a file read
+        // initiate a file read
         reader.addFile(file.c_str(),this);
     }
 }
@@ -606,7 +606,7 @@ void PropertyMeshKernel::Restore(Base::XMLReader &reader)
         hasSetValue();
     } 
     else {
-        // initate a file read
+        // initiate a file read
         reader.addFile(file.c_str(),this);
     }
 }

--- a/src/Mod/Mesh/Gui/DlgEvaluateMeshImp.cpp
+++ b/src/Mod/Mesh/Gui/DlgEvaluateMeshImp.cpp
@@ -1211,12 +1211,12 @@ void DlgEvaluateMeshImp::on_buttonBox_clicked(QAbstractButton* button)
         DlgEvaluateSettings dlg(this);
         dlg.setNonmanifoldPointsChecked(d->checkNonManfoldPoints);
         dlg.setFoldsChecked(d->enableFoldsCheck);
-        dlg.setDegenratedFacetsChecked(d->strictlyDegenerated);
+        dlg.setDegeneratedFacetsChecked(d->strictlyDegenerated);
         if (dlg.exec() == QDialog::Accepted) {
             d->checkNonManfoldPoints = dlg.isNonmanifoldPointsChecked();
             d->enableFoldsCheck = dlg.isFoldsChecked();
             d->showFoldsFunction(d->enableFoldsCheck);
-            d->strictlyDegenerated = dlg.isDegenratedFacetsChecked();
+            d->strictlyDegenerated = dlg.isDegeneratedFacetsChecked();
             if (d->strictlyDegenerated)
                 d->epsilonDegenerated = 0.0f;
             else

--- a/src/Mod/Mesh/Gui/DlgEvaluateSettings.cpp
+++ b/src/Mod/Mesh/Gui/DlgEvaluateSettings.cpp
@@ -63,14 +63,14 @@ bool DlgEvaluateSettings::isFoldsChecked() const
     return ui->checkFolds->isChecked();
 }
 
-void DlgEvaluateSettings::setDegenratedFacetsChecked(bool on)
+void DlgEvaluateSettings::setDegeneratedFacetsChecked(bool on)
 {
-    ui->checkDegenrated->setChecked(on);
+    ui->checkDegenerated->setChecked(on);
 }
 
-bool DlgEvaluateSettings::isDegenratedFacetsChecked() const
+bool DlgEvaluateSettings::isDegeneratedFacetsChecked() const
 {
-    return ui->checkDegenrated->isChecked();
+    return ui->checkDegenerated->isChecked();
 }
 
 #include "moc_DlgEvaluateSettings.cpp"

--- a/src/Mod/Mesh/Gui/DlgEvaluateSettings.h
+++ b/src/Mod/Mesh/Gui/DlgEvaluateSettings.h
@@ -47,8 +47,8 @@ public:
     void setFoldsChecked(bool);
     bool isFoldsChecked() const;
 
-    void setDegenratedFacetsChecked(bool);
-    bool isDegenratedFacetsChecked() const;
+    void setDegeneratedFacetsChecked(bool);
+    bool isDegeneratedFacetsChecked() const;
 
 private:
     Ui_DlgEvaluateSettings* ui;

--- a/src/Mod/Mesh/Gui/DlgEvaluateSettings.ui
+++ b/src/Mod/Mesh/Gui/DlgEvaluateSettings.ui
@@ -35,7 +35,7 @@
        </widget>
       </item>
       <item row="2" column="0">
-       <widget class="QCheckBox" name="checkDegenrated">
+       <widget class="QCheckBox" name="checkDegenerated">
         <property name="text">
          <string>Only consider zero area faces as degenerated</string>
         </property>

--- a/src/Mod/Part/App/PropertyTopoShape.cpp
+++ b/src/Mod/Part/App/PropertyTopoShape.cpp
@@ -263,7 +263,7 @@ void PropertyPartShape::Restore(Base::XMLReader &reader)
     std::string file (reader.getAttribute("file") );
 
     if (!file.empty()) {
-        // initate a file read
+        // initiate a file read
         reader.addFile(file.c_str(),this);
     }
 }
@@ -591,7 +591,7 @@ void PropertyFilletEdges::Restore(Base::XMLReader &reader)
     std::string file (reader.getAttribute("file") );
 
     if (!file.empty()) {
-        // initate a file read
+        // initiate a file read
         reader.addFile(file.c_str(),this);
     }
 }

--- a/src/Mod/Path/App/Area.cpp
+++ b/src/Mod/Path/App/Area.cpp
@@ -2415,8 +2415,8 @@ struct ShapeInfo{
         if(myWires.empty())
             foreachSubshape(myShape,GetWires(myWires,myRTree,myParams),TopAbs_WIRE);
 
-        // Now find the ture nearest point among the wires returned. Currently
-        // only closed wire has a ture nearest point, using OCC's
+        // Now find the true nearest point among the wires returned. Currently
+        // only closed wire has a true nearest point, using OCC's
         // BRepExtrema_DistShapeShape. We don't do this on open wires, because
         // we haven't implemented wire breaking on open wire yet, and I doubt
         // its usefulness.

--- a/src/Mod/Path/App/Path.cpp
+++ b/src/Mod/Path/App/Path.cpp
@@ -338,7 +338,7 @@ void Toolpath::Restore(XMLReader &reader)
     std::string file (reader.getAttribute("file") );
 
     if (!file.empty()) {
-        // initate a file read
+        // initiate a file read
         reader.addFile(file.c_str(),this);
     }
 }

--- a/src/Mod/Path/App/PropertyPath.cpp
+++ b/src/Mod/Path/App/PropertyPath.cpp
@@ -114,7 +114,7 @@ void PropertyPath::Restore(Base::XMLReader &reader)
 
     std::string file (reader.getAttribute("file") );
     if (!file.empty()) {
-        // initate a file read
+        // initiate a file read
         reader.addFile(file.c_str(),this);
     }
 

--- a/src/Mod/Points/App/Points.cpp
+++ b/src/Mod/Points/App/Points.cpp
@@ -176,7 +176,7 @@ void PointKernel::Restore(Base::XMLReader &reader)
     std::string file (reader.getAttribute("file") );
 
     if (!file.empty()) {
-        // initate a file read
+        // initiate a file read
         reader.addFile(file.c_str(),this);
     }
     if (reader.DocumentSchema > 3) {

--- a/src/Mod/Points/App/Properties.cpp
+++ b/src/Mod/Points/App/Properties.cpp
@@ -144,7 +144,7 @@ void PropertyGreyValueList::Restore(Base::XMLReader &reader)
     string file (reader.getAttribute("file") );
 
     if (!file.empty()) {
-        // initate a file read
+        // initiate a file read
         reader.addFile(file.c_str(),this);
     }
 }
@@ -318,7 +318,7 @@ void PropertyNormalList::Restore(Base::XMLReader &reader)
     std::string file (reader.getAttribute("file") );
 
     if (!file.empty()) {
-        // initate a file read
+        // initiate a file read
         reader.addFile(file.c_str(),this);
     }
 }
@@ -578,7 +578,7 @@ void PropertyCurvatureList::Restore(Base::XMLReader &reader)
     std::string file (reader.getAttribute("file") );
 
     if (!file.empty()) {
-        // initate a file read
+        // initiate a file read
         reader.addFile(file.c_str(),this);
     }
 }

--- a/src/Mod/Points/App/PropertyPointKernel.cpp
+++ b/src/Mod/Points/App/PropertyPointKernel.cpp
@@ -104,7 +104,7 @@ void PropertyPointKernel::Restore(Base::XMLReader &reader)
     std::string file (reader.getAttribute("file") );
 
     if (!file.empty()) {
-        // initate a file read
+        // initiate a file read
         reader.addFile(file.c_str(),this);
     }
     if(reader.DocumentSchema > 3)

--- a/src/Mod/Robot/App/kdl_cp/path_line.hpp
+++ b/src/Mod/Robot/App/kdl_cp/path_line.hpp
@@ -98,7 +98,7 @@ class Path_Line : public Path
          * of the frame in which you express your path.
          * Other implementations for RotationalInterpolations COULD be
          *    (not implemented) (yet) :
-         *    1) quaternion interpolation : but this is more difficult for the human to interprete
+         *    1) quaternion interpolation : but this is more difficult for the human to interpret
          *    2) 3-axis interpolation : express the orientation of the frame in e.g.
          *       euler zyx angles alfa,beta, gamma  and interpolate these parameters.
          *       But this is dependent of the frame you choose as a reference and

--- a/src/Mod/Robot/App/kdl_cp/utilities/error_stack.cxx
+++ b/src/Mod/Robot/App/kdl_cp/utilities/error_stack.cxx
@@ -23,7 +23,7 @@
 namespace KDL {
 
 // Trace of the call stack of the I/O routines to help user
-// interprete error messages from I/O
+// interpret error messages from I/O
 typedef std::stack<std::string>  ErrorStack;
 
 // should be in Thread Local Storage if this gets multithreaded one day...

--- a/src/Mod/Show/TempoVis.py
+++ b/src/Mod/Show/TempoVis.py
@@ -319,7 +319,7 @@ class TempoVis(FrozenClass):
     def _enableClipPlane(self, obj, enable, placement = None, offset = 0.0):
         """Enables or disables clipping for an object. Placement specifies the plane (plane 
         is placement's XY plane), and should be in global CS. 
-        Offest shifts the plane; positive offset reveals more material, negative offset 
+        Offset shifts the plane; positive offset reveals more material, negative offset 
         hides more material."""
         if not hasattr(obj, 'getGlobalPlacement'):
             print("    {obj} has no attribute 'getGlobalPlacement'".format(obj= obj.Name))

--- a/src/Tools/fcbt/DistBin.py
+++ b/src/Tools/fcbt/DistBin.py
@@ -41,7 +41,7 @@ FileTools.cpallWithFilter('../../lib',DistDir+DistBin+'/lib',FileTools.SetUpFilt
 
 #====================================================================
 # copy Modules
-sys.stdout.write( 'Copy modul Tree ...\n')
+sys.stdout.write( 'Copy module Tree ...\n')
 DistTools.EnsureDir(DistDir+DistBin+'/Mod')
 FileTools.cpallWithFilter('../../src/Mod',DistDir+DistBin+'/Mod',FileTools.SetUpFilter(DistTools.ModFilter))
 


### PR DESCRIPTION
Found via `codespell -i 3 -w -I ../fc-word-whitelist.txt --skip="*.ts,*.po,./src/3rdParty,./src/Mod/Assembly/App/opendcm,./.git,./src/zipios++"`

Please review fa705d3 carefully. 