### PR TITLE
Draft: test_offset, test wire and closed shape (rectangle)

### DIFF
--- a/src/Mod/Draft/drafttests/test_modification.py
+++ b/src/Mod/Draft/drafttests/test_modification.py
@@ -106,7 +106,26 @@ class DraftModification(unittest.TestCase):
         self.assertTrue(obj.Start.isEqual(c, 1e-12),
                         "'{}' failed".format(operation))
 
-    def test_offset(self):
+    def test_offset_open(self):
+        """Create a wire, then produce an offset copy."""
+        operation = "Draft Offset"
+        _msg("  Test '{}'".format(operation))
+        a = Vector(0, 2, 0)
+        b = Vector(2, 4, 0)
+        c = Vector(5, 2, 0)
+        _msg("  Wire")
+        _msg("  a={0}, b={1}".format(a, b))
+        _msg("  c={0}".format(c))
+        wire = Draft.makeWire([a, b, c])
+        App.ActiveDocument.recompute()
+
+        offset = Vector(-1, 1, 0)
+        _msg("  Offset")
+        _msg("  vector={}".format(offset))
+        obj = Draft.offset(wire, offset, copy=True)
+        self.assertTrue(obj, "'{}' failed".format(operation))
+
+    def test_offset_closed(self):
         """Create a rectangle, then produce an offset copy."""
         operation = "Draft Offset"
         _msg("  Test '{}'".format(operation))


### PR DESCRIPTION
Commit 145f4437 (#2746) changed the `DraftGeomUtils.offsetWire` function, which impacts the `Draft.offset` function. This makes the offset unit test fail.

This commit adds a second unit test in order to test two cases: offset of open wires, and of closed wires, like a rectangle. Therefore, if in the future the offset code breaks again, we can pin-point the problem more precisely.

This code is tested with d0ac80e9 (#2746) which is just before the changes to `DraftGeomUtils`, and it works fine.

Currently the offset test fail, but after #2879 is merged, it should pass again hopefully.

Forum thread: [Draft.offset changed its behavior with pull request 2746](https://forum.freecadweb.org/viewtopic.php?f=23&t=42282)

---

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists
