### PR TITLE
fixed #3755: Crash when using Part - Refine Shape on certain files

### DIFF
--- a/src/Mod/Part/App/modelRefine.cpp
+++ b/src/Mod/Part/App/modelRefine.cpp
@@ -879,14 +879,12 @@ bool FaceTypedBSpline::isEqual(const TopoDS_Face &faceOne, const TopoDS_Face &fa
     int vKnotSequenceTwoCount(vPoleCountTwo + surfaceTwo->VDegree() + 1);
     if (uKnotSequenceOneCount != uKnotSequenceTwoCount || vKnotSequenceOneCount != vKnotSequenceTwoCount)
         return false;
-    TColStd_Array1OfReal uKnotSequenceOne(1, uKnotSequenceOneCount);
-    TColStd_Array1OfReal vKnotSequenceOne(1, vKnotSequenceOneCount);
-    TColStd_Array1OfReal uKnotSequenceTwo(1, uKnotSequenceTwoCount);
-    TColStd_Array1OfReal vKnotSequenceTwo(1, vKnotSequenceTwoCount);
-    surfaceOne->UKnotSequence(uKnotSequenceOne);
-    surfaceOne->VKnotSequence(vKnotSequenceOne);
-    surfaceTwo->UKnotSequence(uKnotSequenceTwo);
-    surfaceTwo->VKnotSequence(vKnotSequenceTwo);
+
+	TColStd_Array1OfReal uKnotSequenceOne = surfaceOne->UKnotSequence();
+	TColStd_Array1OfReal vKnotSequenceOne = surfaceOne->VKnotSequence();
+	TColStd_Array1OfReal uKnotSequenceTwo = surfaceTwo->UKnotSequence();
+	TColStd_Array1OfReal vKnotSequenceTwo = surfaceTwo->VKnotSequence();
+
     for (int indexU = 1; indexU <= uKnotSequenceOneCount; ++indexU)
         if (uKnotSequenceOne.Value(indexU) != uKnotSequenceTwo.Value(indexU))
             return false;

--- a/src/Mod/Part/App/modelRefine.cpp
+++ b/src/Mod/Part/App/modelRefine.cpp
@@ -880,10 +880,22 @@ bool FaceTypedBSpline::isEqual(const TopoDS_Face &faceOne, const TopoDS_Face &fa
     if (uKnotSequenceOneCount != uKnotSequenceTwoCount || vKnotSequenceOneCount != vKnotSequenceTwoCount)
         return false;
 
+
+#if OCC_VERSION_HEX >= 0x070000
 	TColStd_Array1OfReal uKnotSequenceOne = surfaceOne->UKnotSequence();
 	TColStd_Array1OfReal vKnotSequenceOne = surfaceOne->VKnotSequence();
 	TColStd_Array1OfReal uKnotSequenceTwo = surfaceTwo->UKnotSequence();
 	TColStd_Array1OfReal vKnotSequenceTwo = surfaceTwo->VKnotSequence();
+#else
+	TColStd_Array1OfReal uKnotSequenceOne(1, uKnotSequenceOneCount);
+	TColStd_Array1OfReal vKnotSequenceOne(1, vKnotSequenceOneCount);
+	TColStd_Array1OfReal uKnotSequenceTwo(1, uKnotSequenceTwoCount);
+	TColStd_Array1OfReal vKnotSequenceTwo(1, vKnotSequenceTwoCount);
+	surfaceOne->UKnotSequence(uKnotSequenceOne);
+	surfaceOne->VKnotSequence(vKnotSequenceOne);
+	surfaceTwo->UKnotSequence(uKnotSequenceTwo);
+	surfaceTwo->VKnotSequence(vKnotSequenceTwo);
+#endif
 
     for (int indexU = 1; indexU <= uKnotSequenceOneCount; ++indexU)
         if (uKnotSequenceOne.Value(indexU) != uKnotSequenceTwo.Value(indexU))


### PR DESCRIPTION
A workaround for an OCC bug which caused the problem.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [x] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
