### PR TITLE
Fix StartCell/EndCell handling

### DIFF
--- a/src/Mod/TechDraw/App/DrawViewSpreadsheet.h
+++ b/src/Mod/TechDraw/App/DrawViewSpreadsheet.h
@@ -56,6 +56,7 @@ public:
 
 
     virtual App::DocumentObjectExecReturn *execute(void);
+    virtual short mustExecute() const;
     std::string getSheetImage(void);
 
     virtual const char* getViewProviderName(void) const {
@@ -67,6 +68,8 @@ protected:
     std::vector<std::string> getAvailColumns(void);
     std::string getSVGHead(void);
     std::string getSVGTail(void);
+    int colInList(const std::vector<std::string>& list,
+                   const std::string& toFind);
 
 private:
 };


### PR DESCRIPTION
This PR corrects a bug where StartCell and EndCell properties were not being interpreted correctly.  Please merge. 
Thanks.
wf


- multi-character Columns and multi-digit Rows
  were not being interpreted correctly.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
