### PR TITLE
ViewProviderDocumentObject: forbid recursive call of updateView()

### DIFF
--- a/src/Gui/ViewProvider.h
+++ b/src/Gui/ViewProvider.h
@@ -72,7 +72,8 @@ class ObjectItem;
 enum ViewStatus {
     UpdateData = 0,
     Detach = 1,
-    isRestoring = 2
+    isRestoring = 2,
+    UpdatingView = 3,
 };
 
 

--- a/src/Gui/ViewProviderDocumentObject.cpp
+++ b/src/Gui/ViewProviderDocumentObject.cpp
@@ -33,6 +33,7 @@
 #endif
 
 /// Here the FreeCAD includes sorted by Base,App,Gui......
+#include <Base/Tools.h>
 #include <Base/Console.h>
 #include <App/Material.h>
 #include <App/DocumentObjectGroup.h>
@@ -156,6 +157,11 @@ void ViewProviderDocumentObject::show(void)
 
 void ViewProviderDocumentObject::updateView()
 {
+    if(testStatus(ViewStatus::UpdatingView))
+        return;
+
+    Base::ObjectStatusLocker<ViewStatus,ViewProviderDocumentObject> lock(ViewStatus::UpdatingView,this);
+
     std::map<std::string, App::Property*> Map;
     pcObject->getPropertyMap(Map);
 


### PR DESCRIPTION
Because of the way ViewProviderDocumentObject::updateView() is implemented (i.e. call updateData() on every property of the attaching object), it is very easy to be called recursively, especially in Python. This patch prevent that from happening.

https://forum.freecadweb.org/viewtopic.php?f=23&t=30122&e=1&view=unread#unread
