### PR TITLE
TD: add DialogBox for Balloon

### DIFF
--- a/src/Mod/TechDraw/App/DrawViewBalloon.h
+++ b/src/Mod/TechDraw/App/DrawViewBalloon.h
@@ -72,13 +72,14 @@ public:
         return "TechDrawGui::ViewProviderBalloon";
     }
 
+    static const char* balloonTypeEnums[];
+    static const char* endTypeEnums[];
+
 protected:
     void onChanged(const App::Property* prop);
     virtual void onDocumentRestored();
 
 private:
-    static const char* endTypeEnums[];
-    static const char* balloonTypeEnums[];
 };
 
 } //namespace TechDraw

--- a/src/Mod/TechDraw/Gui/CMakeLists.txt
+++ b/src/Mod/TechDraw/Gui/CMakeLists.txt
@@ -39,6 +39,7 @@ set(TechDrawGui_MOC_HDRS
     DlgTemplateField.h
     TaskSectionView.h
     TaskGeomHatch.h
+    DlgBalloon.h
 )
 
 fc_wrap_cpp(TechDrawGui_MOC_SRCS ${TechDrawGui_MOC_HDRS})
@@ -58,6 +59,7 @@ set(TechDrawGui_UIC_SRCS
     DlgTemplateField.ui
     TaskSectionView.ui
     TaskGeomHatch.ui
+    DlgBalloon.ui
 )
 
 if(BUILD_QT5)
@@ -97,6 +99,9 @@ SET(TechDrawGui_SRCS
     TaskSectionView.ui
     TaskSectionView.cpp
     TaskSectionView.h
+    DlgBalloon.ui
+    DlgBalloon.cpp
+    DlgBalloon.h
     TaskGeomHatch.ui
     TaskGeomHatch.cpp
     TaskGeomHatch.h

--- a/src/Mod/TechDraw/Gui/DlgBalloon.cpp
+++ b/src/Mod/TechDraw/Gui/DlgBalloon.cpp
@@ -1,0 +1,92 @@
+/***************************************************************************
+ *   Copyright (c) 2019 Franck Jullien <franck.jullien@gmail.com>          *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+
+#include "PreCompiled.h"
+#include <Base/Console.h>
+#include "DlgBalloon.h"
+
+using namespace TechDrawGui;
+
+DlgBalloon::DlgBalloon( QWidget *parent /* = nullptr */ ) :
+    QDialog(parent)
+{
+    setupUi(this);
+    inputValue->setFocus();
+}
+
+void DlgBalloon::changeEvent(QEvent *e)
+{
+    if (e->type() == QEvent::LanguageChange) {
+        retranslateUi(this);
+    }
+    else {
+        QWidget::changeEvent(e);
+    }
+}
+
+void DlgBalloon::setValue(std::string value)
+{
+    QString qs = QString::fromUtf8(value.data(), value.size());
+    inputValue->setText(qs);
+}
+
+QString DlgBalloon::getValue(void)
+{
+    return inputValue->text();
+}
+
+void DlgBalloon::setScale(double value)
+{
+    QString qs = QString::number(value, 'f', 2);
+    inputScale->setText(qs);
+}
+
+double DlgBalloon::getScale(void)
+{
+    return inputScale->text().toDouble();
+}
+
+void DlgBalloon::accept()
+{
+    QDialog::accept();
+}
+
+void DlgBalloon::reject()
+{
+    QDialog::reject();
+}
+
+void DlgBalloon::populateComboBox(QComboBox *box, const char **values, const char *setVal)
+{
+    QStringList symbols;
+    int i = 0;
+
+    while (values[i] != NULL)
+        symbols << QString::fromUtf8(values[i++]);
+
+    box->addItems(symbols);
+    i = box->findText(QString::fromUtf8(setVal));
+    box->setCurrentIndex(i);
+}
+
+#include <Mod/TechDraw/Gui/moc_DlgBalloon.cpp>

--- a/src/Mod/TechDraw/Gui/DlgBalloon.h
+++ b/src/Mod/TechDraw/Gui/DlgBalloon.h
@@ -1,0 +1,58 @@
+ /**************************************************************************
+ *   Copyright (c) 2019 Franck Jullien <franck.jullien@gmail.com>          *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+
+#ifndef DRAWINGGUI_DLGBALLOON_H
+#define DRAWINGGUI_DLGBALLOON_H
+
+#include <QDialog>
+#include <QString>
+
+#include <Mod/TechDraw/Gui/ui_DlgBalloon.h>
+
+namespace TechDrawGui {
+
+class DlgBalloon : public QDialog, public Ui_dlgBalloon
+{
+    Q_OBJECT
+
+public:
+    DlgBalloon( QWidget *parent = nullptr );
+    virtual ~DlgBalloon() = default;
+
+    void setValue(std::string value);
+    QString getValue(void);
+    void setScale(double value);
+    double getScale(void);
+    void populateComboBox(QComboBox *box, const char **values, const char *setVal);
+
+public Q_SLOTS:
+    void accept();
+    void reject();
+
+protected:
+    void changeEvent(QEvent *e);
+};
+
+} // namespace TechDrawGui
+
+#endif // DRAWINGGUI_DLGBALLOON_H

--- a/src/Mod/TechDraw/Gui/DlgBalloon.ui
+++ b/src/Mod/TechDraw/Gui/DlgBalloon.ui
@@ -1,0 +1,140 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>TechDrawGui::dlgBalloon</class>
+ <widget class="QDialog" name="TechDrawGui::dlgBalloon">
+  <property name="windowModality">
+   <enum>Qt::ApplicationModal</enum>
+  </property>
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>420</width>
+    <height>208</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Change Balloon Properties</string>
+  </property>
+  <property name="modal">
+   <bool>true</bool>
+  </property>
+  <layout class="QGridLayout" name="gridLayout_2">
+   <item row="0" column="0">
+    <widget class="QFrame" name="frame">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::StyledPanel</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Raised</enum>
+     </property>
+     <layout class="QGridLayout" name="gridLayout">
+      <item row="0" column="0">
+       <layout class="QVBoxLayout" name="verticalLayout">
+        <item>
+         <layout class="QFormLayout" name="formLayout">
+          <item row="0" column="0">
+           <widget class="QLabel" name="label">
+            <property name="text">
+             <string>Value:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QLineEdit" name="inputValue"/>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="label_2">
+            <property name="text">
+             <string>Symbol:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QComboBox" name="comboSymbol"/>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="label_3">
+            <property name="text">
+             <string>End Type:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QComboBox" name="comboEndType"/>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="label_4">
+            <property name="text">
+             <string>Scale:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <widget class="QLineEdit" name="inputScale"/>
+          </item>
+         </layout>
+        </item>
+        <item>
+         <widget class="QDialogButtonBox" name="bbButtons">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="standardButtons">
+           <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+          </property>
+          <property name="centerButtons">
+           <bool>false</bool>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <layoutdefault spacing="6" margin="9"/>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>bbButtons</sender>
+   <signal>accepted()</signal>
+   <receiver>TechDrawGui::dlgBalloon</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>209</x>
+     <y>126</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>209</x>
+     <y>79</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>bbButtons</sender>
+   <signal>rejected()</signal>
+   <receiver>TechDrawGui::dlgBalloon</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>209</x>
+     <y>126</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>209</x>
+     <y>79</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/src/Mod/TechDraw/Gui/QGIViewBalloon.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewBalloon.cpp
@@ -69,12 +69,46 @@
 #include "QGVPage.h"
 #include "MDIViewPage.h"
 
+#include "DlgBalloon.h"
+
 #define PI  3.14159
 
 //TODO: hide the Qt coord system (+y down).  
 
 using namespace TechDraw;
 using namespace TechDrawGui;
+
+QRectF QGIBalloonLabel::boundingRect() const
+{
+    return childrenBoundingRect();
+}
+
+void QGIBalloonLabel::mouseDoubleClickEvent(QGraphicsSceneMouseEvent * event)
+{
+    DlgBalloon ui;
+
+    /* Populate Text */
+    ui.setValue(parent->dvBalloon->Text.getValue());
+
+    /* Populate symbol */
+    ui.populateComboBox(ui.comboSymbol, DrawViewBalloon::balloonTypeEnums, parent->dvBalloon->Symbol.getValueAsString());
+ 
+    /* Populate End Type */
+    ui.populateComboBox(ui.comboEndType, DrawViewBalloon::endTypeEnums, parent->dvBalloon->EndType.getValueAsString());
+
+    /* Populate scale */
+    ui.setScale(parent->dvBalloon->SymbolScale.getValue());
+
+    if (ui.exec() == QDialog::Accepted) {
+        parent->dvBalloon->Text.setValue(ui.getValue().toUtf8().constData());
+        parent->dvBalloon->SymbolScale.setValue(ui.getScale());
+        parent->dvBalloon->EndType.setValue(ui.comboEndType->currentText().toUtf8().constData());
+        parent->dvBalloon->Symbol.setValue(ui.comboSymbol->currentText().toUtf8().constData());
+        parent->updateView(true);
+    }
+
+    QGraphicsItem::mouseDoubleClickEvent(event);
+}
 
 //**************************************************************
 QGIViewBalloon::QGIViewBalloon() :
@@ -85,7 +119,9 @@ QGIViewBalloon::QGIViewBalloon() :
     setFlag(QGraphicsItem::ItemIsMovable, false);
     setCacheMode(QGraphicsItem::NoCache);
 
-    balloonLabel = new QGIDatumLabel();
+    balloonLabel = new QGIBalloonLabel();
+    balloonLabel->parent = this;
+
     addToGroup(balloonLabel);
     balloonLabel->setColor(getNormalColor());
     balloonLabel->setPrettyNormal();

--- a/src/Mod/TechDraw/Gui/QGIViewBalloon.h
+++ b/src/Mod/TechDraw/Gui/QGIViewBalloon.h
@@ -52,6 +52,21 @@ class QGIArrow;
 class QGIDimLines;
 class QGIViewBalloon;
 
+class QGIBalloonLabel : public QGIDatumLabel
+{
+Q_OBJECT
+
+public:
+    enum {Type = QGraphicsItem::UserType + 141};
+    int type() const override { return Type;}
+
+    virtual QRectF boundingRect() const override;
+    QGIViewBalloon *parent;
+
+protected:
+    virtual void mouseDoubleClickEvent(QGraphicsSceneMouseEvent *event) override;
+};
+
 //*******************************************************************
 
 class TechDrawGuiExport QGIViewBalloon : public QGIView
@@ -96,7 +111,7 @@ protected:
 
 protected:
     bool hasHover;
-    QGIDatumLabel* balloonLabel;
+    QGIBalloonLabel* balloonLabel;
     QGIDimLines* balloonLines;
     QGIDimLines* balloonShape;
     QGIArrow* arrow;


### PR DESCRIPTION
When double-click on a Balloon label, you can now change its Text,
Symbol, End Type and Scale.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
