### PR TITLE
ScLERP placement interpolation

### DIFF
--- a/src/Base/CMakeLists.txt
+++ b/src/Base/CMakeLists.txt
@@ -238,6 +238,7 @@ SET(FreeCADBase_CPP_SRCS
     CoordinateSystem.cpp
     CoordinateSystemPyImp.cpp
     Debugger.cpp
+    DualQuaternion.cpp
     Exception.cpp
     ExceptionFactory.cpp
     Factory.cpp
@@ -306,6 +307,8 @@ SET(FreeCADBase_HPP_SRCS
     Converter.h
     CoordinateSystem.h
     Debugger.h
+    DualNumber.h
+    DualQuaternion.h
     Exception.h
     ExceptionFactory.h
     Factory.h

--- a/src/Base/DualNumber.h
+++ b/src/Base/DualNumber.h
@@ -1,0 +1,94 @@
+/***************************************************************************
+ *   Copyright (c) 2019 Viktor Titov (DeepSOIC) <vv.titov@gmail.com>       *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef FREECAD_BASE_DUAL_NUMBER_H
+#define FREECAD_BASE_DUAL_NUMBER_H
+
+#include <cmath>
+
+namespace Base {
+
+
+/**
+ * @brief Dual Numbers aer 2-part numbers like complex numbers, but different
+ * algebra. They are denoted as a + b*eps, where eps^2 = 0. eps, the nilpotent,
+ * is like imaginary unit of complex numbers. The neat utility of dual numbers
+ * is that if you use them instead of normal numbers in a function like sin(),
+ * derivative is implicitly calculated as a multiplier to the dual part.
+ */
+class DualNumber
+{
+public:
+    double re = 0.0;
+    double du = 0.0;
+public:
+    DualNumber(){}
+    DualNumber(double re, double du = 0.0)
+        : re(re), du(du)
+    {}
+    DualNumber operator-() const {return DualNumber(-re,-du);}
+};
+
+inline DualNumber operator+(DualNumber a, DualNumber b){
+    return DualNumber(a.re + b.re, a.du + b.du);
+}
+inline DualNumber operator+(DualNumber a, double b){
+    return DualNumber(a.re + b, a.du);
+}
+inline DualNumber operator+(double a, DualNumber b){
+    return DualNumber(a + b.re, b.du);
+}
+
+inline DualNumber operator-(DualNumber a, DualNumber b){
+    return DualNumber(a.re - b.re, a.du - b.du);
+}
+inline DualNumber operator-(DualNumber a, double b){
+    return DualNumber(a.re - b, a.du);
+}
+inline DualNumber operator-(double a, DualNumber b){
+    return DualNumber(a - b.re, -b.du);
+}
+
+inline DualNumber operator*(DualNumber a, DualNumber b){
+    return DualNumber(a.re * b.re, a.re * b.du + a.du * b.re);
+}
+inline DualNumber operator*(double a, DualNumber b){
+    return DualNumber(a * b.re, a * b.du);
+}
+inline DualNumber operator*(DualNumber a, double b){
+    return DualNumber(a.re * b, a.du * b);
+}
+
+inline DualNumber operator/(DualNumber a, DualNumber b){
+    return DualNumber(a.re / b.re, (a.du * b.re - a.re * b.du) / (b.re * b.re));
+}
+inline DualNumber operator/(DualNumber a, double b){
+    return DualNumber(a.re / b, a.du / b);
+}
+
+inline DualNumber pow(DualNumber a, double pw){
+    return Base::DualNumber(std::pow(a.re, pw), pw * std::pow(a.re, pw - 1.0) * a.du);
+}
+} //namespace
+
+
+#endif

--- a/src/Base/DualQuaternion.cpp
+++ b/src/Base/DualQuaternion.cpp
@@ -1,0 +1,166 @@
+/***************************************************************************
+ *   Copyright (c) 2019 Viktor Titov (DeepSOIC) <vv.titov@gmail.com>       *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "PreCompiled.h"
+
+#include "DualQuaternion.h"
+
+#include "cassert"
+
+Base::DualQuat Base::operator+(Base::DualQuat a, Base::DualQuat b)
+{
+    return DualQuat(
+                a.x + b.x,
+                a.y + b.y,
+                a.z + b.z,
+                a.w + b.w
+                );
+}
+
+Base::DualQuat Base::operator-(Base::DualQuat a, Base::DualQuat b)
+{
+    return DualQuat(
+                a.x - b.x,
+                a.y - b.y,
+                a.z - b.z,
+                a.w - b.w
+                );
+}
+
+Base::DualQuat Base::operator*(Base::DualQuat a, Base::DualQuat b)
+{
+    return DualQuat(
+                a.w * b.x + a.x * b.w + a.y * b.z - a.z * b.y,
+                a.w * b.y + a.y * b.w + a.z * b.x - a.x * b.z,
+                a.w * b.z + a.z * b.w + a.x * b.y - a.y * b.x,
+                a.w * b.w - a.x * b.x - a.y * b.y - a.z * b.z
+                );
+}
+
+Base::DualQuat Base::operator*(Base::DualQuat a, double b)
+{
+    return DualQuat(
+                a.x * b,
+                a.y * b,
+                a.z * b,
+                a.w * b
+                );
+}
+
+Base::DualQuat Base::operator*(double a, Base::DualQuat b)
+{
+    return DualQuat(
+                b.x * a,
+                b.y * a,
+                b.z * a,
+                b.w * a
+                );
+}
+
+Base::DualQuat Base::operator*(Base::DualQuat a, Base::DualNumber b)
+{
+    return DualQuat(
+                a.x * b,
+                a.y * b,
+                a.z * b,
+                a.w * b
+                );
+}
+
+Base::DualQuat Base::operator*(Base::DualNumber a, Base::DualQuat b)
+{
+    return DualQuat(
+                b.x * a,
+                b.y * a,
+                b.z * a,
+                b.w * a
+                );
+}
+
+Base::DualQuat::DualQuat(Base::DualQuat re, Base::DualQuat du)
+    : x(re.x.re, du.x.re),
+      y(re.y.re, du.y.re),
+      z(re.z.re, du.z.re),
+      w(re.w.re, du.w.re)
+{
+    assert(re.dual().length() < 1e-12);
+    assert(du.dual().length() < 1e-12);
+}
+
+double Base::DualQuat::dot(Base::DualQuat a, Base::DualQuat b)
+{
+    return  a.x.re * b.x.re +
+            a.y.re * b.y.re +
+            a.z.re * b.z.re +
+            a.w.re * b.w.re   ;
+}
+
+Base::DualQuat Base::DualQuat::pow(double t, bool shorten) const
+{
+    /* implemented after "Dual-Quaternions: From Classical Mechanics to
+     * Computer Graphics and Beyond" by Ben Kenwright www.xbdev.net
+     * bkenwright@xbdev.net
+     * http://www.xbdev.net/misc_demos/demos/dual_quaternions_beyond/paper.pdf
+     *
+     * There are some differences:
+     *
+     * * Special handling of no-rotation situation (because normalization
+     * multiplier becomes infinite in this situation, breaking the algorithm).
+     *
+     * * Dual quaternions are implemented as a collection of dual numbers,
+     * rather than a collection of two quaternions like it is done in suggested
+     * inplementation in the paper.
+     *
+     * * acos replaced with atan2 for improved angle accuracy for small angles
+     *
+     * */
+    double le = this->vec().length();
+    if (le < 1e-12) {
+        //special case of no rotation. Interpolate position
+        return DualQuat(this->real(), this->dual()*t);
+    }
+
+    double normmult = 1.0/le;
+
+    DualQuat self = *this;
+    if (shorten){
+        if (dot(self, identity()) < -1e-12){ //using negative tolerance instead of zero, for stability in situations the choice is ambiguous (180-degree rotations)
+            self = -self;
+        }
+    }
+
+    //to screw coordinates
+    double theta = self.theta();
+    double pitch = -2.0 * self.w.du * normmult;
+    DualQuat l = self.real().vec() * normmult; //abusing DualQuat to store vectors. Very handy in this case.
+    DualQuat m = (self.dual().vec() - pitch/2*cos(theta/2)*l)*normmult;
+
+    //interpolate
+    theta *= t;
+    pitch *= t;
+
+    //back to quaternion
+    return DualQuat(
+        l * sin(theta/2) + DualQuat(0,0,0,cos(theta/2)),
+        m * sin(theta/2) + pitch / 2 * cos(theta/2) * l + DualQuat(0,0,0,-pitch/2*sin(theta/2))
+    );
+}

--- a/src/Base/DualQuaternion.h
+++ b/src/Base/DualQuaternion.h
@@ -1,0 +1,108 @@
+/***************************************************************************
+ *   Copyright (c) 2019 Viktor Titov (DeepSOIC) <vv.titov@gmail.com>       *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef FREECAD_BASE_DUAL_QUATERNION_H
+#define FREECAD_BASE_DUAL_QUATERNION_H
+
+#include "DualNumber.h"
+//#include <Console.h> //DEBUG
+
+namespace Base {
+
+/**
+ * @brief The DualQuat class represents a dual quaternion, as a quaternion of
+ * dual number components. Dual quaternions are useful for placement
+ * interpolation, see pow method.
+ *
+ * Rotation is stored as non-dual part of DualQ. Translation is encoded into
+ * dual part of DualQuat:
+ * DualQuat.dual() = 0.5 * t * r,
+ * where t is quaternion with x,y,z of translation and w of 0, and r is the
+ * rotation quaternion.
+ */
+class BaseExport DualQuat {
+public:
+    DualNumber x;
+    DualNumber y;
+    DualNumber z;
+    DualNumber w;
+public:
+    ///default constructor: init with zeros
+    DualQuat(){}
+    DualQuat(DualNumber x, DualNumber y, DualNumber z, DualNumber w)
+        : x(x), y(y), z(z), w(w) {}
+    DualQuat(double x,double y,double z,double w,double dx,double dy,double dz,double dw)
+        : x(x, dx), y(y, dy), z(z, dz), w(w, dw) {}
+    DualQuat(double x,double y,double z,double w)
+        : x(x), y(y), z(z), w(w) {}
+
+    ///Builds a dual quaternion from real and dual parts provided as pure real quaternions
+    DualQuat(DualQuat re, DualQuat du);
+
+    ///returns dual quaternion for identity placement
+    static DualQuat identity() {return DualQuat(0.0, 0.0, 0.0, 1.0);}
+
+    ///return a copy with dual part zeroed out
+    DualQuat real() const {return DualQuat(x.re, y.re, z.re, w.re);}
+
+    ///return a real-only quaternion made from dual part of this quaternion.
+    DualQuat dual() const {return DualQuat(x.du, y.du, z.du, w.du);}
+
+    ///conjugate
+    DualQuat conj() const {return DualQuat(-x, -y, -z, w);}
+
+    ///return vector part (with scalar part zeroed out)
+    DualQuat vec() const {return DualQuat(x,y,z,0.0);}
+
+    ///magnitude of the quaternion
+    double length() const {return sqrt(x.re*x.re + y.re*y.re + z.re*z.re + w.re*w.re);}
+
+    ///angle of rotation represented by this quaternion, in radians
+    double theta() const {return 2.0 * atan2(vec().length(), w.re);}
+
+    ///dot product between real (rotation) parts of two dual quaternions (to determine if one of them should be negated for shortest interpolation)
+    static double dot(DualQuat a, DualQuat b);
+
+    ///ScLERP. t=0.0 returns identity, t=1.0 returns this. t can also be outside of 0..1 bounds.
+    DualQuat pow(double t, bool shorten = true) const;
+
+    DualQuat operator-() const {return DualQuat(-x, -y, -z, -w);}
+
+    //DEBUG
+    //void print() const {
+    //    Console().Log("%f, %f, %f, %f; %f, %f, %f, %f", x.re,y.re,z.re,w.re, x.du,y.du,z.du, w.du);
+    //}
+};
+
+DualQuat operator+(DualQuat a, DualQuat b);
+DualQuat operator-(DualQuat a, DualQuat b);
+DualQuat operator*(DualQuat a, DualQuat b);
+
+DualQuat operator*(DualQuat a, double b);
+DualQuat operator*(double a, DualQuat b);
+DualQuat operator*(DualQuat a, DualNumber b);
+DualQuat operator*(DualNumber a, DualQuat b);
+
+
+} //namespace
+
+#endif

--- a/src/Base/Placement.h
+++ b/src/Base/Placement.h
@@ -20,7 +20,6 @@
  *                                                                         *
  ***************************************************************************/
 
-
 #ifndef BASE_PLACEMENT_H
 #define BASE_PLACEMENT_H
 
@@ -29,9 +28,9 @@
 #include "Matrix.h"
 
 
-
 namespace Base {
 
+class DualQuat;
 
 /**
  * The Placement class.
@@ -45,11 +44,18 @@ public:
     Placement(const Base::Matrix4D& matrix);
     Placement(const Vector3d& Pos, const Rotation &Rot);
     Placement(const Vector3d& Pos, const Rotation &Rot, const Vector3d& Cnt);
+
+    /** specialty constructors */
+    //@{
+    static Placement fromDualQuaternion(DualQuat qq);
+    //@}
+
     /// Destruction
     ~Placement () {}
 
     Matrix4D toMatrix(void) const;
     void fromMatrix(const Matrix4D& m);
+    DualQuat toDualQuaternion() const;
     const Vector3d& getPosition(void) const {return _pos;}
     const Rotation& getRotation(void) const {return _rot;}
     void setPosition(const Vector3d& Pos){_pos=Pos;}
@@ -67,11 +73,13 @@ public:
     bool operator == (const Placement&) const;
     bool operator != (const Placement&) const;
     Placement& operator = (const Placement&);
+    Placement pow(double t, bool shorten = true) const;
 
     void multVec(const Vector3d & src, Vector3d & dst) const;
     //@}
 
     static Placement slerp(const Placement & p0, const Placement & p1, double t);
+    static Placement sclerp(const Placement & p0, const Placement & p1, double t, bool shorten = true);
 
 protected:
     Vector3<double> _pos;

--- a/src/Base/PlacementPy.xml
+++ b/src/Base/PlacementPy.xml
@@ -85,11 +85,32 @@ Placement(Base, Axis, Angle) -- define position and rotation
 				</UserDocu>
 			</Documentation>
 		</Methode>
-                <Methode Name="inverse" Const="true">
+        <Methode Name="inverse" Const="true">
 			<Documentation>
 				<UserDocu>
 					inverse() -> Placement
 					compute the inverse placement
+				</UserDocu>
+			</Documentation>
+		</Methode>
+        <Methode Name="pow" Const="true">
+			<Documentation>
+				<UserDocu>
+					pow(t, shorten = true): raise this placement to real power using ScLERP interpolation.
+                    If 'shorten' is true, ensures rotation quaternion is net positive, to make the path shorter.
+                    Also available as ** operator.
+				</UserDocu>
+			</Documentation>
+		</Methode>
+        <Methode Name="sclerp" Const="true">
+			<Documentation>
+				<UserDocu>
+					sclerp(t, placement2, shorten = True): interpolate between self and placement2.
+                    Interpolation is a continuous motion along a helical path, made of equal transforms if discretized.
+                    t = 0.0 - return self. t = 1.0 - return placement2. t can also be outside of 0..1 range, for extrapolation.
+                    If quaternions of rotations of the two placements differ in sign, the interpolation will 
+                     take a long path. If 'shorten' is true, the signs are harmonized before interpolation, and the 
+                     interpolation takes the shorter path.
 				</UserDocu>
 			</Documentation>
 		</Methode>

--- a/src/Base/PlacementPyImp.cpp
+++ b/src/Base/PlacementPyImp.cpp
@@ -229,6 +229,29 @@ PyObject* PlacementPy::inverse(PyObject * args)
     return new PlacementPy(new Placement(p));
 }
 
+PyObject* PlacementPy::pow(PyObject* args)
+{
+    double t;
+    PyObject* shorten = Py_True;
+    if (!PyArg_ParseTuple(args, "d|O!", &t, &(PyBool_Type), &shorten))
+        return nullptr;
+    Base::Placement ret = getPlacementPtr()->pow(t, PyObject_IsTrue(shorten));
+    return new PlacementPy(new Placement(ret));
+}
+
+
+PyObject* PlacementPy::sclerp(PyObject* args)
+{
+    PyObject* pyplm2;
+    double t;
+    PyObject* shorten = Py_True;
+    if (!PyArg_ParseTuple(args, "dO!|O!", &t, &(PlacementPy::Type), &pyplm2, &(PyBool_Type), &shorten))
+        return nullptr;
+    Base::Placement plm2 = static_cast<Base::PlacementPy*>(pyplm2)->value();
+    Base::Placement ret = Base::Placement::sclerp(*getPlacementPtr(), plm2, t, PyObject_IsTrue(shorten));
+    return new PlacementPy(new Placement(ret));
+}
+
 PyObject* PlacementPy::isIdentity(PyObject *args)
 {
     if (!PyArg_ParseTuple(args, ""))
@@ -342,34 +365,24 @@ PyObject* PlacementPy::number_multiply_handler(PyObject *self, PyObject *other)
 
 PyObject * PlacementPy::number_power_handler (PyObject* self, PyObject* other, PyObject* arg)
 {
-    if (!PyObject_TypeCheck(self, &(PlacementPy::Type)) ||
+    Py::Object pw(other);
+    Py::Tuple tup(1);
+    tup[0] = pw;
 
-#if PY_MAJOR_VERSION < 3
-            !PyInt_Check(other)
-#else
-            !PyLong_Check(other)
-#endif
-            || arg != Py_None
-       )
+    double pw_v;
+    if (!PyArg_ParseTuple(tup.ptr(), "d", &pw_v)){
+        //PyErr_SetString(PyExc_NotImplementedError, "Wrong exponent type (expect float).");
+        return nullptr;
+    }
+    if (!PyObject_TypeCheck(self, &(PlacementPy::Type))
+        || arg != Py_None)
     {
         PyErr_SetString(PyExc_NotImplementedError, "Not implemented");
         return 0;
     }
 
-    auto a = static_cast<PlacementPy*>(self)->value();
-
-    long b = Py::Int(other);
-    if(!b)
-        return new PlacementPy(Placement());
-
-    if(b < 0) {
-        b = -b;
-        a.invert();
-    }
-    auto res = a;
-    for(--b;b;--b)
-        res *= a;
-    return new PlacementPy(res);
+    Placement a = static_cast<PlacementPy*>(self)->value();
+    return new PlacementPy(a.pow(pw_v));
 }
 
 PyObject* PlacementPy::number_add_handler(PyObject * /*self*/, PyObject * /*other*/)

--- a/src/Mod/Spreadsheet/TestSpreadsheet.py
+++ b/src/Mod/Spreadsheet/TestSpreadsheet.py
@@ -835,6 +835,13 @@ class SpreadsheetCases(unittest.TestCase):
 
     def testMatrix(self):
         ''' Test Matrix/Vector/Placement/Rotation operations'''
+        
+        def plm_equal(plm1, plm2):
+            from math import sqrt
+            qpair = zip(plm1.Rotation.Q, plm2.Rotation.Q)
+            qdiff1 = sqrt(sum([(v1 - v2)**2 for v1,v2 in qpair]))
+            qdiff2 = sqrt(sum([(v1 + v2)**2 for v1,v2 in qpair]))
+            return (plm1.Base-plm2.Base).Length < 1e-7 and (qdiff1 < 1e-12 or dqiff2 < 1e-12)
 
         sheet = self.doc.addObject('Spreadsheet::Sheet','Spreadsheet')
 
@@ -937,16 +944,16 @@ class SpreadsheetCases(unittest.TestCase):
 
         self.assertEqual(sheet.A4,pla)
 
-        self.assertEqual(sheet.B4,ipla*ipla)
-        self.assertEqual(sheet.B4,pla**-2)
-        self.assertEqual(sheet.C4,ipla)
-        self.assertEqual(sheet.C4,pla**-1)
-        self.assertEqual(sheet.D4,FreeCAD.Placement())
-        self.assertEqual(sheet.D4,pla**0)
-        self.assertEqual(sheet.E4,pla)
-        self.assertEqual(sheet.E4,pla**1)
-        self.assertEqual(sheet.F4,pla*pla)
-        self.assertEqual(sheet.F4,pla**2)
+        self.assertTrue(plm_equal(sheet.B4,ipla*ipla))
+        self.assertTrue(plm_equal(sheet.B4,pla**-2))
+        self.assertTrue(plm_equal(sheet.C4,ipla))
+        self.assertTrue(plm_equal(sheet.C4,pla**-1))
+        self.assertTrue(plm_equal(sheet.D4,FreeCAD.Placement()))
+        self.assertTrue(plm_equal(sheet.D4,pla**0))
+        self.assertTrue(plm_equal(sheet.E4,pla))
+        self.assertTrue(plm_equal(sheet.E4,pla**1))
+        self.assertTrue(plm_equal(sheet.F4,pla*pla))
+        self.assertTrue(plm_equal(sheet.F4,pla**2))
 
         tol = 1e-10
 


### PR DESCRIPTION
Features
* support for raising placements to a real-value power (not just integer):
** as pow method
** as ** operator in python
** as ^ operator in expressions (automatic, from above)
* .sclerp method to interpolate between two placements

internal:
* DualNumber class (potentially useful for sketcher too)
* DualQuat class (generic dual quaternion math + sclerp implementation)
* Placement::fromDualQuaternion and ::toDualQuaternion for interfacing with DualQuat

Test coverage: exponentiation is more-or-less covered in TestSpreadsheet. The tests cover negative and positive integer powers via sclerp, and python implementation of ** operator. So the chance of breaking sclerp implementation without disrupting tests is pretty low. Let me know if more tests are necessary.

Demonstration feature for sclerp method is available in Lattice2, see discussion. 
Discussion: https://forum.freecadweb.org/viewtopic.php?f=17&t=40012

![sclerp-demo-extrapolate](https://user-images.githubusercontent.com/8940427/66701658-446c1a00-ed07-11e9-986b-7482ef8b7501.png)

