### PR TITLE
Drawing: print message indicating that it is obsolete

### DIFF
--- a/src/Mod/Drawing/CMakeLists.txt
+++ b/src/Mod/Drawing/CMakeLists.txt
@@ -5,6 +5,7 @@ if(BUILD_GUI)
 endif(BUILD_GUI)
 
 set(Drawing_Scripts
+    README.md
     Init.py
     DrawingExample.py
     DrawingTests.py

--- a/src/Mod/Drawing/Init.py
+++ b/src/Mod/Drawing/Init.py
@@ -24,3 +24,6 @@
 #*                                                                         *
 #*   Juergen Riegel 2002                                                   *
 #***************************************************************************/
+
+FreeCAD.Console.PrintLog("Drawing became obsolete in 0.17; "
+                         "consider using TechDraw instead.\n")

--- a/src/Mod/Drawing/InitGui.py
+++ b/src/Mod/Drawing/InitGui.py
@@ -41,6 +41,11 @@ class DrawingWorkbench (Workbench):
     def Initialize(self):
         # load the module
         import DrawingGui
+
+    def Activated(self):
+        FreeCAD.Console.PrintWarning("Drawing became obsolete in 0.17; "
+                                     "consider using TechDraw instead.\n")
+
     def GetClassName(self):
         return "DrawingGui::Workbench"
         

--- a/src/Mod/Drawing/README.md
+++ b/src/Mod/Drawing/README.md
@@ -1,0 +1,3 @@
+Development of the Drawing Workbench stopped in FreeCAD 0.16, and it became obsolete in FreeCAD 0.17, when the TechDraw Workbench was introduced.
+
+The Drawing Workbench is no longer maintained. It is kept in the source tree for compatibility purposes, although there is no guarantee that it will continue working in future versions of FreeCAD. Eventually it may be removed completely.


### PR DESCRIPTION
README and print message when activating the workbench indicating that it is obsolete, so that users and developers try TechDraw instead.

---

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists