### PR TITLE
[#847] Sketcher: Change snap tolerance to 0.5*Gridsize

### DIFF
--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -489,7 +489,7 @@ void ViewProviderSketch::snapToGrid(double &x, double &y)
 {
     if (GridSnap.getValue() != false) {
         // Snap Tolerance in pixels
-        const double snapTol = GridSize.getValue() / 5;
+        const double snapTol = GridSize.getValue() / 2;
 
         double tmpX = x, tmpY = y;
 


### PR DESCRIPTION

This bug report complains basically about snap tolerance being low
https://www.freecadweb.org/tracker/view.php?id=847

This commit increases the snap tolerance so that it always snaps to grid.

This is different from what the original author, Werner, intended, that was to snap only if close to a point.

It might be a matter of preference.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
