### PR TITLE
Gui: fix SelectionSingleton::checkSelection()

### DIFF
--- a/src/Gui/Selection.cpp
+++ b/src/Gui/Selection.cpp
@@ -1582,7 +1582,7 @@ int SelectionSingleton::checkSelection(const char *pDocName, const char *pObject
     if(!selList)
         selList = &_SelList;
     for (auto &s : *selList) {
-        if (s.DocName==pDocName && s.FeatName==pObjectName) {
+        if (s.DocName==pDocName && s.FeatName==sel.FeatName) {
             if(!pSubName || s.SubName==pSubName)
                 return 1;
             if(resolve>1 && boost::starts_with(s.SubName,prefix))


### PR DESCRIPTION
Reported [here](https://forum.freecadweb.org/viewtopic.php?f=8&t=37757&p=331266#p331229)

There is still some problem, as the edge highlight enforcing mechanism in `DlgFilletEdges` does not quite work with the new context selection. I'll fix that later.