### PR TITLE
Misc. typo and whitespace fixes

### DIFF
--- a/src/Gui/Application.cpp
+++ b/src/Gui/Application.cpp
@@ -139,9 +139,9 @@ namespace Gui {
 // Pimpl class
 struct ApplicationP
 {
-    ApplicationP() : 
-    activeDocument(0L), 
-    isClosing(false), 
+    ApplicationP() :
+    activeDocument(0L),
+    isClosing(false),
     startingUp(true)
     {
         // create the macro manager
@@ -162,7 +162,7 @@ struct ApplicationP
     std::list<Gui::BaseView*> passive;
     bool isClosing;
     bool startingUp;
-    /// Handles all commands 
+    /// Handles all commands
     CommandManager commandManager;
 };
 
@@ -315,7 +315,7 @@ Application::Application(bool GUIenabled)
             (void)coin_setenv("COIN_VBO", "0", true);
         }
 
-        // Check for the symbols for group separator and deciaml point. They must be different otherwise
+        // Check for the symbols for group separator and decimal point. They must be different otherwise
         // Qt doesn't work properly.
 #if defined(Q_OS_WIN32)
         if (QLocale::system().groupSeparator() == QLocale::system().decimalPoint()) {
@@ -435,7 +435,7 @@ Application::Application(bool GUIenabled)
 
     d = new ApplicationP;
 
-    // global access 
+    // global access
     Instance = this;
 
     // instantiate the workbench dictionary
@@ -457,7 +457,7 @@ Application::~Application()
     BitmapFactoryInst::destruct();
 
 #if 0
-    // we must run the garbage collector before shutting down the SoDB 
+    // we must run the garbage collector before shutting down the SoDB
     // subsystem because we may reference some class objects of them in Python
     Base::Interpreter().cleanupSWIG("SoBase *");
     // finish also Inventor subsystem
@@ -703,7 +703,7 @@ void Application::slotDeleteDocument(const App::Document& Doc)
     doc->second->signalDeleteDocument(*doc->second);
     signalDeleteDocument(*doc->second);
 
-    // If the active document gets destructed we must set it to 0. If there are further existing documents then the 
+    // If the active document gets destructed we must set it to 0. If there are further existing documents then the
     // view that becomes active sets the active document again. So, we needn't worry about this.
     if (d->activeDocument == doc->second)
         setActiveDocument(0);
@@ -832,19 +832,19 @@ void Application::setActiveDocument(Gui::Document* pcDocument)
     }
     d->activeDocument = pcDocument;
     std::string nameApp, nameGui;
- 
+
     // This adds just a line to the macro file but does not set the active document
     // Macro recording of this is problematic, thus it's written out as comment.
     if (pcDocument){
         nameApp += "App.setActiveDocument(\"";
-        nameApp += pcDocument->getDocument()->getName(); 
+        nameApp += pcDocument->getDocument()->getName();
         nameApp +=  "\")\n";
         nameApp += "App.ActiveDocument=App.getDocument(\"";
-        nameApp += pcDocument->getDocument()->getName(); 
+        nameApp += pcDocument->getDocument()->getName();
         nameApp +=  "\")";
         macroManager()->addLine(MacroManager::Cmt,nameApp.c_str());
         nameGui += "Gui.ActiveDocument=Gui.getDocument(\"";
-        nameGui += pcDocument->getDocument()->getName(); 
+        nameGui += pcDocument->getDocument()->getName();
         nameGui +=  "\")";
         macroManager()->addLine(MacroManager::Cmt,nameGui.c_str());
     }
@@ -1028,10 +1028,10 @@ void Application::tryClose(QCloseEvent * e)
  * Activate the matching workbench to the registered workbench handler with name \a name.
  * The handler must be an instance of a class written in Python.
  * Normally, if a handler gets activated a workbench with the same name gets created unless it
- * already exists. 
+ * already exists.
  *
  * The old workbench gets deactivated before. If the workbench to the handler is already
- * active or if the switch fails false is returned. 
+ * active or if the switch fails false is returned.
  */
 bool Application::activateWorkbench(const char* name)
 {
@@ -1149,7 +1149,7 @@ bool Application::activateWorkbench(const char* name)
         Base::Console().Error("%s\n", e.getStackTrace().c_str());
         if (!d->startingUp) {
             wc.restoreCursor();
-            QMessageBox::critical(getMainWindow(), QObject::tr("Workbench failure"), 
+            QMessageBox::critical(getMainWindow(), QObject::tr("Workbench failure"),
                 QObject::tr("%1").arg(msg));
             wc.setWaitCursor();
         }
@@ -1290,13 +1290,13 @@ QStringList Application::workbenches(void) const
     std::map<std::string, std::string>::const_iterator st = config.find("StartWorkbench");
     const char* start = (st != config.end() ? st->second.c_str() : "<none>");
     QStringList hidden, extra;
-    if (ht != config.end()) { 
+    if (ht != config.end()) {
         QString items = QString::fromLatin1(ht->second.c_str());
         hidden = items.split(QLatin1Char(';'), QString::SkipEmptyParts);
         if (hidden.isEmpty())
             hidden.push_back(QLatin1String(""));
     }
-    if (et != config.end()) { 
+    if (et != config.end()) {
         QString items = QString::fromLatin1(et->second.c_str());
         extra = items.split(QLatin1Char(';'), QString::SkipEmptyParts);
         if (extra.isEmpty())
@@ -1322,7 +1322,7 @@ QStringList Application::workbenches(void) const
         if (!hidden.isEmpty()&&ok) {
             ok = (hidden.indexOf(QString::fromLatin1(wbName)) == -1);
         }
-    
+
         // okay the item is visible
         if (ok)
             wb.push_back(QString::fromLatin1(wbName));
@@ -1338,7 +1338,7 @@ void Application::setupContextMenu(const char* recipient, MenuItem* items) const
 {
     Workbench* actWb = WorkbenchManager::instance()->active();
     if (actWb) {
-        // when populating the context-menu of a Python workbench invoke the method 
+        // when populating the context-menu of a Python workbench invoke the method
         // 'ContextMenu' of the handler object
         if (actWb->getTypeId().isDerivedFrom(PythonWorkbench::getClassTypeId())) {
             static_cast<PythonWorkbench*>(actWb)->clearContextMenu();
@@ -1540,7 +1540,7 @@ void Application::initTypes(void)
     Gui::ViewProviderGroupExtension             ::init();
     Gui::ViewProviderGroupExtensionPython       ::init();
     Gui::ViewProviderGeoFeatureGroupExtension   ::init();
-    Gui::ViewProviderGeoFeatureGroupExtensionPython::init();    
+    Gui::ViewProviderGeoFeatureGroupExtensionPython::init();
     Gui::ViewProviderOriginGroupExtension       ::init();
     Gui::ViewProviderOriginGroupExtensionPython ::init();
     Gui::ViewProviderExtern                     ::init();

--- a/src/Mod/Ship/shipHydrostatics/PlotAux.py
+++ b/src/Mod/Ship/shipHydrostatics/PlotAux.py
@@ -309,7 +309,7 @@ class Plot(object):
         s.set("A1", "displacement [ton]")
         s.set("B1", "draft [m]")
         s.set("C1", "wetted surface [m^2]")
-        s.set("D1", "1cm triming ship moment [ton*m]")
+        s.set("D1", "1cm trimming ship moment [ton*m]")
         s.set("E1", "Floating area [m^2]")
         s.set("F1", "KBl [m]")
         s.set("G1", "KBt [m]")

--- a/src/Mod/Ship/shipHydrostatics/Tools.py
+++ b/src/Mod/Ship/shipHydrostatics/Tools.py
@@ -132,7 +132,7 @@ def getUnderwaterSide(shape, force=True):
             i += 1
             box.Height = length_format.format(
                 - zmin + H + random.uniform(-random_bounds, random_bounds))
-            App.ActiveDocument.recompute() 
+            App.ActiveDocument.recompute()
 
     out = common.Shape
     App.ActiveDocument.removeObject(common.Name)
@@ -143,7 +143,7 @@ def getUnderwaterSide(shape, force=True):
 
 
 def areas(ship, n, draft=None,
-                   roll=Units.parseQuantity("0 deg"), 
+                   roll=Units.parseQuantity("0 deg"),
                    trim=Units.parseQuantity("0 deg")):
     """Compute the ship transversal areas
 
@@ -213,7 +213,7 @@ def areas(ship, n, draft=None,
 
 
 def displacement(ship, draft=None,
-                       roll=Units.parseQuantity("0 deg"), 
+                       roll=Units.parseQuantity("0 deg"),
                        trim=Units.parseQuantity("0 deg")):
     """Compute the ship displacement
 
@@ -310,7 +310,7 @@ def wettedArea(shape, draft, roll=Units.parseQuantity("0 deg"),
 
 
 def moment(ship, draft=None,
-                 roll=Units.parseQuantity("0 deg"), 
+                 roll=Units.parseQuantity("0 deg"),
                  trim=Units.parseQuantity("0 deg")):
     """Compute the moment required to trim the ship 1cm
 
@@ -344,7 +344,7 @@ def moment(ship, draft=None,
 
 
 def floatingArea(ship, draft=None,
-                       roll=Units.parseQuantity("0 deg"), 
+                       roll=Units.parseQuantity("0 deg"),
                        trim=Units.parseQuantity("0 deg")):
     """Compute the ship floating area
 
@@ -490,7 +490,7 @@ class Point:
     disp -- Ship displacement
     xcb -- Bouyance center X coordinate
     wet -- Wetted ship area
-    mom -- Triming 1cm ship moment
+    mom -- Trimming 1cm ship moment
     farea -- Floating area
     KBt -- Transversal KB height
     BMt -- Transversal BM height

--- a/src/Mod/TechDraw/App/DrawGeomHatch.cpp
+++ b/src/Mod/TechDraw/App/DrawGeomHatch.cpp
@@ -96,7 +96,7 @@ DrawGeomHatch::DrawGeomHatch(void)
     ADD_PROPERTY_TYPE(NamePattern,(""),vgroup,App::Prop_None,"The name of the pattern");
     ADD_PROPERTY_TYPE(ScalePattern,(1.0),vgroup,App::Prop_None,"GeomHatch pattern size adjustment");
     ScalePattern.setConstraints(&scaleRange);
-    
+
     m_saveFile = "";
     m_saveName = "";
 
@@ -177,7 +177,7 @@ std::vector<PATLineSpec> DrawGeomHatch::getDecodedSpecsFromFile()
     return getDecodedSpecsFromFile(fileSpec,myPattern);
 }
 
-     
+
 //!get all the specification lines and decode them into PATLineSpec structures
 /*static*/
 std::vector<PATLineSpec> DrawGeomHatch::getDecodedSpecsFromFile(std::string fileSpec, std::string myPattern)
@@ -189,7 +189,7 @@ std::vector<PATLineSpec> DrawGeomHatch::getDecodedSpecsFromFile(std::string file
         return result;
     }
     result = PATLineSpec::getSpecsForPattern(fileSpec,myPattern);
-    
+
     return result;
 }
 
@@ -206,7 +206,7 @@ std::vector<LineSet>  DrawGeomHatch::getTrimmedLines(int i)   //get the trimmed 
 }
 
 /* static */
-//! get hatch lines trimmed to face outline 
+//! get hatch lines trimmed to face outline
 std::vector<LineSet> DrawGeomHatch::getTrimmedLines(DrawViewPart* source, std::vector<LineSet> lineSets, int iface, double scale )
 {
     std::vector<LineSet> result;
@@ -221,7 +221,7 @@ std::vector<LineSet> DrawGeomHatch::getTrimmedLines(DrawViewPart* source, std::v
     Bnd_Box bBox;
     BRepBndLib::Add(face, bBox);
     bBox.SetGap(0.0);
-    
+
     for (auto& ls: lineSets) {
         PATLineSpec hl = ls.getPATLineSpec();
         std::vector<TopoDS_Edge> candidates = DrawGeomHatch::makeEdgeOverlay(hl, bBox, scale);   //completely cover face bbox with lines
@@ -261,7 +261,7 @@ std::vector<LineSet> DrawGeomHatch::getTrimmedLines(DrawViewPart* source, std::v
             }
             resultEdges.push_back(edge);
         }
-        
+
         std::vector<TechDrawGeometry::BaseGeom*> resultGeoms;
         int i = 0;
         for (auto& e: resultEdges) {
@@ -271,7 +271,7 @@ std::vector<LineSet> DrawGeomHatch::getTrimmedLines(DrawViewPart* source, std::v
                 throw Base::Exception("DGH::getTrimmedLines - baseFactory failed");
             }
             resultGeoms.push_back(base);
-            i++; 
+            i++;
         }
         ls.setEdges(resultEdges);
         ls.setGeoms(resultGeoms);
@@ -308,7 +308,7 @@ std::vector<TopoDS_Edge> DrawGeomHatch::makeEdgeOverlay(PATLineSpec hl, Bnd_Box 
         int repeatDown  = (int) fabs(((atomY - minY)/interval));
         int repeatTotal = repeatUp + repeatDown + 1;
         double yStart = atomY - repeatDown * interval;
-        
+
         // make repeats
         for (int i = 0; i < repeatTotal; i++) {
             Base::Vector3d newStart(minX,yStart + float(i)*interval,0);
@@ -316,7 +316,7 @@ std::vector<TopoDS_Edge> DrawGeomHatch::makeEdgeOverlay(PATLineSpec hl, Bnd_Box 
             TopoDS_Edge newLine = makeLine(newStart,newEnd);
             result.push_back(newLine);
         }
-    } else if ((angle == 90.0)  || 
+    } else if ((angle == 90.0)  ||
                (angle == -90.0))  {         //odd case 2: vertical lines
         interval = hl.getInterval() * scale;
         double atomX  = origin.x;
@@ -336,7 +336,7 @@ std::vector<TopoDS_Edge> DrawGeomHatch::makeEdgeOverlay(PATLineSpec hl, Bnd_Box 
     } else if (angle > 0) {      //oblique  (bottom left -> top right)
         //ex: 60,0,0,0,4.0,25,-25
 //        Base::Console().Message("TRACE - DGH-makeEdgeOverlay - making angle > 0\n");
-        double xLeftAtom = origin.x + (minY - origin.y)/slope;                  //the "atom" is the fill line that passes through the 
+        double xLeftAtom = origin.x + (minY - origin.y)/slope;                  //the "atom" is the fill line that passes through the
                                                                                 //pattern-origin (not necc. R2 origin)
         double xRightAtom = origin.x + (maxY - origin.y)/slope;
         int repeatRight = (int) fabs((maxX - xLeftAtom)/interval);
@@ -345,7 +345,7 @@ std::vector<TopoDS_Edge> DrawGeomHatch::makeEdgeOverlay(PATLineSpec hl, Bnd_Box 
         double leftStartX = xLeftAtom - (repeatLeft * interval);
         double leftEndX   = xRightAtom - (repeatLeft * interval);
         int repeatTotal = repeatRight + repeatLeft + 1;
-        
+
         //make repeats
         for (int i = 0; i < repeatTotal; i++) {
             Base::Vector3d newStart(leftStartX + (float(i) *  interval),minY,0);
@@ -388,7 +388,7 @@ TopoDS_Edge DrawGeomHatch::makeLine(Base::Vector3d s, Base::Vector3d e)
     return result;
 }
 
-//! get all the untrimed hatchlines for a face
+//! get all the untrimmed hatchlines for a face
 //! these will be clipped to shape on the gui side
 std::vector<LineSet> DrawGeomHatch::getFaceOverlay(int fdx)
 {
@@ -419,7 +419,7 @@ std::vector<LineSet> DrawGeomHatch::getFaceOverlay(int fdx)
                 throw Base::Exception("DGH::getFaceOverlay - baseFactory failed");
             }
             resultGeoms.push_back(base);
-            i++; 
+            i++;
         }
         ls.setEdges(candidates);
         ls.setGeoms(resultGeoms);
@@ -443,9 +443,9 @@ TopoDS_Face DrawGeomHatch::extractFace(DrawViewPart* source, int iface )
     }
 
     std::vector<TopoDS_Wire> faceWires;
-    if (usingSection) { 
+    if (usingSection) {
         faceWires = section->getWireForFace(iface);
-    } else { 
+    } else {
         faceWires = source->getWireForFace(iface);
     }
 
@@ -453,7 +453,7 @@ TopoDS_Face DrawGeomHatch::extractFace(DrawViewPart* source, int iface )
     gp_Pnt gOrg(0.0,0.0,0.0);
     gp_Dir gDir(0.0,0.0,1.0);
     gp_Pln plane(gOrg,gDir);
-    
+
     BRepBuilderAPI_MakeFace mkFace(plane, faceWires.front(), true);
     std::vector<TopoDS_Wire>::iterator itWire = ++faceWires.begin();            //starting with second wire
     for (; itWire != faceWires.end(); itWire++) {


### PR DESCRIPTION
`codespell -q 3 -I ../fc-word-whitelist.txt --skip=".git,*.ts,*.po,./src/3rdParty,./src/Mod/Assembly/App/opendcm,./src/zipios++"`