### PR TITLE
Arch: ArchBuildingPart, fix obj.Height.Value in onChanged()

### DIFF
--- a/src/Mod/Arch/ArchBuildingPart.py
+++ b/src/Mod/Arch/ArchBuildingPart.py
@@ -373,7 +373,7 @@ class BuildingPart(ArchIFC.IfcProduct):
             self.svgcache = None
             self.shapecache = None
 
-        if (prop == "Height") and prop.Height.Value:
+        if (prop == "Height") and obj.Height.Value:
             for child in obj.Group:
                 if Draft.getType(child) in ["Wall","Structure"]:
                     if not child.Height.Value:


### PR DESCRIPTION
Bug reported in the forum: [[ Bug ] Arch_Floor error when changing height](https://forum.freecadweb.org/viewtopic.php?f=3&t=39306)

The solution was just using `obj.Height` not `prop.Height`.

---

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists
