### PR TITLE
remove program-specific SVG namespaces

### DIFF
--- a/src/Mod/Arch/Resources/icons/ArchWorkbench.svg
+++ b/src/Mod/Arch/Resources/icons/ArchWorkbench.svg
@@ -1,6 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-
 <svg
    xmlns:dc="http://purl.org/dc/elements/1.1/"
    xmlns:cc="http://creativecommons.org/ns#"
@@ -8,501 +6,326 @@
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="64px"
-   height="64px"
-   id="svg2816"
    version="1.1"
-   inkscape:version="0.48.5 r10040"
-   sodipodi:docname="ArchWorkbench.svg">
+   id="svg2816"
+   height="64px"
+   width="64px">
   <defs
      id="defs2818">
     <linearGradient
-       inkscape:collect="always"
        id="linearGradient3789">
       <stop
-         style="stop-color:#888a85;stop-opacity:1;"
+         id="stop3791"
          offset="0"
-         id="stop3791" />
+         style="stop-color:#888a85;stop-opacity:1;" />
       <stop
-         style="stop-color:#d3d7cf;stop-opacity:1"
+         id="stop3793"
          offset="1"
-         id="stop3793" />
+         style="stop-color:#d3d7cf;stop-opacity:1" />
     </linearGradient>
     <linearGradient
-       inkscape:collect="always"
        id="linearGradient3781">
       <stop
-         style="stop-color:#d3d7cf;stop-opacity:1;"
+         id="stop3783"
          offset="0"
-         id="stop3783" />
+         style="stop-color:#d3d7cf;stop-opacity:1;" />
       <stop
-         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3785"
          offset="1"
-         id="stop3785" />
+         style="stop-color:#ffffff;stop-opacity:1" />
     </linearGradient>
-    <inkscape:perspective
-       sodipodi:type="inkscape:persp3d"
-       inkscape:vp_x="0 : 32 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_z="64 : 32 : 1"
-       inkscape:persp3d-origin="32 : 21.333333 : 1"
-       id="perspective2824" />
-    <inkscape:perspective
-       id="perspective3622"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       id="perspective3622-9"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       id="perspective3653"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       id="perspective3675"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       id="perspective3697"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       id="perspective3720"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       id="perspective3742"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       id="perspective3764"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       id="perspective3785"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       id="perspective3806"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       id="perspective3806-3"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       id="perspective3835"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3781"
-       id="linearGradient3787"
-       x1="93.501396"
-       y1="-0.52792466"
-       x2="92.882462"
+       gradientUnits="userSpaceOnUse"
        y2="-7.2011309"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3789"
-       id="linearGradient3795"
-       x1="140.23918"
-       y1="124.16501"
-       x2="137.60997"
-       y2="117.06711"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3781"
-       id="linearGradient3804"
-       gradientUnits="userSpaceOnUse"
-       x1="93.501396"
-       y1="-0.52792466"
-       x2="92.814743"
-       y2="-5.3353744" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3789"
-       id="linearGradient3806"
-       gradientUnits="userSpaceOnUse"
-       x1="140.23918"
-       y1="124.16501"
-       x2="137.60997"
-       y2="117.06711" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3781-6"
-       id="linearGradient3804-3"
-       gradientUnits="userSpaceOnUse"
-       x1="93.501396"
-       y1="-0.52792466"
        x2="92.882462"
-       y2="-7.2011309" />
+       y1="-0.52792466"
+       x1="93.501396"
+       id="linearGradient3787"
+       xlink:href="#linearGradient3781" />
     <linearGradient
-       inkscape:collect="always"
+       gradientUnits="userSpaceOnUse"
+       y2="117.06711"
+       x2="137.60997"
+       y1="124.16501"
+       x1="140.23918"
+       id="linearGradient3795"
+       xlink:href="#linearGradient3789" />
+    <linearGradient
+       y2="-5.3353744"
+       x2="92.814743"
+       y1="-0.52792466"
+       x1="93.501396"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3804"
+       xlink:href="#linearGradient3781" />
+    <linearGradient
+       y2="117.06711"
+       x2="137.60997"
+       y1="124.16501"
+       x1="140.23918"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3806"
+       xlink:href="#linearGradient3789" />
+    <linearGradient
+       y2="-7.2011309"
+       x2="92.882462"
+       y1="-0.52792466"
+       x1="93.501396"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3804-3"
+       xlink:href="#linearGradient3781-6" />
+    <linearGradient
        id="linearGradient3781-6">
       <stop
-         style="stop-color:#d3d7cf;stop-opacity:1;"
+         id="stop3783-7"
          offset="0"
-         id="stop3783-7" />
+         style="stop-color:#d3d7cf;stop-opacity:1;" />
       <stop
-         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3785-5"
          offset="1"
-         id="stop3785-5" />
+         style="stop-color:#ffffff;stop-opacity:1" />
     </linearGradient>
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3789-5"
-       id="linearGradient3806-3"
-       gradientUnits="userSpaceOnUse"
-       x1="140.23918"
-       y1="124.16501"
+       y2="117.06711"
        x2="137.60997"
-       y2="117.06711" />
+       y1="124.16501"
+       x1="140.23918"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3806-3"
+       xlink:href="#linearGradient3789-5" />
     <linearGradient
-       inkscape:collect="always"
        id="linearGradient3789-5">
       <stop
-         style="stop-color:#888a85;stop-opacity:1;"
+         id="stop3791-6"
          offset="0"
-         id="stop3791-6" />
+         style="stop-color:#888a85;stop-opacity:1;" />
       <stop
-         style="stop-color:#d3d7cf;stop-opacity:1"
+         id="stop3793-2"
          offset="1"
-         id="stop3793-2" />
+         style="stop-color:#d3d7cf;stop-opacity:1" />
     </linearGradient>
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3781-0"
-       id="linearGradient3804-36"
-       gradientUnits="userSpaceOnUse"
-       x1="93.501396"
-       y1="-0.52792466"
+       y2="-7.2011309"
        x2="92.882462"
-       y2="-7.2011309" />
+       y1="-0.52792466"
+       x1="93.501396"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3804-36"
+       xlink:href="#linearGradient3781-0" />
     <linearGradient
-       inkscape:collect="always"
        id="linearGradient3781-0">
       <stop
-         style="stop-color:#d3d7cf;stop-opacity:1;"
+         id="stop3783-6"
          offset="0"
-         id="stop3783-6" />
+         style="stop-color:#d3d7cf;stop-opacity:1;" />
       <stop
-         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3785-2"
          offset="1"
-         id="stop3785-2" />
+         style="stop-color:#ffffff;stop-opacity:1" />
     </linearGradient>
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3789-1"
-       id="linearGradient3806-6"
-       gradientUnits="userSpaceOnUse"
-       x1="140.23918"
-       y1="124.16501"
+       y2="117.06711"
        x2="137.60997"
-       y2="117.06711" />
+       y1="124.16501"
+       x1="140.23918"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3806-6"
+       xlink:href="#linearGradient3789-1" />
     <linearGradient
-       inkscape:collect="always"
        id="linearGradient3789-1">
       <stop
-         style="stop-color:#888a85;stop-opacity:1;"
+         id="stop3791-8"
          offset="0"
-         id="stop3791-8" />
+         style="stop-color:#888a85;stop-opacity:1;" />
       <stop
-         style="stop-color:#d3d7cf;stop-opacity:1"
+         id="stop3793-7"
          offset="1"
-         id="stop3793-7" />
+         style="stop-color:#d3d7cf;stop-opacity:1" />
     </linearGradient>
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3781-8"
-       id="linearGradient3804-2"
-       gradientUnits="userSpaceOnUse"
-       x1="93.501396"
-       y1="-0.52792466"
+       y2="-5.3353744"
        x2="92.814743"
-       y2="-5.3353744" />
+       y1="-0.52792466"
+       x1="93.501396"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3804-2"
+       xlink:href="#linearGradient3781-8" />
     <linearGradient
-       inkscape:collect="always"
        id="linearGradient3781-8">
       <stop
-         style="stop-color:#d3d7cf;stop-opacity:1;"
+         id="stop3783-9"
          offset="0"
-         id="stop3783-9" />
+         style="stop-color:#d3d7cf;stop-opacity:1;" />
       <stop
-         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3785-7"
          offset="1"
-         id="stop3785-7" />
+         style="stop-color:#ffffff;stop-opacity:1" />
     </linearGradient>
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3789-12"
-       id="linearGradient3806-36"
-       gradientUnits="userSpaceOnUse"
-       x1="140.23918"
-       y1="124.16501"
+       y2="117.06711"
        x2="137.60997"
-       y2="117.06711" />
+       y1="124.16501"
+       x1="140.23918"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3806-36"
+       xlink:href="#linearGradient3789-12" />
     <linearGradient
-       inkscape:collect="always"
        id="linearGradient3789-12">
       <stop
-         style="stop-color:#888a85;stop-opacity:1;"
+         id="stop3791-9"
          offset="0"
-         id="stop3791-9" />
+         style="stop-color:#888a85;stop-opacity:1;" />
       <stop
-         style="stop-color:#d3d7cf;stop-opacity:1"
+         id="stop3793-3"
          offset="1"
-         id="stop3793-3" />
+         style="stop-color:#d3d7cf;stop-opacity:1" />
     </linearGradient>
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3781-03"
-       id="linearGradient3804-5"
-       gradientUnits="userSpaceOnUse"
-       x1="93.501396"
-       y1="-0.52792466"
+       y2="-5.3353744"
        x2="92.814743"
-       y2="-5.3353744" />
+       y1="-0.52792466"
+       x1="93.501396"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3804-5"
+       xlink:href="#linearGradient3781-03" />
     <linearGradient
-       inkscape:collect="always"
        id="linearGradient3781-03">
       <stop
-         style="stop-color:#d3d7cf;stop-opacity:1;"
+         id="stop3783-61"
          offset="0"
-         id="stop3783-61" />
+         style="stop-color:#d3d7cf;stop-opacity:1;" />
       <stop
-         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3785-0"
          offset="1"
-         id="stop3785-0" />
+         style="stop-color:#ffffff;stop-opacity:1" />
     </linearGradient>
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3789-2"
-       id="linearGradient3806-63"
-       gradientUnits="userSpaceOnUse"
-       x1="140.23918"
-       y1="124.16501"
+       y2="117.06711"
        x2="137.60997"
-       y2="117.06711" />
+       y1="124.16501"
+       x1="140.23918"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3806-63"
+       xlink:href="#linearGradient3789-2" />
     <linearGradient
-       inkscape:collect="always"
        id="linearGradient3789-2">
       <stop
-         style="stop-color:#888a85;stop-opacity:1;"
+         id="stop3791-0"
          offset="0"
-         id="stop3791-0" />
+         style="stop-color:#888a85;stop-opacity:1;" />
       <stop
-         style="stop-color:#d3d7cf;stop-opacity:1"
+         id="stop3793-6"
          offset="1"
-         id="stop3793-6" />
+         style="stop-color:#d3d7cf;stop-opacity:1" />
     </linearGradient>
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3781-3"
-       id="linearGradient3804-9"
-       gradientUnits="userSpaceOnUse"
-       x1="93.501396"
-       y1="-0.52792466"
+       y2="-5.3353744"
        x2="92.814743"
-       y2="-5.3353744" />
+       y1="-0.52792466"
+       x1="93.501396"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3804-9"
+       xlink:href="#linearGradient3781-3" />
     <linearGradient
-       inkscape:collect="always"
        id="linearGradient3781-3">
       <stop
-         style="stop-color:#d3d7cf;stop-opacity:1;"
+         id="stop3783-74"
          offset="0"
-         id="stop3783-74" />
+         style="stop-color:#d3d7cf;stop-opacity:1;" />
       <stop
-         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3785-52"
          offset="1"
-         id="stop3785-52" />
+         style="stop-color:#ffffff;stop-opacity:1" />
     </linearGradient>
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3789-4"
-       id="linearGradient3806-5"
-       gradientUnits="userSpaceOnUse"
-       x1="140.23918"
-       y1="124.16501"
+       y2="117.06711"
        x2="137.60997"
-       y2="117.06711" />
+       y1="124.16501"
+       x1="140.23918"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3806-5"
+       xlink:href="#linearGradient3789-4" />
     <linearGradient
-       inkscape:collect="always"
        id="linearGradient3789-4">
       <stop
-         style="stop-color:#888a85;stop-opacity:1;"
+         id="stop3791-7"
          offset="0"
-         id="stop3791-7" />
+         style="stop-color:#888a85;stop-opacity:1;" />
       <stop
-         style="stop-color:#d3d7cf;stop-opacity:1"
+         id="stop3793-4"
          offset="1"
-         id="stop3793-4" />
+         style="stop-color:#d3d7cf;stop-opacity:1" />
     </linearGradient>
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3781-84"
-       id="linearGradient3804-8"
-       gradientUnits="userSpaceOnUse"
-       x1="93.501396"
-       y1="-0.52792466"
+       y2="-5.3353744"
        x2="92.814743"
-       y2="-5.3353744" />
+       y1="-0.52792466"
+       x1="93.501396"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3804-8"
+       xlink:href="#linearGradient3781-84" />
     <linearGradient
-       inkscape:collect="always"
        id="linearGradient3781-84">
       <stop
-         style="stop-color:#d3d7cf;stop-opacity:1;"
+         id="stop3783-3"
          offset="0"
-         id="stop3783-3" />
+         style="stop-color:#d3d7cf;stop-opacity:1;" />
       <stop
-         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3785-1"
          offset="1"
-         id="stop3785-1" />
+         style="stop-color:#ffffff;stop-opacity:1" />
     </linearGradient>
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3789-9"
-       id="linearGradient3806-4"
-       gradientUnits="userSpaceOnUse"
-       x1="140.23918"
-       y1="124.16501"
+       y2="117.06711"
        x2="137.60997"
-       y2="117.06711" />
+       y1="124.16501"
+       x1="140.23918"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3806-4"
+       xlink:href="#linearGradient3789-9" />
     <linearGradient
-       inkscape:collect="always"
        id="linearGradient3789-9">
       <stop
-         style="stop-color:#888a85;stop-opacity:1;"
+         id="stop3791-2"
          offset="0"
-         id="stop3791-2" />
+         style="stop-color:#888a85;stop-opacity:1;" />
       <stop
-         style="stop-color:#d3d7cf;stop-opacity:1"
+         id="stop3793-0"
          offset="1"
-         id="stop3793-0" />
+         style="stop-color:#d3d7cf;stop-opacity:1" />
     </linearGradient>
-    <filter
-       inkscape:collect="always"
-       id="filter4088"
-       x="-0.20830691"
-       width="1.4166138"
-       y="-0.64052987"
-       height="2.2810597">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="3.7687677"
-         id="feGaussianBlur4090" />
-    </filter>
     <radialGradient
-       r="18.0625"
-       fy="41.625"
-       fx="25.1875"
-       cy="41.625"
-       cx="25.1875"
-       gradientTransform="matrix(1,0,0,0.32526,0,28.08607)"
-       gradientUnits="userSpaceOnUse"
-       id="radialGradient3169"
        xlink:href="#linearGradient2269-0"
-       inkscape:collect="always" />
+       id="radialGradient3169"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.32526,0,28.08607)"
+       cx="25.1875"
+       cy="41.625"
+       fx="25.1875"
+       fy="41.625"
+       r="18.0625" />
     <linearGradient
-       inkscape:collect="always"
        id="linearGradient2269-0">
       <stop
-         offset="0"
+         style="stop-color:#000000;stop-opacity:1;"
          id="stop2271-4"
-         style="stop-color:#000000;stop-opacity:1;" />
+         offset="0" />
       <stop
-         offset="1"
+         style="stop-color:#000000;stop-opacity:0;"
          id="stop2273-87"
-         style="stop-color:#000000;stop-opacity:0;" />
+         offset="1" />
     </linearGradient>
     <radialGradient
-       r="18.0625"
-       fy="41.625"
-       fx="25.1875"
-       cy="41.625"
-       cx="25.1875"
-       gradientTransform="matrix(1,0,0,0.32526,0,28.08607)"
-       gradientUnits="userSpaceOnUse"
-       id="radialGradient3027"
        xlink:href="#linearGradient2269-0"
-       inkscape:collect="always" />
+       id="radialGradient3027"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.32526,0,28.08607)"
+       cx="25.1875"
+       cy="41.625"
+       fx="25.1875"
+       fy="41.625"
+       r="18.0625" />
   </defs>
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageopacity="0.0"
-     inkscape:pageshadow="2"
-     inkscape:zoom="3.202329"
-     inkscape:cx="5.0308728"
-     inkscape:cy="13.531895"
-     inkscape:current-layer="layer1"
-     showgrid="true"
-     inkscape:document-units="px"
-     inkscape:grid-bbox="true"
-     inkscape:snap-bbox="true"
-     inkscape:bbox-paths="true"
-     inkscape:bbox-nodes="true"
-     inkscape:snap-bbox-edge-midpoints="true"
-     inkscape:snap-bbox-midpoints="true"
-     inkscape:object-paths="true"
-     inkscape:object-nodes="true"
-     inkscape:window-width="800"
-     inkscape:window-height="837"
-     inkscape:window-x="0"
-     inkscape:window-y="27"
-     inkscape:window-maximized="0"
-     inkscape:snap-global="true">
-    <inkscape:grid
-       type="xygrid"
-       id="grid3005"
-       empspacing="2"
-       visible="true"
-       enabled="true"
-       snapvisiblegridlinesonly="true" />
-  </sodipodi:namedview>
   <metadata
      id="metadata2821">
     <rdf:RDF>
@@ -511,7 +334,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
+        <dc:title></dc:title>
         <dc:creator>
           <cc:Agent>
             <dc:title>[triplus]</dc:title>
@@ -541,126 +364,89 @@
     </rdf:RDF>
   </metadata>
   <g
-     id="layer1"
-     inkscape:label="Layer 1"
-     inkscape:groupmode="layer">
+     id="layer1">
     <path
-       id="path2267"
-       sodipodi:cx="25.1875"
-       sodipodi:cy="41.625"
-       transform="matrix(1.6349796,0,0,1.0662685,-9.1810484,1.3522451)"
-       d="m 43.25,41.625 a 18.0625,5.875 0 1 1 -36.125,0 18.0625,5.875 0 1 1 36.125,0 z"
-       sodipodi:type="arc"
        style="opacity:0.26704544;color:#000000;fill:url(#radialGradient3027);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
-       sodipodi:ry="5.875"
-       sodipodi:rx="18.0625" />
+       d="m 43.25,41.625 a 18.0625,5.875 0 1 1 -36.125,0 18.0625,5.875 0 1 1 36.125,0 z"
+       transform="matrix(1.6349796,0,0,1.0662685,-9.1810484,1.3522451)"
+       id="path2267" />
     <g
-       id="g3797"
-       transform="translate(-71.999999,3.9999969)">
+       transform="translate(-71.999999,3.9999969)"
+       id="g3797">
       <path
-         sodipodi:nodetypes="ccccc"
-         inkscape:connector-curvature="0"
-         id="rect2840-3"
-         d="m 82.146381,-7.6186648 23.470399,-2.1767614 0,12 -23.470399,2.1767615 z"
+         transform="matrix(0.93735109,0.34838619,0,1,0,0)"
          style="color:#000000;fill:url(#linearGradient3804);fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:2.06575513;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         transform="matrix(0.93735109,0.34838619,0,1,0,0)" />
+         d="m 82.146381,-7.6186648 23.470399,-2.1767614 0,12 -23.470399,2.1767615 z"
+         id="rect2840-3" />
       <path
-         sodipodi:nodetypes="ccccc"
-         inkscape:connector-curvature="0"
-         id="rect2840-3-4-0"
-         d="m 130.65607,112.26435 15.8371,4.33507 0,12 -15.8371,-4.33507 z"
+         transform="matrix(0.7577145,-0.65258619,0,1,0,0)"
          style="color:#000000;fill:url(#linearGradient3806);fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:2.29761457;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         transform="matrix(0.7577145,-0.65258619,0,1,0,0)" />
+         d="m 130.65607,112.26435 15.8371,4.33507 0,12 -15.8371,-4.33507 z"
+         id="rect2840-3-4-0" />
       <path
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccccc"
-         id="rect2840-3-5"
+         style="color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          d="m 89,15 22,6 -12,6 -22,-6 z"
-         style="color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         id="rect2840-3-5" />
       <path
-         sodipodi:nodetypes="ccccc"
-         inkscape:connector-curvature="0"
-         id="path3009"
+         style="fill:none;stroke:#ffffff;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
          d="m 79,23.757214 0,7.80924 17.977903,4.804999 0.0134,-7.937907 z"
-         style="fill:none;stroke:#ffffff;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+         id="path3009" />
       <path
-         sodipodi:nodetypes="ccccc"
-         inkscape:connector-curvature="0"
-         id="path3011"
+         style="fill:none;stroke:#d3d7cf;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
          d="m 100.99412,28.242488 0.049,7.529189 7.94611,-3.997583 0.0111,-7.540462 z"
-         style="fill:none;stroke:#d3d7cf;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+         id="path3011" />
     </g>
     <g
-       id="g3797-4"
-       transform="translate(-50,10)">
+       transform="translate(-50,10)"
+       id="g3797-4">
       <path
-         sodipodi:nodetypes="ccccc"
-         inkscape:connector-curvature="0"
-         id="rect2840-3-3"
-         d="m 82.146381,-7.6186648 23.470399,-2.1767614 0,12 -23.470399,2.1767615 z"
+         transform="matrix(0.93735109,0.34838619,0,1,0,0)"
          style="color:#000000;fill:url(#linearGradient3804-9);fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:2.06575513;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         transform="matrix(0.93735109,0.34838619,0,1,0,0)" />
+         d="m 82.146381,-7.6186648 23.470399,-2.1767614 0,12 -23.470399,2.1767615 z"
+         id="rect2840-3-3" />
       <path
-         sodipodi:nodetypes="ccccc"
-         inkscape:connector-curvature="0"
-         id="rect2840-3-4-0-0"
-         d="m 130.65607,112.26435 15.8371,4.33507 0,12 -15.8371,-4.33507 z"
+         transform="matrix(0.7577145,-0.65258619,0,1,0,0)"
          style="color:#000000;fill:url(#linearGradient3806-5);fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:2.29761457;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         transform="matrix(0.7577145,-0.65258619,0,1,0,0)" />
+         d="m 130.65607,112.26435 15.8371,4.33507 0,12 -15.8371,-4.33507 z"
+         id="rect2840-3-4-0-0" />
       <path
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccccc"
-         id="rect2840-3-5-7"
+         style="color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          d="m 89,15 22,6 -12,6 -22,-6 z"
-         style="color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         id="rect2840-3-5-7" />
       <path
-         sodipodi:nodetypes="ccccc"
-         inkscape:connector-curvature="0"
-         id="path3009-8"
+         style="fill:none;stroke:#ffffff;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
          d="m 79,23.757214 0,7.80924 17.977903,4.804999 0.0134,-7.937907 z"
-         style="fill:none;stroke:#ffffff;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+         id="path3009-8" />
       <path
-         sodipodi:nodetypes="ccccc"
-         inkscape:connector-curvature="0"
-         id="path3011-6"
+         style="fill:none;stroke:#d3d7cf;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
          d="m 100.99412,28.242488 0.049,7.529189 7.94611,-3.997583 0.0111,-7.540462 z"
-         style="fill:none;stroke:#d3d7cf;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+         id="path3011-6" />
     </g>
     <g
-       id="g3797-6"
-       transform="translate(-61.000004,-5.0000014)">
+       transform="translate(-61.000004,-5.0000014)"
+       id="g3797-6">
       <path
-         sodipodi:nodetypes="ccccc"
-         inkscape:connector-curvature="0"
-         id="rect2840-3-8"
-         d="m 82.146381,-7.6186648 23.470399,-2.1767614 0,12 -23.470399,2.1767615 z"
+         transform="matrix(0.93735109,0.34838619,0,1,0,0)"
          style="color:#000000;fill:url(#linearGradient3804-8);fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:2.06575513;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         transform="matrix(0.93735109,0.34838619,0,1,0,0)" />
+         d="m 82.146381,-7.6186648 23.470399,-2.1767614 0,12 -23.470399,2.1767615 z"
+         id="rect2840-3-8" />
       <path
-         sodipodi:nodetypes="ccccc"
-         inkscape:connector-curvature="0"
-         id="rect2840-3-4-0-9"
-         d="m 130.65607,112.26435 15.8371,4.33507 0,12 -15.8371,-4.33507 z"
+         transform="matrix(0.7577145,-0.65258619,0,1,0,0)"
          style="color:#000000;fill:url(#linearGradient3806-4);fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:2.29761457;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         transform="matrix(0.7577145,-0.65258619,0,1,0,0)" />
+         d="m 130.65607,112.26435 15.8371,4.33507 0,12 -15.8371,-4.33507 z"
+         id="rect2840-3-4-0-9" />
       <path
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccccc"
-         id="rect2840-3-5-2"
+         style="color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
          d="m 89,15 22,6 -12,6 -22,-6 z"
-         style="color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         id="rect2840-3-5-2" />
       <path
-         sodipodi:nodetypes="ccccc"
-         inkscape:connector-curvature="0"
-         id="path3009-6"
+         style="fill:none;stroke:#ffffff;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
          d="m 79,23.757214 0,7.80924 17.977903,4.804999 0.0134,-7.937907 z"
-         style="fill:none;stroke:#ffffff;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+         id="path3009-6" />
       <path
-         sodipodi:nodetypes="ccccc"
-         inkscape:connector-curvature="0"
-         id="path3011-64"
+         style="fill:none;stroke:#d3d7cf;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
          d="m 100.99412,28.242488 0.049,7.529189 7.94611,-3.997583 0.0111,-7.540462 z"
-         style="fill:none;stroke:#d3d7cf;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+         id="path3011-64" />
     </g>
   </g>
 </svg>

--- a/src/Mod/Complete/Gui/Resources/icons/CompleteWorkbench.svg
+++ b/src/Mod/Complete/Gui/Resources/icons/CompleteWorkbench.svg
@@ -1,6 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-
 <svg
    xmlns:dc="http://purl.org/dc/elements/1.1/"
    xmlns:cc="http://creativecommons.org/ns#"
@@ -8,88 +6,53 @@
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="64"
-   height="64"
-   id="svg2989"
    version="1.1"
-   inkscape:version="0.48.5 r10040"
-   sodipodi:docname="CompleteWorkbench.svg">
+   id="svg2989"
+   height="64"
+   width="64">
   <defs
      id="defs2991">
     <linearGradient
        id="linearGradient3767">
       <stop
-         style="stop-color:#c4a000;stop-opacity:1"
+         id="stop3769"
          offset="0"
-         id="stop3769" />
+         style="stop-color:#c4a000;stop-opacity:1" />
       <stop
-         style="stop-color:#fce94f;stop-opacity:1"
+         id="stop3771"
          offset="1"
-         id="stop3771" />
+         style="stop-color:#fce94f;stop-opacity:1" />
     </linearGradient>
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3767"
-       id="linearGradient3773"
-       x1="8.2747869"
-       y1="13.130123"
-       x2="2.9672837"
+       gradientTransform="matrix(1.8841249,0,0,1.9810861,22.409267,-3.0119036)"
+       gradientUnits="userSpaceOnUse"
        y2="-7.060822"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.8841249,0,0,1.9810861,22.409267,-3.0119036)" />
+       x2="2.9672837"
+       y1="13.130123"
+       x1="8.2747869"
+       id="linearGradient3773"
+       xlink:href="#linearGradient3767" />
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3767-4"
-       id="linearGradient3773-7"
-       x1="-2.6557214"
-       y1="13.003332"
-       x2="15.07192"
-       y2="-9.1497173"
+       gradientTransform="matrix(1.8841249,0,0,1.9810861,22.409267,-3.0119036)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.8841249,0,0,1.9810861,22.409267,-3.0119036)" />
+       y2="-9.1497173"
+       x2="15.07192"
+       y1="13.003332"
+       x1="-2.6557214"
+       id="linearGradient3773-7"
+       xlink:href="#linearGradient3767-4" />
     <linearGradient
        id="linearGradient3767-4">
       <stop
-         style="stop-color:#ff8d00;stop-opacity:1;"
+         id="stop3769-0"
          offset="0"
-         id="stop3769-0" />
+         style="stop-color:#ff8d00;stop-opacity:1;" />
       <stop
-         style="stop-color:#fff000;stop-opacity:1;"
+         id="stop3771-9"
          offset="1"
-         id="stop3771-9" />
+         style="stop-color:#fff000;stop-opacity:1;" />
     </linearGradient>
   </defs>
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageopacity="0.0"
-     inkscape:pageshadow="2"
-     inkscape:zoom="11.197802"
-     inkscape:cx="15.16441"
-     inkscape:cy="31.875368"
-     inkscape:current-layer="layer1"
-     showgrid="true"
-     inkscape:grid-bbox="true"
-     inkscape:document-units="px"
-     inkscape:window-width="1920"
-     inkscape:window-height="1057"
-     inkscape:window-x="1912"
-     inkscape:window-y="-8"
-     inkscape:window-maximized="1"
-     inkscape:snap-nodes="false"
-     inkscape:snap-bbox="true">
-    <inkscape:grid
-       type="xygrid"
-       id="grid2987"
-       empspacing="2"
-       visible="true"
-       enabled="true"
-       snapvisiblegridlinesonly="true" />
-  </sodipodi:namedview>
   <metadata
      id="metadata2994">
     <rdf:RDF>
@@ -98,28 +61,20 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
+        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <g
-     id="layer1"
-     inkscape:label="Layer 1"
-     inkscape:groupmode="layer"
-     transform="translate(0,32)">
+     transform="translate(0,32)"
+     id="layer1">
     <path
-       style="color:#000000;fill:url(#linearGradient3773);fill-opacity:1;fill-rule:nonzero;stroke:#3e2709;stroke-width:1.99999975999999990;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       inkscape:transform-center-y="-3.0616143"
-       d="m 32,-29 c 0,0 4.925086,12.811302 8.961494,19.8000864 8.440078,0.9492735 20.038507,2.3539443 20.038507,2.3539443 0,0 -5.000454,4.9806248 -7.523802,7.49396506 -2.52335,2.51334264 -7.616292,7.58608884 -7.616292,7.58608884 0,0 0.549541,2.8086294 1.226719,6.2696154 C 47.763806,17.964686 49.922985,29 49.922985,29 c 0,0 -6.513844,-3.726583 -9.56694,-5.473264 -3.0531,-1.746685 -8.751643,-5.006834 -8.751643,-5.006834 0,0 -5.963387,3.565669 -8.884618,5.31235 C 19.798553,25.578938 14.077014,29 14.077014,29 c 0,0 1.657742,-9.358475 2.294172,-12.951327 0.636432,-3.592854 1.524412,-8.6057861 1.524412,-8.6057861 0,0 -4.22834,-4.0561077 -6.710937,-6.4375829 -2.4826013,-2.3814775 -8.1846612,-7.8512756 -8.1846612,-7.8512756 0,0 7.0833772,-0.8081066 12.2529842,-1.684563 5.169608,-0.8764543 8.425615,-1.1583674 8.425615,-1.1583674 z"
        id="path2997"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="ccczczczczczczczcc" />
+       d="m 32,-29 c 0,0 4.925086,12.811302 8.961494,19.8000864 8.440078,0.9492735 20.038507,2.3539443 20.038507,2.3539443 0,0 -5.000454,4.9806248 -7.523802,7.49396506 -2.52335,2.51334264 -7.616292,7.58608884 -7.616292,7.58608884 0,0 0.549541,2.8086294 1.226719,6.2696154 C 47.763806,17.964686 49.922985,29 49.922985,29 c 0,0 -6.513844,-3.726583 -9.56694,-5.473264 -3.0531,-1.746685 -8.751643,-5.006834 -8.751643,-5.006834 0,0 -5.963387,3.565669 -8.884618,5.31235 C 19.798553,25.578938 14.077014,29 14.077014,29 c 0,0 1.657742,-9.358475 2.294172,-12.951327 0.636432,-3.592854 1.524412,-8.6057861 1.524412,-8.6057861 0,0 -4.22834,-4.0561077 -6.710937,-6.4375829 -2.4826013,-2.3814775 -8.1846612,-7.8512756 -8.1846612,-7.8512756 0,0 7.0833772,-0.8081066 12.2529842,-1.684563 5.169608,-0.8764543 8.425615,-1.1583674 8.425615,-1.1583674 z"
+       style="color:#000000;fill:url(#linearGradient3773);fill-opacity:1;fill-rule:nonzero;stroke:#3e2709;stroke-width:1.99999975999999990;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     <path
-       style="color:#000000;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#fce94f;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       inkscape:transform-center-y="-2.6393226"
-       d="m 31.933023,-23.816732 c 0,0 4.446694,10.530732 7.926357,16.555546 7.27593,0.8183396 16.850384,1.8506563 16.850384,1.8506563 0,0 -4.042827,4.0480575 -6.218127,6.21473085 -2.175302,2.16667415 -6.632745,6.60670855 -6.632745,6.60670855 0,0 0.473741,2.8677493 1.057516,5.8513563 C 45.500183,16.245876 47.138287,25 47.138287,25 c 0,0 -5.347474,-2.989313 -7.979453,-4.495074 -2.631982,-1.505761 -7.499868,-4.226931 -7.499868,-4.226931 0,0 -5.185503,3.029202 -7.703805,4.534959 -2.518302,1.505766 -7.227405,4.276349 -7.227405,4.276349 0,0 1.429087,-7.933696 1.977735,-11.030982 0.548648,-3.097288 1.269497,-7.3294778 1.269497,-7.3294778 0,0 -3.890705,-3.8315319 -6.030876,-5.88452764 C 11.803939,-1.2086828 7.4018645,-5.3882065 7.4018645,-5.3882065 c 0,0 5.7937945,-0.8529261 10.2280285,-1.496861 4.434235,-0.6439348 7.419744,-0.931615 7.419744,-0.931615 z"
        id="path2997-4"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="ccczczczczczczczcc" />
+       d="m 31.933023,-23.816732 c 0,0 4.446694,10.530732 7.926357,16.555546 7.27593,0.8183396 16.850384,1.8506563 16.850384,1.8506563 0,0 -4.042827,4.0480575 -6.218127,6.21473085 -2.175302,2.16667415 -6.632745,6.60670855 -6.632745,6.60670855 0,0 0.473741,2.8677493 1.057516,5.8513563 C 45.500183,16.245876 47.138287,25 47.138287,25 c 0,0 -5.347474,-2.989313 -7.979453,-4.495074 -2.631982,-1.505761 -7.499868,-4.226931 -7.499868,-4.226931 0,0 -5.185503,3.029202 -7.703805,4.534959 -2.518302,1.505766 -7.227405,4.276349 -7.227405,4.276349 0,0 1.429087,-7.933696 1.977735,-11.030982 0.548648,-3.097288 1.269497,-7.3294778 1.269497,-7.3294778 0,0 -3.890705,-3.8315319 -6.030876,-5.88452764 C 11.803939,-1.2086828 7.4018645,-5.3882065 7.4018645,-5.3882065 c 0,0 5.7937945,-0.8529261 10.2280285,-1.496861 4.434235,-0.6439348 7.419744,-0.931615 7.419744,-0.931615 z"
+       style="color:#000000;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#fce94f;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
   </g>
 </svg>

--- a/src/Mod/Draft/Resources/icons/DraftWorkbench.svg
+++ b/src/Mod/Draft/Resources/icons/DraftWorkbench.svg
@@ -1,6 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-
 <svg
    xmlns:osb="http://www.openswatchbook.org/uri/2009/osb"
    xmlns:dc="http://purl.org/dc/elements/1.1/"
@@ -9,312 +7,237 @@
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="64px"
-   height="64px"
-   id="svg2980"
-   sodipodi:version="0.32"
-   inkscape:version="0.48.5 r10040"
-   sodipodi:docname="DraftWorkbench.svg"
-   inkscape:output_extension="org.inkscape.output.svg.inkscape"
    version="1.1"
-   inkscape:export-filename="/home/yorik/Draft_Workbench_Idea16.png"
-   inkscape:export-xdpi="22.5"
-   inkscape:export-ydpi="22.5">
+   id="svg2980"
+   height="64px"
+   width="64px">
   <defs
      id="defs2982">
     <linearGradient
-       inkscape:collect="always"
        id="linearGradient3890">
       <stop
-         style="stop-color:#c4a000;stop-opacity:1"
+         id="stop3892"
          offset="0"
-         id="stop3892" />
+         style="stop-color:#c4a000;stop-opacity:1" />
       <stop
-         style="stop-color:#fce94f;stop-opacity:1"
+         id="stop3894"
          offset="1"
-         id="stop3894" />
+         style="stop-color:#fce94f;stop-opacity:1" />
     </linearGradient>
     <linearGradient
-       inkscape:collect="always"
        id="linearGradient3829">
       <stop
-         style="stop-color:#8f5902;stop-opacity:1"
+         id="stop3831"
          offset="0"
-         id="stop3831" />
+         style="stop-color:#8f5902;stop-opacity:1" />
       <stop
-         style="stop-color:#e9b96e;stop-opacity:1"
+         id="stop3833"
          offset="1"
-         id="stop3833" />
+         style="stop-color:#e9b96e;stop-opacity:1" />
     </linearGradient>
     <linearGradient
-       inkscape:collect="always"
        id="linearGradient3803">
       <stop
-         style="stop-color:#d3d7cf;stop-opacity:1"
+         id="stop3805"
          offset="0"
-         id="stop3805" />
+         style="stop-color:#d3d7cf;stop-opacity:1" />
       <stop
-         style="stop-color:#eeeeec;stop-opacity:1"
+         id="stop3807"
          offset="1"
-         id="stop3807" />
+         style="stop-color:#eeeeec;stop-opacity:1" />
     </linearGradient>
     <linearGradient
        id="linearGradient3855">
       <stop
-         style="stop-color:#e9b96e;stop-opacity:1"
+         id="stop3857"
          offset="0"
-         id="stop3857" />
+         style="stop-color:#e9b96e;stop-opacity:1" />
       <stop
-         style="stop-color:#8f5902;stop-opacity:1"
+         id="stop3859"
          offset="1"
-         id="stop3859" />
+         style="stop-color:#8f5902;stop-opacity:1" />
     </linearGradient>
     <linearGradient
-       id="linearGradient3786"
-       osb:paint="solid">
+       osb:paint="solid"
+       id="linearGradient3786">
       <stop
-         style="stop-color:#a0eb07;stop-opacity:1;"
+         id="stop3788"
          offset="0"
-         id="stop3788" />
+         style="stop-color:#a0eb07;stop-opacity:1;" />
     </linearGradient>
     <linearGradient
        id="linearGradient3864">
       <stop
-         id="stop3866"
+         style="stop-color:#71b2f8;stop-opacity:1;"
          offset="0"
-         style="stop-color:#71b2f8;stop-opacity:1;" />
+         id="stop3866" />
       <stop
-         id="stop3868"
+         style="stop-color:#002795;stop-opacity:1;"
          offset="1"
-         style="stop-color:#002795;stop-opacity:1;" />
+         id="stop3868" />
     </linearGradient>
-    <inkscape:perspective
-       sodipodi:type="inkscape:persp3d"
-       inkscape:vp_x="0 : 32 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_z="64 : 32 : 1"
-       inkscape:persp3d-origin="32 : 21.333333 : 1"
-       id="perspective2988" />
     <linearGradient
        id="linearGradient3377">
       <stop
-         style="stop-color:#ffaa00;stop-opacity:1;"
+         id="stop3379"
          offset="0"
-         id="stop3379" />
+         style="stop-color:#ffaa00;stop-opacity:1;" />
       <stop
-         style="stop-color:#faff2b;stop-opacity:1;"
+         id="stop3381"
          offset="1"
-         id="stop3381" />
+         style="stop-color:#faff2b;stop-opacity:1;" />
     </linearGradient>
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3855"
-       id="linearGradient3863"
-       x1="5.1754909"
-       y1="28.663757"
-       x2="9.3772163"
-       y2="63.578461"
+       gradientTransform="matrix(0.95198975,0,0,0.91651928,0.07298588,1.7291139)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.95198975,0,0,0.91651928,0.07298588,1.7291139)" />
+       y2="63.578461"
+       x2="9.3772163"
+       y1="28.663757"
+       x1="5.1754909"
+       id="linearGradient3863"
+       xlink:href="#linearGradient3855" />
     <linearGradient
-       gradientTransform="translate(63.406413,58.258077)"
-       inkscape:collect="always"
-       xlink:href="#linearGradient3855-2"
-       id="linearGradient3861-4"
-       x1="3.9825215"
-       y1="31.552309"
-       x2="60.769054"
+       gradientUnits="userSpaceOnUse"
        y2="51.094166"
-       gradientUnits="userSpaceOnUse" />
+       x2="60.769054"
+       y1="31.552309"
+       x1="3.9825215"
+       id="linearGradient3861-4"
+       xlink:href="#linearGradient3855-2"
+       gradientTransform="translate(63.406413,58.258077)" />
     <linearGradient
        id="linearGradient3855-2">
       <stop
-         style="stop-color:#d07200;stop-opacity:1;"
+         id="stop3857-1"
          offset="0"
-         id="stop3857-1" />
+         style="stop-color:#d07200;stop-opacity:1;" />
       <stop
-         style="stop-color:#fcb200;stop-opacity:1;"
+         id="stop3859-6"
          offset="1"
-         id="stop3859-6" />
+         style="stop-color:#fcb200;stop-opacity:1;" />
     </linearGradient>
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3855-2"
-       id="linearGradient3863-2"
-       x1="3.9825215"
-       y1="31.552309"
-       x2="23.852976"
+       gradientUnits="userSpaceOnUse"
        y2="45.686504"
-       gradientUnits="userSpaceOnUse" />
+       x2="23.852976"
+       y1="31.552309"
+       x1="3.9825215"
+       id="linearGradient3863-2"
+       xlink:href="#linearGradient3855-2" />
     <linearGradient
        id="linearGradient3880">
       <stop
-         style="stop-color:#d07200;stop-opacity:1;"
+         id="stop3882"
          offset="0"
-         id="stop3882" />
+         style="stop-color:#d07200;stop-opacity:1;" />
       <stop
-         style="stop-color:#fcb200;stop-opacity:1;"
+         id="stop3884"
          offset="1"
-         id="stop3884" />
+         style="stop-color:#fcb200;stop-opacity:1;" />
     </linearGradient>
     <linearGradient
-       gradientTransform="translate(63.406413,58.258077)"
+       xlink:href="#linearGradient3855-2"
+       id="linearGradient3889"
+       gradientUnits="userSpaceOnUse"
+       x1="3.9825215"
+       y1="31.552309"
+       x2="23.852976"
+       y2="45.686504"
+       gradientTransform="translate(63.406413,58.258077)" />
+    <linearGradient
        y2="45.686504"
        x2="23.852976"
        y1="31.552309"
        x1="3.9825215"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3889"
-       xlink:href="#linearGradient3855-2"
-       inkscape:collect="always" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3855-2"
-       id="linearGradient3921"
-       gradientUnits="userSpaceOnUse"
        gradientTransform="translate(63.406413,58.258077)"
-       x1="3.9825215"
-       y1="31.552309"
-       x2="23.852976"
-       y2="45.686504" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3803"
-       id="linearGradient3809"
-       x1="40"
-       y1="59"
-       x2="26"
-       y2="5"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3829"
-       id="linearGradient3835"
-       x1="21"
-       y1="52"
-       x2="19"
-       y2="41"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3855-5"
-       id="linearGradient3863-7"
-       x1="5.1754909"
-       y1="28.663757"
-       x2="9.3772163"
-       y2="63.578461"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.95198975,0,0,0.91651928,0.07298588,1.7291139)" />
+       id="linearGradient3921"
+       xlink:href="#linearGradient3855-2" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="5"
+       x2="26"
+       y1="59"
+       x1="40"
+       id="linearGradient3809"
+       xlink:href="#linearGradient3803" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="41"
+       x2="19"
+       y1="52"
+       x1="21"
+       id="linearGradient3835"
+       xlink:href="#linearGradient3829" />
+    <linearGradient
+       gradientTransform="matrix(0.95198975,0,0,0.91651928,0.07298588,1.7291139)"
+       gradientUnits="userSpaceOnUse"
+       y2="63.578461"
+       x2="9.3772163"
+       y1="28.663757"
+       x1="5.1754909"
+       id="linearGradient3863-7"
+       xlink:href="#linearGradient3855-5" />
     <linearGradient
        id="linearGradient3855-5">
       <stop
-         style="stop-color:#e9b96e;stop-opacity:1"
+         id="stop3857-3"
          offset="0"
-         id="stop3857-3" />
+         style="stop-color:#e9b96e;stop-opacity:1" />
       <stop
-         style="stop-color:#8f5902;stop-opacity:1"
+         id="stop3859-5"
          offset="1"
-         id="stop3859-5" />
+         style="stop-color:#8f5902;stop-opacity:1" />
     </linearGradient>
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3890"
-       id="linearGradient3896"
-       x1="37"
-       y1="38"
-       x2="32"
+       gradientUnits="userSpaceOnUse"
        y2="14"
-       gradientUnits="userSpaceOnUse" />
+       x2="32"
+       y1="38"
+       x1="37"
+       id="linearGradient3896"
+       xlink:href="#linearGradient3890" />
   </defs>
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageopacity="0.0"
-     inkscape:pageshadow="2"
-     inkscape:zoom="9.4464324"
-     inkscape:cx="0.9940587"
-     inkscape:cy="33.68254"
-     inkscape:current-layer="layer1"
-     showgrid="true"
-     inkscape:document-units="px"
-     inkscape:grid-bbox="true"
-     inkscape:window-width="1600"
-     inkscape:window-height="837"
-     inkscape:window-x="0"
-     inkscape:window-y="27"
-     inkscape:window-maximized="1"
-     inkscape:snap-nodes="true"
-     inkscape:object-paths="true"
-     inkscape:object-nodes="true">
-    <inkscape:grid
-       type="xygrid"
-       id="grid3013"
-       units="px"
-       empspacing="2"
-       visible="true"
-       enabled="true"
-       snapvisiblegridlinesonly="true"
-       spacingx="1px"
-       spacingy="1px" />
-  </sodipodi:namedview>
   <g
-     id="layer1"
-     inkscape:label="Layer 1"
-     inkscape:groupmode="layer">
+     id="layer1">
     <rect
-       style="fill:url(#linearGradient3809);fill-opacity:1;stroke:#2e3436;stroke-width:1.99999988000000006;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-       id="rect3783"
-       width="48"
-       height="58"
+       y="3"
        x="13"
-       y="3" />
+       height="58"
+       width="48"
+       id="rect3783"
+       style="fill:url(#linearGradient3809);fill-opacity:1;stroke:#2e3436;stroke-width:1.99999988000000006;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
     <path
-       style="fill:url(#linearGradient3863);fill-opacity:1;stroke:#271903;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-       d="m 7,27 -4,4 0,24 4,4 4,0 0,-32 z"
        id="path3010"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="ccccccc" />
+       d="m 7,27 -4,4 0,24 4,4 4,0 0,-32 z"
+       style="fill:url(#linearGradient3863);fill-opacity:1;stroke:#271903;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
     <rect
-       style="fill:none;stroke:#ffffff;stroke-width:1.99999975999999990;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-       id="rect3783-3"
-       width="44"
-       height="54"
+       y="5"
        x="15"
-       y="5" />
+       height="54"
+       width="44"
+       id="rect3783-3"
+       style="fill:none;stroke:#ffffff;stroke-width:1.99999975999999990;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
     <path
-       style="fill:url(#linearGradient3896);fill-opacity:1;stroke:#302b00;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-       d="m 27,5 0,32 24,0 z m 6,18 6,8 -6,0 z"
        id="path3782"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cccccccc" />
+       d="m 27,5 0,32 24,0 z m 6,18 6,8 -6,0 z"
+       style="fill:url(#linearGradient3896);fill-opacity:1;stroke:#302b00;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
     <path
-       style="fill:none;stroke:#e9b96e;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-       d="M 8,29 5,31.85285 5,54.171675 7.8160622,57 9,57 9,29 z"
        id="path3010-6"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="ccccccc" />
+       d="M 8,29 5,31.85285 5,54.171675 7.8160622,57 9,57 9,29 z"
+       style="fill:none;stroke:#e9b96e;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
     <path
-       style="fill:url(#linearGradient3835);fill-opacity:1;stroke:#271903;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-       d="M 57,39 55,45 5,50 5,39 z"
        id="path3012"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="ccccc" />
+       d="M 57,39 55,45 5,50 5,39 z"
+       style="fill:url(#linearGradient3835);fill-opacity:1;stroke:#271903;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
     <path
-       style="fill:none;stroke:#e9b96e;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-       d="M 54.220725,41 53.465976,43.178411 6.9877375,47.816062 7,41 z"
        id="path3012-6"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="ccccc" />
+       d="M 54.220725,41 53.465976,43.178411 6.9877375,47.816062 7,41 z"
+       style="fill:none;stroke:#e9b96e;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
     <path
-       style="fill:none;stroke:#fce94f;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-       d="m 29,11 0,24 18,0 z"
        id="path3782-2"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cccc" />
+       d="m 29,11 0,24 18,0 z"
+       style="fill:none;stroke:#fce94f;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
   </g>
   <metadata
      id="metadata6050">
@@ -324,7 +247,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title>DraftWorkbench</dc:title>
+        <dc:title></dc:title>
         <cc:license
            rdf:resource="" />
         <dc:date>Fri Feb 26 23:17:43 2016 +0100</dc:date>

--- a/src/Mod/Drawing/Gui/Resources/icons/DrawingWorkbench.svg
+++ b/src/Mod/Drawing/Gui/Resources/icons/DrawingWorkbench.svg
@@ -1,72 +1,252 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-<svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" width="64" height="64" id="svg249" sodipodi:version="0.32" inkscape:version="0.48.5 r10040" sodipodi:docname="DrawingWorkbench.svg" inkscape:export-filename="/home/jimmac/gfx/novell/pdes/trunk/docs/BIGmime-text.png" inkscape:export-xdpi="240.00000" inkscape:export-ydpi="240.00000" inkscape:output_extension="org.inkscape.output.svg.inkscape" version="1.1">
-  <defs id="defs3">
-    <radialGradient inkscape:collect="always" xlink:href="#linearGradient5060" id="radialGradient5031" gradientUnits="userSpaceOnUse" gradientTransform="matrix(-2.774389,0,0,1.969706,112.7623,-872.8854)" cx="605.71429" cy="486.64789" fx="605.71429" fy="486.64789" r="117.14286"/>
-    <linearGradient inkscape:collect="always" id="linearGradient5060">
-      <stop style="stop-color:black;stop-opacity:1;" offset="0" id="stop5062"/>
-      <stop style="stop-color:black;stop-opacity:0;" offset="1" id="stop5064"/>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   version="1.1"
+   id="svg249"
+   height="64"
+   width="64">
+  <defs
+     id="defs3">
+    <radialGradient
+       r="117.14286"
+       fy="486.64789"
+       fx="605.71429"
+       cy="486.64789"
+       cx="605.71429"
+       gradientTransform="matrix(-2.774389,0,0,1.969706,112.7623,-872.8854)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient5031"
+       xlink:href="#linearGradient5060" />
+    <linearGradient
+       id="linearGradient5060">
+      <stop
+         id="stop5062"
+         offset="0"
+         style="stop-color:black;stop-opacity:1;" />
+      <stop
+         id="stop5064"
+         offset="1"
+         style="stop-color:black;stop-opacity:0;" />
     </linearGradient>
-    <radialGradient inkscape:collect="always" xlink:href="#linearGradient5060" id="radialGradient5029" gradientUnits="userSpaceOnUse" gradientTransform="matrix(2.774389,0,0,1.969706,-1891.633,-872.8854)" cx="605.71429" cy="486.64789" fx="605.71429" fy="486.64789" r="117.14286"/>
-    <linearGradient id="linearGradient5048">
-      <stop style="stop-color:black;stop-opacity:0;" offset="0" id="stop5050"/>
-      <stop id="stop5056" offset="0.5" style="stop-color:black;stop-opacity:1;"/>
-      <stop style="stop-color:black;stop-opacity:0;" offset="1" id="stop5052"/>
+    <radialGradient
+       r="117.14286"
+       fy="486.64789"
+       fx="605.71429"
+       cy="486.64789"
+       cx="605.71429"
+       gradientTransform="matrix(2.774389,0,0,1.969706,-1891.633,-872.8854)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient5029"
+       xlink:href="#linearGradient5060" />
+    <linearGradient
+       id="linearGradient5048">
+      <stop
+         id="stop5050"
+         offset="0"
+         style="stop-color:black;stop-opacity:0;" />
+      <stop
+         style="stop-color:black;stop-opacity:1;"
+         offset="0.5"
+         id="stop5056" />
+      <stop
+         id="stop5052"
+         offset="1"
+         style="stop-color:black;stop-opacity:0;" />
     </linearGradient>
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient5048" id="linearGradient5027" gradientUnits="userSpaceOnUse" gradientTransform="matrix(2.774389,0,0,1.969706,-1892.179,-872.8854)" x1="302.85715" y1="366.64789" x2="302.85715" y2="609.50507"/>
-    <linearGradient inkscape:collect="always" id="linearGradient4542">
-      <stop style="stop-color:#000000;stop-opacity:1;" offset="0" id="stop4544"/>
-      <stop style="stop-color:#000000;stop-opacity:0;" offset="1" id="stop4546"/>
+    <linearGradient
+       y2="609.50507"
+       x2="302.85715"
+       y1="366.64789"
+       x1="302.85715"
+       gradientTransform="matrix(2.774389,0,0,1.969706,-1892.179,-872.8854)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5027"
+       xlink:href="#linearGradient5048" />
+    <linearGradient
+       id="linearGradient4542">
+      <stop
+         id="stop4544"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         id="stop4546"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
     </linearGradient>
-    <radialGradient inkscape:collect="always" xlink:href="#linearGradient4542" id="radialGradient4548" cx="24.306795" cy="42.07798" fx="24.306795" fy="42.07798" r="15.821514" gradientTransform="matrix(1,0,0,0.284916,0,30.08928)" gradientUnits="userSpaceOnUse"/>
-    <linearGradient id="linearGradient15662">
-      <stop style="stop-color:#ffffff;stop-opacity:1.0000000;" offset="0.0000000" id="stop15664"/>
-      <stop style="stop-color:#f8f8f8;stop-opacity:1.0000000;" offset="1.0000000" id="stop15666"/>
+    <radialGradient
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.284916,0,30.08928)"
+       r="15.821514"
+       fy="42.07798"
+       fx="24.306795"
+       cy="42.07798"
+       cx="24.306795"
+       id="radialGradient4548"
+       xlink:href="#linearGradient4542" />
+    <linearGradient
+       id="linearGradient15662">
+      <stop
+         id="stop15664"
+         offset="0.0000000"
+         style="stop-color:#ffffff;stop-opacity:1.0000000;" />
+      <stop
+         id="stop15666"
+         offset="1.0000000"
+         style="stop-color:#f8f8f8;stop-opacity:1.0000000;" />
     </linearGradient>
-    <radialGradient gradientUnits="userSpaceOnUse" fy="64.567902" fx="20.892099" r="5.257" cy="64.567902" cx="20.892099" id="aigrd3">
-      <stop id="stop15573" style="stop-color:#F0F0F0" offset="0"/>
-      <stop id="stop15575" style="stop-color:#9a9a9a;stop-opacity:1.0000000;" offset="1.0000000"/>
+    <radialGradient
+       id="aigrd3"
+       cx="20.892099"
+       cy="64.567902"
+       r="5.257"
+       fx="20.892099"
+       fy="64.567902"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         offset="0"
+         style="stop-color:#F0F0F0"
+         id="stop15573" />
+      <stop
+         offset="1.0000000"
+         style="stop-color:#9a9a9a;stop-opacity:1.0000000;"
+         id="stop15575" />
     </radialGradient>
-    <radialGradient gradientUnits="userSpaceOnUse" fy="114.5684" fx="20.892099" r="5.256" cy="114.5684" cx="20.892099" id="aigrd2">
-      <stop id="stop15566" style="stop-color:#F0F0F0" offset="0"/>
-      <stop id="stop15568" style="stop-color:#9a9a9a;stop-opacity:1.0000000;" offset="1.0000000"/>
+    <radialGradient
+       id="aigrd2"
+       cx="20.892099"
+       cy="114.5684"
+       r="5.256"
+       fx="20.892099"
+       fy="114.5684"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         offset="0"
+         style="stop-color:#F0F0F0"
+         id="stop15566" />
+      <stop
+         offset="1.0000000"
+         style="stop-color:#9a9a9a;stop-opacity:1.0000000;"
+         id="stop15568" />
     </radialGradient>
-    <linearGradient id="linearGradient269">
-      <stop style="stop-color:#a3a3a3;stop-opacity:1.0000000;" offset="0.0000000" id="stop270"/>
-      <stop style="stop-color:#4c4c4c;stop-opacity:1.0000000;" offset="1.0000000" id="stop271"/>
+    <linearGradient
+       id="linearGradient269">
+      <stop
+         id="stop270"
+         offset="0.0000000"
+         style="stop-color:#a3a3a3;stop-opacity:1.0000000;" />
+      <stop
+         id="stop271"
+         offset="1.0000000"
+         style="stop-color:#4c4c4c;stop-opacity:1.0000000;" />
     </linearGradient>
-    <linearGradient id="linearGradient259">
-      <stop style="stop-color:#fafafa;stop-opacity:1.0000000;" offset="0.0000000" id="stop260"/>
-      <stop style="stop-color:#bbbbbb;stop-opacity:1.0000000;" offset="1.0000000" id="stop261"/>
+    <linearGradient
+       id="linearGradient259">
+      <stop
+         id="stop260"
+         offset="0.0000000"
+         style="stop-color:#fafafa;stop-opacity:1.0000000;" />
+      <stop
+         id="stop261"
+         offset="1.0000000"
+         style="stop-color:#bbbbbb;stop-opacity:1.0000000;" />
     </linearGradient>
-    <linearGradient id="linearGradient12512">
-      <stop style="stop-color:#ffffff;stop-opacity:1.0000000;" offset="0.0000000" id="stop12513"/>
-      <stop style="stop-color:#fff520;stop-opacity:0.89108908;" offset="0.50000000" id="stop12517"/>
-      <stop style="stop-color:#fff300;stop-opacity:0.0000000;" offset="1.0000000" id="stop12514"/>
+    <linearGradient
+       id="linearGradient12512">
+      <stop
+         id="stop12513"
+         offset="0.0000000"
+         style="stop-color:#ffffff;stop-opacity:1.0000000;" />
+      <stop
+         id="stop12517"
+         offset="0.50000000"
+         style="stop-color:#fff520;stop-opacity:0.89108908;" />
+      <stop
+         id="stop12514"
+         offset="1.0000000"
+         style="stop-color:#fff300;stop-opacity:0.0000000;" />
     </linearGradient>
-    <radialGradient inkscape:collect="always" xlink:href="#linearGradient12512" id="radialGradient278" gradientUnits="userSpaceOnUse" cx="55" cy="125" fx="55" fy="125" r="14.375"/>
-    <radialGradient r="37.751713" fy="33.647495" fx="4.7390747" cy="33.647495" cx="4.7390747" gradientTransform="matrix(1.3247068,0,0,1.3619605,-15.444424,-62.94288)" gradientUnits="userSpaceOnUse" id="radialGradient15656" xlink:href="#linearGradient269" inkscape:collect="always"/>
-    <radialGradient r="86.70845" fy="36.040306" fx="34.985172" cy="36.040306" cx="34.985172" gradientTransform="matrix(1.314063,0,0,1.3729918,-20.032465,-63.79538)" gradientUnits="userSpaceOnUse" id="radialGradient15658" xlink:href="#linearGradient259" inkscape:collect="always"/>
-    <radialGradient r="38.158695" fy="39.113754" fx="7.5266156" cy="39.113754" cx="7.5266156" gradientTransform="matrix(1.3247068,0,0,1.3619605,-15.444424,-62.94288)" gradientUnits="userSpaceOnUse" id="radialGradient15668" xlink:href="#linearGradient15662" inkscape:collect="always"/>
-    <radialGradient inkscape:collect="always" xlink:href="#aigrd2" id="radialGradient2283" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.229703,0,0,0.229703,4.613529,3.979808)" cx="20.892099" cy="114.5684" fx="20.892099" fy="114.5684" r="5.256"/>
-    <radialGradient inkscape:collect="always" xlink:href="#aigrd3" id="radialGradient2285" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.229703,0,0,0.229703,4.613529,3.979808)" cx="20.892099" cy="64.567902" fx="20.892099" fy="64.567902" r="5.257"/>
+    <radialGradient
+       r="14.375"
+       fy="125"
+       fx="55"
+       cy="125"
+       cx="55"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient278"
+       xlink:href="#linearGradient12512" />
+    <radialGradient
+       xlink:href="#linearGradient269"
+       id="radialGradient15656"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3247068,0,0,1.3619605,-15.444424,-62.94288)"
+       cx="4.7390747"
+       cy="33.647495"
+       fx="4.7390747"
+       fy="33.647495"
+       r="37.751713" />
+    <radialGradient
+       xlink:href="#linearGradient259"
+       id="radialGradient15658"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.314063,0,0,1.3729918,-20.032465,-63.79538)"
+       cx="34.985172"
+       cy="36.040306"
+       fx="34.985172"
+       fy="36.040306"
+       r="86.70845" />
+    <radialGradient
+       xlink:href="#linearGradient15662"
+       id="radialGradient15668"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3247068,0,0,1.3619605,-15.444424,-62.94288)"
+       cx="7.5266156"
+       cy="39.113754"
+       fx="7.5266156"
+       fy="39.113754"
+       r="38.158695" />
+    <radialGradient
+       r="5.256"
+       fy="114.5684"
+       fx="20.892099"
+       cy="114.5684"
+       cx="20.892099"
+       gradientTransform="matrix(0.229703,0,0,0.229703,4.613529,3.979808)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient2283"
+       xlink:href="#aigrd2" />
+    <radialGradient
+       r="5.257"
+       fy="64.567902"
+       fx="20.892099"
+       cy="64.567902"
+       cx="20.892099"
+       gradientTransform="matrix(0.229703,0,0,0.229703,4.613529,3.979808)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient2285"
+       xlink:href="#aigrd3" />
   </defs>
-  <sodipodi:namedview id="base" pagecolor="#ffffff" bordercolor="#666666" borderopacity="0.32941176" inkscape:pageopacity="0.0" inkscape:pageshadow="2" inkscape:zoom="5.8571289" inkscape:cx="-10.046772" inkscape:cy="25.164578" inkscape:current-layer="layer1" showgrid="true" inkscape:grid-bbox="true" inkscape:document-units="px" inkscape:window-width="1600" inkscape:window-height="837" inkscape:window-x="0" inkscape:window-y="27" inkscape:showpageshadow="false" inkscape:window-maximized="1">
-    <inkscape:grid type="xygrid" id="grid3070" empspacing="2" visible="true" enabled="true" snapvisiblegridlinesonly="true"/>
-  </sodipodi:namedview>
-  <metadata id="metadata4">
+  <metadata
+     id="metadata4">
     <rdf:RDF>
-      <cc:Work rdf:about="">
+      <cc:Work
+         rdf:about="">
         <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-        <dc:title>New Document</dc:title>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
         <dc:creator>
           <cc:Agent>
             <dc:title>Jakub Steiner</dc:title>
           </cc:Agent>
         </dc:creator>
         <dc:source>http://jimmac.musichall.cz</dc:source>
-        <cc:license rdf:resource="http://creativecommons.ohttps://www.gnu.org/licenses/lgpl.htmlrg/licenses/by-sa/2.0/"/>
+        <cc:license
+           rdf:resource="http://creativecommons.ohttps://www.gnu.org/licenses/lgpl.htmlrg/licenses/by-sa/2.0/" />
         <dc:date>2016-02-26</dc:date>
         <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
         <dc:publisher>
@@ -86,44 +266,141 @@
           </cc:Agent>
         </dc:contributor>
       </cc:Work>
-      <cc:License rdf:about="http://creativecommons.org/licenses/by-sa/2.0/">
-        <cc:permits rdf:resource="http://web.resource.org/cc/Reproduction"/>
-        <cc:permits rdf:resource="http://web.resource.org/cc/Distribution"/>
-        <cc:requires rdf:resource="http://web.resource.org/cc/Notice"/>
-        <cc:requires rdf:resource="http://web.resource.org/cc/Attribution"/>
-        <cc:permits rdf:resource="http://web.resource.org/cc/DerivativeWorks"/>
-        <cc:requires rdf:resource="http://web.resource.org/cc/ShareAlike"/>
+      <cc:License
+         rdf:about="http://creativecommons.org/licenses/by-sa/2.0/">
+        <cc:permits
+           rdf:resource="http://web.resource.org/cc/Reproduction" />
+        <cc:permits
+           rdf:resource="http://web.resource.org/cc/Distribution" />
+        <cc:requires
+           rdf:resource="http://web.resource.org/cc/Notice" />
+        <cc:requires
+           rdf:resource="http://web.resource.org/cc/Attribution" />
+        <cc:permits
+           rdf:resource="http://web.resource.org/cc/DerivativeWorks" />
+        <cc:requires
+           rdf:resource="http://web.resource.org/cc/ShareAlike" />
       </cc:License>
     </rdf:RDF>
   </metadata>
-  <g inkscape:label="Shadow" id="layer6" inkscape:groupmode="layer" transform="translate(0,16)">
-    <g style="display:inline" id="g5022" transform="matrix(0.03068766,0,0,0.02200111,58.892175,40.344687)">
-      <rect y="-150.69685" x="-1559.2523" height="478.35718" width="1339.6335" id="rect4173" style="opacity:0.40206185;color:#000000;fill:url(#linearGradient5027);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"/>
-      <path sodipodi:nodetypes="cccc" id="path5058" d="m -219.61876,-150.68038 c 0,0 0,478.33079 0,478.33079 142.874166,0.90045 345.40022,-107.16966 345.40014,-239.196175 0,-132.026537 -159.436816,-239.134595 -345.40014,-239.134615 z" style="opacity:0.40206185;color:#000000;fill:url(#radialGradient5029);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" inkscape:connector-curvature="0"/>
-      <path style="opacity:0.40206185;color:#000000;fill:url(#radialGradient5031);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" d="m -1559.2523,-150.68038 c 0,0 0,478.33079 0,478.33079 -142.8742,0.90045 -345.4002,-107.16966 -345.4002,-239.196175 0,-132.026537 159.4368,-239.134595 345.4002,-239.134615 z" id="path5018" sodipodi:nodetypes="cccc" inkscape:connector-curvature="0"/>
+  <g
+     transform="translate(0,16)"
+     id="layer6">
+    <g
+       transform="matrix(0.03068766,0,0,0.02200111,58.892175,40.344687)"
+       id="g5022"
+       style="display:inline">
+      <rect
+         style="opacity:0.40206185;color:#000000;fill:url(#linearGradient5027);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
+         id="rect4173"
+         width="1339.6335"
+         height="478.35718"
+         x="-1559.2523"
+         y="-150.69685" />
+      <path
+         style="opacity:0.40206185;color:#000000;fill:url(#radialGradient5029);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
+         d="m -219.61876,-150.68038 c 0,0 0,478.33079 0,478.33079 142.874166,0.90045 345.40022,-107.16966 345.40014,-239.196175 0,-132.026537 -159.436816,-239.134595 -345.40014,-239.134615 z"
+         id="path5058" />
+      <path
+         id="path5018"
+         d="m -1559.2523,-150.68038 c 0,0 0,478.33079 0,478.33079 -142.8742,0.90045 -345.4002,-107.16966 -345.4002,-239.196175 0,-132.026537 159.4368,-239.134595 345.4002,-239.134615 z"
+         style="opacity:0.40206185;color:#000000;fill:url(#radialGradient5031);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
     </g>
   </g>
-  <g id="layer1" inkscape:label="Base" inkscape:groupmode="layer" style="display:inline" transform="translate(0,16)">
-    <rect ry="1.5153066" y="-58.986629" x="-10.998057" height="53.982662" width="48.021397" id="rect15391" style="color:#000000;fill:url(#radialGradient15658);fill-opacity:1;fill-rule:nonzero;stroke:url(#radialGradient15656);stroke-width:1.99999976;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;marker:none;visibility:visible;display:block;overflow:visible" rx="1.5720282" transform="matrix(3.6092691e-4,0.99999993,-0.99999992,3.8845335e-4,0,0)"/>
-    <rect rx="0.20391527" ry="0.19655766" y="-57.003246" x="-8.9778576" height="50.015881" width="43.980576" id="rect15660" style="color:#000000;fill:none;stroke:url(#radialGradient15668);stroke-width:1.99999976;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;marker:none;visibility:visible;display:block;overflow:visible" transform="matrix(3.6092691e-4,0.99999993,-0.99999992,3.8845335e-4,0,0)"/>
-    <g id="g2270" transform="matrix(4.937888e-4,1.3681128,-1.3187488,5.1227249e-4,63.838568,-19.172849)">
-      <g transform="matrix(0.229703,0,0,0.229703,4.967081,4.244972)" style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.74448836;stroke-miterlimit:4" id="g1440">
-        <radialGradient gradientUnits="userSpaceOnUse" fy="114.5684" fx="20.892099" r="5.256" cy="114.5684" cx="20.892099" id="radialGradient1442">
-          <stop id="stop1444" style="stop-color:#F0F0F0" offset="0"/>
-          <stop id="stop1446" style="stop-color:#474747" offset="1"/>
+  <g
+     transform="translate(0,16)"
+     style="display:inline"
+     id="layer1">
+    <rect
+       transform="matrix(3.6092691e-4,0.99999993,-0.99999992,3.8845335e-4,0,0)"
+       rx="1.5720282"
+       style="color:#000000;fill:url(#radialGradient15658);fill-opacity:1;fill-rule:nonzero;stroke:url(#radialGradient15656);stroke-width:1.99999976;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;marker:none;visibility:visible;display:block;overflow:visible"
+       id="rect15391"
+       width="48.021397"
+       height="53.982662"
+       x="-10.998057"
+       y="-58.986629"
+       ry="1.5153066" />
+    <rect
+       transform="matrix(3.6092691e-4,0.99999993,-0.99999992,3.8845335e-4,0,0)"
+       style="color:#000000;fill:none;stroke:url(#radialGradient15668);stroke-width:1.99999976;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;marker:none;visibility:visible;display:block;overflow:visible"
+       id="rect15660"
+       width="43.980576"
+       height="50.015881"
+       x="-8.9778576"
+       y="-57.003246"
+       ry="0.19655766"
+       rx="0.20391527" />
+    <g
+       transform="matrix(4.937888e-4,1.3681128,-1.3187488,5.1227249e-4,63.838568,-19.172849)"
+       id="g2270">
+      <g
+         id="g1440"
+         style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.74448836;stroke-miterlimit:4"
+         transform="matrix(0.229703,0,0,0.229703,4.967081,4.244972)">
+        <radialGradient
+           id="radialGradient1442"
+           cx="20.892099"
+           cy="114.5684"
+           r="5.256"
+           fx="20.892099"
+           fy="114.5684"
+           gradientUnits="userSpaceOnUse">
+          <stop
+             offset="0"
+             style="stop-color:#F0F0F0"
+             id="stop1444" />
+          <stop
+             offset="1"
+             style="stop-color:#474747"
+             id="stop1446" />
         </radialGradient>
-        <path id="path1448" d="m 23.428,113.07 c 0,1.973 -1.6,3.572 -3.573,3.572 -1.974,0 -3.573,-1.6 -3.573,-3.572 0,-1.974 1.6,-3.573 3.573,-3.573 1.973,0 3.573,1.6 3.573,3.573 z" style="stroke:none" inkscape:connector-curvature="0"/>
-        <radialGradient gradientUnits="userSpaceOnUse" fy="64.567902" fx="20.892099" r="5.257" cy="64.567902" cx="20.892099" id="radialGradient1450">
-          <stop id="stop1452" style="stop-color:#F0F0F0" offset="0"/>
-          <stop id="stop1454" style="stop-color:#474747" offset="1"/>
+        <path
+           style="stroke:none"
+           d="m 23.428,113.07 c 0,1.973 -1.6,3.572 -3.573,3.572 -1.974,0 -3.573,-1.6 -3.573,-3.572 0,-1.974 1.6,-3.573 3.573,-3.573 1.973,0 3.573,1.6 3.573,3.573 z"
+           id="path1448" />
+        <radialGradient
+           id="radialGradient1450"
+           cx="20.892099"
+           cy="64.567902"
+           r="5.257"
+           fx="20.892099"
+           fy="64.567902"
+           gradientUnits="userSpaceOnUse">
+          <stop
+             offset="0"
+             style="stop-color:#F0F0F0"
+             id="stop1452" />
+          <stop
+             offset="1"
+             style="stop-color:#474747"
+             id="stop1454" />
         </radialGradient>
-        <path id="path1456" d="m 23.428,63.07 c 0,1.973 -1.6,3.573 -3.573,3.573 -1.974,0 -3.573,-1.6 -3.573,-3.573 0,-1.974 1.6,-3.573 3.573,-3.573 1.973,0 3.573,1.6 3.573,3.573 z" style="stroke:none" inkscape:connector-curvature="0"/>
+        <path
+           style="stroke:none"
+           d="m 23.428,63.07 c 0,1.973 -1.6,3.573 -3.573,3.573 -1.974,0 -3.573,-1.6 -3.573,-3.573 0,-1.974 1.6,-3.573 3.573,-3.573 1.973,0 3.573,1.6 3.573,3.573 z"
+           id="path1456" />
       </g>
-      <path id="path15570" d="m 9.9950109,29.952326 c 0,0.453204 -0.3675248,0.820499 -0.8207288,0.820499 -0.4534338,0 -0.8207289,-0.367524 -0.8207289,-0.820499 0,-0.453434 0.3675248,-0.820729 0.8207289,-0.820729 0.453204,0 0.8207288,0.367525 0.8207288,0.820729 z" style="fill:url(#radialGradient2283);fill-rule:nonzero;stroke:none" inkscape:connector-curvature="0"/>
-      <path id="path15577" d="m 9.9950109,18.467176 c 0,0.453204 -0.3675248,0.820729 -0.8207288,0.820729 -0.4534338,0 -0.8207289,-0.367525 -0.8207289,-0.820729 0,-0.453434 0.3675248,-0.820729 0.8207289,-0.820729 0.453204,0 0.8207288,0.367525 0.8207288,0.820729 z" style="fill:url(#radialGradient2285);fill-rule:nonzero;stroke:none" inkscape:connector-curvature="0"/>
+      <path
+         style="fill:url(#radialGradient2283);fill-rule:nonzero;stroke:none"
+         d="m 9.9950109,29.952326 c 0,0.453204 -0.3675248,0.820499 -0.8207288,0.820499 -0.4534338,0 -0.8207289,-0.367524 -0.8207289,-0.820499 0,-0.453434 0.3675248,-0.820729 0.8207289,-0.820729 0.453204,0 0.8207288,0.367525 0.8207288,0.820729 z"
+         id="path15570" />
+      <path
+         style="fill:url(#radialGradient2285);fill-rule:nonzero;stroke:none"
+         d="m 9.9950109,18.467176 c 0,0.453204 -0.3675248,0.820729 -0.8207288,0.820729 -0.4534338,0 -0.8207289,-0.367525 -0.8207289,-0.820729 0,-0.453434 0.3675248,-0.820729 0.8207289,-0.820729 0.453204,0 0.8207288,0.367525 0.8207288,0.820729 z"
+         id="path15577" />
     </g>
-    <path sodipodi:nodetypes="cc" id="path15672" d="M 56.54826,-4.3133003 6.5589783,-4.2938814" style="fill:none;stroke:#000000;stroke-width:0.98855317;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:0.01754384" inkscape:connector-curvature="0"/>
-    <path sodipodi:nodetypes="cc" id="path15674" d="M 57.173525,-2.9532592 7.0377017,-2.9337842" style="fill:none;stroke:#ffffff;stroke-width:0.99999988;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:0.20467828" inkscape:connector-curvature="0"/>
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.98855317;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:0.01754384"
+       d="M 56.54826,-4.3133003 6.5589783,-4.2938814"
+       id="path15672" />
+    <path
+       style="fill:none;stroke:#ffffff;stroke-width:0.99999988;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:0.20467828"
+       d="M 57.173525,-2.9532592 7.0377017,-2.9337842"
+       id="path15674" />
   </g>
-  <g inkscape:groupmode="layer" id="layer4" inkscape:label="new" style="display:inline" transform="translate(0,16)"/>
+  <g
+     transform="translate(0,16)"
+     style="display:inline"
+     id="layer4" />
 </svg>

--- a/src/Mod/Fem/Gui/Resources/icons/FemWorkbench.svg
+++ b/src/Mod/Fem/Gui/Resources/icons/FemWorkbench.svg
@@ -1,112 +1,408 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-<svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" width="64px" height="64px" id="svg2816" version="1.1" inkscape:version="0.48.5 r10040" sodipodi:docname="FemWorkbench.svg">
-  <defs id="defs2818">
-    <linearGradient inkscape:collect="always" id="linearGradient4114">
-      <stop style="stop-color:#a40000;stop-opacity:1;" offset="0" id="stop4116"/>
-      <stop style="stop-color:#cc0000;stop-opacity:1" offset="1" id="stop4118"/>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   version="1.1"
+   id="svg2816"
+   height="64px"
+   width="64px">
+  <defs
+     id="defs2818">
+    <linearGradient
+       id="linearGradient4114">
+      <stop
+         id="stop4116"
+         offset="0"
+         style="stop-color:#a40000;stop-opacity:1;" />
+      <stop
+         id="stop4118"
+         offset="1"
+         style="stop-color:#cc0000;stop-opacity:1" />
     </linearGradient>
-    <linearGradient id="linearGradient3330" inkscape:collect="always">
-      <stop id="stop3332" offset="0" style="stop-color:#729fcf;stop-opacity:1"/>
-      <stop id="stop3334" offset="1" style="stop-color:#3465a4;stop-opacity:1"/>
+    <linearGradient
+       id="linearGradient3330">
+      <stop
+         style="stop-color:#729fcf;stop-opacity:1"
+         offset="0"
+         id="stop3332" />
+      <stop
+         style="stop-color:#3465a4;stop-opacity:1"
+         offset="1"
+         id="stop3334" />
     </linearGradient>
-    <linearGradient inkscape:collect="always" id="linearGradient3324">
-      <stop style="stop-color:#fce94f;stop-opacity:1" offset="0" id="stop3326"/>
-      <stop style="stop-color:#73d216;stop-opacity:1" offset="1" id="stop3328"/>
+    <linearGradient
+       id="linearGradient3324">
+      <stop
+         id="stop3326"
+         offset="0"
+         style="stop-color:#fce94f;stop-opacity:1" />
+      <stop
+         id="stop3328"
+         offset="1"
+         style="stop-color:#73d216;stop-opacity:1" />
     </linearGradient>
-    <linearGradient inkscape:collect="always" id="linearGradient3318">
-      <stop style="stop-color:#fce94f;stop-opacity:1" offset="0" id="stop3320"/>
-      <stop style="stop-color:#73d216;stop-opacity:1" offset="1" id="stop3322"/>
+    <linearGradient
+       id="linearGradient3318">
+      <stop
+         id="stop3320"
+         offset="0"
+         style="stop-color:#fce94f;stop-opacity:1" />
+      <stop
+         id="stop3322"
+         offset="1"
+         style="stop-color:#73d216;stop-opacity:1" />
     </linearGradient>
-    <linearGradient inkscape:collect="always" id="linearGradient3312">
-      <stop style="stop-color:#fce94f;stop-opacity:1" offset="0" id="stop3314"/>
-      <stop style="stop-color:#73d216;stop-opacity:1" offset="1" id="stop3316"/>
+    <linearGradient
+       id="linearGradient3312">
+      <stop
+         id="stop3314"
+         offset="0"
+         style="stop-color:#fce94f;stop-opacity:1" />
+      <stop
+         id="stop3316"
+         offset="1"
+         style="stop-color:#73d216;stop-opacity:1" />
     </linearGradient>
-    <linearGradient inkscape:collect="always" id="linearGradient3306">
-      <stop style="stop-color:#fce94f;stop-opacity:1" offset="0" id="stop3308"/>
-      <stop style="stop-color:#73d216;stop-opacity:1" offset="1" id="stop3310"/>
+    <linearGradient
+       id="linearGradient3306">
+      <stop
+         id="stop3308"
+         offset="0"
+         style="stop-color:#fce94f;stop-opacity:1" />
+      <stop
+         id="stop3310"
+         offset="1"
+         style="stop-color:#73d216;stop-opacity:1" />
     </linearGradient>
-    <linearGradient inkscape:collect="always" id="linearGradient3300">
-      <stop style="stop-color:#fce94f;stop-opacity:1" offset="0" id="stop3302"/>
-      <stop style="stop-color:#73d216;stop-opacity:1" offset="1" id="stop3304"/>
+    <linearGradient
+       id="linearGradient3300">
+      <stop
+         id="stop3302"
+         offset="0"
+         style="stop-color:#fce94f;stop-opacity:1" />
+      <stop
+         id="stop3304"
+         offset="1"
+         style="stop-color:#73d216;stop-opacity:1" />
     </linearGradient>
-    <linearGradient inkscape:collect="always" id="linearGradient3294">
-      <stop style="stop-color:#73d216;stop-opacity:1" offset="0" id="stop3296"/>
-      <stop style="stop-color:#729fcf;stop-opacity:1" offset="1" id="stop3298"/>
+    <linearGradient
+       id="linearGradient3294">
+      <stop
+         id="stop3296"
+         offset="0"
+         style="stop-color:#73d216;stop-opacity:1" />
+      <stop
+         id="stop3298"
+         offset="1"
+         style="stop-color:#729fcf;stop-opacity:1" />
     </linearGradient>
-    <linearGradient inkscape:collect="always" id="linearGradient3288">
-      <stop style="stop-color:#73d216;stop-opacity:1" offset="0" id="stop3290"/>
-      <stop style="stop-color:#729fcf;stop-opacity:1" offset="1" id="stop3292"/>
+    <linearGradient
+       id="linearGradient3288">
+      <stop
+         id="stop3290"
+         offset="0"
+         style="stop-color:#73d216;stop-opacity:1" />
+      <stop
+         id="stop3292"
+         offset="1"
+         style="stop-color:#729fcf;stop-opacity:1" />
     </linearGradient>
-    <linearGradient inkscape:collect="always" id="linearGradient3282">
-      <stop style="stop-color:#73d216;stop-opacity:1" offset="0" id="stop3284"/>
-      <stop style="stop-color:#729fcf;stop-opacity:1" offset="1" id="stop3286"/>
+    <linearGradient
+       id="linearGradient3282">
+      <stop
+         id="stop3284"
+         offset="0"
+         style="stop-color:#73d216;stop-opacity:1" />
+      <stop
+         id="stop3286"
+         offset="1"
+         style="stop-color:#729fcf;stop-opacity:1" />
     </linearGradient>
-    <linearGradient inkscape:collect="always" id="linearGradient3276">
-      <stop style="stop-color:#cc0000;stop-opacity:1" offset="0" id="stop3278"/>
-      <stop style="stop-color:#fce94f;stop-opacity:1" offset="1" id="stop3280"/>
+    <linearGradient
+       id="linearGradient3276">
+      <stop
+         id="stop3278"
+         offset="0"
+         style="stop-color:#cc0000;stop-opacity:1" />
+      <stop
+         id="stop3280"
+         offset="1"
+         style="stop-color:#fce94f;stop-opacity:1" />
     </linearGradient>
-    <linearGradient inkscape:collect="always" id="linearGradient3270">
-      <stop style="stop-color:#cc0000;stop-opacity:1" offset="0" id="stop3272"/>
-      <stop style="stop-color:#fce94f;stop-opacity:1" offset="1" id="stop3274"/>
+    <linearGradient
+       id="linearGradient3270">
+      <stop
+         id="stop3272"
+         offset="0"
+         style="stop-color:#cc0000;stop-opacity:1" />
+      <stop
+         id="stop3274"
+         offset="1"
+         style="stop-color:#fce94f;stop-opacity:1" />
     </linearGradient>
-    <linearGradient inkscape:collect="always" id="linearGradient5722">
-      <stop style="stop-color:#73d216;stop-opacity:1" offset="0" id="stop5724"/>
-      <stop style="stop-color:#3465a4;stop-opacity:1" offset="1" id="stop5726"/>
+    <linearGradient
+       id="linearGradient5722">
+      <stop
+         id="stop5724"
+         offset="0"
+         style="stop-color:#73d216;stop-opacity:1" />
+      <stop
+         id="stop5726"
+         offset="1"
+         style="stop-color:#3465a4;stop-opacity:1" />
     </linearGradient>
-    <linearGradient id="linearGradient5676" inkscape:collect="always">
-      <stop id="stop5678" offset="0" style="stop-color:#fce94f;stop-opacity:1"/>
-      <stop id="stop5680" offset="1" style="stop-color:#73d216;stop-opacity:1"/>
+    <linearGradient
+       id="linearGradient5676">
+      <stop
+         style="stop-color:#fce94f;stop-opacity:1"
+         offset="0"
+         id="stop5678" />
+      <stop
+         style="stop-color:#73d216;stop-opacity:1"
+         offset="1"
+         id="stop5680" />
     </linearGradient>
-    <linearGradient inkscape:collect="always" id="linearGradient5652">
-      <stop style="stop-color:#fce94f;stop-opacity:1" offset="0" id="stop5654"/>
-      <stop style="stop-color:#73d216;stop-opacity:1" offset="1" id="stop5656"/>
+    <linearGradient
+       id="linearGradient5652">
+      <stop
+         id="stop5654"
+         offset="0"
+         style="stop-color:#fce94f;stop-opacity:1" />
+      <stop
+         id="stop5656"
+         offset="1"
+         style="stop-color:#73d216;stop-opacity:1" />
     </linearGradient>
-    <linearGradient id="linearGradient5646" inkscape:collect="always">
-      <stop id="stop5648" offset="0" style="stop-color:#cc0000;stop-opacity:1"/>
-      <stop id="stop5650" offset="1" style="stop-color:#fce94f;stop-opacity:1"/>
+    <linearGradient
+       id="linearGradient5646">
+      <stop
+         style="stop-color:#cc0000;stop-opacity:1"
+         offset="0"
+         id="stop5648" />
+      <stop
+         style="stop-color:#fce94f;stop-opacity:1"
+         offset="1"
+         id="stop5650" />
     </linearGradient>
-    <linearGradient inkscape:collect="always" id="linearGradient5606">
-      <stop style="stop-color:#729fcf;stop-opacity:1" offset="0" id="stop5608"/>
-      <stop style="stop-color:#3465a4;stop-opacity:1" offset="1" id="stop5610"/>
+    <linearGradient
+       id="linearGradient5606">
+      <stop
+         id="stop5608"
+         offset="0"
+         style="stop-color:#729fcf;stop-opacity:1" />
+      <stop
+         id="stop5610"
+         offset="1"
+         style="stop-color:#3465a4;stop-opacity:1" />
     </linearGradient>
-    <linearGradient id="linearGradient5576" inkscape:collect="always">
-      <stop id="stop5578" offset="0" style="stop-color:#73d216;stop-opacity:1"/>
-      <stop id="stop5580" offset="1" style="stop-color:#729fcf;stop-opacity:1"/>
+    <linearGradient
+       id="linearGradient5576">
+      <stop
+         style="stop-color:#73d216;stop-opacity:1"
+         offset="0"
+         id="stop5578" />
+      <stop
+         style="stop-color:#729fcf;stop-opacity:1"
+         offset="1"
+         id="stop5580" />
     </linearGradient>
-    <linearGradient inkscape:collect="always" id="linearGradient2269">
-      <stop style="stop-color:#000000;stop-opacity:1;" offset="0" id="stop5538"/>
-      <stop style="stop-color:#000000;stop-opacity:0;" offset="1" id="stop5540"/>
+    <linearGradient
+       id="linearGradient2269">
+      <stop
+         id="stop5538"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         id="stop5540"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
     </linearGradient>
-    <radialGradient r="18.0625" fy="41.625" fx="25.1875" cy="41.625" cx="25.1875" gradientTransform="matrix(1.1991353,0,0,0.18727682,9.60253,47.497421)" gradientUnits="userSpaceOnUse" id="radialGradient3049" xlink:href="#linearGradient2269" inkscape:collect="always"/>
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient3276" id="linearGradient5550" x1="19.728148" y1="38.57375" x2="21.638357" y2="33.097897" gradientUnits="userSpaceOnUse" gradientTransform="translate(2,2)"/>
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient3270" id="linearGradient5558" x1="19.145359" y1="38.213882" x2="16.813908" y2="31.730888" gradientUnits="userSpaceOnUse" gradientTransform="translate(2,2)"/>
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient5646" id="linearGradient5566" x1="19.881519" y1="38.502609" x2="26.189007" y2="39.196541" gradientUnits="userSpaceOnUse" gradientTransform="translate(2,2)"/>
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient3294" id="linearGradient5574" x1="29.10784" y1="38.921127" x2="31.672956" y2="36.145401" gradientUnits="userSpaceOnUse" gradientTransform="translate(2,2)"/>
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient3288" id="linearGradient5588" x1="32.311722" y1="41.789768" x2="34.239601" y2="39.562164" gradientUnits="userSpaceOnUse" gradientTransform="translate(2,2)"/>
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient3282" id="linearGradient5596" x1="34.10231" y1="44.436687" x2="36.356281" y2="42.322491" gradientUnits="userSpaceOnUse" gradientTransform="translate(2,2)"/>
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient5576" id="linearGradient5604" x1="27.345615" y1="34.843632" x2="31.261166" y2="32.980549" gradientUnits="userSpaceOnUse" gradientTransform="translate(2,2)"/>
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient5606" id="linearGradient5612" x1="31.979929" y1="35.084328" x2="34.970161" y2="33.275246" gradientUnits="userSpaceOnUse" gradientTransform="translate(2,2)"/>
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient3330" id="linearGradient5620" x1="33.611019" y1="37.152149" x2="36.115841" y2="35.175659" gradientUnits="userSpaceOnUse" gradientTransform="translate(2,2)"/>
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient5652" id="linearGradient5658" x1="27.153559" y1="40.265026" x2="29.432671" y2="39.22818" gradientUnits="userSpaceOnUse" gradientTransform="translate(2,2)"/>
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient3300" id="linearGradient5666" x1="19.64187" y1="31.54216" x2="20.5632" y2="28.801535" gradientUnits="userSpaceOnUse" gradientTransform="translate(2,2)"/>
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient3312" id="linearGradient5674" x1="17.048548" y1="30.556971" x2="15.030108" y2="28.666885" gradientUnits="userSpaceOnUse" gradientTransform="translate(2,2)"/>
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient3318" id="linearGradient5688" x1="15.841824" y1="32.223648" x2="14.456498" y2="30.274158" gradientUnits="userSpaceOnUse" gradientTransform="translate(2,2)"/>
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient3306" id="linearGradient5696" x1="17.666838" y1="30.243673" x2="17.149237" y2="27.200634" gradientUnits="userSpaceOnUse" gradientTransform="translate(2,2)"/>
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient5676" id="linearGradient5704" x1="24.720701" y1="33.487141" x2="24.214138" y2="29.058939" gradientUnits="userSpaceOnUse" gradientTransform="translate(2,2)"/>
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient3324" id="linearGradient5712" x1="24.752634" y1="33.891273" x2="28.001352" y2="30.132702" gradientUnits="userSpaceOnUse" gradientTransform="translate(2,2)"/>
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient5722" id="linearGradient5720" x1="37.336205" y1="45.2005" x2="40.381905" y2="42.779541" gradientUnits="userSpaceOnUse" gradientTransform="translate(2,2)"/>
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient4114" id="linearGradient4120" x1="-46" y1="30" x2="-52" y2="14" gradientUnits="userSpaceOnUse" gradientTransform="translate(68,2)"/>
+    <radialGradient
+       xlink:href="#linearGradient2269"
+       id="radialGradient3049"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.1991353,0,0,0.18727682,9.60253,47.497421)"
+       cx="25.1875"
+       cy="41.625"
+       fx="25.1875"
+       fy="41.625"
+       r="18.0625" />
+    <linearGradient
+       gradientTransform="translate(2,2)"
+       gradientUnits="userSpaceOnUse"
+       y2="33.097897"
+       x2="21.638357"
+       y1="38.57375"
+       x1="19.728148"
+       id="linearGradient5550"
+       xlink:href="#linearGradient3276" />
+    <linearGradient
+       gradientTransform="translate(2,2)"
+       gradientUnits="userSpaceOnUse"
+       y2="31.730888"
+       x2="16.813908"
+       y1="38.213882"
+       x1="19.145359"
+       id="linearGradient5558"
+       xlink:href="#linearGradient3270" />
+    <linearGradient
+       gradientTransform="translate(2,2)"
+       gradientUnits="userSpaceOnUse"
+       y2="39.196541"
+       x2="26.189007"
+       y1="38.502609"
+       x1="19.881519"
+       id="linearGradient5566"
+       xlink:href="#linearGradient5646" />
+    <linearGradient
+       gradientTransform="translate(2,2)"
+       gradientUnits="userSpaceOnUse"
+       y2="36.145401"
+       x2="31.672956"
+       y1="38.921127"
+       x1="29.10784"
+       id="linearGradient5574"
+       xlink:href="#linearGradient3294" />
+    <linearGradient
+       gradientTransform="translate(2,2)"
+       gradientUnits="userSpaceOnUse"
+       y2="39.562164"
+       x2="34.239601"
+       y1="41.789768"
+       x1="32.311722"
+       id="linearGradient5588"
+       xlink:href="#linearGradient3288" />
+    <linearGradient
+       gradientTransform="translate(2,2)"
+       gradientUnits="userSpaceOnUse"
+       y2="42.322491"
+       x2="36.356281"
+       y1="44.436687"
+       x1="34.10231"
+       id="linearGradient5596"
+       xlink:href="#linearGradient3282" />
+    <linearGradient
+       gradientTransform="translate(2,2)"
+       gradientUnits="userSpaceOnUse"
+       y2="32.980549"
+       x2="31.261166"
+       y1="34.843632"
+       x1="27.345615"
+       id="linearGradient5604"
+       xlink:href="#linearGradient5576" />
+    <linearGradient
+       gradientTransform="translate(2,2)"
+       gradientUnits="userSpaceOnUse"
+       y2="33.275246"
+       x2="34.970161"
+       y1="35.084328"
+       x1="31.979929"
+       id="linearGradient5612"
+       xlink:href="#linearGradient5606" />
+    <linearGradient
+       gradientTransform="translate(2,2)"
+       gradientUnits="userSpaceOnUse"
+       y2="35.175659"
+       x2="36.115841"
+       y1="37.152149"
+       x1="33.611019"
+       id="linearGradient5620"
+       xlink:href="#linearGradient3330" />
+    <linearGradient
+       gradientTransform="translate(2,2)"
+       gradientUnits="userSpaceOnUse"
+       y2="39.22818"
+       x2="29.432671"
+       y1="40.265026"
+       x1="27.153559"
+       id="linearGradient5658"
+       xlink:href="#linearGradient5652" />
+    <linearGradient
+       gradientTransform="translate(2,2)"
+       gradientUnits="userSpaceOnUse"
+       y2="28.801535"
+       x2="20.5632"
+       y1="31.54216"
+       x1="19.64187"
+       id="linearGradient5666"
+       xlink:href="#linearGradient3300" />
+    <linearGradient
+       gradientTransform="translate(2,2)"
+       gradientUnits="userSpaceOnUse"
+       y2="28.666885"
+       x2="15.030108"
+       y1="30.556971"
+       x1="17.048548"
+       id="linearGradient5674"
+       xlink:href="#linearGradient3312" />
+    <linearGradient
+       gradientTransform="translate(2,2)"
+       gradientUnits="userSpaceOnUse"
+       y2="30.274158"
+       x2="14.456498"
+       y1="32.223648"
+       x1="15.841824"
+       id="linearGradient5688"
+       xlink:href="#linearGradient3318" />
+    <linearGradient
+       gradientTransform="translate(2,2)"
+       gradientUnits="userSpaceOnUse"
+       y2="27.200634"
+       x2="17.149237"
+       y1="30.243673"
+       x1="17.666838"
+       id="linearGradient5696"
+       xlink:href="#linearGradient3306" />
+    <linearGradient
+       gradientTransform="translate(2,2)"
+       gradientUnits="userSpaceOnUse"
+       y2="29.058939"
+       x2="24.214138"
+       y1="33.487141"
+       x1="24.720701"
+       id="linearGradient5704"
+       xlink:href="#linearGradient5676" />
+    <linearGradient
+       gradientTransform="translate(2,2)"
+       gradientUnits="userSpaceOnUse"
+       y2="30.132702"
+       x2="28.001352"
+       y1="33.891273"
+       x1="24.752634"
+       id="linearGradient5712"
+       xlink:href="#linearGradient3324" />
+    <linearGradient
+       gradientTransform="translate(2,2)"
+       gradientUnits="userSpaceOnUse"
+       y2="42.779541"
+       x2="40.381905"
+       y1="45.2005"
+       x1="37.336205"
+       id="linearGradient5720"
+       xlink:href="#linearGradient5722" />
+    <linearGradient
+       gradientTransform="translate(68,2)"
+       gradientUnits="userSpaceOnUse"
+       y2="14"
+       x2="-52"
+       y1="30"
+       x1="-46"
+       id="linearGradient4120"
+       xlink:href="#linearGradient4114" />
   </defs>
-  <sodipodi:namedview id="base" pagecolor="#ffffff" bordercolor="#666666" borderopacity="1.0" inkscape:pageopacity="0.0" inkscape:pageshadow="2" inkscape:zoom="5.412863" inkscape:cx="43.988104" inkscape:cy="14.398364" inkscape:current-layer="layer1" showgrid="true" inkscape:document-units="px" inkscape:grid-bbox="true" inkscape:window-width="1600" inkscape:window-height="837" inkscape:window-x="0" inkscape:window-y="27" inkscape:window-maximized="1">
-    <inkscape:grid empspacing="2" visible="true" enabled="true" snapvisiblegridlinesonly="true" type="xygrid" id="grid3336"/>
-  </sodipodi:namedview>
-  <metadata id="metadata2821">
+  <metadata
+     id="metadata2821">
     <rdf:RDF>
-      <cc:Work rdf:about="">
+      <cc:Work
+         rdf:about="">
         <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-        <dc:title/>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
         <dc:creator>
           <cc:Agent>
             <dc:title>[triplus]</dc:title>
@@ -135,125 +431,438 @@
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <g id="layer1" inkscape:label="Layer 1" inkscape:groupmode="layer" style="display:inline">
-    <g inkscape:groupmode="layer" id="layer2" inkscape:label="Plate" style="display:inline">
-      <path style="fill:#ef2929;stroke:#280000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1" d="M 5,17 9,19 27,9 23,7 z" id="path4106" inkscape:connector-curvature="0"/>
-      <path style="fill:#cc0000;stroke:#280000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1" d="M 5,17 9,19 9,41 5,39 z" id="path4108" inkscape:connector-curvature="0"/>
-      <path style="fill:url(#linearGradient4120);fill-opacity:1;stroke:#280000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1" d="M 9,41 27,31 27,9 9,19 z" id="path4110" inkscape:connector-curvature="0"/>
-      <path style="fill:none;stroke:#cc0000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" d="m 11,20.2 14,-7.8 0,17.4 -14,7.8 z" id="path4112" inkscape:connector-curvature="0" sodipodi:nodetypes="ccccc"/>
-      <path style="fill:#ef2929;stroke:#280000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1" d="m 14,19 1,4 -4,0 c -0.08854,-1.526035 1.83735,-3.897728 3,-4 z" id="path4122" inkscape:connector-curvature="0" sodipodi:nodetypes="cccc"/>
-      <path style="fill:#ef2929;stroke:#280000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1;display:inline" d="m 20,16 1,4 -4,0 c -0.08854,-1.526035 1.83735,-3.897728 3,-4 z" id="path4122-3" inkscape:connector-curvature="0" sodipodi:nodetypes="cccc"/>
-      <path style="fill:#ef2929;stroke:#280000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1;display:inline" d="m 25,13 1,4 -4,0 c -0.08854,-1.526035 1.83735,-3.897728 3,-4 z" id="path4122-6" inkscape:connector-curvature="0" sodipodi:nodetypes="cccc"/>
-      <path style="fill:#ef2929;stroke:#280000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1;display:inline" d="m 14,26 1,4 -4,0 c -0.08854,-1.526035 1.83735,-3.897728 3,-4 z" id="path4122-7" inkscape:connector-curvature="0" sodipodi:nodetypes="cccc"/>
-      <path style="fill:#ef2929;stroke:#280000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1;display:inline" d="m 20,23 1,4 -4,0 c -0.08854,-1.526035 1.83735,-3.897728 3,-4 z" id="path4122-3-5" inkscape:connector-curvature="0" sodipodi:nodetypes="cccc"/>
-      <path style="fill:#ef2929;stroke:#280000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1;display:inline" d="m 25,20 1,4 -4,0 c -0.08854,-1.526035 1.83735,-3.897728 3,-4 z" id="path4122-6-3" inkscape:connector-curvature="0" sodipodi:nodetypes="cccc"/>
-      <path style="fill:#ef2929;stroke:#280000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1;display:inline" d="m 14,33 1,4 -4,0 c -0.08854,-1.526035 1.83735,-3.897728 3,-4 z" id="path4122-5" inkscape:connector-curvature="0" sodipodi:nodetypes="cccc"/>
-      <path style="fill:#ef2929;stroke:#280000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1;display:inline" d="m 20,30 1,4 -4,0 c -0.08854,-1.526035 1.83735,-3.897728 3,-4 z" id="path4122-3-6" inkscape:connector-curvature="0" sodipodi:nodetypes="cccc"/>
-      <path style="fill:#ef2929;stroke:#280000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1;display:inline" d="m 25,27 1,4 -4,0 c -0.08854,-1.526035 1.83735,-3.897728 3,-4 z" id="path4122-6-2" inkscape:connector-curvature="0" sodipodi:nodetypes="cccc"/>
+  <g
+     style="display:inline"
+     id="layer1">
+    <g
+       style="display:inline"
+       id="layer2">
+      <path
+         id="path4106"
+         d="M 5,17 9,19 27,9 23,7 z"
+         style="fill:#ef2929;stroke:#280000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1" />
+      <path
+         id="path4108"
+         d="M 5,17 9,19 9,41 5,39 z"
+         style="fill:#cc0000;stroke:#280000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1" />
+      <path
+         id="path4110"
+         d="M 9,41 27,31 27,9 9,19 z"
+         style="fill:url(#linearGradient4120);fill-opacity:1;stroke:#280000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1" />
+      <path
+         id="path4112"
+         d="m 11,20.2 14,-7.8 0,17.4 -14,7.8 z"
+         style="fill:none;stroke:#cc0000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      <path
+         id="path4122"
+         d="m 14,19 1,4 -4,0 c -0.08854,-1.526035 1.83735,-3.897728 3,-4 z"
+         style="fill:#ef2929;stroke:#280000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1" />
+      <path
+         id="path4122-3"
+         d="m 20,16 1,4 -4,0 c -0.08854,-1.526035 1.83735,-3.897728 3,-4 z"
+         style="fill:#ef2929;stroke:#280000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1;display:inline" />
+      <path
+         id="path4122-6"
+         d="m 25,13 1,4 -4,0 c -0.08854,-1.526035 1.83735,-3.897728 3,-4 z"
+         style="fill:#ef2929;stroke:#280000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1;display:inline" />
+      <path
+         id="path4122-7"
+         d="m 14,26 1,4 -4,0 c -0.08854,-1.526035 1.83735,-3.897728 3,-4 z"
+         style="fill:#ef2929;stroke:#280000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1;display:inline" />
+      <path
+         id="path4122-3-5"
+         d="m 20,23 1,4 -4,0 c -0.08854,-1.526035 1.83735,-3.897728 3,-4 z"
+         style="fill:#ef2929;stroke:#280000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1;display:inline" />
+      <path
+         id="path4122-6-3"
+         d="m 25,20 1,4 -4,0 c -0.08854,-1.526035 1.83735,-3.897728 3,-4 z"
+         style="fill:#ef2929;stroke:#280000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1;display:inline" />
+      <path
+         id="path4122-5"
+         d="m 14,33 1,4 -4,0 c -0.08854,-1.526035 1.83735,-3.897728 3,-4 z"
+         style="fill:#ef2929;stroke:#280000;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1;display:inline" />
+      <path
+         id="path4122-3-6"
+         d="m 20,30 1,4 -4,0 c -0.08854,-1.526035 1.83735,-3.897728 3,-4 z"
+         style="fill:#ef2929;stroke:#280000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1;display:inline" />
+      <path
+         id="path4122-6-2"
+         d="m 25,27 1,4 -4,0 c -0.08854,-1.526035 1.83735,-3.897728 3,-4 z"
+         style="fill:#ef2929;stroke:#280000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1;display:inline" />
     </g>
-    <g inkscape:groupmode="layer" id="layer4" inkscape:label="Block" style="display:inline"/>
-    <g inkscape:groupmode="layer" id="layer6" inkscape:label="Stress" style="display:inline">
-      <path style="color:#000000;fill:#3465a4;fill-opacity:1;fill-rule:nonzero;stroke:#555753;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" d="m 33,31 9,-1 -3,5 z" id="path4836" inkscape:connector-curvature="0" sodipodi:nodetypes="cccc"/>
-      <path style="color:#000000;fill:#3465a4;fill-opacity:1;fill-rule:nonzero;stroke:#555753;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" d="m 42,30 9,-1 -12,6 z" id="path4838" inkscape:connector-curvature="0" sodipodi:nodetypes="cccc"/>
-      <path style="color:#000000;fill:#3465a4;fill-opacity:1;fill-rule:nonzero;stroke:#555753;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" d="m 42,30 3,-5 6,4 z" id="path4840" inkscape:connector-curvature="0" sodipodi:nodetypes="cccc"/>
-      <path style="color:#000000;fill:#3465a4;fill-opacity:1;fill-rule:nonzero;stroke:#555753;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" d="m 45,25 -3,5 -9,1 z" id="path4842" inkscape:connector-curvature="0" sodipodi:nodetypes="cccc"/>
-      <path style="color:#000000;fill:#3465a4;fill-opacity:1;fill-rule:nonzero;stroke:#505050;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" d="M 39,35 51,29 45,41 z" id="path4844" inkscape:connector-curvature="0" sodipodi:nodetypes="cccc"/>
-      <path style="color:#000000;fill:#3465a4;fill-opacity:1;fill-rule:nonzero;stroke:#505050;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" d="M 38.82977,38.964692 39,35 l 5.99302,5.948288 z" id="path4846" inkscape:connector-curvature="0" sodipodi:nodetypes="cccc"/>
-      <path style="color:#000000;fill:url(#linearGradient5620);fill-opacity:1;fill-rule:nonzero;stroke:#505050;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" d="m 34,38 5,-3 0,9 z" id="path4848" inkscape:connector-curvature="0" sodipodi:nodetypes="cccc"/>
-      <path style="color:#000000;fill:url(#linearGradient5612);fill-opacity:1;fill-rule:nonzero;stroke:#505050;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" d="m 33,31 6,4 -5,3 z" id="path4850" inkscape:connector-curvature="0" sodipodi:nodetypes="cccc"/>
-      <path style="color:#000000;fill:url(#linearGradient5604);fill-opacity:1;fill-rule:nonzero;stroke:#505050;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" d="m 27,37 6,-6 1,7 z" id="path4852" inkscape:connector-curvature="0" sodipodi:nodetypes="cccc"/>
-      <path style="color:#000000;fill:url(#linearGradient5574);fill-opacity:1;fill-rule:nonzero;stroke:#505050;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" d="m 27,37 7,1 1,7 z" id="path4854" inkscape:connector-curvature="0" sodipodi:nodetypes="cccc"/>
-      <path style="color:#000000;fill:url(#linearGradient5588);fill-opacity:1;fill-rule:nonzero;stroke:#505050;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" d="m 34,38 5,6 -4,1 z" id="path4856" inkscape:connector-curvature="0" sodipodi:nodetypes="cccc"/>
-      <path style="color:#000000;fill:url(#linearGradient5658);fill-opacity:1;fill-rule:nonzero;stroke:#505050;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" d="m 27,37 8,8 -5,1 z" id="path4858" inkscape:connector-curvature="0" sodipodi:nodetypes="cccc"/>
-      <path style="color:#000000;fill:#73d216;fill-opacity:1;fill-rule:nonzero;stroke:#505050;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" d="m 30,46 5,-1 4,6 z" id="path4860" inkscape:connector-curvature="0" sodipodi:nodetypes="cccc"/>
-      <path style="color:#000000;fill:url(#linearGradient5596);fill-opacity:1;fill-rule:nonzero;stroke:#505050;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" d="m 35,45 4,-1 0,7 z" id="path4862" inkscape:connector-curvature="0" sodipodi:nodetypes="cccc"/>
-      <path style="color:#000000;fill:#3465a4;fill-opacity:1;fill-rule:nonzero;stroke:#505050;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" d="m 39,39 6,2 -6,3 z" id="path4864" inkscape:connector-curvature="0" sodipodi:nodetypes="cccc"/>
-      <path style="color:#000000;fill:url(#linearGradient5720);fill-opacity:1;fill-rule:nonzero;stroke:#505050;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" d="m 39,44 12,-6 0,7 -12,6 z" id="path4866" inkscape:connector-curvature="0" sodipodi:nodetypes="ccccc"/>
-      <path style="color:#000000;fill:#3465a4;fill-opacity:1;fill-rule:nonzero;stroke:#505050;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" d="m 51,29 0,9 -6,3 z" id="path4868" inkscape:connector-curvature="0" sodipodi:nodetypes="cccc"/>
-      <path style="color:#000000;fill:url(#linearGradient5566);fill-opacity:1;fill-rule:nonzero;stroke:#505050;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" d="m 22,41 5,-4 3,9 z" id="path4870" inkscape:connector-curvature="0" sodipodi:nodetypes="cccc"/>
-      <path style="color:#000000;fill:url(#linearGradient5550);fill-opacity:1;fill-rule:nonzero;stroke:#505050;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" d="m 20,33 7,4 -5,4 z" id="path4872" inkscape:connector-curvature="0" sodipodi:nodetypes="cccc"/>
-      <path style="color:#000000;fill:url(#linearGradient5558);fill-opacity:1;fill-rule:nonzero;stroke:#505050;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" d="m 15,37 5,-4 2,8 z" id="path4874" inkscape:connector-curvature="0" sodipodi:nodetypes="cccc"/>
-      <path style="color:#000000;fill:url(#linearGradient5688);fill-opacity:1;fill-rule:nonzero;stroke:#505050;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" d="m 15,31 5,2 -5,4 z" id="path4876" inkscape:connector-curvature="0" sodipodi:nodetypes="cccc"/>
-      <path style="color:#000000;fill:url(#linearGradient5674);fill-opacity:1;fill-rule:nonzero;stroke:#505050;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" d="m 15,31 0,-10 5,12 z" id="path4878" inkscape:connector-curvature="0" sodipodi:nodetypes="cccc"/>
-      <path style="color:#000000;fill:url(#linearGradient5696);fill-opacity:1;fill-rule:nonzero;stroke:#505050;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" d="m 15,21 6,4 -1,8 z" id="path4880" inkscape:connector-curvature="0" sodipodi:nodetypes="cccc"/>
-      <path style="color:#000000;fill:url(#linearGradient5666);fill-opacity:1;fill-rule:nonzero;stroke:#505050;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" d="m 20,33 1,-8 6,12 0,0 z" id="path4882" inkscape:connector-curvature="0" sodipodi:nodetypes="ccccc"/>
-      <path style="color:#000000;fill:url(#linearGradient5704);fill-opacity:1;fill-rule:nonzero;stroke:#555753;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" d="m 21,25 8,4 -2,8 z" id="path4884" inkscape:connector-curvature="0" sodipodi:nodetypes="cccc"/>
-      <path style="color:#000000;fill:url(#linearGradient5712);fill-opacity:1;fill-rule:nonzero;stroke:#555753;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" d="M 27.23709,35.942293 29,29 l 4,2 z" id="path4886" inkscape:connector-curvature="0" sodipodi:nodetypes="cccc"/>
-      <path style="color:#000000;fill:#73d216;fill-opacity:1;fill-rule:nonzero;stroke:#555753;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" d="m 29,29 4,-3 0.23771,5.583485 z" id="path4888" inkscape:connector-curvature="0" sodipodi:nodetypes="cccc"/>
-      <path style="color:#000000;fill:#73d216;fill-opacity:1;fill-rule:nonzero;stroke:#555753;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" d="m 33,26 6,2 -5.81889,3.72359 z" id="path4890" inkscape:connector-curvature="0" sodipodi:nodetypes="cccc"/>
-      <path style="color:#000000;fill:#73d216;fill-opacity:1;fill-rule:nonzero;stroke:#555753;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" d="m 33,26 0,-7 6,9 z" id="path4892" inkscape:connector-curvature="0" sodipodi:nodetypes="cccc"/>
-      <path style="color:#000000;fill:#73d216;fill-opacity:1;fill-rule:nonzero;stroke:#555753;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" d="m 27,22 6,-3 0,7 z" id="path4894" inkscape:connector-curvature="0" sodipodi:nodetypes="cccc"/>
-      <path style="color:#000000;fill:#73d216;fill-opacity:1;fill-rule:nonzero;stroke:#555753;stroke-width:0.5;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" d="m 27,22 6,4 -4,3 z" id="path4896" inkscape:connector-curvature="0" sodipodi:nodetypes="cccc"/>
-      <path style="color:#000000;fill:#73d216;fill-opacity:1;fill-rule:nonzero;stroke:#555753;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" d="m 21,25 6,-3 2,7 z" id="path4898" inkscape:connector-curvature="0" sodipodi:nodetypes="cccc"/>
-      <path style="color:#000000;fill:#73d216;fill-opacity:1;fill-rule:nonzero;stroke:#555753;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" d="m 24,20 9,-1 -6,3 z" id="path4900" inkscape:connector-curvature="0" sodipodi:nodetypes="cccc"/>
-      <path style="color:#000000;fill:#73d216;fill-opacity:1;fill-rule:nonzero;stroke:#555753;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" d="m 27,15 6,4 -9,1 z" id="path4902" inkscape:connector-curvature="0" sodipodi:nodetypes="cccc"/>
-      <path style="color:#000000;fill:#73d216;fill-opacity:1;fill-rule:nonzero;stroke:#555753;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" d="m 27,15 -3,5 -9,1 z" id="path4904" inkscape:connector-curvature="0" sodipodi:nodetypes="cccc"/>
-      <path style="color:#000000;fill:#73d216;fill-opacity:1;fill-rule:nonzero;stroke:#555753;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" d="m 21,25 3,-5 3,2 z" id="path4906" inkscape:connector-curvature="0" sodipodi:nodetypes="cccc"/>
-      <path style="color:#000000;fill:#73d216;fill-opacity:1;fill-rule:nonzero;stroke:#555753;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" d="m 15,21 9,-1 -3,5 z" id="path4908" inkscape:connector-curvature="0" sodipodi:nodetypes="cccc"/>
+    <g
+       style="display:inline"
+       id="layer4" />
+    <g
+       style="display:inline"
+       id="layer6">
+      <path
+         id="path4836"
+         d="m 33,31 9,-1 -3,5 z"
+         style="color:#000000;fill:#3465a4;fill-opacity:1;fill-rule:nonzero;stroke:#555753;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+      <path
+         id="path4838"
+         d="m 42,30 9,-1 -12,6 z"
+         style="color:#000000;fill:#3465a4;fill-opacity:1;fill-rule:nonzero;stroke:#555753;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+      <path
+         id="path4840"
+         d="m 42,30 3,-5 6,4 z"
+         style="color:#000000;fill:#3465a4;fill-opacity:1;fill-rule:nonzero;stroke:#555753;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+      <path
+         id="path4842"
+         d="m 45,25 -3,5 -9,1 z"
+         style="color:#000000;fill:#3465a4;fill-opacity:1;fill-rule:nonzero;stroke:#555753;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+      <path
+         id="path4844"
+         d="M 39,35 51,29 45,41 z"
+         style="color:#000000;fill:#3465a4;fill-opacity:1;fill-rule:nonzero;stroke:#505050;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+      <path
+         id="path4846"
+         d="M 38.82977,38.964692 39,35 l 5.99302,5.948288 z"
+         style="color:#000000;fill:#3465a4;fill-opacity:1;fill-rule:nonzero;stroke:#505050;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+      <path
+         id="path4848"
+         d="m 34,38 5,-3 0,9 z"
+         style="color:#000000;fill:url(#linearGradient5620);fill-opacity:1;fill-rule:nonzero;stroke:#505050;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+      <path
+         id="path4850"
+         d="m 33,31 6,4 -5,3 z"
+         style="color:#000000;fill:url(#linearGradient5612);fill-opacity:1;fill-rule:nonzero;stroke:#505050;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+      <path
+         id="path4852"
+         d="m 27,37 6,-6 1,7 z"
+         style="color:#000000;fill:url(#linearGradient5604);fill-opacity:1;fill-rule:nonzero;stroke:#505050;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+      <path
+         id="path4854"
+         d="m 27,37 7,1 1,7 z"
+         style="color:#000000;fill:url(#linearGradient5574);fill-opacity:1;fill-rule:nonzero;stroke:#505050;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+      <path
+         id="path4856"
+         d="m 34,38 5,6 -4,1 z"
+         style="color:#000000;fill:url(#linearGradient5588);fill-opacity:1;fill-rule:nonzero;stroke:#505050;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+      <path
+         id="path4858"
+         d="m 27,37 8,8 -5,1 z"
+         style="color:#000000;fill:url(#linearGradient5658);fill-opacity:1;fill-rule:nonzero;stroke:#505050;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+      <path
+         id="path4860"
+         d="m 30,46 5,-1 4,6 z"
+         style="color:#000000;fill:#73d216;fill-opacity:1;fill-rule:nonzero;stroke:#505050;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+      <path
+         id="path4862"
+         d="m 35,45 4,-1 0,7 z"
+         style="color:#000000;fill:url(#linearGradient5596);fill-opacity:1;fill-rule:nonzero;stroke:#505050;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+      <path
+         id="path4864"
+         d="m 39,39 6,2 -6,3 z"
+         style="color:#000000;fill:#3465a4;fill-opacity:1;fill-rule:nonzero;stroke:#505050;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+      <path
+         id="path4866"
+         d="m 39,44 12,-6 0,7 -12,6 z"
+         style="color:#000000;fill:url(#linearGradient5720);fill-opacity:1;fill-rule:nonzero;stroke:#505050;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+      <path
+         id="path4868"
+         d="m 51,29 0,9 -6,3 z"
+         style="color:#000000;fill:#3465a4;fill-opacity:1;fill-rule:nonzero;stroke:#505050;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+      <path
+         id="path4870"
+         d="m 22,41 5,-4 3,9 z"
+         style="color:#000000;fill:url(#linearGradient5566);fill-opacity:1;fill-rule:nonzero;stroke:#505050;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+      <path
+         id="path4872"
+         d="m 20,33 7,4 -5,4 z"
+         style="color:#000000;fill:url(#linearGradient5550);fill-opacity:1;fill-rule:nonzero;stroke:#505050;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+      <path
+         id="path4874"
+         d="m 15,37 5,-4 2,8 z"
+         style="color:#000000;fill:url(#linearGradient5558);fill-opacity:1;fill-rule:nonzero;stroke:#505050;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+      <path
+         id="path4876"
+         d="m 15,31 5,2 -5,4 z"
+         style="color:#000000;fill:url(#linearGradient5688);fill-opacity:1;fill-rule:nonzero;stroke:#505050;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+      <path
+         id="path4878"
+         d="m 15,31 0,-10 5,12 z"
+         style="color:#000000;fill:url(#linearGradient5674);fill-opacity:1;fill-rule:nonzero;stroke:#505050;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+      <path
+         id="path4880"
+         d="m 15,21 6,4 -1,8 z"
+         style="color:#000000;fill:url(#linearGradient5696);fill-opacity:1;fill-rule:nonzero;stroke:#505050;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+      <path
+         id="path4882"
+         d="m 20,33 1,-8 6,12 0,0 z"
+         style="color:#000000;fill:url(#linearGradient5666);fill-opacity:1;fill-rule:nonzero;stroke:#505050;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+      <path
+         id="path4884"
+         d="m 21,25 8,4 -2,8 z"
+         style="color:#000000;fill:url(#linearGradient5704);fill-opacity:1;fill-rule:nonzero;stroke:#555753;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+      <path
+         id="path4886"
+         d="M 27.23709,35.942293 29,29 l 4,2 z"
+         style="color:#000000;fill:url(#linearGradient5712);fill-opacity:1;fill-rule:nonzero;stroke:#555753;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+      <path
+         id="path4888"
+         d="m 29,29 4,-3 0.23771,5.583485 z"
+         style="color:#000000;fill:#73d216;fill-opacity:1;fill-rule:nonzero;stroke:#555753;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+      <path
+         id="path4890"
+         d="m 33,26 6,2 -5.81889,3.72359 z"
+         style="color:#000000;fill:#73d216;fill-opacity:1;fill-rule:nonzero;stroke:#555753;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+      <path
+         id="path4892"
+         d="m 33,26 0,-7 6,9 z"
+         style="color:#000000;fill:#73d216;fill-opacity:1;fill-rule:nonzero;stroke:#555753;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+      <path
+         id="path4894"
+         d="m 27,22 6,-3 0,7 z"
+         style="color:#000000;fill:#73d216;fill-opacity:1;fill-rule:nonzero;stroke:#555753;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+      <path
+         id="path4896"
+         d="m 27,22 6,4 -4,3 z"
+         style="color:#000000;fill:#73d216;fill-opacity:1;fill-rule:nonzero;stroke:#555753;stroke-width:0.5;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+      <path
+         id="path4898"
+         d="m 21,25 6,-3 2,7 z"
+         style="color:#000000;fill:#73d216;fill-opacity:1;fill-rule:nonzero;stroke:#555753;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+      <path
+         id="path4900"
+         d="m 24,20 9,-1 -6,3 z"
+         style="color:#000000;fill:#73d216;fill-opacity:1;fill-rule:nonzero;stroke:#555753;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+      <path
+         id="path4902"
+         d="m 27,15 6,4 -9,1 z"
+         style="color:#000000;fill:#73d216;fill-opacity:1;fill-rule:nonzero;stroke:#555753;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+      <path
+         id="path4904"
+         d="m 27,15 -3,5 -9,1 z"
+         style="color:#000000;fill:#73d216;fill-opacity:1;fill-rule:nonzero;stroke:#555753;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+      <path
+         id="path4906"
+         d="m 21,25 3,-5 3,2 z"
+         style="color:#000000;fill:#73d216;fill-opacity:1;fill-rule:nonzero;stroke:#555753;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+      <path
+         id="path4908"
+         d="m 15,21 9,-1 -3,5 z"
+         style="color:#000000;fill:#73d216;fill-opacity:1;fill-rule:nonzero;stroke:#555753;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
-    <g inkscape:groupmode="layer" id="layer5" inkscape:label="Mesh" style="display:inline"/>
-    <g inkscape:groupmode="layer" id="layer7" inkscape:label="Block Frame" style="display:inline">
-      <path style="fill:none;stroke:#2e3436;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" d="m 15,21 0,16" id="path3100" inkscape:connector-curvature="0" sodipodi:nodetypes="cc"/>
-      <path style="fill:none;stroke:#2e3436;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" d="m 45,25 -12,6 6,4 12,-6 z m 6,4 0,14 z" id="path3108" inkscape:connector-curvature="0" sodipodi:nodetypes="cccccccc"/>
-      <path style="fill:none;stroke:#2e3436;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" d="M 39,51 51,45" id="path3114" inkscape:connector-curvature="0" sodipodi:nodetypes="cc"/>
-      <path style="fill:none;stroke:#2e3436;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" d="M 39,51 15,37" id="path3120" inkscape:connector-curvature="0" sodipodi:nodetypes="cc"/>
-      <path style="fill:none;stroke:#2e3436;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" d="m 15,21 6,4" id="path3122" inkscape:connector-curvature="0" sodipodi:nodetypes="cc"/>
-      <path style="fill:none;stroke:#2e3436;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" d="M 15,21 27,15" id="path3134" inkscape:connector-curvature="0" sodipodi:nodetypes="cc"/>
-      <path style="fill:none;stroke:#2e3436;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" d="M 33,19 27,15" id="path3136" inkscape:connector-curvature="0" sodipodi:nodetypes="cc"/>
-      <path style="fill:none;stroke:#2e3436;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" d="m 21,25 6,12" id="path3116" inkscape:connector-curvature="0" sodipodi:nodetypes="cc"/>
-      <path style="fill:none;stroke:#2e3436;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" d="m 33,31 -6,6" id="path3118" inkscape:connector-curvature="0" sodipodi:nodetypes="cc"/>
-      <path style="fill:none;stroke:#2e3436;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" d="M 39,51 39,35" id="path3126" inkscape:connector-curvature="0" sodipodi:nodetypes="cc"/>
-      <path style="fill:none;stroke:#2e3436;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" d="M 33,19 21,25" id="path3130" inkscape:connector-curvature="0" sodipodi:nodetypes="cc"/>
-      <path style="fill:none;stroke:#2e3436;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" d="m 33,19 6,9" id="path3106" inkscape:connector-curvature="0" sodipodi:nodetypes="cc"/>
+    <g
+       style="display:inline"
+       id="layer5" />
+    <g
+       style="display:inline"
+       id="layer7">
+      <path
+         id="path3100"
+         d="m 15,21 0,16"
+         style="fill:none;stroke:#2e3436;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
+      <path
+         id="path3108"
+         d="m 45,25 -12,6 6,4 12,-6 z m 6,4 0,14 z"
+         style="fill:none;stroke:#2e3436;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
+      <path
+         id="path3114"
+         d="M 39,51 51,45"
+         style="fill:none;stroke:#2e3436;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
+      <path
+         id="path3120"
+         d="M 39,51 15,37"
+         style="fill:none;stroke:#2e3436;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
+      <path
+         id="path3122"
+         d="m 15,21 6,4"
+         style="fill:none;stroke:#2e3436;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
+      <path
+         id="path3134"
+         d="M 15,21 27,15"
+         style="fill:none;stroke:#2e3436;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
+      <path
+         id="path3136"
+         d="M 33,19 27,15"
+         style="fill:none;stroke:#2e3436;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
+      <path
+         id="path3116"
+         d="m 21,25 6,12"
+         style="fill:none;stroke:#2e3436;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
+      <path
+         id="path3118"
+         d="m 33,31 -6,6"
+         style="fill:none;stroke:#2e3436;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
+      <path
+         id="path3126"
+         d="M 39,51 39,35"
+         style="fill:none;stroke:#2e3436;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
+      <path
+         id="path3130"
+         d="M 33,19 21,25"
+         style="fill:none;stroke:#2e3436;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
+      <path
+         id="path3106"
+         d="m 33,19 6,9"
+         style="fill:none;stroke:#2e3436;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
     </g>
-    <g inkscape:groupmode="layer" id="layer3" inkscape:label="Forces" style="display:inline">
-      <g id="g4238" transform="translate(-12,30)">
-        <path sodipodi:nodetypes="cc" inkscape:connector-curvature="0" id="path4187-9" d="m 53,21 4,3" style="fill:none;stroke:#a40000;stroke-width:4;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1;display:inline"/>
-        <path sodipodi:nodetypes="cc" inkscape:connector-curvature="0" id="path4187-9-1" d="m 53.4,20.1 4,3" style="fill:none;stroke:#ef2929;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1;display:inline"/>
-        <path sodipodi:nodetypes="cccc" inkscape:connector-curvature="0" id="path4185" d="m 61,27 -1,-4 c -1.910633,0.509427 -2.918244,1.835875 -3,4 z" style="fill:#ef2929;stroke:#a40000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1"/>
+    <g
+       style="display:inline"
+       id="layer3">
+      <g
+         transform="translate(-12,30)"
+         id="g4238">
+        <path
+           style="fill:none;stroke:#a40000;stroke-width:4;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1;display:inline"
+           d="m 53,21 4,3"
+           id="path4187-9" />
+        <path
+           style="fill:none;stroke:#ef2929;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1;display:inline"
+           d="m 53.4,20.1 4,3"
+           id="path4187-9-1" />
+        <path
+           style="fill:#ef2929;stroke:#a40000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1"
+           d="m 61,27 -1,-4 c -1.910633,0.509427 -2.918244,1.835875 -3,4 z"
+           id="path4185" />
       </g>
-      <g transform="translate(-6,26)" style="display:inline" id="g4238-2">
-        <path sodipodi:nodetypes="cc" inkscape:connector-curvature="0" id="path4187-9-7" d="m 53,21 4,3" style="fill:none;stroke:#a40000;stroke-width:4;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1;display:inline"/>
-        <path sodipodi:nodetypes="cc" inkscape:connector-curvature="0" id="path4187-9-1-0" d="m 53.4,20.1 4,3" style="fill:none;stroke:#ef2929;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1;display:inline"/>
-        <path sodipodi:nodetypes="cccc" inkscape:connector-curvature="0" id="path4185-9" d="m 61,27 -1,-4 c -1.910633,0.509427 -2.918244,1.835875 -3,4 z" style="fill:#ef2929;stroke:#a40000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1"/>
+      <g
+         id="g4238-2"
+         style="display:inline"
+         transform="translate(-6,26)">
+        <path
+           style="fill:none;stroke:#a40000;stroke-width:4;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1;display:inline"
+           d="m 53,21 4,3"
+           id="path4187-9-7" />
+        <path
+           style="fill:none;stroke:#ef2929;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1;display:inline"
+           d="m 53.4,20.1 4,3"
+           id="path4187-9-1-0" />
+        <path
+           style="fill:#ef2929;stroke:#a40000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1"
+           d="m 61,27 -1,-4 c -1.910633,0.509427 -2.918244,1.835875 -3,4 z"
+           id="path4185-9" />
       </g>
-      <g transform="translate(-2,22)" style="display:inline" id="g4238-3">
-        <path sodipodi:nodetypes="cc" inkscape:connector-curvature="0" id="path4187-9-6" d="m 53,21 4,3" style="fill:none;stroke:#a40000;stroke-width:4;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1;display:inline"/>
-        <path sodipodi:nodetypes="cc" inkscape:connector-curvature="0" id="path4187-9-1-06" d="m 53.4,20.1 4,3" style="fill:none;stroke:#ef2929;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1;display:inline"/>
-        <path sodipodi:nodetypes="cccc" inkscape:connector-curvature="0" id="path4185-2" d="m 61,27 -1,-4 c -1.910633,0.509427 -2.918244,1.835875 -3,4 z" style="fill:#ef2929;stroke:#a40000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1"/>
+      <g
+         id="g4238-3"
+         style="display:inline"
+         transform="translate(-2,22)">
+        <path
+           style="fill:none;stroke:#a40000;stroke-width:4;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1;display:inline"
+           d="m 53,21 4,3"
+           id="path4187-9-6" />
+        <path
+           style="fill:none;stroke:#ef2929;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1;display:inline"
+           d="m 53.4,20.1 4,3"
+           id="path4187-9-1-06" />
+        <path
+           style="fill:#ef2929;stroke:#a40000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1"
+           d="m 61,27 -1,-4 c -1.910633,0.509427 -2.918244,1.835875 -3,4 z"
+           id="path4185-2" />
       </g>
-      <g style="display:inline" id="g4238-6" transform="translate(-12,23)">
-        <path sodipodi:nodetypes="cc" inkscape:connector-curvature="0" id="path4187-9-18" d="m 53,21 4,3" style="fill:none;stroke:#a40000;stroke-width:4;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1;display:inline"/>
-        <path sodipodi:nodetypes="cc" inkscape:connector-curvature="0" id="path4187-9-1-7" d="m 53.4,20.1 4,3" style="fill:none;stroke:#ef2929;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1;display:inline"/>
-        <path sodipodi:nodetypes="cccc" inkscape:connector-curvature="0" id="path4185-92" d="m 61,27 -1,-4 c -1.910633,0.509427 -2.918244,1.835875 -3,4 z" style="fill:#ef2929;stroke:#a40000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1"/>
+      <g
+         transform="translate(-12,23)"
+         id="g4238-6"
+         style="display:inline">
+        <path
+           style="fill:none;stroke:#a40000;stroke-width:4;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1;display:inline"
+           d="m 53,21 4,3"
+           id="path4187-9-18" />
+        <path
+           style="fill:none;stroke:#ef2929;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1;display:inline"
+           d="m 53.4,20.1 4,3"
+           id="path4187-9-1-7" />
+        <path
+           style="fill:#ef2929;stroke:#a40000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1"
+           d="m 61,27 -1,-4 c -1.910633,0.509427 -2.918244,1.835875 -3,4 z"
+           id="path4185-92" />
       </g>
-      <g transform="translate(-6,19)" style="display:inline" id="g4238-2-0">
-        <path sodipodi:nodetypes="cc" inkscape:connector-curvature="0" id="path4187-9-7-2" d="m 53,21 4,3" style="fill:none;stroke:#a40000;stroke-width:4;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1;display:inline"/>
-        <path sodipodi:nodetypes="cc" inkscape:connector-curvature="0" id="path4187-9-1-0-3" d="m 53.4,20.1 4,3" style="fill:none;stroke:#ef2929;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1;display:inline"/>
-        <path sodipodi:nodetypes="cccc" inkscape:connector-curvature="0" id="path4185-9-7" d="m 61,27 -1,-4 c -1.910633,0.509427 -2.918244,1.835875 -3,4 z" style="fill:#ef2929;stroke:#a40000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1"/>
+      <g
+         id="g4238-2-0"
+         style="display:inline"
+         transform="translate(-6,19)">
+        <path
+           style="fill:none;stroke:#a40000;stroke-width:4;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1;display:inline"
+           d="m 53,21 4,3"
+           id="path4187-9-7-2" />
+        <path
+           style="fill:none;stroke:#ef2929;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1;display:inline"
+           d="m 53.4,20.1 4,3"
+           id="path4187-9-1-0-3" />
+        <path
+           style="fill:#ef2929;stroke:#a40000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1"
+           d="m 61,27 -1,-4 c -1.910633,0.509427 -2.918244,1.835875 -3,4 z"
+           id="path4185-9-7" />
       </g>
-      <g transform="translate(-2,16)" style="display:inline" id="g4238-3-5">
-        <path sodipodi:nodetypes="cc" inkscape:connector-curvature="0" id="path4187-9-6-9" d="m 53,21 4,3" style="fill:none;stroke:#a40000;stroke-width:4;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1;display:inline"/>
-        <path sodipodi:nodetypes="cc" inkscape:connector-curvature="0" id="path4187-9-1-06-2" d="m 53.4,20.1 4,3" style="fill:none;stroke:#ef2929;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1;display:inline"/>
-        <path sodipodi:nodetypes="cccc" inkscape:connector-curvature="0" id="path4185-2-2" d="m 61,27 -1,-4 c -1.910633,0.509427 -2.918244,1.835875 -3,4 z" style="fill:#ef2929;stroke:#a40000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1"/>
+      <g
+         id="g4238-3-5"
+         style="display:inline"
+         transform="translate(-2,16)">
+        <path
+           style="fill:none;stroke:#a40000;stroke-width:4;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1;display:inline"
+           d="m 53,21 4,3"
+           id="path4187-9-6-9" />
+        <path
+           style="fill:none;stroke:#ef2929;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1;display:inline"
+           d="m 53.4,20.1 4,3"
+           id="path4187-9-1-06-2" />
+        <path
+           style="fill:#ef2929;stroke:#a40000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1"
+           d="m 61,27 -1,-4 c -1.910633,0.509427 -2.918244,1.835875 -3,4 z"
+           id="path4185-2-2" />
       </g>
-      <g style="display:inline" id="g4238-8" transform="translate(-12,15)">
-        <path sodipodi:nodetypes="cc" inkscape:connector-curvature="0" id="path4187-9-9" d="m 53,21 4,3" style="fill:none;stroke:#a40000;stroke-width:4;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1;display:inline"/>
-        <path sodipodi:nodetypes="cc" inkscape:connector-curvature="0" id="path4187-9-1-73" d="m 53.4,20.1 4,3" style="fill:none;stroke:#ef2929;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1;display:inline"/>
-        <path sodipodi:nodetypes="cccc" inkscape:connector-curvature="0" id="path4185-6" d="m 61,27 -1,-4 c -1.910633,0.509427 -2.918244,1.835875 -3,4 z" style="fill:#ef2929;stroke:#a40000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1"/>
+      <g
+         transform="translate(-12,15)"
+         id="g4238-8"
+         style="display:inline">
+        <path
+           style="fill:none;stroke:#a40000;stroke-width:4;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1;display:inline"
+           d="m 53,21 4,3"
+           id="path4187-9-9" />
+        <path
+           style="fill:none;stroke:#ef2929;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1;display:inline"
+           d="m 53.4,20.1 4,3"
+           id="path4187-9-1-73" />
+        <path
+           style="fill:#ef2929;stroke:#a40000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1"
+           d="m 61,27 -1,-4 c -1.910633,0.509427 -2.918244,1.835875 -3,4 z"
+           id="path4185-6" />
       </g>
-      <g transform="translate(-6,12)" style="display:inline" id="g4238-2-1">
-        <path sodipodi:nodetypes="cc" inkscape:connector-curvature="0" id="path4187-9-7-29" d="m 53,21 4,3" style="fill:none;stroke:#a40000;stroke-width:4;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1;display:inline"/>
-        <path sodipodi:nodetypes="cc" inkscape:connector-curvature="0" id="path4187-9-1-0-31" d="m 53.4,20.1 4,3" style="fill:none;stroke:#ef2929;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1;display:inline"/>
-        <path sodipodi:nodetypes="cccc" inkscape:connector-curvature="0" id="path4185-9-9" d="m 61,27 -1,-4 c -1.910633,0.509427 -2.918244,1.835875 -3,4 z" style="fill:#ef2929;stroke:#a40000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1"/>
+      <g
+         id="g4238-2-1"
+         style="display:inline"
+         transform="translate(-6,12)">
+        <path
+           style="fill:none;stroke:#a40000;stroke-width:4;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1;display:inline"
+           d="m 53,21 4,3"
+           id="path4187-9-7-29" />
+        <path
+           style="fill:none;stroke:#ef2929;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1;display:inline"
+           d="m 53.4,20.1 4,3"
+           id="path4187-9-1-0-31" />
+        <path
+           style="fill:#ef2929;stroke:#a40000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1"
+           d="m 61,27 -1,-4 c -1.910633,0.509427 -2.918244,1.835875 -3,4 z"
+           id="path4185-9-9" />
       </g>
-      <g transform="translate(-2,10)" style="display:inline" id="g4238-3-4">
-        <path sodipodi:nodetypes="cc" inkscape:connector-curvature="0" id="path4187-9-6-7" d="m 53,21 4,3" style="fill:none;stroke:#a40000;stroke-width:4;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1;display:inline"/>
-        <path sodipodi:nodetypes="cc" inkscape:connector-curvature="0" id="path4187-9-1-06-8" d="m 53.4,20.1 4,3" style="fill:none;stroke:#ef2929;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1;display:inline"/>
-        <path sodipodi:nodetypes="cccc" inkscape:connector-curvature="0" id="path4185-2-4" d="m 61,27 -1,-4 c -1.910633,0.509427 -2.918244,1.835875 -3,4 z" style="fill:#ef2929;stroke:#a40000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1"/>
+      <g
+         id="g4238-3-4"
+         style="display:inline"
+         transform="translate(-2,10)">
+        <path
+           style="fill:none;stroke:#a40000;stroke-width:4;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1;display:inline"
+           d="m 53,21 4,3"
+           id="path4187-9-6-7" />
+        <path
+           style="fill:none;stroke:#ef2929;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1;display:inline"
+           d="m 53.4,20.1 4,3"
+           id="path4187-9-1-06-8" />
+        <path
+           style="fill:#ef2929;stroke:#a40000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1"
+           d="m 61,27 -1,-4 c -1.910633,0.509427 -2.918244,1.835875 -3,4 z"
+           id="path4185-2-4" />
       </g>
     </g>
-    <path style="fill:#0000ff;fill-opacity:1;stroke:#0000ff;stroke-width:0.09756899;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" d="" id="path5141" inkscape:connector-curvature="0"/>
-    <path style="fill:#0000ff;fill-opacity:1;stroke:#0000ff;stroke-width:0.09756899;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" d="" id="path5143" inkscape:connector-curvature="0"/>
+    <path
+       id="path5141"
+       d=""
+       style="fill:#0000ff;fill-opacity:1;stroke:#0000ff;stroke-width:0.09756899;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       id="path5143"
+       d=""
+       style="fill:#0000ff;fill-opacity:1;stroke:#0000ff;stroke-width:0.09756899;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
 </svg>

--- a/src/Mod/Image/Gui/Resources/icons/ImageWorkbench.svg
+++ b/src/Mod/Image/Gui/Resources/icons/ImageWorkbench.svg
@@ -1,6 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-
 <svg
    xmlns:dc="http://purl.org/dc/elements/1.1/"
    xmlns:cc="http://creativecommons.org/ns#"
@@ -8,197 +6,139 @@
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="64px"
-   height="64px"
-   id="svg2816"
    version="1.1"
-   inkscape:version="0.48.5 r10040"
-   sodipodi:docname="ImageWorkbench.svg">
+   id="svg2816"
+   height="64px"
+   width="64px">
   <defs
      id="defs2818">
     <linearGradient
-       inkscape:collect="always"
        id="linearGradient3825">
       <stop
-         style="stop-color:#4e9a06;stop-opacity:1;"
+         id="stop3827"
          offset="0"
-         id="stop3827" />
+         style="stop-color:#4e9a06;stop-opacity:1;" />
       <stop
-         style="stop-color:#8ae234;stop-opacity:1"
+         id="stop3829"
          offset="1"
-         id="stop3829" />
+         style="stop-color:#8ae234;stop-opacity:1" />
     </linearGradient>
     <linearGradient
-       inkscape:collect="always"
        id="linearGradient3817">
       <stop
-         style="stop-color:#a40000;stop-opacity:1"
+         id="stop3819"
          offset="0"
-         id="stop3819" />
+         style="stop-color:#a40000;stop-opacity:1" />
       <stop
-         style="stop-color:#ef2929;stop-opacity:1"
+         id="stop3821"
          offset="1"
-         id="stop3821" />
+         style="stop-color:#ef2929;stop-opacity:1" />
     </linearGradient>
     <linearGradient
-       inkscape:collect="always"
        id="linearGradient3809">
       <stop
-         style="stop-color:#204a87;stop-opacity:1"
+         id="stop3811"
          offset="0"
-         id="stop3811" />
+         style="stop-color:#204a87;stop-opacity:1" />
       <stop
-         style="stop-color:#729fcf;stop-opacity:1"
+         id="stop3813"
          offset="1"
-         id="stop3813" />
+         style="stop-color:#729fcf;stop-opacity:1" />
     </linearGradient>
     <linearGradient
-       inkscape:collect="always"
        id="linearGradient3767">
       <stop
-         style="stop-color:#c17d11;stop-opacity:1"
+         id="stop3769"
          offset="0"
-         id="stop3769" />
+         style="stop-color:#c17d11;stop-opacity:1" />
       <stop
-         style="stop-color:#e9b96e;stop-opacity:1"
+         id="stop3771"
          offset="1"
-         id="stop3771" />
+         style="stop-color:#e9b96e;stop-opacity:1" />
     </linearGradient>
     <linearGradient
        id="linearGradient3691">
       <stop
-         style="stop-color:#ffffff;stop-opacity:1;"
+         id="stop3693"
          offset="0"
-         id="stop3693" />
+         style="stop-color:#ffffff;stop-opacity:1;" />
       <stop
-         style="stop-color:#ffffff;stop-opacity:0;"
+         id="stop3695"
          offset="1"
-         id="stop3695" />
+         style="stop-color:#ffffff;stop-opacity:0;" />
     </linearGradient>
     <linearGradient
        id="linearGradient3614">
       <stop
-         style="stop-color:#ff9100;stop-opacity:1;"
+         id="stop3616"
          offset="0"
-         id="stop3616" />
+         style="stop-color:#ff9100;stop-opacity:1;" />
       <stop
-         style="stop-color:#ffcb00;stop-opacity:1;"
+         id="stop3618"
          offset="1"
-         id="stop3618" />
+         style="stop-color:#ffcb00;stop-opacity:1;" />
     </linearGradient>
-    <inkscape:perspective
-       sodipodi:type="inkscape:persp3d"
-       inkscape:vp_x="0 : 32 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_z="64 : 32 : 1"
-       inkscape:persp3d-origin="32 : 21.333333 : 1"
-       id="perspective2824" />
-    <inkscape:perspective
-       id="perspective2834"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3691"
-       id="linearGradient3697"
-       x1="31.066811"
-       y1="17.542589"
-       x2="26.010498"
-       y2="24.832104"
+       gradientTransform="translate(-0.37824909,-2.8753906)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-0.37824909,-2.8753906)" />
+       y2="24.832104"
+       x2="26.010498"
+       y1="17.542589"
+       x1="31.066811"
+       id="linearGradient3697"
+       xlink:href="#linearGradient3691" />
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3767"
+       gradientUnits="userSpaceOnUse"
+       y2="11"
+       x2="23"
+       y1="56"
+       x1="38"
        id="linearGradient3773"
-       x1="38"
-       y1="56"
-       x2="23"
-       y2="11"
-       gradientUnits="userSpaceOnUse" />
+       xlink:href="#linearGradient3767" />
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3767-7"
+       gradientUnits="userSpaceOnUse"
+       y2="11"
+       x2="23"
+       y1="56"
+       x1="38"
        id="linearGradient3773-1"
-       x1="38"
-       y1="56"
-       x2="23"
-       y2="11"
-       gradientUnits="userSpaceOnUse" />
+       xlink:href="#linearGradient3767-7" />
     <linearGradient
-       inkscape:collect="always"
        id="linearGradient3767-7">
       <stop
-         style="stop-color:#8f5902;stop-opacity:1"
+         id="stop3769-4"
          offset="0"
-         id="stop3769-4" />
+         style="stop-color:#8f5902;stop-opacity:1" />
       <stop
-         style="stop-color:#e9b96e;stop-opacity:1"
+         id="stop3771-0"
          offset="1"
-         id="stop3771-0" />
+         style="stop-color:#e9b96e;stop-opacity:1" />
     </linearGradient>
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3809"
-       id="linearGradient3815"
-       x1="49"
-       y1="40"
-       x2="43"
+       gradientUnits="userSpaceOnUse"
        y2="29"
-       gradientUnits="userSpaceOnUse" />
+       x2="43"
+       y1="40"
+       x1="49"
+       id="linearGradient3815"
+       xlink:href="#linearGradient3809" />
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3817"
-       id="linearGradient3823"
-       x1="42"
-       y1="52"
-       x2="36"
+       gradientUnits="userSpaceOnUse"
        y2="35"
-       gradientUnits="userSpaceOnUse" />
+       x2="36"
+       y1="52"
+       x1="42"
+       id="linearGradient3823"
+       xlink:href="#linearGradient3817" />
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3825"
-       id="linearGradient3831"
-       x1="31"
-       y1="48"
-       x2="27"
+       gradientUnits="userSpaceOnUse"
        y2="36"
-       gradientUnits="userSpaceOnUse" />
+       x2="27"
+       y1="48"
+       x1="31"
+       id="linearGradient3831"
+       xlink:href="#linearGradient3825" />
   </defs>
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageopacity="0.0"
-     inkscape:pageshadow="2"
-     inkscape:zoom="11"
-     inkscape:cx="27.637923"
-     inkscape:cy="25.980753"
-     inkscape:current-layer="layer1"
-     showgrid="true"
-     inkscape:document-units="px"
-     inkscape:grid-bbox="true"
-     inkscape:window-width="1920"
-     inkscape:window-height="1057"
-     inkscape:window-x="1912"
-     inkscape:window-y="-8"
-     inkscape:window-maximized="1"
-     inkscape:snap-bbox="true"
-     inkscape:snap-nodes="false">
-    <inkscape:grid
-       type="xygrid"
-       id="grid2997"
-       empspacing="2"
-       visible="true"
-       enabled="true"
-       snapvisiblegridlinesonly="true" />
-  </sodipodi:namedview>
   <metadata
      id="metadata2821">
     <rdf:RDF>
@@ -207,37 +147,31 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
+        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <g
-     id="layer1"
-     inkscape:label="Layer 1"
-     inkscape:groupmode="layer">
+     id="layer1">
     <path
-       style="fill:url(#linearGradient3773);fill-opacity:1;stroke:#271903;stroke-width:1.99999988000000010;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-       d="M 14.371999,5.0538129 C 7.8696489,5.9472735 2.7428728,13.491844 3.0099824,21.942056 3.3492104,32.673779 20.653513,54.224555 31.609802,56.533609 42.566089,58.84266 54.497373,52.194832 58.294307,45.024826 62.091243,37.85482 62.551014,24.106355 55.352159,18.710901 48.153305,13.315446 38.635294,17.388528 32.133777,16.028924 25.63226,14.669318 20.874348,4.1603522 14.371999,5.0538129 z m 3.992937,13.5953611 c 3.445997,0.07124 6.845415,3.444682 6.784747,7.009598 -0.992516,10.288311 -15.4911171,1.008006 -10.128426,-5.868502 1.028684,-0.826923 2.195014,-1.16484 3.343679,-1.141096 z"
        id="path2840"
-       sodipodi:nodetypes="cszzzzzcccc"
-       inkscape:connector-curvature="0" />
+       d="M 14.371999,5.0538129 C 7.8696489,5.9472735 2.7428728,13.491844 3.0099824,21.942056 3.3492104,32.673779 20.653513,54.224555 31.609802,56.533609 42.566089,58.84266 54.497373,52.194832 58.294307,45.024826 62.091243,37.85482 62.551014,24.106355 55.352159,18.710901 48.153305,13.315446 38.635294,17.388528 32.133777,16.028924 25.63226,14.669318 20.874348,4.1603522 14.371999,5.0538129 z m 3.992937,13.5953611 c 3.445997,0.07124 6.845415,3.444682 6.784747,7.009598 -0.992516,10.288311 -15.4911171,1.008006 -10.128426,-5.868502 1.028684,-0.826923 2.195014,-1.16484 3.343679,-1.141096 z"
+       style="fill:url(#linearGradient3773);fill-opacity:1;stroke:#271903;stroke-width:1.99999988000000010;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
     <path
-       style="fill:url(#linearGradient3831);stroke:#4e9a06;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;fill-opacity:1"
+       id="path3644"
        d="m 26.484363,35.972858 c -3.430345,1.49337 -1.427147,5.521391 -0.995166,8.148201 0.07684,2.825426 3.049863,6.651994 6.009348,4.612197 2.725914,-2.617267 2.01049,-6.876427 0.925458,-10.088285 -0.847269,-2.556979 -3.463456,-3.681919 -5.93964,-2.672113 z"
-       id="path3644" />
+       style="fill:url(#linearGradient3831);stroke:#4e9a06;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;fill-opacity:1" />
     <path
-       style="fill:url(#linearGradient3823);stroke:#a40000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;fill-opacity:1"
+       id="path3654"
        d="m 35.483904,38.801286 c -0.614014,3.657403 -0.588904,7.644227 1.24659,10.969758 0.526463,0.878063 1.097031,1.827625 2.013469,2.339827 1.295182,0.687126 3.044551,0.542866 4.059789,-0.573318 1.649455,-1.632946 2.102305,-4.363465 1.071235,-6.439563 -0.760845,-1.232935 -2.036005,-2.003223 -3.125803,-2.914563 -1.34932,-1.039951 -2.730874,-2.328706 -2.998644,-4.099852 -0.174498,-1.08408 0.399099,-2.293989 -0.293445,-3.274314 -0.410772,-0.711168 -1.462137,-1.306295 -2.192922,-0.701898 -0.73315,0.818306 -0.346058,2.017311 -0.155827,2.971112 0.141329,0.57038 0.30568,1.13773 0.375558,1.722811 z"
-       id="path3654" />
+       style="fill:url(#linearGradient3823);stroke:#a40000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;fill-opacity:1" />
     <path
-       style="fill:url(#linearGradient3815);stroke:#204a87;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;fill-opacity:1"
+       id="path3666"
        d="m 35.998163,30.058875 c 2.8139,0.725202 5.667849,2.68437 6.055182,5.780259 -0.324522,2.843364 2.643122,3.395323 4.816063,3.564547 2.43744,-0.225527 2.724431,4.475957 5.109502,2.908887 2.027846,-2.172623 1.204782,-5.559781 -0.180215,-7.835537 -1.508283,-2.056753 -2.407321,-5.463248 -5.708611,-4.057709 -3.157474,0.569068 -5.221518,-3.684217 -8.46863,-2.397408 -0.898837,0.220429 -2.117867,0.917831 -1.623291,2.036961 z"
-       id="path3666" />
+       style="fill:url(#linearGradient3815);stroke:#204a87;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;fill-opacity:1" />
     <path
-       style="fill:none;stroke:#e9b96e;stroke-width:1.99999988;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-       d="M 14.405905,7.322401 C 9.0792655,7.2380432 4.7606057,14.838626 5.0092939,22.638821 5.3251269,32.545027 22.617848,52.165325 31.818531,54.478577 41.019214,56.791829 52.673104,51.291734 56.480909,43.945994 60.288714,36.600254 60.898595,25.363909 54.196212,20.38349 47.49383,15.403069 39.359507,19.344659 32.033643,17.998728 24.707779,16.652797 19.732544,7.4067588 14.405905,7.322401 z m 5.092228,9.44841 c 4.847544,0.483596 9.008898,6.329545 7.120365,11.580851 -5.455979,9.65761 -19.8224908,-1.801536 -12.933308,-10.109696 0.989881,-0.827597 4.100672,-1.910909 5.812943,-1.471155 z"
        id="path2840-9"
-       sodipodi:nodetypes="zszzzzzcccc"
-       inkscape:connector-curvature="0" />
+       d="M 14.405905,7.322401 C 9.0792655,7.2380432 4.7606057,14.838626 5.0092939,22.638821 5.3251269,32.545027 22.617848,52.165325 31.818531,54.478577 41.019214,56.791829 52.673104,51.291734 56.480909,43.945994 60.288714,36.600254 60.898595,25.363909 54.196212,20.38349 47.49383,15.403069 39.359507,19.344659 32.033643,17.998728 24.707779,16.652797 19.732544,7.4067588 14.405905,7.322401 z m 5.092228,9.44841 c 4.847544,0.483596 9.008898,6.329545 7.120365,11.580851 -5.455979,9.65761 -19.8224908,-1.801536 -12.933308,-10.109696 0.989881,-0.827597 4.100672,-1.910909 5.812943,-1.471155 z"
+       style="fill:none;stroke:#e9b96e;stroke-width:1.99999988;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
   </g>
 </svg>

--- a/src/Mod/Inspection/Gui/Resources/icons/InspectionWorkbench.svg
+++ b/src/Mod/Inspection/Gui/Resources/icons/InspectionWorkbench.svg
@@ -1,6 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-
 <svg
    xmlns:dc="http://purl.org/dc/elements/1.1/"
    xmlns:cc="http://creativecommons.org/ns#"
@@ -8,17 +6,10 @@
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="64"
-   height="64"
-   id="svg2"
    version="1.1"
-   inkscape:version="0.48.5 r10040"
-   sodipodi:docname="mesh_pipette.svg"
-   inkscape:export-filename="/home/user/Downloads/cad/mystuff/icons/main_icons/pipette_32px.png"
-   inkscape:export-xdpi="45"
-   inkscape:export-ydpi="45">
+   id="svg2"
+   height="64"
+   width="64">
   <title
      id="title3733">mesh_pipette</title>
   <defs
@@ -26,130 +17,90 @@
     <linearGradient
        id="linearGradient3820">
       <stop
-         style="stop-color:#babdb6;stop-opacity:1;"
+         id="stop3822"
          offset="0"
-         id="stop3822" />
+         style="stop-color:#babdb6;stop-opacity:1;" />
       <stop
-         style="stop-color:#eeeeec;stop-opacity:1;"
+         id="stop3824"
          offset="1"
-         id="stop3824" />
+         style="stop-color:#eeeeec;stop-opacity:1;" />
     </linearGradient>
     <linearGradient
        id="linearGradient3757">
       <stop
-         style="stop-color:#555753;stop-opacity:1;"
+         id="stop3759"
          offset="0"
-         id="stop3759" />
+         style="stop-color:#555753;stop-opacity:1;" />
       <stop
-         style="stop-color:#000000;stop-opacity:1;"
+         id="stop3761"
          offset="1"
-         id="stop3761" />
+         style="stop-color:#000000;stop-opacity:1;" />
     </linearGradient>
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3757"
-       id="linearGradient3763"
-       x1="28.796343"
-       y1="39.303909"
-       x2="22.936319"
+       gradientUnits="userSpaceOnUse"
        y2="33.977303"
-       gradientUnits="userSpaceOnUse" />
+       x2="22.936319"
+       y1="39.303909"
+       x1="28.796343"
+       id="linearGradient3763"
+       xlink:href="#linearGradient3757" />
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3820"
-       id="linearGradient3842"
-       x1="49"
-       y1="1043.3622"
-       x2="35"
+       gradientUnits="userSpaceOnUse"
        y2="1045.3622"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3820"
-       id="linearGradient3854"
-       gradientUnits="userSpaceOnUse"
+       x2="35"
+       y1="1043.3622"
        x1="49"
-       y1="1040.3622"
-       x2="39"
+       id="linearGradient3842"
+       xlink:href="#linearGradient3820" />
+    <linearGradient
+       gradientTransform="matrix(0.70710678,0.70710678,-0.70710678,0.70710678,720.43395,268.46023)"
        y2="1042.3622"
-       gradientTransform="matrix(0.70710678,0.70710678,-0.70710678,0.70710678,720.43395,268.46023)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3757"
-       id="linearGradient3870"
-       x1="40"
-       y1="1005.3622"
-       x2="51"
-       y2="1025.3622"
-       gradientUnits="userSpaceOnUse" />
-    <radialGradient
-       r="18.0625"
-       fy="41.625"
-       fx="25.1875"
-       cy="41.625"
-       cx="25.1875"
-       gradientTransform="matrix(1,0,0,0.32526,0,28.08607)"
+       x2="39"
+       y1="1040.3622"
+       x1="49"
        gradientUnits="userSpaceOnUse"
-       id="radialGradient3062"
-       xlink:href="#linearGradient2269"
-       inkscape:collect="always" />
+       id="linearGradient3854"
+       xlink:href="#linearGradient3820" />
     <linearGradient
-       inkscape:collect="always"
+       gradientUnits="userSpaceOnUse"
+       y2="1025.3622"
+       x2="51"
+       y1="1005.3622"
+       x1="40"
+       id="linearGradient3870"
+       xlink:href="#linearGradient3757" />
+    <radialGradient
+       xlink:href="#linearGradient2269"
+       id="radialGradient3062"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.32526,0,28.08607)"
+       cx="25.1875"
+       cy="41.625"
+       fx="25.1875"
+       fy="41.625"
+       r="18.0625" />
+    <linearGradient
        id="linearGradient2269">
       <stop
-         offset="0"
+         style="stop-color:#000000;stop-opacity:1;"
          id="stop2271"
-         style="stop-color:#000000;stop-opacity:1;" />
+         offset="0" />
       <stop
-         offset="1"
+         style="stop-color:#000000;stop-opacity:0;"
          id="stop2273"
-         style="stop-color:#000000;stop-opacity:0;" />
+         offset="1" />
     </linearGradient>
     <radialGradient
-       r="18.0625"
-       fy="41.625"
-       fx="25.1875"
-       cy="41.625"
-       cx="25.1875"
-       gradientTransform="matrix(1,0,0,0.32526,0,28.08607)"
-       gradientUnits="userSpaceOnUse"
-       id="radialGradient3113"
        xlink:href="#linearGradient2269"
-       inkscape:collect="always" />
+       id="radialGradient3113"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.32526,0,28.08607)"
+       cx="25.1875"
+       cy="41.625"
+       fx="25.1875"
+       fy="41.625"
+       r="18.0625" />
   </defs>
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageopacity="0.0"
-     inkscape:pageshadow="2"
-     inkscape:zoom="10.474172"
-     inkscape:cx="14.848964"
-     inkscape:cy="31.910228"
-     inkscape:document-units="px"
-     inkscape:current-layer="g3844"
-     showgrid="true"
-     showborder="true"
-     inkscape:showpageshadow="false"
-     borderlayer="false"
-     inkscape:snap-global="true"
-     inkscape:window-width="800"
-     inkscape:window-height="836"
-     inkscape:window-x="0"
-     inkscape:window-y="27"
-     inkscape:window-maximized="0">
-    <inkscape:grid
-       type="xygrid"
-       id="grid2990"
-       units="px"
-       empspacing="2"
-       visible="true"
-       enabled="true"
-       snapvisiblegridlinesonly="true"
-       spacingx="1px"
-       spacingy="1px" />
-  </sodipodi:namedview>
   <metadata
      id="metadata7">
     <rdf:RDF>
@@ -196,58 +147,39 @@
     </rdf:RDF>
   </metadata>
   <g
-     inkscape:label="Layer 1"
-     inkscape:groupmode="layer"
-     id="layer1"
-     transform="translate(0,-988.36218)">
+     transform="translate(0,-988.36218)"
+     id="layer1">
     <g
        id="g3844">
       <path
-         id="path2267"
-         sodipodi:cx="25.1875"
-         sodipodi:cy="41.625"
-         transform="matrix(1.256055,0,0,0.819149,-3.6368853,1011.4526)"
-         d="m 43.25,41.625 c 0,3.244673 -8.086857,5.875 -18.0625,5.875 -9.975643,0 -18.0625,-2.630327 -18.0625,-5.875 0,-3.244673 8.086857,-5.875 18.0625,-5.875 9.975643,0 18.0625,2.630327 18.0625,5.875 z"
-         sodipodi:type="arc"
          style="opacity:0.26704544;color:#000000;fill:url(#radialGradient3113);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
-         sodipodi:ry="5.875"
-         sodipodi:rx="18.0625" />
+         d="m 43.25,41.625 c 0,3.244673 -8.086857,5.875 -18.0625,5.875 -9.975643,0 -18.0625,-2.630327 -18.0625,-5.875 0,-3.244673 8.086857,-5.875 18.0625,-5.875 9.975643,0 18.0625,2.630327 18.0625,5.875 z"
+         transform="matrix(1.256055,0,0,0.819149,-3.6368853,1011.4526)"
+         id="path2267" />
       <path
-         sodipodi:nodetypes="czcccczcc"
-         inkscape:connector-curvature="0"
-         id="path3798-7"
+         style="fill:url(#linearGradient3854);fill-opacity:1;stroke:none"
          d="m 26.506083,1014.714 c 0,0 -16.970563,16.9706 -19.79899,19.799 -2.828427,2.8284 0,5.6569 0,5.6569 l -3.535534,6.3639 2.828427,2.8284 6.363961,-3.5355 c 0,0 2.828427,2.8284 5.656855,0 2.828427,-2.8284 19.798989,-19.799 19.798989,-19.799 z"
-         style="fill:url(#linearGradient3854);fill-opacity:1;stroke:none" />
+         id="path3798-7" />
       <path
-         sodipodi:nodetypes="czcc"
-         inkscape:connector-curvature="0"
-         id="path3800"
+         style="fill:none;stroke:#ffffff;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
          d="m 27.213204,1016.8353 c 0,0 -19.091883,19.0919 -19.79899,19.799 -0.707107,0.7071 1.337236,2.9054 1.337236,2.9054 l -4.165663,8.4083"
-         style="fill:none;stroke:#ffffff;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+         id="path3800" />
       <path
-         sodipodi:nodetypes="czcccczcc"
-         inkscape:connector-curvature="0"
-         id="path3798"
+         style="fill:none;stroke:#555753;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
          d="m 26.506097,1014.714 c 0,0 -16.970563,16.9706 -19.79899,19.799 -2.828427,2.8284 0,5.6568 0,5.6568 l -3.535534,6.364 2.828427,2.8284 6.363961,-3.5355 c 0,0 2.828428,2.8284 5.656855,0 2.828427,-2.8284 19.79899,-19.799 19.79899,-19.799 z"
-         style="fill:none;stroke:#555753;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+         id="path3798" />
       <path
-         sodipodi:nodetypes="zzzzzzzzzzzzz"
-         inkscape:connector-curvature="0"
-         id="path2992"
+         style="fill:url(#linearGradient3870);stroke:none;fill-opacity:1"
          d="m 24.384763,1011.1785 c 1.414213,-1.4142 4.24264,0 5.656854,0 1.414213,0 1.414213,0 2.828427,-2.8284 1.414213,-2.8285 -2.828427,-8.48535 1.414228,-12.728 4.24264,-4.24264 12.727936,-7.07108 21.213217,1.4142 8.485282,8.4853 5.65684,16.9706 1.4142,21.2132 -4.242655,4.2427 -9.899509,10e-5 -12.727937,1.4143 -2.828427,1.4142 -2.828427,1.4142 -2.828427,2.8284 0,1.4142 1.414214,4.2426 0,5.6568 -1.414213,1.4143 -2.12132,2.1214 -4.24264,1.4143 -2.121321,-0.7071 0,-2.8285 -5.656855,-8.4853 -5.656854,-5.6569 -7.778174,-3.5356 -8.485281,-5.6569 -0.707107,-2.1213 0,-2.8284 1.414214,-4.2426 z"
-         style="fill:url(#linearGradient3870);stroke:none;fill-opacity:1" />
+         id="path2992" />
       <path
-         sodipodi:nodetypes="zzzzzzzzzzzzz"
-         inkscape:connector-curvature="0"
-         id="path2992-3-6"
+         style="fill:none;stroke:#888a85;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
          d="m 25.798976,1012.5927 c 1.414214,-1.4142 4.461915,0.035 5.656854,0 1.19494,-0.035 0.707107,0.7071 2.828427,-2.8284 2.121321,-3.5356 -2.828427,-8.4853 1.414228,-12.72799 4.242641,-4.24264 11.426846,-5.54371 18.384776,1.41422 6.957931,6.95797 5.656855,14.14217 1.414214,18.38477 -4.242655,4.2427 -9.192402,-0.7071 -12.727936,1.4143 -3.535534,2.1213 -2.828427,1.4142 -2.828427,2.8284 0,1.4142 1.414213,4.2426 0,5.6568 -1.414214,1.4142 -1.414214,1.4142 -2.121321,0.7071 -0.707106,-0.7071 -0.636537,-3.0969 -5.275158,-7.7356 -4.63862,-4.6386 -6.745657,-4.2852 -7.452764,-4.9923 -0.707106,-0.7071 -0.707106,-0.7071 0.707107,-2.1213 z"
-         style="fill:none;stroke:#888a85;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+         id="path2992-3-6" />
       <path
-         sodipodi:nodetypes="zzzzzzzzzzzzz"
-         inkscape:connector-curvature="0"
-         id="path2992-3"
+         style="fill:none;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
          d="m 24.384763,1011.1785 c 1.414213,-1.4142 4.24264,0 5.656854,0 1.414213,0 1.414213,0 2.828427,-2.8284 1.414213,-2.8285 -2.828427,-8.48535 1.414228,-12.728 4.24264,-4.24264 12.727936,-7.07108 21.213217,1.4142 8.485282,8.4853 5.65684,16.9706 1.4142,21.2132 -4.242655,4.2427 -9.899509,10e-5 -12.727937,1.4143 -2.828427,1.4142 -2.828427,1.4142 -2.828427,2.8284 0,1.4142 1.414214,4.2426 0,5.6568 -1.414213,1.4143 -2.12132,2.1214 -4.24264,1.4143 -2.121321,-0.7071 0,-2.8285 -5.656855,-8.4853 -5.656854,-5.6569 -7.778174,-3.5356 -8.485281,-5.6569 -0.707107,-2.1213 0,-2.8284 1.414214,-4.2426 z"
-         style="fill:none;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+         id="path2992-3" />
     </g>
   </g>
 </svg>

--- a/src/Mod/Mesh/Gui/Resources/icons/MeshWorkbench.svg
+++ b/src/Mod/Mesh/Gui/Resources/icons/MeshWorkbench.svg
@@ -1,6 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-
 <svg
    xmlns:dc="http://purl.org/dc/elements/1.1/"
    xmlns:cc="http://creativecommons.org/ns#"
@@ -8,16 +6,10 @@
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="64px"
-   height="64px"
+   version="1.1"
    id="svg2568"
-   sodipodi:version="0.32"
-   inkscape:version="0.48.5 r10040"
-   sodipodi:docname="MeshWorkbench.svg"
-   inkscape:output_extension="org.inkscape.output.svg.inkscape"
-   version="1.1">
+   height="64px"
+   width="64px">
   <title
      id="title3032">MeshWorkbench</title>
   <defs
@@ -25,117 +17,75 @@
     <linearGradient
        id="linearGradient3864">
       <stop
-         id="stop3866"
+         style="stop-color:#71f873;stop-opacity:1;"
          offset="0"
-         style="stop-color:#71f873;stop-opacity:1;" />
+         id="stop3866" />
       <stop
-         id="stop3868"
+         style="stop-color:#009520;stop-opacity:1;"
          offset="1"
-         style="stop-color:#009520;stop-opacity:1;" />
+         id="stop3868" />
     </linearGradient>
     <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3864"
-       id="radialGradient3552"
-       gradientUnits="userSpaceOnUse"
-       cx="48.645836"
-       cy="25.149042"
-       fx="48.645836"
+       r="19.571428"
        fy="25.149042"
-       r="19.571428" />
+       fx="48.645836"
+       cy="25.149042"
+       cx="48.645836"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3552"
+       xlink:href="#linearGradient3864" />
     <linearGradient
        id="linearGradient3593">
       <stop
-         style="stop-color:#c8f9d7;stop-opacity:1;"
+         id="stop3595"
          offset="0"
-         id="stop3595" />
+         style="stop-color:#c8f9d7;stop-opacity:1;" />
       <stop
-         style="stop-color:#63ca72;stop-opacity:1;"
+         id="stop3597"
          offset="1"
-         id="stop3597" />
+         style="stop-color:#63ca72;stop-opacity:1;" />
     </linearGradient>
     <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3593"
-       id="radialGradient3599"
-       gradientUnits="userSpaceOnUse"
-       cx="51.63789367675781"
-       cy="24.96270370483398"
-       fx="51.63789367675781"
+       r="19.5714282989502"
        fy="24.96270370483398"
-       r="19.5714282989502" />
-    <inkscape:perspective
-       sodipodi:type="inkscape:persp3d"
-       inkscape:vp_x="0 : 32 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_z="64 : 32 : 1"
-       inkscape:persp3d-origin="32 : 21.333333 : 1"
-       id="perspective2576" />
-    <radialGradient
-       r="18.0625"
-       fy="41.625"
-       fx="25.1875"
-       cy="41.625"
-       cx="25.1875"
-       gradientTransform="matrix(1,0,0,0.32526,0,28.08607)"
+       fx="51.63789367675781"
+       cy="24.96270370483398"
+       cx="51.63789367675781"
        gradientUnits="userSpaceOnUse"
-       id="radialGradient3169"
+       id="radialGradient3599"
+       xlink:href="#linearGradient3593" />
+    <radialGradient
        xlink:href="#linearGradient2269-0"
-       inkscape:collect="always" />
+       id="radialGradient3169"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.32526,0,28.08607)"
+       cx="25.1875"
+       cy="41.625"
+       fx="25.1875"
+       fy="41.625"
+       r="18.0625" />
     <linearGradient
-       inkscape:collect="always"
        id="linearGradient2269-0">
       <stop
-         offset="0"
+         style="stop-color:#000000;stop-opacity:1;"
          id="stop2271-4"
-         style="stop-color:#000000;stop-opacity:1;" />
+         offset="0" />
       <stop
-         offset="1"
+         style="stop-color:#000000;stop-opacity:0;"
          id="stop2273-87"
-         style="stop-color:#000000;stop-opacity:0;" />
+         offset="1" />
     </linearGradient>
     <radialGradient
-       r="18.0625"
-       fy="41.625"
-       fx="25.1875"
-       cy="41.625"
-       cx="25.1875"
-       gradientTransform="matrix(1,0,0,0.32526,0,28.08607)"
-       gradientUnits="userSpaceOnUse"
-       id="radialGradient3026"
        xlink:href="#linearGradient2269-0"
-       inkscape:collect="always" />
+       id="radialGradient3026"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.32526,0,28.08607)"
+       cx="25.1875"
+       cy="41.625"
+       fx="25.1875"
+       fy="41.625"
+       r="18.0625" />
   </defs>
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageopacity="0.0"
-     inkscape:pageshadow="2"
-     inkscape:zoom="68.189417"
-     inkscape:cx="6.5621628"
-     inkscape:cy="30.5"
-     inkscape:current-layer="layer1"
-     showgrid="true"
-     inkscape:document-units="px"
-     inkscape:grid-bbox="true"
-     inkscape:window-width="800"
-     inkscape:window-height="836"
-     inkscape:window-x="0"
-     inkscape:window-y="27"
-     inkscape:window-maximized="0">
-    <inkscape:grid
-       type="xygrid"
-       id="grid2995"
-       units="px"
-       empspacing="2"
-       visible="true"
-       enabled="true"
-       snapvisiblegridlinesonly="true"
-       spacingx="1px"
-       spacingy="1px" />
-  </sodipodi:namedview>
   <metadata
      id="metadata2573">
     <rdf:RDF>
@@ -184,184 +134,127 @@
     </rdf:RDF>
   </metadata>
   <g
-     id="layer1"
-     inkscape:label="Layer 1"
-     inkscape:groupmode="layer">
+     id="layer1">
     <path
-       id="path2267"
-       sodipodi:cx="25.1875"
-       sodipodi:cy="41.625"
-       transform="matrix(1.6349796,0,0,1.0662685,-9.1810487,12.352246)"
-       d="m 43.25,41.625 a 18.0625,5.875 0 1 1 -36.125,0 18.0625,5.875 0 1 1 36.125,0 z"
-       sodipodi:type="arc"
        style="opacity:0.26704544;color:#000000;fill:url(#radialGradient3026);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
-       sodipodi:ry="5.875"
-       sodipodi:rx="18.0625" />
+       d="m 43.25,41.625 a 18.0625,5.875 0 1 1 -36.125,0 18.0625,5.875 0 1 1 36.125,0 z"
+       transform="matrix(1.6349796,0,0,1.0662685,-9.1810487,12.352246)"
+       id="path2267" />
     <path
-       style="fill:#8ae234;stroke:none"
-       d="M 33,5 51,13 19,9 33,5"
        id="path3007-3"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cccc" />
-    <path
-       style="fill:#8ae234;stroke:none"
-       d="M 19,9 9,19 51,13 z"
-       id="path3009-6"
-       inkscape:connector-curvature="0" />
-    <path
-       style="fill:#73d216;stroke:none"
-       d="M 51,13 57,33 9,19 51,13"
-       id="path3011-7"
-       inkscape:connector-curvature="0" />
-    <path
-       style="fill:none;stroke:#8ae234;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       d="M 12,18 56,31"
-       id="path3851"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cc" />
-    <path
-       style="fill:#73d216;stroke:none"
-       d="M 57,33 7,33 9,19 z"
-       id="path3013-5"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cccc" />
-    <path
-       style="fill:none;stroke:#8ae234;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       d="M 55,32 49,13"
-       id="path3853"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cc" />
-    <path
-       style="fill:none;stroke:#8ae234;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       d="m 8,31 42,0"
-       id="path3845"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cc" />
-    <path
-       style="fill:none;stroke:#8ae234;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       d="M 16,20 51,15"
-       id="path3855"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cc" />
-    <path
-       style="fill:#4e9a06;stroke:none"
-       d="M 7,33 49,49 57,33 z"
-       id="path3015-3"
-       inkscape:connector-curvature="0" />
-    <path
-       style="fill:none;stroke:#8ae234;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       d="M 49,33 9,21"
-       id="path3847"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cc" />
-    <path
-       style="fill:none;stroke:#73d216;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       d="M 48,47 55,33"
-       id="path3839"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cc" />
-    <path
-       style="fill:none;stroke:#8ae234;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       d="M 11,20 9,33"
-       id="path3849"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cc" />
-    <path
-       style="fill:#4e9a06;stroke:none"
-       d="M 49,49 13,47 7,33 z"
-       id="path3017-5"
-       inkscape:connector-curvature="0" />
-    <path
-       style="fill:none;stroke:#73d216;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       d="M 56,35 13,35"
-       id="path3841"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cc" />
-    <path
-       style="fill:none;stroke:#73d216;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       d="M 43,47 12,45"
-       id="path3833"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cc" />
-    <path
-       style="fill:none;stroke:#73d216;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       d="M 13,34 49,47"
-       id="path3843"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cc" />
-    <path
-       style="fill:#4e9a06;stroke:none"
-       d="M 49,49 33,55 13,47 z"
-       id="path3019-6"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cccc" />
-    <path
-       style="fill:none;stroke:#73d216;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       d="M 15,47 9,34"
-       id="path3835"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cc" />
-    <path
-       style="fill:none;stroke:#73d216;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       d="m 19,48 16,6"
-       id="path3827"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cc" />
-    <path
-       style="fill:none;stroke:#73d216;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       d="M 8,35 41,48"
-       id="path3837"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cc" />
-    <path
-       style="fill:none;stroke:#172a04;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
        d="M 33,5 51,13 19,9 33,5"
-       id="path3007"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cccc" />
+       style="fill:#8ae234;stroke:none" />
     <path
-       style="fill:none;stroke:#172a04;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+       id="path3009-6"
        d="M 19,9 9,19 51,13 z"
-       id="path3009"
-       inkscape:connector-curvature="0" />
+       style="fill:#8ae234;stroke:none" />
     <path
-       style="fill:none;stroke:#172a04;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+       id="path3011-7"
        d="M 51,13 57,33 9,19 51,13"
-       id="path3011"
-       inkscape:connector-curvature="0" />
+       style="fill:#73d216;stroke:none" />
     <path
-       style="fill:none;stroke:#172a04;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+       id="path3851"
+       d="M 12,18 56,31"
+       style="fill:none;stroke:#8ae234;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       id="path3013-5"
        d="M 57,33 7,33 9,19 z"
-       id="path3013"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cccc" />
+       style="fill:#73d216;stroke:none" />
     <path
-       style="fill:none;stroke:#172a04;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+       id="path3853"
+       d="M 55,32 49,13"
+       style="fill:none;stroke:#8ae234;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       id="path3845"
+       d="m 8,31 42,0"
+       style="fill:none;stroke:#8ae234;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       id="path3855"
+       d="M 16,20 51,15"
+       style="fill:none;stroke:#8ae234;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       id="path3015-3"
        d="M 7,33 49,49 57,33 z"
-       id="path3015"
-       inkscape:connector-curvature="0" />
+       style="fill:#4e9a06;stroke:none" />
     <path
-       style="fill:none;stroke:#73d216;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       d="M 31,54 45,49"
-       id="path3829"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cc" />
+       id="path3847"
+       d="M 49,33 9,21"
+       style="fill:none;stroke:#8ae234;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     <path
-       style="fill:none;stroke:#172a04;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+       id="path3839"
+       d="M 48,47 55,33"
+       style="fill:none;stroke:#73d216;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       id="path3849"
+       d="M 11,20 9,33"
+       style="fill:none;stroke:#8ae234;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       id="path3017-5"
        d="M 49,49 13,47 7,33 z"
-       id="path3017"
-       inkscape:connector-curvature="0" />
+       style="fill:#4e9a06;stroke:none" />
     <path
-       style="fill:none;stroke:#73d216;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       d="m 19,49 26,1"
-       id="path3831"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cc" />
+       id="path3841"
+       d="M 56,35 13,35"
+       style="fill:none;stroke:#73d216;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     <path
-       style="fill:none;stroke:#172a04;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+       id="path3833"
+       d="M 43,47 12,45"
+       style="fill:none;stroke:#73d216;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       id="path3843"
+       d="M 13,34 49,47"
+       style="fill:none;stroke:#73d216;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       id="path3019-6"
        d="M 49,49 33,55 13,47 z"
+       style="fill:#4e9a06;stroke:none" />
+    <path
+       id="path3835"
+       d="M 15,47 9,34"
+       style="fill:none;stroke:#73d216;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       id="path3827"
+       d="m 19,48 16,6"
+       style="fill:none;stroke:#73d216;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       id="path3837"
+       d="M 8,35 41,48"
+       style="fill:none;stroke:#73d216;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       id="path3007"
+       d="M 33,5 51,13 19,9 33,5"
+       style="fill:none;stroke:#172a04;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+    <path
+       id="path3009"
+       d="M 19,9 9,19 51,13 z"
+       style="fill:none;stroke:#172a04;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+    <path
+       id="path3011"
+       d="M 51,13 57,33 9,19 51,13"
+       style="fill:none;stroke:#172a04;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+    <path
+       id="path3013"
+       d="M 57,33 7,33 9,19 z"
+       style="fill:none;stroke:#172a04;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+    <path
+       id="path3015"
+       d="M 7,33 49,49 57,33 z"
+       style="fill:none;stroke:#172a04;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+    <path
+       id="path3829"
+       d="M 31,54 45,49"
+       style="fill:none;stroke:#73d216;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       id="path3017"
+       d="M 49,49 13,47 7,33 z"
+       style="fill:none;stroke:#172a04;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+    <path
+       id="path3831"
+       d="m 19,49 26,1"
+       style="fill:none;stroke:#73d216;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
        id="path3019"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cccc" />
+       d="M 49,49 33,55 13,47 z"
+       style="fill:none;stroke:#172a04;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
   </g>
 </svg>

--- a/src/Mod/OpenSCAD/Resources/icons/OpenSCADWorkbench.svg
+++ b/src/Mod/OpenSCAD/Resources/icons/OpenSCADWorkbench.svg
@@ -1,111 +1,426 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-<svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" width="64px" height="64px" id="svg2784" sodipodi:version="0.32" inkscape:version="0.48.5 r10040" sodipodi:docname="preferences-openscad.svg" inkscape:output_extension="org.inkscape.output.svg.inkscape" version="1.1">
-  <defs id="defs2786">
-    <linearGradient inkscape:collect="always" id="linearGradient4069">
-      <stop style="stop-color:#fce94f;stop-opacity:1" offset="0" id="stop4071"/>
-      <stop style="stop-color:#c4a000;stop-opacity:1" offset="1" id="stop4073"/>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   version="1.1"
+   id="svg2784"
+   height="64px"
+   width="64px">
+  <defs
+     id="defs2786">
+    <linearGradient
+       id="linearGradient4069">
+      <stop
+         id="stop4071"
+         offset="0"
+         style="stop-color:#fce94f;stop-opacity:1" />
+      <stop
+         id="stop4073"
+         offset="1"
+         style="stop-color:#c4a000;stop-opacity:1" />
     </linearGradient>
-    <linearGradient id="linearGradient3960" inkscape:collect="always">
-      <stop id="stop3962" offset="0" style="stop-color:#c4a000;stop-opacity:1"/>
-      <stop id="stop3964" offset="1" style="stop-color:#fce94f;stop-opacity:1"/>
+    <linearGradient
+       id="linearGradient3960">
+      <stop
+         style="stop-color:#c4a000;stop-opacity:1"
+         offset="0"
+         id="stop3962" />
+      <stop
+         style="stop-color:#fce94f;stop-opacity:1"
+         offset="1"
+         id="stop3964" />
     </linearGradient>
-    <linearGradient inkscape:collect="always" id="linearGradient3884">
-      <stop style="stop-color:#c4a000;stop-opacity:1" offset="0" id="stop3886"/>
-      <stop style="stop-color:#fce94f;stop-opacity:1" offset="1" id="stop3888"/>
+    <linearGradient
+       id="linearGradient3884">
+      <stop
+         id="stop3886"
+         offset="0"
+         style="stop-color:#c4a000;stop-opacity:1" />
+      <stop
+         id="stop3888"
+         offset="1"
+         style="stop-color:#fce94f;stop-opacity:1" />
     </linearGradient>
-    <linearGradient id="linearGradient3842">
-      <stop style="stop-color:#c4a000;stop-opacity:1" offset="0" id="stop3844"/>
-      <stop style="stop-color:#edd400;stop-opacity:1" offset="1" id="stop3846"/>
+    <linearGradient
+       id="linearGradient3842">
+      <stop
+         id="stop3844"
+         offset="0"
+         style="stop-color:#c4a000;stop-opacity:1" />
+      <stop
+         id="stop3846"
+         offset="1"
+         style="stop-color:#edd400;stop-opacity:1" />
     </linearGradient>
-    <linearGradient id="linearGradient3834">
-      <stop style="stop-color:#c4a000;stop-opacity:1" offset="0" id="stop3836"/>
-      <stop style="stop-color:#fce94f;stop-opacity:1" offset="1" id="stop3838"/>
+    <linearGradient
+       id="linearGradient3834">
+      <stop
+         id="stop3836"
+         offset="0"
+         style="stop-color:#c4a000;stop-opacity:1" />
+      <stop
+         id="stop3838"
+         offset="1"
+         style="stop-color:#fce94f;stop-opacity:1" />
     </linearGradient>
-    <linearGradient id="linearGradient3826">
-      <stop style="stop-color:#edd400;stop-opacity:1" offset="0" id="stop3828"/>
-      <stop style="stop-color:#c4a000;stop-opacity:1" offset="1" id="stop3830"/>
+    <linearGradient
+       id="linearGradient3826">
+      <stop
+         id="stop3828"
+         offset="0"
+         style="stop-color:#edd400;stop-opacity:1" />
+      <stop
+         id="stop3830"
+         offset="1"
+         style="stop-color:#c4a000;stop-opacity:1" />
     </linearGradient>
-    <linearGradient id="linearGradient3808">
-      <stop style="stop-color:#e4ea00;stop-opacity:1;" offset="0" id="stop3810"/>
-      <stop style="stop-color:#f2db00;stop-opacity:1;" offset="1" id="stop3812"/>
+    <linearGradient
+       id="linearGradient3808">
+      <stop
+         id="stop3810"
+         offset="0"
+         style="stop-color:#e4ea00;stop-opacity:1;" />
+      <stop
+         id="stop3812"
+         offset="1"
+         style="stop-color:#f2db00;stop-opacity:1;" />
     </linearGradient>
-    <linearGradient id="linearGradient3377">
-      <stop id="stop3379" offset="0" style="stop-color:#fce94f;stop-opacity:1"/>
-      <stop id="stop3381" offset="1" style="stop-color:#c4a000;stop-opacity:1"/>
+    <linearGradient
+       id="linearGradient3377">
+      <stop
+         style="stop-color:#fce94f;stop-opacity:1"
+         offset="0"
+         id="stop3379" />
+      <stop
+         style="stop-color:#c4a000;stop-opacity:1"
+         offset="1"
+         id="stop3381" />
     </linearGradient>
-    <radialGradient inkscape:collect="always" xlink:href="#linearGradient3377" id="radialGradient3692" cx="43.599617" cy="29.18952" fx="43.599617" fy="29.18952" r="19.467436" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.58858121,0.89357879,-0.83511467,0.55007389,42.986662,-28.011196)"/>
-    <inkscape:perspective sodipodi:type="inkscape:persp3d" inkscape:vp_x="0 : 32 : 1" inkscape:vp_y="0 : 1000 : 0" inkscape:vp_z="64 : 32 : 1" inkscape:persp3d-origin="32 : 21.333333 : 1" id="perspective2792"/>
-    <radialGradient inkscape:collect="always" xlink:href="#linearGradient3377-7" id="radialGradient3692-1" cx="45.883327" cy="28.869568" fx="45.883327" fy="28.869568" r="19.467436" gradientUnits="userSpaceOnUse" gradientTransform="translate(2.5454545,3.8181818)"/>
-    <linearGradient id="linearGradient3377-7">
-      <stop id="stop3379-4" offset="0" style="stop-color:#faff2b;stop-opacity:1;"/>
-      <stop id="stop3381-0" offset="1" style="stop-color:#ffaa00;stop-opacity:1;"/>
+    <radialGradient
+       gradientTransform="matrix(0.58858121,0.89357879,-0.83511467,0.55007389,42.986662,-28.011196)"
+       gradientUnits="userSpaceOnUse"
+       r="19.467436"
+       fy="29.18952"
+       fx="43.599617"
+       cy="29.18952"
+       cx="43.599617"
+       id="radialGradient3692"
+       xlink:href="#linearGradient3377" />
+    <radialGradient
+       gradientTransform="translate(2.5454545,3.8181818)"
+       gradientUnits="userSpaceOnUse"
+       r="19.467436"
+       fy="28.869568"
+       fx="45.883327"
+       cy="28.869568"
+       cx="45.883327"
+       id="radialGradient3692-1"
+       xlink:href="#linearGradient3377-7" />
+    <linearGradient
+       id="linearGradient3377-7">
+      <stop
+         style="stop-color:#faff2b;stop-opacity:1;"
+         offset="0"
+         id="stop3379-4" />
+      <stop
+         style="stop-color:#ffaa00;stop-opacity:1;"
+         offset="1"
+         id="stop3381-0" />
     </linearGradient>
-    <radialGradient r="19.467436" fy="28.869568" fx="45.883327" cy="28.869568" cx="45.883327" gradientUnits="userSpaceOnUse" id="radialGradient3777" xlink:href="#linearGradient3377-7" inkscape:collect="always"/>
-    <linearGradient id="linearGradient3377-2">
-      <stop id="stop3379-45" offset="0" style="stop-color:#faff2b;stop-opacity:1;"/>
-      <stop id="stop3381-5" offset="1" style="stop-color:#ffaa00;stop-opacity:1;"/>
+    <radialGradient
+       xlink:href="#linearGradient3377-7"
+       id="radialGradient3777"
+       gradientUnits="userSpaceOnUse"
+       cx="45.883327"
+       cy="28.869568"
+       fx="45.883327"
+       fy="28.869568"
+       r="19.467436" />
+    <linearGradient
+       id="linearGradient3377-2">
+      <stop
+         style="stop-color:#faff2b;stop-opacity:1;"
+         offset="0"
+         id="stop3379-45" />
+      <stop
+         style="stop-color:#ffaa00;stop-opacity:1;"
+         offset="1"
+         id="stop3381-5" />
     </linearGradient>
-    <radialGradient r="19.467436" fy="28.869568" fx="45.883327" cy="28.869568" cx="45.883327" gradientUnits="userSpaceOnUse" id="radialGradient3777-1" xlink:href="#linearGradient3377-2" inkscape:collect="always"/>
-    <radialGradient inkscape:collect="always" xlink:href="#linearGradient3377-27" id="radialGradient3692-5" cx="45.883327" cy="28.869568" fx="45.883327" fy="28.869568" r="19.467436" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1.1841662,0,0,1.1841642,-0.69479429,-8.8496725)"/>
-    <linearGradient id="linearGradient3377-27">
-      <stop id="stop3379-6" offset="0" style="stop-color:#faff2b;stop-opacity:1;"/>
-      <stop id="stop3381-1" offset="1" style="stop-color:#ffaa00;stop-opacity:1;"/>
+    <radialGradient
+       xlink:href="#linearGradient3377-2"
+       id="radialGradient3777-1"
+       gradientUnits="userSpaceOnUse"
+       cx="45.883327"
+       cy="28.869568"
+       fx="45.883327"
+       fy="28.869568"
+       r="19.467436" />
+    <radialGradient
+       gradientTransform="matrix(1.1841662,0,0,1.1841642,-0.69479429,-8.8496725)"
+       gradientUnits="userSpaceOnUse"
+       r="19.467436"
+       fy="28.869568"
+       fx="45.883327"
+       cy="28.869568"
+       cx="45.883327"
+       id="radialGradient3692-5"
+       xlink:href="#linearGradient3377-27" />
+    <linearGradient
+       id="linearGradient3377-27">
+      <stop
+         style="stop-color:#faff2b;stop-opacity:1;"
+         offset="0"
+         id="stop3379-6" />
+      <stop
+         style="stop-color:#ffaa00;stop-opacity:1;"
+         offset="1"
+         id="stop3381-1" />
     </linearGradient>
-    <radialGradient r="19.467436" fy="28.869568" fx="45.883327" cy="28.869568" cx="45.883327" gradientUnits="userSpaceOnUse" id="radialGradient3777-4" xlink:href="#linearGradient3377-27" inkscape:collect="always"/>
-    <radialGradient inkscape:collect="always" xlink:href="#linearGradient3377-6" id="radialGradient3692-3" cx="45.883327" cy="28.869568" fx="45.883327" fy="28.869568" r="19.467436" gradientUnits="userSpaceOnUse"/>
-    <linearGradient id="linearGradient3377-6">
-      <stop id="stop3379-7" offset="0" style="stop-color:#faff2b;stop-opacity:1;"/>
-      <stop id="stop3381-53" offset="1" style="stop-color:#ffaa00;stop-opacity:1;"/>
+    <radialGradient
+       xlink:href="#linearGradient3377-27"
+       id="radialGradient3777-4"
+       gradientUnits="userSpaceOnUse"
+       cx="45.883327"
+       cy="28.869568"
+       fx="45.883327"
+       fy="28.869568"
+       r="19.467436" />
+    <radialGradient
+       gradientUnits="userSpaceOnUse"
+       r="19.467436"
+       fy="28.869568"
+       fx="45.883327"
+       cy="28.869568"
+       cx="45.883327"
+       id="radialGradient3692-3"
+       xlink:href="#linearGradient3377-6" />
+    <linearGradient
+       id="linearGradient3377-6">
+      <stop
+         style="stop-color:#faff2b;stop-opacity:1;"
+         offset="0"
+         id="stop3379-7" />
+      <stop
+         style="stop-color:#ffaa00;stop-opacity:1;"
+         offset="1"
+         id="stop3381-53" />
     </linearGradient>
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient3826" id="linearGradient3824" x1="41.644596" y1="7.3131728" x2="32.11372" y2="7.3131728" gradientUnits="userSpaceOnUse" spreadMethod="reflect" gradientTransform="matrix(1.0492215,0,0,1.0539809,-1.6944067,-0.70794444)"/>
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient3834" id="linearGradient3832" x1="10" y1="39" x2="20" y2="51" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1.0143154,0,0,1.0155293,0.0259269,-0.68916943)"/>
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient3842" id="linearGradient3840" x1="48" y1="46" x2="54" y2="40" gradientUnits="userSpaceOnUse" spreadMethod="reflect" gradientTransform="matrix(1.0799199,0,0,1.105453,-3.4193043,-3.9088685)"/>
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient3826-2" id="linearGradient3824-6" x1="39" y1="7" x2="30" y2="7" gradientUnits="userSpaceOnUse" spreadMethod="reflect" gradientTransform="matrix(1.0492215,0,0,1.0539809,-1.6944067,-0.70794444)"/>
-    <linearGradient id="linearGradient3826-2">
-      <stop style="stop-color:#edd400;stop-opacity:1" offset="0" id="stop3828-9"/>
-      <stop style="stop-color:#c4a000;stop-opacity:1" offset="1" id="stop3830-1"/>
+    <linearGradient
+       gradientTransform="matrix(1.0492215,0,0,1.0539809,-1.6944067,-0.70794444)"
+       spreadMethod="reflect"
+       gradientUnits="userSpaceOnUse"
+       y2="7.3131728"
+       x2="32.11372"
+       y1="7.3131728"
+       x1="41.644596"
+       id="linearGradient3824"
+       xlink:href="#linearGradient3826" />
+    <linearGradient
+       gradientTransform="matrix(1.0143154,0,0,1.0155293,0.0259269,-0.68916943)"
+       gradientUnits="userSpaceOnUse"
+       y2="51"
+       x2="20"
+       y1="39"
+       x1="10"
+       id="linearGradient3832"
+       xlink:href="#linearGradient3834" />
+    <linearGradient
+       gradientTransform="matrix(1.0799199,0,0,1.105453,-3.4193043,-3.9088685)"
+       spreadMethod="reflect"
+       gradientUnits="userSpaceOnUse"
+       y2="40"
+       x2="54"
+       y1="46"
+       x1="48"
+       id="linearGradient3840"
+       xlink:href="#linearGradient3842" />
+    <linearGradient
+       gradientTransform="matrix(1.0492215,0,0,1.0539809,-1.6944067,-0.70794444)"
+       spreadMethod="reflect"
+       gradientUnits="userSpaceOnUse"
+       y2="7"
+       x2="30"
+       y1="7"
+       x1="39"
+       id="linearGradient3824-6"
+       xlink:href="#linearGradient3826-2" />
+    <linearGradient
+       id="linearGradient3826-2">
+      <stop
+         id="stop3828-9"
+         offset="0"
+         style="stop-color:#edd400;stop-opacity:1" />
+      <stop
+         id="stop3830-1"
+         offset="1"
+         style="stop-color:#c4a000;stop-opacity:1" />
     </linearGradient>
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient3884" id="linearGradient3890" x1="28" y1="11" x2="33" y2="11" gradientUnits="userSpaceOnUse" spreadMethod="reflect"/>
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient3884-0" id="linearGradient3890-7" x1="28" y1="11" x2="33" y2="11" gradientUnits="userSpaceOnUse" spreadMethod="reflect"/>
-    <linearGradient inkscape:collect="always" id="linearGradient3884-0">
-      <stop style="stop-color:#c4a000;stop-opacity:1" offset="0" id="stop3886-9"/>
-      <stop style="stop-color:#fce94f;stop-opacity:1" offset="1" id="stop3888-3"/>
+    <linearGradient
+       spreadMethod="reflect"
+       gradientUnits="userSpaceOnUse"
+       y2="11"
+       x2="33"
+       y1="11"
+       x1="28"
+       id="linearGradient3890"
+       xlink:href="#linearGradient3884" />
+    <linearGradient
+       spreadMethod="reflect"
+       gradientUnits="userSpaceOnUse"
+       y2="11"
+       x2="33"
+       y1="11"
+       x1="28"
+       id="linearGradient3890-7"
+       xlink:href="#linearGradient3884-0" />
+    <linearGradient
+       id="linearGradient3884-0">
+      <stop
+         id="stop3886-9"
+         offset="0"
+         style="stop-color:#c4a000;stop-opacity:1" />
+      <stop
+         id="stop3888-3"
+         offset="1"
+         style="stop-color:#fce94f;stop-opacity:1" />
     </linearGradient>
-    <linearGradient gradientTransform="matrix(-0.6522254,-0.75802508,0.75802508,-0.6522254,30.23856,73.668577)" y2="11.801114" x2="26.346874" y1="11.483715" x1="30.577625" spreadMethod="reflect" gradientUnits="userSpaceOnUse" id="linearGradient3907" xlink:href="#linearGradient3960" inkscape:collect="always"/>
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient3834-6" id="linearGradient3832-0" x1="10" y1="39" x2="20" y2="51" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1.0143154,0,0,1.0155293,0.0259269,-0.68916943)"/>
-    <linearGradient id="linearGradient3834-6">
-      <stop style="stop-color:#c4a000;stop-opacity:1" offset="0" id="stop3836-2"/>
-      <stop style="stop-color:#fce94f;stop-opacity:1" offset="1" id="stop3838-6"/>
+    <linearGradient
+       xlink:href="#linearGradient3960"
+       id="linearGradient3907"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect"
+       x1="30.577625"
+       y1="11.483715"
+       x2="26.346874"
+       y2="11.801114"
+       gradientTransform="matrix(-0.6522254,-0.75802508,0.75802508,-0.6522254,30.23856,73.668577)" />
+    <linearGradient
+       gradientTransform="matrix(1.0143154,0,0,1.0155293,0.0259269,-0.68916943)"
+       gradientUnits="userSpaceOnUse"
+       y2="51"
+       x2="20"
+       y1="39"
+       x1="10"
+       id="linearGradient3832-0"
+       xlink:href="#linearGradient3834-6" />
+    <linearGradient
+       id="linearGradient3834-6">
+      <stop
+         id="stop3836-2"
+         offset="0"
+         style="stop-color:#c4a000;stop-opacity:1" />
+      <stop
+         id="stop3838-6"
+         offset="1"
+         style="stop-color:#fce94f;stop-opacity:1" />
     </linearGradient>
-    <linearGradient gradientTransform="matrix(-0.6522254,-0.75802508,0.75802508,-0.6522254,30.23856,73.668577)" y2="11.801114" x2="26.346874" y1="11.483715" x1="30.577625" spreadMethod="reflect" gradientUnits="userSpaceOnUse" id="linearGradient3907-8" xlink:href="#linearGradient3960-7" inkscape:collect="always"/>
-    <linearGradient id="linearGradient3960-7" inkscape:collect="always">
-      <stop id="stop3962-9" offset="0" style="stop-color:#c4a000;stop-opacity:1"/>
-      <stop id="stop3964-2" offset="1" style="stop-color:#fce94f;stop-opacity:1"/>
+    <linearGradient
+       xlink:href="#linearGradient3960-7"
+       id="linearGradient3907-8"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect"
+       x1="30.577625"
+       y1="11.483715"
+       x2="26.346874"
+       y2="11.801114"
+       gradientTransform="matrix(-0.6522254,-0.75802508,0.75802508,-0.6522254,30.23856,73.668577)" />
+    <linearGradient
+       id="linearGradient3960-7">
+      <stop
+         style="stop-color:#c4a000;stop-opacity:1"
+         offset="0"
+         id="stop3962-9" />
+      <stop
+         style="stop-color:#fce94f;stop-opacity:1"
+         offset="1"
+         id="stop3964-2" />
     </linearGradient>
-    <linearGradient y2="11.801114" x2="26.346874" y1="11.483715" x1="30.577625" spreadMethod="reflect" gradientTransform="matrix(-0.74430745,0.66783712,-0.66783712,-0.74430745,78.706744,27.311789)" gradientUnits="userSpaceOnUse" id="linearGradient3981" xlink:href="#linearGradient3960-7" inkscape:collect="always"/>
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient3842-7" id="linearGradient3840-3" x1="48" y1="46" x2="54" y2="40" gradientUnits="userSpaceOnUse" spreadMethod="reflect" gradientTransform="matrix(1.0799199,0,0,1.105453,-3.4193043,-3.9088685)"/>
-    <linearGradient id="linearGradient3842-7">
-      <stop style="stop-color:#c4a000;stop-opacity:1" offset="0" id="stop3844-5"/>
-      <stop style="stop-color:#edd400;stop-opacity:1" offset="1" id="stop3846-9"/>
+    <linearGradient
+       xlink:href="#linearGradient3960-7"
+       id="linearGradient3981"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.74430745,0.66783712,-0.66783712,-0.74430745,78.706744,27.311789)"
+       spreadMethod="reflect"
+       x1="30.577625"
+       y1="11.483715"
+       x2="26.346874"
+       y2="11.801114" />
+    <linearGradient
+       gradientTransform="matrix(1.0799199,0,0,1.105453,-3.4193043,-3.9088685)"
+       spreadMethod="reflect"
+       gradientUnits="userSpaceOnUse"
+       y2="40"
+       x2="54"
+       y1="46"
+       x1="48"
+       id="linearGradient3840-3"
+       xlink:href="#linearGradient3842-7" />
+    <linearGradient
+       id="linearGradient3842-7">
+      <stop
+         id="stop3844-5"
+         offset="0"
+         style="stop-color:#c4a000;stop-opacity:1" />
+      <stop
+         id="stop3846-9"
+         offset="1"
+         style="stop-color:#edd400;stop-opacity:1" />
     </linearGradient>
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient4069" id="linearGradient4075" x1="16" y1="47" x2="8" y2="36" gradientUnits="userSpaceOnUse" spreadMethod="reflect"/>
-    <radialGradient r="18.0625" fy="41.625" fx="25.1875" cy="41.625" cx="25.1875" gradientTransform="matrix(1,0,0,0.32526,0,28.08607)" gradientUnits="userSpaceOnUse" id="radialGradient3169" xlink:href="#linearGradient2269-0" inkscape:collect="always"/>
-    <linearGradient inkscape:collect="always" id="linearGradient2269-0">
-      <stop offset="0" id="stop2271-4" style="stop-color:#000000;stop-opacity:1;"/>
-      <stop offset="1" id="stop2273-87" style="stop-color:#000000;stop-opacity:0;"/>
+    <linearGradient
+       spreadMethod="reflect"
+       gradientUnits="userSpaceOnUse"
+       y2="36"
+       x2="8"
+       y1="47"
+       x1="16"
+       id="linearGradient4075"
+       xlink:href="#linearGradient4069" />
+    <radialGradient
+       xlink:href="#linearGradient2269-0"
+       id="radialGradient3169"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.32526,0,28.08607)"
+       cx="25.1875"
+       cy="41.625"
+       fx="25.1875"
+       fy="41.625"
+       r="18.0625" />
+    <linearGradient
+       id="linearGradient2269-0">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         id="stop2271-4"
+         offset="0" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         id="stop2273-87"
+         offset="1" />
     </linearGradient>
-    <radialGradient r="18.0625" fy="41.625" fx="25.1875" cy="41.625" cx="25.1875" gradientTransform="matrix(1,0,0,0.32526,0,28.08607)" gradientUnits="userSpaceOnUse" id="radialGradient3027" xlink:href="#linearGradient2269-0" inkscape:collect="always"/>
+    <radialGradient
+       xlink:href="#linearGradient2269-0"
+       id="radialGradient3027"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.32526,0,28.08607)"
+       cx="25.1875"
+       cy="41.625"
+       fx="25.1875"
+       fy="41.625"
+       r="18.0625" />
   </defs>
-  <sodipodi:namedview id="base" pagecolor="#ffffff" bordercolor="#666666" borderopacity="1.0" inkscape:pageopacity="0.0" inkscape:pageshadow="2" inkscape:zoom="8.9950097" inkscape:cx="43.155625" inkscape:cy="12.276158" inkscape:current-layer="layer1" showgrid="true" inkscape:document-units="px" inkscape:grid-bbox="true" inkscape:window-width="1600" inkscape:window-height="837" inkscape:window-x="0" inkscape:window-y="27" inkscape:window-maximized="1" inkscape:snap-bbox="true" inkscape:snap-nodes="false" inkscape:snap-global="true">
-    <inkscape:grid type="xygrid" id="grid3020" empspacing="2" visible="true" enabled="true" snapvisiblegridlinesonly="true"/>
-  </sodipodi:namedview>
-  <metadata id="metadata2789">
+  <metadata
+     id="metadata2789">
     <rdf:RDF>
-      <cc:Work rdf:about="">
+      <cc:Work
+         rdf:about="">
         <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-        <dc:title/>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
         <dc:creator>
           <cc:Agent>
             <dc:title>[triplus]</dc:title>
@@ -134,26 +449,86 @@
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <g id="layer1" inkscape:label="Layer 1" inkscape:groupmode="layer">
-    <path id="path2267" sodipodi:cx="25.1875" sodipodi:cy="41.625" transform="matrix(1.6608996,0,0,1.0662685,-7.8339099,13.352245)" d="m 43.25,41.625 a 18.0625,5.875 0 1 1 -36.125,0 18.0625,5.875 0 1 1 36.125,0 z" sodipodi:type="arc" style="opacity:0.26704544;color:#000000;fill:url(#radialGradient3027);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" sodipodi:ry="5.875" sodipodi:rx="18.0625"/>
-    <g id="g3564" transform="translate(-0.8153068,-67.540042)">
-      <path transform="matrix(1.4537651,0,0,1.4537628,-44.545755,47.281337)" d="m 71.785715,34.571426 a 18.571428,18.571428 0 1 1 -37.142856,0 18.571428,18.571428 0 1 1 37.142856,0 z" sodipodi:ry="18.571428" sodipodi:rx="18.571428" sodipodi:cy="34.571426" sodipodi:cx="53.214287" id="path3696" style="fill:url(#radialGradient3692);fill-opacity:1;fill-rule:evenodd;stroke:#302b00;stroke-width:1.37573910000000010;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" sodipodi:type="arc"/>
-      <path transform="matrix(1.3461538,0,0,1.3461539,-38.819309,51.001581)" d="m 71.785715,34.571426 a 18.571428,18.571428 0 1 1 -37.142856,0 18.571428,18.571428 0 1 1 37.142856,0 z" sodipodi:ry="18.571428" sodipodi:rx="18.571428" sodipodi:cy="34.571426" sodipodi:cx="53.214287" id="path3696-5" style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#fce94f;stroke-width:1.48571420000000010;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" sodipodi:type="arc"/>
+  <g
+     id="layer1">
+    <path
+       style="opacity:0.26704544;color:#000000;fill:url(#radialGradient3027);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
+       d="m 43.25,41.625 a 18.0625,5.875 0 1 1 -36.125,0 18.0625,5.875 0 1 1 36.125,0 z"
+       transform="matrix(1.6608996,0,0,1.0662685,-7.8339099,13.352245)"
+       id="path2267" />
+    <g
+       transform="translate(-0.8153068,-67.540042)"
+       id="g3564">
+      <path
+         style="fill:url(#radialGradient3692);fill-opacity:1;fill-rule:evenodd;stroke:#302b00;stroke-width:1.37573910000000010;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         id="path3696"
+         d="m 71.785715,34.571426 a 18.571428,18.571428 0 1 1 -37.142856,0 18.571428,18.571428 0 1 1 37.142856,0 z"
+         transform="matrix(1.4537651,0,0,1.4537628,-44.545755,47.281337)" />
+      <path
+         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#fce94f;stroke-width:1.48571420000000010;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         id="path3696-5"
+         d="m 71.785715,34.571426 a 18.571428,18.571428 0 1 1 -37.142856,0 18.571428,18.571428 0 1 1 37.142856,0 z"
+         transform="matrix(1.3461538,0,0,1.3461539,-38.819309,51.001581)" />
     </g>
-    <path inkscape:connector-curvature="0" id="path3800-1" d="m 11.574714,47.876578 c 4.841899,5.547019 10.53529,8.541003 12.695713,6.670124 2.160426,-1.870879 -0.02479,-7.902858 -4.866693,-13.449879 -4.8419,-5.547018 -10.509309,-8.51124 -12.669735,-6.640359 -2.160423,1.870877 -0.0012,7.873094 4.840715,13.420114 z" style="color:#000000;fill:url(#linearGradient4075);stroke:#302b00;stroke-width:1.79201257000000003;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;fill-opacity:1.0"/>
-    <path style="color:#000000;fill:url(#linearGradient3824);fill-opacity:1;fill-rule:evenodd;stroke:#302b00;stroke-width:1.79201280999999990;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" d="m 32.019412,2.8960063 c -7.23616,0 -13.123407,2.2894937 -13.123407,5.1093543 0,2.8198614 5.887247,5.1093554 13.123407,5.1093554 7.236159,0 13.08458,-2.289494 13.08458,-5.1093554 0,-2.8198606 -5.848421,-5.1093543 -13.08458,-5.1093543 z" id="path3758" inkscape:connector-curvature="0"/>
-    <path style="fill:url(#linearGradient3890);stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;fill-opacity:1.0" d="m 32.859401,9.9942376 -4.952493,-1.0219431 -4.873883,2.2011085 6.603325,1.414998 2.908607,0.393055 6.524714,-0.707499 1.965275,-1.021943 -2.594163,-2.1224975 z" id="path3848" inkscape:connector-curvature="0"/>
-    <path style="color:#000000;fill:url(#linearGradient3840);fill-opacity:1;fill-rule:evenodd;stroke:#302b00;stroke-width:1.79201281;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" d="m 44.248159,40.762384 c -5.176792,5.481192 -7.702037,11.609687 -5.624823,13.665404 2.077214,2.055718 7.97551,-0.734634 13.152303,-6.21582 5.176796,-5.481192 7.674265,-11.580275 5.597049,-13.635995 -2.077216,-2.055717 -7.947734,0.705223 -13.124529,6.186411 z" id="path3804" inkscape:connector-curvature="0"/>
-    <path style="color:#000000;fill:none;stroke:#302b00;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" d="m 22.876876,11.218371 c 1.556251,-1.8642167 5.626557,-3.1408527 9.928236,-1.162011 4.844018,-2.1387547 7.538964,0.201582 8.461115,1.678581" id="path3816" inkscape:connector-curvature="0" sodipodi:nodetypes="ccc"/>
-    <path style="color:#000000;fill:url(#radialGradient3692-5);fill-opacity:1;fill-rule:evenodd;stroke:#302b00;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" d="M 32.971953,9.6663518 32.952301,13.42476" id="path3838" inkscape:connector-curvature="0" sodipodi:nodetypes="cc"/>
-    <path style="fill:url(#linearGradient3907);fill-opacity:1;stroke:none" d="m 16.382707,42.241832 2.455483,4.420651 4.886672,1.512101 -3.273558,-5.181578 -1.599123,-2.461157 -4.791885,-4.484449 -2.056461,-0.82319 0.08307,3.350787 z" id="path3848-6" inkscape:connector-curvature="0" sodipodi:nodetypes="ccccccccc"/>
-    <path sodipodi:nodetypes="ccc" inkscape:connector-curvature="0" id="path3858" d="m 23.897135,48.418401 c -2.427392,0.07062 -6.116658,-1.672506 -7.486677,-6.204973 -4.812409,-2.208956 -5.056963,-5.420666 -4.56242,-7.090191" style="color:#000000;fill:none;stroke:#302b00;stroke-width:1.79201281;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
-    <path sodipodi:nodetypes="cc" inkscape:connector-curvature="0" id="path3860" d="m 16.203277,42.567762 2.740376,-2.426316" style="color:#000000;fill:none;stroke:#302b00;stroke-width:1.79201280999999990;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
-    <path style="fill:url(#linearGradient3981);fill-opacity:1;stroke:none" d="m 47.574725,41.817731 4.368669,-2.546818 1.410224,-4.91704 -5.112431,3.38053 -2.427393,1.649922 -4.383901,4.884042 -0.780276,2.073124 3.348336,-0.152685 z" id="path3848-6-0" inkscape:connector-curvature="0" sodipodi:nodetypes="ccccccccc"/>
-    <path sodipodi:nodetypes="ccc" inkscape:connector-curvature="0" id="path3866" d="m 53.422935,34.663278 c 0.04831,2.427936 -1.645327,5.982768 -6.190196,7.311085 -2.25308,4.791907 -5.113172,5.010191 -6.778083,4.500333" style="color:#000000;fill:none;stroke:#302b00;stroke-width:1.79201281;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" inkscape:transform-center-y="-0.72637378"/>
-    <path sodipodi:nodetypes="cc" inkscape:connector-curvature="0" id="path3868" d="M 47.585155,42.184794 45.184113,39.422246" style="color:#000000;fill:none;stroke:#302b00;stroke-width:1.79201280999999990;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" inkscape:transform-center-x="0.61358733" inkscape:transform-center-y="-0.78328765"/>
-    <path style="color:#000000;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#302b00;stroke-width:1.79201280999999990;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" d="m 32.019412,2.8960064 c -7.23616,0 -13.123407,2.2894937 -13.123407,5.1093543 0,2.8198613 5.887247,5.1093553 13.123407,5.1093553 7.236159,0 13.08458,-2.289494 13.08458,-5.1093553 0,-2.8198606 -5.848421,-5.1093543 -13.08458,-5.1093543 z" id="path3758-2" inkscape:connector-curvature="0"/>
-    <path inkscape:connector-curvature="0" id="path3800-1-2" d="m 11.574714,47.876578 c 4.841899,5.547019 10.53529,8.541003 12.695713,6.670124 2.160426,-1.870879 -0.02479,-7.902858 -4.866693,-13.449879 -4.8419,-5.547018 -10.509309,-8.51124 -12.669735,-6.640359 -2.160423,1.870877 -0.0012,7.873094 4.840715,13.420114 z" style="color:#000000;fill:none;stroke:#302b00;stroke-width:1.79201257;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
-    <path style="color:#000000;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#302b00;stroke-width:1.79201280999999990;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" d="m 44.248159,40.762384 c -5.176792,5.481192 -7.702037,11.609687 -5.624823,13.665404 2.077214,2.055718 7.97551,-0.734634 13.152303,-6.21582 5.176796,-5.481192 7.674265,-11.580275 5.597049,-13.635995 -2.077216,-2.055717 -7.947734,0.705223 -13.124529,6.186411 z" id="path3804-2" inkscape:connector-curvature="0"/>
+    <path
+       style="color:#000000;fill:url(#linearGradient4075);stroke:#302b00;stroke-width:1.79201257000000003;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;fill-opacity:1.0"
+       d="m 11.574714,47.876578 c 4.841899,5.547019 10.53529,8.541003 12.695713,6.670124 2.160426,-1.870879 -0.02479,-7.902858 -4.866693,-13.449879 -4.8419,-5.547018 -10.509309,-8.51124 -12.669735,-6.640359 -2.160423,1.870877 -0.0012,7.873094 4.840715,13.420114 z"
+       id="path3800-1" />
+    <path
+       id="path3758"
+       d="m 32.019412,2.8960063 c -7.23616,0 -13.123407,2.2894937 -13.123407,5.1093543 0,2.8198614 5.887247,5.1093554 13.123407,5.1093554 7.236159,0 13.08458,-2.289494 13.08458,-5.1093554 0,-2.8198606 -5.848421,-5.1093543 -13.08458,-5.1093543 z"
+       style="color:#000000;fill:url(#linearGradient3824);fill-opacity:1;fill-rule:evenodd;stroke:#302b00;stroke-width:1.79201280999999990;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    <path
+       id="path3848"
+       d="m 32.859401,9.9942376 -4.952493,-1.0219431 -4.873883,2.2011085 6.603325,1.414998 2.908607,0.393055 6.524714,-0.707499 1.965275,-1.021943 -2.594163,-2.1224975 z"
+       style="fill:url(#linearGradient3890);stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;fill-opacity:1.0" />
+    <path
+       id="path3804"
+       d="m 44.248159,40.762384 c -5.176792,5.481192 -7.702037,11.609687 -5.624823,13.665404 2.077214,2.055718 7.97551,-0.734634 13.152303,-6.21582 5.176796,-5.481192 7.674265,-11.580275 5.597049,-13.635995 -2.077216,-2.055717 -7.947734,0.705223 -13.124529,6.186411 z"
+       style="color:#000000;fill:url(#linearGradient3840);fill-opacity:1;fill-rule:evenodd;stroke:#302b00;stroke-width:1.79201281;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    <path
+       id="path3816"
+       d="m 22.876876,11.218371 c 1.556251,-1.8642167 5.626557,-3.1408527 9.928236,-1.162011 4.844018,-2.1387547 7.538964,0.201582 8.461115,1.678581"
+       style="color:#000000;fill:none;stroke:#302b00;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    <path
+       id="path3838"
+       d="M 32.971953,9.6663518 32.952301,13.42476"
+       style="color:#000000;fill:url(#radialGradient3692-5);fill-opacity:1;fill-rule:evenodd;stroke:#302b00;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    <path
+       id="path3848-6"
+       d="m 16.382707,42.241832 2.455483,4.420651 4.886672,1.512101 -3.273558,-5.181578 -1.599123,-2.461157 -4.791885,-4.484449 -2.056461,-0.82319 0.08307,3.350787 z"
+       style="fill:url(#linearGradient3907);fill-opacity:1;stroke:none" />
+    <path
+       style="color:#000000;fill:none;stroke:#302b00;stroke-width:1.79201281;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       d="m 23.897135,48.418401 c -2.427392,0.07062 -6.116658,-1.672506 -7.486677,-6.204973 -4.812409,-2.208956 -5.056963,-5.420666 -4.56242,-7.090191"
+       id="path3858" />
+    <path
+       style="color:#000000;fill:none;stroke:#302b00;stroke-width:1.79201280999999990;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       d="m 16.203277,42.567762 2.740376,-2.426316"
+       id="path3860" />
+    <path
+       id="path3848-6-0"
+       d="m 47.574725,41.817731 4.368669,-2.546818 1.410224,-4.91704 -5.112431,3.38053 -2.427393,1.649922 -4.383901,4.884042 -0.780276,2.073124 3.348336,-0.152685 z"
+       style="fill:url(#linearGradient3981);fill-opacity:1;stroke:none" />
+    <path
+       style="color:#000000;fill:none;stroke:#302b00;stroke-width:1.79201281;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       d="m 53.422935,34.663278 c 0.04831,2.427936 -1.645327,5.982768 -6.190196,7.311085 -2.25308,4.791907 -5.113172,5.010191 -6.778083,4.500333"
+       id="path3866" />
+    <path
+       style="color:#000000;fill:none;stroke:#302b00;stroke-width:1.79201280999999990;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       d="M 47.585155,42.184794 45.184113,39.422246"
+       id="path3868" />
+    <path
+       id="path3758-2"
+       d="m 32.019412,2.8960064 c -7.23616,0 -13.123407,2.2894937 -13.123407,5.1093543 0,2.8198613 5.887247,5.1093553 13.123407,5.1093553 7.236159,0 13.08458,-2.289494 13.08458,-5.1093553 0,-2.8198606 -5.848421,-5.1093543 -13.08458,-5.1093543 z"
+       style="color:#000000;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#302b00;stroke-width:1.79201280999999990;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    <path
+       style="color:#000000;fill:none;stroke:#302b00;stroke-width:1.79201257;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       d="m 11.574714,47.876578 c 4.841899,5.547019 10.53529,8.541003 12.695713,6.670124 2.160426,-1.870879 -0.02479,-7.902858 -4.866693,-13.449879 -4.8419,-5.547018 -10.509309,-8.51124 -12.669735,-6.640359 -2.160423,1.870877 -0.0012,7.873094 4.840715,13.420114 z"
+       id="path3800-1-2" />
+    <path
+       id="path3804-2"
+       d="m 44.248159,40.762384 c -5.176792,5.481192 -7.702037,11.609687 -5.624823,13.665404 2.077214,2.055718 7.97551,-0.734634 13.152303,-6.21582 5.176796,-5.481192 7.674265,-11.580275 5.597049,-13.635995 -2.077216,-2.055717 -7.947734,0.705223 -13.124529,6.186411 z"
+       style="color:#000000;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#302b00;stroke-width:1.79201280999999990;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
   </g>
 </svg>

--- a/src/Mod/Part/Gui/Resources/icons/PartWorkbench.svg
+++ b/src/Mod/Part/Gui/Resources/icons/PartWorkbench.svg
@@ -1,42 +1,104 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-<svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" width="64px" height="64px" id="svg2980" sodipodi:version="0.32" inkscape:version="0.48.5 r10040" sodipodi:docname="PartWorkbench.svg" inkscape:output_extension="org.inkscape.output.svg.inkscape" version="1.1">
-  <defs id="defs2982">
-    <linearGradient inkscape:collect="always" id="linearGradient3794">
-      <stop style="stop-color:#000000;stop-opacity:1;" offset="0" id="stop3796"/>
-      <stop style="stop-color:#000000;stop-opacity:0;" offset="1" id="stop3798"/>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   version="1.1"
+   id="svg2980"
+   height="64px"
+   width="64px">
+  <defs
+     id="defs2982">
+    <linearGradient
+       id="linearGradient3794">
+      <stop
+         id="stop3796"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         id="stop3798"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
     </linearGradient>
-    <linearGradient id="linearGradient3864">
-      <stop id="stop3866" offset="0" style="stop-color:#71b2f8;stop-opacity:1;"/>
-      <stop id="stop3868" offset="1" style="stop-color:#002795;stop-opacity:1;"/>
+    <linearGradient
+       id="linearGradient3864">
+      <stop
+         style="stop-color:#71b2f8;stop-opacity:1;"
+         offset="0"
+         id="stop3866" />
+      <stop
+         style="stop-color:#002795;stop-opacity:1;"
+         offset="1"
+         id="stop3868" />
     </linearGradient>
-    <inkscape:perspective sodipodi:type="inkscape:persp3d" inkscape:vp_x="0 : 32 : 1" inkscape:vp_y="0 : 1000 : 0" inkscape:vp_z="64 : 32 : 1" inkscape:persp3d-origin="32 : 21.333333 : 1" id="perspective2988"/>
-    <linearGradient gradientTransform="translate(0,-4)" inkscape:collect="always" xlink:href="#linearGradient3767" id="linearGradient3773" x1="22.116516" y1="55.717518" x2="17.328547" y2="21.31134" gradientUnits="userSpaceOnUse"/>
-    <linearGradient inkscape:collect="always" id="linearGradient3767">
-      <stop style="stop-color:#3465a4;stop-opacity:1" offset="0" id="stop3769"/>
-      <stop style="stop-color:#729fcf;stop-opacity:1" offset="1" id="stop3771"/>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="21.31134"
+       x2="17.328547"
+       y1="55.717518"
+       x1="22.116516"
+       id="linearGradient3773"
+       xlink:href="#linearGradient3767"
+       gradientTransform="translate(0,-4)" />
+    <linearGradient
+       id="linearGradient3767">
+      <stop
+         id="stop3769"
+         offset="0"
+         style="stop-color:#3465a4;stop-opacity:1" />
+      <stop
+         id="stop3771"
+         offset="1"
+         style="stop-color:#729fcf;stop-opacity:1" />
     </linearGradient>
-    <linearGradient gradientTransform="translate(0,-4)" inkscape:collect="always" xlink:href="#linearGradient3777" id="linearGradient3783" x1="53.896763" y1="51.179787" x2="47.502235" y2="21.83742" gradientUnits="userSpaceOnUse"/>
-    <linearGradient inkscape:collect="always" id="linearGradient3777">
-      <stop style="stop-color:#204a87;stop-opacity:1" offset="0" id="stop3779"/>
-      <stop style="stop-color:#3465a4;stop-opacity:1" offset="1" id="stop3781"/>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="21.83742"
+       x2="47.502235"
+       y1="51.179787"
+       x1="53.896763"
+       id="linearGradient3783"
+       xlink:href="#linearGradient3777"
+       gradientTransform="translate(0,-4)" />
+    <linearGradient
+       id="linearGradient3777">
+      <stop
+         id="stop3779"
+         offset="0"
+         style="stop-color:#204a87;stop-opacity:1" />
+      <stop
+         id="stop3781"
+         offset="1"
+         style="stop-color:#3465a4;stop-opacity:1" />
     </linearGradient>
-    <radialGradient inkscape:collect="always" xlink:href="#linearGradient3794" id="radialGradient3800" cx="1" cy="45" fx="1" fy="45" r="41" gradientTransform="matrix(0.93348213,-2.2905276e-8,0,0.28687573,0.06651751,32.090592)" gradientUnits="userSpaceOnUse"/>
+    <radialGradient
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.93348213,-2.2905276e-8,0,0.28687573,0.06651751,32.090592)"
+       r="41"
+       fy="45"
+       fx="1"
+       cy="45"
+       cx="1"
+       id="radialGradient3800"
+       xlink:href="#linearGradient3794" />
   </defs>
-  <sodipodi:namedview id="base" pagecolor="#ffffff" bordercolor="#666666" borderopacity="1.0" inkscape:pageopacity="0.0" inkscape:pageshadow="2" inkscape:zoom="1.7026367" inkscape:cx="15.50711" inkscape:cy="79.412627" inkscape:current-layer="layer1" showgrid="true" inkscape:document-units="px" inkscape:grid-bbox="true" inkscape:window-width="800" inkscape:window-height="837" inkscape:window-x="0" inkscape:window-y="27" inkscape:snap-bbox="true" inkscape:snap-nodes="false" inkscape:window-maximized="0">
-    <inkscape:grid type="xygrid" id="grid2991" empspacing="2" visible="true" enabled="true" snapvisiblegridlinesonly="true"/>
-  </sodipodi:namedview>
-  <metadata id="metadata2985">
+  <metadata
+     id="metadata2985">
     <rdf:RDF>
-      <cc:Work rdf:about="">
+      <cc:Work
+         rdf:about="">
         <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
         <dc:creator>
           <cc:Agent>
             <dc:title>[triplus]</dc:title>
           </cc:Agent>
         </dc:creator>
-        <dc:title>PartWorkbench</dc:title>
+        <dc:title></dc:title>
         <dc:date>2016-02-26</dc:date>
         <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
         <dc:publisher>
@@ -59,12 +121,32 @@
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <g id="layer1" inkscape:label="Layer 1" inkscape:groupmode="layer">
-    <path sodipodi:type="arc" style="fill:url(#radialGradient3800);fill-opacity:1;stroke:none" id="path3024" sodipodi:cx="1" sodipodi:cy="45" sodipodi:rx="41" sodipodi:ry="13" d="m 42,45 a 41,13 0 1 1 -82,0 41,13 0 1 1 82,0 z" transform="matrix(0.73170732,0,0,0.80769231,31.268293,15.153846)"/>
-    <path style="fill:#729fcf;stroke:#0b1521;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1" d="M 3,13 37,19 61,11 31,7 z" id="path2993" inkscape:connector-curvature="0" sodipodi:nodetypes="ccccc"/>
-    <path style="fill:url(#linearGradient3783);fill-opacity:1;stroke:#0b1521;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1" d="M 61,11 61,47 37,57 37,19 z" id="path2995" inkscape:connector-curvature="0"/>
-    <path inkscape:connector-curvature="0" sodipodi:nodetypes="ccccc" id="path3825" d="M 3,13 37,19 37,57 3,51 z" style="fill:url(#linearGradient3773);fill-opacity:1;fill-rule:evenodd;stroke:#0b1521;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
-    <path style="fill:none;stroke:#729fcf;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" d="m 5,15.42772 0.00867,33.919116 30.008671,5.268799 -0.0087,-33.933614 z" id="path3765" inkscape:connector-curvature="0" sodipodi:nodetypes="ccccc"/>
-    <path style="fill:none;stroke:#3465a4;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" d="m 39.01243,20.433833 -0.01226,33.535301 20.001105,-8.300993 3.6e-4,-31.867363 z" id="path3775" inkscape:connector-curvature="0" sodipodi:nodetypes="ccccc"/>
+  <g
+     id="layer1">
+    <path
+       transform="matrix(0.73170732,0,0,0.80769231,31.268293,15.153846)"
+       d="m 42,45 a 41,13 0 1 1 -82,0 41,13 0 1 1 82,0 z"
+       id="path3024"
+       style="fill:url(#radialGradient3800);fill-opacity:1;stroke:none" />
+    <path
+       id="path2993"
+       d="M 3,13 37,19 61,11 31,7 z"
+       style="fill:#729fcf;stroke:#0b1521;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1" />
+    <path
+       id="path2995"
+       d="M 61,11 61,47 37,57 37,19 z"
+       style="fill:url(#linearGradient3783);fill-opacity:1;stroke:#0b1521;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1" />
+    <path
+       style="fill:url(#linearGradient3773);fill-opacity:1;fill-rule:evenodd;stroke:#0b1521;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       d="M 3,13 37,19 37,57 3,51 z"
+       id="path3825" />
+    <path
+       id="path3765"
+       d="m 5,15.42772 0.00867,33.919116 30.008671,5.268799 -0.0087,-33.933614 z"
+       style="fill:none;stroke:#729fcf;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       id="path3775"
+       d="m 39.01243,20.433833 -0.01226,33.535301 20.001105,-8.300993 3.6e-4,-31.867363 z"
+       style="fill:none;stroke:#3465a4;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
   </g>
 </svg>

--- a/src/Mod/PartDesign/Gui/Resources/icons/PartDesignWorkbench.svg
+++ b/src/Mod/PartDesign/Gui/Resources/icons/PartDesignWorkbench.svg
@@ -1,66 +1,229 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-<svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" width="64px" height="64px" id="svg2980" sodipodi:version="0.32" inkscape:version="0.48.5 r10040" sodipodi:docname="PartDesignWorkbench.svg" inkscape:output_extension="org.inkscape.output.svg.inkscape" version="1.1">
-  <defs id="defs2982">
-    <linearGradient id="linearGradient3864">
-      <stop id="stop3866" offset="0" style="stop-color:#71b2f8;stop-opacity:1;"/>
-      <stop id="stop3868" offset="1" style="stop-color:#002795;stop-opacity:1;"/>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   version="1.1"
+   id="svg2980"
+   height="64px"
+   width="64px">
+  <defs
+     id="defs2982">
+    <linearGradient
+       id="linearGradient3864">
+      <stop
+         style="stop-color:#71b2f8;stop-opacity:1;"
+         offset="0"
+         id="stop3866" />
+      <stop
+         style="stop-color:#002795;stop-opacity:1;"
+         offset="1"
+         id="stop3868" />
     </linearGradient>
-    <inkscape:perspective sodipodi:type="inkscape:persp3d" inkscape:vp_x="0 : 32 : 1" inkscape:vp_y="0 : 1000 : 0" inkscape:vp_z="64 : 32 : 1" inkscape:persp3d-origin="32 : 21.333333 : 1" id="perspective2988"/>
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient3377-28" id="linearGradient3616-9" gradientUnits="userSpaceOnUse" x1="901.1875" y1="1190.875" x2="1267.9062" y2="1190.875" gradientTransform="matrix(0.1367863,0,0,0.1367863,-122.45404,-135.82061)"/>
-    <linearGradient id="linearGradient3377-28">
-      <stop id="stop3379-2" offset="0" style="stop-color:#ffaa00;stop-opacity:1;"/>
-      <stop id="stop3381-9" offset="1" style="stop-color:#faff2b;stop-opacity:1;"/>
+    <linearGradient
+       gradientTransform="matrix(0.1367863,0,0,0.1367863,-122.45404,-135.82061)"
+       y2="1190.875"
+       x2="1267.9062"
+       y1="1190.875"
+       x1="901.1875"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3616-9"
+       xlink:href="#linearGradient3377-28" />
+    <linearGradient
+       id="linearGradient3377-28">
+      <stop
+         style="stop-color:#ffaa00;stop-opacity:1;"
+         offset="0"
+         id="stop3379-2" />
+      <stop
+         style="stop-color:#faff2b;stop-opacity:1;"
+         offset="1"
+         id="stop3381-9" />
     </linearGradient>
-    <linearGradient gradientUnits="userSpaceOnUse" y2="1190.875" x2="1267.9062" y1="1190.875" x1="901.1875" id="linearGradient3383-7" xlink:href="#linearGradient3377-28" inkscape:collect="always"/>
-    <inkscape:perspective sodipodi:type="inkscape:persp3d" inkscape:vp_x="0 : 0.5 : 1" inkscape:vp_y="0 : 1000 : 0" inkscape:vp_z="1 : 0.5 : 1" inkscape:persp3d-origin="0.5 : 0.33333333 : 1" id="perspective3607-8"/>
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient3377-2" id="linearGradient3616" gradientUnits="userSpaceOnUse" x1="901.1875" y1="1190.875" x2="1267.9062" y2="1190.875" gradientTransform="matrix(0.1367863,0,0,0.1367863,-122.45404,-135.82061)"/>
-    <linearGradient id="linearGradient3377-2">
-      <stop id="stop3379-6" offset="0" style="stop-color:#ffaa00;stop-opacity:1;"/>
-      <stop id="stop3381-7" offset="1" style="stop-color:#faff2b;stop-opacity:1;"/>
+    <linearGradient
+       xlink:href="#linearGradient3377-28"
+       id="linearGradient3383-7"
+       x1="901.1875"
+       y1="1190.875"
+       x2="1267.9062"
+       y2="1190.875"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       gradientTransform="matrix(0.1367863,0,0,0.1367863,-122.45404,-135.82061)"
+       y2="1190.875"
+       x2="1267.9062"
+       y1="1190.875"
+       x1="901.1875"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3616"
+       xlink:href="#linearGradient3377-2" />
+    <linearGradient
+       id="linearGradient3377-2">
+      <stop
+         style="stop-color:#ffaa00;stop-opacity:1;"
+         offset="0"
+         id="stop3379-6" />
+      <stop
+         style="stop-color:#faff2b;stop-opacity:1;"
+         offset="1"
+         id="stop3381-7" />
     </linearGradient>
-    <linearGradient gradientUnits="userSpaceOnUse" y2="1190.875" x2="1267.9062" y1="1190.875" x1="901.1875" id="linearGradient3383-6" xlink:href="#linearGradient3377-2" inkscape:collect="always"/>
-    <inkscape:perspective sodipodi:type="inkscape:persp3d" inkscape:vp_x="0 : 0.5 : 1" inkscape:vp_y="0 : 1000 : 0" inkscape:vp_z="1 : 0.5 : 1" inkscape:persp3d-origin="0.5 : 0.33333333 : 1" id="perspective3607"/>
-    <radialGradient gradientUnits="userSpaceOnUse" gradientTransform="matrix(1.4307499,-1.3605156e-7,1.202713e-8,0.1264801,-475.3928,1244.2826)" r="194.40614" fy="1424.4465" fx="1103.6399" cy="1424.4465" cx="1103.6399" id="radialGradient6355" xlink:href="#linearGradient6349" inkscape:collect="always"/>
-    <inkscape:perspective id="perspective5829" inkscape:persp3d-origin="32 : 21.333333 : 1" inkscape:vp_z="64 : 32 : 1" inkscape:vp_y="0 : 1000 : 0" inkscape:vp_x="0 : 32 : 1" sodipodi:type="inkscape:persp3d"/>
-    <linearGradient gradientUnits="userSpaceOnUse" y2="1190.875" x2="1267.9062" y1="1190.875" x1="901.1875" id="linearGradient3383" xlink:href="#linearGradient3377" inkscape:collect="always"/>
-    <linearGradient id="linearGradient3377">
-      <stop id="stop3379" offset="0" style="stop-color:#ffaa00;stop-opacity:1;"/>
-      <stop id="stop3381" offset="1" style="stop-color:#faff2b;stop-opacity:1;"/>
+    <linearGradient
+       xlink:href="#linearGradient3377-2"
+       id="linearGradient3383-6"
+       x1="901.1875"
+       y1="1190.875"
+       x2="1267.9062"
+       y2="1190.875"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       xlink:href="#linearGradient6349"
+       id="radialGradient6355"
+       cx="1103.6399"
+       cy="1424.4465"
+       fx="1103.6399"
+       fy="1424.4465"
+       r="194.40614"
+       gradientTransform="matrix(1.4307499,-1.3605156e-7,1.202713e-8,0.1264801,-475.3928,1244.2826)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       xlink:href="#linearGradient3377"
+       id="linearGradient3383"
+       x1="901.1875"
+       y1="1190.875"
+       x2="1267.9062"
+       y2="1190.875"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3377">
+      <stop
+         style="stop-color:#ffaa00;stop-opacity:1;"
+         offset="0"
+         id="stop3379" />
+      <stop
+         style="stop-color:#faff2b;stop-opacity:1;"
+         offset="1"
+         id="stop3381" />
     </linearGradient>
-    <linearGradient id="linearGradient6349" inkscape:collect="always">
-      <stop id="stop6351" offset="0" style="stop-color:#000000;stop-opacity:1;"/>
-      <stop id="stop6353" offset="1" style="stop-color:#000000;stop-opacity:0;"/>
+    <linearGradient
+       id="linearGradient6349">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop6351" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop6353" />
     </linearGradient>
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient3377" id="linearGradient3025" gradientUnits="userSpaceOnUse" x1="901.1875" y1="1190.875" x2="1267.9062" y2="1190.875"/>
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient3377-2" id="linearGradient3027" gradientUnits="userSpaceOnUse" x1="901.1875" y1="1190.875" x2="1267.9062" y2="1190.875"/>
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient3377-28" id="linearGradient3029" gradientUnits="userSpaceOnUse" x1="901.1875" y1="1190.875" x2="1267.9062" y2="1190.875"/>
-    <linearGradient gradientTransform="translate(-0.017371,-2.4277202)" inkscape:collect="always" xlink:href="#linearGradient3767" id="linearGradient3773" x1="22.116516" y1="55.717518" x2="17.328547" y2="21.31134" gradientUnits="userSpaceOnUse"/>
-    <linearGradient inkscape:collect="always" id="linearGradient3767">
-      <stop style="stop-color:#3465a4;stop-opacity:1" offset="0" id="stop3769"/>
-      <stop style="stop-color:#729fcf;stop-opacity:1" offset="1" id="stop3771"/>
+    <linearGradient
+       y2="1190.875"
+       x2="1267.9062"
+       y1="1190.875"
+       x1="901.1875"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3025"
+       xlink:href="#linearGradient3377" />
+    <linearGradient
+       y2="1190.875"
+       x2="1267.9062"
+       y1="1190.875"
+       x1="901.1875"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3027"
+       xlink:href="#linearGradient3377-2" />
+    <linearGradient
+       y2="1190.875"
+       x2="1267.9062"
+       y1="1190.875"
+       x1="901.1875"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3029"
+       xlink:href="#linearGradient3377-28" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="21.31134"
+       x2="17.328547"
+       y1="55.717518"
+       x1="22.116516"
+       id="linearGradient3773"
+       xlink:href="#linearGradient3767"
+       gradientTransform="translate(-0.017371,-2.4277202)" />
+    <linearGradient
+       id="linearGradient3767">
+      <stop
+         id="stop3769"
+         offset="0"
+         style="stop-color:#3465a4;stop-opacity:1" />
+      <stop
+         id="stop3771"
+         offset="1"
+         style="stop-color:#729fcf;stop-opacity:1" />
     </linearGradient>
-    <linearGradient gradientTransform="translate(-0.017371,-2.4277202)" inkscape:collect="always" xlink:href="#linearGradient3777" id="linearGradient3783" x1="53.896763" y1="51.179787" x2="47.502235" y2="21.83742" gradientUnits="userSpaceOnUse"/>
-    <linearGradient inkscape:collect="always" id="linearGradient3777">
-      <stop style="stop-color:#204a87;stop-opacity:1" offset="0" id="stop3779"/>
-      <stop style="stop-color:#3465a4;stop-opacity:1" offset="1" id="stop3781"/>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="21.83742"
+       x2="47.502235"
+       y1="51.179787"
+       x1="53.896763"
+       id="linearGradient3783"
+       xlink:href="#linearGradient3777"
+       gradientTransform="translate(-0.017371,-2.4277202)" />
+    <linearGradient
+       id="linearGradient3777">
+      <stop
+         id="stop3779"
+         offset="0"
+         style="stop-color:#204a87;stop-opacity:1" />
+      <stop
+         id="stop3781"
+         offset="1"
+         style="stop-color:#3465a4;stop-opacity:1" />
     </linearGradient>
-    <radialGradient inkscape:collect="always" xlink:href="#linearGradient3794" id="radialGradient3800" cx="1" cy="45" fx="1" fy="45" r="41" gradientTransform="matrix(0.93348213,-2.2905276e-8,0,0.28687573,0.06651751,32.090592)" gradientUnits="userSpaceOnUse"/>
-    <linearGradient inkscape:collect="always" id="linearGradient3794">
-      <stop style="stop-color:#000000;stop-opacity:1;" offset="0" id="stop3796"/>
-      <stop style="stop-color:#000000;stop-opacity:0;" offset="1" id="stop3798"/>
+    <radialGradient
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.93348213,-2.2905276e-8,0,0.28687573,0.06651751,32.090592)"
+       r="41"
+       fy="45"
+       fx="1"
+       cy="45"
+       cx="1"
+       id="radialGradient3800"
+       xlink:href="#linearGradient3794" />
+    <linearGradient
+       id="linearGradient3794">
+      <stop
+         id="stop3796"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         id="stop3798"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
     </linearGradient>
-    <radialGradient r="41" fy="45" fx="1" cy="45" cx="1" gradientTransform="matrix(0.93348213,-2.2905276e-8,0,0.28687573,0.06651751,32.090592)" gradientUnits="userSpaceOnUse" id="radialGradient3071" xlink:href="#linearGradient3794" inkscape:collect="always"/>
+    <radialGradient
+       xlink:href="#linearGradient3794"
+       id="radialGradient3071"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.93348213,-2.2905276e-8,0,0.28687573,0.06651751,32.090592)"
+       cx="1"
+       cy="45"
+       fx="1"
+       fy="45"
+       r="41" />
   </defs>
-  <sodipodi:namedview id="base" pagecolor="#ffffff" bordercolor="#666666" borderopacity="1.0" inkscape:pageopacity="0.0" inkscape:pageshadow="2" inkscape:zoom="3.8588775" inkscape:cx="-4.4982631" inkscape:cy="24.985792" inkscape:current-layer="g3973" showgrid="true" inkscape:document-units="px" inkscape:grid-bbox="true" inkscape:window-width="1600" inkscape:window-height="873" inkscape:window-x="0" inkscape:window-y="27" inkscape:window-maximized="1" inkscape:snap-bbox="true" inkscape:snap-nodes="true">
-    <inkscape:grid type="xygrid" id="grid3088" empspacing="2" visible="true" enabled="true" snapvisiblegridlinesonly="true"/>
-  </sodipodi:namedview>
-  <metadata id="metadata2985">
+  <metadata
+     id="metadata2985">
     <rdf:RDF>
-      <cc:Work rdf:about="">
+      <cc:Work
+         rdf:about="">
         <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-        <dc:title/>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
         <dc:creator>
           <cc:Agent>
             <dc:title>[triplus]</dc:title>
@@ -89,25 +252,79 @@
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <g id="layer1" inkscape:label="Layer 1" inkscape:groupmode="layer">
-    <path sodipodi:type="arc" style="fill:url(#radialGradient3071);fill-opacity:1;stroke:none" id="path3024" sodipodi:cx="1" sodipodi:cy="45" sodipodi:rx="41" sodipodi:ry="13" d="m 42,45 a 41,13 0 1 1 -82,0 41,13 0 1 1 82,0 z" transform="matrix(0.73170732,0,0,0.80769231,31.250922,16.726126)"/>
-    <path style="fill:#729fcf;stroke:#0b1521;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1" d="m 2.982629,14.57228 34,6 23.999999,-8 -29.999999,-4 z" id="path2993" inkscape:connector-curvature="0" sodipodi:nodetypes="ccccc"/>
-    <path style="fill:url(#linearGradient3783);fill-opacity:1;stroke:#0b1521;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1" d="m 60.982628,12.57228 0,36 -23.999999,10 0,-38 z" id="path2995" inkscape:connector-curvature="0"/>
-    <path inkscape:connector-curvature="0" sodipodi:nodetypes="ccccc" id="path3825-3" d="m 2.982629,14.57228 34,6 0,38 -34,-6 z" style="fill:url(#linearGradient3773);fill-opacity:1;fill-rule:evenodd;stroke:#0b1521;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
-    <path style="fill:none;stroke:#729fcf;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" d="M 4.982629,17 4.991329,50.919116 35,56.187915 34.9913,22.254301 z" id="path3765" inkscape:connector-curvature="0" sodipodi:nodetypes="ccccc"/>
-    <path style="fill:none;stroke:#3465a4;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" d="m 38.995059,22.006113 -0.01226,33.535301 20.001109,-8.300993 3.6e-4,-31.867363 z" id="path3775" inkscape:connector-curvature="0" sodipodi:nodetypes="ccccc"/>
-    <g id="g3973" transform="matrix(0.98259094,0,0,1,-534.57346,-68.336561)">
-      <g id="g3090" transform="translate(-0.50884952,-0.49999704)">
-        <path style="fill:#ffffff;stroke:#302b00;stroke-width:2.01763964;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1" d="m 580.17373,91.836561 5.08859,17.999999 -17.3012,-6 -2.03543,-3.999999 10.17717,-10 z" id="path3969" inkscape:connector-curvature="0" sodipodi:nodetypes="cccccc"/>
-        <path style="fill:#fce94f;stroke:none" d="m 559.81938,71.836555 -4.07087,4 20.35435,20.000006 c 0,-3 1.01772,-4 4.07087,-4 z" id="path3843" inkscape:connector-curvature="0" sodipodi:nodetypes="ccccc"/>
-        <path style="fill:#edd400;stroke:none" d="m 555.74851,75.836548 -4.07087,4.000013 20.35435,20 c 0,-3 1.01772,-4 4.07087,-4 z" id="path3843-7" inkscape:connector-curvature="0" sodipodi:nodetypes="ccccc"/>
-        <path style="fill:#c4a000;stroke:none" d="m 551.67764,79.836561 -4.07087,4 20.35435,19.999999 c 0,-3 1.01772,-3.999999 4.07087,-3.999999 z" id="path3843-5" inkscape:connector-curvature="0" sodipodi:nodetypes="ccccc"/>
-        <path style="fill:none;stroke:#edd400;stroke-width:2.01763964;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" d="m 550.65993,81.636553 18.31891,18.00001" id="path3888" inkscape:connector-curvature="0" sodipodi:nodetypes="cc"/>
-        <path style="fill:none;stroke:#fce94f;stroke-width:2.01763964;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" d="M 554.73079,77.636557 573.04971,95.63656" id="path3888-5" inkscape:connector-curvature="0" sodipodi:nodetypes="cc"/>
-        <path style="fill:none;stroke:#302b00;stroke-width:2.01763964;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1" d="m 559.81938,71.836558 -4.07087,4 20.35435,20.000003 c 0,-3 1.01772,-4 4.07087,-4 z" id="path3843-5-6" inkscape:connector-curvature="0" sodipodi:nodetypes="ccccc"/>
-        <path style="fill:none;stroke:#302b00;stroke-width:2.01763964;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1" d="m 555.74851,75.836558 -4.07087,4.000003 20.35435,20 c 0,-3 1.01772,-4 4.07087,-4 z" id="path3843-5-6-2" inkscape:connector-curvature="0" sodipodi:nodetypes="ccccc"/>
-        <path style="fill:none;stroke:#302b00;stroke-width:2.01763964;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1" d="m 551.67764,79.836561 -4.07087,4 20.35435,19.999999 c 0,-3 1.01772,-3.999999 4.07087,-3.999999 z" id="path3843-5-6-9" inkscape:connector-curvature="0" sodipodi:nodetypes="ccccc"/>
-        <path style="fill:#302b00;stroke:#302b00;stroke-width:1.00881982px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1" d="m 583.22688,100.83656 c -2.03543,0 -5.66928,2.51623 -6.1063,5 l 8.14174,4 -2.03544,-8 0,0" id="path3971" inkscape:connector-curvature="0" sodipodi:nodetypes="ccccc"/>
+  <g
+     id="layer1">
+    <path
+       transform="matrix(0.73170732,0,0,0.80769231,31.250922,16.726126)"
+       d="m 42,45 a 41,13 0 1 1 -82,0 41,13 0 1 1 82,0 z"
+       id="path3024"
+       style="fill:url(#radialGradient3071);fill-opacity:1;stroke:none" />
+    <path
+       id="path2993"
+       d="m 2.982629,14.57228 34,6 23.999999,-8 -29.999999,-4 z"
+       style="fill:#729fcf;stroke:#0b1521;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1" />
+    <path
+       id="path2995"
+       d="m 60.982628,12.57228 0,36 -23.999999,10 0,-38 z"
+       style="fill:url(#linearGradient3783);fill-opacity:1;stroke:#0b1521;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1" />
+    <path
+       style="fill:url(#linearGradient3773);fill-opacity:1;fill-rule:evenodd;stroke:#0b1521;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       d="m 2.982629,14.57228 34,6 0,38 -34,-6 z"
+       id="path3825-3" />
+    <path
+       id="path3765"
+       d="M 4.982629,17 4.991329,50.919116 35,56.187915 34.9913,22.254301 z"
+       style="fill:none;stroke:#729fcf;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       id="path3775"
+       d="m 38.995059,22.006113 -0.01226,33.535301 20.001109,-8.300993 3.6e-4,-31.867363 z"
+       style="fill:none;stroke:#3465a4;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <g
+       transform="matrix(0.98259094,0,0,1,-534.57346,-68.336561)"
+       id="g3973">
+      <g
+         transform="translate(-0.50884952,-0.49999704)"
+         id="g3090">
+        <path
+           id="path3969"
+           d="m 580.17373,91.836561 5.08859,17.999999 -17.3012,-6 -2.03543,-3.999999 10.17717,-10 z"
+           style="fill:#ffffff;stroke:#302b00;stroke-width:2.01763964;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1" />
+        <path
+           id="path3843"
+           d="m 559.81938,71.836555 -4.07087,4 20.35435,20.000006 c 0,-3 1.01772,-4 4.07087,-4 z"
+           style="fill:#fce94f;stroke:none" />
+        <path
+           id="path3843-7"
+           d="m 555.74851,75.836548 -4.07087,4.000013 20.35435,20 c 0,-3 1.01772,-4 4.07087,-4 z"
+           style="fill:#edd400;stroke:none" />
+        <path
+           id="path3843-5"
+           d="m 551.67764,79.836561 -4.07087,4 20.35435,19.999999 c 0,-3 1.01772,-3.999999 4.07087,-3.999999 z"
+           style="fill:#c4a000;stroke:none" />
+        <path
+           id="path3888"
+           d="m 550.65993,81.636553 18.31891,18.00001"
+           style="fill:none;stroke:#edd400;stroke-width:2.01763964;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
+        <path
+           id="path3888-5"
+           d="M 554.73079,77.636557 573.04971,95.63656"
+           style="fill:none;stroke:#fce94f;stroke-width:2.01763964;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
+        <path
+           id="path3843-5-6"
+           d="m 559.81938,71.836558 -4.07087,4 20.35435,20.000003 c 0,-3 1.01772,-4 4.07087,-4 z"
+           style="fill:none;stroke:#302b00;stroke-width:2.01763964;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1" />
+        <path
+           id="path3843-5-6-2"
+           d="m 555.74851,75.836558 -4.07087,4.000003 20.35435,20 c 0,-3 1.01772,-4 4.07087,-4 z"
+           style="fill:none;stroke:#302b00;stroke-width:2.01763964;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1" />
+        <path
+           id="path3843-5-6-9"
+           d="m 551.67764,79.836561 -4.07087,4 20.35435,19.999999 c 0,-3 1.01772,-3.999999 4.07087,-3.999999 z"
+           style="fill:none;stroke:#302b00;stroke-width:2.01763964;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1" />
+        <path
+           id="path3971"
+           d="m 583.22688,100.83656 c -2.03543,0 -5.66928,2.51623 -6.1063,5 l 8.14174,4 -2.03544,-8 0,0"
+           style="fill:#302b00;stroke:#302b00;stroke-width:1.00881982px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1" />
       </g>
     </g>
   </g>

--- a/src/Mod/PartDesign/WizardShaft/WizardShaft.svg
+++ b/src/Mod/PartDesign/WizardShaft/WizardShaft.svg
@@ -1,6 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-
 <svg
    xmlns:dc="http://purl.org/dc/elements/1.1/"
    xmlns:cc="http://creativecommons.org/ns#"
@@ -8,548 +6,476 @@
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="64px"
-   height="64px"
-   id="svg2901"
-   sodipodi:version="0.32"
-   inkscape:version="0.48.3.1 r9886"
-   sodipodi:docname="WizardShaft_normandc_v2.svg"
-   inkscape:output_extension="org.inkscape.output.svg.inkscape"
    version="1.1"
-   inkscape:export-filename="/home/yorik/PartDesign_Groove.png"
-   inkscape:export-xdpi="90"
-   inkscape:export-ydpi="90">
+   id="svg2901"
+   height="64px"
+   width="64px">
   <defs
      id="defs2903">
     <linearGradient
        id="linearGradient3937">
       <stop
-         id="stop3939"
+         style="stop-color:#ffa300;stop-opacity:1;"
          offset="0"
-         style="stop-color:#ffa300;stop-opacity:1;" />
+         id="stop3939" />
       <stop
-         style="stop-color:#ffff00;stop-opacity:1;"
+         id="stop3941"
          offset="0.438618"
-         id="stop3941" />
+         style="stop-color:#ffff00;stop-opacity:1;" />
       <stop
-         id="stop3943"
+         style="stop-color:#7f5100;stop-opacity:1;"
          offset="1"
-         style="stop-color:#7f5100;stop-opacity:1;" />
+         id="stop3943" />
     </linearGradient>
     <linearGradient
        id="linearGradient3905">
       <stop
-         id="stop3907"
+         style="stop-color:#ffa300;stop-opacity:1;"
          offset="0"
-         style="stop-color:#ffa300;stop-opacity:1;" />
+         id="stop3907" />
       <stop
-         style="stop-color:#ffff00;stop-opacity:1;"
+         id="stop3909"
          offset="0.45770368"
-         id="stop3909" />
+         style="stop-color:#ffff00;stop-opacity:1;" />
       <stop
-         id="stop3911"
+         style="stop-color:#cc8000;stop-opacity:1;"
          offset="1"
-         style="stop-color:#cc8000;stop-opacity:1;" />
+         id="stop3911" />
     </linearGradient>
     <linearGradient
        id="linearGradient3897">
       <stop
-         style="stop-color:#ffa300;stop-opacity:1;"
-         offset="0"
-         id="stop3899" />
-      <stop
-         id="stop3901"
-         offset="0.40477183"
-         style="stop-color:#ffff00;stop-opacity:1;" />
-      <stop
-         style="stop-color:#7f5100;stop-opacity:1;"
-         offset="1"
-         id="stop3903" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3863">
-      <stop
-         id="stop3865"
+         id="stop3899"
          offset="0"
          style="stop-color:#ffa300;stop-opacity:1;" />
       <stop
          style="stop-color:#ffff00;stop-opacity:1;"
-         offset="0.53160238"
-         id="stop3867" />
+         offset="0.40477183"
+         id="stop3901" />
       <stop
-         id="stop3869"
+         id="stop3903"
          offset="1"
          style="stop-color:#7f5100;stop-opacity:1;" />
     </linearGradient>
     <linearGradient
-       id="linearGradient3830">
-      <stop
-         id="stop3832"
-         offset="0"
-         style="stop-color:#ffa300;stop-opacity:1;" />
-      <stop
-         style="stop-color:#ffff00;stop-opacity:1;"
-         offset="0.64134014"
-         id="stop3834" />
-      <stop
-         id="stop3836"
-         offset="1"
-         style="stop-color:#cc8000;stop-opacity:1;" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient4237">
-      <stop
-         id="stop4239"
-         offset="0"
-         style="stop-color:#f82b39;stop-opacity:1;" />
-      <stop
-         id="stop4241"
-         offset="1"
-         style="stop-color:#520001;stop-opacity:1;" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient4052">
-      <stop
-         style="stop-color:#0090ff;stop-opacity:1;"
-         offset="0"
-         id="stop4054" />
-      <stop
-         id="stop4060"
-         offset="0.5"
-         style="stop-color:#f0f1f1;stop-opacity:1;" />
-      <stop
-         style="stop-color:#0046ff;stop-opacity:1;"
-         offset="1"
-         id="stop4056" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient4044">
-      <stop
-         style="stop-color:#0090ff;stop-opacity:1;"
-         offset="0"
-         id="stop4046" />
-      <stop
-         style="stop-color:#061aff;stop-opacity:1;"
-         offset="1"
-         id="stop4048" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3273">
-      <stop
-         id="stop3275"
-         offset="0"
-         style="stop-color:#c8e0f9;stop-opacity:1;" />
-      <stop
-         id="stop3277"
-         offset="1"
-         style="stop-color:#f7f9fa;stop-opacity:0.09649123;" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3377">
-      <stop
-         id="stop3379"
-         offset="0"
-         style="stop-color:#c8e0f9;stop-opacity:1;" />
-      <stop
-         id="stop3381"
-         offset="1"
-         style="stop-color:#002795;stop-opacity:1;" />
-    </linearGradient>
-    <inkscape:perspective
-       sodipodi:type="inkscape:persp3d"
-       inkscape:vp_x="0 : 32 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_z="64 : 32 : 1"
-       inkscape:persp3d-origin="32 : 21.333333 : 1"
-       id="perspective2909" />
-    <inkscape:perspective
-       id="perspective3674"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4044"
-       id="linearGradient4050"
-       x1="44.858215"
-       y1="14.016123"
-       x2="33.928684"
-       y2="33.216251"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.97680237,0,0,0.96003508,1.4694319,0.12765765)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4052"
-       id="linearGradient4058"
-       x1="42.373707"
-       y1="5.7974987"
-       x2="52.323219"
-       y2="22.675821"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.97680237,0,0,0.96003508,1.4694319,0.12765765)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4052-1"
-       id="linearGradient4058-6"
-       x1="42.373707"
-       y1="5.7974987"
-       x2="52.323219"
-       y2="22.675821"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.97680237,0,0,0.96003508,1.4694319,0.12765765)" />
-    <linearGradient
-       id="linearGradient4052-1">
+       id="linearGradient3863">
       <stop
          style="stop-color:#ffa300;stop-opacity:1;"
          offset="0"
-         id="stop4054-5" />
+         id="stop3865" />
       <stop
-         id="stop4060-8"
-         offset="0.5"
-         style="stop-color:#ffff00;stop-opacity:1;" />
-      <stop
-         style="stop-color:#cc8000;stop-opacity:1;"
-         offset="1"
-         id="stop4056-4" />
-    </linearGradient>
-    <linearGradient
-       gradientTransform="translate(-30.295225,-2.9287147)"
-       y2="22.675821"
-       x2="52.323219"
-       y1="5.7974987"
-       x1="42.373707"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient4078"
-       xlink:href="#linearGradient4052-1"
-       inkscape:collect="always" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4044"
-       id="linearGradient3885"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.97680237,0,0,0.96003508,107.10579,-22.235978)"
-       x1="44.858215"
-       y1="14.016123"
-       x2="33.928684"
-       y2="33.216251" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4052-1"
-       id="linearGradient3890"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.97680237,0,0,0.96003508,107.10579,-22.235978)"
-       x1="42.373707"
-       y1="5.7974987"
-       x2="52.323219"
-       y2="22.675821" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4052"
-       id="linearGradient3893"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.97680237,0,0,0.96003508,107.10579,-22.235978)"
-       x1="42.373707"
-       y1="5.7974987"
-       x2="52.323219"
-       y2="22.675821" />
-    <linearGradient
-       id="linearGradient4052-1-0">
-      <stop
-         style="stop-color:#0090ff;stop-opacity:1;"
-         offset="0"
-         id="stop4054-5-5" />
-      <stop
-         id="stop4060-8-6"
-         offset="0.5"
-         style="stop-color:#f0f1f1;stop-opacity:1;" />
-      <stop
-         style="stop-color:#0046ff;stop-opacity:1;"
-         offset="1"
-         id="stop4056-4-6" />
-    </linearGradient>
-    <linearGradient
-       y2="22.675821"
-       x2="52.323219"
-       y1="5.7974987"
-       x1="42.373707"
-       gradientTransform="matrix(0.97680237,0,0,0.96003508,-3.3630199,-18.322982)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3912"
-       xlink:href="#linearGradient4052-1-0"
-       inkscape:collect="always" />
-    <linearGradient
-       id="linearGradient4052-1-0-0">
-      <stop
-         style="stop-color:#0090ff;stop-opacity:1;"
-         offset="0"
-         id="stop4054-5-5-9" />
-      <stop
-         id="stop4060-8-6-8"
-         offset="0.5"
-         style="stop-color:#f0f1f1;stop-opacity:1;" />
-      <stop
-         style="stop-color:#0046ff;stop-opacity:1;"
-         offset="1"
-         id="stop4056-4-6-4" />
-    </linearGradient>
-    <linearGradient
-       y2="22.675821"
-       x2="52.323219"
-       y1="5.7974987"
-       x1="42.373707"
-       gradientTransform="matrix(0.97680237,0,0,0.96003508,126.73769,-70.092683)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3985"
-       xlink:href="#linearGradient4052-1-0-0"
-       inkscape:collect="always" />
-    <linearGradient
-       id="linearGradient4044-8">
-      <stop
-         style="stop-color:#0090ff;stop-opacity:1;"
-         offset="0"
-         id="stop4046-2" />
-      <stop
-         style="stop-color:#061aff;stop-opacity:1;"
-         offset="1"
-         id="stop4048-1" />
-    </linearGradient>
-    <linearGradient
-       y2="33.216251"
-       x2="33.928684"
-       y1="14.016123"
-       x1="44.858215"
-       gradientTransform="matrix(0.97680237,0,0,0.96003508,-26.24677,-8.4607595)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient4072"
-       xlink:href="#linearGradient4044-8"
-       inkscape:collect="always" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4044-8-4"
-       id="linearGradient3885-6-5"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.97680237,0,0,0.96003508,58.307367,54.671469)"
-       x1="44.858215"
-       y1="14.016123"
-       x2="33.928684"
-       y2="33.216251" />
-    <linearGradient
-       id="linearGradient4044-8-4">
-      <stop
-         style="stop-color:#0090ff;stop-opacity:1;"
-         offset="0"
-         id="stop4046-2-0" />
-      <stop
-         style="stop-color:#061aff;stop-opacity:1;"
-         offset="1"
-         id="stop4048-1-9" />
-    </linearGradient>
-    <linearGradient
-       y2="33.216251"
-       x2="33.928684"
-       y1="14.016123"
-       x1="44.858215"
-       gradientTransform="matrix(0.97680237,0,0,0.96003508,145.41299,94.782221)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient4163"
-       xlink:href="#linearGradient4044-8-4"
-       inkscape:collect="always" />
-    <linearGradient
-       id="linearGradient4052-1-0-9">
-      <stop
-         style="stop-color:#0090ff;stop-opacity:1;"
-         offset="0"
-         id="stop4054-5-5-2" />
-      <stop
-         id="stop4060-8-6-5"
-         offset="0.5"
-         style="stop-color:#f0f1f1;stop-opacity:1;" />
-      <stop
-         style="stop-color:#0046ff;stop-opacity:1;"
-         offset="1"
-         id="stop4056-4-6-5" />
-    </linearGradient>
-    <linearGradient
-       y2="22.675821"
-       x2="52.323219"
-       y1="5.7974987"
-       x1="42.373707"
-       gradientTransform="matrix(0.97680237,0,0,0.96003508,126.73769,-70.092687)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient4217"
-       xlink:href="#linearGradient4052-1-0-9"
-       inkscape:collect="always" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4052-1-05"
-       id="linearGradient3890-3-5"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.55370638,0,0,0.55364331,78.794439,-26.179878)"
-       x1="42.373707"
-       y1="5.7974987"
-       x2="52.323219"
-       y2="22.675821" />
-    <linearGradient
-       id="linearGradient4052-1-05">
-      <stop
-         style="stop-color:#ffa300;stop-opacity:1;"
-         offset="0"
-         id="stop4054-5-1" />
-      <stop
-         id="stop4060-8-8"
-         offset="0.5"
-         style="stop-color:#ffff00;stop-opacity:1;" />
-      <stop
-         style="stop-color:#cc8000;stop-opacity:1;"
-         offset="1"
-         id="stop4056-4-1" />
-    </linearGradient>
-    <linearGradient
-       y2="86.191978"
-       x2="-58.910812"
-       y1="71.868027"
-       x1="-69.202271"
-       gradientTransform="matrix(0.55370638,0,0,0.55364331,63.781226,-9.3780722)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3055"
-       xlink:href="#linearGradient3905"
-       inkscape:collect="always" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4052-1"
-       id="linearGradient4053"
-       x1="-85.640633"
-       y1="54.604424"
-       x2="-37.632126"
-       y2="54.604424"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4052-1"
-       id="linearGradient4057"
-       gradientUnits="userSpaceOnUse"
-       x1="-85.640633"
-       y1="54.604424"
-       x2="-37.632126"
-       y2="54.604424" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4052-1"
-       id="linearGradient4064"
-       gradientUnits="userSpaceOnUse"
-       x1="-85.640633"
-       y1="54.604424"
-       x2="-37.632126"
-       y2="54.604424" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4052-1"
-       id="linearGradient4067"
-       gradientUnits="userSpaceOnUse"
-       x1="-85.640633"
-       y1="54.604424"
-       x2="-37.632126"
-       y2="54.604424" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3830"
-       id="linearGradient3828"
-       x1="48.738834"
-       y1="6.899754"
-       x2="56.940701"
-       y2="19.243893"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       y2="22.675821"
-       x2="52.323219"
-       y1="5.7974987"
-       x1="42.373707"
-       gradientTransform="matrix(0.55370638,0,0,0.55364331,63.781226,-9.3780722)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3055-3"
-       xlink:href="#linearGradient4052-1-05-5"
-       inkscape:collect="always" />
-    <linearGradient
-       id="linearGradient4052-1-05-5">
-      <stop
-         style="stop-color:#ffa300;stop-opacity:1;"
-         offset="0"
-         id="stop4054-5-1-8" />
-      <stop
-         id="stop4060-8-8-0"
-         offset="0.5"
+         id="stop3867"
+         offset="0.53160238"
          style="stop-color:#ffff00;stop-opacity:1;" />
       <stop
          style="stop-color:#7f5100;stop-opacity:1;"
          offset="1"
-         id="stop4056-4-1-1" />
+         id="stop3869" />
     </linearGradient>
+    <linearGradient
+       id="linearGradient3830">
+      <stop
+         style="stop-color:#ffa300;stop-opacity:1;"
+         offset="0"
+         id="stop3832" />
+      <stop
+         id="stop3834"
+         offset="0.64134014"
+         style="stop-color:#ffff00;stop-opacity:1;" />
+      <stop
+         style="stop-color:#cc8000;stop-opacity:1;"
+         offset="1"
+         id="stop3836" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4237">
+      <stop
+         style="stop-color:#f82b39;stop-opacity:1;"
+         offset="0"
+         id="stop4239" />
+      <stop
+         style="stop-color:#520001;stop-opacity:1;"
+         offset="1"
+         id="stop4241" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4052">
+      <stop
+         id="stop4054"
+         offset="0"
+         style="stop-color:#0090ff;stop-opacity:1;" />
+      <stop
+         style="stop-color:#f0f1f1;stop-opacity:1;"
+         offset="0.5"
+         id="stop4060" />
+      <stop
+         id="stop4056"
+         offset="1"
+         style="stop-color:#0046ff;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4044">
+      <stop
+         id="stop4046"
+         offset="0"
+         style="stop-color:#0090ff;stop-opacity:1;" />
+      <stop
+         id="stop4048"
+         offset="1"
+         style="stop-color:#061aff;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3273">
+      <stop
+         style="stop-color:#c8e0f9;stop-opacity:1;"
+         offset="0"
+         id="stop3275" />
+      <stop
+         style="stop-color:#f7f9fa;stop-opacity:0.09649123;"
+         offset="1"
+         id="stop3277" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3377">
+      <stop
+         style="stop-color:#c8e0f9;stop-opacity:1;"
+         offset="0"
+         id="stop3379" />
+      <stop
+         style="stop-color:#002795;stop-opacity:1;"
+         offset="1"
+         id="stop3381" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.97680237,0,0,0.96003508,1.4694319,0.12765765)"
+       gradientUnits="userSpaceOnUse"
+       y2="33.216251"
+       x2="33.928684"
+       y1="14.016123"
+       x1="44.858215"
+       id="linearGradient4050"
+       xlink:href="#linearGradient4044" />
+    <linearGradient
+       gradientTransform="matrix(0.97680237,0,0,0.96003508,1.4694319,0.12765765)"
+       gradientUnits="userSpaceOnUse"
+       y2="22.675821"
+       x2="52.323219"
+       y1="5.7974987"
+       x1="42.373707"
+       id="linearGradient4058"
+       xlink:href="#linearGradient4052" />
+    <linearGradient
+       gradientTransform="matrix(0.97680237,0,0,0.96003508,1.4694319,0.12765765)"
+       gradientUnits="userSpaceOnUse"
+       y2="22.675821"
+       x2="52.323219"
+       y1="5.7974987"
+       x1="42.373707"
+       id="linearGradient4058-6"
+       xlink:href="#linearGradient4052-1" />
+    <linearGradient
+       id="linearGradient4052-1">
+      <stop
+         id="stop4054-5"
+         offset="0"
+         style="stop-color:#ffa300;stop-opacity:1;" />
+      <stop
+         style="stop-color:#ffff00;stop-opacity:1;"
+         offset="0.5"
+         id="stop4060-8" />
+      <stop
+         id="stop4056-4"
+         offset="1"
+         style="stop-color:#cc8000;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient4052-1"
+       id="linearGradient4078"
+       gradientUnits="userSpaceOnUse"
+       x1="42.373707"
+       y1="5.7974987"
+       x2="52.323219"
+       y2="22.675821"
+       gradientTransform="translate(-30.295225,-2.9287147)" />
+    <linearGradient
+       y2="33.216251"
+       x2="33.928684"
+       y1="14.016123"
+       x1="44.858215"
+       gradientTransform="matrix(0.97680237,0,0,0.96003508,107.10579,-22.235978)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3885"
+       xlink:href="#linearGradient4044" />
     <linearGradient
        y2="22.675821"
        x2="52.323219"
        y1="5.7974987"
        x1="42.373707"
-       gradientTransform="matrix(-0.44761712,-0.03974624,0.03968572,-0.44819769,-44.347622,90.842439)"
+       gradientTransform="matrix(0.97680237,0,0,0.96003508,107.10579,-22.235978)"
        gradientUnits="userSpaceOnUse"
-       id="linearGradient3074"
+       id="linearGradient3890"
+       xlink:href="#linearGradient4052-1" />
+    <linearGradient
+       y2="22.675821"
+       x2="52.323219"
+       y1="5.7974987"
+       x1="42.373707"
+       gradientTransform="matrix(0.97680237,0,0,0.96003508,107.10579,-22.235978)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3893"
+       xlink:href="#linearGradient4052" />
+    <linearGradient
+       id="linearGradient4052-1-0">
+      <stop
+         id="stop4054-5-5"
+         offset="0"
+         style="stop-color:#0090ff;stop-opacity:1;" />
+      <stop
+         style="stop-color:#f0f1f1;stop-opacity:1;"
+         offset="0.5"
+         id="stop4060-8-6" />
+      <stop
+         id="stop4056-4-6"
+         offset="1"
+         style="stop-color:#0046ff;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient4052-1-0"
+       id="linearGradient3912"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.97680237,0,0,0.96003508,-3.3630199,-18.322982)"
+       x1="42.373707"
+       y1="5.7974987"
+       x2="52.323219"
+       y2="22.675821" />
+    <linearGradient
+       id="linearGradient4052-1-0-0">
+      <stop
+         id="stop4054-5-5-9"
+         offset="0"
+         style="stop-color:#0090ff;stop-opacity:1;" />
+      <stop
+         style="stop-color:#f0f1f1;stop-opacity:1;"
+         offset="0.5"
+         id="stop4060-8-6-8" />
+      <stop
+         id="stop4056-4-6-4"
+         offset="1"
+         style="stop-color:#0046ff;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient4052-1-0-0"
+       id="linearGradient3985"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.97680237,0,0,0.96003508,126.73769,-70.092683)"
+       x1="42.373707"
+       y1="5.7974987"
+       x2="52.323219"
+       y2="22.675821" />
+    <linearGradient
+       id="linearGradient4044-8">
+      <stop
+         id="stop4046-2"
+         offset="0"
+         style="stop-color:#0090ff;stop-opacity:1;" />
+      <stop
+         id="stop4048-1"
+         offset="1"
+         style="stop-color:#061aff;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient4044-8"
+       id="linearGradient4072"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.97680237,0,0,0.96003508,-26.24677,-8.4607595)"
+       x1="44.858215"
+       y1="14.016123"
+       x2="33.928684"
+       y2="33.216251" />
+    <linearGradient
+       y2="33.216251"
+       x2="33.928684"
+       y1="14.016123"
+       x1="44.858215"
+       gradientTransform="matrix(0.97680237,0,0,0.96003508,58.307367,54.671469)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3885-6-5"
+       xlink:href="#linearGradient4044-8-4" />
+    <linearGradient
+       id="linearGradient4044-8-4">
+      <stop
+         id="stop4046-2-0"
+         offset="0"
+         style="stop-color:#0090ff;stop-opacity:1;" />
+      <stop
+         id="stop4048-1-9"
+         offset="1"
+         style="stop-color:#061aff;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient4044-8-4"
+       id="linearGradient4163"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.97680237,0,0,0.96003508,145.41299,94.782221)"
+       x1="44.858215"
+       y1="14.016123"
+       x2="33.928684"
+       y2="33.216251" />
+    <linearGradient
+       id="linearGradient4052-1-0-9">
+      <stop
+         id="stop4054-5-5-2"
+         offset="0"
+         style="stop-color:#0090ff;stop-opacity:1;" />
+      <stop
+         style="stop-color:#f0f1f1;stop-opacity:1;"
+         offset="0.5"
+         id="stop4060-8-6-5" />
+      <stop
+         id="stop4056-4-6-5"
+         offset="1"
+         style="stop-color:#0046ff;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient4052-1-0-9"
+       id="linearGradient4217"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.97680237,0,0,0.96003508,126.73769,-70.092687)"
+       x1="42.373707"
+       y1="5.7974987"
+       x2="52.323219"
+       y2="22.675821" />
+    <linearGradient
+       y2="22.675821"
+       x2="52.323219"
+       y1="5.7974987"
+       x1="42.373707"
+       gradientTransform="matrix(0.55370638,0,0,0.55364331,78.794439,-26.179878)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3890-3-5"
+       xlink:href="#linearGradient4052-1-05" />
+    <linearGradient
+       id="linearGradient4052-1-05">
+      <stop
+         id="stop4054-5-1"
+         offset="0"
+         style="stop-color:#ffa300;stop-opacity:1;" />
+      <stop
+         style="stop-color:#ffff00;stop-opacity:1;"
+         offset="0.5"
+         id="stop4060-8-8" />
+      <stop
+         id="stop4056-4-1"
+         offset="1"
+         style="stop-color:#cc8000;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3905"
+       id="linearGradient3055"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.55370638,0,0,0.55364331,63.781226,-9.3780722)"
+       x1="-69.202271"
+       y1="71.868027"
+       x2="-58.910812"
+       y2="86.191978" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="54.604424"
+       x2="-37.632126"
+       y1="54.604424"
+       x1="-85.640633"
+       id="linearGradient4053"
+       xlink:href="#linearGradient4052-1" />
+    <linearGradient
+       y2="54.604424"
+       x2="-37.632126"
+       y1="54.604424"
+       x1="-85.640633"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4057"
+       xlink:href="#linearGradient4052-1" />
+    <linearGradient
+       y2="54.604424"
+       x2="-37.632126"
+       y1="54.604424"
+       x1="-85.640633"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4064"
+       xlink:href="#linearGradient4052-1" />
+    <linearGradient
+       y2="54.604424"
+       x2="-37.632126"
+       y1="54.604424"
+       x1="-85.640633"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4067"
+       xlink:href="#linearGradient4052-1" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="19.243893"
+       x2="56.940701"
+       y1="6.899754"
+       x1="48.738834"
+       id="linearGradient3828"
+       xlink:href="#linearGradient3830" />
+    <linearGradient
+       xlink:href="#linearGradient4052-1-05-5"
+       id="linearGradient3055-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.55370638,0,0,0.55364331,63.781226,-9.3780722)"
+       x1="42.373707"
+       y1="5.7974987"
+       x2="52.323219"
+       y2="22.675821" />
+    <linearGradient
+       id="linearGradient4052-1-05-5">
+      <stop
+         id="stop4054-5-1-8"
+         offset="0"
+         style="stop-color:#ffa300;stop-opacity:1;" />
+      <stop
+         style="stop-color:#ffff00;stop-opacity:1;"
+         offset="0.5"
+         id="stop4060-8-8-0" />
+      <stop
+         id="stop4056-4-1-1"
+         offset="1"
+         style="stop-color:#7f5100;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
        xlink:href="#linearGradient3863"
-       inkscape:collect="always" />
+       id="linearGradient3074"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.44761712,-0.03974624,0.03968572,-0.44819769,-44.347622,90.842439)"
+       x1="42.373707"
+       y1="5.7974987"
+       x2="52.323219"
+       y2="22.675821" />
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3897"
-       id="linearGradient3895"
-       x1="-13.054209"
-       y1="55.312195"
-       x2="-12.91594"
+       gradientUnits="userSpaceOnUse"
        y2="41.530754"
-       gradientUnits="userSpaceOnUse" />
+       x2="-12.91594"
+       y1="55.312195"
+       x1="-13.054209"
+       id="linearGradient3895"
+       xlink:href="#linearGradient3897" />
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3937"
-       id="linearGradient3935"
-       x1="17.603668"
-       y1="48.438316"
-       x2="13.874617"
+       gradientUnits="userSpaceOnUse"
        y2="43.090275"
-       gradientUnits="userSpaceOnUse" />
+       x2="13.874617"
+       y1="48.438316"
+       x1="17.603668"
+       id="linearGradient3935"
+       xlink:href="#linearGradient3937" />
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3937"
-       id="linearGradient3882"
-       x1="-13.22155"
-       y1="54.813248"
-       x2="-13.508098"
+       gradientUnits="userSpaceOnUse"
        y2="40.945572"
-       gradientUnits="userSpaceOnUse" />
+       x2="-13.508098"
+       y1="54.813248"
+       x1="-13.22155"
+       id="linearGradient3882"
+       xlink:href="#linearGradient3937" />
   </defs>
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageopacity="0.0"
-     inkscape:pageshadow="2"
-     inkscape:zoom="7.9999996"
-     inkscape:cx="21.190358"
-     inkscape:cy="23.779747"
-     inkscape:current-layer="layer1"
-     showgrid="true"
-     inkscape:document-units="px"
-     inkscape:grid-bbox="true"
-     inkscape:window-width="1863"
-     inkscape:window-height="1056"
-     inkscape:window-x="57"
-     inkscape:window-y="24"
-     inkscape:window-maximized="1"
-     inkscape:snap-global="true"
-     inkscape:snap-nodes="true"
-     inkscape:object-paths="true"
-     inkscape:object-nodes="true"
-     inkscape:snap-intersection-paths="true" />
   <metadata
      id="metadata2906">
     <rdf:RDF>
@@ -563,73 +489,42 @@
     </rdf:RDF>
   </metadata>
   <g
-     id="layer1"
-     inkscape:label="Layer 1"
-     inkscape:groupmode="layer">
+     id="layer1">
     <g
        id="g3884">
       <path
-         transform="matrix(1.0895226,-0.72891705,0.72727205,1.091987,23.576251,-35.797469)"
-         d="m -1.5700722,48.122238 a 11.543545,16.777716 0 1 1 -23.0870898,0 11.543545,16.777716 0 1 1 23.0870898,0 z"
-         sodipodi:ry="16.777716"
-         sodipodi:rx="11.543545"
-         sodipodi:cy="48.122238"
-         sodipodi:cx="-13.113617"
-         id="path3815-2-3"
          style="fill:#ffc700;fill-opacity:1;fill-rule:evenodd;stroke:#5e3800;stroke-width:1.52504533;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-         sodipodi:type="arc" />
-      <path
-         transform="matrix(1.1357751,-0.74679771,0.75814626,1.1187739,6.8790101,-26.758312)"
+         id="path3815-2-3"
          d="m -1.5700722,48.122238 a 11.543545,16.777716 0 1 1 -23.0870898,0 11.543545,16.777716 0 1 1 23.0870898,0 z"
-         sodipodi:ry="16.777716"
-         sodipodi:rx="11.543545"
-         sodipodi:cy="48.122238"
-         sodipodi:cx="-13.113617"
-         id="path3815-2-3-8"
+         transform="matrix(1.0895226,-0.72891705,0.72727205,1.091987,23.576251,-35.797469)" />
+      <path
          style="fill:#ffc700;fill-opacity:1;fill-rule:evenodd;stroke:#5e3800;stroke-width:1.47568027;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-         sodipodi:type="arc" />
+         id="path3815-2-3-8"
+         d="m -1.5700722,48.122238 a 11.543545,16.777716 0 1 1 -23.0870898,0 11.543545,16.777716 0 1 1 23.0870898,0 z"
+         transform="matrix(1.1357751,-0.74679771,0.75814626,1.1187739,6.8790101,-26.758312)" />
       <path
-         sodipodi:nodetypes="csccscc"
-         inkscape:connector-curvature="0"
-         d="m 15.748623,18.102341 c 6.326457,-3.916561 17.677642,-1.857519 25.961443,10.343973 7.531446,11.093323 6.233487,22.335097 -0.521518,27.196968 L 56.488591,44.631176 C 63.703947,39.149865 63.082169,27.921758 56.983564,18.077301 50.10104,6.9674261 38.626161,4.2123456 32.084664,7.9890807 z"
+         id="path3846-3"
          style="color:#000000;fill:url(#linearGradient3828);fill-opacity:1;fill-rule:evenodd;stroke:#5e3800;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         id="path3846-3" />
+         d="m 15.748623,18.102341 c 6.326457,-3.916561 17.677642,-1.857519 25.961443,10.343973 7.531446,11.093323 6.233487,22.335097 -0.521518,27.196968 L 56.488591,44.631176 C 63.703947,39.149865 63.082169,27.921758 56.983564,18.077301 50.10104,6.9674261 38.626161,4.2123456 32.084664,7.9890807 z" />
       <path
-         transform="matrix(0.83124933,-0.53551017,0.55487091,0.8022451,12.515187,-8.6993128)"
-         d="m -2.4280634,48.122238 a 10.685554,16.777716 0 1 1 -21.3711066,0 10.685554,16.777716 0 1 1 21.3711066,0 z"
-         sodipodi:ry="16.777716"
-         sodipodi:rx="10.685554"
-         sodipodi:cy="48.122238"
-         sodipodi:cx="-13.113617"
-         id="path3815"
          style="fill:#ffc700;fill-opacity:1;fill-rule:evenodd;stroke:#5e3800;stroke-width:2.03699708;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-         sodipodi:type="arc" />
+         id="path3815"
+         d="m -2.4280634,48.122238 a 10.685554,16.777716 0 1 1 -21.3711066,0 10.685554,16.777716 0 1 1 21.3711066,0 z"
+         transform="matrix(0.83124933,-0.53551017,0.55487091,0.8022451,12.515187,-8.6993128)" />
       <path
-         sodipodi:nodetypes="ccccc"
-         inkscape:connector-curvature="0"
-         d="M 7.0663951,31.394552 C 17.066527,24.756926 36.306108,51.374843 25.695976,59.303434 l 11.929622,-8.914602 c 11.640747,-8.776616 -7.05728,-34.21213 -18.618933,-26.91968 z"
+         id="path3846-3-3"
          style="color:#000000;fill:url(#linearGradient3055);fill-opacity:1;fill-rule:evenodd;stroke:#5e3800;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         id="path3846-3-3" />
+         d="M 7.0663951,31.394552 C 17.066527,24.756926 36.306108,51.374843 25.695976,59.303434 l 11.929622,-8.914602 c 11.640747,-8.776616 -7.05728,-34.21213 -18.618933,-26.91968 z" />
       <path
-         transform="matrix(0.83172472,-0.55518824,0.55518824,0.83172472,0.57120419,-1.9559883)"
-         d="m -2.2841215,48.122238 a 10.829495,16.777716 0 1 1 -21.6589905,0 10.829495,16.777716 0 1 1 21.6589905,0 z"
-         sodipodi:ry="16.777716"
-         sodipodi:rx="10.829495"
-         sodipodi:cy="48.122238"
-         sodipodi:cx="-13.113617"
-         id="path3815-2"
          style="fill:#ffc700;fill-opacity:1;fill-rule:evenodd;stroke:#5e3800;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-         sodipodi:type="arc" />
-      <path
-         transform="matrix(0.3792391,-0.25314756,0.25314756,0.3792391,8.8844614,24.305486)"
+         id="path3815-2"
          d="m -2.2841215,48.122238 a 10.829495,16.777716 0 1 1 -21.6589905,0 10.829495,16.777716 0 1 1 21.6589905,0 z"
-         sodipodi:ry="16.777716"
-         sodipodi:rx="10.829495"
-         sodipodi:cy="48.122238"
-         sodipodi:cx="-13.113617"
-         id="path3815-2-2"
+         transform="matrix(0.83172472,-0.55518824,0.55518824,0.83172472,0.57120419,-1.9559883)" />
+      <path
          style="fill:url(#linearGradient3882);fill-opacity:1;fill-rule:evenodd;stroke:#5e3800;stroke-width:4.38628149;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-         sodipodi:type="arc" />
+         id="path3815-2-2"
+         d="m -2.2841215,48.122238 a 10.829495,16.777716 0 1 1 -21.6589905,0 10.829495,16.777716 0 1 1 21.6589905,0 z"
+         transform="matrix(0.3792391,-0.25314756,0.25314756,0.3792391,8.8844614,24.305486)" />
     </g>
   </g>
 </svg>

--- a/src/Mod/Path/Gui/Resources/icons/PathWorkbench.svg
+++ b/src/Mod/Path/Gui/Resources/icons/PathWorkbench.svg
@@ -1,125 +1,352 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-<svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" width="64px" height="64px" id="svg2816" version="1.1" inkscape:version="0.48.5 r10040" sodipodi:docname="PathWorkbench.svg">
-  <defs id="defs2818">
-    <linearGradient id="linearGradient4031">
-      <stop id="stop4033" offset="0" style="stop-color:#d3d7cf;stop-opacity:1"/>
-      <stop id="stop4035" offset="1" style="stop-color:#888a85;stop-opacity:1"/>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   version="1.1"
+   id="svg2816"
+   height="64px"
+   width="64px">
+  <defs
+     id="defs2818">
+    <linearGradient
+       id="linearGradient4031">
+      <stop
+         style="stop-color:#d3d7cf;stop-opacity:1"
+         offset="0"
+         id="stop4033" />
+      <stop
+         style="stop-color:#888a85;stop-opacity:1"
+         offset="1"
+         id="stop4035" />
     </linearGradient>
-    <linearGradient id="linearGradient3989">
-      <stop id="stop3991" offset="0" style="stop-color:#d3d7cf;stop-opacity:1"/>
-      <stop id="stop3993" offset="1" style="stop-color:#888a85;stop-opacity:1"/>
+    <linearGradient
+       id="linearGradient3989">
+      <stop
+         style="stop-color:#d3d7cf;stop-opacity:1"
+         offset="0"
+         id="stop3991" />
+      <stop
+         style="stop-color:#888a85;stop-opacity:1"
+         offset="1"
+         id="stop3993" />
     </linearGradient>
-    <linearGradient inkscape:collect="always" id="linearGradient3945">
-      <stop style="stop-color:#8f5902;stop-opacity:1" offset="0" id="stop3947"/>
-      <stop style="stop-color:#e9b96e;stop-opacity:1" offset="1" id="stop3949"/>
+    <linearGradient
+       id="linearGradient3945">
+      <stop
+         id="stop3947"
+         offset="0"
+         style="stop-color:#8f5902;stop-opacity:1" />
+      <stop
+         id="stop3949"
+         offset="1"
+         style="stop-color:#e9b96e;stop-opacity:1" />
     </linearGradient>
-    <linearGradient inkscape:collect="always" id="linearGradient3937">
-      <stop style="stop-color:#8f5902;stop-opacity:1" offset="0" id="stop3939"/>
-      <stop style="stop-color:#e9b96e;stop-opacity:1" offset="1" id="stop3941"/>
+    <linearGradient
+       id="linearGradient3937">
+      <stop
+         id="stop3939"
+         offset="0"
+         style="stop-color:#8f5902;stop-opacity:1" />
+      <stop
+         id="stop3941"
+         offset="1"
+         style="stop-color:#e9b96e;stop-opacity:1" />
     </linearGradient>
-    <linearGradient id="linearGradient4513">
-      <stop style="stop-color:#d3d7cf;stop-opacity:1" offset="0" id="stop4515"/>
-      <stop style="stop-color:#888a85;stop-opacity:1" offset="1" id="stop4517"/>
+    <linearGradient
+       id="linearGradient4513">
+      <stop
+         id="stop4515"
+         offset="0"
+         style="stop-color:#d3d7cf;stop-opacity:1" />
+      <stop
+         id="stop4517"
+         offset="1"
+         style="stop-color:#888a85;stop-opacity:1" />
     </linearGradient>
-    <linearGradient id="linearGradient3681">
-      <stop id="stop3697" offset="0" style="stop-color:#fff110;stop-opacity:1;"/>
-      <stop style="stop-color:#cf7008;stop-opacity:1;" offset="1" id="stop3685"/>
+    <linearGradient
+       id="linearGradient3681">
+      <stop
+         style="stop-color:#fff110;stop-opacity:1;"
+         offset="0"
+         id="stop3697" />
+      <stop
+         id="stop3685"
+         offset="1"
+         style="stop-color:#cf7008;stop-opacity:1;" />
     </linearGradient>
-    <inkscape:perspective sodipodi:type="inkscape:persp3d" inkscape:vp_x="0 : 32 : 1" inkscape:vp_y="0 : 1000 : 0" inkscape:vp_z="64 : 32 : 1" inkscape:persp3d-origin="32 : 21.333333 : 1" id="perspective2824"/>
-    <inkscape:perspective id="perspective3622" inkscape:persp3d-origin="0.5 : 0.33333333 : 1" inkscape:vp_z="1 : 0.5 : 1" inkscape:vp_y="0 : 1000 : 0" inkscape:vp_x="0 : 0.5 : 1" sodipodi:type="inkscape:persp3d"/>
-    <inkscape:perspective id="perspective3622-9" inkscape:persp3d-origin="0.5 : 0.33333333 : 1" inkscape:vp_z="1 : 0.5 : 1" inkscape:vp_y="0 : 1000 : 0" inkscape:vp_x="0 : 0.5 : 1" sodipodi:type="inkscape:persp3d"/>
-    <inkscape:perspective id="perspective3653" inkscape:persp3d-origin="0.5 : 0.33333333 : 1" inkscape:vp_z="1 : 0.5 : 1" inkscape:vp_y="0 : 1000 : 0" inkscape:vp_x="0 : 0.5 : 1" sodipodi:type="inkscape:persp3d"/>
-    <inkscape:perspective id="perspective3675" inkscape:persp3d-origin="0.5 : 0.33333333 : 1" inkscape:vp_z="1 : 0.5 : 1" inkscape:vp_y="0 : 1000 : 0" inkscape:vp_x="0 : 0.5 : 1" sodipodi:type="inkscape:persp3d"/>
-    <inkscape:perspective id="perspective3697" inkscape:persp3d-origin="0.5 : 0.33333333 : 1" inkscape:vp_z="1 : 0.5 : 1" inkscape:vp_y="0 : 1000 : 0" inkscape:vp_x="0 : 0.5 : 1" sodipodi:type="inkscape:persp3d"/>
-    <inkscape:perspective id="perspective3720" inkscape:persp3d-origin="0.5 : 0.33333333 : 1" inkscape:vp_z="1 : 0.5 : 1" inkscape:vp_y="0 : 1000 : 0" inkscape:vp_x="0 : 0.5 : 1" sodipodi:type="inkscape:persp3d"/>
-    <inkscape:perspective id="perspective3742" inkscape:persp3d-origin="0.5 : 0.33333333 : 1" inkscape:vp_z="1 : 0.5 : 1" inkscape:vp_y="0 : 1000 : 0" inkscape:vp_x="0 : 0.5 : 1" sodipodi:type="inkscape:persp3d"/>
-    <inkscape:perspective id="perspective3764" inkscape:persp3d-origin="0.5 : 0.33333333 : 1" inkscape:vp_z="1 : 0.5 : 1" inkscape:vp_y="0 : 1000 : 0" inkscape:vp_x="0 : 0.5 : 1" sodipodi:type="inkscape:persp3d"/>
-    <inkscape:perspective id="perspective3785" inkscape:persp3d-origin="0.5 : 0.33333333 : 1" inkscape:vp_z="1 : 0.5 : 1" inkscape:vp_y="0 : 1000 : 0" inkscape:vp_x="0 : 0.5 : 1" sodipodi:type="inkscape:persp3d"/>
-    <inkscape:perspective id="perspective3806" inkscape:persp3d-origin="0.5 : 0.33333333 : 1" inkscape:vp_z="1 : 0.5 : 1" inkscape:vp_y="0 : 1000 : 0" inkscape:vp_x="0 : 0.5 : 1" sodipodi:type="inkscape:persp3d"/>
-    <inkscape:perspective id="perspective3806-3" inkscape:persp3d-origin="0.5 : 0.33333333 : 1" inkscape:vp_z="1 : 0.5 : 1" inkscape:vp_y="0 : 1000 : 0" inkscape:vp_x="0 : 0.5 : 1" sodipodi:type="inkscape:persp3d"/>
-    <inkscape:perspective id="perspective3835" inkscape:persp3d-origin="0.5 : 0.33333333 : 1" inkscape:vp_z="1 : 0.5 : 1" inkscape:vp_y="0 : 1000 : 0" inkscape:vp_x="0 : 0.5 : 1" sodipodi:type="inkscape:persp3d"/>
-    <inkscape:perspective id="perspective3614" inkscape:persp3d-origin="0.5 : 0.33333333 : 1" inkscape:vp_z="1 : 0.5 : 1" inkscape:vp_y="0 : 1000 : 0" inkscape:vp_x="0 : 0.5 : 1" sodipodi:type="inkscape:persp3d"/>
-    <inkscape:perspective id="perspective3614-8" inkscape:persp3d-origin="0.5 : 0.33333333 : 1" inkscape:vp_z="1 : 0.5 : 1" inkscape:vp_y="0 : 1000 : 0" inkscape:vp_x="0 : 0.5 : 1" sodipodi:type="inkscape:persp3d"/>
-    <inkscape:perspective id="perspective3643" inkscape:persp3d-origin="0.5 : 0.33333333 : 1" inkscape:vp_z="1 : 0.5 : 1" inkscape:vp_y="0 : 1000 : 0" inkscape:vp_x="0 : 0.5 : 1" sodipodi:type="inkscape:persp3d"/>
-    <inkscape:perspective id="perspective3643-3" inkscape:persp3d-origin="0.5 : 0.33333333 : 1" inkscape:vp_z="1 : 0.5 : 1" inkscape:vp_y="0 : 1000 : 0" inkscape:vp_x="0 : 0.5 : 1" sodipodi:type="inkscape:persp3d"/>
-    <inkscape:perspective id="perspective3672" inkscape:persp3d-origin="0.5 : 0.33333333 : 1" inkscape:vp_z="1 : 0.5 : 1" inkscape:vp_y="0 : 1000 : 0" inkscape:vp_x="0 : 0.5 : 1" sodipodi:type="inkscape:persp3d"/>
-    <inkscape:perspective id="perspective3672-5" inkscape:persp3d-origin="0.5 : 0.33333333 : 1" inkscape:vp_z="1 : 0.5 : 1" inkscape:vp_y="0 : 1000 : 0" inkscape:vp_x="0 : 0.5 : 1" sodipodi:type="inkscape:persp3d"/>
-    <inkscape:perspective id="perspective3701" inkscape:persp3d-origin="0.5 : 0.33333333 : 1" inkscape:vp_z="1 : 0.5 : 1" inkscape:vp_y="0 : 1000 : 0" inkscape:vp_x="0 : 0.5 : 1" sodipodi:type="inkscape:persp3d"/>
-    <inkscape:perspective id="perspective3701-8" inkscape:persp3d-origin="0.5 : 0.33333333 : 1" inkscape:vp_z="1 : 0.5 : 1" inkscape:vp_y="0 : 1000 : 0" inkscape:vp_x="0 : 0.5 : 1" sodipodi:type="inkscape:persp3d"/>
-    <inkscape:perspective id="perspective3746" inkscape:persp3d-origin="0.5 : 0.33333333 : 1" inkscape:vp_z="1 : 0.5 : 1" inkscape:vp_y="0 : 1000 : 0" inkscape:vp_x="0 : 0.5 : 1" sodipodi:type="inkscape:persp3d"/>
-    <pattern patternTransform="matrix(0.67643728,-0.81829155,2.4578314,1.8844554,-26.450606,18.294947)" id="pattern5231" xlink:href="#Strips1_1-4" inkscape:collect="always"/>
-    <inkscape:perspective id="perspective5224" inkscape:persp3d-origin="0.5 : 0.33333333 : 1" inkscape:vp_z="1 : 0.5 : 1" inkscape:vp_y="0 : 1000 : 0" inkscape:vp_x="0 : 0.5 : 1" sodipodi:type="inkscape:persp3d"/>
-    <pattern inkscape:stockid="Stripes 1:1" id="Strips1_1-4" patternTransform="matrix(0.66772843,-1.0037085,2.4261878,2.3114548,3.4760987,3.534923)" height="1" width="2" patternUnits="userSpaceOnUse" inkscape:collect="always">
-      <rect id="rect4483-4" height="2" width="1" y="-0.5" x="0" style="fill:black;stroke:none"/>
+    <pattern
+       xlink:href="#Strips1_1-4"
+       id="pattern5231"
+       patternTransform="matrix(0.67643728,-0.81829155,2.4578314,1.8844554,-26.450606,18.294947)" />
+    <pattern
+       patternUnits="userSpaceOnUse"
+       width="2"
+       height="1"
+       patternTransform="matrix(0.66772843,-1.0037085,2.4261878,2.3114548,3.4760987,3.534923)"
+       id="Strips1_1-4">
+      <rect
+         style="fill:black;stroke:none"
+         x="0"
+         y="-0.5"
+         width="1"
+         height="2"
+         id="rect4483-4" />
     </pattern>
-    <inkscape:perspective id="perspective5224-9" inkscape:persp3d-origin="0.5 : 0.33333333 : 1" inkscape:vp_z="1 : 0.5 : 1" inkscape:vp_y="0 : 1000 : 0" inkscape:vp_x="0 : 0.5 : 1" sodipodi:type="inkscape:persp3d"/>
-    <pattern patternTransform="matrix(0.66772843,-1.0037085,2.4261878,2.3114548,39.618381,8.9692804)" id="pattern5231-4" xlink:href="#Strips1_1-6" inkscape:collect="always"/>
-    <inkscape:perspective id="perspective5224-3" inkscape:persp3d-origin="0.5 : 0.33333333 : 1" inkscape:vp_z="1 : 0.5 : 1" inkscape:vp_y="0 : 1000 : 0" inkscape:vp_x="0 : 0.5 : 1" sodipodi:type="inkscape:persp3d"/>
-    <pattern inkscape:stockid="Stripes 1:1" id="Strips1_1-6" patternTransform="matrix(0.66772843,-1.0037085,2.4261878,2.3114548,3.4760987,3.534923)" height="1" width="2" patternUnits="userSpaceOnUse" inkscape:collect="always">
-      <rect id="rect4483-0" height="2" width="1" y="-0.5" x="0" style="fill:black;stroke:none"/>
+    <pattern
+       xlink:href="#Strips1_1-6"
+       id="pattern5231-4"
+       patternTransform="matrix(0.66772843,-1.0037085,2.4261878,2.3114548,39.618381,8.9692804)" />
+    <pattern
+       patternUnits="userSpaceOnUse"
+       width="2"
+       height="1"
+       patternTransform="matrix(0.66772843,-1.0037085,2.4261878,2.3114548,3.4760987,3.534923)"
+       id="Strips1_1-6">
+      <rect
+         style="fill:black;stroke:none"
+         x="0"
+         y="-0.5"
+         width="1"
+         height="2"
+         id="rect4483-0" />
     </pattern>
-    <pattern patternTransform="matrix(0.66513382,-1.0631299,2.4167603,2.4482973,-49.762569,2.9546807)" id="pattern5296" xlink:href="#pattern5231-3" inkscape:collect="always"/>
-    <inkscape:perspective id="perspective5288" inkscape:persp3d-origin="0.5 : 0.33333333 : 1" inkscape:vp_z="1 : 0.5 : 1" inkscape:vp_y="0 : 1000 : 0" inkscape:vp_x="0 : 0.5 : 1" sodipodi:type="inkscape:persp3d"/>
-    <pattern patternTransform="matrix(0.66772843,-1.0037085,2.4261878,2.3114548,-26.336284,10.887197)" id="pattern5231-3" xlink:href="#Strips1_1-4-3" inkscape:collect="always"/>
-    <pattern inkscape:stockid="Stripes 1:1" id="Strips1_1-4-3" patternTransform="matrix(0.66772843,-1.0037085,2.4261878,2.3114548,3.4760987,3.534923)" height="1" width="2" patternUnits="userSpaceOnUse" inkscape:collect="always">
-      <rect id="rect4483-4-6" height="2" width="1" y="-0.5" x="0" style="fill:black;stroke:none"/>
+    <pattern
+       xlink:href="#pattern5231-3"
+       id="pattern5296"
+       patternTransform="matrix(0.66513382,-1.0631299,2.4167603,2.4482973,-49.762569,2.9546807)" />
+    <pattern
+       xlink:href="#Strips1_1-4-3"
+       id="pattern5231-3"
+       patternTransform="matrix(0.66772843,-1.0037085,2.4261878,2.3114548,-26.336284,10.887197)" />
+    <pattern
+       patternUnits="userSpaceOnUse"
+       width="2"
+       height="1"
+       patternTransform="matrix(0.66772843,-1.0037085,2.4261878,2.3114548,3.4760987,3.534923)"
+       id="Strips1_1-4-3">
+      <rect
+         style="fill:black;stroke:none"
+         x="0"
+         y="-0.5"
+         width="1"
+         height="2"
+         id="rect4483-4-6" />
     </pattern>
-    <pattern patternTransform="matrix(0.42844886,-0.62155849,1.5567667,1.431396,27.948414,13.306456)" id="pattern5330" xlink:href="#Strips1_1-9" inkscape:collect="always"/>
-    <inkscape:perspective id="perspective5323" inkscape:persp3d-origin="0.5 : 0.33333333 : 1" inkscape:vp_z="1 : 0.5 : 1" inkscape:vp_y="0 : 1000 : 0" inkscape:vp_x="0 : 0.5 : 1" sodipodi:type="inkscape:persp3d"/>
-    <pattern inkscape:stockid="Stripes 1:1" id="Strips1_1-9" patternTransform="matrix(0.66772843,-1.0037085,2.4261878,2.3114548,3.4760987,3.534923)" height="1" width="2" patternUnits="userSpaceOnUse" inkscape:collect="always">
-      <rect id="rect4483-3" height="2" width="1" y="-0.5" x="0" style="fill:black;stroke:none"/>
+    <pattern
+       xlink:href="#Strips1_1-9"
+       id="pattern5330"
+       patternTransform="matrix(0.42844886,-0.62155849,1.5567667,1.431396,27.948414,13.306456)" />
+    <pattern
+       patternUnits="userSpaceOnUse"
+       width="2"
+       height="1"
+       patternTransform="matrix(0.66772843,-1.0037085,2.4261878,2.3114548,3.4760987,3.534923)"
+       id="Strips1_1-9">
+      <rect
+         style="fill:black;stroke:none"
+         x="0"
+         y="-0.5"
+         width="1"
+         height="2"
+         id="rect4483-3" />
     </pattern>
-    <inkscape:perspective id="perspective5361" inkscape:persp3d-origin="0.5 : 0.33333333 : 1" inkscape:vp_z="1 : 0.5 : 1" inkscape:vp_y="0 : 1000 : 0" inkscape:vp_x="0 : 0.5 : 1" sodipodi:type="inkscape:persp3d"/>
-    <inkscape:perspective id="perspective5383" inkscape:persp3d-origin="0.5 : 0.33333333 : 1" inkscape:vp_z="1 : 0.5 : 1" inkscape:vp_y="0 : 1000 : 0" inkscape:vp_x="0 : 0.5 : 1" sodipodi:type="inkscape:persp3d"/>
-    <inkscape:perspective id="perspective5411" inkscape:persp3d-origin="0.5 : 0.33333333 : 1" inkscape:vp_z="1 : 0.5 : 1" inkscape:vp_y="0 : 1000 : 0" inkscape:vp_x="0 : 0.5 : 1" sodipodi:type="inkscape:persp3d"/>
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient3681" id="linearGradient3687" x1="37.89756" y1="41.087898" x2="4.0605712" y2="40.168594" gradientUnits="userSpaceOnUse" gradientTransform="translate(127.27273,-51.272729)"/>
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient3681" id="linearGradient3695" x1="37.894287" y1="40.484772" x2="59.811455" y2="43.558987" gradientUnits="userSpaceOnUse" gradientTransform="translate(127.27273,-51.272729)"/>
-    <linearGradient id="linearGradient3681-3">
-      <stop id="stop3697-3" offset="0" style="stop-color:#fff110;stop-opacity:1;"/>
-      <stop style="stop-color:#cf7008;stop-opacity:1;" offset="1" id="stop3685-4"/>
+    <linearGradient
+       gradientTransform="translate(127.27273,-51.272729)"
+       gradientUnits="userSpaceOnUse"
+       y2="40.168594"
+       x2="4.0605712"
+       y1="41.087898"
+       x1="37.89756"
+       id="linearGradient3687"
+       xlink:href="#linearGradient3681" />
+    <linearGradient
+       gradientTransform="translate(127.27273,-51.272729)"
+       gradientUnits="userSpaceOnUse"
+       y2="43.558987"
+       x2="59.811455"
+       y1="40.484772"
+       x1="37.894287"
+       id="linearGradient3695"
+       xlink:href="#linearGradient3681" />
+    <linearGradient
+       id="linearGradient3681-3">
+      <stop
+         style="stop-color:#fff110;stop-opacity:1;"
+         offset="0"
+         id="stop3697-3" />
+      <stop
+         id="stop3685-4"
+         offset="1"
+         style="stop-color:#cf7008;stop-opacity:1;" />
     </linearGradient>
-    <linearGradient y2="43.558987" x2="59.811455" y1="40.484772" x1="37.894287" gradientTransform="translate(-37.00068,-20.487365)" gradientUnits="userSpaceOnUse" id="linearGradient3608" xlink:href="#linearGradient3681-3" inkscape:collect="always"/>
-    <linearGradient id="linearGradient4513-2">
-      <stop style="stop-color:#ffffff;stop-opacity:1;" offset="0" id="stop4515-2"/>
-      <stop style="stop-color:#999999;stop-opacity:1;" offset="1" id="stop4517-4"/>
+    <linearGradient
+       xlink:href="#linearGradient3681-3"
+       id="linearGradient3608"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-37.00068,-20.487365)"
+       x1="37.894287"
+       y1="40.484772"
+       x2="59.811455"
+       y2="43.558987" />
+    <linearGradient
+       id="linearGradient4513-2">
+      <stop
+         id="stop4515-2"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="stop4517-4"
+         offset="1"
+         style="stop-color:#999999;stop-opacity:1;" />
     </linearGradient>
-    <radialGradient r="23.634638" fy="7.9319997" fx="32.151962" cy="7.9319997" cx="32.151962" gradientTransform="matrix(1,0,0,1.1841158,-8.5173246,-3.4097568)" gradientUnits="userSpaceOnUse" id="radialGradient4538" xlink:href="#linearGradient4513-2" inkscape:collect="always"/>
-    <linearGradient id="linearGradient4513-1">
-      <stop style="stop-color:#ffffff;stop-opacity:1;" offset="0" id="stop4515-8"/>
-      <stop style="stop-color:#999999;stop-opacity:1;" offset="1" id="stop4517-6"/>
+    <radialGradient
+       xlink:href="#linearGradient4513-2"
+       id="radialGradient4538"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,1.1841158,-8.5173246,-3.4097568)"
+       cx="32.151962"
+       cy="7.9319997"
+       fx="32.151962"
+       fy="7.9319997"
+       r="23.634638" />
+    <linearGradient
+       id="linearGradient4513-1">
+      <stop
+         id="stop4515-8"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="stop4517-6"
+         offset="1"
+         style="stop-color:#999999;stop-opacity:1;" />
     </linearGradient>
-    <radialGradient r="23.634638" fy="7.9319997" fx="32.151962" cy="7.9319997" cx="32.151962" gradientTransform="matrix(1,0,0,1.1841158,-8.5173246,-3.4097568)" gradientUnits="userSpaceOnUse" id="radialGradient4538-6" xlink:href="#linearGradient4513-1" inkscape:collect="always"/>
-    <radialGradient inkscape:collect="always" xlink:href="#linearGradient4513-6" id="radialGradient4521-5" cx="32.151962" cy="7.9319997" fx="32.151962" fy="7.9319997" r="23.634638" gradientTransform="matrix(1.0155652,0,0,1.1851825,-0.65241357,-1.4008677)" gradientUnits="userSpaceOnUse"/>
-    <linearGradient id="linearGradient4513-6">
-      <stop style="stop-color:#ffffff;stop-opacity:1;" offset="0" id="stop4515-29"/>
-      <stop style="stop-color:#999999;stop-opacity:1;" offset="1" id="stop4517-1"/>
+    <radialGradient
+       xlink:href="#linearGradient4513-1"
+       id="radialGradient4538-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,1.1841158,-8.5173246,-3.4097568)"
+       cx="32.151962"
+       cy="7.9319997"
+       fx="32.151962"
+       fy="7.9319997"
+       r="23.634638" />
+    <radialGradient
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0155652,0,0,1.1851825,-0.65241357,-1.4008677)"
+       r="23.634638"
+       fy="7.9319997"
+       fx="32.151962"
+       cy="7.9319997"
+       cx="32.151962"
+       id="radialGradient4521-5"
+       xlink:href="#linearGradient4513-6" />
+    <linearGradient
+       id="linearGradient4513-6">
+      <stop
+         id="stop4515-29"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="stop4517-1"
+         offset="1"
+         style="stop-color:#999999;stop-opacity:1;" />
     </linearGradient>
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient4513" id="linearGradient3935" x1="32" y1="5" x2="33" y2="11" gradientUnits="userSpaceOnUse"/>
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient3937" id="linearGradient3943" x1="14" y1="59" x2="11" y2="49" gradientUnits="userSpaceOnUse"/>
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient3945" id="linearGradient3951" x1="54" y1="59" x2="51" y2="49" gradientUnits="userSpaceOnUse"/>
-    <radialGradient inkscape:collect="always" xlink:href="#linearGradient4513-2-0" id="radialGradient4521-0-7" cx="32.151962" cy="17.949734" fx="32.151962" fy="17.949734" r="23.634638" gradientTransform="matrix(0.67911969,0,0,1.122061,10.189733,-0.72498825)" gradientUnits="userSpaceOnUse"/>
-    <linearGradient id="linearGradient4513-2-0">
-      <stop style="stop-color:#ffffff;stop-opacity:1;" offset="0" id="stop4515-2-9"/>
-      <stop style="stop-color:#999999;stop-opacity:1;" offset="1" id="stop4517-4-3"/>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="11"
+       x2="33"
+       y1="5"
+       x1="32"
+       id="linearGradient3935"
+       xlink:href="#linearGradient4513" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="49"
+       x2="11"
+       y1="59"
+       x1="14"
+       id="linearGradient3943"
+       xlink:href="#linearGradient3937" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="49"
+       x2="51"
+       y1="59"
+       x1="54"
+       id="linearGradient3951"
+       xlink:href="#linearGradient3945" />
+    <radialGradient
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.67911969,0,0,1.122061,10.189733,-0.72498825)"
+       r="23.634638"
+       fy="17.949734"
+       fx="32.151962"
+       cy="17.949734"
+       cx="32.151962"
+       id="radialGradient4521-0-7"
+       xlink:href="#linearGradient4513-2-0" />
+    <linearGradient
+       id="linearGradient4513-2-0">
+      <stop
+         id="stop4515-2-9"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="stop4517-4-3"
+         offset="1"
+         style="stop-color:#999999;stop-opacity:1;" />
     </linearGradient>
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient3989" id="linearGradient3987" x1="31" y1="15" x2="33" y2="23" gradientUnits="userSpaceOnUse"/>
-    <radialGradient inkscape:collect="always" xlink:href="#linearGradient4513-1-6" id="radialGradient4521-4-0" cx="32.151962" cy="35.869175" fx="32.151962" fy="35.869175" r="23.634638" gradientTransform="matrix(0.39497909,0,0,1.1841158,19.452609,-1.4604067)" gradientUnits="userSpaceOnUse"/>
-    <linearGradient id="linearGradient4513-1-6">
-      <stop style="stop-color:#ffffff;stop-opacity:1;" offset="0" id="stop4515-8-2"/>
-      <stop style="stop-color:#999999;stop-opacity:1;" offset="1" id="stop4517-6-6"/>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="23"
+       x2="33"
+       y1="15"
+       x1="31"
+       id="linearGradient3987"
+       xlink:href="#linearGradient3989" />
+    <radialGradient
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.39497909,0,0,1.1841158,19.452609,-1.4604067)"
+       r="23.634638"
+       fy="35.869175"
+       fx="32.151962"
+       cy="35.869175"
+       cx="32.151962"
+       id="radialGradient4521-4-0"
+       xlink:href="#linearGradient4513-1-6" />
+    <linearGradient
+       id="linearGradient4513-1-6">
+      <stop
+         id="stop4515-8-2"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="stop4517-6-6"
+         offset="1"
+         style="stop-color:#999999;stop-opacity:1;" />
     </linearGradient>
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient4031" id="linearGradient4029" x1="27.909092" y1="27.90909" x2="36" y2="54.227272" gradientUnits="userSpaceOnUse"/>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="54.227272"
+       x2="36"
+       y1="27.90909"
+       x1="27.909092"
+       id="linearGradient4029"
+       xlink:href="#linearGradient4031" />
   </defs>
-  <sodipodi:namedview id="base" pagecolor="#ffffff" bordercolor="#666666" borderopacity="1.0" inkscape:pageopacity="0.0" inkscape:pageshadow="2" inkscape:zoom="11" inkscape:cx="16.312829" inkscape:cy="25.733609" inkscape:current-layer="layer1" showgrid="true" inkscape:document-units="px" inkscape:grid-bbox="true" inkscape:snap-bbox="false" inkscape:bbox-paths="false" inkscape:bbox-nodes="false" inkscape:snap-bbox-edge-midpoints="false" inkscape:snap-bbox-midpoints="false" inkscape:object-paths="false" inkscape:object-nodes="false" inkscape:window-width="1920" inkscape:window-height="1057" inkscape:window-x="1912" inkscape:window-y="-8" inkscape:window-maximized="1" inkscape:snap-global="true">
-    <inkscape:grid type="xygrid" id="grid3052" empspacing="2" visible="true" enabled="true" snapvisiblegridlinesonly="true"/>
-  </sodipodi:namedview>
-  <metadata id="metadata2821">
+  <metadata
+     id="metadata2821">
     <rdf:RDF>
-      <cc:Work rdf:about="">
+      <cc:Work
+         rdf:about="">
         <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-        <dc:title/>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
         <dc:title>PathWorkbench</dc:title>
         <dc:date>2016-02-26</dc:date>
         <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
@@ -143,19 +370,66 @@
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <g id="layer1" inkscape:label="Layer 1" inkscape:groupmode="layer">
-    <path style="color:#000000;fill:url(#linearGradient3951);fill-opacity:1;fill-rule:nonzero;stroke:#271903;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" d="m 61,47 0,14 -29,0 13,-8 c 0,0 0.05185,-3.282514 0,-6 z" id="rect4590-5" inkscape:connector-curvature="0" sodipodi:nodetypes="cccccc"/>
-    <path style="color:#000000;fill:url(#linearGradient3943);fill-opacity:1;fill-rule:nonzero;stroke:#271903;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" d="m 3,47 0,14 29,0 -13,-8 c 0,0 -0.05185,-3.282514 0,-6 z" id="rect4590" inkscape:connector-curvature="0" sodipodi:nodetypes="cccccc"/>
-    <rect style="color:#000000;fill:url(#linearGradient3987);fill-opacity:1;fill-rule:nonzero;stroke:#2e3436;stroke-width:1.99999975999999990;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" id="rect4411" width="29.999998" height="12.427311" x="17" y="12.572689"/>
-    <rect style="color:#000000;fill:url(#linearGradient3935);fill-opacity:1;fill-rule:nonzero;stroke:#2e3436;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" id="rect3591" width="46" height="10" x="9" y="3"/>
-    <path inkscape:connector-curvature="0" style="color:#000000;fill:none;stroke:#e9b96e;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:11.60000038;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" d="m 5,49 0,10 20,0 -8,-5 0,-5 z" id="rect4590-6" sodipodi:nodetypes="cccccc"/>
-    <path inkscape:connector-curvature="0" style="color:#000000;fill:none;stroke:#e9b96e;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:11.60000038;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" d="m 59,49 0,10 -20,0 8,-5 0,-5 z" id="rect4590-6-7" sodipodi:nodetypes="cccccc"/>
-    <rect style="color:#000000;fill:none;stroke:#d3d7cf;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" id="rect3591-2" width="42" height="6" x="11" y="5"/>
-    <rect style="color:#000000;fill:none;stroke:#d3d7cf;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" id="rect4411-6" width="26" height="8" x="19" y="15"/>
-    <g id="g3859">
-      <path sodipodi:nodetypes="cccccccccccccccc" inkscape:connector-curvature="0" id="rect4417" d="m 32,25 -9,4 0,8 18,-8 0,-4 z m 9,6 -18,8 0,9 18,-7 z m 0,12 -18,7 9,6 9,-6 z" style="color:#000000;fill:url(#linearGradient4029);fill-opacity:1;fill-rule:nonzero;stroke:#2e3436;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
-      <path sodipodi:nodetypes="cccccccccccccccc" inkscape:connector-curvature="0" id="rect4417-1" d="M 32.369624,26.992756 25.011364,30.170455 25,34 39,28 39,27 z M 38.967859,34.128565 25.064282,40.321412 25,45 38.935718,39.578542 z M 38.981168,45.978888 27.318182,50.5 l 4.762171,3.178588 6.903577,-4.674966 z" style="color:#000000;fill:none;stroke:#d3d7cf;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"/>
-      <path sodipodi:nodetypes="cccc" inkscape:connector-curvature="0" id="path3085" d="m 23,27 0,-2 8,0 z" style="fill:#d3d7cf;stroke:#2e3436;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1"/>
+  <g
+     id="layer1">
+    <path
+       id="rect4590-5"
+       d="m 61,47 0,14 -29,0 13,-8 c 0,0 0.05185,-3.282514 0,-6 z"
+       style="color:#000000;fill:url(#linearGradient3951);fill-opacity:1;fill-rule:nonzero;stroke:#271903;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    <path
+       id="rect4590"
+       d="m 3,47 0,14 29,0 -13,-8 c 0,0 -0.05185,-3.282514 0,-6 z"
+       style="color:#000000;fill:url(#linearGradient3943);fill-opacity:1;fill-rule:nonzero;stroke:#271903;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    <rect
+       y="12.572689"
+       x="17"
+       height="12.427311"
+       width="29.999998"
+       id="rect4411"
+       style="color:#000000;fill:url(#linearGradient3987);fill-opacity:1;fill-rule:nonzero;stroke:#2e3436;stroke-width:1.99999975999999990;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    <rect
+       y="3"
+       x="9"
+       height="10"
+       width="46"
+       id="rect3591"
+       style="color:#000000;fill:url(#linearGradient3935);fill-opacity:1;fill-rule:nonzero;stroke:#2e3436;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    <path
+       id="rect4590-6"
+       d="m 5,49 0,10 20,0 -8,-5 0,-5 z"
+       style="color:#000000;fill:none;stroke:#e9b96e;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:11.60000038;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    <path
+       id="rect4590-6-7"
+       d="m 59,49 0,10 -20,0 8,-5 0,-5 z"
+       style="color:#000000;fill:none;stroke:#e9b96e;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:11.60000038;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    <rect
+       y="5"
+       x="11"
+       height="6"
+       width="42"
+       id="rect3591-2"
+       style="color:#000000;fill:none;stroke:#d3d7cf;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    <rect
+       y="15"
+       x="19"
+       height="8"
+       width="26"
+       id="rect4411-6"
+       style="color:#000000;fill:none;stroke:#d3d7cf;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    <g
+       id="g3859">
+      <path
+         style="color:#000000;fill:url(#linearGradient4029);fill-opacity:1;fill-rule:nonzero;stroke:#2e3436;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         d="m 32,25 -9,4 0,8 18,-8 0,-4 z m 9,6 -18,8 0,9 18,-7 z m 0,12 -18,7 9,6 9,-6 z"
+         id="rect4417" />
+      <path
+         style="color:#000000;fill:none;stroke:#d3d7cf;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         d="M 32.369624,26.992756 25.011364,30.170455 25,34 39,28 39,27 z M 38.967859,34.128565 25.064282,40.321412 25,45 38.935718,39.578542 z M 38.981168,45.978888 27.318182,50.5 l 4.762171,3.178588 6.903577,-4.674966 z"
+         id="rect4417-1" />
+      <path
+         style="fill:#d3d7cf;stroke:#2e3436;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1"
+         d="m 23,27 0,-2 8,0 z"
+         id="path3085" />
     </g>
   </g>
 </svg>

--- a/src/Mod/Path/Images/Tools/drill.svg
+++ b/src/Mod/Path/Images/Tools/drill.svg
@@ -1,166 +1,114 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-
 <svg
    xmlns:dc="http://purl.org/dc/elements/1.1/"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="210mm"
-   height="297mm"
-   viewBox="0 0 210 297"
-   version="1.1"
    id="svg8"
-   inkscape:version="0.92.3 (2405546, 2018-03-11)"
-   sodipodi:docname="drill.svg">
+   version="1.1"
+   viewBox="0 0 210 297"
+   height="297mm"
+   width="210mm">
   <defs
      id="defs2">
     <marker
-       inkscape:isstock="true"
-       style="overflow:visible;"
+       orient="auto"
+       refY="0.0"
+       refX="0.0"
        id="marker8709"
-       refX="0.0"
-       refY="0.0"
-       orient="auto"
-       inkscape:stockid="Arrow1Lend">
+       style="overflow:visible;">
       <path
-         transform="scale(0.8) rotate(180) translate(12.5,0)"
-         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
-         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
-         id="path8707" />
-    </marker>
-    <marker
-       inkscape:isstock="true"
-       style="overflow:visible;"
-       id="marker8663"
-       refX="0.0"
-       refY="0.0"
-       orient="auto"
-       inkscape:stockid="Arrow1Lend">
-      <path
-         transform="scale(0.8) rotate(180) translate(12.5,0)"
-         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
-         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
-         id="path8661" />
-    </marker>
-    <marker
-       inkscape:isstock="true"
-       style="overflow:visible"
-       id="marker8617"
-       refX="0.0"
-       refY="0.0"
-       orient="auto"
-       inkscape:stockid="Arrow1Lstart">
-      <path
-         transform="scale(0.8) translate(12.5,0)"
-         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
-         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
-         id="path8615" />
-    </marker>
-    <marker
-       inkscape:isstock="true"
-       style="overflow:visible"
-       id="marker8589"
-       refX="0.0"
-       refY="0.0"
-       orient="auto"
-       inkscape:stockid="Arrow1Lstart">
-      <path
-         transform="scale(0.8) translate(12.5,0)"
-         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
-         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
-         id="path8587" />
-    </marker>
-    <marker
-       inkscape:stockid="Arrow1Lend"
-       orient="auto"
-       refY="0.0"
-       refX="0.0"
-       id="Arrow1Lend"
-       style="overflow:visible;"
-       inkscape:isstock="true"
-       inkscape:collect="always">
-      <path
-         id="path841"
+         id="path8707"
          d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
          style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
          transform="scale(0.8) rotate(180) translate(12.5,0)" />
     </marker>
     <marker
-       inkscape:stockid="Arrow1Lstart"
        orient="auto"
        refY="0.0"
        refX="0.0"
-       id="Arrow1Lstart"
-       style="overflow:visible"
-       inkscape:isstock="true"
-       inkscape:collect="always">
+       id="marker8663"
+       style="overflow:visible;">
       <path
-         id="path838"
+         id="path8661"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         transform="scale(0.8) rotate(180) translate(12.5,0)" />
+    </marker>
+    <marker
+       orient="auto"
+       refY="0.0"
+       refX="0.0"
+       id="marker8617"
+       style="overflow:visible">
+      <path
+         id="path8615"
          d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
          style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
          transform="scale(0.8) translate(12.5,0)" />
     </marker>
     <marker
-       inkscape:isstock="true"
-       style="overflow:visible"
-       id="marker8589-7"
-       refX="0"
-       refY="0"
        orient="auto"
-       inkscape:stockid="Arrow1Lstart">
+       refY="0.0"
+       refX="0.0"
+       id="marker8589"
+       style="overflow:visible">
       <path
-         inkscape:connector-curvature="0"
-         transform="matrix(0.8,0,0,0.8,10,0)"
-         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
-         d="M 0,0 5,-5 -12.5,0 5,5 Z"
-         id="path8587-0" />
+         id="path8587"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         transform="scale(0.8) translate(12.5,0)" />
     </marker>
     <marker
-       inkscape:isstock="true"
-       style="overflow:visible"
-       id="marker8663-8"
-       refX="0"
-       refY="0"
-       orient="auto"
-       inkscape:stockid="Arrow1Lend">
+       style="overflow:visible;"
+       id="Arrow1Lend"
+       refX="0.0"
+       refY="0.0"
+       orient="auto">
       <path
-         inkscape:connector-curvature="0"
-         transform="matrix(-0.8,0,0,-0.8,-10,0)"
-         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="scale(0.8) rotate(180) translate(12.5,0)"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         id="path841" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow1Lstart"
+       refX="0.0"
+       refY="0.0"
+       orient="auto">
+      <path
+         transform="scale(0.8) translate(12.5,0)"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         id="path838" />
+    </marker>
+    <marker
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker8589-7"
+       style="overflow:visible">
+      <path
+         id="path8587-0"
          d="M 0,0 5,-5 -12.5,0 5,5 Z"
-         id="path8661-1" />
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(0.8,0,0,0.8,10,0)" />
+    </marker>
+    <marker
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker8663-8"
+       style="overflow:visible">
+      <path
+         id="path8661-1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)" />
     </marker>
   </defs>
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageopacity="0.0"
-     inkscape:pageshadow="2"
-     inkscape:zoom="0.80187179"
-     inkscape:cx="372.7787"
-     inkscape:cy="569.98065"
-     inkscape:document-units="mm"
-     inkscape:current-layer="layer1"
-     showgrid="true"
-     inkscape:window-width="1468"
-     inkscape:window-height="1274"
-     inkscape:window-x="785"
-     inkscape:window-y="48"
-     inkscape:window-maximized="0">
-    <inkscape:grid
-       type="xygrid"
-       id="grid815"
-       units="mm"
-       spacingx="1"
-       spacingy="1"
-       empspacing="10" />
-  </sodipodi:namedview>
   <metadata
      id="metadata5">
     <rdf:RDF>
@@ -174,107 +122,80 @@
     </rdf:RDF>
   </metadata>
   <g
-     inkscape:label="Layer 1"
-     inkscape:groupmode="layer"
      id="layer1">
     <path
-       style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="M 60.000001,36.999999 V 257 L 80,277.00001 100,257 V 36.999999 Z"
        id="path817"
-       inkscape:connector-curvature="0" />
+       d="M 60.000001,36.999999 V 257 L 80,277.00001 100,257 V 36.999999 Z"
+       style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     <path
-       style="fill:#000000;fill-opacity:0.1372549;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="M 60.000001,77 V 256.99999 L 80,277 100,256.99999 V 77 Z"
        id="path817-8"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cccccc" />
+       d="M 60.000001,77 V 256.99999 L 80,277 100,256.99999 V 77 Z"
+       style="fill:#000000;fill-opacity:0.1372549;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     <path
-       style="fill:none;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 120,237 v 0 L 130,227 80,277.00001 30.000001,227 v 0 0"
        id="path834"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="ccccccc" />
+       d="m 120,237 v 0 L 130,227 80,277.00001 30.000001,227 v 0 0"
+       style="fill:none;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     <path
-       style="opacity:1;fill:none;fill-opacity:0.1372549;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#Arrow1Lstart);marker-end:url(#Arrow1Lend)"
-       id="path836"
-       sodipodi:type="arc"
-       sodipodi:cx="80"
-       sodipodi:cy="277"
-       sodipodi:rx="60"
-       sodipodi:ry="60"
-       sodipodi:start="3.9397872"
-       sodipodi:end="5.4952908"
        d="m 38.119956,234.03418 a 60,60 0 0 1 84.200404,0.43363"
-       sodipodi:open="true" />
+       id="path836"
+       style="opacity:1;fill:none;fill-opacity:0.1372549;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#Arrow1Lstart);marker-end:url(#Arrow1Lend)" />
     <path
-       style="fill:none;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="M 60.000001,36.999999 V 17 17"
        id="path8569"
-       inkscape:connector-curvature="0" />
+       d="M 60.000001,36.999999 V 17 17"
+       style="fill:none;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     <path
-       style="fill:none;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="M 100,36.999999 V 17"
        id="path8571"
-       inkscape:connector-curvature="0" />
+       d="M 100,36.999999 V 17"
+       style="fill:none;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     <path
-       style="fill:none;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 100,77 h 50"
        id="path8573"
-       inkscape:connector-curvature="0" />
+       d="m 100,77 h 50"
+       style="fill:none;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     <path
-       style="fill:none;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 80,277.00001 h 70"
        id="path8575"
-       inkscape:connector-curvature="0" />
+       d="m 80,277.00001 h 70"
+       style="fill:none;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     <path
-       style="fill:none;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#marker8617);marker-end:url(#marker8709)"
-       d="M 140,77 V 277.00001"
        id="path8577"
-       inkscape:connector-curvature="0" />
+       d="M 140,77 V 277.00001"
+       style="fill:none;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#marker8617);marker-end:url(#marker8709)" />
     <path
-       style="fill:none;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#marker8589)"
-       d="m 100,27 h 30"
        id="path8579"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cc" />
+       d="m 100,27 h 30"
+       style="fill:none;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#marker8589)" />
     <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:34.92499924px;line-height:1.25;font-family:'URW Bookman L';-inkscape-font-specification:'URW Bookman L, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
-       x="145.48189"
+       id="text8767"
        y="195.4776"
-       id="text8767"><tspan
-         sodipodi:role="line"
-         id="tspan8765"
-         x="145.48189"
+       x="145.48189"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:34.92499924px;line-height:1.25;font-family:'URW Bookman L';-inkscape-font-specification:'URW Bookman L, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       xml:space="preserve"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:34.92499924px;font-family:'URW Bookman L';-inkscape-font-specification:'URW Bookman L, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
          y="195.4776"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:34.92499924px;font-family:'URW Bookman L';-inkscape-font-specification:'URW Bookman L, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332">H</tspan></text>
+         x="145.48189"
+         id="tspan8765">H</tspan></text>
     <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:34.92499924px;line-height:1.25;font-family:'URW Bookman L';-inkscape-font-specification:'URW Bookman L, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
-       x="138.63107"
+       id="text8771"
        y="40.097"
-       id="text8771"><tspan
-         sodipodi:role="line"
-         id="tspan8769"
-         x="138.63107"
-         y="40.097"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:34.92499924px;font-family:'URW Bookman L';-inkscape-font-specification:'URW Bookman L, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332">D</tspan></text>
-    <text
-       xml:space="preserve"
+       x="138.63107"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:34.92499924px;line-height:1.25;font-family:'URW Bookman L';-inkscape-font-specification:'URW Bookman L, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
-       x="70.101288"
+       xml:space="preserve"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:34.92499924px;font-family:'URW Bookman L';-inkscape-font-specification:'URW Bookman L, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+         y="40.097"
+         x="138.63107"
+         id="tspan8769">D</tspan></text>
+    <text
+       id="text8785"
        y="243.59914"
-       id="text8785"><tspan
-         sodipodi:role="line"
-         id="tspan8783"
-         x="70.101288"
+       x="70.101288"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:34.92499924px;line-height:1.25;font-family:'URW Bookman L';-inkscape-font-specification:'URW Bookman L, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       xml:space="preserve"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:34.92499924px;font-family:'URW Bookman L';-inkscape-font-specification:'URW Bookman L, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
          y="243.59914"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:34.92499924px;font-family:'URW Bookman L';-inkscape-font-specification:'URW Bookman L, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332">α</tspan></text>
+         x="70.101288"
+         id="tspan8783">α</tspan></text>
     <path
-       style="fill:none;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker8663-8)"
-       d="M 30,27 H 59.999999"
        id="path8579-9"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cc" />
+       d="M 30,27 H 59.999999"
+       style="fill:none;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker8663-8)" />
   </g>
 </svg>

--- a/src/Mod/Path/Images/Tools/endmill.svg
+++ b/src/Mod/Path/Images/Tools/endmill.svg
@@ -1,404 +1,294 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-
 <svg
    xmlns:dc="http://purl.org/dc/elements/1.1/"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="210mm"
-   height="297mm"
-   viewBox="0 0 210 297.00001"
-   version="1.1"
    id="svg8"
-   inkscape:version="0.92.3 (2405546, 2018-03-11)"
-   sodipodi:docname="endmill.svg">
+   version="1.1"
+   viewBox="0 0 210 297.00001"
+   height="297mm"
+   width="210mm">
   <defs
      id="defs2">
     <marker
-       inkscape:stockid="Arrow2Lend"
-       orient="auto"
-       refY="0"
-       refX="0"
+       style="overflow:visible"
        id="marker1185"
-       style="overflow:visible"
-       inkscape:isstock="true">
+       refX="0"
+       refY="0"
+       orient="auto">
       <path
-         id="path1183"
-         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
-         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
          transform="matrix(-1.1,0,0,-1.1,-1.1,0)"
-         inkscape:connector-curvature="0" />
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path1183" />
     </marker>
     <marker
-       inkscape:stockid="Arrow2Lstart"
-       orient="auto"
-       refY="0"
-       refX="0"
+       style="overflow:visible"
        id="marker1181"
-       style="overflow:visible"
-       inkscape:isstock="true">
+       refX="0"
+       refY="0"
+       orient="auto">
       <path
-         id="path1179"
-         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
-         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
          transform="matrix(1.1,0,0,1.1,1.1,0)"
-         inkscape:connector-curvature="0" />
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path1179" />
     </marker>
     <marker
-       inkscape:stockid="Arrow2Lend"
-       orient="auto"
-       refY="0"
-       refX="0"
+       style="overflow:visible"
        id="marker1177"
-       style="overflow:visible"
-       inkscape:isstock="true">
+       refX="0"
+       refY="0"
+       orient="auto">
       <path
-         id="path1175"
-         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
-         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
          transform="matrix(-1.1,0,0,-1.1,-1.1,0)"
-         inkscape:connector-curvature="0" />
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path1175" />
     </marker>
     <marker
-       inkscape:stockid="Arrow2Lstart"
-       orient="auto"
-       refY="0"
-       refX="0"
+       style="overflow:visible"
        id="marker1173"
-       style="overflow:visible"
-       inkscape:isstock="true">
+       refX="0"
+       refY="0"
+       orient="auto">
       <path
-         id="path1171"
-         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
-         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
          transform="matrix(1.1,0,0,1.1,1.1,0)"
-         inkscape:connector-curvature="0" />
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path1171" />
     </marker>
     <marker
-       inkscape:stockid="Arrow2Lend"
-       orient="auto"
-       refY="0"
-       refX="0"
+       style="overflow:visible"
        id="Arrow2Lend"
-       style="overflow:visible"
-       inkscape:isstock="true">
+       refX="0"
+       refY="0"
+       orient="auto">
       <path
-         id="path920"
-         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
-         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
          transform="matrix(-1.1,0,0,-1.1,-1.1,0)"
-         inkscape:connector-curvature="0" />
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path920" />
     </marker>
     <marker
-       inkscape:stockid="Arrow2Lstart"
-       orient="auto"
-       refY="0"
-       refX="0"
+       style="overflow:visible"
        id="Arrow2Lstart"
-       style="overflow:visible"
-       inkscape:isstock="true">
+       refX="0"
+       refY="0"
+       orient="auto">
       <path
-         id="path917"
-         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
-         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
          transform="matrix(1.1,0,0,1.1,1.1,0)"
-         inkscape:connector-curvature="0" />
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path917" />
     </marker>
     <marker
-       inkscape:stockid="Arrow1Lstart"
-       orient="auto"
-       refY="0"
-       refX="0"
+       style="overflow:visible"
        id="Arrow1Lstart"
-       style="overflow:visible"
-       inkscape:isstock="true">
+       refX="0"
+       refY="0"
+       orient="auto">
       <path
-         id="path899"
-         d="M 0,0 5,-5 -12.5,0 5,5 Z"
-         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
          transform="matrix(0.8,0,0,0.8,10,0)"
-         inkscape:connector-curvature="0" />
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path899" />
     </marker>
     <marker
-       inkscape:stockid="Arrow2Mstart"
-       orient="auto"
-       refY="0"
-       refX="0"
+       style="overflow:visible"
        id="Arrow2Mstart"
-       style="overflow:visible"
-       inkscape:isstock="true">
+       refX="0"
+       refY="0"
+       orient="auto">
       <path
-         id="path923"
-         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
-         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
          transform="scale(0.6)"
-         inkscape:connector-curvature="0" />
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path923" />
     </marker>
     <marker
-       inkscape:stockid="Arrow1Mend"
-       orient="auto"
-       refY="0"
-       refX="0"
+       style="overflow:visible"
        id="Arrow1Mend"
-       style="overflow:visible"
-       inkscape:isstock="true">
+       refX="0"
+       refY="0"
+       orient="auto">
       <path
-         id="path908"
-         d="M 0,0 5,-5 -12.5,0 5,5 Z"
-         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
          transform="matrix(-0.4,0,0,-0.4,-4,0)"
-         inkscape:connector-curvature="0" />
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path908" />
     </marker>
     <marker
-       inkscape:stockid="Arrow2Mend"
-       orient="auto"
-       refY="0"
-       refX="0"
+       style="overflow:visible"
        id="marker7497"
-       style="overflow:visible"
-       inkscape:isstock="true">
+       refX="0"
+       refY="0"
+       orient="auto">
       <path
-         id="path7495"
+         transform="scale(-0.6)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
          style="fill:#000025;fill-opacity:1;fill-rule:evenodd;stroke:#000025;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
-         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
-         transform="scale(-0.6)"
-         inkscape:connector-curvature="0" />
+         id="path7495" />
     </marker>
     <marker
-       inkscape:stockid="Arrow1Mstart"
-       orient="auto"
-       refY="0"
-       refX="0"
+       style="overflow:visible"
        id="marker7379"
-       style="overflow:visible"
-       inkscape:isstock="true">
+       refX="0"
+       refY="0"
+       orient="auto">
       <path
-         id="path7377"
-         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         transform="matrix(0.4,0,0,0.4,4,0)"
          style="fill:#000025;fill-opacity:1;fill-rule:evenodd;stroke:#000025;stroke-width:1.00000003pt;stroke-opacity:1"
-         transform="matrix(0.4,0,0,0.4,4,0)"
-         inkscape:connector-curvature="0" />
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path7377" />
     </marker>
     <marker
-       inkscape:isstock="true"
-       style="overflow:visible"
+       orient="auto"
+       refY="0"
+       refX="0"
        id="marker5480"
-       refX="0"
-       refY="0"
-       orient="auto"
-       inkscape:stockid="Arrow2Mend">
+       style="overflow:visible">
       <path
-         transform="scale(-0.6)"
-         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
-         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
          id="path5478"
-         inkscape:connector-curvature="0" />
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="scale(-0.6)" />
     </marker>
     <marker
-       inkscape:isstock="true"
-       style="overflow:visible"
+       orient="auto"
+       refY="0"
+       refX="0"
        id="marker5470"
-       refX="0"
-       refY="0"
-       orient="auto"
-       inkscape:stockid="Arrow2Mend">
+       style="overflow:visible">
       <path
-         transform="scale(-0.6)"
-         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
-         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
          id="path5468"
-         inkscape:connector-curvature="0" />
-    </marker>
-    <marker
-       inkscape:isstock="true"
-       style="overflow:visible"
-       id="marker5220"
-       refX="0"
-       refY="0"
-       orient="auto"
-       inkscape:stockid="Arrow1Mstart">
-      <path
-         transform="matrix(0.4,0,0,0.4,4,0)"
-         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
-         d="M 0,0 5,-5 -12.5,0 5,5 Z"
-         id="path5218"
-         inkscape:connector-curvature="0" />
-    </marker>
-    <marker
-       inkscape:isstock="true"
-       style="overflow:visible"
-       id="marker5210"
-       refX="0"
-       refY="0"
-       orient="auto"
-       inkscape:stockid="Arrow1Mstart">
-      <path
-         transform="matrix(0.4,0,0,0.4,4,0)"
-         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
-         d="M 0,0 5,-5 -12.5,0 5,5 Z"
-         id="path5208"
-         inkscape:connector-curvature="0" />
-    </marker>
-    <marker
-       inkscape:isstock="true"
-       style="overflow:visible"
-       id="marker5072"
-       refX="0"
-       refY="0"
-       orient="auto"
-       inkscape:stockid="Arrow1Lend">
-      <path
-         transform="matrix(-0.8,0,0,-0.8,-10,0)"
-         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
-         d="M 0,0 5,-5 -12.5,0 5,5 Z"
-         id="path5070"
-         inkscape:connector-curvature="0" />
-    </marker>
-    <marker
-       inkscape:isstock="true"
-       style="overflow:visible"
-       id="marker5014"
-       refX="0"
-       refY="0"
-       orient="auto"
-       inkscape:stockid="Arrow1Lend">
-      <path
-         transform="matrix(-0.8,0,0,-0.8,-10,0)"
-         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
-         d="M 0,0 5,-5 -12.5,0 5,5 Z"
-         id="path5012"
-         inkscape:connector-curvature="0" />
-    </marker>
-    <marker
-       inkscape:isstock="true"
-       style="overflow:visible"
-       id="marker4968"
-       refX="0"
-       refY="0"
-       orient="auto"
-       inkscape:stockid="Arrow1Lend">
-      <path
-         transform="matrix(-0.8,0,0,-0.8,-10,0)"
-         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
-         d="M 0,0 5,-5 -12.5,0 5,5 Z"
-         id="path4966"
-         inkscape:connector-curvature="0" />
-    </marker>
-    <marker
-       inkscape:isstock="true"
-       style="overflow:visible"
-       id="marker4884"
-       refX="0"
-       refY="0"
-       orient="auto"
-       inkscape:stockid="Arrow1Lstart">
-      <path
-         transform="matrix(0.8,0,0,0.8,10,0)"
-         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
-         d="M 0,0 5,-5 -12.5,0 5,5 Z"
-         id="path4882"
-         inkscape:connector-curvature="0" />
-    </marker>
-    <marker
-       inkscape:isstock="true"
-       style="overflow:visible"
-       id="marker4856"
-       refX="0"
-       refY="0"
-       orient="auto"
-       inkscape:stockid="Arrow1Lstart">
-      <path
-         transform="matrix(0.8,0,0,0.8,10,0)"
-         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
-         d="M 0,0 5,-5 -12.5,0 5,5 Z"
-         id="path4854"
-         inkscape:connector-curvature="0" />
-    </marker>
-    <marker
-       inkscape:isstock="true"
-       style="overflow:visible"
-       id="marker4834"
-       refX="0"
-       refY="0"
-       orient="auto"
-       inkscape:stockid="Arrow1Lstart">
-      <path
-         transform="matrix(0.8,0,0,0.8,10,0)"
-         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
-         d="M 0,0 5,-5 -12.5,0 5,5 Z"
-         id="path4832"
-         inkscape:connector-curvature="0" />
-    </marker>
-    <marker
-       inkscape:isstock="true"
-       style="overflow:visible"
-       id="marker5220-5"
-       refX="0"
-       refY="0"
-       orient="auto"
-       inkscape:stockid="Arrow1Mstart">
-      <path
-         inkscape:connector-curvature="0"
-         transform="matrix(0.4,0,0,0.4,4,0)"
-         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
-         d="M 0,0 5,-5 -12.5,0 5,5 Z"
-         id="path5218-3" />
-    </marker>
-    <marker
-       inkscape:isstock="true"
-       style="overflow:visible"
-       id="marker5480-5"
-       refX="0"
-       refY="0"
-       orient="auto"
-       inkscape:stockid="Arrow2Mend">
-      <path
-         inkscape:connector-curvature="0"
-         transform="scale(-0.6)"
-         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
          style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
-         id="path5478-7" />
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="scale(-0.6)" />
+    </marker>
+    <marker
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker5220"
+       style="overflow:visible">
+      <path
+         id="path5218"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker5210"
+       style="overflow:visible">
+      <path
+         id="path5208"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker5072"
+       style="overflow:visible">
+      <path
+         id="path5070"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)" />
+    </marker>
+    <marker
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker5014"
+       style="overflow:visible">
+      <path
+         id="path5012"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)" />
+    </marker>
+    <marker
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4968"
+       style="overflow:visible">
+      <path
+         id="path4966"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)" />
+    </marker>
+    <marker
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4884"
+       style="overflow:visible">
+      <path
+         id="path4882"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(0.8,0,0,0.8,10,0)" />
+    </marker>
+    <marker
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4856"
+       style="overflow:visible">
+      <path
+         id="path4854"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(0.8,0,0,0.8,10,0)" />
+    </marker>
+    <marker
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4834"
+       style="overflow:visible">
+      <path
+         id="path4832"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(0.8,0,0,0.8,10,0)" />
+    </marker>
+    <marker
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker5220-5"
+       style="overflow:visible">
+      <path
+         id="path5218-3"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker5480-5"
+       style="overflow:visible">
+      <path
+         id="path5478-7"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="scale(-0.6)" />
     </marker>
   </defs>
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageopacity="0.0"
-     inkscape:pageshadow="2"
-     inkscape:zoom="0.80059015"
-     inkscape:cx="153.85349"
-     inkscape:cy="584.83281"
-     inkscape:document-units="mm"
-     inkscape:current-layer="layer1"
-     showgrid="true"
-     inkscape:window-width="1776"
-     inkscape:window-height="1292"
-     inkscape:window-x="0"
-     inkscape:window-y="48"
-     inkscape:window-maximized="0"
-     fit-margin-top="1"
-     fit-margin-left="2"
-     fit-margin-right="2"
-     fit-margin-bottom="1"
-     scale-x="0.1"
-     units="mm">
-    <inkscape:grid
-       type="xygrid"
-       id="grid4518"
-       units="mm"
-       spacingx="1"
-       spacingy="1"
-       empspacing="10"
-       dotted="false"
-       originx="-16.004899"
-       originy="-74.081585" />
-  </sodipodi:namedview>
   <metadata
      id="metadata5">
     <rdf:RDF>
@@ -412,118 +302,95 @@
     </rdf:RDF>
   </metadata>
   <g
-     inkscape:label="Layer 1"
-     inkscape:groupmode="layer"
-     id="layer1"
-     transform="translate(0.19510138,82.181594)">
+     transform="translate(0.19510138,82.181594)"
+     id="layer1">
     <path
-       style="fill:none;stroke:#000000;stroke-width:3.35350633px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       d="M 49.933333,-22.442786 V 68.899983 H 13 V 147.19377 H 160.73333 V 68.899983 H 123.8 v -91.342769 z"
        id="path4520"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="ccccccccc" />
+       d="M 49.933333,-22.442786 V 68.899983 H 13 V 147.19377 H 160.73333 V 68.899983 H 123.8 v -91.342769 z"
+       style="fill:none;stroke:#000000;stroke-width:3.35350633px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     <path
-       style="fill:none;stroke:#000000;stroke-width:1.26746702;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:10.13973638, 2.53493409, 1.26746704, 2.53493409;stroke-dashoffset:0;stroke-opacity:1"
-       d="M 86.866667,-35.491751 V 160.24274"
        id="path4526"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cc" />
+       d="M 86.866667,-35.491751 V 160.24274"
+       style="fill:none;stroke:#000000;stroke-width:1.26746702;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:10.13973638, 2.53493409, 1.26746704, 2.53493409;stroke-dashoffset:0;stroke-opacity:1" />
     <path
-       style="fill:none;stroke:#000000;stroke-width:0.82385355;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="M 49.933333,-22.442786 V -61.589682"
        id="path4528"
-       inkscape:connector-curvature="0" />
+       d="M 49.933333,-22.442786 V -61.589682"
+       style="fill:none;stroke:#000000;stroke-width:0.82385355;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     <path
-       style="fill:none;stroke:#000000;stroke-width:0.82385355;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="M 123.8,-22.442786 V -61.589682"
        id="path4530"
-       inkscape:connector-curvature="0" />
+       d="M 123.8,-22.442786 V -61.589682"
+       style="fill:none;stroke:#000000;stroke-width:0.82385355;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     <path
-       style="fill:none;stroke:#000000;stroke-width:0.82385355;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 160.73333,186.34067 v -39.1469"
        id="path4538"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cc" />
+       d="m 160.73333,186.34067 v -39.1469"
+       style="fill:none;stroke:#000000;stroke-width:0.82385355;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     <path
-       style="fill:none;stroke:#000000;stroke-width:0.82385355;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#marker1181);marker-end:url(#marker1185)"
-       d="M 49.933333,-48.540717 H 123.8"
        id="path4542"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cc" />
+       d="M 49.933333,-48.540717 H 123.8"
+       style="fill:none;stroke:#000000;stroke-width:0.82385355;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#marker1181);marker-end:url(#marker1185)" />
     <path
-       style="fill:none;stroke:#000000;stroke-width:0.82385355;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#marker1173);marker-end:url(#marker1177)"
-       d="M 13,173.2917 H 160.73333"
        id="path4548"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cc" />
+       d="M 13,173.2917 H 160.73333"
+       style="fill:none;stroke:#000000;stroke-width:0.82385355;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#marker1173);marker-end:url(#marker1177)" />
     <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:35.77073669px;line-height:1.25;font-family:'URW Bookman L';-inkscape-font-specification:'URW Bookman L, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:3.35350633"
-       x="78.952225"
-       y="-51.439281"
+       transform="scale(0.97131606,1.029531)"
        id="text5680"
-       transform="scale(0.97131606,1.029531)"><tspan
-         sodipodi:role="line"
-         id="tspan5678"
-         x="78.952225"
+       y="-51.439281"
+       x="78.952225"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:35.77073669px;line-height:1.25;font-family:'URW Bookman L';-inkscape-font-specification:'URW Bookman L, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:3.35350633"
+       xml:space="preserve"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:35.77073669px;font-family:'URW Bookman L';-inkscape-font-specification:'URW Bookman L, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:3.35350633"
          y="-51.439281"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:35.77073669px;font-family:'URW Bookman L';-inkscape-font-specification:'URW Bookman L, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:3.35350633">S</tspan></text>
+         x="78.952225"
+         id="tspan5678">S</tspan></text>
     <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:35.77073669px;line-height:1.25;font-family:'URW Bookman L';-inkscape-font-specification:'URW Bookman L, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:3.35350633"
-       x="76.05468"
-       y="200.45798"
+       transform="scale(0.97131606,1.029531)"
        id="text5692"
-       transform="scale(0.97131606,1.029531)"><tspan
-         sodipodi:role="line"
-         id="tspan5690"
-         x="76.05468"
-         y="200.45798"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:35.77073669px;font-family:'URW Bookman L';-inkscape-font-specification:'URW Bookman L, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:3.35350633">D</tspan></text>
-    <text
-       xml:space="preserve"
+       y="200.45798"
+       x="76.05468"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:35.77073669px;line-height:1.25;font-family:'URW Bookman L';-inkscape-font-specification:'URW Bookman L, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:3.35350633"
-       x="185.94191"
-       y="119.3151"
+       xml:space="preserve"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:35.77073669px;font-family:'URW Bookman L';-inkscape-font-specification:'URW Bookman L, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:3.35350633"
+         y="200.45798"
+         x="76.05468"
+         id="tspan5690">D</tspan></text>
+    <text
+       transform="scale(0.97131606,1.029531)"
        id="text5692-8"
-       transform="scale(0.97131606,1.029531)"><tspan
-         sodipodi:role="line"
-         id="tspan10475"
-         x="185.94191"
+       y="119.3151"
+       x="185.94191"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:35.77073669px;line-height:1.25;font-family:'URW Bookman L';-inkscape-font-specification:'URW Bookman L, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:3.35350633"
+       xml:space="preserve"><tspan
+         style="stroke-width:3.35350633"
          y="119.3151"
-         style="stroke-width:3.35350633">H</tspan><tspan
-         sodipodi:role="line"
          x="185.94191"
-         y="164.02852"
+         id="tspan10475">H</tspan><tspan
+         style="stroke-width:3.35350633"
          id="tspan895"
-         style="stroke-width:3.35350633" /></text>
+         y="164.02852"
+         x="185.94191" /></text>
     <path
-       style="fill:none;stroke:#000000;stroke-width:0.82385355;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 13,186.34067 v -39.1469"
        id="path4538-8"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cc" />
+       d="m 13,186.34067 v -39.1469"
+       style="fill:none;stroke:#000000;stroke-width:0.82385355;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     <path
-       style="fill:none;stroke:#000000;stroke-width:0.82385355;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#Arrow2Lstart);marker-end:url(#Arrow2Lend)"
-       d="M 173.04444,68.899983 V 147.19377"
        id="path897"
-       inkscape:connector-curvature="0" />
+       d="M 173.04444,68.899983 V 147.19377"
+       style="fill:none;stroke:#000000;stroke-width:0.82385355;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#Arrow2Lstart);marker-end:url(#Arrow2Lend)" />
     <path
-       style="fill:none;stroke:#000000;stroke-width:0.82385355;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 160.73333,68.899983 h 24.62222"
        id="path1187"
-       inkscape:connector-curvature="0" />
+       d="m 160.73333,68.899983 h 24.62222"
+       style="fill:none;stroke:#000000;stroke-width:0.82385355;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     <path
-       style="fill:none;stroke:#000000;stroke-width:0.82385355;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 160.73333,147.19377 h 24.62222"
        id="path1189"
-       inkscape:connector-curvature="0" />
+       d="m 160.73333,147.19377 h 24.62222"
+       style="fill:none;stroke:#000000;stroke-width:0.82385355;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     <rect
-       style="fill:#000000;fill-opacity:0.1365314;stroke:#000025;stroke-width:0.82385355;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="rect1191"
-       width="147.73334"
-       height="78.293793"
+       y="68.899971"
        x="13"
-       y="68.899971" />
+       height="78.293793"
+       width="147.73334"
+       id="rect1191"
+       style="fill:#000000;fill-opacity:0.1365314;stroke:#000025;stroke-width:0.82385355;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
 </svg>

--- a/src/Mod/Path/Images/Tools/v-bit.svg
+++ b/src/Mod/Path/Images/Tools/v-bit.svg
@@ -1,407 +1,294 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-
 <svg
    xmlns:dc="http://purl.org/dc/elements/1.1/"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="210mm"
-   height="297mm"
-   viewBox="0 0 210 297"
-   version="1.1"
    id="svg8"
-   inkscape:version="0.92.3 (2405546, 2018-03-11)"
-   sodipodi:docname="v-bit.svg">
+   version="1.1"
+   viewBox="0 0 210 297"
+   height="297mm"
+   width="210mm">
   <defs
      id="defs2">
     <marker
-       inkscape:isstock="true"
-       style="overflow:visible"
+       orient="auto"
+       refY="0"
+       refX="0"
        id="marker7593"
-       refX="0"
-       refY="0"
-       orient="auto"
-       inkscape:stockid="Arrow2Lstart">
+       style="overflow:visible">
       <path
-         inkscape:connector-curvature="0"
-         transform="matrix(1.1,0,0,1.1,1.1,0)"
-         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         id="path7591"
          style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
-         id="path7591" />
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(1.1,0,0,1.1,1.1,0)" />
     </marker>
     <marker
-       inkscape:stockid="Arrow2Lend"
-       orient="auto"
-       refY="0"
-       refX="0"
+       style="overflow:visible"
        id="marker4880"
-       style="overflow:visible"
-       inkscape:isstock="true">
+       refX="0"
+       refY="0"
+       orient="auto">
       <path
-         id="path4878"
-         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
-         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
          transform="matrix(-1.1,0,0,-1.1,-1.1,0)"
-         inkscape:connector-curvature="0" />
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path4878" />
     </marker>
     <marker
-       inkscape:stockid="Arrow2Lstart"
-       orient="auto"
-       refY="0"
-       refX="0"
+       style="overflow:visible"
        id="marker4732"
-       style="overflow:visible"
-       inkscape:isstock="true">
+       refX="0"
+       refY="0"
+       orient="auto">
       <path
-         id="path4730"
-         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
-         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
          transform="matrix(1.1,0,0,1.1,1.1,0)"
-         inkscape:connector-curvature="0" />
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path4730" />
     </marker>
     <marker
-       inkscape:isstock="true"
-       style="overflow:visible"
+       orient="auto"
+       refY="0"
+       refX="0"
        id="marker4584"
-       refX="0"
-       refY="0"
-       orient="auto"
-       inkscape:stockid="Arrow2Lend">
+       style="overflow:visible">
       <path
-         transform="matrix(-1.1,0,0,-1.1,-1.1,0)"
-         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
-         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
          id="path4582"
-         inkscape:connector-curvature="0" />
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-1.1,0,0,-1.1,-1.1,0)" />
     </marker>
     <marker
-       inkscape:stockid="Arrow2Lend"
-       orient="auto"
-       refY="0"
-       refX="0"
+       style="overflow:visible"
        id="marker4328"
-       style="overflow:visible"
-       inkscape:isstock="true"
-       inkscape:collect="always">
+       refX="0"
+       refY="0"
+       orient="auto">
       <path
-         id="path4326"
-         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
-         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
          transform="matrix(-1.1,0,0,-1.1,-1.1,0)"
-         inkscape:connector-curvature="0" />
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path4326" />
     </marker>
     <marker
-       inkscape:isstock="true"
-       style="overflow:visible"
+       orient="auto"
+       refY="0"
+       refX="0"
        id="marker4186"
-       refX="0"
-       refY="0"
-       orient="auto"
-       inkscape:stockid="Arrow2Lstart">
+       style="overflow:visible">
       <path
-         transform="matrix(1.1,0,0,1.1,1.1,0)"
-         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
-         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
          id="path4184"
-         inkscape:connector-curvature="0" />
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(1.1,0,0,1.1,1.1,0)" />
     </marker>
     <marker
-       inkscape:stockid="Arrow2Lstart"
-       orient="auto"
-       refY="0"
-       refX="0"
+       style="overflow:visible"
        id="marker3948"
-       style="overflow:visible"
-       inkscape:isstock="true"
-       inkscape:collect="always">
+       refX="0"
+       refY="0"
+       orient="auto">
       <path
-         id="path3946"
-         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
-         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
          transform="matrix(1.1,0,0,1.1,1.1,0)"
-         inkscape:connector-curvature="0" />
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path3946" />
     </marker>
     <marker
-       inkscape:stockid="Arrow2Lend"
-       orient="auto"
-       refY="0"
-       refX="0"
+       style="overflow:visible"
        id="Arrow2Lend"
-       style="overflow:visible"
-       inkscape:isstock="true">
+       refX="0"
+       refY="0"
+       orient="auto">
       <path
-         id="path920"
-         style="fill:#000025;fill-opacity:1;fill-rule:evenodd;stroke:#000025;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
-         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
          transform="matrix(-1.1,0,0,-1.1,-1.1,0)"
-         inkscape:connector-curvature="0" />
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000025;fill-opacity:1;fill-rule:evenodd;stroke:#000025;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path920" />
     </marker>
     <marker
-       inkscape:stockid="Arrow2Lstart"
-       orient="auto"
-       refY="0"
-       refX="0"
+       style="overflow:visible"
        id="Arrow2Lstart"
-       style="overflow:visible"
-       inkscape:isstock="true"
-       inkscape:collect="always">
+       refX="0"
+       refY="0"
+       orient="auto">
       <path
-         id="path917"
-         style="fill:#000025;fill-opacity:1;fill-rule:evenodd;stroke:#000025;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
-         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
          transform="matrix(1.1,0,0,1.1,1.1,0)"
-         inkscape:connector-curvature="0" />
-    </marker>
-    <marker
-       inkscape:stockid="Arrow2Mend"
-       orient="auto"
-       refY="0"
-       refX="0"
-       id="marker7497"
-       style="overflow:visible"
-       inkscape:isstock="true">
-      <path
-         id="path7495"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
          style="fill:#000025;fill-opacity:1;fill-rule:evenodd;stroke:#000025;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
-         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
-         transform="scale(-0.6)"
-         inkscape:connector-curvature="0" />
+         id="path917" />
     </marker>
     <marker
-       inkscape:stockid="Arrow1Mstart"
-       orient="auto"
-       refY="0"
+       style="overflow:visible"
+       id="marker7497"
        refX="0"
+       refY="0"
+       orient="auto">
+      <path
+         transform="scale(-0.6)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000025;fill-opacity:1;fill-rule:evenodd;stroke:#000025;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path7495" />
+    </marker>
+    <marker
+       style="overflow:visible"
        id="marker7379"
-       style="overflow:visible"
-       inkscape:isstock="true">
+       refX="0"
+       refY="0"
+       orient="auto">
       <path
-         id="path7377"
-         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         transform="matrix(0.4,0,0,0.4,4,0)"
          style="fill:#000025;fill-opacity:1;fill-rule:evenodd;stroke:#000025;stroke-width:1.00000003pt;stroke-opacity:1"
-         transform="matrix(0.4,0,0,0.4,4,0)"
-         inkscape:connector-curvature="0" />
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path7377" />
     </marker>
     <marker
-       inkscape:isstock="true"
-       style="overflow:visible"
+       orient="auto"
+       refY="0"
+       refX="0"
        id="marker5480"
-       refX="0"
-       refY="0"
-       orient="auto"
-       inkscape:stockid="Arrow2Mend">
+       style="overflow:visible">
       <path
-         transform="scale(-0.6)"
-         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
-         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
          id="path5478"
-         inkscape:connector-curvature="0" />
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="scale(-0.6)" />
     </marker>
     <marker
-       inkscape:isstock="true"
-       style="overflow:visible"
+       orient="auto"
+       refY="0"
+       refX="0"
        id="marker5470"
-       refX="0"
-       refY="0"
-       orient="auto"
-       inkscape:stockid="Arrow2Mend">
+       style="overflow:visible">
       <path
-         transform="scale(-0.6)"
-         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
-         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
          id="path5468"
-         inkscape:connector-curvature="0" />
-    </marker>
-    <marker
-       inkscape:isstock="true"
-       style="overflow:visible"
-       id="marker5220"
-       refX="0"
-       refY="0"
-       orient="auto"
-       inkscape:stockid="Arrow1Mstart">
-      <path
-         transform="matrix(0.4,0,0,0.4,4,0)"
-         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
-         d="M 0,0 5,-5 -12.5,0 5,5 Z"
-         id="path5218"
-         inkscape:connector-curvature="0" />
-    </marker>
-    <marker
-       inkscape:isstock="true"
-       style="overflow:visible"
-       id="marker5210"
-       refX="0"
-       refY="0"
-       orient="auto"
-       inkscape:stockid="Arrow1Mstart">
-      <path
-         transform="matrix(0.4,0,0,0.4,4,0)"
-         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
-         d="M 0,0 5,-5 -12.5,0 5,5 Z"
-         id="path5208"
-         inkscape:connector-curvature="0" />
-    </marker>
-    <marker
-       inkscape:isstock="true"
-       style="overflow:visible"
-       id="marker5072"
-       refX="0"
-       refY="0"
-       orient="auto"
-       inkscape:stockid="Arrow1Lend">
-      <path
-         transform="matrix(-0.8,0,0,-0.8,-10,0)"
-         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
-         d="M 0,0 5,-5 -12.5,0 5,5 Z"
-         id="path5070"
-         inkscape:connector-curvature="0" />
-    </marker>
-    <marker
-       inkscape:isstock="true"
-       style="overflow:visible"
-       id="marker5014"
-       refX="0"
-       refY="0"
-       orient="auto"
-       inkscape:stockid="Arrow1Lend">
-      <path
-         transform="matrix(-0.8,0,0,-0.8,-10,0)"
-         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
-         d="M 0,0 5,-5 -12.5,0 5,5 Z"
-         id="path5012"
-         inkscape:connector-curvature="0" />
-    </marker>
-    <marker
-       inkscape:isstock="true"
-       style="overflow:visible"
-       id="marker4968"
-       refX="0"
-       refY="0"
-       orient="auto"
-       inkscape:stockid="Arrow1Lend">
-      <path
-         transform="matrix(-0.8,0,0,-0.8,-10,0)"
-         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
-         d="M 0,0 5,-5 -12.5,0 5,5 Z"
-         id="path4966"
-         inkscape:connector-curvature="0" />
-    </marker>
-    <marker
-       inkscape:isstock="true"
-       style="overflow:visible"
-       id="marker4884"
-       refX="0"
-       refY="0"
-       orient="auto"
-       inkscape:stockid="Arrow1Lstart">
-      <path
-         transform="matrix(0.8,0,0,0.8,10,0)"
-         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
-         d="M 0,0 5,-5 -12.5,0 5,5 Z"
-         id="path4882"
-         inkscape:connector-curvature="0" />
-    </marker>
-    <marker
-       inkscape:isstock="true"
-       style="overflow:visible"
-       id="marker4856"
-       refX="0"
-       refY="0"
-       orient="auto"
-       inkscape:stockid="Arrow1Lstart">
-      <path
-         transform="matrix(0.8,0,0,0.8,10,0)"
-         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
-         d="M 0,0 5,-5 -12.5,0 5,5 Z"
-         id="path4854"
-         inkscape:connector-curvature="0" />
-    </marker>
-    <marker
-       inkscape:isstock="true"
-       style="overflow:visible"
-       id="marker4834"
-       refX="0"
-       refY="0"
-       orient="auto"
-       inkscape:stockid="Arrow1Lstart">
-      <path
-         transform="matrix(0.8,0,0,0.8,10,0)"
-         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
-         d="M 0,0 5,-5 -12.5,0 5,5 Z"
-         id="path4832"
-         inkscape:connector-curvature="0" />
-    </marker>
-    <marker
-       inkscape:isstock="true"
-       style="overflow:visible"
-       id="marker5220-5"
-       refX="0"
-       refY="0"
-       orient="auto"
-       inkscape:stockid="Arrow1Mstart">
-      <path
-         inkscape:connector-curvature="0"
-         transform="matrix(0.4,0,0,0.4,4,0)"
-         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
-         d="M 0,0 5,-5 -12.5,0 5,5 Z"
-         id="path5218-3" />
-    </marker>
-    <marker
-       inkscape:isstock="true"
-       style="overflow:visible"
-       id="marker5480-5"
-       refX="0"
-       refY="0"
-       orient="auto"
-       inkscape:stockid="Arrow2Mend">
-      <path
-         inkscape:connector-curvature="0"
-         transform="scale(-0.6)"
-         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
          style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
-         id="path5478-7" />
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="scale(-0.6)" />
+    </marker>
+    <marker
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker5220"
+       style="overflow:visible">
+      <path
+         id="path5218"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker5210"
+       style="overflow:visible">
+      <path
+         id="path5208"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker5072"
+       style="overflow:visible">
+      <path
+         id="path5070"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)" />
+    </marker>
+    <marker
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker5014"
+       style="overflow:visible">
+      <path
+         id="path5012"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)" />
+    </marker>
+    <marker
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4968"
+       style="overflow:visible">
+      <path
+         id="path4966"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)" />
+    </marker>
+    <marker
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4884"
+       style="overflow:visible">
+      <path
+         id="path4882"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(0.8,0,0,0.8,10,0)" />
+    </marker>
+    <marker
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4856"
+       style="overflow:visible">
+      <path
+         id="path4854"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(0.8,0,0,0.8,10,0)" />
+    </marker>
+    <marker
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4834"
+       style="overflow:visible">
+      <path
+         id="path4832"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(0.8,0,0,0.8,10,0)" />
+    </marker>
+    <marker
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker5220-5"
+       style="overflow:visible">
+      <path
+         id="path5218-3"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker5480-5"
+       style="overflow:visible">
+      <path
+         id="path5478-7"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="scale(-0.6)" />
     </marker>
   </defs>
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageopacity="0.0"
-     inkscape:pageshadow="2"
-     inkscape:zoom="1.1955247"
-     inkscape:cx="396.85039"
-     inkscape:cy="561.25984"
-     inkscape:document-units="mm"
-     inkscape:current-layer="layer1"
-     showgrid="true"
-     inkscape:window-width="3032"
-     inkscape:window-height="1577"
-     inkscape:window-x="0"
-     inkscape:window-y="48"
-     inkscape:window-maximized="1"
-     fit-margin-top="1"
-     fit-margin-left="2"
-     fit-margin-right="2"
-     fit-margin-bottom="1"
-     scale-x="0.2"
-     units="mm">
-    <inkscape:grid
-       type="xygrid"
-       id="grid4518"
-       units="mm"
-       spacingx="1"
-       spacingy="1"
-       empspacing="10"
-       dotted="false"
-       originx="-8.0381701"
-       originy="-186.5209" />
-  </sodipodi:namedview>
   <metadata
      id="metadata5">
     <rdf:RDF>
@@ -410,187 +297,143 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
+        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <g
-     inkscape:label="Layer 1"
-     inkscape:groupmode="layer"
-     id="layer1"
-     transform="translate(-2.9715041,189.05423)">
+     transform="translate(-2.9715041,189.05423)"
+     id="layer1">
     <path
-       style="fill:#000000;fill-opacity:0.1372549;stroke:#000000;stroke-width:0.80668455;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="M 16.482124,-35.533338 H 161.08374 l -60.25067,63.90854 H 76.732798 Z"
        id="path3652"
-       inkscape:connector-curvature="0" />
+       d="M 16.482124,-35.533338 H 161.08374 l -60.25067,63.90854 H 76.732798 Z"
+       style="fill:#000000;fill-opacity:0.1372549;stroke:#000000;stroke-width:0.80668455;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     <path
-       style="fill:none;stroke:#000000;stroke-width:3.28361988px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       d="m 52.632531,-125.00529 v 89.471952 H 16.482124 l 60.250677,63.90854 h 24.100269 l 60.25067,-63.90854 h -36.15041 v -89.471952 z"
        id="path4520"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="ccccccccc" />
+       d="m 52.632531,-125.00529 v 89.471952 H 16.482124 l 60.250677,63.90854 h 24.100269 l 60.25067,-63.90854 h -36.15041 v -89.471952 z"
+       style="fill:none;stroke:#000000;stroke-width:3.28361988px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     <path
-       style="fill:none;stroke:#000000;stroke-width:1.24105322;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:9.9284259, 2.48210647, 1.24105325, 2.48210647;stroke-dashoffset:0;stroke-opacity:1"
-       d="M 88.782934,-137.787 V 41.156909"
        id="path4526"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cc" />
+       d="M 88.782934,-137.787 V 41.156909"
+       style="fill:none;stroke:#000000;stroke-width:1.24105322;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:9.9284259, 2.48210647, 1.24105325, 2.48210647;stroke-dashoffset:0;stroke-opacity:1" />
     <path
-       style="fill:none;stroke:#000000;stroke-width:0.80668455;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 52.632531,-125.00529 v -38.34513"
        id="path4528"
-       inkscape:connector-curvature="0" />
+       d="m 52.632531,-125.00529 v -38.34513"
+       style="fill:none;stroke:#000000;stroke-width:0.80668455;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     <path
-       style="fill:none;stroke:#000000;stroke-width:0.80668455;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 124.93333,-125.00529 v -38.34513"
        id="path4530"
-       inkscape:connector-curvature="0" />
+       d="m 124.93333,-125.00529 v -38.34513"
+       style="fill:none;stroke:#000000;stroke-width:0.80668455;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     <g
-       id="g7053"
-       transform="matrix(12.050135,0,0,12.781708,4.431989,-176.13213)">
+       transform="matrix(12.050135,0,0,12.781708,4.431989,-176.13213)"
+       id="g7053">
       <path
-         inkscape:connector-curvature="0"
-         id="path4536"
-         d="m 8,16 v 2"
          style="fill:none;stroke:#000000;stroke-width:0.065;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         sodipodi:nodetypes="cc" />
+         d="m 8,16 v 2"
+         id="path4536" />
     </g>
     <path
-       style="fill:none;stroke:#000000;stroke-width:0.80668455;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="M 161.08374,79.502035 V -35.533338"
        id="path4538"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cc" />
+       d="M 161.08374,79.502035 V -35.533338"
+       style="fill:none;stroke:#000000;stroke-width:0.80668455;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     <path
-       style="fill:none;stroke:#000000;stroke-width:0.80668455;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#marker4186);marker-end:url(#marker4584)"
-       d="M 52.632531,-150.56871 H 124.93333"
        id="path4542"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cc" />
+       d="M 52.632531,-150.56871 H 124.93333"
+       style="fill:none;stroke:#000000;stroke-width:0.80668455;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#marker4186);marker-end:url(#marker4584)" />
     <path
-       style="fill:none;stroke:#000000;stroke-width:0.65865523;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#marker4732)"
-       d="m 100.83307,44.466662 v 0 h 24.10026"
        id="path4546"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="ccc" />
+       d="m 100.83307,44.466662 v 0 h 24.10026"
+       style="fill:none;stroke:#000000;stroke-width:0.65865523;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#marker4732)" />
     <path
-       style="fill:none;stroke:#000000;stroke-width:0.80668455;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#marker3948);marker-end:url(#marker4328)"
-       d="M 16.482124,66.720326 H 161.08374"
        id="path4548"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cc" />
+       d="M 16.482124,66.720326 H 161.08374"
+       style="fill:none;stroke:#000000;stroke-width:0.80668455;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#marker3948);marker-end:url(#marker4328)" />
     <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:35.02528px;line-height:1.25;font-family:'URW Bookman L';-inkscape-font-specification:'URW Bookman L, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:3.28361988"
-       x="81.176964"
-       y="-150.39774"
+       transform="scale(0.97096034,1.0299082)"
        id="text5680"
-       transform="scale(0.97096034,1.0299082)"><tspan
-         sodipodi:role="line"
-         id="tspan5678"
-         x="81.176964"
+       y="-150.39774"
+       x="81.176964"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:35.02528px;line-height:1.25;font-family:'URW Bookman L';-inkscape-font-specification:'URW Bookman L, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:3.28361988"
+       xml:space="preserve"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:35.02528px;font-family:'URW Bookman L';-inkscape-font-specification:'URW Bookman L, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:3.28361988"
          y="-150.39774"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:35.02528px;font-family:'URW Bookman L';-inkscape-font-specification:'URW Bookman L, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:3.28361988">S</tspan></text>
+         x="81.176964"
+         id="tspan5678">S</tspan></text>
     <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:35.02528px;line-height:1.25;font-family:'URW Bookman L';-inkscape-font-specification:'URW Bookman L, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:3.28361988"
-       x="78.339798"
-       y="96.250031"
+       transform="scale(0.97096034,1.0299082)"
        id="text5692"
-       transform="scale(0.97096034,1.0299082)"><tspan
-         sodipodi:role="line"
-         id="tspan5690"
-         x="78.339798"
+       y="96.250031"
+       x="78.339798"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:35.02528px;line-height:1.25;font-family:'URW Bookman L';-inkscape-font-specification:'URW Bookman L, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:3.28361988"
+       xml:space="preserve"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:35.02528px;font-family:'URW Bookman L';-inkscape-font-specification:'URW Bookman L, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:3.28361988"
          y="96.250031"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:35.02528px;font-family:'URW Bookman L';-inkscape-font-specification:'URW Bookman L, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:3.28361988">D</tspan></text>
+         x="78.339798"
+         id="tspan5690">D</tspan></text>
     <path
-       style="fill:none;fill-opacity:1;stroke:#000025;stroke-width:0.80668473;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-start:url(#Arrow2Lstart);marker-end:url(#Arrow2Lend)"
-       id="path5698"
-       sodipodi:type="arc"
-       sodipodi:cx="-41.901245"
-       sodipodi:cy="88.551216"
-       sodipodi:rx="76.688599"
-       sodipodi:ry="72.377235"
-       sodipodi:start="5.5187609"
-       sodipodi:end="0.78361543"
-       d="M 13.451117,38.457364 A 76.688599,72.377235 0 0 1 12.422369,139.63833"
        transform="matrix(-0.00747619,-0.99997205,0.99996462,-0.00841146,0,0)"
-       sodipodi:open="true" />
+       d="M 13.451117,38.457364 A 76.688599,72.377235 0 0 1 12.422369,139.63833"
+       id="path5698"
+       style="fill:none;fill-opacity:1;stroke:#000025;stroke-width:0.80668473;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-start:url(#Arrow2Lstart);marker-end:url(#Arrow2Lend)" />
     <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:35.02528px;line-height:1.25;font-family:'URW Bookman L';-inkscape-font-specification:'URW Bookman L, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:3.28361988"
-       x="95.738831"
-       y="-39.443188"
+       transform="scale(0.97096033,1.0299082)"
        id="text5688-7"
-       transform="scale(0.97096033,1.0299082)"><tspan
-         sodipodi:role="line"
-         id="tspan5718"
-         x="95.738831"
-         y="-39.443188"
-         style="stroke-width:3.28361988">α</tspan></text>
-    <text
-       xml:space="preserve"
+       y="-39.443188"
+       x="95.738831"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:35.02528px;line-height:1.25;font-family:'URW Bookman L';-inkscape-font-specification:'URW Bookman L, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:3.28361988"
-       x="28.921215"
-       y="51.168293"
+       xml:space="preserve"><tspan
+         style="stroke-width:3.28361988"
+         y="-39.443188"
+         x="95.738831"
+         id="tspan5718">α</tspan></text>
+    <text
+       transform="scale(0.97096033,1.0299082)"
        id="text5692-8"
-       transform="scale(0.97096033,1.0299082)"><tspan
-         sodipodi:role="line"
-         id="tspan10475"
-         x="28.921215"
+       y="51.168293"
+       x="28.921215"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:35.02528px;line-height:1.25;font-family:'URW Bookman L';-inkscape-font-specification:'URW Bookman L, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:3.28361988"
+       xml:space="preserve"><tspan
+         style="stroke-width:3.28361988"
          y="51.168293"
-         style="stroke-width:3.28361988">d</tspan></text>
+         x="28.921215"
+         id="tspan10475">d</tspan></text>
     <path
-       style="fill:none;stroke:#000000;stroke-width:0.65865511;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker4880)"
-       d="m 50.833067,44.466662 v 0 h 24.100267"
        id="path4546-7"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="ccc" />
+       d="m 50.833067,44.466662 v 0 h 24.100267"
+       style="fill:none;stroke:#000000;stroke-width:0.65865511;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker4880)" />
     <g
-       transform="matrix(12.050135,0,0,12.781708,-19.668283,-176.13213)"
-       id="g7053-6">
+       id="g7053-6"
+       transform="matrix(12.050135,0,0,12.781708,-19.668283,-176.13213)">
       <path
-         inkscape:connector-curvature="0"
-         id="path4536-1"
-         d="m 8,16 v 2"
          style="fill:none;stroke:#000000;stroke-width:0.065;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         sodipodi:nodetypes="cc" />
+         d="m 8,16 v 2"
+         id="path4536-1" />
     </g>
     <path
-       style="fill:none;stroke:#000000;stroke-width:0.80668455;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="M 16.482124,79.502035 V -35.533338"
        id="path4538-8"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cc" />
+       d="M 16.482124,79.502035 V -35.533338"
+       style="fill:none;stroke:#000000;stroke-width:0.80668455;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     <path
-       style="fill:none;stroke:#000000;stroke-width:0.68599999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 160.33172,-35.533338 24.60161,0"
        id="path4548-6"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cc" />
+       d="m 160.33172,-35.533338 24.60161,0"
+       style="fill:none;stroke:#000000;stroke-width:0.68599999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     <path
-       style="fill:none;stroke:#000000;stroke-width:0.75753552;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 100.93333,28.466662 84,0"
        id="path4548-6-8"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cc" />
+       d="m 100.93333,28.466662 84,0"
+       style="fill:none;stroke:#000000;stroke-width:0.75753552;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     <path
-       style="fill:none;stroke:#000000;stroke-width:0.80668455;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#marker7593);marker-end:url(#marker5072)"
-       d="m 174.93333,28.466662 0,-64"
        id="path4538-7"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cc" />
+       d="m 174.93333,28.466662 0,-64"
+       style="fill:none;stroke:#000000;stroke-width:0.80668455;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#marker7593);marker-end:url(#marker5072)" />
     <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:35.02518845px;line-height:1.25;font-family:'URW Bookman L';-inkscape-font-specification:'URW Bookman L, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:3.28361988"
-       x="185.5818"
-       y="9.0554771"
+       transform="scale(0.97096033,1.0299082)"
        id="text5692-9"
-       transform="scale(0.97096033,1.0299082)"><tspan
-         sodipodi:role="line"
-         id="tspan7855"
+       y="9.0554771"
+       x="185.5818"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:35.02518845px;line-height:1.25;font-family:'URW Bookman L';-inkscape-font-specification:'URW Bookman L, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:3.28361988"
+       xml:space="preserve"><tspan
+         y="9.0554771"
          x="185.5818"
-         y="9.0554771">H</tspan></text>
+         id="tspan7855">H</tspan></text>
   </g>
 </svg>

--- a/src/Mod/Points/Gui/Resources/icons/PointsWorkbench.svg
+++ b/src/Mod/Points/Gui/Resources/icons/PointsWorkbench.svg
@@ -1,16 +1,29 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" version="1.0" viewBox="0 0 64 64" id="svg2" inkscape:version="0.48.5 r10040" width="100%" height="100%" sodipodi:docname="PointsWorkbench.svg">
-  <metadata id="metadata56">
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   height="100%"
+   width="100%"
+   id="svg2"
+   viewBox="0 0 64 64"
+   version="1.0">
+  <metadata
+     id="metadata56">
     <rdf:RDF>
-      <cc:Work rdf:about="">
+      <cc:Work
+         rdf:about="">
         <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
         <dc:creator>
           <cc:Agent>
             <dc:title>$committer</dc:title>
           </cc:Agent>
         </dc:creator>
-        <dc:title>PointsWorkbench</dc:title>
+        <dc:title></dc:title>
         <dc:date>2016-02-26</dc:date>
         <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
         <dc:publisher>
@@ -33,19 +46,61 @@
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <defs id="defs54"/>
-  <sodipodi:namedview pagecolor="#ffffff" bordercolor="#666666" borderopacity="1" objecttolerance="10" gridtolerance="10" guidetolerance="10" inkscape:pageopacity="0" inkscape:pageshadow="2" inkscape:window-width="1600" inkscape:window-height="837" id="namedview52" showgrid="true" inkscape:zoom="4.8326416" inkscape:cx="65.914387" inkscape:cy="30.751756" inkscape:window-x="0" inkscape:window-y="27" inkscape:window-maximized="1" inkscape:current-layer="svg2">
-    <inkscape:grid type="xygrid" id="grid3033" empspacing="2" visible="true" enabled="true" snapvisiblegridlinesonly="true"/>
-  </sodipodi:namedview>
-  <path sodipodi:type="arc" style="fill:#d3d7cf;fill-opacity:1;stroke:#2e3436;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0.6" id="path3035" sodipodi:cx="-8" sodipodi:cy="8" sodipodi:rx="4" sodipodi:ry="4" d="m -4,8 a 4,4 0 1 1 -8,0 4,4 0 1 1 8,0 z" transform="translate(15,3)"/>
-  <path sodipodi:type="arc" style="fill:#d3d7cf;fill-opacity:1;stroke:#2e3436;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0.6" id="path3035-1" sodipodi:cx="-8" sodipodi:cy="8" sodipodi:rx="4" sodipodi:ry="4" d="m -4,8 a 4,4 0 1 1 -8,0 4,4 0 1 1 8,0 z" transform="translate(33,-1)"/>
-  <path sodipodi:type="arc" style="fill:#d3d7cf;fill-opacity:1;stroke:#2e3436;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0.6" id="path3035-2" sodipodi:cx="-8" sodipodi:cy="8" sodipodi:rx="4" sodipodi:ry="4" d="m -4,8 a 4,4 0 1 1 -8,0 4,4 0 1 1 8,0 z" transform="translate(59,-1)"/>
-  <path sodipodi:type="arc" style="fill:#d3d7cf;fill-opacity:1;stroke:#2e3436;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0.6" id="path3035-7" sodipodi:cx="-8" sodipodi:cy="8" sodipodi:rx="4" sodipodi:ry="4" d="m -4,8 a 4,4 0 1 1 -8,0 4,4 0 1 1 8,0 z" transform="translate(49,11)"/>
-  <path sodipodi:type="arc" style="fill:#d3d7cf;fill-opacity:1;stroke:#2e3436;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0.6" id="path3035-0" sodipodi:cx="-8" sodipodi:cy="8" sodipodi:rx="4" sodipodi:ry="4" d="m -4,8 a 4,4 0 1 1 -8,0 4,4 0 1 1 8,0 z" transform="translate(61,23)"/>
-  <path sodipodi:type="arc" style="fill:#d3d7cf;fill-opacity:1;stroke:#2e3436;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0.6" id="path3035-9" sodipodi:cx="-8" sodipodi:cy="8" sodipodi:rx="4" sodipodi:ry="4" d="m -4,8 a 4,4 0 1 1 -8,0 4,4 0 1 1 8,0 z" transform="translate(23,13)"/>
-  <path sodipodi:type="arc" style="fill:#d3d7cf;fill-opacity:1;stroke:#2e3436;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0.6" id="path3035-3" sodipodi:cx="-8" sodipodi:cy="8" sodipodi:rx="4" sodipodi:ry="4" d="m -4,8 a 4,4 0 1 1 -8,0 4,4 0 1 1 8,0 z" transform="translate(29,27)"/>
-  <path sodipodi:type="arc" style="fill:#d3d7cf;fill-opacity:1;stroke:#2e3436;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0.6" id="path3035-6" sodipodi:cx="-8" sodipodi:cy="8" sodipodi:rx="4" sodipodi:ry="4" d="m -4,8 a 4,4 0 1 1 -8,0 4,4 0 1 1 8,0 z" transform="translate(25,43)"/>
-  <path sodipodi:type="arc" style="fill:#d3d7cf;fill-opacity:1;stroke:#2e3436;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0.6" id="path3035-06" sodipodi:cx="-8" sodipodi:cy="8" sodipodi:rx="4" sodipodi:ry="4" d="m -4,8 a 4,4 0 1 1 -8,0 4,4 0 1 1 8,0 z" transform="translate(49,43)"/>
-  <path sodipodi:type="arc" style="fill:#d3d7cf;fill-opacity:1;stroke:#2e3436;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0.6" id="path3035-26" sodipodi:cx="-8" sodipodi:cy="8" sodipodi:rx="4" sodipodi:ry="4" d="m -4,8 a 4,4 0 1 1 -8,0 4,4 0 1 1 8,0 z" transform="translate(45,27)"/>
-  <path sodipodi:type="arc" style="fill:#d3d7cf;fill-opacity:1;stroke:#2e3436;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0.6" id="path3035-18" sodipodi:cx="-8" sodipodi:cy="8" sodipodi:rx="4" sodipodi:ry="4" d="m -4,8 a 4,4 0 1 1 -8,0 4,4 0 1 1 8,0 z" transform="translate(63,47)"/>
+  <defs
+     id="defs54" />
+  <path
+     transform="translate(15,3)"
+     d="m -4,8 a 4,4 0 1 1 -8,0 4,4 0 1 1 8,0 z"
+     id="path3035"
+     style="fill:#d3d7cf;fill-opacity:1;stroke:#2e3436;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0.6" />
+  <path
+     transform="translate(33,-1)"
+     d="m -4,8 a 4,4 0 1 1 -8,0 4,4 0 1 1 8,0 z"
+     id="path3035-1"
+     style="fill:#d3d7cf;fill-opacity:1;stroke:#2e3436;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0.6" />
+  <path
+     transform="translate(59,-1)"
+     d="m -4,8 a 4,4 0 1 1 -8,0 4,4 0 1 1 8,0 z"
+     id="path3035-2"
+     style="fill:#d3d7cf;fill-opacity:1;stroke:#2e3436;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0.6" />
+  <path
+     transform="translate(49,11)"
+     d="m -4,8 a 4,4 0 1 1 -8,0 4,4 0 1 1 8,0 z"
+     id="path3035-7"
+     style="fill:#d3d7cf;fill-opacity:1;stroke:#2e3436;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0.6" />
+  <path
+     transform="translate(61,23)"
+     d="m -4,8 a 4,4 0 1 1 -8,0 4,4 0 1 1 8,0 z"
+     id="path3035-0"
+     style="fill:#d3d7cf;fill-opacity:1;stroke:#2e3436;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0.6" />
+  <path
+     transform="translate(23,13)"
+     d="m -4,8 a 4,4 0 1 1 -8,0 4,4 0 1 1 8,0 z"
+     id="path3035-9"
+     style="fill:#d3d7cf;fill-opacity:1;stroke:#2e3436;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0.6" />
+  <path
+     transform="translate(29,27)"
+     d="m -4,8 a 4,4 0 1 1 -8,0 4,4 0 1 1 8,0 z"
+     id="path3035-3"
+     style="fill:#d3d7cf;fill-opacity:1;stroke:#2e3436;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0.6" />
+  <path
+     transform="translate(25,43)"
+     d="m -4,8 a 4,4 0 1 1 -8,0 4,4 0 1 1 8,0 z"
+     id="path3035-6"
+     style="fill:#d3d7cf;fill-opacity:1;stroke:#2e3436;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0.6" />
+  <path
+     transform="translate(49,43)"
+     d="m -4,8 a 4,4 0 1 1 -8,0 4,4 0 1 1 8,0 z"
+     id="path3035-06"
+     style="fill:#d3d7cf;fill-opacity:1;stroke:#2e3436;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0.6" />
+  <path
+     transform="translate(45,27)"
+     d="m -4,8 a 4,4 0 1 1 -8,0 4,4 0 1 1 8,0 z"
+     id="path3035-26"
+     style="fill:#d3d7cf;fill-opacity:1;stroke:#2e3436;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0.6" />
+  <path
+     transform="translate(63,47)"
+     d="m -4,8 a 4,4 0 1 1 -8,0 4,4 0 1 1 8,0 z"
+     id="path3035-18"
+     style="fill:#d3d7cf;fill-opacity:1;stroke:#2e3436;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0.6" />
 </svg>

--- a/src/Mod/Raytracing/Gui/Resources/icons/RaytracingWorkbench.svg
+++ b/src/Mod/Raytracing/Gui/Resources/icons/RaytracingWorkbench.svg
@@ -1,6 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-
 <svg
    xmlns:dc="http://purl.org/dc/elements/1.1/"
    xmlns:cc="http://creativecommons.org/ns#"
@@ -8,209 +6,139 @@
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="64px"
-   height="64px"
-   id="svg2816"
    version="1.1"
-   inkscape:version="0.48.5 r10040"
-   sodipodi:docname="RaytracingWorkbench.svg">
+   id="svg2816"
+   height="64px"
+   width="64px">
   <defs
      id="defs2818">
     <linearGradient
-       inkscape:collect="always"
        id="linearGradient3976">
       <stop
-         style="stop-color:#ffffff;stop-opacity:1;"
+         id="stop3978"
          offset="0"
-         id="stop3978" />
+         style="stop-color:#ffffff;stop-opacity:1;" />
       <stop
-         style="stop-color:#ffffff;stop-opacity:0;"
+         id="stop3980"
          offset="1"
-         id="stop3980" />
+         style="stop-color:#ffffff;stop-opacity:0;" />
     </linearGradient>
     <linearGradient
        id="linearGradient3600">
       <stop
-         style="stop-color:#204a87;stop-opacity:1"
+         id="stop3602"
          offset="0"
-         id="stop3602" />
+         style="stop-color:#204a87;stop-opacity:1" />
       <stop
-         style="stop-color:#729fcf;stop-opacity:1"
+         id="stop3604"
          offset="1"
-         id="stop3604" />
+         style="stop-color:#729fcf;stop-opacity:1" />
     </linearGradient>
-    <inkscape:perspective
-       sodipodi:type="inkscape:persp3d"
-       inkscape:vp_x="0 : 32 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_z="64 : 32 : 1"
-       inkscape:persp3d-origin="32 : 21.333333 : 1"
-       id="perspective2824" />
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3600"
+       gradientUnits="userSpaceOnUse"
+       y2="10.397644"
+       x2="14.872466"
+       y1="47.692612"
+       x1="51.037281"
        id="linearGradient3606"
-       x1="51.037281"
-       y1="47.692612"
-       x2="14.872466"
-       y2="10.397644"
-       gradientUnits="userSpaceOnUse" />
-    <inkscape:perspective
-       id="perspective3618"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
+       xlink:href="#linearGradient3600" />
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3600-6"
-       id="linearGradient3606-5"
-       x1="51.037281"
-       y1="47.692612"
-       x2="14.872466"
+       gradientUnits="userSpaceOnUse"
        y2="10.397644"
-       gradientUnits="userSpaceOnUse" />
+       x2="14.872466"
+       y1="47.692612"
+       x1="51.037281"
+       id="linearGradient3606-5"
+       xlink:href="#linearGradient3600-6" />
     <linearGradient
        id="linearGradient3600-6">
       <stop
-         style="stop-color:#000117;stop-opacity:1;"
+         id="stop3602-5"
          offset="0"
-         id="stop3602-5" />
+         style="stop-color:#000117;stop-opacity:1;" />
       <stop
-         style="stop-color:#4f82b9;stop-opacity:1;"
+         id="stop3604-4"
          offset="1"
-         id="stop3604-4" />
+         style="stop-color:#4f82b9;stop-opacity:1;" />
     </linearGradient>
-    <inkscape:perspective
-       id="perspective3656"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       id="perspective3679"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3600-63"
-       id="linearGradient3606-0"
-       x1="51.037281"
-       y1="47.692612"
-       x2="14.872466"
+       gradientUnits="userSpaceOnUse"
        y2="10.397644"
-       gradientUnits="userSpaceOnUse" />
+       x2="14.872466"
+       y1="47.692612"
+       x1="51.037281"
+       id="linearGradient3606-0"
+       xlink:href="#linearGradient3600-63" />
     <linearGradient
        id="linearGradient3600-63">
       <stop
-         style="stop-color:#000117;stop-opacity:1;"
+         id="stop3602-9"
          offset="0"
-         id="stop3602-9" />
+         style="stop-color:#000117;stop-opacity:1;" />
       <stop
-         style="stop-color:#4f82b9;stop-opacity:1;"
+         id="stop3604-0"
          offset="1"
-         id="stop3604-0" />
+         style="stop-color:#4f82b9;stop-opacity:1;" />
     </linearGradient>
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3600-7"
-       id="linearGradient3606-1"
-       x1="51.037281"
-       y1="47.692612"
-       x2="14.872466"
+       gradientUnits="userSpaceOnUse"
        y2="10.397644"
-       gradientUnits="userSpaceOnUse" />
+       x2="14.872466"
+       y1="47.692612"
+       x1="51.037281"
+       id="linearGradient3606-1"
+       xlink:href="#linearGradient3600-7" />
     <linearGradient
        id="linearGradient3600-7">
       <stop
-         style="stop-color:#204a87;stop-opacity:1"
+         id="stop3602-4"
          offset="0"
-         id="stop3602-4" />
+         style="stop-color:#204a87;stop-opacity:1" />
       <stop
-         style="stop-color:#729fcf;stop-opacity:1"
+         id="stop3604-09"
          offset="1"
-         id="stop3604-09" />
+         style="stop-color:#729fcf;stop-opacity:1" />
     </linearGradient>
     <filter
-       inkscape:collect="always"
-       id="filter3871"
-       x="-0.45363568"
-       width="1.9072714"
+       height="1.9072714"
        y="-0.45363568"
-       height="1.9072714">
+       width="1.9072714"
+       x="-0.45363568"
+       id="filter3871">
       <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="9.8975056"
-         id="feGaussianBlur3873" />
+         id="feGaussianBlur3873"
+         stdDeviation="9.8975056" />
     </filter>
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3600-8"
-       id="linearGradient3606-8"
-       x1="51.037281"
-       y1="47.692612"
-       x2="14.872466"
+       gradientUnits="userSpaceOnUse"
        y2="10.397644"
-       gradientUnits="userSpaceOnUse" />
+       x2="14.872466"
+       y1="47.692612"
+       x1="51.037281"
+       id="linearGradient3606-8"
+       xlink:href="#linearGradient3600-8" />
     <linearGradient
        id="linearGradient3600-8">
       <stop
-         style="stop-color:#204a87;stop-opacity:1"
+         id="stop3602-2"
          offset="0"
-         id="stop3602-2" />
+         style="stop-color:#204a87;stop-opacity:1" />
       <stop
-         style="stop-color:#729fcf;stop-opacity:1"
+         id="stop3604-45"
          offset="1"
-         id="stop3604-45" />
+         style="stop-color:#729fcf;stop-opacity:1" />
     </linearGradient>
     <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3976"
-       id="radialGradient3982"
-       cx="10.691192"
-       cy="19.289801"
-       fx="10.691192"
-       fy="19.289801"
-       r="10.454545"
+       gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(1.5657532,0.0370859,-0.05881345,0.89447218,-5.0994254,1.9283753)"
-       gradientUnits="userSpaceOnUse" />
+       r="10.454545"
+       fy="19.289801"
+       fx="10.691192"
+       cy="19.289801"
+       cx="10.691192"
+       id="radialGradient3982"
+       xlink:href="#linearGradient3976" />
   </defs>
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageopacity="0.0"
-     inkscape:pageshadow="2"
-     inkscape:zoom="5.3702827"
-     inkscape:cx="21.866468"
-     inkscape:cy="15.81839"
-     inkscape:current-layer="layer1"
-     showgrid="true"
-     inkscape:document-units="px"
-     inkscape:grid-bbox="true"
-     inkscape:window-width="1600"
-     inkscape:window-height="873"
-     inkscape:window-x="0"
-     inkscape:window-y="27"
-     inkscape:window-maximized="1"
-     inkscape:snap-bbox="true"
-     inkscape:snap-nodes="false">
-    <inkscape:grid
-       type="xygrid"
-       id="grid3875"
-       empspacing="2"
-       visible="true"
-       enabled="true"
-       snapvisiblegridlinesonly="true" />
-  </sodipodi:namedview>
   <metadata
      id="metadata2821">
     <rdf:RDF>
@@ -219,7 +147,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
+        <dc:title></dc:title>
         <dc:creator>
           <cc:Agent>
             <dc:title>$committer</dc:title>
@@ -249,58 +177,31 @@
     </rdf:RDF>
   </metadata>
   <g
-     id="layer1"
-     inkscape:label="Layer 1"
-     inkscape:groupmode="layer">
+     id="layer1">
     <path
-       sodipodi:type="arc"
-       style="color:#000000;fill:#000000;fill-opacity:0.65625;fill-rule:evenodd;stroke:none;stroke-width:5;marker:none;visibility:visible;display:inline;overflow:visible;filter:url(#filter3871);enable-background:accumulate"
+       transform="matrix(0.48061681,0,0,0.1201542,24.795032,54.351681)"
+       d="m 57.818182,30.363636 a 26.181818,26.181818 0 1 1 -52.363636,0 26.181818,26.181818 0 1 1 52.363636,0 z"
        id="path2826-8"
-       sodipodi:cx="31.636364"
-       sodipodi:cy="30.363636"
-       sodipodi:rx="26.181818"
-       sodipodi:ry="26.181818"
-       d="m 57.818182,30.363636 a 26.181818,26.181818 0 1 1 -52.363636,0 26.181818,26.181818 0 1 1 52.363636,0 z"
-       transform="matrix(0.48061681,0,0,0.1201542,24.795032,54.351681)" />
+       style="color:#000000;fill:#000000;fill-opacity:0.65625;fill-rule:evenodd;stroke:none;stroke-width:5;marker:none;visibility:visible;display:inline;overflow:visible;filter:url(#filter3871);enable-background:accumulate" />
     <path
-       sodipodi:type="arc"
-       style="color:#000000;fill:url(#linearGradient3606);fill-opacity:1;fill-rule:evenodd;stroke:#0b1521;stroke-width:1.80564272;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       transform="matrix(1.1076389,0,0,1.1076389,-3.0416672,-1.6319444)"
+       d="m 57.818182,30.363636 a 26.181818,26.181818 0 1 1 -52.363636,0 26.181818,26.181818 0 1 1 52.363636,0 z"
        id="path2826"
-       sodipodi:cx="31.636364"
-       sodipodi:cy="30.363636"
-       sodipodi:rx="26.181818"
-       sodipodi:ry="26.181818"
-       d="m 57.818182,30.363636 a 26.181818,26.181818 0 1 1 -52.363636,0 26.181818,26.181818 0 1 1 52.363636,0 z"
-       transform="matrix(1.1076389,0,0,1.1076389,-3.0416672,-1.6319444)" />
+       style="color:#000000;fill:url(#linearGradient3606);fill-opacity:1;fill-rule:evenodd;stroke:#0b1521;stroke-width:1.80564272;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     <path
-       sodipodi:type="arc"
-       style="color:#000000;fill:none;stroke:#729fcf;stroke-width:1.93939412;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       transform="matrix(1.03125,0,0,1.03125,-0.62500048,0.68750024)"
+       d="m 57.818182,30.363636 a 26.181818,26.181818 0 1 1 -52.363636,0 26.181818,26.181818 0 1 1 52.363636,0 z"
        id="path2826-4"
-       sodipodi:cx="31.636364"
-       sodipodi:cy="30.363636"
-       sodipodi:rx="26.181818"
-       sodipodi:ry="26.181818"
-       d="m 57.818182,30.363636 a 26.181818,26.181818 0 1 1 -52.363636,0 26.181818,26.181818 0 1 1 52.363636,0 z"
-       transform="matrix(1.03125,0,0,1.03125,-0.62500048,0.68750024)" />
+       style="color:#000000;fill:none;stroke:#729fcf;stroke-width:1.93939412;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     <path
-       sodipodi:type="arc"
-       style="opacity:0.84482756999999986;color:#000000;fill:url(#radialGradient3982);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:5;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="path3608"
-       sodipodi:cx="11.181818"
-       sodipodi:cy="20.181818"
-       sodipodi:rx="15.936976"
-       sodipodi:ry="13.99132"
+       transform="matrix(0.96671212,-0.81479696,0.79456372,0.99132903,-5.8453394,10.104089)"
        d="m 27.118794,20.181818 a 15.936976,13.99132 0 1 1 -31.8739524,0 15.936976,13.99132 0 1 1 31.8739524,0 z"
-       transform="matrix(0.96671212,-0.81479696,0.79456372,0.99132903,-5.8453394,10.104089)" />
+       id="path3608"
+       style="opacity:0.84482756999999986;color:#000000;fill:url(#radialGradient3982);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:5;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     <path
-       sodipodi:type="arc"
-       style="color:#000000;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#0b1521;stroke-width:1.80564272000000000;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="path2826-5"
-       sodipodi:cx="31.636364"
-       sodipodi:cy="30.363636"
-       sodipodi:rx="26.181818"
-       sodipodi:ry="26.181818"
+       transform="matrix(1.1076389,0,0,1.1076389,-3.0416672,-1.6319442)"
        d="m 57.818182,30.363636 a 26.181818,26.181818 0 1 1 -52.363636,0 26.181818,26.181818 0 1 1 52.363636,0 z"
-       transform="matrix(1.1076389,0,0,1.1076389,-3.0416672,-1.6319442)" />
+       id="path2826-5"
+       style="color:#000000;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#0b1521;stroke-width:1.80564272000000000;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
   </g>
 </svg>

--- a/src/Mod/ReverseEngineering/Gui/Resources/icons/ReverseEngineeringWorkbench.svg
+++ b/src/Mod/ReverseEngineering/Gui/Resources/icons/ReverseEngineeringWorkbench.svg
@@ -1,6 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-
 <svg
    xmlns:dc="http://purl.org/dc/elements/1.1/"
    xmlns:cc="http://creativecommons.org/ns#"
@@ -8,560 +6,265 @@
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="64px"
-   height="64px"
-   id="svg2816"
    version="1.1"
-   inkscape:version="0.48.5 r10040"
-   sodipodi:docname="ReverseEngineeringWorkbench.svg">
+   id="svg2816"
+   height="64px"
+   width="64px">
   <defs
      id="defs2818">
     <linearGradient
-       inkscape:collect="always"
        id="linearGradient3884">
       <stop
-         style="stop-color:#c4a000;stop-opacity:1"
+         id="stop3886"
          offset="0"
-         id="stop3886" />
+         style="stop-color:#c4a000;stop-opacity:1" />
       <stop
-         style="stop-color:#edd400;stop-opacity:1"
+         id="stop3888"
          offset="1"
-         id="stop3888" />
+         style="stop-color:#edd400;stop-opacity:1" />
     </linearGradient>
     <linearGradient
-       inkscape:collect="always"
        id="linearGradient3858">
       <stop
-         style="stop-color:#edd400;stop-opacity:1"
+         id="stop3860"
          offset="0"
-         id="stop3860" />
+         style="stop-color:#edd400;stop-opacity:1" />
       <stop
-         style="stop-color:#fce94f;stop-opacity:1"
+         id="stop3862"
          offset="1"
-         id="stop3862" />
+         style="stop-color:#fce94f;stop-opacity:1" />
     </linearGradient>
     <linearGradient
        id="linearGradient3669">
       <stop
-         style="stop-color:#cc8000;stop-opacity:1;"
+         id="stop3671"
          offset="0"
-         id="stop3671" />
+         style="stop-color:#cc8000;stop-opacity:1;" />
       <stop
-         style="stop-color:#ffed00;stop-opacity:1;"
+         id="stop3673"
          offset="1"
-         id="stop3673" />
+         style="stop-color:#ffed00;stop-opacity:1;" />
     </linearGradient>
     <linearGradient
        id="linearGradient3602">
       <stop
-         style="stop-color:#ff2600;stop-opacity:1;"
+         id="stop3604"
          offset="0"
-         id="stop3604" />
+         style="stop-color:#ff2600;stop-opacity:1;" />
       <stop
-         style="stop-color:#ff5f00;stop-opacity:1;"
+         id="stop3606"
          offset="1"
-         id="stop3606" />
+         style="stop-color:#ff5f00;stop-opacity:1;" />
     </linearGradient>
-    <inkscape:perspective
-       sodipodi:type="inkscape:persp3d"
-       inkscape:vp_x="0 : 32 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_z="64 : 32 : 1"
-       inkscape:persp3d-origin="32 : 21.333333 : 1"
-       id="perspective2824" />
-    <inkscape:perspective
-       id="perspective3618"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3602-7"
-       id="linearGradient3608-5"
-       x1="3.909091"
-       y1="14.363636"
-       x2="24.81818"
+       gradientUnits="userSpaceOnUse"
        y2="14.363636"
-       gradientUnits="userSpaceOnUse" />
+       x2="24.81818"
+       y1="14.363636"
+       x1="3.909091"
+       id="linearGradient3608-5"
+       xlink:href="#linearGradient3602-7" />
     <linearGradient
        id="linearGradient3602-7">
       <stop
-         style="stop-color:#c51900;stop-opacity:1;"
+         id="stop3604-1"
          offset="0"
-         id="stop3604-1" />
+         style="stop-color:#c51900;stop-opacity:1;" />
       <stop
-         style="stop-color:#ff5f00;stop-opacity:1;"
+         id="stop3606-3"
          offset="1"
-         id="stop3606-3" />
+         style="stop-color:#ff5f00;stop-opacity:1;" />
     </linearGradient>
-    <inkscape:perspective
-       id="perspective3677"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3602-5"
-       id="linearGradient3608-1"
-       x1="3.909091"
-       y1="14.363636"
-       x2="24.81818"
+       gradientUnits="userSpaceOnUse"
        y2="14.363636"
-       gradientUnits="userSpaceOnUse" />
+       x2="24.81818"
+       y1="14.363636"
+       x1="3.909091"
+       id="linearGradient3608-1"
+       xlink:href="#linearGradient3602-5" />
     <linearGradient
        id="linearGradient3602-5">
       <stop
-         style="stop-color:#c51900;stop-opacity:1;"
+         id="stop3604-9"
          offset="0"
-         id="stop3604-9" />
+         style="stop-color:#c51900;stop-opacity:1;" />
       <stop
-         style="stop-color:#ff5f00;stop-opacity:1;"
+         id="stop3606-9"
          offset="1"
-         id="stop3606-9" />
+         style="stop-color:#ff5f00;stop-opacity:1;" />
     </linearGradient>
     <linearGradient
-       y2="14.363636"
-       x2="24.81818"
-       y1="14.363636"
-       x1="3.909091"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3686"
        xlink:href="#linearGradient3602-5"
-       inkscape:collect="always" />
-    <inkscape:perspective
-       id="perspective3717"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3602-58"
-       id="linearGradient3608-8"
-       x1="3.909091"
-       y1="14.363636"
-       x2="24.81818"
-       y2="14.363636"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       id="linearGradient3602-58">
-      <stop
-         style="stop-color:#c51900;stop-opacity:1;"
-         offset="0"
-         id="stop3604-2" />
-      <stop
-         style="stop-color:#ff5f00;stop-opacity:1;"
-         offset="1"
-         id="stop3606-2" />
-    </linearGradient>
-    <linearGradient
-       y2="14.363636"
-       x2="24.81818"
-       y1="14.363636"
-       x1="3.909091"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3726"
-       xlink:href="#linearGradient3602-58"
-       inkscape:collect="always" />
-    <inkscape:perspective
-       id="perspective4410"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       id="perspective4944"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       id="perspective4966"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       id="perspective5009"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       id="perspective5165"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       id="perspective7581"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       id="perspective7606"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       id="perspective7638"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       id="perspective7660"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       id="perspective7704"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       id="perspective7730"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       id="perspective7762"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       id="perspective7783"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       id="perspective7843"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       id="perspective7881"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       id="perspective7932"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       id="perspective2866"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       id="perspective2878"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <linearGradient
-       id="linearGradient3602-1">
-      <stop
-         style="stop-color:#ff2600;stop-opacity:1;"
-         offset="0"
-         id="stop3604-8" />
-      <stop
-         style="stop-color:#ff5f00;stop-opacity:1;"
-         offset="1"
-         id="stop3606-96" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3602-1"
-       id="linearGradient2875"
+       id="linearGradient3686"
        gradientUnits="userSpaceOnUse"
        x1="3.909091"
        y1="14.363636"
        x2="24.81818"
        y2="14.363636" />
-    <inkscape:perspective
-       id="perspective2885"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="14.363636"
+       x2="24.81818"
+       y1="14.363636"
+       x1="3.909091"
+       id="linearGradient3608-8"
+       xlink:href="#linearGradient3602-58" />
+    <linearGradient
+       id="linearGradient3602-58">
+      <stop
+         id="stop3604-2"
+         offset="0"
+         style="stop-color:#c51900;stop-opacity:1;" />
+      <stop
+         id="stop3606-2"
+         offset="1"
+         style="stop-color:#ff5f00;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3602-58"
+       id="linearGradient3726"
+       gradientUnits="userSpaceOnUse"
+       x1="3.909091"
+       y1="14.363636"
+       x2="24.81818"
+       y2="14.363636" />
+    <linearGradient
+       id="linearGradient3602-1">
+      <stop
+         id="stop3604-8"
+         offset="0"
+         style="stop-color:#ff2600;stop-opacity:1;" />
+      <stop
+         id="stop3606-96"
+         offset="1"
+         style="stop-color:#ff5f00;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="14.363636"
+       x2="24.81818"
+       y1="14.363636"
+       x1="3.909091"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient2875"
+       xlink:href="#linearGradient3602-1" />
     <linearGradient
        id="linearGradient3602-1-5">
       <stop
-         style="stop-color:#ff2600;stop-opacity:1;"
+         id="stop3604-8-3"
          offset="0"
-         id="stop3604-8-3" />
+         style="stop-color:#ff2600;stop-opacity:1;" />
       <stop
-         style="stop-color:#ff5f00;stop-opacity:1;"
+         id="stop3606-96-8"
          offset="1"
-         id="stop3606-96-8" />
+         style="stop-color:#ff5f00;stop-opacity:1;" />
     </linearGradient>
-    <inkscape:perspective
-       id="perspective3720"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
     <linearGradient
        id="linearGradient3602-1-8">
       <stop
-         style="stop-color:#ff2600;stop-opacity:1;"
+         id="stop3604-8-5"
          offset="0"
-         id="stop3604-8-5" />
+         style="stop-color:#ff2600;stop-opacity:1;" />
       <stop
-         style="stop-color:#ff5f00;stop-opacity:1;"
+         id="stop3606-96-2"
          offset="1"
-         id="stop3606-96-2" />
+         style="stop-color:#ff5f00;stop-opacity:1;" />
     </linearGradient>
-    <inkscape:perspective
-       id="perspective3822"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       id="perspective3849"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       id="perspective3879"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       id="perspective2896"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       id="perspective2925"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       id="perspective2925-4"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <inkscape:perspective
-       id="perspective3726"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3669"
-       id="linearGradient3675"
-       x1="81.897568"
-       y1="17.729464"
-       x2="3.0457773"
-       y2="17.729464"
+       gradientTransform="matrix(0.73872768,0,0,1.3536788,-23.287951,-10.010092)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.73872768,0,0,1.3536788,-23.287951,-10.010092)" />
-    <inkscape:perspective
-       id="perspective3689"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
+       y2="17.729464"
+       x2="3.0457773"
+       y1="17.729464"
+       x1="81.897568"
+       id="linearGradient3675"
+       xlink:href="#linearGradient3669" />
     <linearGradient
        id="linearGradient3669-2">
       <stop
-         style="stop-color:#af7d00;stop-opacity:1;"
+         id="stop3671-7"
          offset="0"
-         id="stop3671-7" />
+         style="stop-color:#af7d00;stop-opacity:1;" />
       <stop
-         style="stop-color:#ffed00;stop-opacity:1;"
+         id="stop3673-5"
          offset="1"
-         id="stop3673-5" />
+         style="stop-color:#ffed00;stop-opacity:1;" />
     </linearGradient>
     <linearGradient
-       gradientTransform="matrix(0.73872768,0,0,1.3536788,-2.25,-1.9999999)"
-       y2="1.8468192"
-       x2="48.259949"
-       y1="33.61211"
-       x1="34.290413"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3698"
        xlink:href="#linearGradient3669-2"
-       inkscape:collect="always" />
-    <inkscape:perspective
-       id="perspective3689-6"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3669-22"
-       id="linearGradient3675-0"
-       x1="30.896446"
-       y1="27.685659"
-       x2="53.125"
-       y2="5.124999"
+       id="linearGradient3698"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-23.818281,-9.4797617)" />
+       x1="34.290413"
+       y1="33.61211"
+       x2="48.259949"
+       y2="1.8468192"
+       gradientTransform="matrix(0.73872768,0,0,1.3536788,-2.25,-1.9999999)" />
+    <linearGradient
+       gradientTransform="translate(-23.818281,-9.4797617)"
+       gradientUnits="userSpaceOnUse"
+       y2="5.124999"
+       x2="53.125"
+       y1="27.685659"
+       x1="30.896446"
+       id="linearGradient3675-0"
+       xlink:href="#linearGradient3669-22" />
     <linearGradient
        id="linearGradient3669-22">
       <stop
-         style="stop-color:#af7d00;stop-opacity:1;"
+         id="stop3671-8"
          offset="0"
-         id="stop3671-8" />
+         style="stop-color:#af7d00;stop-opacity:1;" />
       <stop
-         style="stop-color:#ffed00;stop-opacity:1;"
+         id="stop3673-4"
          offset="1"
-         id="stop3673-4" />
+         style="stop-color:#ffed00;stop-opacity:1;" />
     </linearGradient>
     <linearGradient
-       gradientTransform="matrix(0.73872768,0,0,1.3536788,-2.25,-1.9999999)"
-       y2="1.8468192"
-       x2="48.259949"
-       y1="33.61211"
-       x1="34.290413"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3698-3"
        xlink:href="#linearGradient3669-22"
-       inkscape:collect="always" />
-    <inkscape:perspective
-       id="perspective3689-1"
-       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
-       inkscape:vp_z="1 : 0.5 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_x="0 : 0.5 : 1"
-       sodipodi:type="inkscape:persp3d" />
+       id="linearGradient3698-3"
+       gradientUnits="userSpaceOnUse"
+       x1="34.290413"
+       y1="33.61211"
+       x2="48.259949"
+       y2="1.8468192"
+       gradientTransform="matrix(0.73872768,0,0,1.3536788,-2.25,-1.9999999)" />
     <linearGradient
        id="linearGradient3669-0">
       <stop
-         style="stop-color:#af7d00;stop-opacity:1;"
+         id="stop3671-9"
          offset="0"
-         id="stop3671-9" />
+         style="stop-color:#af7d00;stop-opacity:1;" />
       <stop
-         style="stop-color:#ffed00;stop-opacity:1;"
+         id="stop3673-1"
          offset="1"
-         id="stop3673-1" />
+         style="stop-color:#ffed00;stop-opacity:1;" />
     </linearGradient>
     <linearGradient
-       gradientTransform="matrix(0.73872768,0,0,1.3536788,-2.25,-1.9999999)"
-       y2="1.8468192"
-       x2="48.259949"
-       y1="33.61211"
-       x1="34.290413"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3698-9"
        xlink:href="#linearGradient3669-0"
-       inkscape:collect="always" />
+       id="linearGradient3698-9"
+       gradientUnits="userSpaceOnUse"
+       x1="34.290413"
+       y1="33.61211"
+       x2="48.259949"
+       y2="1.8468192"
+       gradientTransform="matrix(0.73872768,0,0,1.3536788,-2.25,-1.9999999)" />
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3858"
-       id="linearGradient3864"
-       x1="20"
-       y1="57"
-       x2="16"
+       gradientUnits="userSpaceOnUse"
        y2="33"
-       gradientUnits="userSpaceOnUse" />
+       x2="16"
+       y1="57"
+       x1="20"
+       id="linearGradient3864"
+       xlink:href="#linearGradient3858" />
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3884"
-       id="linearGradient3890"
-       x1="50.11961"
-       y1="38.894291"
-       x2="45.327534"
+       gradientUnits="userSpaceOnUse"
        y2="21.83534"
-       gradientUnits="userSpaceOnUse" />
+       x2="45.327534"
+       y1="38.894291"
+       x1="50.11961"
+       id="linearGradient3890"
+       xlink:href="#linearGradient3884" />
   </defs>
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageopacity="0.0"
-     inkscape:pageshadow="2"
-     inkscape:zoom="11.313708"
-     inkscape:cx="6.454727"
-     inkscape:cy="34.502991"
-     inkscape:current-layer="layer1"
-     showgrid="true"
-     inkscape:document-units="px"
-     inkscape:grid-bbox="true"
-     inkscape:window-width="1920"
-     inkscape:window-height="1057"
-     inkscape:window-x="1912"
-     inkscape:window-y="-8"
-     inkscape:window-maximized="1"
-     inkscape:snap-bbox="false"
-     inkscape:bbox-paths="true"
-     inkscape:bbox-nodes="true"
-     inkscape:snap-bbox-edge-midpoints="true"
-     inkscape:snap-bbox-midpoints="true"
-     inkscape:object-paths="true"
-     inkscape:snap-intersection-paths="true"
-     inkscape:object-nodes="true"
-     inkscape:snap-smooth-nodes="true"
-     inkscape:snap-midpoints="true"
-     inkscape:snap-global="false">
-    <inkscape:grid
-       type="xygrid"
-       id="grid3064"
-       empspacing="2"
-       visible="true"
-       enabled="true"
-       snapvisiblegridlinesonly="true" />
-  </sodipodi:namedview>
   <metadata
      id="metadata2821">
     <rdf:RDF>
@@ -570,43 +273,37 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
+        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <g
-     id="layer1"
-     inkscape:label="Layer 1"
-     inkscape:groupmode="layer">
+     id="layer1">
     <rect
-       style="fill:url(#linearGradient3864);fill-opacity:1;stroke:#302b00;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:58.79999923999999800;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:2.04000000000000000"
-       id="rect3066"
-       width="28"
-       height="28"
+       y="31"
        x="5"
-       y="31" />
+       height="28"
+       width="28"
+       id="rect3066"
+       style="fill:url(#linearGradient3864);fill-opacity:1;stroke:#302b00;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:58.79999923999999800;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:2.04000000000000000" />
     <path
-       style="fill:#fce94f;stroke:#302b00;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1"
-       d="M 5,31 33,5 59,5 33,31 z"
        id="path3836"
-       inkscape:connector-curvature="0" />
+       d="M 5,31 33,5 59,5 33,31 z"
+       style="fill:#fce94f;stroke:#302b00;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1" />
     <path
-       style="fill:url(#linearGradient3890);stroke:#302b00;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1;fill-opacity:1"
-       d="M 59,5 59,31 33,59 33,31 z"
        id="path3838"
-       inkscape:connector-curvature="0" />
+       d="M 59,5 59,31 33,59 33,31 z"
+       style="fill:url(#linearGradient3890);stroke:#302b00;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1;fill-opacity:1" />
     <rect
-       style="fill:none;fill-opacity:1;stroke:#fce94f;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:58.79999923999999800;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:2.04000000000000000"
-       id="rect3066-1"
-       width="24"
-       height="24"
+       y="33"
        x="7"
-       y="33" />
+       height="24"
+       width="24"
+       id="rect3066-1"
+       style="fill:none;fill-opacity:1;stroke:#fce94f;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:58.79999923999999800;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:2.04000000000000000" />
     <path
-       style="fill:none;stroke:#edd400;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       d="M 56.984375,9.859375 56.96875,30.203125 35.015625,53.890625 35,31.875 z"
        id="path3838-7"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="ccccc" />
+       d="M 56.984375,9.859375 56.96875,30.203125 35.015625,53.890625 35,31.875 z"
+       style="fill:none;stroke:#edd400;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
   </g>
 </svg>

--- a/src/Mod/Robot/Gui/Resources/icons/RobotWorkbench.svg
+++ b/src/Mod/Robot/Gui/Resources/icons/RobotWorkbench.svg
@@ -1,50 +1,138 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-<svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" width="64px" height="64px" id="svg5821" sodipodi:version="0.32" inkscape:version="0.48.5 r10040" sodipodi:docname="RobotWorkbench.svg" inkscape:output_extension="org.inkscape.output.svg.inkscape" version="1.1">
-  <defs id="defs5823">
-    <linearGradient inkscape:collect="always" id="linearGradient3861">
-      <stop style="stop-color:#d3d7cf;stop-opacity:1;" offset="0" id="stop3863"/>
-      <stop style="stop-color:#ffffff;stop-opacity:1" offset="1" id="stop3865"/>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   version="1.1"
+   id="svg5821"
+   height="64px"
+   width="64px">
+  <defs
+     id="defs5823">
+    <linearGradient
+       id="linearGradient3861">
+      <stop
+         id="stop3863"
+         offset="0"
+         style="stop-color:#d3d7cf;stop-opacity:1;" />
+      <stop
+         id="stop3865"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:1" />
     </linearGradient>
-    <linearGradient inkscape:collect="always" id="linearGradient3835">
-      <stop style="stop-color:#d3d7cf;stop-opacity:1;" offset="0" id="stop3837"/>
-      <stop style="stop-color:#888a85;stop-opacity:1" offset="1" id="stop3839"/>
+    <linearGradient
+       id="linearGradient3835">
+      <stop
+         id="stop3837"
+         offset="0"
+         style="stop-color:#d3d7cf;stop-opacity:1;" />
+      <stop
+         id="stop3839"
+         offset="1"
+         style="stop-color:#888a85;stop-opacity:1" />
     </linearGradient>
-    <linearGradient inkscape:collect="always" id="linearGradient3809">
-      <stop style="stop-color:#d3d7cf;stop-opacity:1;" offset="0" id="stop3811"/>
-      <stop style="stop-color:#ffffff;stop-opacity:1" offset="1" id="stop3813"/>
+    <linearGradient
+       id="linearGradient3809">
+      <stop
+         id="stop3811"
+         offset="0"
+         style="stop-color:#d3d7cf;stop-opacity:1;" />
+      <stop
+         id="stop3813"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:1" />
     </linearGradient>
-    <linearGradient id="linearGradient3377">
-      <stop style="stop-color:#ffaa00;stop-opacity:1;" offset="0" id="stop3379"/>
-      <stop style="stop-color:#faff2b;stop-opacity:1;" offset="1" id="stop3381"/>
+    <linearGradient
+       id="linearGradient3377">
+      <stop
+         id="stop3379"
+         offset="0"
+         style="stop-color:#ffaa00;stop-opacity:1;" />
+      <stop
+         id="stop3381"
+         offset="1"
+         style="stop-color:#faff2b;stop-opacity:1;" />
     </linearGradient>
-    <inkscape:perspective sodipodi:type="inkscape:persp3d" inkscape:vp_x="0 : 32 : 1" inkscape:vp_y="0 : 1000 : 0" inkscape:vp_z="64 : 32 : 1" inkscape:persp3d-origin="32 : 21.333333 : 1" id="perspective5829"/>
-    <inkscape:perspective id="perspective3607" inkscape:persp3d-origin="0.5 : 0.33333333 : 1" inkscape:vp_z="1 : 0.5 : 1" inkscape:vp_y="0 : 1000 : 0" inkscape:vp_x="0 : 0.5 : 1" sodipodi:type="inkscape:persp3d"/>
-    <linearGradient id="linearGradient3377-2">
-      <stop style="stop-color:#ffaa00;stop-opacity:1;" offset="0" id="stop3379-6"/>
-      <stop style="stop-color:#faff2b;stop-opacity:1;" offset="1" id="stop3381-7"/>
+    <linearGradient
+       id="linearGradient3377-2">
+      <stop
+         id="stop3379-6"
+         offset="0"
+         style="stop-color:#ffaa00;stop-opacity:1;" />
+      <stop
+         id="stop3381-7"
+         offset="1"
+         style="stop-color:#faff2b;stop-opacity:1;" />
     </linearGradient>
-    <linearGradient gradientTransform="matrix(0.1367863,0,0,0.1367863,-122.45404,-135.82061)" y2="1190.875" x2="1267.9062" y1="1190.875" x1="901.1875" gradientUnits="userSpaceOnUse" id="linearGradient3616" xlink:href="#linearGradient3377-2" inkscape:collect="always"/>
-    <inkscape:perspective id="perspective3607-8" inkscape:persp3d-origin="0.5 : 0.33333333 : 1" inkscape:vp_z="1 : 0.5 : 1" inkscape:vp_y="0 : 1000 : 0" inkscape:vp_x="0 : 0.5 : 1" sodipodi:type="inkscape:persp3d"/>
-    <linearGradient id="linearGradient3377-28">
-      <stop style="stop-color:#ffaa00;stop-opacity:1;" offset="0" id="stop3379-2"/>
-      <stop style="stop-color:#faff2b;stop-opacity:1;" offset="1" id="stop3381-9"/>
+    <linearGradient
+       xlink:href="#linearGradient3377-2"
+       id="linearGradient3616"
+       gradientUnits="userSpaceOnUse"
+       x1="901.1875"
+       y1="1190.875"
+       x2="1267.9062"
+       y2="1190.875"
+       gradientTransform="matrix(0.1367863,0,0,0.1367863,-122.45404,-135.82061)" />
+    <linearGradient
+       id="linearGradient3377-28">
+      <stop
+         id="stop3379-2"
+         offset="0"
+         style="stop-color:#ffaa00;stop-opacity:1;" />
+      <stop
+         id="stop3381-9"
+         offset="1"
+         style="stop-color:#faff2b;stop-opacity:1;" />
     </linearGradient>
-    <linearGradient gradientTransform="matrix(0.1367863,0,0,0.1367863,-122.45404,-135.82061)" y2="1190.875" x2="1267.9062" y1="1190.875" x1="901.1875" gradientUnits="userSpaceOnUse" id="linearGradient3616-9" xlink:href="#linearGradient3377-28" inkscape:collect="always"/>
-    <inkscape:perspective id="perspective3691" inkscape:persp3d-origin="0.5 : 0.33333333 : 1" inkscape:vp_z="1 : 0.5 : 1" inkscape:vp_y="0 : 1000 : 0" inkscape:vp_x="0 : 0.5 : 1" sodipodi:type="inkscape:persp3d"/>
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient3809" id="linearGradient3815" x1="1119.6676" y1="1410.0068" x2="1105.0463" y2="1278.4147" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.92592581,0,0,0.80000035,81.855382,268.84175)"/>
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient3835" id="linearGradient3841" x1="1097.7356" y1="1234.5507" x2="1097.7356" y2="1219.9293" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1,0,0,1.9999971,0,-1227.2365)"/>
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient3861" id="linearGradient3867" x1="1119.6676" y1="1176.0653" x2="1105.0463" y2="1029.8518" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.95238128,0,0,0.92307683,52.620955,84.843064)"/>
+    <linearGradient
+       xlink:href="#linearGradient3377-28"
+       id="linearGradient3616-9"
+       gradientUnits="userSpaceOnUse"
+       x1="901.1875"
+       y1="1190.875"
+       x2="1267.9062"
+       y2="1190.875"
+       gradientTransform="matrix(0.1367863,0,0,0.1367863,-122.45404,-135.82061)" />
+    <linearGradient
+       gradientTransform="matrix(0.92592581,0,0,0.80000035,81.855382,268.84175)"
+       gradientUnits="userSpaceOnUse"
+       y2="1278.4147"
+       x2="1105.0463"
+       y1="1410.0068"
+       x1="1119.6676"
+       id="linearGradient3815"
+       xlink:href="#linearGradient3809" />
+    <linearGradient
+       gradientTransform="matrix(1,0,0,1.9999971,0,-1227.2365)"
+       gradientUnits="userSpaceOnUse"
+       y2="1219.9293"
+       x2="1097.7356"
+       y1="1234.5507"
+       x1="1097.7356"
+       id="linearGradient3841"
+       xlink:href="#linearGradient3835" />
+    <linearGradient
+       gradientTransform="matrix(0.95238128,0,0,0.92307683,52.620955,84.843064)"
+       gradientUnits="userSpaceOnUse"
+       y2="1029.8518"
+       x2="1105.0463"
+       y1="1176.0653"
+       x1="1119.6676"
+       id="linearGradient3867"
+       xlink:href="#linearGradient3861" />
   </defs>
-  <sodipodi:namedview id="base" pagecolor="#ffffff" bordercolor="#666666" borderopacity="1.0" inkscape:pageopacity="0.0" inkscape:pageshadow="2" inkscape:zoom="11" inkscape:cx="28.624877" inkscape:cy="30.300001" inkscape:current-layer="g3360" showgrid="true" inkscape:document-units="px" inkscape:grid-bbox="true" inkscape:window-width="800" inkscape:window-height="834" inkscape:window-x="0" inkscape:window-y="27" inkscape:window-maximized="0" inkscape:snap-bbox="true" inkscape:snap-nodes="false">
-    <inkscape:grid type="xygrid" id="grid3003" empspacing="2" visible="true" enabled="true" snapvisiblegridlinesonly="true"/>
-  </sodipodi:namedview>
-  <metadata id="metadata5826">
+  <metadata
+     id="metadata5826">
     <rdf:RDF>
-      <cc:Work rdf:about="">
+      <cc:Work
+         rdf:about="">
         <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-        <dc:title/>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
         <dc:creator>
           <cc:Agent>
             <dc:title>[triplus]</dc:title>
@@ -73,18 +161,73 @@
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <g id="layer1" inkscape:label="Layer 1" inkscape:groupmode="layer">
-    <g id="g3360" inkscape:export-filename="/home/yorik/Documents/Lab/Draft/icons/draft.png" inkscape:export-xdpi="3.2478156" inkscape:export-ydpi="3.2478156" transform="matrix(0.1367863,0,0,0.1367863,-119.15519,-134.86962)">
-      <rect style="color:#000000;fill:#d3d7cf;fill-opacity:1;fill-rule:evenodd;stroke:#2e3436;stroke-width:14.62135029000000053;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" id="rect3679" width="160.83475" height="58.485413" x="1024.6289" y="1197.9973"/>
-      <rect style="color:#000000;fill:url(#linearGradient3841);fill-opacity:1;fill-rule:evenodd;stroke:#d3d7cf;stroke-width:14.62134743;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" id="rect3679-7" width="131.59204" height="58.485386" x="1039.2502" y="1197.9973"/>
-      <rect style="color:#000000;fill:url(#linearGradient3867);fill-opacity:1;fill-rule:evenodd;stroke:#2e3436;stroke-width:29.24269463;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" id="rect3675" width="292.42697" height="175.45612" x="958.83276" y="1015.2305"/>
-      <rect style="color:#000000;fill:#d3d7cf;fill-opacity:1;fill-rule:evenodd;stroke:#2e3436;stroke-width:29.24269485;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" id="rect3677" width="409.39771" height="160.83482" x="900.34741" y="1263.7933"/>
-      <path sodipodi:type="arc" style="color:#000000;fill:#d3d7cf;fill-opacity:1;fill-rule:evenodd;stroke:#2e3436;stroke-width:1.81818163;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" id="path3681-6-3" sodipodi:cx="21.636364" sodipodi:cy="16.181818" sodipodi:rx="3.6363637" sodipodi:ry="3.6363637" d="m 25.272728,16.181818 a 3.6363637,3.6363637 0 1 1 -7.272728,0 3.6363637,3.6363637 0 1 1 7.272728,0 z" transform="matrix(8.0417438,0,0,8.0417413,865.2561,965.51789)"/>
-      <rect style="color:#000000;fill:url(#linearGradient3815);fill-opacity:1;fill-rule:evenodd;stroke:#ffffff;stroke-width:14.62134743;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" id="rect3677-6" width="365.53369" height="116.97083" x="922.27942" y="1285.7253"/>
-      <rect style="color:#000000;fill:none;stroke:#ffffff;stroke-width:14.62134743;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" id="rect3675-5" width="248.56291" height="131.59213" x="980.76483" y="1037.1625"/>
-      <path sodipodi:type="arc" style="color:#000000;fill:#888a85;fill-opacity:1;fill-rule:evenodd;stroke:#ffffff;stroke-width:3.63636159999999986;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" id="path3681-6-3-3" sodipodi:cx="21.636364" sodipodi:cy="16.181818" sodipodi:rx="3.6363637" sodipodi:ry="3.6363637" d="m 25.272728,16.181818 a 3.6363637,3.6363637 0 1 1 -7.272728,0 3.6363637,3.6363637 0 1 1 7.272728,0 z" transform="matrix(4.0208701,0,0,4.0208758,952.25319,1030.5828)"/>
-      <path sodipodi:type="arc" style="color:#000000;fill:#d3d7cf;fill-opacity:1;fill-rule:evenodd;stroke:#2e3436;stroke-width:1.81818163;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" id="path3681-6-3-5" sodipodi:cx="21.636364" sodipodi:cy="16.181818" sodipodi:rx="3.6363637" sodipodi:ry="3.6363637" d="m 25.272728,16.181818 a 3.6363637,3.6363637 0 1 1 -7.272728,0 3.6363637,3.6363637 0 1 1 7.272728,0 z" transform="matrix(8.0417439,0,0,8.041741,996.84825,965.51789)"/>
-      <path sodipodi:type="arc" style="color:#000000;fill:#888a85;fill-opacity:1;fill-rule:evenodd;stroke:#ffffff;stroke-width:3.6363616;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" id="path3681-6-3-3-6" sodipodi:cx="21.636364" sodipodi:cy="16.181818" sodipodi:rx="3.6363637" sodipodi:ry="3.6363637" d="m 25.272728,16.181818 a 3.6363637,3.6363637 0 1 1 -7.272728,0 3.6363637,3.6363637 0 1 1 7.272728,0 z" transform="matrix(4.0208701,0,0,4.0208758,1083.8454,1030.5828)"/>
+  <g
+     id="layer1">
+    <g
+       transform="matrix(0.1367863,0,0,0.1367863,-119.15519,-134.86962)"
+       id="g3360">
+      <rect
+         y="1197.9973"
+         x="1024.6289"
+         height="58.485413"
+         width="160.83475"
+         id="rect3679"
+         style="color:#000000;fill:#d3d7cf;fill-opacity:1;fill-rule:evenodd;stroke:#2e3436;stroke-width:14.62135029000000053;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+      <rect
+         y="1197.9973"
+         x="1039.2502"
+         height="58.485386"
+         width="131.59204"
+         id="rect3679-7"
+         style="color:#000000;fill:url(#linearGradient3841);fill-opacity:1;fill-rule:evenodd;stroke:#d3d7cf;stroke-width:14.62134743;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+      <rect
+         y="1015.2305"
+         x="958.83276"
+         height="175.45612"
+         width="292.42697"
+         id="rect3675"
+         style="color:#000000;fill:url(#linearGradient3867);fill-opacity:1;fill-rule:evenodd;stroke:#2e3436;stroke-width:29.24269463;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+      <rect
+         y="1263.7933"
+         x="900.34741"
+         height="160.83482"
+         width="409.39771"
+         id="rect3677"
+         style="color:#000000;fill:#d3d7cf;fill-opacity:1;fill-rule:evenodd;stroke:#2e3436;stroke-width:29.24269485;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+      <path
+         transform="matrix(8.0417438,0,0,8.0417413,865.2561,965.51789)"
+         d="m 25.272728,16.181818 a 3.6363637,3.6363637 0 1 1 -7.272728,0 3.6363637,3.6363637 0 1 1 7.272728,0 z"
+         id="path3681-6-3"
+         style="color:#000000;fill:#d3d7cf;fill-opacity:1;fill-rule:evenodd;stroke:#2e3436;stroke-width:1.81818163;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+      <rect
+         y="1285.7253"
+         x="922.27942"
+         height="116.97083"
+         width="365.53369"
+         id="rect3677-6"
+         style="color:#000000;fill:url(#linearGradient3815);fill-opacity:1;fill-rule:evenodd;stroke:#ffffff;stroke-width:14.62134743;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+      <rect
+         y="1037.1625"
+         x="980.76483"
+         height="131.59213"
+         width="248.56291"
+         id="rect3675-5"
+         style="color:#000000;fill:none;stroke:#ffffff;stroke-width:14.62134743;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+      <path
+         transform="matrix(4.0208701,0,0,4.0208758,952.25319,1030.5828)"
+         d="m 25.272728,16.181818 a 3.6363637,3.6363637 0 1 1 -7.272728,0 3.6363637,3.6363637 0 1 1 7.272728,0 z"
+         id="path3681-6-3-3"
+         style="color:#000000;fill:#888a85;fill-opacity:1;fill-rule:evenodd;stroke:#ffffff;stroke-width:3.63636159999999986;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+      <path
+         transform="matrix(8.0417439,0,0,8.041741,996.84825,965.51789)"
+         d="m 25.272728,16.181818 a 3.6363637,3.6363637 0 1 1 -7.272728,0 3.6363637,3.6363637 0 1 1 7.272728,0 z"
+         id="path3681-6-3-5"
+         style="color:#000000;fill:#d3d7cf;fill-opacity:1;fill-rule:evenodd;stroke:#2e3436;stroke-width:1.81818163;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+      <path
+         transform="matrix(4.0208701,0,0,4.0208758,1083.8454,1030.5828)"
+         d="m 25.272728,16.181818 a 3.6363637,3.6363637 0 1 1 -7.272728,0 3.6363637,3.6363637 0 1 1 7.272728,0 z"
+         id="path3681-6-3-3-6"
+         style="color:#000000;fill:#888a85;fill-opacity:1;fill-rule:evenodd;stroke:#ffffff;stroke-width:3.6363616;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
   </g>
 </svg>

--- a/src/Mod/Sketcher/Gui/Resources/icons/SketcherWorkbench.svg
+++ b/src/Mod/Sketcher/Gui/Resources/icons/SketcherWorkbench.svg
@@ -1,6 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-
 <svg
    xmlns:dc="http://purl.org/dc/elements/1.1/"
    xmlns:cc="http://creativecommons.org/ns#"
@@ -8,102 +6,54 @@
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="64px"
-   height="64px"
-   id="svg5821"
-   sodipodi:version="0.32"
-   inkscape:version="0.48.5 r10040"
-   sodipodi:docname="SketcherWorkbench.svg"
-   inkscape:output_extension="org.inkscape.output.svg.inkscape"
    version="1.1"
-   inkscape:export-filename="/media/data/Yorik/FreeCAD/icons/Sketcher.png"
-   inkscape:export-xdpi="45"
-   inkscape:export-ydpi="45">
+   id="svg5821"
+   height="64px"
+   width="64px">
   <defs
      id="defs5823">
     <linearGradient
-       inkscape:collect="always"
        id="linearGradient6349">
       <stop
-         style="stop-color:#000000;stop-opacity:1;"
+         id="stop6351"
          offset="0"
-         id="stop6351" />
+         style="stop-color:#000000;stop-opacity:1;" />
       <stop
-         style="stop-color:#000000;stop-opacity:0;"
+         id="stop6353"
          offset="1"
-         id="stop6353" />
+         style="stop-color:#000000;stop-opacity:0;" />
     </linearGradient>
     <linearGradient
        id="linearGradient3377">
       <stop
-         style="stop-color:#0019a3;stop-opacity:1;"
+         id="stop3379"
          offset="0"
-         id="stop3379" />
+         style="stop-color:#0019a3;stop-opacity:1;" />
       <stop
-         style="stop-color:#0069ff;stop-opacity:1;"
+         id="stop3381"
          offset="1"
-         id="stop3381" />
+         style="stop-color:#0069ff;stop-opacity:1;" />
     </linearGradient>
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3377"
-       id="linearGradient3383"
-       x1="901.1875"
-       y1="1190.875"
-       x2="1267.9062"
-       y2="1190.875"
+       gradientTransform="matrix(-1,0,0,1,2199.356,0)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-1,0,0,1,2199.356,0)" />
-    <inkscape:perspective
-       sodipodi:type="inkscape:persp3d"
-       inkscape:vp_x="0 : 32 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_z="64 : 32 : 1"
-       inkscape:persp3d-origin="32 : 21.333333 : 1"
-       id="perspective5829" />
+       y2="1190.875"
+       x2="1267.9062"
+       y1="1190.875"
+       x1="901.1875"
+       id="linearGradient3383"
+       xlink:href="#linearGradient3377" />
     <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient6349"
-       id="radialGradient6355"
-       cx="1103.6399"
-       cy="1424.4465"
-       fx="1103.6399"
-       fy="1424.4465"
-       r="194.40614"
+       gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(-1.4307499,-1.3605156e-7,-1.202713e-8,0.1264801,2674.7488,1244.2826)"
-       gradientUnits="userSpaceOnUse" />
+       r="194.40614"
+       fy="1424.4465"
+       fx="1103.6399"
+       cy="1424.4465"
+       cx="1103.6399"
+       id="radialGradient6355"
+       xlink:href="#linearGradient6349" />
   </defs>
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageopacity="0.0"
-     inkscape:pageshadow="2"
-     inkscape:zoom="19.413946"
-     inkscape:cx="34.073937"
-     inkscape:cy="31.897146"
-     inkscape:current-layer="g3360"
-     showgrid="true"
-     inkscape:document-units="px"
-     inkscape:grid-bbox="true"
-     inkscape:window-width="1600"
-     inkscape:window-height="873"
-     inkscape:window-x="0"
-     inkscape:window-y="27"
-     inkscape:window-maximized="1"
-     inkscape:snap-bbox="false"
-     inkscape:snap-nodes="true">
-    <inkscape:grid
-       type="xygrid"
-       id="grid2997"
-       empspacing="2"
-       visible="true"
-       enabled="true"
-       snapvisiblegridlinesonly="true" />
-  </sodipodi:namedview>
   <metadata
      id="metadata5826">
     <rdf:RDF>
@@ -112,7 +62,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
+        <dc:title></dc:title>
         <dc:creator>
           <cc:Agent>
             <dc:title>[triplus]</dc:title>
@@ -142,49 +92,34 @@
     </rdf:RDF>
   </metadata>
   <g
-     id="layer1"
-     inkscape:label="Layer 1"
-     inkscape:groupmode="layer">
+     id="layer1">
     <g
-       id="g3360"
-       inkscape:export-filename="/home/yorik/Documents/Lab/Draft/icons/draft.png"
-       inkscape:export-xdpi="3.2478156"
-       inkscape:export-ydpi="3.2478156"
-       transform="matrix(0.1367863,0,0,0.1367863,-119.15519,-134.86962)">
+       transform="matrix(0.1367863,0,0,0.1367863,-119.15519,-134.86962)"
+       id="g3360">
       <rect
-         style="color:#000000;fill:none;stroke:#a40000;stroke-width:43.86403656000000240;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         y="1168.7546"
+         x="907.65808"
+         height="248.5629"
+         width="277.8056"
          id="rect3860-36"
-         width="277.8056"
-         height="248.5629"
-         x="907.65808"
-         y="1168.7546" />
+         style="color:#000000;fill:none;stroke:#a40000;stroke-width:43.86403656000000240;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
       <path
-         sodipodi:type="arc"
-         style="color:#000000;fill:none;stroke:#a40000;stroke-width:5.89896058999999973;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         transform="matrix(7.6396543,0,0,7.2375671,932.95299,913.31967)"
+         d="m 48.363636,33.272728 c 0,10.041541 -8.140277,18.181818 -18.181818,18.181818 C 20.140277,51.454546 12,43.314269 12,33.272728 12,23.231187 20.140277,15.09091 30.181818,15.09091 c 10.041541,0 18.181818,8.140277 18.181818,18.181818 z"
          id="path3862-7"
-         sodipodi:cx="30.181818"
-         sodipodi:cy="33.272728"
-         sodipodi:rx="18.181818"
-         sodipodi:ry="18.181818"
-         d="m 48.363636,33.272728 c 0,10.041541 -8.140277,18.181818 -18.181818,18.181818 C 20.140277,51.454546 12,43.314269 12,33.272728 12,23.231187 20.140277,15.09091 30.181818,15.09091 c 10.041541,0 18.181818,8.140277 18.181818,18.181818 z"
-         transform="matrix(7.6396543,0,0,7.2375671,932.95299,913.31967)" />
+         style="color:#000000;fill:none;stroke:#a40000;stroke-width:5.89896058999999973;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
       <rect
-         style="color:#000000;fill:none;stroke:#ef2929;stroke-width:14.62134743000000014;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         id="rect3860-3"
-         width="277.8056"
-         height="248.5629"
+         y="1168.7546"
          x="907.65808"
-         y="1168.7546" />
+         height="248.5629"
+         width="277.8056"
+         id="rect3860-3"
+         style="color:#000000;fill:none;stroke:#ef2929;stroke-width:14.62134743000000014;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
       <path
-         sodipodi:type="arc"
-         style="color:#000000;fill:none;stroke:#ef2929;stroke-width:1.96632027999999992;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         id="path3862-6"
-         sodipodi:cx="30.181818"
-         sodipodi:cy="33.272728"
-         sodipodi:rx="18.181818"
-         sodipodi:ry="18.181818"
+         transform="matrix(7.6396539,0,0,7.237567,932.95301,913.31967)"
          d="m 48.363636,33.272728 c 0,10.041541 -8.140277,18.181818 -18.181818,18.181818 C 20.140277,51.454546 12,43.314269 12,33.272728 12,23.231187 20.140277,15.09091 30.181818,15.09091 c 10.041541,0 18.181818,8.140277 18.181818,18.181818 z"
-         transform="matrix(7.6396539,0,0,7.237567,932.95301,913.31967)" />
+         id="path3862-6"
+         style="color:#000000;fill:none;stroke:#ef2929;stroke-width:1.96632027999999992;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     </g>
   </g>
 </svg>

--- a/src/Mod/Spreadsheet/Gui/Resources/icons/SpreadsheetWorkbench.svg
+++ b/src/Mod/Spreadsheet/Gui/Resources/icons/SpreadsheetWorkbench.svg
@@ -1,30 +1,87 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-<svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" width="64px" height="64px" id="svg2860" sodipodi:version="0.32" inkscape:version="0.48.5 r10040" sodipodi:docname="Spreadsheet.svg" inkscape:output_extension="org.inkscape.output.svg.inkscape" version="1.1">
-  <defs id="defs2862">
-    <linearGradient inkscape:collect="always" id="linearGradient3783">
-      <stop style="stop-color:#d3d7cf;stop-opacity:1" offset="0" id="stop3785"/>
-      <stop style="stop-color:#ffffff;stop-opacity:1" offset="1" id="stop3787"/>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   version="1.1"
+   id="svg2860"
+   height="64px"
+   width="64px">
+  <defs
+     id="defs2862">
+    <linearGradient
+       id="linearGradient3783">
+      <stop
+         id="stop3785"
+         offset="0"
+         style="stop-color:#d3d7cf;stop-opacity:1" />
+      <stop
+         id="stop3787"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:1" />
     </linearGradient>
-    <radialGradient inkscape:collect="always" xlink:href="#linearGradient3377" id="radialGradient3692" cx="45.883327" cy="28.869568" fx="45.883327" fy="28.869568" r="19.467436" gradientUnits="userSpaceOnUse"/>
-    <radialGradient inkscape:collect="always" xlink:href="#linearGradient3377" id="radialGradient3703" gradientUnits="userSpaceOnUse" cx="135.38333" cy="97.369568" fx="135.38333" fy="97.369568" r="19.467436" gradientTransform="matrix(0.97435,0.2250379,-0.4623105,2.0016728,48.487554,-127.99883)"/>
-    <linearGradient id="linearGradient3377">
-      <stop id="stop3379" offset="0" style="stop-color:#faff2b;stop-opacity:1;"/>
-      <stop id="stop3381" offset="1" style="stop-color:#ffaa00;stop-opacity:1;"/>
+    <radialGradient
+       gradientUnits="userSpaceOnUse"
+       r="19.467436"
+       fy="28.869568"
+       fx="45.883327"
+       cy="28.869568"
+       cx="45.883327"
+       id="radialGradient3692"
+       xlink:href="#linearGradient3377" />
+    <radialGradient
+       gradientTransform="matrix(0.97435,0.2250379,-0.4623105,2.0016728,48.487554,-127.99883)"
+       r="19.467436"
+       fy="97.369568"
+       fx="135.38333"
+       cy="97.369568"
+       cx="135.38333"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3703"
+       xlink:href="#linearGradient3377" />
+    <linearGradient
+       id="linearGradient3377">
+      <stop
+         style="stop-color:#faff2b;stop-opacity:1;"
+         offset="0"
+         id="stop3379" />
+      <stop
+         style="stop-color:#ffaa00;stop-opacity:1;"
+         offset="1"
+         id="stop3381" />
     </linearGradient>
-    <radialGradient inkscape:collect="always" xlink:href="#linearGradient3377" id="radialGradient3705" gradientUnits="userSpaceOnUse" cx="148.88333" cy="81.869568" fx="148.88333" fy="81.869568" r="19.467436" gradientTransform="matrix(1.3852588,-0.05136783,0.03705629,0.9993132,-60.392403,7.7040438)"/>
-    <inkscape:perspective sodipodi:type="inkscape:persp3d" inkscape:vp_x="0 : 32 : 1" inkscape:vp_y="0 : 1000 : 0" inkscape:vp_z="64 : 32 : 1" inkscape:persp3d-origin="32 : 21.333333 : 1" id="perspective2868"/>
-    <linearGradient inkscape:collect="always" xlink:href="#linearGradient3783" id="linearGradient3789" x1="38" y1="58" x2="21" y2="5" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1,0,0,0.77777777,0,5.1111114)"/>
+    <radialGradient
+       gradientTransform="matrix(1.3852588,-0.05136783,0.03705629,0.9993132,-60.392403,7.7040438)"
+       r="19.467436"
+       fy="81.869568"
+       fx="148.88333"
+       cy="81.869568"
+       cx="148.88333"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3705"
+       xlink:href="#linearGradient3377" />
+    <linearGradient
+       gradientTransform="matrix(1,0,0,0.77777777,0,5.1111114)"
+       gradientUnits="userSpaceOnUse"
+       y2="5"
+       x2="21"
+       y1="58"
+       x1="38"
+       id="linearGradient3789"
+       xlink:href="#linearGradient3783" />
   </defs>
-  <sodipodi:namedview id="base" pagecolor="#ffffff" bordercolor="#666666" borderopacity="1.0" inkscape:pageopacity="0.0" inkscape:pageshadow="2" inkscape:zoom="5.0968312" inkscape:cx="-5.5216512" inkscape:cy="40.95075" inkscape:current-layer="layer1" showgrid="true" inkscape:document-units="px" inkscape:grid-bbox="true" inkscape:window-width="1600" inkscape:window-height="837" inkscape:window-x="0" inkscape:window-y="27" inkscape:window-maximized="1">
-    <inkscape:grid type="xygrid" id="grid2995" empspacing="2" visible="true" enabled="true" snapvisiblegridlinesonly="true"/>
-  </sodipodi:namedview>
-  <metadata id="metadata2865">
+  <metadata
+     id="metadata2865">
     <rdf:RDF>
-      <cc:Work rdf:about="">
+      <cc:Work
+         rdf:about="">
         <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-        <dc:title/>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
         <dc:creator>
           <cc:Agent>
             <dc:title>[triplus]</dc:title>
@@ -53,12 +110,37 @@
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <g id="layer1" inkscape:label="Layer 1" inkscape:groupmode="layer">
-    <rect style="color:#000000;fill:#ffffff;stroke:#2e3436;stroke-width:4;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" id="rect3002-9" width="56" height="44" x="4" y="8"/>
-    <rect style="color:#000000;fill:url(#linearGradient3789);fill-opacity:1;stroke:#ffffff;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" id="rect3002-9-3" width="54" height="42" x="5" y="9"/>
-    <path style="fill:none;stroke:#2e3436;stroke-width:4;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" d="m 3,18 58,0" id="path3790" inkscape:connector-curvature="0" sodipodi:nodetypes="cc"/>
-    <path style="fill:none;stroke:#2e3436;stroke-width:3.99999976;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" d="m 22,6 0,48" id="path3792" inkscape:connector-curvature="0" sodipodi:nodetypes="cc"/>
-    <path style="fill:none;stroke:#2e3436;stroke-width:4;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" d="m 3,30 58,0" id="path3794" inkscape:connector-curvature="0" sodipodi:nodetypes="cc"/>
-    <path style="fill:none;stroke:#2e3436;stroke-width:4;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" d="m 3,42 58,0" id="path3796" inkscape:connector-curvature="0" sodipodi:nodetypes="cc"/>
+  <g
+     id="layer1">
+    <rect
+       y="8"
+       x="4"
+       height="44"
+       width="56"
+       id="rect3002-9"
+       style="color:#000000;fill:#ffffff;stroke:#2e3436;stroke-width:4;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    <rect
+       y="9"
+       x="5"
+       height="42"
+       width="54"
+       id="rect3002-9-3"
+       style="color:#000000;fill:url(#linearGradient3789);fill-opacity:1;stroke:#ffffff;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    <path
+       id="path3790"
+       d="m 3,18 58,0"
+       style="fill:none;stroke:#2e3436;stroke-width:4;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+    <path
+       id="path3792"
+       d="m 22,6 0,48"
+       style="fill:none;stroke:#2e3436;stroke-width:3.99999976;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+    <path
+       id="path3794"
+       d="m 3,30 58,0"
+       style="fill:none;stroke:#2e3436;stroke-width:4;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+    <path
+       id="path3796"
+       d="m 3,42 58,0"
+       style="fill:none;stroke:#2e3436;stroke-width:4;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
   </g>
 </svg>

--- a/src/Mod/Start/Gui/Resources/icons/StartWorkbench.svg
+++ b/src/Mod/Start/Gui/Resources/icons/StartWorkbench.svg
@@ -1,6 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-
 <svg
    xmlns:dc="http://purl.org/dc/elements/1.1/"
    xmlns:cc="http://creativecommons.org/ns#"
@@ -8,116 +6,72 @@
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="64px"
-   height="64px"
+   version="1.1"
    id="svg3037"
-   sodipodi:version="0.32"
-   inkscape:version="0.48.5 r10040"
-   sodipodi:docname="StartWorkbench.svg"
-   inkscape:output_extension="org.inkscape.output.svg.inkscape"
-   version="1.1">
+   height="64px"
+   width="64px">
   <defs
      id="defs3039">
     <linearGradient
        id="linearGradient3794">
       <stop
-         id="stop3796"
+         style="stop-color:#729fcf;stop-opacity:1"
          offset="0"
-         style="stop-color:#729fcf;stop-opacity:1" />
+         id="stop3796" />
       <stop
-         id="stop3798"
+         style="stop-color:#204a87;stop-opacity:1"
          offset="1"
-         style="stop-color:#204a87;stop-opacity:1" />
+         id="stop3798" />
     </linearGradient>
     <linearGradient
        id="linearGradient3841">
       <stop
-         style="stop-color:#0619c0;stop-opacity:1;"
+         id="stop3843"
          offset="0"
-         id="stop3843" />
+         style="stop-color:#0619c0;stop-opacity:1;" />
       <stop
-         style="stop-color:#379cfb;stop-opacity:1;"
+         id="stop3845"
          offset="1"
-         id="stop3845" />
+         style="stop-color:#379cfb;stop-opacity:1;" />
     </linearGradient>
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3841"
+       gradientUnits="userSpaceOnUse"
+       y2="1076.6174"
+       x2="3935.5251"
+       y1="1286.7291"
+       x1="3709.3296"
        id="linearGradient3847"
-       x1="3709.3296"
-       y1="1286.7291"
-       x2="3935.5251"
-       y2="1076.6174"
-       gradientUnits="userSpaceOnUse" />
-    <inkscape:perspective
-       sodipodi:type="inkscape:persp3d"
-       inkscape:vp_x="0 : 32 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_z="64 : 32 : 1"
-       inkscape:persp3d-origin="32 : 21.333333 : 1"
-       id="perspective3045" />
+       xlink:href="#linearGradient3841" />
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3794"
-       id="linearGradient2991"
-       gradientUnits="userSpaceOnUse"
-       x1="3718.145"
-       y1="1190.5608"
-       x2="3940.3335"
+       gradientTransform="matrix(0,0.1731146,-0.1731146,0,232.90021,-635.22046)"
        y2="1143.1339"
-       gradientTransform="matrix(0,0.1731146,-0.1731146,0,232.90021,-635.22046)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3841-6"
-       id="linearGradient2991-3"
+       x2="3940.3335"
+       y1="1190.5608"
+       x1="3718.145"
        gradientUnits="userSpaceOnUse"
-       x1="3709.3296"
-       y1="1286.7291"
-       x2="3935.5251"
+       id="linearGradient2991"
+       xlink:href="#linearGradient3794" />
+    <linearGradient
+       gradientTransform="matrix(0,0.1731146,-0.1731146,0,232.90021,-635.22046)"
        y2="1076.6174"
-       gradientTransform="matrix(0,0.1731146,-0.1731146,0,232.90021,-635.22046)" />
+       x2="3935.5251"
+       y1="1286.7291"
+       x1="3709.3296"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient2991-3"
+       xlink:href="#linearGradient3841-6" />
     <linearGradient
        id="linearGradient3841-6">
       <stop
-         style="stop-color:#0619c0;stop-opacity:1;"
+         id="stop3843-7"
          offset="0"
-         id="stop3843-7" />
+         style="stop-color:#0619c0;stop-opacity:1;" />
       <stop
-         style="stop-color:#379cfb;stop-opacity:1;"
+         id="stop3845-5"
          offset="1"
-         id="stop3845-5" />
+         style="stop-color:#379cfb;stop-opacity:1;" />
     </linearGradient>
   </defs>
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageopacity="0.0"
-     inkscape:pageshadow="2"
-     inkscape:zoom="3.598799"
-     inkscape:cx="-13.439241"
-     inkscape:cy="44.491229"
-     inkscape:current-layer="layer1"
-     showgrid="true"
-     inkscape:document-units="px"
-     inkscape:grid-bbox="true"
-     inkscape:window-width="800"
-     inkscape:window-height="836"
-     inkscape:window-x="0"
-     inkscape:window-y="27"
-     inkscape:window-maximized="0"
-     inkscape:snap-global="false">
-    <inkscape:grid
-       type="xygrid"
-       id="grid2990"
-       empspacing="2"
-       visible="true"
-       enabled="true"
-       snapvisiblegridlinesonly="true" />
-  </sodipodi:namedview>
   <metadata
      id="metadata3042">
     <rdf:RDF>
@@ -163,20 +117,14 @@
     </rdf:RDF>
   </metadata>
   <g
-     id="layer1"
-     inkscape:label="Layer 1"
-     inkscape:groupmode="layer">
+     id="layer1">
     <path
-       inkscape:connector-curvature="0"
-       style="fill:url(#linearGradient2991);fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:10;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       d="M 61,31 31,5 l 0,14 -24,0 0,24 24,0 0,14 z"
        id="rect3066"
-       sodipodi:nodetypes="cccccccc" />
+       d="M 61,31 31,5 l 0,14 -24,0 0,24 24,0 0,14 z"
+       style="fill:url(#linearGradient2991);fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:10;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
     <path
-       inkscape:connector-curvature="0"
-       style="fill:none;stroke:#729fcf;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       d="M 58,31 33.012263,9.3801382 33,21 9,21 l 0,20 24,0 0,11.600864 z"
        id="rect3066-3"
-       sodipodi:nodetypes="cccccccc" />
+       d="M 58,31 33.012263,9.3801382 33,21 9,21 l 0,20 24,0 0,11.600864 z"
+       style="fill:none;stroke:#729fcf;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
   </g>
 </svg>

--- a/src/Mod/Start/StartPage/images/new_file_thumbnail.svg
+++ b/src/Mod/Start/StartPage/images/new_file_thumbnail.svg
@@ -1,6 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-
 <svg
    xmlns:dc="http://purl.org/dc/elements/1.1/"
    xmlns:cc="http://creativecommons.org/ns#"
@@ -8,163 +6,131 @@
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="128"
-   height="128"
+   version="1.1"
    id="svg249"
-   sodipodi:version="0.32"
-   inkscape:version="0.92.2 (5c3e80d, 2017-08-06)"
-   sodipodi:docname="new_file_thumbnail.svg"
-   inkscape:export-filename="/home/jimmac/gfx/novell/pdes/trunk/docs/BIGmime-text.png"
-   inkscape:export-xdpi="240.00000"
-   inkscape:export-ydpi="240.00000"
-   version="1.1">
+   height="128"
+   width="128">
   <defs
      id="defs3">
     <linearGradient
        id="linearGradient5048">
       <stop
-         style="stop-color:black;stop-opacity:0;"
+         id="stop5050"
          offset="0"
-         id="stop5050" />
+         style="stop-color:black;stop-opacity:0;" />
       <stop
-         id="stop5056"
+         style="stop-color:black;stop-opacity:1;"
          offset="0.5"
-         style="stop-color:black;stop-opacity:1;" />
+         id="stop5056" />
       <stop
-         style="stop-color:black;stop-opacity:0;"
+         id="stop5052"
          offset="1"
-         id="stop5052" />
+         style="stop-color:black;stop-opacity:0;" />
     </linearGradient>
     <linearGradient
-       inkscape:collect="always"
        id="linearGradient4542">
       <stop
-         style="stop-color:#000000;stop-opacity:1;"
+         id="stop4544"
          offset="0"
-         id="stop4544" />
+         style="stop-color:#000000;stop-opacity:1;" />
       <stop
-         style="stop-color:#000000;stop-opacity:0;"
+         id="stop4546"
          offset="1"
-         id="stop4546" />
+         style="stop-color:#000000;stop-opacity:0;" />
     </linearGradient>
     <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4542"
-       id="radialGradient4548"
-       cx="24.306795"
-       cy="42.07798"
-       fx="24.306795"
-       fy="42.07798"
-       r="15.821514"
+       gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(1,0,0,0.284916,0,30.08928)"
-       gradientUnits="userSpaceOnUse" />
+       r="15.821514"
+       fy="42.07798"
+       fx="24.306795"
+       cy="42.07798"
+       cx="24.306795"
+       id="radialGradient4548"
+       xlink:href="#linearGradient4542" />
     <linearGradient
        id="linearGradient15662">
       <stop
-         style="stop-color:#ffffff;stop-opacity:1.0000000;"
+         id="stop15664"
          offset="0.0000000"
-         id="stop15664" />
+         style="stop-color:#ffffff;stop-opacity:1.0000000;" />
       <stop
-         style="stop-color:#f8f8f8;stop-opacity:1.0000000;"
+         id="stop15666"
          offset="1.0000000"
-         id="stop15666" />
+         style="stop-color:#f8f8f8;stop-opacity:1.0000000;" />
     </linearGradient>
     <radialGradient
-       gradientUnits="userSpaceOnUse"
-       fy="64.567902"
-       fx="20.892099"
-       r="5.257"
-       cy="64.567902"
+       id="aigrd3"
        cx="20.892099"
-       id="aigrd3">
+       cy="64.567902"
+       r="5.257"
+       fx="20.892099"
+       fy="64.567902"
+       gradientUnits="userSpaceOnUse">
       <stop
-         id="stop15573"
+         offset="0"
          style="stop-color:#F0F0F0"
-         offset="0" />
+         id="stop15573" />
       <stop
-         id="stop15575"
+         offset="1.0000000"
          style="stop-color:#9a9a9a;stop-opacity:1.0000000;"
-         offset="1.0000000" />
+         id="stop15575" />
     </radialGradient>
     <radialGradient
-       gradientUnits="userSpaceOnUse"
-       fy="114.5684"
-       fx="20.892099"
-       r="5.256"
-       cy="114.5684"
+       id="aigrd2"
        cx="20.892099"
-       id="aigrd2">
+       cy="114.5684"
+       r="5.256"
+       fx="20.892099"
+       fy="114.5684"
+       gradientUnits="userSpaceOnUse">
       <stop
-         id="stop15566"
+         offset="0"
          style="stop-color:#F0F0F0"
-         offset="0" />
+         id="stop15566" />
       <stop
-         id="stop15568"
+         offset="1.0000000"
          style="stop-color:#9a9a9a;stop-opacity:1.0000000;"
-         offset="1.0000000" />
+         id="stop15568" />
     </radialGradient>
     <linearGradient
        id="linearGradient269">
       <stop
-         style="stop-color:#a3a3a3;stop-opacity:1.0000000;"
+         id="stop270"
          offset="0.0000000"
-         id="stop270" />
+         style="stop-color:#a3a3a3;stop-opacity:1.0000000;" />
       <stop
-         style="stop-color:#4c4c4c;stop-opacity:1.0000000;"
+         id="stop271"
          offset="1.0000000"
-         id="stop271" />
+         style="stop-color:#4c4c4c;stop-opacity:1.0000000;" />
     </linearGradient>
     <linearGradient
        id="linearGradient259">
       <stop
-         style="stop-color:#fafafa;stop-opacity:1.0000000;"
+         id="stop260"
          offset="0.0000000"
-         id="stop260" />
+         style="stop-color:#fafafa;stop-opacity:1.0000000;" />
       <stop
-         style="stop-color:#bbbbbb;stop-opacity:1.0000000;"
+         id="stop261"
          offset="1.0000000"
-         id="stop261" />
+         style="stop-color:#bbbbbb;stop-opacity:1.0000000;" />
     </linearGradient>
     <linearGradient
        id="linearGradient12512">
       <stop
-         style="stop-color:#ffffff;stop-opacity:1.0000000;"
+         id="stop12513"
          offset="0.0000000"
-         id="stop12513" />
+         style="stop-color:#ffffff;stop-opacity:1.0000000;" />
       <stop
-         style="stop-color:#fff520;stop-opacity:0.89108908;"
+         id="stop12517"
          offset="0.50000000"
-         id="stop12517" />
+         style="stop-color:#fff520;stop-opacity:0.89108908;" />
       <stop
-         style="stop-color:#fff300;stop-opacity:0.0000000;"
+         id="stop12514"
          offset="1.0000000"
-         id="stop12514" />
+         style="stop-color:#fff300;stop-opacity:0.0000000;" />
     </linearGradient>
   </defs>
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="0.32941176"
-     inkscape:pageopacity="0.0"
-     inkscape:pageshadow="2"
-     inkscape:zoom="3.1075999"
-     inkscape:cx="60.624406"
-     inkscape:cy="44.384069"
-     inkscape:current-layer="layer4"
-     showgrid="false"
-     inkscape:grid-bbox="true"
-     inkscape:document-units="px"
-     inkscape:window-width="1680"
-     inkscape:window-height="938"
-     inkscape:window-x="0"
-     inkscape:window-y="23"
-     inkscape:showpageshadow="false"
-     inkscape:snap-page="true"
-     inkscape:window-maximized="0"
-     borderlayer="true" />
   <metadata
      id="metadata4">
     <rdf:RDF>
@@ -173,7 +139,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title>New Document</dc:title>
+        <dc:title></dc:title>
         <dc:creator>
           <cc:Agent>
             <dc:title>Jakub Steiner</dc:title>
@@ -201,35 +167,29 @@
     </rdf:RDF>
   </metadata>
   <g
-     inkscape:label="Shadow"
-     id="layer6"
-     inkscape:groupmode="layer"
-     transform="translate(0,80)" />
+     transform="translate(0,80)"
+     id="layer6" />
   <g
-     id="layer1"
-     inkscape:label="Base"
-     inkscape:groupmode="layer"
+     transform="translate(0,80)"
      style="display:inline"
-     transform="translate(0,80)" />
+     id="layer1" />
   <g
-     inkscape:groupmode="layer"
-     id="layer4"
-     inkscape:label="new"
+     transform="translate(0,80)"
      style="display:inline"
-     transform="translate(0,80)">
+     id="layer4">
     <rect
-       style="opacity:1;vector-effect:none;fill:#000000;fill-opacity:0.05882353;fill-rule:evenodd;stroke:none;stroke-width:7.5590539;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="rect911"
-       width="128"
-       height="128"
-       x="0"
-       y="-80"
+       rx="3"
        ry="3"
-       rx="3" />
+       y="-80"
+       x="0"
+       height="128"
+       width="128"
+       id="rect911"
+       style="opacity:1;vector-effect:none;fill:#000000;fill-opacity:0.05882353;fill-rule:evenodd;stroke:none;stroke-width:7.5590539;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
     <path
-       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:0.3137255;fill-rule:nonzero;stroke:none;stroke-width:8;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-       d="M 63.939453 24 A 4.0004 4.0004 0 0 0 60 28.056641 L 60 60 L 28.056641 60 A 4.0004 4.0004 0 1 0 28.056641 68 L 60 68 L 60 99.943359 A 4.0004 4.0004 0 1 0 68 99.943359 L 68 68 L 99.943359 68 A 4.0004 4.0004 0 1 0 99.943359 60 L 68 60 L 68 28.056641 A 4.0004 4.0004 0 0 0 63.939453 24 z "
+       id="path900"
        transform="translate(0,-80)"
-       id="path900" />
+       d="M 63.939453 24 A 4.0004 4.0004 0 0 0 60 28.056641 L 60 60 L 28.056641 60 A 4.0004 4.0004 0 1 0 28.056641 68 L 60 68 L 60 99.943359 A 4.0004 4.0004 0 1 0 68 99.943359 L 68 68 L 99.943359 68 A 4.0004 4.0004 0 1 0 99.943359 60 L 68 60 L 68 28.056641 A 4.0004 4.0004 0 0 0 63.939453 24 z "
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:0.3137255;fill-rule:nonzero;stroke:none;stroke-width:8;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
   </g>
 </svg>

--- a/src/Mod/Test/Gui/Resources/icons/TestWorkbench.svg
+++ b/src/Mod/Test/Gui/Resources/icons/TestWorkbench.svg
@@ -1,6 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-
 <svg
    xmlns:dc="http://purl.org/dc/elements/1.1/"
    xmlns:cc="http://creativecommons.org/ns#"
@@ -8,130 +6,89 @@
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="64"
-   height="64"
-   id="svg2"
    version="1.1"
-   inkscape:version="0.48.5 r10040"
-   sodipodi:docname="TestWorkbench.svg">
+   id="svg2"
+   height="64"
+   width="64">
   <defs
      id="defs4">
     <linearGradient
-       inkscape:collect="always"
        id="linearGradient3861">
       <stop
-         style="stop-color:#555753;stop-opacity:1"
+         id="stop3863"
          offset="0"
-         id="stop3863" />
+         style="stop-color:#555753;stop-opacity:1" />
       <stop
-         style="stop-color:#babdb6;stop-opacity:1"
+         id="stop3865"
          offset="1"
-         id="stop3865" />
+         style="stop-color:#babdb6;stop-opacity:1" />
     </linearGradient>
     <linearGradient
-       inkscape:collect="always"
        id="linearGradient3835">
       <stop
-         style="stop-color:#888a85;stop-opacity:1"
+         id="stop3837"
          offset="0"
-         id="stop3837" />
+         style="stop-color:#888a85;stop-opacity:1" />
       <stop
-         style="stop-color:#d3d7cf;stop-opacity:1"
+         id="stop3839"
          offset="1"
-         id="stop3839" />
+         style="stop-color:#d3d7cf;stop-opacity:1" />
     </linearGradient>
     <linearGradient
-       inkscape:collect="always"
        id="linearGradient3809">
       <stop
-         style="stop-color:#888a85;stop-opacity:1"
+         id="stop3811"
          offset="0"
-         id="stop3811" />
+         style="stop-color:#888a85;stop-opacity:1" />
       <stop
-         style="stop-color:#d3d7cf;stop-opacity:1"
+         id="stop3813"
          offset="1"
-         id="stop3813" />
+         style="stop-color:#d3d7cf;stop-opacity:1" />
     </linearGradient>
     <linearGradient
-       inkscape:collect="always"
        id="linearGradient3783">
       <stop
-         style="stop-color:#8f5902;stop-opacity:1"
+         id="stop3785"
          offset="0"
-         id="stop3785" />
+         style="stop-color:#8f5902;stop-opacity:1" />
       <stop
-         style="stop-color:#e9b96e;stop-opacity:1"
+         id="stop3787"
          offset="1"
-         id="stop3787" />
+         style="stop-color:#e9b96e;stop-opacity:1" />
     </linearGradient>
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3783"
-       id="linearGradient3789"
-       x1="34.94899"
-       y1="56.068802"
-       x2="29.677343"
+       gradientUnits="userSpaceOnUse"
        y2="18.185053"
-       gradientUnits="userSpaceOnUse" />
+       x2="29.677343"
+       y1="56.068802"
+       x1="34.94899"
+       id="linearGradient3789"
+       xlink:href="#linearGradient3783" />
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3809"
-       id="linearGradient3815"
-       x1="48.625"
-       y1="22.874998"
-       x2="43.3125"
+       gradientUnits="userSpaceOnUse"
        y2="11.187498"
-       gradientUnits="userSpaceOnUse" />
+       x2="43.3125"
+       y1="22.874998"
+       x1="48.625"
+       id="linearGradient3815"
+       xlink:href="#linearGradient3809" />
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3835"
-       id="linearGradient3841"
-       x1="38.244366"
-       y1="11.473497"
-       x2="35.803085"
+       gradientUnits="userSpaceOnUse"
        y2="6.6526189"
-       gradientUnits="userSpaceOnUse" />
+       x2="35.803085"
+       y1="11.473497"
+       x1="38.244366"
+       id="linearGradient3841"
+       xlink:href="#linearGradient3835" />
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3861"
-       id="linearGradient3867"
-       x1="52.817749"
-       y1="28.469421"
-       x2="51.800217"
+       gradientUnits="userSpaceOnUse"
        y2="20.900108"
-       gradientUnits="userSpaceOnUse" />
+       x2="51.800217"
+       y1="28.469421"
+       x1="52.817749"
+       id="linearGradient3867"
+       xlink:href="#linearGradient3861" />
   </defs>
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageopacity="0.0"
-     inkscape:pageshadow="2"
-     inkscape:zoom="6.5859375"
-     inkscape:cx="24.7864"
-     inkscape:cy="34.485492"
-     inkscape:document-units="px"
-     inkscape:current-layer="layer1"
-     showgrid="true"
-     inkscape:window-width="1920"
-     inkscape:window-height="1057"
-     inkscape:window-x="1912"
-     inkscape:window-y="-8"
-     inkscape:window-maximized="1"
-     inkscape:snap-bbox="false"
-     inkscape:snap-nodes="true"
-     inkscape:snap-global="false">
-    <inkscape:grid
-       type="xygrid"
-       id="grid2987"
-       empspacing="2"
-       visible="true"
-       enabled="true"
-       snapvisiblegridlinesonly="true" />
-  </sodipodi:namedview>
   <metadata
      id="metadata7">
     <rdf:RDF>
@@ -140,72 +97,49 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
+        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <g
-     inkscape:label="Layer 1"
-     inkscape:groupmode="layer"
-     id="layer1"
-     transform="translate(0,-988.36218)">
+     transform="translate(0,-988.36218)"
+     id="layer1">
     <path
-       style="fill:url(#linearGradient3789);stroke:#271903;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1;fill-opacity:1"
-       d="M 3,53 39,17 45,23 9,59 z"
+       transform="translate(0,988.36218)"
        id="path3763"
-       inkscape:connector-curvature="0"
-       transform="translate(0,988.36218)" />
+       d="M 3,53 39,17 45,23 9,59 z"
+       style="fill:url(#linearGradient3789);stroke:#271903;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1;fill-opacity:1" />
     <path
-       style="fill:none;stroke:#e9b96e;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       d="m 5.8481613,1041.3622 33.2277577,-33.2657 3.392646,2.981 -33.4495852,33.4555 z"
        id="path3763-1"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="ccccc" />
+       d="m 5.8481613,1041.3622 33.2277577,-33.2657 3.392646,2.981 -33.4495852,33.4555 z"
+       style="fill:none;stroke:#e9b96e;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     <path
-       style="fill:url(#linearGradient3867);stroke:#2e3436;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1;fill-opacity:1"
-       d="m 53,19 c 1,1 3,1 4,0 l 4,4 -10,10 -4,-4 c 1,-1 1,-3 0,-4 z"
+       transform="translate(0,988.36218)"
        id="path2991"
-       inkscape:connector-curvature="0"
-       transform="translate(0,988.36218)"
-       sodipodi:nodetypes="ccccccc" />
+       d="m 53,19 c 1,1 3,1 4,0 l 4,4 -10,10 -4,-4 c 1,-1 1,-3 0,-4 z"
+       style="fill:url(#linearGradient3867);stroke:#2e3436;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1;fill-opacity:1" />
     <path
-       style="fill:url(#linearGradient3841);stroke:#2e3436;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1;fill-opacity:1"
-       d="M 49,10 C 36,3 30,3 17,13 28,10 32,10 37,14 z"
+       transform="translate(0,988.36218)"
        id="path3761"
-       inkscape:connector-curvature="0"
-       transform="translate(0,988.36218)"
-       sodipodi:nodetypes="cccc" />
+       d="M 49,10 C 36,3 30,3 17,13 28,10 32,10 37,14 z"
+       style="fill:url(#linearGradient3841);stroke:#2e3436;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1;fill-opacity:1" />
     <path
-       style="fill:none;stroke:#d3d7cf;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:58.79999923999999800;stroke-opacity:1;stroke-dasharray:none"
-       d="m 46,999.36218 c -7.177936,-4.84816 -15.442467,-4.8363 -19.734282,-1.92408 8.810201,-1.5694 12.213523,4.8719 15.163701,5.5563 z"
        id="path3761-4"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cccc" />
+       d="m 46,999.36218 c -7.177936,-4.84816 -15.442467,-4.8363 -19.734282,-1.92408 8.810201,-1.5694 12.213523,4.8719 15.163701,5.5563 z"
+       style="fill:none;stroke:#d3d7cf;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:58.79999923999999800;stroke-opacity:1;stroke-dasharray:none" />
     <path
-       style="fill:none;stroke:#d3d7cf;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       d="m 51.993137,1009.0401 c 1.187891,0.9195 2.745311,1.4563 4.631081,0.7784 l 1.536831,1.5303 -7.134207,7.161 -1.530274,-1.4766 c 0.610798,-1.3489 -0.01342,-3.5973 -0.812109,-4.6376 z"
        id="path2991-0"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="ccccccc" />
+       d="m 51.993137,1009.0401 c 1.187891,0.9195 2.745311,1.4563 4.631081,0.7784 l 1.536831,1.5303 -7.134207,7.161 -1.530274,-1.4766 c 0.610798,-1.3489 -0.01342,-3.5973 -0.812109,-4.6376 z"
+       style="fill:none;stroke:#d3d7cf;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     <path
-       sodipodi:type="arc"
-       style="fill:url(#linearGradient3815);fill-opacity:1;stroke:#2e3436;stroke-width:2.12500000000000000;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:2.04000000000000000"
+       transform="matrix(0.94117647,0,0,0.94117647,1.2352942,989.83277)"
+       d="m 55,16.5 a 8.5,8.5 0 1 1 -17,0 8.5,8.5 0 1 1 17,0 z"
        id="path2989"
-       sodipodi:cx="46.5"
-       sodipodi:cy="16.5"
-       sodipodi:rx="8.5"
-       sodipodi:ry="8.5"
-       d="m 55,16.5 a 8.5,8.5 0 1 1 -17,0 8.5,8.5 0 1 1 17,0 z"
-       transform="matrix(0.94117647,0,0,0.94117647,1.2352942,989.83277)" />
+       style="fill:url(#linearGradient3815);fill-opacity:1;stroke:#2e3436;stroke-width:2.12500000000000000;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:2.04000000000000000" />
     <path
-       sodipodi:type="arc"
-       style="fill:none;fill-opacity:1;stroke:#d3d7cf;stroke-width:2.83333302000000000;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:2.04000000000000000"
-       id="path2989-7"
-       sodipodi:cx="46.5"
-       sodipodi:cy="16.5"
-       sodipodi:rx="8.5"
-       sodipodi:ry="8.5"
+       transform="matrix(0.70588237,0,0,0.70588253,12.17647,993.71512)"
        d="m 55,16.5 a 8.5,8.5 0 1 1 -17,0 8.5,8.5 0 1 1 17,0 z"
-       transform="matrix(0.70588237,0,0,0.70588253,12.17647,993.71512)" />
+       id="path2989-7"
+       style="fill:none;fill-opacity:1;stroke:#d3d7cf;stroke-width:2.83333302000000000;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:2.04000000000000000" />
   </g>
 </svg>

--- a/src/Mod/Web/Gui/Resources/icons/WebWorkbench.svg
+++ b/src/Mod/Web/Gui/Resources/icons/WebWorkbench.svg
@@ -1,6 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-
 <svg
    xmlns:dc="http://purl.org/dc/elements/1.1/"
    xmlns:cc="http://creativecommons.org/ns#"
@@ -8,1014 +6,874 @@
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="64"
-   height="64"
+   version="1.1"
    id="svg3440"
-   sodipodi:version="0.32"
-   inkscape:version="0.48.5 r10040"
-   sodipodi:docname="WebWorkbench.svg"
-   inkscape:output_extension="org.inkscape.output.svg.inkscape"
-   version="1.1">
+   height="64"
+   width="64">
   <defs
      id="defs3">
     <linearGradient
-       inkscape:collect="always"
        id="linearGradient3902">
       <stop
-         style="stop-color:#4e9a06;stop-opacity:1"
+         id="stop3904"
          offset="0"
-         id="stop3904" />
+         style="stop-color:#4e9a06;stop-opacity:1" />
       <stop
-         style="stop-color:#8ae234;stop-opacity:1"
+         id="stop3906"
          offset="1"
-         id="stop3906" />
+         style="stop-color:#8ae234;stop-opacity:1" />
     </linearGradient>
-    <inkscape:perspective
-       sodipodi:type="inkscape:persp3d"
-       inkscape:vp_x="0 : 24 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_z="48 : 24 : 1"
-       inkscape:persp3d-origin="24 : 16 : 1"
-       id="perspective156" />
     <linearGradient
        id="linearGradient4750">
       <stop
-         style="stop-color:#ffffff;stop-opacity:1;"
+         id="stop4752"
          offset="0"
-         id="stop4752" />
+         style="stop-color:#ffffff;stop-opacity:1;" />
       <stop
-         style="stop-color:#fefefe;stop-opacity:1.0000000;"
+         id="stop4758"
          offset="0.37931034"
-         id="stop4758" />
+         style="stop-color:#fefefe;stop-opacity:1.0000000;" />
       <stop
-         style="stop-color:#1d1d1d;stop-opacity:1.0000000;"
+         id="stop4754"
          offset="1.0000000"
-         id="stop4754" />
+         style="stop-color:#1d1d1d;stop-opacity:1.0000000;" />
     </linearGradient>
     <linearGradient
-       inkscape:collect="always"
        id="linearGradient4350">
       <stop
-         style="stop-color:#ffffff;stop-opacity:1;"
+         id="stop4352"
          offset="0"
-         id="stop4352" />
+         style="stop-color:#ffffff;stop-opacity:1;" />
       <stop
-         style="stop-color:#ffffff;stop-opacity:0;"
+         id="stop4354"
          offset="1"
-         id="stop4354" />
+         style="stop-color:#ffffff;stop-opacity:0;" />
     </linearGradient>
     <linearGradient
        id="linearGradient4126">
       <stop
-         style="stop-color:#ffffff;stop-opacity:1.0000000;"
+         id="stop4128"
          offset="0.0000000"
-         id="stop4128" />
+         style="stop-color:#ffffff;stop-opacity:1.0000000;" />
       <stop
-         style="stop-color:#ffffff;stop-opacity:0.16494845;"
+         id="stop4130"
          offset="1.0000000"
-         id="stop4130" />
+         style="stop-color:#ffffff;stop-opacity:0.16494845;" />
     </linearGradient>
     <linearGradient
-       inkscape:collect="always"
        id="linearGradient4114">
       <stop
-         style="stop-color:#000000;stop-opacity:1;"
+         id="stop4116"
          offset="0"
-         id="stop4116" />
+         style="stop-color:#000000;stop-opacity:1;" />
       <stop
-         style="stop-color:#000000;stop-opacity:0;"
+         id="stop4118"
          offset="1"
-         id="stop4118" />
+         style="stop-color:#000000;stop-opacity:0;" />
     </linearGradient>
     <linearGradient
        id="linearGradient3962">
       <stop
-         style="stop-color:#d3e9ff;stop-opacity:1.0000000;"
+         id="stop3964"
          offset="0.0000000"
-         id="stop3964" />
+         style="stop-color:#d3e9ff;stop-opacity:1.0000000;" />
       <stop
-         style="stop-color:#d3e9ff;stop-opacity:1.0000000;"
+         id="stop4134"
          offset="0.15517241"
-         id="stop4134" />
+         style="stop-color:#d3e9ff;stop-opacity:1.0000000;" />
       <stop
-         style="stop-color:#4074ae;stop-opacity:1.0000000;"
+         id="stop4346"
          offset="0.75000000"
-         id="stop4346" />
+         style="stop-color:#4074ae;stop-opacity:1.0000000;" />
       <stop
-         style="stop-color:#36486c;stop-opacity:1.0000000;"
+         id="stop3966"
          offset="1.0000000"
-         id="stop3966" />
+         style="stop-color:#36486c;stop-opacity:1.0000000;" />
     </linearGradient>
     <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3962"
-       id="radialGradient3968"
-       gradientTransform="matrix(1.3888978,0,0,1.3889284,-2.124907,-18.68781)"
-       cx="18.247644"
-       cy="15.716079"
-       fx="18.247644"
-       fy="15.716079"
+       gradientUnits="userSpaceOnUse"
        r="29.993349"
-       gradientUnits="userSpaceOnUse" />
+       fy="15.716079"
+       fx="18.247644"
+       cy="15.716079"
+       cx="18.247644"
+       gradientTransform="matrix(1.3888978,0,0,1.3889284,-2.124907,-18.68781)"
+       id="radialGradient3968"
+       xlink:href="#linearGradient3962" />
     <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4114"
-       id="radialGradient4120"
-       gradientTransform="scale(1.64399,0.608276)"
-       cx="15.115514"
-       cy="63.965389"
-       fx="15.115514"
-       fy="63.965389"
+       gradientUnits="userSpaceOnUse"
        r="12.289036"
-       gradientUnits="userSpaceOnUse" />
+       fy="63.965389"
+       fx="15.115514"
+       cy="63.965389"
+       cx="15.115514"
+       gradientTransform="scale(1.64399,0.608276)"
+       id="radialGradient4120"
+       xlink:href="#linearGradient4114" />
     <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4126"
-       id="radialGradient4132"
-       gradientTransform="matrix(1.3582501,0,0,1.3582491,-1.3715663,-17.89974)"
-       cx="15.601279"
-       cy="12.142302"
-       fx="15.601279"
-       fy="12.142302"
+       gradientUnits="userSpaceOnUse"
        r="43.526714"
-       gradientUnits="userSpaceOnUse" />
+       fy="12.142302"
+       fx="15.601279"
+       cy="12.142302"
+       cx="15.601279"
+       gradientTransform="matrix(1.3582501,0,0,1.3582491,-1.3715663,-17.89974)"
+       id="radialGradient4132"
+       xlink:href="#linearGradient4126" />
     <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4350"
-       id="radialGradient4356"
-       gradientTransform="scale(1.179536,0.847791)"
-       cx="11.826907"
-       cy="10.476453"
-       fx="11.826907"
-       fy="10.476453"
+       gradientUnits="userSpaceOnUse"
        r="32.664848"
-       gradientUnits="userSpaceOnUse" />
+       fy="10.476453"
+       fx="11.826907"
+       cy="10.476453"
+       cx="11.826907"
+       gradientTransform="scale(1.179536,0.847791)"
+       id="radialGradient4356"
+       xlink:href="#linearGradient4350" />
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3902"
-       id="linearGradient3908"
-       x1="29.357769"
-       y1="38.552639"
-       x2="21.962091"
+       gradientUnits="userSpaceOnUse"
        y2="14.780167"
-       gradientUnits="userSpaceOnUse" />
+       x2="21.962091"
+       y1="38.552639"
+       x1="29.357769"
+       id="linearGradient3908"
+       xlink:href="#linearGradient3902" />
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3902-6"
-       id="linearGradient3908-3"
-       x1="31.576473"
-       y1="36.323967"
-       x2="14.566413"
+       gradientUnits="userSpaceOnUse"
        y2="9.5799379"
-       gradientUnits="userSpaceOnUse" />
+       x2="14.566413"
+       y1="36.323967"
+       x1="31.576473"
+       id="linearGradient3908-3"
+       xlink:href="#linearGradient3902-6" />
     <linearGradient
-       inkscape:collect="always"
        id="linearGradient3902-6">
       <stop
-         style="stop-color:#4e9a06;stop-opacity:1"
+         id="stop3904-7"
          offset="0"
-         id="stop3904-7" />
+         style="stop-color:#4e9a06;stop-opacity:1" />
       <stop
-         style="stop-color:#8ae234;stop-opacity:1"
+         id="stop3906-5"
          offset="1"
-         id="stop3906-5" />
+         style="stop-color:#8ae234;stop-opacity:1" />
     </linearGradient>
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3902-6"
+       gradientUnits="userSpaceOnUse"
+       y2="9.5799379"
+       x2="14.566413"
+       y1="36.323967"
+       x1="31.576473"
        id="linearGradient3924"
-       x1="31.576473"
-       y1="36.323967"
-       x2="14.566413"
-       y2="9.5799379"
-       gradientUnits="userSpaceOnUse" />
+       xlink:href="#linearGradient3902-6" />
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3902-6"
+       gradientUnits="userSpaceOnUse"
+       y2="9.5799379"
+       x2="14.566413"
+       y1="36.323967"
+       x1="31.576473"
        id="linearGradient3932"
-       x1="31.576473"
-       y1="36.323967"
-       x2="14.566413"
-       y2="9.5799379"
-       gradientUnits="userSpaceOnUse" />
+       xlink:href="#linearGradient3902-6" />
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3902-6"
+       gradientUnits="userSpaceOnUse"
+       y2="9.5799379"
+       x2="14.566413"
+       y1="36.323967"
+       x1="31.576473"
        id="linearGradient3940"
-       x1="31.576473"
-       y1="36.323967"
-       x2="14.566413"
-       y2="9.5799379"
-       gradientUnits="userSpaceOnUse" />
+       xlink:href="#linearGradient3902-6" />
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3902-6"
+       gradientUnits="userSpaceOnUse"
+       y2="9.5799379"
+       x2="14.566413"
+       y1="36.323967"
+       x1="31.576473"
        id="linearGradient3948"
-       x1="31.576473"
-       y1="36.323967"
-       x2="14.566413"
-       y2="9.5799379"
-       gradientUnits="userSpaceOnUse" />
+       xlink:href="#linearGradient3902-6" />
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3902-6"
+       gradientUnits="userSpaceOnUse"
+       y2="9.5799379"
+       x2="14.566413"
+       y1="36.323967"
+       x1="31.576473"
        id="linearGradient3956"
-       x1="31.576473"
-       y1="36.323967"
-       x2="14.566413"
-       y2="9.5799379"
-       gradientUnits="userSpaceOnUse" />
+       xlink:href="#linearGradient3902-6" />
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3902-6"
+       gradientUnits="userSpaceOnUse"
+       y2="9.5799379"
+       x2="14.566413"
+       y1="36.323967"
+       x1="31.576473"
        id="linearGradient3964"
-       x1="31.576473"
-       y1="36.323967"
-       x2="14.566413"
-       y2="9.5799379"
-       gradientUnits="userSpaceOnUse" />
+       xlink:href="#linearGradient3902-6" />
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3902-6"
+       gradientUnits="userSpaceOnUse"
+       y2="9.5799379"
+       x2="14.566413"
+       y1="36.323967"
+       x1="31.576473"
        id="linearGradient3972"
-       x1="31.576473"
-       y1="36.323967"
-       x2="14.566413"
-       y2="9.5799379"
-       gradientUnits="userSpaceOnUse" />
+       xlink:href="#linearGradient3902-6" />
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3902-6"
+       gradientUnits="userSpaceOnUse"
+       y2="9.5799379"
+       x2="14.566413"
+       y1="36.323967"
+       x1="31.576473"
        id="linearGradient3980"
-       x1="31.576473"
-       y1="36.323967"
-       x2="14.566413"
-       y2="9.5799379"
-       gradientUnits="userSpaceOnUse" />
+       xlink:href="#linearGradient3902-6" />
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3902-6"
+       gradientUnits="userSpaceOnUse"
+       y2="9.5799379"
+       x2="14.566413"
+       y1="36.323967"
+       x1="31.576473"
        id="linearGradient3988"
-       x1="31.576473"
-       y1="36.323967"
-       x2="14.566413"
-       y2="9.5799379"
-       gradientUnits="userSpaceOnUse" />
+       xlink:href="#linearGradient3902-6" />
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3902-6"
+       gradientUnits="userSpaceOnUse"
+       y2="9.5799379"
+       x2="14.566413"
+       y1="36.323967"
+       x1="31.576473"
        id="linearGradient3996"
-       x1="31.576473"
-       y1="36.323967"
-       x2="14.566413"
-       y2="9.5799379"
-       gradientUnits="userSpaceOnUse" />
+       xlink:href="#linearGradient3902-6" />
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3902-6"
+       gradientUnits="userSpaceOnUse"
+       y2="9.5799379"
+       x2="14.566413"
+       y1="36.323967"
+       x1="31.576473"
        id="linearGradient4004"
-       x1="31.576473"
-       y1="36.323967"
-       x2="14.566413"
-       y2="9.5799379"
-       gradientUnits="userSpaceOnUse" />
+       xlink:href="#linearGradient3902-6" />
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3902-6"
+       gradientUnits="userSpaceOnUse"
+       y2="9.5799379"
+       x2="14.566413"
+       y1="36.323967"
+       x1="31.576473"
        id="linearGradient4012"
-       x1="31.576473"
-       y1="36.323967"
-       x2="14.566413"
-       y2="9.5799379"
-       gradientUnits="userSpaceOnUse" />
+       xlink:href="#linearGradient3902-6" />
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3902-6"
+       gradientUnits="userSpaceOnUse"
+       y2="9.5799379"
+       x2="14.566413"
+       y1="36.323967"
+       x1="31.576473"
        id="linearGradient4020"
-       x1="31.576473"
-       y1="36.323967"
-       x2="14.566413"
-       y2="9.5799379"
-       gradientUnits="userSpaceOnUse" />
+       xlink:href="#linearGradient3902-6" />
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3902-6"
+       gradientUnits="userSpaceOnUse"
+       y2="9.5799379"
+       x2="14.566413"
+       y1="36.323967"
+       x1="31.576473"
        id="linearGradient4028"
-       x1="31.576473"
-       y1="36.323967"
-       x2="14.566413"
-       y2="9.5799379"
-       gradientUnits="userSpaceOnUse" />
+       xlink:href="#linearGradient3902-6" />
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3902-6"
+       gradientUnits="userSpaceOnUse"
+       y2="9.5799379"
+       x2="14.566413"
+       y1="36.323967"
+       x1="31.576473"
        id="linearGradient4036"
-       x1="31.576473"
-       y1="36.323967"
-       x2="14.566413"
-       y2="9.5799379"
-       gradientUnits="userSpaceOnUse" />
+       xlink:href="#linearGradient3902-6" />
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3902-6"
+       gradientUnits="userSpaceOnUse"
+       y2="9.5799379"
+       x2="14.566413"
+       y1="36.323967"
+       x1="31.576473"
        id="linearGradient4044"
-       x1="31.576473"
-       y1="36.323967"
-       x2="14.566413"
-       y2="9.5799379"
-       gradientUnits="userSpaceOnUse" />
+       xlink:href="#linearGradient3902-6" />
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3902-6"
+       gradientUnits="userSpaceOnUse"
+       y2="9.5799379"
+       x2="14.566413"
+       y1="36.323967"
+       x1="31.576473"
        id="linearGradient4052"
-       x1="31.576473"
-       y1="36.323967"
-       x2="14.566413"
-       y2="9.5799379"
-       gradientUnits="userSpaceOnUse" />
+       xlink:href="#linearGradient3902-6" />
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3902-6"
+       gradientUnits="userSpaceOnUse"
+       y2="9.5799379"
+       x2="14.566413"
+       y1="36.323967"
+       x1="31.576473"
        id="linearGradient4060"
-       x1="31.576473"
-       y1="36.323967"
-       x2="14.566413"
-       y2="9.5799379"
-       gradientUnits="userSpaceOnUse" />
+       xlink:href="#linearGradient3902-6" />
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3902-6"
+       gradientUnits="userSpaceOnUse"
+       y2="9.5799379"
+       x2="14.566413"
+       y1="36.323967"
+       x1="31.576473"
        id="linearGradient4068"
-       x1="31.576473"
-       y1="36.323967"
-       x2="14.566413"
-       y2="9.5799379"
-       gradientUnits="userSpaceOnUse" />
+       xlink:href="#linearGradient3902-6" />
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3902-6"
+       gradientUnits="userSpaceOnUse"
+       y2="9.5799379"
+       x2="14.566413"
+       y1="36.323967"
+       x1="31.576473"
        id="linearGradient4076"
-       x1="31.576473"
-       y1="36.323967"
-       x2="14.566413"
-       y2="9.5799379"
-       gradientUnits="userSpaceOnUse" />
+       xlink:href="#linearGradient3902-6" />
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3902-6"
+       gradientUnits="userSpaceOnUse"
+       y2="9.5799379"
+       x2="14.566413"
+       y1="36.323967"
+       x1="31.576473"
        id="linearGradient4084"
-       x1="31.576473"
-       y1="36.323967"
-       x2="14.566413"
-       y2="9.5799379"
-       gradientUnits="userSpaceOnUse" />
+       xlink:href="#linearGradient3902-6" />
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3902-6"
+       gradientUnits="userSpaceOnUse"
+       y2="9.5799379"
+       x2="14.566413"
+       y1="36.323967"
+       x1="31.576473"
        id="linearGradient4092"
-       x1="31.576473"
-       y1="36.323967"
-       x2="14.566413"
-       y2="9.5799379"
-       gradientUnits="userSpaceOnUse" />
+       xlink:href="#linearGradient3902-6" />
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3902-6"
+       gradientUnits="userSpaceOnUse"
+       y2="9.5799379"
+       x2="14.566413"
+       y1="36.323967"
+       x1="31.576473"
        id="linearGradient4100"
-       x1="31.576473"
-       y1="36.323967"
-       x2="14.566413"
-       y2="9.5799379"
-       gradientUnits="userSpaceOnUse" />
+       xlink:href="#linearGradient3902-6" />
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3902-6"
+       gradientUnits="userSpaceOnUse"
+       y2="9.5799379"
+       x2="14.566413"
+       y1="36.323967"
+       x1="31.576473"
        id="linearGradient4108"
-       x1="31.576473"
-       y1="36.323967"
-       x2="14.566413"
-       y2="9.5799379"
-       gradientUnits="userSpaceOnUse" />
+       xlink:href="#linearGradient3902-6" />
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3902-6"
+       gradientUnits="userSpaceOnUse"
+       y2="9.5799379"
+       x2="14.566413"
+       y1="36.323967"
+       x1="31.576473"
        id="linearGradient4116"
-       x1="31.576473"
-       y1="36.323967"
-       x2="14.566413"
-       y2="9.5799379"
-       gradientUnits="userSpaceOnUse" />
+       xlink:href="#linearGradient3902-6" />
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3902-6"
+       gradientUnits="userSpaceOnUse"
+       y2="9.5799379"
+       x2="14.566413"
+       y1="36.323967"
+       x1="31.576473"
        id="linearGradient4124"
-       x1="31.576473"
-       y1="36.323967"
-       x2="14.566413"
-       y2="9.5799379"
-       gradientUnits="userSpaceOnUse" />
+       xlink:href="#linearGradient3902-6" />
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3902-6"
+       gradientUnits="userSpaceOnUse"
+       y2="9.5799379"
+       x2="14.566413"
+       y1="36.323967"
+       x1="31.576473"
        id="linearGradient4132"
-       x1="31.576473"
-       y1="36.323967"
-       x2="14.566413"
-       y2="9.5799379"
-       gradientUnits="userSpaceOnUse" />
+       xlink:href="#linearGradient3902-6" />
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3902-6"
+       gradientUnits="userSpaceOnUse"
+       y2="9.5799379"
+       x2="14.566413"
+       y1="36.323967"
+       x1="31.576473"
        id="linearGradient4140"
-       x1="31.576473"
-       y1="36.323967"
-       x2="14.566413"
-       y2="9.5799379"
-       gradientUnits="userSpaceOnUse" />
+       xlink:href="#linearGradient3902-6" />
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3902-6"
+       gradientUnits="userSpaceOnUse"
+       y2="9.5799379"
+       x2="14.566413"
+       y1="36.323967"
+       x1="31.576473"
        id="linearGradient4148"
-       x1="31.576473"
-       y1="36.323967"
-       x2="14.566413"
-       y2="9.5799379"
-       gradientUnits="userSpaceOnUse" />
+       xlink:href="#linearGradient3902-6" />
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3902-6"
+       gradientUnits="userSpaceOnUse"
+       y2="9.5799379"
+       x2="14.566413"
+       y1="36.323967"
+       x1="31.576473"
        id="linearGradient4156"
-       x1="31.576473"
-       y1="36.323967"
-       x2="14.566413"
-       y2="9.5799379"
-       gradientUnits="userSpaceOnUse" />
+       xlink:href="#linearGradient3902-6" />
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3902-6"
+       gradientUnits="userSpaceOnUse"
+       y2="9.5799379"
+       x2="14.566413"
+       y1="36.323967"
+       x1="31.576473"
        id="linearGradient4164"
-       x1="31.576473"
-       y1="36.323967"
-       x2="14.566413"
-       y2="9.5799379"
-       gradientUnits="userSpaceOnUse" />
+       xlink:href="#linearGradient3902-6" />
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3902-6"
+       gradientUnits="userSpaceOnUse"
+       y2="9.5799379"
+       x2="14.566413"
+       y1="36.323967"
+       x1="31.576473"
        id="linearGradient4172"
-       x1="31.576473"
-       y1="36.323967"
-       x2="14.566413"
-       y2="9.5799379"
-       gradientUnits="userSpaceOnUse" />
+       xlink:href="#linearGradient3902-6" />
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3902-6"
+       gradientUnits="userSpaceOnUse"
+       y2="9.5799379"
+       x2="14.566413"
+       y1="36.323967"
+       x1="31.576473"
        id="linearGradient4180"
-       x1="31.576473"
-       y1="36.323967"
-       x2="14.566413"
-       y2="9.5799379"
-       gradientUnits="userSpaceOnUse" />
+       xlink:href="#linearGradient3902-6" />
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3902-6"
+       gradientUnits="userSpaceOnUse"
+       y2="9.5799379"
+       x2="14.566413"
+       y1="36.323967"
+       x1="31.576473"
        id="linearGradient4188"
-       x1="31.576473"
-       y1="36.323967"
-       x2="14.566413"
-       y2="9.5799379"
-       gradientUnits="userSpaceOnUse" />
+       xlink:href="#linearGradient3902-6" />
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3902-6"
+       gradientUnits="userSpaceOnUse"
+       y2="9.5799379"
+       x2="14.566413"
+       y1="36.323967"
+       x1="31.576473"
        id="linearGradient4196"
-       x1="31.576473"
-       y1="36.323967"
-       x2="14.566413"
-       y2="9.5799379"
-       gradientUnits="userSpaceOnUse" />
+       xlink:href="#linearGradient3902-6" />
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3902-6"
+       gradientUnits="userSpaceOnUse"
+       y2="9.5799379"
+       x2="14.566413"
+       y1="36.323967"
+       x1="31.576473"
        id="linearGradient4204"
-       x1="31.576473"
-       y1="36.323967"
-       x2="14.566413"
-       y2="9.5799379"
-       gradientUnits="userSpaceOnUse" />
+       xlink:href="#linearGradient3902-6" />
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3902-6"
+       gradientUnits="userSpaceOnUse"
+       y2="9.5799379"
+       x2="14.566413"
+       y1="36.323967"
+       x1="31.576473"
        id="linearGradient4212"
-       x1="31.576473"
-       y1="36.323967"
-       x2="14.566413"
-       y2="9.5799379"
-       gradientUnits="userSpaceOnUse" />
+       xlink:href="#linearGradient3902-6" />
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3902-6"
+       gradientUnits="userSpaceOnUse"
+       y2="9.5799379"
+       x2="14.566413"
+       y1="36.323967"
+       x1="31.576473"
        id="linearGradient4220"
-       x1="31.576473"
-       y1="36.323967"
-       x2="14.566413"
-       y2="9.5799379"
-       gradientUnits="userSpaceOnUse" />
+       xlink:href="#linearGradient3902-6" />
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3902-6"
+       gradientUnits="userSpaceOnUse"
+       y2="9.5799379"
+       x2="14.566413"
+       y1="36.323967"
+       x1="31.576473"
        id="linearGradient4228"
-       x1="31.576473"
-       y1="36.323967"
-       x2="14.566413"
-       y2="9.5799379"
-       gradientUnits="userSpaceOnUse" />
+       xlink:href="#linearGradient3902-6" />
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3902-6"
+       gradientUnits="userSpaceOnUse"
+       y2="9.5799379"
+       x2="14.566413"
+       y1="36.323967"
+       x1="31.576473"
        id="linearGradient4236"
-       x1="31.576473"
-       y1="36.323967"
-       x2="14.566413"
-       y2="9.5799379"
-       gradientUnits="userSpaceOnUse" />
+       xlink:href="#linearGradient3902-6" />
     <linearGradient
-       y2="9.5799379"
-       x2="14.566413"
-       y1="36.323967"
-       x1="31.576473"
-       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3902-6"
        id="linearGradient4285"
-       xlink:href="#linearGradient3902-6"
-       inkscape:collect="always" />
-    <linearGradient
-       y2="9.5799379"
-       x2="14.566413"
-       y1="36.323967"
-       x1="31.576473"
        gradientUnits="userSpaceOnUse"
+       x1="31.576473"
+       y1="36.323967"
+       x2="14.566413"
+       y2="9.5799379" />
+    <linearGradient
+       xlink:href="#linearGradient3902-6"
        id="linearGradient4287"
-       xlink:href="#linearGradient3902-6"
-       inkscape:collect="always" />
-    <linearGradient
-       y2="9.5799379"
-       x2="14.566413"
-       y1="36.323967"
-       x1="31.576473"
        gradientUnits="userSpaceOnUse"
+       x1="31.576473"
+       y1="36.323967"
+       x2="14.566413"
+       y2="9.5799379" />
+    <linearGradient
+       xlink:href="#linearGradient3902-6"
        id="linearGradient4289"
-       xlink:href="#linearGradient3902-6"
-       inkscape:collect="always" />
-    <linearGradient
-       y2="9.5799379"
-       x2="14.566413"
-       y1="36.323967"
-       x1="31.576473"
        gradientUnits="userSpaceOnUse"
+       x1="31.576473"
+       y1="36.323967"
+       x2="14.566413"
+       y2="9.5799379" />
+    <linearGradient
+       xlink:href="#linearGradient3902-6"
        id="linearGradient4291"
-       xlink:href="#linearGradient3902-6"
-       inkscape:collect="always" />
-    <linearGradient
-       y2="9.5799379"
-       x2="14.566413"
-       y1="36.323967"
-       x1="31.576473"
        gradientUnits="userSpaceOnUse"
+       x1="31.576473"
+       y1="36.323967"
+       x2="14.566413"
+       y2="9.5799379" />
+    <linearGradient
+       xlink:href="#linearGradient3902-6"
        id="linearGradient4293"
-       xlink:href="#linearGradient3902-6"
-       inkscape:collect="always" />
-    <linearGradient
-       y2="9.5799379"
-       x2="14.566413"
-       y1="36.323967"
-       x1="31.576473"
        gradientUnits="userSpaceOnUse"
+       x1="31.576473"
+       y1="36.323967"
+       x2="14.566413"
+       y2="9.5799379" />
+    <linearGradient
+       xlink:href="#linearGradient3902-6"
        id="linearGradient4295"
-       xlink:href="#linearGradient3902-6"
-       inkscape:collect="always" />
-    <linearGradient
-       y2="9.5799379"
-       x2="14.566413"
-       y1="36.323967"
-       x1="31.576473"
        gradientUnits="userSpaceOnUse"
+       x1="31.576473"
+       y1="36.323967"
+       x2="14.566413"
+       y2="9.5799379" />
+    <linearGradient
+       xlink:href="#linearGradient3902-6"
        id="linearGradient4297"
-       xlink:href="#linearGradient3902-6"
-       inkscape:collect="always" />
-    <linearGradient
-       y2="9.5799379"
-       x2="14.566413"
-       y1="36.323967"
-       x1="31.576473"
        gradientUnits="userSpaceOnUse"
+       x1="31.576473"
+       y1="36.323967"
+       x2="14.566413"
+       y2="9.5799379" />
+    <linearGradient
+       xlink:href="#linearGradient3902-6"
        id="linearGradient4299"
-       xlink:href="#linearGradient3902-6"
-       inkscape:collect="always" />
-    <linearGradient
-       y2="9.5799379"
-       x2="14.566413"
-       y1="36.323967"
-       x1="31.576473"
        gradientUnits="userSpaceOnUse"
+       x1="31.576473"
+       y1="36.323967"
+       x2="14.566413"
+       y2="9.5799379" />
+    <linearGradient
+       xlink:href="#linearGradient3902-6"
        id="linearGradient4301"
-       xlink:href="#linearGradient3902-6"
-       inkscape:collect="always" />
-    <linearGradient
-       y2="9.5799379"
-       x2="14.566413"
-       y1="36.323967"
-       x1="31.576473"
        gradientUnits="userSpaceOnUse"
+       x1="31.576473"
+       y1="36.323967"
+       x2="14.566413"
+       y2="9.5799379" />
+    <linearGradient
+       xlink:href="#linearGradient3902-6"
        id="linearGradient4303"
-       xlink:href="#linearGradient3902-6"
-       inkscape:collect="always" />
-    <linearGradient
-       y2="9.5799379"
-       x2="14.566413"
-       y1="36.323967"
-       x1="31.576473"
        gradientUnits="userSpaceOnUse"
+       x1="31.576473"
+       y1="36.323967"
+       x2="14.566413"
+       y2="9.5799379" />
+    <linearGradient
+       xlink:href="#linearGradient3902-6"
        id="linearGradient4305"
-       xlink:href="#linearGradient3902-6"
-       inkscape:collect="always" />
-    <linearGradient
-       y2="9.5799379"
-       x2="14.566413"
-       y1="36.323967"
-       x1="31.576473"
        gradientUnits="userSpaceOnUse"
+       x1="31.576473"
+       y1="36.323967"
+       x2="14.566413"
+       y2="9.5799379" />
+    <linearGradient
+       xlink:href="#linearGradient3902-6"
        id="linearGradient4307"
-       xlink:href="#linearGradient3902-6"
-       inkscape:collect="always" />
-    <linearGradient
-       y2="9.5799379"
-       x2="14.566413"
-       y1="36.323967"
-       x1="31.576473"
        gradientUnits="userSpaceOnUse"
+       x1="31.576473"
+       y1="36.323967"
+       x2="14.566413"
+       y2="9.5799379" />
+    <linearGradient
+       xlink:href="#linearGradient3902-6"
        id="linearGradient4309"
-       xlink:href="#linearGradient3902-6"
-       inkscape:collect="always" />
-    <linearGradient
-       y2="9.5799379"
-       x2="14.566413"
-       y1="36.323967"
-       x1="31.576473"
        gradientUnits="userSpaceOnUse"
+       x1="31.576473"
+       y1="36.323967"
+       x2="14.566413"
+       y2="9.5799379" />
+    <linearGradient
+       xlink:href="#linearGradient3902-6"
        id="linearGradient4311"
-       xlink:href="#linearGradient3902-6"
-       inkscape:collect="always" />
-    <linearGradient
-       y2="9.5799379"
-       x2="14.566413"
-       y1="36.323967"
-       x1="31.576473"
        gradientUnits="userSpaceOnUse"
+       x1="31.576473"
+       y1="36.323967"
+       x2="14.566413"
+       y2="9.5799379" />
+    <linearGradient
+       xlink:href="#linearGradient3902-6"
        id="linearGradient4313"
-       xlink:href="#linearGradient3902-6"
-       inkscape:collect="always" />
-    <linearGradient
-       y2="9.5799379"
-       x2="14.566413"
-       y1="36.323967"
-       x1="31.576473"
        gradientUnits="userSpaceOnUse"
+       x1="31.576473"
+       y1="36.323967"
+       x2="14.566413"
+       y2="9.5799379" />
+    <linearGradient
+       xlink:href="#linearGradient3902-6"
        id="linearGradient4315"
-       xlink:href="#linearGradient3902-6"
-       inkscape:collect="always" />
-    <linearGradient
-       y2="9.5799379"
-       x2="14.566413"
-       y1="36.323967"
-       x1="31.576473"
        gradientUnits="userSpaceOnUse"
+       x1="31.576473"
+       y1="36.323967"
+       x2="14.566413"
+       y2="9.5799379" />
+    <linearGradient
+       xlink:href="#linearGradient3902-6"
        id="linearGradient4317"
-       xlink:href="#linearGradient3902-6"
-       inkscape:collect="always" />
-    <linearGradient
-       y2="9.5799379"
-       x2="14.566413"
-       y1="36.323967"
-       x1="31.576473"
        gradientUnits="userSpaceOnUse"
+       x1="31.576473"
+       y1="36.323967"
+       x2="14.566413"
+       y2="9.5799379" />
+    <linearGradient
+       xlink:href="#linearGradient3902-6"
        id="linearGradient4319"
-       xlink:href="#linearGradient3902-6"
-       inkscape:collect="always" />
-    <linearGradient
-       y2="9.5799379"
-       x2="14.566413"
-       y1="36.323967"
-       x1="31.576473"
        gradientUnits="userSpaceOnUse"
+       x1="31.576473"
+       y1="36.323967"
+       x2="14.566413"
+       y2="9.5799379" />
+    <linearGradient
+       xlink:href="#linearGradient3902-6"
        id="linearGradient4321"
-       xlink:href="#linearGradient3902-6"
-       inkscape:collect="always" />
-    <linearGradient
-       y2="9.5799379"
-       x2="14.566413"
-       y1="36.323967"
-       x1="31.576473"
        gradientUnits="userSpaceOnUse"
+       x1="31.576473"
+       y1="36.323967"
+       x2="14.566413"
+       y2="9.5799379" />
+    <linearGradient
+       xlink:href="#linearGradient3902-6"
        id="linearGradient4323"
-       xlink:href="#linearGradient3902-6"
-       inkscape:collect="always" />
-    <linearGradient
-       y2="9.5799379"
-       x2="14.566413"
-       y1="36.323967"
-       x1="31.576473"
        gradientUnits="userSpaceOnUse"
+       x1="31.576473"
+       y1="36.323967"
+       x2="14.566413"
+       y2="9.5799379" />
+    <linearGradient
+       xlink:href="#linearGradient3902-6"
        id="linearGradient4325"
-       xlink:href="#linearGradient3902-6"
-       inkscape:collect="always" />
-    <linearGradient
-       y2="9.5799379"
-       x2="14.566413"
-       y1="36.323967"
-       x1="31.576473"
        gradientUnits="userSpaceOnUse"
+       x1="31.576473"
+       y1="36.323967"
+       x2="14.566413"
+       y2="9.5799379" />
+    <linearGradient
+       xlink:href="#linearGradient3902-6"
        id="linearGradient4327"
-       xlink:href="#linearGradient3902-6"
-       inkscape:collect="always" />
-    <linearGradient
-       y2="9.5799379"
-       x2="14.566413"
-       y1="36.323967"
-       x1="31.576473"
        gradientUnits="userSpaceOnUse"
+       x1="31.576473"
+       y1="36.323967"
+       x2="14.566413"
+       y2="9.5799379" />
+    <linearGradient
+       xlink:href="#linearGradient3902-6"
        id="linearGradient4329"
-       xlink:href="#linearGradient3902-6"
-       inkscape:collect="always" />
-    <linearGradient
-       y2="9.5799379"
-       x2="14.566413"
-       y1="36.323967"
-       x1="31.576473"
        gradientUnits="userSpaceOnUse"
+       x1="31.576473"
+       y1="36.323967"
+       x2="14.566413"
+       y2="9.5799379" />
+    <linearGradient
+       xlink:href="#linearGradient3902-6"
        id="linearGradient4331"
-       xlink:href="#linearGradient3902-6"
-       inkscape:collect="always" />
-    <linearGradient
-       y2="9.5799379"
-       x2="14.566413"
-       y1="36.323967"
-       x1="31.576473"
        gradientUnits="userSpaceOnUse"
+       x1="31.576473"
+       y1="36.323967"
+       x2="14.566413"
+       y2="9.5799379" />
+    <linearGradient
+       xlink:href="#linearGradient3902-6"
        id="linearGradient4333"
-       xlink:href="#linearGradient3902-6"
-       inkscape:collect="always" />
-    <linearGradient
-       y2="9.5799379"
-       x2="14.566413"
-       y1="36.323967"
-       x1="31.576473"
        gradientUnits="userSpaceOnUse"
+       x1="31.576473"
+       y1="36.323967"
+       x2="14.566413"
+       y2="9.5799379" />
+    <linearGradient
+       xlink:href="#linearGradient3902-6"
        id="linearGradient4335"
-       xlink:href="#linearGradient3902-6"
-       inkscape:collect="always" />
-    <linearGradient
-       y2="9.5799379"
-       x2="14.566413"
-       y1="36.323967"
-       x1="31.576473"
        gradientUnits="userSpaceOnUse"
+       x1="31.576473"
+       y1="36.323967"
+       x2="14.566413"
+       y2="9.5799379" />
+    <linearGradient
+       xlink:href="#linearGradient3902-6"
        id="linearGradient4337"
-       xlink:href="#linearGradient3902-6"
-       inkscape:collect="always" />
-    <linearGradient
-       y2="9.5799379"
-       x2="14.566413"
-       y1="36.323967"
-       x1="31.576473"
        gradientUnits="userSpaceOnUse"
+       x1="31.576473"
+       y1="36.323967"
+       x2="14.566413"
+       y2="9.5799379" />
+    <linearGradient
+       xlink:href="#linearGradient3902-6"
        id="linearGradient4339"
-       xlink:href="#linearGradient3902-6"
-       inkscape:collect="always" />
-    <linearGradient
-       y2="9.5799379"
-       x2="14.566413"
-       y1="36.323967"
-       x1="31.576473"
        gradientUnits="userSpaceOnUse"
+       x1="31.576473"
+       y1="36.323967"
+       x2="14.566413"
+       y2="9.5799379" />
+    <linearGradient
+       xlink:href="#linearGradient3902-6"
        id="linearGradient4341"
-       xlink:href="#linearGradient3902-6"
-       inkscape:collect="always" />
-    <linearGradient
-       y2="9.5799379"
-       x2="14.566413"
-       y1="36.323967"
-       x1="31.576473"
        gradientUnits="userSpaceOnUse"
+       x1="31.576473"
+       y1="36.323967"
+       x2="14.566413"
+       y2="9.5799379" />
+    <linearGradient
+       xlink:href="#linearGradient3902-6"
        id="linearGradient4343"
-       xlink:href="#linearGradient3902-6"
-       inkscape:collect="always" />
-    <linearGradient
-       y2="9.5799379"
-       x2="14.566413"
-       y1="36.323967"
-       x1="31.576473"
        gradientUnits="userSpaceOnUse"
+       x1="31.576473"
+       y1="36.323967"
+       x2="14.566413"
+       y2="9.5799379" />
+    <linearGradient
+       xlink:href="#linearGradient3902-6"
        id="linearGradient4345"
-       xlink:href="#linearGradient3902-6"
-       inkscape:collect="always" />
-    <linearGradient
-       y2="9.5799379"
-       x2="14.566413"
-       y1="36.323967"
-       x1="31.576473"
        gradientUnits="userSpaceOnUse"
+       x1="31.576473"
+       y1="36.323967"
+       x2="14.566413"
+       y2="9.5799379" />
+    <linearGradient
+       xlink:href="#linearGradient3902-6"
        id="linearGradient4347"
-       xlink:href="#linearGradient3902-6"
-       inkscape:collect="always" />
-    <linearGradient
-       y2="9.5799379"
-       x2="14.566413"
-       y1="36.323967"
-       x1="31.576473"
        gradientUnits="userSpaceOnUse"
+       x1="31.576473"
+       y1="36.323967"
+       x2="14.566413"
+       y2="9.5799379" />
+    <linearGradient
+       xlink:href="#linearGradient3902-6"
        id="linearGradient4349"
-       xlink:href="#linearGradient3902-6"
-       inkscape:collect="always" />
-    <linearGradient
-       y2="9.5799379"
-       x2="14.566413"
-       y1="36.323967"
-       x1="31.576473"
        gradientUnits="userSpaceOnUse"
+       x1="31.576473"
+       y1="36.323967"
+       x2="14.566413"
+       y2="9.5799379" />
+    <linearGradient
+       xlink:href="#linearGradient3902-6"
        id="linearGradient4351"
-       xlink:href="#linearGradient3902-6"
-       inkscape:collect="always" />
-    <linearGradient
-       y2="9.5799379"
-       x2="14.566413"
-       y1="36.323967"
-       x1="31.576473"
        gradientUnits="userSpaceOnUse"
+       x1="31.576473"
+       y1="36.323967"
+       x2="14.566413"
+       y2="9.5799379" />
+    <linearGradient
+       xlink:href="#linearGradient3902-6"
        id="linearGradient4353"
-       xlink:href="#linearGradient3902-6"
-       inkscape:collect="always" />
-    <linearGradient
-       y2="9.5799379"
-       x2="14.566413"
-       y1="36.323967"
-       x1="31.576473"
        gradientUnits="userSpaceOnUse"
+       x1="31.576473"
+       y1="36.323967"
+       x2="14.566413"
+       y2="9.5799379" />
+    <linearGradient
+       xlink:href="#linearGradient3902-6"
        id="linearGradient4355"
-       xlink:href="#linearGradient3902-6"
-       inkscape:collect="always" />
-    <linearGradient
-       y2="9.5799379"
-       x2="14.566413"
-       y1="36.323967"
-       x1="31.576473"
        gradientUnits="userSpaceOnUse"
+       x1="31.576473"
+       y1="36.323967"
+       x2="14.566413"
+       y2="9.5799379" />
+    <linearGradient
+       xlink:href="#linearGradient3902-6"
        id="linearGradient4357"
-       xlink:href="#linearGradient3902-6"
-       inkscape:collect="always" />
-    <linearGradient
-       y2="9.5799379"
-       x2="14.566413"
-       y1="36.323967"
-       x1="31.576473"
        gradientUnits="userSpaceOnUse"
+       x1="31.576473"
+       y1="36.323967"
+       x2="14.566413"
+       y2="9.5799379" />
+    <linearGradient
+       xlink:href="#linearGradient3902-6"
        id="linearGradient4359"
-       xlink:href="#linearGradient3902-6"
-       inkscape:collect="always" />
-    <linearGradient
-       y2="9.5799379"
-       x2="14.566413"
-       y1="36.323967"
-       x1="31.576473"
        gradientUnits="userSpaceOnUse"
+       x1="31.576473"
+       y1="36.323967"
+       x2="14.566413"
+       y2="9.5799379" />
+    <linearGradient
+       xlink:href="#linearGradient3902-6"
        id="linearGradient4361"
-       xlink:href="#linearGradient3902-6"
-       inkscape:collect="always" />
-    <linearGradient
-       y2="9.5799379"
-       x2="14.566413"
-       y1="36.323967"
-       x1="31.576473"
        gradientUnits="userSpaceOnUse"
+       x1="31.576473"
+       y1="36.323967"
+       x2="14.566413"
+       y2="9.5799379" />
+    <linearGradient
+       xlink:href="#linearGradient3902-6"
        id="linearGradient4363"
-       xlink:href="#linearGradient3902-6"
-       inkscape:collect="always" />
-    <linearGradient
-       y2="9.5799379"
-       x2="14.566413"
-       y1="36.323967"
-       x1="31.576473"
        gradientUnits="userSpaceOnUse"
-       id="linearGradient4365"
+       x1="31.576473"
+       y1="36.323967"
+       x2="14.566413"
+       y2="9.5799379" />
+    <linearGradient
        xlink:href="#linearGradient3902-6"
-       inkscape:collect="always" />
+       id="linearGradient4365"
+       gradientUnits="userSpaceOnUse"
+       x1="31.576473"
+       y1="36.323967"
+       x2="14.566413"
+       y2="9.5799379" />
     <filter
-       inkscape:label="Darken edges"
-       inkscape:menu="Shadows and Glows"
-       inkscape:menu-tooltip="Darken the edges with an inner blur"
-       color-interpolation-filters="sRGB"
-       id="filter4864">
+       id="filter4864"
+       color-interpolation-filters="sRGB">
       <feGaussianBlur
-         result="result6"
+         id="feGaussianBlur4866"
          stdDeviation="1.5"
-         id="feGaussianBlur4866" />
+         result="result6" />
       <feComposite
-         in2="result6"
-         operator="atop"
-         in="SourceGraphic"
+         id="feComposite4868"
          result="result8"
-         id="feComposite4868" />
-      <feComposite
-         in="result8"
-         in2="SourceAlpha"
+         in="SourceGraphic"
          operator="atop"
+         in2="result6" />
+      <feComposite
+         id="feComposite4870"
          result="result9"
-         id="feComposite4870" />
+         operator="atop"
+         in2="SourceAlpha"
+         in="result8" />
     </filter>
     <linearGradient
-       inkscape:collect="always"
        id="linearGradient3902-6-0">
       <stop
-         style="stop-color:#4e9a06;stop-opacity:1"
+         id="stop3904-7-3"
          offset="0"
-         id="stop3904-7-3" />
+         style="stop-color:#4e9a06;stop-opacity:1" />
       <stop
-         style="stop-color:#8ae234;stop-opacity:1"
+         id="stop3906-5-6"
          offset="1"
-         id="stop3906-5-6" />
+         style="stop-color:#8ae234;stop-opacity:1" />
     </linearGradient>
     <linearGradient
-       y2="9.5799379"
-       x2="14.566413"
-       y1="36.323967"
-       x1="31.576473"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient4363-9"
        xlink:href="#linearGradient3902-6-0"
-       inkscape:collect="always" />
+       id="linearGradient4363-9"
+       gradientUnits="userSpaceOnUse"
+       x1="31.576473"
+       y1="36.323967"
+       x2="14.566413"
+       y2="9.5799379" />
     <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3962-7"
-       id="radialGradient3968-4"
-       gradientTransform="matrix(1.3888978,0,0,1.3889284,-2.124907,-18.68781)"
-       cx="18.247644"
-       cy="15.716079"
-       fx="18.247644"
-       fy="15.716079"
+       gradientUnits="userSpaceOnUse"
        r="29.993349"
-       gradientUnits="userSpaceOnUse" />
+       fy="15.716079"
+       fx="18.247644"
+       cy="15.716079"
+       cx="18.247644"
+       gradientTransform="matrix(1.3888978,0,0,1.3889284,-2.124907,-18.68781)"
+       id="radialGradient3968-4"
+       xlink:href="#linearGradient3962-7" />
     <linearGradient
        id="linearGradient3962-7">
       <stop
-         style="stop-color:#d3e9ff;stop-opacity:1.0000000;"
+         id="stop3964-2"
          offset="0.0000000"
-         id="stop3964-2" />
+         style="stop-color:#d3e9ff;stop-opacity:1.0000000;" />
       <stop
-         style="stop-color:#d3e9ff;stop-opacity:1.0000000;"
+         id="stop4134-4"
          offset="0.15517241"
-         id="stop4134-4" />
+         style="stop-color:#d3e9ff;stop-opacity:1.0000000;" />
       <stop
-         style="stop-color:#4074ae;stop-opacity:1.0000000;"
+         id="stop4346-0"
          offset="0.75000000"
-         id="stop4346-0" />
+         style="stop-color:#4074ae;stop-opacity:1.0000000;" />
       <stop
-         style="stop-color:#36486c;stop-opacity:1.0000000;"
+         id="stop3966-6"
          offset="1.0000000"
-         id="stop3966-6" />
+         style="stop-color:#36486c;stop-opacity:1.0000000;" />
     </linearGradient>
   </defs>
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="0.17254902"
-     inkscape:pageopacity="0.0"
-     inkscape:pageshadow="2"
-     inkscape:zoom="6.3515314"
-     inkscape:cx="4.8618907"
-     inkscape:cy="39.584987"
-     inkscape:current-layer="layer1"
-     showgrid="true"
-     inkscape:grid-bbox="true"
-     inkscape:document-units="px"
-     inkscape:window-width="1440"
-     inkscape:window-height="823"
-     inkscape:window-x="0"
-     inkscape:window-y="27"
-     inkscape:showpageshadow="false"
-     inkscape:snap-bbox="true"
-     inkscape:snap-nodes="false"
-     inkscape:window-maximized="0">
-    <inkscape:grid
-       type="xygrid"
-       id="grid3132"
-       empspacing="2"
-       visible="true"
-       enabled="true"
-       snapvisiblegridlinesonly="true" />
-  </sodipodi:namedview>
   <metadata
      id="metadata4">
     <rdf:RDF>
@@ -1024,7 +882,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title>Globe</dc:title>
+        <dc:title></dc:title>
         <dc:creator>
           <cc:Agent>
             <dc:title>Jakub Steiner</dc:title>
@@ -1061,402 +919,359 @@
     </rdf:RDF>
   </metadata>
   <g
-     id="layer1"
-     inkscape:label="Layer 1"
-     inkscape:groupmode="layer"
-     transform="translate(0,16)">
+     transform="translate(0,16)"
+     id="layer1">
     <path
-       sodipodi:type="arc"
-       style="fill:url(#radialGradient4120);fill-opacity:1;stroke:none;stroke-width:1.29144747"
-       id="path4112"
-       sodipodi:cx="24.849752"
-       sodipodi:cy="38.908627"
-       sodipodi:rx="20.203051"
-       sodipodi:ry="7.4751287"
+       transform="matrix(1.3889131,0,0,1.7267578,-2.124907,-32.955294)"
        d="m 45.052803,38.908627 a 20.203051,7.4751287 0 1 1 -40.4061012,0 20.203051,7.4751287 0 1 1 40.4061012,0 z"
-       transform="matrix(1.3889131,0,0,1.7267578,-2.124907,-32.955294)" />
+       id="path4112"
+       style="fill:url(#radialGradient4120);fill-opacity:1;stroke:none;stroke-width:1.29144747" />
     <path
-       style="fill:url(#radialGradient3968);fill-opacity:1;fill-rule:nonzero;stroke:#39396c;stroke-width:2;stroke-miterlimit:4;stroke-opacity:1"
-       d="M 58.931509,13.931507 C 58.931509,28.806375 46.872822,40.864925 32,40.864925 17.125816,40.864925 5.0678105,28.806239 5.0678105,13.931507 5.0678105,-0.94267845 17.125816,-13 32,-13 c 14.872822,0 26.931509,12.05732155 26.931509,26.931507 l 0,0 z"
        id="path3214"
-       inkscape:connector-curvature="0" />
+       d="M 58.931509,13.931507 C 58.931509,28.806375 46.872822,40.864925 32,40.864925 17.125816,40.864925 5.0678105,28.806239 5.0678105,13.931507 5.0678105,-0.94267845 17.125816,-13 32,-13 c 14.872822,0 26.931509,12.05732155 26.931509,26.931507 l 0,0 z"
+       style="fill:url(#radialGradient3968);fill-opacity:1;fill-rule:nonzero;stroke:#39396c;stroke-width:2;stroke-miterlimit:4;stroke-opacity:1" />
     <path
-       sodipodi:type="arc"
-       style="opacity:0.42159382000000001;fill:url(#radialGradient4356);fill-opacity:1;stroke:none;stroke-width:1.57495408"
-       id="path4348"
-       sodipodi:cx="17.778685"
-       sodipodi:cy="15.271057"
-       sodipodi:rx="12.929953"
-       sodipodi:ry="9.2934036"
+       transform="matrix(1.1610452,0,0,1.3889131,11.607093,-18.68781)"
        d="m 30.708637,15.271057 a 12.929953,9.2934036 0 1 1 -25.859905,0 12.929953,9.2934036 0 1 1 25.859905,0 z"
-       transform="matrix(1.1610452,0,0,1.3889131,11.607093,-18.68781)" />
+       id="path4348"
+       style="opacity:0.42159382000000001;fill:url(#radialGradient4356);fill-opacity:1;stroke:none;stroke-width:1.57495408" />
     <g
-       id="g3216-2"
+       transform="matrix(1.3521411,0,0,1.3460948,-1.6958463,-18.024821)"
        style="color:#000000;fill:url(#linearGradient4365);fill-opacity:1;fill-rule:nonzero;stroke:#172a04;stroke-width:1.46614679999999997;marker:none;visibility:visible;display:inline;overflow:visible;stroke-miterlimit:4;stroke-dasharray:none;stroke-linejoin:round"
-       transform="matrix(1.3521411,0,0,1.3460948,-1.6958463,-18.024821)">
+       id="g3216-2">
       <g
-         id="g3218-9"
-         style="color:#000000;fill:url(#linearGradient4289);fill-opacity:1;stroke-width:1.46614679999999997;marker:none;visibility:visible;display:inline;overflow:visible;stroke:#172a04;stroke-miterlimit:4;stroke-dasharray:none;stroke-linejoin:round">
+         style="color:#000000;fill:url(#linearGradient4289);fill-opacity:1;stroke-width:1.46614679999999997;marker:none;visibility:visible;display:inline;overflow:visible;stroke:#172a04;stroke-miterlimit:4;stroke-dasharray:none;stroke-linejoin:round"
+         id="g3218-9">
         <g
-           id="g3222-1"
-           style="color:#000000;fill:url(#linearGradient4287);fill-opacity:1;stroke-width:1.46614679999999997;marker:none;visibility:visible;display:inline;overflow:visible;stroke:#172a04;stroke-miterlimit:4;stroke-dasharray:none;stroke-linejoin:round">
+           style="color:#000000;fill:url(#linearGradient4287);fill-opacity:1;stroke-width:1.46614679999999997;marker:none;visibility:visible;display:inline;overflow:visible;stroke:#172a04;stroke-miterlimit:4;stroke-dasharray:none;stroke-linejoin:round"
+           id="g3222-1">
           <path
-             d="m 44.0713,20.7144 c 0,0.2627 0,0 0,0 l -0.5449,0.6172 c -0.334,-0.3936 -0.709,-0.7246 -1.0898,-1.0703 l -0.8359,0.123 -0.7637,-0.8633 0,1.0684 0.6543,0.4951 0.4355,0.4932 0.582,-0.6582 c 0.1465,0.2744 0.291,0.5488 0.4365,0.8232 l 0,0.8223 -0.6553,0.7402 -1.1992,0.8232 -0.9082,0.9063 -0.582,-0.6602 0.291,-0.7402 -0.5811,-0.6582 -0.9814,-2.0977 -0.8359,-0.9453 -0.2188,0.2461 0.3281,1.1934 0.6172,0.6992 c 0.3525,1.0176 0.7012,1.9902 1.1641,2.9629 0.7178,0 1.3945,-0.0762 2.1074,-0.166 l 0,0.5762 -0.8721,2.1392 -0.7998,0.9043 -0.6543,1.4004 c 0,0.7676 0,1.5352 0,2.3027 l 0.2188,0.9063 -0.3633,0.4102 -0.8008,0.4941 -0.8359,0.6992 0.6914,0.7813 -0.9453,0.8242 0.1816,0.5332 -1.418,1.6055 -0.9443,0 -0.7998,0.4941 -0.5098,0 0,-0.6582 -0.2168,-1.3184 c -0.2813,-0.8262 -0.5742,-1.6465 -0.8721,-2.4668 0,-0.6055 0.0361,-1.2051 0.0723,-1.8105 l 0.3643,-0.8223 -0.5098,-0.9883 0.0371,-1.3574 -0.6914,-0.7813 0.3457,-1.1309 -0.5625,-0.6382 -0.9824,0 -0.3271,-0.3701 -0.9814,0.6177 -0.3994,-0.4536 -0.9092,0.7817 c -0.6172,-0.6997 -1.2354,-1.3989 -1.8535,-2.0981 l -0.7266,-1.7285 0.6543,-0.9863 -0.3633,-0.4111 0.7988,-1.8936 c 0.6563,-0.8164 1.3418,-1.5996 2.0352,-2.3857 l 1.2363,-0.3291 1.3809,-0.1641 0.9453,0.2471 1.3447,1.3564 0.4727,-0.5342 0.6533,-0.082 1.2363,0.4111 0.9453,0 0.6543,-0.5762 0.291,-0.4111 -0.6553,-0.4111 -1.0908,-0.082 c -0.3027,-0.4199 -0.584,-0.8613 -0.9434,-1.2344 l -0.3643,0.1641 -0.1455,1.0703 -0.6543,-0.7402 -0.1445,-0.8242 -0.7266,-0.5742 -0.292,0 0.7275,0.8223 -0.291,0.7402 -0.5811,0.1641 0.3633,-0.7402 -0.6553,-0.3281 -0.5801,-0.6582 -1.0918,0.2461 -0.1445,0.3281 -0.6543,0.4121 -0.3633,0.9053 -0.9082,0.4521 -0.4004,-0.4521 -0.4355,0 0,-1.4814 0.9453,-0.4941 0.7266,0 -0.1465,-0.5752 -0.5801,-0.5762 0.9805,-0.2061 0.5449,-0.6162 0.4355,-0.7412 0.8008,0 -0.2188,-0.5752 0.5098,-0.3291 0,0.6582 1.0898,0.2461 1.0898,-0.9043 0.0732,-0.4121 0.9443,-0.6577 c -0.3418,0.0425 -0.6836,0.0737 -1.0176,0.1646 l 0,-0.7411 0.3633,-0.8228 -0.3633,0 -0.7984,0.7402 -0.2188,0.4116 0.2188,0.5767 -0.3643,0.9863 -0.5811,-0.3291 -0.5078,-0.5752 -0.8008,0.5752 -0.291,-1.3159 1.3809,-0.9048 0,-0.4941 0.873,-0.5757 1.3809,-0.3296 0.9453,0.3296 1.7441,0.3291 -0.4355,0.4932 -0.9453,0 0.9453,0.9873 0.7266,-0.8223 0.2207,-0.3618 c 0,0 2.7871,2.498 4.3799,5.2305 1.5928,2.7334 2.3408,5.9551 2.3408,6.6094 z"
-             id="path3224-2"
              style="color:#000000;fill:url(#linearGradient4285);fill-opacity:1;stroke-width:1.46614679999999997;marker:none;visibility:visible;display:inline;overflow:visible;stroke:#172a04;stroke-miterlimit:4;stroke-dasharray:none;stroke-linejoin:round"
-             inkscape:connector-curvature="0" />
+             id="path3224-2"
+             d="m 44.0713,20.7144 c 0,0.2627 0,0 0,0 l -0.5449,0.6172 c -0.334,-0.3936 -0.709,-0.7246 -1.0898,-1.0703 l -0.8359,0.123 -0.7637,-0.8633 0,1.0684 0.6543,0.4951 0.4355,0.4932 0.582,-0.6582 c 0.1465,0.2744 0.291,0.5488 0.4365,0.8232 l 0,0.8223 -0.6553,0.7402 -1.1992,0.8232 -0.9082,0.9063 -0.582,-0.6602 0.291,-0.7402 -0.5811,-0.6582 -0.9814,-2.0977 -0.8359,-0.9453 -0.2188,0.2461 0.3281,1.1934 0.6172,0.6992 c 0.3525,1.0176 0.7012,1.9902 1.1641,2.9629 0.7178,0 1.3945,-0.0762 2.1074,-0.166 l 0,0.5762 -0.8721,2.1392 -0.7998,0.9043 -0.6543,1.4004 c 0,0.7676 0,1.5352 0,2.3027 l 0.2188,0.9063 -0.3633,0.4102 -0.8008,0.4941 -0.8359,0.6992 0.6914,0.7813 -0.9453,0.8242 0.1816,0.5332 -1.418,1.6055 -0.9443,0 -0.7998,0.4941 -0.5098,0 0,-0.6582 -0.2168,-1.3184 c -0.2813,-0.8262 -0.5742,-1.6465 -0.8721,-2.4668 0,-0.6055 0.0361,-1.2051 0.0723,-1.8105 l 0.3643,-0.8223 -0.5098,-0.9883 0.0371,-1.3574 -0.6914,-0.7813 0.3457,-1.1309 -0.5625,-0.6382 -0.9824,0 -0.3271,-0.3701 -0.9814,0.6177 -0.3994,-0.4536 -0.9092,0.7817 c -0.6172,-0.6997 -1.2354,-1.3989 -1.8535,-2.0981 l -0.7266,-1.7285 0.6543,-0.9863 -0.3633,-0.4111 0.7988,-1.8936 c 0.6563,-0.8164 1.3418,-1.5996 2.0352,-2.3857 l 1.2363,-0.3291 1.3809,-0.1641 0.9453,0.2471 1.3447,1.3564 0.4727,-0.5342 0.6533,-0.082 1.2363,0.4111 0.9453,0 0.6543,-0.5762 0.291,-0.4111 -0.6553,-0.4111 -1.0908,-0.082 c -0.3027,-0.4199 -0.584,-0.8613 -0.9434,-1.2344 l -0.3643,0.1641 -0.1455,1.0703 -0.6543,-0.7402 -0.1445,-0.8242 -0.7266,-0.5742 -0.292,0 0.7275,0.8223 -0.291,0.7402 -0.5811,0.1641 0.3633,-0.7402 -0.6553,-0.3281 -0.5801,-0.6582 -1.0918,0.2461 -0.1445,0.3281 -0.6543,0.4121 -0.3633,0.9053 -0.9082,0.4521 -0.4004,-0.4521 -0.4355,0 0,-1.4814 0.9453,-0.4941 0.7266,0 -0.1465,-0.5752 -0.5801,-0.5762 0.9805,-0.2061 0.5449,-0.6162 0.4355,-0.7412 0.8008,0 -0.2188,-0.5752 0.5098,-0.3291 0,0.6582 1.0898,0.2461 1.0898,-0.9043 0.0732,-0.4121 0.9443,-0.6577 c -0.3418,0.0425 -0.6836,0.0737 -1.0176,0.1646 l 0,-0.7411 0.3633,-0.8228 -0.3633,0 -0.7984,0.7402 -0.2188,0.4116 0.2188,0.5767 -0.3643,0.9863 -0.5811,-0.3291 -0.5078,-0.5752 -0.8008,0.5752 -0.291,-1.3159 1.3809,-0.9048 0,-0.4941 0.873,-0.5757 1.3809,-0.3296 0.9453,0.3296 1.7441,0.3291 -0.4355,0.4932 -0.9453,0 0.9453,0.9873 0.7266,-0.8223 0.2207,-0.3618 c 0,0 2.7871,2.498 4.3799,5.2305 1.5928,2.7334 2.3408,5.9551 2.3408,6.6094 z" />
         </g>
       </g>
       <g
-         id="g3226-7"
-         style="color:#000000;fill:url(#linearGradient4295);fill-opacity:1;stroke-width:1.46614679999999997;marker:none;visibility:visible;display:inline;overflow:visible;stroke:#172a04;stroke-miterlimit:4;stroke-dasharray:none;stroke-linejoin:round">
+         style="color:#000000;fill:url(#linearGradient4295);fill-opacity:1;stroke-width:1.46614679999999997;marker:none;visibility:visible;display:inline;overflow:visible;stroke:#172a04;stroke-miterlimit:4;stroke-dasharray:none;stroke-linejoin:round"
+         id="g3226-7">
         <g
-           id="g3230-0"
-           style="color:#000000;fill:url(#linearGradient4293);fill-opacity:1;stroke-width:1.46614679999999997;marker:none;visibility:visible;display:inline;overflow:visible;stroke:#172a04;stroke-miterlimit:4;stroke-dasharray:none;stroke-linejoin:round">
+           style="color:#000000;fill:url(#linearGradient4293);fill-opacity:1;stroke-width:1.46614679999999997;marker:none;visibility:visible;display:inline;overflow:visible;stroke:#172a04;stroke-miterlimit:4;stroke-dasharray:none;stroke-linejoin:round"
+           id="g3230-0">
           <path
-             d="m 26.0703,9.2363 -0.0732,0.4932 0.5098,0.3291 0.8711,-0.5757 -0.4355,-0.4937 -0.582,0.3296 -0.29,-0.0825"
-             id="path3232-9"
              style="color:#000000;fill:url(#linearGradient4291);fill-opacity:1;stroke-width:1.46614679999999997;marker:none;visibility:visible;display:inline;overflow:visible;stroke:#172a04;stroke-miterlimit:4;stroke-dasharray:none;stroke-linejoin:round"
-             inkscape:connector-curvature="0" />
+             id="path3232-9"
+             d="m 26.0703,9.2363 -0.0732,0.4932 0.5098,0.3291 0.8711,-0.5757 -0.4355,-0.4937 -0.582,0.3296 -0.29,-0.0825" />
         </g>
       </g>
       <g
-         id="g3234-3"
-         style="color:#000000;fill:url(#linearGradient4301);fill-opacity:1;stroke-width:1.46614679999999997;marker:none;visibility:visible;display:inline;overflow:visible;stroke:#172a04;stroke-miterlimit:4;stroke-dasharray:none;stroke-linejoin:round">
+         style="color:#000000;fill:url(#linearGradient4301);fill-opacity:1;stroke-width:1.46614679999999997;marker:none;visibility:visible;display:inline;overflow:visible;stroke:#172a04;stroke-miterlimit:4;stroke-dasharray:none;stroke-linejoin:round"
+         id="g3234-3">
         <g
-           id="g3238-6"
-           style="color:#000000;fill:url(#linearGradient4299);fill-opacity:1;stroke-width:1.46614679999999997;marker:none;visibility:visible;display:inline;overflow:visible;stroke:#172a04;stroke-miterlimit:4;stroke-dasharray:none;stroke-linejoin:round">
+           style="color:#000000;fill:url(#linearGradient4299);fill-opacity:1;stroke-width:1.46614679999999997;marker:none;visibility:visible;display:inline;overflow:visible;stroke:#172a04;stroke-miterlimit:4;stroke-dasharray:none;stroke-linejoin:round"
+           id="g3238-6">
           <path
-             d="m 26.8701,5.8633 -1.8906,-0.7407 -2.1797,0.2466 -2.6904,0.7402 -0.5088,0.4941 1.6719,1.1514 0,0.6582 -0.6543,0.6582 0.873,1.729 0.5801,-0.3301 0.7285,-1.1514 c 1.123,-0.3472 2.1299,-0.7407 3.1973,-1.2344 l 0.873,-2.2212"
-             id="path3240-0"
              style="color:#000000;fill:url(#linearGradient4297);fill-opacity:1;stroke-width:1.46614679999999997;marker:none;visibility:visible;display:inline;overflow:visible;stroke:#172a04;stroke-miterlimit:4;stroke-dasharray:none;stroke-linejoin:round"
-             inkscape:connector-curvature="0" />
+             id="path3240-0"
+             d="m 26.8701,5.8633 -1.8906,-0.7407 -2.1797,0.2466 -2.6904,0.7402 -0.5088,0.4941 1.6719,1.1514 0,0.6582 -0.6543,0.6582 0.873,1.729 0.5801,-0.3301 0.7285,-1.1514 c 1.123,-0.3472 2.1299,-0.7407 3.1973,-1.2344 l 0.873,-2.2212" />
         </g>
       </g>
       <g
-         id="g3242-6"
-         style="color:#000000;fill:url(#linearGradient4307);fill-opacity:1;stroke-width:1.46614679999999997;marker:none;visibility:visible;display:inline;overflow:visible;stroke:#172a04;stroke-miterlimit:4;stroke-dasharray:none;stroke-linejoin:round">
+         style="color:#000000;fill:url(#linearGradient4307);fill-opacity:1;stroke-width:1.46614679999999997;marker:none;visibility:visible;display:inline;overflow:visible;stroke:#172a04;stroke-miterlimit:4;stroke-dasharray:none;stroke-linejoin:round"
+         id="g3242-6">
         <g
-           id="g3246-2"
-           style="color:#000000;fill:url(#linearGradient4305);fill-opacity:1;stroke-width:1.46614679999999997;marker:none;visibility:visible;display:inline;overflow:visible;stroke:#172a04;stroke-miterlimit:4;stroke-dasharray:none;stroke-linejoin:round">
+           style="color:#000000;fill:url(#linearGradient4305);fill-opacity:1;stroke-width:1.46614679999999997;marker:none;visibility:visible;display:inline;overflow:visible;stroke:#172a04;stroke-miterlimit:4;stroke-dasharray:none;stroke-linejoin:round"
+           id="g3246-2">
           <path
-             d="m 28.833,12.7749 -0.291,-0.7412 -0.5098,0.165 0.1465,0.9043 0.6543,-0.3281"
-             id="path3248-6"
              style="color:#000000;fill:url(#linearGradient4303);fill-opacity:1;stroke-width:1.46614679999999997;marker:none;visibility:visible;display:inline;overflow:visible;stroke:#172a04;stroke-miterlimit:4;stroke-dasharray:none;stroke-linejoin:round"
-             inkscape:connector-curvature="0" />
+             id="path3248-6"
+             d="m 28.833,12.7749 -0.291,-0.7412 -0.5098,0.165 0.1465,0.9043 0.6543,-0.3281" />
         </g>
       </g>
       <g
-         id="g3250-1"
-         style="color:#000000;fill:url(#linearGradient4313);fill-opacity:1;stroke-width:1.46614679999999997;marker:none;visibility:visible;display:inline;overflow:visible;stroke:#172a04;stroke-miterlimit:4;stroke-dasharray:none;stroke-linejoin:round">
+         style="color:#000000;fill:url(#linearGradient4313);fill-opacity:1;stroke-width:1.46614679999999997;marker:none;visibility:visible;display:inline;overflow:visible;stroke:#172a04;stroke-miterlimit:4;stroke-dasharray:none;stroke-linejoin:round"
+         id="g3250-1">
         <g
-           id="g3254-8"
-           style="color:#000000;fill:url(#linearGradient4311);fill-opacity:1;stroke-width:1.46614679999999997;marker:none;visibility:visible;display:inline;overflow:visible;stroke:#172a04;stroke-miterlimit:4;stroke-dasharray:none;stroke-linejoin:round">
+           style="color:#000000;fill:url(#linearGradient4311);fill-opacity:1;stroke-width:1.46614679999999997;marker:none;visibility:visible;display:inline;overflow:visible;stroke:#172a04;stroke-miterlimit:4;stroke-dasharray:none;stroke-linejoin:round"
+           id="g3254-8">
           <path
-             d="m 29.123,12.6089 -0.1455,0.9883 0.7998,-0.165 0.5811,-0.5752 -0.5088,-0.4941 C 29.6787,11.9078 29.4824,11.483 29.2685,11.0465 l -0.4355,0 0,0.4932 0.29,0.3291 0,0.7402"
-             id="path3256-7"
              style="color:#000000;fill:url(#linearGradient4309);fill-opacity:1;stroke-width:1.46614679999999997;marker:none;visibility:visible;display:inline;overflow:visible;stroke:#172a04;stroke-miterlimit:4;stroke-dasharray:none;stroke-linejoin:round"
-             inkscape:connector-curvature="0" />
+             id="path3256-7"
+             d="m 29.123,12.6089 -0.1455,0.9883 0.7998,-0.165 0.5811,-0.5752 -0.5088,-0.4941 C 29.6787,11.9078 29.4824,11.483 29.2685,11.0465 l -0.4355,0 0,0.4932 0.29,0.3291 0,0.7402" />
         </g>
       </g>
       <g
-         id="g3258-9"
-         style="color:#000000;fill:url(#linearGradient4319);fill-opacity:1;stroke-width:1.46614679999999997;marker:none;visibility:visible;display:inline;overflow:visible;stroke:#172a04;stroke-miterlimit:4;stroke-dasharray:none;stroke-linejoin:round">
+         style="color:#000000;fill:url(#linearGradient4319);fill-opacity:1;stroke-width:1.46614679999999997;marker:none;visibility:visible;display:inline;overflow:visible;stroke:#172a04;stroke-miterlimit:4;stroke-dasharray:none;stroke-linejoin:round"
+         id="g3258-9">
         <g
-           id="g3262-2"
-           style="color:#000000;fill:url(#linearGradient4317);fill-opacity:1;stroke-width:1.46614679999999997;marker:none;visibility:visible;display:inline;overflow:visible;stroke:#172a04;stroke-miterlimit:4;stroke-dasharray:none;stroke-linejoin:round">
+           style="color:#000000;fill:url(#linearGradient4317);fill-opacity:1;stroke-width:1.46614679999999997;marker:none;visibility:visible;display:inline;overflow:visible;stroke:#172a04;stroke-miterlimit:4;stroke-dasharray:none;stroke-linejoin:round"
+           id="g3262-2">
           <path
-             d="m 18.3652,28.2422 -0.582,-1.1523 -1.0903,-0.2466 -0.5815,-1.5625 -1.4536,0.1641 -1.2354,-0.9043 -1.3091,1.1514 0,0.1816 c -0.396,-0.1143 -0.8828,-0.1299 -1.2354,-0.3467 l -0.291,-0.8223 0,-0.9053 -0.8721,0.082 c 0.0728,-0.5762 0.145,-1.1514 0.2183,-1.7275 l -0.5093,0 -0.5083,0.6582 -0.5093,0.2461 -0.7271,-0.4102 -0.0728,-0.9053 0.1455,-0.9873 1.0908,-0.8223 0.8721,0 0.145,-0.4941 1.0903,0.2461 0.7998,0.9883 0.1455,-1.6465 1.3813,-1.1514 0.5088,-1.2344 1.0176,-0.4111 0.5815,-0.8223 1.3081,-0.248 0.6548,-0.9863 c -0.6543,0 -1.3086,0 -1.9629,0 l 1.2358,-0.5762 0.8716,0 1.2363,-0.4121 0.1455,-0.4922 -0.4365,-0.4121 -0.5088,-0.165 0.1455,-0.4932 -0.3633,-0.7402 -0.8726,0.3281 0.1455,-0.6577 -1.0176,-0.5762 -0.7993,1.3979 0.0723,0.4941 -0.7993,0.3301 -0.5093,1.0693 -0.2178,-0.9873 -1.3813,-0.5762 -0.2183,-0.7402 1.8174,-1.0703 0.7998,-0.7402 0.0728,-0.9048 -0.436,-0.2471 -0.5815,-0.0825 -0.3633,0.9053 c 0,0 -0.6079,0.1191 -0.7642,0.1577 -1.9961,1.8394 -6.0293,5.8101 -6.9663,13.3062 0.0371,0.1738 0.6792,1.1816 0.6792,1.1816 l 1.5264,0.9043 1.5264,0.4121 0.6548,0.8232 1.0171,0.7402 0.5815,-0.082 0.436,0.1963 0,0.1328 -0.5811,1.563 -0.4365,0.6582 0.1455,0.3301 -0.3633,1.2324 1.3086,2.3867 1.3081,1.1523 0.582,0.8223 -0.0732,1.7285 0.4365,0.9863 -0.4365,1.8926 c 0,0 -0.0342,-0.0117 0.0215,0.1777 0.0562,0.1895 2.3291,1.4512 2.4736,1.3438 0.144,-0.1094 0.2671,-0.2051 0.2671,-0.2051 l -0.145,-0.4102 0.5811,-0.5762 0.2183,-0.5762 0.9453,-0.3301 0.7266,-1.8105 -0.2178,-0.4922 0.5078,-0.7402 1.0908,-0.248 0.582,-1.3164 -0.1455,-1.6445 0.8721,-1.2344 0.1455,-1.2344 C 20.7331,29.4607 19.5495,28.8513 18.365,28.242"
-             id="path3264-0"
              style="color:#000000;fill:url(#linearGradient4315);fill-opacity:1;stroke-width:1.46614679999999997;marker:none;visibility:visible;display:inline;overflow:visible;stroke:#172a04;stroke-miterlimit:4;stroke-dasharray:none;stroke-linejoin:round"
-             inkscape:connector-curvature="0" />
+             id="path3264-0"
+             d="m 18.3652,28.2422 -0.582,-1.1523 -1.0903,-0.2466 -0.5815,-1.5625 -1.4536,0.1641 -1.2354,-0.9043 -1.3091,1.1514 0,0.1816 c -0.396,-0.1143 -0.8828,-0.1299 -1.2354,-0.3467 l -0.291,-0.8223 0,-0.9053 -0.8721,0.082 c 0.0728,-0.5762 0.145,-1.1514 0.2183,-1.7275 l -0.5093,0 -0.5083,0.6582 -0.5093,0.2461 -0.7271,-0.4102 -0.0728,-0.9053 0.1455,-0.9873 1.0908,-0.8223 0.8721,0 0.145,-0.4941 1.0903,0.2461 0.7998,0.9883 0.1455,-1.6465 1.3813,-1.1514 0.5088,-1.2344 1.0176,-0.4111 0.5815,-0.8223 1.3081,-0.248 0.6548,-0.9863 c -0.6543,0 -1.3086,0 -1.9629,0 l 1.2358,-0.5762 0.8716,0 1.2363,-0.4121 0.1455,-0.4922 -0.4365,-0.4121 -0.5088,-0.165 0.1455,-0.4932 -0.3633,-0.7402 -0.8726,0.3281 0.1455,-0.6577 -1.0176,-0.5762 -0.7993,1.3979 0.0723,0.4941 -0.7993,0.3301 -0.5093,1.0693 -0.2178,-0.9873 -1.3813,-0.5762 -0.2183,-0.7402 1.8174,-1.0703 0.7998,-0.7402 0.0728,-0.9048 -0.436,-0.2471 -0.5815,-0.0825 -0.3633,0.9053 c 0,0 -0.6079,0.1191 -0.7642,0.1577 -1.9961,1.8394 -6.0293,5.8101 -6.9663,13.3062 0.0371,0.1738 0.6792,1.1816 0.6792,1.1816 l 1.5264,0.9043 1.5264,0.4121 0.6548,0.8232 1.0171,0.7402 0.5815,-0.082 0.436,0.1963 0,0.1328 -0.5811,1.563 -0.4365,0.6582 0.1455,0.3301 -0.3633,1.2324 1.3086,2.3867 1.3081,1.1523 0.582,0.8223 -0.0732,1.7285 0.4365,0.9863 -0.4365,1.8926 c 0,0 -0.0342,-0.0117 0.0215,0.1777 0.0562,0.1895 2.3291,1.4512 2.4736,1.3438 0.144,-0.1094 0.2671,-0.2051 0.2671,-0.2051 l -0.145,-0.4102 0.5811,-0.5762 0.2183,-0.5762 0.9453,-0.3301 0.7266,-1.8105 -0.2178,-0.4922 0.5078,-0.7402 1.0908,-0.248 0.582,-1.3164 -0.1455,-1.6445 0.8721,-1.2344 0.1455,-1.2344 C 20.7331,29.4607 19.5495,28.8513 18.365,28.242" />
         </g>
       </g>
       <g
-         id="g3266-2"
-         style="color:#000000;fill:url(#linearGradient4325);fill-opacity:1;stroke-width:1.46614679999999997;marker:none;visibility:visible;display:inline;overflow:visible;stroke:#172a04;stroke-miterlimit:4;stroke-dasharray:none;stroke-linejoin:round">
+         style="color:#000000;fill:url(#linearGradient4325);fill-opacity:1;stroke-width:1.46614679999999997;marker:none;visibility:visible;display:inline;overflow:visible;stroke:#172a04;stroke-miterlimit:4;stroke-dasharray:none;stroke-linejoin:round"
+         id="g3266-2">
         <g
-           id="g3270-3"
-           style="color:#000000;fill:url(#linearGradient4323);fill-opacity:1;stroke-width:1.46614679999999997;marker:none;visibility:visible;display:inline;overflow:visible;stroke:#172a04;stroke-miterlimit:4;stroke-dasharray:none;stroke-linejoin:round">
+           style="color:#000000;fill:url(#linearGradient4323);fill-opacity:1;stroke-width:1.46614679999999997;marker:none;visibility:visible;display:inline;overflow:visible;stroke:#172a04;stroke-miterlimit:4;stroke-dasharray:none;stroke-linejoin:round"
+           id="g3270-3">
           <path
-             d="m 16.7656,9.5649 0.7266,0.4937 0.582,0 0,-0.5757 -0.7266,-0.3291 -0.582,0.4111"
-             id="path3272-7"
              style="color:#000000;fill:url(#linearGradient4321);fill-opacity:1;stroke-width:1.46614679999999997;marker:none;visibility:visible;display:inline;overflow:visible;stroke:#172a04;stroke-miterlimit:4;stroke-dasharray:none;stroke-linejoin:round"
-             inkscape:connector-curvature="0" />
+             id="path3272-7"
+             d="m 16.7656,9.5649 0.7266,0.4937 0.582,0 0,-0.5757 -0.7266,-0.3291 -0.582,0.4111" />
         </g>
       </g>
       <g
-         id="g3274-5"
-         style="color:#000000;fill:url(#linearGradient4331);fill-opacity:1;stroke-width:1.46614679999999997;marker:none;visibility:visible;display:inline;overflow:visible;stroke:#172a04;stroke-miterlimit:4;stroke-dasharray:none;stroke-linejoin:round">
+         style="color:#000000;fill:url(#linearGradient4331);fill-opacity:1;stroke-width:1.46614679999999997;marker:none;visibility:visible;display:inline;overflow:visible;stroke:#172a04;stroke-miterlimit:4;stroke-dasharray:none;stroke-linejoin:round"
+         id="g3274-5">
         <g
-           id="g3278-9"
-           style="color:#000000;fill:url(#linearGradient4329);fill-opacity:1;stroke-width:1.46614679999999997;marker:none;visibility:visible;display:inline;overflow:visible;stroke:#172a04;stroke-miterlimit:4;stroke-dasharray:none;stroke-linejoin:round">
+           style="color:#000000;fill:url(#linearGradient4329);fill-opacity:1;stroke-width:1.46614679999999997;marker:none;visibility:visible;display:inline;overflow:visible;stroke:#172a04;stroke-miterlimit:4;stroke-dasharray:none;stroke-linejoin:round"
+           id="g3278-9">
           <path
-             d="m 14.876,8.9072 -0.3638,0.9048 0.7271,0 0.3638,-0.8228 C 15.9166,8.7675 16.2286,8.5444 16.5479,8.331 l 0.7271,0.2471 c 0.4844,0.3291 0.9688,0.6582 1.4536,0.9868 L 19.4561,8.9072 18.6558,8.5781 18.292,7.8374 16.9111,7.6728 16.8383,7.2612 16.184,7.4262 15.8936,8.002 15.5298,7.2613 l -0.145,0.3291 0.0728,0.8228 -0.5816,0.494"
-             id="path3280-2"
              style="color:#000000;fill:url(#linearGradient4327);fill-opacity:1;stroke-width:1.46614679999999997;marker:none;visibility:visible;display:inline;overflow:visible;stroke:#172a04;stroke-miterlimit:4;stroke-dasharray:none;stroke-linejoin:round"
-             inkscape:connector-curvature="0" />
+             id="path3280-2"
+             d="m 14.876,8.9072 -0.3638,0.9048 0.7271,0 0.3638,-0.8228 C 15.9166,8.7675 16.2286,8.5444 16.5479,8.331 l 0.7271,0.2471 c 0.4844,0.3291 0.9688,0.6582 1.4536,0.9868 L 19.4561,8.9072 18.6558,8.5781 18.292,7.8374 16.9111,7.6728 16.8383,7.2612 16.184,7.4262 15.8936,8.002 15.5298,7.2613 l -0.145,0.3291 0.0728,0.8228 -0.5816,0.494" />
         </g>
       </g>
       <g
-         id="g3282-2"
-         style="color:#000000;fill:url(#linearGradient4341);fill-opacity:1;stroke-width:1.46614679999999997;marker:none;visibility:visible;display:inline;overflow:visible;stroke:#172a04;stroke-miterlimit:4;stroke-dasharray:none;stroke-linejoin:round">
+         style="color:#000000;fill:url(#linearGradient4341);fill-opacity:1;stroke-width:1.46614679999999997;marker:none;visibility:visible;display:inline;overflow:visible;stroke:#172a04;stroke-miterlimit:4;stroke-dasharray:none;stroke-linejoin:round"
+         id="g3282-2">
         <g
-           style="opacity:0.75000000000000000;color:#000000;fill:url(#linearGradient4335);fill-opacity:1;stroke-width:1.46614679999999997;marker:none;visibility:visible;display:inline;overflow:visible;stroke:#172a04;stroke-miterlimit:4;stroke-dasharray:none;stroke-linejoin:round"
-           id="g3284-8">
+           id="g3284-8"
+           style="opacity:0.75000000000000000;color:#000000;fill:url(#linearGradient4335);fill-opacity:1;stroke-width:1.46614679999999997;marker:none;visibility:visible;display:inline;overflow:visible;stroke:#172a04;stroke-miterlimit:4;stroke-dasharray:none;stroke-linejoin:round">
           <path
-             d=""
-             style="color:#000000;fill:url(#linearGradient4333);fill-opacity:1;stroke-width:1.46614679999999997;marker:none;visibility:visible;display:inline;overflow:visible;stroke:#172a04;stroke-miterlimit:4;stroke-dasharray:none;stroke-linejoin:round"
              id="path3286-9"
-             inkscape:connector-curvature="0" />
+             style="color:#000000;fill:url(#linearGradient4333);fill-opacity:1;stroke-width:1.46614679999999997;marker:none;visibility:visible;display:inline;overflow:visible;stroke:#172a04;stroke-miterlimit:4;stroke-dasharray:none;stroke-linejoin:round"
+             d="" />
         </g>
         <g
-           id="g3288-7"
-           style="color:#000000;fill:url(#linearGradient4339);fill-opacity:1;stroke-width:1.46614679999999997;marker:none;visibility:visible;display:inline;overflow:visible;stroke:#172a04;stroke-miterlimit:4;stroke-dasharray:none;stroke-linejoin:round">
+           style="color:#000000;fill:url(#linearGradient4339);fill-opacity:1;stroke-width:1.46614679999999997;marker:none;visibility:visible;display:inline;overflow:visible;stroke:#172a04;stroke-miterlimit:4;stroke-dasharray:none;stroke-linejoin:round"
+           id="g3288-7">
           <path
-             d=""
-             id="path3290-3"
              style="color:#000000;fill:url(#linearGradient4337);fill-opacity:1;stroke-width:1.46614679999999997;marker:none;visibility:visible;display:inline;overflow:visible;stroke:#172a04;stroke-miterlimit:4;stroke-dasharray:none;stroke-linejoin:round"
-             inkscape:connector-curvature="0" />
+             id="path3290-3"
+             d="" />
         </g>
       </g>
       <g
-         id="g3292-6"
-         style="color:#000000;fill:url(#linearGradient4351);fill-opacity:1;stroke-width:1.46614679999999997;marker:none;visibility:visible;display:inline;overflow:visible;stroke:#172a04;stroke-miterlimit:4;stroke-dasharray:none;stroke-linejoin:round">
+         style="color:#000000;fill:url(#linearGradient4351);fill-opacity:1;stroke-width:1.46614679999999997;marker:none;visibility:visible;display:inline;overflow:visible;stroke:#172a04;stroke-miterlimit:4;stroke-dasharray:none;stroke-linejoin:round"
+         id="g3292-6">
         <g
-           style="opacity:0.75000000000000000;color:#000000;fill:url(#linearGradient4345);fill-opacity:1;stroke-width:1.46614679999999997;marker:none;visibility:visible;display:inline;overflow:visible;stroke:#172a04;stroke-miterlimit:4;stroke-dasharray:none;stroke-linejoin:round"
-           id="g3294-1">
+           id="g3294-1"
+           style="opacity:0.75000000000000000;color:#000000;fill:url(#linearGradient4345);fill-opacity:1;stroke-width:1.46614679999999997;marker:none;visibility:visible;display:inline;overflow:visible;stroke:#172a04;stroke-miterlimit:4;stroke-dasharray:none;stroke-linejoin:round">
           <path
-             d=""
-             style="color:#000000;fill:url(#linearGradient4343);fill-opacity:1;stroke-width:1.46614679999999997;marker:none;visibility:visible;display:inline;overflow:visible;stroke:#172a04;stroke-miterlimit:4;stroke-dasharray:none;stroke-linejoin:round"
              id="path3296-2"
-             inkscape:connector-curvature="0" />
+             style="color:#000000;fill:url(#linearGradient4343);fill-opacity:1;stroke-width:1.46614679999999997;marker:none;visibility:visible;display:inline;overflow:visible;stroke:#172a04;stroke-miterlimit:4;stroke-dasharray:none;stroke-linejoin:round"
+             d="" />
         </g>
         <g
-           id="g3298-9"
-           style="color:#000000;fill:url(#linearGradient4349);fill-opacity:1;stroke-width:1.46614679999999997;marker:none;visibility:visible;display:inline;overflow:visible;stroke:#172a04;stroke-miterlimit:4;stroke-dasharray:none;stroke-linejoin:round">
+           style="color:#000000;fill:url(#linearGradient4349);fill-opacity:1;stroke-width:1.46614679999999997;marker:none;visibility:visible;display:inline;overflow:visible;stroke:#172a04;stroke-miterlimit:4;stroke-dasharray:none;stroke-linejoin:round"
+           id="g3298-9">
           <path
-             d=""
-             id="path3300-3"
              style="color:#000000;fill:url(#linearGradient4347);fill-opacity:1;stroke-width:1.46614679999999997;marker:none;visibility:visible;display:inline;overflow:visible;stroke:#172a04;stroke-miterlimit:4;stroke-dasharray:none;stroke-linejoin:round"
-             inkscape:connector-curvature="0" />
+             id="path3300-3"
+             d="" />
         </g>
       </g>
       <g
-         id="g3302-1"
-         style="color:#000000;fill:url(#linearGradient4357);fill-opacity:1;stroke-width:1.46614679999999997;marker:none;visibility:visible;display:inline;overflow:visible;stroke:#172a04;stroke-miterlimit:4;stroke-dasharray:none;stroke-linejoin:round">
+         style="color:#000000;fill:url(#linearGradient4357);fill-opacity:1;stroke-width:1.46614679999999997;marker:none;visibility:visible;display:inline;overflow:visible;stroke:#172a04;stroke-miterlimit:4;stroke-dasharray:none;stroke-linejoin:round"
+         id="g3302-1">
         <g
-           id="g3306-9"
-           style="color:#000000;fill:url(#linearGradient4355);fill-opacity:1;stroke-width:1.46614679999999997;marker:none;visibility:visible;display:inline;overflow:visible;stroke:#172a04;stroke-miterlimit:4;stroke-dasharray:none;stroke-linejoin:round">
+           style="color:#000000;fill:url(#linearGradient4355);fill-opacity:1;stroke-width:1.46614679999999997;marker:none;visibility:visible;display:inline;overflow:visible;stroke:#172a04;stroke-miterlimit:4;stroke-dasharray:none;stroke-linejoin:round"
+           id="g3306-9">
           <path
-             d="M 17.4922,6.8496 17.856,6.521 18.5831,6.3564 c 0.498,-0.2422 0.998,-0.4053 1.5264,-0.5762 l -0.29,-0.4937 -0.9385,0.1348 -0.4434,0.4419 -0.731,0.106 -0.6499,0.3052 -0.3159,0.1528 -0.1929,0.2583 0.9443,0.1641"
-             id="path3308-4"
              style="color:#000000;fill:url(#linearGradient4353);fill-opacity:1;stroke-width:1.46614679999999997;marker:none;visibility:visible;display:inline;overflow:visible;stroke:#172a04;stroke-miterlimit:4;stroke-dasharray:none;stroke-linejoin:round"
-             inkscape:connector-curvature="0" />
+             id="path3308-4"
+             d="M 17.4922,6.8496 17.856,6.521 18.5831,6.3564 c 0.498,-0.2422 0.998,-0.4053 1.5264,-0.5762 l -0.29,-0.4937 -0.9385,0.1348 -0.4434,0.4419 -0.731,0.106 -0.6499,0.3052 -0.3159,0.1528 -0.1929,0.2583 0.9443,0.1641" />
         </g>
       </g>
       <g
-         id="g3310-7"
-         style="color:#000000;fill:url(#linearGradient4363);fill-opacity:1;stroke-width:1.46614679999999997;marker:none;visibility:visible;display:inline;overflow:visible;stroke:#172a04;stroke-miterlimit:4;stroke-dasharray:none;stroke-linejoin:round">
+         style="color:#000000;fill:url(#linearGradient4363);fill-opacity:1;stroke-width:1.46614679999999997;marker:none;visibility:visible;display:inline;overflow:visible;stroke:#172a04;stroke-miterlimit:4;stroke-dasharray:none;stroke-linejoin:round"
+         id="g3310-7">
         <g
-           id="g3314-8"
-           style="color:#000000;fill:url(#linearGradient4361);fill-opacity:1;stroke-width:1.46614679999999997;marker:none;visibility:visible;display:inline;overflow:visible;stroke:#172a04;stroke-miterlimit:4;stroke-dasharray:none;stroke-linejoin:round">
+           style="color:#000000;fill:url(#linearGradient4361);fill-opacity:1;stroke-width:1.46614679999999997;marker:none;visibility:visible;display:inline;overflow:visible;stroke:#172a04;stroke-miterlimit:4;stroke-dasharray:none;stroke-linejoin:round"
+           id="g3314-8">
           <path
-             d="m 18.7285,14.6665 0.4365,-0.6582 -0.6548,-0.4932 0.2183,1.1514"
-             id="path3316-4"
              style="color:#000000;fill:url(#linearGradient4359);fill-opacity:1;stroke-width:1.46614679999999997;marker:none;visibility:visible;display:inline;overflow:visible;stroke:#172a04;stroke-miterlimit:4;stroke-dasharray:none;stroke-linejoin:round"
-             inkscape:connector-curvature="0" />
+             id="path3316-4"
+             d="m 18.7285,14.6665 0.4365,-0.6582 -0.6548,-0.4932 0.2183,1.1514" />
         </g>
       </g>
     </g>
     <g
-       id="g3216"
+       transform="matrix(1.3521411,0,0,1.3460948,-1.6958462,-17.895505)"
        style="color:#000000;fill:url(#linearGradient3908);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.46581578000000001;marker:none;visibility:visible;display:inline;overflow:visible"
-       transform="matrix(1.3521411,0,0,1.3460948,-1.6958462,-17.895505)">
+       id="g3216">
       <g
-         id="g3218"
-         style="color:#000000;fill:url(#linearGradient3908);stroke-width:1.46581578000000001;marker:none;visibility:visible;display:inline;overflow:visible;fill-opacity:1">
+         style="color:#000000;fill:url(#linearGradient3908);stroke-width:1.46581578000000001;marker:none;visibility:visible;display:inline;overflow:visible;fill-opacity:1"
+         id="g3218">
         <g
-           id="g3222"
-           style="color:#000000;fill:url(#linearGradient3908);stroke-width:1.46581578000000001;marker:none;visibility:visible;display:inline;overflow:visible;fill-opacity:1">
+           style="color:#000000;fill:url(#linearGradient3908);stroke-width:1.46581578000000001;marker:none;visibility:visible;display:inline;overflow:visible;fill-opacity:1"
+           id="g3222">
           <path
-             d="m 44.0713,20.7144 c 0,0.2627 0,0 0,0 l -0.5449,0.6172 c -0.334,-0.3936 -0.709,-0.7246 -1.0898,-1.0703 l -0.8359,0.123 -0.7637,-0.8633 0,1.0684 0.6543,0.4951 0.4355,0.4932 0.582,-0.6582 c 0.1465,0.2744 0.291,0.5488 0.4365,0.8232 l 0,0.8223 -0.6553,0.7402 -1.1992,0.8232 -0.9082,0.9063 -0.582,-0.6602 0.291,-0.7402 -0.5811,-0.6582 -0.9814,-2.0977 -0.8359,-0.9453 -0.2188,0.2461 0.3281,1.1934 0.6172,0.6992 c 0.3525,1.0176 0.7012,1.9902 1.1641,2.9629 0.7178,0 1.3945,-0.0762 2.1074,-0.166 l 0,0.5762 -0.8721,2.1392 -0.7998,0.9043 -0.6543,1.4004 c 0,0.7676 0,1.5352 0,2.3027 l 0.2188,0.9063 -0.3633,0.4102 -0.8008,0.4941 -0.8359,0.6992 0.6914,0.7813 -0.9453,0.8242 0.1816,0.5332 -1.418,1.6055 -0.9443,0 -0.7998,0.4941 -0.5098,0 0,-0.6582 -0.2168,-1.3184 c -0.2813,-0.8262 -0.5742,-1.6465 -0.8721,-2.4668 0,-0.6055 0.0361,-1.2051 0.0723,-1.8105 l 0.3643,-0.8223 -0.5098,-0.9883 0.0371,-1.3574 -0.6914,-0.7813 0.3457,-1.1309 -0.5625,-0.6382 -0.9824,0 -0.3271,-0.3701 -0.9814,0.6177 -0.3994,-0.4536 -0.9092,0.7817 c -0.6172,-0.6997 -1.2354,-1.3989 -1.8535,-2.0981 l -0.7266,-1.7285 0.6543,-0.9863 -0.3633,-0.4111 0.7988,-1.8936 c 0.6563,-0.8164 1.3418,-1.5996 2.0352,-2.3857 l 1.2363,-0.3291 1.3809,-0.1641 0.9453,0.2471 1.3447,1.3564 0.4727,-0.5342 0.6533,-0.082 1.2363,0.4111 0.9453,0 0.6543,-0.5762 0.291,-0.4111 -0.6553,-0.4111 -1.0908,-0.082 c -0.3027,-0.4199 -0.584,-0.8613 -0.9434,-1.2344 l -0.3643,0.1641 -0.1455,1.0703 -0.6543,-0.7402 -0.1445,-0.8242 -0.7266,-0.5742 -0.292,0 0.7275,0.8223 -0.291,0.7402 -0.5811,0.1641 0.3633,-0.7402 -0.6553,-0.3281 -0.5801,-0.6582 -1.0918,0.2461 -0.1445,0.3281 -0.6543,0.4121 -0.3633,0.9053 -0.9082,0.4521 -0.4004,-0.4521 -0.4355,0 0,-1.4814 0.9453,-0.4941 0.7266,0 -0.1465,-0.5752 -0.5801,-0.5762 0.9805,-0.2061 0.5449,-0.6162 0.4355,-0.7412 0.8008,0 -0.2188,-0.5752 0.5098,-0.3291 0,0.6582 1.0898,0.2461 1.0898,-0.9043 0.0732,-0.4121 0.9443,-0.6577 c -0.3418,0.0425 -0.6836,0.0737 -1.0176,0.1646 l 0,-0.7411 0.3633,-0.8228 -0.3633,0 -0.7984,0.7402 -0.2188,0.4116 0.2188,0.5767 -0.3643,0.9863 -0.5811,-0.3291 -0.5078,-0.5752 -0.8008,0.5752 -0.291,-1.3159 1.3809,-0.9048 0,-0.4941 0.873,-0.5757 1.3809,-0.3296 0.9453,0.3296 1.7441,0.3291 -0.4355,0.4932 -0.9453,0 0.9453,0.9873 0.7266,-0.8223 0.2207,-0.3618 c 0,0 2.7871,2.498 4.3799,5.2305 1.5928,2.7334 2.3408,5.9551 2.3408,6.6094 z"
+             style="color:#000000;fill:url(#linearGradient3908);stroke-width:1.46581578000000001;marker:none;visibility:visible;display:inline;overflow:visible;fill-opacity:1"
              id="path3224"
-             style="color:#000000;fill:url(#linearGradient3908);stroke-width:1.46581578000000001;marker:none;visibility:visible;display:inline;overflow:visible;fill-opacity:1"
-             inkscape:connector-curvature="0" />
+             d="m 44.0713,20.7144 c 0,0.2627 0,0 0,0 l -0.5449,0.6172 c -0.334,-0.3936 -0.709,-0.7246 -1.0898,-1.0703 l -0.8359,0.123 -0.7637,-0.8633 0,1.0684 0.6543,0.4951 0.4355,0.4932 0.582,-0.6582 c 0.1465,0.2744 0.291,0.5488 0.4365,0.8232 l 0,0.8223 -0.6553,0.7402 -1.1992,0.8232 -0.9082,0.9063 -0.582,-0.6602 0.291,-0.7402 -0.5811,-0.6582 -0.9814,-2.0977 -0.8359,-0.9453 -0.2188,0.2461 0.3281,1.1934 0.6172,0.6992 c 0.3525,1.0176 0.7012,1.9902 1.1641,2.9629 0.7178,0 1.3945,-0.0762 2.1074,-0.166 l 0,0.5762 -0.8721,2.1392 -0.7998,0.9043 -0.6543,1.4004 c 0,0.7676 0,1.5352 0,2.3027 l 0.2188,0.9063 -0.3633,0.4102 -0.8008,0.4941 -0.8359,0.6992 0.6914,0.7813 -0.9453,0.8242 0.1816,0.5332 -1.418,1.6055 -0.9443,0 -0.7998,0.4941 -0.5098,0 0,-0.6582 -0.2168,-1.3184 c -0.2813,-0.8262 -0.5742,-1.6465 -0.8721,-2.4668 0,-0.6055 0.0361,-1.2051 0.0723,-1.8105 l 0.3643,-0.8223 -0.5098,-0.9883 0.0371,-1.3574 -0.6914,-0.7813 0.3457,-1.1309 -0.5625,-0.6382 -0.9824,0 -0.3271,-0.3701 -0.9814,0.6177 -0.3994,-0.4536 -0.9092,0.7817 c -0.6172,-0.6997 -1.2354,-1.3989 -1.8535,-2.0981 l -0.7266,-1.7285 0.6543,-0.9863 -0.3633,-0.4111 0.7988,-1.8936 c 0.6563,-0.8164 1.3418,-1.5996 2.0352,-2.3857 l 1.2363,-0.3291 1.3809,-0.1641 0.9453,0.2471 1.3447,1.3564 0.4727,-0.5342 0.6533,-0.082 1.2363,0.4111 0.9453,0 0.6543,-0.5762 0.291,-0.4111 -0.6553,-0.4111 -1.0908,-0.082 c -0.3027,-0.4199 -0.584,-0.8613 -0.9434,-1.2344 l -0.3643,0.1641 -0.1455,1.0703 -0.6543,-0.7402 -0.1445,-0.8242 -0.7266,-0.5742 -0.292,0 0.7275,0.8223 -0.291,0.7402 -0.5811,0.1641 0.3633,-0.7402 -0.6553,-0.3281 -0.5801,-0.6582 -1.0918,0.2461 -0.1445,0.3281 -0.6543,0.4121 -0.3633,0.9053 -0.9082,0.4521 -0.4004,-0.4521 -0.4355,0 0,-1.4814 0.9453,-0.4941 0.7266,0 -0.1465,-0.5752 -0.5801,-0.5762 0.9805,-0.2061 0.5449,-0.6162 0.4355,-0.7412 0.8008,0 -0.2188,-0.5752 0.5098,-0.3291 0,0.6582 1.0898,0.2461 1.0898,-0.9043 0.0732,-0.4121 0.9443,-0.6577 c -0.3418,0.0425 -0.6836,0.0737 -1.0176,0.1646 l 0,-0.7411 0.3633,-0.8228 -0.3633,0 -0.7984,0.7402 -0.2188,0.4116 0.2188,0.5767 -0.3643,0.9863 -0.5811,-0.3291 -0.5078,-0.5752 -0.8008,0.5752 -0.291,-1.3159 1.3809,-0.9048 0,-0.4941 0.873,-0.5757 1.3809,-0.3296 0.9453,0.3296 1.7441,0.3291 -0.4355,0.4932 -0.9453,0 0.9453,0.9873 0.7266,-0.8223 0.2207,-0.3618 c 0,0 2.7871,2.498 4.3799,5.2305 1.5928,2.7334 2.3408,5.9551 2.3408,6.6094 z" />
         </g>
       </g>
       <g
-         id="g3226"
-         style="color:#000000;fill:url(#linearGradient3908);stroke-width:1.46581578000000001;marker:none;visibility:visible;display:inline;overflow:visible;fill-opacity:1">
+         style="color:#000000;fill:url(#linearGradient3908);stroke-width:1.46581578000000001;marker:none;visibility:visible;display:inline;overflow:visible;fill-opacity:1"
+         id="g3226">
         <g
-           id="g3230"
-           style="color:#000000;fill:url(#linearGradient3908);stroke-width:1.46581578000000001;marker:none;visibility:visible;display:inline;overflow:visible;fill-opacity:1">
+           style="color:#000000;fill:url(#linearGradient3908);stroke-width:1.46581578000000001;marker:none;visibility:visible;display:inline;overflow:visible;fill-opacity:1"
+           id="g3230">
           <path
-             d="m 26.0703,9.2363 -0.0732,0.4932 0.5098,0.3291 0.8711,-0.5757 -0.4355,-0.4937 -0.582,0.3296 -0.29,-0.0825"
+             style="color:#000000;fill:url(#linearGradient3908);stroke-width:1.46581578000000001;marker:none;visibility:visible;display:inline;overflow:visible;fill-opacity:1"
              id="path3232"
-             style="color:#000000;fill:url(#linearGradient3908);stroke-width:1.46581578000000001;marker:none;visibility:visible;display:inline;overflow:visible;fill-opacity:1"
-             inkscape:connector-curvature="0" />
+             d="m 26.0703,9.2363 -0.0732,0.4932 0.5098,0.3291 0.8711,-0.5757 -0.4355,-0.4937 -0.582,0.3296 -0.29,-0.0825" />
         </g>
       </g>
       <g
-         id="g3234"
-         style="color:#000000;fill:url(#linearGradient3908);stroke-width:1.46581578000000001;marker:none;visibility:visible;display:inline;overflow:visible;fill-opacity:1">
+         style="color:#000000;fill:url(#linearGradient3908);stroke-width:1.46581578000000001;marker:none;visibility:visible;display:inline;overflow:visible;fill-opacity:1"
+         id="g3234">
         <g
-           id="g3238"
-           style="color:#000000;fill:url(#linearGradient3908);stroke-width:1.46581578000000001;marker:none;visibility:visible;display:inline;overflow:visible;fill-opacity:1">
+           style="color:#000000;fill:url(#linearGradient3908);stroke-width:1.46581578000000001;marker:none;visibility:visible;display:inline;overflow:visible;fill-opacity:1"
+           id="g3238">
           <path
-             d="m 26.8701,5.8633 -1.8906,-0.7407 -2.1797,0.2466 -2.6904,0.7402 -0.5088,0.4941 1.6719,1.1514 0,0.6582 -0.6543,0.6582 0.873,1.729 0.5801,-0.3301 0.7285,-1.1514 c 1.123,-0.3472 2.1299,-0.7407 3.1973,-1.2344 l 0.873,-2.2212"
+             style="color:#000000;fill:url(#linearGradient3908);stroke-width:1.46581578000000001;marker:none;visibility:visible;display:inline;overflow:visible;fill-opacity:1"
              id="path3240"
-             style="color:#000000;fill:url(#linearGradient3908);stroke-width:1.46581578000000001;marker:none;visibility:visible;display:inline;overflow:visible;fill-opacity:1"
-             inkscape:connector-curvature="0" />
+             d="m 26.8701,5.8633 -1.8906,-0.7407 -2.1797,0.2466 -2.6904,0.7402 -0.5088,0.4941 1.6719,1.1514 0,0.6582 -0.6543,0.6582 0.873,1.729 0.5801,-0.3301 0.7285,-1.1514 c 1.123,-0.3472 2.1299,-0.7407 3.1973,-1.2344 l 0.873,-2.2212" />
         </g>
       </g>
       <g
-         id="g3242"
-         style="color:#000000;fill:url(#linearGradient3908);stroke-width:1.46581578000000001;marker:none;visibility:visible;display:inline;overflow:visible;fill-opacity:1">
+         style="color:#000000;fill:url(#linearGradient3908);stroke-width:1.46581578000000001;marker:none;visibility:visible;display:inline;overflow:visible;fill-opacity:1"
+         id="g3242">
         <g
-           id="g3246"
-           style="color:#000000;fill:url(#linearGradient3908);stroke-width:1.46581578000000001;marker:none;visibility:visible;display:inline;overflow:visible;fill-opacity:1">
+           style="color:#000000;fill:url(#linearGradient3908);stroke-width:1.46581578000000001;marker:none;visibility:visible;display:inline;overflow:visible;fill-opacity:1"
+           id="g3246">
           <path
-             d="m 28.833,12.7749 -0.291,-0.7412 -0.5098,0.165 0.1465,0.9043 0.6543,-0.3281"
+             style="color:#000000;fill:url(#linearGradient3908);stroke-width:1.46581578000000001;marker:none;visibility:visible;display:inline;overflow:visible;fill-opacity:1"
              id="path3248"
-             style="color:#000000;fill:url(#linearGradient3908);stroke-width:1.46581578000000001;marker:none;visibility:visible;display:inline;overflow:visible;fill-opacity:1"
-             inkscape:connector-curvature="0" />
+             d="m 28.833,12.7749 -0.291,-0.7412 -0.5098,0.165 0.1465,0.9043 0.6543,-0.3281" />
         </g>
       </g>
       <g
-         id="g3250"
-         style="color:#000000;fill:url(#linearGradient3908);stroke-width:1.46581578000000001;marker:none;visibility:visible;display:inline;overflow:visible;fill-opacity:1">
+         style="color:#000000;fill:url(#linearGradient3908);stroke-width:1.46581578000000001;marker:none;visibility:visible;display:inline;overflow:visible;fill-opacity:1"
+         id="g3250">
         <g
-           id="g3254"
-           style="color:#000000;fill:url(#linearGradient3908);stroke-width:1.46581578000000001;marker:none;visibility:visible;display:inline;overflow:visible;fill-opacity:1">
+           style="color:#000000;fill:url(#linearGradient3908);stroke-width:1.46581578000000001;marker:none;visibility:visible;display:inline;overflow:visible;fill-opacity:1"
+           id="g3254">
           <path
-             d="m 29.123,12.6089 -0.1455,0.9883 0.7998,-0.165 0.5811,-0.5752 -0.5088,-0.4941 C 29.6787,11.9078 29.4824,11.483 29.2685,11.0465 l -0.4355,0 0,0.4932 0.29,0.3291 0,0.7402"
+             style="color:#000000;fill:url(#linearGradient3908);stroke-width:1.46581578000000001;marker:none;visibility:visible;display:inline;overflow:visible;fill-opacity:1"
              id="path3256"
-             style="color:#000000;fill:url(#linearGradient3908);stroke-width:1.46581578000000001;marker:none;visibility:visible;display:inline;overflow:visible;fill-opacity:1"
-             inkscape:connector-curvature="0" />
+             d="m 29.123,12.6089 -0.1455,0.9883 0.7998,-0.165 0.5811,-0.5752 -0.5088,-0.4941 C 29.6787,11.9078 29.4824,11.483 29.2685,11.0465 l -0.4355,0 0,0.4932 0.29,0.3291 0,0.7402" />
         </g>
       </g>
       <g
-         id="g3258"
-         style="color:#000000;fill:url(#linearGradient3908);stroke-width:1.46581578000000001;marker:none;visibility:visible;display:inline;overflow:visible;fill-opacity:1">
+         style="color:#000000;fill:url(#linearGradient3908);stroke-width:1.46581578000000001;marker:none;visibility:visible;display:inline;overflow:visible;fill-opacity:1"
+         id="g3258">
         <g
-           id="g3262"
-           style="color:#000000;fill:url(#linearGradient3908);stroke-width:1.46581578000000001;marker:none;visibility:visible;display:inline;overflow:visible;fill-opacity:1">
+           style="color:#000000;fill:url(#linearGradient3908);stroke-width:1.46581578000000001;marker:none;visibility:visible;display:inline;overflow:visible;fill-opacity:1"
+           id="g3262">
           <path
-             d="m 18.3652,28.2422 -0.582,-1.1523 -1.0903,-0.2466 -0.5815,-1.5625 -1.4536,0.1641 -1.2354,-0.9043 -1.3091,1.1514 0,0.1816 c -0.396,-0.1143 -0.8828,-0.1299 -1.2354,-0.3467 l -0.291,-0.8223 0,-0.9053 -0.8721,0.082 c 0.0728,-0.5762 0.145,-1.1514 0.2183,-1.7275 l -0.5093,0 -0.5083,0.6582 -0.5093,0.2461 -0.7271,-0.4102 -0.0728,-0.9053 0.1455,-0.9873 1.0908,-0.8223 0.8721,0 0.145,-0.4941 1.0903,0.2461 0.7998,0.9883 0.1455,-1.6465 1.3813,-1.1514 0.5088,-1.2344 1.0176,-0.4111 0.5815,-0.8223 1.3081,-0.248 0.6548,-0.9863 c -0.6543,0 -1.3086,0 -1.9629,0 l 1.2358,-0.5762 0.8716,0 1.2363,-0.4121 0.1455,-0.4922 -0.4365,-0.4121 -0.5088,-0.165 0.1455,-0.4932 -0.3633,-0.7402 -0.8726,0.3281 0.1455,-0.6577 -1.0176,-0.5762 -0.7993,1.3979 0.0723,0.4941 -0.7993,0.3301 -0.5093,1.0693 -0.2178,-0.9873 -1.3813,-0.5762 -0.2183,-0.7402 1.8174,-1.0703 0.7998,-0.7402 0.0728,-0.9048 -0.436,-0.2471 -0.5815,-0.0825 -0.3633,0.9053 c 0,0 -0.6079,0.1191 -0.7642,0.1577 -1.9961,1.8394 -6.0293,5.8101 -6.9663,13.3062 0.0371,0.1738 0.6792,1.1816 0.6792,1.1816 l 1.5264,0.9043 1.5264,0.4121 0.6548,0.8232 1.0171,0.7402 0.5815,-0.082 0.436,0.1963 0,0.1328 -0.5811,1.563 -0.4365,0.6582 0.1455,0.3301 -0.3633,1.2324 1.3086,2.3867 1.3081,1.1523 0.582,0.8223 -0.0732,1.7285 0.4365,0.9863 -0.4365,1.8926 c 0,0 -0.0342,-0.0117 0.0215,0.1777 0.0562,0.1895 2.3291,1.4512 2.4736,1.3438 0.144,-0.1094 0.2671,-0.2051 0.2671,-0.2051 l -0.145,-0.4102 0.5811,-0.5762 0.2183,-0.5762 0.9453,-0.3301 0.7266,-1.8105 -0.2178,-0.4922 0.5078,-0.7402 1.0908,-0.248 0.582,-1.3164 -0.1455,-1.6445 0.8721,-1.2344 0.1455,-1.2344 C 20.7331,29.4607 19.5495,28.8513 18.365,28.242"
+             style="color:#000000;fill:url(#linearGradient3908);stroke-width:1.46581578000000001;marker:none;visibility:visible;display:inline;overflow:visible;fill-opacity:1"
              id="path3264"
-             style="color:#000000;fill:url(#linearGradient3908);stroke-width:1.46581578000000001;marker:none;visibility:visible;display:inline;overflow:visible;fill-opacity:1"
-             inkscape:connector-curvature="0" />
+             d="m 18.3652,28.2422 -0.582,-1.1523 -1.0903,-0.2466 -0.5815,-1.5625 -1.4536,0.1641 -1.2354,-0.9043 -1.3091,1.1514 0,0.1816 c -0.396,-0.1143 -0.8828,-0.1299 -1.2354,-0.3467 l -0.291,-0.8223 0,-0.9053 -0.8721,0.082 c 0.0728,-0.5762 0.145,-1.1514 0.2183,-1.7275 l -0.5093,0 -0.5083,0.6582 -0.5093,0.2461 -0.7271,-0.4102 -0.0728,-0.9053 0.1455,-0.9873 1.0908,-0.8223 0.8721,0 0.145,-0.4941 1.0903,0.2461 0.7998,0.9883 0.1455,-1.6465 1.3813,-1.1514 0.5088,-1.2344 1.0176,-0.4111 0.5815,-0.8223 1.3081,-0.248 0.6548,-0.9863 c -0.6543,0 -1.3086,0 -1.9629,0 l 1.2358,-0.5762 0.8716,0 1.2363,-0.4121 0.1455,-0.4922 -0.4365,-0.4121 -0.5088,-0.165 0.1455,-0.4932 -0.3633,-0.7402 -0.8726,0.3281 0.1455,-0.6577 -1.0176,-0.5762 -0.7993,1.3979 0.0723,0.4941 -0.7993,0.3301 -0.5093,1.0693 -0.2178,-0.9873 -1.3813,-0.5762 -0.2183,-0.7402 1.8174,-1.0703 0.7998,-0.7402 0.0728,-0.9048 -0.436,-0.2471 -0.5815,-0.0825 -0.3633,0.9053 c 0,0 -0.6079,0.1191 -0.7642,0.1577 -1.9961,1.8394 -6.0293,5.8101 -6.9663,13.3062 0.0371,0.1738 0.6792,1.1816 0.6792,1.1816 l 1.5264,0.9043 1.5264,0.4121 0.6548,0.8232 1.0171,0.7402 0.5815,-0.082 0.436,0.1963 0,0.1328 -0.5811,1.563 -0.4365,0.6582 0.1455,0.3301 -0.3633,1.2324 1.3086,2.3867 1.3081,1.1523 0.582,0.8223 -0.0732,1.7285 0.4365,0.9863 -0.4365,1.8926 c 0,0 -0.0342,-0.0117 0.0215,0.1777 0.0562,0.1895 2.3291,1.4512 2.4736,1.3438 0.144,-0.1094 0.2671,-0.2051 0.2671,-0.2051 l -0.145,-0.4102 0.5811,-0.5762 0.2183,-0.5762 0.9453,-0.3301 0.7266,-1.8105 -0.2178,-0.4922 0.5078,-0.7402 1.0908,-0.248 0.582,-1.3164 -0.1455,-1.6445 0.8721,-1.2344 0.1455,-1.2344 C 20.7331,29.4607 19.5495,28.8513 18.365,28.242" />
         </g>
       </g>
       <g
-         id="g3266"
-         style="color:#000000;fill:url(#linearGradient3908);stroke-width:1.46581578000000001;marker:none;visibility:visible;display:inline;overflow:visible;fill-opacity:1">
+         style="color:#000000;fill:url(#linearGradient3908);stroke-width:1.46581578000000001;marker:none;visibility:visible;display:inline;overflow:visible;fill-opacity:1"
+         id="g3266">
         <g
-           id="g3270"
-           style="color:#000000;fill:url(#linearGradient3908);stroke-width:1.46581578000000001;marker:none;visibility:visible;display:inline;overflow:visible;fill-opacity:1">
+           style="color:#000000;fill:url(#linearGradient3908);stroke-width:1.46581578000000001;marker:none;visibility:visible;display:inline;overflow:visible;fill-opacity:1"
+           id="g3270">
           <path
-             d="m 16.7656,9.5649 0.7266,0.4937 0.582,0 0,-0.5757 -0.7266,-0.3291 -0.582,0.4111"
+             style="color:#000000;fill:url(#linearGradient3908);stroke-width:1.46581578000000001;marker:none;visibility:visible;display:inline;overflow:visible;fill-opacity:1"
              id="path3272"
-             style="color:#000000;fill:url(#linearGradient3908);stroke-width:1.46581578000000001;marker:none;visibility:visible;display:inline;overflow:visible;fill-opacity:1"
-             inkscape:connector-curvature="0" />
+             d="m 16.7656,9.5649 0.7266,0.4937 0.582,0 0,-0.5757 -0.7266,-0.3291 -0.582,0.4111" />
         </g>
       </g>
       <g
-         id="g3274"
-         style="color:#000000;fill:url(#linearGradient3908);stroke-width:1.46581578000000001;marker:none;visibility:visible;display:inline;overflow:visible;fill-opacity:1">
+         style="color:#000000;fill:url(#linearGradient3908);stroke-width:1.46581578000000001;marker:none;visibility:visible;display:inline;overflow:visible;fill-opacity:1"
+         id="g3274">
         <g
-           id="g3278"
-           style="color:#000000;fill:url(#linearGradient3908);stroke-width:1.46581578000000001;marker:none;visibility:visible;display:inline;overflow:visible;fill-opacity:1">
+           style="color:#000000;fill:url(#linearGradient3908);stroke-width:1.46581578000000001;marker:none;visibility:visible;display:inline;overflow:visible;fill-opacity:1"
+           id="g3278">
           <path
-             d="m 14.876,8.9072 -0.3638,0.9048 0.7271,0 0.3638,-0.8228 C 15.9166,8.7675 16.2286,8.5444 16.5479,8.331 l 0.7271,0.2471 c 0.4844,0.3291 0.9688,0.6582 1.4536,0.9868 L 19.4561,8.9072 18.6558,8.5781 18.292,7.8374 16.9111,7.6728 16.8383,7.2612 16.184,7.4262 15.8936,8.002 15.5298,7.2613 l -0.145,0.3291 0.0728,0.8228 -0.5816,0.494"
+             style="color:#000000;fill:url(#linearGradient3908);stroke-width:1.46581578000000001;marker:none;visibility:visible;display:inline;overflow:visible;fill-opacity:1"
              id="path3280"
-             style="color:#000000;fill:url(#linearGradient3908);stroke-width:1.46581578000000001;marker:none;visibility:visible;display:inline;overflow:visible;fill-opacity:1"
-             inkscape:connector-curvature="0" />
+             d="m 14.876,8.9072 -0.3638,0.9048 0.7271,0 0.3638,-0.8228 C 15.9166,8.7675 16.2286,8.5444 16.5479,8.331 l 0.7271,0.2471 c 0.4844,0.3291 0.9688,0.6582 1.4536,0.9868 L 19.4561,8.9072 18.6558,8.5781 18.292,7.8374 16.9111,7.6728 16.8383,7.2612 16.184,7.4262 15.8936,8.002 15.5298,7.2613 l -0.145,0.3291 0.0728,0.8228 -0.5816,0.494" />
         </g>
       </g>
       <g
-         id="g3282"
-         style="color:#000000;fill:url(#linearGradient3908);stroke-width:1.46581578000000001;marker:none;visibility:visible;display:inline;overflow:visible;fill-opacity:1">
+         style="color:#000000;fill:url(#linearGradient3908);stroke-width:1.46581578000000001;marker:none;visibility:visible;display:inline;overflow:visible;fill-opacity:1"
+         id="g3282">
         <g
-           style="opacity:0.75000000000000000;color:#000000;fill:url(#linearGradient3908);stroke-width:1.46581578000000001;marker:none;visibility:visible;display:inline;overflow:visible;fill-opacity:1"
-           id="g3284">
+           id="g3284"
+           style="opacity:0.75000000000000000;color:#000000;fill:url(#linearGradient3908);stroke-width:1.46581578000000001;marker:none;visibility:visible;display:inline;overflow:visible;fill-opacity:1">
           <path
-             d=""
-             style="color:#000000;fill:url(#linearGradient3908);stroke-width:1.46581578000000001;marker:none;visibility:visible;display:inline;overflow:visible;fill-opacity:1"
              id="path3286"
-             inkscape:connector-curvature="0" />
+             style="color:#000000;fill:url(#linearGradient3908);stroke-width:1.46581578000000001;marker:none;visibility:visible;display:inline;overflow:visible;fill-opacity:1"
+             d="" />
         </g>
         <g
-           id="g3288"
-           style="color:#000000;fill:url(#linearGradient3908);stroke-width:1.46581578000000001;marker:none;visibility:visible;display:inline;overflow:visible;fill-opacity:1">
+           style="color:#000000;fill:url(#linearGradient3908);stroke-width:1.46581578000000001;marker:none;visibility:visible;display:inline;overflow:visible;fill-opacity:1"
+           id="g3288">
           <path
-             d=""
+             style="color:#000000;fill:url(#linearGradient3908);stroke-width:1.46581578000000001;marker:none;visibility:visible;display:inline;overflow:visible;fill-opacity:1"
              id="path3290"
-             style="color:#000000;fill:url(#linearGradient3908);stroke-width:1.46581578000000001;marker:none;visibility:visible;display:inline;overflow:visible;fill-opacity:1"
-             inkscape:connector-curvature="0" />
+             d="" />
         </g>
       </g>
       <g
-         id="g3292"
-         style="color:#000000;fill:url(#linearGradient3908);stroke-width:1.46581578000000001;marker:none;visibility:visible;display:inline;overflow:visible;fill-opacity:1">
+         style="color:#000000;fill:url(#linearGradient3908);stroke-width:1.46581578000000001;marker:none;visibility:visible;display:inline;overflow:visible;fill-opacity:1"
+         id="g3292">
         <g
-           style="opacity:0.75000000000000000;color:#000000;fill:url(#linearGradient3908);stroke-width:1.46581578000000001;marker:none;visibility:visible;display:inline;overflow:visible;fill-opacity:1"
-           id="g3294">
+           id="g3294"
+           style="opacity:0.75000000000000000;color:#000000;fill:url(#linearGradient3908);stroke-width:1.46581578000000001;marker:none;visibility:visible;display:inline;overflow:visible;fill-opacity:1">
           <path
-             d=""
-             style="color:#000000;fill:url(#linearGradient3908);stroke-width:1.46581578000000001;marker:none;visibility:visible;display:inline;overflow:visible;fill-opacity:1"
              id="path3296"
-             inkscape:connector-curvature="0" />
+             style="color:#000000;fill:url(#linearGradient3908);stroke-width:1.46581578000000001;marker:none;visibility:visible;display:inline;overflow:visible;fill-opacity:1"
+             d="" />
         </g>
         <g
-           id="g3298"
-           style="color:#000000;fill:url(#linearGradient3908);stroke-width:1.46581578000000001;marker:none;visibility:visible;display:inline;overflow:visible;fill-opacity:1">
+           style="color:#000000;fill:url(#linearGradient3908);stroke-width:1.46581578000000001;marker:none;visibility:visible;display:inline;overflow:visible;fill-opacity:1"
+           id="g3298">
           <path
-             d=""
+             style="color:#000000;fill:url(#linearGradient3908);stroke-width:1.46581578000000001;marker:none;visibility:visible;display:inline;overflow:visible;fill-opacity:1"
              id="path3300"
-             style="color:#000000;fill:url(#linearGradient3908);stroke-width:1.46581578000000001;marker:none;visibility:visible;display:inline;overflow:visible;fill-opacity:1"
-             inkscape:connector-curvature="0" />
+             d="" />
         </g>
       </g>
       <g
-         id="g3302"
-         style="color:#000000;fill:url(#linearGradient3908);stroke-width:1.46581578000000001;marker:none;visibility:visible;display:inline;overflow:visible;fill-opacity:1">
+         style="color:#000000;fill:url(#linearGradient3908);stroke-width:1.46581578000000001;marker:none;visibility:visible;display:inline;overflow:visible;fill-opacity:1"
+         id="g3302">
         <g
-           id="g3306"
-           style="color:#000000;fill:url(#linearGradient3908);stroke-width:1.46581578000000001;marker:none;visibility:visible;display:inline;overflow:visible;fill-opacity:1">
+           style="color:#000000;fill:url(#linearGradient3908);stroke-width:1.46581578000000001;marker:none;visibility:visible;display:inline;overflow:visible;fill-opacity:1"
+           id="g3306">
           <path
-             d="M 17.4922,6.8496 17.856,6.521 18.5831,6.3564 c 0.498,-0.2422 0.998,-0.4053 1.5264,-0.5762 l -0.29,-0.4937 -0.9385,0.1348 -0.4434,0.4419 -0.731,0.106 -0.6499,0.3052 -0.3159,0.1528 -0.1929,0.2583 0.9443,0.1641"
+             style="color:#000000;fill:url(#linearGradient3908);stroke-width:1.46581578000000001;marker:none;visibility:visible;display:inline;overflow:visible;fill-opacity:1"
              id="path3308"
-             style="color:#000000;fill:url(#linearGradient3908);stroke-width:1.46581578000000001;marker:none;visibility:visible;display:inline;overflow:visible;fill-opacity:1"
-             inkscape:connector-curvature="0" />
+             d="M 17.4922,6.8496 17.856,6.521 18.5831,6.3564 c 0.498,-0.2422 0.998,-0.4053 1.5264,-0.5762 l -0.29,-0.4937 -0.9385,0.1348 -0.4434,0.4419 -0.731,0.106 -0.6499,0.3052 -0.3159,0.1528 -0.1929,0.2583 0.9443,0.1641" />
         </g>
       </g>
       <g
-         id="g3310"
-         style="color:#000000;fill:url(#linearGradient3908);stroke-width:1.46581578000000001;marker:none;visibility:visible;display:inline;overflow:visible;fill-opacity:1">
+         style="color:#000000;fill:url(#linearGradient3908);stroke-width:1.46581578000000001;marker:none;visibility:visible;display:inline;overflow:visible;fill-opacity:1"
+         id="g3310">
         <g
-           id="g3314"
-           style="color:#000000;fill:url(#linearGradient3908);stroke-width:1.46581578000000001;marker:none;visibility:visible;display:inline;overflow:visible;fill-opacity:1">
+           style="color:#000000;fill:url(#linearGradient3908);stroke-width:1.46581578000000001;marker:none;visibility:visible;display:inline;overflow:visible;fill-opacity:1"
+           id="g3314">
           <path
-             d="m 18.7285,14.6665 0.4365,-0.6582 -0.6548,-0.4932 0.2183,1.1514"
-             id="path3316"
              style="color:#000000;fill:url(#linearGradient3908);stroke-width:1.46581578000000001;marker:none;visibility:visible;display:inline;overflow:visible;fill-opacity:1"
-             inkscape:connector-curvature="0" />
+             id="path3316"
+             d="m 18.7285,14.6665 0.4365,-0.6582 -0.6548,-0.4932 0.2183,1.1514" />
         </g>
       </g>
     </g>
     <path
-       style="fill:none;stroke:url(#radialGradient4132);stroke-width:1.99999976;stroke-miterlimit:4;stroke-opacity:1"
-       d="M 57,13.999113 C 57,27.806675 45.806296,38.999999 32.000317,38.999999 18.193071,38.999999 6.9999999,27.806549 6.9999999,13.999113 6.9999999,0.19218278 18.193071,-11 32.000317,-11 45.806296,-11 57,0.19218278 57,13.999113 l 0,0 z"
        id="path4122"
-       inkscape:connector-curvature="0" />
+       d="M 57,13.999113 C 57,27.806675 45.806296,38.999999 32.000317,38.999999 18.193071,38.999999 6.9999999,27.806549 6.9999999,13.999113 6.9999999,0.19218278 18.193071,-11 32.000317,-11 45.806296,-11 57,0.19218278 57,13.999113 l 0,0 z"
+       style="fill:none;stroke:url(#radialGradient4132);stroke-width:1.99999976;stroke-miterlimit:4;stroke-opacity:1" />
     <path
-       style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#39396c;stroke-width:2;stroke-miterlimit:4;stroke-opacity:1"
-       d="M 58.931508,13.931507 C 58.931508,28.806375 46.872821,40.864925 32,40.864925 17.125816,40.864925 5.0678105,28.806239 5.0678105,13.931507 5.0678105,-0.942678 17.125816,-13 32,-13 c 14.872821,0 26.931508,12.057322 26.931508,26.931507 l 0,0 z"
        id="path3214-2"
-       inkscape:connector-curvature="0" />
+       d="M 58.931508,13.931507 C 58.931508,28.806375 46.872821,40.864925 32,40.864925 17.125816,40.864925 5.0678105,28.806239 5.0678105,13.931507 5.0678105,-0.942678 17.125816,-13 32,-13 c 14.872821,0 26.931508,12.057322 26.931508,26.931507 l 0,0 z"
+       style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#39396c;stroke-width:2;stroke-miterlimit:4;stroke-opacity:1" />
   </g>
 </svg>


### PR DESCRIPTION
while fixing a SVG export issue for TechDraw I noticed that some SVG files have program-dependent (and thus not clean) code in it. These are traces of the programs Sodipodi and Inkscape, like e.g. this line:
`inkscape:export-filename="/home/yorik/PartDesign_Groove.png`

This is unnecessary and FC should not use program-dependent code in SVGs but use instead plain SVG that can be displayed and edited by any program.

This PR transforms the few affected SVGs to a plain version.