### PR TITLE
Sketcher: Mode filter of Elements Widget

### DIFF
--- a/src/Mod/Sketcher/Gui/TaskSketcherElements.cpp
+++ b/src/Mod/Sketcher/Gui/TaskSketcherElements.cpp
@@ -78,7 +78,7 @@ class ElementItem : public QListWidgetItem
 public:
     ElementItem(const QIcon & icon, const QString & text, int elementnr,
                 int startingVertex, int midVertex, int endVertex,
-                Base::Type geometryType)
+                Base::Type geometryType, bool construction, bool external)
         : QListWidgetItem(icon,text)
         , ElementNbr(elementnr)
         , StartingVertex(startingVertex)
@@ -89,12 +89,14 @@ public:
         , isEndPointSelected(false)
         , isMidPointSelected(false)
         , GeometryType(geometryType)
+        , isConstruction(construction)
+        , isExternal(external)
     {
 
     }
     ElementItem(const QString & text,int elementnr,
                 int startingVertex, int midVertex, int endVertex,
-                Base::Type geometryType)
+                Base::Type geometryType, bool construction, bool external)
         : QListWidgetItem(text)
         , ElementNbr(elementnr)
         , StartingVertex(startingVertex)
@@ -105,6 +107,8 @@ public:
         , isEndPointSelected(false)
         , isMidPointSelected(false)
         , GeometryType(geometryType)
+        , isConstruction(construction)
+        , isExternal(external)
     {
 
     }
@@ -121,6 +125,8 @@ public:
     bool isEndPointSelected;
     bool isMidPointSelected;
     Base::Type GeometryType;
+    bool isConstruction;
+    bool isExternal;
 };
 
 ElementView::ElementView(QWidget *parent)
@@ -285,6 +291,10 @@ TaskSketcherElements::TaskSketcherElements(ViewProviderSketch *sketchView)
         this                     , SLOT  (on_listWidgetElements_currentFilterChanged(int))
        );
     QObject::connect(
+        ui->comboBoxModeFilter, SIGNAL(currentIndexChanged(int)),
+        this                     , SLOT  (on_listWidgetElements_currentModeFilterChanged(int))
+    );
+    QObject::connect(
         ui->namingBox, SIGNAL(stateChanged(int)),
         this                     , SLOT  (on_namingBox_stateChanged(int))
        );
@@ -299,6 +309,7 @@ TaskSketcherElements::TaskSketcherElements(ViewProviderSketch *sketchView)
     this->groupLayout()->addWidget(proxy);
 
     ui->comboBoxElementFilter->setCurrentIndex(0);
+    ui->comboBoxModeFilter->setCurrentIndex(0);
 
     ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Mod/Sketcher/Elements");
 
@@ -306,6 +317,7 @@ TaskSketcherElements::TaskSketcherElements(ViewProviderSketch *sketchView)
     ui->namingBox->setChecked(hGrp->GetBool("Extended Naming", false));
 
     ui->comboBoxElementFilter->setEnabled(!isautoSwitchBoxChecked);
+    ui->comboBoxModeFilter->setEnabled(true);
 
     slotElementsChanged();
 }
@@ -687,6 +699,7 @@ void TaskSketcherElements::slotElementsChanged(void)
     ui->listWidgetElements->clear();
 
     int element = ui->comboBoxElementFilter->currentIndex();
+    int mode = ui->comboBoxModeFilter->currentIndex();
 
     int i=1;
     for(std::vector< Part::Geometry * >::const_iterator it= vals.begin();it!=vals.end();++it,++i){
@@ -765,7 +778,11 @@ void TaskSketcherElements::slotElementsChanged(void)
         sketchView->getSketchObject()->getVertexIndexGeoPos(i-1,Sketcher::start),
         sketchView->getSketchObject()->getVertexIndexGeoPos(i-1,Sketcher::mid),
         sketchView->getSketchObject()->getVertexIndexGeoPos(i-1,Sketcher::end),
-        type));
+        type,
+        construction,
+        false));
+
+        setItemVisibility(i-1, mode);
     }
 
     const std::vector< Part::Geometry * > &ext_vals = sketchView->getSketchObject()->getExternalGeometry();
@@ -826,39 +843,44 @@ void TaskSketcherElements::slotElementsChanged(void)
             none,
             type == Part::GeomPoint::getClassTypeId()         ? ( isNamingBoxChecked ?
                                                                 (tr("Point") + linkname):
-                                                                (QString::fromLatin1("%1-").arg(i)+tr("Point")))         :
+                                                                (QString::fromLatin1("%1-").arg(i-2)+tr("Point")))         :
             type == Part::GeomLineSegment::getClassTypeId()        ? ( isNamingBoxChecked ?
                                                                 (tr("Line") + linkname):
-                                                                (QString::fromLatin1("%1-").arg(i)+tr("Line")))         :
+                                                                (QString::fromLatin1("%1-").arg(i-2)+tr("Line")))         :
             type == Part::GeomArcOfCircle::getClassTypeId()        ? ( isNamingBoxChecked ?
                                                                 (tr("Arc") + linkname):
-                                                                (QString::fromLatin1("%1-").arg(i)+tr("Arc")))         :
+                                                                (QString::fromLatin1("%1-").arg(i-2)+tr("Arc")))         :
             type == Part::GeomCircle::getClassTypeId()        ? ( isNamingBoxChecked ?
                                                                 (tr("Circle") + linkname):
-                                                                (QString::fromLatin1("%1-").arg(i)+tr("Circle")))         :
+                                                                (QString::fromLatin1("%1-").arg(i-2)+tr("Circle")))         :
             type == Part::GeomEllipse::getClassTypeId()         ? ( isNamingBoxChecked ?
                                                                 (tr("Ellipse") + linkname):
-                                                                (QString::fromLatin1("%1-").arg(i)+tr("Ellipse")))   :
+                                                                (QString::fromLatin1("%1-").arg(i-2)+tr("Ellipse")))   :
             type == Part::GeomArcOfEllipse::getClassTypeId()    ? ( isNamingBoxChecked ?
                                                                 (tr("Elliptical Arc") + linkname):
-                                                                (QString::fromLatin1("%1-").arg(i)+tr("Elliptical Arc")))   :
+                                                                (QString::fromLatin1("%1-").arg(i-2)+tr("Elliptical Arc")))   :
             type == Part::GeomArcOfHyperbola::getClassTypeId()    ? ( isNamingBoxChecked ?
                                                                 (tr("Hyperbolic Arc") + linkname):
-                                                                (QString::fromLatin1("%1-").arg(i)+tr("Hyperbolic Arc")))   :
+                                                                (QString::fromLatin1("%1-").arg(i-2)+tr("Hyperbolic Arc")))   :
             type == Part::GeomArcOfParabola::getClassTypeId()    ? ( isNamingBoxChecked ?
                                                                 (tr("Parabolic Arc") + linkname):
-                                                                (QString::fromLatin1("%1-").arg(i)+tr("Parabolic Arc")))   :
+                                                                (QString::fromLatin1("%1-").arg(i-2)+tr("Parabolic Arc")))   :
             type == Part::GeomBSplineCurve::getClassTypeId()    ? ( isNamingBoxChecked ?
                                                                 (tr("BSpline") + linkname):
-                                                                (QString::fromLatin1("%1-").arg(i)+tr("BSpline")))   :
+                                                                (QString::fromLatin1("%1-").arg(i-2)+tr("BSpline")))   :
             ( isNamingBoxChecked ?
             (tr("Other") + linkname):
-            (QString::fromLatin1("%1-").arg(i)+tr("Other"))),
+            (QString::fromLatin1("%1-").arg(i-2)+tr("Other"))),
             -j,
             sketchView->getSketchObject()->getVertexIndexGeoPos(-j,Sketcher::start),
             sketchView->getSketchObject()->getVertexIndexGeoPos(-j,Sketcher::mid),
             sketchView->getSketchObject()->getVertexIndexGeoPos(-j,Sketcher::end),
-            type));
+            type,
+            false, // externals are not construction geometry in the sense of the sketcher ui
+            true // yes, external geometry
+            ));
+
+        setItemVisibility(i-3, mode); // i is 1 based and H and V axes get ignored.
       }
     }
 }
@@ -948,6 +970,12 @@ void TaskSketcherElements::on_listWidgetElements_currentFilterChanged ( int inde
 
 }
 
+void TaskSketcherElements::on_listWidgetElements_currentModeFilterChanged ( int index )
+{
+    updateVisibility(index);
+}
+
+
 void TaskSketcherElements::updatePreselection()
 {
     inhibitSelectionUpdate=true;
@@ -969,6 +997,37 @@ void TaskSketcherElements::clearWidget()
       item->isStartingPointSelected=false;
       item->isEndPointSelected=false;
       item->isMidPointSelected=false;
+    }
+}
+
+void TaskSketcherElements::setItemVisibility(int elementindex,int filterindex)
+{
+    // index
+    // 0 => all
+    // 1 => Normal
+    // 2 => Construction
+    // 3 => External
+
+    ElementItem* item = static_cast<ElementItem *>(ui->listWidgetElements->item(elementindex));
+
+    if (filterindex == 0)
+        item->setHidden(false);
+    else {
+        if( (!item->isConstruction && !item->isExternal && filterindex == 1)  ||
+            (item->isConstruction  && filterindex == 2)  ||
+            (item->isExternal && filterindex == 3) ) {
+            item->setHidden(false);
+            }
+            else {
+                item->setHidden(true);
+            }
+    }
+}
+
+void TaskSketcherElements::updateVisibility(int filterindex)
+{
+    for (int i=0;i<ui->listWidgetElements->count(); i++) {
+        setItemVisibility(i,filterindex);
     }
 }
 

--- a/src/Mod/Sketcher/Gui/TaskSketcherElements.h
+++ b/src/Mod/Sketcher/Gui/TaskSketcherElements.h
@@ -46,11 +46,11 @@ public:
     explicit ElementView(QWidget *parent = 0);
     ~ElementView();
 
-        
+
 Q_SIGNALS:
     void onFilterShortcutPressed();
     void signalCloseShape();
-    
+
 protected:
     void contextMenuEvent (QContextMenuEvent* event);
     void keyPressEvent(QKeyEvent * event);
@@ -75,7 +75,7 @@ protected Q_SLOTS:
     void doSymmetricConstraint();
     void doTangentConstraint();
     // Other Commands
-    void doToggleConstruction();    
+    void doToggleConstruction();
     // Acelerators
     void doCloseShape();
     void doConnect();
@@ -102,13 +102,16 @@ private:
     void slotElementsChanged(void);
     void updateIcons(int element);
     void updatePreselection();
+    void updateVisibility(int filterindex);
+    void setItemVisibility(int elementindex,int filterindex);
     void clearWidget();
 
 public Q_SLOTS:
-    void on_listWidgetElements_itemSelectionChanged(void); 
+    void on_listWidgetElements_itemSelectionChanged(void);
     void on_listWidgetElements_itemEntered(QListWidgetItem *item);
     void on_listWidgetElements_filterShortcutPressed();
     void on_listWidgetElements_currentFilterChanged ( int index );
+    void on_listWidgetElements_currentModeFilterChanged ( int index );
     void on_namingBox_stateChanged(int state);
     void on_autoSwitchBox_stateChanged(int state);
 
@@ -124,10 +127,10 @@ private:
     Ui_TaskSketcherElements* ui;
     int focusItemIndex;
     int previouslySelectedItemIndex;
-    
+
     bool isNamingBoxChecked;
     bool isautoSwitchBoxChecked;
-    
+
     bool inhibitSelectionUpdate;
 };
 

--- a/src/Mod/Sketcher/Gui/TaskSketcherElements.ui
+++ b/src/Mod/Sketcher/Gui/TaskSketcherElements.ui
@@ -62,6 +62,53 @@
     </layout>
    </item>
    <item>
+    <layout class="QHBoxLayout" name="horizontalLayout1">
+     <item>
+      <widget class="QLabel" name="label1">
+       <property name="text">
+        <string>Mode:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QComboBox" name="comboBoxModeFilter">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="locale">
+        <locale language="English" country="UnitedStates"/>
+       </property>
+       <property name="editable">
+        <bool>false</bool>
+       </property>
+       <property name="currentIndex">
+        <number>0</number>
+       </property>
+       <item>
+        <property name="text">
+         <string>All</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Normal</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Construction</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>External</string>
+        </property>
+       </item>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
     <widget class="ElementView" name="listWidgetElements">
      <property name="modelColumn">
       <number>0</number>


### PR DESCRIPTION
========================================

A combobox type filter to filter out on Normal geometry, Construction geometry, External geometry.

Useful, for example, to select and or delete only construction geometry.

It also fixes a bug, that external geometry was wrongly indexed in non-extended naming mode.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
