### PR TITLE
Path: Return self in addProperty for interface compliance.

### DIFF
--- a/src/Mod/Path/PathScripts/PathSetupSheetOpPrototype.py
+++ b/src/Mod/Path/PathScripts/PathSetupSheetOpPrototype.py
@@ -171,6 +171,7 @@ class OpPrototype(object):
     def addProperty(self, typeString, name, category, info = None):
         prop = self.PropertyType[typeString](name, typeString, category, info)
         self.properties[name] = prop
+        return self
 
     def setEditorMode(self, name, mode):
         self.properties[name].setEditorMode(mode)


### PR DESCRIPTION
The `addProperty` member for the Path operation prototype currently breaks if someone follows the paradigm of setting initial values outlined on the wiki:
https://www.freecadweb.org/wiki/Scripted_objects