### PR TITLE
SMDS_VolumeTool.cpp: Fix compilation warning

### DIFF
--- a/src/3rdParty/salomesmesh/src/SMDS/SMDS_VolumeTool.cpp
+++ b/src/3rdParty/salomesmesh/src/SMDS/SMDS_VolumeTool.cpp
@@ -360,6 +360,7 @@ struct XYZ {
   XYZ()                               { x = 0; y = 0; z = 0; }
   XYZ( double X, double Y, double Z ) { x = X; y = Y; z = Z; }
   XYZ( const XYZ& other )             { x = other.x; y = other.y; z = other.z; }
+  XYZ& operator=( const XYZ& other ) = default;
   XYZ( const SMDS_MeshNode* n )       { x = n->X(); y = n->Y(); z = n->Z(); }
   inline XYZ operator-( const XYZ& other );
   inline XYZ operator+( const XYZ& other );


### PR DESCRIPTION
Create an explicit copy assignment operator for class XYZ, as implicit copy assignment operator is deprecated (-Wdeprecated-copy)