### PR TITLE
Update swigpyrun.in for Python 3.8

### DIFF
--- a/src/Base/swigpyrun.inl
+++ b/src/Base/swigpyrun.inl
@@ -72,7 +72,7 @@ void cleanupSWIG_T(const char* TypeName)
 
     PyObject *module, *dict;
     PyInterpreterState *interp = PyThreadState_GET()->interp;
-    PyObject *modules = interp->modules;
+    PyObject *modules = PyImport_GetModuleDict();
     module = PyDict_GetItemString(modules, "__builtin__");
     if (module != NULL && PyModule_Check(module)) {
         dict = PyModule_GetDict(module);


### PR DESCRIPTION
In Python 3.8 some functions related to thread state were intentionally made private.

This fix (specific to FreeCAD) was suggested here:

https://bugs.python.org/issue35886

Fixes issue #4143.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [X] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
