### PR TITLE
Draft: PySide should be available already

### DIFF
--- a/src/Mod/Draft/DraftGui.py
+++ b/src/Mod/Draft/DraftGui.py
@@ -38,14 +38,18 @@ __url__ = ["http://www.freecadweb.org"]
 Report to Draft.py for info
 """
 
+import os
 import six
+import sys
+import traceback
+import math
 import platform
-import FreeCAD, FreeCADGui, os, Draft, sys, traceback, DraftVecUtils, math
+import FreeCAD
+import FreeCADGui
+import Draft
+import DraftVecUtils
+from PySide import QtCore, QtGui, QtSvg
 
-try:
-    from PySide import QtCore, QtGui, QtSvg
-except ImportError:
-    FreeCAD.Console.PrintMessage("Error: Python-pyside package must be installed on your system to use the Draft module.")
 
 try:
     _encoding = QtGui.QApplication.UnicodeUTF8 if six.PY2 else None


### PR DESCRIPTION
PySide is a dependency of FreeCAD, so it is unnecessary to test for it here. We should just import the module already. If it fails, this will be evident.

Also to comply with PEP8, import each module on its own line.

---

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists
