### PR TITLE
Draft: DraftEdit.py now gets PickRadius from user preferences

### DIFF
--- a/src/Mod/Draft/DraftEdit.py
+++ b/src/Mod/Draft/DraftEdit.py
@@ -65,7 +65,7 @@ class Edit():
 
         # settings
         self.maxObjects = 1
-        self.pick_radius = 30 # TODO: set pick radius according to user preferences
+        self.pick_radius = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/View").GetFloat("PickRadius")
 
         # preview
         self.ghost = None


### PR DESCRIPTION
...instead of being hardcoded.  
Note: PickRadius is the proximity in pixels for picking elements in the 3D view  

Forum thread: https://forum.freecadweb.org/viewtopic.php?f=10&t=39203