### PR TITLE
GH PR Template: Update with link to 0.19 Release Notes forum thread for devs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,6 +5,7 @@ Thank you for creating a pull request to contribute to FreeCAD! To ease integrat
 - [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
 - [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists
 
-And please remember to update the Wiki with the features added or changed once this PR is merged.
+And please remember to update the Wiki with the features added or changed once this PR is merged.  
+**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).
 
 ---


### PR DESCRIPTION
Involving the devs in documentation of their contributions is sorely needed and thanks to @joelgraff who is spearheading better changelog documentation for 0.19 through a forum thread. Now devs can post their contributions and a volunteers can update the 0.19 changelog. 

Discussion thread: https://forum.freecadweb.org/viewtopic.php?f=10&t=34586&p=299976#p299976