### PR TITLE
Add separator between items in propertyfloatlist

### DIFF
--- a/src/Gui/propertyeditor/PropertyItem.cpp
+++ b/src/Gui/propertyeditor/PropertyItem.cpp
@@ -2215,6 +2215,9 @@ void PropertyStringListItem::setValue(const QVariant& value)
 
         std::string pystr = Base::Tools::escapedUnicodeFromUtf8(text.toUtf8());
         str << "u\"" << pystr.c_str() << "\"";
+        if (it != values.end()-1){
+            str << QLocale().groupSeparator();
+        }
     }
     str << "]";
     setPropertyValue(data);


### PR DESCRIPTION
Add local separator between items in propertyfloatlist

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
