### PR TITLE
Crowdin: experiment to fix crowdin 'ghost' strings

### DIFF
--- a/src/Mod/Arch/Resources/translations/Arch.ts
+++ b/src/Mod/Arch/Resources/translations/Arch.ts
@@ -259,7 +259,7 @@
     </message>
     <message>
         <location filename="../../ArchPanel.py" line="1213"/>
-        <source>The position of the tag text. Keep (0,0,0) for automatic center position</source>
+        <source>The position of the tag text. Keep (0,0,0) for center position</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2744,7 +2744,7 @@ Building creation aborted.</source>
     <message>
         <location filename="../../ArchFloor.py" line="101"/>
         <source>You can put anything but the following objects: Site, Building, and Floor - in a Floor object.
-Floor object is not allowed to accept Site or Building objects.
+Floor object is not allowed to accept Site, Building, or Floor objects.
 Site, Building, and Floor objects will be removed from the selection.
 You can change that in the preferences.</source>
         <translation type="unfinished"></translation>


### PR DESCRIPTION
The following translation strings still perpetuate after updating crowdin translations. This commit experiments with removing their source counterparts in the FC .ts files. I'm not sure why they are not rendered obsolete by the normal operations. 
  
* https://crowdin.com/translate/freecad/6766/en-en#6499472  
* https://crowdin.com/translate/freecad/6766/en-en#6573450