### PR TITLE
new style modules: print traceback as error and as log.

### DIFF
--- a/src/App/FreeCADInit.py
+++ b/src/App/FreeCADInit.py
@@ -161,8 +161,15 @@ def InitApplications():
 					try:
 						importlib.import_module(freecad_module_name + '.init')
 						Log('Init: Initializing ' + freecad_module_name + '... done\n')
-					except ImportError as error:
-						Err('During initialization the error ' + str(error) + ' occurred in ' + freecad_module_name + '\n')
+					except Exception as inst:
+						Err('During initialization the error ' + str(inst) + ' occurred in ' + freecad_module_name + '\n')
+						Err('-'*100+'\n')
+						Err(traceback.format_exc())
+						Err('-'*100+'\n')
+						Log('Init:      Initializing ' + freecad_module_name + '... failed\n')
+						Log('-'*100+'\n')
+						Log(traceback.format_exc())
+						Log('-'*100+'\n')
 				else:
 					Log('Init: No init module found in ' + freecad_module_name + ', skipping\n')
 	except ImportError as inst:

--- a/src/App/FreeCADInit.py
+++ b/src/App/FreeCADInit.py
@@ -163,13 +163,13 @@ def InitApplications():
 						Log('Init: Initializing ' + freecad_module_name + '... done\n')
 					except Exception as inst:
 						Err('During initialization the error ' + str(inst) + ' occurred in ' + freecad_module_name + '\n')
-						Err('-'*100+'\n')
+						Err('-'*80+'\n')
 						Err(traceback.format_exc())
-						Err('-'*100+'\n')
+						Err('-'*80+'\n')
 						Log('Init:      Initializing ' + freecad_module_name + '... failed\n')
-						Log('-'*100+'\n')
+						Log('-'*80+'\n')
 						Log(traceback.format_exc())
-						Log('-'*100+'\n')
+						Log('-'*80+'\n')
 				else:
 					Log('Init: No init module found in ' + freecad_module_name + ', skipping\n')
 	except ImportError as inst:

--- a/src/Gui/FreeCADGuiInit.py
+++ b/src/Gui/FreeCADGuiInit.py
@@ -146,13 +146,13 @@ def InitApplications():
 						Log('Init: Initializing ' + freecad_module_name + '... done\n')
 					except Exception as inst:
 						Err('During initialization the error ' + str(inst) + ' occurred in ' + freecad_module_name + '\n')
-						Err('-'*100+'\n')
+						Err('-'*80+'\n')
 						Err(traceback.format_exc())
-						Err('-'*100+'\n')
+						Err('-'*80+'\n')
 						Log('Init:      Initializing ' + freecad_module_name + '... failed\n')
-						Log('-'*100+'\n')
+						Log('-'*80+'\n')
 						Log(traceback.format_exc())
-						Log('-'*100+'\n')
+						Log('-'*80+'\n')
 				else:
 					Log('Init: No init_gui module found in ' + freecad_module_name + ', skipping\n')
 	except ImportError as inst:

--- a/src/Gui/FreeCADGuiInit.py
+++ b/src/Gui/FreeCADGuiInit.py
@@ -144,8 +144,15 @@ def InitApplications():
 					try:
 						importlib.import_module(freecad_module_name + '.init_gui')
 						Log('Init: Initializing ' + freecad_module_name + '... done\n')
-					except ImportError as error:
-						Err('During initialization the error ' + str(error) + ' occurred in ' + freecad_module_name + '\n')
+					except Exception as inst:
+						Err('During initialization the error ' + str(inst) + ' occurred in ' + freecad_module_name + '\n')
+						Err('-'*100+'\n')
+						Err(traceback.format_exc())
+						Err('-'*100+'\n')
+						Log('Init:      Initializing ' + freecad_module_name + '... failed\n')
+						Log('-'*100+'\n')
+						Log(traceback.format_exc())
+						Log('-'*100+'\n')
 				else:
 					Log('Init: No init_gui module found in ' + freecad_module_name + ', skipping\n')
 	except ImportError as inst:


### PR DESCRIPTION
print the exception traceback for new-style modules as an error and add it to the log-file.