### PR TITLE
units, add Fracture Toughness = MPa*m^0.5

### DIFF
--- a/src/App/FreeCADInit.py
+++ b/src/App/FreeCADInit.py
@@ -364,6 +364,9 @@ App.Units.UltimateTensileStrength = App.Units.Unit(-1,1,-2)
 App.Units.YieldStrength           = App.Units.Unit(-1,1,-2)
 App.Units.YoungsModulus           = App.Units.Unit(-1,1,-2)
 
+# FractureToughness
+App.Units.FractureToughness       = App.Units.Unit(-0.5,1,-2)
+
 App.Units.Force         = App.Units.Unit(1,1,-2) 
 App.Units.Work          = App.Units.Unit(2,1,-2) 
 App.Units.Power         = App.Units.Unit(2,1,-3) 

--- a/src/Base/Unit.cpp
+++ b/src/Base/Unit.cpp
@@ -441,6 +441,7 @@ QString Unit::getTypeString(void) const
     if(*this == Unit::AmountOfSubstance           )       return QString::fromLatin1("AmountOfSubstance");
     if(*this == Unit::LuminousIntensity           )       return QString::fromLatin1("LuminousIntensity");
     if(*this == Unit::Pressure                    )       return QString::fromLatin1("Pressure");
+    if(*this == Unit::FractureToughness           )       return QString::fromLatin1("FractureToughness");
     if(*this == Unit::Force                       )       return QString::fromLatin1("Force");
     if(*this == Unit::Work                        )       return QString::fromLatin1("Work");
     if(*this == Unit::Power                       )       return QString::fromLatin1("Power");
@@ -486,6 +487,9 @@ Unit Unit::Stress                  (-1,1,-2);
 Unit Unit::UltimateTensileStrength (-1,1,-2);
 Unit Unit::YieldStrength           (-1,1,-2);
 Unit Unit::YoungsModulus           (-1,1,-2);
+
+// FractureToughness MPa * m^0.5 = kg/m*s^2 * m^0.5 = kg / (m^0.5 * s^2)
+Unit Unit:: FractureToughness      (-0.5,1,-2);
 
 Unit Unit::Force   (1,1,-2);
 Unit Unit::Work    (2,1,-2);

--- a/src/Base/Unit.h
+++ b/src/Base/Unit.h
@@ -134,6 +134,9 @@ public:
     static Unit DynamicViscosity;
     static Unit KinematicViscosity;
 
+    // FractureToughness
+    static Unit FractureToughness;
+
     //@}
 protected:
     UnitSignature Sig;

--- a/src/Base/UnitsSchemaInternal.cpp
+++ b/src/Base/UnitsSchemaInternal.cpp
@@ -163,6 +163,10 @@ QString UnitsSchemaInternal::schemaTranslate(const Quantity &quant, double &fact
             factor = 0.001;
         }
     }
+    else if (unit == Unit::FractureToughness) {
+        unitString = QString::fromLatin1("MPa*m^0.5");
+        factor = 1000.0 * pow(1000.0, 0.5);  // MPa = * 1000 and m^0.5 = * 1000^0.5
+    }
     else if (unit == Unit::Power) {
         unitString = QString::fromLatin1("W");
         factor = 1000000;


### PR DESCRIPTION
I tried to implement a new unit for Fracture Toughness. I would have merged it myself, but the new unit fails :-( ... 

```
>>> 
>>> from FreeCAD import Units
>>> getattr(FreeCAD.Units, 'FractureToughness')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: module 'Units' has no attribute 'FractureToughness'
>>> 
```

https://en.wikipedia.org/wiki/Fracture_toughness
https://de.wikipedia.org/wiki/Bruchz%C3%A4higkeit
