### PR TITLE
AddonManager: Consolidate preference in user.cfg from Plugins to  Addons

### DIFF
--- a/src/Mod/AddonManager/AddonManager.py
+++ b/src/Mod/AddonManager/AddonManager.py
@@ -72,8 +72,10 @@ class CommandAddonManager:
     def Activated(self):
 
         # display first use dialog if needed
-        readWarning = FreeCAD.ParamGet("User parameter:Plugins/addonsRepository").GetBool("readWarning",
-                                                                                          False)
+        readWarningParameter = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Addons")
+        readWarning = readWarningParameter.GetBool("readWarning", False)
+        newReadWarningParameter = FreeCAD.ParamGet("User parameter:Plugins/addonsRepository")
+        readWarning |= newReadWarningParameter.GetBool("readWarning", False)
         if not readWarning:
             if (QtGui.QMessageBox.warning(None,
                                           "FreeCAD",
@@ -85,8 +87,7 @@ class CommandAddonManager:
                                           QtGui.QMessageBox.Cancel |
                                           QtGui.QMessageBox.Ok) !=
                     QtGui.QMessageBox.StandardButton.Cancel):
-                FreeCAD.ParamGet("User parameter:Plugins/addonsRepository").SetBool("readWarning",
-                                                                                    True)
+                readWarningParameter.SetBool("readWarning", True)
                 readWarning = True
 
         if readWarning:


### PR DESCRIPTION
Currently when a user first uses the Addon Manager a dialog popup prompts them about how FC is not liable for the code plugin authors provide. It stores the binary response in a `readWarning` boolean  within the user.cfg file.  

This commit changes the location of said boolean from `User parameter:Plugins` to `User parameter:Addons`

In other words changing:  
```
    <FCParamGroup Name="Plugins">
      <FCParamGroup Name="addonsRepository">
        <FCBool Name="readWarning" Value="1"/>
      </FCParamGroup>
    </FCParamGroup>
``` 
to:   

```
        <FCParamGroup Name="Addons">
          <FCParamGroup Name="addonsRepository">
            <FCBool Name="readWarning" Value="1"/>
          </FCParamGroup>
        </FCParamGroup>
```

Edit: in other words, it makes sense to me to consolidate Addon related preferences all in once place. This PR the first step to doing that.