### PR TITLE
Improved Python style in DraftVecUtils code

### DIFF
--- a/src/Mod/Draft/DraftVecUtils.py
+++ b/src/Mod/Draft/DraftVecUtils.py
@@ -37,7 +37,7 @@ __url__ = ["http://www.freecadweb.org"]
 #  @{
 
 import sys
-import math,FreeCAD
+import math, FreeCAD
 from FreeCAD import Vector, Matrix
 
 try:
@@ -46,18 +46,22 @@ except NameError:
     long = int
 
 params = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/Draft")
-def precision():
-    return params.GetInt("precision",6)
 
-def typecheck (args_and_types, name="?"):
-    for v,t in args_and_types:
-        if not isinstance (v,t):
+
+def precision():
+    return params.GetInt("precision", 6)
+
+
+def typecheck(args_and_types, name="?"):
+    for v, t in args_and_types:
+        if not isinstance(v, t):
             FreeCAD.Console.PrintWarning("typecheck[" + str(name) + "]: " + str(v) + " is not " + str(t) + "\n")
             raise TypeError("fcvec." + str(name))
 
+
 def toString(u):
     "returns a string containing a python command to recreate this vector"
-    if isinstance(u,list):
+    if isinstance(u, list):
         s = "["
         first = True
         for v in u:
@@ -70,13 +74,15 @@ def toString(u):
     else:
         return "FreeCAD.Vector("+str(u.x)+","+str(u.y)+","+str(u.z)+")"
 
-def tup(u,array=False):
+
+def tup(u, array=False):
     "returns a tuple (x,y,z) with the vector coords, or an array if array=true"
-    typecheck ([(u,Vector)], "tup");
+    typecheck([(u, Vector)], "tup")
     if array:
-        return [u.x,u.y,u.z]
+        return [u.x, u.y, u.z]
     else:
-        return (u.x,u.y,u.z)
+        return (u.x, u.y, u.z)
+
 
 def neg(u):
     "neg(Vector) - returns an opposite (negative) vector"

--- a/src/Mod/Draft/DraftVecUtils.py
+++ b/src/Mod/Draft/DraftVecUtils.py
@@ -63,28 +63,30 @@ def precision():
 
 
 def typecheck(args_and_types, name="?"):
-    """Check that the argument is an instance of a certain type.
+    """Check that the arguments are instances of certain types.
 
     Parameters
     ----------
     args_and_types : list
-        A list of tuples. The first element of the tuple is tested as being
+        A list of tuples. The first element of a tuple is tested as being
         an instance of the second element.
-        ``args_and_types = [(a, Type), (b, Type2), ...]``
+        ::
+            args_and_types = [(a, Type), (b, Type2), ...]
 
         Then
-        ``isinstance(a, Type)``,
-        ``isinstance(b, Type2)``
+        ::
+            isinstance(a, Type)
+            isinstance(b, Type2)
 
         A `Type` can also be a tuple of many types, in which case
         the check is done for any of them.
+        ::
+            args_and_types = [(a, (Type3, int, float)), ...]
 
-        ``args_and_types = [(a, (Type3, int, float)), ...]``
-
-        ``isinstance(a, (Type3, int, float))``
+            isinstance(a, (Type3, int, float))
 
     name : str, optional
-        Defaults to '?'. The name of the check.
+        Defaults to `'?'`. The name of the check.
 
     Raises
     -------
@@ -101,7 +103,7 @@ def typecheck(args_and_types, name="?"):
 
 
 def toString(u):
-    """Return a string with the Python command to recreate this Vector.
+    """Return a string with the Python command to recreate this vector.
 
     Parameters
     ----------
@@ -111,8 +113,8 @@ def toString(u):
     Returns
     -------
     str
-        The string with the code that can be input in the Python console
-        to create the same list of FreeCAD.Vectors, or single vector.
+        The string with the code that can be used in the Python console
+        to create the same list of vectors, or single vector.
     """
     if isinstance(u, list):
         s = "["
@@ -145,13 +147,13 @@ def tup(u, array=False):
         A FreeCAD.Vector.
     array : bool, optional
         Defaults to `False`, and the output is a tuple.
-        If `True` the output is an array.
+        If `True` the output is a list.
 
     Returns
     -------
     tuple or list
-    (x, y, z) or [x, y, z]
-        The coordinates of the vector in a tuple or a list, if `array=True`.
+        The coordinates of the vector in a tuple `(x, y, z)`
+        or in a list `[x, y, z]`, if `array=True`.
     """
     typecheck([(u, Vector)], "tup")
     if array:
@@ -161,7 +163,7 @@ def tup(u, array=False):
 
 
 def neg(u):
-    """Return the negative of a given FreeCAD.Vector.
+    """Return the negative of a given vector.
 
     Parameters
     ----------
@@ -179,21 +181,23 @@ def neg(u):
 
 
 def equals(u, v):
-    """Check for equality between two FreeCAD.Vectors.
+    """Check for equality between two vectors.
 
-    Due to rounding errors, two vectors will rarely be 'equal'.
-    Therefore, this fucntion checks that the corresponding elements
-    of the two vectors differ by less than the precision established
+    Due to rounding errors, two vectors will rarely be `equal`.
+    Therefore, this function checks that the corresponding elements
+    of the two vectors differ by less than the `precision` established
     in the parameter database, accessed through `FreeCAD.ParamGet()`.
-    x1 - x2 < precision
-    y1 - y2 < precision
-    z1 - z2 < precision
+    ::
+        x1 - x2 < precision
+        y1 - y2 < precision
+        z1 - z2 < precision
 
     Parameters
     ----------
     u : Base::Vector3
+        The first vector.
     v : Base::Vector3
-        The FreeCAD.Vectors to compare.
+        The second vector.
 
     Returns
     ------
@@ -205,7 +209,7 @@ def equals(u, v):
 
 
 def scale(u, scalar):
-    """Scales (multiplies) a vector by a factor.
+    """Scales (multiplies) a vector by a scalar factor.
 
     Parameters
     ----------
@@ -232,17 +236,19 @@ def scaleTo(u, l):
     """Scale a vector so that its magnitude is equal to a given length.
 
     The magnitude of a vector is
-    ``L = sqrt(x**2 + y**2 + z**2)``
+    ::
+        L = sqrt(x**2 + y**2 + z**2)
 
     This function multiplies each coordinate, `x`, `y`, `z`,
     by a factor to produce the desired magnitude `L`.
     This factor is the ratio of the new magnitude to the old magnitude,
-    ``x_scaled = x * (L_new/L_old)``
+    ::
+        x_scaled = x * (L_new/L_old)
 
     Parameters
     ----------
     u : Base::Vector3
-        The FreeCAD.Vector to scale.
+        The vector to scale.
     l : int or float
         The new magnitude of the vector in standard units (mm).
 
@@ -250,7 +256,7 @@ def scaleTo(u, l):
     -------
     Base::Vector3
         The new vector with each of its elements scaled by a factor.
-        Or the same vector `u` if the vector is `(0, 0, 0)`.
+        Or the same input vector `u`, if it is `(0, 0, 0)`.
     """
     # Python 2 has two integer types, int and long.
     # In Python 3 there is no 'long' anymore.
@@ -271,9 +277,9 @@ def dist(u, v):
     Parameters
     ----------
     u : Base::Vector3
-        First point, defined by a FreeCAD.Vector.
+        First point, defined by a vector.
     v : Base::Vector3
-        Second point, defined by a FreeCAD.Vector.
+        Second point, defined by a vector.
 
     Returns
     -------
@@ -287,7 +293,9 @@ def dist(u, v):
 def angle(u, v=Vector(1, 0, 0), normal=Vector(0, 0, 1)):
     """Return the angle in radians between the two vectors.
 
-    It uses the definition of the dot product, ``A * B = |A||B| cos(angle)``
+    It uses the definition of the dot product
+    ::
+        A * B = |A||B| cos(angle)
 
     If only one vector is given, the angle is between that one and the
     horizontal (+X).
@@ -295,10 +303,9 @@ def angle(u, v=Vector(1, 0, 0), normal=Vector(0, 0, 1)):
     If a third vector is given, it is the normal used to determine
     the sign of the angle.
     This normal is compared with the cross product of the first two vectors.
-
-    ``C = A x B``
-
-    ``factor = C * normal``
+    ::
+        C = A x B
+        factor = C * normal
 
     If the `factor` is positive the angle is positive, otherwise
     it is the opposite sign.
@@ -316,11 +323,10 @@ def angle(u, v=Vector(1, 0, 0), normal=Vector(0, 0, 1)):
 
     Returns
     -------
-    0
-        If the magnitude of one of the vectors is zero,
-        or if they are colinear.
     float
         The angle in radians between the vectors.
+        It is zero if the magnitude of one of the vectors is zero,
+        or if they are colinear.
     """
     typecheck([(u, Vector), (v, Vector)], "angle")
     ll = u.Length * v.Length
@@ -351,13 +357,12 @@ def angle(u, v=Vector(1, 0, 0), normal=Vector(0, 0, 1)):
 def project(u, v):
     """Project the first vector onto the second one.
 
-    It scales the the second vector by a factor.
+    The projection is just the second vector scaled by a factor.
     This factor is the dot product divided by the square
     of the second vector's magnitude.
-
-    ``f = A * B / |B|**2 = |A||B| cos(angle) / |B|**2``
-
-    ``f = |A| cos(angle)/|B|``
+    ::
+        f = A * B / |B|**2 = |A||B| cos(angle) / |B|**2
+        f = |A| cos(angle)/|B|
 
     Parameters
     ----------
@@ -368,10 +373,10 @@ def project(u, v):
 
     Returns
     -------
-    Vector(0, 0, 0)
-        If the magnitude of the second vector is zero.
     Base::Vector3
         The new vector, which is the same vector `v` scaled by a factor.
+        Return `Vector(0, 0, 0)`, if the magnitude of the second vector
+        is zero.
     """
     typecheck([(u, Vector), (v, Vector)], "project")
 
@@ -475,7 +480,7 @@ def rotate(u, angle, axis=Vector(0, 0, 1)):
     s = math.sin(angle)
     t = 1 - c
 
-    # Common products
+    # Various products
     xyt = x * y * t
     xzt = x * z * t
     yzt = y * z * t
@@ -504,8 +509,6 @@ def getRotation(vector, reference=Vector(1, 0, 0)):
 
     Returns
     -------
-    (0, 0, 0, 1.0)
-        If the cross product between the `vector` and the `reference` is null.
     (x, y, z, Q)
         A tuple with the unit elements (normalized) of the cross product
         between the `vector` and the `reference`, and a `Q` value,
@@ -514,6 +517,13 @@ def getRotation(vector, reference=Vector(1, 0, 0)):
         ::
             Q = |A||B| + |A||B| cos(angle)
 
+        It returns `(0, 0, 0, 1.0)`
+        if the cross product between the `vector` and the `reference`
+        is null.
+
+    See Also
+    --------
+    rotate2D, rotate
     """
     c = vector.cross(reference)
     if isNull(c):
@@ -532,8 +542,9 @@ def isNull(vector):
 
     Due to rounding errors, an element is probably never going to be
     exactly zero. Therefore, it rounds the element by the number
-    of decimals specified in the precision parameter.
-    It then compares the rounded number against zero.
+    of decimals specified in the `precision` parameter
+    in the parameter database, accessed through `FreeCAD.ParamGet()`.
+    It then compares the rounded numbers against zero.
 
     Parameters
     ----------

--- a/src/Mod/Draft/DraftVecUtils.py
+++ b/src/Mod/Draft/DraftVecUtils.py
@@ -378,10 +378,39 @@ def project(u, v):
 
 
 def rotate2D(u, angle):
-    "rotate2D(Vector,angle): rotates the given vector around the Z axis"
-    return Vector(math.cos(-angle)*u.x-math.sin(-angle)*u.y,
-                  math.sin(-angle)*u.x+math.cos(-angle)*u.y,
-                  u.z)
+    """Rotate the given vector around the Z axis by the specified angle.
+
+    The rotation occurs in two dimensions only by means of
+    a rotation matrix.
+    ::
+         u_rot                R                 u
+        (x_rot) = (cos(-angle) -sin(-angle)) * (x)
+        (y_rot)   (sin(-angle)  cos(-angle))   (y)
+
+    Normally the angle is positive, but in this case it is negative.
+
+    `"Such non-standard orientations are rarely used in mathematics
+    but are common in 2D computer graphics, which often have the origin
+    in the top left corner and the y-axis pointing down."`
+    W3C Recommendations (2003), Scalable Vector Graphics: the initial
+    coordinate system.
+
+    Parameters
+    ----------
+    u : Base::Vector3
+        The vector.
+    angle : float
+        The angle of rotation given in radians.
+
+    Returns
+    -------
+    Base::Vector3
+        The new rotated vector.
+    """
+    x_rot = math.cos(-angle) * u.x - math.sin(-angle) * u.y
+    y_rot = math.sin(-angle) * u.x + math.cos(-angle) * u.y
+
+    return Vector(x_rot, y_rot, u.z)
 
 
 def rotate(u, angle, axis=Vector(0, 0, 1)):

--- a/src/Mod/Draft/DraftVecUtils.py
+++ b/src/Mod/Draft/DraftVecUtils.py
@@ -339,13 +339,41 @@ def angle(u, v=Vector(1, 0, 0), normal=Vector(0, 0, 1)):
 
 
 def project(u, v):
-    "project(Vector,Vector): projects the first vector onto the second one"
+    """Project the first vector onto the second one.
+
+    It scales the the second vector by a factor.
+    This factor is the dot product divided by the square
+    of the second vector's magnitude.
+
+    ``f = A * B / |B|**2 = |A||B| cos(angle) / |B|**2``
+
+    ``f = |A| cos(angle)/|B|``
+
+    Parameters
+    ----------
+    u : Base::Vector3
+        The first vector.
+    v : Base::Vector3
+        The second vector.
+
+    Returns
+    -------
+    Vector(0, 0, 0)
+        If the magnitude of the second vector is zero.
+    Base::Vector3
+        The new vector, which is the same vector `v` scaled by a factor.
+    """
     typecheck([(u, Vector), (v, Vector)], "project")
+
+    # Dot product with itself equals the magnitude squared.
     dp = v.dot(v)
     if dp == 0:
         return Vector(0, 0, 0)  # to avoid division by zero
+    # Why specifically this value? This should be an else?
     if dp != 15:
         return scale(v, u.dot(v)/dp)
+
+    # Return a null vector if the magnitude squared is 15, why?
     return Vector(0, 0, 0)
 
 

--- a/src/Mod/Draft/DraftVecUtils.py
+++ b/src/Mod/Draft/DraftVecUtils.py
@@ -177,10 +177,10 @@ def rotate(u, angle, axis=Vector(0, 0, 1)):
     if angle == 0:
         return u
 
-    l = axis.Length
-    x=axis.x/l
-    y=axis.y/l
-    z=axis.z/l
+    L = axis.Length
+    x = axis.x/L
+    y = axis.y/L
+    z = axis.z/L
     c = math.cos(angle)
     s = math.sin(angle)
     t = 1 - c

--- a/src/Mod/Draft/DraftVecUtils.py
+++ b/src/Mod/Draft/DraftVecUtils.py
@@ -565,9 +565,24 @@ def isNull(vector):
 
 
 def find(vector, vlist):
-    '''find(vector,vlist): finds a vector in a list of vectors. returns
-    the index of the matching vector, or None if none is found.
-    '''
+    """Find a vector in a list of vectors, and return the index.
+
+    Finding a vector tests for `equality` which depends on the `precision`
+    parameter in the parameter database.
+
+    Parameters
+    ----------
+    vector : Base::Vector3
+        The tested vector.
+    vlist : list
+        A list of Base::Vector3 vectors.
+
+    Returns
+    -------
+    int
+        The index of the list where the vector is found,
+        or `None` if the vector is not found.
+    """
     typecheck([(vector, Vector), (vlist, list)], "find")
     for i, v in enumerate(vlist):
         if equals(vector, v):
@@ -576,9 +591,28 @@ def find(vector, vlist):
 
 
 def closest(vector, vlist):
-    '''closest(vector,vlist): finds the closest vector to the given vector
-    in a list of vectors'''
+    """Find the closest point to one point in a list of points (vectors).
+
+    The scalar distance between the original point and one point in the list
+    is calculated. If the distance is smaller than a previously calculated
+    value, its index is saved, otherwise the next point in the list is tested.
+
+    Parameters
+    ----------
+    vector : Base::Vector3
+        The tested point (or vector).
+    vlist : list
+        A list of points (or vectors).
+
+    Returns
+    -------
+    int
+        The index of the list where the closest point is found.
+    """
     typecheck([(vector, Vector), (vlist, list)], "closest")
+
+    # Initially test against a very large distance, then test the next point
+    # in the list which will probably be much smaller.
     dist = 9999999999999999
     index = None
     for i, v in enumerate(vlist):
@@ -590,20 +624,63 @@ def closest(vector, vlist):
 
 
 def isColinear(vlist):
-    '''isColinear(list_of_vectors): checks if vectors in given list are colinear'''
+    """Check if the vectors in the list are colinear.
+
+    Colinear vectors don't necessarily have the same magnitude,
+    but the angle between them should be zero.
+
+    Due to rounding errors, the angle may not be exactly zero;
+    therefore, it rounds the angle by the number
+    of decimals specified in the `precision` parameter
+    in the parameter database, and then compares the value to zero.
+
+    Parameters
+    ----------
+    vlist : list
+        List of Base::Vector3 vectors.
+        At least three elements must be present.
+
+    Returns
+    -------
+    bool
+        `True` if each of the vectors is colinear.
+        `False` otherwise.
+    """
     typecheck([(vlist, list)], "isColinear")
+
+    # Return True if the list only has two vectors, why?
+    # This doesn't test for colinearity between the first two vectors.
     if len(vlist) < 3:
         return True
+
     p = precision()
+
+    # Difference between the second vector and the first one
     first = vlist[1].sub(vlist[0])
+
+    # Start testing from the third vector and onward
     for i in range(2, len(vlist)):
-        if round(angle(vlist[i].sub(vlist[0]), first), p) != 0:
+        _angle = round(angle(vlist[i].sub(vlist[0]), first), p)
+        if _angle != 0:
             return False
     return True
 
 
 def rounded(v):
-    "returns a rounded vector"
+    """Return a rounded vector to the precision in the parameter database.
+
+    Parameters
+    ----------
+    v : Base::Vector3
+        The input vector.
+
+    Returns
+    -------
+    Base::Vector3
+        The new vector where each element has been rounded
+        to the number of decimals specified in the `precision` parameter
+        in the parameter database.
+    """
     p = precision()
     return Vector(round(v.x, p), round(v.y, p), round(v.z, p))
 

--- a/src/Mod/Draft/DraftVecUtils.py
+++ b/src/Mod/Draft/DraftVecUtils.py
@@ -224,10 +224,10 @@ def scaleTo(u, l):
     The magnitude of a vector is
     ``L = sqrt(x**2 + y**2 + z**2)``
 
-    This function multiplies each coordinate, x, y, z,
-    by a factor to produce the desired magnitude.
+    This function multiplies each coordinate, `x`, `y`, `z`,
+    by a factor to produce the desired magnitude `L`.
     This factor is the ratio of the new magnitude to the old magnitude,
-    ``x_scaled = x * (new/old)``
+    ``x_scaled = x * (L_new/L_old)``
 
     Parameters
     ----------
@@ -240,7 +240,7 @@ def scaleTo(u, l):
     -------
     Base::Vector3
         The new vector with each of its elements scaled by a factor.
-        Or the same vector `u` if the vector is (0, 0, 0).
+        Or the same vector `u` if the vector is `(0, 0, 0)`.
     """
     # Python 2 has two integer types, int and long.
     # In Python 3 there is no 'long' anymore.
@@ -275,23 +275,61 @@ def dist(u, v):
 
 
 def angle(u, v=Vector(1, 0, 0), normal=Vector(0, 0, 1)):
-    '''
-        angle(Vector,[Vector],[Vector]) - returns the angle
-        in radians between the two vectors. If only one is given,
-        angle is between the vector and the horizontal East direction.
+    """Return the angle in radians between the two vectors.
+
+    It uses the definition of the dot product, ``A * B = |A||B| cos(angle)``
+
+    If only one vector is given, the angle is between that one and the
+    horizontal (+X).
+
     If a third vector is given, it is the normal used to determine
-        the sign of the angle.
-    '''
+    the sign of the angle.
+    This normal is compared with the cross product of the first two vectors.
+
+    ``C = A x B``
+
+    ``factor = C * normal``
+
+    If the `factor` is positive the angle is positive, otherwise
+    it is the opposite sign.
+
+    Parameters
+    ----------
+    u : Base::Vector3
+        The first vector.
+    v : Base::Vector3, optional
+        The second vector to test against the first one.
+        It defaults to `(1, 0, 0)`, or +X.
+    normal : Base::Vector3, optional
+        The vector indicating the normal.
+        It defaults to `(0, 0, 1)`, or +Z.
+
+    Returns
+    -------
+    0
+        If the magnitude of one of the vectors is zero,
+        or if they are colinear.
+    float
+        The angle in radians between the vectors.
+    """
     typecheck([(u, Vector), (v, Vector)], "angle")
-    ll = u.Length*v.Length
+    ll = u.Length * v.Length
     if ll == 0:
         return 0
+
+    # The dot product indicates the projection of one vector over the other
     dp = u.dot(v)/ll
-    if (dp < -1):
-        dp = -1  # roundoff errors can push dp out of the ...
-    elif (dp > 1):
-        dp = 1  # ...geometrically meaningful interval [-1,1]
+
+    # Due to rounding errors, the dot product could be outside
+    # the range [-1, 1], so let's force it to be withing this range.
+    if dp < -1:
+        dp = -1
+    elif dp > 1:
+        dp = 1
+
     ang = math.acos(dp)
+
+    # The cross product compared with the provided normal
     normal1 = u.cross(v)
     coeff = normal.dot(normal1)
     if coeff >= 0:

--- a/src/Mod/Draft/DraftVecUtils.py
+++ b/src/Mod/Draft/DraftVecUtils.py
@@ -98,10 +98,12 @@ def toString(u):
             s += "FreeCAD.Vector("
             s += str(v.x) + ", " + str(v.y) + ", " + str(v.z)
             s += ")"
-            # This if test isn't needed, because first never changes value?
+            # This test isn't needed, because `first` never changes value?
             if first:
-                s += ","
+                s += ", "
                 first = True
+        # Remove the last comma
+        s = s.rstrip(",")
         s += "]"
         return s
     else:
@@ -112,7 +114,22 @@ def toString(u):
 
 
 def tup(u, array=False):
-    "returns a tuple (x,y,z) with the vector coords, or an array if array=true"
+    """Return a tuple or a list with the coordinates of a vector.
+
+    Parameters
+    ----------
+    u : Base::Vector3
+        A FreeCAD.Vector.
+    array : bool
+        Defaults to `False`, and the output is a tuple.
+        If `True` the output is an array.
+
+    Returns
+    -------
+    tuple or list
+    (x, y, z) or [x, y, z]
+        The coordinates of the vector in a tuple or a list, if `array=True`.
+    """
     typecheck([(u, Vector)], "tup")
     if array:
         return [u.x, u.y, u.z]

--- a/src/Mod/Draft/DraftVecUtils.py
+++ b/src/Mod/Draft/DraftVecUtils.py
@@ -25,8 +25,6 @@ __title__ = "FreeCAD Draft Workbench - Vector library"
 __author__ = "Yorik van Havre, Werner Mayer, Martin Burbaum, Ken Cline"
 __url__ = ["http://www.freecadweb.org"]
 
-"a vector math library for FreeCAD"
-
 ## \defgroup DRAFTVECUTILS DraftVecUtils
 #  \ingroup UTILITIES
 #  \brief Vector math utilities used in Draft workbench
@@ -61,7 +59,8 @@ def typecheck(args_and_types, name="?"):
     ----------
     args_and_types : iterable
         An iterable of two elements, for example a list,
-        from which the first element is an instance of the second element.
+        from which the first element is tested as being an instance
+        of the second element.
     name : str
         The name of the object.
 
@@ -79,19 +78,37 @@ def typecheck(args_and_types, name="?"):
 
 
 def toString(u):
-    "returns a string containing a python command to recreate this vector"
+    """Return a string with the Python command to recreate this Vector.
+
+    Parameters
+    ----------
+    u : list, or Base::Vector3
+        A list of FreeCAD.Vectors, or a single vector.
+
+    Returns
+    -------
+    str
+        The string with the code that can be input in the Python console
+        to create the same list of FreeCAD.Vectors, or single vector.
+    """
     if isinstance(u, list):
         s = "["
         first = True
         for v in u:
-            s += "FreeCAD.Vector("+str(v.x)+","+str(v.y)+","+str(v.z)+")"
+            s += "FreeCAD.Vector("
+            s += str(v.x) + ", " + str(v.y) + ", " + str(v.z)
+            s += ")"
+            # This if test isn't needed, because first never changes value?
             if first:
                 s += ","
                 first = True
         s += "]"
         return s
     else:
-        return "FreeCAD.Vector("+str(u.x)+","+str(u.y)+","+str(u.z)+")"
+        s = "FreeCAD.Vector("
+        s += str(u.x) + ", " + str(u.y) + ", " + str(u.z)
+        s += ")"
+        return s
 
 
 def tup(u, array=False):

--- a/src/Mod/Draft/DraftVecUtils.py
+++ b/src/Mod/Draft/DraftVecUtils.py
@@ -1,3 +1,19 @@
+## \defgroup DRAFTVECUTILS DraftVecUtils
+#  \ingroup UTILITIES
+#  \brief Vector math utilities used in Draft workbench
+#
+# Vector math utilities used primarily in the Draft workbench
+# but which can also be used in other workbenches and in macros.
+"""\defgroup DRAFTVECUTILS DraftVecUtils
+\ingroup UTILITIES
+\brief Vector math utilities used in Draft workbench
+
+Vector math utilities used primarily in the Draft workbench
+but which can also be used in other workbenches and in macros.
+"""
+# Check code with
+# flake8 --ignore=E226,E266,E401,W503
+
 # ***************************************************************************
 # *                                                                         *
 # *   Copyright (c) 2009, 2010                                              *
@@ -24,13 +40,6 @@
 __title__ = "FreeCAD Draft Workbench - Vector library"
 __author__ = "Yorik van Havre, Werner Mayer, Martin Burbaum, Ken Cline"
 __url__ = ["http://www.freecadweb.org"]
-
-## \defgroup DRAFTVECUTILS DraftVecUtils
-#  \ingroup UTILITIES
-#  \brief Vector math utilities used in Draft workbench
-#
-# Vector math utilities used primarily in the Draft workbench
-# but which can also be used in other workbenches and macros.
 
 ## \addtogroup DRAFTVECUTILS
 #  @{

--- a/src/Mod/Draft/DraftVecUtils.py
+++ b/src/Mod/Draft/DraftVecUtils.py
@@ -302,10 +302,11 @@ def angle(u, v=Vector(1, 0, 0), normal=Vector(0, 0, 1)):
 
     If a third vector is given, it is the normal used to determine
     the sign of the angle.
-    This normal is compared with the cross product of the first two vectors.
+    This normal is used to calculate a `factor` as the dot product
+    with the cross product of the first two vectors.
     ::
         C = A x B
-        factor = C * normal
+        factor = normal * C
 
     If the `factor` is positive the angle is positive, otherwise
     it is the opposite sign.
@@ -626,13 +627,24 @@ def closest(vector, vlist):
 def isColinear(vlist):
     """Check if the vectors in the list are colinear.
 
-    Colinear vectors don't necessarily have the same magnitude,
-    but the angle between them should be zero.
+    Colinear vectors are those whose angle between them is zero.
 
-    Due to rounding errors, the angle may not be exactly zero;
-    therefore, it rounds the angle by the number
-    of decimals specified in the `precision` parameter
-    in the parameter database, and then compares the value to zero.
+    This function tests for colinearity between the difference
+    of the first two vectors, and the difference of the nth vector with
+    the first vector.
+    ::
+        vlist = [a, b, c, d, ..., n]
+
+        k = b - a
+        k2 = c - a
+        k3 = d - a
+        kn = n - a
+
+    Then test
+    ::
+        angle(k2, k) == 0
+        angle(k3, k) == 0
+        angle(kn, k) == 0
 
     Parameters
     ----------
@@ -643,8 +655,16 @@ def isColinear(vlist):
     Returns
     -------
     bool
-        `True` if each of the vectors is colinear.
+        `True` if the vector differences are colinear,
+        or if the list only has two vectors.
         `False` otherwise.
+
+    Notes
+    -----
+    Due to rounding errors, the angle may not be exactly zero;
+    therefore, it rounds the angle by the number
+    of decimals specified in the `precision` parameter
+    in the parameter database, and then compares the value to zero.
     """
     typecheck([(vlist, list)], "isColinear")
 
@@ -660,8 +680,14 @@ def isColinear(vlist):
 
     # Start testing from the third vector and onward
     for i in range(2, len(vlist)):
-        _angle = round(angle(vlist[i].sub(vlist[0]), first), p)
-        if _angle != 0:
+
+        # Difference between the 3rd vector and onward, and the first one.
+        diff = vlist[i].sub(vlist[0])
+
+        # The angle between the difference and the first difference.
+        _angle = angle(diff, first)
+
+        if round(_angle, p) != 0:
             return False
     return True
 
@@ -677,7 +703,7 @@ def rounded(v):
     Returns
     -------
     Base::Vector3
-        The new vector where each element has been rounded
+        The new vector where each element `x`, `y`, `z` has been rounded
         to the number of decimals specified in the `precision` parameter
         in the parameter database.
     """

--- a/src/Mod/Draft/DraftVecUtils.py
+++ b/src/Mod/Draft/DraftVecUtils.py
@@ -161,21 +161,23 @@ def project(u, v):
     return Vector(0, 0, 0)
 
 
-def rotate2D(u,angle):
+def rotate2D(u, angle):
     "rotate2D(Vector,angle): rotates the given vector around the Z axis"
     return Vector(math.cos(-angle)*u.x-math.sin(-angle)*u.y,
-                    math.sin(-angle)*u.x+math.cos(-angle)*u.y,u.z)
+                  math.sin(-angle)*u.x+math.cos(-angle)*u.y,
+                  u.z)
 
-def rotate(u,angle,axis=Vector(0,0,1)):
+
+def rotate(u, angle, axis=Vector(0, 0, 1)):
     '''rotate(Vector,Float,axis=Vector): rotates the first Vector
     around the given axis, at the given angle.
     If axis is omitted, the rotation is made on the xy plane.'''
-    typecheck ([(u,Vector), (angle,(int,float)), (axis,Vector)], "rotate")
+    typecheck([(u, Vector), (angle, (int, float)), (axis, Vector)], "rotate")
 
-    if angle == 0: 
+    if angle == 0:
         return u
 
-    l=axis.Length
+    l = axis.Length
     x=axis.x/l
     y=axis.y/l
     z=axis.z/l
@@ -195,83 +197,91 @@ def rotate(u,angle,axis=Vector(0,0,1)):
                xzt - ys,    yzt + xs,   c + z*z*t,  0)
 
     return m.multiply(u)
-    
-def getRotation(vector,reference=Vector(1,0,0)):
+
+
+def getRotation(vector, reference=Vector(1, 0, 0)):
     '''getRotation(vector,[reference]): returns a tuple
     representing a quaternion rotation between the reference
     (or X axis if omitted) and the vector'''
     c = vector.cross(reference)
     if isNull(c):
-        return (0,0,0,1.0)
+        return (0, 0, 0, 1.0)
     c.normalize()
-    return (c.x,c.y,c.z,math.sqrt((vector.Length ** 2) * (reference.Length ** 2)) + vector.dot(reference))
-    
+    return (c.x, c.y, c.z, math.sqrt((vector.Length ** 2) * (reference.Length ** 2)) + vector.dot(reference))
+
+
 def isNull(vector):
     '''isNull(vector): Tests if a vector is nul vector'''
     p = precision()
-    return (round(vector.x,p)==0 and round(vector.y,p)==0 and round(vector.z,p)==0)
+    return (round(vector.x, p) == 0 and round(vector.y, p) == 0 and round(vector.z, p) == 0)
 
-def find(vector,vlist):
+
+def find(vector, vlist):
     '''find(vector,vlist): finds a vector in a list of vectors. returns
     the index of the matching vector, or None if none is found.
     '''
-    typecheck ([(vector,Vector), (vlist,list)], "find")
-    for i,v in enumerate(vlist):
-        if equals(vector,v):
+    typecheck([(vector, Vector), (vlist, list)], "find")
+    for i, v in enumerate(vlist):
+        if equals(vector, v):
             return i
     return None
-    
-def closest(vector,vlist):
+
+
+def closest(vector, vlist):
     '''closest(vector,vlist): finds the closest vector to the given vector
     in a list of vectors'''
-    typecheck ([(vector,Vector), (vlist,list)], "closest")
+    typecheck([(vector, Vector), (vlist, list)], "closest")
     dist = 9999999999999999
     index = None
-    for i,v in enumerate(vlist):
+    for i, v in enumerate(vlist):
         d = vector.sub(v).Length
         if d < dist:
             dist = d
             index = i
     return index
 
+
 def isColinear(vlist):
     '''isColinear(list_of_vectors): checks if vectors in given list are colinear'''
-    typecheck ([(vlist,list)], "isColinear");
-    if len(vlist) < 3: 
+    typecheck([(vlist, list)], "isColinear")
+    if len(vlist) < 3:
         return True
     p = precision()
     first = vlist[1].sub(vlist[0])
-    for i in range(2,len(vlist)):
-        if round(angle(vlist[i].sub(vlist[0]),first),p) != 0:
+    for i in range(2, len(vlist)):
+        if round(angle(vlist[i].sub(vlist[0]), first), p) != 0:
             return False
     return True
+
 
 def rounded(v):
     "returns a rounded vector"
     p = precision()
-    return Vector(round(v.x,p),round(v.y,p),round(v.z,p))
+    return Vector(round(v.x, p), round(v.y, p), round(v.z, p))
 
-def getPlaneRotation(u,v,w=None):
+
+def getPlaneRotation(u, v, w=None):
     "returns a rotation matrix defining the (u,v,w) coordinates system"
-    if (not u) or (not v): 
+    if (not u) or (not v):
         return None
-    if not w: 
+    if not w:
         w = u.cross(v)
-    typecheck([(u,Vector), (v,Vector), (w,Vector)], "getPlaneRotation")
-    m = FreeCAD.Matrix(u.x,v.x,w.x,0,
-                       u.y,v.y,w.y,0,
-                       u.z,v.z,w.z,0,
-                       0.0,0.0,0.0,1.0)
+    typecheck([(u, Vector), (v, Vector), (w, Vector)], "getPlaneRotation")
+    m = FreeCAD.Matrix(u.x, v.x, w.x, 0,
+                       u.y, v.y, w.y, 0,
+                       u.z, v.z, w.z, 0,
+                       0.0, 0.0, 0.0, 1.0)
     return m
+
 
 def removeDoubles(vlist):
     "removes consecutive doubles from a list of vectors"
-    typecheck ([(vlist,list)], "removeDoubles");
+    typecheck([(vlist, list)], "removeDoubles")
     nlist = []
-    if len(vlist) < 2: 
+    if len(vlist) < 2:
         return vlist
-    for i in range(len(vlist)-1):
-        if not equals(vlist[i],vlist[i+1]):
+    for i in range(len(vlist) - 1):
+        if not equals(vlist[i], vlist[i+1]):
             nlist.append(vlist[i])
     nlist.append(vlist[-1])
     return nlist

--- a/src/Mod/Draft/DraftVecUtils.py
+++ b/src/Mod/Draft/DraftVecUtils.py
@@ -57,17 +57,20 @@ def typecheck(args_and_types, name="?"):
 
     Parameters
     ----------
-    args_and_types : iterable
-        An iterable of two elements, for example a list,
-        from which the first element is tested as being an instance
-        of the second element.
-    name : str
-        The name of the object.
+    args_and_types : list
+    [(a, b), (c, d), ...] : list
+        A list of tuples. The first element of the tuple is tested as being
+        an instance of the second element.
+        `isinstance(a, b)`
+        `isinstance(c, d)`
+    name : str, optional
+        Defaults to '?'. The name of the object.
 
     Raises
     -------
     TypeError
-        If the first argument is not an instance of the second argument.
+        If the first element in the tuple is not an instance of the second
+        element.
     """
     for v, t in args_and_types:
         if not isinstance(v, t):
@@ -103,7 +106,7 @@ def toString(u):
                 s += ", "
                 first = True
         # Remove the last comma
-        s = s.rstrip(",")
+        s = s.rstrip(", ")
         s += "]"
         return s
     else:
@@ -138,7 +141,19 @@ def tup(u, array=False):
 
 
 def neg(u):
-    "neg(Vector) - returns an opposite (negative) vector"
+    """Return the negative of a given FreeCAD.Vector.
+
+    Parameters
+    ----------
+    u : Base::Vector3
+        A FreeCAD.Vector.
+
+    Returns
+    -------
+    Base::Vector3
+        A vector in which each element has the opposite sign as
+        the original element.
+    """
     typecheck([(u, Vector)], "neg")
     return Vector(-u.x, -u.y, -u.z)
 

--- a/src/Mod/Draft/DraftVecUtils.py
+++ b/src/Mod/Draft/DraftVecUtils.py
@@ -86,41 +86,45 @@ def tup(u, array=False):
 
 def neg(u):
     "neg(Vector) - returns an opposite (negative) vector"
-    typecheck ([(u,Vector)],"neg")
+    typecheck([(u, Vector)], "neg")
     return Vector(-u.x, -u.y, -u.z)
 
-def equals(u,v):
-    "returns True if vectors differ by less than precision (from ParamGet), elementwise "
-    typecheck ([(u,Vector), (v,Vector)], "equals")
-    return isNull (u.sub(v))
 
-def scale(u,scalar):
+def equals(u, v):
+    "returns True if vectors differ by less than precision (from ParamGet), elementwise "
+    typecheck([(u, Vector), (v, Vector)], "equals")
+    return isNull(u.sub(v))
+
+
+def scale(u, scalar):
     "scale(Vector,Float) - scales (multiplies) a vector by a factor"
     if sys.version_info.major < 3:
-        typecheck ([(u,Vector), (scalar,(long,int,float))], "scale")
+        typecheck([(u, Vector), (scalar, (long, int, float))], "scale")
     else:
-        typecheck ([(u,Vector), (scalar,(int,int,float))], "scale")
+        typecheck([(u, Vector), (scalar, (int, int, float))], "scale")
     return Vector(u.x*scalar, u.y*scalar, u.z*scalar)
 
-def scaleTo(u,l):
+
+def scaleTo(u, l):
     "scaleTo(Vector,length) - scales a vector to a given length"
     if sys.version_info.major < 3:
-        typecheck ([(u,Vector),(l,(long,int,float))], "scaleTo")
+        typecheck([(u, Vector), (l, (long, int, float))], "scaleTo")
     else:
-        typecheck ([(u,Vector),(l,(int,int,float))], "scaleTo")
+        typecheck([(u, Vector), (l, (int, int, float))], "scaleTo")
     if u.Length == 0:
         return Vector(u)
     else:
         a = l/u.Length
         return Vector(u.x*a, u.y*a, u.z*a)
 
+
 def dist(u, v):
     "dist(Vector,Vector) - returns the distance between both points/vectors"
-    typecheck ([(u,Vector), (v,Vector)], "dist")
-    x=u.sub(v).Length
+    typecheck([(u, Vector), (v, Vector)], "dist")
     return u.sub(v).Length
 
-def angle(u,v=Vector(1,0,0),normal=Vector(0,0,1)):
+
+def angle(u, v=Vector(1, 0, 0), normal=Vector(0, 0, 1)):
     '''
         angle(Vector,[Vector],[Vector]) - returns the angle
         in radians between the two vectors. If only one is given,
@@ -128,15 +132,15 @@ def angle(u,v=Vector(1,0,0),normal=Vector(0,0,1)):
     If a third vector is given, it is the normal used to determine
         the sign of the angle.
     '''
-    typecheck ([(u,Vector), (v,Vector)], "angle")
+    typecheck([(u, Vector), (v, Vector)], "angle")
     ll = u.Length*v.Length
-    if ll==0: 
+    if ll == 0:
         return 0
-    dp=u.dot(v)/ll
-    if (dp < -1): 
-        dp = -1 # roundoff errors can push dp out of the ...
-    elif (dp > 1): 
-        dp = 1 # ...geometrically meaningful interval [-1,1]
+    dp = u.dot(v)/ll
+    if (dp < -1):
+        dp = -1  # roundoff errors can push dp out of the ...
+    elif (dp > 1):
+        dp = 1  # ...geometrically meaningful interval [-1,1]
     ang = math.acos(dp)
     normal1 = u.cross(v)
     coeff = normal.dot(normal1)
@@ -145,15 +149,17 @@ def angle(u,v=Vector(1,0,0),normal=Vector(0,0,1)):
     else:
         return -ang
 
-def project(u,v):
+
+def project(u, v):
     "project(Vector,Vector): projects the first vector onto the second one"
-    typecheck([(u,Vector), (v,Vector)], "project")
+    typecheck([(u, Vector), (v, Vector)], "project")
     dp = v.dot(v)
-    if dp == 0: 
-        return Vector(0,0,0) # to avoid division by zero
-    if dp != 15: 
+    if dp == 0:
+        return Vector(0, 0, 0)  # to avoid division by zero
+    if dp != 15:
         return scale(v, u.dot(v)/dp)
-    return Vector(0,0,0)
+    return Vector(0, 0, 0)
+
 
 def rotate2D(u,angle):
     "rotate2D(Vector,angle): rotates the given vector around the Z axis"

--- a/src/Mod/Draft/DraftVecUtils.py
+++ b/src/Mod/Draft/DraftVecUtils.py
@@ -1,27 +1,27 @@
-#***************************************************************************
-#*                                                                         *
-#*   Copyright (c) 2009, 2010                                              *
-#*   Yorik van Havre <yorik@uncreated.net>, Ken Cline <cline@frii.com>     *  
-#*                                                                         *
-#*   This program is free software; you can redistribute it and/or modify  *
-#*   it under the terms of the GNU Lesser General Public License (LGPL)    *
-#*   as published by the Free Software Foundation; either version 2 of     *
-#*   the License, or (at your option) any later version.                   *
-#*   for detail see the LICENCE text file.                                 *
-#*                                                                         *
-#*   This program is distributed in the hope that it will be useful,       *
-#*   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
-#*   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
-#*   GNU Library General Public License for more details.                  *
-#*                                                                         *
-#*   You should have received a copy of the GNU Library General Public     *
-#*   License along with this program; if not, write to the Free Software   *
-#*   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
-#*   USA                                                                   *
-#*                                                                         *
-#***************************************************************************
+# ***************************************************************************
+# *                                                                         *
+# *   Copyright (c) 2009, 2010                                              *
+# *   Yorik van Havre <yorik@uncreated.net>, Ken Cline <cline@frii.com>     *
+# *                                                                         *
+# *   This program is free software; you can redistribute it and/or modify  *
+# *   it under the terms of the GNU Lesser General Public License (LGPL)    *
+# *   as published by the Free Software Foundation; either version 2 of     *
+# *   the License, or (at your option) any later version.                   *
+# *   for detail see the LICENCE text file.                                 *
+# *                                                                         *
+# *   This program is distributed in the hope that it will be useful,       *
+# *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+# *   GNU Library General Public License for more details.                  *
+# *                                                                         *
+# *   You should have received a copy of the GNU Library General Public     *
+# *   License along with this program; if not, write to the Free Software   *
+# *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
+# *   USA                                                                   *
+# *                                                                         *
+# ***************************************************************************
 
-__title__="FreeCAD Draft Workbench - Vector library"
+__title__ = "FreeCAD Draft Workbench - Vector library"
 __author__ = "Yorik van Havre, Werner Mayer, Martin Burbaum, Ken Cline"
 __url__ = ["http://www.freecadweb.org"]
 
@@ -31,7 +31,8 @@ __url__ = ["http://www.freecadweb.org"]
 #  \ingroup UTILITIES
 #  \brief Vector math utilities used in Draft workbench
 #
-# Vector math utilities
+# Vector math utilities used primarily in the Draft workbench
+# but which can also be used in other workbenches and macros.
 
 ## \addtogroup DRAFTVECUTILS
 #  @{
@@ -39,6 +40,7 @@ __url__ = ["http://www.freecadweb.org"]
 import sys
 import math, FreeCAD
 from FreeCAD import Vector, Matrix
+from FreeCAD import Console as FCC
 
 try:
     long
@@ -53,9 +55,26 @@ def precision():
 
 
 def typecheck(args_and_types, name="?"):
+    """Check that the argument is an instance of a certain type.
+
+    Parameters
+    ----------
+    args_and_types : iterable
+        An iterable of two elements, for example a list,
+        from which the first element is an instance of the second element.
+    name : str
+        The name of the object.
+
+    Raises
+    -------
+    TypeError
+        If the first argument is not an instance of the second argument.
+    """
     for v, t in args_and_types:
         if not isinstance(v, t):
-            FreeCAD.Console.PrintWarning("typecheck[" + str(name) + "]: " + str(v) + " is not " + str(t) + "\n")
+            _msg = ("typecheck[" + str(name) + "]: "
+                    + str(v) + " is not " + str(t) + "\n")
+            FCC.PrintWarning(_msg)
             raise TypeError("fcvec." + str(name))
 
 

--- a/src/Mod/Draft/DraftVecUtils.py
+++ b/src/Mod/Draft/DraftVecUtils.py
@@ -482,14 +482,40 @@ def rotate(u, angle, axis=Vector(0, 0, 1)):
 
 
 def getRotation(vector, reference=Vector(1, 0, 0)):
-    '''getRotation(vector,[reference]): returns a tuple
-    representing a quaternion rotation between the reference
-    (or X axis if omitted) and the vector'''
+    """Return a quaternion rotation between a vector and a reference.
+
+    If the reference is omitted, the +X axis is used.
+
+    Parameters
+    ----------
+    vector : Base::Vector3
+        The original vector.
+    reference : Base::Vector3, optional
+        The reference vector. It defaults to `(1, 0, 0)`, the +X axis.
+
+    Returns
+    -------
+    (0, 0, 0, 1.0)
+        If the cross product between the `vector` and the `reference` is null.
+    (x, y, z, Q)
+        A tuple with the unit elements (normalized) of the cross product
+        between the `vector` and the `reference`, and a `Q` value,
+        which is the sum of the products of the magnitudes,
+        and of the dot product of those vectors.
+        ::
+            Q = |A||B| + |A||B| cos(angle)
+
+    """
     c = vector.cross(reference)
     if isNull(c):
         return (0, 0, 0, 1.0)
     c.normalize()
-    return (c.x, c.y, c.z, math.sqrt((vector.Length ** 2) * (reference.Length ** 2)) + vector.dot(reference))
+
+    q1 = math.sqrt((vector.Length**2) * (reference.Length**2))
+    q2 = vector.dot(reference)
+    Q = q1 + q2
+
+    return (c.x, c.y, c.z, Q)
 
 
 def isNull(vector):

--- a/src/Mod/Draft/DraftVecUtils.py
+++ b/src/Mod/Draft/DraftVecUtils.py
@@ -58,13 +58,23 @@ def typecheck(args_and_types, name="?"):
     Parameters
     ----------
     args_and_types : list
-    [(a, b), (c, d), ...] : list
         A list of tuples. The first element of the tuple is tested as being
         an instance of the second element.
-        `isinstance(a, b)`
-        `isinstance(c, d)`
+        ``args_and_types = [(a, Type), (b, Type2), ...]``
+
+        Then
+        ``isinstance(a, Type)``,
+        ``isinstance(b, Type2)``
+
+        A `Type` can also be a tuple of many types, in which case
+        the check is done for any of them.
+
+        ``args_and_types = [(a, (Type3, int, float)), ...]``
+
+        ``isinstance(a, (Type3, int, float))``
+
     name : str, optional
-        Defaults to '?'. The name of the object.
+        Defaults to '?'. The name of the check.
 
     Raises
     -------
@@ -123,7 +133,7 @@ def tup(u, array=False):
     ----------
     u : Base::Vector3
         A FreeCAD.Vector.
-    array : bool
+    array : bool, optional
         Defaults to `False`, and the output is a tuple.
         If `True` the output is an array.
 
@@ -151,7 +161,7 @@ def neg(u):
     Returns
     -------
     Base::Vector3
-        A vector in which each element has the opposite sign as
+        A vector in which each element has the opposite sign of
         the original element.
     """
     typecheck([(u, Vector)], "neg")
@@ -159,13 +169,48 @@ def neg(u):
 
 
 def equals(u, v):
-    "returns True if vectors differ by less than precision (from ParamGet), elementwise "
+    """Check for equality between two FreeCAD.Vectors.
+
+    Due to rounding errors, two vectors will rarely be 'equal'.
+    Therefore, this fucntion checks that the corresponding elements
+    of the two vectors differ by less than the precision established
+    in the parameter database, accessed through `FreeCAD.ParamGet()`.
+    x1 - x2 < precision
+    y1 - y2 < precision
+    z1 - z2 < precision
+
+    Parameters
+    ----------
+    u : Base::Vector3
+    v : Base::Vector3
+        The FreeCAD.Vectors to compare.
+
+    Returns
+    ------
+    bool
+        `True` if the vectors are within the precision, `False` otherwise.
+    """
     typecheck([(u, Vector), (v, Vector)], "equals")
     return isNull(u.sub(v))
 
 
 def scale(u, scalar):
-    "scale(Vector,Float) - scales (multiplies) a vector by a factor"
+    """Scales (multiplies) a vector by a factor.
+
+    Parameters
+    ----------
+    u : Base::Vector3
+        The FreeCAD.Vector to scale.
+    scalar : float
+        The scaling factor.
+
+    Returns
+    -------
+    Base::Vector3
+        The new vector with each of its elements multiplied by `scalar`.
+    """
+    # Python 2 has two integer types, int and long.
+    # In Python 3 there is no 'long' anymore.
     if sys.version_info.major < 3:
         typecheck([(u, Vector), (scalar, (long, int, float))], "scale")
     else:

--- a/src/Mod/Draft/DraftVecUtils.py
+++ b/src/Mod/Draft/DraftVecUtils.py
@@ -40,6 +40,8 @@ import math, FreeCAD
 from FreeCAD import Vector, Matrix
 from FreeCAD import Console as FCC
 
+# Python 2 has two integer types, int and long.
+# In Python 3 there is no 'long' anymore, so make it 'int'.
 try:
     long
 except NameError:
@@ -49,6 +51,14 @@ params = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/Draft")
 
 
 def precision():
+    """Get the number of decimal numbers used for precision.
+
+    Returns
+    -------
+    int
+        Return the number of decimal places set up in the preferences,
+        or a standard value (6), if the parameter is missing.
+    """
     return params.GetInt("precision", 6)
 
 
@@ -446,10 +456,9 @@ def rotate(u, angle, axis=Vector(0, 0, 1)):
 
     Returns
     -------
-    u
-        If the `angle` is zero, return the original vector.
     Base::Vector3
         The new rotated vector.
+        If the `angle` is zero, return the original vector `u`.
     """
     typecheck([(u, Vector), (angle, (int, float)), (axis, Vector)], "rotate")
 
@@ -519,9 +528,29 @@ def getRotation(vector, reference=Vector(1, 0, 0)):
 
 
 def isNull(vector):
-    '''isNull(vector): Tests if a vector is nul vector'''
+    """Returns `False` if each of the components of the vector is zero.
+
+    Due to rounding errors, an element is probably never going to be
+    exactly zero. Therefore, it rounds the element by the number
+    of decimals specified in the precision parameter.
+    It then compares the rounded number against zero.
+
+    Parameters
+    ----------
+    vector : Base::Vector3
+        The tested vector.
+
+    Returns
+    -------
+    bool
+        `True` if each of the elements is zero within the precision.
+        `False` otherwise.
+    """
     p = precision()
-    return (round(vector.x, p) == 0 and round(vector.y, p) == 0 and round(vector.z, p) == 0)
+    x = round(vector.x, p)
+    y = round(vector.y, p)
+    z = round(vector.z, p)
+    return (x == 0 and y == 0 and z == 0)
 
 
 def find(vector, vlist):

--- a/src/Mod/Draft/DraftVecUtils.py
+++ b/src/Mod/Draft/DraftVecUtils.py
@@ -414,28 +414,65 @@ def rotate2D(u, angle):
 
 
 def rotate(u, angle, axis=Vector(0, 0, 1)):
-    '''rotate(Vector,Float,axis=Vector): rotates the first Vector
-    around the given axis, at the given angle.
-    If axis is omitted, the rotation is made on the xy plane.'''
+    """Rotate the vector by the specified angle, around the given axis.
+
+    If the axis is omitted, the rotation is made around the Z axis
+    (on the XY plane).
+
+    It uses a 3x3 rotation matrix.
+    ::
+        u_rot = R u
+
+                (c + x*x*t    xyt - zs     xzt + ys )
+        u_rot = (xyt + zs     c + y*y*t    yzt - xs ) * u
+                (xzt - ys     yzt + xs     c + z*z*t)
+
+    Where `x`, `y`, `z` indicate unit components of the axis;
+    `c` denotes a cosine of the angle; `t` indicates a complement
+    of that cosine; `xs`, `ys`, `zs` indicate products of the unit
+    components and the sine of the angle; and `xyt`, `xzt`, `yzt`
+    indicate products of two unit components and the complement
+    of the cosine.
+
+    Parameters
+    ----------
+    u : Base::Vector3
+        The vector.
+    angle : float
+        The angle of rotation given in radians.
+    axis : Base::Vector3, optional
+        The vector specifying the axis of rotation.
+        It defaults to `(0, 0, 1)`, the +Z axis.
+
+    Returns
+    -------
+    u
+        If the `angle` is zero, return the original vector.
+    Base::Vector3
+        The new rotated vector.
+    """
     typecheck([(u, Vector), (angle, (int, float)), (axis, Vector)], "rotate")
 
     if angle == 0:
         return u
 
+    # Unit components, so that x**2 + y**2 + z**2 = 1
     L = axis.Length
     x = axis.x/L
     y = axis.y/L
     z = axis.z/L
+
     c = math.cos(angle)
     s = math.sin(angle)
     t = 1 - c
 
-    xyt = x*y*t
-    xzt = x*z*t
-    yzt = y*z*t
-    xs = x*s
-    ys = y*s
-    zs = z*s
+    # Common products
+    xyt = x * y * t
+    xzt = x * z * t
+    yzt = y * z * t
+    xs = x * s
+    ys = y * s
+    zs = z * s
 
     m = Matrix(c + x*x*t,   xyt - zs,   xzt + ys,   0,
                xyt + zs,    c + y*y*t,  yzt - xs,   0,

--- a/src/Mod/Draft/DraftVecUtils.py
+++ b/src/Mod/Draft/DraftVecUtils.py
@@ -219,7 +219,31 @@ def scale(u, scalar):
 
 
 def scaleTo(u, l):
-    "scaleTo(Vector,length) - scales a vector to a given length"
+    """Scale a vector so that its magnitude is equal to a given length.
+
+    The magnitude of a vector is
+    ``L = sqrt(x**2 + y**2 + z**2)``
+
+    This function multiplies each coordinate, x, y, z,
+    by a factor to produce the desired magnitude.
+    This factor is the ratio of the new magnitude to the old magnitude,
+    ``x_scaled = x * (new/old)``
+
+    Parameters
+    ----------
+    u : Base::Vector3
+        The FreeCAD.Vector to scale.
+    l : int or float
+        The new magnitude of the vector in standard units (mm).
+
+    Returns
+    -------
+    Base::Vector3
+        The new vector with each of its elements scaled by a factor.
+        Or the same vector `u` if the vector is (0, 0, 0).
+    """
+    # Python 2 has two integer types, int and long.
+    # In Python 3 there is no 'long' anymore.
     if sys.version_info.major < 3:
         typecheck([(u, Vector), (l, (long, int, float))], "scaleTo")
     else:
@@ -232,7 +256,20 @@ def scaleTo(u, l):
 
 
 def dist(u, v):
-    "dist(Vector,Vector) - returns the distance between both points/vectors"
+    """Return the distance between two points (or vectors).
+
+    Parameters
+    ----------
+    u : Base::Vector3
+        First point, defined by a FreeCAD.Vector.
+    v : Base::Vector3
+        Second point, defined by a FreeCAD.Vector.
+
+    Returns
+    -------
+    float
+        The scalar distance from one point to the other.
+    """
     typecheck([(u, Vector), (v, Vector)], "dist")
     return u.sub(v).Length
 


### PR DESCRIPTION
Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
Improved the Pythonic style of the code, particularly spacing, line length, and docstrings.

All functions got complete docstrings which explain much better how to use them. The docstring should be visible from FreeCAD's own Python console, and from the Doxygen (or Sphinx) automatically generated documentation.

The code was checked with `flake8`, which passed with minimum issues.
```flake8 --ignore=E226,E266,E401,W503 DraftVecUtils.py```

Spyder's static code analyzer was also used to check for serious issues.