### PR TITLE
Sketcher: Polyline snap arc to 45 degrees bug fix

### DIFF
--- a/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp
+++ b/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp
@@ -1155,10 +1155,14 @@ public:
                 if(SnapMode == SNAP_MODE_45Degree && Mode != STATUS_Close) {
                     // -360, -315, -270, -225, -180, -135, -90, -45,  0, 45,  90, 135, 180, 225, 270, 315, 360
                     //  N/A,    a, perp,    a,  par,    a,perp,   a,N/A,  a,perp,   a, par,   a,perp,   a, N/A
+
+                    // #3974: if in radians, the printf %f defaults to six decimals, which leads to loss of precision
+                    double arcAngle = abs(round( (endAngle - startAngle) / (M_PI/4)) * 45); // in degrees
+
                     Gui::Command::doCommand(Gui::Command::Doc,
-                                            "App.ActiveDocument.%s.addConstraint(Sketcher.Constraint('Angle',%i,%f)) ",
+                                            "App.ActiveDocument.%s.addConstraint(Sketcher.Constraint('Angle',%i,App.Units.Quantity('%f deg'))) ",
                                             sketchgui->getObject()->getNameInDocument(),
-                                            lastCurve, abs(endAngle-startAngle));
+                                            lastCurve, arcAngle);
                 }
                 if (Mode == STATUS_Close) {
                     // close the loop by constrain to the first curve point


### PR DESCRIPTION
=================================================

fixes #3974

Snapping to 45 degrees during arc creation (hold ctrl during an arc within a polyline), resulted in
reduced precision, because Gui::Command::doCommand %f defaults only to six decimal positions, which is
a poor representation in radians of, for example, 90 degrees.

A work-around could have been to hardcode a higher number of decimals, as in %0.Xf. However, I do not like
such magic numbers.

The solution chosen is to use an App.Quantity object using as units degrees, which leads to no loss of precision.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [x] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
