### PR TITLE
Draft: standardized module to build messages

### DIFF
--- a/src/Mod/Draft/CMakeLists.txt
+++ b/src/Mod/Draft/CMakeLists.txt
@@ -53,6 +53,7 @@ SET(Draft_utilities
     draftutils/gui_utils.py
     draftutils/todo.py
     draftutils/translate.py
+    draftutils/messages.py
 )
 
 SET(Draft_objects

--- a/src/Mod/Draft/draftutils/messages.py
+++ b/src/Mod/Draft/draftutils/messages.py
@@ -1,0 +1,49 @@
+"""Provide message utility functions for the Draft Workbench."""
+## @package messages
+# \ingroup DRAFT
+# \brief Provide message utility functions for the Draft Workbench.
+
+# ***************************************************************************
+# *   (c) 2020 Eliud Cabrera Castillo <e.cabrera-castillo@tum.de>           *
+# *                                                                         *
+# *   This file is part of the FreeCAD CAx development system.              *
+# *                                                                         *
+# *   This program is free software; you can redistribute it and/or modify  *
+# *   it under the terms of the GNU Lesser General Public License (LGPL)    *
+# *   as published by the Free Software Foundation; either version 2 of     *
+# *   the License, or (at your option) any later version.                   *
+# *   for detail see the LICENCE text file.                                 *
+# *                                                                         *
+# *   FreeCAD is distributed in the hope that it will be useful,            *
+# *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+# *   GNU Library General Public License for more details.                  *
+# *                                                                         *
+# *   You should have received a copy of the GNU Library General Public     *
+# *   License along with FreeCAD; if not, write to the Free Software        *
+# *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
+# *   USA                                                                   *
+# *                                                                         *
+# ***************************************************************************
+
+import FreeCAD as App
+
+
+def _msg(text, end="\n"):
+    """Write messages to console including the line ending."""
+    App.Console.PrintMessage(text + end)
+
+
+def _wrn(text, end="\n"):
+    """Write warnings to console including the line ending."""
+    App.Console.PrintWarning(text + end)
+
+
+def _err(text, end="\n"):
+    """Write errors to console including the line ending."""
+    App.Console.PrintError(text + end)
+
+
+def _log(text, end="\n"):
+    """Write messages to the log file including the line ending."""
+    App.Console.PrintLog(text + end)


### PR DESCRIPTION
Instead of using the long `FreeCAD.Console` commands like `FreeCAD.Console.PrintMessage` we encapsulate these inside a module so the printing functions can be imported and used in Draft, and any other workbench if we wish. These new functions also include a newline `\n` character by default so it doesn't have to be added explicitly like with the old `Console` functions.

Together with the short translation commands in #3002, the messages can be set for translation with the `'Draft'` context like this:
```py
from drafutils.translate import _tr
from drafutils.messages import _msg

_msg("Just a message, no translation")
_msg(_tr("This message will be translated with the context set to 'Draft'"))
```

---

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists