### PR TITLE
Typo and whitespace fixes

### DIFF
--- a/src/Gui/CommandView.cpp
+++ b/src/Gui/CommandView.cpp
@@ -200,7 +200,7 @@ public:
     const char* className() const
     { return "StdCmdFreezeViews"; }
 
-protected: 
+protected:
     virtual void activated(int iMsg);
     virtual bool isActive(void);
     virtual Action * createAction(void);
@@ -297,7 +297,7 @@ void StdCmdFreezeViews::activated(int iMsg)
     }
     else if (iMsg == 4) {
         savedViews = 0;
-        QList<QAction*> acts = pcAction->actions();   
+        QList<QAction*> acts = pcAction->actions();
         for (QList<QAction*>::ConstIterator it = acts.begin()+offset; it != acts.end(); ++it)
             (*it)->setVisible(false);
     }
@@ -322,7 +322,7 @@ void StdCmdFreezeViews::onSaveViews()
     {
         QTextStream str(&file);
         ActionGroup* pcAction = qobject_cast<ActionGroup*>(_pcAction);
-        QList<QAction*> acts = pcAction->actions();      
+        QList<QAction*> acts = pcAction->actions();
         str << "<?xml version='1.0' encoding='utf-8'?>" << endl
             << "<FrozenViews SchemaVersion=\"1\">" << endl;
         str << "  <Views Count=\"" << savedViews <<"\">" << endl;
@@ -354,10 +354,10 @@ void StdCmdFreezeViews::onRestoreViews()
 {
     // Should we clear the already saved views
     if (savedViews > 0) {
-        int ret = QMessageBox::question(getMainWindow(), QObject::tr("Restore views"), 
+        int ret = QMessageBox::question(getMainWindow(), QObject::tr("Restore views"),
             QObject::tr("Importing the restored views would clear the already stored views.\n"
                         "Do you want to continue?"), QMessageBox::Yes|QMessageBox::Default,
-                                                     QMessageBox::No|QMessageBox::Escape); 
+                                                     QMessageBox::No|QMessageBox::Escape);
         if (ret!=QMessageBox::Yes)
             return;
     }
@@ -413,7 +413,7 @@ void StdCmdFreezeViews::onRestoreViews()
         // changed from outside
         int ct = cameras.count();
         ActionGroup* pcAction = qobject_cast<ActionGroup*>(_pcAction);
-        QList<QAction*> acts = pcAction->actions();      
+        QList<QAction*> acts = pcAction->actions();
 
         int numRestoredViews = std::min<int>(ct, acts.size()-offset);
         savedViews = numRestoredViews;
@@ -505,7 +505,7 @@ Action * StdCmdToggleClipPlane::createAction(void)
 
 void StdCmdToggleClipPlane::activated(int iMsg)
 {
-    Q_UNUSED(iMsg); 
+    Q_UNUSED(iMsg);
 #if 0
     View3DInventor* view = qobject_cast<View3DInventor*>(getMainWindow()->activeWindow());
     if (view) {
@@ -786,7 +786,7 @@ StdCmdToggleVisibility::StdCmdToggleVisibility()
 
 void StdCmdToggleVisibility::activated(int iMsg)
 {
-    Q_UNUSED(iMsg); 
+    Q_UNUSED(iMsg);
     // go through all documents
     const std::vector<App::Document*> docs = App::GetApplication().getDocuments();
     for (std::vector<App::Document*>::const_iterator it = docs.begin(); it != docs.end(); ++it) {
@@ -853,7 +853,7 @@ StdCmdToggleSelectability::StdCmdToggleSelectability()
 
 void StdCmdToggleSelectability::activated(int iMsg)
 {
-    Q_UNUSED(iMsg); 
+    Q_UNUSED(iMsg);
     // go through all documents
     const std::vector<App::Document*> docs = App::GetApplication().getDocuments();
     for (std::vector<App::Document*>::const_iterator it = docs.begin(); it != docs.end(); ++it) {
@@ -861,7 +861,7 @@ void StdCmdToggleSelectability::activated(int iMsg)
         std::vector<App::DocumentObject*> sel = Selection().getObjectsOfType
             (App::DocumentObject::getClassTypeId(), (*it)->getName());
 
- 
+
         for (std::vector<App::DocumentObject*>::const_iterator ft=sel.begin();ft!=sel.end();++ft) {
             ViewProvider *pr = pcDoc->getViewProviderByName((*ft)->getNameInDocument());
             if (pr && pr->isDerivedFrom(ViewProviderGeometryObject::getClassTypeId())){
@@ -899,7 +899,7 @@ StdCmdShowSelection::StdCmdShowSelection()
 
 void StdCmdShowSelection::activated(int iMsg)
 {
-    Q_UNUSED(iMsg); 
+    Q_UNUSED(iMsg);
     // go through all documents
     const std::vector<App::Document*> docs = App::GetApplication().getDocuments();
     for (std::vector<App::Document*>::const_iterator it = docs.begin(); it != docs.end(); ++it) {
@@ -935,7 +935,7 @@ StdCmdHideSelection::StdCmdHideSelection()
 
 void StdCmdHideSelection::activated(int iMsg)
 {
-    Q_UNUSED(iMsg); 
+    Q_UNUSED(iMsg);
     // go through all documents
     const std::vector<App::Document*> docs = App::GetApplication().getDocuments();
     for (std::vector<App::Document*>::const_iterator it = docs.begin(); it != docs.end(); ++it) {
@@ -1012,7 +1012,7 @@ StdCmdToggleObjects::StdCmdToggleObjects()
 
 void StdCmdToggleObjects::activated(int iMsg)
 {
-    Q_UNUSED(iMsg); 
+    Q_UNUSED(iMsg);
     // go through active document
     Gui::Document* doc = Application::Instance->activeDocument();
     App::Document* app = doc->getDocument();
@@ -1052,7 +1052,7 @@ StdCmdShowObjects::StdCmdShowObjects()
 
 void StdCmdShowObjects::activated(int iMsg)
 {
-    Q_UNUSED(iMsg); 
+    Q_UNUSED(iMsg);
     // go through active document
     Gui::Document* doc = Application::Instance->activeDocument();
     App::Document* app = doc->getDocument();
@@ -1088,7 +1088,7 @@ StdCmdHideObjects::StdCmdHideObjects()
 
 void StdCmdHideObjects::activated(int iMsg)
 {
-    Q_UNUSED(iMsg); 
+    Q_UNUSED(iMsg);
     // go through active document
     Gui::Document* doc = Application::Instance->activeDocument();
     App::Document* app = doc->getDocument();
@@ -1126,7 +1126,7 @@ StdCmdSetAppearance::StdCmdSetAppearance()
 
 void StdCmdSetAppearance::activated(int iMsg)
 {
-    Q_UNUSED(iMsg); 
+    Q_UNUSED(iMsg);
     static QPointer<QDialog> dlg = 0;
     if (!dlg)
         dlg = new Gui::Dialog::DlgDisplayPropertiesImp(getMainWindow());
@@ -1160,7 +1160,7 @@ StdCmdViewBottom::StdCmdViewBottom()
 
 void StdCmdViewBottom::activated(int iMsg)
 {
-    Q_UNUSED(iMsg); 
+    Q_UNUSED(iMsg);
     doCommand(Command::Gui,"Gui.activeDocument().activeView().viewBottom()");
 }
 
@@ -1184,7 +1184,7 @@ StdCmdViewFront::StdCmdViewFront()
 
 void StdCmdViewFront::activated(int iMsg)
 {
-    Q_UNUSED(iMsg); 
+    Q_UNUSED(iMsg);
     doCommand(Command::Gui,"Gui.activeDocument().activeView().viewFront()");
 }
 
@@ -1208,7 +1208,7 @@ StdCmdViewLeft::StdCmdViewLeft()
 
 void StdCmdViewLeft::activated(int iMsg)
 {
-    Q_UNUSED(iMsg); 
+    Q_UNUSED(iMsg);
     doCommand(Command::Gui,"Gui.activeDocument().activeView().viewLeft()");
 }
 
@@ -1232,7 +1232,7 @@ StdCmdViewRear::StdCmdViewRear()
 
 void StdCmdViewRear::activated(int iMsg)
 {
-    Q_UNUSED(iMsg); 
+    Q_UNUSED(iMsg);
     doCommand(Command::Gui,"Gui.activeDocument().activeView().viewRear()");
 }
 
@@ -1256,7 +1256,7 @@ StdCmdViewRight::StdCmdViewRight()
 
 void StdCmdViewRight::activated(int iMsg)
 {
-    Q_UNUSED(iMsg); 
+    Q_UNUSED(iMsg);
     doCommand(Command::Gui,"Gui.activeDocument().activeView().viewRight()");
 }
 
@@ -1280,7 +1280,7 @@ StdCmdViewTop::StdCmdViewTop()
 
 void StdCmdViewTop::activated(int iMsg)
 {
-    Q_UNUSED(iMsg); 
+    Q_UNUSED(iMsg);
     doCommand(Command::Gui,"Gui.activeDocument().activeView().viewTop()");
 }
 
@@ -1304,7 +1304,7 @@ StdCmdViewAxo::StdCmdViewAxo()
 
 void StdCmdViewAxo::activated(int iMsg)
 {
-    Q_UNUSED(iMsg); 
+    Q_UNUSED(iMsg);
     doCommand(Command::Gui,"Gui.activeDocument().activeView().viewAxonometric()");
 }
 
@@ -1328,7 +1328,7 @@ StdCmdViewRotateLeft::StdCmdViewRotateLeft()
 
 void StdCmdViewRotateLeft::activated(int iMsg)
 {
-    Q_UNUSED(iMsg); 
+    Q_UNUSED(iMsg);
     doCommand(Command::Gui,"Gui.activeDocument().activeView().viewRotateLeft()");
 }
 
@@ -1353,7 +1353,7 @@ StdCmdViewRotateRight::StdCmdViewRotateRight()
 
 void StdCmdViewRotateRight::activated(int iMsg)
 {
-    Q_UNUSED(iMsg); 
+    Q_UNUSED(iMsg);
     doCommand(Command::Gui,"Gui.activeDocument().activeView().viewRotateRight()");
 }
 
@@ -1378,7 +1378,7 @@ StdCmdViewFitAll::StdCmdViewFitAll()
 
 void StdCmdViewFitAll::activated(int iMsg)
 {
-    Q_UNUSED(iMsg); 
+    Q_UNUSED(iMsg);
     //doCommand(Command::Gui,"Gui.activeDocument().activeView().fitAll()");
     doCommand(Command::Gui,"Gui.SendMsgToActiveView(\"ViewFit\")");
 }
@@ -1411,7 +1411,7 @@ StdCmdViewFitSelection::StdCmdViewFitSelection()
 
 void StdCmdViewFitSelection::activated(int iMsg)
 {
-    Q_UNUSED(iMsg); 
+    Q_UNUSED(iMsg);
     //doCommand(Command::Gui,"Gui.activeDocument().activeView().fitAll()");
     doCommand(Command::Gui,"Gui.SendMsgToActiveView(\"ViewSelection\")");
 }
@@ -1441,7 +1441,7 @@ StdViewDock::StdViewDock()
 
 void StdViewDock::activated(int iMsg)
 {
-    Q_UNUSED(iMsg); 
+    Q_UNUSED(iMsg);
 }
 
 bool StdViewDock::isActive(void)
@@ -1469,7 +1469,7 @@ StdViewUndock::StdViewUndock()
 
 void StdViewUndock::activated(int iMsg)
 {
-    Q_UNUSED(iMsg); 
+    Q_UNUSED(iMsg);
 }
 
 bool StdViewUndock::isActive(void)
@@ -1498,7 +1498,7 @@ StdMainFullscreen::StdMainFullscreen()
 
 void StdMainFullscreen::activated(int iMsg)
 {
-    Q_UNUSED(iMsg); 
+    Q_UNUSED(iMsg);
     MDIView* view = getMainWindow()->activeWindow();
 
     if (view)
@@ -1530,7 +1530,7 @@ StdViewFullscreen::StdViewFullscreen()
 
 void StdViewFullscreen::activated(int iMsg)
 {
-    Q_UNUSED(iMsg); 
+    Q_UNUSED(iMsg);
 }
 
 bool StdViewFullscreen::isActive(void)
@@ -1688,7 +1688,7 @@ StdCmdViewVR::StdCmdViewVR()
 
 void StdCmdViewVR::activated(int iMsg)
 {
-    Q_UNUSED(iMsg); 
+    Q_UNUSED(iMsg);
   //doCommand(Command::Gui,"Gui.activeDocument().activeView().fitAll()");
    doCommand(Command::Gui,"Gui.SendMsgToActiveView(\"ViewVR\")");
 }
@@ -1719,7 +1719,7 @@ StdViewScreenShot::StdViewScreenShot()
 
 void StdViewScreenShot::activated(int iMsg)
 {
-    Q_UNUSED(iMsg); 
+    Q_UNUSED(iMsg);
     View3DInventor* view = qobject_cast<View3DInventor*>(getMainWindow()->activeWindow());
     if (view) {
         QStringList formats;
@@ -1801,7 +1801,7 @@ void StdViewScreenShot::activated(int iMsg)
             QString comment = opt->comment();
             if (!comment.isEmpty()) {
                 // Replace newline escape sequence trough '\\n' string to build one big string,
-                // otherwise Python would interpret it as an invalid command. 
+                // otherwise Python would interpret it as an invalid command.
                 // Python does the decoding for us.
                 QStringList lines = comment.split(QLatin1String("\n"), QString::KeepEmptyParts );
                     comment = lines.join(QLatin1String("\\n"));
@@ -1877,7 +1877,7 @@ StdCmdViewCreate::StdCmdViewCreate()
 
 void StdCmdViewCreate::activated(int iMsg)
 {
-    Q_UNUSED(iMsg); 
+    Q_UNUSED(iMsg);
     getActiveGuiDocument()->createView(View3DInventor::getClassTypeId());
     getActiveGuiDocument()->getActiveView()->viewAll();
 }
@@ -1907,7 +1907,7 @@ StdCmdToggleNavigation::StdCmdToggleNavigation()
 
 void StdCmdToggleNavigation::activated(int iMsg)
 {
-    Q_UNUSED(iMsg); 
+    Q_UNUSED(iMsg);
     Gui::MDIView* view = Gui::getMainWindow()->activeWindow();
     if (view && view->isDerivedFrom(Gui::View3DInventor::getClassTypeId())) {
         Gui::View3DInventorViewer* viewer = static_cast<Gui::View3DInventor*>(view)->getViewer();
@@ -2016,7 +2016,7 @@ protected:
         }
     }
 };
-#else 
+#else
 //===========================================================================
 // Std_ViewExample1
 //===========================================================================
@@ -2034,10 +2034,10 @@ StdCmdAxisCross::StdCmdAxisCross()
 
 void StdCmdAxisCross::activated(int iMsg)
 {
-    Q_UNUSED(iMsg); 
+    Q_UNUSED(iMsg);
     Gui::View3DInventor* view = qobject_cast<View3DInventor*>(Gui::getMainWindow()->activeWindow());
     if (view) {
-        if(view->getViewer()->hasAxisCross()== false) 
+        if(view->getViewer()->hasAxisCross()== false)
             doCommand(Command::Gui,"Gui.ActiveDocument.ActiveView.setAxisCross(True)");
         else
             doCommand(Command::Gui,"Gui.ActiveDocument.ActiveView.setAxisCross(False)");
@@ -2060,7 +2060,7 @@ bool StdCmdAxisCross::isActive(void)
 
 }
 
-#endif 
+#endif
 
 //===========================================================================
 // Std_ViewExample1
@@ -2081,7 +2081,7 @@ StdCmdViewExample1::StdCmdViewExample1()
 
 void StdCmdViewExample1::activated(int iMsg)
 {
-    Q_UNUSED(iMsg); 
+    Q_UNUSED(iMsg);
     doCommand(Command::Gui,"Gui.SendMsgToActiveView(\"Example1\")");
 }
 
@@ -2109,7 +2109,7 @@ StdCmdViewExample2::StdCmdViewExample2()
 
 void StdCmdViewExample2::activated(int iMsg)
 {
-    Q_UNUSED(iMsg); 
+    Q_UNUSED(iMsg);
     doCommand(Command::Gui,"Gui.SendMsgToActiveView(\"Example2\")");
 }
 
@@ -2137,7 +2137,7 @@ StdCmdViewExample3::StdCmdViewExample3()
 
 void StdCmdViewExample3::activated(int iMsg)
 {
-    Q_UNUSED(iMsg); 
+    Q_UNUSED(iMsg);
     doCommand(Command::Gui,"Gui.SendMsgToActiveView(\"Example3\")");
 }
 
@@ -2166,7 +2166,7 @@ StdCmdViewIvStereoOff::StdCmdViewIvStereoOff()
 
 void StdCmdViewIvStereoOff::activated(int iMsg)
 {
-    Q_UNUSED(iMsg); 
+    Q_UNUSED(iMsg);
     doCommand(Command::Gui,"Gui.activeDocument().activeView().setStereoType(\"None\")");
 }
 
@@ -2195,7 +2195,7 @@ StdCmdViewIvStereoRedGreen::StdCmdViewIvStereoRedGreen()
 
 void StdCmdViewIvStereoRedGreen::activated(int iMsg)
 {
-    Q_UNUSED(iMsg); 
+    Q_UNUSED(iMsg);
     doCommand(Command::Gui,"Gui.activeDocument().activeView().setStereoType(\"Anaglyph\")");
 }
 
@@ -2223,7 +2223,7 @@ StdCmdViewIvStereoQuadBuff::StdCmdViewIvStereoQuadBuff()
 
 void StdCmdViewIvStereoQuadBuff::activated(int iMsg)
 {
-    Q_UNUSED(iMsg); 
+    Q_UNUSED(iMsg);
     doCommand(Command::Gui,"Gui.activeDocument().activeView().setStereoType(\"QuadBuffer\")");
 }
 
@@ -2251,7 +2251,7 @@ StdCmdViewIvStereoInterleavedRows::StdCmdViewIvStereoInterleavedRows()
 
 void StdCmdViewIvStereoInterleavedRows::activated(int iMsg)
 {
-    Q_UNUSED(iMsg); 
+    Q_UNUSED(iMsg);
     doCommand(Command::Gui,"Gui.activeDocument().activeView().setStereoType(\"InterleavedRows\")");
 }
 
@@ -2279,7 +2279,7 @@ StdCmdViewIvStereoInterleavedColumns::StdCmdViewIvStereoInterleavedColumns()
 
 void StdCmdViewIvStereoInterleavedColumns::activated(int iMsg)
 {
-    Q_UNUSED(iMsg); 
+    Q_UNUSED(iMsg);
     doCommand(Command::Gui,"Gui.activeDocument().activeView().setStereoType(\"InterleavedColumns\")");
 }
 
@@ -2308,7 +2308,7 @@ StdCmdViewIvIssueCamPos::StdCmdViewIvIssueCamPos()
 
 void StdCmdViewIvIssueCamPos::activated(int iMsg)
 {
-    Q_UNUSED(iMsg); 
+    Q_UNUSED(iMsg);
     std::string Temp,Temp2;
     std::string::size_type pos;
 
@@ -2361,7 +2361,7 @@ StdViewZoomIn::StdViewZoomIn()
 
 void StdViewZoomIn::activated(int iMsg)
 {
-    Q_UNUSED(iMsg); 
+    Q_UNUSED(iMsg);
     View3DInventor* view = qobject_cast<View3DInventor*>(getMainWindow()->activeWindow());
     if ( view ) {
         View3DInventorViewer* viewer = view->getViewer();
@@ -2396,7 +2396,7 @@ StdViewZoomOut::StdViewZoomOut()
 
 void StdViewZoomOut::activated(int iMsg)
 {
-    Q_UNUSED(iMsg); 
+    Q_UNUSED(iMsg);
     View3DInventor* view = qobject_cast<View3DInventor*>(getMainWindow()->activeWindow());
     if (view) {
         View3DInventorViewer* viewer = view->getViewer();
@@ -2431,7 +2431,7 @@ StdViewBoxZoom::StdViewBoxZoom()
 
 void StdViewBoxZoom::activated(int iMsg)
 {
-    Q_UNUSED(iMsg); 
+    Q_UNUSED(iMsg);
     View3DInventor* view = qobject_cast<View3DInventor*>(getMainWindow()->activeWindow());
     if ( view ) {
         View3DInventorViewer* viewer = view->getViewer();
@@ -2536,7 +2536,7 @@ static void selectionCallback(void * ud, SoEventCallback * cb)
 
 void StdBoxSelection::activated(int iMsg)
 {
-    Q_UNUSED(iMsg); 
+    Q_UNUSED(iMsg);
     View3DInventor* view = qobject_cast<View3DInventor*>(getMainWindow()->activeWindow());
     if (view) {
         View3DInventorViewer* viewer = view->getViewer();
@@ -2575,7 +2575,7 @@ StdCmdTreeSelection::StdCmdTreeSelection()
 
 void StdCmdTreeSelection::activated(int iMsg)
 {
-    Q_UNUSED(iMsg); 
+    Q_UNUSED(iMsg);
     QList<TreeWidget*> tree = Gui::getMainWindow()->findChildren<TreeWidget*>();
     for (QList<TreeWidget*>::iterator it = tree.begin(); it != tree.end(); ++it) {
         Gui::Document* doc = Gui::Application::Instance->activeDocument();
@@ -2642,7 +2642,7 @@ static const char * cursor_ruler[] = {
 "                         +      "};
 void StdCmdMeasureDistance::activated(int iMsg)
 {
-    Q_UNUSED(iMsg); 
+    Q_UNUSED(iMsg);
     Gui::Document* doc = Gui::Application::Instance->activeDocument();
     Gui::View3DInventor* view = static_cast<Gui::View3DInventor*>(doc->getActiveView());
     if (view) {
@@ -2693,7 +2693,7 @@ StdCmdSceneInspector::StdCmdSceneInspector()
 
 void StdCmdSceneInspector::activated(int iMsg)
 {
-    Q_UNUSED(iMsg); 
+    Q_UNUSED(iMsg);
     Gui::Document* doc = Application::Instance->activeDocument();
     if (doc) {
         static QPointer<Gui::Dialog::DlgInspector> dlg = 0;
@@ -2725,7 +2725,7 @@ StdCmdTextureMapping::StdCmdTextureMapping()
 
 void StdCmdTextureMapping::activated(int iMsg)
 {
-    Q_UNUSED(iMsg); 
+    Q_UNUSED(iMsg);
     Gui::Control().showDialog(new Gui::Dialog::TaskTextureMapping);
 }
 
@@ -2751,7 +2751,7 @@ StdCmdDemoMode::StdCmdDemoMode()
 
 void StdCmdDemoMode::activated(int iMsg)
 {
-    Q_UNUSED(iMsg); 
+    Q_UNUSED(iMsg);
     static QPointer<QDialog> dlg = 0;
     if (!dlg)
         dlg = new Gui::Dialog::DemoMode(getMainWindow());
@@ -2778,7 +2778,7 @@ CmdViewMeasureClearAll::CmdViewMeasureClearAll()
 
 void CmdViewMeasureClearAll::activated(int iMsg)
 {
-    Q_UNUSED(iMsg); 
+    Q_UNUSED(iMsg);
     Gui::View3DInventor *view = dynamic_cast<Gui::View3DInventor*>(Gui::Application::Instance->
         activeDocument()->getActiveView());
     if (!view)
@@ -2808,7 +2808,7 @@ CmdViewMeasureToggleAll::CmdViewMeasureToggleAll()
 
 void CmdViewMeasureToggleAll::activated(int iMsg)
 {
-    Q_UNUSED(iMsg); 
+    Q_UNUSED(iMsg);
     ParameterGrp::handle group = App::GetApplication().GetUserParameter().
     GetGroup("BaseApp")->GetGroup("Preferences")->GetGroup("View");
     bool visibility = group->GetBool("DimensionsVisible", true);
@@ -2836,7 +2836,7 @@ StdTreeSingleDocument::StdTreeSingleDocument()
 
 void StdTreeSingleDocument::activated(int iMsg)
 {
-    Q_UNUSED(iMsg); 
+    Q_UNUSED(iMsg);
 }
 
 //===========================================================================
@@ -2857,7 +2857,7 @@ StdTreeMultiDocument::StdTreeMultiDocument()
 
 void StdTreeMultiDocument::activated(int iMsg)
 {
-    Q_UNUSED(iMsg); 
+    Q_UNUSED(iMsg);
 }
 
 
@@ -2879,7 +2879,7 @@ StdTreeCollapseDocument::StdTreeCollapseDocument()
 
 void StdTreeCollapseDocument::activated(int iMsg)
 {
-    Q_UNUSED(iMsg); 
+    Q_UNUSED(iMsg);
 }
 
 
@@ -2894,9 +2894,9 @@ StdTreeViewDocument::StdTreeViewDocument()
 {
     sGroup        = QT_TR_NOOP("View");
     sMenuText     = QT_TR_NOOP("Document Tree");
-    sToolTipText  = QT_TR_NOOP("Set visiblity of inactive documents in tree view");
+    sToolTipText  = QT_TR_NOOP("Set visibility of inactive documents in tree view");
     sWhatsThis    = "Std_TreeViewDocument";
-    sStatusTip    = QT_TR_NOOP("Set visiblity of inactive documents in tree view");
+    sStatusTip    = QT_TR_NOOP("Set visibility of inactive documents in tree view");
     eType         = 0;
 
     CommandManager &rcCmdMgr = Application::Instance->commandManager();
@@ -3019,4 +3019,3 @@ void CreateViewStdCommands(void)
 }
 
 } // namespace Gui
-

--- a/src/Mod/Path/PathScripts/PathAdaptiveGui.py
+++ b/src/Mod/Path/PathScripts/PathAdaptiveGui.py
@@ -35,7 +35,7 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
         form = QtGui.QWidget()
         layout = QtGui.QVBoxLayout()
 
-        #tool contoller
+        #tool controller
         hlayout = QtGui.QHBoxLayout()
         form.ToolController = QtGui.QComboBox()
         form.ToolControllerLabel=QtGui.QLabel("Tool Controller")
@@ -74,7 +74,7 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
         form.Tolerance.setTickInterval(1)
         form.Tolerance.setValue(10)
         form.Tolerance.setTickPosition(QtGui.QSlider.TicksBelow)
-        form.Tolerance.setToolTip("Influences calculation performace vs stability and accuracy.")
+        form.Tolerance.setToolTip("Influences calculation performance vs stability and accuracy.")
         formLayout.addRow(QtGui.QLabel("Accuracy vs Performance"),form.Tolerance)
 
         #helix angle

--- a/src/Mod/Path/libarea/Adaptive.cpp
+++ b/src/Mod/Path/libarea/Adaptive.cpp
@@ -55,7 +55,7 @@ namespace AdaptivePath {
 	  double l=sqrt(Dx*Dx + dy*dy);
 	  if(l>0.0) {
 	  	pt2.X = long( pt1.X + new_length * Dx/l);
-	  	pt2.Y = long(pt1.Y + new_length * dy/l);	
+	  	pt2.Y = long(pt1.Y + new_length * dy/l);
 		return true;
 	  }
 	  return false;
@@ -312,7 +312,7 @@ namespace AdaptivePath {
 						const IntPoint & s2p1,
 						const IntPoint & s2p2,
 						IntPoint & intersection) {
-		// todo: bounds check for perfomance
+		// TODO: bounds check for performance
 		double S1DX = double(s1p2.X - s1p1.X);
 		double S1DY = double(s1p2.Y - s1p1.Y);
 		double S2DX = double(s2p2.X - s2p1.X);
@@ -342,7 +342,7 @@ namespace AdaptivePath {
 			size_t size=path->size();
 			if(size<2) continue;
 			for(size_t j=0;j<size;j++) {
-				// todo: box check for perfomance
+				// TODO: box check for performance
 				const IntPoint * pp1 = &path->at(j>0?j-1:size-1);
 				const IntPoint * pp2 = &path->at(j);
 				double LDY = double(p2.Y - p1.Y);
@@ -434,7 +434,7 @@ namespace AdaptivePath {
 	}
 
 
-		// finds interim points not neccesarily on the same keeptooldown linking path
+		// finds interim points not necessarily on the same keeptooldown linking path
 	bool FindClosestClearPoints(const Paths & paths,IntPoint p1,IntPoint p2, double distanceLmit, IntPoint &interim1,IntPoint &interim2) {
 		size_t clpPathIndex;
 		size_t clpSegmentIndex1;
@@ -626,7 +626,7 @@ namespace AdaptivePath {
 
 			double interpolateAngle(double targetArea) {
 				std::size_t size = areas.size();
-				if(size<2 || targetArea>areas[size-1]) return MIN_ANGLE; //max engage angle - convinient value to initially measure cut area
+				if(size<2 || targetArea>areas[size-1]) return MIN_ANGLE; //max engage angle - convenient value to initially measure cut area
 				if(targetArea<areas[0]) return MAX_ANGLE; // min engage angle
 
 				for(size_t i=1;i<size;i++) {
@@ -764,7 +764,7 @@ namespace AdaptivePath {
 						state.passes++;
 						if(state.passes>=maxPases) {
 							Perf_NextEngagePoint.Stop();
-							return false; // nothin more to cut
+							return false; // nothing more to cut
 						}
 					 prevArea=0;
 					}
@@ -887,7 +887,7 @@ namespace AdaptivePath {
 				}
 				curPtIndex++; if(curPtIndex>=size) curPtIndex=0;
 			}
-			if(!found) continue; // try anohter path
+			if(!found) continue; // try another path
 
 			// step 2: iterate throuh path from starting point and find the part of the path inside the c2
 			size_t prevPtIndex = curPtIndex;
@@ -1007,7 +1007,7 @@ namespace AdaptivePath {
 
 						// there should be intersection with C2
 						if(Line2CircleIntersect(c2,toolRadiusScaled,segPoint,scanPoint,inters)) {
-							if(inters.size()>1) {										
+							if(inters.size()>1) {
 								intersC2.X = long(inters[1].X);
 								intersC2.Y = long(inters[1].Y);
 							} else {
@@ -1019,7 +1019,7 @@ namespace AdaptivePath {
 						}
 
 						if(Line2CircleIntersect(c1,toolRadiusScaled,segPoint,scanPoint,inters)) {
-								if(inters.size()>1) {											
+								if(inters.size()>1) {
 									intersC1.X = long(inters[1].X);
 									intersC1.Y = long(inters[1].Y);
 								} else {
@@ -1049,7 +1049,7 @@ namespace AdaptivePath {
 			{
 				// old way of calculating cut area based on polygon slipping
 				// used in case when there are multiple intersections of tool with cleared poly (very rare case, but important)
-				// 1. find differene beween old and new tool shape
+				// 1. find differene between old and new tool shape
 				Path oldTool;
 				Path newTool;
 				TranslatePath(toolGeometry,oldTool,c1);
@@ -1135,7 +1135,7 @@ namespace AdaptivePath {
 		Paths toolGeometryPaths;
 		clipof.Execute(toolGeometryPaths,toolRadiusScaled);
 		toolGeometry=toolGeometryPaths[0];
-		//calculate referece area
+		//calculate reference area
 		Path slotCut;
 		TranslatePath(toolGeometryPaths[0],slotCut,IntPoint(toolRadiusScaled/2,0));
 		clip.Clear();
@@ -1832,7 +1832,7 @@ namespace AdaptivePath {
 			angleHistory.clear();
 
 			// append a new path to progress info paths
-			if(progressPaths.size()==0) {						
+			if(progressPaths.size()==0) {
 				progressPaths.push_back(TPath());
 			} else {
 				// append new path if previous not empty
@@ -2003,7 +2003,7 @@ namespace AdaptivePath {
 
 					// append to toolpaths
 					if(passToolPath.size()==0) {
-						// in outside entry first successfull cut defines the helix center and start point
+						// in outside entry first successful cut defines the helix center and start point
 						if(output.AdaptivePaths.size()==0 && outsideEntry) {
 								entryPoint=toolPos;
 								output.HelixCenterPoint.first = double(entryPoint.X)/scaleFactor;


### PR DESCRIPTION
Found via `codespell -q 3 -I ../fc-word-whitelist.txt --skip=".git,*.ts,*.po,./src/3rdParty,./src/Mod/Assembly/App/opendcm,./src/zipios++" -L "entires,fle,actuall"`
