### PR TITLE
Path: Bugfix/tags hyperbola and tool change support for grbl

### DIFF
--- a/src/Mod/Path/PathScripts/PathDressupHoldingTags.py
+++ b/src/Mod/Path/PathScripts/PathDressupHoldingTags.py
@@ -380,7 +380,18 @@ class MapWireToTag:
                     debugEdge(e, ">>>>> no flip")
                     break
                 elif PathGeom.pointsCoincide(p2, p0):
-                    outputEdges.append((PathGeom.flipEdge(e), True))
+                    flipped = PathGeom.flipEdge(e)
+                    if not flipped is None:
+                        outputEdges.append((flipped, True))
+                    else:
+                        p0 = None
+                        cnt = 0
+                        for p in reversed(e.discretize(Deflection=0.01)):
+                            if not p0 is None:
+                                outputEdges.append((Part.Edge(Part.LineSegment(p0, p)), True))
+                                cnt = cnt + 1
+                            p0 = p
+                        PathLog.info("replaced edge with %d straight segments" % cnt)
                     edges.remove(e)
                     lastP = None
                     p0 = p1

--- a/src/Mod/Path/PathScripts/PathGeom.py
+++ b/src/Mod/Path/PathScripts/PathGeom.py
@@ -507,6 +507,8 @@ def flipEdge(edge):
 
         return Part.Edge(flipped)
 
+    PathLog.warning(translate('PathGeom', "%s not support for flipping") % type(edge.Curve))
+
 def flipWire(wire):
     '''Flip the entire wire and all its edges so it is being processed the other way around.'''
     edges = [flipEdge(e) for e in wire.Edges]

--- a/src/Mod/Path/PathScripts/post/grbl_post.py
+++ b/src/Mod/Path/PathScripts/post/grbl_post.py
@@ -50,6 +50,8 @@ parser.add_argument('--no-show-editor', action='store_true', help='don\'t pop up
 parser.add_argument('--precision', default='4', help='number of digits of precision, default=4')
 parser.add_argument('--preamble', help='set commands to be issued before the first command, default="G17\nG90"')
 parser.add_argument('--postamble', help='set commands to be issued after the last command, default="M05\nG17 G90\n; M2"')
+parser.add_argument('--tool-change', action='store_true', help='insert M6 for tool changes')
+parser.add_argument('--no-tool-change', action='store_true', help='suppress all tool chanage commands (default)')
 
 TOOLTIP_ARGS=parser.format_help()
 
@@ -104,6 +106,7 @@ def processArguments(argstring):
     global OUTPUT_HEADER
     global OUTPUT_COMMENTS
     global OUTPUT_LINE_NUMBERS
+    global OUTPUT_TOOL_CHANGE
     global SHOW_EDITOR
     global PRECISION
     global PREAMBLE
@@ -133,6 +136,10 @@ def processArguments(argstring):
             PREAMBLE = args.preamble
         if args.postamble is not None:
             POSTAMBLE = args.postamble
+        if args.tool_change:
+            OUTPUT_TOOL_CHANGE = True
+        if args.no_tool_change:
+            OUTPUT_TOOL_CHANGE = False
     except:
         return False
 
@@ -263,7 +270,7 @@ def parse(pathobj):
                         if command not in RAPID_MOVES:
                             outstring.append(param + format(c.Parameters['F'] * 60, '.2f'))
                     elif param == 'T':
-                        outstring.append(param + str(c.Parameters['T']))
+                        outstring.append(param + str(int(c.Parameters['T'])))
                     else:
                         outstring.append(param + format(c.Parameters[param], precision_string))
 
@@ -272,7 +279,8 @@ def parse(pathobj):
 
             # Check for Tool Change:
             if command == 'M6':
-                if OUTPUT_COMMENTS: out += linenumber() + "(begin toolchange)\n"
+                if OUTPUT_COMMENTS:
+                    out += linenumber() + "(begin toolchange)\n"
                 if not OUTPUT_TOOL_CHANGE:
                     outstring.insert(0, ";")
                 else:


### PR DESCRIPTION
Fixes the currently unsupported hyperbola for holding tags, see also
https://forum.freecadweb.org/viewtopic.php?f=15&p=251765&sid=f180d6c7652f2c015987651a77dae1b5#p251765
Hyperbolas are still not supported but the holding tags dressup will approximate any unsupported edge through straight segments (using `discretize`).

The change also includes the setting to allow the `grbl` post processor to emit a tool change command:
https://forum.freecadweb.org/viewtopic.php?f=15&t=30222