### PR TITLE
Automation.py: unuse setBuffer [fix]

### DIFF
--- a/src/Mod/TemplatePyMod/Automation.py
+++ b/src/Mod/TemplatePyMod/Automation.py
@@ -48,7 +48,6 @@ def makeSnapshotWithoutGui():
 
 	# load it into a buffer
 	inp=coin.SoInput()
-	inp.setBuffer(iv)
 
 	# and create a scenegraph
 	data = coin.SoDB.readAll(inp)


### PR DESCRIPTION
With this line I get:

> Exception while processing file: Automation.py [setBuffer() takes exactly 3 arguments (2 given)]

removing it made the script work (_crystal.png_ gets generated, and it looks good).

Using FreeCAD 0.16

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [NA] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.

---
