### PR TITLE
Path: Added support for copying holding tags from another holding tags dressup

### DIFF
--- a/src/Mod/Path/Gui/Resources/panels/HoldingTagsEdit.ui
+++ b/src/Mod/Path/Gui/Resources/panels/HoldingTagsEdit.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>399</width>
-    <height>582</height>
+    <width>289</width>
+    <height>466</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -17,6 +17,12 @@
    <item row="2" column="0">
     <widget class="QWidget" name="removeEditAddGroup" native="true">
      <layout class="QGridLayout" name="gridLayout">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
       <item row="1" column="2">
        <widget class="QPushButton" name="pbAdd">
         <property name="text">
@@ -42,42 +48,6 @@
         <property name="text">
          <string>Edit...</string>
         </property>
-       </widget>
-      </item>
-      <item row="2" column="0" colspan="3">
-       <widget class="QGroupBox" name="cbTagGeneration">
-        <property name="title">
-         <string>Auto Generate</string>
-        </property>
-        <layout class="QGridLayout" name="gridLayout_3">
-         <item row="1" column="1">
-          <widget class="QSpinBox" name="sbCount">
-           <property name="minimum">
-            <number>2</number>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="1">
-          <widget class="QPushButton" name="pbGenerate">
-           <property name="enabled">
-            <bool>false</bool>
-           </property>
-           <property name="text">
-            <string>Replace All</string>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="0">
-          <widget class="QLabel" name="label">
-           <property name="text">
-            <string>Number of Tags</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-          </widget>
-         </item>
-        </layout>
        </widget>
       </item>
      </layout>
@@ -161,6 +131,54 @@
        <widget class="Gui::InputField" name="ifRadius">
         <property name="toolTip">
          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Radius of the fillet at the top.&lt;/p&gt;&lt;p&gt;If the radius is too big for the tag shape it gets reduced to the maximum possible radius - resulting in a spherical shape.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="4" column="0">
+    <widget class="QGroupBox" name="gbCopy">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="title">
+      <string>Copy From</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_4">
+      <item row="0" column="0">
+       <widget class="QComboBox" name="cbSource"/>
+      </item>
+      <item row="0" column="1">
+       <widget class="QPushButton" name="pbCopy">
+        <property name="text">
+         <string>Replace All</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="QGroupBox" name="cbTagGeneration">
+     <property name="title">
+      <string>Auto Generate</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_3">
+      <item row="1" column="0">
+       <widget class="QSpinBox" name="sbCount">
+        <property name="minimum">
+         <number>2</number>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QPushButton" name="pbGenerate">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="text">
+         <string>Replace All</string>
         </property>
        </widget>
       </item>

--- a/src/Mod/Path/PathScripts/PathDressupTagGui.py
+++ b/src/Mod/Path/PathScripts/PathDressupTagGui.py
@@ -191,6 +191,18 @@ class PathDressupTagTaskPanel:
         self.Disabled = self.obj.Disabled
         self.updateTagsView()
 
+    def copyNewTags(self):
+        sel = self.form.cbSource.currentText()
+        tags = [o for o in FreeCAD.ActiveDocument.Objects if sel == o.Label]
+        if 1 == len(tags):
+            if not self.obj.Proxy.copyTags(self.obj, tags[0]):
+                self.obj.Proxy.execute(self.obj)
+            self.Positions = self.obj.Positions
+            self.Disabled = self.obj.Disabled
+            self.updateTagsView()
+        else:
+            PathLog.error(translate('Path_DressupTag', 'Cannot copy tags - internal error')+'\n')
+
     def updateModel(self):
         self.getFields()
         self.updateTagsView()
@@ -278,6 +290,15 @@ class PathDressupTagTaskPanel:
             self.form.pbGenerate.clicked.connect(self.generateNewTags)
         else:
             self.form.cbTagGeneration.setEnabled(False)
+
+        enableCopy = False
+        for tags in sorted([o.Label for o in FreeCAD.ActiveDocument.Objects if 'DressupTag' in o.Name]):
+            if tags != self.obj.Label:
+                enableCopy = True
+                self.form.cbSource.addItem(tags)
+        if enableCopy:
+            self.form.gbCopy.setEnabled(True)
+            self.form.pbCopy.clicked.connect(self.copyNewTags)
 
         self.form.lwTags.itemChanged.connect(self.whenTagsViewChanged)
         self.form.lwTags.itemSelectionChanged.connect(self.whenTagSelectionChanged)


### PR DESCRIPTION
If the user wants to create a roughing profile and then a cleanup pass they can now copy the holding tags so they match between the two operations.