### PR TITLE
Settings3DView: Add tooltips and rename an option

### DIFF
--- a/src/Gui/DlgEditor.ui
+++ b/src/Gui/DlgEditor.ui
@@ -1,10 +1,8 @@
-<ui version="4.0" >
- <author></author>
- <comment></comment>
- <exportmacro></exportmacro>
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
  <class>Gui::Dialog::DlgEditorSettings</class>
- <widget class="QWidget" name="Gui::Dialog::DlgEditorSettings" >
-  <property name="geometry" >
+ <widget class="QWidget" name="Gui::Dialog::DlgEditorSettings">
+  <property name="geometry">
    <rect>
     <x>0</x>
     <y>0</y>
@@ -12,72 +10,93 @@
     <height>553</height>
    </rect>
   </property>
-  <property name="windowTitle" >
+  <property name="windowTitle">
    <string>Editor</string>
   </property>
-  <layout class="QGridLayout" >
-   <property name="margin" >
+  <layout class="QGridLayout">
+   <property name="leftMargin">
     <number>9</number>
    </property>
-   <property name="spacing" >
+   <property name="topMargin">
+    <number>9</number>
+   </property>
+   <property name="rightMargin">
+    <number>9</number>
+   </property>
+   <property name="bottomMargin">
+    <number>9</number>
+   </property>
+   <property name="spacing">
     <number>6</number>
    </property>
-   <item row="1" column="0" >
-    <widget class="QGroupBox" name="GroupBox2" >
-     <property name="title" >
+   <item row="1" column="0">
+    <widget class="QGroupBox" name="GroupBox2">
+     <property name="title">
       <string>Options</string>
      </property>
-     <layout class="QVBoxLayout" >
-      <property name="margin" >
-       <number>9</number>
-      </property>
-      <property name="spacing" >
+     <layout class="QVBoxLayout">
+      <property name="spacing">
        <number>6</number>
       </property>
+      <property name="leftMargin">
+       <number>9</number>
+      </property>
+      <property name="topMargin">
+       <number>9</number>
+      </property>
+      <property name="rightMargin">
+       <number>9</number>
+      </property>
+      <property name="bottomMargin">
+       <number>9</number>
+      </property>
       <item>
-       <widget class="Gui::PrefCheckBox" name="EnableLineNumber" >
-        <property name="focusPolicy" >
+       <widget class="Gui::PrefCheckBox" name="EnableLineNumber">
+        <property name="focusPolicy">
          <enum>Qt::TabFocus</enum>
         </property>
-        <property name="text" >
+        <property name="toolTip">
+         <string>Code lines will be numbered </string>
+        </property>
+        <property name="text">
          <string>Enable line numbers</string>
         </property>
-        <property name="checked" >
+        <property name="checked">
          <bool>true</bool>
         </property>
-        <property name="prefEntry" stdset="0" >
+        <property name="prefEntry" stdset="0">
          <cstring>EnableLineNumber</cstring>
         </property>
-        <property name="prefPath" stdset="0" >
+        <property name="prefPath" stdset="0">
          <cstring>Editor</cstring>
         </property>
        </widget>
       </item>
       <item>
-       <widget class="Gui::PrefCheckBox" name="EnableFolding" >
-        <property name="text" >
+       <widget class="Gui::PrefCheckBox" name="EnableFolding">
+        <property name="text">
          <string>Enable folding</string>
         </property>
-        <property name="checked" >
+        <property name="checked">
          <bool>true</bool>
         </property>
-        <property name="prefEntry" stdset="0" >
+        <property name="prefEntry" stdset="0">
          <cstring>EnableFolding</cstring>
         </property>
-        <property name="prefPath" stdset="0" >
+        <property name="prefPath" stdset="0">
          <cstring>Editor</cstring>
         </property>
        </widget>
       </item>
       <item>
        <spacer>
-        <property name="orientation" >
+        <property name="orientation">
          <enum>Qt::Vertical</enum>
         </property>
-        <property name="sizeType" >
+        <property name="sizeType">
          <enum>QSizePolicy::Ignored</enum>
         </property>
-        <property name="sizeHint" >
+        <property name="sizeHint" stdset="0">
          <size>
           <width>20</width>
           <height>40</height>
@@ -88,83 +107,104 @@
      </layout>
     </widget>
    </item>
-   <item row="1" column="1" >
-    <widget class="QGroupBox" name="groupBoxIndent" >
-     <property name="title" >
+   <item row="1" column="1">
+    <widget class="QGroupBox" name="groupBoxIndent">
+     <property name="title">
       <string>Indentation</string>
      </property>
-     <layout class="QGridLayout" >
-      <property name="margin" >
+     <layout class="QGridLayout">
+      <property name="leftMargin">
        <number>9</number>
       </property>
-      <property name="spacing" >
+      <property name="topMargin">
+       <number>9</number>
+      </property>
+      <property name="rightMargin">
+       <number>9</number>
+      </property>
+      <property name="bottomMargin">
+       <number>9</number>
+      </property>
+      <property name="spacing">
        <number>6</number>
       </property>
-      <item row="3" column="0" colspan="2" >
-       <widget class="Gui::PrefRadioButton" name="radioSpaces" >
-        <property name="text" >
+      <item row="3" column="0" colspan="2">
+       <widget class="Gui::PrefRadioButton" name="radioSpaces">
+        <property name="toolTip">
+         <string>Pressing &lt;Tab&gt; will insert amount of defined indent size</string>
+        </property>
+        <property name="text">
          <string>Insert spaces</string>
         </property>
-        <property name="prefEntry" stdset="0" >
+        <property name="prefEntry" stdset="0">
          <cstring>Spaces</cstring>
         </property>
-        <property name="prefPath" stdset="0" >
+        <property name="prefPath" stdset="0">
          <cstring>Editor</cstring>
         </property>
        </widget>
       </item>
-      <item row="0" column="0" >
-       <widget class="QLabel" name="textLabel1" >
-        <property name="text" >
+      <item row="0" column="0">
+       <widget class="QLabel" name="textLabel1">
+        <property name="text">
          <string>Tab size:</string>
         </property>
        </widget>
       </item>
-      <item row="0" column="1" >
-       <widget class="Gui::PrefSpinBox" name="tabSize" >
-        <property name="value" >
+      <item row="0" column="1">
+       <widget class="Gui::PrefSpinBox" name="tabSize">
+        <property name="toolTip">
+         <string>Tabulator raster (how many spaces)</string>
+        </property>
+        <property name="value">
          <number>4</number>
         </property>
-        <property name="prefEntry" stdset="0" >
+        <property name="prefEntry" stdset="0">
          <cstring>TabSize</cstring>
         </property>
-        <property name="prefPath" stdset="0" >
+        <property name="prefPath" stdset="0">
          <cstring>Editor</cstring>
         </property>
        </widget>
       </item>
-      <item row="1" column="0" >
-       <widget class="QLabel" name="textLabel2" >
-        <property name="text" >
+      <item row="1" column="0">
+       <widget class="QLabel" name="textLabel2">
+        <property name="text">
          <string>Indent size:</string>
         </property>
        </widget>
       </item>
-      <item row="1" column="1" >
-       <widget class="Gui::PrefSpinBox" name="indentSize" >
-        <property name="value" >
+      <item row="1" column="1">
+       <widget class="Gui::PrefSpinBox" name="indentSize">
+        <property name="toolTip">
+         <string>How many spaces will be inserted when pressing &lt;Tab&gt;</string>
+        </property>
+        <property name="value">
          <number>4</number>
         </property>
-        <property name="prefEntry" stdset="0" >
+        <property name="prefEntry" stdset="0">
          <cstring>IndentSize</cstring>
         </property>
-        <property name="prefPath" stdset="0" >
+        <property name="prefPath" stdset="0">
          <cstring>Editor</cstring>
         </property>
        </widget>
       </item>
-      <item row="2" column="0" colspan="2" >
-       <widget class="Gui::PrefRadioButton" name="radioTabs" >
-        <property name="text" >
+      <item row="2" column="0" colspan="2">
+       <widget class="Gui::PrefRadioButton" name="radioTabs">
+        <property name="toolTip">
+         <string>Pressing &lt;Tab&gt; will insert a tabulator with defined tab size</string>
+        </property>
+        <property name="text">
          <string>Keep tabs</string>
         </property>
-        <property name="checked" >
+        <property name="checked">
          <bool>true</bool>
         </property>
-        <property name="prefEntry" stdset="0" >
+        <property name="prefEntry" stdset="0">
          <cstring>Tabs</cstring>
         </property>
-        <property name="prefPath" stdset="0" >
+        <property name="prefPath" stdset="0">
          <cstring>Editor</cstring>
         </property>
        </widget>
@@ -172,117 +212,132 @@
      </layout>
     </widget>
    </item>
-   <item row="0" column="0" colspan="2" >
-    <widget class="QGroupBox" name="GroupBox5" >
-     <property name="sizePolicy" >
-      <sizepolicy>
-       <hsizetype>5</hsizetype>
-       <vsizetype>7</vsizetype>
+   <item row="0" column="0" colspan="2">
+    <widget class="QGroupBox" name="GroupBox5">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
      </property>
-     <property name="title" >
-      <string>Display Items</string>
+     <property name="title">
+      <string>Display items</string>
      </property>
-     <layout class="QGridLayout" >
-      <property name="margin" >
+     <layout class="QGridLayout">
+      <property name="leftMargin">
        <number>9</number>
       </property>
-      <property name="spacing" >
+      <property name="topMargin">
+       <number>9</number>
+      </property>
+      <property name="rightMargin">
+       <number>9</number>
+      </property>
+      <property name="bottomMargin">
+       <number>9</number>
+      </property>
+      <property name="spacing">
        <number>6</number>
       </property>
-      <item row="1" column="2" >
-       <widget class="Gui::PrefSpinBox" name="fontSize" >
-        <property name="sizePolicy" >
-         <sizepolicy>
-          <hsizetype>7</hsizetype>
-          <vsizetype>0</vsizetype>
+      <item row="1" column="2">
+       <widget class="Gui::PrefSpinBox" name="fontSize">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
           <horstretch>0</horstretch>
           <verstretch>0</verstretch>
          </sizepolicy>
         </property>
-        <property name="minimum" >
+        <property name="toolTip">
+         <string>Font size to be used for selected code type</string>
+        </property>
+        <property name="minimum">
          <number>1</number>
         </property>
-        <property name="value" >
+        <property name="value">
          <number>10</number>
         </property>
-        <property name="prefEntry" stdset="0" >
+        <property name="prefEntry" stdset="0">
          <cstring>FontSize</cstring>
         </property>
-        <property name="prefPath" stdset="0" >
+        <property name="prefPath" stdset="0">
          <cstring>Editor</cstring>
         </property>
        </widget>
       </item>
-      <item rowspan="4" row="0" column="0" >
-       <widget class="QTreeWidget" name="displayItems" >
-        <property name="rootIsDecorated" >
+      <item row="0" column="0" rowspan="4">
+       <widget class="QTreeWidget" name="displayItems">
+        <property name="toolTip">
+         <string>Color and font settings will be applied to selected type</string>
+        </property>
+        <property name="rootIsDecorated">
          <bool>false</bool>
         </property>
+        <column>
+         <property name="text">
+          <string notr="true">1</string>
+         </property>
+        </column>
        </widget>
       </item>
-      <item row="4" column="0" >
-       <widget class="Gui::ColorButton" name="colorButton" >
-        <property name="minimumSize" >
+      <item row="4" column="0">
+       <widget class="Gui::ColorButton" name="colorButton">
+        <property name="minimumSize">
          <size>
           <width>140</width>
           <height>0</height>
          </size>
         </property>
-        <property name="focusPolicy" >
+        <property name="focusPolicy">
          <enum>Qt::TabFocus</enum>
         </property>
-        <property name="text" >
+        <property name="text">
          <string/>
         </property>
        </widget>
       </item>
-      <item row="0" column="1" >
-       <widget class="QLabel" name="TextLabel3" >
-        <property name="text" >
+      <item row="0" column="1">
+       <widget class="QLabel" name="TextLabel3">
+        <property name="text">
          <string>Family:</string>
         </property>
        </widget>
       </item>
-      <item row="1" column="1" >
-       <widget class="QLabel" name="TextLabel4" >
-        <property name="text" >
+      <item row="1" column="1">
+       <widget class="QLabel" name="TextLabel4">
+        <property name="text">
          <string>Size:</string>
         </property>
        </widget>
       </item>
-      <item row="0" column="2" >
-       <widget class="QComboBox" name="fontFamily" >
-        <property name="sizePolicy" >
-         <sizepolicy>
-          <hsizetype>7</hsizetype>
-          <vsizetype>0</vsizetype>
+      <item row="0" column="2">
+       <widget class="QComboBox" name="fontFamily">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
           <horstretch>0</horstretch>
           <verstretch>0</verstretch>
          </sizepolicy>
+        </property>
+        <property name="toolTip">
+         <string>Font family to be used for selected code type</string>
         </property>
        </widget>
       </item>
-      <item row="2" column="1" colspan="2" >
-       <widget class="QLabel" name="label" >
-        <property name="sizePolicy" >
-         <sizepolicy>
-          <hsizetype>5</hsizetype>
-          <vsizetype>0</vsizetype>
+      <item row="2" column="1" colspan="2">
+       <widget class="QLabel" name="label">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
           <horstretch>0</horstretch>
           <verstretch>0</verstretch>
          </sizepolicy>
         </property>
-        <property name="text" >
+        <property name="text">
          <string>Preview:</string>
         </property>
        </widget>
       </item>
-      <item rowspan="2" row="3" column="1" colspan="2" >
-       <widget class="QTextEdit" name="textEdit1" >
-        <property name="tabStopWidth" >
+      <item row="3" column="1" rowspan="2" colspan="2">
+       <widget class="QTextEdit" name="textEdit1">
+        <property name="tabStopWidth">
          <number>40</number>
         </property>
        </widget>
@@ -292,35 +347,27 @@
    </item>
   </layout>
  </widget>
- <layoutdefault spacing="6" margin="11" />
+ <layoutdefault spacing="6" margin="11"/>
  <customwidgets>
   <customwidget>
    <class>Gui::ColorButton</class>
    <extends>QPushButton</extends>
    <header>Gui/Widgets.h</header>
-   <container>0</container>
-   <pixmap></pixmap>
   </customwidget>
   <customwidget>
    <class>Gui::PrefCheckBox</class>
    <extends>QCheckBox</extends>
    <header>Gui/PrefWidgets.h</header>
-   <container>0</container>
-   <pixmap></pixmap>
   </customwidget>
   <customwidget>
    <class>Gui::PrefSpinBox</class>
    <extends>QSpinBox</extends>
    <header>Gui/PrefWidgets.h</header>
-   <container>0</container>
-   <pixmap></pixmap>
   </customwidget>
   <customwidget>
    <class>Gui::PrefRadioButton</class>
    <extends>QRadioButton</extends>
    <header>Gui/PrefWidgets.h</header>
-   <container>0</container>
-   <pixmap></pixmap>
   </customwidget>
  </customwidgets>
  <tabstops>

--- a/src/Gui/DlgGeneral.ui
+++ b/src/Gui/DlgGeneral.ui
@@ -54,7 +54,11 @@
             </widget>
            </item>
            <item>
-            <widget class="QComboBox" name="Languages"/>
+            <widget class="QComboBox" name="Languages">
+             <property name="toolTip">
+              <string>Language of FreeCAD's user interface</string>
+             </property>
+            </widget>
            </item>
           </layout>
          </item>
@@ -106,6 +110,9 @@
            </item>
            <item>
             <widget class="Gui::PrefSpinBox" name="RecentFiles">
+             <property name="toolTip">
+              <string>How many files should be listed in recent files list</string>
+             </property>
              <property name="value">
               <number>4</number>
              </property>
@@ -129,6 +136,10 @@
            </property>
            <item>
             <widget class="QCheckBox" name="tiledBackground">
+             <property name="toolTip">
+              <string>Background of FreeCAD's main window will consist of tiles of a special image.
+See the FreeCAD Wiki for details about the image.</string>
+             </property>
              <property name="text">
               <string>Enable tiled background</string>
              </property>
@@ -152,7 +163,11 @@
             </widget>
            </item>
            <item>
-            <widget class="QComboBox" name="StyleSheets"/>
+            <widget class="QComboBox" name="StyleSheets">
+             <property name="toolTip">
+              <string>Style sheet how user interface will look like</string>
+             </property>
+            </widget>
            </item>
           </layout>
          </item>
@@ -172,7 +187,11 @@
             </widget>
            </item>
            <item>
-            <widget class="QComboBox" name="toolbarIconSize"/>
+            <widget class="QComboBox" name="toolbarIconSize">
+             <property name="toolTip">
+              <string>Size for the toolbar icons</string>
+             </property>
+            </widget>
            </item>
           </layout>
          </item>
@@ -193,6 +212,9 @@
          </property>
          <item row="2" column="0">
           <widget class="Gui::PrefCheckBox" name="SplashScreen">
+           <property name="toolTip">
+            <string>Splash screen of FreeCAD is shown when starting</string>
+           </property>
            <property name="text">
             <string>Enable splash screen at start up</string>
            </property>
@@ -223,7 +245,11 @@
             </widget>
            </item>
            <item row="0" column="1">
-            <widget class="QComboBox" name="AutoloadModuleCombo"/>
+            <widget class="QComboBox" name="AutoloadModuleCombo">
+             <property name="toolTip">
+              <string>What workbench will be used after starting FreeCAD</string>
+             </property>
+            </widget>
            </item>
           </layout>
          </item>
@@ -244,6 +270,10 @@
          </property>
          <item row="0" column="0">
           <widget class="Gui::PrefCheckBox" name="PythonWordWrap">
+           <property name="toolTip">
+            <string>Words will be wrapped when they exceed available
+horizontal space in Python console</string>
+           </property>
            <property name="text">
             <string>Enable word wrap</string>
            </property>

--- a/src/Gui/DlgReportView.ui
+++ b/src/Gui/DlgReportView.ui
@@ -34,6 +34,9 @@
       </property>
       <item row="0" column="0">
        <widget class="Gui::PrefCheckBox" name="checkLogging">
+        <property name="toolTip">
+         <string>Log messages will be recorded</string>
+        </property>
         <property name="text">
          <string>Record log messages</string>
         </property>
@@ -47,6 +50,9 @@
       </item>
       <item row="1" column="0">
        <widget class="Gui::PrefCheckBox" name="checkWarning">
+        <property name="toolTip">
+         <string>Warnings will be recorded</string>
+        </property>
         <property name="text">
          <string>Record warnings</string>
         </property>
@@ -63,6 +69,9 @@
       </item>
       <item row="2" column="0">
        <widget class="Gui::PrefCheckBox" name="checkError">
+        <property name="toolTip">
+         <string>Error messages will be recorded</string>
+        </property>
         <property name="text">
          <string>Record error messages</string>
         </property>
@@ -171,6 +180,9 @@
             <height>0</height>
            </size>
           </property>
+          <property name="toolTip">
+           <string>Font color for normal messages in Report view panel</string>
+          </property>
           <property name="text">
            <string/>
           </property>
@@ -225,6 +237,9 @@
             <width>75</width>
             <height>0</height>
            </size>
+          </property>
+          <property name="toolTip">
+           <string>Font color for log messages in Report view panel</string>
           </property>
           <property name="text">
            <string/>
@@ -281,6 +296,9 @@
             <height>0</height>
            </size>
           </property>
+          <property name="toolTip">
+           <string>Font color for warning messages in Report view panel</string>
+          </property>
           <property name="text">
            <string/>
           </property>
@@ -336,6 +354,9 @@
             <height>0</height>
            </size>
           </property>
+          <property name="toolTip">
+           <string>Font color for error messages in Report view panel</string>
+          </property>
           <property name="text">
            <string/>
           </property>
@@ -367,6 +388,10 @@
      <layout class="QGridLayout" name="gridLayout_2">
       <item row="0" column="0">
        <widget class="Gui::PrefCheckBox" name="pythonOutput">
+        <property name="toolTip">
+         <string>Internal Python output will be redirected
+from Python console to Report view panel</string>
+        </property>
         <property name="text">
          <string>Redirect internal Python output to report view</string>
         </property>
@@ -383,6 +408,10 @@
       </item>
       <item row="1" column="0">
        <widget class="Gui::PrefCheckBox" name="pythonError">
+        <property name="toolTip">
+         <string>Internal Python error messages will be redirected
+from Python console to Report view panel</string>
+        </property>
         <property name="text">
          <string>Redirect internal Python errors to report view</string>
         </property>

--- a/src/Gui/DlgSettings3DView.ui
+++ b/src/Gui/DlgSettings3DView.ui
@@ -22,6 +22,9 @@
      <layout class="QVBoxLayout" name="verticalLayout">
       <item>
        <widget class="Gui::PrefCheckBox" name="CheckBox_CornerCoordSystem">
+        <property name="toolTip">
+         <string>Main coordinate system will always be shown at lower right in opened files</string>
+        </property>
         <property name="text">
          <string>Show coordinate system in the corner</string>
         </property>
@@ -38,6 +41,10 @@
       </item>
       <item>
        <widget class="Gui::PrefCheckBox" name="CheckBox_ShowFPS">
+        <property name="toolTip">
+         <string>Time needed for last operation and resulting frame rate
+will be shown at the lower left in opened files</string>
+        </property>
         <property name="text">
          <string>Show counter of frames per second</string>
         </property>
@@ -53,6 +60,9 @@
        <layout class="QHBoxLayout">
         <item>
          <widget class="Gui::PrefCheckBox" name="CheckBox_NaviCube">
+          <property name="toolTip">
+           <string>Navigation cube will always be shown in opened files </string>
+          </property>
           <property name="text">
            <string>Show navigation cube</string>
           </property>
@@ -89,6 +99,9 @@
         </item>
         <item>
          <widget class="QComboBox" name="naviCubeCorner">
+          <property name="toolTip">
+           <string>Corner where navigation cube is shown</string>
+          </property>
           <property name="currentIndex">
            <number>1</number>
           </property>
@@ -118,8 +131,11 @@
       </item>
       <item>
        <widget class="Gui::PrefCheckBox" name="CheckBox_useVBO">
+        <property name="toolTip">
+         <string>Vertex Buffer Objects (VBO) will be used</string>
+        </property>
         <property name="text">
-         <string>Use OpenGL Vertex Buffer Object</string>
+         <string>Use OpenGL vertex buffer object</string>
         </property>
         <property name="prefEntry" stdset="0">
          <cstring>UseVBO</cstring>
@@ -133,6 +149,9 @@
        <widget class="Gui::PrefCheckBox" name="CheckBox_UseAutoRotation">
         <property name="enabled">
          <bool>true</bool>
+        </property>
+        <property name="toolTip">
+         <string>Enable animated rotations</string>
         </property>
         <property name="text">
          <string>Enable animation</string>
@@ -159,6 +178,9 @@
         </item>
         <item row="0" column="1">
          <widget class="QComboBox" name="comboNavigationStyle">
+          <property name="toolTip">
+           <string>Navigation settings set</string>
+          </property>
           <property name="currentIndex">
            <number>-1</number>
           </property>
@@ -186,6 +208,11 @@
         </item>
         <item row="1" column="1">
          <widget class="QComboBox" name="comboOrbitStyle">
+          <property name="toolTip">
+           <string>Rotation orbit style.
+Trackball: moving the mouse horizontally will rotate the part around the y-axis
+Turntable: the part will be rotated around the z-axis.</string>
+          </property>
           <property name="currentIndex">
            <number>1</number>
           </property>
@@ -210,6 +237,9 @@
         </item>
         <item row="2" column="1">
          <widget class="Gui::PrefComboBox" name="comboAliasing">
+          <property name="toolTip">
+           <string>What kind of multisample anti-aliasing is used </string>
+          </property>
           <property name="prefEntry" stdset="0">
            <cstring>AntiAliasing</cstring>
           </property>
@@ -252,6 +282,9 @@
         </item>
         <item row="3" column="1">
          <widget class="QComboBox" name="comboNewDocView">
+          <property name="toolTip">
+           <string>Camera orientation for new documents </string>
+          </property>
          </widget>
         </item>
        </layout>
@@ -260,6 +293,9 @@
        <layout class="QHBoxLayout" name="horizontalLayout">
         <item>
          <widget class="Gui::PrefCheckBox" name="checkBoxZoomAtCursor">
+          <property name="toolTip">
+           <string>Zoom operations will be performed at position of mouse pointer</string>
+          </property>
           <property name="text">
            <string>Zoom at cursor</string>
           </property>
@@ -296,6 +332,10 @@
         </item>
         <item>
          <widget class="Gui::PrefDoubleSpinBox" name="spinBoxZoomStep">
+          <property name="toolTip">
+           <string>How much will be zoomed.
+Zoom step of '1' means a factor of 7.5 for every zoom step. </string>
+          </property>
           <property name="minimum">
            <double>0.010000000000000</double>
           </property>
@@ -320,6 +360,9 @@
       </item>
       <item>
        <widget class="Gui::PrefCheckBox" name="checkBoxInvertZoom">
+        <property name="toolTip">
+         <string>Direction of zoom operations will be inverted</string>
+        </property>
         <property name="text">
          <string>Invert zoom</string>
         </property>
@@ -337,7 +380,9 @@
       <item>
        <widget class="Gui::PrefCheckBox" name="checkBoxDisableTilt">
         <property name="toolTip">
-         <string>Prevents view tilting when pinch-zooming. Affects only Gesture nav. style. Mouse tilting is not disabled by this setting.</string>
+         <string>Prevents view tilting when pinch-zooming.
+Affects only Gesture navigation style.
+Mouse tilting is not disabled by this setting.</string>
         </property>
         <property name="text">
          <string>Disable touchscreen tilt gesture</string>
@@ -355,8 +400,11 @@
       </item>
       <item>
        <widget class="Gui::PrefCheckBox" name="checkBoxDragAtCursor">
+        <property name="toolTip">
+         <string>Rotations in 3D will use current cursor position as center for rotation</string>
+        </property>
         <property name="text">
-         <string>Drag at cursor</string>
+         <string>Rotate at cursor</string>
         </property>
         <property name="checked">
          <bool>false</bool>
@@ -388,13 +436,20 @@
         </property>
         <item>
          <widget class="QLabel" name="markerSizeLabel">
+          <property name="toolTip">
+           <string/>
+          </property>
           <property name="text">
            <string>Marker size:</string>
           </property>
          </widget>
         </item>
         <item>
-         <widget class="QComboBox" name="boxMarkerSize"/>
+         <widget class="QComboBox" name="boxMarkerSize">
+          <property name="toolTip">
+           <string>Size of vertices in the Sketcher workbench</string>
+          </property>
+         </widget>
         </item>
        </layout>
       </item>
@@ -437,6 +492,11 @@
         </item>
         <item>
          <widget class="Gui::PrefDoubleSpinBox" name="FloatSpinBox_EyeDistance">
+          <property name="toolTip">
+           <string>Eye-to-eye distance used for stereo projections.
+The specified value is a factor that will be multiplied with the
+bounding box size of the 3D object that is currently displayed. </string>
+          </property>
           <property name="decimals">
            <number>1</number>
           </property>
@@ -500,6 +560,9 @@
             <verstretch>0</verstretch>
            </sizepolicy>
           </property>
+          <property name="toolTip">
+           <string>Intensity of the backlight</string>
+          </property>
           <property name="maximum">
            <number>100</number>
           </property>
@@ -531,6 +594,9 @@
           <property name="enabled">
            <bool>false</bool>
           </property>
+          <property name="toolTip">
+           <string>Backlight color</string>
+          </property>
           <property name="color" stdset="0">
            <color>
             <red>255</red>
@@ -548,6 +614,9 @@
         </item>
         <item row="1" column="0">
          <widget class="QLabel" name="backlightLabel">
+          <property name="toolTip">
+           <string/>
+          </property>
           <property name="text">
            <string>Intensity of backlight</string>
           </property>
@@ -555,6 +624,9 @@
         </item>
         <item row="0" column="0">
          <widget class="Gui::PrefCheckBox" name="checkBoxBacklight">
+          <property name="toolTip">
+           <string>Backlight is enabled with the defined color</string>
+          </property>
           <property name="text">
            <string>Enable backlight color</string>
           </property>
@@ -594,6 +666,9 @@
       </property>
       <item row="0" column="1">
        <widget class="Gui::PrefRadioButton" name="radioOrthographic">
+        <property name="toolTip">
+         <string>Objects will be projected in orthographic projection</string>
+        </property>
         <property name="text">
          <string>Or&amp;thographic rendering</string>
         </property>
@@ -610,6 +685,9 @@
       </item>
       <item row="0" column="0">
        <widget class="Gui::PrefRadioButton" name="radioPerspective">
+        <property name="toolTip">
+         <string>Objects will appear in a perspective projection</string>
+        </property>
         <property name="text">
          <string>Perspective renderin&amp;g</string>
         </property>

--- a/src/Gui/DlgSettings3DView.ui
+++ b/src/Gui/DlgSettings3DView.ui
@@ -381,7 +381,7 @@ Zoom step of '1' means a factor of 7.5 for every zoom step. </string>
        <widget class="Gui::PrefCheckBox" name="checkBoxDisableTilt">
         <property name="toolTip">
          <string>Prevents view tilting when pinch-zooming.
-Affects only Gesture navigation style.
+Affects only gesture navigation style.
 Mouse tilting is not disabled by this setting.</string>
         </property>
         <property name="text">

--- a/src/Gui/DlgSettingsDocument.ui
+++ b/src/Gui/DlgSettingsDocument.ui
@@ -33,7 +33,16 @@
       <string>General</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_4">
-      <property name="margin">
+      <property name="leftMargin">
+       <number>9</number>
+      </property>
+      <property name="topMargin">
+       <number>9</number>
+      </property>
+      <property name="rightMargin">
+       <number>9</number>
+      </property>
+      <property name="bottomMargin">
        <number>9</number>
       </property>
       <property name="spacing">
@@ -44,7 +53,16 @@
         <property name="spacing">
          <number>6</number>
         </property>
-        <property name="margin">
+        <property name="leftMargin">
+         <number>0</number>
+        </property>
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <property name="rightMargin">
+         <number>0</number>
+        </property>
+        <property name="bottomMargin">
          <number>0</number>
         </property>
         <item>
@@ -57,6 +75,9 @@
         </item>
         <item>
          <widget class="Gui::PrefSpinBox" name="prefCompression">
+          <property name="toolTip">
+           <string>Compression level for FCStd files</string>
+          </property>
           <property name="value">
            <number>3</number>
           </property>
@@ -75,7 +96,16 @@
         <property name="spacing">
          <number>6</number>
         </property>
-        <property name="margin">
+        <property name="leftMargin">
+         <number>0</number>
+        </property>
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <property name="rightMargin">
+         <number>0</number>
+        </property>
+        <property name="bottomMargin">
          <number>0</number>
         </property>
         <item>
@@ -87,6 +117,9 @@
         </item>
         <item>
          <widget class="Gui::PrefSpinBox" name="prefUndoRedoSize">
+          <property name="toolTip">
+           <string>How many Undo/Redo steps should be recorded</string>
+          </property>
           <property name="value">
            <number>20</number>
           </property>
@@ -102,6 +135,9 @@
       </item>
       <item row="0" column="0">
        <widget class="Gui::PrefCheckBox" name="prefCheckNewDoc">
+        <property name="toolTip">
+         <string>FreeCAD will create a new document when started</string>
+        </property>
         <property name="text">
          <string>Create new document at start up</string>
         </property>
@@ -144,6 +180,9 @@
       </item>
       <item row="4" column="0">
        <widget class="Gui::PrefCheckBox" name="prefUndoRedo">
+        <property name="toolTip">
+         <string>All changes in documents are stored so that they can be undone/redone</string>
+        </property>
         <property name="text">
          <string>Using Undo/Redo on documents</string>
         </property>
@@ -201,6 +240,10 @@
       </item>
       <item row="2" column="0">
        <widget class="Gui::PrefCheckBox" name="prefRecovery">
+        <property name="toolTip">
+         <string>If there is a recovery file available FreeCAD will
+automatically run a file recovery when it is started.</string>
+        </property>
         <property name="text">
          <string>Run AutoRecovery at startup</string>
         </property>
@@ -219,6 +262,9 @@
        <layout class="QHBoxLayout" name="horizontalLayout">
         <item>
          <widget class="Gui::PrefCheckBox" name="prefAutoSaveEnabled">
+          <property name="toolTip">
+           <string>How often a recovery file is written</string>
+          </property>
           <property name="text">
            <string>Save AutoRecovery information every</string>
           </property>
@@ -272,6 +318,9 @@
       </item>
       <item row="5" column="0">
        <widget class="Gui::PrefCheckBox" name="prefSaveThumbnail">
+        <property name="toolTip">
+         <string>A thumbnail will be stored when document is saved</string>
+        </property>
         <property name="text">
          <string>Save thumbnail into project file when saving document</string>
         </property>
@@ -288,11 +337,23 @@
         <property name="spacing">
          <number>6</number>
         </property>
-        <property name="margin">
+        <property name="leftMargin">
+         <number>0</number>
+        </property>
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <property name="rightMargin">
+         <number>0</number>
+        </property>
+        <property name="bottomMargin">
          <number>0</number>
         </property>
         <item>
          <widget class="Gui::PrefCheckBox" name="prefSaveBackupFiles">
+          <property name="toolTip">
+           <string>How many backup files will be kept when saving document</string>
+          </property>
           <property name="text">
            <string>Maximum number of backup files to keep when resaving document</string>
           </property>
@@ -340,6 +401,9 @@
       </item>
       <item row="6" column="0">
        <widget class="Gui::PrefCheckBox" name="prefAddLogo">
+        <property name="toolTip">
+         <string>FreeCAD program logo will be added to the thumbnail</string>
+        </property>
         <property name="text">
          <string>Add the program logo to the generated thumbnail</string>
         </property>
@@ -365,6 +429,9 @@
      <layout class="QGridLayout" name="gridLayout">
       <item row="0" column="0">
        <widget class="Gui::PrefCheckBox" name="prefDuplicateLabel">
+        <property name="toolTip">
+         <string>Allow objects to have same label/name</string>
+        </property>
         <property name="text">
          <string>Allow duplicate object labels in one document</string>
         </property>
@@ -395,7 +462,9 @@
       <item row="0" column="1">
        <widget class="Gui::PrefLineEdit" name="prefAuthor">
         <property name="toolTip">
-         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The name to use on document creation.&lt;/p&gt;&lt;p&gt;Keep blank for anonymous.&lt;/p&gt;&lt;p&gt;You can also use the form:&lt;/p&gt;&lt;p&gt;John Doe &amp;lt;john@doe.com&amp;gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         <string>All documents that will be created will get the specified author name.
+Keep blank for anonymous.
+You can also use the form: John Doe &lt;john@doe.com&gt;</string>
         </property>
         <property name="prefEntry" stdset="0">
          <cstring>prefAuthor</cstring>
@@ -408,7 +477,7 @@
       <item row="0" column="2">
        <widget class="Gui::PrefCheckBox" name="prefSetAuthorOnSave">
         <property name="toolTip">
-         <string>If this is checked, the &quot;Last modified by&quot; field will be set when saving the file</string>
+         <string>The field 'Last modified by' will be set to specified author when saving the file</string>
         </property>
         <property name="text">
          <string>Set on save</string>
@@ -431,7 +500,7 @@
       <item row="1" column="1" colspan="2">
        <widget class="Gui::PrefLineEdit" name="prefCompany">
         <property name="toolTip">
-         <string>The default company to use for new files</string>
+         <string>Default company name to use for new files</string>
         </property>
         <property name="prefEntry" stdset="0">
          <cstring>prefCompany</cstring>
@@ -454,7 +523,7 @@
          <bool>true</bool>
         </property>
         <property name="toolTip">
-         <string>The default license for new documents</string>
+         <string>Default license for new documents</string>
         </property>
         <property name="editable">
          <bool>false</bool>
@@ -527,7 +596,7 @@
       <item row="3" column="1" colspan="2">
        <widget class="Gui::PrefLineEdit" name="prefLicenseUrl">
         <property name="toolTip">
-         <string>A URL where the user can find more details about the license</string>
+         <string>URL describing more about the license</string>
         </property>
         <property name="text">
          <string notr="true">http://en.wikipedia.org/wiki/All_rights_reserved</string>

--- a/src/Gui/DlgSettingsMacro.ui
+++ b/src/Gui/DlgSettingsMacro.ui
@@ -22,6 +22,9 @@
      <layout class="QGridLayout" name="gridLayout">
       <item row="0" column="0">
        <widget class="Gui::PrefCheckBox" name="PrefCheckBox_LocalEnv">
+        <property name="toolTip">
+         <string>Variables defined by macros are created as local variables</string>
+        </property>
         <property name="text">
          <string>Run macros in local environment</string>
         </property>
@@ -78,6 +81,9 @@
          </property>
          <item>
           <widget class="Gui::PrefCheckBox" name="PConsoleCheckBox">
+           <property name="toolTip">
+            <string>Commands executed by macro scripts are shown in Python console</string>
+           </property>
            <property name="text">
             <string>Show script commands in python console</string>
            </property>
@@ -135,6 +141,9 @@
          </property>
          <item row="0" column="0">
           <widget class="Gui::PrefCheckBox" name="PrefCheckBox_RecordGui">
+           <property name="toolTip">
+            <string>Recorded macros will also contain user interface commands</string>
+           </property>
            <property name="text">
             <string>Record GUI commands</string>
            </property>
@@ -151,6 +160,9 @@
          </item>
          <item row="1" column="0">
           <widget class="Gui::PrefCheckBox" name="PrefCheckBox_GuiAsComment">
+           <property name="toolTip">
+            <string>Recorded macros will also contain user interface commands as comments</string>
+           </property>
            <property name="text">
             <string>Record as comment</string>
            </property>

--- a/src/Gui/DlgSettingsUnits.ui
+++ b/src/Gui/DlgSettingsUnits.ui
@@ -44,6 +44,9 @@
         </item>
         <item>
          <widget class="QSpinBox" name="spinBoxDecimals">
+          <property name="toolTip">
+           <string>Number of decimals that should be shown for numbers and dimensions in FreeCAD</string>
+          </property>
           <property name="minimum">
            <number>1</number>
           </property>
@@ -65,6 +68,9 @@
         </item>
         <item>
          <widget class="QComboBox" name="comboBox_ViewSystem">
+          <property name="toolTip">
+           <string>Unit system that should be used for all parts of FreeCAD</string>
+          </property>
           <item>
            <property name="text">
             <string>Standard (mm/kg/s/degree)</string>
@@ -144,7 +150,7 @@
         <item>
          <widget class="QComboBox" name="comboBox_FracInch">
           <property name="toolTip">
-           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Minimum fractional inch to display.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           <string>Minimum fractional inch to be displayed</string>
           </property>
           <item>
            <property name="text">

--- a/src/Gui/DlgSettingsViewColor.ui
+++ b/src/Gui/DlgSettingsViewColor.ui
@@ -111,6 +111,9 @@
             <height>0</height>
            </size>
           </property>
+          <property name="toolTip">
+           <string>Enable preselection and highlight by specified color</string>
+          </property>
           <property name="text">
            <string>Enable preselection highlighting</string>
           </property>
@@ -156,6 +159,9 @@
         </item>
         <item row="1" column="0">
          <widget class="Gui::PrefCheckBox" name="checkBoxSelection">
+          <property name="toolTip">
+           <string>Enable selection highlighting and use specified color</string>
+          </property>
           <property name="text">
            <string>Enable selection highlighting</string>
           </property>
@@ -180,7 +186,8 @@
         <item row="2" column="1">
          <widget class="Gui::PrefDoubleSpinBox" name="spinPickRadius">
           <property name="toolTip">
-           <string>Sets the area of confusion for picking elements in 3D view. Larger value makes it easier to pick stuff, but will make some small features impossible to select.</string>
+           <string>Area for picking elements in 3D view.
+Larger value eases to pick things, but can make small features impossible to select.</string>
           </property>
           <property name="inputMethodHints">
            <set>Qt::ImhPreferNumbers</set>
@@ -308,6 +315,9 @@
         </item>
         <item row="3" column="0">
          <widget class="Gui::PrefCheckBox" name="checkMidColor">
+          <property name="toolTip">
+           <string>Color gradient will get selected color as middle color</string>
+          </property>
           <property name="text">
            <string>Middle color</string>
           </property>
@@ -364,6 +374,9 @@
         </item>
         <item row="1" column="0">
          <widget class="Gui::PrefRadioButton" name="radioButtonGradient">
+          <property name="toolTip">
+           <string>Background for parts will have selected color gradient</string>
+          </property>
           <property name="text">
            <string>Color gradient</string>
           </property>
@@ -406,6 +419,9 @@
             <height>0</height>
            </size>
           </property>
+          <property name="toolTip">
+           <string>Background for parts will have selected color</string>
+          </property>
           <property name="text">
            <string>Simple color</string>
           </property>
@@ -425,7 +441,7 @@
    <item row="2" column="0">
     <widget class="QGroupBox" name="groupBoxTree">
      <property name="title">
-      <string>Tree View</string>
+      <string>Tree view</string>
      </property>
      <layout class="QGridLayout">
       <property name="leftMargin">
@@ -481,6 +497,9 @@
             <height>0</height>
            </size>
           </property>
+          <property name="toolTip">
+           <string/>
+          </property>
           <property name="text">
            <string>Object being edited</string>
           </property>
@@ -493,6 +512,9 @@
             <horstretch>0</horstretch>
             <verstretch>0</verstretch>
            </sizepolicy>
+          </property>
+          <property name="toolTip">
+           <string>Background color for objects in tree view that are currently edited</string>
           </property>
           <property name="color" stdset="0">
            <color>
@@ -523,6 +545,9 @@
             <horstretch>0</horstretch>
             <verstretch>0</verstretch>
            </sizepolicy>
+          </property>
+          <property name="toolTip">
+           <string>Background color for active containers in tree view</string>
           </property>
           <property name="color" stdset="0">
            <color>

--- a/src/Mod/Part/Gui/DlgSettingsObjectColor.ui
+++ b/src/Mod/Part/Gui/DlgSettingsObjectColor.ui
@@ -17,7 +17,7 @@
    <item>
     <widget class="QGroupBox" name="groupBoxDefaultColors">
      <property name="title">
-      <string>Default Part colors</string>
+      <string>Default part colors</string>
      </property>
      <layout class="QHBoxLayout" name="horizontalLayout">
       <item>
@@ -64,7 +64,7 @@
         <item row="1" column="1">
          <widget class="Gui::PrefColorButton" name="DefaultShapeLineColor">
           <property name="toolTip">
-           <string>The default line color for new shapes</string>
+           <string>Default line color for new shapes</string>
           </property>
           <property name="color" stdset="0">
            <color>
@@ -84,7 +84,7 @@
         <item row="0" column="1">
          <widget class="Gui::PrefColorButton" name="DefaultShapeColor">
           <property name="toolTip">
-           <string>The default color for new shapes</string>
+           <string>Default color for new shapes</string>
           </property>
           <property name="color" stdset="0">
            <color>
@@ -104,7 +104,7 @@
         <item row="2" column="1">
          <widget class="Gui::PrefSpinBox" name="DefaultShapeLineWidth">
           <property name="toolTip">
-           <string>The default line thickness for new shapes</string>
+           <string>Default line thickness for new shapes</string>
           </property>
           <property name="suffix">
            <string>px</string>
@@ -126,7 +126,7 @@
         <item row="4" column="1">
          <widget class="Gui::PrefSpinBox" name="DefaultShapeVertexWidth">
           <property name="toolTip">
-           <string>The default size for new vertices</string>
+           <string>Default size for new vertices</string>
           </property>
           <property name="suffix">
            <string>px</string>
@@ -148,7 +148,7 @@
         <item row="5" column="1">
          <widget class="Gui::PrefColorButton" name="BoundingBoxColor">
           <property name="toolTip">
-           <string>The color of bounding boxes in the 3D view</string>
+           <string>Color of bounding boxes in the 3D view</string>
           </property>
           <property name="color" stdset="0">
            <color>
@@ -207,7 +207,7 @@
         <item row="3" column="1">
          <widget class="Gui::PrefColorButton" name="DefaultShapeVertexColor">
           <property name="toolTip">
-           <string>The default color for new vertices</string>
+           <string>Default color for new vertices</string>
           </property>
           <property name="color" stdset="0">
            <color>
@@ -226,6 +226,9 @@
         </item>
         <item row="0" column="2">
          <widget class="Gui::PrefCheckBox" name="checkRandomColor">
+          <property name="toolTip">
+           <string>A random color is used</string>
+          </property>
           <property name="text">
            <string>Random shape color</string>
           </property>
@@ -278,6 +281,9 @@
         </item>
         <item row="0" column="1">
          <widget class="Gui::PrefColorButton" name="AnnotationTextColor">
+          <property name="toolTip">
+           <string>Default text color for document annotations</string>
+          </property>
           <property name="prefEntry" stdset="0">
            <cstring>AnnotationTextColor</cstring>
           </property>

--- a/src/Mod/Sketcher/Gui/SketcherSettings.ui
+++ b/src/Mod/Sketcher/Gui/SketcherSettings.ui
@@ -56,7 +56,7 @@
          <item>
           <widget class="Gui::PrefCheckBox" name="checkBoxNotifyConstraintSubstitutions">
            <property name="toolTip">
-            <string>Notify automatic constraint substitutions</string>
+            <string>Notifies about automatic constraint substitutions</string>
            </property>
            <property name="text">
             <string>Notify automatic constraint substitutions</string>
@@ -90,6 +90,9 @@
       </item>
       <item row="0" column="1">
        <widget class="Gui::PrefSpinBox" name="EditSketcherFontSize">
+        <property name="toolTip">
+         <string>Font size used for labels and constraints</string>
+        </property>
         <property name="suffix">
          <string>px</string>
         </property>
@@ -112,6 +115,9 @@
       </item>
       <item row="1" column="1">
        <widget class="QComboBox" name="comboBox">
+        <property name="toolTip">
+         <string>Line pattern used for grid lines</string>
+        </property>
         <property name="currentIndex">
          <number>-1</number>
         </property>
@@ -119,6 +125,9 @@
       </item>
       <item row="3" column="0" colspan="2">
        <widget class="Gui::PrefCheckBox" name="dialogOnDistanceConstraint">
+        <property name="toolTip">
+         <string>A dialog will pop up to input a value for new dimensional constraints</string>
+        </property>
         <property name="text">
          <string>Ask for value after creating a dimensional constraint</string>
         </property>
@@ -142,8 +151,11 @@
       </item>
       <item row="4" column="0" colspan="2">
        <widget class="Gui::PrefCheckBox" name="continueMode">
+        <property name="toolTip">
+         <string>Current sketcher creation tool will remain active after creation</string>
+        </property>
         <property name="text">
-         <string>Geometry Creation &quot;Continue Mode&quot;</string>
+         <string>Geometry creation &quot;Continue Mode&quot;</string>
         </property>
         <property name="checked">
          <bool>true</bool>
@@ -158,8 +170,11 @@
       </item>
       <item row="5" column="0" colspan="2">
        <widget class="Gui::PrefCheckBox" name="constraintMode">
+        <property name="toolTip">
+         <string>Current constraint creation tool will remain active after creation</string>
+        </property>
         <property name="text">
-         <string>Constraint Creation &quot;Continue Mode&quot;</string>
+         <string>Constraint creation &quot;Continue Mode&quot;</string>
         </property>
         <property name="checked">
          <bool>true</bool>
@@ -208,7 +223,7 @@
          <item>
           <widget class="Gui::PrefCheckBox" name="checkBoxTVHideDependent">
            <property name="toolTip">
-            <string>When opening sketch, hide all features that depend on it.</string>
+            <string>When opening sketch, hide all features that depend on it</string>
            </property>
            <property name="text">
             <string>Hide all objects that depend on the sketch</string>
@@ -227,7 +242,7 @@
          <item>
           <widget class="Gui::PrefCheckBox" name="checkBoxTVShowLinks">
            <property name="toolTip">
-            <string>When opening sketch, show sources for external geometry links.</string>
+            <string>When opening sketch, show sources for external geometry links</string>
            </property>
            <property name="text">
             <string>Show objects used for external geometry</string>
@@ -246,7 +261,7 @@
          <item>
           <widget class="Gui::PrefCheckBox" name="checkBoxTVShowSupport">
            <property name="toolTip">
-            <string>When opening sketch, show objects the sketch is attached to.</string>
+            <string>When opening sketch, show objects the sketch is attached to</string>
            </property>
            <property name="text">
             <string>Show object(s) sketch is attached to</string>
@@ -265,7 +280,7 @@
          <item>
           <widget class="Gui::PrefCheckBox" name="checkBoxTVRestoreCamera">
            <property name="toolTip">
-            <string>When closing sketch, move camera back to where it was before sketch was opened.</string>
+            <string>When closing sketch, move camera back to where it was before sketch was opened</string>
            </property>
            <property name="text">
             <string>Restore camera position after editing</string>
@@ -309,7 +324,7 @@
             </sizepolicy>
            </property>
            <property name="toolTip">
-            <string>Apply current smart visibility to all sketches in open documents (update properties to match).</string>
+            <string>Applies current visibility automation settings to all sketches in open documents</string>
            </property>
            <property name="text">
             <string>Apply to existing sketches</string>
@@ -328,6 +343,9 @@
       </item>
       <item row="2" column="1">
        <widget class="Gui::PrefSpinBox" name="SegmentsPerGeometry">
+        <property name="toolTip">
+         <string>Number of polygons for geometry approximation</string>
+        </property>
         <property name="minimum">
          <number>50</number>
         </property>
@@ -345,7 +363,8 @@
       <item row="6" column="0">
        <widget class="Gui::PrefCheckBox" name="checkBoxHideUnits">
         <property name="toolTip">
-         <string>Do not show base length units in sketches. Supports all unit systems except US Customary and Building US/Euro.</string>
+         <string>Base length units will not be displayed in constraints.
+Supports all unit systems except 'US customary' and 'Building US/Euro'.</string>
         </property>
         <property name="text">
          <string>Hide base length units for supported unit systems</string>
@@ -364,13 +383,17 @@
    <item row="2" column="0">
     <widget class="QGroupBox" name="groupBox_2">
      <property name="title">
-      <string>Sketcher Solver</string>
+      <string>Sketcher solver</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_4">
       <item row="0" column="0">
        <widget class="Gui::PrefCheckBox" name="checkBoxAdvancedSolverTaskBox">
+        <property name="toolTip">
+         <string>Sketcher dialog will have additional section
+'Advanced solver control' to adjust solver settings</string>
+        </property>
         <property name="text">
-         <string>Show Advanced Solver Control in the Task bar</string>
+         <string>Show section 'Advanced solver control' in task dialog</string>
         </property>
         <property name="prefEntry" stdset="0">
          <cstring>ShowSolverAdvancedWidget</cstring>
@@ -386,13 +409,17 @@
    <item row="3" column="0">
     <widget class="QGroupBox" name="groupBox_4">
      <property name="title">
-      <string>Dragging Performance</string>
+      <string>Dragging performance</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_5" rowstretch="0,0" columnstretch="0,0">
       <item row="1" column="0" colspan="2">
        <widget class="Gui::PrefCheckBox" name="checkBoxRecalculateInitialSolutionWhileDragging">
+        <property name="toolTip">
+         <string>Special solver algorithm will be used while dragging sketch elements.
+Requires to re-enter edit mode to take effect.</string>
+        </property>
         <property name="text">
-         <string>Improve solving while dragging (requires to re-enter edit mode to take effect)</string>
+         <string>Improve solving while dragging</string>
         </property>
         <property name="checked">
          <bool>true</bool>

--- a/src/Mod/Sketcher/Gui/SketcherSettingsColors.ui
+++ b/src/Mod/Sketcher/Gui/SketcherSettingsColors.ui
@@ -38,7 +38,7 @@
         <item row="0" column="1">
          <widget class="Gui::PrefColorButton" name="SketchEdgeColor">
           <property name="toolTip">
-           <string>The color of edges being edited</string>
+           <string>Color of edges</string>
           </property>
           <property name="color">
            <color>
@@ -71,7 +71,7 @@
         <item row="1" column="1">
          <widget class="Gui::PrefColorButton" name="SketchVertexColor">
           <property name="toolTip">
-           <string>The color of vertices being edited</string>
+           <string>Color of vertices</string>
           </property>
           <property name="color">
            <color>
@@ -103,6 +103,9 @@
         </item>
         <item row="2" column="1">
          <widget class="Gui::PrefColorButton" name="CreateLineColor">
+          <property name="toolTip">
+           <string>Color used while new sketch elements are created</string>
+          </property>
           <property name="color">
            <color>
             <red>204</red>
@@ -134,7 +137,7 @@
         <item row="3" column="1">
          <widget class="Gui::PrefColorButton" name="EditedEdgeColor">
           <property name="toolTip">
-           <string>The color of edges being edited</string>
+           <string>Color of edges being edited</string>
           </property>
           <property name="color">
            <color>
@@ -167,7 +170,7 @@
         <item row="4" column="1">
          <widget class="Gui::PrefColorButton" name="EditedVertexColor">
           <property name="toolTip">
-           <string>The color of vertices being edited</string>
+           <string>Color of vertices being edited</string>
           </property>
           <property name="color">
            <color>
@@ -200,7 +203,7 @@
         <item row="5" column="1">
          <widget class="Gui::PrefColorButton" name="ConstructionColor">
           <property name="toolTip">
-           <string>The color of construction geometry in edit mode</string>
+           <string>Color of construction geometry in edit mode</string>
           </property>
           <property name="color">
            <color>
@@ -233,7 +236,7 @@
         <item row="6" column="1">
          <widget class="Gui::PrefColorButton" name="ExternalColor">
           <property name="toolTip">
-           <string>The color of external geometry in edit mode</string>
+           <string>Color of external geometry in edit mode</string>
           </property>
           <property name="color">
            <color>
@@ -266,7 +269,7 @@
         <item row="7" column="1">
          <widget class="Gui::PrefColorButton" name="FullyConstrainedColor">
           <property name="toolTip">
-           <string>The color of fully constrained geometry in edit mode</string>
+           <string>Color of fully constrained geometry in edit mode</string>
           </property>
           <property name="color">
            <color>
@@ -299,7 +302,7 @@
         <item row="8" column="1">
          <widget class="Gui::PrefColorButton" name="ConstrainedColor">
           <property name="toolTip">
-           <string>The color of driving constraints in edit mode</string>
+           <string>Color of driving constraints in edit mode</string>
           </property>
           <property name="color">
            <color>
@@ -319,14 +322,14 @@
         <item row="9" column="0">
          <widget class="QLabel" name="label_8">
           <property name="text">
-           <string>Reference Constraint color</string>
+           <string>Reference constraint color</string>
           </property>
          </widget>
         </item>
         <item row="9" column="1">
          <widget class="Gui::PrefColorButton" name="NonDrivingConstraintColor">
           <property name="toolTip">
-           <string>The color of reference constrains and datum in edit mode</string>
+           <string>Color of reference constraints in edit mode</string>
           </property>
           <property name="color">
            <color>
@@ -353,7 +356,7 @@
         <item row="10" column="1">
          <widget class="Gui::PrefColorButton" name="ExprBasedConstrDimColor">
           <property name="toolTip">
-           <string>The color of expression dependent datum constraints in edit mode</string>
+           <string>Color of expression dependent constraints in edit mode</string>
           </property>
           <property name="color">
            <color>
@@ -380,7 +383,7 @@
         <item row="11" column="1">
          <widget class="Gui::PrefColorButton" name="DeactivatedConstrDimColor">
           <property name="toolTip">
-           <string>The color of deactivated constraints in edit mode</string>
+           <string>Color of deactivated constraints in edit mode</string>
           </property>
           <property name="color">
            <color>
@@ -413,7 +416,7 @@
         <item row="12" column="1">
          <widget class="Gui::PrefColorButton" name="DatumColor">
           <property name="toolTip">
-           <string>The color of the datum portion of a driving constraint</string>
+           <string>Color of the datum portion of a driving constraint</string>
           </property>
           <property name="color">
            <color>
@@ -544,12 +547,15 @@
            </size>
           </property>
           <property name="text">
-           <string>Cursor text color</string>
+           <string>Coordinate text color</string>
           </property>
          </widget>
         </item>
         <item row="16" column="1">
          <widget class="Gui::PrefColorButton" name="CursorTextColor">
+          <property name="toolTip">
+           <string>Text color of the coordinates</string>
+          </property>
           <property name="color">
            <color>
             <red>0</red>
@@ -580,6 +586,10 @@
         </item>
         <item row="17" column="1">
          <widget class="Gui::PrefColorButton" name="CursorCrosshairColor">
+          <property name="toolTip">
+           <string>Color of crosshair cursor.
+(The one you get when creating a new sketch element.)</string>
+          </property>
           <property name="color">
            <color>
             <red>255</red>

--- a/src/Mod/Sketcher/Gui/TaskSketcherConstrains.ui
+++ b/src/Mod/Sketcher/Gui/TaskSketcherConstrains.ui
@@ -59,8 +59,11 @@
    </item>
    <item>
     <widget class="Gui::PrefCheckBox" name="filterInternalAlignment">
+     <property name="toolTip">
+      <string>Internal alignments will be hidden</string>
+     </property>
      <property name="text">
-      <string>Hide Internal Alignment</string>
+      <string>Hide internal alignment</string>
      </property>
      <property name="checked">
       <bool>true</bool>
@@ -74,21 +77,24 @@
     </widget>
    </item>
    <item>
-       <widget class="Gui::PrefCheckBox" name="extendedInformation">
-           <property name="text">
-               <string>Extended Information</string>
-           </property>
-           <property name="checked">
-               <bool>false</bool>
-           </property>
-           <property name="prefEntry" stdset="0">
-               <cstring>ExtendedConstraintInformation</cstring>
-           </property>
-           <property name="prefPath" stdset="0">
-               <cstring>Mod/Sketcher</cstring>
-           </property>
-       </widget>
-   </item>   
+    <widget class="Gui::PrefCheckBox" name="extendedInformation">
+     <property name="toolTip">
+      <string>Extended information will be added to the list</string>
+     </property>
+     <property name="text">
+      <string>Extended information</string>
+     </property>
+     <property name="checked">
+      <bool>false</bool>
+     </property>
+     <property name="prefEntry" stdset="0">
+      <cstring>ExtendedConstraintInformation</cstring>
+     </property>
+     <property name="prefPath" stdset="0">
+      <cstring>Mod/Sketcher</cstring>
+     </property>
+    </widget>
+   </item>
    <item>
     <widget class="ConstraintView" name="listWidgetConstraints">
      <property name="modelColumn">

--- a/src/Mod/Sketcher/Gui/TaskSketcherElements.ui
+++ b/src/Mod/Sketcher/Gui/TaskSketcherElements.ui
@@ -117,8 +117,11 @@
    </item>
    <item>
     <widget class="QCheckBox" name="namingBox">
+     <property name="toolTip">
+      <string>Extended naming containing info about element mode</string>
+     </property>
      <property name="text">
-      <string>Extended Naming</string>
+      <string>Extended naming</string>
      </property>
      <property name="checked">
       <bool>false</bool>
@@ -127,6 +130,9 @@
    </item>
    <item>
     <widget class="QCheckBox" name="autoSwitchBox">
+     <property name="toolTip">
+      <string>Only the type 'Edge' will be available for the list</string>
+     </property>
      <property name="text">
       <string>Auto-switch to Edge</string>
      </property>

--- a/src/Mod/Sketcher/Gui/TaskSketcherGeneral.ui
+++ b/src/Mod/Sketcher/Gui/TaskSketcherGeneral.ui
@@ -16,6 +16,9 @@
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <widget class="QCheckBox" name="checkBoxShowGrid">
+     <property name="toolTip">
+      <string>A grid will be shown</string>
+     </property>
      <property name="text">
       <string>Show grid</string>
      </property>
@@ -35,6 +38,9 @@
      </item>
      <item>
       <widget class="Gui::PrefQuantitySpinBox" name="gridSize" native="true">
+       <property name="toolTip">
+        <string>Distance between two subsequent grid lines</string>
+       </property>
        <property name="unit" stdset="0">
         <string notr="true">mm</string>
        </property>
@@ -62,6 +68,10 @@
      <property name="enabled">
       <bool>true</bool>
      </property>
+     <property name="toolTip">
+      <string>New points will snap to the nearest grid line.
+Points must be set closer than a fifth of the grid size to a grid line to snap.</string>
+     </property>
      <property name="text">
       <string>Grid snap</string>
      </property>
@@ -71,6 +81,9 @@
     <widget class="QCheckBox" name="checkBoxAutoconstraints">
      <property name="enabled">
       <bool>true</bool>
+     </property>
+     <property name="toolTip">
+      <string>Sketcher proposes automatically sensible constraints.</string>
      </property>
      <property name="text">
       <string>Auto constraints</string>
@@ -82,6 +95,9 @@
    </item>
    <item>
     <widget class="Gui::PrefCheckBox" name="checkBoxRedundantAutoconstraints">
+     <property name="toolTip">
+      <string>Sketcher tries not to propose redundant auto constraints</string>
+     </property>
      <property name="text">
       <string>Avoid redundant auto constraints</string>
      </property>
@@ -105,6 +121,9 @@
    </item>
    <item>
     <widget class="QListWidget" name="renderingOrder">
+     <property name="toolTip">
+      <string>To change, drag and drop a geometry type to top or bottom</string>
+     </property>
      <property name="dragEnabled">
       <bool>true</bool>
      </property>

--- a/src/Mod/Sketcher/Gui/TaskSketcherMessages.ui
+++ b/src/Mod/Sketcher/Gui/TaskSketcherMessages.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>253</width>
-    <height>115</height>
+    <height>132</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -49,10 +49,10 @@
    <item>
     <widget class="Gui::PrefCheckBox" name="autoRemoveRedundants">
      <property name="toolTip">
-      <string>Automatically removes redundant constraints.</string>
+      <string>New constraints that would be redundant will automatically be removed</string>
      </property>
      <property name="text">
-      <string>Auto Remove Redundants</string>
+      <string>Auto remove redundants</string>
      </property>
      <property name="checked">
       <bool>false</bool>
@@ -64,7 +64,7 @@
       <cstring>Mod/Sketcher</cstring>
      </property>
     </widget>
-   </item>   
+   </item>
    <item>
     <spacer name="horizontalSpacer">
      <property name="orientation">
@@ -83,10 +83,10 @@
      <item>
       <widget class="Gui::PrefCheckBox" name="autoUpdate">
        <property name="toolTip">
-        <string>Executes a recompute of the active document after every command</string>
+        <string>Executes a recomputation of active document after every sketch action</string>
        </property>
        <property name="text">
-        <string>Auto Update</string>
+        <string>Auto update</string>
        </property>
        <property name="checked">
         <bool>false</bool>
@@ -98,11 +98,11 @@
         <cstring>Mod/Sketcher</cstring>
        </property>
       </widget>
-     </item>     
+     </item>
      <item>
       <widget class="QPushButton" name="manualUpdate">
        <property name="toolTip">
-        <string>Forces a recompute of the active document</string>
+        <string>Forces recomputation of active document</string>
        </property>
        <property name="text">
         <string>Update</string>

--- a/src/Mod/Sketcher/Gui/TaskSketcherSolverAdvanced.ui
+++ b/src/Mod/Sketcher/Gui/TaskSketcherSolverAdvanced.ui
@@ -22,12 +22,17 @@
         <string>Default algorithm used for Sketch solving</string>
        </property>
        <property name="text">
-        <string>Default Solver:</string>
+        <string>Default solver:</string>
        </property>
       </widget>
      </item>
      <item>
       <widget class="Gui::PrefComboBox" name="comboBoxDefaultSolver">
+       <property name="toolTip">
+        <string>Solver is used for solving the geometry.
+LevenbergMarquardt and DogLeg are trust region optimization algorithms.
+BFGS solver uses the Broyden–Fletcher–Goldfarb–Shanno algorithm.</string>
+       </property>
        <property name="currentIndex">
         <number>2</number>
        </property>
@@ -70,6 +75,9 @@
      </item>
      <item>
       <widget class="Gui::PrefComboBox" name="comboBoxDogLegGaussStep">
+       <property name="toolTip">
+        <string>Step type used in the DogLeg algorithm</string>
+       </property>
        <property name="currentIndex">
         <number>0</number>
        </property>
@@ -106,12 +114,15 @@
         <string>Maximum number of iterations of the default algorithm</string>
        </property>
        <property name="text">
-        <string>Maximum Iterations:</string>
+        <string>Maximum iterations:</string>
        </property>
       </widget>
      </item>
      <item>
       <widget class="Gui::PrefSpinBox" name="spinBoxMaxIter">
+       <property name="toolTip">
+        <string>Maximum iterations to find convergence before solver is stopped</string>
+       </property>
        <property name="alignment">
         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
        </property>
@@ -151,6 +162,9 @@
          <verstretch>0</verstretch>
         </sizepolicy>
        </property>
+       <property name="toolTip">
+        <string>Maximum iterations will be multiplied by number of parameters</string>
+       </property>
        <property name="layoutDirection">
         <enum>Qt::RightToLeft</enum>
        </property>
@@ -181,6 +195,10 @@
      </item>
      <item>
       <widget class="Gui::PrefLineEdit" name="lineEditConvergence">
+       <property name="toolTip">
+        <string>Threshold for squared error that is used
+to determine whether a solution converges or not</string>
+       </property>
        <property name="layoutDirection">
         <enum>Qt::LeftToRight</enum>
        </property>
@@ -280,12 +298,17 @@
         <string>Algorithm used for the rank revealing QR decomposition</string>
        </property>
        <property name="text">
-        <string>QR Algorithm:</string>
+        <string>QR algorithm:</string>
        </property>
       </widget>
      </item>
      <item>
       <widget class="Gui::PrefComboBox" name="comboBoxQRMethod">
+       <property name="toolTip">
+        <string>During diagnosing the QR rank of matrix is calculated.
+Eigen Dense QR is a dense matrix QR with full pivoting; usually slower
+Eigen Sparse QR algorithm is optimized for sparse matrices; usually faster</string>
+       </property>
        <property name="currentIndex">
         <number>1</number>
        </property>
@@ -320,6 +343,9 @@
      </item>
      <item>
       <widget class="Gui::PrefLineEdit" name="lineEditQRPivotThreshold">
+       <property name="toolTip">
+        <string>During a QR, values under the pivot threshold are treated as zero</string>
+       </property>
        <property name="text">
         <string>1E-13</string>
        </property>
@@ -344,12 +370,15 @@
         <string>Solving algorithm used for determination of Redundant constraints</string>
        </property>
        <property name="text">
-        <string>Redundant Solver:</string>
+        <string>Redundant solver:</string>
        </property>
       </widget>
      </item>
      <item>
       <widget class="Gui::PrefComboBox" name="comboBoxRedundantDefaultSolver">
+       <property name="toolTip">
+        <string>Solver used to determine whether a group is redundant or conflicting</string>
+       </property>
        <property name="currentIndex">
         <number>2</number>
        </property>
@@ -386,14 +415,14 @@
         <string>Maximum number of iterations of the solver used for determination of Redundant constraints</string>
        </property>
        <property name="text">
-        <string>Red. Max Iterations:</string>
+        <string>Redundant max. iterations:</string>
        </property>
       </widget>
      </item>
      <item>
       <widget class="Gui::PrefSpinBox" name="spinBoxRedundantSolverMaxIterations">
        <property name="toolTip">
-        <string/>
+        <string>Same as 'Maximum iterations', but for redundant solving</string>
        </property>
        <property name="alignment">
         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -422,12 +451,15 @@
         <string>If selected, the Maximum iterations value for the redundant algorithm is multiplied by the sketch size</string>
        </property>
        <property name="text">
-        <string>Red. Sketch size multiplier:</string>
+        <string>Redundant sketch size multiplier:</string>
        </property>
       </widget>
      </item>
      <item>
       <widget class="Gui::PrefCheckBox" name="checkBoxRedundantSketchSizeMultiplier">
+       <property name="toolTip">
+        <string>Same as 'Sketch size multiplier', but for redundant solving</string>
+       </property>
        <property name="layoutDirection">
         <enum>Qt::RightToLeft</enum>
        </property>
@@ -452,12 +484,15 @@
         <string>Error threshold under which convergence is reached for the solving of redundant constraints</string>
        </property>
        <property name="text">
-        <string>Red. Convergence</string>
+        <string>Redundant convergence</string>
        </property>
       </widget>
      </item>
      <item>
       <widget class="Gui::PrefLineEdit" name="lineEditRedundantConvergence">
+       <property name="toolTip">
+        <string>Same as 'Convergence', but for redundant solving</string>
+       </property>
        <property name="text">
         <string>1E-10</string>
        </property>
@@ -479,7 +514,7 @@
      <item>
       <widget class="QLabel" name="labelRedundantSolverParam1">
        <property name="text">
-        <string>Red. Param1</string>
+        <string>Redundant param1</string>
        </property>
       </widget>
      </item>
@@ -503,7 +538,7 @@
      <item>
       <widget class="QLabel" name="labelRedundantSolverParam2">
        <property name="text">
-        <string>Red. Param2</string>
+        <string>Redundant param2</string>
        </property>
       </widget>
      </item>
@@ -527,7 +562,7 @@
      <item>
       <widget class="QLabel" name="labelRedundantSolverParam3">
        <property name="text">
-        <string>Red. Param3</string>
+        <string>Redundant param3</string>
        </property>
       </widget>
      </item>
@@ -554,12 +589,15 @@
         <string>Degree of verbosity of the debug output to the console</string>
        </property>
        <property name="text">
-        <string>Console Debug mode:</string>
+        <string>Console debug mode:</string>
        </property>
       </widget>
      </item>
      <item>
       <widget class="Gui::PrefComboBox" name="comboBoxDebugMode">
+       <property name="toolTip">
+        <string>Verbosity of console output</string>
+       </property>
        <property name="currentIndex">
         <number>1</number>
        </property>


### PR DESCRIPTION
This commit is part of the tooltip project, see bug 3866
The info for the tooltips is from https://www.freecadweb.org/wiki/Preferences_Editor that I created with the help of the forum community.