### PR TITLE
Add SVG render to dLabel

### DIFF
--- a/src/Mod/Arch/ArchSectionPlane.py
+++ b/src/Mod/Arch/ArchSectionPlane.py
@@ -174,7 +174,7 @@ def getSVG(section, renderMode="Wireframe", allOn=False, showHidden=False, scale
     for o in objs:
         if Draft.getType(o) == "Space":
             spaces.append(o)
-        elif Draft.getType(o) in ["Dimension","Annotation"]:
+        elif Draft.getType(o) in ["Dimension","Annotation","Label"]:
             drafts.append(o)
         elif o.isDerivedFrom("Part::Part2DObject"):
             drafts.append(o)

--- a/src/Mod/Draft/Draft.py
+++ b/src/Mod/Draft/Draft.py
@@ -2545,6 +2545,18 @@ def getSVG(obj,scale=1,linewidth=0.35,fontsize=12,fillstyle="shape color",direct
                         tbase = getProj(prx.tbase)
                     svg += getText(stroke,fontsize,obj.ViewObject.FontName,tangle,tbase,prx.string)
 
+    elif getType(obj) == "Label":
+        if gui:
+            if not obj.ViewObject:
+                print ("export of texts to SVG is only available in GUI mode")
+            else:
+                fontname = obj.ViewObject.TextFont
+                position = getProj(obj.Placement.Base)
+                rotation = obj.Placement.Rotation
+                justification = obj.ViewObject.TextAlignment
+                text = obj.Text
+                svg += getText(stroke, fontsize, fontname, rotation, position, text, linespacing, justification)
+
     elif getType(obj) in ["Annotation","DraftText"]:
         "returns an svg representation of a document annotation"
         if gui:

--- a/src/Mod/Draft/Draft.py
+++ b/src/Mod/Draft/Draft.py
@@ -2546,6 +2546,21 @@ def getSVG(obj,scale=1,linewidth=0.35,fontsize=12,fillstyle="shape color",direct
                     svg += getText(stroke,fontsize,obj.ViewObject.FontName,tangle,tbase,prx.string)
 
     elif getType(obj) == "Label":
+
+        def format_point (coords, letter='L'):
+            return "{letter}{x},{y}".format(x=coords.x, y=coords.y, letter=letter)
+
+        proj_points = list(map(getProj,obj.Points))
+        path_dir_list = [format_point(proj_points[0], letter='M')]
+        path_dir_list += map(format_point,proj_points[1:])
+        path_dir_str = " ".join(path_dir_list)
+        svg_path = '<path fill="none" stroke="{stroke}" stroke-width="{linewidth}" d="{directions}"/>'.format(
+            stroke=stroke,
+            linewidth=linewidth,
+            directions=path_dir_str
+        )
+        svg += svg_path
+
         if gui:
             if not obj.ViewObject:
                 print ("export of texts to SVG is only available in GUI mode")
@@ -6175,7 +6190,7 @@ class _PointArray(_DraftObject):
         	        i += 1
         	        base.append(nshape)
         obj.Count = i
-        if i > 0: 
+        if i > 0:
             obj.Shape = Part.makeCompound(base)
         else:
             FreeCAD.Console.PrintError(translate("draft","No point found\n"))


### PR DESCRIPTION
Currently dLabel (draft Label) is not rendered in TechDrawing/Arch Section because Draft module provides no svg code for dLabel.

This patch adds this support.

It was discussed in the forum thread: https://forum.freecadweb.org/viewtopic.php?f=3&t=31726&start=10