### PR TITLE
Improve search for coin3d tag file

### DIFF
--- a/cMake/FindCoin3DDoc.cmake
+++ b/cMake/FindCoin3DDoc.cmake
@@ -26,14 +26,14 @@ IF (COIN3D_FOUND)
       )
       IF( EXISTS ${COIN3D_DOC_PATH})
         message(STATUS "Coin3D doc is installed")
-        find_file(COIN3D_DOC_TAGFILE coin.tag 
+        find_file(COIN3D_DOC_TAGFILE coin.tag Coin.tag 
             ${COIN3D_DOC_PATH}
         )
         IF( EXISTS ${COIN3D_DOC_TAGFILE})
           SET( COIN3D_DOC_FOUND "YES"
           )
         ELSE( EXISTS ${COIN3D_DOC_TAGFILE})
-          find_file(COIN3D_DOC_TAGFILE_GZ coin.tag.gz 
+          find_file(COIN3D_DOC_TAGFILE_GZ coin.tag.gz Coin.tag.gz 
               ${COIN3D_DOC_PATH}
           )
           IF( EXISTS ${COIN3D_DOC_TAGFILE_GZ})


### PR DESCRIPTION
Currently cmake looks for coin.tag and coin.tag.gz when searching a
tag file of the Coin3D documentation. On some coin3d installations,
the tag file is named Coin.tag or Coin.tag.gz. This patch improves
the search by adding additional hints to the find_file() test for
the tag file.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---

See https://forum.freecadweb.org/viewtopic.php?f=10&t=30635 for this patch.
