### PR TITLE
Fix various (doxy) typos and whitespace issues

### DIFF
--- a/src/App/Application.cpp
+++ b/src/App/Application.cpp
@@ -133,7 +133,7 @@ using namespace boost;
 using namespace boost::program_options;
 
 
-// scriptings (scripts are build in but can be overridden by command line option)
+// scriptings (scripts are built-in but can be overridden by command line option)
 #include <App/InitScript.h>
 #include <App/TestScript.h>
 #include <App/CMakeScript.h>
@@ -2241,7 +2241,7 @@ void Application::LoadParameters(void)
 
 #if defined(_MSC_VER)
 // fix weird error while linking boost (all versions of VC)
-// VS2010: http://forum.freecadweb.org/viewtopic.php?f=4&t=1886&p=12553&hilit=boost%3A%3Afilesystem%3A%3Aget#p12553
+// VS2010: https://forum.freecadweb.org/viewtopic.php?f=4&t=1886&p=12553&hilit=boost%3A%3Afilesystem%3A%3Aget#p12553
 namespace boost { namespace program_options { std::string arg="arg"; } }
 #if (defined (BOOST_VERSION) && (BOOST_VERSION >= 104100))
 namespace boost { namespace program_options {
@@ -2931,7 +2931,7 @@ std::string Application::FindHomePath(const char* sCall)
     binPath += L"bin";
     SetDllDirectoryW(binPath.c_str());
 
-    // http://stackoverflow.com/questions/5625884/conversion-of-stdwstring-to-qstring-throws-linker-error
+    // https://stackoverflow.com/questions/5625884/conversion-of-stdwstring-to-qstring-throws-linker-error
 #ifdef _MSC_VER
     QString str = QString::fromUtf16(reinterpret_cast<const ushort *>(homePath.c_str()));
 #else

--- a/src/App/Document.cpp
+++ b/src/App/Document.cpp
@@ -193,7 +193,7 @@ struct DocumentP
         static std::random_device _RD;
         static std::mt19937 _RGEN(_RD());
         static std::uniform_int_distribution<> _RDIST(0,5000);
-        // Set some random offset to reduce likelihood of ID collison when
+        // Set some random offset to reduce likelihood of ID collision when
         // copying shape from other document. It is probably better to randomize
         // on each object ID.
         lastObjectId = _RDIST(_RGEN); 
@@ -4129,7 +4129,7 @@ DocumentObject* Document::moveObject(DocumentObject* obj, bool recursive)
     if(objs.empty()) 
         return 0;
     // Some object may delete its children if deleted, so we collect the IDs
-    // or all depdending objects for safety reason.
+    // or all depending objects for safety reason.
     std::vector<int> ids;
     ids.reserve(deps.size());
     for(auto o : deps)

--- a/src/App/DocumentObject.cpp
+++ b/src/App/DocumentObject.cpp
@@ -361,7 +361,7 @@ std::vector<App::DocumentObject*> DocumentObject::getInListRecursive(void) const
 
 #else
 // The original algorithm is highly inefficient in some special case.
-// Considering an object is linked by every other objects. After exculding this
+// Considering an object is linked by every other objects. After excluding this
 // object, there is another object linked by every other of the remaining
 // objects, and so on.  The vector 'result' above will be of magnitude n^2.
 // Even if we replace the vector with a set, we still need to visit that amount
@@ -1197,4 +1197,3 @@ void DocumentObject::onPropertyStatusChanged(const Property &prop, unsigned long
     if(!Document::isAnyRestoring() && getNameInDocument() && getDocument())
         getDocument()->signalChangePropertyEditor(*getDocument(),prop);
 }
-

--- a/src/App/DocumentObject.h
+++ b/src/App/DocumentObject.h
@@ -123,7 +123,7 @@ public:
     /**
      * The function indicates whether the object type allows to define a view provider type
      * different than the standard type. The default implementation returns false.
-     * The function can be overriden by Python feature to return true where the type can be
+     * The function can be overridden by Python feature to return true where the type can be
      * retrieved from its proxy object.
      * \sa getViewProviderNameOverride()
      */
@@ -623,7 +623,7 @@ private:
     // accessed by App::Document to record and restore the correct view provider type
     std::string _pcViewProviderName;
 
-    // unique identifier (ammong a document) of this object.
+    // unique identifier (among a document) of this object.
     long _Id;
     
 private:

--- a/src/App/Link.cpp
+++ b/src/App/Link.cpp
@@ -761,7 +761,7 @@ void LinkBaseExtension::update(App::DocumentObject *parent, const Property *prop
         else {
             auto objs = getElementListValue();
 
-            // preseve element properties in ourself
+            // preserve element properties in ourself
             std::vector<Base::Placement> placements;
             placements.reserve(objs.size());
             std::vector<Base::Vector3d> scales;

--- a/src/App/ObjectIdentifier.h
+++ b/src/App/ObjectIdentifier.h
@@ -375,8 +375,8 @@ public:
 
     Py::Object getPyValue(bool pathValue=false, bool *isPseudoProperty=0) const;
 
-    // Setter; is const because it does not alter the object state,
-    // but does have a aide effect.
+    // Setter: is const because it does not alter the object state,
+    // but does have an aiding effect.
 
     void setValue(const App::any & value) const;
 

--- a/src/App/Origin.cpp
+++ b/src/App/Origin.cpp
@@ -93,7 +93,7 @@ App::Plane *Origin::getPlane( const char *role ) const {
         return static_cast<App::Plane *> (feat);
     } else {
         std::stringstream err;
-        err << "Origin \"" << getFullName () << "\" comtains bad Plane object for role \""
+        err << "Origin \"" << getFullName () << "\" contains bad Plane object for role \""
             << role << '"';
         throw Base::RuntimeError ( err.str().c_str () );
     }

--- a/src/App/PropertyContainer.cpp
+++ b/src/App/PropertyContainer.cpp
@@ -244,9 +244,9 @@ void PropertyContainer::Save (Base::Writer &writer) const
     writer.Stream() << writer.ind() << "<Properties Count=\"" << Map.size()
                     << "\" TransientCount=\"" << transients.size() << "\">" << endl;
 
-    // First store transient properties to persisit their status value. We use
+    // First store transient properties to persist their status value. We use
     // a new element named "_Property" so that the save file can be opened by
-    // older version FC.
+    // older versions of FC.
     writer.incInd();
     for(auto prop : transients) {
         writer.Stream() << writer.ind() << "<_Property name=\"" << prop->getName() 
@@ -635,4 +635,3 @@ void PropertyContainer::Restore(Base::Reader &reader)
 \endcode
 
 */
-

--- a/src/App/PropertyLinks.cpp
+++ b/src/App/PropertyLinks.cpp
@@ -2428,14 +2428,14 @@ bool PropertyLinkSubList::adjustLink(const std::set<App::DocumentObject*> &inLis
 // DocInfo
 //++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-// Key on aboslute path. 
+// Key on absolute path.
 // Because of possible symbolic links, multiple entry may refer to the same
 // file. We use QFileInfo::canonicalPath to resolve that.
 typedef std::map<QString,DocInfoPtr> DocInfoMap;
 DocInfoMap _DocInfoMap;
 
 class App::DocInfo : 
-    public std::enable_shared_from_this<App::DocInfo> 
+    public std::enable_shared_from_this<App::DocInfo>
 {
 public:
     typedef boost::signals2::scoped_connection Connection;
@@ -3099,7 +3099,7 @@ void PropertyXLink::Save (Base::Writer &writer) const {
         std::string _path;
         if(exporting) {
             // Here means we are exporting the owner but not exporting the
-            // linked object.  Try to use aboslute file path for easy transition
+            // linked object.  Try to use absolute file path for easy transition
             // into document at different directory
             if(docInfo) 
                 _path = docInfo->filePath();

--- a/src/Base/Exception.h
+++ b/src/Base/Exception.h
@@ -256,7 +256,7 @@ public:
   virtual const char* what() const throw() override;
   /// Report generation
   virtual void ReportException (void) const override;
-  /// Get file name for use with tranlatable message
+  /// Get file name for use with translatable message
   std::string getFileName() const;
   /// returns a Python dictionary containing the exception data
   virtual PyObject * getPyObject(void) override;
@@ -801,4 +801,3 @@ private:
 } //namespace Base
 
 #endif // BASE_EXCEPTION_H
-

--- a/src/Base/FileInfo.h
+++ b/src/Base/FileInfo.h
@@ -99,9 +99,9 @@ public:
     bool isReadable () const;
     /// Checks if the file exist and is writable
     bool isWritable () const;
-    /// Tries to set the file permisson
+    /// Tries to set the file permission
     bool setPermissions (Permissions);
-    /// Checks if it is a file (not a direrctory)
+    /// Checks if it is a file (not a directory)
     bool isFile () const;
     /// Checks if it is a directory (not a file)
     bool isDir () const;
@@ -148,4 +148,3 @@ protected:
 
 
 #endif // BASE_FILEINFO_H
-

--- a/src/Gui/3Dconnexion/GuiNativeEventWin32.cpp
+++ b/src/Gui/3Dconnexion/GuiNativeEventWin32.cpp
@@ -587,7 +587,7 @@ void Gui::GuiNativeEvent::On3dmouseInput()
 			motionData[axis] *= mouseData2Rotation;
 		}
 
-		// Now that the data has had the filters and sensitivty settings applied
+		// Now that the data has had the filters and sensitivity settings applied
 		// calculate the displacements since the last view update
 		for (int axis = 0; axis < 6; axis++) {
 			motionData[axis] *= dwElapsedTime;

--- a/src/Gui/Application.cpp
+++ b/src/Gui/Application.cpp
@@ -706,7 +706,7 @@ void Application::slotNewDocument(const App::Document& Doc, bool isMainDoc)
     if(isMainDoc)
         pDoc->createView(View3DInventor::getClassTypeId());
     // FIXME: Do we really need this further? Calling processEvents() mixes up order of execution in an
-    // unpredicatable way. At least it seems that with Qt5 we don't need this any more.
+    // unpredictable way. At least it seems that with Qt5 we don't need this any more.
 #if QT_VERSION < 0x050000
     // qApp->processEvents(); // make sure to show the window stuff on the right place
 #endif

--- a/src/Gui/BitmapFactory.h
+++ b/src/Gui/BitmapFactory.h
@@ -112,7 +112,7 @@ public:
      */
     QPixmap merge(const QPixmap& p1, const QPixmap& p2, bool vertical) const;
     /** Merges the two pixmaps  \a p1 and \a p2 to one pixmap.
-     * The position of the smaller pimxap \a p2 is drawn into the given
+     * The position of the smaller pixmap \a p2 is drawn into the given
      * position \a pos of the bigger pixmap \a p1. This method does not
      * resize the resulting pixmap.
      */

--- a/src/Gui/Command.cpp
+++ b/src/Gui/Command.cpp
@@ -1418,7 +1418,7 @@ void PythonGroupCommand::activated(int iMsg)
         // text change. The net effect is that the GUI won't change by user
         // inovking command through runCommandByName()
 #if 0
-        // Since the default icon is reset when enabing/disabling the command we have
+        // Since the default icon is reset when enabling/disabling the command we have
         // to explicitly set the icon of the used command.
         pcAction->setIcon(a[iMsg]->icon());
 #endif

--- a/src/Gui/DlgCustomizeImp.h
+++ b/src/Gui/DlgCustomizeImp.h
@@ -70,7 +70,7 @@ private:
     //@{
     QPushButton* buttonHelp; /**< the help button */
     QPushButton* buttonClose; /**< the cancel button */
-    QTabWidget* tabWidget; /**< tab wigdets containing all pages */ 
+    QTabWidget* tabWidget; /**< tab widgets containing all pages */ 
     QGridLayout* customLayout; /**< layout */
     QHBoxLayout* layout; /** horizontal layout */
     static QList<QByteArray> _pages; /**< Name of all registered preference pages */

--- a/src/Gui/Document.cpp
+++ b/src/Gui/Document.cpp
@@ -991,7 +991,7 @@ bool Document::save(void)
             if(docs.size()>1) {
                 int ret = QMessageBox::question(getMainWindow(),
                         QObject::tr("Save dependent files"),
-                        QObject::tr("The file contain external depencencies. "
+                        QObject::tr("The file contains external dependencies. "
                         "Do you want to save the dependent files, too?"),
                         QMessageBox::Yes,QMessageBox::No);
                 if (ret != QMessageBox::Yes) {
@@ -2239,4 +2239,3 @@ void Document::slotChangePropertyEditor(const App::Document &doc, const App::Pro
         setModified(true);
     }
 }
-

--- a/src/Gui/InputField.h
+++ b/src/Gui/InputField.h
@@ -177,14 +177,14 @@ Q_SIGNALS:
     /** gets emitted if the user has entered a VALID input
      *  Valid means the user inputted string obeys all restrictions
      *  like: minimum, maximum and/or the right Unit (if specified). 
-     *  If you want the unfiltered/unvalidated input use textChanged(const QString&) 
+     *  If you want the unfiltered/non-validated input use textChanged(const QString&) 
      *  instead:
      */
     void valueChanged(const Base::Quantity&);
     /** gets emitted if the user has entered a VALID input
      *  Valid means the user inputted string obeys all restrictions
      *  like: minimum, maximum and/or the right Unit (if specified). 
-     *  If you want the unfiltered/unvalidated input use textChanged(const QString&) 
+     *  If you want the unfiltered/non-validated input use textChanged(const QString&) 
      *  instead:
      */
     void valueChanged(double);

--- a/src/Gui/SoFCUnifiedSelection.cpp
+++ b/src/Gui/SoFCUnifiedSelection.cpp
@@ -680,7 +680,7 @@ bool SoFCUnifiedSelection::setSelection(const std::vector<PickedInfo> &infos, bo
         return true;
     }
 
-    // Hierarchy acending
+    // Hierarchy ascending
     //
     // If the clicked subelement is already selected, check if there is an
     // upper hierarchy, and select that hierarchy instead. 

--- a/src/Gui/TaskView/TaskSelectLinkProperty.h
+++ b/src/Gui/TaskView/TaskSelectLinkProperty.h
@@ -68,7 +68,7 @@ public:
     /// set the TaskSelectLinkProperty active, means setting the selection and control it
     void activate(void);
 
-    /// call this to accept the changes the user has made and send back to the Propterty (Ok)
+    /// call this to accept the changes the user has made and send back to the Property (Ok)
     bool accept(void);
     /// This discards the changes of the user and leaves the Property untouched (Cancel)
     bool reject(void);

--- a/src/Gui/Tree.cpp
+++ b/src/Gui/Tree.cpp
@@ -2708,7 +2708,7 @@ void TreeWidget::onItemSelectionChanged ()
         if(TreeParams::Instance()->RecordSelection())
             Gui::Selection().selStackPush();
 
-        // This special handling to deal with possible discrepency of
+        // This special handling to deal with possible discrepancy of
         // Gui.Selection and Tree view selection because of newly added
         // DocumentObject::redirectSubName()
         Selection().clearCompleteSelection();
@@ -4883,4 +4883,3 @@ TreeWidget *DocumentObjectItem::getTree() const{
 }
 
 #include "moc_Tree.cpp"
-

--- a/src/Gui/ViewProviderGeometryObject.h
+++ b/src/Gui/ViewProviderGeometryObject.h
@@ -40,7 +40,7 @@ class SoFCBoundingBox;
 class View3DInventorViewer;
 
 /**
- * The base class for all view providers that display geometric data, like mesh, point cloudes and shapes.
+ * The base class for all view providers that display geometric data, like mesh, point clouds and shapes.
  * @author Werner Mayer
  */
 class GuiExport ViewProviderGeometryObject : public ViewProviderDragger
@@ -106,4 +106,3 @@ protected:
 
 
 #endif // GUI_VIEWPROVIDER_GEOMETRYOBJECT_H
-

--- a/src/Gui/ViewProviderPy.xml
+++ b/src/Gui/ViewProviderPy.xml
@@ -143,7 +143,7 @@ getElementColors(elementName=None) -> dict(elementName:color)
                 <UserDocu>
 setElementColors(colors): set element colors
 
-colors: color dictonary of type elementName:(r,g,b,a)
+colors: color dictionary of type elementName:(r,g,b,a)
                 </UserDocu>
 			</Documentation>
 		</Methode>

--- a/src/Gui/ViewProviderPyImp.cpp
+++ b/src/Gui/ViewProviderPyImp.cpp
@@ -456,7 +456,7 @@ PyObject* ViewProviderPy::setElementColors(PyObject* args)
     for(auto it=dict.begin();it!=dict.end();++it) {
         const auto &value = *it;
         if(!value.first.isString() || !value.second.isSequence())
-            throw Py::TypeError("Expect the dictonary contain items of type elementName:(r,g,b,a)");
+            throw Py::TypeError("Expect the dictionary to contain items of type elementName:(r,g,b,a)");
 
         App::PropertyColor prop;
         prop.setPyObject(value.second.ptr());

--- a/src/Mod/Draft/importDXF.py
+++ b/src/Mod/Draft/importDXF.py
@@ -1889,7 +1889,7 @@ def attribs(insert):
     Returns
     -------
     list
-        It returns a list with the entitites that have `'attrib'` data,
+        It returns a list with the entities that have `'attrib'` data,
         until `'seqend'` is found.
 
         It returns an empty list `[]`, if DXF code 66 ("Entities follow")

--- a/src/Mod/Drawing/DrawingExample.py
+++ b/src/Mod/Drawing/DrawingExample.py
@@ -1,4 +1,4 @@
-# exampel how to use the scripting API of the drawing module
+# example how to use the scripting API of the drawing module
 # 
 # first of all you need the Part and the Drawing module:
 import FreeCAD, Part, Drawing
@@ -96,4 +96,3 @@ App.activeDocument().Page.addObject(App.activeDocument().ViewSelf)
 App.activeDocument().recompute()
 
 del Shape,ViewSVG, resultSVG
-

--- a/src/Mod/Fem/App/FemConstraint.h
+++ b/src/Mod/Fem/App/FemConstraint.h
@@ -36,7 +36,7 @@ namespace Fem {
  * @brief Base class of all Constraint Objects of the Fem module.
  *
  * @details
- *  @ref Constraint isn't intended to be used directely. Actual Constraints
+ *  @ref Constraint isn't intended to be used directly. Actual Constraints
  *  used to specify a simulation are children of this class. The base class
  *  essentially does two things: Most importantely it has a property @ref
  *  Constraint::References which is a list of all sub objects the constraint
@@ -185,7 +185,7 @@ protected:
      *  index in normals[i].
      *
      * @param[out] points
-     *  For each vertex a point equal to the location of that vertix is pushed
+     *  For each vertex a point equal to the location of that vertex is pushed
      *  into the points vector. For each edge at least to points, the beginning
      *  and the end of the edge, are pushed into the vector. Depending on the
      *  length of the edge more points may be added in between. For each face a

--- a/src/Mod/Fem/Gui/Command.cpp
+++ b/src/Mod/Fem/Gui/Command.cpp
@@ -1489,7 +1489,7 @@ void CmdFemPostFunctions::activated(int iMsg)
             qApp->translate("CmdFemPostClipFilter", "Select a pipeline, please."));
     }
 
-    // Since the default icon is reset when enabing/disabling the command we have
+    // Since the default icon is reset when enabling/disabling the command we have
     // to explicitly set the icon of the used command.
     Gui::ActionGroup* pcAction = qobject_cast<Gui::ActionGroup*>(_pcAction);
     QList<QAction*> a = pcAction->actions();

--- a/src/Mod/Fem/femsolver/run.py
+++ b/src/Mod/Fem/femsolver/run.py
@@ -74,7 +74,7 @@ def run_fem_solver(solver, working_dir=None):
         A document object which must be a framework compliant solver. This means
         that it should be derived from the document object provided by
         :mod:`femsolver.solverbase` and implement all required methods
-        correctely. Of particular importance is :meth:`getMachine
+        correctly. Of particular importance is :meth:`getMachine
         <femsolver.solverbase.Proxy.getMachine>` as it is used by this method
         the get the :class:`Machine` used to execute the solver.
 
@@ -154,7 +154,7 @@ def getMachine(solver, path=None):
         A document object which must be a framework compliant solver. This means
         that it should be derived from the document object provided by
         :mod:`femsolver.solverbase` and implement all required methods
-        correctely. Of particular importance is :meth:`getMachine
+        correctly. Of particular importance is :meth:`getMachine
         <femsolver.solverbase.Proxy.getMachine>` as it is used by this method
         to create a new :class:`Machine` on cache miss.
 

--- a/src/Mod/Fem/femtools/femutils.py
+++ b/src/Mod/Fem/femtools/femutils.py
@@ -268,7 +268,7 @@ def get_pref_working_dir(solver_obj):
      If user setting is set to BESIDE and the document isn't saved.
 
     :note:
-     Not working correctely for most cases because this circumvents directory
+     Not working correctly for most cases because this circumvents directory
      caching of the solver framework. For solver use getMachine from run.py
      instead.
     """

--- a/src/Mod/Part/Gui/Command.cpp
+++ b/src/Mod/Part/Gui/Command.cpp
@@ -568,7 +568,7 @@ void CmdPartCompJoinFeatures::activated(int iMsg)
     else
         return;
 
-    // Since the default icon is reset when enabing/disabling the command we have
+    // Since the default icon is reset when enabling/disabling the command we have
     // to explicitly set the icon of the used command.
     Gui::ActionGroup* pcAction = qobject_cast<Gui::ActionGroup*>(_pcAction);
     QList<QAction*> a = pcAction->actions();
@@ -676,7 +676,7 @@ void CmdPartCompSplitFeatures::activated(int iMsg)
     else
         return;
 
-    // Since the default icon is reset when enabing/disabling the command we have
+    // Since the default icon is reset when enabling/disabling the command we have
     // to explicitly set the icon of the used command.
     Gui::ActionGroup* pcAction = qobject_cast<Gui::ActionGroup*>(_pcAction);
     QList<QAction*> a = pcAction->actions();
@@ -796,7 +796,7 @@ void CmdPartCompCompoundTools::activated(int iMsg)
     else
         return;
 
-    // Since the default icon is reset when enabing/disabling the command we have
+    // Since the default icon is reset when enabling/disabling the command we have
     // to explicitly set the icon of the used command.
     Gui::ActionGroup* pcAction = qobject_cast<Gui::ActionGroup*>(_pcAction);
     QList<QAction*> a = pcAction->actions();
@@ -1739,7 +1739,7 @@ void CmdPartCompOffset::activated(int iMsg)
     else
         return;
 
-    // Since the default icon is reset when enabing/disabling the command we have
+    // Since the default icon is reset when enabling/disabling the command we have
     // to explicitly set the icon of the used command.
     Gui::ActionGroup* pcAction = qobject_cast<Gui::ActionGroup*>(_pcAction);
     QList<QAction*> a = pcAction->actions();

--- a/src/Mod/PartDesign/App/FeatureDressUp.h
+++ b/src/Mod/PartDesign/App/FeatureDressUp.h
@@ -56,7 +56,7 @@ public:
      */
     virtual Part::Feature* getBaseObject(bool silent=false) const;
     /// extracts all edges from the subshapes (including face edges) and furthermore adds
-    /// all C0 continuos edges to the vector
+    /// all C0 continuous edges to the vector
     void getContiniusEdges(Part::TopoShape, std::vector< std::string >&);
 
 protected:

--- a/src/Mod/PartDesign/App/FeatureTransformed.h
+++ b/src/Mod/PartDesign/App/FeatureTransformed.h
@@ -83,7 +83,7 @@ public:
     //@}
 
     /** returns a list of the transformations that where rejected during the last execute
-      * because they did not ovelap with the support
+      * because they did not overlap with the support
       */
     typedef std::map<App::DocumentObject*, std::list<gp_Trsf> > rejectedMap;
     const rejectedMap getRejectedTransformations(void) { return rejected; }

--- a/src/Mod/PartDesign/Gui/Command.cpp
+++ b/src/Mod/PartDesign/Gui/Command.cpp
@@ -1939,7 +1939,7 @@ void prepareTransformed(PartDesign::Body *pcActiveBody, Gui::Command* cmd, const
 
         auto Feat = pcActiveBody->getDocument()->getObject(FeatName.c_str());
 
-        // TODO Wjat that function supposed to do? (2015-08-05, Fat-Zer)
+        // TODO What is this function supposed to do? (2015-08-05, Fat-Zer)
         func(Feat, features);
 
         // Set the tip of the body

--- a/src/Mod/PartDesign/Gui/ReferenceSelection.cpp
+++ b/src/Mod/PartDesign/Gui/ReferenceSelection.cpp
@@ -212,7 +212,7 @@ void getReferencedSelection(const App::DocumentObject* thisObj, const Gui::Selec
     
     //check if the selection is an external reference and ask the user what to do
     //of course only if thisObj is in a body, as otherwise the old workflow would not 
-    //be supportet
+    //be supported
     PartDesign::Body* body = PartDesignGui::getBodyFor(thisObj, false);
     bool originfeature = selObj->isDerivedFrom(App::OriginFeature::getClassTypeId());
     if (!originfeature && body) {

--- a/src/Mod/PartDesign/Gui/WorkflowManager.h
+++ b/src/Mod/PartDesign/Gui/WorkflowManager.h
@@ -44,7 +44,7 @@ enum class Workflow {
 
 /**
  * This class controls the workflow of each file.
- * It has been introdused to support legacy files migrating to the new workflow.
+ * It has been introduced to support legacy files migrating to the new workflow.
  */
 class PartDesignGuiExport WorkflowManager {
 public:

--- a/src/Mod/Path/App/Area.cpp
+++ b/src/Mod/Path/App/Area.cpp
@@ -883,8 +883,8 @@ struct WireJoiner {
                     if(vit->pt().SquareDistance(pt[i]) > tol)
                         break;
                     auto &vinfo = *vit;
-                    // yse, we push ourself, too, because other edges require
-                    // this info in the adjcent list. We'll do filtering later.
+                    // yes, we push ourself too, because other edges require
+                    // this info in the adjacent list. We'll do filtering later.
                     adjacentList.push_back(vinfo);
                     ++info.iEnd[i];
                 }
@@ -3416,4 +3416,3 @@ void Area::setDefaultParams(const AreaStaticParams &params){
 const AreaStaticParams &Area::getDefaultParams() {
     return s_params;
 }
-

--- a/src/Mod/Raytracing/RaytracingExample.py
+++ b/src/Mod/Raytracing/RaytracingExample.py
@@ -1,4 +1,4 @@
-# exampel how to use the scripting API of the drawing module
+# example how to use the scripting API of the drawing module
 # 
 # first of all you need the Part and the Drawing module:
 import FreeCAD, Part, Drawing
@@ -96,4 +96,3 @@ App.activeDocument().Page.addObject(App.activeDocument().ViewSelf)
 App.activeDocument().recompute()
 
 del Shape,ViewSVG, resultSVG
-

--- a/src/Mod/Ship/shipHydrostatics/TaskPanel.py
+++ b/src/Mod/Ship/shipHydrostatics/TaskPanel.py
@@ -488,7 +488,7 @@ class TaskPanel:
             "Computing external faces",
             None)
         App.Console.PrintMessage(msg + '...\n')
-        # Valid/unvalid faces detection loop
+        # Valid/Invalid faces detection loop
         for i in range(len(faces)):
             App.Console.PrintMessage("\t{} / {}\n".format(i + 1, len(faces)))
             f = faces[i]

--- a/src/Mod/Show/Containers.py
+++ b/src/Mod/Show/Containers.py
@@ -182,7 +182,7 @@ def _getMetacontainerChildren(container, isrightcontainer_func):
 
 def isAContainer(obj, links_too = False):
     '''isAContainer(obj, links_too): returns True if obj is an object container, such as 
-    Group, Part, Body. The important characterisic of an object being a 
+    Group, Part, Body. The important characteristic of an object being a 
     container is that it can be activated to receive new objects. Documents 
     are considered containers, too.
     If links_too, App::Link objects are considered containers, too. Then, container tree 

--- a/src/Mod/Sketcher/App/planegcs/GCS.cpp
+++ b/src/Mod/Sketcher/App/planegcs/GCS.cpp
@@ -4067,7 +4067,7 @@ SolverReportingManager::Manager().LogToFile("GCS::System::diagnose()\n");
         }
 
         // Last (NumParams-rank) rows of Q construct the dependent part of J
-        // in conjuntion with the R matrix
+        // in conjunction with the R matrix
         // Last (NumParams-rank) cols of Q never contribute as R is zero after the rank
         /*std::set<int> associatedParamCols;
         for(int i = rank; i < paramsNum; i++) {

--- a/src/Mod/Sketcher/Gui/CommandConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/CommandConstraints.cpp
@@ -5884,7 +5884,7 @@ void CmdSketcherCompConstrainRadDia::activated(int iMsg)
     else
         return;
 
-    // Since the default icon is reset when enabing/disabling the command we have
+    // Since the default icon is reset when enabling/disabling the command we have
     // to explicitly set the icon of the used command.
     Gui::ActionGroup* pcAction = qobject_cast<Gui::ActionGroup*>(_pcAction);
     QList<QAction*> a = pcAction->actions();

--- a/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp
+++ b/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp
@@ -2026,7 +2026,7 @@ void CmdSketcherCompCreateArc::activated(int iMsg)
     else
         return;
 
-    // Since the default icon is reset when enabing/disabling the command we have
+    // Since the default icon is reset when enabling/disabling the command we have
     // to explicitly set the icon of the used command.
     Gui::ActionGroup* pcAction = qobject_cast<Gui::ActionGroup*>(_pcAction);
     QList<QAction*> a = pcAction->actions();
@@ -4309,7 +4309,7 @@ void CmdSketcherCompCreateConic::activated(int iMsg)
         return;
     }
 
-    // Since the default icon is reset when enabing/disabling the command we have
+    // Since the default icon is reset when enabling/disabling the command we have
     // to explicitly set the icon of the used command.
     Gui::ActionGroup* pcAction = qobject_cast<Gui::ActionGroup*>(_pcAction);
     QList<QAction*> a = pcAction->actions();
@@ -4950,7 +4950,7 @@ void CmdSketcherCompCreateBSpline::activated(int iMsg)
         return;
     }
 
-    // Since the default icon is reset when enabing/disabling the command we have
+    // Since the default icon is reset when enabling/disabling the command we have
     // to explicitly set the icon of the used command.
     Gui::ActionGroup* pcAction = qobject_cast<Gui::ActionGroup*>(_pcAction);
     QList<QAction*> a = pcAction->actions();
@@ -5304,7 +5304,7 @@ void CmdSketcherCompCreateCircle::activated(int iMsg)
     else
         return;
 
-    // Since the default icon is reset when enabing/disabling the command we have
+    // Since the default icon is reset when enabling/disabling the command we have
     // to explicitly set the icon of the used command.
     Gui::ActionGroup* pcAction = qobject_cast<Gui::ActionGroup*>(_pcAction);
     QList<QAction*> a = pcAction->actions();
@@ -7585,7 +7585,7 @@ void CmdSketcherCompCreateRegularPolygon::activated(int iMsg)
         return;
     }
 
-    // Since the default icon is reset when enabing/disabling the command we have
+    // Since the default icon is reset when enabling/disabling the command we have
     // to explicitly set the icon of the used command.
     Gui::ActionGroup* pcAction = qobject_cast<Gui::ActionGroup*>(_pcAction);
     QList<QAction*> a = pcAction->actions();

--- a/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp
+++ b/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp
@@ -267,7 +267,7 @@ void CmdSketcherCompBSplineShowHideGeometryInformation::activated(int iMsg)
 
     cmd->invoke(0);
 
-    // Since the default icon is reset when enabing/disabling the command we have
+    // Since the default icon is reset when enabling/disabling the command we have
     // to explicitly set the icon of the used command.
     Gui::ActionGroup* pcAction = qobject_cast<Gui::ActionGroup*>(_pcAction);
     QList<QAction*> a = pcAction->actions();
@@ -830,7 +830,7 @@ void CmdSketcherCompModifyKnotMultiplicity::activated(int iMsg)
 
     cmd->invoke(0);
 
-    // Since the default icon is reset when enabing/disabling the command we have
+    // Since the default icon is reset when enabling/disabling the command we have
     // to explicitly set the icon of the used command.
     Gui::ActionGroup* pcAction = qobject_cast<Gui::ActionGroup*>(_pcAction);
     QList<QAction*> a = pcAction->actions();

--- a/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp
+++ b/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp
@@ -1545,7 +1545,7 @@ void CmdSketcherCompCopy::activated(int iMsg)
     if (iMsg<0 || iMsg>2)
         return;
 
-    // Since the default icon is reset when enabing/disabling the command we have
+    // Since the default icon is reset when enabling/disabling the command we have
     // to explicitly set the icon of the used command.
     Gui::ActionGroup* pcAction = qobject_cast<Gui::ActionGroup*>(_pcAction);
     QList<QAction*> a = pcAction->actions();

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -4339,7 +4339,7 @@ Restart:
                 continue;
             }
 
-            // distinquish different constraint types to build up
+            // distinguish different constraint types to build up
             switch (Constr->Type) {
                 case Block:
                 case Horizontal: // write the new position of the Horizontal constraint Same as vertical position.


### PR DESCRIPTION
Found via `codespell -q 3 -L aci,ake,aline,alle,alledges,alocation,als,ang,anid,ba,beginn,behaviour,bloaded,byteorder,calculater,cancelled,cancelling,cas,cascade,centimetre,childs,colour,colours,commen,currenty,dof,doubleclick,dum,eiter,elemente,feld,freez,hist,iff,indicies,initialisation,initialise,initialised,initialises,initialisiert,ist,kilometre,lod,mantatory,methode,metres,millimetre,modell,nd,noe,normale,normaly,nto,numer,oder,orgin,orginx,orginy,ot,pard,pres,programm,que,recurrance,rougly,seperator,serie,sinc,strack,substraction,te,thist,thru,tread,uint,unter,vertexes,wallthickness,whitespaces -S ./.git,*.po,*.ts,./ChangeLog.txt,./src/3rdParty,./src/Mod/Assembly/App/opendcm,./src/CXX,./src/zipios++,./src/Base/swig*,./src/Mod/Robot/App/kdl_cp,./src/Mod/Import/App/SCL,./src/WindowsInstaller,./src/Doc/FreeCAD.uml`