### PR TITLE
FR1973 Draft ShapeString Ui

### DIFF
--- a/src/Mod/Draft/Draft.py
+++ b/src/Mod/Draft/Draft.py
@@ -3181,10 +3181,8 @@ def makePoint(X=0, Y=0, Z=0,color=None,name = "Point", point_size= 5):
     return obj
 
 def makeShapeString(String,FontFile,Size = 100,Tracking = 0):
-
     '''ShapeString(Text,FontFile,Height,Track): Turns a text string
     into a Compound Shape'''
-
     if not FreeCAD.ActiveDocument:
         FreeCAD.Console.PrintError("No active document. Aborting\n")
         return

--- a/src/Mod/Draft/DraftGui.py
+++ b/src/Mod/Draft/DraftGui.py
@@ -47,7 +47,10 @@ except ImportError:
     FreeCAD.Console.PrintMessage("Error: Python-pyside package must be installed on your system to use the Draft module.")
 
 try:
-    _encoding = QtGui.QApplication.UnicodeUTF8
+    if sys.version_info.major >= 3:
+        _encoding = None
+    else:
+        _encoding = QtGui.QApplication.UnicodeUTF8
     def translate(context, text, utf8_decode=True):
         """convenience function for Qt translator
             context: str
@@ -58,7 +61,9 @@ try:
                 if set to true utf8 encoded unicode will be returned. This option does not have influence
                 on python3 as for python3 we are returning utf-8 encoded unicode by default!
         """
-        if sys.version_info.major >= 3 or utf8_decode:
+        if sys.version_info.major >= 3:
+            return QtGui.QApplication.translate(context, text, None)
+        elif utf8_decode:
             return QtGui.QApplication.translate(context, text, None, _encoding)
         else:
             return QtGui.QApplication.translate(context, text, None, _encoding).encode("utf8")
@@ -74,10 +79,12 @@ except AttributeError:
                 if set to true utf8 encoded unicode will be returned. This option does not have influence
                 on python3 as for python3 we are returning utf-8 encoded unicode by default!
         """
-        if sys.version_info.major >= 3 or utf8_decode:
+        if sys.version_info.major >= 3:
             return QtGui.QApplication.translate(context, text, None)
+        elif utf8_decode:
+            return QtGui.QApplication.translate(context, text, None, _encoding)
         else:
-            return QtGui.QApplication.translate(context, text, None).encode("utf8")
+            return QtGui.QApplication.translate(context, text, None, _encoding).encode("utf8")
 
 def utf8_decode(text):
     """py2: str     -> unicode
@@ -2365,6 +2372,112 @@ class ScaleTaskPanel:
             self.sourceCmd.finish()
         FreeCADGui.ActiveDocument.resetEdit()
         return True
+
+def translateWidget(w, context=None, disAmb=None):
+    '''translator for items where retranslateUi() is unavailable.
+    translates widget w and children.'''
+    #handle w itself
+    if w.metaObject().className() == "QWidget":
+        origText = None
+        origText = w.windowTitle()
+        if origText:
+            newText = translate(context, str(origText))
+            if newText:
+                w.setWindowTitle(newText)
+
+    #handle children
+    wKids = w.findChildren(QtGui.QWidget)
+    for i in wKids:
+        className = i.metaObject().className()
+        if hasattr(i,"text") and hasattr(i,"setText"):
+            origText = i.text()
+            newText = translate(context, str(origText))
+            if newText:
+                i.setText(newText)
+        elif hasattr(i,"title") and hasattr(i,"setTitle"):
+            origText = i.title()
+            newText = translate(context, str(origText))
+            if newText:
+                i.setTitle(newText)
+        elif hasattr(i,"itemText") and hasattr(i,"setItemText"):
+            for item in range(i.count()):
+                oldText = i.itemText(item)
+                newText = translate(context, str(origText))
+                if newText:
+                    i.setItemText(item,newText)
+#for debugging:
+#        else:
+#            msg = "TranslateWidget: Can not translate widget: {0} type: {1}\n".format(w.objectName(),w.metaObject().className())
+#            FreeCAD.Console.PrintMessage(msg)
+
+class ShapeStringTaskPanel:
+    '''A TaskPanel for ShapeString'''
+    def __init__(self):
+        self.form = QtGui.QWidget()
+        self.form.setObjectName("ShapeStringTaskPanel")
+        self.form.setWindowTitle(translate("draft","ShapeString"))
+        layout = QtGui.QVBoxLayout(self.form)
+        uiFile = QtCore.QFile(u":/ui/TaskShapeString.ui")  #this has to change if ui not in Resource file
+        loader = FreeCADGui.UiLoader()
+        self.task = loader.load(uiFile)
+        layout.addWidget(self.task)
+        
+        qStart = FreeCAD.Units.Quantity(0.0, FreeCAD.Units.Length)
+        self.task.sbX.setProperty('rawValue',qStart.Value)
+        self.task.sbX.setProperty('unit',qStart.getUserPreferred()[2])
+        self.task.sbY.setProperty('rawValue',qStart.Value)
+        self.task.sbY.setProperty('unit',qStart.getUserPreferred()[2])
+        self.task.sbZ.setProperty('rawValue',qStart.Value)
+        self.task.sbZ.setProperty('unit',qStart.getUserPreferred()[2])
+        self.task.sbHeight.setProperty('rawValue',10.0)
+        self.task.sbHeight.setProperty('unit',qStart.getUserPreferred()[2])
+
+        self.stringText = translate("draft","Default")
+        self.task.leString.setText(self.stringText)
+        self.task.fcFontFile.setFileName(Draft.getParam("FontFile",""))
+        self.fileSpec = Draft.getParam("FontFile","")
+
+        QtCore.QObject.connect(self.task.fcFontFile,QtCore.SIGNAL("fileNameSelected(const QString&)"),self.fileSelect)
+
+        self.retranslateUi()
+
+    def fileSelect(self, fn):
+        self.fileSpec = fn
+
+    def accept(self):
+        FreeCAD.ActiveDocument.openTransaction("ShapeString")
+        qr,sup,points,fil = self.sourceCmd.getStrings()
+        height = FreeCAD.Units.Quantity(self.task.sbHeight.text()).Value
+        ss = Draft.makeShapeString(str(self.task.leString.text()),  ##needs to be bytes for Py3!
+                                   str(self.fileSpec),
+                                   height,
+                                   0.0)
+
+        x = FreeCAD.Units.Quantity(self.task.sbX.text()).Value
+        y = FreeCAD.Units.Quantity(self.task.sbY.text()).Value
+        z = FreeCAD.Units.Quantity(self.task.sbZ.text()).Value
+        ssBase = FreeCAD.Vector(x,y,z)
+        plm=FreeCAD.Placement()
+        plm.Base = ssBase
+        elements = qr[1:-1].split(",")  #string to tuple
+        mytuple = tuple(elements)       #to prevent
+        plm.Rotation.Q = mytuple        #PyCXX: Error creating object of type N2Py5TupleE from '(0.0,-0.0,-0.0,1.0)'
+        ss.Placement=plm
+        if sup:
+            ss.Support = FreeCAD.ActiveDocument.getObject(sup)
+        Draft.autogroup(ss)
+        FreeCAD.ActiveDocument.commitTransaction()
+
+        FreeCAD.ActiveDocument.recompute()
+        FreeCADGui.ActiveDocument.resetEdit()
+        return True
+
+    def reject(self):
+        FreeCADGui.ActiveDocument.resetEdit()
+        return True
+
+    def retranslateUi(self):
+        translateWidget(self.form, "draft")
 
 if not hasattr(FreeCADGui,"draftToolBar"):
     FreeCADGui.draftToolBar = DraftToolBar()

--- a/src/Mod/Draft/DraftTools.py
+++ b/src/Mod/Draft/DraftTools.py
@@ -2221,17 +2221,23 @@ class ShapeString(Creator):
         Creator.Activated(self,name)
         if self.ui:
             self.ui.sourceCmd = self
-            self.dialog = None
-            self.text = ''
-            self.ui.sourceCmd = self
-            self.ui.pointUi(name)
-            self.active = True
-            self.call = self.view.addEventCallback("SoEvent",self.action)
-            self.ssBase = None
-            self.ui.xValue.setFocus()
-            self.ui.xValue.selectAll()
-            msg(translate("draft", "Pick ShapeString location point:")+"\n")
-            FreeCADGui.draftToolBar.show()
+            self.taskmode = Draft.getParam("UiMode",1)
+            if self.taskmode:
+                self.task = DraftGui.ShapeStringTaskPanel()
+                self.task.sourceCmd = self
+                DraftGui.todo.delay(FreeCADGui.Control.showDialog,self.task)
+            else:
+                self.dialog = None
+                self.text = ''
+                self.ui.sourceCmd = self
+                self.ui.pointUi(name)
+                self.active = True
+                self.call = self.view.addEventCallback("SoEvent",self.action)
+                self.ssBase = None
+                self.ui.xValue.setFocus()
+                self.ui.xValue.selectAll()
+                msg(translate("draft", "Pick ShapeString location point:")+"\n")
+                FreeCADGui.draftToolBar.show()
 
     def createObject(self):
         "creates object in the current doc"

--- a/src/Mod/Draft/Resources/Draft.qrc
+++ b/src/Mod/Draft/Resources/Draft.qrc
@@ -128,5 +128,6 @@
         <file>ui/preferences-dwg.ui</file>
         <file>ui/preferences-svg.ui</file>
         <file>ui/preferences-oca.ui</file>
+        <file>ui/TaskShapeString.ui</file>
     </qresource>
-</RCC> 
+</RCC>

--- a/src/Mod/Draft/Resources/ui/TaskShapeString.ui
+++ b/src/Mod/Draft/Resources/ui/TaskShapeString.ui
@@ -1,0 +1,180 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>DraftShapeStringGui</class>
+ <widget class="QWidget" name="DraftShapeStringGui">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>445</width>
+    <height>480</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>250</width>
+    <height>0</height>
+   </size>
+  </property>
+  <property name="windowTitle">
+   <string>ShapeString</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="0" column="0">
+    <widget class="QGroupBox" name="groupBox">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="title">
+      <string/>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_4">
+      <item row="1" column="0">
+       <layout class="QGridLayout" name="gridLayout_6">
+        <item row="0" column="1">
+         <widget class="QLineEdit" name="leString">
+          <property name="toolTip">
+           <string>Text to be made into ShapeString</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="0">
+         <widget class="QLabel" name="labelString">
+          <property name="text">
+           <string>String</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item row="7" column="0">
+       <layout class="QGridLayout" name="gridLayout_2" columnstretch="1,1">
+        <item row="0" column="0">
+         <widget class="QLabel" name="labelHeight">
+          <property name="text">
+           <string>Height</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1">
+         <widget class="Gui::QuantitySpinBox" name="sbHeight">
+          <property name="toolTip">
+           <string>Height of the result</string>
+          </property>
+          <property name="unit" stdset="0">
+           <string notr="true"/>
+          </property>
+          <property name="minimum">
+           <double>0.000000000000000</double>
+          </property>
+          <property name="value">
+           <double>10.000000000000000</double>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item row="9" column="0">
+       <spacer name="verticalSpacer_2">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>40</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item row="0" column="0">
+       <layout class="QGridLayout" name="gridLayout_7">
+        <item row="0" column="1">
+         <widget class="Gui::QuantitySpinBox" name="sbX">
+          <property name="unit" stdset="0">
+           <string notr="true"/>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="1">
+         <widget class="Gui::QuantitySpinBox" name="sbY">
+          <property name="unit" stdset="0">
+           <string notr="true"/>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="0">
+         <widget class="QLabel" name="labelX">
+          <property name="text">
+           <string>X</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="1">
+         <widget class="Gui::QuantitySpinBox" name="sbZ">
+          <property name="unit" stdset="0">
+           <string notr="true"/>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="0">
+         <widget class="QLabel" name="labelY">
+          <property name="text">
+           <string>Y</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="0">
+         <widget class="QLabel" name="labelZ">
+          <property name="text">
+           <string>Z</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item row="8" column="0">
+       <layout class="QGridLayout" name="gridLayout_3">
+        <item row="1" column="0">
+         <widget class="QLabel" name="labelFontFile">
+          <property name="text">
+           <string>Font file</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="1">
+         <widget class="Gui::FileChooser" name="fcFontFile"/>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>Gui::FileChooser</class>
+   <extends>QWidget</extends>
+   <header>Gui/FileDialog.h</header>
+  </customwidget>
+  <customwidget>
+   <class>Gui::QuantitySpinBox</class>
+   <extends>QWidget</extends>
+   <header>Gui/QuantitySpinBox.h</header>
+  </customwidget>
+ </customwidgets>
+ <resources>
+  <include location="../Draft.qrc"/>
+ </resources>
+ <connections/>
+</ui>


### PR DESCRIPTION
This PR implements Feature Request [1973](https://www.freecadweb.org/tracker/view.php?id=1973).     FR1973 addresses one of @sliptonic's "[5 ways FreeCAD will annoy you](https://www.youtube.com/watch?v=R9KIa3_dJu8)".  Please merge.
Thanks,
wf

- load new ui from Resource file
- minor updates to translate for Py3

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
