### PR TITLE
TestDraft: Fix testRotate and testOffset cases

### DIFF
--- a/src/Mod/Draft/TestDraft.py
+++ b/src/Mod/Draft/TestDraft.py
@@ -123,12 +123,14 @@ class DraftTest(unittest.TestCase):
     def testRotate(self):
         FreeCAD.Console.PrintLog ('Checking Draft Rotate...\n')
         l = Draft.makeLine(FreeCAD.Vector(2,0,0),FreeCAD.Vector(4,0,0))
+        FreeCAD.ActiveDocument.recompute()
         Draft.rotate(l,90)
         self.assertTrue(l.Start.isEqual(FreeCAD.Vector(0,2,0), 1e-12),"Draft Rotate failed")
 
     def testOffset(self):
         FreeCAD.Console.PrintLog ('Checking Draft Offset...\n')
         r = Draft.makeRectangle(4,2)
+        FreeCAD.ActiveDocument.recompute()
         r2 = Draft.offset(r,FreeCAD.Vector(-1,-1,0),copy=True)
         self.failUnless(r2,"Draft Offset failed")
 


### PR DESCRIPTION
Wire needs to be recomputed to update it's dimensions.

This fixes the following test errors:
```
======================================================================
ERROR: testOffset (TestDraft.DraftTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/tyszja/dev/FreeCAD/build/Mod/Draft/TestDraft.py", line 134, in testOffset
    r2 = Draft.offset(r,FreeCAD.Vector(-1,-1,0),copy=True)
  File "/home/tyszja/dev/FreeCAD/build/Mod/Draft/Draft.py", line 1879, in offset
    newwire = DraftGeomUtils.offsetWire(obj.Shape,delta)
  File "/home/tyszja/dev/FreeCAD/build/Mod/Draft/DraftGeomUtils.py", line 1198, in offsetWire
    e = edges[0]
IndexError: list index out of range

======================================================================
FAIL: testRotate (TestDraft.DraftTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/tyszja/dev/FreeCAD/build/Mod/Draft/TestDraft.py", line 129, in testRotate
    self.assertTrue(l.Start.isEqual(FreeCAD.Vector(0,2,0), 1e-12),"Draft Rotate failed")
AssertionError: Draft Rotate failed

----------------------------------------------------------------------
```