### PR TITLE
fem: use time.process_time instead of removed time.clock()

### DIFF
--- a/src/Mod/Fem/femmesh/femmesh2mesh.py
+++ b/src/Mod/Fem/femmesh/femmesh2mesh.py
@@ -92,7 +92,7 @@ def femmesh_2_mesh(myFemMesh, myResults=None):
     # This code generates a dict and a faceCode for each face of all elements
     # All faceCodes are than sorted.
 
-    start_time = time.clock()
+    start_time = time.process_time()
     faceCodeList = []
     faceCodeDict = {}
 
@@ -196,7 +196,7 @@ def femmesh_2_mesh(myFemMesh, myResults=None):
                 output_mesh.extend(triangle)
                 # print("my 2. triangle: ", triangle)
 
-    end_time = time.clock()
+    end_time = time.process_time()
     FreeCAD.Console.PrintMessage(
         "Mesh by surface search method: {}\n".format(end_time - start_time)
     )

--- a/src/Mod/Fem/femsolver/calculix/writer.py
+++ b/src/Mod/Fem/femsolver/calculix/writer.py
@@ -97,7 +97,7 @@ class FemInputWriterCcx(writerbase.FemInputWriter):
         )
 
     def write_calculix_input_file(self):
-        timestart = time.clock()
+        timestart = time.process_time()
         FreeCAD.Console.PrintMessage("Start writing CalculiX input file\n")
         FreeCAD.Console.PrintMessage("Write ccx input file to: {}\n".format(self.file_name))
         FreeCAD.Console.PrintLog(
@@ -115,7 +115,7 @@ class FemInputWriterCcx(writerbase.FemInputWriter):
             self.write_calculix_one_input_file()
         writing_time_string = (
             "Writing time CalculiX input file: {} seconds"
-            .format(round((time.clock() - timestart), 2))
+            .format(round((time.process_time() - timestart), 2))
         )
         if self.femelement_count_test is True:
             FreeCAD.Console.PrintMessage(writing_time_string + " \n\n")

--- a/src/Mod/Fem/femsolver/z88/writer.py
+++ b/src/Mod/Fem/femsolver/z88/writer.py
@@ -92,7 +92,7 @@ class FemInputWriterZ88(FemInputWriter.FemInputWriter):
         )
 
     def write_z88_input(self):
-        timestart = time.clock()
+        timestart = time.process_time()
         if not self.femnodes_mesh:
             self.femnodes_mesh = self.femmesh.Nodes
         if not self.femelement_table:
@@ -109,7 +109,7 @@ class FemInputWriterZ88(FemInputWriter.FemInputWriter):
         self.write_z88_solver_parameter()
         writing_time_string = (
             "Writing time input file: {} seconds"
-            .format(round((time.clock() - timestart), 2))
+            .format(round((time.process_time() - timestart), 2))
         )
         FreeCAD.Console.PrintMessage(writing_time_string + " \n\n")
         return self.dir_name


### PR DESCRIPTION
@berndhahnebach time.clock() is removed in python3.8.
https://forum.freecadweb.org/viewtopic.php?f=42&t=40625&p=345087#p359910


Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
