### PR TITLE
Gui: Gesture: stop reacting to gestures on Macs

### DIFF
--- a/src/Gui/GestureNavigationStyle.cpp
+++ b/src/Gui/GestureNavigationStyle.cpp
@@ -940,6 +940,16 @@ SbBool GestureNavigationStyle::processSoEvent(const SoEvent* const ev)
         (this->shiftdown   ? NS::Event::SHIFTDOWN : 0) |
         (this->altdown     ? NS::Event::ALTDOWN : 0);
 
+#ifdef FC_OS_MACOSX
+    // On Mac, Qt gesture events seem to be broken. At least that's what event
+    // logs from @chrisb tell me. So, for until a developer on a mac gets here to
+    // make gestures work, I disable them. --DeepSOIC
+
+    if (smev.isGestureEvent())
+        return superclass::processSoEvent(ev);
+#endif
+
+
     if (! smev.flags->processed)
         this->naviMachine->processEvent(smev);
     if(! smev.flags->propagated && ! smev.flags->processed)


### PR DESCRIPTION
Gesture event processing causes problems on macs. Disabling for now.

https://forum.freecadweb.org/viewtopic.php?f=9&t=36387&start=10#p314575

