### PR TITLE
flake8 noqa a Python 3 syntax error

### DIFF
--- a/src/Tools/generateBase/__exec_old.py
+++ b/src/Tools/generateBase/__exec_old.py
@@ -1,4 +1,5 @@
 # remove this file once the python2 support has stopped
 
+
 def __exec_old__(text, globals, locals):
-    exec text in globals, locals
+    exec text in globals, locals  # noqa: E999 a Python 3 syntax error


### PR DESCRIPTION
As discussed in #1885 we need to [workaround](https://github.com/FreeCAD/FreeCAD/blob/master/src/Tools/generateBase/generateTools.py#L10L21) an obscure Python 2 bug so this PR adds a __# noqa__ linter directive to placate flake8 and thereby supress:
```
./src/Tools/generateBase/__exec_old.py:4:13: E999 SyntaxError: invalid syntax
    exec text in globals, locals
            ^
```
 
Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
