### PR TITLE
Part Explode

### DIFF
--- a/src/Mod/Part/BOPTools/SplitFeatures.py
+++ b/src/Mod/Part/BOPTools/SplitFeatures.py
@@ -251,22 +251,22 @@ class ViewProviderSlice:
             FreeCAD.Console.PrintError("Error in onDelete: " + str(err))
         return True
 
-def cmdCreateSliceFeature(name, mode):
+def cmdCreateSliceFeature(name, mode, transaction= True):
     """cmdCreateSliceFeature(name, mode): implementation of GUI command to create
     Slice feature. Mode can be "Standard", "Split", or "CompSolid"."""
     sel = FreeCADGui.Selection.getSelectionEx()
-    FreeCAD.ActiveDocument.openTransaction("Create Slice")
+    if transaction: FreeCAD.ActiveDocument.openTransaction("Create Slice")
     FreeCADGui.addModule("BOPTools.SplitFeatures")
-    FreeCADGui.doCommand("j = BOPTools.SplitFeatures.makeSlice(name= '{name}')".format(name= name))
-    FreeCADGui.doCommand("j.Base = {sel}[0]\n"
-                         "j.Tools = {sel}[1:]".format(
+    FreeCADGui.doCommand("f = BOPTools.SplitFeatures.makeSlice(name= '{name}')".format(name= name))
+    FreeCADGui.doCommand("f.Base = {sel}[0]\n"
+                         "f.Tools = {sel}[1:]".format(
        sel= "["  +  ", ".join(["App.ActiveDocument."+so.Object.Name for so in sel])  +  "]"
        ))
-    FreeCADGui.doCommand("j.Mode = {mode}".format(mode= repr(mode)))
+    FreeCADGui.doCommand("f.Mode = {mode}".format(mode= repr(mode)))
 
     try:
-        FreeCADGui.doCommand("j.Proxy.execute(j)")
-        FreeCADGui.doCommand("j.purgeTouched()")
+        FreeCADGui.doCommand("f.Proxy.execute(f)")
+        FreeCADGui.doCommand("f.purgeTouched()")
     except Exception as err:
         mb = QtGui.QMessageBox()
         mb.setIcon(mb.Icon.Warning)
@@ -280,25 +280,64 @@ def cmdCreateSliceFeature(name, mode):
         mb.exec_()
 
         if mb.clickedButton() is btnAbort:
-            FreeCAD.ActiveDocument.abortTransaction()
-            return
+            if transaction: FreeCAD.ActiveDocument.abortTransaction()
+            return False
 
-    FreeCADGui.doCommand("for obj in j.ViewObject.Proxy.claimChildren():\n"
+    FreeCADGui.doCommand("for obj in f.ViewObject.Proxy.claimChildren():\n"
                          "    obj.ViewObject.hide()")
 
-    FreeCAD.ActiveDocument.commitTransaction()
+    if transaction: FreeCAD.ActiveDocument.commitTransaction()
+    return True
+
+def cmdSliceApart():
+    FreeCAD.ActiveDocument.openTransaction("Slice apart")
+    made = cmdCreateSliceFeature(name= "Slice", mode= "Split", transaction= False)
+    
+    if made:
+        FreeCADGui.addModule("CompoundTools.Explode")
+        FreeCADGui.doCommand("CompoundTools.Explode.explodeCompound(f)")
+        FreeCADGui.doCommand("f.ViewObject.hide()")
+        FreeCAD.ActiveDocument.commitTransaction()
+        FreeCADGui.doCommand("App.ActiveDocument.recompute()")
+    else:
+        FreeCAD.ActiveDocument.abortTransaction()
+        
 
 class CommandSlice:
     "Command to create Slice feature"
     def GetResources(self):
         return {'Pixmap'  : getIconPath("Part_Slice.svg"),
-                'MenuText': QtCore.QT_TRANSLATE_NOOP("Part_SplitFeatures","Slice"),
+                'MenuText': QtCore.QT_TRANSLATE_NOOP("Part_SplitFeatures","Slice to compound"),
                 'Accel': "",
-                'ToolTip': QtCore.QT_TRANSLATE_NOOP("Part_SplitFeatures","Part_Slice: split object by intersections with other objects")}
+                'ToolTip': QtCore.QT_TRANSLATE_NOOP("Part_SplitFeatures","Part_Slice: split object by intersections with other objects, and pack the pieces into a compound.")}
 
     def Activated(self):
         if len(FreeCADGui.Selection.getSelectionEx()) > 1 :
             cmdCreateSliceFeature(name= "Slice", mode= "Split")
+        else:
+            mb = QtGui.QMessageBox()
+            mb.setIcon(mb.Icon.Warning)
+            mb.setText(_translate("Part_SplitFeatures", "Select at least two objects, first! First one is the object to be sliced; the rest are objects to slice with.", None))
+            mb.setWindowTitle(_translate("Part_SplitFeatures","Bad selection", None))
+            mb.exec_()
+
+    def IsActive(self):
+        if FreeCAD.ActiveDocument:
+            return True
+        else:
+            return False
+
+class CommandSliceApart:
+    "Command to create exploded Slice feature"
+    def GetResources(self):
+        return {'Pixmap'  : getIconPath("Part_SliceApart.svg"),
+                'MenuText': QtCore.QT_TRANSLATE_NOOP("Part_SplitFeatures","Slice apart"),
+                'Accel': "",
+                'ToolTip': QtCore.QT_TRANSLATE_NOOP("Part_SplitFeatures","Part_SliceApart: split object by intersections with other objects.")}
+
+    def Activated(self):
+        if len(FreeCADGui.Selection.getSelectionEx()) > 1 :
+            cmdSliceApart()
         else:
             mb = QtGui.QMessageBox()
             mb.setIcon(mb.Icon.Warning)
@@ -451,4 +490,5 @@ class CommandXOR:
 def addCommands():
     FreeCADGui.addCommand('Part_BooleanFragments',CommandBooleanFragments())
     FreeCADGui.addCommand('Part_Slice',CommandSlice())
+    FreeCADGui.addCommand('Part_SliceApart',CommandSliceApart())
     FreeCADGui.addCommand('Part_XOR',CommandXOR())

--- a/src/Mod/Part/CMakeLists.txt
+++ b/src/Mod/Part/CMakeLists.txt
@@ -40,7 +40,9 @@ set(BOPTools_Scripts
 set(CompoundTools_Scripts
     CompoundTools/__init__.py
     CompoundTools/_CommandCompoundFilter.py
+    CompoundTools/_CommandExplodeCompound.py
     CompoundTools/CompoundFilter.py
+    CompoundTools/Explode.py
 )
 
 add_custom_target(PartScripts ALL SOURCES

--- a/src/Mod/Part/CompoundTools/CompoundFilter.py
+++ b/src/Mod/Part/CompoundTools/CompoundFilter.py
@@ -40,9 +40,14 @@ DistConfusion = 1e-7
 ParaConfusion = 1e-8
 
 
-def makeCompoundFilter(name):
+def makeCompoundFilter(name, into_group = None):
     '''makeCompoundFilter(name): makes a CompoundFilter object.'''
-    obj = FreeCAD.ActiveDocument.addObject("Part::FeaturePython", name)
+    if into_group is None:
+        into_group = FreeCAD.ActiveDocument
+    if into_group.isDerivedFrom('App::Document'):
+        obj = into_group.addObject("Part::FeaturePython", name)
+    else:
+        obj = into_group.newObject("Part::FeaturePython", name)
     _CompoundFilter(obj)
     if obj.ViewObject:    
         _ViewProviderCompoundFilter(obj.ViewObject)

--- a/src/Mod/Part/CompoundTools/Explode.py
+++ b/src/Mod/Part/CompoundTools/Explode.py
@@ -1,0 +1,25 @@
+from .CompoundFilter import makeCompoundFilter 
+
+def explodeCompound(compound_obj, b_group = None):
+    """explodeCompound(compound_obj, b_group = None): creates a bunch of compound filters, to extract every child of a compount into a separate object. 
+    group: if True, Group is always made. If False, group is never made. If None, group is made if there is more than one child.
+    returns: (group_object, list_of_child_objects)"""
+    sh = compound_obj.Shape
+    n = len(sh.childShapes(False,False))
+    if b_group is None:
+        b_group = n > 1
+    if b_group:
+        group = compound_obj.Document.addObject('App::DocumentObjectGroup','GrExplode_'+compound_obj.Name)
+        group.Label = 'Exploded {obj.Label}'.format(obj = compound_obj)        
+    else:
+        group = compound_obj.Document
+    features_created = []
+    for i in range(0, n):
+        cf = makeCompoundFilter('{obj.Name}_child{child_num}'.format(obj = compound_obj, child_num = i), group)
+        cf.Label = '{obj.Label}.{child_num}'.format(obj = compound_obj, child_num = i)
+        cf.Base = compound_obj
+        cf.FilterType = 'specific items'
+        cf.items = str(i)
+        cf.ViewObject.DontUnhideOnDelete = True
+        features_created.append(cf)
+    return (group, features_created)

--- a/src/Mod/Part/CompoundTools/_CommandExplodeCompound.py
+++ b/src/Mod/Part/CompoundTools/_CommandExplodeCompound.py
@@ -1,0 +1,101 @@
+# ***************************************************************************
+# *                                                                         *
+# *   Copyright (c) 2016 - Victor Titov (DeepSOIC) <vv.titov@gmail.com>     *
+# *                                                                         *
+# *   This program is free software; you can redistribute it and/or modify  *
+# *   it under the terms of the GNU Lesser General Public License (LGPL)    *
+# *   as published by the Free Software Foundation; either version 2 of     *
+# *   the License, or (at your option) any later version.                   *
+# *   for detail see the LICENCE text file.                                 *
+# *                                                                         *
+# *   This program is distributed in the hope that it will be useful,       *
+# *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+# *   GNU Library General Public License for more details.                  *
+# *                                                                         *
+# *   You should have received a copy of the GNU Library General Public     *
+# *   License along with this program; if not, write to the Free Software   *
+# *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
+# *   USA                                                                   *
+# *                                                                         *
+# ***************************************************************************
+
+__title__ = "CompoundTools._CommandExplodeCompound"
+__author__ = "DeepSOIC"
+__url__ = "http://www.freecadweb.org"
+__doc__ = "ExplodeCompound: create a bunch of CompoundFilter objects to split a compound into pieces."
+
+from .Explode import explodeCompound
+
+import FreeCAD
+if FreeCAD.GuiUp:
+    import FreeCADGui
+    from PySide import QtGui
+    from PySide import QtCore
+
+
+# translation-related code
+    try:
+        _fromUtf8 = QtCore.QString.fromUtf8
+    except Exception:
+        def _fromUtf8(s):
+            return s
+    try:
+        _encoding = QtGui.QApplication.UnicodeUTF8
+        def _translate(context, text, disambig):
+            return QtGui.QApplication.translate(context, text, disambig, _encoding)
+    except AttributeError:
+        def _translate(context, text, disambig):
+            return QtGui.QApplication.translate(context, text, disambig)
+
+
+# command class
+class _CommandExplodeCompound:
+    "Command to explode a compound"
+    def GetResources(self):
+        return {'Pixmap': ":/icons/Part_ExplodeCompound.svg",
+                'MenuText': QtCore.QT_TRANSLATE_NOOP("Part_ExplodeCompound", "Explode compound"),
+                'Accel': "",
+                'ToolTip': QtCore.QT_TRANSLATE_NOOP("Part_ExplodeCompound", "Explode compound: split up a list of shapes into separate objects")}
+
+    def Activated(self):
+        if len(FreeCADGui.Selection.getSelection()) == 1:
+            cmdExplode()
+        else:
+            mb = QtGui.QMessageBox()
+            mb.setIcon(mb.Icon.Warning)
+            mb.setText(_translate("Part_ExplodeCompound", "Select a shape that is a compound, first!", None))
+            mb.setWindowTitle(_translate("Part_ExplodeCompound", "Bad selection", None))
+            mb.exec_()
+
+    def IsActive(self):
+        if FreeCAD.ActiveDocument:
+            return True
+        else:
+            return False
+
+
+if FreeCAD.GuiUp:
+    FreeCADGui.addCommand('Part_ExplodeCompound', _CommandExplodeCompound())
+
+
+
+
+def cmdExplode():
+    FreeCAD.ActiveDocument.openTransaction("Explode")
+    try:
+        sel = FreeCADGui.Selection.getSelectionEx()
+        if len(sel) != 1:
+            raise ValueError("Bad selection","More than one object selected. You have selected {num} objects.".format(num= len(sel)))
+        obj = sel[0].Object
+        FreeCADGui.addModule("CompoundTools.Explode")
+        FreeCADGui.doCommand("input_obj = App.ActiveDocument."+obj.Name)
+        FreeCADGui.doCommand("CompoundTools.Explode.explodeCompound(input_obj)")
+        FreeCADGui.doCommand("input_obj.ViewObject.hide()")
+    except Exception:
+        FreeCAD.ActiveDocument.abortTransaction()
+        raise
+        
+    FreeCAD.ActiveDocument.commitTransaction()
+    FreeCADGui.doCommand("App.ActiveDocument.recompute()")
+    

--- a/src/Mod/Part/Gui/Command.cpp
+++ b/src/Mod/Part/Gui/Command.cpp
@@ -759,6 +759,114 @@ bool CmdPartCompSplitFeatures::isActive(void)
 }
 
 //===========================================================================
+// Part_CompCompoundTools (dropdown toolbar button for BooleanFragments, Slice)
+//===========================================================================
+
+DEF_STD_CMD_ACL(CmdPartCompCompoundTools);
+
+CmdPartCompCompoundTools::CmdPartCompCompoundTools()
+  : Command("Part_CompCompoundTools")
+{
+    sAppModule      = "Part";
+    sGroup          = QT_TR_NOOP("Part");
+    sMenuText       = QT_TR_NOOP("Counpound tools");
+    sToolTipText    = QT_TR_NOOP("Compound tools: working with lists of shapes.");
+    sWhatsThis      = "Part_CompCompoundTools";
+    sStatusTip      = sToolTipText;
+}
+
+void CmdPartCompCompoundTools::activated(int iMsg)
+{
+    Gui::CommandManager &rcCmdMgr = Gui::Application::Instance->commandManager();
+    if (iMsg==0)
+        rcCmdMgr.runCommandByName("Part_Compound");
+    else if (iMsg==1)
+        rcCmdMgr.runCommandByName("Part_ExplodeCompound");
+    else if (iMsg==2)
+        rcCmdMgr.runCommandByName("Part_CompoundFilter");
+    else
+        return;
+
+    // Since the default icon is reset when enabing/disabling the command we have
+    // to explicitly set the icon of the used command.
+    Gui::ActionGroup* pcAction = qobject_cast<Gui::ActionGroup*>(_pcAction);
+    QList<QAction*> a = pcAction->actions();
+
+    assert(iMsg < a.size());
+    pcAction->setIcon(a[iMsg]->icon());
+}
+
+Gui::Action * CmdPartCompCompoundTools::createAction(void)
+{
+    Gui::ActionGroup* pcAction = new Gui::ActionGroup(this, Gui::getMainWindow());
+    pcAction->setDropDownMenu(true);
+    applyCommandData(this->className(), pcAction);
+
+    QAction* cmd0 = pcAction->addAction(QString());
+    cmd0->setIcon(Gui::BitmapFactory().pixmap("Part_Compound"));
+    QAction* cmd1 = pcAction->addAction(QString());
+    cmd1->setIcon(Gui::BitmapFactory().pixmap("Part_ExplodeCompound"));
+    QAction* cmd2 = pcAction->addAction(QString());
+    cmd2->setIcon(Gui::BitmapFactory().pixmap("Part_CompoundFilter"));
+
+    _pcAction = pcAction;
+    languageChange();
+
+    pcAction->setIcon(cmd0->icon());
+    int defaultId = 0;
+    pcAction->setProperty("defaultAction", QVariant(defaultId));
+
+    return pcAction;
+}
+
+void CmdPartCompCompoundTools::languageChange()
+{
+    Command::languageChange();
+
+    if (!_pcAction)
+        return;
+
+    Gui::CommandManager &rcCmdMgr = Gui::Application::Instance->commandManager();
+
+    Gui::ActionGroup* pcAction = qobject_cast<Gui::ActionGroup*>(_pcAction);
+    QList<QAction*> a = pcAction->actions();
+
+    Gui::Command* cmdCompound = rcCmdMgr.getCommandByName("Part_Compound");
+    if (cmdCompound) {
+        QAction* cmd0 = a[0];
+        cmd0->setText(QApplication::translate("CmdPartCompound", cmdCompound->getMenuText()));
+        cmd0->setToolTip(QApplication::translate("CmdPartCompound", cmdCompound->getToolTipText()));
+        cmd0->setStatusTip(QApplication::translate("CmdPartCompound", cmdCompound->getStatusTip()));
+    }
+
+    Gui::Command* cmdExplode = rcCmdMgr.getCommandByName("Part_ExplodeCompound");
+    if (cmdExplode) {
+        QAction* cmd1 = a[1];
+        cmd1->setText(QApplication::translate("Part_CompoundTools", cmdExplode->getMenuText()));
+        cmd1->setToolTip(QApplication::translate("Part_CompoundTools", cmdExplode->getToolTipText()));
+        cmd1->setStatusTip(QApplication::translate("Part_CompoundTools", cmdExplode->getStatusTip()));
+    }
+
+    Gui::Command* cmdCompoundFilter = rcCmdMgr.getCommandByName("Part_CompoundFilter");
+    if (cmdCompoundFilter) {
+        QAction* cmd2 = a[2];
+        cmd2->setText(QApplication::translate("Part_CompoundTools", cmdCompoundFilter->getMenuText()));
+        cmd2->setToolTip(QApplication::translate("Part_CompoundTools", cmdCompoundFilter->getToolTipText()));
+        cmd2->setStatusTip(QApplication::translate("Part_CompoundTools", cmdCompoundFilter->getStatusTip()));
+    }
+}
+
+bool CmdPartCompCompoundTools::isActive(void)
+{
+    if (getActiveGuiDocument())
+        return true;
+    else
+        return false;
+}
+
+
+
+//===========================================================================
 // Part_Compound
 //===========================================================================
 DEF_STD_CMD_A(CmdPartCompound);
@@ -2271,6 +2379,7 @@ void CreatePartCommands(void)
     rcCmdMgr.addCommand(new CmdPartFuse());
     rcCmdMgr.addCommand(new CmdPartCompJoinFeatures());
     rcCmdMgr.addCommand(new CmdPartCompSplitFeatures());
+    rcCmdMgr.addCommand(new CmdPartCompCompoundTools());
     rcCmdMgr.addCommand(new CmdPartCompound());
     rcCmdMgr.addCommand(new CmdPartSection());
     //rcCmdMgr.addCommand(new CmdPartBox2());

--- a/src/Mod/Part/Gui/Command.cpp
+++ b/src/Mod/Part/Gui/Command.cpp
@@ -671,8 +671,10 @@ void CmdPartCompSplitFeatures::activated(int iMsg)
     if (iMsg==0)
         rcCmdMgr.runCommandByName("Part_BooleanFragments");
     else if (iMsg==1)
-        rcCmdMgr.runCommandByName("Part_Slice");
+        rcCmdMgr.runCommandByName("Part_SliceApart");
     else if (iMsg==2)
+        rcCmdMgr.runCommandByName("Part_Slice");
+    else if (iMsg==3)
         rcCmdMgr.runCommandByName("Part_XOR");
     else
         return;
@@ -695,9 +697,11 @@ Gui::Action * CmdPartCompSplitFeatures::createAction(void)
     QAction* cmd0 = pcAction->addAction(QString());
     cmd0->setIcon(Gui::BitmapFactory().pixmap("Part_BooleanFragments"));
     QAction* cmd1 = pcAction->addAction(QString());
-    cmd1->setIcon(Gui::BitmapFactory().pixmap("Part_Slice"));
+    cmd1->setIcon(Gui::BitmapFactory().pixmap("Part_SliceApart"));
     QAction* cmd2 = pcAction->addAction(QString());
-    cmd2->setIcon(Gui::BitmapFactory().pixmap("Part_XOR"));
+    cmd2->setIcon(Gui::BitmapFactory().pixmap("Part_Slice"));
+    QAction* cmd3 = pcAction->addAction(QString());
+    cmd3->setIcon(Gui::BitmapFactory().pixmap("Part_XOR"));
 
     _pcAction = pcAction;
     languageChange();
@@ -729,9 +733,17 @@ void CmdPartCompSplitFeatures::languageChange()
         cmd0->setStatusTip(QApplication::translate("Part_SplitFeatures", splitBoolFragments->getStatusTip()));
     }
 
+    Gui::Command* splitSliceApart = rcCmdMgr.getCommandByName("Part_SliceApart");
+    if (splitSliceApart) {
+        QAction* cmd1 = a[1];
+        cmd1->setText(QApplication::translate("Part_SplitFeatures", splitSliceApart->getMenuText()));
+        cmd1->setToolTip(QApplication::translate("Part_SplitFeatures", splitSliceApart->getToolTipText()));
+        cmd1->setStatusTip(QApplication::translate("Part_SplitFeatures", splitSliceApart->getStatusTip()));
+    }
+
     Gui::Command* splitSlice = rcCmdMgr.getCommandByName("Part_Slice");
     if (splitSlice) {
-        QAction* cmd1 = a[1];
+        QAction* cmd1 = a[2];
         cmd1->setText(QApplication::translate("Part_SplitFeatures", splitSlice->getMenuText()));
         cmd1->setToolTip(QApplication::translate("Part_SplitFeatures", splitSlice->getToolTipText()));
         cmd1->setStatusTip(QApplication::translate("Part_SplitFeatures", splitSlice->getStatusTip()));
@@ -739,7 +751,7 @@ void CmdPartCompSplitFeatures::languageChange()
 
     Gui::Command* splitXOR = rcCmdMgr.getCommandByName("Part_XOR");
     if (splitXOR) {
-        QAction* cmd2 = a[2];
+        QAction* cmd2 = a[3];
         cmd2->setText(QApplication::translate("Part_SplitFeatures", splitXOR->getMenuText()));
         cmd2->setToolTip(QApplication::translate("Part_SplitFeatures", splitXOR->getToolTipText()));
         cmd2->setStatusTip(QApplication::translate("Part_SplitFeatures", splitXOR->getStatusTip()));

--- a/src/Mod/Part/Gui/Resources/Part.qrc
+++ b/src/Mod/Part/Gui/Resources/Part.qrc
@@ -17,6 +17,7 @@
         <file>icons/Part_CreatePrimitives.svg</file>
         <file>icons/Part_Cylinder.svg</file>
         <file>icons/Part_Extrude.svg</file>
+        <file>icons/Part_ExplodeCompound.svg</file>
         <file>icons/Part_Fillet.svg</file>
         <file>icons/Part_Fuse.svg</file>
         <file>icons/Part_Import.svg</file>

--- a/src/Mod/Part/Gui/Resources/Part.qrc
+++ b/src/Mod/Part/Gui/Resources/Part.qrc
@@ -34,6 +34,7 @@
         <file>icons/Part_Shapebuilder.png</file>
         <file>icons/Part_ShapeInfo.svg</file>
         <file>icons/Part_Slice.svg</file>
+        <file>icons/Part_SliceApart.svg</file>
         <file>icons/Part_Sphere.svg</file>
         <file>icons/Part_Sweep.svg</file>
         <file>icons/Part_Thickness.svg</file>

--- a/src/Mod/Part/Gui/Resources/icons/Part_ExplodeCompound.svg
+++ b/src/Mod/Part/Gui/Resources/icons/Part_ExplodeCompound.svg
@@ -15,7 +15,7 @@
    id="svg2568"
    sodipodi:version="0.32"
    inkscape:version="0.48.4 r9939"
-   sodipodi:docname="Part_ExplodeCompound.svg"
+   sodipodi:docname="Lattice2_Explode.svg"
    inkscape:output_extension="org.inkscape.output.svg.inkscape"
    version="1.1"
    inkscape:export-filename="/home/user/Downloads/cad/mystuff/icons/Part/mystuff/Part_Compound_5_32px.png"
@@ -344,21 +344,21 @@
      inkscape:label="Layer 1"
      inkscape:groupmode="layer">
     <g
-       transform="matrix(0.79537386,0,0,0.79537386,6.7574559,7.4643977)"
+       transform="matrix(0.69755245,0,0,0.69755245,6.0594406,2.1783216)"
        id="g3004">
       <path
          sodipodi:nodetypes="ccccc"
          inkscape:connector-curvature="0"
          id="path2993"
          d="M 3,13 37,19 61,11 31,7 z"
-         style="fill:#729fcf;stroke:#0b1521;stroke-width:2.51454091;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1" />
+         style="fill:#729fcf;stroke:#0b1521;stroke-width:2.86716795;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1" />
       <path
          inkscape:connector-curvature="0"
          id="path2995"
          d="M 61,11 61,47 37,57 37,19 z"
-         style="fill:url(#linearGradient3783);fill-opacity:1;stroke:#0b1521;stroke-width:2.51454091;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1" />
+         style="fill:url(#linearGradient3783);fill-opacity:1;stroke:#0b1521;stroke-width:2.86716795;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1" />
       <path
-         style="fill:url(#linearGradient3773);fill-opacity:1;fill-rule:evenodd;stroke:#0b1521;stroke-width:2.51454091;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         style="fill:url(#linearGradient3773);fill-opacity:1;fill-rule:evenodd;stroke:#0b1521;stroke-width:2.86716795;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          d="M 3,13 37,19 37,57 3,51 z"
          id="path3825-8"
          sodipodi:nodetypes="ccccc"
@@ -368,22 +368,22 @@
          inkscape:connector-curvature="0"
          id="path3765"
          d="m 5,15.42772 0.00867,33.919116 30.008671,5.268799 -0.0087,-33.933614 z"
-         style="fill:none;stroke:#729fcf;stroke-width:2.51454091;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+         style="fill:none;stroke:#729fcf;stroke-width:2.86716795;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
       <path
          sodipodi:nodetypes="ccccc"
          inkscape:connector-curvature="0"
          id="path3775"
          d="m 39.01243,20.433833 -0.01226,33.535301 20.001105,-8.300993 3.6e-4,-31.867363 z"
-         style="fill:none;stroke:#3465a4;stroke-width:2.51454091;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+         style="fill:none;stroke:#3465a4;stroke-width:2.86716795;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
     <g
        id="g3049"
        style="stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none"
-       transform="matrix(1.4922477,0,0,1.7510489,-2.6103509,-33.760719)">
+       transform="matrix(1.3087192,0,0,1.535691,-2.1562387,-33.976602)">
       <g
          id="g3827">
         <path
-           style="fill:none;stroke:#ffffff;stroke-width:4.3304038;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:0.8565401;stroke-dasharray:none"
+           style="fill:none;stroke:#ffffff;stroke-width:4.93767881;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:0.8565401;stroke-dasharray:none"
            d="m 10.351377,24.493827 -5.6980057,0 0,25.925926 5.6980057,0"
            id="path3045"
            inkscape:connector-curvature="0"
@@ -393,7 +393,7 @@
            inkscape:connector-curvature="0"
            id="path3825"
            d="m 10.351377,24.493827 -5.6980057,0 0,25.925926 5.6980057,0"
-           style="fill:none;stroke:#000000;stroke-width:1.2372582;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+           style="fill:none;stroke:#000000;stroke-width:1.41076541;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
       </g>
       <use
          x="0"
@@ -403,6 +403,109 @@
          transform="matrix(-1,0,0,1,46.557279,0)"
          width="64"
          height="64" />
+    </g>
+    <g
+       transform="matrix(0.91273618,0,0,0.90349515,6.5354045,-0.91856045)"
+       id="g4095">
+      <path
+         sodipodi:nodetypes="cczccc"
+         inkscape:connector-curvature="0"
+         id="path3206"
+         d="m 38.506483,33.425344 0,30.990759 c 0,0 1.752973,4.427251 9.641343,4.427251 7.88837,0 9.641339,-4.427251 9.641339,-4.427251 l 0,-30.990759 z"
+         style="fill:url(#linearGradient4000-2);fill-opacity:1;stroke:#280000;stroke-width:2.20239091;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="cczccc"
+         inkscape:connector-curvature="0"
+         id="path3206-6"
+         d="m 40.697698,35.63897 0,28.223727 c 0,0 1.704278,2.767032 7.669251,2.767032 5.964972,0 7.669249,-2.767032 7.669249,-2.767032 l 0,-28.223727 z"
+         style="fill:none;stroke:#ef2929;stroke-width:2.20239115;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      <path
+         transform="matrix(0.85818027,0,0,1.0066384,36.189573,4.1993198)"
+         d="m 25.169065,29.033289 c 0,2.428978 -5.029918,4.398055 -11.234635,4.398055 -6.2047171,0 -11.2346343,-1.969077 -11.2346343,-4.398055 0,-2.428979 5.0299172,-4.398055 11.2346343,-4.398055 6.204717,0 11.234635,1.969076 11.234635,4.398055 z"
+         sodipodi:ry="4.3980546"
+         sodipodi:rx="11.234634"
+         sodipodi:cy="29.033289"
+         sodipodi:cx="13.93443"
+         id="path3186"
+         style="fill:#cc0000;fill-opacity:1;stroke:#280000;stroke-width:2.36956406;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:6.8"
+         sodipodi:type="arc" />
+      <path
+         transform="matrix(0.68264328,0,0,0.50331927,38.854701,18.812331)"
+         d="m 25.169065,29.033289 c 0,2.428978 -5.029918,4.398055 -11.234635,4.398055 -6.2047171,0 -11.2346343,-1.969077 -11.2346343,-4.398055 0,-2.428979 5.0299172,-4.398055 11.2346343,-4.398055 6.204717,0 11.234635,1.969076 11.234635,4.398055 z"
+         sodipodi:ry="4.3980546"
+         sodipodi:rx="11.234634"
+         sodipodi:cy="29.033289"
+         sodipodi:cx="13.93443"
+         id="path3186-0"
+         style="fill:none;stroke:#ef2929;stroke-width:3.75729895;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:6.8"
+         sodipodi:type="arc" />
+      <path
+         sodipodi:nodetypes="czc"
+         inkscape:connector-curvature="0"
+         id="path4002"
+         d="m 40.259454,38.516683 c 0,0 2.629455,1.549538 7.88837,1.549538 5.258915,0 7.88837,-1.549538 7.88837,-1.549538"
+         style="fill:none;stroke:#ef2929;stroke-width:2.20239091;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      <path
+         transform="matrix(1.0956068,0,0,1.1068128,-8.6046095,1.3277733)"
+         sodipodi:nodetypes="czc"
+         inkscape:connector-curvature="0"
+         id="path4004"
+         d="m 52.000002,28 c 0,0 -3.289969,-4.344762 -3,-8 0.289968,-3.655238 2,-5 2,-5"
+         style="fill:none;stroke:#2e3436;stroke-width:6;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="czc"
+         inkscape:connector-curvature="0"
+         id="path4004-2"
+         d="m 48.366947,32.318532 c 0,0 -3.604513,-4.808838 -3.286821,-8.854503 0.317691,-4.045664 2.191213,-5.534064 2.191213,-5.534064"
+         style="fill:none;stroke:#d3d7cf;stroke-width:2.20239115;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path4024"
+         d="m 38.506483,17.929966 -4.382426,2.213625"
+         style="fill:none;stroke:#a40000;stroke-width:6.60717344;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path4024-6"
+         d="m 38.506483,17.929966 -4.382426,2.213625"
+         style="fill:none;stroke:#ef2929;stroke-width:2.20239115;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path4024-1"
+         d="M 58.227407,22.357217 53.84498,20.143591"
+         style="fill:none;stroke:#a40000;stroke-width:6.60717344;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path4024-6-8"
+         d="M 58.227407,22.357217 53.84498,20.143591"
+         style="fill:none;stroke:#ef2929;stroke-width:2.20239115;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path4024-7"
+         d="M 53.84498,6.8618373 51.653766,11.289089"
+         style="fill:none;stroke:#a40000;stroke-width:6.60717344;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path4024-6-9"
+         d="M 53.84498,6.8618373 51.653766,11.289089"
+         style="fill:none;stroke:#ef2929;stroke-width:2.20239115;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path4024-7-2"
+         d="m 40.697698,6.8618373 2.191214,4.4272517"
+         style="fill:none;stroke:#a40000;stroke-width:6.60717344;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path4024-6-9-0"
+         d="m 40.697698,6.8618373 2.191214,4.4272517"
+         style="fill:none;stroke:#ef2929;stroke-width:2.20239115;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
     </g>
   </g>
 </svg>

--- a/src/Mod/Part/Gui/Resources/icons/Part_SliceApart.svg
+++ b/src/Mod/Part/Gui/Resources/icons/Part_SliceApart.svg
@@ -1,0 +1,362 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="64px"
+   height="64px"
+   id="svg2568"
+   sodipodi:version="0.32"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="Part_Slice.svg"
+   inkscape:output_extension="org.inkscape.output.svg.inkscape"
+   version="1.1">
+  <defs
+     id="defs2570">
+    <linearGradient
+       id="linearGradient3864">
+      <stop
+         id="stop3866"
+         offset="0"
+         style="stop-color:#71b2f8;stop-opacity:1;" />
+      <stop
+         id="stop3868"
+         offset="1"
+         style="stop-color:#002795;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3593">
+      <stop
+         style="stop-color:#c8e0f9;stop-opacity:1;"
+         offset="0"
+         id="stop3595" />
+      <stop
+         style="stop-color:#637dca;stop-opacity:1;"
+         offset="1"
+         id="stop3597" />
+    </linearGradient>
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 32 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="64 : 32 : 1"
+       inkscape:persp3d-origin="32 : 21.333333 : 1"
+       id="perspective2576" />
+    <radialGradient
+       r="19.571428"
+       fy="26.281744"
+       fx="46.534134"
+       cy="26.281744"
+       cx="46.534134"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3090"
+       xlink:href="#linearGradient3143"
+       inkscape:collect="always"
+       gradientTransform="matrix(1.1486088,1.8477617,-3.056673,1.900094,73.257745,-112.1016)" />
+    <linearGradient
+       id="linearGradient3143">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0"
+         id="stop3145" />
+      <stop
+         style="stop-color:#d3d7cf;stop-opacity:1"
+         offset="1"
+         id="stop3147" />
+    </linearGradient>
+    <radialGradient
+       r="19.571428"
+       fy="25.149042"
+       fx="48.645836"
+       cy="25.149042"
+       cx="48.645836"
+       gradientTransform="matrix(0.63294029,0.93089132,-0.82695376,0.56227002,38.653022,-34.275496)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3165"
+       xlink:href="#linearGradient3143-7"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3143-7">
+      <stop
+         style="stop-color:#729fcf;stop-opacity:1"
+         offset="0"
+         id="stop3145-0" />
+      <stop
+         style="stop-color:#3465a4;stop-opacity:1"
+         offset="1"
+         id="stop3147-9" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3143-8"
+       id="radialGradient3991"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.51094884,-0.61313857,0.25133659,-0.20944716,57.452467,81.167084)"
+       cx="56.831726"
+       cy="30.181183"
+       fx="56.831726"
+       fy="30.181183"
+       r="19.571428" />
+    <linearGradient
+       id="linearGradient3143-8">
+      <stop
+         style="stop-color:#3465a4;stop-opacity:1"
+         offset="0"
+         id="stop3145-4" />
+      <stop
+         style="stop-color:#729fcf;stop-opacity:1"
+         offset="1"
+         id="stop3147-50" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3994-3"
+       id="linearGradient4000-2"
+       x1="62.000004"
+       y1="34"
+       x2="52"
+       y2="34"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect"
+       gradientTransform="matrix(0.87648555,0,0,1.1068128,0.81760416,1.3277733)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3994-3">
+      <stop
+         style="stop-color:#a40000;stop-opacity:1"
+         offset="0"
+         id="stop3996-7" />
+      <stop
+         style="stop-color:#ef2929;stop-opacity:1"
+         offset="1"
+         id="stop3998-5" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="6.522097"
+     inkscape:cx="8.5765871"
+     inkscape:cy="40.116319"
+     inkscape:current-layer="g3560"
+     showgrid="true"
+     inkscape:document-units="px"
+     inkscape:grid-bbox="true"
+     inkscape:window-width="1920"
+     inkscape:window-height="1001"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid2996"
+       empspacing="2"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata2573">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>[DeepSOIC]</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:title>Part_Slice</dc:title>
+        <dc:date>2016-07-29</dc:date>
+        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>FreeCAD</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:identifier>FreeCAD/src/Mod/Part/Gui/Resources/icons/Part_Slice.svg</dc:identifier>
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>FreeCAD LGPL2+</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <cc:license>https://www.gnu.org/copyleft/lesser.html</cc:license>
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title>[agryson] Alexander Gryson</dc:title>
+          </cc:Agent>
+        </dc:contributor>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer">
+    <g
+       id="g3560"
+       transform="matrix(0.91273618,0,0,0.90349515,105.85374,2.800363)">
+      <path
+         transform="matrix(1.1209541,0,0,1.1324194,-151.52151,2.0236756)"
+         d="m 71.785715,34.571426 c 0,10.256717 -8.314712,18.571429 -18.571428,18.571429 -10.256717,0 -18.571428,-8.314712 -18.571428,-18.571429 0,-10.256716 8.314711,-18.571428 18.571428,-18.571428 10.256716,0 18.571428,8.314712 18.571428,18.571428 z"
+         sodipodi:ry="18.571428"
+         sodipodi:rx="18.571428"
+         sodipodi:cy="34.571426"
+         sodipodi:cx="53.214287"
+         id="path3550-3-3"
+         style="fill:url(#radialGradient3165);fill-opacity:1;fill-rule:evenodd;stroke:#0b1521;stroke-width:1.95265329;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         sodipodi:type="arc" />
+      <path
+         transform="matrix(1.0029659,0,0,1.0132241,-145.24287,6.1444238)"
+         d="m 71.785715,34.571426 c 0,10.256717 -8.314712,18.571429 -18.571428,18.571429 -10.256717,0 -18.571428,-8.314712 -18.571428,-18.571429 0,-10.256716 8.314711,-18.571428 18.571428,-18.571428 10.256716,0 18.571428,8.314712 18.571428,18.571428 z"
+         sodipodi:ry="18.571428"
+         sodipodi:rx="18.571428"
+         sodipodi:cy="34.571426"
+         sodipodi:cx="53.214287"
+         id="path3550-3-1-6"
+         style="fill:none;stroke:#729fcf;stroke-width:2.18236232;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         sodipodi:type="arc" />
+      <path
+         transform="matrix(1.1209541,0,0,1.1324194,-131.80057,-13.471699)"
+         d="m 71.785715,34.571426 c 0,10.256717 -8.314712,18.571429 -18.571428,18.571429 -10.256717,0 -18.571428,-8.314712 -18.571428,-18.571429 0,-10.256716 8.314711,-18.571428 18.571428,-18.571428 10.256716,0 18.571428,8.314712 18.571428,18.571428 z"
+         sodipodi:ry="18.571428"
+         sodipodi:rx="18.571428"
+         sodipodi:cy="34.571426"
+         sodipodi:cx="53.214287"
+         id="path3550-3"
+         style="fill:url(#radialGradient3090);fill-opacity:1;fill-rule:evenodd;stroke:#2e3436;stroke-width:1.95265328999999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         sodipodi:type="arc" />
+      <g
+         id="g3987"
+         transform="matrix(0.84821111,0.2296021,-0.22920173,0.86414155,-95.764174,-3.5769808)">
+        <path
+           id="path3550-3-36"
+           d="m 22,21 c -0.1166,0 -0.22765,0.02916 -0.34375,0.03125 C 21.22885,22.614131 21,24.282004 21,26 c 0,10.49401 8.50599,19 19,19 0.1166,0 0.22765,-0.02916 0.34375,-0.03125 C 40.77115,43.385869 41,41.717996 41,40 41,29.50599 32.49401,21 22,21 z"
+           style="fill:url(#radialGradient3991);fill-opacity:1;fill-rule:evenodd;stroke:#0b1521;stroke-width:2.48211598;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+           inkscape:connector-curvature="0" />
+        <path
+           id="path3550-3-1-1"
+           d="m 23.72748,23.909844 c -0.155127,0.889936 -0.263225,1.808987 -0.263225,2.743203 0,8.367259 6.481855,15.207464 14.711346,15.817191 0.155127,-0.889934 0.263225,-1.808987 0.263225,-2.743203 0,-8.367258 -6.481856,-15.207464 -14.711346,-15.817191 z"
+           style="fill:none;stroke:#729fcf;stroke-width:2.48211575;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+           inkscape:connector-curvature="0" />
+      </g>
+      <g
+         transform="translate(-107.44028,-2.8457408)"
+         id="g4095">
+        <path
+           sodipodi:nodetypes="cczccc"
+           inkscape:connector-curvature="0"
+           id="path3206"
+           d="m 38.506483,33.425344 0,30.990759 c 0,0 1.752973,4.427251 9.641343,4.427251 7.88837,0 9.641339,-4.427251 9.641339,-4.427251 l 0,-30.990759 z"
+           style="fill:url(#linearGradient4000-2);fill-opacity:1;stroke:#280000;stroke-width:2.20239091;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1" />
+        <path
+           sodipodi:nodetypes="cczccc"
+           inkscape:connector-curvature="0"
+           id="path3206-6"
+           d="m 40.697698,35.63897 0,28.223727 c 0,0 1.704278,2.767032 7.669251,2.767032 5.964972,0 7.669249,-2.767032 7.669249,-2.767032 l 0,-28.223727 z"
+           style="fill:none;stroke:#ef2929;stroke-width:2.20239115;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+        <path
+           transform="matrix(0.85818027,0,0,1.0066384,36.189573,4.1993198)"
+           d="m 25.169065,29.033289 c 0,2.428978 -5.029918,4.398055 -11.234635,4.398055 -6.2047171,0 -11.2346343,-1.969077 -11.2346343,-4.398055 0,-2.428979 5.0299172,-4.398055 11.2346343,-4.398055 6.204717,0 11.234635,1.969076 11.234635,4.398055 z"
+           sodipodi:ry="4.3980546"
+           sodipodi:rx="11.234634"
+           sodipodi:cy="29.033289"
+           sodipodi:cx="13.93443"
+           id="path3186"
+           style="fill:#cc0000;fill-opacity:1;stroke:#280000;stroke-width:2.36956406;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:6.8"
+           sodipodi:type="arc" />
+        <path
+           transform="matrix(0.68264328,0,0,0.50331927,38.854701,18.812331)"
+           d="m 25.169065,29.033289 c 0,2.428978 -5.029918,4.398055 -11.234635,4.398055 -6.2047171,0 -11.2346343,-1.969077 -11.2346343,-4.398055 0,-2.428979 5.0299172,-4.398055 11.2346343,-4.398055 6.204717,0 11.234635,1.969076 11.234635,4.398055 z"
+           sodipodi:ry="4.3980546"
+           sodipodi:rx="11.234634"
+           sodipodi:cy="29.033289"
+           sodipodi:cx="13.93443"
+           id="path3186-0"
+           style="fill:none;stroke:#ef2929;stroke-width:3.75729895;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:6.8"
+           sodipodi:type="arc" />
+        <path
+           sodipodi:nodetypes="czc"
+           inkscape:connector-curvature="0"
+           id="path4002"
+           d="m 40.259454,38.516683 c 0,0 2.629455,1.549538 7.88837,1.549538 5.258915,0 7.88837,-1.549538 7.88837,-1.549538"
+           style="fill:none;stroke:#ef2929;stroke-width:2.20239091;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+        <path
+           transform="matrix(1.0956068,0,0,1.1068128,-8.6046095,1.3277733)"
+           sodipodi:nodetypes="czc"
+           inkscape:connector-curvature="0"
+           id="path4004"
+           d="m 52.000002,28 c 0,0 -3.289969,-4.344762 -3,-8 0.289968,-3.655238 2,-5 2,-5"
+           style="fill:none;stroke:#2e3436;stroke-width:6;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+        <path
+           sodipodi:nodetypes="czc"
+           inkscape:connector-curvature="0"
+           id="path4004-2"
+           d="m 48.366947,32.318532 c 0,0 -3.604513,-4.808838 -3.286821,-8.854503 0.317691,-4.045664 2.191213,-5.534064 2.191213,-5.534064"
+           style="fill:none;stroke:#d3d7cf;stroke-width:2.20239115;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path4024"
+           d="m 38.506483,17.929966 -4.382426,2.213625"
+           style="fill:none;stroke:#a40000;stroke-width:6.60717344;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path4024-6"
+           d="m 38.506483,17.929966 -4.382426,2.213625"
+           style="fill:none;stroke:#ef2929;stroke-width:2.20239115;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path4024-1"
+           d="M 58.227407,22.357217 53.84498,20.143591"
+           style="fill:none;stroke:#a40000;stroke-width:6.60717344;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path4024-6-8"
+           d="M 58.227407,22.357217 53.84498,20.143591"
+           style="fill:none;stroke:#ef2929;stroke-width:2.20239115;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path4024-7"
+           d="M 53.84498,6.8618373 51.653766,11.289089"
+           style="fill:none;stroke:#a40000;stroke-width:6.60717344;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path4024-6-9"
+           d="M 53.84498,6.8618373 51.653766,11.289089"
+           style="fill:none;stroke:#ef2929;stroke-width:2.20239115;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path4024-7-2"
+           d="m 40.697698,6.8618373 2.191214,4.4272517"
+           style="fill:none;stroke:#a40000;stroke-width:6.60717344;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
+        <path
+           sodipodi:nodetypes="cc"
+           inkscape:connector-curvature="0"
+           id="path4024-6-9-0"
+           d="m 40.697698,6.8618373 2.191214,4.4272517"
+           style="fill:none;stroke:#ef2929;stroke-width:2.20239115;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/src/Mod/Part/Gui/ViewProviderCompound.cpp
+++ b/src/Mod/Part/Gui/ViewProviderCompound.cpp
@@ -39,6 +39,7 @@ PROPERTY_SOURCE(PartGui::ViewProviderCompound,PartGui::ViewProviderPart)
 
 ViewProviderCompound::ViewProviderCompound()
 {
+    sPixmap = "Part_Compound.svg";
 }
 
 ViewProviderCompound::~ViewProviderCompound()

--- a/src/Mod/Part/Gui/Workbench.cpp
+++ b/src/Mod/Part/Gui/Workbench.cpp
@@ -88,6 +88,7 @@ Gui::MenuItem* Workbench::setupMenuBar() const
     Gui::MenuItem* compound = new Gui::MenuItem;
     compound->setCommand("Compound");
     *compound << "Part_Compound"
+              << "Part_ExplodeCompound"
               << "Part_CompoundFilter";
 
     Gui::MenuItem* part = new Gui::MenuItem;
@@ -184,7 +185,8 @@ Gui::ToolBarItem* Workbench::setupToolBars() const
 
     Gui::ToolBarItem* boolop = new Gui::ToolBarItem(root);
     boolop->setCommand("Boolean");
-    *boolop << "Part_Boolean"
+    *boolop << "Part_CompCompoundTools"
+            << "Part_Boolean"
             << "Part_Cut"
             << "Part_Fuse"
             << "Part_Common"

--- a/src/Mod/Part/InitGui.py
+++ b/src/Mod/Part/InitGui.py
@@ -44,6 +44,7 @@ class PartWorkbench ( Workbench ):
 
         try:
             import CompoundTools._CommandCompoundFilter
+            import CompoundTools._CommandExplodeCompound
         except ImportError as err:
             FreeCAD.Console.PrintError("Features from CompoundTools package cannot be loaded. {err}\n".format(err= str(err)))
 


### PR DESCRIPTION
New tool for Part workbench:
* Explode, to break apart compounds and shapes into child shapes (creates a bunch of CompoundFilter objects in a group)
Company: 
* Slice-Apart command in split-features dropdown toolbar button
* Compound tools dropdown command
* new icon for Compound

![slice-apart-demo](https://user-images.githubusercontent.com/8940427/50426500-3ba57700-08a0-11e9-96c5-ab0dbe97a083.png)
