### PR TITLE
add toolbar icon to create mesh from shape

### DIFF
--- a/src/Mod/Mesh/Gui/Workbench.cpp
+++ b/src/Mod/Mesh/Gui/Workbench.cpp
@@ -238,7 +238,7 @@ Gui::ToolBarItem* Workbench::setupToolBars() const
     Gui::ToolBarItem* root = StdWorkbench::setupToolBars();
     Gui::ToolBarItem* mesh = new Gui::ToolBarItem(root);
     mesh->setCommand("Mesh tools");
-    *mesh << "Mesh_Import" << "Mesh_Export" << "Separator" << "Mesh_PolyCut" << "Mesh_VertexCurvature";
+    *mesh << "Mesh_Import" << "Mesh_Export" << "Mesh_FromPartShape" << "Separator" << "Mesh_PolyCut" << "Mesh_VertexCurvature";
     return root;
 }
 


### PR DESCRIPTION
In daily work there are 2 main methods to work with meshes: creating one from a shape or importing an existent one.
Since the generation from a shape is often needed, add its icon to the default toolbar.