### PR TITLE
FEM: mesh: XML fenics mesh export fixed

### DIFF
--- a/src/Mod/Fem/feminout/writeFenicsXML.py
+++ b/src/Mod/Fem/feminout/writeFenicsXML.py
@@ -68,17 +68,17 @@ def write_fenics_mesh_xml(fem_mesh_obj, outputfile):
         "hexahedron": 8
     }
 
-    Console.Message("Converting " + fem_mesh_obj.Label + " to fenics XML File\n")
-    Console.Message("Dimension of mesh: %d\n" % (get_FemMeshObjectDimension(fem_mesh_obj),))
+    Console.PrintMessage(u"Converting " + fem_mesh_obj.Label + u" to fenics XML File\n")
+    Console.PrintMessage(u"Dimension of mesh: %d\n" % (get_FemMeshObjectDimension(fem_mesh_obj),))
 
     elements_in_mesh = get_FemMeshObjectElementTypes(fem_mesh_obj)
-    Console.Message("Elements appearing in mesh: %s" % (str(elements_in_mesh),))
+    Console.PrintMessage(u"Elements appearing in mesh: %s" % (str(elements_in_mesh),))
     celltype_in_mesh = get_MaxDimElementFromList(elements_in_mesh)
     (num_cells, cellname_fc, dim_cell) = celltype_in_mesh
     cellname_fenics = FreeCAD_to_Fenics_dict[cellname_fc]
     num_verts_cell = XML_Number_of_Nodes_dict[cellname_fenics]
-    Console.Message(
-        "Celltype in mesh -> %s and its Fenics name: %s\n"
+    Console.PrintMessage(
+        u"Celltype in mesh -> %s and its Fenics name: %s\n"
         % (str(celltype_in_mesh), cellname_fenics)
     )
 


### PR DESCRIPTION
XML fenics mesh export was broken, due to an API change for the FreeCAD.Console.

This small PR fixes the issue. @qingfengxia provided the fix which was discussed in https://forum.freecadweb.org/viewtopic.php?f=18&t=35778&sid=d574cf84b7474a3941f601066d5a9b76&start=20

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [X] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [X] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
