### PR TITLE
Dxf Version Override and Coverity fixes

### DIFF
--- a/src/Mod/Import/App/AppImportPy.cpp
+++ b/src/Mod/Import/App/AppImportPy.cpp
@@ -409,7 +409,7 @@ private:
             if (usePolyline == Py_True) {
                polyOverride = true; 
             }
-            if (optionSource) {
+            if (optionSource != nullptr) {
                 strcpy(useOptionSource,optionSource);
             } else {
                 useOptionSource = defaultOptions;
@@ -422,7 +422,7 @@ private:
                 if (versionOverride) {
                     writer.setVersion(versionParm);
                 }
-                writer.setPolyOverride(true);
+                writer.setPolyOverride(polyOverride);
                 writer.setLayerName(layerName);
                 writer.init();
                 Py::Sequence list(shapeObj);
@@ -458,7 +458,7 @@ private:
             if (usePolyline == Py_True) {
                polyOverride = true; 
             }
-            if (optionSource) {
+            if (optionSource != nullptr) {
                 strcpy(useOptionSource,optionSource);
             } else {
                 useOptionSource = defaultOptions;
@@ -521,7 +521,7 @@ private:
                polyOverride = true; 
             }
 
-            if (optionSource) {
+            if (optionSource != nullptr) {
                 strcpy(useOptionSource,optionSource);
             } else {
                 useOptionSource = defaultOptions;
@@ -555,7 +555,7 @@ private:
                 throw Py::RuntimeError(e.what());
             }
         } else if (PyArg_ParseTuple(args.ptr(), "O!et|iOs",
-                                                &(Part::PartFeaturePy::Type) ,
+                                                &(App::DocumentObjectPy::Type) ,
                                                 &docObj, 
                                                 "utf-8",
                                                 &fname, 
@@ -574,7 +574,7 @@ private:
                polyOverride = true; 
             }
 
-            if (optionSource) {
+            if (optionSource != nullptr) {
                 strcpy(useOptionSource,optionSource);
             } else {
                 useOptionSource = defaultOptions;
@@ -587,7 +587,7 @@ private:
                 if (versionOverride) {
                     writer.setVersion(versionParm);
                 }
-                writer.setPolyOverride(true);
+                writer.setPolyOverride(polyOverride);
                 writer.setLayerName(layerName);
                 writer.init();
                 App::DocumentObject* obj = static_cast<App::DocumentObjectPy*>(docObj)->getDocumentObjectPtr();

--- a/src/Mod/Import/App/AppImportPy.cpp
+++ b/src/Mod/Import/App/AppImportPy.cpp
@@ -95,10 +95,10 @@ public:
             "readDXF(filename,[document,ignore_errors]): Imports a DXF file into the given document. ignore_errors is True by default."
         );
         add_varargs_method("writeDXFShape",&Module::writeDXFShape,
-            "writeDXFShape([shape],filename): Exports Shape(s) to a DXF file."
+            "writeDXFShape([shape],filename [version,usePolyline,optionSource]): Exports Shape(s) to a DXF file."
         );
         add_varargs_method("writeDXFObject",&Module::writeDXFObject,
-            "writeDXFObject([objects],filename): Exports DocumentObject(s) to a DXF file."
+            "writeDXFObject([objects],filename [,version,usePolyline,optionSource]): Exports DocumentObject(s) to a DXF file."
         );
        initialize("This module is the Import module."); // register with Python       
     }
@@ -385,21 +385,44 @@ private:
         const char* optionSource = nullptr;
         char* defaultOptions = "User parameter:BaseApp/Preferences/Mod/Import";
         char* useOptionSource = nullptr;
+        int   versionParm = -1;
+        bool  versionOverride = false;
+        bool  polyOverride = false;
+        PyObject *usePolyline = Py_False;
 
-        if (PyArg_ParseTuple(args.ptr(), "O!et|s",  &(PyList_Type) ,&shapeObj, "utf-8",&fname, &optionSource)) {
+        //handle list of shapes
+        if (PyArg_ParseTuple(args.ptr(), "O!et|iOs",  &(PyList_Type) ,
+                                                      &shapeObj, 
+                                                      "utf-8",
+                                                      &fname, 
+                                                      &versionParm,
+                                                      &usePolyline,
+                                                      &optionSource)) {
             filePath = std::string(fname);
             layerName = "none";
             PyMem_Free(fname);
 
+            if ((versionParm == 12) or 
+               (versionParm == 14)) {
+               versionOverride = true;
+            }
+            if (usePolyline == Py_True) {
+               polyOverride = true; 
+            }
             if (optionSource) {
                 strcpy(useOptionSource,optionSource);
             } else {
                 useOptionSource = defaultOptions;
             }
+
             try {
                 ImpExpDxfWrite writer(filePath);
                 writer.setOptionSource(useOptionSource);
                 writer.setOptions();
+                if (versionOverride) {
+                    writer.setVersion(versionParm);
+                }
+                writer.setPolyOverride(true);
                 writer.setLayerName(layerName);
                 writer.init();
                 Py::Sequence list(shapeObj);
@@ -415,25 +438,40 @@ private:
             catch (const Base::Exception& e) {
                 throw Py::RuntimeError(e.what());
             }
-        } else if (PyArg_ParseTuple(args.ptr(), "O!et|s",
+
+        } else if (PyArg_ParseTuple(args.ptr(), "O!et|iOs",
                                                 &(Part::TopoShapePy::Type) ,
                                                 &shapeObj, 
                                                 "utf-8",
                                                 &fname, 
+                                                &versionParm,
+                                                &usePolyline,
                                                 &optionSource)) {
             filePath = std::string(fname);
             layerName = "none";
             PyMem_Free(fname);
 
+            if ((versionParm == 12) or 
+               (versionParm == 14)) {
+               versionOverride = true;
+            }
+            if (usePolyline == Py_True) {
+               polyOverride = true; 
+            }
             if (optionSource) {
                 strcpy(useOptionSource,optionSource);
             } else {
                 useOptionSource = defaultOptions;
             }
+
             try {
                 ImpExpDxfWrite writer(filePath);
                 writer.setOptionSource(useOptionSource);
                 writer.setOptions();
+                if (versionOverride) {
+                    writer.setVersion(versionParm);
+                }
+                writer.setPolyOverride(polyOverride);
                 writer.setLayerName(layerName);
                 writer.init();
                 Part::TopoShape* obj = static_cast<Part::TopoShapePy*>(shapeObj)->getTopoShapePtr();
@@ -459,22 +497,44 @@ private:
         const char* optionSource = nullptr;
         char* defaultOptions = "User parameter:BaseApp/Preferences/Mod/Import";
         char* useOptionSource = nullptr;
+        int   versionParm = -1;
+        bool  versionOverride = false;
+        bool  polyOverride = false;
+        PyObject *usePolyline = Py_False;
 
-
-        if (PyArg_ParseTuple(args.ptr(), "O!et|s",  &(PyList_Type) ,&docObj, "utf-8",&fname, &optionSource)) {
-            filePath = std::string(fname);
+        if (PyArg_ParseTuple(args.ptr(), "O!et|iOs",  &(PyList_Type) ,
+                                                      &docObj, 
+                                                      "utf-8",
+                                                      &fname, 
+                                                      &versionParm,
+                                                      &usePolyline,
+                                                      &optionSource)) {
+           filePath = std::string(fname);
             layerName = "none";
             PyMem_Free(fname);
+
+            if ((versionParm == 12) or 
+               (versionParm == 14)) {
+               versionOverride = true;
+            }
+            if (usePolyline == Py_True) {
+               polyOverride = true; 
+            }
 
             if (optionSource) {
                 strcpy(useOptionSource,optionSource);
             } else {
                 useOptionSource = defaultOptions;
             }
+
             try {
                 ImpExpDxfWrite writer(filePath);
                 writer.setOptionSource(useOptionSource);
                 writer.setOptions();
+                if (versionOverride) {
+                    writer.setVersion(versionParm);
+                }
+                writer.setPolyOverride(polyOverride);
                 writer.setLayerName(layerName);
                 writer.init();
                 Py::Sequence list(docObj);
@@ -494,25 +554,40 @@ private:
             catch (const Base::Exception& e) {
                 throw Py::RuntimeError(e.what());
             }
-        } else if (PyArg_ParseTuple(args.ptr(), "O!et|s",
+        } else if (PyArg_ParseTuple(args.ptr(), "O!et|iOs",
                                                 &(Part::PartFeaturePy::Type) ,
                                                 &docObj, 
                                                 "utf-8",
                                                 &fname, 
+                                                &versionParm,
+                                                &usePolyline,
                                                 &optionSource)) {
             filePath = std::string(fname);
             layerName = "none";
             PyMem_Free(fname);
+
+            if ((versionParm == 12) or 
+               (versionParm == 14)) {
+               versionOverride = true;
+            }
+            if (usePolyline == Py_True) {
+               polyOverride = true; 
+            }
 
             if (optionSource) {
                 strcpy(useOptionSource,optionSource);
             } else {
                 useOptionSource = defaultOptions;
             }
+            
             try {
                 ImpExpDxfWrite writer(filePath);
                 writer.setOptionSource(useOptionSource);
                 writer.setOptions();
+                if (versionOverride) {
+                    writer.setVersion(versionParm);
+                }
+                writer.setPolyOverride(true);
                 writer.setLayerName(layerName);
                 writer.init();
                 App::DocumentObject* obj = static_cast<App::DocumentObjectPy*>(docObj)->getDocumentObjectPtr();

--- a/src/Mod/Import/App/ImpExpDxf.cpp
+++ b/src/Mod/Import/App/ImpExpDxf.cpp
@@ -486,7 +486,7 @@ bool ImpExpDxfWrite::gp_PntCompare(gp_Pnt p1, gp_Pnt p2)
 }
 
 
-void ImpExpDxfWrite::exportCircle(const BRepAdaptor_Curve& c)
+void ImpExpDxfWrite::exportCircle(BRepAdaptor_Curve& c)
 {
     gp_Circ circ = c.Circle();
     gp_Pnt p = circ.Location();
@@ -498,7 +498,7 @@ void ImpExpDxfWrite::exportCircle(const BRepAdaptor_Curve& c)
     writeCircle(center, radius);
 }
 
-void ImpExpDxfWrite::exportEllipse(const BRepAdaptor_Curve& c)
+void ImpExpDxfWrite::exportEllipse(BRepAdaptor_Curve& c)
 {
     gp_Elips ellp = c.Ellipse();
     gp_Pnt p = ellp.Location();
@@ -517,7 +517,7 @@ void ImpExpDxfWrite::exportEllipse(const BRepAdaptor_Curve& c)
     writeEllipse(center, major, minor, rotation, 0.0, 6.28318, true );
 }
 
-void ImpExpDxfWrite::exportArc(const BRepAdaptor_Curve& c)
+void ImpExpDxfWrite::exportArc(BRepAdaptor_Curve& c)
 {
     gp_Circ circ = c.Circle();
     gp_Pnt p = circ.Location();
@@ -543,7 +543,7 @@ void ImpExpDxfWrite::exportArc(const BRepAdaptor_Curve& c)
     writeArc(start, end, center, dir );
 }
 
-void ImpExpDxfWrite::exportEllipseArc(const BRepAdaptor_Curve& c)
+void ImpExpDxfWrite::exportEllipseArc(BRepAdaptor_Curve& c)
 {
     gp_Elips ellp = c.Ellipse();
     gp_Pnt p = ellp.Location();
@@ -583,7 +583,7 @@ void ImpExpDxfWrite::exportEllipseArc(const BRepAdaptor_Curve& c)
     writeEllipse(center, major, minor, rotation, startAngle, endAngle, endIsCW);
 }
 
-void ImpExpDxfWrite::exportBSpline(const BRepAdaptor_Curve& c)
+void ImpExpDxfWrite::exportBSpline(BRepAdaptor_Curve& c)
 {
     SplineDataOut sd;
     Handle(Geom_BSplineCurve) spline;
@@ -658,13 +658,13 @@ void ImpExpDxfWrite::exportBSpline(const BRepAdaptor_Curve& c)
     writeSpline(sd);
 }
 
-void ImpExpDxfWrite::exportBCurve(const BRepAdaptor_Curve& c)
+void ImpExpDxfWrite::exportBCurve(BRepAdaptor_Curve& c)
 {
     (void) c;
     Base::Console().Message("BCurve dxf export not yet supported\n");
 }
 
-void ImpExpDxfWrite::exportLine(const BRepAdaptor_Curve& c)
+void ImpExpDxfWrite::exportLine(BRepAdaptor_Curve& c)
 {
     double f = c.FirstParameter();
     double l = c.LastParameter();
@@ -677,7 +677,7 @@ void ImpExpDxfWrite::exportLine(const BRepAdaptor_Curve& c)
     writeLine(start, end);
 }
 
-void ImpExpDxfWrite::exportLWPoly(const BRepAdaptor_Curve& c)
+void ImpExpDxfWrite::exportLWPoly(BRepAdaptor_Curve& c)
 {
     LWPolyDataOut pd;
     pd.Flag = c.IsClosed();
@@ -702,7 +702,7 @@ void ImpExpDxfWrite::exportLWPoly(const BRepAdaptor_Curve& c)
     }
 }
 
-void ImpExpDxfWrite::exportPolyline(const BRepAdaptor_Curve& c)
+void ImpExpDxfWrite::exportPolyline(BRepAdaptor_Curve& c)
 {
     LWPolyDataOut pd;
     pd.Flag = c.IsClosed();

--- a/src/Mod/Import/App/ImpExpDxf.cpp
+++ b/src/Mod/Import/App/ImpExpDxf.cpp
@@ -341,9 +341,10 @@ void ImpExpDxfWrite::setOptions(void)
 {
     ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath(getOptionSource().c_str());
     optionMaxLength = hGrp->GetFloat("maxsegmentlength",5.0);
-    optionPolyLine  = hGrp->GetBool("DiscretizeEllipses",false);
     optionExpPoints  = hGrp->GetBool("ExportPoints",false);
     m_version = hGrp->GetInt("DxfVersionOut",14);
+    optionPolyLine  = hGrp->GetBool("DiscretizeEllipses",false);
+    m_polyOverride = hGrp->GetBool("DiscretizeEllipses",false);
     setDataDir(App::Application::getResourceDir() + "Mod/Import/DxfPlate/");
 }
 
@@ -370,37 +371,66 @@ void ImpExpDxfWrite::exportShape(const TopoDS_Shape input)
             gp_Pnt s = adapt.Value(f);
             gp_Pnt e = adapt.Value(l);
             if (fabs(l-f) > 1.0 && s.SquareDistance(e) < 0.001) {
-                if ((optionPolyLine) &&
-                    (m_version >= 14) ) {
-                    exportLWPoly(adapt);
-                } else if ((optionPolyLine) ||
-                    (m_version < 14) ) {
-                    exportPolyline(adapt);
-                } else {
+                if (m_polyOverride) {
+                    if (m_version >= 14) {
+                        exportLWPoly(adapt);
+                    } else {           //m_version < 14
+                        exportPolyline(adapt);
+                    }
+                } else if (optionPolyLine) {
+                    if (m_version >= 14) {
+                        exportLWPoly(adapt);
+                    } else {           //m_version < 14
+                        exportPolyline(adapt);
+                    }
+                } else {                                  //no overrides, do what's right!
+                    if (m_version < 14) {
+                        exportPolyline(adapt);
+                    } else {
                     exportEllipse(adapt);
+                    }
                 }
-            } else {
-                if ((optionPolyLine) &&
-                    (m_version >= 14) ) {
-                    exportLWPoly(adapt);
-                } else if ((optionPolyLine) ||
-                    (m_version < 14) ) {
-                    exportPolyline(adapt);
-                } else {
-                    exportEllipseArc(adapt);
+            } else {                                     // it's an arc
+                if (m_polyOverride) {
+                    if (m_version >= 14) {
+                        exportLWPoly(adapt);
+                    } else {           //m_version < 14
+                        exportPolyline(adapt);
+                    }
+                } else if (optionPolyLine) {
+                    if (m_version >= 14) {
+                        exportLWPoly(adapt);
+                    } else {           //m_version < 14
+                        exportPolyline(adapt);
+                    }
+                } else {                                  //no overrides, do what's right!
+                    if (m_version < 14) {
+                        exportPolyline(adapt);
+                    } else {
+                        exportEllipseArc(adapt);
+                    }
                 }
             }
-
         } else if (adapt.GetType() == GeomAbs_BSplineCurve) {
-            if ((optionPolyLine) &&
-                (m_version >= 14) ) {
-                exportLWPoly(adapt);
-            } else if ((optionPolyLine)  ||
-                (m_version < 14) ) {
-                exportPolyline(adapt);
-            } else {
-                exportBSpline(adapt);
-            }
+                if (m_polyOverride) {
+                    if (m_version >= 14) {
+                        exportLWPoly(adapt);
+                    } else {           //m_version < 14
+                        exportPolyline(adapt);
+                    }
+                } else if (optionPolyLine) {
+                    if (m_version >= 14) {
+                        exportLWPoly(adapt);
+                    } else {           //m_version < 14
+                        exportPolyline(adapt);
+                    }
+                } else {                                  //no overrides, do what's right!
+                    if (m_version < 14) {
+                        exportPolyline(adapt);
+                    } else {
+                        exportBSpline(adapt);
+                    }
+                }
         } else if (adapt.GetType() == GeomAbs_BezierCurve) {
             exportBCurve(adapt);
         } else if (adapt.GetType() == GeomAbs_Line) {

--- a/src/Mod/Import/App/ImpExpDxf.cpp
+++ b/src/Mod/Import/App/ImpExpDxf.cpp
@@ -486,7 +486,7 @@ bool ImpExpDxfWrite::gp_PntCompare(gp_Pnt p1, gp_Pnt p2)
 }
 
 
-void ImpExpDxfWrite::exportCircle(BRepAdaptor_Curve c)
+void ImpExpDxfWrite::exportCircle(const BRepAdaptor_Curve& c)
 {
     gp_Circ circ = c.Circle();
     gp_Pnt p = circ.Location();
@@ -498,7 +498,7 @@ void ImpExpDxfWrite::exportCircle(BRepAdaptor_Curve c)
     writeCircle(center, radius);
 }
 
-void ImpExpDxfWrite::exportEllipse(BRepAdaptor_Curve c)
+void ImpExpDxfWrite::exportEllipse(const BRepAdaptor_Curve& c)
 {
     gp_Elips ellp = c.Ellipse();
     gp_Pnt p = ellp.Location();
@@ -517,7 +517,7 @@ void ImpExpDxfWrite::exportEllipse(BRepAdaptor_Curve c)
     writeEllipse(center, major, minor, rotation, 0.0, 6.28318, true );
 }
 
-void ImpExpDxfWrite::exportArc(BRepAdaptor_Curve c)
+void ImpExpDxfWrite::exportArc(const BRepAdaptor_Curve& c)
 {
     gp_Circ circ = c.Circle();
     gp_Pnt p = circ.Location();
@@ -543,7 +543,7 @@ void ImpExpDxfWrite::exportArc(BRepAdaptor_Curve c)
     writeArc(start, end, center, dir );
 }
 
-void ImpExpDxfWrite::exportEllipseArc(BRepAdaptor_Curve c)
+void ImpExpDxfWrite::exportEllipseArc(const BRepAdaptor_Curve& c)
 {
     gp_Elips ellp = c.Ellipse();
     gp_Pnt p = ellp.Location();
@@ -583,7 +583,7 @@ void ImpExpDxfWrite::exportEllipseArc(BRepAdaptor_Curve c)
     writeEllipse(center, major, minor, rotation, startAngle, endAngle, endIsCW);
 }
 
-void ImpExpDxfWrite::exportBSpline(BRepAdaptor_Curve c)
+void ImpExpDxfWrite::exportBSpline(const BRepAdaptor_Curve& c)
 {
     SplineDataOut sd;
     Handle(Geom_BSplineCurve) spline;
@@ -658,13 +658,13 @@ void ImpExpDxfWrite::exportBSpline(BRepAdaptor_Curve c)
     writeSpline(sd);
 }
 
-void ImpExpDxfWrite::exportBCurve(BRepAdaptor_Curve c)
+void ImpExpDxfWrite::exportBCurve(const BRepAdaptor_Curve& c)
 {
     (void) c;
     Base::Console().Message("BCurve dxf export not yet supported\n");
 }
 
-void ImpExpDxfWrite::exportLine(BRepAdaptor_Curve c)
+void ImpExpDxfWrite::exportLine(const BRepAdaptor_Curve& c)
 {
     double f = c.FirstParameter();
     double l = c.LastParameter();
@@ -677,7 +677,7 @@ void ImpExpDxfWrite::exportLine(BRepAdaptor_Curve c)
     writeLine(start, end);
 }
 
-void ImpExpDxfWrite::exportLWPoly(BRepAdaptor_Curve c)
+void ImpExpDxfWrite::exportLWPoly(const BRepAdaptor_Curve& c)
 {
     LWPolyDataOut pd;
     pd.Flag = c.IsClosed();
@@ -702,7 +702,7 @@ void ImpExpDxfWrite::exportLWPoly(BRepAdaptor_Curve c)
     }
 }
 
-void ImpExpDxfWrite::exportPolyline(BRepAdaptor_Curve c)
+void ImpExpDxfWrite::exportPolyline(const BRepAdaptor_Curve& c)
 {
     LWPolyDataOut pd;
     pd.Flag = c.IsClosed();

--- a/src/Mod/Import/App/ImpExpDxf.h
+++ b/src/Mod/Import/App/ImpExpDxf.h
@@ -100,15 +100,15 @@ namespace Import
         static bool gp_PntCompare(gp_Pnt p1, gp_Pnt p2);
 
     protected:
-        void exportCircle(const BRepAdaptor_Curve& c);
-        void exportEllipse(const BRepAdaptor_Curve& c);
-        void exportArc(const BRepAdaptor_Curve& c);
-        void exportEllipseArc(const BRepAdaptor_Curve& c);
-        void exportBSpline(const BRepAdaptor_Curve& c);
-        void exportBCurve(const BRepAdaptor_Curve& c);
-        void exportLine(const BRepAdaptor_Curve& c);
-        void exportLWPoly(const BRepAdaptor_Curve& c);   //LWPolyline not supported in R12?
-        void exportPolyline(const BRepAdaptor_Curve& c);
+        void exportCircle(BRepAdaptor_Curve& c);
+        void exportEllipse(BRepAdaptor_Curve& c);
+        void exportArc(BRepAdaptor_Curve& c);
+        void exportEllipseArc(BRepAdaptor_Curve& c);
+        void exportBSpline(BRepAdaptor_Curve& c);
+        void exportBCurve(BRepAdaptor_Curve& c);
+        void exportLine(BRepAdaptor_Curve& c);
+        void exportLWPoly(BRepAdaptor_Curve& c);   //LWPolyline not supported in R12?
+        void exportPolyline(BRepAdaptor_Curve& c);
 
 //        std::string m_optionSource;
         double optionMaxLength;

--- a/src/Mod/Import/App/ImpExpDxf.h
+++ b/src/Mod/Import/App/ImpExpDxf.h
@@ -100,15 +100,15 @@ namespace Import
         static bool gp_PntCompare(gp_Pnt p1, gp_Pnt p2);
 
     protected:
-        void exportCircle(BRepAdaptor_Curve c);
-        void exportEllipse(BRepAdaptor_Curve c);
-        void exportArc(BRepAdaptor_Curve c);
-        void exportEllipseArc(BRepAdaptor_Curve c);
-        void exportBSpline(BRepAdaptor_Curve c);
-        void exportBCurve(BRepAdaptor_Curve c);
-        void exportLine(BRepAdaptor_Curve c);
-        void exportLWPoly(BRepAdaptor_Curve c);   //LWPolyline not supported in R12?
-        void exportPolyline(BRepAdaptor_Curve c);
+        void exportCircle(const BRepAdaptor_Curve& c);
+        void exportEllipse(const BRepAdaptor_Curve& c);
+        void exportArc(const BRepAdaptor_Curve& c);
+        void exportEllipseArc(const BRepAdaptor_Curve& c);
+        void exportBSpline(const BRepAdaptor_Curve& c);
+        void exportBCurve(const BRepAdaptor_Curve& c);
+        void exportLine(const BRepAdaptor_Curve& c);
+        void exportLWPoly(const BRepAdaptor_Curve& c);   //LWPolyline not supported in R12?
+        void exportPolyline(const BRepAdaptor_Curve& c);
 
 //        std::string m_optionSource;
         double optionMaxLength;

--- a/src/Mod/Import/App/dxf.cpp
+++ b/src/Mod/Import/App/dxf.cpp
@@ -521,7 +521,7 @@ void CDxfWrite::putLine(const Base::Vector3d s, const Base::Vector3d e,
 //***************************
 //writeLWPolyLine  (Note: LWPolyline might not be supported in R12
 //added by Wandererfan 2018 (wandererfan@gmail.com) for FreeCAD project
-void CDxfWrite::writeLWPolyLine(LWPolyDataOut pd)
+void CDxfWrite::writeLWPolyLine(const LWPolyDataOut &pd)
 {
     (*m_ssEntity) << "  0"               << endl;
     (*m_ssEntity) << "LWPOLYLINE"     << endl;
@@ -579,7 +579,7 @@ void CDxfWrite::writeLWPolyLine(LWPolyDataOut pd)
 //***************************
 //writePolyline
 //added by Wandererfan 2018 (wandererfan@gmail.com) for FreeCAD project
-void CDxfWrite::writePolyline(LWPolyDataOut pd)
+void CDxfWrite::writePolyline(const LWPolyDataOut &pd)
 {
     (*m_ssEntity) << "  0"            << endl;
     (*m_ssEntity) << "POLYLINE"       << endl;
@@ -796,7 +796,7 @@ void CDxfWrite::writeEllipse(const double* c, double major_radius, double minor_
 //***************************
 //writeSpline
 //added by Wandererfan 2018 (wandererfan@gmail.com) for FreeCAD project
-void CDxfWrite::writeSpline(SplineDataOut sd)
+void CDxfWrite::writeSpline(const SplineDataOut &sd)
 {
     (*m_ssEntity) << "  0"          << endl;
     (*m_ssEntity) << "SPLINE"       << endl;

--- a/src/Mod/Import/App/dxf.cpp
+++ b/src/Mod/Import/App/dxf.cpp
@@ -63,7 +63,6 @@ void CDxfWrite::init(void)
     writeHeaderSection();
     makeBlockRecordTableHead();
     makeBlockSectionHead();
-
 }
 
 //! assemble pieces into output file

--- a/src/Mod/Import/App/dxf.h
+++ b/src/Mod/Import/App/dxf.h
@@ -191,9 +191,9 @@ public:
     void writeEllipse(const double* c, double major_radius, double minor_radius, 
                       double rotation, double start_angle, double end_angle, bool endIsCW);
     void writeCircle(const double* c, double radius );
-    void writeSpline(SplineDataOut sd);
-    void writeLWPolyLine(LWPolyDataOut pd);
-    void writePolyline(LWPolyDataOut pd);
+    void writeSpline(const SplineDataOut &sd);
+    void writeLWPolyLine(const LWPolyDataOut &pd);
+    void writePolyline(const LWPolyDataOut &pd);
     void writeVertex(double x, double y, double z);
     void writeText(const char* text, const double* location1, const double* location2,
                    const double height, const int horizJust);

--- a/src/Mod/Import/App/dxf.h
+++ b/src/Mod/Import/App/dxf.h
@@ -156,6 +156,7 @@ protected:
     int m_layerHandle;
     int m_blockHandle;
     int m_blkRecordHandle;
+    bool m_polyOverride;
     
     std::string m_saveModelSpaceHandle;
     std::string m_savePaperSpaceHandle;
@@ -180,6 +181,8 @@ public:
 //    bool isVersionValid(int vers);
     std::string getLayerName() { return m_layerName; }
     void setLayerName(std::string s);
+    void setVersion(int v) { m_version = v;}
+    void setPolyOverride(bool b) { m_polyOverride = b; }
     void addBlockName(std::string s, std::string blkRecordHandle);
 
     void writeLine(const double* s, const double* e);


### PR DESCRIPTION
This PR adds override parameters for version number and splines as polylines to DXF export functions and corrects errors in Import module reported by Coverity.  Please merge.
Thanks,
wf

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
