### PR TITLE
🚑🐛 Don't install doc/freecad.qch with no GUI

### DIFF
--- a/src/Doc/CMakeLists.txt
+++ b/src/Doc/CMakeLists.txt
@@ -19,11 +19,14 @@ if(BUILD_GUI)
     endforeach()
 
     configure_file(freecad.qhc ${CMAKE_BINARY_DIR}/doc/freecad.qhc COPYONLY)
+    INSTALL(FILES
+        ${CMAKE_BINARY_DIR}/doc/freecad.qch
+        DESTINATION ${CMAKE_INSTALL_DOCDIR}
+    )
 endif(BUILD_GUI)
 
 INSTALL(FILES
     freecad.qhc
-    ${CMAKE_BINARY_DIR}/doc/freecad.qch
     ThirdPartyLibraries.html
     DESTINATION ${CMAKE_INSTALL_DOCDIR}
 )


### PR DESCRIPTION
TL;DR This fixes `make install` crash with `BUILD_GUI=off`. Long story short the script generates `freecad.qch` only `if(BUILD_GUI)`, but tries to install it unconditionally and fails with file not found.

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists