### PR TITLE
Sketcher: Workaround for Trimming Bug

### DIFF
--- a/src/Mod/Part/App/AppPart.cpp
+++ b/src/Mod/Part/App/AppPart.cpp
@@ -477,6 +477,7 @@ PyMOD_INIT_FUNC(Part)
     Part::GeomBezierCurve         ::init();
     Part::GeomBSplineCurve        ::init();
     Part::GeomConic               ::init();
+    Part::GeomTrimmedCurve        ::init();
     Part::GeomArcOfConic          ::init();
     Part::GeomCircle              ::init();
     Part::GeomArcOfCircle         ::init();
@@ -489,7 +490,6 @@ PyMOD_INIT_FUNC(Part)
     Part::GeomLine                ::init();
     Part::GeomLineSegment         ::init();
     Part::GeomOffsetCurve         ::init();
-    Part::GeomTrimmedCurve        ::init();
     Part::GeomSurface             ::init();
     Part::GeomBezierSurface       ::init();
     Part::GeomBSplineSurface      ::init();

--- a/src/Mod/Part/App/Geometry.cpp
+++ b/src/Mod/Part/App/Geometry.cpp
@@ -459,7 +459,30 @@ bool GeomCurve::intersect(  GeomCurve * c,
     try {
     
         if(!curve1.IsNull() && !curve2.IsNull()) {        
-        
+            // https://forum.freecadweb.org/viewtopic.php?f=10&t=31700
+            if (curve1->IsKind(STANDARD_TYPE(Geom_BoundedCurve)) &&
+                curve2->IsKind(STANDARD_TYPE(Geom_BoundedCurve))){
+                
+                Handle(Geom_BoundedCurve) bcurve1 = Handle(Geom_BoundedCurve)::DownCast(curve1);
+                Handle(Geom_BoundedCurve) bcurve2 = Handle(Geom_BoundedCurve)::DownCast(curve2);
+                
+                gp_Pnt c1s = bcurve1->StartPoint();
+                gp_Pnt c2s = bcurve2->StartPoint();
+                gp_Pnt c1e = bcurve1->EndPoint();
+                gp_Pnt c2e = bcurve2->EndPoint();
+            
+                auto checkendpoints = [&points,tol]( gp_Pnt p1, gp_Pnt p2) {
+                    if(p1.Distance(p2) < tol)
+                        points.emplace_back(Base::Vector3d(p1.X(),p1.Y(),p1.Z()),Base::Vector3d(p2.X(),p2.Y(),p2.Z()));
+                };
+                
+                checkendpoints(c1s,c2s);
+                checkendpoints(c1s,c2e);
+                checkendpoints(c1e,c2s);
+                checkendpoints(c1e,c2e);
+                
+            }
+            
             GeomAPI_ExtremaCurveCurve intersector(curve1, curve2);
             
             if (intersector.NbExtrema() == 0 || intersector.LowerDistance() > tol) {
@@ -1489,10 +1512,10 @@ bool GeomTrimmedCurve::intersectBasisCurves(  const GeomTrimmedCurve * c,
 {
     Handle(Geom_TrimmedCurve) curve1 =  Handle(Geom_TrimmedCurve)::DownCast(handle());
     Handle(Geom_TrimmedCurve) curve2 =  Handle(Geom_TrimmedCurve)::DownCast(c->handle());
-        
+    
     Handle(Geom_Conic) bcurve1 = Handle(Geom_Conic)::DownCast( curve1->BasisCurve() );
     Handle(Geom_Conic) bcurve2 = Handle(Geom_Conic)::DownCast( curve2->BasisCurve() );
-    
+
     try {
     
         if(!bcurve1.IsNull() && !bcurve2.IsNull()) {

--- a/src/Mod/Part/App/Geometry.cpp
+++ b/src/Mod/Part/App/Geometry.cpp
@@ -3564,7 +3564,7 @@ PyObject *GeomLine::getPyObject(void)
 
 // -------------------------------------------------
 
-TYPESYSTEM_SOURCE(Part::GeomLineSegment,Part::GeomCurve)
+TYPESYSTEM_SOURCE(Part::GeomLineSegment,Part::GeomTrimmedCurve)
 
 GeomLineSegment::GeomLineSegment()
 {

--- a/src/Mod/Part/App/Geometry.cpp
+++ b/src/Mod/Part/App/Geometry.cpp
@@ -373,7 +373,7 @@ GeomBSplineCurve* GeomCurve::toBSpline(double first, double last) const
     Handle(Geom_Curve) c = Handle(Geom_Curve)::DownCast(handle());
     Handle(Geom_BSplineCurve) spline = scc.ConvertToBSpline(c, first, last, Precision::Confusion());
     if (spline.IsNull())
-        throw Base::RuntimeError("Conversion to B-spline failed");
+        THROWM(Base::CADKernelError,"Conversion to B-spline failed")
     return new GeomBSplineCurve(spline);
 }
 
@@ -443,7 +443,7 @@ bool GeomCurve::normalAt(double u, Base::Vector3d& dir) const
         return false;
     }
     catch (Standard_Failure& e) {
-        throw Base::RuntimeError(e.GetMessageString());
+        THROWM(Base::CADKernelError,e.GetMessageString())
     }
 
     return false;
@@ -455,19 +455,13 @@ bool GeomCurve::intersect(  GeomCurve * c,
 {
     Handle(Geom_Curve) curve1 = Handle(Geom_Curve)::DownCast(handle());
     Handle(Geom_Curve) curve2 = Handle(Geom_Curve)::DownCast(c->handle());
-    
-    try {
-    
-        if(!curve1.IsNull() && !curve2.IsNull()) {        
-            return intersect(curve1,curve2,points, tol);
-        }
-        else
-            return false;
+
+    if(!curve1.IsNull() && !curve2.IsNull()) {        
+        return intersect(curve1,curve2,points, tol);
     }
-    catch (Standard_Failure& e) {
-        throw Base::RuntimeError(e.GetMessageString());
-    }
-    
+    else
+        return false;
+
 }
 
 bool GeomCurve::intersect(const Handle(Geom_Curve) curve1, const Handle(Geom_Curve) curve2, 
@@ -521,7 +515,7 @@ bool GeomCurve::intersect(const Handle(Geom_Curve) curve1, const Handle(Geom_Cur
         if(points.size()>0)
             return points.size()>0?true:false;
         else
-            throw Base::RuntimeError(e.GetMessageString());
+            THROWM(Base::CADKernelError,e.GetMessageString())
     }
     
 
@@ -551,18 +545,18 @@ bool GeomCurve::closestParameter(const Base::Vector3d& point, double &u) const
                 u = c->LastParameter();
         }
         else
-            throw Base::RuntimeError(e.GetMessageString());
+            THROWM(Base::CADKernelError,e.GetMessageString())
 
         return true;
     }
     catch (Standard_Failure& e) {
-        throw Base::RuntimeError(e.GetMessageString());
+        THROWM(Base::CADKernelError,e.GetMessageString())
     }
 
     return false;
 }
 
-bool GeomCurve::closestParameterToBasicCurve(const Base::Vector3d& point, double &u) const
+bool GeomCurve::closestParameterToBasisCurve(const Base::Vector3d& point, double &u) const
 {
     Handle(Geom_Curve) c = Handle(Geom_Curve)::DownCast(handle());
 
@@ -578,8 +572,7 @@ bool GeomCurve::closestParameterToBasicCurve(const Base::Vector3d& point, double
             }
         }
         catch (Standard_Failure& e) {
-    
-            throw Base::RuntimeError(e.GetMessageString());
+            THROWM(Base::CADKernelError,e.GetMessageString())
         }
 
         return false;
@@ -599,7 +592,7 @@ double GeomCurve::getFirstParameter() const
     }
     catch (Standard_Failure& e) {
 
-        throw Base::RuntimeError(e.GetMessageString());
+        THROWM(Base::CADKernelError,e.GetMessageString())
     }
 }
 
@@ -613,7 +606,7 @@ double GeomCurve::getLastParameter() const
     }
     catch (Standard_Failure& e) {
 
-        throw Base::RuntimeError(e.GetMessageString());
+        THROWM(Base::CADKernelError,e.GetMessageString())
     }        
 }
 
@@ -627,7 +620,7 @@ double GeomCurve::curvatureAt(double u) const
     }
     catch (Standard_Failure& e) {
 
-        throw Base::RuntimeError(e.GetMessageString());
+        THROWM(Base::CADKernelError,e.GetMessageString())
     }
 }
 
@@ -642,7 +635,7 @@ double GeomCurve::length(double u, double v) const
     }
     catch (Standard_Failure& e) {
 
-        throw Base::RuntimeError(e.GetMessageString());
+        THROWM(Base::CADKernelError,e.GetMessageString())
     }
 }
 
@@ -655,7 +648,7 @@ void GeomCurve::reverse(void)
     }
     catch (Standard_Failure& e) {
 
-        throw Base::RuntimeError(e.GetMessageString());
+        THROWM(Base::CADKernelError,e.GetMessageString())
     }
 }
 
@@ -840,11 +833,11 @@ void GeomBezierCurve::Restore(Base::XMLReader& reader)
         if (!bezier.IsNull())
             this->myCurve = bezier;
         else
-            throw Base::RuntimeError("BezierCurve restore failed");
+            THROWM(Base::CADKernelError,"BezierCurve restore failed")
     }
     catch (Standard_Failure& e) {
-
-        throw Base::RuntimeError(e.GetMessageString());
+        
+        THROWM(Base::CADKernelError,e.GetMessageString())
     }
 }
 
@@ -951,7 +944,7 @@ void GeomBSplineCurve::setPole(int index, const Base::Vector3d& pole, double wei
     }
     catch (Standard_Failure& e) {
 
-        throw Base::RuntimeError(e.GetMessageString());
+        THROWM(Base::CADKernelError,e.GetMessageString())
     }
 }
 
@@ -1015,7 +1008,7 @@ void GeomBSplineCurve::setWeights(const std::vector<double>& weights)
     }
     catch (Standard_Failure& e) {
 
-        throw Base::RuntimeError(e.GetMessageString());
+        THROWM(Base::CADKernelError,e.GetMessageString())
     }
 }
 
@@ -1029,7 +1022,7 @@ void GeomBSplineCurve::setKnot(int index, const double val, int mult)
     }
     catch (Standard_Failure& e) {
 
-        throw Base::RuntimeError(e.GetMessageString());
+        THROWM(Base::CADKernelError,e.GetMessageString())
     }
 }
 
@@ -1089,7 +1082,7 @@ int GeomBSplineCurve::getMultiplicity(int index) const
     }
     catch (Standard_Failure& e) {
 
-        throw Base::RuntimeError(e.GetMessageString());
+        THROWM(Base::CADKernelError,e.GetMessageString())
     }
 }
 
@@ -1210,7 +1203,7 @@ void GeomBSplineCurve::increaseDegree(double degree)
     }
     catch (Standard_Failure& e) {
 
-        throw Base::RuntimeError(e.GetMessageString());
+        THROWM(Base::CADKernelError,e.GetMessageString())
     }
 }
 
@@ -1223,7 +1216,7 @@ void GeomBSplineCurve::increaseMultiplicity(int index, int multiplicity)
     }
     catch (Standard_Failure& e) {
 
-        throw Base::RuntimeError(e.GetMessageString());
+        THROWM(Base::CADKernelError,e.GetMessageString())
     }
 }
 
@@ -1235,7 +1228,7 @@ bool GeomBSplineCurve::removeKnot(int index, int multiplicity, double tolerance)
     }
     catch (Standard_Failure& e) {
 
-        throw Base::RuntimeError(e.GetMessageString());
+        THROWM(Base::CADKernelError,e.GetMessageString())
     }
 }
 
@@ -1348,11 +1341,11 @@ void GeomBSplineCurve::Restore(Base::XMLReader& reader)
         if (!spline.IsNull())
             this->myCurve = spline;
         else
-            throw Base::RuntimeError("BSpline restore failed");
+            THROWM(Base::CADKernelError,"BSpline restore failed")
     }
     catch (Standard_Failure& e) {
 
-        throw Base::RuntimeError(e.GetMessageString());
+        THROWM(Base::CADKernelError,e.GetMessageString())
     }
 }
 
@@ -1392,7 +1385,7 @@ void GeomConic::setLocation(const Base::Vector3d& Center)
     }
     catch (Standard_Failure& e) {
 
-        throw Base::RuntimeError(e.GetMessageString());
+        THROWM(Base::CADKernelError,e.GetMessageString())
     }
 }
 
@@ -1414,7 +1407,7 @@ void GeomConic::setCenter(const Base::Vector3d& Center)
     }
     catch (Standard_Failure& e) {
 
-        throw Base::RuntimeError(e.GetMessageString());
+        THROWM(Base::CADKernelError,e.GetMessageString())
     }
 }
 
@@ -1463,7 +1456,7 @@ void GeomConic::setAngleXU(double angle)
     }
     catch (Standard_Failure& e) {
 
-        throw Base::RuntimeError(e.GetMessageString());
+        THROWM(Base::CADKernelError,e.GetMessageString())
     }
 }
 
@@ -1534,17 +1527,14 @@ bool GeomTrimmedCurve::intersectBasisCurves(  const GeomTrimmedCurve * c,
     Handle(Geom_Curve) bcurve1 = curve1->BasisCurve();
     Handle(Geom_Curve) bcurve2 = curve2->BasisCurve();
 
-    try {
+
+    if(!bcurve1.IsNull() && !bcurve2.IsNull()) {
     
-        if(!bcurve1.IsNull() && !bcurve2.IsNull()) {
-        
-            return intersect(bcurve1, bcurve2, points, tol);
-        }
-        return false;
+        return intersect(bcurve1, bcurve2, points, tol);
     }
-    catch (Standard_Failure& e) {
-        throw Base::RuntimeError(e.GetMessageString());
-    }    
+    else
+        return false;
+  
 }
 
 // -------------------------------------------------
@@ -1621,7 +1611,7 @@ void GeomArcOfConic::setCenter(const Base::Vector3d& Center)
     }
     catch (Standard_Failure& e) {
 
-        throw Base::RuntimeError(e.GetMessageString());
+        THROWM(Base::CADKernelError,e.GetMessageString())
     }
 }
 
@@ -1636,7 +1626,7 @@ void GeomArcOfConic::setLocation(const Base::Vector3d& Center)
     }
     catch (Standard_Failure& e) {
 
-        throw Base::RuntimeError(e.GetMessageString());
+       THROWM(Base::CADKernelError,e.GetMessageString())
     }
 }
 
@@ -1698,7 +1688,7 @@ void GeomArcOfConic::setAngleXU(double angle)
     }
     catch (Standard_Failure& e) {
 
-        throw Base::RuntimeError(e.GetMessageString());
+        THROWM(Base::CADKernelError,e.GetMessageString())
     }
 }
 
@@ -1744,7 +1734,7 @@ void GeomArcOfConic::setXAxisDir(const Base::Vector3d& newdir)
     }
     catch (Standard_Failure& e) {
 
-        throw Base::RuntimeError(e.GetMessageString());
+        THROWM(Base::CADKernelError,e.GetMessageString())
     }
 }
 
@@ -1849,7 +1839,7 @@ void GeomCircle::setRadius(double Radius)
     }
     catch (Standard_Failure& e) {
 
-        throw Base::RuntimeError(e.GetMessageString());
+        THROWM(Base::CADKernelError,e.GetMessageString())
     }
 }
 
@@ -1916,13 +1906,13 @@ void GeomCircle::Restore(Base::XMLReader& reader)
     try {
         GC_MakeCircle mc(xdir, Radius);
         if (!mc.IsDone())
-            throw Base::Exception(gce_ErrorStatusText(mc.Status()));
+            THROWM(Base::CADKernelError,gce_ErrorStatusText(mc.Status()))
 
         this->myCurve = mc.Value();
     }
     catch (Standard_Failure& e) {
 
-        throw Base::RuntimeError(e.GetMessageString());
+        THROWM(Base::CADKernelError,e.GetMessageString())
     }
 }
 
@@ -2001,7 +1991,7 @@ void GeomArcOfCircle::setRadius(double Radius)
     }
     catch (Standard_Failure& e) {
 
-        throw Base::RuntimeError(e.GetMessageString());
+        THROWM(Base::CADKernelError,e.GetMessageString())
     }
 }
 
@@ -2074,7 +2064,7 @@ void GeomArcOfCircle::setRange(double u, double v, bool emulateCCWXY)
     }
     catch (Standard_Failure& e) {
 
-        throw Base::RuntimeError(e.GetMessageString());
+        THROWM(Base::CADKernelError,e.GetMessageString())
     }
 }
 
@@ -2147,10 +2137,10 @@ void GeomArcOfCircle::Restore(Base::XMLReader &reader)
     try {
         GC_MakeCircle mc(xdir, Radius);
         if (!mc.IsDone())
-            throw Base::Exception(gce_ErrorStatusText(mc.Status()));
+            THROWM(Base::CADKernelError,gce_ErrorStatusText(mc.Status()))
         GC_MakeArcOfCircle ma(mc.Value()->Circ(), StartAngle, EndAngle, 1);
         if (!ma.IsDone())
-            throw Base::Exception(gce_ErrorStatusText(ma.Status()));
+            THROWM(Base::CADKernelError,gce_ErrorStatusText(ma.Status()))
 
         Handle(Geom_TrimmedCurve) tmpcurve = ma.Value();
         Handle(Geom_Circle) tmpcircle = Handle(Geom_Circle)::DownCast(tmpcurve->BasisCurve());
@@ -2161,7 +2151,7 @@ void GeomArcOfCircle::Restore(Base::XMLReader &reader)
     }
     catch (Standard_Failure& e) {
 
-        throw Base::RuntimeError(e.GetMessageString());
+        THROWM(Base::CADKernelError,e.GetMessageString())
     }
 }
 
@@ -2269,7 +2259,7 @@ void GeomEllipse::setMajorRadius(double Radius)
     }
     catch (Standard_Failure& e) {
 
-        throw Base::RuntimeError(e.GetMessageString());
+        THROWM(Base::CADKernelError,e.GetMessageString())
     }
 }
 
@@ -2288,7 +2278,7 @@ void GeomEllipse::setMinorRadius(double Radius)
     }
     catch (Standard_Failure& e) {
 
-        throw Base::RuntimeError(e.GetMessageString());
+        THROWM(Base::CADKernelError,e.GetMessageString())
     }
 }
 
@@ -2326,7 +2316,7 @@ void GeomEllipse::setMajorAxisDir(Base::Vector3d newdir)
     }
     catch (Standard_Failure& e) {
 
-        throw Base::RuntimeError(e.GetMessageString());
+        THROWM(Base::CADKernelError,e.GetMessageString())
     }
 }
 
@@ -2402,13 +2392,13 @@ void GeomEllipse::Restore(Base::XMLReader& reader)
     try {
         GC_MakeEllipse mc(xdir, MajorRadius, MinorRadius);
         if (!mc.IsDone())
-            throw Base::Exception(gce_ErrorStatusText(mc.Status()));
+            THROWM(Base::CADKernelError,gce_ErrorStatusText(mc.Status()))
 
         this->myCurve = mc.Value();
     }
     catch (Standard_Failure& e) {
 
-        throw Base::RuntimeError(e.GetMessageString());
+        THROWM(Base::CADKernelError,e.GetMessageString())
     }
 }
 
@@ -2484,7 +2474,7 @@ void GeomArcOfEllipse::setMajorRadius(double Radius)
     }
     catch (Standard_Failure& e) {
 
-        throw Base::RuntimeError(e.GetMessageString());
+        THROWM(Base::CADKernelError,e.GetMessageString())
     }
 }
 
@@ -2503,7 +2493,7 @@ void GeomArcOfEllipse::setMinorRadius(double Radius)
     }
     catch (Standard_Failure& e) {
 
-        throw Base::RuntimeError(e.GetMessageString());
+        THROWM(Base::CADKernelError,e.GetMessageString())
     }
 }
 
@@ -2545,7 +2535,7 @@ void GeomArcOfEllipse::setMajorAxisDir(Base::Vector3d newdir)
     }
     catch (Standard_Failure& e) {
 
-        throw Base::RuntimeError(e.GetMessageString());
+        THROWM(Base::CADKernelError,e.GetMessageString())
     }
 }
 
@@ -2592,7 +2582,7 @@ void GeomArcOfEllipse::setRange(double u, double v, bool emulateCCWXY)
     }
     catch (Standard_Failure& e) {
 
-        throw Base::RuntimeError(e.GetMessageString());
+        THROWM(Base::CADKernelError,e.GetMessageString())
     }
 }
 
@@ -2670,11 +2660,11 @@ void GeomArcOfEllipse::Restore(Base::XMLReader &reader)
     try {
         GC_MakeEllipse mc(xdir, MajorRadius, MinorRadius);
         if (!mc.IsDone())
-            throw Base::Exception(gce_ErrorStatusText(mc.Status()));
+            THROWM(Base::CADKernelError,gce_ErrorStatusText(mc.Status()))
 
         GC_MakeArcOfEllipse ma(mc.Value()->Elips(), StartAngle, EndAngle, 1);
         if (!ma.IsDone())
-            throw Base::Exception(gce_ErrorStatusText(ma.Status()));
+            THROWM(Base::CADKernelError,gce_ErrorStatusText(ma.Status()))
 
         Handle(Geom_TrimmedCurve) tmpcurve = ma.Value();
         Handle(Geom_Ellipse) tmpellipse = Handle(Geom_Ellipse)::DownCast(tmpcurve->BasisCurve());
@@ -2685,7 +2675,7 @@ void GeomArcOfEllipse::Restore(Base::XMLReader &reader)
     }
     catch (Standard_Failure& e) {
 
-        throw Base::RuntimeError(e.GetMessageString());
+        THROWM(Base::CADKernelError,e.GetMessageString())
     }
 }
 
@@ -2751,7 +2741,7 @@ void GeomHyperbola::setMajorRadius(double Radius)
     }
     catch (Standard_Failure& e) {
 
-        throw Base::RuntimeError(e.GetMessageString());
+        THROWM(Base::CADKernelError,e.GetMessageString())
     }
 }
 
@@ -2770,7 +2760,7 @@ void GeomHyperbola::setMinorRadius(double Radius)
     }
     catch (Standard_Failure& e) {
 
-        throw Base::RuntimeError(e.GetMessageString());
+        THROWM(Base::CADKernelError,e.GetMessageString())
     }
 }
 
@@ -2840,13 +2830,13 @@ void GeomHyperbola::Restore(Base::XMLReader& reader)
     try {
         GC_MakeHyperbola mc(xdir, MajorRadius, MinorRadius);
         if (!mc.IsDone())
-            throw Base::Exception(gce_ErrorStatusText(mc.Status()));
+            THROWM(Base::CADKernelError,gce_ErrorStatusText(mc.Status()))
 
         this->myCurve = mc.Value();
     }
     catch (Standard_Failure& e) {
 
-        throw Base::RuntimeError(e.GetMessageString());
+        THROWM(Base::CADKernelError,e.GetMessageString())
     }
 }
 
@@ -2922,7 +2912,7 @@ void GeomArcOfHyperbola::setMajorRadius(double Radius)
     }
     catch (Standard_Failure& e) {
 
-        throw Base::RuntimeError(e.GetMessageString());
+        THROWM(Base::CADKernelError,e.GetMessageString())
     }
 }
 
@@ -2941,7 +2931,7 @@ void GeomArcOfHyperbola::setMinorRadius(double Radius)
     }
     catch (Standard_Failure& e) {
 
-        throw Base::RuntimeError(e.GetMessageString());
+        THROWM(Base::CADKernelError,e.GetMessageString())
     }
 }
 
@@ -2984,7 +2974,7 @@ void GeomArcOfHyperbola::setMajorAxisDir(Base::Vector3d newdir)
     }
     catch (Standard_Failure& e) {
 
-        throw Base::RuntimeError(e.GetMessageString());
+        THROWM(Base::CADKernelError,e.GetMessageString())
     }
 }
 
@@ -3001,7 +2991,7 @@ void GeomArcOfHyperbola::getRange(double& u, double& v, bool emulateCCWXY) const
     }
     catch (Standard_Failure& e) {
 
-        throw Base::RuntimeError(e.GetMessageString());
+        THROWM(Base::CADKernelError,e.GetMessageString())
     }
 
     u = myCurve->FirstParameter();
@@ -3023,7 +3013,7 @@ void GeomArcOfHyperbola::setRange(double u, double v, bool emulateCCWXY)
     }
     catch (Standard_Failure& e) {
 
-        throw Base::RuntimeError(e.GetMessageString());
+        THROWM(Base::CADKernelError,e.GetMessageString())
     }
 }
 
@@ -3100,11 +3090,11 @@ void GeomArcOfHyperbola::Restore(Base::XMLReader &reader)
     try {
         GC_MakeHyperbola mc(xdir, MajorRadius, MinorRadius);
         if (!mc.IsDone())
-            throw Base::Exception(gce_ErrorStatusText(mc.Status()));
+            THROWM(Base::CADKernelError,gce_ErrorStatusText(mc.Status()))
 
         GC_MakeArcOfHyperbola ma(mc.Value()->Hypr(), StartAngle, EndAngle, 1);
         if (!ma.IsDone())
-            throw Base::Exception(gce_ErrorStatusText(ma.Status()));
+            THROWM(Base::CADKernelError,gce_ErrorStatusText(ma.Status()))
 
         Handle(Geom_TrimmedCurve) tmpcurve = ma.Value();
         Handle(Geom_Hyperbola) tmphyperbola = Handle(Geom_Hyperbola)::DownCast(tmpcurve->BasisCurve());
@@ -3115,7 +3105,7 @@ void GeomArcOfHyperbola::Restore(Base::XMLReader &reader)
     }
     catch (Standard_Failure& e) {
 
-        throw Base::RuntimeError(e.GetMessageString());
+        THROWM(Base::CADKernelError,e.GetMessageString())
     }
 }
 
@@ -3181,7 +3171,7 @@ void GeomParabola::setFocal(double length)
     }
     catch (Standard_Failure& e) {
 
-        throw Base::RuntimeError(e.GetMessageString());
+        THROWM(Base::CADKernelError,e.GetMessageString())
     }
 }
 
@@ -3249,13 +3239,13 @@ void GeomParabola::Restore(Base::XMLReader& reader)
     try {
         gce_MakeParab mc(xdir, Focal);
         if (!mc.IsDone())
-            throw Base::Exception(gce_ErrorStatusText(mc.Status()));
+            THROWM(Base::CADKernelError,gce_ErrorStatusText(mc.Status()))
 
         this->myCurve = new Geom_Parabola(mc.Value());
     }
     catch (Standard_Failure& e) {
 
-        throw Base::RuntimeError(e.GetMessageString());
+        THROWM(Base::CADKernelError,e.GetMessageString())
     }
 }
 
@@ -3331,7 +3321,7 @@ void GeomArcOfParabola::setFocal(double length)
     }
     catch (Standard_Failure& e) {
 
-        throw Base::RuntimeError(e.GetMessageString());
+        THROWM(Base::CADKernelError,e.GetMessageString())
     }
 }
 
@@ -3356,7 +3346,7 @@ void GeomArcOfParabola::getRange(double& u, double& v, bool emulateCCWXY) const
     }
     catch (Standard_Failure& e) {
 
-        throw Base::RuntimeError(e.GetMessageString());
+        THROWM(Base::CADKernelError,e.GetMessageString())
     }
 
     u = myCurve->FirstParameter();
@@ -3377,7 +3367,7 @@ void GeomArcOfParabola::setRange(double u, double v, bool emulateCCWXY)
     }
     catch (Standard_Failure& e) {
 
-        throw Base::RuntimeError(e.GetMessageString());
+        THROWM(Base::CADKernelError,e.GetMessageString())
     }
 }
 
@@ -3452,11 +3442,11 @@ void GeomArcOfParabola::Restore(Base::XMLReader &reader)
     try {
         gce_MakeParab mc(xdir, Focal);
         if (!mc.IsDone())
-            throw Base::Exception(gce_ErrorStatusText(mc.Status()));
+            THROWM(Base::CADKernelError,gce_ErrorStatusText(mc.Status()))
 
         GC_MakeArcOfParabola ma(mc.Value(), StartAngle, EndAngle, 1);
         if (!ma.IsDone())
-            throw Base::Exception(gce_ErrorStatusText(ma.Status()));
+            THROWM(Base::CADKernelError,gce_ErrorStatusText(ma.Status()))
 
         Handle(Geom_TrimmedCurve) tmpcurve = ma.Value();
         Handle(Geom_Parabola) tmpparabola = Handle(Geom_Parabola)::DownCast(tmpcurve->BasisCurve());
@@ -3467,7 +3457,7 @@ void GeomArcOfParabola::Restore(Base::XMLReader &reader)
     }
     catch (Standard_Failure& e) {
 
-        throw Base::RuntimeError(e.GetMessageString());
+        THROWM(Base::CADKernelError,e.GetMessageString())
     }
 }
 
@@ -3660,7 +3650,7 @@ void GeomLineSegment::setPoints(const Base::Vector3d& Start, const Base::Vector3
             Standard_Failure::Raise("Both points are equal");
         GC_MakeSegment ms(p1, p2);
         if (!ms.IsDone()) {
-            throw Base::Exception(gce_ErrorStatusText(ms.Status()));
+            THROWM(Base::CADKernelError,gce_ErrorStatusText(ms.Status()))
         }
 
         // get Geom_Line of line segment
@@ -3673,7 +3663,7 @@ void GeomLineSegment::setPoints(const Base::Vector3d& Start, const Base::Vector3
     }
     catch (Standard_Failure& e) {
 
-        throw Base::RuntimeError(e.GetMessageString());
+        THROWM(Base::CADKernelError,e.GetMessageString())
     }
 }
 
@@ -3851,7 +3841,7 @@ bool GeomSurface::isUmbillic(double u, double v) const
         return prop.IsUmbilic();
     }
 
-    throw Base::RuntimeError("No curvature defined");
+    THROWM(Base::RuntimeError,"No curvature defined")
 }
 
 double GeomSurface::curvature(double u, double v, Curvature type) const
@@ -3878,7 +3868,7 @@ double GeomSurface::curvature(double u, double v, Curvature type) const
         return value;
     }
 
-    throw Base::RuntimeError("No curvature defined");
+    THROWM(Base::RuntimeError,"No curvature defined")
 }
 
 void GeomSurface::curvatureDirections(double u, double v, gp_Dir& maxD, gp_Dir& minD) const
@@ -3890,7 +3880,7 @@ void GeomSurface::curvatureDirections(double u, double v, gp_Dir& maxD, gp_Dir& 
         return;
     }
 
-    throw Base::RuntimeError("No curvature defined");
+    THROWM(Base::RuntimeError,"No curvature defined")
 }
 
 // -------------------------------------------------

--- a/src/Mod/Part/App/Geometry.cpp
+++ b/src/Mod/Part/App/Geometry.cpp
@@ -1482,7 +1482,7 @@ bool GeomConic::isReversed() const
 
 // -------------------------------------------------
 
-TYPESYSTEM_SOURCE(Part::GeomTrimmedCurve,Part::GeomCurve)
+TYPESYSTEM_SOURCE(Part::GeomTrimmedCurve,Part::GeomBoundedCurve)
 
 GeomTrimmedCurve::GeomTrimmedCurve()
 {

--- a/src/Mod/Part/App/Geometry.cpp
+++ b/src/Mod/Part/App/Geometry.cpp
@@ -482,7 +482,7 @@ bool GeomCurve::intersect(  GeomCurve * c,
             return false;
     }
     catch (Standard_Failure& e) {
-        return false;
+        throw Base::RuntimeError(e.GetMessageString());
     }
     
 }
@@ -1518,7 +1518,7 @@ bool GeomTrimmedCurve::intersectBasisCurves(  const GeomTrimmedCurve * c,
         return false;
     }
     catch (Standard_Failure& e) {
-        return false;
+        throw Base::RuntimeError(e.GetMessageString());
     }    
 }
 

--- a/src/Mod/Part/App/Geometry.h
+++ b/src/Mod/Part/App/Geometry.h
@@ -165,7 +165,7 @@ public:
     Base::Vector3d firstDerivativeAtParameter(double u) const;
     Base::Vector3d secondDerivativeAtParameter(double u) const;
     bool closestParameter(const Base::Vector3d& point, double &u) const;
-    bool closestParameterToBasicCurve(const Base::Vector3d& point, double &u) const;
+    bool closestParameterToBasisCurve(const Base::Vector3d& point, double &u) const;
     double getFirstParameter() const;
     double getLastParameter() const;
     double curvatureAt(double u) const;

--- a/src/Mod/Part/App/Geometry.h
+++ b/src/Mod/Part/App/Geometry.h
@@ -171,6 +171,9 @@ public:
     double curvatureAt(double u) const;
     double length(double u, double v) const;
     bool normalAt(double u, Base::Vector3d& dir) const;
+    bool intersect(GeomCurve * c, 
+                   std::vector<std::pair<Base::Vector3d, Base::Vector3d>>& points, 
+                   double tol = Precision::Confusion()) const;
     
     void reverse(void);
 };
@@ -366,6 +369,10 @@ public:
     virtual PyObject *getPyObject(void) = 0;
 
     const Handle(Geom_Geometry)& handle() const = 0;
+    
+    bool intersectBasisCurves(  const GeomArcOfConic * c, 
+                                std::vector<std::pair<Base::Vector3d, Base::Vector3d>>& points, 
+                                double tol = Precision::Confusion()) const;
 };
 
 class PartExport GeomCircle : public GeomConic

--- a/src/Mod/Part/App/Geometry.h
+++ b/src/Mod/Part/App/Geometry.h
@@ -176,6 +176,11 @@ public:
                    double tol = Precision::Confusion()) const;
     
     void reverse(void);
+    
+protected:
+    bool intersect(const Handle(Geom_Curve) c, const Handle(Geom_Curve) c2, 
+                   std::vector<std::pair<Base::Vector3d, Base::Vector3d>>& points, 
+                   double tol = Precision::Confusion()) const;    
 };
 
 class PartExport GeomBoundedCurve : public GeomCurve

--- a/src/Mod/Part/App/Geometry.h
+++ b/src/Mod/Part/App/Geometry.h
@@ -333,7 +333,7 @@ public:
     const Handle(Geom_Geometry)& handle() const = 0;
 };
 
-class PartExport GeomTrimmedCurve : public GeomCurve
+class PartExport GeomTrimmedCurve : public GeomBoundedCurve
 {
     TYPESYSTEM_HEADER();
 public:
@@ -373,9 +373,11 @@ public:
     virtual ~GeomArcOfConic();
     virtual Geometry *copy(void) const = 0;
 
-    Base::Vector3d getStartPoint(bool emulateCCWXY=false) const;
-    Base::Vector3d getEndPoint(bool emulateCCWXY=false) const;
+    Base::Vector3d getStartPoint(bool emulateCCWXY) const;
+    Base::Vector3d getEndPoint(bool emulateCCWXY) const;
 
+    inline virtual Base::Vector3d getStartPoint() const {return getStartPoint(false);};
+    inline virtual Base::Vector3d getEndPoint() const {return getEndPoint(false);};
     /*!
      * \deprecated use getLocation
      * \brief getCenter

--- a/src/Mod/Part/App/Geometry.h
+++ b/src/Mod/Part/App/Geometry.h
@@ -328,7 +328,36 @@ public:
     const Handle(Geom_Geometry)& handle() const = 0;
 };
 
-class PartExport GeomArcOfConic : public GeomCurve
+class PartExport GeomTrimmedCurve : public GeomCurve
+{
+    TYPESYSTEM_HEADER();
+public:
+    GeomTrimmedCurve();
+    GeomTrimmedCurve(const Handle(Geom_TrimmedCurve)&);
+    virtual ~GeomTrimmedCurve();
+    virtual Geometry *copy(void) const;
+
+    // Persistence implementer ---------------------
+    virtual unsigned int getMemSize(void) const;
+    virtual void Save(Base::Writer &/*writer*/) const;
+    virtual void Restore(Base::XMLReader &/*reader*/);
+    // Base implementer ----------------------------
+    virtual PyObject *getPyObject(void);
+
+    void setHandle(const Handle(Geom_TrimmedCurve)&);
+    const Handle(Geom_Geometry)& handle() const;
+
+    bool intersectBasisCurves(  const GeomTrimmedCurve * c, 
+                            std::vector<std::pair<Base::Vector3d, Base::Vector3d>>& points, 
+                            double tol = Precision::Confusion()) const;
+    
+protected:
+    Handle(Geom_TrimmedCurve) myCurve;
+};
+
+
+
+class PartExport GeomArcOfConic : public GeomTrimmedCurve
 {
     TYPESYSTEM_HEADER();
 
@@ -369,10 +398,6 @@ public:
     virtual PyObject *getPyObject(void) = 0;
 
     const Handle(Geom_Geometry)& handle() const = 0;
-    
-    bool intersectBasisCurves(  const GeomArcOfConic * c, 
-                                std::vector<std::pair<Base::Vector3d, Base::Vector3d>>& points, 
-                                double tol = Precision::Confusion()) const;
 };
 
 class PartExport GeomCircle : public GeomConic
@@ -430,8 +455,6 @@ public:
     void setHandle(const Handle(Geom_Circle)&);
     const Handle(Geom_Geometry)& handle() const;
 
-private:
-    Handle(Geom_TrimmedCurve) myCurve;
 };
 
 class PartExport GeomEllipse : public GeomConic
@@ -495,9 +518,6 @@ public:
     void setHandle(const Handle(Geom_TrimmedCurve)&);
     void setHandle(const Handle(Geom_Ellipse)&);
     const Handle(Geom_Geometry)& handle() const;
-
-private:
-    Handle(Geom_TrimmedCurve) myCurve;
 };
 
 
@@ -560,9 +580,6 @@ public:
     void setHandle(const Handle(Geom_TrimmedCurve)&);
     void setHandle(const Handle(Geom_Hyperbola)&);
     const Handle(Geom_Geometry)& handle() const;
-
-private:
-    Handle(Geom_TrimmedCurve) myCurve;
 };
 
 class PartExport GeomParabola : public GeomConic
@@ -620,9 +637,6 @@ public:
     void setHandle(const Handle(Geom_TrimmedCurve)&);
     void setHandle(const Handle(Geom_Parabola)&);
     const Handle(Geom_Geometry)& handle() const;
-
-private:
-    Handle(Geom_TrimmedCurve) myCurve;
 };
 
 class PartExport GeomLine : public GeomCurve
@@ -653,7 +667,7 @@ private:
     Handle(Geom_Line) myCurve;
 };
 
-class PartExport GeomLineSegment : public GeomCurve
+class PartExport GeomLineSegment : public GeomTrimmedCurve
 {
     TYPESYSTEM_HEADER();
 public:
@@ -679,8 +693,6 @@ public:
     void setHandle(const Handle(Geom_Line)&);
     const Handle(Geom_Geometry)& handle() const;
 
-private:
-    Handle(Geom_TrimmedCurve) myCurve;
 };
 
 class PartExport GeomOffsetCurve : public GeomCurve
@@ -689,6 +701,7 @@ class PartExport GeomOffsetCurve : public GeomCurve
 public:
     GeomOffsetCurve();
     GeomOffsetCurve(const Handle(Geom_Curve)&, double, const gp_Dir&);
+    GeomOffsetCurve(const Handle(Geom_Curve)&, double, Base::Vector3d&);
     GeomOffsetCurve(const Handle(Geom_OffsetCurve)&);
     virtual ~GeomOffsetCurve();
     virtual Geometry *copy(void) const;
@@ -705,29 +718,6 @@ public:
 
 private:
     Handle(Geom_OffsetCurve) myCurve;
-};
-
-class PartExport GeomTrimmedCurve : public GeomCurve
-{
-    TYPESYSTEM_HEADER();
-public:
-    GeomTrimmedCurve();
-    GeomTrimmedCurve(const Handle(Geom_TrimmedCurve)&);
-    virtual ~GeomTrimmedCurve();
-    virtual Geometry *copy(void) const;
-
-    // Persistence implementer ---------------------
-    virtual unsigned int getMemSize(void) const;
-    virtual void Save(Base::Writer &/*writer*/) const;
-    virtual void Restore(Base::XMLReader &/*reader*/);
-    // Base implementer ----------------------------
-    virtual PyObject *getPyObject(void);
-
-    void setHandle(const Handle(Geom_TrimmedCurve)&);
-    const Handle(Geom_Geometry)& handle() const;
-
-private:
-    Handle(Geom_TrimmedCurve) myCurve;
 };
 
 class PartExport GeomSurface : public Geometry

--- a/src/Mod/Part/App/GeometryCurvePyImp.cpp
+++ b/src/Mod/Part/App/GeometryCurvePyImp.cpp
@@ -478,22 +478,19 @@ PyObject* GeometryCurvePy::centerOfCurvature(PyObject *args)
 
 PyObject* GeometryCurvePy::parameter(PyObject *args)
 {
-    Handle(Geom_Geometry) g = getGeometryPtr()->handle();
-    Handle(Geom_Curve) c = Handle(Geom_Curve)::DownCast(g);
     try {
-        if (!c.IsNull()) {
-            PyObject *p;
-            if (!PyArg_ParseTuple(args, "O!", &(Base::VectorPy::Type), &p))
-                return 0;
-            Base::Vector3d v = Py::Vector(p, false).toVector();
-            gp_Pnt pnt(v.x,v.y,v.z);
-            GeomAPI_ProjectPointOnCurve ppc(pnt, c);
-            double val = ppc.LowerDistanceParameter();
-            return Py::new_reference_to(Py::Float(val));
-        }
+        PyObject *p;
+        if (!PyArg_ParseTuple(args, "O!", &(Base::VectorPy::Type), &p))
+            return 0;
+        Base::Vector3d v = Py::Vector(p, false).toVector();
+        
+        double u;
+        
+        if(static_cast<Part::GeomCurve *>(getGeometryPtr())->closestParameter(v,u))
+            return Py::new_reference_to(Py::Float(u));
     }
-    catch (Standard_Failure& e) {
-        PyErr_SetString(PartExceptionOCCError, e.GetMessageString());
+    catch (Base::RuntimeError& e) {
+        PyErr_SetString(PartExceptionOCCError, e.what());
         return 0;
     }
 

--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -1370,10 +1370,23 @@ int SketchObject::fillet(int GeoId1, int GeoId2,
         double refparam1;
         double refparam2;
         
-        if(!curve1->closestParameter(refPnt1,refparam1))
-            return -1;
-        if(!curve2->closestParameter(refPnt2,refparam2))
-            return -1;
+        try {
+            if(!curve1->closestParameter(refPnt1,refparam1))
+                return -1;
+        }
+        catch (Base::CADKernelError e) {
+            e.ReportException();
+            THROWM(Base::CADKernelError, "Unable to determine the parameter of the first selected curve at the reference point.")
+        }
+        
+        try {
+             if(!curve2->closestParameter(refPnt2,refparam2))
+                return -1;
+        }
+        catch (Base::CADKernelError e) {
+            e.ReportException();            
+            THROWM(Base::CADKernelError, "Unable to determine the parameter of the second selected curve at the reference point.")
+        }
         
         //Base::Console().Log("Ref param: (%f);(%f)",refparam1,refparam2);
         
@@ -1431,8 +1444,14 @@ int SketchObject::fillet(int GeoId1, int GeoId2,
                 const Part::GeomTrimmedCurve *tcurve1 = static_cast<const Part::GeomTrimmedCurve*>(geo1);
                 const Part::GeomTrimmedCurve *tcurve2 = static_cast<const Part::GeomTrimmedCurve*>(geo2);
                 
-                if(!tcurve1->intersectBasisCurves(tcurve2,points))
-                    return -1;
+                try {
+                    if(!tcurve1->intersectBasisCurves(tcurve2,points))
+                        return -1;
+                }
+                catch (Base::CADKernelError e) {
+                    e.ReportException();
+                    THROWMT(Base::CADKernelError,QT_TRANSLATE_NOOP("Exceptions", "Unable to guess intersection of curves. Try adding a coincident constraint between the vertices of the curves you are intending to fillet."))
+                }                
 
                 int res = selectintersection(points,interpoints,refPnt1, refPnt2);
             
@@ -1447,11 +1466,24 @@ int SketchObject::fillet(int GeoId1, int GeoId2,
         // Now that we know where the curves intersect, get the parameters in the curves of those points
         double intparam1;
         double intparam2;
+
+        try {
+            if(!curve1->closestParameter(interpoints.first,intparam1))
+                return -1;
+        }
+        catch (Base::CADKernelError e) {
+            e.ReportException();
+            THROWM(Base::CADKernelError,"Unable to determine the parameter of the first selected curve at the intersection of the curves.")
+        }
         
-        if(!curve1->closestParameter(interpoints.first,intparam1))
-            return -1;
-        if(!curve2->closestParameter(interpoints.second,intparam2))
-            return -1;
+        try {
+            if(!curve2->closestParameter(interpoints.second,intparam2))
+                return -1;
+        }
+        catch (Base::CADKernelError e) {
+            e.ReportException();
+            THROWM(Base::CADKernelError,"Unable to determine the parameter of the second selected curve at the intersection of the curves.")
+        }
         
         // get a fillet radius if zero was given
         Base::Vector3d ref21 = refPnt2 - refPnt1;
@@ -1486,6 +1518,7 @@ int SketchObject::fillet(int GeoId1, int GeoId2,
         double sdir2 = tdir2.Cross(-ref21).Dot(vn);
         
         //Base::Console().Log("sign of offset: (%f,%f)\n",sdir1,sdir2);
+        //Base::Console().Log("radius: %f\n",radius);
         
         Part::GeomOffsetCurve * ocurve1 = new Part::GeomOffsetCurve(Handle(Geom_Curve)::DownCast(curve1->handle()), (sdir1<0)?radius:-radius, vn);
         
@@ -1496,14 +1529,28 @@ int SketchObject::fillet(int GeoId1, int GeoId2,
         
         //Base::Console().Log("start point offset curves: (%f,%f,%f);(%f,%f,%f)\n",oc1pf.x,oc1pf.y,oc1pf.z,oc2pf.x,oc2pf.y,oc2pf.z);        
         
+        /*auto printoffsetcurve = [](Part::GeomOffsetCurve *c) {
         
+            for(double param = c->getFirstParameter(); param < c->getLastParameter(); param = param + (c->getLastParameter()-c->getFirstParameter())/10)
+                Base::Console().Log("\n%f: (%f,%f,0)\n", param, c->pointAtParameter(param).x,c->pointAtParameter(param).y);
+        
+        };
+        
+        printoffsetcurve(ocurve1);
+        printoffsetcurve(ocurve2);*/
+            
         // Next we calculate the intersection of offset curves to get the center of the fillet
         std::pair<Base::Vector3d, Base::Vector3d> filletcenterpoint;
         std::vector<std::pair<Base::Vector3d, Base::Vector3d>> offsetintersectionpoints;
 
-        if(!ocurve1->intersect(ocurve2,offsetintersectionpoints))
-            return -1;
-        
+        try {
+            if(!ocurve1->intersect(ocurve2,offsetintersectionpoints))
+                return -1;
+        }
+        catch (Base::CADKernelError e) {
+            e.ReportException();          
+            THROWM(Base::CADKernelError,"Unable to find intersection between offset curves.")
+        }
         
         int res = selectintersection(offsetintersectionpoints,filletcenterpoint,refPnt1, refPnt2);
         
@@ -1513,10 +1560,23 @@ int SketchObject::fillet(int GeoId1, int GeoId2,
         double refoparam1;
         double refoparam2;
         
-        if(!curve1->closestParameter(filletcenterpoint.first,refoparam1))
-            return -1;
-        if(!curve2->closestParameter(filletcenterpoint.second,refoparam2))
-            return -1;
+        try {
+            if(!curve1->closestParameter(filletcenterpoint.first,refoparam1))
+                return -1;
+        }     
+        catch (Base::CADKernelError e) {
+            e.ReportException();
+            THROWM(Base::CADKernelError,"Unable to determine the starting point of the arc.")
+        }
+        
+        try {
+            if(!curve2->closestParameter(filletcenterpoint.second,refoparam2))
+                return -1;
+        }
+        catch (Base::CADKernelError e) {
+            e.ReportException();
+            THROWM(Base::CADKernelError,"Unable to determine the end point of the arc.")
+        }
         
         // Next we calculate the closest points to the fillet center, so the points where tangency is to be applied
         Base::Vector3d refp1 = curve1->pointAtParameter(refoparam1);

--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -45,6 +45,7 @@
 # include <Geom_Parabola.hxx>
 # include <Geom_BSplineCurve.hxx>
 # include <Geom_TrimmedCurve.hxx>
+# include <Geom_OffsetCurve.hxx>
 # include <GeomAPI_ProjectPointOnSurf.hxx>
 # include <BRepOffsetAPI_NormalProjection.hxx>
 # include <BRepBuilderAPI_MakeFace.hxx>
@@ -1312,11 +1313,11 @@ int SketchObject::fillet(int GeoId1, int GeoId2,
         
         return 0;
     }
-    else if( geo1->isDerivedFrom(Part::GeomArcOfConic::getClassTypeId()) &&
-             geo2->isDerivedFrom(Part::GeomArcOfConic::getClassTypeId())) {
+    else if( geo1->isDerivedFrom(Part::GeomTrimmedCurve::getClassTypeId()) &&
+             geo2->isDerivedFrom(Part::GeomTrimmedCurve::getClassTypeId())) {
                 
-        const Part::GeomArcOfConic *curve1 = static_cast<const Part::GeomArcOfConic*>(geo1);
-        const Part::GeomArcOfConic *curve2 = static_cast<const Part::GeomArcOfConic*>(geo2);
+        const Part::GeomTrimmedCurve *curve1 = static_cast<const Part::GeomTrimmedCurve*>(geo1);
+        const Part::GeomTrimmedCurve *curve2 = static_cast<const Part::GeomTrimmedCurve*>(geo2);
 
         double refparam1;
         double refparam2;
@@ -1334,37 +1335,47 @@ int SketchObject::fillet(int GeoId1, int GeoId2,
             
         if(!curve1->intersectBasisCurves(curve2,points))
             return -1;
-            
-        if(points.size() == 0) {
-            return -1;
-        }
-        else {
-            
-            auto distance = [](Base::Vector3d ip1, Base::Vector3d ip2, Base::Vector3d ref1, Base::Vector3d ref2) {
-                return (ip1 - ref1).Length() + (ip2 - ref2).Length();
-            };
-            
-            double dist = distance(points[0].first, points[0].second, refPnt1, refPnt2);
-            int i = 0, si = 0;
-            
-            for( auto ipoints : points)
-            {
-                double d = distance(ipoints.first, ipoints.second, refPnt1, refPnt2);
-                
-                if (d<dist) {
-                    si = i;
-                    dist = d;
-                }
-                    
-                i++;
-            }
-            
-            interpoints = points[si];
-        }
         
-        /*Base::Console().Log("Interpoints: (%f,%f,%f);(%f,%f,%f)",interpoints.first.x,interpoints.first.y,interpoints.first.z, \
-                                                               interpoints.second.x,interpoints.second.y,interpoints.second.z);
-        */
+        auto selectintersection = [](std::vector<std::pair<Base::Vector3d, Base::Vector3d>> & points,
+                                     std::pair<Base::Vector3d, Base::Vector3d>& interpoints,
+                                     const Base::Vector3d& refPnt1, const Base::Vector3d& refPnt2) {
+        
+            if(points.size() == 0) {
+                return -1;
+            }
+            else {
+                
+                auto distance = [](Base::Vector3d ip1, Base::Vector3d ip2, Base::Vector3d ref1, Base::Vector3d ref2) {
+                    return (ip1 - ref1).Length() + (ip2 - ref2).Length();
+                };
+                
+                double dist = distance(points[0].first, points[0].second, refPnt1, refPnt2);
+                int i = 0, si = 0;
+                
+                for( auto ipoints : points)
+                {
+                    double d = distance(ipoints.first, ipoints.second, refPnt1, refPnt2);
+                    
+                    if (d<dist) {
+                        si = i;
+                        dist = d;
+                    }
+                        
+                    i++;
+                }
+                
+                interpoints = points[si];
+                
+                return 0;
+            }
+        };
+        
+        int res = selectintersection(points,interpoints,refPnt1, refPnt2);
+        
+        if(res != 0)
+            return res;
+                
+        
         double intparam1;
         double intparam2;
         
@@ -1372,8 +1383,6 @@ int SketchObject::fillet(int GeoId1, int GeoId2,
             return -1;
         if(!curve2->closestParameter(interpoints.second,intparam2))
             return -1;
-        
-        //Base::Console().Log("Interpoints param: (%f);(%f)",intparam1,intparam2);
         
         Base::Vector3d dir1;
         Base::Vector3d dir2;
@@ -1384,30 +1393,78 @@ int SketchObject::fillet(int GeoId1, int GeoId2,
         if(!curve2->normalAt(refparam2, dir2))
             return -1;
         
-        double det = -dir1.x*dir2.y + dir2.x*dir1.y;
-        if(abs(det) < Precision::Confusion())
-            return -1; // no intersection of normals
-        
-        Base::Vector3d refp1 = curve1->pointAtParameter(refparam1);
-        Base::Vector3d refp2 = curve2->pointAtParameter(refparam2);
-        
-        //Base::Console().Log("refpoints: (%f,%f,%f);(%f,%f,%f)",refp1.x,refp1.y,refp1.z,refp2.x,refp2.y,refp2.z);
+        Base::Vector3d ref21 = refPnt2 - refPnt1;
+                
+        if(radius == .0f) {
+            // guess a radius
+            radius = ref21.Length();
+        }
         
         double spc1 = curve1->getFirstParameter();
         double spc2 = curve2->getFirstParameter(); 
         
-        //Base::Console().Log("Start param: (%f);(%f)",spc1,spc2);
+        Base::Console().Log("Start param: (%f);(%f)\n",spc1,spc2);
         
-        Base::Vector3d filletCenter(
-            (-dir1.x*dir2.x*refp1.y + dir1.x*dir2.x*refp2.y - dir1.x*dir2.y*refp2.x + dir2.x*dir1.y*refp1.x)/det,
-            (-dir1.x*dir2.y*refp1.y + dir2.x*dir1.y*refp2.y + dir1.y*dir2.y*refp1.x - dir1.y*dir2.y*refp2.x)/det,0);
+        Base::Vector3d c1pf = curve1->pointAtParameter(spc1);
+        Base::Vector3d c2pf = curve2->pointAtParameter(spc2);
         
+        Base::Console().Log("start point curves: (%f,%f,%f);(%f,%f,%f)\n",c1pf.x,c1pf.y,c1pf.z,c2pf.x,c2pf.y,c2pf.z);
+        
+        // We create Offset curves at the suggested radius
+        Base::Vector3d tdir1 = curve1->firstDerivativeAtParameter(refparam1);
+        Base::Vector3d tdir2 = curve2->firstDerivativeAtParameter(refparam2);
+
+        Base::Console().Log("tangent vectors: (%f,%f,%f);(%f,%f,%f)\n",tdir1.x,tdir1.y,tdir1.z,tdir2.x,tdir2.y,tdir2.z);
+        
+        Base::Console().Log("inter-ref vector: (%f,%f,%f)\n",ref21.x,ref21.y,ref21.z);
+        
+        Base::Vector3d vn(0,0,1);
+        
+        double sdir1 = tdir1.Cross(ref21).Dot(vn);
+        double sdir2 = tdir2.Cross(-ref21).Dot(vn);
+        
+        Base::Console().Log("sign of offset: (%f,%f)\n",sdir1,sdir2);
+        
+        Part::GeomOffsetCurve * ocurve1 = new Part::GeomOffsetCurve(Handle(Geom_Curve)::DownCast(curve1->handle()), (sdir1<0)?radius:-radius, vn);
+        
+        Part::GeomOffsetCurve * ocurve2 = new Part::GeomOffsetCurve(Handle(Geom_Curve)::DownCast(curve2->handle()), (sdir2<0)?radius:-radius, vn);
+ 
+        Base::Vector3d oc1pf = ocurve1->pointAtParameter(ocurve1->getFirstParameter());
+        Base::Vector3d oc2pf = ocurve2->pointAtParameter(ocurve2->getFirstParameter());
+        
+        Base::Console().Log("start point offset curves: (%f,%f,%f);(%f,%f,%f)\n",oc1pf.x,oc1pf.y,oc1pf.z,oc2pf.x,oc2pf.y,oc2pf.z);        
+        
+        // intersection of basic curves is specially relevant to determine curve enpoints to trim
+        std::pair<Base::Vector3d, Base::Vector3d> filletcenterpoint;
+        std::vector<std::pair<Base::Vector3d, Base::Vector3d>> offsetintersectionpoints;
+            
+        if(!ocurve1->intersect(ocurve2,offsetintersectionpoints))
+            return -1;
+        
+        
+        res = selectintersection(offsetintersectionpoints,filletcenterpoint,refPnt1, refPnt2);
+        
+        if(res != 0)
+            return res;
+        
+        double refoparam1;
+        double refoparam2;
+        
+        if(!curve1->closestParameter(filletcenterpoint.first,refoparam1))
+            return -1;
+        if(!curve2->closestParameter(filletcenterpoint.second,refoparam2))
+            return -1;
+        
+        Base::Vector3d refp1 = curve1->pointAtParameter(refoparam1);
+        Base::Vector3d refp2 = curve2->pointAtParameter(refoparam2);
+        
+        Base::Console().Log("refpoints: (%f,%f,%f);(%f,%f,%f)",refp1.x,refp1.y,refp1.z,refp2.x,refp2.y,refp2.z);
         
         // create arc from known parameters and lines
         double startAngle, endAngle, range;
        
-        Base::Vector3d radDir1 = refp1 - filletCenter;
-        Base::Vector3d radDir2 = refp2 - filletCenter;
+        Base::Vector3d radDir1 = refp1 - filletcenterpoint.first;
+        Base::Vector3d radDir2 = refp2 - filletcenterpoint.first;
         
         startAngle = atan2(radDir1.y, radDir1.x);
         
@@ -1428,7 +1485,7 @@ int SketchObject::fillet(int GeoId1, int GeoId2,
         // Create Arc Segment
         Part::GeomArcOfCircle *arc = new Part::GeomArcOfCircle();
         arc->setRadius(radDir1.Length());
-        arc->setCenter(filletCenter);
+        arc->setCenter(filletcenterpoint.first);
         arc->setRange(startAngle, endAngle, /*emulateCCWXY=*/true);
         
         // add arc to sketch geometry
@@ -1456,8 +1513,8 @@ int SketchObject::fillet(int GeoId1, int GeoId2,
                 }
             };
             
-            PointPos PosId1 = selectend(intparam1,refparam1,spc1);
-            PointPos PosId2 = selectend(intparam2,refparam2,spc2);
+            PointPos PosId1 = selectend(intparam1,refoparam1,spc1);
+            PointPos PosId2 = selectend(intparam2,refoparam2,spc2);
 
             delConstraintOnPoint(GeoId1, PosId1, false);
             delConstraintOnPoint(GeoId2, PosId2, false);
@@ -1500,6 +1557,8 @@ int SketchObject::fillet(int GeoId1, int GeoId2,
             delete tangent2;
         }
         delete arc;
+        delete ocurve1;
+        delete ocurve2;
         
         if(noRecomputes) // if we do not have a recompute after the geometry creation, the sketch must be solved to update the DoF of the solver
             solve();

--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -1313,30 +1313,14 @@ int SketchObject::fillet(int GeoId1, int GeoId2,
         
         return 0;
     }
-    else if( geo1->isDerivedFrom(Part::GeomTrimmedCurve::getClassTypeId()) &&
-             geo2->isDerivedFrom(Part::GeomTrimmedCurve::getClassTypeId())) {
+    else if(geo1->isDerivedFrom(Part::GeomBoundedCurve::getClassTypeId())  &&
+            geo2->isDerivedFrom(Part::GeomBoundedCurve::getClassTypeId())) {
+        
+        auto distancetorefpoints = [](Base::Vector3d ip1, Base::Vector3d ip2, Base::Vector3d ref1, Base::Vector3d ref2) {
+                    return (ip1 - ref1).Length() + (ip2 - ref2).Length();
+                };
                 
-        const Part::GeomTrimmedCurve *curve1 = static_cast<const Part::GeomTrimmedCurve*>(geo1);
-        const Part::GeomTrimmedCurve *curve2 = static_cast<const Part::GeomTrimmedCurve*>(geo2);
-
-        double refparam1;
-        double refparam2;
-        
-        if(!curve1->closestParameter(refPnt1,refparam1))
-            return -1;
-        if(!curve2->closestParameter(refPnt2,refparam2))
-            return -1;
-        
-        //Base::Console().Log("Ref param: (%f);(%f)",refparam1,refparam2);
-        
-        // intersection of basic curves is specially relevant to determine curve enpoints to trim
-        std::pair<Base::Vector3d, Base::Vector3d> interpoints;
-        std::vector<std::pair<Base::Vector3d, Base::Vector3d>> points;
-            
-        if(!curve1->intersectBasisCurves(curve2,points))
-            return -1;
-        
-        auto selectintersection = [](std::vector<std::pair<Base::Vector3d, Base::Vector3d>> & points,
+        auto selectintersection = [&distancetorefpoints](std::vector<std::pair<Base::Vector3d, Base::Vector3d>> & points,
                                      std::pair<Base::Vector3d, Base::Vector3d>& interpoints,
                                      const Base::Vector3d& refPnt1, const Base::Vector3d& refPnt2) {
         
@@ -1345,16 +1329,12 @@ int SketchObject::fillet(int GeoId1, int GeoId2,
             }
             else {
                 
-                auto distance = [](Base::Vector3d ip1, Base::Vector3d ip2, Base::Vector3d ref1, Base::Vector3d ref2) {
-                    return (ip1 - ref1).Length() + (ip2 - ref2).Length();
-                };
-                
-                double dist = distance(points[0].first, points[0].second, refPnt1, refPnt2);
+                double dist = distancetorefpoints(points[0].first, points[0].second, refPnt1, refPnt2);
                 int i = 0, si = 0;
                 
                 for( auto ipoints : points)
                 {
-                    double d = distance(ipoints.first, ipoints.second, refPnt1, refPnt2);
+                    double d = distancetorefpoints(ipoints.first, ipoints.second, refPnt1, refPnt2);
                     
                     if (d<dist) {
                         si = i;
@@ -1369,13 +1349,102 @@ int SketchObject::fillet(int GeoId1, int GeoId2,
                 return 0;
             }
         };
-        
-        int res = selectintersection(points,interpoints,refPnt1, refPnt2);
-        
-        if(res != 0)
-            return res;
                 
+        // NOTE: While it is not a requirement that the endpoints of the corner to trim are coincident
+        //       for GeomTrimmedCurves, it is for GeomBoundedCurves. The reason is that there is no basiscurve
+        //       that can be extended to find an intersection.
+        //
+        //       However, GeomTrimmedCurves sometimes run into problems when trying to calculate the intersection
+        //       of basis curves, for example in the case of hyperbola sometimes the cosh goes out of range while
+        //       calculating this intersection of basis curves.
+        //
+        //        Consequently:
+        //        i. for GeomBoundedCurves, other than GeomTrimmedCurves, a coincident endpoint is mandatory.
+        //        ii. for GeomTrimmedCurves, if there is a coincident endpoint, it is used for the fillet,
+        //        iii. for GeomTrimmedCurves, if there is not a coincident endpoint, an intersection of basis curves
+        //             is attempted.
         
+        const Part::GeomCurve *curve1 = static_cast<const Part::GeomCurve*>(geo1);
+        const Part::GeomCurve *curve2 = static_cast<const Part::GeomCurve*>(geo2);
+        
+        double refparam1;
+        double refparam2;
+        
+        if(!curve1->closestParameter(refPnt1,refparam1))
+            return -1;
+        if(!curve2->closestParameter(refPnt2,refparam2))
+            return -1;
+        
+        //Base::Console().Log("Ref param: (%f);(%f)",refparam1,refparam2);
+        
+        std::pair<Base::Vector3d, Base::Vector3d> interpoints;
+        std::vector<std::pair<Base::Vector3d, Base::Vector3d>> points;
+        
+        
+        // look for coincident constraints between curves, take the coincident closest to the refpoints
+        Sketcher::PointPos curve1PosId = Sketcher::none;
+        Sketcher::PointPos curve2PosId = Sketcher::none;
+        
+        double dist=INFINITY;
+        
+        const std::vector<Constraint *> &constraints = this->Constraints.getValues();
+
+        for (std::vector<Constraint *>::const_iterator it=constraints.begin(); it != constraints.end(); ++it) {
+            if ((*it)->Type == Sketcher::Coincident) {
+                if ((*it)->First == GeoId1 && (*it)->Second == GeoId2) {
+                    Base::Vector3d tmpp1 = getPoint((*it)->First,(*it)->FirstPos);
+                    Base::Vector3d tmpp2 = getPoint((*it)->Second,(*it)->SecondPos);
+                    double tmpdist = distancetorefpoints(tmpp1, 
+                                                         tmpp2,
+                                                         refPnt1,
+                                                         refPnt2);
+                    if(tmpdist < dist) {
+                        curve1PosId = (*it)->FirstPos;
+                        curve2PosId = (*it)->SecondPos;
+                        dist = tmpdist;
+                        interpoints = std::make_pair(tmpp1,tmpp2);
+                    }
+                }
+                else if ((*it)->First == GeoId2 && (*it)->Second == GeoId1) {
+                    Base::Vector3d tmpp2 = getPoint((*it)->First,(*it)->FirstPos);
+                    Base::Vector3d tmpp1 = getPoint((*it)->Second,(*it)->SecondPos);
+                    double tmpdist = distancetorefpoints(tmpp1, 
+                                                         tmpp2,
+                                                         refPnt1,
+                                                         refPnt2);
+                    if(tmpdist < dist) {                    
+                        curve2PosId = (*it)->FirstPos;
+                        curve1PosId = (*it)->SecondPos;
+                        dist = tmpdist;
+                        interpoints = std::make_pair(tmpp1,tmpp2);
+                    }
+                }
+            }
+        }
+        
+        if( curve1PosId == Sketcher::none ) { 
+            // no coincident was found, try basis curve intersection if GeomTrimmedCurve
+            if( geo1->isDerivedFrom(Part::GeomTrimmedCurve::getClassTypeId()) &&
+                geo2->isDerivedFrom(Part::GeomTrimmedCurve::getClassTypeId())) { 
+        
+            
+                const Part::GeomTrimmedCurve *tcurve1 = static_cast<const Part::GeomTrimmedCurve*>(geo1);
+                const Part::GeomTrimmedCurve *tcurve2 = static_cast<const Part::GeomTrimmedCurve*>(geo2);
+                
+                if(!tcurve1->intersectBasisCurves(tcurve2,points))
+                    return -1;
+
+                int res = selectintersection(points,interpoints,refPnt1, refPnt2);
+            
+                if(res != 0)
+                    return res;
+                   
+            }
+            else
+                return -1; // not a GeomTrimmedCurve and no coincident point.
+        }
+
+        // Now that we know where the curves intersect, get the parameters in the curves of those points
         double intparam1;
         double intparam2;
         
@@ -1384,15 +1453,7 @@ int SketchObject::fillet(int GeoId1, int GeoId2,
         if(!curve2->closestParameter(interpoints.second,intparam2))
             return -1;
         
-        Base::Vector3d dir1;
-        Base::Vector3d dir2;
-        
-        if(!curve1->normalAt(refparam1, dir1))
-            return -1;
-        
-        if(!curve2->normalAt(refparam2, dir2))
-            return -1;
-        
+        // get a fillet radius if zero was given
         Base::Vector3d ref21 = refPnt2 - refPnt1;
                 
         if(radius == .0f) {
@@ -1400,49 +1461,51 @@ int SketchObject::fillet(int GeoId1, int GeoId2,
             radius = ref21.Length();
         }
         
+        // get the starting parameters of each curve
         double spc1 = curve1->getFirstParameter();
         double spc2 = curve2->getFirstParameter(); 
         
-        Base::Console().Log("Start param: (%f);(%f)\n",spc1,spc2);
+        //Base::Console().Log("Start param: (%f);(%f)\n",spc1,spc2);
         
-        Base::Vector3d c1pf = curve1->pointAtParameter(spc1);
-        Base::Vector3d c2pf = curve2->pointAtParameter(spc2);
+        //Base::Vector3d c1pf = curve1->pointAtParameter(spc1);
+        //Base::Vector3d c2pf = curve2->pointAtParameter(spc2);
         
-        Base::Console().Log("start point curves: (%f,%f,%f);(%f,%f,%f)\n",c1pf.x,c1pf.y,c1pf.z,c2pf.x,c2pf.y,c2pf.z);
+        //Base::Console().Log("start point curves: (%f,%f,%f);(%f,%f,%f)\n",c1pf.x,c1pf.y,c1pf.z,c2pf.x,c2pf.y,c2pf.z);
         
-        // We create Offset curves at the suggested radius
+        // We create Offset curves at the suggested radius, the direction of offset is estimated from the tangency vector
         Base::Vector3d tdir1 = curve1->firstDerivativeAtParameter(refparam1);
         Base::Vector3d tdir2 = curve2->firstDerivativeAtParameter(refparam2);
 
-        Base::Console().Log("tangent vectors: (%f,%f,%f);(%f,%f,%f)\n",tdir1.x,tdir1.y,tdir1.z,tdir2.x,tdir2.y,tdir2.z);
+        //Base::Console().Log("tangent vectors: (%f,%f,%f);(%f,%f,%f)\n",tdir1.x,tdir1.y,tdir1.z,tdir2.x,tdir2.y,tdir2.z);
         
-        Base::Console().Log("inter-ref vector: (%f,%f,%f)\n",ref21.x,ref21.y,ref21.z);
+        //Base::Console().Log("inter-ref vector: (%f,%f,%f)\n",ref21.x,ref21.y,ref21.z);
         
         Base::Vector3d vn(0,0,1);
         
         double sdir1 = tdir1.Cross(ref21).Dot(vn);
         double sdir2 = tdir2.Cross(-ref21).Dot(vn);
         
-        Base::Console().Log("sign of offset: (%f,%f)\n",sdir1,sdir2);
+        //Base::Console().Log("sign of offset: (%f,%f)\n",sdir1,sdir2);
         
         Part::GeomOffsetCurve * ocurve1 = new Part::GeomOffsetCurve(Handle(Geom_Curve)::DownCast(curve1->handle()), (sdir1<0)?radius:-radius, vn);
         
         Part::GeomOffsetCurve * ocurve2 = new Part::GeomOffsetCurve(Handle(Geom_Curve)::DownCast(curve2->handle()), (sdir2<0)?radius:-radius, vn);
  
-        Base::Vector3d oc1pf = ocurve1->pointAtParameter(ocurve1->getFirstParameter());
-        Base::Vector3d oc2pf = ocurve2->pointAtParameter(ocurve2->getFirstParameter());
+        //Base::Vector3d oc1pf = ocurve1->pointAtParameter(ocurve1->getFirstParameter());
+        //Base::Vector3d oc2pf = ocurve2->pointAtParameter(ocurve2->getFirstParameter());
         
-        Base::Console().Log("start point offset curves: (%f,%f,%f);(%f,%f,%f)\n",oc1pf.x,oc1pf.y,oc1pf.z,oc2pf.x,oc2pf.y,oc2pf.z);        
+        //Base::Console().Log("start point offset curves: (%f,%f,%f);(%f,%f,%f)\n",oc1pf.x,oc1pf.y,oc1pf.z,oc2pf.x,oc2pf.y,oc2pf.z);        
         
-        // intersection of basic curves is specially relevant to determine curve enpoints to trim
+        
+        // Next we calculate the intersection of offset curves to get the center of the fillet
         std::pair<Base::Vector3d, Base::Vector3d> filletcenterpoint;
         std::vector<std::pair<Base::Vector3d, Base::Vector3d>> offsetintersectionpoints;
-            
+
         if(!ocurve1->intersect(ocurve2,offsetintersectionpoints))
             return -1;
         
         
-        res = selectintersection(offsetintersectionpoints,filletcenterpoint,refPnt1, refPnt2);
+        int res = selectintersection(offsetintersectionpoints,filletcenterpoint,refPnt1, refPnt2);
         
         if(res != 0)
             return res;
@@ -1455,12 +1518,14 @@ int SketchObject::fillet(int GeoId1, int GeoId2,
         if(!curve2->closestParameter(filletcenterpoint.second,refoparam2))
             return -1;
         
+        // Next we calculate the closest points to the fillet center, so the points where tangency is to be applied
         Base::Vector3d refp1 = curve1->pointAtParameter(refoparam1);
         Base::Vector3d refp2 = curve2->pointAtParameter(refoparam2);
         
-        Base::Console().Log("refpoints: (%f,%f,%f);(%f,%f,%f)",refp1.x,refp1.y,refp1.z,refp2.x,refp2.y,refp2.z);
+        //Base::Console().Log("refpoints: (%f,%f,%f);(%f,%f,%f)",refp1.x,refp1.y,refp1.z,refp2.x,refp2.y,refp2.z);
         
-        // create arc from known parameters and lines
+        
+        // Now we create arc for the fillet
         double startAngle, endAngle, range;
        
         Base::Vector3d radDir1 = refp1 - filletcenterpoint.first;
@@ -1513,11 +1578,19 @@ int SketchObject::fillet(int GeoId1, int GeoId2,
                 }
             };
             
-            PointPos PosId1 = selectend(intparam1,refoparam1,spc1);
-            PointPos PosId2 = selectend(intparam2,refoparam2,spc2);
+            // Two cases: 
+            // a) there as a coincidence constraint
+            // b) we used the basis curve intersection
+            
+            
+            if( curve1PosId == Sketcher::none ) {
+                curve1PosId = selectend(intparam1,refoparam1,spc1);
+                curve2PosId = selectend(intparam2,refoparam2,spc2);
+            }
+            
 
-            delConstraintOnPoint(GeoId1, PosId1, false);
-            delConstraintOnPoint(GeoId2, PosId2, false);
+            delConstraintOnPoint(GeoId1, curve1PosId, false);
+            delConstraintOnPoint(GeoId2, curve2PosId, false);
             
             
             Sketcher::Constraint *tangent1 = new Sketcher::Constraint();
@@ -1525,12 +1598,12 @@ int SketchObject::fillet(int GeoId1, int GeoId2,
 
             tangent1->Type = Sketcher::Tangent;
             tangent1->First = GeoId1;
-            tangent1->FirstPos = PosId1;
+            tangent1->FirstPos = curve1PosId;
             tangent1->Second = filletId;
 
             tangent2->Type = Sketcher::Tangent;
             tangent2->First = GeoId2;
-            tangent2->FirstPos = PosId2;
+            tangent2->FirstPos = curve2PosId;
             tangent2->Second = filletId;
 
             double dist1 = (refp1 - arc->getStartPoint(true)).Length();
@@ -1541,14 +1614,14 @@ int SketchObject::fillet(int GeoId1, int GeoId2,
             if (dist1 < dist2) {
                 tangent1->SecondPos = start;
                 tangent2->SecondPos = end;
-                movePoint(GeoId1, PosId1, arc->getStartPoint(true),false,true);
-                movePoint(GeoId2, PosId2, arc->getEndPoint(true),false,true);
+                movePoint(GeoId1, curve1PosId, arc->getStartPoint(true),false,true);
+                movePoint(GeoId2, curve2PosId, arc->getEndPoint(true),false,true);
             }
             else {
                 tangent1->SecondPos = end;
                 tangent2->SecondPos = start;
-                movePoint(GeoId1, PosId1, arc->getEndPoint(true),false,true);
-                movePoint(GeoId2, PosId2, arc->getStartPoint(true),false,true);
+                movePoint(GeoId1, curve1PosId, arc->getEndPoint(true),false,true);
+                movePoint(GeoId2, curve2PosId, arc->getStartPoint(true),false,true);
             }
             
             addConstraint(tangent1);

--- a/src/Mod/Sketcher/App/SketchObjectPyImp.cpp
+++ b/src/Mod/Sketcher/App/SketchObjectPyImp.cpp
@@ -876,9 +876,9 @@ PyObject* SketchObjectPy::fillet(PyObject *args)
 
         if (this->getSketchObjectPtr()->fillet(geoId1, geoId2, v1, v2, radius, trim?true:false)) {
             std::stringstream str;
-            str << "Not able to fillet lineSegments with ids : (" << geoId1 << ", " << geoId2 << ") and points (" << v1.x << ", " << v1.y << ", " << v1.z << ") & "
+            str << "Not able to fillet curves with ids : (" << geoId1 << ", " << geoId2 << ") and points (" << v1.x << ", " << v1.y << ", " << v1.z << ") & "
             << "(" << v2.x << ", " << v2.y << ", " << v2.z << ")";
-            PyErr_SetString(PyExc_ValueError, str.str().c_str());
+            THROWM(Base::ValueError, str.str().c_str())
             return 0;
         }
         Py_Return;

--- a/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp
+++ b/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp
@@ -27,6 +27,8 @@
 # include <QApplication>
 #endif
 
+# include <QMessageBox>
+
 #include <stdlib.h>
 #include <qdebug.h>
 #include <QString>
@@ -5848,9 +5850,21 @@ public:
                                   secondPos.x, secondPos.y, radius);
                         Gui::Command::commitCommand();
                     }
-                    catch (const Base::Exception& e) {
-                        Base::Console().Error("Failed to create fillet: %s\n", e.what());
+                    catch (const Base::CADKernelError& e) {
+                        e.ReportException();
+                        if(e.getTranslatable()) {
+                            QMessageBox::warning(Gui::getMainWindow(), QObject::tr("CAD Kernel Error"),
+                                                QObject::tr(e.getMessage().c_str()));
+                        }
+                        Gui::Selection().clearSelection();
                         Gui::Command::abortCommand();
+                        Mode = STATUS_SEEK_First;
+                    }
+                    catch (const Base::ValueError& e) {
+                        e.ReportException();
+                        Gui::Selection().clearSelection();
+                        Gui::Command::abortCommand();
+                        Mode = STATUS_SEEK_First;
                     }
 
                     tryAutoRecompute(static_cast<Sketcher::SketchObject *>(sketchgui->getObject()));


### PR DESCRIPTION

Bug:
https://www.freecadweb.org/tracker/view.php?id=2463
https://tracker.dev.opencascade.org/view.php?id=30217

Workaround:
Check whether the projection of the endpoints of any bounded curve on the curve to trim exists and is closer than precision::confusion, and regard such points as detected intersections.


Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [x] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
