### PR TITLE
Path: small fix for Python 2 syntax

### DIFF
--- a/src/Mod/Path/PathScripts/post/dynapath_post.py
+++ b/src/Mod/Path/PathScripts/post/dynapath_post.py
@@ -258,7 +258,7 @@ def export(objectslist, filename, argstring):
     for line in POSTAMBLE.splitlines(True):
         gcode += linenumber() + line
 
-    print(f'show editor: {SHOW_EDITOR}')
+    print('show editor: {}'.format(SHOW_EDITOR))
     if FreeCAD.GuiUp and SHOW_EDITOR:
         dia = PostUtils.GCodeEditorDialog()
         dia.editor.setText(gcode)


### PR DESCRIPTION
Small fix for Python 2 syntax, as it causes the Travis test to fail with Python 2.

If there are more errors, more commits can be added to this pull request to solve them.

---

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

