### PR TITLE
[ArchWall] Use OverridenWidth/Align when ArchSketch getWidths/Aligns() not implemented

### DIFF
--- a/src/Mod/Arch/ArchWall.py
+++ b/src/Mod/Arch/ArchWall.py
@@ -835,10 +835,13 @@ class _Wall(ArchComponent.Component):
                     widths = obj.Base.Proxy.getWidths(obj.Base)  # return a list of Width corresponds to indexes of sorted edges of Sketch
 
         # Get width of each edge/wall segment from ArchWall.OverrideWidth if Base Object does not provide it
+
         if not widths:
+
             if obj.OverrideWidth:
-                if Draft.getType(obj.Base) == 'Sketch':
-                    # If Base Object is ordinary Sketch, sort the width list in OverrrideWidth to correspond to indexes of sorted edges of Sketch
+                if obj.Base.isDerivedFrom("Sketcher::SketchObject"):
+                    # If Base Object is ordinary Sketch (or when ArchSketch.getWidth() not implementted yet):-
+                    # sort the width list in OverrrideWidth to correspond to indexes of sorted edges of Sketch
                     try:
                         import ArchSketchObject
                     except:
@@ -872,8 +875,9 @@ class _Wall(ArchComponent.Component):
         # Get align of each edge/wall segment from ArchWall.OverrideAlign if Base Object does not provide it
         if not aligns:
             if obj.OverrideAlign:
-                if Draft.getType(obj.Base) == 'Sketch':
-                    # If Base Object is ordinary Sketch, sort the align list in OverrideAlign to correspond to indexes of sorted edges of Sketch
+                if obj.Base.isDerivedFrom("Sketcher::SketchObject"):
+                    # If Base Object is ordinary Sketch (or when ArchSketch.getAligns() not implementted yet):-
+                    # sort the align list in OverrideAlign to correspond to indexes of sorted edges of Sketch
                     try:
                         import ArchSketchObject
                     except:

--- a/src/Mod/Arch/ArchWall.py
+++ b/src/Mod/Arch/ArchWall.py
@@ -840,7 +840,7 @@ class _Wall(ArchComponent.Component):
 
             if obj.OverrideWidth:
                 if obj.Base.isDerivedFrom("Sketcher::SketchObject"):
-                    # If Base Object is ordinary Sketch (or when ArchSketch.getWidth() not implementted yet):-
+                    # If Base Object is ordinary Sketch (or when ArchSketch.getWidth() not implemented yet):-
                     # sort the width list in OverrrideWidth to correspond to indexes of sorted edges of Sketch
                     try:
                         import ArchSketchObject
@@ -876,7 +876,7 @@ class _Wall(ArchComponent.Component):
         if not aligns:
             if obj.OverrideAlign:
                 if obj.Base.isDerivedFrom("Sketcher::SketchObject"):
-                    # If Base Object is ordinary Sketch (or when ArchSketch.getAligns() not implementted yet):-
+                    # If Base Object is ordinary Sketch (or when ArchSketch.getAligns() not implemented yet):-
                     # sort the align list in OverrideAlign to correspond to indexes of sorted edges of Sketch
                     try:
                         import ArchSketchObject


### PR DESCRIPTION

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
