### PR TITLE
Thumbnail generation

### DIFF
--- a/src/Gui/View3DInventorViewer.cpp
+++ b/src/Gui/View3DInventorViewer.cpp
@@ -1517,8 +1517,13 @@ void View3DInventorViewer::imageFromFramebuffer(int width, int height, int sampl
     // format and in the output image search for the above color and
     // replaces it with the color requested by the user.
 #if defined(HAVE_QT5_OPENGL)
-    //fboFormat.setInternalTextureFormat(GL_RGBA32F_ARB);
-    fboFormat.setInternalTextureFormat(GL_RGB32F_ARB);
+    if (App::GetApplication().GetParameterGroupByPath
+        ("User parameter:BaseApp/Preferences/Document")->GetBool("SaveThumbnailFix",false)) {
+        fboFormat.setInternalTextureFormat(GL_RGBA32F_ARB);
+    }
+    else {
+        fboFormat.setInternalTextureFormat(GL_RGB32F_ARB);
+    }
 #else
     //fboFormat.setInternalTextureFormat(GL_RGBA);
     fboFormat.setInternalTextureFormat(GL_RGB);


### PR DESCRIPTION
https://forum.freecadweb.org/viewtopic.php?f=10&t=30340&p=273281#p273281

Dynamically check whether to apply the fix for thumbnail generation.

Some QT5 version seem to be affected. This problem appears in some linux distributions with some window managers.

You may check/activate this fix:

>>> hgrp = App.ParamGet("User parameter:BaseApp/Preferences/Document")
>>> hgrp.GetBool("SaveThumbnailFix")
False
>>> hgrp.SetBool("SaveThumbnailFix",True)
>>> hgrp.GetBool("SaveThumbnailFix")
True

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
