### PR TITLE
[Sketcher] Fix initial autoconstraints behavior

### DIFF
--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -301,7 +301,7 @@ ViewProviderSketch::ViewProviderSketch()
         this->RestoreCamera.setValue(hGrp->GetBool("RestoreCamera", true));
 
         // well it is not visibility automation but a good place nevertheless
-        this->Autoconstraints.setValue(hGrp->GetBool("AutoConstraints",false));
+        this->Autoconstraints.setValue(hGrp->GetBool("AutoConstraints", true));
     }
 
     sPixmap = "Sketcher_Sketch";


### PR DESCRIPTION
Problem:
In Sketcher GUI checkbox "Auto constraints" is selected by default, but program think that it's not selected.
Result:
Program will think that "Auto constraints" enabled by default.
