### PR TITLE
TD - Fix BSpline/Circle Conversion

### DIFF
--- a/src/Mod/TechDraw/App/DrawUtil.cpp
+++ b/src/Mod/TechDraw/App/DrawUtil.cpp
@@ -317,6 +317,16 @@ std::string DrawUtil::formatVector(const gp_Vec& v)
     return result;
 }
 
+std::string DrawUtil::formatVector(const gp_Pnt& v)
+{
+    std::string result;
+    std::stringstream builder;
+    builder << std::fixed << std::setprecision(3) ;
+    builder << " (" << v.X()  << "," << v.Y() << "," << v.Z() << ") ";
+    result = builder.str();
+    return result;
+}
+
 
 //! compare 2 vectors for sorting - true if v1 < v2
 bool DrawUtil::vectorLess(const Base::Vector3d& v1, const Base::Vector3d& v2)  

--- a/src/Mod/TechDraw/App/DrawUtil.h
+++ b/src/Mod/TechDraw/App/DrawUtil.h
@@ -73,6 +73,7 @@ class TechDrawExport DrawUtil {
         static std::string formatVector(const Base::Vector2d& v);
         static std::string formatVector(const gp_Dir& v);
         static std::string formatVector(const gp_Vec& v);
+        static std::string formatVector(const gp_Pnt& v);
         static bool vectorLess(const Base::Vector3d& v1, const Base::Vector3d& v2);
         static Base::Vector3d toR3(const gp_Ax2 fromSystem, const Base::Vector3d fromPoint);
         static bool checkParallel(const Base::Vector3d v1, const Base::Vector3d v2, double tolerance = FLT_EPSILON);

--- a/src/Mod/TechDraw/App/Geometry.cpp
+++ b/src/Mod/TechDraw/App/Geometry.cpp
@@ -623,8 +623,8 @@ bool BSpline::isCircle()
     Base::Vector3d center;
     bool isArc = false;
     getCircleParms(result,radius,center,isArc);
-    Base::Console().Message("TRACE - GEO::BS::isCircle - result: %d radius: %.3f center: %s isArc %d\n",
-                            result,radius,DrawUtil::formatVector(center).c_str(),isArc);
+//    Base::Console().Message("TRACE - GEO::BS::isCircle - result: %d radius: %.3f center: %s isArc %d\n",
+//                            result,radius,DrawUtil::formatVector(center).c_str(),isArc);
     
     return result;
 }
@@ -756,12 +756,14 @@ TopoDS_Edge BSpline::isCircle2(bool& arc)
     gp_Pnt center2 = circle2.Location();
     Base::Vector3d vc2 = DrawUtil::gpPnt2V3(center2);
 
-    // test circle creation and compare radii
+    // test circle creation and compare radii & centers
+    double allowError = 0.0008;          //trial and error 8/10,000mm printer resolution is 0.085mm
     double radius;
     Base::Vector3d center;
     if ( (gce_circ1.Status() == gce_Done) && 
          (gce_circ2.Status() == gce_Done) && 
-         (!DrawUtil::fpCompare(radius2,radius1)) ) {
+         (DrawUtil::fpCompare(radius2,radius1, allowError)) &&
+         (vc1.IsEqual(vc2,allowError))) {
         if (arc) {
             GC_MakeArcOfCircle makeArc(s,pcm,e);
             Handle(Geom_TrimmedCurve) tCurve = makeArc.Value();


### PR DESCRIPTION
This PR corrects an error in the routine that determines if a BSpline should be treated as a Circle for drawing & dimensioning.  Please merge.
Thanks,
wf

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
