### PR TITLE
Draft: fix CMakeLists to install files in new directories

### DIFF
--- a/src/Mod/Draft/CMakeLists.txt
+++ b/src/Mod/Draft/CMakeLists.txt
@@ -4,6 +4,33 @@ IF (BUILD_GUI)
     PYSIDE_WRAP_RC(Draft_QRC_SRCS Resources/Draft.qrc)
 ENDIF (BUILD_GUI)
 
+SET(Draft_SRCS_base
+    Init.py
+    InitGui.py
+    Draft.py
+    DraftTools.py
+    DraftGui.py
+    DraftSnap.py
+    DraftTrackers.py
+    DraftVecUtils.py
+    DraftGeomUtils.py
+    DraftLayer.py
+    DraftEdit.py
+    DraftFillet.py
+    DraftSelectPlane.py
+    WorkingPlane.py
+    getSVG.py
+    TestDraft.py
+)
+
+SET(Draft_import
+    importAirfoilDAT.py
+    importDXF.py
+    importDWG.py
+    importOCA.py
+    importSVG.py
+)
+
 SET(Draft_tests
     drafttests/__init__.py
     drafttests/auxiliary.py
@@ -37,62 +64,56 @@ SET(Draft_task_panels
     drafttaskpanels/__init__.py
 )
 
-SET(Draft_SRCS
+SET(Draft_SRCS_all
+    ${Draft_SRCS_base}
+    ${Draft_import}
     ${Draft_tests}
     ${Draft_objects}
     ${Draft_view_providers}
     ${Draft_GUI_tools}
     ${Draft_task_panels}
-    Init.py
-    InitGui.py
-    Draft.py
-    DraftTools.py
-    DraftGui.py
-    DraftSnap.py
-    DraftTrackers.py
-    DraftVecUtils.py
-    DraftGeomUtils.py
-    DraftLayer.py
-    DraftEdit.py
-    DraftFillet.py
-    DraftSelectPlane.py
-    WorkingPlane.py
-    getSVG.py
-    importDXF.py
-    importOCA.py
-    importSVG.py
-    importDWG.py
-    importAirfoilDAT.py
-    TestDraft.py
 )
-SOURCE_GROUP("" FILES ${Draft_SRCS})
+
+# Cmake documentation: source_group defines a group into which sources
+# will be placed in project files. This is intended to set up file tabs
+# in Visual Studio.
+#
+# Maybe we don't need this anymore? For example, FEM doesn't use it.
+SOURCE_GROUP("" FILES ${Draft_SRCS_all})
 
 SET(DraftGuiIcon_SVG
     Resources/icons/DraftWorkbench.svg
 )
 
 ADD_CUSTOM_TARGET(Draft ALL
-    SOURCES ${Draft_SRCS} ${Draft_QRC_SRCS} ${DraftGuiIcon_SVG}
+    SOURCES ${Draft_SRCS_all} ${Draft_QRC_SRCS} ${DraftGuiIcon_SVG}
 )
 
-fc_copy_sources(Draft "${CMAKE_BINARY_DIR}/Mod/Draft" ${Draft_SRCS})
+fc_copy_sources(Draft "${CMAKE_BINARY_DIR}/Mod/Draft" ${Draft_SRCS_all})
 
 fc_copy_sources(Draft "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_DATADIR}/Mod/Draft" ${DraftGuiIcon_SVG})
 
 IF (BUILD_GUI)
     fc_target_copy_resource(Draft
-        ${CMAKE_CURRENT_BINARY_DIR}
-        ${CMAKE_BINARY_DIR}/Mod/Draft
+        "${CMAKE_CURRENT_BINARY_DIR}"
+        "${CMAKE_BINARY_DIR}/Mod/Draft"
         Draft_rc.py)
 ENDIF (BUILD_GUI)
 
 INSTALL(
     FILES
-        ${Draft_SRCS}
+        ${Draft_SRCS_base}
+        ${Draft_import}
         ${Draft_QRC_SRCS}
     DESTINATION
         Mod/Draft
 )
+
+INSTALL(FILES ${Draft_tests} DESTINATION Mod/Draft/drafttests)
+INSTALL(FILES ${Draft_objects} DESTINATION Mod/Draft/draftobjects)
+INSTALL(FILES ${Draft_view_providers} DESTINATION Mod/Draft/draftviewproviders)
+INSTALL(FILES ${Draft_GUI_tools} DESTINATION Mod/Draft/draftguitools)
+INSTALL(FILES ${Draft_task_panels} DESTINATION Mod/Draft/drafttaskpanels)
 
 INSTALL(
     FILES
@@ -100,4 +121,3 @@ INSTALL(
     DESTINATION
        "${CMAKE_INSTALL_DATADIR}/Mod/Draft/Resources/icons"
 )
-


### PR DESCRIPTION
Pull request #2829 uncovered a problem with the way new files are installed in directories. This resulted in the Travis tests failing because certain tools in Draft weren't being found.

This commit adds specific `INSTALL` instructions in the `CMakeLists.txt` file so that files are installed in the right directories.

See #2829, and the forum thread referenced there for more information. This also affects #2830, #2831, and #2832.

This pull request needs to be merged before those, and also before #2824 and #2825.

---

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists
