### PR TITLE
Improvements based on static analysis

### DIFF
--- a/src/3rdParty/salomesmesh/inc/UNV_Utilities.hxx
+++ b/src/3rdParty/salomesmesh/inc/UNV_Utilities.hxx
@@ -99,7 +99,7 @@ namespace UNV{
      * 6th element, to improve speed.
      * We dont expect a "D" earlier
      */
-    const int position = number.find("D",6);
+    const int position = number.find('D',6);
     if(position != std::string::npos){
       number.replace(position, 1, "e"); 
     }

--- a/src/3rdParty/salomesmesh/src/DriverUNV/DriverUNV_R_SMDS_Mesh.cpp
+++ b/src/3rdParty/salomesmesh/src/DriverUNV/DriverUNV_R_SMDS_Mesh.cpp
@@ -419,7 +419,7 @@ Driver_Mesh::Status DriverUNV_R_SMDS_Mesh::Perform()
             int i = aGrName.find( "\r\n" );
             if (i > 0)
               aGrName.erase (i, 2);
-            i = aGrName.find( "\r" );
+            i = aGrName.find( '\r' );
             if (i > 0)
               aGrName.erase (i, 1);
             myGroupNames.insert(TGroupNamesMap::value_type(aNodesGroup, aGrName));
@@ -449,7 +449,7 @@ Driver_Mesh::Status DriverUNV_R_SMDS_Mesh::Perform()
                     int i = aEdgesGrName.find( "\r\n" );
                     if (i > 0)
                       aEdgesGrName.erase (i, 2);
-                    i = aEdgesGrName.find( "\r" );
+                    i = aEdgesGrName.find( '\r' );
                     if (i > 0)
                       aEdgesGrName.erase (i, 1);
                     myGroupNames.insert(TGroupNamesMap::value_type(aEdgesGroup, aEdgesGrName));
@@ -466,7 +466,7 @@ Driver_Mesh::Status DriverUNV_R_SMDS_Mesh::Perform()
                     int i = aFacesGrName.find( "\r\n" );
                     if (i > 0)
                       aFacesGrName.erase (i, 2);
-                    i = aFacesGrName.find( "\r" );
+                    i = aFacesGrName.find( '\r' );
                     if (i > 0)
                       aFacesGrName.erase (i, 1);
                     myGroupNames.insert(TGroupNamesMap::value_type(aFacesGroup, aFacesGrName));
@@ -483,7 +483,7 @@ Driver_Mesh::Status DriverUNV_R_SMDS_Mesh::Perform()
                     int i = aVolumeGrName.find( "\r\n" );
                     if (i > 0)
                       aVolumeGrName.erase (i, 2);
-                    i = aVolumeGrName.find( "\r" );
+                    i = aVolumeGrName.find( '\r' );
                     if (i > 0)
                       aVolumeGrName.erase (i, 1);
                     myGroupNames.insert(TGroupNamesMap::value_type(aVolumeGroup, aVolumeGrName));

--- a/src/3rdParty/salomesmesh/src/SMESH/GEOMUtils.cpp
+++ b/src/3rdParty/salomesmesh/src/SMESH/GEOMUtils.cpp
@@ -246,8 +246,8 @@ namespace
 
   GEOMUtils::LevelsList parseWard( const std::string& theData, std::size_t& theCursor )
   {
-    std::size_t indexStart = theData.find( "{", theCursor ) + 1;
-    std::size_t indexEnd = theData.find( "}", indexStart );
+    std::size_t indexStart = theData.find( '{', theCursor ) + 1;
+    std::size_t indexEnd = theData.find( '}', indexStart );
 
     std::string ward = theData.substr( indexStart, indexEnd - indexStart );
     std::stringstream ss(ward);
@@ -1082,8 +1082,8 @@ void GEOMUtils::ConvertStringToTree( const std::string& dependencyStr,
     std::string objectEntry = dependencyStr.substr( cursor, objectIndex - cursor );
     cursor = objectIndex;
 
-    std::size_t upwardIndexBegin = dependencyStr.find("{",cursor) + 1;
-    std::size_t upwardIndexFinish = dependencyStr.find("}",upwardIndexBegin);
+    std::size_t upwardIndexBegin = dependencyStr.find('{',cursor) + 1;
+    std::size_t upwardIndexFinish = dependencyStr.find('}',upwardIndexBegin);
     LevelsList upwardList = parseWard( dependencyStr, cursor );
 
     LevelsList downwardList = parseWard( dependencyStr, cursor );

--- a/src/App/ExpressionParser.tab.c
+++ b/src/App/ExpressionParser.tab.c
@@ -1835,7 +1835,7 @@ yyreduce:
 
   case 66:
 #line 190 "ExpressionParser.y" /* yacc.c:1646  */
-    { (yyvsp[-1].expr)->addComponent(std::move((yyvsp[0].component))); (yyval.expr) = (yyvsp[-1].expr); }
+    { (yyvsp[-1].expr)->addComponent((yyvsp[0].component)); (yyval.expr) = (yyvsp[-1].expr); }
 #line 1840 "ExpressionParser.tab.c" /* yacc.c:1646  */
     break;
 

--- a/src/App/Extension.cpp
+++ b/src/App/Extension.cpp
@@ -111,7 +111,7 @@ std::string Extension::name() const {
         throw Base::RuntimeError("Extension::name: Extension type not set");
     
     std::string temp(m_extensionType.getName());
-    std::string::size_type pos = temp.find_last_of(":");
+    std::string::size_type pos = temp.find_last_of(':');
 
     if(pos != std::string::npos)
         return temp.substr(pos+1);

--- a/src/App/ObjectIdentifier.cpp
+++ b/src/App/ObjectIdentifier.cpp
@@ -1857,7 +1857,7 @@ void ObjectIdentifier::resolveAmbiguity(ResolveResults &result) {
     if(result.resolvedDocumentObject == owner) {
         setDocumentObjectName(owner,false,std::move(subname));
     }else if(result.flags.test(ResolveByIdentifier))
-        setDocumentObjectName(std::move(result.resolvedDocumentObject),true,std::move(subname));
+        setDocumentObjectName(result.resolvedDocumentObject,true,std::move(subname));
     else
         setDocumentObjectName(
                 String(result.resolvedDocumentObject->Label.getStrValue(),true,false),true,std::move(subname));

--- a/src/App/ObjectIdentifier.h
+++ b/src/App/ObjectIdentifier.h
@@ -267,7 +267,7 @@ public:
         documentObjectNameSet = other.documentObjectNameSet;
         localProperty = other.localProperty;
         _cache = std::move(other._cache);
-        _hash = std::move(other._hash);
+        _hash = other._hash;
         return *this;
     }
 

--- a/src/App/PropertyLinks.cpp
+++ b/src/App/PropertyLinks.cpp
@@ -2161,7 +2161,7 @@ void PropertyLinkSubList::Restore(Base::XMLReader &reader)
     reader.readEndElement("LinkSubList");
 
     // assignment
-    setValues(values,std::move(SubNames),std::move(shadows));
+    setValues(values,SubNames,std::move(shadows));
     _mapped.swap(mapped);
 }
 
@@ -2941,7 +2941,7 @@ void PropertyXLink::setValue(App::DocumentObject *lValue,
     _pcLink=lValue;
     if(docInfo && docInfo->pcDoc)
         stamp=docInfo->pcDoc->LastModifiedDate.getValue();
-    objectName = std::move(name);
+    objectName = name;
     setSubValues(std::move(subs),std::move(shadows));
     hasSetValue();
 }

--- a/src/Base/Interpreter.cpp
+++ b/src/Base/Interpreter.cpp
@@ -792,7 +792,7 @@ int getSWIGVersionFromModule(const std::string& module)
             Py::String file(mod.getAttr("__file__"));
             std::string filename = (std::string)file;
             // file can have the extension .py or .pyc
-            filename = filename.substr(0, filename.rfind("."));
+            filename = filename.substr(0, filename.rfind('.'));
             filename += ".py";
             boost::regex rx("^# Version ([1-9])\\.([0-9])\\.([0-9]+)");
             boost::cmatch what;

--- a/src/Base/Writer.cpp
+++ b/src/Base/Writer.cpp
@@ -317,7 +317,7 @@ void FileWriter::writeFiles(void)
         if (shouldWrite(entry.FileName, entry.Object)) {
             std::string filePath = entry.FileName;
             std::string::size_type pos = 0;
-            while ((pos = filePath.find("/", pos)) != std::string::npos) {
+            while ((pos = filePath.find('/', pos)) != std::string::npos) {
                 std::string dirName = DirName + "/" + filePath.substr(0, pos);
                 pos++;
                 Base::FileInfo fi(dirName);

--- a/src/Gui/AutoSaver.cpp
+++ b/src/Gui/AutoSaver.cpp
@@ -375,7 +375,7 @@ void RecoveryWriter::writeFiles(void)
         if (shouldWrite(entry.FileName, entry.Object)) {
             std::string filePath = entry.FileName;
             std::string::size_type pos = 0;
-            while ((pos = filePath.find("/", pos)) != std::string::npos) {
+            while ((pos = filePath.find('/', pos)) != std::string::npos) {
                 std::string dirName = DirName + "/" + filePath.substr(0, pos);
                 pos++;
                 Base::FileInfo fi(dirName);

--- a/src/Gui/DAGView/DAGModel.cpp
+++ b/src/Gui/DAGView/DAGModel.cpp
@@ -46,6 +46,8 @@
 #include <QAbstractEventDispatcher>
 
 #include <deque>
+#include <memory>
+
 #include <unordered_set>
 
 #include <Base/TimeInfo.h>
@@ -105,8 +107,8 @@ Model::Model(QObject *parentIn, const Gui::Document &documentIn) : QGraphicsScen
   //underneath cursor.
   this->setItemIndexMethod(QGraphicsScene::NoIndex);
   
-  theGraph = std::shared_ptr<Graph>(new Graph());
-  graphLink = std::shared_ptr<GraphLinkContainer>(new GraphLinkContainer());
+  theGraph = std::make_shared<Graph>();
+  graphLink = std::make_shared<GraphLinkContainer>();
   setupViewConstants();
   setupFilters();
   
@@ -488,7 +490,7 @@ void Model::updateSlot()
       boost::tie(edge, result) = boost::add_edge(currentVertex, otherVertex, *theGraph);
       if (result)
       {
-        (*theGraph)[edge].connector = std::shared_ptr<QGraphicsPathItem>(new QGraphicsPathItem());
+        (*theGraph)[edge].connector = std::make_shared<QGraphicsPathItem>();
         (*theGraph)[edge].connector->setZValue(0.0);
       }
     }

--- a/src/Gui/DAGView/DAGModel.cpp
+++ b/src/Gui/DAGView/DAGModel.cpp
@@ -893,7 +893,7 @@ void Model::updateStates()
 std::size_t Model::columnFromMask(const ColumnMask &maskIn)
 {
   std::string maskString = maskIn.to_string();
-  return maskString.size() - maskString.find("1") - 1;
+  return maskString.size() - maskString.find('1') - 1;
 }
 
 RectItem* Model::getRectFromPosition(const QPointF& position)

--- a/src/Gui/DAGView/DAGView.cpp
+++ b/src/Gui/DAGView/DAGView.cpp
@@ -26,6 +26,8 @@
 #include <QVBoxLayout>
 #endif
 
+#include <memory>
+
 #include <sstream>
 
 #include <Base/Console.h>
@@ -70,7 +72,7 @@ void View::slotActiveDocument(const Document &documentIn)
   ModelMap::const_iterator it = modelMap.find(&documentIn);
   if (it == modelMap.end())
   {
-    ModelMap::value_type entry(std::make_pair(&documentIn, std::shared_ptr<Model>(new Model(this, documentIn))));
+    ModelMap::value_type entry(std::make_pair(&documentIn, std::make_shared<Model>(this, documentIn)));
     modelMap.insert(entry);
     this->setScene(entry.second.get());
   }

--- a/src/Mod/Fem/App/FemMesh.cpp
+++ b/src/Mod/Fem/App/FemMesh.cpp
@@ -1023,7 +1023,7 @@ void FemMesh::readNastran(const std::string &Filename)
     {
         std::getline(inputfile,line1);
         if (line1.size() == 0) continue;
-        if (!nastran_free_format && line1.find(",")!= std::string::npos)
+        if (!nastran_free_format && line1.find(',')!= std::string::npos)
             nastran_free_format = true;
         if (!nastran_free_format && line1.find("GRID*")!= std::string::npos ) //We found a Grid line
         {

--- a/src/Mod/Mesh/App/Core/MeshIO.cpp
+++ b/src/Mod/Mesh/App/Core/MeshIO.cpp
@@ -1624,7 +1624,7 @@ bool MeshInput::LoadNastran (std::istream &rstrIn)
         if (line.find("GRID*") == 0) {
             assert(0);
         }
-        else if (line.find("*") == 0) {
+        else if (line.find('*') == 0) {
             assert(0);
         }
         // insert the read-in vertex into a map to preserve the order

--- a/src/Mod/PartDesign/Gui/CommandBody.cpp
+++ b/src/Mod/PartDesign/Gui/CommandBody.cpp
@@ -394,7 +394,7 @@ void CmdPartDesignMigrate::activated(int iMsg)
             // we are basing on some partdesign feature which supposed to belong to some body
             PartDesign::Feature *baseFeat = static_cast <PartDesign::Feature *>( base );
 
-            auto baseFeatSetIt = find ( migrateFeatures.begin (), migrateFeatures.end (), baseFeat );
+            auto baseFeatSetIt = migrateFeatures.find(baseFeat);
 
             if ( baseFeatSetIt != migrateFeatures.end() ) {
                 // base feature is pending for migration, switch to it and continue over

--- a/src/Mod/Path/App/Path.cpp
+++ b/src/Mod/Path/App/Path.cpp
@@ -261,7 +261,7 @@ void Toolpath::setFromGCode(const std::string instr)
             }
             mode = "comment";
             last = found;
-            found = str.find_first_of(")", found+1);
+            found = str.find_first_of(')', found+1);
         } else if (str[found] == ')') {
             // end of comment
             std::string gcodestr = str.substr(last, found-last+1);

--- a/src/Mod/Path/libarea/AreaOrderer.cpp
+++ b/src/Mod/Path/libarea/AreaOrderer.cpp
@@ -28,6 +28,7 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 #include "AreaOrderer.h"
+#include <memory>
 #include "Area.h"
 
 using namespace std;
@@ -132,7 +133,7 @@ void CInnerCurves::Unite(shared_ptr<CInnerCurves> c)
 		else
 		{
 			if(curve.IsClockwise())curve.Reverse();
-			Insert(shared_ptr<CCurve>(new CCurve(curve)));
+			Insert(std::make_shared<CCurve>(curve));
 		}
 	}
 }

--- a/src/Mod/Sketcher/App/planegcs/GCS.cpp
+++ b/src/Mod/Sketcher/App/planegcs/GCS.cpp
@@ -4060,7 +4060,7 @@ SolverReportingManager::Manager().LogToFile("GCS::System::diagnose()\n");
 
         // If not independent, must be dependent
         for(int j=0; j < paramsNum; j++) {
-            auto result = std::find(indepParamCols.begin(), indepParamCols.end(), j);
+            auto result = indepParamCols.find(j);
             if(result == indepParamCols.end()) {
                 depParamCols.insert(j);
             }

--- a/src/Mod/TechDraw/App/HatchLine.cpp
+++ b/src/Mod/TechDraw/App/HatchLine.cpp
@@ -343,7 +343,7 @@ bool  PATLineSpec::findPatternStart(std::ifstream& inFile, std::string& parmName
              (line.empty()) )  {           //is cr/lf empty?
              continue;
          } else if (nameTag == "*") {
-             commaPos = line.find(",",1);
+             commaPos = line.find(',',1);
              if (commaPos != std::string::npos) {
                   patternName = line.substr(1,commaPos-1);
              } else {
@@ -396,7 +396,7 @@ std::vector<std::string> PATLineSpec::getPatternList(std::string& parmFile)
         std::string nameTag = line.substr(0,1);               //dupl code here
         unsigned long int commaPos;
         if (nameTag == "*") {  //found a pattern
-            commaPos = line.find(",",1);
+            commaPos = line.find(',',1);
             std::string patternName;
             if (commaPos != std::string::npos) {
                  patternName = line.substr(1,commaPos-1);

--- a/src/Mod/TechDraw/App/LineGroup.cpp
+++ b/src/Mod/TechDraw/App/LineGroup.cpp
@@ -148,7 +148,7 @@ std::string LineGroup::getRecordFromFile(std::string parmFile, std::string group
              (line.empty()) )  {           //is cr/lf empty?
              continue;
          } else if (nameTag == "*") {
-             commaPos = line.find(",",1);
+             commaPos = line.find(',',1);
              if (commaPos != std::string::npos) {
                   foundName = line.substr(1,commaPos-1);
              } else {


### PR DESCRIPTION
1) Remove useless move (on const and unmovable objects). clang-tiy + 'performance-move-const-arg' check
2) Use make_shared and make_unique. 'modernize-make-unique' and  'modernize-make-shared checks'
3) Used inbuilt metods instead of external algoritms in a couple of places. 'performance-inefficient-algorithm' check 
4) Used single quotes for single character in string::find (more efficient). 'performance-faster-string-find' check