### PR TITLE
Change hotkey of of cycle snap from tab to ` to prevent clashes

### DIFF
--- a/src/Mod/Draft/DraftGui.py
+++ b/src/Mod/Draft/DraftGui.py
@@ -123,7 +123,7 @@ inCommandShortcuts = {
     "Length":     ["H",translate("draft","Length mode"),          "lengthValue"],
     "Wipe":       ["W",translate("draft","Wipe"),                 "wipeButton"],
     "SetWP":      ["U",translate("draft","Set Working Plane"), "orientWPButton"],
-    "CycleSnap":  [QtCore.Qt.Key_Tab,translate("draft","Cycle snap object"), None]
+    "CycleSnap":  ["`",translate("draft","Cycle snap object"), None]
 }
 
 
@@ -275,7 +275,7 @@ class DraftBaseWidget(QtGui.QWidget):
     def __init__(self,parent = None):
         QtGui.QWidget.__init__(self,parent)
     def eventFilter(self, widget, event):
-        if event.type() == QtCore.QEvent.KeyPress and event.key()==inCommandShortcuts["CycleSnap"][0]:
+        if event.type() == QtCore.QEvent.KeyPress and event.text().upper()==inCommandShortcuts["CycleSnap"][0]:
             if hasattr(FreeCADGui,"Snapper"):
                 FreeCADGui.Snapper.cycleSnapObject()
             return True


### PR DESCRIPTION
Change hotkey of of cycle snap from tab to ` to prevent clashes with current tab behaviour due to complaints here:

https://forum.freecadweb.org/viewtopic.php?f=10&t=30340&start=510

I will start another thread to discuss a more long-term solution :) For now, changing the shortcut key should keep users happy I think.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
