### PR TITLE
Weakref

### DIFF
--- a/src/App/Application.h
+++ b/src/App/Application.h
@@ -494,7 +494,8 @@ private:
     static PyObject *sGetActiveTransaction  (PyObject *self,PyObject *args);
     static PyObject *sCloseActiveTransaction(PyObject *self,PyObject *args);
     static PyObject *sCheckAbort(PyObject *self,PyObject *args);
-    static PyMethodDef    Methods[]; 
+    static PyObject *sTestWeakRef(PyObject *self,PyObject *args);
+    static PyMethodDef    Methods[];
 
     friend class ApplicationObserver;
 

--- a/src/Base/PyObjectBase.cpp
+++ b/src/Base/PyObjectBase.cpp
@@ -52,6 +52,13 @@ PyObjectBase::PyObjectBase(void* p,PyTypeObject *T)
     StatusBits.set(Notify);
 }
 
+void PyObjectBase::PyDestructor(PyObject* P)
+{
+    if (static_cast<PyObjectBase*>(P)->weakRefList)
+        PyObject_ClearWeakRefs(P);
+    delete ((PyObjectBase *) P);
+}
+
 /// destructor
 PyObjectBase::~PyObjectBase() 
 {

--- a/src/Base/PyObjectBase.h
+++ b/src/Base/PyObjectBase.h
@@ -220,8 +220,7 @@ public:
      */
     PyObjectBase(void*, PyTypeObject *T);
     /// Wrapper for the Python destructor
-    static void PyDestructor(PyObject *P)   // python wrapper
-    {  delete ((PyObjectBase *) P);  }
+    static void PyDestructor(PyObject *P);
     /// incref method wrapper (see python extending manual)
     PyObjectBase* IncRef(void) {Py_INCREF(this);return this;}
     /// decref method wrapper (see python extending manual)	
@@ -343,6 +342,8 @@ protected:
 
 private:
     PyObject* attrDict;
+public:
+    PyObject* weakRefList = nullptr; //for use by python's weakref module
 };
 
 

--- a/src/Mod/Test/BaseTests.py
+++ b/src/Mod/Test/BaseTests.py
@@ -288,3 +288,13 @@ class ParameterTestCase(unittest.TestCase):
         #remove all
         TestPar = FreeCAD.ParamGet("System parameter:Test")
         TestPar.Clear()
+
+class WeakRefTestCase(unittest.TestCase):
+    def setUp(self):
+        pass
+
+    def testWeakRef(self):
+        FreeCAD._testWeakRef()
+
+    def tearDown(self):
+        pass

--- a/src/Tools/generateTemplates/templateClassPyExport.py
+++ b/src/Tools/generateTemplates/templateClassPyExport.py
@@ -340,7 +340,7 @@ PyTypeObject @self.export.Name@::Type = {
 = else:
     0,                                                /*tp_richcompare */
 -
-    0,                                                /*tp_weaklistoffset */
+    offsetof(PyObjectBase, weakRefList) - offsetof(PyObjectBase, ob_refcnt) + offsetof(PyObject, ob_refcnt),    /*tp_weaklistoffset */
     0,                                                /*tp_iter */
     0,                                                /*tp_iternext */
     @self.export.Namespace@::@self.export.Name@::Methods,                     /*tp_methods */


### PR DESCRIPTION
adds support for weakrefs on FreeCAD extension types.

I want it for ConstraintSolver. This is why:
I have a geometry object, and a rule constraint (e.g., an arc of circle, and two point-on-circle constraints that tie the endpoints onto the circle). The constraint refs the geometry. I would like the geometry to know its rule constraint. It can't ref the constraint, because that will make the pair immortal. So I want something like weakref. I could roll a special mechanism emulating the weakref behavior, but supporting python weakref seems more universal and better solution.

Unfortunately, I probably made the weakref work through undefined behavior. I used offsetof() macro (only supposed to give good results on plain-old-data structs) on PyObjectBase member variable (PyObjectBase is a full-blown C++ object with inheritance and virtual methods). But I don't see any way of doing it without this undefined behavior just yet. So I added a unit test, and let's see how it survives different compilers. 

see also https://forum.freecadweb.org/viewtopic.php?f=10&t=41818
