### PR TITLE
Improved Python style in importOCA code

### DIFF
--- a/src/Mod/Draft/importOCA.py
+++ b/src/Mod/Draft/importOCA.py
@@ -2,8 +2,7 @@
 ## @package importOCA
 #  \ingroup DRAFT
 #  \brief OCA (Open CAD Format) file importer & exporter
-'''
-@package importOCA
+'''@package importOCA
 \ingroup DRAFT
 \brief OCA (Open CAD Format) file importer & exporter
 
@@ -73,26 +72,28 @@ def getpoint(data):
         A vector with the data arranged, depending on the contents of `data`.
     """
     print("found point ", data)
-    if (len(data) == 3):
+    if len(data) == 3:
         return Vector(float(data[0]), float(data[1]), float(data[2]))
     elif (data[0] == "P") and (len(data) == 4):
         return Vector(float(data[1]), float(data[2]), float(data[3]))
     elif (data[0][0] == "P") and (len(data[0]) > 1):
-        if (len(data) == 1):
+        if len(data) == 1:
             return objects[data[0]]
         else:
-            if (data[1][0] == "R"):
+            if data[1][0] == "R":
                 return objects[data[0]].add(objects[data[1]])
-            elif (data[1][0] == "C"):
+            elif data[1][0] == "C":
+                # Error: DraftGeomUtils.findProjection()
+                # doesn't exist
                 return DraftGeomUtils.findProjection(objects[data[0]],
                                                      objects[data[1]])
-    elif (data[0][0] == "C"):
+    elif data[0][0] == "C":
         if objects[data[0]]:
             p1 = objects[data[0]].Curve.Position
-            if (len(data) == 1):
+            if len(data) == 1:
                 return p1
             else:
-                if (data[1][0] == "L"):
+                if data[1][0] == "L":
                     L = objects[data[1]]
                     return p1.add(DraftGeomUtils.vec(L))
 
@@ -111,12 +112,12 @@ def getarea(data):
         A wire object from the points in `data`.
     """
     print("found area ", data)
-    if (data[0] == "S"):
-        if (data[1] == "POL"):
+    if data[0] == "S":
+        if data[1] == "POL":
             pts = data[2:]
             verts = []
             for p in pts:
-                if (p[0] == "P"):
+                if p[0] == "P":
                     verts.append(getpoint([p]))
             w = Part.makePolygon(verts)
             return w
@@ -137,45 +138,47 @@ def getarc(data):
     """
     print("found arc ", data)
     c = None
-    if (data[0] == "ARC"):
+    if data[0] == "ARC":
         # 3-points arc
         pts = data[1:]
         verts = []
         for p in range(len(pts)):
-            if (pts[p] == "P"):
+            if pts[p] == "P":
                 verts.append(getpoint(pts[p:p+3]))
-            elif (pts[p][0] == "P"):
+            elif pts[p][0] == "P":
                 verts.append(getpoint([pts[p]]))
         if verts[0] and verts[1] and verts[2]:
             c = Part.Arc(verts[0], verts[1], verts[2])
-    elif (data[0][0] == "P"):
+    elif data[0][0] == "P":
         # 2-point circle
         verts = []
         rad = None
         lines = []
         for p in range(len(data)):
-            if (data[p] == "P"):
+            if data[p] == "P":
                 verts.append(getpoint(data[p:p+4]))
-            elif (data[p][0] == "P"):
+            elif data[p][0] == "P":
                 verts.append(getpoint([data[p]]))
-            elif (data[p] == "VAL"):
+            elif data[p] == "VAL":
                 rad = float(data[p+1])
-            elif (data[p][0] == "L"):
+            elif data[p][0] == "L":
                 lines.append(objects[data[p]])
         c = Part.Circle()
         c.Center = verts[0]
         if rad:
             c.Radius = rad
         else:
+            # Error: DraftVecUtils.new()
+            # doesn't exist
             c.Radius = DraftVecUtils.new(verts[0], verts[1]).Length
-    elif (data[0][0] == "L"):
+    elif data[0][0] == "L":
         # 2-lines circle
         lines = []
         rad = None
         for p in range(len(data)):
-            if (data[p] == "VAL"):
+            if data[p] == "VAL":
                 rad = float(data[p+1])
-            elif (data[p][0] == "L"):
+            elif data[p][0] == "L":
                 lines.append(objects[data[p]])
         circles = DraftGeomUtils.circleFrom2LinesRadius(lines[0],
                                                         lines[1],
@@ -202,9 +205,9 @@ def getline(data):
     print("found line ", data)
     verts = []
     for p in range(len(data)):
-        if (data[p] == "P"):
+        if data[p] == "P":
             verts.append(getpoint(data[p:p+4]))
-        elif (data[p][0] == "P"):
+        elif data[p][0] == "P":
             verts.append(getpoint([data[p]]))
     L = Part.LineSegment(verts[0], verts[1])
     return L.toShape()
@@ -224,11 +227,11 @@ def gettranslation(data):
         A vector with X, Y, or Z displacement, or (0, 0, 0).
     """
     print("found translation ", data)
-    if (data[0] == "Z"):
+    if data[0] == "Z":
         return Vector(0, 0, float(data[1]))
-    elif (data[0] == "Y"):
+    elif data[0] == "Y":
         return Vector(0, float(data[1]), 0)
-    elif (data[0] == "X"):
+    elif data[0] == "X":
         return Vector(float(data[1]), 0, 0)
     return Vector(0, 0, 0)
 
@@ -249,12 +252,12 @@ def writepoint(vector):
     return "P("+str(vector.x)+" "+str(vector.y)+" "+str(vector.z)+")"
 
 
-def createobject(id, doc):
+def createobject(oid, doc):
     """Create Part::Feature object in the current document.
 
     Parameters
     ----------
-    id : str
+    oid : str
         ID number of a particular object in the document.
 
     doc : App::Document
@@ -263,9 +266,9 @@ def createobject(id, doc):
     -------
     None
     """
-    if isinstance(objects[id], Part.Shape):
-        ob = doc.addObject("Part::Feature", id)
-        ob.Shape = objects[id]
+    if isinstance(objects[oid], Part.Shape):
+        ob = doc.addObject("Part::Feature", oid)
+        ob.Shape = objects[oid]
         if FreeCAD.GuiUp:
             ob.ViewObject.ShapeColor = color
 
@@ -291,38 +294,38 @@ def parse(filename, doc):
     color = (0, 0, 0)
     for l in filebuffer:
         readline = l.replace(",", " ").upper()
-        if ("=" in readline):
+        if "=" in readline:
             # entity definitions
             pair = readline.split("=")
-            id = pair[0]
+            _id = pair[0]
             data = pair[1]
             data = data.replace(",", " ")
             data = data.replace("(", " ")
             data = data.replace(")", " ")
             data = data.split()
-            if id[0] == "P":
+            if _id[0] == "P":
                 # point
-                objects[id] = getpoint(data)
-            elif ((id[0] == "A") and params.GetBool("ocaareas")):
+                objects[_id] = getpoint(data)
+            elif ((_id[0] == "A") and params.GetBool("ocaareas")):
                 # area
-                objects[id] = getarea(data)
-                createobject(id, doc)
+                objects[_id] = getarea(data)
+                createobject(_id, doc)
 
-            elif id[0] == "C":
+            elif _id[0] == "C":
                 # arc or circle
-                objects[id] = getarc(data)
-                createobject(id, doc)
+                objects[_id] = getarc(data)
+                createobject(_id, doc)
 
-            elif id[0] == "L":
+            elif _id[0] == "L":
                 # line
-                objects[id] = getline(data)
-                createobject(id, doc)
+                objects[_id] = getline(data)
+                createobject(_id, doc)
 
-            elif id[0] == "R":
+            elif _id[0] == "R":
                 # translation
-                objects[id] = gettranslation(data)
+                objects[_id] = gettranslation(data)
 
-        elif (readline[0:6] == "DEFCOL"):
+        elif readline[0:6] == "DEFCOL":
             # color
             c = readline.split()
             color = (float(c[1])/255,
@@ -372,7 +375,7 @@ def open(filename):
     """
     docname = os.path.split(filename)[1]
     doc = FreeCAD.newDocument(docname)
-    if (docname[-4:] == "gcad"):
+    if docname[-4:] == "gcad":
         doc.Label = docname[:-5]
     else:
         doc.Label = docname[:-4]
@@ -452,7 +455,7 @@ def export(exportList, filename):
             oca.write(writepoint(e.Vertexes[-1].Point))
             oca.write("\r\n")
         elif DraftGeomUtils.geomType(e) == "Circle":
-            if (len(e.Vertexes) > 1):
+            if len(e.Vertexes) > 1:
                 oca.write("C"+str(count)+"=ARC ")
                 oca.write(writepoint(e.Vertexes[0].Point))
                 oca.write(" ")

--- a/src/Mod/Draft/importOCA.py
+++ b/src/Mod/Draft/importOCA.py
@@ -10,7 +10,7 @@ This module provides support for importing from and exporting to
 the OCA format or GCAD format from GCAD3D (http://www.gcad3d.org/).
 See: https://groups.google.com/forum/#!forum/open_cad_format
 
-By 2019 this file format is practically obsolete, and this module is not
+As of 2019 this file format is practically obsolete, and this module is not
 maintained.
 '''
 # Check code with

--- a/src/Mod/Draft/importOCA.py
+++ b/src/Mod/Draft/importOCA.py
@@ -22,7 +22,7 @@
 #*                                                                         *
 #***************************************************************************
 
-__title__="FreeCAD Draft Workbench - OCA importer/exporter"
+__title__= "FreeCAD Draft Workbench - OCA importer/exporter"
 __author__ = "Yorik van Havre <yorik@uncreated.net>"
 __url__ = ["http://www.freecadweb.org"]
 
@@ -41,13 +41,16 @@ This script imports OCA/gcad files into FreeCAD.
 import FreeCAD, os, Part, math, DraftVecUtils, DraftGeomUtils
 from FreeCAD import Vector
 
-try: import FreeCADGui
-except ValueError: gui = False
-else: gui = True
+try:
+    import FreeCADGui
+except ValueError:
+    gui = False
+else:
+    gui = True
 
-if open.__module__ in ['__builtin__','io']:
+if open.__module__ in ['__builtin__', 'io']:
     pythonopen = open
-    
+
 params = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/Draft")
 
 
@@ -64,11 +67,11 @@ def getpoint(data):
     Base::Vector3
         A vector with the data arranged, depending on the contents of `data`.
     """
-    print("found point ",data)
+    print("found point ", data)
     if (len(data) == 3):
-        return Vector(float(data[0]),float(data[1]),float(data[2]))
+        return Vector(float(data[0]), float(data[1]), float(data[2]))
     elif (data[0] == "P") and (len(data) == 4):
-        return Vector(float(data[1]),float(data[2]),float(data[3]))
+        return Vector(float(data[1]), float(data[2]), float(data[3]))
     elif (data[0][0] == "P") and (len(data[0]) > 1):
         if (len(data) == 1):
             return objects[data[0]]
@@ -76,7 +79,8 @@ def getpoint(data):
             if (data[1][0] == "R"):
                 return objects[data[0]].add(objects[data[1]])
             elif (data[1][0] == "C"):
-                return DraftGeomUtils.findProjection(objects[data[0]],objects[data[1]])
+                return DraftGeomUtils.findProjection(objects[data[0]],
+                                                     objects[data[1]])
     elif (data[0][0] == "C"):
         if objects[data[0]]:
             p1 = objects[data[0]].Curve.Position
@@ -84,8 +88,8 @@ def getpoint(data):
                 return p1
             else:
                 if (data[1][0] == "L"):
-                    l = objects[data[1]]
-                    return p1.add(DraftGeomUtils.vec(l))
+                    L = objects[data[1]]
+                    return p1.add(DraftGeomUtils.vec(L))
 
 
 def getarea(data):
@@ -101,7 +105,7 @@ def getarea(data):
     Part.Wire
         A wire object from the points in `data`.
     """
-    print("found area ",data)
+    print("found area ", data)
     if (data[0] == "S"):
         if (data[1] == "POL"):
             pts = data[2:]
@@ -138,7 +142,7 @@ def getarc(data):
             elif (pts[p][0] == "P"):
                 verts.append(getpoint([pts[p]]))
         if verts[0] and verts[1] and verts[2]:
-            c = Part.Arc(verts[0],verts[1],verts[2])
+            c = Part.Arc(verts[0], verts[1], verts[2])
     elif (data[0][0] == "P"):
         # 2-point circle
         verts = []
@@ -154,8 +158,10 @@ def getarc(data):
                 lines.append(objects[data[p]])
         c = Part.Circle()
         c.Center = verts[0]
-        if rad: c.Radius = rad
-        else: c.Radius = DraftVecUtils.new(verts[0],verts[1]).Length
+        if rad:
+            c.Radius = rad
+        else:
+            c.Radius = DraftVecUtils.new(verts[0], verts[1]).Length
     elif (data[0][0] == "L"):
         # 2-lines circle
         lines = []
@@ -165,9 +171,13 @@ def getarc(data):
                 rad = float(data[p+1])
             elif (data[p][0] == "L"):
                 lines.append(objects[data[p]])
-        circles = DraftGeomUtils.circleFrom2LinesRadius(lines[0],lines[1],rad)
-        if circles: c = circles[0]
-    if c: return c.toShape()
+        circles = DraftGeomUtils.circleFrom2LinesRadius(lines[0],
+                                                        lines[1],
+                                                        rad)
+        if circles:
+            c = circles[0]
+    if c:
+        return c.toShape()
 
 
 def getline(data):
@@ -190,8 +200,8 @@ def getline(data):
             verts.append(getpoint(data[p:p+4]))
         elif (data[p][0] == "P"):
             verts.append(getpoint([data[p]]))
-    l = Part.LineSegment(verts[0],verts[1])
-    return l.toShape()
+    L = Part.LineSegment(verts[0], verts[1])
+    return L.toShape()
 
 
 def gettranslation(data):
@@ -207,14 +217,14 @@ def gettranslation(data):
     Base::Vector3
         A vector with X, Y, or Z displacement, or (0, 0, 0).
     """
-    print("found translation ",data)
+    print("found translation ", data)
     if (data[0] == "Z"):
-        return Vector(0,0,float(data[1]))
+        return Vector(0, 0, float(data[1]))
     elif (data[0] == "Y"):
-        return Vector(0,float(data[1]),0)
+        return Vector(0, float(data[1]), 0)
     elif (data[0] == "X"):
-        return Vector(float(data[1]),0,0)    
-    return Vector(0,0,0)
+        return Vector(float(data[1]), 0, 0)
+    return Vector(0, 0, 0)
 
 
 def writepoint(vector):
@@ -233,7 +243,7 @@ def writepoint(vector):
     return "P("+str(vector.x)+" "+str(vector.y)+" "+str(vector.z)+")"
 
 
-def createobject(id,doc):
+def createobject(id, doc):
     """Create Part::Feature object in the current document.
 
     Parameters
@@ -247,13 +257,14 @@ def createobject(id,doc):
     -------
     None
     """
-    if isinstance(objects[id],Part.Shape):
-        ob = doc.addObject("Part::Feature",id)
+    if isinstance(objects[id], Part.Shape):
+        ob = doc.addObject("Part::Feature", id)
         ob.Shape = objects[id]
-        if gui: ob.ViewObject.ShapeColor = color
+        if gui:
+            ob.ViewObject.ShapeColor = color
 
 
-def parse(filename,doc):
+def parse(filename, doc):
     """Import an opened OCA file into the given document.
 
     Parameters
@@ -271,17 +282,17 @@ def parse(filename,doc):
     global objects
     objects = {}
     global color
-    color = (0,0,0)
+    color = (0, 0, 0)
     for l in filebuffer:
-        readline = l.replace(","," ").upper()
+        readline = l.replace(",", " ").upper()
         if ("=" in readline):
             # entity definitions
             pair = readline.split("=")
             id = pair[0]
             data = pair[1]
-            data = data.replace(","," ")
-            data = data.replace("("," ")
-            data = data.replace(")"," ")
+            data = data.replace(",", " ")
+            data = data.replace("(", " ")
+            data = data.replace(")", " ")
             data = data.split()
             if id[0] == "P":
                 # point
@@ -289,18 +300,18 @@ def parse(filename,doc):
             elif ((id[0] == "A") and params.GetBool("ocaareas")):
                 # area
                 objects[id] = getarea(data)
-                createobject(id,doc)
+                createobject(id, doc)
 
             elif id[0] == "C":
                 # arc or circle
                 objects[id] = getarc(data)
-                createobject(id,doc)
+                createobject(id, doc)
 
             elif id[0] == "L":
                 # line
                 objects[id] = getline(data)
-                createobject(id,doc)
-                
+                createobject(id, doc)
+
             elif id[0] == "R":
                 # translation
                 objects[id] = gettranslation(data)
@@ -308,7 +319,9 @@ def parse(filename,doc):
         elif (readline[0:6] == "DEFCOL"):
             # color
             c = readline.split()
-            color = (float(c[1])/255,float(c[2])/255,float(c[3])/255)
+            color = (float(c[1])/255,
+                     float(c[2])/255,
+                     float(c[3])/255)
 
     del color
 
@@ -337,7 +350,7 @@ def decodeName(name):
             print("oca: error: couldn't determine character encoding")
             decodedName = name
     return decodedName
-    
+
 
 def open(filename):
     """Open filename and parse.
@@ -351,15 +364,17 @@ def open(filename):
     -------
     None
     """
-    docname=os.path.split(filename)[1]
-    doc=FreeCAD.newDocument(docname)
-    if (docname[-4:] == "gcad"): doc.Label = docname[:-5]
-    else: doc.Label = docname[:-4]
-    parse(filename,doc)
+    docname = os.path.split(filename)[1]
+    doc = FreeCAD.newDocument(docname)
+    if (docname[-4:] == "gcad"):
+        doc.Label = docname[:-5]
+    else:
+        doc.Label = docname[:-4]
+    parse(filename, doc)
     doc.recompute()
 
 
-def insert(filename,docname):
+def insert(filename, docname):
     """Get an active document and parse.
 
     If no document exist, it is created.
@@ -377,15 +392,15 @@ def insert(filename,docname):
     None
     """
     try:
-        doc=FreeCAD.getDocument(docname)
+        doc = FreeCAD.getDocument(docname)
     except NameError:
-        doc=FreeCAD.newDocument(docname)
+        doc = FreeCAD.newDocument(docname)
     FreeCAD.ActiveDocument = doc
-    parse(filename,doc)
+    parse(filename, doc)
     doc.recompute()
 
 
-def export(exportList,filename):
+def export(exportList, filename):
     """Export the OCA file with a given list of objects.
 
     The objects must be edges or faces, in order to be processed
@@ -405,7 +420,7 @@ def export(exportList,filename):
     """
     faces = []
     edges = []
-    
+
     # getting faces and edges
     for ob in exportList:
         if ob.Shape.Faces:
@@ -417,9 +432,9 @@ def export(exportList,filename):
     if not (edges or faces):
         print("oca: found no data to export")
         return
-    
+
     # writing file
-    oca = pythonopen(filename,'wb')
+    oca = pythonopen(filename, 'wb')
     oca.write("#oca file generated from FreeCAD\r\n")
     oca.write("# edges\r\n")
     count = 1

--- a/src/Mod/Draft/importOCA.py
+++ b/src/Mod/Draft/importOCA.py
@@ -50,8 +50,20 @@ if open.__module__ in ['__builtin__','io']:
     
 params = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/Draft")
 
+
 def getpoint(data):
-    "turns an OCA point definition into a FreeCAD Vector"
+    """Turn an OCA point definition into a FreeCAD.Vector.
+
+    Parameters
+    ----------
+    data : list
+        Different types of data.
+
+    Returns
+    -------
+    Base::Vector3
+        A vector with the data arranged, depending on the contents of `data`.
+    """
     print("found point ",data)
     if (len(data) == 3):
         return Vector(float(data[0]),float(data[1]),float(data[2]))
@@ -74,9 +86,21 @@ def getpoint(data):
                 if (data[1][0] == "L"):
                     l = objects[data[1]]
                     return p1.add(DraftGeomUtils.vec(l))
-              
+
+
 def getarea(data):
-    "turns an OCA area definition into a FreeCAD Part Wire"
+    """Turn an OCA area definition into a FreeCAD Part.Wire.
+
+    Parameters
+    ----------
+    data : list
+        Different types of data.
+
+    Returns
+    -------
+    Part.Wire
+        A wire object from the points in `data`.
+    """
     print("found area ",data)
     if (data[0] == "S"):
         if (data[1] == "POL"):
@@ -88,8 +112,20 @@ def getarea(data):
             w = Part.makePolygon(verts)
             return w
 
+
 def getarc(data):
-    "turns an OCA arc definition into a FreeCAD Part Edge"
+    """Turn an OCA arc definition into a FreeCAD Part.Edge.
+
+    Parameters
+    ----------
+    data : list
+        Different types of data.
+
+    Returns
+    -------
+    Part.Edge
+        An edge object from the points in `data`.
+    """
     print("found arc ", data)
     c = None
     if (data[0] == "ARC"):
@@ -133,9 +169,21 @@ def getarc(data):
         if circles: c = circles[0]
     if c: return c.toShape()
 
+
 def getline(data):
+    """Turns an OCA line definition into a FreeCAD Part.Edge.
+
+    Parameters
+    ----------
+    data : list
+        Different types of data.
+
+    Returns
+    -------
+    Part.Edge
+        An edge object from the points in `data`.
+    """
     print("found line ", data)
-    "turns an OCA line definition into a FreeCAD Part Edge"
     verts = []
     for p in range(len(data)):
         if (data[p] == "P"):
@@ -145,8 +193,20 @@ def getline(data):
     l = Part.LineSegment(verts[0],verts[1])
     return l.toShape()
 
+
 def gettranslation(data):
-    "retrieves a transformation vector"
+    """Retrieve a translation (move) vector from `data`.
+
+    Parameters
+    ----------
+    data : list
+        Different types of data.
+
+    Returns
+    -------
+    Base::Vector3
+        A vector with X, Y, or Z displacement, or (0, 0, 0).
+    """
     print("found translation ",data)
     if (data[0] == "Z"):
         return Vector(0,0,float(data[1]))
@@ -156,19 +216,57 @@ def gettranslation(data):
         return Vector(float(data[1]),0,0)    
     return Vector(0,0,0)
 
+
 def writepoint(vector):
-    "writes a FreeCAD vector in OCA format"
+    """Write a FreeCAD.Vector in OCA format.
+
+    Parameters
+    ----------
+    vector : Base::Vector3
+        A vector with three components.
+
+    Returns
+    -------
+    str
+        A string "P(X Y Z)" with the information from `vector`.
+    """
     return "P("+str(vector.x)+" "+str(vector.y)+" "+str(vector.z)+")"
 
+
 def createobject(id,doc):
-    "creates an object in the current document"
+    """Create Part::Feature object in the current document.
+
+    Parameters
+    ----------
+    id : str
+        ID number of a particular object in the document.
+
+    doc : App::Document
+        A FreeCAD document to which the object is added.
+    Returns
+    -------
+    None
+    """
     if isinstance(objects[id],Part.Shape):
         ob = doc.addObject("Part::Feature",id)
         ob.Shape = objects[id]
         if gui: ob.ViewObject.ShapeColor = color
 
+
 def parse(filename,doc):
-    "inports an opened OCA file into the given doc"
+    """Import an opened OCA file into the given document.
+
+    Parameters
+    ----------
+    filename : str
+        The path to the OCA file.
+    doc : App::Document
+        A FreeCAD document to which the object is added.
+
+    Returns
+    -------
+    None
+    """
     filebuffer = pythonopen(filename)
     global objects
     objects = {}
@@ -214,8 +312,22 @@ def parse(filename,doc):
 
     del color
 
+
 def decodeName(name):
-    "decodes encoded strings"
+    """Decode encoded name.
+
+    Parameters
+    ----------
+    name : str
+        The string to decode.
+
+    Returns
+    -------
+    tuple
+    (string)
+        A tuple containing the decoded `name` in 'utf8', otherwise in 'latin1'.
+        If it fails it returns the original `name`.
+    """
     try:
         decodedName = (name.decode("utf8"))
     except UnicodeDecodeError:
@@ -226,7 +338,19 @@ def decodeName(name):
             decodedName = name
     return decodedName
     
+
 def open(filename):
+    """Open filename and parse.
+
+    Parameters
+    ----------
+    filename : str
+        The path to the filename to be opened.
+
+    Returns
+    -------
+    None
+    """
     docname=os.path.split(filename)[1]
     doc=FreeCAD.newDocument(docname)
     if (docname[-4:] == "gcad"): doc.Label = docname[:-5]
@@ -234,7 +358,24 @@ def open(filename):
     parse(filename,doc)
     doc.recompute()
 
+
 def insert(filename,docname):
+    """Get an active document and parse.
+
+    If no document exist, it is created.
+
+    Parameters
+    ----------
+    filename : str
+        The path to the filename to be opened.
+    docname : str
+        The name of the active App::Document if one exists, or
+        of the new one created.
+
+    Returns
+    -------
+    None
+    """
     try:
         doc=FreeCAD.getDocument(docname)
     except NameError:
@@ -242,9 +383,26 @@ def insert(filename,docname):
     FreeCAD.ActiveDocument = doc
     parse(filename,doc)
     doc.recompute()
-            
+
+
 def export(exportList,filename):
-    "called when freecad exports a file"
+    """Export the OCA file with a given list of objects.
+
+    The objects must be edges or faces, in order to be processed
+    and exported.
+
+    Parameters
+    ----------
+    exportList : list
+        List of document objects to export.
+    filename : str
+        Path to the new file.
+
+    Returns
+    -------
+    None
+        If `exportList` doesn't have shapes to export.
+    """
     faces = []
     edges = []
     
@@ -301,17 +459,3 @@ def export(exportList,filename):
     # closing
     oca.close()
     FreeCAD.Console.PrintMessage("successfully exported "+filename)
-    
-        
-            
-            
-        
-    
-            
-                
-                
-            
-        
-
-        
-    

--- a/src/Mod/Draft/importOCA.py
+++ b/src/Mod/Draft/importOCA.py
@@ -44,6 +44,7 @@ __url__ = ["http://www.freecadweb.org"]
 
 import FreeCAD, os, Part, DraftVecUtils, DraftGeomUtils
 from FreeCAD import Vector
+from FreeCAD import Console as FCC
 
 if FreeCAD.GuiUp:
     from DraftTools import translate
@@ -71,7 +72,7 @@ def getpoint(data):
     Base::Vector3
         A vector with the data arranged, depending on the contents of `data`.
     """
-    print("found point ", data)
+    FCC.PrintMessage("found point %s \n" % data)
     if len(data) == 3:
         return Vector(float(data[0]), float(data[1]), float(data[2]))
     elif (data[0] == "P") and (len(data) == 4):
@@ -111,7 +112,7 @@ def getarea(data):
     Part.Wire
         A wire object from the points in `data`.
     """
-    print("found area ", data)
+    FCC.PrintMessage("found area %s \n" % data)
     if data[0] == "S":
         if data[1] == "POL":
             pts = data[2:]
@@ -136,7 +137,7 @@ def getarc(data):
     Part.Edge
         An edge object from the points in `data`.
     """
-    print("found arc ", data)
+    FCC.PrintMessage("found arc %s \n" % data)
     c = None
     if data[0] == "ARC":
         # 3-points arc
@@ -202,7 +203,7 @@ def getline(data):
     Part.Edge
         An edge object from the points in `data`.
     """
-    print("found line ", data)
+    FCC.PrintMessage("found line %s \n" % data)
     verts = []
     for p in range(len(data)):
         if data[p] == "P":
@@ -226,7 +227,7 @@ def gettranslation(data):
     Base::Vector3
         A vector with X, Y, or Z displacement, or (0, 0, 0).
     """
-    print("found translation ", data)
+    FCC.PrintMessage("found translation %s \n" % data)
     if data[0] == "Z":
         return Vector(0, 0, float(data[1]))
     elif data[0] == "Y":
@@ -357,6 +358,10 @@ def decodeName(name):
             decodedName = (name.decode("latin1"))
         except UnicodeDecodeError:
             print("oca: error: couldn't determine character encoding")
+            FCC.PrintError(translate("importOCA",
+                                     "OCA error: "
+                                     "couldn't determine character encoding")
+                           + "\n")
             decodedName = name
     return decodedName
 
@@ -440,6 +445,9 @@ def export(exportList, filename):
                 edges.append(e)
     if not (edges or faces):
         print("oca: found no data to export")
+        FCC.PrintMessage(translate("importOCA",
+                                   "OCA: found no data to export")
+                         + "\n")
         return
 
     # writing file
@@ -482,4 +490,6 @@ def export(exportList, filename):
 
     # closing
     oca.close()
-    FreeCAD.Console.PrintMessage("successfully exported "+filename)
+    FCC.PrintMessage(translate("importOCA",
+                               "successfully exported ")
+                     + filename + "\n")

--- a/src/Mod/Draft/importOCA.py
+++ b/src/Mod/Draft/importOCA.py
@@ -1,53 +1,58 @@
 # -*- coding: utf8 -*-
+## @package importOCA
+#  \ingroup DRAFT
+#  \brief OCA (Open CAD Format) file importer & exporter
+'''
+@package importOCA
+\ingroup DRAFT
+\brief OCA (Open CAD Format) file importer & exporter
 
-#***************************************************************************
-#*                                                                         *
-#*   Copyright (c) 2009 Yorik van Havre <yorik@uncreated.net>              *
-#*                                                                         *
-#*   This program is free software; you can redistribute it and/or modify  *
-#*   it under the terms of the GNU Lesser General Public License (LGPL)    *
-#*   as published by the Free Software Foundation; either version 2 of     *
-#*   the License, or (at your option) any later version.                   *
-#*   for detail see the LICENCE text file.                                 *
-#*                                                                         *
-#*   This program is distributed in the hope that it will be useful,       *
-#*   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
-#*   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
-#*   GNU Library General Public License for more details.                  *
-#*                                                                         *
-#*   You should have received a copy of the GNU Library General Public     *
-#*   License along with this program; if not, write to the Free Software   *
-#*   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
-#*   USA                                                                   *
-#*                                                                         *
-#***************************************************************************
+This module provides support for importing from and exporting to
+the OCA format or GCAD format from GCAD3D (http://www.gcad3d.org/).
+See: https://groups.google.com/forum/#!forum/open_cad_format
 
-__title__= "FreeCAD Draft Workbench - OCA importer/exporter"
+By 2019 this file format is practically obsolete, and this module is not
+maintained.
+'''
+# Check code with
+# flake8 --ignore=E226,E266,E401,W503
+
+# ***************************************************************************
+# *                                                                         *
+# *   Copyright (c) 2009 Yorik van Havre <yorik@uncreated.net>              *
+# *                                                                         *
+# *   This program is free software; you can redistribute it and/or modify  *
+# *   it under the terms of the GNU Lesser General Public License (LGPL)    *
+# *   as published by the Free Software Foundation; either version 2 of     *
+# *   the License, or (at your option) any later version.                   *
+# *   for detail see the LICENCE text file.                                 *
+# *                                                                         *
+# *   This program is distributed in the hope that it will be useful,       *
+# *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+# *   GNU Library General Public License for more details.                  *
+# *                                                                         *
+# *   You should have received a copy of the GNU Library General Public     *
+# *   License along with this program; if not, write to the Free Software   *
+# *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
+# *   USA                                                                   *
+# *                                                                         *
+# ***************************************************************************
+
+__title__ = "FreeCAD Draft Workbench - OCA importer/exporter"
 __author__ = "Yorik van Havre <yorik@uncreated.net>"
 __url__ = ["http://www.freecadweb.org"]
 
-## @package importOCA
-#  \ingroup DRAFT
-#  \brief OCA (Open CAD Format) file import & export
-#
-#  This module provides support for importing and exporting to the OCA format from GCAD3D.
-#  Warning, this file format is today practically obsolete and this module is not
-#  maintained anymore.
-
-'''
-This script imports OCA/gcad files into FreeCAD.
-'''
-
-import FreeCAD, os, Part, math, DraftVecUtils, DraftGeomUtils
+import FreeCAD, os, Part, DraftVecUtils, DraftGeomUtils
 from FreeCAD import Vector
 
-try:
-    import FreeCADGui
-except ValueError:
-    gui = False
+if FreeCAD.GuiUp:
+    from DraftTools import translate
 else:
-    gui = True
+    def translate(context, txt):
+        return txt
 
+# Save the native open function to avoid collisions
 if open.__module__ in ['__builtin__', 'io']:
     pythonopen = open
 
@@ -147,6 +152,7 @@ def getarc(data):
         # 2-point circle
         verts = []
         rad = None
+        lines = []
         for p in range(len(data)):
             if (data[p] == "P"):
                 verts.append(getpoint(data[p:p+4]))
@@ -260,7 +266,7 @@ def createobject(id, doc):
     if isinstance(objects[id], Part.Shape):
         ob = doc.addObject("Part::Feature", id)
         ob.Shape = objects[id]
-        if gui:
+        if FreeCAD.GuiUp:
             ob.ViewObject.ShapeColor = color
 
 

--- a/src/Mod/Draft/importOCA.py
+++ b/src/Mod/Draft/importOCA.py
@@ -357,7 +357,6 @@ def decodeName(name):
         try:
             decodedName = (name.decode("latin1"))
         except UnicodeDecodeError:
-            print("oca: error: couldn't determine character encoding")
             FCC.PrintError(translate("importOCA",
                                      "OCA error: "
                                      "couldn't determine character encoding")
@@ -444,14 +443,13 @@ def export(exportList, filename):
             for e in ob.Shape.Edges:
                 edges.append(e)
     if not (edges or faces):
-        print("oca: found no data to export")
         FCC.PrintMessage(translate("importOCA",
                                    "OCA: found no data to export")
                          + "\n")
         return
 
     # writing file
-    oca = pythonopen(filename, 'wb')
+    oca = pythonopen(filename, 'w')
     oca.write("#oca file generated from FreeCAD\r\n")
     oca.write("# edges\r\n")
     count = 1


### PR DESCRIPTION
Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
Improved the Pythonic style of the code, particularly the spacing and adding docstring to the public functions.

The code was inspected with
```flake8 --ignore=E226,E266,E401,W503 importOCA.py```

The OCA file format is used by the GCAD3D software (http://www.gcad3d.org/) but it's not very popular.

This module isn't maintained but some small improvements were made to have a better style, including printing to the console and possibility of translating the messages.