### PR TITLE
Fix missing app ID and icon on Wayland

### DIFF
--- a/src/Main/MainGui.cpp
+++ b/src/Main/MainGui.cpp
@@ -182,6 +182,10 @@ int main( int argc, char ** argv )
     App::Application::Config()["SplashTextColor" ] = "#ffffff"; // white
     App::Application::Config()["SplashInfoColor" ] = "#c8c8c8"; // light grey
 
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 7, 0))
+    QGuiApplication::setDesktopFileName(QStringLiteral("org.freecadweb.FreeCAD.desktop"));
+#endif
+
     try {
         // Init phase ===========================================================
         // sets the default run mode for FC, starts with gui if not overridden in InitConfig...


### PR DESCRIPTION
Fixes the problem where the app icon would not show under Gnome/Wayland.

Wayland needs to know the name of the .desktop file to show a dock icon and application name.

See: https://community.kde.org/Guidelines_and_HOWTOs/Wayland_Porting_Notes#Application_Icon

- [X] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [X] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

Note that the unit tests are failing on `master` for me (before my change). Can somebody please confirm? There is no change to the test output (ie no new failures) with my change.