### PR TITLE
Fix SectionLine Preference Location

### DIFF
--- a/src/Mod/TechDraw/Gui/QGISectionLine.cpp
+++ b/src/Mod/TechDraw/Gui/QGISectionLine.cpp
@@ -280,7 +280,7 @@ QColor QGISectionLine::getSectionColor()
 Qt::PenStyle QGISectionLine::getSectionStyle()
 {
     Base::Reference<ParameterGrp> hGrp = App::GetApplication().GetUserParameter().GetGroup("BaseApp")->
-                                         GetGroup("Preferences")->GetGroup("Mod/TechDraw");
+                                         GetGroup("Preferences")->GetGroup("Mod/TechDraw/Decorations");
     Qt::PenStyle sectStyle = static_cast<Qt::PenStyle> (hGrp->GetInt("SectionLine", 2));
     return sectStyle;
 }


### PR DESCRIPTION
This PR corrects a bug where QGISectionLine looks in the wrong part of the preference tree for the desired line style.  Please merge.
Thanks,
wf

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
