### PR TITLE
[Draft] ShapeString Task Panel Allow Windows...

### DIFF
--- a/src/Mod/Draft/DraftGui.py
+++ b/src/Mod/Draft/DraftGui.py
@@ -39,7 +39,7 @@ Report to Draft.py for info
 """
 
 import six
-
+import platform
 import FreeCAD, FreeCADGui, os, Draft, sys, traceback, DraftVecUtils, math
 
 try:
@@ -2459,6 +2459,7 @@ class ShapeStringTaskPanel:
 
         self.stringText = translate("draft","Default")
         self.task.leString.setText(self.stringText)
+        self.platWinDialog(1)
         self.task.fcFontFile.setFileName(Draft.getParam("FontFile",""))
         self.fileSpec = Draft.getParam("FontFile","")
         self.point = FreeCAD.Vector(0.0,0.0,0.0)
@@ -2530,12 +2531,21 @@ class ShapeStringTaskPanel:
         except Exception as e:
             FreeCAD.Console.PrintError("Draft_ShapeString: error delaying commit\n")
 
+    def platWinDialog(self, OnOff):
+        tDialog = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Dialog")
+        if platform.system() == 'Windows':
+            if OnOff == 1:
+                return tDialog.SetBool("DontUseNativeDialog", True)
+            else:
+                return tDialog.SetBool("DontUseNativeDialog", False)
+
     def accept(self):
         self.createObject();
         if self.call: self.view.removeEventCallback("SoEvent",self.call)
         FreeCADGui.ActiveDocument.resetEdit()
         FreeCADGui.Snapper.off()
         self.sourceCmd.creator.finish(self.sourceCmd)
+        self.platWinDialog(0)
         return True
 
     def reject(self):
@@ -2543,6 +2553,7 @@ class ShapeStringTaskPanel:
         FreeCADGui.ActiveDocument.resetEdit()
         FreeCADGui.Snapper.off()
         self.sourceCmd.creator.finish(self.sourceCmd)
+        self.platWinDialog(0)
         return True
 
 if not hasattr(FreeCADGui,"draftToolBar"):


### PR DESCRIPTION
....Users to view Font Files without the need to modify permissions on the Fonts folder. Also keeping the rest of FreeCAD file dialog boxes as standard.

Discussion : https://forum.freecadweb.org/viewtopic.php?f=23&t=38305

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
