### PR TITLE
py3: Arch: fix TypeError exception

### DIFF
--- a/src/Mod/Arch/ArchAxis.py
+++ b/src/Mod/Arch/ArchAxis.py
@@ -585,7 +585,7 @@ class _ViewProviderAxis:
                 return str(num+1).zfill(3)
             elif vobj.NumberingStyle == "A,B,C":
                 result = ""
-                base = num/26
+                base = num//26
                 if base:
                     result += chars[base].upper()
                 remainder = num % 26
@@ -593,7 +593,7 @@ class _ViewProviderAxis:
                 return result
             elif vobj.NumberingStyle == "a,b,c":
                 result = ""
-                base = num/26
+                base = num//26
                 if base:
                     result += chars[base]
                 remainder = num % 26


### PR DESCRIPTION
fixes the axis numbering problem mentioned in https://forum.freecadweb.org/viewtopic.php?f=10&t=12534&start=780#p266730

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
