### PR TITLE
[Draft] fix circular array python2

### DIFF
--- a/src/Mod/Draft/Draft.py
+++ b/src/Mod/Draft/Draft.py
@@ -5349,7 +5349,7 @@ class _Array(_DraftLink):
             n = math.floor(c/tdist)
             n = int(math.floor(n/sym)*sym)
             if n == 0: continue
-            angle = 360/n
+            angle = 360.0/n
             for ycount in range(0, n):
                 npl = pl.copy()
                 trans = FreeCAD.Vector(direction).multiply(rc)


### PR DESCRIPTION
There was a semantic change of the division operator ‘/’ from python2 to python3. This fix makes the circular array work with python2 correctly.
See [PEP 238](https://www.python.org/dev/peps/pep-0238/)

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
