### PR TITLE
Fix PDF orientation for ANSI B Landscape

### DIFF
--- a/src/Mod/TechDraw/Gui/MDIViewPage.cpp
+++ b/src/Mod/TechDraw/Gui/MDIViewPage.cpp
@@ -571,7 +571,12 @@ void MDIViewPage::printPdf(std::string file)
     printer.setFullPage(true);
     printer.setOutputFormat(QPrinter::PdfFormat);
     printer.setOutputFileName(filename);
-    printer.setOrientation(m_orientation);
+//    printer.setOrientation(m_orientation);
+    if (m_paperSize == QPrinter::Ledger)  {
+        printer.setOrientation((QPrinter::Orientation) (1 - m_orientation));  //reverse 0/1
+    } else {
+        printer.setOrientation(m_orientation);
+    }
     printer.setPaperSize(m_paperSize);
     print(&printer);
 }
@@ -728,8 +733,8 @@ QPrinter::PaperSize MDIViewPage::getPaperSize(int w, int h) const
         {105, 241}, // US Common
         {110, 220}, // DLE
         {210, 330}, // Folio
-        {431.8f, 279.4f}, // Ledger
-        {279.4f, 431.8f} // Tabloid
+        {431.8f, 279.4f}, // Ledger (28)   note, two names for same size paper (ANSI B)
+        {279.4f, 431.8f} // Tabloid (29)   causes trouble with orientation on PDF export
     };
 
     QPrinter::PaperSize ps = QPrinter::Custom;
@@ -739,13 +744,19 @@ QPrinter::PaperSize MDIViewPage::getPaperSize(int w, int h) const
             ps = static_cast<QPrinter::PaperSize>(i);
             break;
         }
-        else
+        else                                          //handle landscape & portrait w/h
         if (std::abs(paperSizes[i][0]-h) <= 1 &&
             std::abs(paperSizes[i][1]-w) <= 1) {
             ps = static_cast<QPrinter::PaperSize>(i);
             break;
         }
     }
+    if (ps == QPrinter::Ledger)  {                    //check if really Tabloid
+        if (w < 431) {
+            ps = QPrinter::Tabloid;
+        }
+    }
+
     return ps;
 }
 

--- a/src/Mod/TechDraw/Templates/ANSIB_Portrait.svg
+++ b/src/Mod/TechDraw/Templates/ANSIB_Portrait.svg
@@ -1,0 +1,448 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:freecad="http://www.freecadweb.org/wiki/index.php?title=Svg_Namespace"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="279.39999mm"
+   height="431.79999mm"
+   viewBox="0 0 279.39999 431.79999"
+   version="1.1"
+   id="svg8"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)"
+   sodipodi:docname="ANSIB_Portrait_layer1.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="0.62990198"
+     inkscape:cx="834.28265"
+     inkscape:cy="1514.5214"
+     inkscape:document-units="mm"
+     inkscape:current-layer="svg8"
+     showgrid="false"
+     inkscape:window-width="1358"
+     inkscape:window-height="703"
+     inkscape:window-x="0"
+     inkscape:window-y="26"
+     inkscape:window-maximized="1"
+     inkscape:snap-global="false" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <rect
+       style="opacity:0.6;vector-effect:none;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.67692828;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect1366"
+       width="254.72307"
+       height="407.12308"
+       x="12.338463"
+       y="12.338455" />
+    <rect
+       y="18.574959"
+       x="18.574974"
+       height="394.65009"
+       width="242.25006"
+       id="rect898"
+       style="opacity:0.6;vector-effect:none;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.64995557;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+    <rect
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:0.99607843;fill-rule:nonzero;stroke:#000000;stroke-width:0.79825026;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       id="rect2985"
+       width="146.65559"
+       height="48.074078"
+       x="113.98052"
+       y="365.37579" />
+    <rect
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:0.99607843;fill-rule:nonzero;stroke:#000000;stroke-width:0.6584819;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       id="rect3757"
+       width="99.500763"
+       height="48.216183"
+       x="161.20407"
+       y="365.30472" />
+    <rect
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:0.99607843;fill-rule:nonzero;stroke:#000000;stroke-width:0.64497554;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       id="rect3767"
+       width="99.514038"
+       height="11.517738"
+       x="161.19748"
+       y="365.29785" />
+    <rect
+       y="398.84869"
+       x="161.19926"
+       height="14.677185"
+       width="99.510429"
+       id="rect3868"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:0.99607843;fill-rule:nonzero;stroke:#000000;stroke-width:0.64865702;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+    <rect
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:0.99607843;fill-rule:nonzero;stroke:#000000;stroke-width:0.61844289;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       id="rect3765"
+       width="90.267151"
+       height="14.707904"
+       x="170.4574"
+       y="398.83337" />
+    <rect
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:0.99607843;fill-rule:nonzero;stroke:#000000;stroke-width:0.52405274;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       id="rect3870"
+       width="64.395569"
+       height="14.803872"
+       x="196.37543"
+       y="398.78534" />
+    <rect
+       y="398.84363"
+       x="252.39435"
+       height="14.687314"
+       width="8.3202477"
+       id="rect3872"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:0.99607843;fill-rule:nonzero;stroke:#000000;stroke-width:0.63869441;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+    <rect
+       y="408.09113"
+       x="161.19202"
+       height="5.4422503"
+       width="99.524933"
+       id="rect3864"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:0.99607843;fill-rule:nonzero;stroke:#000000;stroke-width:0.63390392;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+    <rect
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:0.99607843;fill-rule:nonzero;stroke:#000000;stroke-width:0.55786246;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       id="rect3763"
+       width="75.999939"
+       height="5.5195618"
+       x="184.75443"
+       y="408.05255" />
+    <rect
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:0.99607843;fill-rule:nonzero;stroke:#000000;stroke-width:0.41417363;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       id="rect3866"
+       width="40.811127"
+       height="5.6656513"
+       x="220.01389"
+       y="407.97943" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.66519201;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 161.03081,382.85627 H 114.02765"
+       id="path5183"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.26607683;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 146.70735,382.99999 v 9.05611"
+       id="path5185"
+       inkscape:connector-curvature="0" />
+    <rect
+       y="392.20856"
+       x="114.31078"
+       height="5.4509139"
+       width="46.6772"
+       id="rect5966"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:0.99607843;fill-rule:nonzero;stroke:#000000;stroke-width:0.62538338;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+    <rect
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:0.99607843;fill-rule:nonzero;stroke:#000000;stroke-width:0.62538338;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       id="rect6005"
+       width="46.6772"
+       height="5.4509139"
+       x="114.31078"
+       y="397.42633" />
+    <rect
+       y="402.64404"
+       x="114.31078"
+       height="5.4509139"
+       width="46.6772"
+       id="rect6007"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:0.99607843;fill-rule:nonzero;stroke:#000000;stroke-width:0.62538338;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+    <rect
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:0.99607843;fill-rule:nonzero;stroke:#000000;stroke-width:0.62538338;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       id="rect6009"
+       width="46.6772"
+       height="5.4509139"
+       x="114.31078"
+       y="407.86182" />
+    <line
+       style="stroke:#404040;stroke-width:0.05776427;stroke-dasharray:2.02174926, 0.28882132, 0.28882132, 0.28882132;stroke-dashoffset:17.5"
+       id="line5117"
+       y2="387.49994"
+       x2="159.15182"
+       y1="387.49994"
+       x1="148.31696" />
+    <line
+       style="stroke:#404040;stroke-width:0.05776427;stroke-dasharray:2.02174926, 0.28882132, 0.28882132, 0.28882132;stroke-dashoffset:17.5"
+       id="line5119"
+       y2="390.57953"
+       x2="156.44312"
+       y1="384.42032"
+       x1="156.44312" />
+    <polygon
+       style="fill:none;stroke:#000000;stroke-width:2"
+       id="polygon5123"
+       points="90,70 10,90 10,10 90,30 "
+       transform="matrix(0.05417425,0,0,0.06159218,148.34027,384.65875)" />
+    <ellipse
+       ry="1.2318436"
+       rx="1.083485"
+       style="fill:none;stroke:#000000;stroke-width:0.11552852"
+       id="circle5125"
+       cy="387.73834"
+       cx="156.46642" />
+    <ellipse
+       ry="2.4636872"
+       rx="2.16697"
+       style="fill:none;stroke:#000000;stroke-width:0.11552852"
+       id="circle5127"
+       cy="387.73834"
+       cx="156.46642" />
+    <text
+       id="text3332"
+       y="391.29807"
+       x="116.95573"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.11443925px;line-height:0%;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1"
+       xml:space="preserve"
+       transform="scale(0.98782896,1.012321)"><tspan
+         style="stroke-width:1"
+         y="391.29807"
+         x="116.95573"
+         id="tspan3334">Drawn:</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.11443925px;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1"
+       x="116.95573"
+       y="396.19965"
+       id="text3348"
+       transform="scale(0.98782896,1.012321)"><tspan
+         id="tspan3350"
+         x="116.95573"
+         y="396.19965"
+         style="font-family:sans-serif;stroke-width:1">Checked:</tspan></text>
+    <text
+       id="text3364"
+       y="401.1492"
+       x="116.95573"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.11443925px;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1"
+       xml:space="preserve"
+       transform="scale(0.98782896,1.012321)"><tspan
+         y="401.1492"
+         x="116.95573"
+         id="tspan3366"
+         style="font-family:sans-serif;stroke-width:1">Approved:</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.11443925px;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1"
+       x="116.95573"
+       y="406.44733"
+       id="text3380"
+       transform="scale(0.98782896,1.012321)"><tspan
+         id="tspan3382"
+         x="116.95573"
+         y="406.44733"
+         style="font-family:sans-serif;stroke-width:1">Approved:</tspan></text>
+    <text
+       freecad:editable="CompanyName"
+       id="BlockACompany"
+       y="370.31152"
+       x="164.71768"
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.24420738px;line-height:0%;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:start;writing-mode:lr-tb;text-anchor:start;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke-width:1;marker:none;enable-background:accumulate"
+       xml:space="preserve"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.24420738px;font-family:sans-serif;-inkscape-font-specification:sans-serif;stroke-width:1"
+         y="370.31152"
+         x="164.71768"
+         id="tspan6595">Company Name</tspan></text>
+    <text
+       freecad:editable="CompanyAddress"
+       id="BlockAAddress"
+       y="375.33215"
+       x="164.54343"
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.24420738px;line-height:0%;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:start;writing-mode:lr-tb;text-anchor:start;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke-width:1;marker:none;enable-background:accumulate"
+       xml:space="preserve"><tspan
+         style="stroke-width:1"
+         y="375.33215"
+         x="164.54343"
+         id="tspan6603">1234 Main St</tspan></text>
+    <text
+       freecad:editable="DrawingTitle1"
+       id="BlockB Title1"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:5.24250412px;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1"
+       xml:space="preserve"
+       y="382.61057"
+       x="165.23309"><tspan
+         style="font-family:sans-serif;stroke-width:1"
+         id="tspan4467">Drawing Title 1</tspan></text>
+    <text
+       freecad:editable="DrawingTitle2"
+       id="BlockBTitle2"
+       y="389.28107"
+       x="165.43893"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:sans;-inkscape-font-specification:sans;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1"
+       xml:space="preserve"><tspan
+         style="font-size:3.14550209px;line-height:1.25;stroke-width:1"
+         y="389.28107"
+         x="165.43893"
+         id="tspan3762-4"
+         sodipodi:role="line">Drawing Title 2</tspan></text>
+    <text
+       freecad:editable="DrawingTitle3"
+       id="BlockB Title3"
+       y="395.18433"
+       x="165.43893"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:sans;-inkscape-font-specification:sans;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1"
+       xml:space="preserve"><tspan
+         style="font-size:3.14550209px;line-height:1.25;stroke-width:1"
+         y="395.18433"
+         x="165.43893"
+         id="tspan3766-5"
+         sodipodi:role="line">Drawing Title 3</tspan></text>
+    <text
+       freecad:editable="DrawingNumber"
+       id="BlockC DrawingNumber"
+       y="405.91364"
+       x="199.7832"
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:0px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1px;marker:none;enable-background:accumulate"
+       xml:space="preserve"><tspan
+         style="font-size:4.19400311px;line-height:1.25;font-family:sans-serif;stroke-width:1px"
+         y="405.91364"
+         x="199.7832"
+         id="tspan3792-9"
+         sodipodi:role="line">Drawing Number</tspan></text>
+    <text
+       freecad:editable="Revision"
+       id="BlockD Revision"
+       y="405.54474"
+       x="253.53323"
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:0px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1px;marker:none;enable-background:accumulate"
+       xml:space="preserve"><tspan
+         style="font-size:3.14550209px;line-height:1.25;font-family:sans-serif;stroke-width:1px"
+         y="405.54474"
+         x="253.53323"
+         id="tspan3796-0"
+         sodipodi:role="line">Rev</tspan></text>
+    <text
+       freecad:editable="DrawnBy"
+       id="BlockE DrawnBy"
+       y="396.58838"
+       x="135.98755"
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:start;writing-mode:lr-tb;text-anchor:start;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:2;stroke-opacity:1;marker:none;enable-background:accumulate"
+       xml:space="preserve"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:2.94890809px;line-height:1.25;font-family:sans;-inkscape-font-specification:sans;stroke:none;stroke-width:1"
+         y="396.58838"
+         x="135.98755"
+         id="tspan6969"
+         sodipodi:role="line">Drawn By</tspan></text>
+    <text
+       freecad:editable="CheckedBy"
+       id="BlockE CheckedBy"
+       y="401.8028"
+       x="136.11139"
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:sans;-inkscape-font-specification:sans;text-align:start;writing-mode:lr-tb;text-anchor:start;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke-width:1;marker:none;enable-background:accumulate"
+       xml:space="preserve"><tspan
+         style="font-size:2.94890809px;line-height:1.25;stroke-width:1"
+         y="401.8028"
+         x="136.11139"
+         id="tspan6973"
+         sodipodi:role="line">Checked By</tspan></text>
+    <text
+       freecad:editable="Approved1"
+       id="BlockE Approved1"
+       y="406.97186"
+       x="136.25394"
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:sans;-inkscape-font-specification:sans;text-align:start;writing-mode:lr-tb;text-anchor:start;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke-width:1;marker:none;enable-background:accumulate"
+       xml:space="preserve"><tspan
+         style="font-size:2.94890809px;line-height:1.25;stroke-width:1"
+         y="406.97186"
+         x="136.25394"
+         id="tspan6977"
+         sodipodi:role="line">Approved 1</tspan></text>
+    <text
+       freecad:editable="Approved2"
+       id="BlockE Approved2"
+       y="412.14093"
+       x="136.25394"
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:sans;-inkscape-font-specification:sans;text-align:start;writing-mode:lr-tb;text-anchor:start;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke-width:1;marker:none;enable-background:accumulate"
+       xml:space="preserve"><tspan
+         style="font-size:2.94890809px;line-height:1.25;stroke-width:1"
+         y="412.14093"
+         x="136.25394"
+         id="tspan6981"
+         sodipodi:role="line">Approved 2</tspan></text>
+    <text
+       freecad:editable="Scale"
+       id="BlockH Scale"
+       y="412.65485"
+       x="165.41287"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1"
+       xml:space="preserve"><tspan
+         style="font-size:3.14550209px;line-height:1.25;font-family:sans-serif;stroke-width:1"
+         y="412.65485"
+         x="165.41287"
+         id="tspan3770-2"
+         sodipodi:role="line">Scale</tspan></text>
+    <text
+       freecad:editable="Code"
+       id="BlockI Code"
+       y="405.79584"
+       x="173.50632"
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:0px;word-spacing:0px;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1px;marker:none;enable-background:accumulate"
+       xml:space="preserve"><tspan
+         style="font-size:4.19400311px;line-height:1.25;font-family:sans-serif;stroke-width:1px"
+         y="405.79584"
+         x="173.50632"
+         id="tspan3788-7"
+         sodipodi:role="line">Code</tspan></text>
+    <text
+       id="BlockJ Size"
+       y="405.62616"
+       x="163.83875"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:12px;line-height:0%;font-family:sans-serif;-inkscape-font-specification:'Sans Bold';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1"
+       xml:space="preserve"><tspan
+         style="font-size:5.32153606px;line-height:1.25;font-family:sans-serif;stroke-width:1"
+         y="405.62616"
+         x="163.83875"
+         id="tspan3784"
+         sodipodi:role="line">B</tspan></text>
+    <text
+       freecad:editable="Weight"
+       id="BlockK Weight"
+       y="412.6095"
+       x="191.14706"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1"
+       xml:space="preserve"><tspan
+         style="font-size:3.14550209px;line-height:1.25;font-family:sans-serif;stroke-width:1"
+         y="412.6095"
+         x="191.14706"
+         id="tspan3774-9"
+         sodipodi:role="line">Weight</tspan><tspan
+         style="font-size:3.14550209px;line-height:1.25;font-family:sans-serif;stroke-width:1"
+         id="tspan3776-8"
+         y="416.87555"
+         x="191.14706"
+         sodipodi:role="line"> </tspan></text>
+    <text
+       freecad:editable="Sheet"
+       id="BlockL Sheet"
+       y="411.65485"
+       x="226.52933"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:sans-serif;-inkscape-font-specification:Sans;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1"
+       xml:space="preserve"><tspan
+         style="font-size:3.14550209px;line-height:1.25;font-family:sans-serif;stroke-width:1"
+         y="411.65485"
+         x="226.52933"
+         id="tspan3780-0"
+         sodipodi:role="line">Sheet n of m</tspan></text>
+  </g>
+</svg>


### PR DESCRIPTION
This PR corrects a formatting error in PDF exports.  Please merge.
Thanks,
wf

- PDF exports in landscape orientation on ANSI B (Ledger) paper
  were formatted as landscape, but on portrait paper orientation.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
