### PR TITLE
Addons manager - check if icon file exists [skip ci]

### DIFF
--- a/src/Mod/AddonManager/AddonManager.py
+++ b/src/Mod/AddonManager/AddonManager.py
@@ -276,7 +276,11 @@ class CommandAddonManager:
 
         import AddonManager_rc
         from PySide import QtGui
-        addonicon = QtGui.QIcon(":/icons/" + repo + "_workbench_icon.svg")
+        path = ":/icons/" + repo + "_workbench_icon.svg"
+        if QtCore.QFile.exists(path):
+            addonicon = QtGui.QIcon(path)
+        else:
+            addonicon = QtGui.QIcon(":/icons/document-package.svg")
         if addonicon.isNull():
             addonicon = QtGui.QIcon(":/icons/document-package.svg")
         return addonicon


### PR DESCRIPTION
Currently .isNull is used, to detect icon validity, but such method doesn't take the file path detection into an account. Result being a lot of messages outputted to the Report view and fallback icon not being used.

This PR fixes such icon path related issues.