### PR TITLE
[Path] 4th-axis rotation analysis Z-orientation fix

### DIFF
--- a/src/Mod/Path/PathScripts/PathAreaOp.py
+++ b/src/Mod/Path/PathScripts/PathAreaOp.py
@@ -43,10 +43,10 @@ __url__ = "http://www.freecadweb.org"
 __doc__ = "Base class and properties for Path.Area based operations."
 __contributors__ = "russ4262 (Russell Johnson)"
 __createdDate__ = "2017"
-__scriptVersion__ = "2h testing"
-__lastModified__ = "2019-06-30 17:17 CST"
+__scriptVersion__ = "2j testing"
+__lastModified__ = "2019-07-12 00:11 CST"
 
-LOGLEVEL = PathLog.Level.DEBUG
+LOGLEVEL = PathLog.Level.INFO
 PathLog.setLevel(LOGLEVEL, PathLog.thisModule())
 # PathLog.setLevel(PathLog.Level.INFO, PathLog.thisModule())
 
@@ -578,7 +578,6 @@ class ObjectOp(PathOp.ObjectOp):
 
         praInfo = "faceRotationAnalysis()"
         rtn = True
-        # axis = 'X'
         orientation = 'X'
         angle = 500.0
         precision = 6
@@ -681,6 +680,8 @@ class ObjectOp(PathOp.ObjectOp):
                     axis = 'X'
                 else:
                     rtn = False
+        elif orientation == 'Z':
+            axis = 'X'
 
         if math.fabs(angle) == 0.0:
             angle = 0.0

--- a/src/Mod/Path/PathScripts/PathCircularHoleBase.py
+++ b/src/Mod/Path/PathScripts/PathCircularHoleBase.py
@@ -50,8 +50,8 @@ __url__ = "http://www.freecadweb.org"
 __doc__ = "Base class an implementation for operations on circular holes."
 __contributors__ = "russ4262 (Russell Johnson)"
 __created__ = "2017"
-__scriptVersion__ = "1c testing"
-__lastModified__ = "2019-06-25 14:49 CST"
+__scriptVersion__ = "1d testing"
+__lastModified__ = "2019-07-09 22:59 CST"
 
 
 # Qt translation handling
@@ -479,7 +479,6 @@ class ObjectOp(PathOp.ObjectOp):
 
         praInfo = "faceRotationAnalysis(): "
         rtn = True
-        axis = 'X'
         orientation = 'X'
         angle = 500.0
         precision = 6
@@ -582,6 +581,8 @@ class ObjectOp(PathOp.ObjectOp):
                     axis = 'X'
                 else:
                     rtn = False
+        elif orientation == 'Z':
+            axis = 'X'
 
         if math.fabs(angle) == 0.0:
             angle = 0.0


### PR DESCRIPTION
orientation == 'Z' was failing in some cases due to undefined "axis" variable. "axis" declaration was commented out in an earlier commit. Declaration now restored for all orientations.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
