### PR TITLE
[Path] Auto prefix job template filename on save

### DIFF
--- a/src/Mod/Path/PathScripts/PathJobCmd.py
+++ b/src/Mod/Path/PathScripts/PathJobCmd.py
@@ -133,7 +133,14 @@ class CommandJobTemplateExport:
                 "Path - Job Template",
                 PathPreferences.filePath(),
                 "job_*.json")[0]
-        if foo: 
+        if foo:
+            s = '/'
+            splitList = foo.split(s)
+            li = len(splitList) - 1
+            if splitList[li][-5:] == '.json':
+                if splitList[li][:4] != 'job_' and splitList[li][:4] != 'Job_':
+                    splitList[li] = 'Job_' + splitList[li]
+                    foo = s.join(splitList)
             cls.Execute(job, foo, dialog)
 
     @classmethod


### PR DESCRIPTION
Code checks for user-entered prefix of "Job_" (case-insensitive). If missing, prefix is added before saving template.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
