### PR TITLE
Arch: division including a float to obtain correct result

### DIFF
--- a/src/Mod/Arch/ArchFence.py
+++ b/src/Mod/Arch/ArchFence.py
@@ -428,7 +428,7 @@ if __name__ == '__main__':
 
         for i in range(8):
             parts.append(Part.makeBox(20, 20, 1000 - 60,
-                                      FreeCAD.Vector((2000 / 9 * (i + 1)) - 10, 15, 30)))
+                                      FreeCAD.Vector((2000.0 / 9 * (i + 1)) - 10, 15, 30)))
 
         Part.show(Part.makeCompound(parts), "Section")
 


### PR DESCRIPTION
The LGTM code analyzer detects an issue which just affects Python 2.

In Python 3 this division will produce the correct floating point value.

Forum discussion: [Arch Fence](https://forum.freecadweb.org/viewtopic.php?p=354451#p354451)

---

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists
