### PR TITLE
CombiView tab icon for active TaskPanel

### DIFF
--- a/src/Gui/CombiView.cpp
+++ b/src/Gui/CombiView.cpp
@@ -90,9 +90,12 @@ CombiView::~CombiView()
 
 void CombiView::showDialog(Gui::TaskView::TaskDialog *dlg)
 {
+    static QIcon icon = Gui::BitmapFactory().pixmap("edit-edit.svg");
+
     // switch to the TaskView tab
     oldTabIndex = tabs->currentIndex();
     tabs->setCurrentIndex(1);
+    tabs->setTabIcon(1, icon);
     // set the dialog
     taskPanel->showDialog(dlg);
 }
@@ -105,8 +108,11 @@ void CombiView::closeDialog()
 
 void CombiView::closedDialog()
 {
+    static QIcon icon = QIcon();
+
     // dialog has been closed
     tabs->setCurrentIndex(oldTabIndex);
+    tabs->setTabIcon(1, icon);
 }
 
 void CombiView::showTreeView()


### PR DESCRIPTION
Adds an icon to the tab when a task is pending in the TaskPanel. Removes the icon once the edit session has ended.

This seems more intuitive and easier to notice than having two different icons - especially due to my  challenges processing colour.