### PR TITLE
Fix #3891 S/S Contents not displayed at load

### DIFF
--- a/src/Mod/TechDraw/App/DrawViewSpreadsheet.cpp
+++ b/src/Mod/TechDraw/App/DrawViewSpreadsheet.cpp
@@ -158,6 +158,8 @@ std::string DrawViewSpreadsheet::getSheetImage(void)
     std::stringstream result;
 
     App::DocumentObject* link = Source.getValue();
+    link->recomputeFeature();   //make sure s/s is up to date
+
     std::string scellstart = CellStart.getValue();
     std::string scellend = CellEnd.getValue();
 


### PR DESCRIPTION
This PR corrects [issue #3891](https://www.freecadweb.org/tracker/view.php?id=3891) where a DrawViewSpreadsheet is empty after document load until a recompute occurs.   NOTE: this is not an elegant fix.  It just calls recomputeFeature on the Spreadsheet before getting the Spreadsheet contents.  

Please merge. 
Thanks,
wf


Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
