### PR TITLE
Path adaptive - as standard feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,4 +34,4 @@ OpenSCAD_rc.py
 /\.idea/
 .tags
 tags
-.vscode/settings.json
+/\.vscode/

--- a/src/Mod/Path/InitGui.py
+++ b/src/Mod/Path/InitGui.py
@@ -78,7 +78,7 @@ class PathWorkbench (Workbench):
         projcmdlist = ["Path_Job", "Path_Post"]
         toolcmdlist = ["Path_Inspect", "Path_Simulator", "Path_ToolLibraryEdit", "Path_SelectLoop"]
         prepcmdlist = ["Path_Fixture", "Path_Comment", "Path_Stop", "Path_Custom"]
-        twodopcmdlist = ["Path_Contour", "Path_Profile_Faces", "Path_Profile_Edges", "Path_Pocket_Shape", "Path_Drilling", "Path_MillFace", "Path_Helix" ]
+        twodopcmdlist = ["Path_Contour", "Path_Profile_Faces", "Path_Profile_Edges", "Path_Pocket_Shape", "Path_Drilling", "Path_MillFace", "Path_Helix", "Path_Adaptive" ]
         threedopcmdlist = ["Path_Pocket_3D"]
         engravecmdlist = ["Path_Engrave"]
         modcmdlist = ["Path_OperationCopy", "Path_Array", "Path_SimpleCopy" ]
@@ -100,7 +100,6 @@ class PathWorkbench (Workbench):
             threedcmdgroup = ['Path_3dTools']
             FreeCADGui.addCommand('Path_3dTools', PathCommandGroup(threedopcmdlist, QtCore.QT_TRANSLATE_NOOP("Path",'3D Operations')))
 
-            twodopcmdlist.append("Path_Adaptive")
         else:
             engravecmdgroup = engravecmdlist
             threedcmdgroup = threedopcmdlist


### PR DESCRIPTION
- fixed side-effect introduced by last change (completely collinear paths were filtered out)
- removed from experimental and included as standard feature in the Path workbench

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
