### PR TITLE
Remove extra indentation from webGL template.

### DIFF
--- a/src/Mod/Arch/importWebGL.py
+++ b/src/Mod/Arch/importWebGL.py
@@ -52,68 +52,68 @@ wireframeStyle = "faceloop" # this can be "faceloop", "multimaterial", or None
 cameraPosition = None # set this to a tuple to change, for ex. (0,0,0)
 linewidth = 1
 template = """<!DOCTYPE html>
-        <html>
-        <head>
-            <title>FreeCAD model</title>
-            <script type="text/javascript" src="http://cdnjs.cloudflare.com/ajax/libs/three.js/r50/three.min.js"></script>
-            
-            <script>
-            
-            var camera, controls, scene, renderer;
-            
-            window.onload = function() {
+<html>
+<head>
+    <title>FreeCAD model</title>
+    <script type="text/javascript" src="http://cdnjs.cloudflare.com/ajax/libs/three.js/r50/three.min.js"></script>
 
-                var SCREEN_WIDTH = window.innerWidth, SCREEN_HEIGHT = window.innerHeight;
-                var VIEW_ANGLE = 35, ASPECT = SCREEN_WIDTH / SCREEN_HEIGHT, NEAR = 0.1, FAR = 20000;
+    <script>
 
-                renderer = new THREE.WebGLRenderer();
-                renderer.setSize( SCREEN_WIDTH, SCREEN_HEIGHT );
-                document.body.appendChild( renderer.domElement );
-        
-                scene = new THREE.Scene();
-        
-                camera = new THREE.PerspectiveCamera(
-                    VIEW_ANGLE,      // Field of view
-                    ASPECT,          // Aspect ratio
-                    NEAR,            // Near plane
-                    FAR              // Far plane
-                );
-                $CameraData // placeholder for the FreeCAD camera
-                
-                controls = new THREE.TrackballControls( camera );
-                controls.rotateSpeed = 1.0;
-                controls.zoomSpeed = 1.2;
-                controls.panSpeed = 0.8;
-                controls.noZoom = false;
-                controls.noPan = false;
-                controls.staticMoving = true;
-                controls.dynamicDampingFactor = 0.3;
-                controls.keys = [ 65, 83, 68 ]; 
-        
-                $ObjectsData // placeholder for the FreeCAD objects
-        
-                var light = new THREE.PointLight( 0xFFFF00 );
-                light.position.set( -10000, -10000, 10000 );
-                scene.add( light );
-        
-                renderer.render( scene, camera );
-                
-                animate();
-            };
-            
-            function animate(){
-                requestAnimationFrame( animate );
-                render();
-            };
-            
-            function render(){
-                controls.update();
-                renderer.render( scene, camera );
-            };
-            </script>
-        </head>
-        <body></body>
-        </html>"""
+    var camera, controls, scene, renderer;
+
+    window.onload = function() {
+
+        var SCREEN_WIDTH = window.innerWidth, SCREEN_HEIGHT = window.innerHeight;
+        var VIEW_ANGLE = 35, ASPECT = SCREEN_WIDTH / SCREEN_HEIGHT, NEAR = 0.1, FAR = 20000;
+
+        renderer = new THREE.WebGLRenderer();
+        renderer.setSize( SCREEN_WIDTH, SCREEN_HEIGHT );
+        document.body.appendChild( renderer.domElement );
+
+        scene = new THREE.Scene();
+
+        camera = new THREE.PerspectiveCamera(
+            VIEW_ANGLE,      // Field of view
+            ASPECT,          // Aspect ratio
+            NEAR,            // Near plane
+            FAR              // Far plane
+        );
+        $CameraData // placeholder for the FreeCAD camera
+
+        controls = new THREE.TrackballControls( camera );
+        controls.rotateSpeed = 1.0;
+        controls.zoomSpeed = 1.2;
+        controls.panSpeed = 0.8;
+        controls.noZoom = false;
+        controls.noPan = false;
+        controls.staticMoving = true;
+        controls.dynamicDampingFactor = 0.3;
+        controls.keys = [ 65, 83, 68 ]; 
+
+        $ObjectsData // placeholder for the FreeCAD objects
+
+        var light = new THREE.PointLight( 0xFFFF00 );
+        light.position.set( -10000, -10000, 10000 );
+        scene.add( light );
+
+        renderer.render( scene, camera );
+
+        animate();
+    };
+
+    function animate(){
+        requestAnimationFrame( animate );
+        render();
+    };
+
+    function render(){
+        controls.update();
+        renderer.render( scene, camera );
+    };
+    </script>
+</head>
+<body></body>
+</html>"""
 
 
 if open.__module__ in ['__builtin__','io']:
@@ -126,7 +126,7 @@ def export(exportList,filename):
     outfile = pythonopen(filename,"w")
     outfile.write(html)
     outfile.close()
-    FreeCAD.Console.PrintMessage(translate("Arch","Successfully written", utf8_decode=True) + ' ' + filename + "\n")
+    FreeCAD.Console.PrintMessage(translate("Arch", "Successfully written", utf8_decode=True) + ' ' + filename + "\n")
     
 def getHTML(objectsList):
     "returns the complete HTML code of a viewer for the given objects"
@@ -236,4 +236,3 @@ def getObjectData(obj,wireframeMode=wireframeStyle):
             result += tab+"scene.add( mesh );\n"+tab
         
     return result
-        


### PR DESCRIPTION
The template remains the same, but the extra indentation is removed, such that the resulting .html file looks as expected.