### PR TITLE
Add Qt includes to fix compile errors

### DIFF
--- a/src/Gui/ProgressDialog.cpp
+++ b/src/Gui/ProgressDialog.cpp
@@ -26,6 +26,11 @@
 #include "ProgressDialog.h"
 #include "MainWindow.h"
 
+#include <QApplication>
+#inlcude <QMessageBox>
+#include <QThread>
+#include <QTime>
+
 
 using namespace Gui;
 


### PR DESCRIPTION
Just add Qt includes which required to compile "src/Gui/ProgressDialog.cpp".