### PR TITLE
Misc. typos and whitespace fixes

### DIFF
--- a/src/App/Application.h
+++ b/src/App/Application.h
@@ -1,5 +1,5 @@
 /***************************************************************************
- *   (c) Jürgen Riegel (juergen.riegel@web.de) 2002                        *   
+ *   (c) Jürgen Riegel (juergen.riegel@web.de) 2002                        *
  *                                                                         *
  *   This file is part of the FreeCAD CAx development system.              *
  *                                                                         *
@@ -10,7 +10,7 @@
  *   for detail see the LICENCE text file.                                 *
  *                                                                         *
  *   FreeCAD is distributed in the hope that it will be useful,            *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of        * 
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
  *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
  *   GNU Library General Public License for more details.                  *
  *                                                                         *
@@ -34,9 +34,9 @@
 #include <Base/Observer.h>
 
 
-namespace Base 
+namespace Base
 {
-    class ConsoleObserverStd; 
+    class ConsoleObserverStd;
     class ConsoleObserverFile;
 }
 
@@ -71,7 +71,7 @@ public:
      * spaces and not starting with a number. This name gets also forced to be unique
      * in this Application. You can avoid the renaming by using getUniqueDocumentName()
      * to get a unique name before calling newDoucument().
-     * The second name is a UTF8 name of any kind. It's that name normally shown to 
+     * The second name is a UTF8 name of any kind. It's that name normally shown to
      * the user and stored in the App::Document::Name property.
      */
     App::Document* newDocument(const char * Name=0l, const char * UserName=0l);
@@ -128,13 +128,13 @@ public:
 
 
     /** @name Signals of the document
-     * This signals are an aggregation of all document. If you only 
+     * This signals are an aggregation of all document. If you only
      * the signal of a special document connect to the document itself
      */
     //@{
     /// signal before change of doc property
     boost::signal<void (const App::Document&, const App::Property&)> signalBeforeChangeDocument;
-    /// signal on changed doc proeprty
+    /// signal on changed doc property
     boost::signal<void (const App::Document&, const App::Property&)> signalChangedDocument;
     /// signal on new Object
     boost::signal<void (const App::DocumentObject&)> signalNewObject;
@@ -155,7 +155,7 @@ public:
     boost::signal<void (const App::DocumentObject&)> signalObjectRecomputed;
     // signal on opened transaction
     boost::signal<void (const App::Document&, std::string)> signalOpenTransaction;
-    // signal a commited transaction
+    // signal a committed transaction
     boost::signal<void (const App::Document&)> signalCommitTransaction;
     // signal an aborted transaction
     boost::signal<void (const App::Document&)> signalAbortTransaction;
@@ -198,12 +198,12 @@ public:
     void RemoveParameterSet(const char* sName);
     //@}
 
-    /** @name methods for the open handler 
-     *  With this facility a Application module can register 
-     *  a ending (filetype) which he can handle to open. 
+    /** @name methods for the open handler
+     *  With this facility a Application module can register
+     *  a ending (filetype) which he can handle to open.
      *  The ending and the module name are stored and if the file
      *  type is opened the module get loaded and need to register a
-     *  OpenHandler class in the OpenHandlerFactorySingleton. 
+     *  OpenHandler class in the OpenHandlerFactorySingleton.
      *  After the module is loaded a OpenHandler of this type is created
      *  and the file get loaded.
      *  @see OpenHandler
@@ -280,7 +280,7 @@ protected:
     /// get called by the document when the name is changing
     void renameDocument(const char *OldName, const char *NewName);
 
-    /** @name I/O of the document 
+    /** @name I/O of the document
      * This slot get connected to all App::Documents created
      */
     //@{
@@ -353,7 +353,7 @@ private:
     static PyObject *sSetLogLevel       (PyObject *self,PyObject *args);
     static PyObject *sGetLogLevel       (PyObject *self,PyObject *args);
 
-    static PyMethodDef    Methods[]; 
+    static PyMethodDef    Methods[];
 
     friend class ApplicationObserver;
 
@@ -414,4 +414,3 @@ inline App::Application &GetApplication(void){
 
 
 #endif // APP_APPLICATION_H
-

--- a/src/App/Document.h
+++ b/src/App/Document.h
@@ -140,7 +140,7 @@ public:
     /** signal on load/save document
      * this signal is given when the document gets streamed.
      * you can use this hook to write additional information in
-     * the file (like the Gui::Document it does).
+     * the file (like the Gui::Document does).
      */
     boost::signal<void (Base::Writer   &)> signalSaveDocument;
     boost::signal<void (Base::XMLReader&)> signalRestoreDocument;
@@ -160,7 +160,7 @@ public:
     boost::signal<void (const App::DocumentObject&)> signalRecomputedObject;
     //signal a new opened transaction
     boost::signal<void (const App::Document&, std::string)> signalOpenTransaction;
-    // signal a commited transaction
+    // signal a committed transaction
     boost::signal<void (const App::Document&)> signalCommitTransaction;
     // signal an aborted transaction
     boost::signal<void (const App::Document&)> signalAbortTransaction;
@@ -219,7 +219,7 @@ public:
      * is raised.
      */
     void addObject(DocumentObject*, const char* pObjectName=0);
-    
+
 
     /** Copy an object from another document to this document
      * If \a recursive is true then all objects this object depends on

--- a/src/App/DocumentObject.h
+++ b/src/App/DocumentObject.h
@@ -139,7 +139,7 @@ public:
 
     /** DAG handling
         This part of the interface deals with viewing the document as
-        an DAG (directed acyclic graph). 
+        a DAG (directed acyclic graph).
     */
     //@{
     /// returns a list of objects this object is pointing to by Links
@@ -152,7 +152,7 @@ public:
     std::vector<std::list<App::DocumentObject*> > getPathsByOutList(App::DocumentObject* to) const;
     /// get all objects link to this object
     std::vector<App::DocumentObject*> getInList(void) const;
-    /// get all objects link directly or indirectly to this object 
+    /// get all objects link directly or indirectly to this object
     std::vector<App::DocumentObject*> getInListRecursive(void) const;
     /// get group if object is part of a group, otherwise 0 is returned
     DocumentObjectGroup* getGroup() const;
@@ -191,8 +191,8 @@ public:
      *  We call this method to check if the object was modified to
      *  be invoked. If the object label or an argument is modified.
      *  If we must recompute the object - to call the method execute().
-     *  0: no recompution is needed
-     *  1: recompution needed
+     *  0: no recomputation is needed
+     *  1: recomputation needed
      *
      * @remark If an object is marked as 'touched' then this does not
      * necessarily mean that it will be recomputed. It only means that all
@@ -243,7 +243,7 @@ protected:
     /** get called by the document to recompute this feature
       * Normally this method get called in the processing of
       * Document::recompute().
-      * In execute() the outpupt properties get recomputed
+      * In execute() the output properties get recomputed
       * with the data from linked objects and objects own
       * properties.
       */
@@ -251,7 +251,7 @@ protected:
 
     /** Status bits of the document object
      * The first 8 bits are used for the base system the rest can be used in
-     * descendent classes to to mark special stati on the objects.
+     * descendent classes to mark special statuses on the objects.
      * The bits and their meaning are listed below:
      *  0 - object is marked as 'touched'
      *  1 - object is marked as 'erroneous'
@@ -284,7 +284,7 @@ protected:
     /// get called when object is going to be removed from the document
     virtual void unsetupObject();
 
-     /// python object of this class and all descendend
+     /// python object of this class and all descendent
 protected: // attributes
     Py::Object PythonObject;
     /// pointer to the document this object belongs to
@@ -300,7 +300,7 @@ protected: // attributes
 
     // pointer to the document name string (for performance)
     const std::string *pcNameInDocument;
-    
+
 private:
     // Back pointer to all the fathers in a DAG of the document
     // this is used by the document (via friend) to have a effective DAG handling

--- a/src/App/Property.h
+++ b/src/App/Property.h
@@ -90,7 +90,7 @@ public:
     virtual const char* getEditorName(void) const { return ""; }
 
     /// Get the type of the property in the container
-    short getType(void) const; 
+    short getType(void) const;
 
     /// Get the group of this property
     const char* getGroup(void) const;
@@ -121,11 +121,11 @@ public:
     //@{
     /// Set the property touched
     void touch();
-    /// Test if this property is touched 
+    /// Test if this property is touched
     inline bool isTouched(void) const {
         return StatusBits.test(Touched);
     }
-    /// Reset this property touched 
+    /// Reset this property touched
     inline void purgeTouched(void) {
         StatusBits.reset(Touched);
     }
@@ -166,7 +166,7 @@ public:
 protected:
     /** Status bits of the property
      * The first 8 bits are used for the base system the rest can be used in
-     * descendent classes to to mark special stati on the objects.
+     * descendent classes to mark special statuses on the objects.
      * The bits and their meaning are listed below:
      * 0 - object is marked as 'touched'
      * 1 - object is marked as 'immutable'
@@ -196,7 +196,7 @@ private:
 
 /** Base class of all property lists.
  * The PropertyLists class is the base class for properties which can contain
- * multiple values, not only a single value. 
+ * multiple values, not only a single value.
  * All property types which may contain more than one value inherits this class.
  */
 class AppExport PropertyLists : public Property
@@ -204,24 +204,28 @@ class AppExport PropertyLists : public Property
     TYPESYSTEM_HEADER();
 
 public:
-    virtual void setSize(int newSize)=0;   
-    virtual int getSize(void) const =0;   
+    virtual void setSize(int newSize)=0;
+    virtual int getSize(void) const =0;
 };
 
 /** A template class that is used to inhibit multiple nested calls to aboutToSetValue/hasSetValue for properties.
  *
- * A template class that is used to inhibit multiple nested calls to aboutToSetValue/hasSetValue for properties, and
- * only invoke it the first and last time it is needed. This is useful in cases where you want to change multiple
- * values in a property "atomically", using possibly multiple primitive functions that normally would trigger
- * aboutToSetValue/hasSetValue calls on their own.
+ * A template class that is used to inhibit multiple nested calls to
+ * aboutToSetValue/hasSetValue for properties, and only invoke it the first and
+ * last time it is needed. This is useful in cases where you want to change multiple
+ * values in a property "atomically", using possibly multiple primitive functions
+ * that normally would trigger aboutToSetValue/hasSetValue calls on their own.
  *
- * To use, inherit privately from the AtomicPropertyChangeInterface class, using your class name as the template argument.
- * In all cases where you normally would call aboutToSetValue/hasSetValue before and after a change, create
- * an AtomicPropertyChange object before you do the change. Depending on a counter in the main property, the constructor might
- * invoke aboutToSetValue. When the AtomicPropertyChange object is destructed, it might call hasSetValue if it is found
- * necessary to do (i.e last item on the AtomicPropertyChange stack). This makes it easy to match the calls, and it is also
- * exception safe in the sense that the destructors are guaranteed to be called during unwinding and exception
- * handling, making the calls to boutToSetValue and hasSetValue balanced.
+ * To use, inherit privately from the AtomicPropertyChangeInterface class, using
+ * your class name as the template argument. In all cases where you normally would
+ * call aboutToSetValue/hasSetValue before and after a change, create an
+ * AtomicPropertyChange object before you do the change. Depending on a counter
+ * in the main property, the constructor might invoke aboutToSetValue. When the
+ * AtomicPropertyChange object is destructed, it might call hasSetValue if it is
+ * found necessary to do (i.e last item on the AtomicPropertyChange stack).
+ * This makes it easy to match the calls, and it is also exception safe in the
+ * sense that the destructors are guaranteed to be called during unwinding and
+ * exception handling, making the calls to boutToSetValue and hasSetValue balanced.
  *
  */
 

--- a/src/App/Property.h
+++ b/src/App/Property.h
@@ -145,7 +145,7 @@ public:
         return testStatus(App::Property::ReadOnly);
     }
     /// Sets precision of properties using floating point
-    /// numners to single, the default is double.
+    /// numbers to single, the default is double.
     void setSinglePrecision(bool single) {
         setStatus(App::Property::Single, single);
     }

--- a/src/Base/BaseClassPy.xml
+++ b/src/Base/BaseClassPy.xml
@@ -21,7 +21,7 @@
     </Methode>
     <Methode Name="getAllDerivedFrom" Const="true">
       <Documentation>
-        <UserDocu>Returns all descendence</UserDocu>
+        <UserDocu>Returns all descendants</UserDocu>
       </Documentation>
     </Methode>
     <Attribute Name="TypeId" ReadOnly="true">

--- a/src/Base/BaseClassPy.xml
+++ b/src/Base/BaseClassPy.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <GenerateModel xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="generateMetaModel_Module.xsd">
-  <PythonExport 
-      Father="PyObjectBase" 
-      Name="BaseClassPy" 
-      Twin="BaseClass" 
-      TwinPointer="BaseClass" 
-      Include="Base/BaseClass.h" 
-      FatherInclude="Base/PyObjectBase.h" 
-      Namespace="Base" 
+  <PythonExport
+      Father="PyObjectBase"
+      Name="BaseClassPy"
+      Twin="BaseClass"
+      TwinPointer="BaseClass"
+      Include="Base/BaseClass.h"
+      FatherInclude="Base/PyObjectBase.h"
+      Namespace="Base"
       FatherNamespace="Base">
     <Documentation>
       <Author Licence="LGPL" Name="Juergen Riegel" EMail="FreeCAD@juergen-riegel.net" />
@@ -21,7 +21,7 @@
     </Methode>
     <Methode Name="getAllDerivedFrom" Const="true">
       <Documentation>
-        <UserDocu>Returns all descentences</UserDocu>
+        <UserDocu>Returns all descendence</UserDocu>
       </Documentation>
     </Methode>
     <Attribute Name="TypeId" ReadOnly="true">

--- a/src/Gui/SoFCColorBar.h
+++ b/src/Gui/SoFCColorBar.h
@@ -41,7 +41,7 @@ namespace Gui {
 class SoFCColorGradient;
 
 /**
- * The abstract color bar base class to get most important information on how to convert a scalar to an RGB color. 
+ * The abstract color bar base class to get most important information on how to convert a scalar to an RGB color.
  * @author Werner Mayer
  */
 class GuiExport SoFCColorBarBase : public SoSeparator, public App::ValueFloatToRGB {
@@ -82,24 +82,24 @@ public:
    * This method must be implemented in subclasses.
    */
   virtual void setOutsideGrayed (bool bVal) = 0;
-  /** Returns the current minimum of the parameter range. 
+  /** Returns the current minimum of the parameter range.
    *
    * This method must be implemented in subclasses.
    */
   virtual float getMinValue (void) const = 0;
-  /** Returns the current maximum of the parameter range. 
+  /** Returns the current maximum of the parameter range.
    *
    * This method must be implemented in subclasses.
    */
   virtual float getMaxValue (void) const = 0;
   /**
-   * Opems a dialog to customie the current settings of the color bar.
+   * Opens a dialog to customize the current settings of the color bar.
    * Returns true if the settings have been changed, false otherwise.
    *
    * This method must be implemented in subclasses.
    */
   virtual bool customize() = 0;
-  /** Returns the name of the color bar. 
+  /** Returns the name of the color bar.
    *
    * This method must be implemented in subclasses.
    */
@@ -123,7 +123,7 @@ private:
 // --------------------------------------------------------------------------
 
 /**
- * The color bar class that redirects all calls to its handled color bars. 
+ * The color bar class that redirects all calls to its handled color bars.
  * @author Werner Mayer
  */
 class GuiExport SoFCColorBar : public SoFCColorBarBase, public Base::Subject<int> {
@@ -161,19 +161,19 @@ public:
    * Returns the return value of the currently active color bar.
    */
   bool isVisible (float fVal) const;
-  /** 
-   * Returns the current minimum of the parameter range of the currently active color bar. 
+  /**
+   * Returns the current minimum of the parameter range of the currently active color bar.
    */
   float getMinValue (void) const;
-  /** 
-   * Returns the current maximum of the parameter range of the currently active color bar. 
+  /**
+   * Returns the current maximum of the parameter range of the currently active color bar.
    */
   float getMaxValue (void) const;
   /**
    * Customizes the currently active color bar.
    */
   bool customize();
-  /** Returns the name of the color bar. 
+  /** Returns the name of the color bar.
    */
   const char* getColorBarName() const { return "Color Bar"; }
 
@@ -192,7 +192,7 @@ private:
   float _fMaxX, _fMinX, _fMaxY, _fMinY;
   QTime _timer;
 
-  SoSwitch* pColorMode; 
+  SoSwitch* pColorMode;
   std::vector<SoFCColorBarBase*> _colorBars;
 };
 
@@ -200,4 +200,3 @@ private:
 
 
 #endif // GUI_SOFCCOLORBAR_H
-

--- a/src/Gui/SoFCColorGradient.h
+++ b/src/Gui/SoFCColorGradient.h
@@ -66,7 +66,7 @@ public:
   /** Returns the current maximum of the parameter range. */
   float getMaxValue (void) const { return _cColGrad.getMaxValue(); }
   /**
-   * Opems a dialog to customie the current settings of the color gradient bar.
+   * Opens a dialog to customize the current settings of the color gradient bar.
    * Returns true if the settings have been changed, false otherwise.
    */
   bool customize();
@@ -75,7 +75,7 @@ public:
 
 protected:
   /**
-   * Sets the current viewer size this color gradient is embedded into to recalculate its new position.
+   * Sets the current viewer size this color gradient is embedded into, to recalculate its new position.
    */
   void setViewportSize( const SbVec2s& size );
 
@@ -112,4 +112,3 @@ private:
 
 
 #endif // GUI_SOFCCOLORGRADIENT_H
-

--- a/src/Gui/View3DInventorViewer.cpp
+++ b/src/Gui/View3DInventorViewer.cpp
@@ -605,7 +605,7 @@ void View3DInventorViewer::aboutToDestroyGLContext()
 
 void View3DInventorViewer::setDocument(Gui::Document* pcDocument)
 {
-    // write the document the viewer belongs to to the selection node
+    // write the document the viewer belongs to the selection node
     guiDocument = pcDocument;
     selectionRoot->pcDocument = pcDocument;
 }
@@ -628,7 +628,7 @@ void View3DInventorViewer::initialize()
 void View3DInventorViewer::OnChange(Gui::SelectionSingleton::SubjectType& rCaller,
                                     Gui::SelectionSingleton::MessageType Reason)
 {
-    Q_UNUSED(rCaller); 
+    Q_UNUSED(rCaller);
     if (Reason.Type == SelectionChanges::AddSelection ||
         Reason.Type == SelectionChanges::RmvSelection ||
         Reason.Type == SelectionChanges::SetSelection ||

--- a/src/Mod/PartDesign/Gui/TaskFeaturePick.cpp
+++ b/src/Mod/PartDesign/Gui/TaskFeaturePick.cpp
@@ -58,6 +58,7 @@
 using namespace PartDesignGui;
 using namespace Attacher;
 
+// ***WMAYER, this comment needs revising***
 // TODO Do ve should snap here to App:Part or GeoFeatureGroup/DocumentObjectGroup ? (2015-09-04, Fat-Zer)
 const QString TaskFeaturePick::getFeatureStatusString(const featureStatus st)
 {
@@ -295,7 +296,7 @@ std::vector<App::DocumentObject*> TaskFeaturePick::buildFeatures()
 }
 
 App::DocumentObject* TaskFeaturePick::makeCopy(App::DocumentObject* obj, std::string sub, bool independent) {
-    
+
     App::DocumentObject* copy = nullptr;
     // Check for null to avoid segfault
     if (!obj)

--- a/src/Mod/Path/App/FeaturePathCompoundPyImp.cpp
+++ b/src/Mod/Path/App/FeaturePathCompoundPyImp.cpp
@@ -33,7 +33,7 @@
 using namespace Path;
 
 
-// returns a string which represent the object e.g. when printed in python
+// returns a string which represents the object e.g. when printed in python
 std::string FeaturePathCompoundPy::representation(void) const
 {
     return std::string("<Path::FeatureCompound>");
@@ -69,7 +69,7 @@ PyObject*  FeaturePathCompoundPy::addObject(PyObject *args)
             Py::Object vp = static_cast<App::PropertyPythonObject*>(proxy)->getValue();
             if (vp.hasAttr(std::string("addObject"))) {
                 Py::Callable method(vp.getAttr(std::string("addObject")));
-                // check which this method belongs to to avoid an infinite recursion
+                // check to which method this belongs to avoid an infinite recursion
                 if (method.getAttr(std::string("__self__")) != Py::Object(this)) {
                     Py::Tuple args(1);
                     args[0] = Py::Object(object);
@@ -110,7 +110,7 @@ PyObject*  FeaturePathCompoundPy::removeObject(PyObject *args)
             Py::Object vp = static_cast<App::PropertyPythonObject*>(proxy)->getValue();
             if (vp.hasAttr(std::string("removeObject"))) {
                 Py::Callable method(vp.getAttr(std::string("removeObject")));
-                // check which this method belongs to to avoid an infinite recursion
+                // check to which method this belongs to avoid an infinite recursion
                 if (method.getAttr(std::string("__self__")) != Py::Object(this)) {
                     Py::Tuple args(1);
                     args[0] = Py::Object(object);
@@ -137,4 +137,3 @@ int FeaturePathCompoundPy::setCustomAttributes(const char* /*attr*/, PyObject* /
 {
     return 0;
 }
-


### PR DESCRIPTION
Found via `codespell -q 3 --skip="*.po,*.ts,./.git,./src/3rdParty,./src/CXX,./src/zipios++,./src/Mod/Assembly/App/opendcm" -I ../fc-word-whitelist.txt` and `grep`