### PR TITLE
Path: fix drill job creation

### DIFF
--- a/src/Mod/Path/PathScripts/PathCircularHoleBaseGui.py
+++ b/src/Mod/Path/PathScripts/PathCircularHoleBaseGui.py
@@ -52,6 +52,8 @@ class TaskPanelHoleGeometryPage(PathOpGui.TaskPanelBaseGeometryPage):
     DataObject      = QtCore.Qt.ItemDataRole.UserRole + 1
     DataObjectSub   = QtCore.Qt.ItemDataRole.UserRole + 2
 
+    InitBase = False
+
     def getForm(self):
         '''getForm() ... load and return page'''
         return FreeCADGui.PySideUic.loadUi(":/panels/PageBaseHoleGeometryEdit.ui")

--- a/src/Mod/Path/PathScripts/PathOpGui.py
+++ b/src/Mod/Path/PathScripts/PathOpGui.py
@@ -1017,7 +1017,7 @@ class TaskPanel(object):
         if self.deleteOnReject and PathOp.FeatureBaseGeometry & self.obj.Proxy.opFeatures(self.obj):
             sel = FreeCADGui.Selection.getSelectionEx()
             for page in self.featurePages:
-                if hasattr(page, 'addBase'):
+                if getattr(page, 'InitBase', True) and hasattr(page, 'addBase'):
                     page.clearBase()
                     page.addBaseGeometry(sel)
 


### PR DESCRIPTION
To reproduce the problem, create a sketch with some circle. Create a Path job using the sketch. Create a drill object. There will be no circular edge selected. 

The problem is caused by PathOpGui.TaskPanel.setupUI() reseting the holes found by PathCircularHoleBase.ObjectOp.findAllHoles().