### PR TITLE
Gui: fix DlgSettings3DView.ui, remove bold tags <b> because it causes an error in compilation

### DIFF
--- a/src/Gui/DlgSettings3DView.ui
+++ b/src/Gui/DlgSettings3DView.ui
@@ -139,7 +139,7 @@ VBOs offer substantial performance gains because the data resides
 in the graphics memory rather than the system memory and so it
 can be rendered directly by GPU. 
 
-<b>Note</b>: Sometimes this feature may lead to a host of different issues ranging
+Note: Sometimes this feature may lead to a host of different issues ranging
 from graphical anomalies to GPU crash bugs. Remember to report this setting
 is enabled when seeking support on the FreeCAD forums.</string>
         </property>


### PR DESCRIPTION
The compilation errors when the `.ui` file has `<b>tags</b>` inside the `<string>` tags; so we remove these `<b></b>` pair.

```
uic: Error in line 142, column 3 : Unexpected element b
File '/opt/freecad-source-vocx/src/Gui/DlgSettings3DView.ui' is not valid
src/Gui/CMakeFiles/FreeCADGui.dir/build.make:322: recipe for target 'src/Gui/ui_DlgSettings3DView.h' failed
make[2]: *** [src/Gui/ui_DlgSettings3DView.h] Error 1
```

---

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists
