### PR TITLE
Fix Detail highlight position for rotated DPGI

### DIFF
--- a/src/Mod/TechDraw/App/DrawProjGroupItem.cpp
+++ b/src/Mod/TechDraw/App/DrawProjGroupItem.cpp
@@ -195,7 +195,6 @@ gp_Ax2 DrawProjGroupItem::getViewAxis(const Base::Vector3d& pt,
     return viewAxis;
 }
 
-//obs??
 //get the angle between the current RotationVector vector and the original X dir angle
 double DrawProjGroupItem::getRotateAngle()
 {
@@ -212,8 +211,7 @@ double DrawProjGroupItem::getRotateAngle()
     gp_Dir gxDir = viewAxis.XDirection();
     Base::Vector3d origX(gxDir.X(),gxDir.Y(),gxDir.Z());
     origX.Normalize();
-    double dot = fabs(origX.Dot(nx));  
-    double angle = acos(dot);
+    double angle = origX.GetAngle(nx);
 
     Base::Vector3d rotAxis = origX.Cross(nx);
     if (rotAxis == Direction.getValue()) {

--- a/src/Mod/TechDraw/App/DrawViewDetail.cpp
+++ b/src/Mod/TechDraw/App/DrawViewDetail.cpp
@@ -207,12 +207,20 @@ App::DocumentObjectExecReturn *DrawViewDetail::execute(void)
     if (dpgi != nullptr) {
         viewAxis = dpgi->getViewAxis(shapeCenter, dirDetail);
         vaBase = TechDrawGeometry::getViewAxis(shapeCenter,dirDetail,false);
-        if (!vaBase.Direction().IsEqual(viewAxis.Direction(), Precision::Angular())) {
+
+        Base::Vector3d vaDir(vaBase.Direction().X(),vaBase.Direction().Y(),vaBase.Direction().Z());
+        Base::Vector3d vabDir(vaBase.Direction().X(),vaBase.Direction().Y(),vaBase.Direction().Z());
+        double vaDot = vaDir.Dot(vabDir);
+
+        if (DrawUtil::fpCompare(vaDot,-1.0)) {                //anti-parallel, flip
             myShape = TechDrawGeometry::rotateShape(myShape,
                                                     viewAxis,
                                                     180.0);
         }
-        if (!vaBase.XDirection().IsEqual(viewAxis.XDirection(), Precision::Angular())) {
+        Base::Vector3d vaxDir(vaBase.XDirection().X(),vaBase.XDirection().Y(),vaBase.XDirection().Z());
+        Base::Vector3d vabxDir(vaBase.XDirection().X(),vaBase.XDirection().Y(),vaBase.XDirection().Z());
+        double vaxDot = vaxDir.Dot(vabxDir);
+        if (DrawUtil::fpCompare(vaxDot,-1.0)) {
             myShape = TechDrawGeometry::rotateShape(myShape,
                                                     viewAxis,
                                                     180.0);

--- a/src/Mod/TechDraw/Gui/QGCustomText.cpp
+++ b/src/Mod/TechDraw/Gui/QGCustomText.cpp
@@ -41,6 +41,9 @@
 #include <qmath.h>
 #include <QRectF>
 #include "Rez.h"
+#include "ZVALUE.h"
+#include "DrawGuiUtil.h"
+#include "QGICMark.h"
 #include "QGIView.h"
 #include "QGCustomText.h"
 
@@ -152,6 +155,8 @@ void QGCustomText::paint ( QPainter * painter, const QStyleOptionGraphicsItem * 
         painter->scale(1.0,1.0);
     }
 
+//    painter->drawRect(boundingRect());          //good for debugging
+
     setDefaultTextColor(m_colCurrent);
     QGraphicsTextItem::paint (painter, &myOption, widget);
 }
@@ -200,3 +205,20 @@ Base::Reference<ParameterGrp> QGCustomText::getParmGroup()
         .GetGroup("BaseApp")->GetGroup("Preferences")->GetGroup("Mod/TechDraw/Colors");
     return hGrp;
 }
+
+void QGCustomText::makeMark(double x, double y)
+{
+    QGICMark* cmItem = new QGICMark(-1);
+    cmItem->setParentItem(this);
+    cmItem->setPos(x,y);
+    cmItem->setThick(1.0);
+    cmItem->setSize(40.0);
+    cmItem->setZValue(ZVALUE::VERTEX);
+}
+
+void QGCustomText::makeMark(Base::Vector3d v)
+{
+    makeMark(v.x,v.y);
+}
+
+

--- a/src/Mod/TechDraw/Gui/QGCustomText.h
+++ b/src/Mod/TechDraw/Gui/QGCustomText.h
@@ -33,6 +33,7 @@ class QStyleOptionGraphicsItem;
 QT_END_NAMESPACE
 
 #include <Base/Parameter.h>
+#include <Base/Vector3D.h>
 
 namespace TechDrawGui
 {
@@ -57,6 +58,8 @@ public:
     virtual QColor getNormalColor(void);
     virtual QColor getPreColor(void);
     virtual QColor getSelectColor(void);
+    void makeMark(double x, double y);
+    void makeMark(Base::Vector3d v);
 
 protected:
     virtual void hoverEnterEvent(QGraphicsSceneHoverEvent *event);

--- a/src/Mod/TechDraw/Gui/QGIDecoration.cpp
+++ b/src/Mod/TechDraw/Gui/QGIDecoration.cpp
@@ -36,6 +36,10 @@
 #include <Base/Console.h>
 #include <Base/Parameter.h>
 
+#include "Rez.h"
+#include "ZVALUE.h"
+#include "DrawGuiUtil.h"
+#include "QGICMark.h"
 #include "QGIDecoration.h"
 
 using namespace TechDrawGui;
@@ -82,3 +86,20 @@ void QGIDecoration::setColor(QColor c)
     m_colCurrent = c;
     m_pen.setColor(m_colCurrent);
 }
+
+void QGIDecoration::makeMark(double x, double y)
+{
+    QGICMark* cmItem = new QGICMark(-1);
+    cmItem->setParentItem(this);
+    cmItem->setPos(x,y);
+    cmItem->setThick(2.0);
+    cmItem->setSize(40.0);
+    cmItem->setZValue(ZVALUE::VERTEX);
+}
+
+void QGIDecoration::makeMark(Base::Vector3d v)
+{
+    makeMark(v.x,v.y);
+}
+
+

--- a/src/Mod/TechDraw/Gui/QGIDecoration.h
+++ b/src/Mod/TechDraw/Gui/QGIDecoration.h
@@ -34,6 +34,7 @@ QT_END_NAMESPACE
 
 #include <Base/Parameter.h>
 #include <Base/Console.h>
+#include <Base/Vector3D.h>
 
 namespace TechDrawGui
 {
@@ -51,6 +52,8 @@ public:
     void setWidth(double w);
     void setStyle(Qt::PenStyle s);
     void setColor(QColor c);
+    void makeMark(double x, double y);
+    void makeMark(Base::Vector3d v);
 
 protected:
     QPen m_pen;

--- a/src/Mod/TechDraw/Gui/QGIHighlight.cpp
+++ b/src/Mod/TechDraw/Gui/QGIHighlight.cpp
@@ -32,8 +32,11 @@
 #include <Base/Console.h>
 #include <Base/Parameter.h>
 
+#include <Mod/TechDraw/App/DrawUtil.h>
+
 #include <qmath.h>
 #include "Rez.h"
+#include "DrawGuiUtil.h"
 #include "QGIView.h"
 #include "QGIHighlight.h"
 
@@ -85,10 +88,17 @@ void QGIHighlight::makeReference()
     m_reference->setFont(m_refFont);
     m_reference->setPlainText(QString::fromUtf8(m_refText));
     double fudge = Rez::guiX(1.0);
-//    m_reference->centerAt(m_end.x() + fudge, m_start.y() - fudge);
-    m_reference->setPos(m_end.x() + fudge, m_start.y() - m_refSize - fudge);
-}
+    QPointF newPos(m_end.x() + fudge, m_start.y() - m_refSize - fudge);
+    m_reference->setPos(newPos);   
 
+    double highRot = rotation();
+    if (!TechDraw::DrawUtil::fpCompare(highRot,0.0)) {
+        QRectF refBR = m_reference->boundingRect();
+        QPointF refCenter = refBR.center();
+        m_reference->setTransformOriginPoint(refCenter);
+        m_reference->setRotation(-highRot);
+    }
+}
 
 void QGIHighlight::setBounds(double x1,double y1,double x2,double y2)
 {
@@ -138,6 +148,7 @@ void QGIHighlight::paint ( QPainter * painter, const QStyleOptionGraphicsItem * 
     myOption.state &= ~QStyle::State_Selected;
 
     setTools();
+//    painter->drawRect(boundingRect());          //good for debugging
     QGIDecoration::paint (painter, &myOption, widget);
 }
 

--- a/src/Mod/TechDraw/Gui/QGIViewPart.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewPart.cpp
@@ -56,6 +56,7 @@
 #include <Mod/TechDraw/App/DrawHatch.h>
 #include <Mod/TechDraw/App/DrawGeomHatch.h>
 #include <Mod/TechDraw/App/DrawViewDetail.h>
+#include <Mod/TechDraw/App/DrawProjGroupItem.h>
 
 #include "Rez.h"
 #include "ZVALUE.h"
@@ -736,6 +737,11 @@ void QGIViewPart::drawHighlight(TechDraw::DrawViewDetail* viewDetail, bool b)
         return;
     }
 
+    TechDraw::DrawProjGroupItem* dpgi = nullptr;
+    if (viewPart->isDerivedFrom(TechDraw::DrawProjGroupItem::getClassTypeId())) {
+        dpgi = static_cast<TechDraw::DrawProjGroupItem*>(viewPart);
+    }
+
     if (b) {
         double fontSize = getPrefFontSize();
         QGIHighlight* highlight = new QGIHighlight();
@@ -748,10 +754,18 @@ void QGIViewPart::drawHighlight(TechDraw::DrawViewDetail* viewDetail, bool b)
         highlight->setWidth(Rez::guiX(vp->IsoWidth.getValue()));
         highlight->setFont(m_font, fontSize);
         highlight->setZValue(ZVALUE::HIGHLIGHT);
+
+        QPointF rotCenter = highlight->mapFromParent(transformOriginPoint());
+        highlight->setTransformOriginPoint(rotCenter);
+        double rotation = viewPart->Rotation.getValue();
+        if (dpgi != nullptr) {
+            double rotDpgi = dpgi->getRotateAngle() * 180.0/M_PI;
+            rotation += rotDpgi;
+        }
+        highlight->setRotation(rotation);
         highlight->draw();
     }
 }
-
 
 void QGIViewPart::drawMatting()
 {


### PR DESCRIPTION
This PR corrects a bug where the Detail highlight is not positioned properly if the Source view is a DrawProjGroupItem that has been rotated by the RotationVector property.  Please merge.
Thanks
wf

- highlight position calculation was not taking into account
  rotation of DPGI due to RotationVector property.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
