### PR TITLE
Travis: install Pivy for Python 2 and 3 to run the tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -186,7 +186,7 @@ before_install:
                                libmetis-dev                     \
                                libspnav-dev
        # Runtime deps
-       sudo apt-get install -y --no-install-recommends freecad-daily-python3 python-ply python3-ply
+       sudo apt-get install -y --no-install-recommends freecad-daily-python3 python-pivy python3-pivy python-ply python3-ply
 
        export DISPLAY=:99.0
        sh -e /etc/init.d/xvfb start


### PR DESCRIPTION
The tests done in #3082 indicate that Travis does not have pivy for Python 2, so some tests with GCC and Python 2 fail.

Both `python-pivy` and `python3-pivy` are runtime dependencies of Draft. It seems the Python 3 version was installed and didn't fail, but there is no version available for Python 2 so the tests fail some times. Maybe this solves those issues with #3082.

---

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists
