### PR TITLE
Path: refactor PathEngrave.py

### DIFF
--- a/src/Mod/Path/PathScripts/PathEngrave.py
+++ b/src/Mod/Path/PathScripts/PathEngrave.py
@@ -30,7 +30,6 @@ import PathScripts.PathEngraveBase as PathEngraveBase
 import PathScripts.PathLog as PathLog
 import PathScripts.PathOp as PathOp
 import PathScripts.PathUtils as PathUtils
-import traceback
 
 from PySide import QtCore
 
@@ -42,24 +41,26 @@ if False:
 else:
     PathLog.setLevel(PathLog.Level.INFO, PathLog.thisModule())
 
+
 # Qt tanslation handling
 def translate(context, text, disambig=None):
     return QtCore.QCoreApplication.translate(context, text, disambig)
+
 
 class ObjectEngrave(PathEngraveBase.ObjectOp):
     '''Proxy class for Engrave operation.'''
 
     def opFeatures(self, obj):
         '''opFeatures(obj) ... return all standard features and edges based geomtries'''
-        return PathOp.FeatureTool | PathOp.FeatureDepths | PathOp.FeatureHeights | PathOp.FeatureStepDown | PathOp.FeatureBaseEdges;
+        return PathOp.FeatureTool | PathOp.FeatureDepths | PathOp.FeatureHeights | PathOp.FeatureStepDown | PathOp.FeatureBaseEdges
 
     def setupAdditionalProperties(self, obj):
         if not hasattr(obj, 'BaseShapes'):
             obj.addProperty("App::PropertyLinkList", "BaseShapes", "Path", QtCore.QT_TRANSLATE_NOOP("PathEngrave", "Additional base objects to be engraved"))
-        obj.setEditorMode('BaseShapes', 2) # hide
+        obj.setEditorMode('BaseShapes', 2)  # hide
         if not hasattr(obj, 'BaseObject'):
             obj.addProperty("App::PropertyLink", "BaseObject", "Path", QtCore.QT_TRANSLATE_NOOP("PathEngrave", "Additional base objects to be engraved"))
-        obj.setEditorMode('BaseObject', 2) # hide
+        obj.setEditorMode('BaseObject', 2)  # hide
 
     def initOperation(self, obj):
         '''initOperation(obj) ... create engraving specific properties.'''
@@ -74,99 +75,72 @@ class ObjectEngrave(PathEngraveBase.ObjectOp):
         '''opExecute(obj) ... process engraving operation'''
         PathLog.track()
 
-        job = PathUtils.findParentJob(obj)
-
         jobshapes = []
-        zValues = self.getZValues(obj)
 
-        try:
-            if len(self.model) == 1 and self.model[0].isDerivedFrom('Sketcher::SketchObject') or \
-                    self.model[0].isDerivedFrom('Part::Part2DObject') or \
-                    hasattr(self.model[0], 'ArrayType'):
-                PathLog.track()
+        if len(obj.Base) >= 1:  # user has selected specific subelements
+            wires = []
+            for base, subs in obj.Base:
+                edges = []
+                basewires = []
+                for feature in subs:
+                    sub = base.Shape.getElement(feature)
+                    if type(sub) == Part.Edge:
+                        edges.append(sub)
+                    elif sub.Wires:
+                        basewires.extend(sub.Wires)
+                    else:
+                        basewires.append(Part.Wire(sub.Edges))
 
+                for edgelist in Part.sortEdges(edges):
+                    basewires.append(Part.Wire(edgelist))
+
+                wires.extend(basewires)
+                jobshapes.append(Part.makeCompound(wires))
+
+        else:  # Use the Job Base object
+            for base in self.model:
+                PathLog.track(base.Label)
+                if base.isDerivedFrom('Part::Part2DObject'):
+                    jobshapes.append(base.Shape)
+                elif base.isDerivedFrom('Sketcher::SketchObject'):
+                    jobshapes.append(base.Shape)
+                elif hasattr(base, 'ArrayType'):
+                    jobshapes.append(base.Shape)
+                elif isinstance(base.Proxy, ArchPanel.PanelSheet):
+                    for tag in self.model[0].Proxy.getTags(self.model[0], transform=True):
+                        tagWires = []
+                        for w in tag.Wires:
+                            tagWires.append(Part.Wire(w.Edges))
+                        jobshapes.append(Part.makeCompound(tagWires))
+
+        if len(jobshapes) > 0:
+            PathLog.debug('processing {} jobshapes'.format(len(jobshapes)))
+            PathLog.track()
+            wires = []
+            for shape in jobshapes:
+                PathLog.debug('jobshape has {} edges'.format(len(shape.Edges)))
                 self.commandlist.append(Path.Command('G0', {'Z': obj.ClearanceHeight.Value, 'F': self.vertRapid}))
-
-                # we only consider the outer wire if this is a Face
-                wires = []
-                for w in self.model[0].Shape.Wires:
-                    wires.append(Part.Wire(w.Edges))
-                self.buildpathocc(obj, wires, zValues)
-                self.wires = wires
-
-            elif len(self.model) == 1 and isinstance(self.model[0].Proxy, ArchPanel.PanelSheet):  # process the sheet
-                PathLog.track()
-                wires = []
-                for tag in self.model[0].Proxy.getTags(self.model[0], transform=True):
-                    self.commandlist.append(Path.Command('G0', {'Z': obj.ClearanceHeight.Value, 'F': self.vertRapid}))
-                    tagWires = []
-                    for w in tag.Wires:
-                        tagWires.append(Part.Wire(w.Edges))
-                    self.buildpathocc(obj, tagWires, zValues)
-                    wires.extend(tagWires)
-                self.wires = wires
-            elif obj.Base:
-                PathLog.track()
-                wires = []
-                for base, subs in obj.Base:
-                    edges = []
-                    basewires = []
-                    for feature in subs:
-                        sub = base.Shape.getElement(feature)
-                        if type(sub) == Part.Edge:
-                            edges.append(sub)
-                        elif sub.Wires:
-                            basewires.extend(sub.Wires)
-                        else:
-                            basewires.append(Part.Wire(sub.Edges))
-
-                    for edgelist in Part.sortEdges(edges):
-                        basewires.append(Part.Wire(edgelist))
-
-                    wires.extend(basewires)
-                self.buildpathocc(obj, wires, zValues)
-                self.wires = wires
-            elif not obj.BaseShapes:
-                PathLog.track()
-                if not obj.Base and not obj.BaseShapes:
-                    for base in self.model:
-                        PathLog.track(base.Label)
-                        if base.isDerivedFrom('Part::Part2DObject'):
-                            jobshapes.append(base)
-
-                if not jobshapes:
-                    raise ValueError(translate('PathEngrave', "Unknown baseobject type for engraving (%s)") % (obj.Base))
-
-            if obj.BaseShapes or jobshapes:
-                PathLog.track()
-                wires = []
-                for shape in obj.BaseShapes + jobshapes:
-                    PathLog.track(shape.Label)
-                    shapeWires = shape.Shape.Wires
-                    self.buildpathocc(obj, shapeWires, zValues)
-                    wires.extend(shapeWires)
-                self.wires = wires
-            # the last command is a move to clearance, which is automatically added by PathOp
-            if self.commandlist:
-                self.commandlist.pop()
-
-        except Exception as e:
-            PathLog.error(e)
-            traceback.print_exc()
-            PathLog.error(translate('PathEngrave', 'The Job Base Object has no engraveable element.  Engraving operation will produce no output.'))
+                shapeWires = shape.Wires
+                self.buildpathocc(obj, shape.Wires, self.getZValues(obj))
+                wires.extend(shapeWires)
+            self.wires = wires
+        # the last command is a move to clearance, which is automatically added by PathOp
+        if self.commandlist:
+            self.commandlist.pop()
 
     def opUpdateDepths(self, obj, ignoreErrors=False):
         '''updateDepths(obj) ... engraving is always done at the top most z-value'''
         job = PathUtils.findParentJob(obj)
         self.opSetDefaultValues(obj, job)
 
-def SetupProperties():
-    return [ "StartVertex" ]
 
-def Create(name, obj = None):
+def SetupProperties():
+    return ["StartVertex"]
+
+
+def Create(name, obj=None):
     '''Create(name) ... Creates and returns an Engrave operation.'''
     if obj is None:
         obj = FreeCAD.ActiveDocument.addObject("Path::FeaturePython", name)
     proxy = ObjectEngrave(obj, name)
     return obj
-


### PR DESCRIPTION
Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---

There's several edge cases in PathEngrave that aren't being handled correctly.  
If a user selects individual segments from a shapestring, the whole shapestring is processed anyway.

This PR cleans up some of the code in the OpExecute method.  It still doesn't correctly handle all cases and may require PathEngraveBase.buildpathocc() method to be revised. 

Review needed.
