### PR TITLE
Draft: override text in dimension only when GUI is up

### DIFF
--- a/src/Mod/Draft/Draft.py
+++ b/src/Mod/Draft/Draft.py
@@ -297,11 +297,13 @@ def makeDimension(p1,p2,p3=None,p4=None):
         l.append((p1,"Edge"+str(p2+1)))
         if p3 == "radius":
             #l.append((p1,"Center"))
-            obj.ViewObject.Override = "R $dim"
+            if FreeCAD.GuiUp:
+                obj.ViewObject.Override = "R $dim"
             obj.Diameter = False
         elif p3 == "diameter":
             #l.append((p1,"Diameter"))
-            obj.ViewObject.Override = "Ø $dim"
+            if FreeCAD.GuiUp:
+                obj.ViewObject.Override = "Ø $dim"
             obj.Diameter = True
         obj.LinkedGeometry = l
         obj.Support = p1


### PR DESCRIPTION
Set the viewprovider's `Override` property only when the interface is up, otherwise the `makeDimension` function will return an error. This could happen when creating a test file as in #3012, or when running the new unit tests, as in #3005.

---

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists