### PR TITLE
Use github api to find the total number of commits

### DIFF
--- a/package/fedora/rpkg.conf
+++ b/package/fedora/rpkg.conf
@@ -1,2 +1,0 @@
-[rpkg]
-auto_pack = False

--- a/package/fedora/rpkg.macros
+++ b/package/fedora/rpkg.macros
@@ -1,4 +1,4 @@
 function git_commits_no {
-	commits=$(git fetch --unshallow && git rev-list master --count)
-	echo $commits
+	commits=$(curl -s 'https://api.github.com/repos/FreeCAD/FreeCAD/compare/120ca87015...master' | grep "ahead_by" | sed -s 's/ //g' | sed -s 's/"ahead_by"://' | sed -s 's/,//')
+	echo $((commits + 1))
 }


### PR DESCRIPTION
That approach is faster and doesn't require huge download to determine
the total number of commits.

Signed-off-by: Przemo Firszt <przemo@firszt.eu>

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [X] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [X] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
