### PR TITLE
Fix spurious error message in PD::Groove

### DIFF
--- a/src/Mod/PartDesign/App/FeatureGroove.cpp
+++ b/src/Mod/PartDesign/App/FeatureGroove.cpp
@@ -37,6 +37,7 @@
 #endif
 
 #include <Base/Axis.h>
+#include <Base/Console.h>
 #include <Base/Exception.h>
 #include <Base/Placement.h>
 #include <Base/Tools.h>
@@ -156,13 +157,14 @@ App::DocumentObjectExecReturn *Groove::execute(void)
             if (solRes.IsNull())
                 return new App::DocumentObjectExecReturn("Resulting shape is not a solid");
 
-            int solidCount = countSolids(result);
+            solRes = refineShapeIfActive(solRes);
+            this->Shape.setValue(getSolid(solRes));
+
+            int solidCount = countSolids(solRes);
             if (solidCount > 1) {
                 return new App::DocumentObjectExecReturn("Groove: Result has multiple solids. This is not supported at this time.");
             }
-
-            solRes = refineShapeIfActive(solRes);
-            this->Shape.setValue(getSolid(solRes));
+            
         }
         else
             return new App::DocumentObjectExecReturn("Could not revolve the sketch!");


### PR DESCRIPTION
THis PR fixes an error in PartDesign::FeatureGroove where a multi-solid error message was reported for a single solid result.   Please merge.
Thanks,
wf

-  in FeatureGroove, the check for multiple
   solids in result was checking the wrong
   variable.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
