### PR TITLE
Travis CI: Allow_failures on Python3 and osx tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,9 @@ env:
     - OSX_PORTS_CACHE=${OSX_PORTS_CACHE:-FreeCAD/FreeCAD-ports-cache}
     - DEPLOY=${DEPLOY:-0}
   matrix:
+    allow_failures:
+      - os: osx
+      - python: 3.6
     # chunk.io key (if needed, obtain it with Yorik, PrzemoF, Kunda1)
     secure: MJu0ZU/9Yqut6bUkHoSrXTV/c/WhCLR0KnHKCsnEU081PYoukzH6ngzgKk7/trAH2In080d/ra4B2OmTNl/LAgV6DXKFY9dO1aG8QwcrHgaMPf0pHYUy/OfwQSFYFByQDV2OEMAHcIWc/dtNkzK2QUi44Kn7d0GtSEiN4s816lriWtjg0vmEGAU8MjvcAGss4gKyn05Xm1NUCYPKgpgIHsywLbpE76lv0eOYoosEuKv5Q9Pb4FMQts02+JUlqE8eY4ZZ3nV8iQbgIDdseOSA7Ixn05zWjU/ZRZ74TrYxMnzfUAwQcJe9OcqoESq+pPWQt5HYG66VmeVxQim1gmsiDASH51U/nswKt0Q4bISj3tVk0YZMFV8Ax+SzPvLEmFZJQGfgO1mg7HdNcz9N9G5JHPawrV19DwYIEFbAw8MCSAoIXFOcPQZUWXCbtjm7NO9vCjMrqyVJMDD9L8omvQajHoajuHbOT8KB250gFokeLj3z8yu++Tz+IrZX5inUMrXsARVt/ALXpi8rJPXmoFMpMUjyWmDPqPWlnqUhLtTtEtKpuOWP8ZnWVwkg4QYOUhCy95C1okJSGkG+ylHWncWfY4mS+UBT525laoh+GOhH+sRW+p2xkI21xGFRqg1oHjjgY1yIYF6nnSHPzxMBRYmZwagyXsjkFG5FPMWR2oYk0Yg
 cache:
@@ -33,7 +36,7 @@ cache:
 language: cpp
 python:
     - 2.7
-    - 3.4
+    - 3.6
 
 # Inject osx build into matrix - needed to specify image/dist
 matrix:
@@ -61,12 +64,12 @@ matrix:
 
 # This is commented out to stop permanently failing osx builds. Please check this thread for the details:
 # https://forum.freecadweb.org/viewtopic.php?f=10&t=32272
-#      - os: osx
-#        osx_image: xcode7.3
-#        compiler: clang
-#        env:
-#          - CMAKE_OPTS="-DBUILD_FEM_NETGEN=ON" QT=Qt5
-#          - PYTHON_MAJOR_VERSION=2
+      - os: osx
+        osx_image: xcode7.3
+        compiler: clang
+        env:
+          - CMAKE_OPTS="-DBUILD_FEM_NETGEN=ON" QT=Qt5
+          - PYTHON_MAJOR_VERSION=2
 
 git:
   depth: 5000
@@ -130,7 +133,7 @@ before_install:
                                swig                             \
                                libvtk6-dev                      \
                                libmed-dev                       \
-                               libmedc-dev			\
+                               libmedc-dev                      \
                                asciidoc
 
        # Make sure dpkg is upgraded for Ubuntu 14.04 (required for eigen3)


### PR DESCRIPTION
This allows us to keep Travis tests passing while we work on both Python 3 and macOS compatibility.

Also upgrade from Python 3.4 --> 3.6 because the EOL of Python 3.4 is in just a few months...
* https://devguide.python.org/#branchstatus

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
