### PR TITLE
fix crash on macOS when opening OpenSCAD Workbench

### DIFF
--- a/src/Mod/OpenSCAD/OpenSCADUtils.py
+++ b/src/Mod/OpenSCAD/OpenSCADUtils.py
@@ -42,6 +42,7 @@ except AttributeError:
         return QtGui.QApplication.translate(context, text, None)
 
 import io
+import sys
 
 try:
     import FreeCAD
@@ -77,7 +78,7 @@ def searchforopenscadexe():
                 stdout=subprocess.PIPE,stderr=subprocess.PIPE)
         stdout,stderr = p1.communicate(ascript)
         if p1.returncode == 0:
-            opathl=stdout.split('\n')
+            opathl = stdout.decode().split('\n') if sys.version[0] == '3' else stdout.split('\n')
             if len(opathl) >=1:
                 return opathl[0]+'Contents/MacOS/OpenSCAD'
         #test the default path


### PR DESCRIPTION
The OpenSCAD Workbench crashes on open on macOS with error
"a bytes-like object is required, not 'str'", due to python 2 to python 3 incompatibility. This is me implementing the fix described by oapa at https://forum.freecadweb.org/viewtopic.php?t=35384#p311908 (with an untested attempt to make it also still run with python 2).

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [x] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
