### PR TITLE
Fix Slow DetailView

### DIFF
--- a/src/Mod/TechDraw/App/DrawViewPart.cpp
+++ b/src/Mod/TechDraw/App/DrawViewPart.cpp
@@ -335,7 +335,9 @@ TechDrawGeometry::GeometryObject* DrawViewPart::buildGeometryObject(TopoDS_Shape
         go->projectShape(shape,
             viewAxis);
     }
-    
+
+    auto start = chrono::high_resolution_clock::now();
+
     go->extractGeometry(TechDrawGeometry::ecHARD,                   //always show the hard&outline visible lines
                         true);
     go->extractGeometry(TechDrawGeometry::ecOUTLINE,
@@ -370,6 +372,11 @@ TechDrawGeometry::GeometryObject* DrawViewPart::buildGeometryObject(TopoDS_Shape
         go->extractGeometry(TechDrawGeometry::ecUVISO,
                             false);
     }
+    auto end   = chrono::high_resolution_clock::now();
+    auto diff  = end - start;
+    double diffOut = chrono::duration <double, milli> (diff).count();
+    Base::Console().Log("TIMING - %s DVP spent: %.3f millisecs in GO::extractGeometry\n",getNameInDocument(),diffOut);
+
     bbox = go->calcBoundingBox();
     return go;
 }

--- a/src/Mod/TechDraw/App/GeometryObject.cpp
+++ b/src/Mod/TechDraw/App/GeometryObject.cpp
@@ -192,6 +192,8 @@ void GeometryObject::projectShape(const TopoDS_Shape& input,
     double diffOut = chrono::duration <double, milli> (diff).count();
     Base::Console().Log("TIMING - %s GO spent: %.3f millisecs in HLRBRep_Algo & co\n",m_parentName.c_str(),diffOut);
 
+    start = chrono::high_resolution_clock::now();
+
     try {
         HLRBRep_HLRToShape hlrToShape(brep_hlr);
 
@@ -221,6 +223,11 @@ void GeometryObject::projectShape(const TopoDS_Shape& input,
     catch (...) {
         Standard_Failure::Raise("GeometryObject::projectShape - error occurred while extracting edges");
     }
+    end   = chrono::high_resolution_clock::now();
+    diff  = end - start;
+    diffOut = chrono::duration <double, milli> (diff).count();
+    Base::Console().Log("TIMING - %s GO spent: %.3f millisecs in hlrToShape and BuildCurves\n",m_parentName.c_str(),diffOut);
+
 }
 
 //!set up a hidden line remover and project a shape with it

--- a/src/Mod/TechDraw/Gui/QGIMatting.cpp
+++ b/src/Mod/TechDraw/Gui/QGIMatting.cpp
@@ -79,7 +79,7 @@ QGIMatting::QGIMatting() :
 void QGIMatting::draw()
 {
     prepareGeometryChange();
-    double radiusFudge = 1.1;                    //keep slightly larger than fudge in App/DVDetail to prevent bleed through
+    double radiusFudge = 1.25;                    //keep slightly larger than fudge in App/DVDetail to prevent bleed through
     double outerRadius = m_radius * radiusFudge;
     m_width = outerRadius;
     m_height = outerRadius;


### PR DESCRIPTION
This PR corrects a problem with slow response time from DrawDetailView.  Please merge.
Thanks,
wf

- cutting with cylinder produced too many
  short bsplines from HLR.  Straight cut
  from prism reduces these and speeds up
  HLR significantly.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
