### PR TITLE
Ability to prevent auto-switching to PartDesign WB (#2703) + Expression input dialog UI update (#4079)

### DIFF
--- a/src/Gui/DlgExpressionInput.ui
+++ b/src/Gui/DlgExpressionInput.ui
@@ -176,7 +176,10 @@
        <item>
         <widget class="QPushButton" name="discardBtn">
          <property name="text">
-          <string>&amp;Discard</string>
+          <string>&amp;Clear</string>
+         </property>
+         <property name="toolTip">
+          <string>Revert to last calculated value (as constant)</string>
          </property>
          <property name="autoDefault">
           <bool>false</bool>

--- a/src/Mod/PartDesign/Gui/ViewProviderBody.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderBody.cpp
@@ -157,7 +157,8 @@ bool ViewProviderBody::doubleClicked(void)
     } else {
 
         // assure the PartDesign workbench
-        Gui::Command::assureWorkbench("PartDesignWorkbench");
+        if(App::GetApplication().GetUserParameter().GetGroup("BaseApp")->GetGroup("Preferences")->GetGroup("Mod/PartDesign")->GetBool("SwitchToWB", true))
+            Gui::Command::assureWorkbench("PartDesignWorkbench");
 
         // and set correct active objects
         auto* part = App::Part::getPartOfObject ( getObject() );


### PR DESCRIPTION
- [X ] Branch rebased on latest master `git pull --rebase upstream master`
- [X ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0` => _**Complete test doesn't pass due to unrelated errors in FEM, other unit tests (base, PartDesign, ...) are OK**_
- [X ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [X ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

Regarding newly introduced boolean parameter, I'll document it in the Wiki if/when the PR is merged. ;)
