### PR TITLE
Add id=PageName to Exported Svg

### DIFF
--- a/src/Mod/TechDraw/Gui/QGVPage.h
+++ b/src/Mod/TechDraw/Gui/QGVPage.h
@@ -26,6 +26,8 @@
 #include <QGraphicsView>
 #include <QGraphicsScene>
 
+class QTemporaryFile;
+
 namespace TechDraw {
 class DrawView;
 class DrawViewPart;
@@ -100,6 +102,7 @@ public:
 
     /// Renders the page to SVG with filename.
     void saveSvg(QString filename);
+    void postProcessXml(QTemporaryFile* tempFile, QString filename, QString pagename);
 
 public Q_SLOTS:
     void setHighQualityAntialiasing(bool highQualityAntialiasing);


### PR DESCRIPTION
[Forum discussion](https://www.forum.freecadweb.org/viewtopic.php?f=35&t=32257).  This PR adds an id attribute to exported TD pages.  This makes TD pages easier to work with in Inkscape.  Please merge. 
Thanks,
wf

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
