### PR TITLE
Draft: re-organization of Draft Edit code

### DIFF
--- a/src/Mod/Draft/CMakeLists.txt
+++ b/src/Mod/Draft/CMakeLists.txt
@@ -13,7 +13,6 @@ SET(Draft_SRCS_base
     DraftVecUtils.py
     DraftGeomUtils.py
     DraftLayer.py
-    DraftEdit.py
     DraftFillet.py
     WorkingPlane.py
     getSVG.py
@@ -85,6 +84,7 @@ SET(Draft_GUI_tools
     draftguitools/gui_snaps.py
     draftguitools/gui_snapper.py
     draftguitools/gui_trackers.py
+    draftguitools/gui_edit.py
     draftguitools/README.md
 )
 

--- a/src/Mod/Draft/DraftTools.py
+++ b/src/Mod/Draft/DraftTools.py
@@ -36,7 +36,7 @@ __url__ = "https://www.freecadweb.org"
 # Generic stuff
 #---------------------------------------------------------------------------
 
-import sys, os, FreeCAD, FreeCADGui, WorkingPlane, math, re, Draft, Draft_rc, DraftVecUtils
+import sys, FreeCAD, FreeCADGui, WorkingPlane, math, Draft, Draft_rc, DraftVecUtils
 from FreeCAD import Vector
 from PySide import QtCore,QtGui
 import DraftGui
@@ -56,9 +56,9 @@ if not hasattr(FreeCAD, "DraftWorkingPlane"):
 # Commands that have been migrated to their own modules
 #---------------------------------------------------------------------------
 
-import DraftEdit
-# import DraftFillet
+import draftguitools.gui_edit
 import draftguitools.gui_selectplane
+# import DraftFillet
 import drafttaskpanels.task_shapestring as task_shapestring
 import drafttaskpanels.task_scale as task_scale
 

--- a/src/Mod/Draft/draftguitools/gui_edit.py
+++ b/src/Mod/Draft/draftguitools/gui_edit.py
@@ -1,4 +1,8 @@
-# -*- coding: utf8 -*-
+"""Provide the Draft_Edit command used by the Draft workbench."""
+## @package gui_edit
+# \ingroup DRAFT
+# \brief Provide the Draft_Edit command used by the Draft workbench
+
 #***************************************************************************
 #*   Copyright (c) 2009, 2010 Yorik van Havre <yorik@uncreated.net>        *
 #*   Copyright (c) 2009, 2010 Ken Cline <cline@frii.com>                   *

--- a/src/Mod/Draft/drafttests/test_import_tools.py
+++ b/src/Mod/Draft/drafttests/test_import_tools.py
@@ -38,7 +38,7 @@ class DraftImportTools(unittest.TestCase):
 
     def test_import_gui_draftedit(self):
         """Import Draft Edit."""
-        module = "DraftEdit"
+        module = "draftguitools.gui_edit"
         if not App.GuiUp:
             aux._no_gui(module)
             self.assertTrue(True)


### PR DESCRIPTION
* The edit module is moved to another module, `gui_edit`.
* Update the unit tests so they pass.

This pull request needs to be merged after #3096 is merged so that the new files are correctly included in the variables in `CMakeLists.txt`. When this happens, this request will create a conflict, so this pull request will have to be rebased onto the master branch, and then it will be able to be merged.

Since this request touches `DraftEdit.py`, it will cause a conflict with #3023.

Depending on which pull request is merged first, one or the other will have to be rebased to solve the conflicts.

Forum thread: [[Discussion] Splitting Draft tools into their own modules](https://forum.freecadweb.org/viewtopic.php?f=23&t=38593&start=40#p370895).

---

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists