### PR TITLE
AddonManager: Fixes download of metadata.txt with Py3

### DIFF
--- a/src/Mod/AddonManager/AddonManager.py
+++ b/src/Mod/AddonManager/AddonManager.py
@@ -1003,6 +1003,13 @@ class InstallWorker(QtCore.QThread):
             # metadata.txt found
             depsfile = mu.read()
             mu.close()
+            
+            # urllib2 gives us a bytelike object instead of a string. Have to consider that
+            try:
+                depsfile = depsfile.decode('utf-8')
+            except AttributeError:
+                pass
+            
             deps = depsfile.split("\n")
             for l in deps:
                 if l.startswith("workbenches="):


### PR DESCRIPTION
urllib2 in Py3 gives us a bytearray instead of a string. We have to decode it first to get the metadata.txt. When decoding fails we assume that we are in Py2 and process as before.

See this FreeCAD forum thread for further details: https://forum.freecadweb.org/viewtopic.php?p=252984#p252984

Was not able to clone the repository to my local machine. So couldn't run the unit tests. But i think this small change should not have that much impact.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)


