### PR TITLE
Fix Movement of Front View in ProjectionGroup

### DIFF
--- a/src/Mod/TechDraw/App/DrawProjGroup.cpp
+++ b/src/Mod/TechDraw/App/DrawProjGroup.cpp
@@ -204,13 +204,6 @@ Base::BoundBox3d DrawProjGroup::getBoundingBox() const
             bbox.Add(bb);
         }
     }
-    // This /should/ leave the centre of the bounding box at (0,0) except when
-    // we're in the process of updating the anchor view's position (eg called
-    // by moveToCentre())
-    if (anchorView) { //TODO: It looks like we might be getting called before an anchor view is set - weird...
-        bbox.MoveX(anchorView->X.getValue());
-        bbox.MoveY(anchorView->Y.getValue());
-    }
     return bbox;
 }
 
@@ -302,18 +295,6 @@ void DrawProjGroup::minimumBbViews(DrawProjGroupItem *viewPtrs[10],
     height = row0h + row1h + row2h;
 }
 
-
-void DrawProjGroup::moveToCentre(void)
-{
-    // Update the anchor view's X and Y to keep the bounding box centred on the origin
-    Base::BoundBox3d tempbbox = getBoundingBox();
-    DrawProjGroupItem *anchorView = dynamic_cast<DrawProjGroupItem *>(Anchor.getValue());
-    if (anchorView) {
-        anchorView->X.setValue((tempbbox.MinX + tempbbox.MaxX) / -2.0);
-        anchorView->Y.setValue((tempbbox.MinY + tempbbox.MaxY) / -2.0);
-    }
-}
-
 App::DocumentObject * DrawProjGroup::getProjObj(const char *viewProjType) const
 {
     for( auto it : Views.getValues() ) {
@@ -382,14 +363,16 @@ App::DocumentObject * DrawProjGroup::addProjection(const char *viewProjType)
         view->Type.setValue( viewProjType );
         view->Label.setValue( viewProjType );
         view->Source.setValues( Source.getValues() );
-        if (strcmp(viewProjType, "Front") != 0 ) {
+        if (strcmp(viewProjType, "Front") != 0 ) {  //not Front!
             vecs = getDirsFromFront(view);
             view->Direction.setValue(vecs.first);
             view->RotationVector.setValue(vecs.second);
+        } else {  //Front
+            view->LockPosition.setValue(true);  //lock "Front" position within DPG (note not Page!).
+            view->LockPosition.setStatus(App::Property::ReadOnly,true); //Front should stay locked.
         }
 
         addView(view);         //from DrawViewCollection
-        moveToCentre();
         if (view != getAnchor()) {                //anchor is done elsewhere
             view->recomputeFeature();
         }
@@ -414,7 +397,6 @@ int DrawProjGroup::removeProjection(const char *viewProjType)
                 if ( strcmp(viewProjType, projPtr->Type.getValueAsString()) == 0 ) {
                     removeView(projPtr);                                        // Remove from collection
                     getDocument()->removeObject( it->getNameInDocument() );        // Remove from the document
-                    moveToCentre();
                     return Views.getValues().size();
                 }
             }
@@ -517,7 +499,11 @@ std::pair<Base::Vector3d,Base::Vector3d> DrawProjGroup::getDirsFromFront(std::st
 
 Base::Vector3d DrawProjGroup::getXYPosition(const char *viewTypeCStr)
 {
-    Base::Vector3d result;
+    Base::Vector3d result(0.0,0.0,0.0);
+    //Front view position is always (0,0)
+    if (strcmp(viewTypeCStr, "Front") == 0 ) {  // Front!
+        return result;
+    }
     const int idxCount = 10;
     DrawProjGroupItem *viewPtrs[idxCount];
     arrangeViewPointers(viewPtrs);
@@ -778,11 +764,6 @@ void DrawProjGroup::updateChildren(void)
         }
     }
 }
-
-//void DrawProjGroup::updateChildren(const App::Property* prop)
-//{
-//    view->....setValue(s)(prop->getValue(s));
-//}
 
 /*! 
  * tell children DPGIs that parent DPG has changed Source

--- a/src/Mod/TechDraw/App/DrawProjGroup.h
+++ b/src/Mod/TechDraw/App/DrawProjGroup.h
@@ -130,9 +130,6 @@ public:
 protected:
     void onChanged(const App::Property* prop) override;
 
-    //! Moves anchor view to keep our bounding box centre on the origin
-    void moveToCentre();
-
     /// Annoying helper - keep in sync with DrawProjGroupItem::TypeEnums
     /*!
      * \todo {See note regarding App::PropertyEnumeration on my wiki page http://freecadweb.org/wiki/User:Ian.rees}

--- a/src/Mod/TechDraw/App/DrawView.cpp
+++ b/src/Mod/TechDraw/App/DrawView.cpp
@@ -140,10 +140,6 @@ void DrawView::onChanged(const App::Property* prop)
                 }
             }
         }
-//        if (prop == &X ||       //nothing needs to be calculated, just the graphic needs to be shifted.
-//            prop == &Y) {
-//            requestPaint();
-//        }
     }
     App::DocumentObject::onChanged(prop);
 }

--- a/src/Mod/TechDraw/Gui/QGIProjGroup.cpp
+++ b/src/Mod/TechDraw/Gui/QGIProjGroup.cpp
@@ -52,10 +52,11 @@ QGIProjGroup::QGIProjGroup()
     m_origin->setParentItem(this);
 
     // In place to ensure correct drawing and bounding box calculations
-    m_backgroundItem = new QGraphicsRectItem();
-    m_backgroundItem->setPen(QPen(QColor(Qt::black)));
+    // WF: obs? not even part of QGIGroup!
+    m_groupBackground = new QGraphicsRectItem();
+    m_groupBackground->setPen(QPen(QColor(Qt::black)));
 
-    //addToGroup(m_backgroundItem);
+    //addToGroup(m_groupBackground);
     setFlag(ItemIsSelectable, false);
     setFlag(ItemIsMovable, true);
     setFiltersChildEvents(true);
@@ -116,7 +117,8 @@ QVariant QGIProjGroup::itemChange(GraphicsItemChange change, const QVariant &val
                 QString type = QString::fromLatin1(projItemPtr->Type.getValueAsString());
 
                 if (type == QString::fromLatin1("Front")) {
-                    gView->setLocked(true);
+                    gView->setLocked(true);                  //this locks in GUI only
+                    fView->LockPosition.setValue(true);      //lock in App also
                     installSceneEventFilter(gView);
                     App::DocumentObject *docObj = getViewObject();
                     TechDraw::DrawProjGroup *projectionGroup = dynamic_cast<TechDraw::DrawProjGroup *>(docObj);
@@ -135,7 +137,6 @@ QVariant QGIProjGroup::itemChange(GraphicsItemChange change, const QVariant &val
     }
     return QGIViewCollection::itemChange(change, value);
 }
-
 
 void QGIProjGroup::mousePressEvent(QGraphicsSceneMouseEvent * event)
 {
@@ -208,7 +209,7 @@ QGIView * QGIProjGroup::getAnchorQItem() const
 
 void QGIProjGroup::updateView(bool update)
 {
-    m_backgroundItem->setRect(boundingRect());
+    m_groupBackground->setRect(boundingRect());
     return QGIViewCollection::updateView(update);
 }
 
@@ -217,3 +218,4 @@ void QGIProjGroup::drawBorder()
 //QGIProjGroup does not have a border!
 //    Base::Console().Message("TRACE - QGIProjGroup::drawBorder - doing nothing!!\n");
 }
+

--- a/src/Mod/TechDraw/Gui/QGIProjGroup.h
+++ b/src/Mod/TechDraw/Gui/QGIProjGroup.h
@@ -67,7 +67,7 @@ private:
     /// Convenience function
     TechDraw::DrawProjGroup * getDrawView(void) const;
 
-    QGraphicsRectItem *m_backgroundItem;
+    QGraphicsRectItem *m_groupBackground;
     QGraphicsItem* m_origin;
     QPoint mousePos;
 };


### PR DESCRIPTION
This PR fixes an issue where the Front View in a ProjectionGroup wanders around its correct position while being dragged with the mouse.  Please merge. 
Thanks,
wf

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
