### PR TITLE
Fem: variable name 'children', not 'childs'

### DIFF
--- a/src/Mod/Fem/femguiobjects/_ViewProviderFemMeshGmsh.py
+++ b/src/Mod/Fem/femguiobjects/_ViewProviderFemMeshGmsh.py
@@ -176,10 +176,10 @@ class _ViewProviderFemMeshGmsh:
         return (reg_childs + gro_childs + bou_childs)
 
     def onDelete(self, feature, subelements):
-        childs = self.claimChildren()
-        if len(childs) > 0:
+        children = self.claimChildren()
+        if len(children) > 0:
             try:
-                for obj in childs:
+                for obj in children:
                     obj.ViewObject.show()
             except Exception as err:
                 FreeCAD.Console.PrintError("Error in onDelete: {0} \n".format(err))

--- a/src/Mod/Fem/femguiobjects/_ViewProviderFemResultMechanical.py
+++ b/src/Mod/Fem/femguiobjects/_ViewProviderFemResultMechanical.py
@@ -108,10 +108,10 @@ class _ViewProviderFemResultMechanical:
         return [self.Object.Mesh]  # claimChildren needs to return a list !
 
     def onDelete(self, feature, subelements):
-        childs = self.claimChildren()
-        if len(childs) > 0:
+        children = self.claimChildren()
+        if len(children) > 0:
             try:
-                for obj in childs:
+                for obj in children:
                     obj.ViewObject.show()
             except Exception as err:
                 FreeCAD.Console.PrintError("Error in onDelete: {0} \n".format(err))


### PR DESCRIPTION
Children is the plural of child, just like Kinder is the plural of Kind.

---

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists