### PR TITLE
Gui: fix crash on Document resetEdit

### DIFF
--- a/src/Gui/Application.cpp
+++ b/src/Gui/Application.cpp
@@ -971,6 +971,8 @@ Gui::MDIView* Application::editViewOfNode(SoNode *node) const
 }
 
 void Application::setEditDocument(Gui::Document *doc) {
+    if(doc == d->editDocument)
+        return;
     if(!doc) 
         d->editDocument = 0;
     for(auto &v : d->documents)

--- a/src/Gui/Document.cpp
+++ b/src/Gui/Document.cpp
@@ -462,7 +462,12 @@ void Document::_resetEdit(void)
         }
 
         d->_editViewProvider->finishEditing();
-        if (d->_editViewProvider->isDerivedFrom(ViewProviderDocumentObject::getClassTypeId())) 
+
+        // Have to check d->_editViewProvider below, because there is a chance
+        // the editing object gets deleted inside the above call to
+        // 'finishEditing()', which will trigger our slotDeletedObject(), which
+        // nullifies _editViewProvider.
+        if (d->_editViewProvider && d->_editViewProvider->isDerivedFrom(ViewProviderDocumentObject::getClassTypeId())) 
             signalResetEdit(*(static_cast<ViewProviderDocumentObject*>(d->_editViewProvider)));
         d->_editViewProvider = 0;
 


### PR DESCRIPTION
To reproduce the crash, open the attached file (rename it to FCStd). Switch to Path workbench. Click toolbar button 'Create a Path Drilling object...'. Then click application menu action File -> Close All.

The cause of crash is Path drill object triggers undo inside its finishEditing() function, which deletes the newly created editing object.

[resetEditCrash.FCStd.zip](https://github.com/FreeCAD/FreeCAD/files/4190784/resetEditCrash.FCStd.zip)

