### PR TITLE
Import transparent and IFC4 colours

### DIFF
--- a/src/Mod/Arch/importIFC.py
+++ b/src/Mod/Arch/importIFC.py
@@ -799,9 +799,12 @@ def insert(filename,docname,skip=[],only=[],root=None,preferences=None):
 
             # color
 
-            if FreeCAD.GuiUp and (pid in colors) and hasattr(obj.ViewObject,"ShapeColor"):
+            if FreeCAD.GuiUp and (pid in colors) and colors[pid]:
                 # if preferences['DEBUG']: print("    setting color: ",int(colors[pid][0]*255),"/",int(colors[pid][1]*255),"/",int(colors[pid][2]*255))
-                obj.ViewObject.ShapeColor = colors[pid]
+                if hasattr(obj.ViewObject,"ShapeColor"):
+                    obj.ViewObject.ShapeColor = tuple(colors[pid][0:3])
+                if hasattr(obj.ViewObject,"Transparency"):
+                    obj.ViewObject.Transparency = colors[pid][3]
 
             # if preferences['DEBUG'] is on, recompute after each shape
             if preferences['DEBUG']: FreeCAD.ActiveDocument.recompute()


### PR DESCRIPTION
This was based on this thread: https://forums.buildingsmart.org/t/why-is-it-so-difficult-to-get-colors-to-show-up/2312/7

A note: to get their file imported properly, change:
`#29 = IFCSITE('307$HOAJv978fdh6iQQOQD', $, 'Hypar Site', 'The default site generated by Hypar', $, $, $, $, .ELEMENT., (0, 0), (0, 0), 0.0, $, $);`
to `#29 = IFCSITE('307$HOAJv978fdh6iQQOQD', $, 'Hypar Site', 'The default site generated by Hypar', $, $, $, $, .ELEMENT., (0, 0, 0), (0, 0, 0), 0.0, $, $);` otherwise their file is invalid and will not import, as they do not provide the seconds field of the long/lats.

This PR fixes a few things:

 - In IFC4, IfcPresentationStyleAssignment is deprecated and instead IfcPresentationStyleSelect is directly used. The code now accommodates both IFC2X3 and IFC4 materials.
 - The IFC4 transparency data is now detected and imported.