### PR TITLE
[Arch]Window Options value changes

### DIFF
--- a/src/Mod/Arch/ArchWindow.py
+++ b/src/Mod/Arch/ArchWindow.py
@@ -27,6 +27,7 @@ if FreeCAD.GuiUp:
     from PySide import QtCore, QtGui, QtSvg
     from DraftTools import translate
     from PySide.QtCore import QT_TRANSLATE_NOOP
+    import WheelFilter 
 else:
     # \cond
     def translate(ctxt,txt):
@@ -575,8 +576,6 @@ def makeWindowPreset(windowtype,width,height,h1,h2,h3,w1,w2,o1,o2,placement=None
 
     print("Arch: Unknown window type")
 
-
-
 class _CommandWindow:
 
     "the Arch Window command definition"
@@ -762,10 +761,10 @@ class _CommandWindow:
         # sill height
         labels = QtGui.QLabel(translate("Arch","Sill height"))
         values = ui.createWidget("Gui::InputField")
+        WheelFilter.WheelFilter(values)
         grid.addWidget(labels,1,0,1,1)
         grid.addWidget(values,1,1,1,1)
         QtCore.QObject.connect(values,QtCore.SIGNAL("valueChanged(double)"),self.setSill)
-
         # check for Parts library
         self.librarypresets = []
         librarypath = FreeCAD.ParamGet('User parameter:Plugins/parts_library').GetString('destination','')
@@ -791,6 +790,9 @@ class _CommandWindow:
         valuep.setSizeAdjustPolicy(QtGui.QComboBox.AdjustToContents)
         valuep.addItems(WindowPresets)
         valuep.setCurrentIndex(self.Preset)
+
+        WheelFilter.WheelFilter(valuep)
+
         grid.addWidget(labelp,2,0,1,1)
         grid.addWidget(valuep,2,1,1,1)
         QtCore.QObject.connect(valuep,QtCore.SIGNAL("currentIndexChanged(int)"),self.setPreset)
@@ -816,6 +818,7 @@ class _CommandWindow:
             lab = QtGui.QLabel(translate("Arch",param))
             setattr(self,"val"+param,ui.createWidget("Gui::InputField"))
             wid = getattr(self,"val"+param)
+            WheelFilter.WheelFilter(wid)
             if param == "Width":
                 wid.setText(FreeCAD.Units.Quantity(self.Width,FreeCAD.Units.Length).UserString)
             elif param == "Height":

--- a/src/Mod/Arch/CMakeLists.txt
+++ b/src/Mod/Arch/CMakeLists.txt
@@ -51,6 +51,7 @@ SET(Arch_SRCS
     ArchFence.py
     OfflineRenderingUtils.py
     exportIFC.py
+    WheelFilter.py
 )
 
 SET(Dice3DS_SRCS

--- a/src/Mod/Arch/WheelFilter.py
+++ b/src/Mod/Arch/WheelFilter.py
@@ -1,0 +1,46 @@
+#***************************************************************************
+#*   Copyright (c) 2020 WandererFan <wandererfan@gmail.com>                *
+#*                                                                         *
+#*   This program is free software; you can redistribute it and/or modify  *
+#*   it under the terms of the GNU Lesser General Public License (LGPL)    *
+#*   as published by the Free Software Foundation; either version 2 of     *
+#*   the License, or (at your option) any later version.                   *
+#*   for detail see the LICENCE text file.                                 *
+#*                                                                         *
+#*   This program is distributed in the hope that it will be useful,       *
+#*   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+#*   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+#*   GNU Library General Public License for more details.                  *
+#*                                                                         *
+#*   You should have received a copy of the GNU Library General Public     *
+#*   License along with this program; if not, write to the Free Software   *
+#*   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
+#*   USA                                                                   *
+#*                                                                         *
+#***************************************************************************
+
+from PySide import QtCore
+
+class WheelFilter(QtCore.QObject):
+    '''WheelFilter(widget) - prevent widget from changing value when cursor/mouse wheel scrolls through widget's
+    screen area.  Usage:  myWidget = QtGui.QComboBox() , WheelFilter(myWidget)'''
+
+    def __init__(self, widget):
+        super().__init__(widget)
+        self.widget = widget
+        self.savePolicy = self.widget.focusPolicy()
+        self.widget.installEventFilter(self)
+        self.widget.setFocusPolicy(QtCore.Qt.StrongFocus)
+
+    def eventFilter(self, object, event):
+        if event.type() == QtCore.QEvent.Type.Wheel:
+            if object == self.widget:
+                if not self.widget.hasFocus():
+                    return True;                     #skip this event
+        return super(WheelFilter, self).eventFilter(object, event)
+
+    def removeFilter(self):
+        '''clear the event filter from a QObject(QWidget).  Usage:  WheelFilter.removeFilter(myWidget)'''
+        print("removing filter!")
+        self.widget.removeEventFilter(self)
+        self.widget.setFocusPolicy(self.savePolicy) 


### PR DESCRIPTION
- when scrolling through the Window Options in ArchWindow,
  the Sill Height, Width, etc parameters change without
  the widgets having focus.
- Add eventFilter to prevent update on wheel event without
  focus.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
