### PR TITLE
Path: Add UseOutline property to PocketShape in order to mill full pockets …

### DIFF
--- a/src/Mod/Path/Gui/Resources/panels/PageOpPocketFullEdit.ui
+++ b/src/Mod/Path/Gui/Resources/panels/PageOpPocketFullEdit.ui
@@ -214,6 +214,23 @@
    <item>
     <widget class="QWidget" name="pocketWidget" native="true">
      <layout class="QGridLayout" name="gridLayout">
+      <item row="2" column="1">
+       <widget class="QCheckBox" name="minTravel">
+        <property name="text">
+         <string>Min Travel</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QCheckBox" name="useOutline">
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If selected the operation uses the outline of the selected base geometry and ignores all holes and islands.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="text">
+         <string>Use Outline</string>
+        </property>
+       </widget>
+      </item>
       <item row="1" column="0">
        <widget class="QCheckBox" name="useStartPoint">
         <property name="toolTip">
@@ -221,20 +238,6 @@
         </property>
         <property name="text">
          <string>Use Start Point</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="1">
-       <widget class="QCheckBox" name="keepToolDown">
-        <property name="text">
-         <string>Keep tool down</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QCheckBox" name="minTravel">
-        <property name="text">
-         <string>Min Travel</string>
         </property>
        </widget>
       </item>

--- a/src/Mod/Path/PathScripts/PathJob.py
+++ b/src/Mod/Path/PathScripts/PathJob.py
@@ -119,6 +119,7 @@ class ObjectJob:
         ops = FreeCAD.ActiveDocument.addObject("Path::FeatureCompoundPython", "Operations")
         if ops.ViewObject:
             ops.ViewObject.Proxy = 0
+            ops.ViewObject.Visibility = False
         obj.Operations = ops
         obj.setEditorMode('Operations', 2) # hide
         obj.setEditorMode('Placement', 2)

--- a/src/Mod/Path/PathScripts/PathOp.py
+++ b/src/Mod/Path/PathScripts/PathOp.py
@@ -177,6 +177,8 @@ class ObjectOp(object):
             if FeatureNoFinalDepth & features:
                 obj.setEditorMode('OpFinalDepth', 2)
 
+        self.opOnDocumentRestored(obj)
+
     def __getstate__(self):
         '''__getstat__(self) ... called when receiver is saved.
         Can safely be overwritten by subclasses.'''
@@ -195,6 +197,11 @@ class ObjectOp(object):
 
     def initOperation(self, obj):
         '''initOperation(obj) ... implement to create additional properties.
+        Should be overwritten by subclasses.'''
+        pass
+
+    def opOnDocumentRestored(self, obj):
+        '''opOnDocumentRestored(obj) ... implement if an op needs special handling like migrating the data model.
         Should be overwritten by subclasses.'''
         pass
 

--- a/src/Mod/Path/PathScripts/PathPocketBase.py
+++ b/src/Mod/Path/PathScripts/PathPocketBase.py
@@ -79,7 +79,7 @@ class ObjectPocket(PathAreaOp.ObjectOp):
         obj.addProperty("App::PropertyEnumeration", "OffsetPattern", "Face", QtCore.QT_TRANSLATE_NOOP("App::Property", "Clearing pattern to use"))
         obj.OffsetPattern = ['ZigZag', 'Offset', 'Spiral', 'ZigZagOffset', 'Line', 'Grid', 'Triangle']
         obj.addProperty("App::PropertyBool", "MinTravel", "Pocket", QtCore.QT_TRANSLATE_NOOP("App::Property", "Use 3D Sorting of Path"))
-        obj.addProperty("App::PropertyBool", "KeepToolDown", "Face", QtCore.QT_TRANSLATE_NOOP("App::Property", "Attempts to avoid unnecessary retractions."))
+        obj.addProperty("App::PropertyBool", "KeepToolDown", "Pocket", QtCore.QT_TRANSLATE_NOOP("App::Property", "Attempts to avoid unnecessary retractions."))
 
         self.initPocketOp(obj)
 

--- a/src/Mod/Path/PathScripts/PathPocketBaseGui.py
+++ b/src/Mod/Path/PathScripts/PathPocketBaseGui.py
@@ -40,20 +40,22 @@ __doc__ = "Base page controller and command implementation for path pocket opera
 def translate(context, text, disambig=None):
     return QtCore.QCoreApplication.translate(context, text, disambig)
 
-FeaturePocket = 0x01
-FeatureFacing = 0x02
+FeaturePocket   = 0x01
+FeatureFacing   = 0x02
+FeatureOutline  = 0x04
 
 class TaskPanelOpPage(PathOpGui.TaskPanelPage):
-    '''Page controller class for pocket operations, supports two different features:
+    '''Page controller class for pocket operations, supports:
           FeaturePocket  ... used for pocketing operation
           FeatureFacing  ... used for face milling operation
+          FeatureOutline ... used for pocket-shape operation
     '''
 
     def pocketFeatures(self):
         '''pocketFeatures() ... return which features of the UI are supported by the operation.
-        Typically one of the following is enabled:
           FeaturePocket  ... used for pocketing operation
           FeatureFacing  ... used for face milling operation
+          FeatureOutline ... used for pocket-shape operation
         Must be overwritten by subclasses'''
         pass
 
@@ -68,9 +70,11 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
             form.extraOffsetLabel.setText(translate("PathPocket", "Pass Extension"))
             form.extraOffset.setToolTip(translate("PathPocket", "The distance the facing operation will extend beyond the boundary shape."))
 
+        if not (FeatureOutline & self.pocketFeatures()):
+            form.useOutline.hide()
+
         if True:
             # currently doesn't have an effect or is experimental
-            form.keepToolDown.hide()
             form.minTravel.hide()
 
         return form
@@ -109,8 +113,10 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
 
         if obj.UseStartPoint != self.form.useStartPoint.isChecked():
             obj.UseStartPoint = self.form.useStartPoint.isChecked()
-        if obj.KeepToolDown != self.form.keepToolDown.isChecked():
-            obj.KeepToolDown = self.form.keepToolDown.isChecked()
+
+        if FeatureOutline & self.pocketFeatures():
+            if obj.UseOutline != self.form.useOutline.isChecked():
+                obj.UseOutline = self.form.useOutline.isChecked()
 
         self.updateMinTravel(obj)
 
@@ -123,7 +129,8 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
         self.form.stepOverPercent.setValue(obj.StepOver)
         self.form.extraOffset.setText(FreeCAD.Units.Quantity(obj.ExtraOffset.Value, FreeCAD.Units.Length).UserString)
         self.form.useStartPoint.setChecked(obj.UseStartPoint)
-        self.form.keepToolDown.setChecked(obj.KeepToolDown)
+        if FeatureOutline & self.pocketFeatures():
+            self.form.useOutline.setChecked(obj.UseOutline)
 
         self.form.zigZagAngle.setText(FreeCAD.Units.Quantity(obj.ZigZagAngle, FreeCAD.Units.Angle).UserString)
         self.updateZigZagAngle(obj, False)
@@ -149,7 +156,7 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
         signals.append(self.form.toolController.currentIndexChanged)
         signals.append(self.form.extraOffset.editingFinished)
         signals.append(self.form.useStartPoint.clicked)
-        signals.append(self.form.keepToolDown.clicked)
+        signals.append(self.form.useOutline.clicked)
         signals.append(self.form.minTravel.clicked)
 
         if FeatureFacing & self.pocketFeatures():

--- a/src/Mod/Path/PathScripts/PathPocketShapeGui.py
+++ b/src/Mod/Path/PathScripts/PathPocketShapeGui.py
@@ -39,7 +39,7 @@ class TaskPanelOpPage(PathPocketBaseGui.TaskPanelOpPage):
 
     def pocketFeatures(self):
         '''pocketFeatures() ... return FeaturePocket (see PathPocketBaseGui)'''
-        return PathPocketBaseGui.FeaturePocket
+        return PathPocketBaseGui.FeaturePocket | PathPocketBaseGui.FeatureOutline
 
 Command = PathOpGui.SetupOperation('Pocket Shape',
         PathPocketShape.Create,


### PR DESCRIPTION
…and not have to add all sub-shapes.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
