### PR TITLE
Add ability that PartDesign doesn't switch to Task panel when activated

### DIFF
--- a/src/Mod/PartDesign/Gui/Workbench.cpp
+++ b/src/Mod/PartDesign/Gui/Workbench.cpp
@@ -430,7 +430,8 @@ void Workbench::activated()
     _switchToDocument(App::GetApplication().getActiveDocument());
 
     addTaskWatcher(Watcher);
-    Gui::Control().showTaskView();
+    if(App::GetApplication().GetUserParameter().GetGroup("BaseApp")->GetGroup("Preferences")->GetGroup("Mod/PartDesign")->GetBool("SwitchToTask", true))
+        Gui::Control().showTaskView();
 
     // Let us be notified when a document is activated, so that we can update the ActivePartObject
     Gui::Application::Instance->signalActiveDocument.connect(boost::bind(&Workbench::slotActiveDocument, this, _1));


### PR DESCRIPTION
As of today, when PartDesign WB is activated, it automatically switches the ComboView to Task Panel.
This is hard-coded and not desirable for all users.
This PR adds ability to prevent this behavior by manually a boolean parameter named "SwitchToTask" in "Mod/PartDesign"
Setting this parameter to false prevents PartDesign to switch ComboView to Task panel.
If the parameter doesn't exist, it defaults to 'true' so current behavior is continued.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [X] Branch rebased on latest master `git pull --rebase upstream master`
- [X] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [X] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)