### PR TITLE
Set window visibility based on wall

### DIFF
--- a/src/Mod/Arch/ArchComponent.py
+++ b/src/Mod/Arch/ArchComponent.py
@@ -821,6 +821,11 @@ class ViewProviderComponent:
                 if len(vobj.DiffuseColor) > 1:
                     d = vobj.DiffuseColor
                     vobj.DiffuseColor = d
+        elif prop == "Visibility":
+            for host in self.getHosts():
+                if hasattr(host, 'ViewObject'):
+                    host.ViewObject.Visibility = vobj.Visibility
+
         return
 
     def attach(self,vobj):
@@ -917,15 +922,9 @@ class ViewProviderComponent:
                     objlink = getattr(self.Object,link)
                     if objlink:
                         c.append(objlink)
-            for link in self.Object.InList:
-                if hasattr(link,"Host"):
-                    if link.Host:
-                        if link.Host == self.Object:
-                            c.append(link)
-                elif hasattr(link,"Hosts"):
-                    for host in link.Hosts:
-                        if host == self.Object:
-                            c.append(link)
+            for link in self.getHosts():
+                c.append(link)
+
             return c
         return []
 
@@ -969,6 +968,22 @@ class ViewProviderComponent:
         if obj.CloneOf:
             if self.areDifferentColors(obj.ViewObject.DiffuseColor,obj.CloneOf.ViewObject.DiffuseColor) or force:
                 obj.ViewObject.DiffuseColor = obj.CloneOf.ViewObject.DiffuseColor
+    
+    def getHosts(self):
+        hosts = []
+
+        if hasattr(self,"Object"):
+            for link in self.Object.InList:
+                if hasattr(link,"Host"):
+                    if link.Host:
+                        if link.Host == self.Object:
+                            hosts.append(link)
+                elif hasattr(link,"Hosts"):
+                    for host in link.Hosts:
+                        if host == self.Object:
+                            hosts.append(link)
+        
+        return hosts
 
 
 class ArchSelectionObserver:


### PR DESCRIPTION
Previously windows attached to walls were not hidden or shown when the
visibility of the wall changed. This commit searches for all windows
that are based on the wall and hides or unhides them.

https://forum.freecadweb.org/viewtopic.php?f=23&t=34166
https://www.freecadweb.org/tracker/view.php?id=3833

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ x ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ x ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ x ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
