### PR TITLE
Path: fix boundaryDressup Apply button enable

### DIFF
--- a/src/Mod/Path/PathScripts/PathDressupPathBoundaryGui.py
+++ b/src/Mod/Path/PathScripts/PathDressupPathBoundaryGui.py
@@ -169,6 +169,17 @@ class TaskPanel(object):
 
         self.form.stock.currentIndexChanged.connect(self.updateStockEditor)
         self.form.stockInside.stateChanged.connect(self.setDirty)
+        self.form.stockExtXneg.textChanged.connect(self.setDirty)
+        self.form.stockExtXpos.textChanged.connect(self.setDirty)
+        self.form.stockExtYneg.textChanged.connect(self.setDirty)
+        self.form.stockExtYpos.textChanged.connect(self.setDirty)
+        self.form.stockExtZneg.textChanged.connect(self.setDirty)
+        self.form.stockExtZpos.textChanged.connect(self.setDirty)
+        self.form.stockBoxLength.textChanged.connect(self.setDirty)
+        self.form.stockBoxWidth.textChanged.connect(self.setDirty)
+        self.form.stockBoxHeight.textChanged.connect(self.setDirty)
+        self.form.stockCylinderRadius.textChanged.connect(self.setDirty)
+        self.form.stockCylinderHeight.textChanged.connect(self.setDirty)
 
 
 class DressupPathBoundaryViewProvider(object):


### PR DESCRIPTION
ensure Apply button enabled when boundary limits are edited.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
