### PR TITLE
[Robot] Fix compiler warnings

### DIFF
--- a/src/Mod/Robot/App/kdl_cp/chainiksolverpos_lma.cpp
+++ b/src/Mod/Robot/App/kdl_cp/chainiksolverpos_lma.cpp
@@ -195,7 +195,7 @@ int ChainIkSolverPos_LMA::CartToJnt(const KDL::JntArray& q_init, const KDL::Fram
 
 		svd.compute(jac);
 		original_Aii = svd.singularValues();
-		for (unsigned int j=0;j<original_Aii.rows();++j) {
+		for (Eigen::Index j=0;j<original_Aii.rows();++j) {
 			original_Aii(j) = original_Aii(j)/( original_Aii(j)*original_Aii(j)+lambda);
 
 		}

--- a/src/Mod/Robot/App/kdl_cp/jacobian.cpp
+++ b/src/Mod/Robot/App/kdl_cp/jacobian.cpp
@@ -83,7 +83,7 @@ namespace KDL
     }
 
     void Jacobian::changeRefPoint(const Vector& base_AB){
-        for(unsigned int i=0;i<data.cols();i++)
+        for(Eigen::Index i=0;i<data.cols();i++)
             this->setColumn(i,this->getColumn(i).RefPoint(base_AB));
     }
 
@@ -97,7 +97,7 @@ namespace KDL
     }
     
     void Jacobian::changeBase(const Rotation& rot){
-        for(unsigned int i=0;i<data.cols();i++)
+        for(Eigen::Index i=0;i<data.cols();i++)
             this->setColumn(i,rot*this->getColumn(i));;
     }
 
@@ -111,7 +111,7 @@ namespace KDL
     }
 
     void Jacobian::changeRefFrame(const Frame& frame){
-        for(unsigned int i=0;i<data.cols();i++)
+        for(Eigen::Index i=0;i<data.cols();i++)
             this->setColumn(i,frame*this->getColumn(i));
     }
     

--- a/src/Mod/Robot/App/kdl_cp/treeiksolvervel_wdls.cpp
+++ b/src/Mod/Robot/App/kdl_cp/treeiksolvervel_wdls.cpp
@@ -89,9 +89,9 @@ namespace KDL {
         Wq_V.noalias() = Wq * V;
         
         // tmp = (Si*Wy*U'*y),
-        for (unsigned int i = 0; i < J.cols(); i++) {
+        for (Eigen::Index i = 0; i < J.cols(); i++) {
             double sum = 0.0;
-            for (unsigned int j = 0; j < J.rows(); j++) {
+            for (Eigen::Index j = 0; j < J.rows(); j++) {
                 if (i < Wy_t.rows())
                     sum += U(j, i) * Wy_t(j);
                 else

--- a/src/Mod/Robot/App/kdl_cp/utilities/svd_eigen_Macie.hpp
+++ b/src/Mod/Robot/App/kdl_cp/utilities/svd_eigen_Macie.hpp
@@ -70,8 +70,8 @@ namespace KDL
                 rotate=false;
                 rotations=0;
                 //Perform rotations between columns of B
-                for(unsigned int i=0;i<B.cols();i++){
-                    for(unsigned int j=i+1;j<B.cols();j++){
+                for(Eigen::Index i=0;i<B.cols();i++){
+                    for(Eigen::Index j=i+1;j<B.cols();j++){
                         //calculate plane rotation
                         double p = B.col(i).dot(B.col(j));
                         double qi =B.col(i).dot(B.col(i));
@@ -111,7 +111,7 @@ namespace KDL
                 }
                 //Only calculate new U and S if there were any rotations
                 if(rotations!=0){
-                    for(unsigned int i=0;i<U.rows();i++) {
+                    for(Eigen::Index i=0;i<U.rows();i++) {
                         if(i<B.cols()){
                             double si=sqrt(B.col(i).dot(B.col(i)));
                             if(si==0)
@@ -134,8 +134,8 @@ namespace KDL
                 rotate=false;
                 rotations=0;
                 //Perform rotations between rows of B
-                for(unsigned int i=0;i<B.cols();i++){
-                    for(unsigned int j=i+1;j<B.cols();j++){
+                for(Eigen::Index i=0;i<B.cols();i++){
+                    for(Eigen::Index j=i+1;j<B.cols();j++){
                         //calculate plane rotation
                         double p = B.row(i).dot(B.row(j));
                         double qi = B.row(i).dot(B.row(i));
@@ -179,7 +179,7 @@ namespace KDL
 
                 //Only calculate new U and S if there were any rotations
                 if(rotations!=0){
-                    for(unsigned int i=0;i<V.rows();i++) {
+                    for(Eigen::Index i=0;i<V.rows();i++) {
                         double si=sqrt(B.row(i).dot(B.row(i)));
                         if(si==0)
                             V.col(i) = B.row(i);


### PR DESCRIPTION
"Warning: comparison between signed and unsigned integer expressions [-Wsign-compare]"
Changed 'unsigned int' into 'Eigen::Index' type for several loop indexes...



- [x ] Branch rebased on latest master `git pull --rebase upstream master`
- [x ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated 

