### PR TITLE
Fix SetupPython.cmake so it finds pythonlibs 3.x when python 2.7 is present

### DIFF
--- a/cMake/FreeCAD_Helpers/SetupPython.cmake
+++ b/cMake/FreeCAD_Helpers/SetupPython.cmake
@@ -119,6 +119,12 @@ macro(SetupPython)
     endif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin" AND NOT BUILD_WITH_CONDA)
 
     find_package(PythonInterp REQUIRED)
+    
+    # Issue in cmake prevents finding pythonlibs 3.x when python 2.7 is present
+    # setting NOTFOUND here resolves the issue
+    set(PYTHON_INCLUDE_DIR "NOTFOUND")
+    set(PYTHON_LIBRARY "NOTFOUND")
+    
     set(Python_ADDITIONAL_VERSIONS ${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR})
     if (NOT DEFINED PYTHON_VERSION_STRING)
         find_package(PythonLibs REQUIRED)


### PR DESCRIPTION
Build environment Ubunto 19.10 minimal (using cmake 3.13.4) with Kdevelop 5.4.2.

Out of the box cmake doesn't find pythonlibs for python 3. This fix dug out from elsewhere on the internet appears to fix this issue, allowing FreeCAD to build.

Units tests run (some errors listed not related to this change) - I don't know what the correct behavior is to expect from the unit test run).
