### PR TITLE
[TD]Embed Hatch and Symbols Files in Document

### DIFF
--- a/src/App/PropertyFile.h
+++ b/src/App/PropertyFile.h
@@ -111,6 +111,8 @@ public:
     std::string getExchangeTempFile(void) const;
     std::string getOriginalFileName(void) const;
 
+    bool isEmpty(void){return _cValue.empty();}
+
 protected:
     // get the transient path if the property is in a DocumentObject
     std::string getDocTransientPath(void) const;

--- a/src/Mod/TechDraw/App/DrawGeomHatch.h
+++ b/src/Mod/TechDraw/App/DrawGeomHatch.h
@@ -58,13 +58,13 @@ public:
     App::PropertyString      NamePattern;
     App::PropertyFloatConstraint ScalePattern;
 
-    virtual short mustExecute() const;
-    virtual App::DocumentObjectExecReturn *execute(void);
-    virtual void onChanged(const App::Property* prop);
-    virtual const char* getViewProviderName(void) const {
+    virtual short mustExecute() const override;
+    virtual App::DocumentObjectExecReturn *execute(void) override;
+    virtual void onChanged(const App::Property* prop) override;
+    virtual const char* getViewProviderName(void) const override {
         return "TechDrawGui::ViewProviderGeomHatch";
     }
-    virtual PyObject *getPyObject(void);
+    virtual PyObject *getPyObject(void) override;
 
     DrawViewPart* getSourceView(void) const;
 
@@ -78,8 +78,8 @@ public:
     static TopoDS_Face extractFace(DrawViewPart* source, int iface );
 
 protected:
-    virtual void onDocumentRestored();
-    virtual void setupObject();
+    virtual void onDocumentRestored() override;
+    virtual void setupObject() override;
     void setupPatIncluded(void);
     void replacePatIncluded(std::string newPatFile);
     void copyFile(std::string inSpec, std::string outSpec);

--- a/src/Mod/TechDraw/App/DrawGeomHatch.h
+++ b/src/Mod/TechDraw/App/DrawGeomHatch.h
@@ -54,6 +54,7 @@ public:
 
     App::PropertyLinkSub     Source;                                   //the dvX & face(s) this crosshatch belongs to
     App::PropertyFile        FilePattern;
+    App::PropertyFileIncluded PatIncluded;
     App::PropertyString      NamePattern;
     App::PropertyFloatConstraint ScalePattern;
 
@@ -77,6 +78,14 @@ public:
     static TopoDS_Face extractFace(DrawViewPart* source, int iface );
 
 protected:
+    virtual void onDocumentRestored();
+    virtual void setupObject();
+    void setupPatIncluded(void);
+    void replacePatIncluded(std::string newPatFile);
+    void copyFile(std::string inSpec, std::string outSpec);
+
+    void makeLineSets(void);
+
     void getParameters(void);
     std::vector<PATLineSpec> getDecodedSpecsFromFile();
     std::vector<LineSet> m_lineSets;

--- a/src/Mod/TechDraw/App/DrawHatch.cpp
+++ b/src/Mod/TechDraw/App/DrawHatch.cpp
@@ -220,13 +220,18 @@ void DrawHatch::replaceSvgIncluded(std::string newSvgFile)
 
 void DrawHatch::onDocumentRestored() 
 {
+//if this is a restore, we should be checking for SvgIncluded empty,
+// if it is, set it up from hatchPattern,
+// else, don't do anything
 //    Base::Console().Message("DH::onDocumentRestored()\n");
-    if (!HatchPattern.isEmpty()) {
-        std::string svgFileName = HatchPattern.getValue();
-        Base::FileInfo tfi(svgFileName);
-        if (tfi.isReadable()) {
-            if (SvgIncluded.isEmpty()) {
-                setupSvgIncluded();
+    if (SvgIncluded.isEmpty()) {
+        if (!HatchPattern.isEmpty()) {
+            std::string svgFileName = HatchPattern.getValue();
+            Base::FileInfo tfi(svgFileName);
+            if (tfi.isReadable()) {
+                if (SvgIncluded.isEmpty()) {
+                    setupSvgIncluded();
+                }
             }
         }
     }

--- a/src/Mod/TechDraw/App/DrawHatch.h
+++ b/src/Mod/TechDraw/App/DrawHatch.h
@@ -43,6 +43,7 @@ public:
     App::PropertyVector      DirProjection;                            //Source is only valid for original projection?
     App::PropertyLinkSub     Source;                                   //the dvp & face this hatch belongs to
     App::PropertyFile        HatchPattern;
+    App::PropertyFileIncluded SvgIncluded;
 
     virtual App::DocumentObjectExecReturn *execute(void);
 
@@ -62,6 +63,11 @@ public:
 
 protected:
     void onChanged(const App::Property* prop);
+    virtual void onDocumentRestored();
+    virtual void setupObject();
+    void setupSvgIncluded(void);
+    void replaceSvgIncluded(std::string newSvgFile);
+    void copyFile(std::string inSpec, std::string outSpec);
 
 private:
 

--- a/src/Mod/TechDraw/App/DrawHatch.h
+++ b/src/Mod/TechDraw/App/DrawHatch.h
@@ -45,13 +45,13 @@ public:
     App::PropertyFile        HatchPattern;
     App::PropertyFileIncluded SvgIncluded;
 
-    virtual App::DocumentObjectExecReturn *execute(void);
+    virtual App::DocumentObjectExecReturn *execute(void) override;
 
-    virtual const char* getViewProviderName(void) const {
+    virtual const char* getViewProviderName(void) const override {
         return "TechDrawGui::ViewProviderHatch";
     }
     //return PyObject as DrawHatchPy
-    virtual PyObject *getPyObject(void);
+    virtual PyObject *getPyObject(void) override;
 
     DrawViewPart* getSourceView(void) const;
     bool affectsFace(int i);
@@ -62,9 +62,9 @@ public:
 
 
 protected:
-    void onChanged(const App::Property* prop);
-    virtual void onDocumentRestored();
-    virtual void setupObject();
+    void onChanged(const App::Property* prop) override;
+    virtual void onDocumentRestored() override;
+    virtual void setupObject() override;
     void setupSvgIncluded(void);
     void replaceSvgIncluded(std::string newSvgFile);
     void copyFile(std::string inSpec, std::string outSpec);

--- a/src/Mod/TechDraw/App/DrawTileWeld.cpp
+++ b/src/Mod/TechDraw/App/DrawTileWeld.cpp
@@ -25,10 +25,14 @@
 #ifndef _PreComp_
 #endif
 
+#include <sstream>
+#include <fstream>
+
 #include <App/Application.h>
 #include <Base/Console.h>
 #include <Base/Exception.h>
 #include <Base/Parameter.h>
+#include <Base/Tools.h>
 
 #include "DrawUtil.h"
 
@@ -52,6 +56,9 @@ DrawTileWeld::DrawTileWeld(void)
     ADD_PROPERTY_TYPE(RightText, (0), group, App::Prop_None, "Text RHS");
     ADD_PROPERTY_TYPE(CenterText, (0), group, App::Prop_None, "Text above Symbol");
     ADD_PROPERTY_TYPE(SymbolFile, (""), group, App::Prop_None, "Svg Symbol File");
+
+    SymbolFile.setStatus(App::Property::ReadOnly,true);
+
 }
 
 DrawTileWeld::~DrawTileWeld()
@@ -76,6 +83,29 @@ App::DocumentObjectExecReturn *DrawTileWeld::execute(void)
 { 
 //    Base::Console().Message("DTW::execute()\n");
     return DrawTile::execute();
+}
+
+void DrawTileWeld::replaceSymbol(std::string newSymbolFile)
+{
+//    Base::Console().Message("DTW::replaceSymbol(%s)\n", newSymbolFile.c_str());
+    std::string special = getNameInDocument();
+    special += "Symbol.svg";
+    std::string tempName = SymbolFile.getExchangeTempFile();
+    copyFile(newSymbolFile, tempName);
+    SymbolFile.setValue(tempName.c_str(), special.c_str());
+}
+
+//copy whole text file from inSpec to outSpec
+void DrawTileWeld::copyFile(std::string inSpec, std::string outSpec)
+{
+//    Base::Console().Message("DTW::copyFile(%s, %s)\n", inSpec.c_str(), outSpec.c_str());
+    if (inSpec.empty()) {
+        std::ofstream  dst(outSpec);   //make an empty file
+    } else {
+        std::ifstream  src(inSpec);
+        std::ofstream  dst(outSpec);
+        dst << src.rdbuf();
+    }
 }
 
 PyObject *DrawTileWeld::getPyObject(void)

--- a/src/Mod/TechDraw/App/DrawTileWeld.h
+++ b/src/Mod/TechDraw/App/DrawTileWeld.h
@@ -23,6 +23,8 @@
 #ifndef _TechDraw_DrawTileWeld_h_
 #define _TechDraw_DrawTileWeld_h_
 
+#include <QString>
+
 #include <App/DocumentObject.h>
 #include <App/FeaturePython.h>
 #include <App/PropertyFile.h>
@@ -56,8 +58,11 @@ public:
     virtual PyObject *getPyObject(void);
     virtual QRectF getRect() const { return QRectF(0,0,1,1);}
 
+    void replaceSymbol(std::string newSymbolFile);
+
 protected:
     virtual void onChanged(const App::Property* prop);
+    void copyFile(std::string inSpec, std::string outSpec);
 
 private:
 };

--- a/src/Mod/TechDraw/App/DrawViewSection.cpp
+++ b/src/Mod/TechDraw/App/DrawViewSection.cpp
@@ -130,8 +130,10 @@ DrawViewSection::DrawViewSection()
     ADD_PROPERTY_TYPE(CutSurfaceDisplay,((long)2),fgroup, App::Prop_None, "Appearance of Cut Surface");
     ADD_PROPERTY_TYPE(FileHatchPattern ,(""),fgroup,App::Prop_None,"The hatch pattern file for the cut surface");
     ADD_PROPERTY_TYPE(FileGeomPattern ,(""),fgroup,App::Prop_None,"The PAT pattern file for geometric hatching");
-    ADD_PROPERTY_TYPE(SvgIncluded ,(""),fgroup,App::Prop_None,"Embedded Svg hatch file");   // n/a to end users
-    ADD_PROPERTY_TYPE(PatIncluded ,(""),fgroup,App::Prop_None,"Embedded Pat pattern file"); // n/a to end users
+    ADD_PROPERTY_TYPE(SvgIncluded ,(""),fgroup,App::Prop_None,
+                                            "Embedded Svg hatch file. System use only.");   // n/a to end users
+    ADD_PROPERTY_TYPE(PatIncluded ,(""),fgroup,App::Prop_None,
+                                            "Embedded Pat pattern file. System use only."); // n/a to end users
     ADD_PROPERTY_TYPE(NameGeomPattern ,(""),fgroup,App::Prop_None,"The pattern name for geometric hatching");
     ADD_PROPERTY_TYPE(HatchScale,(1.0),fgroup,App::Prop_None,"Hatch pattern size adjustment");
 
@@ -142,8 +144,8 @@ DrawViewSection::DrawViewSection()
     hatchFilter = ("PAT files (*.pat *.PAT);;All files (*)");
     FileGeomPattern.setFilter(hatchFilter);
 
-//    SvgIncluded.setStatus(App::Property::ReadOnly,true);
-//    PatIncluded.setStatus(App::Property::ReadOnly,true);
+    SvgIncluded.setStatus(App::Property::ReadOnly,true);
+    PatIncluded.setStatus(App::Property::ReadOnly,true);
 }
 
 DrawViewSection::~DrawViewSection()
@@ -237,9 +239,7 @@ void DrawViewSection::onChanged(const App::Property* prop)
 void DrawViewSection::replaceSvgIncluded(std::string newSvgFile)
 {
 //    Base::Console().Message("DVS::replaceSvgHatch(%s)\n", newSvgFile.c_str());
-    const char* temp = SvgIncluded.getValue();
-    //if (SvgIncluded.isEmpty()) {
-    if (temp[0] == '\0') {
+    if (SvgIncluded.isEmpty()) {
         setupSvgIncluded();
     } else {
         std::string tempName = SvgIncluded.getExchangeTempFile();
@@ -251,8 +251,7 @@ void DrawViewSection::replaceSvgIncluded(std::string newSvgFile)
 void DrawViewSection::replacePatIncluded(std::string newPatFile)
 {
 //    Base::Console().Message("DVS::replacePatHatch(%s)\n", newPatFile.c_str());
-    const char* temp = PatIncluded.getValue();
-    if (temp[0] == '\0') {
+    if (PatIncluded.isEmpty()) {
         setupPatIncluded();
     } else {
         std::string tempName = PatIncluded.getExchangeTempFile();
@@ -889,14 +888,21 @@ void DrawViewSection::onDocumentRestored()
         std::string svgFileName = FileHatchPattern.getValue();
         Base::FileInfo tfi(svgFileName);
         if (tfi.isReadable()) {
-            const char* svg = SvgIncluded.getValue();
-//            if (SvgIncluded.isEmpty()) {
-            if (svg[0] == '\0') {
+            if (SvgIncluded.isEmpty()) {
                 setupSvgIncluded();
             }
         }
     }
 
+    if (!FileGeomPattern.isEmpty()) {
+        std::string patFileName = FileGeomPattern.getValue();
+        Base::FileInfo tfi(patFileName);
+        if (tfi.isReadable()) {
+            if (PatIncluded.isEmpty()) {
+                setupPatIncluded();
+            }
+        }
+    }
     DrawViewPart::onDocumentRestored();
 }
 
@@ -918,9 +924,7 @@ void DrawViewSection::setupSvgIncluded(void)
     std::string dir = doc->TransientDir.getValue();
     std::string svgName = dir + special;
 
-    const char* includedName = SvgIncluded.getValue();
-    //if (SvgIncluded.isEmpty()) {
-//    if (includedName[0] == '\0') {
+    if (SvgIncluded.isEmpty()) {
         copyFile(std::string(), svgName);
         SvgIncluded.setValue(svgName.c_str());
     }
@@ -940,9 +944,7 @@ void DrawViewSection::setupPatIncluded(void)
     special += "PatHatch.pat";
     std::string dir = doc->TransientDir.getValue();
     std::string patName = dir + special;
-    //if (PatIncluded.isEmpty()) {
-    const char* includedName = PatIncluded.getValue();
-    if (includedName[0] == '\0') {
+    if (PatIncluded.isEmpty()) {
         copyFile(std::string(), patName);
         PatIncluded.setValue(patName.c_str());
     }

--- a/src/Mod/TechDraw/App/DrawViewSection.h
+++ b/src/Mod/TechDraw/App/DrawViewSection.h
@@ -134,8 +134,8 @@ protected:
     void copyFile(std::string inSpec, std::string outSpec);
 
 
-    virtual void onDocumentRestored();
-    virtual void setupObject();
+    virtual void onDocumentRestored() override;
+    virtual void setupObject() override;
     void setupSvgIncluded(void);
     void setupPatIncluded(void);
     void replaceSvgIncluded(std::string newSvgFile);

--- a/src/Mod/TechDraw/App/DrawViewSection.h
+++ b/src/Mod/TechDraw/App/DrawViewSection.h
@@ -89,7 +89,6 @@ public:
     }
     virtual void unsetupObject() override;
     virtual short mustExecute() const override;
-    virtual void onSettingDocument() override;
 
     std::vector<TechDraw::Face*> getFaceGeometry();
 

--- a/src/Mod/TechDraw/App/DrawViewSection.h
+++ b/src/Mod/TechDraw/App/DrawViewSection.h
@@ -71,6 +71,8 @@ public:
     App::PropertyEnumeration CutSurfaceDisplay;        //new v019
     App::PropertyFile   FileHatchPattern;
     App::PropertyFile   FileGeomPattern;               //new v019
+    App::PropertyFileIncluded SvgIncluded;
+    App::PropertyFileIncluded PatIncluded;
     App::PropertyString NameGeomPattern;
     App::PropertyFloat  HatchScale;
 
@@ -87,8 +89,8 @@ public:
     }
     virtual void unsetupObject() override;
     virtual short mustExecute() const override;
+    virtual void onSettingDocument() override;
 
-public:
     std::vector<TechDraw::Face*> getFaceGeometry();
 
     void setCSFromBase(const std::string sectionName);
@@ -129,6 +131,18 @@ protected:
     bool debugSection(void) const;
 
     TopoDS_Shape m_cutShape;
+
+    void copyFile(std::string inSpec, std::string outSpec);
+
+
+    virtual void onDocumentRestored();
+    virtual void setupObject();
+    void setupSvgIncluded(void);
+    void setupPatIncluded(void);
+    void replaceSvgIncluded(std::string newSvgFile);
+    void replacePatIncluded(std::string newPatFile);
+
+
 };
 
 typedef App::FeaturePythonT<DrawViewSection> DrawViewSectionPython;

--- a/src/Mod/TechDraw/App/DrawWeldSymbol.h
+++ b/src/Mod/TechDraw/App/DrawWeldSymbol.h
@@ -50,6 +50,7 @@ public:
 
     virtual short mustExecute() const;
     virtual App::DocumentObjectExecReturn *execute(void);
+    virtual void onSettingDocument(void);
 
     virtual const char* getViewProviderName(void) const {
         return "TechDrawGui::ViewProviderWeld";

--- a/src/Mod/TechDraw/Gui/QGITile.h
+++ b/src/Mod/TechDraw/Gui/QGITile.h
@@ -52,7 +52,7 @@ class QGIWeldSymbol;
 class TechDrawGuiExport QGITile : public QGIDecoration
 {
 public:
-    explicit QGITile();
+    explicit QGITile(TechDraw::DrawTileWeld*);
     ~QGITile(void);
 
     enum {Type = QGraphicsItem::UserType + 325};
@@ -93,6 +93,9 @@ protected:
     void makeText(void);
 
     bool getAltWeld(void);
+    bool isReadable(QString filePath);
+    std::string getStringFromFile(std::string inSpec);
+
 
 private:
     QGCustomText*      m_qgTextL;
@@ -114,6 +117,7 @@ private:
     int                m_col;
     bool               m_tailRight;
     bool               m_altWeld;
+    TechDraw::DrawTileWeld* m_tileFeat;
 };
 
 }

--- a/src/Mod/TechDraw/Gui/QGIViewSection.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewSection.cpp
@@ -123,7 +123,8 @@ void QGIViewSection::drawSectionFace()
                 newFace->setFillMode(QGIFace::SvgFill);
                 newFace->setHatchColor(sectionVp->HatchColor.getValue());
                 newFace->setHatchScale(section->HatchScale.getValue());
-                std::string hatchSpec = section->FileHatchPattern.getValue();
+//                std::string hatchSpec = section->FileHatchPattern.getValue();
+                std::string hatchSpec = section->SvgIncluded.getValue();
                 newFace->setHatchFile(hatchSpec);
             }
         } else if (section->CutSurfaceDisplay.isValue("PatHatch")) {

--- a/src/Mod/TechDraw/Gui/QGIWeldSymbol.cpp
+++ b/src/Mod/TechDraw/Gui/QGIWeldSymbol.cpp
@@ -212,11 +212,11 @@ void QGIWeldSymbol::drawTile(TechDraw::DrawTileWeld* tileFeat)
     std::string tileTextL = tileFeat->LeftText.getValue();
     std::string tileTextR = tileFeat->RightText.getValue();
     std::string tileTextC = tileFeat->CenterText.getValue();
-    std::string symbolFile = tileFeat->SymbolFile.getValue();
+//    std::string symbolFile = tileFeat->SymbolFile.getValue();
     int row = tileFeat->TileRow.getValue();
     int col = tileFeat->TileColumn.getValue();
 
-    QGITile* tile = new QGITile();
+    QGITile* tile = new QGITile(tileFeat);
     addToGroup(tile);
 
     QPointF org = getTileOrigin();
@@ -226,7 +226,7 @@ void QGIWeldSymbol::drawTile(TechDraw::DrawTileWeld* tileFeat)
     tile->setTileTextLeft(tileTextL);
     tile->setTileTextRight(tileTextR);
     tile->setTileTextCenter(tileTextC);
-    tile->setSymbolFile(symbolFile);
+//    tile->setSymbolFile(symbolFile);
     tile->setZValue(ZVALUE::DIMENSION);
     tile->setTileScale(featScale);
     tile->setTailRight(m_weldFeat->isTailRightSide());

--- a/src/Mod/TechDraw/Gui/TaskWeldingSymbol.h
+++ b/src/Mod/TechDraw/Gui/TaskWeldingSymbol.h
@@ -76,6 +76,7 @@ public:
     std::string centerText;
     std::string rightText;
     std::string symbolPath;
+    std::string symbolString;
     std::string tileName;
     void init(void) {
         toBeSaved = false;
@@ -86,6 +87,7 @@ public:
         centerText = "";
         rightText = "";
         symbolPath= "";
+        symbolString = "";
         tileName = "";
     }
 
@@ -132,8 +134,9 @@ protected:
     TechDraw::DrawWeldSymbol* createWeldingSymbol(void);
     void updateWeldingSymbol(void);
 
-    std::vector<App::DocumentObject*> createTiles(void);
-    std::vector<App::DocumentObject*> updateTiles(void);
+/*    std::vector<App::DocumentObject*> createTiles(void);*/
+    void getTileFeats(void);
+    void updateTiles(void);
 
     void collectArrowData(void);
     void collectOtherData(void);
@@ -148,16 +151,20 @@ private:
 
     TechDraw::DrawLeaderLine* m_leadFeat;
     TechDraw::DrawWeldSymbol* m_weldFeat;
-    TechDraw::DrawTileWeld*   m_arrowIn;
-    TechDraw::DrawTileWeld*   m_otherIn;
+/*    TechDraw::DrawTileWeld*   m_arrowIn;    //save starting values*/
+/*    TechDraw::DrawTileWeld*   m_otherIn;*/
+    TechDraw::DrawTileWeld*   m_arrowFeat;
+    TechDraw::DrawTileWeld*   m_otherFeat;
 
     TileImage m_arrowOut;
     TileImage m_otherOut;
 
     QString m_arrowPath;
     QString m_otherPath;
+    QString m_arrowSymbol;
+    QString m_otherSymbol;
 
-    std::vector<std::string> m_toRemove;
+/*    std::vector<std::string> m_toRemove;*/
 
     QPushButton* m_btnOK;
     QPushButton* m_btnCancel;


### PR DESCRIPTION
Currently in order to share documents, sender and receiver must have the same hatch and welding symbol files in the same locations.   This PR uses PropertyFileIncluded to embed the originator's hatch and welding symbols in the documents.   

Hatch and Symbol files are small (64x64) Svg files.  The Pat hatch file is less than a dozen lines of text.


Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
