### PR TITLE
Gui: avoid unnecessary visibility change when update view provider

### DIFF
--- a/src/Gui/ViewProviderDocumentObject.cpp
+++ b/src/Gui/ViewProviderDocumentObject.cpp
@@ -183,8 +183,12 @@ void ViewProviderDocumentObject::onChanged(const App::Property* prop)
             Visibility.getValue() ? show() : hide();
             Visibility.setStatus(App::Property::User2, false);
         }
-        if(getObject() && getObject()->Visibility.getValue()!=Visibility.getValue())
+        if (!Visibility.testStatus(App::Property::User1)
+                && getObject() 
+                && getObject()->Visibility.getValue()!=Visibility.getValue())
+        {
             getObject()->Visibility.setValue(Visibility.getValue());
+        }
     }
     else if (prop == &SelectionStyle) {
         if(getRoot()->isOfType(SoFCSelectionRoot::getClassTypeId())) {
@@ -238,6 +242,9 @@ void ViewProviderDocumentObject::updateView()
         return;
 
     Base::ObjectStatusLocker<ViewStatus,ViewProviderDocumentObject> lock(ViewStatus::UpdatingView,this);
+
+    // Disable object visibility syncing
+    Base::ObjectStatusLocker<App::Property::Status,App::Property> lock2(App::Property::User1, &Visibility);
 
     std::map<std::string, App::Property*> Map;
     pcObject->getPropertyMap(Map);
@@ -298,8 +305,12 @@ void ViewProviderDocumentObject::update(const App::Property* prop)
     if(prop == &getObject()->Visibility) {
         if(!isRestoring() && Visibility.getValue()!=getObject()->Visibility.getValue())
             Visibility.setValue(!Visibility.getValue());
-    }else
+    } else {
+        // Disable object visibility syncing
+        Base::ObjectStatusLocker<App::Property::Status,App::Property>
+            guard(App::Property::User1, &Visibility);
         ViewProvider::update(prop);
+    }
 }
 
 Gui::Document* ViewProviderDocumentObject::getDocument() const

--- a/src/Gui/ViewProviderGroupExtension.cpp
+++ b/src/Gui/ViewProviderGroupExtension.cpp
@@ -145,7 +145,12 @@ void ViewProviderGroupExtension::extensionHide(void) {
 
     // when reading the Visibility property from file then do not hide the
     // objects of this group because they have stored their visibility status, too
-    if (!getExtendedViewProvider()->isRestoring()) {
+    //
+    // Property::User1 is used by ViewProviderDocumentObject to mark for
+    // temporary visibility changes. Do not propagate the change to children.
+    if (!getExtendedViewProvider()->isRestoring()
+            && !getExtendedViewProvider()->Visibility.testStatus(App::Property::User1)) 
+    {
         auto* group = getExtendedViewProvider()->getObject()->getExtensionByType<App::GroupExtension>();
         for(auto obj : group->Group.getValues()) {
             if(obj && obj->Visibility.getValue())


### PR DESCRIPTION
This commit avoids DocumentObject::Visiblity sync with ViewProviderDocumentObject::Visibility when the view provider is updated. It also serve as a temporary fix of the problem mentioned [here](https://forum.freecadweb.org/viewtopic.php?f=23&t=38779&start=10). 