### PR TITLE
FEM : Correct writer.py at line 1623 and replaced ccx_elset by elset_data

### DIFF
--- a/src/Mod/Fem/femsolver/calculix/writer.py
+++ b/src/Mod/Fem/femsolver/calculix/writer.py
@@ -1620,7 +1620,7 @@ class FemInputWriterCcx(writerbase.FemInputWriter):
                         {"long": shellth_obj.Name, "short": shellth_data["ShortName"]}
                     ]
                     ccx_elset = {}
-                    ccx_elset["ccx_elset"] = ccx_elset
+                    ccx_elset["ccx_elset"] = elset_data
                     ccx_elset["ccx_elset_name"] = get_ccx_elset_name_standard(names)
                     ccx_elset["mat_obj_name"] = mat_obj.Name
                     ccx_elset["ccx_mat_name"] = mat_obj.Material["Name"]


### PR DESCRIPTION
When running a multiple materials and multiple shells FEM analysis calculix solver crashes.

After inspection, it appears that the crash comes from line 1623 in _writer.py_ file where _ccx_elset_ is used while it should be _elset_data_