### PR TITLE
Fix runtime warning from Qt.

### DIFF
--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -1998,7 +1998,7 @@ void StatusBarObserver::SendLog(const std::string& msg, Base::LogStyle level)
     MainWindow* win = getMainWindow();
     if(win != nullptr)
     {
-        QApplication::postEvent(getMainWindow(), ev);
+        QApplication::postEvent(win, ev);
     }
 }
 

--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -1994,7 +1994,12 @@ void StatusBarObserver::SendLog(const std::string& msg, Base::LogStyle level)
 
     // Send the event to the main window to allow thread-safety. Qt will delete it when done.
     CustomMessageEvent* ev = new CustomMessageEvent(messageType, QString::fromUtf8(msg.c_str()));
-    QApplication::postEvent(getMainWindow(), ev);
+    // TODO: Can we just get rid of this postEvent altogether?
+    MainWindow* win = getMainWindow();
+    if(win != nullptr)
+    {
+        QApplication::postEvent(getMainWindow(), ev);
+    }
 }
 
 // -------------------------------------------------------------


### PR DESCRIPTION
The warning was due to trying to send an event to a Qt object that has already been destructed. This patch adds a simple check for nullptr, though please note the `TODO` -> do we need this postEvent ever?

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- n/a Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
