### PR TITLE
Manual dimension centers the plane's view

### DIFF
--- a/src/Mod/PartDesign/Gui/ViewProviderDatumPlane.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderDatumPlane.cpp
@@ -134,8 +134,8 @@ void ViewProviderDatumPlane::setExtents(double l, double w)
 {
     // Change the coordinates of the line
     pCoords->point.setNum (4);
-    pCoords->point.set1Value(0, l, w, 0);
-    pCoords->point.set1Value(1, 0, w, 0);
-    pCoords->point.set1Value(2, 0, 0, 0);
-    pCoords->point.set1Value(3, l, 0, 0);
+    pCoords->point.set1Value(0, l/2, w/2, 0);
+    pCoords->point.set1Value(1, -l/2, w/2, 0);
+    pCoords->point.set1Value(2, -l/2, -w/2, 0);
+    pCoords->point.set1Value(3, l/2, -w/2, 0);
 }


### PR DESCRIPTION
With the current manual dimensions a Datum Plane is visually ex-centred from it's origin, so when drawing a circle the circle is outside of the Plane representation. With this proposed change the visual representation is centred.

See forum thread:

https://forum.freecadweb.org/viewtopic.php?f=8&t=41710

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ x ] Branch rebased on latest master `git pull --rebase upstream master`
- [ - ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ x ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ - ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
