### PR TITLE
Fix Out of Warnings

### DIFF
--- a/src/Mod/TechDraw/App/DrawGeomHatch.cpp
+++ b/src/Mod/TechDraw/App/DrawGeomHatch.cpp
@@ -92,7 +92,8 @@ DrawGeomHatch::DrawGeomHatch(void)
     static const char *vgroup = "GeomHatch";
 
     ADD_PROPERTY_TYPE(Source,(0),vgroup,(App::PropertyType)(App::Prop_None),"The View + Face to be crosshatched");
-    ADD_PROPERTY_TYPE(FilePattern ,(""),vgroup,App::Prop_None,"The crosshatch pattern file for this area");
+    Source.setScope(App::LinkScope::Global);
+   ADD_PROPERTY_TYPE(FilePattern ,(""),vgroup,App::Prop_None,"The crosshatch pattern file for this area");
     ADD_PROPERTY_TYPE(NamePattern,(""),vgroup,App::Prop_None,"The name of the pattern");
     ADD_PROPERTY_TYPE(ScalePattern,(1.0),vgroup,App::Prop_None,"GeomHatch pattern size adjustment");
     ScalePattern.setConstraints(&scaleRange);

--- a/src/Mod/TechDraw/App/DrawHatch.cpp
+++ b/src/Mod/TechDraw/App/DrawHatch.cpp
@@ -59,6 +59,7 @@ DrawHatch::DrawHatch(void)
 
     ADD_PROPERTY_TYPE(DirProjection ,(0,0,1.0)    ,vgroup,App::Prop_None,"Projection direction when Hatch was defined");     //sb RO?
     ADD_PROPERTY_TYPE(Source,(0),vgroup,(App::PropertyType)(App::Prop_None),"The View + Face to be hatched");
+    Source.setScope(App::LinkScope::Global);
     ADD_PROPERTY_TYPE(HatchPattern ,(""),vgroup,App::Prop_None,"The hatch pattern file for this area");
 
     DirProjection.setStatus(App::Property::ReadOnly,true);

--- a/src/Mod/TechDraw/App/DrawPage.cpp
+++ b/src/Mod/TechDraw/App/DrawPage.cpp
@@ -81,7 +81,9 @@ DrawPage::DrawPage(void)
 
     ADD_PROPERTY_TYPE(KeepUpdated, (autoUpdate), group, (App::PropertyType)(App::Prop_None), "Keep page in sync with model");
     ADD_PROPERTY_TYPE(Template, (0), group, (App::PropertyType)(App::Prop_None), "Attached Template");
+    Template.setScope(App::LinkScope::Global);
     ADD_PROPERTY_TYPE(Views, (0), group, (App::PropertyType)(App::Prop_None), "Attached Views");
+    Views.setScope(App::LinkScope::Global);
 
     // Projection Properties
     ProjectionType.setEnums(ProjectionTypeEnums);

--- a/src/Mod/TechDraw/App/DrawProjGroup.cpp
+++ b/src/Mod/TechDraw/App/DrawProjGroup.cpp
@@ -70,6 +70,7 @@ DrawProjGroup::DrawProjGroup(void)
     ADD_PROPERTY_TYPE(Source    ,(0), group, App::Prop_None,"Shape to view");
     Source.setScope(App::LinkScope::Global);
     ADD_PROPERTY_TYPE(Anchor, (0), group, App::Prop_None, "The root view to align projections with");
+    Anchor.setScope(App::LinkScope::Global);
     ProjectionType.setEnums(ProjectionTypeEnums);
     ADD_PROPERTY(ProjectionType, ((long)0));
 

--- a/src/Mod/TechDraw/App/DrawProjectSplit.h
+++ b/src/Mod/TechDraw/App/DrawProjectSplit.h
@@ -29,7 +29,6 @@
 #include <TopoDS_Wire.hxx>
 
 #include <App/DocumentObject.h>
-#include <App/PropertyLinks.h>
 #include <App/PropertyStandard.h>
 #include <App/FeaturePython.h>
 #include <Base/Vector3D.h>

--- a/src/Mod/TechDraw/App/DrawSVGTemplate.h
+++ b/src/Mod/TechDraw/App/DrawSVGTemplate.h
@@ -23,7 +23,6 @@
 #ifndef _TECHDRAW_DrawSVGTemplate_h_
 #define _TECHDRAW_DrawSVGTemplate_h_
 
-#include <App/PropertyLinks.h>
 #include <App/PropertyStandard.h>
 #include <App/PropertyFile.h>
 #include <App/FeaturePython.h>

--- a/src/Mod/TechDraw/App/DrawTemplate.h
+++ b/src/Mod/TechDraw/App/DrawTemplate.h
@@ -25,7 +25,6 @@
 
 #include <App/DocumentObject.h>
 
-#include <App/PropertyLinks.h>
 #include <App/PropertyStandard.h>
 #include <App/PropertyUnits.h>
 #include <App/FeaturePython.h>

--- a/src/Mod/TechDraw/App/DrawViewAnnotation.h
+++ b/src/Mod/TechDraw/App/DrawViewAnnotation.h
@@ -28,7 +28,6 @@
 #define _DrawViewAnnotation_h_
 
 #include <App/DocumentObject.h>
-#include <App/PropertyLinks.h>
 #include <App/PropertyStandard.h>
 #include <App/PropertyUnits.h>
 #include <App/FeaturePython.h>

--- a/src/Mod/TechDraw/App/DrawViewClip.cpp
+++ b/src/Mod/TechDraw/App/DrawViewClip.cpp
@@ -55,6 +55,7 @@ DrawViewClip::DrawViewClip(void)
     ADD_PROPERTY_TYPE(ShowFrame  ,(0) ,group,App::Prop_None,"Specifies if the clip frame appears on the page or not");
     ADD_PROPERTY_TYPE(ShowLabels ,(0) ,group,App::Prop_None,"Specifies if View labels appear within the clip area");
     ADD_PROPERTY_TYPE(Views      ,(0) ,group,App::Prop_None,"The Views in this Clip group");
+    Views.setScope(App::LinkScope::Global);
 
     // hide N/A properties
     ScaleType.setStatus(App::Property::ReadOnly,true);

--- a/src/Mod/TechDraw/App/DrawViewCollection.cpp
+++ b/src/Mod/TechDraw/App/DrawViewCollection.cpp
@@ -47,7 +47,7 @@ DrawViewCollection::DrawViewCollection()
     nowUnsetting = false;
     static const char *group = "Drawing view";
     ADD_PROPERTY_TYPE(Views     ,(0), group, App::Prop_None,"Attached Views");
-
+    Views.setScope(App::LinkScope::Global);
 }
 
 DrawViewCollection::~DrawViewCollection()

--- a/src/Mod/TechDraw/App/DrawViewDetail.cpp
+++ b/src/Mod/TechDraw/App/DrawViewDetail.cpp
@@ -103,6 +103,7 @@ DrawViewDetail::DrawViewDetail()
     static const char *dgroup = "Detail";
 
     ADD_PROPERTY_TYPE(BaseView ,(0),dgroup,App::Prop_None,"2D View source for this Section");
+    BaseView.setScope(App::LinkScope::Global);
     ADD_PROPERTY_TYPE(AnchorPoint ,(0,0,0) ,dgroup,App::Prop_None,"Location of detail in BaseView");
     ADD_PROPERTY_TYPE(Radius,(10.0),dgroup, App::Prop_None, "Size of detail area");
     ADD_PROPERTY_TYPE(Reference ,("1"),dgroup,App::Prop_None,"An identifier for this detail");

--- a/src/Mod/TechDraw/App/DrawViewImage.h
+++ b/src/Mod/TechDraw/App/DrawViewImage.h
@@ -24,7 +24,6 @@
 #define _DrawViewImage_h_
 
 #include <App/DocumentObject.h>
-#include <App/PropertyLinks.h>
 #include <App/PropertyFile.h>
 #include "DrawView.h"
 #include <App/FeaturePython.h>

--- a/src/Mod/TechDraw/App/DrawViewSection.cpp
+++ b/src/Mod/TechDraw/App/DrawViewSection.cpp
@@ -109,6 +109,7 @@ DrawViewSection::DrawViewSection()
 
     ADD_PROPERTY_TYPE(SectionSymbol ,("A"),sgroup,App::Prop_None,"The identifier for this section");
     ADD_PROPERTY_TYPE(BaseView ,(0),sgroup,App::Prop_None,"2D View source for this Section");
+    BaseView.setScope(App::LinkScope::Global);
     ADD_PROPERTY_TYPE(SectionNormal ,(0,0,1.0) ,sgroup,App::Prop_None,"Section Plane normal direction");  //direction of extrusion of cutting prism
     ADD_PROPERTY_TYPE(SectionOrigin ,(0,0,0) ,sgroup,App::Prop_None,"Section Plane Origin");
     SectionDirection.setEnums(SectionDirEnums);

--- a/src/Mod/TechDraw/App/DrawViewSpreadsheet.cpp
+++ b/src/Mod/TechDraw/App/DrawViewSpreadsheet.cpp
@@ -63,6 +63,7 @@ DrawViewSpreadsheet::DrawViewSpreadsheet(void)
     std::string fontName = hGrp->GetASCII("LabelFont", "osifont");
 
     ADD_PROPERTY_TYPE(Source ,(0),vgroup,App::Prop_None,"Spreadsheet to view");
+    Source.setScope(App::LinkScope::Global);
     ADD_PROPERTY_TYPE(CellStart ,("A1"),vgroup,App::Prop_None,"The top left cell of the range to display");
     ADD_PROPERTY_TYPE(CellEnd ,("B2"),vgroup,App::Prop_None,"The bottom right cell of the range to display");
     ADD_PROPERTY_TYPE(Font ,((fontName.c_str())),vgroup,App::Prop_None,"The name of the font to use");

--- a/src/Mod/TechDraw/App/DrawViewSymbol.h
+++ b/src/Mod/TechDraw/App/DrawViewSymbol.h
@@ -24,7 +24,6 @@
 #define _DrawViewSymbol_h_
 
 #include <App/DocumentObject.h>
-#include <App/PropertyLinks.h>
 #include "DrawView.h"
 #include <App/FeaturePython.h>
 

--- a/src/Mod/TechDraw/Gui/QGIProjGroup.h
+++ b/src/Mod/TechDraw/Gui/QGIProjGroup.h
@@ -25,7 +25,6 @@
 
 #include <QGraphicsItemGroup>
 #include <QObject>
-#include <App/PropertyLinks.h>
 
 #include "QGIViewCollection.h"
 

--- a/src/Mod/TechDraw/Gui/QGISectionLine.h
+++ b/src/Mod/TechDraw/Gui/QGISectionLine.h
@@ -85,7 +85,7 @@ private:
     double             m_arrowSize;
     //QColor             m_color;
     double             m_extLen;
-    int                m_sectionFormat;     //0 = ASME, 1 = ISO
+//    int                m_sectionFormat;     //0 = ASME, 1 = ISO
 };
 
 }

--- a/src/Mod/TechDraw/Gui/QGIView.h
+++ b/src/Mod/TechDraw/Gui/QGIView.h
@@ -28,7 +28,6 @@
 #include <QFont>
 
 #include <App/DocumentObject.h>
-#include <App/PropertyLinks.h>
 #include <Base/Parameter.h>
 #include <Gui/ViewProvider.h>
 

--- a/src/Mod/TechDraw/Gui/QGIViewCollection.h
+++ b/src/Mod/TechDraw/Gui/QGIViewCollection.h
@@ -25,7 +25,6 @@
 
 #include <QGraphicsItemGroup>
 #include <QObject>
-#include <App/PropertyLinks.h>
 
 #include "QGIView.h"
 

--- a/src/Mod/TechDraw/Gui/ViewProviderViewPart.h
+++ b/src/Mod/TechDraw/Gui/ViewProviderViewPart.h
@@ -24,7 +24,6 @@
 #ifndef DRAWINGGUI_VIEWPROVIDERVIEWPART_H
 #define DRAWINGGUI_VIEWPROVIDERVIEWPART_H
 
-#include <App/PropertyLinks.h>
 #include <App/PropertyStandard.h>
 #include <App/PropertyUnits.h>
 


### PR DESCRIPTION
This PR corrects "out of scope" run time warnings and a compile warning in TD.  Please merge.
Thanks,
wf

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
