### PR TITLE
[TD]Fix slow GC of QGIPrimPath (v0.18 backport)

### DIFF
--- a/src/Mod/TechDraw/Gui/QGIViewPart.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewPart.cpp
@@ -547,7 +547,8 @@ void QGIViewPart::removePrimitives()
     for (auto& c:children) {
          QGIPrimPath* prim = dynamic_cast<QGIPrimPath*>(c);
          if (prim) {
-            removeFromGroup(prim);
+            prim->hide();
+//            removeFromGroup(prim);
             scene()->removeItem(prim);
             delete prim;
          }
@@ -565,11 +566,13 @@ void QGIViewPart::removeDecorations()
          QGIDecoration* decor = dynamic_cast<QGIDecoration*>(c);
          QGIMatting* mat = dynamic_cast<QGIMatting*>(c);
          if (decor) {
-            removeFromGroup(decor);
+            decor->hide();
+//            removeFromGroup(decor);
             scene()->removeItem(decor);
             delete decor;
          } else if (mat) {
-            removeFromGroup(mat);
+            mat->hide();
+//            removeFromGroup(mat);
             scene()->removeItem(mat);
             delete mat;
          }


### PR DESCRIPTION
In some cases the collection and deletion of old graphics primitives can slow TechDraw (and the rest of FC) significantly.   This change speeds up the garbage collection process significantly for models with large primitive counts. 

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
