### PR TITLE
Explicitly specify encoding in PythonToCPP.py

### DIFF
--- a/src/Tools/PythonToCPP.py
+++ b/src/Tools/PythonToCPP.py
@@ -7,13 +7,13 @@ import os,sys,string
 #os.chdir("E:\\Develop\\FreeCADWin\\scripts")
 
 
-file = open(sys.argv[1])
+file = open(sys.argv[1],encoding="utf-8")
 
 if(len(sys.argv) > 4):
     sys.stderr.write("Wrong Parameter\n  Usage:\n  PythonToCPP Infile.py [Outfile][Variable]\n")
 
 if(len(sys.argv) > 2):
-    out = open(sys.argv[2],"w");
+    out = open(sys.argv[2],"w",encoding="utf-8");
 else:
     out = sys.stdout
 


### PR DESCRIPTION
On Windows, the python script opens a file with the default ANSI encoding. This causes UnicodeDecodeError in some region. The encoding should be set explicitly to match the files.
