### PR TITLE
Fix missing door symbols in getSVG

### DIFF
--- a/src/Mod/Arch/ArchSectionPlane.py
+++ b/src/Mod/Arch/ArchSectionPlane.py
@@ -238,11 +238,12 @@ def getSVG(section, renderMode="Wireframe", allOn=False, showHidden=False, scale
             # print(render.info())
             section.Proxy.svgcache = [svgcache,renderMode,showHidden,showFill]
     else:
+        shapes,hshapes,sshapes,cutface,cutvolume,invcutvolume = getCutShapes(objs,section,showHidden)
+        
         if not svgcache:
             svgcache = ""
             # render using the Drawing module
             import Drawing, Part
-            shapes,hshapes,sshapes,cutface,cutvolume,invcutvolume = getCutShapes(objs,section,showHidden)
             if shapes:
                 baseshape = Part.makeCompound(shapes)
                 style = {'stroke':       "SVGLINECOLOR",


### PR DESCRIPTION
The ArchSectionPlane has a built in SVG Cache. But the door symbols and
a few other things are not inside the cache. This things not inside the
cache rely on the presence of a cutface. But this cutface was only built
when the cache is not available.

So the First invocation after the cache was cleared added the symbols.
The next invocations of the method, with a cached SVG did not calculate
the symbols again, because the cutfaces where missing.

This commit fixes it by calculating the cutfaces independent from the
cache.

Reported in https://forum.freecadweb.org/viewtopic.php?f=3&t=33987

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0` --> not sure about this. I ran the Tests but it used all available Memory. After a few minutes FreeCAD closed without any notification or output in the console.
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists --> no issue available but the commit message references the forum topic.

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
