### PR TITLE
remove unnecessary whitespace from general sketcher dialog

### DIFF
--- a/src/Mod/Sketcher/Gui/TaskSketcherConstrains.ui
+++ b/src/Mod/Sketcher/Gui/TaskSketcherConstrains.ui
@@ -10,6 +10,18 @@
     <height>288</height>
    </rect>
   </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="maximumSize">
+   <size>
+    <width>16777215</width>
+    <height>288</height>
+   </size>
+  </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>

--- a/src/Mod/Sketcher/Gui/TaskSketcherElements.ui
+++ b/src/Mod/Sketcher/Gui/TaskSketcherElements.ui
@@ -110,6 +110,18 @@
    </item>
    <item>
     <widget class="ElementView" name="listWidgetElements">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="MinimumExpanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>237</height>
+      </size>
+     </property>
      <property name="modelColumn">
       <number>0</number>
      </property>

--- a/src/Mod/Sketcher/Gui/TaskSketcherGeneral.ui
+++ b/src/Mod/Sketcher/Gui/TaskSketcherGeneral.ui
@@ -122,7 +122,7 @@ Points must be set closer than a fifth of the grid size to a grid line to snap.<
    <item>
     <widget class="QListWidget" name="renderingOrder">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
+      <sizepolicy hsizetype="Expanding" vsizetype="MinimumExpanding">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
@@ -136,11 +136,17 @@ Points must be set closer than a fifth of the grid size to a grid line to snap.<
      <property name="toolTip">
       <string>To change, drag and drop a geometry type to top or bottom</string>
      </property>
+     <property name="sizeAdjustPolicy">
+      <enum>QAbstractScrollArea::AdjustToContents</enum>
+     </property>
      <property name="dragEnabled">
       <bool>true</bool>
      </property>
      <property name="dragDropMode">
       <enum>QAbstractItemView::InternalMove</enum>
+     </property>
+     <property name="resizeMode">
+      <enum>QListView::Fixed</enum>
      </property>
      <property name="sortingEnabled">
       <bool>false</bool>

--- a/src/Mod/Sketcher/Gui/TaskSketcherGeneral.ui
+++ b/src/Mod/Sketcher/Gui/TaskSketcherGeneral.ui
@@ -130,7 +130,7 @@ Points must be set closer than a fifth of the grid size to a grid line to snap.<
      <property name="minimumSize">
       <size>
        <width>12</width>
-       <height>12</height>
+       <height>60</height>
       </size>
      </property>
      <property name="toolTip">

--- a/src/Mod/Sketcher/Gui/TaskSketcherMessages.ui
+++ b/src/Mod/Sketcher/Gui/TaskSketcherMessages.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>253</width>
-    <height>132</height>
+    <height>108</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -64,19 +64,6 @@
       <cstring>Mod/Sketcher</cstring>
      </property>
     </widget>
-   </item>
-   <item>
-    <spacer name="horizontalSpacer">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>40</width>
-       <height>20</height>
-      </size>
-     </property>
-    </spacer>
    </item>
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout">


### PR DESCRIPTION
Reduce whitespace for general task sketcher dialog.

There is too much whitespace, see https://forum.freecadweb.org/viewtopic.php?t=37935&p=324176

With this PR it there is only as much space as necessary: https://forum.freecadweb.org/viewtopic.php?f=17&t=37935&start=10#p336020
