### PR TITLE
Add option to colorize ArchFence

### DIFF
--- a/src/Mod/Arch/ArchFence.py
+++ b/src/Mod/Arch/ArchFence.py
@@ -317,6 +317,18 @@ class _ViewProviderFence(ArchComponent.ViewProviderComponent):
 
     def normalizeColors(self, obj, numberOfFaces):
         colors = obj.ViewObject.DiffuseColor
+
+        if obj.TypeId == 'PartDesign::Body':
+            # When colorizing a PartDesign Body we have two options
+            # 1. The whole body got a shape color, that means the tip has only a single diffuse color set
+            #   so we use the shape color of the body
+            # 2. "Set colors" was called on the tip and the individual faces where colorized.
+            #   We use the diffuseColors of the tip in that case
+            tipColors = obj.Tip.ViewObject.DiffuseColor
+            
+            if len(tipColors) > 1:
+                colors = tipColors
+
         numberOfColors = len(colors)
 
         if numberOfColors == 1:


### PR DESCRIPTION
When "UseOriginalColors" is set to true, the fence will copy the diffuse
colors of the original post and section to colorize itself.


Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [x] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
