### PR TITLE
Part preferences: hide unused option from dialog

### DIFF
--- a/src/Mod/Part/Gui/DlgSettingsGeneral.ui
+++ b/src/Mod/Part/Gui/DlgSettingsGeneral.ui
@@ -67,6 +67,9 @@
      <property name="title">
       <string>Object naming</string>
      </property>
+     <property name="visible">
+      <bool>false</bool>
+     </property>
      <layout class="QGridLayout" name="gridLayout_2">
       <item row="0" column="0">
        <widget class="Gui::PrefCheckBox" name="checkObjectNaming">


### PR DESCRIPTION
As we found out: https://forum.freecadweb.org/viewtopic.php?p=322805#p322672
the option "Add name of base object" is not used and can be removed from the dialog.