### PR TITLE
Extend python document observer capabilities

### DIFF
--- a/src/App/Application.cpp
+++ b/src/App/Application.cpp
@@ -423,6 +423,8 @@ Document* Application::newDocument(const char * Name, const char * UserName)
     _pActiveDoc->signalActivatedObject.connect(boost::bind(&App::Application::slotActivatedObject, this, _1));
     _pActiveDoc->signalUndo.connect(boost::bind(&App::Application::slotUndoDocument, this, _1));
     _pActiveDoc->signalRedo.connect(boost::bind(&App::Application::slotRedoDocument, this, _1));
+    _pActiveDoc->signalRecomputedObject.connect(boost::bind(&App::Application::slotRecomputedObject, this, _1));
+    _pActiveDoc->signalRecomputed.connect(boost::bind(&App::Application::slotRecomputed, this, _1));
 
     // make sure that the active document is set in case no GUI is up
     {
@@ -1005,6 +1007,15 @@ void Application::slotUndoDocument(const App::Document& d)
 void Application::slotRedoDocument(const App::Document& d)
 {
     this->signalRedoDocument(d);
+}
+void Application::slotRecomputedObject(const DocumentObject& obj)
+{
+    this->signalObjectRecomputed(obj);
+}
+
+void Application::slotRecomputed(const Document& doc)
+{
+    this->signalRecomputed(doc);
 }
 
 //**************************************************************************

--- a/src/App/Application.cpp
+++ b/src/App/Application.cpp
@@ -425,6 +425,9 @@ Document* Application::newDocument(const char * Name, const char * UserName)
     _pActiveDoc->signalRedo.connect(boost::bind(&App::Application::slotRedoDocument, this, _1));
     _pActiveDoc->signalRecomputedObject.connect(boost::bind(&App::Application::slotRecomputedObject, this, _1));
     _pActiveDoc->signalRecomputed.connect(boost::bind(&App::Application::slotRecomputed, this, _1));
+    _pActiveDoc->signalOpenTransaction.connect(boost::bind(&App::Application::slotOpenTransaction, this, _1, _2));
+    _pActiveDoc->signalCommitTransaction.connect(boost::bind(&App::Application::slotCommitTransaction, this, _1));
+    _pActiveDoc->signalAbortTransaction.connect(boost::bind(&App::Application::slotAbortTransaction, this, _1));
 
     // make sure that the active document is set in case no GUI is up
     {
@@ -1016,6 +1019,21 @@ void Application::slotRecomputedObject(const DocumentObject& obj)
 void Application::slotRecomputed(const Document& doc)
 {
     this->signalRecomputed(doc);
+}
+
+void Application::slotOpenTransaction(const Document& d, string s)
+{
+    this->signalOpenTransaction(d, s);
+}
+
+void Application::slotCommitTransaction(const Document& d)
+{
+    this->signalCommitTransaction(d);
+}
+
+void Application::slotAbortTransaction(const Document& d)
+{
+    this->signalAbortTransaction(d);
 }
 
 //**************************************************************************

--- a/src/App/Application.cpp
+++ b/src/App/Application.cpp
@@ -416,6 +416,8 @@ Document* Application::newDocument(const char * Name, const char * UserName)
 
 
     // connect the signals to the application for the new document
+    _pActiveDoc->signalBeforeChange.connect(boost::bind(&App::Application::slotBeforeChangeDoc, this, _1, _2));
+    _pActiveDoc->signalChanged.connect(boost::bind(&App::Application::slotChangedDoc, this, _1, _2));
     _pActiveDoc->signalNewObject.connect(boost::bind(&App::Application::slotNewObject, this, _1));
     _pActiveDoc->signalDeletedObject.connect(boost::bind(&App::Application::slotDeletedObject, this, _1));
     _pActiveDoc->signalBeforeChangeObject.connect(boost::bind(&App::Application::slotBeforeChangeObject, this, _1, _2));
@@ -978,6 +980,16 @@ std::map<std::string, std::string> Application::getExportFilters(void) const
 
 //**************************************************************************
 // signaling
+void Application::slotBeforeChangeDoc(const App::Document& doc, const Property& prop)
+{
+    this->signalBeforeChangeDoc(doc, prop);
+}
+
+void Application::slotChangedDoc(const App::Document& doc, const Property& prop)
+{
+    this->signalChangedDoc(doc, prop);
+}
+
 void Application::slotNewObject(const App::DocumentObject&O)
 {
     this->signalNewObject(O);

--- a/src/App/Application.cpp
+++ b/src/App/Application.cpp
@@ -418,6 +418,7 @@ Document* Application::newDocument(const char * Name, const char * UserName)
     // connect the signals to the application for the new document
     _pActiveDoc->signalNewObject.connect(boost::bind(&App::Application::slotNewObject, this, _1));
     _pActiveDoc->signalDeletedObject.connect(boost::bind(&App::Application::slotDeletedObject, this, _1));
+    _pActiveDoc->signalBeforeChangeObject.connect(boost::bind(&App::Application::slotBeforeChangeObject, this, _1, _2));
     _pActiveDoc->signalChangedObject.connect(boost::bind(&App::Application::slotChangedObject, this, _1, _2));
     _pActiveDoc->signalRelabelObject.connect(boost::bind(&App::Application::slotRelabelObject, this, _1));
     _pActiveDoc->signalActivatedObject.connect(boost::bind(&App::Application::slotActivatedObject, this, _1));
@@ -985,6 +986,11 @@ void Application::slotNewObject(const App::DocumentObject&O)
 void Application::slotDeletedObject(const App::DocumentObject&O)
 {
     this->signalDeletedObject(O);
+}
+
+void Application::slotBeforeChangeObject(const DocumentObject& O, const Property& Prop)
+{
+    this->signalBeforeChangeObject(O, Prop);
 }
 
 void Application::slotChangedObject(const App::DocumentObject&O, const App::Property& P)

--- a/src/App/Application.h
+++ b/src/App/Application.h
@@ -139,6 +139,10 @@ public:
     boost::signal<void (const App::DocumentObject&)> signalRelabelObject;
     /// signal on activated Object
     boost::signal<void (const App::DocumentObject&)> signalActivatedObject;
+    /// signal on recomputed document
+    boost::signal<void (const App::Document&)> signalRecomputed;
+    /// signal on recomputed document object
+    boost::signal<void (const App::DocumentObject&)> signalObjectRecomputed;
     //@}
 
     /** @name Signals of property changes
@@ -271,6 +275,8 @@ protected:
     void slotActivatedObject(const App::DocumentObject&);
     void slotUndoDocument(const App::Document&);
     void slotRedoDocument(const App::Document&);
+    void slotRecomputedObject(const App::DocumentObject&);
+    void slotRecomputed(const App::Document&);
     //@}
 
 private:

--- a/src/App/Application.h
+++ b/src/App/Application.h
@@ -128,6 +128,10 @@ public:
      * the signal of a special document connect to the document itself
      */
     //@{
+    /// signal before change of doc property
+    boost::signal<void (const App::Document&, const App::Property&)> signalBeforeChangeDoc;
+    /// signal on changed doc proeprty
+    boost::signal<void (const App::Document&, const App::Property&)> signalChangedDoc;
     /// signal on new Object
     boost::signal<void (const App::DocumentObject&)> signalNewObject;
     //boost::signal<void (const App::DocumentObject&)>     m_sig;
@@ -276,6 +280,8 @@ protected:
      * This slot get connected to all App::Documents created
      */
     //@{
+    void slotBeforeChangeDoc(const App::Document&, const App::Property&);
+    void slotChangedDoc(const App::Document&, const App::Property&);
     void slotNewObject(const App::DocumentObject&);
     void slotDeletedObject(const App::DocumentObject&);
     void slotBeforeChangeObject(const App::DocumentObject&, const App::Property& Prop);

--- a/src/App/Application.h
+++ b/src/App/Application.h
@@ -143,6 +143,12 @@ public:
     boost::signal<void (const App::Document&)> signalRecomputed;
     /// signal on recomputed document object
     boost::signal<void (const App::DocumentObject&)> signalObjectRecomputed;
+    // signal on opened transaction
+    boost::signal<void (const App::Document&, std::string)> signalOpenTransaction;
+    // signal a commited transaction
+    boost::signal<void (const App::Document&)> signalCommitTransaction;
+    // signal an aborted transaction
+    boost::signal<void (const App::Document&)> signalAbortTransaction;
     //@}
 
     /** @name Signals of property changes
@@ -277,6 +283,9 @@ protected:
     void slotRedoDocument(const App::Document&);
     void slotRecomputedObject(const App::DocumentObject&);
     void slotRecomputed(const App::Document&);
+    void slotOpenTransaction(const App::Document&, std::string);
+    void slotCommitTransaction(const App::Document&);
+    void slotAbortTransaction(const App::Document&);
     //@}
 
 private:

--- a/src/App/Application.h
+++ b/src/App/Application.h
@@ -134,6 +134,8 @@ public:
     /// signal on deleted Object
     boost::signal<void (const App::DocumentObject&)> signalDeletedObject;
     /// signal on changed Object
+    boost::signal<void (const App::DocumentObject&, const App::Property&)> signalBeforeChangeObject;
+    /// signal on changed Object
     boost::signal<void (const App::DocumentObject&, const App::Property&)> signalChangedObject;
     /// signal on relabeled Object
     boost::signal<void (const App::DocumentObject&)> signalRelabelObject;
@@ -276,6 +278,7 @@ protected:
     //@{
     void slotNewObject(const App::DocumentObject&);
     void slotDeletedObject(const App::DocumentObject&);
+    void slotBeforeChangeObject(const App::DocumentObject&, const App::Property& Prop);
     void slotChangedObject(const App::DocumentObject&, const App::Property& Prop);
     void slotRelabelObject(const App::DocumentObject&);
     void slotActivatedObject(const App::DocumentObject&);

--- a/src/App/Document.cpp
+++ b/src/App/Document.cpp
@@ -2178,6 +2178,7 @@ int Document::recompute()
                 d->vertexMap.clear();
                 return -1;
             }
+            signalRecomputedObject(*Cur);
             ++objectCount;
         }
     }
@@ -2244,6 +2245,7 @@ int Document::recompute()
 
         if ((*objIt)->isTouched() || doRecompute) {
             (*objIt)->purgeTouched();
+            signalObjectRecomputed(*(*objOt));
             // force recompute of all dependent objects
             for (auto inObjIt : (*objIt)->getInList())
                 inObjIt->enforceRecompute();

--- a/src/App/Document.cpp
+++ b/src/App/Document.cpp
@@ -962,7 +962,7 @@ void Document::openTransaction(const char* name)
         else
             d->activeUndoTransaction->Name = "<empty>";
         
-        signalOpenTransaction(*this, name);
+        signalOpenTransaction(*this, d->activeUndoTransaction->Name);
     }
 }
 
@@ -1140,8 +1140,8 @@ void Document::onChanged(const Property* prop)
 
 void Document::onBeforeChangeProperty(const TransactionalObject *Who, const Property *What)
 {
-    if(Who->isDerivedFrom(App::DocumentObject::getClassTypeId())
-        signalBeforeChangeObject(*static_cast<App::DocuemntObject*>(Who), *What);
+    if(Who->isDerivedFrom(App::DocumentObject::getClassTypeId()))
+        signalBeforeChangeObject(*static_cast<const App::DocumentObject*>(Who), *What);
     
     if (d->activeUndoTransaction && !d->rollback)
         d->activeUndoTransaction->addObjectChange(Who,What);
@@ -2252,7 +2252,7 @@ int Document::recompute()
 
         if ((*objIt)->isTouched() || doRecompute) {
             (*objIt)->purgeTouched();
-            signalObjectRecomputed(*(*objOt));
+            signalRecomputedObject(*(*objIt));
             // force recompute of all dependent objects
             for (auto inObjIt : (*objIt)->getInList())
                 inObjIt->enforceRecompute();
@@ -2520,8 +2520,10 @@ void Document::recomputeFeature(DocumentObject* Feat)
     _RecomputeLog.clear();
 
     // verify that the feature is (active) part of the document
-    if (Feat->getNameInDocument())
+    if (Feat->getNameInDocument()) {
         _recomputeFeature(Feat);
+        signalRecomputedObject(*Feat);
+    }
 }
 
 DocumentObject * Document::addObject(const char* sType, const char* pObjectName, bool isNew)

--- a/src/App/Document.cpp
+++ b/src/App/Document.cpp
@@ -1098,8 +1098,15 @@ unsigned int Document::getMaxUndoStackSize(void)const
     return d->UndoMaxStackSize;
 }
 
+void Document::onBeforeChange(const Property* prop) {
+ 
+    signalBeforeChange(*this, *prop);
+}
+
 void Document::onChanged(const Property* prop)
 {
+    signalChanged(*this, *prop);
+    
     // the Name property is a label for display purposes
     if (prop == &Label) {
         App::GetApplication().signalRelabelDocument(*this);

--- a/src/App/Document.cpp
+++ b/src/App/Document.cpp
@@ -1140,6 +1140,9 @@ void Document::onChanged(const Property* prop)
 
 void Document::onBeforeChangeProperty(const TransactionalObject *Who, const Property *What)
 {
+    if(Who->isDerivedFrom(App::DocumentObject::getClassTypeId())
+        signalBeforeChangeObject(*static_cast<App::DocuemntObject*>(Who), *What);
+    
     if (d->activeUndoTransaction && !d->rollback)
         d->activeUndoTransaction->addObjectChange(Who,What);
 }

--- a/src/App/Document.cpp
+++ b/src/App/Document.cpp
@@ -961,6 +961,8 @@ void Document::openTransaction(const char* name)
             d->activeUndoTransaction->Name = name;
         else
             d->activeUndoTransaction->Name = "<empty>";
+        
+        signalOpenTransaction(*this, name);
     }
 }
 
@@ -1000,6 +1002,7 @@ void Document::commitTransaction()
             delete mUndoTransactions.front();
             mUndoTransactions.pop_front();
         }
+        signalCommitTransaction(*this);
     }
 }
 
@@ -1014,6 +1017,7 @@ void Document::abortTransaction()
         // destroy the undo
         delete d->activeUndoTransaction;
         d->activeUndoTransaction = 0;
+        signalAbortTransaction(*this);
     }
 }
 

--- a/src/App/Document.h
+++ b/src/App/Document.h
@@ -117,6 +117,8 @@ public:
     //boost::signal<void (const App::DocumentObject&)>     m_sig;
     /// signal on deleted Object
     boost::signal<void (const App::DocumentObject&)> signalDeletedObject;
+    /// signal before changing an Object
+    boost::signal<void (const App::DocumentObject&, const App::Property&)> signalBeforeChangeObject;
     /// signal on changed Object
     boost::signal<void (const App::DocumentObject&, const App::Property&)> signalChangedObject;
     /// signal on relabeled Object

--- a/src/App/Document.h
+++ b/src/App/Document.h
@@ -112,6 +112,10 @@ public:
 
     /** @name Signals of the document */
     //@{
+    /// signal before changing an doc property
+    boost::signal<void (const App::Document&, const App::Property&)> signalBeforeChange;
+    /// signal on changed doc property
+    boost::signal<void (const App::Document&, const App::Property&)> signalChanged;
     /// signal on new Object
     boost::signal<void (const App::DocumentObject&)> signalNewObject;
     //boost::signal<void (const App::DocumentObject&)>     m_sig;
@@ -375,6 +379,7 @@ protected:
     void writeObjects(const std::vector<App::DocumentObject*>&, Base::Writer &writer) const;
     bool saveToFile(const char* filename) const;
 
+    void onBeforeChange(const Property* prop);
     void onChanged(const Property* prop);
     /// callback from the Document objects before property will be changed
     void onBeforeChangeProperty(const TransactionalObject *Who, const Property *What);

--- a/src/App/Document.h
+++ b/src/App/Document.h
@@ -147,6 +147,7 @@ public:
     boost::signal<void (const std::vector<App::DocumentObject*>&, Base::Reader&,
                         const std::map<std::string, std::string>&)> signalImportViewObjects;
     boost::signal<void (const App::Document&)> signalRecomputed;
+    boost::signal<void (const App::DocumentObject&)> signalRecomputedObject;
     //@}
 
     /** @name File handling of the document */

--- a/src/App/Document.h
+++ b/src/App/Document.h
@@ -148,6 +148,12 @@ public:
                         const std::map<std::string, std::string>&)> signalImportViewObjects;
     boost::signal<void (const App::Document&)> signalRecomputed;
     boost::signal<void (const App::DocumentObject&)> signalRecomputedObject;
+    //signal a new opened transaction
+    boost::signal<void (const App::Document&, std::string)> signalOpenTransaction;
+    // signal a commited transaction
+    boost::signal<void (const App::Document&)> signalCommitTransaction;
+    // signal an aborted transaction
+    boost::signal<void (const App::Document&)> signalAbortTransaction;
     //@}
 
     /** @name File handling of the document */

--- a/src/App/DocumentObserver.cpp
+++ b/src/App/DocumentObserver.cpp
@@ -228,6 +228,10 @@ void DocumentObserver::attachDocument(Document* doc)
             (&DocumentObserver::slotDeletedObject, this, _1));
         this->connectDocumentChangedObject = _document->signalChangedObject.connect(boost::bind
             (&DocumentObserver::slotChangedObject, this, _1, _2));
+        this->connectDocumentRecomputedObject = _document->signalRecomputedObject.connect(boost::bind
+            (&DocumentObserver::slotRecomputedObject, this, _1));
+        this->connectDocumentRecomputed = _document->signalRecomputed.connect(boost::bind
+            (&DocumentObserver::slotRecomputedDocument, this, _1));
     }
 }
 
@@ -238,6 +242,8 @@ void DocumentObserver::detachDocument()
         this->connectDocumentCreatedObject.disconnect();
         this->connectDocumentDeletedObject.disconnect();
         this->connectDocumentChangedObject.disconnect();
+        this->connectDocumentRecomputedObject.disconnect();
+        this->connectDocumentRecomputed.disconnect();
     }
 }
 
@@ -260,6 +266,15 @@ void DocumentObserver::slotDeletedObject(const App::DocumentObject& /*Obj*/)
 void DocumentObserver::slotChangedObject(const App::DocumentObject& /*Obj*/, const App::Property& /*Prop*/)
 {
 }
+
+void DocumentObserver::slotRecomputedObject(const DocumentObject& /*Obj*/)
+{
+}
+
+void DocumentObserver::slotRecomputedDocument(const Document& /*doc*/)
+{
+}
+
 
 // -----------------------------------------------------------------------------
 

--- a/src/App/DocumentObserver.h
+++ b/src/App/DocumentObserver.h
@@ -151,6 +151,10 @@ private:
     virtual void slotDeletedObject(const App::DocumentObject& Obj);
     /** The property of an observed object has changed */
     virtual void slotChangedObject(const App::DocumentObject& Obj, const App::Property& Prop);
+    /** Called when a given object is recomputed */
+    virtual void slotRecomputedObject(const App::DocumentObject& Obj);
+    /** Called when a observed document is recomputed */
+    virtual void slotRecomputedDocument(const App::Document& Doc);
 
 protected:
     Document* getDocument() const;
@@ -163,6 +167,8 @@ private:
     Connection connectDocumentCreatedObject;
     Connection connectDocumentDeletedObject;
     Connection connectDocumentChangedObject;
+    Connection connectDocumentRecomputedObject;
+    Connection connectDocumentRecomputed;
 };
 
 /**

--- a/src/App/DocumentObserverPython.cpp
+++ b/src/App/DocumentObserverPython.cpp
@@ -455,7 +455,7 @@ void DocumentObserverPython::slotAppendDynamicProperty(const App::Property& Prop
             auto container = Prop.getContainer();
             Py::Callable method(this->inst.getAttr(std::string("slotAppendDynamicProperty")));
             Py::Tuple args(2);
-            args.setItem(0, Py::Object(static_cast<App::DocumentObject*>(container)->getPyObject(), true));
+            args.setItem(0, Py::Object(container->getPyObject(), true));
             // If a property is touched but not part of a document object then its name is null.
             // In this case the slot function must not be called.
             const char* prop_name = container->getPropertyName(&Prop);
@@ -479,7 +479,7 @@ void DocumentObserverPython::slotRemoveDynamicProperty(const App::Property& Prop
             auto container = Prop.getContainer();
             Py::Callable method(this->inst.getAttr(std::string("slotRemoveDynamicProperty")));
             Py::Tuple args(2);
-            args.setItem(0, Py::Object(static_cast<App::DocumentObject*>(container)->getPyObject(), true));
+            args.setItem(0, Py::Object(container->getPyObject(), true));
             // If a property is touched but not part of a document object then its name is null.
             // In this case the slot function must not be called.
             const char* prop_name = container->getPropertyName(&Prop);
@@ -503,7 +503,7 @@ void DocumentObserverPython::slotChangePropertyEditor(const App::Property& Prop)
             auto container = Prop.getContainer();
             Py::Callable method(this->inst.getAttr(std::string("slotChangePropertyEditor")));
             Py::Tuple args(2);
-            args.setItem(0, Py::Object(static_cast<App::DocumentObject*>(container)->getPyObject(), true));
+            args.setItem(0, Py::Object(container->getPyObject(), true));
             // If a property is touched but not part of a document object then its name is null.
             // In this case the slot function must not be called.
             const char* prop_name = container->getPropertyName(&Prop);

--- a/src/App/DocumentObserverPython.cpp
+++ b/src/App/DocumentObserverPython.cpp
@@ -76,7 +76,7 @@ DocumentObserverPython::DocumentObserverPython(const Py::Object& obj) : inst(obj
         (&DocumentObserverPython::slotCreatedObject, this, _1));
     this->connectDocumentDeletedObject = App::GetApplication().signalDeletedObject.connect(boost::bind
         (&DocumentObserverPython::slotDeletedObject, this, _1));
-    this->connectDocumentChangedObject = App::GetApplication().signalBeforeChangeObject.connect(boost::bind
+    this->connectDocumentBeforeChangeObject = App::GetApplication().signalBeforeChangeObject.connect(boost::bind
         (&DocumentObserverPython::slotBeforeChangeObject, this, _1, _2));
     this->connectDocumentChangedObject = App::GetApplication().signalChangedObject.connect(boost::bind
         (&DocumentObserverPython::slotChangedObject, this, _1, _2));
@@ -105,6 +105,7 @@ DocumentObserverPython::~DocumentObserverPython()
 
     this->connectDocumentCreatedObject.disconnect();
     this->connectDocumentDeletedObject.disconnect();
+    this->connectDocumentBeforeChangeObject.disconnect();
     this->connectDocumentChangedObject.disconnect();
     this->connectDocumentObjectRecomputed.disconnect();
     this->connectDocumentRecomputed.disconnect();

--- a/src/App/DocumentObserverPython.cpp
+++ b/src/App/DocumentObserverPython.cpp
@@ -83,6 +83,13 @@ DocumentObserverPython::DocumentObserverPython(const Py::Object& obj) : inst(obj
         (&DocumentObserverPython::slotRecomputedObject, this, _1));
     this->connectDocumentRecomputed = App::GetApplication().signalRecomputed.connect(boost::bind
         (&DocumentObserverPython::slotRecomputedDocument, this, _1));
+    
+    this->connectDocumentOpenTransaction = App::GetApplication().signalOpenTransaction.connect(boost::bind
+        (&DocumentObserverPython::slotOpenTransaction, this, _1, _2));
+    this->connectDocumentCommitTransaction = App::GetApplication().signalCommitTransaction.connect(boost::bind
+        (&DocumentObserverPython::slotCommitTransaction, this, _1));
+    this->connectDocumentAbortTransaction = App::GetApplication().signalAbortTransaction.connect(boost::bind
+        (&DocumentObserverPython::slotAbortTransaction, this, _1));
 }
 
 DocumentObserverPython::~DocumentObserverPython()
@@ -99,6 +106,9 @@ DocumentObserverPython::~DocumentObserverPython()
     this->connectDocumentChangedObject.disconnect();
     this->connectDocumentObjectRecomputed.disconnect();
     this->connectDocumentRecomputed.disconnect();
+    this->connectDocumentOpenTransaction.disconnect();
+    this->connectDocumentCommitTransaction.disconnect();
+    this->connectDocumentAbortTransaction.disconnect();
 }
 
 void DocumentObserverPython::slotCreatedDocument(const App::Document& Doc)
@@ -284,6 +294,58 @@ void DocumentObserverPython::slotRecomputedDocument(const App::Document& doc)
     try {
         if (this->inst.hasAttr(std::string("slotRecomputedDocument"))) {
             Py::Callable method(this->inst.getAttr(std::string("slotRecomputedDocument")));
+            Py::Tuple args(1);
+            args.setItem(0, Py::Object(const_cast<App::Document&>(doc).getPyObject(), true));
+            method.apply(args);
+        }
+    }
+    catch (Py::Exception&) {
+        Base::PyException e; // extract the Python error text
+        e.ReportException();
+    }
+}
+
+void DocumentObserverPython::slotOpenTransaction(const App::Document& doc, std::string str)
+{
+    Base::PyGILStateLocker lock;
+    try {
+        if (this->inst.hasAttr(std::string("slotOpenTransaction"))) {
+            Py::Callable method(this->inst.getAttr(std::string("slotOpenTransaction")));
+            Py::Tuple args(2);
+            args.setItem(0, Py::Object(const_cast<App::Document&>(doc).getPyObject(), true));
+            args.setItem(1, Py::String(str));
+            method.apply(args);
+        }
+    }
+    catch (Py::Exception&) {
+        Base::PyException e; // extract the Python error text
+        e.ReportException();
+    }
+}
+
+void DocumentObserverPython::slotCommitTransaction(const App::Document& doc)
+{
+    Base::PyGILStateLocker lock;
+    try {
+        if (this->inst.hasAttr(std::string("slotCommitTransaction"))) {
+            Py::Callable method(this->inst.getAttr(std::string("slotCommitTransaction")));
+            Py::Tuple args(1);
+            args.setItem(0, Py::Object(const_cast<App::Document&>(doc).getPyObject(), true));
+            method.apply(args);
+        }
+    }
+    catch (Py::Exception&) {
+        Base::PyException e; // extract the Python error text
+        e.ReportException();
+    }
+}
+
+void DocumentObserverPython::slotAbortTransaction(const App::Document& doc)
+{
+    Base::PyGILStateLocker lock;
+    try {
+        if (this->inst.hasAttr(std::string("slotAbortTransaction"))) {
+            Py::Callable method(this->inst.getAttr(std::string("slotAbortTransaction")));
             Py::Tuple args(1);
             args.setItem(0, Py::Object(const_cast<App::Document&>(doc).getPyObject(), true));
             method.apply(args);

--- a/src/App/DocumentObserverPython.cpp
+++ b/src/App/DocumentObserverPython.cpp
@@ -96,6 +96,13 @@ DocumentObserverPython::DocumentObserverPython(const Py::Object& obj) : inst(obj
         (&DocumentObserverPython::slotCommitTransaction, this, _1));
     this->connectDocumentAbortTransaction = App::GetApplication().signalAbortTransaction.connect(boost::bind
         (&DocumentObserverPython::slotAbortTransaction, this, _1));
+    
+    this->connectObjectAppendDynamicProperty = App::GetApplication().signalAppendDynamicProperty.connect(boost::bind
+        (&DocumentObserverPython::slotAppendDynamicProperty, this, _1));
+    this->connectObjectRemoveDynamicProperty = App::GetApplication().signalRemoveDynamicProperty.connect(boost::bind
+        (&DocumentObserverPython::slotRemoveDynamicProperty, this, _1));
+    this->connectObjectChangePropertyEditor = App::GetApplication().signalChangePropertyEditor.connect(boost::bind
+        (&DocumentObserverPython::slotChangePropertyEditor, this, _1));
 }
 
 DocumentObserverPython::~DocumentObserverPython()
@@ -118,6 +125,10 @@ DocumentObserverPython::~DocumentObserverPython()
     this->connectDocumentOpenTransaction.disconnect();
     this->connectDocumentCommitTransaction.disconnect();
     this->connectDocumentAbortTransaction.disconnect();
+    
+    this->connectObjectAppendDynamicProperty.disconnect();
+    this->connectObjectRemoveDynamicProperty.disconnect();
+    this->connectObjectChangePropertyEditor.disconnect();
 }
 
 void DocumentObserverPython::slotCreatedDocument(const App::Document& Doc)
@@ -428,6 +439,78 @@ void DocumentObserverPython::slotAbortTransaction(const App::Document& doc)
             Py::Tuple args(1);
             args.setItem(0, Py::Object(const_cast<App::Document&>(doc).getPyObject(), true));
             method.apply(args);
+        }
+    }
+    catch (Py::Exception&) {
+        Base::PyException e; // extract the Python error text
+        e.ReportException();
+    }
+}
+
+void DocumentObserverPython::slotAppendDynamicProperty(const App::Property& Prop)
+{
+    Base::PyGILStateLocker lock;
+    try {
+        if (this->inst.hasAttr(std::string("slotAppendDynamicProperty"))) {
+            auto container = Prop.getContainer();
+            Py::Callable method(this->inst.getAttr(std::string("slotAppendDynamicProperty")));
+            Py::Tuple args(2);
+            args.setItem(0, Py::Object(static_cast<App::DocumentObject*>(container)->getPyObject(), true));
+            // If a property is touched but not part of a document object then its name is null.
+            // In this case the slot function must not be called.
+            const char* prop_name = container->getPropertyName(&Prop);
+            if (prop_name) {
+                args.setItem(1, Py::String(prop_name));
+                method.apply(args);
+            }
+        }
+    }
+    catch (Py::Exception&) {
+        Base::PyException e; // extract the Python error text
+        e.ReportException();
+    }
+}
+
+void DocumentObserverPython::slotRemoveDynamicProperty(const App::Property& Prop)
+{
+    Base::PyGILStateLocker lock;
+    try {
+        if (this->inst.hasAttr(std::string("slotRemoveDynamicProperty"))) {
+            auto container = Prop.getContainer();
+            Py::Callable method(this->inst.getAttr(std::string("slotRemoveDynamicProperty")));
+            Py::Tuple args(2);
+            args.setItem(0, Py::Object(static_cast<App::DocumentObject*>(container)->getPyObject(), true));
+            // If a property is touched but not part of a document object then its name is null.
+            // In this case the slot function must not be called.
+            const char* prop_name = container->getPropertyName(&Prop);
+            if (prop_name) {
+                args.setItem(1, Py::String(prop_name));
+                method.apply(args);
+            }
+        }
+    }
+    catch (Py::Exception&) {
+        Base::PyException e; // extract the Python error text
+        e.ReportException();
+    }    
+}
+
+void DocumentObserverPython::slotChangePropertyEditor(const App::Property& Prop)
+{
+    Base::PyGILStateLocker lock;
+    try {
+        if (this->inst.hasAttr(std::string("slotChangePropertyEditor"))) {
+            auto container = Prop.getContainer();
+            Py::Callable method(this->inst.getAttr(std::string("slotChangePropertyEditor")));
+            Py::Tuple args(2);
+            args.setItem(0, Py::Object(static_cast<App::DocumentObject*>(container)->getPyObject(), true));
+            // If a property is touched but not part of a document object then its name is null.
+            // In this case the slot function must not be called.
+            const char* prop_name = container->getPropertyName(&Prop);
+            if (prop_name) {
+                args.setItem(1, Py::String(prop_name));
+                method.apply(args);
+            }
         }
     }
     catch (Py::Exception&) {

--- a/src/App/DocumentObserverPython.h
+++ b/src/App/DocumentObserverPython.h
@@ -59,6 +59,10 @@ private:
     void slotRelabelDocument(const App::Document& Doc);
     /** Checks if the given document is activated */
     void slotActivateDocument(const App::Document& Doc);
+    /** The property of an observed document has changed */
+    void slotBeforeChangeDocument(const App::Document& Obj, const App::Property& Prop);
+    /** The property of an observed document has changed */
+    void slotChangedDocument(const App::Document& Obj, const App::Property& Prop);
     /** Checks if a new object was added. */
     void slotCreatedObject(const App::DocumentObject& Obj);
     /** Checks if the given object is about to be removed. */
@@ -93,6 +97,8 @@ private:
     Connection connectApplicationActivateDocument;
     Connection connectApplicationUndoDocument;
     Connection connectApplicationRedoDocument;
+    Connection connectDocumentBeforeChange;
+    Connection connectDocumentChanged;
     Connection connectDocumentCreatedObject;
     Connection connectDocumentDeletedObject;
     Connection connectDocumentBeforeChangeObject;

--- a/src/App/DocumentObserverPython.h
+++ b/src/App/DocumentObserverPython.h
@@ -95,6 +95,7 @@ private:
     Connection connectApplicationRedoDocument;
     Connection connectDocumentCreatedObject;
     Connection connectDocumentDeletedObject;
+    Connection connectDocumentBeforeChangeObject;
     Connection connectDocumentChangedObject;
     Connection connectDocumentObjectRecomputed;
     Connection connectDocumentRecomputed;

--- a/src/App/DocumentObserverPython.h
+++ b/src/App/DocumentObserverPython.h
@@ -85,6 +85,12 @@ private:
     void slotCommitTransaction(const App::Document& Doc);
     /** Called when a observed document aborts a transaction */
     void slotAbortTransaction(const App::Document& Doc);
+    /** Called when a object get a new dynamic property added*/
+    void slotAppendDynamicProperty(const App::Property& Prop);
+    /** Called when a object get a dynamic property removed*/
+    void slotRemoveDynamicProperty(const App::Property& Prop);
+    /** Called when a object property get a new editor relevant status like hidden or read only*/
+    void slotChangePropertyEditor(const App::Property& Prop);
 
 private:
     Py::Object inst;
@@ -108,6 +114,9 @@ private:
     Connection connectDocumentOpenTransaction;
     Connection connectDocumentCommitTransaction;
     Connection connectDocumentAbortTransaction;
+    Connection connectObjectAppendDynamicProperty;
+    Connection connectObjectRemoveDynamicProperty;
+    Connection connectObjectChangePropertyEditor;
 };
 
 } //namespace App

--- a/src/App/DocumentObserverPython.h
+++ b/src/App/DocumentObserverPython.h
@@ -64,6 +64,8 @@ private:
     /** Checks if the given object is about to be removed. */
     void slotDeletedObject(const App::DocumentObject& Obj);
     /** The property of an observed object has changed */
+    void slotBeforeChangeObject(const App::DocumentObject& Obj, const App::Property& Prop);
+    /** The property of an observed object has changed */
     void slotChangedObject(const App::DocumentObject& Obj, const App::Property& Prop);
     /** Undoes the last transaction of the document */
     void slotUndoDocument(const App::Document& Doc);

--- a/src/App/DocumentObserverPython.h
+++ b/src/App/DocumentObserverPython.h
@@ -73,6 +73,12 @@ private:
     void slotRecomputedObject(const App::DocumentObject& Obj);
     /** Called when a observed document is recomputed */
     void slotRecomputedDocument(const App::Document& Doc);
+    /** Called when a observed document opens a transaction */
+    void slotOpenTransaction(const App::Document& Doc, std::string str);
+    /** Called when a observed document commits a transaction */
+    void slotCommitTransaction(const App::Document& Doc);
+    /** Called when a observed document aborts a transaction */
+    void slotAbortTransaction(const App::Document& Doc);
 
 private:
     Py::Object inst;
@@ -90,6 +96,9 @@ private:
     Connection connectDocumentChangedObject;
     Connection connectDocumentObjectRecomputed;
     Connection connectDocumentRecomputed;
+    Connection connectDocumentOpenTransaction;
+    Connection connectDocumentCommitTransaction;
+    Connection connectDocumentAbortTransaction;
 };
 
 } //namespace App

--- a/src/App/DocumentObserverPython.h
+++ b/src/App/DocumentObserverPython.h
@@ -69,6 +69,10 @@ private:
     void slotUndoDocument(const App::Document& Doc);
     /** Redoes the last undone transaction of the document */
     void slotRedoDocument(const App::Document& Doc);
+    /** Called when a given object is recomputed */
+    void slotRecomputedObject(const App::DocumentObject& Obj);
+    /** Called when a observed document is recomputed */
+    void slotRecomputedDocument(const App::Document& Doc);
 
 private:
     Py::Object inst;
@@ -84,6 +88,8 @@ private:
     Connection connectDocumentCreatedObject;
     Connection connectDocumentDeletedObject;
     Connection connectDocumentChangedObject;
+    Connection connectDocumentObjectRecomputed;
+    Connection connectDocumentRecomputed;
 };
 
 } //namespace App

--- a/src/Gui/Application.cpp
+++ b/src/Gui/Application.cpp
@@ -96,6 +96,7 @@
 #include "SplitView3DInventor.h"
 #include "View3DInventor.h"
 #include "ViewProvider.h"
+#include "ViewProviderDocumentObject.h"
 #include "ViewProviderExtension.h"
 #include "ViewProviderExtern.h"
 #include "ViewProviderFeature.h"
@@ -678,8 +679,9 @@ void Application::slotNewDocument(const App::Document& Doc)
     pDoc->signalChangedObject.connect(boost::bind(&Gui::Application::slotChangedObject, this, _1, _2));
     pDoc->signalRelabelObject.connect(boost::bind(&Gui::Application::slotRelabelObject, this, _1));
     pDoc->signalActivatedObject.connect(boost::bind(&Gui::Application::slotActivatedObject, this, _1));
-
-
+    pDoc->signalInEdit.connect(boost::bind(&Gui::Application::slotInEdit, this, _1));
+    pDoc->signalResetEdit.connect(boost::bind(&Gui::Application::slotResetEdit, this, _1));
+ 
     signalNewDocument(*pDoc);
     pDoc->createView(View3DInventor::getClassTypeId());
     // FIXME: Do we really need this further? Calling processEvents() mixes up order of execution in an
@@ -779,6 +781,16 @@ void Application::slotRelabelObject(const ViewProvider& vp)
 void Application::slotActivatedObject(const ViewProvider& vp)
 {
     this->signalActivatedObject(vp);
+}
+
+void Application::slotInEdit(const Gui::ViewProviderDocumentObject& vp)
+{
+    this->signalInEdit(vp);
+}
+
+void Application::slotResetEdit(const Gui::ViewProviderDocumentObject& vp)
+{
+    this->signalResetEdit(vp);
 }
 
 void Application::onLastWindowClosed(Gui::Document* pcDoc)

--- a/src/Gui/Application.h
+++ b/src/Gui/Application.h
@@ -43,6 +43,7 @@ class MDIView;
 class MainWindow;
 class MenuItem;
 class ViewProvider;
+class ViewProviderDocumentObject;
 
 /** The Application main class
  * This is the central class of the GUI 
@@ -115,6 +116,10 @@ public:
     boost::signal<void (const char*)> signalRemoveWorkbench;
     /// signal on activating view
     boost::signal<void (const Gui::MDIView*)> signalActivateView;
+    /// signal on entering in edit mode
+    boost::signal<void (const Gui::ViewProviderDocumentObject&)> signalInEdit;
+    /// signal on leaving edit mode
+    boost::signal<void (const Gui::ViewProviderDocumentObject&)> signalResetEdit;
     //@}
 
     /** @name methods for Document handling */
@@ -131,6 +136,8 @@ protected:
     void slotChangedObject(const ViewProvider&, const App::Property& Prop);
     void slotRelabelObject(const ViewProvider&);
     void slotActivatedObject(const ViewProvider&);
+    void slotInEdit(const Gui::ViewProviderDocumentObject&);
+    void slotResetEdit(const Gui::ViewProviderDocumentObject&);
 
 public:
     /// message when a GuiDocument is about to vanish

--- a/src/Gui/Application.h
+++ b/src/Gui/Application.h
@@ -251,6 +251,9 @@ public:
 
     static PyObject* sCreateViewer             (PyObject *self,PyObject *args);
     static PyObject* sGetMarkerIndex           (PyObject *self,PyObject *args);
+    
+    static PyObject* sAddDocObserver           (PyObject *self,PyObject *args);
+    static PyObject* sRemoveDocObserver        (PyObject *self,PyObject *args);
 
     static PyMethodDef    Methods[]; 
 

--- a/src/Gui/ApplicationPy.cpp
+++ b/src/Gui/ApplicationPy.cpp
@@ -57,6 +57,7 @@
 #include "Language/Translator.h"
 #include "DownloadManager.h"
 #include "DlgPreferencesImp.h"
+#include "DocumentObserverPython.h"
 #include <App/DocumentObjectPy.h>
 #include <App/DocumentPy.h>
 #include <App/PropertyFile.h>
@@ -188,6 +189,13 @@ PyMethodDef Application::Methods[] = {
 
   {"getMarkerIndex", (PyCFunction) Application::sGetMarkerIndex, METH_VARARGS,
    "Get marker index according to marker size setting"},
+   
+    {"addDocumentObserver",  (PyCFunction) Application::sAddDocObserver, METH_VARARGS,
+     "addDocumentObserver() -> None\n\n"
+     "Add an observer to get notified about changes on documents."},
+    {"removeDocumentObserver",  (PyCFunction) Application::sRemoveDocObserver, METH_VARARGS,
+     "removeDocumentObserver() -> None\n\n"
+     "Remove an added document observer."},
 
   {NULL, NULL, 0, NULL}		/* Sentinel */
 };
@@ -1267,4 +1275,27 @@ PyObject* Application::sGetMarkerIndex(PyObject * /*self*/, PyObject *args)
         else
             return Py_BuildValue("i", Gui::Inventor::MarkerBitmaps::getMarkerIndex("CIRCLE_FILLED", hGrp->GetInt("MarkerSize", defSize)));
     }PY_CATCH;
+}
+
+
+PyObject* Application::sAddDocObserver(PyObject * /*self*/, PyObject *args)
+{
+    PyObject* o;
+    if (!PyArg_ParseTuple(args, "O",&o))
+        return NULL;
+    PY_TRY {
+        DocumentObserverPython::addObserver(Py::Object(o));
+        Py_Return;
+    } PY_CATCH;
+}
+
+PyObject* Application::sRemoveDocObserver(PyObject * /*self*/, PyObject *args)
+{
+    PyObject* o;
+    if (!PyArg_ParseTuple(args, "O",&o))
+        return NULL;
+    PY_TRY {
+        DocumentObserverPython::removeObserver(Py::Object(o));
+        Py_Return;
+    } PY_CATCH;
 }

--- a/src/Gui/CMakeLists.txt
+++ b/src/Gui/CMakeLists.txt
@@ -1110,6 +1110,7 @@ SET(FreeCADGui_CPP_SRCS
     DocumentModel.cpp
     DocumentPyImp.cpp
     DocumentObserver.cpp
+    DocumentObserverPython.cpp
     ExpressionBinding.cpp
     GraphicsViewZoom.cpp
     ExpressionCompleter.cpp
@@ -1136,6 +1137,7 @@ SET(FreeCADGui_SRCS
     Document.h
     DocumentModel.h
     DocumentObserver.h
+    DocumentObserverPython.h
     ExpressionBinding.cpp
     ExpressionCompleter.h
     FreeCADGuiInit.py

--- a/src/Gui/DocumentObserverPython.cpp
+++ b/src/Gui/DocumentObserverPython.cpp
@@ -1,0 +1,236 @@
+/***************************************************************************
+ *   Copyright (c) 2018 Stefan Tröger <stefantroeger@gmx.net>              *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+
+#include "PreCompiled.h"
+
+#ifndef _PreComp_
+#endif
+
+#include "Application.h"
+#include "Document.h"
+#include "ViewProvider.h"
+#include "DocumentObserverPython.h"
+#include <Base/Interpreter.h>
+#include <Base/Console.h>
+
+using namespace Gui;
+
+std::vector<DocumentObserverPython*> DocumentObserverPython::_instances;
+
+void DocumentObserverPython::addObserver(const Py::Object& obj)
+{
+    _instances.push_back(new DocumentObserverPython(obj));
+}
+
+void DocumentObserverPython::removeObserver(const Py::Object& obj)
+{
+    DocumentObserverPython* obs=0;
+    for (std::vector<DocumentObserverPython*>::iterator it =
+        _instances.begin(); it != _instances.end(); ++it) {
+        if ((*it)->inst == obj) {
+            obs = *it;
+            _instances.erase(it);
+            break;
+        }
+    }
+
+    delete obs;
+}
+
+DocumentObserverPython::DocumentObserverPython(const Py::Object& obj) : inst(obj)
+{
+    this->connectApplicationCreatedDocument = Gui::Application::Instance->signalNewDocument.connect(boost::bind
+        (&DocumentObserverPython::slotCreatedDocument, this, _1));
+    this->connectApplicationDeletedDocument = Gui::Application::Instance->signalDeleteDocument.connect(boost::bind
+        (&DocumentObserverPython::slotDeletedDocument, this, _1));
+    this->connectApplicationRelabelDocument = Gui::Application::Instance->signalRelabelDocument.connect(boost::bind
+        (&DocumentObserverPython::slotRelabelDocument, this, _1));
+    this->connectApplicationRenameDocument = Gui::Application::Instance->signalRenameDocument.connect(boost::bind
+        (&DocumentObserverPython::slotRelabelDocument, this, _1));
+    this->connectApplicationActivateDocument = Gui::Application::Instance->signalActiveDocument.connect(boost::bind
+        (&DocumentObserverPython::slotActivateDocument, this, _1));
+
+    this->connectDocumentCreatedObject = Gui::Application::Instance->signalNewObject.connect(boost::bind
+        (&DocumentObserverPython::slotCreatedObject, this, _1));
+    this->connectDocumentDeletedObject = Gui::Application::Instance->signalDeletedObject.connect(boost::bind
+        (&DocumentObserverPython::slotDeletedObject, this, _1));
+    this->connectDocumentChangedObject = Gui::Application::Instance->signalChangedObject.connect(boost::bind
+        (&DocumentObserverPython::slotChangedObject, this, _1, _2));
+    
+}
+
+DocumentObserverPython::~DocumentObserverPython()
+{
+    this->connectApplicationCreatedDocument.disconnect();
+    this->connectApplicationDeletedDocument.disconnect();
+    this->connectApplicationRelabelDocument.disconnect();
+    this->connectApplicationRenameDocument.disconnect();
+    this->connectApplicationActivateDocument.disconnect();
+
+    this->connectDocumentCreatedObject.disconnect();
+    this->connectDocumentDeletedObject.disconnect();
+    this->connectDocumentChangedObject.disconnect();
+}
+
+void DocumentObserverPython::slotCreatedDocument(const Gui::Document& Doc)
+{
+    Base::PyGILStateLocker lock;
+    try {
+        if (this->inst.hasAttr(std::string("slotCreatedDocument"))) {
+            Py::Callable method(this->inst.getAttr(std::string("slotCreatedDocument")));
+            Py::Tuple args(1);
+            args.setItem(0, Py::Object(const_cast<Gui::Document&>(Doc).getPyObject(), true));
+            method.apply(args);
+        }
+    }
+    catch (Py::Exception&) {
+        Base::PyException e; // extract the Python error text
+        e.ReportException();
+    }
+}
+
+void DocumentObserverPython::slotDeletedDocument(const Gui::Document& Doc)
+{
+    Base::PyGILStateLocker lock;
+    try {
+        if (this->inst.hasAttr(std::string("slotDeletedDocument"))) {
+            Py::Callable method(this->inst.getAttr(std::string("slotDeletedDocument")));
+            Py::Tuple args(1);
+            args.setItem(0, Py::Object(const_cast<Gui::Document&>(Doc).getPyObject(), true));
+            method.apply(args);
+        }
+    }
+    catch (Py::Exception&) {
+        Base::PyException e; // extract the Python error text
+        e.ReportException();
+    }
+}
+
+void DocumentObserverPython::slotRelabelDocument(const Gui::Document& Doc)
+{
+    Base::PyGILStateLocker lock;
+    try {
+        if (this->inst.hasAttr(std::string("slotRelabelDocument"))) {
+            Py::Callable method(this->inst.getAttr(std::string("slotRelabelDocument")));
+            Py::Tuple args(1);
+            args.setItem(0, Py::Object(const_cast<Gui::Document&>(Doc).getPyObject(), true));
+            method.apply(args);
+        }
+    }
+    catch (Py::Exception&) {
+        Base::PyException e; // extract the Python error text
+        e.ReportException();
+    }
+}
+
+void DocumentObserverPython::slotRenameDocument(const Gui::Document& Doc)
+{
+    Base::PyGILStateLocker lock;
+    try {
+        if (this->inst.hasAttr(std::string("slotRenameDocument"))) {
+            Py::Callable method(this->inst.getAttr(std::string("slotRenameDocument")));
+            Py::Tuple args(1);
+            args.setItem(0, Py::Object(const_cast<Gui::Document&>(Doc).getPyObject(), true));
+            method.apply(args);
+        }
+    }
+    catch (Py::Exception&) {
+        Base::PyException e; // extract the Python error text
+        e.ReportException();
+    }
+}
+
+void DocumentObserverPython::slotActivateDocument(const Gui::Document& Doc)
+{
+    Base::PyGILStateLocker lock;
+    try {
+        if (this->inst.hasAttr(std::string("slotActivateDocument"))) {
+            Py::Callable method(this->inst.getAttr(std::string("slotActivateDocument")));
+            Py::Tuple args(1);
+            args.setItem(0, Py::Object(const_cast<Gui::Document&>(Doc).getPyObject(), true));
+            method.apply(args);
+        }
+    }
+    catch (Py::Exception&) {
+        Base::PyException e; // extract the Python error text
+        e.ReportException();
+    }
+}
+
+void DocumentObserverPython::slotCreatedObject(const Gui::ViewProvider& Obj)
+{
+    Base::PyGILStateLocker lock;
+    try {
+        if (this->inst.hasAttr(std::string("slotCreatedObject"))) {
+            Py::Callable method(this->inst.getAttr(std::string("slotCreatedObject")));
+            Py::Tuple args(1);
+            args.setItem(0, Py::Object(const_cast<Gui::ViewProvider&>(Obj).getPyObject(), true));
+            method.apply(args);
+        }
+    }
+    catch (Py::Exception&) {
+        Base::PyException e; // extract the Python error text
+        e.ReportException();
+    }
+}
+
+void DocumentObserverPython::slotDeletedObject(const Gui::ViewProvider& Obj)
+{
+    Base::PyGILStateLocker lock;
+    try {
+        if (this->inst.hasAttr(std::string("slotDeletedObject"))) {
+            Py::Callable method(this->inst.getAttr(std::string("slotDeletedObject")));
+            Py::Tuple args(1);
+            args.setItem(0, Py::Object(const_cast<Gui::ViewProvider&>(Obj).getPyObject(), true));
+            method.apply(args);
+        }
+    }
+    catch (Py::Exception&) {
+        Base::PyException e; // extract the Python error text
+        e.ReportException();
+    }
+}
+
+void DocumentObserverPython::slotChangedObject(const Gui::ViewProvider& Obj,
+                                               const App::Property& Prop)
+{
+    Base::PyGILStateLocker lock;
+    try {
+        if (this->inst.hasAttr(std::string("slotChangedObject"))) {
+            Py::Callable method(this->inst.getAttr(std::string("slotChangedObject")));
+            Py::Tuple args(2);
+            args.setItem(0, Py::Object(const_cast<Gui::ViewProvider&>(Obj).getPyObject(), true));
+            // If a property is touched but not part of a document object then its name is null.
+            // In this case the slot function must not be called.
+            const char* prop_name = Obj.getPropertyName(&Prop);
+            if (prop_name) {
+                args.setItem(1, Py::String(prop_name));
+                method.apply(args);
+            }
+        }
+    }
+    catch (Py::Exception&) {
+        Base::PyException e; // extract the Python error text
+        e.ReportException();
+    }
+}

--- a/src/Gui/DocumentObserverPython.h
+++ b/src/Gui/DocumentObserverPython.h
@@ -66,6 +66,10 @@ private:
     void slotDeletedObject(const Gui::ViewProvider& Obj);
     /** The property of an observed object has changed */
     void slotChangedObject(const Gui::ViewProvider& Obj, const App::Property& Prop);
+    /** The object was set into edit mode */
+    void slotInEdit(const Gui::ViewProviderDocumentObject& Obj);
+    /** The has left edit mode */
+    void slotResetEdit(const Gui::ViewProviderDocumentObject& Obj);
 
 private:
     Py::Object inst;
@@ -80,6 +84,8 @@ private:
     Connection connectDocumentCreatedObject;
     Connection connectDocumentDeletedObject;
     Connection connectDocumentChangedObject;
+    Connection connectDocumentObjectInEdit;
+    Connection connectDocumentObjectResetEdit;
 };
 
 } //namespace Gui

--- a/src/Gui/DocumentObserverPython.h
+++ b/src/Gui/DocumentObserverPython.h
@@ -1,0 +1,87 @@
+/***************************************************************************
+ *   Copyright (c) 2018 Stefan Tröger <stefantroeger@gmx.net>              *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+
+#ifndef GUI_DOCUMENTOBSERVERPYTHON_H
+#define GUI_DOCUMENTOBSERVERPYTHON_H
+
+#include <CXX/Objects.hxx>
+
+#include <boost/signals.hpp>
+#include <boost/bind.hpp>
+
+namespace Gui
+{
+
+/**
+ * The DocumentObserverPython class is used to notify registered Python instances
+ * whenever something happens to a document, like creation, destruction, adding or
+ * removing viewproviders or when viewprovider property changes. This is the equivalent to the app 
+ * python document observer
+*/
+class GuiExport DocumentObserverPython
+{
+
+public:
+    /// Constructor
+    DocumentObserverPython(const Py::Object& obj);
+    virtual ~DocumentObserverPython();
+
+    static void addObserver(const Py::Object& obj);
+    static void removeObserver(const Py::Object& obj);
+
+private:   
+    /** Checks if a new document was created */
+    void slotCreatedDocument(const Gui::Document& Doc);
+    /** Checks if the given document is about to be closed */
+    void slotDeletedDocument(const Gui::Document& Doc);
+    /** Checks if the given document is relabeled */
+    void slotRelabelDocument(const Gui::Document& Doc);
+    /** Checks if the given document is renamed */
+    void slotRenameDocument(const Gui::Document& Doc);
+    /** Checks if the given document is activated */
+    void slotActivateDocument(const Gui::Document& Doc);
+    /** Checks if a new object was added. */
+    void slotCreatedObject(const Gui::ViewProvider& Obj);
+    /** Checks if the given object is about to be removed. */
+    void slotDeletedObject(const Gui::ViewProvider& Obj);
+    /** The property of an observed object has changed */
+    void slotChangedObject(const Gui::ViewProvider& Obj, const App::Property& Prop);
+
+private:
+    Py::Object inst;
+    static std::vector<DocumentObserverPython*> _instances;
+
+    typedef boost::signals::connection Connection;
+    Connection connectApplicationCreatedDocument;
+    Connection connectApplicationDeletedDocument;
+    Connection connectApplicationRelabelDocument;
+    Connection connectApplicationRenameDocument;
+    Connection connectApplicationActivateDocument;
+    Connection connectDocumentCreatedObject;
+    Connection connectDocumentDeletedObject;
+    Connection connectDocumentChangedObject;
+};
+
+} //namespace Gui
+
+#endif // GUI_DOCUMENTOBSERVERPYTHON_H

--- a/src/Mod/Test/Document.py
+++ b/src/Mod/Test/Document.py
@@ -1459,11 +1459,12 @@ class DocumentObserverCases(unittest.TestCase):
     FreeCAD.addDocumentObserver(self.Obs);
 
   def testDocument(self):
-
+    
     # testing document level signals
     self.Doc1 = FreeCAD.newDocument("Observer1");  
-    self.failUnless(self.Obs.signal.pop(0) == 'DocActivated')
-    self.failUnless(self.Obs.parameter.pop(0) is self.Doc1)
+    if FreeCAD.GuiUp:
+      self.failUnless(self.Obs.signal.pop(0) == 'DocActivated')
+      self.failUnless(self.Obs.parameter.pop(0) is self.Doc1)
     self.failUnless(self.Obs.signal.pop(0) == 'DocCreated')
     self.failUnless(self.Obs.parameter.pop(0) is self.Doc1)
     self.failUnless(self.Obs.signal.pop(0) == 'DocBeforeChange')
@@ -1477,8 +1478,9 @@ class DocumentObserverCases(unittest.TestCase):
     self.failUnless(not self.Obs.signal and not self.Obs.parameter and not self.Obs.parameter2)
     
     self.Doc2 = FreeCAD.newDocument("Observer2");
-    self.failUnless(self.Obs.signal.pop(0) == 'DocActivated')
-    self.failUnless(self.Obs.parameter.pop(0) is self.Doc2)
+    if FreeCAD.GuiUp:
+      self.failUnless(self.Obs.signal.pop(0) == 'DocActivated')
+      self.failUnless(self.Obs.parameter.pop(0) is self.Doc2)
     self.failUnless(self.Obs.signal.pop(0) == 'DocCreated')
     self.failUnless(self.Obs.parameter.pop(0) is self.Doc2)
     self.failUnless(self.Obs.signal.pop(0) == 'DocBeforeChange')
@@ -1496,6 +1498,10 @@ class DocumentObserverCases(unittest.TestCase):
     self.failUnless(self.Obs.parameter.pop() is self.Doc1)
     self.failUnless(not self.Obs.signal and not self.Obs.parameter and not self.Obs.parameter2)
 
+    #undo/redo is not enabled in cmd line mode by default
+    if not FreeCAD.GuiUp:
+      self.Doc2.UndoMode = 1
+    
     self.Doc2.openTransaction('test')
     self.failUnless(self.Obs.signal.pop() == 'DocOpenTransaction')
     self.failUnless(self.Obs.parameter.pop() is self.Doc2)

--- a/src/Mod/Test/Document.py
+++ b/src/Mod/Test/Document.py
@@ -1392,6 +1392,21 @@ class DocumentObserverCases(unittest.TestCase):
       self.signal.append('ObjRecomputed');
       self.parameter.append(obj)
       
+    def slotAppendDynamicProperty(self, obj, prop):
+      self.signal.append('ObjAddDynProp');
+      self.parameter.append(obj)
+      self.parameter2.append(prop)
+    
+    def slotRemoveDynamicProperty(self, obj, prop):
+      self.signal.append('ObjRemoveDynProp');
+      self.parameter.append(obj)
+      self.parameter2.append(prop)
+    
+    def slotChangePropertyEditor(self, obj, prop):
+      self.signal.append('ObjChangePropEdit');
+      self.parameter.append(obj)
+      self.parameter2.append(prop)
+      
     
   def setUp(self):
     self.Obs = self.Observer();
@@ -1529,8 +1544,32 @@ class DocumentObserverCases(unittest.TestCase):
     self.failUnless(self.Obs.parameter.pop() is obj)
     self.failUnless(not self.Obs.signal and not self.Obs.parameter and not self.Obs.parameter2)
     
+    pyobj = self.Doc1.addObject("App::FeaturePython","pyobj")
+    self.Obs.signal = []
+    self.Obs.parameter = []
+    self.Obs.parameter2 = []
+    pyobj.addProperty("App::PropertyLength","Prop","Group","test property")
+    self.failUnless(self.Obs.signal.pop() == 'ObjAddDynProp')
+    self.failUnless(self.Obs.parameter.pop() is pyobj)
+    self.failUnless(self.Obs.parameter2.pop() == 'Prop')
+    self.failUnless(not self.Obs.signal and not self.Obs.parameter and not self.Obs.parameter2)
+    
+    pyobj.setEditorMode('Prop', ['ReadOnly'])
+    self.failUnless(self.Obs.signal.pop() == 'ObjChangePropEdit')
+    self.failUnless(self.Obs.parameter.pop() is pyobj)
+    self.failUnless(self.Obs.parameter2.pop() == 'Prop')
+    self.failUnless(not self.Obs.signal and not self.Obs.parameter and not self.Obs.parameter2)
+    
+    pyobj.removeProperty('Prop')
+    self.failUnless(self.Obs.signal.pop() == 'ObjRemoveDynProp')
+    self.failUnless(self.Obs.parameter.pop() is pyobj)
+    self.failUnless(self.Obs.parameter2.pop() == 'Prop')
+    self.failUnless(not self.Obs.signal and not self.Obs.parameter and not self.Obs.parameter2)
+    
     FreeCAD.closeDocument('Observer1')
     self.Obs.signal = []
+    self.Obs.parameter = []
+    self.Obs.parameter2 = []
     
   def testUndoDisabledDocument(self):
 

--- a/src/Mod/Test/Document.py
+++ b/src/Mod/Test/Document.py
@@ -1359,6 +1359,16 @@ class DocumentObserverCases(unittest.TestCase):
     def slotAbortTransaction(self, doc):
       self.signal.append('DocAbortTransaction');
       self.parameter = doc;
+     
+    def slotBeforeChangeDocument(self, doc, prop):
+        self.signal.append('DocBeforeChange')
+        self.parameter = doc
+        self.parameter2 = prop
+        
+    def slotChangedDocument(self, doc, prop):
+        self.signal.append('DocChanged')
+        self.parameter = doc
+        self.parameter2 = prop
       
     def slotCreatedObject(self, obj):
       self.signal.append('ObjCreated');
@@ -1393,6 +1403,8 @@ class DocumentObserverCases(unittest.TestCase):
     self.Doc1 = FreeCAD.newDocument("Observer1");    
     self.failUnless(self.Obs.signal.pop(0) == 'DocActivated')
     self.failUnless(self.Obs.signal.pop(0) == 'DocCreated')
+    self.failUnless(self.Obs.signal.pop(0) == 'DocBeforeChange')
+    self.failUnless(self.Obs.signal.pop(0) == 'DocChanged')
     self.failUnless(self.Obs.signal.pop(0) == 'DocRelabled')
     self.failUnless(self.Obs.parameter is self.Doc1)
     self.failUnless(not self.Obs.signal)
@@ -1400,6 +1412,8 @@ class DocumentObserverCases(unittest.TestCase):
     self.Doc2 = FreeCAD.newDocument("Observer2");
     self.failUnless(self.Obs.signal.pop(0) == 'DocActivated')
     self.failUnless(self.Obs.signal.pop(0) == 'DocCreated')
+    self.failUnless(self.Obs.signal.pop(0) == 'DocBeforeChange')
+    self.failUnless(self.Obs.signal.pop(0) == 'DocChanged')
     self.failUnless(self.Obs.signal.pop(0) == 'DocRelabled')
     self.failUnless(self.Obs.parameter is self.Doc2)
     self.failUnless(not self.Obs.signal)
@@ -1439,6 +1453,12 @@ class DocumentObserverCases(unittest.TestCase):
     self.failUnless(self.Obs.signal.pop() == 'DocRedo')
     self.failUnless(self.Obs.parameter is self.Doc2)
     self.failUnless(not self.Obs.signal)
+    
+    self.Doc1.Comment = 'test comment'
+    self.failUnless(self.Obs.signal.pop(0) == 'DocBeforeChange')
+    self.failUnless(self.Obs.signal.pop(0) == 'DocChanged')
+    self.failUnless(self.Obs.parameter is self.Doc1)
+    self.failUnless(self.Obs.parameter2 == 'Comment')
     
     FreeCAD.closeDocument('Observer2')
     self.failUnless(self.Obs.signal.pop() == 'DocDeleted')

--- a/src/Mod/Test/Document.py
+++ b/src/Mod/Test/Document.py
@@ -1316,81 +1316,81 @@ class DocumentObserverCases(unittest.TestCase):
   class Observer():
     
     signal = []
-    parameter = None
-    parameter2 = None
+    parameter = []
+    parameter2 = []
     
     def slotCreatedDocument(self, doc):
       self.signal.append('DocCreated');
-      self.parameter = doc;
+      self.parameter.append(doc);
       
     def slotDeletedDocument(self, doc):
       self.signal.append('DocDeleted');
-      self.parameter = doc;
+      self.parameter.append(doc);
       
     def slotRelabelDocument(self, doc):
       self.signal.append('DocRelabled');
-      self.parameter = doc;
+      self.parameter.append(doc);
       
     def slotActivateDocument(self, doc):
       self.signal.append('DocActivated');
-      self.parameter = doc;
+      self.parameter.append(doc);
       
     def slotRecomputedDocument(self, doc):
       self.signal.append('DocRecomputed');
-      self.parameter = doc;
+      self.parameter.append(doc);
 
     def slotUndoDocument(self, doc):
       self.signal.append('DocUndo');
-      self.parameter = doc;
+      self.parameter.append(doc);
       
     def slotRedoDocument(self, doc):
       self.signal.append('DocRedo');
-      self.parameter = doc;
+      self.parameter.append(doc);
 
     def slotOpenTransaction(self, doc, name):
       self.signal.append('DocOpenTransaction');
-      self.parameter = doc;
-      self.parameter2 = name;
+      self.parameter.append(doc);
+      self.parameter2.append(name);
       
     def slotCommitTransaction(self, doc):
       self.signal.append('DocCommitTransaction');
-      self.parameter = doc;
+      self.parameter.append(doc);
       
     def slotAbortTransaction(self, doc):
       self.signal.append('DocAbortTransaction');
-      self.parameter = doc;
+      self.parameter.append(doc);
      
     def slotBeforeChangeDocument(self, doc, prop):
         self.signal.append('DocBeforeChange')
-        self.parameter = doc
-        self.parameter2 = prop
+        self.parameter.append(doc)
+        self.parameter2.append(prop)
         
     def slotChangedDocument(self, doc, prop):
         self.signal.append('DocChanged')
-        self.parameter = doc
-        self.parameter2 = prop
+        self.parameter.append(doc)
+        self.parameter2.append(prop)
       
     def slotCreatedObject(self, obj):
       self.signal.append('ObjCreated');
-      self.parameter = obj;
+      self.parameter.append(obj);
 
     def slotDeletedObject(self, obj):
       self.signal.append('ObjDeleted');
-      self.parameter = obj;
+      self.parameter.append(obj)
 
     def slotChangedObject(self, obj, prop):
       self.signal.append('ObjChanged');
-      self.parameter = obj;
-      self.parameter2 = prop;
+      self.parameter.append(obj)
+      self.parameter2.append(prop)
       
     def slotBeforeChangeObject(self, obj, prop):
       self.signal.append('ObjBeforeChange');
-      self.parameter = obj;
-      self.parameter2 = prop;
+      self.parameter.append(obj)
+      self.parameter2.append(prop)
 
     def slotRecomputedObject(self, obj):
       self.signal.append('ObjRecomputed');
-      self.parameter = obj;
+      self.parameter.append(obj)
       
     
   def setUp(self):
@@ -1400,112 +1400,134 @@ class DocumentObserverCases(unittest.TestCase):
   def testDocument(self):
 
     # testing document level signals
-    self.Doc1 = FreeCAD.newDocument("Observer1");    
+    self.Doc1 = FreeCAD.newDocument("Observer1");  
     self.failUnless(self.Obs.signal.pop(0) == 'DocActivated')
+    self.failUnless(self.Obs.parameter.pop(0) is self.Doc1)
     self.failUnless(self.Obs.signal.pop(0) == 'DocCreated')
+    self.failUnless(self.Obs.parameter.pop(0) is self.Doc1)
     self.failUnless(self.Obs.signal.pop(0) == 'DocBeforeChange')
+    self.failUnless(self.Obs.parameter.pop(0) is self.Doc1)
+    self.failUnless(self.Obs.parameter2.pop(0) == 'Label')
     self.failUnless(self.Obs.signal.pop(0) == 'DocChanged')
+    self.failUnless(self.Obs.parameter.pop(0) is self.Doc1)
+    self.failUnless(self.Obs.parameter2.pop(0) == 'Label')
     self.failUnless(self.Obs.signal.pop(0) == 'DocRelabled')
-    self.failUnless(self.Obs.parameter is self.Doc1)
-    self.failUnless(not self.Obs.signal)
+    self.failUnless(self.Obs.parameter.pop(0) is self.Doc1)
+    self.failUnless(not self.Obs.signal and not self.Obs.parameter and not self.Obs.parameter2)
     
     self.Doc2 = FreeCAD.newDocument("Observer2");
     self.failUnless(self.Obs.signal.pop(0) == 'DocActivated')
+    self.failUnless(self.Obs.parameter.pop(0) is self.Doc2)
     self.failUnless(self.Obs.signal.pop(0) == 'DocCreated')
+    self.failUnless(self.Obs.parameter.pop(0) is self.Doc2)
     self.failUnless(self.Obs.signal.pop(0) == 'DocBeforeChange')
+    self.failUnless(self.Obs.parameter.pop(0) is self.Doc2)
+    self.failUnless(self.Obs.parameter2.pop(0) == 'Label')
     self.failUnless(self.Obs.signal.pop(0) == 'DocChanged')
+    self.failUnless(self.Obs.parameter.pop(0) is self.Doc2)
+    self.failUnless(self.Obs.parameter2.pop(0) == 'Label')
     self.failUnless(self.Obs.signal.pop(0) == 'DocRelabled')
-    self.failUnless(self.Obs.parameter is self.Doc2)
-    self.failUnless(not self.Obs.signal)
+    self.failUnless(self.Obs.parameter.pop(0) is self.Doc2)
+    self.failUnless(not self.Obs.signal and not self.Obs.parameter and not self.Obs.parameter2)
     
     FreeCAD.setActiveDocument('Observer1')
     self.failUnless(self.Obs.signal.pop() == 'DocActivated')
-    self.failUnless(self.Obs.parameter is self.Doc1)
-    self.failUnless(not self.Obs.signal)
-    
+    self.failUnless(self.Obs.parameter.pop() is self.Doc1)
+    self.failUnless(not self.Obs.signal and not self.Obs.parameter and not self.Obs.parameter2)
+
     self.Doc2.openTransaction('test')
     self.failUnless(self.Obs.signal.pop() == 'DocOpenTransaction')
-    self.failUnless(self.Obs.parameter is self.Doc2)
-    self.failUnless(self.Obs.parameter2 == 'test')
-    self.failUnless(not self.Obs.signal)
+    self.failUnless(self.Obs.parameter.pop() is self.Doc2)
+    self.failUnless(self.Obs.parameter2.pop() == 'test')
+    self.failUnless(not self.Obs.signal and not self.Obs.parameter and not self.Obs.parameter2)
     
     self.Doc2.commitTransaction()
     self.failUnless(self.Obs.signal.pop() == 'DocCommitTransaction')
-    self.failUnless(self.Obs.parameter is self.Doc2)
-    self.failUnless(not self.Obs.signal)
+    self.failUnless(self.Obs.parameter.pop() is self.Doc2)
+    self.failUnless(not self.Obs.signal and not self.Obs.parameter and not self.Obs.parameter2)
     
     self.Doc2.openTransaction('test2')
     self.failUnless(self.Obs.signal.pop() == 'DocOpenTransaction')
-    self.failUnless(self.Obs.parameter is self.Doc2)
-    self.failUnless(not self.Obs.signal)
+    self.failUnless(self.Obs.parameter.pop() is self.Doc2)
+    self.failUnless(self.Obs.parameter2.pop() == 'test2')
+    self.failUnless(not self.Obs.signal and not self.Obs.parameter and not self.Obs.parameter2)
     
     self.Doc2.abortTransaction()
     self.failUnless(self.Obs.signal.pop() == 'DocAbortTransaction')
-    self.failUnless(self.Obs.parameter is self.Doc2)
-    self.failUnless(not self.Obs.signal)
+    self.failUnless(self.Obs.parameter.pop() is self.Doc2)
+    self.failUnless(not self.Obs.signal and not self.Obs.parameter and not self.Obs.parameter2)
     
     self.Doc2.undo()
     self.failUnless(self.Obs.signal.pop() == 'DocUndo')
-    self.failUnless(self.Obs.parameter is self.Doc2)
-    self.failUnless(not self.Obs.signal)
+    self.failUnless(self.Obs.parameter.pop() is self.Doc2)
+    self.failUnless(not self.Obs.signal and not self.Obs.parameter and not self.Obs.parameter2)
     
     self.Doc2.redo()
     self.failUnless(self.Obs.signal.pop() == 'DocRedo')
-    self.failUnless(self.Obs.parameter is self.Doc2)
-    self.failUnless(not self.Obs.signal)
+    self.failUnless(self.Obs.parameter.pop() is self.Doc2)
+    self.failUnless(not self.Obs.signal and not self.Obs.parameter and not self.Obs.parameter2)
     
     self.Doc1.Comment = 'test comment'
     self.failUnless(self.Obs.signal.pop(0) == 'DocBeforeChange')
+    self.failUnless(self.Obs.parameter.pop(0) is self.Doc1)
+    self.failUnless(self.Obs.parameter2.pop(0) == 'Comment')
     self.failUnless(self.Obs.signal.pop(0) == 'DocChanged')
-    self.failUnless(self.Obs.parameter is self.Doc1)
-    self.failUnless(self.Obs.parameter2 == 'Comment')
+    self.failUnless(self.Obs.parameter.pop(0) is self.Doc1)
+    self.failUnless(self.Obs.parameter2.pop(0) == 'Comment')
     
     FreeCAD.closeDocument('Observer2')
     self.failUnless(self.Obs.signal.pop() == 'DocDeleted')
-    self.failUnless(self.Obs.parameter is self.Doc2)
-    self.failUnless(not self.Obs.signal)
+    self.failUnless(self.Obs.parameter.pop() is self.Doc2)
+    self.failUnless(not self.Obs.signal and not self.Obs.parameter and not self.Obs.parameter2)
     
     FreeCAD.closeDocument('Observer1')
     self.failUnless(self.Obs.signal.pop() == 'DocDeleted')
-    self.failUnless(self.Obs.parameter is self.Doc1)
-    self.failUnless(not self.Obs.signal)
+    self.failUnless(self.Obs.parameter.pop() is self.Doc1)
+    self.failUnless(not self.Obs.signal and not self.Obs.parameter and not self.Obs.parameter2)
        
   def testObject(self):
     #testing signal on object changes
     
     self.Doc1 = FreeCAD.newDocument("Observer1")
     self.Obs.signal = []
+    self.Obs.parameter = []
+    self.Obs.parameter2 = []
     
     obj = self.Doc1.addObject("App::DocumentObject","obj")
     self.failUnless(self.Obs.signal.pop() == 'ObjCreated')
-    self.failUnless(self.Obs.parameter is obj)
+    self.failUnless(self.Obs.parameter.pop() is obj)
     #there are multiple object change signals
     self.Obs.signal = []
+    self.Obs.parameter = []
+    self.Obs.parameter2 = []
     
     obj.Label = "myobj"
     self.failUnless(self.Obs.signal.pop(0) == 'ObjBeforeChange')
+    self.failUnless(self.Obs.parameter.pop(0) is obj)
+    self.failUnless(self.Obs.parameter2.pop(0) == "Label")
     self.failUnless(self.Obs.signal.pop(0) == 'ObjChanged')
-    self.failUnless(self.Obs.parameter is obj)
-    self.failUnless(self.Obs.parameter2 == "Label")
-    self.failUnless(not self.Obs.signal)
+    self.failUnless(self.Obs.parameter.pop(0) is obj)
+    self.failUnless(self.Obs.parameter2.pop(0) == "Label")
+    self.failUnless(not self.Obs.signal and not self.Obs.parameter and not self.Obs.parameter2)
     
     obj.touch()
     obj.recompute()
     self.failUnless(self.Obs.signal.pop(0) == 'ObjRecomputed')
-    self.failUnless(self.Obs.parameter is obj)
-    self.failUnless(not self.Obs.signal)
+    self.failUnless(self.Obs.parameter.pop(0) is obj)
+    self.failUnless(not self.Obs.signal and not self.Obs.parameter and not self.Obs.parameter2)
     
     obj.touch()
     self.Doc1.recompute()
     self.failUnless(self.Obs.signal.pop(0) == 'ObjRecomputed')
+    self.failUnless(self.Obs.parameter.pop(0) is obj)
     self.failUnless(self.Obs.signal.pop(0) == 'DocRecomputed')
-    self.failUnless(self.Obs.parameter is self.Doc1)
-    self.failUnless(not self.Obs.signal)
+    self.failUnless(self.Obs.parameter.pop(0) is self.Doc1)
+    self.failUnless(not self.Obs.signal and not self.Obs.parameter and not self.Obs.parameter2)
     
     FreeCAD.ActiveDocument.removeObject(obj.Name)
-    self.failUnless(self.Obs.signal.pop(0) == 'ObjDeleted')
-    self.failUnless(self.Obs.parameter is obj)
-    self.failUnless(not self.Obs.signal)
+    self.failUnless(self.Obs.signal.pop() == 'ObjDeleted')
+    self.failUnless(self.Obs.parameter.pop() is obj)
+    self.failUnless(not self.Obs.signal and not self.Obs.parameter and not self.Obs.parameter2)
     
     FreeCAD.closeDocument('Observer1')
     self.Obs.signal = []
@@ -1516,15 +1538,19 @@ class DocumentObserverCases(unittest.TestCase):
     self.Doc1 = FreeCAD.newDocument("Observer1"); 
     self.Doc1.UndoMode = 0
     self.Obs.signal = []
+    self.Obs.parameter = []
+    self.Obs.parameter2 = []
      
     self.Doc1.openTransaction('test')  
     self.Doc1.commitTransaction()
     self.Doc1.undo()
     self.Doc1.redo()    
-    self.failUnless(not self.Obs.signal)
+    self.failUnless(not self.Obs.signal and not self.Obs.parameter and not self.Obs.parameter2)
   
     FreeCAD.closeDocument('Observer1')
     self.Obs.signal = []
+    self.Obs.parameter = []
+    self.Obs.parameter2 = []
 
   def tearDown(self):
     #closing doc


### PR DESCRIPTION
Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [x] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

--
The freecad document observers, which are addable from python, receive more signals for the app document. Furthermore, an additional observer for gui documents was added. This allows a more comprehensible  observation of document actions from python.