### PR TITLE
Fix typos and misc. formatting [skip ci]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ set(FREECAD_VERSION "${PACKAGE_VERSION_MAJOR}.${PACKAGE_VERSION_MINOR}")
 set(PACKAGE_VERSION "${PACKAGE_VERSION_MAJOR}.${PACKAGE_VERSION_MINOR}.${PACKAGE_VERSION_PATCH}")
 set(PACKAGE_STRING "${PROJECT_NAME} ${PACKAGE_VERSION}")
 
-# include local  modules
+# include local modules
 include(AddFileDependencies)
 include(cMake/FreeCadMacros.cmake)
 # include helper functions/macros

--- a/src/App/ComplexGeoData.h
+++ b/src/App/ComplexGeoData.h
@@ -162,9 +162,9 @@ public:
     static const std::string &elementMapPrefix();
     /// Special postfix to mark the following tag
     static const std::string &tagPostfix();
-    /// Speical postfix to mark the index of an array element
+    /// Special postfix to mark the index of an array element
     static const std::string &indexPostfix();
-    /// Speical prefix to mark a missing element
+    /// Special prefix to mark a missing element
     static const std::string &missingPrefix();
     /// Check if a subname contains missing element
     static bool hasMissingElement(const char *subname);

--- a/src/App/Document.cpp
+++ b/src/App/Document.cpp
@@ -3758,7 +3758,7 @@ void Document::removeObject(const char* sName)
         return;
 
     if (pos->second->testStatus(ObjectStatus::PendingRecompute)) {
-        // TODO: shall we allow removal if there is active udno transaction?
+        // TODO: shall we allow removal if there is active undo transaction?
         FC_LOG("pending remove of " << sName << " after recomputing document " << getName());
         pos->second->setStatus(ObjectStatus::PendingRemove,true);
         return;

--- a/src/App/DocumentObject.h
+++ b/src/App/DocumentObject.h
@@ -457,13 +457,13 @@ public:
     /** Resolve a link reference that is relative to this object reference
      *
      * @param subname: on input, this is the subname reference to the object
-     * that is to be assigned a link. On output, the reference may be offsetted
-     * to be rid off any common parent.
+     * that is to be assigned a link. On output, the reference may be offset
+     * to be rid of any common parent.
      * @param link: on input, this is the top parent of the link reference. On
      * output, it may be altered to one of its child to be rid off any common
      * parent.
      * @param linkSub: on input, this the subname of the link reference. On
-     * output, it may be offsetted to be rid off any common parent.
+     * output, it may be offset to be rid off any common parent.
      *
      * @return The corrected top parent of the object that is to be assigned the
      * link. If the output 'subname' is empty, then return the object itself.

--- a/src/App/LinkBaseExtensionPy.xml
+++ b/src/App/LinkBaseExtensionPy.xml
@@ -19,7 +19,7 @@
 configLinkProperty(key=val,...): property configuration
 configLinkProperty(key,...): property configuration with default name
 
-This methode is here to impelement what I called Property Design
+This methode is here to implement what I called Property Design
 Pattern. The extension operates on a predefined set of properties,
 but it relies on the extended object to supply the actual property by
 calling this methode. You can choose a sub set of functionality of

--- a/src/Base/DualQuaternion.cpp
+++ b/src/Base/DualQuaternion.cpp
@@ -128,7 +128,7 @@ Base::DualQuat Base::DualQuat::pow(double t, bool shorten) const
      *
      * * Dual quaternions are implemented as a collection of dual numbers,
      * rather than a collection of two quaternions like it is done in suggested
-     * inplementation in the paper.
+     * implementation in the paper.
      *
      * * acos replaced with atan2 for improved angle accuracy for small angles
      *

--- a/src/Gui/DlgParameterImp.cpp
+++ b/src/Gui/DlgParameterImp.cpp
@@ -823,7 +823,7 @@ ParameterGroupItem::~ParameterGroupItem()
 
 void ParameterGroupItem::fillUp(void)
 {
-    // filing up groups
+    // filling up groups
     std::vector<Base::Reference<ParameterGrp> > vhcParamGrp = _hcGrp->GetGroups();
 
     setText(0,QString::fromUtf8(_hcGrp->GetGroupName()));

--- a/src/Gui/PrefWidgets.cpp
+++ b/src/Gui/PrefWidgets.cpp
@@ -95,7 +95,7 @@ QByteArray PrefWidget::paramGrpPath() const
 }
 
 /** 
- * This method is called if one ore more values in the parameter settings are changed 
+ * This method is called if one or more values in the parameter settings are changed 
  * where getParamGrp() points to. 
  * Note: This method is called for each parameter inside the parameter group. So
  * you have to filter out the appropriate parameter with the name \a sReason.

--- a/src/Gui/Selection.cpp
+++ b/src/Gui/Selection.cpp
@@ -759,7 +759,7 @@ int SelectionSingleton::setPreselect(const char* pDocName, const char* pObjectNa
 
     if(DocName==pDocName && FeatName==pObjectName && SubName==pSubName) {
         // MovePreselect is likely going to slow down large scene rendering.
-        // Disable it fow now.
+        // Disable it for now.
 #if 0
         if(hx!=x || hy!=y || hz!=z) {
             hx = x;
@@ -2344,4 +2344,3 @@ PyObject *SelectionSingleton::sGetSelectionFromStack(PyObject * /*self*/, PyObje
         return Py::new_reference_to(list);
     } PY_CATCH;
 }
-

--- a/src/Gui/Selection.h
+++ b/src/Gui/Selection.h
@@ -553,7 +553,7 @@ public:
      *
      * If \c resolve is true, then the selection is first resolved before
      * matching its owner document. So in case the selected sub-object is
-     * linked from an extenal document, it may not match the input \c doc.
+     * linked from an external document, it may not match the input \c doc.
      * If \c resolve is false, then the match is only done with the top
      * level parent object.
      */
@@ -602,21 +602,21 @@ public:
      */
     std::vector<Gui::SelectionObject> selStackGet(const char* pDocName=0,int resolve=1,int index=0) const;
 
-    /** Go back selection histroy
+    /** Go back selection history
      *
      * @param count: optional number of steps to go back
      *
      * This function pops the selection stack, and populate the current
-     * selection with the content of the last poped entry
+     * selection with the content of the last pop'd entry
      */
     void selStackGoBack(int count=1);
 
-    /** Go forward selection histroy 
+    /** Go forward selection history 
      *
      * @param count: optional number of steps to go back
      *
      * This function pops the selection stack, and populate the current
-     * selection with the content of the last poped entry
+     * selection with the content of the last pop'd entry
      */
     void selStackGoForward(int count=1);
 

--- a/src/Gui/ViewProviderLink.cpp
+++ b/src/Gui/ViewProviderLink.cpp
@@ -2425,7 +2425,7 @@ bool ViewProviderLink::initDraggingPlacement() {
     dragCtx->bbox.ScaleZ(scale.z);
     auto offset = dragCtx->bbox.GetCenter();
 
-    // This determins the initial placement of the dragger. We place it at the
+    // This determines the initial placement of the dragger. We place it at the
     // center of our bounding box.
     dragCtx->initialPlacement = pla * Base::Placement(offset, Base::Rotation());
 

--- a/src/Mod/Arch/importOBJ.py
+++ b/src/Mod/Arch/importOBJ.py
@@ -61,7 +61,7 @@ def findVert(aVertex,aList):
     return None
 
 def getIndices(obj,shape,offsetv,offsetvn):
-    "returns a list with 2 lists: vertices and face indexes, offsetted with the given amount"
+    "returns a list with 2 lists: vertices and face indexes, offset with the given amount"
     vlist = []
     vnlist = []
     elist = []

--- a/src/Mod/Cam/App/cutting_tools.cpp
+++ b/src/Mod/Cam/App/cutting_tools.cpp
@@ -354,7 +354,7 @@ bool cutting_tools::arrangecuts_ZLEVEL()
         for (MOrderIt = m_MachiningOrder.begin();MOrderIt != m_MachiningOrder.end(); ++MOrderIt)
         {
             float temp_max = MOrderIt->first.z;
-            //the check if MOrderIt+1 != end is performend at the bottom of the function
+            //the check if MOrderIt+1 != end is performed at the bottom of the function
             float temp_min = (MOrderIt+1)->first.z;
             //set the direction flags
             if (temp_max> temp_min)
@@ -828,7 +828,7 @@ TopoDS_Wire cutting_tools::ordercutShape(const TopoDS_Shape &aShape)
 //
 // //  outfile << projectedPoint.X() <<","<<projectedPoint.Y()<<","<<projectedPoint.Z()<<std::endl;
 //   //Jetzt die aktuelle Kurve als BSpline interpolieren
-//  //check for intersections due to wrong offsetted points
+//  //check for intersections due to wrong offset points
 //  checkPointIntersection(finalPoints);
 //  std::vector<gp_Pnt> finalPointscorrected;
 //  finalPointscorrected.clear();
@@ -2738,7 +2738,7 @@ std::vector<SpiralHelper> cutting_tools::OffsetSpiral(const std::vector<SpiralHe
         }
         else if ((i+1==SpiralPoints.size()) && (OffsetPoints.rbegin()->SurfacePoint.SquareDistance(OffsetPoint.SurfacePoint)<(Precision::Confusion()*Precision::Confusion())))
         {
-            //This part is necessary as the last point of the current spiral would otherwise not be offsetted
+            //This part is necessary as the last point of the current spiral would otherwise not be offset
             OffsetPoints.pop_back();//Delete the two currently last points
             OffsetPoints.pop_back();
             OffsetPoints.push_back(OffsetPoint);//Add the last point
@@ -3643,4 +3643,3 @@ double cutting_tools::GetEdgeLength(const TopoDS_Edge& anEdge)
     double length = lProps.Mass();
     return length;
 }
-

--- a/src/Mod/Cloud/App/AppCloud.cpp
+++ b/src/Mod/Cloud/App/AppCloud.cpp
@@ -399,7 +399,7 @@ Cloud::CloudWriter::CloudWriter(const char* Url, const char* AccessKey, const ch
                         curl_easy_strerror(res));
                 curl_easy_cleanup(curl);
 		free( RequestData);
-		// Let's dump temporarly for debug purpose of s3v4 implementation
+		// Lets dump temporarily for debug purposes of s3v4 implementation
 
                 std::stringstream input(s);
 
@@ -422,7 +422,7 @@ Cloud::CloudWriter::CloudWriter(const char* Url, const char* AccessKey, const ch
                 parser->parse(myxml_buf);
                 auto* dom=parser->getDocument();
 		// Is there an Error entry into the document ?
-		// if yes then we must create the Bucket
+		// if yes, then we must create the Bucket
                 checkXML(dom);
 		if ( strcmp(errorCode,"NoSuchBucket") == 0 )
 		{
@@ -760,7 +760,7 @@ void Cloud::CloudWriter::writeFiles(void)
 {
 
     // use a while loop because it is possible that while
-    // processing the files new ones can be added
+    // processing the files, new ones can be added
     std::string tmp="";
     char *cstr;
     size_t index = 0;
@@ -874,7 +874,7 @@ bool Cloud::Module::cloudRestore (const char *BucketName)
 
     Document* doc = GetApplication().getActiveDocument();
     // clean up if the document is not empty
-    // !TODO mind exceptions while restoring!
+    // !TODO: mind exceptions while restoring!
 
     doc->clearUndos();
 

--- a/src/Mod/Draft/Draft.py
+++ b/src/Mod/Draft/Draft.py
@@ -1943,8 +1943,8 @@ def offset(obj,delta,copy=False,bind=False,sym=False,occ=False):
     """offset(object,delta,[copymode],[bind]): offsets the given wire by
     applying the given delta Vector to its first vertex. If copymode is
     True, another object is created, otherwise the same object gets
-    offsetted. If bind is True, and provided the wire is open, the original
-    and the offsetted wires will be bound by their endpoints, forming a face
+    offset. If bind is True, and provided the wire is open, the original
+    and the offset wires will be bound by their endpoints, forming a face
     if sym is True, bind must be true too, and the offset is made on both
     sides, the total width being the given delta length. If offsetting a
     BSpline, the delta must not be a Vector but a list of Vectors, one for

--- a/src/Mod/Draft/DraftGeomUtils.py
+++ b/src/Mod/Draft/DraftGeomUtils.py
@@ -1183,7 +1183,7 @@ def offsetWire(wire,dvec,bind=False,occ=False,widthList=None):
     offsetWire(wire,vector,[bind]): offsets the given wire along the
     given vector. The vector will be applied at the first vertex of
     the wire. If bind is True (and the shape is open), the original
-    wire and the offsetted one are bound by 2 edges, forming a face.
+    wire and the offset one are bound by 2 edges, forming a face.
 
         If widthList is provided (values only, not lengths - i.e. no unit),
         each value will be used to offset each corresponding edge in the wire

--- a/src/Mod/Draft/Resources/ui/TaskSelectPlane.ui
+++ b/src/Mod/Draft/Resources/ui/TaskSelectPlane.ui
@@ -124,7 +124,7 @@
    <item>
     <widget class="QLabel" name="label_7">
      <property name="text">
-      <string>Or select a single vertex to move the current working plane without changing its orienatation. Then, press the button below</string>
+      <string>Or select a single vertex to move the current working plane without changing its orientation. Then, press the button below</string>
      </property>
      <property name="wordWrap">
       <bool>true</bool>

--- a/src/Mod/Fem/App/FemAnalysis.h
+++ b/src/Mod/Fem/App/FemAnalysis.h
@@ -45,7 +45,7 @@ namespace Fem {
  *  compatibility handling via handleChangedPropertyName.
  *
  *  This implies that it is not checked which objects are put into the
- *  Analsis object. Every document object of FreeCAD can be part of a
+ *  Analysis object. Every document object of FreeCAD can be part of a
  *  Analysis.
  */
 class AppFemExport FemAnalysis : public App::DocumentObjectGroup {

--- a/src/Mod/Fem/App/FemConstraintFluidBoundary.cpp
+++ b/src/Mod/Fem/App/FemConstraintFluidBoundary.cpp
@@ -70,7 +70,7 @@ ConstraintFluidBoundary::ConstraintFluidBoundary()
                       "Basic boundary type like inlet, wall, outlet,etc");
     BoundaryType.setEnums(BoundaryTypes);
     ADD_PROPERTY_TYPE(Subtype,(1),"FluidBoundary",(App::PropertyType)(App::Prop_None),
-                      "Subtype defines more specific boudnary types");
+                      "Subtype defines more specific boundary types");
     Subtype.setEnums(WallSubtypes);
     ADD_PROPERTY_TYPE(BoundaryValue,(0.0),"FluidBoundary",(App::PropertyType)(App::Prop_None),
                       "Scaler value for the specific value subtype, like pressure, velocity magnitude");

--- a/src/Mod/Fem/App/FemResultObject.cpp
+++ b/src/Mod/Fem/App/FemResultObject.cpp
@@ -41,7 +41,7 @@ FemResultObject::FemResultObject()
     ADD_PROPERTY_TYPE(Mesh,(0), "General",Prop_None,"Link to the corresponding mesh");
     ADD_PROPERTY_TYPE(NodeNumbers,(0), "NodeData",Prop_None,"Numbers of the result nodes");
     ADD_PROPERTY_TYPE(Stats,(0), "Data",Prop_None,"Statistics of the results");
-    ADD_PROPERTY_TYPE(Time,(0), "Data",Prop_None,"Time of analysis incement");
+    ADD_PROPERTY_TYPE(Time,(0), "Data",Prop_None,"Time of analysis increment");
 
     // make read-only for property editor
     NodeNumbers.setStatus(App::Property::ReadOnly, true);

--- a/src/Mod/Fem/coding_conventions.md
+++ b/src/Mod/Fem/coding_conventions.md
@@ -1,17 +1,24 @@
 # FEM coding_conventions
-- These coding rules apply to FEM module code only. Other modules or the base system may use different coding rules especially in naming policy of Python.
-
+These coding rules apply to FEM module code only. Other modules or the base system may use different coding rules especially in naming policy of Python.
 
 ## Spelling
 - Be mindful of spelling. Spell checks are quite often neglected.
-- [codespell]((https://github.com/codespell-project/codespell#updating) could be used  
+- Utilize [codespell](https://github.com/codespell-project/codespell) to discover and quickly correct spelling errors.  
 
-~~~
-codespell -q 2 -S *.ts  -L childs,dof,dum,methode,nd,normaly,uint,vertexes,freez  src/Mod/Fem/
-~~~
+  ```bash
+  # Find typos
+  codespell -q 2 -S *.ts -L childs,dof,dum,methode,nd,normaly,uint,vertexes,freez src/Mod/Fem/
+  # Interactively fix said typos
+  codespell -i 3 -w -S *.ts -L childs,dof,dum,methode,nd,normaly,uint,vertexes,freez src/Mod/Fem/
+  ```
+
+  **Notes:**  
+  1) We recommend running the dev version as it uses the most up to date typo dictionaries.  
+  2) To find the most amount of typos we recommend running a quick `pip install --upgrade`  
+  See the [codespell docs](https://github.com/codespell-project/codespell#updating) for more info.
 
 ## Python and C++
-#### Code formatting
+### Code formatting
 - All files should have a license header
 - Unix line endings are preferred
 - never use mixed line endings on one file
@@ -20,7 +27,7 @@ codespell -q 2 -S *.ts  -L childs,dof,dum,methode,nd,normaly,uint,vertexes,freez
 
 
 ## Python
-#### Code formatting
+### Code formatting
 - except W503 all Python code is pep8 compliant
 - maximal line length is 100
 - double quotes as string identifier
@@ -31,32 +38,29 @@ codespell -q 2 -S *.ts  -L childs,dof,dum,methode,nd,normaly,uint,vertexes,freez
 - snake_case_names
 - ClassNames, variable_names_without_capitals and CONSTANTS_USE_CAPITALS, functions_without_capitals
 - Function expected to return a value should indicate what is expected, so is_mesh_valid is a good name, but check_mesh is not a good name
-- Class names, methode names and variable that are locally and not supposed to be used for scripting should start with underscore like _MyInternalClass
+- Class names, method names and variable that are locally and not supposed to be used for scripting should start with underscore like _MyInternalClass
 
 ### Python code formatting tools
-- flake8
-    - in source code directory on Linux shell
-~~~
+- **flake8** in source code directory on Linux shell
+```bash
 find src/Mod/Fem/ -name "*\.py" | grep -v InitGui.py | xargs -I [] flake8 --ignore=E266,W503 --max-line-length=100 []
-~~~
-
+```
 - [LGTM](www.lgtm.com)
 - TODO: check pylint
-- automatic code formatter will not be used for existent code
-- for new code if someone would like to use a code formatter black should be used
+- Automatic code formatter will not be used for existent code
+- For new code if someone would like to use a code formatter black should be used
 
 ### Coding
 - print() vs. FreeCAD.Console.PrintMessage()
-    - FreeCAD.Console.PrintMessage() or Log or Error should be used
-    - print() should be used for debugging only
-    - forum topic https://forum.freecadweb.org/viewtopic.php?f=10&t=39110
-    - BTW: Console prints need a new line where as print does not need one
+  - `FreeCAD.Console.PrintMessage()` or Log or Error should be used
+  - `print()` should be used for debugging only
+  - [forum topic](https://forum.freecadweb.org/viewtopic.php?f=10&t=39110) 
+  - BTW: Console prints need a new line where as print does not need one
 
 ### Documenting
-- Python style is preferred over Doxygen style
-    - see ccx tools module in fem tools package
-    - see forum topic: https://forum.freecadweb.org/viewtopic.php?f=10&t=37094
-
+Python style is preferred over Doxygen style
+  - see `ccx` tools module in fem tools package
+  - see [forum topic](https://forum.freecadweb.org/viewtopic.php?f=10&t=37094)
 
 ## C++
 ### Naming policy

--- a/src/Mod/Fem/femsolver/elmer/writer.py
+++ b/src/Mod/Fem/femsolver/elmer/writer.py
@@ -482,7 +482,7 @@ class Writer(object):
                 dimension = "M/L^3"
                 if name.startswith("Edge"):
                     # not tested, but it seems needed
-                    # because denisty does not exist (IMHO, bernd)
+                    # because density does not exist (IMHO, bernd)
                     density = None
                     if density:
                         density.Unit = Units.Unit(-2, 1)

--- a/src/Mod/Fem/femsolver/settings.py
+++ b/src/Mod/Fem/femsolver/settings.py
@@ -34,7 +34,7 @@ are supported:
     - ElmerSolver
     - Z88
 
-To query settings about those solver the solver name must be given exactely in
+To query settings about those solver the solver name must be given exactly in
 the form written in the list above. To make the solver recognize settings for a
 new solver have a look at :class:`_SolverDlg`.
 """

--- a/src/Mod/Fem/femtools/femutils.py
+++ b/src/Mod/Fem/femtools/femutils.py
@@ -195,7 +195,7 @@ def get_mesh_to_solve(analysis):
 
     :returns:
      A tuple ``(object, message)``. If and only if the analysis contains
-     exactely one mesh object the first value of the tuple is the mesh document
+     exactly one mesh object the first value of the tuple is the mesh document
      object. Otherwise the first value is ``None`` and the second value is a
      error message indicating what went wrong.
     """
@@ -235,7 +235,7 @@ def is_of_type(obj, ty):
 
     :returns:
      ``True`` if *obj* is of type *ty*, ``False`` otherwise. Type must match
-     exactely: Derived objects are not considered to be of type of one of their
+     exactly: Derived objects are not considered to be of type of one of their
      super classes.
     """
     return type_of_obj(obj) == ty

--- a/src/Mod/Mesh/App/Core/Algorithm.cpp
+++ b/src/Mod/Mesh/App/Core/Algorithm.cpp
@@ -599,7 +599,7 @@ void MeshAlgorithm::SplitBoundaryLoops( std::list<std::vector<unsigned long> >& 
         it != aBorders.end(); ++it) {
         bool split=false;
         for (std::vector<unsigned long>::iterator jt = it->begin(); jt != it->end(); ++jt) {
-            // two (ore more) boundaries meet in one non-manifold point
+            // two (or more) boundaries meet in one non-manifold point
             if (openPointDegree[*jt] > 2) {
                 split = true;
                 break;

--- a/src/Mod/Mesh/App/Core/SetOperations.h
+++ b/src/Mod/Mesh/App/Core/SetOperations.h
@@ -163,7 +163,7 @@ private:
   std::set<MeshPoint>       _cutPoints;
   /** all edges */
   std::map<Edge, EdgeInfo>  _edges;
-  /** map from facet index to his cutted points (mesh 1 and mesh 2) Key: Facet-Index  Value: List of iterators of set<MeshPoint> */
+  /** map from facet index to its cut points (mesh 1 and mesh 2) Key: Facet-Index  Value: List of iterators of set<MeshPoint> */
   std::map<unsigned long, std::list<std::set<MeshPoint>::iterator> > _facet2points[2];
   /** Facets collected from region growing */
   std::vector<MeshGeomFacet> _facetsOf[2];
@@ -172,7 +172,7 @@ private:
 
   /** Cut mesh 1 with mesh 2 */
   void Cut (std::set<unsigned long>& facetsNotCuttingEdge0, std::set<unsigned long>& facetsCuttingEdge1);
-  /** Trianglute each facets cutted with his cutting points */
+  /** Trianglute each facets cut with its cutting points */
   void TriangulateMesh (const MeshKernel &cutMesh, int side);
   /** search facets for adding (with region growing) */
   void CollectFacets (int side, float mult);

--- a/src/Mod/Mesh/Gui/ViewProviderTransformDemolding.cpp
+++ b/src/Mod/Mesh/Gui/ViewProviderTransformDemolding.cpp
@@ -200,7 +200,7 @@ void ViewProviderMeshTransformDemolding::valueChangedCallback(void)
   temp.setTransform( SbVec3f(0,0,0),    // no transformation
                      rot,               // rotation from the dragger
                      SbVec3f(1,1,1),    // no scaling
-                     SbRotation() ,     // no scaling oriantation
+                     SbRotation() ,     // no scaling orientation
                      SbVec3f(center.x,center.y,center.z)); // center of rotation
   pcTransformDrag->setMatrix( temp );
 }

--- a/src/Mod/Part/App/PartFeature.cpp
+++ b/src/Mod/Part/App/PartFeature.cpp
@@ -163,7 +163,7 @@ App::DocumentObject *Feature::getSubObject(const char *subname,
             bool copy = sCopy?true:false;
             if(!copy) {
                 // Work around OCC bug on transforming circular edge with an
-                // offsetted surface. The bug probably affect other shape type,
+                // offset surface. The bug probably affect other shape type,
                 // too.
                 TopExp_Explorer exp(ts.getShape(),TopAbs_EDGE);
                 if(exp.More()) {

--- a/src/Mod/Part/Gui/ViewProviderExt.h
+++ b/src/Mod/Part/Gui/ViewProviderExt.h
@@ -129,7 +129,7 @@ public:
     void unsetHighlightedPoints();
     //@}
 
-    /** @name Color mangement methods 
+    /** @name Color management methods 
      */
     //@{
     virtual std::map<std::string,App::Color> getElementColors(const char *element=0) const override;
@@ -192,4 +192,3 @@ private:
 }
 
 #endif // PARTGUI_VIEWPROVIDERPARTEXT_H
-

--- a/src/Mod/Path/App/Area.cpp
+++ b/src/Mod/Path/App/Area.cpp
@@ -1768,7 +1768,7 @@ TopoDS_Shape Area::getShape(int index) {
 
     FC_TIME_INIT(t);
 
-    // do offset first, then pocket the inner most offsetted shape
+    // do offset first, then pocket the inner most offset shape
     std::list<shared_ptr<CArea> > areas;
     makeOffset(areas,PARAM_FIELDS(AREA_MY,AREA_PARAMS_OFFSET));
 

--- a/src/Mod/Path/App/Area.h
+++ b/src/Mod/Path/App/Area.h
@@ -145,7 +145,7 @@ protected:
     /** Called internally to obtain the combined children shapes */
     TopoDS_Shape toShape(CArea &area, short fill, int reorient=0);
 
-    /** Obtain a list of offsetted areas
+    /** Obtain a list of offset areas
      *
      * See #AREA_PARAMS_OFFSET for description of the arguments.
      */

--- a/src/Mod/Robot/Gui/ViewProviderRobotObject.cpp
+++ b/src/Mod/Robot/Gui/ViewProviderRobotObject.cpp
@@ -350,7 +350,7 @@ void ViewProviderRobotObject::setAxisTo(float A1,float A2,float A3,float A4,floa
     Robot::RobotObject* robObj = static_cast<Robot::RobotObject*>(pcObject);
 
 	if(Axis1Node)
-        // FIXME Uggly hack for the wrong transformation of the Kuka 500 robot VRML the minus sign on Axis 1
+        // FIXME Ugly hack for the wrong transformation of the Kuka 500 robot VRML the minus sign on Axis 1
 		Axis1Node->rotation.setValue(SbVec3f(0.0,1.0,0.0),A1*(M_PI/180));
 	if(Axis2Node)
 		Axis2Node->rotation.setValue(SbVec3f(0.0,1.0,0.0),A2*(M_PI/180));
@@ -391,4 +391,3 @@ void ViewProviderRobotObject::DraggerMotionCallback(SoDragger *dragger)
     Base::Vector3d pos(translation[0],translation[1],translation[2]);
     robObj->Tcp.setValue(Base::Placement(pos,rot));
 }
-

--- a/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp
+++ b/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp
@@ -928,7 +928,7 @@ public:
 
                 arcRadius = (onSketchPos - EditCurve[0]).Length()/(2.0*sin(theta));
 
-                // At this point we need a unit normal vector pointing torwards
+                // At this point we need a unit normal vector pointing towards
                 // the center of the arc we are drawing. Derivation of the formula
                 // used here can be found at http://people.richland.edu/james/lecture/m116/matrices/area.html
                 double x1 = EditCurve[0].x;


### PR DESCRIPTION
Found via `codespell -q 3 -L aci,ake,aline,alle,alledges,alocation,als,ang,anid,ba,beginn,behaviour,bloaded,byteorder,calculater,cancelled,cancelling,cas,cascade,centimetre,childs,colour,colours,commen,currenty,dof,doubleclick,dum,eiter,elemente,feld,freez,hist,iff,indicies,initialisation,initialise,initialised,initialises,initialisiert,ist,kilometre,lod,mantatory,methode,metres,millimetre,modell,nd,noe,normale,normaly,nto,numer,oder,orgin,orginx,orginy,ot,pard,pres,programm,que,recurrance,rougly,seperator,serie,sinc,strack,substraction,te,thist,thru,tread,uint,unter,vertexes,wallthickness,whitespaces -S ./.git,*.po,*.ts,./ChangeLog.txt,./src/3rdParty,./src/Mod/Assembly/App/opendcm,./src/CXX,./src/zipios++,./src/Base/swig*,./src/Mod/Robot/App/kdl_cp,./src/Mod/Import/App/SCL,./src/WindowsInstaller,./src/Doc/FreeCAD.uml`