### PR TITLE
Draft: Fix potential uninitialized variable error

### DIFF
--- a/src/Mod/Draft/DraftEdit.py
+++ b/src/Mod/Draft/DraftEdit.py
@@ -299,6 +299,7 @@ class Edit():
         else: return selobjs
 
     def lookForClickedNode(self,selobjs,tolerance=20):
+        ep = None
         for info in selobjs:
             #if info["Object"] == self.obj.Name:
             #    return


### PR DESCRIPTION
It seems that it is possible that none of the code paths in
"lookForClickedNode" gets executed. In such a case the "return ep" at
the end of the method throws a "variable referenced before initialized"
exception.

This commit fixes it by initializing the variable to none at the beginning
of the method. As some other code paths also return nothing, this should
cause no harm.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
