### PR TITLE
Fix Crash on RevertDocument

### DIFF
--- a/src/Mod/TechDraw/Gui/ViewProviderPage.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderPage.cpp
@@ -83,6 +83,7 @@ ViewProviderPage::ViewProviderPage()
 
 ViewProviderPage::~ViewProviderPage()
 {
+    removeMDIView();                    //if the MDIViewPage is still in MainWindow, remove it.
 }
 
 void ViewProviderPage::attach(App::DocumentObject *pcFeat)
@@ -115,13 +116,18 @@ std::vector<std::string> ViewProviderPage::getDisplayModes(void) const
 
 void ViewProviderPage::show(void)
 {
+    Visibility.setValue(true);
     showMDIViewPage();
 }
 
-//this "hide" is only used for Visibility property toggle
-//not when Page tab is closed.
-//WF: is this right? same behaviour either way.
 void ViewProviderPage::hide(void)
+{
+    Visibility.setValue(false);
+    removeMDIView();
+    ViewProviderDocumentObject::hide();
+}
+
+void ViewProviderPage::removeMDIView(void)
 {
     if (!m_mdiView.isNull()) {                                //m_mdiView is a QPointer
         // https://forum.freecadweb.org/viewtopic.php?f=3&t=22797&p=182614#p182614
@@ -136,7 +142,6 @@ void ViewProviderPage::hide(void)
             }
         }
     }
-    ViewProviderDocumentObject::hide();
 }
 
 void ViewProviderPage::updateData(const App::Property* prop)
@@ -162,9 +167,7 @@ void ViewProviderPage::updateData(const App::Property* prop)
 bool ViewProviderPage::onDelete(const std::vector<std::string> &items)
 {
     bool rc = ViewProviderDocumentObject::onDelete(items);
-    if (!m_mdiView.isNull()) {
-        m_mdiView->deleteSelf();
-    }
+    removeMDIView();
     return rc;
 }
 
@@ -207,8 +210,11 @@ bool ViewProviderPage::doubleClicked(void)
 bool ViewProviderPage::showMDIViewPage()
 {
    if (isRestoring()) {
-        return true;
-    }
+       return true;
+   }
+   if (!Visibility.getValue())   {
+       return true;
+   }
 
     if (m_mdiView.isNull()){
         Gui::Document* doc = Gui::Application::Instance->getDocument

--- a/src/Mod/TechDraw/Gui/ViewProviderPage.h
+++ b/src/Mod/TechDraw/Gui/ViewProviderPage.h
@@ -80,6 +80,7 @@ public:
     void unsetEdit(int ModNum);
     MDIViewPage* getMDIViewPage();
     bool showMDIViewPage();
+    void removeMDIView(void);
 
 protected:
     bool setEdit(int ModNum);


### PR DESCRIPTION
This PR fixes a crash in TD on reverting document.   Please merge.
Thanks,
wf

- MDIViewPage was not being deleted when document
  was closed. On reload, stale MDIViewPage was using
  old object pointers.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
