### PR TITLE
[Arch] suggested feature: add the ability to choose whether an Arch BuildingPart transmits its height value to children

### DIFF
--- a/src/Mod/Arch/ArchBuildingPart.py
+++ b/src/Mod/Arch/ArchBuildingPart.py
@@ -334,6 +334,9 @@ class BuildingPart(ArchIFC.IfcProduct):
         pl = obj.PropertiesList
         if not "Height" in pl:
             obj.addProperty("App::PropertyLength","Height","BuildingPart",QT_TRANSLATE_NOOP("App::Property","The height of this object"))
+        if not "HeightPropagate" in pl:
+            obj.addProperty("App::PropertyBool","HeightPropagate","Children",QT_TRANSLATE_NOOP("App::Property","If true, the height value propagates to contained objects"))
+            obj.HeightPropagate = True
         if not "LevelOffset" in pl:
             obj.addProperty("App::PropertyLength","LevelOffset","BuildingPart",QT_TRANSLATE_NOOP("App::Property","The level of the (0,0,0) point of this level"))
         if not "Area" in pl:
@@ -376,7 +379,7 @@ class BuildingPart(ArchIFC.IfcProduct):
             self.svgcache = None
             self.shapecache = None
 
-        if (prop == "Height") and obj.Height.Value:
+        if (prop == "Height" or prop == "HeightPropagate") and obj.Height.Value:
             self.touchChildren(obj)
 
         elif prop == "Placement":
@@ -466,7 +469,7 @@ class BuildingPart(ArchIFC.IfcProduct):
                 if not child.Height.Value:
                     print("Executing ",child.Label)
                     child.Proxy.execute(child)
-            elif Draft.getType(child) in ["Group"]:
+            elif Draft.getType(child) in ["Group","BuildingPart"]:
                 self.touchChildren(child)
 
 

--- a/src/Mod/Arch/ArchComponent.py
+++ b/src/Mod/Arch/ArchComponent.py
@@ -276,8 +276,9 @@ class Component(ArchIFC.IfcProduct):
         for parent in obj.InList:
             if Draft.getType(parent) in ["Floor","BuildingPart"]:
                 if obj in parent.Group:
-                    if parent.Height.Value:
-                        return parent.Height.Value
+                    if parent.HeightPropagate:
+                        if parent.Height.Value:
+                            return parent.Height.Value
         # not found? get one level higher
         for parent in obj.InList:
             if hasattr(parent,"Group"):


### PR DESCRIPTION
I thougt that, as Arch Building Part is a generic arch container, it might be of help in certain conditions to be able to pull it off the hierarchical tree of height inheritance.

[see this forum thread for discussion](https://forum.freecadweb.org/viewtopic.php?f=23&t=39302&start=10)

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
