### PR TITLE
Draft: new command Draft_PolarArray

### DIFF
--- a/src/Mod/Draft/CMakeLists.txt
+++ b/src/Mod/Draft/CMakeLists.txt
@@ -49,19 +49,23 @@ SET(Draft_tests
 
 SET(Draft_objects
     draftobjects/__init__.py
+    draftobjects/polararray.py
 )
 
 SET(Draft_view_providers
     draftviewproviders/__init__.py
+    draftviewproviders/view_polararray.py
 )
 
 SET(Draft_GUI_tools
     draftguitools/__init__.py
     draftguitools/gui_base.py
+    draftguitools/gui_polararray.py
 )
 
 SET(Draft_task_panels
     drafttaskpanels/__init__.py
+    drafttaskpanels/task_polararray.py
 )
 
 SET(Draft_SRCS_all

--- a/src/Mod/Draft/InitGui.py
+++ b/src/Mod/Draft/InitGui.py
@@ -65,6 +65,7 @@ class DraftWorkbench(Workbench):
         try:
             import os, Draft_rc, DraftTools, DraftGui, DraftFillet
             from DraftTools import translate
+            from draftguitools import gui_polararray
             FreeCADGui.addLanguagePath(":/translations")
             FreeCADGui.addIconPath(":/icons")
         except Exception as inst:
@@ -85,6 +86,7 @@ class DraftWorkbench(Workbench):
                         "Draft_WireToBSpline", "Draft_AddPoint",
                         "Draft_DelPoint", "Draft_Shape2DView",
                         "Draft_Draft2Sketch", "Draft_Array", "Draft_LinkArray",
+                        "Draft_PolarArray",
                         "Draft_PathArray", "Draft_PathLinkArray", "Draft_PointArray", "Draft_Clone",
                         "Draft_Drawing", "Draft_Mirror", "Draft_Stretch"]
         self.treecmdList = ["Draft_ApplyStyle", "Draft_ToggleDisplayMode",

--- a/src/Mod/Draft/Resources/Draft.qrc
+++ b/src/Mod/Draft/Resources/Draft.qrc
@@ -51,6 +51,7 @@
         <file>icons/Draft_PathLinkArray.svg</file>
         <file>icons/Draft_Point.svg</file>
         <file>icons/Draft_PointArray.svg</file>
+        <file>icons/Draft_PolarArray.svg</file>
         <file>icons/Draft_Polygon.svg</file>
         <file>icons/Draft_Rectangle.svg</file>
         <file>icons/Draft_Rotate.svg</file>
@@ -148,6 +149,7 @@
         <file>ui/preferences-dxf.ui</file>
         <file>ui/preferences-oca.ui</file>
         <file>ui/preferences-svg.ui</file>
+        <file>ui/TaskPanel_PolarArray.ui</file>
         <file>ui/TaskSelectPlane.ui</file>
         <file>ui/TaskShapeString.ui</file>
     </qresource>

--- a/src/Mod/Draft/Resources/icons/Draft_PolarArray.svg
+++ b/src/Mod/Draft/Resources/icons/Draft_PolarArray.svg
@@ -1,0 +1,412 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="64px"
+   height="64px"
+   id="svg5821"
+   sodipodi:version="0.32"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)"
+   sodipodi:docname="Draft_PolarArray.svg"
+   inkscape:output_extension="org.inkscape.output.svg.inkscape"
+   version="1.1"
+   inkscape:export-filename="/home/user/Downloads/cad/mystuff/icons/Draft_wb_primitives/Draft_Array/Draft_Array_Ortho_16px.png"
+   inkscape:export-xdpi="22.5"
+   inkscape:export-ydpi="22.5">
+  <defs
+     id="defs5823">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient6349">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop6351" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop6353" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3377">
+      <stop
+         style="stop-color:#0019a3;stop-opacity:1;"
+         offset="0"
+         id="stop3379" />
+      <stop
+         style="stop-color:#0069ff;stop-opacity:1;"
+         offset="1"
+         id="stop3381" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3377"
+       id="linearGradient3383"
+       x1="901.1875"
+       y1="1190.875"
+       x2="1267.9062"
+       y2="1190.875"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1,0,0,1,2199.356,0)" />
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 32 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="64 : 32 : 1"
+       inkscape:persp3d-origin="32 : 21.333333 : 1"
+       id="perspective5829" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6349"
+       id="radialGradient6355"
+       cx="1103.6399"
+       cy="1424.4465"
+       fx="1103.6399"
+       fy="1424.4465"
+       r="194.40614"
+       gradientTransform="matrix(-1.4307499,-1.3605156e-7,-1.202713e-8,0.1264801,2674.7488,1244.2826)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3791-6">
+      <stop
+         style="stop-color:#204a87;stop-opacity:1"
+         offset="0"
+         id="stop3793-7" />
+      <stop
+         style="stop-color:#729fcf;stop-opacity:1"
+         offset="1"
+         id="stop3795-5" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3791-6"
+       id="linearGradient3820"
+       x1="939.98767"
+       y1="1097.5122"
+       x2="893.2572"
+       y2="989.77716"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3791-0">
+      <stop
+         style="stop-color:#204a87;stop-opacity:1"
+         offset="0"
+         id="stop3793-6" />
+      <stop
+         style="stop-color:#729fcf;stop-opacity:1"
+         offset="1"
+         id="stop3795-2" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3791-0"
+       id="linearGradient3896"
+       x1="939.98767"
+       y1="1097.5122"
+       x2="893.2572"
+       y2="989.77716"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3791-6-9">
+      <stop
+         style="stop-color:#204a87;stop-opacity:1"
+         offset="0"
+         id="stop3793-7-7" />
+      <stop
+         style="stop-color:#729fcf;stop-opacity:1"
+         offset="1"
+         id="stop3795-5-3" />
+    </linearGradient>
+    <linearGradient
+       y2="989.77716"
+       x2="893.2572"
+       y1="1097.5122"
+       x1="939.98767"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3834-6"
+       xlink:href="#linearGradient3791-6-9"
+       inkscape:collect="always"
+       gradientTransform="matrix(1.251547,0,0,1.2214422,104.06364,54.837797)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3791-2">
+      <stop
+         style="stop-color:#204a87;stop-opacity:1"
+         offset="0"
+         id="stop3793-9" />
+      <stop
+         style="stop-color:#729fcf;stop-opacity:1"
+         offset="1"
+         id="stop3795-3" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3791-2"
+       id="linearGradient3896-1"
+       x1="939.98767"
+       y1="1097.5122"
+       x2="893.2572"
+       y2="989.77716"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3791-6-9"
+       id="linearGradient911"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.251547,0,0,1.2214422,104.06364,54.837797)"
+       x1="939.98767"
+       y1="1097.5122"
+       x2="893.2572"
+       y2="1049.63" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3791-6-9"
+       id="linearGradient926"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.251547,0,0,1.2214422,104.06352,186.42979)"
+       x1="939.98773"
+       y1="989.77716"
+       x2="893.2572"
+       y2="941.8949" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3791-6-9"
+       id="linearGradient934"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.251547,0,0,1.2214422,104.06352,186.42979)"
+       x1="939.98773"
+       y1="989.77716"
+       x2="893.2572"
+       y2="941.8949" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3791-6-9"
+       id="linearGradient942"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.251547,0,0,1.2214422,104.06352,186.42979)"
+       x1="939.98773"
+       y1="989.77716"
+       x2="893.2572"
+       y2="941.8949" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="5.149742"
+     inkscape:cx="-4.8471235"
+     inkscape:cy="44.978809"
+     inkscape:current-layer="g3360"
+     showgrid="true"
+     inkscape:document-units="px"
+     inkscape:grid-bbox="true"
+     inkscape:window-width="1853"
+     inkscape:window-height="1025"
+     inkscape:window-x="1433"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3010"
+       units="px"
+       empspacing="2"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true"
+       spacingx="1"
+       spacingy="1"
+       originx="0"
+       originy="0" />
+  </sodipodi:namedview>
+  <g
+     id="layer1"
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer">
+    <g
+       id="g3360"
+       inkscape:export-filename="/home/yorik/Documents/Lab/Draft/icons/draft.png"
+       inkscape:export-xdpi="3.2478156"
+       inkscape:export-ydpi="3.2478156"
+       transform="matrix(0.1367863,0,0,0.1367863,-119.15519,-134.86962)">
+      <path
+         sodipodi:nodetypes="cc"
+         style="fill:none;fill-rule:evenodd;stroke:#0c1622;stroke-width:14.62134731;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:43.86404194,14.62134731;stroke-opacity:0.50196078;stroke-dashoffset:0"
+         d="m 1002.6968,1380.7642 h 233.9416"
+         id="path864"
+         inkscape:connector-curvature="0" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path862"
+         d="M 944.21145,1322.2788 V 1088.3372"
+         style="fill:none;fill-rule:evenodd;stroke:#0c1622;stroke-width:14.62134731;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:43.86404194,14.62134731;stroke-opacity:0.50196078;stroke-dashoffset:0"
+         sodipodi:nodetypes="cc" />
+      <path
+         style="fill:none;fill-rule:evenodd;stroke:#0c1622;stroke-width:14.62134731;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:43.86404194,14.62134731;stroke-opacity:0.50196078;stroke-dashoffset:0"
+         d="M 973.45414,1329.5894 1096.1609,1117.5799"
+         id="path858"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path860"
+         d="M 1002.6968,1351.5215 1222.017,1234.5507"
+         style="fill:none;fill-rule:evenodd;stroke:#0c1622;stroke-width:14.62134731;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:43.86404194,14.62134731;stroke-opacity:0.50196078;stroke-dashoffset:0"
+         sodipodi:nodetypes="cc" />
+      <path
+         style="opacity:0.5;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#0b1521;stroke-width:14.62134743;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="path944"
+         sodipodi:type="arc"
+         sodipodi:cx="943.94775"
+         sodipodi:cy="1380.7642"
+         sodipodi:rx="285.37994"
+         sodipodi:ry="281.36465"
+         sodipodi:start="4.712389"
+         sodipodi:end="0"
+         d="m 943.94776,1099.3995 a 285.37994,281.36465 0 0 1 285.37994,281.3647"
+         sodipodi:open="true" />
+      <g
+         id="g903">
+        <rect
+           y="1329.5894"
+           x="1214.7063"
+           height="73.106735"
+           width="73.106735"
+           id="rect3808-6-1-20"
+           style="fill:url(#linearGradient3834-6);fill-opacity:1;fill-rule:nonzero;stroke:#729fcf;stroke-width:14.62134743;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      </g>
+      <g
+         id="g916"
+         transform="translate(0,14.621347)">
+        <rect
+           y="1314.968"
+           x="1200.0851"
+           height="102.34943"
+           width="102.34941"
+           id="rect3808-2-6"
+           style="fill:#3465a4;fill-opacity:1;fill-rule:nonzero;stroke:#0b1521;stroke-width:14.62134838;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+        <rect
+           style="fill:url(#linearGradient911);fill-opacity:1;fill-rule:nonzero;stroke:#729fcf;stroke-width:14.62134743;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           id="rect905"
+           width="73.106735"
+           height="73.106735"
+           x="1214.7063"
+           y="1329.5894" />
+      </g>
+      <g
+         id="g922"
+         transform="translate(-29.242576,-131.59199)">
+        <rect
+           style="fill:#3465a4;fill-opacity:1;fill-rule:nonzero;stroke:#0b1521;stroke-width:14.62134838;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           id="rect918"
+           width="102.34941"
+           height="102.34943"
+           x="1200.0851"
+           y="1314.968" />
+        <rect
+           y="1329.5894"
+           x="1214.7063"
+           height="73.106735"
+           width="73.106735"
+           id="rect920"
+           style="fill:url(#linearGradient926);fill-opacity:1;fill-rule:nonzero;stroke:#729fcf;stroke-width:14.62134743;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      </g>
+      <g
+         transform="translate(-153.52403,-248.56277)"
+         id="g932">
+        <rect
+           y="1314.968"
+           x="1200.0851"
+           height="102.34943"
+           width="102.34941"
+           id="rect928"
+           style="fill:#3465a4;fill-opacity:1;fill-rule:nonzero;stroke:#0b1521;stroke-width:14.62134838;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+        <rect
+           style="fill:url(#linearGradient934);fill-opacity:1;fill-rule:nonzero;stroke:#729fcf;stroke-width:14.62134743;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           id="rect930"
+           width="73.106735"
+           height="73.106735"
+           x="1214.7063"
+           y="1329.5894" />
+      </g>
+      <g
+         id="g940"
+         transform="translate(-307.04835,-292.42682)">
+        <rect
+           style="fill:#3465a4;fill-opacity:1;fill-rule:nonzero;stroke:#0b1521;stroke-width:14.62134838;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           id="rect936"
+           width="102.34941"
+           height="102.34943"
+           x="1200.0851"
+           y="1314.968" />
+        <rect
+           y="1329.5894"
+           x="1214.7063"
+           height="73.106735"
+           width="73.106735"
+           id="rect938"
+           style="fill:url(#linearGradient942);fill-opacity:1;fill-rule:nonzero;stroke:#729fcf;stroke-width:14.62134743;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      </g>
+    </g>
+  </g>
+  <metadata
+     id="metadata3357">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>Draft_Array</dc:title>
+        <cc:license
+           rdf:resource="" />
+        <dc:date>Sat Dec 10 18:31:32 2011 +0000</dc:date>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>[yorikvanhavre]</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>FreeCAD LGPL2+</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>FreeCAD</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:identifier>FreeCAD/src/Mod/Draft/Resources/icons/Draft_Array.svg</dc:identifier>
+        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title>[agryson] Alexander Gryson</dc:title>
+          </cc:Agent>
+        </dc:contributor>
+        <dc:description>Six rectangles in a 2 x 3 linear array</dc:description>
+        <dc:subject>
+          <rdf:Bag>
+            <rdf:li>rectangle</rdf:li>
+            <rdf:li>array</rdf:li>
+          </rdf:Bag>
+        </dc:subject>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+</svg>

--- a/src/Mod/Draft/Resources/ui/TaskPanel_PolarArray.ui
+++ b/src/Mod/Draft/Resources/ui/TaskPanel_PolarArray.ui
@@ -1,0 +1,247 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>DraftPolarArrayTaskPanel</class>
+ <widget class="QWidget" name="DraftPolarArrayTaskPanel">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>445</width>
+    <height>488</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>250</width>
+    <height>0</height>
+   </size>
+  </property>
+  <property name="windowTitle">
+   <string>Polar array</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout_3">
+   <item row="1" column="0">
+    <widget class="QGroupBox" name="main_group">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="title">
+      <string/>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_4">
+      <item row="9" column="0">
+       <spacer name="verticalSpacer">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>40</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item row="5" column="0">
+       <widget class="QGroupBox" name="group_center">
+        <property name="toolTip">
+         <string>The coordinates of the point through which the axis of rotation passes.</string>
+        </property>
+        <property name="title">
+         <string>Center of rotation</string>
+        </property>
+        <layout class="QGridLayout" name="gridLayout_2">
+         <item row="0" column="0">
+          <layout class="QGridLayout" name="grid_center">
+           <item row="2" column="0">
+            <widget class="QLabel" name="label_c_z">
+             <property name="text">
+              <string>Z</string>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="1">
+            <widget class="Gui::InputField" name="input_c_x">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="unit" stdset="0">
+              <string notr="true"/>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="1">
+            <widget class="Gui::InputField" name="input_c_y">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="unit" stdset="0">
+              <string notr="true"/>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="1">
+            <widget class="Gui::InputField" name="input_c_z">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="unit" stdset="0">
+              <string notr="true"/>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="0">
+            <widget class="QLabel" name="label_c_x">
+             <property name="text">
+              <string>X</string>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="0">
+            <widget class="QLabel" name="label_c_y">
+             <property name="text">
+              <string>Y</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+         <item row="1" column="0">
+          <widget class="QPushButton" name="button_reset">
+           <property name="toolTip">
+            <string>Reset the coordinates of the center of rotation</string>
+           </property>
+           <property name="text">
+            <string>Reset point</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item row="6" column="0">
+       <layout class="QVBoxLayout" name="vertical_layout">
+        <item>
+         <widget class="QCheckBox" name="checkbox_fuse">
+          <property name="toolTip">
+           <string>If checked, the resulting objects in the array will be fused if they touch each other</string>
+          </property>
+          <property name="text">
+           <string>Fuse</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QCheckBox" name="checkbox_link">
+          <property name="toolTip">
+           <string>If checked, the resulting objects in the array will be Links instead of simple copies</string>
+          </property>
+          <property name="text">
+           <string>Use Links</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item row="1" column="0">
+       <layout class="QGridLayout" name="grid_values">
+        <item row="0" column="0">
+         <widget class="QLabel" name="label_angle">
+          <property name="toolTip">
+           <string>Sweeping angle of the polar distribution</string>
+          </property>
+          <property name="text">
+           <string>Polar angle</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1">
+         <widget class="Gui::QuantitySpinBox" name="spinbox_angle">
+          <property name="toolTip">
+           <string>Sweeping angle of the polar distribution</string>
+          </property>
+          <property name="unit" stdset="0">
+           <string notr="true"/>
+          </property>
+          <property name="value">
+           <double>180.000000000000000</double>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="0">
+         <widget class="QLabel" name="label_number">
+          <property name="toolTip">
+           <string>Number of elements in the array, including a copy of the original object. It must be at least 2.</string>
+          </property>
+          <property name="text">
+           <string>Number of elements</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="1">
+         <widget class="QSpinBox" name="spinbox_number">
+          <property name="toolTip">
+           <string>Number of elements in the array, including a copy of the original object. It must be at least 2.</string>
+          </property>
+          <property name="value">
+           <number>4</number>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_icon">
+        <property name="text">
+         <string>(Placeholder for the icon)</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>Gui::InputField</class>
+   <extends>QLineEdit</extends>
+   <header>Gui/InputField.h</header>
+  </customwidget>
+  <customwidget>
+   <class>Gui::QuantitySpinBox</class>
+   <extends>QWidget</extends>
+   <header>Gui/QuantitySpinBox.h</header>
+  </customwidget>
+ </customwidgets>
+ <tabstops>
+  <tabstop>spinbox_angle</tabstop>
+  <tabstop>spinbox_number</tabstop>
+  <tabstop>input_c_x</tabstop>
+  <tabstop>input_c_y</tabstop>
+  <tabstop>input_c_z</tabstop>
+  <tabstop>button_reset</tabstop>
+  <tabstop>checkbox_fuse</tabstop>
+  <tabstop>checkbox_link</tabstop>
+ </tabstops>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/Mod/Draft/draftguitools/gui_polararray.py
+++ b/src/Mod/Draft/draftguitools/gui_polararray.py
@@ -1,0 +1,155 @@
+"""This module provides the Draft PolarArray tool.
+"""
+## @package gui_polararray
+# \ingroup DRAFT
+# \brief This module provides the Draft PolarArray tool.
+
+# ***************************************************************************
+# *   (c) 2019 Eliud Cabrera Castillo <e.cabrera-castillo@tum.de>           *
+# *                                                                         *
+# *   This file is part of the FreeCAD CAx development system.              *
+# *                                                                         *
+# *   This program is free software; you can redistribute it and/or modify  *
+# *   it under the terms of the GNU Lesser General Public License (LGPL)    *
+# *   as published by the Free Software Foundation; either version 2 of     *
+# *   the License, or (at your option) any later version.                   *
+# *   for detail see the LICENCE text file.                                 *
+# *                                                                         *
+# *   FreeCAD is distributed in the hope that it will be useful,            *
+# *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+# *   GNU Library General Public License for more details.                  *
+# *                                                                         *
+# *   You should have received a copy of the GNU Library General Public     *
+# *   License along with FreeCAD; if not, write to the Free Software        *
+# *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
+# *   USA                                                                   *
+# *                                                                         *
+# ***************************************************************************
+
+import FreeCAD as App
+import FreeCADGui as Gui
+import Draft
+import DraftGui
+import Draft_rc
+from . import gui_base
+from drafttaskpanels import task_polararray
+
+
+if App.GuiUp:
+    from PySide.QtCore import QT_TRANSLATE_NOOP
+    # import DraftTools
+    from DraftGui import translate
+    # from DraftGui import displayExternal
+    from pivy import coin
+else:
+    def QT_TRANSLATE_NOOP(context, text):
+        return text
+
+    def translate(context, text):
+        return text
+
+
+def _tr(text):
+    """Function to translate with the context set"""
+    return translate("Draft", text)
+
+
+# So the resource file doesn't trigger errors from code checkers (flake8)
+True if Draft_rc.__name__ else False
+
+
+class GuiCommandPolarArray(gui_base.GuiCommandBase):
+    """Gui command for the PolarArray tool"""
+
+    def __init__(self):
+        super().__init__()
+        self.command_name = "PolarArray"
+        self.location = None
+        self.mouse_event = None
+        self.view = None
+        self.callback_move = None
+        self.callback_click = None
+        self.ui = None
+        self.point = App.Vector()
+
+    def GetResources(self):
+        _msg = ("Creates copies of a selected object, "
+                "and places the copies in a polar pattern.\n"
+                "The properties of the array can be further modified after "
+                "the new object is created, including turning it into "
+                "a different type of array.")
+        d = {'Pixmap': 'Draft_PolarArray',
+             'MenuText': QT_TRANSLATE_NOOP("Draft", "Polar array"),
+             'ToolTip': QT_TRANSLATE_NOOP("Draft", _msg)}
+        return d
+
+    def Activated(self):
+        """This is called when the command is executed.
+
+        We add callbacks that connect the 3D view with
+        the widgets of the task panel.
+        """
+        self.location = coin.SoLocation2Event.getClassTypeId()
+        self.mouse_event = coin.SoMouseButtonEvent.getClassTypeId()
+        self.view = Draft.get3DView()
+        self.callback_move = \
+            self.view.addEventCallbackPivy(self.location, self.move)
+        self.callback_click = \
+            self.view.addEventCallbackPivy(self.mouse_event, self.click)
+
+        self.ui = task_polararray.TaskPanelPolarArray()
+        # The calling class (this one) is saved in the object
+        # of the interface, to be able to call a function from within it.
+        self.ui.source_command = self
+        # Gui.Control.showDialog(self.ui)
+        DraftGui.todo.delay(Gui.Control.showDialog, self.ui)
+
+    def move(self, event_cb):
+        """This is a callback for when the mouse pointer moves in the 3D view.
+
+        It should automatically update the coordinates in the widgets
+        of the task panel.
+        """
+        event = event_cb.getEvent()
+        mousepos = event.getPosition().getValue()
+        ctrl = event.wasCtrlDown()
+        self.point = Gui.Snapper.snap(mousepos, active=ctrl)
+        if self.ui:
+            self.ui.display_point(self.point)
+
+    def click(self, event_cb=None):
+        """This is a callback for when the mouse pointer clicks on the 3D view.
+
+        It should act as if the Enter key was pressed, or the OK button
+        was pressed in the task panel.
+        """
+        if event_cb:
+            event = event_cb.getEvent()
+            if (event.getState() != coin.SoMouseButtonEvent.DOWN
+                    or event.getButton() != coin.SoMouseButtonEvent.BUTTON1):
+                return
+        if self.ui and self.point:
+            # The accept function of the interface
+            # should call the completed function
+            # of the calling class (this one).
+            self.ui.accept()
+
+    def completed(self):
+        """This is called when the command is terminated.
+
+        We should remove the callbacks that were added to the 3D view
+        and then close the task panel.
+        """
+        self.view.removeEventCallbackPivy(self.location,
+                                          self.callback_move)
+        self.view.removeEventCallbackPivy(self.mouse_event,
+                                          self.callback_click)
+        if Gui.Control.activeDialog():
+            Gui.Snapper.off()
+            Gui.Control.closeDialog()
+            super().finish()
+
+
+if App.GuiUp:
+    Gui.addCommand('Draft_PolarArray', GuiCommandPolarArray())

--- a/src/Mod/Draft/draftobjects/polararray.py
+++ b/src/Mod/Draft/draftobjects/polararray.py
@@ -1,0 +1,42 @@
+"""This module provides the object code for Draft PolarArray.
+"""
+## @package polararray
+# \ingroup DRAFT
+# \brief This module provides the object code for Draft PolarArray.
+
+# ***************************************************************************
+# *   (c) 2019 Eliud Cabrera Castillo <e.cabrera-castillo@tum.de>           *
+# *                                                                         *
+# *   This file is part of the FreeCAD CAx development system.              *
+# *                                                                         *
+# *   This program is free software; you can redistribute it and/or modify  *
+# *   it under the terms of the GNU Lesser General Public License (LGPL)    *
+# *   as published by the Free Software Foundation; either version 2 of     *
+# *   the License, or (at your option) any later version.                   *
+# *   for detail see the LICENCE text file.                                 *
+# *                                                                         *
+# *   FreeCAD is distributed in the hope that it will be useful,            *
+# *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+# *   GNU Library General Public License for more details.                  *
+# *                                                                         *
+# *   You should have received a copy of the GNU Library General Public     *
+# *   License along with FreeCAD; if not, write to the Free Software        *
+# *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
+# *   USA                                                                   *
+# *                                                                         *
+# ***************************************************************************
+
+import FreeCAD as App
+import Draft
+
+
+def make_polar_array(obj,
+                     center=App.Vector(0, 0, 0), angle=180, number=4,
+                     use_link=False):
+    """Create a polar array from the given object.
+    """
+    obj = Draft.makeArray(obj,
+                          arg1=center, arg2=angle, arg3=number,
+                          useLink=use_link)
+    return obj

--- a/src/Mod/Draft/drafttaskpanels/task_polararray.py
+++ b/src/Mod/Draft/drafttaskpanels/task_polararray.py
@@ -1,0 +1,377 @@
+"""This module provides the task panel for the Draft PolarArray tool.
+"""
+## @package task_polararray
+# \ingroup DRAFT
+# \brief This module provides the task panel code for the PolarArray tool.
+
+# ***************************************************************************
+# *   (c) 2019 Eliud Cabrera Castillo <e.cabrera-castillo@tum.de>           *
+# *                                                                         *
+# *   This file is part of the FreeCAD CAx development system.              *
+# *                                                                         *
+# *   This program is free software; you can redistribute it and/or modify  *
+# *   it under the terms of the GNU Lesser General Public License (LGPL)    *
+# *   as published by the Free Software Foundation; either version 2 of     *
+# *   the License, or (at your option) any later version.                   *
+# *   for detail see the LICENCE text file.                                 *
+# *                                                                         *
+# *   FreeCAD is distributed in the hope that it will be useful,            *
+# *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+# *   GNU Library General Public License for more details.                  *
+# *                                                                         *
+# *   You should have received a copy of the GNU Library General Public     *
+# *   License along with FreeCAD; if not, write to the Free Software        *
+# *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
+# *   USA                                                                   *
+# *                                                                         *
+# ***************************************************************************
+
+import FreeCAD as App
+import FreeCADGui as Gui
+# import Draft
+import Draft_rc
+import DraftVecUtils
+
+import PySide.QtCore as QtCore
+import PySide.QtGui as QtGui
+from PySide.QtCore import QT_TRANSLATE_NOOP
+# import DraftTools
+from DraftGui import translate
+# from DraftGui import displayExternal
+
+_Quantity = App.Units.Quantity
+
+
+def _Msg(text, end="\n"):
+    """Print message with newline"""
+    App.Console.PrintMessage(text + end)
+
+
+def _Wrn(text, end="\n"):
+    """Print warning with newline"""
+    App.Console.PrintWarning(text + end)
+
+
+def _tr(text):
+    """Function to translate with the context set"""
+    return translate("Draft", text)
+
+
+# So the resource file doesn't trigger errors from code checkers (flake8)
+True if Draft_rc.__name__ else False
+
+
+class TaskPanelPolarArray:
+    """TaskPanel for the PolarArray command.
+
+    The names of the widgets are defined in the `.ui` file.
+    In this class all those widgets are automatically created
+    under the name `self.form.<name>`
+
+    The `.ui` file may use special FreeCAD widgets such as
+    `Gui::InputField` (based on `QLineEdit`) and
+    `Gui::QuantitySpinBox` (based on `QAbstractSpinBox`).
+    See the Doxygen documentation of the corresponding files in `src/Gui/`,
+    for example, `InputField.h` and `QuantitySpinBox.h`.
+    """
+
+    def __init__(self):
+        ui_file = ":/ui/TaskPanel_PolarArray.ui"
+        self.form = Gui.PySideUic.loadUi(ui_file)
+        self.name = self.form.windowTitle()
+
+        icon_name = "Draft_PolarArray"
+        svg = ":/icons/" + icon_name
+        pix = QtGui.QPixmap(svg)
+        icon = QtGui.QIcon.fromTheme(icon_name, QtGui.QIcon(svg))
+        self.form.setWindowIcon(icon)
+        self.form.label_icon.setPixmap(pix.scaled(32, 32))
+
+        start_angle = _Quantity(180.0, App.Units.Angle)
+        angle_unit = start_angle.getUserPreferred()[2]
+        self.form.spinbox_angle.setProperty('rawValue', start_angle.Value)
+        self.form.spinbox_angle.setProperty('unit', angle_unit)
+        self.form.spinbox_number.setValue(4)
+
+        self.angle_str = self.form.spinbox_angle.text()
+        self.angle = start_angle.Value
+
+        self.number = self.form.spinbox_number.value()
+
+        start_point = _Quantity(0.0, App.Units.Length)
+        length_unit = start_point.getUserPreferred()[2]
+        self.form.input_c_x.setProperty('rawValue', start_point.Value)
+        self.form.input_c_x.setProperty('unit', length_unit)
+        self.form.input_c_y.setProperty('rawValue', start_point.Value)
+        self.form.input_c_y.setProperty('unit', length_unit)
+        self.form.input_c_z.setProperty('rawValue', start_point.Value)
+        self.form.input_c_z.setProperty('unit', length_unit)
+        self.valid_input = True
+
+        self.c_x_str = ""
+        self.c_y_str = ""
+        self.c_z_str = ""
+        self.center = App.Vector(0, 0, 0)
+
+        # Old style for Qt4
+        # QtCore.QObject.connect(self.form.button_reset,
+        #                        QtCore.SIGNAL("clicked()"),
+        #                        self.reset_point)
+        # New style for Qt5
+        self.form.button_reset.clicked.connect(self.reset_point)
+
+        # The mask is not used at the moment, but could be used in the future
+        # by a callback to restrict the coordinates of the pointer.
+        self.mask = ""
+
+        # When the checkbox changes, change the fuse value
+        self.fuse = False
+        QtCore.QObject.connect(self.form.checkbox_fuse,
+                               QtCore.SIGNAL("stateChanged(int)"),
+                               self.set_fuse)
+
+        self.use_link = False
+        QtCore.QObject.connect(self.form.checkbox_link,
+                               QtCore.SIGNAL("stateChanged(int)"),
+                               self.set_link)
+
+    def accept(self):
+        """Function that executes when clicking the OK button"""
+        selection = Gui.Selection.getSelection()
+        self.number = self.form.spinbox_number.value()
+        self.valid_input = self.validate_input(selection,
+                                               self.number)
+        if self.valid_input:
+            self.create_object(selection)
+            self.print_messages(selection)
+            self.finish()
+
+    def validate_input(self, selection, number):
+        """Check that the input is valid"""
+        if not selection:
+            _Wrn(_tr("At least one element must be selected"))
+            return False
+        if number < 2:
+            _Wrn(_tr("Number of elements must be at least 2"))
+            return False
+        # Todo: each of the elements of the selection could be tested,
+        # not only the first one.
+        if selection[0].isDerivedFrom("App::FeaturePython"):
+            _Wrn(_tr("Selection is not suitable for array"))
+            _Wrn(_tr("Object:") + " {}".format(selection[0].Label))
+            return False
+        return True
+
+    def create_object(self, selection):
+        """Create the actual object"""
+        self.angle_str = self.form.spinbox_angle.text()
+        self.angle = _Quantity(self.angle_str).Value
+
+        self.center = self.set_point()
+
+        if len(selection) == 1:
+            sel_obj = selection[0]
+        else:
+            # This can be changed so a compound of multiple
+            # selected objects is produced
+            sel_obj = selection[0]
+
+        self.fuse = self.form.checkbox_fuse.isChecked()
+        self.use_link = self.form.checkbox_link.isChecked()
+
+        # This creates the object immediately
+        # obj = Draft.makeArray(sel_obj,
+        #                       self.center, self.angle, self.number)
+        # if obj:
+        #     obj.Fuse = self.fuse
+
+        # Instead, we build the commands to execute through the parent
+        # of this class, the GuiCommand.
+        # This is needed to schedule geometry manipulation
+        # that would crash Coin3D if done in the event callback.
+        _cmd = "obj = Draft.makeArray("
+        _cmd += "FreeCAD.ActiveDocument." + sel_obj.Name + ", "
+        _cmd += "arg1=" + DraftVecUtils.toString(self.center) + ", "
+        _cmd += "arg2=" + str(self.angle) + ", "
+        _cmd += "arg3=" + str(self.number) + ", "
+        _cmd += "useLink=" + str(self.use_link) + ")"
+
+        _cmd_list = ["FreeCADGui.addModule('Draft')",
+                     _cmd,
+                     "obj.Fuse = " + str(self.fuse),
+                     "Draft.autogroup(obj)",
+                     "FreeCAD.ActiveDocument.recompute()"]
+        self.source_command.commit("Polar array", _cmd_list)
+
+    def set_point(self):
+        """Assign the values to the center"""
+        self.c_x_str = self.form.input_c_x.text()
+        self.c_y_str = self.form.input_c_y.text()
+        self.c_z_str = self.form.input_c_z.text()
+        center = App.Vector(_Quantity(self.c_x_str).Value,
+                            _Quantity(self.c_y_str).Value,
+                            _Quantity(self.c_z_str).Value)
+        return center
+
+    def reset_point(self):
+        """Reset the point to the original distance"""
+        self.form.input_c_x.setProperty('rawValue', 0)
+        self.form.input_c_y.setProperty('rawValue', 0)
+        self.form.input_c_z.setProperty('rawValue', 0)
+
+        self.center = self.set_point()
+        _Msg(_tr("Center reset:")
+             + " ({0}, {1}, {2})".format(self.center.x,
+                                         self.center.y,
+                                         self.center.z))
+
+    def print_fuse_state(self):
+        """Print the state translated"""
+        if self.fuse:
+            translated_state = QT_TRANSLATE_NOOP("Draft", "True")
+        else:
+            translated_state = QT_TRANSLATE_NOOP("Draft", "False")
+        _Msg(_tr("Fuse:") + " {}".format(translated_state))
+
+    def set_fuse(self):
+        """This function is called when the fuse checkbox changes"""
+        self.fuse = self.form.checkbox_fuse.isChecked()
+        self.print_fuse_state()
+
+    def print_link_state(self):
+        """Print the state translated"""
+        if self.use_link:
+            translated_state = QT_TRANSLATE_NOOP("Draft", "True")
+        else:
+            translated_state = QT_TRANSLATE_NOOP("Draft", "False")
+        _Msg(_tr("Use Link object:") + " {}".format(translated_state))
+
+    def set_link(self):
+        """This function is called when the fuse checkbox changes"""
+        self.use_link = self.form.checkbox_link.isChecked()
+        self.print_link_state()
+
+    def print_messages(self, selection):
+        """Print messages about the operation"""
+        if len(selection) == 1:
+            sel_obj = selection[0]
+        else:
+            # This can be changed so a compound of multiple
+            # selected objects is produced
+            sel_obj = selection[0]
+        _Msg("{}".format(16*"-"))
+        _Msg("{}".format(self.name))
+        _Msg(_tr("Object:") + " {}".format(sel_obj.Label))
+        _Msg(_tr("Start angle:") + " {}".format(self.angle_str))
+        _Msg(_tr("Number of elements:") + " {}".format(self.number))
+        _Msg(_tr("Center of rotation:")
+             + " ({0}, {1}, {2})".format(self.center.x,
+                                         self.center.y,
+                                         self.center.z))
+        self.print_fuse_state()
+        self.print_link_state()
+
+    def display_point(self, point=None, plane=None, mask=None):
+        """Displays the coordinates in the x, y, and z widgets.
+
+        This function should be used in a Coin callback so that
+        the coordinate values are automatically updated when the
+        mouse pointer moves.
+        This was copied from `DraftGui.py` but needs to be improved
+        for this particular command.
+
+        point :
+            is a vector that arrives by the callback.
+        plane :
+            is a `WorkingPlane` instance, for example,
+            `App.DraftWorkingPlane`. It is not used at the moment,
+            but could be used to set up the grid.
+        mask :
+            is a string that specifies which coordinate is being
+            edited. It is used to restrict edition of a single coordinate.
+            It is not used at the moment but could be used with a callback.
+        """
+        # Get the coordinates to display
+        dp = None
+        if point:
+            dp = point
+
+        # Set the widgets to the value of the mouse pointer.
+        #
+        # setProperty() is used if the widget is a FreeCAD widget like
+        # Gui::InputField or Gui::QuantitySpinBox, which are based on
+        # QLineEdit and QAbstractSpinBox.
+        #
+        # setText() is used to set the text inside the widget, this may be
+        # useful in some circumstances.
+        #
+        # The mask allows editing only one field, that is, only one coordinate.
+        # sbx = self.form.spinbox_c_x
+        # sby = self.form.spinbox_c_y
+        # sbz = self.form.spinbox_c_z
+        if dp:
+            if self.mask in ('y', 'z'):
+                # sbx.setText(displayExternal(dp.x, None, 'Length'))
+                self.form.input_c_x.setProperty('rawValue', dp.x)
+            else:
+                # sbx.setText(displayExternal(dp.x, None, 'Length'))
+                self.form.input_c_x.setProperty('rawValue', dp.x)
+            if self.mask in ('x', 'z'):
+                # sby.setText(displayExternal(dp.y, None, 'Length'))
+                self.form.input_c_y.setProperty('rawValue', dp.y)
+            else:
+                # sby.setText(displayExternal(dp.y, None, 'Length'))
+                self.form.input_c_y.setProperty('rawValue', dp.y)
+            if self.mask in ('x', 'y'):
+                # sbz.setText(displayExternal(dp.z, None, 'Length'))
+                self.form.input_c_z.setProperty('rawValue', dp.z)
+            else:
+                # sbz.setText(displayExternal(dp.z, None, 'Length'))
+                self.form.input_c_z.setProperty('rawValue', dp.z)
+
+        # Set masks
+        if (mask == "x") or (self.mask == "x"):
+            self.form.input_c_x.setEnabled(True)
+            self.form.input_c_y.setEnabled(False)
+            self.form.input_c_z.setEnabled(False)
+            self.set_focus("x")
+        elif (mask == "y") or (self.mask == "y"):
+            self.form.input_c_x.setEnabled(False)
+            self.form.input_c_y.setEnabled(True)
+            self.form.input_c_z.setEnabled(False)
+            self.set_focus("y")
+        elif (mask == "z") or (self.mask == "z"):
+            self.form.input_c_x.setEnabled(False)
+            self.form.input_c_y.setEnabled(False)
+            self.form.input_c_z.setEnabled(True)
+            self.set_focus("z")
+        else:
+            self.form.input_c_x.setEnabled(True)
+            self.form.input_c_y.setEnabled(True)
+            self.form.input_c_z.setEnabled(True)
+            self.set_focus()
+
+    def set_focus(self, key=None):
+        """Set the focus on the widget that receives the key signal"""
+        if key is None or key == "x":
+            self.form.input_c_x.setFocus()
+            self.form.input_c_x.selectAll()
+        elif key == "y":
+            self.form.input_c_y.setFocus()
+            self.form.input_c_y.selectAll()
+        elif key == "z":
+            self.form.input_c_z.setFocus()
+            self.form.input_c_z.selectAll()
+
+    def reject(self):
+        """Function that executes when clicking the Cancel button"""
+        _Msg(_tr("Aborted:") + " {}".format(self.name))
+        self.finish()
+
+    def finish(self):
+        """Function that runs at the end after OK or Cancel"""
+        # App.ActiveDocument.commitTransaction()
+        Gui.ActiveDocument.resetEdit()
+        # Runs the parent command to complete the call
+        self.source_command.completed()

--- a/src/Mod/Draft/draftviewproviders/view_polararray.py
+++ b/src/Mod/Draft/draftviewproviders/view_polararray.py
@@ -1,0 +1,44 @@
+"""This module provides the view provider code for Draft PolarArray.
+"""
+## @package polararray
+# \ingroup DRAFT
+# \brief This module provides the view provider code for Draft PolarArray.
+
+# ***************************************************************************
+# *   (c) 2019 Eliud Cabrera Castillo <e.cabrera-castillo@tum.de>           *
+# *                                                                         *
+# *   This file is part of the FreeCAD CAx development system.              *
+# *                                                                         *
+# *   This program is free software; you can redistribute it and/or modify  *
+# *   it under the terms of the GNU Lesser General Public License (LGPL)    *
+# *   as published by the Free Software Foundation; either version 2 of     *
+# *   the License, or (at your option) any later version.                   *
+# *   for detail see the LICENCE text file.                                 *
+# *                                                                         *
+# *   FreeCAD is distributed in the hope that it will be useful,            *
+# *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+# *   GNU Library General Public License for more details.                  *
+# *                                                                         *
+# *   You should have received a copy of the GNU Library General Public     *
+# *   License along with FreeCAD; if not, write to the Free Software        *
+# *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
+# *   USA                                                                   *
+# *                                                                         *
+# ***************************************************************************
+
+import Draft
+import Draft_rc
+ViewProviderDraftArray = Draft._ViewProviderDraftArray
+
+# So the resource file doesn't trigger errors from code checkers (flake8)
+True if Draft_rc.__name__ else False
+
+
+class ViewProviderPolarArray(ViewProviderDraftArray):
+
+    def __init__(self, vobj):
+        super().__init__(self, vobj)
+
+    def getIcon(self):
+        return ":/icons/Draft_PolarArray"


### PR DESCRIPTION
The [Draft_Array](https://www.freecadweb.org/wiki/Draft_Array) command has three modes, rectangular, polar and circular. However, currently they are launched from a single button. Further modification needs to be done in the property editor. This works but it isn't very user friendly. Therefore, this pull request introduces a new button to create the [Draft_PolarArray](https://www.freecadweb.org/wiki/Draft_PolarArray) directly. Further changes can still be done in the property editor.

This pull request uses the new Gui Command structure described in #2823, and thus this request should be merged after that request. Visit that link for more information.

See also [Making the creation of arrays more user friendly](https://forum.freecadweb.org/viewtopic.php?f=23&t=41816), for further discussion on improving the [Draft_Array](https://www.freecadweb.org/wiki/Draft_Array) tools.

---

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists
