### PR TITLE
[TD]Prevent crash in SelectionSingleton on Spacebar Toggle

### DIFF
--- a/src/Mod/TechDraw/Gui/MDIViewPage.cpp
+++ b/src/Mod/TechDraw/Gui/MDIViewPage.cpp
@@ -1033,6 +1033,8 @@ void MDIViewPage::clearSceneSelection()
 //!Update QGIView's selection state based on Selection made outside Drawing Interface
 void MDIViewPage::selectQGIView(App::DocumentObject *obj, const bool isSelected)
 {
+//    Base::Console().Message("MDIVP::selectQGIV(%s) - %d\n", obj->getNameInDocument(), isSelected);
+
     App::DocumentObject* objCopy = obj;
     TechDraw::DrawHatch* hatchObj = dynamic_cast<TechDraw::DrawHatch*>(objCopy);
     if (hatchObj) {                                                    //Hatch does not have a QGIV of it's own. mark parent as selected.
@@ -1055,6 +1057,7 @@ void MDIViewPage::selectQGIView(App::DocumentObject *obj, const bool isSelected)
 //really "onTreeSelectionChanged"
 void MDIViewPage::onSelectionChanged(const Gui::SelectionChanges& msg)
 {
+//    Base::Console().Message("MDIVP::onSelectionChanged()\n");
     std::vector<Gui::SelectionSingleton::SelObj> selObjs = Gui::Selection().getSelection(msg.pDocName);
     if (msg.Type == Gui::SelectionChanges::ClrSelection) {
         clearSceneSelection();
@@ -1082,6 +1085,7 @@ void MDIViewPage::onSelectionChanged(const Gui::SelectionChanges& msg)
 //! maintain QGScene selected items in selection order
 void MDIViewPage::sceneSelectionManager()
 {
+//    Base::Console().Message("MDIVP::sceneSelectionManager()\n");
     QList<QGraphicsItem*> sceneSel = m_view->scene()->selectedItems();
 
     if (sceneSel.isEmpty()) {
@@ -1128,6 +1132,7 @@ void MDIViewPage::sceneSelectionManager()
 //triggered by m_view->scene() signal
 void MDIViewPage::sceneSelectionChanged()
 {
+//    Base::Console().Message("MDIVP::sceneSelctionChanged()\n");
     sceneSelectionManager();
 
 //    QList<QGraphicsItem*> dbsceneSel = m_view->scene()->selectedItems();
@@ -1152,6 +1157,7 @@ void MDIViewPage::sceneSelectionChanged()
 //Note: Qt says: "no guarantee of selection order"!!!
 void MDIViewPage::setTreeToSceneSelect(void)
 {
+//    Base::Console().Message("MDIVP::setTreeToSceneSelect()\n");
     bool saveBlock = blockConnection(true); // block selectionChanged signal from Tree/Observer
     blockSelection(true);
     Gui::Selection().clearSelection();
@@ -1319,6 +1325,7 @@ void MDIViewPage::setTreeToSceneSelect(void)
 
 bool MDIViewPage::compareSelections(std::vector<Gui::SelectionObject> treeSel, QList<QGraphicsItem*> sceneSel)
 {
+//    Base::Console().Message("MDIVP::compareSelections()\n");
     bool result = true;
 
     if (treeSel.empty() && sceneSel.empty()) {

--- a/src/Mod/TechDraw/Gui/ViewProviderDrawingView.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderDrawingView.cpp
@@ -121,11 +121,11 @@ void ViewProviderDrawingView::onChanged(const App::Property *prop)
     }
 
     if (prop == &Visibility) {
-       if(Visibility.getValue()) {
-            show();
-        } else {
-            hide();
-        }
+//       if(Visibility.getValue()) {
+//            show();
+//        } else {
+//            hide();
+//        }
     } else if (prop == &KeepLabel) {
         QGIView* qgiv = getQView();
         if (qgiv) {
@@ -161,11 +161,20 @@ void ViewProviderDrawingView::hide(void)
     if (obj->getTypeId().isDerivedFrom(TechDraw::DrawView::getClassTypeId())) {
         QGIView* qView = getQView();
         if (qView) {
-            qView->draw();
-            qView->hide();
+            //note: hiding an item in the scene clears its selection status
+            //      this confuses Gui::Selection.
+            //      So we block selection changes while we are hiding the qgiv
+            //      in FC Tree hiding does not change selection state.
+            //      block/unblock selection protects against crash in Gui::SelectionSingleton::setVisible
+            MDIViewPage* mdi = getMDIViewPage();
+            if (mdi != nullptr) {                  //if there is no mdivp, there is nothing to hide!
+                mdi->blockSelection(true);
+                qView->hide();
+                ViewProviderDocumentObject::hide();
+                mdi->blockSelection(false);
+            }
         }
     }
-    ViewProviderDocumentObject::hide();
 }
 
 QGIView* ViewProviderDrawingView::getQView(void)


### PR DESCRIPTION
- in SelectionSingleton::setVisible, if the selection changes during
  loop, a crash may occur.
- in QGraphicsScene, hiding an item changes its selected status.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
