### PR TITLE
AddonManager: add CFD module's inkscape icons (96DPI)

### DIFF
--- a/src/Mod/AddonManager/Resources/AddonManager.qrc
+++ b/src/Mod/AddonManager/Resources/AddonManager.qrc
@@ -11,6 +11,7 @@
         <file>icons/BOLTSFC_workbench_icon.svg</file>
         <file>icons/CADExchanger_workbench_icon.svg</file>
         <file>icons/cadquery_module_workbench_icon.svg</file>
+        <file>icons/Cfd_workbench_icon.svg</file>
         <file>icons/CfdOF_workbench_icon.svg</file>
         <file>icons/CurvedShapes_workbench_icon.svg</file>
         <file>icons/Curves_workbench_icon.svg</file>

--- a/src/Mod/AddonManager/Resources/icons/Cfd_workbench_icon.svg
+++ b/src/Mod/AddonManager/Resources/icons/Cfd_workbench_icon.svg
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   sodipodi:docname="Cfd_workbench_icon.svg"
+   inkscape:version="1.0beta2 (2b71d25, 2019-12-03)"
+   version="1.1"
+   id="svg2816"
+   height="64px"
+   width="64px">
+  <defs
+     id="defs2818" />
+  <sodipodi:namedview
+     inkscape:document-rotation="0"
+     inkscape:window-maximized="1"
+     inkscape:window-y="61"
+     inkscape:window-x="0"
+     inkscape:window-height="1052"
+     inkscape:window-width="1920"
+     inkscape:grid-bbox="true"
+     inkscape:document-units="px"
+     showgrid="true"
+     inkscape:current-layer="layer8"
+     inkscape:cy="34.077045"
+     inkscape:cx="30.558985"
+     inkscape:zoom="10.825726"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     borderopacity="1.0"
+     bordercolor="#666666"
+     pagecolor="#ffffff"
+     id="base" />
+  <metadata
+     id="metadata2821">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 2"
+     id="layer8"
+     inkscape:groupmode="layer">
+    <path
+       sodipodi:nodetypes="cscsc"
+       inkscape:connector-curvature="0"
+       id="path3657"
+       d="M 61.095169,40.506926 C 39.817023,35.498558 36.885357,34.950109 17.577376,30.137198 -9.2686372,23.445279 13.357079,17.237473 11.337223,18.144965 c -3.2085292,0.389803 4.901242,-1.121067 9.635335,-0.398369 6.282158,0.959024 40.322493,22.708263 40.322493,22.708263"
+       style="display:inline;fill:#00ff00;fill-rule:evenodd;stroke:#000000;stroke-width:1.75748;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path3667"
+       d="M 6.7552618,34.820785 C 31.016687,42.543302 36.822807,41.477249 54.227408,47.648859"
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:#0000ee;stroke-width:2.13543;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path3671"
+       d="m 49.568669,42.379789 4.658739,5.26907 v 0 l -4.991506,4.630397"
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:#0000ee;stroke-width:1.96535;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path3667-3"
+       d="M 3.3627108,15.373641 C 12.801608,7.8011794 33.065789,12.824069 56.2526,24.488284"
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:#ef0000;stroke-width:2.13543;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path3671-6"
+       d="m 52.78476,18.746343 5.329732,5.379334 v 0 l -5.710427,4.727294"
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:#ef0000;stroke-width:1.87465;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       sodipodi:nodetypes="cccc" />
+  </g>
+</svg>


### PR DESCRIPTION
It is a resent PR, previous closed PR (https://github.com/FreeCAD/FreeCAD/pull/2910) has icon 90dpi (generated by old version of inkscape), it has been corrected as suggested by maintainers.

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)


And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
