### PR TITLE
Add ability to remember active workbench for each viewport tab

### DIFF
--- a/src/Gui/DlgSettings3DView.ui
+++ b/src/Gui/DlgSettings3DView.ui
@@ -41,6 +41,25 @@ lower right corner within opened files</string>
        </widget>
       </item>
       <item>
+       <widget class="Gui::PrefCheckBox" name="CheckBox_WbByTab">
+        <property name="toolTip">
+         <string>If checked, application will remember which workbench is active for each tab of the viewport</string>
+        </property>
+        <property name="text">
+         <string>Remember active workbench by tab</string>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>SaveWBbyTab</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>View</cstring>
+        </property>
+       </widget>
+      </item>
+      <item>
        <widget class="Gui::PrefCheckBox" name="CheckBox_ShowFPS">
         <property name="toolTip">
          <string>Time needed for last operation and resulting frame rate

--- a/src/Gui/DlgSettings3DViewImp.cpp
+++ b/src/Gui/DlgSettings3DViewImp.cpp
@@ -102,6 +102,7 @@ void DlgSettings3DViewImp::saveSettings()
     ui->spinBoxZoomStep->onSave();
     ui->checkBoxDragAtCursor->onSave();
     ui->CheckBox_CornerCoordSystem->onSave();
+    ui->CheckBox_WbByTab->onSave();
     ui->CheckBox_ShowFPS->onSave();
     ui->CheckBox_useVBO->onSave();
     ui->CheckBox_NaviCube->onSave();
@@ -134,6 +135,7 @@ void DlgSettings3DViewImp::loadSettings()
     ui->spinBoxZoomStep->onRestore();
     ui->checkBoxDragAtCursor->onRestore();
     ui->CheckBox_CornerCoordSystem->onRestore();
+    ui->CheckBox_WbByTab->onRestore();
     ui->CheckBox_ShowFPS->onRestore();
     ui->CheckBox_useVBO->onRestore();
     ui->CheckBox_NaviCube->onRestore();


### PR DESCRIPTION
Can be enabled/disabled through preferences => Connected to 'SaveWBbyTab' parameter
Workbench is saved when it is changed or when a new subwindow is created
It is restored when subwindow is activated if one was previously saved

- [X] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [X] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)

Wiki will be updated when merged