### PR TITLE
Add Proxy to Addon Manager with UI

### DIFF
--- a/src/Mod/AddonManager/AddonManager.py
+++ b/src/Mod/AddonManager/AddonManager.py
@@ -589,6 +589,10 @@ class CommandAddonManager:
         pref = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Addons")
         self.config.checkUpdates.setChecked(pref.GetBool("AutoCheck",False))
         self.config.customRepositories.setPlainText(pref.GetString("CustomRepositories",""))
+        self.config.radioButtonNoProxy.setChecked(pref.GetBool("NoProxyCheck",True))
+        self.config.radioButtonSystemProxy.setChecked(pref.GetBool("SystemProxyCheck",False))
+        self.config.radioButtonUserProxy.setChecked(pref.GetBool("UserProxyCheck",False))
+        self.config.userProxy.setPlainText(pref.GetString("ProxyUrl",""))
 
         # center the dialog over the Addon Manager
         self.config.move(self.dialog.frameGeometry().topLeft() + self.dialog.rect().center() - self.config.rect().center())
@@ -599,6 +603,10 @@ class CommandAddonManager:
             # OK button has been pressed
             pref.SetBool("AutoCheck",self.config.checkUpdates.isChecked())
             pref.SetString("CustomRepositories",self.config.customRepositories.toPlainText())
+            pref.SetBool("NoProxyCheck",self.config.radioButtonNoProxy.isChecked())
+            pref.SetBool("SystemProxyCheck",self.config.radioButtonSystemProxy.isChecked())
+            pref.SetBool("UserProxyCheck",self.config.radioButtonUserProxy.isChecked())
+            pref.SetString("ProxyUrl",self.config.userProxy.toPlainText())
 
 def check_updates(addon_name,callback):
 

--- a/src/Mod/AddonManager/AddonManagerOptions.ui
+++ b/src/Mod/AddonManager/AddonManagerOptions.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>390</width>
-    <height>183</height>
+    <height>247</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -23,6 +23,9 @@ installed addons will be checked for available updates
      </property>
      <property name="text">
       <string>Automatically check for updates at start (requires GitPython)</string>
+     </property>
+     <property name="autoExclusive">
+      <bool>false</bool>
      </property>
     </widget>
    </item>
@@ -40,6 +43,47 @@ installed addons will be checked for available updates
 sto be scanned for available addons</string>
      </property>
     </widget>
+   </item>
+   <item>
+    <widget class="Line" name="line">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="labelProxy">
+     <property name="text">
+      <string>Proxy </string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QRadioButton" name="radioButtonNoProxy">
+     <property name="text">
+      <string>No proxy</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QRadioButton" name="radioButtonSystemProxy">
+     <property name="text">
+      <string>User system proxy</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QRadioButton" name="radioButtonUserProxy">
+     <property name="text">
+      <string>User defined proxy :</string>
+     </property>
+     <property name="checked">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QTextEdit" name="userProxy"/>
    </item>
    <item>
     <widget class="QDialogButtonBox" name="buttonBox">
@@ -62,12 +106,12 @@ sto be scanned for available addons</string>
    <slot>accept()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>248</x>
-     <y>254</y>
+     <x>257</x>
+     <y>237</y>
     </hint>
     <hint type="destinationlabel">
      <x>157</x>
-     <y>274</y>
+     <y>246</y>
     </hint>
    </hints>
   </connection>
@@ -78,12 +122,12 @@ sto be scanned for available addons</string>
    <slot>reject()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>316</x>
-     <y>260</y>
+     <x>325</x>
+     <y>237</y>
     </hint>
     <hint type="destinationlabel">
      <x>286</x>
-     <y>274</y>
+     <y>246</y>
     </hint>
    </hints>
   </connection>

--- a/src/Mod/AddonManager/addonmanager_macro.py
+++ b/src/Mod/AddonManager/addonmanager_macro.py
@@ -103,6 +103,9 @@ class Macro(object):
         except:
             print("AddonManager: Debug: unable to open URL",url)
             return
+        if u is None :
+            print("AddonManager: Debug: connection is lost (proxy setting changed?)",url)
+            return
         p = u.read()
         if sys.version_info.major >= 3 and isinstance(p, bytes):
             p = p.decode('utf-8')

--- a/src/Mod/AddonManager/addonmanager_utilities.py
+++ b/src/Mod/AddonManager/addonmanager_utilities.py
@@ -40,12 +40,12 @@ except ImportError:
     pass
 else:
     try:
-        ssl_ctx = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
+        ssl_ctx = ssl.create_default_context(ssl.Purpose.SERVER_AUTH)
     except AttributeError:
         pass
+        
 
-
-
+        
 def translate(context, text, disambig=None):
     
     "Main translation function"
@@ -90,20 +90,37 @@ def urlopen(url):
     timeout = 5
 
     if sys.version_info.major < 3:
-        import urllib2
+        import urllib2     
     else:
         import urllib.request as urllib2
+        
+    # Proxy an ssl configuration
+    pref = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Addons")
+    if pref.GetBool("NoProxyCheck",True):
+        proxies = {}  
+    else:
+        if pref.GetBool("SystemProxyCheck",False):
+            proxy = urllib2.getproxies()  
+            proxies = {"http": proxy.get('http'),"https": proxy.get('http')}
+        elif pref.GetBool("UserProxyCheck",False):
+            proxy = pref.GetString("ProxyUrl","")   
+            proxies = {"http": proxy, "https": proxy}                         
 
+    if ssl_ctx:
+        handler = urllib2.HTTPSHandler(context=ssl_ctx)
+    else:
+        handler = {}
+    proxy_support = urllib2.ProxyHandler(proxies)    
+    opener = urllib2.build_opener(proxy_support, handler)
+    urllib2.install_opener(opener) 
+    
+    # Url opening
     try:
-        if ssl_ctx:
-            u = urllib2.urlopen(url, context=ssl_ctx, timeout=timeout)
-        else:
-            u = urllib2.urlopen(url, timeout=timeout)
+        u = urllib2.urlopen(url, timeout=timeout)
     except:
         return None
     else:
         return u
-
 
 def getserver(url):
 

--- a/src/Mod/AddonManager/addonmanager_utilities.py
+++ b/src/Mod/AddonManager/addonmanager_utilities.py
@@ -90,7 +90,7 @@ def urlopen(url):
     timeout = 5
 
     if sys.version_info.major < 3:
-        import urllib2     
+        import urllib2
     else:
         import urllib.request as urllib2
         


### PR DESCRIPTION
I re-coded the functionnality to use proxy for the Addon Manager.
Proxy is now managable in Addon Manager Options UI with 3 configuration :
- No proxy
- System proxy
- User proxy

This functionnality was develloped beforehand [Proxy settings #63](https://github.com/FreeCAD/FreeCAD-addons/pull/63) and was lost during a merge : 
[Regression : Add Proxy settings to AddonManager in master issue #157](https://github.com/FreeCAD/FreeCAD-addons/issues/157)
[AddonManager does not work behind corporate NTLM-proxy #57](https://github.com/FreeCAD/FreeCAD-addons/issues/57)

Current discussion here : [Proxy internet](https://forum.freecadweb.org/viewtopic.php?f=3&t=38246&start=10#p358970)
My own unresponded question in french : [Proxy internet FR](https://forum.freecadweb.org/viewtopic.php?f=12&t=38255)

---
Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:
- [X] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists