### PR TITLE
OpenSCAD: fix error in workaroundforissue128needed with date formats (YYYYMMDD vs YYYY.MM.DD)

### DIFF
--- a/src/Mod/OpenSCAD/OpenSCADUtils.py
+++ b/src/Mod/OpenSCAD/OpenSCADUtils.py
@@ -100,7 +100,11 @@ def workaroundforissue128needed():
     see https://github.com/openscad/openscad/issues/128'''
     vdate=getopenscadversion().split('-')[0]
     vdate=vdate.split(' ')[2].split('.')
-    year,mon=int(vdate[0]),int(vdate[1])
+    if len(vdate) == 1: # probably YYYYMMDD format (i.e. git version)
+        vdate = vdate[0]
+        year, mon = int("".join(vdate[0:4])), int("".join(vdate[4:6]))
+    else: # YYYY.MM(.DD?) (latest release)
+        year,mon=int(vdate[0]),int(vdate[1])
     return (year<2012 or (year==2012 and (mon <6 or (mon == 6 and \
         (len(vdate)<3 or int(vdate[2]) <=23)))))
     #ifdate=int(vdate[0])+(int(vdate[1])-1)/12.0


### PR DESCRIPTION
Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
  - Compiling takes hours on my >7-year-old machine, patch is quite trivial.
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists
  - not applicable

And please remember to update the Wiki with the features added or changed once this PR is merged.

---

This happens when the git version of OpenSCAD is installed (which uses YYYYMMDD), instead of the latest released version (from 2015, which uses YYYY.MM.DD).