### PR TITLE
Draft: lowercase use_link option for arrays

### DIFF
--- a/src/Mod/Draft/Draft.py
+++ b/src/Mod/Draft/Draft.py
@@ -688,7 +688,7 @@ def makeBlock(objectslist):
         select(obj)
     return obj
 
-def makeArray(baseobject,arg1,arg2,arg3,arg4=None,arg5=None,arg6=None,name="Array",useLink=False):
+def makeArray(baseobject,arg1,arg2,arg3,arg4=None,arg5=None,arg6=None,name="Array",use_link=False):
     """makeArray(object,xvector,yvector,xnum,ynum,[name]) for rectangular array, or
     makeArray(object,xvector,yvector,zvector,xnum,ynum,znum,[name]) for rectangular array, or
     makeArray(object,center,totalangle,totalnum,[name]) for polar array, or
@@ -707,7 +707,7 @@ def makeArray(baseobject,arg1,arg2,arg3,arg4=None,arg5=None,arg6=None,name="Arra
     if not FreeCAD.ActiveDocument:
         FreeCAD.Console.PrintError("No active document. Aborting\n")
         return
-    if useLink:
+    if use_link:
         obj = FreeCAD.ActiveDocument.addObject("Part::FeaturePython",name,_Array(None),None,True)
     else:
         obj = FreeCAD.ActiveDocument.addObject("Part::FeaturePython",name)
@@ -742,7 +742,7 @@ def makeArray(baseobject,arg1,arg2,arg3,arg4=None,arg5=None,arg6=None,name="Arra
         obj.Angle = arg2
         obj.NumberPolar = arg3
     if gui:
-        if useLink:
+        if use_link:
             _ViewProviderDraftLink(obj.ViewObject)
         else:
             _ViewProviderDraftArray(obj.ViewObject)
@@ -753,8 +753,8 @@ def makeArray(baseobject,arg1,arg2,arg3,arg4=None,arg5=None,arg6=None,name="Arra
         select(obj)
     return obj
 
-def makePathArray(baseobject,pathobject,count,xlate=None,align=False,pathobjsubs=[],useLink=False):
-    """makePathArray(docobj,path,count,xlate,align,pathobjsubs,useLink): distribute
+def makePathArray(baseobject,pathobject,count,xlate=None,align=False,pathobjsubs=[],use_link=False):
+    """makePathArray(docobj,path,count,xlate,align,pathobjsubs,use_link): distribute
     count copies of a document baseobject along a pathobject or subobjects of a
     pathobject. Optionally translates each copy by FreeCAD.Vector xlate direction
     and distance to adjust for difference in shape centre vs shape reference point.
@@ -762,7 +762,7 @@ def makePathArray(baseobject,pathobject,count,xlate=None,align=False,pathobjsubs
     if not FreeCAD.ActiveDocument:
         FreeCAD.Console.PrintError("No active document. Aborting\n")
         return
-    if useLink:
+    if use_link:
         obj = FreeCAD.ActiveDocument.addObject("Part::FeaturePython","PathArray",_PathArray(None),None,True)
     else:
         obj = FreeCAD.ActiveDocument.addObject("Part::FeaturePython","PathArray")
@@ -780,7 +780,7 @@ def makePathArray(baseobject,pathobject,count,xlate=None,align=False,pathobjsubs
         obj.Xlate = xlate
     obj.Align = align
     if gui:
-        if useLink:
+        if use_link:
             _ViewProviderDraftLink(obj.ViewObject)
         else:
             _ViewProviderDraftArray(obj.ViewObject)
@@ -5146,7 +5146,7 @@ class _Shape2DView(_DraftObject):
 class _DraftLink(_DraftObject):
 
     def __init__(self,obj,tp):
-        self.useLink = False if obj else True
+        self.use_link = False if obj else True
         _DraftObject.__init__(self,obj,tp)
         if obj:
             self.attach(obj)
@@ -5158,11 +5158,11 @@ class _DraftLink(_DraftObject):
         if isinstance(state,dict):
             self.__dict__ = state
         else:
-            self.useLink = False
+            self.use_link = False
             _DraftObject.__setstate__(self,state)
 
     def attach(self,obj):
-        if self.useLink:
+        if self.use_link:
             obj.addExtension('App::LinkExtensionPython', None)
             self.linkSetup(obj)
 
@@ -5195,12 +5195,30 @@ class _DraftLink(_DraftObject):
         obj.configLinkProperty('LinkTransform','ColoredElements')
 
     def getViewProviderName(self,_obj):
-        if self.useLink:
+        if self.use_link:
             return 'Gui::ViewProviderLinkPython'
         return ''
 
+    def migrate_attributes(self, obj):
+        """Migrate old attribute names to new names if they exist.
+
+        This is done to comply with Python guidelines or fix small issues
+        in older code.
+        """
+        if hasattr(self, "useLink"):
+            # This is only needed for some models created in 0.19
+            # while it was in development. Afterwards,
+            # all models should use 'use_link' by default
+            # and this won't be run.
+            self.use_link = bool(self.useLink)
+            FreeCAD.Console.PrintWarning("Migrating 'useLink' to 'use_link', "
+                                         "{} ({})\n".format(obj.Label,
+                                                            obj.TypeId))
+            del self.useLink
+
     def onDocumentRestored(self, obj):
-        if self.useLink:
+        self.migrate_attributes(obj)
+        if self.use_link:
             self.linkSetup(obj)
         else:
             obj.setPropertyStatus('Shape','-Transient')
@@ -5214,7 +5232,7 @@ class _DraftLink(_DraftObject):
         import Part
         import DraftGeomUtils
 
-        if self.useLink:
+        if self.use_link:
             if not getattr(obj,'ExpandArray',True) or obj.Count != len(pls):
                 obj.setPropertyStatus('PlacementList','-Immutable')
                 obj.PlacementList = pls
@@ -5244,11 +5262,11 @@ class _DraftLink(_DraftObject):
                 if not DraftGeomUtils.isNull(pl):
                     obj.Placement = pl
 
-        if self.useLink:
+        if self.use_link:
             return False # return False to call LinkExtension::execute()
 
     def onChanged(self, obj, prop):
-        if not getattr(self,'useLink',False):
+        if not getattr(self,'use_link',False):
             return
         if prop == 'Fuse':
             if obj.Fuse:
@@ -5287,7 +5305,7 @@ class _Array(_DraftLink):
         obj.addProperty("App::PropertyInteger","Symmetry","Draft",QT_TRANSLATE_NOOP("App::Property","number of circles"))
         obj.addProperty("App::PropertyBool","Fuse","Draft",QT_TRANSLATE_NOOP("App::Property","Specifies if copies must be fused (slower)"))
         obj.Fuse = False
-        if self.useLink:
+        if self.use_link:
             obj.addProperty("App::PropertyInteger","Count","Draft",'')
             obj.addProperty("App::PropertyBool","ExpandArray","Draft",
                     QT_TRANSLATE_NOOP("App::Property","Show array element as children object"))
@@ -5421,7 +5439,7 @@ class _PathArray(_DraftLink):
         obj.Xlate = FreeCAD.Vector(0,0,0)
         obj.Align = False
 
-        if self.useLink:
+        if self.use_link:
             obj.addProperty("App::PropertyBool","ExpandArray","Draft",
                     QT_TRANSLATE_NOOP("App::Property","Show array element as children object"))
             obj.ExpandArray = False

--- a/src/Mod/Draft/DraftTools.py
+++ b/src/Mod/Draft/DraftTools.py
@@ -4635,9 +4635,9 @@ class Draft2Sketch(Modifier):
 class Array(Modifier):
     """The Shape2DView FreeCAD command definition"""
 
-    def __init__(self,useLink=False):
+    def __init__(self,use_link=False):
         Modifier.__init__(self)
-        self.useLink = useLink
+        self.use_link = use_link
 
     def GetResources(self):
         return {'Pixmap'  : 'Draft_Array',
@@ -4661,7 +4661,7 @@ class Array(Modifier):
             obj = FreeCADGui.Selection.getSelection()[0]
             FreeCADGui.addModule("Draft")
             self.commit(translate("draft","Array"),
-                        ['obj = Draft.makeArray(FreeCAD.ActiveDocument.{},FreeCAD.Vector(1,0,0),FreeCAD.Vector(0,1,0),2,2,useLink={})'.format(obj.Name,self.useLink),
+                        ['obj = Draft.makeArray(FreeCAD.ActiveDocument.{},FreeCAD.Vector(1,0,0),FreeCAD.Vector(0,1,0),2,2,use_link={})'.format(obj.Name,self.use_link),
                          'Draft.autogroup(obj)',
                          'FreeCAD.ActiveDocument.recompute()'])
         self.finish()
@@ -4680,9 +4680,9 @@ class LinkArray(Array):
 class PathArray(Modifier):
     """The PathArray FreeCAD command definition"""
 
-    def __init__(self,useLink=False):
+    def __init__(self,use_link=False):
         Modifier.__init__(self)
-        self.useLink = useLink
+        self.use_link = use_link
 
     def GetResources(self):
         return {'Pixmap'  : 'Draft_PathArray',
@@ -4712,7 +4712,7 @@ class PathArray(Modifier):
             defCount = 4
             defAlign = False
             FreeCAD.ActiveDocument.openTransaction("PathArray")
-            Draft.makePathArray(base,path,defCount,defXlate,defAlign,pathsubs,useLink=self.useLink)
+            Draft.makePathArray(base,path,defCount,defXlate,defAlign,pathsubs,use_link=self.use_link)
             FreeCAD.ActiveDocument.commitTransaction()
             FreeCAD.ActiveDocument.recompute()                                  # feature won't appear until recompute.
         self.finish()

--- a/src/Mod/Draft/draftobjects/circulararray.py
+++ b/src/Mod/Draft/draftobjects/circulararray.py
@@ -41,5 +41,5 @@ def make_circular_array(obj,
     obj = Draft.makeArray(obj,
                           arg1=r_distance, arg2=tan_distance,
                           arg3=axis, arg4=center, arg5=number, arg6=symmetry,
-                          useLink=use_link)
+                          use_link=use_link)
     return obj

--- a/src/Mod/Draft/draftobjects/orthoarray.py
+++ b/src/Mod/Draft/draftobjects/orthoarray.py
@@ -42,7 +42,7 @@ def make_ortho_array(obj,
     obj = Draft.makeArray(obj,
                           arg1=v_x, arg2=v_y, arg3=v_z,
                           arg4=n_x, arg5=n_y, arg6=n_z,
-                          useLink=use_link)
+                          use_link=use_link)
     return obj
 
 
@@ -56,5 +56,5 @@ def make_ortho_array2(obj,
     obj = Draft.makeArray(obj,
                           arg1=v_x, arg2=v_y,
                           arg3=n_x, arg4=n_y,
-                          useLink=use_link)
+                          use_link=use_link)
     return obj

--- a/src/Mod/Draft/draftobjects/polararray.py
+++ b/src/Mod/Draft/draftobjects/polararray.py
@@ -38,5 +38,5 @@ def make_polar_array(obj,
     """
     obj = Draft.makeArray(obj,
                           arg1=center, arg2=angle, arg3=number,
-                          useLink=use_link)
+                          use_link=use_link)
     return obj

--- a/src/Mod/Draft/drafttaskpanels/task_circulararray.py
+++ b/src/Mod/Draft/drafttaskpanels/task_circulararray.py
@@ -218,7 +218,8 @@ class TaskPanelCircularArray:
         _cmd += "arg4=" + DraftVecUtils.toString(self.center) + ", "
         _cmd += "arg5=" + str(self.number) + ", "
         _cmd += "arg6=" + str(self.symmetry) + ", "
-        _cmd += "useLink=" + str(self.use_link) + ")"
+        _cmd += "use_link=" + str(self.use_link)
+        _cmd += ")"
 
         _cmd_list = ["FreeCADGui.addModule('Draft')",
                      _cmd,

--- a/src/Mod/Draft/drafttaskpanels/task_orthoarray.py
+++ b/src/Mod/Draft/drafttaskpanels/task_orthoarray.py
@@ -209,7 +209,7 @@ class TaskPanelOrthoArray:
         _cmd += "arg4=" + str(self.n_X) + ", "
         _cmd += "arg5=" + str(self.n_Y) + ", "
         _cmd += "arg6=" + str(self.n_Z) + ", "
-        _cmd += "useLink=" + str(self.use_link)
+        _cmd += "use_link=" + str(self.use_link)
         _cmd += ")"
 
         _cmd_list = ["FreeCADGui.addModule('Draft')",

--- a/src/Mod/Draft/drafttaskpanels/task_polararray.py
+++ b/src/Mod/Draft/drafttaskpanels/task_polararray.py
@@ -195,7 +195,8 @@ class TaskPanelPolarArray:
         _cmd += "arg1=" + DraftVecUtils.toString(self.center) + ", "
         _cmd += "arg2=" + str(self.angle) + ", "
         _cmd += "arg3=" + str(self.number) + ", "
-        _cmd += "useLink=" + str(self.use_link) + ")"
+        _cmd += "use_link=" + str(self.use_link)
+        _cmd += ")"
 
         _cmd_list = ["FreeCADGui.addModule('Draft')",
                      _cmd,


### PR DESCRIPTION
For the functions that create arrays (`makeArray`), we prefer to use Python-style naming conventions so the parameter `useLink` is renamed to `use_link`. We also make this change in the Gui Commands that use this parameter, meaning, `Draft_PolarArray`, `Draft_CircularArray`, `Draft_PathLinkArray`, and the new `Draft_OrthoArray`.

We don't risk breaking 0.18 code because the `App::Link` object and the Link arrays were introduced in the middle of 0.19. We could only break code that was developed in the middle of 0.19, but this is easy to correct manually.

The old `Array` objects have an attribute called `useLink` which we also rename to `use_link`. Inside the class `_DraftLink` the `onDocumentRestored` function tests for the existence of this old attribute `useLink` (a boolean). If it is present, it creates a new boolean, `use_link`. Then the old `useLink` is deleted so it is not longer saved when the document is saved. This effectively migrates the code from an older name to a newer name. Again, this should only affect model files created from the LinkMerge until now, or about 6 months.

This pull request should be merged after #2988 is merged because the change also affects the newly introduced command `Draft_OrthoArray`. When this happens, this request will create a conflict, so this pull request will have to be rebased onto the master branch, and then it will be able to be merged.

Forum thread: [Making the creation of arrays more user friendly](https://forum.freecadweb.org/viewtopic.php?f=23&t=41816&p=365888#p365888)

---

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists
