### PR TITLE
update and reshape tooltips for FEM import-export settings

### DIFF
--- a/src/Mod/Fem/Gui/DlgSettingsFemExportAbaqus.ui
+++ b/src/Mod/Fem/Gui/DlgSettingsFemExportAbaqus.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Abaqus INP</string>
+   <string>INP</string>
   </property>
   <layout class="QGridLayout" name="gridLayout_4">
    <item row="1" column="0">
@@ -38,7 +38,10 @@
         <item row="1" column="1">
          <widget class="Gui::PrefCheckBox" name="checkBoxWriteGroups">
           <property name="toolTip">
-           <string>If checked, the mesh groups from the mesh are exported as well.</string>
+           <string>Mesh groups are exported too.
+Every constraint and, if there are different materials, material
+consists of two mesh groups, faces and nodes where the
+constraint or material is applied.</string>
           </property>
           <property name="text">
            <string/>
@@ -64,7 +67,13 @@
         <item row="0" column="1">
          <widget class="Gui::PrefComboBox" name="comboBoxElemChoiceParam">
           <property name="toolTip">
-           <string>element parameter: All: all elements, highest: highest elements only, FEM: FEM elements only (only edges not belonging to faces and faces not belonging to volumes)</string>
+           <string>All: All elements will be exported.
+
+Highest: Only the highest elements will be exported. This means
+for means volumes for a volume mesh and faces for a shell mesh.
+
+FEM: Only FEM elements will be exported. This means only edges
+not belonging to faces and faces not belonging to volumes.</string>
           </property>
           <property name="statusTip">
            <string/>

--- a/src/Mod/Fem/Gui/DlgSettingsFemInOutVtk.ui
+++ b/src/Mod/Fem/Gui/DlgSettingsFemInOutVtk.ui
@@ -48,7 +48,16 @@
         <item row="0" column="1">
          <widget class="Gui::PrefComboBox" name="comboBoxVtkImportObject">
           <property name="toolTip">
-           <string>How to import VTK files: VTK result object: mesh and results will be imported into a FreeCAD FEM pipline object, FEM mesh object: mesh will be imported into a FreeCAD FEM mesh object, FreeCAD result object: mesh and results will be imported into a FreeCAD FEM result object (because the result component names have to fit with the FreeCAD result object, this might proper work only on VTK files exported from FreeCAD)</string>
+           <string>VTK result object: A FreeCAD FEM VTK result object will be imported
+(equals to the object which was exported).
+
+FEM mesh object: The results in the VTK file will be omitted, only the
+mesh data will be imported and a FreeCAD FEM mesh object will be created.
+
+FreeCAD result object: The imported data will be converted into a
+FreeCAD FEM Result object. Note: this setting needs the exact result
+component names and thus it only works properly with VTK files
+exported from FreeCAD.</string>
           </property>
           <property name="statusTip">
            <string/>


### PR DESCRIPTION
Add info we collected in https://www.freecadweb.org/wiki/Import_Export_Preference.
Also reshape some tooltips to make them readable on smaller screens.
Also rename a tab to "INP" because all other file export tabs use only the abbreviation as title. (E.g. just "DXF" not "AutoCAD DXF")