### PR TITLE
Set focus to sketcher window when a new handler is activated to ensure proper handling of keys, espcially Escape.

### DIFF
--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -374,6 +374,12 @@ void ViewProviderSketch::activateHandler(DrawSketchHandler *newHandler)
     Mode = STATUS_SKETCH_UseHandler;
     edit->sketchHandler->sketchgui = this;
     edit->sketchHandler->activated(this);
+
+    // make sure receiver has focus so immediately pressing Escape will be handled by
+    // ViewProviderSketch::keyPressed() and dismiss the active handler, and not the entire
+    // sketcher editor
+    Gui::MDIView *mdi = Gui::Application::Instance->activeDocument()->getActiveView();
+    mdi->setFocus();
 }
 
 void ViewProviderSketch::deactivateHandler()


### PR DESCRIPTION
In this discussion we talked about the inconsistencies of pressing Escape and wmayer root caused it to which window happens to have the focus when Escape is pressed:

https://forum.freecadweb.org/viewtopic.php?f=10&t=30759

This changeset moves the focus to the sketcher window when a sketcher tool is activated so if the user presses Escape immediately (because they got the wrong tool) the tool is dismissed and not the entire sketch editor.