### PR TITLE
Build with Multiple Processes, decreases the build time

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1180,6 +1180,9 @@ IF(MSVC)
     IF(FREECAD_RELEASE_SEH)
 		SET (CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /EHa")
     ENDIF(FREECAD_RELEASE_SEH)
+    # set "Build with Multiple Processes"
+    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP")
+	SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /MP")
 
 	# Mark 32 bit executables large address aware so they can use > 2GB address space
 	# NOTE: This setting only has an effect on machines with at least 3GB of RAM, although it sets the linker option it doesn't set the linker switch 'Enable Large Addresses'


### PR DESCRIPTION
Add this compiler flag decreases the build time. Made tests on two systems:
First system: 
Time Elapsed 00:54:16.04 without /MP 
Time Elapsed 00:38:42.81 with /MP
Second system: 
Time Elapsed 00:24:32.34 without /MP 
Time Elapsed 00:14:09.22 with /MP