### PR TITLE
Draft: DraftTools, place the CubicBezCurve tool before the BezCurve, as the cubic curve is more used.

### DIFF
--- a/src/Mod/Draft/DraftTools.py
+++ b/src/Mod/Draft/DraftTools.py
@@ -5652,7 +5652,7 @@ FreeCADGui.addCommand('Draft_Polygon',Polygon())
 FreeCADGui.addCommand('Draft_BSpline',BSpline())
 class CommandBezierGroup:
     def GetCommands(self):
-        return tuple(['Draft_BezCurve','Draft_CubicBezCurve'])
+        return tuple(['Draft_CubicBezCurve', 'Draft_BezCurve'])
     def GetResources(self):
         return { 'MenuText': QtCore.QT_TRANSLATE_NOOP("Draft_BezierTools",'Bezier tools'),
                  'ToolTip': QtCore.QT_TRANSLATE_NOOP("Draft_BezierTools",'Bezier tools')


### PR DESCRIPTION
The traditional [Draft_BezCurve](https://www.freecadweb.org/wiki/Draft_BezCurve) produces a Bezier curve whose degree depends on the points that are entered. In most other drawing applications a Bezier tool produces only cubic Bezier curves, which are defined by only four points. This curve is generally enough to produce complex splines.

In pull request #2072, this cubic Bezier was implemented in the Draft Workbench. Now it's possible to create long splines composed of many cubic Bezier segments, as it's common in other applications. See the wiki information, [Draft_CubicBezCurve](https://www.freecadweb.org/wiki/Draft_CubicBezCurve).

This pull request just places the Draft_CubicBezCurve tool before the old Draft_BezCurve in the list, so that the new user sees and picks the former first, instead of the general tool.

---

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists