### PR TITLE
use emplace_back instead of push_back where justified

### DIFF
--- a/src/3rdParty/salomesmesh/src/Controls/SMESH_Controls.cpp
+++ b/src/3rdParty/salomesmesh/src/Controls/SMESH_Controls.cpp
@@ -3031,7 +3031,7 @@ void CoplanarFaces::SetMesh( const SMDS_Mesh* theMesh )
     std::set< SMESH_TLink > checkedLinks;
 
     std::list< pair< const SMDS_MeshElement*, gp_Vec > > faceQueue;
-    faceQueue.push_back( make_pair( face, myNorm ));
+    faceQueue.emplace_back( face, myNorm );
     while ( !faceQueue.empty() )
     {
       face   = faceQueue.front().first;
@@ -3054,7 +3054,7 @@ void CoplanarFaces::SetMesh( const SMDS_Mesh* theMesh )
             if (!normOK || myNorm.Angle( norm ) <= radianTol)
             {
               myCoplanarIDs.insert( f->GetID() );
-              faceQueue.push_back( make_pair( f, norm ));
+              faceQueue.emplace_back( f, norm );
             }
           }
         }

--- a/src/3rdParty/salomesmesh/src/SMESH/DriverMED_W_Field.cpp
+++ b/src/3rdParty/salomesmesh/src/SMESH/DriverMED_W_Field.cpp
@@ -107,7 +107,7 @@ bool DriverMED_W_Field::Set(SMESHDS_Mesh *      mesh,
       nbElems = mesh->GetMeshInfo().NbElements( geom );
       if ( nbElems < 1 ) continue;
 
-      _nbElemsByGeom.push_back( std::make_pair( geom, nbElems + _nbElemsByGeom.back().second ));
+      _nbElemsByGeom.emplace_back( geom, nbElems + _nbElemsByGeom.back().second );
     }
     // add nodes of missing 0D elements on VERTEXes
     if ( _addODOnVertices && _elemType == SMDSAbs_0DElement )
@@ -118,9 +118,9 @@ bool DriverMED_W_Field::Set(SMESHDS_Mesh *      mesh,
       if ( !nodes.empty() )
       {
         if ( _nbElemsByGeom.size() == 1 )
-          _nbElemsByGeom.push_back( std::make_pair( SMDSEntity_0D, 0));
-        _nbElemsByGeom.push_back( std::make_pair( SMDSEntity_Node,
-                                             nodes.size() + _nbElemsByGeom.back().second ));
+          _nbElemsByGeom.emplace_back( SMDSEntity_0D, 0);
+        _nbElemsByGeom.emplace_back( SMDSEntity_Node,
+                                             nodes.size() + _nbElemsByGeom.back().second );
       }
     }
 

--- a/src/3rdParty/salomesmesh/src/SMESH/DriverMED_W_SMESHDS_Mesh.cpp
+++ b/src/3rdParty/salomesmesh/src/SMESH/DriverMED_W_SMESHDS_Mesh.cpp
@@ -572,131 +572,131 @@ Driver_Mesh::Status DriverMED_W_SMESHDS_Mesh::Perform()
 #ifdef _ELEMENTS_BY_DIM_
     anEntity = eNOEUD_ELEMENT;
 #endif
-    aTElemTypeDatas.push_back(TElemTypeData(anEntity,
+    aTElemTypeDatas.emplace_back(anEntity,
                                             ePOINT1,
                                             nbElemInfo.Nb0DElements() + nodesOf0D.size(),
-                                            SMDSAbs_0DElement));
+                                            SMDSAbs_0DElement);
 #ifdef _ELEMENTS_BY_DIM_
     anEntity = eSTRUCT_ELEMENT;
 #endif
-    aTElemTypeDatas.push_back( TElemTypeData(anEntity,
+    aTElemTypeDatas.emplace_back(anEntity,
                                              eBALL,
                                              nbElemInfo.NbBalls(),
-                                             SMDSAbs_Ball));
+                                             SMDSAbs_Ball);
 #ifdef _ELEMENTS_BY_DIM_
     anEntity = eARETE;
 #endif
-    aTElemTypeDatas.push_back( TElemTypeData(anEntity,
+    aTElemTypeDatas.emplace_back(anEntity,
                                              eSEG2,
                                              nbElemInfo.NbEdges( ORDER_LINEAR ),
-                                             SMDSAbs_Edge));
-    aTElemTypeDatas.push_back( TElemTypeData(anEntity,
+                                             SMDSAbs_Edge);
+    aTElemTypeDatas.emplace_back(anEntity,
                                              eSEG3,
                                              nbElemInfo.NbEdges( ORDER_QUADRATIC ),
-                                             SMDSAbs_Edge));
+                                             SMDSAbs_Edge);
 #ifdef _ELEMENTS_BY_DIM_
     anEntity = eFACE;
 #endif
-    aTElemTypeDatas.push_back( TElemTypeData(anEntity,
+    aTElemTypeDatas.emplace_back(anEntity,
                                              eTRIA3,
                                              nbElemInfo.NbTriangles( ORDER_LINEAR ),
-                                             SMDSAbs_Face));
-    aTElemTypeDatas.push_back( TElemTypeData(anEntity,
+                                             SMDSAbs_Face);
+    aTElemTypeDatas.emplace_back(anEntity,
                                              eTRIA6,
                                              nbElemInfo.NbTriangles( ORDER_QUADRATIC ) -
                                              nbElemInfo.NbBiQuadTriangles(),
-                                             SMDSAbs_Face));
-    aTElemTypeDatas.push_back( TElemTypeData(anEntity,
+                                             SMDSAbs_Face);
+    aTElemTypeDatas.emplace_back(anEntity,
                                              eTRIA7,
                                              nbElemInfo.NbBiQuadTriangles(),
-                                             SMDSAbs_Face));
-    aTElemTypeDatas.push_back( TElemTypeData(anEntity,
+                                             SMDSAbs_Face);
+    aTElemTypeDatas.emplace_back(anEntity,
                                              eQUAD4,
                                              nbElemInfo.NbQuadrangles( ORDER_LINEAR ),
-                                             SMDSAbs_Face));
-    aTElemTypeDatas.push_back( TElemTypeData(anEntity,
+                                             SMDSAbs_Face);
+    aTElemTypeDatas.emplace_back(anEntity,
                                              eQUAD8,
                                              nbElemInfo.NbQuadrangles( ORDER_QUADRATIC ) -
                                              nbElemInfo.NbBiQuadQuadrangles(),
-                                             SMDSAbs_Face));
-    aTElemTypeDatas.push_back( TElemTypeData(anEntity,
+                                             SMDSAbs_Face);
+    aTElemTypeDatas.emplace_back(anEntity,
                                              eQUAD9,
                                              nbElemInfo.NbBiQuadQuadrangles(),
-                                             SMDSAbs_Face));
+                                             SMDSAbs_Face);
     if ( polyTypesSupported ) {
-      aTElemTypeDatas.push_back( TElemTypeData(anEntity,
+      aTElemTypeDatas.emplace_back(anEntity,
                                                ePOLYGONE,
                                                nbElemInfo.NbPolygons( ORDER_LINEAR ),
-                                               SMDSAbs_Face));
+                                               SMDSAbs_Face);
       // we need one more loop on poly elements to count nb of their nodes
-      aTElemTypeDatas.push_back( TElemTypeData(anEntity,
+      aTElemTypeDatas.emplace_back(anEntity,
                                                ePOLYGONE,
                                                nbElemInfo.NbPolygons( ORDER_LINEAR ),
-                                               SMDSAbs_Face));
-      aTElemTypeDatas.push_back( TElemTypeData(anEntity,
+                                               SMDSAbs_Face);
+      aTElemTypeDatas.emplace_back(anEntity,
                                                ePOLYGON2,
                                                nbElemInfo.NbPolygons( ORDER_QUADRATIC ),
-                                               SMDSAbs_Face));
+                                               SMDSAbs_Face);
       // we need one more loop on QUAD poly elements to count nb of their nodes
-      aTElemTypeDatas.push_back( TElemTypeData(anEntity,
+      aTElemTypeDatas.emplace_back(anEntity,
                                                ePOLYGON2,
                                                nbElemInfo.NbPolygons( ORDER_QUADRATIC ),
-                                               SMDSAbs_Face));
+                                               SMDSAbs_Face);
     }
 #ifdef _ELEMENTS_BY_DIM_
     anEntity = eMAILLE;
 #endif
-    aTElemTypeDatas.push_back( TElemTypeData(anEntity,
+    aTElemTypeDatas.emplace_back(anEntity,
                                              eTETRA4,
                                              nbElemInfo.NbTetras( ORDER_LINEAR ),
-                                             SMDSAbs_Volume));
-    aTElemTypeDatas.push_back( TElemTypeData(anEntity,
+                                             SMDSAbs_Volume);
+    aTElemTypeDatas.emplace_back(anEntity,
                                              eTETRA10,
                                              nbElemInfo.NbTetras( ORDER_QUADRATIC ),
-                                             SMDSAbs_Volume));
-    aTElemTypeDatas.push_back( TElemTypeData(anEntity,
+                                             SMDSAbs_Volume);
+    aTElemTypeDatas.emplace_back(anEntity,
                                              ePYRA5,
                                              nbElemInfo.NbPyramids( ORDER_LINEAR ),
-                                             SMDSAbs_Volume));
-    aTElemTypeDatas.push_back( TElemTypeData(anEntity,
+                                             SMDSAbs_Volume);
+    aTElemTypeDatas.emplace_back(anEntity,
                                              ePYRA13,
                                              nbElemInfo.NbPyramids( ORDER_QUADRATIC ),
-                                             SMDSAbs_Volume));
-    aTElemTypeDatas.push_back( TElemTypeData(anEntity,
+                                             SMDSAbs_Volume);
+    aTElemTypeDatas.emplace_back(anEntity,
                                              ePENTA6,
                                              nbElemInfo.NbPrisms( ORDER_LINEAR ),
-                                             SMDSAbs_Volume));
-    aTElemTypeDatas.push_back( TElemTypeData(anEntity,
+                                             SMDSAbs_Volume);
+    aTElemTypeDatas.emplace_back(anEntity,
                                              ePENTA15,
                                              nbElemInfo.NbPrisms( ORDER_QUADRATIC ),
-                                             SMDSAbs_Volume));
-    aTElemTypeDatas.push_back( TElemTypeData(anEntity,
+                                             SMDSAbs_Volume);
+    aTElemTypeDatas.emplace_back(anEntity,
                                              eHEXA8,
                                              nbElemInfo.NbHexas( ORDER_LINEAR ),
-                                             SMDSAbs_Volume));
-    aTElemTypeDatas.push_back( TElemTypeData(anEntity,
+                                             SMDSAbs_Volume);
+    aTElemTypeDatas.emplace_back(anEntity,
                                              eHEXA20,
                                              nbElemInfo.NbHexas( ORDER_QUADRATIC )-
                                              nbElemInfo.NbTriQuadHexas(),
-                                             SMDSAbs_Volume));
-    aTElemTypeDatas.push_back( TElemTypeData(anEntity,
+                                             SMDSAbs_Volume);
+    aTElemTypeDatas.emplace_back(anEntity,
                                              eHEXA27,
                                              nbElemInfo.NbTriQuadHexas(),
-                                             SMDSAbs_Volume));
-    aTElemTypeDatas.push_back( TElemTypeData(anEntity,
+                                             SMDSAbs_Volume);
+    aTElemTypeDatas.emplace_back(anEntity,
                                              eOCTA12,
                                              nbElemInfo.NbHexPrisms(),
-                                             SMDSAbs_Volume));
+                                             SMDSAbs_Volume);
     if ( polyTypesSupported ) {
-      aTElemTypeDatas.push_back( TElemTypeData(anEntity,
+      aTElemTypeDatas.emplace_back(anEntity,
                                                ePOLYEDRE,
                                                nbElemInfo.NbPolyhedrons(),
-                                               SMDSAbs_Volume));
+                                               SMDSAbs_Volume);
       // we need one more loop on poly elements to count nb of their nodes
-      aTElemTypeDatas.push_back( TElemTypeData(anEntity,
+      aTElemTypeDatas.emplace_back(anEntity,
                                                ePOLYEDRE,
                                                nbElemInfo.NbPolyhedrons(),
-                                               SMDSAbs_Volume));
+                                               SMDSAbs_Volume);
     }
 
     vector< bool > isElemFamMapBuilt( SMDSAbs_NbElementTypes, false );

--- a/src/3rdParty/salomesmesh/src/SMESH/SMESH_Gen.cpp
+++ b/src/3rdParty/salomesmesh/src/SMESH/SMESH_Gen.cpp
@@ -624,7 +624,7 @@ static bool checkConformIgnoredAlgos(SMESH_Mesh&               aMesh,
 
     if ( aLocIgnoAlgo ) // algo is hidden by a local algo of upper dim
     {
-      theErrors.push_back( SMESH_Gen::TAlgoStateError() );
+      theErrors.emplace_back( );
       theErrors.back().Set( SMESH_Hypothesis::HYP_HIDDEN_ALGO, algo, false );
       INFOS( "Local <" << algo->GetName() << "> is hidden by local <"
             << aLocIgnoAlgo->GetName() << ">");
@@ -640,7 +640,7 @@ static bool checkConformIgnoredAlgos(SMESH_Mesh&               aMesh,
           ( isGlobal || !aGlobIgnoAlgo->SupportSubmeshes() ))
       {
         // algo is hidden by a global algo
-        theErrors.push_back( SMESH_Gen::TAlgoStateError() );
+        theErrors.emplace_back( );
         theErrors.back().Set( SMESH_Hypothesis::HYP_HIDDEN_ALGO, algo, true );
         INFOS( ( isGlobal ? "Global" : "Local" )
               << " <" << algo->GetName() << "> is hidden by global <"
@@ -656,7 +656,7 @@ static bool checkConformIgnoredAlgos(SMESH_Mesh&               aMesh,
           INFOS( "ERROR: Local <" << algo->GetName() <<
                 "> would produce not conform mesh: "
                 "<Not Conform Mesh Allowed> hypotesis is missing");
-          theErrors.push_back( SMESH_Gen::TAlgoStateError() );
+          theErrors.emplace_back( );
           theErrors.back().Set( SMESH_Hypothesis::HYP_NOTCONFORM, algo, false );
         }
 
@@ -722,7 +722,7 @@ static bool checkMissing(SMESH_Gen*                aGen,
       {
         MESSAGE( "ERROR: " << shapeDim << "D algorithm is missing" );
         ret = false;
-        theErrors.push_back( SMESH_Gen::TAlgoStateError() );
+        theErrors.emplace_back( );
         theErrors.back().Set( SMESH_Hypothesis::HYP_MISSING, shapeDim, true );
       }
     }
@@ -752,7 +752,7 @@ static bool checkMissing(SMESH_Gen*                aGen,
       }
       if (IsGlobalHypothesis)
         globalChecked[ algo->GetDim() ] = true;
-      theErrors.push_back( SMESH_Gen::TAlgoStateError() );
+      theErrors.emplace_back( );
       theErrors.back().Set( errName, algo, IsGlobalHypothesis );
     }
     ret = false;
@@ -942,7 +942,7 @@ bool SMESH_Gen::GetAlgoState(SMESH_Mesh&               theMesh,
 
   if ( !hasAlgo ) {
     ret = false;
-    theErrors.push_back( TAlgoStateError() );
+    theErrors.emplace_back( );
     theErrors.back().Set( SMESH_Hypothesis::HYP_MISSING, theMesh.HasShapeToMesh() ? 1 : 3, true );
   }
 

--- a/src/3rdParty/salomesmesh/src/SMESH/SMESH_MeshAlgos.cpp
+++ b/src/3rdParty/salomesmesh/src/SMESH/SMESH_MeshAlgos.cpp
@@ -611,7 +611,7 @@ void SMESH_ElementSearcherImpl::findOuterBoundary(const SMDS_MeshElement* outerF
   list < TFaceLink > startLinks;
 
   // load startLinks with the first outerFace
-  startLinks.push_back( TFaceLink( outerFace->GetNode(0), outerFace->GetNode(1), outerFace));
+  startLinks.emplace_back( outerFace->GetNode(0), outerFace->GetNode(1), outerFace);
   _outerFaces.insert( outerFace );
 
   TIDSortedElemSet emptySet;
@@ -674,7 +674,7 @@ void SMESH_ElementSearcherImpl::findOuterBoundary(const SMDS_MeshElement* outerF
       {
         SMESH_TLink link2( outerFace2->GetNode(i), outerFace2->GetNode((i+1)%nbNodes));
         if ( visitedLinks.insert( link2 ).second )
-          startLinks.push_back( TFaceLink( link2.node1(), link2.node2(), outerFace2 ));
+          startLinks.emplace_back( link2.node1(), link2.node2(), outerFace2 );
       }
     }
     startLinks.pop_front();
@@ -891,7 +891,7 @@ TopAbs_State SMESH_ElementSearcherImpl::GetPointState(const gp_Pnt& point)
         continue;
       if ( intersection.IsInQuadric() )
       {
-        tangentInters[ axis ].push_back( TInters( *face, fNorm, true ));
+        tangentInters[ axis ].emplace_back( *face, fNorm, true );
       }
       else if ( ! intersection.IsParallel() && intersection.NbPoints() > 0 )
       {

--- a/src/3rdParty/salomesmesh/src/SMESH/SMESH_MeshEditor.cpp
+++ b/src/3rdParty/salomesmesh/src/SMESH/SMESH_MeshEditor.cpp
@@ -1248,7 +1248,7 @@ int SMESH_MeshEditor::Reorient2D (TIDSortedElemSet &       theFaces,
           if ( otherFace != theFace)
           {
             facesNearLink.push_back( otherFace );
-            nodeIndsOfFace.push_back( make_pair( nodeInd1, nodeInd2 ));
+            nodeIndsOfFace.emplace_back( nodeInd1, nodeInd2 );
             avoidSet.insert( otherFace );
           }
         if ( facesNearLink.size() > 1 )
@@ -2419,9 +2419,9 @@ void SMESH_MeshEditor::SplitVolumes (const TFacetOfElem & theElems,
               facets.push_back( t012 );
               facets.push_back( t023 );
               for ( int iLast = iCom+4; iLast < iCom+nbNodes; ++iLast )
-                facets.push_back( TTriangleFacet( nInd[ iQ * ( iCom             )],
+                facets.emplace_back( nInd[ iQ * ( iCom             )],
                                                   nInd[ iQ * ((iLast-1)%nbNodes )],
-                                                  nInd[ iQ * ((iLast  )%nbNodes )]));
+                                                  nInd[ iQ * ((iLast  )%nbNodes )]);
               break;
             }
           }
@@ -10244,8 +10244,8 @@ SMESH_MeshEditor::SewSideElements (TIDSortedElemSet&    theSide1,
 
   typedef pair< const SMDS_MeshNode*, const SMDS_MeshNode* > NLink;
   list< NLink > linkList[2];
-  linkList[0].push_back( NLink( theFirstNode1, theSecondNode1 ));
-  linkList[1].push_back( NLink( theFirstNode2, theSecondNode2 ));
+  linkList[0].emplace_back( theFirstNode1, theSecondNode1 );
+  linkList[1].emplace_back( theFirstNode2, theSecondNode2 );
   // loop on links in linkList; find faces by links and append links
   // of the found faces to linkList
   list< NLink >::iterator linkIt[] = { linkList[0].begin(), linkList[1].begin() } ;
@@ -10348,8 +10348,8 @@ SMESH_MeshEditor::SewSideElements (TIDSortedElemSet&    theSide1,
         {
           const SMDS_MeshNode* n1 = fnodes[0][ iNode ];
           const SMDS_MeshNode* n2 = fnodes[0][ iNode + 1];
-          linkList[0].push_back ( NLink( n1, n2 ));
-          linkList[1].push_back ( NLink( nReplaceMap[n1], nReplaceMap[n2] ));
+          linkList[0].emplace_back( n1, n2 );
+          linkList[1].emplace_back( nReplaceMap[n1], nReplaceMap[n2] );
         }
       }
     } // 2 faces found
@@ -10472,8 +10472,8 @@ SMESH_MeshEditor::FindMatchingNodes(set<const SMDS_MeshElement*>& theSide1,
   linkSet.insert( SMESH_TLink( theFirstNode1, theSecondNode1 ));
 
   list< NLink > linkList[2];
-  linkList[0].push_back( NLink( theFirstNode1, theSecondNode1 ));
-  linkList[1].push_back( NLink( theFirstNode2, theSecondNode2 ));
+  linkList[0].emplace_back( theFirstNode1, theSecondNode1 );
+  linkList[1].emplace_back( theFirstNode2, theSecondNode2 );
 
   // loop on links in linkList; find faces by links and append links
   // of the found faces to linkList
@@ -10595,8 +10595,8 @@ SMESH_MeshEditor::FindMatchingNodes(set<const SMDS_MeshElement*>& theSide1,
           MESSAGE ( "Add link 1: " << n1->GetID() << " " << n2->GetID() << " "
                     << " | link 2: " << nReplaceMap[n1]->GetID() << " " << nReplaceMap[n2]->GetID() << " " );
 #endif
-          linkList[0].push_back ( NLink( n1, n2 ));
-          linkList[1].push_back ( NLink( nReplaceMap[n1], nReplaceMap[n2] ));
+          linkList[0].emplace_back( n1, n2 );
+          linkList[1].emplace_back( nReplaceMap[n1], nReplaceMap[n2] );
         }
         n1 = n2;
       }

--- a/src/3rdParty/salomesmesh/src/SMESH/SMESH_MesherHelper.cpp
+++ b/src/3rdParty/salomesmesh/src/SMESH/SMESH_MesherHelper.cpp
@@ -4255,7 +4255,7 @@ namespace { // Structures used by FixQuadraticElements()
 
       if ( resultChains.size() == nbBndLinks / 2 )
         return _NOT_RECT;
-      resultChains.push_back( TChain() );
+      resultChains.emplace_back( );
       TChain& columnChain = resultChains.back();
 
       TLinkInSet botLink = startLink; // current horizontal link to go up from
@@ -4300,7 +4300,7 @@ namespace { // Structures used by FixQuadraticElements()
             return _MANY_ROWS; // different nb of rows in columns
           if ( resultChains.size() == nbBndLinks / 2 )
             return _NOT_RECT;
-          resultChains.push_back( TChain() );
+          resultChains.emplace_back( );
           rowChains.push_back( & resultChains.back() );
         }
         rowChains[iRow]->push_back( *sideLink );
@@ -4680,7 +4680,7 @@ namespace { // Structures used by FixQuadraticElements()
                   theHelper.GetTLinkNodeMap().find( link );
                 if ( linkIt != theHelper.GetTLinkNodeMap().end() )
                 {
-                  links.push_back( make_pair( linkIt->first, linkIt->second  ));
+                  links.emplace_back( linkIt->first, linkIt->second  );
                   if ( !isDistorted ) {
                     // compare projections of nInSolid and nMedium to face normal
                     gp_Pnt pMedium = SMESH_TNodeXYZ( linkIt->second );

--- a/src/3rdParty/salomesmesh/src/SMESH/SMESH_Pattern.cpp
+++ b/src/3rdParty/salomesmesh/src/SMESH/SMESH_Pattern.cpp
@@ -368,7 +368,7 @@ bool SMESH_Pattern::Load (const char* theFileContents)
 
   while ( readLine( fields, lineBeg, clearFields ))
   {
-    myElemPointIDs.push_back( TElemDef() );
+    myElemPointIDs.emplace_back( );
     TElemDef& elemPoints = myElemPointIDs.back();
     for ( fIt = fields.begin(); fIt != fields.end(); fIt++ )
     {
@@ -631,7 +631,7 @@ bool SMESH_Pattern::Load (SMESH_Mesh*        theMesh,
     while ( fIt->more() )
     {
       const SMDS_MeshElement* face = fIt->next();
-      myElemPointIDs.push_back( TElemDef() );
+      myElemPointIDs.emplace_back( );
       TElemDef& elemPoints = myElemPointIDs.back();
       int nbNodes = face->NbCornerNodes();
       for ( int i = 0;i < nbNodes; ++i )
@@ -927,7 +927,7 @@ bool SMESH_Pattern::Load (SMESH_Mesh*        theMesh,
       {
         const SMDS_MeshElement* elem = elemIt->next();
         SMDS_ElemIteratorPtr nIt = elem->nodesIterator();
-        myElemPointIDs.push_back( TElemDef() );
+        myElemPointIDs.emplace_back( );
         TElemDef& elemPoints = myElemPointIDs.back();
         // find point indices corresponding to element nodes
         while ( nIt->more() )
@@ -1558,7 +1558,7 @@ bool SMESH_Pattern::
     set< double >::iterator par1It = params1.begin();
     for ( ; par1It != params1.end(); par1It++ )
     {
-      nodes.push_back( TIsoNode( *par0It, *par1It ) );
+      nodes.emplace_back( *par0It, *par1It );
       isoLine0.push_back( & nodes.back() );
       isoMap[1][ *par1It ].push_back( & nodes.back() );
     }
@@ -1616,7 +1616,7 @@ bool SMESH_Pattern::
           if ( Abs( nodePar - otherPar ) <= toler )
             node = ( nIt == isoLine.end() ) ? isoLine.back() : (*nIt);
           else {
-            nodes.push_back( TIsoNode( initUV.X(), initUV.Y() ) );
+            nodes.emplace_back( initUV.X(), initUV.Y() );
             node = & nodes.back();
             isoLine.insert( nIt, node );
           }
@@ -2366,7 +2366,7 @@ bool SMESH_Pattern::sortSameSizeWires (TListOfEdgesList &                theWire
     setFirstEdge( wire, eID );
 
     // compute eventual UV and fill theEdgesPointsList
-    theEdgesPointsList.push_back( list< TPoint* >() );
+    theEdgesPointsList.emplace_back( );
     list< TPoint* > & edgesPoints = theEdgesPointsList.back();
     for ( eIt = wire.begin(); eIt != wire.end(); eIt++ )
     {
@@ -2433,7 +2433,7 @@ bool SMESH_Pattern::Apply (const TopoDS_Face&   theFace,
 
   // points on edges to be used for UV computation of in-face points
   list< list< TPoint* > > edgesPointsList;
-  edgesPointsList.push_back( list< TPoint* >() );
+  edgesPointsList.emplace_back( );
   list< TPoint* > * edgesPoints = & edgesPointsList.back();
   list< TPoint* >::iterator pIt, pEnd;
 
@@ -2466,7 +2466,7 @@ bool SMESH_Pattern::Apply (const TopoDS_Face&   theFace,
     for ( nbEIt++; nbEIt != nbVertexInWires.end(); nbEIt++ )
     {
       int nbEdges = *nbEIt;
-      wireList.push_back( list< TopoDS_Edge >() );
+      wireList.emplace_back( );
       list< TopoDS_Edge > & wire = wireList.back();
       for ( iE = 0 ; iE < nbEdges; eIt++, iE++ )
       {
@@ -2510,7 +2510,7 @@ bool SMESH_Pattern::Apply (const TopoDS_Face&   theFace,
         setFirstEdge( wire, id1 );
 
         // compute eventual UV and collect on-edge points
-        edgesPointsList.push_back( list< TPoint* >() );
+        edgesPointsList.emplace_back( );
         edgesPoints = & edgesPointsList.back();
         int eID = id1;
         for ( eIt = wire.begin(); eIt != wire.end(); eIt++ )
@@ -2709,7 +2709,7 @@ bool SMESH_Pattern::Apply (const SMDS_MeshFace* theFace,
 
   // points on edges to be used for UV computation of in-face points
   list< list< TPoint* > > edgesPointsList;
-  edgesPointsList.push_back( list< TPoint* >() );
+  edgesPointsList.emplace_back( );
   list< TPoint* > * edgesPoints = & edgesPointsList.back();
   list< TPoint* >::iterator pIt;
 
@@ -2862,7 +2862,7 @@ bool SMESH_Pattern::Apply (SMESH_Mesh*          theMesh,
 
   // points on edges to be used for UV computation of in-face points
   list< list< TPoint* > > edgesPointsList;
-  edgesPointsList.push_back( list< TPoint* >() );
+  edgesPointsList.emplace_back( );
   list< TPoint* > * edgesPoints = & edgesPointsList.back();
   list< TPoint* >::iterator pIt;
 
@@ -3017,7 +3017,7 @@ bool SMESH_Pattern::Apply (SMESH_Mesh*                     theMesh,
     list< TElemDef >::iterator ll = myElemPointIDs.begin();
     for ( ; ll != myElemPointIDs.end(); ++ll )
     {
-      myElemXYZIDs.push_back(TElemDef());
+      myElemXYZIDs.emplace_back();
       TElemDef& xyzIds = myElemXYZIDs.back();
       TElemDef& pIds = *ll;
       for ( TElemDef::iterator id = pIds.begin(); id != pIds.end(); id++ ) {
@@ -3046,12 +3046,12 @@ bool SMESH_Pattern::Apply (SMESH_Mesh*                     theMesh,
         int nId = ( *p - &myPoints[0] ) + ind1;
         myXYZIdToNodeMap[ nId ] = n1;
         list< list< int > >& groups = myIdsOnBoundary[ node1Set ];
-        groups.push_back(list< int > ());
+        groups.emplace_back();
         groups.back().push_back( nId );
       }
       // add the linkSet to the map
       list< list< int > >& groups = myIdsOnBoundary[ linkSet ];
-      groups.push_back(list< int > ());
+      groups.emplace_back();
       list< int >& indList = groups.back();
       // add points to the map excluding the end points
       for ( p++; *p != linkPoints.back(); p++ )
@@ -3124,7 +3124,7 @@ bool SMESH_Pattern::Apply (std::set<const SMDS_MeshVolume*> & theVolumes,
     list< TElemDef >::iterator ll = myElemPointIDs.begin();
     for ( ; ll != myElemPointIDs.end(); ++ll )
     {
-      myElemXYZIDs.push_back(TElemDef());
+      myElemXYZIDs.emplace_back();
       TElemDef& xyzIds = myElemXYZIDs.back();
       TElemDef& pIds = *ll;
       for ( TElemDef::iterator id = pIds.begin(); id != pIds.end(); id++ ) {
@@ -3163,7 +3163,7 @@ bool SMESH_Pattern::Apply (std::set<const SMDS_MeshVolume*> & theVolumes,
       list< TPoint* > & points = getShapePoints( Id );
       list< TPoint* >::iterator p = points.begin();
       list< list< int > >& groups = myIdsOnBoundary[ subNodes ];
-      groups.push_back(list< int > ());
+      groups.emplace_back();
       list< int >& indList = groups.back();
       for ( ; p != points.end(); p++ )
         indList.push_back( pointIndex[ *p ] + ind1 );
@@ -3288,7 +3288,7 @@ bool SMESH_Pattern::Load (SMESH_Mesh*         theMesh,
     SMDS_ElemIteratorPtr elemIt = aSubMesh->GetElements();
     while ( elemIt->more() ) {
       const SMDS_MeshElement* elem = elemIt->next();
-      myElemPointIDs.push_back( TElemDef() );
+      myElemPointIDs.emplace_back( );
       TElemDef& elemPoints = myElemPointIDs.back();
       int nbNodes = elem->NbCornerNodes();
       for ( int i = 0;i < nbNodes; ++i )
@@ -3577,7 +3577,7 @@ void SMESH_Pattern::
 
           // some links of <face> are split;
           // make list of xyz for <face>
-          myPolyElemXYZIDs.push_back(TElemDef());
+          myPolyElemXYZIDs.emplace_back();
           TElemDef & faceNodeIds = myPolyElemXYZIDs.back();
           // loop on links of a <face>
           SMDS_ElemIteratorPtr nIt = face->nodesIterator();
@@ -3696,8 +3696,8 @@ void SMESH_Pattern::
           if ( !volTool.Set( elem ) || !avoidSet.insert( elem ).second )
             continue; // skip faces or refined elements
           // add polyhedron definition
-          myPolyhedronQuantities.push_back(vector<int> ());
-          myPolyElemXYZIDs.push_back(TElemDef());
+          myPolyhedronQuantities.emplace_back();
+          myPolyElemXYZIDs.emplace_back();
           vector<int>& quantity = myPolyhedronQuantities.back();
           TElemDef &   elemDef  = myPolyElemXYZIDs.back();
           // get definitions of new elements on volume faces
@@ -4570,7 +4570,7 @@ bool SMESH_Pattern::findBoundaryPoints()
 
     // 2. chain up boundary points
     list< list< TPoint* > > boundaryList;
-    boundaryList.push_back( list< TPoint* >() );
+    boundaryList.emplace_back( );
     list< TPoint* > * boundary = & boundaryList.back();
 
     TPoint *point1, *point2, *keypoint1;
@@ -4613,7 +4613,7 @@ bool SMESH_Pattern::findBoundaryPoints()
             break; // all boundaries containing key-points are found
 
           // prepare to search for the next boundary
-          boundaryList.push_back( list< TPoint* >() );
+          boundaryList.emplace_back( );
           boundary = & boundaryList.back();
           point2 = keypoint1 = (*keyPointSet.begin());
         }

--- a/src/3rdParty/salomesmesh/src/SMESH/SMESH_subMesh.cpp
+++ b/src/3rdParty/salomesmesh/src/SMESH/SMESH_subMesh.cpp
@@ -2204,7 +2204,7 @@ void SMESH_subMesh::SetEventListener(EventListener*     listener,
 {
   if ( listener && where ) {
     where->setEventListener( listener, data );
-    _ownListeners.push_back( OwnListenerData( where, listener ));
+    _ownListeners.emplace_back( where, listener );
   }
 }
 

--- a/src/3rdParty/salomesmesh/src/StdMeshers/SMESH_MAT2d.cpp
+++ b/src/3rdParty/salomesmesh/src/StdMeshers/SMESH_MAT2d.cpp
@@ -553,7 +553,7 @@ namespace
       Handle(Geom2d_Curve) c2d = BRep_Tool::CurveOnSurface( edges[ iE ], face, f, l );
       if ( c2d.IsNull() ) return false;
 
-      points.push_back( UVU( c2d->Value( f ), f ));
+      points.emplace_back( c2d->Value( f ), f );
       uvBox.Add( points.back()._uv );
 
       Geom2dAdaptor_Curve c2dAdaptor (c2d, f,l );
@@ -595,11 +595,11 @@ namespace
             for ( int iD = 1; iD < nbDiv; ++iD )
             {
               double uD = points.back()._u + dU;
-              points.push_back( UVU( c2d->Value( uD ), uD ));
+              points.emplace_back( c2d->Value( uD ), uD );
             }
             pPrev = p;
           }
-          points.push_back( UVU( c2d->Value( u ), u ));
+          points.emplace_back( c2d->Value( u ), u );
           uvBox.Add( points.back()._uv );
         }
       // if ( !c3d.IsNull() )
@@ -634,7 +634,7 @@ namespace
       // }
       if ( points.size() < 2 )
       {
-        points.push_back( UVU( c2d->Value( l ), l ));
+        points.emplace_back( c2d->Value( l ), l );
         uvBox.Add( points.back()._uv );
       }
       if ( edges[ iE ].Orientation() == TopAbs_REVERSED )
@@ -702,7 +702,7 @@ namespace
         for ( size_t i = points.size()-1; i >= 1; --i )
         {
           inPoints[ iP++ ] = points[i-1].getInPoint( scale );
-          inSegments.push_back( InSegment( & inPoints[ iP-2 ], & inPoints[ iP-1 ], iE ));
+          inSegments.emplace_back( & inPoints[ iP-2 ], & inPoints[ iP-1 ], iE );
         }
       }
     }
@@ -715,7 +715,7 @@ namespace
         for ( size_t i = 1; i < points.size(); ++i )
         {
           inPoints[ iP++ ] = points[i].getInPoint( scale );
-          inSegments.push_back( InSegment( & inPoints[ iP-2 ], & inPoints[ iP-1 ], iE ));
+          inSegments.emplace_back( & inPoints[ iP-2 ], & inPoints[ iP-1 ], iE );
         }
       }
     }
@@ -932,16 +932,16 @@ namespace
         size_t ip0 = inSeg._p0->index( inPoints );
         if ( inPntChecked[ ip0 ] )
           for ( e = inSeg._p0->_edges.rbegin(); e != inSeg._p0->_edges.rend(); ++e )
-            bndSegs.push_back( BndSeg( &inSeg, *e, inSeg._p0->_param ));
+            bndSegs.emplace_back( &inSeg, *e, inSeg._p0->_param );
         inPntChecked[ ip0 ] = false;
 
         // segments of InSegment's
         const size_t nbMaEdges = inSeg._edges.size();
         switch ( nbMaEdges ) {
         case 0: // "around" circle center
-          bndSegs.push_back( BndSeg( &inSeg, 0, inSeg._p1->_param )); break;
+          bndSegs.emplace_back( &inSeg, nullptr, inSeg._p1->_param ); break;
         case 1:
-          bndSegs.push_back( BndSeg( &inSeg, inSeg._edges.back(), inSeg._p1->_param )); break;
+          bndSegs.emplace_back( &inSeg, inSeg._edges.back(), inSeg._p1->_param ); break;
         default:
           gp_XY inSegDir( inSeg._p1->_a - inSeg._p0->_a,
                           inSeg._p1->_b - inSeg._p0->_b );
@@ -953,15 +953,15 @@ namespace
                         (*e)->vertex0()->y() - inSeg._p0->_b );
             double r = toMA * inSegDir / inSegLen2;
             double u = r * inSeg._p1->_param + ( 1. - r ) * inSeg._p0->_param;
-            bndSegs.push_back( BndSeg( &inSeg, *e, u ));
+            bndSegs.emplace_back( &inSeg, *e, u );
           }
-          bndSegs.push_back( BndSeg( &inSeg, *e, inSeg._p1->_param ));
+          bndSegs.emplace_back( &inSeg, *e, inSeg._p1->_param );
         }
         // segments around 2nd concave point
         size_t ip1 = inSeg._p1->index( inPoints );
         if ( inPntChecked[ ip1 ] )
           for ( e = inSeg._p1->_edges.rbegin(); e != inSeg._p1->_edges.rend(); ++e )
-            bndSegs.push_back( BndSeg( &inSeg, *e, inSeg._p1->_param ));
+            bndSegs.emplace_back( &inSeg, *e, inSeg._p1->_param );
         inPntChecked[ ip1 ] = false;
       }
       if ( !bndSegs.empty() )
@@ -1228,7 +1228,7 @@ namespace
           dInd = bndSegs[ i ]._branchID > 0 ? +1 : -1;
         }
 
-        bndPoints._maEdges.push_back( make_pair( br, ( 1 + edgeInd ) * dInd ));
+        bndPoints._maEdges.emplace_back( br, ( 1 + edgeInd ) * dInd );
 
       } // loop on bndSegs of an EDGE
     } // loop on all bndSegs to construct Boundary

--- a/src/3rdParty/salomesmesh/src/StdMeshers/StdMeshers_Cartesian_3D.cpp
+++ b/src/3rdParty/salomesmesh/src/StdMeshers/StdMeshers_Cartesian_3D.cpp
@@ -550,8 +550,7 @@ namespace
             if ( faceToFindEqual->_polyLinks[iL]._nodes[0] == n1 &&
                  faceToFindEqual->_polyLinks[iL]._nodes[1] == n0 )
             {
-              _links.push_back
-                ( _OrientedLink( & faceToFindEqual->_polyLinks[iL], /*reverse=*/true ));
+              _links.emplace_back( & faceToFindEqual->_polyLinks[iL], /*reverse=*/true );
               return;
             }
         }
@@ -559,7 +558,7 @@ namespace
         l._nodes[0] = n0;
         l._nodes[1] = n1;
         _polyLinks.push_back( l );
-        _links.push_back( _OrientedLink( &_polyLinks.back() ));
+        _links.emplace_back( &_polyLinks.back() );
       }
     };
     // --------------------------------------------------------------------------------
@@ -1163,7 +1162,7 @@ namespace
         intersector._intPoints.clear();
         (intersector.*interFunction)( gridLine ); // <- intersection with gridLine
         for ( size_t i = 0; i < intersector._intPoints.size(); ++i )
-          _intersections.push_back( make_pair( &gridLine, intersector._intPoints[i] ));
+          _intersections.emplace_back( &gridLine, intersector._intPoints[i] );
       }
     }
   }
@@ -1557,7 +1556,7 @@ namespace
         link._fIntNodes.resize( link._fIntPoints.size() );
         for ( size_t i = 0; i < link._fIntPoints.size(); ++i )
         {
-          _intNodes.push_back( _Node( 0, link._fIntPoints[i] ));
+          _intNodes.emplace_back( nullptr, link._fIntPoints[i] );
           link._fIntNodes[ i ] = & _intNodes.back();
         }
 
@@ -1620,7 +1619,7 @@ namespace
             equalNode->Add( _eIntPoints[ iP ] );
           }
           else {
-            _intNodes.push_back( _Node( 0, _eIntPoints[ iP ]));
+            _intNodes.emplace_back( nullptr, _eIntPoints[ iP ]);
             quad._eIntNodes.push_back( & _intNodes.back() );
           }
           break;
@@ -1636,7 +1635,7 @@ namespace
           }
           else
           {
-            _intNodes.push_back( _Node( 0, _eIntPoints[ iP ]));
+            _intNodes.emplace_back( nullptr, _eIntPoints[ iP ]);
             for ( int iF = 0; iF < 2; ++iF )
             {
               _Face& quad = _hexQuads[ facets[iF] - SMESH_Block::ID_FirstF ];
@@ -1661,7 +1660,7 @@ namespace
           }
           else
           {
-            _intNodes.push_back( _Node( 0, _eIntPoints[ iP ]));
+            _intNodes.emplace_back( nullptr, _eIntPoints[ iP ]);
             for ( int iF = 0; iF < 3; ++iF )
             {
               _Face& quad = _hexQuads[ facets[iF] - SMESH_Block::ID_FirstF ];
@@ -1687,7 +1686,7 @@ namespace
           }
           else if ( nbFacets == 0 ) {
             if ( _intNodes.empty() || _intNodes.back().EdgeIntPnt() != _eIntPoints[ iP ])
-              _intNodes.push_back( _Node( 0, _eIntPoints[ iP ]));
+              _intNodes.emplace_back( nullptr, _eIntPoints[ iP ]);
             _vIntNodes.push_back( & _intNodes.back() );
           }
         }

--- a/src/3rdParty/salomesmesh/src/StdMeshers/StdMeshers_CompositeHexa_3D.cpp
+++ b/src/3rdParty/salomesmesh/src/StdMeshers/StdMeshers_CompositeHexa_3D.cpp
@@ -1618,7 +1618,7 @@ _FaceSide::_FaceSide(const list<TopoDS_Edge>& edges):
 {
   list<TopoDS_Edge>::const_iterator edge = edges.begin(), eEnd = edges.end();
   for ( ; edge != eEnd; ++edge ) {
-    myChildren.push_back( _FaceSide( *edge ));
+    myChildren.emplace_back( *edge );
     myNbChildren++;
 //     myVertices.insert( myChildren.back().myVertices.begin(),
 //                        myChildren.back().myVertices.end() );

--- a/src/3rdParty/salomesmesh/src/StdMeshers/StdMeshers_FaceSide.cpp
+++ b/src/3rdParty/salomesmesh/src/StdMeshers/StdMeshers_FaceSide.cpp
@@ -389,7 +389,7 @@ const vector<UVPtStruct>& StdMeshers_FaceSide::GetUVPtStruct(bool   isXConst,
               break;
             }
             double normPar = prevNormPar + r * aLenU / myEdgeLength[iE];
-            u2nodeVec.push_back( make_pair( normPar, nodes[i] ));
+            u2nodeVec.emplace_back( normPar, nodes[i] );
           }
         if ( u2nodeVec.empty() )
           for ( size_t i = 0; i < nodes.size(); ++i )
@@ -397,7 +397,7 @@ const vector<UVPtStruct>& StdMeshers_FaceSide::GetUVPtStruct(bool   isXConst,
             double u = eHelper.GetNodeU( myEdge[iE], nodes[i], 0, &paramOK );
             // paramSize is signed so orientation is taken into account
             double normPar = prevNormPar + r * ( u - myFirst[iE] ) / paramSize;
-            u2nodeVec.push_back( make_pair( normPar, nodes[i] ));
+            u2nodeVec.emplace_back( normPar, nodes[i] );
           }
         for ( size_t j = 0; j < u2nodeVec.size(); ++j )
           u2node.insert( u2node.end(), u2nodeVec[j] );

--- a/src/3rdParty/salomesmesh/src/StdMeshers/StdMeshers_HexaFromSkin_3D.cpp
+++ b/src/3rdParty/salomesmesh/src/StdMeshers/StdMeshers_HexaFromSkin_3D.cpp
@@ -418,7 +418,7 @@ namespace
           return error("Non-quadrangle elements in the input mesh");
 
         if ( _allSides.empty() || !_allSides.back()._grid.empty() )
-          _allSides.push_back( _BlockSide() );
+          _allSides.emplace_back( );
 
         _BlockSide& side = _allSides.back();
         if ( !fillSide( side, face, *corner ) )

--- a/src/3rdParty/salomesmesh/src/StdMeshers/StdMeshers_Import_1D.cpp
+++ b/src/3rdParty/salomesmesh/src/StdMeshers/StdMeshers_Import_1D.cpp
@@ -250,7 +250,7 @@ namespace // INTERNAL STUFF
     for ( ; d != dList.end(); ++d )
       if ( d->_srcMesh == srcMesh )
         return &*d;
-    dList.push_back(_ImportData(srcMesh));
+    dList.emplace_back(srcMesh);
     return &dList.back();
   }
 
@@ -679,7 +679,7 @@ bool StdMeshers_Import_1D::Compute(SMESH_Mesh & theMesh, const TopoDS_Shape & th
       //MESSAGE("_gen->Compute " << n);
       if ( !n ) return false; // very strange
     }
-    vertexNodes.push_back( SMESH_TNodeXYZ( n ));
+    vertexNodes.emplace_back( n );
     //MESSAGE("SMESH_Algo::VertexNode " << n->GetID() << " " << n->X() << " " << n->Y() << " " << n->Z() );
   }
 

--- a/src/3rdParty/salomesmesh/src/StdMeshers/StdMeshers_Prism_3D.cpp
+++ b/src/3rdParty/salomesmesh/src/StdMeshers/StdMeshers_Prism_3D.cpp
@@ -2563,7 +2563,7 @@ namespace // utils used by StdMeshers_Prism_3D::IsApplicable()
     for ( nbE = nbEdgesInWires.begin(); nbE != nbEdgesInWires.end(); ++nbE )
     {
       for ( iE = 0; iE < *nbE; ++e, ++iE )
-        edges.push_back( EdgeWithNeighbors( *e, iE, *nbE, nbTot ));
+        edges.emplace_back( *e, iE, *nbE, nbTot );
       nbTot += *nbE;
     }
     return edges.size();

--- a/src/3rdParty/salomesmesh/src/StdMeshers/StdMeshers_ProjectionUtils.cpp
+++ b/src/3rdParty/salomesmesh/src/StdMeshers/StdMeshers_ProjectionUtils.cpp
@@ -721,8 +721,8 @@ bool StdMeshers_ProjectionUtils::FindSubShapeAssociation(const TopoDS_Shape& the
       // association of face sub-shapes and neighbour faces
       list< pair < TopoDS_Face, TopoDS_Edge > > FE1, FE2;
       list< pair < TopoDS_Face, TopoDS_Edge > >::iterator fe1, fe2;
-      FE1.push_back( make_pair( TopoDS::Face( F1 ), edge1 ));
-      FE2.push_back( make_pair( TopoDS::Face( F2 ), edge2 ));
+      FE1.emplace_back( TopoDS::Face( F1 ), edge1 );
+      FE2.emplace_back( TopoDS::Face( F2 ), edge2 );
       for ( fe1 = FE1.begin(), fe2 = FE2.begin(); fe1 != FE1.end(); ++fe1, ++fe2 )
       {
         const TopoDS_Face& face1 = fe1->first;
@@ -760,8 +760,8 @@ bool StdMeshers_ProjectionUtils::FindSubShapeAssociation(const TopoDS_Shape& the
               nextFace1.Reverse();
             if ( SMESH_MesherHelper::GetSubShapeOri( nextFace2, *eIt2 ) == eIt2->Orientation() )
               nextFace2.Reverse();
-            FE1.push_back( make_pair( nextFace1, *eIt1 ));
-            FE2.push_back( make_pair( nextFace2, *eIt2 ));
+            FE1.emplace_back( nextFace1, *eIt1 );
+            FE2.emplace_back( nextFace2, *eIt2 );
           }
         }
       }

--- a/src/3rdParty/salomesmesh/src/StdMeshers/StdMeshers_QuadrangleParams.cpp
+++ b/src/3rdParty/salomesmesh/src/StdMeshers/StdMeshers_QuadrangleParams.cpp
@@ -178,7 +178,7 @@ istream & StdMeshers_QuadrangleParams::LoadFrom(istream & load)
       if ( load >> x &&
            load >> y &&
            load >> z )
-        _enforcedPoints.push_back( gp_Pnt( x,y,z ));
+        _enforcedPoints.emplace_back( x,y,z );
       else
         break;
   }

--- a/src/3rdParty/salomesmesh/src/StdMeshers/StdMeshers_Quadrangle_2D.cpp
+++ b/src/3rdParty/salomesmesh/src/StdMeshers/StdMeshers_Quadrangle_2D.cpp
@@ -1886,7 +1886,7 @@ bool StdMeshers_Quadrangle_2D::computeQuadPref (SMESH_Mesh &        aMesh,
       }
       // Make Cb quad
       FaceQuadStruct* qCb = new FaceQuadStruct( quad->face, "Cb" );
-      myQuadList.push_back( FaceQuadStruct::Ptr( qCb ));
+      myQuadList.emplace_back( qCb );
       qCb->side.resize(4);
       qCb->side[0] = quad->side[0];
       qCb->side[1] = quad->side[1];
@@ -1895,7 +1895,7 @@ bool StdMeshers_Quadrangle_2D::computeQuadPref (SMESH_Mesh &        aMesh,
       qCb->side[1].to = dmin+1;
       // Make L quad
       FaceQuadStruct* qL = new FaceQuadStruct( quad->face, "L" );
-      myQuadList.push_back( FaceQuadStruct::Ptr( qL ));
+      myQuadList.emplace_back( qL );
       qL->side.resize(4);
       qL->side[0] = sideLCb;
       qL->side[1] = sideLCt;
@@ -2059,7 +2059,7 @@ bool StdMeshers_Quadrangle_2D::computeQuadPref (SMESH_Mesh &        aMesh,
     }
     // Make Cb quad
     FaceQuadStruct* qCb = new FaceQuadStruct( quad->face, "Cb" );
-    myQuadList.push_back( FaceQuadStruct::Ptr( qCb ));
+    myQuadList.emplace_back( qCb );
     qCb->side.resize(4);
     qCb->side[0] = quad->side[0];
     qCb->side[1] = sideRCb;
@@ -2067,7 +2067,7 @@ bool StdMeshers_Quadrangle_2D::computeQuadPref (SMESH_Mesh &        aMesh,
     qCb->side[3] = sideLCb;
     // Make L quad
     FaceQuadStruct* qL = new FaceQuadStruct( quad->face, "L" );
-    myQuadList.push_back( FaceQuadStruct::Ptr( qL ));
+    myQuadList.emplace_back( qL );
     qL->side.resize(4);
     qL->side[0] = sideLCb;
     qL->side[1] = sideLCt;
@@ -2076,7 +2076,7 @@ bool StdMeshers_Quadrangle_2D::computeQuadPref (SMESH_Mesh &        aMesh,
     qL->side[2].to = ( lw + 1 ) * dt + tfrom;
     // Make R quad
     FaceQuadStruct* qR = new FaceQuadStruct( quad->face, "R" );
-    myQuadList.push_back( FaceQuadStruct::Ptr( qR ));
+    myQuadList.emplace_back( qR );
     qR->side.resize(4);
     qR->side[0] = sideRCb;
     qR->side[0].from = lw;
@@ -3957,8 +3957,8 @@ void StdMeshers_Quadrangle_2D::smooth (FaceQuadStruct::Ptr quad)
       const int nextInd = myHelper->WrapIndex( nInd + 1, nbN );
       const SMDS_MeshNode* prevNode = face->GetNode( prevInd );
       const SMDS_MeshNode* nextNode = face->GetNode( nextInd );
-      sNode._triangles.push_back( TTriangle( & smooNoMap[ prevNode ],
-                                             & smooNoMap[ nextNode ]));
+      sNode._triangles.emplace_back( & smooNoMap[ prevNode ],
+                                             & smooNoMap[ nextNode ]);
     }
   }
   // set _uv of smooth nodes on FACE boundary
@@ -4999,7 +4999,7 @@ bool StdMeshers_Quadrangle_2D::addEnforcedNodes()
 int StdMeshers_Quadrangle_2D::splitQuad(FaceQuadStruct::Ptr quad, int I, int J)
 {
   FaceQuadStruct* newQuad = new FaceQuadStruct( quad->face );
-  myQuadList.push_back( FaceQuadStruct::Ptr( newQuad ));
+  myQuadList.emplace_back( newQuad );
 
   vector<UVPtStruct> points;
   if ( I > 0 && I <= quad->iSize-2 )

--- a/src/3rdParty/salomesmesh/src/StdMeshers/StdMeshers_ViscousLayers.cpp
+++ b/src/3rdParty/salomesmesh/src/StdMeshers/StdMeshers_ViscousLayers.cpp
@@ -945,7 +945,7 @@ StdMeshers_ViscousLayers::Compute(SMESH_Mesh&         theMesh,
       if ( toMakeN2NMap && !pm->_n2nMapComputed )
         if ( !bulder.MakeN2NMap( pm ))
           return SMESH_ProxyMesh::Ptr();
-      components.push_back( SMESH_ProxyMesh::Ptr( pm ));
+      components.emplace_back( pm );
       pm->myIsDeletable = false; // it will de deleted by boost::shared_ptr
 
       if ( pm->_warning && !pm->_warning->IsOK() )
@@ -1640,7 +1640,7 @@ bool _ViscousBuilder::findSolidsWithLayers()
           _MeshOfSolid* proxyMesh = _ViscousListener::GetSolidMesh( _mesh,
                                                                     allSolids(i),
                                                                     /*toCreate=*/true);
-          _sdVec.push_back( _SolidData( allSolids(i), proxyMesh ));
+          _sdVec.emplace_back( allSolids(i), proxyMesh );
           soData = & _sdVec.back();
           soData->_index = getMeshDS()->ShapeToIndex( allSolids(i));
         }
@@ -1680,7 +1680,7 @@ bool _ViscousBuilder::findFacesWithLayers(const bool onlyWith)
     list< TopoDS_Shape >::iterator hypShape = _sdVec[i]._hypShapes.begin();
     for ( ; hyp != _sdVec[i]._hyps.end(); ++hyp, ++hypShape )
     {
-      ignoreFacesOfHyps.push_back( TFacesOfHyp( set<TGeomID>(), *hyp ));
+      ignoreFacesOfHyps.emplace_back( set<TGeomID>(), *hyp );
       getIgnoreFaces( _sdVec[i]._solid, *hyp, *hypShape, ignoreFacesOfHyps.back().first );
     }
 
@@ -2998,14 +2998,14 @@ bool _ViscousBuilder::setEdgeData(_LayerEdge&         edge,
     if ( eos.SWOLType() == TopAbs_EDGE )
     {
       double u = helper.GetNodeU( TopoDS::Edge( eos._sWOL ), node, 0, &normOK );
-      edge._pos.push_back( gp_XYZ( u, 0, 0 ));
+      edge._pos.emplace_back( u, 0, 0 );
       if ( edge._nodes.size() > 1 )
         getMeshDS()->SetNodeOnEdge( tgtNode, TopoDS::Edge( eos._sWOL ), u );
     }
     else // TopAbs_FACE
     {
       gp_XY uv = helper.GetNodeUV( TopoDS::Face( eos._sWOL ), node, 0, &normOK );
-      edge._pos.push_back( gp_XYZ( uv.X(), uv.Y(), 0));
+      edge._pos.emplace_back( uv.X(), uv.Y(), 0);
       if ( edge._nodes.size() > 1 )
         getMeshDS()->SetNodeOnFace( tgtNode, TopoDS::Face( eos._sWOL ), uv.X(), uv.Y() );
     }
@@ -3445,7 +3445,7 @@ gp_XYZ _LayerEdge::Copy( _LayerEdge&         other,
   if ( eos.SWOLType() == TopAbs_EDGE )
   {
     double u = helper.GetNodeU( TopoDS::Edge( eos._sWOL ), _nodes[0] );
-    _pos.push_back( gp_XYZ( u, 0, 0));
+    _pos.emplace_back( u, 0, 0);
 
     u = helper.GetNodeU( TopoDS::Edge( eos._sWOL ), _nodes.back() );
     lastPos.SetX( u );
@@ -3453,7 +3453,7 @@ gp_XYZ _LayerEdge::Copy( _LayerEdge&         other,
   else // TopAbs_FACE
   {
     gp_XY uv = helper.GetNodeUV( TopoDS::Face( eos._sWOL ), _nodes[0]);
-    _pos.push_back( gp_XYZ( uv.X(), uv.Y(), 0));
+    _pos.emplace_back( uv.X(), uv.Y(), 0);
 
     uv = helper.GetNodeUV( TopoDS::Face( eos._sWOL ), _nodes.back() );
     lastPos.SetX( uv.X() );
@@ -3501,7 +3501,7 @@ void _Simplex::GetSimplices( const SMDS_MeshNode* node,
     const SMDS_MeshNode* nOpp  = f->GetNode( SMESH_MesherHelper::WrapIndex( srcInd+2, nbNodes ));
     if ( dataToCheckOri && dataToCheckOri->_reversedFaceIds.count( shapeInd ))
       std::swap( nPrev, nNext );
-    simplices.push_back( _Simplex( nPrev, nNext, nOpp ));
+    simplices.emplace_back( nPrev, nNext, nOpp );
   }
 
   if ( toSort )

--- a/src/3rdParty/salomesmesh/src/StdMeshers/StdMeshers_ViscousLayers2D.cpp
+++ b/src/3rdParty/salomesmesh/src/StdMeshers/StdMeshers_ViscousLayers2D.cpp
@@ -1513,7 +1513,7 @@ bool _ViscousBuilder2D::fixCollisions()
                 blockedEdgesList.push_back( &LE1 );
                 if ( L1._advancable && newLen2D > 0 )
                 {
-                  edgeLenLimitList.push_back( make_pair( &LE1, newLen2D ));
+                  edgeLenLimitList.emplace_back( &LE1, newLen2D );
                   blockedEdgesList.push_back( &L2._lEdges[ foundSegs[i]->_indexInLine     ]);
                   blockedEdgesList.push_back( &L2._lEdges[ foundSegs[i]->_indexInLine + 1 ]);
                 }
@@ -1526,8 +1526,8 @@ bool _ViscousBuilder2D::fixCollisions()
                   newLen2D = intersection._param2 / 2;
                   if ( newLen2D > 0 )
                   {
-                    edgeLenLimitList.push_back( make_pair( LE2[0], newLen2D ));
-                    edgeLenLimitList.push_back( make_pair( LE2[1], newLen2D ));
+                    edgeLenLimitList.emplace_back( LE2[0], newLen2D );
+                    edgeLenLimitList.emplace_back( LE2[1], newLen2D );
                   }
                 }
               }
@@ -1567,9 +1567,9 @@ bool _ViscousBuilder2D::fixCollisions()
       if ( newLen2DL > 0 && newLen2DR > 0 )
       {
         if ( newLen2DL < 1.1 * LEL._length2D )
-          edgeLenLimitList.push_back( make_pair( &LEL, newLen2DL ));
+          edgeLenLimitList.emplace_back( &LEL, newLen2DL );
         if ( newLen2DR < 1.1 * LER._length2D )
-          edgeLenLimitList.push_back( make_pair( &LER, newLen2DR ));
+          edgeLenLimitList.emplace_back( &LER, newLen2DR );
       }
     }
   }

--- a/src/App/ColorModel.cpp
+++ b/src/App/ColorModel.cpp
@@ -334,8 +334,8 @@ ColorLegend::ColorLegend (void)
 : _bOutsideGrayed(false)
 {
     // default  green, red
-    _aclColorFields.push_back(Color(0, 1, 0));
-    _aclColorFields.push_back(Color(1, 0, 0));
+    _aclColorFields.emplace_back(0, 1, 0);
+    _aclColorFields.emplace_back(1, 0, 0);
 
     _aclNames.push_back("Min");
     _aclNames.push_back("Max");

--- a/src/App/Property.cpp
+++ b/src/App/Property.cpp
@@ -130,7 +130,7 @@ const boost::any Property::getPathValue(const ObjectIdentifier &path) const
 
 void Property::getPaths(std::vector<ObjectIdentifier> &paths) const
 {
-    paths.push_back(App::ObjectIdentifier(getContainer(), getName()));
+    paths.emplace_back(getContainer(), getName());
 }
 
 ObjectIdentifier Property::canonicalPath(const ObjectIdentifier &p) const

--- a/src/App/PropertyExpressionEngine.cpp
+++ b/src/App/PropertyExpressionEngine.cpp
@@ -245,7 +245,7 @@ void PropertyExpressionEngine::buildGraphStructures(const ObjectIdentifier & pat
                     int s = nodes.size();
                     nodes[cPath] = s;
                 }
-                edges.push_back(std::make_pair(nodes[path], nodes[cPath]));
+                edges.emplace_back(nodes[path], nodes[cPath]);
             }
         }
     }

--- a/src/App/PropertyLinks.cpp
+++ b/src/App/PropertyLinks.cpp
@@ -1781,7 +1781,7 @@ void PropertyLinkSubList::setValue(DocumentObject* lValue, const std::vector<str
     if (size == 0) {
         if (lValue) {
             this->_lValueList.push_back(lValue);
-            this->_lSubList.push_back(std::string());
+            this->_lSubList.emplace_back();
         }
     }
     else {
@@ -1893,7 +1893,7 @@ std::vector<PropertyLinkSubList::SubSet> PropertyLinkSubList::getSubListValues(b
             sub = _lSubList[i];
         if (values.size() == 0 || values.back().first != link){
             //new object started, start a new subset.
-            values.push_back(SubSet(link, std::vector<std::string>()));
+            values.emplace_back(link, std::vector<std::string>());
         }
         values.back().second.push_back(sub);
     }

--- a/src/Base/FileInfo.cpp
+++ b/src/Base/FileInfo.cpp
@@ -589,7 +589,7 @@ std::vector<Base::FileInfo> FileInfo::getDirectoryContent(void) const
     {
         std::string dir = dentry->d_name;
         if (dir != "." && dir != "..")
-            List.push_back(FileInfo(FileName + "/" + dir));
+            List.emplace_back(FileName + "/" + dir);
     }
     closedir(dp);
 #else

--- a/src/Base/Parameter.cpp
+++ b/src/Base/Parameter.cpp
@@ -485,9 +485,9 @@ std::vector<std::pair<std::string,bool> > ParameterGrp::GetBoolMap(const char * 
         // check on filter condition
         if (sFilter == NULL || Name.find(sFilter)!= std::string::npos) {
             if (strcmp(StrX(static_cast<DOMElement*>(pcTemp)->getAttribute(XStr("Value").unicodeForm())).c_str(),"1"))
-                vrValues.push_back(std::make_pair(Name, false));
+                vrValues.emplace_back(Name, false);
             else
-                vrValues.push_back(std::make_pair(Name, true));
+                vrValues.emplace_back(Name, true);
         }
         pcTemp = FindNextElement(pcTemp,"FCBool");
     }
@@ -549,8 +549,8 @@ std::vector<std::pair<std::string,long> > ParameterGrp::GetIntMap(const char * s
         Name = StrX(static_cast<DOMElement*>(pcTemp)->getAttributes()->getNamedItem(XStr("Name").unicodeForm())->getNodeValue()).c_str();
         // check on filter condition
         if (sFilter == NULL || Name.find(sFilter)!= std::string::npos) {
-            vrValues.push_back(std::make_pair(Name,
-                               ( atol (StrX(static_cast<DOMElement*>(pcTemp)->getAttribute(XStr("Value").unicodeForm())).c_str()))));
+            vrValues.emplace_back(Name,
+                               ( atol (StrX(static_cast<DOMElement*>(pcTemp)->getAttribute(XStr("Value").unicodeForm())).c_str())));
         }
         pcTemp = FindNextElement(pcTemp,"FCInt") ;
     }
@@ -612,8 +612,8 @@ std::vector<std::pair<std::string,unsigned long> > ParameterGrp::GetUnsignedMap(
         Name = StrX(static_cast<DOMElement*>(pcTemp)->getAttributes()->getNamedItem(XStr("Name").unicodeForm())->getNodeValue()).c_str();
         // check on filter condition
         if (sFilter == NULL || Name.find(sFilter)!= std::string::npos) {
-            vrValues.push_back(std::make_pair(Name,
-                               ( strtoul (StrX(static_cast<DOMElement*>(pcTemp)->getAttribute(XStr("Value").unicodeForm())).c_str(),0,10) )));
+            vrValues.emplace_back(Name,
+                               ( strtoul (StrX(static_cast<DOMElement*>(pcTemp)->getAttribute(XStr("Value").unicodeForm())).c_str(),0,10) ));
         }
         pcTemp = FindNextElement(pcTemp,"FCUInt");
     }
@@ -675,8 +675,8 @@ std::vector<std::pair<std::string,double> > ParameterGrp::GetFloatMap(const char
         Name = StrX(static_cast<DOMElement*>(pcTemp)->getAttributes()->getNamedItem(XStr("Name").unicodeForm())->getNodeValue()).c_str();
         // check on filter condition
         if (sFilter == NULL || Name.find(sFilter)!= std::string::npos) {
-            vrValues.push_back(std::make_pair(Name,
-                               ( atof (StrX(static_cast<DOMElement*>(pcTemp)->getAttribute(XStr("Value").unicodeForm())).c_str()))));
+            vrValues.emplace_back(Name,
+                               ( atof (StrX(static_cast<DOMElement*>(pcTemp)->getAttribute(XStr("Value").unicodeForm())).c_str())));
         }
         pcTemp = FindNextElement(pcTemp,"FCFloat");
     }
@@ -754,7 +754,7 @@ std::vector<std::string> ParameterGrp::GetASCIIs(const char * sFilter) const
             // retrieve the text element
             DOMNode *pcElem2 = pcTemp->getFirstChild();
             if (pcElem2)
-                vrValues.push_back( std::string(StrXUTF8(pcElem2->getNodeValue()).c_str()) );
+                vrValues.emplace_back(StrXUTF8(pcElem2->getNodeValue()).c_str() );
         }
         pcTemp = FindNextElement(pcTemp,"FCText");
     }
@@ -776,7 +776,7 @@ std::vector<std::pair<std::string,std::string> > ParameterGrp::GetASCIIMap(const
             // retrieve the text element
             DOMNode *pcElem2 = pcTemp->getFirstChild();
             if (pcElem2)
-                vrValues.push_back(std::make_pair(Name, std::string(StrXUTF8(pcElem2->getNodeValue()).c_str())));
+                vrValues.emplace_back(Name, std::string(StrXUTF8(pcElem2->getNodeValue()).c_str()));
         }
         pcTemp = FindNextElement(pcTemp,"FCText");
     }

--- a/src/Gui/Document.cpp
+++ b/src/Gui/Document.cpp
@@ -969,7 +969,7 @@ std::vector<std::pair<ViewProviderDocumentObject*,int> > Document::getViewProvid
         if (node->isOfType(SoSeparator::getClassTypeId())) {
             auto it = d->_CoinMap.find(static_cast<SoSeparator*>(node));
             if(it!=d->_CoinMap.end())
-                ret.push_back(std::make_pair(it->second,i));
+                ret.emplace_back(it->second,i);
         }
     }
     return ret;

--- a/src/Gui/NaviCube.cpp
+++ b/src/Gui/NaviCube.cpp
@@ -583,13 +583,13 @@ void NaviCubeImplementation::addFace(const Vector3f& x, const Vector3f& z, int f
 	int t = m_VertexArray.size();
 
 	m_VertexArray.push_back(z - x - y);
-	m_TextureCoordArray.push_back(Vector2f(0, 0));
+	m_TextureCoordArray.emplace_back(0, 0);
 	m_VertexArray.push_back(z + x - y);
-	m_TextureCoordArray.push_back(Vector2f(1, 0));
+	m_TextureCoordArray.emplace_back(1, 0);
 	m_VertexArray.push_back(z + x + y);
-	m_TextureCoordArray.push_back(Vector2f(1, 1));
+	m_TextureCoordArray.emplace_back(1, 1);
 	m_VertexArray.push_back(z - x + y);
-	m_TextureCoordArray.push_back(Vector2f(0, 1));
+	m_TextureCoordArray.emplace_back(0, 1);
 
 	// TEX_TOP, TEX_BACK_FACE, TEX_FRONT_FACE, TEX_TOP
 	// TEX_TOP 			frontTex,

--- a/src/Gui/Selection.cpp
+++ b/src/Gui/Selection.cpp
@@ -530,7 +530,7 @@ std::vector<SelectionObject> SelectionSingleton::getObjectList(const char* pDocN
                 if(resolve && !temp[it->second]._SubNameSet.insert(subelement).second)
                     continue;
                 temp[it->second].SubNames.push_back(subelement);
-                temp[it->second].SelPoses.push_back(Base::Vector3d(sel.x,sel.y,sel.z));
+                temp[it->second].SelPoses.emplace_back(sel.x,sel.y,sel.z);
             }
         }
         else {
@@ -542,7 +542,7 @@ std::vector<SelectionObject> SelectionSingleton::getObjectList(const char* pDocN
             temp.emplace_back(obj);
             if (subelement && *subelement) {
                 temp.back().SubNames.push_back(subelement);
-                temp.back().SelPoses.push_back(Base::Vector3d(sel.x,sel.y,sel.z));
+                temp.back().SelPoses.emplace_back(sel.x,sel.y,sel.z);
                 if(resolve)
                     temp.back()._SubNameSet.insert(subelement);
             }
@@ -617,7 +617,7 @@ int SelectionSingleton::getAsPropertyLinkSubList(App::PropertyLinkSubList &prop)
         const std::vector<std::string> &subnames = selitem.getSubNames();
         if (subnames.size() == 0){//whole object is selected
             objs.push_back(obj);
-            subs.push_back(std::string());
+            subs.emplace_back();
         } else {
             for (std::size_t isub = 0; isub < subnames.size(); isub++) {
                 objs.push_back(obj);
@@ -995,7 +995,7 @@ bool SelectionSingleton::addSelection(const char* pDocName, const char* pObjectN
     if(pickedList) {
         _PickedList.clear();
         for(const auto &sel : *pickedList) {
-            _PickedList.push_back(_SelObj());
+            _PickedList.emplace_back();
             auto &s = _PickedList.back();
             s.DocName = sel.DocName;
             s.FeatName = sel.FeatName;
@@ -1276,7 +1276,7 @@ void SelectionSingleton::rmvSelection(const char* pDocName, const char* pObjectN
     if(pickedList) {
         _PickedList.clear();
         for(const auto &sel : *pickedList) {
-            _PickedList.push_back(_SelObj());
+            _PickedList.emplace_back();
             auto &s = _PickedList.back();
             s.DocName = sel.DocName;
             s.FeatName = sel.FeatName;
@@ -2172,7 +2172,7 @@ PyObject *SelectionSingleton::sGetSelectionObject(PyObject * /*self*/, PyObject 
                 double x = (double)Py::Float(t.getItem(0));
                 double y = (double)Py::Float(t.getItem(1));
                 double z = (double)Py::Float(t.getItem(2));
-                selObj.SelPoses.push_back(Base::Vector3d(x,y,z));
+                selObj.SelPoses.emplace_back(x,y,z);
             }
         }
 

--- a/src/Gui/SelectionObject.cpp
+++ b/src/Gui/SelectionObject.cpp
@@ -52,7 +52,7 @@ SelectionObject::SelectionObject(const Gui::SelectionChanges& msg)
     TypeName = msg.pTypeName ? msg.pTypeName : "";
     if (msg.pSubName) {
         SubNames.push_back(msg.pSubName);
-        SelPoses.push_back(Base::Vector3d(msg.x, msg.y, msg.z));
+        SelPoses.emplace_back(msg.x, msg.y, msg.z);
     }
 }
 

--- a/src/Gui/ViewProvider.cpp
+++ b/src/Gui/ViewProvider.cpp
@@ -612,7 +612,7 @@ std::vector<Base::Vector3d> ViewProvider::getModelPoints(const SoPickedPoint* pp
     // the default implementation just returns the picked point from the visual representation
     std::vector<Base::Vector3d> pts;
     const SbVec3f& vec = pp->getPoint();
-    pts.push_back(Base::Vector3d(vec[0],vec[1],vec[2]));
+    pts.emplace_back(vec[0],vec[1],vec[2]);
     return pts;
 }
 

--- a/src/Mod/Fem/App/FemConstraint.cpp
+++ b/src/Mod/Fem/App/FemConstraint.cpp
@@ -178,7 +178,7 @@ bool Constraint::getPoints(std::vector<Base::Vector3d> &points, std::vector<Base
         if (sh.ShapeType() == TopAbs_VERTEX) {
             const TopoDS_Vertex& vertex = TopoDS::Vertex(sh);
             gp_Pnt p = BRep_Tool::Pnt(vertex);
-            points.push_back(Base::Vector3d(p.X(), p.Y(), p.Z()));
+            points.emplace_back(p.X(), p.Y(), p.Z());
             normals.push_back(NormalDirection.getValue());
             //OvG: Scale by whole object mass in case of a vertex
             GProp_GProps props;
@@ -217,7 +217,7 @@ bool Constraint::getPoints(std::vector<Base::Vector3d> &points, std::vector<Base
             for (int i = 0; i < steps + 1; i++) {
                 // Parameter values must be in the range [fp, lp] (#0003683)
                 gp_Pnt p = curve.Value(fp + i * step);
-                points.push_back(Base::Vector3d(p.X(), p.Y(), p.Z()));
+                points.emplace_back(p.X(), p.Y(), p.Z());
                 normals.push_back(NormalDirection.getValue());
             }
         }
@@ -331,10 +331,10 @@ bool Constraint::getPoints(std::vector<Base::Vector3d> &points, std::vector<Base
                     gp_Pnt p = surface.Value(u, v);
                     BRepClass_FaceClassifier classifier(face, p, Precision::Confusion());
                     if (classifier.State() != TopAbs_OUT) {
-                        points.push_back(Base::Vector3d(p.X(), p.Y(), p.Z()));
+                        points.emplace_back(p.X(), p.Y(), p.Z());
                         props.Normal(u, v,center,normal);
                         normal.Normalize();
-                        normals.push_back(Base::Vector3d(normal.X(), normal.Y(), normal.Z()));
+                        normals.emplace_back(normal.X(), normal.Y(), normal.Z());
                     }
                 }
             }

--- a/src/Mod/Fem/App/FemMesh.cpp
+++ b/src/Mod/Fem/App/FemMesh.cpp
@@ -595,7 +595,7 @@ std::list<std::pair<int, int> > FemMesh::getVolumesByFace(const TopoDS_Face &fac
 
             // For curved faces it is possible that a volume contributes more than one face
             if (element_face_nodes.size() == static_cast<std::size_t>(numNodes)) {
-                result.push_back(std::make_pair(vol->GetID(), face->GetID()));
+                result.emplace_back(vol->GetID(), face->GetID());
             }
         }
     }

--- a/src/Mod/Mesh/App/AppMeshPy.cpp
+++ b/src/Mod/Mesh/App/AppMeshPy.cpp
@@ -460,8 +460,8 @@ private:
         float hy = y/2.0f;
 
         std::vector<MeshCore::MeshGeomFacet> TriaList;
-        TriaList.push_back(MeshCore::MeshGeomFacet(Base::Vector3f(-hx, -hy, 0.0),Base::Vector3f(hx, hy, 0.0),Base::Vector3f(-hx, hy, 0.0)));
-        TriaList.push_back(MeshCore::MeshGeomFacet(Base::Vector3f(-hx, -hy, 0.0),Base::Vector3f(hx, -hy, 0.0),Base::Vector3f(hx, hy, 0.0)));
+        TriaList.emplace_back(Base::Vector3f(-hx, -hy, 0.0),Base::Vector3f(hx, hy, 0.0),Base::Vector3f(-hx, hy, 0.0));
+        TriaList.emplace_back(Base::Vector3f(-hx, -hy, 0.0),Base::Vector3f(hx, -hy, 0.0),Base::Vector3f(hx, hy, 0.0));
 
         std::unique_ptr<MeshObject> mesh(new MeshObject);
         mesh->addFacets(TriaList);

--- a/src/Mod/Mesh/App/Core/Algorithm.cpp
+++ b/src/Mod/Mesh/App/Core/Algorithm.cpp
@@ -498,7 +498,7 @@ void MeshAlgorithm::GetFacetBorders (const std::vector<unsigned long> &raulInd,
         // thus doesn't invalidate the iterator itself, only the referenced object
         if ((pEI == aclEdges.end()) || aclEdges.empty() || (ulLast == ulFirst)) {
             // no further edge found or closed polyline, respectively
-            rclBorders.push_back(std::vector<unsigned long>(clBorder.begin(), clBorder.end()));
+            rclBorders.emplace_back(clBorder.begin(), clBorder.end());
             clBorder.clear();
 
             if (aclEdges.size() > 0) {
@@ -1455,7 +1455,7 @@ bool MeshAlgorithm::CutWithPlane (const Base::Vector3f &clBase, const Base::Vect
 
     // Facet schneiden und Schnittstrecke ablegen
     if (clF.IntersectWithPlane(clBase, clNormal, clE1, clE2) == true)
-      clTempPoly.push_back(std::pair<Base::Vector3f, Base::Vector3f>(clE1, clE2));
+      clTempPoly.emplace_back(clE1, clE2);
   }
 
   if(bConnectPolygons)
@@ -1574,7 +1574,7 @@ bool MeshAlgorithm::ConnectLines (std::list<std::pair<Base::Vector3f, Base::Vect
         }
         while (bFoundLine);
 
-        rclPolylines.push_back(std::vector<Base::Vector3f>(clPoly.begin(), clPoly.end()));
+        rclPolylines.emplace_back(clPoly.begin(), clPoly.end());
     }
 
     // remove all polylines with too few length

--- a/src/Mod/Mesh/App/Core/Evaluation.cpp
+++ b/src/Mod/Mesh/App/Core/Evaluation.cpp
@@ -373,7 +373,7 @@ bool MeshEvalTopology::Evaluate ()
         else {
             if (count > 2) {
                 // Edge that is shared by more than 2 facets
-                nonManifoldList.push_back(std::make_pair(p0, p1));
+                nonManifoldList.emplace_back(p0, p1);
                 nonManifoldFacets.push_back(facets);
             }
 
@@ -681,7 +681,7 @@ void MeshEvalSelfIntersection::GetIntersections(const std::vector<std::pair<unsi
         if (box1 && box2) {
             int ret = cMF1->IntersectWithFacet(*cMF2, pt1, pt2);
             if (ret == 2) {
-                intersection.push_back(std::make_pair(pt1, pt2));
+                intersection.emplace_back(pt1, pt2);
             }
         }
     }
@@ -749,7 +749,7 @@ void MeshEvalSelfIntersection::GetIntersections(std::vector<std::pair<unsigned l
                     facet2 = *cMFI;
                     int ret = facet1.IntersectWithFacet(facet2, pt1, pt2);
                     if (ret == 2) {
-                        intersection.push_back(std::make_pair (*it,*jt));
+                        intersection.emplace_back (*it,*jt);
                     }
                 }
             }

--- a/src/Mod/Mesh/App/Core/MeshIO.cpp
+++ b/src/Mod/Mesh/App/Core/MeshIO.cpp
@@ -378,7 +378,7 @@ bool MeshInput::LoadOBJ (std::istream &rstrIn)
         }
         else if (boost::regex_match(line.c_str(), what, rx_u)) {
             if (!materialName.empty()) {
-                _materialNames.push_back(std::make_pair(materialName, countMaterialFacets));
+                _materialNames.emplace_back(materialName, countMaterialFacets);
             }
             materialName = Base::Tools::escapedUnicodeToUtf8(what[1].first);
             countMaterialFacets = 0;
@@ -441,7 +441,7 @@ bool MeshInput::LoadOBJ (std::istream &rstrIn)
 
     // Add the last added material name
     if (!materialName.empty()) {
-        _materialNames.push_back(std::make_pair(materialName, countMaterialFacets));
+        _materialNames.emplace_back(materialName, countMaterialFacets);
     }
 
     // now get back the colors from the vertex property
@@ -679,7 +679,7 @@ bool MeshInput::LoadOFF (std::istream &rstrIn)
                     float fg = static_cast<float>(g)/255.0f;
                     float fb = static_cast<float>(b)/255.0f;
                     float fa = static_cast<float>(a)/255.0f;
-                    _material->diffuseColor.push_back(App::Color(fr, fg, fb, fa));
+                    _material->diffuseColor.emplace_back(fr, fg, fb, fa);
                 }
                 meshPoints.push_back(MeshPoint(Base::Vector3f(fX, fY, fZ)));
                 cntPoints++;
@@ -893,7 +893,7 @@ bool MeshInput::LoadPLY (std::istream &inp)
                 }
 
                 // store the property name and type
-                vertex_props.push_back(std::make_pair(name, number));
+                vertex_props.emplace_back(name, number);
             }
             else if (element == "face") {
                 std::string list, uchr;
@@ -1064,7 +1064,7 @@ bool MeshInput::LoadPLY (std::istream &inp)
                 float r = (prop_values["red"]) / 255.0f;
                 float g = (prop_values["green"]) / 255.0f;
                 float b = (prop_values["blue"]) / 255.0f;
-                _material->diffuseColor.push_back(App::Color(r, g, b));
+                _material->diffuseColor.emplace_back(r, g, b);
             }
         }
 
@@ -1146,7 +1146,7 @@ bool MeshInput::LoadPLY (std::istream &inp)
                 float r = (prop_values["red"]) / 255.0f;
                 float g = (prop_values["green"]) / 255.0f;
                 float b = (prop_values["blue"]) / 255.0f;
-                _material->diffuseColor.push_back(App::Color(r, g, b));
+                _material->diffuseColor.emplace_back(r, g, b);
             }
         }
 

--- a/src/Mod/Mesh/App/Core/Projection.cpp
+++ b/src/Mod/Mesh/App/Core/Projection.cpp
@@ -185,23 +185,23 @@ bool MeshProjection::projectLineOnMesh(const MeshFacetGrid& grid,
                         continue;
                     }
 
-                    cutLine.push_back(std::pair<Base::Vector3f, Base::Vector3f>(e1, e2));
+                    cutLine.emplace_back(e1, e2);
                 }
                 else {
                     if (*it == f1) { // start facet
                         if (((e2 - v1) * dir) > 0.0f)
-                            cutLine.push_back(std::pair<Base::Vector3f, Base::Vector3f>(v1, e2));
+                            cutLine.emplace_back(v1, e2);
                         else
-                            cutLine.push_back(std::pair<Base::Vector3f, Base::Vector3f>(v1, e1));
+                            cutLine.emplace_back(v1, e1);
 
                         //start = it - facets.begin();
                     }
 
                     if (*it == f2) { // end facet
                         if (((e2 - v2) * -dir) > 0.0f)
-                            cutLine.push_back(std::pair<Base::Vector3f, Base::Vector3f>(v2, e2));
+                            cutLine.emplace_back(v2, e2);
                         else
-                            cutLine.push_back(std::pair<Base::Vector3f, Base::Vector3f>(v2, e1));
+                            cutLine.emplace_back(v2, e1);
 
                         //end = it - facets.begin();
                     }

--- a/src/Mod/Mesh/App/Core/TopoAlgorithm.cpp
+++ b/src/Mod/Mesh/App/Core/TopoAlgorithm.cpp
@@ -425,7 +425,7 @@ void MeshTopoAlgorithm::AdjustEdgesToCurvatureDirection()
   MeshPointIterator cPIt( _rclMesh );
   aPnts.reserve(_rclMesh.CountPoints());
   for ( cPIt.Init(); cPIt.More(); cPIt.Next() )
-    aPnts.push_back( Wm4::Vector3<float>( cPIt->x, cPIt->y, cPIt->z ) );
+    aPnts.emplace_back( cPIt->x, cPIt->y, cPIt->z );
 
   // get all point connections
   std::vector<int> aIdx;

--- a/src/Mod/Mesh/App/Core/Triangulation.cpp
+++ b/src/Mod/Mesh/App/Core/Triangulation.cpp
@@ -648,7 +648,7 @@ bool DelaunayTriangulator::Triangulate()
     std::vector<Wm4::Vector2d> akVertex;
     akVertex.reserve(_points.size());
     for (std::vector<Base::Vector3f>::iterator it = _points.begin(); it != _points.end(); ++it) {
-        akVertex.push_back(Wm4::Vector2d(static_cast<double>(it->x), static_cast<double>(it->y)));
+        akVertex.emplace_back(static_cast<double>(it->x), static_cast<double>(it->y));
     }
 
     Wm4::Delaunay2d del(static_cast<int>(akVertex.size()), &(akVertex[0]), 0.001, false, Wm4::Query::QT_INT64);

--- a/src/Mod/Mesh/App/Mesh.cpp
+++ b/src/Mod/Mesh/App/Mesh.cpp
@@ -458,7 +458,7 @@ void MeshObject::swapKernel(MeshCore::MeshKernel& kernel,
         if (prop < it->_ulProp) {
             prop = it->_ulProp;
             if (!segment.empty()) {
-                this->_segments.push_back(Segment(this,segment,true));
+                this->_segments.emplace_back(this,segment,true);
                 segment.clear();
             }
         }
@@ -468,7 +468,7 @@ void MeshObject::swapKernel(MeshCore::MeshKernel& kernel,
 
     // if the whole mesh is a single object then don't mark as segment
     if (!segment.empty() && (segment.size() < faces.size())) {
-        this->_segments.push_back(Segment(this,segment,true));
+        this->_segments.emplace_back(this,segment,true);
     }
 
     // apply the group names to the segments
@@ -1213,7 +1213,7 @@ void MeshObject::splitEdges()
             if (!pF->IsFlag(MeshCore::MeshFacet::VISIT) && !rFace.IsFlag(MeshCore::MeshFacet::VISIT)) {
                 pF->SetFlag(MeshCore::MeshFacet::VISIT);
                 rFace.SetFlag(MeshCore::MeshFacet::VISIT);
-                adjacentFacet.push_back(std::make_pair(pF-rFacets.begin(), pF->_aulNeighbours[id]));
+                adjacentFacet.emplace_back(pF-rFacets.begin(), pF->_aulNeighbours[id]);
             }
         }
     }
@@ -1368,7 +1368,7 @@ void MeshObject::removeSelfIntersections(const std::vector<unsigned long>& indic
     for (it = indices.begin(); it != indices.end(); ) {
         unsigned long id1 = *it; ++it;
         unsigned long id2 = *it; ++it;
-        selfIntersections.push_back(std::make_pair(id1,id2));
+        selfIntersections.emplace_back(id1,id2);
     }
 
     if (!selfIntersections.empty()) {
@@ -1747,7 +1747,7 @@ void MeshObject::addSegment(const std::vector<unsigned long>& inds)
             throw Base::IndexError("Index out of range");
     }
 
-    this->_segments.push_back(Segment(this,inds,true));
+    this->_segments.emplace_back(this,inds,true);
 }
 
 const Segment& MeshObject::getSegment(unsigned long index) const
@@ -1810,7 +1810,7 @@ std::vector<Segment> MeshObject::getSegmentsOfType(MeshObject::GeometryType type
 
         const std::vector<MeshCore::MeshSegment>& data = surf->GetSegments();
         for (std::vector<MeshCore::MeshSegment>::const_iterator it = data.begin(); it != data.end(); ++it) {
-            segm.push_back(Segment(const_cast<MeshObject*>(this), *it, false));
+            segm.emplace_back(const_cast<MeshObject*>(this), *it, false);
         }
     }
 

--- a/src/Mod/Mesh/App/MeshPyImp.cpp
+++ b/src/Mod/Mesh/App/MeshPyImp.cpp
@@ -248,7 +248,7 @@ PyObject*  MeshPy::write(PyObject *args, PyObject *kwds)
                 float r = (float)Py::Float(t.getItem(0));
                 float g = (float)Py::Float(t.getItem(1));
                 float b = (float)Py::Float(t.getItem(2));
-                mat.diffuseColor.push_back(App::Color(r,g,b));
+                mat.diffuseColor.emplace_back(r,g,b);
             }
 
             if (mat.diffuseColor.size() == getMeshObjectPtr()->countPoints())
@@ -288,7 +288,7 @@ PyObject*  MeshPy::write(PyObject *args, PyObject *kwds)
                 float r = (float)Py::Float(t.getItem(0));
                 float g = (float)Py::Float(t.getItem(1));
                 float b = (float)Py::Float(t.getItem(2));
-                mat->diffuseColor.push_back(App::Color(r,g,b));
+                mat->diffuseColor.emplace_back(r,g,b);
             }
 
             if (mat->diffuseColor.size() == getMeshObjectPtr()->countPoints())
@@ -324,7 +324,7 @@ PyObject*  MeshPy::writeInventor(PyObject *args)
     std::vector<Base::Vector3f> coords;
     coords.reserve(mesh->countPoints());
     for (MeshObject::const_point_iterator it = mesh->points_begin(); it != mesh->points_end(); ++it)
-        coords.push_back(Base::Vector3f((float)it->x,(float)it->y,(float)it->z));
+        coords.emplace_back((float)it->x,(float)it->y,(float)it->z);
     indices.reserve(4*faces.size());
     for (MeshCore::MeshFacetArray::_TConstIterator it = faces.begin(); it != faces.end(); ++it) {
         indices.push_back(it->_aulPoints[0]);
@@ -710,7 +710,7 @@ PyObject*  MeshPy::addFacets(PyObject *args)
         for (Py::List::iterator it = list_v.begin(); it != list_v.end(); ++it) {
             if ((*it).isType(vType)) {
                 Base::Vector3d v = static_cast<Base::VectorPy*>((*it).ptr())->value();
-                vertices.push_back(Base::Vector3f((float)v.x,(float)v.y,(float)v.z));
+                vertices.emplace_back((float)v.x,(float)v.y,(float)v.z);
             }
         }
 

--- a/src/Mod/Mesh/Gui/SoFCIndexedFaceSet.cpp
+++ b/src/Mod/Mesh/Gui/SoFCIndexedFaceSet.cpp
@@ -970,8 +970,7 @@ void SoFCIndexedFaceSet::stopSelection(SoAction * action)
     GLint index=0;
     for (GLint ii=0;ii<hits && index<bufSize;ii++) {
         GLint ct = (GLint)selectBuf[index];
-        hit.push_back(std::pair<double,unsigned int>
-            (selectBuf[index+1]/4294967295.0,selectBuf[index+3]));
+        hit.emplace_back(selectBuf[index+1]/4294967295.0,selectBuf[index+3]);
         index = index+ct+3;
     }
 

--- a/src/Mod/Mesh/Gui/SoFCMeshObject.cpp
+++ b/src/Mod/Mesh/Gui/SoFCMeshObject.cpp
@@ -1046,8 +1046,7 @@ void SoFCMeshObjectShape::stopSelection(SoAction * action, const Mesh::MeshObjec
     GLuint index=0;
     for (GLint ii=0;ii<hits && index<bufSize;ii++) {
         GLint ct = (GLint)selectBuf[index];
-        hit.push_back(std::pair<double,unsigned int>
-            (selectBuf[index+1]/4294967295.0,selectBuf[index+3]));
+        hit.emplace_back(selectBuf[index+1]/4294967295.0,selectBuf[index+3]);
         index = index+ct+3;
     }
 

--- a/src/Mod/Mesh/Gui/ViewProvider.cpp
+++ b/src/Mod/Mesh/Gui/ViewProvider.cpp
@@ -708,7 +708,7 @@ void ViewProviderMesh::exportMesh(const char* filename, const char* fmt) const
     mat.diffuseColor.reserve(numColors);
     for (int i=0; i<numColors; i++) {
         const SbColor& c = colors[i];
-        mat.diffuseColor.push_back(App::Color(c[0], c[1], c[2]));
+        mat.diffuseColor.emplace_back(c[0], c[1], c[2]);
     }
 
     Mesh::MeshObject mesh = static_cast<Mesh::Feature*>(getObject())->Mesh.getValue();
@@ -800,12 +800,12 @@ bool ViewProviderMesh::createToolMesh(const std::vector<SbVec2f>& rclPoly, const
 
         if (it+1 < rclPoly.end()) {
             pt1.getValue(fX, fY, fZ);
-            top.push_back( Base::Vector3f(fX, fY, fZ) );
+            top.emplace_back(fX, fY, fZ );
             pt2.getValue(fX, fY, fZ);
-            bottom.push_back( Base::Vector3f(fX, fY, fZ) );
+            bottom.emplace_back(fX, fY, fZ );
             // polygon we need to triangulate (in x,y-plane)
             it->getValue(fX, fY);
-            polygon.push_back( Base::Vector3f(fX, fY, 0.0f) );
+            polygon.emplace_back(fX, fY, 0.0f );
         }
     }
 

--- a/src/Mod/Mesh/Gui/ViewProviderDefects.cpp
+++ b/src/Mod/Mesh/Gui/ViewProviderDefects.cpp
@@ -646,7 +646,7 @@ void ViewProviderMeshSelfIntersections::showDefects(const std::vector<unsigned l
     for (it = indices.begin(); it != indices.end(); ) {
         unsigned long id1 = *it; ++it;
         unsigned long id2 = *it; ++it;
-        intersection.push_back(std::make_pair(id1,id2));
+        intersection.emplace_back(id1,id2);
     }
 
     std::vector<std::pair<Base::Vector3f, Base::Vector3f> > lines;

--- a/src/Mod/Mesh/Gui/ViewProviderTransformDemolding.cpp
+++ b/src/Mod/Mesh/Gui/ViewProviderTransformDemolding.cpp
@@ -141,7 +141,7 @@ void ViewProviderMeshTransformDemolding::calcNormalVector(void)
     const MeshGeomFacet& rFace = *cFIt;
 
     Base::Vector3f norm(rFace.GetNormal());
-    normalVector.push_back(SbVec3f(norm.x,norm.y,norm.z));
+    normalVector.emplace_back(norm.x,norm.y,norm.z);
   }
 }
 

--- a/src/Mod/MeshPart/App/CurveProjector.cpp
+++ b/src/Mod/MeshPart/App/CurveProjector.cpp
@@ -301,9 +301,9 @@ void CurveProjectorSimple::GetSampledCurves( const TopoDS_Edge& aEdge, std::vect
     for (unsigned long i = 0; i < ulNbOfPoints; i++)
     {
       gp_Pnt gpPt = hCurve->Value(fBegin + (fLen * float(i)) / float(ulNbOfPoints-1));
-      rclPoints.push_back(Base::Vector3f((float)gpPt.X(),
+      rclPoints.emplace_back((float)gpPt.X(),
                                          (float)gpPt.Y(),
-                                         (float)gpPt.Z()));
+                                         (float)gpPt.Z());
     }
 }
 
@@ -670,10 +670,10 @@ void CurveProjectorWithToolMesh::makeToolMesh( const TopoDS_Edge& aEdge,std::vec
       p5 = (*It2).p + ((*It2).n * (-ToolSize));
       p6 = (*It2).p + ((*It2).n *  ToolSize);
 
-      cVAry.push_back(MeshGeomFacet(p3,p2,p6));
-      cVAry.push_back(MeshGeomFacet(p3,p6,p4));
-      cVAry.push_back(MeshGeomFacet(p1,p3,p4));
-      cVAry.push_back(MeshGeomFacet(p1,p4,p5));
+      cVAry.emplace_back(p3,p2,p6);
+      cVAry.emplace_back(p3,p6,p4);
+      cVAry.emplace_back(p1,p3,p4);
+      cVAry.emplace_back(p1,p4,p5);
 
     }
 
@@ -705,7 +705,7 @@ void MeshProjection::discretize(const TopoDS_Edge& aEdge, std::vector<Base::Vect
         Standard_Integer nNbPoints = clDefl.NbPoints();
         for (Standard_Integer i = 1; i <= nNbPoints; i++) {
             gp_Pnt gpPt = clCurve.Value(clDefl.Parameter(i));
-            polyline.push_back( Base::Vector3f( (float)gpPt.X(), (float)gpPt.Y(), (float)gpPt.Z() ) );
+            polyline.emplace_back( (float)gpPt.X(), (float)gpPt.Y(), (float)gpPt.Z() );
         }
     }
 
@@ -716,7 +716,7 @@ void MeshProjection::discretize(const TopoDS_Edge& aEdge, std::vector<Base::Vect
             Standard_Integer nNbPoints = clAbsc.NbPoints();
             for (Standard_Integer i = 1; i <= nNbPoints; i++) {
                 gp_Pnt gpPt = clCurve.Value(clAbsc.Parameter(i));
-                polyline.push_back( Base::Vector3f( (float)gpPt.X(), (float)gpPt.Y(), (float)gpPt.Z() ) );
+                polyline.emplace_back( (float)gpPt.X(), (float)gpPt.Y(), (float)gpPt.Z() );
             }
         }
     }
@@ -951,12 +951,12 @@ void MeshProjection::projectParallelToMesh (const TopoDS_Shape &aShape, const Ba
             Base::Vector3f result;
             unsigned long index;
             if (clAlg.NearestFacetOnRay(it, dir, cGrid, result, index)) {
-                hitPoints.push_back(std::make_pair(result, index));
+                hitPoints.emplace_back(result, index);
 
                 if (hitPoints.size() > 1) {
                     HitPoint p1 = hitPoints[hitPoints.size()-2];
                     HitPoint p2 = hitPoints[hitPoints.size()-1];
-                    hitPointPairs.push_back(std::make_pair(p1, p2));
+                    hitPointPairs.emplace_back(p1, p2);
                 }
             }
         }
@@ -996,12 +996,12 @@ void MeshProjection::projectParallelToMesh (const std::vector<PolyLine> &aEdges,
             Base::Vector3f result;
             unsigned long index;
             if (clAlg.NearestFacetOnRay(it, dir, cGrid, result, index)) {
-                hitPoints.push_back(std::make_pair(result, index));
+                hitPoints.emplace_back(result, index);
 
                 if (hitPoints.size() > 1) {
                     HitPoint p1 = hitPoints[hitPoints.size()-2];
                     HitPoint p2 = hitPoints[hitPoints.size()-1];
-                    hitPointPairs.push_back(std::make_pair(p1, p2));
+                    hitPointPairs.emplace_back(p1, p2);
                 }
             }
         }

--- a/src/Mod/MeshPart/App/MeshAlgos.cpp
+++ b/src/Mod/MeshPart/App/MeshAlgos.cpp
@@ -571,8 +571,8 @@ void MeshAlgos::LoftOnCurve(MeshCore::MeshKernel &ResultMesh, const TopoDS_Shape
                      p3 = prePoint[l],
                      p4 = actPoint[l];
 
-            cVAry.push_back(MeshGeomFacet(p1,p2,p3));
-            cVAry.push_back(MeshGeomFacet(p3,p2,p4));
+            cVAry.emplace_back(p1,p2,p3);
+            cVAry.emplace_back(p3,p2,p4);
           }
         }
       }

--- a/src/Mod/MeshPart/Gui/CurveOnMesh.cpp
+++ b/src/Mod/MeshPart/Gui/CurveOnMesh.cpp
@@ -507,9 +507,9 @@ void CurveOnMeshHandler::approximateEdge(const TopoDS_Edge& edge, double toleran
         pts.reserve(numNodes);
         for (int i=aNodes.Lower(); i<=aNodes.Upper(); i++) {
             const gp_Pnt& p = aNodes.Value(i);
-            pts.push_back(SbVec3f(static_cast<float>(p.X()),
+            pts.emplace_back(static_cast<float>(p.X()),
                                   static_cast<float>(p.Y()),
-                                  static_cast<float>(p.Z())));
+                                  static_cast<float>(p.Z()));
         }
 
         d_ptr->curve->setPoints(pts);

--- a/src/Mod/Part/App/AppPartPy.cpp
+++ b/src/Mod/Part/App/AppPartPy.cpp
@@ -152,15 +152,15 @@ PartExport void getPyShapes(PyObject *obj, std::vector<TopoShape> &shapes) {
     if(PyObject_TypeCheck(obj,&Part::TopoShapePy::Type))
         shapes.push_back(*static_cast<TopoShapePy*>(obj)->getTopoShapePtr());
     else if (PyObject_TypeCheck(obj, &GeometryPy::Type)) 
-        shapes.push_back(TopoShape(static_cast<GeometryPy*>(obj)->getGeometryPtr()->toShape()));
+        shapes.emplace_back(static_cast<GeometryPy*>(obj)->getGeometryPtr()->toShape());
     else if(PySequence_Check(obj)) {
         Py::Sequence list(obj);
         for (Py::Sequence::iterator it = list.begin(); it != list.end(); ++it) {
             if (PyObject_TypeCheck((*it).ptr(), &(Part::TopoShapePy::Type)))
                 shapes.push_back(*static_cast<TopoShapePy*>((*it).ptr())->getTopoShapePtr());
             else if (PyObject_TypeCheck((*it).ptr(), &GeometryPy::Type)) 
-                shapes.push_back(TopoShape(static_cast<GeometryPy*>(
-                                (*it).ptr())->getGeometryPtr()->toShape()));
+                shapes.emplace_back(static_cast<GeometryPy*>(
+                                (*it).ptr())->getGeometryPtr()->toShape());
             else
                 throw Py::TypeError("expect shape in sequence");
         }

--- a/src/Mod/Part/App/Attacher.cpp
+++ b/src/Mod/Part/App/Attacher.cpp
@@ -821,7 +821,7 @@ void AttachEngine::readLinks(const App::PropertyLinkSubList &references,
             shapes[i] = &(storage[storage.size()-1]);
         } else {
             Base::Console().Warning("Attacher: linked object %s is unexpected, assuming it has no shape.\n",geof->getNameInDocument());
-            storage.push_back(TopoDS_Shape());
+            storage.emplace_back();
             shapes[i] = &(storage[storage.size()-1]);
         }
 

--- a/src/Mod/Part/App/BRepOffsetAPI_MakeOffsetFix.cpp
+++ b/src/Mod/Part/App/BRepOffsetAPI_MakeOffsetFix.cpp
@@ -82,7 +82,7 @@ void BRepOffsetAPI_MakeOffsetFix::AddWire(const TopoDS_Wire& Spine)
             edgeLocation = edge.Location();
             edge.Location(TopLoc_Location());
             mkWire.Add(edge);
-            myLocations.push_back(std::make_pair(edge, edgeLocation));
+            myLocations.emplace_back(edge, edgeLocation);
             xp.Next();
         }
 

--- a/src/Mod/Part/App/BSplineCurvePyImp.cpp
+++ b/src/Mod/Part/App/BSplineCurvePyImp.cpp
@@ -926,7 +926,7 @@ PyObject* BSplineCurvePy::getCardinalSplineTangents(PyObject *args, PyObject *kw
         for (Py::Sequence::iterator it = list.begin(); it != list.end(); ++it) {
             Py::Vector v(*it);
             Base::Vector3d pnt = v.toVector();
-            interpPoints.push_back(gp_Pnt(pnt.x,pnt.y,pnt.z));
+            interpPoints.emplace_back(pnt.x,pnt.y,pnt.z);
         }
 
         GeomBSplineCurve* bspline = this->getGeomBSplineCurvePtr();
@@ -948,7 +948,7 @@ PyObject* BSplineCurvePy::getCardinalSplineTangents(PyObject *args, PyObject *kw
         for (Py::Sequence::iterator it = list.begin(); it != list.end(); ++it) {
             Py::Vector v(*it);
             Base::Vector3d pnt = v.toVector();
-            interpPoints.push_back(gp_Pnt(pnt.x,pnt.y,pnt.z));
+            interpPoints.emplace_back(pnt.x,pnt.y,pnt.z);
         }
 
         Py::Sequence list2(tgs);

--- a/src/Mod/Part/App/Geom2d/BSplineCurve2dPyImp.cpp
+++ b/src/Mod/Part/App/Geom2d/BSplineCurve2dPyImp.cpp
@@ -925,7 +925,7 @@ PyObject* BSplineCurve2dPy::getCardinalSplineTangents(PyObject *args, PyObject *
         interpPoints.reserve(list.size());
         for (Py::Sequence::iterator it = list.begin(); it != list.end(); ++it) {
             Base::Vector2d pnt = Py::toVector2d(*it);
-            interpPoints.push_back(gp_Pnt2d(pnt.x,pnt.y));
+            interpPoints.emplace_back(pnt.x,pnt.y);
         }
 
         Geom2dBSplineCurve* bspline = this->getGeom2dBSplineCurvePtr();
@@ -952,7 +952,7 @@ PyObject* BSplineCurve2dPy::getCardinalSplineTangents(PyObject *args, PyObject *
         interpPoints.reserve(list.size());
         for (Py::Sequence::iterator it = list.begin(); it != list.end(); ++it) {
             Base::Vector2d pnt = Py::toVector2d(*it);
-            interpPoints.push_back(gp_Pnt2d(pnt.x,pnt.y));
+            interpPoints.emplace_back(pnt.x,pnt.y);
         }
 
         Py::Sequence list2(tgs);

--- a/src/Mod/Part/App/Geometry.cpp
+++ b/src/Mod/Part/App/Geometry.cpp
@@ -887,7 +887,7 @@ std::vector<Base::Vector3d> GeomBezierCurve::getPoles() const
 
     for (Standard_Integer i=p.Lower(); i<=p.Upper(); i++) {
         const gp_Pnt& pnt = p(i);
-        poles.push_back(Base::Vector3d(pnt.X(), pnt.Y(), pnt.Z()));
+        poles.emplace_back(pnt.X(), pnt.Y(), pnt.Z());
     }
     return poles;
 }
@@ -1121,7 +1121,7 @@ std::vector<Base::Vector3d> GeomBSplineCurve::getPoles() const
 
     for (Standard_Integer i=p.Lower(); i<=p.Upper(); i++) {
         const gp_Pnt& pnt = p(i);
-        poles.push_back(Base::Vector3d(pnt.X(), pnt.Y(), pnt.Z()));
+        poles.emplace_back(pnt.X(), pnt.Y(), pnt.Z());
     }
     return poles;
 }

--- a/src/Mod/Part/App/Geometry2d.cpp
+++ b/src/Mod/Part/App/Geometry2d.cpp
@@ -466,7 +466,7 @@ std::vector<Base::Vector2d> Geom2dBSplineCurve::getPoles() const
 
     for (Standard_Integer i=p.Lower(); i<=p.Upper(); i++) {
         const gp_Pnt2d& pnt = p(i);
-        poles.push_back(Base::Vector2d(pnt.X(), pnt.Y()));
+        poles.emplace_back(pnt.X(), pnt.Y());
     }
     return poles;
 }

--- a/src/Mod/Part/App/Part2DObject.cpp
+++ b/src/Mod/Part/App/Part2DObject.cpp
@@ -165,8 +165,8 @@ bool Part2DObject::seekTrimPoints(const std::vector<Geometry *> &geomlist,
 
                     Part::GeomBoundedCurve * bcurve = static_cast<Part::GeomBoundedCurve *>(geomlist[id]);
 
-                    points.push_back(gp_Pnt2d (bcurve->getStartPoint().x,bcurve->getStartPoint().y));
-                    points.push_back(gp_Pnt2d (bcurve->getEndPoint().x,bcurve->getEndPoint().y));
+                    points.emplace_back(bcurve->getStartPoint().x,bcurve->getStartPoint().y);
+                    points.emplace_back(bcurve->getEndPoint().x,bcurve->getEndPoint().y);
                 }
 
                 Intersector.Init(primaryCurve, secondaryCurve, 1.0e-12);

--- a/src/Mod/Part/App/TopoShape.cpp
+++ b/src/Mod/Part/App/TopoShape.cpp
@@ -3206,7 +3206,7 @@ void TopoShape::getDomains(std::vector<Domain>& domains) const
             p.Transform(loc.Transformation());
             Standard_Real X, Y, Z;
             p.Coord (X, Y, Z);
-            domain.points.push_back(Base::Vector3d(X, Y, Z));
+            domain.points.emplace_back(X, Y, Z);
         }
 
         // copy the triangles
@@ -3424,7 +3424,7 @@ void TopoShape::getPoints(std::vector<Base::Vector3d> &Points,
     for (TopExp_Explorer xp(_Shape, TopAbs_VERTEX, TopAbs_EDGE); xp.More(); xp.Next()) {
         gp_Pnt p = BRep_Tool::Pnt(TopoDS::Vertex(xp.Current()));
         Points.push_back(Base::convertTo<Base::Vector3d>(p));
-        Normals.push_back(Base::Vector3d(0,0,0));
+        Normals.emplace_back(0,0,0);
     }
 
     // sample inner points of all free edges
@@ -3436,7 +3436,7 @@ void TopoShape::getPoints(std::vector<Base::Vector3d> &Points,
             for (int i=1; i<=nbPoints; i++) {
                 gp_Pnt p = curve.Value (discretizer.Parameter(i));
                 Points.push_back(Base::convertTo<Base::Vector3d>(p));
-                Normals.push_back(Base::Vector3d(0,0,0));
+                Normals.emplace_back(0,0,0);
             }
         }
     }
@@ -3510,7 +3510,7 @@ void TopoShape::getPoints(std::vector<Base::Vector3d> &Points,
                         Normals.push_back(Base::convertTo<Base::Vector3d>(normal));
                     }
                     else {
-                        Normals.push_back(Base::Vector3d(0,0,0));
+                        Normals.emplace_back(0,0,0);
                     }
                 }
             }

--- a/src/Mod/Part/App/TopoShapePyImp.cpp
+++ b/src/Mod/Part/App/TopoShapePyImp.cpp
@@ -228,9 +228,9 @@ PyObject* TopoShapePy::replaceShape(PyObject *args)
             Py::Tuple tuple(*it);
             Py::TopoShape sh1(tuple[0]);
             Py::TopoShape sh2(tuple[1]);
-            shapes.push_back(std::make_pair(
+            shapes.emplace_back(
                 sh1.extensionObject()->getTopoShapePtr()->getShape(),
-                sh2.extensionObject()->getTopoShapePtr()->getShape())
+                sh2.extensionObject()->getTopoShapePtr()->getShape()
             );
         }
         PyTypeObject* type = this->GetType();

--- a/src/Mod/Part/App/modelRefine.cpp
+++ b/src/Mod/Part/App/modelRefine.cpp
@@ -1074,7 +1074,7 @@ bool FaceUniter::process()
                     if (!temp.empty())
                     {
                         for (FaceVectorType::iterator f = temp.begin(); f != temp.end(); ++f)
-                              modifiedShapes.push_back(std::make_pair(*f, newFace));
+                              modifiedShapes.emplace_back(*f, newFace);
                     }
                 }
             }
@@ -1160,7 +1160,7 @@ bool FaceUniter::process()
                 // Catch faces that were not united but whose boundary was changed (probably because
                 // several adjacent faces were united)
                 // See https://sourceforge.net/apps/mantisbt/free-cad/view.php?id=873
-                modifiedShapes.push_back(std::make_pair(mapIt.Key(), mapIt.Value()));
+                modifiedShapes.emplace_back(mapIt.Key(), mapIt.Value());
             }
         }
         // Handle edges that were fused. See https://sourceforge.net/apps/mantisbt/free-cad/view.php?id=873
@@ -1177,7 +1177,7 @@ bool FaceUniter::process()
             for (edgeIt.Initialize(edges); edgeIt.More(); edgeIt.Next())
             {
                 if (newEdges.IsBound(idx))
-                    modifiedShapes.push_back(std::make_pair(edgeIt.Value(), newEdges(idx)));
+                    modifiedShapes.emplace_back(edgeIt.Value(), newEdges(idx));
             }
             // TODO: Handle vertices that have disappeared in the fusion of the edges
         }

--- a/src/Mod/Part/Gui/TaskCheckGeometry.cpp
+++ b/src/Mod/Part/Gui/TaskCheckGeometry.cpp
@@ -747,13 +747,13 @@ void TaskCheckGeometryResults::dispatchError(ResultEntry *entry, const BRepCheck
 
 void TaskCheckGeometryResults::setupFunctionMap()
 {
-    functionMap.push_back(FunctionMapType(TopAbs_SHELL, BRepCheck_NotClosed, goSetupResultShellNotClosed));
-    functionMap.push_back(FunctionMapType(TopAbs_WIRE, BRepCheck_NotClosed, goSetupResultWireNotClosed));
-    functionMap.push_back(FunctionMapType(TopAbs_VERTEX, BRepCheck_InvalidPointOnCurve, goSetupResultInvalidPointCurve));
-    functionMap.push_back(FunctionMapType(TopAbs_FACE, BRepCheck_IntersectingWires, goSetupResultIntersectingWires));
-    functionMap.push_back(FunctionMapType(TopAbs_EDGE, BRepCheck_InvalidCurveOnSurface, goSetupResultInvalidCurveSurface));
-    functionMap.push_back(FunctionMapType(TopAbs_EDGE, BRepCheck_InvalidSameParameterFlag, goSetupResultInvalidSameParameterFlag));
-    functionMap.push_back(FunctionMapType(TopAbs_FACE, BRepCheck_UnorientableShape, goSetupResultUnorientableShapeFace));
+    functionMap.emplace_back(TopAbs_SHELL, BRepCheck_NotClosed, goSetupResultShellNotClosed);
+    functionMap.emplace_back(TopAbs_WIRE, BRepCheck_NotClosed, goSetupResultWireNotClosed);
+    functionMap.emplace_back(TopAbs_VERTEX, BRepCheck_InvalidPointOnCurve, goSetupResultInvalidPointCurve);
+    functionMap.emplace_back(TopAbs_FACE, BRepCheck_IntersectingWires, goSetupResultIntersectingWires);
+    functionMap.emplace_back(TopAbs_EDGE, BRepCheck_InvalidCurveOnSurface, goSetupResultInvalidCurveSurface);
+    functionMap.emplace_back(TopAbs_EDGE, BRepCheck_InvalidSameParameterFlag, goSetupResultInvalidSameParameterFlag);
+    functionMap.emplace_back(TopAbs_FACE, BRepCheck_UnorientableShape, goSetupResultUnorientableShapeFace);
 }
 
 void TaskCheckGeometryResults::currentRowChanged (const QModelIndex &current, const QModelIndex &previous)

--- a/src/Mod/Part/Gui/TaskDimension.cpp
+++ b/src/Mod/Part/Gui/TaskDimension.cpp
@@ -131,7 +131,7 @@ bool PartGui::evaluateLinearPreSelection(TopoDS_Shape &shape1, TopoDS_Shape &sha
     if (shape.IsNull())
       break;
     shapes.push_back(shape);
-    sels[i].selections.push_back(DimSelections::DimSelection());
+    sels[i].selections.emplace_back();
     auto &sel = sels[i].selections[0];
     ++i;
     sel.documentName = it->DocName;
@@ -841,9 +841,9 @@ bool PartGui::evaluateAngularPreSelection(VectorAdapter &vector1Out, VectorAdapt
            sels.back().selections.back().shapeType!=DimSelections::Vertex ||
            sels.back().selections.size()==1) 
         {
-            sels.push_back(PartGui::DimSelections());
+            sels.emplace_back();
         }
-        sels.back().selections.push_back(DimSelections::DimSelection());
+        sels.back().selections.emplace_back();
         auto &sel = sels.back().selections.back();
         sel.documentName = it->DocName;
         sel.objectName = it->FeatName;
@@ -860,7 +860,7 @@ bool PartGui::evaluateAngularPreSelection(VectorAdapter &vector1Out, VectorAdapt
       {
 	//need something here for 0 length vector.
 	//create a point half way between to vertices.
-	adapters.push_back(VectorAdapter(currentVertex, lastVertex));
+	adapters.emplace_back(currentVertex, lastVertex);
 	lastVertex = TopoDS_Vertex();
       }
       else
@@ -880,8 +880,8 @@ bool PartGui::evaluateAngularPreSelection(VectorAdapter &vector1Out, VectorAdapt
       continue;
     }
 
-    sels.push_back(PartGui::DimSelections());
-    sels.back().selections.push_back(DimSelections::DimSelection());
+    sels.emplace_back();
+    sels.back().selections.emplace_back();
     auto &sel = sels.back().selections.back();
     sel.documentName = it->DocName;
     sel.objectName = it->FeatName;
@@ -908,7 +908,7 @@ bool PartGui::evaluateAngularPreSelection(VectorAdapter &vector1Out, VectorAdapt
 	else
 	  edge.Orientation(TopAbs_FORWARD);
       }
-      adapters.push_back(VectorAdapter(edge, pickPoint));
+      adapters.emplace_back(edge, pickPoint);
       continue;
     }
 
@@ -916,7 +916,7 @@ bool PartGui::evaluateAngularPreSelection(VectorAdapter &vector1Out, VectorAdapt
     {
       sel.shapeType = DimSelections::Face;
       TopoDS_Face face = TopoDS::Face(shape);
-      adapters.push_back(VectorAdapter(face, pickPoint));
+      adapters.emplace_back(face, pickPoint);
       continue;
     }
   }

--- a/src/Mod/Part/Gui/ViewProviderExt.cpp
+++ b/src/Mod/Part/Gui/ViewProviderExt.cpp
@@ -647,7 +647,7 @@ std::vector<Base::Vector3d> ViewProviderPartExt::getModelPoints(const SoPickedPo
         if (subShape.ShapeType() == TopAbs_VERTEX) {
             const TopoDS_Vertex& v = TopoDS::Vertex(subShape);
             gp_Pnt p = BRep_Tool::Pnt(v);
-            pts.push_back(Base::Vector3d(p.X(),p.Y(),p.Z()));
+            pts.emplace_back(p.X(),p.Y(),p.Z());
         }
         // get the nearest point on the edge
         else if (subShape.ShapeType() == TopAbs_EDGE) {
@@ -656,7 +656,7 @@ std::vector<Base::Vector3d> ViewProviderPartExt::getModelPoints(const SoPickedPo
             BRepExtrema_DistShapeShape distSS(subShape, mkVert.Vertex(), 0.1);
             if (distSS.NbSolution() > 0) {
                 gp_Pnt p = distSS.PointOnShape1(1);
-                pts.push_back(Base::Vector3d(p.X(),p.Y(),p.Z()));
+                pts.emplace_back(p.X(),p.Y(),p.Z());
             }
         }
         // get the nearest point on the face
@@ -666,7 +666,7 @@ std::vector<Base::Vector3d> ViewProviderPartExt::getModelPoints(const SoPickedPo
             BRepExtrema_DistShapeShape distSS(subShape, mkVert.Vertex(), 0.1);
             if (distSS.NbSolution() > 0) {
                 gp_Pnt p = distSS.PointOnShape1(1);
-                pts.push_back(Base::Vector3d(p.X(),p.Y(),p.Z()));
+                pts.emplace_back(p.X(),p.Y(),p.Z());
             }
         }
 

--- a/src/Mod/PartDesign/App/FeatureLoft.cpp
+++ b/src/Mod/PartDesign/App/FeatureLoft.cpp
@@ -108,7 +108,7 @@ App::DocumentObjectExecReturn *Loft::execute(void)
 
         std::vector<std::vector<TopoDS_Wire>> wiresections;
         for(TopoDS_Wire& wire : wires)
-            wiresections.push_back(std::vector<TopoDS_Wire>(1, wire));
+            wiresections.emplace_back(1, wire);
 
         for(App::DocumentObject* obj : multisections) {
             if(!obj->isDerivedFrom(Part::Feature::getClassTypeId()))

--- a/src/Mod/PartDesign/App/FeaturePipe.cpp
+++ b/src/Mod/PartDesign/App/FeaturePipe.cpp
@@ -177,7 +177,7 @@ App::DocumentObjectExecReturn *Pipe::execute(void)
         auto multisections = Sections.getValues();
         std::vector<std::vector<TopoDS_Wire>> wiresections;
         for(TopoDS_Wire& wire : wires)
-            wiresections.push_back(std::vector<TopoDS_Wire>(1, wire));
+            wiresections.emplace_back(1, wire);
         //maybe we need a sacling law
         Handle(Law_Function) scalinglaw;
 

--- a/src/Mod/Path/libarea/Adaptive.cpp
+++ b/src/Mod/Path/libarea/Adaptive.cpp
@@ -470,14 +470,14 @@ bool Line2CircleIntersect(const IntPoint &c, double radius, const IntPoint &p1, 
 	if (clamp)
 	{
 		if (t1 >= 0.0 && t1 <= 1.0)
-			result.push_back(DoublePoint(p1.X + t1 * dx, p1.Y + t1 * dy));
+			result.emplace_back(p1.X + t1 * dx, p1.Y + t1 * dy);
 		if (t2 >= 0.0 && t2 <= 1.0)
-			result.push_back(DoublePoint(p1.X + t2 * dx, p1.Y + t2 * dy));
+			result.emplace_back(p1.X + t2 * dx, p1.Y + t2 * dy);
 	}
 	else
 	{
-		result.push_back(DoublePoint(p1.X + t2 * dx, p1.Y + t2 * dy));
-		result.push_back(DoublePoint(p1.X + t2 * dx, p1.Y + t2 * dy));
+		result.emplace_back(p1.X + t2 * dx, p1.Y + t2 * dy);
+		result.emplace_back(p1.X + t2 * dx, p1.Y + t2 * dy);
 	}
 	return result.size() > 0;
 }
@@ -617,7 +617,7 @@ void SmoothPaths(Paths &paths, double stepSize, long pointCount, long iterations
 		{
 			if (points.empty())
 			{
-				points.push_back(pair<size_t /*path index*/, IntPoint>(i, pt));
+				points.emplace_back(i, pt);
 				continue;
 			}
 			const auto back=points.back();
@@ -629,7 +629,7 @@ void SmoothPaths(Paths &paths, double stepSize, long pointCount, long iterations
 			if (l < 0.5*stepScaled )
 			{
 				if(points.size()>1) points.pop_back();
-				points.push_back(pair<size_t /*path index*/, IntPoint>(i, pt));
+				points.emplace_back(i, pt);
 				continue;
 			}
 			size_t lastPathIndex = back.first;
@@ -649,9 +649,9 @@ void SmoothPaths(Paths &paths, double stepSize, long pointCount, long iterations
 				if(idx==0 && DistanceSqrd(back.second,ptx)<scale && points.size()>1) points.pop_back();
 
 				if (p < 0.5)
-					points.push_back(pair<size_t /*path index*/, IntPoint>(lastPathIndex, ptx));
+					points.emplace_back(lastPathIndex, ptx);
 				else
-					points.push_back(pair<size_t /*path index*/, IntPoint>(i, ptx));
+					points.emplace_back(i, ptx);
 			}
 		}
 	}
@@ -2137,7 +2137,7 @@ bool Adaptive2d::IsAllowedToCutTrough(const IntPoint &p1, const IntPoint &p2, Cl
 bool Adaptive2d::ResolveLinkPath(const IntPoint &startPoint, const IntPoint &endPoint, ClearedArea &clearedArea, Path &output)
 {
 	vector<pair<IntPoint, IntPoint>> queue;
-	queue.push_back(pair<IntPoint, IntPoint>(startPoint, endPoint));
+	queue.emplace_back(startPoint, endPoint);
 	Path checkPath;
 	double totalLength = 0;
 	double directDistance = sqrt(DistanceSqrd(startPoint, endPoint));
@@ -2262,8 +2262,8 @@ bool Adaptive2d::ResolveLinkPath(const IntPoint &startPoint, const IntPoint &end
 				checkPath.push_back(checkPoint1);
 				if (IsClearPath(checkPath, clearedArea, clearance + 1))
 				{ // check if point clear
-					queue.push_back(pair<IntPoint, IntPoint>(pointPair.first, checkPoint1));
-					queue.push_back(pair<IntPoint, IntPoint>(checkPoint1, pointPair.second));
+					queue.emplace_back(pointPair.first, checkPoint1);
+					queue.emplace_back(checkPoint1, pointPair.second);
 					break;
 				}
 				else
@@ -2273,8 +2273,8 @@ bool Adaptive2d::ResolveLinkPath(const IntPoint &startPoint, const IntPoint &end
 					checkPath.push_back(checkPoint2);
 					if (IsClearPath(checkPath, clearedArea, clearance + 1))
 					{
-						queue.push_back(pair<IntPoint, IntPoint>(pointPair.first, checkPoint2));
-						queue.push_back(pair<IntPoint, IntPoint>(checkPoint2, pointPair.second));
+						queue.emplace_back(pointPair.first, checkPoint2);
+						queue.emplace_back(checkPoint2, pointPair.second);
 						break;
 					}
 				}
@@ -2483,7 +2483,7 @@ void Adaptive2d::AppendToolPath(TPaths &progressPaths, AdaptiveOutput &output,
 			linkPath1.first = MotionType::mtCutting;
 			for (const auto &pt : leadOutPath)
 			{
-				linkPath1.second.push_back(DPoint(double(pt.X) / scaleFactor, double(pt.Y) / scaleFactor));
+				linkPath1.second.emplace_back(double(pt.X) / scaleFactor, double(pt.Y) / scaleFactor);
 			}
 			output.AdaptivePaths.push_back(linkPath1);
 
@@ -2492,7 +2492,7 @@ void Adaptive2d::AppendToolPath(TPaths &progressPaths, AdaptiveOutput &output,
 			linkPath2.first = linkType;
 			for (const auto &pt : linkPath)
 			{
-				linkPath2.second.push_back(DPoint(double(pt.X) / scaleFactor, double(pt.Y) / scaleFactor));
+				linkPath2.second.emplace_back(double(pt.X) / scaleFactor, double(pt.Y) / scaleFactor);
 			}
 			output.AdaptivePaths.push_back(linkPath2);
 
@@ -2501,7 +2501,7 @@ void Adaptive2d::AppendToolPath(TPaths &progressPaths, AdaptiveOutput &output,
 			linkPath3.first = MotionType::mtCutting;
 			for (const auto &pt : leadInPath)
 			{
-				linkPath3.second.push_back(DPoint(double(pt.X) / scaleFactor, double(pt.Y) / scaleFactor));
+				linkPath3.second.emplace_back(double(pt.X) / scaleFactor, double(pt.Y) / scaleFactor);
 			}
 
 			output.AdaptivePaths.push_back(linkPath3);
@@ -2527,8 +2527,8 @@ void Adaptive2d::AppendToolPath(TPaths &progressPaths, AdaptiveOutput &output,
 
 			TPath linkPath;
 			linkPath.first = mt;
-			linkPath.second.push_back(DPoint(double(startPoint.X) / scaleFactor, double(startPoint.Y) / scaleFactor));
-			linkPath.second.push_back(DPoint(double(endPoint.X) / scaleFactor, double(endPoint.Y) / scaleFactor));
+			linkPath.second.emplace_back(double(startPoint.X) / scaleFactor, double(startPoint.Y) / scaleFactor);
+			linkPath.second.emplace_back(double(endPoint.X) / scaleFactor, double(endPoint.Y) / scaleFactor);
 			output.AdaptivePaths.push_back(linkPath);
 		}
 	}
@@ -2580,8 +2580,8 @@ void Adaptive2d::AddPathsToProgress(TPaths &progressPaths, Paths paths, MotionTy
 			progressPaths.push_back(TPath());
 			progressPaths.back().first = mt;
 			for (const auto pt : pth)
-				progressPaths.back().second.push_back(DPoint(double(pt.X) / scaleFactor, double(pt.Y) / scaleFactor));
-			progressPaths.back().second.push_back(DPoint(double(pth.front().X) / scaleFactor, double(pth.front().Y) / scaleFactor));
+				progressPaths.back().second.emplace_back(double(pt.X) / scaleFactor, double(pt.Y) / scaleFactor);
+			progressPaths.back().second.emplace_back(double(pth.front().X) / scaleFactor, double(pth.front().Y) / scaleFactor);
 		}
 	}
 }
@@ -2593,7 +2593,7 @@ void Adaptive2d::AddPathToProgress(TPaths &progressPaths, const Path pth, Motion
 		progressPaths.push_back(TPath());
 		progressPaths.back().first = mt;
 		for (const auto pt : pth)
-			progressPaths.back().second.push_back(DPoint(double(pt.X) / scaleFactor, double(pt.Y) / scaleFactor));
+			progressPaths.back().second.emplace_back(double(pt.X) / scaleFactor, double(pt.Y) / scaleFactor);
 	}
 }
 
@@ -2922,7 +2922,7 @@ void Adaptive2d::ProcessPolyNode(Paths boundPaths, Paths toolBoundPaths)
 				// append to progress info paths
 				if (progressPaths.size() == 0)
 					progressPaths.push_back(TPath());
-				progressPaths.back().second.push_back(DPoint(double(newToolPos.X) / scaleFactor, double(newToolPos.Y) / scaleFactor));
+				progressPaths.back().second.emplace_back(double(newToolPos.X) / scaleFactor, double(newToolPos.Y) / scaleFactor);
 
 				// append gyro
 				gyro.push_back(newToolDir);
@@ -3069,7 +3069,7 @@ void Adaptive2d::ProcessPolyNode(Paths boundPaths, Paths toolBoundPaths)
 		// show in progress cb
 		for (auto &pt : finShiftedPath)
 		{
-			progressPaths.back().second.push_back(DPoint(double(pt.X) / scaleFactor, double(pt.Y) / scaleFactor));
+			progressPaths.back().second.emplace_back(double(pt.X) / scaleFactor, double(pt.Y) / scaleFactor);
 		}
 
 		if (!finShiftedPath.empty())

--- a/src/Mod/Path/libarea/Area.cpp
+++ b/src/Mod/Path/libarea/Area.cpp
@@ -392,7 +392,7 @@ static void make_zig_curve(const CCurve& input_curve, double y0, double y)
 	}
         
     if(zig_finished)
-		zigzag_list_for_zigs.push_back(ZigZag(zig, zag));
+		zigzag_list_for_zigs.emplace_back(zig, zag);
 }
 
 void make_zig(const CArea &a, double y0, double y)
@@ -534,11 +534,11 @@ static void zigzag(const CArea &input_a)
 		Point p2(x1, y);
 		Point p3(x1, y0);
 		CCurve c;
-		c.m_vertices.push_back(CVertex(0, p0, null_point, 0));
-		c.m_vertices.push_back(CVertex(0, p1, null_point, 0));
-		c.m_vertices.push_back(CVertex(0, p2, null_point, 1));
-		c.m_vertices.push_back(CVertex(0, p3, null_point, 0));
-		c.m_vertices.push_back(CVertex(0, p0, null_point, 1));
+		c.m_vertices.emplace_back(0, p0, null_point, 0);
+		c.m_vertices.emplace_back(0, p1, null_point, 0);
+		c.m_vertices.emplace_back(0, p2, null_point, 1);
+		c.m_vertices.emplace_back(0, p3, null_point, 0);
+		c.m_vertices.emplace_back(0, p0, null_point, 1);
 		CArea a2;
 		a2.m_curves.push_back(c);
 		a2.Intersect(a);
@@ -635,7 +635,7 @@ void CArea::Split(std::list<CArea> &m_areas)const
 		for(std::list<CCurve>::const_iterator It = m_curves.begin(); It != m_curves.end(); It++)
 		{
 			const CCurve& curve = *It;
-			m_areas.push_back(CArea());
+			m_areas.emplace_back();
 			m_areas.back().m_curves.push_back(curve);
 		}
 	}
@@ -656,7 +656,7 @@ void CArea::Split(std::list<CArea> &m_areas)const
 			}
 			else
 			{
-				m_areas.push_back(CArea());
+				m_areas.emplace_back();
 				m_areas.back().m_curves.push_back(curve);
 			}
 		}
@@ -725,11 +725,11 @@ bool IsInside(const Point& p, const CArea& a)
 {
 	CArea a2;
 	CCurve c;
-	c.m_vertices.push_back(CVertex(Point(p.x - 0.01, p.y - 0.01)));
-	c.m_vertices.push_back(CVertex(Point(p.x + 0.01, p.y - 0.01)));
-	c.m_vertices.push_back(CVertex(Point(p.x + 0.01, p.y + 0.01)));
-	c.m_vertices.push_back(CVertex(Point(p.x - 0.01, p.y + 0.01)));
-	c.m_vertices.push_back(CVertex(Point(p.x - 0.01, p.y - 0.01)));
+	c.m_vertices.emplace_back(Point(p.x - 0.01, p.y - 0.01));
+	c.m_vertices.emplace_back(Point(p.x + 0.01, p.y - 0.01));
+	c.m_vertices.emplace_back(Point(p.x + 0.01, p.y + 0.01));
+	c.m_vertices.emplace_back(Point(p.x - 0.01, p.y + 0.01));
+	c.m_vertices.emplace_back(Point(p.x - 0.01, p.y - 0.01));
 	a2.m_curves.push_back(c);
 	a2.Intersect(a);
 	if(fabs(a2.GetArea()) < 0.0004)return false;

--- a/src/Mod/Path/libarea/AreaClipper.cpp
+++ b/src/Mod/Path/libarea/AreaClipper.cpp
@@ -374,7 +374,7 @@ static void SetFromResult( CArea& area, TPolyPolygon& pp, bool reverse=true, boo
 	{
 		TPolygon& p = pp[i];
 
-		area.m_curves.push_back(CCurve());
+		area.m_curves.emplace_back();
 		CCurve &curve = area.m_curves.back();
 		SetFromResult(curve, p, reverse, is_closed);
     }

--- a/src/Mod/Path/libarea/AreaDxf.cpp
+++ b/src/Mod/Path/libarea/AreaDxf.cpp
@@ -13,7 +13,7 @@ void AreaDxfRead::StartCurveIfNecessary(const double* s)
 	if((m_area->m_curves.size() == 0) || (m_area->m_curves.back().m_vertices.size() == 0) || (m_area->m_curves.back().m_vertices.back().m_p != ps))
 	{
 		// start a new curve
-		m_area->m_curves.push_back(CCurve());
+		m_area->m_curves.emplace_back();
 		m_area->m_curves.back().m_vertices.push_back(ps);
 	}
 }
@@ -27,5 +27,5 @@ void AreaDxfRead::OnReadLine(const double* s, const double* e)
 void AreaDxfRead::OnReadArc(const double* s, const double* e, const double* c, bool dir)
 {
 	StartCurveIfNecessary(s);
-	m_area->m_curves.back().m_vertices.push_back(CVertex(dir?1:0, Point(e), Point(c)));
+	m_area->m_curves.back().m_vertices.emplace_back(dir?1:0, Point(e), Point(c));
 }

--- a/src/Mod/Path/libarea/AreaPocket.cpp
+++ b/src/Mod/Path/libarea/AreaPocket.cpp
@@ -135,7 +135,7 @@ void GetCurveItem::GetCurve(CCurve& output)
 				std::list<CVertex>::iterator VIt = output.m_vertices.insert(this->EndIt, CVertex(inner.point_on_parent));
 
 				//inner.GetCurve(output);
-				GetCurveItem::to_do_list.push_back(GetCurveItem(&inner, VIt));
+				GetCurveItem::to_do_list.emplace_back(&inner, VIt);
 			}
 
 			if(back().m_p != vertex.m_p)output.m_vertices.insert(this->EndIt, vertex);
@@ -157,7 +157,7 @@ void GetCurveItem::GetCurve(CCurve& output)
 		std::list<CVertex>::iterator VIt = output.m_vertices.insert(this->EndIt, CVertex(inner.point_on_parent));
 
 		//inner.GetCurve(output);
-		GetCurveItem::to_do_list.push_back(GetCurveItem(&inner, VIt));
+		GetCurveItem::to_do_list.emplace_back(&inner, VIt);
 
 	}
 }
@@ -243,7 +243,7 @@ void CurveTree::MakeOffsets2()
 			for(std::list<IslandAndOffset*>::const_iterator It2 = island_and_offset->touching_offsets.begin(); It2 != island_and_offset->touching_offsets.end(); It2++)
 			{
 				const IslandAndOffset* touching = *It2;
-				touching_list.push_back(IslandAndOffsetLink(touching, inners.back()));
+				touching_list.emplace_back(touching, inners.back());
 				added.insert(touching);
 			}
 
@@ -276,7 +276,7 @@ void CurveTree::MakeOffsets2()
 				{
 					if(added.find(*It2)==added.end() && ((*It2) != island_and_offset))
 					{
-						touching_list.push_back(IslandAndOffsetLink(*It2, touching.add_to->inners.back()));
+						touching_list.emplace_back(*It2, touching.add_to->inners.back());
 						added.insert(*It2);
 					}
 				}
@@ -501,10 +501,10 @@ void CArea::MakeOnePocketCurve(std::list<CCurve> &curve_list, const CAreaPocketP
 	if(CArea::m_please_abort)return;
 	CArea::m_processing_done = CArea::m_after_MakeOffsets_length;
 
-	curve_list.push_back(CCurve());
+	curve_list.emplace_back();
 	CCurve& output = curve_list.back();
 
-	GetCurveItem::to_do_list.push_back(GetCurveItem(&top_level, output.m_vertices.end()));
+	GetCurveItem::to_do_list.emplace_back(&top_level, output.m_vertices.end());
 
 	while(GetCurveItem::to_do_list.size() > 0)
 	{

--- a/src/Mod/Path/libarea/Curve.cpp
+++ b/src/Mod/Path/libarea/Curve.cpp
@@ -161,11 +161,11 @@ void CCurve::AddArcOrLines(bool check_for_arc, std::list<CVertex> &new_vertices,
 		{
 			if(arc.AlmostALine())
 			{
-				new_vertices.push_back(CVertex(arc.m_e, arc.m_user_data));
+				new_vertices.emplace_back(arc.m_e, arc.m_user_data);
 			}
 			else
 			{
-				new_vertices.push_back(CVertex(arc.m_dir ? 1:-1, arc.m_e, arc.m_c, arc.m_user_data));
+				new_vertices.emplace_back(arc.m_dir ? 1:-1, arc.m_e, arc.m_c, arc.m_user_data);
 			}
 
 			arc_added = true;
@@ -350,7 +350,7 @@ void CCurve::UnFitArcs()
 					double nx = vertex.m_c.x * CArea::m_units + radius * cos(phi-dphi);
 					double ny = vertex.m_c.y * CArea::m_units + radius * sin(phi-dphi);
 
-					new_pts.push_back(Point(nx, ny));
+					new_pts.emplace_back(nx, ny);
 
 					px = nx;
 					py = ny;
@@ -535,7 +535,7 @@ void CCurve::ChangeStart(const Point &p) {
 					}
 					else
 					{
-						new_curve.m_vertices.push_back(CVertex(p));
+						new_curve.m_vertices.emplace_back(p);
 						started = true;
 						start_span = span_index;
 						if(p != vertex.m_p)new_curve.m_vertices.push_back(vertex);
@@ -826,7 +826,7 @@ void CCurve::GetSpans(std::list<Span> &spans)const
 		const CVertex& vertex = *It;
 		if(prev_p)
 		{
-			spans.push_back(Span(*prev_p, vertex));
+			spans.emplace_back(*prev_p, vertex);
 		}
 		prev_p = &(vertex.m_p);
 	}
@@ -880,7 +880,7 @@ void CCurve::OffsetForward(double forwards_value, bool refit_arcs)
 				// add an arc to the start of the next span
 				int arc_type = ((sin_angle > 0) ? 1 : (-1));
 				Point centre = span.m_v.m_p - v * forwards_value;
-				m_vertices.push_back(CVertex(arc_type, next_span.m_p, centre));
+				m_vertices.emplace_back(arc_type, next_span.m_p, centre);
 			}
 		}
 	}
@@ -978,7 +978,7 @@ void CCurve::operator+=(const CCurve& curve)
 		{
 			if((m_vertices.size() == 0) || (It->m_p != m_vertices.back().m_p))
 			{
-				m_vertices.push_back(CVertex(It->m_p));
+				m_vertices.emplace_back(It->m_p);
 			}
 		}
 		else
@@ -1307,8 +1307,8 @@ void Span::Intersect(const Span& s, std::list<Point> &pts)const
 	geoff_geometry::Point pInt1, pInt2;
 	double t[4];
 	int num_int = MakeSpan(*this).Intof(MakeSpan(s), pInt1, pInt2, t);
-	if(num_int > 0)pts.push_back(Point(pInt1.x, pInt1.y));
-	if(num_int > 1)pts.push_back(Point(pInt2.x, pInt2.y));
+	if(num_int > 0)pts.emplace_back(pInt1.x, pInt1.y);
+	if(num_int > 1)pts.emplace_back(pInt2.x, pInt2.y);
 }
 
 void tangential_arc(const Point &p0, const Point &p1, const Point &v0, Point &c, int &dir)

--- a/src/Mod/Path/libarea/PythonStuff.cpp
+++ b/src/Mod/Path/libarea/PythonStuff.cpp
@@ -139,7 +139,7 @@ static CArea AreaFromDxf(const char* filepath)
 
 static void append_point(CCurve& c, const Point& p)
 {
-	c.m_vertices.push_back(CVertex(p));
+	c.m_vertices.emplace_back(p);
 }
 
 static boost::python::tuple nearest_point_to_curve(CCurve& c1, const CCurve& c2)

--- a/src/Mod/Path/libarea/clipper.cpp
+++ b/src/Mod/Path/libarea/clipper.cpp
@@ -3885,7 +3885,7 @@ void ClipperOffset::DoOffset(double delta)
     if (node.m_endtype == etClosedLine || node.m_endtype == etClosedPolygon)
       m_normals.push_back(GetUnitNormal(m_srcPoly[len - 1], m_srcPoly[0]));
     else
-      m_normals.push_back(DoublePoint(m_normals[len - 2]));
+      m_normals.emplace_back(m_normals[len - 2]);
 
     if (node.m_endtype == etClosedPolygon)
     {

--- a/src/Mod/Points/App/Points.cpp
+++ b/src/Mod/Points/App/Points.cpp
@@ -156,10 +156,10 @@ std::vector<PointKernel::value_type> PointKernel::getValidPoints() const
         if (!(boost::math::isnan(it->x) || 
               boost::math::isnan(it->y) ||
               boost::math::isnan(it->z)))
-            valid.push_back(value_type(
+            valid.emplace_back(
                     static_cast<float_type>(it->x),
                     static_cast<float_type>(it->y),
-                    static_cast<float_type>(it->z)));
+                    static_cast<float_type>(it->z));
     }
     return valid;
 }

--- a/src/Mod/Points/App/PointsAlgos.cpp
+++ b/src/Mod/Points/App/PointsAlgos.cpp
@@ -613,7 +613,7 @@ void PlyReader::read(const std::string& filename)
     if (hasData && hasNormal) {
         normals.reserve(numPoints);
         for (std::size_t i=0; i<numPoints; i++) {
-            normals.push_back(Base::Vector3f(data(i,normal_x),data(i,normal_y),data(i,normal_z)));
+            normals.emplace_back(data(i,normal_x),data(i,normal_y),data(i,normal_z));
         }
     }
 
@@ -634,10 +634,10 @@ void PlyReader::read(const std::string& filename)
                 float b = data(i, blue);
                 if (alpha != max_size)
                     a = data(i, alpha);
-                colors.push_back(App::Color(static_cast<float>(r)/255.0f,
+                colors.emplace_back(static_cast<float>(r)/255.0f,
                                             static_cast<float>(g)/255.0f,
                                             static_cast<float>(b)/255.0f,
-                                            static_cast<float>(a)/255.0f));
+                                            static_cast<float>(a)/255.0f);
             }
         }
         else if (types[red] == "float") {
@@ -647,7 +647,7 @@ void PlyReader::read(const std::string& filename)
                 float b = data(i, blue);
                 if (alpha != max_size)
                     a = data(i, alpha);
-                colors.push_back(App::Color(r, g, b, a));
+                colors.emplace_back(r, g, b, a);
             }
         }
     }
@@ -726,7 +726,7 @@ std::size_t PlyReader::readHeader(std::istream& in,
             else {
                 // if another element than 'vertex' comes first then calculate the offset
                 if (numPoints == 0) {
-                    count_props.push_back(std::make_pair(count, 0));
+                    count_props.emplace_back(count, 0);
                 }
                 else {
                     // this happens for elements coming after 'vertex'
@@ -1062,7 +1062,7 @@ void PcdReader::read(const std::string& filename)
     if (hasData && hasNormal) {
         normals.reserve(numPoints);
         for (std::size_t i=0; i<numPoints; i++) {
-            normals.push_back(Base::Vector3f(data(i,normal_x),data(i,normal_y),data(i,normal_z)));
+            normals.emplace_back(data(i,normal_x),data(i,normal_y),data(i,normal_z));
         }
     }
 
@@ -1082,10 +1082,10 @@ void PcdReader::read(const std::string& filename)
                 uint32_t r = (packed >> 16) & 0xff;
                 uint32_t g = (packed >> 8) & 0xff;
                 uint32_t b = packed & 0xff;
-                colors.push_back(App::Color(static_cast<float>(r)/255.0f,
+                colors.emplace_back(static_cast<float>(r)/255.0f,
                                             static_cast<float>(g)/255.0f,
                                             static_cast<float>(b)/255.0f,
-                                            static_cast<float>(a)/255.0f));
+                                            static_cast<float>(a)/255.0f);
             }
         }
         else if (types[rgba] == "F") {
@@ -1102,10 +1102,10 @@ void PcdReader::read(const std::string& filename)
                 uint32_t r = (packed >> 16) & 0xff;
                 uint32_t g = (packed >> 8) & 0xff;
                 uint32_t b = packed & 0xff;
-                colors.push_back(App::Color(static_cast<float>(r)/255.0f,
+                colors.emplace_back(static_cast<float>(r)/255.0f,
                                             static_cast<float>(g)/255.0f,
                                             static_cast<float>(b)/255.0f,
-                                            static_cast<float>(a)/255.0f));
+                                            static_cast<float>(a)/255.0f);
             }
         }
     }

--- a/src/Mod/ReverseEngineering/App/AppReverseEngineering.cpp
+++ b/src/Mod/ReverseEngineering/App/AppReverseEngineering.cpp
@@ -218,10 +218,10 @@ private:
                 pts.reserve(l.size());
                 for (Py::Sequence::iterator it = l.begin(); it != l.end(); ++it) {
                     Py::Tuple t(*it);
-                    pts.push_back(Base::Vector3f(
+                    pts.emplace_back(
                         (float)Py::Float(t.getItem(0)),
                         (float)Py::Float(t.getItem(1)),
-                        (float)Py::Float(t.getItem(2)))
+                        (float)Py::Float(t.getItem(2))
                     );
                 }
             }

--- a/src/Mod/ReverseEngineering/App/ApproxSurface.cpp
+++ b/src/Mod/ReverseEngineering/App/ApproxSurface.cpp
@@ -638,7 +638,7 @@ bool ParameterCorrection::GetUVParameters(double fSizeFactor)
     for (int ii=_pvcPoints->Lower(); ii<=_pvcPoints->Upper(); ii++) {
         const gp_Pnt& pnt = (*_pvcPoints)(ii);
         Wm4::Vector3d clProjPnt = clRotMatTrans * Wm4::Vector3d(pnt.X(), pnt.Y(), pnt.Z());
-        vcProjPts.push_back(Base::Vector2d(clProjPnt.X(), clProjPnt.Y()));
+        vcProjPts.emplace_back(clProjPnt.X(), clProjPnt.Y());
         clBBox.Add(Base::Vector2d(clProjPnt.X(), clProjPnt.Y()));
     }
 

--- a/src/Mod/Sketcher/App/Sketch.cpp
+++ b/src/Mod/Sketcher/App/Sketch.cpp
@@ -3021,7 +3021,7 @@ bool Sketch::updateGeometry()
                 std::vector<double *>::const_iterator it2;
 
                 for( it1 = mybsp.poles.begin(), it2 = mybsp.weights.begin(); it1 != mybsp.poles.end() && it2 != mybsp.weights.end(); ++it1, ++it2) {
-                    poles.push_back(Vector3d( *(*it1).x , *(*it1).y , 0.0));
+                    poles.emplace_back( *(*it1).x , *(*it1).y , 0.0);
                     weights.push_back(*(*it2));
                 }
 

--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -5287,7 +5287,7 @@ int SketchObject::addExternal(App::DocumentObject *Obj, const char* SubName)
 
     // add the new ones
     Objects.push_back(Obj);
-    SubElements.push_back(std::string(SubName));
+    SubElements.emplace_back(SubName);
 
     // set the Link list.
     ExternalGeometry.setValues(Objects,SubElements);

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -3556,7 +3556,7 @@ void ViewProviderSketch::draw(bool temp /*=false*/, bool rebuildinformationlayer
     int stdcountsegments = hGrp->GetInt("SegmentsPerGeometry", 50);
 
     // RootPoint
-    Points.push_back(Base::Vector3d(0.,0.,0.));
+    Points.emplace_back(0.,0.,0.);
 
     for (std::vector<Part::Geometry *>::const_iterator it = geomlist->begin(); it != geomlist->end()-2; ++it, GeoId++) {
         if (GeoId >= intGeoCount)
@@ -3587,11 +3587,11 @@ void ViewProviderSketch::draw(bool temp /*=false*/, bool rebuildinformationlayer
             double segment = (2 * M_PI) / countSegments;
             for (int i=0; i < countSegments; i++) {
                 gp_Pnt pnt = curve->Value(i*segment);
-                Coords.push_back(Base::Vector3d(pnt.X(), pnt.Y(), pnt.Z()));
+                Coords.emplace_back(pnt.X(), pnt.Y(), pnt.Z());
             }
 
             gp_Pnt pnt = curve->Value(0);
-            Coords.push_back(Base::Vector3d(pnt.X(), pnt.Y(), pnt.Z()));
+            Coords.emplace_back(pnt.X(), pnt.Y(), pnt.Z());
 
             Index.push_back(countSegments+1);
             edit->CurvIdToGeoId.push_back(GeoId);
@@ -3607,11 +3607,11 @@ void ViewProviderSketch::draw(bool temp /*=false*/, bool rebuildinformationlayer
             double segment = (2 * M_PI) / countSegments;
             for (int i=0; i < countSegments; i++) {
                 gp_Pnt pnt = curve->Value(i*segment);
-                Coords.push_back(Base::Vector3d(pnt.X(), pnt.Y(), pnt.Z()));
+                Coords.emplace_back(pnt.X(), pnt.Y(), pnt.Z());
             }
 
             gp_Pnt pnt = curve->Value(0);
-            Coords.push_back(Base::Vector3d(pnt.X(), pnt.Y(), pnt.Z()));
+            Coords.emplace_back(pnt.X(), pnt.Y(), pnt.Z());
 
             Index.push_back(countSegments+1);
             edit->CurvIdToGeoId.push_back(GeoId);
@@ -3637,13 +3637,13 @@ void ViewProviderSketch::draw(bool temp /*=false*/, bool rebuildinformationlayer
 
             for (int i=0; i < countSegments; i++) {
                 gp_Pnt pnt = curve->Value(startangle);
-                Coords.push_back(Base::Vector3d(pnt.X(), pnt.Y(), pnt.Z()));
+                Coords.emplace_back(pnt.X(), pnt.Y(), pnt.Z());
                 startangle += segment;
             }
 
             // end point
             gp_Pnt pnt = curve->Value(endangle);
-            Coords.push_back(Base::Vector3d(pnt.X(), pnt.Y(), pnt.Z()));
+            Coords.emplace_back(pnt.X(), pnt.Y(), pnt.Z());
 
             Index.push_back(countSegments+1);
             edit->CurvIdToGeoId.push_back(GeoId);
@@ -3673,13 +3673,13 @@ void ViewProviderSketch::draw(bool temp /*=false*/, bool rebuildinformationlayer
 
             for (int i=0; i < countSegments; i++) {
                 gp_Pnt pnt = curve->Value(startangle);
-                Coords.push_back(Base::Vector3d(pnt.X(), pnt.Y(), pnt.Z()));
+                Coords.emplace_back(pnt.X(), pnt.Y(), pnt.Z());
                 startangle += segment;
             }
 
             // end point
             gp_Pnt pnt = curve->Value(endangle);
-            Coords.push_back(Base::Vector3d(pnt.X(), pnt.Y(), pnt.Z()));
+            Coords.emplace_back(pnt.X(), pnt.Y(), pnt.Z());
 
             Index.push_back(countSegments+1);
             edit->CurvIdToGeoId.push_back(GeoId);
@@ -3709,13 +3709,13 @@ void ViewProviderSketch::draw(bool temp /*=false*/, bool rebuildinformationlayer
 
             for (int i=0; i < countSegments; i++) {
                 gp_Pnt pnt = curve->Value(startangle);
-                Coords.push_back(Base::Vector3d(pnt.X(), pnt.Y(), pnt.Z()));
+                Coords.emplace_back(pnt.X(), pnt.Y(), pnt.Z());
                 startangle += segment;
             }
 
             // end point
             gp_Pnt pnt = curve->Value(endangle);
-            Coords.push_back(Base::Vector3d(pnt.X(), pnt.Y(), pnt.Z()));
+            Coords.emplace_back(pnt.X(), pnt.Y(), pnt.Z());
 
             Index.push_back(countSegments+1);
             edit->CurvIdToGeoId.push_back(GeoId);
@@ -3745,13 +3745,13 @@ void ViewProviderSketch::draw(bool temp /*=false*/, bool rebuildinformationlayer
 
             for (int i=0; i < countSegments; i++) {
                 gp_Pnt pnt = curve->Value(startangle);
-                Coords.push_back(Base::Vector3d(pnt.X(), pnt.Y(), pnt.Z()));
+                Coords.emplace_back(pnt.X(), pnt.Y(), pnt.Z());
                 startangle += segment;
             }
 
             // end point
             gp_Pnt pnt = curve->Value(endangle);
-            Coords.push_back(Base::Vector3d(pnt.X(), pnt.Y(), pnt.Z()));
+            Coords.emplace_back(pnt.X(), pnt.Y(), pnt.Z());
 
             Index.push_back(countSegments+1);
             edit->CurvIdToGeoId.push_back(GeoId);
@@ -3781,13 +3781,13 @@ void ViewProviderSketch::draw(bool temp /*=false*/, bool rebuildinformationlayer
 
             for (int i=0; i < countSegments; i++) {
                 gp_Pnt pnt = curve->Value(first);
-                Coords.push_back(Base::Vector3d(pnt.X(), pnt.Y(), pnt.Z()));
+                Coords.emplace_back(pnt.X(), pnt.Y(), pnt.Z());
                 first += segment;
             }
 
             // end point
             gp_Pnt end = curve->Value(last);
-            Coords.push_back(Base::Vector3d(end.X(), end.Y(), end.Z()));
+            Coords.emplace_back(end.X(), end.Y(), end.Z());
 
             Index.push_back(countSegments+1);
             edit->CurvIdToGeoId.push_back(GeoId);

--- a/src/Mod/Spreadsheet/Gui/Command.cpp
+++ b/src/Mod/Spreadsheet/Gui/Command.cpp
@@ -812,8 +812,8 @@ void CmdSpreadsheetSetAlias::activated(int iMsg)
             if (selection.size() == 1) {
                 std::vector<Range> range;
 
-                range.push_back(Range(selection[0].row(), selection[0].column(),
-                                      selection[0].row(), selection[0].column()));
+                range.emplace_back(selection[0].row(), selection[0].column(),
+                                      selection[0].row(), selection[0].column());
 
                 std::unique_ptr<PropertiesDialog> dialog(new PropertiesDialog(sheet, range, sheetView));
 

--- a/src/Mod/Spreadsheet/Gui/SheetTableView.cpp
+++ b/src/Mod/Spreadsheet/Gui/SheetTableView.cpp
@@ -137,8 +137,8 @@ std::vector<Range> SheetTableView::selectedRanges() const
         std::pair<int, int> ul = (*i).first;
         std::pair<int, int> size = (*i).second;
 
-        result.push_back(Range(ul.first, ul.second,
-                                                   ul.first + size.first - 1, ul.second + size.second - 1));
+        result.emplace_back(ul.first, ul.second,
+                                                   ul.first + size.first - 1, ul.second + size.second - 1);
     }
 
     return result;

--- a/src/Mod/Surface/Gui/TaskFilling.cpp
+++ b/src/Mod/Surface/Gui/TaskFilling.cpp
@@ -621,7 +621,7 @@ void FillingPanel::onSelectionChanged(const Gui::SelectionChanges& msg)
             // extend faces and continuities lists if needed
             auto faces = editedObject->BoundaryFaces.getValues();
             if (count == faces.size()) {
-                faces.push_back(std::string());
+                faces.emplace_back();
                 editedObject->BoundaryFaces.setValues(faces);
             }
             auto conts = editedObject->BoundaryOrder.getValues();

--- a/src/Mod/Surface/Gui/TaskFillingUnbound.cpp
+++ b/src/Mod/Surface/Gui/TaskFillingUnbound.cpp
@@ -401,7 +401,7 @@ void FillingUnboundPanel::onSelectionChanged(const Gui::SelectionChanges& msg)
             // extend faces and continuities lists if needed
             auto faces = editedObject->UnboundFaces.getValues();
             if (count == faces.size()) {
-                faces.push_back(std::string());
+                faces.emplace_back();
                 editedObject->UnboundFaces.setValues(faces);
             }
             auto conts = editedObject->UnboundOrder.getValues();

--- a/src/Mod/TechDraw/App/DrawParametricTemplate.cpp
+++ b/src/Mod/TechDraw/App/DrawParametricTemplate.cpp
@@ -119,8 +119,8 @@ int DrawParametricTemplate::drawLine(double x1, double y1, double x2, double y2)
 {
     TechDraw::Generic *line = new TechDraw::Generic();
 
-    line->points.push_back(Base::Vector3d(x1, y1));
-    line->points.push_back(Base::Vector3d(x2, y2));
+    line->points.emplace_back(x1, y1);
+    line->points.emplace_back(x2, y2);
 
     geom.push_back(line); // Push onto geometry stack
     return geom.size() -1;

--- a/src/Mod/TechDraw/App/Geometry.cpp
+++ b/src/Mod/TechDraw/App/Geometry.cpp
@@ -229,9 +229,9 @@ std::vector<Base::Vector3d> BaseGeom::findEndPoints()
 
     if (!occEdge.IsNull()) {
         gp_Pnt p = BRep_Tool::Pnt(TopExp::FirstVertex(occEdge));
-        result.push_back(Base::Vector3d(p.X(),p.Y(), p.Z()));
+        result.emplace_back(p.X(),p.Y(), p.Z());
         p = BRep_Tool::Pnt(TopExp::LastVertex(occEdge));
-        result.push_back(Base::Vector3d(p.X(),p.Y(), p.Z()));
+        result.emplace_back(p.X(),p.Y(), p.Z());
     } else {
         //TODO: this should throw something
         Base::Console().Message("Geometry::findEndPoints - OCC edge not found\n");
@@ -293,13 +293,13 @@ std::vector<Base::Vector3d> BaseGeom::getQuads()
     double q3 = u + (3.0 * range / 4.0);
     BRepLProp_CLProps prop(adapt,q1,0,Precision::Confusion());
     const gp_Pnt& p1 = prop.Value();
-    result.push_back(Base::Vector3d(p1.X(),p1.Y(), 0.0));
+    result.emplace_back(p1.X(),p1.Y(), 0.0);
     prop.SetParameter(q2);
     const gp_Pnt& p2 = prop.Value();
-    result.push_back(Base::Vector3d(p2.X(),p2.Y(), 0.0));
+    result.emplace_back(p2.X(),p2.Y(), 0.0);
     prop.SetParameter(q3);
     const gp_Pnt& p3 = prop.Value();
-    result.push_back(Base::Vector3d(p3.X(),p3.Y(), 0.0));
+    result.emplace_back(p3.X(),p3.Y(), 0.0);
     return result;
 }
 
@@ -814,14 +814,14 @@ Generic::Generic(const TopoDS_Edge &e)
     if (!polygon.IsNull()) {
         const TColgp_Array1OfPnt &nodes = polygon->Nodes();
         for (int i = nodes.Lower(); i <= nodes.Upper(); i++){
-            points.push_back(Base::Vector3d(nodes(i).X(), nodes(i).Y(), nodes(i).Z()));
+            points.emplace_back(nodes(i).X(), nodes(i).Y(), nodes(i).Z());
         }
     } else {
         //no polygon representation? approximate with line
         gp_Pnt p = BRep_Tool::Pnt(TopExp::FirstVertex(occEdge));
-        points.push_back(Base::Vector3d(p.X(), p.Y(), p.Z()));
+        points.emplace_back(p.X(), p.Y(), p.Z());
         p = BRep_Tool::Pnt(TopExp::LastVertex(occEdge));
-        points.push_back(Base::Vector3d(p.X(), p.Y(), p.Z()));
+        points.emplace_back(p.X(), p.Y(), p.Z());
     }
 }
 
@@ -1022,7 +1022,7 @@ BSpline::BSpline(const TopoDS_Edge &e)
         tempSegment.degree = bezier->Degree();
         for (int pole = 1; pole <= tempSegment.poles; ++pole) {
             controlPoint = bezier->Pole(pole);
-            tempSegment.pnts.push_back(Base::Vector3d(controlPoint.X(), controlPoint.Y(), controlPoint.Z()));
+            tempSegment.pnts.emplace_back(controlPoint.X(), controlPoint.Y(), controlPoint.Z());
         }
         segments.push_back(tempSegment);
     }
@@ -1292,7 +1292,7 @@ BezierSegment::BezierSegment(const TopoDS_Edge &e)
     }
     for (int i = 1; i <= poles; ++i) {
         gp_Pnt controlPoint = bez->Pole(i);
-        pnts.push_back(Base::Vector3d(controlPoint.X(), controlPoint.Y(), controlPoint.Z()));
+        pnts.emplace_back(controlPoint.X(), controlPoint.Y(), controlPoint.Z());
     }
 }
 


### PR DESCRIPTION
emplace_back has two advantages over the push_back
1) Creates a new object "in place" whereas push_back creates a temporary object then moves it
2) Makes the code shorter

_I used the modernize-use-emplace check from clang-tidy with enabled IgnoreImplicitConstructors_