### PR TITLE
Draft: plane proxy by default saves the state and view

### DIFF
--- a/src/Mod/Draft/Draft.py
+++ b/src/Mod/Draft/Draft.py
@@ -6018,6 +6018,8 @@ class ViewProviderWorkingPlaneProxy:
         c = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/Arch").GetUnsigned("ColorHelpers",674321151)
         vobj.LineColor = (float((c>>24)&0xFF)/255.0,float((c>>16)&0xFF)/255.0,float((c>>8)&0xFF)/255.0,0.0)
         vobj.Proxy = self
+        vobj.RestoreView = True
+        vobj.RestoreState = True
 
     def getIcon(self):
         import Draft_rc


### PR DESCRIPTION
Discussion about saving the view, and restoring it later: [3d PMI or similar functionally in FreeCAD](https://forum.freecadweb.org/viewtopic.php?f=23&t=42547#p362411). The plane proxy could be used to show dimensions only in certain views.

By default the view properties `RestoreView` and `RestoreState` were set to `False`, so the plane proxy seemed like it didn't perform its intended purpose. This request sets the properties to `True` by default so they start working the moment the plane proxy is created.

---

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists