### PR TITLE
Draft: preserving face colors and names when downgrading/upgrading (splitFaces and makeShell only) 

### DIFF
--- a/src/Mod/Draft/Resources/ui/preferences-draftvisual.ui
+++ b/src/Mod/Draft/Resources/ui/preferences-draftvisual.ui
@@ -353,6 +353,46 @@
         </item>
        </layout>
       </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_4">
+        <item>
+         <widget class="Gui::PrefCheckBox" name="gui::prefcheckbox">
+          <property name="toolTip">
+           <string>Check this if you want to preserve colors of faces while doing downgrade and upgrade (splitFaces and makeShell only)</string>
+          </property>
+          <property name="text">
+           <string>Preserve colors of faces during downgrade/upgrade</string>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>preserveFaceColor</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/Draft</cstring>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_4">
+        <item>
+         <widget class="Gui::PrefCheckBox" name="gui::prefcheckbox">
+          <property name="toolTip">
+           <string>Check this if you want the face names to derive from the originating object name and vice versa while doing downgrade/upgrade (splitFaces and makeShell only)</string>
+          </property>
+          <property name="text">
+           <string>Preserve names of faces during downgrade/upgrade</string>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>preserveFaceNames</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/Draft</cstring>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
      </layout>
     </widget>
    </item>


### PR DESCRIPTION
This patch adds functionality to preserve face colors when downgrading/upgrading via Draft workbench, for splitFaces and makeShell functions (which are relevant for editing STEP models). Also, it adds functionality for preserving (parts) of object names. Forum thread for reference:

  Delete faces from colored STEP model? - FreeCAD Forum
  https://forum.freecadweb.org/viewtopic.php?f=3&t=32674

It has been tested with:

* https://raw.githubusercontent.com/beagleboard/capes/master/beaglebone/Robotics/models/SD-101D%20Robotics%20Cape%203D%20Model.STEP (big model, 1800+ faces)
* [sph_tor_rect_cyl.step](https://www.cmiss.org/cmgui/wiki/sphtorrectcylstep/at_download/file), a simple file which I've attached here as [test.fcstd.zip](https://github.com/FreeCAD/FreeCAD/files/2665722/test.fcstd.zip) (just rename `test.fcstd.zip` to `test.fcstd`)

Since at the upgrade (makeShell), there are new faces created for a new object with new hashCodes and with different ordering, a re-mapping needs to be done to obtain the original colors, which unfortunately can take a lot of time. I've tried replacing the double for loop in makeShell with this list comprehension, which works correctly:

```
                        remapindsarr = [fcind for ind, face in enumerate(newobj.Shape.Faces) for fcind, fcface in enumerate(facecolors[1]) if ((face.Area == fcface.Area) and (face.CenterOfMass == fcface.CenterOfMass))]
                        colarray = [facecolors[0][fcind] for fcind in remapindsarr]
```
... unfortunately, this seems to want to go through entire N^2 steps, as I cannot find how to break it.

Since this feature can introduce longer times during downgrade/upgrade, it also features checkboxes in the GUI, under Edit/Preferences - the Draft submenu (which first appears when the Draft workbench is opened), and also get saved in `~/.FreeCAD/user.cfg` as `preserveFaceColor` and `preserveFaceNames`. They are disabled by default, and they need to be enabled to show the functionality.

Typically I see STEP models like `sd-101d robotics cape 3d model.step`, which import in Freecad as one object with many faces - this patch mostly handles preserving colors between this kind of an object with many colored faces, and many objects for each face separately. In case of multiple objects like in `test.fcstd`, select a face on one object, then downgrade will work on that object only (for upgrade one needs to make a selection of possibly all face objects, anyways).
