### PR TITLE
PartDesign: new "dogbone" operator

### DIFF
--- a/src/Base/Unit.h
+++ b/src/Base/Unit.h
@@ -32,6 +32,10 @@
 #include <string>
 #include <QString>
 
+#ifndef BaseExport
+#define BaseExport
+#endif
+
 namespace Base {
 
 #define UnitSignatureLengthBits 4

--- a/src/Main/MainGui.cpp
+++ b/src/Main/MainGui.cpp
@@ -127,19 +127,19 @@ int main( int argc, char ** argv )
     // See https://forum.freecadweb.org/viewtopic.php?f=18&t=20600
     // See Gui::Application::runApplication()
     putenv("LC_NUMERIC=C");
-    putenv("PYTHONPATH=");
+    // putenv("PYTHONPATH=");
 #elif defined(FC_OS_MACOSX)
     (void)QLocale::system();
-    putenv("PYTHONPATH=");
+    // putenv("PYTHONPATH=");
 #else
-    _putenv("PYTHONPATH=");
+    // _putenv("PYTHONPATH=");
     // https://forum.freecadweb.org/viewtopic.php?f=4&t=18288
     // https://forum.freecadweb.org/viewtopic.php?f=3&t=20515
-    const char* fc_py_home = getenv("FC_PYTHONHOME");
-    if (fc_py_home)
-        _putenv_s("PYTHONHOME", fc_py_home);
-    else
-        _putenv("PYTHONHOME=");
+    //const char* fc_py_home = getenv("FC_PYTHONHOME");
+    //if (fc_py_home)
+    //    _putenv_s("PYTHONHOME", fc_py_home);
+    //else
+    //    _putenv("PYTHONHOME=");
 #endif
 
 #if defined (FC_OS_WIN32)

--- a/src/Mod/PartDesign/App/AppPartDesign.cpp
+++ b/src/Mod/PartDesign/App/AppPartDesign.cpp
@@ -34,6 +34,7 @@
 #include "FeatureSolid.h"
 #include "FeaturePocket.h"
 #include "FeatureFillet.h"
+#include "FeatureDogbone.h"
 #include "FeatureSketchBased.h"
 #include "FeatureRevolution.h"
 #include "FeatureGroove.h"
@@ -105,6 +106,7 @@ PyMOD_INIT_FUNC(_PartDesign)
     PartDesign::Pad                         ::init();
     PartDesign::Pocket                      ::init();
     PartDesign::Fillet                      ::init();
+    PartDesign::Dogbone                     ::init();
     PartDesign::Revolution                  ::init();
     PartDesign::Groove                      ::init();
     PartDesign::Chamfer                     ::init();

--- a/src/Mod/PartDesign/App/CMakeLists.txt
+++ b/src/Mod/PartDesign/App/CMakeLists.txt
@@ -77,6 +77,8 @@ SET(FeaturesDressUp_SRCS
     FeatureDressUp.h
     FeatureFillet.cpp
     FeatureFillet.h
+    FeatureDogbone.cpp
+    FeatureDogbone.h
     FeatureChamfer.cpp
     FeatureChamfer.h
     FeatureDraft.cpp

--- a/src/Mod/PartDesign/App/FeatureDogbone.cpp
+++ b/src/Mod/PartDesign/App/FeatureDogbone.cpp
@@ -1,0 +1,193 @@
+/***************************************************************************
+ *   Copyright (c) 2010 Juergen Riegel <FreeCAD@juergen-riegel.net>        *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+
+#include "PreCompiled.h"
+#ifndef _PreComp_
+# include <BRepAlgo.hxx>
+# include <BRepPrimAPI_MakeCylinder.hxx>
+# include <BRepAlgoAPI_Cut.hxx>
+# include <TopExp.hxx>
+# include <TopExp_Explorer.hxx>
+# include <TopoDS.hxx>
+# include <TopoDS_Edge.hxx>
+# include <TopTools_IndexedMapOfShape.hxx>
+# include <TopTools_IndexedDataMapOfShapeListOfShape.hxx>
+# include <TopTools_ListOfShape.hxx>
+# include <BRep_Tool.hxx>
+# include <ShapeFix_Shape.hxx>
+# include <ShapeFix_ShapeTolerance.hxx>
+# include <Standard_Version.hxx>
+#endif
+
+#include <Base/Console.h>
+#include <Base/Exception.h>
+#include <Base/Reader.h>
+#include <Mod/Part/App/TopoShape.h>
+
+#include <gce_MakeDir.hxx>
+#include <BRepGProp.hxx>
+#include <ShapeAnalysis_Edge.hxx>
+#include <GProp_GProps.hxx>
+
+#include "FeatureDogbone.h"
+
+
+using namespace PartDesign;
+
+
+PROPERTY_SOURCE(PartDesign::Dogbone, PartDesign::DressUp)
+
+const App::PropertyQuantityConstraint::Constraints floatRadius = {0.0,FLT_MAX,0.1};
+
+Dogbone::Dogbone()
+{
+    ADD_PROPERTY(Radius,(1.0));
+    Radius.setUnit(Base::Unit::Length);
+    Radius.setConstraints(&floatRadius);
+}
+
+short Dogbone::mustExecute() const
+{
+    if (Placement.isTouched() || Radius.isTouched())
+        return 1;
+    return DressUp::mustExecute();
+}
+
+App::DocumentObjectExecReturn *Dogbone::execute(void)
+{
+    // NOTE: Normally the Base property and the BaseFeature property should point to the same object.
+    // The only difference is that the Base property also stores the edges that are to be chamfered
+    Part::TopoShape TopShape;
+    try {
+        TopShape = getBaseShape();
+    } catch (Base::Exception& e) {
+        return new App::DocumentObjectExecReturn(e.what());
+    }
+
+    std::vector<std::string> SubNames = std::vector<std::string>(Base.getSubValues());
+    getContiniusEdges(TopShape, SubNames);
+
+    if (SubNames.size() == 0)
+        return new App::DocumentObjectExecReturn("No edges specified");
+
+    double size = Radius.getValue();
+    if (size <= 0)
+        return new App::DocumentObjectExecReturn("Radius must be greater than zero");
+
+    this->positionByBaseFeature();
+    // create an untransformed copy of the basefeature shape
+    Part::TopoShape baseShape(TopShape);
+    baseShape.setTransform(Base::Matrix4D());
+    try {
+        GProp_GProps edgeProps;
+        ShapeAnalysis_Edge edgeAnalysis;
+
+        Part::TopoShape result = baseShape;
+
+        for (std::vector<std::string>::const_iterator it=SubNames.begin(); it != SubNames.end(); ++it) {
+            TopoDS_Edge edge = TopoDS::Edge(baseShape.getSubShape(it->c_str()));
+            BRepGProp::LinearProperties(edge, edgeProps);
+            TopExp_Explorer exp(edge, TopAbs_VERTEX);
+
+            gp_Pnt first = BRep_Tool::Pnt(edgeAnalysis.FirstVertex(edge));
+            gp_Pnt last = BRep_Tool::Pnt(edgeAnalysis.LastVertex(edge));
+
+            gp_Ax2 ax2(first, gce_MakeDir(first, last).Value());
+
+            std::cerr << "Pos: " << first.X() << " " << first.Y() << " " << first.Z() << std::endl;
+
+            BRepPrimAPI_MakeCylinder mkCylr(ax2, Radius.getValue(), edgeProps.Mass());
+            TopoDS_Shape cyl = mkCylr.Shape();
+
+            BRepAlgoAPI_Cut mkCut(result.getShape(), cyl);
+            result = mkCut.Shape();
+            if (!mkCut.IsDone()) {
+                return new App::DocumentObjectExecReturn("Failed to create Dogbone");
+            }
+            if (result.isNull()) {
+                return new App::DocumentObjectExecReturn("Resulting shape is null");
+            }
+        }
+
+        TopoDS_Shape resultShape = result.getShape();
+
+        TopTools_ListOfShape aLarg;
+        aLarg.Append(baseShape.getShape());
+        if (!BRepAlgo::IsValid(aLarg, resultShape, Standard_False, Standard_False)) {
+            ShapeFix_ShapeTolerance aSFT;
+            aSFT.LimitTolerance(resultShape, Precision::Confusion(), Precision::Confusion(), TopAbs_SHAPE);
+            Handle(ShapeFix_Shape) aSfs = new ShapeFix_Shape(resultShape);
+            aSfs->Perform();
+            result = aSfs->Shape();
+            if (!BRepAlgo::IsValid(aLarg, resultShape, Standard_False, Standard_False)) {
+                return new App::DocumentObjectExecReturn("Resulting shape is invalid");
+            }
+        }
+        int solidCount = countSolids(resultShape);
+        if (solidCount > 1) {
+            return new App::DocumentObjectExecReturn("Dogbone: Result has multiple solids. This is not supported at this time.");
+        }
+
+        this->Shape.setValue(getSolid(resultShape));
+        return App::DocumentObject::StdReturn;
+    }
+    catch (Standard_Failure& e) {
+        return new App::DocumentObjectExecReturn(e.GetMessageString());
+    }
+}
+
+void Dogbone::Restore(Base::XMLReader &reader)
+{
+    reader.readElement("Properties");
+    int Cnt = reader.getAttributeAsInteger("Count");
+
+    for (int i=0 ;i<Cnt ;i++) {
+        reader.readElement("Property");
+        const char* PropName = reader.getAttribute("name");
+        const char* TypeName = reader.getAttribute("type");
+        App::Property* prop = getPropertyByName(PropName);
+
+        try {
+            if (prop && strcmp(prop->getTypeId().getName(), TypeName) == 0) {
+                prop->Restore(reader);
+            }
+            else if (prop && strcmp(TypeName,"App::PropertyFloatConstraint") == 0 &&
+                     strcmp(prop->getTypeId().getName(), "App::PropertyQuantityConstraint") == 0) {
+                App::PropertyFloatConstraint p;
+                p.Restore(reader);
+                static_cast<App::PropertyQuantityConstraint*>(prop)->setValue(p.getValue());
+            }
+        }
+        catch (const Base::XMLParseException&) {
+            throw; // re-throw
+        }
+        catch (const Base::Exception &e) {
+            Base::Console().Error("%s\n", e.what());
+        }
+        catch (const std::exception &e) {
+            Base::Console().Error("%s\n", e.what());
+        }
+        reader.readEndElement("Property");
+    }
+    reader.readEndElement("Properties");
+}

--- a/src/Mod/PartDesign/App/FeatureDogbone.h
+++ b/src/Mod/PartDesign/App/FeatureDogbone.h
@@ -1,0 +1,63 @@
+/***************************************************************************
+ *   Copyright (c) 2010 Juergen Riegel <FreeCAD@juergen-riegel.net>        *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+
+#ifndef PARTDESIGN_FEATUREDogbone_H
+#define PARTDESIGN_FEATUREDogbone_H
+
+#include <App/PropertyStandard.h>
+#include <App/PropertyUnits.h>
+#include <App/PropertyLinks.h>
+#include "FeatureDressUp.h"
+
+namespace PartDesign
+{
+
+class PartDesignExport Dogbone : public DressUp
+{
+    PROPERTY_HEADER(PartDesign::Dogbone);
+
+public:
+    Dogbone();
+
+    App::PropertyQuantityConstraint Radius;
+
+    /** @name methods override feature */
+    //@{
+    /// recalculate the feature
+    App::DocumentObjectExecReturn *execute(void);
+    short mustExecute() const;
+    /// returns the type name of the view provider
+    const char* getViewProviderName(void) const {
+        return "PartDesignGui::ViewProviderDogbone";
+    }
+    //@}
+
+protected:
+    void Restore(Base::XMLReader &reader);
+
+};
+
+} //namespace Part
+
+
+#endif // PARTDESIGN_FEATUREDogbone_H

--- a/src/Mod/PartDesign/Gui/AppPartDesignGui.cpp
+++ b/src/Mod/PartDesign/Gui/AppPartDesignGui.cpp
@@ -42,6 +42,7 @@
 #include "ViewProviderPad.h"
 #include "ViewProviderChamfer.h"
 #include "ViewProviderFillet.h"
+#include "ViewProviderDogbone.h"
 #include "ViewProviderDraft.h"
 #include "ViewProviderDressUp.h"
 #include "ViewProviderRevolution.h"
@@ -136,6 +137,7 @@ PyMOD_INIT_FUNC(PartDesignGui)
     PartDesignGui::ViewProviderGroove        ::init();
     PartDesignGui::ViewProviderChamfer       ::init();
     PartDesignGui::ViewProviderFillet        ::init();
+    PartDesignGui::ViewProviderDogbone       ::init();
     PartDesignGui::ViewProviderDraft         ::init();
     PartDesignGui::ViewProviderThickness     ::init();
     PartDesignGui::ViewProviderTransformed   ::init();

--- a/src/Mod/PartDesign/Gui/CMakeLists.txt
+++ b/src/Mod/PartDesign/Gui/CMakeLists.txt
@@ -35,6 +35,7 @@ set(PartDesignGui_MOC_HDRS
     TaskSketchBasedParameters.h
     TaskPadParameters.h
     TaskPocketParameters.h
+    TaskDogboneParameters.h
     TaskChamferParameters.h
     TaskFilletParameters.h
     TaskDraftParameters.h
@@ -69,6 +70,7 @@ set(PartDesignGui_UIC_SRCS
     TaskFeaturePick.ui
     TaskPadParameters.ui
     TaskPocketParameters.ui
+    TaskDogboneParameters.ui
     TaskChamferParameters.ui
     TaskFilletParameters.ui
     TaskDraftParameters.ui
@@ -110,6 +112,8 @@ SET(PartDesignGuiViewProvider_SRCS
     ViewProviderHole.h
     ViewProviderPocket.cpp
     ViewProviderPocket.h
+    ViewProviderDogbone.cpp
+    ViewProviderDogbone.h
     ViewProviderChamfer.cpp
     ViewProviderChamfer.h
     ViewProviderFillet.cpp
@@ -179,6 +183,9 @@ SET(PartDesignGuiTaskDlgs_SRCS
     TaskPocketParameters.ui
     TaskPocketParameters.cpp
     TaskPocketParameters.h
+    TaskDogboneParameters.ui
+    TaskDogboneParameters.cpp
+    TaskDogboneParameters.h
     TaskChamferParameters.ui
     TaskChamferParameters.cpp
     TaskChamferParameters.h

--- a/src/Mod/PartDesign/Gui/Command.cpp
+++ b/src/Mod/PartDesign/Gui/Command.cpp
@@ -1673,6 +1673,42 @@ bool CmdPartDesignFillet::isActive(void)
 }
 
 //===========================================================================
+// PartDesign_Dogbone
+//===========================================================================
+DEF_STD_CMD_A(CmdPartDesignDogbone);
+
+CmdPartDesignDogbone::CmdPartDesignDogbone()
+  :Command("PartDesign_Dogbone")
+{
+    sAppModule    = "PartDesign";
+    sGroup        = QT_TR_NOOP("PartDesign");
+    sMenuText     = QT_TR_NOOP("Dogbone");
+    sToolTipText  = QT_TR_NOOP("Make a Dogbone on an edge, face or body");
+    sWhatsThis    = "PartDesign_Dogbone";
+    sStatusTip    = sToolTipText;
+    sPixmap       = "PartDesign_Dogbone";
+}
+
+void CmdPartDesignDogbone::activated(int iMsg)
+{
+
+    Gui::SelectionObject selected;
+    if (!dressupGetSelected (this, "Dogbone", selected))
+        return;
+
+    Part::Feature *base = static_cast<Part::Feature*>(selected.getObject());
+
+    std::vector<std::string> SubNames = std::vector<std::string>(selected.getSubNames());
+
+    finishDressupFeature (this, "Dogbone", base, SubNames);
+}
+
+bool CmdPartDesignDogbone::isActive(void)
+{
+    return hasActiveDocument();
+}
+
+//===========================================================================
 // PartDesign_Chamfer
 //===========================================================================
 DEF_STD_CMD_A(CmdPartDesignChamfer);
@@ -2362,6 +2398,7 @@ void CreatePartDesignCommands(void)
     rcCmdMgr.addCommand(new CmdPartDesignSubtractiveLoft);
 
     rcCmdMgr.addCommand(new CmdPartDesignFillet());
+    rcCmdMgr.addCommand(new CmdPartDesignDogbone());
     rcCmdMgr.addCommand(new CmdPartDesignDraft());
     rcCmdMgr.addCommand(new CmdPartDesignChamfer());
     rcCmdMgr.addCommand(new CmdPartDesignThickness());

--- a/src/Mod/PartDesign/Gui/Resources/PartDesign.qrc
+++ b/src/Mod/PartDesign/Gui/Resources/PartDesign.qrc
@@ -1,92 +1,93 @@
 <RCC>
-    <qresource>
-        <file>icons/PartDesign_Chamfer.svg</file>
-        <file>icons/PartDesign_Fillet.svg</file>
-        <file>icons/PartDesign_Draft.svg</file>
-        <file>icons/PartDesign_Thickness.svg</file>
-        <file>icons/PartDesign_Groove.svg</file>
-        <file>icons/PartDesign_Pad.svg</file>
-        <file>icons/PartDesign_Pocket.svg</file>
-        <file>icons/PartDesign_Revolution.svg</file>
-        <file>icons/PartDesign_Mirrored.svg</file>
-        <file>icons/PartDesign_LinearPattern.svg</file>
-        <file>icons/PartDesign_PolarPattern.svg</file>
-        <file>icons/PartDesign_Scaled.svg</file>
-        <file>icons/PartDesign_MultiTransform.svg</file>
-        <file>icons/PartDesign_Hole.svg</file>
-        <file>icons/PartDesign_Body.svg</file>
-        <file>icons/PartDesign_Boolean.svg</file>
-        <file>icons/PartDesign_ShapeBinder.svg</file>
-        <file>icons/PartDesign_Clone.svg</file>
-        <file>icons/PartDesign_Plane.svg</file>
-        <file>icons/PartDesign_Line.svg</file>
-        <file>icons/PartDesign_Point.svg</file>
-        <file>icons/PartDesign_CoordinateSystem.svg</file>
-        <file>icons/PartDesign_MoveTip.svg</file>
-        <file>icons/Tree_PartDesign_Pad.svg</file>
-        <file>icons/Tree_PartDesign_Revolution.svg</file>	
-        <file>icons/PartDesign_InternalExternalGear.svg</file>
-        <file>icons/PartDesign_InvoluteGear.svg</file>
+    <qresource prefix="/">
         <file>icons/PartDesignWorkbench.svg</file>
+        <file>icons/PartDesign_Additive_Box.svg</file>
+        <file>icons/PartDesign_Additive_Cone.svg</file>
+        <file>icons/PartDesign_Additive_Cylinder.svg</file>
+        <file>icons/PartDesign_Additive_Ellipsoid.svg</file>
+        <file>icons/PartDesign_Additive_Loft.svg</file>
+        <file>icons/PartDesign_Additive_Pipe.svg</file>
+        <file>icons/PartDesign_Additive_Prism.svg</file>
+        <file>icons/PartDesign_Additive_Sphere.svg</file>
+        <file>icons/PartDesign_Additive_Torus.svg</file>
+        <file>icons/PartDesign_Additive_Wedge.svg</file>
+        <file>icons/PartDesign_BaseFeature.svg</file>
+        <file>icons/PartDesign_Body.svg</file>
         <file>icons/PartDesign_Body_Create_New.svg</file>
         <file>icons/PartDesign_Body_Tree.svg</file>
-        <file>icons/PartDesign_Additive_Pipe.svg</file>
-        <file>icons/PartDesign_Subtractive_Pipe.svg</file>
-        <file>icons/PartDesign_Additive_Loft.svg</file>
-        <file>icons/PartDesign_Subtractive_Loft.svg</file>
-        <file>icons/PartDesign_Additive_Box.svg</file>	
-        <file>icons/PartDesign_Additive_Cylinder.svg</file>	
-        <file>icons/PartDesign_Additive_Sphere.svg</file>	
-        <file>icons/PartDesign_Additive_Cone.svg</file>	
-        <file>icons/PartDesign_Additive_Torus.svg</file>	
-        <file>icons/PartDesign_Additive_Ellipsoid.svg</file>
-        <file>icons/PartDesign_Additive_Prism.svg</file>	
-        <file>icons/PartDesign_Additive_Wedge.svg</file>
-        <file>icons/PartDesign_Subtractive_Box.svg</file>	
+        <file>icons/PartDesign_Boolean.svg</file>
+        <file>icons/PartDesign_Chamfer.svg</file>
+        <file>icons/PartDesign_Clone.svg</file>
+        <file>icons/PartDesign_CoordinateSystem.svg</file>
+        <file>icons/PartDesign_Draft.svg</file>
+        <file>icons/PartDesign_Fillet.svg</file>
+        <file>icons/PartDesign_Groove.svg</file>
+        <file>icons/PartDesign_Hole.svg</file>
+        <file>icons/PartDesign_InternalExternalGear.svg</file>
+        <file>icons/PartDesign_InvoluteGear.svg</file>
+        <file>icons/PartDesign_Line.svg</file>
+        <file>icons/PartDesign_LinearPattern.svg</file>
+        <file>icons/PartDesign_Mirrored.svg</file>
+        <file>icons/PartDesign_MoveTip.svg</file>
+        <file>icons/PartDesign_MultiTransform.svg</file>
+        <file>icons/PartDesign_Pad.svg</file>
+        <file>icons/PartDesign_Plane.svg</file>
+        <file>icons/PartDesign_Pocket.svg</file>
+        <file>icons/PartDesign_Point.svg</file>
+        <file>icons/PartDesign_PolarPattern.svg</file>
+        <file>icons/PartDesign_Revolution.svg</file>
+        <file>icons/PartDesign_Scaled.svg</file>
+        <file>icons/PartDesign_ShapeBinder.svg</file>
+        <file>icons/PartDesign_Subtractive_Box.svg</file>
+        <file>icons/PartDesign_Subtractive_Cone.svg</file>
         <file>icons/PartDesign_Subtractive_Cylinder.svg</file>
-        <file>icons/PartDesign_Subtractive_Sphere.svg</file>
-        <file>icons/PartDesign_Subtractive_Cone.svg</file>	
-        <file>icons/PartDesign_Subtractive_Torus.svg</file>	
         <file>icons/PartDesign_Subtractive_Ellipsoid.svg</file>
-        <file>icons/PartDesign_Subtractive_Prism.svg</file>	
+        <file>icons/PartDesign_Subtractive_Loft.svg</file>
+        <file>icons/PartDesign_Subtractive_Pipe.svg</file>
+        <file>icons/PartDesign_Subtractive_Prism.svg</file>
+        <file>icons/PartDesign_Subtractive_Sphere.svg</file>
+        <file>icons/PartDesign_Subtractive_Torus.svg</file>
         <file>icons/PartDesign_Subtractive_Wedge.svg</file>
-        <file>icons/PartDesign_BaseFeature.svg</file>
+        <file>icons/PartDesign_Thickness.svg</file>
+        <file>icons/Tree_PartDesign_Pad.svg</file>
+        <file>icons/Tree_PartDesign_Revolution.svg</file>
         <file>translations/PartDesign_af.qm</file>
+        <file>translations/PartDesign_ar.qm</file>
+        <file>translations/PartDesign_ca.qm</file>
+        <file>translations/PartDesign_cs.qm</file>
         <file>translations/PartDesign_de.qm</file>
+        <file>translations/PartDesign_el.qm</file>
+        <file>translations/PartDesign_es-ES.qm</file>
+        <file>translations/PartDesign_eu.qm</file>
         <file>translations/PartDesign_fi.qm</file>
+        <file>translations/PartDesign_fil.qm</file>
         <file>translations/PartDesign_fr.qm</file>
+        <file>translations/PartDesign_gl.qm</file>
         <file>translations/PartDesign_hr.qm</file>
+        <file>translations/PartDesign_hu.qm</file>
+        <file>translations/PartDesign_id.qm</file>
         <file>translations/PartDesign_it.qm</file>
+        <file>translations/PartDesign_ja.qm</file>
+        <file>translations/PartDesign_kab.qm</file>
+        <file>translations/PartDesign_ko.qm</file>
+        <file>translations/PartDesign_lt.qm</file>
         <file>translations/PartDesign_nl.qm</file>
         <file>translations/PartDesign_no.qm</file>
         <file>translations/PartDesign_pl.qm</file>
-        <file>translations/PartDesign_ru.qm</file>
-        <file>translations/PartDesign_uk.qm</file>
-        <file>translations/PartDesign_tr.qm</file>
-        <file>translations/PartDesign_sv-SE.qm</file>
-        <file>translations/PartDesign_zh-TW.qm</file>
         <file>translations/PartDesign_pt-BR.qm</file>
-        <file>translations/PartDesign_cs.qm</file>
-        <file>translations/PartDesign_sk.qm</file>
-        <file>translations/PartDesign_es-ES.qm</file>
-        <file>translations/PartDesign_zh-CN.qm</file>
-        <file>translations/PartDesign_ja.qm</file>
-        <file>translations/PartDesign_ro.qm</file>
-        <file>translations/PartDesign_hu.qm</file>
         <file>translations/PartDesign_pt-PT.qm</file>
-        <file>translations/PartDesign_sr.qm</file>
-        <file>translations/PartDesign_el.qm</file>
+        <file>translations/PartDesign_ro.qm</file>
+        <file>translations/PartDesign_ru.qm</file>
+        <file>translations/PartDesign_sk.qm</file>
         <file>translations/PartDesign_sl.qm</file>
-        <file>translations/PartDesign_eu.qm</file>
-        <file>translations/PartDesign_ca.qm</file>
-        <file>translations/PartDesign_gl.qm</file>
-        <file>translations/PartDesign_kab.qm</file>
-        <file>translations/PartDesign_ko.qm</file>
-        <file>translations/PartDesign_fil.qm</file>
-        <file>translations/PartDesign_id.qm</file>
-        <file>translations/PartDesign_lt.qm</file>
+        <file>translations/PartDesign_sr.qm</file>
+        <file>translations/PartDesign_sv-SE.qm</file>
+        <file>translations/PartDesign_tr.qm</file>
+        <file>translations/PartDesign_uk.qm</file>
         <file>translations/PartDesign_val-ES.qm</file>
-        <file>translations/PartDesign_ar.qm</file>
         <file>translations/PartDesign_vi.qm</file>
+        <file>translations/PartDesign_zh-CN.qm</file>
+        <file>translations/PartDesign_zh-TW.qm</file>
+        <file>icons/PartDesign_Dogbone.svg</file>
     </qresource>
 </RCC>

--- a/src/Mod/PartDesign/Gui/Resources/icons/PartDesign_Dogbone.svg
+++ b/src/Mod/PartDesign/Gui/Resources/icons/PartDesign_Dogbone.svg
@@ -1,0 +1,302 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="64px"
+   height="64px"
+   id="svg3364"
+   sodipodi:version="0.32"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
+   sodipodi:docname="PartDesign_Dogbone.svg"
+   inkscape:output_extension="org.inkscape.output.svg.inkscape"
+   version="1.1">
+  <defs
+     id="defs3366">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3854">
+      <stop
+         style="stop-color:#204a87;stop-opacity:1;"
+         offset="0"
+         id="stop3856" />
+      <stop
+         style="stop-color:#3465a4;stop-opacity:1"
+         offset="1"
+         id="stop3858" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3776">
+      <stop
+         style="stop-color:#f82b39;stop-opacity:1;"
+         offset="0"
+         id="stop3778" />
+      <stop
+         style="stop-color:#520001;stop-opacity:1;"
+         offset="1"
+         id="stop3780" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3835">
+      <stop
+         id="stop3837"
+         offset="0"
+         style="stop-color:#637dca;stop-opacity:1;" />
+      <stop
+         id="stop3839"
+         offset="1"
+         style="stop-color:#9eaede;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3827">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop3829" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop3831" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3864">
+      <stop
+         id="stop3866"
+         offset="0"
+         style="stop-color:#f82b39;stop-opacity:1;" />
+      <stop
+         id="stop3868"
+         offset="1"
+         style="stop-color:#520001;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3593">
+      <stop
+         style="stop-color:#00aff9;stop-opacity:1;"
+         offset="0"
+         id="stop3595" />
+      <stop
+         style="stop-color:#001ccc;stop-opacity:1;"
+         offset="1"
+         id="stop3597" />
+    </linearGradient>
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="-24.909091 : 16.545455 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="116.36364 : 23.818182 : 1"
+       inkscape:persp3d-origin="32 : 21.333333 : 1"
+       id="perspective3372" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3593-0"
+       id="radialGradient3004-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-320.59978,-6.63068)"
+       cx="330.63791"
+       cy="39.962704"
+       fx="330.63791"
+       fy="39.962704"
+       r="19.571428" />
+    <linearGradient
+       id="linearGradient3593-0">
+      <stop
+         style="stop-color:#c8e0f9;stop-opacity:1;"
+         offset="0"
+         id="stop3595-2" />
+      <stop
+         style="stop-color:#637dca;stop-opacity:1;"
+         offset="1"
+         id="stop3597-1" />
+    </linearGradient>
+    <radialGradient
+       r="19.571428"
+       fy="39.962704"
+       fx="330.63791"
+       cy="39.962704"
+       cx="330.63791"
+       gradientTransform="matrix(-0.93227784,0,0,1.3554421,396.33347,-27.208207)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3036"
+       xlink:href="#linearGradient3593-0"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3593"
+       id="linearGradient3799"
+       x1="5.3636365"
+       y1="34"
+       x2="57"
+       y2="34"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2844364,0,0,1.2700541,-1.1984108,-15.131825)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3776"
+       id="linearGradient3784"
+       x1="24.566774"
+       y1="12.948906"
+       x2="17.990864"
+       y2="28.911695"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       gradientTransform="matrix(1.2080212,0,0,1.1944945,1.5099511,-11.061201)"
+       inkscape:collect="always"
+       xlink:href="#linearGradient3786"
+       id="linearGradient3792"
+       x1="20.000002"
+       y1="45.199997"
+       x2="23.000002"
+       y2="30.199999"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3786">
+      <stop
+         style="stop-color:#ef2929;stop-opacity:1"
+         offset="0"
+         id="stop3788" />
+      <stop
+         style="stop-color:#a40000;stop-opacity:1"
+         offset="1"
+         id="stop3790" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3854"
+       id="linearGradient3860"
+       x1="-32"
+       y1="45"
+       x2="-38"
+       y2="24"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2080212,0,0,1.1944945,101.77571,-10.822302)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="10.727455"
+     inkscape:cx="27.664813"
+     inkscape:cy="31.714264"
+     inkscape:current-layer="g3780"
+     showgrid="true"
+     inkscape:document-units="px"
+     inkscape:grid-bbox="true"
+     inkscape:window-width="1920"
+     inkscape:window-height="1063"
+     inkscape:window-x="2560"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3039"
+       empspacing="2"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata3369">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>[wmayer]</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:title>PartDesign_Fillet</dc:title>
+        <dc:date>2012-09-10</dc:date>
+        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>FreeCAD</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:identifier>FreeCAD/src/Mod/PartDesign/Gui/Resources/icons/PartDesign_</dc:identifier>
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>FreeCAD LGPL2+</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <cc:license>https://www.gnu.org/copyleft/lesser.html</cc:license>
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title>[agryson] Alexander Gryson</dc:title>
+          </cc:Agent>
+        </dc:contributor>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer">
+    <g
+       id="g3780"
+       transform="matrix(0.82780005,0,0,0.83717425,-0.2499405,9.0601524)">
+      <path
+         sodipodi:nodetypes="ccccc"
+         id="rect2568"
+         d="m 3.9259975,33.373993 33.8245935,11.944945 0,14.333933 L 3.9259975,47.707927 z"
+         style="fill:#3465a4;fill-opacity:1;fill-rule:evenodd;stroke:#0b1521;stroke-width:2.4024775;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="ccccc"
+         id="rect2568-6"
+         d="m 6.3420406,36.718578 28.9925084,10.272652 0,9.317057 L 6.3420406,46.035634 z"
+         style="fill:none;stroke:#729fcf;stroke-width:2.4024775;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:url(#linearGradient3860);fill-opacity:1;stroke:#0b1521;stroke-width:2.4024775;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1"
+         d="m 37.750589,59.652874 0,-14.333935 c 2e-6,-20.306407 10.872191,-28.667869 24.160424,-33.445845 l 12.080212,-4.7779785 0,33.4458465 z"
+         id="path3066"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccccc" />
+      <path
+         style="fill:none;stroke:#3465a4;stroke-width:2.4024775;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="M 40.166633,55.472142 V 45.318938 C 53.454866,42.929949 64.327056,25.012532 61.004998,14.85933 l 10.570186,-4.180732 0.302006,28.070621 z"
+         id="path3066-3"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccccc" />
+      <g
+         transform="matrix(1.2080212,0,0,1.1944945,0.30193305,-12.016798)"
+         id="g3009">
+        <path
+           sodipodi:nodetypes="ccccc"
+           id="path2573"
+           d="M 35,5 61,15 51.000002,18.999999 23,9 Z"
+           style="display:inline;overflow:visible;visibility:visible;fill:#729fcf;fill-opacity:1;fill-rule:evenodd;stroke:#0b1521;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+           inkscape:connector-curvature="0" />
+        <path
+           sodipodi:nodetypes="ccccc"
+           d="M 51.000002,18.999999 C 49,27 49,42 31,47 L 3,37 C 21,29 22,19.000001 23,9 Z"
+           style="display:inline;overflow:visible;visibility:visible;fill:#ef2929;fill-opacity:1;fill-rule:evenodd;stroke:#280000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+           id="rect3347"
+           inkscape:connector-curvature="0" />
+      </g>
+      <path
+         sodipodi:nodetypes="ccccc"
+         d="m 58.286951,11.873093 c 0,8.361461 -3.624064,26.278878 -21.744382,29.862361 L 9.9661029,32.179499 C 25.670378,25.012532 30.502464,8.5285083 30.502463,2.3171372 Z"
+         style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3792);fill-opacity:1;stroke:#ef2929;stroke-width:2.4024775;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+         id="rect3347-3"
+         inkscape:connector-curvature="0" />
+    </g>
+  </g>
+</svg>

--- a/src/Mod/PartDesign/Gui/TaskDogboneParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskDogboneParameters.cpp
@@ -1,0 +1,201 @@
+/***************************************************************************
+ *   Copyright (c) 2011 Juergen Riegel <FreeCAD@juergen-riegel.net>        *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+
+#include "PreCompiled.h"
+
+#ifndef _PreComp_
+# include <QAction>
+#endif
+
+#include "ui_TaskDogboneParameters.h"
+#include "TaskDogboneParameters.h"
+#include <Base/UnitsApi.h>
+#include <App/Application.h>
+#include <App/Document.h>
+#include <Gui/Application.h>
+#include <Gui/Document.h>
+#include <Gui/BitmapFactory.h>
+#include <Gui/ViewProvider.h>
+#include <Gui/WaitCursor.h>
+#include <Base/Console.h>
+#include <Gui/Selection.h>
+#include <Gui/Command.h>
+#include <Mod/PartDesign/App/FeatureDogbone.h>
+#include <Mod/Sketcher/App/SketchObject.h>
+
+
+using namespace PartDesignGui;
+using namespace Gui;
+
+/* TRANSLATOR PartDesignGui::TaskDogboneParameters */
+
+TaskDogboneParameters::TaskDogboneParameters(ViewProviderDressUp *DressUpView,QWidget *parent)
+    : TaskDressUpParameters(DressUpView, true, true, parent)
+{
+    // we need a separate container widget to add all controls to
+    proxy = new QWidget(this);
+    ui = new Ui_TaskDogboneParameters();
+    ui->setupUi(proxy);
+
+    this->groupLayout()->addWidget(proxy);
+
+    PartDesign::Dogbone* pcDogbone = static_cast<PartDesign::Dogbone*>(DressUpView->getObject());
+    double r = pcDogbone->Radius.getValue();
+
+    ui->dogboneRadius->setUnit(Base::Unit::Length);
+    ui->dogboneRadius->setValue(r);
+    ui->dogboneRadius->setMinimum(0);
+    ui->dogboneRadius->selectNumber();
+    ui->dogboneRadius->bind(pcDogbone->Radius);
+    QMetaObject::invokeMethod(ui->dogboneRadius, "setFocus", Qt::QueuedConnection);
+    std::vector<std::string> strings = pcDogbone->Base.getSubValues();
+    for (std::vector<std::string>::const_iterator i = strings.begin(); i != strings.end(); i++)
+    {
+        ui->listWidgetReferences->addItem(QString::fromStdString(*i));
+    }
+
+    QMetaObject::connectSlotsByName(this);
+
+    connect(ui->dogboneRadius, SIGNAL(valueChanged(double)),
+            this, SLOT(onLengthChanged(double)));
+    connect(ui->buttonRefAdd, SIGNAL(toggled(bool)),
+            this, SLOT(onButtonRefAdd(bool)));
+    connect(ui->buttonRefRemove, SIGNAL(toggled(bool)),
+            this, SLOT(onButtonRefRemove(bool)));
+
+    // Create context menu
+    QAction* action = new QAction(tr("Remove"), this);
+    action->setShortcut(QString::fromLatin1("Del"));
+    ui->listWidgetReferences->addAction(action);
+    connect(action, SIGNAL(triggered()), this, SLOT(onRefDeleted()));
+    ui->listWidgetReferences->setContextMenuPolicy(Qt::ActionsContextMenu);
+}
+
+void TaskDogboneParameters::onSelectionChanged(const Gui::SelectionChanges& msg)
+{
+    if (selectionMode == none)
+        return;
+
+    if (msg.Type == Gui::SelectionChanges::AddSelection) {
+        if (referenceSelected(msg)) {
+            if (selectionMode == refAdd)
+                ui->listWidgetReferences->addItem(QString::fromStdString(msg.pSubName));
+            else
+                removeItemFromListWidget(ui->listWidgetReferences, msg.pSubName);
+            clearButtons(none);
+            exitSelectionMode();
+        }
+    }
+}
+
+void TaskDogboneParameters::clearButtons(const selectionModes notThis)
+{
+    if (notThis != refAdd) ui->buttonRefAdd->setChecked(false);
+    if (notThis != refRemove) ui->buttonRefRemove->setChecked(false);
+    DressUpView->highlightReferences(false);
+}
+
+void TaskDogboneParameters::onRefDeleted(void)
+{
+    PartDesign::Dogbone* pcDogbone = static_cast<PartDesign::Dogbone*>(DressUpView->getObject());
+    App::DocumentObject* base = pcDogbone->Base.getValue();
+    std::vector<std::string> refs = pcDogbone->Base.getSubValues();
+    refs.erase(refs.begin() + ui->listWidgetReferences->currentRow());
+    pcDogbone->Base.setValue(base, refs);
+    ui->listWidgetReferences->model()->removeRow(ui->listWidgetReferences->currentRow());
+    pcDogbone->getDocument()->recomputeFeature(pcDogbone);
+}
+
+void TaskDogboneParameters::onLengthChanged(double len)
+{
+    clearButtons(none);
+    PartDesign::Dogbone* pcDogbone = static_cast<PartDesign::Dogbone*>(DressUpView->getObject());
+    pcDogbone->Radius.setValue(len);
+    pcDogbone->getDocument()->recomputeFeature(pcDogbone);
+}
+
+double TaskDogboneParameters::getRadius(void) const
+{
+    return ui->dogboneRadius->value().getValue();
+}
+
+TaskDogboneParameters::~TaskDogboneParameters()
+{
+    Gui::Selection().rmvSelectionGate();
+    delete ui;
+}
+
+void TaskDogboneParameters::changeEvent(QEvent *e)
+{
+    TaskBox::changeEvent(e);
+    if (e->type() == QEvent::LanguageChange) {
+        ui->retranslateUi(proxy);
+    }
+}
+
+void TaskDogboneParameters::apply()
+{
+    std::string name = getDressUpView()->getObject()->getNameInDocument();
+
+    //Gui::Command::openCommand("Dogbone changed");
+    ui->dogboneRadius->apply();
+}
+
+//**************************************************************************
+//**************************************************************************
+// TaskDialog
+//++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+TaskDlgDogboneParameters::TaskDlgDogboneParameters(ViewProviderDogbone *DressUpView)
+    : TaskDlgDressUpParameters(DressUpView)
+{
+    parameter  = new TaskDogboneParameters(DressUpView);
+
+    Content.push_back(parameter);
+}
+
+TaskDlgDogboneParameters::~TaskDlgDogboneParameters()
+{
+
+}
+
+//==== calls from the TaskView ===============================================================
+
+
+//void TaskDlgDogboneParameters::open()
+//{
+//    // a transaction is already open at creation time of the Dogbone
+//    if (!Gui::Command::hasPendingCommand()) {
+//        QString msg = tr("Edit Dogbone");
+//        Gui::Command::openCommand((const char*)msg.toUtf8());
+//    }
+//}
+bool TaskDlgDogboneParameters::accept()
+{
+    parameter->showObject();
+    parameter->apply();
+
+    return TaskDlgDressUpParameters::accept();
+}
+
+#include "moc_TaskDogboneParameters.cpp"

--- a/src/Mod/PartDesign/Gui/TaskDogboneParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskDogboneParameters.h
@@ -1,0 +1,74 @@
+/***************************************************************************
+ *   Copyright (c) 2011 Juergen Riegel <FreeCAD@juergen-riegel.net>        *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+
+#ifndef GUI_TASKVIEW_TaskDogboneParameters_H
+#define GUI_TASKVIEW_TaskDogboneParameters_H
+
+#include "TaskDressUpParameters.h"
+#include "ViewProviderDogbone.h"
+
+class Ui_TaskDogboneParameters;
+
+namespace PartDesignGui {
+
+class TaskDogboneParameters : public TaskDressUpParameters
+{
+    Q_OBJECT
+
+public:
+    TaskDogboneParameters(ViewProviderDressUp *DressUpView, QWidget *parent=0);
+    ~TaskDogboneParameters();
+
+    virtual void apply();
+
+private Q_SLOTS:
+    void onLengthChanged(double);
+    void onRefDeleted(void);
+
+protected:
+    double getRadius(void) const;
+    virtual void clearButtons(const selectionModes notThis);
+    void changeEvent(QEvent *e);
+    virtual void onSelectionChanged(const Gui::SelectionChanges& msg);
+
+private:
+    Ui_TaskDogboneParameters* ui;
+};
+
+/// simulation dialog for the TaskView
+class TaskDlgDogboneParameters : public TaskDlgDressUpParameters
+{
+    Q_OBJECT
+
+public:
+    TaskDlgDogboneParameters(ViewProviderDogbone *DressUpView);
+    ~TaskDlgDogboneParameters();
+
+public:
+    /// is called by the framework if the dialog is accepted (Ok)
+    virtual bool accept();
+};
+
+} //namespace PartDesignGui
+
+#endif // GUI_TASKVIEW_TaskDogboneParameters_H

--- a/src/Mod/PartDesign/Gui/TaskDogboneParameters.ui
+++ b/src/Mod/PartDesign/Gui/TaskDogboneParameters.ui
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>PartDesignGui::TaskDogboneParameters</class>
+ <widget class="QWidget" name="PartDesignGui::TaskDogboneParameters">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>211</width>
+    <height>168</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QToolButton" name="buttonRefAdd">
+       <property name="text">
+        <string>Add ref</string>
+       </property>
+       <property name="checkable">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QToolButton" name="buttonRefRemove">
+       <property name="text">
+        <string>Remove ref</string>
+       </property>
+       <property name="checkable">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QListWidget" name="listWidgetReferences"/>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <item>
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>Radius:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="Gui::QuantitySpinBox" name="dogboneRadius" native="true"/>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>Gui::QuantitySpinBox</class>
+   <extends>QWidget</extends>
+   <header>Gui/QuantitySpinBox.h</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/Mod/PartDesign/Gui/ViewProviderDogbone.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderDogbone.cpp
@@ -1,0 +1,45 @@
+/***************************************************************************
+ *   Copyright (c) 2011 Juergen Riegel <FreeCAD@juergen-riegel.net>        *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+
+#include "PreCompiled.h"
+
+#ifndef _PreComp_
+#endif
+
+#include "TaskDogboneParameters.h"
+#include "ViewProviderDogbone.h"
+
+using namespace PartDesignGui;
+
+PROPERTY_SOURCE(PartDesignGui::ViewProviderDogbone,PartDesignGui::ViewProviderDressUp)
+
+
+const std::string & ViewProviderDogbone::featureName() const {
+    static const std::string name = "Dogbone";
+    return name;
+}
+
+
+TaskDlgFeatureParameters *ViewProviderDogbone::getEditDialog() {
+    return new TaskDlgDogboneParameters (this);
+}

--- a/src/Mod/PartDesign/Gui/ViewProviderDogbone.h
+++ b/src/Mod/PartDesign/Gui/ViewProviderDogbone.h
@@ -1,0 +1,52 @@
+/***************************************************************************
+ *   Copyright (c) 2011 Juergen Riegel <FreeCAD@juergen-riegel.net>        *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+
+#ifndef PARTGUI_ViewProviderDogbone_H
+#define PARTGUI_ViewProviderDogbone_H
+
+#include "ViewProviderDressUp.h"
+
+
+namespace PartDesignGui {
+
+class PartDesignGuiExport ViewProviderDogbone : public ViewProviderDressUp
+{
+    PROPERTY_HEADER(PartDesignGui::ViewProviderDogbone);
+
+public:
+    /// constructor
+    ViewProviderDogbone()
+        { sPixmap = "PartDesign_Dogbone.svg"; }
+
+    /// return "Dogbone"
+    virtual const std::string & featureName() const;
+
+protected:
+    /// Returns a newly create dialog for the part to be placed in the task view
+    virtual TaskDlgFeatureParameters *getEditDialog();
+};
+
+} // namespace PartDesignGui
+
+
+#endif // PARTGUI_ViewProviderDogbone_H

--- a/src/Mod/PartDesign/Gui/Workbench.cpp
+++ b/src/Mod/PartDesign/Gui/Workbench.cpp
@@ -267,6 +267,7 @@ void Workbench::activated()
 
     const char* Edge[] = {
         "PartDesign_Fillet",
+        "PartDesign_Dogbone",
         "PartDesign_Chamfer",
         "PartDesign_Point",
         "PartDesign_Line",
@@ -502,6 +503,7 @@ Gui::MenuItem* Workbench::setupMenuBar() const
           << "PartDesign_MultiTransform"
           << "Separator"
           << "PartDesign_Fillet"
+          << "PartDesign_Dogbone"
           << "PartDesign_Chamfer"
           << "PartDesign_Draft"
           << "PartDesign_Thickness"


### PR DESCRIPTION
This generates geometry for dogbone corners.
Known limitations:

  - The operator lets you select faces, but ignores them.
  - Curved edges are not handled correctly

This PR is currently in what I would consider an RFC state. It works, but the UI is still a bit janky, and this is my first time working with OpenCascade so I suspect my algorithm for generating the final shape is far from optimal. It's also missing tests, I can write those prior to merge assuming the implementation looks good.

---
Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [x] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
