### PR TITLE
Change reference to PyQt5 to PySide2

### DIFF
--- a/src/Gui/WidgetFactory.cpp
+++ b/src/Gui/WidgetFactory.cpp
@@ -339,9 +339,9 @@ Py::Object PythonWrapper::fromQWidget(QWidget* widget, const char* className)
     arguments[0] = Py::asObject(PyLong_FromVoidPtr(widget));
 
 #if QT_VERSION >= 0x050000
-    module = PyImport_ImportModule((char*)"PyQt5.QtWidgets");
+    module = PyImport_ImportModule((char*)"PySide2.QtWidgets");
     if (!module)
-        throw Py::Exception(PyExc_ImportError, "Cannot load PyQt5.QtWidgets module");
+        throw Py::Exception(PyExc_ImportError, "Cannot load PySide2.QtWidgets module");
 #else
     module = PyImport_ImportModule((char*)"PyQt4.Qt");
     if (!module)


### PR DESCRIPTION
Per forum thread: https://forum.freecadweb.org/viewtopic.php?f=4&t=30218 - There's a reference to PyQt5, which should probably be to PySide2.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [n/a] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [n/a] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
