### PR TITLE
more fixes for the UnitsCalculator

### DIFF
--- a/src/Base/UnitsApi.cpp
+++ b/src/Base/UnitsApi.cpp
@@ -95,7 +95,7 @@ const char* UnitsApi::getDescription(UnitSystem system)
     case UnitSystem::Centimeters:
         return "Building Euro (cm/m²/m³)";
     case UnitSystem::ImperialBuilding:
-        return "Building US (ft-in/sqft/cuft)";
+        return "Building US (ft-in/sqft/cft)";
     case UnitSystem::MmMin:
         return "Metric small parts & CNC(mm, mm/min)";
     case UnitSystem::ImperialCivil:

--- a/src/Base/UnitsSchemaImperial1.cpp
+++ b/src/Base/UnitsSchemaImperial1.cpp
@@ -178,7 +178,11 @@ QString UnitsSchemaImperialDecimal::schemaTranslate(const Base::Quantity& quant,
     }
     else if (unit == Unit::Velocity) {
         unitString = QString::fromLatin1("in/min");
-        factor = 25.4/60;
+        factor = 25.4 / 60;
+    }
+    else if (unit == Unit::Acceleration) {
+        unitString = QString::fromLatin1("in/min^2");
+        factor = 25.4 / 3600;
     }
     else {
         // default action for all cases without special treatment:

--- a/src/Gui/DlgSettingsUnits.ui
+++ b/src/Gui/DlgSettingsUnits.ui
@@ -71,46 +71,6 @@
           <property name="toolTip">
            <string>Unit system that should be used for all parts the application</string>
           </property>
-          <item>
-           <property name="text">
-            <string>Standard (mm/kg/s/degree)</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>MKS (m/kg/s/degree)</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>US customary (in/lb)</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Imperial decimal (in/lb)</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Building Euro (cm/m²/m³)</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Building US (ft-in/sqft/cuft)</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Metric small parts &amp; CNC(mm, mm/min)</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Imperial Civil (ft/ft^2/ft^3)</string>
-           </property>
-          </item>
          </widget>
         </item>
        </layout>

--- a/src/Gui/DlgSettingsUnitsImp.cpp
+++ b/src/Gui/DlgSettingsUnitsImp.cpp
@@ -53,6 +53,12 @@ DlgSettingsUnitsImp::DlgSettingsUnitsImp(QWidget* parent)
     ui->setupUi(this);
     ui->spinBoxDecimals->setMaximum(std::numeric_limits<double>::digits10 + 1);
 
+    int num = static_cast<int>(Base::UnitSystem::NumUnitSystemTypes);
+    for (int i = 0; i < num; i++) {
+        QString item = QString::fromUtf8(Base::UnitsApi::getDescription(static_cast<Base::UnitSystem>(i)));
+        ui->comboBox_ViewSystem->addItem(item, i);
+    }
+
     //fillUpListBox();
     ui->tableWidget->setVisible(false);
     //

--- a/src/Gui/DlgUnitsCalculatorImp.cpp
+++ b/src/Gui/DlgUnitsCalculatorImp.cpp
@@ -53,7 +53,7 @@ DlgUnitsCalculator::DlgUnitsCalculator( QWidget* parent, Qt::WindowFlags fl )
     ui->comboBoxScheme->addItem(QString::fromLatin1("Preference system"), static_cast<int>(-1));
     int num = static_cast<int>(Base::UnitSystem::NumUnitSystemTypes);
     for (int i=0; i<num; i++) {
-        QString item = QString::fromLatin1(Base::UnitsApi::getDescription(static_cast<Base::UnitSystem>(i)));
+        QString item = QString::fromUtf8(Base::UnitsApi::getDescription(static_cast<Base::UnitSystem>(i)));
         ui->comboBoxScheme->addItem(item, i);
     }
 


### PR DESCRIPTION
- we must read the unit system description as UTF8 to get the characters ² and ³
- update unit system description according to today's unit "cft" addition
- don't hardcode the unit system descriptions in the .ui file
- add acceleration to imperial schema