### PR TITLE
Arch: Fix missing cache value for SectionPlane

### DIFF
--- a/src/Mod/Arch/ArchSectionPlane.py
+++ b/src/Mod/Arch/ArchSectionPlane.py
@@ -298,7 +298,7 @@ def getSVG(section, renderMode="Wireframe", allOn=False, showHidden=False, scale
                 svgcache += render.getHiddenSVG(linewidth="SVGLINEWIDTH")
             svgcache += '</g>\n'
             # print(render.info())
-            section.Proxy.svgcache = [svgcache,renderMode,showHidden,showFill]
+            section.Proxy.svgcache = [svgcache,renderMode,showHidden,showFill,fillSpaces]
     else:
 
         if not svgcache:


### PR DESCRIPTION
When the Arch SectionPlane was rendered via TechDraw in Solid mode, the
last parameter "fillSpaces" was not set for the svgcache.
So the next render operation threw an exeption because there where only
4 instead of 5 elements in the cache list.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---

Link to a forum thread describing the exception:
https://forum.freecadweb.org/viewtopic.php?f=3&t=38554