### PR TITLE
Fix misc. source comment typos

### DIFF
--- a/src/Mod/Arch/OfflineRenderingUtils.py
+++ b/src/Mod/Arch/OfflineRenderingUtils.py
@@ -297,7 +297,7 @@ def render(outputfile,scene=None,camera=None,zoom=False,width=400,height=300,bac
     the given coin camera (ortho or perspective). If zoom is True the camera will be resized to fit all
     objects. The outputfile must be a file path to save a png image. Optionally a light direction as a (x,y,z)
     tuple can be given. In this case, a directional light will be added and shadows will
-    be turned on. This might not work with soem 3D drivers."""
+    be turned on. This might not work with some 3D drivers."""
 
     # On Linux, the X server must have indirect rendering enabled in order to be able to do offline
     # PNG rendering. Unfortunately, this is turned off by default on most recent distros. The easiest
@@ -428,7 +428,7 @@ def viewer(scene=None,background=(1.0,1.0,1.0),lightdir=None):
     a standalone coin viewer with the contents of the given scene. You can
     give a background color, and optionally a light direction as a (x,y,z)
     tuple. In this case, a directional light will be added and shadows will
-    be turned on. This might not work with soem 3D drivers."""
+    be turned on. This might not work with some 3D drivers."""
 
     # Initialize Coin. This returns a main window to use
     from pivy import sogui

--- a/src/Mod/Arch/importIFC.py
+++ b/src/Mod/Arch/importIFC.py
@@ -1235,7 +1235,7 @@ def insert(filename,docname,skip=[],only=[],root=None):
             if mdict:
                 mat.Material = mdict
             fcmats[mat.Name] = mat
-        # fill material attribut of the objects 
+        # fill material attribute of the objects 
         for o,m in mattable.items():
             if m == material.id():
                 if o in objects:

--- a/src/Mod/Draft/importSVG.py
+++ b/src/Mod/Draft/importSVG.py
@@ -31,7 +31,7 @@ __url__ = ["http://www.freecadweb.org"]
 #
 #  This module provides support for importing and exporting SVG files. It
 #  enables importing/exporting objects directly to/from the 3D document, but
-#  doesn't handle the SVG output from the Drawng and TechDraw modules.
+#  doesn't handle the SVG output from the Drawing and TechDraw modules.
 
 '''
 This script imports SVG files in FreeCAD. Currently only reads the following entities:
@@ -43,7 +43,7 @@ currently unsupported: use, image
 # handle image element (external references and inline base64)
 # debug Problem with 'Sans' font from Inkscape
 # debug Problem with fill color
-# implement inherting fill style from group
+# implement inheriting fill style from group
 # handle relative units
 
 import xml.sax, string, FreeCAD, os, math, re, Draft, DraftVecUtils
@@ -528,7 +528,7 @@ class svgHandler(xml.sax.ContentHandler):
                         self.svgdpi = 96.0
                 if 'style' in data:
                         if not data['style']:
-                                pass#empty style attribute stops inhertig from parent
+                                pass#empty style attribute stops inheriting from parent
                         else:
                                 content = data['style'].replace(' ','')
                                 content = content.split(';')

--- a/src/Mod/Mesh/App/Core/Evaluation.cpp
+++ b/src/Mod/Mesh/App/Core/Evaluation.cpp
@@ -840,7 +840,7 @@ bool MeshEvalNeighbourhood::Evaluate ()
         }
         else {
             // we handle only the cases for 1 and 2, for all higher
-            // values we have a non-manifold that is ignorned here
+            // values we have a non-manifold that is ignored here
             if (count == 2) {
                 const MeshFacet& rFace0 = rclFAry[f0];
                 const MeshFacet& rFace1 = rclFAry[f1];
@@ -906,7 +906,7 @@ std::vector<unsigned long> MeshEvalNeighbourhood::GetIndices() const
         }
         else {
             // we handle only the cases for 1 and 2, for all higher
-            // values we have a non-manifold that is ignorned here
+            // values we have a non-manifold that is ignored here
             if (count == 2) {
                 const MeshFacet& rFace0 = rclFAry[f0];
                 const MeshFacet& rFace1 = rclFAry[f1];
@@ -982,7 +982,7 @@ void MeshKernel::RebuildNeighbours (unsigned long index)
         }
         else {
             // we handle only the cases for 1 and 2, for all higher
-            // values we have a non-manifold that is ignorned here
+            // values we have a non-manifold that is ignored here
             if (count == 2) {
                 MeshFacet& rFace0 = this->_aclFacetArray[f0];
                 MeshFacet& rFace1 = this->_aclFacetArray[f1];
@@ -1005,7 +1005,7 @@ void MeshKernel::RebuildNeighbours (unsigned long index)
     }
 
     // we handle only the cases for 1 and 2, for all higher
-    // values we have a non-manifold that is ignorned here
+    // values we have a non-manifold that is ignored here
     if (count == 2) {
         MeshFacet& rFace0 = this->_aclFacetArray[f0];
         MeshFacet& rFace1 = this->_aclFacetArray[f1];

--- a/src/Mod/OpenSCAD/OpenSCAD2Dgeom.py
+++ b/src/Mod/OpenSCAD/OpenSCAD2Dgeom.py
@@ -413,7 +413,7 @@ def superWireReverse(debuglist,closed=False):
     '''superWireReverse(debuglist,[closed]): forces a wire between edges
     that don't necessarily have coincident endpoints. If closed=True, wire
     will always be closed. debuglist has a tuple for every edge.The first
-    entry is the edge, the second is the flag 'does not nedd to be inverted'
+    entry is the edge, the second is the flag 'does not need to be inverted'
     '''
     #taken from draftlibs
     def median(v1,v2):

--- a/src/Tools/fcinfo
+++ b/src/Tools/fcinfo
@@ -130,7 +130,7 @@ class FreeCADFileHandler(xml.sax.ContentHandler):
 
         elif tag == "Property":
             self.prop = None
-            # skip "internal" properties, unuseful for a diff
+            # skip "internal" properties, useless for a diff
             if attributes["name"] not in ["Symbol","AttacherType","MapMode","MapPathParameter","MapReversed",
                                           "AttachmentOffset","SelectionStyle","TightGrid","GridSize","GridSnap",
                                           "GridStyle","Lighting","Deviation","AngularDeflection","BoundingBox",
@@ -252,6 +252,3 @@ if __name__ == '__main__':
     print("Document: "+sys.argv[-1]+" ("+s+")")
     print("   SHA1: "+str(hashlib.sha1(open(sys.argv[-1],'rb').read()).hexdigest()))
     xml.sax.parseString(doc,FreeCADFileHandler(zfile,short))
-
-
-


### PR DESCRIPTION
Found via `codespell -q 3 -I ../fc-word-whitelist.txt -S ./.git,*.po,*.ts,./ChangeLog.txt,./src/3rdParty,./src/Mod/Assembly/App/opendcm,./src/CXX,./src/zipios++,./src/Base/swig*,./src/Mod/Robot/App/kdl_cp,./src/Mod/Import/App/SCL,./src/WindowsInstaller`