### PR TITLE
Allow tabbing to cycle through objects to snap

### DIFF
--- a/src/Mod/Draft/DraftGui.py
+++ b/src/Mod/Draft/DraftGui.py
@@ -270,7 +270,17 @@ def displayExternal(internValue,decimals=None,dim='Length',showUnit=True,unit=No
 # Customized widgets
 #---------------------------------------------------------------------------
 
-class DraftDockWidget(QtGui.QWidget):
+class DraftBaseWidget(QtGui.QWidget):
+    def __init__(self,parent = None):
+        QtGui.QWidget.__init__(self,parent)
+    def eventFilter(self, widget, event):
+        if event.type() == QtCore.QEvent.KeyPress and event.key()==QtCore.Qt.Key_Tab:
+            if hasattr(FreeCADGui,"Snapper"):
+                FreeCADGui.Snapper.cycleSnapObject()
+            return True
+        return QtGui.QWidget.eventFilter(self, widget, event)
+
+class DraftDockWidget(DraftBaseWidget):
     "custom Widget that emits a resized() signal when resized"
     def __init__(self,parent = None):
         QtGui.QWidget.__init__(self,parent)
@@ -359,7 +369,7 @@ class DraftToolBar:
         
         if self.taskmode:
             # add only a dummy widget, since widgets are created on demand
-            self.baseWidget = QtGui.QWidget()
+            self.baseWidget = DraftBaseWidget()
             self.tray = QtGui.QToolBar(None)
             self.tray.setObjectName("Draft tray")
             self.tray.setWindowTitle("Draft tray")
@@ -505,6 +515,7 @@ class DraftToolBar:
         self.layout.addLayout(bl)
         self.labelx = self._label("labelx", xl)
         self.xValue = self._inputfield("xValue", xl) #width=60
+        self.xValue.installEventFilter(self.baseWidget)
         self.xValue.setText(FreeCAD.Units.Quantity(0,FreeCAD.Units.Length).UserString)
         self.labely = self._label("labely", yl)
         self.yValue = self._inputfield("yValue", yl)
@@ -843,7 +854,7 @@ class DraftToolBar:
         if self.taskmode:
             self.isTaskOn = True
             todo.delay(FreeCADGui.Control.closeDialog,None)
-            self.baseWidget = QtGui.QWidget()
+            self.baseWidget = DraftBaseWidget()
             self.layout = QtGui.QVBoxLayout(self.baseWidget)
             self.setupToolBar(task=True)
             self.retranslateUi(self.baseWidget)

--- a/src/Mod/Draft/DraftGui.py
+++ b/src/Mod/Draft/DraftGui.py
@@ -122,7 +122,8 @@ inCommandShortcuts = {
     "AddHold":    ["Q",translate("draft","Add custom snap point"),None],
     "Length":     ["H",translate("draft","Length mode"),          "lengthValue"],
     "Wipe":       ["W",translate("draft","Wipe"),                 "wipeButton"],
-    "SetWP":      ["U",translate("draft","Set Working Plane"),    "orientWPButton"]
+    "SetWP":      ["U",translate("draft","Set Working Plane"), "orientWPButton"],
+    "CycleSnap":  [QtCore.Qt.Key_Tab,translate("draft","Cycle snap object"), None]
 }
 
 
@@ -274,7 +275,7 @@ class DraftBaseWidget(QtGui.QWidget):
     def __init__(self,parent = None):
         QtGui.QWidget.__init__(self,parent)
     def eventFilter(self, widget, event):
-        if event.type() == QtCore.QEvent.KeyPress and event.key()==QtCore.Qt.Key_Tab:
+        if event.type() == QtCore.QEvent.KeyPress and event.key()==inCommandShortcuts["CycleSnap"][0]:
             if hasattr(FreeCADGui,"Snapper"):
                 FreeCADGui.Snapper.cycleSnapObject()
             return True
@@ -1238,7 +1239,10 @@ class DraftToolBar:
                         first = False
                     else:
                         cmdstr += ", "
-                    cmdstr += v[0] + ":" + v[1]
+                    try:
+                        cmdstr += v[0] + ":" + v[1]
+                    except:
+                        pass
             FreeCAD.Console.PrintMessage(cmdstr+"\n\n")
 
     def checkLocal(self):


### PR DESCRIPTION
To do this, the object snapping code has been refactored into a snapToObject function. This allows it to be called on different objects easily. A new base class which handles the tab event has been added.

To see it in action, try and draw two overlapping lines. When you next try to draw a line, it will only snap to one of them - if you press tab it will allow you to snap to the other one.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
