### PR TITLE
QuantitySpinBox: add function to set/change tooltip at runtime

### DIFF
--- a/src/Gui/QuantitySpinBox.cpp
+++ b/src/Gui/QuantitySpinBox.cpp
@@ -290,6 +290,16 @@ void Gui::QuantitySpinBox::setExpression(boost::shared_ptr<Expression> expr)
     }
 }
 
+void Gui::QuantitySpinBox::setTooltipLE(const QString &name)
+{
+    lineEdit()->setToolTip(name);
+}
+
+void Gui::QuantitySpinBox::setTooltipIL(const QString &name)
+{
+    iconLabel->setToolTip(name);
+}
+
 QString QuantitySpinBox::boundToName() const
 {
     if (isBound()) {

--- a/src/Gui/QuantitySpinBox.h
+++ b/src/Gui/QuantitySpinBox.h
@@ -129,6 +129,10 @@ public:
     bool event(QEvent *event);
 
     void setExpression(boost::shared_ptr<App::Expression> expr);
+    /// Sets a tooltip for the LineEdit
+    void setTooltipLE(const QString &name);
+    /// Sets a tooltip for the IconLabel
+    void setTooltipIL(const QString &name);
     void bind(const App::ObjectIdentifier &_path);
     bool apply(const std::string &propName);
 


### PR DESCRIPTION
I noticed that it is not yet possible to change the tooltip of a QuantitySpinBox at runtime.  Since all other QObjects allow this, QuantitySpinBox should allow this too.

I added 2 functions but maybe only one is sufficient.