### PR TITLE
[PartDesign] Add intersection-toggle to thickness-tool

### DIFF
--- a/src/Mod/PartDesign/App/FeatureThickness.cpp
+++ b/src/Mod/PartDesign/App/FeatureThickness.cpp
@@ -46,6 +46,7 @@ Thickness::Thickness()
     ADD_PROPERTY_TYPE(Join,(long(0)),"Thickness",App::Prop_None,"Join type");
     Join.setEnums(JoinEnums);
     ADD_PROPERTY_TYPE(Reversed,(false),"Thickness",App::Prop_None,"Apply the thickness towards the solids interior");
+    ADD_PROPERTY_TYPE(Intersection,(false),"Thickness",App::Prop_None,"Enable intersection-handling");
 }
 
 short Thickness::mustExecute() const
@@ -76,6 +77,7 @@ App::DocumentObjectExecReturn *Thickness::execute(void)
     }
 
     bool reversed = Reversed.getValue();
+    bool intersection = Intersection.getValue();
     double thickness =  (reversed ? -1. : 1. )*Value.getValue();
     double tol = Precision::Confusion();
     short mode = (short)Mode.getValue();
@@ -85,7 +87,7 @@ App::DocumentObjectExecReturn *Thickness::execute(void)
         join = 2;
 
     if (fabs(thickness) > 2*tol)
-        this->Shape.setValue(getSolid(TopShape.makeThickSolid(closingFaces, thickness, tol, false, false, mode, join)));
+        this->Shape.setValue(getSolid(TopShape.makeThickSolid(closingFaces, thickness, tol, intersection, false, mode, join)));
     else
         this->Shape.setValue(getSolid(TopShape.getShape()));
     return App::DocumentObject::StdReturn;

--- a/src/Mod/PartDesign/App/FeatureThickness.h
+++ b/src/Mod/PartDesign/App/FeatureThickness.h
@@ -41,6 +41,7 @@ public:
 
     App::PropertyLength         Value;
     App::PropertyBool           Reversed;
+    App::PropertyBool           Intersection;
     App::PropertyEnumeration    Mode;
     App::PropertyEnumeration    Join;      
 

--- a/src/Mod/PartDesign/Gui/TaskThicknessParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskThicknessParameters.cpp
@@ -73,6 +73,9 @@ TaskThicknessParameters::TaskThicknessParameters(ViewProviderDressUp *DressUpVie
     bool r = pcThickness->Reversed.getValue();
     ui->checkReverse->setChecked(r);
 
+    bool i = pcThickness->Intersection.getValue();
+    ui->checkIntersection->setChecked(i);
+
     std::vector<std::string> strings = pcThickness->Base.getSubValues();
     for (std::vector<std::string>::const_iterator i = strings.begin(); i != strings.end(); i++)
     {
@@ -85,6 +88,8 @@ TaskThicknessParameters::TaskThicknessParameters(ViewProviderDressUp *DressUpVie
             this, SLOT(onValueChanged(double)));
     connect(ui->checkReverse, SIGNAL(toggled(bool)),
             this, SLOT(onReversedChanged(bool)));
+    connect(ui->checkIntersection, SIGNAL(toggled(bool)),
+            this, SLOT(onIntersectionChanged(bool)));
     connect(ui->buttonRefAdd, SIGNAL(toggled(bool)),
             this, SLOT(onButtonRefAdd(bool)));
     connect(ui->buttonRefRemove, SIGNAL(toggled(bool)),
@@ -192,6 +197,18 @@ bool TaskThicknessParameters::getReversed(void) const
     return ui->checkReverse->isChecked();
 }
 
+void TaskThicknessParameters::onIntersectionChanged(const bool on) {
+    clearButtons(none);
+    PartDesign::Thickness* pcThickness = static_cast<PartDesign::Thickness*>(DressUpView->getObject());
+    pcThickness->Intersection.setValue(on);
+    pcThickness->getDocument()->recomputeFeature(pcThickness);
+}
+
+bool TaskThicknessParameters::getIntersection(void) const
+{
+    return ui->checkIntersection->isChecked();
+}
+
 int TaskThicknessParameters::getJoinType(void) const {
     
     return ui->joinComboBox->currentIndex();
@@ -264,6 +281,7 @@ bool TaskDlgThicknessParameters::accept()
     FCMD_OBJ_CMD(obj,"Value = " << draftparameter->getValue());
     FCMD_OBJ_CMD(obj,"Reversed = " << draftparameter->getReversed());
     FCMD_OBJ_CMD(obj,"Mode = " << draftparameter->getMode());
+    FCMD_OBJ_CMD(obj,"Intersection = " << draftparameter->getIntersection());
     FCMD_OBJ_CMD(obj,"Join = " << draftparameter->getJoinType());
 
     return TaskDlgDressUpParameters::accept();

--- a/src/Mod/PartDesign/Gui/TaskThicknessParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskThicknessParameters.h
@@ -41,6 +41,7 @@ public:
 
     double getValue(void) const;
     bool getReversed(void) const;
+    bool getIntersection(void) const;
     int  getMode(void) const;
     int  getJoinType(void) const;
 
@@ -49,6 +50,7 @@ private Q_SLOTS:
     void onModeChanged(int mode);
     void onJoinTypeChanged(int join);
     void onReversedChanged(bool reversed);
+    void onIntersectionChanged(bool intersection);
     void onRefDeleted(void);
 
 protected:

--- a/src/Mod/PartDesign/Gui/TaskThicknessParameters.ui
+++ b/src/Mod/PartDesign/Gui/TaskThicknessParameters.ui
@@ -52,6 +52,9 @@
      </item>
      <item row="0" column="1">
       <widget class="Gui::QuantitySpinBox" name="Value" native="true">
+       <property name="focusPolicy">
+        <enum>Qt::TabFocus</enum>
+       </property>
        <property name="unit" stdset="0">
         <string notr="true">mm</string>
        </property>
@@ -119,6 +122,13 @@
     </layout>
    </item>
    <item>
+    <widget class="QCheckBox" name="checkIntersection">
+     <property name="text">
+      <string>Intersection</string>
+     </property>
+    </widget>
+   </item>
+   <item>
     <widget class="QCheckBox" name="checkReverse">
      <property name="text">
       <string>Make thickness inwards</string>
@@ -134,6 +144,16 @@
    <header>Gui/QuantitySpinBox.h</header>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>Value</tabstop>
+  <tabstop>modeComboBox</tabstop>
+  <tabstop>joinComboBox</tabstop>
+  <tabstop>checkIntersection</tabstop>
+  <tabstop>checkReverse</tabstop>
+  <tabstop>buttonRefAdd</tabstop>
+  <tabstop>buttonRefRemove</tabstop>
+  <tabstop>listWidgetReferences</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>


### PR DESCRIPTION
added intersection-toggle to PartDesign-Thickness-GUI and fixed tab-order, to control intersection flag on makeThickSolid-call.

see: “Thickness tools is missing intersection-toogle”
https://forum.freecadweb.org/viewtopic.php?f=19&t=37952

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass TestPartDesignApp and TestPartDesignGui.
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [x] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists
  · does not exist

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
