### PR TITLE
Add library foc concurremcy in >= VS2015

### DIFF
--- a/src/Base/CMakeLists.txt
+++ b/src/Base/CMakeLists.txt
@@ -37,8 +37,11 @@ if(MSVC)
         list(APPEND FreeCADBase_LIBS
             debug vcruntimed.lib
             debug ucrtd.lib
+			debug concrtd.lib
             optimized vcruntime.lib
             optimized ucrt.lib
+			optimized concrt.lib
+			
         )
     endif()
 elseif(MINGW)

--- a/src/Mod/Points/App/Points.cpp
+++ b/src/Mod/Points/App/Points.cpp
@@ -88,7 +88,7 @@ Base::BoundBox3d PointKernel::getBoundBox(void)const
     Base::BoundBox3d bnd;
 
     //FIXME: VS 2015 or later causes a linker error
-#if defined (_MSC_VER) && (_MSC_VER <= 1800)
+#if defined _WIN32 
     // Thread-local bounding boxes
     Concurrency::combinable<Base::BoundBox3d> bbs;
     // Cannot use a const_point_iterator here as it is *not* a proper iterator (fails the for_each template)


### PR DESCRIPTION
add concurrency library for VS >=2015
revert conditional in Points.cpp (i.e. reactivate parallel handling)

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
