### PR TITLE
Part.BSplineSurface.buildFromPolesMultsKnots(): Fix 'Truth value of an array ... use a.any() or a.all()' when explicit knots or weights provided

### DIFF
--- a/src/Mod/Part/App/BSplineSurfacePyImp.cpp
+++ b/src/Mod/Part/App/BSplineSurfacePyImp.cpp
@@ -1405,7 +1405,7 @@ PyObject* BSplineSurfacePy::buildFromPolesMultsKnots(PyObject *args, PyObject *k
         Standard_Integer lv = col.size();
         TColgp_Array2OfPnt occpoles(1, lu, 1, lv);
         TColStd_Array2OfReal occweights(1, lu, 1, lv);
-        Standard_Boolean genweights = PyObject_Not(weights) ? Standard_True : Standard_False; //cache
+        Standard_Boolean genweights = (weights==Py_None) ? Standard_True : Standard_False; //cache
         Standard_Integer index1 = 0;
         Standard_Integer index2 = 0;
         for (Py::Sequence::iterator it1 = list.begin(); it1 != list.end(); ++it1) {
@@ -1445,8 +1445,8 @@ PyObject* BSplineSurfacePy::buildFromPolesMultsKnots(PyObject *args, PyObject *k
         }
         number_of_uknots = PyObject_Length(umults);
         number_of_vknots = PyObject_Length(vmults);
-        if ((PyObject_IsTrue(uknots) && PyObject_Length(uknots) != number_of_uknots) ||
-                (PyObject_IsTrue(vknots) && PyObject_Length(vknots) != number_of_vknots)){
+        if (((uknots != Py_None) && PyObject_Length(uknots) != number_of_uknots) ||
+                ((vknots != Py_None) && PyObject_Length(vknots) != number_of_vknots)){
             Standard_Failure::Raise("number of knots and mults mismatch");
             return 0;
         }


### PR DESCRIPTION
Calls to BSplineSurface.buildFromPolesMultsKnots() with explicit knots or weights fail in recent versions of FreeCAD (tested on 0.18.3 with python3; possible python3 regression) with the message 'The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()'. 

This trivial fix follows the pattern used later in the function of explicit comparisons with Py_None, replacing PyObject_Not() and PyObject_IsTrue()  when they are used to determine whether explicit weights or knots have been provided.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x ] Branch rebased on latest master `git pull --rebase upstream master`
- [ (unit test behavior is the same as without the patch)] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ (none exists; can add bug report if you want)] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

---
