### PR TITLE
Add eval() to distance line edit during scaling

### DIFF
--- a/src/Mod/Image/ImageTools/_CommandImageScaling.py
+++ b/src/Mod/Image/ImageTools/_CommandImageScaling.py
@@ -139,7 +139,7 @@ def cmdCreateImageScaling(name):
             sel = FreeCADGui.Selection.getSelection()
             try:
                 locale=QtCore.QLocale.system()
-                d, ok = locale.toFloat(self.lineEdit.text())
+                d, ok = locale.toFloat(str(eval(self.lineEdit.text())))
                 if not ok:
                     raise ValueError
                 s=d/self.distance


### PR DESCRIPTION
This adds the ability to enter things like 6 * 25.4 into the distance line edit widget during scaling operations in the image workbench.  Can also enter something like math.pi * 3 or 2**3, etc.  Basically, any legal python input can be used.

Using eval() is not considered a secure way of doing things, but in this context the user would be entering malicious code into his own computer.  Also, what can the user do in eval() that he can't already do just by entering directly into the python console?

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
