### PR TITLE
Fix -Wredundant-move warnings, 2nd try

### DIFF
--- a/src/3rdParty/salomesmesh/src/SMESH/GEOMUtils.cpp
+++ b/src/3rdParty/salomesmesh/src/SMESH/GEOMUtils.cpp
@@ -643,7 +643,7 @@ TopoDS_Shape GEOMUtils::CompsolidToCompound (const TopoDS_Shape& theCompsolid)
     }
   }
 
-  return std::move(aCompound);
+  return TopoDS_Shape(std::move(aCompound));
 }
 
 //=======================================================================

--- a/src/3rdParty/salomesmesh/src/SMESH/SMESH_subMesh.cpp
+++ b/src/3rdParty/salomesmesh/src/SMESH/SMESH_subMesh.cpp
@@ -2100,7 +2100,7 @@ TopoDS_Shape SMESH_subMesh::getCollection(SMESH_Gen * theGen,
     }
   }
 
-  return std::move(aCompound);
+  return TopoDS_Compound(std::move(aCompound));
 }
 
 //=======================================================================

--- a/src/Mod/Part/App/FaceMakerCheese.cpp
+++ b/src/Mod/Part/App/FaceMakerCheese.cpp
@@ -236,7 +236,7 @@ TopoDS_Shape FaceMakerCheese::makeFace(const std::vector<TopoDS_Wire>& w)
                 builder.Add(comp, aFace);
         }
 
-        return std::move(comp);
+        return TopoDS_Shape(std::move(comp));
     }
     else {
         return TopoDS_Shape(); // error

--- a/src/Mod/Part/App/TopoShape.cpp
+++ b/src/Mod/Part/App/TopoShape.cpp
@@ -2222,7 +2222,7 @@ TopoDS_Shape TopoShape::makeHelix(Standard_Real pitch, Standard_Real height,
     TopoDS_Edge edgeOnSurf = BRepBuilderAPI_MakeEdge(segm , surf);
     TopoDS_Wire wire = BRepBuilderAPI_MakeWire(edgeOnSurf);
     BRepLib::BuildCurves3d(wire);
-    return std::move(wire);
+    return TopoDS_Shape(std::move(wire));
 }
 
 //***********
@@ -2308,7 +2308,7 @@ TopoDS_Shape TopoShape::makeLongHelix(Standard_Real pitch, Standard_Real height,
 
     TopoDS_Wire wire = mkWire.Wire();
     BRepLib::BuildCurves3d(wire);
-    return std::move(wire);
+    return TopoDS_Shape(std::move(wire));
 }
 
 TopoDS_Shape TopoShape::makeThread(Standard_Real pitch,
@@ -2926,9 +2926,10 @@ TopoDS_Shape TopoShape::makeOffset2D(double offset, short joinType, bool fill, b
         TopoDS_Compound result;
         BRep_Builder builder;
         builder.MakeCompound(result);
-        for(TopoDS_Shape &sh : shapesToReturn)
+        for(TopoDS_Shape &sh : shapesToReturn) {
             builder.Add(result, sh);
-        return std::move(result);
+        }
+        return TopoDS_Shape(std::move(result));
     }
     else {
         return shapesToReturn[0];
@@ -3175,7 +3176,7 @@ TopoDS_Shape TopoShape::removeSplitter() const
                 builder.Add(comp, xp.Current());
         }
 
-        return std::move(comp);
+        return TopoDS_Shape(std::move(comp));
     }
 
     return _Shape;

--- a/src/Mod/Part/Gui/DlgProjectionOnSurface.cpp
+++ b/src/Mod/Part/Gui/DlgProjectionOnSurface.cpp
@@ -542,7 +542,7 @@ TopoDS_Shape PartGui::DlgProjectionOnSurface::create_compound(const std::vector<
       }
     }
   }
-  return std::move(aCompound);
+  return TopoDS_Shape(std::move(aCompound));
 }
 
 void PartGui::DlgProjectionOnSurface::show_projected_shapes(const std::vector<SShapeStore>& iShapeStoreVec)

--- a/src/Mod/Path/App/Area.cpp
+++ b/src/Mod/Path/App/Area.cpp
@@ -1730,7 +1730,7 @@ TopoDS_Shape Area::toShape(CArea &area, short fill, int reorient) {
                 builder.Add(compound,s);\
             }\
             if(TopExp_Explorer(compound,TopAbs_EDGE).More())\
-                return std::move(compound);\
+                return TopoDS_Shape(std::move(compound));\
             return TopoDS_Shape();\
         }\
         return mySections[_index]->_op(_index, ## __VA_ARGS__);\
@@ -1867,8 +1867,9 @@ TopoDS_Shape Area::makeOffset(int index,PARAM_ARGS(PARAM_FARG,AREA_PARAMS_OFFSET
     }
     if(thicken)
         FC_DURATION_LOG(d,"Thicken");
-    if(TopExp_Explorer(compound,TopAbs_EDGE).More())
-        return std::move(compound);
+    if(TopExp_Explorer(compound,TopAbs_EDGE).More()) {
+        return TopoDS_Shape(std::move(compound));
+    }
     return TopoDS_Shape();
 }
 
@@ -2255,7 +2256,7 @@ TopoDS_Shape Area::toShape(const CArea &area, bool fill, const gp_Trsf *trsf, in
             AREA_WARN("FaceMakerBullseye failed: "<<e.what());
         }
     }
-    return std::move(compound);
+    return TopoDS_Shape(std::move(compound));
 }
 
 struct WireInfo {

--- a/src/Mod/Sketcher/App/ExternalGeometryExtension.cpp
+++ b/src/Mod/Sketcher/App/ExternalGeometryExtension.cpp
@@ -66,14 +66,14 @@ void ExternalGeometryExtension::Restore(Base::XMLReader &reader)
 
 std::unique_ptr<Part::GeometryExtension> ExternalGeometryExtension::copy(void) const
 {
-    std::unique_ptr<ExternalGeometryExtension> cpy = std::make_unique<ExternalGeometryExtension>();
+    auto cpy = std::make_unique<ExternalGeometryExtension>();
 
     cpy->Ref = this->Ref;
     cpy->Flags = this->Flags;
 
     cpy->setName(this->getName()); // Base Class
 
-    return std::move(cpy);
+    return cpy;
 }
 
 PyObject * ExternalGeometryExtension::getPyObject(void)

--- a/src/Mod/Sketcher/App/SketchGeometryExtension.cpp
+++ b/src/Mod/Sketcher/App/SketchGeometryExtension.cpp
@@ -75,13 +75,13 @@ void SketchGeometryExtension::Restore(Base::XMLReader &reader)
 
 std::unique_ptr<Part::GeometryExtension> SketchGeometryExtension::copy(void) const
 {
-    std::unique_ptr<SketchGeometryExtension> cpy = std::make_unique<SketchGeometryExtension>();
+    auto cpy = std::make_unique<SketchGeometryExtension>();
 
     cpy->Id = this->Id;
 
     cpy->setName(this->getName()); // Base Class
 
-    return std::move(cpy);
+    return cpy;
 }
 
 PyObject * SketchGeometryExtension::getPyObject(void)


### PR DESCRIPTION
std::move is redundant when it is used to return a local object from a function (eg return std::move(local)): indeed, returning a local object from a function implicitly moves it. Moreover using std::move this way may also prevent compiler optimization, like copy elision (See https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Rf-return-move-local). GCC 9.2 emits warnings when it encounters such cases.

However, in order to avoid "-Wreturn-std-move" from Clang as well:
In the case a Derived object is returned when the return-expression is of Base type, a Base temporary object is move-constructed from Derived and returned instead.

This PR replaces PR #2683 (see discussion in this PR). 

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [X] Branch rebased on latest master `git pull --rebase upstream master`
- [X] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [X] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
