### PR TITLE
FEM: replaces #1626 and #1846

### DIFF
--- a/src/Mod/Fem/ObjectsFem.py
+++ b/src/Mod/Fem/ObjectsFem.py
@@ -362,6 +362,53 @@ def makeResultMechanical(doc, name="MechanicalResult"):
     return obj
 
 
+def makePostVtkFilterClipRegion(doc, base_vtk_result, name="FEMVtkFilterClipRegion"):
+    '''makePostVtkFilterClipRegion(document, base_vtk_result, [name]): creates an FEM post processing region clip filter object (vtk based)'''
+    obj = doc.addObject("Fem::FemPostClipFilter", name)
+    tmp_filter_list = base_vtk_result.Filter
+    tmp_filter_list.append(obj)
+    base_vtk_result.Filter = tmp_filter_list
+    del tmp_filter_list
+    return obj
+
+
+def makePostVtkFilterClipScalar(doc, base_vtk_result, name="FEMVtkFilterClipScalar"):
+    '''makePostVtkFilterClipScalar(document, base_vtk_result, [name]): creates an FEM post processing scalar clip filter object (vtk based)'''
+    obj = doc.addObject("Fem::FemPostScalarClipFilter", name)
+    tmp_filter_list = base_vtk_result.Filter
+    tmp_filter_list.append(obj)
+    base_vtk_result.Filter = tmp_filter_list
+    del tmp_filter_list
+    return obj
+
+
+def makePostVtkFilterCutFunction(doc, base_vtk_result, name="FEMVtkFilterCutFunction"):
+    '''makePostVtkFilterCutFunction(document, base_vtk_result, [name]): creates an FEM post processing cut function filter object (vtk based)'''
+    obj = doc.addObject("Fem::FemPostClipFilter", name)
+    tmp_filter_list = base_vtk_result.Filter
+    tmp_filter_list.append(obj)
+    base_vtk_result.Filter = tmp_filter_list
+    del tmp_filter_list
+    return obj
+
+
+def makePostVtkFilterWarp(doc, base_vtk_result, name="FEMVtkFilterWarp"):
+    '''makePostVtkFilterWarp(document, base_vtk_result, [name]): creates an FEM post processing warp filter object (vtk based)'''
+    obj = doc.addObject("Fem::FemPostWarpVectorFilter", name)
+    tmp_filter_list = base_vtk_result.Filter
+    tmp_filter_list.append(obj)
+    base_vtk_result.Filter = tmp_filter_list
+    del tmp_filter_list
+    return obj
+
+
+def makePostVtkResult(doc, base_result, name="FEMVtkResult"):
+    '''makePostVtkResult(document, base_result [name]): creates an FEM post processing result object (vtk based) to hold FEM results'''
+    obj = doc.addObject("Fem::FemPostPipeline", name)
+    obj.load(base_result)
+    return obj
+
+
 # ********* solver objects *********
 def makeEquationElasticity(doc, base_solver):
     '''makeEquationElasticity(document, base_solver): creates a FEM elasticity equation for a solver'''

--- a/src/Mod/Fem/femtest/testmesh.py
+++ b/src/Mod/Fem/femtest/testmesh.py
@@ -304,7 +304,6 @@ class TestMeshEleTetra10(unittest.TestCase):
             "Test writing " + self.elem + " mesh to " + filetyp + " file failed. Volumes are different.\n"
         )
 
-    '''
     def test_tetra10_vkt(self):
         # tetra10 element: reading from and writing to unv mesh file format
         filetyp = 'vtk'
@@ -312,43 +311,45 @@ class TestMeshEleTetra10(unittest.TestCase):
         testfile = self.base_testfile + filetyp
         # fcc_print(outfile)
         # fcc_print(testfile)
-        self.femmesh.write(outfile)  # write the mesh
-        femmesh_outfile = Fem.read(outfile)  # read the mesh from written mesh
-        femmesh_testfile = Fem.read(testfile)  # read the mesh from test mesh
-        # reading the test mesh
-        self.assertEqual(
-            femmesh_testfile.Nodes,
-            self.expected_nodes['nodes'],
-            "Test writing " + self.elem + " mesh to " + filetyp + " file failed. Nodes are different.\n"
-        )
-        self.assertEqual(
-            [femmesh_testfile.Volumes[0], femmesh_testfile.getElementNodes(femmesh_outfile.Volumes[0])],
-            self.expected_elem['volumes'],
-            "Test writing " + self.elem + " mesh to " + filetyp + " file failed. Volumes are different.\n"
-        )
-        # reading the written mesh
-        self.assertEqual(
-            femmesh_outfile.Nodes,
-            self.expected_nodes['nodes'],
-            "Test writing " + self.elem + " mesh to " + filetyp + " file failed. Nodes are different.\n"
-        )
-        self.assertEqual(
-            [femmesh_outfile.Volumes[0], femmesh_outfile.getElementNodes(femmesh_outfile.Volumes[0])],
-            self.expected_elem['volumes'],
-            "Test writing " + self.elem + " mesh to " + filetyp + " file failed. Volumes are different.\n"
-        )
-        # both
-        self.assertEqual(
-            femmesh_outfile.Nodes,
-            femmesh_testfile.Nodes,
-            "Test writing " + self.elem + " mesh to " + filetyp + " file failed. Nodes are different.\n"
-        )
-        self.assertEqual(
-            femmesh_outfile.Volumes,
-            femmesh_testfile.Volumes,
-            "Test writing " + self.elem + " mesh to " + filetyp + " file failed. Volumes are different.\n"
-        )
-    '''
+        if "BUILD_FEM_VTK" in FreeCAD.__cmake__:
+            self.femmesh.write(outfile)  # write the mesh
+            femmesh_outfile = Fem.read(outfile)  # read the mesh from written mesh
+            femmesh_testfile = Fem.read(testfile)  # read the mesh from test mesh
+            # reading the test mesh
+            self.assertEqual(
+                femmesh_testfile.Nodes,
+                self.expected_nodes['nodes'],
+                "Test writing " + self.elem + " mesh to " + filetyp + " file failed. Nodes are different.\n"
+            )
+            self.assertEqual(
+                [femmesh_testfile.Volumes[0], femmesh_testfile.getElementNodes(femmesh_outfile.Volumes[0])],
+                self.expected_elem['volumes'],
+                "Test writing " + self.elem + " mesh to " + filetyp + " file failed. Volumes are different.\n"
+            )
+            # reading the written mesh
+            self.assertEqual(
+                femmesh_outfile.Nodes,
+                self.expected_nodes['nodes'],
+                "Test writing " + self.elem + " mesh to " + filetyp + " file failed. Nodes are different.\n"
+            )
+            self.assertEqual(
+                [femmesh_outfile.Volumes[0], femmesh_outfile.getElementNodes(femmesh_outfile.Volumes[0])],
+                self.expected_elem['volumes'],
+                "Test writing " + self.elem + " mesh to " + filetyp + " file failed. Volumes are different.\n"
+            )
+            # both
+            self.assertEqual(
+                femmesh_outfile.Nodes,
+                femmesh_testfile.Nodes,
+                "Test writing " + self.elem + " mesh to " + filetyp + " file failed. Nodes are different.\n"
+            )
+            self.assertEqual(
+                femmesh_outfile.Volumes,
+                femmesh_testfile.Volumes,
+                "Test writing " + self.elem + " mesh to " + filetyp + " file failed. Volumes are different.\n"
+            )
+        else:
+            fcc_print('FEM_VTK post processing is disabled.')
 
     def test_tetra10_z88(self):
         # tetra10 element: reading from and writing to z88 mesh file format

--- a/src/Mod/Fem/femtest/testobject.py
+++ b/src/Mod/Fem/femtest/testobject.py
@@ -83,7 +83,13 @@ class TestObjectCreate(unittest.TestCase):
         analysis.addObject(ObjectsFem.makeMeshNetgen(doc))
         analysis.addObject(ObjectsFem.makeMeshResult(doc))
 
-        analysis.addObject(ObjectsFem.makeResultMechanical(doc))
+        res = analysis.addObject(ObjectsFem.makeResultMechanical(doc))[0]
+        if "BUILD_FEM_VTK" in FreeCAD.__cmake__:
+            vres = analysis.addObject(ObjectsFem.makePostVtkResult(doc, res))[0]
+            analysis.addObject(ObjectsFem.makePostVtkFilterClipRegion(doc, vres))
+            analysis.addObject(ObjectsFem.makePostVtkFilterClipScalar(doc, vres))
+            analysis.addObject(ObjectsFem.makePostVtkFilterCutFunction(doc, vres))
+            analysis.addObject(ObjectsFem.makePostVtkFilterWarp(doc, vres))
 
         analysis.addObject(ObjectsFem.makeSolverCalculixCcxTools(doc))
         analysis.addObject(ObjectsFem.makeSolverCalculix(doc))
@@ -95,13 +101,19 @@ class TestObjectCreate(unittest.TestCase):
         analysis.addObject(ObjectsFem.makeEquationFlow(doc, sol))
         analysis.addObject(ObjectsFem.makeEquationFluxsolver(doc, sol))
         analysis.addObject(ObjectsFem.makeEquationHeat(doc, sol))
-        # is = 43 (just copy in empty file to test, or run unit test case, it is printed)
+        # is = 48 (just copy in empty file to test, or run unit test case, it is printed)
         # TODO if the equations and gmsh mesh childs are added to the analysis,
         # they show up twice on Tree (on solver resp. gemsh mesh obj and on analysis)
         # https://forum.freecadweb.org/viewtopic.php?t=25283
 
         doc.recompute()
-        self.assertEqual(len(analysis.Group), testtools.get_defmake_count() - 1)  # because of the analysis itself count -1
+
+        # if FEM VTK post processing is disabled, we are not able to create VTK post objects
+        if "BUILD_FEM_VTK" in FreeCAD.__cmake__:
+            fem_vtk_post = True
+        else:
+            fem_vtk_post = False
+        self.assertEqual(len(analysis.Group), testtools.get_defmake_count(fem_vtk_post) - 1)  # because of the analysis itself count -1
 
     def tearDown(self):
         FreeCAD.closeDocument(self.doc_name)

--- a/src/Mod/Fem/femtest/utilstest.py
+++ b/src/Mod/Fem/femtest/utilstest.py
@@ -54,7 +54,7 @@ def fcc_print(message):
     FreeCAD.Console.PrintMessage('{} \n'.format(message))
 
 
-def get_defmake_count():
+def get_defmake_count(fem_vtk_post=True):
     '''
     count the def make in module ObjectsFem
     could also be done in bash with
@@ -65,6 +65,12 @@ def get_defmake_count():
     lines_modefile = modfile.readlines()
     modfile.close()
     lines_defmake = [l for l in lines_modefile if l.startswith('def make')]
+    if not fem_vtk_post:  # FEM VTK post processing is disabled, we are not able to create VTK post objects
+        new_lines = []
+        for l in lines_defmake:
+            if not "PostVtk" in l:
+                new_lines.append(l)
+        lines_defmake = new_lines
     return len(lines_defmake)
 
 


### PR DESCRIPTION
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [x] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT]

FEM: replaces #1626 and #1846

see: https://forum.freecadweb.org/viewtopic.php?f=10&p=274490&sid=471b0889aea842eb07f15676ea568051#p274490