### PR TITLE
Fix PVS-Studio Error

### DIFF
--- a/src/Mod/TechDraw/Gui/QGICMark.cpp
+++ b/src/Mod/TechDraw/Gui/QGICMark.cpp
@@ -41,7 +41,6 @@ using namespace TechDrawGui;
 
 QGICMark::QGICMark(int index) : QGIVertex(index)
 {
-    projIndex = 0;
     m_size = 3.0;
     m_width = 0.75;
     draw();

--- a/src/Mod/TechDraw/Gui/QGICMark.h
+++ b/src/Mod/TechDraw/Gui/QGICMark.h
@@ -41,8 +41,6 @@ public:
     virtual QRectF boundingRect() const override;
     virtual QPainterPath shape() const override;
 
-    int getProjIndex() const { return projIndex; }
-
     void draw(void);
     float getSize() { return m_size; }
     void setSize(float s);
@@ -53,7 +51,6 @@ public:
     double getMarkFuzz(void) const;
 
 protected:
-    int projIndex;
     QColor getCMarkColor();
 
 private:


### PR DESCRIPTION
This PR addresses an error detected by PVS-Studio - QGCMark duplicates field & method from base class QGIVertex.   Please merge when appropriate.   Thanks.
wf

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
