### PR TITLE
apply() was removed in Python 3

### DIFF
--- a/src/Mod/Test/unittestgui.py
+++ b/src/Mod/Test/unittestgui.py
@@ -51,7 +51,7 @@ class BaseGUITestRunner:
         self.currentResult = None
         self.running = 0
         self.__rollbackImporter = None
-        apply(self.initGUI, args, kwargs)
+        self.initGUI(*args, **kwargs)
 
     def getSelectedTestName(self):
         "Override to return the name of the test selected to be run"
@@ -75,7 +75,7 @@ class BaseGUITestRunner:
             test = unittest.defaultTestLoader.loadTestsFromName(testName)
         except:
             exc_type, exc_value, exc_tb = sys.exc_info()
-            apply(traceback.print_exception,sys.exc_info())
+            traceback.print_exception(*sys.exc_info())
             self.errorDialog("Unable to run test '%s'" % testName,
                              "Error loading specified test: %s, %s" % \
                              (exc_type, exc_value))
@@ -341,7 +341,7 @@ class TkTestRunner(BaseGUITestRunner):
         test, error = self.errorInfo[selected]
         tk.Label(window, text=str(test),
                  foreground="red", justify=tk.LEFT).pack(anchor=tk.W)
-        tracebackLines = apply(traceback.format_exception, error + (10,))
+        tracebackLines = traceback.format_exception(*error + (10,))
         tracebackText = string.join(tracebackLines,'')
         tk.Label(window, text=tracebackText, justify=tk.LEFT).pack()
         tk.Button(window, text="Close",
@@ -356,7 +356,7 @@ class ProgressBar(tk.Frame):
     the given colour."""
 
     def __init__(self, *args, **kwargs):
-        apply(tk.Frame.__init__, (self,) + args, kwargs)
+        tk.Frame.__init__(*(self,) + args, **kwargs)
         self.canvas = tk.Canvas(self, height='20', width='60',
                                 background='white', borderwidth=3)
         self.canvas.pack(fill=tk.X, expand=1)


### PR DESCRIPTION
The [nonessential builtin function __apply()__](https://docs.python.org/2/library/functions.html#apply) was deprecated in Python 2.3 and was removed in Python 3.
```
./src/Mod/Test/unittestgui.py:54:9: F821 undefined name 'apply'
        apply(self.initGUI, args, kwargs)
        ^
./src/Mod/Test/unittestgui.py:78:13: F821 undefined name 'apply'
            apply(traceback.print_exception,sys.exc_info())
            ^
./src/Mod/Test/unittestgui.py:344:26: F821 undefined name 'apply'
        tracebackLines = apply(traceback.format_exception, error + (10,))
                         ^
./src/Mod/Test/unittestgui.py:359:9: F821 undefined name 'apply'
        apply(tk.Frame.__init__, (self,) + args, kwargs)
        ^
```
Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
