### PR TITLE
Draft: DraftGui, use boolean values to set up an option instead of numeric values 1 and 0

### DIFF
--- a/src/Mod/Draft/DraftGui.py
+++ b/src/Mod/Draft/DraftGui.py
@@ -2459,7 +2459,7 @@ class ShapeStringTaskPanel:
 
         self.stringText = translate("draft","Default")
         self.task.leString.setText(self.stringText)
-        self.platWinDialog(1)
+        self.platWinDialog(True)
         self.task.fcFontFile.setFileName(Draft.getParam("FontFile",""))
         self.fileSpec = Draft.getParam("FontFile","")
         self.point = FreeCAD.Vector(0.0,0.0,0.0)
@@ -2534,7 +2534,7 @@ class ShapeStringTaskPanel:
     def platWinDialog(self, OnOff):
         tDialog = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Dialog")
         if platform.system() == 'Windows':
-            if OnOff == 1:
+            if OnOff:
                 return tDialog.SetBool("DontUseNativeDialog", True)
             else:
                 return tDialog.SetBool("DontUseNativeDialog", False)
@@ -2545,7 +2545,7 @@ class ShapeStringTaskPanel:
         FreeCADGui.ActiveDocument.resetEdit()
         FreeCADGui.Snapper.off()
         self.sourceCmd.creator.finish(self.sourceCmd)
-        self.platWinDialog(0)
+        self.platWinDialog(False)
         return True
 
     def reject(self):
@@ -2553,7 +2553,7 @@ class ShapeStringTaskPanel:
         FreeCADGui.ActiveDocument.resetEdit()
         FreeCADGui.Snapper.off()
         self.sourceCmd.creator.finish(self.sourceCmd)
-        self.platWinDialog(0)
+        self.platWinDialog(False)
         return True
 
 if not hasattr(FreeCADGui,"draftToolBar"):


### PR DESCRIPTION
Following pull request #2610, I think it's better to use explicit boolean values True and False, instead of numeric values 1 and 0. With boolean values it is clear that the function only has two states.

---

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists
