### PR TITLE
Misc. typo fixes

### DIFF
--- a/src/Gui/ProgressBar.cpp
+++ b/src/Gui/ProgressBar.cpp
@@ -287,7 +287,7 @@ void Sequencer::resetData()
     }
     else {
         d->bar->reset();
-        // Note: Under Qt 4.1.4 this forces to run QWindowsStyle::eventFilter() twice 
+        // Note: Under Qt 4.1.4 this forces to run QWindowsStyle::eventFilter() twice
         // handling the same event thus a warning is printed. Possibly, this is a bug
         // in Qt. The message is QEventDispatcherUNIX::unregisterTimer: invalid argument.
         d->bar->hide();
@@ -398,7 +398,7 @@ void ProgressBar::delayedShow()
 bool ProgressBar::canAbort() const
 {
     int ret = QMessageBox::question(getMainWindow(),tr("Aborting"),
-    tr("Do you really want to abort the operation?"),  QMessageBox::Yes, 
+    tr("Do you really want to abort the operation?"),  QMessageBox::Yes,
     QMessageBox::No|QMessageBox::Default);
 
     return (ret == QMessageBox::Yes) ? true : false;
@@ -464,7 +464,7 @@ bool ProgressBar::eventFilter(QObject* o, QEvent* e)
                 return true;
             }   break;
 
-        // ignore alle these events
+        // ignore all these events
         case QEvent::KeyRelease:
         case QEvent::Enter:
         case QEvent::Leave:
@@ -473,15 +473,15 @@ bool ProgressBar::eventFilter(QObject* o, QEvent* e)
             {
                 return true;
             }   break;
-      
-        // special case if the main window's close button was pressed 
+
+        // special case if the main window's close button was pressed
         case QEvent::Close:
             {
                 // avoid to exit while app is working
                 // note: all other widget types are allowed to be closed anyway
                 if (o == getMainWindow()) {
                     e->ignore();
-                    return true; 
+                    return true;
                 }
             }   break;
 

--- a/src/Mod/Assembly/Gui/TaskAssemblyConstraints.cpp
+++ b/src/Mod/Assembly/Gui/TaskAssemblyConstraints.cpp
@@ -460,7 +460,7 @@ void TaskAssemblyConstraints::setPossibleOptions() {
     //                }
     //            };
 
-    //            if(isCombination(g1,g2, dcm::geometry::line, dcm::geometry::plane)  ||
+    //            if(isCombination(g1,g2,easier dcm::geometry::line, dcm::geometry::plane)  ||
     //                    isCombination(g1,g2, dcm::geometry::plane, dcm::geometry::cylinder)) {
     //                ui->perpendicular->setEnabled(true);
 
@@ -486,7 +486,7 @@ void TaskAssemblyConstraints::setPossibleOptions() {
 
 void TaskAssemblyConstraints::setPossibleConstraints()
 {
-    ////diasble all constraints for easyer enabling
+    ////diasble all constraints for easier enabling
     //ui->fix->setEnabled(false);
     //ui->distance->setEnabled(false);
     //ui->orientation->setEnabled(false);
@@ -632,4 +632,3 @@ bool TaskAssemblyConstraints::isCombination(boost::shared_ptr<Geometry3D> g1, bo
 
 
 #include "moc_TaskAssemblyConstraints.cpp"
-

--- a/src/Mod/Assembly/Gui/TaskAssemblyConstraints.cpp
+++ b/src/Mod/Assembly/Gui/TaskAssemblyConstraints.cpp
@@ -460,7 +460,7 @@ void TaskAssemblyConstraints::setPossibleOptions() {
     //                }
     //            };
 
-    //            if(isCombination(g1,g2,easier dcm::geometry::line, dcm::geometry::plane)  ||
+    //            if(isCombination(g1,g2, dcm::geometry::line, dcm::geometry::plane)  ||
     //                    isCombination(g1,g2, dcm::geometry::plane, dcm::geometry::cylinder)) {
     //                ui->perpendicular->setEnabled(true);
 

--- a/src/Mod/Sandbox/exportDRAWEXE.py
+++ b/src/Mod/Sandbox/exportDRAWEXE.py
@@ -61,7 +61,7 @@ def f2s(n,angle=False,axis=False):
                 return s
 
 def ax2_xdir(normal):
-    #adaped from gp_Ax2.ccc (c) OpenCascade SAS LGPL 2.1+
+    #adapted from gp_Ax2.ccc (c) OpenCascade SAS LGPL 2.1+
 
     xa=abs(normal.x)
     ya=abs(normal.y)
@@ -211,7 +211,7 @@ def isDraftWire(ob):
         if isinstance(ob.Proxy,Draft._Wire):
             #only return true if we support all options
             #"Closed" append last point at the end
-            #"MakeFace" 
+            #"MakeFace"
             #"Points" data we need
             # the usage of 'start' and 'end' is not clear
             if ob.Base is None and ob.Tool is None and \

--- a/src/Mod/TechDraw/Templates/A0_Landscape_ISO7200_Pep.svg
+++ b/src/Mod/TechDraw/Templates/A0_Landscape_ISO7200_Pep.svg
@@ -153,11 +153,11 @@
   </g>
   <g id="titleblock-structure" style="fill:none;stroke:#000000;stroke-width:0.35;stroke-linecap:miter;stroke-miterlimit:4">
     <rect width="140" height="34" x="1035" y="793" />
-		<path d="m 1035,801 h 140" /> <!-- upper horizontal Separator Titelblock -->
+		<path d="m 1035,801 h 140" /> <!-- upper horizontal Separator Titleblock -->
 		<path d="m 1035,819 h 87" /> <!-- lower horizontal Separator Document-Type -->
 		<path d="m 1035,823 h 140" /> <!-- lower horizontal Separator Copyright -->
 		<path d="m 1080,793 v 8" /> <!-- Separator Author / Owner -->
-		<path d="m 1122,793 v 30" /> <!-- Separator Titel / Liste RH -->
+		<path d="m 1122,793 v 30" /> <!-- Separator Title / Liste RH -->
 		<path d="m 1152,793 v 8" /> <!-- Separator Scale / Sheet -->
 		<path d="m 1122,809 h 53" /> <!-- Separator Part / Drawing-Nr -->
 		<path d="m 1122,815 h 53" /> <!-- Separator DRW-Info / Revision -->

--- a/src/Mod/TechDraw/Templates/A1_Landscape_ISO7200_Pep.svg
+++ b/src/Mod/TechDraw/Templates/A1_Landscape_ISO7200_Pep.svg
@@ -113,11 +113,11 @@
   </g>
   <g id="titleblock-structure" style="fill:none;stroke:#000000;stroke-width:0.35;stroke-linecap:miter;stroke-miterlimit:4">
     <rect width="140" height="34" x="687" y="546" />
-		<path d="m 687,554 h 140" /> <!-- upper horizontal Separator Titelblock -->
+		<path d="m 687,554 h 140" /> <!-- upper horizontal Separator Titleblock -->
 		<path d="m 687,572 h 87" /> <!-- lower horizontal Separator Document-Type -->
 		<path d="m 687,576 h 140" /> <!-- lower horizontal Separator Copyright -->
 		<path d="m 732,546 v 8" /> <!-- Separator Author / Owner -->
-		<path d="m 774,546 v 30" /> <!-- Separator Titel / Liste RH -->
+		<path d="m 774,546 v 30" /> <!-- Separator Title / Liste RH -->
 		<path d="m 804,546 v 8" /> <!-- Separator Scale / Sheet -->
 		<path d="m 774,562 h 53" /> <!-- Separator Part / Drawing-Nr -->
 		<path d="m 774,568 h 53" /> <!-- Separator DRW-Info / Revision -->

--- a/src/Mod/TechDraw/Templates/A2_Landscape_ISO7200_Pep.svg
+++ b/src/Mod/TechDraw/Templates/A2_Landscape_ISO7200_Pep.svg
@@ -85,11 +85,11 @@
   </g>
     <g id="titleblock-structure" style="fill:none;stroke:#000000;stroke-width:0.35;stroke-linecap:miter;stroke-miterlimit:4">
     <rect width="140" height="34" x="440" y="372" />
-		<path d="m 440,380 h 140" /> <!-- upper horizontal Separator Titelblock -->
+		<path d="m 440,380 h 140" /> <!-- upper horizontal Separator Titleblock -->
 		<path d="m 440,398 h 87" /> <!-- lower horizontal Separator Document-Type -->
 		<path d="m 440,402 h 140" /> <!-- lower horizontal Separator Copyright -->
 		<path d="m 485,372 v 8" /> <!-- Separator Author / Owner -->
-		<path d="m 527,372 v 30" /> <!-- Separator Titel / Liste RH -->
+		<path d="m 527,372 v 30" /> <!-- Separator Title / Liste RH -->
 		<path d="m 557,372 v 8" /> <!-- Separator Scale / Sheet -->
 		<path d="m 527,388 h 53" /> <!-- Separator Part / Drawing-Nr -->
 		<path d="m 527,394 h 53" /> <!-- Separator DRW-Info / Revision -->

--- a/src/Mod/TechDraw/Templates/A3_Landscape_ISO7200_Pep.svg
+++ b/src/Mod/TechDraw/Templates/A3_Landscape_ISO7200_Pep.svg
@@ -65,11 +65,11 @@
   </g>
     <g id="titleblock-structure" style="fill:none;stroke:#000000;stroke-width:0.35;stroke-linecap:miter;stroke-miterlimit:4">
     <rect width="140" height="34" x="269" y="252" />
-		<path d="m 269,260 h 140" /> <!-- upper horizontal Separator Titelblock -->
+		<path d="m 269,260 h 140" /> <!-- upper horizontal Separator Titleblock -->
 		<path d="m 269,278 h 87" /> <!-- lower horizontal Separator Document-Type -->
 		<path d="m 269,282 h 140" /> <!-- lower horizontal Separator Copyright -->
 		<path d="m 314,252 v 8" /> <!-- Separator Author / Owner -->
-		<path d="m 356,252 v 30" /> <!-- Separator Titel / Liste RH -->
+		<path d="m 356,252 v 30" /> <!-- Separator Title / Liste RH -->
 		<path d="m 386,252 v 8" /> <!-- Separator Scale / Sheet -->
 		<path d="m 356,268 h 53" /> <!-- Separator Part / Drawing-Nr -->
 		<path d="m 356,274 h 53" /> <!-- Separator DRW-Info / Revision -->

--- a/src/Mod/TechDraw/Templates/A4_Landscape_ISO7200_Pep.svg
+++ b/src/Mod/TechDraw/Templates/A4_Landscape_ISO7200_Pep.svg
@@ -8,11 +8,11 @@
   </g>
   <g id="titleblock-structure" style="fill:none;stroke:#000000;stroke-width:0.35;stroke-linecap:miter;stroke-miterlimit:4">
 		<rect width="140" height="34" x="150" y="169" />
-		<path d="m 150,177 h 140" /> <!-- upper horizontal Separator Titelblock -->
+		<path d="m 150,177 h 140" /> <!-- upper horizontal Separator Titleblock -->
 		<path d="m 150,195 h 87" /> <!-- lower horizontal Separator Document-Type -->
 		<path d="m 150,199 h 140" /> <!-- lower horizontal Separator Copyright -->
 		<path d="m 195,169 v 8" /> <!-- Separator Author / Owner -->
-		<path d="m 237,169 v 30" /> <!-- Separator Titel / Liste RH -->
+		<path d="m 237,169 v 30" /> <!-- Separator Title / Liste RH -->
 		<path d="m 267,169 v 8" /> <!-- Separator Scale / Sheet -->
 		<path d="m 237,185 h 53" /> <!-- Separator Part / Drawing-Nr -->
 		<path d="m 237,191 h 53" /> <!-- Separator DRW-Info / Revision -->

--- a/src/Mod/TechDraw/Templates/A4_Portrait_ISO7200Pep.svg
+++ b/src/Mod/TechDraw/Templates/A4_Portrait_ISO7200Pep.svg
@@ -8,11 +8,11 @@
 	</g>
   <g id="titleblock-structure" style="fill:none;stroke:#000000;stroke-width:0.35;stroke-linecap:miter;stroke-miterlimit:4">
     <rect width="140" height="34" x="63" y="256" />
-		<path d="m 63,264 h 140" /> <!-- upper horizontal Separator Titelblock -->
+		<path d="m 63,264 h 140" /> <!-- upper horizontal Separator Titleblock -->
 		<path d="m 63,282 h 87" /> <!-- lower horizontal Separator Document-Type -->
 		<path d="m 63,286 h 140" /> <!-- lower horizontal Separator Copyright -->
 		<path d="m 108,256 v 8" /> <!-- Separator Author / Owner -->
-		<path d="m 150,256 v 30" /> <!-- Separator Titel / Liste RH -->
+		<path d="m 150,256 v 30" /> <!-- Separator Title / Liste RH -->
 		<path d="m 180,256 v 8" /> <!-- Separator Scale / Sheet -->
 		<path d="m 150,272 h 53" /> <!-- Separator Part / Drawing-Nr -->
 		<path d="m 150,278 h 53" /> <!-- Separator DRW-Info / Revision -->

--- a/src/Tools/fcbt/DistBin.py
+++ b/src/Tools/fcbt/DistBin.py
@@ -6,7 +6,7 @@ import os,sys
 
 import DistTools, FileTools
 
-# line separator 
+# line separator
 ls = os.linesep
 # path separator
 ps = os.pathsep
@@ -26,13 +26,13 @@ if (DistTools.EnsureDir(DistDir+DistBin) == 1):
     raise "Dist path already there!!"
 
 #====================================================================
-# copy src 
+# copy src
 sys.stdout.write( 'Copy src Tree ...\n')
 DistTools.EnsureDir(DistDir+DistBin+'/src')
 FileTools.cpallWithFilter('../../src',DistDir+DistBin+'/src',FileTools.SetUpFilter(DistTools.SrcFilter))
 
 #====================================================================
-# copy bin and lib 
+# copy bin and lib
 sys.stdout.write( 'Copy bin and lib Tree ...\n')
 DistTools.EnsureDir(DistDir+DistBin+'/bin')
 FileTools.cpallWithFilter('../../bin',DistDir+DistBin+'/bin',FileTools.SetUpFilter(DistTools.BinFilter))
@@ -55,7 +55,7 @@ FileTools.cpallWithFilter('../../src/Mod',DistDir+DistBin+'/Mod',FileTools.SetUp
 #DistTools.cpfile("../Tools/BuildTool.py",DistDir+DistBin+"/BuildTool.py")
 
 #====================================================================
-# ziping a archiv
+# zipping an archive
 #os.popen("rar.exe a "+DistDir+DistBin+".rar "+ DistDir+DistBin)
 os.popen("7z a -tzip "+DistDir+DistBin+".zip "+ DistDir+DistBin+ " -mx9")
 


### PR DESCRIPTION
Found via `codespell -q 3 --skip="*.po,*.ts,./.git,./src/3rdParty,./src/CXX,./src/zipios++,./src/Mod/Assembly/App/opendcm" -I ../fc-word-whitelist.txt`