### PR TITLE
Draft: new icon for Draft_Dimension in the tree view in SVG, instead of XPM

### DIFF
--- a/src/Mod/Draft/Draft.py
+++ b/src/Mod/Draft/Draft.py
@@ -4354,31 +4354,7 @@ class _ViewProviderDimension(_ViewProviderDraft):
         return mode
 
     def getIcon(self):
-        return """
-            /* XPM */
-            static char * dim_xpm[] = {
-            "16 16 4 1",
-            "   c None",
-            ".  c #000000",
-            "+  c #FFFF00",
-            "@  c #FFFFFF",
-            "                ",
-            "                ",
-            "     .    .     ",
-            "    ..    ..    ",
-            "   .+.    .+.   ",
-            "  .++.    .++.  ",
-            " .+++. .. .+++. ",
-            ".++++. .. .++++.",
-            " .+++. .. .+++. ",
-            "  .++.    .++.  ",
-            "   .+.    .+.   ",
-            "    ..    ..    ",
-            "     .    .     ",
-            "                ",
-            "                ",
-            "                "};
-            """
+        return ":/icons/Draft_Dimension_Tree.svg"
 
     def __getstate__(self):
         return self.Object.ViewObject.DisplayMode
@@ -4694,31 +4670,7 @@ class _ViewProviderAngularDimension(_ViewProviderDraft):
             return ["2D","3D"][getParam("dimstyle",0)]
 
     def getIcon(self):
-        return """
-                        /* XPM */
-                        static char * dim_xpm[] = {
-                        "16 16 4 1",
-                        "   c None",
-                        ".  c #000000",
-                        "+  c #FFFF00",
-                        "@  c #FFFFFF",
-                        "                ",
-                        "                ",
-                        "     .    .     ",
-                        "    ..    ..    ",
-                        "   .+.    .+.   ",
-                        "  .++.    .++.  ",
-                        " .+++. .. .+++. ",
-                        ".++++. .. .++++.",
-                        " .+++. .. .+++. ",
-                        "  .++.    .++.  ",
-                        "   .+.    .+.   ",
-                        "    ..    ..    ",
-                        "     .    .     ",
-                        "                ",
-                        "                ",
-                        "                "};
-                        """
+        return ":/icons/Draft_Dimension_Tree.svg"
 
     def __getstate__(self):
         return self.Object.ViewObject.DisplayMode

--- a/src/Mod/Draft/Resources/Draft.qrc
+++ b/src/Mod/Draft/Resources/Draft.qrc
@@ -1,144 +1,152 @@
 <RCC>
     <qresource> 
+        <file>icons/Draft_2DShapeView.svg</file>
         <file>icons/Draft_AddPoint.svg</file>
         <file>icons/Draft_AddToGroup.svg</file>
         <file>icons/Draft_Apply.svg</file>
         <file>icons/Draft_Arc.svg</file>
         <file>icons/Draft_Arc_3Points.svg</file>
-        <file>icons/Draft_BSpline.svg</file>
+        <file>icons/Draft_Array.svg</file>
+        <file>icons/Draft_AutoGroup.svg</file>
+        <file>icons/Draft_AutoGroup_on.svg</file>
+        <file>icons/Draft_AutoGroup_off.svg</file>
         <file>icons/Draft_BezCurve.svg</file>
         <file>icons/Draft_BezSharpNode.svg</file>
-        <file>icons/Draft_BezTanNode.svg</file>
         <file>icons/Draft_BezSymNode.svg</file>
-        <file>icons/Draft_CubicBezCurve.svg</file>
+        <file>icons/Draft_BezTanNode.svg</file>
+        <file>icons/Draft_BSpline.svg</file>
         <file>icons/Draft_Circle.svg</file>
+        <file>icons/Draft_Clone.svg</file>
         <file>icons/Draft_Construction.svg</file>
+        <file>icons/Draft_CubicBezCurve.svg</file>
+        <file>icons/Draft_Cursor.svg</file>
         <file>icons/Draft_DelPoint.svg</file>
         <file>icons/Draft_Dimension.svg</file>
+        <file>icons/Draft_Dot.svg</file>
         <file>icons/Draft_Downgrade.svg</file>
+        <file>icons/Draft_Draft.svg</file>
+        <file>icons/Draft_Draft2Sketch.svg</file>
         <file>icons/Draft_Drawing.svg</file>
         <file>icons/Draft_Edit.svg</file>
-        <file>icons/Draft_Finish.svg</file>
+        <file>icons/Draft_Ellipse.svg</file>
+        <file>icons/Draft_Facebinder.svg</file>
+        <file>icons/Draft_Facebinder_Provider.svg</file>
         <file>icons/Draft_Fillet.svg</file>
+        <file>icons/Draft_Finish.svg</file>
+        <file>icons/Draft_FlipDimension.svg</file>
+        <file>icons/Draft_Grid.svg</file>
+        <file>icons/Draft_Heal.svg</file>
         <file>icons/Draft_Join.svg</file>
+        <file>icons/Draft_Label.svg</file>
         <file>icons/Draft_Layer.svg</file>
         <file>icons/Draft_Line.svg</file>
+        <file>icons/Draft_LinkArray.svg</file>
         <file>icons/Draft_Lock.svg</file>
         <file>icons/Draft_Macro.svg</file>
+        <file>icons/Draft_Mirror.svg</file>
         <file>icons/Draft_Move.svg</file>
         <file>icons/Draft_Offset.svg</file>
+        <file>icons/Draft_PathArray.svg</file>
+        <file>icons/Draft_PathLinkArray.svg</file>
+        <file>icons/Draft_Point.svg</file>
+        <file>icons/Draft_PointArray.svg</file>
         <file>icons/Draft_Polygon.svg</file>
         <file>icons/Draft_Rectangle.svg</file>
         <file>icons/Draft_Rotate.svg</file>
         <file>icons/Draft_Scale.svg</file>
         <file>icons/Draft_SelectGroup.svg</file>
         <file>icons/Draft_SelectPlane.svg</file>
+        <file>icons/Draft_ShapeString.svg</file>
+        <file>icons/Draft_Slope.svg</file>
+        <file>icons/Draft_Snap.svg</file>
         <file>icons/Draft_Split.svg</file>
+        <file>icons/Draft_Stretch.svg</file>
         <file>icons/Draft_SwitchMode.svg</file>
         <file>icons/Draft_Text.svg</file>
         <file>icons/Draft_Trimex.svg</file>
         <file>icons/Draft_Upgrade.svg</file>
+        <file>icons/Draft_VisGroup.svg</file>
+        <file>icons/Draft_Wipe.svg</file>
         <file>icons/Draft_Wire.svg</file>
         <file>icons/Draft_WireToBSpline.svg</file>
+        <file>icons/DraftWorkbench.svg</file>
         <file>icons/preferences-draft.svg</file>
-        <file>icons/Draft_Draft.svg</file>
-        <file>icons/Draft_2DShapeView.svg</file>
-        <file>icons/Draft_Wipe.svg</file>
-        <file>icons/Draft_Draft2Sketch.svg</file>
-        <file>icons/Draft_Array.svg</file>
-        <file>icons/Draft_LinkArray.svg</file>
-        <file>icons/Draft_Cursor.svg</file>
-        <file>icons/Draft_Dot.svg</file>
-        <file>icons/Draft_Point.svg</file>
-        <file>icons/Draft_Snap.svg</file>
-        <file>icons/Draft_PathArray.svg</file>
-        <file>icons/Draft_PathLinkArray.svg</file>
-        <file>icons/Draft_PointArray.svg</file>
-        <file>icons/Draft_VisGroup.svg</file>
-        <file>icons/Snap_Lock.svg</file>
-        <file>icons/Snap_Endpoint.svg</file>
-        <file>icons/Snap_Midpoint.svg</file>
-        <file>icons/Snap_Perpendicular.svg</file>
-        <file>icons/Snap_Grid.svg</file>
-        <file>icons/Snap_Intersection.svg</file>
-        <file>icons/Snap_Parallel.svg</file>
         <file>icons/Snap_Angle.svg</file>
         <file>icons/Snap_Center.svg</file>
-        <file>icons/Snap_Extension.svg</file>
-        <file>icons/Snap_Ortho.svg</file>
-        <file>icons/Snap_Near.svg</file>
         <file>icons/Snap_Dimensions.svg</file>
-        <file>icons/Snap_WorkingPlane.svg</file>
+        <file>icons/Snap_Endpoint.svg</file>
+        <file>icons/Snap_Extension.svg</file>
+        <file>icons/Snap_Grid.svg</file>
+        <file>icons/Snap_Intersection.svg</file>
+        <file>icons/Snap_Lock.svg</file>
+        <file>icons/Snap_Midpoint.svg</file>
+        <file>icons/Snap_Near.svg</file>
+        <file>icons/Snap_Ortho.svg</file>
+        <file>icons/Snap_Parallel.svg</file>
+        <file>icons/Snap_Perpendicular.svg</file>
         <file>icons/Snap_Special.svg</file>
-        <file>icons/Draft_Clone.svg</file>
-        <file>icons/Draft_Heal.svg</file>
-        <file>icons/Draft_Ellipse.svg</file>
-        <file>icons/Draft_ShapeString.svg</file>
-        <file>icons/Draft_Facebinder.svg</file>
-        <file>icons/Draft_Facebinder_Provider.svg</file>
-        <file>icons/Draft_FlipDimension.svg</file>
-        <file>icons/Draft_Mirror.svg</file>
-        <file>icons/Draft_Grid.svg</file>
-        <file>icons/Draft_Slope.svg</file>
-        <file>icons/DraftWorkbench.svg</file>
-        <file>icons/Draft_Stretch.svg</file>
-        <file>icons/Draft_AutoGroup.svg</file>
-        <file>icons/Draft_AutoGroup_on.svg</file>
-        <file>icons/Draft_AutoGroup_off.svg</file>
-        <file>icons/Draft_Label.svg</file>
+        <file>icons/Snap_WorkingPlane.svg</file>
+        <file>patterns/brick01</file>
         <file>patterns/concrete.svg</file>
         <file>patterns/cross.svg</file>
+        <file>patterns/diagonal1.svg</file>
+        <file>patterns/diagonal2.svg</file>
+        <file>patterns/earth.svg</file>
+        <file>patterns/hbone.svg</file>
         <file>patterns/line.svg</file>
+        <file>patterns/plus.svg</file>
         <file>patterns/simple.svg</file>
+        <file>patterns/solid.svg</file>
         <file>patterns/square.svg</file>
+        <file>patterns/steel.svg</file>
         <file>patterns/wood.svg</file>
         <file>patterns/woodgrain.svg</file>
         <file>translations/Draft_af.qm</file>
-        <file>translations/Draft_de.qm</file>
-        <file>translations/Draft_fi.qm</file>
-        <file>translations/Draft_fr.qm</file>
-        <file>translations/Draft_it.qm</file>
-        <file>translations/Draft_nl.qm</file>
-        <file>translations/Draft_no.qm</file>
-        <file>translations/Draft_ru.qm</file>
-        <file>translations/Draft_uk.qm</file>
-        <file>translations/Draft_pl.qm</file>
-        <file>translations/Draft_hr.qm</file>
-        <file>translations/Draft_ja.qm</file>
-        <file>translations/Draft_hu.qm</file>
-        <file>translations/Draft_tr.qm</file>
-        <file>translations/Draft_sv-SE.qm</file>
-        <file>translations/Draft_zh-TW.qm</file>
-        <file>translations/Draft_pt-BR.qm</file>
-        <file>translations/Draft_cs.qm</file>
-        <file>translations/Draft_sk.qm</file>
-        <file>translations/Draft_es-ES.qm</file>
-        <file>translations/Draft_zh-CN.qm</file>
-        <file>translations/Draft_ro.qm</file>
-        <file>translations/Draft_pt-PT.qm</file>
-        <file>translations/Draft_sr.qm</file>
-        <file>translations/Draft_el.qm</file>
-        <file>translations/Draft_sl.qm</file>
-        <file>translations/Draft_eu.qm</file>
+        <file>translations/Draft_ar.qm</file>
         <file>translations/Draft_ca.qm</file>
+        <file>translations/Draft_cs.qm</file>
+        <file>translations/Draft_de.qm</file>
+        <file>translations/Draft_el.qm</file>
+        <file>translations/Draft_es-ES.qm</file>
+        <file>translations/Draft_eu.qm</file>
+        <file>translations/Draft_fi.qm</file>
+        <file>translations/Draft_fil.qm</file>
+        <file>translations/Draft_fr.qm</file>
         <file>translations/Draft_gl.qm</file>
+        <file>translations/Draft_hr.qm</file>
+        <file>translations/Draft_hu.qm</file>
+        <file>translations/Draft_id.qm</file>
+        <file>translations/Draft_it.qm</file>
+        <file>translations/Draft_ja.qm</file>
         <file>translations/Draft_kab.qm</file>
         <file>translations/Draft_ko.qm</file>
-        <file>translations/Draft_fil.qm</file>
-        <file>translations/Draft_id.qm</file>
         <file>translations/Draft_lt.qm</file>
+        <file>translations/Draft_nl.qm</file>
+        <file>translations/Draft_no.qm</file>
+        <file>translations/Draft_pl.qm</file>
+        <file>translations/Draft_pt-BR.qm</file>
+        <file>translations/Draft_pt-PT.qm</file>
+        <file>translations/Draft_ro.qm</file>
+        <file>translations/Draft_ru.qm</file>
+        <file>translations/Draft_sk.qm</file>
+        <file>translations/Draft_sl.qm</file>
+        <file>translations/Draft_sr.qm</file>
+        <file>translations/Draft_sv-SE.qm</file>
+        <file>translations/Draft_tr.qm</file>
+        <file>translations/Draft_uk.qm</file>
         <file>translations/Draft_val-ES.qm</file>
-        <file>translations/Draft_ar.qm</file>
         <file>translations/Draft_vi.qm</file>
+        <file>translations/Draft_zh-CN.qm</file>
+        <file>translations/Draft_zh-TW.qm</file>
         <file>ui/preferences-draft.ui</file>
         <file>ui/preferences-draftsnap.ui</file>
         <file>ui/preferences-drafttexts.ui</file>
         <file>ui/preferences-draftvisual.ui</file>
-        <file>ui/preferences-dxf.ui</file>
         <file>ui/preferences-dwg.ui</file>
-        <file>ui/preferences-svg.ui</file>
+        <file>ui/preferences-dxf.ui</file>
         <file>ui/preferences-oca.ui</file>
-        <file>ui/TaskShapeString.ui</file>
+        <file>ui/preferences-svg.ui</file>
         <file>ui/TaskSelectPlane.ui</file>
+        <file>ui/TaskShapeString.ui</file>
     </qresource>
 </RCC> 

--- a/src/Mod/Draft/Resources/Draft.qrc
+++ b/src/Mod/Draft/Resources/Draft.qrc
@@ -22,6 +22,7 @@
         <file>icons/Draft_Cursor.svg</file>
         <file>icons/Draft_DelPoint.svg</file>
         <file>icons/Draft_Dimension.svg</file>
+        <file>icons/Draft_Dimension_Tree.svg</file>
         <file>icons/Draft_Dot.svg</file>
         <file>icons/Draft_Downgrade.svg</file>
         <file>icons/Draft_Draft.svg</file>


### PR DESCRIPTION
Also re-order alphabetically the resources in `Draft.qrc` to be easier to see if there are missing files when looking at the file explorer.

---

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists
