### PR TITLE
Fix cut an object with a plane feature translation in Arch module

### DIFF
--- a/src/Mod/Arch/ArchCutPlane.py
+++ b/src/Mod/Arch/ArchCutPlane.py
@@ -51,14 +51,14 @@ def cutComponentwithPlane(archObject, cutPlane, sideFace):
     else:
         cutVolume = cutVolume[1]
     if cutVolume:
-        obj = FreeCAD.ActiveDocument.addObject("Part::Feature", str(translate("Arch","CutVolume")))
+        obj = FreeCAD.ActiveDocument.addObject("Part::Feature","CutVolume")
         obj.Shape = cutVolume
         obj.ViewObject.ShapeColor = (1.00,0.00,0.00)
         obj.ViewObject.Transparency = 75
         if "Additions" in archObject.Object.PropertiesList:
             return ArchCommands.removeComponents(obj,archObject.Object)
         else:
-            cutObj = FreeCAD.ActiveDocument.addObject("Part::Cut", str(translate("Arch","CutPlane")))
+            cutObj = FreeCAD.ActiveDocument.addObject("Part::Cut","CutPlane")
             cutObj.Base = archObject.Object
             cutObj.Tool = obj
             return cutObj
@@ -98,7 +98,7 @@ class _CutPlaneTaskPanel:
         self.combobox.setCurrentIndex(0)
         self.grid.addWidget(self.combobox, 2, 1)
         QtCore.QObject.connect(self.combobox,QtCore.SIGNAL("currentIndexChanged(int)"),self.previewCutVolume)
-        self.previewObj = FreeCAD.ActiveDocument.addObject("Part::Feature", str(translate("Arch", "PreviewCutVolume")))
+        self.previewObj = FreeCAD.ActiveDocument.addObject("Part::Feature","PreviewCutVolume")
         self.retranslateUi(self.form)
         self.previewCutVolume(self.combobox.currentIndex())
 
@@ -111,7 +111,7 @@ class _CutPlaneTaskPanel:
         s = FreeCADGui.Selection.getSelectionEx()
         if len(s) > 1:
             if s[1].SubObjects:
-                FreeCAD.ActiveDocument.openTransaction(str(translate("Arch","Cutting")))
+                FreeCAD.ActiveDocument.openTransaction(translate("Arch","Cutting"))
                 FreeCADGui.addModule("Arch")
                 FreeCADGui.doCommand("Arch.cutComponentwithPlane(FreeCADGui.Selection.getSelectionEx()[0],FreeCADGui.Selection.getSelectionEx()[1].SubObjects[0],"+ str(val) +")")
                 FreeCAD.ActiveDocument.commitTransaction()


### PR DESCRIPTION
Fix not working translation for "cut an object with a plane" feature in arch module.
Without this fix cut an object with a plane does not work in languages different to English.
Similar bugs was fixed earlier, but this was harder to find because of initially grayed out feature.
Moreover this bug comparing to previous encoding bug (issue #3827), that was fixed with commit 21dc8c5, was not found by test framework. It was found manually. Maybe we shouls add additional test.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

* [x]  Branch rebased on latest master `git pull --rebase upstream master`
* [x]  Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
* [x]  Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
* [ ]  Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.