### PR TITLE
Extend PySide2 wrapper to support QtUiTools

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1021,6 +1021,7 @@ endif()
                                                             "from PySide2.QtWidgets import *\n"
                                                             "QHeaderView.setResizeMode = QHeaderView.setSectionResizeMode\n")
         file(WRITE ${CMAKE_BINARY_DIR}/Ext/PySide/QtSvg.py  "from PySide2.QtSvg import *\n")
+        file(WRITE ${CMAKE_BINARY_DIR}/Ext/PySide/QtUiTools.py  "from PySide2.QtUiTools import *\n")
 
 	if(APPLE AND NOT BUILD_WITH_CONDA)
 	    INSTALL(


### PR DESCRIPTION
Reports started to emerge as ATM importing QtUiTools doesn't work on Qt5 builds:

https://forum.freecadweb.org/viewtopic.php?f=22&t=32947
https://forum.freecadweb.org/viewtopic.php?f=37&t=33629
