### PR TITLE
TechDraw: Fix font size issues when exporting to SVG

### DIFF
--- a/src/Mod/TechDraw/Gui/DlgPrefsTechDraw.ui
+++ b/src/Mod/TechDraw/Gui/DlgPrefsTechDraw.ui
@@ -707,7 +707,7 @@
            <string>View Label size in units</string>
           </property>
           <property name="value">
-           <double>6.000000000000000</double>
+           <double>8.000000000000000</double>
           </property>
           <property name="prefEntry" stdset="0">
            <cstring>LabelSize</cstring>

--- a/src/Mod/TechDraw/Gui/DlgPrefsTechDraw2.ui
+++ b/src/Mod/TechDraw/Gui/DlgPrefsTechDraw2.ui
@@ -259,7 +259,7 @@
            <string>Dimension font size in units</string>
           </property>
           <property name="value">
-           <double>3.500000000000000</double>
+           <double>5.000000000000000</double>
           </property>
           <property name="prefEntry" stdset="0">
            <cstring>FontSize</cstring>

--- a/src/Mod/TechDraw/Gui/MDIViewPage.cpp
+++ b/src/Mod/TechDraw/Gui/MDIViewPage.cpp
@@ -1374,4 +1374,13 @@ void MDIViewPage::showStatusMsg(const char* s1, const char* s2, const char* s3) 
     }
 }
 
+MDIViewPage *MDIViewPage::getFromScene(const QGraphicsScene *scene)
+{
+    if (scene != nullptr && scene->parent() != nullptr) {
+        return dynamic_cast<MDIViewPage *>(scene->parent());
+    }
+
+    return nullptr;
+}
+
 #include <Mod/TechDraw/Gui/moc_MDIViewPage.cpp>

--- a/src/Mod/TechDraw/Gui/MDIViewPage.h
+++ b/src/Mod/TechDraw/Gui/MDIViewPage.h
@@ -71,7 +71,7 @@ public:
     void matchSceneRectToTemplate(void);
     
     bool onMsg(const char* pMsg,const char** ppReturn);
-      bool onHasMsg(const char* pMsg) const;
+    bool onHasMsg(const char* pMsg) const;
 
     void print();
     void print(QPrinter* printer);
@@ -100,6 +100,8 @@ public:
     void setTabText(std::string t);
 
     bool addView(const App::DocumentObject *obj);
+
+    static MDIViewPage *getFromScene(const QGraphicsScene *scene);
 
 public Q_SLOTS:
     void viewAll();

--- a/src/Mod/TechDraw/Gui/QGCustomLabel.cpp
+++ b/src/Mod/TechDraw/Gui/QGCustomLabel.cpp
@@ -77,23 +77,5 @@ void QGCustomLabel::paint ( QPainter * painter, const QStyleOptionGraphicsItem *
     QStyleOptionGraphicsItem myOption(*option);
     myOption.state &= ~QStyle::State_Selected;
     
-    //see QGCustomText for explanation of this code
-    double dppt = 3.53;
-    double svgMagicX = Rez::guiX(8.0);
-    double svgMagicY = Rez::guiX(12.0);
-    double svgMagicYoffset = Rez::guiX(3.0);
-    double fontSize = Rez::appX(font().pointSizeF());
-    double ty = svgMagicY + (svgMagicYoffset*fontSize)/dppt;
-    QPointF svgMove(-svgMagicX/dppt,ty);
-
-    QPaintDevice* hw = painter->device();
-    QSvgGenerator* svg = dynamic_cast<QSvgGenerator*>(hw);
-    if (svg) {
-        painter->scale(Rez::appX(dppt),Rez::appX(dppt));
-        painter->translate(svgMove);
-    } else {
-        painter->scale(1.0,1.0);
-    }
-    
     QGraphicsTextItem::paint (painter, &myOption, widget);
 }

--- a/src/Mod/TechDraw/Gui/QGCustomText.cpp
+++ b/src/Mod/TechDraw/Gui/QGCustomText.cpp
@@ -131,32 +131,6 @@ void QGCustomText::paint ( QPainter * painter, const QStyleOptionGraphicsItem * 
     QStyleOptionGraphicsItem myOption(*option);
     myOption.state &= ~QStyle::State_Selected;
 
-    //svg text is much larger than screen text.  scene units(mm or 0.1mm in hirez) vs points.
-    //need to scale text if going to svg.
-    //TODO: magic translation happens. why? approx: right ~8mm  down: 12mm + (3mm per mm of text height)
-    //SVG transform matrix translation values are different for same font size + different fonts (Sans vs Ubuntu vs Arial)???
-    //                     scale values are same for same font size + different fonts.
-    //calculate dots/mm 
-    //in hirez - say factor = 10, we have 10 dpmm in scene space. 
-    //  so 254dpi / 72pts/in  => 3.53 dppt 
-    double dpmm = 3.53;         //dots/pt
-    double svgMagicX = Rez::guiX(8.0);                      //8mm -> 80 gui dots
-    double svgMagicY = Rez::guiX(12.0);
-    double svgMagicYoffset = Rez::guiX(3.0);                // 3mm per mm of font size => 30gunits / mm of font size
-    double fontSize = Rez::appX(font().pointSizeF());       //gui pts 4mm text * 10 scunits/mm = size 40 text but still only 4mm
-    double ty = svgMagicY + (svgMagicYoffset*fontSize)/dpmm;
-                    // 12mm (in gunits) + [3mm (in gunits) * (# of mm)]/ [dots per mm]  works out to dots?
-    QPointF svgMove(-svgMagicX/dpmm,ty);
-
-    QPaintDevice* hw = painter->device();
-    QSvgGenerator* svg = dynamic_cast<QSvgGenerator*>(hw);
-    if (svg) {
-        painter->scale(Rez::appX(dpmm),Rez::appX(dpmm));
-        painter->translate(svgMove);
-    } else {
-        painter->scale(1.0,1.0);
-    }
-
 //    painter->drawRect(boundingRect());          //good for debugging
 
     setDefaultTextColor(m_colCurrent);

--- a/src/Mod/TechDraw/Gui/QGIHighlight.cpp
+++ b/src/Mod/TechDraw/Gui/QGIHighlight.cpp
@@ -84,7 +84,7 @@ void QGIHighlight::makeHighlight()
 void QGIHighlight::makeReference()
 {
     prepareGeometryChange();
-    m_refFont.setPointSize(m_refSize);
+    m_refFont.setPointSizeF(QGIView::calculateFontPointSizeF(this, m_refSize));
     m_reference->setFont(m_refFont);
     m_reference->setPlainText(QString::fromUtf8(m_refText));
     double fudge = Rez::guiX(1.0);

--- a/src/Mod/TechDraw/Gui/QGISectionLine.cpp
+++ b/src/Mod/TechDraw/Gui/QGISectionLine.cpp
@@ -203,7 +203,7 @@ void QGISectionLine::makeSymbolsTrad()
     extLineStart = m_start + offset;
     extLineEnd = m_end + offset;
     prepareGeometryChange();
-    m_symFont.setPointSize(m_symSize);
+    m_symFont.setPointSizeF(QGIView::calculateFontPointSizeF(this, m_symSize));
     m_symbol1->setFont(m_symFont);
     m_symbol1->setPlainText(QString::fromUtf8(m_symbol));
     if (m_arrowDir.y < 0.0) {         //pointing down
@@ -246,7 +246,7 @@ void QGISectionLine::makeSymbolsISO()
     symPosEnd = m_end - offset;
 
     prepareGeometryChange();
-    m_symFont.setPointSize(m_symSize);
+    m_symFont.setPointSizeF(QGIView::calculateFontPointSizeF(this, m_symSize));
     m_symbol1->setFont(m_symFont);
     m_symbol1->setPlainText(QString::fromUtf8(m_symbol));
     m_symbol1->centerAt(symPosStart);

--- a/src/Mod/TechDraw/Gui/QGIView.h
+++ b/src/Mod/TechDraw/Gui/QGIView.h
@@ -111,7 +111,11 @@ public:
     
     static Gui::ViewProvider* getViewProvider(App::DocumentObject* obj);
     static QGVPage* getGraphicsView(TechDraw::DrawView* dv);
+    static double calculateFontPointSizeF(const QGraphicsItem *graphicsItem, double sizeInMillimetres);
+    static const double DefaultFontSizeInMM;
+
     MDIViewPage* getMDIViewPage(void) const;
+
     // Mouse handling
     virtual void mousePressEvent(QGraphicsSceneMouseEvent *event) override;
     boost::signals2::signal<void (QGIView*, QPointF)> signalSelectPoint;
@@ -133,6 +137,8 @@ protected:
 
     QString getPrefFont(void);
     double getPrefFontSize(void);
+    double calculateFontPointSizeF(double sizeInMillimetres) const;
+
     Base::Reference<ParameterGrp> getParmGroupCol(void);
 
     TechDraw::DrawView *viewObj;

--- a/src/Mod/TechDraw/Gui/QGIViewBalloon.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewBalloon.cpp
@@ -181,7 +181,7 @@ void QGIViewBalloon::placeBalloon(QPointF pos)
         balloon->Text.setValue(std::to_string(idx).c_str());
      
         QFont font = balloonLabel->getFont();
-        font.setPointSizeF(Rez::guiX(vp->Fontsize.getValue()));
+        font.setPointSizeF(calculateFontPointSizeF(vp->Fontsize.getValue()));
         font.setFamily(QString::fromUtf8(vp->Font.getValue()));
         balloonLabel->setFont(font);
         prepareGeometryChange();
@@ -263,7 +263,7 @@ void QGIViewBalloon::updateBalloon(bool obtuse)
     }
 
     QFont font = balloonLabel->getFont();
-    font.setPointSizeF(Rez::guiX(vp->Fontsize.getValue()));
+    font.setPointSizeF(calculateFontPointSizeF(vp->Fontsize.getValue()));
     font.setFamily(QString::fromUtf8(vp->Font.getValue()));
     balloonLabel->setFont(font);
 

--- a/src/Mod/TechDraw/Gui/QGIViewDimension.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewDimension.cpp
@@ -402,10 +402,6 @@ void QGIViewDimension::updateView(bool update)
      }
      else if(vp->Fontsize.isTouched() ||
                vp->Font.isTouched()) {
-         QFont font = datumLabel->getFont();
-         font.setPointSizeF(Rez::guiX(vp->Fontsize.getValue()));
-         font.setFamily(QString::fromLatin1(vp->Font.getValue()));
-         datumLabel->setFont(font);
          updateDim();
     } else if (vp->LineWidth.isTouched()) {           //never happens!!
         m_lineWidth = vp->LineWidth.getValue();
@@ -432,10 +428,10 @@ void QGIViewDimension::updateDim(bool obtuse)
     QString labelText = QString::fromUtf8(dim->getFormatedValue(m_obtuse).c_str());
     
     QFont font = datumLabel->getFont();
-    font.setPointSizeF(Rez::guiX(vp->Fontsize.getValue()));
     font.setFamily(QString::fromUtf8(vp->Font.getValue()));
-
+    font.setPointSizeF(calculateFontPointSizeF(this, vp->Fontsize.getValue()));
     datumLabel->setFont(font);
+
     prepareGeometryChange();
     datumLabel->setDimString(labelText);
     datumLabel->setTolString();

--- a/src/Mod/TechDraw/Gui/QGVPage.cpp
+++ b/src/Mod/TechDraw/Gui/QGVPage.cpp
@@ -96,6 +96,7 @@
 #include "ZVALUE.h"
 #include "ViewProviderPage.h"
 #include "QGVPage.h"
+#include "MDIViewPage.h"
 
 using namespace Gui;
 using namespace TechDraw;
@@ -746,7 +747,9 @@ void QGVPage::saveSvg(QString filename)
     // the width and height attributes of the <svg> element."  >> but Inkscape won't read it without size info??
     svgGen.setViewBox(QRect(0, 0, Rez::guiX(page->getPageWidth()), Rez::guiX(page->getPageHeight())));
 
-    svgGen.setResolution(Rez::guiX(25.4));    // docs say this is DPI. Rez::guiX(1dot/mm) so 254 dpi?
+    // Set resolution in DPI. To keep text dimensions as they are on screen,
+    // use the very same resolution the screen paint device reports.
+    svgGen.setResolution(MDIViewPage::getFromScene(scene())->logicalDpiY());
 
     svgGen.setTitle(QObject::tr("FreeCAD SVG Export"));
     svgGen.setDescription(svgDescription);

--- a/src/Mod/TechDraw/Gui/ViewProviderBalloon.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderBalloon.cpp
@@ -70,7 +70,7 @@ ViewProviderBalloon::ViewProviderBalloon()
 
     hGrp = App::GetApplication().GetUserParameter()
                                          .GetGroup("BaseApp")->GetGroup("Preferences")->GetGroup("Mod/TechDraw/Dimensions");
-    double fontSize = hGrp->GetFloat("FontSize", 3.5);
+    double fontSize = hGrp->GetFloat("FontSize", QGIView::DefaultFontSizeInMM);
     ADD_PROPERTY_TYPE(Font ,(fontName.c_str()),group,App::Prop_None, "The name of the font to use");
     ADD_PROPERTY_TYPE(Fontsize,(fontSize)    ,group,(App::PropertyType)(App::Prop_None),"Dimension text size in units");
 

--- a/src/Mod/TechDraw/Gui/ViewProviderDimension.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderDimension.cpp
@@ -60,7 +60,7 @@ ViewProviderDimension::ViewProviderDimension()
 
     hGrp = App::GetApplication().GetUserParameter()
                                          .GetGroup("BaseApp")->GetGroup("Preferences")->GetGroup("Mod/TechDraw/Dimensions");
-    double fontSize = hGrp->GetFloat("FontSize", 3.5);
+    double fontSize = hGrp->GetFloat("FontSize", QGIView::DefaultFontSizeInMM);
     ADD_PROPERTY_TYPE(Font ,(fontName.c_str()),group,App::Prop_None, "The name of the font to use");
     ADD_PROPERTY_TYPE(Fontsize,(fontSize)    ,group,(App::PropertyType)(App::Prop_None),"Dimension text size in units");
 


### PR DESCRIPTION
The texts in TechDraw drawings exported to SVG are slightly shifted and have slightly different sizes. This pull request aims to fix this by correctly computing the font size in points from user settings in mm and stating the exported SVG resolution in DPI is the same as logical screen has.

For more explanation please see the "[Labels are not exported in svg, dimensions are offsetted](https://forum.freecadweb.org/viewtopic.php?f=35&t=27108)" TechDraw Development topic.
