### PR TITLE
[Arch] fix true north handling on IFC import and export

### DIFF
--- a/src/Mod/Arch/exportIFC.py
+++ b/src/Mod/Arch/exportIFC.py
@@ -224,8 +224,8 @@ def export(exportList,filename,colors=None,preferences=None):
     objectslist = [obj for obj in objectslist if obj != contextCreator.project_object]
 
     if Draft.getObjectsOfType(objectslist, "Site"):  # we assume one site and one representation context only
-        trueNorthX = math.tan(-Draft.getObjectsOfType(objectslist, "Site")[0].Declination.getValueAs(FreeCAD.Units.Radian))
-        contextCreator.model_context.TrueNorth.DirectionRatios = (trueNorthX, 1.)
+        decl = Draft.getObjectsOfType(objectslist, "Site")[0].Declination.getValueAs(FreeCAD.Units.Radian)
+        contextCreator.model_context.TrueNorth.DirectionRatios = (math.cos(decl+math.pi/2), math.sin(decl+math.pi/2))
 
     products = {} # { Name: IfcEntity, ... }
     subproducts = {} # { Name: IfcEntity, ... } for storing additions/subtractions and other types of subcomponents of a product

--- a/src/Mod/Arch/importIFC.py
+++ b/src/Mod/Arch/importIFC.py
@@ -836,9 +836,10 @@ def insert(filename,docname,skip=[],only=[],root=None,preferences=None):
                         obj.PostalCode = product.SiteAddress.PostalCode
                 project = product.Decomposes[0].RelatingObject
                 modelRC = next((rc for rc in project.RepresentationContexts if rc.ContextType == "Model"), None)
-                if modelRC and modelRC.TrueNorth and modelRC.TrueNorth.DirectionRatios[1] > 0:
-                    obj.Declination = -math.degrees(math.atan(modelRC.TrueNorth.DirectionRatios[0] / modelRC.TrueNorth.DirectionRatios[1]))
-                    if(FreeCAD.GuiUp):
+                if modelRC and modelRC.TrueNorth:
+                    (x, y) = modelRC.TrueNorth.DirectionRatios[:2]
+                    obj.Declination = ((math.degrees(math.atan2(y,x))-90+180)%360)-180
+                    if (FreeCAD.GuiUp):
                         obj.ViewObject.CompassRotation.Value = obj.Declination
 
         try:


### PR DESCRIPTION
Handles true north for all possible values. 2504247d65271b937dd5f033a0ef fixed division by zero in import by excluding all cases with trueNorth y<0 . In export, 90 and -90 degrees declination resulted in erroneous true north values. All these cases work now.