### PR TITLE
[Hold]Material: Create and save material colors as 3 floats

### DIFF
--- a/src/Mod/Material/MaterialEditor.py
+++ b/src/Mod/Material/MaterialEditor.py
@@ -550,8 +550,8 @@ class MaterialsDelegate(QtGui.QStyledItemDelegate):
         if Type == "Color":
 
             color = editor.property('color')
-            color = color.getRgb()
-            item.setText(str(color))
+            color = color.getRgbF()
+            item.setText(str(color[:-1]))
 
         elif Type == "File":
 
@@ -623,7 +623,7 @@ def matProperWidget(parent=None, matproperty=None, Type="String", Value=None,
         if Value:
             value = string2tuple(Value)
             color = QtGui.QColor()
-            color.setRgb(value[0], value[1], value[2], value[3])
+            color.setRgbF(value[0], value[1], value[2])
             widget.setProperty('color', color)
 
     else:
@@ -650,7 +650,7 @@ def string2tuple(string):
     "provisionally"
     value = string[1:-1]
     value = value.split(',')
-    value = [int(v) for v in value]
+    value = [float(v) for v in value]
     value = tuple(value)
     return value
 


### PR DESCRIPTION
This fixes creating emissive, specular,.. colors in the material card dialog and changing the diffuse color.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
