### PR TITLE
fix python3 issues

### DIFF
--- a/src/Mod/AddonManager/AddonManager.py
+++ b/src/Mod/AddonManager/AddonManager.py
@@ -216,7 +216,7 @@ class AddonsInstaller(QtGui.QDialog):
                     if not thread.isFinished():
                         oktoclose = False
         if oktoclose:
-            shutil.rmtree(self.macro_repo_dir)
+            shutil.rmtree(self.macro_repo_dir,onerror=self.remove_readonly)
             QtGui.QDialog.reject(self)
 
     def retranslateUi(self):
@@ -683,7 +683,12 @@ class Macro(object):
                 code = code.encode('utf8')
                 code = code.replace('\xc2\xa0', ' ')
             except:
-                FreeCAD.Console.PrintWarning(translate("AddonsInstaller", "Unable to clean macro code: ") + code + '\n')
+                #HTMLParser().unescape() didn't work, so try manually
+                try:
+                    code = code.replace('&gt;','>').replace('&lt;','<').replace('&#160;','').replace('&amp;','&').replace('\xc2\xa0', ' ')
+                    code = code.replace('\t','    ')#some macros in the wiki have tabs interspersed, this might fix some of them
+                except: 
+                    FreeCAD.Console.PrintWarning(translate("AddonsInstaller", "Unable to clean macro code: ") + code + '\n')
         desc = re.findall("<td class=\"ctEven left macro-description\">(.*?)<\/td>", p.replace('\n', ' '))
         if desc:
             desc = desc[0]

--- a/src/Mod/AddonManager/AddonManager.py
+++ b/src/Mod/AddonManager/AddonManager.py
@@ -677,18 +677,15 @@ class Macro(object):
                 from HTMLParser import HTMLParser
             except ImportError:
                 from html.parser import HTMLParser
-            try:
+            if sys.version_info.major < 3:
                 code = code.decode('utf8')
+            try:
                 code = HTMLParser().unescape(code)
-                code = code.encode('utf8')
-                code = code.replace('\xc2\xa0', ' ')
+                code = code.replace(b'\xc2\xa0'.decode("utf-8"), ' ')
             except:
-                #HTMLParser().unescape() didn't work, so try manually
-                try:
-                    code = code.replace('&gt;','>').replace('&lt;','<').replace('&#160;','').replace('&amp;','&').replace('\xc2\xa0', ' ')
-                    code = code.replace('\t','    ')#some macros in the wiki have tabs interspersed, this might fix some of them
-                except: 
-                    FreeCAD.Console.PrintWarning(translate("AddonsInstaller", "Unable to clean macro code: ") + code + '\n')
+                FreeCAD.Console.PrintWarning(translate("AddonsInstaller", "Unable to clean macro code: ") + code + '\n')
+            if sys.version_info.major < 3:
+                code = code.encode('utf8')
         desc = re.findall("<td class=\"ctEven left macro-description\">(.*?)<\/td>", p.replace('\n', ' '))
         if desc:
             desc = desc[0]


### PR DESCRIPTION
* fix attempts to remove readonly temp folder in windows, which was preventing addon manager window from closing
* cleanup (unescape) macros manually if HTMLParser().unescape() fails
* replace tabs in macros with 4 spaces

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
