### PR TITLE
[Sketcher] Allow externals from other body

### DIFF
--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -2807,7 +2807,7 @@ bool SketchObject::isExternalAllowed(App::Document *pDoc, App::DocumentObject *p
         } else {
             if (rsn)
                 *rsn = rlOtherBody;
-            return false;
+            return allowOtherBody;
         }
     }
     else {


### PR DESCRIPTION
Problem:
For multi-body projects it is more user-friendly and usable to allow externals from another bodies.
Solution:
Return allowOtherBody value to make this feature configurable. 
