### PR TITLE
Revert "remove unused shiboken wrapper for Base::Quantity"

### DIFF
--- a/src/Gui/View3DInventorViewer.h
+++ b/src/Gui/View3DInventorViewer.h
@@ -43,6 +43,7 @@
 class SoTranslation;
 class SoTransform;
 class SoText2;
+namespace Quarter = SIM::Coin3D::Quarter;
 
 class SoSeparator;
 class SoShapeHints;
@@ -55,8 +56,6 @@ class SoVectorizeAction;
 class QImage;
 class SoGroup;
 class NaviCube;
-
-namespace Quarter = SIM::Coin3D::Quarter;
 
 namespace Gui {
 

--- a/src/Gui/WidgetFactory.cpp
+++ b/src/Gui/WidgetFactory.cpp
@@ -114,6 +114,81 @@ PyTypeObject** SbkPySide2_QtWidgetsTypes=NULL;
 
 using namespace Gui;
 
+#if defined (HAVE_SHIBOKEN)
+
+PyObject* toPythonFuncQuantityTyped(Base::Quantity cpx) {
+    return new Base::QuantityPy(new Base::Quantity(cpx));
+}
+
+PyObject* toPythonFuncQuantity(const void* cpp)
+{
+    return toPythonFuncQuantityTyped(*reinterpret_cast<const Base::Quantity*>(cpp));
+}
+
+void toCppPointerConvFuncQuantity(PyObject* pyobj,void* cpp)
+{
+   *((Base::Quantity*)cpp) = *static_cast<Base::QuantityPy*>(pyobj)->getQuantityPtr();
+}
+
+PythonToCppFunc toCppPointerCheckFuncQuantity(PyObject* obj)
+{
+    if (PyObject_TypeCheck(obj, &(Base::QuantityPy::Type)))
+        return toCppPointerConvFuncQuantity;
+    else
+        return 0;
+}
+
+void BaseQuantity_PythonToCpp_QVariant(PyObject* pyIn, void* cppOut)
+{
+    Base::Quantity* q = static_cast<Base::QuantityPy*>(pyIn)->getQuantityPtr();
+    *((QVariant*)cppOut) = QVariant::fromValue<Base::Quantity>(*q);
+}
+
+PythonToCppFunc isBaseQuantity_PythonToCpp_QVariantConvertible(PyObject* obj)
+{
+    if (PyObject_TypeCheck(obj, &(Base::QuantityPy::Type)))
+        return BaseQuantity_PythonToCpp_QVariant;
+    return 0;
+}
+
+#if QT_VERSION >= 0x050200
+Base::Quantity convertWrapperToQuantity(const PySide::PyObjectWrapper &w)
+{
+    PyObject* pyIn = static_cast<PyObject*>(w);
+    if (PyObject_TypeCheck(pyIn, &(Base::QuantityPy::Type))) {
+        return *static_cast<Base::QuantityPy*>(pyIn)->getQuantityPtr();
+    }
+
+    return Base::Quantity(std::numeric_limits<double>::quiet_NaN());
+}
+#endif
+
+void registerTypes()
+{
+    SbkConverter* convert = Shiboken::Conversions::createConverter(&Base::QuantityPy::Type,
+                                                                   toPythonFuncQuantity);
+    Shiboken::Conversions::setPythonToCppPointerFunctions(convert,
+                                                          toCppPointerConvFuncQuantity,
+                                                          toCppPointerCheckFuncQuantity);
+    Shiboken::Conversions::registerConverterName(convert, "Base::Quantity");
+
+    SbkConverter* qvariant_conv = Shiboken::Conversions::getConverter("QVariant");
+    if (qvariant_conv) {
+        // The type QVariant already has a converter from PyBaseObject_Type which will
+        // come before our own converter.
+        Shiboken::Conversions::addPythonToCppValueConversion(qvariant_conv,
+                                                             BaseQuantity_PythonToCpp_QVariant,
+                                                             isBaseQuantity_PythonToCpp_QVariantConvertible);
+    }
+
+#if QT_VERSION >= 0x050200
+    QMetaType::registerConverter<PySide::PyObjectWrapper, Base::Quantity>(&convertWrapperToQuantity);
+#endif
+}
+#endif
+
+// --------------------------------------------------------
+
 namespace Gui {
 template<typename qttype>
 Py::Object qt_wrapInstance(qttype object, const char* className,
@@ -173,6 +248,13 @@ void* qt_getCppPointer(const Py::Object& pyobject, const char* shiboken, const c
 
 PythonWrapper::PythonWrapper()
 {
+#if defined (HAVE_SHIBOKEN)
+    static bool init = false;
+    if (!init) {
+        init = true;
+        registerTypes();
+    }
+#endif
 }
 
 bool PythonWrapper::toCString(const Py::Object& pyobject, std::string& str)


### PR DESCRIPTION
Hi,

I am asking if we can revert commit 0c63ab4234e257b290230feafd2356d25bb6ca40 - "remove unused shiboken wrapper for Base::Quantity". This gives issues when trying to catch the valueChanged(Quantity) signal in Python code, when it is emitted in the InputField::newInput() function.

We get the error message - "TypeError: Can't call meta function because I have no idea how to handle Base::Quantity". This error message is produced when [this line](https://github.com/FreeCAD/FreeCAD/blob/c950d1f093c6e1e846ac5fd5806646ab69adbfbe/src/Gui/InputField.cpp#L298) is reached in the code, and the signal is not caught in python. It was reported [here](https://forum.freecadweb.org/viewtopic.php?f=37&t=24147&p=263202#p263188).

As I don't know anything about Shiboken, I am happy to be corrected if there is some other way this should be handled :)


Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [*] Branch rebased on latest master `git pull --rebase upstream master`
- [* ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [* ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [* ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
