### PR TITLE
When generating python modules using fcbt.py, use FreeCAD.getUserAppDataDir() rather than FreeCAD.getHomePath()

### DIFF
--- a/src/Tools/_TEMPLATEPY_/InitGui.py
+++ b/src/Tools/_TEMPLATEPY_/InitGui.py
@@ -5,7 +5,7 @@
 
 class _TEMPLATEPY_Workbench ( Workbench ):
     "_TEMPLATEPY_ workbench object"
-    Icon = FreeCAD.getHomePath() + "Mod/_TEMPLATEPY_/Resources/icons/_TEMPLATEPY_Workbench.svg"
+    Icon = FreeCAD.getUserAppDataDir() + "Mod/_TEMPLATEPY_/Resources/icons/_TEMPLATEPY_Workbench.svg"
     MenuText = "_TEMPLATEPY_"
     ToolTip = "_TEMPLATEPY_ workbench"
     


### PR DESCRIPTION
Hi and thanks for a great project!

I just created my first python module for FreeCAD using fcbt.py, following the tutorial here:

https://www.freecadweb.org/wiki/Module_Creation

In general, it worked fine, but the icon could not be loaded. This is because I'm using the AppImage version of freecad, and the icon was loaded relative to FreeCAD.getHomePath(). I poked around among the existing modules and found:

https://github.com/edwardvmills/Silk/blob/master/InitGui.py

Where it loads the icon relative to FreeCAD.getUserAppDataDir(). When I changed my module to do the same it worked, and the icon could be loaded.

This PR changes the template for the python module created using fcbt.py, so the icon will be loaded relative to FreeCAD.getUserAppDataDir()