### PR TITLE
Fix typos and some trailing whitespace

### DIFF
--- a/src/App/Expression.cpp
+++ b/src/App/Expression.cpp
@@ -243,8 +243,8 @@ void ExpressionVisitor::getDeps(Expression &e, ExpressionDeps &deps) {
     e._getDeps(deps);
 }
 
-void ExpressionVisitor::getDepObjects(Expression &e, 
-        std::set<App::DocumentObject*> &deps, std::vector<std::string> *labels) 
+void ExpressionVisitor::getDepObjects(Expression &e,
+        std::set<App::DocumentObject*> &deps, std::vector<std::string> *labels)
 {
     e._getDepObjects(deps,labels);
 }
@@ -261,8 +261,8 @@ void ExpressionVisitor::importSubNames(Expression &e, const ObjectIdentifier::Su
     e._importSubNames(subNameMap);
 }
 
-void ExpressionVisitor::updateLabelReference(Expression &e, 
-        DocumentObject *obj, const std::string &ref, const char *newLabel) 
+void ExpressionVisitor::updateLabelReference(Expression &e,
+        DocumentObject *obj, const std::string &ref, const char *newLabel)
 {
     e._updateLabelReference(obj,ref,newLabel);
 }
@@ -272,7 +272,7 @@ bool ExpressionVisitor::updateElementReference(Expression &e, App::DocumentObjec
 }
 
 bool ExpressionVisitor::relabeledDocument(
-        Expression &e, const std::string &oldName, const std::string &newName) 
+        Expression &e, const std::string &oldName, const std::string &newName)
 {
     return e._relabeledDocument(oldName,newName,*this);
 }
@@ -283,7 +283,7 @@ bool ExpressionVisitor::renameObjectIdentifier(Expression &e,
     return e._renameObjectIdentifier(paths,path,*this);
 }
 
-void ExpressionVisitor::collectReplacement(Expression &e, 
+void ExpressionVisitor::collectReplacement(Expression &e,
         std::map<ObjectIdentifier,ObjectIdentifier> &paths,
         const App::DocumentObject *parent, App::DocumentObject *oldObj, App::DocumentObject *newObj) const
 {
@@ -440,7 +440,7 @@ static Py::Object _pyObjectFromAny(const App::any &value, const Expression *e) {
         return Py::Float(cast<double>(value));
     else if (is_type(value,typeid(float)))
         return Py::Float(cast<float>(value));
-    else if (is_type(value,typeid(int))) 
+    else if (is_type(value,typeid(int)))
 #if PY_MAJOR_VERSION < 3
         return Py::Int(cast<int>(value));
 #else
@@ -498,7 +498,7 @@ App::any pyObjectToAny(Py::Object value, bool check) {
 #endif
     else if (PyUnicode_Check(pyvalue)) {
         PyObject * s = PyUnicode_AsUTF8String(pyvalue);
-        if(!s) 
+        if(!s)
             FC_THROWM(Base::ValueError,"Invalid unicode string");
         Py::Object o(s,true);
 
@@ -529,8 +529,8 @@ bool pyToQuantity(Quantity &q, const Py::Object &pyobj) {
     return true;
 }
 
-static inline Quantity pyToQuantity(const Py::Object &pyobj, 
-        const Expression *e, const char *msg=0) 
+static inline Quantity pyToQuantity(const Py::Object &pyobj,
+        const Expression *e, const char *msg=0)
 {
     Quantity q;
     if(!pyToQuantity(q,pyobj)) {
@@ -607,13 +607,13 @@ static inline bool anyToDouble(double &res, const App::any &value) {
 }
 
 bool isAnyEqual(const App::any &v1, const App::any &v2) {
-    if(v1.empty()) 
+    if(v1.empty())
         return v2.empty();
     else if(v2.empty())
         return false;
 
     if(!is_type(v1,v2.type())) {
-        if(is_type(v1,typeid(Quantity))) 
+        if(is_type(v1,typeid(Quantity)))
             return cast<Quantity>(v1) == anyToQuantity(v2);
         else if(is_type(v2,typeid(Quantity)))
             return anyToQuantity(v1) == cast<Quantity>(v2);
@@ -621,7 +621,7 @@ bool isAnyEqual(const App::any &v1, const App::any &v2) {
         long l1,l2;
         double d1,d2;
         if(anyToLong(l1,v1)) {
-            if(anyToLong(l2,v2)) 
+            if(anyToLong(l2,v2))
                 return l1==l2;
             else if(anyToDouble(d2,v2))
                 return essentiallyEqual((double)l1,d2);
@@ -649,21 +649,21 @@ bool isAnyEqual(const App::any &v1, const App::any &v2) {
         return cast<int>(v1) == cast<int>(v2);
     if (is_type(v1,typeid(long)))
         return cast<long>(v1) == cast<long>(v2);
-    if (is_type(v1,typeid(std::string))) 
+    if (is_type(v1,typeid(std::string)))
         return cast<std::string>(v1) == cast<std::string>(v2);
     if (is_type(v1,typeid(const char*))) {
         auto c1 = cast<const char*>(v1);
         auto c2 = cast<const char*>(v2);
         return c1==c2 || (c1 && c2 && strcmp(c1,c2)==0);
     }
-    if (is_type(v1,typeid(bool))) 
+    if (is_type(v1,typeid(bool)))
         return cast<bool>(v1) == cast<bool>(v2);
-    if (is_type(v1,typeid(double))) 
+    if (is_type(v1,typeid(double)))
         return essentiallyEqual(cast<double>(v1), cast<double>(v2));
-    if (is_type(v1,typeid(float))) 
+    if (is_type(v1,typeid(float)))
         return essentiallyEqual(cast<float>(v1), cast<float>(v2));
 
-    if (is_type(v1,typeid(Quantity))) 
+    if (is_type(v1,typeid(Quantity)))
         return cast<Quantity>(v1) == cast<Quantity>(v2);
 
     if (!isAnyPyObject(v1))
@@ -681,7 +681,7 @@ bool isAnyEqual(const App::any &v1, const App::any &v2) {
 }
 
 Expression* expressionFromPy(const DocumentObject *owner, const Py::Object &value) {
-    if (value.isNone()) 
+    if (value.isNone())
         return new PyObjectExpression(owner);
     if(value.isString()) {
         return new StringExpression(owner,value.as_string());
@@ -714,7 +714,7 @@ Expression::Component::Component(const std::string &n)
 Expression::Component::Component(Expression *_e1, Expression *_e2, Expression *_e3, bool isRange)
     :e1(_e1) ,e2(_e2) ,e3(_e3)
 {
-    if(isRange || e2 || e3) 
+    if(isRange || e2 || e3)
         comp = ObjectIdentifier::RangeComponent(0);
 }
 
@@ -730,7 +730,7 @@ Expression::Component::Component(const Component &other)
     ,e3(other.e3?other.e3->copy():0)
 {}
 
-Expression::Component::~Component() 
+Expression::Component::~Component()
 {
     delete e1;
     delete e2;
@@ -789,7 +789,7 @@ Py::Object Expression::Component::get(const Expression *owner, const Py::Object 
     return Py::Object();
 }
 
-void Expression::Component::set(const Expression *owner, Py::Object &pyobj, const Py::Object &value) const 
+void Expression::Component::set(const Expression *owner, Py::Object &pyobj, const Py::Object &value) const
 {
     if(!e1 && !e2 && !e3)
         return comp.set(pyobj,value);
@@ -861,7 +861,7 @@ void Expression::Component::visit(ExpressionVisitor &v) {
 }
 
 bool Expression::Component::isTouched() const {
-    return (e1&&e1->isTouched()) || 
+    return (e1&&e1->isTouched()) ||
             (e2&&e2->isTouched()) ||
             (e3&&e3->isTouched());
 }
@@ -895,7 +895,7 @@ void Expression::Component::toString(std::ostream &ss, bool persistent) const {
 TYPESYSTEM_SOURCE_ABSTRACT(App::Expression, Base::BaseClass)
 
 Expression::Expression(const DocumentObject *_owner)
-    : owner(const_cast<App::DocumentObject*>(_owner)) 
+    : owner(const_cast<App::DocumentObject*>(_owner))
 {
 
 }
@@ -911,7 +911,7 @@ Expression::Component* Expression::createComponent(const std::string &n) {
 }
 
 Expression::Component* Expression::createComponent(
-        Expression* e1, Expression* e2, Expression* e3, bool isRange) 
+        Expression* e1, Expression* e2, Expression* e3, bool isRange)
 {
     return new Component(e1,e2,e3,isRange);
 }
@@ -1080,7 +1080,7 @@ public:
 };
 
 ExpressionPtr Expression::updateLabelReference(
-        App::DocumentObject *obj, const std::string &ref, const char *newLabel) const 
+        App::DocumentObject *obj, const std::string &ref, const char *newLabel) const
 {
     if(ref.size()<=2)
         return ExpressionPtr();
@@ -1107,9 +1107,9 @@ public:
     }
 
     void visit(Expression &e) {
-        if(collect) 
+        if(collect)
             this->collectReplacement(e,paths,parent,oldObj,newObj);
-        else 
+        else
             this->renameObjectIdentifier(e,paths,dummy);
     }
 
@@ -1121,8 +1121,8 @@ public:
     bool collect = true;
 };
 
-ExpressionPtr Expression::replaceObject(const DocumentObject *parent, 
-        DocumentObject *oldObj, DocumentObject *newObj) const 
+ExpressionPtr Expression::replaceObject(const DocumentObject *parent,
+        DocumentObject *oldObj, DocumentObject *newObj) const
 {
     ReplaceObjectExpressionVisitor v(parent,oldObj,newObj);
 
@@ -1299,7 +1299,7 @@ Expression *UnitExpression::_copy() const
 }
 
 Py::Object UnitExpression::_getPyValue() const {
-    if(!cache) 
+    if(!cache)
         cache = Py::new_reference_to(pyFromQuantity(quantity));
     return Py::Object(cache);
 }
@@ -1390,7 +1390,7 @@ bool OperatorExpression::isTouched() const
 }
 
 static Py::Object calc(const Expression *expr, int op,
-                 const Expression *left, const Expression *right, bool inplace) 
+                 const Expression *left, const Expression *right, bool inplace)
 {
     Py::Object l = left->getPyValue();
 
@@ -1423,7 +1423,7 @@ static Py::Object calc(const Expression *expr, int op,
                 && !r.isNumeric()
                 && !r.isString()
                 && !r.isList()
-                && !r.isDict()) 
+                && !r.isDict())
     {
         __EXPR_THROW(Base::TypeError,"Unsupported operator", expr);
     }
@@ -1512,11 +1512,11 @@ static Py::Object calc(const Expression *expr, int op,
     case OperatorExpression::MOD: {
         PyObject *res;
 #if PY_MAJOR_VERSION < 3
-        if (PyString_CheckExact(l.ptr()) && 
-                (!PyString_Check(r.ptr()) || PyString_CheckExact(r.ptr()))) 
+        if (PyString_CheckExact(l.ptr()) &&
+                (!PyString_Check(r.ptr()) || PyString_CheckExact(r.ptr())))
             res = PyString_Format(l.ptr(), r.ptr());
 #else
-        if (PyUnicode_CheckExact(l.ptr()) && 
+        if (PyUnicode_CheckExact(l.ptr()) &&
                 (!PyUnicode_Check(r.ptr()) || PyUnicode_CheckExact(r.ptr())))
             res = PyUnicode_Format(l.ptr(), r.ptr());
 #endif
@@ -1826,7 +1826,7 @@ FunctionExpression::~FunctionExpression()
 }
 
 /**
-  * Determinte whether the expressions is considered touched, i.e one or both of its arguments
+  * Determine whether the expressions is considered touched, i.e one or both of its arguments
   * are touched.
   *
   * @return True if touched, false if not.
@@ -2015,7 +2015,7 @@ Py::Object FunctionExpression::evalAggregate(
         }
         else {
             Quantity q;
-            if(pyToQuantity(q,arg->getPyValue())) 
+            if(pyToQuantity(q,arg->getPyValue()))
                 c->collect(q);
         }
     }
@@ -2023,7 +2023,7 @@ Py::Object FunctionExpression::evalAggregate(
     return pyFromQuantity(c->getQuantity());
 }
 
-Py::Object FunctionExpression::evaluate(const Expression *expr, int f, const std::vector<Expression*> &args) 
+Py::Object FunctionExpression::evaluate(const Expression *expr, int f, const std::vector<Expression*> &args)
 {
     if(!expr || !expr->getOwner())
         _EXPR_THROW("Invalid owner.", expr);
@@ -2109,7 +2109,7 @@ Py::Object FunctionExpression::evaluate(const Expression *expr, int f, const std
             _EXPR_THROW("Function requires the first argument to be a string.",expr);
         std::string type(pytype.as_string());
         Py::Object res;
-        if(boost::iequals(type,"matrix")) 
+        if(boost::iequals(type,"matrix"))
             res = Py::asObject(new Base::MatrixPy(Base::Matrix4D()));
         else if(boost::iequals(type,"vector"))
             res = Py::asObject(new Base::VectorPy(Base::Vector3d()));
@@ -2657,12 +2657,12 @@ bool VariableExpression::_relabeledDocument(const std::string &oldName,
 }
 
 bool VariableExpression::_adjustLinks(
-        const std::set<App::DocumentObject *> &inList, ExpressionVisitor &v) 
+        const std::set<App::DocumentObject *> &inList, ExpressionVisitor &v)
 {
     return var.adjustLinks(v,inList);
 }
 
-void VariableExpression::_importSubNames(const ObjectIdentifier::SubNameMap &subNameMap) 
+void VariableExpression::_importSubNames(const ObjectIdentifier::SubNameMap &subNameMap)
 {
     var.importSubNames(subNameMap);
 }
@@ -2674,13 +2674,13 @@ void VariableExpression::_updateLabelReference(
 }
 
 bool VariableExpression::_updateElementReference(
-        App::DocumentObject *feature, bool reverse, ExpressionVisitor &v) 
+        App::DocumentObject *feature, bool reverse, ExpressionVisitor &v)
 {
     return var.updateElementReference(v,feature,reverse);
 }
 
 bool VariableExpression::_renameObjectIdentifier(
-        const std::map<ObjectIdentifier,ObjectIdentifier> &paths, 
+        const std::map<ObjectIdentifier,ObjectIdentifier> &paths,
         const ObjectIdentifier &path, ExpressionVisitor &v)
 {
     const auto &oldPath = var.canonicalPath();
@@ -2698,8 +2698,8 @@ bool VariableExpression::_renameObjectIdentifier(
 
 void VariableExpression::_collectReplacement(
         std::map<ObjectIdentifier,ObjectIdentifier> &paths,
-        const App::DocumentObject *parent, 
-        App::DocumentObject *oldObj, 
+        const App::DocumentObject *parent,
+        App::DocumentObject *oldObj,
         App::DocumentObject *newObj) const
 {
     ObjectIdentifier path;
@@ -2707,8 +2707,8 @@ void VariableExpression::_collectReplacement(
         paths[var.canonicalPath()] = std::move(path);
 }
 
-void VariableExpression::_moveCells(const CellAddress &address, 
-        int rowCount, int colCount, ExpressionVisitor &v) 
+void VariableExpression::_moveCells(const CellAddress &address,
+        int rowCount, int colCount, ExpressionVisitor &v)
 {
     if(var.hasDocumentObjectName(true))
         return;
@@ -2929,7 +2929,7 @@ void ConditionalExpression::_visit(ExpressionVisitor &v)
 
 TYPESYSTEM_SOURCE(App::ConstantExpression, App::NumberExpression)
 
-ConstantExpression::ConstantExpression(const DocumentObject *_owner, 
+ConstantExpression::ConstantExpression(const DocumentObject *_owner,
         const char *_name, const Quantity & _quantity)
     : NumberExpression(_owner, _quantity)
     , name(_name)
@@ -2961,8 +2961,8 @@ Py::Object ConstantExpression::_getPyValue() const {
 }
 
 bool ConstantExpression::isNumber() const {
-    return strcmp(name,"None") 
-        && strcmp(name,"True") 
+    return strcmp(name,"None")
+        && strcmp(name,"True")
         && strcmp(name, "False");
 }
 
@@ -3036,7 +3036,7 @@ Range RangeExpression::getRange() const
     Base::PyGILStateLocker lock;
     static const std::string attr("getCellFromAlias");
     Py::Object pyobj(owner->getPyObject(),true);
-    if(!pyobj.hasAttr(attr)) 
+    if(!pyobj.hasAttr(attr))
         EXPR_THROW("Invalid cell range " << begin << ':' << end);
     Py::Callable callable(pyobj.getAttr(attr));
     if(!c1.isValid()) {
@@ -3065,7 +3065,7 @@ Range RangeExpression::getRange() const
 }
 
 bool RangeExpression::_renameObjectIdentifier(
-        const std::map<ObjectIdentifier,ObjectIdentifier> &paths, 
+        const std::map<ObjectIdentifier,ObjectIdentifier> &paths,
         const ObjectIdentifier &path, ExpressionVisitor &v)
 {
     (void)path;
@@ -3086,7 +3086,7 @@ bool RangeExpression::_renameObjectIdentifier(
 }
 
 void RangeExpression::_moveCells(const CellAddress &address,
-        int rowCount, int colCount, ExpressionVisitor &v) 
+        int rowCount, int colCount, ExpressionVisitor &v)
 {
     CellAddress addr = stringToAddress(begin.c_str(),true);
     if(addr.isValid()) {
@@ -3112,14 +3112,14 @@ void RangeExpression::_moveCells(const CellAddress &address,
     }
 }
 
-void RangeExpression::_offsetCells(int rowOffset, int colOffset, ExpressionVisitor &v) 
+void RangeExpression::_offsetCells(int rowOffset, int colOffset, ExpressionVisitor &v)
 {
     CellAddress addr = stringToAddress(begin.c_str(),true);
     if(addr.isValid() && (!addr.isAbsoluteRow() || !addr.isAbsoluteCol())) {
         v.aboutToChange();
         if(!addr.isAbsoluteRow())
             addr.setRow(addr.row()+rowOffset);
-        if(!addr.isAbsoluteCol()) 
+        if(!addr.isAbsoluteCol())
             addr.setCol(addr.col()+colOffset);
         begin = addr.toString();
     }
@@ -3128,7 +3128,7 @@ void RangeExpression::_offsetCells(int rowOffset, int colOffset, ExpressionVisit
         v.aboutToChange();
         if(!addr.isAbsoluteRow())
             addr.setRow(addr.row()+rowOffset);
-        if(!addr.isAbsoluteCol()) 
+        if(!addr.isAbsoluteCol())
             addr.setCol(addr.col()+colOffset);
         end = addr.toString();
     }

--- a/src/Gui/PythonWorkbenchPyImp.cpp
+++ b/src/Gui/PythonWorkbenchPyImp.cpp
@@ -32,8 +32,8 @@
 using namespace Gui;
 
 /** @class PythonWorkbenchPy
- * The workbench Python class provides additional methods for manipulation of python worbench
- * objects. 
+ * The workbench Python class provides additional methods for manipulation of python
+ * workbench objects.
  * From the view of Python PythonWorkbenchPy is also derived from WorkbenchPy as in C++.
  * @see Workbench
  * @see WorkbenchPy
@@ -54,7 +54,7 @@ PyObject*  PythonWorkbenchPy::appendMenu(PyObject *args)
         PyObject* pPath;
         PyObject* pItems;
         if ( !PyArg_ParseTuple(args, "OO", &pPath, &pItems) )
-            return NULL;                             // NULL triggers exception 
+            return NULL;                             // NULL triggers exception
 
         // menu path
         std::list<std::string> path;
@@ -95,7 +95,7 @@ PyObject*  PythonWorkbenchPy::appendMenu(PyObject *args)
 #endif
         } else {
             PyErr_SetString(PyExc_AssertionError, "Expected either a string or a stringlist as first argument");
-            return NULL;                             // NULL triggers exception 
+            return NULL;                             // NULL triggers exception
         }
 
         // menu items
@@ -137,12 +137,12 @@ PyObject*  PythonWorkbenchPy::appendMenu(PyObject *args)
 #endif
         } else {
             PyErr_SetString(PyExc_AssertionError, "Expected either a string or a stringlist as first argument");
-            return NULL;                             // NULL triggers exception 
+            return NULL;                             // NULL triggers exception
         }
 
         getPythonBaseWorkbenchPtr()->appendMenu( path, items );
 
-        Py_Return; 
+        Py_Return;
     } PY_CATCH;
 }
 
@@ -151,11 +151,11 @@ PyObject*  PythonWorkbenchPy::removeMenu(PyObject *args)
 {
     PY_TRY {
         char *psMenu;
-        if (!PyArg_ParseTuple(args, "s", &psMenu))     // convert args: Python->C 
-            return NULL;                             // NULL triggers exception 
-    
+        if (!PyArg_ParseTuple(args, "s", &psMenu))     // convert args: Python->C
+            return NULL;                             // NULL triggers exception
+
         getPythonBaseWorkbenchPtr()->removeMenu( psMenu );
-        Py_Return; 
+        Py_Return;
     } PY_CATCH;
 }
 
@@ -178,7 +178,7 @@ PyObject*  PythonWorkbenchPy::listMenus(PyObject *args)
 #endif
             PyList_SetItem(pyList, i, str);
         }
-        return pyList; 
+        return pyList;
     } PY_CATCH;
 }
 
@@ -189,7 +189,7 @@ PyObject*  PythonWorkbenchPy::appendContextMenu(PyObject *args)
         PyObject* pPath;
         PyObject* pItems;
         if ( !PyArg_ParseTuple(args, "OO", &pPath, &pItems) )
-            return NULL;                             // NULL triggers exception 
+            return NULL;                             // NULL triggers exception
 
         // menu path
         std::list<std::string> path;
@@ -230,7 +230,7 @@ PyObject*  PythonWorkbenchPy::appendContextMenu(PyObject *args)
 #endif
         } else {
             PyErr_SetString(PyExc_AssertionError, "Expected either a string or a stringlist as first argument");
-            return NULL;                             // NULL triggers exception 
+            return NULL;                             // NULL triggers exception
         }
 
         // menu items
@@ -272,12 +272,12 @@ PyObject*  PythonWorkbenchPy::appendContextMenu(PyObject *args)
 #endif
         } else {
             PyErr_SetString(PyExc_AssertionError, "Expected either a string or a stringlist as first argument");
-            return NULL;                             // NULL triggers exception 
+            return NULL;                             // NULL triggers exception
         }
 
         getPythonBaseWorkbenchPtr()->appendContextMenu( path, items );
 
-        Py_Return; 
+        Py_Return;
     } PY_CATCH;
 }
 
@@ -286,11 +286,11 @@ PyObject*  PythonWorkbenchPy::removeContextMenu(PyObject *args)
 {
     PY_TRY {
         char *psMenu;
-        if (!PyArg_ParseTuple(args, "s", &psMenu))     // convert args: Python->C 
-            return NULL;                             // NULL triggers exception 
-    
+        if (!PyArg_ParseTuple(args, "s", &psMenu))     // convert args: Python->C
+            return NULL;                             // NULL triggers exception
+
         getPythonBaseWorkbenchPtr()->removeContextMenu( psMenu );
-        Py_Return; 
+        Py_Return;
     } PY_CATCH;
 }
 
@@ -301,10 +301,10 @@ PyObject*  PythonWorkbenchPy::appendToolbar(PyObject *args)
         PyObject* pObject;
         char* psToolBar;
         if ( !PyArg_ParseTuple(args, "sO", &psToolBar, &pObject) )
-            return NULL;                             // NULL triggers exception 
+            return NULL;                             // NULL triggers exception
         if (!PyList_Check(pObject)) {
             PyErr_SetString(PyExc_AssertionError, "Expected a list as second argument");
-            return NULL;                             // NULL triggers exception 
+            return NULL;                             // NULL triggers exception
         }
 
         std::list<std::string> items;
@@ -330,7 +330,7 @@ PyObject*  PythonWorkbenchPy::appendToolbar(PyObject *args)
         }
         getPythonBaseWorkbenchPtr()->appendToolbar( psToolBar, items );
 
-        Py_Return; 
+        Py_Return;
     } PY_CATCH;
 }
 
@@ -339,11 +339,11 @@ PyObject*  PythonWorkbenchPy::removeToolbar(PyObject *args)
 {
     PY_TRY {
         char *psToolBar;
-        if (!PyArg_ParseTuple(args, "s", &psToolBar))     // convert args: Python->C 
-            return NULL;                             // NULL triggers exception 
-    
+        if (!PyArg_ParseTuple(args, "s", &psToolBar))     // convert args: Python->C
+            return NULL;                             // NULL triggers exception
+
         getPythonBaseWorkbenchPtr()->removeToolbar( psToolBar );
-        Py_Return; 
+        Py_Return;
     } PY_CATCH;
 }
 
@@ -366,7 +366,7 @@ PyObject*  PythonWorkbenchPy::listToolbars(PyObject *args)
 #endif
             PyList_SetItem(pyList, i, str);
         }
-        return pyList; 
+        return pyList;
     } PY_CATCH;
 }
 
@@ -377,10 +377,10 @@ PyObject*  PythonWorkbenchPy::appendCommandbar(PyObject *args)
         PyObject* pObject;
         char* psToolBar;
         if ( !PyArg_ParseTuple(args, "sO", &psToolBar, &pObject) )
-            return NULL;                             // NULL triggers exception 
+            return NULL;                             // NULL triggers exception
         if (!PyList_Check(pObject)) {
             PyErr_SetString(PyExc_AssertionError, "Expected a list as second argument");
-            return NULL;                             // NULL triggers exception 
+            return NULL;                             // NULL triggers exception
         }
 
         std::list<std::string> items;
@@ -407,7 +407,7 @@ PyObject*  PythonWorkbenchPy::appendCommandbar(PyObject *args)
 
         getPythonBaseWorkbenchPtr()->appendCommandbar( psToolBar, items );
 
-        Py_Return; 
+        Py_Return;
     } PY_CATCH;
 }
 
@@ -416,11 +416,11 @@ PyObject*  PythonWorkbenchPy::removeCommandbar(PyObject *args)
 {
     PY_TRY {
         char *psToolBar;
-        if (!PyArg_ParseTuple(args, "s", &psToolBar))     // convert args: Python->C 
-            return NULL;                             // NULL triggers exception 
-    
+        if (!PyArg_ParseTuple(args, "s", &psToolBar))     // convert args: Python->C
+            return NULL;                             // NULL triggers exception
+
         getPythonBaseWorkbenchPtr()->removeCommandbar( psToolBar );
-        Py_Return; 
+        Py_Return;
     } PY_CATCH;
 }
 
@@ -443,7 +443,7 @@ PyObject*  PythonWorkbenchPy::listCommandbars(PyObject *args)
 #endif
             PyList_SetItem(pyList, i, str);
         }
-        return pyList; 
+        return pyList;
     } PY_CATCH;
 }
 
@@ -454,7 +454,7 @@ PyObject *PythonWorkbenchPy::getCustomAttributes(const char* ) const
 
 int PythonWorkbenchPy::setCustomAttributes(const char* , PyObject *)
 {
-    return 0; 
+    return 0;
 }
 
 PyObject*  PythonWorkbenchPy::AppendMenu(PyObject *args)
@@ -511,5 +511,3 @@ PyObject*  PythonWorkbenchPy::ListCommandbars(PyObject *args)
 {
     return listCommandbars(args);
 }
-
-

--- a/src/Mod/Arch/OfflineRenderingUtils.py
+++ b/src/Mod/Arch/OfflineRenderingUtils.py
@@ -362,7 +362,7 @@ def render(outputfile,scene=None,camera=None,zoom=False,width=400,height=300,bac
 def buildScene(objects,colors=None):
 
     """buildScene(objects,colors=None): builds a coin node from a given list of FreeCAD
-    objects. Optional colors argument can be a dicionary of objName:ShapeColorTuple
+    objects. Optional colors argument can be a dictionary of objName:ShapeColorTuple
     or obj:DiffuseColorList pairs."""
 
     from pivy import coin

--- a/src/Mod/Arch/importIFCHelper.py
+++ b/src/Mod/Arch/importIFCHelper.py
@@ -433,7 +433,7 @@ def buildRelProperties(ifcfile):
 
 
 def getIfcPropertySets(ifcfile, pid):
-    """Returns a dicionary of {pset_id:[prop_id, prop_id...]} for an IFC object"""
+    """Returns a dictionary of {pset_id:[prop_id, prop_id...]} for an IFC object"""
 
     # get psets for this pid
     psets = {}

--- a/src/Mod/Draft/TestDraft.py
+++ b/src/Mod/Draft/TestDraft.py
@@ -462,7 +462,7 @@ class DraftCreation(unittest.TestCase):
         """Create a linear dimension."""
         operation = "Draft Dimension"
         _msg("  Test '{}'".format(operation))
-        _msg("  Occasionaly crashes")
+        _msg("  Occasionally crashes")
         a = Vector(0, 0, 0)
         b = Vector(9, 0, 0)
         c = Vector(4, -1, 0)
@@ -577,7 +577,7 @@ class DraftCreation(unittest.TestCase):
         """Create a label."""
         operation = "Draft Label"
         _msg("  Test '{}'".format(operation))
-        _msg("  Occasionaly crashes")
+        _msg("  Occasionally crashes")
         target_point = Vector(0, 0, 0)
         distance = -25
         placement = App.Placement(Vector(50, 50, 0), App.Rotation())

--- a/src/Mod/Fem/femtest/app/test_femimport.py
+++ b/src/Mod/Fem/femtest/app/test_femimport.py
@@ -34,7 +34,7 @@ class TestFemImport(unittest.TestCase):
 
     # ********************************************************************************************
     # no is document needed to test import Fem and import FemGui
-    # thus neiter setUp nor tearDown methods are needed
+    # thus neither setUp nor tearDown methods are needed
 
     def test_00print(
         self

--- a/src/Mod/MeshPart/Gui/Tessellation.cpp
+++ b/src/Mod/MeshPart/Gui/Tessellation.cpp
@@ -285,7 +285,7 @@ bool Tessellation::accept()
                     // TODO: currently, we can only retrieve part feature
                     // color. The problem is that if the feature is linked,
                     // there are potentially many places where the color can
-                    // get overriden.
+                    // get overridden.
                     //
                     // With topo naming feature merged, it will be possible to
                     // infer more accurate colors from just the shape names,

--- a/src/Mod/Path/App/AreaParams.h
+++ b/src/Mod/Path/App/AreaParams.h
@@ -96,7 +96,7 @@
 
 /** Pocket parameters
  *
- * These parameters cooresponds to CAreaPocketParams in libarea
+ * These parameters corresponds to CAreaPocketParams in libarea
  * */
 #define AREA_PARAMS_POCKET \
     ((enum,mode,PocketMode,0,"Selects the pocket toolpath pattern",\

--- a/src/Mod/Path/App/ParamsHelper.h
+++ b/src/Mod/Path/App/ParamsHelper.h
@@ -27,15 +27,15 @@
  * \ingroup PATH
  * Collections of macros for managing groups of parameters.
  *
- * \section Motivation 
+ * \section Motivation
  *
  * For an application like FreeCAD, there are often cases where the same set of
  * parameters are referred in dozons of different places. The macros here is
  * designed to help managing those parameters, so that you can define groups of
  * parameters once, and refer them everywhere in groups with simple macro calls for
  * all kinds of purposes. Any changing, adding and removing of parameters in the
- * group become much easier. And by everywhere, I mean \ref ParamCommon 
- * "class definition, impelentation", \ref ParamProperty "document object properties",
+ * group become much easier. And by everywhere, I mean \ref ParamCommon
+ * "class definition, implementation", \ref ParamProperty "document object properties",
  * \ref ParamPy "python c++ classes", and even \ref ParamDoc "doc string",
  * pretty much everything except the python code, which although not implemented
  * yet, is in fact also possible to be done using C preprocessor (No one says C
@@ -49,7 +49,7 @@
  * goes wrong, the compiler error message is kind of cryptic. If so, first
  * double check your macro definition of the parameter is correctly, not missing
  * or having extra parathesis or comma.  Then, you can use the CMake
- * intermeidate file target to get the preprocessor output for checking. For
+ * intermediate file target to get the preprocessor output for checking. For
  * example, for a file located at \c src/Mod/Path/App/Area.cpp,
  * \code{.sh}
  *     cd <your_build_dir>/src/Mod/Path/App
@@ -65,7 +65,7 @@
  *
  * The macros here make heavy use of the awsome
  * [Boost.Preprocessor](http://www.boost.org/libs/preprocessor/) (short for
- * Boost.PP).  Here are some brief introduction on Boost.PP conecept in order to
+ * Boost.PP).  Here are is a brief introduction on Boost.PP concept in order to
  * explain why this marco library is designed the way it is.
  *
  * In Boost.PP, a sequence is defined as,
@@ -145,13 +145,13 @@
  * Area.h, Area.cpp, FeatureArea.h, FeatureArea.cpp for usage of variouse macros.
  *
  * See struct AreaDoc for an example of doc string generation.
- * 
- * Each field of the parameter can be referred to with various 
- * \ref ParamAccessor "various accessor macros", and can be easily 
+ *
+ * Each field of the parameter can be referred to with various
+ * \ref ParamAccessor "various accessor macros", and can be easily
  * \ref ParamStringizer "stringified".
  *
  * \anchor ParamField You can also use #PARAM_FIELD(_field,_param) to refer to
- * each field, where \a _field is one of <tt>TYPE, ARG, NAME, DEF, DOC, or SEQ</tt>. 
+ * each field, where \a _field is one of <tt>TYPE, ARG, NAME, DEF, DOC, or SEQ</tt>.
  * And #PARAM_FIELD_STR to stringify.
  *
  * Here \a _param is the parameter definition described above in the form of a
@@ -184,7 +184,7 @@
 
 /**
  * \defgroup ParamAccessor Field accessors
- * To abstract parameter field details 
+ * To abstract parameter field details
  * \ingroup ParamHelper
  * @{
  */
@@ -229,7 +229,7 @@
 #define PARAM_FSEQ_STR_(_i,_elem) \
     BOOST_PP_COMMA_IF(_i) BOOST_PP_STRINGIZE(_elem)
 
-/** \c SEQ stringizer will stringify each element separately 
+/** \c SEQ stringizer will stringify each element separately
  *
  * Expands to:
  *      #seq[0], #seq[1] ...
@@ -261,7 +261,7 @@
 /** Helper for #PARAM_FOREACH_I */
 #define PARAM_FOREACH_I_(_,_op,_i,_param) _op(_i,_param)
 
-/** Apply macro \a _op to each parameter in sequence \a _seq with additional index 
+/** Apply macro \a _op to each parameter in sequence \a _seq with additional index
  *
  * Operation macro \a _op should be defined as,
  * \code
@@ -277,9 +277,9 @@
 #define PARAM_TYPED_FOREACH_(_1,_op,_param) \
     PARAM_TYPED(_op,_param)(_param)
 
-/** Type depended macro construction 
+/** Type depended macro construction
  *
- * Convert macro \a _op to \a _op##\<type\>. Note that it only converts the 
+ * Convert macro \a _op to \a _op##\<type\>. Note that it only converts the
  * macro name, not contsucts a macro call. To expand to a macro call, simply
  * \code
  *      PARAM_TYPED(_op,_param)(_param)
@@ -289,7 +289,7 @@
 #define PARAM_TYPED(_op,_param) \
     BOOST_PP_CAT(_op,PARAM_FTYPE(_param))
 
-/** Apply type dependent macro call to a sequence of parameters 
+/** Apply type dependent macro call to a sequence of parameters
  *
  * \a _op will be converted to \a _op##\<type\> for each parameter
  * \ingroup ParamLooper
@@ -298,7 +298,7 @@
     BOOST_PP_SEQ_FOR_EACH(PARAM_TYPED_FOREACH_,_op,_seq)
 
 
-/** \defgroup ParamCommon Common helpers 
+/** \defgroup ParamCommon Common helpers
  * \ingroup ParamHelper
  */
 
@@ -311,7 +311,7 @@
 
 /** Obtain parameter type
  *
- * The main purpose is to alias enum type to short 
+ * The main purpose is to alias enum type to short
  * \ingroup ParamCommon
  */
 #define PARAM_TYPE(_param) \
@@ -334,17 +334,17 @@
  *      #define MY_SRC(_param) BOOST_PP_CAT(my,PARAM_FNAME(_param))
  *      ->
  *          my##<name>
- * \endcode 
+ * \endcode
  *
  * Expands to:
  * \code{.unparsed}
  *         type1 _src(_param1);type2 _src(_param2); ...
- * \endcode 
+ * \endcode
  * \ingroup ParamCommon
  */
 #define PARAM_DECLARE(_src,_seq) \
     BOOST_PP_SEQ_FOR_EACH(PARAM_DECLARE_,_src,_seq)
- 
+
 
 /** Helper for #PARAM_DECLARE_INIT */
 #define PARAM_DECLARE_INIT_(_1,_src,_param) \
@@ -360,7 +360,7 @@
  * Expands to:
  * \code{.unparsed}
  *         type1 _src(_param1)=_def1;type2 _src(_param2)=_def2; ...
- * \endcode 
+ * \endcode
  * \ingroup ParamCommon
  */
 #define PARAM_DECLARE_INIT(_src,_seq) \
@@ -379,7 +379,7 @@
 #define PARAM_ENUM_DECLARE_bool(_param)
 #define PARAM_ENUM_DECLARE_enum2 PARAM_ENUM_DECLARE_enum
 
-/** \defgroup ParamEnumHelper Enum convert helpers 
+/** \defgroup ParamEnumHelper Enum convert helpers
  * \ingroup ParamCommon
  */
 
@@ -423,7 +423,7 @@
                                             BOOST_PP_TUPLE_ELEM(2,_args),\
                                             _param)
 
-/** Convert single enum parameter value into user defined enum type 
+/** Convert single enum parameter value into user defined enum type
  *
  * This macro is used by #PARAM_ENUM_CONVERT to convert each parameter, but
  * you can use it directly for a single parameter. Check #PARAM_NUM_CONVERT
@@ -449,7 +449,7 @@
  *
  * This assumes the user defined enum type is given in \ref ParamSeq "seq_type"
  * of the parameter definition, and it has the same postfix as the ones
- * specified in \ref ParamSeq "seq" member of the parameter definition. See 
+ * specified in \ref ParamSeq "seq" member of the parameter definition. See
  * \ref ParamEnumHelper "here" for implementations
  *
  * \ingroup ParamEnumHelper
@@ -460,7 +460,7 @@
  * access the field. Or, supply your own macro to append any prefix as you
  * like.
  * \arg \c _dst: Same as above.
- * \arg \c _default: A macro to call for invalid value. Signature should be 
+ * \arg \c _default: A macro to call for invalid value. Signature should be
  * <tt>_default(_param)<\tt>, where \c _param is the parameter definition. You
  * can use #PARAM_ENUM_EXCEPT to throw Base::ValueError exception in FreeCAD
  * \arg \c _seq: Parameter sequence
@@ -481,7 +481,7 @@
  *
  * expands to
  * \code{.unparsed}
- *      MyEnum1 myTest1; 
+ *      MyEnum1 myTest1;
  *      switch(Test1) {
  *      case Test1Foo:
  *          myTest1 = myEnum1Foo;
@@ -492,7 +492,7 @@
  *      default:
  *          throw Base::ValueError("invalid value for enum Test1");
  *      }
- *      MyEnum2 myTest2; 
+ *      MyEnum2 myTest2;
  *      switch(Test2) {
  *      case Test1Foo:
  *          myTest2 = myEnum2Foo;
@@ -537,7 +537,7 @@
 
 /* Validate enum type parameters
  *
- * This macro validates the value a variable of enum type parameters. See 
+ * This macro validates the value a variable of enum type parameters. See
  * similar macro #PARAM_ENUM_CONVERT for detail usage.
  *
  * \ingroup ParamEnumHelper
@@ -548,7 +548,7 @@
  * access the field. Or, supply your own macro to append any prefix as you
  * like.
  *
- * \arg \c _default: A macro to call for invalid value. Signature should be 
+ * \arg \c _default: A macro to call for invalid value. Signature should be
  * <tt>_default(_param)<\tt>, where \c _param is the parameter definition. You
  * can use #PARAM_ENUM_EXCEPT to throw Base::ValueError exception in FreeCAD
  *
@@ -581,7 +581,7 @@
  *      ...
  * \endcode
  * Example usage:
- *      PARAM_ENUM_STRING_DECLARE(static const char *Enum, MyParamsSeq) 
+ *      PARAM_ENUM_STRING_DECLARE(static const char *Enum, MyParamsSeq)
  * \ingroup ParamEnumHelper
  */
 #define PARAM_ENUM_STRING_DECLARE(_prefix,_seq) \
@@ -599,7 +599,7 @@
  *
  * Expand to,
  * \code{.unparsed}
- *       _src(_param1)(def1), _src(_param1)(def2)...  
+ *       _src(_param1)(def1), _src(_param1)(def2)...
  * \endcode
  * \ingroup ParamCommon
  */
@@ -656,14 +656,14 @@
 #define PARAM_ARGS_(_,_src,_i,_param) \
     BOOST_PP_COMMA_IF(_i) PARAM_TYPE(_param) _src(_param)
 
-/** Declare the parameters as function argument list without defaults. 
+/** Declare the parameters as function argument list without defaults.
  *
  * \arg \c _src: macro to generate source field. See \ref ParamSrc "here" for
  * more details
  *
  * Expand to:
  * \code{.unparsed}
- *      type1 _src(_param1), type2 _src(_param2) ... 
+ *      type1 _src(_param1), type2 _src(_param2) ...
  * \endcode
  * \ingroup ParamCommon
  */
@@ -677,7 +677,7 @@
  */
 
 /** \defgroup ParamDoc Python doc helper
- * Generate argument doc string for Python 
+ * Generate argument doc string for Python
  * \ingroup ParamPy
  */
 
@@ -703,7 +703,7 @@
 #define PARAM_PY_DOC_(_,_field,_param) \
     PARAM_TYPED(PARAM_PY_DOC_,_param)(_field,_param)
 
-/* Generate document of a sequence of parameters 
+/* Generate document of a sequence of parameters
  * \ingroup ParamDoc
  */
 #define PARAM_PY_DOC(_field,_seq) \
@@ -714,7 +714,7 @@
 #define PARAM_PY_ARGS_DOC_(_,_field,_i,_param) \
     BOOST_PP_IF(_i,", "," ") PARAM_FIELD_STR(_field,_param) "=" PARAM_FDEF_STR(_param)
 
-/** Generate argument list string 
+/** Generate argument list string
  * \arg \c _field: specifies the \ref ParamField "field" to use as name
  *
  * Expand to a single string:
@@ -732,7 +732,7 @@
 #define PARAM_FIELDS_(_1,_src,_i,_param) \
     BOOST_PP_COMMA_IF(_i) _src(_param)
 
-/** Expand to a list of the given field in the parameter sequence 
+/** Expand to a list of the given field in the parameter sequence
  *
  * \arg \c _src: macro to generate source field. See \ref ParamSrc "here" for
  * more details
@@ -771,7 +771,7 @@
  * \arg \c _src: macro to generate source field. See \ref ParamSrc "here" for
  * more details
  *
- * The field will be casted from python C to C type 
+ * The field will be casted from python C to C type
  * \ingroup ParamCommon ParamPy
  */
 #define PARAM_PY_FIELDS(_src,_seq) \
@@ -800,7 +800,7 @@
 #define PARAM_PY_KWDS_(_param) \
     PARAM_TYPED(PARAM_PYARG_,_param)
 
-/** Generate a format string for kewords based argument 
+/** Generate a format string for kewords based argument
  * \ingroup ParamPy
  */
 #define PARAM_PY_KWDS(_seq) \
@@ -817,7 +817,7 @@
 #define PARAM_PY_DECLARE_(_1,_src,_param) \
     PARAM_TYPED(PARAM_PY_TYPE_,_param) _src(_param);
 
-/** Declare field variables for Python C type without initialization 
+/** Declare field variables for Python C type without initialization
  * \ingroup ParamPy
  */
 #define PARAM_PY_DECLARE(_src,_seq) \
@@ -853,7 +853,7 @@
  * more details
  * Expand to:
  * \code{.unparsed}
- *      &_src(_param1), &_src(_param1) ... 
+ *      &_src(_param1), &_src(_param1) ...
  * \endcode
  * \ingroup ParamPy
  */
@@ -874,7 +874,7 @@
 #define PARAM_CAST_PYOBJ_enum2       PARAM_CAST_PYOBJ_short
 
 
-/** Stringize field to a Python string 
+/** Stringize field to a Python string
  * \ingroup ParamPy ParamStringizer
  */
 #if PY_MAJOR_VERSION < 3
@@ -901,8 +901,8 @@
  * Roughly translated to:
  * \code{.unparsed}
  *      PyDict_SetItem(_dict,#_field1,_src(_param));
- *      PyDict_SetItem(_dict,#_field2,_src(_param)); 
- *      ... 
+ *      PyDict_SetItem(_dict,#_field2,_src(_param));
+ *      ...
  * \endcode
  * \ingroup ParamPy
  */
@@ -951,8 +951,8 @@
  * Roughly translated to:
  * \code{.unparsed}
  *      PyDict_SetItem(_dict,#_field1,doc1);
- *      PyDict_SetItem(_dict,#_field1,doc2); 
- *      ... 
+ *      PyDict_SetItem(_dict,#_field1,doc2);
+ *      ...
  * \endcode
  * \ingroup ParamDoc
  */
@@ -961,7 +961,7 @@
 
 
 /** \defgroup ParamProperty Property Macros
- * Helper macros for FreeCAD properties 
+ * Helper macros for FreeCAD properties
  * \ingroup ParamHelper
  * @{*/
 #define PARAM_PROP_bool(_param) App::PropertyBool PARAM_FNAME(_param)
@@ -976,7 +976,7 @@
 #define PARAM_PROP_DECLARE_(_param) \
     PARAM_TYPED(PARAM_PROP_,_param)(_param);
 
-/** Declare FreeCAD properties 
+/** Declare FreeCAD properties
  * \ingroup ParamProperty
  */
 #define PARAM_PROP_DECLARE(_seq) \
@@ -1025,7 +1025,7 @@
 /** Setup \c enum type parameter */
 #define PARAM_PROP_SET_ENUM_enum(_prefix,_param) \
     PARAM_FNAME(_param).setEnums(BOOST_PP_CAT(_prefix,PARAM_FNAME(_param)));
- 
+
 /** Helper for #PARAM_PROP_SET_ENUM */
 #define PARAM_PROP_SET_ENUM_TYPED(_1,_prefix,_param) \
     PARAM_TYPED(PARAM_PROP_SET_ENUM_,_param)(_prefix,_param)
@@ -1041,7 +1041,7 @@
 #define PARAM_PROP_ARGS_(_i,_param) \
     BOOST_PP_COMMA_IF(_i) PARAM_FNAME(_param).getValue()
 
-/** Expand the property list as function arguments 
+/** Expand the property list as function arguments
  *
  * Expand to:
  * \code{.unparsed}
@@ -1056,8 +1056,8 @@
 /** Helper for #PARAM_PROP_TOUCHED */
 #define PARAM_PROP_TOUCHED_(_param) \
     if(PARAM_FNAME(_param).isTouched()) return 1;
-    
-/** Returns 1 if any properties is touched 
+
+/** Returns 1 if any properties is touched
  *
  * Expand to:
  * \code{.unparsed}

--- a/src/Mod/Path/Gui/Resources/preferences/PathJob.ui
+++ b/src/Mod/Path/Gui/Resources/preferences/PathJob.ui
@@ -281,7 +281,7 @@
              <bool>true</bool>
             </property>
             <property name="toolTip">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;It doesn't seem there are any post processor scripts installed. Pleas add some into your macro directory and make sure the file name ends with &amp;quot;_post.py&amp;quot;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;It doesn't seem there are any post processor scripts installed. Please add some into your macro directory and make sure the file name ends with &amp;quot;_post.py&amp;quot;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
            </widget>
           </item>

--- a/src/Mod/Path/PathScripts/PathDressupRampEntry.py
+++ b/src/Mod/Path/PathScripts/PathDressupRampEntry.py
@@ -501,7 +501,7 @@ class ObjectDressup:
         1. Start from the original startpoint of the plunge
         2. Calculate the distance on the path which is needed to implement the ramp
            and travel that distance while maintaining start depth
-        3. Start ramping while travelling the original path backwards until reaching the
+        3. Start ramping while traveling the original path backwards until reaching the
            original plunge end point
         4. Continue with the original path
         """
@@ -541,7 +541,7 @@ class ObjectDressup:
                     curPoint = newPoint
 
                 else:
-                    # we are travelling on start depth
+                    # we are traveling on start depth
                     newPoint = FreeCAD.Base.Vector(redge.valueAt(redge.LastParameter).x, redge.valueAt(redge.LastParameter).y, p0.z)
                     outedges.append(self.createRampEdge(redge, curPoint, newPoint))
                     curPoint = newPoint

--- a/src/Mod/Path/PathScripts/PathSurface.py
+++ b/src/Mod/Path/PathScripts/PathSurface.py
@@ -1262,8 +1262,8 @@ class ObjectSurface(PathOp.ObjectOp):
         pnt.y = RNG[0].y
         pnt.z = RNG[0].z + float(obj.DepthOffset.Value)
 
-        # Adjust feed rate based on radius/circumferance of cutter.
-        # Original feed rate based on travel at circumferance.
+        # Adjust feed rate based on radius/circumference of cutter.
+        # Original feed rate based on travel at circumference.
         if rN > 0:
             # if pnt.z > self.layerEndPnt.z:
             if pnt.z >= self.layerEndzMax:

--- a/src/Mod/Path/PathScripts/PathUtils.py
+++ b/src/Mod/Path/PathScripts/PathUtils.py
@@ -223,7 +223,7 @@ def horizontalFaceLoop(obj, face, faceList=None):
         outline = TechDraw.findShapeOutline(comp, 1, FreeCAD.Vector(0, 0, 1))
 
         # findShapeOutline always returns closed wires, by removing the
-        # trace-backs single edge spikes don't contriubte to the bound box
+        # trace-backs single edge spikes don't contribute to the bound box
         uniqueEdges = []
         for edge in outline.Edges:
             if any(PathGeom.edgesMatch(edge, e) for e in uniqueEdges):

--- a/src/Mod/Path/libarea/kurve/geometry.h
+++ b/src/Mod/Path/libarea/kurve/geometry.h
@@ -875,7 +875,7 @@ inline bool FNEZ(double a, double tolerance = TIGHT_TOLERANCE) {return fabs(a) >
 
 
 		void	AddIndex(int vertexNumber, const SpanDataObject* data);
-		bool	Split(double MaximumRadius, double reslution);	// split arcs larger than MaximumRadius to resoultion
+		bool	Split(double MaximumRadius, double reslution);	// split arcs larger than MaximumRadius to resolution
 		int	IntExtWire( Kurve& kSec, double Ref, double Sec, double height, Kurve* kOut);	// interpolate / extrapolate a mid height kurve (wire)
 		void	SetZ(double z) { e[11] = z; if(fabs(z) > 1.0e-6) m_unit = false;}				// assigns kurve to fixed height (wire)
 

--- a/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp
+++ b/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp
@@ -838,7 +838,7 @@ public:
                     case TRANSITION_MODE_Perpendicular_L: // 5th mode
                         TransitionMode = TRANSITION_MODE_Perpendicular_R;
                         break;
-                    default: // 6th mode (Perpendicular_R) + unexpexted mode
+                    default: // 6th mode (Perpendicular_R) + unexpected mode
                         SegmentMode = SEGMENT_MODE_Line;
                         if (geom->getTypeId() == Part::GeomArcOfCircle::getClassTypeId())
                             TransitionMode = TRANSITION_MODE_Tangent;
@@ -7014,14 +7014,14 @@ public:
                     EditCurve[16].x,EditCurve[16].y,EditCurve[17].x,EditCurve[17].y, // line1
                     EditCurve[0].x,EditCurve[0].y,EditCurve[34].x,EditCurve[34].y, // line2
                     Gui::Command::getObjectCmd(sketchgui->getObject()).c_str(), // the sketch
-                    geometryCreationMode==Construction?"True":"False", // geometry as construction or not                                        
+                    geometryCreationMode==Construction?"True":"False", // geometry as construction or not
                     firstCurve,firstCurve+3, // tangent1
                     firstCurve,firstCurve+2, // tangent2
                     firstCurve+2,firstCurve+1, // tangent3
                     firstCurve+3,firstCurve+1, // tangent4
                     (fabs(lx)>fabs(ly))?"Horizontal":"Vertical", firstCurve+2, // vertical or horizontal constraint
                     firstCurve,firstCurve+1, // equal constraint
-                    Gui::Command::getObjectCmd(sketchgui->getObject()).c_str()); // the sketch                
+                    Gui::Command::getObjectCmd(sketchgui->getObject()).c_str()); // the sketch
 
                 Gui::Command::commitCommand();
 

--- a/src/Mod/TechDraw/App/DrawDimHelper.cpp
+++ b/src/Mod/TechDraw/App/DrawDimHelper.cpp
@@ -83,14 +83,14 @@ hTrimCurve::hTrimCurve(Handle(Geom2d_Curve) hCurveIn,
     //just a convenient struct for now.
 }
 
-//All this occ math is being done on on edges(&vertices) that have been through the center/scale/mirror process.
+//All this OCC math is being done on on edges(&vertices) that have been through the center/scale/mirror process.
 
 //TODO: this needs to be exposed to Python
 void DrawDimHelper::makeExtentDim(DrawViewPart* dvp,
                                   std::vector<std::string> edgeNames,
                                   int direction)
 {
-//    Base::Console().Message("DDH::makeExtentDim() - dvp: %s edgeNames: %d\n", 
+//    Base::Console().Message("DDH::makeExtentDim() - dvp: %s edgeNames: %d\n",
 //                            dvp->Label.getValue(), edgeNames.size());
     if (dvp == nullptr) {
 //        Base::Console().Message("DDH::makeExtentDim - dvp: %X\n", dvp);
@@ -131,11 +131,11 @@ void DrawDimHelper::makeExtentDim(DrawViewPart* dvp,
         int idx1 = DrawUtil::getIndexFromName(subElements[1]);
         v0 = dvp->getProjVertexByIndex(idx0);
         v1 = dvp->getProjVertexByIndex(idx1);
-        if ( (v0 != nullptr) && 
+        if ( (v0 != nullptr) &&
              (!v0->cosmeticTag.empty()) ) {
             tag0 = v0->cosmeticTag;
         }
-        if ( (v1 != nullptr) && 
+        if ( (v1 != nullptr) &&
              (!v1->cosmeticTag.empty()) ) {
             tag1 = v1->cosmeticTag;
         }
@@ -198,15 +198,15 @@ std::pair<Base::Vector3d, Base::Vector3d> DrawDimHelper::minMax(DrawViewPart* dv
     }
 
     //can't use Bnd_Box2d here as BndLib_Add2dCurve::Add adds the poles of splines to the box.
-    //poles are not neccessarily on the curve!  3d Bnd_Box does it properly. FC bbx3 is already calculated
+    //poles are not necessarily on the curve! 3d Bnd_Box does it properly. FC bbx3 is already calculated
     //bbx3 is scaled??
 //    double scale = dvp->getScale();
-    
+
     Base::BoundBox3d bbx3 = dvp->getBoundingBox();
 
     double xMid = (bbx3.MaxX + bbx3.MinX) / 2.0;
     double yMid = (bbx3.MaxY + bbx3.MinY) / 2.0;
-    
+
     gp_Pnt2d rightMid(bbx3.MaxX, yMid);
     gp_Pnt2d leftMid(bbx3.MinX, yMid);
     gp_Pnt2d topMid(xMid, bbx3.MaxY);
@@ -390,7 +390,7 @@ DrawViewDimension* DrawDimHelper::makeDistDim(DrawViewPart* dvp,
     if (!dim) {
         throw Base::TypeError("DDH::makeDistDim - dim not found\n");
     }
-    
+
     dim->References2D.setValues(objs, subs);
 
     dvp->requestPaint();
@@ -398,4 +398,3 @@ DrawViewDimension* DrawDimHelper::makeDistDim(DrawViewPart* dvp,
 
     return dim;
 }
-

--- a/src/Mod/TemplatePyMod/DocumentObject.py
+++ b/src/Mod/TemplatePyMod/DocumentObject.py
@@ -1,16 +1,16 @@
-# FreeCAD module provding base classes for document objects and view provider  
+# FreeCAD module providing base classes for document objects and view provider  
 # (c) 2011 Werner Mayer LGPL
 
 import FreeCAD
 
 class DocumentObject(object):
     """The Document object is the base class for all FreeCAD objects."""
-    
+
     def __init__(self):
         self.__object__=None
         self.initialised=False
     #------------------------------Methods for the user to override :
-    
+
     def execute(self):
         "this method is executed on object creation and whenever the document is recomputed"
         raise NotImplementedError("Not yet implemented")
@@ -22,7 +22,7 @@ class DocumentObject(object):
         #will be called each time a property is changed
         pass
     #--------------------------------
-    
+
 
     def __getattr__(self, attr):
         if attr !="__object__" and hasattr(self.__object__,attr):
@@ -265,19 +265,19 @@ class ViewProvider(object):
         return self.__vobject__.Object
 
 
-#Example : 
+#Example :
 import Part
 
 class Box(DocumentObject):
     #type :
     type = "Part::FeaturePython"
-    
+
     #-----------------------------INIT----------------------------------------
     def init(self):
         self.addProperty("App::PropertyLength","Length","Box","Length of the box").Length=1.0
         self.addProperty("App::PropertyLength","Width","Box","Width of the box").Width=1.0
         self.addProperty("App::PropertyLength","Height","Box", "Height of the box").Height=1.0
-        
+
     #-----------------------------BEHAVIOR------------------------------------
     def propertyChanged(self,prop):
         FreeCAD.Console.PrintMessage("Box property changed : "+ prop+ "\n")
@@ -287,22 +287,22 @@ class Box(DocumentObject):
     def execute(self):
         FreeCAD.Console.PrintMessage("Recompute Python Box feature\n")
         self._recomputeShape()
-        
+
     #---------------------------PUBLIC FUNCTIONS-------------------------------
     #These functions will be present in the object
     def customFunctionSetLength(self,attr):
         self.Length = attr
         self._privateFunctionExample(attr)
-        
+
     #---------------------------PRIVATE FUNCTIONS------------------------------
     #These function won't be present in the object (begin with '_')
     def _privateFunctionExample(self,attr):
         FreeCAD.Console.PrintMessage("The length : "+str(attr)+"\n")
-        
+
     def _recomputeShape(self):
         if hasattr(self,"Length") and hasattr(self,"Width") and hasattr(self,"Height"):
             self.Shape = Part.makeBox(self.Length,self.Width,self.Height)
-        
+
 
 def makeBox():
     FreeCAD.newDocument()

--- a/src/Mod/mod.dox
+++ b/src/Mod/mod.dox
@@ -1,7 +1,7 @@
 /** \addtogroup WORKBENCHES
     Most of FreeCAD's functionality is defined in dedicated Workbenches
 
-    Those plugins, also called \b modules or \b worbenches, provide
+    Those plugins, also called \b modules or \b workbenches, provide
     functionality for specialized facets of FreeCAD. The word \b module
     refers to any new group of tools, while \b workbench designates
     specifically a GUI group of tools in the FreeCAD interface. All
@@ -28,4 +28,3 @@
  * \ingroup WORKBENCHES
  * \brief Modules that provide utility tools to FreeCAD but don't define a workbench
 */
-


### PR DESCRIPTION
Found via:  
```
codespell -q 3 -L aci,ake,aline,alle,alledges,alocation,als,ang,anid,ba,beginn,behaviour,bloaded,byteorder,calculater,cancelled,cancelling,cas,cascade,centimetre,childs,colour,colours,commen,currenty,dof,doubleclick,dum,eiter,elemente,feld,freez,hist,iff,indicies,initialisation,initialise,initialised,initialises,initialisiert,ist,kilometre,lod,mantatory,methode,metres,millimetre,modell,nd,noe,normale,normaly,nto,numer,oder,orgin,orginx,orginy,ot,pard,pres,programm,que,recurrance,rougly,seperator,serie,sinc,strack,substraction,te,thist,thru,tread,uint,unter,vertexes,wallthickness,whitespaces -S ./.git,*.po,*.ts,./ChangeLog.txt,./src/3rdParty,./src/Mod/Assembly/App/opendcm,./src/CXX,./src/zipios++,./src/Base/swig*,./src/Mod/Robot/App/kdl_cp,./src/Mod/Import/App/SCL,./src/WindowsInstaller,./src/Doc/FreeCAD.uml
```