### PR TITLE
Fix draft missing line tracker when snapper detects an object without any snap targets

### DIFF
--- a/src/Mod/Draft/DraftGui.py
+++ b/src/Mod/Draft/DraftGui.py
@@ -1875,69 +1875,70 @@ class DraftToolBar:
     def displayPoint(self, point=None, last=None, plane=None, mask=None):
         "this function displays the passed coords in the x, y, and z widgets"
 
-        if (not self.taskmode) or self.isTaskOn:
+        if self.taskmode and (not self.isTaskOn):
+            return
 
-            # get coords to display
-            dp = None
-            if point:
-                dp = point
-                if self.relativeMode and (last != None):
-                    if plane:
-                        dp = plane.getLocalRot(FreeCAD.Vector(point.x-last.x, point.y-last.y, point.z-last.z))
-                    else:
-                        dp = FreeCAD.Vector(point.x-last.x, point.y-last.y, point.z-last.z)
-                elif plane:
-                    dp = plane.getLocalCoords(point)
-
-            # set widgets
-            if dp:
-                if self.mask in ['y','z']:
-                    self.xValue.setText(displayExternal(dp.x,None,'Length'))
+        # get coords to display
+        dp = None
+        if point:
+            dp = point
+            if self.relativeMode and (last != None):
+                if plane:
+                    dp = plane.getLocalRot(FreeCAD.Vector(point.x-last.x, point.y-last.y, point.z-last.z))
                 else:
-                    self.xValue.setText(displayExternal(dp.x,None,'Length'))
-                if self.mask in ['x','z']:
-                    self.yValue.setText(displayExternal(dp.y,None,'Length'))
-                else:
-                    self.yValue.setText(displayExternal(dp.y,None,'Length'))
-                if self.mask in ['x','y']:
-                    self.zValue.setText(displayExternal(dp.z,None,'Length'))
-                else:
-                    self.zValue.setText(displayExternal(dp.z,None,'Length'))
+                    dp = FreeCAD.Vector(point.x-last.x, point.y-last.y, point.z-last.z)
+            elif plane:
+                dp = plane.getLocalCoords(point)
 
-            # set length and angle
-            if last and dp and plane:
-                self.lengthValue.setText(displayExternal(dp.Length,None,'Length'))
-                a = math.degrees(-DraftVecUtils.angle(dp,plane.u,plane.axis))
-                if not self.angleLock.isChecked():
-                    self.angleValue.setText(displayExternal(a,None,'Angle'))
-                if not mask:
-                    # automask
-                    if a in [0,180,-180]:
-                        mask = "x"
-                    elif a in [90,270,-90]:
-                        mask = "y"
-
-            # set masks
-            if (mask == "x") or (self.mask == "x"):
-                self.xValue.setEnabled(True)
-                self.yValue.setEnabled(False)
-                self.zValue.setEnabled(False)
-                self.setFocus()
-            elif (mask == "y") or (self.mask == "y"):
-                self.xValue.setEnabled(False)
-                self.yValue.setEnabled(True)
-                self.zValue.setEnabled(False)
-                self.setFocus("y")
-            elif (mask == "z") or (self.mask == "z"):
-                self.xValue.setEnabled(False)
-                self.yValue.setEnabled(False)
-                self.zValue.setEnabled(True)
-                self.setFocus("z")
+        # set widgets
+        if dp:
+            if self.mask in ['y','z']:
+                self.xValue.setText(displayExternal(dp.x,None,'Length'))
             else:
-                self.xValue.setEnabled(True)
-                self.yValue.setEnabled(True)
-                self.zValue.setEnabled(True)
-                self.setFocus()
+                self.xValue.setText(displayExternal(dp.x,None,'Length'))
+            if self.mask in ['x','z']:
+                self.yValue.setText(displayExternal(dp.y,None,'Length'))
+            else:
+                self.yValue.setText(displayExternal(dp.y,None,'Length'))
+            if self.mask in ['x','y']:
+                self.zValue.setText(displayExternal(dp.z,None,'Length'))
+            else:
+                self.zValue.setText(displayExternal(dp.z,None,'Length'))
+
+        # set length and angle
+        if last and dp and plane:
+            self.lengthValue.setText(displayExternal(dp.Length,None,'Length'))
+            a = math.degrees(-DraftVecUtils.angle(dp,plane.u,plane.axis))
+            if not self.angleLock.isChecked():
+                self.angleValue.setText(displayExternal(a,None,'Angle'))
+            if not mask:
+                # automask
+                if a in [0,180,-180]:
+                    mask = "x"
+                elif a in [90,270,-90]:
+                    mask = "y"
+
+        # set masks
+        if (mask == "x") or (self.mask == "x"):
+            self.xValue.setEnabled(True)
+            self.yValue.setEnabled(False)
+            self.zValue.setEnabled(False)
+            self.setFocus()
+        elif (mask == "y") or (self.mask == "y"):
+            self.xValue.setEnabled(False)
+            self.yValue.setEnabled(True)
+            self.zValue.setEnabled(False)
+            self.setFocus("y")
+        elif (mask == "z") or (self.mask == "z"):
+            self.xValue.setEnabled(False)
+            self.yValue.setEnabled(False)
+            self.zValue.setEnabled(True)
+            self.setFocus("z")
+        else:
+            self.xValue.setEnabled(True)
+            self.yValue.setEnabled(True)
+            self.zValue.setEnabled(True)
+            self.setFocus()
 
 
     def getDefaultColor(self,type,rgb=False):

--- a/src/Mod/Draft/DraftSnap.py
+++ b/src/Mod/Draft/DraftSnap.py
@@ -225,9 +225,8 @@ class Snapper:
         point = self.getApparentPoint(screenpos[0],screenpos[1])
 
         # setup a track line if we got a last point
-        if lastpoint:
-            if self.trackLine:
-                self.trackLine.p1(lastpoint)
+        if lastpoint and self.trackLine:
+            self.trackLine.p1(lastpoint)
 
         # checking if parallel to one of the edges of the last objects or to a polar direction
         if active:
@@ -286,12 +285,10 @@ class Snapper:
                 return self.spoint
 
         if not active:
-
             # passive snapping
             snaps = [self.snapToVertex(self.snapInfo)]
 
         else:
-
             # first stick to the snapped object
             s = self.snapToVertex(self.snapInfo)
             if s:
@@ -383,6 +380,9 @@ class Snapper:
         if not snaps:
             self.spoint = self.cstr(lastpoint, constrain, point)
             self.running = False
+            if self.trackLine and lastpoint:
+                self.trackLine.p2(self.spoint)
+                self.trackLine.on()
             return self.spoint
 
         # calculating the nearest snap point


### PR DESCRIPTION
Basically the snapper is called to draw the line tracker. When the snapper comes across another object, it attempts to snap to objects. During the snap to objects function, it makes a list of things it can snap to (vertices, edges, etc), but if it doesn't find anything (because there isn't anything, or because all your snaps are disabled in your settings), then it doesn't bother to draw the line tracker. The actual fix is only a few lines, L383-385 in DraftSnap.py.

The reason this PR is quite big is because as I was reading through the logic to make the PR, I did some code cleanup:

 - Predicates in if-statements that could be simplified, were simplified
 - As above, if I could return the function early, in order to prevent code indentation, then I did so
 - Functions are reordered so that they are ordered in the same order that they are called, to make it more natural to read

The code cleanup only contains one refactor, and therefore only improves readability but does not change any flow or scope of logic.