### PR TITLE
Fix two Python 3 syntax errors

### DIFF
--- a/src/Tools/ArchiveNameFromVersionHeader.py
+++ b/src/Tools/ArchiveNameFromVersionHeader.py
@@ -38,7 +38,7 @@ def main():
 
     version = deserializeVersionHeader(sys.argv[1])
     if SHA:
-	version['FCRepositoryHash'] = SHA
+        version['FCRepositoryHash'] = SHA
 
     print('FreeCAD_{Major}.{Minor}-{RevCount}.{GitShortSHA}-{OS}-{Arch}'.format(
           Major=version['FCVersionMajor'],
@@ -50,4 +50,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-

--- a/src/Tools/generateBase/__exec_new.py
+++ b/src/Tools/generateBase/__exec_new.py
@@ -1,4 +1,0 @@
-# remove this once python2 support has stopped
-
-def __exec_new__(text, globals, locals):
-    exec(text, globals, locals)

--- a/src/Tools/generateBase/__exec_old.py
+++ b/src/Tools/generateBase/__exec_old.py
@@ -1,4 +1,0 @@
-# remove this file once the python2 support has stopped
-
-def __exec_old__(text, globals, locals):
-    exec text in globals, locals

--- a/src/Tools/generateBase/generateTools.py
+++ b/src/Tools/generateBase/generateTools.py
@@ -4,21 +4,8 @@
 
 from __future__ import print_function # this allows py2 to print(str1,str2) correctly
 
-import os, errno
-
-
-def temporary_exec(text, globals, locals):
-    """this function is a dirty hack to allow using the copier from
-       python2 and python3. Once the support of python2 has stopped
-       feel free to remove this function and use the std exec function 
-       instead"""
-    # maybe this should be fixed by rewriting the generators.
-    if sys.version_info[0] < 3:
-        from .__exec_old import __exec_old__
-        __exec_old__(text, globals, locals)
-    else:
-        from .__exec_new import __exec_new__
-        __exec_new__(text, globals, locals)
+import errno
+import os
 
 
 def ensureDir(path,mode=0o777):
@@ -91,7 +78,7 @@ class copier:
                 stat = self.preproc(stat, 'exec')
                 stat = '%s _cb(%s,%s)' % (stat,i+1,j)
                 # for debugging, uncomment...: print("-> Executing: {"+stat+"}")
-                temporary_exec(stat, self.globals, self.locals)
+                exec(stat, self.globals, self.locals)
                 i=j+1
             else:       # normal line, just copy with substitution
                 try:


### PR DESCRIPTION
Fix mixed indentation error and the __exec()__ function works in both Python 2 and Python 3.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
