### PR TITLE
Let getSupport() check if WP mode is set to auto before changing WP needlessly

### DIFF
--- a/src/Mod/Draft/DraftTools.py
+++ b/src/Mod/Draft/DraftTools.py
@@ -136,34 +136,54 @@ def getPoint(target,args,mobile=False,sym=False,workingplane=True,noTracker=Fals
     else: ui.displayPoint(point, plane=plane, mask=mask)
     return point,ctrlPoint,info
 
-def getSupport(args=None):
+def getSupport(mouseEvent=None):
     "returns the supporting object and sets the working plane"
-    if not args:
-        sel = FreeCADGui.Selection.getSelectionEx()
-        if len(sel) == 1:
-            sel = sel[0]
-            if sel.HasSubObjects:
-                if len(sel.SubElementNames) == 1:
-                    if "Face" in sel.SubElementNames[0]:
-                        if plane.weak:
-                            plane.alignToFace(sel.SubObjects[0])
-                        return sel.Object
+    plane.save()
+    if mouseEvent:
+        return setWorkingPlaneToObjectUnderCursor(mouseEvent)
+    return setWorkingPlaneToSelectedObject()
+
+def setWorkingPlaneToObjectUnderCursor(mouseEvent):
+    objectUnderCursor = Draft.get3DView().getObjectInfo((
+        mouseEvent["Position"][0],
+        mouseEvent["Position"][1]))
+
+    if not objectUnderCursor:
         return None
 
-    snapped = Draft.get3DView().getObjectInfo((args["Position"][0],args["Position"][1]))
-    if not snapped: return None
-    obj = None
-    plane.save()
     try:
-        obj = FreeCAD.ActiveDocument.getObject(snapped['Object'])
-        shape = obj.Shape
-        component = getattr(shape,snapped["Component"])
-        if plane.alignToFace(component, 0) \
-                or plane.alignToCurve(component, 0):
-            self.display(plane.axis)
+        componentUnderCursor = getattr(
+            FreeCAD.ActiveDocument.getObject(
+                objectUnderCursor['Object']
+                ).Shape,
+            objectUnderCursor["Component"])
+
+        if not plane.weak:
+            return None
+
+        if "Face" in objectUnderCursor["Component"]:
+            plane.alignToFace(componentUnderCursor)
+        else:
+            plane.alignToCurve(componentUnderCursor)
+        plane.weak = True
+        return objectUnderCursor
     except:
         pass
-    # don't set the object's support if we are in the middle of an operation
+
+    return None
+
+def setWorkingPlaneToSelectedObject():
+    sel = FreeCADGui.Selection.getSelectionEx()
+    if len(sel) != 1:
+        return None
+    sel = sel[0]
+    if sel.HasSubObjects \
+        and len(sel.SubElementNames) == 1 \
+        and "Face" in sel.SubElementNames[0]:
+        if plane.weak:
+            plane.alignToFace(sel.SubObjects[0])
+            plane.weak = True
+        return sel.Object
     return None
 
 def hasMod(args,mod):


### PR DESCRIPTION
Also refactor getSupport() function to be a little bit more semantic and reduce nested if statements so logic is clearer.

To check that it all works as expected, I tested working plane "auto" mode behaviour as follows:

 1. Set to auto.
 2. The simplest case is that it sets the working plane to current "View" rotation of the viewport.
 3. If you have a face selected already, it will set the WP to that face when you draft your new objects
 4. Otherwise, if you begin drafting, but start drafting on an existing object's face, the WP will match that face's alignment

If you WP mode is not on "auto", it will stay on whatever you set to WP to and will not change (which was what the report on the forum was all about).

https://forum.freecadweb.org/viewtopic.php?f=23&t=36508