### PR TITLE
Missing import FreeCAD and/or FreeCADGui

### DIFF
--- a/src/App/FreeCADTest.py
+++ b/src/App/FreeCADTest.py
@@ -32,7 +32,10 @@
 
 Log ("FreeCAD test running...\n\n")
 
-import TestApp, sys
+import sys
+
+import FreeCAD
+import TestApp
 
 testCase = FreeCAD.ConfigGet("TestCase")
 

--- a/src/Mod/AddonManager/InitGui.py
+++ b/src/Mod/AddonManager/InitGui.py
@@ -2,6 +2,8 @@
 # AddonManager gui init module
 # (c) 2001 Juergen Riegel
 # License LGPL
+
+import FreeCADGui
 from AddonManagerGui import CmdAddonMgr
 
 FreeCADGui.addCommand('Std_AddonMgr', CmdAddonMgr())

--- a/src/Mod/Arch/Init.py
+++ b/src/Mod/Arch/Init.py
@@ -21,6 +21,8 @@
 #*                                                                         *
 #***************************************************************************
 
+import FreeCAD
+
 # add import/export types
 FreeCAD.addImportType("Industry Foundation Classes (*.ifc)","importIFC")
 FreeCAD.addExportType("Industry Foundation Classes (*.ifc)","importIFC")

--- a/src/Mod/Arch/InitGui.py
+++ b/src/Mod/Arch/InitGui.py
@@ -21,6 +21,10 @@
 #*                                                                         *
 #***************************************************************************
 
+import FreeCAD
+import FreeCADGui
+
+
 class ArchWorkbench(Workbench):
     "Arch workbench object"
     def __init__(self):

--- a/src/Mod/Assembly/InitGui.py
+++ b/src/Mod/Assembly/InitGui.py
@@ -29,6 +29,7 @@
 #*   Juergen Riegel 2002                                                   *
 #***************************************************************************/
 
+import FreeCAD
 
 
 class AssemblyWorkbench ( Workbench ):

--- a/src/Mod/Complete/InitGui.py
+++ b/src/Mod/Complete/InitGui.py
@@ -29,6 +29,8 @@
 #*   Juergen Riegel 2002                                                   *
 #***************************************************************************/
 
+import FreeCAD
+
 
 class CompleteWorkbench(Workbench):
     "Complete workbench object"

--- a/src/Mod/Draft/InitGui.py
+++ b/src/Mod/Draft/InitGui.py
@@ -20,9 +20,13 @@
 #*                                                                         *
 #***************************************************************************
 
-__title__="FreeCAD Draft Workbench - Init file"
+import FreeCAD
+import FreeCADGui
+
+__title__ = "FreeCAD Draft Workbench - Init file"
 __author__ = "Yorik van Havre <yorik@uncreated.net>"
 __url__ = ["http://www.freecadweb.org"]
+
 
 class DraftWorkbench (Workbench):
     "the Draft Workbench"

--- a/src/Mod/Drawing/InitGui.py
+++ b/src/Mod/Drawing/InitGui.py
@@ -29,6 +29,8 @@
 #*   Juergen Riegel 2002                                                   *
 #***************************************************************************/
 
+import FreeCAD
+
 
 class DrawingWorkbench (Workbench):
     "Drawing workbench object"

--- a/src/Mod/Idf/Init.py
+++ b/src/Mod/Idf/Init.py
@@ -29,7 +29,7 @@
 #*   Juergen Riegel 2002                                                   *
 #***************************************************************************/
 
-
+import FreeCAD
 
 # two options for IDF added by Milos Koutny (12-Feb-2010)
 FreeCAD.addImportType("IDF emn file File Type (*.emn)","Idf") 

--- a/src/Mod/Image/InitGui.py
+++ b/src/Mod/Image/InitGui.py
@@ -29,6 +29,7 @@
 #*   Juergen Riegel 2002                                                   *
 #***************************************************************************/
 
+import FreeCAD
 
 
 class ImageWorkbench ( Workbench ):

--- a/src/Mod/Import/Init.py
+++ b/src/Mod/Import/Init.py
@@ -25,7 +25,7 @@
 #*   Juergen Riegel 2002                                                   *
 #***************************************************************************/
 
-
+import FreeCAD
 
 # Append the open handler
 #FreeCAD.addImportType("STEP 214 (*.step *.stp)","ImportGui")

--- a/src/Mod/Inspection/InitGui.py
+++ b/src/Mod/Inspection/InitGui.py
@@ -29,6 +29,7 @@
 #*   Juergen Riegel 2002                                                   *
 #***************************************************************************/
 
+import FreeCAD
 
 
 class InspectionWorkbench ( Workbench ):

--- a/src/Mod/JtReader/Init.py
+++ b/src/Mod/JtReader/Init.py
@@ -1,5 +1,7 @@
 # FreeCAD init script of the JtReader module
 # (c) 2007 Juergen Riegel LGPL
 
+import FreeCAD
+
 # Append the open handler
 FreeCAD.addImportType("JtOpen (*.jt)","JtReader")

--- a/src/Mod/Mesh/Init.py
+++ b/src/Mod/Mesh/Init.py
@@ -1,6 +1,8 @@
 # FreeCAD init script of the Mesh module
 # (c) 2004 Werner Mayer LGPL
 
+import FreeCAD
+
 # Append the open handler
 FreeCAD.addImportType("STL Mesh (*.stl *.ast)", "Mesh")
 FreeCAD.addImportType("Binary Mesh (*.bms)","Mesh")

--- a/src/Mod/Mesh/InitGui.py
+++ b/src/Mod/Mesh/InitGui.py
@@ -29,6 +29,9 @@
 #*   Werner Mayer 2004                                                     *
 #***************************************************************************/
 
+import FreeCAD
+
+
 class MeshWorkbench (Workbench):
     "Mesh workbench object"
     def __init__(self):

--- a/src/Mod/OpenSCAD/InitGui.py
+++ b/src/Mod/OpenSCAD/InitGui.py
@@ -29,6 +29,8 @@
 #***************************************************************************/
 
 import FreeCAD
+import FreeCADGui
+
 param = FreeCAD.ParamGet(\
     "User parameter:BaseApp/Preferences/Mod/OpenSCAD")
 openscadfilename = param.GetString('openscadexecutable')

--- a/src/Mod/Part/Init.py
+++ b/src/Mod/Part/Init.py
@@ -25,6 +25,7 @@
 #*   Juergen Riegel 2002                                                   *
 #***************************************************************************/
 
+import FreeCAD
 
 #FreeCAD.addImportType("CAD formats (*.igs *.iges *.step *.stp *.brep *.brp)","Part")
 #FreeCAD.addExportType("CAD formats (*.igs *.iges *.step *.stp *.brep *.brp)","Part")

--- a/src/Mod/Part/InitGui.py
+++ b/src/Mod/Part/InitGui.py
@@ -29,6 +29,7 @@
 #*   Juergen Riegel 2002                                                   *
 #***************************************************************************/
 
+import FreeCAD
 
 
 class PartWorkbench ( Workbench ):

--- a/src/Mod/PartDesign/Init.py
+++ b/src/Mod/PartDesign/Init.py
@@ -25,4 +25,6 @@
 #*   Juergen Riegel 2002                                                   *
 #***************************************************************************/
 
+import FreeCAD
+
 FreeCAD.__unit_test__ += [ "TestPartDesignApp" ]

--- a/src/Mod/PartDesign/InitGui.py
+++ b/src/Mod/PartDesign/InitGui.py
@@ -29,6 +29,9 @@
 #*   Juergen Riegel 2002                                                   *
 #***************************************************************************/
 
+import FreeCAD
+
+
 class PartDesignWorkbench ( Workbench ):
     "PartDesign workbench object"
     def __init__(self):

--- a/src/Mod/Path/Init.py
+++ b/src/Mod/Path/Init.py
@@ -20,7 +20,9 @@
 #*   USA                                                                   *
 #*                                                                         *
 #***************************************************************************/
-            
+     
+import FreeCAD
+
 # Get the Parameter Group of this module
 ParGrp = App.ParamGet("System parameter:Modules").GetGroup("Path")
 

--- a/src/Mod/Path/InitGui.py
+++ b/src/Mod/Path/InitGui.py
@@ -21,6 +21,10 @@
 # *                                                                         *
 # ***************************************************************************/
 
+import FreeCAD
+import FreeCADGui
+
+
 class PathCommandGroup:
     def __init__(self, cmdlist, menu, tooltip = None):
         self.cmdlist = cmdlist

--- a/src/Mod/Path/PathScripts/Macros/create_tool.py
+++ b/src/Mod/Path/PathScripts/Macros/create_tool.py
@@ -24,9 +24,11 @@
 This macro is used in conjunction with the toolpathparams script to create an object that represents a tool for use in a CNC program. Create a group and then select it- then run the macro.
 You will have to edit the parameters inside the Data tab of the tool object.
 '''
+
+import FreeCAD
+import FreeCADGui
 import PathScripts
 import toolpathparams as tp
-
 
 tl = FreeCAD.ActiveDocument.addObject("App::FeaturePython","Tools")
 

--- a/src/Mod/Plot/InitGui.py
+++ b/src/Mod/Plot/InitGui.py
@@ -21,6 +21,8 @@
 #*                                                                         *
 #***************************************************************************
 
+import FreeCAD
+
 
 class PlotWorkbench(Workbench):
     """Workbench of Plot module."""

--- a/src/Mod/Points/Init.py
+++ b/src/Mod/Points/Init.py
@@ -25,6 +25,7 @@
 #*   Juergen Riegel 2002                                                   *
 #***************************************************************************/
 
+import FreeCAD
 
 
 # Append the open handler

--- a/src/Mod/Points/InitGui.py
+++ b/src/Mod/Points/InitGui.py
@@ -29,6 +29,7 @@
 #*   Juergen Riegel 2002                                                   *
 #***************************************************************************/
 
+import FreeCAD
 
 
 class PointsWorkbench ( Workbench ):

--- a/src/Mod/Raytracing/InitGui.py
+++ b/src/Mod/Raytracing/InitGui.py
@@ -29,6 +29,7 @@
 #*   Juergen Riegel 2002                                                   *
 #***************************************************************************/
 
+import FreeCAD
 
 
 class RaytracingWorkbench ( Workbench ):

--- a/src/Mod/ReverseEngineering/InitGui.py
+++ b/src/Mod/ReverseEngineering/InitGui.py
@@ -29,6 +29,7 @@
 #*   Juergen Riegel 2002                                                   *
 #***************************************************************************/
 
+import FreeCAD
 
 
 class ReverseEngineeringWorkbench ( Workbench ):

--- a/src/Mod/Robot/InitGui.py
+++ b/src/Mod/Robot/InitGui.py
@@ -29,6 +29,7 @@
 #*   Juergen Riegel 2009                                                   *
 #***************************************************************************/
 
+import FreeCAD
 
 
 class RobotWorkbench ( Workbench ):

--- a/src/Mod/Ship/InitGui.py
+++ b/src/Mod/Ship/InitGui.py
@@ -21,6 +21,8 @@
 #*                                                                         *
 #***************************************************************************
 
+import FreeCAD
+
 
 class ShipWorkbench(Workbench):
     """Ships design workbench."""

--- a/src/Mod/Sketcher/Init.py
+++ b/src/Mod/Sketcher/Init.py
@@ -25,5 +25,6 @@
 #*   Juergen Riegel 2002                                                   *
 #***************************************************************************/
 
+import FreeCAD
 
 FreeCAD.__unit_test__ += [ "TestSketcherApp" ]

--- a/src/Mod/Sketcher/InitGui.py
+++ b/src/Mod/Sketcher/InitGui.py
@@ -29,6 +29,7 @@
 #*   Juergen Riegel 2002                                                   *
 #***************************************************************************/
 
+import FreeCAD
 
 
 class SketcherWorkbench ( Workbench ):

--- a/src/Mod/Spreadsheet/InitGui.py
+++ b/src/Mod/Spreadsheet/InitGui.py
@@ -30,6 +30,8 @@
 #*   Juergen Riegel 2002                                                   *
 #***************************************************************************/
 
+import FreeCAD
+
 
 class SpreadsheetWorkbench ( Workbench ):
     "Spreadsheet workbench object"

--- a/src/Mod/Start/InitGui.py
+++ b/src/Mod/Start/InitGui.py
@@ -29,6 +29,7 @@
 #*   Juergen Riegel 2002                                                   *
 #***************************************************************************/
 
+import FreeCAD
 
 
 class StartWorkbench ( Workbench ):

--- a/src/Mod/TechDraw/Init.py
+++ b/src/Mod/TechDraw/Init.py
@@ -25,4 +25,6 @@
 #*   Juergen Riegel 2002                                                   *
 #***************************************************************************/
 
+import FreeCAD
+
 FreeCAD.__unit_test__ += [ "TestTechDrawApp" ]

--- a/src/Mod/TechDraw/InitGui.py
+++ b/src/Mod/TechDraw/InitGui.py
@@ -29,6 +29,7 @@
 #*   Juergen Riegel 2002                                                   *
 #***************************************************************************/
 
+import FreeCAD
 
 class TechDrawWorkbench (Workbench):
     "Technical Drawing workbench object"

--- a/src/Mod/TechDraw/moveViews.py
+++ b/src/Mod/TechDraw/moveViews.py
@@ -7,6 +7,7 @@
 #          (ie an SVG symbol)
 
 import FreeCAD
+import FreeCADGui
 import Part
 import Drawing
 import TechDraw

--- a/src/Mod/TemplatePyMod/SplineSurface.py
+++ b/src/Mod/TemplatePyMod/SplineSurface.py
@@ -5,6 +5,8 @@
 # len(knot_u) := nNodes_u + degree_u + 1
 # len(knot_v) := nNodes_v + degree_v + 1
 
+import FreeCAD
+
 degree_u=2
 degree_v=2
 nNodes_u=5

--- a/src/Mod/Test/Init.py
+++ b/src/Mod/Test/Init.py
@@ -25,6 +25,8 @@
 #*   Juergen Riegel 2002                                                   *
 #***************************************************************************/
 
+import FreeCAD
+
 # Base system tests
 FreeCAD.__unit_test__ += [ "BaseTests",
                            "UnitTests",

--- a/src/Mod/Test/InitGui.py
+++ b/src/Mod/Test/InitGui.py
@@ -26,6 +26,7 @@
 #*   Juergen Riegel 2002                                                   *
 #***************************************************************************/
 
+import FreeCAD
 
 
 class TestWorkbench ( Workbench ):

--- a/src/Mod/Test/testPathArray.py
+++ b/src/Mod/Test/testPathArray.py
@@ -7,6 +7,7 @@
 # DWire, etc) then run this macro.
 
 import FreeCAD
+import FreeCADGui
 import Part
 import Draft
 

--- a/src/Mod/Test/testPathArraySel.py
+++ b/src/Mod/Test/testPathArraySel.py
@@ -6,6 +6,7 @@
 # tree, not document view!!), then select edges from the "wire" object.
 
 import FreeCAD
+import FreeCADGui
 import Part
 import Draft
 

--- a/src/Mod/Tux/InitGui.py
+++ b/src/Mod/Tux/InitGui.py
@@ -18,6 +18,8 @@
 
 """Tux module for FreeCAD."""
 
+import FreeCAD
+
 p = FreeCAD.ParamGet("User parameter:Tux")
 
 

--- a/src/Mod/Web/InitGui.py
+++ b/src/Mod/Web/InitGui.py
@@ -29,6 +29,7 @@
 #*   Juergen Riegel 2002                                                   *
 #***************************************************************************/
 
+import FreeCAD
 
 
 class WebWorkbench ( Workbench ):

--- a/src/Tools/_TEMPLATEPY_/InitGui.py
+++ b/src/Tools/_TEMPLATEPY_/InitGui.py
@@ -3,6 +3,9 @@
 # (c) 2001 Juergen Riegel
 # License LGPL
 
+import FreeCAD
+
+
 class _TEMPLATEPY_Workbench ( Workbench ):
     "_TEMPLATEPY_ workbench object"
     Icon = FreeCAD.getHomePath() + "Mod/_TEMPLATEPY_/Resources/icons/_TEMPLATEPY_Workbench.svg"


### PR DESCRIPTION
These files refer to __FreeCAD__ and/or __FreeCADGui__ but those modules are not imported which results in an _undefined name_ which has the potential to raise NameError at runtime.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
