### PR TITLE
Update commit count reference for shallow clones

### DIFF
--- a/src/Tools/SubWCRev.py
+++ b/src/Tools/SubWCRev.py
@@ -180,10 +180,8 @@ class GitControl(VersionControl):
         blessed master repository.
         the second part, separated by " +" reflects the number of commits that are
         different from the master repository"""
-        #referencecommit="f119e740c87918b103140b66b2316ae96f136b0e"
-        #referencerevision=4138
-        referencecommit="6b3d7b17a749e03bcbf2cf79bbbb903137298c44"
-        referencerevision=5235
+        referencecommit="7d8e53aaab17961d85c5009de34f69f2af084e8b"
+        referencerevision=14555
 
         result = None
         countallfh=os.popen("git rev-list --count %s..HEAD" % \


### PR DESCRIPTION
Clone depth for travis is set to 5000. Using the current HEAD
as reference means we won't have to update it again for awhile.

