### PR TITLE
Repair pythonopen in line 126 for Python3

### DIFF
--- a/src/Mod/Arch/importWebGL.py
+++ b/src/Mod/Arch/importWebGL.py
@@ -123,7 +123,7 @@ def export(exportList,filename):
     "exports the given objects to an .html file"
 
     html = getHTML(exportList)
-    outfile = pythonopen(filename,"wb")
+    outfile = pythonopen(filename,"w")
     outfile.write(html)
     outfile.close()
     FreeCAD.Console.PrintMessage(translate("Arch","Successfully written", utf8_decode=True) + ' ' + filename + "\n")


### PR DESCRIPTION
Python 3 is fussy about match of data type for a file open or write. Python 2 does not seem to care if a string is written with a 'wb' indicating a binary type, but Python 3 flags it as an error.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
