### PR TITLE
Improved Python style in WorkingPlane code

### DIFF
--- a/src/Mod/Draft/WorkingPlane.py
+++ b/src/Mod/Draft/WorkingPlane.py
@@ -684,6 +684,10 @@ class plane:
             self.weak = True
 
     def reset(self):
+        """Reset the plane.
+
+        Set the `doc` attribute to `None`, and `weak` to `True`.
+        """
         self.doc = None
         self.weak = True
 

--- a/src/Mod/Draft/WorkingPlane.py
+++ b/src/Mod/Draft/WorkingPlane.py
@@ -946,7 +946,7 @@ class plane:
         return pt.add(self.position)
 
     def getLocalRot(self, point):
-        """Like getLocalCoords, but doesn't use the plane's `position`.
+        """Like getLocalCoords, but doesn't use the plane's position.
 
         If the `point` was constructed using the plane as origin,
         return the relative coordinates from the `point` to the plane.
@@ -1020,7 +1020,24 @@ class plane:
         return pt
 
     def getClosestAxis(self, point):
-        "returns which of the workingplane axes is closest from the given vector"
+        """Return the closest axis of the plane to the given point (vector).
+
+        It tests the angle that the `point` vector makes with the unit vectors
+        `u`, `v`, and `axis`, as well their negatives.
+        The smallest angle indicates the closest axis.
+
+        Parameters
+        ----------
+        point : Base::Vector3
+            The external point to test.
+
+        Returns
+        -------
+        str
+            * It is `'x'` if the closest axis is `u` or `-u`.
+            * It is `'y'` if the closest axis is `v` or `-v`.
+            * It is `'z'` if the closest axis is `axis` or `-axis`.
+        """
         ax = point.getAngle(self.u)
         ay = point.getAngle(self.v)
         az = point.getAngle(self.axis)
@@ -1038,7 +1055,11 @@ class plane:
             return None
 
     def isGlobal(self):
-        "returns True if the plane axes are equal to the global axes"
+        """Return True if the plane axes are equal to the global axes.
+
+        Return `False` if any of `u`, `v`, or `axis` does not correspond
+        to `+X`, `+Y`, or `+Z`, respectively.
+        """
         if self.u != Vector(1, 0, 0):
             return False
         if self.v != Vector(0, 1, 0):

--- a/src/Mod/Draft/WorkingPlane.py
+++ b/src/Mod/Draft/WorkingPlane.py
@@ -317,8 +317,66 @@ class plane:
         # FreeCAD.Console.PrintMessage("(position = " + str(self.position) + ")\n")
         # FreeCAD.Console.PrintMessage("Current workplane: x="+str(DraftVecUtils.rounded(self.u))+" y="+str(DraftVecUtils.rounded(self.v))+" z="+str(DraftVecUtils.rounded(self.axis))+"\n")
 
-    def alignToPointAndAxis_SVG(self, point, axis, offset):
-        # based on cases table
+    def alignToPointAndAxis_SVG(self, point, axis, offset=0):
+        """Align the working plane to a point and an axis (vector).
+
+        It aligns `u` and `v` based on the magnitude of the components
+        of `axis`.
+        Also set `weak` to `False`.
+
+        Parameters
+        ----------
+        point : Base::Vector3
+            The new `position` of the plane, adjusted by
+            the `offset`.
+        axis : Base::Vector3
+            A vector whose unit vector will be used as the new `axis`
+            of the plane.
+            The magnitudes of the `x`, `y`, `z` components of the axis
+            determine the orientation of `u` and `v` of the plane.
+        offset : float, optional
+            Defaults to zero. A value which will be used to offset
+            the plane in the direction of its `axis`.
+
+        Cases
+        -----
+        The `u` and `v` are always calculated the same
+
+            * `u` is the cross product of the positive or negative of `axis`
+              with a `reference vector`.
+              ::
+                  u = [+1|-1] axis.cross(ref_vec)
+            * `v` is `u` rotated 90 degrees around `axis`.
+
+        Whether the `axis` is positive or negative, and which reference
+        vector is used, depends on the absolute values of the `x`, `y`, `z`
+        components of the `axis` unit vector.
+
+         #. If `x > y`, and `y > z`
+             The reference vector is +Z
+             ::
+                 u = -1 axis.cross(+Z)
+         #. If `y > z`, and `z >= x`
+             The reference vector is +X.
+             ::
+                 u = -1 axis.cross(+X)
+         #. If `y >= x`, and `x > z`
+             The reference vector is +Z.
+             ::
+                 u = +1 axis.cross(+Z)
+         #. If `x > z`, and `z >= y`
+             The reference vector is +Y.
+             ::
+                 u = +1 axis.cross(+Y)
+         #. If `z >= y`, and `y > x`
+             The reference vector is +X.
+             ::
+                 u = +1 axis.cross(+X)
+         #. otherwise
+             The reference vector is +Y.
+             ::
+                 u = -1 axis.cross(+Y)
+        """
         self.doc = FreeCAD.ActiveDocument
         self.axis = axis
         self.axis.normalize()

--- a/src/Mod/Draft/WorkingPlane.py
+++ b/src/Mod/Draft/WorkingPlane.py
@@ -266,6 +266,31 @@ class plane:
         return p.add(t)
 
     def alignToPointAndAxis(self, point, axis, offset=0, upvec=None):
+        """Align the working plane to a point and an axis (vector).
+
+        Set `v` as the cross product of `axis` with `(1, 0, 0)` or `+X`,
+        and `u` as `v` rotated -90 degrees around the `axis`.
+        Also set `weak` to `False`.
+
+        Parameters
+        ----------
+        point : Base::Vector3
+            The new `position` of the plane, adjusted by
+            the `offset`.
+        axis : Base::Vector3
+            A vector whose unit vector will be used as the new `axis`
+            of the plane.
+            If it is very close to the `X` or `-X` axes,
+            it will use this axis exactly, and will adjust `u` and `v`
+            to `+Y` and `+Z`, or `-Y` and `+Z`, respectively.
+        offset : float, optional
+            Defaults to zero. A value which will be used to offset
+            the plane in the direction of its `axis`.
+        upvec : Base::Vector3, optional
+            Defaults to `None`.
+            If it exists, its unit vector will be used as `v`,
+            and will set `u` as the cross product of `v` with `axis`.
+        """
         self.doc = FreeCAD.ActiveDocument
         self.axis = axis
         self.axis.normalize()

--- a/src/Mod/Draft/WorkingPlane.py
+++ b/src/Mod/Draft/WorkingPlane.py
@@ -145,7 +145,8 @@ class plane:
             self.v = axis.cross(Vector(1, 0, 0))
             self.v.normalize()
             self.u = DraftVecUtils.rotate(self.v, -math.pi/2, self.axis)
-        offsetVector = Vector(axis); offsetVector.multiply(offset)
+        offsetVector = Vector(axis)
+        offsetVector.multiply(offset)
         self.position = point.add(offsetVector)
         self.weak = False
         # FreeCAD.Console.PrintMessage("(position = " + str(self.position) + ")\n")
@@ -475,6 +476,7 @@ class plane:
             norm = proj.cross(self.u)
             return DraftVecUtils.angle(self.u, proj, norm)
 
+
 def getPlacementFromPoints(points):
     "returns a placement from a list of 3 or 4 vectors"
     pl = plane()
@@ -491,6 +493,7 @@ def getPlacementFromPoints(points):
     p = pl.getPlacement()
     del pl
     return p
+
 
 def getPlacementFromFace(face, rotated=False):
     "returns a placement from a face"

--- a/src/Mod/Draft/WorkingPlane.py
+++ b/src/Mod/Draft/WorkingPlane.py
@@ -1119,7 +1119,32 @@ class plane:
 
 
 def getPlacementFromPoints(points):
-    "returns a placement from a list of 3 or 4 vectors"
+    """Return a placement from a list of 3 or 4 points.
+
+    With these points a temporary plane is defined.
+    The first point is the plane's `position`.
+    The other two points are used to define the `u` and `v` axes,
+    as originating from the first point.
+
+    If the fourth point exists, it is used to define the plane's `axis`
+    as originating from the first point.
+    If no fourth point is provided, the cross product bewtween the previously
+    defined `u` and `v` is used as `axis`.
+
+    Then it returns the `Base::Placement` returned from `getPlacement()`.
+
+    Parameters
+    ----------
+    points : list of Base::Vector3
+        A list with 3 or 4 points to create a temporary plane
+        from which to extract the placement.
+
+    Return
+    ------
+    Base::Placement
+        A placement obtained from the temporary plane
+        defined by the points.
+    """
     pl = plane()
     try:
         pl.position = points[0]

--- a/src/Mod/Draft/WorkingPlane.py
+++ b/src/Mod/Draft/WorkingPlane.py
@@ -108,7 +108,7 @@ class plane:
         gd = self.getGlobalRot(Vector(ld.x, ld.y, 0))
         hyp = abs(math.tan(a) * lp.z)
         return gp.add(DraftVecUtils.scaleTo(gd, hyp))
-                
+
     def projectPointOld(self, p, direction=None):
         '''project point onto plane, default direction is orthogonal. Obsolete'''
         if not direction:
@@ -161,7 +161,7 @@ class plane:
             self.u.normalize()
             self.v = DraftVecUtils.rotate(self.u, math.pi/2, self.axis)
             #projcase = "Case new"
-        
+
         elif ((abs(axis.y) > abs(axis.z)) and (abs(axis.z) >= abs(axis.x))):
             ref_vec = Vector(1.0, 0.0, 0.0)
             self.u = axis.negative().cross(ref_vec)
@@ -198,7 +198,7 @@ class plane:
         #spat_vec = self.u.cross(self.v)
         #spat_res = spat_vec.dot(axis)
         #FreeCAD.Console.PrintMessage(projcase + " spat Prod = " + str(spat_res) + "\n")
-        
+
         offsetVector = Vector(axis); offsetVector.multiply(offset)
         self.position = point.add(offsetVector)
         self.weak = False
@@ -252,7 +252,7 @@ class plane:
                     self.u, self.v = self.v.negative(), self.u
                 elif DraftVecUtils.equals(self.u, Vector(0, 0, -1)):
                     self.u, self.v = self.v, self.u.negative()
-                    
+
             self.weak = False
             return True
         else:
@@ -358,7 +358,7 @@ class plane:
         self.axis = rot.multVec(FreeCAD.Vector(0, 0, 1))
         if rebase:
             self.position = pl.Base
-        
+
     def inverse(self):
         "inverts the direction of the working plane"
         self.u = self.u.negative()
@@ -426,7 +426,7 @@ class plane:
         vz = Vector(self.axis).multiply(point.z)
         pt = (vx.add(vy)).add(vz)
         return pt
-        
+
     def getClosestAxis(self, point):
         "returns which of the workingplane axes is closest from the given vector"
         ax = point.getAngle(self.u)
@@ -444,7 +444,7 @@ class plane:
             return "z"
         else:
             return None
-            
+
     def isGlobal(self):
         "returns True if the plane axes are equal to the global axes"
         if self.u != Vector(1, 0, 0):
@@ -454,15 +454,15 @@ class plane:
         if self.axis != Vector(0, 0, 1):
             return False
         return True
-        
+
     def isOrtho(self):
         "returns True if the plane axes are following the global axes"
         if round(self.u.getAngle(Vector(0, 1, 0)), 6) in [0, -1.570796, 1.570796, -3.141593, 3.141593, -4.712389, 4.712389, 6.283185]:
-            if round(self.v.getAngle(Vector(0,1,0)),6) in [0, -1.570796, 1.570796, -3.141593, 3.141593, -4.712389, 4.712389, 6.283185]:
-                if round(self.axis.getAngle(Vector(0,1,0)),6) in [0, -1.570796, 1.570796, -3.141593, 3.141593, -4.712389, 4.712389, 6.283185]:
+            if round(self.v.getAngle(Vector(0, 1, 0)), 6) in [0, -1.570796, 1.570796, -3.141593, 3.141593, -4.712389, 4.712389, 6.283185]:
+                if round(self.axis.getAngle(Vector(0, 1, 0)), 6) in [0, -1.570796, 1.570796, -3.141593, 3.141593, -4.712389, 4.712389, 6.283185]:
                     return True
         return False
-        
+
     def getDeviation(self):
         "returns the deviation angle between the u axis and the horizontal plane"
         proj = Vector(self.u.x, self.u.y, 0)
@@ -471,7 +471,7 @@ class plane:
         else:
             norm = proj.cross(self.u)
             return DraftVecUtils.angle(self.u, proj, norm)
-                
+
 def getPlacementFromPoints(points):
     "returns a placement from a list of 3 or 4 vectors"
     pl = plane()
@@ -488,7 +488,7 @@ def getPlacementFromPoints(points):
     p = pl.getPlacement()
     del pl
     return p
-    
+
 def getPlacementFromFace(face, rotated=False):
     "returns a placement from a face"
     pl = plane()

--- a/src/Mod/Draft/WorkingPlane.py
+++ b/src/Mod/Draft/WorkingPlane.py
@@ -828,11 +828,15 @@ class plane:
             self.stored = None
 
     def getLocalCoords(self, point):
-        """Return the coordinates of a given point projected on the plane.
+        """Return the coordinates of the given point, from the plane.
+
+        If the `point` was constructed using the plane as origin,
+        return the relative coordinates from the `point` to the plane.
 
         A vector is calculated from the plane's `position`
-        to the external `point`, and this vector is projected into
-        each of the `u`, `v` and `axis` of the plane.
+        to the external `point`, and this vector is projected onto
+        each of the `u`, `v` and `axis` of the plane to determine
+        the local, relative vector.
 
         Parameters
         ----------
@@ -842,7 +846,35 @@ class plane:
         Returns
         -------
         Base::Vector3
-            The point projected on the plane.
+            The relative coordinates of the point from the plane.
+
+        See also
+        --------
+        getGlobalCoords
+
+        Notes
+        -----
+        The following graphic explains the coordinates.
+        ::
+                                  g GlobalCoords (1, 11)
+                                  |
+                                  |
+                                  |
+                              (n) p point (1, 6)
+                                  | LocalCoords (1, 1)
+                                  |
+            ----plane--------c-------- position (0, 5)
+
+        In the graphic
+
+            * `p` is an arbitrary point, external to the plane
+            * `c` is the plane's `position`
+            * `g` is the global coordinates of `p` when added to the plane
+            * `n` is the relative coordinates of `p` when referred to the plane
+
+        To do
+        -----
+        Maybe a better name would be getRelativeCoords?
         """
         pt = point.sub(self.position)
         xv = DraftVecUtils.project(pt, self.u)
@@ -863,7 +895,50 @@ class plane:
         return Vector(x, y, z)
 
     def getGlobalCoords(self, point):
-        "returns the global coordinates of the given point, taken relatively to this working plane"
+        """Return the coordinates of the given point, added to the plane.
+
+        If the `point` was constructed using the plane as origin,
+        return the absolute coordinates from the `point`
+        to the global origin.
+
+        The `u`, `v`, and `axis` vectors scale the components of `point`,
+        and the result is added to the planes `position`.
+
+        Parameters
+        ----------
+        point : Base::Vector3
+            The external point.
+
+        Returns
+        -------
+        Base::Vector3
+            The coordinates of the point from the absolute origin.
+
+        See also
+        --------
+        getLocalCoords
+
+        Notes
+        -----
+        The following graphic explains the coordinates.
+        ::
+                                  g GlobalCoords (1, 11)
+                                  |
+                                  |
+                                  |
+                              (n) p point (1, 6)
+                                  | LocalCoords (1, 1)
+                                  |
+            ----plane--------c-------- position (0, 5)
+
+        In the graphic
+
+            * `p` is an arbitrary point, external to the plane
+            * `c` is the plane's `position`
+            * `g` is the global coordinates of `p` when added to the plane
+            * `n` is the relative coordinates of `p` when referred to the plane
+
+        """
         vx = Vector(self.u).multiply(point.x)
         vy = Vector(self.v).multiply(point.y)
         vz = Vector(self.axis).multiply(point.z)

--- a/src/Mod/Draft/WorkingPlane.py
+++ b/src/Mod/Draft/WorkingPlane.py
@@ -509,7 +509,7 @@ class plane:
 
         Parameter
         --------
-        shape : Part.Shape
+        shape : Part.Face
             A shape of type `'Face'`.
 
         offset : float

--- a/src/Mod/Draft/WorkingPlane.py
+++ b/src/Mod/Draft/WorkingPlane.py
@@ -67,6 +67,24 @@ class plane:
     """
 
     def __init__(self, u=Vector(1, 0, 0), v=Vector(0, 1, 0), w=Vector(0, 0, 1), pos=Vector(0, 0, 0)):
+        """Initialize the working plane.
+
+        Parameters
+        ----------
+        u : Base::Vector3, optional
+            An axis (vector) that helps define the working plane.
+            It defaults to `(1, 0, 0)`, or the +X axis.
+        v : Base::Vector3, optional
+            An axis (vector) that helps define the working plane.
+            It defaults to `(0, 1, 0)`, or the +Y axis.
+        w : Base::Vector3, optional
+            An axis that is supposed to be perpendicular to `u` and `v`;
+            it is redundant.
+            It defaults to `(0, 0, 1)`, or the +Z axis.
+        pos : Base::Vector3, optional
+            The position of the working plane.
+            It defaults to the origin `(0, 0, 0)`.
+        """
         # keep track of active document.  Reset view when doc changes.
         self.doc = None
         self.weak = True

--- a/src/Mod/Draft/WorkingPlane.py
+++ b/src/Mod/Draft/WorkingPlane.py
@@ -1121,17 +1121,9 @@ class plane:
 def getPlacementFromPoints(points):
     """Return a placement from a list of 3 or 4 points.
 
-    With these points a temporary plane is defined.
-    The first point is the plane's `position`.
-    The other two points are used to define the `u` and `v` axes,
-    as originating from the first point.
+    With these points a temporary `plane` is defined.
 
-    If the fourth point exists, it is used to define the plane's `axis`
-    as originating from the first point.
-    If no fourth point is provided, the cross product bewtween the previously
-    defined `u` and `v` is used as `axis`.
-
-    Then it returns the `Base::Placement` returned from `getPlacement()`.
+    Then it returns the `Base::Placement` returned from `plane.getPlacement()`.
 
     Parameters
     ----------
@@ -1139,11 +1131,25 @@ def getPlacementFromPoints(points):
         A list with 3 or 4 points to create a temporary plane
         from which to extract the placement.
 
+        The first point is the plane's `position`.
+        The other two points are used to define the `u` and `v` axes,
+        as originating from the first point.
+
+        If the fourth point exists, it is used to define the plane's `axis`
+        as originating from the first point.
+        If no fourth point is provided, the cross product bewtween
+        the previously defined `u` and `v` is used as `axis`.
+
     Return
     ------
     Base::Placement
         A placement obtained from the temporary plane
-        defined by the points.
+        defined by `points`,
+        or `None` is it fails to use the points.
+
+    See also
+    --------
+    getPlacement
     """
     pl = plane()
     try:
@@ -1162,7 +1168,33 @@ def getPlacementFromPoints(points):
 
 
 def getPlacementFromFace(face, rotated=False):
-    "returns a placement from a face"
+    """Return a placement from a face.
+
+    It creates a temporary `plane` and uses `alignToFace(face)`
+    to set its orientation.
+
+    Then it returns the `Base::Placement` returned
+    from `plane.getPlacement(rotated)`.
+
+    Parameter
+    ---------
+    face : Part.Face
+        A shape of type `'Face'`.
+    rotated : bool, optional
+        It defaults to `False`. If it is `True`, the temporary plane
+        switches `axis` with `-v` to produce a rotated placement.
+
+    Returns
+    -------
+    Base::Placement
+        A placement obtained from the temporary plane
+        defined by `face`,
+        or `None` if it fails to use `face`.
+
+    See also
+    --------
+    alignToFace, getPlacement
+    """
     pl = plane()
     try:
         pl.alignToFace(face)

--- a/src/Mod/Draft/WorkingPlane.py
+++ b/src/Mod/Draft/WorkingPlane.py
@@ -1071,7 +1071,7 @@ class plane:
     def isOrtho(self):
         """Return True if the plane axes are orthogonal with the global axes.
 
-        Orthogonal means that the angle between `u` with the global `+X`
+        Orthogonal means that the angle between `u` and the global axis `+X`
         is a multiple of 90 degrees, meaning 0, -90, 90, -180, 180,
         -270, 270, or 360 degrees.
         And similarly for `v` and `axis` with `+Y` and `+Z`, respectively.
@@ -1080,8 +1080,8 @@ class plane:
         -------
         bool
             Returns `True` if all three `u`, `v`, and `axis`
-            are orthogonal with their respective
-            global axis `+X`, `+Y`, and `+Z`.
+            are orthogonal with their respective global axes `+X`, `+Y`,
+            and `+Z`.
             Otherwise it returns `False`.
         """
         if round(self.u.getAngle(Vector(0, 1, 0)), 6) in [0, -1.570796, 1.570796, -3.141593, 3.141593, -4.712389, 4.712389, 6.283185]:
@@ -1091,7 +1091,25 @@ class plane:
         return False
 
     def getDeviation(self):
-        "returns the deviation angle between the u axis and the horizontal plane"
+        """Return the angle between the u axis and the horizontal plane.
+
+        It defines a projection of `u` on the horizontal plane
+        (without a Z component), and then measures the angle between
+        this projection and `u`.
+
+        It also considers the cross product of the projection
+        and `u` to determine the sign of the angle.
+
+        Returns
+        -------
+        float
+            Angle between the `u` vector, and a projected vector
+            on the global horizontal plane.
+
+        See also
+        --------
+        DraftVecUtils.angle
+        """
         proj = Vector(self.u.x, self.u.y, 0)
         if self.u.getAngle(proj) == 0:
             return 0

--- a/src/Mod/Draft/WorkingPlane.py
+++ b/src/Mod/Draft/WorkingPlane.py
@@ -202,7 +202,24 @@ class plane:
         return direction.dot(self.position.sub(p))
 
     def projectPoint(self, p, direction=None):
-        '''project point onto plane, default direction is orthogonal'''
+        """Project a point onto the plane, by default orthogonally.
+
+        Parameters
+        ----------
+        p : Base::Vector3
+            The point to project.
+        direction : Base::Vector3, optional
+            The unit vector that indicates the direction of projection.
+
+            It defaults to `None`, which then uses the `plane.axis` (normal)
+            value, meaning that the point is projected perpendicularly
+            to the plane.
+
+        Returns
+        -------
+        Base::Vector3
+            The projected vector, scaled to the appropriate distance.
+        """
         if not direction:
             direction = self.axis
         lp = self.getLocalCoords(p)
@@ -217,7 +234,26 @@ class plane:
         return gp.add(DraftVecUtils.scaleTo(gd, hyp))
 
     def projectPointOld(self, p, direction=None):
-        '''project point onto plane, default direction is orthogonal. Obsolete'''
+        """Project a point onto the plane. OBSOLETE.
+
+        Parameters
+        ----------
+        p : Base::Vector3
+            The point to project.
+        direction : Base::Vector3, optional
+            The unit vector that indicates the direction of projection.
+
+            It defaults to `None`, which then uses the `plane.axis` (normal)
+            value, meaning that the point is projected perpendicularly
+            to the plane.
+
+        Returns
+        -------
+        Base::Vector3
+            The projected point,
+            or the original point if the angle between the `direction`
+            and the `plane.axis` is 90 degrees.
+        """
         if not direction:
             direction = self.axis
         t = Vector(direction)

--- a/src/Mod/Draft/WorkingPlane.py
+++ b/src/Mod/Draft/WorkingPlane.py
@@ -115,8 +115,8 @@ class plane:
             direction = self.axis
         t = Vector(direction)
         #t.normalize()
-        a = round(t.getAngle(self.axis),DraftVecUtils.precision())
-        pp = round((math.pi)/2,DraftVecUtils.precision())
+        a = round(t.getAngle(self.axis), DraftVecUtils.precision())
+        pp = round((math.pi)/2, DraftVecUtils.precision())
         if a == pp:
             return p
         t.multiply(self.offsetToPoint(p, direction))
@@ -126,20 +126,20 @@ class plane:
         self.doc = FreeCAD.ActiveDocument
         self.axis = axis
         self.axis.normalize()
-        if axis.getAngle(Vector(1,0,0)) < 0.00001:
-            self.axis = Vector(1,0,0)
-            self.u = Vector(0,1,0)
-            self.v = Vector(0,0,1)
-        elif axis.getAngle(Vector(-1,0,0)) < 0.00001:
-            self.axis = Vector(-1,0,0)
-            self.u = Vector(0,-1,0)
-            self.v = Vector(0,0,1)
+        if axis.getAngle(Vector(1, 0, 0)) < 0.00001:
+            self.axis = Vector(1, 0, 0)
+            self.u = Vector(0, 1, 0)
+            self.v = Vector(0, 0, 1)
+        elif axis.getAngle(Vector(-1, 0, 0)) < 0.00001:
+            self.axis = Vector(-1, 0, 0)
+            self.u = Vector(0, -1, 0)
+            self.v = Vector(0, 0, 1)
         elif upvec:
             self.v = upvec
             self.v.normalize()
             self.u = self.v.cross(self.axis)
         else:
-            self.v = axis.cross(Vector(1,0,0))
+            self.v = axis.cross(Vector(1, 0, 0))
             self.v.normalize()
             self.u = DraftVecUtils.rotate(self.v, -math.pi/2, self.axis)
         offsetVector = Vector(axis); offsetVector.multiply(offset)
@@ -218,7 +218,7 @@ class plane:
         else:
             return False
 
-    def alignToEdges(self,edges):
+    def alignToEdges(self, edges):
         # use a list of edges to find a plane position
         if len(edges) > 2:
             return False

--- a/src/Mod/Draft/WorkingPlane.py
+++ b/src/Mod/Draft/WorkingPlane.py
@@ -1,25 +1,38 @@
-#***************************************************************************
-#*                                                                         *
-#*   Copyright (c) 2009, 2010                                              *
-#*   Ken Cline <cline@frii.com>                                            *
-#*                                                                         *
-#*   This program is free software; you can redistribute it and/or modify  *
-#*   it under the terms of the GNU Lesser General Public License (LGPL)    *
-#*   as published by the Free Software Foundation; either version 2 of     *
-#*   the License, or (at your option) any later version.                   *
-#*   for detail see the LICENCE text file.                                 *
-#*                                                                         *
-#*   This program is distributed in the hope that it will be useful,       *
-#*   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
-#*   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
-#*   GNU Library General Public License for more details.                  *
-#*                                                                         *
-#*   You should have received a copy of the GNU Library General Public     *
-#*   License along with this program; if not, write to the Free Software   *
-#*   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
-#*   USA                                                                   *
-#*                                                                         *
-#***************************************************************************
+## @package WorkingPlane
+#  \ingroup DRAFT
+#  \brief This module handles the Working Plane and grid of the Draft module.
+#
+#  This module provides the plane class which provides a virtual working plane
+#  in FreeCAD and a couple of utility functions.
+"""
+This module provides the plane class which provides a virtual working plane
+in FreeCAD and a couple of utility functions.
+The Working Plane is mostly intended to be used in the Draft Workbench
+to draw 2D objects.
+"""
+
+# ***************************************************************************
+# *                                                                         *
+# *   Copyright (c) 2009, 2010                                              *
+# *   Ken Cline <cline@frii.com>                                            *
+# *                                                                         *
+# *   This program is free software; you can redistribute it and/or modify  *
+# *   it under the terms of the GNU Lesser General Public License (LGPL)    *
+# *   as published by the Free Software Foundation; either version 2 of     *
+# *   the License, or (at your option) any later version.                   *
+# *   for detail see the LICENCE text file.                                 *
+# *                                                                         *
+# *   This program is distributed in the hope that it will be useful,       *
+# *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+# *   GNU Library General Public License for more details.                  *
+# *                                                                         *
+# *   You should have received a copy of the GNU Library General Public     *
+# *   License along with this program; if not, write to the Free Software   *
+# *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
+# *   USA                                                                   *
+# *                                                                         *
+# ***************************************************************************
 
 
 import FreeCAD, math, DraftVecUtils
@@ -29,16 +42,6 @@ __title__ = "FreeCAD Working Plane utility"
 __author__ = "Ken Cline"
 __url__ = "http://www.freecadweb.org"
 
-## @package WorkingPlane
-#  \ingroup DRAFT
-#  \brief This module handles the Working Plane and grid of the Draft module.
-#
-#  This module contains the plane class which provides a virtual plane in FreeCAD
-#  and a couple of utility functions
-
-'''
-This module provides a class called plane to assist in selecting and maintaining a working plane.
-'''
 
 class plane:
     '''A WorkPlane object'''

--- a/src/Mod/Draft/WorkingPlane.py
+++ b/src/Mod/Draft/WorkingPlane.py
@@ -769,14 +769,33 @@ class plane:
         return n
 
     def setFromPlacement(self, pl, rebase=False):
-        "sets the working plane from a placement (rotaton ONLY, unless rebase=True)"
+        """Set the plane from a placement.
+
+        It normally uses only the rotation, unless `rebase` is `True`.
+
+        Parameters
+        ----------
+        pl : Base::Placement or Base::Matrix4D
+            A placement, comprised of a `Base` (`Base::Vector3`),
+            and a `Rotation` (`Base::Rotation`),
+            or a `Base::Matrix4D` that defines a placement.
+        rebase : bool, optional
+            It defaults to `False`.
+            If `True`, it will use `pl.Base` as the new `position`
+            of the plane. Otherwise it will only consider `pl.Rotation`.
+
+        To do
+        -----
+        If `pl` is a `Base::Matrix4D`, it shouldn't try to use `pl.Base`
+        because a matrix has no `Base`.
+        """
         rot = FreeCAD.Placement(pl).Rotation
         self.u = rot.multVec(FreeCAD.Vector(1, 0, 0))
         self.v = rot.multVec(FreeCAD.Vector(0, 1, 0))
         self.axis = rot.multVec(FreeCAD.Vector(0, 0, 1))
         if rebase:
             self.position = pl.Base
-
+            
     def inverse(self):
         "inverts the direction of the working plane"
         self.u = self.u.negative()

--- a/src/Mod/Draft/WorkingPlane.py
+++ b/src/Mod/Draft/WorkingPlane.py
@@ -701,8 +701,8 @@ class plane:
         Returns
         -------
         Base::Placement
-            A placement, comprised of a basepoint `Base::Vector3`,
-            and a rotation `Base::Rotation`.
+            A placement, comprised of a `Base` (`Base::Vector3`),
+            and a `Rotation` (`Base::Rotation`).
         """
         m = DraftVecUtils.getPlaneRotation(self.u, self.v, self.axis)
         p = FreeCAD.Placement(m)
@@ -723,6 +723,12 @@ class plane:
         rotated : bool, optional
             It defaults to `False`. If it is `True`, it switches `axis`
             with `-v` to produce a rotated placement.
+
+        Returns
+        -------
+        Base::Placement
+            A placement, comprised of a `Base` (`Base::Vector3`),
+            and a `Rotation` (`Base::Rotation`).
         """
         if rotated:
             m = FreeCAD.Matrix(

--- a/src/Mod/Draft/WorkingPlane.py
+++ b/src/Mod/Draft/WorkingPlane.py
@@ -439,7 +439,7 @@ class plane:
         ----------
         shape : Part.Shape
             A curve that will serve to align the plane.
-            It can be an `Edge` or `Wire`.
+            It can be an `'Edge'` or `'Wire'`.
         offset : float
             Defaults to zero. A value which will be used to offset
             the plane in the direction of its `axis`.
@@ -462,6 +462,23 @@ class plane:
             return False
 
     def alignToEdges(self, edges):
+        """Align plane to two edges.
+
+        Uses the two points of the first edge to define the direction
+        of the unit vector `u`, the other two points of the other edge
+        to define the other unit vector `v`, and then the cross product
+        of `u` with `v` to define the `axis`.
+
+        Parameters
+        ----------
+        edges : list
+            A list of two edges.
+
+        Returns
+        -------
+        False
+            Return `False` if `edges` is a list of more than 2 elements.
+        """
         # use a list of edges to find a plane position
         if len(edges) > 2:
             return False
@@ -479,6 +496,36 @@ class plane:
         self.axis = v3
 
     def alignToFace(self, shape, offset=0):
+        """Align the plane to a face.
+
+        It uses the center of mass of the face as `position`,
+        and its normal in the center of the face as `axis`,
+        then calls `alignToPointAndAxis(position, axis, offset)`.
+
+        If the face is a quadrilateral, then it adjusts the position
+        of the plane according to its reported X direction and Y direction.
+
+        Also set `weak` to `False`.
+
+        Parameter
+        --------
+        shape : Part.Shape
+            A shape of type `'Face'`.
+
+        offset : float
+            Defaults to zero. A value which will be used to offset
+            the plane in the direction of its `axis`.
+
+        Returns
+        -------
+        bool
+            `True` if the operation was succesful, and `False` if the shape
+            is not a `'Face'`.
+
+        See Also
+        --------
+        alignToPointAndAxis, DraftGeomUtils.getQuad
+        """
         # Set face to the unique selected face, if found
         if shape.ShapeType == 'Face':
             self.alignToPointAndAxis(shape.Faces[0].CenterOfMass, shape.Faces[0].normalAt(0, 0), offset)

--- a/src/Mod/Draft/WorkingPlane.py
+++ b/src/Mod/Draft/WorkingPlane.py
@@ -476,15 +476,15 @@ def getPlacementFromPoints(points):
     "returns a placement from a list of 3 or 4 vectors"
     pl = plane()
     try:
-            pl.position = points[0]
-            pl.u = (points[1].sub(points[0]).normalize())
-            pl.v = (points[2].sub(points[0]).normalize())
-            if len(points) == 4:
-                pl.axis = (points[3].sub(points[0]).normalize())
-            else:
-                pl.axis = ((pl.u).cross(pl.v)).normalize()
+        pl.position = points[0]
+        pl.u = (points[1].sub(points[0]).normalize())
+        pl.v = (points[2].sub(points[0]).normalize())
+        if len(points) == 4:
+            pl.axis = (points[3].sub(points[0]).normalize())
+        else:
+            pl.axis = ((pl.u).cross(pl.v)).normalize()
     except:
-            return None
+        return None
     p = pl.getPlacement()
     del pl
     return p

--- a/src/Mod/Draft/WorkingPlane.py
+++ b/src/Mod/Draft/WorkingPlane.py
@@ -25,7 +25,7 @@
 import FreeCAD, math, DraftVecUtils
 from FreeCAD import Vector
 
-__title__="FreeCAD Working Plane utility"
+__title__ = "FreeCAD Working Plane utility"
 __author__ = "Ken Cline"
 __url__ = "http://www.freecadweb.org"
 
@@ -43,7 +43,7 @@ This module provides a class called plane to assist in selecting and maintaining
 class plane:
     '''A WorkPlane object'''
 
-    def __init__(self,u=Vector(1,0,0),v=Vector(0,1,0),w=Vector(0,0,1),pos=Vector(0,0,0)):
+    def __init__(self, u=Vector(1, 0, 0), v=Vector(0, 1, 0), w=Vector(0, 0, 1), pos=Vector(0, 0, 0)):
         # keep track of active document.  Reset view when doc changes.
         self.doc = None
         # self.weak is true if the plane has been defined by self.setup or has been reset
@@ -60,7 +60,7 @@ class plane:
         return "Workplane x="+str(DraftVecUtils.rounded(self.u))+" y="+str(DraftVecUtils.rounded(self.v))+" z="+str(DraftVecUtils.rounded(self.axis))
 
     def copy(self):
-        return plane(u=self.u,v=self.v,w=self.axis,pos=self.position)
+        return plane(u=self.u, v=self.v, w=self.axis, pos=self.position)
 
     def offsetToPoint(self, p, direction=None):
         '''
@@ -99,15 +99,15 @@ class plane:
         if not direction:
             direction = self.axis
         lp = self.getLocalCoords(p)
-        gp = self.getGlobalCoords(Vector(lp.x,lp.y,0))
+        gp = self.getGlobalCoords(Vector(lp.x, lp.y, 0))
         a = direction.getAngle(gp.sub(p))
         if a > math.pi/2:
             direction = direction.negative()
             a = math.pi - a
         ld = self.getLocalRot(direction)
-        gd = self.getGlobalRot(Vector(ld.x,ld.y,0))
+        gd = self.getGlobalRot(Vector(ld.x, ld.y, 0))
         hyp = abs(math.tan(a) * lp.z)
-        return gp.add(DraftVecUtils.scaleTo(gd,hyp))
+        return gp.add(DraftVecUtils.scaleTo(gd, hyp))
                 
     def projectPointOld(self, p, direction=None):
         '''project point onto plane, default direction is orthogonal. Obsolete'''

--- a/src/Mod/Draft/WorkingPlane.py
+++ b/src/Mod/Draft/WorkingPlane.py
@@ -238,31 +238,31 @@ class plane:
     def alignToFace(self, shape, offset=0):
         # Set face to the unique selected face, if found
         if shape.ShapeType == 'Face':
-            self.alignToPointAndAxis(shape.Faces[0].CenterOfMass, shape.Faces[0].normalAt(0,0), offset)
+            self.alignToPointAndAxis(shape.Faces[0].CenterOfMass, shape.Faces[0].normalAt(0, 0), offset)
             import DraftGeomUtils
             q = DraftGeomUtils.getQuad(shape)
             if q:
                 self.u = q[1]
                 self.v = q[2]
-                if not DraftVecUtils.equals(self.u.cross(self.v),self.axis):
+                if not DraftVecUtils.equals(self.u.cross(self.v), self.axis):
                     self.u = q[2]
                     self.v = q[1]
-                if DraftVecUtils.equals(self.u,Vector(0,0,1)):
+                if DraftVecUtils.equals(self.u, Vector(0, 0, 1)):
                     # the X axis is vertical: rotate 90 degrees
-                    self.u,self.v = self.v.negative(),self.u
-                elif DraftVecUtils.equals(self.u,Vector(0,0,-1)):
-                    self.u,self.v = self.v,self.u.negative()
+                    self.u, self.v = self.v.negative(), self.u
+                elif DraftVecUtils.equals(self.u, Vector(0, 0, -1)):
+                    self.u, self.v = self.v, self.u.negative()
                     
             self.weak = False
             return True
         else:
             return False
 
-    def alignTo3Points(self,p1,p2,p3,offset=0):
+    def alignTo3Points(self, p1, p2, p3, offset=0):
         import Part
-        w = Part.makePolygon([p1,p2,p3,p1])
+        w = Part.makePolygon([p1, p2, p3, p1])
         f = Part.Face(w)
-        return self.alignToFace(f,offset)
+        return self.alignToFace(f, offset)
 
     def alignToSelection(self, offset):
         '''If selection uniquely defines a plane, align working plane to it.  Return success (bool)'''
@@ -291,11 +291,11 @@ class plane:
                     import FreeCADGui
                     from pivy import coin
                     rot = FreeCADGui.ActiveDocument.ActiveView.getCameraNode().getField("orientation").getValue()
-                    upvec = Vector(rot.multVec(coin.SbVec3f(0,1,0)).getValue())
+                    upvec = Vector(rot.multVec(coin.SbVec3f(0, 1, 0)).getValue())
                     vdir = FreeCADGui.ActiveDocument.ActiveView.getViewDirection()
                     if (vdir.getAngle(self.axis) > 0.001) and (vdir.getAngle(self.axis) < 3.14159):
                         # don't change the WP if it is already perpendicular to the current view
-                        self.alignToPointAndAxis(Vector(0,0,0), vdir.negative(), 0, upvec)
+                        self.alignToPointAndAxis(Vector(0, 0, 0), vdir.negative(), 0, upvec)
                 except:
                     pass
             self.weak = True
@@ -306,7 +306,7 @@ class plane:
 
     def getRotation(self):
         "returns a placement describing the working plane orientation ONLY"
-        m = DraftVecUtils.getPlaneRotation(self.u,self.v,self.axis)
+        m = DraftVecUtils.getPlaneRotation(self.u, self.v, self.axis)
         p = FreeCAD.Placement(m)
         # Arch active container
         if FreeCAD.GuiUp:
@@ -317,20 +317,20 @@ class plane:
                     p = a.Placement.inverse().multiply(p)
         return p
 
-    def getPlacement(self,rotated=False):
+    def getPlacement(self, rotated=False):
         "returns the placement of the working plane"
         if rotated:
             m = FreeCAD.Matrix(
-                self.u.x,self.axis.x,-self.v.x,self.position.x,
-                self.u.y,self.axis.y,-self.v.y,self.position.y,
-                self.u.z,self.axis.z,-self.v.z,self.position.z,
-                0.0,0.0,0.0,1.0)
+                self.u.x, self.axis.x, -self.v.x, self.position.x,
+                self.u.y, self.axis.y, -self.v.y, self.position.y,
+                self.u.z, self.axis.z, -self.v.z, self.position.z,
+                0.0, 0.0, 0.0, 1.0)
         else:
             m = FreeCAD.Matrix(
-                self.u.x,self.v.x,self.axis.x,self.position.x,
-                self.u.y,self.v.y,self.axis.y,self.position.y,
-                self.u.z,self.v.z,self.axis.z,self.position.z,
-                0.0,0.0,0.0,1.0)
+                self.u.x, self.v.x, self.axis.x, self.position.x,
+                self.u.y, self.v.y, self.axis.y, self.position.y,
+                self.u.z, self.v.z, self.axis.z, self.position.z,
+                0.0, 0.0, 0.0, 1.0)
         p = FreeCAD.Placement(m)
         # Arch active container if based on App Part
         #if FreeCAD.GuiUp:
@@ -350,7 +350,7 @@ class plane:
         #        n = a.Placement.inverse().Rotation.multVec(n)
         return n
 
-    def setFromPlacement(self,pl,rebase=False):
+    def setFromPlacement(self, pl, rebase=False):
         "sets the working plane from a placement (rotaton ONLY, unless rebase=True)"
         rot = FreeCAD.Placement(pl).Rotation
         self.u = rot.multVec(FreeCAD.Vector(1,0,0))

--- a/src/Mod/Draft/WorkingPlane.py
+++ b/src/Mod/Draft/WorkingPlane.py
@@ -633,7 +633,36 @@ class plane:
             return False
 
     def setup(self, direction=None, point=None, upvec=None):
-        '''If working plane is undefined, define it!'''
+        """Setup the working plane if it exists but is undefined.
+
+        If `direction` and `point` are present,
+        it calls `alignToPointAndAxis(point, direction, 0, upvec)`.
+
+        Otherwise, it gets the camera orientation to define
+        a working plane that is perpendicular to the current view,
+        centered at the origin, and with `v` pointing up on the screen.
+
+        This method only works when the `weak` attribute is `True`.
+        This method also sets `weak` to `True`.
+
+        This method only works when `FreeCAD.GuiUp` is `True`,
+        that is, when the graphical interface is loaded.
+        Otherwise it fails silently.
+
+        Parameters
+        ----------
+        direction : Base::Vector3, optional
+            It defaults to `None`. It is the new `axis` of the plane.
+        point : Base::Vector3, optional
+            It defaults to `None`. It is the new `position` of the plane.
+        upvec : Base::Vector3, optional
+            It defaults to `None`. It is the new `v` orientation of the plane.
+
+        To do
+        -----
+        It should fail loudly, with a message at least
+        `FreeCAD.Console.PrintError()`.
+        """
         if self.weak:
             if direction and point:
                 self.alignToPointAndAxis(point, direction, 0, upvec)

--- a/src/Mod/Draft/WorkingPlane.py
+++ b/src/Mod/Draft/WorkingPlane.py
@@ -692,7 +692,18 @@ class plane:
         self.weak = True
 
     def getRotation(self):
-        "returns a placement describing the working plane orientation ONLY"
+        """Return a placement describing the plane orientation only.
+
+        If `FreeCAD.GuiUp` is `True`, that is, if the graphical interface
+        is loaded, it will test if the active object is an `Arch` container
+        and will calculate the placement accordingly.
+
+        Returns
+        -------
+        Base::Placement
+            A placement, comprised of a basepoint `Base::Vector3`,
+            and a rotation `Base::Rotation`.
+        """
         m = DraftVecUtils.getPlaneRotation(self.u, self.v, self.axis)
         p = FreeCAD.Placement(m)
         # Arch active container
@@ -705,7 +716,14 @@ class plane:
         return p
 
     def getPlacement(self, rotated=False):
-        "returns the placement of the working plane"
+        """Return the placement of the plane.
+
+        Parameters
+        ----------
+        rotated : bool, optional
+            It defaults to `False`. If it is `True`, it switches `axis`
+            with `-v` to produce a rotated placement.
+        """
         if rotated:
             m = FreeCAD.Matrix(
                 self.u.x, self.axis.x, -self.v.x, self.position.x,

--- a/src/Mod/Draft/WorkingPlane.py
+++ b/src/Mod/Draft/WorkingPlane.py
@@ -1069,7 +1069,21 @@ class plane:
         return True
 
     def isOrtho(self):
-        "returns True if the plane axes are following the global axes"
+        """Return True if the plane axes are orthogonal with the global axes.
+
+        Orthogonal means that the angle between `u` with the global `+X`
+        is a multiple of 90 degrees, meaning 0, -90, 90, -180, 180,
+        -270, 270, or 360 degrees.
+        And similarly for `v` and `axis` with `+Y` and `+Z`, respectively.
+
+        Returns
+        -------
+        bool
+            Returns `True` if all three `u`, `v`, and `axis`
+            are orthogonal with their respective
+            global axis `+X`, `+Y`, and `+Z`.
+            Otherwise it returns `False`.
+        """
         if round(self.u.getAngle(Vector(0, 1, 0)), 6) in [0, -1.570796, 1.570796, -3.141593, 3.141593, -4.712389, 4.712389, 6.283185]:
             if round(self.v.getAngle(Vector(0, 1, 0)), 6) in [0, -1.570796, 1.570796, -3.141593, 3.141593, -4.712389, 4.712389, 6.283185]:
                 if round(self.axis.getAngle(Vector(0, 1, 0)), 6) in [0, -1.570796, 1.570796, -3.141593, 3.141593, -4.712389, 4.712389, 6.283185]:

--- a/src/Mod/Draft/WorkingPlane.py
+++ b/src/Mod/Draft/WorkingPlane.py
@@ -752,6 +752,13 @@ class plane:
         return p
 
     def getNormal(self):
+        """Return the normal vector of the plane (axis).
+
+        Returns
+        -------
+        Base::Vector3
+            The `axis` attribute of the plane.
+        """
         n = self.axis
         # Arch active container if based on App Part
         #if FreeCAD.GuiUp:

--- a/src/Mod/Draft/WorkingPlane.py
+++ b/src/Mod/Draft/WorkingPlane.py
@@ -813,6 +813,11 @@ class plane:
         self.stored = [self.u, self.v, self.axis, self.position, self.weak]
 
     def restore(self):
+        """Restore the plane attributes that were saved.
+
+        Restores the attributes `u`, `v`, `axis`, `position` and `weak`
+        from `stored`, and set `stored` to `None`.
+        """
         "restores a previously saved plane state, if exists"
         if self.stored:
             self.u = self.stored[0]

--- a/src/Mod/Draft/WorkingPlane.py
+++ b/src/Mod/Draft/WorkingPlane.py
@@ -432,8 +432,24 @@ class plane:
         # FreeCAD.Console.PrintMessage("(position = " + str(self.position) + ")\n")
         # FreeCAD.Console.PrintMessage("Current workplane: x="+str(DraftVecUtils.rounded(self.u))+" y="+str(DraftVecUtils.rounded(self.v))+" z="+str(DraftVecUtils.rounded(self.axis))+"\n")
 
+    def alignToCurve(self, shape, offset=0):
+        """Align plane to curve. NOT YET IMPLEMENTED.
 
-    def alignToCurve(self, shape, offset):
+        Parameters
+        ----------
+        shape : Part.Shape
+            A curve that will serve to align the plane.
+            It can be an `Edge` or `Wire`.
+        offset : float
+            Defaults to zero. A value which will be used to offset
+            the plane in the direction of its `axis`.
+
+        Returns
+        -------
+        False
+            Returns `False` if the shape is null.
+            Currently it always returns `False`.
+        """
         if shape.isNull():
             return False
         elif shape.ShapeType == 'Edge':

--- a/src/Mod/Draft/WorkingPlane.py
+++ b/src/Mod/Draft/WorkingPlane.py
@@ -585,6 +585,9 @@ class plane:
         It extracts the shape of the object or subobject
         and then calls `alignToFace(shape, offset)`.
 
+        This method only works when the `FreeCADGui.Selection`
+        class is available, that is, when the graphical interface is loaded.
+
         Parameter
         ---------
         offset : float

--- a/src/Mod/Draft/WorkingPlane.py
+++ b/src/Mod/Draft/WorkingPlane.py
@@ -828,10 +828,28 @@ class plane:
             self.stored = None
 
     def getLocalCoords(self, point):
-        "returns the coordinates of a given point on the working plane"
+        """Return the coordinates of a given point projected on the plane.
+
+        A vector is calculated from the plane's `position`
+        to the external `point`, and this vector is projected into
+        each of the `u`, `v` and `axis` of the plane.
+
+        Parameters
+        ----------
+        point : Base::Vector3
+            The point external to the plane.
+
+        Returns
+        -------
+        Base::Vector3
+            The point projected on the plane.
+        """
         pt = point.sub(self.position)
         xv = DraftVecUtils.project(pt, self.u)
         x = xv.Length
+        # If the angle between the projection xv and u
+        # is larger than 1 radian (57.29 degrees), use the negative
+        # of the magnitude. Why exactly 1 radian?
         if xv.getAngle(self.u) > 1:
             x = -x
         yv = DraftVecUtils.project(pt, self.v)

--- a/src/Mod/Draft/WorkingPlane.py
+++ b/src/Mod/Draft/WorkingPlane.py
@@ -124,7 +124,7 @@ class plane:
 
     def alignToPointAndAxis(self, point, axis, offset=0, upvec=None):
         self.doc = FreeCAD.ActiveDocument
-        self.axis = axis;
+        self.axis = axis
         self.axis.normalize()
         if axis.getAngle(Vector(1,0,0)) < 0.00001:
             self.axis = Vector(1,0,0)
@@ -151,7 +151,7 @@ class plane:
     def alignToPointAndAxis_SVG(self, point, axis, offset):
         # based on cases table
         self.doc = FreeCAD.ActiveDocument
-        self.axis = axis;
+        self.axis = axis
         self.axis.normalize()
         ref_vec = Vector(0.0, 1.0, 0.0)
 
@@ -384,15 +384,15 @@ class plane:
         xv = DraftVecUtils.project(pt,self.u)
         x = xv.Length
         if xv.getAngle(self.u) > 1:
-                x = -x
+            x = -x
         yv = DraftVecUtils.project(pt,self.v)
         y = yv.Length
         if yv.getAngle(self.v) > 1:
-                y = -y
+            y = -y
         zv = DraftVecUtils.project(pt,self.axis)
         z = zv.Length
         if zv.getAngle(self.axis) > 1:
-                z = -z
+            z = -z
         return Vector(x,y,z)
 
     def getGlobalCoords(self,point):
@@ -408,15 +408,15 @@ class plane:
         xv = DraftVecUtils.project(point,self.u)
         x = xv.Length
         if xv.getAngle(self.u) > 1:
-                x = -x
+            x = -x
         yv = DraftVecUtils.project(point,self.v)
         y = yv.Length
         if yv.getAngle(self.v) > 1:
-                y = -y
+            y = -y
         zv = DraftVecUtils.project(point,self.axis)
         z = zv.Length
         if zv.getAngle(self.axis) > 1:
-                z = -z
+            z = -z
         return Vector(x,y,z)
 
     def getGlobalRot(self,point):
@@ -480,9 +480,9 @@ def getPlacementFromPoints(points):
             pl.u = (points[1].sub(points[0]).normalize())
             pl.v = (points[2].sub(points[0]).normalize())
             if len(points) == 4:
-                    pl.axis = (points[3].sub(points[0]).normalize())
+                pl.axis = (points[3].sub(points[0]).normalize())
             else:
-                    pl.axis = ((pl.u).cross(pl.v)).normalize()
+                pl.axis = ((pl.u).cross(pl.v)).normalize()
     except:
             return None
     p = pl.getPlacement()

--- a/src/Mod/Draft/WorkingPlane.py
+++ b/src/Mod/Draft/WorkingPlane.py
@@ -353,9 +353,9 @@ class plane:
     def setFromPlacement(self, pl, rebase=False):
         "sets the working plane from a placement (rotaton ONLY, unless rebase=True)"
         rot = FreeCAD.Placement(pl).Rotation
-        self.u = rot.multVec(FreeCAD.Vector(1,0,0))
-        self.v = rot.multVec(FreeCAD.Vector(0,1,0))
-        self.axis = rot.multVec(FreeCAD.Vector(0,0,1))
+        self.u = rot.multVec(FreeCAD.Vector(1, 0, 0))
+        self.v = rot.multVec(FreeCAD.Vector(0, 1, 0))
+        self.axis = rot.multVec(FreeCAD.Vector(0, 0, 1))
         if rebase:
             self.position = pl.Base
         
@@ -366,7 +366,7 @@ class plane:
 
     def save(self):
         "stores the current plane state"
-        self.stored = [self.u,self.v,self.axis,self.position,self.weak]
+        self.stored = [self.u, self.v, self.axis, self.position, self.weak]
 
     def restore(self):
         "restores a previously saved plane state, if exists"
@@ -378,24 +378,24 @@ class plane:
             self.weak = self.stored[4]
             self.stored = None
 
-    def getLocalCoords(self,point):
+    def getLocalCoords(self, point):
         "returns the coordinates of a given point on the working plane"
         pt = point.sub(self.position)
-        xv = DraftVecUtils.project(pt,self.u)
+        xv = DraftVecUtils.project(pt, self.u)
         x = xv.Length
         if xv.getAngle(self.u) > 1:
             x = -x
-        yv = DraftVecUtils.project(pt,self.v)
+        yv = DraftVecUtils.project(pt, self.v)
         y = yv.Length
         if yv.getAngle(self.v) > 1:
             y = -y
-        zv = DraftVecUtils.project(pt,self.axis)
+        zv = DraftVecUtils.project(pt, self.axis)
         z = zv.Length
         if zv.getAngle(self.axis) > 1:
             z = -z
-        return Vector(x,y,z)
+        return Vector(x, y, z)
 
-    def getGlobalCoords(self,point):
+    def getGlobalCoords(self, point):
         "returns the global coordinates of the given point, taken relatively to this working plane"
         vx = Vector(self.u).multiply(point.x)
         vy = Vector(self.v).multiply(point.y)
@@ -403,23 +403,23 @@ class plane:
         pt = (vx.add(vy)).add(vz)
         return pt.add(self.position)
 
-    def getLocalRot(self,point):
+    def getLocalRot(self, point):
         "Same as getLocalCoords, but discards the WP position"
-        xv = DraftVecUtils.project(point,self.u)
+        xv = DraftVecUtils.project(point, self.u)
         x = xv.Length
         if xv.getAngle(self.u) > 1:
             x = -x
-        yv = DraftVecUtils.project(point,self.v)
+        yv = DraftVecUtils.project(point, self.v)
         y = yv.Length
         if yv.getAngle(self.v) > 1:
             y = -y
-        zv = DraftVecUtils.project(point,self.axis)
+        zv = DraftVecUtils.project(point, self.axis)
         z = zv.Length
         if zv.getAngle(self.axis) > 1:
             z = -z
-        return Vector(x,y,z)
+        return Vector(x, y, z)
 
-    def getGlobalRot(self,point):
+    def getGlobalRot(self, point):
         "Same as getGlobalCoords, but discards the WP position"
         vx = Vector(self.u).multiply(point.x)
         vy = Vector(self.v).multiply(point.y)
@@ -427,7 +427,7 @@ class plane:
         pt = (vx.add(vy)).add(vz)
         return pt
         
-    def getClosestAxis(self,point):
+    def getClosestAxis(self, point):
         "returns which of the workingplane axes is closest from the given vector"
         ax = point.getAngle(self.u)
         ay = point.getAngle(self.v)
@@ -435,42 +435,42 @@ class plane:
         bx = point.getAngle(self.u.negative())
         by = point.getAngle(self.v.negative())
         bz = point.getAngle(self.axis.negative())
-        b = min(ax,ay,az,bx,by,bz)
-        if b in [ax,bx]:
+        b = min(ax, ay, az, bx, by, bz)
+        if b in [ax, bx]:
             return "x"
-        elif b in [ay,by]:
+        elif b in [ay, by]:
             return "y"
-        elif b in [az,bz]:
+        elif b in [az, bz]:
             return "z"
         else:
             return None
             
     def isGlobal(self):
         "returns True if the plane axes are equal to the global axes"
-        if self.u != Vector(1,0,0):
+        if self.u != Vector(1, 0, 0):
             return False
-        if self.v != Vector(0,1,0):
+        if self.v != Vector(0, 1, 0):
             return False
-        if self.axis != Vector(0,0,1):
+        if self.axis != Vector(0, 0, 1):
             return False
         return True
         
     def isOrtho(self):
         "returns True if the plane axes are following the global axes"
-        if round(self.u.getAngle(Vector(0,1,0)),6) in [0,-1.570796,1.570796,-3.141593,3.141593,-4.712389,4.712389,6.283185]:
-            if round(self.v.getAngle(Vector(0,1,0)),6) in [0,-1.570796,1.570796,-3.141593,3.141593,-4.712389,4.712389,6.283185]:
-                if round(self.axis.getAngle(Vector(0,1,0)),6) in [0,-1.570796,1.570796,-3.141593,3.141593,-4.712389,4.712389,6.283185]:
+        if round(self.u.getAngle(Vector(0, 1, 0)), 6) in [0, -1.570796, 1.570796, -3.141593, 3.141593, -4.712389, 4.712389, 6.283185]:
+            if round(self.v.getAngle(Vector(0,1,0)),6) in [0, -1.570796, 1.570796, -3.141593, 3.141593, -4.712389, 4.712389, 6.283185]:
+                if round(self.axis.getAngle(Vector(0,1,0)),6) in [0, -1.570796, 1.570796, -3.141593, 3.141593, -4.712389, 4.712389, 6.283185]:
                     return True
         return False
         
     def getDeviation(self):
         "returns the deviation angle between the u axis and the horizontal plane"
-        proj = Vector(self.u.x,self.u.y,0)
+        proj = Vector(self.u.x, self.u.y, 0)
         if self.u.getAngle(proj) == 0:
             return 0
         else:
             norm = proj.cross(self.u)
-            return DraftVecUtils.angle(self.u,proj,norm)
+            return DraftVecUtils.angle(self.u, proj, norm)
                 
 def getPlacementFromPoints(points):
     "returns a placement from a list of 3 or 4 vectors"
@@ -489,7 +489,7 @@ def getPlacementFromPoints(points):
     del pl
     return p
     
-def getPlacementFromFace(face,rotated=False):
+def getPlacementFromFace(face, rotated=False):
     "returns a placement from a face"
     pl = plane()
     try:

--- a/src/Mod/Draft/WorkingPlane.py
+++ b/src/Mod/Draft/WorkingPlane.py
@@ -585,8 +585,8 @@ class plane:
         It extracts the shape of the object or subobject
         and then calls `alignToFace(shape, offset)`.
 
-        This method only works when the `FreeCADGui.Selection`
-        class is available, that is, when the graphical interface is loaded.
+        This method only works when `FreeCAD.GuiUp` is `True`,
+        that is, when the graphical interface is loaded.
 
         Parameter
         ---------
@@ -612,6 +612,9 @@ class plane:
 
         The method could work for curves (`'Edge'`  or `'Wire'`) but
         `alignToCurve()` isn't fully implemented.
+
+        When the interface is not loaded it should fail and print
+        a message, `FreeCAD.Console.PrintError()`.
 
         See also
         --------
@@ -660,8 +663,8 @@ class plane:
 
         To do
         -----
-        It should fail loudly, with a message at least
-        `FreeCAD.Console.PrintError()`.
+        When the interface is not loaded it should fail and print
+        a message, `FreeCAD.Console.PrintError()`.
         """
         if self.weak:
             if direction and point:

--- a/src/Mod/Draft/WorkingPlane.py
+++ b/src/Mod/Draft/WorkingPlane.py
@@ -850,7 +850,7 @@ class plane:
 
         See also
         --------
-        getGlobalCoords
+        getGlobalCoords, getLocalRot, getGlobalRot
 
         Notes
         -----
@@ -916,7 +916,7 @@ class plane:
 
         See also
         --------
-        getLocalCoords
+        getLocalCoords, getLocalRot, getGlobalRot
 
         Notes
         -----
@@ -946,7 +946,33 @@ class plane:
         return pt.add(self.position)
 
     def getLocalRot(self, point):
-        "Same as getLocalCoords, but discards the WP position"
+        """Like getLocalCoords, but doesn't use the plane's `position`.
+
+        If the `point` was constructed using the plane as origin,
+        return the relative coordinates from the `point` to the plane.
+        However, in this case, the plane is assumed to have its `position`
+        at the global origin, therefore, the returned coordinates
+        will only consider the orientation of the plane.
+
+        The external `point` is a vector, which is projected onto
+        each of the `u`, `v` and `axis` of the plane to determine
+        the local, relative vector.
+
+        Parameters
+        ----------
+        point : Base::Vector3
+            The point external to the plane.
+
+        Returns
+        -------
+        Base::Vector3
+            The relative coordinates of the point from the plane,
+            if the plane had its `position` at the global origin.
+
+        See also
+        --------
+        getLocalCoords, getGlobalCoords, getGlobalRot
+        """
         xv = DraftVecUtils.project(point, self.u)
         x = xv.Length
         if xv.getAngle(self.u) > 1:
@@ -962,7 +988,31 @@ class plane:
         return Vector(x, y, z)
 
     def getGlobalRot(self, point):
-        "Same as getGlobalCoords, but discards the WP position"
+        """Like getGlobalCoords, but doesn't use the plane's position.
+
+        If the `point` was constructed using the plane as origin,
+        return the absolute coordinates from the `point`
+        to the global origin.
+        However, in this case, the plane is assumed to have its `position`
+        at the global origin, therefore, the returned coordinates
+        will only consider the orientation of the plane.
+
+        The `u`, `v`, and `axis` vectors scale the components of `point`.
+
+        Parameters
+        ----------
+        point : Base::Vector3
+            The external point.
+
+        Returns
+        -------
+        Base::Vector3
+            The coordinates of the point from the absolute origin.
+
+        See also
+        --------
+        getGlobalCoords, getLocalCoords, getLocalRot
+        """
         vx = Vector(self.u).multiply(point.x)
         vy = Vector(self.v).multiply(point.y)
         vz = Vector(self.axis).multiply(point.z)

--- a/src/Mod/Draft/WorkingPlane.py
+++ b/src/Mod/Draft/WorkingPlane.py
@@ -795,14 +795,21 @@ class plane:
         self.axis = rot.multVec(FreeCAD.Vector(0, 0, 1))
         if rebase:
             self.position = pl.Base
-            
+
     def inverse(self):
-        "inverts the direction of the working plane"
+        """Invert the direction of the plane.
+
+        It inverts the `u` and `axis` vectors.
+        """
         self.u = self.u.negative()
         self.axis = self.axis.negative()
 
     def save(self):
-        "stores the current plane state"
+        """Store the plane attributes.
+
+        Store `u`, `v`, `axis`, `position` and `weak`
+        in a list in `stored`.
+        """
         self.stored = [self.u, self.v, self.axis, self.position, self.weak]
 
     def restore(self):

--- a/src/Mod/Draft/WorkingPlane.py
+++ b/src/Mod/Draft/WorkingPlane.py
@@ -54,9 +54,9 @@ class plane:
         It is `True` if the plane has been defined by `setup()`
         or has been reset.
     u : Base::Vector3
-        A vector that helps define the working plane.
+        An axis (vector) that helps define the working plane.
     v : Base::Vector3
-        A vector that helps define the working plane.
+        An axis (vector) that helps define the working plane.
     axis : Base::Vector3
         A vector that is supposed to be perpendicular to `u` and `v`;
         it is helpful although redundant.
@@ -69,9 +69,7 @@ class plane:
     def __init__(self, u=Vector(1, 0, 0), v=Vector(0, 1, 0), w=Vector(0, 0, 1), pos=Vector(0, 0, 0)):
         # keep track of active document.  Reset view when doc changes.
         self.doc = None
-        # self.weak is true if the plane has been defined by self.setup or has been reset
         self.weak = True
-        # u, v axes and position define plane, perpendicular axis is handy, though redundant.
         self.u = u
         self.v = v
         self.axis = w

--- a/src/Mod/Draft/WorkingPlane.py
+++ b/src/Mod/Draft/WorkingPlane.py
@@ -549,13 +549,71 @@ class plane:
             return False
 
     def alignTo3Points(self, p1, p2, p3, offset=0):
+        """Align the plane to three points.
+
+        It makes a closed quadrilateral face with the three points,
+        and then calls `alignToFace(shape, offset)`.
+
+        Parameter
+        ---------
+        p1 : Base::Vector3
+            The first point.
+        p2 : Base::Vector3
+            The second point.
+        p3 : Base::Vector3
+            The third point.
+
+        offset : float
+            Defaults to zero. A value which will be used to offset
+            the plane in the direction of its `axis`.
+
+        Returns
+        -------
+        bool
+            `True` if the operation was succesful, and `False` otherwise.
+        """
         import Part
         w = Part.makePolygon([p1, p2, p3, p1])
         f = Part.Face(w)
         return self.alignToFace(f, offset)
 
-    def alignToSelection(self, offset):
-        '''If selection uniquely defines a plane, align working plane to it.  Return success (bool)'''
+    def alignToSelection(self, offset=0):
+        """Align the plane to a selection if it defines a plane.
+
+        If the selection uniquely defines a plane it will be used.
+        Currently it only works with one object selected, a `'Face'`.
+        It extracts the shape of the object or subobject
+        and then calls `alignToFace(shape, offset)`.
+
+        Parameter
+        ---------
+        offset : float
+            Defaults to zero. A value which will be used to offset
+            the plane in the direction of its `axis`.
+
+        Returns
+        -------
+        bool
+            `True` if the operation was succesful, and `False` otherwise.
+            It returns `False` if the selection has no elements,
+            or if it has more than one element,
+            or if the object is not derived from `'Part::Feature'`
+            or if the object doesn't have a `Shape`.
+
+        To do
+        -----
+        The method returns `False` if the selection list has more than
+        one element.
+        The method should search the list for objects like faces, points,
+        edges, wires, etc., and call the appropriate aligning submethod.
+
+        The method could work for curves (`'Edge'`  or `'Wire'`) but
+        `alignToCurve()` isn't fully implemented.
+
+        See also
+        --------
+        alignToFace, alignToCurve
+        """
         import FreeCADGui
         sex = FreeCADGui.Selection.getSelectionEx(FreeCAD.ActiveDocument.Name)
         if len(sex) == 0:

--- a/src/Mod/Draft/WorkingPlane.py
+++ b/src/Mod/Draft/WorkingPlane.py
@@ -44,7 +44,27 @@ __url__ = "http://www.freecadweb.org"
 
 
 class plane:
-    '''A WorkPlane object'''
+    """A WorkPlane object.
+
+    Attributes
+    ----------
+    doc : App::Document
+        The active document. Reset view when `doc` changes.
+    weak : bool
+        It is `True` if the plane has been defined by `setup()`
+        or has been reset.
+    u : Base::Vector3
+        A vector that helps define the working plane.
+    v : Base::Vector3
+        A vector that helps define the working plane.
+    axis : Base::Vector3
+        A vector that is supposed to be perpendicular to `u` and `v`;
+        it is helpful although redundant.
+    position : Base::Vector3
+        A vector that helps define the working plane.
+    stored : bool
+        A placeholder for a stored state.
+    """
 
     def __init__(self, u=Vector(1, 0, 0), v=Vector(0, 1, 0), w=Vector(0, 0, 1), pos=Vector(0, 0, 0)):
         # keep track of active document.  Reset view when doc changes.


### PR DESCRIPTION
- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

---

Improved the Pythonic style of the code, particularly all functions were given a proper docstring in Numpy/SciPy style, which makes it easier to create automatic documentation with Doxygen and Sphinx.

Spaces were added after commas and mathematical operators as necessary to comply with PEP8, and some trailing spaces were removed.

The code was checked with ``flake8``, which passed with minimum issues.
```flake8 --ignore=E226,E266,E401,W503 WorkingPlane.py```

Most warnings about line lengths, comments, and except blocks will be corrected in future commits.