### PR TITLE
TechDraw, fixed Doxygen complaint: @brief not @Brief

### DIFF
--- a/src/Mod/TechDraw/Gui/mrichtextedit.h
+++ b/src/Mod/TechDraw/Gui/mrichtextedit.h
@@ -33,7 +33,7 @@
 #include "ui_mrichtextedit.h"
 
 /**
- * @Brief A simple rich-text editor
+ * @brief A simple rich-text editor
  */
 class MRichTextEdit : public QWidget, protected Ui::MRichTextEdit {
     Q_OBJECT


### PR DESCRIPTION
All Doxygen commands are lowercase `@brief` not `@Brief`.

---

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists