### PR TITLE
Pyside2 config

### DIFF
--- a/cMake/FreeCAD_Helpers/SetupShibokenAndPyside.cmake
+++ b/cMake/FreeCAD_Helpers/SetupShibokenAndPyside.cmake
@@ -43,11 +43,17 @@ macro(SetupShibokenAndPyside)
             endif()
         endif()
 
-        if(NOT SHIBOKEN_INCLUDE_DIR)
+        # pyside2 changed it's cmake files, this is the dance we have
+        # to dance to be compatible with the old (<5.12) and the new versions (>=5.12)
+        if(NOT SHIBOKEN_LIBRARY AND TARGET Shiboken2::libshiboken)
+                get_property(SHIBOKEN_LIBRARY TARGET Shiboken2::libshiboken PROPERTY IMPORTED_LOCATION_RELEASE)
+        endif(NOT SHIBOKEN_LIBRARY AND TARGET Shiboken2::libshiboken)
+
+        if(NOT SHIBOKEN_LIBRARY)
             message("====================\n"
                     "shiboken2 not found.\n"
                     "====================\n")
-        endif(NOT SHIBOKEN_INCLUDE_DIR)
+        endif(NOT SHIBOKEN_LIBRARY)
 
         find_package(PySide2 QUIET)# REQUIRED
         if(NOT PYSIDE_INCLUDE_DIR)


### PR DESCRIPTION
Based on https://github.com/FreeCAD/FreeCAD/pull/2020
Trying to find pyside2/shiboken2 library/headers with a python script and passing the output to cmake. 

I also added a cmake option: FREECAD_USE_PYTHON3 to enforce python3.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
