### PR TITLE
[TD]Fix mishandling of escaped html in Templates

### DIFF
--- a/src/Mod/TechDraw/Gui/TemplateTextField.cpp
+++ b/src/Mod/TechDraw/Gui/TemplateTextField.cpp
@@ -29,6 +29,8 @@
   #include <QTextDocument>
 #endif // #ifndef _PreCmp_
 
+#include <Base/Console.h>
+
 #include "DlgTemplateField.h"
 #include "TemplateTextField.h"
 
@@ -64,11 +66,15 @@ void TemplateTextField::mouseReleaseEvent(QGraphicsSceneMouseEvent *event)
         ui.setFieldContent(tmplte->EditableTexts[fieldNameStr]);
 
         if (ui.exec() == QDialog::Accepted) {
-#if QT_VERSION >= 0x050000
-            QString qsClean = ui.getFieldContent().toHtmlEscaped();
-#else
-            QString qsClean = Qt::escape( ui.getFieldContent() );
-#endif
+        //WF: why is this escaped? 
+        //    "<" is converted elsewhere and no other characters cause problems.
+        //    escaping causes "&" to appear as "&amp;" etc
+//#if QT_VERSION >= 0x050000
+//            QString qsClean = ui.getFieldContent().toHtmlEscaped();
+//#else
+//            QString qsClean = Qt::escape( ui.getFieldContent() );
+//#endif
+            QString qsClean = ui.getFieldContent();
             std::string utf8Content = qsClean.toUtf8().constData();
             tmplte->EditableTexts.setValue(fieldNameStr, utf8Content);
         }


### PR DESCRIPTION
Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
