### PR TITLE
Fix selection problems

### DIFF
--- a/src/Mod/TechDraw/Gui/Command.cpp
+++ b/src/Mod/TechDraw/Gui/Command.cpp
@@ -516,6 +516,7 @@ void CmdTechDrawProjGroup::activated(int iMsg)
     //set projection direction from selected Face
     //use first object with a face selected
     std::vector<Gui::SelectionObject> selection = getSelection().getSelectionEx();
+    Base::Console().Message("TRACE - CMDPROJGROUP - selection: %d\n",selection.size());
     Part::Feature* partFeat = 0;
     std::vector<std::string> SubNames;
     std::string faceName;

--- a/src/Mod/TechDraw/Gui/CommandDecorate.cpp
+++ b/src/Mod/TechDraw/Gui/CommandDecorate.cpp
@@ -356,6 +356,7 @@ void CreateTechDrawCommandsDecorate(void)
 
 bool _checkSelectionHatch(Gui::Command* cmd) {
     std::vector<Gui::SelectionObject> selection = cmd->getSelection().getSelectionEx();
+    Base::Console().Message("TRACE - CMDDEC::checkSelectionHatch - selection: %d\n",selection.size());
     if (selection.size() == 0) {
         QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Incorrect selection"),
                              QObject::tr("Select a Face first"));


### PR DESCRIPTION
This PR corrects an issue with selecting Edges in QGraphicsScene.  Please merge.
- After commit f898eafd64 (boost::signals2) edge selection in
  TechDraw stopped working.  This commit restores functionality.
  No idea why signals2 change affected MDIViewPage.
Thanks,
wf

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
