### PR TITLE
Fix Decoration positions on Views derived from DPG Base

### DIFF
--- a/src/Mod/TechDraw/App/DrawProjGroupItem.cpp
+++ b/src/Mod/TechDraw/App/DrawProjGroupItem.cpp
@@ -102,19 +102,14 @@ App::DocumentObjectExecReturn *DrawProjGroupItem::execute(void)
 {
     if (DrawUtil::checkParallel(Direction.getValue(),
                                 RotationVector.getValue())) {
-        Base::Console().Message("TRACE - DPGI::execute - Projdir: %s X: %s\n",
-                        TechDraw::DrawUtil::formatVector(Direction.getValue()).c_str(),
-                        TechDraw::DrawUtil::formatVector(RotationVector.getValue()).c_str());
-
         return new App::DocumentObjectExecReturn("DPGI: Direction and RotationVector are parallel");
     }
-
+    
     App::DocumentObjectExecReturn * ret = DrawViewPart::execute();
     delete ret;
 
     autoPosition();
     requestPaint();
-
     return App::DocumentObject::StdReturn;
 }
 
@@ -122,10 +117,6 @@ void DrawProjGroupItem::autoPosition()
 {
     auto pgroup = getPGroup();
     Base::Vector3d newPos;
-//    if (isAnchor()) {
-//        X.setValue(0.0);
-//        Y.setValue(0.0);
-//    } else 
     if ((pgroup != nullptr) && 
         (pgroup->AutoDistribute.getValue()) &&
         (!LockPosition.getValue())) {
@@ -171,44 +162,37 @@ bool DrawProjGroupItem::isAnchor(void)
     return result;
 }
 
-/// get a coord system aligned with Direction and Rotation Vector
+/// get a coord system aligned with Direction and Rotation Vector   
 gp_Ax2 DrawProjGroupItem::getViewAxis(const Base::Vector3d& pt,
                                  const Base::Vector3d& axis, 
                                  const bool flip) const
 {
-     (void) flip;
-     gp_Ax2 viewAxis;
-     Base::Vector3d x = RotationVector.getValue();
-     Base::Vector3d nx = x;
-     x.Normalize();
-     Base::Vector3d na = axis;
-     na.Normalize();
+    (void) flip;
+    gp_Ax2 viewAxis;
+    Base::Vector3d projDir = Direction.getValue();
+    Base::Vector3d rotVec  = RotationVector.getValue();
 
-     if (DrawUtil::checkParallel(nx,na)) {
-         Base::Console().Warning("DPGI::getVA - axis and X parallel. using defaults\n");
-         viewAxis = TechDrawGeometry::getViewAxis(pt,axis,false);
-     } else {
-         viewAxis = TechDrawGeometry::getViewAxis(pt,na,nx,false);
-     }
-//     gp_Dir va_Main = viewAxis.Direction();
-//     gp_Dir va_X    = viewAxis.XDirection();
-//     gp_Ax3 R3;
-//     gp_Ax3 viewCS(viewAxis);
-//     gp_Trsf txTo, txFrom;
-//     txTo.SetTransformation(R3,viewCS);
-//     txFrom = txTo.Inverted();
-//     gp_Dir dirFrom = va_Main.Transformed(txFrom);
-//     gp_Dir dirTo   = va_Main.Transformed(txTo);
-//     Base::Console().Message("TRACE - DPGI::getVA - dirFrom: %s dirTo: %s\n",
-//                             DrawUtil::formatVector(dirFrom).c_str(),
-//                             DrawUtil::formatVector(dirTo).c_str());
-//     gp_Dir xFrom = va_X.Transformed(txFrom);
-//     gp_Dir xTo   = va_X.Transformed(txTo);
-//     Base::Console().Message("TRACE - DPGI::getVA - xFrom: %s xTo: %s\n",
-//                             DrawUtil::formatVector(xFrom).c_str(),
-//                             DrawUtil::formatVector(xTo).c_str());
+// mirror projDir through XZ plane
+    Base::Vector3d yNorm(0.0,1.0,0.0);
+    projDir = projDir - (yNorm * 2.0) * (projDir.Dot(yNorm));
+    rotVec = rotVec - (yNorm * 2.0) * (rotVec.Dot(yNorm));
 
-     return viewAxis;
+    if (DrawUtil::checkParallel(projDir,rotVec)) {
+         Base::Console().Warning("DPGI::getVA - %s - Direction and RotationVector parallel. using defaults\n",
+                                 getNameInDocument());
+    }
+    try {
+        viewAxis = gp_Ax2(gp_Pnt(pt.x,pt.y,pt.z),
+                          gp_Dir(projDir.x, projDir.y, projDir.z),
+                          gp_Dir(rotVec.x, rotVec.y, rotVec.z));
+    }
+   catch (Standard_Failure& e4) {
+            Base::Console().Message("PROBLEM - DPGI (%s) failed to create viewAxis: %s **\n",
+                                    getNameInDocument(),e4.GetMessageString());
+            return TechDrawGeometry::getViewAxis(pt,axis,false);
+   }
+
+    return viewAxis;
 }
 
 //obs??

--- a/src/Mod/TechDraw/App/DrawViewPart.cpp
+++ b/src/Mod/TechDraw/App/DrawViewPart.cpp
@@ -246,8 +246,11 @@ App::DocumentObjectExecReturn *DrawViewPart::execute(void)
     }
 
     gp_Pnt inputCenter;
+    Base::Vector3d stdOrg(0.0,0.0,0.0);
+    
     inputCenter = TechDrawGeometry::findCentroid(shape,
-                                                 Direction.getValue());
+                                                 getViewAxis(stdOrg,Direction.getValue()));
+                                                 
     shapeCentroid = Base::Vector3d(inputCenter.X(),inputCenter.Y(),inputCenter.Z());
     TopoDS_Shape mirroredShape;
     mirroredShape = TechDrawGeometry::mirrorShape(shape,
@@ -332,6 +335,7 @@ TechDrawGeometry::GeometryObject* DrawViewPart::buildGeometryObject(TopoDS_Shape
         go->projectShape(shape,
             viewAxis);
     }
+    
     go->extractGeometry(TechDrawGeometry::ecHARD,                   //always show the hard&outline visible lines
                         true);
     go->extractGeometry(TechDrawGeometry::ecOUTLINE,
@@ -472,7 +476,7 @@ void DrawViewPart::extractFaces()
     ew.loadEdges(newEdges);
     bool success = ew.perform();
     if (!success) {
-        Base::Console().Warning("DVP::extractFaces - input is not planar graph. No face detection\n");
+        Base::Console().Warning("DVP::extractFaces - %s -Can't make faces from projected edges\n", getNameInDocument());
         return;
     }
     std::vector<TopoDS_Wire> fw = ew.getResultNoDups();
@@ -692,13 +696,7 @@ gp_Ax2 DrawViewPart::getViewAxis(const Base::Vector3d& pt,
 {
     gp_Ax2 viewAxis = TechDrawGeometry::getViewAxis(pt,axis,flip);
      
-    //put X dir of viewAxis on other side to get view right side up
-    gp_Ax1 rotAxis(viewAxis.Location(),viewAxis.Direction());
-    gp_Dir xDir = viewAxis.XDirection();
-    gp_Dir newX = xDir.Rotated(rotAxis, M_PI);
-    viewAxis.SetXDirection(newX);
-
-     return viewAxis;
+    return viewAxis;
 }
 
 void DrawViewPart::saveParamSpace(const Base::Vector3d& direction, const Base::Vector3d& xAxis)

--- a/src/Mod/TechDraw/App/GeometryObject.h
+++ b/src/Mod/TechDraw/App/GeometryObject.h
@@ -66,6 +66,8 @@ TopoDS_Shape TechDrawExport moveShape(const TopoDS_Shape &input,
 //! Returns the centroid of shape, as viewed according to direction
 gp_Pnt TechDrawExport findCentroid(const TopoDS_Shape &shape,
                         const Base::Vector3d &direction);
+gp_Pnt TechDrawExport findCentroid(const TopoDS_Shape &shape,
+                                      const gp_Ax2 viewAxis);
 Base::Vector3d TechDrawExport findCentroidVec(const TopoDS_Shape &shape,
                         const Base::Vector3d &direction);
 


### PR DESCRIPTION
This PR corrects some positioning errors in TechDraw.  Please merge.
Thanks,
wf

- Section faces, detail highlights, center and section lines
  were wrong when the BaseView was a DPGI

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
