### PR TITLE
Fix selection problem in Front view

### DIFF
--- a/src/Mod/TechDraw/Gui/QGIPrimPath.cpp
+++ b/src/Mod/TechDraw/Gui/QGIPrimPath.cpp
@@ -240,4 +240,5 @@ void QGIPrimPath::mousePressEvent(QGraphicsSceneMouseEvent * event)
             Base::Console().Log("QGIPP::mousePressEvent - no QGIView parent\n");
         }
     }
+    QGraphicsPathItem::mousePressEvent(event);
 }

--- a/src/Mod/TechDraw/Gui/QGIView.cpp
+++ b/src/Mod/TechDraw/Gui/QGIView.cpp
@@ -192,11 +192,7 @@ void QGIView::mousePressEvent(QGraphicsSceneMouseEvent * event)
 {
     signalSelectPoint(this, event->pos());
 
-    if(m_locked) {
-        event->ignore();
-    } else {
-      QGraphicsItem::mousePressEvent(event);
-    }
+    QGraphicsItemGroup::mousePressEvent(event);
 }
 
 void QGIView::mouseMoveEvent(QGraphicsSceneMouseEvent * event)


### PR DESCRIPTION
New Balloon feature was stealing mouse clicks from Front View in Projection Group.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
