### PR TITLE
Draft: DraftFillet, improved the tool, now the radius can be chosen when the tool is launched (resubmitted)

### DIFF
--- a/src/Mod/Draft/DraftFillet.py
+++ b/src/Mod/Draft/DraftFillet.py
@@ -202,16 +202,25 @@ class CommandFillet(DraftTools.Creator):
             self.ui.labelRadius.setText(label)
             self.ui.radiusValue.setToolTip(tooltip)
             self.ui.setRadiusValue(self.rad, "Length")
-            self.ui.checkdelete = self.ui._checkbox("isdelete",
-                                                    self.ui.layout,
-                                                    checked=self.delete)
-            self.ui.checkdelete.setText(translate("draft",
-                                                  "Delete original objects"))
-            self.ui.checkdelete.show()
+            self.ui.check_delete = self.ui._checkbox("isdelete",
+                                                     self.ui.layout,
+                                                     checked=self.delete)
+            self.ui.check_delete.setText(translate("draft",
+                                                   "Delete original objects"))
+            self.ui.check_delete.show()
+            self.ui.check_chamfer = self.ui._checkbox("ischamfer",
+                                                      self.ui.layout,
+                                                      checked=self.chamfer)
+            self.ui.check_chamfer.setText(translate("draft",
+                                                    "Create chamfer"))
+            self.ui.check_chamfer.show()
 
-            QtCore.QObject.connect(self.ui.checkdelete,
+            QtCore.QObject.connect(self.ui.check_delete,
                                    QtCore.SIGNAL("stateChanged(int)"),
                                    self.set_delete)
+            QtCore.QObject.connect(self.ui.check_chamfer,
+                                   QtCore.SIGNAL("stateChanged(int)"),
+                                   self.set_chamfer)
             self.linetrack = DraftTrackers.lineTracker(dotted=True)
             self.arctrack = DraftTrackers.arcTracker()
             # self.call = self.view.addEventCallback("SoEvent", self.action)
@@ -232,18 +241,24 @@ class CommandFillet(DraftTools.Creator):
             DraftTools.redraw3DView()
 
     def set_delete(self):
-        """This function is called when the checkbox state changes"""
-        self.delete = self.ui.checkdelete.isChecked()
+        """This function is called when the delete checkbox changes"""
+        self.delete = self.ui.check_delete.isChecked()
         FCC.PrintMessage(translate("draft", "Delete original objects: ")
                          + str(self.delete) + "\n")
+
+    def set_chamfer(self):
+        """This function is called when the chamfer checkbox changes"""
+        self.chamfer = self.ui.check_chamfer.isChecked()
+        FCC.PrintMessage(translate("draft", "Chamfer mode: ")
+                         + str(self.chamfer) + "\n")
 
     def numericRadius(self, rad):
         """This function is called when a valid radius is entered"""
         self.rad = rad
-        self.draw_arc(rad, self.delete)
+        self.draw_arc(rad, self.chamfer, self.delete)
         self.finish()
 
-    def draw_arc(self, rad, delete):
+    def draw_arc(self, rad, chamfer, delete):
         """Processes the selection and draws the actual object"""
         wires = FreeCADGui.Selection.getSelection()
         _two = translate("draft", "two elements needed")
@@ -276,6 +291,8 @@ class CommandFillet(DraftTools.Creator):
         name = translate("draft", "Create fillet")
 
         args = _wires + ', radius=' + str(rad)
+        if chamfer:
+            args += ', chamfer=' + str(chamfer)
         if delete:
             args += ', delete=' + str(delete)
         func = ['arc = DraftFillet.makeFillet(' + args + ')']

--- a/src/Mod/Draft/DraftFillet.py
+++ b/src/Mod/Draft/DraftFillet.py
@@ -297,13 +297,14 @@ class CommandFillet(DraftTools.Creator):
             args += ', delete=' + str(delete)
         func = ['arc = DraftFillet.makeFillet(' + args + ')']
         func.append('Draft.autogroup(arc)')
-        func.append('FreeCAD.ActiveDocument.recompute()')
-        self.commit(name, func)
 
         # Here we could remove the old objects, but the makeFillet()
         # command already includes an option to remove them.
+        # Therefore, the following is not necessary
         # rems = [doc + 'removeObject("' + o.Name + '")' for o in wires]
         # func.extend(rems)
+        func.append('FreeCAD.ActiveDocument.recompute()')
+        self.commit(name, func)
 
     def finish(self, close=False):
         """Terminates the operation."""

--- a/src/Mod/Draft/DraftFillet.py
+++ b/src/Mod/Draft/DraftFillet.py
@@ -1,3 +1,9 @@
+"""This module provides the Draft fillet tool.
+"""
+## @package DraftFillet
+# \ingroup DRAFT
+# \brief This module provides the Draft fillet tool.
+
 import FreeCAD
 from FreeCAD import Console as FCC
 import Draft

--- a/src/Mod/Draft/InitGui.py
+++ b/src/Mod/Draft/InitGui.py
@@ -64,7 +64,7 @@ class DraftWorkbench(Workbench):
 
         # Import Draft tools, icons
         try:
-            import os, Draft_rc, DraftTools, DraftGui
+            import os, Draft_rc, DraftTools, DraftGui, DraftFillet
             from DraftTools import translate
             FreeCADGui.addLanguagePath(":/translations")
             FreeCADGui.addIconPath(":/icons")


### PR DESCRIPTION
This was originally pull request #2472. However, since that request had some merge conflicts it was withdrawn. This pull request is the correct one.

---
Improved the tool, now the radius of the fillet can be chosen when the tool is launched, and options to delete the original two lines, and creating a chamfer are provided.

Now the tool should work without needing to run `import DraftFillet` before loading the Draft Workbench.
Forum thread: [New tool: Draft_Fillet, prototype implementation](https://forum.freecadweb.org/viewtopic.php?f=23&t=38715)

---
- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists