### PR TITLE
[Arch] Update translate in no GUIup case

### DIFF
--- a/src/Mod/Arch/importWebGL.py
+++ b/src/Mod/Arch/importWebGL.py
@@ -36,7 +36,7 @@ if FreeCAD.GuiUp:
 else:
     FreeCADGui = None
     # \cond
-    def translate(ctxt,txt):
+    def translate(ctxt,txt,utf8_decode=True):
         return txt
     # \endcond
 


### PR DESCRIPTION
If the `utf8_decode` is not added, when saving on server side, the following error occurs: 
```
  File "/usr/share/freecad/Mod/Arch/importWebGL.py", line 129, in export
    FreeCAD.Console.PrintMessage(translate("Arch","Successfully written", utf8_decode=True) + ' ' + filename + "\n")
TypeError: translate() got an unexpected keyword argument 'utf8_decode'
```

This fix mitigates the error.