### PR TITLE
Crowdin: Experiment to remove obsolete translations from .ts file

### DIFF
--- a/src/Mod/Arch/Resources/translations/Arch.ts
+++ b/src/Mod/Arch/Resources/translations/Arch.ts
@@ -2444,11 +2444,6 @@ Site creation aborted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../ArchPanel.py" line="579"/>
-        <source>Error computing shape of </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../../ArchWall.py" line="310"/>
         <source>Wall Presets...</source>
         <translation type="unfinished"></translation>

--- a/src/Mod/Path/Gui/Resources/translations/Path.ts
+++ b/src/Mod/Path/Gui/Resources/translations/Path.ts
@@ -369,11 +369,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="PathCompoundExtended.py" line="45"/>
-        <source>An ptional description of this compounded operation</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="PathCompoundExtended.py" line="46"/>
         <source>An optional description of this compounded operation</source>
         <translation type="unfinished"></translation>


### PR DESCRIPTION
Crowdin currently has an issue where typo strings that have been fixed in the FC source haven't been permeating in to the Crowdin UI. This maybe do to discrepency between lupdate and crowdin.  This PR experiments with removing a few lingering obsolete translations in the main .ts file of the Arch and Path WBs. If this works then a follow-up PR will be made to remove all the rest of the obsolete strings. 