### PR TITLE
Draft: disable the excessive output in the ToDo class

### DIFF
--- a/src/Mod/Draft/draftutils/todo.py
+++ b/src/Mod/Draft/draftutils/todo.py
@@ -43,6 +43,8 @@ __title__ = "FreeCAD Draft Workbench, Todo class"
 __author__ = "Yorik van Havre <yorik@uncreated.net>"
 __url__ = ["http://www.freecadweb.org"]
 
+_DEBUG = 0
+
 
 class ToDo:
     """A static class that delays execution of functions.
@@ -100,6 +102,7 @@ class ToDo:
     a string to identify the operation, and a `command_list` which is
     a list of strings, each string an individual Python instruction.
     """
+
     itinerary = []
     commitlist = []
     afteritinerary = []
@@ -110,12 +113,13 @@ class ToDo:
 
         The lists are `itinerary`, `commitlist` and `afteritinerary`.
         """
-        print("Debug: doing delayed tasks.\n"
-              "itinerary: {0}\n"
-              "commitlist: {1}\n"
-              "afteritinerary: {2}\n".format(todo.itinerary,
-                                             todo.commitlist,
-                                             todo.afteritinerary))
+        if _DEBUG:
+            print("Debug: doing delayed tasks.\n"
+                  "itinerary: {0}\n"
+                  "commitlist: {1}\n"
+                  "afteritinerary: {2}\n".format(todo.itinerary,
+                                                 todo.commitlist,
+                                                 todo.afteritinerary))
         try:
             for f, arg in todo.itinerary:
                 try:


### PR DESCRIPTION
During refactoring of the classes (#2831) the print statement was useful to observe the output of the commands. Now we disable it, but we can reactivate it with a variable.

In my opinion, this pull request should be merged instead of #2987, as this is a more complete solution.

Forum thread: [Message of debug when open Arch/Bim WB](https://forum.freecadweb.org/viewtopic.php?p=365865#p365865)

---

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists
