### PR TITLE
Add Python console option to save history across sessions

### DIFF
--- a/src/Gui/PythonConsole.cpp
+++ b/src/Gui/PythonConsole.cpp
@@ -1423,7 +1423,10 @@ void PythonConsole::saveHistory() const
     QFile f(d->historyFile);
     if (f.open(QIODevice::WriteOnly)) {
         QTextStream t (&f);
-        const QStringList& hist = d->history.values();
+        QStringList hist = d->history.values();
+        // only save last 100 entries so we don't inflate forever...
+        if (hist.length() > 100)
+            hist = hist.mid(hist.length()-100);
         for (QStringList::ConstIterator it = hist.begin(); it != hist.end(); ++it)
             t << *it << "\n";
         f.close();

--- a/src/Gui/PythonConsole.cpp
+++ b/src/Gui/PythonConsole.cpp
@@ -92,7 +92,7 @@ struct PythonConsoleP
     InteractiveInterpreter* interpreter;
     CallTipsList* callTipsList;
     ConsoleHistory history;
-    QString output, error, info;
+    QString output, error, info, historyFile;
     QStringList statements;
     bool interactive;
     QMap<QString, QColor> colormap; // Color map
@@ -106,6 +106,7 @@ struct PythonConsoleP
         interpreter = 0;
         callTipsList = 0;
         interactive = false;
+        historyFile = QString::fromUtf8((App::Application::getUserAppDataDir() + "PythonHistory.log").c_str());
         colormap[QLatin1String("Text")] = Qt::black;
         colormap[QLatin1String("Bookmark")] = Qt::cyan;
         colormap[QLatin1String("Breakpoint")] = Qt::red;
@@ -472,11 +473,13 @@ PythonConsole::PythonConsole(QWidget *parent)
     .arg(QString::fromLatin1(version), QString::fromLatin1(platform));
     d->output = d->info;
     printPrompt(PythonConsole::Complete);
+    loadHistory();
 }
 
 /** Destroys the object and frees any allocated resources */
 PythonConsole::~PythonConsole()
 {
+    saveHistory();
     Base::PyGILStateLocker lock;
     getWindowParameter()->Detach( this );
     delete pythonSyntax;
@@ -1273,6 +1276,16 @@ void PythonConsole::contextMenuEvent ( QContextMenuEvent * e )
         this->setWordWrapMode(QTextOption::NoWrap);
     }
 
+    QAction* saveh = menu.addAction(tr("Save history"));
+    saveh->setToolTip(tr("Saves python history across FreeCAD sessions"));
+    saveh->setCheckable(true);
+
+    if (hGrp->GetBool("SavePythonHistory", false)) {
+        saveh->setChecked(true);
+    } else {
+        saveh->setChecked(false);
+    }
+
     QAction* exec = menu.exec(e->globalPos());
     if (exec == wrap) {
         if (wrap->isChecked()) {
@@ -1282,7 +1295,14 @@ void PythonConsole::contextMenuEvent ( QContextMenuEvent * e )
             this->setWordWrapMode(QTextOption::NoWrap);
             hGrp->SetBool("PythonWordWrap", false);
         }
+    } else if (exec == saveh) {
+        if (saveh->isChecked()) {
+            hGrp->SetBool("SavePythonHistory", true);
+        } else {
+            hGrp->SetBool("SavePythonHistory", false);
+        }
     }
+
 }
 
 void PythonConsole::onClearConsole()
@@ -1361,6 +1381,53 @@ QString PythonConsole::readline( void )
       { PyErr_SetInterrupt(); }            //< send SIGINT to python
     this->_sourceDrain = NULL;             //< disable source drain
     return inputBuffer.append(QChar::fromLatin1('\n')); //< pass a newline here, since the readline-caller may need it!
+}
+
+/**
+ * loads history contents from the default history file
+ */
+void PythonConsole::loadHistory() const
+{
+    // only load contents if history is empty, to not overwrite anything
+    if (!d->history.isEmpty())
+        return;
+    ParameterGrp::handle hGrp = App::GetApplication().GetUserParameter().
+        GetGroup("BaseApp")->GetGroup("Preferences")->GetGroup("General");
+    if (!hGrp->GetBool("SavePythonHistory", false))
+        return;
+    QFile f(d->historyFile);
+    if (f.open(QIODevice::ReadOnly | QIODevice::Text)) {
+        QString l;
+        while (!f.atEnd()) {
+            l = QString::fromUtf8(f.readLine());
+            if (!l.isEmpty()) {
+                l.chop(1); // removes the last \n
+                d->history.append(l);
+            }
+        }
+        f.close();
+    }
+}
+
+/**
+ * saves the current history to the default history file
+ */
+void PythonConsole::saveHistory() const
+{
+    if (d->history.isEmpty())
+        return;
+    ParameterGrp::handle hGrp = App::GetApplication().GetUserParameter().
+        GetGroup("BaseApp")->GetGroup("Preferences")->GetGroup("General");
+    if (!hGrp->GetBool("SavePythonHistory", false))
+        return;
+    QFile f(d->historyFile);
+    if (f.open(QIODevice::WriteOnly)) {
+        QTextStream t (&f);
+        const QStringList& hist = d->history.values();
+        for (QStringList::ConstIterator it = hist.begin(); it != hist.end(); ++it)
+            t << *it << "\n";
+        f.close();
+    }
 }
 
 // ---------------------------------------------------------------------

--- a/src/Gui/PythonConsole.h
+++ b/src/Gui/PythonConsole.h
@@ -79,13 +79,13 @@ public:
     void append(const QString &inputLine);
     const QStringList& values() const;
     void restart();
-		void markScratch( void );
-		void doScratch( void );
+    void markScratch( void );
+    void doScratch( void );
 
 private:
     QStringList                _history;
     QStringList::ConstIterator _it;
-		int                        _scratchBegin;
+    int                        _scratchBegin;
     QString                    _prefix;
 };
 
@@ -150,6 +150,8 @@ private:
     void insertPythonError (const QString&);
     void runSourceFromMimeData(const QString&);
     void appendOutput(const QString&, int);
+    void loadHistory() const;
+    void saveHistory() const;
 
 Q_SIGNALS:
     void pendingSource( void );
@@ -163,6 +165,7 @@ private:
 private:
     PythonConsoleHighlighter* pythonSyntax;
     QString                 *_sourceDrain;
+    QString                  _historyFile;
 };
 
 /**


### PR DESCRIPTION
This PR adds a context menu option to the python console to remember history across sessions, the same way as the linux terminal does. If enabled, it saves a PythonHistory.log file in the UserAppData dir

This PR is basically so some C++ guru out there can have a look before merging

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
