### PR TITLE
Customizable the dimension colors of the part workbench.

### DIFF
--- a/src/Mod/Part/Gui/TaskDimension.cpp
+++ b/src/Mod/Part/Gui/TaskDimension.cpp
@@ -218,24 +218,37 @@ Gui::View3DInventorViewer * PartGui::getViewer()
 
 void PartGui::addLinearDimensions(const BRepExtrema_DistShapeShape &measure)
 {
+  ParameterGrp::handle hPartGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Mod/Part"); 
+  QString clCone = QString::fromStdString(hPartGrp->GetASCII("DimensionConeColor", "1.0/0.0/0.0")); 
+  QStringList clRGB = clCone.split(QLatin1String("/"));
+  float clR = clRGB.value(0).toFloat();
+  float clG = clRGB.value(1).toFloat();
+  float clB = clRGB.value(2).toFloat();
+
   Gui::View3DInventorViewer *viewer = getViewer();
   if (!viewer)
     return;
   gp_Pnt point1 = measure.PointOnShape1(1);
   gp_Pnt point2 = measure.PointOnShape2(1);
-  viewer->addDimension3d(createLinearDimension(point1, point2, SbColor(1.0, 0.0, 0.0)));
-  
+  viewer->addDimension3d(createLinearDimension(point1, point2, SbColor(clR, clG, clB)));
+
+  QString clLine = QString::fromStdString(hPartGrp->GetASCII("DimensionLinearColor", "0.0/1.0/0.0")); 
+  clRGB = clLine.split(QLatin1String("/"));
+  clR = clRGB.value(0).toFloat();
+  clG = clRGB.value(1).toFloat();
+  clB = clRGB.value(2).toFloat();
+ 
   //create deltas. point1 will always be the same.
   gp_Pnt temp = point1;
   gp_Pnt lastTemp = temp;
   temp.SetX(point2.X());
-  viewer->addDimensionDelta(createLinearDimension(lastTemp, temp, SbColor(0.0, 1.0, 0.0)));
+  viewer->addDimensionDelta(createLinearDimension(lastTemp, temp, SbColor(clR, clG, clB)));
   lastTemp = temp;
   temp.SetY(point2.Y());
-  viewer->addDimensionDelta(createLinearDimension(lastTemp, temp, SbColor(0.0, 1.0, 0.0)));
+  viewer->addDimensionDelta(createLinearDimension(lastTemp, temp, SbColor(clR, clG, clB)));
   lastTemp = temp;
   temp.SetZ(point2.Z());
-  viewer->addDimensionDelta(createLinearDimension(lastTemp, temp, SbColor(0.0, 1.0, 0.0)));
+  viewer->addDimensionDelta(createLinearDimension(lastTemp, temp, SbColor(clR, clG, clB)));
 }
 
 SoNode* PartGui::createLinearDimension(const gp_Pnt &point1, const gp_Pnt &point2, const SbColor &color)
@@ -1002,6 +1015,13 @@ void PartGui::goDimensionAngularNoTask(const VectorAdapter &vector1Adapter, cons
     
     dimSys = dimSys.transpose();
   }
+
+  ParameterGrp::handle hPartGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Mod/Part"); 
+  QString clCone = QString::fromStdString(hPartGrp->GetASCII("DimensionAngularColor", "0.0/0.0/1.0")); 
+  QStringList clRGB = clCone.split(QLatin1String("/"));
+  float clR = clRGB.value(0).toFloat();
+  float clG = clRGB.value(1).toFloat();
+  float clB = clRGB.value(2).toFloat();
   
   DimensionAngular *dimension = new DimensionAngular();
   dimension->ref();
@@ -1009,7 +1029,7 @@ void PartGui::goDimensionAngularNoTask(const VectorAdapter &vector1Adapter, cons
   dimension->radius.setValue(radius);
   dimension->angle.setValue(static_cast<float>(displayAngle));
   dimension->text.setValue((Base::Quantity(180 * angle / M_PI, Base::Unit::Angle)).getUserString().toUtf8().constData());
-  dimension->dColor.setValue(SbColor(0.0, 0.0, 1.0));
+  dimension->dColor.setValue(SbColor(clR, clG, clB));
   dimension->setupDimension();
   
   Gui::View3DInventorViewer *viewer = getViewer();


### PR DESCRIPTION
Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT]

See [https://forum.freecadweb.org/viewtopic.php?f=13&p=299228](url)  // Is german, sorry!

To use it:

`hPartGrp = FreeCAD.ParamGet('User parameter:BaseApp/Preferences/Mod/Part')
hPartGrp.SetString('DimensionConeColor', '1.0/0.0/1.0')
hPartGrp.SetString('DimensionLinearColor', '1.0/1.0/0.0')
hPartGrp.SetString('DimensionAngularColor', '0.0/1.0/`

I know that is not the best solution. But the demand is not high. 

And please remember to update the Wiki with the features added or changed once this PR is merged.



---
