### PR TITLE
Misc. typos and whitespace

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -575,7 +575,7 @@ endif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin" AND NOT BUILD_WITH_CONDA)
     if(FREECAD_USE_PCL)
         find_package(PCL REQUIRED COMPONENTS common kdtree features surface io filters segmentation sample_consensus)
     endif(FREECAD_USE_PCL)
-    
+
 # -------------------------------- PyBind11 -----------------------------
 # necessary for flat-mesh feature
 OPTION(FREECAD_USE_PYBIND11 "Use pybind11" OFF)
@@ -674,7 +674,7 @@ endif()
             endforeach()
         endif()
 
-        # don't check VERSION 6 as this would exlude VERSION 7
+        # don't check VERSION 6 as this would exclude VERSION 7
         if(AVAILABLE_VTK_COMPONENTS)
             message(STATUS "VTK components: ${AVAILABLE_VTK_COMPONENTS}")
             find_package(VTK COMPONENTS ${AVAILABLE_VTK_COMPONENTS} REQUIRED NO_MODULE)
@@ -992,14 +992,14 @@ endif()
 
 	if(APPLE)
 	    INSTALL(
-	        DIRECTORY	
+	        DIRECTORY
                     ${CMAKE_BINARY_DIR}/Ext/PySide
 		DESTINATION
                     MacOS
             )
 	else()
             INSTALL(
-	        DIRECTORY	
+	        DIRECTORY
                     ${CMAKE_BINARY_DIR}/Ext/PySide
                 DESTINATION
                     Ext

--- a/src/Base/UnitsSchemaImperial1.cpp
+++ b/src/Base/UnitsSchemaImperial1.cpp
@@ -109,7 +109,7 @@ QString UnitsSchemaImperial1::schemaTranslate(const Quantity &quant, double &fac
         factor = 16387.064;
     }
     else if (unit == Unit::Mass) {
-        // TODO Cascade for the wights
+        // TODO Cascade for the weights
         // default action for all cases without special treatment:
         unitString = QString::fromLatin1("lb");
         factor = 0.45359237;
@@ -175,7 +175,7 @@ QString UnitsSchemaImperialDecimal::schemaTranslate(const Base::Quantity& quant,
         factor = 16387.064;
     }
     else if (unit == Unit::Mass) {
-        // TODO Cascade for the wights
+        // TODO Cascade for the weights
         // default action for all cases without special treatment:
         unitString = QString::fromLatin1("lb");
         factor = 0.45359237;
@@ -216,7 +216,7 @@ QString UnitsSchemaImperialBuilding::schemaTranslate(const Quantity &quant, doub
         double totalInches = std::abs(quant.getValue())/factor;
 
         // minimum denominator (8 for 1/8, 16 for 1/16, etc)
-        int       minden; 
+        int       minden;
 
         // Outputs
         int       feet;    // whole feet
@@ -283,11 +283,11 @@ QString UnitsSchemaImperialBuilding::schemaTranslate(const Quantity &quant, doub
             // if there is to be trailing numbers, add space
             if( inches!=0 || num!=0 )
             {
-                output << " "; 
+                output << " ";
             }
         }
 
-        // Three cases: 
+        // Three cases:
         //   1. Whole inches, no fraction
         //   2. Whole inches, fraction
         //   3. Fraction only
@@ -303,7 +303,7 @@ QString UnitsSchemaImperialBuilding::schemaTranslate(const Quantity &quant, doub
         {
             output << num << "/" << den << "\"";
         }
-        
+
         // Done!
         return QString::fromLatin1(output.str().c_str());
     }

--- a/src/Base/UnitsSchemaInternal.cpp
+++ b/src/Base/UnitsSchemaInternal.cpp
@@ -94,7 +94,7 @@ QString UnitsSchemaInternal::schemaTranslate(const Quantity &quant, double &fact
         factor = 1.0;
     }
     else if (unit == Unit::Mass) {
-        // TODO Cascade for the wights
+        // TODO Cascade for the weights
         // default action for all cases without special treatment:
         unitString = quant.getUnit().getString();
         factor = 1.0;

--- a/src/Base/UnitsSchemaMKS.cpp
+++ b/src/Base/UnitsSchemaMKS.cpp
@@ -87,7 +87,7 @@ QString UnitsSchemaMKS::schemaTranslate(const Quantity &quant, double &factor, Q
         }
     }
     else if (unit == Unit::Mass) {
-        // TODO Cascade for the wights
+        // TODO Cascade for the weights
         // default action for all cases without special treatment:
         unitString = quant.getUnit().getString();
         factor = 1.0;

--- a/src/Mod/Fem/femguiobjects/_ViewProviderFemResultMechanical.py
+++ b/src/Mod/Fem/femguiobjects/_ViewProviderFemResultMechanical.py
@@ -44,7 +44,7 @@ import numpy as np
 
 
 class _ViewProviderFemResultMechanical:
-    "A View Provider for the FemResultObject Python dervied FemResult class"
+    "A View Provider for the FemResultObject Python derived FemResult class"
 
     def __init__(self, vobj):
         vobj.Proxy = self

--- a/src/Mod/Fem/femmesh/meshtools.py
+++ b/src/Mod/Fem/femmesh/meshtools.py
@@ -1152,7 +1152,7 @@ def get_ref_facenodes_areas(femnodes_mesh, face_table):
 
 def get_ref_shape_node_sum_geom_table(node_geom_table):
     # shape could be Edge or Face, geom could be length or area
-    # sum of legth or area for each node of the ref_shape
+    # sum of length or area for each node of the ref_shape
     node_sum_geom_table = {}
     for n, A in node_geom_table:
         # print(n, ' --> ', A)

--- a/src/Mod/Fem/femobjects/_FemResultMechanical.py
+++ b/src/Mod/Fem/femobjects/_FemResultMechanical.py
@@ -65,7 +65,7 @@ class _FemResultMechanical():
     # standard Feature methods
     def execute(self, obj):
         """"this method is executed on object creation and whenever the document is recomputed"
-        update Part or Mesh should NOT lead to recompution of the analysis automatically, time consuming
+        update Part or Mesh should NOT lead to recomputation of the analysis automatically, time consuming
         """
         return
 

--- a/src/Mod/Part/App/Part2DObject.cpp
+++ b/src/Mod/Part/App/Part2DObject.cpp
@@ -20,7 +20,7 @@
  *                                                                         *
  ***************************************************************************/
 
- 
+
 #include "PreCompiled.h"
 #ifndef _PreComp_
 # include <TopoDS_Shape.hxx>
@@ -157,7 +157,7 @@ bool Part2DObject::seekTrimPoints(const std::vector<Geometry *> &geomlist,
                 std::vector<gp_Pnt2d> points;
 
                 // #2463 Check for endpoints of secondarycurve on primary curve
-                // If the OCCT Intersector should detect endpoint tangency when triming, then
+                // If the OCCT Intersector should detect endpoint tangency when trimming, then
                 // this is just a work-around until that bug is fixed.
                 // https://www.freecadweb.org/tracker/view.php?id=2463
                 // https://tracker.dev.opencascade.org/view.php?id=30217
@@ -287,4 +287,3 @@ namespace App {
 // explicit template instantiation
   template class PartExport FeaturePythonT<Part::Part2DObject>;
 }
-

--- a/src/Mod/TechDraw/Gui/CommandCreateDims.cpp
+++ b/src/Mod/TechDraw/Gui/CommandCreateDims.cpp
@@ -100,8 +100,8 @@ char* _edgeTypeToText(int e);
 //bool _checkActive(Gui::Command* cmd, Base::Type classType, bool needSubs);
 
 
-//NOTE: this is not shown in toolbar and doesn't always work right in the menu. 
-//      should be removed. 
+//NOTE: this is not shown in toolbar and doesn't always work right in the menu.
+//      should be removed.
 //===========================================================================
 // TechDraw_NewDimension
 //===========================================================================
@@ -284,7 +284,7 @@ void CmdTechDrawNewRadiusDimension::activated(int iMsg)
         objs.push_back(objFeat);
         subs.push_back(SubNames[0]);
     } else if (edgeType == isBSplineCircle) {
-        QMessageBox::StandardButton result = 
+        QMessageBox::StandardButton result =
         QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Selection Warning"),
                                                    QObject::tr("Selected edge is a BSpline.  Radius will be approximate."),
                                                    QMessageBox::Ok | QMessageBox::Cancel,
@@ -384,7 +384,7 @@ void CmdTechDrawNewDiameterDimension::activated(int iMsg)
         objs.push_back(objFeat);
         subs.push_back(SubNames[0]);
     } else if (edgeType == isBSplineCircle) {
-        QMessageBox::StandardButton result = 
+        QMessageBox::StandardButton result =
         QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Selection Warning"),
                                                    QObject::tr("Selected edge is a BSpline.  Diameter will be approximate."),
                                                    QMessageBox::Ok | QMessageBox::Cancel,
@@ -402,7 +402,7 @@ void CmdTechDrawNewDiameterDimension::activated(int iMsg)
                                                    QObject::tr(edgeMsg.str().c_str()));
         return;
     }
-    
+
     openCommand("Create Dimension");
     doCommand(Doc,"App.activeDocument().addObject('TechDraw::DrawViewDimension','%s')",FeatName.c_str());
     doCommand(Doc,"App.activeDocument().%s.Type = '%s'",FeatName.c_str()
@@ -507,7 +507,7 @@ void CmdTechDrawNewLengthDimension::activated(int iMsg)
         subs.push_back(SubNames[1]);
     } else {
         std::stringstream edgeMsg;
-        edgeMsg << "Need 2 Vetexes, 1 straight Edge, 1 Vertex/1 straight edge or 2 straight Edges for length Dimension (edge type: " << _edgeTypeToText(edgeType) << ")";
+        edgeMsg << "Need 2 Vertexes, 1 straight Edge, 1 Vertex/1 straight edge or 2 straight Edges for length Dimension (edge type: " << _edgeTypeToText(edgeType) << ")";
         QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Incorrect Selection"),
                                                    QObject::tr(edgeMsg.str().c_str()));
         return;
@@ -530,7 +530,7 @@ void CmdTechDrawNewLengthDimension::activated(int iMsg)
     TechDraw::pointPair pp = dim->getLinearPoints();
     Base::Vector3d mid = (pp.first + pp.second)/2.0;
     dim->X.setValue(mid.x);
-    dim->Y.setValue(-mid.y); 
+    dim->Y.setValue(-mid.y);
 
     //Horrible hack to force Tree update (claimChildren)
     double x = objFeat->X.getValue();
@@ -619,7 +619,7 @@ void CmdTechDrawNewDistanceXDimension::activated(int iMsg)
         subs.push_back(SubNames[1]);
     } else {
         std::stringstream edgeMsg;
-        edgeMsg << "Need 2 Vetexes, 1 straight Edge, 1 Vertex/1 straight edge or 2 straight Edges for Horizontal Dimension (edge type: " << _edgeTypeToText(edgeType) << ")";
+        edgeMsg << "Need 2 Vertexes, 1 straight Edge, 1 Vertex/1 straight edge or 2 straight Edges for Horizontal Dimension (edge type: " << _edgeTypeToText(edgeType) << ")";
         QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Incorrect Selection"),
                                                    QObject::tr(edgeMsg.str().c_str()));
         return;
@@ -643,7 +643,7 @@ void CmdTechDrawNewDistanceXDimension::activated(int iMsg)
     TechDraw::pointPair pp = dim->getLinearPoints();
     Base::Vector3d mid = (pp.first + pp.second)/2.0;
     dim->X.setValue(mid.x);
-    dim->Y.setValue(-mid.y); 
+    dim->Y.setValue(-mid.y);
 
     //Horrible hack to force Tree update
     double x = objFeat->X.getValue();
@@ -732,7 +732,7 @@ void CmdTechDrawNewDistanceYDimension::activated(int iMsg)
         subs.push_back(SubNames[1]);
     } else {
         std::stringstream edgeMsg;
-        edgeMsg << "Need 2 Vetexes, 1 straight Edge, 1 Vertex/1 straight edge or 2 straight Edges for Horizontal Dimension (edge type: " << _edgeTypeToText(edgeType) << ")";
+        edgeMsg << "Need 2 Vertexes, 1 straight Edge, 1 Vertex/1 straight edge or 2 straight Edges for Horizontal Dimension (edge type: " << _edgeTypeToText(edgeType) << ")";
         QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Incorrect Selection"),
                                                    QObject::tr(edgeMsg.str().c_str()));
         return;
@@ -755,7 +755,7 @@ void CmdTechDrawNewDistanceYDimension::activated(int iMsg)
     TechDraw::pointPair pp = dim->getLinearPoints();
     Base::Vector3d mid = (pp.first + pp.second)/2.0;
     dim->X.setValue(mid.x);
-    dim->Y.setValue(-mid.y); 
+    dim->Y.setValue(-mid.y);
 
     //Horrible hack to force Tree update
     double x = objFeat->X.getValue();
@@ -905,7 +905,7 @@ void CmdTechDrawNewAngle3PtDimension::activated(int iMsg)
     std::vector<App::DocumentObject *> objs;
     std::vector<std::string> subs;
 
-    if (_isValidVertexes(this, 3))  { 
+    if (_isValidVertexes(this, 3))  {
         objs.push_back(objFeat);
         objs.push_back(objFeat);
         objs.push_back(objFeat);
@@ -1142,7 +1142,7 @@ int _isValidSingleEdge(Gui::Command* cmd) {
                 edgeType = isEllipse;
             } else if (geom->geomType == TechDrawGeometry::BSPLINE) {
                 TechDrawGeometry::BSpline* spline = static_cast<TechDrawGeometry::BSpline*>(geom);
-                if (spline->isCircle()) {           
+                if (spline->isCircle()) {
                     edgeType = isBSplineCircle;
                 } else {
                     edgeType = isBSpline;


### PR DESCRIPTION
Found via `codespell -q 3 --skip="*.po,*.ts,./.git,./src/3rdParty,./src/CXX,./src/zipios++,./src/Mod/Assembly/App/opendcm,./ChangeLog.txt" -I ../fc-word-whitelist.txt` and `grep`. Excess whitespace auto-removed by Atom editor. 