### PR TITLE
[NaviCube] Add 'Step by turn' to preferences dialog

### DIFF
--- a/src/Gui/DlgSettings3DView.ui
+++ b/src/Gui/DlgSettings3DView.ui
@@ -92,6 +92,48 @@ will be shown at the lower left corner in opened files</string>
          </spacer>
         </item>
         <item>
+         <widget class="QLabel" name="stepLabel">
+          <property name="text">
+           <string>Steps by turn</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="Gui::PrefSpinBox" name="prefStepByTurn">
+          <property name="toolTip">
+           <string>Number of steps by turn when using arrows (default = 8 : step angle = 360/8 = 45 deg)</string>
+          </property>
+          <property name="value">
+           <number>8</number>
+          </property>
+          <property name="minimum">
+           <double>4</double>
+          </property>
+          <property name="maximum">
+           <double>36</double>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>NaviStepByTurn</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>View</cstring>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer>
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
          <widget class="QLabel" name="cornerLabel">
           <property name="text">
            <string>Corner</string>
@@ -848,6 +890,11 @@ bounding box size of the 3D object that is currently displayed. </string>
    <extends>QWidget</extends>
    <header>Gui/PrefWidgets.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>Gui::PrefSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>Gui/PrefWidgets.h</header>
   </customwidget>
  </customwidgets>
  <tabstops>

--- a/src/Gui/DlgSettings3DViewImp.cpp
+++ b/src/Gui/DlgSettings3DViewImp.cpp
@@ -113,6 +113,7 @@ void DlgSettings3DViewImp::saveSettings()
     ui->radioPerspective->onSave();
     ui->radioOrthographic->onSave();
     ui->qspinNewDocScale->onSave();
+    ui->prefStepByTurn->onSave();
 
     QVariant camera = ui->comboNewDocView->itemData(ui->comboNewDocView->currentIndex(), Qt::UserRole);
     hGrp->SetASCII("NewDocumentCameraOrientation", (const char*)camera.toByteArray());
@@ -144,6 +145,7 @@ void DlgSettings3DViewImp::loadSettings()
     ui->radioPerspective->onRestore();
     ui->radioOrthographic->onRestore();
     ui->qspinNewDocScale->onRestore();
+    ui->prefStepByTurn->onRestore();
 
     ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath
         ("User parameter:BaseApp/Preferences/View");

--- a/src/Gui/NaviCube.cpp
+++ b/src/Gui/NaviCube.cpp
@@ -1157,7 +1157,7 @@ bool NaviCubeImplementation::mouseReleased(short x, short y) {
 		int pick = pickFace(x, y);
 
 		ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/View");
-		float rotStepAngle = 360/hGrp->GetInt("NaviStepByTurn",8);
+		float rotStepAngle = 360.0f/hGrp->GetInt("NaviStepByTurn",8);
 
 		switch (pick) {
 		default:


### PR DESCRIPTION
- [X] Branch rebased on latest master `git pull --rebase upstream master`
- [X] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0` => Tests fail for reasons other than this PR
- [X] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)

Following PR #2921, this subsequent PR :
- Fixes a bug in previous PR (wasn't correctly working when angle increment step was not an integer)
- Add the 'NaviCube step by turn' to the preferences dialog (Display category)

Wiki will be updated at PR merging