### PR TITLE
Fix trivial typo on italian translation for 'Draft' workbench

### DIFF
--- a/src/Mod/Draft/Resources/translations/Draft_it.ts
+++ b/src/Mod/Draft/Resources/translations/Draft_it.ts
@@ -750,7 +750,7 @@ http://www.freecadweb.org/wiki/Dxf_Importer_Install</translation>
     <message>
       <location filename="../../DraftGui.py" line="2361"/>
       <source>X factor</source>
-      <translation>Fatttore X</translation>
+      <translation>Fattore X</translation>
     </message>
     <message>
       <location filename="../../DraftGui.py" line="2362"/>


### PR DESCRIPTION
While testing 0.19 pre-release, I found and fixed a trivial typo on 'Draft' workbench translation for italian users.