### PR TITLE
[Path] fix ProfileFaces limited depth;  fix to remove phantom paths;  proxy improvements

### DIFF
--- a/src/Mod/Path/PathScripts/PathAdaptive.py
+++ b/src/Mod/Path/PathScripts/PathAdaptive.py
@@ -536,5 +536,5 @@ def Create(name, obj = None):
     '''Create(name) ... Creates and returns a Adaptive operation.'''
     if obj is None:
         obj = FreeCAD.ActiveDocument.addObject("Path::FeaturePython", name)
-    proxy = PathAdaptive(obj,name)
+    obj.Proxy = PathAdaptive(obj,name)
     return obj

--- a/src/Mod/Path/PathScripts/PathDrilling.py
+++ b/src/Mod/Path/PathScripts/PathDrilling.py
@@ -135,7 +135,7 @@ def Create(name, obj = None):
     '''Create(name) ... Creates and returns a Drilling operation.'''
     if obj is None:
         obj = FreeCAD.ActiveDocument.addObject("Path::FeaturePython", name)
-    proxy = ObjectDrilling(obj, name)
+    obj.Proxy = ObjectDrilling(obj, name)
     if obj.Proxy:
-        proxy.findAllHoles(obj)
+        obj.Proxy.findAllHoles(obj)
     return obj

--- a/src/Mod/Path/PathScripts/PathJob.py
+++ b/src/Mod/Path/PathScripts/PathJob.py
@@ -409,6 +409,6 @@ def Create(name, base, templateFile = None):
     else:
         models = base
     obj = FreeCAD.ActiveDocument.addObject("Path::FeaturePython", name)
-    proxy = ObjectJob(obj, models, templateFile)
+    obj.Proxy = ObjectJob(obj, models, templateFile)
     return obj
 

--- a/src/Mod/Path/PathScripts/PathJobGui.py
+++ b/src/Mod/Path/PathScripts/PathJobGui.py
@@ -1060,6 +1060,10 @@ class TaskPanel:
             Draft.move(sel.Object, by)
 
     def updateSelection(self):
+        # Remove Job object if present in Selection: source of phantom paths
+        if self.obj in FreeCADGui.Selection.getSelection():
+            FreeCADGui.Selection.removeSelection(self.obj)
+
         sel = FreeCADGui.Selection.getSelectionEx()
 
         if len(sel) == 1 and len(sel[0].SubObjects) == 1:


### PR DESCRIPTION
This PR addresses the following:
- fixes the limited Final Depth issue for PathProfileFaces introduced in PR 2231. See forum topic [Profile Faces: manual Final Depth is limited](https://forum.freecadweb.org/viewtopic.php?f=15&t=37127)
- fixes #4008 in [MantisBT](https://www.freecadweb.org/tracker/view.php?id=4008). Forum discussions are [BUG 4008: crazy path after Setup origin shift](https://forum.freecadweb.org/viewtopic.php?f=15&t=36825) and [Path - Job - setup move creates double path](https://forum.freecadweb.org/viewtopic.php?f=15&t=37123)
- converts additional `proxy` declarations to `obj.Proxy`. @sliptonic suggested this change be made when found in PathWB operations scripts.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
