### PR TITLE
Add US Civil Engineering Units

### DIFF
--- a/src/App/ExpressionParser.y
+++ b/src/App/ExpressionParser.y
@@ -69,6 +69,7 @@ input:     exp                			{ ScanResult = $1; valueExpression = true;     
 
 exp:      num                			{ $$ = $1;                                                                        }
         | num unit_exp %prec NUM_AND_UNIT       { $$ = new OperatorExpression(DocumentObject, $1, OperatorExpression::UNIT, $2);  }
+        | num unit_exp %prec NUM_AND_UNIT %prec NUM_AND_UNIT       { $$ = new OperatorExpression(DocumentObject, $1, OperatorExpression::UNIT, $2, $3);  }
         | STRING                                { $$ = new StringExpression(DocumentObject, $1);                                  }
         | identifier                            { $$ = new VariableExpression(DocumentObject, $1);                                }
         | MINUSSIGN exp %prec NEG               { $$ = new OperatorExpression(DocumentObject, $2, OperatorExpression::NEG, new NumberExpression(DocumentObject, Quantity(-1))); }

--- a/src/Base/Quantity.cpp
+++ b/src/Base/Quantity.cpp
@@ -32,6 +32,7 @@
 #include "Quantity.h"
 #include "Exception.h"
 #include "UnitsApi.h"
+#include "Console.h"
 
 // suppress annoying warnings from generated source files
 #ifdef _MSC_VER
@@ -305,6 +306,8 @@ Quantity Quantity::WattSecond       (1e+6          ,Unit(2,1,-2));  // Joule (kg
 Quantity Quantity::KMH              (277.778       ,Unit(1,0,-1));  // km/h
 Quantity Quantity::MPH              (447.04        ,Unit(1,0,-1));  // Mile/h
 
+Quantity Quantity::AngMinute        (1.0/60.0      ,Unit(0,0,0,0,0,0,0,1)); // angular minute
+Quantity Quantity::AngSecond        (1.0/3600.0    ,Unit(0,0,0,0,0,0,0,1)); // angular minute
 Quantity Quantity::Degree           (1.0           ,Unit(0,0,0,0,0,0,0,1)); // degree         (internal standard angle)
 Quantity Quantity::Radian           (180/M_PI      ,Unit(0,0,0,0,0,0,0,1)); // radian
 Quantity Quantity::Gon              (360.0/400.0   ,Unit(0,0,0,0,0,0,0,1)); // gon

--- a/src/Base/Quantity.h
+++ b/src/Base/Quantity.h
@@ -256,6 +256,8 @@ public:
     static Quantity Degree;
     static Quantity Radian;
     static Quantity Gon;
+    static Quantity AngMinute;
+    static Quantity AngSecond;
     //@}
 
 

--- a/src/Base/QuantityLexer.c
+++ b/src/Base/QuantityLexer.c
@@ -9,12 +9,12 @@
 #define FLEX_SCANNER
 #define YY_FLEX_MAJOR_VERSION 2
 #define YY_FLEX_MINOR_VERSION 6
-#define YY_FLEX_SUBMINOR_VERSION 0
+#define YY_FLEX_SUBMINOR_VERSION 4
 #if YY_FLEX_SUBMINOR_VERSION > 0
 #define FLEX_BETA
 #endif
 
-/* First, we deal with platform-specific or compiler-specific issues. */
+/* First, we deal with  platform-specific or compiler-specific issues. */
 
 /* begin standard C headers. */
 #include <stdio.h>
@@ -84,60 +84,48 @@ typedef unsigned int flex_uint32_t;
 #define UINT32_MAX             (4294967295U)
 #endif
 
+#ifndef SIZE_MAX
+#define SIZE_MAX               (~(size_t)0)
+#endif
+
 #endif /* ! C99 */
 
 #endif /* ! FLEXINT_H */
 
-#ifdef __cplusplus
+/* begin standard C++ headers. */
 
-/* The "const" storage-class-modifier is valid. */
-#define YY_USE_CONST
-
-#else	/* ! __cplusplus */
-
-/* C99 requires __STDC__ to be defined as 1. */
-#if defined (__STDC__)
-
-#define YY_USE_CONST
-
-#endif	/* defined (__STDC__) */
-#endif	/* ! __cplusplus */
-
-#ifdef YY_USE_CONST
+/* TODO: this is always defined, so inline it */
 #define yyconst const
+
+#if defined(__GNUC__) && __GNUC__ >= 3
+#define yynoreturn __attribute__((__noreturn__))
 #else
-#define yyconst
+#define yynoreturn
 #endif
 
 /* Returned upon end-of-file. */
 #define YY_NULL 0
 
-/* Promotes a possibly negative, possibly signed char to an unsigned
- * integer for use as an array index.  If the signed char is negative,
- * we want to instead treat it as an 8-bit unsigned char, hence the
- * double cast.
+/* Promotes a possibly negative, possibly signed char to an
+ *   integer in range [0..255] for use as an array index.
  */
-#define YY_SC_TO_UI(c) ((unsigned int) (unsigned char) c)
+#define YY_SC_TO_UI(c) ((YY_CHAR) (c))
 
 /* Enter a start condition.  This macro really ought to take a parameter,
  * but we do it the disgusting crufty way forced on us by the ()-less
  * definition of BEGIN.
  */
 #define BEGIN (yy_start) = 1 + 2 *
-
 /* Translate the current start state into a value that can be later handed
  * to BEGIN to return to the state.  The YYSTATE alias is for lex
  * compatibility.
  */
 #define YY_START (((yy_start) - 1) / 2)
 #define YYSTATE YY_START
-
 /* Action number for EOF rule of a given start state. */
 #define YY_STATE_EOF(state) (YY_END_OF_BUFFER + state + 1)
-
 /* Special action meaning "start processing a new file". */
-#define YY_NEW_FILE yyrestart(yyin  )
-
+#define YY_NEW_FILE yyrestart( yyin  )
 #define YY_END_OF_BUFFER_CHAR 0
 
 /* Size of default input buffer. */
@@ -167,14 +155,14 @@ typedef struct yy_buffer_state *YY_BUFFER_STATE;
 typedef size_t yy_size_t;
 #endif
 
-extern yy_size_t yyleng;
+extern int yyleng;
 
 extern FILE *yyin, *yyout;
 
 #define EOB_ACT_CONTINUE_SCAN 0
 #define EOB_ACT_END_OF_FILE 1
 #define EOB_ACT_LAST_MATCH 2
-
+    
     #define YY_LESS_LINENO(n)
     #define YY_LINENO_REWIND_TO(ptr)
     
@@ -191,7 +179,6 @@ extern FILE *yyin, *yyout;
 		YY_DO_BEFORE_ACTION; /* set up yytext again */ \
 		} \
 	while ( 0 )
-
 #define unput(c) yyunput( c, (yytext_ptr)  )
 
 #ifndef YY_STRUCT_YY_BUFFER_STATE
@@ -206,7 +193,7 @@ struct yy_buffer_state
 	/* Size of input buffer in bytes, not including room for EOB
 	 * characters.
 	 */
-	yy_size_t yy_buf_size;
+	int yy_buf_size;
 
 	/* Number of characters read into yy_ch_buf, not including EOB
 	 * characters.
@@ -234,7 +221,7 @@ struct yy_buffer_state
 
     int yy_bs_lineno; /**< The line count. */
     int yy_bs_column; /**< The column count. */
-    
+
 	/* Whether to try to fill the input buffer when we reach the
 	 * end of it.
 	 */
@@ -262,7 +249,7 @@ struct yy_buffer_state
 /* Stack of input buffers. */
 static size_t yy_buffer_stack_top = 0; /**< index of top of stack. */
 static size_t yy_buffer_stack_max = 0; /**< capacity of stack. */
-static YY_BUFFER_STATE * yy_buffer_stack = 0; /**< Stack as an array. */
+static YY_BUFFER_STATE * yy_buffer_stack = NULL; /**< Stack as an array. */
 
 /* We provide macros for accessing buffer states in case in the
  * future we want to put the buffer states in a more general
@@ -273,7 +260,6 @@ static YY_BUFFER_STATE * yy_buffer_stack = 0; /**< Stack as an array. */
 #define YY_CURRENT_BUFFER ( (yy_buffer_stack) \
                           ? (yy_buffer_stack)[(yy_buffer_stack_top)] \
                           : NULL)
-
 /* Same as previous macro, but useful when we know that the buffer stack is not
  * NULL or when we need an lvalue. For internal use only.
  */
@@ -282,10 +268,10 @@ static YY_BUFFER_STATE * yy_buffer_stack = 0; /**< Stack as an array. */
 /* yy_hold_char holds the character lost when yytext is formed. */
 static char yy_hold_char;
 static int yy_n_chars;		/* number of characters read into yy_ch_buf */
-yy_size_t yyleng;
+int yyleng;
 
 /* Points to current character in buffer. */
-static char *yy_c_buf_p = (char *) 0;
+static char *yy_c_buf_p = NULL;
 static int yy_init = 0;		/* whether we need to initialize */
 static int yy_start = 0;	/* start state number */
 
@@ -294,63 +280,57 @@ static int yy_start = 0;	/* start state number */
  */
 static int yy_did_buffer_switch_on_eof;
 
-void yyrestart (FILE *input_file  );
-void yy_switch_to_buffer (YY_BUFFER_STATE new_buffer  );
-YY_BUFFER_STATE yy_create_buffer (FILE *file,int size  );
-void yy_delete_buffer (YY_BUFFER_STATE b  );
-void yy_flush_buffer (YY_BUFFER_STATE b  );
-void yypush_buffer_state (YY_BUFFER_STATE new_buffer  );
-void yypop_buffer_state (void );
+void yyrestart ( FILE *input_file  );
+void yy_switch_to_buffer ( YY_BUFFER_STATE new_buffer  );
+YY_BUFFER_STATE yy_create_buffer ( FILE *file, int size  );
+void yy_delete_buffer ( YY_BUFFER_STATE b  );
+void yy_flush_buffer ( YY_BUFFER_STATE b  );
+void yypush_buffer_state ( YY_BUFFER_STATE new_buffer  );
+void yypop_buffer_state ( void );
 
-static void yyensure_buffer_stack (void );
-static void yy_load_buffer_state (void );
-static void yy_init_buffer (YY_BUFFER_STATE b,FILE *file  );
+static void yyensure_buffer_stack ( void );
+static void yy_load_buffer_state ( void );
+static void yy_init_buffer ( YY_BUFFER_STATE b, FILE *file  );
+#define YY_FLUSH_BUFFER yy_flush_buffer( YY_CURRENT_BUFFER )
 
-#define YY_FLUSH_BUFFER yy_flush_buffer(YY_CURRENT_BUFFER )
+YY_BUFFER_STATE yy_scan_buffer ( char *base, yy_size_t size  );
+YY_BUFFER_STATE yy_scan_string ( const char *yy_str  );
+YY_BUFFER_STATE yy_scan_bytes ( const char *bytes, int len  );
 
-YY_BUFFER_STATE yy_scan_buffer (char *base,yy_size_t size  );
-YY_BUFFER_STATE yy_scan_string (yyconst char *yy_str  );
-YY_BUFFER_STATE yy_scan_bytes (yyconst char *bytes,yy_size_t len  );
-
-void *yyalloc (yy_size_t  );
-void *yyrealloc (void *,yy_size_t  );
-void yyfree (void *  );
+void *yyalloc ( yy_size_t  );
+void *yyrealloc ( void *, yy_size_t  );
+void yyfree ( void *  );
 
 #define yy_new_buffer yy_create_buffer
-
 #define yy_set_interactive(is_interactive) \
 	{ \
 	if ( ! YY_CURRENT_BUFFER ){ \
         yyensure_buffer_stack (); \
 		YY_CURRENT_BUFFER_LVALUE =    \
-            yy_create_buffer(yyin,YY_BUF_SIZE ); \
+            yy_create_buffer( yyin, YY_BUF_SIZE ); \
 	} \
 	YY_CURRENT_BUFFER_LVALUE->yy_is_interactive = is_interactive; \
 	}
-
 #define yy_set_bol(at_bol) \
 	{ \
 	if ( ! YY_CURRENT_BUFFER ){\
         yyensure_buffer_stack (); \
 		YY_CURRENT_BUFFER_LVALUE =    \
-            yy_create_buffer(yyin,YY_BUF_SIZE ); \
+            yy_create_buffer( yyin, YY_BUF_SIZE ); \
 	} \
 	YY_CURRENT_BUFFER_LVALUE->yy_at_bol = at_bol; \
 	}
-
 #define YY_AT_BOL() (YY_CURRENT_BUFFER_LVALUE->yy_at_bol)
 
 #define yywrap() (/*CONSTCOND*/1)
 #define YY_SKIP_YYWRAP
+typedef flex_uint8_t YY_CHAR;
 
-typedef unsigned char YY_CHAR;
-
-FILE *yyin = (FILE *) 0, *yyout = (FILE *) 0;
+FILE *yyin = NULL, *yyout = NULL;
 
 typedef int yy_state_type;
 
 extern int yylineno;
-
 int yylineno = 1;
 
 extern char *yytext;
@@ -359,26 +339,22 @@ extern char *yytext;
 #endif
 #define yytext_ptr yytext
 
-static yy_state_type yy_get_previous_state (void );
-static yy_state_type yy_try_NUL_trans (yy_state_type current_state  );
-static int yy_get_next_buffer (void );
-#if defined(__GNUC__) && __GNUC__ >= 3
-__attribute__((__noreturn__))
-#endif
-static void yy_fatal_error (yyconst char msg[]  );
+static yy_state_type yy_get_previous_state ( void );
+static yy_state_type yy_try_NUL_trans ( yy_state_type current_state  );
+static int yy_get_next_buffer ( void );
+static void yynoreturn yy_fatal_error ( const char* msg  );
 
 /* Done after the current pattern has been matched and before the
  * corresponding action - sets up yytext.
  */
 #define YY_DO_BEFORE_ACTION \
 	(yytext_ptr) = yy_bp; \
-	yyleng = (size_t) (yy_cp - yy_bp); \
+	yyleng = (int) (yy_cp - yy_bp); \
 	(yy_hold_char) = *yy_cp; \
 	*yy_cp = '\0'; \
 	(yy_c_buf_p) = yy_cp;
-
-#define YY_NUM_RULES 101
-#define YY_END_OF_BUFFER 102
+#define YY_NUM_RULES 103
+#define YY_END_OF_BUFFER 104
 /* This struct is not used in this scanner,
    but its presence is necessary. */
 struct yy_trans_info
@@ -386,31 +362,31 @@ struct yy_trans_info
 	flex_int32_t yy_verify;
 	flex_int32_t yy_nxt;
 	};
-static yyconst flex_int16_t yy_accept[190] =
+static const flex_int16_t yy_accept[191] =
     {   0,
-        0,    0,    0,    0,  102,  100,    4,    5,   38,   40,
-        6,  100,    7,  100,   78,   77,   27,  100,  100,   68,
-       31,  100,   51,  100,  100,   67,   65,    1,  100,  100,
-      100,   83,  100,   21,   26,  100,  100,   17,   15,  100,
-      100,  100,  100,   24,   23,  100,  100,  100,  100,    3,
-      101,    2,    5,   81,   79,   80,   78,   78,    0,   71,
-        0,   30,   53,    0,   69,   55,    0,   66,   72,    0,
-        0,    0,    0,   36,   13,    0,    0,    0,   14,    0,
-       39,    0,   37,   29,   52,    0,   22,   16,    0,   45,
-        0,   28,   32,   54,    0,   20,   44,   12,    0,    9,
+        0,    0,    0,    0,  104,  102,    4,    5,   38,   40,
+        6,  102,    7,  102,   80,   79,   27,  102,  102,   68,
+       31,   77,   51,  102,   78,  102,   67,   65,    1,  102,
+      102,  102,   85,  102,   21,   26,  102,  102,   17,   15,
+      102,  102,  102,  102,   24,   23,  102,  102,  102,  102,
+        3,  103,    2,    5,   83,   81,   82,   80,   80,    0,
+       71,    0,   30,   53,    0,   69,   55,    0,   66,   72,
+        0,    0,    0,    0,   36,   13,    0,    0,    0,   14,
+        0,   39,    0,   37,   29,   52,    0,   22,   16,    0,
+       45,    0,   28,   32,   54,    0,   20,   44,   12,    0,
 
-       47,   82,    0,    0,    0,    0,    0,   48,    0,    0,
-       34,    0,   18,   10,   43,   73,    0,    0,    0,    0,
-       80,    0,   78,    0,    0,   78,   58,   57,    0,   70,
-       90,    0,    0,    0,   88,   49,   74,   89,   76,   56,
-       64,   50,   46,   92,    0,   42,   25,   91,   35,   94,
-       63,   75,   95,    0,   97,    0,    0,   33,    0,   19,
-       11,    8,    0,   81,    0,   79,    0,   80,    0,   78,
-       59,   84,   85,   86,    0,    0,   96,   99,   98,   41,
-        0,    0,   87,   93,   60,   61,    0,   62,    0
+        9,   47,   84,    0,    0,    0,    0,    0,   48,    0,
+        0,   34,    0,   18,   10,   43,   73,    0,    0,    0,
+        0,   82,    0,   80,    0,    0,   80,   58,   57,    0,
+       70,   92,    0,    0,    0,   90,   49,   74,   91,   76,
+       56,   64,   50,   46,   94,    0,   42,   25,   93,   35,
+       96,   63,   75,   97,    0,   99,    0,    0,   33,    0,
+       19,   11,    8,    0,   83,    0,   81,    0,   82,    0,
+       80,   59,   86,   87,   88,    0,    0,   98,  101,  100,
+       41,    0,    0,   89,   95,   60,   61,    0,   62,    0
     } ;
 
-static yyconst YY_CHAR yy_ec[256] =
+static const YY_CHAR yy_ec[256] =
     {   0,
         1,    1,    1,    1,    1,    1,    1,    1,    2,    3,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
@@ -420,174 +396,178 @@ static yyconst YY_CHAR yy_ec[256] =
        14,   14,   14,   14,   14,   14,   14,    1,    1,    1,
         6,    1,    1,    1,   15,    1,   16,    1,   17,    1,
        18,    1,    1,   19,   20,    1,   21,   22,    1,   23,
-        1,    1,    1,   24,    1,   25,   26,    1,    1,    1,
-       27,    1,   28,    6,    1,    1,   29,   30,   31,   32,
+        1,    1,   24,   25,    1,   26,   27,    1,    1,    1,
+       28,    1,   29,    6,    1,    1,   30,   31,   32,   33,
 
-       33,   34,   35,   36,   37,    1,   38,   39,   40,   41,
-       42,   43,   44,   45,   46,   47,   48,    1,   49,   50,
-       51,   52,    1,    1,    1,    1,    1,    1,    1,    1,
-        1,    1,    1,    1,    1,   53,    1,    1,    1,    1,
+       34,   35,   36,   37,   38,    1,   39,   40,   41,   42,
+       43,   44,   45,   46,   47,   48,   49,    1,   50,   51,
+       52,   53,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    1,   54,    1,    1,    1,    1,
-        1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
-        1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    1,   55,    1,    1,    1,    1,
-       56,    1,    1,    1,    1,    1,    1,    1,    1,    1,
-        1,    1,    1,   57,    1,    1,    1,    1,    1,    1,
+        1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
+        1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
+        1,    1,    1,    1,    1,   56,    1,    1,    1,    1,
+       57,    1,    1,    1,    1,    1,    1,    1,    1,    1,
+        1,    1,    1,   58,    1,    1,    1,    1,    1,    1,
 
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
-        1,    1,    1,    1,    1,   58,    1,    1,    1,    1,
+        1,    1,    1,    1,    1,   59,    1,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    1
     } ;
 
-static yyconst YY_CHAR yy_meta[59] =
+static const YY_CHAR yy_meta[60] =
     {   0,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
-        1,    1,    1,    1,    1,    1,    1,    1
+        1,    1,    1,    1,    1,    1,    1,    1,    1
     } ;
 
-static yyconst flex_uint16_t yy_base[191] =
+static const flex_int16_t yy_base[192] =
     {   0,
-        0,    0,   56,   57,  317,  318,  318,  313,  318,  318,
-      318,   50,  318,   54,   61,   69,  318,  290,  291,  318,
-      318,   73,  273,  283,  269,  295,  263,  318,   59,   59,
-       60,  258,  260,  264,  318,  264,   88,   62,   98,  264,
-      251,   70,  273,   77,   90,  107,  269,   42,  247,  318,
-      318,  318,  296,  132,  139,  146,  156,  170,  179,  318,
-      269,  318,  318,  268,  318,  318,  251,  249,  318,  248,
-      251,  255,  262,  318,  318,  244,  242,  253,  318,  244,
-      318,  245,  318,  318,  318,  256,  318,  318,  247,   36,
-      248,  318,  318,  318,  207,  318,   76,  318,   93,  318,
+        0,    0,   57,   58,  318,  319,  319,  314,  319,  319,
+      319,   51,  319,   55,   62,   80,  319,  290,  292,  319,
+      319,   62,  273,  283,  319,  269,  296,  263,  319,   51,
+       62,   37,  258,  260,  264,  319,  264,   85,   58,   95,
+      264,  251,   66,  273,   80,   86,   86,  269,   24,  247,
+      319,  319,  319,  297,  128,  135,  142,  153,  167,  179,
+      319,  269,  319,  319,  268,  319,  319,  251,  249,  319,
+      248,  251,  255,  262,  319,  319,  244,  242,  253,  319,
+      244,  319,  245,  319,  319,  319,  256,  319,  319,  247,
+       89,  248,  319,  319,  319,  240,  319,   95,  319,  110,
 
-      318,  318,  199,  202,  203,  192,  187,  318,  182,  177,
-      318,  165,  318,  318,  318,  318,  174,  151,  188,  199,
-      204,  213,  217,  229,  163,  233,  318,  318,  159,  318,
-      318,  150,  144,  130,  318,  318,  318,  318,  318,  318,
-      318,  318,  318,  154,  119,  318,  318,  318,  318,  318,
-      318,  318,  126,  114,  119,  106,  103,  318,   99,  318,
-      318,  318,  240,  244,  248,  252,  256,  260,  264,  268,
-      318,  318,  318,  126,  126,   91,  318,  318,  318,  318,
-       85,   84,  318,  318,  318,  318,   64,  318,  318,   86
+      319,  319,  319,  232,  243,  247,  237,  203,  319,  206,
+      192,  319,  188,  319,  319,  319,  319,  169,  167,  195,
+      204,  186,  212,  216,  225,  160,  229,  319,  319,  168,
+      319,  319,  165,  154,  153,  319,  319,  319,  319,  319,
+      319,  319,  319,  319,  173,  137,  319,  319,  319,  319,
+      319,  319,  319,  145,  120,  126,  112,  114,  319,  115,
+      319,  319,  319,  233,  240,  244,  248,  252,  256,  260,
+      264,  319,  319,  319,  144,  140,   98,  319,  319,  319,
+      319,   88,   83,  319,  319,  319,  319,   73,  319,  319,
+      101
+
     } ;
 
-static yyconst flex_int16_t yy_def[191] =
+static const flex_int16_t yy_def[192] =
     {   0,
-      189,    1,  190,  190,  189,  189,  189,  189,  189,  189,
-      189,  189,  189,  189,  189,  189,  189,  189,  189,  189,
-      189,  189,  189,  189,  189,  189,  189,  189,  189,  189,
-      189,  189,  189,  189,  189,  189,  189,  189,  189,  189,
-      189,  189,  189,  189,  189,  189,  189,  189,  189,  189,
-      189,  189,  189,  189,  189,  189,  189,  189,  189,  189,
-      189,  189,  189,  189,  189,  189,  189,  189,  189,  189,
-      189,  189,  189,  189,  189,  189,  189,  189,  189,  189,
-      189,  189,  189,  189,  189,  189,  189,  189,  189,  189,
-      189,  189,  189,  189,  189,  189,  189,  189,  189,  189,
+      190,    1,  191,  191,  190,  190,  190,  190,  190,  190,
+      190,  190,  190,  190,  190,  190,  190,  190,  190,  190,
+      190,  190,  190,  190,  190,  190,  190,  190,  190,  190,
+      190,  190,  190,  190,  190,  190,  190,  190,  190,  190,
+      190,  190,  190,  190,  190,  190,  190,  190,  190,  190,
+      190,  190,  190,  190,  190,  190,  190,  190,  190,  190,
+      190,  190,  190,  190,  190,  190,  190,  190,  190,  190,
+      190,  190,  190,  190,  190,  190,  190,  190,  190,  190,
+      190,  190,  190,  190,  190,  190,  190,  190,  190,  190,
+      190,  190,  190,  190,  190,  190,  190,  190,  190,  190,
 
-      189,  189,  189,  189,  189,  189,  189,  189,  189,  189,
-      189,  189,  189,  189,  189,  189,  189,  189,  189,  189,
-      189,  189,  189,  189,  189,  189,  189,  189,  189,  189,
-      189,  189,  189,  189,  189,  189,  189,  189,  189,  189,
-      189,  189,  189,  189,  189,  189,  189,  189,  189,  189,
-      189,  189,  189,  189,  189,  189,  189,  189,  189,  189,
-      189,  189,  189,  189,  189,  189,  189,  189,  189,  189,
-      189,  189,  189,  189,  189,  189,  189,  189,  189,  189,
-      189,  189,  189,  189,  189,  189,  189,  189,    0,  189
+      190,  190,  190,  190,  190,  190,  190,  190,  190,  190,
+      190,  190,  190,  190,  190,  190,  190,  190,  190,  190,
+      190,  190,  190,  190,  190,  190,  190,  190,  190,  190,
+      190,  190,  190,  190,  190,  190,  190,  190,  190,  190,
+      190,  190,  190,  190,  190,  190,  190,  190,  190,  190,
+      190,  190,  190,  190,  190,  190,  190,  190,  190,  190,
+      190,  190,  190,  190,  190,  190,  190,  190,  190,  190,
+      190,  190,  190,  190,  190,  190,  190,  190,  190,  190,
+      190,  190,  190,  190,  190,  190,  190,  190,  190,    0,
+      190
+
     } ;
 
-static yyconst flex_uint16_t yy_nxt[377] =
+static const flex_int16_t yy_nxt[379] =
     {   0,
         6,    7,    8,    9,   10,   11,   11,   12,   13,   14,
        15,   16,   15,   15,   17,   18,    6,   19,   20,   21,
-       22,   23,   24,   25,   26,   27,   28,    6,   29,    6,
-       30,   31,   32,   33,   34,   35,   36,   37,   38,   39,
-       40,   41,   42,    6,   43,   44,   45,   46,    6,    6,
-       47,    6,    6,    6,    6,    6,   48,   49,   51,   51,
-       54,   54,   54,   54,   55,   55,   55,   55,   56,  142,
-       57,   58,   58,   58,   58,  143,   56,   59,   57,   58,
-       58,   58,   58,   52,   52,   59,   50,   62,   70,   71,
-       74,   90,   78,   59,   63,   64,  116,  117,   75,   79,
+       22,   23,   24,   25,   26,   27,   28,   29,    6,   30,
+        6,   31,   32,   33,   34,   35,   36,   37,   38,   39,
+       40,   41,   42,   43,    6,   44,   45,   46,   47,    6,
+        6,   48,    6,    6,    6,    6,    6,   49,   50,   52,
+       52,   55,   55,   55,   55,   56,   56,   56,   56,   57,
+       79,   58,   59,   59,   59,   59,   63,   80,   60,  117,
+      118,   71,   72,   64,   65,   53,   53,   57,   91,   58,
+       59,   59,   59,   59,   75,   60,   60,   73,   74,   85,
 
-       76,   59,   84,   91,   72,   73,  102,   77,  188,   85,
-       86,  103,   92,  106,  146,  104,  147,   93,  109,   94,
-      107,   95,   87,  108,  148,  110,  111,   88,  187,  186,
-      112,  149,   96,   89,   97,  185,  184,   98,  183,   99,
-      182,  113,   54,   54,   54,   54,  114,  181,  119,   55,
-       55,   55,   55,  180,  179,  120,  121,  121,  121,  121,
-      178,  177,  122,  176,  119,  175,  123,  123,  123,  123,
-      174,  120,  124,  126,  126,  126,  126,   56,  122,   57,
-       58,   58,   58,   58,  173,  125,   59,  125,  124,  126,
-      126,  126,  126,  158,  163,  172,  163,  159,  164,  164,
+       92,   51,   76,  103,   77,  112,   86,   87,  104,   93,
+      113,   78,  105,   60,   94,  110,   95,  107,  189,   96,
+       88,  114,  111,  143,  108,   89,  115,  109,  188,  144,
+       97,   90,   98,  187,  147,   99,  148,  100,   55,   55,
+       55,   55,  149,  186,  120,   56,   56,   56,   56,  150,
+      185,  121,  122,  122,  122,  122,  184,  183,  123,  182,
+      181,  120,  180,  124,  124,  124,  124,  179,  121,  125,
+      127,  127,  127,  127,   57,  123,   58,   59,   59,   59,
+       59,  178,  177,   60,  176,  126,  125,  126,  159,  127,
+      127,  127,  127,  160,  175,  174,  122,  122,  122,  122,
 
-      164,  164,   59,  171,  162,  165,  157,  165,  160,  166,
-      166,  166,  166,  161,  121,  121,  121,  121,  156,  167,
-      122,  167,  155,  168,  168,  168,  168,  123,  123,  123,
-      123,  154,  153,  124,  152,  169,  122,  169,  151,  170,
-      170,  170,  170,  126,  126,  126,  126,  150,  145,  124,
-      164,  164,  164,  164,  164,  164,  164,  164,  166,  166,
-      166,  166,  166,  166,  166,  166,  168,  168,  168,  168,
-      168,  168,  168,  168,  170,  170,  170,  170,  170,  170,
-      170,  170,  144,  141,  140,  139,  138,  137,  136,  135,
-      134,  133,  132,  131,  130,  129,  128,  127,   53,  118,
+       60,  164,  123,  164,  161,  165,  165,  165,  165,  162,
+      166,  173,  166,  172,  167,  167,  167,  167,  168,  123,
+      168,  163,  169,  169,  169,  169,  124,  124,  124,  124,
+      158,  170,  125,  170,  157,  171,  171,  171,  171,  127,
+      127,  127,  127,  165,  165,  165,  165,  156,  155,  125,
+      165,  165,  165,  165,  167,  167,  167,  167,  167,  167,
+      167,  167,  169,  169,  169,  169,  169,  169,  169,  169,
+      171,  171,  171,  171,  171,  171,  171,  171,  154,  153,
+      152,  151,  146,  145,  142,  141,  140,  139,  138,  137,
+      136,  135,  134,  133,  132,  131,  130,  129,  128,   54,
 
-      115,  105,  101,  100,   83,   82,   81,   80,   69,   68,
-       67,   66,   65,   61,   60,   53,  189,    5,  189,  189,
-      189,  189,  189,  189,  189,  189,  189,  189,  189,  189,
-      189,  189,  189,  189,  189,  189,  189,  189,  189,  189,
-      189,  189,  189,  189,  189,  189,  189,  189,  189,  189,
-      189,  189,  189,  189,  189,  189,  189,  189,  189,  189,
-      189,  189,  189,  189,  189,  189,  189,  189,  189,  189,
-      189,  189,  189,  189,  189,  189
+      119,  116,  106,  102,  101,   84,   83,   82,   81,   70,
+       69,   68,   67,   66,   62,   61,   54,  190,    5,  190,
+      190,  190,  190,  190,  190,  190,  190,  190,  190,  190,
+      190,  190,  190,  190,  190,  190,  190,  190,  190,  190,
+      190,  190,  190,  190,  190,  190,  190,  190,  190,  190,
+      190,  190,  190,  190,  190,  190,  190,  190,  190,  190,
+      190,  190,  190,  190,  190,  190,  190,  190,  190,  190,
+      190,  190,  190,  190,  190,  190,  190,  190
     } ;
 
-static yyconst flex_int16_t yy_chk[377] =
+static const flex_int16_t yy_chk[379] =
     {   0,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
-        1,    1,    1,    1,    1,    1,    1,    1,    3,    4,
-       12,   12,   12,   12,   14,   14,   14,   14,   15,   90,
-       15,   15,   15,   15,   15,   90,   16,   15,   16,   16,
-       16,   16,   16,    3,    4,   16,  190,   22,   29,   29,
-       30,   38,   31,   15,   22,   22,   48,   48,   30,   31,
+        1,    1,    1,    1,    1,    1,    1,    1,    1,    3,
+        4,   12,   12,   12,   12,   14,   14,   14,   14,   15,
+       32,   15,   15,   15,   15,   15,   22,   32,   15,   49,
+       49,   30,   30,   22,   22,    3,    4,   16,   39,   16,
+       16,   16,   16,   16,   31,   15,   16,   30,   30,   38,
 
-       30,   16,   37,   38,   29,   29,   42,   30,  187,   37,
-       37,   42,   39,   44,   97,   42,   97,   39,   45,   39,
-       44,   39,   37,   44,   99,   45,   46,   37,  182,  181,
-       46,   99,   39,   37,   39,  176,  175,   39,  174,   39,
-      159,   46,   54,   54,   54,   54,   46,  157,   54,   55,
-       55,   55,   55,  156,  155,   55,   56,   56,   56,   56,
-      154,  153,   56,  145,   54,  144,   57,   57,   57,   57,
-      134,   55,   57,  125,  125,  125,  125,   58,   56,   58,
-       58,   58,   58,   58,  133,   59,   58,   59,   57,   59,
-       59,   59,   59,  117,  119,  132,  119,  117,  119,  119,
+       39,  191,   31,   43,   31,   47,   38,   38,   43,   40,
+       47,   31,   43,   16,   40,   46,   40,   45,  188,   40,
+       38,   47,   46,   91,   45,   38,   47,   45,  183,   91,
+       40,   38,   40,  182,   98,   40,   98,   40,   55,   55,
+       55,   55,  100,  177,   55,   56,   56,   56,   56,  100,
+      176,   56,   57,   57,   57,   57,  175,  160,   57,  158,
+      157,   55,  156,   58,   58,   58,   58,  155,   56,   58,
+      126,  126,  126,  126,   59,   57,   59,   59,   59,   59,
+       59,  154,  146,   59,  145,   60,   58,   60,  118,   60,
+       60,   60,   60,  118,  135,  134,  122,  122,  122,  122,
 
-      119,  119,   58,  129,  118,  120,  112,  120,  117,  120,
-      120,  120,  120,  117,  121,  121,  121,  121,  110,  122,
-      121,  122,  109,  122,  122,  122,  122,  123,  123,  123,
-      123,  107,  106,  123,  105,  124,  121,  124,  104,  124,
-      124,  124,  124,  126,  126,  126,  126,  103,   95,  123,
-      163,  163,  163,  163,  164,  164,  164,  164,  165,  165,
-      165,  165,  166,  166,  166,  166,  167,  167,  167,  167,
-      168,  168,  168,  168,  169,  169,  169,  169,  170,  170,
-      170,  170,   91,   89,   86,   82,   80,   78,   77,   76,
-       73,   72,   71,   70,   68,   67,   64,   61,   53,   49,
+       59,  120,  122,  120,  118,  120,  120,  120,  120,  118,
+      121,  133,  121,  130,  121,  121,  121,  121,  123,  122,
+      123,  119,  123,  123,  123,  123,  124,  124,  124,  124,
+      113,  125,  124,  125,  111,  125,  125,  125,  125,  127,
+      127,  127,  127,  164,  164,  164,  164,  110,  108,  124,
+      165,  165,  165,  165,  166,  166,  166,  166,  167,  167,
+      167,  167,  168,  168,  168,  168,  169,  169,  169,  169,
+      170,  170,  170,  170,  171,  171,  171,  171,  107,  106,
+      105,  104,   96,   92,   90,   87,   83,   81,   79,   78,
+       77,   74,   73,   72,   71,   69,   68,   65,   62,   54,
 
-       47,   43,   41,   40,   36,   34,   33,   32,   27,   26,
-       25,   24,   23,   19,   18,    8,    5,  189,  189,  189,
-      189,  189,  189,  189,  189,  189,  189,  189,  189,  189,
-      189,  189,  189,  189,  189,  189,  189,  189,  189,  189,
-      189,  189,  189,  189,  189,  189,  189,  189,  189,  189,
-      189,  189,  189,  189,  189,  189,  189,  189,  189,  189,
-      189,  189,  189,  189,  189,  189,  189,  189,  189,  189,
-      189,  189,  189,  189,  189,  189
+       50,   48,   44,   42,   41,   37,   35,   34,   33,   28,
+       27,   26,   24,   23,   19,   18,    8,    5,  190,  190,
+      190,  190,  190,  190,  190,  190,  190,  190,  190,  190,
+      190,  190,  190,  190,  190,  190,  190,  190,  190,  190,
+      190,  190,  190,  190,  190,  190,  190,  190,  190,  190,
+      190,  190,  190,  190,  190,  190,  190,  190,  190,  190,
+      190,  190,  190,  190,  190,  190,  190,  190,  190,  190,
+      190,  190,  190,  190,  190,  190,  190,  190
     } ;
 
 static yy_state_type yy_last_accepting_state;
@@ -604,21 +584,23 @@ int yy_flex_debug = 0;
 #define YY_MORE_ADJ 0
 #define YY_RESTORE_YY_MORE_OFFSET
 char *yytext;
-#line 1 "QuantityParser.l"
-#line 2 "QuantityParser.l"
+#line 1 "<stdin>"
+#line 2 "<stdin>"
 /* Lexer for the FreeCAD  Units language   */
 /* (c) 2013 Juergen Riegel  LGPL           */
 
+/* flex --outfile=QuantityLexer.c QuantityParser.l */
 
 /* This disables inclusion of unistd.h, which is not available under Visual C++
  * on Win32. The C++ scanner uses STL streams instead. */
 #define YY_NO_UNISTD_H
 
+#line 599 "QuantityLexer.c"
 /*** Flex Declarations and Options ***/
 /* the manual says "somewhat more optimized" */
 /* no support for include files is planned */
 
-#line 622 "QuantityLexer.c"
+#line 604 "QuantityLexer.c"
 
 #define INITIAL 0
 #define C_COMMENT 1
@@ -635,36 +617,36 @@ char *yytext;
 #define YY_EXTRA_TYPE void *
 #endif
 
-static int yy_init_globals (void );
+static int yy_init_globals ( void );
 
 /* Accessor methods to globals.
    These are made visible to non-reentrant scanners for convenience. */
 
-int yylex_destroy (void );
+int yylex_destroy ( void );
 
-int yyget_debug (void );
+int yyget_debug ( void );
 
-void yyset_debug (int debug_flag  );
+void yyset_debug ( int debug_flag  );
 
-YY_EXTRA_TYPE yyget_extra (void );
+YY_EXTRA_TYPE yyget_extra ( void );
 
-void yyset_extra (YY_EXTRA_TYPE user_defined  );
+void yyset_extra ( YY_EXTRA_TYPE user_defined  );
 
-FILE *yyget_in (void );
+FILE *yyget_in ( void );
 
-void yyset_in  (FILE * _in_str  );
+void yyset_in  ( FILE * _in_str  );
 
-FILE *yyget_out (void );
+FILE *yyget_out ( void );
 
-void yyset_out  (FILE * _out_str  );
+void yyset_out  ( FILE * _out_str  );
 
-yy_size_t yyget_leng (void );
+			int yyget_leng ( void );
 
-char *yyget_text (void );
+char *yyget_text ( void );
 
-int yyget_lineno (void );
+int yyget_lineno ( void );
 
-void yyset_lineno (int _line_number  );
+void yyset_lineno ( int _line_number  );
 
 /* Macros after this point can all be overridden by user definitions in
  * section 1.
@@ -672,9 +654,9 @@ void yyset_lineno (int _line_number  );
 
 #ifndef YY_SKIP_YYWRAP
 #ifdef __cplusplus
-extern "C" int yywrap (void );
+extern "C" int yywrap ( void );
 #else
-extern int yywrap (void );
+extern int yywrap ( void );
 #endif
 #endif
 
@@ -683,19 +665,18 @@ extern int yywrap (void );
 #endif
 
 #ifndef yytext_ptr
-static void yy_flex_strncpy (char *,yyconst char *,int );
+static void yy_flex_strncpy ( char *, const char *, int );
 #endif
 
 #ifdef YY_NEED_STRLEN
-static int yy_flex_strlen (yyconst char * );
+static int yy_flex_strlen ( const char * );
 #endif
 
 #ifndef YY_NO_INPUT
-
 #ifdef __cplusplus
-static int yyinput (void );
+static int yyinput ( void );
 #else
-static int input (void );
+static int input ( void );
 #endif
 
 #endif
@@ -715,7 +696,7 @@ static int input (void );
 /* This used to be an fputs(), but since the string might contain NUL's,
  * we now use fwrite().
  */
-#define ECHO do { if (fwrite( yytext, yyleng, 1, yyout )) {} } while (0)
+#define ECHO do { if (fwrite( yytext, (size_t) yyleng, 1, yyout )) {} } while (0)
 #endif
 
 /* Gets input and stuffs it into "buf".  number of characters read, or YY_NULL,
@@ -726,7 +707,7 @@ static int input (void );
 	if ( YY_CURRENT_BUFFER_LVALUE->yy_is_interactive ) \
 		{ \
 		int c = '*'; \
-		size_t n; \
+		int n; \
 		for ( n = 0; n < max_size && \
 			     (c = getc( yyin )) != EOF && c != '\n'; ++n ) \
 			buf[n] = (char) c; \
@@ -739,7 +720,7 @@ static int input (void );
 	else \
 		{ \
 		errno=0; \
-		while ( (result = fread(buf, 1, max_size, yyin))==0 && ferror(yyin)) \
+		while ( (result = (int) fread(buf, 1, (yy_size_t) max_size, yyin)) == 0 && ferror(yyin)) \
 			{ \
 			if( errno != EINTR) \
 				{ \
@@ -828,17 +809,17 @@ YY_DECL
 		if ( ! YY_CURRENT_BUFFER ) {
 			yyensure_buffer_stack ();
 			YY_CURRENT_BUFFER_LVALUE =
-				yy_create_buffer(yyin,YY_BUF_SIZE );
+				yy_create_buffer( yyin, YY_BUF_SIZE );
 		}
 
-		yy_load_buffer_state( );
+		yy_load_buffer_state(  );
 		}
 
 	{
-#line 31 "QuantityParser.l"
+#line 32 "<stdin>"
 
 
-#line 842 "QuantityLexer.c"
+#line 823 "QuantityLexer.c"
 
 	while ( /*CONSTCOND*/1 )		/* loops until end-of-file is reached */
 		{
@@ -865,13 +846,13 @@ yy_match:
 			while ( yy_chk[yy_base[yy_current_state] + yy_c] != yy_current_state )
 				{
 				yy_current_state = (int) yy_def[yy_current_state];
-				if ( yy_current_state >= 190 )
-					yy_c = yy_meta[(unsigned int) yy_c];
+				if ( yy_current_state >= 191 )
+					yy_c = yy_meta[yy_c];
 				}
-			yy_current_state = yy_nxt[yy_base[yy_current_state] + (unsigned int) yy_c];
+			yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
 			++yy_cp;
 			}
-		while ( yy_current_state != 189 );
+		while ( yy_current_state != 190 );
 		yy_cp = (yy_last_accepting_cpos);
 		yy_current_state = (yy_last_accepting_state);
 
@@ -893,511 +874,521 @@ do_action:	/* This label is used only to access EOF actions. */
 
 case 1:
 YY_RULE_SETUP
-#line 33 "QuantityParser.l"
+#line 34 "<stdin>"
 { BEGIN(C_COMMENT); }
 	YY_BREAK
 case 2:
 YY_RULE_SETUP
-#line 34 "QuantityParser.l"
+#line 35 "<stdin>"
 { BEGIN(INITIAL); }
 	YY_BREAK
 case 3:
 YY_RULE_SETUP
-#line 35 "QuantityParser.l"
+#line 36 "<stdin>"
 { ;}
 	YY_BREAK
 case 4:
 YY_RULE_SETUP
-#line 38 "QuantityParser.l"
+#line 39 "<stdin>"
 ;
 	YY_BREAK
 case 5:
 /* rule 5 can match eol */
 YY_RULE_SETUP
-#line 39 "QuantityParser.l"
+#line 40 "<stdin>"
 ;
 	YY_BREAK
 case 6:
 YY_RULE_SETUP
-#line 41 "QuantityParser.l"
+#line 42 "<stdin>"
 { return *yytext; }
 	YY_BREAK
 case 7:
 YY_RULE_SETUP
-#line 43 "QuantityParser.l"
+#line 44 "<stdin>"
 return MINUSSIGN;
 	YY_BREAK
 case 8:
 YY_RULE_SETUP
-#line 44 "QuantityParser.l"
+#line 45 "<stdin>"
 return MINUSSIGN;
 	YY_BREAK
 case 9:
 YY_RULE_SETUP
-#line 46 "QuantityParser.l"
+#line 47 "<stdin>"
 yylval = Quantity::NanoMetre;           return UNIT; // nano meter
 	YY_BREAK
 case 10:
 YY_RULE_SETUP
-#line 47 "QuantityParser.l"
+#line 48 "<stdin>"
 yylval = Quantity::MicroMetre;          return UNIT; // micro meter
 	YY_BREAK
 case 11:
 YY_RULE_SETUP
-#line 48 "QuantityParser.l"
+#line 49 "<stdin>"
 yylval = Quantity::MicroMetre;          return UNIT; // micro meter    (greek micro in UTF8)
 	YY_BREAK
 case 12:
 YY_RULE_SETUP
-#line 49 "QuantityParser.l"
+#line 50 "<stdin>"
 yylval = Quantity::MilliMetre;          return UNIT; // milli meter    (internal standard length)
 	YY_BREAK
 case 13:
 YY_RULE_SETUP
-#line 50 "QuantityParser.l"
+#line 51 "<stdin>"
 yylval = Quantity::CentiMetre;          return UNIT; // centi meter
 	YY_BREAK
 case 14:
 YY_RULE_SETUP
-#line 51 "QuantityParser.l"
+#line 52 "<stdin>"
 yylval = Quantity::DeciMetre;           return UNIT; // deci meter
 	YY_BREAK
 case 15:
 YY_RULE_SETUP
-#line 52 "QuantityParser.l"
+#line 53 "<stdin>"
 yylval = Quantity::Metre;               return UNIT; // metre
 	YY_BREAK
 case 16:
 YY_RULE_SETUP
-#line 53 "QuantityParser.l"
+#line 54 "<stdin>"
 yylval = Quantity::KiloMetre;           return UNIT; // kilo meter
 	YY_BREAK
 case 17:
 YY_RULE_SETUP
-#line 55 "QuantityParser.l"
+#line 56 "<stdin>"
 yylval = Quantity::Liter;               return UNIT; // Liter      dm^3
 	YY_BREAK
 case 18:
 YY_RULE_SETUP
-#line 57 "QuantityParser.l"
+#line 58 "<stdin>"
 yylval = Quantity::MicroGram;           return UNIT; // micro gram
 	YY_BREAK
 case 19:
 YY_RULE_SETUP
-#line 58 "QuantityParser.l"
+#line 59 "<stdin>"
 yylval = Quantity::MicroGram;           return UNIT; // micro gram
 	YY_BREAK
 case 20:
 YY_RULE_SETUP
-#line 59 "QuantityParser.l"
+#line 60 "<stdin>"
 yylval = Quantity::MilliGram;           return UNIT; // milli gram
 	YY_BREAK
 case 21:
 YY_RULE_SETUP
-#line 60 "QuantityParser.l"
+#line 61 "<stdin>"
 yylval = Quantity::Gram;                return UNIT; // gram
 	YY_BREAK
 case 22:
 YY_RULE_SETUP
-#line 61 "QuantityParser.l"
+#line 62 "<stdin>"
 yylval = Quantity::KiloGram;            return UNIT; // kilo gram      (internal standard for mass) 
 	YY_BREAK
 case 23:
 YY_RULE_SETUP
-#line 62 "QuantityParser.l"
+#line 63 "<stdin>"
 yylval = Quantity::Ton;                 return UNIT; // Metric Tonne
 	YY_BREAK
 case 24:
 YY_RULE_SETUP
-#line 64 "QuantityParser.l"
+#line 65 "<stdin>"
 yylval = Quantity::Second;              return UNIT; // second         (internal standard time)
 	YY_BREAK
 case 25:
 YY_RULE_SETUP
-#line 65 "QuantityParser.l"
+#line 66 "<stdin>"
 yylval = Quantity::Minute;              return UNIT; // minute
 	YY_BREAK
 case 26:
 YY_RULE_SETUP
-#line 66 "QuantityParser.l"
+#line 67 "<stdin>"
 yylval = Quantity::Hour;                return UNIT; // hour  
 	YY_BREAK
 case 27:
 YY_RULE_SETUP
-#line 68 "QuantityParser.l"
+#line 69 "<stdin>"
 yylval = Quantity::Ampere;              return UNIT; // Ampere         (internal standard electric current)
 	YY_BREAK
 case 28:
 YY_RULE_SETUP
-#line 69 "QuantityParser.l"
+#line 70 "<stdin>"
 yylval = Quantity::MilliAmpere;         return UNIT; // milli Ampere
 	YY_BREAK
 case 29:
 YY_RULE_SETUP
-#line 70 "QuantityParser.l"
+#line 71 "<stdin>"
 yylval = Quantity::KiloAmpere;          return UNIT; // kilo Ampere
 	YY_BREAK
 case 30:
 YY_RULE_SETUP
-#line 71 "QuantityParser.l"
+#line 72 "<stdin>"
 yylval = Quantity::MegaAmpere;          return UNIT; // Mega Ampere
 	YY_BREAK
 case 31:
 YY_RULE_SETUP
-#line 73 "QuantityParser.l"
+#line 74 "<stdin>"
 yylval = Quantity::Kelvin;              return UNIT; // Kelvin         (internal standard thermodynamic temperature)
 	YY_BREAK
 case 32:
 YY_RULE_SETUP
-#line 74 "QuantityParser.l"
+#line 75 "<stdin>"
 yylval = Quantity::MilliKelvin;         return UNIT; // Kelvin
 	YY_BREAK
 case 33:
 YY_RULE_SETUP
-#line 75 "QuantityParser.l"
+#line 76 "<stdin>"
 yylval = Quantity::MicroKelvin;         return UNIT; // Kelvin
 	YY_BREAK
 case 34:
 YY_RULE_SETUP
-#line 76 "QuantityParser.l"
+#line 77 "<stdin>"
 yylval = Quantity::MicroKelvin;         return UNIT; // Kelvin
 	YY_BREAK
 case 35:
 YY_RULE_SETUP
-#line 78 "QuantityParser.l"
+#line 79 "<stdin>"
 yylval = Quantity::Mole;                return UNIT; // Mole           (internal standard amount of substance)
 	YY_BREAK
 case 36:
 YY_RULE_SETUP
-#line 80 "QuantityParser.l"
+#line 81 "<stdin>"
 yylval = Quantity::Candela;             return UNIT; // Candela        (internal standard luminous intensity)
 	YY_BREAK
 case 37:
 YY_RULE_SETUP
-#line 82 "QuantityParser.l"
+#line 83 "<stdin>"
 yylval = Quantity::Inch;                return UNIT; // inch
 	YY_BREAK
 case 38:
 YY_RULE_SETUP
-#line 83 "QuantityParser.l"
+#line 84 "<stdin>"
 yylval = Quantity::Inch;                return UNIT; // inch
 	YY_BREAK
 case 39:
 YY_RULE_SETUP
-#line 84 "QuantityParser.l"
+#line 85 "<stdin>"
 yylval = Quantity::Foot;                return UNIT; // foot
 	YY_BREAK
 case 40:
 YY_RULE_SETUP
-#line 85 "QuantityParser.l"
+#line 86 "<stdin>"
 yylval = Quantity::Foot;                return UNIT; // foot
 	YY_BREAK
 case 41:
 YY_RULE_SETUP
-#line 86 "QuantityParser.l"
+#line 87 "<stdin>"
 yylval = Quantity::Thou;                return UNIT; // thou (in/1000)
 	YY_BREAK
 case 42:
 YY_RULE_SETUP
-#line 87 "QuantityParser.l"
+#line 88 "<stdin>"
 yylval = Quantity::Thou;                return UNIT; // mil  (the thou in US)
 	YY_BREAK
 case 43:
 YY_RULE_SETUP
-#line 88 "QuantityParser.l"
+#line 89 "<stdin>"
 yylval = Quantity::Yard;                return UNIT; // yard
 	YY_BREAK
 case 44:
 YY_RULE_SETUP
-#line 89 "QuantityParser.l"
+#line 90 "<stdin>"
 yylval = Quantity::Mile;                return UNIT; // mile
 	YY_BREAK
 case 45:
 YY_RULE_SETUP
-#line 93 "QuantityParser.l"
+#line 94 "<stdin>"
 yylval = Quantity::Pound;               return UNIT; // pound
 	YY_BREAK
 case 46:
 YY_RULE_SETUP
-#line 94 "QuantityParser.l"
+#line 95 "<stdin>"
 yylval = Quantity::Pound;               return UNIT; // pound 
 	YY_BREAK
 case 47:
 YY_RULE_SETUP
-#line 95 "QuantityParser.l"
+#line 96 "<stdin>"
 yylval = Quantity::Ounce;               return UNIT; // ounce
 	YY_BREAK
 case 48:
 YY_RULE_SETUP
-#line 96 "QuantityParser.l"
+#line 97 "<stdin>"
 yylval = Quantity::Stone;               return UNIT; // Stone
 	YY_BREAK
 case 49:
 YY_RULE_SETUP
-#line 97 "QuantityParser.l"
+#line 98 "<stdin>"
 yylval = Quantity::Hundredweights;      return UNIT; // hundredweights
 	YY_BREAK
 case 50:
 YY_RULE_SETUP
-#line 99 "QuantityParser.l"
+#line 100 "<stdin>"
 yylval = Quantity::PoundForce;          return UNIT; // pound
 	YY_BREAK
 case 51:
 YY_RULE_SETUP
-#line 101 "QuantityParser.l"
+#line 102 "<stdin>"
 yylval = Quantity::Newton;              return UNIT; // Newton (kg*m/s^2)
 	YY_BREAK
 case 52:
 YY_RULE_SETUP
-#line 102 "QuantityParser.l"
+#line 103 "<stdin>"
 yylval = Quantity::KiloNewton;          return UNIT; // Newton
 	YY_BREAK
 case 53:
 YY_RULE_SETUP
-#line 103 "QuantityParser.l"
+#line 104 "<stdin>"
 yylval = Quantity::MegaNewton;          return UNIT; // Newton
 	YY_BREAK
 case 54:
 YY_RULE_SETUP
-#line 104 "QuantityParser.l"
+#line 105 "<stdin>"
 yylval = Quantity::MilliNewton;         return UNIT; // Newton
 	YY_BREAK
 case 55:
 YY_RULE_SETUP
-#line 106 "QuantityParser.l"
+#line 107 "<stdin>"
 yylval = Quantity::Pascal;              return UNIT; // Pascal (kg/m/s^2 or N/m^2)
 	YY_BREAK
 case 56:
 YY_RULE_SETUP
-#line 107 "QuantityParser.l"
+#line 108 "<stdin>"
 yylval = Quantity::KiloPascal;          return UNIT; // Pascal
 	YY_BREAK
 case 57:
 YY_RULE_SETUP
-#line 108 "QuantityParser.l"
+#line 109 "<stdin>"
 yylval = Quantity::MegaPascal;          return UNIT; // Pascal
 	YY_BREAK
 case 58:
 YY_RULE_SETUP
-#line 109 "QuantityParser.l"
+#line 110 "<stdin>"
 yylval = Quantity::GigaPascal;          return UNIT; // Pascal
 	YY_BREAK
 case 59:
 YY_RULE_SETUP
-#line 111 "QuantityParser.l"
+#line 112 "<stdin>"
 yylval = Quantity::Torr;                return UNIT; // portion of Pascal ( 101325/760 )
 	YY_BREAK
 case 60:
 YY_RULE_SETUP
-#line 112 "QuantityParser.l"
+#line 113 "<stdin>"
 yylval = Quantity::mTorr;               return UNIT; //
 	YY_BREAK
 case 61:
 YY_RULE_SETUP
-#line 113 "QuantityParser.l"
+#line 114 "<stdin>"
 yylval = Quantity::yTorr;               return UNIT; //
 	YY_BREAK
 case 62:
 YY_RULE_SETUP
-#line 114 "QuantityParser.l"
+#line 115 "<stdin>"
 yylval = Quantity::yTorr;               return UNIT; //
 	YY_BREAK
 case 63:
 YY_RULE_SETUP
-#line 116 "QuantityParser.l"
+#line 117 "<stdin>"
 yylval = Quantity::PSI;                 return UNIT; // pounds/in^2
 	YY_BREAK
 case 64:
 YY_RULE_SETUP
-#line 117 "QuantityParser.l"
+#line 118 "<stdin>"
 yylval = Quantity::KSI;                 return UNIT; // 1000 x pounds/in^2
 	YY_BREAK
 case 65:
 YY_RULE_SETUP
-#line 119 "QuantityParser.l"
+#line 120 "<stdin>"
 yylval = Quantity::Watt;                return UNIT; // Watt (kg*m^2/s^3)
 	YY_BREAK
 case 66:
 YY_RULE_SETUP
-#line 120 "QuantityParser.l"
+#line 121 "<stdin>"
 yylval = Quantity::VoltAmpere;          return UNIT; // VoltAmpere (kg*m^2/s^3)
 	YY_BREAK
 case 67:
 YY_RULE_SETUP
-#line 122 "QuantityParser.l"
+#line 123 "<stdin>"
 yylval = Quantity::Volt;                return UNIT; // Volt (kg*m^2/A/s^3)
 	YY_BREAK
 case 68:
 YY_RULE_SETUP
-#line 124 "QuantityParser.l"
+#line 125 "<stdin>"
 yylval = Quantity::Joule;               return UNIT; // Joule (kg*m^2/s^2)
 	YY_BREAK
 case 69:
 YY_RULE_SETUP
-#line 125 "QuantityParser.l"
+#line 126 "<stdin>"
 yylval = Quantity::NewtonMeter;         return UNIT; // N*m = Joule
 	YY_BREAK
 case 70:
 YY_RULE_SETUP
-#line 126 "QuantityParser.l"
+#line 127 "<stdin>"
 yylval = Quantity::VoltAmpereSecond;    return UNIT; // V*A*s = Joule
 	YY_BREAK
 case 71:
 YY_RULE_SETUP
-#line 127 "QuantityParser.l"
+#line 128 "<stdin>"
 yylval = Quantity::WattSecond;          return UNIT; //
 	YY_BREAK
 case 72:
 YY_RULE_SETUP
-#line 128 "QuantityParser.l"
+#line 129 "<stdin>"
 yylval = Quantity::WattSecond;          return UNIT; // W*s = Joule
 	YY_BREAK
 case 73:
 YY_RULE_SETUP
-#line 130 "QuantityParser.l"
+#line 131 "<stdin>"
 yylval = Quantity::Degree;              return UNIT; // degree         (internal standard angle)
 	YY_BREAK
 case 74:
 YY_RULE_SETUP
-#line 131 "QuantityParser.l"
+#line 132 "<stdin>"
 yylval = Quantity::Degree;              return UNIT; // degree         (internal standard angle)
 	YY_BREAK
 case 75:
 YY_RULE_SETUP
-#line 132 "QuantityParser.l"
+#line 133 "<stdin>"
 yylval = Quantity::Radian;              return UNIT; // radian
 	YY_BREAK
 case 76:
 YY_RULE_SETUP
-#line 133 "QuantityParser.l"
+#line 134 "<stdin>"
 yylval = Quantity::Gon;                 return UNIT; // gon
 	YY_BREAK
 case 77:
 YY_RULE_SETUP
-#line 135 "QuantityParser.l"
-yylval = Quantity(1.0);                 return ONE;
+#line 135 "<stdin>"
+yylval = Quantity::AngMinute;           return UNIT; // minute(Angular)
 	YY_BREAK
 case 78:
 YY_RULE_SETUP
-#line 136 "QuantityParser.l"
-{  yylval = Quantity(num_change(yytext,'.',','));return NUM;  }
+#line 136 "<stdin>"
+yylval = Quantity::AngSecond;           return UNIT; // second(Angular) 
 	YY_BREAK
 case 79:
 YY_RULE_SETUP
-#line 137 "QuantityParser.l"
-{  yylval = Quantity(num_change(yytext,'.',','));return NUM;  }
+#line 138 "<stdin>"
+yylval = Quantity(1.0);                 return ONE;
 	YY_BREAK
 case 80:
 YY_RULE_SETUP
-#line 138 "QuantityParser.l"
-{  yylval = Quantity(num_change(yytext,',','.'));return NUM;  }
+#line 139 "<stdin>"
+{  yylval = Quantity(num_change(yytext,'.',','));return NUM;  }
 	YY_BREAK
 case 81:
 YY_RULE_SETUP
-#line 139 "QuantityParser.l"
-{  yylval = Quantity(num_change(yytext,',','.'));return NUM;  }
+#line 140 "<stdin>"
+{  yylval = Quantity(num_change(yytext,'.',','));return NUM;  }
 	YY_BREAK
 case 82:
 YY_RULE_SETUP
-#line 142 "QuantityParser.l"
-{yylval = Quantity(M_PI)          ; return NUM;} // constant pi
+#line 141 "<stdin>"
+{  yylval = Quantity(num_change(yytext,',','.'));return NUM;  }
 	YY_BREAK
 case 83:
 YY_RULE_SETUP
-#line 143 "QuantityParser.l"
-{yylval = Quantity(M_E)           ; return NUM;} // constant e
+#line 142 "<stdin>"
+{  yylval = Quantity(num_change(yytext,',','.'));return NUM;  }
 	YY_BREAK
 case 84:
 YY_RULE_SETUP
-#line 145 "QuantityParser.l"
-return ACOS;
+#line 145 "<stdin>"
+{yylval = Quantity(M_PI)          ; return NUM;} // constant pi
 	YY_BREAK
 case 85:
 YY_RULE_SETUP
-#line 146 "QuantityParser.l"
-return ASIN;
+#line 146 "<stdin>"
+{yylval = Quantity(M_E)           ; return NUM;} // constant e
 	YY_BREAK
 case 86:
 YY_RULE_SETUP
-#line 147 "QuantityParser.l"
-return ATAN;
+#line 148 "<stdin>"
+return ACOS;
 	YY_BREAK
 case 87:
 YY_RULE_SETUP
-#line 148 "QuantityParser.l"
-return ATAN2;
+#line 149 "<stdin>"
+return ASIN;
 	YY_BREAK
 case 88:
 YY_RULE_SETUP
-#line 149 "QuantityParser.l"
-return COS;
+#line 150 "<stdin>"
+return ATAN;
 	YY_BREAK
 case 89:
 YY_RULE_SETUP
-#line 150 "QuantityParser.l"
-return EXP;
+#line 151 "<stdin>"
+return ATAN2;
 	YY_BREAK
 case 90:
 YY_RULE_SETUP
-#line 151 "QuantityParser.l"
-return ABS;
+#line 152 "<stdin>"
+return COS;
 	YY_BREAK
 case 91:
 YY_RULE_SETUP
-#line 152 "QuantityParser.l"
-return MOD;
+#line 153 "<stdin>"
+return EXP;
 	YY_BREAK
 case 92:
 YY_RULE_SETUP
-#line 153 "QuantityParser.l"
-return LOG;
+#line 154 "<stdin>"
+return ABS;
 	YY_BREAK
 case 93:
 YY_RULE_SETUP
-#line 154 "QuantityParser.l"
-return LOG10;
+#line 155 "<stdin>"
+return MOD;
 	YY_BREAK
 case 94:
 YY_RULE_SETUP
-#line 155 "QuantityParser.l"
-return POW;
+#line 156 "<stdin>"
+return LOG;
 	YY_BREAK
 case 95:
 YY_RULE_SETUP
-#line 156 "QuantityParser.l"
-return SIN;
+#line 157 "<stdin>"
+return LOG10;
 	YY_BREAK
 case 96:
 YY_RULE_SETUP
-#line 157 "QuantityParser.l"
-return SINH;
+#line 158 "<stdin>"
+return POW;
 	YY_BREAK
 case 97:
 YY_RULE_SETUP
-#line 158 "QuantityParser.l"
-return TAN;
+#line 159 "<stdin>"
+return SIN;
 	YY_BREAK
 case 98:
 YY_RULE_SETUP
-#line 159 "QuantityParser.l"
-return TANH;
+#line 160 "<stdin>"
+return SINH;
 	YY_BREAK
 case 99:
 YY_RULE_SETUP
-#line 160 "QuantityParser.l"
-return SQRT;
+#line 161 "<stdin>"
+return TAN;
 	YY_BREAK
 case 100:
 YY_RULE_SETUP
-#line 162 "QuantityParser.l"
-return *yytext;
+#line 162 "<stdin>"
+return TANH;
 	YY_BREAK
 case 101:
 YY_RULE_SETUP
-#line 163 "QuantityParser.l"
+#line 163 "<stdin>"
+return SQRT;
+	YY_BREAK
+case 102:
+YY_RULE_SETUP
+#line 165 "<stdin>"
+return *yytext;
+	YY_BREAK
+case 103:
+YY_RULE_SETUP
+#line 166 "<stdin>"
 ECHO;
 	YY_BREAK
-#line 1401 "QuantityLexer.c"
+#line 1392 "QuantityLexer.c"
 case YY_STATE_EOF(INITIAL):
 case YY_STATE_EOF(C_COMMENT):
 	yyterminate();
@@ -1477,7 +1468,7 @@ case YY_STATE_EOF(C_COMMENT):
 				{
 				(yy_did_buffer_switch_on_eof) = 0;
 
-				if ( yywrap( ) )
+				if ( yywrap(  ) )
 					{
 					/* Note: because we've taken care in
 					 * yy_get_next_buffer() to have set up
@@ -1544,7 +1535,7 @@ static int yy_get_next_buffer (void)
 {
     	char *dest = YY_CURRENT_BUFFER_LVALUE->yy_ch_buf;
 	char *source = (yytext_ptr);
-	yy_size_t number_to_move, i;
+	int number_to_move, i;
 	int ret_val;
 
 	if ( (yy_c_buf_p) > &YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[(yy_n_chars) + 1] )
@@ -1573,7 +1564,7 @@ static int yy_get_next_buffer (void)
 	/* Try to read more data. */
 
 	/* First move last chars to start of buffer. */
-	number_to_move = (yy_size_t) ((yy_c_buf_p) - (yytext_ptr)) - 1;
+	number_to_move = (int) ((yy_c_buf_p) - (yytext_ptr) - 1);
 
 	for ( i = 0; i < number_to_move; ++i )
 		*(dest++) = *(source++);
@@ -1586,7 +1577,7 @@ static int yy_get_next_buffer (void)
 
 	else
 		{
-			yy_size_t num_to_read =
+			int num_to_read =
 			YY_CURRENT_BUFFER_LVALUE->yy_buf_size - number_to_move - 1;
 
 		while ( num_to_read <= 0 )
@@ -1600,7 +1591,7 @@ static int yy_get_next_buffer (void)
 
 			if ( b->yy_is_our_buffer )
 				{
-				yy_size_t new_size = b->yy_buf_size * 2;
+				int new_size = b->yy_buf_size * 2;
 
 				if ( new_size <= 0 )
 					b->yy_buf_size += b->yy_buf_size / 8;
@@ -1609,11 +1600,12 @@ static int yy_get_next_buffer (void)
 
 				b->yy_ch_buf = (char *)
 					/* Include room in for 2 EOB chars. */
-					yyrealloc((void *) b->yy_ch_buf,b->yy_buf_size + 2  );
+					yyrealloc( (void *) b->yy_ch_buf,
+							 (yy_size_t) (b->yy_buf_size + 2)  );
 				}
 			else
 				/* Can't grow it, we don't own it. */
-				b->yy_ch_buf = 0;
+				b->yy_ch_buf = NULL;
 
 			if ( ! b->yy_ch_buf )
 				YY_FATAL_ERROR(
@@ -1641,7 +1633,7 @@ static int yy_get_next_buffer (void)
 		if ( number_to_move == YY_MORE_ADJ )
 			{
 			ret_val = EOB_ACT_END_OF_FILE;
-			yyrestart(yyin  );
+			yyrestart( yyin  );
 			}
 
 		else
@@ -1655,12 +1647,15 @@ static int yy_get_next_buffer (void)
 	else
 		ret_val = EOB_ACT_CONTINUE_SCAN;
 
-	if ((int) ((yy_n_chars) + number_to_move) > YY_CURRENT_BUFFER_LVALUE->yy_buf_size) {
+	if (((yy_n_chars) + number_to_move) > YY_CURRENT_BUFFER_LVALUE->yy_buf_size) {
 		/* Extend the array by 50%, plus the number we really need. */
 		int new_size = (yy_n_chars) + number_to_move + ((yy_n_chars) >> 1);
-		YY_CURRENT_BUFFER_LVALUE->yy_ch_buf = (char *) yyrealloc((void *) YY_CURRENT_BUFFER_LVALUE->yy_ch_buf,new_size  );
+		YY_CURRENT_BUFFER_LVALUE->yy_ch_buf = (char *) yyrealloc(
+			(void *) YY_CURRENT_BUFFER_LVALUE->yy_ch_buf, (yy_size_t) new_size  );
 		if ( ! YY_CURRENT_BUFFER_LVALUE->yy_ch_buf )
 			YY_FATAL_ERROR( "out of dynamic memory in yy_get_next_buffer()" );
+		/* "- 2" to take care of EOB's */
+		YY_CURRENT_BUFFER_LVALUE->yy_buf_size = (int) (new_size - 2);
 	}
 
 	(yy_n_chars) += number_to_move;
@@ -1692,10 +1687,10 @@ static int yy_get_next_buffer (void)
 		while ( yy_chk[yy_base[yy_current_state] + yy_c] != yy_current_state )
 			{
 			yy_current_state = (int) yy_def[yy_current_state];
-			if ( yy_current_state >= 190 )
-				yy_c = yy_meta[(unsigned int) yy_c];
+			if ( yy_current_state >= 191 )
+				yy_c = yy_meta[yy_c];
 			}
-		yy_current_state = yy_nxt[yy_base[yy_current_state] + (unsigned int) yy_c];
+		yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
 		}
 
 	return yy_current_state;
@@ -1720,11 +1715,11 @@ static int yy_get_next_buffer (void)
 	while ( yy_chk[yy_base[yy_current_state] + yy_c] != yy_current_state )
 		{
 		yy_current_state = (int) yy_def[yy_current_state];
-		if ( yy_current_state >= 190 )
-			yy_c = yy_meta[(unsigned int) yy_c];
+		if ( yy_current_state >= 191 )
+			yy_c = yy_meta[yy_c];
 		}
-	yy_current_state = yy_nxt[yy_base[yy_current_state] + (unsigned int) yy_c];
-	yy_is_jam = (yy_current_state == 189);
+	yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
+	yy_is_jam = (yy_current_state == 190);
 
 		return yy_is_jam ? 0 : yy_current_state;
 }
@@ -1757,7 +1752,7 @@ static int yy_get_next_buffer (void)
 
 		else
 			{ /* need more input */
-			yy_size_t offset = (yy_c_buf_p) - (yytext_ptr);
+			int offset = (int) ((yy_c_buf_p) - (yytext_ptr));
 			++(yy_c_buf_p);
 
 			switch ( yy_get_next_buffer(  ) )
@@ -1774,14 +1769,14 @@ static int yy_get_next_buffer (void)
 					 */
 
 					/* Reset buffer status. */
-					yyrestart(yyin );
+					yyrestart( yyin );
 
 					/*FALLTHROUGH*/
 
 				case EOB_ACT_END_OF_FILE:
 					{
-					if ( yywrap( ) )
-						return EOF;
+					if ( yywrap(  ) )
+						return 0;
 
 					if ( ! (yy_did_buffer_switch_on_eof) )
 						YY_NEW_FILE;
@@ -1818,11 +1813,11 @@ static int yy_get_next_buffer (void)
 	if ( ! YY_CURRENT_BUFFER ){
         yyensure_buffer_stack ();
 		YY_CURRENT_BUFFER_LVALUE =
-            yy_create_buffer(yyin,YY_BUF_SIZE );
+            yy_create_buffer( yyin, YY_BUF_SIZE );
 	}
 
-	yy_init_buffer(YY_CURRENT_BUFFER,input_file );
-	yy_load_buffer_state( );
+	yy_init_buffer( YY_CURRENT_BUFFER, input_file );
+	yy_load_buffer_state(  );
 }
 
 /** Switch to a different input buffer.
@@ -1850,7 +1845,7 @@ static int yy_get_next_buffer (void)
 		}
 
 	YY_CURRENT_BUFFER_LVALUE = new_buffer;
-	yy_load_buffer_state( );
+	yy_load_buffer_state(  );
 
 	/* We don't actually know whether we did this switch during
 	 * EOF (yywrap()) processing, but the only time this flag
@@ -1878,22 +1873,22 @@ static void yy_load_buffer_state  (void)
 {
 	YY_BUFFER_STATE b;
     
-	b = (YY_BUFFER_STATE) yyalloc(sizeof( struct yy_buffer_state )  );
+	b = (YY_BUFFER_STATE) yyalloc( sizeof( struct yy_buffer_state )  );
 	if ( ! b )
 		YY_FATAL_ERROR( "out of dynamic memory in yy_create_buffer()" );
 
-	b->yy_buf_size = (yy_size_t)size;
+	b->yy_buf_size = size;
 
 	/* yy_ch_buf has to be 2 characters longer than the size given because
 	 * we need to put in 2 end-of-buffer characters.
 	 */
-	b->yy_ch_buf = (char *) yyalloc(b->yy_buf_size + 2  );
+	b->yy_ch_buf = (char *) yyalloc( (yy_size_t) (b->yy_buf_size + 2)  );
 	if ( ! b->yy_ch_buf )
 		YY_FATAL_ERROR( "out of dynamic memory in yy_create_buffer()" );
 
 	b->yy_is_our_buffer = 1;
 
-	yy_init_buffer(b,file );
+	yy_init_buffer( b, file );
 
 	return b;
 }
@@ -1912,9 +1907,9 @@ static void yy_load_buffer_state  (void)
 		YY_CURRENT_BUFFER_LVALUE = (YY_BUFFER_STATE) 0;
 
 	if ( b->yy_is_our_buffer )
-		yyfree((void *) b->yy_ch_buf  );
+		yyfree( (void *) b->yy_ch_buf  );
 
-	yyfree((void *) b  );
+	yyfree( (void *) b  );
 }
 
 /* Initializes or reinitializes a buffer.
@@ -1926,7 +1921,7 @@ static void yy_load_buffer_state  (void)
 {
 	int oerrno = errno;
     
-	yy_flush_buffer(b );
+	yy_flush_buffer( b );
 
 	b->yy_input_file = file;
 	b->yy_fill_buffer = 1;
@@ -1969,7 +1964,7 @@ static void yy_load_buffer_state  (void)
 	b->yy_buffer_status = YY_BUFFER_NEW;
 
 	if ( b == YY_CURRENT_BUFFER )
-		yy_load_buffer_state( );
+		yy_load_buffer_state(  );
 }
 
 /** Pushes the new state onto the stack. The new state becomes
@@ -2000,7 +1995,7 @@ void yypush_buffer_state (YY_BUFFER_STATE new_buffer )
 	YY_CURRENT_BUFFER_LVALUE = new_buffer;
 
 	/* copied from yy_switch_to_buffer. */
-	yy_load_buffer_state( );
+	yy_load_buffer_state(  );
 	(yy_did_buffer_switch_on_eof) = 1;
 }
 
@@ -2019,7 +2014,7 @@ void yypop_buffer_state (void)
 		--(yy_buffer_stack_top);
 
 	if (YY_CURRENT_BUFFER) {
-		yy_load_buffer_state( );
+		yy_load_buffer_state(  );
 		(yy_did_buffer_switch_on_eof) = 1;
 	}
 }
@@ -2037,15 +2032,15 @@ static void yyensure_buffer_stack (void)
 		 * scanner will even need a stack. We use 2 instead of 1 to avoid an
 		 * immediate realloc on the next call.
          */
-		num_to_alloc = 1; /* After all that talk, this was set to 1 anyways... */
+      num_to_alloc = 1; /* After all that talk, this was set to 1 anyways... */
 		(yy_buffer_stack) = (struct yy_buffer_state**)yyalloc
 								(num_to_alloc * sizeof(struct yy_buffer_state*)
 								);
 		if ( ! (yy_buffer_stack) )
 			YY_FATAL_ERROR( "out of dynamic memory in yyensure_buffer_stack()" );
-								  
+
 		memset((yy_buffer_stack), 0, num_to_alloc * sizeof(struct yy_buffer_state*));
-				
+
 		(yy_buffer_stack_max) = num_to_alloc;
 		(yy_buffer_stack_top) = 0;
 		return;
@@ -2074,7 +2069,7 @@ static void yyensure_buffer_stack (void)
  * @param base the character buffer
  * @param size the size in bytes of the character buffer
  * 
- * @return the newly allocated buffer state object. 
+ * @return the newly allocated buffer state object.
  */
 YY_BUFFER_STATE yy_scan_buffer  (char * base, yy_size_t  size )
 {
@@ -2084,23 +2079,23 @@ YY_BUFFER_STATE yy_scan_buffer  (char * base, yy_size_t  size )
 	     base[size-2] != YY_END_OF_BUFFER_CHAR ||
 	     base[size-1] != YY_END_OF_BUFFER_CHAR )
 		/* They forgot to leave room for the EOB's. */
-		return 0;
+		return NULL;
 
-	b = (YY_BUFFER_STATE) yyalloc(sizeof( struct yy_buffer_state )  );
+	b = (YY_BUFFER_STATE) yyalloc( sizeof( struct yy_buffer_state )  );
 	if ( ! b )
 		YY_FATAL_ERROR( "out of dynamic memory in yy_scan_buffer()" );
 
-	b->yy_buf_size = size - 2;	/* "- 2" to take care of EOB's */
+	b->yy_buf_size = (int) (size - 2);	/* "- 2" to take care of EOB's */
 	b->yy_buf_pos = b->yy_ch_buf = base;
 	b->yy_is_our_buffer = 0;
-	b->yy_input_file = 0;
+	b->yy_input_file = NULL;
 	b->yy_n_chars = b->yy_buf_size;
 	b->yy_is_interactive = 0;
 	b->yy_at_bol = 1;
 	b->yy_fill_buffer = 0;
 	b->yy_buffer_status = YY_BUFFER_NEW;
 
-	yy_switch_to_buffer(b  );
+	yy_switch_to_buffer( b  );
 
 	return b;
 }
@@ -2113,10 +2108,10 @@ YY_BUFFER_STATE yy_scan_buffer  (char * base, yy_size_t  size )
  * @note If you want to scan bytes that may contain NUL values, then use
  *       yy_scan_bytes() instead.
  */
-YY_BUFFER_STATE yy_scan_string (yyconst char * yystr )
+YY_BUFFER_STATE yy_scan_string (const char * yystr )
 {
     
-	return yy_scan_bytes(yystr,strlen(yystr) );
+	return yy_scan_bytes( yystr, (int) strlen(yystr) );
 }
 
 /** Setup the input buffer state to scan the given bytes. The next call to yylex() will
@@ -2126,16 +2121,16 @@ YY_BUFFER_STATE yy_scan_string (yyconst char * yystr )
  * 
  * @return the newly allocated buffer state object.
  */
-YY_BUFFER_STATE yy_scan_bytes  (yyconst char * yybytes, yy_size_t  _yybytes_len )
+YY_BUFFER_STATE yy_scan_bytes  (const char * yybytes, int  _yybytes_len )
 {
 	YY_BUFFER_STATE b;
 	char *buf;
 	yy_size_t n;
-	yy_size_t i;
+	int i;
     
 	/* Get memory for full buffer, including space for trailing EOB's. */
-	n = _yybytes_len + 2;
-	buf = (char *) yyalloc(n  );
+	n = (yy_size_t) (_yybytes_len + 2);
+	buf = (char *) yyalloc( n  );
 	if ( ! buf )
 		YY_FATAL_ERROR( "out of dynamic memory in yy_scan_bytes()" );
 
@@ -2144,7 +2139,7 @@ YY_BUFFER_STATE yy_scan_bytes  (yyconst char * yybytes, yy_size_t  _yybytes_len 
 
 	buf[_yybytes_len] = buf[_yybytes_len+1] = YY_END_OF_BUFFER_CHAR;
 
-	b = yy_scan_buffer(buf,n );
+	b = yy_scan_buffer( buf, n );
 	if ( ! b )
 		YY_FATAL_ERROR( "bad buffer in yy_scan_bytes()" );
 
@@ -2160,9 +2155,9 @@ YY_BUFFER_STATE yy_scan_bytes  (yyconst char * yybytes, yy_size_t  _yybytes_len 
 #define YY_EXIT_FAILURE 2
 #endif
 
-static void yy_fatal_error (yyconst char* msg )
+static void yynoreturn yy_fatal_error (const char* msg )
 {
-			(void) fprintf( stderr, "%s\n", msg );
+			fprintf( stderr, "%s\n", msg );
 	exit( YY_EXIT_FAILURE );
 }
 
@@ -2183,19 +2178,19 @@ static void yy_fatal_error (yyconst char* msg )
 		} \
 	while ( 0 )
 
-/* Accessor methods (get/set functions) to struct members. */
+/* Accessor  methods (get/set functions) to struct members. */
 
 /** Get the current line number.
- *
+ * 
  */
 int yyget_lineno  (void)
 {
-
+    
     return yylineno;
 }
 
 /** Get the input stream.
- *
+ * 
  */
 FILE *yyget_in  (void)
 {
@@ -2213,7 +2208,7 @@ FILE *yyget_out  (void)
 /** Get the length of the current token.
  * 
  */
-yy_size_t yyget_leng  (void)
+int yyget_leng  (void)
 {
         return yyleng;
 }
@@ -2269,10 +2264,10 @@ static int yy_init_globals (void)
      * This function is called from yylex_destroy(), so don't allocate here.
      */
 
-    (yy_buffer_stack) = 0;
+    (yy_buffer_stack) = NULL;
     (yy_buffer_stack_top) = 0;
     (yy_buffer_stack_max) = 0;
-    (yy_c_buf_p) = (char *) 0;
+    (yy_c_buf_p) = NULL;
     (yy_init) = 0;
     (yy_start) = 0;
 
@@ -2281,8 +2276,8 @@ static int yy_init_globals (void)
     yyin = stdin;
     yyout = stdout;
 #else
-    yyin = (FILE *) 0;
-    yyout = (FILE *) 0;
+    yyin = NULL;
+    yyout = NULL;
 #endif
 
     /* For future reference: Set errno on error, since we are called by
@@ -2297,7 +2292,7 @@ int yylex_destroy  (void)
     
     /* Pop the buffer stack, destroying each element. */
 	while(YY_CURRENT_BUFFER){
-		yy_delete_buffer(YY_CURRENT_BUFFER  );
+		yy_delete_buffer( YY_CURRENT_BUFFER  );
 		YY_CURRENT_BUFFER_LVALUE = NULL;
 		yypop_buffer_state();
 	}
@@ -2318,7 +2313,7 @@ int yylex_destroy  (void)
  */
 
 #ifndef yytext_ptr
-static void yy_flex_strncpy (char* s1, yyconst char * s2, int n )
+static void yy_flex_strncpy (char* s1, const char * s2, int n )
 {
 		
 	int i;
@@ -2328,7 +2323,7 @@ static void yy_flex_strncpy (char* s1, yyconst char * s2, int n )
 #endif
 
 #ifdef YY_NEED_STRLEN
-static int yy_flex_strlen (yyconst char * s )
+static int yy_flex_strlen (const char * s )
 {
 	int n;
 	for ( n = 0; s[n]; ++n )
@@ -2340,7 +2335,7 @@ static int yy_flex_strlen (yyconst char * s )
 
 void *yyalloc (yy_size_t  size )
 {
-			return (void *) malloc( size );
+			return malloc(size);
 }
 
 void *yyrealloc  (void * ptr, yy_size_t  size )
@@ -2353,7 +2348,7 @@ void *yyrealloc  (void * ptr, yy_size_t  size )
 	 * any pointer type to void*, and deal with argument conversions
 	 * as though doing an assignment.
 	 */
-	return (void *) realloc( (char *) ptr, size );
+	return realloc(ptr, size);
 }
 
 void yyfree (void * ptr )
@@ -2363,4 +2358,4 @@ void yyfree (void * ptr )
 
 #define YYTABLES_NAME "yytables"
 
-#line 163 "QuantityParser.l"
+#line 166 "<stdin>"

--- a/src/Base/QuantityParser.c
+++ b/src/Base/QuantityParser.c
@@ -108,8 +108,8 @@ extern int yydebug;
   enum yytokentype
   {
     UNIT = 258,
-    NUM = 259,
-    ONE = 260,
+    ONE = 259,
+    NUM = 260,
     MINUSSIGN = 261,
     ACOS = 262,
     ASIN = 263,
@@ -127,8 +127,7 @@ extern int yydebug;
     TAN = 275,
     TANH = 276,
     SQRT = 277,
-    RECIPROCALSLASH = 278,
-    NEG = 279
+    NEG = 278
   };
 #endif
 
@@ -148,7 +147,7 @@ int yyparse (void);
 
 /* Copy the second part of user declarations.  */
 
-#line 152 "QuantityParser.c" /* yacc.c:358  */
+#line 151 "QuantityParser.c" /* yacc.c:358  */
 
 #ifdef short
 # undef short
@@ -390,21 +389,21 @@ union yyalloc
 /* YYFINAL -- State number of the termination state.  */
 #define YYFINAL  42
 /* YYLAST -- Last index in YYTABLE.  */
-#define YYLAST   245
+#define YYLAST   236
 
 /* YYNTOKENS -- Number of terminals.  */
-#define YYNTOKENS  31
+#define YYNTOKENS  30
 /* YYNNTS -- Number of nonterminals.  */
 #define YYNNTS  5
 /* YYNRULES -- Number of rules.  */
-#define YYNRULES  35
+#define YYNRULES  36
 /* YYNSTATES -- Number of states.  */
-#define YYNSTATES  93
+#define YYNSTATES  94
 
 /* YYTRANSLATE[YYX] -- Symbol number corresponding to YYX as returned
    by yylex, with out-of-bounds checking.  */
 #define YYUNDEFTOK  2
-#define YYMAXUTOK   279
+#define YYMAXUTOK   278
 
 #define YYTRANSLATE(YYX)                                                \
   ((unsigned int) (YYX) <= YYMAXUTOK ? yytranslate[YYX] : YYUNDEFTOK)
@@ -417,12 +416,12 @@ static const yytype_uint8 yytranslate[] =
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
-      29,    30,    25,    23,     2,     2,     2,    26,     2,     2,
+      28,    29,    24,    23,     2,     2,     2,    25,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
-       2,     2,     2,     2,    28,     2,     2,     2,     2,     2,
+       2,     2,     2,     2,    27,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
@@ -440,17 +439,17 @@ static const yytype_uint8 yytranslate[] =
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     1,     2,     3,     4,
        5,     6,     7,     8,     9,    10,    11,    12,    13,    14,
-      15,    16,    17,    18,    19,    20,    21,    22,    24,    27
+      15,    16,    17,    18,    19,    20,    21,    22,    26
 };
 
 #if YYDEBUG
   /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
 static const yytype_uint8 yyrline[] =
 {
-       0,    34,    34,    35,    36,    37,    38,    40,    41,    42,
+       0,    34,    34,    35,    36,    37,    38,    39,    41,    42,
       43,    44,    45,    46,    47,    48,    49,    50,    51,    52,
-      53,    54,    55,    56,    57,    58,    59,    60,    61,    63,
-      64,    65,    66,    67,    68,    70
+      53,    54,    55,    56,    57,    58,    59,    60,    61,    62,
+      65,    66,    67,    68,    69,    70,    72
 };
 #endif
 
@@ -459,11 +458,11 @@ static const yytype_uint8 yyrline[] =
    First, the terminals, then, starting at YYNTOKENS, nonterminals.  */
 static const char *const yytname[] =
 {
-  "$end", "error", "$undefined", "UNIT", "NUM", "ONE", "MINUSSIGN",
+  "$end", "error", "$undefined", "UNIT", "ONE", "NUM", "MINUSSIGN",
   "ACOS", "ASIN", "ATAN", "ATAN2", "COS", "EXP", "ABS", "MOD", "LOG",
-  "LOG10", "POW", "SIN", "SINH", "TAN", "TANH", "SQRT", "'+'",
-  "RECIPROCALSLASH", "'*'", "'/'", "NEG", "'^'", "'('", "')'", "$accept",
-  "input", "num", "unit", "quantity", YY_NULLPTR
+  "LOG10", "POW", "SIN", "SINH", "TAN", "TANH", "SQRT", "'+'", "'*'",
+  "'/'", "NEG", "'^'", "'('", "')'", "$accept", "input", "num", "unit",
+  "quantity", YY_NULLPTR
 };
 #endif
 
@@ -474,15 +473,14 @@ static const yytype_uint16 yytoknum[] =
 {
        0,   256,   257,   258,   259,   260,   261,   262,   263,   264,
      265,   266,   267,   268,   269,   270,   271,   272,   273,   274,
-     275,   276,   277,    43,   278,    42,    47,   279,    94,    40,
-      41
+     275,   276,   277,    43,    42,    47,   278,    94,    40,    41
 };
 # endif
 
-#define YYPACT_NINF -22
+#define YYPACT_NINF -26
 
 #define yypact_value_is_default(Yystate) \
-  (!!((Yystate) == (-22)))
+  (!!((Yystate) == (-26)))
 
 #define YYTABLE_NINF -1
 
@@ -493,16 +491,16 @@ static const yytype_uint16 yytoknum[] =
      STATE-NUM.  */
 static const yytype_int16 yypact[] =
 {
-      53,   -22,   -22,   -22,    99,   -19,   -12,    -8,    -7,    -4,
-      -3,    -1,    13,    14,    15,    16,    24,    34,    53,    19,
-      73,   -14,    99,    -2,   -22,    99,    42,    99,    99,    99,
-      99,    99,    99,    99,    99,    99,    99,    99,    99,    99,
-      61,   -21,   -22,    51,    99,    99,    99,    99,    99,    -2,
-     -14,    -2,    -2,    99,    73,   -22,    52,   107,   116,   125,
-     134,   143,   152,   161,   170,   179,   188,   197,   206,   215,
-     -22,   -22,   -10,   -10,    42,    42,    42,    52,    52,   -15,
-     -22,   -22,   -22,   -22,   -22,   -22,   -22,   -22,   -22,   -22,
-     -22,   -22,   -22
+      72,   -26,   -26,   -26,   117,   -25,   -23,   -10,    -7,    -5,
+      -4,    -3,    21,    22,    23,    24,    26,    28,    72,    57,
+      92,   -12,   117,    -2,   -26,   117,    31,   117,   117,   117,
+     117,   117,   117,   117,   117,   117,   117,   117,   117,   117,
+      36,   -18,   -26,    37,   117,   117,   117,   117,   117,    -2,
+     -12,    -2,    -2,   117,    92,   117,    39,    80,   125,   134,
+     141,   149,   156,   163,   171,   178,   185,   193,   200,   207,
+     -26,   -26,    -8,    -8,    31,    31,    31,    39,    39,   -13,
+     -26,   -26,   -26,   -26,   -26,   -26,   -26,   -26,   -26,   -26,
+     -26,   -26,   -26,   -26
 };
 
   /* YYDEFACT[STATE-NUM] -- Default reduction number in state STATE-NUM.
@@ -510,22 +508,22 @@ static const yytype_int16 yypact[] =
      means the default is an error.  */
 static const yytype_uint8 yydefact[] =
 {
-       2,    29,     7,     8,     0,     0,     0,     0,     0,     0,
+       2,    30,     9,     8,     0,     0,     0,     0,     0,     0,
        0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       3,     4,     5,     0,     8,     0,    13,     0,     0,     0,
+       3,     4,     5,     0,     9,     0,    14,     0,     0,     0,
        0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
        0,     0,     1,     0,     0,     0,     0,     0,     0,     0,
-      35,     0,     0,     0,     0,     6,    30,     0,     0,     0,
+      36,     0,     0,     0,     0,     6,    31,     0,     0,     0,
        0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-      15,    34,    10,     9,    11,    12,    14,    31,    32,    33,
-      16,    17,    18,    28,    20,    19,    21,    22,    23,    24,
-      25,    26,    27
+      16,    35,    11,    10,    12,    13,    15,    32,    33,    34,
+       7,    17,    18,    19,    29,    21,    20,    22,    23,    24,
+      25,    26,    27,    28
 };
 
   /* YYPGOTO[NTERM-NUM].  */
 static const yytype_int8 yypgoto[] =
 {
-     -22,   -22,     2,     0,    59
+     -26,   -26,     0,    20,   -14
 };
 
   /* YYDEFGOTO[NTERM-NUM].  */
@@ -539,60 +537,58 @@ static const yytype_int8 yydefgoto[] =
      number is the opposite.  If YYTABLE_NINF, syntax error.  */
 static const yytype_uint8 yytable[] =
 {
-      21,     1,    20,    43,    51,    52,    26,    53,    45,    71,
-      27,    51,    52,    48,    53,    46,    47,    28,    48,    42,
-      50,    29,    30,    56,    54,    31,    32,    49,    33,    57,
-      58,    59,    60,    61,    62,    63,    64,    65,    66,    67,
-      68,    69,    34,    35,    36,    37,    72,    73,    74,    75,
-      76,    77,    78,    38,    50,    79,     1,     2,     3,     4,
-       5,     6,     7,    39,     8,     9,    10,    44,    11,    12,
-      48,    13,    14,    15,    16,    17,     1,    23,    43,    44,
-      53,    55,    18,     0,    45,     0,    46,    47,     0,    48,
-       0,    70,     0,     0,     0,     0,    45,     0,    46,    47,
-       0,    48,    49,     2,    24,     4,     5,     6,     7,     0,
-       8,     9,    10,    44,    11,    12,     0,    13,    14,    15,
-      16,    17,    44,     0,     0,     0,     0,     0,    25,     0,
-      45,    44,    46,    47,     0,    48,     0,    80,     0,    45,
-      44,    46,    47,     0,    48,     0,    81,     0,    45,    44,
-      46,    47,     0,    48,     0,    82,     0,    45,    44,    46,
-      47,     0,    48,     0,    83,     0,    45,    44,    46,    47,
-       0,    48,     0,    84,     0,    45,    44,    46,    47,     0,
-      48,     0,    85,     0,    45,    44,    46,    47,     0,    48,
-       0,    86,     0,    45,    44,    46,    47,     0,    48,     0,
-      87,     0,    45,    44,    46,    47,     0,    48,     0,    88,
-       0,    45,    44,    46,    47,     0,    48,     0,    89,     0,
-      45,    44,    46,    47,     0,    48,     0,    90,     0,    45,
-       0,    46,    47,     0,    48,     0,    91,     0,    45,     0,
-      46,    47,     0,    48,     0,    92
+      20,     1,    43,    27,    26,    28,    51,    52,    55,    53,
+      45,    71,    51,    52,    48,    53,    46,    47,    29,    48,
+      21,    30,    54,    31,    32,    33,    49,    57,    58,    59,
+      60,    61,    62,    63,    64,    65,    66,    67,    68,    69,
+      50,    80,    44,    56,    72,    73,    74,    75,    76,    34,
+      35,    36,    37,    79,    38,    54,    39,    42,    48,    45,
+      46,    47,    23,    48,     0,    70,    53,     0,     0,     0,
+       0,    77,    78,     0,    50,     1,     2,     3,     4,     5,
+       6,     7,     0,     8,     9,    10,    44,    11,    12,     0,
+      13,    14,    15,    16,    17,     1,    43,     0,    44,     0,
+      18,     0,     0,    45,    46,    47,     0,    48,     0,    81,
+       0,     0,     0,     0,     0,    45,    46,    47,     0,    48,
+      49,    24,     3,     4,     5,     6,     7,     0,     8,     9,
+      10,    44,    11,    12,     0,    13,    14,    15,    16,    17,
+      44,     0,     0,     0,     0,    25,     0,    44,    45,    46,
+      47,     0,    48,     0,    82,    44,     0,    45,    46,    47,
+       0,    48,    44,    83,    45,    46,    47,     0,    48,    44,
+      84,     0,    45,    46,    47,     0,    48,    44,    85,    45,
+      46,    47,     0,    48,    44,    86,    45,    46,    47,     0,
+      48,    44,    87,     0,    45,    46,    47,     0,    48,    44,
+      88,    45,    46,    47,     0,    48,    44,    89,    45,    46,
+      47,     0,    48,    44,    90,     0,    45,    46,    47,     0,
+      48,     0,    91,    45,    46,    47,     0,    48,     0,    92,
+      45,    46,    47,     0,    48,     0,    93
 };
 
 static const yytype_int8 yycheck[] =
 {
-       0,     3,     0,     5,    25,    26,     4,    28,    23,    30,
-      29,    25,    26,    28,    28,    25,    26,    29,    28,     0,
-      20,    29,    29,    23,    22,    29,    29,    29,    29,    27,
-      28,    29,    30,    31,    32,    33,    34,    35,    36,    37,
-      38,    39,    29,    29,    29,    29,    44,    45,    46,    47,
-      48,    51,    52,    29,    54,    53,     3,     4,     5,     6,
-       7,     8,     9,    29,    11,    12,    13,     6,    15,    16,
-      28,    18,    19,    20,    21,    22,     3,    26,     5,     6,
-      28,    22,    29,    -1,    23,    -1,    25,    26,    -1,    28,
-      -1,    30,    -1,    -1,    -1,    -1,    23,    -1,    25,    26,
-      -1,    28,    29,     4,     5,     6,     7,     8,     9,    -1,
-      11,    12,    13,     6,    15,    16,    -1,    18,    19,    20,
-      21,    22,     6,    -1,    -1,    -1,    -1,    -1,    29,    -1,
-      23,     6,    25,    26,    -1,    28,    -1,    30,    -1,    23,
-       6,    25,    26,    -1,    28,    -1,    30,    -1,    23,     6,
-      25,    26,    -1,    28,    -1,    30,    -1,    23,     6,    25,
-      26,    -1,    28,    -1,    30,    -1,    23,     6,    25,    26,
-      -1,    28,    -1,    30,    -1,    23,     6,    25,    26,    -1,
-      28,    -1,    30,    -1,    23,     6,    25,    26,    -1,    28,
-      -1,    30,    -1,    23,     6,    25,    26,    -1,    28,    -1,
-      30,    -1,    23,     6,    25,    26,    -1,    28,    -1,    30,
-      -1,    23,     6,    25,    26,    -1,    28,    -1,    30,    -1,
-      23,     6,    25,    26,    -1,    28,    -1,    30,    -1,    23,
-      -1,    25,    26,    -1,    28,    -1,    30,    -1,    23,    -1,
-      25,    26,    -1,    28,    -1,    30
+       0,     3,     4,    28,     4,    28,    24,    25,    22,    27,
+      23,    29,    24,    25,    27,    27,    24,    25,    28,    27,
+       0,    28,    22,    28,    28,    28,    28,    27,    28,    29,
+      30,    31,    32,    33,    34,    35,    36,    37,    38,    39,
+      20,    55,     6,    23,    44,    45,    46,    47,    48,    28,
+      28,    28,    28,    53,    28,    55,    28,     0,    27,    23,
+      24,    25,    25,    27,    -1,    29,    27,    -1,    -1,    -1,
+      -1,    51,    52,    -1,    54,     3,     4,     5,     6,     7,
+       8,     9,    -1,    11,    12,    13,     6,    15,    16,    -1,
+      18,    19,    20,    21,    22,     3,     4,    -1,     6,    -1,
+      28,    -1,    -1,    23,    24,    25,    -1,    27,    -1,    29,
+      -1,    -1,    -1,    -1,    -1,    23,    24,    25,    -1,    27,
+      28,     4,     5,     6,     7,     8,     9,    -1,    11,    12,
+      13,     6,    15,    16,    -1,    18,    19,    20,    21,    22,
+       6,    -1,    -1,    -1,    -1,    28,    -1,     6,    23,    24,
+      25,    -1,    27,    -1,    29,     6,    -1,    23,    24,    25,
+      -1,    27,     6,    29,    23,    24,    25,    -1,    27,     6,
+      29,    -1,    23,    24,    25,    -1,    27,     6,    29,    23,
+      24,    25,    -1,    27,     6,    29,    23,    24,    25,    -1,
+      27,     6,    29,    -1,    23,    24,    25,    -1,    27,     6,
+      29,    23,    24,    25,    -1,    27,     6,    29,    23,    24,
+      25,    -1,    27,     6,    29,    -1,    23,    24,    25,    -1,
+      27,    -1,    29,    23,    24,    25,    -1,    27,    -1,    29,
+      23,    24,    25,    -1,    27,    -1,    29
 };
 
   /* YYSTOS[STATE-NUM] -- The (internal number of the) accessing
@@ -600,33 +596,33 @@ static const yytype_int8 yycheck[] =
 static const yytype_uint8 yystos[] =
 {
        0,     3,     4,     5,     6,     7,     8,     9,    11,    12,
-      13,    15,    16,    18,    19,    20,    21,    22,    29,    32,
-      33,    34,    35,    26,     5,    29,    33,    29,    29,    29,
-      29,    29,    29,    29,    29,    29,    29,    29,    29,    29,
-      33,    34,     0,     5,     6,    23,    25,    26,    28,    29,
-      34,    25,    26,    28,    33,    35,    34,    33,    33,    33,
-      33,    33,    33,    33,    33,    33,    33,    33,    33,    33,
-      30,    30,    33,    33,    33,    33,    33,    34,    34,    33,
-      30,    30,    30,    30,    30,    30,    30,    30,    30,    30,
-      30,    30,    30
+      13,    15,    16,    18,    19,    20,    21,    22,    28,    31,
+      32,    33,    34,    25,     4,    28,    32,    28,    28,    28,
+      28,    28,    28,    28,    28,    28,    28,    28,    28,    28,
+      32,    33,     0,     4,     6,    23,    24,    25,    27,    28,
+      33,    24,    25,    27,    32,    34,    33,    32,    32,    32,
+      32,    32,    32,    32,    32,    32,    32,    32,    32,    32,
+      29,    29,    32,    32,    32,    32,    32,    33,    33,    32,
+      34,    29,    29,    29,    29,    29,    29,    29,    29,    29,
+      29,    29,    29,    29
 };
 
   /* YYR1[YYN] -- Symbol number of symbol that rule YYN derives.  */
 static const yytype_uint8 yyr1[] =
 {
-       0,    31,    32,    32,    32,    32,    32,    33,    33,    33,
-      33,    33,    33,    33,    33,    33,    33,    33,    33,    33,
-      33,    33,    33,    33,    33,    33,    33,    33,    33,    34,
-      34,    34,    34,    34,    34,    35
+       0,    30,    31,    31,    31,    31,    31,    31,    32,    32,
+      32,    32,    32,    32,    32,    32,    32,    32,    32,    32,
+      32,    32,    32,    32,    32,    32,    32,    32,    32,    32,
+      33,    33,    33,    33,    33,    33,    34
 };
 
   /* YYR2[YYN] -- Number of symbols on the right hand side of rule YYN.  */
 static const yytype_uint8 yyr2[] =
 {
-       0,     2,     0,     1,     1,     1,     2,     1,     1,     3,
-       3,     3,     3,     2,     3,     3,     4,     4,     4,     4,
-       4,     4,     4,     4,     4,     4,     4,     4,     4,     1,
-       3,     3,     3,     3,     3,     2
+       0,     2,     0,     1,     1,     1,     2,     3,     1,     1,
+       3,     3,     3,     3,     2,     3,     3,     4,     4,     4,
+       4,     4,     4,     4,     4,     4,     4,     4,     4,     4,
+       1,     3,     3,     3,     3,     3,     2
 };
 
 
@@ -1305,209 +1301,215 @@ yyreduce:
         case 2:
 #line 34 "QuantityParser.y" /* yacc.c:1646  */
     { QuantResult = Quantity(DOUBLE_MIN); /* empty input */ }
-#line 1309 "QuantityParser.c" /* yacc.c:1646  */
+#line 1305 "QuantityParser.c" /* yacc.c:1646  */
     break;
 
   case 3:
 #line 35 "QuantityParser.y" /* yacc.c:1646  */
     { QuantResult = (yyvsp[0])     ;            }
-#line 1315 "QuantityParser.c" /* yacc.c:1646  */
+#line 1311 "QuantityParser.c" /* yacc.c:1646  */
     break;
 
   case 4:
 #line 36 "QuantityParser.y" /* yacc.c:1646  */
     { QuantResult = (yyvsp[0])     ;            }
-#line 1321 "QuantityParser.c" /* yacc.c:1646  */
+#line 1317 "QuantityParser.c" /* yacc.c:1646  */
     break;
 
   case 5:
 #line 37 "QuantityParser.y" /* yacc.c:1646  */
     { QuantResult = (yyvsp[0])     ;            }
-#line 1327 "QuantityParser.c" /* yacc.c:1646  */
+#line 1323 "QuantityParser.c" /* yacc.c:1646  */
     break;
 
   case 6:
 #line 38 "QuantityParser.y" /* yacc.c:1646  */
     { QuantResult = (yyvsp[-1]) + (yyvsp[0]);            }
-#line 1333 "QuantityParser.c" /* yacc.c:1646  */
+#line 1329 "QuantityParser.c" /* yacc.c:1646  */
     break;
 
   case 7:
-#line 40 "QuantityParser.y" /* yacc.c:1646  */
-    { (yyval) = (yyvsp[0]);         	}
-#line 1339 "QuantityParser.c" /* yacc.c:1646  */
+#line 39 "QuantityParser.y" /* yacc.c:1646  */
+    { QuantResult = (yyvsp[-2]) + (yyvsp[-1]) + (yyvsp[0]);       }
+#line 1335 "QuantityParser.c" /* yacc.c:1646  */
     break;
 
   case 8:
 #line 41 "QuantityParser.y" /* yacc.c:1646  */
-    { (yyval) = (yyvsp[0]);          }
-#line 1345 "QuantityParser.c" /* yacc.c:1646  */
+    { (yyval) = (yyvsp[0]);         	}
+#line 1341 "QuantityParser.c" /* yacc.c:1646  */
     break;
 
   case 9:
 #line 42 "QuantityParser.y" /* yacc.c:1646  */
-    { (yyval) = Quantity((yyvsp[-2]).getValue() + (yyvsp[0]).getValue());    	}
-#line 1351 "QuantityParser.c" /* yacc.c:1646  */
+    { (yyval) = (yyvsp[0]);         	}
+#line 1347 "QuantityParser.c" /* yacc.c:1646  */
     break;
 
   case 10:
 #line 43 "QuantityParser.y" /* yacc.c:1646  */
-    { (yyval) = Quantity((yyvsp[-2]).getValue() - (yyvsp[0]).getValue());    	}
-#line 1357 "QuantityParser.c" /* yacc.c:1646  */
+    { (yyval) = Quantity((yyvsp[-2]).getValue() + (yyvsp[0]).getValue());    	}
+#line 1353 "QuantityParser.c" /* yacc.c:1646  */
     break;
 
   case 11:
 #line 44 "QuantityParser.y" /* yacc.c:1646  */
-    { (yyval) = Quantity((yyvsp[-2]).getValue() * (yyvsp[0]).getValue());    	}
-#line 1363 "QuantityParser.c" /* yacc.c:1646  */
+    { (yyval) = Quantity((yyvsp[-2]).getValue() - (yyvsp[0]).getValue());    	}
+#line 1359 "QuantityParser.c" /* yacc.c:1646  */
     break;
 
   case 12:
 #line 45 "QuantityParser.y" /* yacc.c:1646  */
-    { (yyval) = Quantity((yyvsp[-2]).getValue() / (yyvsp[0]).getValue());    	}
-#line 1369 "QuantityParser.c" /* yacc.c:1646  */
+    { (yyval) = Quantity((yyvsp[-2]).getValue() * (yyvsp[0]).getValue());    	}
+#line 1365 "QuantityParser.c" /* yacc.c:1646  */
     break;
 
   case 13:
 #line 46 "QuantityParser.y" /* yacc.c:1646  */
-    { (yyval) = Quantity(-(yyvsp[0]).getValue());        	}
-#line 1375 "QuantityParser.c" /* yacc.c:1646  */
+    { (yyval) = Quantity((yyvsp[-2]).getValue() / (yyvsp[0]).getValue());    	}
+#line 1371 "QuantityParser.c" /* yacc.c:1646  */
     break;
 
   case 14:
 #line 47 "QuantityParser.y" /* yacc.c:1646  */
-    { (yyval) = Quantity(pow ((yyvsp[-2]).getValue(), (yyvsp[0]).getValue()));}
-#line 1381 "QuantityParser.c" /* yacc.c:1646  */
+    { (yyval) = Quantity(-(yyvsp[0]).getValue());                    }
+#line 1377 "QuantityParser.c" /* yacc.c:1646  */
     break;
 
   case 15:
 #line 48 "QuantityParser.y" /* yacc.c:1646  */
-    { (yyval) = (yyvsp[-1]);         	}
-#line 1387 "QuantityParser.c" /* yacc.c:1646  */
+    { (yyval) = Quantity(pow ((yyvsp[-2]).getValue(), (yyvsp[0]).getValue()));}
+#line 1383 "QuantityParser.c" /* yacc.c:1646  */
     break;
 
   case 16:
 #line 49 "QuantityParser.y" /* yacc.c:1646  */
-    { (yyval) = Quantity(acos((yyvsp[-1]).getValue()));   	}
-#line 1393 "QuantityParser.c" /* yacc.c:1646  */
+    { (yyval) = (yyvsp[-1]);         	}
+#line 1389 "QuantityParser.c" /* yacc.c:1646  */
     break;
 
   case 17:
 #line 50 "QuantityParser.y" /* yacc.c:1646  */
-    { (yyval) = Quantity(asin((yyvsp[-1]).getValue()));   	}
-#line 1399 "QuantityParser.c" /* yacc.c:1646  */
+    { (yyval) = Quantity(acos((yyvsp[-1]).getValue()));   }
+#line 1395 "QuantityParser.c" /* yacc.c:1646  */
     break;
 
   case 18:
 #line 51 "QuantityParser.y" /* yacc.c:1646  */
-    { (yyval) = Quantity(atan((yyvsp[-1]).getValue()));   	}
-#line 1405 "QuantityParser.c" /* yacc.c:1646  */
+    { (yyval) = Quantity(asin((yyvsp[-1]).getValue()));   }
+#line 1401 "QuantityParser.c" /* yacc.c:1646  */
     break;
 
   case 19:
 #line 52 "QuantityParser.y" /* yacc.c:1646  */
-    { (yyval) = Quantity(fabs((yyvsp[-1]).getValue()));   	}
-#line 1411 "QuantityParser.c" /* yacc.c:1646  */
+    { (yyval) = Quantity(atan((yyvsp[-1]).getValue()));   }
+#line 1407 "QuantityParser.c" /* yacc.c:1646  */
     break;
 
   case 20:
 #line 53 "QuantityParser.y" /* yacc.c:1646  */
-    { (yyval) = Quantity(exp((yyvsp[-1]).getValue()));    	}
-#line 1417 "QuantityParser.c" /* yacc.c:1646  */
+    { (yyval) = Quantity(fabs((yyvsp[-1]).getValue()));   }
+#line 1413 "QuantityParser.c" /* yacc.c:1646  */
     break;
 
   case 21:
 #line 54 "QuantityParser.y" /* yacc.c:1646  */
-    { (yyval) = Quantity(log((yyvsp[-1]).getValue()));     }
-#line 1423 "QuantityParser.c" /* yacc.c:1646  */
+    { (yyval) = Quantity(exp((yyvsp[-1]).getValue()));    }
+#line 1419 "QuantityParser.c" /* yacc.c:1646  */
     break;
 
   case 22:
 #line 55 "QuantityParser.y" /* yacc.c:1646  */
-    { (yyval) = Quantity(log10((yyvsp[-1]).getValue()));   }
-#line 1429 "QuantityParser.c" /* yacc.c:1646  */
+    { (yyval) = Quantity(log((yyvsp[-1]).getValue()));    }
+#line 1425 "QuantityParser.c" /* yacc.c:1646  */
     break;
 
   case 23:
 #line 56 "QuantityParser.y" /* yacc.c:1646  */
-    { (yyval) = Quantity(sin((yyvsp[-1]).getValue()));     }
-#line 1435 "QuantityParser.c" /* yacc.c:1646  */
+    { (yyval) = Quantity(log10((yyvsp[-1]).getValue()));  }
+#line 1431 "QuantityParser.c" /* yacc.c:1646  */
     break;
 
   case 24:
 #line 57 "QuantityParser.y" /* yacc.c:1646  */
-    { (yyval) = Quantity(sinh((yyvsp[-1]).getValue()));    }
-#line 1441 "QuantityParser.c" /* yacc.c:1646  */
+    { (yyval) = Quantity(sin((yyvsp[-1]).getValue()));    }
+#line 1437 "QuantityParser.c" /* yacc.c:1646  */
     break;
 
   case 25:
 #line 58 "QuantityParser.y" /* yacc.c:1646  */
-    { (yyval) = Quantity(tan((yyvsp[-1]).getValue()));     }
-#line 1447 "QuantityParser.c" /* yacc.c:1646  */
+    { (yyval) = Quantity(sinh((yyvsp[-1]).getValue()));   }
+#line 1443 "QuantityParser.c" /* yacc.c:1646  */
     break;
 
   case 26:
 #line 59 "QuantityParser.y" /* yacc.c:1646  */
-    { (yyval) = Quantity(tanh((yyvsp[-1]).getValue()));    }
-#line 1453 "QuantityParser.c" /* yacc.c:1646  */
+    { (yyval) = Quantity(tan((yyvsp[-1]).getValue()));    }
+#line 1449 "QuantityParser.c" /* yacc.c:1646  */
     break;
 
   case 27:
 #line 60 "QuantityParser.y" /* yacc.c:1646  */
-    { (yyval) = Quantity(sqrt((yyvsp[-1]).getValue()));    }
-#line 1459 "QuantityParser.c" /* yacc.c:1646  */
+    { (yyval) = Quantity(tanh((yyvsp[-1]).getValue()));   }
+#line 1455 "QuantityParser.c" /* yacc.c:1646  */
     break;
 
   case 28:
 #line 61 "QuantityParser.y" /* yacc.c:1646  */
-    { (yyval) = Quantity(cos((yyvsp[-1]).getValue()));    }
-#line 1465 "QuantityParser.c" /* yacc.c:1646  */
+    { (yyval) = Quantity(sqrt((yyvsp[-1]).getValue()));   }
+#line 1461 "QuantityParser.c" /* yacc.c:1646  */
     break;
 
   case 29:
-#line 63 "QuantityParser.y" /* yacc.c:1646  */
-    { (yyval) = (yyvsp[0]);         	                }
-#line 1471 "QuantityParser.c" /* yacc.c:1646  */
+#line 62 "QuantityParser.y" /* yacc.c:1646  */
+    { (yyval) = Quantity(cos((yyvsp[-1]).getValue()));    }
+#line 1467 "QuantityParser.c" /* yacc.c:1646  */
     break;
 
   case 30:
-#line 64 "QuantityParser.y" /* yacc.c:1646  */
-    { (yyval) = Quantity(1.0)/(yyvsp[0]);     	    }
-#line 1477 "QuantityParser.c" /* yacc.c:1646  */
+#line 65 "QuantityParser.y" /* yacc.c:1646  */
+    { (yyval) = (yyvsp[0]);         	                }
+#line 1473 "QuantityParser.c" /* yacc.c:1646  */
     break;
 
   case 31:
-#line 65 "QuantityParser.y" /* yacc.c:1646  */
-    { (yyval) = (yyvsp[-2]) * (yyvsp[0]);    	                }
-#line 1483 "QuantityParser.c" /* yacc.c:1646  */
+#line 66 "QuantityParser.y" /* yacc.c:1646  */
+    { (yyval) = Quantity(1.0)/(yyvsp[0]);  	        }
+#line 1479 "QuantityParser.c" /* yacc.c:1646  */
     break;
 
   case 32:
-#line 66 "QuantityParser.y" /* yacc.c:1646  */
-    { (yyval) = (yyvsp[-2]) / (yyvsp[0]);    	                }
-#line 1489 "QuantityParser.c" /* yacc.c:1646  */
+#line 67 "QuantityParser.y" /* yacc.c:1646  */
+    { (yyval) = (yyvsp[-2]) * (yyvsp[0]);    	                }
+#line 1485 "QuantityParser.c" /* yacc.c:1646  */
     break;
 
   case 33:
-#line 67 "QuantityParser.y" /* yacc.c:1646  */
-    { (yyval) = (yyvsp[-2]).pow ((yyvsp[0]));                 }
-#line 1495 "QuantityParser.c" /* yacc.c:1646  */
+#line 68 "QuantityParser.y" /* yacc.c:1646  */
+    { (yyval) = (yyvsp[-2]) / (yyvsp[0]);    	                }
+#line 1491 "QuantityParser.c" /* yacc.c:1646  */
     break;
 
   case 34:
-#line 68 "QuantityParser.y" /* yacc.c:1646  */
-    { (yyval) = (yyvsp[-1]);                          }
-#line 1501 "QuantityParser.c" /* yacc.c:1646  */
+#line 69 "QuantityParser.y" /* yacc.c:1646  */
+    { (yyval) = (yyvsp[-2]).pow ((yyvsp[0]));                 }
+#line 1497 "QuantityParser.c" /* yacc.c:1646  */
     break;
 
   case 35:
 #line 70 "QuantityParser.y" /* yacc.c:1646  */
+    { (yyval) = (yyvsp[-1]);                          }
+#line 1503 "QuantityParser.c" /* yacc.c:1646  */
+    break;
+
+  case 36:
+#line 72 "QuantityParser.y" /* yacc.c:1646  */
     { (yyval) = (yyvsp[-1])*(yyvsp[0]);    	                }
-#line 1507 "QuantityParser.c" /* yacc.c:1646  */
+#line 1509 "QuantityParser.c" /* yacc.c:1646  */
     break;
 
 
-#line 1511 "QuantityParser.c" /* yacc.c:1646  */
+#line 1513 "QuantityParser.c" /* yacc.c:1646  */
       default: break;
     }
   /* User semantic actions sometimes alter yychar, and that requires
@@ -1735,5 +1737,5 @@ yyreturn:
 #endif
   return yyresult;
 }
-#line 74 "QuantityParser.y" /* yacc.c:1906  */
+#line 76 "QuantityParser.y" /* yacc.c:1906  */
 

--- a/src/Base/QuantityParser.l
+++ b/src/Base/QuantityParser.l
@@ -132,6 +132,8 @@ CGRP     '\,'[0-9][0-9][0-9]
 "deg"      yylval = Quantity::Degree;              return UNIT; // degree         (internal standard angle)
 "rad"      yylval = Quantity::Radian;              return UNIT; // radian
 "gon"      yylval = Quantity::Gon;                 return UNIT; // gon
+"M"        yylval = Quantity::AngMinute;           return UNIT; // minute(Angular)
+"S"        yylval = Quantity::AngSecond;           return UNIT; // second(Angular) 
 
 "1"        yylval = Quantity(1.0);                 return ONE;
 {DIGIT}+"."?{DIGIT}*{EXPO}?                         {  yylval = Quantity(num_change(yytext,'.',','));return NUM;  }

--- a/src/Base/QuantityParser.y
+++ b/src/Base/QuantityParser.y
@@ -36,6 +36,7 @@
             |  unit                         { QuantResult = $1     ;            }
             |  quantity                     { QuantResult = $1     ;            }
             |  quantity quantity            { QuantResult = $1 + $2;            }
+            |  quantity quantity quantity   { QuantResult = $1 + $2 + $3;       }
  ;
      num:      NUM                			{ $$ = $1;         	}
              | ONE                			{ $$ = $1;         	}

--- a/src/Base/UnitsApi.cpp
+++ b/src/Base/UnitsApi.cpp
@@ -97,6 +97,8 @@ const char* UnitsApi::getDescription(UnitSystem system)
         return "Building US (ft-in/sqft/cuft)";
     case MmMin:
         return "Metric small parts & CNC(mm, mm/min)";
+    case ImperialCivil:
+        return "Imperial for Civil Eng (ft, ft/sec)";
     default:
         return "Unknown schema";
     }
@@ -119,6 +121,8 @@ UnitsSchema* UnitsApi::createSchema(UnitSystem s)
         return new UnitsSchemaImperialBuilding();
     case MmMin:
         return new UnitsSchemaMmMin();
+    case ImperialCivil:
+        return new UnitsSchemaImperialCivil();
     default:
         break;
     }

--- a/src/Base/UnitsSchema.h
+++ b/src/Base/UnitsSchema.h
@@ -41,6 +41,7 @@ enum UnitSystem {
     Centimeters = 4, /** All lengths in centimeters, areas and volumes in square/cubic meters */
     ImperialBuilding = 5, /** All lengths in feet + inches + fractions */
     MmMin = 6, /** Lengths in mm, Speed in mm/min. Angle in degrees. Useful for small parts & CNC */
+    ImperialCivil = 7, /** Lengths in ft, Speed in ft/sec. Used in Civil Eng in North America */
     NumUnitSystemTypes // must be the last item!
 };
 

--- a/src/Base/UnitsSchemaImperial1.cpp
+++ b/src/Base/UnitsSchemaImperial1.cpp
@@ -31,14 +31,15 @@
 
 #include <QString>
 #include <QLocale>
+#include "Console.h"
 #include "Exception.h"
 #include "UnitsApi.h"
 #include "UnitsSchemaImperial1.h"
 #include <cmath>
+#include <iomanip>
+
 
 using namespace Base;
-
-
 
 //void UnitsSchemaImperial1::setSchemaUnits(void){
 //    // here you could change the constances used by the parser (defined in Quantity.cpp)
@@ -326,3 +327,84 @@ QString UnitsSchemaImperialBuilding::schemaTranslate(const Quantity &quant, doub
 
     return toLocale(quant, factor, unitString);
 }
+
+QString UnitsSchemaImperialCivil::schemaTranslate(const Base::Quantity& quant, double &factor, QString &unitString)
+{
+//    double UnitValue = std::abs(quant.getValue());
+    Unit unit = quant.getUnit();
+    // for imperial user/programmer mind; UnitValue is in internal system, that means
+    // mm/kg/s. And all combined units have to be calculated from there!
+
+    // now do special treatment on all cases seems necessary:
+    if (unit == Unit::Length) {  // Length handling ============================
+            unitString = QString::fromLatin1("ft");  //always ft
+            factor = 304.8;      //12 * 25.4
+    }
+    else if (unit == Unit::Area) {
+        unitString = QString::fromLatin1("ft^2");    //always sq.ft
+        factor = 92903.04;
+    }
+    else if (unit == Unit::Volume) {
+        unitString = QString::fromLatin1("ft^3");    //always cu. ft
+        factor = 28316846.592;
+    }
+    else if (unit == Unit::Mass) {
+        unitString = QString::fromLatin1("lb");     //always lbs. 
+        factor = 0.45359237;
+    }
+    else if (unit == Unit::Pressure) {
+            unitString = QString::fromLatin1("psi");
+            factor = 6.894744825494;
+    }
+    else if (unit == Unit::Velocity) {
+        unitString = QString::fromLatin1("mph");
+        factor =  0.002235598;                         //1mm/sec => mph
+    }
+    // this schema expresses angles in degrees + minutes + seconds
+    else if (unit == Unit::Angle) {
+        unitString = QString::fromUtf8("deg");
+        QString degreeString = QString::fromUtf8("\xC2\xB0");
+        QString minuteString = QString::fromUtf8("M");
+        QString secondString = QString::fromUtf8("S");
+        factor = 1.0;                                  //1deg = 1"\xC2\xB0 "
+
+        double totalDegrees = std::abs(quant.getValue())/factor;
+        double wholeDegrees = std::floor(totalDegrees);
+        double sumMinutes = totalDegrees * 60.0;            //quant as minutes
+        double rawMinutes = sumMinutes - wholeDegrees * 60.0;
+        double wholeMinutes = std::floor(rawMinutes);
+        double sumSeconds = totalDegrees * 3600.0;          //quant as seconds
+        double rawSeconds = sumSeconds - (wholeDegrees * 3600.0) - (wholeMinutes * 60);
+//        double wholeSeconds = std::floor(rawSeconds);
+//        double remainSeconds = rawSeconds - wholeSeconds;
+
+        int outDeg = (int) wholeDegrees;
+        int outMin = (int) wholeMinutes;
+        int outSec = (int) std::round(rawSeconds);
+
+        std::stringstream output;
+        output << outDeg << degreeString.toUtf8().constData();
+        if ((outMin > 0) || (outSec > 0)) {
+            output << outMin << minuteString.toStdString();
+        }
+        if (outSec > 0) {
+            output << outSec << secondString.toStdString();
+        }
+// uncomment this for decimals on seconds
+//        if (remainSeconds < (1.0 * pow(10.0,-Base::UnitsApi::getDecimals())) ) {
+//            //NOP too small to display
+//        } else {
+//            output << std::setprecision(Base::UnitsApi::getDecimals()) << std::fixed <<
+//                      rawSeconds << secondString.toStdString();
+//        }
+        return QString::fromUtf8(output.str().c_str());
+    }
+    else {
+        // default action for all cases without special treatment:
+        unitString = quant.getUnit().getString();
+        factor = 1.0;
+    }
+
+    return toLocale(quant, factor, unitString);
+}
+

--- a/src/Base/UnitsSchemaImperial1.h
+++ b/src/Base/UnitsSchemaImperial1.h
@@ -68,6 +68,18 @@ public:
     virtual QString schemaTranslate(const Base::Quantity& quant, double &factor, QString &unitString);
 };
 
+/** The schema class for Civil Engineering in the imperial unit system
+ *  All measurements in ft, ft^2, ft^3, ft/sec.  
+ *  Pressure is in psi.
+ */
+class UnitsSchemaImperialCivil: public UnitsSchema
+{
+public:
+    //virtual void setSchemaUnits(void);
+    //virtual void resetSchemaUnits(void);
+    virtual QString schemaTranslate(const Base::Quantity& quant, double &factor, QString &unitString);
+};
+
 
 } // namespace Base
 

--- a/src/Gui/DlgSettingsUnits.ui
+++ b/src/Gui/DlgSettingsUnits.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>380</width>
+    <width>484</width>
     <height>388</height>
    </rect>
   </property>
@@ -98,6 +98,11 @@
           <item>
            <property name="text">
             <string>Metric small parts &amp; CNC(mm, mm/min)</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Imperial Civil (ft/ft^2/ft^3)</string>
            </property>
           </item>
          </widget>


### PR DESCRIPTION
[Forum discussion.](https://www.forum.freecadweb.org/viewtopic.php?f=8&t=32416
)
This PR adds a unit schema suitable for US civil engineering and modifies TechDraw to display those units with the correct symbols.  Unmodified modules will display angles from this schema as dd°mmMssS as the "m","s","\'" and "\"" symbols are already used for other units. 
Please merge. 
Thanks,
wf

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
