### PR TITLE
Cannot mix bytes and nonbytes literals in OpenSCADUtils.py

### DIFF
--- a/src/Mod/OpenSCAD/OpenSCADUtils.py
+++ b/src/Mod/OpenSCAD/OpenSCADUtils.py
@@ -70,9 +70,9 @@ def searchforopenscadexe():
                 return testpath
     elif sys.platform == 'darwin':
         ascript = (b'tell application "Finder"\n'
-        'POSIX path of (application file id "org.openscad.OpenSCAD"'
-        'as alias)\n'
-        'end tell')
+        b'POSIX path of (application file id "org.openscad.OpenSCAD"'
+        b'as alias)\n'
+        b'end tell')
         p1=subprocess.Popen(['osascript','-'],stdin=subprocess.PIPE,\
                 stdout=subprocess.PIPE,stderr=subprocess.PIPE)
         stdout,stderr = p1.communicate(ascript)


### PR DESCRIPTION
Fixes Travis test failure: https://travis-ci.org/FreeCAD/FreeCAD/jobs/474743289#L8528

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
