### PR TITLE
Arch: ArchCommands, change the color of the vertices of the subcomponent when using Arch Remove, just like the line color and shape color are changed.

### DIFF
--- a/src/Mod/Arch/ArchCommands.py
+++ b/src/Mod/Arch/ArchCommands.py
@@ -275,6 +275,8 @@ def setAsSubcomponent(obj):
             color = getDefaultColor("Construction")
             if hasattr(obj.ViewObject,"LineColor"):
                 obj.ViewObject.LineColor = color
+            if hasattr(obj.ViewObject, "PointColor"):
+                obj.ViewObject.PointColor = color
             if hasattr(obj.ViewObject,"ShapeColor"):
                 obj.ViewObject.ShapeColor = color
             if hasattr(obj.ViewObject,"Transparency"):


### PR DESCRIPTION
When a Part object, like a box, is used with Arch_Remove to create an opening in a wall, its color changes to the "construction" color, and becomes slightly transparent.

The LineColor and ShapeColor turn to that color; this pull request makes it so that the PointColor also changes.

See the forum thread, [After Arch Remove geometry changes color](https://forum.freecadweb.org/viewtopic.php?f=23&t=39385).

Edited the thread, it was the wrong one.

---

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists
