### PR TITLE
FreeCAD: Application: removed banner in Cmd RunMode

### DIFF
--- a/src/App/Application.cpp
+++ b/src/App/Application.cpp
@@ -1550,20 +1550,23 @@ void Application::initConfig(int argc, char ** argv)
         _pConsoleObserverFile = 0;
 
     // Banner ===========================================================
-    if (!(mConfig["Verbose"] == "Strict"))
-        Console().Message("%s %s, Libs: %s.%sR%s\n%s",mConfig["ExeName"].c_str(),
-                          mConfig["ExeVersion"].c_str(),
-                          mConfig["BuildVersionMajor"].c_str(),
-                          mConfig["BuildVersionMinor"].c_str(),
-                          mConfig["BuildRevision"].c_str(),
-                          mConfig["CopyrightInfo"].c_str());
-    else
-        Console().Message("%s %s, Libs: %s.%sB%s\n",mConfig["ExeName"].c_str(),
-                          mConfig["ExeVersion"].c_str(),
-                          mConfig["BuildVersionMajor"].c_str(),
-                          mConfig["BuildVersionMinor"].c_str(),
-                          mConfig["BuildRevision"].c_str());
-
+    if (!(mConfig["RunMode"] == "Cmd")) {
+        // Remove banner if FreeCAD is invoked via the -c command as regular
+        // Python interpreter
+        if (!(mConfig["Verbose"] == "Strict"))
+            Console().Message("%s %s, Libs: %s.%sR%s\n%s",mConfig["ExeName"].c_str(),
+                              mConfig["ExeVersion"].c_str(),
+                              mConfig["BuildVersionMajor"].c_str(),
+                              mConfig["BuildVersionMinor"].c_str(),
+                              mConfig["BuildRevision"].c_str(),
+                              mConfig["CopyrightInfo"].c_str());
+        else
+            Console().Message("%s %s, Libs: %s.%sB%s\n",mConfig["ExeName"].c_str(),
+                              mConfig["ExeVersion"].c_str(),
+                              mConfig["BuildVersionMajor"].c_str(),
+                              mConfig["BuildVersionMinor"].c_str(),
+                              mConfig["BuildRevision"].c_str());
+    }
     LoadParameters();
 
     auto loglevelParam = _pcUserParamMngr->GetGroup("BaseApp/LogLevels");


### PR DESCRIPTION
Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [X] Branch rebased on latest master `git pull --rebase upstream master`
- [X] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0` (there appeared some `ReferenceError: Cannot access attribute 'isDerivedFrom' of deleted object` in the PartOMagic workbench)
- [X] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)

This PR should lead to a more "normal" behaviour of FreeCAD when invoked as standard Python interpreter. In some tools (i.e. Fenics) a JIT compiler asks for the Python version by using the actual binary and performing the following script.

     $ ./bin/FreeCAD -c "import sys; print sys.version"
     2.7.12 (default, Nov 12 2018, 14:36:49) 
     [GCC 5.4.0 20160609]

Usually the output is used to derive some directories (i.e. include, lib, ...) for JIT compiling from it. This does not work when the banner is shown, since the version string is malformed. Therefore it is maybe useful to remove the banner when using the "Cmd" RunMode.
