### PR TITLE
Path: fix grbl_post postamble parameter handling

### DIFF
--- a/src/Mod/Path/PathScripts/post/grbl_post.py
+++ b/src/Mod/Path/PathScripts/post/grbl_post.py
@@ -135,7 +135,7 @@ def processArguments(argstring):
         print("Show editor = %d" % SHOW_EDITOR)
         PRECISION = args.precision
         if not args.preamble is None:
-            PREAMBLE = args.preamble
+            PREAMBLE = args.preamble.replace('\\n', '\n')
         if not args.postamble is None:
             POSTAMBLE = args.postamble.replace('\\n', '\n')
         if not args.tool_change is None:

--- a/src/Mod/Path/PathScripts/post/grbl_post.py
+++ b/src/Mod/Path/PathScripts/post/grbl_post.py
@@ -137,7 +137,7 @@ def processArguments(argstring):
         if not args.preamble is None:
             PREAMBLE = args.preamble
         if not args.postamble is None:
-            POSTAMBLE = args.postamble
+            POSTAMBLE = args.postamble.replace('\\n', '\n')
         if not args.tool_change is None:
             OUTPUT_TOOL_CHANGE = int(args.tool_change) > 0
             SUPPRESS_TOOL_CHANGE = min(1, int(args.tool_change) - 1)


### PR DESCRIPTION
Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---

grbl_post takes `--preamble` and `--postamble` parameters which will typically be multiline, but there is no way to set them reliably in the UI: 
* setting a param to `'line1\nline2'` gets the string included as is (with literal `\n`) because the backslashes are being escaped
* setting the param from the console works, but is clunky; also, it needs to be set again after opening job properties, because newlines get turned into spaces

this PR turns `\n` in preamble and postamble parameters to actual newlines