### PR TITLE
Undefined name: Typo ‘newob‘ —> ‘newobj’

### DIFF
--- a/src/Mod/Draft/Draft.py
+++ b/src/Mod/Draft/Draft.py
@@ -2684,7 +2684,7 @@ def upgrade(objects,delete=False,force=None):
                     newobj.Shape = sol
                     addList.append(newobj)
                     deleteList.append(obj)
-            return newob
+            return newobj
 
     def closeWire(obj):
         """closes a wire object, if possible"""


### PR DESCRIPTION
Discovered via #1883

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
