### PR TITLE
Remove reuse of variable-name.

### DIFF
--- a/src/Tools/plugins/widget/customwidgets.cpp
+++ b/src/Tools/plugins/widget/customwidgets.cpp
@@ -284,50 +284,50 @@ void AccelLineEdit::keyPressEvent ( QKeyEvent * e)
     {
     case Qt::ControlModifier:
         {
-            QKeySequence key(Qt::CTRL+key);
-            txt += key.toString(QKeySequence::NativeText);
+            QKeySequence keyseq(Qt::CTRL+key);
+            txt += keyseq.toString(QKeySequence::NativeText);
             setText(txt);
         }   break;
     case Qt::AltModifier:
         {
-            QKeySequence key(Qt::ALT+key);
-            txt += key.toString(QKeySequence::NativeText);
+            QKeySequence keyseq(Qt::ALT+key);
+            txt += keyseq.toString(QKeySequence::NativeText);
             setText(txt);
         }   break;
     case Qt::ShiftModifier:
         {
-            QKeySequence key(Qt::SHIFT+key);
-            txt += key.toString(QKeySequence::NativeText);
+            QKeySequence keyseq(Qt::SHIFT+key);
+            txt += keyseq.toString(QKeySequence::NativeText);
             setText(txt);
         }   break;
     case Qt::ControlModifier+Qt::AltModifier:
         {
-            QKeySequence key(Qt::CTRL+Qt::ALT+key);
-            txt += key.toString(QKeySequence::NativeText);
+            QKeySequence keyseq(Qt::CTRL+Qt::ALT+key);
+            txt += keyseq.toString(QKeySequence::NativeText);
             setText(txt);
         }   break;
     case Qt::ControlModifier+Qt::ShiftModifier:
         {
-            QKeySequence key(Qt::CTRL+Qt::SHIFT+key);
-            txt += key.toString(QKeySequence::NativeText);
+            QKeySequence keyseq(Qt::CTRL+Qt::SHIFT+key);
+            txt += keyseq.toString(QKeySequence::NativeText);
             setText(txt);
         }   break;
     case Qt::ShiftModifier+Qt::AltModifier:
         {
-            QKeySequence key(Qt::SHIFT+Qt::ALT+key);
-            txt += key.toString(QKeySequence::NativeText);
+            QKeySequence keyseq(Qt::SHIFT+Qt::ALT+key);
+            txt += keyseq.toString(QKeySequence::NativeText);
             setText(txt);
         }   break;
     case Qt::ControlModifier+Qt::AltModifier+Qt::ShiftModifier:
         {
-            QKeySequence key(Qt::CTRL+Qt::ALT+Qt::SHIFT+key);
-            txt += key.toString(QKeySequence::NativeText);
+            QKeySequence keyseq(Qt::CTRL+Qt::ALT+Qt::SHIFT+key);
+            txt += keyseq.toString(QKeySequence::NativeText);
             setText(txt);
         }   break;
     default:
         {
-            QKeySequence key(key);
-            txt += key.toString(QKeySequence::NativeText);
+            QKeySequence keyseq(key);
+            txt += keyseq.toString(QKeySequence::NativeText);
             setText(txt);
         }   break;
     }


### PR DESCRIPTION
customwidgets.cpp: In member function ‘virtual void Gui::AccelLineEdit::keyPressEvent(QKeyEvent*)’:
customwidgets.cpp:287:38: error: no match for ‘operator+’ (operand types are ‘Qt::Modifier’ and ‘QKeySequence’)
             QKeySequence key(Qt::CTRL+key);
                              ~~~~~~~~^~~~
In file included from /usr/include/x86_64-linux-gnu/qt5/QtGui/QtGui:38:0,
                 from customwidgets.cpp:24:

g++ (Ubuntu 7.3.0-27ubuntu1~18.04) 7.3.0

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
