### PR TITLE
[0.18] FEM: Py3 fix in result reader

### DIFF
--- a/src/Mod/Fem/feminout/importToolsFem.py
+++ b/src/Mod/Fem/feminout/importToolsFem.py
@@ -275,14 +275,14 @@ def fill_femresult_mechanical(res_obj, result_set):
             if len(Peeq) > 0:
                 if len(Peeq.values()) != len(disp.values()):
                     Pe = []
-                    Pe_extra_nodes = Peeq.values()
+                    Pe_extra_nodes = list(Peeq.values())
                     nodes = len(disp.values())
                     for i in range(nodes):
                         Pe_value = Pe_extra_nodes[i]
                         Pe.append(Pe_value)
                     res_obj.Peeq = Pe
                 else:
-                    res_obj.Peeq = Peeq.values()
+                    res_obj.Peeq = list(Peeq.values())
 
     # fill res_obj.Temperature if they exist
     # TODO, check if it is possible to have Temperature without disp, we would need to set NodeNumbers than
@@ -291,7 +291,7 @@ def fill_femresult_mechanical(res_obj, result_set):
         if len(Temperature) > 0:
             if len(Temperature.values()) != len(disp.values()):
                 Temp = []
-                Temp_extra_nodes = Temperature.values()
+                Temp_extra_nodes = list(Temperature.values())
                 nodes = len(disp.values())
                 for i in range(nodes):
                     Temp_value = Temp_extra_nodes[i]


### PR DESCRIPTION
- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)

without this fix constraint nonlinear material and temperature does not work at all with calculix because results could not be read at all if these constraints are used.

It seams today I was the first ever on Python 3 who used these constraints ...

on 0.19 this commit is included in another PR from myself