### PR TITLE
[Gui]fix missing #includes for Qt

### DIFF
--- a/src/Gui/ProgressDialog.cpp
+++ b/src/Gui/ProgressDialog.cpp
@@ -22,7 +22,10 @@
 
 
 #include "PreCompiled.h"
-
+#include <QApplication>
+#include <QMessageBox>
+#include <QTime>
+#include <QThread>
 #include "ProgressDialog.h"
 #include "MainWindow.h"
 


### PR DESCRIPTION
#include<Qt4All.h> removed from ProgressDialog.h in previous change, but no replacement for QApplication, etc inserted.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
