### PR TITLE
Fix Start WB behavior for missing examples dir in Debian package

### DIFF
--- a/src/Mod/Start/StartPage/StartPage.py
+++ b/src/Mod/Start/StartPage/StartPage.py
@@ -332,9 +332,12 @@ def handle():
     if FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/Start").GetBool("ShowExamples",True):
         SECTION_EXAMPLES = encode("<h2>"+TranslationTexts.T_EXAMPLES+"</h2>")
         SECTION_EXAMPLES += "<ul>"
-        for basename in os.listdir(FreeCAD.getResourceDir()+"examples"):
-            filename = FreeCAD.getResourceDir()+"examples"+os.sep+basename
-            SECTION_EXAMPLES += encode(buildCard(filename,method="LoadExample.py?filename="))
+        examples_path = FreeCAD.getResourceDir()+"examples"
+        if os.path.exists(examples_path):
+            examples = os.listdir(examples_path)
+            for basename in examples:
+                filename = FreeCAD.getResourceDir()+"examples"+os.sep+basename
+                SECTION_EXAMPLES += encode(buildCard(filename,method="LoadExample.py?filename="))
         SECTION_EXAMPLES += "</ul>"
     HTML = HTML.replace("SECTION_EXAMPLES",SECTION_EXAMPLES)
 


### PR DESCRIPTION
Until our example `.FCStd` files are accompanied by `.py` files that can be used to generate them, they'll be considered "compiled binary objects" and must be excluded from Debian packages per the Debian Free Software Guidelines. This corrects the behavior of the Start WB in light of this--it assumes the presence of a `/usr/share/freecad/examples` dir, errors, and fails to load.