### PR TITLE
[TD]Fix #4017 Crash on bad hatch scale (backport to v0.18)

### DIFF
--- a/src/Mod/TechDraw/Gui/QGIFace.cpp
+++ b/src/Mod/TechDraw/Gui/QGIFace.cpp
@@ -517,6 +517,7 @@ void QGIFace::buildSvgHatch()
     before.append(QString::fromStdString(SVGCOLPREFIX + SVGCOLDEFAULT));
     after.append(QString::fromStdString(SVGCOLPREFIX + m_svgCol));
     QByteArray colorXML = m_svgXML.replace(before,after);
+    long int tileCount = 0;
     for (int iw = 0; iw < int(nw); iw++) {
         for (int ih = 0; ih < int(nh); ih++) {
             QGCustomSvg* tile = new QGCustomSvg();
@@ -525,6 +526,14 @@ void QGIFace::buildSvgHatch()
                 tile->setParentItem(m_rect);
                 tile->setPos(iw*wTile,-h + ih*hTile);
             }
+            tileCount++;
+            if (tileCount > m_maxTile) {
+                Base::Console().Warning("SVG tile count exceeded: %ld\n",tileCount);
+                break;
+            }
+        }
+        if (tileCount > m_maxTile) {
+            break;
         }
     }
 }
@@ -611,6 +620,10 @@ void QGIFace::getParameters(void)
         .GetGroup("BaseApp")->GetGroup("Preferences")->GetGroup("Mod/TechDraw/PAT");
 
     m_maxSeg = hGrp->GetInt("MaxSeg",10000l);
+
+    hGrp = App::GetApplication().GetUserParameter()
+        .GetGroup("BaseApp")->GetGroup("Preferences")->GetGroup("Mod/TechDraw/Decorations");
+    m_maxTile = hGrp->GetInt("MaxSVGTile",10000l);
 }
 
 

--- a/src/Mod/TechDraw/Gui/QGIFace.h
+++ b/src/Mod/TechDraw/Gui/QGIFace.h
@@ -147,6 +147,7 @@ protected:
     std::vector<DashSpec> m_dashSpecs;
     long int m_segCount;
     long int m_maxSeg;
+    long int m_maxTile;
 
 
 private:

--- a/src/Mod/TechDraw/Gui/QGIViewPart.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewPart.cpp
@@ -374,7 +374,10 @@ void QGIViewPart::drawViewPart()
                         }
                         newFace->isHatched(true);
                         newFace->setFillMode(QGIFace::GeomHatchFill);
-                        newFace->setHatchScale(fGeom->ScalePattern.getValue());
+                        double hatchScale = fGeom->ScalePattern.getValue();
+                        if (hatchScale > 0.0) {
+                            newFace->setHatchScale(fGeom->ScalePattern.getValue());
+                        }
                         newFace->setHatchFile(fGeom->FilePattern.getValue());
                         Gui::ViewProvider* gvp = QGIView::getViewProvider(fGeom);
                         ViewProviderGeomHatch* geomVp = dynamic_cast<ViewProviderGeomHatch*>(gvp);
@@ -392,7 +395,10 @@ void QGIViewPart::drawViewPart()
                     Gui::ViewProvider* gvp = QGIView::getViewProvider(fHatch);
                     ViewProviderHatch* hatchVp = dynamic_cast<ViewProviderHatch*>(gvp);
                     if (hatchVp != nullptr) {
-                        newFace->setHatchScale(hatchVp->HatchScale.getValue());
+                        double hatchScale = hatchVp->HatchScale.getValue();
+                        if (hatchScale > 0.0) {
+                            newFace->setHatchScale(hatchVp->HatchScale.getValue());
+                        }
                         newFace->setHatchColor(hatchVp->HatchColor.getValue());
                     }
                 }

--- a/src/Mod/TechDraw/Gui/ViewProviderHatch.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderHatch.cpp
@@ -47,8 +47,13 @@
 
 using namespace TechDrawGui;
 
-App::PropertyFloatConstraint::Constraints ViewProviderHatch::scaleRange = {Precision::Confusion(),
-                                                                  std::numeric_limits<double>::max(),
+//scaleRange = {lowerLimit, upperLimit, stepSize}
+//original range is far too broad for drawing.  causes massive loop counts.
+//App::PropertyFloatConstraint::Constraints ViewProviderHatch::scaleRange = {Precision::Confusion(),
+//                                                                  std::numeric_limits<double>::max(),
+//                                                                  pow(10,- Base::UnitsApi::getDecimals())};
+App::PropertyFloatConstraint::Constraints ViewProviderHatch::scaleRange = {pow(10,- Base::UnitsApi::getDecimals()),
+                                                                  1000.0,
                                                                   pow(10,- Base::UnitsApi::getDecimals())};
 
 
@@ -99,9 +104,11 @@ void ViewProviderHatch::onChanged(const App::Property* prop)
 {
     if ((prop == &HatchScale) ||
         (prop == &HatchColor)) {
-        TechDraw::DrawViewPart* parent = getViewObject()->getSourceView();
-        if (parent) {
-            parent->requestPaint();
+        if (HatchScale.getValue() > 0.0) {
+            TechDraw::DrawViewPart* parent = getViewObject()->getSourceView();
+            if (parent) {
+                parent->requestPaint();
+            }
         }
     }
 }


### PR DESCRIPTION
When a hatch scale parameter is being changed in the Property Editor, the scale temporarily become the lower limit of the constraint range.  This cause an extremely long pause due to millions of iterations.  This fix prevents this behaviour.

wf

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
