### PR TITLE
fem: osx: try to fix default ccx detection

### DIFF
--- a/src/Mod/Fem/femtools/ccxtools.py
+++ b/src/Mod/Fem/femtools/ccxtools.py
@@ -536,11 +536,11 @@ class FemToolsCcx(QtCore.QRunnable, QtCore.QObject):
                 ccx_path = FreeCAD.getHomePath() + "bin/ccx.exe"
                 FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/Fem/Ccx").SetString("ccxBinaryPath", ccx_path)
                 self.ccx_binary = ccx_path
-            elif system() == "Linux":
+            elif system() in ("Linux", "Darwin"):
                 p1 = subprocess.Popen(['which', 'ccx'], stdout=subprocess.PIPE)
                 if p1.wait() == 0:
                     if sys.version_info.major >= 3:
-                        ccx_path = str(p1.stdout.read()).split('\n')[0]
+                        ccx_path = p1.stdout.read().decode("utf8").split('\n')[0]
                     else:
                         ccx_path = p1.stdout.read().split('\n')[0]
                 elif p1.wait() == 1:
@@ -551,7 +551,8 @@ class FemToolsCcx(QtCore.QRunnable, QtCore.QObject):
                     if FreeCAD.GuiUp:
                         QtGui.QMessageBox.critical(None, error_title, error_message)
                     raise Exception(error_message)
-                self.ccx_binary = ccx_path
+                # we use the default ccx command and we don't have to use the path to ccx for calling it
+                # self.ccx_binary = ccx_path 
         else:
             if not ccx_binary:
                 self.ccx_prefs = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/Fem/Ccx")


### PR DESCRIPTION
@berndhahnebach I tested this and it seems to work on osx. The real problem was related to wrong bytes->unicode decoding. But I also changed another line to use "ccx" (the command) instead of "path/to/ccx". To me this seems like the better approach as we test if the ccx command is available (so we should also use it).

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
