### PR TITLE
TD and Dxf Export Fixes

### DIFF
--- a/src/Mod/Draft/Resources/ui/preferences-dxf.ui
+++ b/src/Mod/Draft/Resources/ui/preferences-dxf.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>506</width>
-    <height>647</height>
+    <width>649</width>
+    <height>773</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -46,6 +46,19 @@
      </property>
      <property name="prefEntry" stdset="0">
       <cstring>dxfUseLegacyImporter</cstring>
+     </property>
+     <property name="prefPath" stdset="0">
+      <cstring>Mod/Draft</cstring>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="Gui::PrefCheckBox" name="checkBox_7">
+     <property name="text">
+      <string>Use legacy python exporter</string>
+     </property>
+     <property name="prefEntry" stdset="0">
+      <cstring>dxfUseLegacyExporter</cstring>
      </property>
      <property name="prefPath" stdset="0">
       <cstring>Mod/Draft</cstring>

--- a/src/Mod/Draft/importDXF.py
+++ b/src/Mod/Draft/importDXF.py
@@ -1940,8 +1940,14 @@ def getStrGroup(ob):
 def export(objectslist,filename,nospline=False,lwPoly=False):
 
     "called when freecad exports a file. If nospline=True, bsplines are exported as straight segs. lwPoly=True is for OpenSCAD DXF"
-
     readPreferences()
+    if not dxfUseLegacyExporter:
+        import Import
+        version = 14
+        if nospline:
+            version = 12
+        Import.writeDXFObject(objectslist,filename,version,lwPoly)
+        return
     getDXFlibs()
     if dxfLibrary:
         global exportList
@@ -2307,6 +2313,7 @@ def readPreferences():
     global dxfMakeBlocks, dxfJoin, dxfRenderPolylineWidth, dxfImportTexts, dxfImportLayouts
     global dxfImportPoints, dxfImportHatches, dxfUseStandardSize, dxfGetColors, dxfUseDraftVisGroups
     global dxfFillMode, dxfBrightBackground, dxfDefaultColor, dxfUseLegacyImporter, dxfExportBlocks, dxfScaling
+    global dxfUseLegacyExporter
     dxfCreatePart = p.GetBool("dxfCreatePart",True)
     dxfCreateDraft = p.GetBool("dxfCreateDraft",False)
     dxfCreateSketch = p.GetBool("dxfCreateSketch",False)
@@ -2324,6 +2331,7 @@ def readPreferences():
     dxfUseDraftVisGroups = p.GetBool("dxfUseDraftVisGroups",False)
     dxfFillMode = p.GetBool("fillmode",True)
     dxfUseLegacyImporter = p.GetBool("dxfUseLegacyImporter",False)
+    dxfUseLegacyExporter = p.GetBool("dxfUseLegacyExporter",False)
     dxfBrightBackground = isBrightBackground()
     dxfDefaultColor = getColor()
     dxfExportBlocks = p.GetBool("dxfExportBlocks",True)

--- a/src/Mod/Import/App/ImpExpDxf.cpp
+++ b/src/Mod/Import/App/ImpExpDxf.cpp
@@ -606,7 +606,7 @@ void ImpExpDxfWrite::exportBSpline(BRepAdaptor_Curve& c)
     gp_Pnt s,ePt;
 
     Standard_Real tol3D = 0.001;
-    Standard_Integer maxDegree = 3, maxSegment = 100;
+    Standard_Integer maxDegree = 3, maxSegment = 200;
     Handle(BRepAdaptor_HCurve) hCurve = new BRepAdaptor_HCurve(c);
     Approx_Curve3d approx(hCurve, tol3D, GeomAbs_C0, maxSegment, maxDegree);
     if (approx.IsDone() && approx.HasResult()) {

--- a/src/Mod/TechDraw/App/Geometry.cpp
+++ b/src/Mod/TechDraw/App/Geometry.cpp
@@ -530,7 +530,7 @@ BSpline::BSpline(const TopoDS_Edge &e)
     }
 
     Standard_Real tol3D = 0.001;                                   //1/1000 of a mm? screen can't resolve this
-    Standard_Integer maxDegree = 3, maxSegment = 100;
+    Standard_Integer maxDegree = 3, maxSegment = 200;
     Handle(BRepAdaptor_HCurve) hCurve = new BRepAdaptor_HCurve(c);
     // approximate the curve using a tolerance
     //Approx_Curve3d approx(hCurve, tol3D, GeomAbs_C2, maxSegment, maxDegree);   //gives degree == 5  ==> too many poles ==> buffer overrun

--- a/src/Mod/TechDraw/Gui/DlgPrefsTechDraw2.ui
+++ b/src/Mod/TechDraw/Gui/DlgPrefsTechDraw2.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>521</width>
-    <height>732</height>
+    <height>771</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -24,6 +24,9 @@
        <layout class="QGridLayout" name="gridLayout" columnstretch="1,0,0">
         <item row="0" column="0">
          <widget class="Gui::PrefCheckBox" name="cbShowUnits">
+          <property name="toolTip">
+           <string>Append unit to Dimension text</string>
+          </property>
           <property name="text">
            <string>Show Units</string>
           </property>
@@ -35,15 +38,18 @@
           </property>
          </widget>
         </item>
-        <item row="4" column="0">
+        <item row="5" column="0">
          <widget class="QLabel" name="label_3">
           <property name="text">
            <string>Color</string>
           </property>
          </widget>
         </item>
-        <item row="4" column="2">
+        <item row="5" column="2">
          <widget class="Gui::PrefColorButton" name="colDimColor">
+          <property name="toolTip">
+           <string>Dimension text color</string>
+          </property>
           <property name="color">
            <color>
             <red>0</red>
@@ -59,14 +65,14 @@
           </property>
          </widget>
         </item>
-        <item row="3" column="0">
+        <item row="4" column="0">
          <widget class="QLabel" name="label_2">
           <property name="text">
            <string>Font Size</string>
           </property>
          </widget>
         </item>
-        <item row="3" column="1">
+        <item row="4" column="1">
          <spacer name="horizontalSpacer">
           <property name="orientation">
            <enum>Qt::Horizontal</enum>
@@ -86,26 +92,29 @@
           </property>
          </widget>
         </item>
-        <item row="7" column="0">
+        <item row="8" column="0">
          <widget class="QLabel" name="label_12">
           <property name="text">
            <string>Arrow Size</string>
           </property>
          </widget>
         </item>
-        <item row="5" column="0">
+        <item row="6" column="0">
          <widget class="QLabel" name="label_8">
           <property name="text">
            <string>Diameter Symbol</string>
           </property>
          </widget>
         </item>
-        <item row="5" column="2">
+        <item row="6" column="2">
          <widget class="Gui::PrefLineEdit" name="leDiameter">
           <property name="font">
            <font>
             <pointsize>12</pointsize>
            </font>
+          </property>
+          <property name="toolTip">
+           <string>Character to use to indicate Diameter dimension</string>
           </property>
           <property name="text">
            <string>⌀</string>
@@ -123,6 +132,9 @@
         </item>
         <item row="1" column="0">
          <widget class="Gui::PrefCheckBox" name="cbGlobalDecimals">
+          <property name="toolTip">
+           <string>Use system setting for decimal places.</string>
+          </property>
           <property name="text">
            <string>Use Global Decimals</string>
           </property>
@@ -137,7 +149,7 @@
           </property>
          </widget>
         </item>
-        <item row="6" column="2">
+        <item row="7" column="2">
          <widget class="Gui::PrefComboBox" name="pcbArrow">
           <property name="toolTip">
            <string>Preferred arrowhead style</string>
@@ -206,7 +218,7 @@
           </item>
          </widget>
         </item>
-        <item row="6" column="0">
+        <item row="7" column="0">
          <widget class="QLabel" name="label_9">
           <property name="text">
            <string>Arrow Style</string>
@@ -215,6 +227,9 @@
         </item>
         <item row="2" column="2">
          <widget class="Gui::PrefSpinBox" name="sbAltDecimals">
+          <property name="toolTip">
+           <string>Number of decimal places if not using Global Decimals</string>
+          </property>
           <property name="alignment">
            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
           </property>
@@ -229,7 +244,7 @@
           </property>
          </widget>
         </item>
-        <item row="3" column="2">
+        <item row="4" column="2">
          <widget class="Gui::PrefUnitSpinBox" name="plsb_FontSize">
           <property name="toolTip">
            <string>Dimension font size in units</string>
@@ -245,7 +260,7 @@
           </property>
          </widget>
         </item>
-        <item row="7" column="2">
+        <item row="8" column="2">
          <widget class="Gui::PrefUnitSpinBox" name="plsb_ArrowSize">
           <property name="toolTip">
            <string>Dimension arrowhead size in units</string>
@@ -258,6 +273,26 @@
           </property>
           <property name="prefPath" stdset="0">
            <cstring>Mod/TechDraw/Dimensions</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="0">
+         <widget class="QLabel" name="label_15">
+          <property name="text">
+           <string>Default Format</string>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="2">
+         <widget class="Gui::PrefLineEdit" name="leformatSpec">
+          <property name="toolTip">
+           <string>Custom format for Dimension text</string>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>formatSpec</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>/Mod/TechDraw/Dimensions</cstring>
           </property>
          </widget>
         </item>
@@ -276,6 +311,9 @@
        <layout class="QGridLayout" name="gridLayout_2" columnstretch="1,0,0">
         <item row="3" column="2">
          <widget class="Gui::PrefColorButton" name="colCenterLine">
+          <property name="toolTip">
+           <string>Color for centerlines</string>
+          </property>
           <property name="color">
            <color>
             <red>175</red>
@@ -316,6 +354,9 @@
         </item>
         <item row="1" column="2">
          <widget class="Gui::PrefComboBox" name="pcbMatting">
+          <property name="toolTip">
+           <string>Round or Square outline in Detail view</string>
+          </property>
           <property name="prefEntry" stdset="0">
            <cstring>MattingStyle</cstring>
           </property>
@@ -357,6 +398,9 @@
         </item>
         <item row="2" column="2">
          <widget class="Gui::PrefComboBox" name="pcbCenterStyle">
+          <property name="toolTip">
+           <string>Line type for centerlines</string>
+          </property>
           <property name="currentIndex">
            <number>2</number>
           </property>
@@ -457,6 +501,9 @@
         </item>
         <item row="5" column="2">
          <widget class="Gui::PrefColorButton" name="colSectionLine">
+          <property name="toolTip">
+           <string>Line color for sectionlines</string>
+          </property>
           <property name="color">
            <color>
             <red>175</red>
@@ -494,6 +541,9 @@
         </item>
         <item row="0" column="2">
          <widget class="Gui::PrefLineEdit" name="leLineGroup">
+          <property name="toolTip">
+           <string>Name of entry in LineGroup CSV file</string>
+          </property>
           <property name="text">
            <string notr="true">FC 0.70mm</string>
           </property>
@@ -514,6 +564,9 @@
         </item>
         <item row="7" column="2">
          <widget class="Gui::PrefColorButton" name="pcb_VertexColor">
+          <property name="toolTip">
+           <string>Vertex display color</string>
+          </property>
           <property name="color">
            <color>
             <red>150</red>

--- a/src/Mod/TechDraw/Gui/DlgPrefsTechDraw2Imp.cpp
+++ b/src/Mod/TechDraw/Gui/DlgPrefsTechDraw2Imp.cpp
@@ -57,6 +57,7 @@ void DlgPrefsTechDraw2Imp::saveSettings()
     pcbArrow->onSave();
     cbGlobalDecimals->onSave();
     sbAltDecimals->onSave();
+    leformatSpec->onSave();
     plsb_ArrowSize->onSave();
     leLineGroup->onSave();
     pdsb_VertexScale->onSave();
@@ -77,6 +78,7 @@ void DlgPrefsTechDraw2Imp::loadSettings()
     pcbArrow->onRestore();
     cbGlobalDecimals->onRestore();
     sbAltDecimals->onRestore();
+    leformatSpec->onRestore();
     plsb_ArrowSize->onRestore();
     leLineGroup->onRestore();
     pdsb_VertexScale->onRestore();

--- a/src/Mod/TechDraw/Gui/MDIViewPage.cpp
+++ b/src/Mod/TechDraw/Gui/MDIViewPage.cpp
@@ -498,11 +498,9 @@ bool MDIViewPage::onMsg(const char *pMsg, const char **)
         return true;
     } else if (strcmp("Save", pMsg) == 0 ) {
         doc->save();
-        Gui::Command::updateActive();
         return true;
     } else if (strcmp("SaveAs", pMsg) == 0 ) {
         doc->saveAs();
-        Gui::Command::updateActive();
         return true;
     } else if (strcmp("Undo", pMsg) == 0 ) {
         doc->undo(1);

--- a/src/Mod/TechDraw/Gui/MDIViewPage.h
+++ b/src/Mod/TechDraw/Gui/MDIViewPage.h
@@ -71,7 +71,7 @@ public:
     void matchSceneRectToTemplate(void);
     
     bool onMsg(const char* pMsg,const char** ppReturn);
-    bool onHasMsg(const char* pMsg) const;
+      bool onHasMsg(const char* pMsg) const;
 
     void print();
     void print(QPrinter* printer);

--- a/src/Mod/TechDraw/Gui/QGIViewDimension.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewDimension.cpp
@@ -698,11 +698,12 @@ void QGIViewDimension::draw()
                 a1Dir = dirDim;
                 a2Dir = -dirDim;
             }
+
             if (fauxToDim1 < fauxToDim2)  {
                 dim1Tail = fauxCenter;
-                dim2Tail = dim2Tip;
+                dim2Tail = dim2Tip - tailLength*a2Dir;
             } else {
-                dim1Tail = dim1Tip;
+                dim1Tail = dim1Tip - tailLength*a1Dir;
                 dim2Tail = fauxCenter;
             }
         }


### PR DESCRIPTION
This PR fixes issues* with Dxf export and TechDraw.  Please merge.
Thanks,
wf

* missing offside arrow tail
* surplus execute on doc save if TD tab is active
* add Draft preference "UseLegacyDXFExporter"
* correct handling of spline approximation in TechDraw and Import modules


Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
