### PR TITLE
[Path] MillFace: SetupProperties() syntax correction for broken Job GUI fix

### DIFF
--- a/src/Mod/Path/PathScripts/PathMillFace.py
+++ b/src/Mod/Path/PathScripts/PathMillFace.py
@@ -253,7 +253,10 @@ class ObjectFace(PathPocketBase.ObjectPocket):
 
 
 def SetupProperties():
-    return PathPocketBase.SetupProperties().extend(["BoundaryShape", "ExcludeRaisedAreas"])
+    setup = PathPocketBase.SetupProperties()
+    setup.append("BoundaryShape")
+    setup.append("ExcludeRaisedAreas")
+    return setup
 
 
 def Create(name, obj=None):


### PR DESCRIPTION
Path Job GUI broken due to SetupProperties() syntax error
Bug reported in forum: [Bug in Job gui](https://forum.freecadweb.org/viewtopic.php?f=15&t=38068)

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
