### PR TITLE
Undefined name: to --> 'to'

### DIFF
--- a/src/Tools/fcbt/FileTools.py
+++ b/src/Tools/fcbt/FileTools.py
@@ -44,7 +44,7 @@ def cpall(dirFrom, dirTo):
                 cpfile(pathFrom, pathTo)
                 fcount = fcount+1
             except:
-                print('Error copying', pathFrom, to, pathTo, '--skipped')
+                print('Error copying', pathFrom, 'to', pathTo, '--skipped')
                 print(sys.exc_type, sys.exc_value)
         else:
             if verbose: print('copying dir', pathFrom, 'to', pathTo)
@@ -83,7 +83,7 @@ def cpallWithFilter(dirFrom, dirTo,MatchList):
                     cpfile(pathFrom, pathTo)
                     fcount = fcount+1
                 except:
-                    print('Error copying', pathFrom, to, pathTo, '--skipped')
+                    print('Error copying', pathFrom, 'to', pathTo, '--skipped')
                     print(sys.exc_type, sys.exc_value)
             else:
                 if verbose: print('copying dir', pathFrom, 'to', pathTo)


### PR DESCRIPTION
```
./src/Tools/fcbt/FileTools.py:47:50: F821 undefined name 'to'
                print('Error copying', pathFrom, to, pathTo, '--skipped')
                                                 ^
./src/Tools/fcbt/FileTools.py:86:54: F821 undefined name 'to'
                    print('Error copying', pathFrom, to, pathTo, '--skipped')
                                                     ^
```

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
