### PR TITLE
Draft: clean-up the initialization, toolbars and menus

### DIFF
--- a/src/Mod/Draft/CMakeLists.txt
+++ b/src/Mod/Draft/CMakeLists.txt
@@ -49,6 +49,7 @@ SET(Draft_tests
 
 SET(Draft_utilities
     draftutils/__init__.py
+    draftutils/init_tools.py
     draftutils/utils.py
     draftutils/gui_utils.py
     draftutils/todo.py

--- a/src/Mod/Draft/InitGui.py
+++ b/src/Mod/Draft/InitGui.py
@@ -91,68 +91,35 @@ class DraftWorkbench(FreeCADGui.Workbench):
                                        "Draft will not work as expected.\n")
 
         # Set up command lists
-        self.cmdList = ["Draft_Line", "Draft_Wire", "Draft_Fillet", "Draft_ArcTools",
-                        "Draft_Circle", "Draft_Ellipse", "Draft_Rectangle", "Draft_Polygon",  
-                        "Draft_BSpline", "Draft_BezierTools", "Draft_Point", 
-                        "Draft_Facebinder"]
-
-        self.annotation_tools = ["Draft_Text", "Draft_ShapeString", "Draft_Dimension",
-                                 "Draft_Label"]
-
-        self.modList = ["Draft_Move", "Draft_Rotate", "Draft_Offset",
-                        "Draft_Trimex", "Draft_Join", "Draft_Split",
-                        "Draft_Upgrade", "Draft_Downgrade", "Draft_Scale",
-                        "Draft_Edit", "Draft_SubelementHighlight",
-                        "Draft_WireToBSpline", "Draft_AddPoint",
-                        "Draft_DelPoint", "Draft_Shape2DView",
-                        "Draft_Draft2Sketch", "Draft_Array", "Draft_LinkArray",
-                        "Draft_PolarArray", "Draft_CircularArray",
-                        "Draft_PathArray", "Draft_PathLinkArray", "Draft_PointArray", "Draft_Clone",
-                        "Draft_Drawing", "Draft_Mirror", "Draft_Stretch"]
-
-        self.treecmdList = ["Draft_ApplyStyle", "Draft_ToggleDisplayMode",
-                            "Draft_AddToGroup", "Draft_SelectGroup",
-                            "Draft_SelectPlane", "Draft_ShowSnapBar",
-                            "Draft_ToggleGrid", "Draft_AutoGroup"]
-
-        self.lineList = ["Draft_UndoLine", "Draft_FinishLine",
-                         "Draft_CloseLine"]
-
-        self.utils = ["Draft_Layer", "Draft_Heal", "Draft_FlipDimension",
-                      "Draft_ToggleConstructionMode",
-                      "Draft_ToggleContinueMode", "Draft_Edit",
-                      "Draft_Slope", "Draft_SetWorkingPlaneProxy",
-                      "Draft_AddConstruction"]
-
-        self.snapList = ['Draft_Snap_Lock', 'Draft_Snap_Midpoint',
-                         'Draft_Snap_Perpendicular',
-                         'Draft_Snap_Grid', 'Draft_Snap_Intersection',
-                         'Draft_Snap_Parallel',
-                         'Draft_Snap_Endpoint', 'Draft_Snap_Angle',
-                         'Draft_Snap_Center',
-                         'Draft_Snap_Extension', 'Draft_Snap_Near',
-                         'Draft_Snap_Ortho', 'Draft_Snap_Special',
-                         'Draft_Snap_Dimensions', 'Draft_Snap_WorkingPlane']
+        import draftutils.init_tools as it
+        self.drawing_commands = it.get_draft_drawing_commands()
+        self.annotation_commands = it.get_draft_annotation_commands()
+        self.modification_commands = it.get_draft_modification_commands()
+        self.context_commands = it.get_draft_context_commands()
+        self.line_commands = it.get_draft_line_commands()
+        self.utility_commands = it.get_draft_utility_commands()
 
         # Set up toolbars
-        self.appendToolbar("Draft creation tools", self.cmdList)
-        self.appendToolbar("Draft annotation tools", self.annotation_tools)
-        self.appendToolbar("Draft modification tools", self.modList)
+        self.appendToolbar(QT_TRANSLATE_NOOP("Draft", "Draft creation tools"), self.drawing_commands)
+        self.appendToolbar(QT_TRANSLATE_NOOP("Draft", "Draft annotation tools"), self.annotation_commands)
+        self.appendToolbar(QT_TRANSLATE_NOOP("Draft", "Draft modification tools"), self.modification_commands)
 
-        # Set up menu
-        self.appendMenu(QT_TRANSLATE_NOOP("draft","&2D Drafting"),self.cmdList)
-        self.appendMenu(QT_TRANSLATE_NOOP("draft","&Modify"),self.modList)
-        self.appendMenu(QT_TRANSLATE_NOOP("draft","&Annotation"),self.annotation_tools)
-        self.appendMenu(QT_TRANSLATE_NOOP("draft", "&Utilities"), self.utils + self.treecmdList)
+        # Set up menus
+        self.appendMenu(QT_TRANSLATE_NOOP("Draft", "&Drafting"), self.drawing_commands)
+        self.appendMenu(QT_TRANSLATE_NOOP("Draft", "&Annotation"), self.annotation_commands)
+        self.appendMenu(QT_TRANSLATE_NOOP("Draft", "&Modification"), self.modification_commands)
+        self.appendMenu(QT_TRANSLATE_NOOP("Draft", "&Utilities"), self.utility_commands + self.context_commands)
 
+        # Set up preferences pages
         if hasattr(FreeCADGui, "draftToolBar"):
             if not hasattr(FreeCADGui.draftToolBar, "loadedPreferences"):
-                FreeCADGui.addPreferencePage(":/ui/preferences-draft.ui", QT_TRANSLATE_NOOP("draft", "Draft"))
-                FreeCADGui.addPreferencePage(":/ui/preferences-draftsnap.ui", QT_TRANSLATE_NOOP("draft", "Draft"))
-                FreeCADGui.addPreferencePage(":/ui/preferences-draftvisual.ui", QT_TRANSLATE_NOOP("draft", "Draft"))
-                FreeCADGui.addPreferencePage(":/ui/preferences-drafttexts.ui", QT_TRANSLATE_NOOP("draft", "Draft"))
+                FreeCADGui.addPreferencePage(":/ui/preferences-draft.ui", QT_TRANSLATE_NOOP("Draft", "Draft"))
+                FreeCADGui.addPreferencePage(":/ui/preferences-draftsnap.ui", QT_TRANSLATE_NOOP("Draft", "Draft"))
+                FreeCADGui.addPreferencePage(":/ui/preferences-draftvisual.ui", QT_TRANSLATE_NOOP("Draft", "Draft"))
+                FreeCADGui.addPreferencePage(":/ui/preferences-drafttexts.ui", QT_TRANSLATE_NOOP("Draft", "Draft"))
                 FreeCADGui.draftToolBar.loadedPreferences = True
-        FreeCAD.Console.PrintLog('Loading Draft module, done.\n')
+
+        FreeCAD.Console.PrintLog('Loading Draft workbench, done.\n')
 
     def Activated(self):
         """When entering the workbench."""
@@ -176,17 +143,17 @@ class DraftWorkbench(FreeCADGui.Workbench):
         if recipient == "View":
             if FreeCAD.activeDraftCommand is None:
                 if FreeCADGui.Selection.getSelection():
-                    self.appendContextMenu("Draft", self.cmdList + self.modList)
-                    self.appendContextMenu("Utilities", self.treecmdList)
+                    self.appendContextMenu("Draft", self.drawing_commands + self.modification_commands)
+                    self.appendContextMenu("Utilities", self.context_commands)
                 else:
-                    self.appendContextMenu("Draft", self.cmdList)
+                    self.appendContextMenu("Draft", self.drawing_commands)
             else:
                 if FreeCAD.activeDraftCommand.featureName == translate("draft","Line"):
                     # BUG: line subcommands are not usable while another command is active
-                    self.appendContextMenu("", self.lineList)
+                    self.appendContextMenu("", self.line_commands)
         else:
             if FreeCADGui.Selection.getSelection():
-                self.appendContextMenu("Utilities", self.treecmdList)
+                self.appendContextMenu("Utilities", self.context_commands)
 
     def GetClassName(self):
         """Type of workbench."""
@@ -198,9 +165,10 @@ FreeCADGui.addWorkbench(DraftWorkbench)
 # Preference pages for importing and exporting various file formats
 # are independent of the loading of the workbench and can be loaded at startup
 import Draft_rc
-FreeCADGui.addPreferencePage(":/ui/preferences-dxf.ui", "Import-Export")
-FreeCADGui.addPreferencePage(":/ui/preferences-dwg.ui", "Import-Export")
-FreeCADGui.addPreferencePage(":/ui/preferences-svg.ui", "Import-Export")
-FreeCADGui.addPreferencePage(":/ui/preferences-oca.ui", "Import-Export")
+from PySide.QtCore import QT_TRANSLATE_NOOP
+FreeCADGui.addPreferencePage(":/ui/preferences-dxf.ui", QT_TRANSLATE_NOOP("Draft", "Import-Export"))
+FreeCADGui.addPreferencePage(":/ui/preferences-dwg.ui", QT_TRANSLATE_NOOP("Draft", "Import-Export"))
+FreeCADGui.addPreferencePage(":/ui/preferences-svg.ui", QT_TRANSLATE_NOOP("Draft", "Import-Export"))
+FreeCADGui.addPreferencePage(":/ui/preferences-oca.ui", QT_TRANSLATE_NOOP("Draft", "Import-Export"))
 
 FreeCAD.__unit_test__ += ["TestDraft"]

--- a/src/Mod/Draft/InitGui.py
+++ b/src/Mod/Draft/InitGui.py
@@ -1,3 +1,4 @@
+"""Initialization of the Draft workbench (graphical interface)."""
 # ***************************************************************************
 # *   Copyright (c) 2009 Yorik van Havre <yorik@uncreated.net>              *
 # *                                                                         *
@@ -18,63 +19,78 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
+import os
+import FreeCAD
+import FreeCADGui
 
 __title__ = "FreeCAD Draft Workbench - Init file"
 __author__ = "Yorik van Havre <yorik@uncreated.net>"
 __url__ = "https://www.freecadweb.org"
 
 
-class DraftWorkbench(Workbench):
-    '''The Draft Workbench definition'''
-    def __init__(self):
+class DraftWorkbench(FreeCADGui.Workbench):
+    """The Draft Workbench definition."""
 
-        def QT_TRANSLATE_NOOP(scope, text):
+    def __init__(self):
+        def QT_TRANSLATE_NOOP(context, text):
             return text
 
-        self.__class__.Icon = FreeCAD.getResourceDir() + "Mod/Draft/Resources/icons/DraftWorkbench.svg"
+        __dirname__ = os.path.join(FreeCAD.getResourceDir(), "Mod", "Draft")
+        _tooltip = "The Draft workbench is used for 2D drafting on a grid"
+        self.__class__.Icon = os.path.join(__dirname__,
+                                           "Resources", "icons",
+                                           "DraftWorkbench.svg")
         self.__class__.MenuText = QT_TRANSLATE_NOOP("draft", "Draft")
-        self.__class__.ToolTip = QT_TRANSLATE_NOOP("draft", "The Draft module is used for basic 2D CAD Drafting")
+        self.__class__.ToolTip = QT_TRANSLATE_NOOP("draft", _tooltip)
 
     def Initialize(self):
-        def QT_TRANSLATE_NOOP(scope, text):
+        """When the workbench is first loaded."""
+
+        def QT_TRANSLATE_NOOP(context, text):
             return text
 
-        # run self-tests
-        depsOK = False
+        # Run self-tests
+        dependencies_OK = False
         try:
             from pivy import coin
             if FreeCADGui.getSoDBVersion() != coin.SoDB.getVersion():
-                raise AssertionError("FreeCAD and Pivy use different versions of Coin. This will lead to unexpected behaviour.")
+                raise AssertionError("FreeCAD and Pivy use different versions "
+                                     "of Coin. "
+                                     "This will lead to unexpected behaviour.")
         except AssertionError:
-            FreeCAD.Console.PrintWarning("Error: FreeCAD and Pivy use different versions of Coin. This will lead to unexpected behaviour.\n")
+            FreeCAD.Console.PrintWarning("Error: FreeCAD and Pivy "
+                                         "use different versions of Coin. "
+                                         "This will lead to unexpected "
+                                         "behaviour.\n")
         except ImportError:
-            FreeCAD.Console.PrintWarning("Error: Pivy not found, Draft Workbench will be disabled.\n")
-        except:
-            FreeCAD.Console.PrintWarning("Error: Unknown error while trying to load Pivy\n")
+            FreeCAD.Console.PrintWarning("Error: Pivy not found, "
+                                         "Draft Workbench will be disabled.\n")
+        except Exception:
+            FreeCAD.Console.PrintWarning("Error: Unknown error "
+                                         "while trying to load Pivy.\n")
         else:
-            try:
-                import PySide
-            except ImportError:
-                FreeCAD.Console.PrintWarning("Error: PySide not found, Draft Workbench will be disabled.\n")
-            else:
-                depsOK = True
-        if not depsOK:
+            dependencies_OK = True
+
+        if not dependencies_OK:
             return
 
         # Import Draft tools, icons
         try:
-            import os, Draft_rc, DraftTools, DraftGui, DraftFillet
-            from DraftTools import translate
+            import Draft_rc
+            import DraftTools
+            import DraftGui
+            import DraftFillet
             from draftguitools import gui_circulararray
             from draftguitools import gui_polararray
             FreeCADGui.addLanguagePath(":/translations")
             FreeCADGui.addIconPath(":/icons")
-        except Exception as inst:
-            print(inst)
-            FreeCAD.Console.PrintError("Error: Initializing one or more of the Draft modules failed, Draft will not work as expected.\n")
+        except Exception as exc:
+            FreeCAD.Console.PrintError(exc)
+            FreeCAD.Console.PrintError("Error: Initializing one or more "
+                                       "of the Draft modules failed, "
+                                       "Draft will not work as expected.\n")
 
-        # setup command lists
-
+        # Set up command lists
         self.cmdList = ["Draft_Line", "Draft_Wire", "Draft_Fillet", "Draft_ArcTools",
                         "Draft_Circle", "Draft_Ellipse", "Draft_Rectangle", "Draft_Polygon",  
                         "Draft_BSpline", "Draft_BezierTools", "Draft_Point", 
@@ -117,20 +133,18 @@ class DraftWorkbench(Workbench):
                          'Draft_Snap_Extension', 'Draft_Snap_Near',
                          'Draft_Snap_Ortho', 'Draft_Snap_Special',
                          'Draft_Snap_Dimensions', 'Draft_Snap_WorkingPlane']
-        
-        # setup toolbars
-        
+
+        # Set up toolbars
         self.appendToolbar("Draft creation tools", self.cmdList)
         self.appendToolbar("Draft annotation tools", self.annotation_tools)
         self.appendToolbar("Draft modification tools", self.modList)
 
-        # setup menu
-
+        # Set up menu
         self.appendMenu(QT_TRANSLATE_NOOP("draft","&2D Drafting"),self.cmdList)
         self.appendMenu(QT_TRANSLATE_NOOP("draft","&Modify"),self.modList)
         self.appendMenu(QT_TRANSLATE_NOOP("draft","&Annotation"),self.annotation_tools)
         self.appendMenu(QT_TRANSLATE_NOOP("draft", "&Utilities"), self.utils + self.treecmdList)
-        
+
         if hasattr(FreeCADGui, "draftToolBar"):
             if not hasattr(FreeCADGui.draftToolBar, "loadedPreferences"):
                 FreeCADGui.addPreferencePage(":/ui/preferences-draft.ui", QT_TRANSLATE_NOOP("draft", "Draft"))
@@ -138,23 +152,26 @@ class DraftWorkbench(Workbench):
                 FreeCADGui.addPreferencePage(":/ui/preferences-draftvisual.ui", QT_TRANSLATE_NOOP("draft", "Draft"))
                 FreeCADGui.addPreferencePage(":/ui/preferences-drafttexts.ui", QT_TRANSLATE_NOOP("draft", "Draft"))
                 FreeCADGui.draftToolBar.loadedPreferences = True
-        Log('Loading Draft module...done\n')
+        FreeCAD.Console.PrintLog('Loading Draft module, done.\n')
 
     def Activated(self):
+        """When entering the workbench."""
         if hasattr(FreeCADGui, "draftToolBar"):
             FreeCADGui.draftToolBar.Activated()
         if hasattr(FreeCADGui, "Snapper"):
             FreeCADGui.Snapper.show()
-        Log("Draft workbench activated\n")
+        FreeCAD.Console.PrintLog("Draft workbench activated.\n")
 
     def Deactivated(self):
+        """When quitting the workbench."""
         if hasattr(FreeCADGui, "draftToolBar"):
             FreeCADGui.draftToolBar.Deactivated()
         if hasattr(FreeCADGui, "Snapper"):
             FreeCADGui.Snapper.hide()
-        Log("Draft workbench deactivated\n")
+        FreeCAD.Console.PrintLog("Draft workbench deactivated.\n")
 
     def ContextMenu(self, recipient):
+        """Define an optional custom context menu."""
         from DraftGui import translate
         if recipient == "View":
             if FreeCAD.activeDraftCommand is None:
@@ -172,12 +189,14 @@ class DraftWorkbench(Workbench):
                 self.appendContextMenu("Utilities", self.treecmdList)
 
     def GetClassName(self):
+        """Type of workbench."""
         return "Gui::PythonWorkbench"
 
 
 FreeCADGui.addWorkbench(DraftWorkbench)
 
-# File format pref pages are independent and can be loaded at startup
+# Preference pages for importing and exporting various file formats
+# are independent of the loading of the workbench and can be loaded at startup
 import Draft_rc
 FreeCADGui.addPreferencePage(":/ui/preferences-dxf.ui", "Import-Export")
 FreeCADGui.addPreferencePage(":/ui/preferences-dwg.ui", "Import-Export")

--- a/src/Mod/Draft/draftutils/init_tools.py
+++ b/src/Mod/Draft/draftutils/init_tools.py
@@ -1,0 +1,156 @@
+"""Provides lists of commands for the Draft Workbench.
+
+This module returns lists of commands, so that the toolbars
+can be initilized by Draft, and by other workbenches.
+These commands should be defined in `DraftTools`, and in the individual
+modules in `draftguitools`.
+"""
+## @package init_tools
+# \ingroup DRAFT
+# \brief This module provides lists of commands for the Draft Workbench.
+
+# ***************************************************************************
+# *   (c) 2020 Eliud Cabrera Castillo <e.cabrera-castillo@tum.de>           *
+# *                                                                         *
+# *   This file is part of the FreeCAD CAx development system.              *
+# *                                                                         *
+# *   This program is free software; you can redistribute it and/or modify  *
+# *   it under the terms of the GNU Lesser General Public License (LGPL)    *
+# *   as published by the Free Software Foundation; either version 2 of     *
+# *   the License, or (at your option) any later version.                   *
+# *   for detail see the LICENCE text file.                                 *
+# *                                                                         *
+# *   FreeCAD is distributed in the hope that it will be useful,            *
+# *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+# *   GNU Library General Public License for more details.                  *
+# *                                                                         *
+# *   You should have received a copy of the GNU Library General Public     *
+# *   License along with FreeCAD; if not, write to the Free Software        *
+# *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
+# *   USA                                                                   *
+# *                                                                         *
+# ***************************************************************************
+
+from PySide.QtCore import QT_TRANSLATE_NOOP
+
+# Comment out commands that aren't ready to be used
+
+
+def get_draft_drawing_commands():
+    """Return the drawing commands list."""
+    return ["Draft_Line", "Draft_Wire",  # "Draft_Fillet",
+            "Draft_ArcTools",
+            "Draft_Circle", "Draft_Ellipse", "Draft_Rectangle",
+            "Draft_Polygon", "Draft_BSpline", "Draft_BezierTools",
+            "Draft_Point", "Draft_Facebinder"]
+
+
+def get_draft_annotation_commands():
+    """Return the annotation commands list."""
+    return ["Draft_Text", "Draft_ShapeString", "Draft_Dimension",
+            "Draft_Label"]
+
+
+def get_draft_array_commands():
+    """Return the array commands list."""
+    # After the array commands are grouped, return this
+    # return ["Draft_ArrayTools"]
+    return ["Draft_Array", "Draft_LinkArray",
+            "Draft_PolarArray", "Draft_CircularArray",
+            "Draft_PathArray", "Draft_PathLinkArray", "Draft_PointArray"]
+
+
+def get_draft_modification_commands():
+    """Return the modification commands list."""
+    lst = ["Draft_Move", "Draft_Rotate", "Draft_Offset",
+           "Draft_Trimex", "Draft_Join", "Draft_Split",
+           "Draft_Upgrade", "Draft_Downgrade", "Draft_Scale",
+           "Draft_Edit", "Draft_SubelementHighlight",
+           "Draft_WireToBSpline", "Draft_AddPoint",
+           "Draft_DelPoint", "Draft_Shape2DView",
+           "Draft_Draft2Sketch"]
+    lst += get_draft_array_commands()
+    lst += ["Draft_Clone",
+            "Draft_Drawing", "Draft_Mirror", "Draft_Stretch"]
+    return lst
+
+
+def get_draft_context_commands():
+    """Return the context menu commands list."""
+    return ["Draft_ApplyStyle", "Draft_ToggleDisplayMode",
+            "Draft_AddToGroup", "Draft_SelectGroup",
+            "Draft_SelectPlane", "Draft_ShowSnapBar",
+            "Draft_ToggleGrid", "Draft_AutoGroup"]
+
+
+def get_draft_line_commands():
+    """Return the line commands list."""
+    return ["Draft_UndoLine", "Draft_FinishLine",
+            "Draft_CloseLine"]
+
+
+def get_draft_utility_commands():
+    """Return the utility commands list."""
+    return ["Draft_Layer", "Draft_Heal", "Draft_FlipDimension",
+            "Draft_ToggleConstructionMode",
+            "Draft_ToggleContinueMode", "Draft_Edit",
+            "Draft_Slope", "Draft_SetWorkingPlaneProxy",
+            "Draft_AddConstruction"]
+
+
+def get_draft_snap_commands():
+    """Return the snapping commands list."""
+    return ['Draft_Snap_Lock', 'Draft_Snap_Midpoint',
+            'Draft_Snap_Perpendicular',
+            'Draft_Snap_Grid', 'Draft_Snap_Intersection',
+            'Draft_Snap_Parallel',
+            'Draft_Snap_Endpoint', 'Draft_Snap_Angle',
+            'Draft_Snap_Center',
+            'Draft_Snap_Extension', 'Draft_Snap_Near',
+            'Draft_Snap_Ortho', 'Draft_Snap_Special',
+            'Draft_Snap_Dimensions', 'Draft_Snap_WorkingPlane']
+
+
+def init_draft_toolbars(workbench):
+    """Initialize the Draft toolbars.
+
+    Parameters
+    ----------
+    workbench : Gui.Workbench
+        The workbench class on which the commands have to be available.
+        If called from within the `Initialize` method
+        of a workbench class defined inside `InitGui.py`,
+        it can be used as `setup_draft_toolbars(self)`.
+    """
+    workbench.appendToolbar(QT_TRANSLATE_NOOP("Draft",
+                                              "Draft creation tools"),
+                            get_draft_drawing_commands())
+    workbench.appendToolbar(QT_TRANSLATE_NOOP("Draft",
+                                              "Draft annotation tools"),
+                            get_draft_annotation_commands())
+    workbench.appendToolbar(QT_TRANSLATE_NOOP("Draft",
+                                              "Draft modification tools"),
+                            get_draft_modification_commands())
+
+
+def init_draft_menus(workbench):
+    """Initialize the Draft menus.
+
+    Parameters
+    ----------
+    workbench : Gui.Workbench
+        The workbench class on which the commands have to be available.
+        If called from within the `Initialize` method
+        of a workbench class defined inside `InitGui.py`,
+        it can be used as `setup_draft_menus(self)`.
+    """
+    workbench.appendMenu(QT_TRANSLATE_NOOP("Draft", "&Drafting"),
+                         get_draft_drawing_commands())
+    workbench.appendMenu(QT_TRANSLATE_NOOP("Draft", "&Annotation"),
+                         get_draft_annotation_commands())
+    workbench.appendMenu(QT_TRANSLATE_NOOP("Draft", "&Modification"),
+                         get_draft_modification_commands())
+    workbench.appendMenu(QT_TRANSLATE_NOOP("Draft", "&Utilities"),
+                         get_draft_utility_commands()
+                         + get_draft_context_commands())


### PR DESCRIPTION
Clean up a bit the initialization code of the workbench.

The Draft GUI commands lists are provided by an external module in order to create the toolbars and menus. This external module can then be used by other workbenches, for example, Arch, to create the same toolbars and menus.

Forum thread: [Draft menus](https://forum.freecadweb.org/viewtopic.php?f=23&t=42670#p362943)

---

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists