### PR TITLE
Trim fixes revisit

### DIFF
--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -2159,6 +2159,17 @@ int SketchObject::trim(int GeoId, const Base::Vector3d& point)
                 }
             };
             
+            auto handlemultipleintersection = [this] (Constraint * constr, int GeoId, PointPos pos, PointPos & secondPos) {
+                
+                Base::Vector3d cp = getPoint(constr->First,constr->FirstPos);
+            
+                Base::Vector3d ee = getPoint(GeoId,pos);
+            
+                if( (ee-cp).Length() < Precision::Confusion() ) {
+                    secondPos = constr->FirstPos;
+                }
+            };
+            
             
             PointPos secondPos1 = Sketcher::none, secondPos2 = Sketcher::none;
             ConstraintType constrType1 = Sketcher::PointOnObject, constrType2 = Sketcher::PointOnObject;
@@ -2171,7 +2182,7 @@ int SketchObject::trim(int GeoId, const Base::Vector3d& point)
                         handleinternalalignment(constr, GeoId, secondPos1);
                     }
                     else {
-                        secondPos1 = constr->FirstPos;
+                        handlemultipleintersection(constr, GeoId, start, secondPos1);
                     }
                     
                 } else if(secondPos2 == Sketcher::none && (constr->First == GeoId2  && constr->Second == GeoId)) {
@@ -2181,7 +2192,7 @@ int SketchObject::trim(int GeoId, const Base::Vector3d& point)
                         handleinternalalignment(constr, GeoId, secondPos2);
                     }
                     else {
-                        secondPos2 = constr->FirstPos;
+                        handlemultipleintersection(constr, GeoId, end, secondPos2);
                     }
                 }
             }


### PR DESCRIPTION
Bug fixing of trimming operations in presence of internal alignment constraints and/or multiple intersections. It does not correspond to a bug tracker ticket, below are the threads where the bugs were reported.

Bugs:
https://forum.freecadweb.org/viewtopic.php?f=3&t=31594&sid=37481b7a6c1ae2614c9840fc27a7773e&start=60#p267248

https://forum.freecadweb.org/viewtopic.php?f=3&t=31594&sid=37481b7a6c1ae2614c9840fc27a7773e&start=60#p267536


Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
