### PR TITLE
[Gui]Fix Py SyntaxError on " in PropertyStringList

### DIFF
--- a/src/Gui/propertyeditor/PropertyItem.cpp
+++ b/src/Gui/propertyeditor/PropertyItem.cpp
@@ -2308,6 +2308,7 @@ void PropertyStringListItem::setValue(const QVariant& value)
         text.replace(QString::fromUtf8("'"),QString::fromUtf8("\\'"));
 
         std::string pystr = Base::Tools::escapedUnicodeFromUtf8(text.toUtf8());
+        pystr = Base::Interpreter().strToPython(pystr.c_str());
         str << "u\"" << pystr.c_str() << "\", ";
     }
     str << "]";


### PR DESCRIPTION
If the double quote character(") is entered in a PropertyStringList item, an exception will be raised as: 

<class 'SyntaxError'>: ('invalid syntax', ('<string>', 1, 87, 'FreeCAD.getDocument("Unnamed").getObject("Annotation").Text = [u"quote " in string", u"", ]\n'))
Stack Trace: 
-or-
<class 'SyntaxError'>: ('EOL while scanning string literal', ('<string>', 1, 87, 'FreeCAD.getDocument("Unnamed").getObject("Annotation").Text = [u"quote " in string", ]\n'))
Stack Trace: 

This fix adds a call to Base::Interpreter::strToPython as used in PropertyString.




Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
