### PR TITLE
Fix -Wredundant-move warnings

### DIFF
--- a/src/3rdParty/salomesmesh/src/SMESH/GEOMUtils.cpp
+++ b/src/3rdParty/salomesmesh/src/SMESH/GEOMUtils.cpp
@@ -643,7 +643,7 @@ TopoDS_Shape GEOMUtils::CompsolidToCompound (const TopoDS_Shape& theCompsolid)
     }
   }
 
-  return std::move(aCompound);
+  return aCompound;
 }
 
 //=======================================================================

--- a/src/3rdParty/salomesmesh/src/SMESH/SMESH_subMesh.cpp
+++ b/src/3rdParty/salomesmesh/src/SMESH/SMESH_subMesh.cpp
@@ -2100,7 +2100,7 @@ TopoDS_Shape SMESH_subMesh::getCollection(SMESH_Gen * theGen,
     }
   }
 
-  return std::move(aCompound);
+  return aCompound;
 }
 
 //=======================================================================

--- a/src/Mod/Part/App/FaceMakerCheese.cpp
+++ b/src/Mod/Part/App/FaceMakerCheese.cpp
@@ -236,7 +236,7 @@ TopoDS_Shape FaceMakerCheese::makeFace(const std::vector<TopoDS_Wire>& w)
                 builder.Add(comp, aFace);
         }
 
-        return std::move(comp);
+        return comp;
     }
     else {
         return TopoDS_Shape(); // error

--- a/src/Mod/Part/App/TopoShape.cpp
+++ b/src/Mod/Part/App/TopoShape.cpp
@@ -2222,7 +2222,7 @@ TopoDS_Shape TopoShape::makeHelix(Standard_Real pitch, Standard_Real height,
     TopoDS_Edge edgeOnSurf = BRepBuilderAPI_MakeEdge(segm , surf);
     TopoDS_Wire wire = BRepBuilderAPI_MakeWire(edgeOnSurf);
     BRepLib::BuildCurves3d(wire);
-    return std::move(wire);
+    return wire;
 }
 
 //***********
@@ -2308,7 +2308,7 @@ TopoDS_Shape TopoShape::makeLongHelix(Standard_Real pitch, Standard_Real height,
 
     TopoDS_Wire wire = mkWire.Wire();
     BRepLib::BuildCurves3d(wire);
-    return std::move(wire);
+    return wire;
 }
 
 TopoDS_Shape TopoShape::makeThread(Standard_Real pitch,
@@ -2928,7 +2928,7 @@ TopoDS_Shape TopoShape::makeOffset2D(double offset, short joinType, bool fill, b
         builder.MakeCompound(result);
         for(TopoDS_Shape &sh : shapesToReturn)
             builder.Add(result, sh);
-        return std::move(result);
+        return result;
     }
     else {
         return shapesToReturn[0];
@@ -3175,7 +3175,7 @@ TopoDS_Shape TopoShape::removeSplitter() const
                 builder.Add(comp, xp.Current());
         }
 
-        return std::move(comp);
+        return comp;
     }
 
     return _Shape;

--- a/src/Mod/Part/Gui/DlgProjectionOnSurface.cpp
+++ b/src/Mod/Part/Gui/DlgProjectionOnSurface.cpp
@@ -542,7 +542,7 @@ TopoDS_Shape PartGui::DlgProjectionOnSurface::create_compound(const std::vector<
       }
     }
   }
-  return std::move(aCompound);
+  return aCompound;
 }
 
 void PartGui::DlgProjectionOnSurface::show_projected_shapes(const std::vector<SShapeStore>& iShapeStoreVec)

--- a/src/Mod/Path/App/Area.cpp
+++ b/src/Mod/Path/App/Area.cpp
@@ -1730,7 +1730,7 @@ TopoDS_Shape Area::toShape(CArea &area, short fill, int reorient) {
                 builder.Add(compound,s);\
             }\
             if(TopExp_Explorer(compound,TopAbs_EDGE).More())\
-                return std::move(compound);\
+                return compound;\
             return TopoDS_Shape();\
         }\
         return mySections[_index]->_op(_index, ## __VA_ARGS__);\
@@ -1868,7 +1868,7 @@ TopoDS_Shape Area::makeOffset(int index,PARAM_ARGS(PARAM_FARG,AREA_PARAMS_OFFSET
     if(thicken)
         FC_DURATION_LOG(d,"Thicken");
     if(TopExp_Explorer(compound,TopAbs_EDGE).More())
-        return std::move(compound);
+        return compound;
     return TopoDS_Shape();
 }
 
@@ -2255,7 +2255,7 @@ TopoDS_Shape Area::toShape(const CArea &area, bool fill, const gp_Trsf *trsf, in
             AREA_WARN("FaceMakerBullseye failed: "<<e.what());
         }
     }
-    return std::move(compound);
+    return compound;
 }
 
 struct WireInfo {

--- a/src/Mod/Sketcher/App/ExternalGeometryExtension.cpp
+++ b/src/Mod/Sketcher/App/ExternalGeometryExtension.cpp
@@ -66,14 +66,14 @@ void ExternalGeometryExtension::Restore(Base::XMLReader &reader)
 
 std::unique_ptr<Part::GeometryExtension> ExternalGeometryExtension::copy(void) const
 {
-    std::unique_ptr<ExternalGeometryExtension> cpy = std::make_unique<ExternalGeometryExtension>();
+    auto cpy = std::make_unique<ExternalGeometryExtension>();
 
     cpy->Ref = this->Ref;
     cpy->Flags = this->Flags;
 
     cpy->setName(this->getName()); // Base Class
 
-    return std::move(cpy);
+    return cpy;
 }
 
 PyObject * ExternalGeometryExtension::getPyObject(void)

--- a/src/Mod/Sketcher/App/SketchGeometryExtension.cpp
+++ b/src/Mod/Sketcher/App/SketchGeometryExtension.cpp
@@ -75,13 +75,13 @@ void SketchGeometryExtension::Restore(Base::XMLReader &reader)
 
 std::unique_ptr<Part::GeometryExtension> SketchGeometryExtension::copy(void) const
 {
-    std::unique_ptr<SketchGeometryExtension> cpy = std::make_unique<SketchGeometryExtension>();
+    auto cpy = std::make_unique<SketchGeometryExtension>();
 
     cpy->Id = this->Id;
 
     cpy->setName(this->getName()); // Base Class
 
-    return std::move(cpy);
+    return cpy;
 }
 
 PyObject * SketchGeometryExtension::getPyObject(void)


### PR DESCRIPTION
Fix redundant use of `std::move`.
`std::move` is redundant when it is used to return a local object from a function (eg `return std::move(local)`): indeed, returning a local object from a function implicitly moves it. Moreover using `std::move` this way may also prevent copy elision optimization.
See https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Rf-return-move-local

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [X] Branch rebased on latest master `git pull --rebase upstream master`
- [X] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [X] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
