### PR TITLE
Draft: fix double translation in Draft._PointArray

### DIFF
--- a/src/Mod/Draft/Draft.py
+++ b/src/Mod/Draft/Draft.py
@@ -6030,7 +6030,8 @@ class _PointArray(_DraftObject):
                         place = pts.Placement
                         nshape.translate(place.Base)
                         nshape.rotate(place.Base, place.Rotation.Axis, place.Rotation.Angle * 180 /  math.pi )
-                    nshape.translate(Base.Vector(pts.X,pts.Y,pts.Z))
+                    else:
+                        nshape.translate(Base.Vector(pts.X,pts.Y,pts.Z))
                     i += 1
                     base.append(nshape)
         obj.Count = i


### PR DESCRIPTION
The `nshape.translate()` operation is called twice, once inside `if hasattr(pts, 'Placement')`, and once outside. This results in incorrectly spaced arrays.

We put the second translation in an `else` clause, so that only one translation is executed.

See forum thread for pictures: [Bug: Draft PointArray uses points with twice the spacing](https://forum.freecadweb.org/viewtopic.php?f=23&t=40342)

---

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists
