### PR TITLE
[Path] PathPocket: Fix SetupProperties() syntax issue

### DIFF
--- a/src/Mod/Path/PathScripts/PathPocket.py
+++ b/src/Mod/Path/PathScripts/PathPocket.py
@@ -21,12 +21,6 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-# *                                                                         *
-# *   Additional modifications and contributions beginning 2019             *
-# *   Focus: improve 3D facial pockets                                      *
-# *   by Russell Johnson  <russ4262@gmail.com>                              *
-# *                                                                         *
-# ***************************************************************************
 
 import FreeCAD
 import Part
@@ -43,8 +37,8 @@ __url__ = "http://www.freecadweb.org"
 __doc__ = "Class and implementation of the 3D Pocket operation."
 __contributors__ = "russ4262 (Russell Johnson)"
 __created__ = "2014"
-__scriptVersion__ = "1a testing"
-__lastModified__ = "2019-06-28 23:45 CST"
+__scriptVersion__ = "1b testing"
+__lastModified__ = "2019-07-01 20:13 CST"
 
 LOGLEVEL = False
 
@@ -134,7 +128,7 @@ class ObjectPocket(PathPocketBase.ObjectPocket):
 
 
 def SetupProperties():
-    return PathPocketBase.SetupProperties().append("HandleMultipleFeatures")
+    return PathPocketBase.SetupProperties() + ["HandleMultipleFeatures"]
 
 
 def Create(name, obj=None):


### PR DESCRIPTION
fix for SetupProperties() syntax issue presented at:
[Re: Two bugs when using Profile Faces.](https://forum.freecadweb.org/viewtopic.php?f=15&t=37368#p318253)

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
