### PR TITLE
py3: OpenSCAD: make Mod/OpenSCAD python3 compatible 

### DIFF
--- a/src/Mod/Arch/ArchCommands.py
+++ b/src/Mod/Arch/ArchCommands.py
@@ -654,7 +654,11 @@ def download(url,force=False):
     '''download(url,force=False): downloads a file from the given URL and saves it in the
     macro path. Returns the path to the saved file. If force is True, the file will be
     downloaded again evn if it already exists.'''
-    import urllib2, os
+    try:
+        from urllib.request import urlopen
+    except ImportError:
+        from urllib2 import urlopen
+    import os
     name = url.split('/')[-1]
     p = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Macro")
     macropath = p.GetString("MacroPath","")
@@ -665,7 +669,7 @@ def download(url,force=False):
         return filepath
     try:
         FreeCAD.Console.PrintMessage("downloading "+url+" ...\n")
-        response = urllib2.urlopen(url)
+        response = urlopen(url)
         s = response.read()
         f = open(filepath,'wb')
         f.write(s)

--- a/src/Mod/OpenSCAD/OpenSCAD2Dgeom.py
+++ b/src/Mod/OpenSCAD/OpenSCAD2Dgeom.py
@@ -28,6 +28,8 @@ __url__ = ["http://www.freecadweb.org"]
 This Script includes python functions to convert imported dxf geometry to Faces
 '''
 
+from functools import reduce
+
 class Overlappingfaces():
     '''combines overlapping faces together'''
     def __init__(self,facelist):

--- a/src/Mod/OpenSCAD/OpenSCADCommands.py
+++ b/src/Mod/OpenSCAD/OpenSCADCommands.py
@@ -41,9 +41,6 @@ except AttributeError:
         "convenience function for Qt translator"
         return QtGui.QApplication.translate(context, text, None)
 
-def utf8(unio):
-    return unicode(unio).encode('UTF8')
-
 class ExplodeGroup:
     "Ungroup Objects"
     def IsActive(self):
@@ -95,8 +92,8 @@ class ExplodeGroup:
                                 else:
                                     oo.ViewObject.DiffuseColor=color
                 else:
-                    FreeCAD.Console.PrintError(unicode(translate('OpenSCAD',\
-                    'Unable to explode %s')) % obj.Name +u'\n')
+                    FreeCAD.Console.PrintError(translate('OpenSCAD',\
+                    'Unable to explode %s') % obj.Name +u'\n')
 
         for obj in FreeCADGui.Selection.getSelection():
             if len(obj.InList) == 0: # allowed only for for top level objects
@@ -224,8 +221,8 @@ class ReplaceObject:
                 tuple((len(obj.InList)) for obj in objs) in ((0,1),(1,0)):
             replaceobj.replaceobjfromselection(objs)
         else:
-            FreeCAD.Console.PrintError(unicode(translate('OpenSCAD',\
-                    'Please select 3 objects first'))+u'\n')
+            FreeCAD.Console.PrintError(translate('OpenSCAD',\
+                    'Please select 3 objects first')+u'\n')
     def GetResources(self):
         return {'Pixmap'  : 'OpenSCAD_ReplaceObject', 'MenuText': \
                 QtCore.QT_TRANSLATE_NOOP('OpenSCAD_ReplaceObject',\
@@ -290,7 +287,7 @@ class AddSCADTask:
         return True
 
     def addelement(self):
-        scadstr=unicode(self.form.textEdit.toPlainText()).encode('utf8')
+        scadstr=self.form.textEdit.toPlainText()
         asmesh=self.form.checkboxmesh.checkState()
         import OpenSCADUtils, os
         extension= 'stl' if asmesh else 'csg'

--- a/src/Mod/OpenSCAD/OpenSCADUtils.py
+++ b/src/Mod/OpenSCAD/OpenSCADUtils.py
@@ -42,6 +42,11 @@ except AttributeError:
         return QtGui.QApplication.translate(context, text, None)
 
 try:
+    from io import open
+except ImportError:
+    from codecs import open
+
+try:
     import FreeCAD
     BaseError = FreeCAD.Base.FreeCADError
 except (ImportError, AttributeError):
@@ -140,6 +145,8 @@ def callopenscad(inputfilename,outputfilename=None,outputext='csg',keepname=Fals
         kwargs.update({'stdout':subprocess.PIPE,'stderr':subprocess.PIPE})
         p=subprocess.Popen(*args,**kwargs)
         stdoutd,stderrd = p.communicate()
+        stdoutd = stdoutd.decode("utf8")
+        stderrd = stderrd.decode("utf8")
         if p.returncode != 0:
             raise OpenSCADError('%s %s\n' % (stdoutd.strip(),stderrd.strip()))
             #raise Exception,'stdout %s\n stderr%s' %(stdoutd,stderrd)
@@ -173,7 +180,7 @@ def callopenscadstring(scadstr,outputext='csg'):
     import os,tempfile,time
     dir1=tempfile.gettempdir()
     inputfilename=os.path.join(dir1,'%s.scad' % next(tempfilenamegen))
-    inputfile = open(inputfilename,'w')
+    inputfile = open(inputfilename,'w', encoding="utf8")
     inputfile.write(scadstr)
     inputfile.close()
     outputfilename = callopenscad(inputfilename,outputext=outputext,\
@@ -194,7 +201,7 @@ def reverseimporttypes():
 
     importtypes={}
     import FreeCAD
-    for key,value in FreeCAD.getImportType().iteritems():
+    for key,value in FreeCAD.getImportType().items():
         if type(value) is str:
             getsetfromdict(importtypes,value).add(key)
         else:
@@ -222,7 +229,7 @@ def multiplymat(l,r):
 
 def isorthogonal(submatrix,precision=4):
     """checking if 3x3 Matrix is orthogonal (M*Transp(M)==I)"""
-    prod=multiplymat(submatrix,zip(*submatrix))
+    prod=multiplymat(submatrix,list(zip(*submatrix)))
     return [[round(f,precision) for f in line] \
         for line in prod]==[[1,0,0],[0,1,0],[0,0,1]]
 
@@ -562,8 +569,8 @@ def process_ObjectsViaOpenSCADShape(doc,children,name,maxmeshpoints=None):
         return process3D_ObjectsViaOpenSCADShape(children,name,maxmeshpoints)
     else:
         import FreeCAD
-        FreeCAD.Console.PrintError( unicode(translate('OpenSCAD',\
-            "Error all shapes must be either 2D or both must be 3D"))+u'\n')
+        FreeCAD.Console.PrintError( translate('OpenSCAD',\
+            "Error all shapes must be either 2D or both must be 3D")+u'\n')
 
 def process_ObjectsViaOpenSCAD(doc,children,name):
     if all((not obj.Shape.isNull() and obj.Shape.Volume == 0) \
@@ -574,8 +581,8 @@ def process_ObjectsViaOpenSCAD(doc,children,name):
         return process3D_ObjectsViaOpenSCAD(doc,children,name)
     else:
         import FreeCAD
-        FreeCAD.Console.PrintError( unicode(translate('OpenSCAD',\
-            "Error all shapes must be either 2D or both must be 3D"))+u'\n')
+        FreeCAD.Console.PrintError( translate('OpenSCAD',\
+            "Error all shapes must be either 2D or both must be 3D")+u'\n')
 
 def removesubtree(objs):
     def addsubobjs(obj,toremoveset):

--- a/src/Mod/OpenSCAD/exportCSG.py
+++ b/src/Mod/OpenSCAD/exportCSG.py
@@ -50,8 +50,7 @@ convexity = 'convexity = %d' % conv
 #***************************************************************************
 # Radius values not fixed for value apart from cylinder & Cone
 # no doubt there will be a problem when they do implement Value
-if open.__module__ == '__builtin__':
-        pythonopen = open
+pythonopen = open
 
 def center(b):
     if b == 2:
@@ -248,7 +247,7 @@ def export(exportList,filename):
     # process Objects
     print("\nStart Export 0.1d\n")
     print("Open Output File")
-    csg = pythonopen(filename,'w')
+    csg = pythonopen(filename,'w', encoding="utf8")
     print("Write Initial Output")
     # Not sure if comments as per scad are allowed in csg file              
     csg.write("// CSG file generated from FreeCAD %s\n" % \

--- a/src/Mod/OpenSCAD/importCSG.py
+++ b/src/Mod/OpenSCAD/importCSG.py
@@ -52,8 +52,7 @@ from OpenSCADUtils import *
 params = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/OpenSCAD")
 printverbose = params.GetBool('printVerbose',False)
 
-if open.__module__ == '__builtin__':
-    pythonopen = open # to distinguish python built-in open function from the one declared here
+pythonopen = open
 
 # Get the token map from the lexer.  This is required.
 import tokrules
@@ -136,7 +135,7 @@ def processcsg(filename):
     if printverbose: print('Parser Loaded')
     # Give the lexer some input
     #f=open('test.scad', 'r')
-    f = pythonopen(filename, 'r')
+    f = pythonopen(filename, 'r', encoding="utf8")
     #lexer.input(f.read())
 
     if printverbose: print('Start Parser')
@@ -431,7 +430,7 @@ def p_not_supported(p):
     if gui and not FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/OpenSCAD").\
             GetBool('usePlaceholderForUnsupported'):
         from PySide import QtGui
-        QtGui.QMessageBox.critical(None, unicode(translate('OpenSCAD',"Unsupported Function"))+" : "+p[1],unicode(translate('OpenSCAD',"Press OK")))
+        QtGui.QMessageBox.critical(None, translate('OpenSCAD',"Unsupported Function")+" : "+p[1],translate('OpenSCAD',"Press OK"))
     else:
         p[0] = [placeholder(p[1],p[6],p[3])]
 
@@ -1204,6 +1203,6 @@ def p_projection_action(p) :
         if gui and not FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/OpenSCAD").\
                 GetBool('usePlaceholderForUnsupported'):
             from PySide import QtGui
-            QtGui.QMessageBox.critical(None, unicode(translate('OpenSCAD',"Unsupported Function"))+" : "+p[1],unicode(translate('OpenSCAD',"Press OK")))
+            QtGui.QMessageBox.critical(None, translate('OpenSCAD',"Unsupported Function")+" : "+p[1],translate('OpenSCAD',"Press OK"))
         else:
             p[0] = [placeholder(p[1],p[6],p[3])]


### PR DESCRIPTION
a few changes to get Mod/OpenSCAD working with python3
Mod/OpenSCAD is using the download function provided by Mod/Arch, because of that only one pull request for both commits.

changes tested on:

OS: Fedora 28 (Workstation Edition)
Word size of OS: 64-bit
Word size of FreeCAD: 64-bit
Version: 0.18.14996 (Git)
Build type: Release
Branch: master
Hash: c950d1f093c6e1e846ac5fd5806646ab69adbfbe
Python version: 3.6.6
Qt version: 5.6.2
Coin version: 4.0.0a
OCC version: 7.3.0
Locale: German/Austria (de_AT)

OS: Linux
Word size of OS: 64-bit
Word size of FreeCAD: 64-bit
Version: 0.18.15007 (Git)
Build type: Release
Branch: master
Hash: 70fef3934190aabc61f5e1346483359d5ad21403
Python version: 2.7.6
Qt version: 4.8.6
Coin version: 4.0.0a
OCC version: 7.3.0
Locale: German/Austria (de_AT)

OS: Windows 7
Word size of OS: 64-bit
Word size of FreeCAD: 64-bit
Version: 0.18.15007 (Git)
Build type: Release
Branch: master
Hash: 70fef3934190aabc61f5e1346483359d5ad21403
Python version: 3.6.6
Qt version: 5.6.2
Coin version: 4.0.0a
OCC version: 7.3.0
Locale: German/Austria (de_AT)

OS: Windows 7
Word size of OS: 64-bit
Word size of FreeCAD: 64-bit
Version: 0.18.15007 (Git)
Build type: Release
Branch: master
Hash: 70fef3934190aabc61f5e1346483359d5ad21403
Python version: 2.7.14
Qt version: 4.8.7
Coin version: 4.0.0a
OCC version: 7.2.0
Locale: German/Austria (de_AT)


- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)