### PR TITLE
Gui: block more events when ProgressBar is shown

### DIFF
--- a/src/Gui/ProgressBar.cpp
+++ b/src/Gui/ProgressBar.cpp
@@ -571,6 +571,9 @@ bool ProgressBar::eventFilter(QObject* o, QEvent* e)
         case QEvent::Enter:
         case QEvent::Leave:
         case QEvent::MouseButtonDblClick:
+        case QEvent::MouseButtonRelease:
+        case QEvent::MouseMove:
+        case QEvent::NativeGesture:
         case QEvent::ContextMenu:
             {
                 return true;


### PR DESCRIPTION
Block more mouse event when progress is shown, or else may lead to event loop reentry, and easily crash the gesture recognition state machine. 