### PR TITLE
LGTM: remove unnecessary 'pass' statements 

### DIFF
--- a/src/App/FreeCADInit.py
+++ b/src/App/FreeCADInit.py
@@ -192,7 +192,6 @@ def InitApplications():
 			PathEnvironment += path + os.pathsep
 		except UnicodeDecodeError:
 			Wrn('Filter invalid module path: u{}\n'.format(repr(path)))
-			pass
 
 	# new paths must be prepended to avoid to load a wrong version of a library
 	try:

--- a/src/Mod/Import/stepZ.py
+++ b/src/Mod/Import/stepZ.py
@@ -105,7 +105,6 @@ def import_stpz(fn,fc,doc):
         os.remove(tempfilepath)
     except OSError:
         sayzerr("error on removing "+tempfilepath+" file")
-        pass
 ###
 
 def open(filename,doc=None):

--- a/src/Mod/OpenSCAD/OpenSCADCommands.py
+++ b/src/Mod/OpenSCAD/OpenSCADCommands.py
@@ -327,7 +327,6 @@ class OpenSCADMeshBooleanWidget(QtGui.QWidget):
 
 class OpenSCADMeshBooleanTask:
     def __init__(self):
-        pass
         self.form = OpenSCADMeshBooleanWidget()
         self.form.buttonadd.clicked.connect(self.doboolean)
     def getStandardButtons(self):


### PR DESCRIPTION
Issue: A pass statement is only necessary when it is the only statement in a block (the list of statements forming part of a compound statement). This is because the purpose of the pass statement is to allow empty blocks where they would otherwise be syntactically invalid. If the block already contains other statements then the pass statement is unnecessary.

Recommendation: Remove the pass statement.

Relevant links: 
https://lgtm.com/projects/g/FreeCAD/FreeCAD/snapshot/1a82a5e136d24ed9862c0fd7e41070049a23fa32/files/src/Mod/Import/stepZ.py?sort=name&dir=ASC&mode=heatmap#x78f479c31a062553:1

https://lgtm.com/projects/g/FreeCAD/FreeCAD/snapshot/1a82a5e136d24ed9862c0fd7e41070049a23fa32/files/src/Mod/OpenSCAD/OpenSCADCommands.py#xad4868ffcdf82498:1

https://lgtm.com/projects/g/FreeCAD/FreeCAD/snapshot/1a82a5e136d24ed9862c0fd7e41070049a23fa32/files/src/App/FreeCADInit.py#x9034ec6815c48e38:1