### PR TITLE
Attachment dialog improvements

### DIFF
--- a/src/Mod/Part/AttachmentEditor/TaskAttachmentEditor.ui
+++ b/src/Mod/Part/AttachmentEditor/TaskAttachmentEditor.ui
@@ -270,6 +270,12 @@
           <verstretch>0</verstretch>
          </sizepolicy>
         </property>
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>5</height>
+         </size>
+        </property>
         <property name="toolTip">
          <string>Rotation around the x-axis
 Note: The placement is expressed in local space of object being attached.</string>
@@ -296,6 +302,12 @@ Note: The placement is expressed in local space of object being attached.</strin
           <verstretch>0</verstretch>
          </sizepolicy>
         </property>
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>5</height>
+         </size>
+        </property>
         <property name="toolTip">
          <string>Rotation around the y-axis
 Note: The placement is expressed in local space of object being attached.</string>
@@ -321,6 +333,12 @@ Note: The placement is expressed in local space of object being attached.</strin
           <horstretch>0</horstretch>
           <verstretch>0</verstretch>
          </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>5</height>
+         </size>
         </property>
         <property name="toolTip">
          <string>Rotation around the z-axis

--- a/src/Mod/Part/Gui/TaskAttacher.cpp
+++ b/src/Mod/Part/Gui/TaskAttacher.cpp
@@ -215,6 +215,12 @@ TaskAttacher::TaskAttacher(Gui::ViewProviderDocumentObject *ViewProvider,QWidget
     Gui::Document* document = Gui::Application::Instance->getDocument(ViewProvider->getObject()->getDocument());
     connectDelObject = document->signalDeletedObject.connect(bnd1);
     connectDelDocument = document->signalDeleteDocument.connect(bnd2);
+
+    // set tooltips because the ones in the .ui file are not taken for QuantitySpinBoxes (see bug https://freecadweb.org/tracker/view.php?id=4059)
+    // FIXME: remove this once the bug is fixed
+    ui->attachmentOffsetRoll->setTooltipLE(QString::fromUtf8("Rotation around the x-axis\nNote: The placement is expressed in local coordinate system\nof object being attached."));
+    ui->attachmentOffsetPitch->setTooltipLE(QString::fromUtf8("Rotation around the y-axis\nNote: The placement is expressed in local coordinate system\nof object being attached."));
+    ui->attachmentOffsetYaw->setTooltipLE(QString::fromUtf8("Rotation around the z-axis\nNote: The placement is expressed in local coordinate system\nof object being attached."));
 }
 
 TaskAttacher::~TaskAttacher()


### PR DESCRIPTION
- explicitly set the tooltips since the one in the .ui file were not taken for QuantitySpinBoxes (workaround for bug https://freecadweb.org/tracker/view.php?id=4059)
- uniform the height of all LineEdits in the TaskAttachmentEditor.ui (the 3 angles were higher than the 3 movements)