### PR TITLE
Fix Direction of Draft Arrows

### DIFF
--- a/src/Mod/Draft/getSVG.py
+++ b/src/Mod/Draft/getSVG.py
@@ -805,11 +805,11 @@ def getSVG(obj,scale=1,linewidth=0.35,fontsize=12,fillstyle="shape color",direct
         if FreeCAD.GuiUp:
             if hasattr(obj.ViewObject,"EndArrow") and hasattr(obj.ViewObject,"ArrowType") and (len(obj.Shape.Vertexes) > 1):
                 if obj.ViewObject.EndArrow:
-                    p1 = getProj(obj.Shape.Vertexes[-2].Point, plane)
-                    p2 = getProj(obj.Shape.Vertexes[-1].Point, plane)
+                    p1 = getProj(obj.Shape.Vertexes[-1].Point, plane)
+                    p2 = getProj(obj.Shape.Vertexes[-2].Point, plane)
                     angle = -DraftVecUtils.angle(p2.sub(p1))
                     arrowsize = obj.ViewObject.ArrowSize.Value/pointratio
-                    svg += getArrow(obj.ViewObject.ArrowType,p2,arrowsize,stroke,linewidth,angle)
+                    svg += getArrow(obj.ViewObject.ArrowType,p1,arrowsize,stroke,linewidth,angle)
 
     # techdraw expects bottom-to-top coordinates
     if techdraw:


### PR DESCRIPTION
This PR corrects an issue with the display of arrows in DraftView.  Please merge.
Thanks,
wf

- Arrowheads in DraftView were reverse when displayed
  in TechDraw.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
