### PR TITLE
make the /mp compile flag optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1180,10 +1180,14 @@ IF(MSVC)
     IF(FREECAD_RELEASE_SEH)
 		SET (CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /EHa")
     ENDIF(FREECAD_RELEASE_SEH)
+  
+  OPTION(MP_COMPILE_FLAG "Add /MP flag to the compiler definitions. Speeds up the compile on multi processor machines" OFF)
+  if( MP_COMPILE_FLAG )
     # set "Build with Multiple Processes"
     SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP")
-	SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /MP")
-
+    SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /MP")
+  endif()
+  
 	# Mark 32 bit executables large address aware so they can use > 2GB address space
 	# NOTE: This setting only has an effect on machines with at least 3GB of RAM, although it sets the linker option it doesn't set the linker switch 'Enable Large Addresses'
 	IF(CMAKE_SIZEOF_VOID_P EQUAL 4)


### PR DESCRIPTION
According to this discussion (https://forum.freecadweb.org/viewtopic.php?f=4&t=34708&p=300038#p300038)
The /MP compile flag is now optional, otherwise the builds seems to be slower on AppVeyor.
To activate call: "cmake -DMP_COMPILE_FLAG=ON"