### PR TITLE
App/Gui: unify NotImplementedError handling in python features

### DIFF
--- a/src/App/Document.cpp
+++ b/src/App/Document.cpp
@@ -3378,6 +3378,7 @@ int Document::_recomputeFeature(DocumentObject* Feat)
     }
     catch(Base::AbortException &e){
         e.ReportException();
+        FC_ERR("Failed to recompute " << Feat->getFullName() << ": " << e.what());
         d->addRecomputeLog("User abort",Feat);
         return -1;
     }
@@ -3388,6 +3389,7 @@ int Document::_recomputeFeature(DocumentObject* Feat)
     }
     catch (Base::Exception &e) {
         e.ReportException();
+        FC_ERR("Failed to recompute " << Feat->getFullName() << ": " << e.what());
         d->addRecomputeLog(e.what(),Feat);
         return 1;
     }
@@ -3409,11 +3411,7 @@ int Document::_recomputeFeature(DocumentObject* Feat)
     }else{
         returnCode->Which = Feat;
         d->addRecomputeLog(returnCode);
-#ifdef FC_DEBUG
         FC_ERR("Failed to recompute " << Feat->getFullName() << ": " << returnCode->Why);
-#else
-        FC_LOG("Failed to recompute " << Feat->getFullName() << ": " << returnCode->Why);
-#endif
         return 1;
     }
     return 0;

--- a/src/App/FeaturePython.cpp
+++ b/src/App/FeaturePython.cpp
@@ -84,6 +84,10 @@ bool FeaturePythonImp::execute()
         }
     }
     catch (Py::Exception&) {
+        if (PyErr_ExceptionMatches(PyExc_NotImplementedError)) {
+            PyErr_Clear();
+            return false;
+        }
         Base::PyException e; // extract the Python error text
         e.ReportException();
         std::stringstream str;
@@ -272,6 +276,10 @@ bool FeaturePythonImp::getSubObject(DocumentObject *&ret, const char *subname,
         return true;
     }
     catch (Py::Exception&) {
+        if (PyErr_ExceptionMatches(PyExc_NotImplementedError)) {
+            PyErr_Clear();
+            return false;
+        }
         Base::PyException e; // extract the Python error text
         e.ReportException();
         ret = 0;
@@ -301,6 +309,10 @@ bool FeaturePythonImp::getSubObjects(std::vector<std::string> &ret, int reason) 
         return true;
     }
     catch (Py::Exception&) {
+        if (PyErr_ExceptionMatches(PyExc_NotImplementedError)) {
+            PyErr_Clear();
+            return false;
+        }
         Base::PyException e; // extract the Python error text
         e.ReportException();
         return true;
@@ -346,6 +358,10 @@ bool FeaturePythonImp::getLinkedObject(DocumentObject *&ret, bool recurse,
         return true;
     }
     catch (Py::Exception&) {
+        if (PyErr_ExceptionMatches(PyExc_NotImplementedError)) {
+            PyErr_Clear();
+            return false;
+        }
         Base::PyException e; // extract the Python error text
         e.ReportException();
         ret = 0;
@@ -369,11 +385,14 @@ int FeaturePythonImp::hasChildElement() const {
         return static_cast<bool>(ok) ? 1 : 0;
     }
     catch (Py::Exception&) {
+        if (PyErr_ExceptionMatches(PyExc_NotImplementedError)) {
+            PyErr_Clear();
+            return -1;
+        }
         Base::PyException e; // extract the Python error text
         e.ReportException();
+        return 0;
     }
-
-    return -1;
 }
 
 int FeaturePythonImp::isElementVisible(const char *element) const {
@@ -386,10 +405,14 @@ int FeaturePythonImp::isElementVisible(const char *element) const {
         return Py::Int(Base::pyCall(py_isElementVisible.ptr(),args.ptr()));
     }
     catch (Py::Exception&) {
+        if (PyErr_ExceptionMatches(PyExc_NotImplementedError)) {
+            PyErr_Clear();
+            return -2;
+        }
         Base::PyException e; // extract the Python error text
         e.ReportException();
+        return -1;
     }
-    return -2;
 }
 
 int FeaturePythonImp::setElementVisible(const char *element, bool visible) {
@@ -403,11 +426,14 @@ int FeaturePythonImp::setElementVisible(const char *element, bool visible) {
         return Py::Int(Base::pyCall(py_setElementVisible.ptr(),args.ptr()));
     }
     catch (Py::Exception&) {
+        if (PyErr_ExceptionMatches(PyExc_NotImplementedError)) {
+            PyErr_Clear();
+            return -2;
+        }
         Base::PyException e; // extract the Python error text
         e.ReportException();
+        return -1;
     }
-
-    return -2;
 }
 
 std::string FeaturePythonImp::getViewProviderName()
@@ -437,6 +463,10 @@ int FeaturePythonImp::canLinkProperties() const {
         return ok?1:0;
     }
     catch (Py::Exception&) {
+        if (PyErr_ExceptionMatches(PyExc_NotImplementedError)) {
+            PyErr_Clear();
+            return -1;
+        }
         Base::PyException e; // extract the Python error text
         e.ReportException();
         return 0;
@@ -453,6 +483,10 @@ int FeaturePythonImp::allowDuplicateLabel() const {
         return ok?1:0;
     }
     catch (Py::Exception&) {
+        if (PyErr_ExceptionMatches(PyExc_NotImplementedError)) {
+            PyErr_Clear();
+            return -1;
+        }
         Base::PyException e; // extract the Python error text
         e.ReportException();
         return 0;
@@ -469,13 +503,17 @@ int FeaturePythonImp::canLoadPartial() const {
         return ret;
     }
     catch (Py::Exception&) {
+        if (PyErr_ExceptionMatches(PyExc_NotImplementedError)) {
+            PyErr_Clear();
+            return -1;
+        }
         Base::PyException e; // extract the Python error text
         e.ReportException();
+        return 0;
     }
-    return -1;
 }
 
-bool FeaturePythonImp::redirectSubName(std::ostringstream &ss,
+int FeaturePythonImp::redirectSubName(std::ostringstream &ss,
         App::DocumentObject *topParent, App::DocumentObject *child) const 
 {
     FC_PY_CALL_CHECK(redirectSubName);
@@ -488,16 +526,20 @@ bool FeaturePythonImp::redirectSubName(std::ostringstream &ss,
         args.setItem(3,child?Py::Object(child->getPyObject(),true):Py::Object());
         Py::Object ret(Base::pyCall(py_redirectSubName.ptr(),args.ptr()));
         if(ret.isNone())
-            return false;
+            return 0;
         ss.str("");
         ss << ret.as_string();
-        return true;
+        return 1;
     }
     catch (Py::Exception&) {
+        if (PyErr_ExceptionMatches(PyExc_NotImplementedError)) {
+            PyErr_Clear();
+            return -1;
+        }
         Base::PyException e; // extract the Python error text
         e.ReportException();
+        return 0;
     }
-    return false;
 }
 
 // ---------------------------------------------------------

--- a/src/App/FeaturePython.cpp
+++ b/src/App/FeaturePython.cpp
@@ -88,11 +88,7 @@ bool FeaturePythonImp::execute()
             PyErr_Clear();
             return false;
         }
-        Base::PyException e; // extract the Python error text
-        e.ReportException();
-        std::stringstream str;
-        str << object->Label.getValue() << ": " << e.what();
-        throw Base::RuntimeError(str.str());
+        Base::PyException::ThrowException(); // extract the Python error text
     }
 
     return false;
@@ -165,7 +161,7 @@ bool FeaturePythonImp::onBeforeChangeLabel(std::string &newLabel)
         Py::Object ret(Base::pyCall(py_onBeforeChangeLabel.ptr(),args.ptr()));
         if(!ret.isNone()) {
             if(!ret.isString())
-                throw Base::TypeError("onBeforeChangeLabel expects to return a string");
+                throw Py::TypeError("onBeforeChangeLabel expects to return a string");
             newLabel = ret.as_string();
             return true;
         }
@@ -252,14 +248,14 @@ bool FeaturePythonImp::getSubObject(DocumentObject *&ret, const char *subname,
         if(!res.isTrue())
             return false;
         if(!res.isSequence())
-            throw Base::TypeError("getSubObject expects return type of tuple");
+            throw Py::TypeError("getSubObject expects return type of tuple");
         Py::Sequence seq(res);
         if(seq.length() < 2 ||
                 (!seq.getItem(0).isNone() && 
                  !PyObject_TypeCheck(seq.getItem(0).ptr(),&DocumentObjectPy::Type)) ||
                 !PyObject_TypeCheck(seq.getItem(1).ptr(),&Base::MatrixPy::Type))
         {
-            throw Base::TypeError("getSubObject expects return type of (obj,matrix,pyobj)");
+            throw Py::TypeError("getSubObject expects return type of (obj,matrix,pyobj)");
         }
         if(_mat) 
             *_mat = *static_cast<Base::MatrixPy*>(seq.getItem(1).ptr())->getMatrixPtr();
@@ -298,12 +294,12 @@ bool FeaturePythonImp::getSubObjects(std::vector<std::string> &ret, int reason) 
         if(!res.isTrue())
             return true;
         if(!res.isSequence())
-            throw Base::TypeError("getSubObjects expects return type of tuple");
+            throw Py::TypeError("getSubObjects expects return type of tuple");
         Py::Sequence seq(res);
         for(size_t i=0;i<seq.length();++i) {
             Py::Object name(seq[i].ptr());
             if(!name.isString())
-                throw Base::TypeError("getSubObjects expects string in returned sequence");
+                throw Py::TypeError("getSubObjects expects string in returned sequence");
             ret.push_back(name.as_string());
         }
         return true;
@@ -340,14 +336,14 @@ bool FeaturePythonImp::getLinkedObject(DocumentObject *&ret, bool recurse,
             return true;
         }
         if(!res.isSequence())
-            throw Base::TypeError("getLinkedObject expects return type of (object,matrix)");
+            throw Py::TypeError("getLinkedObject expects return type of (object,matrix)");
         Py::Sequence seq(res);
         if(seq.length() != 2 ||
                 (!seq.getItem(0).isNone() && 
                  !PyObject_TypeCheck(seq.getItem(0).ptr(),&DocumentObjectPy::Type)) ||
                 !PyObject_TypeCheck(seq.getItem(1).ptr(),&Base::MatrixPy::Type))
         {
-            throw Base::TypeError("getLinkedObject expects return type of (object,matrix)");
+            throw Py::TypeError("getLinkedObject expects return type of (object,matrix)");
         }
         if(_mat) 
             *_mat = *static_cast<Base::MatrixPy*>(seq.getItem(1).ptr())->getMatrixPtr();

--- a/src/App/FeaturePython.h
+++ b/src/App/FeaturePython.h
@@ -66,7 +66,7 @@ public:
 
     int allowDuplicateLabel() const;
 
-    bool redirectSubName(std::ostringstream &ss,
+    int redirectSubName(std::ostringstream &ss,
             App::DocumentObject *topParent, App::DocumentObject *child) const;
 
     int canLoadPartial() const;
@@ -268,8 +268,10 @@ public:
     virtual bool redirectSubName(std::ostringstream &ss,
             App::DocumentObject *topParent, App::DocumentObject *child) const override 
     {
-        return imp->redirectSubName(ss,topParent,child) ||
-            FeatureT::redirectSubName(ss,topParent,child);
+        int ret = imp->redirectSubName(ss,topParent,child);
+        if(ret < 0)
+            return FeatureT::redirectSubName(ss,topParent,child);
+        return ret?true:false;
     }
 
     virtual int canLoadPartial() const override {

--- a/src/Gui/ViewProviderPythonFeature.cpp
+++ b/src/Gui/ViewProviderPythonFeature.cpp
@@ -364,19 +364,21 @@ QIcon ViewProviderPythonFeatureImp::getIcon() const
         }
     }
     catch (Py::Exception&) {
-        Base::PyException e; // extract the Python error text
-        e.ReportException();
+        if (PyErr_ExceptionMatches(PyExc_NotImplementedError))
+            PyErr_Clear();
+        else {
+            Base::PyException e; // extract the Python error text
+            e.ReportException();
+        }
     }
 
     return QIcon();
 }
 
-std::vector<App::DocumentObject*> 
-ViewProviderPythonFeatureImp::claimChildren(std::vector<App::DocumentObject*>&& base) const 
+bool ViewProviderPythonFeatureImp::claimChildren(std::vector<App::DocumentObject*> &children) const 
 {
-    _FC_PY_CALL_CHECK(claimChildren,return(base));
+    _FC_PY_CALL_CHECK(claimChildren,return(false));
 
-    std::vector<App::DocumentObject*> children;
     Base::PyGILStateLocker lock;
     try {
         Py::Sequence list(Base::pyCall(py_claimChildren.ptr()));
@@ -389,24 +391,10 @@ ViewProviderPythonFeatureImp::claimChildren(std::vector<App::DocumentObject*>&& 
         }
     }
     catch (Py::Exception&) {
-        Base::PyException e; // extract the Python error text
-        e.ReportException();
-    }
-
-    return children;
-}
-
-bool ViewProviderPythonFeatureImp::useNewSelectionModel() const
-{
-    _FC_PY_CALL_CHECK(useNewSelectionModel,return(true));
-
-    // Run the useNewSelectionModel method of the proxy object.
-    Base::PyGILStateLocker lock;
-    try {
-        Py::Boolean ok(Py::Callable(py_useNewSelectionModel).apply(Py::Tuple()));
-        return (bool)ok;
-    }
-    catch (Py::Exception&) {
+        if (PyErr_ExceptionMatches(PyExc_NotImplementedError)) {
+            PyErr_Clear();
+            return false;
+        }
         Base::PyException e; // extract the Python error text
         e.ReportException();
     }
@@ -414,9 +402,32 @@ bool ViewProviderPythonFeatureImp::useNewSelectionModel() const
     return true;
 }
 
-std::string ViewProviderPythonFeatureImp::getElement(const SoDetail *det) const
+ViewProviderPythonFeatureImp::ValueT
+ViewProviderPythonFeatureImp::useNewSelectionModel() const
 {
-    _FC_PY_CALL_CHECK(getElement,return(std::string()));
+    FC_PY_CALL_CHECK(useNewSelectionModel);
+
+    // Run the useNewSelectionModel method of the proxy object.
+    Base::PyGILStateLocker lock;
+    try {
+        Py::Boolean ok(Py::Callable(py_useNewSelectionModel).apply(Py::Tuple()));
+        return ok?Accepted:Rejected;
+    }
+    catch (Py::Exception&) {
+        if (PyErr_ExceptionMatches(PyExc_NotImplementedError)) {
+            PyErr_Clear();
+            return NotImplemented;
+        }
+        Base::PyException e; // extract the Python error text
+        e.ReportException();
+    }
+
+    return Accepted;
+}
+
+bool ViewProviderPythonFeatureImp::getElement(const SoDetail *det, std::string &res) const
+{
+    _FC_PY_CALL_CHECK(getElement,return(false));
 
     // Run the onChanged method of the proxy object.
     Base::PyGILStateLocker lock;
@@ -429,17 +440,22 @@ std::string ViewProviderPythonFeatureImp::getElement(const SoDetail *det) const
         Py::Tuple args(1);
         args.setItem(0, Py::Object(pivy, true));
         Py::String name(Base::pyCall(py_getElement.ptr(),args.ptr()));
-        return (std::string)name;
+        res = name;
+        return true;
     }
     catch (const Base::Exception& e) {
         e.ReportException();
     }
     catch (Py::Exception&) {
+        if (PyErr_ExceptionMatches(PyExc_NotImplementedError)) {
+            PyErr_Clear();
+            return false;
+        }
         Base::PyException e; // extract the Python error text
         e.ReportException();
     }
 
-    return std::string();
+    return true;
 }
 
 ViewProviderPythonFeatureImp::ValueT
@@ -462,37 +478,46 @@ ViewProviderPythonFeatureImp::getElementPicked(const SoPickedPoint *pp, std::str
         e.ReportException();
     }
     catch (Py::Exception&) {
+        if (PyErr_ExceptionMatches(PyExc_NotImplementedError)) {
+            PyErr_Clear();
+            return NotImplemented;
+        }
         Base::PyException e; // extract the Python error text
         e.ReportException();
     }
 
-    return NotImplemented;
+    return Rejected;
 }
 
-SoDetail* ViewProviderPythonFeatureImp::getDetail(const char* name) const
+bool ViewProviderPythonFeatureImp::getDetail(const char* name, SoDetail *&det) const
 {
-    _FC_PY_CALL_CHECK(getDetail,return(0));
+    _FC_PY_CALL_CHECK(getDetail,return(false));
 
     // Run the onChanged method of the proxy object.
     Base::PyGILStateLocker lock;
     try {
         Py::Tuple args(1);
         args.setItem(0, Py::String(name));
-        Py::Object det(Base::pyCall(py_getDetail.ptr(),args.ptr()));
+        Py::Object pydet(Base::pyCall(py_getDetail.ptr(),args.ptr()));
         void* ptr = 0;
-        Base::Interpreter().convertSWIGPointerObj("pivy.coin", "SoDetail *", det.ptr(), &ptr, 0);
+        Base::Interpreter().convertSWIGPointerObj("pivy.coin", "SoDetail *", pydet.ptr(), &ptr, 0);
         SoDetail* detail = reinterpret_cast<SoDetail*>(ptr);
-        return detail ? detail->copy() : 0;
+        det = detail ? detail->copy() : 0;
+        return true;
     }
     catch (const Base::Exception& e) {
         e.ReportException();
     }
     catch (Py::Exception&) {
+        if (PyErr_ExceptionMatches(PyExc_NotImplementedError)) {
+            PyErr_Clear();
+            return false;
+        }
         Base::PyException e; // extract the Python error text
         e.ReportException();
     }
 
-    return 0;
+    return true;
 }
 
 ViewProviderPythonFeatureImp::ValueT ViewProviderPythonFeatureImp::getDetailPath(
@@ -527,6 +552,10 @@ ViewProviderPythonFeatureImp::ValueT ViewProviderPythonFeatureImp::getDetailPath
         e.ReportException();
     }
     catch (Py::Exception&) {
+        if (PyErr_ExceptionMatches(PyExc_NotImplementedError)) {
+            PyErr_Clear();
+            return NotImplemented;
+        }
         Base::PyException e; // extract the Python error text
         e.ReportException();
     }
@@ -570,23 +599,15 @@ ViewProviderPythonFeatureImp::setEdit(int ModNum)
         }
     }
     catch (Py::Exception&) {
-        // If an explicit NotImplementedError is raised then
-        // handle it differently to other RuntimeError
         if (PyErr_ExceptionMatches(PyExc_NotImplementedError)) {
             PyErr_Clear();
             return NotImplemented;
-        }
-        // If a runtime error occurred when calling setEdit
-        // then handle it like returning false
-        if (PyErr_ExceptionMatches(PyExc_RuntimeError)) {
-            PyErr_Clear();
-            return Rejected;
         }
         Base::PyException e; // extract the Python error text
         e.ReportException();
     }
 
-    return NotImplemented;
+    return Rejected;
 }
 
 ViewProviderPythonFeatureImp::ValueT
@@ -619,28 +640,21 @@ ViewProviderPythonFeatureImp::unsetEdit(int ModNum)
         }
     }
     catch (Py::Exception&) {
-        // If an explicit NotImplementedError is raised then
-        // handle it differently to other RuntimeError
         if (PyErr_ExceptionMatches(PyExc_NotImplementedError)) {
             PyErr_Clear();
             return NotImplemented;
-        }
-        // If a runtime error occurred when calling setEdit
-        // then handle it like returning false
-        if (PyErr_ExceptionMatches(PyExc_RuntimeError)) {
-            PyErr_Clear();
-            return Rejected;
         }
         Base::PyException e; // extract the Python error text
         e.ReportException();
     }
 
-    return NotImplemented;
+    return Rejected;
 }
 
-bool ViewProviderPythonFeatureImp::setEditViewer(View3DInventorViewer *viewer, int ModNum)
+ViewProviderPythonFeatureImp::ValueT
+ViewProviderPythonFeatureImp::setEditViewer(View3DInventorViewer *viewer, int ModNum)
 {
-    _FC_PY_CALL_CHECK(setEditViewer,return(false))
+    FC_PY_CALL_CHECK(setEditViewer)
 
     Base::PyGILStateLocker lock;
     try {
@@ -649,18 +663,23 @@ bool ViewProviderPythonFeatureImp::setEditViewer(View3DInventorViewer *viewer, i
         args.setItem(1, Py::Object(viewer->getPyObject(),true));
         args.setItem(2, Py::Int(ModNum));
         Py::Object ret(Base::pyCall(py_setEditViewer.ptr(),args.ptr()));
-        return ret.isTrue();
+        return ret.isTrue()?Accepted:Rejected;
     }
     catch (Py::Exception&) {
+        if (PyErr_ExceptionMatches(PyExc_NotImplementedError)) {
+            PyErr_Clear();
+            return NotImplemented;
+        }
         Base::PyException e; // extract the Python error text
         e.ReportException();
     }
-    return false;
+    return Rejected;
 }
 
-bool ViewProviderPythonFeatureImp::unsetEditViewer(View3DInventorViewer *viewer)
+ViewProviderPythonFeatureImp::ValueT
+ViewProviderPythonFeatureImp::unsetEditViewer(View3DInventorViewer *viewer)
 {
-    _FC_PY_CALL_CHECK(unsetEditViewer,return(false))
+    FC_PY_CALL_CHECK(unsetEditViewer)
 
     // Run the onChanged method of the proxy object.
     Base::PyGILStateLocker lock;
@@ -669,13 +688,17 @@ bool ViewProviderPythonFeatureImp::unsetEditViewer(View3DInventorViewer *viewer)
         args.setItem(0, Py::Object(object->getPyObject(),true));
         args.setItem(1, Py::Object(viewer->getPyObject(),true));
         Py::Object ret(Base::pyCall(py_unsetEditViewer.ptr(),args.ptr()));
-        return ret.isTrue();
+        return ret.isTrue()?Accepted:Rejected;
     }
     catch (Py::Exception&) {
+        if (PyErr_ExceptionMatches(PyExc_NotImplementedError)) {
+            PyErr_Clear();
+            return NotImplemented;
+        }
         Base::PyException e; // extract the Python error text
         e.ReportException();
     }
-    return false;
+    return Rejected;
 }
 
 ViewProviderPythonFeatureImp::ValueT
@@ -700,16 +723,20 @@ ViewProviderPythonFeatureImp::doubleClicked(void)
         }
     }
     catch (Py::Exception&) {
+        if (PyErr_ExceptionMatches(PyExc_NotImplementedError)) {
+            PyErr_Clear();
+            return NotImplemented;
+        }
         Base::PyException e; // extract the Python error text
         e.ReportException();
     }
 
-    return NotImplemented;
+    return Rejected;
 }
 
-void ViewProviderPythonFeatureImp::setupContextMenu(QMenu* menu)
+bool ViewProviderPythonFeatureImp::setupContextMenu(QMenu* menu)
 {
-    _FC_PY_CALL_CHECK(setupContextMenu,return);
+    _FC_PY_CALL_CHECK(setupContextMenu,return(false));
 
     // Run the attach method of the proxy object.
     Base::PyGILStateLocker lock;
@@ -720,7 +747,7 @@ void ViewProviderPythonFeatureImp::setupContextMenu(QMenu* menu)
             wrap.loadWidgetsModule();
             Py::Tuple args(1);
             args.setItem(0, wrap.fromQWidget(menu, "QMenu"));
-            Base::pyCall(py_setupContextMenu.ptr(),args.ptr());
+            return Base::pyCall(py_setupContextMenu.ptr(),args.ptr()).isTrue();
         }
         else {
             PythonWrapper wrap;
@@ -729,13 +756,18 @@ void ViewProviderPythonFeatureImp::setupContextMenu(QMenu* menu)
             Py::Tuple args(2);
             args.setItem(0, Py::Object(object->getPyObject(), true));
             args.setItem(1, wrap.fromQWidget(menu, "QMenu"));
-            Base::pyCall(py_setupContextMenu.ptr(),args.ptr());
+            return Base::pyCall(py_setupContextMenu.ptr(),args.ptr()).isTrue();
         }
     }
     catch (Py::Exception&) {
+        if (PyErr_ExceptionMatches(PyExc_NotImplementedError)) {
+            PyErr_Clear();
+            return false;
+        }
         Base::PyException e; // extract the Python error text
         e.ReportException();
     }
+    return true;
 }
 
 void ViewProviderPythonFeatureImp::attach(App::DocumentObject *pcObject)
@@ -850,9 +882,10 @@ void ViewProviderPythonFeatureImp::finishRestoring()
     }
 }
 
-bool ViewProviderPythonFeatureImp::onDelete(const std::vector<std::string> & sub)
+ViewProviderPythonFeatureImp::ValueT
+ViewProviderPythonFeatureImp::onDelete(const std::vector<std::string> & sub)
 {
-    _FC_PY_CALL_CHECK(onDelete,return(true)); 
+    FC_PY_CALL_CHECK(onDelete); 
 
     Base::PyGILStateLocker lock;
     try {
@@ -866,22 +899,25 @@ bool ViewProviderPythonFeatureImp::onDelete(const std::vector<std::string> & sub
             Py::Tuple args(1);
             args.setItem(0, seq);
             Py::Boolean ok(Base::pyCall(py_onDelete.ptr(),args.ptr()));
-            return (bool)ok;
+            return ok?Accepted:Rejected;
         }
         else {
             Py::Tuple args(2);
             args.setItem(0, Py::Object(object->getPyObject(), true));
             args.setItem(1, seq);
             Py::Boolean ok(Base::pyCall(py_onDelete.ptr(),args.ptr()));
-            return (bool)ok;
+            return ok?Accepted:Rejected;
         }
     }
     catch (Py::Exception&) {
+        if (PyErr_ExceptionMatches(PyExc_NotImplementedError)) {
+            PyErr_Clear();
+            return NotImplemented;
+        }
         Base::PyException e; // extract the Python error text
         e.ReportException();
+        return Rejected;
     }
-
-    return true;
 }
 
 ViewProviderPythonFeatureImp::ValueT
@@ -896,47 +932,59 @@ ViewProviderPythonFeatureImp::canDelete(App::DocumentObject *obj) const
         return Py::Boolean(Base::pyCall(py_canDelete.ptr(),args.ptr()))?Accepted:Rejected;
     }
     catch (Py::Exception&) {
+        if (PyErr_ExceptionMatches(PyExc_NotImplementedError)) {
+            PyErr_Clear();
+            return NotImplemented;
+        }
         Base::PyException e; // extract the Python error text
         e.ReportException();
         return Rejected;
     }
 }
 
-bool ViewProviderPythonFeatureImp::canAddToSceneGraph() const
+ViewProviderPythonFeatureImp::ValueT
+ViewProviderPythonFeatureImp::canAddToSceneGraph() const
 {
-    _FC_PY_CALL_CHECK(canAddToSceneGraph,return(true));
+    FC_PY_CALL_CHECK(canAddToSceneGraph);
 
     Base::PyGILStateLocker lock;
     try {
-        return Py::Boolean(Py::Callable(py_canAddToSceneGraph).apply(Py::Tuple()));
+        return Py::Boolean(Py::Callable(py_canAddToSceneGraph).apply(Py::Tuple()))?Accepted:Rejected;
     }
     catch (Py::Exception&) {
+        if (PyErr_ExceptionMatches(PyExc_NotImplementedError)) {
+            PyErr_Clear();
+            return NotImplemented;
+        }
         Base::PyException e; // extract the Python error text
         e.ReportException();
     }
-    return true;
+    return Accepted;
 }
 
-const char* ViewProviderPythonFeatureImp::getDefaultDisplayMode() const
+bool ViewProviderPythonFeatureImp::getDefaultDisplayMode(std::string &mode) const
 {
     _FC_PY_CALL_CHECK(getDefaultDisplayMode,return(0));
 
     // Run the getDefaultDisplayMode method of the proxy object.
     Base::PyGILStateLocker lock;
-    static std::string mode;
     try {
         Py::String str(Base::pyCall(py_getDefaultDisplayMode.ptr()));
         //if (str.isUnicode())
         //    str = str.encode("ascii"); // json converts strings into unicode
         mode = str.as_std_string("ascii");
-        return mode.c_str();
+        return true;
     }
     catch (Py::Exception&) {
+        if (PyErr_ExceptionMatches(PyExc_NotImplementedError)) {
+            PyErr_Clear();
+            return false;
+        }
         Base::PyException e; // extract the Python error text
         e.ReportException();
     }
 
-    return 0;
+    return true;
 }
 
 std::vector<std::string> ViewProviderPythonFeatureImp::getDisplayModes(void) const
@@ -965,8 +1013,12 @@ std::vector<std::string> ViewProviderPythonFeatureImp::getDisplayModes(void) con
         }
     }
     catch (Py::Exception&) {
-        Base::PyException e; // extract the Python error text
-        e.ReportException();
+        if (PyErr_ExceptionMatches(PyExc_NotImplementedError))
+            PyErr_Clear();
+        else {
+            Base::PyException e; // extract the Python error text
+            e.ReportException();
+        }
     }
 
     return modes;
@@ -1003,6 +1055,10 @@ ViewProviderPythonFeatureImp::canDragObjects() const
         return static_cast<bool>(ok) ? Accepted : Rejected;
     }
     catch (Py::Exception&) {
+        if (PyErr_ExceptionMatches(PyExc_NotImplementedError)) {
+            PyErr_Clear();
+            return NotImplemented;
+        }
         Base::PyException e; // extract the Python error text
         e.ReportException();
     }
@@ -1023,6 +1079,10 @@ ViewProviderPythonFeatureImp::canDragObject(App::DocumentObject* obj) const
         return static_cast<bool>(ok) ? Accepted : Rejected;
     }
     catch (Py::Exception&) {
+        if (PyErr_ExceptionMatches(PyExc_NotImplementedError)) {
+            PyErr_Clear();
+            return NotImplemented;
+        }
         Base::PyException e; // extract the Python error text
         e.ReportException();
     }
@@ -1053,6 +1113,10 @@ ViewProviderPythonFeatureImp::dragObject(App::DocumentObject* obj)
         }
     }
     catch (Py::Exception&) {
+        if (PyErr_ExceptionMatches(PyExc_NotImplementedError)) {
+            PyErr_Clear();
+            return NotImplemented;
+        }
         Base::PyException e; // extract the Python error text
         e.ReportException();
     }
@@ -1071,6 +1135,10 @@ ViewProviderPythonFeatureImp::canDropObjects() const
         return static_cast<bool>(ok) ? Accepted : Rejected;
     }
     catch (Py::Exception&) {
+        if (PyErr_ExceptionMatches(PyExc_NotImplementedError)) {
+            PyErr_Clear();
+            return NotImplemented;
+        }
         Base::PyException e; // extract the Python error text
         e.ReportException();
     }
@@ -1091,6 +1159,10 @@ ViewProviderPythonFeatureImp::canDropObject(App::DocumentObject* obj) const
         return static_cast<bool>(ok) ? Accepted : Rejected;
     }
     catch (Py::Exception&) {
+        if (PyErr_ExceptionMatches(PyExc_NotImplementedError)) {
+            PyErr_Clear();
+            return NotImplemented;
+        }
         Base::PyException e; // extract the Python error text
         e.ReportException();
     }
@@ -1120,9 +1192,11 @@ ViewProviderPythonFeatureImp::dropObject(App::DocumentObject* obj)
         }
     }
     catch (Py::Exception&) {
-        Base::PyException e; // extract the Python error text
-        e.ReportException();
-        throw e;
+        if (PyErr_ExceptionMatches(PyExc_NotImplementedError)) {
+            PyErr_Clear();
+            return NotImplemented;
+        }
+        Base::PyException::ThrowException();
     }
 
     return Rejected;
@@ -1140,6 +1214,10 @@ ViewProviderPythonFeatureImp::canDragAndDropObject(App::DocumentObject *obj) con
         return static_cast<bool>(ok) ? Accepted : Rejected;
     }
     catch (Py::Exception&) {
+        if (PyErr_ExceptionMatches(PyExc_NotImplementedError)) {
+            PyErr_Clear();
+            return NotImplemented;
+        }
         Base::PyException e; // extract the Python error text
         e.ReportException();
     }
@@ -1168,6 +1246,10 @@ ViewProviderPythonFeatureImp::canDropObjectEx(App::DocumentObject* obj,
         return static_cast<bool>(ok) ? Accepted : Rejected;
     }
     catch (Py::Exception&) {
+        if (PyErr_ExceptionMatches(PyExc_NotImplementedError)) {
+            PyErr_Clear();
+            return NotImplemented;
+        }
         Base::PyException e; // extract the Python error text
         e.ReportException();
     }
@@ -1175,11 +1257,10 @@ ViewProviderPythonFeatureImp::canDropObjectEx(App::DocumentObject* obj,
     return Rejected;
 }
 
-ViewProviderPythonFeatureImp::ValueT
-ViewProviderPythonFeatureImp::dropObjectEx(App::DocumentObject* obj, App::DocumentObject *owner, 
+bool ViewProviderPythonFeatureImp::dropObjectEx(App::DocumentObject* obj, App::DocumentObject *owner, 
         const char *subname, const std::vector<std::string> &elements,std::string &ret)
 {
-    FC_PY_CALL_CHECK(dropObjectEx);
+    _FC_PY_CALL_CHECK(dropObjectEx, return(false));
 
     Base::PyGILStateLocker lock;
     try {
@@ -1196,29 +1277,38 @@ ViewProviderPythonFeatureImp::dropObjectEx(App::DocumentObject* obj, App::Docume
         res = Base::pyCall(py_dropObjectEx.ptr(),args.ptr());
         if(!res.isNone())
             ret = res.as_string();
-        return Accepted;
+        return true;
     }
     catch (Py::Exception&) {
-        Base::PyException e; // extract the Python error text
-        throw e;
+        if (PyErr_ExceptionMatches(PyExc_NotImplementedError)) {
+            PyErr_Clear();
+            return false;
+        }
+        Base::PyException::ThrowException();
     }
+    return true;
 }
 
-bool ViewProviderPythonFeatureImp::isShow() const
+ViewProviderPythonFeatureImp::ValueT
+ViewProviderPythonFeatureImp::isShow() const
 {
-    _FC_PY_CALL_CHECK(isShow,return(false));
+    FC_PY_CALL_CHECK(isShow);
 
     Base::PyGILStateLocker lock;
     try {
         Py::Boolean ok(Base::pyCall(py_isShow.ptr()));
-        return static_cast<bool>(ok) ? true : false;
+        return static_cast<bool>(ok) ? Accepted : Rejected;
     }
     catch (Py::Exception&) {
+        if (PyErr_ExceptionMatches(PyExc_NotImplementedError)) {
+            PyErr_Clear();
+            return NotImplemented;
+        }
         Base::PyException e; // extract the Python error text
         e.ReportException();
     }
 
-    return false;
+    return Rejected;
 }
 
 
@@ -1233,6 +1323,10 @@ ViewProviderPythonFeatureImp::canRemoveChildrenFromRoot() const {
         return static_cast<bool>(ok) ? Accepted : Rejected;
     }
     catch (Py::Exception&) {
+        if (PyErr_ExceptionMatches(PyExc_NotImplementedError)) {
+            PyErr_Clear();
+            return NotImplemented;
+        }
         Base::PyException e; // extract the Python error text
         e.ReportException();
     }
@@ -1252,10 +1346,14 @@ bool ViewProviderPythonFeatureImp::getDropPrefix(std::string &prefix) const {
         return true;
     }
     catch (Py::Exception&) {
+        if (PyErr_ExceptionMatches(PyExc_NotImplementedError)) {
+            PyErr_Clear();
+            return false;
+        }
         Base::PyException e; // extract the Python error text
         e.ReportException();
     }
-    return false;
+    return true;
 }
 
 ViewProviderPythonFeatureImp::ValueT 
@@ -1276,16 +1374,20 @@ ViewProviderPythonFeatureImp::replaceObject(
         return ok ? Accepted : Rejected;
     }
     catch (Py::Exception&) {
+        if (PyErr_ExceptionMatches(PyExc_NotImplementedError)) {
+            PyErr_Clear();
+            return NotImplemented;
+        }
         Base::PyException e; // extract the Python error text
         e.ReportException();
     }
     return Rejected;
 }
 
-ViewProviderDocumentObject *
-ViewProviderPythonFeatureImp::getLinkedViewProvider(bool recursive) const
+bool ViewProviderPythonFeatureImp::getLinkedViewProvider(
+        ViewProviderDocumentObject *&vp, std::string *subname, bool recursive) const
 {
-    _FC_PY_CALL_CHECK(getLinkedViewProvider,return(0));
+    _FC_PY_CALL_CHECK(getLinkedViewProvider,return(false));
 
     Base::PyGILStateLocker lock;
     try {
@@ -1293,19 +1395,33 @@ ViewProviderPythonFeatureImp::getLinkedViewProvider(bool recursive) const
         args.setItem(0,Py::Boolean(recursive));
         Py::Object res(Base::pyCall(py_getLinkedViewProvider.ptr(),args.ptr()));
         if(res.isNone())
-            return 0;
-        if(PyObject_TypeCheck(res.ptr(),&ViewProviderDocumentObjectPy::Type))
-            return static_cast<ViewProviderDocumentObjectPy*>(
+            return true;
+        if(PyObject_TypeCheck(res.ptr(),&ViewProviderDocumentObjectPy::Type)) {
+            vp = static_cast<ViewProviderDocumentObjectPy*>(
                     res.ptr())->getViewProviderDocumentObjectPtr();
-
-        FC_ERR("getLinkedViewProvider(): invalid return object type '"
-                << res.ptr()->ob_type->tp_name << "'");
+        } else if (PySequence_Check(res.ptr()) && PySequence_Length(res.ptr())==2) {
+            Py::Sequence seq(res);
+            Py::Object item0(seq[0].ptr());
+            Py::Object item1(seq[0].ptr());
+            if(PyObject_TypeCheck(item0.ptr(), &ViewProviderDocumentObjectPy::Type) && item1.isString()) {
+                if(subname)
+                    *subname = Py::String(item1).as_std_string("utf-8");
+                vp = static_cast<ViewProviderDocumentObjectPy*>(
+                        item0.ptr())->getViewProviderDocumentObjectPtr();
+            }
+        } else 
+            FC_ERR("getLinkedViewProvider(): invalid return type, expects ViewObject or (ViewObject, subname)");
+        return true;
     }
     catch (Py::Exception&) {
+        if (PyErr_ExceptionMatches(PyExc_NotImplementedError)) {
+            PyErr_Clear();
+            return false;
+        }
         Base::PyException e; // extract the Python error text
         e.ReportException();
     }
-    return 0;
+    return true;
 }
 
 

--- a/src/Gui/ViewProviderPythonFeature.h
+++ b/src/Gui/ViewProviderPythonFeature.h
@@ -53,19 +53,19 @@ public:
 
     // Returns the icon
     QIcon getIcon() const;
-    std::vector<App::DocumentObject*> claimChildren(std::vector<App::DocumentObject*>&&) const;
-    bool useNewSelectionModel() const;
+    bool claimChildren(std::vector<App::DocumentObject*>&) const;
+    ValueT useNewSelectionModel() const;
     ValueT getElementPicked(const SoPickedPoint *pp, std::string &subname) const;
-    std::string getElement(const SoDetail *det) const;
-    SoDetail* getDetail(const char*) const;
+    bool getElement(const SoDetail *det, std::string &) const;
+    bool getDetail(const char*, SoDetail *&det) const;
     ValueT getDetailPath(const char *name, SoFullPath *path, bool append, SoDetail *&det) const;
     std::vector<Base::Vector3d> getSelectionShape(const char* Element) const;
     ValueT setEdit(int ModNum);
     ValueT unsetEdit(int ModNum);
-    bool setEditViewer(View3DInventorViewer*, int ModNum);
-    bool unsetEditViewer(View3DInventorViewer*);
+    ValueT setEditViewer(View3DInventorViewer*, int ModNum);
+    ValueT unsetEditViewer(View3DInventorViewer*);
     ValueT doubleClicked(void);
-    void setupContextMenu(QMenu* menu);
+    bool setupContextMenu(QMenu* menu);
 
     /** @name Update data methods*/
     //@{
@@ -74,16 +74,16 @@ public:
     void onChanged(const App::Property* prop);
     void startRestoring();
     void finishRestoring();
-    bool onDelete(const std::vector<std::string> & sub);
+    ValueT onDelete(const std::vector<std::string> & sub);
     ValueT canDelete(App::DocumentObject *obj) const;
     //@}
 
     /** @name Display methods */
     //@{
     /// Returns true if the icon must always appear enabled in the tree view
-    bool isShow() const;
+    ValueT isShow() const;
     /// get the default display mode
-    const char* getDefaultDisplayMode() const;
+    bool getDefaultDisplayMode(std::string &mode) const;
     /// returns a list of all possible modes
     std::vector<std::string> getDisplayModes(void) const;
     /// set the display mode
@@ -112,14 +112,15 @@ public:
     ValueT canDropObjectEx(App::DocumentObject *obj, App::DocumentObject *, 
             const char *,const std::vector<std::string> &elements) const;
     /** Add an object with full quanlified name to the view provider by drag and drop */
-    ValueT dropObjectEx(App::DocumentObject *obj, App::DocumentObject *,
+    bool dropObjectEx(App::DocumentObject *obj, App::DocumentObject *,
             const char *, const std::vector<std::string> &elements, std::string &ret);
     ValueT replaceObject(App::DocumentObject *, App::DocumentObject *);
     //@}
 
-    ViewProviderDocumentObject *getLinkedViewProvider(bool recursive) const;
+    bool getLinkedViewProvider(ViewProviderDocumentObject *&res, 
+            std::string *subname, bool recursive) const;
 
-    bool canAddToSceneGraph() const;
+    ValueT canAddToSceneGraph() const;
 
     bool getDropPrefix(std::string &prefix) const;
 
@@ -213,7 +214,10 @@ public:
     }
 
     std::vector<App::DocumentObject*> claimChildren() const override {
-        return imp->claimChildren(ViewProviderT::claimChildren());
+        std::vector<App::DocumentObject *> res;
+        if(!imp->claimChildren(res))
+            return ViewProviderT::claimChildren();
+        return res;
     }
 
     /** @name Nodes */
@@ -233,7 +237,14 @@ public:
     /** @name Selection handling */
     //@{
     virtual bool useNewSelectionModel() const override {
-        return imp->useNewSelectionModel();
+        switch(imp->useNewSelectionModel()) {
+        case ViewProviderPythonFeatureImp::Accepted:
+            return true;
+        case ViewProviderPythonFeatureImp::Rejected:
+            return false;
+        default:
+            return ViewProviderT::useNewSelectionModel();
+        }
     }
     virtual bool getElementPicked(const SoPickedPoint *pp, std::string &subname) const override {
         auto ret = imp->getElementPicked(pp,subname);
@@ -244,13 +255,15 @@ public:
         return false;
     }
     virtual std::string getElement(const SoDetail *det) const override {
-        std::string name = imp->getElement(det);
-        if (!name.empty()) return name;
-        return ViewProviderT::getElement(det);
+        std::string name;
+        if(!imp->getElement(det,name))
+            return ViewProviderT::getElement(det);
+        return name;
     }
     virtual SoDetail* getDetail(const char* name) const override {
-        SoDetail* det = imp->getDetail(name);
-        if (det) return det;
+        SoDetail *det = 0;
+        if(!imp->getDetail(name,det))
+            return det;
         return ViewProviderT::getDetail(name);
     }
     virtual bool getDetailPath(const char *name, SoFullPath *path, bool append,SoDetail *&det) const override {
@@ -279,9 +292,14 @@ public:
         ViewProviderT::getTaskViewContent(c);
     }
     virtual bool onDelete(const std::vector<std::string> & sub) override {
-        bool ok = imp->onDelete(sub);
-        if (!ok) return ok;
-        return ViewProviderT::onDelete(sub);
+        switch(imp->onDelete(sub)) {
+        case ViewProviderPythonFeatureImp::Accepted:
+            return true;
+        case ViewProviderPythonFeatureImp::Rejected:
+            return false;
+        default:
+            return ViewProviderT::onDelete(sub);
+        }
     }
     virtual bool canDelete(App::DocumentObject *obj) const override {
         switch(imp->canDelete(obj)) {
@@ -404,13 +422,8 @@ public:
     {
         App::AutoTransaction committer;
         std::string ret;
-        switch (imp->dropObjectEx(obj,owner,subname,elements,ret)) {
-        case ViewProviderPythonFeatureImp::NotImplemented:
+        if(!imp->dropObjectEx(obj,owner,subname,elements,ret))
             ret = ViewProviderT::dropObjectEx(obj,owner,subname,elements);
-            break;
-        default:
-            break;
-        }
         return ret;
     }
     //@}
@@ -419,13 +432,21 @@ public:
     //@{
     /// Returns true if the icon must always appear enabled in the tree view
     virtual bool isShow() const override {
-        bool ok = imp->isShow();
-        if (ok) return ok;
-        return ViewProviderT::isShow();
+        switch(imp->isShow()) {
+        case ViewProviderPythonFeatureImp::Accepted:
+            return true;
+        case ViewProviderPythonFeatureImp::Rejected:
+            return false;
+        default:
+            return ViewProviderT::isShow();
+        }
     }
     /// get the default display mode
     virtual const char* getDefaultDisplayMode() const override {
-        return imp->getDefaultDisplayMode();
+        defaultMode.clear();
+        if(imp->getDefaultDisplayMode(defaultMode))
+            return defaultMode.c_str();
+        return ViewProviderT::getDefaultDisplayMode();
     }
     /// returns a list of all possible modes
     virtual std::vector<std::string> getDisplayModes(void) const override {
@@ -458,7 +479,14 @@ public:
     }
 
     virtual bool canAddToSceneGraph() const override {
-        return ViewProviderT::canAddToSceneGraph() && imp->canAddToSceneGraph();
+        switch(imp->canAddToSceneGraph()) {
+        case ViewProviderPythonFeatureImp::Accepted:
+            return true;
+        case ViewProviderPythonFeatureImp::Rejected:
+            return false;
+        default:
+            return ViewProviderT::canAddToSceneGraph();
+        }
     }
 
 protected:
@@ -539,28 +567,19 @@ protected:
         }
     }
 
-//FIXME: ViewProviderPythonFeatureT hides overloaded virtual functions
-#if defined(__clang__)
-# pragma clang diagnostic push
-# pragma clang diagnostic ignored "-Woverloaded-virtual"
-#endif
-
-    virtual ViewProviderDocumentObject *getLinkedViewProvider(bool recursive=false) const {
-        auto res = imp->getLinkedViewProvider(recursive);
-        if(!res)
-            res = ViewProviderT::getLinkedViewProvider();
+    virtual ViewProviderDocumentObject *getLinkedViewProvider(
+            std::string *subname=0, bool recursive=false) const override{
+        ViewProviderDocumentObject *res = 0;
+        if(!imp->getLinkedViewProvider(res, subname, recursive))
+            res = ViewProviderT::getLinkedViewProvider(subname,recursive);
         return res;
     }
-
-#if defined(__clang__)
-# pragma clang diagnostic pop
-#endif
 
 public:
     virtual void setupContextMenu(QMenu* menu, QObject* recipient, const char* member) override
     {
-        ViewProviderT::setupContextMenu(menu, recipient, member);
-        imp->setupContextMenu(menu);
+        if(!imp->setupContextMenu(menu))
+            ViewProviderT::setupContextMenu(menu, recipient, member);
     }
 
 protected:
@@ -585,6 +604,7 @@ protected:
 private:
     ViewProviderPythonFeatureImp* imp;
     App::PropertyPythonObject Proxy;
+    mutable std::string defaultMode;
     std::string viewerMode;
     bool _attached;
 };


### PR DESCRIPTION
Recognize NotImplementedError as an indication to call the C++ implementation, for both FeaturePython and ViewProviderPythonFeature.

BTW, this patch also fixed virtual function shadowing in ViewProviderPythonFeature.
