### PR TITLE
Path: Feature/auto job selection

### DIFF
--- a/src/Mod/Path/PathScripts/PathGeom.py
+++ b/src/Mod/Path/PathScripts/PathGeom.py
@@ -135,6 +135,7 @@ def isVertical(obj):
     '''isVertical(obj) ... answer True if obj points into Z'''
     if type(obj) == FreeCAD.Vector:
         return isRoughly(obj.x, 0) and isRoughly(obj.y, 0)
+
     if obj.ShapeType == 'Face':
         if type(obj.Surface) == Part.Plane:
             return isHorizontal(obj.Surface.Axis)
@@ -144,9 +145,12 @@ def isVertical(obj):
             return True
         if type(obj.Surface) == Part.SurfaceOfExtrusion:
             return isVertical(obj.Surface.Direction)
+        if type(obj.Surface) == Part.SurfaceOfRevolution:
+            return isHorizontal(obj.Surface.Direction)
         if type(obj.Surface) != Part.BSplineSurface:
             PathLog.info(translate('PathGeom', "face %s not handled, assuming not vertical") % type(obj.Surface))
         return None
+
     if obj.ShapeType == 'Edge':
         if type(obj.Curve) == Part.Line or type(obj.Curve) == Part.LineSegment:
             return isVertical(obj.Vertexes[1].Point - obj.Vertexes[0].Point)
@@ -158,6 +162,7 @@ def isVertical(obj):
         if type(obj.Curve) != Part.BSplineCurve:
             PathLog.info(translate('PathGeom', "edge %s not handled, assuming not vertical") % type(obj.Curve))
         return None
+
     PathLog.error(translate('PathGeom', "isVertical(%s) not supported") % obj)
     return None
 
@@ -165,6 +170,7 @@ def isHorizontal(obj):
     '''isHorizontal(obj) ... answer True if obj points into X or Y'''
     if type(obj) == FreeCAD.Vector:
         return isRoughly(obj.z, 0)
+
     if obj.ShapeType == 'Face':
         if type(obj.Surface) == Part.Plane:
             return isVertical(obj.Surface.Axis)
@@ -174,13 +180,17 @@ def isHorizontal(obj):
             return True
         if type(obj.Surface) == Part.SurfaceOfExtrusion:
             return isHorizontal(obj.Surface.Direction)
+        if type(obj.Surface) == Part.SurfaceOfRevolution:
+            return isVertical(obj.Surface.Direction)
         return isRoughly(obj.BoundBox.ZLength, 0.0)
+
     if obj.ShapeType == 'Edge':
         if type(obj.Curve) == Part.Line or type(obj.Curve) == Part.LineSegment:
             return isHorizontal(obj.Vertexes[1].Point - obj.Vertexes[0].Point)
         if type(obj.Curve) == Part.Circle or type(obj.Curve) == Part.Ellipse: # or type(obj.Curve) == Part.BSplineCurve:
             return isVertical(obj.Curve.Axis)
         return isRoughly(obj.BoundBox.ZLength, 0.0)
+
     PathLog.error(translate('PathGeom', "isHorizontal(%s) not supported") % obj)
     return None
 

--- a/src/Mod/Path/PathScripts/PathUtils.py
+++ b/src/Mod/Path/PathScripts/PathUtils.py
@@ -510,10 +510,9 @@ def addToJob(obj, jobname=None):
                         mylist = [j.Label for j in jobs]
                     form.cboProject.addItems(mylist)
                     r = form.exec_()
-                    if r is False:
+                    if r is False or r == 0:
                         return None
                     else:
-                        print(form.cboProject.currentText())
                         job = [j for j in jobs if j.Label == form.cboProject.currentText()][0]
 
     if obj and job:

--- a/src/Mod/Path/PathScripts/PathUtils.py
+++ b/src/Mod/Path/PathScripts/PathUtils.py
@@ -493,16 +493,28 @@ def addToJob(obj, jobname=None):
         elif len(jobs) == 1:
             job = jobs[0]
         else:
-            # form = FreeCADGui.PySideUic.loadUi(FreeCAD.getHomePath() + "Mod/Path/DlgJobChooser.ui")
-            form = FreeCADGui.PySideUic.loadUi(":/panels/DlgJobChooser.ui")
-            mylist = [i.Label for i in jobs]
-            form.cboProject.addItems(mylist)
-            r = form.exec_()
-            if r is False:
-                return None
+            selected = FreeCADGui.Selection.getSelection()
+            baseSelected = [job for job in jobs if any([job.Base == o for o in selected])]
+            if 1 == len(baseSelected):
+                job = baseSelected[0]
             else:
-                print(form.cboProject.currentText())
-                job = [i for i in jobs if i.Label == form.cboProject.currentText()][0]
+                baseObjectSelected = [job for job in jobs if any([job.Proxy.baseObject(job) == o for o in selected])]
+                if 1 == len(baseObjectSelected):
+                    job = baseObjectSelected[0]
+                else:
+                    # form = FreeCADGui.PySideUic.loadUi(FreeCAD.getHomePath() + "Mod/Path/DlgJobChooser.ui")
+                    form = FreeCADGui.PySideUic.loadUi(":/panels/DlgJobChooser.ui")
+                    if baseObjectSelected:
+                        mylist = [j.Label for j in baseObjectSelected]
+                    else:
+                        mylist = [j.Label for j in jobs]
+                    form.cboProject.addItems(mylist)
+                    r = form.exec_()
+                    if r is False:
+                        return None
+                    else:
+                        print(form.cboProject.currentText())
+                        job = [j for j in jobs if j.Label == form.cboProject.currentText()][0]
 
     if obj and job:
         job.Proxy.addOperation(obj)


### PR DESCRIPTION
This change adds some convenience default selections if there are multiple Job objects in a single document. If the user has a feature selected the algorithm now checks if the selection uniquely identifies a base model object of an existing job - if so it will use that job automatically. If there is any ambiguity it will bring up the job selection dialog as it did so far.