### PR TITLE
Gui: Set QT settings before creating QCoreApplication.

### DIFF
--- a/src/Gui/Application.cpp
+++ b/src/Gui/Application.cpp
@@ -1761,14 +1761,23 @@ void Application::runApplication(void)
     QCoreApplication::setAttribute(Qt::AA_ShareOpenGLContexts);
 #endif
 
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 12, 0))
+    QCoreApplication::setAttribute(Qt::AA_UseDesktopOpenGL);
+#endif
+#if QT_VERSION >= 0x050600
+    //Enable automatic scaling based on pixel density of display (added in Qt 5.6)
+    QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+#endif
+#if QT_VERSION >= 0x050100
+    //Enable support for highres images (added in Qt 5.1, but off by default)
+    QCoreApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
+#endif
+
     // if application not yet created by the splasher
     int argc = App::Application::GetARGC();
     GUISingleApplication mainApp(argc, App::Application::GetARGV());
     // http://forum.freecadweb.org/viewtopic.php?f=3&t=15540
     mainApp.setAttribute(Qt::AA_DontShowIconsInMenus, false);
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 12, 0))
-    mainApp.setAttribute(Qt::AA_UseDesktopOpenGL);
-#endif
 
 #ifdef Q_OS_UNIX
     // Make sure that we use '.' as decimal point. See also
@@ -1805,14 +1814,6 @@ void Application::runApplication(void)
         return;
     }
 
-#if QT_VERSION >= 0x050600
-    //Enable automatic scaling based on pixel density of display (added in Qt 5.6)
-    mainApp.setAttribute(Qt::AA_EnableHighDpiScaling);
-#endif
-#if QT_VERSION >= 0x050100
-    //Enable support for highres images (added in Qt 5.1, but off by default)
-    mainApp.setAttribute(Qt::AA_UseHighDpiPixmaps);
-#endif
     // set application icon and window title
     it = cfg.find("Application");
     if (it != cfg.end()) {


### PR DESCRIPTION
When starting FC I get the following warnings in the command line:
markus@yolanda:~/projects/FreeCAD/mlampert/FreeCAD$ ../build/bin/FreeCAD box.FCStd
```
FreeCAD 0.19, Libs: 0.19R18714 (Git)
© Juergen Riegel, Werner Mayer, Yorik van Havre 2001-2019
  #####                 ####  ###   ####  
  #                    #      # #   #   # 
  #     ##  #### ####  #     #   #  #   # 
  ####  # # #  # #  #  #     #####  #   # 
  #     #   #### ####  #    #     # #   # 
  #     #   #    #     #    #     # #   #  ##  ##  ##
  #     #   #### ####   ### #     # ####   ##  ##  ##

Attribute Qt::AA_UseDesktopOpenGL must be set before QCoreApplication is created.
Attribute Qt::AA_EnableHighDpiScaling must be set before QCoreApplication is created.  
```

This change moves the attributes before the creation of the application. The effect is quite dramatic TBH.