### PR TITLE
changed the FreeCAD... startup "logo"

### DIFF
--- a/src/Main/MainGui.cpp
+++ b/src/Main/MainGui.cpp
@@ -58,6 +58,7 @@
 
 void PrintInitHelp(void);
 
+/*
 const char sBanner[] = "\xc2\xa9 Juergen Riegel, Werner Mayer, Yorik van Havre 2001-2019\n"\
 "  #####                 ####  ###   ####  \n" \
 "  #                    #      # #   #   # \n" \
@@ -66,6 +67,28 @@ const char sBanner[] = "\xc2\xa9 Juergen Riegel, Werner Mayer, Yorik van Havre 2
 "  #     #   #### ####  #    #     # #   # \n" \
 "  #     #   #    #     #    #     # #   #  ##  ##  ##\n" \
 "  #     #   #### ####   ### #     # ####   ##  ##  ##\n\n" ;
+*/
+
+const char sBanner[] = "\xc2\xa9 Juergen Riegel, Werner Mayer, Yorik van Havre 2001-2018\n"\
+                       "   _____               ____    _    ____   \n" \
+                       "  |  ___| __ ___  ___ / ___|  / \\  |  _ \\   \n" \
+                       "  | |_ | '__/ _ \\/ _ \\ |     / _ \\ | | | | \n" \
+                       "  |  _|| | |  __/  __/ |___ / ___ \\| |_| |  _   _   _  \n" \
+                       "  |_|  |_|  \\___|\\___|\\____/_/   \\_\\____/  (_) (_) (_) \n\n" ;
+
+
+/*
+outputs:
+
+© Juergen Riegel, Werner Mayer, Yorik van Havre 2001-2018
+   _____               ____    _    ____   
+  |  ___| __ ___  ___ / ___|  / \  |  _ \   
+  | |_ | '__/ _ \/ _ \ |     / _ \ | | | | 
+  |  _|| | |  __/  __/ |___ / ___ \| |_| |  _   _   _  
+  |_|  |_|  \___|\___|\____/_/   \_\____/  (_) (_) (_)
+
+*/
+
 
 #if defined(_MSC_VER)
 void InitMiniDumpWriter(const std::string&);


### PR DESCRIPTION
Changed in ~/src/Main/MainGui.cpp
the "FreeCAD..." logo when launching FreeCAD from the command line, replaced the ### by a figlet output:
> figlet "FreeCAD ..."
and escaped the \ by \\
will propose it for MainCmd.cpp too

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
