### PR TITLE
Path: more pylint3 cleanup

### DIFF
--- a/src/Mod/Path/Gui/Resources/panels/PageDepthsEdit.ui
+++ b/src/Mod/Path/Gui/Resources/panels/PageDepthsEdit.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>296</width>
+    <width>345</width>
     <height>235</height>
    </rect>
   </property>
@@ -71,6 +71,9 @@
    </item>
    <item row="0" column="2">
     <widget class="QToolButton" name="startDepthSet">
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Transfer the Z value of the selected feature as the Start Depth for the operation.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
      <property name="text">
       <string>...</string>
      </property>
@@ -82,6 +85,9 @@
    </item>
    <item row="1" column="2">
     <widget class="QToolButton" name="finalDepthSet">
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Transfer the Z value of the selected feature as the Final Depth for the operation.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
      <property name="text">
       <string>...</string>
      </property>
@@ -114,7 +120,7 @@
    <item row="3" column="1">
     <widget class="Gui::QuantitySpinBox" name="stepDown">
      <property name="toolTip">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The depth in Z-axis the operation moves downwards between layers.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;This value depends on the tool being used, the material to be cut, available cooling and many other factors. Please consult the tool manufacturers data sheets for the proper value.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The depth in Z-axis the operation moves downwards between layers.&lt;/p&gt;&lt;p&gt;This value depends on the tool being used, the material to be cut, available cooling and many other factors. Please consult the tool manufacturers data sheets for the proper value.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
      <property name="alignment">
       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>

--- a/src/Mod/Path/PathScripts/PathAdaptive.py
+++ b/src/Mod/Path/PathScripts/PathAdaptive.py
@@ -55,8 +55,6 @@ scenePathNodes = [] #for scene cleanup aftewards
 topZ = 10
 
 def sceneDrawPath(path, color=(0, 0, 1)):
-    global sceneGraph
-    global scenePathNodes
     coPoint = coin.SoCoordinate3()
 
     pts = []
@@ -76,8 +74,6 @@ def sceneDrawPath(path, color=(0, 0, 1)):
     scenePathNodes.append(pathNode) #for scene cleanup afterwards
 
 def sceneClean():
-    global scenePathNodes
-
     for n in scenePathNodes:
         sceneGraph.removeChild(n)
 
@@ -91,6 +87,7 @@ def discretize(edge, flipDirection = False):
     return pts
 
 def GenerateGCode(op,obj,adaptiveResults, helixDiameter):
+    # pylint: disable=unused-argument
     if len(adaptiveResults) == 0 or len(adaptiveResults[0]["AdaptivePaths"]) == 0:
         return
 
@@ -138,6 +135,9 @@ def GenerateGCode(op,obj,adaptiveResults, helixDiameter):
 
 
 
+    # ml: this is dangerous because it'll hide all unused variables hence forward
+    #     however, I don't know wht lx and ly signify so I leave them for now
+    # pylint: disable=unused-variable
     lx = adaptiveResults[0]["HelixCenterPoint"][0]
     ly = adaptiveResults[0]["HelixCenterPoint"][1]
     lz = passStartDepth
@@ -307,6 +307,7 @@ def GenerateGCode(op,obj,adaptiveResults, helixDiameter):
     lz = z
 
 def Execute(op,obj):
+    # pylint: disable=global-statement
     global sceneGraph
     global topZ
 
@@ -400,11 +401,11 @@ def Execute(op,obj):
         adaptiveResults = None
 
         if obj.AdaptiveOutputState != None and obj.AdaptiveOutputState != "":
-             adaptiveResults = obj.AdaptiveOutputState
+            adaptiveResults = obj.AdaptiveOutputState
 
         if json.dumps(obj.AdaptiveInputState) != json.dumps(inputStateObject):
-             inputStateChanged = True
-             adaptiveResults = None
+            inputStateChanged = True
+            adaptiveResults = None
 
         # progress callback fn, if return true it will stop processing
         def progressFn(tpaths):

--- a/src/Mod/Path/PathScripts/PathArray.py
+++ b/src/Mod/Path/PathScripts/PathArray.py
@@ -29,7 +29,7 @@ import PathScripts
 from PySide import QtCore
 import math
 
-"""Path Array object and FreeCAD command"""
+__doc__ = """Path Array object and FreeCAD command"""
 
 # Qt translation handling
 def translate(context, text, disambig=None):
@@ -213,6 +213,7 @@ class ObjectArray:
 class ViewProviderArray:
 
     def __init__(self, vobj):
+        self.Object = vobj.Object
         vobj.Proxy = self
 
     def attach(self, vobj):

--- a/src/Mod/Path/PathScripts/PathCollision.py
+++ b/src/Mod/Path/PathScripts/PathCollision.py
@@ -50,20 +50,21 @@ class _CollisionSim:
         obj.Proxy = self
 
     def execute(self, fp):
-        "'''Do something when doing a recomputation, this method is mandatory'''"
-        pass
+        '''Do something when doing a recomputation, this method is mandatory'''
+        print('_CollisionSim', fp)
 
 
 class _ViewProviderCollisionSim:
     def __init__(self, vobj):
+        self.Object = vobj.Object
         vobj.Proxy = self
         vobj.addProperty("App::PropertyLink", "Original", "reference", QtCore.QT_TRANSLATE_NOOP("App::Property", "The base object this collision refers to"))
 
     def attach(self, vobj):
         self.Object = vobj.Object
-        return
 
     def setEdit(self, vobj, mode=0):
+        # pylint: disable=unused-argument
         return True
 
     def getIcon(self):
@@ -73,9 +74,11 @@ class _ViewProviderCollisionSim:
         return None
 
     def __setstate__(self, state):
+        # pylint: disable=unused-argument
         return None
 
     def onDelete(self, feature, subelements):
+        # pylint: disable=unused-argument
         feature.Original.ViewObject.Visibility = True
         return True
 
@@ -101,9 +104,9 @@ def getCollisionObject(baseobject, simobject):
         colorassignment = []
         gougedShape = baseobject.Shape.cut(simobject)
 
-        for idx, i in enumerate(gougedShape.Faces):
+        for i in gougedShape.Faces:
             match = False
-            for jdx, j in enumerate(cVol.Faces):
+            for j in cVol.Faces:
                 if __compareBBSpace(i.BoundBox, j.BoundBox):
                     match = True
             if match is True:

--- a/src/Mod/Path/PathScripts/PathComment.py
+++ b/src/Mod/Path/PathScripts/PathComment.py
@@ -82,6 +82,7 @@ class _ViewProviderComment:
         return ":/icons/Path-Comment.svg"
 
     def onChanged(self, vobj, prop):  # optional
+        # pylint: disable=unused-argument
         mode = 2
         vobj.setEditorMode('LineWidth', mode)
         vobj.setEditorMode('MarkerColor', mode)
@@ -105,7 +106,7 @@ class CommandPathComment:
         if FreeCAD.ActiveDocument is not None:
             for o in FreeCAD.ActiveDocument.Objects:
                 if o.Name[:3] == "Job":
-                        return True
+                    return True
         return False
 
     def Activated(self):

--- a/src/Mod/Path/PathScripts/PathCopy.py
+++ b/src/Mod/Path/PathScripts/PathCopy.py
@@ -24,9 +24,9 @@
 
 import FreeCAD
 import FreeCADGui
-from PySide import QtCore, QtGui
+from PySide import QtCore
 
-"""Path Copy object and FreeCAD command"""
+__doc__ = """Path Copy object and FreeCAD command"""
 
 # Qt translation handling
 def translate(context, text, disambig=None):
@@ -57,6 +57,7 @@ class ObjectPathCopy:
 class ViewProviderPathCopy:
 
     def __init__(self, vobj):
+        self.Object = vobj.Object
         vobj.Proxy = self
 
     def attach(self, vobj):
@@ -84,7 +85,7 @@ class CommandPathCopy:
         if FreeCAD.ActiveDocument is not None:
             for o in FreeCAD.ActiveDocument.Objects:
                 if o.Name[:3] == "Job":
-                        return True
+                    return True
         return False
 
     def Activated(self):

--- a/src/Mod/Path/PathScripts/PathCustom.py
+++ b/src/Mod/Path/PathScripts/PathCustom.py
@@ -26,7 +26,7 @@ import FreeCADGui
 import Path
 from PySide import QtCore
 
-"""Path Custom object and FreeCAD command"""
+__doc__ = """Path Custom object and FreeCAD command"""
 
 
 # Qt translation handling
@@ -68,7 +68,7 @@ class CommandPathCustom:
         if FreeCAD.ActiveDocument is not None:
             for o in FreeCAD.ActiveDocument.Objects:
                 if o.Name[:3] == "Job":
-                        return True
+                    return True
         return False
 
     def Activated(self):

--- a/src/Mod/Path/PathScripts/PathFixture.py
+++ b/src/Mod/Path/PathScripts/PathFixture.py
@@ -83,6 +83,7 @@ class _ViewProviderFixture:
         return ":/icons/Path-Datums.svg"
 
     def onChanged(self, vobj, prop):  # optional
+        # pylint: disable=unused-argument
         mode = 2
         vobj.setEditorMode('LineWidth', mode)
         vobj.setEditorMode('MarkerColor', mode)
@@ -118,7 +119,7 @@ class CommandPathFixture:
         if FreeCAD.ActiveDocument is not None:
             for o in FreeCAD.ActiveDocument.Objects:
                 if o.Name[:3] == "Job":
-                        return True
+                    return True
         return False
 
     def Activated(self):

--- a/src/Mod/Path/PathScripts/PathHop.py
+++ b/src/Mod/Path/PathScripts/PathHop.py
@@ -25,9 +25,9 @@
 import FreeCAD
 import FreeCADGui
 import Path
-from PySide import QtCore, QtGui
+from PySide import QtCore
 
-"""Path Hop object and FreeCAD command"""
+__doc__ = """Path Hop object and FreeCAD command"""
 
 # Qt translation handling
 def translate(context, text, disambig=None):
@@ -73,11 +73,11 @@ class ObjectHop:
 class ViewProviderPathHop:
 
     def __init__(self, vobj):
+        self.Object = vobj.Object
         vobj.Proxy = self
 
     def attach(self, vobj):
         self.Object = vobj.Object
-        return
 
     def getIcon(self):
         return ":/icons/Path-Hop.svg"
@@ -100,7 +100,7 @@ class CommandPathHop:
         if FreeCAD.ActiveDocument is not None:
             for o in FreeCAD.ActiveDocument.Objects:
                 if o.Name[:3] == "Job":
-                        return True
+                    return True
         return False
 
     def Activated(self):

--- a/src/Mod/Path/PathScripts/PathInspect.py
+++ b/src/Mod/Path/PathScripts/PathInspect.py
@@ -78,12 +78,12 @@ class GCodeHighlighter(QtGui.QSyntaxHighlighter):
 
     def highlightBlock(self, text):
 
-        for pattern, format in self.highlightingRules:
+        for pattern, fmt in self.highlightingRules:
             expression = QtCore.QRegExp(pattern)
             index = expression.indexIn(text)
             while index >= 0:
                 length = expression.matchedLength()
-                self.setFormat(index, length, format)
+                self.setFormat(index, length, fmt)
                 index = expression.indexIn(text, index + length)
 
 
@@ -201,7 +201,6 @@ def show(obj):
             # exec_() returns 0 or 1 depending on the button pressed (Ok or
             # Cancel)
             if result:
-                import Path
                 p = Path.Path(dia.editor.toPlainText())
                 FreeCAD.ActiveDocument.openTransaction("Edit Path")
                 obj.Path = p
@@ -221,7 +220,7 @@ class CommandPathInspect:
         if FreeCAD.ActiveDocument is not None:
             for o in FreeCAD.ActiveDocument.Objects:
                 if o.Name[:3] == "Job":
-                        return True
+                    return True
         return False
 
     def Activated(self):

--- a/src/Mod/Path/PathScripts/PathPlane.py
+++ b/src/Mod/Path/PathScripts/PathPlane.py
@@ -26,7 +26,7 @@
 import FreeCAD
 import FreeCADGui
 import Path
-from PySide import QtCore, QtGui
+from PySide import QtCore
 
 # Qt translation handling
 def translate(context, text, disambig=None):
@@ -79,6 +79,7 @@ class _ViewProviderPlane:
         return ":/icons/Path-Plane.svg"
 
     def onChanged(self, vobj, prop):  # optional
+        # pylint: disable=unused-argument
         mode = 2
         vobj.setEditorMode('LineWidth', mode)
         vobj.setEditorMode('MarkerColor', mode)
@@ -114,7 +115,7 @@ class CommandPathPlane:
         if FreeCAD.ActiveDocument is not None:
             for o in FreeCAD.ActiveDocument.Objects:
                 if o.Name[:3] == "Job":
-                        return True
+                    return True
         return False
 
     def Activated(self):

--- a/src/Mod/Path/PathScripts/PathSimpleCopy.py
+++ b/src/Mod/Path/PathScripts/PathSimpleCopy.py
@@ -26,7 +26,7 @@ import FreeCADGui
 import PathScripts
 from PySide import QtCore
 
-"""Path SimpleCopy command"""
+__doc__ = """Path SimpleCopy command"""
 
 
 # Qt translation handling
@@ -47,7 +47,7 @@ class CommandPathSimpleCopy:
         try:
             obj = FreeCADGui.Selection.getSelectionEx()[0].Object
             return isinstance(obj.Proxy, PathScripts.PathOp.ObjectOp)
-        except Exception:
+        except Exception: # pylint: disable=broad-except
             return False
 
     def Activated(self):

--- a/src/Mod/Path/PathScripts/PathStop.py
+++ b/src/Mod/Path/PathScripts/PathStop.py
@@ -85,6 +85,7 @@ class _ViewProviderStop:
         return ":/icons/Path-Stop.svg"
 
     def onChanged(self, vobj, prop):  # optional
+        # pylint: disable=unused-argument
         mode = 2
         vobj.setEditorMode('LineWidth', mode)
         vobj.setEditorMode('MarkerColor', mode)
@@ -108,7 +109,7 @@ class CommandPathStop:
         if FreeCAD.ActiveDocument is not None:
             for o in FreeCAD.ActiveDocument.Objects:
                 if o.Name[:3] == "Job":
-                        return True
+                    return True
         return False
 
     def Activated(self):

--- a/src/Mod/Path/PathScripts/post/centroid_post.py
+++ b/src/Mod/Path/PathScripts/post/centroid_post.py
@@ -116,6 +116,7 @@ if open.__module__ in ['__builtin__', 'io']:
 
 
 def processArguments(argstring):
+    # pylint: disable=global-statement
     global OUTPUT_HEADER
     global OUTPUT_COMMENTS
     global OUTPUT_LINE_NUMBERS
@@ -147,6 +148,7 @@ def processArguments(argstring):
 
 
 def export(objectslist, filename, argstring):
+    # pylint: disable=global-statement
     processArguments(argstring)
     for i in objectslist:
         print(i.Name)
@@ -221,6 +223,7 @@ def export(objectslist, filename, argstring):
 
 
 def linenumber():
+    # pylint: disable=global-statement
     global LINENR
     if OUTPUT_LINE_NUMBERS is True:
         LINENR += 10
@@ -229,8 +232,6 @@ def linenumber():
 
 
 def parse(pathobj):
-    global AXIS_PRECISION
-    global FEED_PRECISION
     out = ""
     lastcommand = None
     axis_precision_string = '.' + str(AXIS_PRECISION) + 'f'

--- a/src/Mod/Path/PathScripts/post/comparams_post.py
+++ b/src/Mod/Path/PathScripts/post/comparams_post.py
@@ -23,7 +23,6 @@
 # ***************************************************************************
 import FreeCAD
 import Path
-import PathScripts
 import PathScripts.PostUtils as PostUtils
 
 TOOLTIP = ''' Example Post, using Path.Commands instead of Path.toGCode strings for Path gcode output. '''
@@ -81,6 +80,7 @@ def lineout(command, oldvals, modal):
 
 
 def export(obj, filename, argstring):
+    # pylint: disable=unused-argument
     modal = True
     gcode = ''
     safetyblock1 = 'G90G40G49\n'

--- a/src/Mod/Path/PathScripts/post/dumper_post.py
+++ b/src/Mod/Path/PathScripts/post/dumper_post.py
@@ -40,6 +40,9 @@ if open.__module__ in ['__builtin__','io']:
 
 
 def export(objectslist, filename,argstring):
+    "called when freecad exports a list of objects"
+    # pylint: disable=unused-argument
+
     output = '''(This output produced with the dump post processor)
 (Dump is useful for inspecting the raw commands in your paths)
 (but is not useful for driving machines.)
@@ -48,7 +51,6 @@ def export(objectslist, filename,argstring):
 
 '''
 
-    "called when freecad exports a list of objects"
     for obj in objectslist:
 
         if not hasattr(obj, "Path"):

--- a/src/Mod/Path/PathScripts/post/dynapath_post.py
+++ b/src/Mod/Path/PathScripts/post/dynapath_post.py
@@ -111,7 +111,8 @@ if open.__module__ in ['__builtin__','io']:
 
 
 def export(objectslist,filename,argstring):
-    global UNITS
+    # pylint: disable=unused-argument
+    global UNITS # pylint: disable=global-statement
     for obj in objectslist:
         if not hasattr(obj,"Path"):
             print("the object " + obj.Name + " is not a path. Please select only path and Compounds.")
@@ -128,9 +129,9 @@ def export(objectslist,filename,argstring):
             myMachine = pathobj.MachineName
         if hasattr(pathobj, "MachineUnits"):
             if pathobj.MachineUnits == "Metric":
-               UNITS = "G21"
+                UNITS = "G21"
             else:
-               UNITS = "G20"
+                UNITS = "G20"
     if myMachine is None:
         print("No machine found in this selection")
 
@@ -185,7 +186,7 @@ def export(objectslist,filename,argstring):
 
 
 def linenumber():
-    global LINENR
+    global LINENR # pylint: disable=global-statement
     if OUTPUT_LINE_NUMBERS == True:
         LINENR += 1
         return "N" + str(LINENR) + " "

--- a/src/Mod/Path/PathScripts/post/example_post.py
+++ b/src/Mod/Path/PathScripts/post/example_post.py
@@ -41,6 +41,7 @@ if open.__module__ in ['__builtin__','io']:
 
 def export(objectslist, filename,argstring):
     "called when freecad exports a list of objects"
+    # pylint: disable=unused-argument
     if len(objectslist) > 1:
         print("This script is unable to write more than one Path object")
         return

--- a/src/Mod/Path/PathScripts/post/example_pre.py
+++ b/src/Mod/Path/PathScripts/post/example_pre.py
@@ -50,8 +50,8 @@ if open.__module__ in ['__builtin__', 'io']:
 
 
 def open(filename):
-    PathLog.track(filename)
     "called when freecad opens a file."
+    PathLog.track(filename)
     docname = os.path.splitext(os.path.basename(filename))[0]
     doc = FreeCAD.newDocument(docname)
     insert(filename, doc.Name)

--- a/src/Mod/Path/PathScripts/post/fablin_post.py
+++ b/src/Mod/Path/PathScripts/post/fablin_post.py
@@ -94,6 +94,7 @@ if open.__module__ in ['__builtin__', 'io']:
 
 
 def processArguments(argstring):
+    # pylint: disable=global-statement
     global OUTPUT_HEADER
     global OUTPUT_COMMENTS
     global OUTPUT_LINE_NUMBERS
@@ -124,6 +125,7 @@ def processArguments(argstring):
 
 
 def export(objectslist, filename, argstring):
+    # pylint: disable=global-statement
     processArguments(argstring)
     global UNITS
     for obj in objectslist:
@@ -205,6 +207,7 @@ def export(objectslist, filename, argstring):
 
 
 def linenumber():
+    # pylint: disable=global-statement
     global LINENR
     if OUTPUT_LINE_NUMBERS is True:
         LINENR += 10

--- a/src/Mod/Path/PathScripts/post/jtech_post.py
+++ b/src/Mod/Path/PathScripts/post/jtech_post.py
@@ -110,6 +110,7 @@ if open.__module__ == '__builtin__':
 
 
 def processArguments(argstring):
+    # pylint: disable=global-statement
     global OUTPUT_HEADER
     global OUTPUT_COMMENTS
     global OUTPUT_LINE_NUMBERS
@@ -151,7 +152,7 @@ def processArguments(argstring):
             OUTPUT_DOUBLES = False
         POWER_ON_DELAY = float(args.power_on_delay) / 1000  # milliseconds
 
-    except Exception:
+    except Exception: # pylint: disable=broad-except
         return False
 
     return True
@@ -160,9 +161,6 @@ def processArguments(argstring):
 def export(objectslist, filename, argstring):
     if not processArguments(argstring):
         return None
-    global UNITS
-    global UNIT_FORMAT
-    global UNIT_SPEED_FORMAT
 
     for obj in objectslist:
         if not hasattr(obj, "Path"):
@@ -229,7 +227,7 @@ def export(objectslist, filename, argstring):
 
 
 def linenumber():
-    global LINENR
+    global LINENR # pylint: disable=global-statement
     if OUTPUT_LINE_NUMBERS is True:
         LINENR += 10
         return "N" + str(LINENR) + " "
@@ -237,15 +235,6 @@ def linenumber():
 
 
 def parse(pathobj):
-    global PRECISION
-    global MODAL
-    global OUTPUT_DOUBLES
-    global UNIT_FORMAT
-    global UNIT_SPEED_FORMAT
-    global POWER_ON_DELAY
-    global PRE_FEED
-    global POST_FEED
-
     out = ""
     lastcommand = None
     precision_string = '.' + str(PRECISION) + 'f'

--- a/src/Mod/Path/PathScripts/post/linuxcnc_post.py
+++ b/src/Mod/Path/PathScripts/post/linuxcnc_post.py
@@ -102,6 +102,7 @@ if open.__module__ in ['__builtin__','io']:
 
 
 def processArguments(argstring):
+    # pylint: disable=global-statement
     global OUTPUT_HEADER
     global OUTPUT_COMMENTS
     global OUTPUT_LINE_NUMBERS
@@ -142,13 +143,14 @@ def processArguments(argstring):
             print ('here')
             OUTPUT_DOUBLES = False
 
-    except Exception:
+    except Exception: # pylint: disable=broad-except
         return False
 
     return True
 
 
 def export(objectslist, filename, argstring):
+    # pylint: disable=global-statement
     if not processArguments(argstring):
         return None
     global UNITS
@@ -239,6 +241,7 @@ def export(objectslist, filename, argstring):
 
 
 def linenumber():
+    # pylint: disable=global-statement
     global LINENR
     if OUTPUT_LINE_NUMBERS is True:
         LINENR += 10
@@ -247,6 +250,7 @@ def linenumber():
 
 
 def parse(pathobj):
+    # pylint: disable=global-statement
     global PRECISION
     global MODAL
     global OUTPUT_DOUBLES

--- a/src/Mod/Path/PathScripts/post/opensbp_post.py
+++ b/src/Mod/Path/PathScripts/post/opensbp_post.py
@@ -98,6 +98,7 @@ GetValue = getMetricValue
 
 
 def export(objectslist, filename, argstring):
+    # pylint: disable=global-statement
     global OUTPUT_COMMENTS
     global OUTPUT_HEADER
     global SHOW_EDITOR
@@ -182,8 +183,6 @@ def export(objectslist, filename, argstring):
 
 
 def move(command):
-    global CurrentState
-
     txt = ""
 
     # if 'F' in command.Parameters:
@@ -298,7 +297,7 @@ def tool_change(command):
 
 
 def comment(command):
-    print("a comment")
+    print("a comment", command)
     return
 
 
@@ -333,8 +332,6 @@ scommands = {
 
 
 def parse(pathobj):
-    global CurrentState
-
     output = ""
     # Above list controls the order of parameters
 

--- a/src/Mod/Path/PathScripts/post/opensbp_pre.py
+++ b/src/Mod/Path/PathScripts/post/opensbp_pre.py
@@ -68,9 +68,9 @@ def open(filename):
 
 
 def insert(filename, docname):
-    "called when freecad imports a file"
-    "This insert expects parse to return a list of strings"
-    "each string will become a separate path"
+    '''called when freecad imports a file
+    This insert expects parse to return a list of strings
+    each string will become a separate path'''
     gfile = pythonopen(filename)
     gcode = gfile.read()
     gfile.close()

--- a/src/Mod/Path/PathScripts/post/philips_post.py
+++ b/src/Mod/Path/PathScripts/post/philips_post.py
@@ -27,7 +27,6 @@
 #   reload(generic_post)
 
 import FreeCAD
-from FreeCAD import Units
 import argparse
 import time
 from PathScripts import PostUtils
@@ -220,31 +219,19 @@ parser.add_argument('--no-show-editor', action='store_true', help='don\'t pop up
 TOOLTIP_ARGS = parser.format_help()
 
 def processArguments(argstring):
-    global OUTPUT_HEADER
-    global OUTPUT_COMMENTS
-    global OUTPUT_LINE_NUMBERS
+    # pylint: disable=global-statement
+    global LINENUMBERS
     global SHOW_EDITOR
-    global PRECISION
 
     for arg in argstring.split():
-        if arg == '--header':
-            OUTPUT_HEADER = True
-        elif arg == '--no-header':
-            OUTPUT_HEADER = False
-        elif arg == '--comments':
-            OUTPUT_COMMENTS = True
-        elif arg == '--no-comments':
-            OUTPUT_COMMENTS = False
-        elif arg == '--line-numbers':
-            OUTPUT_LINE_NUMBERS = True
+        if arg == '--line-numbers':
+            LINENUMBERS = True
         elif arg == '--no-line-numbers':
-            OUTPUT_LINE_NUMBERS = False
+            LINENUMBERS = False
         elif arg == '--show-editor':
             SHOW_EDITOR = True
         elif arg == '--no-show-editor':
             SHOW_EDITOR = False
-        elif arg.split('=')[0] == '--output-precision':
-            PRECISION = arg.split('=')[1]
 
 def mkHeader(selection):
     job = PathUtils.findParentJob(selection[0])
@@ -324,7 +311,7 @@ def mapGCode(command):
 
 def linenumberify(GCodeString):
     # add a linenumber at every beginning of line
-    global linenr
+    global linenr # pylint: disable=global-statement
     if not LINENUMBERS:
         result = GCodeString + "\n"
     else:
@@ -342,11 +329,9 @@ def linenumberify(GCodeString):
     return result
 
 def export(objectslist, filename, argstring):
+    # pylint: disable=unused-argument,global-statement
     global UNITS
     global linenr
-    global ABSOLUTE_CIRCLE_CENTER
-    global USE_RADIUS_IF_POSSIBLE
-    global RADIUS_COMMENT
 
     linenr = STARTLINENR
     lastX = 0
@@ -474,7 +459,7 @@ def export(objectslist, filename, argstring):
                                 # absolute center
                                 outstring.append(
                                     '(' + param + PostUtils.fmt(c.Parameters[param], AXIS_DECIMALS, UNITS) + ')')
-                                z = c.Parameters['Z']
+                                z = c.Parameters['Z'] # pylint: disable=unused-variable
                                 k = c.Parameters['K']
                                 if USE_RADIUS_IF_POSSIBLE and angleUnder180(command, lastX, lastY, c.Parameters['X'], c.Parameters['Y'], i, j):
                                     # R is handled with the I parameter, here:

--- a/src/Mod/Path/PathScripts/post/rml_post.py
+++ b/src/Mod/Path/PathScripts/post/rml_post.py
@@ -46,6 +46,7 @@ if open.__module__ in ['__builtin__','io']:
 # Entrypoint used by FreeCAD
 def export(objectslist, filename, argstring):
     "Export objects as Roland Modela code."
+    # pylint: disable=unused-argument
 
     code = ""
     for obj in objectslist:
@@ -68,8 +69,8 @@ def home():
     return [ "H;" ]
 
 def setjog():
-   # "!PZ%d,%d;",iz_down,iz_up); // set z down, jog
-   return ""
+    # "!PZ%d,%d;",iz_down,iz_up); // set z down, jog
+    return ""
 
 def addheader():
     return [ "PA;PA;" ] # absolute positioning
@@ -80,8 +81,10 @@ def mm2cord(mm):
     mm = float(mm)
     return int(40.0*mm)
 
-def feed(x=None, y=None, z=None, state={}):
+def feed(x=None, y=None, z=None, state=None):
     c = []
+    if state is None:
+        state = {}
 
     if x is not None:
         x = float(x)
@@ -100,21 +103,22 @@ def feed(x=None, y=None, z=None, state={}):
         # 2d in XY plane
         c.append("PD%d,%d;" % (mm2cord(x), mm2cord(y)))
     elif z is not None:
-        pass # XXX: is this used?
+        pass
     return c
 
-def jog(x=None, y=None, z=None, state={}):
+def jog(x=None, y=None, z=None, state=None):
     c = []
+    if state is None:
+        state = {}
     if x is not None and y is not None:
-      x, y = float(x), float(y)
-      c.append("PU%d,%d;" % (mm2cord(x), mm2cord(y)))
-      state['X'] = x
-      state['Y'] = y
+        x, y = float(x), float(y)
+        c.append("PU%d,%d;" % (mm2cord(x), mm2cord(y)))
+        state['X'] = x
+        state['Y'] = y
     if z is not None:
-      z = float(z)
-      c.append("PU;")
-      # TODO: use !ZZ command
-      state['Z'] = z
+        z = float(z)
+        c.append("PU;")
+        state['Z'] = z
 
     return c
 
@@ -132,16 +136,18 @@ def xyarc(args, state):
     p0 = circle.parameter(lastPoint)
     p1 = circle.parameter(newPoint)
     arc = Part.ArcOfCircle(circle, p0, p1)
-    steps = 64 # TODO: specify max error instead
+    steps = 64 # specify max error instead?
     points = arc.discretize(steps)
-    # TODO: consider direction
+    # consider direction?
     #print('p = Part.ArcOfCircle(Part.Circle(FreeCAD.Vector(%f, %f), FreeCAD.Vector(0, 0, 1), %f), %f, %f)' % (center.x, center.y, radius, p0, p1))
     for p in points:
         c += feed(p.x, p.y, state['Z'], state)
     return c
 
-def speed(xy=None, z=None, state={}):
+def speed(xy=None, z=None, state=None):
     c = []
+    if state is None:
+        state = {}
     print(xy, z, state)
     if xy is not None:
         xy = float(xy)
@@ -223,7 +229,7 @@ def parse(inputstring):
 
     output += speed(2.0, 1.0, state) # defaults
 
-    # TODO: respect clearance height
+    # respect clearance height?
 
     # treat the input line by line
     lines = inputstring.split("\n")

--- a/src/Mod/Path/PathScripts/post/smoothie_post.py
+++ b/src/Mod/Path/PathScripts/post/smoothie_post.py
@@ -106,6 +106,8 @@ POST_OPERATION = ''''''
 # Tool Change commands will be inserted before a tool change
 TOOL_CHANGE = ''''''
 
+# Number of digits after the decimal point
+PRECISION = 5
 
 # to distinguish python built-in open function from the one declared below
 if open.__module__ in ['__builtin__', 'io']:
@@ -113,6 +115,7 @@ if open.__module__ in ['__builtin__', 'io']:
 
 
 def processArguments(argstring):
+    # pylint: disable=global-statement
     global OUTPUT_HEADER
     global OUTPUT_COMMENTS
     global OUTPUT_LINE_NUMBERS
@@ -159,7 +162,7 @@ def processArguments(argstring):
         IP_ADDR = args.IP_ADDR
         VERBOSE = args.verbose
 
-    except Exception:
+    except Exception: # pylint: disable=broad-except
         return False
 
     return True
@@ -167,8 +170,7 @@ def processArguments(argstring):
 
 def export(objectslist, filename, argstring):
     processArguments(argstring)
-    global UNITS
-    global IP_ADDR
+    global UNITS # pylint: disable=global-statement
     for obj in objectslist:
         if not hasattr(obj, "Path"):
             FreeCAD.Console.PrintError("the object " + obj.Name + " is not a path. Please select only path and Compounds.\n")
@@ -252,11 +254,10 @@ def export(objectslist, filename, argstring):
     return final
 
 
-def sendToSmoothie(IP_ADDR, GCODE, fname):
+def sendToSmoothie(ip, GCODE, fname):
     import sys
     import socket
     import os
-    global VERBOSE
 
     fname = os.path.basename(fname)
     FreeCAD.Console.PrintMessage('sending to smoothie: {}\n'.format(fname))
@@ -266,7 +267,7 @@ def sendToSmoothie(IP_ADDR, GCODE, fname):
     # make connection to sftp server
     s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     s.settimeout(4.0)
-    s.connect((IP_ADDR, 115))
+    s.connect((ip, 115))
     tn = s.makefile(mode='rw')
 
 # read startup prompt
@@ -330,7 +331,7 @@ def sendToSmoothie(IP_ADDR, GCODE, fname):
 
 
 def linenumber():
-    global LINENR
+    global LINENR # pylint: disable=global-statement
     if OUTPUT_LINE_NUMBERS is True:
         LINENR += 10
         return "N" + str(LINENR) + " "
@@ -338,10 +339,10 @@ def linenumber():
 
 
 def parse(pathobj):
-    global PRECISION
+    global SPINDLE_SPEED # pylint: disable=global-statement
+
     out = ""
     lastcommand = None
-    global SPINDLE_SPEED
     precision_string = '.' + str(PRECISION) + 'f'
 
     # params = ['X','Y','Z','A','B','I','J','K','F','S'] #This list control

--- a/src/Mod/Path/PathTests/TestPathDeburr.py
+++ b/src/Mod/Path/PathTests/TestPathDeburr.py
@@ -26,7 +26,6 @@ import Path
 import PathScripts.PathDeburr as PathDeburr
 import PathScripts.PathLog as PathLog
 import PathTests.PathTestUtils as PathTestUtils
-import math
 
 PathLog.setLevel(PathLog.Level.INFO, PathLog.thisModule())
 #PathLog.trackModule(PathLog.thisModule())

--- a/src/Mod/Path/PathTests/TestPathDressupDogbone.py
+++ b/src/Mod/Path/PathTests/TestPathDressupDogbone.py
@@ -24,14 +24,10 @@
 
 import FreeCAD
 import Path
-import PathScripts
 import PathScripts.PathDressupDogbone as PathDressupDogbone
 import PathScripts.PathJob as PathJob
 import PathScripts.PathProfileFaces as PathProfileFaces
-import math
-import unittest
 
-from FreeCAD import Vector
 from PathTests.PathTestUtils import PathTestBase
 
 class TestProfile:
@@ -48,6 +44,7 @@ class TestFeature:
         self.Path = Path.Path()
 
     def addProperty(self, typ, nam, category, tip):
+        # pylint: disable=unused-argument
         setattr(self, nam, None)
 
     def setEditorMode(self, prop, mode):
@@ -61,31 +58,29 @@ class TestDressupDogbone(PathTestBase):
 
     def test00(self):
         '''Verify bones are inserted for simple moves.'''
-        path = []
         base = TestProfile('Inside', 'CW', 'G0 X10 Y10 Z10\nG1 Z0\nG1 Y100\nG1 X12\nG1 Y10\nG1 X10\nG1 Z10')
         obj = TestFeature()
         db = PathDressupDogbone.ObjectDressup(obj, base)
         db.setup(obj, True)
         db.execute(obj, False)
-        self.assertEquals(len(db.bones), 4)
-        self.assertEquals("1: (10.00, 100.00)", self.formatBone(db.bones[0]))
-        self.assertEquals("2: (12.00, 100.00)", self.formatBone(db.bones[1]))
-        self.assertEquals("3: (12.00, 10.00)", self.formatBone(db.bones[2]))
-        self.assertEquals("4: (10.00, 10.00)", self.formatBone(db.bones[3]))
+        self.assertEqual(len(db.bones), 4)
+        self.assertEqual("1: (10.00, 100.00)", self.formatBone(db.bones[0]))
+        self.assertEqual("2: (12.00, 100.00)", self.formatBone(db.bones[1]))
+        self.assertEqual("3: (12.00, 10.00)", self.formatBone(db.bones[2]))
+        self.assertEqual("4: (10.00, 10.00)", self.formatBone(db.bones[3]))
 
     def test01(self):
         '''Verify bones are inserted if hole ends with rapid move out.'''
-        path = []
         base = TestProfile('Inside', 'CW', 'G0 X10 Y10 Z10\nG1 Z0\nG1 Y100\nG1 X12\nG1 Y10\nG1 X10\nG0 Z10')
         obj = TestFeature()
         db = PathDressupDogbone.ObjectDressup(obj, base)
         db.setup(obj, True)
         db.execute(obj, False)
-        self.assertEquals(len(db.bones), 4)
-        self.assertEquals("1: (10.00, 100.00)", self.formatBone(db.bones[0]))
-        self.assertEquals("2: (12.00, 100.00)", self.formatBone(db.bones[1]))
-        self.assertEquals("3: (12.00, 10.00)", self.formatBone(db.bones[2]))
-        self.assertEquals("4: (10.00, 10.00)", self.formatBone(db.bones[3]))
+        self.assertEqual(len(db.bones), 4)
+        self.assertEqual("1: (10.00, 100.00)", self.formatBone(db.bones[0]))
+        self.assertEqual("2: (12.00, 100.00)", self.formatBone(db.bones[1]))
+        self.assertEqual("3: (12.00, 10.00)", self.formatBone(db.bones[2]))
+        self.assertEqual("4: (10.00, 10.00)", self.formatBone(db.bones[3]))
 
     def test02(self):
         '''Verify bones are correctly generated for a Profile.'''
@@ -113,7 +108,7 @@ class TestDressupDogbone(PathTestBase):
             if f.Surface.Axis == FreeCAD.Vector(0,0,1) and f.Orientation == 'Forward':
                 break
 
-        job = PathJob.Create('Job', [cut], None)
+        PathJob.Create('Job', [cut], None)
 
         profile = PathProfileFaces.Create('Profile Faces')
         profile.Base = (cut, face)
@@ -138,14 +133,14 @@ class TestDressupDogbone(PathTestBase):
             return "(%.2f, %.2f)" % (pt[0], pt[1])
 
         # Make sure we get 8 bones, 2 in each corner (different heights)
-        self.assertEquals(len(locs), 8)
-        self.assertEquals("(27.50, 27.50)", formatBoneLoc(locs[0]))
-        self.assertEquals("(27.50, 27.50)", formatBoneLoc(locs[1]))
-        self.assertEquals("(27.50, 72.50)", formatBoneLoc(locs[2]))
-        self.assertEquals("(27.50, 72.50)", formatBoneLoc(locs[3]))
-        self.assertEquals("(72.50, 27.50)", formatBoneLoc(locs[4]))
-        self.assertEquals("(72.50, 27.50)", formatBoneLoc(locs[5]))
-        self.assertEquals("(72.50, 72.50)", formatBoneLoc(locs[6]))
-        self.assertEquals("(72.50, 72.50)", formatBoneLoc(locs[7]))
+        self.assertEqual(len(locs), 8)
+        self.assertEqual("(27.50, 27.50)", formatBoneLoc(locs[0]))
+        self.assertEqual("(27.50, 27.50)", formatBoneLoc(locs[1]))
+        self.assertEqual("(27.50, 72.50)", formatBoneLoc(locs[2]))
+        self.assertEqual("(27.50, 72.50)", formatBoneLoc(locs[3]))
+        self.assertEqual("(72.50, 27.50)", formatBoneLoc(locs[4]))
+        self.assertEqual("(72.50, 27.50)", formatBoneLoc(locs[5]))
+        self.assertEqual("(72.50, 72.50)", formatBoneLoc(locs[6]))
+        self.assertEqual("(72.50, 72.50)", formatBoneLoc(locs[7]))
 
         FreeCAD.closeDocument("TestDressupDogbone")

--- a/src/Mod/Path/PathTests/TestPathDressupHoldingTags.py
+++ b/src/Mod/Path/PathTests/TestPathDressupHoldingTags.py
@@ -22,17 +22,13 @@
 # *                                                                         *
 # ***************************************************************************
 
-import FreeCAD
-import Path
-import PathScripts
+import PathTests.PathTestUtils as PathTestUtils
 import math
-import unittest
 
 from FreeCAD import Vector
-from PathScripts.PathDressupHoldingTags import *
-from PathTests.PathTestUtils import PathTestBase
+from PathScripts.PathDressupHoldingTags import Tag
 
-class TestHoldingTags(PathTestBase):
+class TestHoldingTags(PathTestUtils.PathTestBase):
     """Unit tests for the HoldingTags dressup."""
 
     def test00(self):

--- a/src/Mod/Path/PathTests/TestPathGeom.py
+++ b/src/Mod/Path/PathTests/TestPathGeom.py
@@ -22,13 +22,10 @@
 # *                                                                         *
 # ***************************************************************************
 
-import FreeCAD
 import Part
 import Path
-import PathScripts
 import PathScripts.PathGeom as PathGeom
 import math
-import unittest
 
 from FreeCAD import Vector
 from PathTests.PathTestUtils import PathTestBase
@@ -238,10 +235,6 @@ class TestPathGeom(PathTestBase):
         self.assertLine(PathGeom.edgeForCmd(Path.Command('G1',  {'X': 7, 'Y': 2, 'Z': 3}), spt), spt, Vector(7, 2, 3))
         self.assertLine(PathGeom.edgeForCmd(Path.Command('G01', {'X': 1, 'Y': 3, 'Z': 5}), spt), spt, Vector(1, 3, 5))
 
-    def test15(self):
-        """Verify proper feed rate for G1 commands is assigned."""
-        pass
-
     def test20(self):
         """Verify proper geometry for arcs in the XY-plane are created."""
         p1 = Vector(0, -1, 2)
@@ -369,7 +362,6 @@ class TestPathGeom(PathTestBase):
         e = PathGeom.arcToHelix(Part.Edge(Part.Arc(p11, p12, p13)), 2, -2)
         self.assertCurve(e, p1 + Vector(0,0,2), p2, p3 + Vector(0,0,-2))
 
-        o = 10*math.sin(math.pi/4)
         p1 = Vector(10, -10, 1)
         p2 = Vector(10 - 10*math.sin(math.pi/4), -10*math.cos(math.pi/4), 1)
         p3 = Vector(0, 0, 1)
@@ -431,8 +423,6 @@ class TestPathGeom(PathTestBase):
         o = 10*math.sin(math.pi/4)
         p12 = Vector(10 - o, -o, 2.5)
         p23 = Vector(10 - o, +o, 7.5)
-        pf = e[0].valueAt((e[0].FirstParameter + e[0].LastParameter)/2)
-        pl = e[1].valueAt((e[1].FirstParameter + e[1].LastParameter)/2)
         self.assertCurve(e[0], p1, p12, p2)
         self.assertCurve(e[1], p2, p23, p3)
 

--- a/src/Mod/Path/PathTests/TestPathLog.py
+++ b/src/Mod/Path/PathTests/TestPathLog.py
@@ -35,11 +35,11 @@ class TestPathLog(unittest.TestCase):
         PathLog.untrackAllModules()
 
     def callerFile(self):
-        return PathLog._caller()[0]
+        return PathLog._caller()[0] # pylint: disable=protected-access
     def callerLine(self):
-        return PathLog._caller()[1]
+        return PathLog._caller()[1] # pylint: disable=protected-access
     def callerFunc(self):
-        return PathLog._caller()[2]
+        return PathLog._caller()[2] # pylint: disable=protected-access
 
     def test00(self):
         """Check for proper module extraction."""

--- a/src/Mod/Path/PathTests/TestPathOpTools.py
+++ b/src/Mod/Path/PathTests/TestPathOpTools.py
@@ -24,7 +24,6 @@
 
 import FreeCAD
 import Part
-import Path
 import PathScripts.PathGeom as PathGeom
 import PathScripts.PathOpTools as PathOpTools
 import PathScripts.PathLog as PathLog
@@ -78,7 +77,7 @@ class TestPathOpTools(PathTestUtils.PathTestBase):
 
     @classmethod
     def setUpClass(cls):
-        global doc
+        global doc # pylint: disable=global-statement
         doc = FreeCAD.openDocument(FreeCAD.getHomePath() + 'Mod/Path/PathTests/test_geomop.fcstd')
 
     @classmethod

--- a/src/Mod/Path/PathTests/TestPathPost.py
+++ b/src/Mod/Path/PathTests/TestPathPost.py
@@ -33,6 +33,7 @@ import PathScripts.PathUtil
 import difflib
 import unittest
 
+WriteDebugOutput = False
 
 class PathPostTestCases(unittest.TestCase):
 
@@ -63,8 +64,8 @@ class PathPostTestCases(unittest.TestCase):
             refGCode = fp.read()
 
         # Use if this test fails in order to have a real good look at the changes
-        if False:
-            with open('tab.tmp', 'w') as fp:
+        if WriteDebugOutput:
+            with open('testLinuxCNC.tmp', 'w') as fp:
                 fp.write(gcode)
 
         if gcode != refGCode:
@@ -81,8 +82,8 @@ class PathPostTestCases(unittest.TestCase):
             refGCode = fp.read()
 
         # Use if this test fails in order to have a real good look at the changes
-        if False:
-            with open('tab.tmp', 'w') as fp:
+        if WriteDebugOutput:
+            with open('testLinuxCNCImplerial.tmp', 'w') as fp:
                 fp.write(gcode)
 
         if gcode != refGCode:
@@ -99,8 +100,8 @@ class PathPostTestCases(unittest.TestCase):
             refGCode = fp.read()
 
         # Use if this test fails in order to have a real good look at the changes
-        if False:
-            with open('tab.tmp', 'w') as fp:
+        if WriteDebugOutput:
+            with open('testCentroid.tmp', 'w') as fp:
                 fp.write(gcode)
 
         if gcode != refGCode:

--- a/src/Mod/Path/PathTests/TestPathSetupSheet.py
+++ b/src/Mod/Path/PathTests/TestPathSetupSheet.py
@@ -23,7 +23,6 @@
 # ***************************************************************************
 
 import FreeCAD
-import Path
 import PathScripts.PathSetupSheet as PathSetupSheet
 import PathScripts.PathLog as PathLog
 import sys

--- a/src/Mod/Path/PathTests/TestPathStock.py
+++ b/src/Mod/Path/PathTests/TestPathStock.py
@@ -23,8 +23,6 @@
 # ***************************************************************************
 
 import FreeCAD
-import Part
-import Path
 import PathScripts.PathStock as PathStock
 
 from PathTests.PathTestUtils import PathTestBase

--- a/src/Mod/Path/PathTests/TestPathTool.py
+++ b/src/Mod/Path/PathTests/TestPathTool.py
@@ -22,7 +22,6 @@
 # *                                                                         *
 # ***************************************************************************
 
-import FreeCAD
 import Path
 
 from PathTests.PathTestUtils import PathTestBase

--- a/src/Mod/Path/PathTests/TestPathTooltable.py
+++ b/src/Mod/Path/PathTests/TestPathTooltable.py
@@ -22,7 +22,6 @@
 # *                                                                         *
 # ***************************************************************************
 
-import FreeCAD
 import Path
 
 from PathTests.PathTestUtils import PathTestBase

--- a/src/Mod/Path/PathTests/TestPathUtil.py
+++ b/src/Mod/Path/PathTests/TestPathUtil.py
@@ -23,10 +23,7 @@
 # ***************************************************************************
 
 import FreeCAD
-import Part
-import Path
 import PathScripts.PathUtil as PathUtil
-import Sketcher
 import TestSketcherApp
 
 from PathTests.PathTestUtils import PathTestBase

--- a/src/Mod/Path/utils/path-lint.sh
+++ b/src/Mod/Path/utils/path-lint.sh
@@ -57,6 +57,7 @@ EXTERNAL_MODULES+=' PySide'
 EXTERNAL_MODULES+=' PySide.QtCore'
 EXTERNAL_MODULES+=' PySide.QtGui'
 EXTERNAL_MODULES+=' TechDraw'
+EXTERNAL_MODULES+=' TestSketcherApp'
 EXTERNAL_MODULES+=' area'
 EXTERNAL_MODULES+=' importlib'
 EXTERNAL_MODULES+=' ocl'
@@ -79,6 +80,7 @@ if [ -z "$(which pylint3)" ]; then
   exit 1
 fi
 
-#pylint3 ${ARGS} PathScripts/ PathTests/
-pylint3 ${ARGS} PathScripts/
+pylint3 ${ARGS} PathScripts/ PathTests/
+#pylint3 ${ARGS} PathScripts/
+#pylint3 ${ARGS} PathTests/
 

--- a/src/Mod/Path/utils/path-lint.sh
+++ b/src/Mod/Path/utils/path-lint.sh
@@ -62,10 +62,14 @@ EXTERNAL_MODULES+=' importlib'
 EXTERNAL_MODULES+=' ocl'
 EXTERNAL_MODULES+=' pivy'
 
+IGNORE_MODULES+=' post'
+IGNORE_MODULES+=' PathSimulatorGui.py'
+IGNORE_MODULES+=' PathSurface.py'
+
 #ARGS+=" --errors-only"
 ARGS+=" --disable=C,R"
 ARGS+=" --ignored-modules=$(echo ${EXTERNAL_MODULES} | tr ' ' ',')"
-ARGS+=" --ignore=post"
+ARGS+=" --ignore=$(echo ${IGNORE_MODULES} | tr ' ' ',')"
 ARGS+=" --jobs=4"
 
 if [ -z "$(which pylint3)" ]; then

--- a/src/Mod/Path/utils/path-lint.sh
+++ b/src/Mod/Path/utils/path-lint.sh
@@ -62,15 +62,17 @@ EXTERNAL_MODULES+=' importlib'
 EXTERNAL_MODULES+=' ocl'
 EXTERNAL_MODULES+=' pivy'
 
-IGNORE_MODULES+=' post'
+IGNORE_MODULES+=' grbl_post.py'
 IGNORE_MODULES+=' PathSimulatorGui.py'
 IGNORE_MODULES+=' PathSurface.py'
 
 #ARGS+=" --errors-only"
 ARGS+=" --disable=C,R"
 ARGS+=" --ignored-modules=$(echo ${EXTERNAL_MODULES} | tr ' ' ',')"
-ARGS+=" --ignore=$(echo ${IGNORE_MODULES} | tr ' ' ',')"
-ARGS+=" --jobs=4"
+if [ -n "${IGNORE_MODULES}" ]; then
+  ARGS+=" --ignore=$(echo ${IGNORE_MODULES} | tr ' ' ',')"
+fi
+ARGS+=" --jobs=0"
 
 if [ -z "$(which pylint3)" ]; then
   echo "Cannot find pylint, please install and try again!"


### PR DESCRIPTION
cleanup of the remaining ops, post processors and unit tests.
There are currently 3 exceptions not being linted:
* PathSimationGui.py
* PathSurface
* grbl_post.py
I don't use any of these at the moment and they have a significant amount of issues to be addressed. I hope to engage the respective authors once these changes are in.