### PR TITLE
Fix XPM height of 'Not attached' overlay icon

### DIFF
--- a/src/Mod/Part/Gui/ViewProviderAttachExtension.cpp
+++ b/src/Mod/Part/Gui/ViewProviderAttachExtension.cpp
@@ -59,7 +59,7 @@ QIcon ViewProviderAttachExtension::extensionMergeOverlayIcons(const QIcon & orig
                 QPixmap px;
 
                 static const char * const feature_detached_xpm[]={
-                    "9 9 3 1",
+                    "9 10 3 1",
                     ". c None",
                     "# c #cc00cc",
                     "a c #ffffff",


### PR DESCRIPTION
- [X] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0` => Just checked compile + functional
- [X] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)