### PR TITLE
Port SpaceNavigator support on Linux to Qt5

### DIFF
--- a/src/Gui/CMakeLists.txt
+++ b/src/Gui/CMakeLists.txt
@@ -106,6 +106,12 @@ else()
 endif()
 
 IF(SPNAV_FOUND)
+    if (BUILD_QT5 AND UNIX AND NOT APPLE)
+        find_package(Qt5X11Extras REQUIRED)
+        include_directories(${Qt5X11Extras_INCLUDE_DIRS})
+        list(APPEND FreeCADGui_LIBS ${Qt5X11Extras_LIBRARIES})
+    endif()
+
     add_definitions(-DSPNAV_FOUND)
     include_directories(
         ${SPNAV_INCLUDE_DIR}

--- a/src/Gui/GuiApplicationNativeEventAware.cpp
+++ b/src/Gui/GuiApplicationNativeEventAware.cpp
@@ -25,7 +25,26 @@
 #include <QGlobalStatic>
 #if defined(Q_OS_LINUX) && defined(SPNAV_FOUND)
   #include <QX11Info>
-  #include <xcb/xcb.h>
+  #include <spnav.h>
+
+  #if QT_VERSION >= 0x050000
+    #include <X11/Xlib.h>
+    #undef Bool
+    #undef CursorShape
+    #undef Expose
+    #undef KeyPress
+    #undef KeyRelease
+    #undef FocusIn
+    #undef FocusOut
+    #undef FontChange
+    #undef None
+    #undef Status
+    #undef Unsorted
+    #undef False
+    #undef True
+    #undef Complex
+  #endif // #if QT_VERSION >= 0x050000
+
 #endif // if defined(Q_OS_LINUX) && defined(SPNAV_FOUND)
 #include <QMainWindow>
 #include <QWidget>
@@ -34,10 +53,6 @@
 #include "GuiApplicationNativeEventAware.h"
 #include "SpaceballEvent.h"
 #include "Application.h"
-
-#if defined(Q_OS_LINUX) && defined(SPNAV_FOUND)
-  #include <spnav.h>
-#endif // if defined(Q_OS_LINUX) && defined(SPNAV_FOUND)
 
 #ifdef _USE_3DCONNEXION_SDK
 //windows

--- a/src/Gui/GuiApplicationNativeEventAware.h
+++ b/src/Gui/GuiApplicationNativeEventAware.h
@@ -32,7 +32,7 @@
 
 class QMainWindow;
 
-#if defined(Q_OS_UNIX)
+#if defined(Q_OS_LINUX)
   #include <X11/Xlib.h>
   #undef Bool
   #undef CursorShape
@@ -48,7 +48,7 @@ class QMainWindow;
   #undef False
   #undef True
   #undef Complex
-  #include <functional>
+  #include <xcb/xproto.h>
 
 #elif defined(Q_OS_WIN) && defined(_USE_3DCONNEXION_SDK)
 #include "3Dconnexion/MouseParameters.h"
@@ -114,14 +114,14 @@ namespace Gui
         float convertPrefToSensitivity(int value);
 
 // For X11
-#ifdef Q_OS_UNIX
+#ifdef Q_OS_LINUX
     public:
   #if QT_VERSION >= 0x050000
-        bool xcbEventFilter(void *message, long *result);
+        bool xcbEventFilter(const xcb_client_message_event_t *message);
   #else
         bool x11EventFilter(XEvent *event);
   #endif // if/else QT_VERSION >= 0x050000
-#endif // Q_OS_UNIX
+#endif // Q_OS_LINUX
 
 #ifdef _USE_3DCONNEXION_SDK
 // For Windows

--- a/src/Gui/GuiApplicationNativeEventAware.h
+++ b/src/Gui/GuiApplicationNativeEventAware.h
@@ -32,21 +32,35 @@
 
 class QMainWindow;
 
+#if defined(Q_OS_UNIX)
+  #include <X11/Xlib.h>
+  #undef Bool
+  #undef CursorShape
+  #undef Expose
+  #undef KeyPress
+  #undef KeyRelease
+  #undef FocusIn
+  #undef FocusOut
+  #undef FontChange
+  #undef None
+  #undef Status
+  #undef Unsorted
+  #undef False
+  #undef True
+  #undef Complex
+  #include <functional>
 
-#ifdef _USE_3DCONNEXION_SDK
-
-#ifdef Q_OS_WIN
+#elif defined(Q_OS_WIN) && defined(_USE_3DCONNEXION_SDK)
 #include "3Dconnexion/MouseParameters.h"
 
 #include <vector>
 #include <map>
 
 //#define _WIN32_WINNT 0x0501  //target at least windows XP
-
 #include <Windows.h>
-#endif // Q_OS_WIN
 
-#ifdef Q_OS_MACX
+#elif defined(Q_OS_MACX) && defined(_USE_3DCONNEXION_SDK)
+
 #include <IOKit/IOKitLib.h>
 #include <ConnexionClientAPI.h>
 // Note that InstallConnexionHandlers will be replaced with
@@ -59,9 +73,7 @@ extern UInt16 RegisterConnexionClient(UInt32 signature, UInt8 *name, UInt16 mode
                                       UInt32 mask) __attribute__((weak_import));
 extern void UnregisterConnexionClient(UInt16 clientID) __attribute__((weak_import));
 extern void CleanupConnexionHandlers(void) __attribute__((weak_import));
-#endif // Q_OS_MACX
-
-#endif // _USE_3DCONNEXION_SDK
+#endif // Platform switch
 
 namespace Gui
 {
@@ -82,7 +94,7 @@ namespace Gui
     private:
         EventFilter eventFilter;
     };
-#endif
+#endif // if QT_VERSION >= 0x050000
 
     class GUIApplicationNativeEventAware : public QApplication
     {
@@ -102,10 +114,14 @@ namespace Gui
         float convertPrefToSensitivity(int value);
 
 // For X11
-#ifdef Q_WS_X11
+#ifdef Q_OS_UNIX
     public:
+  #if QT_VERSION >= 0x050000
+        bool xcbEventFilter(void *message, long *result);
+  #else
         bool x11EventFilter(XEvent *event);
-#endif // Q_WS_X11
+  #endif // if/else QT_VERSION >= 0x050000
+#endif // Q_OS_UNIX
 
 #ifdef _USE_3DCONNEXION_SDK
 // For Windows
@@ -168,7 +184,7 @@ namespace Gui
 
 #endif// Q_OS_MACX
 #endif // _USE_3DCONNEXION_SDK
-    };
-}
+    }; // end class GUIApplicationNativeEventAware
+} // end namespace Gui
 
 #endif // GUIAPPLICATIONNATIVEEVENTAWARE_H

--- a/src/Gui/GuiApplicationNativeEventAware.h
+++ b/src/Gui/GuiApplicationNativeEventAware.h
@@ -32,22 +32,8 @@
 
 class QMainWindow;
 
-#if defined(Q_OS_LINUX)
-  #include <X11/Xlib.h>
-  #undef Bool
-  #undef CursorShape
-  #undef Expose
-  #undef KeyPress
-  #undef KeyRelease
-  #undef FocusIn
-  #undef FocusOut
-  #undef FontChange
-  #undef None
-  #undef Status
-  #undef Unsorted
-  #undef False
-  #undef True
-  #undef Complex
+#if defined(Q_OS_LINUX) && QT_VERSION >= 0x050000
+  #include <xcb/xcb.h>
   #include <xcb/xproto.h>
 
 #elif defined(Q_OS_WIN) && defined(_USE_3DCONNEXION_SDK)


### PR DESCRIPTION
The main change here, is that the native event management on Linux switched from XEvent on Qt4 to XCB events with Qt5.  The event caching mechanism we use with Qt4 is problematic with Qt5 - I tried preserving it, but it made the SpaceNavigator very jerky and unresponsive (on a fairly fast machine).  I think that Quarter is accomplishing something similar with regards to event caching anyways, so I've made the XCB handler pass events through directly.  We might need to do some more work in this area, if it's not responsive enough on slower hardware.

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [x] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
