### PR TITLE
Draft: grouping of the array commands

### DIFF
--- a/src/Mod/Arch/InitGui.py
+++ b/src/Mod/Arch/InitGui.py
@@ -51,6 +51,7 @@ class ArchWorkbench(FreeCADGui.Workbench):
         import DraftGui
         from draftguitools import gui_circulararray
         from draftguitools import gui_polararray
+        from draftguitools import gui_arrays
         import Arch_rc
         import Arch
 

--- a/src/Mod/Draft/CMakeLists.txt
+++ b/src/Mod/Draft/CMakeLists.txt
@@ -74,6 +74,7 @@ SET(Draft_GUI_tools
     draftguitools/gui_base.py
     draftguitools/gui_circulararray.py
     draftguitools/gui_polararray.py
+    draftguitools/gui_arrays.py
 )
 
 SET(Draft_task_panels

--- a/src/Mod/Draft/InitGui.py
+++ b/src/Mod/Draft/InitGui.py
@@ -82,6 +82,7 @@ class DraftWorkbench(FreeCADGui.Workbench):
             import DraftFillet
             from draftguitools import gui_circulararray
             from draftguitools import gui_polararray
+            from draftguitools import gui_arrays
             FreeCADGui.addLanguagePath(":/translations")
             FreeCADGui.addIconPath(":/icons")
         except Exception as exc:

--- a/src/Mod/Draft/draftguitools/gui_arrays.py
+++ b/src/Mod/Draft/draftguitools/gui_arrays.py
@@ -1,0 +1,56 @@
+"""Provide the Draft ArrayTools command to group the other array tools."""
+## @package gui_arrays
+# \ingroup DRAFT
+# \brief Provide the Draft ArrayTools command to group the other array tools.
+
+# ***************************************************************************
+# *   (c) 2020 Eliud Cabrera Castillo <e.cabrera-castillo@tum.de>           *
+# *                                                                         *
+# *   This file is part of the FreeCAD CAx development system.              *
+# *                                                                         *
+# *   This program is free software; you can redistribute it and/or modify  *
+# *   it under the terms of the GNU Lesser General Public License (LGPL)    *
+# *   as published by the Free Software Foundation; either version 2 of     *
+# *   the License, or (at your option) any later version.                   *
+# *   for detail see the LICENCE text file.                                 *
+# *                                                                         *
+# *   FreeCAD is distributed in the hope that it will be useful,            *
+# *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+# *   GNU Library General Public License for more details.                  *
+# *                                                                         *
+# *   You should have received a copy of the GNU Library General Public     *
+# *   License along with FreeCAD; if not, write to the Free Software        *
+# *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
+# *   USA                                                                   *
+# *                                                                         *
+# ***************************************************************************
+import FreeCAD as App
+import FreeCADGui as Gui
+from PySide.QtCore import QT_TRANSLATE_NOOP
+
+
+class ArrayGroupCommand:
+    """Gui command for the group of array tools."""
+
+    def GetCommands(self):
+        """Tuple of array commands."""
+        return tuple(["Draft_Array", "Draft_LinkArray",
+                      "Draft_PolarArray", "Draft_CircularArray",
+                      "Draft_PathArray", "Draft_PathLinkArray",
+                      "Draft_PointArray"])
+
+    def GetResources(self):
+        """Add menu and tooltip."""
+        _tooltip = ("Create various types of arrays, "
+                    "including rectangular, polar, circular, "
+                    "path, and point")
+        return {'MenuText': QT_TRANSLATE_NOOP("Draft", "Array tools"),
+                'ToolTip': QT_TRANSLATE_NOOP("Arch", _tooltip)}
+
+    def IsActive(self):
+        """Be active only when a document is active."""
+        return App.ActiveDocument is not None
+
+
+Gui.addCommand('Draft_ArrayTools', ArrayGroupCommand())

--- a/src/Mod/Draft/draftutils/init_tools.py
+++ b/src/Mod/Draft/draftutils/init_tools.py
@@ -54,11 +54,7 @@ def get_draft_annotation_commands():
 
 def get_draft_array_commands():
     """Return the array commands list."""
-    # After the array commands are grouped, return this
-    # return ["Draft_ArrayTools"]
-    return ["Draft_Array", "Draft_LinkArray",
-            "Draft_PolarArray", "Draft_CircularArray",
-            "Draft_PathArray", "Draft_PathLinkArray", "Draft_PointArray"]
+    return ["Draft_ArrayTools"]
 
 
 def get_draft_modification_commands():


### PR DESCRIPTION
The various Draft array tools (rectangular, polar, circular, path, point) are collected inside a command group to organize them and reduce the length of the toolbar.

Forum thread: [Making the creation of arrays more user friendly](https://forum.freecadweb.org/viewtopic.php?f=23&t=41816&p=364867#p364867)

This pull request should be merged after #2970 and #2971 are merged. When this happens, this request will create a conflict, so this pull request will have to be rebased onto the master branch, and then it will be able to be merged.

---

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists
