### PR TITLE
py3: Draft: use proper way to test if an object has a specific property

### DIFF
--- a/src/Mod/Draft/Draft.py
+++ b/src/Mod/Draft/Draft.py
@@ -7323,17 +7323,17 @@ class ViewProviderDraftText:
 
     def onChanged(self,vobj,prop):
         if prop == "TextColor":
-            if hasattr(vobj,"TextColor"):
+            if "TextColor" in vobj.PropertiesList:
                 l = vobj.TextColor
                 self.mattext.diffuseColor.setValue([l[0],l[1],l[2]])
         elif (prop == "FontName"):
-            if hasattr(vobj,"FontName"):
+            if "FontName" in vobj.PropertiesList:
                 self.font.name = vobj.FontName.encode("utf8")
         elif prop  == "FontSize":
-            if hasattr(vobj,"FontSize"):
+            if "FontSize" in vobj.PropertiesList:
                 self.font.size = vobj.FontSize.Value
         elif prop == "Justification":
-            if hasattr(vobj,"Justification"):
+            if "Justification" in vobj.PropertiesList:
                 from pivy import coin
                 if vobj.Justification == "Left":
                     self.text2d.justification = coin.SoText2.LEFT
@@ -7345,7 +7345,7 @@ class ViewProviderDraftText:
                     self.text2d.justification = coin.SoText2.CENTER
                     self.text3d.justification = coin.SoAsciiText.CENTER
         elif prop == "LineSpacing":
-            if hasattr(vobj,"LineSpacing"):
+            if "LineSpacing" in vobj.PropertiesList:
                 self.text2d.spacing = vobj.LineSpacing
                 self.text3d.spacing = vobj.LineSpacing
 


### PR DESCRIPTION
if the attribute is not available py3 raises: `<class 'AssertionError'>: The enum is empty`. For py2 hasattr simple returns False. Similar changes should be applied also to other places.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
