### PR TITLE
App: fix PropertyXLink file path saving

### DIFF
--- a/src/App/PropertyLinks.cpp
+++ b/src/App/PropertyLinks.cpp
@@ -2902,6 +2902,8 @@ void PropertyXLink::setValue(App::DocumentObject *lValue,
     if(lValue == owner)
         throw Base::ValueError("self linking");
 
+    aboutToSetValue();
+
     DocInfoPtr info;
     const char *name = "";
     if(lValue) {
@@ -2921,7 +2923,6 @@ void PropertyXLink::setValue(App::DocumentObject *lValue,
     }
 
     setFlag(LinkDetached,false);
-    aboutToSetValue();
 #ifndef USE_OLD_DAG
     if (!owner->testStatus(ObjectStatus::Destroy) && _pcScope!=LinkScope::Hidden) {
         if(_pcLink)
@@ -2934,9 +2935,7 @@ void PropertyXLink::setValue(App::DocumentObject *lValue,
         unlink();
         docInfo = info;
     }
-    if(docInfo)
-        filePath = docInfo->filePath();
-    else
+    if(!docInfo)
         filePath.clear();
     _pcLink=lValue;
     if(docInfo && docInfo->pcDoc)
@@ -2981,9 +2980,7 @@ void PropertyXLink::setValue(std::string &&filename, std::string &&name,
         unlink();
         docInfo = info;
     }
-    if(docInfo)
-        filePath = docInfo->filePath();
-    else
+    if(!docInfo)
         filePath.clear();
     if(docInfo && docInfo->pcDoc)
         stamp=docInfo->pcDoc->LastModifiedDate.getValue();

--- a/src/App/PropertyLinks.h
+++ b/src/App/PropertyLinks.h
@@ -1125,6 +1125,10 @@ public:
 
     virtual void setAllowPartial(bool enable) override;
 
+    const char *getFilePath() const {
+        return filePath.c_str();
+    }
+
 protected:
     void unlink();
     void detach();

--- a/src/Gui/propertyeditor/PropertyItem.cpp
+++ b/src/Gui/propertyeditor/PropertyItem.cpp
@@ -3623,10 +3623,19 @@ QVariant PropertyLinkItem::toString(const QVariant& prop) const
 }
 
 QVariant PropertyLinkItem::data(int column, int role) const {
-    if(propertyItems.size() && column == 1 && role == Qt::TextColorRole) {
+    if(propertyItems.size() && column == 1 
+            && (role == Qt::TextColorRole || role == Qt::ToolTipRole))
+    {
         auto xlink = Base::freecad_dynamic_cast<const App::PropertyXLink>(propertyItems[0]);
-        if(xlink && xlink->checkRestore()>1)
-            return QVariant::fromValue(QColor(0xff,0,0));
+        if(xlink) {
+            if(role==Qt::TextColorRole && xlink->checkRestore()>1)
+                return QVariant::fromValue(QColor(0xff,0,0));
+            else if(role == Qt::ToolTipRole) {
+                const char *filePath = xlink->getFilePath();
+                if(filePath && filePath[0])
+                    return QVariant::fromValue(QString::fromUtf8(filePath));
+            }
+        }
     }
     return PropertyItem::data(column,role);
 }


### PR DESCRIPTION
Save path as relative instead of absolute. Also modified ProeprtyLinkItem to show file path as tooltip.

Forum thread https://forum.freecadweb.org/viewtopic.php?f=20&t=40403