### PR TITLE
UnitsCalculator fixes

### DIFF
--- a/src/Gui/DlgUnitsCalculatorImp.cpp
+++ b/src/Gui/DlgUnitsCalculatorImp.cpp
@@ -80,6 +80,7 @@ DlgUnitsCalculator::DlgUnitsCalculator( QWidget* parent, Qt::WindowFlags fl )
         ui->unitsBox->addItem(it->getTypeString());
     }
 
+    ui->quantitySpinBox->setValue(1.0);
     ui->quantitySpinBox->setUnit(units.front());
 }
 
@@ -106,8 +107,11 @@ void DlgUnitsCalculator::textChanged(QString unit)
 
 void DlgUnitsCalculator::valueChanged(const Base::Quantity& quant)
 {
-    // first check the unit, if it is invalid, getTypeString() outputs an empty string 
-    if (Base::Unit(ui->UnitInput->text()).getTypeString().isEmpty()) {
+    // first check the unit, if it is invalid, getTypeString() outputs an empty string
+    // explicitly check for "ee" like in "eeV" because this would trigger an exception in Base::Unit
+    // since it expects then a scientific notation number like "1e3"
+    if ( (ui->UnitInput->text().mid(0, 2) == QString::fromLatin1("ee")) ||
+        Base::Unit(ui->UnitInput->text()).getTypeString().isEmpty()) {
         ui->ValueOutput->setText(tr("unknown unit: ") + ui->UnitInput->text());
         ui->pushButton_Copy->setEnabled(false);
     } else { // the unit is valid


### PR DESCRIPTION
- missing initial value
- missing check for invalid units starting with 'ee'

When this is in, only one known UnitsCalculator issue is open: https://forum.freecadweb.org/viewtopic.php?f=10&t=41820