### PR TITLE
Draft: DraftLayer, provide Draft_Layer.svg icon, and use it for consistency instead of Draft_VisGroup.svg

### DIFF
--- a/src/Mod/Draft/DraftLayer.py
+++ b/src/Mod/Draft/DraftLayer.py
@@ -78,7 +78,7 @@ class CommandLayer():
     """The Draft_Layer FreeCAD command"""
 
     def GetResources(self):
-        return {'Pixmap'  : 'Draft_VisGroup',
+        return {'Pixmap'  : 'Draft_Layer',
                 'MenuText': QT_TRANSLATE_NOOP("Draft_Layer", "Layer"),
                 'ToolTip' : QT_TRANSLATE_NOOP("Draft_Layer", "Adds a layer")}
 
@@ -152,7 +152,7 @@ class ViewProviderLayer:
         if hasattr(self,"icondata"):
             return self.icondata
         import Draft_rc
-        return ":/icons/Draft_VisGroup.svg"
+        return ":/icons/Draft_Layer.svg"
 
     def attach(self,vobj):
         self.Object = vobj.Object
@@ -329,7 +329,7 @@ class ViewProviderLayerContainer:
     def getIcon(self):
 
         import Draft_rc
-        return ":/icons/Draft_VisGroup.svg"
+        return ":/icons/Draft_Layer.svg"
 
     def attach(self,vobj):
 
@@ -339,7 +339,7 @@ class ViewProviderLayerContainer:
 
         import Draft_rc
         from PySide import QtCore,QtGui
-        action1 = QtGui.QAction(QtGui.QIcon(":/icons/Draft_VisGroup.svg"),"Merge duplicates",menu)
+        action1 = QtGui.QAction(QtGui.QIcon(":/icons/Draft_Layer.svg"),"Merge duplicates",menu)
         action1.triggered.connect(self.mergeByName)
         menu.addAction(action1)
 
@@ -348,7 +348,7 @@ class ViewProviderLayerContainer:
         if hasattr(self,"Object") and hasattr(self.Object,"Group"):
             layers = [o for o in self.Object.Group if (hasattr(o,"Proxy") and isinstance(o.Proxy,Layer))]
             todelete = []
-            for layer in layerss:
+            for layer in layers:
                 if layer.Label[-1].isdigit() and layer.Label[-2].isdigit() and layer.Label[-3].isdigit():
                     orig = None
                     for ol in layer:

--- a/src/Mod/Draft/Resources/Draft.qrc
+++ b/src/Mod/Draft/Resources/Draft.qrc
@@ -21,6 +21,7 @@
         <file>icons/Draft_Finish.svg</file>
         <file>icons/Draft_Fillet.svg</file>
         <file>icons/Draft_Join.svg</file>
+        <file>icons/Draft_Layer.svg</file>
         <file>icons/Draft_Line.svg</file>
         <file>icons/Draft_Lock.svg</file>
         <file>icons/Draft_Macro.svg</file>

--- a/src/Mod/Draft/Resources/icons/Draft_Layer.svg
+++ b/src/Mod/Draft/Resources/icons/Draft_Layer.svg
@@ -1,0 +1,214 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="64px"
+   height="64px"
+   id="svg2985"
+   version="1.1"
+   inkscape:version="0.48.5 r10040"
+   sodipodi:docname="Draft_VisGroup.svg">
+  <defs
+     id="defs2987">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3815">
+      <stop
+         style="stop-color:#d3d7cf;stop-opacity:1;"
+         offset="0"
+         id="stop3817" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="1"
+         id="stop3819" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3807">
+      <stop
+         style="stop-color:#d3d7cf;stop-opacity:1;"
+         offset="0"
+         id="stop3809" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="1"
+         id="stop3811" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3799">
+      <stop
+         style="stop-color:#d3d7cf;stop-opacity:1;"
+         offset="0"
+         id="stop3801" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="1"
+         id="stop3803" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3799"
+       id="linearGradient3805"
+       x1="53.257175"
+       y1="19.086002"
+       x2="25.928942"
+       y2="-1.3815211"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-0.02151317,-0.91811256)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3807"
+       id="linearGradient3813"
+       x1="61.719494"
+       y1="27.953379"
+       x2="36.843666"
+       y2="12.022611"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0.75600263,0.0412295)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3815"
+       id="linearGradient3821"
+       x1="74.313408"
+       y1="43.419685"
+       x2="48.388607"
+       y2="23.542751"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-0.18895427,-1.1237431)" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="6.6796359"
+     inkscape:cx="-11.390884"
+     inkscape:cy="30.609684"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:document-units="px"
+     inkscape:grid-bbox="true"
+     inkscape:window-width="1600"
+     inkscape:window-height="837"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:snap-bbox="true"
+     inkscape:snap-global="false"
+     inkscape:snap-nodes="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid2985"
+       units="px"
+       empspacing="2"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true"
+       spacingx="1px"
+       spacingy="1px" />
+  </sodipodi:namedview>
+  <g
+     id="layer1"
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer">
+    <rect
+       style="color:#000000;fill:url(#linearGradient3821);fill-opacity:1;fill-rule:evenodd;stroke:#2e3436;stroke-width:2.1126256;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="rect2993"
+       width="39.045357"
+       height="27.016869"
+       x="40.359722"
+       y="16.492231"
+       transform="matrix(0.92408158,0.38219528,-0.75246174,0.65863596,0,0)" />
+    <path
+       style="color:#000000;fill:none;stroke:#ffffff;stroke-width:2;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       d="M 25.329927,28.679638 57.173418,41.866954 40.234042,56.653163 8.3211848,43.465847 z"
+       id="rect2993-0-9-3-7"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <rect
+       style="color:#000000;fill:url(#linearGradient3813);fill-opacity:1;fill-rule:evenodd;stroke:#2e3436;stroke-width:2.1126256;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="rect2993-0"
+       width="39.045357"
+       height="27.016869"
+       x="31.989382"
+       y="6.2172832"
+       transform="matrix(0.92408158,0.38219528,-0.75246174,0.65863596,0,0)" />
+    <path
+       style="color:#000000;fill:none;stroke:#ffffff;stroke-width:2;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       d="M 25.30824,18.773895 57.151731,31.961211 40.212355,46.74742 8.2994962,33.560104 z"
+       id="rect2993-0-9-3-6"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <rect
+       style="color:#000000;fill:url(#linearGradient3805);fill-opacity:1;fill-rule:evenodd;stroke:#2e3436;stroke-width:2.1126256;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="rect2993-0-9"
+       width="39.045357"
+       height="27.016869"
+       x="21.896566"
+       y="-6.1819811"
+       transform="matrix(0.92408158,0.38219528,-0.75246174,0.65863596,0,0)" />
+    <path
+       style="color:#000000;fill:none;stroke:#ffffff;stroke-width:2;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       d="M 25.281278,6.6563352 57.124769,19.843651 40.185393,34.62986 8.2725348,21.442544 z"
+       id="rect2993-0-9-3"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+  </g>
+  <metadata
+     id="metadata5826">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>Draft_VisGroup</dc:title>
+        <cc:license
+           rdf:resource="" />
+        <dc:date>Tue Jun 10 10:21:01 2014 -0300</dc:date>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>[Yorik van Havre]</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>FreeCAD LGPL2+</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>FreeCAD</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:identifier>FreeCAD/src/Mod/Draft/Resources/icons/Draft_VisGroup.svg</dc:identifier>
+        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title>[agryson] Alexander Gryson</dc:title>
+          </cc:Agent>
+        </dc:contributor>
+        <dc:subject>
+          <rdf:Bag>
+            <rdf:li>page</rdf:li>
+            <rdf:li>pages</rdf:li>
+            <rdf:li>rectangles</rdf:li>
+            <rdf:li>stack</rdf:li>
+          </rdf:Bag>
+        </dc:subject>
+        <dc:description>Three pages or rectangles stacked on top of each other</dc:description>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+</svg>

--- a/src/Mod/Draft/Resources/ui/preferences-dxf.ui
+++ b/src/Mod/Draft/Resources/ui/preferences-dxf.ui
@@ -398,7 +398,7 @@ instead of the size they have in the DXF document</string>
         <item>
          <widget class="Gui::PrefCheckBox" name="checkBox">
           <property name="toolTip">
-           <string>If this is checked, DXF layers will be imported as Draft VisGroups</string>
+           <string>If this is checked, DXF layers will be imported as Draft Layers</string>
           </property>
           <property name="text">
            <string>Use Layers</string>


### PR DESCRIPTION
Provide Draft_Layer.svg icon, and use it for consistency instead of Draft_VisGroup.svg, as this command won't be used any more by this name.

Also fixed a tiny misspelling `layerss`.

---

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists