### PR TITLE
Fix crash when clicking link to allow internetaccess, and not having…

### DIFF
--- a/src/Mod/Web/Gui/BrowserView.cpp
+++ b/src/Mod/Web/Gui/BrowserView.cpp
@@ -329,7 +329,8 @@ void BrowserView::onLinkClicked (const QUrl & url)
                     QMessageBox::critical(this, tr("Error"), QString::fromUtf8(e.what()));
                 }
 
-                if(this->getAppDocument()->testStatus(App::Document::PartialRestore))
+                App::Document *doc = BaseView::getAppDocument();
+                if(doc && doc->testStatus(App::Document::PartialRestore))
                     QMessageBox::critical(this, tr("Error"), tr("There were errors while loading the file. Some data might have been modified or not recovered at all. Look in the report view for more specific information about the objects involved."));
             }
         }


### PR DESCRIPTION
Fix crash when clicking link to allow internetaccess, and not having a open document

Occurs when clicking link from startpage

