### PR TITLE
Fix potential crash when exit editing

### DIFF
--- a/src/Gui/ViewProvider.cpp
+++ b/src/Gui/ViewProvider.cpp
@@ -24,6 +24,7 @@
 #include "PreCompiled.h"
 
 #ifndef _PreComp_
+# include <QApplication>
 # include <QPixmap>
 # include <QTimer>
 # include <Inventor/SoPickedPoint.h>
@@ -55,6 +56,8 @@
 #include "ViewProviderExtension.h"
 
 #include <boost/bind.hpp>
+
+FC_LOG_LEVEL_INIT("ViewProvider",true,true)
 
 using namespace std;
 using namespace Gui;
@@ -178,13 +181,20 @@ void ViewProvider::eventCallback(void * ud, SoEventCallback * node)
                 if (self->keyPressed (press, ke->getKey())) {
                     node->setHandled();
                 }
-                else {
+                else if(QApplication::mouseButtons()==Qt::NoButton) {
+                    // Because of a Coin bug (https://bitbucket.org/Coin3D/coin/pull-requests/119),
+                    // FC may crash if user hits ESC to cancel while still
+                    // holding the mouse button while using some SoDragger.
+                    // Therefore, we shall ignore ESC while any mouse button is
+                    // pressed, until this Coin bug is fixed.
+
                     Gui::TimerFunction* func = new Gui::TimerFunction();
                     func->setAutoDelete(true);
                     Gui::Document* doc = Gui::Application::Instance->activeDocument();
                     func->setFunction(boost::bind(&Document::resetEdit, doc));
                     QTimer::singleShot(0, func, SLOT(timeout()));
-                }
+                }else if(press)
+                    FC_WARN("Please release all mouse buttons before exiting editing");
                 break;
             default:
                 // call the virtual method


### PR DESCRIPTION
To reproduce the crash,
* Create a Part Box
* Double click the item to enter transformation edit mode
* Drag the box
* Press ESC to exit editing while dragging the box
* Crash

The crash is most likely caused by a Coin [bug](https://bitbucket.org/Coin3D/coin/pull-requests/119). The workaround is to ignore ESC if any mouse button is pressed.