### PR TITLE
TechDraw Response Time v2

### DIFF
--- a/src/Mod/TechDraw/App/DrawProjGroup.cpp
+++ b/src/Mod/TechDraw/App/DrawProjGroup.cpp
@@ -144,7 +144,7 @@ void DrawProjGroup::onChanged(const App::Property* prop)
 
 App::DocumentObjectExecReturn *DrawProjGroup::execute(void)
 {
-//    Base::Console().Message("DPG::execute()\n");
+//    Base::Console().Message("DPG::execute() - %s\n", getNameInDocument());
     if (!keepUpdated()) {
         return App::DocumentObject::StdReturn;
     }
@@ -421,7 +421,7 @@ App::DocumentObject * DrawProjGroup::addProjection(const char *viewProjType)
             view->LockPosition.setStatus(App::Property::ReadOnly,true); //Front should stay locked.
             App::GetApplication().signalChangePropertyEditor(view->LockPosition);
             view->LockPosition.purgeTouched();
-//            requestPaint();
+            requestPaint();   //make sure the group object is on the Gui page
         }
 //        addView(view);                            //from DrawViewCollection
 //        if (view != getAnchor()) {                //anchor is done elsewhere
@@ -871,8 +871,6 @@ void DrawProjGroup::updateChildrenLock(void)
             Base::Console().Log("PROBLEM - DPG::updateChildrenLock - non DPGI entry in Views! %s\n",
                                     getNameInDocument());
             throw Base::TypeError("Error: projection in DPG list is not a DPGI!");
-        } else {
-            view->requestPaint();
         }
     }
 }

--- a/src/Mod/TechDraw/App/DrawProjGroup.cpp
+++ b/src/Mod/TechDraw/App/DrawProjGroup.cpp
@@ -202,6 +202,12 @@ Base::BoundBox3d DrawProjGroup::getBoundingBox() const
 
     std::vector<App::DocumentObject*> views = Views.getValues();
     TechDraw::DrawProjGroupItem *anchorView = dynamic_cast<TechDraw::DrawProjGroupItem *>(Anchor.getValue());
+    if (anchorView == nullptr) {
+        //if an element in Views is not a DPGI, something really bad has happened somewhere
+        Base::Console().Log("PROBLEM - DPG::getBoundingBox - non DPGI entry in Views! %s\n",
+                                getNameInDocument());
+        throw Base::TypeError("Error: projection in DPG list is not a DPGI!");
+    }
     for (std::vector<App::DocumentObject*>::const_iterator it = views.begin(); it != views.end(); ++it) {
          if ((*it)->getTypeId().isDerivedFrom(DrawViewPart::getClassTypeId())) {
             DrawViewPart *part = static_cast<DrawViewPart *>(*it);
@@ -314,8 +320,12 @@ App::DocumentObject * DrawProjGroup::getProjObj(const char *viewProjType) const
 {
     for( auto it : Views.getValues() ) {
         auto projPtr( dynamic_cast<DrawProjGroupItem *>(it) );
-        if( projPtr &&
-            strcmp(viewProjType, projPtr->Type.getValueAsString()) == 0 ) {
+        if (projPtr == nullptr) {
+            //if an element in Views is not a DPGI, something really bad has happened somewhere
+            Base::Console().Log("PROBLEM - DPG::getProjObj - non DPGI entry in Views! %s / %s\n",
+                                    getNameInDocument(),viewProjType);
+            throw Base::TypeError("Error: projection in DPG list is not a DPGI!");
+        } else if(strcmp(viewProjType, projPtr->Type.getValueAsString()) == 0 ) {
             return it;
         }
     }
@@ -326,7 +336,14 @@ App::DocumentObject * DrawProjGroup::getProjObj(const char *viewProjType) const
 DrawProjGroupItem* DrawProjGroup::getProjItem(const char *viewProjType) const
 {
     App::DocumentObject* docObj = getProjObj(viewProjType);
-    DrawProjGroupItem* result = static_cast<DrawProjGroupItem*>(docObj);
+    auto result( dynamic_cast<TechDraw::DrawProjGroupItem *>(docObj) );
+    if ( (result == nullptr) &&
+         (docObj != nullptr) ) {
+        //should never have a item in DPG that is not a DPGI. 
+        Base::Console().Log("PROBLEM - DPG::getProjItem finds non-DPGI in Group %s / %s\n",
+                                getNameInDocument(),viewProjType);
+        throw Base::TypeError("Error: projection in DPG list is not a DPGI!");
+    }
     return result;
 }
 
@@ -354,7 +371,14 @@ bool DrawProjGroup::hasProjection(const char *viewProjType) const
 {
     for( const auto it : Views.getValues() ) {
         auto view( dynamic_cast<TechDraw::DrawProjGroupItem *>(it) );
-        if( view && strcmp(viewProjType, view->Type.getValueAsString()) == 0 ) {
+        if (view == nullptr) {
+            //should never have a item in DPG that is not a DPGI. 
+            Base::Console().Log("PROBLEM - DPG::hasProjection finds non-DPGI in Group %s / %s\n",
+                                    getNameInDocument(),viewProjType);
+            throw Base::TypeError("Error: projection in DPG list is not a DPGI!");
+        }
+
+        if (strcmp(viewProjType, view->Type.getValueAsString()) == 0 ) {
             return true;
         }
     }
@@ -366,11 +390,19 @@ App::DocumentObject * DrawProjGroup::addProjection(const char *viewProjType)
     DrawProjGroupItem *view( nullptr );
     std::pair<Base::Vector3d,Base::Vector3d> vecs;
 
+
     if ( checkViewProjType(viewProjType) && !hasProjection(viewProjType) ) {
         std::string FeatName = getDocument()->getUniqueObjectName("ProjItem");
         auto docObj( getDocument()->addObject( "TechDraw::DrawProjGroupItem",     //add to Document
                                                FeatName.c_str() ) );
-        view = static_cast<TechDraw::DrawProjGroupItem *>( docObj );
+        view = dynamic_cast<TechDraw::DrawProjGroupItem *>(docObj);
+        if ( (view == nullptr) &&
+             (docObj != nullptr) ) {
+            //should never happen that we create a DPGI that isn't a DPGI!! 
+            Base::Console().Log("PROBLEM - DPG::addProjection - created a non DPGI! %s / %s\n",
+                                    getNameInDocument(),viewProjType);
+            throw Base::TypeError("Error: new projection is not a DPGI!");
+        }
         addView(view);                            //from DrawViewCollection
         view->Source.setValues( Source.getValues() );
         view->Scale.setValue( getScale() );
@@ -412,12 +444,17 @@ int DrawProjGroup::removeProjection(const char *viewProjType)
         // Iterate through the child views and find the projection type
         for( auto it : Views.getValues() ) {
             auto projPtr( dynamic_cast<TechDraw::DrawProjGroupItem *>(it) );
-            if( projPtr ) {
+            if( projPtr != nullptr) {
                 if ( strcmp(viewProjType, projPtr->Type.getValueAsString()) == 0 ) {
-                    removeView(projPtr);                                        // Remove from collection
+                    removeView(projPtr);                                           // Remove from collection
                     getDocument()->removeObject( it->getNameInDocument() );        // Remove from the document
                     return Views.getValues().size();
                 }
+            } else {
+                //if an element in Views is not a DPGI, something really bad has happened somewhere
+                Base::Console().Log("PROBLEM - DPG::removeProjection - tries to remove non DPGI! %s / %s\n",
+                                    getNameInDocument(),viewProjType);
+                throw Base::TypeError("Error: projection in DPG list is not a DPGI!");
             }
         }
     }
@@ -433,9 +470,14 @@ int DrawProjGroup::purgeProjections()
         DrawProjGroupItem* dpgi;
         DocumentObject* dObj =  views.back();
         dpgi = dynamic_cast<DrawProjGroupItem*>(dObj);
-        if (dpgi) {
+        if (dpgi != nullptr) {
             std::string itemName = dpgi->Type.getValueAsString();
             removeProjection(itemName.c_str());
+        } else {
+            //if an element in Views is not a DPGI, something really bad has happened somewhere
+            Base::Console().Log("PROBLEM - DPG::purgeProjection - tries to remove non DPGI! %s\n",
+                                    getNameInDocument());
+            throw Base::TypeError("Error: projection in DPG list is not a DPGI!");
         }
     }
     auto page = findParentPage();
@@ -721,7 +763,12 @@ void DrawProjGroup::arrangeViewPointers(DrawProjGroupItem *viewPtrs[10]) const
         bool thirdAngle = (strcmp(projType, "Third Angle") == 0);
         for (auto it : Views.getValues()) {
             auto oView( dynamic_cast<DrawProjGroupItem *>(it) );
-            if (oView) {
+            if (oView == nullptr) {
+                //if an element in Views is not a DPGI, something really bad has happened somewhere
+                Base::Console().Log("PROBLEM - DPG::arrangeViewPointers - non DPGI in Views! %s\n",
+                                    getNameInDocument());
+                throw Base::TypeError("Error: projection in DPG list is not a DPGI!");
+            } else {
                 const char *viewTypeCStr = oView->Type.getValueAsString();
                 if (strcmp(viewTypeCStr, "Front") == 0) {
                   //viewPtrs[thirdAngle ? 4 : 4] = oView;
@@ -782,7 +829,12 @@ void DrawProjGroup::updateChildren(void)
 {
     for( const auto it : Views.getValues() ) {
         auto view( dynamic_cast<DrawProjGroupItem *>(it) );
-        if( view ) {
+        if (view == nullptr) {
+            //if an element in Views is not a DPGI, something really bad has happened somewhere
+            Base::Console().Log("PROBLEM - DPG::updateChildren - non DPGI entry in Views! %s\n",
+                                    getNameInDocument());
+            throw Base::TypeError("Error: projection in DPG list is not a DPGI!");
+        } else {
             view->Scale.setValue(Scale.getValue());
         }
     }
@@ -795,7 +847,12 @@ void DrawProjGroup::updateChildrenSource(void)
 {
     for( const auto it : Views.getValues() ) {
         auto view( dynamic_cast<DrawProjGroupItem *>(it) );
-        if( view ) {
+        if (view == nullptr) {
+            //if an element in Views is not a DPGI, something really bad has happened somewhere
+            Base::Console().Log("PROBLEM - DPG::updateChildrenSource - non DPGI entry in Views! %s\n",
+                                    getNameInDocument());
+            throw Base::TypeError("Error: projection in DPG list is not a DPGI!");
+        } else {
             view->Source.setValues(Source.getValues());
         }
     }
@@ -809,8 +866,12 @@ void DrawProjGroup::updateChildrenLock(void)
 {
     for( const auto it : Views.getValues() ) {
         auto view( dynamic_cast<DrawProjGroupItem *>(it) );
-        if( view ) {
-            Base::Console().Message("DPG::updateChildrenLock requests paint for %s\n",view->getNameInDocument());
+        if (view == nullptr) {
+            //if an element in Views is not a DPGI, something really bad has happened somewhere
+            Base::Console().Log("PROBLEM - DPG::updateChildrenLock - non DPGI entry in Views! %s\n",
+                                    getNameInDocument());
+            throw Base::TypeError("Error: projection in DPG list is not a DPGI!");
+        } else {
             view->requestPaint();
         }
     }

--- a/src/Mod/TechDraw/App/DrawProjGroup.cpp
+++ b/src/Mod/TechDraw/App/DrawProjGroup.cpp
@@ -144,7 +144,7 @@ void DrawProjGroup::onChanged(const App::Property* prop)
 
 App::DocumentObjectExecReturn *DrawProjGroup::execute(void)
 {
-    Base::Console().Message("DPG::execute()\n");
+//    Base::Console().Message("DPG::execute()\n");
     if (!keepUpdated()) {
         return App::DocumentObject::StdReturn;
     }
@@ -162,13 +162,13 @@ App::DocumentObjectExecReturn *DrawProjGroup::execute(void)
 
     App::DocumentObject* docObj = Anchor.getValue();
     if (docObj == nullptr) {
-        //no anchor yet.  Should we create 1 here? 
+        //no anchor yet.  nothing to do.
         return DrawViewCollection::execute();
     }
     
-    for (auto& v: Views.getValues()) {
-        v->recomputeFeature();
-    }
+//    for (auto& v: Views.getValues()) {          //is this needed here? Up to DPGI to keep up to date. 
+//        v->recomputeFeature();
+//    }
 
     for (auto& item: getViewsAsDPGI()) {
         item->autoPosition();
@@ -366,7 +366,6 @@ App::DocumentObject * DrawProjGroup::addProjection(const char *viewProjType)
     DrawProjGroupItem *view( nullptr );
     std::pair<Base::Vector3d,Base::Vector3d> vecs;
 
-
     if ( checkViewProjType(viewProjType) && !hasProjection(viewProjType) ) {
         std::string FeatName = getDocument()->getUniqueObjectName("ProjItem");
         auto docObj( getDocument()->addObject( "TechDraw::DrawProjGroupItem",     //add to Document
@@ -384,7 +383,6 @@ App::DocumentObject * DrawProjGroup::addProjection(const char *viewProjType)
             view->RotationVector.setValue(vecs.second);
             view->recomputeFeature();
         } else {  //Front
-            //where do direction & Rotation Vector get set for front???  from cmd::newDPG
             Anchor.setValue(view);
             Anchor.purgeTouched();
             view->LockPosition.setValue(true);  //lock "Front" position within DPG (note not Page!).
@@ -462,6 +460,10 @@ std::pair<Base::Vector3d,Base::Vector3d> DrawProjGroup::getDirsFromFront(std::st
 
     Base::Vector3d projDir, rotVec;
     DrawProjGroupItem* anch = getAnchor();
+    if (anch == nullptr) {
+        Base::Console().Warning("DPG::getDirsFromFront - %s - No Anchor!\n",Label.getValue());
+        throw Base::RuntimeError("Project Group missing Anchor projection item");
+    }
      
     Base::Vector3d dirAnch = anch->Direction.getValue();
     Base::Vector3d rotAnch = anch->RotationVector.getValue();

--- a/src/Mod/TechDraw/App/DrawProjGroupItem.cpp
+++ b/src/Mod/TechDraw/App/DrawProjGroupItem.cpp
@@ -124,7 +124,6 @@ App::DocumentObjectExecReturn *DrawProjGroupItem::execute(void)
         return ret;
     } else {
         autoPosition();
-        requestPaint();
         delete ret;
     }
     return App::DocumentObject::StdReturn;
@@ -141,11 +140,11 @@ void DrawProjGroupItem::autoPosition()
                 newPos = pgroup->getXYPosition(Type.getValueAsString());
                 X.setValue(newPos.x);
                 Y.setValue(newPos.y);
+                requestPaint();
+                purgeTouched();               //prevents "still touched after recompute" message
             }
         }
     }
-    requestPaint();
-    purgeTouched();               //prevents "still touched after recompute" message
 }
 
 void DrawProjGroupItem::onDocumentRestored()

--- a/src/Mod/TechDraw/App/DrawView.cpp
+++ b/src/Mod/TechDraw/App/DrawView.cpp
@@ -142,7 +142,6 @@ void DrawView::onChanged(const App::Property* prop)
         } else if (prop == &LockPosition) {
             handleXYLock();
             LockPosition.purgeTouched(); 
-            requestPaint();
         }
     }
     App::DocumentObject::onChanged(prop);
@@ -161,26 +160,22 @@ void DrawView::handleXYLock(void)
             X.setStatus(App::Property::ReadOnly,true);
             App::GetApplication().signalChangePropertyEditor(X);
             X.purgeTouched();
-            requestPaint();
         }
         if (!Y.testStatus(App::Property::ReadOnly)) {
             Y.setStatus(App::Property::ReadOnly,true);
             App::GetApplication().signalChangePropertyEditor(Y);
             Y.purgeTouched();
-            requestPaint();
         }
     } else {
         if (X.testStatus(App::Property::ReadOnly)) {
             X.setStatus(App::Property::ReadOnly,false);
             App::GetApplication().signalChangePropertyEditor(X);
             X.purgeTouched();
-            requestPaint();
         }
         if (Y.testStatus(App::Property::ReadOnly)) {
             Y.setStatus(App::Property::ReadOnly,false);
             App::GetApplication().signalChangePropertyEditor(Y);
             Y.purgeTouched();
-            requestPaint();
         }
     }
 }

--- a/src/Mod/TechDraw/App/DrawViewPart.cpp
+++ b/src/Mod/TechDraw/App/DrawViewPart.cpp
@@ -266,6 +266,7 @@ App::DocumentObjectExecReturn *DrawViewPart::execute(void)
     geometryObject =  buildGeometryObject(mirroredShape,viewAxis);
 
 #if MOD_TECHDRAW_HANDLE_FACES
+    auto start = chrono::high_resolution_clock::now();
     if (handleFaces() && !geometryObject->usePolygonHLR()) {
         try {
             extractFaces();
@@ -275,6 +276,12 @@ App::DocumentObjectExecReturn *DrawViewPart::execute(void)
             return new App::DocumentObjectExecReturn(e4.GetMessageString());
         }
     }
+    auto end   = chrono::high_resolution_clock::now();
+    auto diff  = end - start;
+    double diffOut = chrono::duration <double, milli> (diff).count();
+    Base::Console().Log("TIMING - %s DVP spent: %.3f millisecs handling Faces\n",
+                        getNameInDocument(),diffOut);
+
 #endif //#if MOD_TECHDRAW_HANDLE_FACES
 
     requestPaint();

--- a/src/Mod/TechDraw/App/DrawViewPart.cpp
+++ b/src/Mod/TechDraw/App/DrawViewPart.cpp
@@ -239,10 +239,18 @@ App::DocumentObjectExecReturn *DrawViewPart::execute(void)
     if (!keepUpdated()) {
         return App::DocumentObject::StdReturn;
     }
+    
+    const std::vector<App::DocumentObject*>& links = Source.getValues();
+    if (links.empty())  {
+        Base::Console().Log("DVP::execute - %s - No Sources - creation time?\n",getNameInDocument());
+        return App::DocumentObject::StdReturn;
+    }
 
-    TopoDS_Shape shape = getSourceShape();
+    TopoDS_Shape shape = getSourceShape();          //if shape is null, it is probably obj creation time.
     if (shape.IsNull()) {
-        return new App::DocumentObjectExecReturn("DVP - Linked shape object is invalid");
+        Base::Console().Log("DVP::execute - %s - source shape is invalid - creation time?\n",
+                            getNameInDocument());
+        return App::DocumentObject::StdReturn;
     }
 
     gp_Pnt inputCenter;

--- a/src/Mod/TechDraw/Gui/Command.cpp
+++ b/src/Mod/TechDraw/Gui/Command.cpp
@@ -316,17 +316,20 @@ void CmdTechDrawNewView::activated(int iMsg)
     if (subFound) {
         std::pair<Base::Vector3d,Base::Vector3d> dirs = DrawGuiUtil::getProjDirFromFace(partFeat,faceName);
         projDir = dirs.first;
+        getDocument()->setStatus(App::Document::Status::SkipRecompute, true);
         doCommand(Doc,"App.activeDocument().%s.Direction = FreeCAD.Vector(%.3f,%.3f,%.3f)",
                   FeatName.c_str(), projDir.x,projDir.y,projDir.z);
         doCommand(Doc,"App.activeDocument().%s.recompute()", FeatName.c_str());
+        getDocument()->setStatus(App::Document::Status::SkipRecompute, false);
    } else {
         std::pair<Base::Vector3d,Base::Vector3d> dirs = DrawGuiUtil::get3DDirAndRot();
         projDir = dirs.first;
+        getDocument()->setStatus(App::Document::Status::SkipRecompute, true);
         doCommand(Doc,"App.activeDocument().%s.Direction = FreeCAD.Vector(%.3f,%.3f,%.3f)",
                   FeatName.c_str(), projDir.x,projDir.y,projDir.z);
+        getDocument()->setStatus(App::Document::Status::SkipRecompute, false);
         doCommand(Doc,"App.activeDocument().%s.recompute()", FeatName.c_str());
     }
-    updateActive();
     commitCommand();
 }
 
@@ -390,7 +393,7 @@ void CmdTechDrawNewViewSection::activated(int iMsg)
     doCommand(Doc,"App.activeDocument().%s.Scale = %0.6f",FeatName.c_str(),baseScale);
     Gui::Control().showDialog(new TaskDlgSectionView(dvp,dsv));
 
-    updateActive();
+    updateActive();             //ok here since dialog doesn't call doc.recompute()
     commitCommand();
 }
 
@@ -457,7 +460,7 @@ void CmdTechDrawNewViewDetail::activated(int iMsg)
     doCommand(Doc,"App.activeDocument().%s.Direction = App.activeDocument().%s.Direction",FeatName.c_str(),dvp->getNameInDocument());
     doCommand(Doc,"App.activeDocument().%s.addView(App.activeDocument().%s)",PageName.c_str(),FeatName.c_str());
 
-    updateActive();
+    updateActive();            //ok here, no preceeding recompute
     commitCommand();
 }
 
@@ -545,10 +548,12 @@ void CmdTechDrawProjGroup::activated(int iMsg)
 
     App::DocumentObject *docObj = getDocument()->getObject(multiViewName.c_str());
     auto multiView( static_cast<TechDraw::DrawProjGroup *>(docObj) );
+    doCommand(Doc,"App.activeDocument().%s.addProjection('Front')",multiViewName.c_str());
     multiView->Source.setValues(shapes);
 
     if (subFound) {
         std::pair<Base::Vector3d,Base::Vector3d> dirs = DrawGuiUtil::getProjDirFromFace(partFeat,faceName);
+        getDocument()->setStatus(App::Document::Status::SkipRecompute, true);
         doCommand(Doc,"App.activeDocument().%s.Anchor.Direction = FreeCAD.Vector(%.3f,%.3f,%.3f)",
                       multiViewName.c_str(), dirs.first.x,dirs.first.y,dirs.first.z);
         doCommand(Doc,"App.activeDocument().%s.Anchor.RotationVector = FreeCAD.Vector(%.3f,%.3f,%.3f)",
@@ -565,7 +570,6 @@ void CmdTechDrawProjGroup::activated(int iMsg)
         getDocument()->setStatus(App::Document::Status::SkipRecompute, false);
         doCommand(Doc,"App.activeDocument().%s.Anchor.recompute()", multiViewName.c_str());
     }
-    //updateActive();    //exec all pending actions, but there's nothing to do here.
     commitCommand();   //write the undo
 
     // create the rest of the desired views
@@ -1192,7 +1196,6 @@ void CmdTechDrawExportPageDxf::activated(int iMsg)
     openCommand("Save page to dxf");
     doCommand(Doc,"import TechDraw");
     doCommand(Doc,"TechDraw.writeDXFPage(App.activeDocument().%s,u\"%s\")",PageName.c_str(),(const char*)fileName.toUtf8());
-    updateActive();
     commitCommand();
 }
 

--- a/src/Mod/TechDraw/Gui/Command.cpp
+++ b/src/Mod/TechDraw/Gui/Command.cpp
@@ -548,8 +548,8 @@ void CmdTechDrawProjGroup::activated(int iMsg)
 
     App::DocumentObject *docObj = getDocument()->getObject(multiViewName.c_str());
     auto multiView( static_cast<TechDraw::DrawProjGroup *>(docObj) );
-    doCommand(Doc,"App.activeDocument().%s.addProjection('Front')",multiViewName.c_str());
     multiView->Source.setValues(shapes);
+    doCommand(Doc,"App.activeDocument().%s.addProjection('Front')",multiViewName.c_str());
 
     if (subFound) {
         std::pair<Base::Vector3d,Base::Vector3d> dirs = DrawGuiUtil::getProjDirFromFace(partFeat,faceName);

--- a/src/Mod/TechDraw/Gui/MDIViewPage.cpp
+++ b/src/Mod/TechDraw/Gui/MDIViewPage.cpp
@@ -268,6 +268,11 @@ void MDIViewPage::centerOnPage(void)
     }
 }
 
+bool MDIViewPage::addView(const App::DocumentObject *obj)
+{
+    return attachView(const_cast<App::DocumentObject*>(obj));
+}
+
 bool MDIViewPage::attachView(App::DocumentObject *obj)
 {
     auto typeId(obj->getTypeId());

--- a/src/Mod/TechDraw/Gui/MDIViewPage.cpp
+++ b/src/Mod/TechDraw/Gui/MDIViewPage.cpp
@@ -852,7 +852,6 @@ void MDIViewPage::saveDXF(std::string fileName)
     Gui::Command::doCommand(Gui::Command::Doc,"import TechDraw");
     Gui::Command::doCommand(Gui::Command::Doc,"TechDraw.writeDXFPage(App.activeDocument().%s,u\"%s\")",
                             PageName.c_str(),(const char*)fileName.c_str());
-    Gui::Command::updateActive();
     Gui::Command::commitCommand();
 }
 

--- a/src/Mod/TechDraw/Gui/MDIViewPage.h
+++ b/src/Mod/TechDraw/Gui/MDIViewPage.h
@@ -102,6 +102,7 @@ public:
     
     void setTabText(std::string t);
 
+    bool addView(const App::DocumentObject *obj);
 
 public Q_SLOTS:
     void viewAll();

--- a/src/Mod/TechDraw/Gui/QGIView.cpp
+++ b/src/Mod/TechDraw/Gui/QGIView.cpp
@@ -275,6 +275,7 @@ QGIViewClip* QGIView::getClipGroup(void)
 void QGIView::updateView(bool update)
 {
 //    Base::Console().Message("QGIV::updateView() - %s\n",getViewObject()->getNameInDocument());
+    (void) update;
     if (getViewObject()->isLocked()) {
         setFlag(QGraphicsItem::ItemIsMovable, false);
     } else {
@@ -294,10 +295,7 @@ void QGIView::updateView(bool update)
         rotateView();
     }
 
-    draw();
-    
-    if (update)
-        QGraphicsItem::update();
+    QGIView::draw();
 }
 
 //QGIVP derived classes do not need a rotate view method as rotation is handled on App side.

--- a/src/Mod/TechDraw/Gui/QGIViewPart.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewPart.cpp
@@ -125,9 +125,7 @@ void QGIViewPart::setViewPartFeature(TechDraw::DrawViewPart *obj)
     if (!obj)
         return;
 
-    // called from QGVPage
     setViewFeature(static_cast<TechDraw::DrawView *>(obj));
-    draw();
 }
 
 QPainterPath QGIViewPart::drawPainterPath(TechDrawGeometry::BaseGeom *baseGeom) const
@@ -315,7 +313,7 @@ void QGIViewPart::updateView(bool update)
     auto end   = std::chrono::high_resolution_clock::now();
     auto diff  = end - start;
     double diffOut = std::chrono::duration <double, std::milli> (diff).count();
-    Base::Console().Log("TIMING - QGIVP::updateView - total %.3f millisecs\n",diffOut);
+    Base::Console().Log("TIMING - QGIVP::updateView - %s - total %.3f millisecs\n",getViewName(),diffOut);
 }
 
 void QGIViewPart::draw() {
@@ -324,7 +322,6 @@ void QGIViewPart::draw() {
     QGIView::draw();
     drawCenterLines(true);   //have to draw centerlines after border to get size correct.
     drawAllSectionLines();   //same for section lines
-
 }
 
 void QGIViewPart::drawViewPart()

--- a/src/Mod/TechDraw/Gui/QGVPage.cpp
+++ b/src/Mod/TechDraw/Gui/QGVPage.cpp
@@ -203,30 +203,33 @@ std::vector<QGIView *> QGVPage::getViews() const
 
 int QGVPage::addQView(QGIView *view)
 {
-    auto ourScene( scene() );
-    assert(ourScene);
+    //don't add twice!
+    QGIView* existing = getQGIVByName(view->getViewName());
+    if (existing == nullptr) {
+        auto ourScene( scene() );
+        assert(ourScene);
 
-    ourScene->addItem(view);
+        ourScene->addItem(view);
 
-    // Find if it belongs to a parent
-    QGIView *parent = 0;
-    parent = findParent(view);
+        // Find if it belongs to a parent
+        QGIView *parent = 0;
+        parent = findParent(view);
 
-    QPointF viewPos(Rez::guiX(view->getViewObject()->X.getValue()),
-                    Rez::guiX(view->getViewObject()->Y.getValue() * -1));
+        QPointF viewPos(Rez::guiX(view->getViewObject()->X.getValue()),
+                        Rez::guiX(view->getViewObject()->Y.getValue() * -1));
 
-    if(parent) {
-        // move child view to center of parent
-        QPointF posRef(0.,0.);
-        QPointF mapPos = view->mapToItem(parent, posRef);
-        view->moveBy(-mapPos.x(), -mapPos.y());
+        if(parent) {
+            // move child view to center of parent
+            QPointF posRef(0.,0.);
+            QPointF mapPos = view->mapToItem(parent, posRef);
+            view->moveBy(-mapPos.x(), -mapPos.y());
 
-        parent->addToGroup(view);
+            parent->addToGroup(view);
+        }
+
+        view->setPos(viewPos);
+        view->updateView(true);
     }
-
-    view->setPos(viewPos);
-    view->updateView(true);
-
     return 0;
 }
 
@@ -281,8 +284,6 @@ QGIView * QGVPage::addViewPart(TechDraw::DrawViewPart *part)
 {
     QGIView* existing = findQViewForDocObj(part);
     if (existing != nullptr) {
-       Base::Console().Log("INFO - QGVP::addViewPart -  %s - QView exists\n", 
-                                              part->getNameInDocument());
        return existing;
     }
 

--- a/src/Mod/TechDraw/Gui/QGVPage.cpp
+++ b/src/Mod/TechDraw/Gui/QGVPage.cpp
@@ -279,6 +279,13 @@ void QGVPage::removeQViewFromScene(QGIView *view)
 
 QGIView * QGVPage::addViewPart(TechDraw::DrawViewPart *part)
 {
+    QGIView* existing = findQViewForDocObj(part);
+    if (existing != nullptr) {
+       Base::Console().Log("INFO - QGVP::addViewPart -  %s - QView exists\n", 
+                                              part->getNameInDocument());
+       return existing;
+    }
+
     auto viewPart( new QGIViewPart );
 
     viewPart->setViewPartFeature(part);
@@ -666,7 +673,7 @@ void QGVPage::postProcessXml(QTemporaryFile* tempFile, QString fileName, QString
 
     QFile outFile( fileName );
     if( !outFile.open( QIODevice::WriteOnly | QIODevice::Text ) ) {
-        Base::Console().Message("QGVP::ppxml - failed to open file for writing: %s\n.",qPrintable(fileName) );
+        Base::Console().Message("QGVP::ppxml - failed to open file for writing: %s\n",qPrintable(fileName) );
     }
     QTextStream stream( &outFile );
     stream << doc.toString();

--- a/src/Mod/TechDraw/Gui/TaskProjGroup.cpp
+++ b/src/Mod/TechDraw/Gui/TaskProjGroup.cpp
@@ -170,7 +170,6 @@ void TaskProjGroup::rotateButtonClicked(void)
             multiView->spinCCW();
         }
         setUiPrimary();
-        Gui::Command::updateActive();
     }
 }
 
@@ -257,7 +256,6 @@ void TaskProjGroup::scaleTypeChanged(int index)
     }
 
     multiView->recomputeFeature();
-    Gui::Command::updateActive();
 }
 
 std::pair<int, int> TaskProjGroup::nearestFraction(const double val, const long int maxDenom) const
@@ -375,7 +373,6 @@ void TaskProjGroup::scaleManuallyChanged(int i)
     Gui::Command::doCommand(Gui::Command::Doc, "App.activeDocument().%s.Scale = %f", multiView->getNameInDocument()
                                                                                      , scale);
     multiView->recomputeFeature();  //just a repaint.  multiView is already marked for recompute by changed to Scale
-    Gui::Command::updateActive();
 }
 
 void TaskProjGroup::changeEvent(QEvent *e)
@@ -500,7 +497,6 @@ bool TaskProjGroup::reject()
             Base::Console().Log("TaskProjGroup: Edit mode - NO command is active\n");
         }
 
-        Gui::Command::updateActive();
         Gui::Command::doCommand(Gui::Command::Gui,"Gui.ActiveDocument.resetEdit()");
     }
     return false;

--- a/src/Mod/TechDraw/Gui/ViewProviderDimension.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderDimension.cpp
@@ -137,7 +137,7 @@ void ViewProviderDimension::onChanged(const App::Property* p)
             qgiv->updateView(true);
         }
     }
-    Gui::ViewProviderDocumentObject::onChanged(p);
+    ViewProviderDrawingView::onChanged(p);
 }
 
 TechDraw::DrawViewDimension* ViewProviderDimension::getViewObject() const

--- a/src/Mod/TechDraw/Gui/ViewProviderDrawingView.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderDrawingView.cpp
@@ -244,9 +244,9 @@ void ViewProviderDrawingView::onGuiRepaint(const TechDraw::DrawView* dv)
         if (qgiv) {
             qgiv->updateView(true);
         } else {                                //we are not part of the Gui page yet. ask page to add us.
-            auto page = dv->findParentPage();
+            MDIViewPage* page = getMDIViewPage();
             if (page != nullptr) {
-                page->requestPaint();
+                page->addView(dv);
             }
         }
     }

--- a/src/Mod/TechDraw/Gui/ViewProviderProjGroup.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderProjGroup.cpp
@@ -71,18 +71,18 @@ ViewProviderProjGroup::~ViewProviderProjGroup()
 void ViewProviderProjGroup::attach(App::DocumentObject *pcFeat)
 {
     // call parent attach method
-    ViewProviderDocumentObject::attach(pcFeat);
+    ViewProviderDrawingView::attach(pcFeat);
 }
 
 void ViewProviderProjGroup::setDisplayMode(const char* ModeName)
 {
-    ViewProviderDocumentObject::setDisplayMode(ModeName);
+    ViewProviderDrawingView::setDisplayMode(ModeName);
 }
 
 std::vector<std::string> ViewProviderProjGroup::getDisplayModes(void) const
 {
     // get the modes of the father
-    std::vector<std::string> StrList = ViewProviderDocumentObject::getDisplayModes();
+    std::vector<std::string> StrList = ViewProviderDrawingView::getDisplayModes();
     StrList.push_back("Drawing");
     return StrList;
 }

--- a/src/Mod/TechDraw/Gui/ViewProviderProjGroupItem.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderProjGroupItem.cpp
@@ -68,13 +68,13 @@ void ViewProviderProjGroupItem::attach(App::DocumentObject *pcFeat)
 
 void ViewProviderProjGroupItem::setDisplayMode(const char* ModeName)
 {
-    ViewProviderDocumentObject::setDisplayMode(ModeName);
+    ViewProviderViewPart::setDisplayMode(ModeName);
 }
 
 std::vector<std::string> ViewProviderProjGroupItem::getDisplayModes(void) const
 {
     // get the modes of the father
-    std::vector<std::string> StrList = ViewProviderDocumentObject::getDisplayModes();
+    std::vector<std::string> StrList = ViewProviderViewPart::getDisplayModes();
     StrList.push_back("Drawing");
     return StrList;
 }

--- a/src/Mod/TechDraw/Gui/ViewProviderViewPart.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderViewPart.cpp
@@ -137,13 +137,13 @@ void ViewProviderViewPart::attach(App::DocumentObject *pcFeat)
 
 void ViewProviderViewPart::setDisplayMode(const char* ModeName)
 {
-    ViewProviderDocumentObject::setDisplayMode(ModeName);
+    ViewProviderDrawingView::setDisplayMode(ModeName);
 }
 
 std::vector<std::string> ViewProviderViewPart::getDisplayModes(void) const
 {
     // get the modes of the father
-    std::vector<std::string> StrList = ViewProviderDocumentObject::getDisplayModes();
+    std::vector<std::string> StrList = ViewProviderDrawingView::getDisplayModes();
 
     return StrList;
 }

--- a/src/Mod/TechDraw/Gui/ViewProviderViewSection.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderViewSection.cpp
@@ -73,13 +73,13 @@ void ViewProviderViewSection::attach(App::DocumentObject *pcFeat)
 
 void ViewProviderViewSection::setDisplayMode(const char* ModeName)
 {
-    ViewProviderDocumentObject::setDisplayMode(ModeName);
+    ViewProviderViewPart::setDisplayMode(ModeName);
 }
 
 std::vector<std::string> ViewProviderViewSection::getDisplayModes(void) const
 {
     // get the modes of the father
-    std::vector<std::string> StrList = ViewProviderDocumentObject::getDisplayModes();
+    std::vector<std::string> StrList = ViewProviderViewPart::getDisplayModes();
 
     return StrList;
 }

--- a/src/Mod/TechDraw/TDTest/DProjGroupTest.py
+++ b/src/Mod/TechDraw/TDTest/DProjGroupTest.py
@@ -65,8 +65,8 @@ def DProjGroupTest():
     print("added Bottom")
 
     #remove a view from projection group
-    #iv = group.removeProjection("Left")
-    #print("removed Left")
+    iv = group.removeProjection("Left")
+    print("removed Left")
 
     ##test getItemByLabel method
     print("testing getItemByLabel")

--- a/src/Mod/TechDraw/TDTest/DProjGroupTest.py
+++ b/src/Mod/TechDraw/TDTest/DProjGroupTest.py
@@ -42,9 +42,17 @@ def DProjGroupTest():
     print("making a projection group")
     group = FreeCAD.ActiveDocument.addObject('TechDraw::DrawProjGroup','ProjGroup')
     rc = page.addView(group)
+    print("Group created")
     group.Source = [fusion]
 
     print("adding views")
+    frontView = group.addProjection("Front")               ##need an Anchor
+    print("added Front")
+
+    #update group
+    group.Anchor.Direction = FreeCAD.Vector(0,0,1)
+    group.Anchor.RotationVector = FreeCAD.Vector(1,0,0)
+
     leftView = group.addProjection("Left")
     print("added Left")
     topView = group.addProjection("Top")


### PR DESCRIPTION
This PR is a replacement for [#2001.](https://github.com/FreeCAD/FreeCAD/pull/2001) It addresses an issue of slow response by TechDraw. Under certain conditions, unnecessary screen paints were being performed. In addition the issues identified for (segfault on missing Anchor view, use of dynamic_cast) PR2001 have been corrected.
Please merge
Thanks,
wf


Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
