### PR TITLE
uniforms option names and add tooltips for sketcher

### DIFF
--- a/src/Mod/Sketcher/Gui/SketcherSettings.ui
+++ b/src/Mod/Sketcher/Gui/SketcherSettings.ui
@@ -56,7 +56,7 @@
          <item>
           <widget class="Gui::PrefCheckBox" name="checkBoxNotifyConstraintSubstitutions">
            <property name="toolTip">
-            <string>Notify automatic constraint substitutions</string>
+            <string>Notifies about automatic constraint substitutions</string>
            </property>
            <property name="text">
             <string>Notify automatic constraint substitutions</string>
@@ -90,6 +90,9 @@
       </item>
       <item row="0" column="1">
        <widget class="Gui::PrefSpinBox" name="EditSketcherFontSize">
+        <property name="toolTip">
+         <string>Font size used for labels and constraints</string>
+        </property>
         <property name="suffix">
          <string>px</string>
         </property>
@@ -112,6 +115,9 @@
       </item>
       <item row="1" column="1">
        <widget class="QComboBox" name="comboBox">
+        <property name="toolTip">
+         <string>Line pattern used for grid lines</string>
+        </property>
         <property name="currentIndex">
          <number>-1</number>
         </property>
@@ -119,6 +125,9 @@
       </item>
       <item row="3" column="0" colspan="2">
        <widget class="Gui::PrefCheckBox" name="dialogOnDistanceConstraint">
+        <property name="toolTip">
+         <string>A dialog will pop up to input a value for new dimensional constraints</string>
+        </property>
         <property name="text">
          <string>Ask for value after creating a dimensional constraint</string>
         </property>
@@ -142,8 +151,11 @@
       </item>
       <item row="4" column="0" colspan="2">
        <widget class="Gui::PrefCheckBox" name="continueMode">
+        <property name="toolTip">
+         <string>Current sketcher creation tool will remain active after creation</string>
+        </property>
         <property name="text">
-         <string>Geometry Creation &quot;Continue Mode&quot;</string>
+         <string>Geometry creation &quot;Continue Mode&quot;</string>
         </property>
         <property name="checked">
          <bool>true</bool>
@@ -158,8 +170,11 @@
       </item>
       <item row="5" column="0" colspan="2">
        <widget class="Gui::PrefCheckBox" name="constraintMode">
+        <property name="toolTip">
+         <string>Current constraint creation tool will remain active after creation</string>
+        </property>
         <property name="text">
-         <string>Constraint Creation &quot;Continue Mode&quot;</string>
+         <string>Constraint creation &quot;Continue Mode&quot;</string>
         </property>
         <property name="checked">
          <bool>true</bool>
@@ -208,7 +223,7 @@
          <item>
           <widget class="Gui::PrefCheckBox" name="checkBoxTVHideDependent">
            <property name="toolTip">
-            <string>When opening sketch, hide all features that depend on it.</string>
+            <string>When opening sketch, hide all features that depend on it</string>
            </property>
            <property name="text">
             <string>Hide all objects that depend on the sketch</string>
@@ -227,7 +242,7 @@
          <item>
           <widget class="Gui::PrefCheckBox" name="checkBoxTVShowLinks">
            <property name="toolTip">
-            <string>When opening sketch, show sources for external geometry links.</string>
+            <string>When opening sketch, show sources for external geometry links</string>
            </property>
            <property name="text">
             <string>Show objects used for external geometry</string>
@@ -246,7 +261,7 @@
          <item>
           <widget class="Gui::PrefCheckBox" name="checkBoxTVShowSupport">
            <property name="toolTip">
-            <string>When opening sketch, show objects the sketch is attached to.</string>
+            <string>When opening sketch, show objects the sketch is attached to</string>
            </property>
            <property name="text">
             <string>Show object(s) sketch is attached to</string>
@@ -265,7 +280,7 @@
          <item>
           <widget class="Gui::PrefCheckBox" name="checkBoxTVRestoreCamera">
            <property name="toolTip">
-            <string>When closing sketch, move camera back to where it was before sketch was opened.</string>
+            <string>When closing sketch, move camera back to where it was before sketch was opened</string>
            </property>
            <property name="text">
             <string>Restore camera position after editing</string>
@@ -309,7 +324,7 @@
             </sizepolicy>
            </property>
            <property name="toolTip">
-            <string>Apply current smart visibility to all sketches in open documents (update properties to match).</string>
+            <string>Applies current visibility automation settings to all sketches in open documents</string>
            </property>
            <property name="text">
             <string>Apply to existing sketches</string>
@@ -328,6 +343,9 @@
       </item>
       <item row="2" column="1">
        <widget class="Gui::PrefSpinBox" name="SegmentsPerGeometry">
+        <property name="toolTip">
+         <string>Number of polygons for geometry approximation</string>
+        </property>
         <property name="minimum">
          <number>50</number>
         </property>
@@ -345,7 +363,8 @@
       <item row="6" column="0">
        <widget class="Gui::PrefCheckBox" name="checkBoxHideUnits">
         <property name="toolTip">
-         <string>Do not show base length units in sketches. Supports all unit systems except US Customary and Building US/Euro.</string>
+         <string>Base length units will not be displayed in constraints.
+Supports all unit systems except 'US customary' and 'Building US/Euro'.</string>
         </property>
         <property name="text">
          <string>Hide base length units for supported unit systems</string>
@@ -364,13 +383,17 @@
    <item row="2" column="0">
     <widget class="QGroupBox" name="groupBox_2">
      <property name="title">
-      <string>Sketcher Solver</string>
+      <string>Sketcher solver</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_4">
       <item row="0" column="0">
        <widget class="Gui::PrefCheckBox" name="checkBoxAdvancedSolverTaskBox">
+        <property name="toolTip">
+         <string>Sketcher dialog will have additional section
+'Advanced solver control' to adjust solver settings</string>
+        </property>
         <property name="text">
-         <string>Show Advanced Solver Control in the Task bar</string>
+         <string>Show section 'Advanced solver control' in task dialog</string>
         </property>
         <property name="prefEntry" stdset="0">
          <cstring>ShowSolverAdvancedWidget</cstring>
@@ -386,13 +409,17 @@
    <item row="3" column="0">
     <widget class="QGroupBox" name="groupBox_4">
      <property name="title">
-      <string>Dragging Performance</string>
+      <string>Dragging performance</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_5" rowstretch="0,0" columnstretch="0,0">
       <item row="1" column="0" colspan="2">
        <widget class="Gui::PrefCheckBox" name="checkBoxRecalculateInitialSolutionWhileDragging">
+        <property name="toolTip">
+         <string>Special solver algorithm will be used while dragging sketch elements.
+Requires to re-enter edit mode to take effect.</string>
+        </property>
         <property name="text">
-         <string>Improve solving while dragging (requires to re-enter edit mode to take effect)</string>
+         <string>Improve solving while dragging</string>
         </property>
         <property name="checked">
          <bool>true</bool>

--- a/src/Mod/Sketcher/Gui/SketcherSettingsColors.ui
+++ b/src/Mod/Sketcher/Gui/SketcherSettingsColors.ui
@@ -38,7 +38,7 @@
         <item row="0" column="1">
          <widget class="Gui::PrefColorButton" name="SketchEdgeColor">
           <property name="toolTip">
-           <string>The color of edges being edited</string>
+           <string>Color of edges</string>
           </property>
           <property name="color">
            <color>
@@ -71,7 +71,7 @@
         <item row="1" column="1">
          <widget class="Gui::PrefColorButton" name="SketchVertexColor">
           <property name="toolTip">
-           <string>The color of vertices being edited</string>
+           <string>Color of vertices</string>
           </property>
           <property name="color">
            <color>
@@ -103,6 +103,9 @@
         </item>
         <item row="2" column="1">
          <widget class="Gui::PrefColorButton" name="CreateLineColor">
+          <property name="toolTip">
+           <string>Color used while new sketch elements are created</string>
+          </property>
           <property name="color">
            <color>
             <red>204</red>
@@ -134,7 +137,7 @@
         <item row="3" column="1">
          <widget class="Gui::PrefColorButton" name="EditedEdgeColor">
           <property name="toolTip">
-           <string>The color of edges being edited</string>
+           <string>Color of edges being edited</string>
           </property>
           <property name="color">
            <color>
@@ -167,7 +170,7 @@
         <item row="4" column="1">
          <widget class="Gui::PrefColorButton" name="EditedVertexColor">
           <property name="toolTip">
-           <string>The color of vertices being edited</string>
+           <string>Color of vertices being edited</string>
           </property>
           <property name="color">
            <color>
@@ -200,7 +203,7 @@
         <item row="5" column="1">
          <widget class="Gui::PrefColorButton" name="ConstructionColor">
           <property name="toolTip">
-           <string>The color of construction geometry in edit mode</string>
+           <string>Color of construction geometry in edit mode</string>
           </property>
           <property name="color">
            <color>
@@ -233,7 +236,7 @@
         <item row="6" column="1">
          <widget class="Gui::PrefColorButton" name="ExternalColor">
           <property name="toolTip">
-           <string>The color of external geometry in edit mode</string>
+           <string>Color of external geometry in edit mode</string>
           </property>
           <property name="color">
            <color>
@@ -266,7 +269,7 @@
         <item row="7" column="1">
          <widget class="Gui::PrefColorButton" name="FullyConstrainedColor">
           <property name="toolTip">
-           <string>The color of fully constrained geometry in edit mode</string>
+           <string>Color of fully constrained geometry in edit mode</string>
           </property>
           <property name="color">
            <color>
@@ -299,7 +302,7 @@
         <item row="8" column="1">
          <widget class="Gui::PrefColorButton" name="ConstrainedColor">
           <property name="toolTip">
-           <string>The color of driving constraints in edit mode</string>
+           <string>Color of driving constraints in edit mode</string>
           </property>
           <property name="color">
            <color>
@@ -319,14 +322,14 @@
         <item row="9" column="0">
          <widget class="QLabel" name="label_8">
           <property name="text">
-           <string>Reference Constraint color</string>
+           <string>Reference constraint color</string>
           </property>
          </widget>
         </item>
         <item row="9" column="1">
          <widget class="Gui::PrefColorButton" name="NonDrivingConstraintColor">
           <property name="toolTip">
-           <string>The color of reference constrains and datum in edit mode</string>
+           <string>Color of reference constraints in edit mode</string>
           </property>
           <property name="color">
            <color>
@@ -353,7 +356,7 @@
         <item row="10" column="1">
          <widget class="Gui::PrefColorButton" name="ExprBasedConstrDimColor">
           <property name="toolTip">
-           <string>The color of expression dependent datum constraints in edit mode</string>
+           <string>Color of expression dependent constraints in edit mode</string>
           </property>
           <property name="color">
            <color>
@@ -380,7 +383,7 @@
         <item row="11" column="1">
          <widget class="Gui::PrefColorButton" name="DeactivatedConstrDimColor">
           <property name="toolTip">
-           <string>The color of deactivated constraints in edit mode</string>
+           <string>Color of deactivated constraints in edit mode</string>
           </property>
           <property name="color">
            <color>
@@ -413,7 +416,7 @@
         <item row="12" column="1">
          <widget class="Gui::PrefColorButton" name="DatumColor">
           <property name="toolTip">
-           <string>The color of the datum portion of a driving constraint</string>
+           <string>Color of the datum portion of a driving constraint</string>
           </property>
           <property name="color">
            <color>
@@ -544,12 +547,15 @@
            </size>
           </property>
           <property name="text">
-           <string>Cursor text color</string>
+           <string>Coordinate text color</string>
           </property>
          </widget>
         </item>
         <item row="16" column="1">
          <widget class="Gui::PrefColorButton" name="CursorTextColor">
+          <property name="toolTip">
+           <string>Text color of the coordinates</string>
+          </property>
           <property name="color">
            <color>
             <red>0</red>
@@ -580,6 +586,10 @@
         </item>
         <item row="17" column="1">
          <widget class="Gui::PrefColorButton" name="CursorCrosshairColor">
+          <property name="toolTip">
+           <string>Color of crosshair cursor.
+(The one you get when creating a new sketch element.)</string>
+          </property>
           <property name="color">
            <color>
             <red>255</red>

--- a/src/Mod/Sketcher/Gui/TaskSketcherConstrains.ui
+++ b/src/Mod/Sketcher/Gui/TaskSketcherConstrains.ui
@@ -59,8 +59,11 @@
    </item>
    <item>
     <widget class="Gui::PrefCheckBox" name="filterInternalAlignment">
+     <property name="toolTip">
+      <string>Internal alignments will be hidden</string>
+     </property>
      <property name="text">
-      <string>Hide Internal Alignment</string>
+      <string>Hide internal alignment</string>
      </property>
      <property name="checked">
       <bool>true</bool>
@@ -74,21 +77,24 @@
     </widget>
    </item>
    <item>
-       <widget class="Gui::PrefCheckBox" name="extendedInformation">
-           <property name="text">
-               <string>Extended Information</string>
-           </property>
-           <property name="checked">
-               <bool>false</bool>
-           </property>
-           <property name="prefEntry" stdset="0">
-               <cstring>ExtendedConstraintInformation</cstring>
-           </property>
-           <property name="prefPath" stdset="0">
-               <cstring>Mod/Sketcher</cstring>
-           </property>
-       </widget>
-   </item>   
+    <widget class="Gui::PrefCheckBox" name="extendedInformation">
+     <property name="toolTip">
+      <string>Extended information will be added to the list</string>
+     </property>
+     <property name="text">
+      <string>Extended information</string>
+     </property>
+     <property name="checked">
+      <bool>false</bool>
+     </property>
+     <property name="prefEntry" stdset="0">
+      <cstring>ExtendedConstraintInformation</cstring>
+     </property>
+     <property name="prefPath" stdset="0">
+      <cstring>Mod/Sketcher</cstring>
+     </property>
+    </widget>
+   </item>
    <item>
     <widget class="ConstraintView" name="listWidgetConstraints">
      <property name="modelColumn">

--- a/src/Mod/Sketcher/Gui/TaskSketcherElements.ui
+++ b/src/Mod/Sketcher/Gui/TaskSketcherElements.ui
@@ -117,8 +117,11 @@
    </item>
    <item>
     <widget class="QCheckBox" name="namingBox">
+     <property name="toolTip">
+      <string>Extended naming containing info about element mode</string>
+     </property>
      <property name="text">
-      <string>Extended Naming</string>
+      <string>Extended naming</string>
      </property>
      <property name="checked">
       <bool>false</bool>
@@ -127,6 +130,9 @@
    </item>
    <item>
     <widget class="QCheckBox" name="autoSwitchBox">
+     <property name="toolTip">
+      <string>Only the type 'Edge' will be available for the list</string>
+     </property>
      <property name="text">
       <string>Auto-switch to Edge</string>
      </property>

--- a/src/Mod/Sketcher/Gui/TaskSketcherGeneral.ui
+++ b/src/Mod/Sketcher/Gui/TaskSketcherGeneral.ui
@@ -16,6 +16,9 @@
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <widget class="QCheckBox" name="checkBoxShowGrid">
+     <property name="toolTip">
+      <string>A grid will be shown</string>
+     </property>
      <property name="text">
       <string>Show grid</string>
      </property>
@@ -35,6 +38,9 @@
      </item>
      <item>
       <widget class="Gui::PrefQuantitySpinBox" name="gridSize" native="true">
+       <property name="toolTip">
+        <string>Distance between two subsequent grid lines</string>
+       </property>
        <property name="unit" stdset="0">
         <string notr="true">mm</string>
        </property>
@@ -62,6 +68,10 @@
      <property name="enabled">
       <bool>true</bool>
      </property>
+     <property name="toolTip">
+      <string>New points will snap to the nearest grid line.
+Points must be set closer than a fifth of the grid size to a grid line to snap.</string>
+     </property>
      <property name="text">
       <string>Grid snap</string>
      </property>
@@ -71,6 +81,9 @@
     <widget class="QCheckBox" name="checkBoxAutoconstraints">
      <property name="enabled">
       <bool>true</bool>
+     </property>
+     <property name="toolTip">
+      <string>Sketcher proposes automatically sensible constraints.</string>
      </property>
      <property name="text">
       <string>Auto constraints</string>
@@ -82,6 +95,9 @@
    </item>
    <item>
     <widget class="Gui::PrefCheckBox" name="checkBoxRedundantAutoconstraints">
+     <property name="toolTip">
+      <string>Sketcher tries not to propose redundant auto constraints</string>
+     </property>
      <property name="text">
       <string>Avoid redundant auto constraints</string>
      </property>
@@ -105,6 +121,9 @@
    </item>
    <item>
     <widget class="QListWidget" name="renderingOrder">
+     <property name="toolTip">
+      <string>To change, drag and drop a geometry type to top or bottom</string>
+     </property>
      <property name="dragEnabled">
       <bool>true</bool>
      </property>

--- a/src/Mod/Sketcher/Gui/TaskSketcherMessages.ui
+++ b/src/Mod/Sketcher/Gui/TaskSketcherMessages.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>253</width>
-    <height>115</height>
+    <height>132</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -49,10 +49,10 @@
    <item>
     <widget class="Gui::PrefCheckBox" name="autoRemoveRedundants">
      <property name="toolTip">
-      <string>Automatically removes redundant constraints.</string>
+      <string>New constraints that would be redundant will automatically be removed</string>
      </property>
      <property name="text">
-      <string>Auto Remove Redundants</string>
+      <string>Auto remove redundants</string>
      </property>
      <property name="checked">
       <bool>false</bool>
@@ -64,7 +64,7 @@
       <cstring>Mod/Sketcher</cstring>
      </property>
     </widget>
-   </item>   
+   </item>
    <item>
     <spacer name="horizontalSpacer">
      <property name="orientation">
@@ -83,10 +83,10 @@
      <item>
       <widget class="Gui::PrefCheckBox" name="autoUpdate">
        <property name="toolTip">
-        <string>Executes a recompute of the active document after every command</string>
+        <string>Executes a recomputation of active document after every sketch action</string>
        </property>
        <property name="text">
-        <string>Auto Update</string>
+        <string>Auto update</string>
        </property>
        <property name="checked">
         <bool>false</bool>
@@ -98,11 +98,11 @@
         <cstring>Mod/Sketcher</cstring>
        </property>
       </widget>
-     </item>     
+     </item>
      <item>
       <widget class="QPushButton" name="manualUpdate">
        <property name="toolTip">
-        <string>Forces a recompute of the active document</string>
+        <string>Forces recomputation of active document</string>
        </property>
        <property name="text">
         <string>Update</string>

--- a/src/Mod/Sketcher/Gui/TaskSketcherSolverAdvanced.ui
+++ b/src/Mod/Sketcher/Gui/TaskSketcherSolverAdvanced.ui
@@ -22,12 +22,17 @@
         <string>Default algorithm used for Sketch solving</string>
        </property>
        <property name="text">
-        <string>Default Solver:</string>
+        <string>Default solver:</string>
        </property>
       </widget>
      </item>
      <item>
       <widget class="Gui::PrefComboBox" name="comboBoxDefaultSolver">
+       <property name="toolTip">
+        <string>Solver is used for solving the geometry.
+LevenbergMarquardt and DogLeg are trust region optimization algorithms.
+BFGS solver uses the Broyden–Fletcher–Goldfarb–Shanno algorithm.</string>
+       </property>
        <property name="currentIndex">
         <number>2</number>
        </property>
@@ -70,6 +75,9 @@
      </item>
      <item>
       <widget class="Gui::PrefComboBox" name="comboBoxDogLegGaussStep">
+       <property name="toolTip">
+        <string>Step type used in the DogLeg algorithm</string>
+       </property>
        <property name="currentIndex">
         <number>0</number>
        </property>
@@ -106,12 +114,15 @@
         <string>Maximum number of iterations of the default algorithm</string>
        </property>
        <property name="text">
-        <string>Maximum Iterations:</string>
+        <string>Maximum iterations:</string>
        </property>
       </widget>
      </item>
      <item>
       <widget class="Gui::PrefSpinBox" name="spinBoxMaxIter">
+       <property name="toolTip">
+        <string>Maximum iterations to find convergence before solver is stopped</string>
+       </property>
        <property name="alignment">
         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
        </property>
@@ -151,6 +162,9 @@
          <verstretch>0</verstretch>
         </sizepolicy>
        </property>
+       <property name="toolTip">
+        <string>Maximum iterations will be multiplied by number of parameters</string>
+       </property>
        <property name="layoutDirection">
         <enum>Qt::RightToLeft</enum>
        </property>
@@ -181,6 +195,10 @@
      </item>
      <item>
       <widget class="Gui::PrefLineEdit" name="lineEditConvergence">
+       <property name="toolTip">
+        <string>Threshold for squared error that is used
+to determine whether a solution converges or not</string>
+       </property>
        <property name="layoutDirection">
         <enum>Qt::LeftToRight</enum>
        </property>
@@ -280,12 +298,17 @@
         <string>Algorithm used for the rank revealing QR decomposition</string>
        </property>
        <property name="text">
-        <string>QR Algorithm:</string>
+        <string>QR algorithm:</string>
        </property>
       </widget>
      </item>
      <item>
       <widget class="Gui::PrefComboBox" name="comboBoxQRMethod">
+       <property name="toolTip">
+        <string>During diagnosing the QR rank of matrix is calculated.
+Eigen Dense QR is a dense matrix QR with full pivoting; usually slower
+Eigen Sparse QR algorithm is optimized for sparse matrices; usually faster</string>
+       </property>
        <property name="currentIndex">
         <number>1</number>
        </property>
@@ -320,6 +343,9 @@
      </item>
      <item>
       <widget class="Gui::PrefLineEdit" name="lineEditQRPivotThreshold">
+       <property name="toolTip">
+        <string>During a QR, values under the pivot threshold are treated as zero</string>
+       </property>
        <property name="text">
         <string>1E-13</string>
        </property>
@@ -344,12 +370,15 @@
         <string>Solving algorithm used for determination of Redundant constraints</string>
        </property>
        <property name="text">
-        <string>Redundant Solver:</string>
+        <string>Redundant solver:</string>
        </property>
       </widget>
      </item>
      <item>
       <widget class="Gui::PrefComboBox" name="comboBoxRedundantDefaultSolver">
+       <property name="toolTip">
+        <string>Solver used to determine whether a group is redundant or conflicting</string>
+       </property>
        <property name="currentIndex">
         <number>2</number>
        </property>
@@ -386,14 +415,14 @@
         <string>Maximum number of iterations of the solver used for determination of Redundant constraints</string>
        </property>
        <property name="text">
-        <string>Red. Max Iterations:</string>
+        <string>Redundant max. iterations:</string>
        </property>
       </widget>
      </item>
      <item>
       <widget class="Gui::PrefSpinBox" name="spinBoxRedundantSolverMaxIterations">
        <property name="toolTip">
-        <string/>
+        <string>Same as 'Maximum iterations', but for redundant solving</string>
        </property>
        <property name="alignment">
         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -422,12 +451,15 @@
         <string>If selected, the Maximum iterations value for the redundant algorithm is multiplied by the sketch size</string>
        </property>
        <property name="text">
-        <string>Red. Sketch size multiplier:</string>
+        <string>Redundant sketch size multiplier:</string>
        </property>
       </widget>
      </item>
      <item>
       <widget class="Gui::PrefCheckBox" name="checkBoxRedundantSketchSizeMultiplier">
+       <property name="toolTip">
+        <string>Same as 'Sketch size multiplier', but for redundant solving</string>
+       </property>
        <property name="layoutDirection">
         <enum>Qt::RightToLeft</enum>
        </property>
@@ -452,12 +484,15 @@
         <string>Error threshold under which convergence is reached for the solving of redundant constraints</string>
        </property>
        <property name="text">
-        <string>Red. Convergence</string>
+        <string>Redundant convergence</string>
        </property>
       </widget>
      </item>
      <item>
       <widget class="Gui::PrefLineEdit" name="lineEditRedundantConvergence">
+       <property name="toolTip">
+        <string>Same as 'Convergence', but for redundant solving</string>
+       </property>
        <property name="text">
         <string>1E-10</string>
        </property>
@@ -479,7 +514,7 @@
      <item>
       <widget class="QLabel" name="labelRedundantSolverParam1">
        <property name="text">
-        <string>Red. Param1</string>
+        <string>Redundant param1</string>
        </property>
       </widget>
      </item>
@@ -503,7 +538,7 @@
      <item>
       <widget class="QLabel" name="labelRedundantSolverParam2">
        <property name="text">
-        <string>Red. Param2</string>
+        <string>Redundant param2</string>
        </property>
       </widget>
      </item>
@@ -527,7 +562,7 @@
      <item>
       <widget class="QLabel" name="labelRedundantSolverParam3">
        <property name="text">
-        <string>Red. Param3</string>
+        <string>Redundant param3</string>
        </property>
       </widget>
      </item>
@@ -554,12 +589,15 @@
         <string>Degree of verbosity of the debug output to the console</string>
        </property>
        <property name="text">
-        <string>Console Debug mode:</string>
+        <string>Console debug mode:</string>
        </property>
       </widget>
      </item>
      <item>
       <widget class="Gui::PrefComboBox" name="comboBoxDebugMode">
+       <property name="toolTip">
+        <string>Verbosity of console output</string>
+       </property>
        <property name="currentIndex">
         <number>1</number>
        </property>


### PR DESCRIPTION
This PR uniforms option names and adds tooltips for sketcher with info from https://www.freecadweb.org/wiki/Sketcher_Preferences and https://www.freecadweb.org/wiki/Sketcher_Dialog
(fixes issue 4052)