### PR TITLE
importDXF draftWPlane Fix

### DIFF
--- a/src/Mod/Draft/importDXF.py
+++ b/src/Mod/Draft/importDXF.py
@@ -50,10 +50,14 @@ CURRENTDXFLIB = 1.40 # the minimal version of the dxfLibrary needed to run
 
 import six
 
-import sys, FreeCAD, os, Part, math, re, string, Mesh, Draft, DraftVecUtils, DraftGeomUtils
+import sys, FreeCAD, os, Part, math, re, string, Mesh, Draft, DraftVecUtils, DraftGeomUtils, WorkingPlane
 from Draft import _Dimension, _ViewProviderDimension
 from FreeCAD import Vector
 
+# sets the default working plane
+plane = WorkingPlane.plane()
+FreeCAD.DraftWorkingPlane = plane
+	
 gui = FreeCAD.GuiUp
 draftui = None
 if gui:

--- a/src/Mod/Draft/importDXF.py
+++ b/src/Mod/Draft/importDXF.py
@@ -54,9 +54,10 @@ import sys, FreeCAD, os, Part, math, re, string, Mesh, Draft, DraftVecUtils, Dra
 from Draft import _Dimension, _ViewProviderDimension
 from FreeCAD import Vector
 
-# sets the default working plane
-plane = WorkingPlane.plane()
-FreeCAD.DraftWorkingPlane = plane
+# sets the default working plane if Draft hasn't been started yet
+if not hasattr(FreeCAD,"DraftWorkingPlane"):
+    plane = WorkingPlane.plane()
+    FreeCAD.DraftWorkingPlane = plane
 	
 gui = FreeCAD.GuiUp
 draftui = None


### PR DESCRIPTION
To fix error:
    w.Placement = placementFromDXFOCS(polyline)
  File "E:\Data\My Downloads\FreeCAD_0.19.16587_x64_Conda_Py3QT5-WinVS2015\FreeCAD_0.19.16587_x64_Conda_Py3QT5-WinVS2015\Mod\Draft\importDXF.py", line 422, in placementFromDXFOCS
    draftWPlane = FreeCAD.DraftWorkingPlane
<class 'AttributeError'>: module 'FreeCAD' has no attribute 'DraftWorkingPlane'

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
