### PR TITLE
FeaturePython set edit default handling

### DIFF
--- a/src/Gui/ViewProviderPythonFeature.cpp
+++ b/src/Gui/ViewProviderPythonFeature.cpp
@@ -433,6 +433,15 @@ ViewProviderPythonFeatureImp::setEdit(int ModNum)
                     args.setItem(0, Py::Int(ModNum));
                     Py::Boolean ok(method.apply(args));
                     bool value = (bool)ok;
+                    if (value &&
+                        (ViewProvider::EditMode::Transform == ModNum ||
+                         ViewProvider::EditMode::Cutting == ModNum ||
+                         ViewProvider::EditMode::Color == ModNum)) {
+                      // returning NotImplemented for the system edit modes if the receiver returns True
+                      // so python features can implement their own edit dialog and yet still allow for
+                      // the transformation tool / color assignment to work
+                        return NotImplemented;
+                    }
                     return value ? Accepted : Rejected;
                 }
                 else {
@@ -442,6 +451,15 @@ ViewProviderPythonFeatureImp::setEdit(int ModNum)
                     args.setItem(1, Py::Int(ModNum));
                     Py::Boolean ok(method.apply(args));
                     bool value = (bool)ok;
+                    if (value &&
+                        (ViewProvider::EditMode::Transform == ModNum ||
+                         ViewProvider::EditMode::Cutting == ModNum ||
+                         ViewProvider::EditMode::Color == ModNum)) {
+                      // returning NotImplemented for the system edit modes if the receiver returns True
+                      // so python features can implement their own edit dialog and yet still allow for
+                      // the transformation tool / color assignment to work
+                        return NotImplemented;
+                    }
                     return value ? Accepted : Rejected;
                 }
             }

--- a/src/Mod/Path/PathScripts/PathIconViewProvider.py
+++ b/src/Mod/Path/PathScripts/PathIconViewProvider.py
@@ -42,6 +42,7 @@ class ViewProvider(object):
 
     def __init__(self, vobj, icon):
         self.icon = icon
+        self.attach(vobj)
         vobj.Proxy = self
 
     def attach(self, vobj):
@@ -88,12 +89,12 @@ def Attach(vobj, name):
     '''Attach(vobj, name) ... attach the appropriate view provider to the view object.
     If no view provider was registered for the given name a default IconViewProvider is created.'''
 
-    PathLog.track(name)
+    PathLog.track(vobj.Object.Label, name)
     global _factory
     for key,value in PathUtil.keyValueIter(_factory):
         if key == name:
             return value(vobj, name)
-    PathLog.track(name, 'PathIconViewProvider')
+    PathLog.track(vobj.Object.Label, name, 'PathIconViewProvider')
     return ViewProvider(vobj, name)
 
 def RegisterViewProvider(name, provider):

--- a/src/Mod/Path/PathScripts/PathIconViewProvider.py
+++ b/src/Mod/Path/PathScripts/PathIconViewProvider.py
@@ -75,13 +75,21 @@ class ViewProvider(object):
             callback = getattr(mod, self.editCallback)
             callback(self.obj, self.vobj, edit)
 
-    def setEdit(self, vobj, mode=0):
+    def setEdit(self, vobj=None, mode=0):
         if 0 == mode:
             self._onEditCallback(True)
         return True
 
     def unsetEdit(self, arg1, arg2):
         self._onEditCallback(False)
+
+    def setupContextMenu(self, vobj, menu):
+        PathLog.track()
+        from PySide import QtCore, QtGui
+        edit = QtCore.QCoreApplication.translate('Path', 'Edit', None)
+        action = QtGui.QAction(edit, menu)
+        action.triggered.connect(self.setEdit)
+        menu.addAction(action)
 
 _factory = {}
 

--- a/src/Mod/Path/PathScripts/PathJobGui.py
+++ b/src/Mod/Path/PathScripts/PathJobGui.py
@@ -65,6 +65,13 @@ def _OpenCloseResourceEditor(obj, vobj, edit):
             job.ViewObject.Proxy.editObject(obj)
         else:
             job.ViewObject.Proxy.uneditObject(obj)
+    else:
+        missing = 'Job'
+        if job:
+            missing = 'ViewObject'
+            if job.ViewObject:
+                missing = 'Proxy'
+        PathLog.warning("Cannot edit %s - no %s" % (obj.Label, missing))
 
 @contextmanager
 def selectionEx():

--- a/src/Mod/Path/PathScripts/PathUtils.py
+++ b/src/Mod/Path/PathScripts/PathUtils.py
@@ -467,7 +467,7 @@ def findParentJob(obj):
     for i in obj.InList:
         if hasattr(i, 'Proxy') and isinstance(i.Proxy, PathScripts.PathJob.ObjectJob):
             return i
-        if i.TypeId == "Path::FeaturePython" or i.TypeId == "Path::FeatureCompoundPython":
+        if i.TypeId == "Path::FeaturePython" or i.TypeId == "Path::FeatureCompoundPython" or i.TypeId == "App::DocumentObjectGroup":
             grandParent = findParentJob(i)
             if grandParent is not None:
                 return grandParent


### PR DESCRIPTION
Changed `ViewPoviderFeaturePython` to invoke the standard editors, if the view provider implements `setEdit` and returns `True` for any of the modes `Transform`, `Cutting` or `Set Color`.

Subsequently fixes the context menu for the PathIconViewProvider.