### PR TITLE
[Path] PathHelix: Add simple x,y path sorting

### DIFF
--- a/src/Mod/Path/PathScripts/PathCircularHoleBase.py
+++ b/src/Mod/Path/PathScripts/PathCircularHoleBase.py
@@ -51,7 +51,7 @@ __doc__ = "Base class an implementation for operations on circular holes."
 __contributors__ = "russ4262 (Russell Johnson)"
 __created__ = "2017"
 __scriptVersion__ = "1d testing"
-__lastModified__ = "2019-07-09 22:59 CST"
+__lastModified__ = "2019-07-12 09:58 CST"
 
 
 # Qt translation handling
@@ -323,7 +323,7 @@ class ObjectOp(PathOp.ObjectOp):
 
                         # If user has not adjusted Final Depth value, attempt to determine from sub
                         if obj.OpFinalDepth.Value == obj.FinalDepth.Value:
-                            PathLog.info(translate('Path', 'Auto detecting Final Depth based on {}.'.format(sub)))
+                            PathLog.debug(translate('Path', 'Auto detecting Final Depth based on {}.'.format(sub)))
                             trgtDep = finDep
                         else:
                             trgtDep = max(obj.FinalDepth.Value, finDep)

--- a/src/Mod/Path/PathScripts/PathHelix.py
+++ b/src/Mod/Path/PathScripts/PathHelix.py
@@ -31,6 +31,7 @@ import PathScripts.PathOp as PathOp
 
 from PathScripts.PathUtils import fmt
 from PathScripts.PathUtils import findParentJob
+from PathScripts.PathUtils import sort_jobs
 from PySide import QtCore
 
 __title__ = "Path Helix Drill Operation"
@@ -39,8 +40,8 @@ __url__ = "http://www.freecadweb.org"
 __doc__ = "Class and implementation of Helix Drill operation"
 __contributors__ = "russ4262 (Russell Johnson)"
 __created__ = "2016"
-__scriptVersion__ = "1a testing"
-__lastModified__ = "2019-07-03 11:45 CST"
+__scriptVersion__ = "1b testing"
+__lastModified__ = "2019-07-12 09:50 CST"
 
 
 def translate(context, text, disambig=None):
@@ -81,6 +82,7 @@ class ObjectHelix(PathCircularHoleBase.ObjectOp):
         output = ''
         output += "G0 Z" + fmt(zsafe)
 
+        holes = sort_jobs(holes, ['x', 'y'])
         for hole in holes:
             output += self.helix_cut(obj, hole['x'], hole['y'], hole['r'] / 2, float(obj.StartRadius.Value), (float(obj.StepOver.Value) / 50.0) * self.radius)
         PathLog.debug(output)


### PR DESCRIPTION
PathHelix.py:  Same PathUtils.sort_jobs() method copied from PathDrilling
PathCircularHoleBase.py:  Change feedback comment to debug category

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
