### PR TITLE
Fix TabError for Python 3

### DIFF
--- a/src/Tools/ArchiveNameFromVersionHeader.py
+++ b/src/Tools/ArchiveNameFromVersionHeader.py
@@ -38,7 +38,7 @@ def main():
 
     version = deserializeVersionHeader(sys.argv[1])
     if SHA:
-	version['FCRepositoryHash'] = SHA
+        version['FCRepositoryHash'] = SHA
 
     print('FreeCAD_{Major}.{Minor}-{RevCount}.{GitShortSHA}-{OS}-{Arch}'.format(
           Major=version['FCVersionMajor'],


### PR DESCRIPTION
Was split out of #1885...  Python 3 treats TabErrors as SyntaxErrors.
* _TabError: inconsistent use of tabs and spaces in indentation_
```
./src/Tools/ArchiveNameFromVersionHeader.py:41:34: E999 TabError: inconsistent use of tabs and spaces in indentation
	version['FCRepositoryHash'] = SHA
                                 ^
```

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
