### PR TITLE
Fix -Wclass-memaccess warning

### DIFF
--- a/src/Mod/Mesh/App/WildMagic4/Wm4MeshCurvature.cpp
+++ b/src/Mod/Mesh/App/WildMagic4/Wm4MeshCurvature.cpp
@@ -31,7 +31,7 @@ MeshCurvature<Real>::MeshCurvature (int iVQuantity,
 
     // compute normal vectors
     m_akNormal = WM4_NEW Vector3<Real>[m_iVQuantity];
-    memset(m_akNormal,0,m_iVQuantity*sizeof(Vector3<Real>));
+    std::fill_n(m_akNormal,m_iVQuantity,Vector3<Real>{0,0,0});
     int i, iV0, iV1, iV2;
     for (i = 0; i < m_iTQuantity; i++)
     {
@@ -58,8 +58,8 @@ MeshCurvature<Real>::MeshCurvature (int iVQuantity,
     Matrix3<Real>* akDNormal = WM4_NEW Matrix3<Real>[m_iVQuantity];
     Matrix3<Real>* akWWTrn = WM4_NEW Matrix3<Real>[m_iVQuantity];
     Matrix3<Real>* akDWTrn = WM4_NEW Matrix3<Real>[m_iVQuantity];
-    memset(akWWTrn,0,m_iVQuantity*sizeof(Matrix3<Real>));
-    memset(akDWTrn,0,m_iVQuantity*sizeof(Matrix3<Real>));
+    std::fill_n(akWWTrn,m_iVQuantity,Matrix3<Real>{0,0,0,0,0,0,0,0,0});
+    std::fill_n(akDWTrn,m_iVQuantity,Matrix3<Real>{0,0,0,0,0,0,0,0,0});
 
     int iRow, iCol;
     aiIndex = m_aiIndex;

--- a/src/Mod/Mesh/App/WildMagic4/Wm4MeshSmoother.cpp
+++ b/src/Mod/Mesh/App/WildMagic4/Wm4MeshSmoother.cpp
@@ -89,8 +89,8 @@ void MeshSmoother<Real>::Destroy ()
 template <class Real>
 void MeshSmoother<Real>::Update (Real fTime)
 {
-    memset(m_akNormal,0,m_iVQuantity*sizeof(Vector3<Real>));
-    memset(m_akMean,0,m_iVQuantity*sizeof(Vector3<Real>));
+    std::fill_n(m_akNormal,m_iVQuantity,Vector3<Real>{0,0,0});
+    std::fill_n(m_akMean,m_iVQuantity,Vector3<Real>{0,0,0});
 
     const int* piIndex = m_aiIndex;
     int i;

--- a/src/Mod/Path/libarea/clipper.cpp
+++ b/src/Mod/Path/libarea/clipper.cpp
@@ -50,38 +50,38 @@
 
 namespace ClipperLib {
 
-static double const pi = 3.141592653589793238;
-static double const two_pi = pi *2;
-static double const def_arc_tolerance = 0.25;
+static double constexpr pi = 3.141592653589793238;
+static double constexpr two_pi = pi *2;
+static double constexpr def_arc_tolerance = 0.25;
 
 enum Direction { dRightToLeft, dLeftToRight };
 
-static int const Unassigned = -1;  //edge not currently 'owning' a solution
-static int const Skip = -2;        //edge that would otherwise close a path
+static int constexpr Unassigned = -1;  //edge not currently 'owning' a solution
+static int constexpr Skip = -2;        //edge that would otherwise close a path
 
 #define HORIZONTAL (-1.0E+40)
 #define TOLERANCE (1.0e-20)
 #define NEAR_ZERO(val) (((val) > -TOLERANCE) && ((val) < TOLERANCE))
 
 struct TEdge {
-  IntPoint Bot;
-  IntPoint Curr;
-  IntPoint Top;
-  IntPoint Delta;
-  double Dx;
-  PolyType PolyTyp;
-  EdgeSide Side;
-  int WindDelta; //1 or -1 depending on winding direction
-  int WindCnt;
-  int WindCnt2; //winding count of the opposite polytype
-  int OutIdx;
-  TEdge *Next;
-  TEdge *Prev;
-  TEdge *NextInLML;
-  TEdge *NextInAEL;
-  TEdge *PrevInAEL;
-  TEdge *NextInSEL;
-  TEdge *PrevInSEL;
+  IntPoint Bot{0,0};
+  IntPoint Curr{0,0};
+  IntPoint Top{0,0};
+  IntPoint Delta{0,0};
+  double Dx = 0.0;
+  PolyType PolyTyp = ptSubject;
+  EdgeSide Side = esLeft;
+  int WindDelta = 0; //1 or -1 depending on winding direction
+  int WindCnt = 0;
+  int WindCnt2 = 0; //winding count of the opposite polytype
+  int OutIdx = 0;
+  TEdge *Next = nullptr;
+  TEdge *Prev = nullptr;
+  TEdge *NextInLML = nullptr;
+  TEdge *NextInAEL = nullptr;
+  TEdge *PrevInAEL = nullptr;
+  TEdge *NextInSEL = nullptr;
+  TEdge *PrevInSEL = nullptr;
 };
 
 struct IntersectNode {
@@ -715,7 +715,6 @@ void DisposeOutPts(OutPt*& pp)
 
 inline void InitEdge(TEdge* e, TEdge* eNext, TEdge* ePrev, const IntPoint& Pt)
 {
-  std::memset(e, 0, sizeof(TEdge));
   e->Next = eNext;
   e->Prev = ePrev;
   e->Curr = Pt;


### PR DESCRIPTION
Replace C-style memset with C++ value-initialization/assignment (smarter and safer: see https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#slcon3-avoid-bounds-errors )

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [X] Branch rebased on latest master `git pull --rebase upstream master`
- [] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [X] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
