### PR TITLE
[Draft] Respawn working plane grid when you start a new document

### DIFF
--- a/src/Mod/Draft/DraftSnap.py
+++ b/src/Mod/Draft/DraftSnap.py
@@ -1466,8 +1466,3 @@ class Snapper:
 
 if not hasattr(FreeCADGui,"Snapper"):
     FreeCADGui.Snapper = Snapper()
-if not hasattr(FreeCAD,"DraftWorkingPlane"):
-    import WorkingPlane, Draft_rc
-    FreeCAD.DraftWorkingPlane = WorkingPlane.plane()
-    #print(FreeCAD.DraftWorkingPlane)
-    FreeCADGui.addIconPath(":/icons")

--- a/src/Mod/Draft/WorkingPlane.py
+++ b/src/Mod/Draft/WorkingPlane.py
@@ -40,6 +40,12 @@ __url__ = "http://www.freecadweb.org"
 This module provides a class called plane to assist in selecting and maintaining a working plane.
 '''
 
+class WorkingPlaneDocumentObserver():
+    def slotCreatedDocument(self, doc):
+        if FreeCAD.GuiUp:
+            import FreeCADGui
+            FreeCADGui.runCommand('Draft_ToggleGrid')
+
 class plane:
     '''A WorkPlane object'''
 
@@ -55,6 +61,10 @@ class plane:
         self.position = pos
         # a placeholder for a stored state
         self.stored = None
+
+        if not hasattr(FreeCAD, "WorkingPlaneDocumentObserver"):
+            self.WorkingPlaneDocumentObserver = WorkingPlaneDocumentObserver()
+            FreeCAD.addDocumentObserver(self.WorkingPlaneDocumentObserver)
 
     def __repr__(self):
         return "Workplane x="+str(DraftVecUtils.rounded(self.u))+" y="+str(DraftVecUtils.rounded(self.v))+" z="+str(DraftVecUtils.rounded(self.axis))


### PR DESCRIPTION
Also, grid is init from both drafttools and draftsnap: only one init is necessary so I've removed the one in draftsnap.

https://forum.freecadweb.org/viewtopic.php?f=23&t=36503