### PR TITLE
[Draft/Arch - do not merge] Proposal change move/rotate when applied to groups, parts and other arch objects.

### DIFF
--- a/src/Mod/Arch/ArchWall.py
+++ b/src/Mod/Arch/ArchWall.py
@@ -298,7 +298,12 @@ class _CommandWall:
         FreeCADGui.addModule("Draft")
         if FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/Arch").GetBool("WallSketches",True):
             FreeCADGui.doCommand('base=FreeCAD.ActiveDocument.addObject("Sketcher::SketchObject","WallTrace")')
-            FreeCADGui.doCommand('base.Placement = FreeCAD.DraftWorkingPlane.getPlacement()')
+            #FreeCADGui.doCommand('base.Placement = FreeCAD.DraftWorkingPlane.getPlacement()')
+            FreeCADGui.doCommand('delta = trace.EndPoint.sub(trace.StartPoint)')
+            FreeCADGui.doCommand('centre = trace.StartPoint.add(delta/2)')
+            FreeCADGui.doCommand('trace = Part.LineSegment(FreeCAD.Vector(-delta.Length/2,0,0),FreeCAD.Vector(delta.Length/2,0,0))')
+            FreeCADGui.doCommand('import math, DraftVecUtils')
+            FreeCADGui.doCommand('base.Placement=App.Placement(centre,FreeCAD.Rotation(FreeCAD.DraftWorkingPlane.getNormal(),(-math.degrees(DraftVecUtils.angle(delta, normal=FreeCAD.DraftWorkingPlane.getNormal())))))')
             FreeCADGui.doCommand('base.addGeometry(trace)')
         else:
             FreeCADGui.doCommand('base=Draft.makeLine(trace)')

--- a/src/Mod/Arch/ArchWall.py
+++ b/src/Mod/Arch/ArchWall.py
@@ -752,10 +752,18 @@ class _Wall(ArchComponent.Component):
         obj.Area = obj.Length.Value * obj.Height.Value
 
     def onBeforeChange(self,obj,prop):
+        if prop == "Placement":
+            self.oldPlacement = FreeCAD.Placement(obj.Placement)
+
         if prop == "Length":
             self.oldLength = obj.Length.Value
 
     def onChanged(self, obj, prop):
+        if prop == "Placement":
+            print("placement changed")
+            super().onChanged(obj, prop)
+            self.oldPlacement = None
+
         if prop == "Length":
             if obj.Base and obj.Length.Value and hasattr(self,"oldLength") and (self.oldLength != None) and (self.oldLength != obj.Length.Value):
                 if obj.Base.isDerivedFrom("Part::Feature"):

--- a/src/Mod/Draft/Draft.py
+++ b/src/Mod/Draft/Draft.py
@@ -399,48 +399,17 @@ def getGroupContents(objectslist,walls=False,addgroups=False,spaces=False,noarch
     is a group, its content is appended to the list, which is returned. If walls is True,
     walls and structures are also scanned for included windows or rebars. If addgroups
     is true, the group itself is also included in the list."""
-    def getWindows(obj):
-        l = []
-        if getType(obj) in ["Wall","Structure"]:
-            for o in obj.OutList:
-                l.extend(getWindows(o))
-            for i in obj.InList:
-                if (getType(i) in ["Window"]) or isClone(obj,"Window"):
-                    if hasattr(i,"Hosts"):
-                        if obj in i.Hosts:
-                            l.append(i)
-                elif (getType(i) in ["Rebar"]) or isClone(obj,"Rebar"):
-                    if hasattr(i,"Host"):
-                        if obj == i.Host:
-                            l.append(i)
-        elif (getType(obj) in ["Window","Rebar"]) or isClone(obj,["Window","Rebar"]):
-            l.append(obj)
-        return l
 
     newlist = []
     if not isinstance(objectslist,list):
         objectslist = [objectslist]
     for obj in objectslist:
         if obj:
-            if obj.isDerivedFrom("App::DocumentObjectGroup") or ((getType(obj) in ["App::Part","Building","BuildingPart","Space","Site"]) and hasattr(obj,"Group")):
-                if getType(obj) == "Site":
-                    if obj.Shape:
-                        newlist.append(obj)
-                if obj.isDerivedFrom("Drawing::FeaturePage"):
-                    # skip if the group is a page
-                    newlist.append(obj)
-                else:
-                    if addgroups or (spaces and (getType(obj) == "Space")):
-                        newlist.append(obj)
-                    if noarchchild and (getType(obj) in ["Building","BuildingPart"]):
-                        pass
-                    else:
-                        newlist.extend(getGroupContents(obj.Group,walls,addgroups))
+            if obj.isDerivedFrom("App::DocumentObjectGroup") and hasattr(obj,"Group"):
+                newlist.extend(getGroupContents(obj.Group,walls,addgroups))
             else:
                 #print("adding ",obj.Name)
                 newlist.append(obj)
-                if walls:
-                    newlist.extend(getWindows(obj))
 
     # cleaning possible duplicates
     cleanlist = []


### PR DESCRIPTION
Do not merge: this PR is made to show a proof of concept of modified behaviour of Draft Move and Rotate commands.

Currently DraftMove and DraftRotate parse user selection and add Arch childrens like windows. I propose to limit Draft modifiers to 2 options:
- groups: all the contained objects are added to selection;
- all other objects: just the selected object is moved/rotated. To handle special cases in Arch (like moving windows when wall is moved): the parent object, once moved, will propagate the placement to its children.

Reference to forum:
https://forum.freecadweb.org/viewtopic.php?f=23&t=40400&start=10#p344985

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
