### PR TITLE
Sketcher: Avoid transfering angle constraints

### DIFF
--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -1137,8 +1137,17 @@ int SketchObject::transferConstraints(int fromGeoId, PointPos fromPosId, int toG
             constNew->First = toGeoId;
             constNew->FirstPos = toPosId;
 
-            if(vals[i]->Type == Sketcher::Tangent || vals[i]->Type == Sketcher::Perpendicular)
+            if(vals[i]->Type == Sketcher::Tangent || vals[i]->Type == Sketcher::Perpendicular){
                 constNew->Type = Sketcher::Coincident;
+            }
+            // with respect to angle constraints, if it is a DeepSOIC style angle constraint (segment+segment+point), then no problem arises
+            // as the segments are PosId=none. In this case there is not call to this function.
+            //
+            // However, other angle constraints are problematic because they are created on segments, but internally operate on vertices, PosId=start
+            // such constraint may not be succesfully transfered on deletion of the segments.
+            else if(vals[i]->Type == Sketcher::Angle) {
+                continue;
+            }
 
             newVals[i] = constNew;
             changed.push_back(constNew);
@@ -1153,8 +1162,12 @@ int SketchObject::transferConstraints(int fromGeoId, PointPos fromPosId, int toG
             // Nothing guarantees that a tangent can be freely transferred to another coincident point, as
             // the transfer destination edge most likely won't be intended to be tangent. However, if it is
             // an end to end point tangency, the user expects it to be substituted by a coincidence constraint.
-            if(vals[i]->Type == Sketcher::Tangent || vals[i]->Type == Sketcher::Perpendicular)
+            if(vals[i]->Type == Sketcher::Tangent || vals[i]->Type == Sketcher::Perpendicular) {
                 constNew->Type = Sketcher::Coincident;
+            }
+            else if(vals[i]->Type == Sketcher::Angle) {
+                continue;
+            }
 
             newVals[i] = constNew;
             changed.push_back(constNew);


### PR DESCRIPTION

Angle constraints are internally coded using the diverging points of the segments (PointPos != none) in normal 2 segment angle constraints.

This creates a problem with the mechanism to transfer enpoints on angle deletion.

fixes #3589

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [x] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
