### PR TITLE
Change the name of the Wire object

### DIFF
--- a/src/Mod/Draft/TestDraft.py
+++ b/src/Mod/Draft/TestDraft.py
@@ -53,7 +53,7 @@ class DraftTest(unittest.TestCase):
     def testWire(self):
         FreeCAD.Console.PrintLog ('Checking Draft Wire...\n')
         Draft.makeWire([FreeCAD.Vector(0,0,0),FreeCAD.Vector(2,0,0),FreeCAD.Vector(2,2,0)])
-        self.failUnless(FreeCAD.ActiveDocument.getObject("DWire"),"Draft Wire failed")
+        self.failUnless(FreeCAD.ActiveDocument.getObject("Wire"),"Draft Wire failed")
 
     def testBSpline(self):
         FreeCAD.Console.PrintLog ('Checking Draft BSpline...\n')


### PR DESCRIPTION
After changing the name from DWire to Wire the test fails, because an element with the name DWire does not exists.
The name change came in with commit "684b4ab03a27231e0cc603ca815bf9ea367fd0b9"
in file "src\Mod\Draft\Draft.py"

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
