### PR TITLE
increased default snapRange from 5 to 8

### DIFF
--- a/src/Mod/Draft/DraftGui.py
+++ b/src/Mod/Draft/DraftGui.py
@@ -655,7 +655,7 @@ class DraftToolBar:
         self.layout.addLayout(gl)
         self.snapLabel = self._label("snapLabel", gl)
         self.snapValue = self._spinbox("snapValue", gl)
-        self.snapValue.setValue(Draft.getParam("snapRange",5))
+        self.snapValue.setValue(Draft.getParam("snapRange", 8))
 
         # spacer
         if not self.taskmode:
@@ -1007,7 +1007,7 @@ class DraftToolBar:
         self.centerPlane.show()
         self.snapLabel.show()
         self.snapValue.show()
-        p = Draft.getParam("snapRange",5)
+        p = Draft.getParam("snapRange", 8)
         self.snapValue.setValue(p)
 
     def extraLineUi(self):
@@ -2133,7 +2133,7 @@ class DraftToolBar:
 
     def toggleradius(self,val):
         if hasattr(FreeCADGui,"Snapper"):
-            par = Draft.getParam("snapRange",10)
+            par = Draft.getParam("snapRange", 8)
             Draft.setParam("snapRange",par+val)
             FreeCADGui.Snapper.showradius()
 

--- a/src/Mod/Draft/DraftSnap.py
+++ b/src/Mod/Draft/DraftSnap.py
@@ -195,7 +195,7 @@ class Snapper:
         self.setTrackers()
 
         # getting current snap Radius
-        self.radius =  self.getScreenDist(Draft.getParam("snapRange",5),screenpos)
+        self.radius =  self.getScreenDist(Draft.getParam("snapRange", 8),screenpos)
         if self.radiusTracker:
             self.radiusTracker.update(self.radius)
             self.radiusTracker.off()
@@ -1360,7 +1360,7 @@ class Snapper:
 
     def showradius(self):
         "shows the snap radius indicator"
-        self.radius =  self.getScreenDist(Draft.getParam("snapRange",10),(400,300))
+        self.radius =  self.getScreenDist(Draft.getParam("snapRange", 8),(400,300))
         if self.radiusTracker:
             self.radiusTracker.update(self.radius)
             self.radiusTracker.on()

--- a/src/Mod/Draft/DraftTrackers.py
+++ b/src/Mod/Draft/DraftTrackers.py
@@ -736,7 +736,7 @@ class PlaneTracker(Tracker):
         # getting screen distance
         p1 = Draft.get3DView().getPoint((100,100))
         p2 = Draft.get3DView().getPoint((110,100))
-        bl = (p2.sub(p1)).Length * (Draft.getParam("snapRange",5)/2)
+        bl = (p2.sub(p1)).Length * (Draft.getParam("snapRange", 8)/2)
         pick = coin.SoPickStyle()
         pick.style.setValue(coin.SoPickStyle.UNPICKABLE)
         self.trans = coin.SoTransform()


### PR DESCRIPTION
Grid snapping will fail with a snapRange of 5 if a line or arc passes through the grid point.

https://forum.freecadweb.org/viewtopic.php?f=23&t=36335