### PR TITLE
Fix Draft.getSVG for TechDraw DraftView

### DIFF
--- a/src/Mod/Draft/getSVG.py
+++ b/src/Mod/Draft/getSVG.py
@@ -177,11 +177,10 @@ def getSVG(obj,scale=1,linewidth=0.35,fontsize=12,fillstyle="shape color",direct
                             elif len(e.Vertexes) == 1 and isellipse:
                                 #svg = getEllipse(e)
                                 #return svg
-                                endpoints = (getProj(c.value((c.LastParameter-\
-                                        c.FirstParameter)/2.0), plane), \
-                                        getProj(vs[-1].Point, plane))
+                                endpoints = [getProj(c.value((c.LastParameter-c.FirstParameter)/2.0), plane),
+                                             getProj(vs[-1].Point, plane)]
                             else:
-                                endpoints = (getProj(vs[-1].Point), plane)
+                                endpoints = [getProj(vs[-1].Point, plane)]
                             # arc
                             if iscircle:
                                 rx = ry = c.Radius


### PR DESCRIPTION
[Forum discussion](https://www.forum.freecadweb.org/viewtopic.php?f=3&t=35621#p301011url)

Draft.getSvg.py fails due to use of tuple where list expected.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
