### PR TITLE
Fix mesh rendering

### DIFF
--- a/src/Gui/GLBuffer.cpp
+++ b/src/Gui/GLBuffer.cpp
@@ -71,8 +71,11 @@ OpenGLBuffer::~OpenGLBuffer()
  * When calling this function there must be a current OpenGL context.
  * \return
  */
-bool OpenGLBuffer::isVBOSupported()
+bool OpenGLBuffer::isVBOSupported(uint32_t ctx)
 {
+    auto glue = cc_glglue_instance(ctx);
+    if (!glue || !cc_glglue_has_vertex_buffer_object(glue))
+        return false;
     const GLubyte * str = glGetString(GL_EXTENSIONS);
     if (!str)
         return false;

--- a/src/Gui/GLBuffer.h
+++ b/src/Gui/GLBuffer.h
@@ -34,7 +34,7 @@ public:
     OpenGLBuffer(GLenum type);
     ~OpenGLBuffer();
 
-    static bool isVBOSupported();
+    static bool isVBOSupported(uint32_t ctx);
 
     void setCurrentContext(uint32_t ctx);
     bool create();

--- a/src/Mod/Mesh/Gui/SoFCIndexedFaceSet.cpp
+++ b/src/Mod/Mesh/Gui/SoFCIndexedFaceSet.cpp
@@ -576,6 +576,9 @@ void SoFCIndexedFaceSet::drawFaces(SoGLRenderAction *action)
 
         drawCoords(static_cast<const SoGLCoordinateElement*>(coords), cindices, numindices,
                    normals, nindices, &mb, mindices, binding, &tb, tindices);
+
+        if(normalCacheUsed)
+            this->readUnlockNormalCache();
         // Disable caching for this node
         SoGLCacheContextElement::shouldAutoCache(state, SoGLCacheContextElement::DONT_AUTO_CACHE);
 #endif
@@ -847,6 +850,9 @@ void SoFCIndexedFaceSet::generateGLArrays(SoGLRenderAction * action)
     }
 
     render.generateGLArrays(action, matbind, face_vertices, face_indices);
+
+    if(normalCacheUsed)
+        this->readUnlockNormalCache();
 }
 
 void SoFCIndexedFaceSet::doAction(SoAction * action)

--- a/src/Mod/Mesh/Gui/SoFCIndexedFaceSet.cpp
+++ b/src/Mod/Mesh/Gui/SoFCIndexedFaceSet.cpp
@@ -106,7 +106,7 @@ bool MeshRenderer::Private::canRenderGLArray(SoGLRenderAction *action) const
     static bool init = false;
     static bool vboAvailable = false;
     if (!init) {
-        vboAvailable = Gui::OpenGLBuffer::isVBOSupported();
+        vboAvailable = Gui::OpenGLBuffer::isVBOSupported(action->getCacheContext());
         if (!vboAvailable) {
             SoDebugError::postInfo("MeshRenderer",
                                    "GL_ARB_vertex_buffer_object extension not supported");


### PR DESCRIPTION
The first commit fix normal cache deadlock. To demonstrate this, simply open a file with any mesh object, and then go to Part and create a box. FC will freeze.

The second commit fix VBO support checking. I have an intel graphics card, and VBO is disabled by coin because of [this](https://bitbucket.org/Coin3D/coin/src/bcc3be20676d766fb58eba35b2927902244cd556/src/glue/gl.cpp#lines-1337). `isVBOSupport()` failed to check for this case, and cause empty rendering output.

PS. @wwmayer, the comment in the above source code is more than 10 years ago. My intel graphics driver seems fine now. Shall we force enable this (by creating a env variable COIN_VBO=0) somewhere if FC?