### PR TITLE
Path: feature - by default use same tool as the previous op of a job

### DIFF
--- a/src/Mod/Path/PathScripts/PathOp.py
+++ b/src/Mod/Path/PathScripts/PathOp.py
@@ -255,7 +255,10 @@ class ObjectOp(object):
         features = self.opFeatures(obj)
 
         if FeatureTool & features:
-            obj.ToolController = PathUtils.findToolController(obj)
+            if 1 < len(job.Operations.Group):
+                obj.ToolController = PathUtil.toolControllerForOp(job.Operations.Group[-2])
+            else:
+                obj.ToolController = PathUtils.findToolController(obj)
             if not obj.ToolController:
                 return False
             obj.OpToolDiameter = obj.ToolController.Tool.Diameter


### PR DESCRIPTION
Instead of bringing up the TC selection dialog every time a new op will use the same TC as the previous op of the same job. If the new op is the very first op of the job the behaviour is identical to the existing behaviour - unless the job only has a single TC a dialog is brought up for selection.