### PR TITLE
Misc. typo and whitespace fixes

### DIFF
--- a/src/App/MaterialPyImp.cpp
+++ b/src/App/MaterialPyImp.cpp
@@ -33,7 +33,7 @@ using namespace App;
 
 PyObject *MaterialPy::PyMake(struct _typeobject *, PyObject *, PyObject *)  // Python wrapper
 {
-    // create a new instance of MaterialPy and the Twin object 
+    // create a new instance of MaterialPy and the Twin object
     return new MaterialPy(new Material);
 }
 
@@ -45,11 +45,11 @@ int MaterialPy::PyInit(PyObject* args, PyObject* kwds)
     PyObject* specular = 0;
     PyObject* emissive = 0;
     PyObject* shininess = 0;
-    PyObject* transpareny = 0;
+    PyObject* transparency = 0;
     static char* kwds_colors[] = { "DiffuseColor", "AmbientColor", "SpecularColor", "EmissiveColor", "Shininess", "Transparency", NULL };
 
     if (!PyArg_ParseTupleAndKeywords(args, kwds, "|OOOOOO", kwds_colors,
-        &diffuse, &ambient, &specular, &emissive, &shininess, &transpareny))
+        &diffuse, &ambient, &specular, &emissive, &shininess, &transparency))
         return -1;
 
     if (diffuse) {
@@ -72,8 +72,8 @@ int MaterialPy::PyInit(PyObject* args, PyObject* kwds)
         setShininess(Py::Float(shininess));
     }
 
-    if (transpareny) {
-        setTransparency(Py::Float(transpareny));
+    if (transparency) {
+        setTransparency(Py::Float(transparency));
     }
 
     return 0;
@@ -88,8 +88,8 @@ std::string MaterialPy::representation(void) const
 PyObject* MaterialPy::set(PyObject * args)
 {
     char *pstr;
-    if (!PyArg_ParseTuple(args, "s", &pstr))     // convert args: Python->C 
-        return NULL;                             // NULL triggers exception 
+    if (!PyArg_ParseTuple(args, "s", &pstr))     // convert args: Python->C
+        return NULL;                             // NULL triggers exception
 
     getMaterialPtr()->set(pstr);
 
@@ -207,5 +207,5 @@ PyObject *MaterialPy::getCustomAttributes(const char* /*attr*/) const
 
 int MaterialPy::setCustomAttributes(const char* /*attr*/, PyObject* /*obj*/)
 {
-    return 0; 
+    return 0;
 }

--- a/src/Mod/Path/PathScripts/PathAreaOp.py
+++ b/src/Mod/Path/PathScripts/PathAreaOp.py
@@ -386,7 +386,7 @@ class ObjectOp(PathOp.ObjectOp):
                 if obj.StartDepth.Value == obj.OpStartDepth.Value:
                     obj.StartDepth.Value = self.strDep
 
-            # Create visual axises when debugging.
+            # Create visual axes when debugging.
             if PathLog.getLevel(PathLog.thisModule()) == 4:
                 self.visualAxis()
         else:

--- a/src/Mod/Path/PathScripts/PathPocketShape.py
+++ b/src/Mod/Path/PathScripts/PathPocketShape.py
@@ -428,7 +428,7 @@ class ObjectPocket(PathPocketBase.ObjectPocket):
                                     if planar is True:
                                         base = FreeCAD.ActiveDocument.getObject(useFace)
                                         sub = 'Face1'
-                                        PathLog.debug('  -successful face crated: {}'.format(useFace))
+                                        PathLog.debug('  -successful face created: {}'.format(useFace))
                                     else:
                                         PathLog.error(translate("Path", "Failed to create a planar face from edges in {}.".format(sub)))
                                 # --------------------------------------------------------


### PR DESCRIPTION
Found via `codespell -q 3 -I ../fc-word-whitelist.txt -S ./.git,*.po,*.ts,./ChangeLog.txt,./src/3rdParty,./src/Mod/Assembly/App/opendcm,./src/CXX,./src/zipios++,./src/Base/swig*,./src/Mod/Robot/App/kdl_cp,./src/Mod/Import/App/SCL,./src/WindowsInstaller`