### PR TITLE
[consider for v0.18] Geom python fixes 

### DIFF
--- a/src/Mod/Part/App/ArcOfConicPy.xml
+++ b/src/Mod/Part/App/ArcOfConicPy.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <GenerateModel xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="generateMetaModel_Module.xsd">
   <PythonExport
-      Father="ArcPy"
+      Father="TrimmedCurvePy"
       Name="ArcOfConicPy"
       PythonName="Part.ArcOfConic"
       Twin="GeomArcOfConic"
       TwinPointer="GeomArcOfConic"
       Include="Mod/Part/App/Geometry.h"
       Namespace="Part"
-      FatherInclude="Mod/Part/App/ArcPy.h"
+      FatherInclude="Mod/Part/App/TrimmedCurvePy.h"
       FatherNamespace="Part"
       Constructor="true">
     <Documentation>

--- a/src/Mod/Part/App/ArcOfConicPy.xml
+++ b/src/Mod/Part/App/ArcOfConicPy.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <GenerateModel xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="generateMetaModel_Module.xsd">
-  <PythonExport 
-      Father="GeometryCurvePy" 
+  <PythonExport
+      Father="ArcPy"
       Name="ArcOfConicPy"
       PythonName="Part.ArcOfConic"
       Twin="GeomArcOfConic"
       TwinPointer="GeomArcOfConic"
-      Include="Mod/Part/App/Geometry.h" 
-      Namespace="Part" 
-      FatherInclude="Mod/Part/App/GeometryCurvePy.h" 
+      Include="Mod/Part/App/Geometry.h"
+      Namespace="Part"
+      FatherInclude="Mod/Part/App/ArcPy.h"
       FatherNamespace="Part"
       Constructor="true">
     <Documentation>

--- a/src/Mod/Part/App/ArcPy.xml
+++ b/src/Mod/Part/App/ArcPy.xml
@@ -29,5 +29,12 @@
     const Geom_Ellipse &amp; value(void) const {return *getGeom_EllipsePtr();}
 	</ClassDeclarations>
 	-->
+    <Methode Name="setParameterRange" Const="false">
+        <Documentation>
+            <UserDocu>
+                Re-trims this curve to the provided parameter range ([Float=First, Float=Last])
+                    </UserDocu>
+                </Documentation>
+            </Methode>
   </PythonExport>
 </GenerateModel>

--- a/src/Mod/Part/App/ArcPy.xml
+++ b/src/Mod/Part/App/ArcPy.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <GenerateModel xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="generateMetaModel_Module.xsd">
   <PythonExport
-      Father="BoundedCurvePy"
+      Father="TrimmedCurvePy"
       Name="ArcPy"
       PythonName="Part.Arc"
       Twin="GeomTrimmedCurve"
       TwinPointer="GeomTrimmedCurve"
       Include="Mod/Part/App/Geometry.h"
       Namespace="Part"
-      FatherInclude="Mod/Part/App/BoundedCurvePy.h"
+      FatherInclude="Mod/Part/App/TrimmedCurvePy.h"
       FatherNamespace="Part"
       Constructor="true">
     <Documentation>
@@ -29,12 +29,5 @@
     const Geom_Ellipse &amp; value(void) const {return *getGeom_EllipsePtr();}
 	</ClassDeclarations>
 	-->
-    <Methode Name="setParameterRange" Const="false">
-        <Documentation>
-            <UserDocu>
-                Re-trims this curve to the provided parameter range ([Float=First, Float=Last])
-                    </UserDocu>
-                </Documentation>
-            </Methode>
   </PythonExport>
 </GenerateModel>

--- a/src/Mod/Part/App/ArcPy.xml
+++ b/src/Mod/Part/App/ArcPy.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <GenerateModel xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="generateMetaModel_Module.xsd">
-  <PythonExport 
-      Father="GeometryCurvePy" 
-      Name="ArcPy" 
+  <PythonExport
+      Father="BoundedCurvePy"
+      Name="ArcPy"
       PythonName="Part.Arc"
-      Twin="GeomTrimmedCurve" 
-      TwinPointer="GeomTrimmedCurve" 
-      Include="Mod/Part/App/Geometry.h" 
-      Namespace="Part" 
-      FatherInclude="Mod/Part/App/GeometryCurvePy.h" 
+      Twin="GeomTrimmedCurve"
+      TwinPointer="GeomTrimmedCurve"
+      Include="Mod/Part/App/Geometry.h"
+      Namespace="Part"
+      FatherInclude="Mod/Part/App/BoundedCurvePy.h"
       FatherNamespace="Part"
       Constructor="true">
     <Documentation>

--- a/src/Mod/Part/App/ArcPyImp.cpp
+++ b/src/Mod/Part/App/ArcPyImp.cpp
@@ -197,6 +197,31 @@ int ArcPy::PyInit(PyObject* args, PyObject* /*kwd*/)
     return -1;
 }
 
+PyObject* ArcPy::setParameterRange(PyObject * args)
+{
+    Handle(Geom_Geometry) g = getGeomTrimmedCurvePtr()->handle();
+    Handle(Geom_TrimmedCurve) c = Handle(Geom_TrimmedCurve)::DownCast(g);
+    try {
+        if (!c.IsNull()) {
+            double u,v;
+            u=c->FirstParameter();
+            v=c->LastParameter();
+            if (!PyArg_ParseTuple(args, "|dd", &u,&v))
+                return 0;
+            getGeomTrimmedCurvePtr()->setRange(u,v);
+            Py_Return;
+        }
+    }
+    catch (Base::CADKernelError& e) {
+        PyErr_SetString(PartExceptionOCCError, e.what());
+        return 0;
+    }
+
+    PyErr_SetString(PartExceptionOCCError, "Geometry is not a trimmed curve");
+    return 0;
+}
+
+
 PyObject *ArcPy::getCustomAttributes(const char* /*attr*/) const
 {
     return 0;
@@ -204,5 +229,5 @@ PyObject *ArcPy::getCustomAttributes(const char* /*attr*/) const
 
 int ArcPy::setCustomAttributes(const char* /*attr*/, PyObject* /*obj*/)
 {
-    return 0; 
+    return 0;
 }

--- a/src/Mod/Part/App/ArcPyImp.cpp
+++ b/src/Mod/Part/App/ArcPyImp.cpp
@@ -197,31 +197,6 @@ int ArcPy::PyInit(PyObject* args, PyObject* /*kwd*/)
     return -1;
 }
 
-PyObject* ArcPy::setParameterRange(PyObject * args)
-{
-    Handle(Geom_Geometry) g = getGeomTrimmedCurvePtr()->handle();
-    Handle(Geom_TrimmedCurve) c = Handle(Geom_TrimmedCurve)::DownCast(g);
-    try {
-        if (!c.IsNull()) {
-            double u,v;
-            u=c->FirstParameter();
-            v=c->LastParameter();
-            if (!PyArg_ParseTuple(args, "|dd", &u,&v))
-                return 0;
-            getGeomTrimmedCurvePtr()->setRange(u,v);
-            Py_Return;
-        }
-    }
-    catch (Base::CADKernelError& e) {
-        PyErr_SetString(PartExceptionOCCError, e.what());
-        return 0;
-    }
-
-    PyErr_SetString(PartExceptionOCCError, "Geometry is not a trimmed curve");
-    return 0;
-}
-
-
 PyObject *ArcPy::getCustomAttributes(const char* /*attr*/) const
 {
     return 0;

--- a/src/Mod/Part/App/BSplineCurvePy.xml
+++ b/src/Mod/Part/App/BSplineCurvePy.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <GenerateModel xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="generateMetaModel_Module.xsd">
 	<PythonExport
-		Father="GeometryCurvePy"
+                Father="BoundedCurvePy"
 		Name="BSplineCurvePy"
-        PythonName="Part.BSplineCurve"
+                PythonName="Part.BSplineCurve"
 		Twin="GeomBSplineCurve"
 		TwinPointer="GeomBSplineCurve"
 		Include="Mod/Part/App/Geometry.h"
 		Namespace="Part"
-		FatherInclude="Mod/Part/App/GeometryCurvePy.h"
+                FatherInclude="Mod/Part/App/BoundedCurvePy.h"
 		FatherNamespace="Part"
 		Constructor="true">
 		<Documentation>
@@ -142,7 +142,7 @@ done if Degree is less than or equal to the current degree.</UserDocu>
 			<Documentation>
 				<UserDocu>
 				insertKnot(u, mult = 1, tol = 0.0)
-				Inserts a knot value in the sequence of knots. If u is an existing knot the 
+				Inserts a knot value in the sequence of knots. If u is an existing knot the
 				multiplicity is increased by mult. </UserDocu>
 			</Documentation>
 		</Methode>
@@ -154,12 +154,12 @@ done if Degree is less than or equal to the current degree.</UserDocu>
 
 				For each u = list_of_floats[i], mult = list_of_ints[i]
 
-				If u is an existing knot the multiplicity is increased by mult if bool_add is 
+				If u is an existing knot the multiplicity is increased by mult if bool_add is
 				True, otherwise increased to mult.
 
 				If u is not on the parameter range nothing is done.
 
-				If the multiplicity is negative or null nothing is done. The new multiplicity 
+				If the multiplicity is negative or null nothing is done. The new multiplicity
 				is limited to the degree.
 
 				The tolerance criterion for knots equality is the max of Epsilon(U) and ParametricTolerance.
@@ -266,7 +266,7 @@ ensures that:
 Index1 and Index2 are the indexes in the table of poles of this B-Spline curve
 of the first and last poles designated to be moved.
 
-Returns: (FirstModifiedPole, LastModifiedPole). They are the indexes of the 
+Returns: (FirstModifiedPole, LastModifiedPole). They are the indexes of the
 first and last poles which are effectively modified.</UserDocu>
 			</Documentation>
 		</Methode>
@@ -290,7 +290,7 @@ the knots and poles tables are modified.</UserDocu>
 		</Methode>
         <Methode Name="getMultiplicity" Const="true">
 			<Documentation>
-				<UserDocu>Returns the multiplicity of the knot of index 
+				<UserDocu>Returns the multiplicity of the knot of index
 from the knots table of this B-Spline curve.</UserDocu>
 			</Documentation>
 		</Methode>
@@ -307,7 +307,7 @@ from the knots table of this B-Spline curve.</UserDocu>
 					Replaces this B-Spline curve by approximating a set of points.
 					The function accepts keywords as arguments.
 
-					approximate(Points = list_of_points) 
+					approximate(Points = list_of_points)
 
 					Optional arguments :
 
@@ -318,9 +318,9 @@ from the knots table of this B-Spline curve.</UserDocu>
 					Possible values : 'C0','G1','C1','G2','C2','C3','CN'
 
 					LengthWeight = float, CurvatureWeight = float, TorsionWeight = float
-					If one of these arguments is not null, the functions approximates the 
-					points using variational smoothing algorithm, which tries to minimize 
-					additional criterium: 
+					If one of these arguments is not null, the functions approximates the
+					points using variational smoothing algorithm, which tries to minimize
+					additional criterium:
 					LengthWeight*CurveLength + CurvatureWeight*Curvature + TorsionWeight*Torsion
                                         Continuity must be C0, C1(with DegMax >= 3) or C2(with DegMax >= 5).
 
@@ -330,7 +330,7 @@ from the knots table of this B-Spline curve.</UserDocu>
 					ParamType = string ('Uniform','Centripetal' or 'ChordLength')
 					Parameterization type. Only used if weights and Parameters above aren't specified.
 
-					Note : Continuity of the spline defaults to C2. However, it may not be applied if 
+					Note : Continuity of the spline defaults to C2. However, it may not be applied if
 					it conflicts with other parameters ( especially DegMax ).
 				</UserDocu>
 			</Documentation>
@@ -346,7 +346,7 @@ from the knots table of this B-Spline curve.</UserDocu>
 					Replaces this B-Spline curve by interpolating a set of points.
 					The function accepts keywords as arguments.
 
-					interpolate(Points = list_of_points) 
+					interpolate(Points = list_of_points)
 
 					Optional arguments :
 
@@ -360,7 +360,7 @@ from the knots table of this B-Spline curve.</UserDocu>
 					EndPoint Tangent constraints :
 
 					InitialTangent = vector, FinalTangent = vector
-					specify tangent vectors for starting and ending points 
+					specify tangent vectors for starting and ending points
 					of the BSpline. Either none, or both must be specified.
 
 					Full Tangent constraints :
@@ -371,7 +371,7 @@ from the knots table of this B-Spline curve.</UserDocu>
 					TangentFlags (bool) activates or deactivates the corresponding tangent.
 					These arguments will be ignored if EndPoint Tangents (above) are also defined.
 
-					Note : Continuity of the spline defaults to C2. However, if periodic, or tangents 
+					Note : Continuity of the spline defaults to C2. However, if periodic, or tangents
 					are supplied, the continuity will drop to C1.
 				</UserDocu>
 			</Documentation>
@@ -388,7 +388,7 @@ from the knots table of this B-Spline curve.</UserDocu>
 			<UserDocu>
 				Builds a B-Spline by a lists of Poles, Mults, Knots.
 				arguments: poles (sequence of Base.Vector), [mults , knots, periodic, degree, weights (sequence of float), CheckRational]
-				
+
 				Examples:
 				from FreeCAD import Base
 				import Part
@@ -399,7 +399,7 @@ from the knots table of this B-Spline curve.</UserDocu>
 				n=Part.BSplineCurve()
 				n.buildFromPolesMultsKnots(poles,(3,1,3),(0,0.5,1),False,2)
 				Part.show(n.toShape())
-				
+
 				# periodic spline
 				p=Part.BSplineCurve()
 				p.buildFromPolesMultsKnots(poles,(1,1,1,1,1),(0,0.25,0.5,0.75,1),True,2)
@@ -438,11 +438,11 @@ from the knots table of this B-Spline curve.</UserDocu>
 			<Documentation>
 				<UserDocu>
 					makeC1Continuous(tol = 1e-6, ang_tol = 1e-7)
-					Reduces as far as possible the multiplicities of the knots of this BSpline 
-					(keeping the geometry). It returns a new BSpline, which could still be C0. 
-					tol is a geometrical tolerance. 
-					The tol_ang is angular tolerance, in radians. It sets tolerable angle mismatch 
-					of the tangents on the left and on the right to decide if the curve is G1 or 
+					Reduces as far as possible the multiplicities of the knots of this BSpline
+					(keeping the geometry). It returns a new BSpline, which could still be C0.
+					tol is a geometrical tolerance.
+					The tol_ang is angular tolerance, in radians. It sets tolerable angle mismatch
+					of the tangents on the left and on the right to decide if the curve is G1 or
 					not at a given point.
 				</UserDocu>
 			</Documentation>

--- a/src/Mod/Part/App/BezierCurvePy.xml
+++ b/src/Mod/Part/App/BezierCurvePy.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <GenerateModel xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="generateMetaModel_Module.xsd">
 	<PythonExport
-		Father="GeometryCurvePy"
+                Father="BoundedCurvePy"
 		Name="BezierCurvePy"
-        PythonName="Part.BezierCurve"
+                PythonName="Part.BezierCurve"
 		Twin="GeomBezierCurve"
 		TwinPointer="GeomBezierCurve"
 		Include="Mod/Part/App/Geometry.h"
 		Namespace="Part"
-		FatherInclude="Mod/Part/App/GeometryCurvePy.h"
+                FatherInclude="Mod/Part/App/BoundedCurvePy.h"
 		FatherNamespace="Part"
 		Constructor="true">
 		<Documentation>

--- a/src/Mod/Part/App/BezierCurvePyImp.cpp
+++ b/src/Mod/Part/App/BezierCurvePyImp.cpp
@@ -47,7 +47,7 @@ std::string BezierCurvePy::representation(void) const
 
 PyObject *BezierCurvePy::PyMake(struct _typeobject *, PyObject *, PyObject *)  // Python wrapper
 {
-    // create a new instance of BezierCurvePy and the Twin object 
+    // create a new instance of BezierCurvePy and the Twin object
     return new BezierCurvePy(new GeomBezierCurve);
 }
 
@@ -347,21 +347,21 @@ Py::Long BezierCurvePy::getDegree(void) const
 {
     Handle(Geom_BezierCurve) curve = Handle(Geom_BezierCurve)::DownCast
         (getGeometryPtr()->handle());
-    return Py::Long(curve->Degree()); 
+    return Py::Long(curve->Degree());
 }
 
 Py::Long BezierCurvePy::getMaxDegree(void) const
 {
     Handle(Geom_BezierCurve) curve = Handle(Geom_BezierCurve)::DownCast
         (getGeometryPtr()->handle());
-    return Py::Long(curve->MaxDegree()); 
+    return Py::Long(curve->MaxDegree());
 }
 
 Py::Long BezierCurvePy::getNbPoles(void) const
 {
     Handle(Geom_BezierCurve) curve = Handle(Geom_BezierCurve)::DownCast
         (getGeometryPtr()->handle());
-    return Py::Long(curve->NbPoles()); 
+    return Py::Long(curve->NbPoles());
 }
 
 Py::Object BezierCurvePy::getStartPoint(void) const
@@ -387,5 +387,5 @@ PyObject *BezierCurvePy::getCustomAttributes(const char* /*attr*/) const
 
 int BezierCurvePy::setCustomAttributes(const char* /*attr*/, PyObject* /*obj*/)
 {
-    return 0; 
+    return 0;
 }

--- a/src/Mod/Part/App/BoundedCurvePy.xml
+++ b/src/Mod/Part/App/BoundedCurvePy.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<GenerateModel xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="generateMetaModel_Module.xsd">
+    <PythonExport
+        Father="GeometryCurvePy"
+	Name="BoundedCurvePy"
+        PythonName="Part.BoundedCurve"
+        Twin="GeomBoundedCurve"
+        TwinPointer="GeomBoundedCurve"
+	Include="Mod/Part/App/Geometry.h"
+	Namespace="Part"
+	FatherInclude="Mod/Part/App/GeometryCurvePy.h"
+	FatherNamespace="Part"
+	Constructor="true">
+	<Documentation>
+            <Author Licence="LGPL" Name="Abdullah Tahiri" EMail="abdullah.tahiri.yo@gmail.com" />
+            <UserDocu>
+                The abstract class BoundedCurve is the root class of all bounded curve objects.
+            </UserDocu>
+        </Documentation>
+        <Attribute Name="StartPoint" ReadOnly="true">
+            <Documentation>
+                <UserDocu>
+                    Returns the starting point of the bounded curve.
+		</UserDocu>
+            </Documentation>
+            <Parameter Name="StartPoint" Type="Object"/>
+	</Attribute>
+        <Attribute Name="EndPoint" ReadOnly="true">
+            <Documentation>
+                <UserDocu>
+                    Returns the end point of the bounded curve.
+                </UserDocu>
+            </Documentation>
+            <Parameter Name="EndPoint" Type="Object"/>
+        </Attribute>
+        </PythonExport>
+</GenerateModel>

--- a/src/Mod/Part/App/BoundedCurvePyImp.cpp
+++ b/src/Mod/Part/App/BoundedCurvePyImp.cpp
@@ -1,0 +1,77 @@
+/***************************************************************************
+ *   Copyright (c) 2009 Werner Mayer <wmayer[at]users.sourceforge.net>     *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+
+#include "PreCompiled.h"
+#ifndef _PreComp_
+# include <sstream>
+#endif
+
+#include <Base/GeometryPyCXX.h>
+#include <Base/VectorPy.h>
+
+#include "Geometry.h"
+#include "BoundedCurvePy.h"
+#include "BoundedCurvePy.cpp"
+
+
+using namespace Part;
+
+// returns a string which represents the object e.g. when printed in python
+std::string BoundedCurvePy::representation(void) const
+{
+    return "<Curve object>";
+}
+
+PyObject *BoundedCurvePy::PyMake(struct _typeobject *, PyObject *, PyObject *)  // Python wrapper
+{
+    // never create such objects with the constructor
+    PyErr_SetString(PyExc_RuntimeError,
+                    "You cannot create an instance of the abstract class 'BoundedCurve'.");
+    return 0;
+}
+
+// constructor method
+int BoundedCurvePy::PyInit(PyObject* /*args*/, PyObject* /*kwd*/)
+{
+    return 0;
+}
+
+Py::Object BoundedCurvePy::getStartPoint(void) const
+{
+    return Py::Vector(getGeomBoundedCurvePtr()->getStartPoint());
+}
+
+Py::Object BoundedCurvePy::getEndPoint(void) const
+{
+    return Py::Vector(getGeomBoundedCurvePtr()->getEndPoint());
+}
+
+PyObject *BoundedCurvePy::getCustomAttributes(const char* /*attr*/) const
+{
+    return 0;
+}
+
+int BoundedCurvePy::setCustomAttributes(const char* /*attr*/, PyObject* /*obj*/)
+{
+    return 0;
+}

--- a/src/Mod/Part/App/CMakeLists.txt
+++ b/src/Mod/Part/App/CMakeLists.txt
@@ -52,6 +52,7 @@ generate_from_xml(ParabolaPy)
 generate_from_xml(OffsetCurvePy)
 generate_from_xml(GeometryPy)
 generate_from_xml(GeometryCurvePy)
+generate_from_xml(BoundedCurvePy)
 generate_from_xml(GeometrySurfacePy)
 generate_from_xml(LinePy)
 generate_from_xml(LineSegmentPy)
@@ -211,6 +212,8 @@ SET(Python_SRCS
     GeometryPyImp.cpp
     GeometryCurvePy.xml
     GeometryCurvePyImp.cpp
+    BoundedCurvePy.xml
+    BoundedCurvePyImp.cpp
     GeometrySurfacePy.xml
     GeometrySurfacePyImp.cpp
     LinePy.xml

--- a/src/Mod/Part/App/CMakeLists.txt
+++ b/src/Mod/Part/App/CMakeLists.txt
@@ -53,6 +53,7 @@ generate_from_xml(OffsetCurvePy)
 generate_from_xml(GeometryPy)
 generate_from_xml(GeometryCurvePy)
 generate_from_xml(BoundedCurvePy)
+generate_from_xml(TrimmedCurvePy)
 generate_from_xml(GeometrySurfacePy)
 generate_from_xml(LinePy)
 generate_from_xml(LineSegmentPy)
@@ -214,6 +215,8 @@ SET(Python_SRCS
     GeometryCurvePyImp.cpp
     BoundedCurvePy.xml
     BoundedCurvePyImp.cpp
+    TrimmedCurvePy.xml
+    TrimmedCurvePyImp.cpp
     GeometrySurfacePy.xml
     GeometrySurfacePyImp.cpp
     LinePy.xml

--- a/src/Mod/Part/App/Geometry.cpp
+++ b/src/Mod/Part/App/Geometry.cpp
@@ -1549,6 +1549,25 @@ bool GeomTrimmedCurve::intersectBasisCurves(  const GeomTrimmedCurve * c,
 
 }
 
+void GeomTrimmedCurve::getRange(double& u, double& v) const
+{
+    Handle(Geom_TrimmedCurve) curve =  Handle(Geom_TrimmedCurve)::DownCast(handle());
+    u = curve->FirstParameter();
+    v = curve->LastParameter();
+}
+
+void GeomTrimmedCurve::setRange(double u, double v)
+{
+    try {
+        Handle(Geom_TrimmedCurve) curve =  Handle(Geom_TrimmedCurve)::DownCast(handle());
+
+        curve->SetTrim(u, v);
+    }
+    catch (Standard_Failure& e) {
+        THROWM(Base::CADKernelError,e.GetMessageString())
+    }
+}
+
 // -------------------------------------------------
 TYPESYSTEM_SOURCE_ABSTRACT(Part::GeomArcOfConic,Part::GeomTrimmedCurve)
 

--- a/src/Mod/Part/App/Geometry.h
+++ b/src/Mod/Part/App/Geometry.h
@@ -101,9 +101,9 @@ protected:
 
 protected:
     Geometry();
-    
+
 protected:
-    boost::uuids::uuid tag;    
+    boost::uuids::uuid tag;
 
 private:
     Geometry(const Geometry&);
@@ -172,12 +172,12 @@ public:
     double curvatureAt(double u) const;
     double length(double u, double v) const;
     bool normalAt(double u, Base::Vector3d& dir) const;
-    bool intersect(GeomCurve * c, 
-                   std::vector<std::pair<Base::Vector3d, Base::Vector3d>>& points, 
+    bool intersect(GeomCurve * c,
+                   std::vector<std::pair<Base::Vector3d, Base::Vector3d>>& points,
                    double tol = Precision::Confusion()) const;
-    
+
     void reverse(void);
-    
+
 protected:
     static bool intersect(const Handle(Geom_Curve) c, const Handle(Geom_Curve) c2,
                           std::vector<std::pair<Base::Vector3d, Base::Vector3d>>& points,
@@ -228,11 +228,11 @@ class PartExport GeomBSplineCurve : public GeomBoundedCurve
 public:
     GeomBSplineCurve();
     GeomBSplineCurve(const Handle(Geom_BSplineCurve)&);
-    
+
     GeomBSplineCurve( const std::vector<Base::Vector3d>& poles, const std::vector<double>& weights,
                       const std::vector<double>& knots, const std::vector<int>& multiplicities,
                       int degree, bool periodic=false, bool checkrational = true);
-    
+
     virtual ~GeomBSplineCurve();
     virtual Geometry *copy(void) const;
 
@@ -353,10 +353,13 @@ public:
     void setHandle(const Handle(Geom_TrimmedCurve)&);
     const Handle(Geom_Geometry)& handle() const;
 
-    bool intersectBasisCurves(  const GeomTrimmedCurve * c, 
-                            std::vector<std::pair<Base::Vector3d, Base::Vector3d>>& points, 
+    bool intersectBasisCurves(  const GeomTrimmedCurve * c,
+                            std::vector<std::pair<Base::Vector3d, Base::Vector3d>>& points,
                             double tol = Precision::Confusion()) const;
-    
+
+    virtual void getRange(double& u, double& v) const;
+    virtual void setRange(double u, double v);
+
 protected:
     Handle(Geom_TrimmedCurve) myCurve;
 };
@@ -395,6 +398,9 @@ public:
     virtual void getRange(double& u, double& v, bool emulateCCWXY) const = 0;
     virtual void setRange(double u, double v, bool emulateCCWXY) = 0;
 
+    inline virtual void getRange(double& u, double& v) const { getRange(u,v,false);};
+    inline virtual void setRange(double u, double v) { setRange(u,v,false);};
+
     bool isReversed() const;
     double getAngleXU(void) const;
     void setAngleXU(double angle);
@@ -429,7 +435,7 @@ public:
     virtual GeomBSplineCurve* toNurbs(double first, double last) const;
 
     const Handle(Geom_Geometry)& handle() const;
-    
+
     void setHandle(const Handle(Geom_Circle)&);
 
 private:
@@ -537,7 +543,7 @@ public:
     GeomHyperbola(const Handle(Geom_Hyperbola)&);
     virtual ~GeomHyperbola();
     virtual Geometry *copy(void) const;
-    
+
     double getMajorRadius(void) const;
     void setMajorRadius(double Radius);
     double getMinorRadius(void) const;
@@ -598,7 +604,7 @@ public:
     GeomParabola(const Handle(Geom_Parabola)&);
     virtual ~GeomParabola();
     virtual Geometry *copy(void) const;
-    
+
     double getFocal(void) const;
     void setFocal(double length);
 
@@ -628,9 +634,9 @@ public:
 
     double getFocal(void) const;
     void setFocal(double length);
-    
+
     Base::Vector3d getFocus(void) const;
-    
+
     virtual void getRange(double& u, double& v, bool emulateCCWXY) const;
     virtual void setRange(double u, double v, bool emulateCCWXY);
 
@@ -687,7 +693,7 @@ public:
     Base::Vector3d getStartPoint() const;
     Base::Vector3d getEndPoint() const;
 
-    void setPoints(const Base::Vector3d& p1, 
+    void setPoints(const Base::Vector3d& p1,
                    const Base::Vector3d& p2);
 
     // Persistence implementer ---------------------
@@ -1038,7 +1044,7 @@ private:
 
 
 // Helper functions for fillet tools
-PartExport 
+PartExport
 bool find2DLinesIntersection(const Base::Vector3d &orig1, const Base::Vector3d &dir1,
                              const Base::Vector3d &orig2, const Base::Vector3d &dir2,
                              Base::Vector3d &point);

--- a/src/Mod/Part/App/GeometryPy.xml
+++ b/src/Mod/Part/App/GeometryPy.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <GenerateModel xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="generateMetaModel_Module.xsd">
-  <PythonExport 
-      Father="PyObjectBase" 
-      Name="GeometryPy" 
-      Twin="Geometry" 
-      TwinPointer="Geometry" 
-      Include="Mod/Part/App/Geometry.h" 
-      Namespace="Part" 
-      FatherInclude="Base/PyObjectBase.h" 
+  <PythonExport
+      Father="PyObjectBase"
+      Name="GeometryPy"
+      Twin="Geometry"
+      TwinPointer="Geometry"
+      Include="Mod/Part/App/Geometry.h"
+      Namespace="Part"
+      FatherInclude="Base/PyObjectBase.h"
       FatherNamespace="Base"
       Constructor="true"
       Delete="true">
@@ -47,6 +47,11 @@ It describes the common behavior of these objects when:
       <Documentation>
         <UserDocu>Create a copy of this geometry</UserDocu>
       </Documentation>
+    </Methode>
+    <Methode Name="clone" Const="true">
+        <Documentation>
+            <UserDocu>Create a clone of this geometry with the same Tag</UserDocu>
+        </Documentation>
     </Methode>
     <Attribute Name="Construction" ReadOnly="false">
       <Documentation>

--- a/src/Mod/Part/App/GeometryPyImp.cpp
+++ b/src/Mod/Part/App/GeometryPyImp.cpp
@@ -114,7 +114,7 @@ PyObject* GeometryPy::rotate(PyObject *args)
 
     rot.getValue(dir, angle);
     pnt = plm->getPosition();
-    
+
     gp_Ax1 ax1(gp_Pnt(pnt.x,pnt.y,pnt.z), gp_Dir(dir.x,dir.y,dir.z));
     getGeometryPtr()->handle()->Rotate(ax1, angle);
     Py_Return;
@@ -131,7 +131,7 @@ PyObject* GeometryPy::scale(PyObject *args)
         getGeometryPtr()->handle()->Scale(pnt, scale);
         Py_Return;
     }
-    
+
     PyErr_Clear();
     if (PyArg_ParseTuple(args, "O!d", &PyTuple_Type,&o, &scale)) {
         vec = Base::getVectorFromTuple<double>(o);
@@ -212,6 +212,33 @@ PyObject* GeometryPy::copy(PyObject *args)
     return cpy;
 }
 
+PyObject* GeometryPy::clone(PyObject *args)
+{
+    if (!PyArg_ParseTuple(args, ""))
+        return NULL;
+
+    Part::Geometry* geom = this->getGeometryPtr();
+    PyTypeObject* type = this->GetType();
+    PyObject* cpy = 0;
+    // let the type object decide
+    if (type->tp_new)
+        cpy = type->tp_new(type, this, 0);
+    if (!cpy) {
+        PyErr_SetString(PyExc_TypeError, "failed to create clone of geometry");
+        return 0;
+    }
+
+    Part::GeometryPy* geompy = static_cast<Part::GeometryPy*>(cpy);
+    // the PyMake function must have created the corresponding instance of the 'Geometry' subclass
+    // so delete it now to avoid a memory leak
+    if (geompy->_pcTwinPointer) {
+        Part::Geometry* clone = static_cast<Part::Geometry*>(geompy->_pcTwinPointer);
+        delete clone;
+    }
+    geompy->_pcTwinPointer = geom->clone();
+    return cpy;
+}
+
 Py::Boolean GeometryPy::getConstruction(void) const
 {
     return Py::Boolean(getGeometryPtr()->Construction);
@@ -236,5 +263,5 @@ PyObject *GeometryPy::getCustomAttributes(const char* /*attr*/) const
 
 int GeometryPy::setCustomAttributes(const char* /*attr*/, PyObject* /*obj*/)
 {
-    return 0; 
+    return 0;
 }

--- a/src/Mod/Part/App/LineSegmentPy.xml
+++ b/src/Mod/Part/App/LineSegmentPy.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <GenerateModel xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="generateMetaModel_Module.xsd">
-  <PythonExport 
-      Father="GeometryCurvePy" 
+  <PythonExport
+      Father="ArcPy"
       Name="LineSegmentPy"
       PythonName="Part.LineSegment"
-      Twin="GeomLineSegment" 
-      TwinPointer="GeomLineSegment" 
-      Include="Mod/Part/App/Geometry.h" 
-      Namespace="Part" 
-      FatherInclude="Mod/Part/App/GeometryCurvePy.h" 
+      Twin="GeomLineSegment"
+      TwinPointer="GeomLineSegment"
+      Include="Mod/Part/App/Geometry.h"
+      Namespace="Part"
+      FatherInclude="Mod/Part/App/ArcPy.h"
       FatherNamespace="Part"
       Constructor="true">
     <Documentation>

--- a/src/Mod/Part/App/LineSegmentPy.xml
+++ b/src/Mod/Part/App/LineSegmentPy.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <GenerateModel xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="generateMetaModel_Module.xsd">
   <PythonExport
-      Father="ArcPy"
+      Father="TrimmedCurvePy"
       Name="LineSegmentPy"
       PythonName="Part.LineSegment"
       Twin="GeomLineSegment"
       TwinPointer="GeomLineSegment"
       Include="Mod/Part/App/Geometry.h"
       Namespace="Part"
-      FatherInclude="Mod/Part/App/ArcPy.h"
+      FatherInclude="Mod/Part/App/TrimmedCurvePy.h"
       FatherNamespace="Part"
       Constructor="true">
     <Documentation>

--- a/src/Mod/Part/App/TrimmedCurvePy.xml
+++ b/src/Mod/Part/App/TrimmedCurvePy.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<GenerateModel xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="generateMetaModel_Module.xsd">
+    <PythonExport
+        Father="BoundedCurvePy"
+	Name="TrimmedCurvePy"
+        PythonName="Part.TrimmedCurve"
+        Twin="GeomTrimmedCurve"
+        TwinPointer="GeomTrimmedCurve"
+	Include="Mod/Part/App/Geometry.h"
+	Namespace="Part"
+        FatherInclude="Mod/Part/App/BoundedCurvePy.h"
+	FatherNamespace="Part"
+	Constructor="true">
+	<Documentation>
+            <Author Licence="LGPL" Name="Abdullah Tahiri" EMail="abdullah.tahiri.yo@gmail.com" />
+            <UserDocu>
+                The abstract class TrimmedCurve is the root class of all trimmed curve objects.
+            </UserDocu>
+        </Documentation>
+        <Methode Name="setParameterRange" Const="false">
+            <Documentation>
+                <UserDocu>
+                    Re-trims this curve to the provided parameter range ([Float=First, Float=Last])
+                </UserDocu>
+            </Documentation>
+        </Methode>
+        </PythonExport>
+</GenerateModel>


### PR DESCRIPTION
During v0.18 we changed the inheritance hierarchy of Geometry in c++, but we did not adapt the Python classes correspondingly. The first commit does this.

The second commit provides python functionality to re-trim a trimmed curve.

The third commit exposes the clone functionality to Python, so that power users may produce copies with the same tagid.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
