### PR TITLE
Path: Prefer Shape.tessellate() over MeshPart.meshFromShape() to tess…

### DIFF
--- a/src/Mod/Path/PathScripts/PathSurface.py
+++ b/src/Mod/Path/PathScripts/PathSurface.py
@@ -25,6 +25,7 @@
 from __future__ import print_function
 
 import FreeCAD
+import Mesh
 import MeshPart
 # import Part
 import Path
@@ -140,8 +141,15 @@ class ObjectSurface(PathOp.ObjectOp):
                 except AttributeError:
                     import PathScripts.PathPreferences as PathPreferences
                     deflection = PathPreferences.defaultGeometryTolerance()
-                base.Shape.tessellate(0.5)
-                mesh = MeshPart.meshFromShape(base.Shape, Deflection=deflection)
+                tessellation = base.Shape.tessellate(0.5)
+                faces = []
+                for triangle in tessellation[1]:
+                    face = []
+                    for i in range(3):
+                        vindex = triangle[i]
+                        face.append(tessellation[0][vindex])
+                    faces.append(face)
+                mesh = Mesh.Mesh(faces)
             if obj.BoundBox == "BaseBoundBox":
                 bb = mesh.BoundBox
             else:


### PR DESCRIPTION
…elate surfaces.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---

Hey,

this is a bit of a mixture between a bug report and a patch, so apologies if I'm screwing up the process a bit.

I have a fairly simple workpiece:
![Screenshot from 2019-04-17 22-34-42](https://user-images.githubusercontent.com/51410/56320480-9838e480-6164-11e9-9960-1e4b541d5291.png)

And wanted to create milling toolpaths using the experimental 3d surface feature. However, the result was pretty terrible: (the grey shape shows the mesh returned by `meshFromShape()`, the black area is a hole with z = 0)
![Screenshot from 2019-04-17 22-31-19](https://user-images.githubusercontent.com/51410/56320171-c9fd7b80-6163-11e9-98cb-de3143aad9a7.png)

A better result can be obtained by changing the `Deviation` parameter, although I had to do that by editing the source since I did not find a GUI element to change that parameter. However, even doing that the result still looked inferior to the mesh returned by `shape.tessellate(0.5)`. Here's the result after applying this PR:

![Screenshot from 2019-04-17 22-28-52](https://user-images.githubusercontent.com/51410/56320094-a33f4500-6163-11e9-8f0e-fc1bab2d78be.png)

Of course, I don't really have any other test pieces for this code change, so if this screws up meshing for some other shapes it might be better to instead expose the `Deviation` parameter(s) so that they can be adjusted by the user.