### PR TITLE
cmake: pyside2: we also need headers from shiboken and pyside2

### DIFF
--- a/cMake/FreeCAD_Helpers/SetupShibokenAndPyside.cmake
+++ b/cMake/FreeCAD_Helpers/SetupShibokenAndPyside.cmake
@@ -47,20 +47,27 @@ macro(SetupShibokenAndPyside)
         # to dance to be compatible with the old (<5.12) and the new versions (>=5.12)
         if(NOT SHIBOKEN_LIBRARY AND TARGET Shiboken2::libshiboken)
                 get_property(SHIBOKEN_LIBRARY TARGET Shiboken2::libshiboken PROPERTY IMPORTED_LOCATION_RELEASE)
+                get_property(SHIBOKEN_INCLUDE_DIR TARGET Shiboken2::libshiboken PROPERTY INTERFACE_INCLUDE_DIRECTORIES)
         endif(NOT SHIBOKEN_LIBRARY AND TARGET Shiboken2::libshiboken)
 
-        if(NOT SHIBOKEN_LIBRARY)
+        if(NOT SHIBOKEN_LIBRARY AND NOT SHIBOKEN_INCLUDE_DIR)
             message("====================\n"
                     "shiboken2 not found.\n"
                     "====================\n")
-        endif(NOT SHIBOKEN_LIBRARY)
+        endif(NOT SHIBOKEN_LIBRARY AND NOT SHIBOKEN_INCLUDE_DIR)
 
         find_package(PySide2 QUIET)# REQUIRED
-        if(NOT PYSIDE_INCLUDE_DIR)
+
+        if(NOT PYSIDE_LIBRARY AND TARGET PySide2::pyside2)
+                get_property(PYSIDE_LIBRARY TARGET PySide2::pyside2 PROPERTY IMPORTED_LOCATION_RELEASE)
+                get_property(PYSIDE_INCLUDE_DIR TARGET PySide2::pyside2 PROPERTY INTERFACE_INCLUDE_DIRECTORIES)
+        endif(NOT PYSIDE_LIBRARY AND TARGET PySide2::pyside2)
+
+        if(NOT PYSIDE_LIBRARY AND NOT PYSIDE_INCLUDE_DIR)
             message("==================\n"
                     "PySide2 not found.\n"
                     "==================\n")
-        endif(NOT PYSIDE_INCLUDE_DIR)
+        endif(NOT PYSIDE_LIBRARY AND NOT PYSIDE_INCLUDE_DIR)
 
         find_package(PySide2Tools QUIET) #REQUIRED # PySide2 utilities (pyside2-uic & pyside2-rcc)
         if(NOT PYSIDE2_TOOLS_FOUND)


### PR DESCRIPTION
As experienced in this [topic](https://forum.freecadweb.org/viewtopic.php?f=18&t=39093&p=337566#p337566) we also need the headers of shiboken2 or pyside2. Not yet sure which one are really needed, but using this the same way as used for older versions of qt5 might be the best solution to not break anything. 


Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
