### PR TITLE
fix problem that too large splash image make dialog too large

### DIFF
--- a/src/Gui/AboutApplication.ui
+++ b/src/Gui/AboutApplication.ui
@@ -50,7 +50,7 @@
    <item row="0" column="0">
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
-      <number>1</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="tab_about">
       <attribute name="title">
@@ -59,6 +59,12 @@
       <layout class="QVBoxLayout" name="verticalLayout">
        <item>
         <widget class="QLabel" name="labelSplashPicture">
+         <property name="maximumSize">
+          <size>
+           <width>450</width>
+           <height>850</height>
+          </size>
+         </property>
          <property name="text">
           <string/>
          </property>


### PR DESCRIPTION
avoid problem that too large splash image make the dialog too large as discussed here:
https://forum.freecadweb.org/viewtopic.php?f=3&t=34656&start=10#p291867

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
