### PR TITLE
Fix typos, grammar, and some whitespace issues

### DIFF
--- a/src/App/Document.h
+++ b/src/App/Document.h
@@ -433,7 +433,7 @@ public:
     };
     /** Get a complete list of all objects the given objects depend on. 
      *
-     * This function is defined as static because it accpets objects from
+     * This function is defined as static because it accepts objects from
      * different documents, and the returned list will contain dependent
      * objects from all relevant documents
      *

--- a/src/Gui/ExpressionCompleter.cpp
+++ b/src/Gui/ExpressionCompleter.cpp
@@ -439,8 +439,8 @@ void ExpressionCompleter::slotUpdate(const QString & prefix, int pos)
     // in the middle of a token, and we shall include that token.
     for(auto it=tokens.begin();it!=tokens.end();++it) {
         if(get<1>(*it) >= pos) {
-            // Include the immediatly followed '.' or '#', because we'll be
-            // inserting these separater too, in ExpressionCompleteModel::pathFromIndex()
+            // Include the immediately followed '.' or '#', because we'll be
+            // inserting these separators too, in ExpressionCompleteModel::pathFromIndex()
             if(it!=tokens.begin() && get<0>(*it)!='.' && get<0>(*it)!='#')
                 it = it-1;
             tokens.resize(it-tokens.begin()+1);

--- a/src/Gui/View3DPy.cpp
+++ b/src/Gui/View3DPy.cpp
@@ -192,7 +192,7 @@ void View3DInventorPy::init_type()
         "noManip: whether to create a manipulator\n"
         "pla: clipping plane placement");
     add_varargs_method("hasClippingPlane",&View3DInventorPy::hasClippingPlane,
-        "hasClippingPlane(): check whether ths clipping plane is active");
+        "hasClippingPlane(): check whether this clipping plane is active");
 }
 
 View3DInventorPy::View3DInventorPy(View3DInventor *vi)

--- a/src/Mod/Arch/OfflineRenderingUtils.py
+++ b/src/Mod/Arch/OfflineRenderingUtils.py
@@ -301,7 +301,7 @@ def render(outputfile,scene=None,camera=None,zoom=False,width=400,height=300,bac
 
     # On Linux, the X server must have indirect rendering enabled in order to be able to do offline
     # PNG rendering. Unfortunately, this is turned off by default on most recent distros. The easiest
-    # way I found is to edit (or create if inexistant) /etc/X11/xorg.conf and add this:
+    # way I found is to edit (or create if inexistent) /etc/X11/xorg.conf and add this:
     #
     # Section "ServerFlags"
     #    Option "AllowIndirectGLX" "on"

--- a/src/Mod/Cloud/App/AppCloud.cpp
+++ b/src/Mod/Cloud/App/AppCloud.cpp
@@ -670,7 +670,7 @@ bool Cloud::Module::cloudRestore (const char *BucketName)
                                   (const char*)this->TcpPort.getStrValue().c_str(),
                                   BucketName);
 
-    // we shall pass there the intial Document.xml file
+    // we shall pass there the initial Document.xml file
 
     Base::XMLReader reader("Document.xml", myreader.GetEntry("Document.xml")->FileStream);
 
@@ -707,4 +707,3 @@ bool Cloud::Module::cloudRestore (const char *BucketName)
     return(true);
 
 }
-

--- a/src/Mod/Draft/importDXF.py
+++ b/src/Mod/Draft/importDXF.py
@@ -1986,7 +1986,7 @@ def addText(text, attrib=False):
         It defaults to `False`. If `True` it determines
         the layer name from the DXF code 8, the text value from code 1,
         the position from codes 10, 20, 30, the height from code 40,
-        the roation from code 50, and assigns the name `'Attribute'`.
+        the rotation from code 50, and assigns the name `'Attribute'`.
         Otherwise, it assumes these values from `text`
         and sets the name to `'Text'`.
 
@@ -2910,7 +2910,7 @@ def getArcData(edge):
     -------
     (tuple, float, float, float)
         It returns a tuple of four values; the first value is a tuple
-        with the cordinates of the center `(x, y, z)`;
+        with the coordinates of the center `(x, y, z)`;
         the other three represent the magnitude of the radius,
         and the start and end angles in degrees that define the arc.
 
@@ -3573,7 +3573,7 @@ def export(objectslist, filename, nospline=False, lwPoly=False):
 
     Returns
     -------
-    It returns `None` if the export is succesful.
+    It returns `None` if the export is successful.
 
     See also
     --------

--- a/src/Mod/Fem/coding_conventions.md
+++ b/src/Mod/Fem/coding_conventions.md
@@ -2,8 +2,8 @@
 - These coding rules apply to FEM module code only. Other modules or the base system may use different coding rules especially in naming policy of Python.
 
 ## Python and C++
-- All files should have a licence header
-- Unix line endings are preferend
+- All files should have a license header
+- Unix line endings are preferred
 - never use mixed line endings on one file
 - 4 Spaces for indent
 - no trailing white spaces
@@ -29,18 +29,17 @@
 find src/Mod/Fem/ -name "*\.py" | grep -v InitGui.py | xargs -I [] flake8 --ignore=E266,W503 --max-line-length=100 []
 ~~~
 
-- www.lgtm.com
+- [LGTM](www.lgtm.com)
 - TODO: check pylint
-- automatic code formater will not be used for existant code
-- for new code if someone would like to use a code formater black should be used
+- automatic code formatter will not be used for existent code
+- for new code if someone would like to use a code formatter black should be used
 
 ## C++
 ### Naming policy
 - CamelCase names
 
 ## Spelling
-- Take care on spelling. Quit often it is ignored to check for missspelling.
-- codespelling could be used
-~~~
-codespell -q 3 -L aci,aline,alledges,als,ang,beginn,behaviour,bloaded,calculater,cancelled,cancelling,cas,cascade,centimetre,childs,colour,colours,currenty,doubleclick,dum,eiter,elemente,feld,freez,iff,indicies,initialisation,initialise,initialised,initialises,initialisiert,kilometre,lod,mantatory,methode,metres,millimetre,modell,nd,noe,normale,normaly,nto,numer,oder,ot,pres,programm,que,recurrance,rougly,seperator,serie,sinc,strack,substraction,te,thist,thru,tread,vertexes,uint,unter,whitespaces -S *.ts,*.po src/Mod/Fem
-~~~
+- Be mindful of spelling. Spell checks are quite often neglected.
+- [codespell]((https://github.com/codespell-project/codespell#updating) could be used  
+
+> codespell -q 3 -L aci,ake,aline,alle,alledges,alocation,als,ang,anid,ba,beginn,behaviour,bloaded,byteorder,calculater,cancelled,cancelling,cas,cascade,centimetre,childs,colour,colours,commen,currenty,dof,doubleclick,dum,eiter,elemente,feld,freez,hist,iff,indicies,initialisation,initialise,initialised,initialises,initialisiert,ist,kilometre,lod,mantatory,methode,metres,millimetre,modell,nd,noe,normale,normaly,nto,numer,oder,orgin,orginx,orginy,ot,pard,pres,programm,que,recurrance,rougly,seperator,serie,sinc,strack,substraction,te,thist,thru,tread,uint,unter,vertexes,wallthickness,whitespaces -S *.ts,*.po src/Mod/Fem

--- a/src/Mod/Show/TempoVis.py
+++ b/src/Mod/Show/TempoVis.py
@@ -194,7 +194,7 @@ class TempoVis(object):
     def restore(self, ultimate = True):
         '''restore(ultimate = True): undoes all changes done through this tempovis / restores saved scene details.
         ultimate: if true, the saved values are cleaned out, and the TV is withdrawn from 
-        the stack. If false, the TV will still remember stuff, and resore can be called again.
+        the stack. If false, the TV will still remember stuff, and restore can be called again.
         '''
         if self.state == S_RESTORED:
             return
@@ -525,4 +525,3 @@ class TempoVis(object):
         self._init_attrs()
     
         
-

--- a/src/Mod/TechDraw/Gui/QGIPrimPath.h
+++ b/src/Mod/TechDraw/Gui/QGIPrimPath.h
@@ -91,8 +91,8 @@ protected:
     Qt::PenCapStyle m_capStyle;
 
     QBrush m_brush;
-    Qt::BrushStyle m_fill;                      //current fille style
-    Qt::BrushStyle m_fillStyle;                 //current fill style*/
+    Qt::BrushStyle m_fill;                      //current fill style
+    Qt::BrushStyle m_fillStyle;                 //current fill style
     QColor m_fillColor;                         //current fill color
 
     QColor m_colDefFill;                        //"no color" default normal fill color


### PR DESCRIPTION
Found via ` codespell -q 2 -L aci,ake,aline,alle,alledges,alocation,als,ang,anid,ba,beginn,behaviour,bloaded,byteorder,calculater,cancelled,cancelling,cas,cascade,centimetre,childs,colour,colours,commen,currenty,dof,doubleclick,dum,eiter,elemente,feld,freez,hist,iff,indicies,initialisation,initialise,initialised,initialises,initialisiert,ist,kilometre,lod,mantatory,methode,metres,millimetre,modell,nd,noe,normale,normaly,nto,numer,oder,orgin,orginx,orginy,ot,pard,pres,programm,que,recurrance,rougly,seperator,serie,sinc,strack,substraction,te,thist,thru,tread,uint,unter,vertexes,wallthickness,whitespaces -S ./.git,*.po,*.ts,./ChangeLog.txt,./src/3rdParty,./src/Mod/Assembly/App/opendcm,./src/CXX,./src/zipios++,./src/Base/swig*,./src/Mod/Robot/App/kdl_cp,./src/Mod/Import/App/SCL,./src/WindowsInstaller,./src/Doc/FreeCAD.uml`