### PR TITLE
Make Part_Measure_Clear_All icon more intuitive

### DIFF
--- a/src/Gui/Icons/Part_Measure_Clear_All.svg
+++ b/src/Gui/Icons/Part_Measure_Clear_All.svg
@@ -15,7 +15,7 @@
    height="64px"
    id="svg2943"
    sodipodi:version="0.32"
-   inkscape:version="0.48.5 r10040"
+   inkscape:version="0.92.1 r15371"
    sodipodi:docname="Part_Measure_Clear_All.svg"
    inkscape:output_extension="org.inkscape.output.svg.inkscape"
    version="1.1">
@@ -439,17 +439,17 @@
      borderopacity="1.0"
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
-     inkscape:zoom="3.9921875"
-     inkscape:cx="130.50981"
-     inkscape:cy="34.047321"
+     inkscape:zoom="1.4114514"
+     inkscape:cx="2.5629415"
+     inkscape:cy="48.271732"
      inkscape:current-layer="g3939"
      showgrid="true"
      inkscape:document-units="px"
      inkscape:grid-bbox="true"
-     inkscape:window-width="1600"
-     inkscape:window-height="837"
-     inkscape:window-x="0"
-     inkscape:window-y="27"
+     inkscape:window-width="1366"
+     inkscape:window-height="705"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
      inkscape:window-maximized="1">
     <inkscape:grid
        type="xygrid"
@@ -537,7 +537,7 @@
                style="fill:url(#linearGradient3198);fill-opacity:1;stroke:#babdb6;stroke-width:2.37868047;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
             <path
                transform="matrix(-0.26138323,0.99529292,-1.2077963,0.35456154,487.87344,60.853785)"
-               d="m -78,39 c 0,8.284271 -6.715729,15 -15,15 -8.28427,0 -15,-6.715729 -15,-15 0,-8.284271 6.71573,-15 15,-15 8.284271,0 15,6.715729 15,15 z"
+               d="m -78,39 a 15,15 0 0 1 -15,15 15,15 0 0 1 -15,-15 15,15 0 0 1 15,-15 15,15 0 0 1 15,15 z"
                sodipodi:ry="15"
                sodipodi:rx="15"
                sodipodi:cy="39"
@@ -570,57 +570,55 @@
                d="m 433.23844,39.690755 -4.92782,1.44661 -4.77913,-5.48624 4.92781,-1.44661 z"
                style="fill:#d3d7cf;stroke:#2e3436;stroke-width:2.37868047;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1" />
           </g>
-          <rect
-             transform="matrix(-0.71328835,0.7008707,0.71328836,0.70087068,0,0)"
-             y="375.18082"
-             x="-253.6333"
-             height="4.0355906"
-             width="16.827255"
-             id="rect3933"
-             style="fill:#d3d7cf;fill-opacity:1;stroke:#2e3436;stroke-width:2.37886381;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.89999998;stroke-opacity:1;stroke-dasharray:none" />
+          <g
+             id="g3890-0"
+             transform="matrix(-0.02477995,1.1554758,-1.231953,0.36165297,539.67526,-29.301855)">
+            <rect
+               transform="matrix(-0.70710678,0.70710678,0.70710678,0.70710678,0,0)"
+               ry="2"
+               y="110.13708"
+               x="-19.97056"
+               height="6"
+               width="36.76955"
+               id="rect3839-0"
+               style="fill:#cc0000;fill-opacity:1;stroke:#280000;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+            <rect
+               transform="rotate(45)"
+               ry="2"
+               y="-4.5857863"
+               x="94.752312"
+               height="6"
+               width="36.76955"
+               id="rect3839-5-8"
+               style="fill:#cc0000;fill-opacity:1;stroke:#280000;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+            <rect
+               transform="rotate(-45)"
+               ry="0"
+               y="112.14682"
+               x="-4.8928065"
+               height="2"
+               width="13"
+               id="rect3888-0"
+               style="fill:#cc0000;stroke:#cc0000;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+          </g>
           <path
-             style="fill:#ffffff;stroke:#302b00;stroke-width:2.37868023000000006;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1"
-             d="m 477.31119,113.47336 5.38951,17.33174 -17.6928,-5.799 -2.03543,-4 10.17717,-10 z"
-             id="path3969"
+             style="fill:none;stroke:#ef2929;stroke-width:2.37868047;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+             d="M 438.93871,90.258929 427.41855,82.734492"
+             id="path3922"
              inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cccccc" />
+             sodipodi:nodetypes="cc" />
           <path
-             style="fill:#fce94f;stroke:#302b00;stroke-width:2.37868023000000006;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1"
-             d="m 451.40433,88.017513 -4.00089,3.931243 25.18722,24.748734 c 0.002,-3.68844 0.56098,-3.37983 4.72053,-3.22413 z"
-             id="path3843-5-6"
+             style="fill:none;stroke:#ef2929;stroke-width:2.37868047;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+             d="M 455.30447,101.05805 443.70535,93.481696"
+             id="path3922-2"
              inkscape:connector-curvature="0"
-             sodipodi:nodetypes="ccccc" />
+             sodipodi:nodetypes="cc" />
           <path
-             style="fill:#edd400;stroke:#302b00;stroke-width:2.37868023000000006;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1"
-             d="m 447.40344,91.948756 -4.0009,3.931244 25.18723,24.74874 c 0.0722,-3.7572 0.002,-3.68845 4.00089,-3.93125 z"
-             id="path3843-5-6-2"
+             style="fill:none;stroke:#ef2929;stroke-width:2.37868047;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
+             d="m 455.92254,75.970929 -1.78201,-1.17183"
+             id="path3922-7"
              inkscape:connector-curvature="0"
-             sodipodi:nodetypes="ccccc" />
-          <path
-             style="fill:#c4a000;stroke:#302b00;stroke-width:2.37868023000000006;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1"
-             d="m 443.40254,95.880002 -4.00089,3.93124 25.18722,24.748738 c 0.56118,-3.37983 0.0722,-3.75719 4.0009,-3.93124 z"
-             id="path3843-5-6-9"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="ccccc" />
-          <path
-             style="fill:#271903;stroke:#271903;stroke-width:1.18934011px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1"
-             d="m 479.82216,122.31981 c -3.19428,0.31024 -5.19473,2.27586 -5.75708,5.65686 l 8.63562,2.82843 -2.87854,-8.48529 0,0"
-             id="path3971"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="ccccc" />
-          <rect
-             transform="matrix(-0.71328835,0.7008707,0.71328836,0.70087068,0,0)"
-             y="369.12744"
-             x="-253.6333"
-             height="6.0533857"
-             width="16.827255"
-             id="rect3935"
-             style="fill:#cc0000;fill-opacity:1;stroke:#280000;stroke-width:2.37886381;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.89999998;stroke-opacity:1;stroke-dasharray:none" />
-          <path
-             inkscape:connector-curvature="0"
-             id="path3937"
-             d="m 445.80571,86.447596 -2.1589,-2.121316 -9.00202,8.845293"
-             style="fill:none;stroke:#ef2929;stroke-width:2.37868047;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+             sodipodi:nodetypes="cc" />
         </g>
       </g>
     </g>


### PR DESCRIPTION
Previously the icon was made up of a tape measure and a pencil. But pencil
icons normally mean editing something. It was not clear that this icon was
meant to delete all the measurements.

This commit replaces the pencil with a red X to make clear it deletes
something. The X was taken because existing delte icons in FreeCAD also
use a red X.
 - https://www.freecadweb.org/wiki/File:Mesh_Remove_Components.svg
 - https://www.freecadweb.org/wiki/File:OpenSCAD_RemoveSubtree.svg
 - https://www.freecadweb.org/wiki/File:Delete.svg

The forum discussion can be found here: https://forum.freecadweb.org/viewtopic.php?f=34&t=31062
A image showing the new icon next to the existing ones can be seen in the forum topic as well.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
(https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
