### PR TITLE
View scaling for new documents

### DIFF
--- a/src/Gui/DlgSettings3DView.ui
+++ b/src/Gui/DlgSettings3DView.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>477</width>
-    <height>630</height>
+    <height>763</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -202,23 +202,6 @@ will be shown at the lower left in opened files</string>
       </item>
       <item>
        <layout class="QGridLayout" name="gridLayout2">
-        <item row="0" column="0">
-         <widget class="QLabel" name="navigationLabel">
-          <property name="text">
-           <string>3D Navigation</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="1">
-         <widget class="QComboBox" name="comboNavigationStyle">
-          <property name="toolTip">
-           <string>Navigation settings set</string>
-          </property>
-          <property name="currentIndex">
-           <number>-1</number>
-          </property>
-         </widget>
-        </item>
         <item row="0" column="2">
          <widget class="QPushButton" name="mouseButton">
           <property name="sizePolicy">
@@ -232,10 +215,10 @@ will be shown at the lower left in opened files</string>
           </property>
          </widget>
         </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="orbitLabel">
+        <item row="2" column="0">
+         <widget class="QLabel" name="aliasingLAbel">
           <property name="text">
-           <string>Orbit style</string>
+           <string>Anti-Aliasing</string>
           </property>
          </widget>
         </item>
@@ -259,13 +242,6 @@ Turntable: the part will be rotated around the z-axis.</string>
             <string>Trackball</string>
            </property>
           </item>
-         </widget>
-        </item>
-        <item row="2" column="0">
-         <widget class="QLabel" name="aliasingLAbel">
-          <property name="text">
-           <string>Anti-Aliasing</string>
-          </property>
          </widget>
         </item>
         <item row="2" column="1">
@@ -313,10 +289,66 @@ Turntable: the part will be rotated around the z-axis.</string>
           </property>
          </widget>
         </item>
+        <item row="0" column="1">
+         <widget class="QComboBox" name="comboNavigationStyle">
+          <property name="toolTip">
+           <string>Navigation settings set</string>
+          </property>
+          <property name="currentIndex">
+           <number>-1</number>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="0">
+         <widget class="QLabel" name="orbitLabel">
+          <property name="text">
+           <string>Orbit style</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="0">
+         <widget class="QLabel" name="navigationLabel">
+          <property name="text">
+           <string>3D Navigation</string>
+          </property>
+         </widget>
+        </item>
         <item row="3" column="1">
          <widget class="QComboBox" name="comboNewDocView">
           <property name="toolTip">
            <string>Camera orientation for new documents </string>
+          </property>
+         </widget>
+        </item>
+        <item row="4" column="0">
+         <widget class="QLabel" name="label_2">
+          <property name="text">
+           <string>New document scale</string>
+          </property>
+         </widget>
+        </item>
+        <item row="4" column="1">
+         <widget class="PrefUnitSpinBox" name="qspinNewDocScale" native="true">
+          <property name="toolTip">
+           <string>Sets camera zoom for new documents. The value is the diameter of the sphere to fit on the screen.</string>
+          </property>
+          <property name="unit" stdset="0">
+           <string>mm</string>
+          </property>
+          <property name="minimum" stdset="0">
+           <double>0.000010000000000</double>
+          </property>
+          <property name="maximum" stdset="0">
+           <double>10000000.000000000000000</double>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <string>NewDocumentCameraScale</string>
+          </property>
+          <property name="prefPath" stdset="0">
+           <string>View</string>
+          </property>
+          <property name="rawValue" stdset="0">
+           <double>100.000000000000000</double>
           </property>
          </widget>
         </item>
@@ -786,6 +818,12 @@ bounding box size of the 3D object that is currently displayed. </string>
    <class>Gui::PrefDoubleSpinBox</class>
    <extends>QDoubleSpinBox</extends>
    <header>Gui/PrefWidgets.h</header>
+  </customwidget>
+  <customwidget>
+   <class>PrefUnitSpinBox</class>
+   <extends>QWidget</extends>
+   <header>Gui/PrefWidgets.h</header>
+   <container>1</container>
   </customwidget>
  </customwidgets>
  <tabstops>

--- a/src/Gui/DlgSettings3DViewImp.cpp
+++ b/src/Gui/DlgSettings3DViewImp.cpp
@@ -110,6 +110,7 @@ void DlgSettings3DViewImp::saveSettings()
     sliderIntensity->onSave();
     radioPerspective->onSave();
     radioOrthographic->onSave();
+    qspinNewDocScale->onSave();
 
     QVariant camera = comboNewDocView->itemData(comboNewDocView->currentIndex(), Qt::UserRole);
     hGrp->SetASCII("NewDocumentCameraOrientation", (const char*)camera.toByteArray());
@@ -140,6 +141,7 @@ void DlgSettings3DViewImp::loadSettings()
     sliderIntensity->onRestore();
     radioPerspective->onRestore();
     radioOrthographic->onRestore();
+    qspinNewDocScale->onRestore();
 
     ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath
         ("User parameter:BaseApp/Preferences/View");
@@ -185,7 +187,7 @@ void DlgSettings3DViewImp::loadSettings()
     comboNewDocView->addItem(tr("Rear"), QByteArray("Rear"));
     comboNewDocView->addItem(tr("Bottom"), QByteArray("Bottom"));
     comboNewDocView->addItem(tr("Custom"), QByteArray("Custom"));
-    std::string camera = hGrp->GetASCII("NewDocumentCameraOrientation", "Top");
+    std::string camera = hGrp->GetASCII("NewDocumentCameraOrientation", "Trimetric");
     index = comboNewDocView->findData(QByteArray(camera.c_str()));
     if (index > -1) comboNewDocView->setCurrentIndex(index);
     if (camera == "Custom") {

--- a/src/Gui/ViewProviderOrigin.cpp
+++ b/src/Gui/ViewProviderOrigin.cpp
@@ -154,6 +154,12 @@ void ViewProviderOrigin::resetTemporaryVisibility() {
     tempVisMap.clear ();
 }
 
+double ViewProviderOrigin::defaultSize()
+{
+    ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/View");
+    return 0.25 * hGrp->GetFloat("NewDocumentCameraScale",100.0);
+}
+
 bool ViewProviderOrigin::isTemporaryVisibility() {
     return !tempVisMap.empty();
 }

--- a/src/Gui/ViewProviderOrigin.h
+++ b/src/Gui/ViewProviderOrigin.h
@@ -75,7 +75,7 @@ public:
     }
 
     /// Returns default size. Use this if it is not possible to determine appropriate size by other means
-    static double defaultSize() {return 10.;}
+    static double defaultSize();
 protected:
     virtual void onChanged(const App::Property* prop);
     virtual bool onDelete(const std::vector<std::string> &);

--- a/src/Mod/PartDesign/Gui/Command.cpp
+++ b/src/Mod/PartDesign/Gui/Command.cpp
@@ -720,24 +720,6 @@ void CmdPartDesignNewSketch::activated(int iMsg)
                 Base::Console().Error("Failed to create a Body object");
                 return;
             }
-
-            // The method 'SoCamera::viewBoundingBox' is still declared as protected in Coin3d versions
-            // older than 4.0.
-#if COIN_MAJOR_VERSION >= 4
-            // if no part feature was there then auto-adjust the camera
-            Gui::Document* guidoc = Gui::Application::Instance->getDocument(doc);
-            Gui::View3DInventor* view = guidoc ? qobject_cast<Gui::View3DInventor*>(guidoc->getActiveView()) : nullptr;
-            if (view) {
-                SoCamera* camera = view->getViewer()->getCamera();
-                SbViewportRegion vpregion = view->getViewer()->getViewportRegion();
-                float aspectratio = vpregion.getViewportAspectRatio();
-
-                float size = Gui::ViewProviderOrigin::defaultSize();
-                SbBox3f bbox;
-                bbox.setBounds(-size,-size,-size,size,size,size);
-                camera->viewBoundingBox(bbox, aspectratio, 1.0f);
-            }
-#endif
         }
 
         // At this point, we have pcActiveBody

--- a/src/Mod/Show/TempoVis.py
+++ b/src/Mod/Show/TempoVis.py
@@ -447,7 +447,12 @@ class TempoVis(object):
     
     def activateWorkbench(self, wb_name):
         from .SceneDetails.Workbench import Workbench
-        self.modify(Workbench(wb_name))
+        wb = Workbench(wb_name)
+        if wb.scene_value() == 'StartWorkbench':
+            #exclusion - don't switch back to Start, as it causes Start page to appear
+            wb.apply_data(wb_name)
+            return
+        self.modify(wb)
     
   #</convenience functions>
 


### PR DESCRIPTION
* added preference for default view scaling
* changed initial default camera orientation to trimetric (FreeCAD is first and foremost about 3D, so Top isn't a good initial value IMO).
* fix sketch from switching back to Start workbench ([this is why](https://forum.freecadweb.org/viewtopic.php?f=3&t=39143)) 
![pr-view-scale](https://user-images.githubusercontent.com/8940427/64491611-237d5880-d273-11e9-94d5-318ed45ea4ee.png)
