### PR TITLE
PATH: fix for issue 3548

### DIFF
--- a/src/Mod/Path/PathScripts/PathPocketShape.py
+++ b/src/Mod/Path/PathScripts/PathPocketShape.py
@@ -110,13 +110,10 @@ class ObjectPocket(PathPocketBase.ObjectPocket):
                 f.translate(FreeCAD.Vector(0, 0, obj.FinalDepth.Value - f.BoundBox.ZMin))
 
             # check all faces and see if they are touching/overlapping and combine those into a compound
-            self.horizontal = []
-            for shape in PathGeom.combineConnectedShapes(self.horiz):
+            self.horizontal = PathGeom.combineConnectedShapes(self.horiz)
+            for shape in self.horizontal:
                 shape.sewShape()
                 shape.tessellate(0.1)
-                wire = TechDraw.findShapeOutline(shape, 1, FreeCAD.Vector(0, 0, 1))
-                wire.translate(FreeCAD.Vector(0, 0, obj.FinalDepth.Value - wire.BoundBox.ZMin))
-                self.horizontal.append(Part.Face(wire))
 
             # extrude all faces up to StartDepth and those are the removal shapes
             extent = FreeCAD.Vector(0, 0, obj.StartDepth.Value - obj.FinalDepth.Value)


### PR DESCRIPTION
Revert "Get the outline of the syntesized shape for PocketShape before extruding."

This reverts commit 135ede46fe266b3231a504119b01232ef8c323a3.

https://www.freecadweb.org/tracker/view.php?id=3548