### PR TITLE
Draft: various fixes in code, style, spaces, and organization

### DIFF
--- a/src/Mod/Draft/Draft.py
+++ b/src/Mod/Draft/Draft.py
@@ -1,73 +1,77 @@
 # -*- coding: utf-8 -*-
-#***************************************************************************
-#*   Copyright (c) 2009, 2010 Yorik van Havre <yorik@uncreated.net>        *
-#*   Copyright (c) 2009, 2010 Ken Cline <cline@frii.com>                   *
-#*                                                                         *
-#*   This program is free software; you can redistribute it and/or modify  *
-#*   it under the terms of the GNU Lesser General Public License (LGPL)    *
-#*   as published by the Free Software Foundation; either version 2 of     *
-#*   the License, or (at your option) any later version.                   *
-#*   for detail see the LICENCE text file.                                 *
-#*                                                                         *
-#*   This program is distributed in the hope that it will be useful,       *
-#*   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
-#*   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
-#*   GNU Library General Public License for more details.                  *
-#*                                                                         *
-#*   You should have received a copy of the GNU Library General Public     *
-#*   License along with this program; if not, write to the Free Software   *
-#*   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
-#*   USA                                                                   *
-#*                                                                         *
-#***************************************************************************
+# ***************************************************************************
+# *   Copyright (c) 2009, 2010 Yorik van Havre <yorik@uncreated.net>        *
+# *   Copyright (c) 2009, 2010 Ken Cline <cline@frii.com>                   *
+# *                                                                         *
+# *   This program is free software; you can redistribute it and/or modify  *
+# *   it under the terms of the GNU Lesser General Public License (LGPL)    *
+# *   as published by the Free Software Foundation; either version 2 of     *
+# *   the License, or (at your option) any later version.                   *
+# *   for detail see the LICENCE text file.                                 *
+# *                                                                         *
+# *   This program is distributed in the hope that it will be useful,       *
+# *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+# *   GNU Library General Public License for more details.                  *
+# *                                                                         *
+# *   You should have received a copy of the GNU Library General Public     *
+# *   License along with this program; if not, write to the Free Software   *
+# *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
+# *   USA                                                                   *
+# *                                                                         *
+# ***************************************************************************
+"""Provide the Draft Workbench public programming interface.
 
-#from __future__ import division
-
-__title__="FreeCAD Draft Workbench"
-__author__ = "Yorik van Havre, Werner Mayer, Martin Burbaum, Ken Cline, Dmitry Chigrin, Daniel Falck"
-__url__ = "https://www.freecadweb.org"
-
+The Draft module offers tools to create and manipulate 2D objects.
+The functions in this file must be usable without requiring the
+graphical user interface.
+These functions can be used as the backend for the graphical commands
+defined in `DraftTools.py`.
+"""
 ## \addtogroup DRAFT
 #  \brief Create and manipulate basic 2D objects
 #
-#  This module offers a range of tools to create and manipulate basic 2D objects
+#  This module offers tools to create and manipulate basic 2D objects
 #
-#  The module allows to create 2D geometric objects such as line, rectangle, circle,
-#  etc, modify these objects by moving, scaling or rotating them, and offers a couple of
-#  other utilities to manipulate further these objects, such as decompose them (downgrade)
-#  into smaller elements.
+#  The module allows to create 2D geometric objects such as line, rectangle,
+#  circle, etc., modify these objects by moving, scaling or rotating them,
+#  and offers a couple of other utilities to manipulate further these objects,
+#  such as decompose them (downgrade) into smaller elements.
 #
 #  The functionality of the module is divided into GUI tools, usable from the
-#  FreeCAD interface, and corresponding python functions, that can perform the same
-#  operation programmatically.
+#  visual interface, and corresponding python functions, that can perform
+#  the same operation programmatically.
 #
 #  @{
 
-"""The Draft module offers a range of tools to create and manipulate basic 2D objects"""
-
-import FreeCAD, math, sys, os, DraftVecUtils, WorkingPlane
-import DraftGeomUtils
-import draftutils.translate
-from FreeCAD import Vector
+import math
+import sys
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
+import FreeCAD
+from FreeCAD import Vector
+
+import DraftVecUtils
+import WorkingPlane
+from draftutils.translate import translate
 
 if FreeCAD.GuiUp:
-    import FreeCADGui, Draft_rc
-    from PySide import QtCore
+    import FreeCADGui
+    import Draft_rc
     gui = True
-    #from DraftGui import translate
+    # To prevent complaints from code checkers (flake8)
+    True if Draft_rc.__name__ else False
 else:
-    # def QT_TRANSLATE_NOOP(ctxt,txt):
-    #     return txt
-    #print("FreeCAD Gui not present. Draft module will have some features disabled.")
     gui = False
 
-translate = draftutils.translate.translate
+__title__ = "FreeCAD Draft Workbench"
+__author__ = ("Yorik van Havre, Werner Mayer, Martin Burbaum, Ken Cline, "
+              "Dmitry Chigrin, Daniel Falck")
+__url__ = "https://www.freecadweb.org"
 
-#---------------------------------------------------------------------------
+# ---------------------------------------------------------------------------
 # Backwards compatibility
-#---------------------------------------------------------------------------
+# ---------------------------------------------------------------------------
 
 import DraftLayer
 _VisGroup = DraftLayer.Layer
@@ -78,9 +82,9 @@ makeLayer = DraftLayer.makeLayer
 # Fillet = DraftFillet.Fillet
 # makeFillet = DraftFillet.makeFillet
 
-#---------------------------------------------------------------------------
+# ---------------------------------------------------------------------------
 # General functions
-#---------------------------------------------------------------------------
+# ---------------------------------------------------------------------------
 import draftutils.utils
 import draftutils.gui_utils
 

--- a/src/Mod/Draft/Draft.py
+++ b/src/Mod/Draft/Draft.py
@@ -72,11 +72,9 @@ __url__ = "https://www.freecadweb.org"
 # ---------------------------------------------------------------------------
 # Backwards compatibility
 # ---------------------------------------------------------------------------
-
-import DraftLayer
-_VisGroup = DraftLayer.Layer
-_ViewProviderVisGroup = DraftLayer.ViewProviderLayer
-makeLayer = DraftLayer.makeLayer
+from DraftLayer import Layer as _VisGroup
+from DraftLayer import ViewProviderLayer as _ViewProviderVisGroup
+from DraftLayer import makeLayer
 
 # import DraftFillet
 # Fillet = DraftFillet.Fillet
@@ -85,94 +83,91 @@ makeLayer = DraftLayer.makeLayer
 # ---------------------------------------------------------------------------
 # General functions
 # ---------------------------------------------------------------------------
-import draftutils.utils
-import draftutils.gui_utils
+from draftutils.utils import ARROW_TYPES as arrowtypes
 
-arrowtypes = draftutils.utils.ARROW_TYPES
+from draftutils.utils import stringencodecoin
+from draftutils.utils import string_encode_coin
 
-stringencodecoin = draftutils.utils.string_encode_coin
-string_encode_coin = draftutils.utils.string_encode_coin
+from draftutils.utils import typecheck
+from draftutils.utils import type_check
 
-typecheck = draftutils.utils.type_check
-type_check = draftutils.utils.type_check
+from draftutils.utils import getParamType
+from draftutils.utils import get_param_type
 
-getParamType = draftutils.utils.get_param_type
-get_param_type = draftutils.utils.get_param_type
+from draftutils.utils import getParam
+from draftutils.utils import get_param
 
-getParam = draftutils.utils.get_param
-get_param = draftutils.utils.get_param
+from draftutils.utils import setParam
+from draftutils.utils import set_param
 
-setParam = draftutils.utils.set_param
-set_param = draftutils.utils.set_param
+from draftutils.utils import precision
+from draftutils.utils import tolerance
+from draftutils.utils import epsilon
 
-precision = draftutils.utils.precision
-tolerance = draftutils.utils.tolerance
-epsilon = draftutils.utils.epsilon
+from draftutils.utils import getRealName
+from draftutils.utils import get_real_name
 
-getRealName = draftutils.utils.get_real_name
-get_real_name = draftutils.utils.get_real_name
+from draftutils.utils import getType
+from draftutils.utils import get_type
 
-getType = draftutils.utils.get_type
-get_type = draftutils.utils.get_type
+from draftutils.utils import getObjectsOfType
+from draftutils.utils import get_objects_of_type
 
-getObjectsOfType = draftutils.utils.get_objects_of_type
-get_objects_of_type = draftutils.utils.get_objects_of_type
+from draftutils.utils import isClone
+from draftutils.utils import is_clone
 
-get3DView = draftutils.gui_utils.get_3d_view
-get_3d_view = draftutils.gui_utils.get_3d_view
+from draftutils.utils import getGroupNames
+from draftutils.utils import get_group_names
 
-isClone = draftutils.utils.is_clone
-is_clone = draftutils.utils.is_clone
+from draftutils.utils import ungroup
 
-getGroupNames = draftutils.utils.get_group_names
-get_group_names = draftutils.utils.get_group_names
+from draftutils.utils import getGroupContents
+from draftutils.utils import get_group_contents
 
-ungroup = draftutils.utils.ungroup
+from draftutils.utils import printShape
+from draftutils.utils import print_shape
 
-autogroup = draftutils.gui_utils.autogroup
+from draftutils.utils import compareObjects
+from draftutils.utils import compare_objects
 
-dimSymbol = draftutils.gui_utils.dim_symbol
-dim_symbol = draftutils.gui_utils.dim_symbol
+from draftutils.utils import shapify
 
-dimDash = draftutils.gui_utils.dim_dash
-dim_dash = draftutils.gui_utils.dim_dash
+from draftutils.utils import loadSvgPatterns
+from draftutils.utils import load_svg_patterns
 
-shapify = draftutils.utils.shapify
+from draftutils.utils import svgpatterns
+from draftutils.utils import svg_patterns
 
-getGroupContents = draftutils.utils.get_group_contents
-get_group_contents = draftutils.utils.get_group_contents
+from draftutils.utils import getMovableChildren
+from draftutils.utils import get_movable_children
 
-removeHidden = draftutils.gui_utils.remove_hidden
-remove_hidden = draftutils.gui_utils.remove_hidden
+from draftutils.gui_utils import get3DView
+from draftutils.gui_utils import get_3d_view
 
-printShape = draftutils.utils.print_shape
-print_shape = draftutils.utils.print_shape
+from draftutils.gui_utils import autogroup
 
-compareObjects = draftutils.utils.compare_objects
-compare_objects = draftutils.utils.compare_objects
+from draftutils.gui_utils import dimSymbol
+from draftutils.gui_utils import dim_symbol
 
-formatObject = draftutils.gui_utils.format_object
-format_object = draftutils.gui_utils.format_object
+from draftutils.gui_utils import dimDash
+from draftutils.gui_utils import dim_dash
 
-getSelection = draftutils.gui_utils.get_selection
-get_selection = draftutils.gui_utils.get_selection
+from draftutils.gui_utils import removeHidden
+from draftutils.gui_utils import remove_hidden
 
-getSelectionEx = draftutils.gui_utils.get_selection_ex
-get_selection_ex = draftutils.gui_utils.get_selection_ex
+from draftutils.gui_utils import formatObject
+from draftutils.gui_utils import format_object
 
-select = draftutils.gui_utils.select
+from draftutils.gui_utils import getSelection
+from draftutils.gui_utils import get_selection
 
-loadSvgPatterns = draftutils.utils.load_svg_patterns
-load_svg_patterns = draftutils.utils.load_svg_patterns
+from draftutils.gui_utils import getSelectionEx
+from draftutils.gui_utils import get_selection_ex
 
-svgpatterns = draftutils.utils.svg_patterns
-svg_patterns = draftutils.utils.svg_patterns
+from draftutils.gui_utils import select
 
-loadTexture = draftutils.gui_utils.load_texture
-load_texture = draftutils.gui_utils.load_texture
-
-getMovableChildren = draftutils.utils.get_movable_children
-get_movable_children = draftutils.utils.get_movable_children
+from draftutils.gui_utils import loadTexture
+from draftutils.gui_utils import load_texture
 
 
 def makeCircle(radius, placement=None, face=None, startangle=None, endangle=None, support=None):
@@ -3879,6 +3874,7 @@ class _ViewProviderDimension(_ViewProviderDraft):
         return mode
 
     def is_linked_to_circle(self):
+        import DraftGeomUtils
         _obj = self.Object
         if _obj.LinkedGeometry and len(_obj.LinkedGeometry) == 1:
             lobj = _obj.LinkedGeometry[0][0]

--- a/src/Mod/Draft/DraftGeomUtils.py
+++ b/src/Mod/Draft/DraftGeomUtils.py
@@ -52,6 +52,7 @@ params = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/Draft")
 
 # Generic functions *********************************************************
 
+
 def precision():
     """precision(): returns the Draft precision setting"""
     # Set precision level with a cap to avoid overspecification that:
@@ -63,10 +64,11 @@ def precision():
     precisionMax = 10
     precisionInt = params.GetInt("precision",6)
     precisionInt = (precisionInt if precisionInt <=10 else precisionMax)
-    return precisionInt								#return params.GetInt("precision",6)
+    return precisionInt	 # return params.GetInt("precision",6)
+
 
 def vec(edge):
-    "vec(edge) or vec(line): returns a vector from an edge or a Part.LineSegment"
+    """vec(edge) or vec(line): returns a vector from an edge or a Part.LineSegment"""
     # if edge is not straight, you'll get strange results!
     if isinstance(edge,Part.Shape):
         return edge.Vertexes[-1].Point.sub(edge.Vertexes[0].Point)
@@ -75,14 +77,16 @@ def vec(edge):
     else:
         return None
 
-def edg(p1,p2):
-    "edg(Vector,Vector): returns an edge from 2 vectors"
+
+def edg(p1, p2):
+    """edg(Vector,Vector): returns an edge from 2 vectors"""
     if isinstance(p1,FreeCAD.Vector) and isinstance(p2,FreeCAD.Vector):
         if DraftVecUtils.equals(p1,p2): return None
         else: return Part.LineSegment(p1,p2).toShape()
 
+
 def getVerts(shape):
-    "getVerts(shape): returns a list containing vectors of each vertex of the shape"
+    """getVerts(shape): returns a list containing vectors of each vertex of the shape"""
     if not hasattr(shape,"Vertexes"):
         return []
     p = []
@@ -90,13 +94,15 @@ def getVerts(shape):
             p.append(v.Point)
     return p
 
+
 def v1(edge):
-    "v1(edge): returns the first point of an edge"
+    """v1(edge): returns the first point of an edge"""
     return edge.Vertexes[0].Point
 
+
 def isNull(something):
-    '''isNull(object): returns true if the given shape is null or the given placement is null or
-    if the given vector is (0,0,0)'''
+    """isNull(object): returns true if the given shape is null or the given placement is null or
+    if the given vector is (0,0,0)"""
     if isinstance(something,Part.Shape):
             return something.isNull()
     elif isinstance(something,FreeCAD.Vector):
@@ -110,8 +116,9 @@ def isNull(something):
             else:
                     return False
 
-def isPtOnEdge(pt,edge) :
-    '''isPtOnEdge(Vector,edge): Tests if a point is on an edge'''
+
+def isPtOnEdge(pt, edge):
+    """isPtOnEdge(Vector,edge): Tests if a point is on an edge"""
     v = Part.Vertex(pt)
     try:
         d = v.distToShape(edge)
@@ -123,15 +130,17 @@ def isPtOnEdge(pt,edge) :
                 return True
     return False
 
+
 def hasCurves(shape):
-    "hasCurve(shape): checks if the given shape has curves"
+    """hasCurve(shape): checks if the given shape has curves"""
     for e in shape.Edges:
             if not isinstance(e.Curve,(Part.LineSegment,Part.Line)):
                     return True
     return False
 
-def isAligned(edge,axis="x"):
-    "isAligned(edge,axis): checks if the given edge or line is aligned to the given axis (x, y or z)"
+
+def isAligned(edge, axis="x"):
+    """isAligned(edge,axis): checks if the given edge or line is aligned to the given axis (x, y or z)"""
     if axis == "x":
         if isinstance(edge,Part.Edge):
             if len(edge.Vertexes) == 2:
@@ -158,6 +167,7 @@ def isAligned(edge,axis="x"):
                     return True
     return False
 
+
 def getQuad(face):
     """getQuad(face): returns a list of 3 vectors (basepoint, Xdir, Ydir) if the face
     is a quad, or None if not."""
@@ -178,7 +188,8 @@ def getQuad(face):
             ov.normalize()
             return [face.Edges[0].Vertexes[0].Point,v1,ov]
 
-def areColinear(e1,e2):
+
+def areColinear(e1, e2):
     """areColinear(e1,e2): returns True if both edges are colinear"""
     if not isinstance(e1.Curve,(Part.LineSegment,Part.Line)):
         return False
@@ -197,8 +208,9 @@ def areColinear(e1,e2):
                 return True
     return False
 
+
 def hasOnlyWires(shape):
-    "hasOnlyWires(shape): returns True if all the edges are inside a wire"
+    """hasOnlyWires(shape): returns True if all the edges are inside a wire"""
     ne = 0
     for w in shape.Wires:
         ne += len(w.Edges)
@@ -206,8 +218,9 @@ def hasOnlyWires(shape):
         return True
     return False
 
+
 def geomType(edge):
-    "returns the type of geom this edge is based on"
+    """returns the type of geom this edge is based on"""
     try:
         if isinstance(edge.Curve,(Part.LineSegment,Part.Line)):
             return "Line"
@@ -224,8 +237,9 @@ def geomType(edge):
     except:
         return "Unknown"
 
+
 def isValidPath(shape):
-    "isValidPath(shape): returns True if the shape can be used as an extrusion path"
+    """isValidPath(shape): returns True if the shape can be used as an extrusion path"""
     if shape.isNull():
         return False
     if shape.Faces:
@@ -239,10 +253,11 @@ def isValidPath(shape):
         return False
     return True
 
-# edge functions *****************************************************************
+# edge functions *************************************************************
 
-def findEdge(anEdge,aList):
-    '''findEdge(anEdge,aList): returns True if anEdge is found in aList of edges'''
+
+def findEdge(anEdge, aList):
+    """findEdge(anEdge,aList): returns True if anEdge is found in aList of edges"""
     for e in range(len(aList)):
         if str(anEdge.Curve) == str(aList[e].Curve):
             if DraftVecUtils.equals(anEdge.Vertexes[0].Point,aList[e].Vertexes[0].Point):
@@ -251,13 +266,16 @@ def findEdge(anEdge,aList):
     return None
 
 
-def findIntersection(edge1,edge2,infinite1=False,infinite2=False,ex1=False,ex2=False,dts=True,findAll=False) :
-    '''findIntersection(edge1,edge2,infinite1=False,infinite2=False,dts=True):
+def findIntersection(edge1, edge2,
+                     infinite1=False, infinite2=False,
+                     ex1=False, ex2=False,
+                     dts=True, findAll=False):
+    """findIntersection(edge1,edge2,infinite1=False,infinite2=False,dts=True):
     returns a list containing the intersection point(s) of 2 edges.
     You can also feed 4 points instead of edge1 and edge2. If dts is used,
-    Shape.distToShape() is used, which can be buggy'''
+    Shape.distToShape() is used, which can be buggy"""
 
-    def getLineIntersections(pt1,pt2,pt3,pt4,infinite1,infinite2):
+    def getLineIntersections(pt1, pt2, pt3, pt4, infinite1, infinite2):
         if pt1:
             # first check if we don't already have coincident endpoints
             if (pt1 in [pt3,pt4]):
@@ -424,9 +442,7 @@ def findIntersection(edge1,edge2,infinite1=False,infinite2=False,ex1=False,ex2=F
         return int
 
     elif (geomType(edge1) == "Circle") and (geomType(edge2) == "Circle") :
-
         # deals with 2 arcs or circles
-
         cent1, cent2 = edge1.Curve.Center, edge2.Curve.Center
         rad1 , rad2  = edge1.Curve.Radius, edge2.Curve.Radius
         axis1, axis2 = edge1.Curve.Axis  , edge2.Curve.Axis
@@ -458,7 +474,7 @@ def findIntersection(edge1,edge2,infinite1=False,infinite2=False,ex1=False,ex2=F
                     else :
                         int = [cent1.add(c2c)]
             else :
-                return [] # circles are on parallel planes
+                return []  # circles are on parallel planes
         else :
             # circles aren't on same plane
             axis1.normalize() ; axis2.normalize()
@@ -489,15 +505,17 @@ def findIntersection(edge1,edge2,infinite1=False,infinite2=False,ex1=False,ex2=F
         print("DraftGeomUtils: Unsupported curve type: (" + str(edge1.Curve) + ", " + str(edge2.Curve) + ")")
         return []
 
-def wiresIntersect(wire1,wire2):
-    "wiresIntersect(wire1,wire2): returns True if some of the edges of the wires are intersecting otherwise False"
+
+def wiresIntersect(wire1, wire2):
+    """wiresIntersect(wire1,wire2): returns True if some of the edges of the wires are intersecting otherwise False"""
     for e1 in wire1.Edges:
         for e2 in wire2.Edges:
             if findIntersection(e1,e2,dts=False):
                 return True
     return False
 
-def pocket2d(shape,offset):
+
+def pocket2d(shape, offset):
     """pocket2d(shape,offset): return a list of wires obtained from offsetting the wires from the given shape
     by the given offset, and intersection if needed."""
     # find the outer wire
@@ -563,6 +581,7 @@ def pocket2d(shape,offset):
     offsetWires = [o for o in offsetWires if o != None]
     return offsetWires
 
+
 def orientEdge(edge, normal=None, make_arc=False):
     """Re-orients 'edge' such that it is in the x-y plane. If 'normal' is passed, this
     is used as the basis for the rotation, otherwise the Placement property of 'edge'
@@ -593,8 +612,9 @@ def orientEdge(edge, normal=None, make_arc=False):
                                     edge.LastParameter,edge.Curve.Axis.z>0)
     return edge.Curve
 
-def mirror (point, edge):
-    "finds mirror point relative to an edge"
+
+def mirror(point, edge):
+    """Find mirror point relative to an edge."""
     normPoint = point.add(findDistance(point, edge, False))
     if normPoint:
         normPoint_point = Vector.sub(point, normPoint)
@@ -604,8 +624,9 @@ def mirror (point, edge):
     else:
         return None
 
-def isClockwise(edge,ref=None):
-    """Returns True if a circle-based edge has a clockwise direction"""
+
+def isClockwise(edge, ref=None):
+    """Return True if a circle-based edge has a clockwise direction."""
     if not geomType(edge) == "Circle":
         return True
     v1 = edge.Curve.tangent(edge.ParameterRange[0])[0]
@@ -625,7 +646,8 @@ def isClockwise(edge,ref=None):
         return False
     return True
 
-def isSameLine(e1,e2):
+
+def isSameLine(e1, e2):
     """isSameLine(e1,e2): return True if the 2 edges are lines and have the same
     points"""
     if not isinstance(e1.Curve,Part.LineSegment):
@@ -640,6 +662,7 @@ def isSameLine(e1,e2):
            return True
     return False
 
+
 def isWideAngle(edge):
     """returns True if the given edge is an arc with angle > 180 degrees"""
     if geomType(edge) != "Circle":
@@ -650,12 +673,13 @@ def isWideAngle(edge):
         return True
     return False
 
-def findClosest(basepoint,pointslist):
-    '''
+
+def findClosest(basepoint, pointslist):
+    """
     findClosest(vector,list)
     in a list of 3d points, finds the closest point to the base point.
     an index from the list is returned.
-    '''
+    """
     npoint = None
     if not pointslist:
         return None
@@ -667,8 +691,9 @@ def findClosest(basepoint,pointslist):
             npoint = n
     return npoint
 
+
 def concatenate(shape):
-    "concatenate(shape) -- turns several faces into one"
+    """concatenate(shape) -- turns several faces into one"""
     edges = getBoundary(shape)
     edges = Part.__sortEdges__(edges)
     try:
@@ -681,8 +706,9 @@ def concatenate(shape):
         if not wire.isClosed(): return(wire)
         else: return(face)
 
+
 def getBoundary(shape):
-    "getBoundary(shape) -- this function returns the boundary edges of a group of faces"
+    """getBoundary(shape) -- this function returns the boundary edges of a group of faces"""
     # make a lookup-table where we get the number of occurrences
     # to each edge in the fused face
     if isinstance(shape,list):
@@ -699,8 +725,9 @@ def getBoundary(shape):
         if lut[e.hashCode()] == 1: bound.append(e)
     return bound
 
+
 def isLine(bsp):
-    "returns True if the given BSpline curve is a straight line"
+    """Return True if the given BSpline curve is a straight line."""
     step = bsp.LastParameter/10
     b = bsp.tangent(0)
     for i in range(10):
@@ -710,8 +737,7 @@ def isLine(bsp):
 
 
 def sortEdges(edges):
-    "Deprecated. Use Part.__sortEdges__ instead"
-
+    """Deprecated. Use Part.__sortEdges__ instead."""
     raise DeprecationWarning("Deprecated. Use Part.__sortEdges__ instead")
 
     # Build a dictionary of edges according to their end points.
@@ -788,8 +814,7 @@ def sortEdges(edges):
 
 
 def sortEdgesOld(lEdges, aVertex=None):
-    "Deprecated. Use Part.__sortEdges__ instead"
-
+    """Deprecated. Use Part.__sortEdges__ instead."""
     raise DeprecationWarning("Deprecated. Use Part.__sortEdges__ instead")
 
     #There is no reason to limit this to lines only because every non-closed edge always
@@ -800,8 +825,8 @@ def sortEdgesOld(lEdges, aVertex=None):
     #                return lEdges
 
     def lookfor(aVertex, inEdges):
-        ''' Look for (aVertex, inEdges) returns count, the position of the instance
-        the position in the instance and the instance of the Edge'''
+        """Look for (aVertex, inEdges) returns count, the position of the instance
+        the position in the instance and the instance of the Edge"""
         count = 0
         linstances = [] #lists the instances of aVertex
         for i in range(len(inEdges)) :
@@ -880,7 +905,7 @@ def sortEdgesOld(lEdges, aVertex=None):
 
 
 def invert(shape):
-    '''invert(edge): returns an inverted copy of this edge or wire'''
+    """invert(edge): returns an inverted copy of this edge or wire"""
     if shape.ShapeType == "Wire":
         edges = [invert(edge) for edge in shape.OrderedEdges]
         edges.reverse()
@@ -902,9 +927,10 @@ def invert(shape):
         print("DraftGeomUtils.invert: unable to handle",shape.ShapeType)
         return shape
 
+
 def flattenWire(wire):
-    '''flattenWire(wire): forces a wire to get completely flat
-    along its normal.'''
+    """flattenWire(wire): forces a wire to get completely flat
+    along its normal."""
     import WorkingPlane
     n = getNormal(wire)
     if not n:
@@ -920,11 +946,13 @@ def flattenWire(wire):
     w = Part.makePolygon(verts)
     return w
 
+
 def findWires(edgeslist):
     return [ Part.Wire(e) for e in Part.sortEdges(edgeslist)]
 
+
 def findWiresOld2(edgeslist):
-    '''finds connected wires in the given list of edges'''
+    """Find connected wires in the given list of edges."""
 
     def touches(e1,e2):
         if len(e1.Vertexes) < 2:
@@ -981,9 +1009,10 @@ def findWiresOld2(edgeslist):
             nwires.append(wi)
     return nwires
 
-def superWire(edgeslist,closed=False):
-        '''superWire(edges,[closed]): forces a wire between edges that don't necessarily
-        have coincident endpoints. If closed=True, wire will always be closed'''
+
+def superWire(edgeslist, closed=False):
+        """superWire(edges,[closed]): forces a wire between edges that don't necessarily
+        have coincident endpoints. If closed=True, wire will always be closed"""
         def median(v1,v2):
                 vd = v2.sub(v1)
                 vd.scale(.5,.5,.5)
@@ -1035,8 +1064,9 @@ def superWire(edgeslist,closed=False):
         print(newedges)
         return Part.Wire(newedges)
 
+
 def findMidpoint(edge):
-    "calculates the midpoint of an edge"
+    """Calculate the midpoint of an edge."""
     first = edge.Vertexes[0].Point
     last = edge.Vertexes[-1].Point
     if geomType(edge) == "Circle":
@@ -1066,15 +1096,15 @@ def findMidpoint(edge):
         return None
 
 
-def findPerpendicular(point,edgeslist,force=None):
-    '''
+def findPerpendicular(point, edgeslist, force=None):
+    """
     findPerpendicular(vector,wire,[force]):
     finds the shortest perpendicular distance between a point and an edgeslist.
     If force is specified, only the edge[force] will be considered, and it will be
     considered infinite.
     The function will return a list [vector_from_point_to_closest_edge,edge_index]
     or None if no perpendicular vector could be found.
-    '''
+    """
     if not isinstance(edgeslist,list):
         try:
             edgeslist = edgeslist.Edges
@@ -1097,13 +1127,14 @@ def findPerpendicular(point,edgeslist,force=None):
         else: return None
         return None
 
-def offset(edge,vector,trim=False):
-    '''
+
+def offset(edge, vector, trim=False):
+    """
     offset(edge,vector)
     returns a copy of the edge at a certain (vector) distance
     if the edge is an arc, the vector will be added at its first point
     and a complete circle will be returned
-    '''
+    """
     if (not isinstance(edge,Part.Shape)) or (not isinstance(vector,FreeCAD.Vector)):
         return None
     if geomType(edge) == "Line":
@@ -1121,9 +1152,9 @@ def offset(edge,vector,trim=False):
     else:
         return None
 
-def isReallyClosed(wire):
-    "checks if a wire is really closed"
 
+def isReallyClosed(wire):
+    """Check if a wire is really closed."""
     ## TODO yet to find out why not use wire.isClosed() direct, in isReallyClosed(wire)
 
     # Remark out below - Found not true if a vertex is used again in a wire in sketch ( e.g. wire with shape like 'd', 'b', 'g'... )
@@ -1147,8 +1178,9 @@ def isReallyClosed(wire):
     if DraftVecUtils.equals(v1,v2): return True
     return False
 
+
 def getNormal(shape):
-        "finds the normal of a shape, if possible"
+        """Find the normal of a shape, if possible."""
         n = Vector(0,0,1)
         if shape.isNull():
             return n
@@ -1177,8 +1209,9 @@ def getNormal(shape):
             return None
         return n
 
-def getRotation(v1,v2=FreeCAD.Vector(0,0,1)):
-    '''Get the rotation Quaternion between 2 vectors'''
+
+def getRotation(v1, v2=FreeCAD.Vector(0, 0, 1)):
+    """Get the rotation Quaternion between 2 vectors."""
     if (v1.dot(v2) > 0.999999) or (v1.dot(v2) < -0.999999):
         # vectors are opposite
         return None
@@ -1188,10 +1221,11 @@ def getRotation(v1,v2=FreeCAD.Vector(0,0,1)):
     angle = math.degrees(DraftVecUtils.angle(v1,v2,axis))
     return FreeCAD.Rotation(axis,angle)
 
+
 def calculatePlacement(shape):
-    '''calculatePlacement(shape): if the given shape is planar, this function
+    """calculatePlacement(shape): if the given shape is planar, this function
     returns a placement located at the center of gravity of the shape, and oriented
-    towards the shape's normal. Otherwise, it returns a null placement.'''
+    towards the shape's normal. Otherwise, it returns a null placement."""
     if not isPlanar(shape):
         return FreeCAD.Placement()
     pos = shape.BoundBox.Center
@@ -1204,8 +1238,10 @@ def calculatePlacement(shape):
     return pla
 
 
-def offsetWire(wire,dvec,bind=False,occ=False,widthList=None, offsetMode=None, alignList=[], normal=None, basewireOffset=0):  # offsetMode="BasewireMode" or None
-    '''
+def offsetWire(wire, dvec, bind=False, occ=False,
+               widthList=None, offsetMode=None, alignList=[],
+               normal=None, basewireOffset=0):  # offsetMode="BasewireMode" or None
+    """
     offsetWire(wire,vector,[bind]): offsets the given wire along the given
     vector. The vector will be applied at the first vertex of the wire. If bind
     is True (and the shape is open), the original wire and the offsetted one
@@ -1226,16 +1262,16 @@ def offsetWire(wire,dvec,bind=False,occ=False,widthList=None, offsetMode=None, a
         'dvec' vector to offset is now derived (and can be ignored) in this function if widthList and alignList are provided - 'dvec' to be obsolete in future ?
 
         'basewireOffset' corresponds to 'offset' in ArchWall which offset the basewire before creating the wall outline
-    '''
+    """
 
     # Accept 'wire' as a list of edges (use the list directly), or previously as a wire or a face (Draft Wire with MakeFace True or False supported)
 
     if isinstance(wire,Part.Wire) or isinstance(wire,Part.Face):
-        edges = wire.Edges							# Seems has repeatedly sortEdges, remark out here - edges = Part.__sortEdges__(wire.Edges)
+        edges = wire.Edges  # Seems has repeatedly sortEdges, remark out here - edges = Part.__sortEdges__(wire.Edges)
     elif isinstance(wire, list):
         if isinstance(wire[0],Part.Edge):
             edges = wire.copy()
-            wire = Part.Wire( Part.__sortEdges__(edges) )			# How to avoid __sortEdges__ again?  Make getNormal directly tackle edges ?
+            wire = Part.Wire( Part.__sortEdges__(edges) )  # How to avoid __sortEdges__ again?  Make getNormal directly tackle edges ?
     else:
         print ("Either Part.Wire or Part.Edges should be provided, returning None ")
         return None
@@ -1245,7 +1281,7 @@ def offsetWire(wire,dvec,bind=False,occ=False,widthList=None, offsetMode=None, a
     if normal:
         norm = normal
     else:
-        norm = getNormal(wire)	#norm = Vector(0,0,1)
+        norm = getNormal(wire)  # norm = Vector(0, 0, 1)
 
     closed = isReallyClosed(wire)
     nedges = []
@@ -1272,7 +1308,6 @@ def offsetWire(wire,dvec,bind=False,occ=False,widthList=None, offsetMode=None, a
     alignListC = list(alignList)  # Python 2 and 3
 
     # Check the direction / offset of starting edge
-
     firstDir = None
     try:
         if alignListC[0] == 'Left':
@@ -1288,7 +1323,6 @@ def offsetWire(wire,dvec,bind=False,occ=False,widthList=None, offsetMode=None, a
         pass  # Should no longer happen for ArchWall - as aligns are 'filled in' by ArchWall
 
     # If not provided by alignListC checked above, check the direction of offset in dvec (not 'align') 
-
     if not firstDir:  ## TODO Should check if dvec is provided or not ('legacy/backward-compatible' mode)
         if isinstance(e.Curve,Part.Circle):  # need to test against Part.Circle, not Part.ArcOfCircle
             v0 = e.Vertexes[0].Point.sub(e.Curve.Center)
@@ -1310,7 +1344,6 @@ def offsetWire(wire,dvec,bind=False,occ=False,widthList=None, offsetMode=None, a
             alignListC.append('Left')
 
     for i in range(len(edges)):
-
         # make a copy so it do not reverse the self.baseWires edges pointed to by _Wall.getExtrusionData() ?
         curredge = edges[i].copy()
 
@@ -1331,7 +1364,6 @@ def offsetWire(wire,dvec,bind=False,occ=False,widthList=None, offsetMode=None, a
             curOrientation = curredge.Vertexes[0].Orientation			# TODO Could be edge.Orientation in fact
 
         # Consider individual edge width
-
         if widthList:  # ArchWall should now always provide widthList
             try:
                 if widthList[i] > 0:
@@ -1351,12 +1383,11 @@ def offsetWire(wire,dvec,bind=False,occ=False,widthList=None, offsetMode=None, a
             delta = DraftVecUtils.scaleTo(delta,dvec.Length)
 
         # Consider individual edge Align direction - ArchWall should now always provide alignList
-
         if i == 0:
             if alignListC[0] == 'Center':
                 delta = DraftVecUtils.scaleTo(delta, delta.Length/2)
-            #No need to do anything for 'Left' and 'Rigtht' as original dvec have set both the direction and amount of offset correct
-            #elif alignListC[i] == 'Left':  #elif alignListC[i] == 'Right':
+            # No need to do anything for 'Left' and 'Right' as original dvec have set both the direction and amount of offset correct
+            # elif alignListC[i] == 'Left':  #elif alignListC[i] == 'Right':
         if i != 0:
             try:
                 if alignListC[i] == 'Left':
@@ -1379,7 +1410,6 @@ def offsetWire(wire,dvec,bind=False,occ=False,widthList=None, offsetMode=None, a
                     delta = DraftVecUtils.scaleTo(delta, delta.Length/2)
 
         # Consider whether generating the 'offset wire' or the 'base wire'
-
         if offsetMode == None:
             # Consider if curOrientation and/or curDir match their firstOrientation/firstDir - to determine whether and how to offset the current edge 
             if (curOrientation == firstOrientation) != (curDir == firstDir):	# i.e. xor
@@ -1394,7 +1424,7 @@ def offsetWire(wire,dvec,bind=False,occ=False,widthList=None, offsetMode=None, a
                     delta = DraftVecUtils.scaleTo(delta, delta.Length+basewireOffset)
                 nedge = offset(curredge,delta,trim=True)
 
-            if curOrientation == "Reversed": # TODO arc always in counter-clockwise directinon ... ( not necessarily 'reversed')
+            if curOrientation == "Reversed":  # TODO arc always in counter-clockwise directinon ... ( not necessarily 'reversed')
                 if not isinstance(curredge.Curve,Part.Circle):  # need to test against Part.Circle, not Part.ArcOfCircle
                     # if not arc/circle, assume straight line, reverse it
                     nedge = Part.Edge(nedge.Vertexes[1],nedge.Vertexes[0])
@@ -1437,7 +1467,7 @@ def offsetWire(wire,dvec,bind=False,occ=False,widthList=None, offsetMode=None, a
                     nedge = Part.ArcOfCircle(nedge.Vertexes[1].Point, midOfArc, nedge.Vertexes[0].Point).toShape()
                     # TODO any better solution than to calculate midpoint of arc to reverse ?
         else:
-            print (" something wrong ")
+            print(" something wrong ")
             return
         if not nedge:
             return None
@@ -1458,8 +1488,8 @@ def offsetWire(wire,dvec,bind=False,occ=False,widthList=None, offsetMode=None, a
     else:
         return nedges
 
-def connect(edges,closed=False):
-        '''connects the edges in the given list by their intersections'''
+def connect(edges, closed=False):
+        """Connect the edges in the given list by their intersections."""
         nedges = []
         v2 = None
 
@@ -1524,12 +1554,12 @@ def connect(edges,closed=False):
                 print(e.Curve, " ",e.Vertexes[0].Point, " ", e.Vertexes[-1].Point)
             return None
 
-def findDistance(point,edge,strict=False):
-    '''
+def findDistance(point, edge, strict=False):
+    """
     findDistance(vector,edge,[strict]) - Returns a vector from the point to its
     closest point on the edge. If strict is True, the vector will be returned
     only if its endpoint lies on the edge. Edge can also be a list of 2 points.
-    '''
+    """
     if isinstance(point, FreeCAD.Vector):
         if isinstance(edge,list):
             segment = edge[1].sub(edge[0])
@@ -1612,7 +1642,7 @@ def findDistance(point,edge,strict=False):
 
 
 def angleBisection(edge1, edge2):
-    "angleBisection(edge,edge) - Returns an edge that bisects the angle between the 2 edges."
+    """angleBisection(edge,edge) - Returns an edge that bisects the angle between the 2 edges."""
     if (geomType(edge1) == "Line") and (geomType(edge2) == "Line"):
         p1 = edge1.Vertexes[0].Point
         p2 = edge1.Vertexes[-1].Point
@@ -1635,8 +1665,8 @@ def angleBisection(edge1, edge2):
     else:
         return None
 
-def findClosestCircle(point,circles):
-    "findClosestCircle(Vector, list of circles) -- returns the circle with closest center"
+def findClosestCircle(point, circles):
+    """Return the circle with closest center."""
     dist = 1000000
     closest = None
     for c in circles:
@@ -1645,8 +1675,9 @@ def findClosestCircle(point,circles):
             closest = c
     return closest
 
-def isCoplanar(faces,tolerance=0):
-    "isCoplanar(faces,[tolerance]): checks if all faces in the given list are coplanar. Tolerance is the max deviation to be considered coplanar"
+
+def isCoplanar(faces, tolerance=0):
+    """isCoplanar(faces,[tolerance]): checks if all faces in the given list are coplanar. Tolerance is the max deviation to be considered coplanar"""
     if len(faces) < 2:
         return True
     base =faces[0].normalAt(0,0)
@@ -1658,8 +1689,9 @@ def isCoplanar(faces,tolerance=0):
                 return False
     return True
 
+
 def isPlanar(shape):
-    "checks if the given shape is planar"
+    """Check if the given shape is planar."""
     if len(shape.Vertexes) <= 3:
         return True
     n = getNormal(shape)
@@ -1670,9 +1702,10 @@ def isPlanar(shape):
             return False
     return True
 
+
 def findWiresOld(edges):
-        '''finds connected edges in the list, and returns a list of lists containing edges
-        that can be connected'''
+        """finds connected edges in the list, and returns a list of lists containing edges
+        that can be connected"""
         raise DeprecationWarning("This function shouldn't be called anymore - use findWires() instead")
         def verts(shape):
                 return [shape.Vertexes[0].Point,shape.Vertexes[-1].Point]
@@ -1702,11 +1735,12 @@ def findWiresOld(edges):
                 edgeSet = result[1]
         return result[1]
 
-def getTangent(edge,frompoint=None):
-        '''
+
+def getTangent(edge, frompoint=None):
+        """
         returns the tangent to an edge. If from point is given, it is used to
         calculate the tangent (only useful for an arc of course).
-        '''
+        """
         if geomType(edge) == "Line":
                 return vec(edge)
         elif geomType(edge) == "BSplineCurve" or \
@@ -1723,9 +1757,10 @@ def getTangent(edge,frompoint=None):
                 return v1.cross(edge.Curve.Axis)
         return None
 
-def bind(w1,w2):
-    '''bind(wire1,wire2): binds 2 wires by their endpoints and
-    returns a face'''
+
+def bind(w1, w2):
+    """bind(wire1,wire2): binds 2 wires by their endpoints and
+    returns a face"""
     if (not w1) or (not w2):
         print("DraftGeomUtils: unable to bind wires")
         return None
@@ -1748,16 +1783,16 @@ def bind(w1,w2):
             return None
 
 def cleanFaces(shape):
-        "removes inner edges from coplanar faces"
+        """Remove inner edges from coplanar faces."""
         faceset = shape.Faces
         def find(hc):
-                "finds a face with the given hashcode"
+                """finds a face with the given hashcode"""
                 for f in faceset:
                         if f.hashCode() == hc:
                                 return f
 
         def findNeighbour(hface,hfacelist):
-                "finds the first neighbour of a face in a list, and returns its index"
+                """finds the first neighbour of a face in a list, and returns its index"""
                 eset = []
                 for e in find(hface).Edges:
                         eset.append(e.hashCode())
@@ -1848,8 +1883,8 @@ def cleanFaces(shape):
 
 
 def isCubic(shape):
-    '''isCubic(shape): verifies if a shape is cubic, that is, has
-    8 vertices, 6 faces, and all angles are 90 degrees.'''
+    """isCubic(shape): verifies if a shape is cubic, that is, has
+    8 vertices, 6 faces, and all angles are 90 degrees."""
     # first we try fast methods
     if len(shape.Vertexes) != 8:
         return False
@@ -1873,10 +1908,11 @@ def isCubic(shape):
                 return False
     return True
 
+
 def getCubicDimensions(shape):
-    '''getCubicDimensions(shape): returns a list containing the placement,
+    """getCubicDimensions(shape): returns a list containing the placement,
     the length, the width and the height of a cubic shape. If not cubic, nothing
-    is returned. The placement point is the lowest corner of the shape.'''
+    is returned. The placement point is the lowest corner of the shape."""
     if not isCubic(shape): return None
     # determine lowest face, which will be our base
     z = [10,1000000000000]
@@ -1914,9 +1950,10 @@ def getCubicDimensions(shape):
     mat.rotateZ(rotZ)
     return [FreeCAD.Placement(mat),round(vx.Length,precision()),round(vy.Length,precision()),round(vz.Length,precision())]
 
+
 def removeInterVertices(wire):
-        '''removeInterVertices(wire) - remove unneeded vertices (those that
-        are in the middle of a straight line) from a wire, returns a new wire.'''
+        """removeInterVertices(wire) - remove unneeded vertices (those that
+        are in the middle of a straight line) from a wire, returns a new wire."""
         edges = Part.__sortEdges__(wire.Edges)
         nverts = []
         def getvec(v1,v2):
@@ -1936,6 +1973,7 @@ def removeInterVertices(wire):
                 return w
         else:
                 return wire
+
 
 def arcFromSpline(edge):
         """arcFromSpline(edge): turns the given edge into an arc, by taking
@@ -1970,33 +2008,33 @@ def arcFromSpline(edge):
                 except:
                         print("couldn't make a circle out of this edge")
 
-# Fillet code graciously donated by Jacques-Antoine Gaudin
 
-def fillet(lEdges,r,chamfer=False):
-    '''fillet(lEdges,r,chamfer=False): Take a list of two Edges & a float as argument,
-    Returns a list of sorted edges describing a round corner'''
+def fillet(lEdges, r, chamfer=False):
+    """fillet(lEdges,r,chamfer=False): Take a list of two Edges & a float as argument,
+    Returns a list of sorted edges describing a round corner"""
+    # Fillet code graciously donated by Jacques-Antoine Gaudin
 
-    def getCurveType(edge,existingCurveType = None):
-            '''Builds or completes a dictionary containing edges with keys "Arc" and "Line"'''
-            if not existingCurveType :
+    def getCurveType(edge, existingCurveType=None):
+            """Builds or completes a dictionary containing edges with keys "Arc" and 'Line'"""
+            if not existingCurveType:
                     existingCurveType = { 'Line' : [], 'Arc' : [] }
-            if issubclass(type(edge.Curve),Part.LineSegment) :
+            if issubclass(type(edge.Curve),Part.LineSegment):
                     existingCurveType['Line'] += [edge]
-            elif issubclass(type(edge.Curve),Part.Line) :
+            elif issubclass(type(edge.Curve),Part.Line):
                     existingCurveType['Line'] += [edge]
-            elif issubclass(type(edge.Curve),Part.Circle) :
+            elif issubclass(type(edge.Curve),Part.Circle):
                     existingCurveType['Arc']  += [edge]
-            else :
+            else:
                     raise ValueError("Edge's curve must be either Line or Arc")
             return existingCurveType
 
     rndEdges = lEdges[0:2]
     rndEdges = Part.__sortEdges__(rndEdges)
 
-    if len(rndEdges) < 2 :
+    if len(rndEdges) < 2:
         return rndEdges
 
-    if r <= 0 :
+    if r <= 0:
         print("DraftGeomUtils.fillet : Error : radius is negative.")
         return rndEdges
 
@@ -2006,9 +2044,7 @@ def fillet(lEdges,r,chamfer=False):
     lVertexes = rndEdges[0].Vertexes + [rndEdges[1].Vertexes[-1]]
 
     if len(curveType['Line']) == 2:
-
         # Deals with 2-line-edges lists --------------------------------------
-
         U1 = lVertexes[0].Point.sub(lVertexes[1].Point) ; U1.normalize()
         U2 = lVertexes[2].Point.sub(lVertexes[1].Point) ; U2.normalize()
         alpha = U1.getAngle(U2)
@@ -2055,12 +2091,10 @@ def fillet(lEdges,r,chamfer=False):
         return rndEdges
 
     elif len(curveType['Arc']) == 1 :
-
-        # Deals with lists containing an arc and a line ----------------------------------
-
-        if lEdges[0] in curveType['Arc'] :
+        # Deals with lists containing an arc and a line ----------------------
+        if lEdges[0] in curveType['Arc']:
             lineEnd = lVertexes[2] ; arcEnd = lVertexes[0] ; arcFirst = True
-        else :
+        else:
             lineEnd = lVertexes[0] ; arcEnd = lVertexes[2] ; arcFirst = False
         arcCenter = curveType['Arc'][0].Curve.Center
         arcRadius = curveType['Arc'][0].Curve.Radius
@@ -2071,23 +2105,23 @@ def fillet(lEdges,r,chamfer=False):
         toCenter = arcCenter.sub(lVertexes[1].Point)
         if arcFirst : # make sure the tangent points towards the arc
             T = arcAxis.cross(toCenter)
-        else :
+        else:
             T = toCenter.cross(arcAxis)
 
         projCenter = toCenter.dot(U1)
-        if round(abs(projCenter),precision()) > 0 :
+        if round(abs(projCenter),precision()) > 0:
             normToLine = U1.cross(T).cross(U1)
-        else :
+        else:
             normToLine = Vector(toCenter)
         normToLine.normalize()
 
         dCenterToLine = toCenter.dot(normToLine) - r
 
-        if  round(projCenter,precision()) > 0 :
+        if  round(projCenter,precision()) > 0:
             newRadius = arcRadius - r
         elif round(projCenter,precision()) < 0 or (round(projCenter,precision()) == 0 and U1.dot(T) > 0):
             newRadius = arcRadius + r
-        else :
+        else:
             print("DraftGeomUtils.fillet : Warning : edges are already tangent. Did nothing")
             return rndEdges
 
@@ -2146,9 +2180,7 @@ def fillet(lEdges,r,chamfer=False):
         return rndEdges
 
     elif len(curveType['Arc']) == 2 :
-
-        # Deals with lists of 2 arc-edges --------------------------------------------
-
+        # Deals with lists of 2 arc-edges -----------------------------------
         arcCenter, arcRadius, arcAxis, arcLength, toCenter, T, newRadius = [], [], [], [], [], [], []
         for i in range(2) :
             arcCenter += [curveType['Arc'][i].Curve.Center]
@@ -2173,10 +2205,10 @@ def fillet(lEdges,r,chamfer=False):
             elif T[0].dot(T[1]) > 0 :
                 newRadius += [arcRadius[0]+r]
                 newRadius += [arcRadius[1]+r]
-            else :
+            else:
                 print("DraftGeomUtils.fillet : Warning : edges are already tangent. Did nothing")
                 return rndEdges
-        elif not sameDirection :
+        elif not sameDirection:
             if   round(TcrossT.dot(arcAxis[0]),precision()) > 0 :
                 newRadius += [arcRadius[0]+r]
                 newRadius += [arcRadius[1]-r]
@@ -2247,10 +2279,11 @@ def fillet(lEdges,r,chamfer=False):
 
         return rndEdges
 
-def filletWire(aWire,r,chamfer=False):
-    ''' Fillets each angle of a wire with r as radius value
+
+def filletWire(aWire, r, chamfer=False):
+    """Fillets each angle of a wire with r as radius value
     if chamfer is true, a chamfer is made instead and r is the
-    size of the chamfer'''
+    size of the chamfer"""
 
     edges = aWire.Edges
     edges = Part.__sortEdges__(edges)
@@ -2268,8 +2301,9 @@ def filletWire(aWire,r,chamfer=False):
             filEdges[0]   = result[2]
     return Part.Wire(filEdges)
 
+
 def getCircleFromSpline(edge):
-    "returns a circle-based edge from a bspline-based edge"
+    """Return a circle-based edge from a bspline-based edge."""
     if geomType(edge) != "BSplineCurve":
         return None
     if len(edge.Vertexes) != 1:
@@ -2297,7 +2331,8 @@ def getCircleFromSpline(edge):
     #print(circle.Curve)
     return circle
 
-def curvetowire(obj,steps):
+
+def curvetowire(obj, steps):
     points = obj.copy().discretize(steps)
     p0 = points[0]
     edgelist = []
@@ -2307,8 +2342,9 @@ def curvetowire(obj,steps):
         p0 = p
     return edgelist
 
-def cleanProjection(shape,tessellate=True,seglength=.05):
-    "returns a valid compound of edges, by recreating them"
+
+def cleanProjection(shape, tessellate=True, seglength=0.05):
+    """Return a valid compound of edges, by recreating them."""
     # this is because the projection algorithm somehow creates wrong shapes.
     # they display fine, but on loading the file the shape is invalid
     # Now with tanderson's fix to ProjectionAlgos, that isn't the case, but this
@@ -2351,7 +2387,8 @@ def cleanProjection(shape,tessellate=True,seglength=.05):
             print("Debug: error cleaning edge ",e)
     return Part.makeCompound(newedges)
 
-def curvetosegment(curve,seglen):
+
+def curvetosegment(curve, seglen):
     points = curve.discretize(seglen)
     p0 = points[0]
     edgelist = []
@@ -2361,9 +2398,10 @@ def curvetosegment(curve,seglen):
         p0 = p
     return edgelist
 
-def tessellateProjection(shape,seglen):
-    ''' Returns projection with BSplines and Ellipses broken into line segments.
-        Useful for exporting projected views to *dxf files.'''
+
+def tessellateProjection(shape, seglen):
+    """Returns projection with BSplines and Ellipses broken into line segments.
+        Useful for exporting projected views to *dxf files."""
     oldedges = shape.Edges
     newedges = []
     for e in oldedges:
@@ -2383,8 +2421,7 @@ def tessellateProjection(shape,seglen):
     return Part.makeCompound(newedges)
 
 
-def rebaseWire(wire,vidx):
-
+def rebaseWire(wire, vidx):
     """rebaseWire(wire,vidx): returns a new wire which is a copy of the
     current wire, but where the first vertex is the vertex indicated by the given
     index vidx, starting from 1. 0 will return an exact copy of the wire."""
@@ -2424,9 +2461,9 @@ def removeSplitter(shape):
 # circle functions *********************************************************
 
 
-def getBoundaryAngles(angle,alist):
-        '''returns the 2 closest angles from the list that
-        encompass the given angle'''
+def getBoundaryAngles(angle, alist):
+        """returns the 2 closest angles from the list that
+        encompass the given angle"""
         negs = True
         while negs:
                 negs = False
@@ -2467,7 +2504,7 @@ def getBoundaryAngles(angle,alist):
 
 
 def circleFrom2tan1pt(tan1, tan2, point):
-    "circleFrom2tan1pt(edge, edge, Vector)"
+    """circleFrom2tan1pt(edge, edge, Vector)"""
     if (geomType(tan1) == "Line") and (geomType(tan2) == "Line") and isinstance(point, FreeCAD.Vector):
         return circlefrom2Lines1Point(tan1, tan2, point)
     elif (geomType(tan1) == "Circle") and (geomType(tan2) == "Line") and isinstance(point, FreeCAD.Vector):
@@ -2477,8 +2514,9 @@ def circleFrom2tan1pt(tan1, tan2, point):
     elif (geomType(tan2) == "Circle") and (geomType(tan1) == "Circle") and isinstance(point, FreeCAD.Vector):
         return circlefrom2Circles1Point(tan2, tan1, point)
 
+
 def circleFrom2tan1rad(tan1, tan2, rad):
-    "circleFrom2tan1rad(edge, edge, float)"
+    """circleFrom2tan1rad(edge, edge, float)"""
     if (geomType(tan1) == "Line") and (geomType(tan2) == "Line"):
         return circleFrom2LinesRadius(tan1, tan2, rad)
     elif (geomType(tan1) == "Circle") and (geomType(tan2) == "Line"):
@@ -2488,17 +2526,20 @@ def circleFrom2tan1rad(tan1, tan2, rad):
     elif (geomType(tan1) == "Circle") and (geomType(tan2) == "Circle"):
         return circleFrom2CirclesRadius(tan1, tan2, rad)
 
+
 def circleFrom1tan2pt(tan1, p1, p2):
     if (geomType(tan1) == "Line") and isinstance(p1, FreeCAD.Vector) and isinstance(p2, FreeCAD.Vector):
         return circlefrom1Line2Points(tan1, p1, p2)
     if (geomType(tan1) == "Line") and isinstance(p1, FreeCAD.Vector) and isinstance(p2, FreeCAD.Vector):
         return circlefrom1Circle2Points(tan1, p1, p2)
 
+
 def circleFrom1tan1pt1rad(tan1, p1, rad):
     if (geomType(tan1) == "Line") and isinstance(p1, FreeCAD.Vector):
         return circleFromPointLineRadius(p1, tan1, rad)
     if (geomType(tan1) == "Circle") and isinstance(p1, FreeCAD.Vector):
         return circleFromPointCircleRadius(p1, tan1, rad)
+
 
 def circleFrom3tan(tan1, tan2, tan3):
     tan1IsLine = (geomType(tan1) == "Line")
@@ -2524,15 +2565,17 @@ def circleFrom3tan(tan1, tan2, tan3):
     elif (tan1IsCircle and tan2IsCircle and tan3IsLine):
         return circleFrom2Circle1Lines(tan1, tan2, tan3)
 
+
 def circlefrom2Lines1Point(edge1, edge2, point):
-    "circlefrom2Lines1Point(edge, edge, Vector)"
+    """circlefrom2Lines1Point(edge, edge, Vector)"""
     bis = angleBisection(edge1, edge2)
     if not bis: return None
     mirrPoint = mirror(point, bis)
     return circlefrom1Line2Points(edge1, point, mirrPoint)
 
+
 def circlefrom1Line2Points(edge, p1, p2):
-    "circlefrom1Line2Points(edge, Vector, Vector)"
+    """circlefrom1Line2Points(edge, Vector, Vector)"""
     p1_p2 = edg(p1, p2)
     s = findIntersection(edge, p1_p2, True, True)
     if not s: return None
@@ -2562,8 +2605,9 @@ def circlefrom1Line2Points(edge, p1, p2):
     if circles: return circles
     else: return None
 
-def circleFrom2LinesRadius (edge1, edge2, radius):
-    "circleFrom2LinesRadius(edge,edge,radius)"
+
+def circleFrom2LinesRadius(edge1, edge2, radius):
+    """circleFrom2LinesRadius(edge,edge,radius)"""
     int = findIntersection(edge1, edge2, True, True)
     if not int: return None
     int = int[0]
@@ -2584,8 +2628,9 @@ def circleFrom2LinesRadius (edge1, edge2, radius):
     circles.append(Part.Circle(cen, NORM, radius))
     return circles
 
-def circleFrom3LineTangents (edge1, edge2, edge3):
-    "circleFrom3LineTangents(edge,edge,edge)"
+
+def circleFrom3LineTangents(edge1, edge2, edge3):
+    """circleFrom3LineTangents(edge,edge,edge)"""
     def rot(ed):
         return Part.LineSegment(v1(ed),v1(ed).add(DraftVecUtils.rotate(vec(ed),math.pi/2))).toShape()
     bis12 = angleBisection(edge1,edge2)
@@ -2630,8 +2675,8 @@ def circleFrom3LineTangents (edge1, edge2, edge3):
     else:
         return None
 
-def circleFromPointLineRadius (point, edge, radius):
-    "circleFromPointLineRadius (point, edge, radius)"
+def circleFromPointLineRadius(point, edge, radius):
+    """circleFromPointLineRadius (point, edge, radius)"""
     dist = findDistance(point, edge, False)
     center1 = None
     center2 = None
@@ -2676,8 +2721,9 @@ def circleFromPointLineRadius (point, edge, radius):
     else:
         return None
 
+
 def circleFrom2PointsRadius(p1, p2, radius):
-    "circleFrom2PointsRadiust(Vector, Vector, radius)"
+    """circleFrom2PointsRadiust(Vector, Vector, radius)"""
     if DraftVecUtils.equals(p1, p2): return None
 
     p1_p2 = Part.LineSegment(p1, p2).toShape()
@@ -2699,9 +2745,8 @@ def circleFrom2PointsRadius(p1, p2, radius):
     else: return None
 
 
-def arcFrom2Pts(firstPt,lastPt,center,axis=None):
-
-    '''Builds an arc with center and 2 points, can be oriented with axis'''
+def arcFrom2Pts(firstPt, lastPt, center, axis=None):
+    """Build an arc with center and 2 points, can be oriented with axis."""
 
     radius1  = firstPt.sub(center).Length
     radius2  = lastPt.sub(center).Length
@@ -2730,9 +2775,7 @@ def arcFrom2Pts(firstPt,lastPt,center,axis=None):
 
 
 def outerSoddyCircle(circle1, circle2, circle3):
-    '''
-    Computes the outer soddy circle for three tightly packed circles.
-    '''
+    """Compute the outer soddy circle for three tightly packed circles."""
     if (geomType(circle1) == "Circle") and (geomType(circle2) == "Circle") \
     and (geomType(circle3) == "Circle"):
         # Original Java code Copyright (rc) 2008 Werner Randelshofer
@@ -2782,10 +2825,9 @@ def outerSoddyCircle(circle1, circle2, circle3):
         # FreeCAD.Console.PrintMessage("debug: outerSoddyCircle bad parameters!\n")
         return None
 
+
 def innerSoddyCircle(circle1, circle2, circle3):
-    '''
-    Computes the inner soddy circle for three tightly packed circles.
-    '''
+    """Compute the inner soddy circle for three tightly packed circles."""
     if (geomType(circle1) == "Circle") and (geomType(circle2) == "Circle") \
     and (geomType(circle3) == "Circle"):
         # Original Java code Copyright (rc) 2008 Werner Randelshofer
@@ -2834,12 +2876,13 @@ def innerSoddyCircle(circle1, circle2, circle3):
         # FreeCAD.Console.PrintMessage("debug: innerSoddyCircle bad parameters!\n")
         return None
 
+
 def circleFrom3CircleTangents(circle1, circle2, circle3):
-    '''
+    """
     http://en.wikipedia.org/wiki/Problem_of_Apollonius#Inversive_methods
     http://mathworld.wolfram.com/ApolloniusCircle.html
     http://mathworld.wolfram.com/ApolloniusProblem.html
-    '''
+    """
 
     if (geomType(circle1) == "Circle") and (geomType(circle2) == "Circle") \
     and (geomType(circle3) == "Circle"):
@@ -2888,9 +2931,9 @@ def circleFrom3CircleTangents(circle1, circle2, circle3):
         return None
 
 
-def linearFromPoints (p1, p2):
-    '''
-    Calculate linear equation from points.
+def linearFromPoints(p1, p2):
+    """Calculate linear equation from points.
+
     Calculate the slope and offset parameters of the linear equation of a line defined by two points.
 
     Linear equation:
@@ -2899,7 +2942,7 @@ def linearFromPoints (p1, p2):
     m ... Slope
     b ... Offset (point where the line intersects the y axis)
     dx/dy ... Delta x and y. Using both as a vector results in a non-offset direction vector.
-    '''
+    """
     if isinstance(p1, Vector) and isinstance(p2, Vector):
         line = {}
         line['dx'] = (p2.x - p1.x)
@@ -2911,11 +2954,11 @@ def linearFromPoints (p1, p2):
         return None
 
 
-def determinant (mat,n):
-    '''
+def determinant(mat, n):
+    """
     determinant(matrix,int) - Determinat function. Returns the determinant
     of a n-matrix. It recursively expands the minors.
-    '''
+    """
     matTemp = [[0.0,0.0,0.0],[0.0,0.0,0.0],[0.0,0.0,0.0]]
     if (n > 1):
         if n == 2:
@@ -2938,13 +2981,11 @@ def determinant (mat,n):
 
 
 def findHomotheticCenterOfCircles(circle1, circle2):
-    '''
-    findHomotheticCenterOfCircles(circle1, circle2)
-    Calculates the homothetic center(s) of two circles.
+    """Calculate the homothetic center(s) of two circles.
 
     http://en.wikipedia.org/wiki/Homothetic_center
     http://mathworld.wolfram.com/HomotheticCenter.html
-    '''
+    """
 
     if (geomType(circle1) == "Circle") and (geomType(circle2) == "Circle"):
         if DraftVecUtils.equals(circle1.Curve.Center, circle2.Curve.Center):
@@ -2981,14 +3022,13 @@ def findHomotheticCenterOfCircles(circle1, circle2):
             return None
 
     else:
-        print("debug: findHomotheticCenterOfCircles bad parameters!\n")
         FreeCAD.Console.PrintMessage("debug: findHomotheticCenterOfCirclescleFrom3tan bad parameters!\n")
         return None
 
 
 def findRadicalAxis(circle1, circle2):
-    '''
-    Calculates the radical axis of two circles.
+    """Calculate the radical axis of two circles.
+
     On the radical axis (also called power line) of two circles any
     tangents drawn from a point on the axis to both circles have the same length.
 
@@ -2996,8 +3036,7 @@ def findRadicalAxis(circle1, circle2):
     http://mathworld.wolfram.com/RadicalLine.html
 
     @sa findRadicalCenter
-    '''
-
+    """
     if (geomType(circle1) == "Circle") and (geomType(circle2) == "Circle"):
         if DraftVecUtils.equals(circle1.Curve.Center, circle2.Curve.Center):
             return None
@@ -3032,14 +3071,12 @@ def findRadicalAxis(circle1, circle2):
         else:
             return None
     else:
-        print("debug: findRadicalAxis bad parameters!\n")
         FreeCAD.Console.PrintMessage("debug: findRadicalAxis bad parameters!\n")
         return None
 
 
-
 def findRadicalCenter(circle1, circle2, circle3):
-    '''
+    """
     findRadicalCenter(circle1, circle2, circle3):
     Calculates the radical center (also called the power center) of three circles.
     It is the intersection point of the three radical axes of the pairs of circles.
@@ -3048,8 +3085,7 @@ def findRadicalCenter(circle1, circle2, circle3):
     http://mathworld.wolfram.com/RadicalCenter.html
 
     @sa findRadicalAxis
-    '''
-
+    """
     if (geomType(circle1) == "Circle") and (geomType(circle2) == "Circle"):
         radicalAxis12 = findRadicalAxis(circle1, circle2)
         radicalAxis23 = findRadicalAxis(circle1, circle2)
@@ -3066,22 +3102,21 @@ def findRadicalCenter(circle1, circle2, circle3):
             # No radical center could be calculated.
             return None
     else:
-        print("debug: findRadicalCenter bad parameters!\n")
         FreeCAD.Console.PrintMessage("debug: findRadicalCenter bad parameters!\n")
         return None
 
+
 def pointInversion(circle, point):
-    '''
+    """Circle inversion of a point.
+
     pointInversion(Circle, Vector)
 
-    Circle inversion of a point.
     Will calculate the inversed point an return it.
     If the given point is equal to the center of the circle "None" will be returned.
 
     See also:
     http://en.wikipedia.org/wiki/Inversive_geometry
-    '''
-
+    """
     if (geomType(circle) == "Circle") and isinstance(point, FreeCAD.Vector):
         cen = circle.Curve.Center
         rad = circle.Curve.Radius
@@ -3102,19 +3137,20 @@ def pointInversion(circle, point):
         return invPoint
 
     else:
-        print("debug: pointInversion bad parameters!\n")
         FreeCAD.Console.PrintMessage("debug: pointInversion bad parameters!\n")
         return None
 
+
 def polarInversion(circle, edge):
-    '''
+    """Return the inversion pole of a line.
+
     polarInversion(circle, edge):
-    Returns the inversion pole of a line.
+
     edge ... The polar.
     i.e. The nearest point on the line is inversed.
 
     http://mathworld.wolfram.com/InversionPole.html
-    '''
+    """
 
     if (geomType(circle) == "Circle") and (geomType(edge) == "Line"):
         nearest = circle.Curve.Center.add(findDistance(circle.Curve.Center, edge, False))
@@ -3122,18 +3158,17 @@ def polarInversion(circle, edge):
             inversionPole = pointInversion(circle, nearest)
             if inversionPole:
                 return inversionPole
-
     else:
-        print("debug: circleInversionPole bad parameters!\n")
         FreeCAD.Console.PrintMessage("debug: circleInversionPole bad parameters!\n")
         return None
 
+
 def circleInversion(circle, circle2):
-    '''
+    """
     pointInversion(Circle, Circle)
 
     Circle inversion of a circle.
-    '''
+    """
     if (geomType(circle) == "Circle") and (geomType(circle2) == "Circle"):
         cen1 = circle.Curve.Center
         rad1 = circle.Curve.Radius
@@ -3149,7 +3184,6 @@ def circleInversion(circle, circle2):
         return Part.Circle(invCen2, norm, DraftVecUtils.dist(invCen2, invPointOnCircle2))
 
     else:
-        print("debug: circleInversion bad parameters!\n")
         FreeCAD.Console.PrintMessage("debug: circleInversion bad parameters!\n")
         return None
 

--- a/src/Mod/Draft/DraftGeomUtils.py
+++ b/src/Mod/Draft/DraftGeomUtils.py
@@ -1,29 +1,31 @@
-#***************************************************************************
-#*   Copyright (c) 2009, 2010 Yorik van Havre <yorik@uncreated.net>        *
-#*   Copyright (c) 2009, 2010 Ken Cline <cline@frii.com>                   *
-#*                                                                         *
-#*   This program is free software; you can redistribute it and/or modify  *
-#*   it under the terms of the GNU Lesser General Public License (LGPL)    *
-#*   as published by the Free Software Foundation; either version 2 of     *
-#*   the License, or (at your option) any later version.                   *
-#*   for detail see the LICENCE text file.                                 *
-#*                                                                         *
-#*   This program is distributed in the hope that it will be useful,       *
-#*   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
-#*   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
-#*   GNU Library General Public License for more details.                  *
-#*                                                                         *
-#*   You should have received a copy of the GNU Library General Public     *
-#*   License along with this program; if not, write to the Free Software   *
-#*   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
-#*   USA                                                                   *
-#*                                                                         *
-#***************************************************************************
+# ***************************************************************************
+# *   Copyright (c) 2009, 2010 Yorik van Havre <yorik@uncreated.net>        *
+# *   Copyright (c) 2009, 2010 Ken Cline <cline@frii.com>                   *
+# *                                                                         *
+# *   This program is free software; you can redistribute it and/or modify  *
+# *   it under the terms of the GNU Lesser General Public License (LGPL)    *
+# *   as published by the Free Software Foundation; either version 2 of     *
+# *   the License, or (at your option) any later version.                   *
+# *   for detail see the LICENCE text file.                                 *
+# *                                                                         *
+# *   This program is distributed in the hope that it will be useful,       *
+# *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+# *   GNU Library General Public License for more details.                  *
+# *                                                                         *
+# *   You should have received a copy of the GNU Library General Public     *
+# *   License along with this program; if not, write to the Free Software   *
+# *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
+# *   USA                                                                   *
+# *                                                                         *
+# ***************************************************************************
+"""Define geometry functions for manipulating shapes in the Draft Workbench.
 
-__title__="FreeCAD Draft Workbench - Geometry library"
-__author__ = "Yorik van Havre, Jacques-Antoine Gaudin, Ken Cline"
-__url__ = ["https://www.freecadweb.org"]
-
+These functions are used by different object creation functions
+of the Draft Workbench, both in `Draft.py` and `DraftTools.py`.
+They operate on the internal shapes (`Part::TopoShape`) of different objects
+and on their subelements, that is, vertices, edges, and faces.
+"""
 ## \defgroup DRAFTGEOMUTILS DraftGeomUtils
 #  \ingroup UTILITIES
 #  \brief Shape manipulation utilities for the Draft workbench
@@ -32,20 +34,26 @@ __url__ = ["https://www.freecadweb.org"]
 
 ## \addtogroup DRAFTGEOMUTILS
 #  @{
+import cmath
+import math
 
-"this file contains generic geometry functions for manipulating Part shapes"
-
-import FreeCAD, Part, DraftVecUtils, math, cmath
+import FreeCAD
+import Part
+import DraftVecUtils
 from FreeCAD import Vector
 
-NORM = Vector(0,0,1) # provisory normal direction for all geometry ops.
+__title__ = "FreeCAD Draft Workbench - Geometry library"
+__author__ = "Yorik van Havre, Jacques-Antoine Gaudin, Ken Cline"
+__url__ = ["https://www.freecadweb.org"]
+
+NORM = Vector(0, 0, 1)  # provisory normal direction for all geometry ops.
 
 params = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/Draft")
 
 # Generic functions *********************************************************
 
 def precision():
-    "precision(): returns the Draft precision setting"
+    """precision(): returns the Draft precision setting"""
     # Set precision level with a cap to avoid overspecification that:
     #  1 - whilst it is precise enough (e.g. that OCC would consider 2 points are coincident)
     #      (not sure what it should be 10 or otherwise);
@@ -1260,7 +1268,8 @@ def offsetWire(wire,dvec,bind=False,occ=False,widthList=None, offsetMode=None, a
 
     # Make a copy of alignList - to avoid changes in this function become starting input of next call of this function ?
     # https://www.dataquest.io/blog/tutorial-functions-modify-lists-dictionaries-python/
-    alignListC = alignList.copy()
+    # alignListC = alignList.copy()  # Only Python 3
+    alignListC = list(alignList)  # Python 2 and 3
 
     # Check the direction / offset of starting edge
 

--- a/src/Mod/Draft/DraftTools.py
+++ b/src/Mod/Draft/DraftTools.py
@@ -2237,14 +2237,22 @@ class Dimension(Creator):
             if not self.cont:
                 self.finish()
 
+
 class ShapeString(Creator):
-    """This class creates a shapestring feature."""
+    """The Draft_ShapeString FreeCAD command definition."""
 
     def GetResources(self):
-        return {'Pixmap'  : 'Draft_ShapeString',
-                'Accel' : "S, S",
-                'MenuText': QtCore.QT_TRANSLATE_NOOP("Draft_ShapeString", "Shape from text..."),
-                'ToolTip': QtCore.QT_TRANSLATE_NOOP("Draft_ShapeString", "Creates text string in shapes.")}
+        """Set icon, menu and tooltip."""
+        _menu = "Shape from text"
+        _tooltip = ("Creates a shape from a text string by choosing "
+                    "a specific font and a placement.\n"
+                    "The closed shapes can be used for extrusions "
+                    "and boolean operations.")
+        d = {'Pixmap': 'Draft_ShapeString',
+             'Accel': "S, S",
+             'MenuText': QtCore.QT_TRANSLATE_NOOP("Draft_ShapeString", _menu),
+             'ToolTip': QtCore.QT_TRANSLATE_NOOP("Draft_ShapeString", _tooltip)}
+        return d
 
     def Activated(self):
         name = translate("draft","ShapeString")

--- a/src/Mod/Draft/DraftTools.py
+++ b/src/Mod/Draft/DraftTools.py
@@ -1,50 +1,69 @@
 # -*- coding: utf8 -*-
-#***************************************************************************
-#*   Copyright (c) 2009, 2010 Yorik van Havre <yorik@uncreated.net>        *
-#*   Copyright (c) 2009, 2010 Ken Cline <cline@frii.com>                   *
-#*                                                                         *
-#*   This program is free software; you can redistribute it and/or modify  *
-#*   it under the terms of the GNU Lesser General Public License (LGPL)    *
-#*   as published by the Free Software Foundation; either version 2 of     *
-#*   the License, or (at your option) any later version.                   *
-#*   for detail see the LICENCE text file.                                 *
-#*                                                                         *
-#*   This program is distributed in the hope that it will be useful,       *
-#*   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
-#*   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
-#*   GNU Library General Public License for more details.                  *
-#*                                                                         *
-#*   You should have received a copy of the GNU Library General Public     *
-#*   License along with this program; if not, write to the Free Software   *
-#*   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
-#*   USA                                                                   *
-#*                                                                         *
-#***************************************************************************
+# ***************************************************************************
+# *   Copyright (c) 2009, 2010 Yorik van Havre <yorik@uncreated.net>        *
+# *   Copyright (c) 2009, 2010 Ken Cline <cline@frii.com>                   *
+# *                                                                         *
+# *   This program is free software; you can redistribute it and/or modify  *
+# *   it under the terms of the GNU Lesser General Public License (LGPL)    *
+# *   as published by the Free Software Foundation; either version 2 of     *
+# *   the License, or (at your option) any later version.                   *
+# *   for detail see the LICENCE text file.                                 *
+# *                                                                         *
+# *   This program is distributed in the hope that it will be useful,       *
+# *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+# *   GNU Library General Public License for more details.                  *
+# *                                                                         *
+# *   You should have received a copy of the GNU Library General Public     *
+# *   License along with this program; if not, write to the Free Software   *
+# *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
+# *   USA                                                                   *
+# *                                                                         *
+# ***************************************************************************
+"""Provide GUI commands of the Draft Workbench.
 
-__title__="FreeCAD Draft Workbench GUI Tools"
-__author__ = "Yorik van Havre, Werner Mayer, Martin Burbaum, Ken Cline, Dmitry Chigrin"
-__url__ = "https://www.freecadweb.org"
-
+This module loads all graphical commands of the Draft Workbench,
+that is, those actions that can be called from menus and buttons.
+This module must be imported only when the graphical user interface
+is available, for example, during the workbench definition in `IntiGui.py`.
+"""
 ## @package DraftTools
 #  \ingroup DRAFT
-#  \brief GUI Commands of the Draft workbench
+#  \brief Provide GUI commands of the Draft workbench.
 #
-#  This module contains all the FreeCAD commands
-#  of the Draft module
+#  This module contains all the graphical commands of the Draft workbench,
+#  that is, those actions that can be called from menus and buttons.
 
-#---------------------------------------------------------------------------
+# ---------------------------------------------------------------------------
 # Generic stuff
-#---------------------------------------------------------------------------
+# ---------------------------------------------------------------------------
+import math
+import sys
+from PySide import QtCore, QtGui
+from pivy import coin
 
-import sys, FreeCAD, FreeCADGui, WorkingPlane, math, Draft, Draft_rc, DraftVecUtils
+import FreeCAD
+import FreeCADGui
 from FreeCAD import Vector
-from PySide import QtCore,QtGui
-import DraftGui
-from draftutils.todo import todo
+
+import Draft
+import Draft_rc
+import DraftGui  # Initializes the DraftToolBar class
+import DraftVecUtils
+import WorkingPlane
+from draftutils.todo import ToDo
 from draftutils.translate import translate
 import draftguitools.gui_snapper as gui_snapper
 import draftguitools.gui_trackers as trackers
-from pivy import coin
+
+# The module is used to prevent complaints from code checkers (flake8)
+True if Draft_rc.__name__ else False
+True if DraftGui.__name__ else False
+
+__title__ = "FreeCAD Draft Workbench GUI Tools"
+__author__ = ("Yorik van Havre, Werner Mayer, Martin Burbaum, Ken Cline, "
+              "Dmitry Chigrin")
+__url__ = "https://www.freecadweb.org"
 
 if not hasattr(FreeCADGui, "Snapper"):
     FreeCADGui.Snapper = gui_snapper.Snapper()
@@ -52,20 +71,18 @@ if not hasattr(FreeCADGui, "Snapper"):
 if not hasattr(FreeCAD, "DraftWorkingPlane"):
     FreeCAD.DraftWorkingPlane = WorkingPlane.plane()
 
-#---------------------------------------------------------------------------
+# ---------------------------------------------------------------------------
 # Commands that have been migrated to their own modules
-#---------------------------------------------------------------------------
-
+# ---------------------------------------------------------------------------
 import draftguitools.gui_edit
 import draftguitools.gui_selectplane
 # import DraftFillet
 import drafttaskpanels.task_shapestring as task_shapestring
 import drafttaskpanels.task_scale as task_scale
 
-#---------------------------------------------------------------------------
+# ---------------------------------------------------------------------------
 # Preflight stuff
-#---------------------------------------------------------------------------
-
+# ---------------------------------------------------------------------------
 # update the translation engine
 FreeCADGui.updateLocale()
 
@@ -86,10 +103,9 @@ MODCONSTRAIN = MODS[Draft.getParam("modconstrain",0)]
 MODSNAP = MODS[Draft.getParam("modsnap",1)]
 MODALT = MODS[Draft.getParam("modalt",2)]
 
-#---------------------------------------------------------------------------
+# ---------------------------------------------------------------------------
 # General functions
-#---------------------------------------------------------------------------
-
+# ---------------------------------------------------------------------------
 def formatUnit(exp,unit="mm"):
     '''returns a formatting string to set a number to the correct unit'''
     return FreeCAD.Units.Quantity(exp,FreeCAD.Units.Length).UserString
@@ -221,12 +237,9 @@ def setMod(args,mod,state):
         args["AltDown"] = state
 
 
-
-
-#---------------------------------------------------------------------------
+# ---------------------------------------------------------------------------
 # Base Class
-#---------------------------------------------------------------------------
-
+# ---------------------------------------------------------------------------
 class DraftTool:
     """The base class of all Draft Tools"""
 
@@ -296,7 +309,7 @@ class DraftTool:
                 pass
             self.call = None
         if self.commitList:
-            todo.delayCommit(self.commitList)
+            ToDo.delayCommit(self.commitList)
         self.commitList = []
 
     def commit(self,name,func):
@@ -334,10 +347,9 @@ class DraftTool:
         return qr,sup,points,fil
 
 
-#---------------------------------------------------------------------------
+# ---------------------------------------------------------------------------
 # Geometry constructors
-#---------------------------------------------------------------------------
-
+# ---------------------------------------------------------------------------
 def redraw3DView():
     """redraw3DView(): forces a redraw of 3d view."""
     try:
@@ -463,7 +475,7 @@ class Line(Creator):
                 # object already deleted, for some reason
                 pass
             else:
-                todo.delay(self.doc.removeObject,old)
+                ToDo.delay(self.doc.removeObject, old)
         self.obj = None
 
     def undolast(self):
@@ -575,7 +587,7 @@ class Wire(Line):
                     pts = pts.replace("Vector","FreeCAD.Vector")
                     rems = ["FreeCAD.ActiveDocument.removeObject(\""+o.Name+"\")" for o in FreeCADGui.Selection.getSelection()]
                     FreeCADGui.addModule("Draft")
-                    todo.delayCommit([(translate("draft","Convert to Wire"),
+                    ToDo.delayCommit([(translate("draft", "Convert to Wire"),
                             ['wire = Draft.makeWire(['+pts+'])']+rems+['Draft.autogroup(wire)',
                              'FreeCAD.ActiveDocument.recompute()'])])
                     return
@@ -665,7 +677,7 @@ class BSpline(Line):
         if self.obj:
             # remove temporary object, if any
             old = self.obj.Name
-            todo.delay(self.doc.removeObject,old)
+            ToDo.delay(self.doc.removeObject, old)
         if (len(self.node) > 1):
             try:
                 # building command string
@@ -785,7 +797,7 @@ class BezCurve(Line):
         if self.obj:
             # remove temporary object, if any
             old = self.obj.Name
-            todo.delay(self.doc.removeObject,old)
+            ToDo.delay(self.doc.removeObject, old)
         if (len(self.node) > 1):
             try:
                 # building command string
@@ -944,7 +956,7 @@ class CubicBezCurve(Line):
         if self.obj:
             # remove temporary object, if any
             old = self.obj.Name
-            todo.delay(self.doc.removeObject,old)
+            ToDo.delay(self.doc.removeObject, old)
         if closed == False :
             cleannd=(len(self.node)-1) % self.degree
             if cleannd == 0 : self.node = self.node[0:-3]
@@ -2248,7 +2260,7 @@ class ShapeString(Creator):
                     pass
                 self.task = task_shapestring.ShapeStringTaskPanel()
                 self.task.sourceCmd = self
-                todo.delay(FreeCADGui.Control.showDialog,self.task)
+                ToDo.delay(FreeCADGui.Control.showDialog, self.task)
             else:
                 self.dialog = None
                 self.text = ''
@@ -2408,7 +2420,7 @@ class Move(Modifier):
             ghost.finalize()
         if cont and self.ui:
             if self.ui.continueMode:
-                todo.delayAfter(self.Activated,[])
+                ToDo.delayAfter(self.Activated, [])
         Modifier.finish(self)
 
     def action(self,arg):
@@ -2750,7 +2762,7 @@ class Rotate(Modifier):
             ghost.finalize()
         if cont and self.ui:
             if self.ui.continueMode:
-                todo.delayAfter(self.Activated,[])
+                ToDo.delayAfter(self.Activated, [])
         Modifier.finish(self)
         if self.doc:
             self.doc.recompute()
@@ -4133,9 +4145,9 @@ class Scale(Modifier):
                 self.view.removeEventCallback("SoEvent",self.call)
             self.task = task_scale.ScaleTaskPanel()
             self.task.sourceCmd = self
-            todo.delay(FreeCADGui.Control.showDialog,self.task)
-            todo.delay(self.task.xValue.selectAll,None)
-            todo.delay(self.task.xValue.setFocus,None)
+            ToDo.delay(FreeCADGui.Control.showDialog, self.task)
+            ToDo.delay(self.task.xValue.selectAll, None)
+            ToDo.delay(self.task.xValue.setFocus, None)
             for ghost in self.ghosts:
                 ghost.on()
         elif len(self.node) == 2:
@@ -4788,7 +4800,7 @@ class Point(Creator):
                                         ['point = Draft.makePoint('+str(self.stack[0][0])+','+str(self.stack[0][1])+','+str(self.stack[0][2])+')',
                                          'Draft.autogroup(point)',
                                          'FreeCAD.ActiveDocument.recompute()']))
-                todo.delayCommit(commitlist)
+                ToDo.delayCommit(commitlist)
                 FreeCADGui.Snapper.off()
             self.finish()
 
@@ -4856,7 +4868,7 @@ class Draft_Clone(Modifier):
     def finish(self,close=False):
         Modifier.finish(self,close=False)
         if self.moveAfterCloning:
-            todo.delay(FreeCADGui.runCommand,"Draft_Move")
+            ToDo.delay(FreeCADGui.runCommand, "Draft_Move")
 
 
 class ToggleGrid():

--- a/src/Mod/Draft/DraftVecUtils.py
+++ b/src/Mod/Draft/DraftVecUtils.py
@@ -1,19 +1,3 @@
-## \defgroup DRAFTVECUTILS DraftVecUtils
-#  \ingroup UTILITIES
-#  \brief Vector math utilities used in Draft workbench
-#
-# Vector math utilities used primarily in the Draft workbench
-# but which can also be used in other workbenches and in macros.
-"""\defgroup DRAFTVECUTILS DraftVecUtils
-\ingroup UTILITIES
-\brief Vector math utilities used in Draft workbench
-
-Vector math utilities used primarily in the Draft workbench
-but which can also be used in other workbenches and in macros.
-"""
-# Check code with
-# flake8 --ignore=E226,E266,E401,W503
-
 # ***************************************************************************
 # *   Copyright (c) 2009, 2010 Yorik van Havre <yorik@uncreated.net>        *
 # *   Copyright (c) 2009, 2010 Ken Cline <cline@frii.com>                   *
@@ -35,18 +19,31 @@ but which can also be used in other workbenches and in macros.
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
+"""Provide vector math utilities used in the Draft workbench.
+
+Vector math utilities used primarily in the Draft workbench
+but which can also be used in other workbenches and in macros.
+"""
+## \defgroup DRAFTVECUTILS DraftVecUtils
+#  \ingroup UTILITIES
+#  \brief Vector math utilities used in Draft workbench
+#
+# Vector math utilities used primarily in the Draft workbench
+# but which can also be used in other workbenches and in macros.
+
+# Check code with
+# flake8 --ignore=E226,E266,E401,W503
+
+import math
+import sys
+
+import FreeCAD
+from FreeCAD import Vector
+import draftutils.messages as messages
 
 __title__ = "FreeCAD Draft Workbench - Vector library"
 __author__ = "Yorik van Havre, Werner Mayer, Martin Burbaum, Ken Cline"
 __url__ = "https://www.freecadweb.org"
-
-## \addtogroup DRAFTVECUTILS
-#  @{
-
-import sys
-import math, FreeCAD
-from FreeCAD import Vector, Matrix
-from FreeCAD import Console as FCC
 
 # Python 2 has two integer types, int and long.
 # In Python 3 there is no 'long' anymore, so make it 'int'.
@@ -56,6 +53,9 @@ except NameError:
     long = int
 
 params = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/Draft")
+
+## \addtogroup DRAFTVECUTILS
+#  @{
 
 
 def precision():
@@ -97,16 +97,15 @@ def typecheck(args_and_types, name="?"):
         Defaults to `'?'`. The name of the check.
 
     Raises
-    -------
+    ------
     TypeError
         If the first element in the tuple is not an instance of the second
         element.
     """
     for v, t in args_and_types:
         if not isinstance(v, t):
-            _msg = ("typecheck[" + str(name) + "]: "
-                    + str(v) + " is not " + str(t) + "\n")
-            FCC.PrintWarning(_msg)
+            _msg = "typecheck[{0}]: {1} is not {2}".format(name, v, t)
+            messages._wrn(_msg)
             raise TypeError("fcvec." + str(name))
 
 
@@ -208,7 +207,7 @@ def equals(u, v):
         The second vector.
 
     Returns
-    ------
+    -------
     bool
         `True` if the vectors are within the precision, `False` otherwise.
     """
@@ -497,9 +496,9 @@ def rotate(u, angle, axis=Vector(0, 0, 1)):
     ys = y * s
     zs = z * s
 
-    m = Matrix(c + x*x*t,   xyt - zs,   xzt + ys,   0,
-               xyt + zs,    c + y*y*t,  yzt - xs,   0,
-               xzt - ys,    yzt + xs,   c + z*z*t,  0)
+    m = FreeCAD.Matrix(c + x*x*t,   xyt - zs,   xzt + ys,   0,
+                       xyt + zs,    c + y*y*t,  yzt - xs,   0,
+                       xzt - ys,    yzt + xs,   c + z*z*t,  0)
 
     return m.multiply(u)
 
@@ -547,7 +546,7 @@ def getRotation(vector, reference=Vector(1, 0, 0)):
 
 
 def isNull(vector):
-    """Returns `False` if each of the components of the vector is zero.
+    """Return False if each of the components of the vector is zero.
 
     Due to rounding errors, an element is probably never going to be
     exactly zero. Therefore, it rounds the element by the number

--- a/src/Mod/Draft/InitGui.py
+++ b/src/Mod/Draft/InitGui.py
@@ -1,4 +1,3 @@
-"""Initialization of the Draft workbench (graphical interface)."""
 # ***************************************************************************
 # *   Copyright (c) 2009 Yorik van Havre <yorik@uncreated.net>              *
 # *                                                                         *
@@ -19,7 +18,10 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
+"""Initialization of the Draft workbench (graphical interface)."""
+
 import os
+
 import FreeCAD
 import FreeCADGui
 

--- a/src/Mod/Draft/WorkingPlane.py
+++ b/src/Mod/Draft/WorkingPlane.py
@@ -1,20 +1,3 @@
-## @package WorkingPlane
-#  \ingroup DRAFT
-#  \brief This module handles the Working Plane and grid of the Draft module.
-#
-#  This module provides the plane class which provides a virtual working plane
-#  in FreeCAD and a couple of utility functions.
-"""@package WorkingPlane
-\ingroup DRAFT
-\brief This module handles the working plane and grid of the Draft Workbench.
-
-This module provides the plane class which provides a virtual working plane
-in FreeCAD and a couple of utility functions.
-The working plane is mostly intended to be used in the Draft Workbench
-to draw 2D objects in various orientations, not only in the standard XY,
-YZ, and XZ planes.
-"""
-
 # ***************************************************************************
 # *   Copyright (c) 2009, 2010 Ken Cline <cline@frii.com>                   *
 # *                                                                         *
@@ -35,64 +18,87 @@ YZ, and XZ planes.
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
+"""Provide the working plane code and utilities for the Draft Workbench.
 
+This module provides the plane class which provides a virtual working plane
+in FreeCAD and a couple of utility functions.
+The working plane is mostly intended to be used in the Draft Workbench
+to draw 2D objects in various orientations, not only in the standard XY,
+YZ, and XZ planes.
+"""
+## @package WorkingPlane
+#  \ingroup DRAFT
+#  \brief This module handles the Working Plane and grid of the Draft module.
+#
+#  This module provides the plane class which provides a virtual working plane
+#  in FreeCAD and a couple of utility functions.
 
-import FreeCAD, math, DraftVecUtils
+import math
+
+import FreeCAD
+import DraftVecUtils
 from FreeCAD import Vector
-from FreeCAD import Console as FCC
 
 __title__ = "FreeCAD Working Plane utility"
 __author__ = "Ken Cline"
 __url__ = "https://www.freecadweb.org"
 
 
-class plane:
+class Plane:
     """A WorkPlane object.
+
+    Parameters
+    ----------
+    u: Base::Vector3, optional
+        An axis (vector) that helps define the working plane.
+        It defaults to `(1, 0, 0)`, or the +X axis.
+
+    v: Base::Vector3, optional
+        An axis (vector) that helps define the working plane.
+        It defaults to `(0, 1, 0)`, or the +Y axis.
+
+    w: Base::Vector3, optional
+        An axis that is supposed to be perpendicular to `u` and `v`;
+        it is redundant.
+        It defaults to `(0, 0, 1)`, or the +Z axis.
+
+    pos: Base::Vector3, optional
+        A point through which the plane goes through.
+        It defaults to the origin `(0, 0, 0)`.
 
     Attributes
     ----------
-    doc : App::Document
+    doc: App::Document
         The active document. Reset view when `doc` changes.
-    weak : bool
+
+    weak: bool
         It is `True` if the plane has been defined by `setup()`
         or has been reset. A weak plane can be changed
         (it is the "auto" mode), while a strong plane will keep
         its position until weakened (it is "locked")
-    u : Base::Vector3
+
+    u: Base::Vector3
         An axis (vector) that helps define the working plane.
-    v : Base::Vector3
+
+    v: Base::Vector3
         An axis (vector) that helps define the working plane.
-    axis : Base::Vector3
+
+    axis: Base::Vector3
         A vector that is supposed to be perpendicular to `u` and `v`;
         it is helpful although redundant.
-    position : Base::Vector3
+
+    position: Base::Vector3
         A point, which the plane goes through,
         that helps define the working plane.
-    stored : bool
+
+    stored: bool
         A placeholder for a stored state.
     """
 
     def __init__(self,
                  u=Vector(1, 0, 0), v=Vector(0, 1, 0), w=Vector(0, 0, 1),
                  pos=Vector(0, 0, 0)):
-        """Initialize the working plane.
 
-        Parameters
-        ----------
-        u : Base::Vector3, optional
-            An axis (vector) that helps define the working plane.
-            It defaults to `(1, 0, 0)`, or the +X axis.
-        v : Base::Vector3, optional
-            An axis (vector) that helps define the working plane.
-            It defaults to `(0, 1, 0)`, or the +Y axis.
-        w : Base::Vector3, optional
-            An axis that is supposed to be perpendicular to `u` and `v`;
-            it is redundant.
-            It defaults to `(0, 0, 1)`, or the +Z axis.
-        pos : Base::Vector3, optional
-            A point through which the plane goes through.
-            It defaults to the origin `(0, 0, 0)`.
-        """
         # keep track of active document.  Reset view when doc changes.
         self.doc = None
         self.weak = True
@@ -122,6 +128,7 @@ class plane:
         ----------
         p : Base::Vector3
             The external point to consider.
+
         direction : Base::Vector3, optional
             The unit vector that indicates the direction of the distance.
 
@@ -326,8 +333,8 @@ class plane:
         offsetVector.multiply(offset)
         self.position = point.add(offsetVector)
         self.weak = False
-        # FCC.PrintMessage("(position = " + str(self.position) + ")\n")
-        # FCC.PrintMessage(self.__repr__() + "\n")
+        # Console.PrintMessage("(position = " + str(self.position) + ")\n")
+        # Console.PrintMessage(self.__repr__() + "\n")
 
     def alignToPointAndAxis_SVG(self, point, axis, offset=0):
         """Align the working plane to a point and an axis (vector).
@@ -436,14 +443,14 @@ class plane:
 
         # spat_vec = self.u.cross(self.v)
         # spat_res = spat_vec.dot(axis)
-        # FCC.PrintMessage(projcase + " spat Prod = " + str(spat_res) + "\n")
+        # Console.PrintMessage(projcase + " spat Prod = " + str(spat_res) + "\n")
 
         offsetVector = Vector(axis)
         offsetVector.multiply(offset)
         self.position = point.add(offsetVector)
         self.weak = False
-        # FCC.PrintMessage("(position = " + str(self.position) + ")\n")
-        # FCC.PrintMessage(self.__repr__() + "\n")
+        # Console.PrintMessage("(position = " + str(self.position) + ")\n")
+        # Console.PrintMessage(self.__repr__() + "\n")
 
     def alignToCurve(self, shape, offset=0):
         """Align plane to curve. NOT YET IMPLEMENTED.
@@ -631,7 +638,7 @@ class plane:
         When the interface is not loaded it should fail and print
         a message, `FreeCAD.Console.PrintError()`.
 
-        See also
+        See Also
         --------
         alignToFace, alignToCurve
         """
@@ -652,7 +659,7 @@ class plane:
             return False
 
     def setup(self, direction=None, point=None, upvec=None, force=False):
-        """Setup the working plane if it exists but is undefined.
+        """Set up the working plane if it exists but is undefined.
 
         If `direction` and `point` are present,
         it calls `alignToPointAndAxis(point, direction, 0, upvec)`.
@@ -704,7 +711,7 @@ class plane:
                         # perpendicular to the current view
                         self.alignToPointAndAxis(Vector(0, 0, 0),
                                                  vdir.negative(), 0, upvec)
-                except:
+                except Exception:
                     pass
             if force:
                 self.weak = False
@@ -878,7 +885,7 @@ class plane:
         Base::Vector3
             The relative coordinates of the point from the plane.
 
-        See also
+        See Also
         --------
         getGlobalCoords, getLocalRot, getGlobalRot
 
@@ -944,7 +951,7 @@ class plane:
         Base::Vector3
             The coordinates of the point from the absolute origin.
 
-        See also
+        See Also
         --------
         getLocalCoords, getLocalRot, getGlobalRot
 
@@ -999,7 +1006,7 @@ class plane:
             The relative coordinates of the point from the plane,
             if the plane had its `position` at the global origin.
 
-        See also
+        See Also
         --------
         getLocalCoords, getGlobalCoords, getGlobalRot
         """
@@ -1039,7 +1046,7 @@ class plane:
         Base::Vector3
             The coordinates of the point from the absolute origin.
 
-        See also
+        See Also
         --------
         getGlobalCoords, getLocalCoords, getLocalRot
         """
@@ -1144,7 +1151,7 @@ class plane:
             Angle between the `u` vector, and a projected vector
             on the global horizontal plane.
 
-        See also
+        See Also
         --------
         DraftVecUtils.angle
         """
@@ -1154,6 +1161,9 @@ class plane:
         else:
             norm = proj.cross(self.u)
             return DraftVecUtils.angle(self.u, proj, norm)
+
+
+plane = Plane
 
 
 def getPlacementFromPoints(points):
@@ -1185,7 +1195,7 @@ def getPlacementFromPoints(points):
         defined by `points`,
         or `None` is it fails to use the points.
 
-    See also
+    See Also
     --------
     getPlacement
     """
@@ -1198,7 +1208,7 @@ def getPlacementFromPoints(points):
             pl.axis = (points[3].sub(points[0]).normalize())
         else:
             pl.axis = ((pl.u).cross(pl.v)).normalize()
-    except:
+    except Exception:
         return None
     p = pl.getPlacement()
     del pl
@@ -1229,14 +1239,14 @@ def getPlacementFromFace(face, rotated=False):
         defined by `face`,
         or `None` if it fails to use `face`.
 
-    See also
+    See Also
     --------
     alignToFace, getPlacement
     """
     pl = plane()
     try:
         pl.alignToFace(face)
-    except:
+    except Exception:
         return None
     p = pl.getPlacement(rotated)
     del pl

--- a/src/Mod/Draft/draftguitools/__init__.py
+++ b/src/Mod/Draft/draftguitools/__init__.py
@@ -1,0 +1,6 @@
+"""Commands that require the graphical user interface to work.
+
+These GUI commands are called by buttons, menus, contextual menus,
+toolbars, or other ways that require graphical widgets.
+They are normally loaded in the workbench's `InitGui.py`.
+"""

--- a/src/Mod/Draft/draftguitools/gui_arrays.py
+++ b/src/Mod/Draft/draftguitools/gui_arrays.py
@@ -1,8 +1,3 @@
-"""Provide the Draft ArrayTools command to group the other array tools."""
-## @package gui_arrays
-# \ingroup DRAFT
-# \brief Provide the Draft ArrayTools command to group the other array tools.
-
 # ***************************************************************************
 # *   (c) 2020 Eliud Cabrera Castillo <e.cabrera-castillo@tum.de>           *
 # *                                                                         *
@@ -25,9 +20,14 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
+"""Provide the Draft ArrayTools command to group the other array tools."""
+## @package gui_arrays
+# \ingroup DRAFT
+# \brief Provide the Draft ArrayTools command to group the other array tools.
+from PySide.QtCore import QT_TRANSLATE_NOOP
+
 import FreeCAD as App
 import FreeCADGui as Gui
-from PySide.QtCore import QT_TRANSLATE_NOOP
 
 
 class ArrayGroupCommand:
@@ -49,8 +49,11 @@ class ArrayGroupCommand:
                 'ToolTip': QT_TRANSLATE_NOOP("Arch", _tooltip)}
 
     def IsActive(self):
-        """Be active only when a document is active."""
-        return App.ActiveDocument is not None
+        """Return True when this command should be available."""
+        if App.ActiveDocument:
+            return True
+        else:
+            return False
 
 
 Gui.addCommand('Draft_ArrayTools', ArrayGroupCommand())

--- a/src/Mod/Draft/draftguitools/gui_base.py
+++ b/src/Mod/Draft/draftguitools/gui_base.py
@@ -1,9 +1,3 @@
-"""This module provides the Base object for all Draft Gui commands.
-"""
-## @package gui_base
-# \ingroup DRAFT
-# \brief This module provides the Base object for all Draft Gui commands.
-
 # ***************************************************************************
 # *   (c) 2009 Yorik van Havre <yorik@uncreated.net>                        *
 # *   (c) 2010 Ken Cline <cline@frii.com>                                   *
@@ -28,10 +22,14 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
+"""Provide the Base object for all Draft Gui commands."""
+## @package gui_base
+# \ingroup DRAFT
+# \brief This module provides the Base object for all Draft Gui commands.
 
 import FreeCAD as App
 import FreeCADGui as Gui
-import DraftGui
+import draftutils.todo as todo
 
 
 class GuiCommandBase:
@@ -52,7 +50,7 @@ class GuiCommandBase:
 
         Each string in the list of strings represents a Python instruction
         which will be executed in a delayed fashion
-        by `DraftGui.todo.delayCommit()`
+        by `todo.ToDo.delayCommit()`
         ::
             list1 = ["a = FreeCAD.Vector()",
                      "pl = FreeCAD.Placement()",
@@ -69,6 +67,7 @@ class GuiCommandBase:
             >>> pl = FreeCAD.Placement()
             >>> Draft.autogroup(obj)
     """
+
     def __init__(self):
         self.call = None
         self.commit_list = []
@@ -78,7 +77,8 @@ class GuiCommandBase:
         self.planetrack = None
 
     def IsActive(self):
-        if Gui.ActiveDocument:
+        """Return True when this command should be available."""
+        if App.ActiveDocument:
             return True
         else:
             return False
@@ -102,7 +102,7 @@ class GuiCommandBase:
                 pass
             self.call = None
         if self.commit_list:
-            DraftGui.todo.delayCommit(self.commit_list)
+            todo.ToDo.delayCommit(self.commit_list)
         self.commit_list = []
 
     def commit(self, name, func):

--- a/src/Mod/Draft/draftguitools/gui_circulararray.py
+++ b/src/Mod/Draft/draftguitools/gui_circulararray.py
@@ -1,9 +1,3 @@
-"""This module provides the Draft CircularArray tool.
-"""
-## @package gui_circulararray
-# \ingroup DRAFT
-# \brief This module provides the Draft CircularArray tool.
-
 # ***************************************************************************
 # *   (c) 2019 Eliud Cabrera Castillo <e.cabrera-castillo@tum.de>           *
 # *                                                                         *
@@ -26,41 +20,28 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
+"""Provides the Draft CircularArray tool."""
+## @package gui_circulararray
+# \ingroup DRAFT
+# \brief This module provides the Draft CircularArray tool.
+
+from pivy import coin
+from PySide.QtCore import QT_TRANSLATE_NOOP
 
 import FreeCAD as App
 import FreeCADGui as Gui
 import Draft
-import DraftGui
 import Draft_rc
-from . import gui_base
+from draftguitools import gui_base
 from drafttaskpanels import task_circulararray
+import draftutils.todo as todo
 
-
-if App.GuiUp:
-    from PySide.QtCore import QT_TRANSLATE_NOOP
-    # import DraftTools
-    from DraftGui import translate
-    # from DraftGui import displayExternal
-    from pivy import coin
-else:
-    def QT_TRANSLATE_NOOP(context, text):
-        return text
-
-    def translate(context, text):
-        return text
-
-
-def _tr(text):
-    """Function to translate with the context set"""
-    return translate("Draft", text)
-
-
-# So the resource file doesn't trigger errors from code checkers (flake8)
+# The module is used to prevent complaints from code checkers (flake8)
 True if Draft_rc.__name__ else False
 
 
 class GuiCommandCircularArray(gui_base.GuiCommandBase):
-    """Gui command for the CircularArray tool"""
+    """Gui command for the CircularArray tool."""
 
     def __init__(self):
         super().__init__()
@@ -74,6 +55,7 @@ class GuiCommandCircularArray(gui_base.GuiCommandBase):
         self.point = App.Vector()
 
     def GetResources(self):
+        """Set icon, menu and tooltip."""
         _msg = ("Creates copies of a selected object, "
                 "and places the copies in a circular pattern.\n"
                 "The properties of the array can be further modified after "
@@ -85,7 +67,7 @@ class GuiCommandCircularArray(gui_base.GuiCommandBase):
         return d
 
     def Activated(self):
-        """This is called when the command is executed.
+        """Execute when the command is called.
 
         We add callbacks that connect the 3D view with
         the widgets of the task panel.
@@ -103,10 +85,10 @@ class GuiCommandCircularArray(gui_base.GuiCommandBase):
         # of the interface, to be able to call a function from within it.
         self.ui.source_command = self
         # Gui.Control.showDialog(self.ui)
-        DraftGui.todo.delay(Gui.Control.showDialog, self.ui)
+        todo.ToDo.delay(Gui.Control.showDialog, self.ui)
 
     def move(self, event_cb):
-        """This is a callback for when the mouse pointer moves in the 3D view.
+        """Execute as a callback when the pointer moves in the 3D view.
 
         It should automatically update the coordinates in the widgets
         of the task panel.
@@ -119,7 +101,7 @@ class GuiCommandCircularArray(gui_base.GuiCommandBase):
             self.ui.display_point(self.point)
 
     def click(self, event_cb=None):
-        """This is a callback for when the mouse pointer clicks on the 3D view.
+        """Execute as a callback when the pointer clicks on the 3D view.
 
         It should act as if the Enter key was pressed, or the OK button
         was pressed in the task panel.
@@ -136,7 +118,7 @@ class GuiCommandCircularArray(gui_base.GuiCommandBase):
             self.ui.accept()
 
     def completed(self):
-        """This is called when the command is terminated.
+        """Execute when the command is terminated.
 
         We should remove the callbacks that were added to the 3D view
         and then close the task panel.
@@ -146,10 +128,8 @@ class GuiCommandCircularArray(gui_base.GuiCommandBase):
         self.view.removeEventCallbackPivy(self.mouse_event,
                                           self.callback_click)
         if Gui.Control.activeDialog():
-            Gui.Snapper.off()
             Gui.Control.closeDialog()
             super().finish()
 
 
-if App.GuiUp:
-    Gui.addCommand('Draft_CircularArray', GuiCommandCircularArray())
+Gui.addCommand('Draft_CircularArray', GuiCommandCircularArray())

--- a/src/Mod/Draft/draftguitools/gui_edit.py
+++ b/src/Mod/Draft/draftguitools/gui_edit.py
@@ -269,7 +269,7 @@ class Edit:
         """
         if self.running:
             self.finish()
-        DraftTools.Modifier.Activated(self,"Edit")
+        DraftTools.Modifier.Activated(self, "Edit")
         if not App.ActiveDocument:
             self.finish()
 
@@ -281,26 +281,26 @@ class Edit:
         else:
             self.ui.selectUi()
             App.Console.PrintMessage(translate("draft", 
-                                                   "Select a Draft object to edit")
-                                                   + "\n")
+                                               "Select a Draft object to edit")
+                                               + "\n")
             self.register_selection_callback()
 
     def proceed(self):
-        "this method defines editpoints and set the editTrackers"
+        """this method defines editpoints and set the editTrackers"""
         self.unregister_selection_callback()
         self.edited_objects = self.getObjsFromSelection()
         if not self.edited_objects:
-            return self.finish() 
+            return self.finish()
 
         # Save selectstate and turn selectable false.
         # Object can remain selectable commenting following lines:
-        # self.saveSelectState(self.obj)        
+        # self.saveSelectState(self.obj)
         # self.setSelectState(self.obj, False)
 
         # start object editing
         Gui.Selection.clearSelection()
         Gui.Snapper.setSelectMode(True)
-        
+
         self.ui.editUi()
 
         for obj in self.edited_objects:
@@ -313,10 +313,8 @@ class Edit:
         # self.alignWorkingPlane()
 
 
-    def finish(self,closed=False):
-        """
-        terminates Edit Tool
-        """
+    def finish(self, closed=False):
+        """Terminate Edit Tool."""
         self.unregister_selection_callback()
         self.unregister_editing_callbacks()
         self.editing = None
@@ -347,16 +345,14 @@ class Edit:
         self.running = False
         # delay resetting edit mode otherwise it doesn't happen
         from PySide import QtCore
-        QtCore.QTimer.singleShot(0,Gui.ActiveDocument.resetEdit)
+        QtCore.QTimer.singleShot(0, Gui.ActiveDocument.resetEdit)
 
     # -------------------------------------------------------------------------
     # SCENE EVENTS CALLBACKS
     # -------------------------------------------------------------------------
 
     def register_selection_callback(self):
-        """
-        register callback for selection when command is launched
-        """
+        """Register callback for selection when command is launched."""
         self.unregister_selection_callback()
         self.selection_callback = self.view.addEventCallback("SoEvent",DraftTools.selectObject)
 
@@ -365,7 +361,7 @@ class Edit:
         remove selection callback if it exists
         """
         if self.selection_callback:
-            self.view.removeEventCallback("SoEvent",self.selection_callback)
+            self.view.removeEventCallback("SoEvent", self.selection_callback)
         self.selection_callback = None
 
     def register_editing_callbacks(self):
@@ -409,23 +405,21 @@ class Edit:
     # -------------------------------------------------------------------------
 
     def keyPressed(self, event_callback):
-        """
-        keyboard event handler
-        """
-        #TODO: Get the keys from preferences
+        """Execute as callback for keyboard event."""
+        # TODO: Get the keys from preferences
         event = event_callback.getEvent()
         if event.getState() == coin.SoKeyboardEvent.DOWN:
             key = event.getKey()
-            #App.Console.PrintMessage("pressed key : "+str(key)+"\n")
-            if key == 65307: # ESC
+            # App.Console.PrintMessage("pressed key : "+str(key)+"\n")
+            if key == 65307:  # ESC
                 self.finish()
-            if key == 97: # "a"
+            if key == 97:  # "a"
                 self.finish()
-            if key == 111: # "o"
+            if key == 111:  # "o"
                 self.finish(closed=True)
-            if key == 101: # "e"
+            if key == 101:  # "e"
                 self.display_tracker_menu(event)
-            if key == 105: # "i"
+            if key == 105:  # "i"
                 if Draft.getType(self.obj) == "Circle":
                     self.arcInvert(self.obj)
 
@@ -441,14 +435,17 @@ class Edit:
                 if self.editing is None:
                     self.startEditing(event)
                 else:
-                    self.endEditing(self.obj,self.editing)
-            elif event.wasAltDown(): #left click with ctrl down
+                    self.endEditing(self.obj, self.editing)
+            elif event.wasAltDown():  # left click with ctrl down
                 self.display_tracker_menu(event)
 
     def mouseMoved(self, event_callback):
-        "mouse moved event handler, update tracker position and update preview ghost"
+        """Execute as callback for mouse movement.
+
+        Update tracker position and update preview ghost.
+        """
         event = event_callback.getEvent()
-        if self.editing != None:
+        if self.editing is not None:
             self.updateTrackerAndGhost(event)
         else:
             # look for a node in mouse position and highlight it
@@ -466,7 +463,7 @@ class Edit:
                     self.overNode = None
 
     def startEditing(self, event):
-        "start editing selected EditNode"
+        """Start editing selected EditNode."""
         pos = event.getPosition()
         node = self.getEditNode(pos)
         ep = self.getEditNodeIndex(node)
@@ -494,18 +491,19 @@ class Edit:
         self.hideTrackers()
 
     def updateTrackerAndGhost(self, event):
-        "updates tracker position when editing and update ghost"
+        """Update tracker position when editing and update ghost."""
         pos = event.getPosition().getValue()
         orthoConstrain = False
-        if event.wasShiftDown() == 1: orthoConstrain = True
+        if event.wasShiftDown() == 1:
+            orthoConstrain = True
         snappedPos = Gui.Snapper.snap((pos[0],pos[1]),self.node[-1], constrain=orthoConstrain)
         self.trackers[self.obj.Name][self.editing].set(snappedPos)
-        self.ui.displayPoint(snappedPos,self.node[-1])
+        self.ui.displayPoint(snappedPos, self.node[-1])
         if self.ghost:
-            self.updateGhost(obj=self.obj,idx=self.editing,pt=snappedPos)
+            self.updateGhost(obj=self.obj, idx=self.editing, pt=snappedPos)
 
-    def endEditing(self, obj, nodeIndex, v = None):
-        "terminate editing and start object updating process"
+    def endEditing(self, obj, nodeIndex, v=None):
+        """Terminate editing and start object updating process."""
         self.finalizeGhost()
         self.trackers[obj.Name][nodeIndex].on()
         Gui.Snapper.setSelectMode(True)
@@ -529,7 +527,7 @@ class Edit:
     # -------------------------------------------------------------------------
 
     def getObjsFromSelection(self):
-        "evaluate selection and returns a valid object to edit"
+        """Evaluate selection and return a valid object to edit."""
         selection = Gui.Selection.getSelection()
         self.edited_objects = []
         if len(selection) > self.maxObjects:
@@ -552,8 +550,9 @@ class Edit:
         return self.edited_objects
 
     def get_selected_obj_at_position(self, pos):
-        """return object at given position
-        if object is one of the edited objects (self.edited_objects)
+        """Return object at given position.
+
+        If object is one of the edited objects (self.edited_objects).
         """
         selobjs = Gui.ActiveDocument.ActiveView.getObjectsInfo((pos[0],pos[1]))
         if not selobjs:
@@ -566,19 +565,22 @@ class Edit:
                     return obj
 
     def numericInput(self, v, numy=None, numz=None):
-        """this function gets called by the toolbar
-        or by the mouse click and activate the update function"""
-        if (numy is not None):
-            v = App.Vector(v,numy,numz)
+        """Execute callback by the toolbar to activate the update function.
+
+        This function gets called by the toolbar
+        or by the mouse click and activate the update function.
+        """
+        if numy:
+            v = App.Vector(v, numy, numz)
         self.endEditing(self.obj, self.editing, v)
         App.ActiveDocument.recompute()
 
-    def setSelectState(self, obj, selState = False):
-        if hasattr(obj.ViewObject,"Selectable"):
+    def setSelectState(self, obj, selState=False):
+        if hasattr(obj.ViewObject, "Selectable"):
             obj.ViewObject.Selectable = selState
 
     def saveSelectState(self, obj):
-        if hasattr(obj.ViewObject,"Selectable"):
+        if hasattr(obj.ViewObject, "Selectable"):
             self.selectstate = obj.ViewObject.Selectable
 
     def restoreSelectState(self,obj):
@@ -586,8 +588,12 @@ class Edit:
             if hasattr(obj.ViewObject,"Selectable") and (self.selectstate is not None):
                 obj.ViewObject.Selectable = self.selectstate
 
-    def setPlacement(self,obj):
-        "set self.pl and self.invpl to self.obj placement and inverse placement"
+    def setPlacement(self, obj):
+        """Set placement of object.
+
+        Set self.pl and self.invpl to self.obj placement
+        and inverse placement.
+        """
         if not obj:
             return
         if "Placement" in obj.PropertiesList:
@@ -595,7 +601,7 @@ class Edit:
             self.invpl = self.pl.inverse()
 
     def alignWorkingPlane(self):
-        "align working plane to self.obj"
+        """Align working plane to self.obj."""
         if "Shape" in self.obj.PropertiesList:
             if DraftTools.plane.weak:
                 DraftTools.plane.alignToFace(self.obj.Shape)
@@ -603,12 +609,12 @@ class Edit:
             self.planetrack.set(self.editpoints[0])
 
     def getEditNode(self, pos):
-        "get edit node from given screen position"
+        """Get edit node from given screen position."""
         node = self.sendRay(pos)
         return node
     
     def sendRay(self, mouse_pos):
-        "sends a ray through the scene and return the nearest entity"
+        """Send a ray through the scene and return the nearest entity."""
         ray_pick = coin.SoRayPickAction(self.render_manager.getViewportRegion())
         ray_pick.setPoint(coin.SbVec2s(*mouse_pos))
         ray_pick.setRadius(self.pick_radius)
@@ -618,7 +624,7 @@ class Edit:
         return self.searchEditNode(picked_point)
 
     def searchEditNode(self, picked_point):
-        "search edit node inside picked point list and retrurn node number"
+        """Search edit node inside picked point list and return node number."""
         for point in picked_point:
             path = point.getPath()
             length = path.getLength()
@@ -629,7 +635,7 @@ class Edit:
         return None
 
     def getEditNodeIndex(self, point):
-        "get edit node index from given screen position"
+        """Get edit node index from given screen position."""
         if point:
             subElement = str(point.subElementName.getValue())
             ep = int(subElement[8:])
@@ -637,19 +643,18 @@ class Edit:
         else:
             return None
 
-
     # -------------------------------------------------------------------------
     # EDIT TRACKERS functions
     # -------------------------------------------------------------------------
 
     def setTrackers(self, obj, points=None):
-        "set Edit Trackers for editpoints collected from self.obj"
+        """Set Edit Trackers for editpoints collected from self.obj."""
         if points is None or len(points) == 0:
             App.Console.PrintWarning(translate("draft", 
-                                                   "No edit point found for selected object")
-                                                   + "\n")
+                                               "No edit point found for selected object")
+                                               + "\n")
             # do not finish if some trackers are still present
-            if self.trackers == {'object':[]}:
+            if self.trackers == {'object': []}:
                 self.finish()
             return
         self.trackers[obj.Name] = []
@@ -662,12 +667,12 @@ class Edit:
                 self.trackers[obj.Name].append(trackers.editTracker(pos=points[ep],name=obj.Name,idx=ep))
 
     def resetTrackers(self, obj):
-        "reset Edit Trackers and set them again"
+        """Reset Edit Trackers and set them again."""
         self.removeTrackers(obj)
         self.setTrackers(obj, self.getEditPoints(obj))
 
-    def removeTrackers(self, obj = None):
-        "reset Edit Trackers and set them again"
+    def removeTrackers(self, obj=None):
+        """Remove Edit Trackers."""
         if obj:
             if obj.Name in self.trackers:
                 for t in self.trackers[obj.Name]:
@@ -677,16 +682,16 @@ class Edit:
             for key in self.trackers.keys():
                 for t in self.trackers[key]:
                     t.finalize()
-            self.trackers = {'object':[]}
+            self.trackers = {'object': []}
 
 
     def hideTrackers(self, obj=None):
-        """hide Edit Trackers
+        """Hide Edit Trackers.
 
         Attributes
         ----------
-        obj : FreeCAD object
-            hides trackers only for given object, 
+        obj: FreeCAD object
+            Hides trackers only for given object,
             if obj is None, hides all trackers
         """
         if obj is None:
@@ -698,12 +703,12 @@ class Edit:
                 t.off()
 
     def showTrackers(self, obj=None):
-        """show Edit Trackers
+        """Show Edit Trackers.
 
         Attributes
         ----------
-        obj : FreeCAD object
-            shows trackers only for given object, 
+        obj: FreeCAD object
+            Shows trackers only for given object,
             if obj is None, shows all trackers
         """
         if obj is None:
@@ -718,8 +723,8 @@ class Edit:
     # PREVIEW
     # -------------------------------------------------------------------------
 
-    def initGhost(self,obj):
-        "initialize preview ghost"
+    def initGhost(self, obj):
+        """Initialize preview ghost."""
         if Draft.getType(obj) == "Wire":
             return trackers.wireTracker(obj.Shape)
         elif Draft.getType(obj) == "BSpline":
@@ -729,7 +734,7 @@ class Edit:
         elif Draft.getType(obj) == "Circle":
             return trackers.arcTracker()
 
-    def updateGhost(self,obj,idx,pt):
+    def updateGhost(self, obj, idx, pt):
         if Draft.getType(obj) in ["Wire"]:
             self.ghost.on()
             pointList = self.applyPlacement(obj.Points)
@@ -777,9 +782,9 @@ class Edit:
                         self.ghost.setCenter(self.pl.multVec(p0))
                         return
                     else:
-                        p1=self.getArcStart(obj,global_placement=True)
-                        p2=self.getArcMid(obj,global_placement=True)
-                        p3=self.getArcEnd(obj,global_placement=True)
+                        p1 = self.getArcStart(obj, global_placement=True)
+                        p2 = self.getArcMid(obj, global_placement=True)
+                        p3 = self.getArcEnd(obj, global_placement=True)
                         if self.editing == 1:
                             p1=pt
                         elif self.editing == 3:
@@ -801,7 +806,7 @@ class Edit:
                         self.ghost.setRadius(self.invpl.multVec(pt).Length)
         DraftTools.redraw3DView()
 
-    def applyPlacement(self,pointList):
+    def applyPlacement(self, pointList):
         if self.pl:
             plist = []
             for p in pointList:
@@ -822,10 +827,10 @@ class Edit:
     # EDIT OBJECT TOOLS : Add/Delete Vertexes
     # -------------------------------------------------------------------------
 
-    def addPoint(self,event):
-        "called by action, add point to obj and reset trackers"
+    def addPoint(self, event):
+        """Execute callback, add point to obj and reset trackers."""
         pos = event.getPosition()
-        #self.setSelectState(self.obj, True)
+        # self.setSelectState(self.obj, True)
         selobjs = Gui.ActiveDocument.ActiveView.getObjectsInfo((pos[0],pos[1]))
         if not selobjs:
             return
@@ -842,27 +847,26 @@ class Edit:
                 pt = App.Vector(info["x"], info["y"], info["z"])
                 self.addPointToWire(self.obj, pt, int(info["Component"][4:]))
             elif Draft.getType(self.obj) in ["BSpline", "BezCurve"]: #to fix double vertex created
-                #pt = self.point
+                # pt = self.point
                 if "x" in info:# prefer "real" 3D location over working-plane-driven one if possible
                     pt = App.Vector(info["x"], info["y"], info["z"])
                 else:
                     continue
-                self.addPointToCurve(pt,info)
+                self.addPointToCurve(pt, info)
         self.obj.recompute()
         self.removeTrackers(self.obj)
         self.setEditPoints(self.obj)
         # self.setSelectState(self.obj, False)
         return
 
-
     def addPointToWire(self, obj, newPoint, edgeIndex):
         newPoints = []
         hasAddedPoint = False
         if hasattr(obj, "ChamferSize") and hasattr(obj, "FilletRadius"):
             if obj.ChamferSize > 0 and obj.FilletRadius > 0:
-                edgeIndex = (edgeIndex +3) / 4
+                edgeIndex = (edgeIndex + 3) / 4
             elif obj.ChamferSize > 0 or obj.FilletRadius > 0:
-                edgeIndex = (edgeIndex +1) / 2
+                edgeIndex = (edgeIndex + 1) / 2
 
         for index, point in enumerate(self.obj.Points):
             if index == edgeIndex:
@@ -874,24 +878,24 @@ class Edit:
             newPoints.append(self.invpl.multVec(newPoint))
         obj.Points = newPoints
 
-    def addPointToCurve(self,point,info=None):
+    def addPointToCurve(self, point, info=None):
         import Part
-        if not (Draft.getType(self.obj) in ["BSpline","BezCurve"]):
+        if not (Draft.getType(self.obj) in ["BSpline", "BezCurve"]):
             return
         pts = self.obj.Points
         if Draft.getType(self.obj) == "BezCurve":
             if not info['Component'].startswith('Edge'):
-                return # clicked control point
-            edgeindex = int(info['Component'].lstrip('Edge')) -1
+                return  # clicked control point
+            edgeindex = int(info['Component'].lstrip('Edge')) - 1
             wire = self.obj.Shape.Wires[0]
             bz = wire.Edges[edgeindex].Curve
             param = bz.parameter(point)
             seg1 = wire.Edges[edgeindex].copy().Curve
             seg2 = wire.Edges[edgeindex].copy().Curve
-            seg1.segment(seg1.FirstParameter,param)
-            seg2.segment(param,seg2.LastParameter)
+            seg1.segment(seg1.FirstParameter, param)
+            seg2.segment(param, seg2.LastParameter)
             if edgeindex == len(wire.Edges):
-                #we hit the last segment, we need to fix the degree
+                # we hit the last segment, we need to fix the degree
                 degree=wire.Edges[0].Curve.Degree
                 seg1.increase(degree)
                 seg2.increase(degree)
@@ -917,44 +921,44 @@ class Edit:
             uPoints = []
             for p in self.obj.Points:
                 uPoints.append(curve.parameter(p))
-            for i in range(len(uPoints) -1):
+            for i in range(len(uPoints) - 1):
                 if ( uNewPoint > uPoints[i] ) and ( uNewPoint < uPoints[i+1] ):
                     pts.insert(i + 1, self.invpl.multVec(point))
                     break
             # DNC: fix: add points to last segment if curve is closed
-            if ( self.obj.Closed ) and ( uNewPoint > uPoints[-1] ) :
+            if self.obj.Closed and (uNewPoint > uPoints[-1]):
                 pts.append(self.invpl.multVec(point))
         self.obj.Points = pts
 
-    def delPoint(self,event):
+    def delPoint(self, event):
         pos = event.getPosition()
         node = self.getEditNode(pos)
         ep = self.getEditNodeIndex(node)
 
         if ep is None:
             return App.Console.PrintWarning(translate("draft",
-                                                          "Node not found")
-                                                          + "\n")
+                                                      "Node not found")
+                                                      + "\n")
 
         doc = App.getDocument(str(node.documentName.getValue()))
         self.obj = doc.getObject(str(node.objectName.getValue()))
         if self.obj is None:
             return
-        if not (Draft.getType(self.obj) in ["Wire","BSpline","BezCurve"]):
+        if not (Draft.getType(self.obj) in ["Wire", "BSpline", "BezCurve"]):
             return
         if len(self.obj.Points) <= 2:
             App.Console.PrintWarning(translate("draft", 
-                                                   "Active object must have more than two points/nodes") 
-                                                   + "\n")
+                                               "Active object must have more than two points/nodes") 
+                                               + "\n")
             return
 
         pts = self.obj.Points
         pts.pop(ep)
         self.obj.Points = pts
-        if Draft.getType(self.obj) =="BezCurve":
+        if Draft.getType(self.obj) == "BezCurve":
             self.obj.Proxy.resetcontinuity(self.obj)
         self.obj.recompute()
-        
+
         # don't do tan/sym on DWire/BSpline!
         self.removeTrackers(self.obj)
         self.setEditPoints(self.obj)
@@ -963,22 +967,22 @@ class Edit:
     # EDIT OBJECT TOOLS : GENERAL
     # -------------------------------------------------------------------------
 
-    def setEditPoints(self,obj):
-        "append given object's editpoints to self.edipoints and set EditTrackers"
-        
+    def setEditPoints(self, obj):
+        """append given object's editpoints to self.edipoints and set EditTrackers"""
         self.setPlacement(obj)
         self.editpoints = self.getEditPoints(obj)
-        if self.editpoints: # set trackers and align plane
+        if self.editpoints:  # set trackers and align plane
             self.setTrackers(obj, self.editpoints)
             self.editpoints = []
 
     def getEditPoints(self, obj):
-        """
-        (object) return a list of App.Vectors relative to object edit nodes
+        """Return a list of App.Vectors relative to object edit nodes.
+
+        (object)
         """
         objectType = Draft.getType(obj)
 
-        if objectType in ["Wire","BSpline"]:
+        if objectType in ["Wire", "BSpline"]:
             self.ui.editUi("Wire")
             return self.getWirePts(obj)
         elif objectType == "BezCurve":
@@ -1015,13 +1019,13 @@ class Edit:
         else:
             return None
 
-    def update(self,obj, nodeIndex, v):
-        "apply the App.Vector to the modified point and update self.obj"
+    def update(self, obj, nodeIndex, v):
+        """Apply the App.Vector to the modified point and update self.obj."""
 
         objectType = Draft.getType(obj)
         App.ActiveDocument.openTransaction("Edit")
 
-        if objectType in ["Wire","BSpline"]:
+        if objectType in ["Wire", "BSpline"]:
             self.updateWire(obj, nodeIndex, v)
         elif objectType == "BezCurve":
             self.updateWire(obj, nodeIndex, v)
@@ -1051,7 +1055,6 @@ class Edit:
             self.updatePartLine(obj, nodeIndex, v)
         elif objectType == "Part" and self.obj.TypeId == "Part::Box":
             self.updatePartBox(obj, nodeIndex, v)
-        
         obj.recompute()
 
         App.ActiveDocument.commitTransaction()
@@ -1065,7 +1068,7 @@ class Edit:
     # EDIT OBJECT TOOLS : Line/Wire/Bspline/Bezcurve
     # -------------------------------------------------------------------------
 
-    def getWirePts(self,obj):
+    def getWirePts(self, obj):
         editpoints = []
         for p in obj.Points:
             p = obj.getGlobalPlacement().multVec(p)
@@ -1108,8 +1111,8 @@ class Edit:
         obj.Points = pts
         self.trackers[obj.Name][nodeIndex].set(v)
 
-
-    def recomputePointsBezier(self,obj,pts,idx,v,degree,moveTrackers=True):
+    def recomputePointsBezier(self, obj, pts, idx, v,
+                              degree, moveTrackers=True):
         """
         (object, Points as list, nodeIndex as Int, App.Vector of new point, moveTrackers as Bool)
         return the new point list, applying the App.Vector to the given index point
@@ -1143,18 +1146,18 @@ class Edit:
 
         elif ispole == 1 and (idx >=2 or obj.Closed): #right pole
             knot = idx -1
-            changep = idx -2 # -1 in case of closed curve
+            changep = idx - 2  # -1 in case of closed curve
 
-        elif ispole == degree-1 and idx <= len(pts)-3: #left pole
-            knot = idx +1
-            changep = idx +2
+        elif ispole == degree-1 and idx <= len(pts)-3:  # left pole
+            knot = idx + 1
+            changep = idx + 2
 
         elif ispole == degree-1 and obj.Closed and idx == len(pts)-1: #last pole
             knot = 0
             changep = 1
 
-        if knot is not None: # we need to modify the opposite pole
-            segment = int(knot / degree) -1
+        if knot is not None:  # we need to modify the opposite pole
+            segment = int(knot / degree) - 1
             cont = obj.Continuity[segment] if len(obj.Continuity) > segment else 0
             if cont == 1: #tangent
                 pts[changep] = obj.Proxy.modifytangentpole(pts[knot],
@@ -1165,12 +1168,12 @@ class Edit:
                 pts[changep] = obj.Proxy.modifysymmetricpole(pts[knot],editPnt)
                 if moveTrackers:
                     self.trackers[obj.Name][changep].set(pts[changep])
-        pts[idx]=v
+        pts[idx] = v
 
-        return pts #returns the list of new points, taking into account knot continuity
+        return pts  # returns the list of new points, taking into account knot continuity
 
     def resetTrackersBezier(self, obj):
-        #in future move tracker definition to DraftTrackers
+        # in future move tracker definition to DraftTrackers
         from pivy import coin
         knotmarkers = (coin.SoMarkerSet.DIAMOND_FILLED_9_9,#sharp
                 coin.SoMarkerSet.SQUARE_FILLED_9_9,        #tangent
@@ -1188,8 +1191,8 @@ class Edit:
                 knotmarkeri = cont[edgeindex] if len(cont) > edgeindex else 0
                 pointswithmarkers.append((poles[-1],knotmarkers[knotmarkeri]))
         for index, pwm in enumerate(pointswithmarkers):
-            p,marker = pwm
-            #if self.pl: p = self.pl.multVec(p)
+            p, marker = pwm
+            # if self.pl: p = self.pl.multVec(p)
             self.trackers[obj.Name].append(trackers.editTracker(p,obj.Name,
                 index,obj.ViewObject.LineColor,marker=marker))
 
@@ -1204,8 +1207,8 @@ class Edit:
         deg = obj.Degree
         if deg < 2:
             return
-        if point % deg != 0: #point is a pole
-            if deg >=3: #allow to select poles
+        if point % deg != 0:  # point is a pole
+            if deg >=3:  # allow to select poles
                 if (point % deg == 1) and (point > 2 or obj.Closed): #right pole
                     knot = point -1
                     keepp = point
@@ -1221,9 +1224,9 @@ class Edit:
                     keepp = point
                     changep = 1
                 else:
-                    App.Console.PrintWarning(translate("draft", 
-                                                           "Can't change Knot belonging to pole %d"%point)
-                                                           + "\n")
+                    App.Console.PrintWarning(translate("draft",
+                                                       "Can't change Knot belonging to pole %d"%point)
+                                                       + "\n")
                     return
                 if knot:
                     if style == 'Tangent':
@@ -1235,9 +1238,9 @@ class Edit:
                     else: #sharp
                         pass #
             else:
-                App.Console.PrintWarning(translate("draft", 
-                                                       "Selection is not a Knot")
-                                                       + "\n")
+                App.Console.PrintWarning(translate("draft",
+                                                   "Selection is not a Knot")
+                                                   + "\n")
                 return
         else: #point is a knot
             if style == 'Sharp':
@@ -1249,12 +1252,12 @@ class Edit:
                 prev, next = obj.Proxy.tangentpoles(pts[point], pts[point-1], pts[point+1])
                 pts[point-1] = prev
                 pts[point+1] = next
-                knot = point #index for continuity
+                knot = point  # index for continuity
             elif style == 'Symmetric' and point > 0 and point < len(pts)-1:
                 prev, next = obj.Proxy.symmetricpoles(pts[point], pts[point-1], pts[point+1])
                 pts[point-1] = prev
                 pts[point+1] = next
-                knot = point #index for continuity
+                knot = point  # index for continuity
             elif obj.Closed and (style == 'Symmetric' or style == 'Tangent'):
                 if style == 'Tangent':
                     pts[1], pts[-1] = obj.Proxy.tangentpoles(pts[0], pts[1], pts[-1])
@@ -1266,8 +1269,8 @@ class Edit:
                                                        "Endpoint of BezCurve can't be smoothed")
                                                        + "\n")
                 return
-        segment = knot // deg #segment index
-        newcont = obj.Continuity[:] #don't edit a property inplace !!!
+        segment = knot // deg  # segment index
+        newcont = obj.Continuity[:]  # don't edit a property inplace !!!
         if not obj.Closed and (len(obj.Continuity) == segment -1 or
             segment == 0) :
             pass # open curve
@@ -1276,7 +1279,7 @@ class Edit:
             newcont[segment-1] = style2cont.get(style)
         else: #should not happen
             App.Console.PrintWarning('Continuity indexing error:'
-                                         + 'point:%d deg:%d len(cont):%d' % (knot,deg,
+                                     + 'point:%d deg:%d len(cont):%d' % (knot,deg,
                                          len(obj.Continuity)))
         obj.Points = pts
         obj.Continuity = newcont
@@ -1287,8 +1290,8 @@ class Edit:
     # -------------------------------------------------------------------------
 
     def getRectanglePts(self, obj):
-        """
-        returns the list of edipoints for the given Draft Rectangle
+        """Return the list of edipoints for the given Draft Rectangle.
+
         0 : Placement.Base
         1 : Length
         2 : Height
@@ -1308,8 +1311,8 @@ class Edit:
         import DraftVecUtils
         delta = obj.getGlobalPlacement().inverse().multVec(v)
         if nodeIndex == 0:
-            #p = obj.getGlobalPlacement()
-            #p.move(delta)
+            # p = obj.getGlobalPlacement()
+            # p.move(delta)
             obj.Placement.move(delta)
         elif self.editing == 1:
             obj.Length = DraftVecUtils.project(delta,App.Vector(1,0,0)).Length
@@ -1332,17 +1335,18 @@ class Edit:
     # -------------------------------------------------------------------------
 
     def getCirclePts(self, obj):
-        """
-        returns the list of edipoints for the given Draft Arc or Circle
+        """Return the list of edipoints for the given Draft Arc or Circle.
+
         circle:
         0 : Placement.Base or center
         1 : radius
+
         arc:
         0 : Placement.Base or center
         1 : first endpoint
         2 : second endpoint
         3 : midpoint
-        """        
+        """
         editpoints = []
         editpoints.append(obj.getGlobalPlacement().Base)
         if obj.FirstAngle == obj.LastAngle:
@@ -1382,7 +1386,7 @@ class Edit:
                 # edit arc by 3 points
                 import Part
                 if nodeIndex == 0:
-                    #center point
+                    # center point
                     import DraftVecUtils
                     p1 = self.getArcStart(obj)
                     p2 = self.getArcEnd(obj)
@@ -1436,7 +1440,7 @@ class Edit:
     def getArcStart(self, obj, global_placement=False):#Returns object midpoint
         if Draft.getType(obj) == "Circle":
             return self.pointOnCircle(obj, obj.FirstAngle, global_placement)
-    
+
     def getArcEnd(self, obj, global_placement=False):#Returns object midpoint
         if Draft.getType(obj) == "Circle":
             return self.pointOnCircle(obj, obj.LastAngle, global_placement)
@@ -1502,7 +1506,7 @@ class Edit:
         editpoints.append(obj.Start)
         editpoints.append(obj.End)
         editpoints.append(obj.Dimline)
-        editpoints.append(App.Vector(p[0],p[1],p[2]))
+        editpoints.append(App.Vector(p[0], p[1], p[2]))
         return editpoints
 
     def updateDimension(self, obj, nodeIndex, v):
@@ -1522,8 +1526,9 @@ class Edit:
     # SKETCH: just if it's composed by a single segment-----------------------
 
     def getSketchPts(self, obj):
-        """
-        returns the list of edipoints for the given single line sketch (WallTrace)
+        """Return the list of edipoints for the given single line sketch.
+
+        (WallTrace)
         0 : startpoint
         1 : endpoint
         """
@@ -1534,13 +1539,14 @@ class Edit:
             return editpoints
         else:
             App.Console.PrintWarning(translate("draft",
-                                                   "Sketch is too complex to edit: "
-                                                   "it is suggested to use sketcher default editor")
+                                               "Sketch is too complex to edit: "
+                                               "it is suggested to use sketcher default editor")
                                      + "\n")
             return None
 
     def updateSketch(self, obj, nodeIndex, v):
-        """
+        """Move a single line sketch vertex a certain displacement.
+
         (single segment sketch object, node index as Int, App.Vector)
         move a single line sketch (WallTrace) vertex according to a given App.Vector
         0 : startpoint
@@ -1552,17 +1558,16 @@ class Edit:
             obj.movePoint(0,2,obj.getGlobalPlacement().inverse().multVec(v))
         obj.recompute()
 
-
     # WALL---------------------------------------------------------------------
 
     def getWallPts(self, obj):
-        """
-        returns the list of edipoints for the given Arch Wall object
+        """Return the list of edipoints for the given Arch Wall object.
+
         0 : height of the wall
         1-to end : base object editpoints, in place with the wall
         """
         editpoints = []
-        #height of the wall
+        # height of the wall
         editpoints.append(obj.getGlobalPlacement().multVec(App.Vector(0,0,obj.Height)))
         # try to add here an editpoint based on wall height (maybe should be good to associate it with a circular tracker)
         if obj.Base:
@@ -1575,28 +1580,24 @@ class Edit:
                     editpoints.append(obj.Placement.multVec(point)) #works ok except if App::Part is rotated... why?
         return editpoints
 
-
     def updateWallTrackers(self, obj):
-        """
-        update self.trackers[obj.Name][0] to match with given object
-        """
+        """Update self.trackers[obj.Name][0] to match with given object."""
         pass
 
     def updateWall(self, obj, nodeIndex, v):
         import DraftVecUtils
         if nodeIndex == 0:
             delta= obj.getGlobalPlacement().inverse().multVec(v)
-            vz=DraftVecUtils.project(delta,App.Vector(0,0,1))
+            vz=DraftVecUtils.project(delta,App.Vector(0, 0, 1))
             if vz.Length > 0:
                 obj.Height = vz.Length
         elif nodeIndex > 0:
             if obj.Base:
-                if Draft.getType(obj.Base) in ["Wire","Circle","Rectangle",
-                                                "Polygon", "Sketch"]:
+                if Draft.getType(obj.Base) in ["Wire", "Circle", "Rectangle",
+                                               "Polygon", "Sketch"]:
                     self.update(obj.Base, nodeIndex - 1, 
                         obj.Placement.inverse().multVec(v))
         obj.recompute()
-
 
     # WINDOW-------------------------------------------------------------------
 
@@ -1615,9 +1616,9 @@ class Edit:
         return editpoints
 
     def updateWindow(self, obj, nodeIndex, v):
-        pos=self.obj.Base.Placement.Base
+        pos = self.obj.Base.Placement.Base
         if self.editing == 0:
-            self.obj.Base.Placement.Base=v
+            self.obj.Base.Placement.Base = v
             self.obj.Base.recompute()
         if self.editing == 1:
             self.obj.Width = pos.sub(v).Length
@@ -1639,7 +1640,7 @@ class Edit:
             self.originalNodes = obj.ViewObject.ShowNodes
             self.obj.ViewObject.DisplayMode = "Wireframe"
             self.obj.ViewObject.NodeSize = 1
-            #   self.obj.ViewObject.ShowNodes = True
+            # self.obj.ViewObject.ShowNodes = True
             for p in obj.Nodes:
                 if self.pl:
                     p = self.pl.multVec(p)
@@ -1719,9 +1720,9 @@ class Edit:
     def getPartBoxPts(self, obj):
         editpoints = []
         editpoints.append(obj.Placement.Base)
-        editpoints.append(self.pl.multVec(App.Vector(obj.Length,0,0)))
-        editpoints.append(self.pl.multVec(App.Vector(0,obj.Width,0)))
-        editpoints.append(self.pl.multVec(App.Vector(0,0,obj.Height)))
+        editpoints.append(self.pl.multVec(App.Vector(obj.Length, 0, 0)))
+        editpoints.append(self.pl.multVec(App.Vector(0, obj.Width, 0)))
+        editpoints.append(self.pl.multVec(App.Vector(0, 0, obj.Height)))
         return editpoints
 
     def updatePartBox(self, obj, nodeIndex, v):
@@ -1731,14 +1732,14 @@ class Edit:
             self.obj.Placement.Base = v
             self.setPlacement(self.obj)
         elif self.editing == 1:
-            xApp.Vector = DraftVecUtils.project(delta,App.Vector(1,0,0))
-            self.obj.Length = xApp.Vector.Length            
+            xApp.Vector = DraftVecUtils.project(delta, App.Vector(1, 0, 0))
+            self.obj.Length = xApp.Vector.Length
         elif self.editing == 2:
-            xApp.Vector = DraftVecUtils.project(delta,App.Vector(0,1,0))
-            self.obj.Width = xApp.Vector.Length            
+            xApp.Vector = DraftVecUtils.project(delta, App.Vector(0, 1, 0))
+            self.obj.Width = xApp.Vector.Length
         elif self.editing == 3:
-            xApp.Vector = DraftVecUtils.project(delta,App.Vector(0,0,1))
-            self.obj.Height = xApp.Vector.Length            
+            xApp.Vector = DraftVecUtils.project(delta, App.Vector(0, 0, 1))
+            self.obj.Height = xApp.Vector.Length
         self.trackers[self.obj.Name][0].set(self.obj.Placement.Base)
         self.trackers[self.obj.Name][1].set(self.pl.multVec(App.Vector(self.obj.Length,0,0)))
         self.trackers[self.obj.Name][2].set(self.pl.multVec(App.Vector(0,self.obj.Width,0)))
@@ -1761,23 +1762,24 @@ class Edit:
                 actions = ["delete point"]
             elif Draft.getType(obj) in ["Circle"]:
                 if obj.FirstAngle != obj.LastAngle:
-                    if ep == 0: # user is over arc start point
+                    if ep == 0:  # user is over arc start point
                         actions = ["move arc"]
-                    elif ep == 1: # user is over arc start point
+                    elif ep == 1:  # user is over arc start point
                         actions = ["set first angle"]
-                    elif ep == 2: # user is over arc end point
+                    elif ep == 2:  # user is over arc end point
                         actions = ["set last angle"]
-                    elif ep == 3: # user is over arc mid point
+                    elif ep == 3:  # user is over arc mid point
                         actions = ["set radius"]
             elif Draft.getType(obj) in ["BezCurve"]:
-                actions = ["make sharp", "make tangent", "make symmetric", "delete point"]
+                actions = ["make sharp", "make tangent",
+                           "make symmetric", "delete point"]
             else:
                 return
         else:
             # if user is over an edited object
             pos = self.event.getPosition()
             obj = self.get_selected_obj_at_position(pos)
-            if Draft.getType(obj) in ["Line", "Wire","BSpline", "BezCurve"]:
+            if Draft.getType(obj) in ["Line", "Wire", "BSpline", "BezCurve"]:
                 actions = ["add point"]
             elif Draft.getType(obj) in ["Circle"] and obj.FirstAngle != obj.LastAngle:
                 actions = ["invert arc"]
@@ -1788,7 +1790,7 @@ class Edit:
         self.tracker_menu.popup(Gui.getMainWindow().cursor().pos())
         QtCore.QObject.connect(self.tracker_menu,QtCore.SIGNAL("triggered(QAction *)"),self.evaluate_menu_action)
 
-    def evaluate_menu_action(self,labelname):
+    def evaluate_menu_action(self, labelname):
         action_label = str(labelname.text())
         # Bezier curve menu
         if action_label in ["make sharp", "make tangent", "make symmetric"]:
@@ -1807,7 +1809,8 @@ class Edit:
         elif action_label == "add point":
             self.addPoint(self.event)
         # arc tools
-        elif action_label in ["move arc","set radius", "set first angle", "set last angle"]:
+        elif action_label in ("move arc", "set radius",
+                              "set first angle", "set last angle"):
             self.alt_edit_mode = 1
             self.startEditing(self.event)
         elif action_label == "invert arc":

--- a/src/Mod/Draft/draftguitools/gui_orthoarray.py
+++ b/src/Mod/Draft/draftguitools/gui_orthoarray.py
@@ -1,8 +1,3 @@
-"""Provide the Draft OrthoArray tool."""
-## @package gui_orthoarray
-# \ingroup DRAFT
-# \brief Provide the Draft OrthoArray tool.
-
 # ***************************************************************************
 # *   (c) 2020 Eliud Cabrera Castillo <e.cabrera-castillo@tum.de>           *
 # *                                                                         *
@@ -25,36 +20,23 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
+"""Provides the Draft OrthoArray GuiCommand."""
+## @package gui_orthoarray
+# \ingroup DRAFT
+# \brief Provides the Draft OrthoArray GuiCommand.
+
+from pivy import coin
+from PySide.QtCore import QT_TRANSLATE_NOOP
 
 import FreeCAD as App
 import FreeCADGui as Gui
 import Draft
-import DraftGui
 import Draft_rc
-from . import gui_base
+from draftguitools import gui_base
 from drafttaskpanels import task_orthoarray
+import draftutils.todo as todo
 
-
-if App.GuiUp:
-    from PySide.QtCore import QT_TRANSLATE_NOOP
-    # import DraftTools
-    from draftutils.translate import translate
-    # from DraftGui import displayExternal
-    from pivy import coin
-else:
-    def QT_TRANSLATE_NOOP(context, text):
-        return text
-
-    def translate(context, text):
-        return text
-
-
-def _tr(text):
-    """Translate the text with the context set."""
-    return translate("Draft", text)
-
-
-# So the resource file doesn't trigger errors from code checkers (flake8)
+# The module is used to prevent complaints from code checkers (flake8)
 True if Draft_rc.__name__ else False
 
 
@@ -85,7 +67,7 @@ class GuiCommandOrthoArray(gui_base.GuiCommandBase):
         return d
 
     def Activated(self):
-        """Execute this when the command is called.
+        """Execute when the command is called.
 
         We add callbacks that connect the 3D view with
         the widgets of the task panel.
@@ -103,10 +85,10 @@ class GuiCommandOrthoArray(gui_base.GuiCommandBase):
         # of the interface, to be able to call a function from within it.
         self.ui.source_command = self
         # Gui.Control.showDialog(self.ui)
-        DraftGui.todo.delay(Gui.Control.showDialog, self.ui)
+        todo.ToDo.delay(Gui.Control.showDialog, self.ui)
 
     def click(self, event_cb=None):
-        """Run callback for when the mouse pointer clicks on the 3D view.
+        """Execute as a callback when the pointer clicks on the 3D view.
 
         It should act as if the Enter key was pressed, or the OK button
         was pressed in the task panel.
@@ -123,7 +105,7 @@ class GuiCommandOrthoArray(gui_base.GuiCommandBase):
             self.ui.accept()
 
     def completed(self):
-        """Run when the command is terminated.
+        """Execute when the command is terminated.
 
         We should remove the callbacks that were added to the 3D view
         and then close the task panel.
@@ -133,10 +115,8 @@ class GuiCommandOrthoArray(gui_base.GuiCommandBase):
         self.view.removeEventCallbackPivy(self.mouse_event,
                                           self.callback_click)
         if Gui.Control.activeDialog():
-            Gui.Snapper.off()
             Gui.Control.closeDialog()
             super().finish()
 
 
-if App.GuiUp:
-    Gui.addCommand('Draft_OrthoArray', GuiCommandOrthoArray())
+Gui.addCommand('Draft_OrthoArray', GuiCommandOrthoArray())

--- a/src/Mod/Draft/draftguitools/gui_polararray.py
+++ b/src/Mod/Draft/draftguitools/gui_polararray.py
@@ -1,9 +1,3 @@
-"""This module provides the Draft PolarArray tool.
-"""
-## @package gui_polararray
-# \ingroup DRAFT
-# \brief This module provides the Draft PolarArray tool.
-
 # ***************************************************************************
 # *   (c) 2019 Eliud Cabrera Castillo <e.cabrera-castillo@tum.de>           *
 # *                                                                         *
@@ -26,41 +20,28 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
+"""Provides the Draft PolarArray tool."""
+## @package gui_polararray
+# \ingroup DRAFT
+# \brief This module provides the Draft PolarArray tool.
+
+from pivy import coin
+from PySide.QtCore import QT_TRANSLATE_NOOP
 
 import FreeCAD as App
 import FreeCADGui as Gui
 import Draft
-import DraftGui
 import Draft_rc
-from . import gui_base
+from draftguitools import gui_base
 from drafttaskpanels import task_polararray
+import draftutils.todo as todo
 
-
-if App.GuiUp:
-    from PySide.QtCore import QT_TRANSLATE_NOOP
-    # import DraftTools
-    from DraftGui import translate
-    # from DraftGui import displayExternal
-    from pivy import coin
-else:
-    def QT_TRANSLATE_NOOP(context, text):
-        return text
-
-    def translate(context, text):
-        return text
-
-
-def _tr(text):
-    """Function to translate with the context set"""
-    return translate("Draft", text)
-
-
-# So the resource file doesn't trigger errors from code checkers (flake8)
+# The module is used to prevent complaints from code checkers (flake8)
 True if Draft_rc.__name__ else False
 
 
 class GuiCommandPolarArray(gui_base.GuiCommandBase):
-    """Gui command for the PolarArray tool"""
+    """Gui command for the PolarArray tool."""
 
     def __init__(self):
         super().__init__()
@@ -74,6 +55,7 @@ class GuiCommandPolarArray(gui_base.GuiCommandBase):
         self.point = App.Vector()
 
     def GetResources(self):
+        """Set icon, menu and tooltip."""
         _msg = ("Creates copies of a selected object, "
                 "and places the copies in a polar pattern.\n"
                 "The properties of the array can be further modified after "
@@ -85,7 +67,7 @@ class GuiCommandPolarArray(gui_base.GuiCommandBase):
         return d
 
     def Activated(self):
-        """This is called when the command is executed.
+        """Execute when the command is called.
 
         We add callbacks that connect the 3D view with
         the widgets of the task panel.
@@ -103,10 +85,10 @@ class GuiCommandPolarArray(gui_base.GuiCommandBase):
         # of the interface, to be able to call a function from within it.
         self.ui.source_command = self
         # Gui.Control.showDialog(self.ui)
-        DraftGui.todo.delay(Gui.Control.showDialog, self.ui)
+        todo.ToDo.delay(Gui.Control.showDialog, self.ui)
 
     def move(self, event_cb):
-        """This is a callback for when the mouse pointer moves in the 3D view.
+        """Execute as a callback when the pointer moves in the 3D view.
 
         It should automatically update the coordinates in the widgets
         of the task panel.
@@ -119,7 +101,7 @@ class GuiCommandPolarArray(gui_base.GuiCommandBase):
             self.ui.display_point(self.point)
 
     def click(self, event_cb=None):
-        """This is a callback for when the mouse pointer clicks on the 3D view.
+        """Execute as a callback when the pointer clicks on the 3D view.
 
         It should act as if the Enter key was pressed, or the OK button
         was pressed in the task panel.
@@ -136,7 +118,7 @@ class GuiCommandPolarArray(gui_base.GuiCommandBase):
             self.ui.accept()
 
     def completed(self):
-        """This is called when the command is terminated.
+        """Execute when the command is terminated.
 
         We should remove the callbacks that were added to the 3D view
         and then close the task panel.
@@ -146,10 +128,8 @@ class GuiCommandPolarArray(gui_base.GuiCommandBase):
         self.view.removeEventCallbackPivy(self.mouse_event,
                                           self.callback_click)
         if Gui.Control.activeDialog():
-            Gui.Snapper.off()
             Gui.Control.closeDialog()
             super().finish()
 
 
-if App.GuiUp:
-    Gui.addCommand('Draft_PolarArray', GuiCommandPolarArray())
+Gui.addCommand('Draft_PolarArray', GuiCommandPolarArray())

--- a/src/Mod/Draft/draftguitools/gui_selectplane.py
+++ b/src/Mod/Draft/draftguitools/gui_selectplane.py
@@ -1,4 +1,3 @@
-# -*- coding: utf8 -*-
 # ***************************************************************************
 # *   Copyright (c) 2019 Yorik van Havre <yorik@uncreated.net>              *
 # *                                                                         *
@@ -19,23 +18,32 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
+"""Provides the Draft SelectPlane tool."""
+## @package gui_selectplane
+# \ingroup DRAFT
+# \brief This module provides the Draft SelectPlane tool.
 
-__title__ = "FreeCAD Draft Workbench GUI Tools - Working plane-related tools"
-__author__ = "Yorik van Havre, Werner Mayer, Martin Burbaum, Ken Cline, Dmitry Chigrin"
-__url__ = "https://www.freecadweb.org"
-
+import math
+from pivy import coin
+from PySide import QtGui
+from PySide.QtCore import QT_TRANSLATE_NOOP
 
 import FreeCAD
 import FreeCADGui
-import math
 import Draft
+import Draft_rc
 import DraftVecUtils
 from draftutils.todo import todo
+from draftutils.messages import _msg
 from draftutils.translate import translate
 
+# The module is used to prevent complaints from code checkers (flake8)
+True if Draft_rc.__name__ else False
 
-def QT_TRANSLATE_NOOP(ctx,txt): return txt
-
+__title__ = "FreeCAD Draft Workbench GUI Tools - Working plane-related tools"
+__author__ = ("Yorik van Havre, Werner Mayer, Martin Burbaum, Ken Cline, "
+              "Dmitry Chigrin")
+__url__ = "https://www.freecadweb.org"
 
 
 class Draft_SelectPlane:
@@ -48,10 +56,15 @@ class Draft_SelectPlane:
 
     def GetResources(self):
         """Set icon, menu and tooltip."""
-        return {'Pixmap'  : 'Draft_SelectPlane',
-                'Accel' : "W, P",
-                'MenuText': QT_TRANSLATE_NOOP("Draft_SelectPlane", "SelectPlane"),
-                'ToolTip' : QT_TRANSLATE_NOOP("Draft_SelectPlane", "Select a working plane for geometry creation")}
+        _msg = ("Select the face of solid body to create a working plane "
+                "on which to sketch Draft objects.\n"
+                "You may also select a three vertices or "
+                "a Working Plane Proxy.")
+        d = {'Pixmap': 'Draft_SelectPlane',
+             'Accel': "W, P",
+             'MenuText': QT_TRANSLATE_NOOP("Draft_SelectPlane", "SelectPlane"),
+             'ToolTip': QT_TRANSLATE_NOOP("Draft_SelectPlane", _msg)}
+        return d
 
     def IsActive(self):
         """Return True when this command should be available."""
@@ -61,34 +74,33 @@ class Draft_SelectPlane:
             return False
 
     def Activated(self):
-        """Execute this when the command is called."""
-        # reset variables
+        """Execute when the command is called."""
+        # Reset variables
         self.view = Draft.get3DView()
         self.wpButton = FreeCADGui.draftToolBar.wplabel
         FreeCAD.DraftWorkingPlane.setup()
 
-        # write current WP if states are empty
+        # Write current WP if states are empty
         if not self.states:
             p = FreeCAD.DraftWorkingPlane
             self.states.append([p.u, p.v, p.axis, p.position])
 
-        m = translate("draft", "Pick a face, 3 vertices or a WP Proxy to define the drawing plane")
-        FreeCAD.Console.PrintMessage(m+"\n")
+        m = translate("draft", "Pick a face, 3 vertices "
+                      "or a WP Proxy to define the drawing plane")
+        _msg(m)
 
-        from PySide import QtCore,QtGui
-
-        # create UI panel
+        # Create task panel
         FreeCADGui.Control.closeDialog()
         self.taskd = SelectPlane_TaskPanel()
 
-        # fill values
-        self.taskd.form.checkCenter.setChecked(self.param.GetBool("CenterPlaneOnView",False))
-        q = FreeCAD.Units.Quantity(self.param.GetFloat("gridSpacing",1.0),FreeCAD.Units.Length)
+        # Fill values
+        self.taskd.form.checkCenter.setChecked(self.param.GetBool("CenterPlaneOnView", False))
+        q = FreeCAD.Units.Quantity(self.param.GetFloat("gridSpacing", 1.0), FreeCAD.Units.Length)
         self.taskd.form.fieldGridSpacing.setText(q.UserString)
-        self.taskd.form.fieldGridMainLine.setValue(self.param.GetInt("gridEvery",10))
-        self.taskd.form.fieldSnapRadius.setValue(self.param.GetInt("snapRange",8))
+        self.taskd.form.fieldGridMainLine.setValue(self.param.GetInt("gridEvery", 10))
+        self.taskd.form.fieldSnapRadius.setValue(self.param.GetInt("snapRange", 8))
 
-        # set icons
+        # Set icons
         self.taskd.form.setWindowIcon(QtGui.QIcon(":/icons/Draft_SelectPlane.svg"))
         self.taskd.form.buttonTop.setIcon(QtGui.QIcon(":/icons/view-top.svg"))
         self.taskd.form.buttonFront.setIcon(QtGui.QIcon(":/icons/view-front.svg"))
@@ -99,7 +111,7 @@ class Draft_SelectPlane:
         self.taskd.form.buttonCenter.setIcon(QtGui.QIcon(":/icons/view-fullscreen.svg"))
         self.taskd.form.buttonPrevious.setIcon(QtGui.QIcon(":/icons/edit-undo.svg"))
 
-        # connect slots
+        # Connect slots
         self.taskd.form.buttonTop.clicked.connect(self.onClickTop)
         self.taskd.form.buttonFront.clicked.connect(self.onClickFront)
         self.taskd.form.buttonSide.clicked.connect(self.onClickSide)
@@ -112,57 +124,59 @@ class Draft_SelectPlane:
         self.taskd.form.fieldGridMainLine.valueChanged.connect(self.onSetMainline)
         self.taskd.form.fieldSnapRadius.valueChanged.connect(self.onSetSnapRadius)
 
-        # try to find a WP from the current selection
+        # Try to find a WP from the current selection
         if self.handle():
             return
 
-        # try other method
+        # Try another method
         if FreeCAD.DraftWorkingPlane.alignToSelection():
             FreeCADGui.Selection.clearSelection()
             self.display(FreeCAD.DraftWorkingPlane.axis)
             self.finish()
             return
-        
-        # rock 'n roll!
+
+        # Execute the actual task panel
         FreeCADGui.Control.showDialog(self.taskd)
         self.call = self.view.addEventCallback("SoEvent", self.action)
 
-    def finish(self,close=False):
+    def finish(self, close=False):
+        """Execute when the command is terminated."""
+        # Store values
+        self.param.SetBool("CenterPlaneOnView",
+                           self.taskd.form.checkCenter.isChecked())
 
-        # store values
-        self.param.SetBool("CenterPlaneOnView",self.taskd.form.checkCenter.isChecked())
-
-        # terminate coin callbacks
+        # Terminate coin callbacks
         if self.call:
             try:
-                self.view.removeEventCallback("SoEvent",self.call)
+                self.view.removeEventCallback("SoEvent", self.call)
             except RuntimeError:
-                # the view has been deleted already
+                # The view has been deleted already
                 pass
             self.call = None
 
-        # reset everything else
+        # Reset everything else
         FreeCADGui.Control.closeDialog()
         FreeCAD.DraftWorkingPlane.restore()
         FreeCADGui.ActiveDocument.resetEdit()
         return True
 
     def reject(self):
-
+        """Execute when clicking the Cancel button."""
         self.finish()
         return True
 
     def action(self, arg):
-
+        """Set the callbacks for the view."""
         if arg["Type"] == "SoKeyboardEvent" and arg["Key"] == "ESCAPE":
             self.finish()
         if arg["Type"] == "SoMouseButtonEvent":
             if (arg["State"] == "DOWN") and (arg["Button"] == "BUTTON1"):
-                # coin detection happens before the selection got a chance of being updated, so we must delay
-                todo.delay(self.checkSelection,None)
+                # Coin detection happens before the selection
+                # got a chance of being updated, so we must delay
+                todo.delay(self.checkSelection, None)
 
     def checkSelection(self):
-
+        """Check the selection, if there is a handle, finish the command."""
         if self.handle():
             self.finish()
 
@@ -175,18 +189,19 @@ class Draft_SelectPlane:
                 FreeCAD.DraftWorkingPlane.alignToEdges(sel.Object.Shape.Edges)
                 self.display(FreeCAD.DraftWorkingPlane.axis)
                 return True
-            elif Draft.getType(sel.Object) in ["WorkingPlaneProxy","BuildingPart"]:
-                FreeCAD.DraftWorkingPlane.setFromPlacement(sel.Object.Placement,rebase=True)
+            elif Draft.getType(sel.Object) in ("WorkingPlaneProxy",
+                                               "BuildingPart"):
+                FreeCAD.DraftWorkingPlane.setFromPlacement(sel.Object.Placement, rebase=True)
                 FreeCAD.DraftWorkingPlane.weak = False
-                if hasattr(sel.Object.ViewObject,"AutoWorkingPlane"):
+                if hasattr(sel.Object.ViewObject, "AutoWorkingPlane"):
                     if sel.Object.ViewObject.AutoWorkingPlane:
                         FreeCAD.DraftWorkingPlane.weak = True
-                if hasattr(sel.Object.ViewObject,"CutView") and hasattr(sel.Object.ViewObject,"AutoCutView"):
+                if hasattr(sel.Object.ViewObject, "CutView") and hasattr(sel.Object.ViewObject, "AutoCutView"):
                     if sel.Object.ViewObject.AutoCutView:
                         sel.Object.ViewObject.CutView = True
-                if hasattr(sel.Object.ViewObject,"RestoreView"):
+                if hasattr(sel.Object.ViewObject, "RestoreView"):
                     if sel.Object.ViewObject.RestoreView:
-                        if hasattr(sel.Object.ViewObject,"ViewData"):
+                        if hasattr(sel.Object.ViewObject, "ViewData"):
                             if len(sel.Object.ViewObject.ViewData) >= 12:
                                 d = sel.Object.ViewObject.ViewData
                                 camtype = "orthographic"
@@ -194,16 +209,15 @@ class Draft_SelectPlane:
                                     if d[12] == 1:
                                         camtype = "perspective"
                                 c = FreeCADGui.ActiveDocument.ActiveView.getCameraNode()
-                                from pivy import coin
-                                if isinstance(c,coin.SoOrthographicCamera):
+                                if isinstance(c, coin.SoOrthographicCamera):
                                     if camtype == "perspective":
                                         FreeCADGui.ActiveDocument.ActiveView.setCameraType("Perspective")
-                                elif isinstance(c,coin.SoPerspectiveCamera):
+                                elif isinstance(c, coin.SoPerspectiveCamera):
                                     if camtype == "orthographic":
                                         FreeCADGui.ActiveDocument.ActiveView.setCameraType("Orthographic")
                                 c = FreeCADGui.ActiveDocument.ActiveView.getCameraNode()
-                                c.position.setValue([d[0],d[1],d[2]])
-                                c.orientation.setValue([d[3],d[4],d[5],d[6]])
+                                c.position.setValue([d[0], d[1], d[2]])
+                                c.orientation.setValue([d[3], d[4], d[5], d[6]])
                                 c.nearDistance.setValue(d[7])
                                 c.farDistance.setValue(d[8])
                                 c.aspectRatio.setValue(d[9])
@@ -212,9 +226,9 @@ class Draft_SelectPlane:
                                     c.height.setValue(d[11])
                                 else:
                                     c.heightAngle.setValue(d[11])
-                if hasattr(sel.Object.ViewObject,"RestoreState"):
+                if hasattr(sel.Object.ViewObject, "RestoreState"):
                     if sel.Object.ViewObject.RestoreState:
-                        if hasattr(sel.Object.ViewObject,"VisibilityMap"):
+                        if hasattr(sel.Object.ViewObject, "VisibilityMap"):
                             if sel.Object.ViewObject.VisibilityMap:
                                 for k,v in sel.Object.ViewObject.VisibilityMap.items():
                                     o = FreeCADGui.ActiveDocument.getObject(k)
@@ -226,7 +240,7 @@ class Draft_SelectPlane:
                 self.wpButton.setToolTip(translate("draft", "Current working plane")+": "+self.wpButton.text())
                 return True
             elif Draft.getType(sel.Object) == "SectionPlane":
-                FreeCAD.DraftWorkingPlane.setFromPlacement(sel.Object.Placement,rebase=True)
+                FreeCAD.DraftWorkingPlane.setFromPlacement(sel.Object.Placement, rebase=True)
                 FreeCAD.DraftWorkingPlane.weak = False
                 self.display(FreeCAD.DraftWorkingPlane.axis)
                 self.wpButton.setText(sel.Object.Label)
@@ -239,7 +253,7 @@ class Draft_SelectPlane:
                         self.display(FreeCAD.DraftWorkingPlane.axis)
                         return True
                     elif sel.SubElementNames[0] == "Plane":
-                        FreeCAD.DraftWorkingPlane.setFromPlacement(sel.Object.Placement,rebase=True)
+                        FreeCAD.DraftWorkingPlane.setFromPlacement(sel.Object.Placement, rebase=True)
                         self.display(FreeCAD.DraftWorkingPlane.axis)
                         return True
                 elif len(sel.SubElementNames) == 3:
@@ -263,7 +277,7 @@ class Draft_SelectPlane:
             import Part
             for s in sel:
                 for so in s.SubObjects:
-                    if isinstance(so,Part.Vertex):
+                    if isinstance(so, Part.Vertex):
                         subs.append(so)
             if len(subs) == 3:
                 FreeCAD.DraftWorkingPlane.alignTo3Points(subs[0].Point,
@@ -275,25 +289,31 @@ class Draft_SelectPlane:
         return False
 
     def getCenterPoint(self, x, y, z):
-
+        """Get the center point."""
         if not self.taskd.form.checkCenter.isChecked():
             return FreeCAD.Vector()
-        v = FreeCAD.Vector(x,y,z)
-        cam1 = FreeCAD.Vector(FreeCADGui.ActiveDocument.ActiveView.getCameraNode().position.getValue().getValue())
+        v = FreeCAD.Vector(x, y, z)
+        view = FreeCADGui.ActiveDocument.ActiveView
+        camera = view.getCameraNode()
+        cam1 = FreeCAD.Vector(camera.position.getValue().getValue())
         cam2 = FreeCADGui.ActiveDocument.ActiveView.getViewDirection()
-        vcam1 = DraftVecUtils.project(cam1,v)
+        vcam1 = DraftVecUtils.project(cam1, v)
         a = vcam1.getAngle(cam2)
         if a < 0.0001:
             return FreeCAD.Vector()
         d = vcam1.Length
         L = d/math.cos(a)
-        vcam2 = DraftVecUtils.scaleTo(cam2,L)
+        vcam2 = DraftVecUtils.scaleTo(cam2, L)
         cp = cam1.add(vcam2)
         return cp
 
     def tostr(self, v):
         """Make a string from a vector or tuple."""
-        return "FreeCAD.Vector("+str(v[0])+","+str(v[1])+","+str(v[2])+")"
+        string = "FreeCAD.Vector("
+        string += str(v[0]) + ", "
+        string += str(v[1]) + ", "
+        string += str(v[2]) + ")"
+        return string
 
     def getOffset(self):
         """Return the offset value as a float in mm."""
@@ -305,48 +325,66 @@ class Draft_SelectPlane:
         return o
 
     def onClickTop(self):
-
-        o = str(self.getOffset())
-        FreeCADGui.doCommandGui(self.ac+"("+self.tostr(self.getCenterPoint(0,0,1))+","+self.tostr((0,0,1))+","+o+")")
+        """Execute when pressing the top button."""
+        offset = str(self.getOffset())
+        _cmd = self.ac
+        _cmd += "("
+        _cmd += self.tostr(self.getCenterPoint(0, 0, 1)) + ", "
+        _cmd += self.tostr((0, 0, 1)) + ", "
+        _cmd += offset
+        _cmd += ")"
+        FreeCADGui.doCommandGui(_cmd)
         self.display('Top')
         self.finish()
 
     def onClickFront(self):
-
-        o = str(self.getOffset())
-        FreeCADGui.doCommandGui(self.ac+"("+self.tostr(self.getCenterPoint(0,-1,0))+","+self.tostr((0,-1,0))+","+o+")")
+        """Execute when pressing the front button."""
+        offset = str(self.getOffset())
+        _cmd = self.ac
+        _cmd += "("
+        _cmd += self.tostr(self.getCenterPoint(0, -1, 0)) + ", "
+        _cmd += self.tostr((0, -1, 0)) + ", "
+        _cmd += offset
+        _cmd += ")"
+        FreeCADGui.doCommandGui(_cmd)
         self.display('Front')
         self.finish()
 
     def onClickSide(self):
-
-        o = str(self.getOffset())
-        FreeCADGui.doCommandGui(self.ac+"("+self.tostr(self.getCenterPoint(1,0,0))+","+self.tostr((1,0,0))+","+o+")")
+        """Execute when pressing the side button."""
+        offset = str(self.getOffset())
+        _cmd = self.ac
+        _cmd += "("
+        _cmd += self.tostr(self.getCenterPoint(1, 0, 0)) + ", "
+        _cmd += self.tostr((1, 0, 0)) + ", "
+        _cmd += offset
+        _cmd += ")"
+        FreeCADGui.doCommandGui(_cmd)
         self.display('Side')
         self.finish()
 
     def onClickAlign(self):
-
+        """Execute when pressing the align."""
         FreeCADGui.doCommandGui("FreeCAD.DraftWorkingPlane.setup(force=True)")
         d = self.view.getViewDirection().negative()
         self.display(d)
         self.finish()
 
     def onClickAuto(self):
-
+        """Execute when pressing the auto button."""
         FreeCADGui.doCommandGui("FreeCAD.DraftWorkingPlane.reset()")
         self.display('Auto')
         self.finish()
 
     def onClickMove(self):
-
+        """Execute when pressing the move button."""
         sel = FreeCADGui.Selection.getSelectionEx()
         if sel:
             verts = []
             import Part
             for s in sel:
                 for so in s.SubObjects:
-                    if isinstance(so,Part.Vertex):
+                    if isinstance(so, Part.Vertex):
                         verts.append(so)
             if len(verts) == 1:
                 target = verts[0].Point
@@ -358,13 +396,13 @@ class Draft_SelectPlane:
             c = FreeCADGui.ActiveDocument.ActiveView.getCameraNode()
             p = FreeCAD.Vector(c.position.getValue().getValue())
             d = FreeCADGui.ActiveDocument.ActiveView.getViewDirection()
-            pp = FreeCAD.DraftWorkingPlane.projectPoint(p,d)
+            pp = FreeCAD.DraftWorkingPlane.projectPoint(p, d)
             FreeCAD.DraftWorkingPlane.position = pp
             self.display(pp)
             self.finish()
 
     def onClickCenter(self):
-
+        """Execute when pressing the center button."""
         c = FreeCADGui.ActiveDocument.ActiveView.getCameraNode()
         r = FreeCAD.DraftWorkingPlane.getRotation().Rotation.Q
         c.orientation.setValue(r)
@@ -377,7 +415,7 @@ class Draft_SelectPlane:
         self.finish()
 
     def onClickPrevious(self):
-
+        """Execute when pressing the previous button."""
         p = FreeCAD.DraftWorkingPlane
         if len(self.states) > 1:
             self.states.pop()  # discard the last one
@@ -389,32 +427,32 @@ class Draft_SelectPlane:
             FreeCADGui.Snapper.setGrid()
             self.finish()
 
-    def onSetGridSize(self,text):
-
+    def onSetGridSize(self, text):
+        """Execute when setting the grid size."""
         try:
             q = FreeCAD.Units.Quantity(text)
-        except:
+        except Exception:
             pass
         else:
-            self.param.SetFloat("gridSpacing",q.Value)
-            if hasattr(FreeCADGui,"Snapper"):
+            self.param.SetFloat("gridSpacing", q.Value)
+            if hasattr(FreeCADGui, "Snapper"):
                 FreeCADGui.Snapper.setGrid()
 
-    def onSetMainline(self,i):
-
+    def onSetMainline(self, i):
+        """Execute when setting main line grid spacing."""
         if i > 1:
-            self.param.SetInt("gridEvery",i)
-            if hasattr(FreeCADGui,"Snapper"):
+            self.param.SetInt("gridEvery", i)
+            if hasattr(FreeCADGui, "Snapper"):
                 FreeCADGui.Snapper.setGrid()
 
-    def onSetSnapRadius(self,i):
-
-        self.param.SetInt("snapRange",i)
+    def onSetSnapRadius(self, i):
+        """Execute when setting the snap radius."""
+        self.param.SetInt("snapRange", i)
         if hasattr(FreeCADGui, "Snapper"):
             FreeCADGui.Snapper.showradius()
 
-    def display(self,arg):
-        """Set the text of the working plane button."""
+    def display(self, arg):
+        """Set the text of the working plane button in the toolbar."""
         o = self.getOffset()
         if o:
             if o > 0:
@@ -423,20 +461,33 @@ class Draft_SelectPlane:
                 suffix = ' -O'
         else:
             suffix = ''
-        vdir = FreeCAD.DraftWorkingPlane.axis
-        vdir = '('+str(vdir.x)[:4]+','+str(vdir.y)[:4]+','+str(vdir.z)[:4]+')'
-        vdir = " "+translate("draft","Dir")+": "+vdir
-        if type(arg).__name__  == 'str':
-            self.wpButton.setText(arg+suffix)
+        _vdir = FreeCAD.DraftWorkingPlane.axis
+        vdir = '('
+        vdir += str(_vdir.x)[:4] + ','
+        vdir += str(_vdir.y)[:4] + ','
+        vdir += str(_vdir.z)[:4]
+        vdir += ')'
+
+        vdir = " " + translate("draft", "Dir") + ": " + vdir
+        if type(arg).__name__ == 'str':
+            self.wpButton.setText(arg + suffix)
             if o != 0:
-                o = " "+translate("draft","Offset")+": "+str(o)
+                o = " " + translate("draft", "Offset") + ": " + str(o)
             else:
                 o = ""
-            self.wpButton.setToolTip(translate("draft", "Current working plane")+": "+self.wpButton.text()+o+vdir)
+            _tool = translate("draft", "Current working plane") + ": "
+            _tool += self.wpButton.text() + o + vdir
+            self.wpButton.setToolTip(_tool)
         elif type(arg).__name__ == 'Vector':
-            plv = '('+str(arg.x)[:6]+','+str(arg.y)[:6]+','+str(arg.z)[:6]+')'
-            self.wpButton.setText(translate("draft","Custom"))
-            self.wpButton.setToolTip(translate("draft", "Current working plane")+": "+plv+vdir)
+            plv = '('
+            plv += str(arg.x)[:6] + ','
+            plv += str(arg.y)[:6] + ','
+            plv += str(arg.z)[:6]
+            plv += ')'
+            self.wpButton.setText(translate("draft", "Custom"))
+            _tool = translate("draft", "Current working plane")
+            _tool += ": " + plv + vdir
+            self.wpButton.setToolTip(_tool)
         p = FreeCAD.DraftWorkingPlane
         self.states.append([p.u, p.v, p.axis, p.position])
         FreeCADGui.doCommandGui("FreeCADGui.Snapper.setGrid()")
@@ -446,23 +497,26 @@ class SelectPlane_TaskPanel:
     """The task panel definition of the Draft_SelectPlane command."""
 
     def __init__(self):
-
-        import Draft_rc
         self.form = FreeCADGui.PySideUic.loadUi(":/ui/TaskSelectPlane.ui")
 
     def getStandardButtons(self):
-
+        """Execute to set the standard buttons."""
         return 2097152  # int(QtGui.QDialogButtonBox.Close)
 
 
-class Draft_SetWorkingPlaneProxy():
-    """The Draft_SetWorkingPlaneProxy FreeCAD command definition"""
+class Draft_SetWorkingPlaneProxy:
+    """The Draft_SetWorkingPlaneProxy FreeCAD command definition."""
 
     def GetResources(self):
         """Set icon, menu and tooltip."""
-        return {'Pixmap': 'Draft_SelectPlane',
-                'MenuText': QT_TRANSLATE_NOOP("Draft_SetWorkingPlaneProxy", "Create Working Plane Proxy"),
-                'ToolTip': QT_TRANSLATE_NOOP("Draft_SetWorkingPlaneProxy", "Creates a proxy object from the current working plane")}
+        _menu = "Create Working Plane Proxy"
+        _tip = "Creates a proxy object from the current working plane"
+        d = {'Pixmap': 'Draft_SelectPlane',
+             'MenuText': QT_TRANSLATE_NOOP("Draft_SetWorkingPlaneProxy",
+                                           _menu),
+             'ToolTip': QT_TRANSLATE_NOOP("Draft_SetWorkingPlaneProxy",
+                                          _tip)}
+        return d
 
     def IsActive(self):
         """Return True when this command should be available."""
@@ -472,14 +526,18 @@ class Draft_SetWorkingPlaneProxy():
             return False
 
     def Activated(self):
-        """Execute this when the command is called."""
+        """Execute when the command is called."""
         if hasattr(FreeCAD, "DraftWorkingPlane"):
             FreeCAD.ActiveDocument.openTransaction("Create WP proxy")
             FreeCADGui.addModule("Draft")
-            FreeCADGui.doCommand("Draft.makeWorkingPlaneProxy(FreeCAD.DraftWorkingPlane.getPlacement())")
+            _cmd = "Draft.makeWorkingPlaneProxy("
+            _cmd += "FreeCAD.DraftWorkingPlane.getPlacement()"
+            _cmd += ")"
+            FreeCADGui.doCommand(_cmd)
             FreeCAD.ActiveDocument.recompute()
             FreeCAD.ActiveDocument.commitTransaction()
 
 
 FreeCADGui.addCommand('Draft_SelectPlane', Draft_SelectPlane())
-FreeCADGui.addCommand('Draft_SetWorkingPlaneProxy', Draft_SetWorkingPlaneProxy())
+FreeCADGui.addCommand('Draft_SetWorkingPlaneProxy',
+                      Draft_SetWorkingPlaneProxy())

--- a/src/Mod/Draft/draftguitools/gui_snaps.py
+++ b/src/Mod/Draft/draftguitools/gui_snaps.py
@@ -1,9 +1,3 @@
-"""Provide the Draft_Snap commands used by the snapping mechanism in Draft."""
-## @package gui_snaps
-# \ingroup DRAFT
-# \brief Provide the Draft_Snap commands used by the snapping mechanism
-# in Draft.
-
 # ***************************************************************************
 # *   (c) 2009, 2010 Yorik van Havre <yorik@uncreated.net>                  *
 # *   (c) 2009, 2010 Ken Cline <cline@frii.com>                             *
@@ -28,8 +22,15 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-import FreeCADGui
+"""Provide the Draft_Snap commands used by the snapping mechanism in Draft."""
+## @package gui_snaps
+# \ingroup DRAFT
+# \brief Provide the Draft_Snap commands used by the snapping mechanism
+# in Draft.
+
 from PySide.QtCore import QT_TRANSLATE_NOOP
+
+import FreeCADGui as Gui
 
 
 class Draft_Snap_Lock:
@@ -47,12 +48,12 @@ class Draft_Snap_Lock:
 
     def Activated(self):
         """Execute this when the command is called."""
-        if hasattr(FreeCADGui, "Snapper"):
-            if hasattr(FreeCADGui.Snapper, "masterbutton"):
-                FreeCADGui.Snapper.masterbutton.toggle()
+        if hasattr(Gui, "Snapper"):
+            if hasattr(Gui.Snapper, "masterbutton"):
+                Gui.Snapper.masterbutton.toggle()
 
 
-FreeCADGui.addCommand('Draft_Snap_Lock', Draft_Snap_Lock())
+Gui.addCommand('Draft_Snap_Lock', Draft_Snap_Lock())
 
 
 class Draft_Snap_Midpoint:
@@ -68,14 +69,14 @@ class Draft_Snap_Midpoint:
 
     def Activated(self):
         """Execute this when the command is called."""
-        if hasattr(FreeCADGui, "Snapper"):
-            if hasattr(FreeCADGui.Snapper, "toolbarButtons"):
-                for b in FreeCADGui.Snapper.toolbarButtons:
+        if hasattr(Gui, "Snapper"):
+            if hasattr(Gui.Snapper, "toolbarButtons"):
+                for b in Gui.Snapper.toolbarButtons:
                     if b.objectName() == "SnapButtonmidpoint":
                         b.toggle()
 
 
-FreeCADGui.addCommand('Draft_Snap_Midpoint', Draft_Snap_Midpoint())
+Gui.addCommand('Draft_Snap_Midpoint', Draft_Snap_Midpoint())
 
 
 class Draft_Snap_Perpendicular:
@@ -93,14 +94,14 @@ class Draft_Snap_Perpendicular:
 
     def Activated(self):
         """Execute this when the command is called."""
-        if hasattr(FreeCADGui, "Snapper"):
-            if hasattr(FreeCADGui.Snapper, "toolbarButtons"):
-                for b in FreeCADGui.Snapper.toolbarButtons:
+        if hasattr(Gui, "Snapper"):
+            if hasattr(Gui.Snapper, "toolbarButtons"):
+                for b in Gui.Snapper.toolbarButtons:
                     if b.objectName() == "SnapButtonperpendicular":
                         b.toggle()
 
 
-FreeCADGui.addCommand('Draft_Snap_Perpendicular', Draft_Snap_Perpendicular())
+Gui.addCommand('Draft_Snap_Perpendicular', Draft_Snap_Perpendicular())
 
 
 class Draft_Snap_Grid:
@@ -115,14 +116,14 @@ class Draft_Snap_Grid:
 
     def Activated(self):
         """Execute this when the command is called."""
-        if hasattr(FreeCADGui, "Snapper"):
-            if hasattr(FreeCADGui.Snapper, "toolbarButtons"):
-                for b in FreeCADGui.Snapper.toolbarButtons:
+        if hasattr(Gui, "Snapper"):
+            if hasattr(Gui.Snapper, "toolbarButtons"):
+                for b in Gui.Snapper.toolbarButtons:
                     if b.objectName() == "SnapButtongrid":
                         b.toggle()
 
 
-FreeCADGui.addCommand('Draft_Snap_Grid', Draft_Snap_Grid())
+Gui.addCommand('Draft_Snap_Grid', Draft_Snap_Grid())
 
 
 class Draft_Snap_Intersection:
@@ -140,14 +141,14 @@ class Draft_Snap_Intersection:
 
     def Activated(self):
         """Execute this when the command is called."""
-        if hasattr(FreeCADGui, "Snapper"):
-            if hasattr(FreeCADGui.Snapper, "toolbarButtons"):
-                for b in FreeCADGui.Snapper.toolbarButtons:
+        if hasattr(Gui, "Snapper"):
+            if hasattr(Gui.Snapper, "toolbarButtons"):
+                for b in Gui.Snapper.toolbarButtons:
                     if b.objectName() == "SnapButtonintersection":
                         b.toggle()
 
 
-FreeCADGui.addCommand('Draft_Snap_Intersection', Draft_Snap_Intersection())
+Gui.addCommand('Draft_Snap_Intersection', Draft_Snap_Intersection())
 
 
 class Draft_Snap_Parallel:
@@ -163,14 +164,14 @@ class Draft_Snap_Parallel:
 
     def Activated(self):
         """Execute this when the command is called."""
-        if hasattr(FreeCADGui, "Snapper"):
-            if hasattr(FreeCADGui.Snapper, "toolbarButtons"):
-                for b in FreeCADGui.Snapper.toolbarButtons:
+        if hasattr(Gui, "Snapper"):
+            if hasattr(Gui.Snapper, "toolbarButtons"):
+                for b in Gui.Snapper.toolbarButtons:
                     if b.objectName() == "SnapButtonparallel":
                         b.toggle()
 
 
-FreeCADGui.addCommand('Draft_Snap_Parallel', Draft_Snap_Parallel())
+Gui.addCommand('Draft_Snap_Parallel', Draft_Snap_Parallel())
 
 
 class Draft_Snap_Endpoint:
@@ -186,14 +187,14 @@ class Draft_Snap_Endpoint:
 
     def Activated(self):
         """Execute this when the command is called."""
-        if hasattr(FreeCADGui, "Snapper"):
-            if hasattr(FreeCADGui.Snapper, "toolbarButtons"):
-                for b in FreeCADGui.Snapper.toolbarButtons:
+        if hasattr(Gui, "Snapper"):
+            if hasattr(Gui.Snapper, "toolbarButtons"):
+                for b in Gui.Snapper.toolbarButtons:
                     if b.objectName() == "SnapButtonendpoint":
                         b.toggle()
 
 
-FreeCADGui.addCommand('Draft_Snap_Endpoint', Draft_Snap_Endpoint())
+Gui.addCommand('Draft_Snap_Endpoint', Draft_Snap_Endpoint())
 
 
 class Draft_Snap_Angle:
@@ -208,14 +209,14 @@ class Draft_Snap_Angle:
 
     def Activated(self):
         """Execute this when the command is called."""
-        if hasattr(FreeCADGui, "Snapper"):
-            if hasattr(FreeCADGui.Snapper, "toolbarButtons"):
-                for b in FreeCADGui.Snapper.toolbarButtons:
+        if hasattr(Gui, "Snapper"):
+            if hasattr(Gui.Snapper, "toolbarButtons"):
+                for b in Gui.Snapper.toolbarButtons:
                     if b.objectName() == "SnapButtonangle":
                         b.toggle()
 
 
-FreeCADGui.addCommand('Draft_Snap_Angle', Draft_Snap_Angle())
+Gui.addCommand('Draft_Snap_Angle', Draft_Snap_Angle())
 
 
 class Draft_Snap_Center:
@@ -230,14 +231,14 @@ class Draft_Snap_Center:
 
     def Activated(self):
         """Execute this when the command is called."""
-        if hasattr(FreeCADGui, "Snapper"):
-            if hasattr(FreeCADGui.Snapper, "toolbarButtons"):
-                for b in FreeCADGui.Snapper.toolbarButtons:
+        if hasattr(Gui, "Snapper"):
+            if hasattr(Gui.Snapper, "toolbarButtons"):
+                for b in Gui.Snapper.toolbarButtons:
                     if b.objectName() == "SnapButtoncenter":
                         b.toggle()
 
 
-FreeCADGui.addCommand('Draft_Snap_Center', Draft_Snap_Center())
+Gui.addCommand('Draft_Snap_Center', Draft_Snap_Center())
 
 
 class Draft_Snap_Extension:
@@ -253,14 +254,14 @@ class Draft_Snap_Extension:
 
     def Activated(self):
         """Execute this when the command is called."""
-        if hasattr(FreeCADGui, "Snapper"):
-            if hasattr(FreeCADGui.Snapper, "toolbarButtons"):
-                for b in FreeCADGui.Snapper.toolbarButtons:
+        if hasattr(Gui, "Snapper"):
+            if hasattr(Gui.Snapper, "toolbarButtons"):
+                for b in Gui.Snapper.toolbarButtons:
                     if b.objectName() == "SnapButtonextension":
                         b.toggle()
 
 
-FreeCADGui.addCommand('Draft_Snap_Extension', Draft_Snap_Extension())
+Gui.addCommand('Draft_Snap_Extension', Draft_Snap_Extension())
 
 
 class Draft_Snap_Near:
@@ -275,14 +276,14 @@ class Draft_Snap_Near:
 
     def Activated(self):
         """Execute this when the command is called."""
-        if hasattr(FreeCADGui, "Snapper"):
-            if hasattr(FreeCADGui.Snapper, "toolbarButtons"):
-                for b in FreeCADGui.Snapper.toolbarButtons:
+        if hasattr(Gui, "Snapper"):
+            if hasattr(Gui.Snapper, "toolbarButtons"):
+                for b in Gui.Snapper.toolbarButtons:
                     if b.objectName() == "SnapButtonpassive":
                         b.toggle()
 
 
-FreeCADGui.addCommand('Draft_Snap_Near', Draft_Snap_Near())
+Gui.addCommand('Draft_Snap_Near', Draft_Snap_Near())
 
 
 class Draft_Snap_Ortho:
@@ -297,14 +298,14 @@ class Draft_Snap_Ortho:
 
     def Activated(self):
         """Execute this when the command is called."""
-        if hasattr(FreeCADGui, "Snapper"):
-            if hasattr(FreeCADGui.Snapper, "toolbarButtons"):
-                for b in FreeCADGui.Snapper.toolbarButtons:
+        if hasattr(Gui, "Snapper"):
+            if hasattr(Gui.Snapper, "toolbarButtons"):
+                for b in Gui.Snapper.toolbarButtons:
                     if b.objectName() == "SnapButtonortho":
                         b.toggle()
 
 
-FreeCADGui.addCommand('Draft_Snap_Ortho', Draft_Snap_Ortho())
+Gui.addCommand('Draft_Snap_Ortho', Draft_Snap_Ortho())
 
 
 class Draft_Snap_Special:
@@ -320,14 +321,14 @@ class Draft_Snap_Special:
 
     def Activated(self):
         """Execute this when the command is called."""
-        if hasattr(FreeCADGui, "Snapper"):
-            if hasattr(FreeCADGui.Snapper, "toolbarButtons"):
-                for b in FreeCADGui.Snapper.toolbarButtons:
+        if hasattr(Gui, "Snapper"):
+            if hasattr(Gui.Snapper, "toolbarButtons"):
+                for b in Gui.Snapper.toolbarButtons:
                     if b.objectName() == "SnapButtonspecial":
                         b.toggle()
 
 
-FreeCADGui.addCommand('Draft_Snap_Special', Draft_Snap_Special())
+Gui.addCommand('Draft_Snap_Special', Draft_Snap_Special())
 
 
 class Draft_Snap_Dimensions:
@@ -343,14 +344,14 @@ class Draft_Snap_Dimensions:
 
     def Activated(self):
         """Execute this when the command is called."""
-        if hasattr(FreeCADGui, "Snapper"):
-            if hasattr(FreeCADGui.Snapper, "toolbarButtons"):
-                for b in FreeCADGui.Snapper.toolbarButtons:
+        if hasattr(Gui, "Snapper"):
+            if hasattr(Gui.Snapper, "toolbarButtons"):
+                for b in Gui.Snapper.toolbarButtons:
                     if b.objectName() == "SnapButtonDimensions":
                         b.toggle()
 
 
-FreeCADGui.addCommand('Draft_Snap_Dimensions', Draft_Snap_Dimensions())
+Gui.addCommand('Draft_Snap_Dimensions', Draft_Snap_Dimensions())
 
 
 class Draft_Snap_WorkingPlane:
@@ -368,11 +369,11 @@ class Draft_Snap_WorkingPlane:
 
     def Activated(self):
         """Execute this when the command is called."""
-        if hasattr(FreeCADGui, "Snapper"):
-            if hasattr(FreeCADGui.Snapper, "toolbarButtons"):
-                for b in FreeCADGui.Snapper.toolbarButtons:
+        if hasattr(Gui, "Snapper"):
+            if hasattr(Gui.Snapper, "toolbarButtons"):
+                for b in Gui.Snapper.toolbarButtons:
                     if b.objectName() == "SnapButtonWorkingPlane":
                         b.toggle()
 
 
-FreeCADGui.addCommand('Draft_Snap_WorkingPlane', Draft_Snap_WorkingPlane())
+Gui.addCommand('Draft_Snap_WorkingPlane', Draft_Snap_WorkingPlane())

--- a/src/Mod/Draft/draftguitools/gui_trackers.py
+++ b/src/Mod/Draft/draftguitools/gui_trackers.py
@@ -917,7 +917,7 @@ class PlaneTracker(Tracker):
 class wireTracker(Tracker):
     """A wire tracker."""
 
-    def __init__(self,wire):
+    def __init__(self, wire):
         self.line = coin.SoLineSet()
         self.closed = DraftGeomUtils.isReallyClosed(wire)
         if self.closed:
@@ -926,36 +926,41 @@ class wireTracker(Tracker):
             self.line.numVertices.setValue(len(wire.Vertexes))
         self.coords = coin.SoCoordinate3()
         self.update(wire)
-        Tracker.__init__(self,children=[self.coords,self.line],name="wireTracker")
+        Tracker.__init__(self, children=[self.coords, self.line],
+                         name="wireTracker")
 
-    def update(self,wire,forceclosed=False):
+    def update(self, wire, forceclosed=False):
+        """Update the tracker."""
         if wire:
             if self.closed or forceclosed:
-                self.line.numVertices.setValue(len(wire.Vertexes)+1)
+                self.line.numVertices.setValue(len(wire.Vertexes) + 1)
             else:
                 self.line.numVertices.setValue(len(wire.Vertexes))
             for i in range(len(wire.Vertexes)):
-                p=wire.Vertexes[i].Point
-                self.coords.point.set1Value(i,[p.x,p.y,p.z])
+                p = wire.Vertexes[i].Point
+                self.coords.point.set1Value(i, [p.x, p.y, p.z])
             if self.closed or forceclosed:
                 t = len(wire.Vertexes)
                 p = wire.Vertexes[0].Point
-                self.coords.point.set1Value(t,[p.x,p.y,p.z])
+                self.coords.point.set1Value(t, [p.x, p.y, p.z])
 
-    def updateFromPointlist(self,points,forceclosed=False):
+    def updateFromPointlist(self, points, forceclosed=False):
+        """Update the tracker from points."""
         if points:
             for i in range(len(points)):
-                p=points[i]
-                self.coords.point.set1Value(i,[p.x,p.y,p.z])
+                p = points[i]
+                self.coords.point.set1Value(i, [p.x, p.y, p.z])
+
 
 class gridTracker(Tracker):
-    """A grid tracker"""
+    """A grid tracker."""
+
     def __init__(self):
         col = self.getGridColor()
         pick = coin.SoPickStyle()
         pick.style.setValue(coin.SoPickStyle.UNPICKABLE)
         self.trans = coin.SoTransform()
-        self.trans.translation.setValue([0,0,0])
+        self.trans.translation.setValue([0, 0, 0])
         mat1 = coin.SoMaterial()
         mat1.transparency.setValue(0.7)
         mat1.diffuseColor.setValue(col)
@@ -984,46 +989,48 @@ class gridTracker(Tracker):
         s.addChild(mat3)
         s.addChild(self.coords3)
         s.addChild(self.lines3)
-        Tracker.__init__(self,children=[s],name="gridTracker")
+        Tracker.__init__(self, children=[s], name="gridTracker")
         self.reset()
 
     def getGridColor(self):
+        """Get the grid color from the parameter editor."""
         color = Draft.getParam("gridColor", 842157055)
-        r = ((color>>24)&0xFF)/255
-        g = ((color>>16)&0xFF)/255
-        b = ((color>>8)&0xFF)/255
+        r = ((color >> 24) & 0xFF) / 255
+        g = ((color >> 16) & 0xFF) / 255
+        b = ((color >> 8) & 0xFF) / 255
         return [r, g, b]
 
     def update(self):
-        """redraws the grid"""
-        # resize the grid to make sure it fits an exact pair number of main lines
-        numlines = self.numlines//self.mainlines//2*2*self.mainlines
-        bound = (numlines//2)*self.space
+        """Redraw the grid."""
+        # Resize the grid to make sure it fits
+        # an exact pair number of main lines
+        numlines = self.numlines // self.mainlines // 2 * 2 * self.mainlines
+        bound = (numlines // 2) * self.space
         pts = []
         mpts = []
         apts = []
-        for i in range(numlines+1):
-            curr = -bound + i*self.space
+        for i in range(numlines + 1):
+            curr = -bound + i * self.space
             z = 0
-            if i/float(self.mainlines) == i//self.mainlines:
-                if round(curr,4) == 0:
-                    apts.extend([[-bound,curr,z],[bound,curr,z]])
-                    apts.extend([[curr,-bound,z],[curr,bound,z]])
+            if i / float(self.mainlines) == i // self.mainlines:
+                if round(curr, 4) == 0:
+                    apts.extend([[-bound, curr, z], [bound, curr, z]])
+                    apts.extend([[curr, -bound, z], [curr, bound, z]])
                 else:
-                    mpts.extend([[-bound,curr,z],[bound,curr,z]])
-                    mpts.extend([[curr,-bound,z],[curr,bound,z]])
+                    mpts.extend([[-bound, curr, z], [bound, curr, z]])
+                    mpts.extend([[curr, -bound, z], [curr, bound, z]])
             else:
-                pts.extend([[-bound,curr,z],[bound,curr,z]])
-                pts.extend([[curr,-bound,z],[curr,bound,z]])
+                pts.extend([[-bound, curr, z], [bound, curr, z]])
+                pts.extend([[curr, -bound, z], [curr, bound, z]])
         if pts != self.pts:
             idx = []
             midx = []
             aidx = []
-            for p in range(0,len(pts),2):
+            for p in range(0, len(pts), 2):
                 idx.append(2)
-            for mp in range(0,len(mpts),2):
+            for mp in range(0, len(mpts), 2):
                 midx.append(2)
-            for ap in range(0,len(apts),2):
+            for ap in range(0, len(apts), 2):
                 aidx.append(2)
             self.lines1.numVertices.deleteValues(0)
             self.lines2.numVertices.deleteValues(0)
@@ -1035,52 +1042,57 @@ class gridTracker(Tracker):
             self.coords3.point.setValues(apts)
             self.lines3.numVertices.setValues(aidx)
             self.pts = pts
-        
-    def setSize(self,size):
+
+    def setSize(self, size):
+        """Set size of the lines and update."""
         self.numlines = size
         self.update()
 
-    def setSpacing(self,space):
+    def setSpacing(self, space):
+        """Set spacing and update."""
         self.space = space
         self.update()
 
-    def setMainlines(self,ml):
+    def setMainlines(self, ml):
+        """Set mainlines and update."""
         self.mainlines = ml
         self.update()
-        
+
     def reset(self):
-        """resets the grid according to preferences settings"""
-        self.space = Draft.getParam("gridSpacing",1)
-        self.mainlines = Draft.getParam("gridEvery",10)
-        self.numlines = Draft.getParam("gridSize",100)
+        """Reset the grid according to preferences settings."""
+        self.space = Draft.getParam("gridSpacing", 1)
+        self.mainlines = Draft.getParam("gridEvery", 10)
+        self.numlines = Draft.getParam("gridSize", 100)
         self.update()
 
     def set(self):
-        """moves and rotates the grid according to the current WP"""
+        """Move and rotate the grid according to the current working plane."""
         self.reset()
         Q = FreeCAD.DraftWorkingPlane.getRotation().Rotation.Q
         P = FreeCAD.DraftWorkingPlane.position
-        self.trans.rotation.setValue([Q[0],Q[1],Q[2],Q[3]])
-        self.trans.translation.setValue([P.x,P.y,P.z])
+        self.trans.rotation.setValue([Q[0], Q[1], Q[2], Q[3]])
+        self.trans.translation.setValue([P.x, P.y, P.z])
         self.on()
 
-    def getClosestNode(self,point):
-        """returns the closest node from the given point"""
+    def getClosestNode(self, point):
+        """Return the closest node from the given point."""
         # get the 2D coords.
         # point = FreeCAD.DraftWorkingPlane.projectPoint(point)
         pt = FreeCAD.DraftWorkingPlane.getLocalCoords(point)
-        pu = (round(pt.x/self.space,0))*self.space
-        pv = (round(pt.y/self.space,0))*self.space
-        pt = FreeCAD.DraftWorkingPlane.getGlobalCoords(Vector(pu,pv,0))
+        pu = round(pt.x / self.space, 0) * self.space
+        pv = round(pt.y / self.space, 0) * self.space
+        pt = FreeCAD.DraftWorkingPlane.getGlobalCoords(Vector(pu, pv, 0))
         return pt
-    
-class boxTracker(Tracker):                
-    """A box tracker, can be based on a line object"""
-    def __init__(self,line=None,width=0.1,height=1,shaded=False):
+
+
+class boxTracker(Tracker):
+    """A box tracker, can be based on a line object."""
+
+    def __init__(self, line=None, width=0.1, height=1, shaded=False):
         self.trans = coin.SoTransform()
         m = coin.SoMaterial()
         m.transparency.setValue(0.8)
-        m.diffuseColor.setValue([0.4,0.4,0.6])
+        m.diffuseColor.setValue([0.4, 0.4, 0.6])
         w = coin.SoDrawStyle()
         w.style = coin.SoDrawStyle.LINES
         self.cube = coin.SoCube()
@@ -1091,16 +1103,19 @@ class boxTracker(Tracker):
             self.baseline = line
             self.update()
         if shaded:
-            Tracker.__init__(self,children=[self.trans,m,self.cube],name="boxTracker")
+            Tracker.__init__(self, children=[self.trans, m, self.cube],
+                             name="boxTracker")
         else:
-            Tracker.__init__(self,children=[self.trans,w,self.cube],name="boxTracker")
+            Tracker.__init__(self, children=[self.trans, w, self.cube],
+                             name="boxTracker")
 
-    def update(self,line=None,normal=None):
+    def update(self, line=None, normal=None):
+        """Update the tracker."""
         import WorkingPlane, DraftGeomUtils
         if not normal:
             normal = FreeCAD.DraftWorkingPlane.axis
         if line:
-            if isinstance(line,list):
+            if isinstance(line, list):
                 bp = line[0]
                 lvec = line[1].sub(line[0])
             else:
@@ -1113,109 +1128,129 @@ class boxTracker(Tracker):
             return
         right = lvec.cross(normal)
         self.cube.width.setValue(lvec.Length)
-        p = WorkingPlane.getPlacementFromPoints([bp,bp.add(lvec),bp.add(right)])
+        p = WorkingPlane.getPlacementFromPoints([bp,
+                                                 bp.add(lvec),
+                                                 bp.add(right)])
         if p:
             self.trans.rotation.setValue(p.Rotation.Q)
         bp = bp.add(lvec.multiply(0.5))
-        bp = bp.add(DraftVecUtils.scaleTo(normal,self.cube.depth.getValue()/2))
+        bp = bp.add(DraftVecUtils.scaleTo(normal, self.cube.depth.getValue()/2.0))
         self.pos(bp)
-        
-    def setRotation(self,rot):
+
+    def setRotation(self, rot):
+        """Set the rotation."""
         self.trans.rotation.setValue(rot.Q)
 
-    def pos(self,p):
+    def pos(self, p):
+        """Set the translation."""
         self.trans.translation.setValue(DraftVecUtils.tup(p))
 
-    def width(self,w=None):
+    def width(self, w=None):
+        """Set the width."""
         if w:
             self.cube.height.setValue(w)
         else:
             return self.cube.height.getValue()
 
-    def length(self,l=None):
+    def length(self, l=None):
+        """Set the length."""
         if l:
             self.cube.width.setValue(l)
         else:
             return self.cube.width.getValue()
-        
-    def height(self,h=None):
+
+    def height(self, h=None):
+        """Set the height."""
         if h:
             self.cube.depth.setValue(h)
             self.update()
         else:
             return self.cube.depth.getValue()
 
+
 class radiusTracker(Tracker):
-    """A tracker that displays a transparent sphere to inicate a radius"""
-    def __init__(self,position=FreeCAD.Vector(0,0,0),radius=1):
+    """A tracker that displays a transparent sphere to inicate a radius."""
+
+    def __init__(self, position=FreeCAD.Vector(0, 0, 0), radius=1):
         self.trans = coin.SoTransform()
-        self.trans.translation.setValue([position.x,position.y,position.z])
+        self.trans.translation.setValue([position.x, position.y, position.z])
         m = coin.SoMaterial()
         m.transparency.setValue(0.9)
-        m.diffuseColor.setValue([0,1,0])
+        m.diffuseColor.setValue([0, 1, 0])
         self.sphere = coin.SoSphere()
         self.sphere.radius.setValue(radius)
         self.baseline = None
-        Tracker.__init__(self,children=[self.trans,m,self.sphere],name="radiusTracker")
+        Tracker.__init__(self, children=[self.trans, m, self.sphere],
+                         name="radiusTracker")
 
-    def update(self,arg1,arg2=None):
-        if isinstance(arg1,FreeCAD.Vector):
-            self.trans.translation.setValue([arg1.x,arg1.y,arg1.z])
+    def update(self, arg1, arg2=None):
+        """Update the tracker."""
+        if isinstance(arg1, FreeCAD.Vector):
+            self.trans.translation.setValue([arg1.x, arg1.y, arg1.z])
         else:
             self.sphere.radius.setValue(arg1)
-        if arg2 != None:
-            if isinstance(arg2,FreeCAD.Vector):
-                self.trans.translation.setValue([arg2.x,arg2.y,arg2.z])
+        if arg2 is not None:
+            if isinstance(arg2, FreeCAD.Vector):
+                self.trans.translation.setValue([arg2.x, arg2.y, arg2.z])
             else:
                 self.sphere.radius.setValue(arg2)
-                
+
+
 class archDimTracker(Tracker):
-    """A wrapper around a Sketcher dim"""
-    def __init__(self,p1=FreeCAD.Vector(0,0,0),p2=FreeCAD.Vector(1,0,0),mode=1):
+    """A wrapper around a Sketcher dim."""
+
+    def __init__(self,
+                 p1=FreeCAD.Vector(0, 0, 0),
+                 p2=FreeCAD.Vector(1, 0, 0), mode=1):
         import SketcherGui
         self.dimnode = coin.SoType.fromName("SoDatumLabel").createInstance()
-        p1node = coin.SbVec3f([p1.x,p1.y,p1.z])
-        p2node = coin.SbVec3f([p2.x,p2.y,p2.z])
-        self.dimnode.pnts.setValues([p1node,p2node])
+        p1node = coin.SbVec3f([p1.x, p1.y, p1.z])
+        p2node = coin.SbVec3f([p2.x, p2.y, p2.z])
+        self.dimnode.pnts.setValues([p1node, p2node])
         self.dimnode.lineWidth = 1
         color = FreeCADGui.draftToolBar.getDefaultColor("snap")
         self.dimnode.textColor.setValue(coin.SbVec3f(color))
         self.setString()
         self.setMode(mode)
-        Tracker.__init__(self,children=[self.dimnode],name="archDimTracker")
-        
-    def setString(self,text=None):
-        """sets the dim string to the given value or auto value"""
+        Tracker.__init__(self, children=[self.dimnode], name="archDimTracker")
+
+    def setString(self, text=None):
+        """Set the dim string to the given value or auto value."""
         self.dimnode.param1.setValue(.5)
         p1 = Vector(self.dimnode.pnts.getValues()[0].getValue())
         p2 = Vector(self.dimnode.pnts.getValues()[-1].getValue())
         m = self.dimnode.datumtype.getValue()
         if m == 2:
-            self.Distance = (DraftVecUtils.project(p2.sub(p1),Vector(1,0,0))).Length
+            self.Distance = (DraftVecUtils.project(p2.sub(p1), Vector(1, 0, 0))).Length
         elif m == 3:
-            self.Distance = (DraftVecUtils.project(p2.sub(p1),Vector(0,1,0))).Length
+            self.Distance = (DraftVecUtils.project(p2.sub(p1), Vector(0, 1, 0))).Length
         else:
             self.Distance = (p2.sub(p1)).Length
-        text = FreeCAD.Units.Quantity(self.Distance,FreeCAD.Units.Length).UserString
+        text = FreeCAD.Units.Quantity(self.Distance, FreeCAD.Units.Length).UserString
         self.dimnode.string.setValue(text.encode('utf8'))
-        
-    def setMode(self,mode=1):
-        """sets the mode: 0 = without lines (a simple mark), 1 =
-        aligned (default), 2 = horizontal, 3 = vertical."""
+
+    def setMode(self, mode=1):
+        """Set the mode.
+
+        0 = without lines (a simple mark)
+        1 = aligned (default)
+        2 = horizontal
+        3 = vertical.
+        """
         self.dimnode.datumtype.setValue(mode)
 
-    def p1(self,point=None):
-        """sets or gets the first point of the dim"""
+    def p1(self, point=None):
+        """Set or get the first point of the dim."""
         if point:
-            self.dimnode.pnts.set1Value(0,point.x,point.y,point.z)
+            self.dimnode.pnts.set1Value(0, point.x, point.y, point.z)
             self.setString()
         else:
             return Vector(self.dimnode.pnts.getValues()[0].getValue())
 
-    def p2(self,point=None):
-        """sets or gets the second point of the dim"""
+    def p2(self, point=None):
+        """Set or get the second point of the dim."""
         if point:
-            self.dimnode.pnts.set1Value(1,point.x,point.y,point.z)
+            self.dimnode.pnts.set1Value(1, point.x, point.y, point.z)
             self.setString()
         else:
             return Vector(self.dimnode.pnts.getValues()[-1].getValue())

--- a/src/Mod/Draft/draftobjects/__init__.py
+++ b/src/Mod/Draft/draftobjects/__init__.py
@@ -1,0 +1,8 @@
+"""Functions and classes that define custom scripted objects.
+
+These classes define a custom object which is based on one of the core
+objects defined in C++. The custom object inherits some basic properties,
+and new properties are added.
+
+Most Draft objects are based on Part::Part2DObject.
+"""

--- a/src/Mod/Draft/drafttaskpanels/__init__.py
+++ b/src/Mod/Draft/drafttaskpanels/__init__.py
@@ -1,0 +1,7 @@
+"""Classes that define the task panels of GUI commands.
+
+These classes load `.ui` files that will be used in the task panel
+of the graphical commands.
+The classes define the behavior and callbacks of the different widgets
+included in the `.ui` file.
+"""

--- a/src/Mod/Draft/drafttests/__init__.py
+++ b/src/Mod/Draft/drafttests/__init__.py
@@ -1,1 +1,7 @@
-#
+"""Classes and functions used to test the workbench.
+
+These classes are called by the unit test launcher
+that is defined in `Init.py` and `InitGui.py`.
+
+The unit tests are based on the standard `unittest` module.
+"""

--- a/src/Mod/Draft/draftutils/__init__.py
+++ b/src/Mod/Draft/draftutils/__init__.py
@@ -1,0 +1,6 @@
+"""Utility functions that do not require the graphical user interface.
+
+These functions are used throughout the Draft Workbench.
+They can be called from any module, whether it uses the graphical
+user interface or not.
+"""

--- a/src/Mod/Draft/draftutils/gui_utils.py
+++ b/src/Mod/Draft/draftutils/gui_utils.py
@@ -1,12 +1,3 @@
-"""This module provides GUI utility functions for the Draft Workbench.
-
-This module should contain auxiliary functions which require
-the graphical user interface (GUI).
-"""
-## @package gui_utils
-# \ingroup DRAFT
-# \brief This module provides utility functions for the Draft Workbench
-
 # ***************************************************************************
 # *   (c) 2009, 2010                                                        *
 # *   Yorik van Havre <yorik@uncreated.net>, Ken Cline <cline@frii.com>     *
@@ -31,24 +22,32 @@ the graphical user interface (GUI).
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
+"""Provides GUI utility functions for the Draft Workbench.
 
+This module contains auxiliary functions which can be used
+in other modules of the workbench, and which require
+the graphical user interface (GUI), as they access the view providers
+of the objects or the 3D view.
+"""
+## @package gui_utils
+# \ingroup DRAFT
+# \brief This module provides GUI utility functions for the Draft Workbench
+
+import math
+import os
+import six
 
 import FreeCAD
-from .utils import _msg
-from .utils import _wrn
-# from .utils import _log
-from .utils import _tr
-from .utils import getParam
-from .utils import get_type
-import os
-import math
-import six
+from draftutils.messages import _msg, _wrn
+from draftutils.utils import getParam
+from draftutils.utils import get_type
+from draftutils.translate import _tr, translate
 
 if FreeCAD.GuiUp:
     import FreeCADGui
     from pivy import coin
     from PySide import QtGui
-#   from PySide import QtSvg  # for load_texture
+    # from PySide import QtSvg  # for load_texture
 
 
 def get_3d_view():
@@ -80,7 +79,7 @@ get3DView = get_3d_view
 
 
 def autogroup(obj):
-    """Adds a given object to the defined Draft autogroup, if applicable.
+    """Add a given object to the defined Draft autogroup, if applicable.
 
     This function only works if the graphical interface is available.
     It checks that the `FreeCAD.draftToolBar` class is available,

--- a/src/Mod/Draft/draftutils/init_tools.py
+++ b/src/Mod/Draft/draftutils/init_tools.py
@@ -1,14 +1,3 @@
-"""Provides lists of commands for the Draft Workbench.
-
-This module returns lists of commands, so that the toolbars
-can be initialized by Draft, and by other workbenches.
-These commands should be defined in `DraftTools`, and in the individual
-modules in `draftguitools`.
-"""
-## @package init_tools
-# \ingroup DRAFT
-# \brief This module provides lists of commands for the Draft Workbench.
-
 # ***************************************************************************
 # *   (c) 2020 Eliud Cabrera Castillo <e.cabrera-castillo@tum.de>           *
 # *                                                                         *
@@ -31,6 +20,16 @@ modules in `draftguitools`.
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
+"""Provides lists of commands for the Draft Workbench.
+
+This module returns lists of commands, so that the toolbars
+can be initialized by Draft, and by other workbenches.
+These commands should be defined in `DraftTools`, and in the individual
+modules in `draftguitools`.
+"""
+## @package init_tools
+# \ingroup DRAFT
+# \brief This module provides lists of commands for the Draft Workbench.
 
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
@@ -61,7 +60,7 @@ def get_draft_modification_commands():
     """Return the modification commands list."""
     lst = ["Draft_Move", "Draft_Rotate",
            "Draft_Scale", "Draft_Mirror",
-           "Draft_Offset", "Draft_Trimex", 
+           "Draft_Offset", "Draft_Trimex",
            "Draft_Stretch",
            "Separator",
            "Draft_Clone"]

--- a/src/Mod/Draft/draftutils/init_tools.py
+++ b/src/Mod/Draft/draftutils/init_tools.py
@@ -42,12 +42,13 @@ def get_draft_drawing_commands():
             "Draft_ArcTools",
             "Draft_Circle", "Draft_Ellipse", "Draft_Rectangle",
             "Draft_Polygon", "Draft_BSpline", "Draft_BezierTools",
-            "Draft_Point", "Draft_Facebinder"]
+            "Draft_Point", "Draft_Facebinder",
+            "Draft_ShapeString"]
 
 
 def get_draft_annotation_commands():
     """Return the annotation commands list."""
-    return ["Draft_Text", "Draft_ShapeString", "Draft_Dimension",
+    return ["Draft_Text", "Draft_Dimension",
             "Draft_Label"]
 
 

--- a/src/Mod/Draft/draftutils/messages.py
+++ b/src/Mod/Draft/draftutils/messages.py
@@ -1,8 +1,3 @@
-"""Provide message utility functions for the Draft Workbench."""
-## @package messages
-# \ingroup DRAFT
-# \brief Provide message utility functions for the Draft Workbench.
-
 # ***************************************************************************
 # *   (c) 2020 Eliud Cabrera Castillo <e.cabrera-castillo@tum.de>           *
 # *                                                                         *
@@ -25,6 +20,16 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
+"""Provide message utility functions for the Draft Workbench.
+
+The Console module has long function names, so we define some shorthands
+that are suitable for use in every workbench. These shorthands also include
+a newline character at the end of the string, so it doesn't have to be
+added manually.
+"""
+## @package messages
+# \ingroup DRAFT
+# \brief Provide message utility functions for the Draft Workbench.
 
 import FreeCAD as App
 

--- a/src/Mod/Draft/draftutils/utils.py
+++ b/src/Mod/Draft/draftutils/utils.py
@@ -1,13 +1,4 @@
 # -*- coding: utf-8 -*-
-"""This module provides utility functions for the Draft Workbench.
-
-This module should contain auxiliary functions which don't require
-the graphical user interface (GUI).
-"""
-## @package utils
-# \ingroup DRAFT
-# \brief This module provides utility functions for the Draft Workbench
-
 # ***************************************************************************
 # *   (c) 2009, 2010                                                        *
 # *   Yorik van Havre <yorik@uncreated.net>, Ken Cline <cline@frii.com>     *
@@ -32,52 +23,35 @@ the graphical user interface (GUI).
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
+"""Provides utility functions for the Draft Workbench.
+
+This module contains auxiliary functions which can be used
+in other modules of the workbench, and which don't require
+the graphical user interface (GUI).
+"""
+## @package utils
+# \ingroup DRAFT
+# \brief This module provides utility functions for the Draft Workbench
 
 import os
-import FreeCAD
 from PySide import QtCore
+
+import FreeCAD
 import Draft_rc
+from draftutils.messages import _msg
+from draftutils.translate import _tr
+
 App = FreeCAD
 
 # The module is used to prevent complaints from code checkers (flake8)
 True if Draft_rc else False
-
-
-if App.GuiUp:
-    # The right translate function needs to be imported here
-    # from DraftGui import translate
-
-    # At the moment it is the same function as without GUI
-    def translate(context, text):
-        return text
-else:
-    def translate(context, text):
-        return text
-
-
-def _tr(text):
-    """Function to translate with the context set."""
-    return translate("Draft", text)
-
-
-def _msg(text, end="\n"):
-    App.Console.PrintMessage(text + end)
-
-
-def _wrn(text, end="\n"):
-    App.Console.PrintWarning(text + end)
-
-
-def _log(text, end="\n"):
-    App.Console.PrintLog(text + end)
-
 
 ARROW_TYPES = ["Dot", "Circle", "Arrow", "Tick", "Tick-2"]
 arrowtypes = ARROW_TYPES
 
 
 def string_encode_coin(ustr):
-    """Encode a unicode object to be used as a string in coin
+    """Encode a unicode object to be used as a string in coin.
 
     Parameters
     ----------
@@ -132,7 +106,7 @@ def type_check(args_and_types, name="?"):
         Defaults to `'?'`. The name of the check.
 
     Raises
-    -------
+    ------
     TypeError
         If the first element in the tuple is not an instance of the second
         element, it raises `Draft.name`.
@@ -265,7 +239,7 @@ getParam = get_param
 
 
 def set_param(param, value):
-    """Set a Draft parameter with the given value
+    """Set a Draft parameter with the given value.
 
     The parameter database is located in the tree
     ::
@@ -981,7 +955,7 @@ getMovableChildren = get_movable_children
 
 
 def utf8_decode(text):
-    """Decode the input string and return a unicode string.
+    r"""Decode the input string and return a unicode string.
 
     Python 2:
     ::
@@ -1017,14 +991,14 @@ def utf8_decode(text):
 
         >>> "Aá".decode("utf-8")
         >>> b"Aá".decode("utf-8")
-        u'A\\xe1'
+        u'A\xe1'
 
         In Python 2 the unicode string is prefixed with `u`,
         and unicode characters are replaced by their two-digit hexadecimal
         representation, or four digit unicode escape.
 
         >>> "AáBẃCñ".decode("utf-8")
-        u'A\\xe1B\\u1e83C\\xf1'
+        u'A\xe1B\u1e83C\xf1'
 
         In Python 2 it will always return a `unicode` object.
 

--- a/src/Mod/Draft/draftviewproviders/__init__.py
+++ b/src/Mod/Draft/draftviewproviders/__init__.py
@@ -1,0 +1,7 @@
+"""Classes that define the viewproviders of custom scripted objects.
+
+These classes define viewproviders for the custom objects
+defined in `draftobjects`.
+The viewproviders can be used only when the graphical interface
+is available; in console mode the viewproviders are not available.
+"""

--- a/src/Mod/Draft/importSVG.py
+++ b/src/Mod/Draft/importSVG.py
@@ -1,23 +1,3 @@
-## @package importSVG
-#  \ingroup DRAFT
-#  \brief SVG file importer & exporter
-'''@package importSVG
-\ingroup DRAFT
-\brief SVG file importer & exporter
-
-This module provides support for importing and exporting SVG files. It
-enables importing/exporting objects directly to/from the 3D document, but
-doesn't handle the SVG output from the Drawing and TechDraw modules.
-
-Currently it only reads the following entities:
-* paths, lines, circular arcs, rects, circles, ellipses, polygons, polylines.
-
-Currently unsupported:
-* use, image.
-'''
-# Check code with
-# flake8 --ignore=E226,E266,E401,W503
-
 # ***************************************************************************
 # *   Copyright (c) 2009 Yorik van Havre <yorik@uncreated.net>              *
 # *                                                                         *
@@ -38,12 +18,29 @@ Currently unsupported:
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
+"""Provides support for importing and exporting SVG files.
+
+It enables importing/exporting objects directly to/from the 3D document
+but doesn't handle the SVG output from the Drawing and TechDraw modules.
+
+Currently it only reads the following entities:
+* paths, lines, circular arcs, rects, circles, ellipses, polygons, polylines.
+
+Currently unsupported:
+* use, image.
+"""
+## @package importSVG
+#  \ingroup DRAFT
+#  \brief SVG file importer and exporter
+
+# Check code with
+# flake8 --ignore=E226,E266,E401,W503
 
 __title__ = "FreeCAD Draft Workbench - SVG importer/exporter"
 __author__ = "Yorik van Havre, Sebastian Hoogen"
 __url__ = "https://www.freecadweb.org"
 
-# ToDo:
+# TODO:
 # ignoring CDATA
 # handle image element (external references and inline base64)
 # debug Problem with 'Sans' font from Inkscape
@@ -51,27 +48,28 @@ __url__ = "https://www.freecadweb.org"
 # implement inheriting fill style from group
 # handle relative units
 
-import xml.sax, FreeCAD, os, math, re, Draft, DraftVecUtils
+import math
+import os
+import re
+import xml.sax
+
+import FreeCAD
+import Draft
+import DraftVecUtils
 from FreeCAD import Vector
 from FreeCAD import Console as FCC
+from draftutils.translate import translate
 
 if FreeCAD.GuiUp:
-    from DraftTools import translate
     from PySide import QtGui
-else:
-    def translate(context, txt):
-        return txt
-
-try:
     import FreeCADGui
-except ImportError:
-    gui = False
-else:
     gui = True
-
-try:
-    draftui = FreeCADGui.draftToolBar
-except AttributeError:
+    try:
+        draftui = FreeCADGui.draftToolBar
+    except AttributeError:
+        draftui = None
+else:
+    gui = False
     draftui = None
 
 # Save the native open function to avoid collisions


### PR DESCRIPTION
This pull request includes many commits that are meant to be small fixes in the code style, to better organize it, and to comply with PEP8.
* It moves the header comments at the beginning of the file so that the LGPL2 license is the first element. Then it arranges the import of modules immediately after.
* It adds various `"""documentation strings"""` to many functions and classes.
* It adds many spaces after commas, particularly in lists, tuples, and argument functions: `(0,1,2)` becomes `(0, 1, 2)`.
* It adds spaces when necessary and removes trailing spaces in other cases.
* It shortens lines so that they are shorter than 80 characters per line.
* It does not introduce new functions or major changes that could disrupt the workbench.

For this pull request I don't want to squash the commits into a smaller number of commits; ideally each commit modifies a single file, so it is easy to review the changes. Only a few commits modify more than one file.

This request needs to be merged after #3097 because it builds after it. When that one is merged, this one should be rebased.

Since this request touches many files, it may also cause a conflict with other requests like #2985, #3023, #3102, and #3137, so these will have to be rebased.

Forum thread: [[Discussion] Splitting Draft tools into their own modules](https://forum.freecadweb.org/viewtopic.php?f=23&t=38593&p=375838#p375838)

---

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists
