### PR TITLE
Draft: add README files to explain the new structure

### DIFF
--- a/src/Mod/Draft/draftguitools/README.md
+++ b/src/Mod/Draft/draftguitools/README.md
@@ -1,0 +1,13 @@
+2020 February
+
+These files define the GuiCommands, that is, actions called in a graphical
+way, either buttons, menu entries, or context commands.
+
+These tools should be split from the big `DraftTools.py` module.
+
+These tools are initialized by `InitGui.py`, and require the graphical
+interface to exist.
+
+Those commands that require a "task panel" call the respective module
+and class in `drafttaskpanels/`.
+

--- a/src/Mod/Draft/draftobjects/README.md
+++ b/src/Mod/Draft/draftobjects/README.md
@@ -1,0 +1,7 @@
+2020 February
+
+At the moment these object functions aren't used.
+
+When the Draft tools are eventually split into individual modules,
+the code of the object creation functions should be placed here.
+

--- a/src/Mod/Draft/drafttaskpanels/README.md
+++ b/src/Mod/Draft/drafttaskpanels/README.md
@@ -1,0 +1,13 @@
+2020 February
+
+These files provide the logic behind the task panel of the GuiCommands
+defined in `draftguitools/`.
+
+The task panel graphical interface is properly defined in
+the `Resources/ui/` files, which are made with QtCreator.
+
+There are many commands which aren't defined in `draftguitools/`.
+These are defined in the big `DraftGui.py` module, which needs to be split
+into individual GuiCommands, and each should have its own dedicated
+`.ui` file.
+

--- a/src/Mod/Draft/draftviewproviders/README.md
+++ b/src/Mod/Draft/draftviewproviders/README.md
@@ -1,0 +1,7 @@
+2020 February
+
+At the moment these view providers aren't used at all.
+
+When the Draft tools are eventually split into individual modules,
+the code of the view providers should be placed here.
+


### PR DESCRIPTION
Some README files that explain a bit what these directories are for, and what classes they use. In particular, the `draftguitools/` modules utilize the code in `drafttaskpanels/`, which in turn use the `.ui` files defined in `Resources/ui/`.

This is part of the big re-organization task of the workbench.

[[Discussion] Splitting Draft tools into their own modules](https://forum.freecadweb.org/viewtopic.php?f=23&t=38593)

---

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists