### PR TITLE
[Arch] suggested feature: add the ability to choose if an Arch BuildingPart transmits its height value to children or not

### DIFF
--- a/src/Mod/Arch/ArchBuildingPart.py
+++ b/src/Mod/Arch/ArchBuildingPart.py
@@ -332,10 +332,11 @@ class BuildingPart(ArchIFC.IfcProduct):
         ArchIFC.IfcProduct.setProperties(self, obj)
 
         pl = obj.PropertiesList
-        if not "HeightPropagate" in pl:
-            obj.addProperty("App::PropertyBool","HeightPropagate","Children",QT_TRANSLATE_NOOP("App::Property","If true, the height value propagates to children objects"))
         if not "Height" in pl:
             obj.addProperty("App::PropertyLength","Height","BuildingPart",QT_TRANSLATE_NOOP("App::Property","The height of this object"))
+        if not "HeightPropagate" in pl:
+            obj.addProperty("App::PropertyBool","HeightPropagate","Children",QT_TRANSLATE_NOOP("App::Property","If true, the height value propagates to contained objects"))
+            obj.HeightPropagate = True
         if not "LevelOffset" in pl:
             obj.addProperty("App::PropertyLength","LevelOffset","BuildingPart",QT_TRANSLATE_NOOP("App::Property","The level of the (0,0,0) point of this level"))
         if not "Area" in pl:
@@ -465,11 +466,10 @@ class BuildingPart(ArchIFC.IfcProduct):
 
         for child in obj.Group:
             if Draft.getType(child) in ["Wall","Structure"]:
-                if obj.HeightPropagate:
-                    if not child.Height.Value:
-                        print("Executing ",child.Label)
-                        child.Proxy.execute(child)
-            elif Draft.getType(child) in ["Group"]:
+                if not child.Height.Value:
+                    print("Executing ",child.Label)
+                    child.Proxy.execute(child)
+            elif ((Draft.getType(child) in ["Group"]) or (Draft.getType(child) in ["BuildingPart"])):
                 self.touchChildren(child)
 
 

--- a/src/Mod/Arch/ArchBuildingPart.py
+++ b/src/Mod/Arch/ArchBuildingPart.py
@@ -469,7 +469,7 @@ class BuildingPart(ArchIFC.IfcProduct):
                 if not child.Height.Value:
                     print("Executing ",child.Label)
                     child.Proxy.execute(child)
-            elif ((Draft.getType(child) in ["Group"]) or (Draft.getType(child) in ["BuildingPart"])):
+            elif Draft.getType(child) in ["Group","BuildingPart"]:
                 self.touchChildren(child)
 
 

--- a/src/Mod/Arch/ArchBuildingPart.py
+++ b/src/Mod/Arch/ArchBuildingPart.py
@@ -332,6 +332,8 @@ class BuildingPart(ArchIFC.IfcProduct):
         ArchIFC.IfcProduct.setProperties(self, obj)
 
         pl = obj.PropertiesList
+        if not "HeightPropagate" in pl:
+            obj.addProperty("App::PropertyBool","HeightPropagate","Children",QT_TRANSLATE_NOOP("App::Property","If true, the height value propagates to children objects"))
         if not "Height" in pl:
             obj.addProperty("App::PropertyLength","Height","BuildingPart",QT_TRANSLATE_NOOP("App::Property","The height of this object"))
         if not "LevelOffset" in pl:
@@ -376,7 +378,7 @@ class BuildingPart(ArchIFC.IfcProduct):
             self.svgcache = None
             self.shapecache = None
 
-        if (prop == "Height") and obj.Height.Value:
+        if (prop == "Height" or prop == "HeightPropagate") and obj.Height.Value:
             self.touchChildren(obj)
 
         elif prop == "Placement":
@@ -463,9 +465,10 @@ class BuildingPart(ArchIFC.IfcProduct):
 
         for child in obj.Group:
             if Draft.getType(child) in ["Wall","Structure"]:
-                if not child.Height.Value:
-                    print("Executing ",child.Label)
-                    child.Proxy.execute(child)
+                if obj.HeightPropagate:
+                    if not child.Height.Value:
+                        print("Executing ",child.Label)
+                        child.Proxy.execute(child)
             elif Draft.getType(child) in ["Group"]:
                 self.touchChildren(child)
 

--- a/src/Mod/Arch/ArchComponent.py
+++ b/src/Mod/Arch/ArchComponent.py
@@ -276,8 +276,9 @@ class Component(ArchIFC.IfcProduct):
         for parent in obj.InList:
             if Draft.getType(parent) in ["Floor","BuildingPart"]:
                 if obj in parent.Group:
-                    if parent.Height.Value:
-                        return parent.Height.Value
+                    if parent.HeightPropagate:
+                        if parent.Height.Value:
+                            return parent.Height.Value
         # not found? get one level higher
         for parent in obj.InList:
             if hasattr(parent,"Group"):

--- a/src/Mod/Draft/DraftSelectPlane.py
+++ b/src/Mod/Draft/DraftSelectPlane.py
@@ -112,7 +112,7 @@ class Draft_SelectPlane:
         self.taskd.form.buttonPrevious.clicked.connect(self.onClickPrevious)
         self.taskd.form.fieldGridSpacing.textEdited.connect(self.onSetGridSize)
         self.taskd.form.fieldGridMainLine.valueChanged.connect(self.onSetMainline)
-        self.taskd.form.fieldSnapRadius.valueChanged.connect(self.onSetSnapRadius)        
+        self.taskd.form.fieldSnapRadius.valueChanged.connect(self.onSetSnapRadius)
 
         # try to find a WP from the current selection
         if self.handle():

--- a/src/Mod/Draft/DraftSelectPlane.py
+++ b/src/Mod/Draft/DraftSelectPlane.py
@@ -112,7 +112,7 @@ class Draft_SelectPlane:
         self.taskd.form.buttonPrevious.clicked.connect(self.onClickPrevious)
         self.taskd.form.fieldGridSpacing.textEdited.connect(self.onSetGridSize)
         self.taskd.form.fieldGridMainLine.valueChanged.connect(self.onSetMainline)
-        self.taskd.form.fieldSnapRadius.valueChanged.connect(self.onSetSnapRadius)
+        self.taskd.form.fieldSnapRadius.valueChanged.connect(self.onSetSnapRadius)        
 
         # try to find a WP from the current selection
         if self.handle():


### PR DESCRIPTION
Not sure if this can be useful and if it is the right approach to it, but I thougt that, as Arch Building Part is a generic arch container, it might be of help in certain conditions to be able to pull it off the hierarchical tree of height inheritance.


Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
