### PR TITLE
Draft: new module for the translate function

### DIFF
--- a/src/Mod/Draft/CMakeLists.txt
+++ b/src/Mod/Draft/CMakeLists.txt
@@ -52,6 +52,7 @@ SET(Draft_utilities
     draftutils/utils.py
     draftutils/gui_utils.py
     draftutils/todo.py
+    draftutils/translate.py
 )
 
 SET(Draft_objects

--- a/src/Mod/Draft/Draft.py
+++ b/src/Mod/Draft/Draft.py
@@ -46,22 +46,23 @@ __url__ = "https://www.freecadweb.org"
 """The Draft module offers a range of tools to create and manipulate basic 2D objects"""
 
 import FreeCAD, math, sys, os, DraftVecUtils, WorkingPlane
+import draftutils.translate
 from FreeCAD import Vector
+from PySide.QtCore import QT_TRANSLATE_NOOP
+
 
 if FreeCAD.GuiUp:
     import FreeCADGui, Draft_rc
     from PySide import QtCore
-    from PySide.QtCore import QT_TRANSLATE_NOOP
     gui = True
     #from DraftGui import translate
 else:
-    def QT_TRANSLATE_NOOP(ctxt,txt):
-        return txt
+    # def QT_TRANSLATE_NOOP(ctxt,txt):
+    #     return txt
     #print("FreeCAD Gui not present. Draft module will have some features disabled.")
     gui = False
 
-def translate(ctx,txt):
-    return txt
+translate = draftutils.translate.translate
 
 #---------------------------------------------------------------------------
 # Backwards compatibility

--- a/src/Mod/Draft/DraftGui.py
+++ b/src/Mod/Draft/DraftGui.py
@@ -49,48 +49,9 @@ import DraftVecUtils
 from PySide import QtCore, QtGui, QtSvg
 
 
-try:
-    _encoding = QtGui.QApplication.UnicodeUTF8 if six.PY2 else None
-    def translate(context, text, utf8_decode=True):
-        """convenience function for Qt translator
-            context: str
-                context is typically a class name (e.g., "MyDialog")
-            text: str
-                text which gets translated
-            utf8_decode: bool [False]
-                if set to true utf8 encoded unicode will be returned. This option does not have influence
-                on python3 as for python3 we are returning utf-8 encoded unicode by default!
-        """
-        if six.PY3:
-            return QtGui.QApplication.translate(context, text, None)
-        elif utf8_decode:
-            return QtGui.QApplication.translate(context, text, None, _encoding)
-        else:
-            return QtGui.QApplication.translate(context, text, None, _encoding).encode("utf8")
+import draftutils.translate
+translate = draftutils.translate.translate
 
-except AttributeError:
-    def translate(context, text, utf8_decode=False):
-        """convenience function for Qt translator
-            context: str
-                context is typically a class name (e.g., "MyDialog")
-            text: str
-                text which gets translated
-            utf8_decode: bool [False]
-                if set to true utf8 encoded unicode will be returned. This option does not have influence
-                on python3 as for python3 we are returning utf-8 encoded unicode by default!
-        """
-        if six.PY3:
-            return QtGui.QApplication.translate(context, text, None)
-        elif QtCore.qVersion() > "4":
-            if utf8_decode:
-                return QtGui.QApplication.translate(context, text, None)
-            else:
-                return QtGui.QApplication.translate(context, text, None).encode("utf8")
-        else:
-            if utf8_decode:
-                return QtGui.QApplication.translate(context, text, None, _encoding)
-            else:
-                return QtGui.QApplication.translate(context, text, None, _encoding).encode("utf8")
 
 import draftutils.utils
 utf8_decode = draftutils.utils.utf8_decode

--- a/src/Mod/Draft/draftutils/translate.py
+++ b/src/Mod/Draft/draftutils/translate.py
@@ -1,0 +1,200 @@
+"""This module provides translate functions for the Draft Workbench.
+
+This module contains auxiliary functions to translate strings
+using the QtGui module.
+"""
+## @package translate
+# \ingroup DRAFT
+# \brief This module provides translate functions for the Draft Workbench
+
+# ***************************************************************************
+# *   (c) 2009 Yorik van Havre <yorik@uncreated.net>                        *
+# *   (c) 2019 Eliud Cabrera Castillo <e.cabrera-castillo@tum.de>           *
+# *                                                                         *
+# *   This file is part of the FreeCAD CAx development system.              *
+# *                                                                         *
+# *   This program is free software; you can redistribute it and/or modify  *
+# *   it under the terms of the GNU Lesser General Public License (LGPL)    *
+# *   as published by the Free Software Foundation; either version 2 of     *
+# *   the License, or (at your option) any later version.                   *
+# *   for detail see the LICENCE text file.                                 *
+# *                                                                         *
+# *   FreeCAD is distributed in the hope that it will be useful,            *
+# *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+# *   GNU Library General Public License for more details.                  *
+# *                                                                         *
+# *   You should have received a copy of the GNU Library General Public     *
+# *   License along with FreeCAD; if not, write to the Free Software        *
+# *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
+# *   USA                                                                   *
+# *                                                                         *
+# ***************************************************************************
+from PySide import QtCore
+from PySide import QtGui
+import six
+
+Qtranslate = QtGui.QApplication.translate
+
+# This property only exists in Qt4, which is normally paired
+# with Python 2.
+# But if Python 2 is used with Qt5 (rare),
+# this assignment will fail.
+try:
+    _encoding = QtGui.QApplication.UnicodeUTF8
+except AttributeError:
+    _encoding = None
+
+
+def translate(context, text, utf8_decode=False):
+    """Convenience function for the Qt translate function.
+
+    It wraps around `QtGui.QApplication.translate`,
+    which is the same as `QtCore.QCoreApplication.translate`.
+
+    Parameters
+    ----------
+    context : str
+        In C++ it is typically a class name.
+        But it can also be any other string to categorize the translation,
+        for example, the name of a workbench, tool, or function
+        that is being translated. Usually it will be the name
+        of the workbench.
+
+    text : str
+        Text that will be translated. It could be a single word,
+        a full sentence, paragraph, or multiple paragraphs with new lines.
+        Usually the last endline character '\\\\n'
+        that finishes the string doesn't need to be included
+        for translation.
+
+    utf8_decode : bool
+        It defaults to `False`.
+        This must be set to `True` to indicate that the `text`
+        is an `'utf8'` encoded string, so it should be returned as such.
+        This option is ignored when using Python 3
+        as with Python 3 all strings are `'utf8'` by default.
+
+    Returns
+    -------
+    str
+        A unicode string returned by `QtGui.QApplication.translate`.
+
+        If `utf8_decode` is `True`, the resulting string will be encoded
+        in `'utf8'`, and a `bytes` object will be returned.
+        ::
+            Qtranslate = QtGui.QApplication.translate
+            return Qtranslate(context, text, None).encode("utf8")
+
+    Unicode strings
+    ---------------
+    Whether it is Qt4 or Qt5, the `translate` function
+    always returns a unicode string.
+    The difference is how it handles the input.
+
+    Reference: https://pyside.github.io/docs/pyside/PySide/QtCore/
+
+    In Qt4 the translate function has a 4th parameter to define the encoding
+    of the input string.
+
+    >>> QtCore.QCoreApplication.translate(context, text, None, UnicodeUT8)
+    >>> QtGui.QApplication.translate(context, text, None, UnicodeUT8)
+
+    Reference: https://doc.qt.io/qtforpython/PySide2/QtCore
+
+    In Qt5 the strings are always assumed unicode, so the 4th parameter
+    is for a different use, and it is not used.
+
+    >>> QtCore.QCoreApplication.translate(context, text, None)
+    >>> QtGui.QApplication.translate(context, text, None)
+    """
+    # Python 3 and Qt5
+    # The text is a utf8 string, and since it is Qt5
+    # the translate function doesn't use the 4th parameter
+    if six.PY3:
+        return Qtranslate(context, text, None)
+    # Python 2
+    elif QtCore.qVersion() > "4":
+        # Python 2 and Qt5
+        if utf8_decode:
+            # The text is a utf8 string, and since it is Qt5
+            # the translate function doesn't use the 4th parameter
+            return Qtranslate(context, text, None)
+        else:
+            # The text is not a unicode string, and since it is Qt5
+            # the translate function doesn't use the 4th parameter.
+            # Therefore the output string needs to be encoded manually
+            # as utf8 bytes before returning.
+            return Qtranslate(context, text, None).encode("utf8")
+    else:
+        # Python 2 and Qt4
+        if utf8_decode:
+            # The text is a utf8 string, and since it is Qt4
+            # the translate function uses the 4th parameter
+            # to handle the input encoding.
+            return Qtranslate(context, text, None, _encoding)
+        else:
+            # The text is not a unicode string, and since it is Qt4
+            # the translate function uses the 4th parameter
+            # to handle the encoding.
+            # In this case, the `encoding` is `None`, therefore
+            # the output string needs to be encoded manually
+            # as utf8 bytes before returning.
+            return Qtranslate(context, text, None, _encoding).encode("utf8")
+
+
+# Original code no longer used. It is listed here for reference
+# to show how the different pairings Py2/Qt4, Py3/Qt5, Py2/Qt5, Py3/Qt4
+# were handled in the past.
+# If there is a problem with the code above, this code can be made active
+# again, and the code above can be commented out.
+#
+# =============================================================================
+# try:
+#     _encoding = QtGui.QApplication.UnicodeUTF8 if six.PY2 else None
+#     def translate(context, text, utf8_decode=True):
+#         """convenience function for Qt translator
+#             context: str
+#                 context is typically a class name (e.g., "MyDialog")
+#             text: str
+#                 text which gets translated
+#             utf8_decode: bool [False]
+#                 if set to true utf8 encoded unicode will be returned.
+#                 This option does not have influence
+#                 on python3 as for python3 we are returning utf-8 encoded
+#                 unicode by default!
+#         """
+#         if six.PY3:
+#             return Qtranslate(context, text, None)
+#         elif utf8_decode:
+#             return Qtranslate(context, text, None, _encoding)
+#         else:
+#             return Qtranslate(context, text, None, _encoding).encode("utf8")
+#
+# except AttributeError:
+#     def translate(context, text, utf8_decode=False):
+#         """convenience function for Qt translator
+#             context: str
+#                 context is typically a class name (e.g., "MyDialog")
+#             text: str
+#                 text which gets translated
+#             utf8_decode: bool [False]
+#                 if set to true utf8 encoded unicode will be returned.
+#                 This option does not have influence
+#                 on python3 as for python3 we are returning utf-8 encoded
+#                 unicode by default!
+#         """
+#         if six.PY3:
+#             return Qtranslate(context, text, None)
+#         elif QtCore.qVersion() > "4":
+#             if utf8_decode:
+#                 return Qtranslate(context, text, None)
+#             else:
+#                 return Qtranslate(context, text, None).encode("utf8")
+#         else:
+#             if utf8_decode:
+#                 return Qtranslate(context, text, None, _encoding)
+#             else:
+#                 return Qtranslate(context, text, None,
+#                                   _encoding).encode("utf8")
+# =============================================================================


### PR DESCRIPTION
Many auxiliary tools used by `DraftGui.py` can be defined in another module so that this file is not very big, and so that these tools can be used without importing the entire `DraftGui` module. In specific, the `translate` function which wraps around the corresponding `QtCore` function is moved to a separate module.

There are some changes in the implementation of the `translate` function. These changes are discussed at length in [Translation of strings](https://forum.freecadweb.org/viewtopic.php?f=23&t=40975). The changes are due to the way strings are treated in Python 2 and Python 3 when used with Qt4 or Qt5. In Python 3 and Qt5 all strings are `unicode` by default so there is less string manipulation required. Manipulating the strings is mostly necessary in Python 2 and Qt4, as the strings are normally encoded as `bytes` except when they are explicitly entered as `unicode` objects.

Since Python 2 and Qt4 are obsolete, supporting these two frameworks is not very well tested. Nevertheless, the older code is still included inside the file in case reverting the implementation of the `translate` function is necessary to maintain backwards compatibility.

This pull request continues with the re-organization proposed in #2823. See that link for more information.

Since this pull request adds a new module and has a modified `CMakeLists.txt` file, this pull request should be merged after #2829, #2830, and #2831.

---

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists