### PR TITLE
Fix misc. typos, whitespace, and http:// to https:// issues 

### DIFF
--- a/src/App/Document.cpp
+++ b/src/App/Document.cpp
@@ -2249,7 +2249,7 @@ bool Document::saveToFile(const char* filename) const
 
         writer.Stream() << "<?xml version='1.0' encoding='utf-8'?>" << endl
                         << "<!--" << endl
-                        << " FreeCAD Document, see http://www.freecadweb.org for more information..." << endl
+                        << " FreeCAD Document, see https://www.freecadweb.org for more information..." << endl
                         << "-->" << endl;
         Document::Save(writer);
 
@@ -3055,7 +3055,7 @@ int Document::recompute(const std::vector<App::DocumentObject*> &objs, bool forc
     }
     if (testStatus(Document::Recomputing)) {
         // this is clearly a bug in the calling instance
-        FC_ERR("Recusrive calling of recomput for dcument " << getName());
+        FC_ERR("Recursive calling of recompute for document " << getName());
         return 0;
     }
     // The 'SkipRecompute' flag can be (tmp.) set to avoid too many
@@ -3075,7 +3075,7 @@ int Document::recompute(const std::vector<App::DocumentObject*> &objs, bool forc
 
 #if 0
     //////////////////////////////////////////////////////////////////////////
-    // Comment by Realthunder: 
+    // FIXME Comment by Realthunder: 
     // the topologicalSrot() below cannot handle partial recompute, haven't got
     // time to figure out the code yet, simply use back boost::topological_sort
     // for now, that is, rely on getDependencyList() to do the sorting. The
@@ -4321,4 +4321,3 @@ bool Document::mustExecute() const
             return true;
     return false;
 }
-

--- a/src/App/DocumentObjectPy.xml
+++ b/src/App/DocumentObjectPy.xml
@@ -153,7 +153,7 @@ Return -1 if element visibility is not supported or element not found, 0 if invi
         </Methode>
         <Methode Name="getParentGeoFeatureGroup">
             <Documentation>
-                <UserDocu>Returns the GeoFeatureGroup, and hence the local coorinate system, the object 
+                <UserDocu>Returns the GeoFeatureGroup, and hence the local coordinate system, the object 
                           is in or None if it is not part of a group. Note that an object can only be 
                           in a single group, hence only a single return value.</UserDocu>
             </Documentation>

--- a/src/App/Property.cpp
+++ b/src/App/Property.cpp
@@ -231,7 +231,7 @@ void PropertyListsBase::_setPyObject(PyObject *value) {
 #else
             if(!PyLong_Check(key))
 #endif
-                throw Base::TypeError("expect key type to be interger");
+                throw Base::TypeError("expect key type to be integer");
             long idx = PyLong_AsLong(key);
             if(idx<-1 || idx>listSize) 
                 throw Base::ValueError("index out of bound");

--- a/src/Mod/Arch/ArchSectionPlane.py
+++ b/src/Mod/Arch/ArchSectionPlane.py
@@ -723,7 +723,7 @@ def getCoinSVG(cutplane,objs,cameradata=None,linewidth=0.2,singleface=False,face
         vz = cutplane.Placement.Rotation.multVec(FreeCAD.Vector(0,0,1))
         rot = FreeCAD.Rotation(vx,vy,vz,"ZXY")
         v.setCameraOrientation(rot.Q)
-    # this is needed to set correct focal depth, otherwise saving doesnt work properly
+    # this is needed to set correct focal depth, otherwise saving doesn't work properly
     v.fitAll()
 
     # save view

--- a/src/Mod/Arch/exportIFC.py
+++ b/src/Mod/Arch/exportIFC.py
@@ -1,7 +1,6 @@
 # ***************************************************************************
 # *                                                                         *
-# *   Copyright (c) 2014                                                    *
-# *   Yorik van Havre <yorik@uncreated.net>                                 *
+# *   Copyright (c) 2014 Yorik van Havre <yorik@uncreated.net>              *
 # *                                                                         *
 # *   This program is free software; you can redistribute it and/or modify  *
 # *   it under the terms of the GNU Lesser General Public License (LGPL)    *
@@ -25,7 +24,7 @@ from __future__ import print_function
 
 __title__ =  "FreeCAD IFC export"
 __author__ = "Yorik van Havre","Jonathan Wiedemann","Bernd Hahnebach"
-__url__ =    "http://www.freecadweb.org"
+__url__ =    "https://www.freecadweb.org"
 
 import six
 import os

--- a/src/Mod/Draft/DraftEdit.py
+++ b/src/Mod/Draft/DraftEdit.py
@@ -25,7 +25,7 @@
 
 __title__= "FreeCAD Draft Edit Tool"
 __author__ = "Yorik van Havre, Werner Mayer, Martin Burbaum, Ken Cline, Dmitry Chigrin, Carlo Pavan"
-__url__ = "http://www.freecadweb.org"
+__url__ = "https://www.freecadweb.org"
 
 import FreeCAD
 import Draft
@@ -1000,7 +1000,7 @@ class Edit():
         self.trackers[self.obj.Name][1].set(self.obj.Shape.Vertexes[2].Point)
 
     #---------------------------------------------------------------------------
-    # EDIT OBJECT TOOLS : Ellipse (yet to be implemented)
+    # EDIT OBJECT TOOLS : Ellipse (# TODO: yet to be implemented)
     #---------------------------------------------------------------------------
 
     def setEllipsePts(self):

--- a/src/Mod/Draft/importDWG.py
+++ b/src/Mod/Draft/importDWG.py
@@ -190,7 +190,7 @@ def getTeighaConverter():
 def convertToDxf(dwgfilename):
     """Convert a DWG file to a DXF file.
 
-    If the converter is found it is used, otherwise the convesion fails.
+    If the converter is found it is used, otherwise the conversion fails.
 
     Parameters
     ----------
@@ -234,7 +234,7 @@ def convertToDxf(dwgfilename):
 def convertToDwg(dxffilename, dwgfilename):
     """Convert a DXF file to a DWG file.
 
-    If the converter is found it is used, otherwise the convesion fails.
+    If the converter is found it is used, otherwise the conversion fails.
 
     Parameters
     ----------

--- a/src/Mod/Fem/femmesh/meshtools.py
+++ b/src/Mod/Fem/femmesh/meshtools.py
@@ -671,7 +671,7 @@ def get_femmesh_groupdata_sets_by_name(
     # no check is done in this regard !!!
     # we just check for the group name and the group data type
     # what happens if a reference shape was changed
-    # but the mesh and the mesh groups where not created new !?!
+    # but the mesh and the mesh groups were not created new !?!
     obj = fem_object["Object"]
     if femmesh.GroupCount:
         for g in femmesh.Groups:

--- a/src/Mod/Import/App/ImportOCAF2.cpp
+++ b/src/Mod/Import/App/ImportOCAF2.cpp
@@ -192,7 +192,7 @@ void ImportOCAF2::setMode(int m) {
             Base::FileInfo fi(pDocument->FileName.getValue());
             filePath = fi.dirPath();
         }else
-            FC_WARN("Diable multi-document mode because the input document is not saved.");
+            FC_WARN("Disable multi-document mode because the input document is not saved.");
     }
 }
 
@@ -982,7 +982,7 @@ void ExportOCAF2::setupObject(TDF_Label label, App::DocumentObject *obj,
             names.push_back(prefix + obj->getNameInDocument() + "_i" + name + ".");
         }
         // Finally, the subname reference allows to use the label for naming
-        // with preceeding '$'
+        // with preceding '$'
         names.push_back(prefix + "$" + obj->Label.getValue() + ".");
     }
 

--- a/src/Mod/Material/StandardMaterial/Readme.txt
+++ b/src/Mod/Material/StandardMaterial/Readme.txt
@@ -1,7 +1,7 @@
 This is the FreeCAD standard material library. It's intended to gather
 the most common Material definitions.
 How to do a description is explained here:
-http://www.freecadweb.org/wiki/index.php?title=Material
+https://www.freecadweb.org/wiki/Material
 
 To make the material description useful for a lot of applications only
 files with the (CC BY 3.0) license will be accepted into the FreeCAD

--- a/src/Mod/Path/PathScripts/PathCircularHoleBase.py
+++ b/src/Mod/Path/PathScripts/PathCircularHoleBase.py
@@ -46,7 +46,7 @@ if FreeCAD.GuiUp:
 
 __title__ = "Path Circular Holes Base Operation"
 __author__ = "sliptonic (Brad Collette)"
-__url__ = "http://www.freecadweb.org"
+__url__ = "https://www.freecadweb.org"
 __doc__ = "Base class an implementation for operations on circular holes."
 __contributors__ = "russ4262 (Russell Johnson)"
 __created__ = "2017"
@@ -150,7 +150,7 @@ class ObjectOp(PathOp.ObjectOp):
                         return shape.Edges[i].Curve.Radius * 2
                         
             
-            # for all other shapes the diameter is just the dimension in X. This may be inaccurate as the BoundBox is calculated on the tesselated geometry
+            # for all other shapes the diameter is just the dimension in X. This may be inaccurate as the BoundBox is calculated on the tessellated geometry
             PathLog.warning(translate("Path", "Hole diameter may be inaccurate due to tessellation on face. Consider selecting hole edge."))
             return shape.BoundBox.XLength
         except Part.OCCError as e:

--- a/src/Mod/Path/libarea/Adaptive.cpp
+++ b/src/Mod/Path/libarea/Adaptive.cpp
@@ -1606,7 +1606,7 @@ double Adaptive2d::CalcCutArea(Clipper &clip, const IntPoint &c1, const IntPoint
 		Perf_CalcCutAreaClip.Start();
 		// old way of calculating cut area based on polygon clipping
 		// used in case when there are multiple intersections of tool with cleared poly (very rare case, but important)
-		// 1. find differene between old and new tool shape
+		// 1. find difference between old and new tool shape
 		Path oldTool;
 		Path newTool;
 		TranslatePath(toolGeometry, oldTool, c1);

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -592,7 +592,7 @@ bool ViewProviderSketch::mouseButtonPressed(int Button, bool pressed, const SbVe
                                             const Gui::View3DInventorViewer *viewer)
 {
     assert(edit);
-    App::AutoTransaction comitter;
+    App::AutoTransaction committer;
 
     // Calculate 3d point to the mouse position
     SbLine line;

--- a/src/Tools/embedded/Win32/FreeCAD_widget/FreeCAD_widget.cpp
+++ b/src/Tools/embedded/Win32/FreeCAD_widget/FreeCAD_widget.cpp
@@ -208,7 +208,7 @@ INT_PTR CALLBACK About(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam)
 
 #include <Python.h>
 
-// See also http://www.freecadweb.org/wiki/index.php?title=Embedding_FreeCAD
+// See also https://www.freecadweb.org/wiki/Embedding_FreeCAD
 
 std::string OnFileOpen(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 {


### PR DESCRIPTION
Typos found via `codespell -q 3 -I ../fc-word-whitelist.txt -S ./.git,*.po,*.ts,./ChangeLog.txt,./src/3rdParty,./src/Mod/Assembly/App/opendcm,./src/CXX,./src/zipios++,./src/Base/swig*,./src/Mod/Robot/App/kdl_cp,./src/Mod/Import/App/SCL,./src/WindowsInstaller -L od,orign,orginx,orginy`