### PR TITLE
Respect Qt file dialog flag in Gui::FileChooser

### DIFF
--- a/src/Gui/FileDialog.cpp
+++ b/src/Gui/FileDialog.cpp
@@ -670,11 +670,19 @@ void FileChooser::chooseFile()
         prechosenDirectory = FileDialog::getWorkingDirectory();
     }
 
+#if defined(USE_QT_FILEDIALOG)
+    QFileDialog::Options dlgOpt = QFileDialog::DontUseNativeDialog;
+#else
+    QFileDialog::Options dlgOpt;
+#endif
+
     QString fn;
-    if ( mode() == File )
-        fn = QFileDialog::getOpenFileName( this, tr( "Select a file" ), prechosenDirectory, _filter );
-    else
-        fn = QFileDialog::getExistingDirectory( this, tr( "Select a directory" ), prechosenDirectory );
+    if ( mode() == File ) {
+        fn = QFileDialog::getOpenFileName( this, tr( "Select a file" ), prechosenDirectory, _filter,0,dlgOpt );
+    } else {
+        QFileDialog::Options option = QFileDialog::ShowDirsOnly | dlgOpt;
+        fn = QFileDialog::getExistingDirectory( this, tr( "Select a directory" ), prechosenDirectory,option );
+    }
 
     if (!fn.isEmpty()) {
         fn = QDir::fromNativeSeparators(fn);
@@ -745,6 +753,7 @@ QString FileChooser::buttonText() const
 {
     return button->text();
 }
+
 
 // ----------------------------------------------------------------------
 

--- a/src/Tools/plugins/widget/customwidgets.cpp
+++ b/src/Tools/plugins/widget/customwidgets.cpp
@@ -175,13 +175,15 @@ void FileChooser::setFileName( const QString &fn )
 
 void FileChooser::chooseFile()
 {
+    QFileDialog::Options dlgOpt = QFileDialog::DontUseNativeDialog;
     QString fn;
-    if ( mode() == File )
+    if ( mode() == File ) {
         fn = QFileDialog::getOpenFileName(this, tr("Select a file"),
-        lineEdit->text(), _filter);
-    else
-        fn = QFileDialog::getExistingDirectory(this, tr("Select a directory"),
-        lineEdit->text() );
+        lineEdit->text(), _filter,0,dlgOpt);
+    } else {
+        QFileDialog::Options option = QFileDialog::ShowDirsOnly | dlgOpt;
+        fn = QFileDialog::getExistingDirectory( this, tr( "Select a directory" ), lineEdit->text(),option );
+    }
 
     if (!fn.isEmpty()) {
         lineEdit->setText(fn);


### PR DESCRIPTION
This PR adds conditional logic for compile flag USE_QT_FILEDIALOG to Gui::FileChooser.  Please merge.
wf


Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
