### PR TITLE
Draft: improved and additional unit tests

### DIFF
--- a/src/Mod/Draft/CMakeLists.txt
+++ b/src/Mod/Draft/CMakeLists.txt
@@ -45,6 +45,7 @@ SET(Draft_tests
     drafttests/test_dwg.py
     drafttests/test_oca.py
     drafttests/test_airfoildat.py
+    drafttests/draft_test_objects.py
 )
 
 SET(Draft_utilities

--- a/src/Mod/Draft/drafttests/auxiliary.py
+++ b/src/Mod/Draft/drafttests/auxiliary.py
@@ -1,5 +1,3 @@
-"""Auxiliary functions for the unit tests of the Draft Workbench.
-"""
 # ***************************************************************************
 # *   Copyright (c) 2013 Yorik van Havre <yorik@uncreated.net>              *
 # *   Copyright (c) 2019 Eliud Cabrera Castillo <e.cabrera-castillo@tum.de> *
@@ -23,38 +21,32 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
+"""Auxiliary functions for the unit tests of the Draft Workbench."""
 
-import FreeCAD as App
-
-
-def _msg(text, end="\n"):
-    App.Console.PrintMessage(text + end)
-
-
-def _wrn(text, end="\n"):
-    App.Console.PrintWarning(text + end)
-
-
-def _log(text, end="\n"):
-    App.Console.PrintLog(text + end)
+import traceback
+from draftutils.messages import _msg
 
 
 def _draw_header():
+    """Draw a header for the tests."""
     _msg("")
     _msg(78*"-")
 
 
 def _import_test(module):
+    """Try importing a module."""
     _msg("  Try importing '{}'".format(module))
     try:
         imported = __import__("{}".format(module))
     except ImportError as exc:
         imported = False
         _msg("  {}".format(exc))
+        _msg(traceback.format_exc())
     return imported
 
 
 def _no_gui(module):
+    """Print a message that there is no user interface."""
     _msg("  #-----------------------------------------------------#\n"
          "  #    No GUI; cannot test for '{}'\n"
          "  #-----------------------------------------------------#\n"
@@ -62,6 +54,7 @@ def _no_gui(module):
 
 
 def _no_test():
+    """Print a message that the test is not currently implemented."""
     _msg("  #-----------------------------------------------------#\n"
          "  #    This test is not implemented currently\n"
          "  #-----------------------------------------------------#\n"
@@ -69,6 +62,7 @@ def _no_test():
 
 
 def _fake_function(p1=None, p2=None, p3=None, p4=None, p5=None):
+    """Print a message for a test that doesn't actually exist."""
     _msg("  Arguments to placeholder function")
     _msg("  p1={0}; p2={1}".format(p1, p2))
     _msg("  p3={0}; p4={1}".format(p3, p4))

--- a/src/Mod/Draft/drafttests/draft_test_objects.py
+++ b/src/Mod/Draft/drafttests/draft_test_objects.py
@@ -1,0 +1,597 @@
+"""Run this file to create a standard test document for Draft objects.
+
+Use as input to the freecad executable.
+    freecad draft_test_objects.py
+
+Or load it as a module and use the defined function.
+    import drafttests.draft_test_objects as dt
+    dt.create_test_file()
+"""
+# ***************************************************************************
+# *   (c) 2020 Eliud Cabrera Castillo <e.cabrera-castillo@tum.de>           *
+# *                                                                         *
+# *   This file is part of the FreeCAD CAx development system.              *
+# *                                                                         *
+# *   This program is free software; you can redistribute it and/or modify  *
+# *   it under the terms of the GNU Lesser General Public License (LGPL)    *
+# *   as published by the Free Software Foundation; either version 2 of     *
+# *   the License, or (at your option) any later version.                   *
+# *   for detail see the LICENCE text file.                                 *
+# *                                                                         *
+# *   FreeCAD is distributed in the hope that it will be useful,            *
+# *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+# *   GNU Library General Public License for more details.                  *
+# *                                                                         *
+# *   You should have received a copy of the GNU Library General Public     *
+# *   License along with FreeCAD; if not, write to the Free Software        *
+# *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
+# *   USA                                                                   *
+# *                                                                         *
+# ***************************************************************************
+import os
+import datetime
+import math
+import FreeCAD as App
+from FreeCAD import Vector
+import Draft
+from draftutils.messages import _msg, _wrn
+import draftobjects.arc_3points
+
+if App.GuiUp:
+    import DraftFillet
+    import FreeCADGui as Gui
+
+
+def _set_text(obj):
+    """Set properties of text object."""
+    if App.GuiUp:
+        obj.ViewObject.FontSize = 75
+
+
+def create_frame():
+    """Draw a frame with information on the version of the software.
+
+    It includes the date created, the version, the release type,
+    and the branch.
+    """
+    version = App.Version()
+    now = datetime.datetime.now().strftime("%Y/%m/%dT%H:%M:%S")
+
+    record = Draft.makeText(["Draft test file",
+                             "Created: {}".format(now),
+                             "\n",
+                             "Version: " + ".".join(version[0:3]),
+                             "Release: " + " ".join(version[3:5]),
+                             "Branch: " + " ".join(version[5:])],
+                            Vector(0, -1000, 0))
+
+    if App.GuiUp:
+        record.ViewObject.FontSize = 400
+
+    frame = Draft.makeRectangle(21000, 12000)
+    frame.Placement.Base = Vector(-1000, -3500)
+
+
+def create_test_file(file_name="draft_test_objects",
+                     font_file="/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
+                     file_path="",
+                     save=False):
+    """Create a complete test file of Draft objects.
+
+    It draws a frame with information on the software used to create
+    the test document, and fills it with every object that can be created.
+
+    Parameters
+    ----------
+    file_name: str, optional
+        It defaults to `'draft_test_objects'`.
+        It is the name of document that is created.
+
+    font_file: str, optional
+        It defaults to `"/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf"`.
+        It is the full path of a font in the system to be used
+        with `Draft_ShapeString`.
+        If the font is not found, this object is not created.
+
+    file_path: str, optional
+        It defaults to the empty string `''`, in which case,
+        it will use the value returned by `App.getUserAppDataDir()`,
+        for example, `'/home/user/.FreeCAD/'`.
+
+        The `file_name` will be appended to `file_path`
+        to determine the actual path to save. The extension `.FCStd`
+        will be added automatically.
+
+    save: bool, optional
+        It defaults to `False`. If it is `True` the new document
+        will be saved to disk after creating all objects.
+    """
+    doc = App.newDocument(file_name)
+    _msg(16 * "-")
+    _msg("Filename: {}".format(file_name))
+    _msg("If the units tests fail, this script may fail as well")
+
+    create_frame()
+
+    # Line, wire, and fillet
+    _msg(16 * "-")
+    _msg("Line")
+    Draft.makeLine(Vector(0, 0, 0), Vector(500, 500, 0))
+    t_xpos = -50
+    t_ypos = -200
+    _t = Draft.makeText(["Line"], Vector(t_xpos, t_ypos, 0))
+    _set_text(_t)
+
+    _msg(16 * "-")
+    _msg("Wire")
+    Draft.makeWire([Vector(500, 0, 0),
+                    Vector(1000, 500, 0),
+                    Vector(1000, 1000, 0)])
+    t_xpos += 500
+    _t = Draft.makeText(["Wire"], Vector(t_xpos, t_ypos, 0))
+    _set_text(_t)
+
+    _msg(16 * "-")
+    _msg("Fillet")
+    line_h_1 = Draft.makeLine(Vector(1500, 0, 0), Vector(1500, 500, 0))
+    line_h_2 = Draft.makeLine(Vector(1500, 500, 0), Vector(2000, 500, 0))
+    if App.GuiUp:
+        line_h_1.ViewObject.DrawStyle = "Dotted"
+        line_h_2.ViewObject.DrawStyle = "Dotted"
+    App.ActiveDocument.recompute()
+
+    try:
+        DraftFillet.makeFillet([line_h_1, line_h_2], 400)
+    except Exception:
+        _wrn("Fillet could not be created")
+        _wrn("Possible cause: at this moment it may need the interface")
+        rect = Draft.makeRectangle(500, 100)
+        rect.Placement.Base = Vector(14000, 500)
+
+    t_xpos += 900
+    _t = Draft.makeText(["Fillet"], Vector(t_xpos, t_ypos, 0))
+    _set_text(_t)
+
+    # Circle, arc, arc by 3 points
+    _msg(16 * "-")
+    _msg("Circle")
+    circle = Draft.makeCircle(350)
+    circle.Placement.Base = Vector(2500, 500, 0)
+    t_xpos += 1050
+    _t = Draft.makeText(["Circle"], Vector(t_xpos, t_ypos, 0))
+    _set_text(_t)
+
+    _msg(16 * "-")
+    _msg("Circular arc")
+    arc = Draft.makeCircle(350, startangle=0, endangle=100)
+    arc.Placement.Base = Vector(3200, 500, 0)
+    t_xpos += 800
+    _t = Draft.makeText(["Circular arc"], Vector(t_xpos, t_ypos, 0))
+    _set_text(_t)
+
+    _msg(16 * "-")
+    _msg("Circular arc 3 points")
+    draftobjects.arc_3points.make_arc_3points([Vector(4600, 0, 0),
+                                               Vector(4600, 800, 0),
+                                               Vector(4000, 1000, 0)])
+    t_xpos += 600
+    _t = Draft.makeText(["Circular arc 3 points"], Vector(t_xpos, t_ypos, 0))
+    _set_text(_t)
+
+    # Ellipse, polygon, rectangle
+    _msg(16 * "-")
+    _msg("Ellipse")
+    ellipse = Draft.makeEllipse(500, 300)
+    ellipse.Placement.Base = Vector(5500, 250, 0)
+    t_xpos += 1600
+    _t = Draft.makeText(["Ellipse"], Vector(t_xpos, t_ypos, 0))
+    _set_text(_t)
+
+    _msg(16 * "-")
+    _msg("Polygon")
+    polygon = Draft.makePolygon(5, 250)
+    polygon.Placement.Base = Vector(6500, 500, 0)
+    t_xpos += 950
+    _t = Draft.makeText(["Polygon"], Vector(t_xpos, t_ypos, 0))
+    _set_text(_t)
+
+    _msg(16 * "-")
+    _msg("Rectangle")
+    rectangle = Draft.makeRectangle(500, 1000, 0)
+    rectangle.Placement.Base = Vector(7000, 0, 0)
+    t_xpos += 650
+    _t = Draft.makeText(["Rectangle"], Vector(t_xpos, t_ypos, 0))
+    _set_text(_t)
+
+    # Text
+    _msg(16 * "-")
+    _msg("Text")
+    text = Draft.makeText(["Testing"], Vector(7700, 500, 0))
+    if App.GuiUp:
+        text.ViewObject.FontSize = 100
+    t_xpos += 700
+    _t = Draft.makeText(["Text"], Vector(t_xpos, t_ypos, 0))
+    _set_text(_t)
+
+    # Linear dimension
+    _msg(16 * "-")
+    _msg("Linear dimension")
+    dimension = Draft.makeDimension(Vector(8500, 500, 0),
+                                    Vector(8500, 1000, 0),
+                                    Vector(9000, 750, 0))
+    if App.GuiUp:
+        dimension.ViewObject.ArrowSize = 15
+        dimension.ViewObject.ExtLines = 1000
+        dimension.ViewObject.ExtOvershoot = 100
+        dimension.ViewObject.FontSize = 100
+        dimension.ViewObject.ShowUnit = False
+    t_xpos += 680
+    _t = Draft.makeText(["Dimension"], Vector(t_xpos, t_ypos, 0))
+    _set_text(_t)
+
+    # Radius and diameter dimension
+    _msg(16 * "-")
+    _msg("Radius and diameter dimension")
+    arc_h = Draft.makeCircle(500, startangle=0, endangle=90)
+    arc_h.Placement.Base = Vector(9500, 0, 0)
+    App.ActiveDocument.recompute()
+
+    dimension_r = Draft.makeDimension(arc_h, 0, "radius",
+                                      Vector(9750, 200, 0))
+    if App.GuiUp:
+        dimension_r.ViewObject.ArrowSize = 15
+        dimension_r.ViewObject.FontSize = 100
+        dimension_r.ViewObject.ShowUnit = False
+
+    arc_h2 = Draft.makeCircle(450, startangle=-120, endangle=80)
+    arc_h2.Placement.Base = Vector(10000, 1000, 0)
+    App.ActiveDocument.recompute()
+
+    dimension_d = Draft.makeDimension(arc_h2, 0, "diameter",
+                                      Vector(10750, 900, 0))
+    if App.GuiUp:
+        dimension_d.ViewObject.ArrowSize = 15
+        dimension_d.ViewObject.FontSize = 100
+        dimension_d.ViewObject.ShowUnit = False
+    t_xpos += 950
+    _t = Draft.makeText(["Radius dimension",
+                         "Diameter dimension"], Vector(t_xpos, t_ypos, 0))
+    _set_text(_t)
+
+    # Angular dimension
+    _msg(16 * "-")
+    _msg("Angular dimension")
+    Draft.makeLine(Vector(10500, 300, 0), Vector(11500, 1000, 0))
+    Draft.makeLine(Vector(10500, 300, 0), Vector(11500, 0, 0))
+    angle1 = math.radians(40)
+    angle2 = math.radians(-20)
+    dimension_a = Draft.makeAngularDimension(Vector(10500, 300, 0),
+                                             [angle1, angle2],
+                                             Vector(11500, 300, 0))
+    if App.GuiUp:
+        dimension_a.ViewObject.ArrowSize = 15
+        dimension_a.ViewObject.FontSize = 100
+    t_xpos += 1700
+    _t = Draft.makeText(["Angle dimension"], Vector(t_xpos, t_ypos, 0))
+    _set_text(_t)
+
+    # BSpline
+    _msg(16 * "-")
+    _msg("BSpline")
+    Draft.makeBSpline([Vector(12500, 0, 0),
+                       Vector(12500, 500, 0),
+                       Vector(13000, 500, 0),
+                       Vector(13000, 1000, 0)])
+    t_xpos += 1500
+    _t = Draft.makeText(["BSpline"], Vector(t_xpos, t_ypos, 0))
+    _set_text(_t)
+
+    # Point
+    _msg(16 * "-")
+    _msg("Point")
+    point = Draft.makePoint(13500, 500, 0)
+    if App.GuiUp:
+        point.ViewObject.PointSize = 10
+    t_xpos += 900
+    _t = Draft.makeText(["Point"], Vector(t_xpos, t_ypos, 0))
+    _set_text(_t)
+
+    # Shapestring
+    _msg(16 * "-")
+    _msg("Shapestring")
+    try:
+        shape_string = Draft.makeShapeString("Testing",
+                                             font_file,
+                                             100)
+        shape_string.Placement.Base = Vector(14000, 500)
+    except Exception:
+        _wrn("Shapestring could not be created")
+        _wrn("Possible cause: the font file may not exist")
+        _wrn(font_file)
+        rect = Draft.makeRectangle(500, 100)
+        rect.Placement.Base = Vector(14000, 500)
+    t_xpos += 600
+    _t = Draft.makeText(["Shapestring"], Vector(t_xpos, t_ypos, 0))
+    _set_text(_t)
+
+    # Facebinder
+    _msg(16 * "-")
+    _msg("Facebinder")
+    box = App.ActiveDocument.addObject("Part::Box", "Cube")
+    box.Length = 200
+    box.Width = 500
+    box.Height = 100
+    box.Placement.Base = Vector(15000, 0, 0)
+    if App.GuiUp:
+        box.ViewObject.Visibility = False
+
+    facebinder = Draft.makeFacebinder([(box, ("Face1", "Face3", "Face6"))])
+    facebinder.Extrusion = 10
+    t_xpos += 780
+    _t = Draft.makeText(["Facebinder"], Vector(t_xpos, t_ypos, 0))
+    _set_text(_t)
+
+    # Cubic bezier curve, n-degree bezier curve
+    _msg(16 * "-")
+    _msg("Cubic bezier")
+    Draft.makeBezCurve([Vector(15500, 0, 0),
+                        Vector(15578, 485, 0),
+                        Vector(15879, 154, 0),
+                        Vector(15975, 400, 0),
+                        Vector(16070, 668, 0),
+                        Vector(16423, 925, 0),
+                        Vector(16500, 500, 0)], degree=3)
+    t_xpos += 680
+    _t = Draft.makeText(["Cubic bezier"], Vector(t_xpos, t_ypos, 0))
+    _set_text(_t)
+
+    _msg(16 * "-")
+    _msg("N-degree bezier")
+    Draft.makeBezCurve([Vector(16500, 0, 0),
+                        Vector(17000, 500, 0),
+                        Vector(17500, 500, 0),
+                        Vector(17500, 1000, 0),
+                        Vector(17000, 1000, 0),
+                        Vector(17063, 1256, 0),
+                        Vector(17732, 1227, 0),
+                        Vector(17790, 720, 0),
+                        Vector(17702, 242, 0)])
+    t_xpos += 1200
+    _t = Draft.makeText(["n-Bezier"], Vector(t_xpos, t_ypos, 0))
+    _set_text(_t)
+
+    # Label
+    _msg(16 * "-")
+    _msg("Label")
+    place = App.Placement(Vector(18500, 500, 0), App.Rotation())
+    label = Draft.makeLabel(targetpoint=Vector(18000, 0, 0),
+                            distance=-250,
+                            placement=place)
+    label.Text = "Testing"
+    if App.GuiUp:
+        label.ViewObject.ArrowSize = 15
+        label.ViewObject.TextSize = 100
+    App.ActiveDocument.recompute()
+    t_xpos += 1200
+    _t = Draft.makeText(["Label"], Vector(t_xpos, t_ypos, 0))
+    _set_text(_t)
+
+    # Orthogonal array and orthogonal link array
+    _msg(16 * "-")
+    _msg("Orthogonal array")
+    rect_h = Draft.makeRectangle(500, 500)
+    rect_h.Placement.Base = Vector(1500, 2500, 0)
+    if App.GuiUp:
+        rect_h.ViewObject.Visibility = False
+
+    Draft.makeArray(rect_h,
+                    Vector(600, 0, 0),
+                    Vector(0, 600, 0),
+                    Vector(0, 0, 0),
+                    3, 2, 1)
+    t_xpos = 1700
+    t_ypos = 2200
+    _t = Draft.makeText(["Array"], Vector(t_xpos, t_ypos, 0))
+    _set_text(_t)
+
+    rect_h_2 = Draft.makeRectangle(500, 100)
+    rect_h_2.Placement.Base = Vector(1500, 5000, 0)
+    if App.GuiUp:
+        rect_h_2.ViewObject.Visibility = False
+
+    _msg(16 * "-")
+    _msg("Orthogonal link array")
+    Draft.makeArray(rect_h_2,
+                    Vector(800, 0, 0),
+                    Vector(0, 500, 0),
+                    Vector(0, 0, 0),
+                    2, 4, 1,
+                    use_link=True)
+    t_ypos += 2600
+    _t = Draft.makeText(["Link array"], Vector(t_xpos, t_ypos, 0))
+    _set_text(_t)
+
+    # Polar array and polar link array
+    _msg(16 * "-")
+    _msg("Polar array")
+    wire_h = Draft.makeWire([Vector(5500, 3000, 0),
+                             Vector(6000, 3500, 0),
+                             Vector(6000, 3200, 0),
+                             Vector(5800, 3200, 0)])
+    if App.GuiUp:
+        wire_h.ViewObject.Visibility = False
+
+    Draft.makeArray(wire_h,
+                    Vector(5000, 3000, 0),
+                    200,
+                    8)
+    t_xpos = 4600
+    t_ypos = 2200
+    _t = Draft.makeText(["Polar array"], Vector(t_xpos, t_ypos, 0))
+    _set_text(_t)
+
+    _msg(16 * "-")
+    _msg("Polar link array")
+    wire_h_2 = Draft.makeWire([Vector(5500, 6000, 0),
+                               Vector(6000, 6000, 0),
+                               Vector(5800, 5700, 0),
+                               Vector(5800, 5750, 0)])
+    if App.GuiUp:
+        wire_h_2.ViewObject.Visibility = False
+
+    Draft.makeArray(wire_h_2,
+                    Vector(5000, 6000, 0),
+                    200,
+                    8,
+                    use_link=True)
+    t_ypos += 3200
+    _t = Draft.makeText(["Polar link array"], Vector(t_xpos, t_ypos, 0))
+    _set_text(_t)
+
+    # Circular array and circular link array
+    _msg(16 * "-")
+    _msg("Circular array")
+    poly_h = Draft.makePolygon(5, 200)
+    poly_h.Placement.Base = Vector(8000, 3000, 0)
+    if App.GuiUp:
+        poly_h.ViewObject.Visibility = False
+
+    Draft.makeArray(poly_h,
+                    500, 600,
+                    Vector(0, 0, 1),
+                    Vector(0, 0, 0),
+                    3,
+                    1)
+    t_xpos = 7700
+    t_ypos = 1700
+    _t = Draft.makeText(["Circular array"], Vector(t_xpos, t_ypos, 0))
+    _set_text(_t)
+
+    _msg(16 * "-")
+    _msg("Circular link array")
+    poly_h_2 = Draft.makePolygon(6, 150)
+    poly_h_2.Placement.Base = Vector(8000, 6250, 0)
+    if App.GuiUp:
+        poly_h_2.ViewObject.Visibility = False
+
+    Draft.makeArray(poly_h_2,
+                    550, 450,
+                    Vector(0, 0, 1),
+                    Vector(0, 0, 0),
+                    3,
+                    1,
+                    use_link=True)
+    t_ypos += 3100
+    _t = Draft.makeText(["Circular link array"], Vector(t_xpos, t_ypos, 0))
+    _set_text(_t)
+
+    # Path array and path link array
+    _msg(16 * "-")
+    _msg("Path array")
+    poly_h = Draft.makePolygon(3, 250)
+    poly_h.Placement.Base = Vector(10500, 3000, 0)
+    if App.GuiUp:
+        poly_h.ViewObject.Visibility = False
+
+    bspline_path = Draft.makeBSpline([Vector(10500, 2500, 0),
+                                      Vector(11000, 3000, 0),
+                                      Vector(11500, 3200, 0),
+                                      Vector(12000, 4000, 0)])
+
+    Draft.makePathArray(poly_h, bspline_path, 5)
+    t_xpos = 10400
+    t_ypos = 2200
+    _t = Draft.makeText(["Path array"], Vector(t_xpos, t_ypos, 0))
+    _set_text(_t)
+
+    _msg(16 * "-")
+    _msg("Path link array")
+    poly_h_2 = Draft.makePolygon(4, 200)
+    poly_h_2.Placement.Base = Vector(10500, 5000, 0)
+    if App.GuiUp:
+        poly_h_2.ViewObject.Visibility = False
+
+    bspline_path_2 = Draft.makeBSpline([Vector(10500, 4500, 0),
+                                        Vector(11000, 6800, 0),
+                                        Vector(11500, 6000, 0),
+                                        Vector(12000, 5200, 0)])
+
+    Draft.makePathArray(poly_h_2, bspline_path_2, 6,
+                        use_link=True)
+    t_ypos += 2000
+    _t = Draft.makeText(["Path link array"], Vector(t_xpos, t_ypos, 0))
+    _set_text(_t)
+
+    # Point array
+    _msg(16 * "-")
+    _msg("Point array")
+    poly_h = Draft.makePolygon(3, 250)
+
+    point_1 = Draft.makePoint(13000, 3000, 0)
+    point_2 = Draft.makePoint(13000, 3500, 0)
+    point_3 = Draft.makePoint(14000, 2500, 0)
+    point_4 = Draft.makePoint(14000, 3000, 0)
+
+    add_list, delete_list = Draft.upgrade([point_1, point_2,
+                                           point_3, point_4])
+    compound = add_list[0]
+    if App.GuiUp:
+        compound.ViewObject.PointSize = 5
+
+    Draft.makePointArray(poly_h, compound)
+    t_xpos = 13000
+    t_ypos = 2200
+    _t = Draft.makeText(["Point array"], Vector(t_xpos, t_ypos, 0))
+    _set_text(_t)
+
+    # Clone and mirror
+    _msg(16 * "-")
+    _msg("Clone")
+    wire_h = Draft.makeWire([Vector(15000, 2500, 0),
+                             Vector(15200, 3000, 0),
+                             Vector(15500, 2500, 0),
+                             Vector(15200, 2300, 0)])
+
+    Draft.clone(wire_h, Vector(0, 1000, 0))
+    t_xpos = 15000
+    t_ypos = 2100
+    _t = Draft.makeText(["Clone"], Vector(t_xpos, t_ypos, 0))
+    _set_text(_t)
+
+    _msg(16 * "-")
+    _msg("Mirror")
+    wire_h = Draft.makeWire([Vector(17000, 2500, 0),
+                             Vector(16500, 4000, 0),
+                             Vector(16000, 2700, 0),
+                             Vector(16500, 2500, 0),
+                             Vector(16700, 2700, 0)])
+
+    Draft.mirror(wire_h,
+                 Vector(17100, 2000, 0),
+                 Vector(17100, 4000, 0))
+    t_xpos = 17000
+    t_ypos = 2200
+    _t = Draft.makeText(["Mirror"], Vector(t_xpos, t_ypos, 0))
+    _set_text(_t)
+
+    App.ActiveDocument.recompute()
+
+    if App.GuiUp:
+        Gui.runCommand("Std_ViewFitAll")
+
+    # Export
+    if not file_path:
+        file_path = App.getUserAppDataDir()
+    out_name = os.path.join(file_path, file_name + ".FCStd")
+    doc.FileName = out_name
+    if save:
+        doc.save()
+        _msg(16 * "-")
+        _msg("Saved: {}".format(out_name))
+
+    return doc
+
+
+if __name__ == "__main__":
+    create_test_file()

--- a/src/Mod/Draft/drafttests/test_airfoildat.py
+++ b/src/Mod/Draft/drafttests/test_airfoildat.py
@@ -1,5 +1,3 @@
-"""Unit test for the Draft module, Airfoil DAT import and export tests.
-"""
 # ***************************************************************************
 # *   Copyright (c) 2013 Yorik van Havre <yorik@uncreated.net>              *
 # *   Copyright (c) 2019 Eliud Cabrera Castillo <e.cabrera-castillo@tum.de> *
@@ -23,14 +21,14 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
+"""Unit test for the Draft Workbench, Airfoil DAT import and export tests."""
 
 import os
 import unittest
 import FreeCAD as App
 import Draft
-from .auxiliary import _msg
-from .auxiliary import _draw_header
-from .auxiliary import _fake_function
+import drafttests.auxiliary as aux
+from draftutils.messages import _msg
 
 
 class DraftAirfoilDAT(unittest.TestCase):
@@ -42,7 +40,7 @@ class DraftAirfoilDAT(unittest.TestCase):
         This is executed before every test, so we create a document
         to hold the objects.
         """
-        _draw_header()
+        aux._draw_header()
         self.doc_name = self.__class__.__name__
         if App.ActiveDocument:
             if App.ActiveDocument.Name != self.doc_name:
@@ -64,7 +62,7 @@ class DraftAirfoilDAT(unittest.TestCase):
         _msg("  file={}".format(in_file))
         _msg("  exists={}".format(os.path.exists(in_file)))
 
-        Draft.import_AirfoilDAT = _fake_function
+        Draft.import_AirfoilDAT = aux._fake_function
         obj = Draft.import_AirfoilDAT(in_file)
         self.assertTrue(obj, "'{}' failed".format(operation))
 
@@ -78,7 +76,7 @@ class DraftAirfoilDAT(unittest.TestCase):
         _msg("  file={}".format(out_file))
         _msg("  exists={}".format(os.path.exists(out_file)))
 
-        Draft.export_importAirfoilDAT = _fake_function
+        Draft.export_importAirfoilDAT = aux._fake_function
         obj = Draft.export_importAirfoilDAT(out_file)
         self.assertTrue(obj, "'{}' failed".format(operation))
 

--- a/src/Mod/Draft/drafttests/test_creation.py
+++ b/src/Mod/Draft/drafttests/test_creation.py
@@ -1,5 +1,3 @@
-"""Unit test for the Draft module, object creation tests.
-"""
 # ***************************************************************************
 # *   Copyright (c) 2013 Yorik van Havre <yorik@uncreated.net>              *
 # *   Copyright (c) 2019 Eliud Cabrera Castillo <e.cabrera-castillo@tum.de> *
@@ -23,15 +21,14 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
+"""Unit test for the Draft Workbench, object creation tests."""
 
 import unittest
 import FreeCAD as App
 import Draft
+import drafttests.auxiliary as aux
 from FreeCAD import Vector
-from .auxiliary import _msg
-from .auxiliary import _draw_header
-from .auxiliary import _no_gui
-from .auxiliary import _fake_function
+from draftutils.messages import _msg
 
 
 class DraftCreation(unittest.TestCase):
@@ -43,7 +40,7 @@ class DraftCreation(unittest.TestCase):
         This is executed before every test, so we create a document
         to hold the objects.
         """
-        _draw_header()
+        aux._draw_header()
         self.doc_name = self.__class__.__name__
         if App.ActiveDocument:
             if App.ActiveDocument.Name != self.doc_name:
@@ -91,7 +88,7 @@ class DraftCreation(unittest.TestCase):
         App.ActiveDocument.recompute()
 
         if not App.GuiUp:
-            _no_gui("DraftFillet")
+            aux._no_gui("DraftFillet")
             self.assertTrue(True)
             return
 
@@ -200,7 +197,7 @@ class DraftCreation(unittest.TestCase):
         c = Vector(0, 5, 0)
         _msg("  a={0}, b={1}".format(a, b))
         _msg("  c={}".format(c))
-        Draft.make_dimension_radial = _fake_function
+        Draft.make_dimension_radial = aux._fake_function
         obj = Draft.make_dimension_radial(a, b, c)
         self.assertTrue(obj, "'{}' failed".format(operation))
 
@@ -231,9 +228,10 @@ class DraftCreation(unittest.TestCase):
         _msg("  Test '{}'".format(operation))
         _msg("  In order to test this, a font file is needed.")
         text = "Testing Shapestring "
-        font = None  # TODO: get a font file here
+        # TODO: find a reliable way to always get a font file here
+        font = None
         _msg("  text='{0}', font='{1}'".format(text, font))
-        Draft.makeShapeString = _fake_function
+        Draft.makeShapeString = aux._fake_function
         obj = Draft.makeShapeString("Text", font)
         # Draft.makeShapeString("Text", FontFile="")
         self.assertTrue(obj, "'{}' failed".format(operation))

--- a/src/Mod/Draft/drafttests/test_creation.py
+++ b/src/Mod/Draft/drafttests/test_creation.py
@@ -119,7 +119,7 @@ class DraftCreation(unittest.TestCase):
         _msg("  startangle={0}, endangle={1}".format(start_angle,
                                                      end_angle))
         obj = Draft.makeCircle(radius,
-                               start_angle, end_angle)
+                               startangle=start_angle, endangle=end_angle)
         self.assertTrue(obj, "'{}' failed".format(operation))
 
     def test_arc_3points(self):
@@ -189,17 +189,22 @@ class DraftCreation(unittest.TestCase):
         self.assertTrue(obj, "'{}' failed".format(operation))
 
     def test_dimension_radial(self):
-        """Create a radial dimension. NOT IMPLEMENTED CURRENTLY."""
+        """Create a circle and then a radial dimension."""
         operation = "Draft Dimension Radial"
         _msg("  Test '{}'".format(operation))
-        a = Vector(5, 0, 0)
-        b = Vector(4, 3, 0)
-        c = Vector(0, 5, 0)
-        _msg("  a={0}, b={1}".format(a, b))
-        _msg("  c={}".format(c))
-        Draft.make_dimension_radial = aux._fake_function
-        obj = Draft.make_dimension_radial(a, b, c)
-        self.assertTrue(obj, "'{}' failed".format(operation))
+        radius = 3
+        start_angle = 0
+        end_angle = 90
+        _msg("  radius={}".format(radius))
+        _msg("  startangle={0}, endangle={1}".format(start_angle,
+                                                     end_angle))
+        circ = Draft.makeCircle(radius,
+                                startangle=start_angle, endangle=end_angle)
+        obj1 = Draft.makeDimension(circ, 0,
+                                   p3="radius", p4=Vector(1, 1, 0))
+        obj2 = Draft.makeDimension(circ, 0,
+                                   p3="diameter", p4=Vector(3, 1, 0))
+        self.assertTrue(obj1 and obj2, "'{}' failed".format(operation))
 
     def test_bspline(self):
         """Create a BSpline of three points."""

--- a/src/Mod/Draft/drafttests/test_creation.py
+++ b/src/Mod/Draft/drafttests/test_creation.py
@@ -134,8 +134,9 @@ class DraftCreation(unittest.TestCase):
         c = Vector(0, 5, 0)
         _msg("  a={0}, b={1}".format(a, b))
         _msg("  c={}".format(c))
-        Draft.make_arc_3points = _fake_function
-        obj = Draft.make_arc_3points(a, b, c)
+
+        import draftobjects.arc_3points as arc3
+        obj = arc3.make_arc_3points([a, b, c])
         self.assertTrue(obj, "'{}' failed".format(operation))
 
     def test_ellipse(self):

--- a/src/Mod/Draft/drafttests/test_creation.py
+++ b/src/Mod/Draft/drafttests/test_creation.py
@@ -24,6 +24,7 @@
 """Unit test for the Draft Workbench, object creation tests."""
 
 import unittest
+import math
 import FreeCAD as App
 import Draft
 import drafttests.auxiliary as aux
@@ -205,6 +206,22 @@ class DraftCreation(unittest.TestCase):
         obj2 = Draft.makeDimension(circ, 0,
                                    p3="diameter", p4=Vector(3, 1, 0))
         self.assertTrue(obj1 and obj2, "'{}' failed".format(operation))
+
+    def test_dimension_angular(self):
+        """Create an angular dimension between two lines at given angles."""
+        operation = "Draft Dimension Angular"
+        _msg("  Test '{}'".format(operation))
+        _msg("  Occasionally crashes")
+        center = Vector(0, 0, 0)
+        angle1 = math.radians(60)
+        angle2 = math.radians(10)
+        p3 = Vector(3, 1, 0)
+        _msg("  center={}".format(center))
+        _msg("  angle1={0}, angle2={1}".format(math.degrees(angle1),
+                                               math.degrees(angle2)))
+        _msg("  point={}".format(p3))
+        obj = Draft.makeAngularDimension(center, [angle1, angle2], p3)
+        self.assertTrue(obj, "'{}' failed".format(operation))
 
     def test_bspline(self):
         """Create a BSpline of three points."""

--- a/src/Mod/Draft/drafttests/test_dwg.py
+++ b/src/Mod/Draft/drafttests/test_dwg.py
@@ -1,5 +1,3 @@
-"""Unit test for the Draft module, DWG import and export tests.
-"""
 # ***************************************************************************
 # *   Copyright (c) 2013 Yorik van Havre <yorik@uncreated.net>              *
 # *   Copyright (c) 2019 Eliud Cabrera Castillo <e.cabrera-castillo@tum.de> *
@@ -23,14 +21,14 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
+"""Unit test for the Draft Workbench, DWG import and export tests."""
 
 import os
 import unittest
 import FreeCAD as App
 import Draft
-from .auxiliary import _msg
-from .auxiliary import _draw_header
-from .auxiliary import _fake_function
+import drafttests.auxiliary as aux
+from draftutils.messages import _msg
 
 
 class DraftDWG(unittest.TestCase):
@@ -42,7 +40,7 @@ class DraftDWG(unittest.TestCase):
         This is executed before every test, so we create a document
         to hold the objects.
         """
-        _draw_header()
+        aux._draw_header()
         self.doc_name = self.__class__.__name__
         if App.ActiveDocument:
             if App.ActiveDocument.Name != self.doc_name:
@@ -64,7 +62,7 @@ class DraftDWG(unittest.TestCase):
         _msg("  file={}".format(in_file))
         _msg("  exists={}".format(os.path.exists(in_file)))
 
-        Draft.import_DWG = _fake_function
+        Draft.import_DWG = aux._fake_function
         obj = Draft.import_DWG(in_file)
         self.assertTrue(obj, "'{}' failed".format(operation))
 
@@ -78,7 +76,7 @@ class DraftDWG(unittest.TestCase):
         _msg("  file={}".format(out_file))
         _msg("  exists={}".format(os.path.exists(out_file)))
 
-        Draft.export_DWG = _fake_function
+        Draft.export_DWG = aux._fake_function
         obj = Draft.export_DWG(out_file)
         self.assertTrue(obj, "'{}' failed".format(operation))
 

--- a/src/Mod/Draft/drafttests/test_dxf.py
+++ b/src/Mod/Draft/drafttests/test_dxf.py
@@ -1,5 +1,3 @@
-"""Unit test for the Draft module, DXF import and export tests.
-"""
 # ***************************************************************************
 # *   Copyright (c) 2013 Yorik van Havre <yorik@uncreated.net>              *
 # *   Copyright (c) 2019 Eliud Cabrera Castillo <e.cabrera-castillo@tum.de> *
@@ -23,14 +21,14 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
+"""Unit test for the Draft Workbench, DXF import and export tests."""
 
 import os
 import unittest
 import FreeCAD as App
 import Draft
-from .auxiliary import _msg
-from .auxiliary import _draw_header
-from .auxiliary import _fake_function
+import drafttests.auxiliary as aux
+from draftutils.messages import _msg
 
 
 class DraftDXF(unittest.TestCase):
@@ -42,7 +40,7 @@ class DraftDXF(unittest.TestCase):
         This is executed before every test, so we create a document
         to hold the objects.
         """
-        _draw_header()
+        aux._draw_header()
         self.doc_name = self.__class__.__name__
         if App.ActiveDocument:
             if App.ActiveDocument.Name != self.doc_name:
@@ -64,7 +62,7 @@ class DraftDXF(unittest.TestCase):
         _msg("  file={}".format(in_file))
         _msg("  exists={}".format(os.path.exists(in_file)))
 
-        Draft.import_DXF = _fake_function
+        Draft.import_DXF = aux._fake_function
         obj = Draft.import_DXF(in_file)
         self.assertTrue(obj, "'{}' failed".format(operation))
 
@@ -78,7 +76,7 @@ class DraftDXF(unittest.TestCase):
         _msg("  file={}".format(out_file))
         _msg("  exists={}".format(os.path.exists(out_file)))
 
-        Draft.export_DXF = _fake_function
+        Draft.export_DXF = aux._fake_function
         obj = Draft.export_DXF(out_file)
         self.assertTrue(obj, "'{}' failed".format(operation))
 

--- a/src/Mod/Draft/drafttests/test_import.py
+++ b/src/Mod/Draft/drafttests/test_import.py
@@ -1,5 +1,3 @@
-"""Unit test for the Draft module, import tests.
-"""
 # ***************************************************************************
 # *   Copyright (c) 2013 Yorik van Havre <yorik@uncreated.net>              *
 # *   Copyright (c) 2019 Eliud Cabrera Castillo <e.cabrera-castillo@tum.de> *
@@ -23,39 +21,40 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
+"""Unit test for the Draft Workbench, import tests."""
 
 import unittest
-from .auxiliary import _draw_header
-from .auxiliary import _import_test
+import drafttests.auxiliary as aux
 
 
 class DraftImport(unittest.TestCase):
     """Import the Draft modules."""
+
     # No document is needed to test 'import Draft' or other modules
     # thus 'setUp' just draws a line, and 'tearDown' isn't defined.
     def setUp(self):
-        _draw_header()
+        aux._draw_header()
 
     def test_import_draft(self):
         """Import the Draft module."""
         module = "Draft"
-        imported = _import_test(module)
+        imported = aux._import_test(module)
         self.assertTrue(imported, "Problem importing '{}'".format(module))
 
     def test_import_draft_geomutils(self):
         """Import Draft geometrical utilities."""
         module = "DraftGeomUtils"
-        imported = _import_test(module)
+        imported = aux._import_test(module)
         self.assertTrue(imported, "Problem importing '{}'".format(module))
 
     def test_import_draft_vecutils(self):
         """Import Draft vector utilities."""
         module = "DraftVecUtils"
-        imported = _import_test(module)
+        imported = aux._import_test(module)
         self.assertTrue(imported, "Problem importing '{}'".format(module))
 
     def test_import_draft_svg(self):
         """Import Draft SVG utilities."""
         module = "getSVG"
-        imported = _import_test(module)
+        imported = aux._import_test(module)
         self.assertTrue(imported, "Problem importing '{}'".format(module))

--- a/src/Mod/Draft/drafttests/test_import_gui.py
+++ b/src/Mod/Draft/drafttests/test_import_gui.py
@@ -1,5 +1,3 @@
-"""Unit test for the Draft module, GUI import tests.
-"""
 # ***************************************************************************
 # *   Copyright (c) 2013 Yorik van Havre <yorik@uncreated.net>              *
 # *   Copyright (c) 2019 Eliud Cabrera Castillo <e.cabrera-castillo@tum.de> *
@@ -23,57 +21,57 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
+"""Unit test for the Draft Workbench, GUI import tests."""
 
 import unittest
 import FreeCAD as App
-from .auxiliary import _draw_header
-from .auxiliary import _no_gui
-from .auxiliary import _import_test
+import drafttests.auxiliary as aux
 
 
 class DraftGuiImport(unittest.TestCase):
     """Import the Draft graphical modules."""
+
     # No document is needed to test 'import DraftGui' or other modules
     # thus 'setUp' just draws a line, and 'tearDown' isn't defined.
     def setUp(self):
-        _draw_header()
+        aux._draw_header()
 
     def test_import_gui_draftgui(self):
         """Import Draft TaskView GUI tools."""
         module = "DraftGui"
         if not App.GuiUp:
-            _no_gui(module)
+            aux._no_gui(module)
             self.assertTrue(True)
             return
-        imported = _import_test(module)
+        imported = aux._import_test(module)
         self.assertTrue(imported, "Problem importing '{}'".format(module))
 
     def test_import_gui_draft_snap(self):
         """Import Draft snapping."""
         module = "DraftSnap"
         if not App.GuiUp:
-            _no_gui(module)
+            aux._no_gui(module)
             self.assertTrue(True)
             return
-        imported = _import_test(module)
+        imported = aux._import_test(module)
         self.assertTrue(imported, "Problem importing '{}'".format(module))
 
     def test_import_gui_draft_tools(self):
         """Import Draft graphical commands."""
         module = "DraftTools"
         if not App.GuiUp:
-            _no_gui(module)
+            aux._no_gui(module)
             self.assertTrue(True)
             return
-        imported = _import_test(module)
+        imported = aux._import_test(module)
         self.assertTrue(imported, "Problem importing '{}'".format(module))
 
     def test_import_gui_draft_trackers(self):
         """Import Draft tracker utilities."""
         module = "DraftTrackers"
         if not App.GuiUp:
-            _no_gui(module)
+            aux._no_gui(module)
             self.assertTrue(True)
             return
-        imported = _import_test(module)
+        imported = aux._import_test(module)
         self.assertTrue(imported, "Problem importing '{}'".format(module))

--- a/src/Mod/Draft/drafttests/test_import_tools.py
+++ b/src/Mod/Draft/drafttests/test_import_tools.py
@@ -1,5 +1,3 @@
-"""Unit test for the Draft module, tools import tests.
-"""
 # ***************************************************************************
 # *   Copyright (c) 2013 Yorik van Havre <yorik@uncreated.net>              *
 # *   Copyright (c) 2019 Eliud Cabrera Castillo <e.cabrera-castillo@tum.de> *
@@ -23,67 +21,67 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
+"""Unit test for the Draft Workbench, tools import tests."""
 
 import unittest
 import FreeCAD as App
-from .auxiliary import _draw_header
-from .auxiliary import _no_gui
-from .auxiliary import _import_test
+import drafttests.auxiliary as aux
 
 
 class DraftImportTools(unittest.TestCase):
     """Test for each individual module that defines a tool."""
+
     # No document is needed to test 'import' of other modules
     # thus 'setUp' just draws a line, and 'tearDown' isn't defined.
     def setUp(self):
-        _draw_header()
+        aux._draw_header()
 
     def test_import_gui_draftedit(self):
         """Import Draft Edit."""
         module = "DraftEdit"
         if not App.GuiUp:
-            _no_gui(module)
+            aux._no_gui(module)
             self.assertTrue(True)
             return
-        imported = _import_test(module)
+        imported = aux._import_test(module)
         self.assertTrue(imported, "Problem importing '{}'".format(module))
 
     def test_import_gui_draftfillet(self):
         """Import Draft Fillet."""
         module = "DraftFillet"
         if not App.GuiUp:
-            _no_gui(module)
+            aux._no_gui(module)
             self.assertTrue(True)
             return
-        imported = _import_test(module)
+        imported = aux._import_test(module)
         self.assertTrue(imported, "Problem importing '{}'".format(module))
 
     def test_import_gui_draftlayer(self):
         """Import Draft Layer."""
         module = "DraftLayer"
         if not App.GuiUp:
-            _no_gui(module)
+            aux._no_gui(module)
             self.assertTrue(True)
             return
-        imported = _import_test(module)
+        imported = aux._import_test(module)
         self.assertTrue(imported, "Problem importing '{}'".format(module))
 
     def test_import_gui_draftplane(self):
         """Import Draft SelectPlane."""
         module = "DraftSelectPlane"
         if not App.GuiUp:
-            _no_gui(module)
+            aux._no_gui(module)
             self.assertTrue(True)
             return
-        imported = _import_test(module)
+        imported = aux._import_test(module)
         self.assertTrue(imported, "Problem importing '{}'".format(module))
 
     def test_import_gui_workingplane(self):
         """Import Draft WorkingPlane."""
         module = "WorkingPlane"
         if not App.GuiUp:
-            _no_gui(module)
+            aux._no_gui(module)
             self.assertTrue(True)
             return
-        imported = _import_test(module)
+        imported = aux._import_test(module)
         self.assertTrue(imported, "Problem importing '{}'".format(module))

--- a/src/Mod/Draft/drafttests/test_modification.py
+++ b/src/Mod/Draft/drafttests/test_modification.py
@@ -1,5 +1,3 @@
-"""Unit test for the Draft module, object modification tests.
-"""
 # ***************************************************************************
 # *   Copyright (c) 2013 Yorik van Havre <yorik@uncreated.net>              *
 # *   Copyright (c) 2019 Eliud Cabrera Castillo <e.cabrera-castillo@tum.de> *
@@ -23,15 +21,14 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
+"""Unit test for the Draft Workbench, object modification tests."""
 
 import unittest
 import FreeCAD as App
 import Draft
+import drafttests.auxiliary as aux
 from FreeCAD import Vector
-from .auxiliary import _msg
-from .auxiliary import _wrn
-from .auxiliary import _draw_header
-from .auxiliary import _fake_function
+from draftutils.messages import _msg, _wrn
 
 
 class DraftModification(unittest.TestCase):
@@ -43,7 +40,7 @@ class DraftModification(unittest.TestCase):
         This is executed before every test, so we create a document
         to hold the objects.
         """
-        _draw_header()
+        aux._draw_header()
         self.doc_name = self.__class__.__name__
         if App.ActiveDocument:
             if App.ActiveDocument.Name != self.doc_name:
@@ -160,7 +157,7 @@ class DraftModification(unittest.TestCase):
         line2 = Draft.makeLine(c, d)
         App.ActiveDocument.recompute()
 
-        Draft.trim_objects = _fake_function
+        Draft.trim_objects = aux._fake_function
         obj = Draft.trim_objects(line, line2)
         self.assertTrue(obj, "'{}' failed".format(operation))
 
@@ -181,7 +178,7 @@ class DraftModification(unittest.TestCase):
         line2 = Draft.makeLine(c, d)
         App.ActiveDocument.recompute()
 
-        Draft.extrude = _fake_function
+        Draft.extrude = aux._fake_function
         obj = Draft.extrude(line, line2)
         self.assertTrue(obj, "'{}' failed".format(operation))
 
@@ -577,7 +574,7 @@ class DraftModification(unittest.TestCase):
         line = Draft.makeLine(a, b)
         direction = Vector(4, 1, 0)
 
-        Draft.stretch = _fake_function
+        Draft.stretch = aux._fake_function
         obj = Draft.stretch(line, direction)
         self.assertTrue(obj, "'{}' failed".format(operation))
 

--- a/src/Mod/Draft/drafttests/test_oca.py
+++ b/src/Mod/Draft/drafttests/test_oca.py
@@ -1,5 +1,3 @@
-"""Unit test for the Draft module, OCA import and export tests.
-"""
 # ***************************************************************************
 # *   Copyright (c) 2013 Yorik van Havre <yorik@uncreated.net>              *
 # *   Copyright (c) 2019 Eliud Cabrera Castillo <e.cabrera-castillo@tum.de> *
@@ -23,14 +21,14 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
+"""Unit test for the Draft Workbench, OCA import and export tests."""
 
 import os
 import unittest
 import FreeCAD as App
 import Draft
-from .auxiliary import _msg
-from .auxiliary import _draw_header
-from .auxiliary import _fake_function
+import drafttests.auxiliary as aux
+from draftutils.messages import _msg
 
 
 class DraftOCA(unittest.TestCase):
@@ -42,7 +40,7 @@ class DraftOCA(unittest.TestCase):
         This is executed before every test, so we create a document
         to hold the objects.
         """
-        _draw_header()
+        aux._draw_header()
         self.doc_name = self.__class__.__name__
         if App.ActiveDocument:
             if App.ActiveDocument.Name != self.doc_name:
@@ -64,7 +62,7 @@ class DraftOCA(unittest.TestCase):
         _msg("  file={}".format(in_file))
         _msg("  exists={}".format(os.path.exists(in_file)))
 
-        Draft.import_OCA = _fake_function
+        Draft.import_OCA = aux._fake_function
         obj = Draft.import_OCA(in_file)
         self.assertTrue(obj, "'{}' failed".format(operation))
 
@@ -78,7 +76,7 @@ class DraftOCA(unittest.TestCase):
         _msg("  file={}".format(out_file))
         _msg("  exists={}".format(os.path.exists(out_file)))
 
-        Draft.export_OCA = _fake_function
+        Draft.export_OCA = aux._fake_function
         obj = Draft.export_OCA(out_file)
         self.assertTrue(obj, "'{}' failed".format(operation))
 

--- a/src/Mod/Draft/drafttests/test_pivy.py
+++ b/src/Mod/Draft/drafttests/test_pivy.py
@@ -1,5 +1,3 @@
-"""Unit test for the Draft module, Pivy (Coin) tests.
-"""
 # ***************************************************************************
 # *   Copyright (c) 2013 Yorik van Havre <yorik@uncreated.net>              *
 # *   Copyright (c) 2019 Eliud Cabrera Castillo <e.cabrera-castillo@tum.de> *
@@ -23,14 +21,13 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
+"""Unit test for the Draft Workbench, Coin (Pivy) tests."""
 
 import unittest
 import FreeCAD as App
 import FreeCADGui as Gui
-from .auxiliary import _msg
-from .auxiliary import _draw_header
-from .auxiliary import _no_gui
-from .auxiliary import _import_test
+import drafttests.auxiliary as aux
+from draftutils.messages import _msg
 
 
 class DraftPivy(unittest.TestCase):
@@ -42,7 +39,7 @@ class DraftPivy(unittest.TestCase):
         This is executed before every test, so we create a document
         to hold the objects.
         """
-        _draw_header()
+        aux._draw_header()
         self.doc_name = self.__class__.__name__
         if App.ActiveDocument:
             if App.ActiveDocument.Name != self.doc_name:
@@ -54,16 +51,16 @@ class DraftPivy(unittest.TestCase):
         _msg("  Temporary document '{}'".format(self.doc_name))
 
     def test_pivy_import(self):
-        """Import Pivy Coin."""
+        """Import Coin (Pivy)."""
         module = "pivy.coin"
-        imported = _import_test(module)
+        imported = aux._import_test(module)
         self.assertTrue(imported, "Problem importing '{}'".format(module))
 
     def test_pivy_draw(self):
         """Use Coin (pivy.coin) to draw a cube on the active view."""
         module = "pivy.coin"
         if not App.GuiUp:
-            _no_gui(module)
+            aux._no_gui(module)
             self.assertTrue(True)
             return
 

--- a/src/Mod/Draft/drafttests/test_svg.py
+++ b/src/Mod/Draft/drafttests/test_svg.py
@@ -1,5 +1,3 @@
-"""Unit test for the Draft module, SVG import and export tests.
-"""
 # ***************************************************************************
 # *   Copyright (c) 2013 Yorik van Havre <yorik@uncreated.net>              *
 # *   Copyright (c) 2019 Eliud Cabrera Castillo <e.cabrera-castillo@tum.de> *
@@ -23,14 +21,14 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
+"""Unit test for the Draft Workbench, SVG import and export tests."""
 
 import os
 import unittest
 import FreeCAD as App
 import Draft
-from .auxiliary import _msg
-from .auxiliary import _draw_header
-from .auxiliary import _fake_function
+import drafttests.auxiliary as aux
+from draftutils.messages import _msg
 
 
 class DraftSVG(unittest.TestCase):
@@ -42,7 +40,7 @@ class DraftSVG(unittest.TestCase):
         This is executed before every test, so we create a document
         to hold the objects.
         """
-        _draw_header()
+        aux._draw_header()
         self.doc_name = self.__class__.__name__
         if App.ActiveDocument:
             if App.ActiveDocument.Name != self.doc_name:
@@ -64,7 +62,7 @@ class DraftSVG(unittest.TestCase):
         _msg("  file={}".format(in_file))
         _msg("  exists={}".format(os.path.exists(in_file)))
 
-        Draft.import_SVG = _fake_function
+        Draft.import_SVG = aux._fake_function
         obj = Draft.import_SVG(in_file)
         self.assertTrue(obj, "'{}' failed".format(operation))
 
@@ -78,7 +76,7 @@ class DraftSVG(unittest.TestCase):
         _msg("  file={}".format(out_file))
         _msg("  exists={}".format(os.path.exists(out_file)))
 
-        Draft.export_SVG = _fake_function
+        Draft.export_SVG = aux._fake_function
         obj = Draft.export_SVG(out_file)
         self.assertTrue(obj, "'{}' failed".format(operation))
 


### PR DESCRIPTION
This complements the Draft unit tests #2668 and #2727. Some unit tests are improved and others are newly added. See [New unit tests for Draft Workbench](https://forum.freecadweb.org/viewtopic.php?f=23&t=40405&p=368819#p368819).

The unit test `test_arc_3points` is now real. The appropriate command to test was introduced in #3004. Previously, there was a placeholder function that always passed the test.

All unit tests received some cleanup, now using the `messages` module introduced in #3003.

A problem was fixed with the `test_arc` unit test. Now it creates a real arc, and not just a circle.

The unit test `test_dimension_radial` is now real. Previously, there was a placeholder function that always passed the test.

A new unit test was created `test_dimension_angular`. The `_AngularDimension` object shows an error because it tries to round up the internal angles, which are properties of type `App::PropertyAngle`. This needs to be solved in the `_AngularDimension` code itself, but it doesn't seem to be a big problem, as the dimension is in fact created. Thus, despite this error, the unit test still passes. Fore more information, see [[Bug 4261] Bad behavior when using '°' unit in expressions](https://forum.freecadweb.org/viewtopic.php?f=3&t=43074#p366563).

This pull request needs to be merged after #3004 is merged because it will use the new `make_arc_3points` function. When this happens, this request will create a conflict, so this pull request will have to be rebased onto the master branch, and then it will be able to be merged.

---

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists
