### PR TITLE
Draft: rename SubelementModify to SubelementHighlight

### DIFF
--- a/src/Mod/Draft/DraftTools.py
+++ b/src/Mod/Draft/DraftTools.py
@@ -2367,7 +2367,7 @@ class Move(Modifier):
     def Activated(self):
         self.name = translate("draft","Move", utf8_decode=True)
         Modifier.Activated(self, self.name,
-                           is_subtool=isinstance(FreeCAD.activeDraftCommand, SubelementModify))
+                           is_subtool=isinstance(FreeCAD.activeDraftCommand, SubelementHighlight))
         if not self.ui:
             return
         self.ghosts = []
@@ -4270,8 +4270,8 @@ class ToggleDisplayMode():
                 if "Flat Lines" in obj.ViewObject.listDisplayModes():
                     obj.ViewObject.DisplayMode = "Flat Lines"
 
-class SubelementModify(Modifier):
-    """The Draft_SubelementModify FreeCAD command definition"""
+class SubelementHighlight(Modifier):
+    """The Draft_SubelementHighlight FreeCAD command definition"""
 
     def __init__(self):
         self.is_running = False
@@ -4279,18 +4279,20 @@ class SubelementModify(Modifier):
         self.original_view_settings = {}
 
     def GetResources(self):
-        return {'Pixmap'  : 'Draft_SubelementModify',
+        return {'Pixmap'  : 'Draft_SubelementHighlight',
                 'Accel' : "D, E",
-                'MenuText': QtCore.QT_TRANSLATE_NOOP("Draft_SubelementModify", "Subelement modify"),
-                'ToolTip': QtCore.QT_TRANSLATE_NOOP("Draft_SubelementModify",
-                                                    "Allows editing the subelements "
-                                                    "of the selected objects with other modification tools")}
+                'MenuText': QtCore.QT_TRANSLATE_NOOP("Draft_SubelementHighlight", "Subelement highlight"),
+                'ToolTip': QtCore.QT_TRANSLATE_NOOP("Draft_SubelementHighlight",
+                                                    "Highlight the subelements "
+                                                    "of the selected objects, "
+                                                    "so that they can then be edited "
+                                                    "with the move, rotate, and scale tools")}
 
     def Activated(self):
         if self.is_running:
             return self.finish()
         self.is_running = True
-        Modifier.Activated(self, "SubelementModify")
+        Modifier.Activated(self, "SubelementHighlight")
         self.get_selection()
 
     def proceed(self):
@@ -5683,7 +5685,7 @@ FreeCADGui.addCommand('Draft_Downgrade',Downgrade())
 FreeCADGui.addCommand('Draft_Trimex',Trimex())
 FreeCADGui.addCommand('Draft_Scale',Scale())
 FreeCADGui.addCommand('Draft_Drawing',Drawing())
-FreeCADGui.addCommand('Draft_SubelementModify', SubelementModify())
+FreeCADGui.addCommand('Draft_SubelementHighlight', SubelementHighlight())
 FreeCADGui.addCommand('Draft_AddPoint',AddPoint())
 FreeCADGui.addCommand('Draft_DelPoint',DelPoint())
 FreeCADGui.addCommand('Draft_WireToBSpline',WireToBSpline())

--- a/src/Mod/Draft/InitGui.py
+++ b/src/Mod/Draft/InitGui.py
@@ -82,7 +82,7 @@ class DraftWorkbench(Workbench):
         self.modList = ["Draft_Move", "Draft_Rotate", "Draft_Offset",
                         "Draft_Trimex", "Draft_Join", "Draft_Split",
                         "Draft_Upgrade", "Draft_Downgrade", "Draft_Scale",
-                        "Draft_Edit", "Draft_SubelementModify",
+                        "Draft_Edit", "Draft_SubelementHighlight",
                         "Draft_WireToBSpline", "Draft_AddPoint",
                         "Draft_DelPoint", "Draft_Shape2DView",
                         "Draft_Draft2Sketch", "Draft_Array", "Draft_LinkArray",

--- a/src/Mod/Draft/Resources/Draft.qrc
+++ b/src/Mod/Draft/Resources/Draft.qrc
@@ -62,7 +62,7 @@
         <file>icons/Draft_Snap.svg</file>
         <file>icons/Draft_Split.svg</file>
         <file>icons/Draft_Stretch.svg</file>
-        <file>icons/Draft_SubelementModify.svg</file>
+        <file>icons/Draft_SubelementHighlight.svg</file>
         <file>icons/Draft_SwitchMode.svg</file>
         <file>icons/Draft_Text.svg</file>
         <file>icons/Draft_Trimex.svg</file>

--- a/src/Mod/Draft/Resources/icons/Draft_SubelementHighlight.svg
+++ b/src/Mod/Draft/Resources/icons/Draft_SubelementHighlight.svg
@@ -15,7 +15,7 @@
    id="svg3612"
    version="1.1"
    inkscape:version="0.92.3 (2405546, 2018-03-11)"
-   sodipodi:docname="Draft_SubelementModify.svg">
+   sodipodi:docname="Draft_SubelementHighlight.svg">
   <defs
      id="defs3614">
     <radialGradient


### PR DESCRIPTION
This pull request is a continuation of #2597. It just renames `Draft_SubelementModify` (previously Draft_Edit_Improved) to `Draft_SubelementHighlight`.

This was mentioned by @carlopav before, so I finally took his advice. This command doesn't actually modify anything, it only highlights the nodes so they can be modified by the move, rotate, and scale tools. I adjusted the tooltip as well.

---

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists