### PR TITLE
GestureNavigationStyle logging

### DIFF
--- a/src/Gui/GestureNavigationStyle.cpp
+++ b/src/Gui/GestureNavigationStyle.cpp
@@ -227,6 +227,7 @@ public:
 
 public:
     virtual void processEvent(NS::Event& ev) {
+        ev.log();
         this->process_event(ev);
     }
 };
@@ -239,6 +240,7 @@ public:
     IdleState(my_context ctx):my_base(ctx)
     {
         this->outermost_context().ns.setViewingMode(NavigationStyle::IDLE);
+        Base::Console().Log(" -> IdleState\n");
     }
     virtual ~IdleState(){}
 
@@ -493,6 +495,7 @@ public:
     {
         this->outermost_context().ns.setViewingMode(NavigationStyle::DRAGGING);
         this->base_pos = static_cast<const NS::Event*>(this->triggering_event())->inventor_event->getPosition();
+        Base::Console().Log(" -> RotateState\n");
     }
     virtual ~RotateState(){}
 
@@ -534,6 +537,7 @@ public:
         auto &ns = this->outermost_context().ns;
         ns.setViewingMode(NavigationStyle::PANNING);
         this->base_pos = static_cast<const NS::Event*>(this->triggering_event())->inventor_event->getPosition();
+        Base::Console().Log(" -> PanState\n");
         this->ratio = ns.viewer->getSoRenderManager()->getViewportRegion().getViewportAspectRatio();
         ns.pan(ns.viewer->getSoRenderManager()->getCamera());//set up panningplane
     }
@@ -579,6 +583,7 @@ public:
         auto &ns = this->outermost_context().ns;
         ns.setViewingMode(NavigationStyle::PANNING);
         this->base_pos = static_cast<const NS::Event*>(this->triggering_event())->inventor_event->getPosition();
+        Base::Console().Log(" -> StickyPanState\n");
         this->ratio = ns.viewer->getSoRenderManager()->getViewportRegion().getViewportAspectRatio();
         ns.pan(ns.viewer->getSoRenderManager()->getCamera());//set up panningplane
     }
@@ -623,6 +628,7 @@ public:
         auto &ns = this->outermost_context().ns;
         ns.setViewingMode(NavigationStyle::DRAGGING);
         this->base_pos = static_cast<const NS::Event*>(this->triggering_event())->inventor_event->getPosition();
+        Base::Console().Log(" -> TiltState\n");
         ns.pan(ns.viewer->getSoRenderManager()->getCamera());//set up panningplane
     }
     virtual ~TiltState(){}
@@ -671,6 +677,7 @@ public:
         auto &ns = this->outermost_context().ns;
         ns.setViewingMode(NavigationStyle::PANNING);
         this->base_pos = static_cast<const NS::Event*>(this->triggering_event())->inventor_event->getPosition();
+        Base::Console().Log(" -> GestureState\n");
         ns.pan(ns.viewer->getSoRenderManager()->getCamera());//set up panningplane
         this->ratio = ns.viewer->getSoRenderManager()->getViewportRegion().getViewportAspectRatio();
         enableTilt = !(App::GetApplication().GetParameterGroupByPath
@@ -747,6 +754,7 @@ public:
 public:
     AwaitingReleaseState(my_context ctx):my_base(ctx)
     {
+        Base::Console().Log(" -> AwaitingReleaseState\n");
     }
     virtual ~AwaitingReleaseState(){}
 
@@ -796,6 +804,7 @@ public:
     {
         auto &ns = this->outermost_context().ns;
         ns.setViewingMode(NavigationStyle::INTERACT);
+        Base::Console().Log(" -> InteractState\n");
     }
     virtual ~InteractState(){}
 
@@ -957,9 +966,11 @@ void GestureNavigationStyle::onRollGesture(int direction)
 {
     std::string cmd;
     if (direction == +1){
+        Base::Console().Log("Roll forward gesture\n");
         cmd = App::GetApplication().GetParameterGroupByPath
             ("User parameter:BaseApp/Preferences/View")->GetASCII("GestureRollFwdCommand");
     } else if (direction == -1) {
+        Base::Console().Log("Roll backward gesture\n");
         cmd = App::GetApplication().GetParameterGroupByPath
             ("User parameter:BaseApp/Preferences/View")->GetASCII("GestureRollBackCommand");
     }
@@ -991,6 +1002,8 @@ void GestureNavigationStyle::EventQueue::post(const NS::Event& ev)
 {
     ev.flags->processed = true;
     this->push(*ev.asMouseButtonEvent());
+    Base::Console().Log("postponed: ");
+    ev.log();
 }
 
 void GestureNavigationStyle::EventQueue::discardAll()

--- a/src/Gui/GestureNavigationStyle.cpp
+++ b/src/Gui/GestureNavigationStyle.cpp
@@ -227,7 +227,8 @@ public:
 
 public:
     virtual void processEvent(NS::Event& ev) {
-        ev.log();
+        if (ns.logging)
+            ev.log();
         this->process_event(ev);
     }
 };
@@ -239,8 +240,10 @@ public:
 
     IdleState(my_context ctx):my_base(ctx)
     {
-        this->outermost_context().ns.setViewingMode(NavigationStyle::IDLE);
-        Base::Console().Log(" -> IdleState\n");
+        auto &ns = this->outermost_context().ns;
+        ns.setViewingMode(NavigationStyle::IDLE);
+        if (ns.logging)
+            Base::Console().Log(" -> IdleState\n");
     }
     virtual ~IdleState(){}
 
@@ -357,6 +360,8 @@ public:
     AwaitingMoveState(my_context ctx):my_base(ctx)
     {
         auto &ns = this->outermost_context().ns;
+        if (ns.logging)
+            Base::Console().Log(" -> AwaitingMoveState\n");
         ns.setViewingMode(NavigationStyle::IDLE);
         this->base_pos = static_cast<const NS::Event*>(this->triggering_event())->inventor_event->getPosition();
         this->since = static_cast<const NS::Event*>(this->triggering_event())->inventor_event->getTime();
@@ -493,9 +498,11 @@ private:
 public:
     RotateState(my_context ctx):my_base(ctx)
     {
-        this->outermost_context().ns.setViewingMode(NavigationStyle::DRAGGING);
+        auto &ns = this->outermost_context().ns;
+        ns.setViewingMode(NavigationStyle::DRAGGING);
         this->base_pos = static_cast<const NS::Event*>(this->triggering_event())->inventor_event->getPosition();
-        Base::Console().Log(" -> RotateState\n");
+        if (ns.logging)
+            Base::Console().Log(" -> RotateState\n");
     }
     virtual ~RotateState(){}
 
@@ -537,7 +544,8 @@ public:
         auto &ns = this->outermost_context().ns;
         ns.setViewingMode(NavigationStyle::PANNING);
         this->base_pos = static_cast<const NS::Event*>(this->triggering_event())->inventor_event->getPosition();
-        Base::Console().Log(" -> PanState\n");
+        if (ns.logging)
+            Base::Console().Log(" -> PanState\n");
         this->ratio = ns.viewer->getSoRenderManager()->getViewportRegion().getViewportAspectRatio();
         ns.pan(ns.viewer->getSoRenderManager()->getCamera());//set up panningplane
     }
@@ -583,7 +591,8 @@ public:
         auto &ns = this->outermost_context().ns;
         ns.setViewingMode(NavigationStyle::PANNING);
         this->base_pos = static_cast<const NS::Event*>(this->triggering_event())->inventor_event->getPosition();
-        Base::Console().Log(" -> StickyPanState\n");
+        if (ns.logging)
+            Base::Console().Log(" -> StickyPanState\n");
         this->ratio = ns.viewer->getSoRenderManager()->getViewportRegion().getViewportAspectRatio();
         ns.pan(ns.viewer->getSoRenderManager()->getCamera());//set up panningplane
     }
@@ -628,7 +637,8 @@ public:
         auto &ns = this->outermost_context().ns;
         ns.setViewingMode(NavigationStyle::DRAGGING);
         this->base_pos = static_cast<const NS::Event*>(this->triggering_event())->inventor_event->getPosition();
-        Base::Console().Log(" -> TiltState\n");
+        if (ns.logging)
+            Base::Console().Log(" -> TiltState\n");
         ns.pan(ns.viewer->getSoRenderManager()->getCamera());//set up panningplane
     }
     virtual ~TiltState(){}
@@ -677,7 +687,8 @@ public:
         auto &ns = this->outermost_context().ns;
         ns.setViewingMode(NavigationStyle::PANNING);
         this->base_pos = static_cast<const NS::Event*>(this->triggering_event())->inventor_event->getPosition();
-        Base::Console().Log(" -> GestureState\n");
+        if (ns.logging)
+            Base::Console().Log(" -> GestureState\n");
         ns.pan(ns.viewer->getSoRenderManager()->getCamera());//set up panningplane
         this->ratio = ns.viewer->getSoRenderManager()->getViewportRegion().getViewportAspectRatio();
         enableTilt = !(App::GetApplication().GetParameterGroupByPath
@@ -754,7 +765,9 @@ public:
 public:
     AwaitingReleaseState(my_context ctx):my_base(ctx)
     {
-        Base::Console().Log(" -> AwaitingReleaseState\n");
+        auto &ns = this->outermost_context().ns;
+        if (ns.logging)
+            Base::Console().Log(" -> AwaitingReleaseState\n");
     }
     virtual ~AwaitingReleaseState(){}
 
@@ -804,7 +817,8 @@ public:
     {
         auto &ns = this->outermost_context().ns;
         ns.setViewingMode(NavigationStyle::INTERACT);
-        Base::Console().Log(" -> InteractState\n");
+        if (ns.logging)
+            Base::Console().Log(" -> InteractState\n");
     }
     virtual ~InteractState(){}
 
@@ -831,6 +845,8 @@ GestureNavigationStyle::GestureNavigationStyle()
     : naviMachine(new NS::NaviMachine(*this)),
       postponedEvents(*this)
 {
+    this->logging = App::GetApplication().GetParameterGroupByPath
+                ("User parameter:BaseApp/Preferences/View")->GetBool("NavigationDebug");
     mouseMoveThreshold = QApplication::startDragDistance();
     naviMachine->initiate();
 
@@ -966,11 +982,13 @@ void GestureNavigationStyle::onRollGesture(int direction)
 {
     std::string cmd;
     if (direction == +1){
-        Base::Console().Log("Roll forward gesture\n");
+        if (logging)
+            Base::Console().Log("Roll forward gesture\n");
         cmd = App::GetApplication().GetParameterGroupByPath
             ("User parameter:BaseApp/Preferences/View")->GetASCII("GestureRollFwdCommand");
     } else if (direction == -1) {
-        Base::Console().Log("Roll backward gesture\n");
+        if (logging)
+            Base::Console().Log("Roll backward gesture\n");
         cmd = App::GetApplication().GetParameterGroupByPath
             ("User parameter:BaseApp/Preferences/View")->GetASCII("GestureRollBackCommand");
     }
@@ -1002,8 +1020,10 @@ void GestureNavigationStyle::EventQueue::post(const NS::Event& ev)
 {
     ev.flags->processed = true;
     this->push(*ev.asMouseButtonEvent());
-    Base::Console().Log("postponed: ");
-    ev.log();
+    if (ns.logging){
+        Base::Console().Log("postponed: ");
+        ev.log();
+    }
 }
 
 void GestureNavigationStyle::EventQueue::discardAll()

--- a/src/Gui/GestureNavigationStyle.h
+++ b/src/Gui/GestureNavigationStyle.h
@@ -96,6 +96,7 @@ protected: // members variables
     int mouseMoveThreshold = 5;
     ///used by roll gesture detection logic, in AwaitingMoveState and AwaitingReleaseState.
     int rollDir = 0;
+    bool logging = false;
 
 protected: //helper functions
     bool isDraggerUnderCursor(SbVec2s pos);


### PR DESCRIPTION
chrisb has a problem with gesture zoom on mac. I want to see what's going on.
https://forum.freecadweb.org/viewtopic.php?f=9&t=36387

To debug issues other people have, I make the logging optional (when it's enabled, it pollutes report view quite substantially). To enable logging, execute:

App.ParamGet("User parameter:BaseApp/Preferences/View").SetBool("NavigationDebug",True)