### PR TITLE
[App][Gui]Add Filter for PropertyFile in PropertyEditor

### DIFF
--- a/src/App/PropertyFile.cpp
+++ b/src/App/PropertyFile.cpp
@@ -630,11 +630,21 @@ TYPESYSTEM_SOURCE(App::PropertyFile , App::PropertyString)
 
 PropertyFile::PropertyFile()
 {
-
+    m_filter = "";
 }
 
 PropertyFile::~PropertyFile()
 {
 
+}
+
+void PropertyFile::setFilter(const std::string f)
+{
+    m_filter = f;
+}
+
+std::string PropertyFile::getFilter(void) const
+{
+    return m_filter;
 }
 

--- a/src/App/PropertyFile.h
+++ b/src/App/PropertyFile.h
@@ -52,9 +52,15 @@ class AppExport PropertyFile : public PropertyString
 public:
     PropertyFile(void);
     virtual ~PropertyFile();
-    
+
     virtual const char* getEditorName(void) const
     { return "Gui::PropertyEditor::PropertyFileItem"; }
+
+    virtual void setFilter(const std::string filter);
+    virtual std::string getFilter(void) const;
+
+private:
+    std::string m_filter;
 };
 
 /** File include properties

--- a/src/Gui/propertyeditor/PropertyItem.cpp
+++ b/src/Gui/propertyeditor/PropertyItem.cpp
@@ -3369,7 +3369,13 @@ QWidget* PropertyFileItem::createEditor(QWidget* parent, const QObject* receiver
 
 void PropertyFileItem::setEditorData(QWidget *editor, const QVariant& data) const
 {
+    const App::Property* prop = getFirstProperty();
+    const App::PropertyFile* propFile = static_cast<const App::PropertyFile*>(prop);
+    std::string filter = propFile->getFilter();
     Gui::FileChooser *fc = qobject_cast<Gui::FileChooser*>(editor);
+    if (!filter.empty()) {
+        fc->setFilter(Base::Tools::fromStdString(filter));
+    }
     fc->setFileName(data.toString());
 }
 


### PR DESCRIPTION
@wwmayer :
This PR was prompted by this comment from a user: "8. While choosing a pattern for a Hatch, I see *.dll files in the list. Awesome."

Since it touches the Property system, I thought you should have a look before merge. 

When invoking the FileChooser from the PropertyEditor the default nameFilter of "All files (*)" is used.  The FileChooser supports nameFilters ("Svg Files (*.svg)") but there was no way to pass the desired filter to the PropertyEditor to use with FileChooser.  

This PR add a filter variable to PropertyFile, and modifies PropertyFileItem to use the filter if specified. If no filter is specified, the behaviour is unchanged from the current version.

Usage of this feature would be: 
   std::string svgFilter("Svg files (*.svg *.SVG);;All files (*)");
   Template.setFilter(svgFilter);
where Template is a PropertyFile.

Please review.  If you approve I will merge it. 

Thanks,
wf










Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
