### PR TITLE
Mesh: fix utf8 encoding

### DIFF
--- a/src/Mod/Mesh/App/MeshTestsApp.py
+++ b/src/Mod/Mesh/App/MeshTestsApp.py
@@ -1,3 +1,4 @@
+# -*- coding: utf8 -*-
 #  Copyright (c) 2007 Jürgen Riegel <juergen.riegel@web.de>
 #  LGPL
 


### PR DESCRIPTION
When Travis compiles the code, it also compiles against Python 2. With Python 2 the strings inside the Python source files are considered ASCII unless a specific codification is indicated.

With a recent commit d923798, and c766d75, many source files were edited to have non-ASCII characters like u-umlaut. This causes a problem with the self-tests with Python 2 as these files didn't indicate the string codification.

This commit adds such indication. It has to be added to every file that has such umlaut characters or accents. This is only needed if the files are used with Python 2. With Python 3 this is not necessary.

See the following Travis check https://travis-ci.org/FreeCAD/FreeCAD/jobs/630244533#L8450-L8462
```sh
Traceback (most recent call last):
  File "<string>", line 41, in <module>
  File "/usr/local/Mod/Test/TestApp.py", line 69, in TestText
    s = unittest.defaultTestLoader.loadTestsFromName(s)
  File "/usr/lib/python2.7/unittest/loader.py", line 115, in loadTestsFromName
    test = obj()
  File "/usr/local/Mod/Test/TestApp.py", line 63, in All
    suite.addTest(tryLoadingTest(test))
  File "/usr/local/Mod/Test/TestApp.py", line 38, in tryLoadingTest
    return unittest.defaultTestLoader.loadTestsFromName(testName)
  File "/usr/lib/python2.7/unittest/loader.py", line 91, in loadTestsFromName
    module = __import__('.'.join(parts_copy))
<type 'exceptions.SyntaxError'>: Non-ASCII character '\xc3' in file /usr/local/Mod/Mesh/MeshTestsApp.py on line 1, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details (MeshTestsApp.py, line 1)
```

---

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists