### PR TITLE
Fix -Wdeprecated-copy warnings (rule of 5/3/0)

### DIFF
--- a/src/3rdParty/salomesmesh/src/StdMeshers/StdMeshers_CompositeHexa_3D.cpp
+++ b/src/3rdParty/salomesmesh/src/StdMeshers/StdMeshers_CompositeHexa_3D.cpp
@@ -100,6 +100,9 @@ class _FaceSide
 {
 public:
   _FaceSide(const _FaceSide& other);
+  _FaceSide& operator=(const _FaceSide& other);
+  _FaceSide(_FaceSide&&) = default;
+  _FaceSide& operator=(_FaceSide&&) = default;
   _FaceSide(const TopoDS_Edge& edge=TopoDS_Edge());
   _FaceSide(const list<TopoDS_Edge>& edges);
   _FaceSide* GetSide(const int i);
@@ -1566,6 +1569,28 @@ _FaceSide::_FaceSide(const _FaceSide& other)
   myVertices.Assign( other.myVertices );
   myID = other.myID;
 }
+
+
+//=======================================================================
+//function : _FaceSide
+//purpose  : copy assignment
+//=======================================================================
+_FaceSide& _FaceSide::operator=(const _FaceSide& other)
+{
+  if (this == &other) return *this;
+
+  // Use copy-and-swap idiom to ensure exception safety
+  _FaceSide tmp(other);
+
+  std::swap(myEdge, tmp.myEdge);
+  std::swap(myChildren, tmp.myChildren);
+  std::swap(myNbChildren, tmp.myNbChildren);
+  std::swap(myVertices, tmp.myVertices);
+  std::swap(myID, tmp.myID);
+
+  return *this;
+}
+
 
 //================================================================================
 /*!

--- a/src/Base/TimeInfo.h
+++ b/src/Base/TimeInfo.h
@@ -66,7 +66,7 @@ public:
     uint64_t getSeconds(void) const; 
     unsigned short  getMiliseconds(void) const; 
 
-    void operator =  (const TimeInfo &time); 
+    //void operator =  (const TimeInfo &time); 
     bool operator == (const TimeInfo &time) const;
     bool operator != (const TimeInfo &time) const;
 
@@ -106,11 +106,11 @@ TimeInfo::operator != (const TimeInfo &time) const
     return (timebuffer.time != time.timebuffer.time || timebuffer.millitm != time.timebuffer.millitm);
 }
 
-inline void
-TimeInfo::operator = (const TimeInfo &time) 
-{
-    timebuffer = time.timebuffer;
-}
+//inline void
+//TimeInfo::operator = (const TimeInfo &time) 
+//{
+    //timebuffer = time.timebuffer;
+//}
 
 inline bool
 TimeInfo::operator == (const TimeInfo &time) const

--- a/src/Mod/Path/libarea/clipper.cpp
+++ b/src/Mod/Path/libarea/clipper.cpp
@@ -257,7 +257,7 @@ class Int128
     }
 
 
-    Int128(const Int128 &val): lo(val.lo), hi(val.hi){}
+    //Int128(const Int128 &val): lo(val.lo), hi(val.hi){}
 
     Int128(const long64& _hi, const ulong64& _lo): lo(_lo), hi(_hi){}
     

--- a/src/Mod/Path/libarea/kurve/Matrix.cpp
+++ b/src/Mod/Path/libarea/kurve/Matrix.cpp
@@ -29,10 +29,10 @@ namespace geoff_geometry {
 		this->IsMirrored();
 	}
 
-	Matrix::Matrix( const Matrix& m)
-	{
-		*this = m;
-	}
+	//Matrix::Matrix( const Matrix& m)
+	//{
+		//*this = m;
+	//}
 
 	bool Matrix::operator==(const Matrix &m)const{
 		// m1 == m2

--- a/src/Mod/Path/libarea/kurve/geometry.h
+++ b/src/Mod/Path/libarea/kurve/geometry.h
@@ -158,7 +158,7 @@ inline bool FNEZ(double a, double tolerance = TIGHT_TOLERANCE) {return fabs(a) >
 		// constructors etc...
 		Matrix();													// create a unit matrix
 		Matrix(double m[16]);										// from an array
-		Matrix(const Matrix& m);									// copy constructor
+		//Matrix(const Matrix& m);									// copy constructor
 
 		~Matrix(){};
 
@@ -213,9 +213,11 @@ inline bool FNEZ(double a, double tolerance = TIGHT_TOLERANCE) {return fabs(a) >
 		inline	Point(){x=0; y=0; ok=false;}																// Point p1
 		inline	Point( double xord, double yord, bool okay = true) {					// Point p1(10,30);
 			x = xord; y = yord; ok = okay;}
-		inline	Point( const Point& p ) {												// copy constructor  Point p1(p2);
-			x = p.x; y = p.y; ok = p.ok;}
-				Point( const Point3d& p );												// copy constructor  Point p1(p2);
+
+		//inline	Point( const Point& p ) {												// copy constructor  Point p1(p2);
+			//x = p.x; y = p.y; ok = p.ok;}
+
+		Point( const Point3d& p );												// copy constructor  Point p1(p2);
 		Point(const Vector2d& v);
 
 		// operators
@@ -257,8 +259,8 @@ inline bool FNEZ(double a, double tolerance = TIGHT_TOLERANCE) {return fabs(a) >
 		inline	Point3d(const double* xyz) {x = xyz[0], y = xyz[1]; z = xyz[2];}
 		inline	Point3d( double xord, double yord, double zord = 0/*, bool okay = true*/) {	// Point p1(10,30.5);
 			x = xord; y = yord; z = zord;/* ok = okay;*/}
-		inline	Point3d( const Point3d& p ) {											// copy constructor  Point p1(p2);
-			x = p.x; y = p.y;  z = p.z;/* ok = p.ok;*/}
+		//inline	Point3d( const Point3d& p ) {											// copy constructor  Point p1(p2);
+			//x = p.x; y = p.y;  z = p.z;[> ok = p.ok;<]}
 		inline	Point3d( const Point& p ) {												// copy constructor  Point p1(p2);
 			x = p.x; y = p.y;  z = 0; /*ok = p.ok;*/}
 		inline	Point3d( const Point& p, double zord ) {								// copy constructor  Point p1(p2, z);
@@ -297,8 +299,8 @@ inline bool FNEZ(double a, double tolerance = TIGHT_TOLERANCE) {return fabs(a) >
 
 		// constructors
 		inline	Vector2d() {dx = 0; dy = 0;}
-		inline	Vector2d(const Vector2d &v) { dx = v.dx; dy = v.dy;}
-				Vector2d(const Vector3d &v);		// careful
+		//inline	Vector2d(const Vector2d &v) { dx = v.dx; dy = v.dy;}
+	        Vector2d(const Vector3d &v);		// careful
 		inline	Vector2d(double x, double y) {dx = x, dy = y;}
 		inline	Vector2d(const Point& p0, const Point& p1) {dx = p1.x - p0.x; dy = p1.y - p0.y;}
 		inline	Vector2d(const Point *p0, const Point *p1) {dx = p1->x - p0->x; dy = p1->y - p0->y;}
@@ -307,7 +309,7 @@ inline bool FNEZ(double a, double tolerance = TIGHT_TOLERANCE) {return fabs(a) >
 
 
 		// operators
-		inline	const	Vector2d& operator=(const Vector2d &v){dx = v.dx; dy = v.dy; return *this;}			// v1 = v2;
+		//inline	const	Vector2d& operator=(const Vector2d &v){dx = v.dx; dy = v.dy; return *this;}			// v1 = v2;
 		inline			Vector2d operator+(const Vector2d &v)const{return Vector2d(dx + v.dx, dy + v.dy);}	// v2 = v0 + v1;
 		inline			Point	operator+(const Point &p)const{return Point(this->dx + p.x, this->dy + p.y);}			// p1 = v0 + p0;
 		inline			Vector2d operator+(const double d){ return Vector2d(dx + d, dy + d); };
@@ -365,7 +367,7 @@ inline bool FNEZ(double a, double tolerance = TIGHT_TOLERANCE) {return fabs(a) >
 
 		// constructors
 		Vector3d() {dx = 0; dy = 0; dz = 0;}
-		Vector3d(const Vector3d &v) { dx = v.dx; dy = v.dy; dz = v.dz;}
+		//Vector3d(const Vector3d &v) { dx = v.dx; dy = v.dy; dz = v.dz;}
 		Vector3d(double x, double y, double z = 0) {dx = x, dy = y; dz = z;}
 		Vector3d(const double* x) {dx = x[0], dy = x[1]; dz = x[2];}
 		Vector3d(const double* x0, const double* x1) {dx = x1[0] - x0[0], dy = x1[1] - x0[1]; dz = x1[2] - x0[2];}
@@ -376,7 +378,7 @@ inline bool FNEZ(double a, double tolerance = TIGHT_TOLERANCE) {return fabs(a) >
 		// operators
 		bool operator==(const Vector3d &v)const { return(FEQ(dx, v.dx, UNIT_VECTOR_TOLERANCE) && FEQ(dy, v.dy, UNIT_VECTOR_TOLERANCE) && FEQ(dz, v.dz, UNIT_VECTOR_TOLERANCE)); }		// v1 == v2 (unit only!)
 		bool operator!=(const Vector3d &v)const { return (!(*this == v)); }											// v1 != v2
-		const	Vector3d& operator=(const Vector3d &v){dx = v.dx; dy = v.dy; dz = v.dz;return *this;}				// v1 = v2;
+		//const	Vector3d& operator=(const Vector3d &v){dx = v.dx; dy = v.dy; dz = v.dz;return *this;}				// v1 = v2;
 		//	const	Vector3d& operator=(const Vector2d &v){dx = v.getx(); dy = v.gety(); dz = 0.0;return *this;}	// v1 = v2;
 		inline		Point3d	operator+(const Point3d &p)const{return Point3d(dx + p.x, dy + p.y, dz + p.z);}			// p1 = v0 + p0;
 		Vector3d operator+(const Vector3d &v)const{return Vector3d(dx + v.dx, dy + v.dy, dz + v.dz);}				// v2 = v0 + v1;
@@ -440,7 +442,7 @@ inline bool FNEZ(double a, double tolerance = TIGHT_TOLERANCE) {return fabs(a) >
 		inline	CLine()	{ok = false;};
 		inline	CLine(const Point& p0, double dx, double dy, bool normalise = true){ p = p0; v = Vector2d(dx, dy); if(normalise) Normalise();};
 		inline	CLine(const Point& p0, const Vector2d& v0, bool normalise = true) {p = p0; v = v0; if(normalise) Normalise();};
-		inline	CLine(const CLine& s) {p = s.p; v = s.v; ok = s.ok;}				// copy constructor  CLine s1(s2);
+		//inline	CLine(const CLine& s) {p = s.p; v = s.v; ok = s.ok;}				// copy constructor  CLine s1(s2);
 		inline	CLine(const Point& p0, const Point& p1) {p = p0; v = Vector2d(p0, p1); Normalise();};
 		CLine(const Span& sp);
 
@@ -480,7 +482,7 @@ inline bool FNEZ(double a, double tolerance = TIGHT_TOLERANCE) {return fabs(a) >
 		inline	Circle() {ok = false; radius = 0;}
 		Circle( const Point& p, double r);										// Circle  c1(Point(10,30), 20);
 		Circle( const Point& p, const Point& pc);								// Circle  c1(p[222], p[223]);
-		Circle( const Circle& c ){*this = c;}									// copy constructor  Circle c1(c2);
+		//Circle( const Circle& c ){*this = c;}									// copy constructor  Circle c1(c2);
 		Circle( const Span& sp);														// constructor
 
 		// methods

--- a/src/zipios++/ziphead.cpp
+++ b/src/zipios++/ziphead.cpp
@@ -54,31 +54,31 @@ bool operator== ( const ZipLocalEntry &zlh, const ZipCDirEntry &ze ) {
 const uint32 ZipLocalEntry::signature = 0x04034b50 ;
 
 
+// Commented because same as default...
+//ZipCDirEntry &ZipCDirEntry::operator=( const class ZipCDirEntry &src ) {
+  //writer_version      = src.writer_version      ;
+  //extract_version     = src.extract_version     ;
+  //gp_bitfield         = src.gp_bitfield         ;
+  //compress_method     = src.compress_method     ;
+  //last_mod_ftime      = src.last_mod_ftime      ;
+  //last_mod_fdate      = src.last_mod_fdate      ;
+  //crc_32              = src.crc_32              ;
+  //compress_size       = src.compress_size       ; 
+  //uncompress_size     = src.uncompress_size     ;
+  //filename_len        = src.filename_len        ;
+  //extra_field_len     = src.extra_field_len     ;
+  //file_comment_len    = src.file_comment_len    ; 
+  //disk_num_start      = src.disk_num_start      ;
+  //intern_file_attr    = src.intern_file_attr    ;
+  //extern_file_attr    = src.extern_file_attr    ;
+  //rel_offset_loc_head = src.rel_offset_loc_head ;
 
-ZipCDirEntry &ZipCDirEntry::operator=( const class ZipCDirEntry &src ) {
-  writer_version      = src.writer_version      ;
-  extract_version     = src.extract_version     ;
-  gp_bitfield         = src.gp_bitfield         ;
-  compress_method     = src.compress_method     ;
-  last_mod_ftime      = src.last_mod_ftime      ;
-  last_mod_fdate      = src.last_mod_fdate      ;
-  crc_32              = src.crc_32              ;
-  compress_size       = src.compress_size       ; 
-  uncompress_size     = src.uncompress_size     ;
-  filename_len        = src.filename_len        ;
-  extra_field_len     = src.extra_field_len     ;
-  file_comment_len    = src.file_comment_len    ; 
-  disk_num_start      = src.disk_num_start      ;
-  intern_file_attr    = src.intern_file_attr    ;
-  extern_file_attr    = src.extern_file_attr    ;
-  rel_offset_loc_head = src.rel_offset_loc_head ;
+  //filename     = src.filename     ;
+  //extra_field  = src.extra_field  ; 
+  //file_comment = src.file_comment ;
 
-  filename     = src.filename     ;
-  extra_field  = src.extra_field  ; 
-  file_comment = src.file_comment ;
-
-  return *this ;
-}
+  //return *this ;
+//}
 
 bool EndOfCentralDirectory::checkSignature ( uint32 sig ) const {
   return signature == sig ;

--- a/src/zipios++/ziphead.h
+++ b/src/zipios++/ziphead.h
@@ -35,7 +35,7 @@ public:
   }
 
   void setDefaultExtract() ;
-  inline ZipLocalEntry &operator=( const class ZipLocalEntry &src ) ;
+  //inline ZipLocalEntry &operator=( const class ZipLocalEntry &src ) ;
   virtual string getComment() const ;
   virtual uint32 getCompressedSize() const ;
   virtual uint32 getCrc() const ;
@@ -123,7 +123,7 @@ public:
 
   void setDefaultWriter() ;
 
-  ZipCDirEntry &operator=( const class ZipCDirEntry &src ) ;
+  //ZipCDirEntry &operator=( const class ZipCDirEntry &src ) ;
   virtual string toString() const ;
 
   virtual string getComment() const ;


### PR DESCRIPTION
Fix -Wdeprecated-copy warnings in various places. Consists in enforcing
rule of five/three/zero (https://en.cppreference.com/w/cpp/language/rule_of_three)
mainly by deleting redundant copy constructors or copy assignment operators
that replicate default constructors/operators, or more rarely by adding
missing copy/move constructors/operators.
See also https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#c20-if-you-can-avoid-defining-default-operations-do

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
