### PR TITLE
[For v0.19] New draft edit tool for multiple object editing and with all modifiers

### DIFF
--- a/src/Gui/Selection.cpp
+++ b/src/Gui/Selection.cpp
@@ -1077,6 +1077,8 @@ PyMethodDef SelectionSingleton::Methods[] = {
      "given the complete selection is cleared."},
     {"isSelected",           (PyCFunction) SelectionSingleton::sIsSelected, METH_VARARGS,
      "isSelected(object) -- Check if a given object is selected"},
+    {"setPreselection",      (PyCFunction) SelectionSingleton::sSetPreselection, METH_VARARGS,
+     "setPreselection() -- Set preselected object"},
     {"getPreselection",      (PyCFunction) SelectionSingleton::sGetPreselection, METH_VARARGS,
      "getPreselection() -- Get preselected object"},
     {"clearPreselection",   (PyCFunction) SelectionSingleton::sRemPreselection, METH_VARARGS,
@@ -1258,6 +1260,29 @@ PyObject *SelectionSingleton::sGetSelection(PyObject * /*self*/, PyObject *args)
     catch (Py::Exception&) {
         return 0;
     }
+}
+
+PyObject *SelectionSingleton::sSetPreselection(PyObject * /*self*/, PyObject *args)
+{
+    PyObject *object;
+    char* subname=0;
+    float x=0,y=0,z=0;
+    if (PyArg_ParseTuple(args, "O!|sfff", &(App::DocumentObjectPy::Type),&object,&subname,&x,&y,&z)) {
+        App::DocumentObjectPy* docObjPy = static_cast<App::DocumentObjectPy*>(object);
+        App::DocumentObject* docObj = docObjPy->getDocumentObjectPtr();
+        if (!docObj || !docObj->getNameInDocument()) {
+            PyErr_SetString(Base::BaseExceptionFreeCADError, "Cannot check invalid object");
+            return NULL;
+        }
+
+        Selection().setPreselect(docObj->getDocument()->getName(),
+                                 docObj->getNameInDocument(),
+                                 subname,x,y,z);
+        Py_Return;
+    }
+
+    PyErr_SetString(PyExc_ValueError, "type must be 'DocumentObject[,subname[,x,y,z]]'");
+    return 0;
 }
 
 PyObject *SelectionSingleton::sGetPreselection(PyObject * /*self*/, PyObject *args)

--- a/src/Gui/Selection.h
+++ b/src/Gui/Selection.h
@@ -341,6 +341,7 @@ protected:
     static PyObject *sIsSelected          (PyObject *self,PyObject *args);
     static PyObject *sCountObjectsOfType  (PyObject *self,PyObject *args);
     static PyObject *sGetSelection        (PyObject *self,PyObject *args);
+    static PyObject *sSetPreselection     (PyObject *self,PyObject *args);
     static PyObject *sGetPreselection     (PyObject *self,PyObject *args);
     static PyObject *sRemPreselection     (PyObject *self,PyObject *args);
     static PyObject *sGetCompleteSelection(PyObject *self,PyObject *args);

--- a/src/Gui/SoFCUnifiedSelection.cpp
+++ b/src/Gui/SoFCUnifiedSelection.cpp
@@ -375,6 +375,12 @@ void SoFCUnifiedSelection::doAction(SoAction *action)
                 currenthighlight = 0;
             }
         } else if (hilaction->SelChange.Type == SelectionChanges::SetPreselect) {
+            if (currenthighlight) {
+                SoHighlightElementAction action;
+                action.apply(currenthighlight);
+                currenthighlight->unref();
+                currenthighlight = 0;
+            }
             App::Document* doc = App::GetApplication().getDocument(hilaction->SelChange.pDocName);
             App::DocumentObject* obj = doc->getObject(hilaction->SelChange.pObjectName);
             ViewProvider*vp = Application::Instance->getViewProvider(obj);

--- a/src/Gui/SoFCUnifiedSelection.cpp
+++ b/src/Gui/SoFCUnifiedSelection.cpp
@@ -374,6 +374,22 @@ void SoFCUnifiedSelection::doAction(SoAction *action)
                 currenthighlight->unref();
                 currenthighlight = 0;
             }
+        } else if (hilaction->SelChange.Type == SelectionChanges::SetPreselect) {
+            App::Document* doc = App::GetApplication().getDocument(hilaction->SelChange.pDocName);
+            App::DocumentObject* obj = doc->getObject(hilaction->SelChange.pObjectName);
+            ViewProvider*vp = Application::Instance->getViewProvider(obj);
+            SoDetail* detail = vp->getDetail(hilaction->SelChange.pSubName);
+            SoHighlightElementAction action;
+            action.setHighlighted(true);
+            action.setColor(this->colorHighlight.getValue());
+            action.setElement(detail);
+            action.apply(vp->getRoot());
+            delete detail;
+            SoSearchAction sa;
+            sa.setNode(vp->getRoot());
+            sa.apply(vp->getRoot());
+            currenthighlight = static_cast<SoFullPath*>(sa.getPath()->copy());
+            currenthighlight->ref();
         }
     }
 

--- a/src/Gui/View3DInventorViewer.cpp
+++ b/src/Gui/View3DInventorViewer.cpp
@@ -643,7 +643,8 @@ void View3DInventorViewer::OnChange(Gui::SelectionSingleton::SubjectType& rCalle
         SoFCSelectionAction cAct(Reason);
         cAct.apply(pcViewProviderRoot);
     }
-    else if (Reason.Type == SelectionChanges::RmvPreselect) {
+    else if (Reason.Type == SelectionChanges::RmvPreselect ||
+        Reason.Type == SelectionChanges::SetPreselect) {
         SoFCHighlightAction cAct(Reason);
         cAct.apply(pcViewProviderRoot);
     }

--- a/src/Mod/Draft/Draft.py
+++ b/src/Mod/Draft/Draft.py
@@ -1472,7 +1472,7 @@ def move(objectslist,vector,copy=False):
     in objects (that can be an object or a list of objects)
     in the direction and distance indicated by the given
     vector. If copy is True, the actual objects are not moved, but copies
-    are created instead.he objects (or their copies) are returned.'''
+    are created instead. The objects (or their copies) are returned.'''
     typecheck([(vector,Vector), (copy,bool)], "move")
     if not isinstance(objectslist,list): objectslist = [objectslist]
     objectslist.extend(getMovableChildren(objectslist))

--- a/src/Mod/Draft/Draft.py
+++ b/src/Mod/Draft/Draft.py
@@ -1467,6 +1467,16 @@ def cut(object1,object2):
     FreeCAD.ActiveDocument.recompute()
     return obj
 
+def moveVertex(object, vertex_index, vertex, vector):
+    points = object.Points
+    points[vertex_index] = object.Placement.inverse().multVec(vertex).add(vector)
+    object.Points = points
+    FreeCAD.ActiveDocument.recompute()
+
+def moveEdge(object, edge_index, edge, vector):
+    moveVertex(object, edge_index, object.Placement.multVec(object.Points[edge_index]), vector)
+    moveVertex(object, edge_index+1, object.Placement.multVec(object.Points[edge_index+1]), vector)
+
 def move(objectslist,vector,copy=False):
     '''move(objects,vector,[copy]): Moves the objects contained
     in objects (that can be an object or a list of objects)

--- a/src/Mod/Draft/Draft.py
+++ b/src/Mod/Draft/Draft.py
@@ -1762,7 +1762,8 @@ def scale(objectslist,delta=Vector(1,1,1),center=Vector(0,0,0),copy=False,legacy
     given center. If legacy is True, direct (old) mode is used, otherwise
     a parametric copy is made. If copy is True, the actual objects are not moved,
     but copies are created instead. The objects (or their copies) are returned.'''
-    if not isinstance(objectslist,list): objectslist = [objectslist]
+    if not isinstance(objectslist, list):
+        objectslist = [objectslist]
     if legacy:
         newobjlist = []
         for obj in objectslist:
@@ -1800,7 +1801,6 @@ def scale(objectslist,delta=Vector(1,1,1),center=Vector(0,0,0),copy=False,legacy
             elif getType(obj) == "Wire":
                 p = []
                 for v in sh.Vertexes: p.append(v.Point)
-                #print(p)
                 newobj.Points = p
             elif getType(obj) == "BSpline":
                 p = []

--- a/src/Mod/Draft/Draft.py
+++ b/src/Mod/Draft/Draft.py
@@ -1471,9 +1471,8 @@ def moveVertex(object, vertex_index, vertex, vector):
     points = object.Points
     points[vertex_index] = object.Placement.inverse().multVec(vertex).add(vector)
     object.Points = points
-    FreeCAD.ActiveDocument.recompute()
 
-def moveEdge(object, edge_index, edge, vector):
+def moveEdge(object, edge_index, vector):
     moveVertex(object, edge_index, object.Placement.multVec(object.Points[edge_index]), vector)
     moveVertex(object, edge_index+1, object.Placement.multVec(object.Points[edge_index+1]), vector)
 

--- a/src/Mod/Draft/Draft.py
+++ b/src/Mod/Draft/Draft.py
@@ -1479,6 +1479,20 @@ def moveEdge(object, edge_index, vector):
     else:
         moveVertex(object, edge_index+1, object.Placement.multVec(object.Points[edge_index+1]), vector)
 
+def copyEdges(copy_edge_arguments):
+    copied_edges = []
+    for argument in copy_edge_arguments:
+        copied_edges.append(copyEdge(argument[0], argument[1], argument[2]))
+    joinWires(copied_edges)
+
+def copyEdge(object, edge_index, vector):
+    vertex1 = object.Placement.multVec(object.Points[edge_index]).add(vector)
+    if isClosedEdge(edge_index, object):
+        vertex2 = object.Placement.multVec(object.Points[0]).add(vector)
+    else:
+        vertex2 = object.Placement.multVec(object.Points[edge_index+1]).add(vector)
+    return makeLine(vertex1, vertex2)
+
 def isClosedEdge(edge_index, object):
     return edge_index + 1 >= len(object.Points)
 

--- a/src/Mod/Draft/Draft.py
+++ b/src/Mod/Draft/Draft.py
@@ -1642,6 +1642,15 @@ def array(objectslist,arg1,arg2,arg3,arg4=None,arg5=None,arg6=None):
     else:
         polarArray(objectslist,arg1,arg2,arg3)
 
+def rotateVertex(object, vertex_index, angle, center, axis):
+    points = object.Points
+    v = object.Placement.multVec(points[vertex_index])
+    rv = v.sub(center)
+    rv = DraftVecUtils.rotate(rv, math.radians(angle), axis)
+    v = center.add(rv)
+    points[vertex_index] = object.Placement.inverse().multVec(v)
+    object.Points = points
+
 def rotate(objectslist,angle,center=Vector(0,0,0),axis=Vector(0,0,1),copy=False):
     '''rotate(objects,angle,[center,axis,copy]): Rotates the objects contained
     in objects (that can be a list of objects or an object) of the given angle

--- a/src/Mod/Draft/Draft.py
+++ b/src/Mod/Draft/Draft.py
@@ -1474,7 +1474,13 @@ def moveVertex(object, vertex_index, vertex, vector):
 
 def moveEdge(object, edge_index, vector):
     moveVertex(object, edge_index, object.Placement.multVec(object.Points[edge_index]), vector)
-    moveVertex(object, edge_index+1, object.Placement.multVec(object.Points[edge_index+1]), vector)
+    if isClosedEdge(edge_index, object):
+        moveVertex(object, 0, object.Placement.multVec(object.Points[0]), vector)
+    else:
+        moveVertex(object, edge_index+1, object.Placement.multVec(object.Points[edge_index+1]), vector)
+
+def isClosedEdge(edge_index, object):
+    return edge_index + 1 >= len(object.Points)
 
 def move(objectslist,vector,copy=False):
     '''move(objects,vector,[copy]): Moves the objects contained

--- a/src/Mod/Draft/Draft.py
+++ b/src/Mod/Draft/Draft.py
@@ -1467,17 +1467,17 @@ def cut(object1,object2):
     FreeCAD.ActiveDocument.recompute()
     return obj
 
-def moveVertex(object, vertex_index, vertex, vector):
+def moveVertex(object, vertex_index, vector):
     points = object.Points
-    points[vertex_index] = object.Placement.inverse().multVec(vertex).add(vector)
+    points[vertex_index] = points[vertex_index].add(vector)
     object.Points = points
 
 def moveEdge(object, edge_index, vector):
-    moveVertex(object, edge_index, object.Placement.multVec(object.Points[edge_index]), vector)
+    moveVertex(object, edge_index, vector)
     if isClosedEdge(edge_index, object):
-        moveVertex(object, 0, object.Placement.multVec(object.Points[0]), vector)
+        moveVertex(object, 0, vector)
     else:
-        moveVertex(object, edge_index+1, object.Placement.multVec(object.Points[edge_index+1]), vector)
+        moveVertex(object, edge_index+1, vector)
 
 def copyEdges(copy_edge_arguments):
     copied_edges = []

--- a/src/Mod/Draft/DraftGui.py
+++ b/src/Mod/Draft/DraftGui.py
@@ -110,6 +110,7 @@ inCommandShortcuts = {
     "Continue":   ["T",translate("draft","Continue"),             "continueCmd"],
     "Close":      ["O",translate("draft","Close"),                "closeButton"],
     "Copy":       ["P",translate("draft","Copy"),                 "isCopy"],
+    "SubelementMode": ["D",translate("draft","Subelement mode"), "isSubelementMode"],
     "Fill":       ["L",translate("draft","Fill"),                 "hasFill"],
     "Exit":       ["A",translate("draft","Exit"),                 "finishButton"],
     "Snap":       ["S",translate("draft","Snap On/Off"),          None],
@@ -594,6 +595,7 @@ class DraftToolBar:
         self.currentViewButton = self._pushbutton("view", self.layout,icon="view-isometric")
         self.resetPlaneButton = self._pushbutton("none", self.layout,icon="view-axonometric")
         self.isCopy = self._checkbox("isCopy",self.layout,checked=False)
+        self.isSubelementMode = self._checkbox("isSubelementMode",self.layout,checked=False)
         gl = QtGui.QHBoxLayout()
         self.layout.addLayout(gl)
         self.gridLabel = self._label("gridLabel", gl)
@@ -816,6 +818,8 @@ class DraftToolBar:
         self.resetPlaneButton.setToolTip(translate("draft", "Do not project points to a drawing plane"))
         self.isCopy.setText(translate("draft", "Copy")+" ("+inCommandShortcuts["Copy"][0]+")")
         self.isCopy.setToolTip(translate("draft", "If checked, objects will be copied instead of moved. Preferences -> Draft -> Global copy mode to keep this mode in next commands"))
+        self.isSubelementMode.setText(translate("draft", "Modify subelements")+" ("+inCommandShortcuts["SubelementMode"][0]+")")
+        self.isSubelementMode.setToolTip(translate("draft", "If checked, subelements will be modified instead of entire objects"))
         self.SStringValue.setToolTip(translate("draft", "Text string to draw"))
         self.labelSString.setText(translate("draft", "String"))
         self.SSizeValue.setToolTip(translate("draft", "Height of text"))
@@ -1213,6 +1217,7 @@ class DraftToolBar:
 
     def modUi(self):
         self.isCopy.show()
+        self.isSubelementMode.show()
         p = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/Draft")
         if p.GetBool("copymode",True):
             self.isCopy.setChecked(p.GetBool("copymodeValue",False))
@@ -1696,6 +1701,10 @@ class DraftToolBar:
         elif txt.upper().endswith(inCommandShortcuts["Copy"][0]):
             if self.isCopy.isVisible():
                 self.isCopy.setChecked(not self.isCopy.isChecked())
+            spec = True
+        elif txt.upper().endswith(inCommandShortcuts["SubelementMode"][0]):
+            if self.isSubelementMode.isVisible():
+                self.isSubelementMode.setChecked(not self.isSubelementMode.isChecked())
             spec = True
         if spec:
             for i,k in enumerate([self.xValue,self.yValue,self.zValue,self.lengthValue,self.angleValue]):

--- a/src/Mod/Draft/DraftGui.py
+++ b/src/Mod/Draft/DraftGui.py
@@ -2339,17 +2339,12 @@ class ScaleTaskPanel:
         layout.addWidget(self.lock,3,0,1,2)
         self.relative = QtGui.QCheckBox()
         layout.addWidget(self.relative,4,0,1,2)
-        self.rLabel = QtGui.QLabel()
-        layout.addWidget(self.rLabel,5,0,1,2)
-        self.isClone = QtGui.QRadioButton()
-        layout.addWidget(self.isClone,6,0,1,2)
-        self.isClone.setChecked(True)
-        self.isOriginal = QtGui.QRadioButton()
-        layout.addWidget(self.isOriginal,7,0,1,2)
-        self.isCopy = QtGui.QRadioButton()
-        layout.addWidget(self.isCopy,8,0,1,2)
+        self.isCopy = QtGui.QCheckBox()
+        layout.addWidget(self.isCopy,5,0,1,2)
+        self.isSubelementMode = QtGui.QCheckBox()
+        layout.addWidget(self.isSubelementMode,6,0,1,2)
         self.pickrefButton = QtGui.QPushButton()
-        layout.addWidget(self.pickrefButton,9,0,1,2)
+        layout.addWidget(self.pickrefButton,7,0,1,2)
         QtCore.QObject.connect(self.xValue,QtCore.SIGNAL("valueChanged(double)"),self.setValue)
         QtCore.QObject.connect(self.yValue,QtCore.SIGNAL("valueChanged(double)"),self.setValue)
         QtCore.QObject.connect(self.zValue,QtCore.SIGNAL("valueChanged(double)"),self.setValue)
@@ -2371,10 +2366,8 @@ class ScaleTaskPanel:
         self.zLabel.setText(QtGui.QApplication.translate("Draft", "Z factor", None))
         self.lock.setText(QtGui.QApplication.translate("Draft", "Uniform scaling", None))
         self.relative.setText(QtGui.QApplication.translate("Draft", "Working plane orientation", None))
-        self.rLabel.setText(QtGui.QApplication.translate("Draft", "Result", None))
-        self.isClone.setText(QtGui.QApplication.translate("Draft", "Create a clone", None))
-        self.isOriginal.setText(QtGui.QApplication.translate("Draft", "Modify original", None))
-        self.isCopy.setText(QtGui.QApplication.translate("Draft", "Create a copy", None))
+        self.isCopy.setText(QtGui.QApplication.translate("draft", "Copy"))
+        self.isSubelementMode.setText(QtGui.QApplication.translate("draft", "Modify subelements"))
         self.pickrefButton.setText(QtGui.QApplication.translate("Draft", "Pick from/to points", None))
 
     def pickRef(self):
@@ -2383,17 +2376,7 @@ class ScaleTaskPanel:
 
     def accept(self):
         if self.sourceCmd:
-            x = self.xValue.value()
-            y = self.yValue.value()
-            z = self.zValue.value()
-            rel = self.relative.isChecked()
-            if self.isClone.isChecked():
-                mod = 0
-            elif self.isOriginal.isChecked():
-                mod = 1
-            else:
-                mod = 2
-            self.sourceCmd.scale(x,y,z,rel,mod)
+            self.sourceCmd.scale()
         FreeCADGui.ActiveDocument.resetEdit()
         return True
 

--- a/src/Mod/Draft/DraftTools.py
+++ b/src/Mod/Draft/DraftTools.py
@@ -3909,29 +3909,46 @@ class Scale(Modifier):
     def Activated(self):
         self.name = translate("draft","Scale", utf8_decode=True)
         Modifier.Activated(self,self.name)
-        self.ghost = None
-        if self.ui:
-            if not FreeCADGui.Selection.getSelection():
-                self.ui.selectUi()
-                msg(translate("draft", "Select an object to scale")+"\n")
-                self.call = self.view.addEventCallback("SoEvent",selectObject)
-            else:
-                self.proceed()
+        if not self.ui:
+            return
+        self.ghosts = []
+        self.get_object_selection()
+
+    def get_object_selection(self):
+        if FreeCADGui.Selection.getSelection():
+            return self.proceed()
+        self.ui.selectUi()
+        msg(translate("draft", "Select an object to scale")+"\n")
+        self.call = self.view.addEventCallback("SoEvent",selectObject)
 
     def proceed(self):
-        if self.call: self.view.removeEventCallback("SoEvent",self.call)
-        self.sel = FreeCADGui.Selection.getSelection()
-        self.sel = Draft.getGroupContents(self.sel)
+        if self.call:
+            self.view.removeEventCallback("SoEvent", self.call)
+        self.selected_objects = FreeCADGui.Selection.getSelection()
+        self.selected_objects = Draft.getGroupContents(self.selected_objects)
+        self.selected_subelements = FreeCADGui.Selection.getSelectionEx()
         self.refs = []
         self.ui.pointUi(self.name)
         self.ui.modUi()
         self.ui.xValue.setFocus()
         self.ui.xValue.selectAll()
-        self.ghost = ghostTracker(self.sel)
         self.pickmode = False
         self.task = None
-        self.call = self.view.addEventCallback("SoEvent",self.action)
+        self.call = self.view.addEventCallback("SoEvent", self.action)
         msg(translate("draft", "Pick base point:")+"\n")
+
+    def set_ghosts(self):
+        if self.ui.isSubelementMode.isChecked():
+            return self.set_subelement_ghosts()
+        self.ghosts = [ghostTracker(self.selected_objects)]
+
+    def set_subelement_ghosts(self):
+        import Part
+        for object in self.selected_subelements:
+            for subelement in object.SubObjects:
+                if isinstance(subelement, Part.Vertex) \
+                    or isinstance(subelement, Part.Edge):
+                    self.ghosts.append(ghostTracker(subelement))
 
     def pickRef(self):
         self.pickmode = True
@@ -3940,10 +3957,29 @@ class Scale(Modifier):
         msg(translate("draft", "Pick reference distance from base point:")+"\n")
         self.call = self.view.addEventCallback("SoEvent",self.action)
 
+    def action(self,arg):
+        "scene event handler"
+        if arg["Type"] == "SoKeyboardEvent" and arg["Key"] == "ESCAPE":
+            self.finish()
+        elif arg["Type"] == "SoLocation2Event":
+            self.handle_mouse_move_event(arg)
+        elif arg["Type"] == "SoMouseButtonEvent" \
+            and arg["State"] == "DOWN" \
+            and (arg["Button"] == "BUTTON1") \
+            and self.point:
+                if not self.ghosts:
+                    self.set_ghosts()
+                self.numericInput(self.point.x, self.point.y, self.point.z)
+
+    def handle_mouse_move_event(self, arg):
+        for ghost in self.ghosts:
+            ghost.off()
+        self.point, ctrlPoint, info = getPoint(self, arg, sym=True)
+
     def finish(self,closed=False,cont=False):
         Modifier.finish(self)
-        if self.ghost:
-            self.ghost.finalize()
+        for ghost in self.ghosts:
+            ghost.finalize()
 
     def scale(self,x,y,z,rel,mode):
         delta = Vector(x,y,z)
@@ -3958,16 +3994,10 @@ class Scale(Modifier):
         elif mode == 2:
             copy = True
             legacy = True
-        "moving the real shapes"
-        sel = '['
-        for o in self.sel:
-            if len(sel) > 1:
-                sel += ','
-            sel += 'FreeCAD.ActiveDocument.'+o.Name
-        sel += ']'
+        objects = '[' + ','.join(['FreeCAD.ActiveDocument.' + object.Name for object in self.selected_objects]) + ']'
         FreeCADGui.addModule("Draft")
         self.commit(translate("draft","Copy"),
-                    ['Draft.scale('+sel+',delta='+DraftVecUtils.toString(delta)+',center='+DraftVecUtils.toString(self.node[0])+',copy='+str(copy)+',legacy='+str(legacy)+')',
+                    ['Draft.scale('+objects+',delta='+DraftVecUtils.toString(delta)+',center='+DraftVecUtils.toString(self.node[0])+',copy='+str(copy)+',legacy='+str(legacy)+')',
                      'FreeCAD.ActiveDocument.recompute()'])
         self.finish()
 
@@ -3975,28 +4005,15 @@ class Scale(Modifier):
         delta = Vector(x,y,z)
         if rel:
             delta = FreeCAD.DraftWorkingPlane.getGlobalCoords(delta)
-        self.ghost.scale(delta)
+        for ghost in self.ghosts:
+            ghost.scale(delta)
         # calculate a correction factor depending on the scaling center
         corr = Vector(self.node[0].x,self.node[0].y,self.node[0].z)
         corr.scale(delta.x,delta.y,delta.z)
         corr = (corr.sub(self.node[0])).negative()
-        self.ghost.move(corr)
-        self.ghost.on()
-
-    def action(self,arg):
-        "scene event handler"
-        if arg["Type"] == "SoKeyboardEvent":
-            if arg["Key"] == "ESCAPE":
-                self.finish()
-        elif arg["Type"] == "SoLocation2Event": #mouse movement detection
-            if self.ghost:
-                self.ghost.off()
-            self.point,ctrlPoint,info = getPoint(self,arg,sym=True)
-        elif arg["Type"] == "SoMouseButtonEvent":
-            if (arg["State"] == "DOWN") and (arg["Button"] == "BUTTON1"):
-                if self.point:
-                    #self.ui.redraw()
-                    self.numericInput(self.point.x,self.point.y,self.point.z)
+        for ghost in self.ghosts:
+            ghost.move(corr)
+            ghost.on()
 
     def numericInput(self,numx,numy,numz):
         "this function gets called by the toolbar when a valid base point has been entered"
@@ -4009,8 +4026,8 @@ class Scale(Modifier):
             self.task = DraftGui.ScaleTaskPanel()
             self.task.sourceCmd = self
             DraftGui.todo.delay(FreeCADGui.Control.showDialog,self.task)
-            if self.ghost:
-                self.ghost.on()
+            for ghost in self.ghosts:
+                ghost.on()
         elif len(self.node) == 2:
             msg(translate("draft", "Pick new distance from base point:")+"\n")
         elif len(self.node) == 3:

--- a/src/Mod/Draft/DraftTools.py
+++ b/src/Mod/Draft/DraftTools.py
@@ -2418,7 +2418,7 @@ class Move(Modifier):
 
     def handle_mouse_click_event(self, arg):
         if not self.ghosts:
-            self.set_ghost()
+            self.set_ghosts()
         if not self.point:
             return
         self.ui.redraw()
@@ -2439,7 +2439,7 @@ class Move(Modifier):
             else:
                 self.finish(cont=True)
 
-    def set_ghost(self):
+    def set_ghosts(self):
         if self.ui.isSubelementMode.isChecked():
             return self.set_subelement_ghosts()
         self.ghosts = [ghostTracker(self.selected_objects)]
@@ -2450,9 +2450,7 @@ class Move(Modifier):
             for subelement in object.SubObjects:
                 if isinstance(subelement, Part.Vertex) \
                     or isinstance(subelement, Part.Edge):
-                    ghost = ghostTracker(subelement)
-                    ghost.on()
-                    self.ghosts.append(ghost)
+                    self.ghosts.append(ghostTracker(subelement))
 
     def move(self):
         if self.ui.isSubelementMode.isChecked():
@@ -2492,10 +2490,9 @@ class Move(Modifier):
         for object in self.selected_subelements:
             for index, subelement in enumerate(object.SubObjects):
                 if isinstance(subelement, Part.Vertex):
-                    command.append('Draft.moveVertex(FreeCAD.ActiveDocument.{}, {}, {}, {})'.format(
+                    command.append('Draft.moveVertex(FreeCAD.ActiveDocument.{}, {}, {})'.format(
                         object.ObjectName,
                         int(object.SubElementNames[index][len("Vertex"):])-1,
-                        DraftVecUtils.toString(subelement.Point),
                         DraftVecUtils.toString(self.vector)
                         ))
                 elif isinstance(subelement, Part.Edge):

--- a/src/Mod/Draft/DraftTools.py
+++ b/src/Mod/Draft/DraftTools.py
@@ -2462,9 +2462,29 @@ class Move(Modifier):
 
     def move_subelements(self):
         try:
-            self.commit(translate("draft", "Move"), self.build_move_subelements_command())
+            if self.ui.isCopy.isChecked():
+                self.commit(translate("draft", "Copy"), self.build_copy_subelements_command())
+            else:
+                self.commit(translate("draft", "Move"), self.build_move_subelements_command())
         except:
             FreeCAD.Console.PrintError(translate("draft", "Some subelements could not be moved."))
+
+    def build_copy_subelements_command(self):
+        import Part
+        command = []
+        copy_edge_arguments = []
+        for object in self.selected_subelements:
+            for index, subelement in enumerate(object.SubObjects):
+                if not isinstance(subelement, Part.Edge):
+                    continue
+                copy_edge_arguments.append('[FreeCAD.ActiveDocument.{}, {}, {}]'.format(
+                    object.ObjectName,
+                    int(object.SubElementNames[index][len("Edge"):])-1,
+                    DraftVecUtils.toString(self.vector)
+                    ))
+        command.append('Draft.copyEdges([{}])'.format(','.join(copy_edge_arguments)))
+        command.append('FreeCAD.ActiveDocument.recompute()')
+        return command
 
     def build_move_subelements_command(self):
         import Part

--- a/src/Mod/Draft/DraftTools.py
+++ b/src/Mod/Draft/DraftTools.py
@@ -217,8 +217,8 @@ class DraftTool:
         else:
             return False
 
-    def Activated(self,name="None",noplanesetup=False):
-        if FreeCAD.activeDraftCommand:
+    def Activated(self, name="None", noplanesetup=False, is_subtool=False):
+        if FreeCAD.activeDraftCommand and not is_subtool:
             FreeCAD.activeDraftCommand.finish()
 
         global Part, DraftGeomUtils
@@ -2348,115 +2348,134 @@ class Move(Modifier):
 
     def __init__(self):
         Modifier.__init__(self)
-        self.copymode = False
 
     def GetResources(self):
         return {'Pixmap'  : 'Draft_Move',
                 'Accel' : "M, V",
                 'MenuText': QtCore.QT_TRANSLATE_NOOP("Draft_Move", "Move"),
-                'ToolTip': QtCore.QT_TRANSLATE_NOOP("Draft_Move", "Moves the selected objects between 2 points. CTRL to snap, SHIFT to constrain, ALT to copy")}
+                'ToolTip': QtCore.QT_TRANSLATE_NOOP("Draft_Move", "Moves the selected objects between 2 points. CTRL to snap, SHIFT to constrain")}
 
     def Activated(self):
         self.name = translate("draft","Move", utf8_decode=True)
-        if not isinstance(FreeCAD.activeDraftCommand, EditImproved):
-            Modifier.Activated(self,self.name)
-        else:
-            self.ui = FreeCADGui.draftToolBar
-            self.view = Draft.get3DView()
-            self.call = None
-            self.node = []
-            self.extendedCopy = False
-            self.featureName = "Edit_Improved"
-            self.planetrack = None
-        self.ghost = None
-        if self.ui:
-            if not FreeCADGui.Selection.getSelection():
-                self.ui.selectUi()
-                msg(translate("draft", "Select an object to move")+"\n")
-                self.call = self.view.addEventCallback("SoEvent",selectObject)
-            else:
-                self.proceed()
+        Modifier.Activated(self, self.name, is_subtool=isinstance(FreeCAD.activeDraftCommand, EditImproved))
+        if not self.ui:
+            return
+        self.ghosts = []
+        self.get_object_selection()
+
+    def get_object_selection(self):
+        if FreeCADGui.Selection.getSelectionEx():
+            return self.proceed()
+        self.ui.selectUi()
+        msg(translate("draft", "Select an object to move")+"\n")
+        self.call = self.view.addEventCallback("SoEvent", selectObject)
 
     def proceed(self):
-        if self.call: self.view.removeEventCallback("SoEvent",self.call)
-        self.sel = FreeCADGui.Selection.getSelection()
-        self.sel = Draft.getGroupContents(self.sel,addgroups=True,spaces=True,noarchchild=True)
+        if self.call:
+            self.view.removeEventCallback("SoEvent",self.call)
+        self.selected_objects = FreeCADGui.Selection.getSelection()
+        self.selected_objects = Draft.getGroupContents(self.selected_objects, addgroups=True, spaces=True, noarchchild=True)
+        self.selected_subelements = FreeCADGui.Selection.getSelectionEx()
         self.ui.pointUi(self.name)
         self.ui.modUi()
-        if self.copymode:
-            self.ui.isCopy.setChecked(True)
         self.ui.xValue.setFocus()
         self.ui.xValue.selectAll()
-        self.ghost = ghostTracker(self.sel)
-        self.call = self.view.addEventCallback("SoEvent",self.action)
+        self.call = self.view.addEventCallback("SoEvent", self.action)
         msg(translate("draft", "Pick start point:")+"\n")
 
     def finish(self,closed=False,cont=False):
-        if self.ghost:
-            self.ghost.finalize()
+        for ghost in self.ghosts:
+            ghost.finalize()
         if cont and self.ui:
             if self.ui.continueMode:
                 todo.delayAfter(self.Activated,[])
         Modifier.finish(self)
 
-    def move(self,delta,copy=False):
-        "moving the real shapes"
-        sel = '['
-        for o in self.sel:
-            if len(sel) > 1:
-                sel += ','
-            sel += 'FreeCAD.ActiveDocument.'+o.Name
-        sel += ']'
-        FreeCADGui.addModule("Draft")
-        if copy:
-            self.commit(translate("draft","Copy"),
-                        ['Draft.move('+sel+','+DraftVecUtils.toString(delta)+',copy='+str(copy)+')',
-                         'FreeCAD.ActiveDocument.recompute()'])
-        else:
-            self.commit(translate("draft","Move"),
-                        ['Draft.move('+sel+','+DraftVecUtils.toString(delta)+',copy='+str(copy)+')',
-                         'FreeCAD.ActiveDocument.recompute()'])
-
     def action(self,arg):
         "scene event handler"
-        if arg["Type"] == "SoKeyboardEvent":
-            if arg["Key"] == "ESCAPE":
-                self.finish()
-        elif arg["Type"] == "SoLocation2Event": #mouse movement detection
-            if self.ghost:
-                self.ghost.off()
-            self.point,ctrlPoint,info = getPoint(self,arg)
-            if (len(self.node) > 0):
-                last = self.node[len(self.node)-1]
-                delta = self.point.sub(last)
-                if self.ghost:
-                    self.ghost.move(delta)
-                    self.ghost.on()
-            if self.extendedCopy:
-                if not hasMod(arg,MODALT): self.finish()
-            redraw3DView()
-        elif arg["Type"] == "SoMouseButtonEvent":
-            if (arg["State"] == "DOWN") and (arg["Button"] == "BUTTON1"):
-                if self.point:
-                    self.ui.redraw()
-                    if (self.node == []):
-                        self.node.append(self.point)
-                        self.ui.isRelative.show()
-                        if self.ghost:
-                            self.ghost.on()
-                        msg(translate("draft", "Pick end point:")+"\n")
-                        if self.planetrack:
-                            self.planetrack.set(self.point)
-                    else:
-                        last = self.node[0]
-                        if self.ui.isCopy.isChecked() or hasMod(arg,MODALT):
-                            self.move(self.point.sub(last),True)
-                        else:
-                            self.move(self.point.sub(last))
-                        if hasMod(arg,MODALT):
-                            self.extendedCopy = True
-                        else:
-                            self.finish(cont=True)
+        if arg["Type"] == "SoKeyboardEvent" and arg["Key"] == "ESCAPE":
+            self.finish()
+        elif arg["Type"] == "SoLocation2Event":
+            self.handle_mouse_move_event(arg)
+        elif arg["Type"] == "SoMouseButtonEvent" \
+            and arg["State"] == "DOWN" \
+            and arg["Button"] == "BUTTON1":
+            self.handle_mouse_click_event(arg)
+
+    def handle_mouse_move_event(self, arg):
+        for ghost in self.ghosts:
+            ghost.off()
+        self.point, ctrlPoint, info = getPoint(self,arg)
+        if (len(self.node) > 0):
+            last = self.node[len(self.node)-1]
+            delta = self.point.sub(last)
+            for ghost in self.ghosts:
+                ghost.move(delta)
+                ghost.on()
+        if self.extendedCopy:
+            if not hasMod(arg,MODALT): self.finish()
+        redraw3DView()
+
+    def handle_mouse_click_event(self, arg):
+        if not self.ghosts:
+            self.set_ghost()
+        if not self.point:
+            return
+        self.ui.redraw()
+        if self.node == []:
+            self.node.append(self.point)
+            self.ui.isRelative.show()
+            for ghost in self.ghosts:
+                ghost.on()
+            msg(translate("draft", "Pick end point:")+"\n")
+            if self.planetrack:
+                self.planetrack.set(self.point)
+        else:
+            last = self.node[0]
+            self.move(self.point.sub(last))
+            if hasMod(arg,MODALT):
+                self.extendedCopy = True
+            else:
+                self.finish(cont=True)
+
+    def set_ghost(self):
+        if self.ui.isSubelementMode.isChecked():
+            return self.set_subelement_ghosts()
+        self.ghosts = [ghostTracker(self.selected_objects)]
+
+    def set_subelement_ghosts(self):
+        import Part
+        for object in self.selected_subelements:
+            for subelement in object.SubObjects:
+                if isinstance(subelement, Part.Vertex) \
+                    or isinstance(subelement, Part.Edge):
+                    ghost = ghostTracker(subelement)
+                    ghost.on()
+                    self.ghosts.append(ghost)
+
+    def move(self, delta):
+        if self.ui.isSubelementMode.isChecked():
+            self.move_subelements(delta)
+        else:
+            self.move_object(delta)
+
+    def move_subelements(self, delta):
+        for object in self.selected_subelements:
+            for index, subelement in enumerate(object.SubObjects):
+                if isinstance(subelement, Part.Vertex):
+                    Draft.moveVertex(getattr(FreeCAD.ActiveDocument, object.ObjectName),
+                            int(object.SubElementNames[index][len("Vertex"):])-1,
+                            subelement.Point, delta)
+                elif isinstance(subelement, Part.Edge):
+                    Draft.moveEdge(getattr(FreeCAD.ActiveDocument, object.ObjectName),
+                            int(object.SubElementNames[index][len("Edge"):])-1,
+                            subelement, delta)
+
+    def move_object(self, delta):
+        objects = '[' + ','.join(['FreeCAD.ActiveDocument.' + object.Name for object in self.selected_objects]) + ']'
+        FreeCADGui.addModule("Draft")
+        self.commit(translate("draft","Copy" if self.ui.isCopy.isChecked() else "Move"),
+            ['Draft.move('+objects+','+DraftVecUtils.toString(delta)+',copy='+str(self.ui.isCopy.isChecked())+')', 'FreeCAD.ActiveDocument.recompute()'])
 
     def numericInput(self,numx,numy,numz):
         "this function gets called by the toolbar when valid x, y, and z have been entered there"
@@ -2474,7 +2493,6 @@ class Move(Modifier):
             else:
                 self.move(self.point.sub(last))
             self.finish()
-
 
 class ApplyStyle(Modifier):
     "The Draft_ApplyStyle FreeCA command definition"

--- a/src/Mod/Draft/DraftTools.py
+++ b/src/Mod/Draft/DraftTools.py
@@ -2575,36 +2575,158 @@ class Rotate(Modifier):
 
     def Activated(self):
         Modifier.Activated(self,"Rotate")
-        self.ghost = None
+        if not self.ui:
+            return
+        self.ghosts = []
         self.arctrack = None
-        if self.ui:
-            if not FreeCADGui.Selection.getSelection():
-                self.ui.selectUi()
-                msg(translate("draft", "Select an object to rotate")+"\n")
-                self.call = self.view.addEventCallback("SoEvent",selectObject)
-            else:
-                self.proceed()
+        self.get_object_selection()
+
+    def get_object_selection(self):
+        if FreeCADGui.Selection.getSelection():
+            return self.proceed()
+        self.ui.selectUi()
+        msg(translate("draft", "Select an object to rotate")+"\n")
+        self.call = self.view.addEventCallback("SoEvent", selectObject)
 
     def proceed(self):
-        if self.call: self.view.removeEventCallback("SoEvent",self.call)
-        self.sel = FreeCADGui.Selection.getSelection()
-        self.sel = Draft.getGroupContents(self.sel,addgroups=True,spaces=True,noarchchild=True)
+        if self.call:
+            self.view.removeEventCallback("SoEvent", self.call)
+        self.selected_objects = FreeCADGui.Selection.getSelection()
+        self.selected_objects = Draft.getGroupContents(self.selected_objects, addgroups=True, spaces=True, noarchchild=True)
+        self.selected_subelements = FreeCADGui.Selection.getSelectionEx()
         self.step = 0
         self.center = None
         self.ui.arcUi()
         self.ui.modUi()
         self.ui.setTitle("Rotate")
         self.arctrack = arcTracker()
-        self.ghost = ghostTracker(self.sel)
         self.call = self.view.addEventCallback("SoEvent",self.action)
         msg(translate("draft", "Pick rotation center:")+"\n")
 
-    def finish(self,closed=False,cont=False):
+    def action(self, arg):
+        "scene event handler"
+        if arg["Type"] == "SoKeyboardEvent" and arg["Key"] == "ESCAPE":
+                self.finish()
+        elif arg["Type"] == "SoLocation2Event":
+            self.handle_mouse_move_event(arg)
+        elif arg["Type"] == "SoMouseButtonEvent" \
+            and arg["State"] == "DOWN" \
+            and arg["Button"] == "BUTTON1":
+            self.handle_mouse_click_event(arg)
+
+    def handle_mouse_move_event(self, arg):
+        for ghost in self.ghosts:
+            ghost.off()
+        self.point,ctrlPoint,info = getPoint(self,arg)
+        # this is to make sure radius is what you see on screen
+        if self.center and DraftVecUtils.dist(self.point,self.center):
+            viewdelta = DraftVecUtils.project(self.point.sub(self.center), plane.axis)
+            if not DraftVecUtils.isNull(viewdelta):
+                self.point = self.point.add(viewdelta.negative())
+        if self.extendedCopy:
+            if not hasMod(arg,MODALT):
+                self.step = 3
+                self.finish()
+        if (self.step == 0):
+            pass
+        elif (self.step == 1):
+            currentrad = DraftVecUtils.dist(self.point,self.center)
+            if (currentrad != 0):
+                angle = DraftVecUtils.angle(plane.u, self.point.sub(self.center), plane.axis)
+            else: angle = 0
+            self.ui.setRadiusValue(math.degrees(angle),unit="Angle")
+            self.firstangle = angle
+            self.ui.radiusValue.setFocus()
+            self.ui.radiusValue.selectAll()
+        elif (self.step == 2):
+            currentrad = DraftVecUtils.dist(self.point,self.center)
+            if (currentrad != 0):
+                angle = DraftVecUtils.angle(plane.u, self.point.sub(self.center), plane.axis)
+            else: angle = 0
+            if (angle < self.firstangle):
+                sweep = (2*math.pi-self.firstangle)+angle
+            else:
+                sweep = angle - self.firstangle
+            self.arctrack.setApertureAngle(sweep)
+            for ghost in self.ghosts:
+                ghost.rotate(plane.axis,sweep)
+                ghost.on()
+            self.ui.setRadiusValue(math.degrees(sweep), 'Angle')
+            self.ui.radiusValue.setFocus()
+            self.ui.radiusValue.selectAll()
+        redraw3DView()
+
+    def handle_mouse_click_event(self, arg):
+        if not self.point:
+            return
+        if self.step == 0:
+            self.set_center()
+        elif self.step == 1:
+            self.set_start_point()
+        else:
+            self.set_rotation_angle(arg)
+
+    def set_center(self):
+        if not self.ghosts:
+            self.set_ghosts()
+        self.center = self.point
+        self.node = [self.point]
+        self.ui.radiusUi()
+        self.ui.radiusValue.setText(FreeCAD.Units.Quantity(0,FreeCAD.Units.Angle).UserString)
+        self.ui.hasFill.hide()
+        self.ui.labelRadius.setText("Base angle")
+        self.arctrack.setCenter(self.center)
+        for ghost in self.ghosts:
+            ghost.center(self.center)
+        self.step = 1
+        msg(translate("draft", "Pick base angle:")+"\n")
+        if self.planetrack:
+            self.planetrack.set(self.point)
+
+    def set_start_point(self):
+        self.ui.labelRadius.setText("Rotation")
+        self.rad = DraftVecUtils.dist(self.point,self.center)
+        self.arctrack.on()
+        self.arctrack.setStartPoint(self.point)
+        for ghost in self.ghosts:
+            ghost.on()
+        self.step = 2
+        msg(translate("draft", "Pick rotation angle:")+"\n")
+
+    def set_rotation_angle(self, arg):
+        currentrad = DraftVecUtils.dist(self.point,self.center)
+        angle = self.point.sub(self.center).getAngle(plane.u)
+        if DraftVecUtils.project(self.point.sub(self.center), plane.v).getAngle(plane.v) > 1:
+            angle = -angle
+        if (angle < self.firstangle):
+            self.angle = (2*math.pi-self.firstangle)+angle
+        else:
+            self.angle = angle - self.firstangle
+        self.rotate(self.ui.isCopy.isChecked() or hasMod(arg,MODALT))
+        if hasMod(arg,MODALT):
+            self.extendedCopy = True
+        else:
+            self.finish(cont=True)
+
+    def set_ghosts(self):
+        if self.ui.isSubelementMode.isChecked():
+            return self.set_subelement_ghosts()
+        self.ghosts = [ghostTracker(self.selected_objects)]
+
+    def set_subelement_ghosts(self):
+        import Part
+        for object in self.selected_subelements:
+            for subelement in object.SubObjects:
+                if isinstance(subelement, Part.Vertex) \
+                    or isinstance(subelement, Part.Edge):
+                    self.ghosts.append(ghostTracker(subelement))
+
+    def finish(self, closed=False, cont=False):
         "finishes the arc"
         if self.arctrack:
             self.arctrack.finalize()
-        if self.ghost:
-            self.ghost.finalize()
+        for ghost in self.ghosts:
+            ghost.finalize()
         if cont and self.ui:
             if self.ui.continueMode:
                 todo.delayAfter(self.Activated,[])
@@ -2612,112 +2734,52 @@ class Rotate(Modifier):
         if self.doc:
             self.doc.recompute()
 
-    def rot (self,angle,copy=False):
-        "rotating the real shapes"
-        sel = '['
-        for o in self.sel:
-            if len(sel) > 1:
-                sel += ','
-            sel += 'FreeCAD.ActiveDocument.'+o.Name
-        sel += ']'
-        FreeCADGui.addModule("Draft")
-        if copy:
-            self.commit(translate("draft","Copy"),
-                        ['Draft.rotate('+sel+','+str(math.degrees(angle))+','+DraftVecUtils.toString(self.center)+',axis='+DraftVecUtils.toString(plane.axis)+',copy='+str(copy)+')'])
+    def rotate(self, is_copy=False):
+        if self.ui.isSubelementMode.isChecked():
+            self.rotate_subelements(is_copy)
         else:
-            self.commit(translate("draft","Rotate"),
-                        ['Draft.rotate('+sel+','+str(math.degrees(angle))+','+DraftVecUtils.toString(self.center)+',axis='+DraftVecUtils.toString(plane.axis)+',copy='+str(copy)+')'])
+            self.rotate_object(is_copy)
 
-    def action(self,arg):
-        "scene event handler"
-        if arg["Type"] == "SoKeyboardEvent":
-            if arg["Key"] == "ESCAPE":
-                self.finish()
-        elif arg["Type"] == "SoLocation2Event":
-            if self.ghost:
-                self.ghost.off()
-            self.point,ctrlPoint,info = getPoint(self,arg)
-            # this is to make sure radius is what you see on screen
-            if self.center and DraftVecUtils.dist(self.point,self.center):
-                viewdelta = DraftVecUtils.project(self.point.sub(self.center), plane.axis)
-                if not DraftVecUtils.isNull(viewdelta):
-                    self.point = self.point.add(viewdelta.negative())
-            if self.extendedCopy:
-                if not hasMod(arg,MODALT):
-                    self.step = 3
-                    self.finish()
-            if (self.step == 0):
-                pass
-            elif (self.step == 1):
-                currentrad = DraftVecUtils.dist(self.point,self.center)
-                if (currentrad != 0):
-                    angle = DraftVecUtils.angle(plane.u, self.point.sub(self.center), plane.axis)
-                else: angle = 0
-                self.ui.setRadiusValue(math.degrees(angle),unit="Angle")
-                self.firstangle = angle
-                self.ui.radiusValue.setFocus()
-                self.ui.radiusValue.selectAll()
-            elif (self.step == 2):
-                currentrad = DraftVecUtils.dist(self.point,self.center)
-                if (currentrad != 0):
-                    angle = DraftVecUtils.angle(plane.u, self.point.sub(self.center), plane.axis)
-                else: angle = 0
-                if (angle < self.firstangle):
-                    sweep = (2*math.pi-self.firstangle)+angle
-                else:
-                    sweep = angle - self.firstangle
-                self.arctrack.setApertureAngle(sweep)
-                if self.ghost:
-                    self.ghost.rotate(plane.axis,sweep)
-                    self.ghost.on()
-                self.ui.setRadiusValue(math.degrees(sweep), 'Angle')
-                self.ui.radiusValue.setFocus()
-                self.ui.radiusValue.selectAll()
-            redraw3DView()
+    def rotate_subelements(self, is_copy):
+        self.commit(translate("draft", "Rotate"), self.build_rotate_subelements_command())
+        return
+        try:
+            if self.ui.isCopy.isChecked():
+                self.commit(translate("draft", "Copy"), self.build_copy_subelements_command())
+            else:
+                self.commit(translate("draft", "Rotate"), self.build_rotate_subelements_command())
+        except:
+            FreeCAD.Console.PrintError(translate("draft", "Some subelements could not be moved."))
 
-        elif arg["Type"] == "SoMouseButtonEvent":
-            if (arg["State"] == "DOWN") and (arg["Button"] == "BUTTON1"):
-                if self.point:
-                    if (self.step == 0):
-                        self.center = self.point
-                        self.node = [self.point]
-                        self.ui.radiusUi()
-                        self.ui.radiusValue.setText(FreeCAD.Units.Quantity(0,FreeCAD.Units.Angle).UserString)
-                        self.ui.hasFill.hide()
-                        self.ui.labelRadius.setText("Base angle")
-                        self.arctrack.setCenter(self.center)
-                        if self.ghost:
-                            self.ghost.center(self.center)
-                        self.step = 1
-                        msg(translate("draft", "Pick base angle:")+"\n")
-                        if self.planetrack:
-                            self.planetrack.set(self.point)
-                    elif (self.step == 1):
-                        self.ui.labelRadius.setText("Rotation")
-                        self.rad = DraftVecUtils.dist(self.point,self.center)
-                        self.arctrack.on()
-                        self.arctrack.setStartPoint(self.point)
-                        if self.ghost:
-                            self.ghost.on()
-                        self.step = 2
-                        msg(translate("draft", "Pick rotation angle:")+"\n")
-                    else:
-                        currentrad = DraftVecUtils.dist(self.point,self.center)
-                        angle = self.point.sub(self.center).getAngle(plane.u)
-                        if DraftVecUtils.project(self.point.sub(self.center), plane.v).getAngle(plane.v) > 1:
-                            angle = -angle
-                        if (angle < self.firstangle):
-                            sweep = (2*math.pi-self.firstangle)+angle
-                        else:
-                            sweep = angle - self.firstangle
-                        if self.ui.isCopy.isChecked() or hasMod(arg,MODALT):
-                            self.rot(sweep,True)
-                        else:
-                            self.rot(sweep)
-                        if hasMod(arg,MODALT):
-                            self.extendedCopy = True
-                        else:
-                            self.finish(cont=True)
+    def build_copy_subelements_command(self):
+        pass
+
+    def build_rotate_subelements_command(self):
+        import Part
+        command = []
+        for object in self.selected_subelements:
+            for index, subelement in enumerate(object.SubObjects):
+                if isinstance(subelement, Part.Vertex):
+                    command.append('Draft.rotateVertex(FreeCAD.ActiveDocument.{}, {}, {}, {}, {})'.format(
+                        object.ObjectName,
+                        int(object.SubElementNames[index][len("Vertex"):])-1,
+                        math.degrees(self.angle),
+                        DraftVecUtils.toString(self.center),
+                        DraftVecUtils.toString(plane.axis)))
+        command.append('FreeCAD.ActiveDocument.recompute()')
+        return command
+
+    def rotate_object(self, is_copy):
+        objects = '[' + ','.join(['FreeCAD.ActiveDocument.' + object.Name for object in self.selected_objects]) + ']'
+        FreeCADGui.addModule("Draft")
+        self.commit(translate("draft","Copy" if is_copy else "Rotate"),
+            ['Draft.rotate({},{},{},axis={},copy={})'.format(
+                objects,
+                math.degrees(self.angle),
+                DraftVecUtils.toString(self.center),
+                DraftVecUtils.toString(plane.axis),
+                is_copy
+            )])
 
     def numericInput(self,numx,numy,numz):
         "this function gets called by the toolbar when valid x, y, and z have been entered there"
@@ -2744,7 +2806,7 @@ class Rotate(Modifier):
             self.step = 2
             msg(translate("draft", "Pick rotation angle:")+"\n")
         else:
-            self.rot(math.radians(rad),self.ui.isCopy.isChecked())
+            self.rotate(math.radians(rad),self.ui.isCopy.isChecked())
             self.finish(cont=True)
 
 

--- a/src/Mod/Draft/DraftTools.py
+++ b/src/Mod/Draft/DraftTools.py
@@ -4124,12 +4124,14 @@ class EditImproved(Modifier):
 
     def restore_editable_objects_graphics(self):
         for object in self.editable_objects:
-            if not object.Name:
-                continue
-            for attribute, value in self.original_view_settings[object.Name].items():
-                view_object = object.ViewObject
-                setattr(view_object, attribute, value)
-                view_object.RootNode.removeChild(view_object.RootNode.getByName("xray"))
+            try:
+                for attribute, value in self.original_view_settings[object.Name].items():
+                    view_object = object.ViewObject
+                    setattr(view_object, attribute, value)
+                    view_object.RootNode.removeChild(view_object.RootNode.getByName("xray"))
+            except:
+                # This can occur if objects have had graph changing operations
+                pass
 
 class Edit(Modifier):
     "The Draft_Edit FreeCAD command definition"

--- a/src/Mod/Draft/DraftTrackers.py
+++ b/src/Mod/Draft/DraftTrackers.py
@@ -569,7 +569,23 @@ class ghostTracker(Tracker):
         if not isinstance(sel,list):
             sel = [sel]
         for obj in sel:
-            rootsep.addChild(self.getNode(obj))
+            import Part
+            if not isinstance(obj, Part.Vertex):
+                rootsep.addChild(self.getNode(obj))
+            else:
+                self.coords = coin.SoCoordinate3()
+                self.coords.point.setValue((obj.X,obj.Y,obj.Z))
+                color = coin.SoBaseColor()
+                color.rgb = FreeCADGui.draftToolBar.getDefaultColor("snap")
+                self.marker = coin.SoMarkerSet() # this is the marker symbol
+                self.marker.markerIndex = FreeCADGui.getMarkerIndex("quad", 9)
+                node = coin.SoAnnotation()
+                selnode = coin.SoSeparator()
+                selnode.addChild(self.coords)
+                selnode.addChild(color)
+                selnode.addChild(self.marker)
+                node.addChild(selnode)
+                rootsep.addChild(node)
         self.children.append(rootsep)        
         Tracker.__init__(self,dotted,scolor,swidth,children=self.children,name="ghostTracker")
 
@@ -651,7 +667,6 @@ class ghostTracker(Tracker):
                           matrix.A31,matrix.A32,matrix.A33,matrix.A34,
                           matrix.A41,matrix.A42,matrix.A43,matrix.A44)
         self.trans.setMatrix(m)
-
 
 class editTracker(Tracker):
     "A node edit tracker"

--- a/src/Mod/Draft/InitGui.py
+++ b/src/Mod/Draft/InitGui.py
@@ -74,7 +74,7 @@ class DraftWorkbench (Workbench):
                         "Draft_ShapeString","Draft_Facebinder","Draft_BezCurve","Draft_Label"]
         self.modList = ["Draft_Move","Draft_Rotate","Draft_Offset",
                         "Draft_Trimex", "Draft_Join", "Draft_Split", "Draft_Upgrade", "Draft_Downgrade", "Draft_Scale",
-                        "Draft_Edit","Draft_WireToBSpline","Draft_AddPoint",
+                        "Draft_Edit","Draft_Edit_Improved","Draft_WireToBSpline","Draft_AddPoint",
                         "Draft_DelPoint","Draft_Shape2DView","Draft_Draft2Sketch","Draft_Array",
                         "Draft_PathArray", "Draft_PointArray","Draft_Clone",
                         "Draft_Drawing","Draft_Mirror","Draft_Stretch"]


### PR DESCRIPTION


This is the in-progress PR of creating a new, refactored, edit tool that:

 1. Allows editing of one or more objects at once
 2. Allows you to use all modifiers on individual vertices or edges to modify an existing wire

When complete I am hoping for the current draft edit tool to be deprecated.

Discussion thread: https://forum.freecadweb.org/viewtopic.php?f=23&t=34114

 * It allows you to select multiple objects to edit instead of just one.
 * It highlights the object lines and the points in red.
 * It stays in the mode and allows you to run other modifiers.
 * A very hackish hook into the move modifier is added as a proof of concept.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
