### PR TITLE
Arch: clean-up the initialization, toolbars and menus

### DIFF
--- a/src/Mod/Arch/InitGui.py
+++ b/src/Mod/Arch/InitGui.py
@@ -1,70 +1,100 @@
-#***************************************************************************
-#*   Copyright (c) 2011 Yorik van Havre <yorik@uncreated.net>              *
-#*                                                                         *
-#*   This program is free software; you can redistribute it and/or modify  *
-#*   it under the terms of the GNU Lesser General Public License (LGPL)    *
-#*   as published by the Free Software Foundation; either version 2 of     *
-#*   the License, or (at your option) any later version.                   *
-#*   for detail see the LICENCE text file.                                 *
-#*                                                                         *
-#*   This program is distributed in the hope that it will be useful,       *
-#*   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
-#*   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
-#*   GNU Library General Public License for more details.                  *
-#*                                                                         *
-#*   You should have received a copy of the GNU Library General Public     *
-#*   License along with this program; if not, write to the Free Software   *
-#*   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
-#*   USA                                                                   *
-#*                                                                         *
-#***************************************************************************
+"""Initialization of the Arch workbench (graphical interface)."""
+# ***************************************************************************
+# *   Copyright (c) 2011 Yorik van Havre <yorik@uncreated.net>              *
+# *                                                                         *
+# *   This program is free software; you can redistribute it and/or modify  *
+# *   it under the terms of the GNU Lesser General Public License (LGPL)    *
+# *   as published by the Free Software Foundation; either version 2 of     *
+# *   the License, or (at your option) any later version.                   *
+# *   for detail see the LICENCE text file.                                 *
+# *                                                                         *
+# *   This program is distributed in the hope that it will be useful,       *
+# *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+# *   GNU Library General Public License for more details.                  *
+# *                                                                         *
+# *   You should have received a copy of the GNU Library General Public     *
+# *   License along with this program; if not, write to the Free Software   *
+# *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
+# *   USA                                                                   *
+# *                                                                         *
+# ***************************************************************************
+import os
+import FreeCAD
+import FreeCADGui
 
-class ArchWorkbench(Workbench):
-    "Arch workbench object"
+
+class ArchWorkbench(FreeCADGui.Workbench):
+    """The Arch workbench definition."""
+
     def __init__(self):
-        self.__class__.Icon = FreeCAD.getResourceDir() + "Mod/Arch/Resources/icons/ArchWorkbench.svg"
-        self.__class__.MenuText = "Arch"
-        self.__class__.ToolTip = "Architecture workbench"
+        def QT_TRANSLATE_NOOP(context, text):
+            return text
+
+        __dirname__ = os.path.join(FreeCAD.getResourceDir(), "Mod", "Arch")
+        _tooltip = ("The Arch workbench is used to model "
+                    "architectural components, and entire buildings")
+        self.__class__.Icon = os.path.join(__dirname__,
+                                           "Resources", "icons",
+                                           "ArchWorkbench.svg")
+        self.__class__.MenuText = QT_TRANSLATE_NOOP("Arch", "Arch")
+        self.__class__.ToolTip = QT_TRANSLATE_NOOP("Arch", _tooltip)
 
     def Initialize(self):
-        import DraftTools,DraftGui,Arch_rc,Arch,Draft_rc
-        from DraftTools import translate
+        """When the workbench is first loaded."""
 
-        # arch tools
-        self.archtools = ["Arch_Wall","Arch_Structure","Arch_Rebar","Arch_BuildingPart",
-                     "Arch_Project", "Arch_Site", "Arch_Building", "Arch_Floor", "Arch_Reference",
-                     "Arch_Window","Arch_Roof","Arch_AxisTools",
-                     "Arch_SectionPlane","Arch_Space","Arch_Stairs",
-                     "Arch_PanelTools","Arch_Equipment",
-                     "Arch_Frame", "Arch_Fence", "Arch_MaterialTools","Arch_Schedule","Arch_PipeTools",
-                     "Arch_CutPlane", "Arch_CutLine",
-                     "Arch_Add","Arch_Remove","Arch_Survey"]
-        self.utilities = ["Arch_Component","Arch_CloneComponent","Arch_SplitMesh","Arch_MeshToShape",
-                     "Arch_SelectNonSolidMeshes","Arch_RemoveShape",
-                     "Arch_CloseHoles","Arch_MergeWalls","Arch_Check",
-                     "Arch_ToggleIfcBrepFlag","Arch_3Views",
-                     "Arch_IfcSpreadsheet","Arch_ToggleSubs"]
+        def QT_TRANSLATE_NOOP(context, text):
+            return text
 
-        # try to locate the Rebar addon
+        import Draft_rc
+        import DraftTools
+        import DraftGui
+        from draftguitools import gui_circulararray
+        from draftguitools import gui_polararray
+        import Arch_rc
+        import Arch
+
+        # Set up command lists
+        self.archtools = ["Arch_Wall", "Arch_Structure", "Arch_Rebar",
+                          "Arch_BuildingPart",
+                          "Arch_Project", "Arch_Site", "Arch_Building",
+                          "Arch_Floor", "Arch_Reference",
+                          "Arch_Window", "Arch_Roof", "Arch_AxisTools",
+                          "Arch_SectionPlane", "Arch_Space", "Arch_Stairs",
+                          "Arch_PanelTools", "Arch_Equipment",
+                          "Arch_Frame", "Arch_Fence", "Arch_MaterialTools",
+                          "Arch_Schedule", "Arch_PipeTools",
+                          "Arch_CutPlane", "Arch_CutLine",
+                          "Arch_Add", "Arch_Remove", "Arch_Survey"]
+        self.utilities = ["Arch_Component", "Arch_CloneComponent",
+                          "Arch_SplitMesh", "Arch_MeshToShape",
+                          "Arch_SelectNonSolidMeshes", "Arch_RemoveShape",
+                          "Arch_CloseHoles", "Arch_MergeWalls", "Arch_Check",
+                          "Arch_ToggleIfcBrepFlag", "Arch_3Views",
+                          "Arch_IfcSpreadsheet", "Arch_ToggleSubs"]
+
+        # Add the rebar tools from the Reinforcement addon, if available
         try:
             import RebarTools
-        except:
+        except Exception:
             pass
         else:
             class RebarGroupCommand:
                 def GetCommands(self):
-                    return tuple(RebarTools.RebarCommands+["Arch_Rebar"])
+                    return tuple(RebarTools.RebarCommands + ["Arch_Rebar"])
+
                 def GetResources(self):
-                    return { 'MenuText': 'Rebar tools',
-                             'ToolTip': 'Rebar tools'
-                           }
+                    _tooltip = ("Create various types of rebars, "
+                                "including U-shaped, L-shaped, and stirrup")
+                    return {'MenuText': QT_TRANSLATE_NOOP("Arch", 'Rebar tools'),
+                            'ToolTip': QT_TRANSLATE_NOOP("Arch", _tooltip)}
+
                 def IsActive(self):
                     return not FreeCAD.ActiveDocument is None
             FreeCADGui.addCommand('Arch_RebarTools', RebarGroupCommand())
             self.archtools[2] = "Arch_RebarTools"
 
-
-        # draft tools
+        # Set up Draft command lists
         self.drafttools = ["Draft_Line","Draft_Wire","Draft_Circle","Draft_Arc","Draft_Ellipse",
                         "Draft_Polygon","Draft_Rectangle", "Draft_Text",
                         "Draft_Dimension", "Draft_BSpline","Draft_Point",
@@ -88,55 +118,69 @@ class ArchWorkbench(Workbench):
                          'Draft_Snap_Extension','Draft_Snap_Near','Draft_Snap_Ortho','Draft_Snap_Special',
                          'Draft_Snap_Dimensions','Draft_Snap_WorkingPlane']
 
-        def QT_TRANSLATE_NOOP(scope, text): return text
-        self.appendToolbar(QT_TRANSLATE_NOOP("Workbench","Arch tools"),self.archtools)
-        self.appendToolbar(QT_TRANSLATE_NOOP("Workbench","Draft tools"),self.drafttools)
-        self.appendToolbar(QT_TRANSLATE_NOOP("Workbench","Draft mod tools"),self.draftmodtools)
-        self.appendMenu([QT_TRANSLATE_NOOP("arch","&Arch"),QT_TRANSLATE_NOOP("arch","Utilities")],self.utilities)
-        self.appendMenu(QT_TRANSLATE_NOOP("arch","&Arch"),self.archtools)
-        self.appendMenu(QT_TRANSLATE_NOOP("arch","&Draft"),self.drafttools+self.draftmodtools+self.draftextratools)
-        self.appendMenu([QT_TRANSLATE_NOOP("arch","&Draft"),QT_TRANSLATE_NOOP("arch","Utilities")],self.draftutils+self.draftcontexttools)
-        self.appendMenu([QT_TRANSLATE_NOOP("arch","&Draft"),QT_TRANSLATE_NOOP("arch","Snapping")],self.snapList)
+        self.appendToolbar(QT_TRANSLATE_NOOP("Workbench", "Arch tools"), self.archtools)
+        self.appendToolbar(QT_TRANSLATE_NOOP("Workbench", "Draft tools"), self.drafttools)
+        self.appendToolbar(QT_TRANSLATE_NOOP("Workbench", "Draft mod tools"), self.draftmodtools)
+
+        self.appendMenu([QT_TRANSLATE_NOOP("arch", "&Arch"),
+                         QT_TRANSLATE_NOOP("arch", "Utilities")],
+                        self.utilities)
+        self.appendMenu(QT_TRANSLATE_NOOP("arch", "&Arch"), self.archtools)
+        self.appendMenu(QT_TRANSLATE_NOOP("arch", "&Draft"),
+                        self.drafttools + self.draftmodtools + self.draftextratools)
+        self.appendMenu([QT_TRANSLATE_NOOP("arch", "&Draft"),
+                         QT_TRANSLATE_NOOP("arch", "Utilities")],
+                        self.draftutils + self.draftcontexttools)
+        self.appendMenu([QT_TRANSLATE_NOOP("arch", "&Draft"),
+                         QT_TRANSLATE_NOOP("arch", "Snapping")], self.snapList)
         FreeCADGui.addIconPath(":/icons")
         FreeCADGui.addLanguagePath(":/translations")
-        if hasattr(FreeCADGui,"draftToolBar"):
-            if not hasattr(FreeCADGui.draftToolBar,"loadedArchPreferences"):
-                FreeCADGui.addPreferencePage(":/ui/preferences-arch.ui","Arch")
-                FreeCADGui.addPreferencePage(":/ui/preferences-archdefaults.ui","Arch")
+
+        if hasattr(FreeCADGui, "draftToolBar"):
+            if not hasattr(FreeCADGui.draftToolBar, "loadedArchPreferences"):
+                FreeCADGui.addPreferencePage(":/ui/preferences-arch.ui", QT_TRANSLATE_NOOP("Arch", "Arch"))
+                FreeCADGui.addPreferencePage(":/ui/preferences-archdefaults.ui", QT_TRANSLATE_NOOP("Arch", "Arch"))
                 FreeCADGui.draftToolBar.loadedArchPreferences = True
-            if not hasattr(FreeCADGui.draftToolBar,"loadedPreferences"):
-                FreeCADGui.addPreferencePage(":/ui/preferences-draft.ui","Draft")
-                FreeCADGui.addPreferencePage(":/ui/preferences-draftsnap.ui","Draft")
-                FreeCADGui.addPreferencePage(":/ui/preferences-draftvisual.ui","Draft")
-                FreeCADGui.addPreferencePage(":/ui/preferences-drafttexts.ui","Draft")
+            if not hasattr(FreeCADGui.draftToolBar, "loadedPreferences"):
+                FreeCADGui.addPreferencePage(":/ui/preferences-draft.ui", QT_TRANSLATE_NOOP("Draft", "Draft"))
+                FreeCADGui.addPreferencePage(":/ui/preferences-draftsnap.ui", QT_TRANSLATE_NOOP("Draft", "Draft"))
+                FreeCADGui.addPreferencePage(":/ui/preferences-draftvisual.ui", QT_TRANSLATE_NOOP("Draft", "Draft"))
+                FreeCADGui.addPreferencePage(":/ui/preferences-drafttexts.ui", QT_TRANSLATE_NOOP("Draft", "Draft"))
                 FreeCADGui.draftToolBar.loadedPreferences = True
-        Log ('Loading Arch module... done\n')
+        FreeCAD.Console.PrintLog('Loading Arch module, done\n')
 
     def Activated(self):
-        if hasattr(FreeCADGui,"draftToolBar"):
+        """When entering the workbench."""
+        if hasattr(FreeCADGui, "draftToolBar"):
             FreeCADGui.draftToolBar.Activated()
-        if hasattr(FreeCADGui,"Snapper"):
+        if hasattr(FreeCADGui, "Snapper"):
             FreeCADGui.Snapper.show()
-        Log("Arch workbench activated\n")
-                
+        FreeCAD.Console.PrintLog("Arch workbench activated.\n")
+
     def Deactivated(self):
-        if hasattr(FreeCADGui,"draftToolBar"):
+        """When leaving the workbench."""
+        if hasattr(FreeCADGui, "draftToolBar"):
             FreeCADGui.draftToolBar.Deactivated()
-        if hasattr(FreeCADGui,"Snapper"):
+        if hasattr(FreeCADGui, "Snapper"):
             FreeCADGui.Snapper.hide()
-        Log("Arch workbench deactivated\n")
+        FreeCAD.Console.PrintLog("Arch workbench deactivated.\n")
 
     def ContextMenu(self, recipient):
-        self.appendContextMenu("Utilities",self.draftcontexttools)
+        """Define an optional custom context menu."""
+        self.appendContextMenu("Utilities", self.draftcontexttools)
 
-    def GetClassName(self): 
+    def GetClassName(self):
+        """Type of workbench."""
         return "Gui::PythonWorkbench"
+
 
 FreeCADGui.addWorkbench(ArchWorkbench)
 
-# File format pref pages are independent and can be loaded at startup
+# Preference pages for importing and exporting various file formats
+# are independent of the loading of the workbench and can be loaded at startup
 import Arch_rc
-FreeCADGui.addPreferencePage(":/ui/preferences-ifc.ui","Import-Export")
-FreeCADGui.addPreferencePage(":/ui/preferences-dae.ui","Import-Export")
+from PySide.QtCore import QT_TRANSLATE_NOOP
+FreeCADGui.addPreferencePage(":/ui/preferences-ifc.ui", QT_TRANSLATE_NOOP("Draft", "Import-Export"))
+FreeCADGui.addPreferencePage(":/ui/preferences-dae.ui", QT_TRANSLATE_NOOP("Draft", "Import-Export"))
 
-FreeCAD.__unit_test__ += [ "TestArch" ]
+FreeCAD.__unit_test__ += ["TestArch"]

--- a/src/Mod/Arch/InitGui.py
+++ b/src/Mod/Arch/InitGui.py
@@ -95,47 +95,43 @@ class ArchWorkbench(FreeCADGui.Workbench):
             self.archtools[2] = "Arch_RebarTools"
 
         # Set up Draft command lists
-        self.drafttools = ["Draft_Line","Draft_Wire","Draft_Circle","Draft_Arc","Draft_Ellipse",
-                        "Draft_Polygon","Draft_Rectangle", "Draft_Text",
-                        "Draft_Dimension", "Draft_BSpline","Draft_Point",
-                        "Draft_Facebinder","Draft_BezCurve","Draft_Label"]
-        self.draftmodtools = ["Draft_Move","Draft_Rotate","Draft_Offset",
-                        "Draft_Trimex", "Draft_Upgrade", "Draft_Downgrade", "Draft_Scale",
-                        "Draft_Shape2DView","Draft_Draft2Sketch","Draft_Array",
-                        "Draft_Clone","Draft_Edit"]
-        self.draftextratools = ["Draft_WireToBSpline","Draft_AddPoint","Draft_DelPoint","Draft_ShapeString",
-                                "Draft_PathArray","Draft_Mirror","Draft_Stretch"]
-        self.draftcontexttools = ["Draft_ApplyStyle","Draft_ToggleDisplayMode","Draft_AddToGroup","Draft_AutoGroup",
-                            "Draft_SelectGroup","Draft_SelectPlane",
-                            "Draft_ShowSnapBar","Draft_ToggleGrid","Draft_UndoLine",
-                            "Draft_FinishLine","Draft_CloseLine"]
-        self.draftutils = ["Draft_Layer","Draft_Heal","Draft_FlipDimension",
-                           "Draft_ToggleConstructionMode","Draft_ToggleContinueMode","Draft_Edit",
-                           "Draft_Slope","Draft_SetWorkingPlaneProxy","Draft_AddConstruction"]
-        self.snapList = ['Draft_Snap_Lock','Draft_Snap_Midpoint','Draft_Snap_Perpendicular',
-                         'Draft_Snap_Grid','Draft_Snap_Intersection','Draft_Snap_Parallel',
-                         'Draft_Snap_Endpoint','Draft_Snap_Angle','Draft_Snap_Center',
-                         'Draft_Snap_Extension','Draft_Snap_Near','Draft_Snap_Ortho','Draft_Snap_Special',
-                         'Draft_Snap_Dimensions','Draft_Snap_WorkingPlane']
+        import draftutils.init_tools as it
+        self.draft_drawing_commands = it.get_draft_drawing_commands()
+        self.draft_annotation_commands = it.get_draft_annotation_commands()
+        self.draft_modification_commands = it.get_draft_modification_commands()
+        self.draft_context_commands = it.get_draft_context_commands()
+        self.draft_line_commands = it.get_draft_line_commands()
+        self.draft_utility_commands = it.get_draft_utility_commands()
 
+        # Set up toolbars
         self.appendToolbar(QT_TRANSLATE_NOOP("Workbench", "Arch tools"), self.archtools)
-        self.appendToolbar(QT_TRANSLATE_NOOP("Workbench", "Draft tools"), self.drafttools)
-        self.appendToolbar(QT_TRANSLATE_NOOP("Workbench", "Draft mod tools"), self.draftmodtools)
+        self.appendToolbar(QT_TRANSLATE_NOOP("Draft", "Draft creation tools"), self.draft_drawing_commands)
+        self.appendToolbar(QT_TRANSLATE_NOOP("Draft", "Draft annotation tools"), self.draft_annotation_commands)
+        self.appendToolbar(QT_TRANSLATE_NOOP("Draft", "Draft modification tools"), self.draft_modification_commands)
 
+        # Set up menus
         self.appendMenu([QT_TRANSLATE_NOOP("arch", "&Arch"),
                          QT_TRANSLATE_NOOP("arch", "Utilities")],
                         self.utilities)
         self.appendMenu(QT_TRANSLATE_NOOP("arch", "&Arch"), self.archtools)
-        self.appendMenu(QT_TRANSLATE_NOOP("arch", "&Draft"),
-                        self.drafttools + self.draftmodtools + self.draftextratools)
+
+        self.appendMenu([QT_TRANSLATE_NOOP("arch", "&Draft"),
+                         QT_TRANSLATE_NOOP("arch", "Creation")],
+                        self.draft_drawing_commands)
+        self.appendMenu([QT_TRANSLATE_NOOP("arch", "&Draft"),
+                         QT_TRANSLATE_NOOP("arch", "Annotation")],
+                        self.draft_annotation_commands)
+        self.appendMenu([QT_TRANSLATE_NOOP("arch", "&Draft"),
+                         QT_TRANSLATE_NOOP("arch", "Modification")],
+                        self.draft_modification_commands)
         self.appendMenu([QT_TRANSLATE_NOOP("arch", "&Draft"),
                          QT_TRANSLATE_NOOP("arch", "Utilities")],
-                        self.draftutils + self.draftcontexttools)
-        self.appendMenu([QT_TRANSLATE_NOOP("arch", "&Draft"),
-                         QT_TRANSLATE_NOOP("arch", "Snapping")], self.snapList)
+                        self.draft_utility_commands
+                        + self.draft_context_commands)
         FreeCADGui.addIconPath(":/icons")
         FreeCADGui.addLanguagePath(":/translations")
 
+        # Set up preferences pages
         if hasattr(FreeCADGui, "draftToolBar"):
             if not hasattr(FreeCADGui.draftToolBar, "loadedArchPreferences"):
                 FreeCADGui.addPreferencePage(":/ui/preferences-arch.ui", QT_TRANSLATE_NOOP("Arch", "Arch"))
@@ -147,7 +143,8 @@ class ArchWorkbench(FreeCADGui.Workbench):
                 FreeCADGui.addPreferencePage(":/ui/preferences-draftvisual.ui", QT_TRANSLATE_NOOP("Draft", "Draft"))
                 FreeCADGui.addPreferencePage(":/ui/preferences-drafttexts.ui", QT_TRANSLATE_NOOP("Draft", "Draft"))
                 FreeCADGui.draftToolBar.loadedPreferences = True
-        FreeCAD.Console.PrintLog('Loading Arch module, done\n')
+
+        FreeCAD.Console.PrintLog('Loading Arch workbench, done.\n')
 
     def Activated(self):
         """When entering the workbench."""
@@ -167,7 +164,7 @@ class ArchWorkbench(FreeCADGui.Workbench):
 
     def ContextMenu(self, recipient):
         """Define an optional custom context menu."""
-        self.appendContextMenu("Utilities", self.draftcontexttools)
+        self.appendContextMenu("Utilities", self.draft_context_commands)
 
     def GetClassName(self):
         """Type of workbench."""


### PR DESCRIPTION
Clean up a bit the initialization code of the workbench. Particularly explicitly importing the necessary modules, and setting of tools.

The Arch workbench is supposed to import the same tools from the Draft workbench. We import these tools from the same module defined in #2970 .

Forum thread: [Draft menus](https://forum.freecadweb.org/viewtopic.php?f=23&t=42670#p362943)

This pull request should be merged after #2970 is merged. When this happens, this request will create a conflict, so this pull request will have to be rebased onto the master branch, and then it will be able to be merged.

---

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists