### PR TITLE
[Gui]Add options for page size, lineWidth and background on Svg Save

### DIFF
--- a/src/Gui/SoFCVectorizeSVGAction.cpp
+++ b/src/Gui/SoFCVectorizeSVGAction.cpp
@@ -31,6 +31,7 @@
 
 #include <qglobal.h>
 #include <Base/FileInfo.h>
+#include <Base/Console.h>
 #include "SoFCVectorizeSVGAction.h"
 
 using namespace Gui;
@@ -306,7 +307,7 @@ void SoFCVectorizeSVGActionP::printTriangle(const SbVec3f * v, const SbColor * c
         << "; stroke:#"
         << std::hex << std::setw(6) << std::setfill('0') << (cc >> 8)
         << ";" << std::endl
-        << "    stroke-width:1.0;" << std::endl
+        << "    stroke-width:" << publ->getLineWidth() << ";" << std::endl
         << "    stroke-linecap:round;stroke-linejoin:round\"/>" << std::endl;
 }
 
@@ -350,8 +351,9 @@ void SoFCVectorizeSVGActionP::printLine(const SoVectorizeLine * item) const
         << "x1=\"" << v[0][0] << "\" y1=\"" << v[0][1] << "\" "
         << "x2=\"" << v[1][0] << "\" y2=\"" << v[1][1] << "\" "
         << "stroke=\"#"
-        << std::hex << std::setw(6) << std::setfill('0') << (cc >> 8)
-        << "\" stroke-width=\"1px\" />\n";
+        << std::hex << std::setw(6) << std::setfill('0') << (cc >> 8) << "\""
+        << " stroke-linecap=\"square\" "
+        << " stroke-width=\"" << publ->getLineWidth() << "\" />\n";
 }
 
 void SoFCVectorizeSVGActionP::printPoint(const SoVectorizePoint * item) const
@@ -375,7 +377,10 @@ void SoFCVectorizeSVGAction::initClass(void)
     SO_ACTION_INIT_CLASS(SoFCVectorizeSVGAction, SoVectorizeAction);
 }
 
-SoFCVectorizeSVGAction::SoFCVectorizeSVGAction()
+SoFCVectorizeSVGAction::SoFCVectorizeSVGAction() :
+    m_backgroundState(true),
+    m_lineWidth(1.0),
+    m_usemm(false)
 {
     SO_ACTION_CONSTRUCTOR(SoFCVectorizeSVGAction);
     this->setOutput(new SoSVGVectorOutput);
@@ -400,12 +405,18 @@ void SoFCVectorizeSVGAction::printHeader(void) const
     str << "<!-- Created with FreeCAD (http://www.freecadweb.org) -->" << std::endl;
     str << "<svg xmlns=\"http://www.w3.org/2000/svg\"" << std::endl;
     str << "     xmlns:xlink=\"http://www.w3.org/1999/xlink\" xmlns:ev=\"http://www.w3.org/2001/xml-events\"" << std::endl;
-    str << "     version=\"1.1\" baseProfile=\"full\"" << std::endl;
+    str << "     version=\"1.1\" baseProfile=\"full\""  << std::endl;
 
     SbVec2f size = getPageSize();
-    if (this->getOrientation() == LANDSCAPE)
+    if (this->getOrientation() == LANDSCAPE) {
         SbSwap<float>(size[0], size[1]);
-    str << "     width=\"" << size[0] << "\" height=\"" << size[1] << "\">" << std::endl;
+    }
+    if (getUseMM()) {
+        str << "     width=\"" << size[0] << "mm\" height=\"" << size[1] << "mm\""<< std::endl;
+        str << "     viewBox=\"0 0 " << size[0] << " " << size[1] << "\">" << std::endl;
+    } else {            //original code used px
+        str << "     width=\"" << size[0] << "\" height=\"" << size[1] << "\">" << std::endl;
+    }
     str << "<g>" << std::endl;
 }
 
@@ -447,7 +458,7 @@ void SoFCVectorizeSVGAction::printBackground(void) const
     str << "   style=\"fill:#"
         << std::hex << std::setw(6) << std::setfill('0') << (cc >> 8)
         << ";fill-opacity:1;fill-rule:evenodd;stroke:none;"
-           "stroke-width:1px;stroke-linecap:butt;stroke-linejoin:"
+           "stroke-width:" << getLineWidth() << ";stroke-linecap:butt;stroke-linejoin:"
            "miter;stroke-opacity:1\" />\n";
     str << "<g>" << std::endl;
 }

--- a/src/Gui/SoFCVectorizeSVGAction.h
+++ b/src/Gui/SoFCVectorizeSVGAction.h
@@ -62,6 +62,13 @@ public:
     static void initClass(void);
     SoSVGVectorOutput * getSVGOutput(void) const;
 
+    virtual void setBackgroundState(bool b) { m_backgroundState = b; }
+    virtual bool getBackgroundState(void) const { return m_backgroundState; } 
+    virtual void setLineWidth(double w) { m_lineWidth = w; }
+    virtual double getLineWidth(void) const { return m_lineWidth; } 
+    virtual void setUseMM(bool b) { m_usemm = b; }
+    virtual bool getUseMM(void) const { return m_usemm; } 
+
 protected:
     virtual void printHeader(void) const;
     virtual void printFooter(void) const;
@@ -72,6 +79,9 @@ protected:
 private:
     SoFCVectorizeSVGActionP* p;
     friend class SoFCVectorizeSVGActionP;
+    bool m_backgroundState;
+    double m_lineWidth;
+    bool m_usemm;
 };
 
 } // namespace Gui


### PR DESCRIPTION
This PR concerns the saving of the 3D view as an Svg file.   This change will support subsequent changes in TechDraw and Arch.  Specifically, this change affects Gui/SoFCVectorizeSvgAction as follows: 

SVG header 
    switch added to use mm for page width & height instead of px  and use viewbox for correct coordinate handling.
Background
    switch added to show/hide background 
Line width
    stroke-width attribute added
Line ends & corners
    stroke-linecap="square" added to prevent notches at corners

The default condition behaves as before.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
