### PR TITLE
PathAdaptive:  bugfix

### DIFF
--- a/src/Mod/Path/libarea/Adaptive.cpp
+++ b/src/Mod/Path/libarea/Adaptive.cpp
@@ -620,7 +620,7 @@ void SmoothPaths(Paths &paths, double stepSize, long pointCount, long iterations
 				points.push_back(pair<size_t /*path index*/, IntPoint>(i, pt));
 				continue;
 			}
-			const auto &back=points.back();
+			const auto back=points.back();
 			const IntPoint & lastPt = back.second;
 
 


### PR DESCRIPTION
fix for "path to nowhere" that occurs on some enviroments

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
