### PR TITLE
Arch: fix IFC import for non-ascii group name, sync IFC import/export with compass

### DIFF
--- a/src/Mod/Arch/ArchSite.py
+++ b/src/Mod/Arch/ArchSite.py
@@ -877,8 +877,8 @@ class _ViewProviderSite:
         if not hasattr(vobj, 'UpdateDeclination') or not vobj.UpdateDeclination:
             return
         compassRotation = vobj.CompassRotation.Value
-        siteRotation = math.degrees(obj.Placement.Rotation.Angle)
-        obj.Declination = compassRotation + siteRotation
+        siteRotation = math.degrees(vobj.Object.Placement.Rotation.Angle) # This assumes Rotation.axis = (0,0,1)
+        vobj.Object.Declination = compassRotation + siteRotation
 
     def addTrueNorthRotation(self):
 

--- a/src/Mod/Arch/importIFC.py
+++ b/src/Mod/Arch/importIFC.py
@@ -1544,8 +1544,9 @@ def export(exportList,filename,colors=None):
     context = ifcfile.by_type("IfcGeometricRepresentationContext")[0]
     project = ifcfile.by_type("IfcProject")[0]
     objectslist = Draft.getGroupContents(exportList,walls=True,addgroups=True)
-    trueNorthX = math.tan(-Draft.getObjectsOfType(objectslist, "Site")[0].Declination.getValueAs(FreeCAD.Units.Radian)) # we assume one site and one representation context only
-    context.TrueNorth.DirectionRatios = (trueNorthX, 1., 1.)
+    if(Draft.getObjectsOfType(objectslist, "Site")):  # we assume one site and one representation context only
+        trueNorthX = math.tan(-Draft.getObjectsOfType(objectslist, "Site")[0].Declination.getValueAs(FreeCAD.Units.Radian))
+        context.TrueNorth.DirectionRatios = (trueNorthX, 1., 1.)
     annotations = []
     for obj in objectslist:
         if obj.isDerivedFrom("Part::Part2DObject"):

--- a/src/Mod/Arch/importIFC.py
+++ b/src/Mod/Arch/importIFC.py
@@ -1002,8 +1002,8 @@ def insert(filename,docname,skip=[],only=[],root=None):
             else:
                 if DEBUG: print("no group name specified for entity: #", ifcfile[host].id(), ", entity type is used!")
                 grp_name = ifcfile[host].is_a() + "_" + str(ifcfile[host].id())
-                if six.PY2:
-                    grp_name = grp_name.encode("utf8")
+            if six.PY2:
+                grp_name = grp_name.encode("utf8")
             grp =  FreeCAD.ActiveDocument.addObject("App::DocumentObjectGroup",grp_name)
             grp.Label = grp_name
             objects[host] = grp


### PR DESCRIPTION
Non-ASCII group names are a minor issue in IFC import, only relevant if used with Python2. Here is a sample file for testing: [groupname-utf8.ifc.txt](https://github.com/FreeCAD/FreeCAD/files/3411815/groupname-utf8.ifc.txt).

The compass rotation syncing with IFC import/export is based on the IFC2x3 way of specifying true north, which is still available in IFC4. It will probably become obsoled with the work of Dion @Moult in https://github.com/FreeCAD/FreeCAD/pull/2259 where also the new way of georeferencing is supported.