### PR TITLE
several Win installer fixes and improvements

### DIFF
--- a/src/WindowsInstaller/README.md
+++ b/src/WindowsInstaller/README.md
@@ -20,14 +20,14 @@ To build the installer you can do the following:
    (You can alternatively get nsProcess from https://nsis.sourceforge.io/NsProcess_plugin)
 7. Copy all FreeCAD files to the folder "~\FreeCAD"
    e.g. "C:\FreeCAD\Installer\FreeCAD"
-8. If you use compiled FreeCAD using another MSVC version than MSVC 2015, copy
+8. If you use compiled FreeCAD using another MSVC version than MSVC 2017, copy
    its distributable DLLs to the folder FILES_DEPS (see step 2).
 9. Right-click on the file FreeCAD-installer.nsi and choose "Compile NSIS script"
    to compile the installer
-10. The folder ~\MSVCRedist contains already all MSVC 2015 redistributable DLLs necessary
-   for FreeCAD. If another MSVC version was used to compile FreeCAD, replace the DLLs by
+10. The folder ~\MSVCRedist contains already all MSVC 2017 x64 redistributable DLLs necessary
+   for FreeCAD 0.19dev. If another MSVC version was used to compile FreeCAD, replace the DLLs by
    the ones of the used MSVC. (They are usually available in the folder
-   C:\Program Files (x86)\MSVC2xxx\VC\redist)
+   C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Redist\MSVC)
 
 For test builds of the installer you can turn off the compression. This speeds up
 the build time for the installer a lot but increases its file size. The compression

--- a/src/WindowsInstaller/Settings.nsh
+++ b/src/WindowsInstaller/Settings.nsh
@@ -16,11 +16,12 @@ SetCompressor /SOLID lzma
 # Version number
 
 !define APP_VERSION_MAJOR 0
-!define APP_VERSION_MINOR 18
+!define APP_VERSION_MINOR 19
 !define APP_VERSION_REVISION 0
-!define APP_VERSION_EMERGENCY "" # use "1" for an emergency release of FreeCAD otherwise ""
+!define APP_VERSION_EMERGENCY "rev18542" # use "1" for an emergency release of FreeCAD otherwise ""
+	# alternatively you can use APP_VERSION_EMERGENCY for a custom suffix of the version number
 !define APP_EMERGENCY_DOT "" # use "." for an emergency release of FreeCAD otherwise ""
-!define APP_VERSION_BUILD 10 # Start with 1 for the installer releases of each version
+!define APP_VERSION_BUILD 1 # Start with 1 for the installer releases of each version
 
 !define APP_VERSION "${APP_VERSION_MAJOR}.${APP_VERSION_MINOR}.${APP_VERSION_REVISION}${APP_EMERGENCY_DOT}${APP_VERSION_EMERGENCY}" # Version to display
 

--- a/src/WindowsInstaller/include/declarations.nsh
+++ b/src/WindowsInstaller/include/declarations.nsh
@@ -1,4 +1,4 @@
-/*
+﻿/*
 declaration.nsh
 
 Configuration and variables of FreeCAD installer
@@ -32,8 +32,8 @@ Configuration and variables of FreeCAD installer
 !define APP_WIKI_INFO "${APP_NAME} Wiki"
 !define APP_COPYRIGHT "${APP_NAME} is Copyright © 2001-${COPYRIGHT_YEAR} by the ${APP_NAME} Team"
 
-!define APP_RUN "bin\FreeCAD.exe"
-!define BIN_FREECAD "FreeCAD.exe"
+!define APP_RUN "bin\${APP_NAME}.exe"
+!define BIN_FREECAD "${APP_NAME}.exe"
 
 !define APP_REGKEY "Software\${APP_NAME}${APP_SERIES_KEY}" # like "FreeCAD0180"
 !define APP_REGKEY_SETUP "${APP_REGKEY}\Setup"

--- a/src/WindowsInstaller/include/init.nsh
+++ b/src/WindowsInstaller/include/init.nsh
@@ -130,7 +130,10 @@ Function .onInit
    ${endif} 
   ${next}
   
-  ${if} $OldVersionNumber > ${APP_SERIES_KEY}
+  # NSIS cannot handle numbers with leading zero, thus cut it off before comparing
+  StrCpy $1 $OldVersionNumber "" 1
+  StrCpy $2 ${APP_SERIES_KEY} "" 1
+  ${if} $1 > $2
    # store the version number and reformat it temporarily for the error message
    StrCpy $R0 $OldVersionNumber
    StrCpy $OldVersionNumber $R5

--- a/src/WindowsInstaller/setup/configure.nsh
+++ b/src/WindowsInstaller/setup/configure.nsh
@@ -43,7 +43,7 @@ Section -InstallData
   
   WriteRegStr SHCTX ${APP_UNINST_KEY} "UninstallString" '"$INSTDIR\${SETUP_UNINSTALLER}"'
   WriteRegStr SHCTX ${APP_UNINST_KEY} "DisplayVersion" "${APP_VERSION}"
-  WriteRegStr SHCTX ${APP_UNINST_KEY} "DisplayIcon" "$INSTDIR\bin\FreeCAD.exe"
+  WriteRegStr SHCTX ${APP_UNINST_KEY} "DisplayIcon" "$INSTDIR\bin\${APP_NAME}.exe"
   WriteRegStr SHCTX ${APP_UNINST_KEY} "URLUpdateInfo" "${APP_WEBPAGE}"
   WriteRegStr SHCTX ${APP_UNINST_KEY} "URLInfoAbout" "https://www.freecadweb.org/"
   WriteRegStr SHCTX ${APP_UNINST_KEY} "Publisher" "${APP_NAME} Team"
@@ -53,10 +53,15 @@ Section -InstallData
   WriteRegStr SHCTX ${APP_UNINST_KEY} "StartMenu" "$SMPROGRAMS\$StartmenuFolder"
   
   # if we install over an older existing version, remove the old uninstaller information
-  ${if} $OldVersionNumber < ${APP_SERIES_KEY}
+  # NSIS cannot handle numbers with leading zero, thus cut it off before comparing
+  StrCpy $1 $OldVersionNumber "" 1
+  StrCpy $2 ${APP_SERIES_KEY} "" 1
+  ${if} $1 < $2
    DeleteRegKey SHCTX "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APP_NAME}$OldVersionNumber"
+   DeleteRegKey SHCTX "SOFTWARE\${APP_NAME}$OldVersionNumber"
    # also delete in the case of an emergency release
    DeleteRegKey SHCTX "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APP_NAME}$OldVersionNumber1"
+   DeleteRegKey SHCTX "SOFTWARE\${APP_NAME}$OldVersionNumber1"
   ${endif}
   
 SectionEnd

--- a/src/WindowsInstaller/setup/install.nsh
+++ b/src/WindowsInstaller/setup/install.nsh
@@ -15,7 +15,7 @@ Section -ProgramFiles SecProgramFiles
   # be installed directly to C:\programs - the uninstaller will then delete the whole
   # C:\programs directory
   StrCpy $String $INSTDIR
-  StrCpy $Search "FreeCAD"
+  StrCpy $Search ${APP_NAME}
   Call StrPoint # function from Utils.nsh
   ${if} $Pointer == "-1"
    StrCpy $INSTDIR "$INSTDIR\${APP_DIR}"
@@ -43,6 +43,7 @@ Section -ProgramFiles SecProgramFiles
   File /r "${FILES_FREECAD}\Ext"
   File /r "${FILES_FREECAD}\lib"
   File /r "${FILES_FREECAD}\Mod"
+  File /r "${FILES_FREECAD}\resources"
     
   # Create uninstaller
   WriteUninstaller "$INSTDIR\${SETUP_UNINSTALLER}"


### PR DESCRIPTION
- fix bug that registry uninstaller settings of the previous version are not replaced when installing new version of the same series

- avoid explicit calls of the name "FreeCAD"

- update example code and description to MSVC 2017 and FreeCAD 0.19git