### PR TITLE
ProjectionGroup fixes

### DIFF
--- a/src/Mod/TechDraw/App/DrawProjGroup.cpp
+++ b/src/Mod/TechDraw/App/DrawProjGroup.cpp
@@ -77,6 +77,8 @@ DrawProjGroup::DrawProjGroup(void)
     ADD_PROPERTY_TYPE(AutoDistribute ,(autoDist),agroup,App::Prop_None,"Distribute Views Automatically or Manually");
     ADD_PROPERTY_TYPE(spacingX, (15), agroup, App::Prop_None, "Horizontal spacing between views");
     ADD_PROPERTY_TYPE(spacingY, (15), agroup, App::Prop_None, "Vertical spacing between views");
+    Rotation.setStatus(App::Property::Hidden,true);   //DPG does not rotate
+
 }
 
 DrawProjGroup::~DrawProjGroup()
@@ -123,6 +125,13 @@ void DrawProjGroup::onChanged(const App::Property* prop)
                 if(std::abs(getScale() - newScale) > FLT_EPSILON) {
                     Scale.setValue(newScale);
                 }
+            }
+        }
+        if (prop == &Rotation) {
+            if (!DrawUtil::fpCompare(Rotation.getValue(),0.0)) {
+                Rotation.setValue(0.0);
+                purgeTouched();
+                Base::Console().Warning("DPG: Projection Groups do not rotate. Change ignored.\n");
             }
         }
 

--- a/src/Mod/TechDraw/Gui/QGIProjGroup.cpp
+++ b/src/Mod/TechDraw/Gui/QGIProjGroup.cpp
@@ -213,6 +213,12 @@ void QGIProjGroup::updateView(bool update)
     return QGIViewCollection::updateView(update);
 }
 
+//QGIPG does not rotate. Only individual views rotate
+void QGIProjGroup::rotateView(void)
+{
+    Base::Console().Warning("QGIPG: Projection Groups do not rotate. Change ignored\n");
+}    
+
 void QGIProjGroup::drawBorder()
 {
 //QGIProjGroup does not have a border!

--- a/src/Mod/TechDraw/Gui/QGIProjGroup.h
+++ b/src/Mod/TechDraw/Gui/QGIProjGroup.h
@@ -51,6 +51,8 @@ public:
     void alignTo(QGIProjGroup *, const QString &alignment);
 
     virtual void updateView(bool update = false);
+    virtual void rotateView(void) override;
+
     virtual void drawBorder(void);
 
 protected:

--- a/src/Mod/TechDraw/Gui/TaskProjGroup.ui
+++ b/src/Mod/TechDraw/Gui/TaskProjGroup.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>371</width>
-    <height>506</height>
+    <height>511</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -213,7 +213,7 @@
           <item row="1" column="1">
            <widget class="QLineEdit" name="lePrimary">
             <property name="enabled">
-             <bool>true</bool>
+             <bool>false</bool>
             </property>
             <property name="font">
              <font>
@@ -227,7 +227,7 @@
              <enum>Qt::NoFocus</enum>
             </property>
             <property name="toolTip">
-             <string>Primary View Direction</string>
+             <string>Current primary view direction</string>
             </property>
             <property name="alignment">
              <set>Qt::AlignCenter</set>


### PR DESCRIPTION
This PR addresses two issues with ProjectionGroup.
- it was possible for the read-only current primary view direction field to obtain focus in the ProjectionGroup dialog.  This caused problems with event handling.
- the Rotation property, which is not applicable to ProjectionGroups, was modifiable.  It has been hidden.
Please merge.
Thanks,
wf

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
