### PR TITLE
Draft: load separate unit tests in Init.py and InitGui.py

### DIFF
--- a/src/Mod/Draft/CMakeLists.txt
+++ b/src/Mod/Draft/CMakeLists.txt
@@ -17,6 +17,7 @@ SET(Draft_SRCS_base
     WorkingPlane.py
     getSVG.py
     TestDraft.py
+    TestDraftGui.py
 )
 
 SET(Draft_import

--- a/src/Mod/Draft/Init.py
+++ b/src/Mod/Draft/Init.py
@@ -1,31 +1,36 @@
-#***************************************************************************
-#*   Copyright (c) 2009 Yorik van Havre <yorik@uncreated.net>              *
-#*                                                                         *
-#*   This program is free software; you can redistribute it and/or modify  *
-#*   it under the terms of the GNU Lesser General Public License (LGPL)    *
-#*   as published by the Free Software Foundation; either version 2 of     *
-#*   the License, or (at your option) any later version.                   *
-#*   for detail see the LICENCE text file.                                 *
-#*                                                                         *
-#*   This program is distributed in the hope that it will be useful,       *
-#*   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
-#*   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
-#*   GNU Library General Public License for more details.                  *
-#*                                                                         *
-#*   You should have received a copy of the GNU Library General Public     *
-#*   License along with this program; if not, write to the Free Software   *
-#*   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
-#*   USA                                                                   *
-#*                                                                         *
-#***************************************************************************
+# ***************************************************************************
+# *   Copyright (c) 2009 Yorik van Havre <yorik@uncreated.net>              *
+# *                                                                         *
+# *   This program is free software; you can redistribute it and/or modify  *
+# *   it under the terms of the GNU Lesser General Public License (LGPL)    *
+# *   as published by the Free Software Foundation; either version 2 of     *
+# *   the License, or (at your option) any later version.                   *
+# *   for detail see the LICENCE text file.                                 *
+# *                                                                         *
+# *   This program is distributed in the hope that it will be useful,       *
+# *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+# *   GNU Library General Public License for more details.                  *
+# *                                                                         *
+# *   You should have received a copy of the GNU Library General Public     *
+# *   License along with this program; if not, write to the Free Software   *
+# *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
+# *   USA                                                                   *
+# *                                                                         *
+# ***************************************************************************
+"""Initialization file of the workbench, non-GUI."""
+
+import FreeCAD as App
 
 # add Import/Export types
-App.addImportType("Autodesk DXF 2D (*.dxf)","importDXF") 
-App.addImportType("SVG as geometry (*.svg)","importSVG")
-App.addImportType("Open CAD Format (*.oca *.gcad)","importOCA")
-App.addImportType("Common airfoil data (*.dat)","importAirfoilDAT")
-App.addExportType("Autodesk DXF 2D (*.dxf)","importDXF")
-App.addExportType("Flattened SVG (*.svg)","importSVG")
-App.addExportType("Open CAD Format (*.oca)","importOCA")
-App.addImportType("Autodesk DWG 2D (*.dwg)","importDWG") 
-App.addExportType("Autodesk DWG 2D (*.dwg)","importDWG")
+App.addImportType("Autodesk DXF 2D (*.dxf)", "importDXF")
+App.addImportType("SVG as geometry (*.svg)", "importSVG")
+App.addImportType("Open CAD Format (*.oca *.gcad)", "importOCA")
+App.addImportType("Common airfoil data (*.dat)", "importAirfoilDAT")
+App.addExportType("Autodesk DXF 2D (*.dxf)", "importDXF")
+App.addExportType("Flattened SVG (*.svg)", "importSVG")
+App.addExportType("Open CAD Format (*.oca)", "importOCA")
+App.addImportType("Autodesk DWG 2D (*.dwg)", "importDWG")
+App.addExportType("Autodesk DWG 2D (*.dwg)", "importDWG")
+
+App.__unit_test__ += ["TestDraft"]

--- a/src/Mod/Draft/InitGui.py
+++ b/src/Mod/Draft/InitGui.py
@@ -174,3 +174,5 @@ FreeCADGui.addPreferencePage(":/ui/preferences-dxf.ui", QT_TRANSLATE_NOOP("Draft
 FreeCADGui.addPreferencePage(":/ui/preferences-dwg.ui", QT_TRANSLATE_NOOP("Draft", "Import-Export"))
 FreeCADGui.addPreferencePage(":/ui/preferences-svg.ui", QT_TRANSLATE_NOOP("Draft", "Import-Export"))
 FreeCADGui.addPreferencePage(":/ui/preferences-oca.ui", QT_TRANSLATE_NOOP("Draft", "Import-Export"))
+
+FreeCAD.__unit_test__ += ["TestDraftGui"]

--- a/src/Mod/Draft/InitGui.py
+++ b/src/Mod/Draft/InitGui.py
@@ -174,5 +174,3 @@ FreeCADGui.addPreferencePage(":/ui/preferences-dxf.ui", QT_TRANSLATE_NOOP("Draft
 FreeCADGui.addPreferencePage(":/ui/preferences-dwg.ui", QT_TRANSLATE_NOOP("Draft", "Import-Export"))
 FreeCADGui.addPreferencePage(":/ui/preferences-svg.ui", QT_TRANSLATE_NOOP("Draft", "Import-Export"))
 FreeCADGui.addPreferencePage(":/ui/preferences-oca.ui", QT_TRANSLATE_NOOP("Draft", "Import-Export"))
-
-FreeCAD.__unit_test__ += ["TestDraft"]

--- a/src/Mod/Draft/TestDraft.py
+++ b/src/Mod/Draft/TestDraft.py
@@ -1,12 +1,3 @@
-"""Unit tests for the Draft workbench.
-
-From the terminal, run the following:
-FreeCAD -t TestDraft
-
-From within FreeCAD, run the following:
-import Test, TestDraft
-Test.runTestsFromModule(TestDraft)
-"""
 # ***************************************************************************
 # *   Copyright (c) 2013 Yorik van Havre <yorik@uncreated.net>              *
 # *   Copyright (c) 2019 Eliud Cabrera Castillo <e.cabrera-castillo@tum.de> *
@@ -30,6 +21,15 @@ Test.runTestsFromModule(TestDraft)
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
+"""Unit tests for the Draft workbench.
+
+From the terminal, run the following:
+FreeCAD -t TestDraft
+
+From within FreeCAD, run the following:
+import Test, TestDraft
+Test.runTestsFromModule(TestDraft)
+"""
 
 # ===========================================================================
 # The unit tests can be run from the operating system terminal, or from

--- a/src/Mod/Draft/TestDraftGui.py
+++ b/src/Mod/Draft/TestDraftGui.py
@@ -1,6 +1,6 @@
 # ***************************************************************************
 # *   Copyright (c) 2013 Yorik van Havre <yorik@uncreated.net>              *
-# *   Copyright (c) 2019 Eliud Cabrera Castillo <e.cabrera-castillo@tum.de> *
+# *   Copyright (c) 2020 Eliud Cabrera Castillo <e.cabrera-castillo@tum.de> *
 # *                                                                         *
 # *   This file is part of the FreeCAD CAx development system.              *
 # *                                                                         *
@@ -21,16 +21,16 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Unit tests for the Draft workbench, non-GUI only.
+"""Unit tests for the Draft workbench, GUI only.
 
 From the terminal, run the following:
-FreeCAD -t TestDraft
+FreeCAD -t TestDraftGui
 
 From within FreeCAD, run the following:
-import Test, TestDraft
-Test.runTestsFromModule(TestDraft)
+import Test, TestDraftGui
+Test.runTestsFromModule(TestDraftGui)
 
-For the GUI-only tests see TestDraftGui.
+For the non-GUI tests see TestDraft.
 """
 
 # ===========================================================================
@@ -95,25 +95,11 @@ For the GUI-only tests see TestDraftGui.
 # that follows a defined alphanumeric sequence.
 
 # Import tests
-from drafttests.test_import import DraftImport as DraftTest01
-
-# Objects tests
-from drafttests.test_creation import DraftCreation as DraftTest02
-from drafttests.test_modification import DraftModification as DraftTest03
-
-# Handling of file formats tests
-from drafttests.test_svg import DraftSVG as DraftTest04
-from drafttests.test_dxf import DraftDXF as DraftTest05
-from drafttests.test_dwg import DraftDWG as DraftTest06
-from drafttests.test_oca import DraftOCA as DraftTest07
-from drafttests.test_airfoildat import DraftAirfoilDAT as DraftTest08
+from drafttests.test_import_gui import DraftGuiImport as DraftTestGui01
+from drafttests.test_import_tools import DraftImportTools as DraftTestGui02
+from drafttests.test_pivy import DraftPivy as DraftTestGui03
 
 # Use the modules so that code checkers don't complain (flake8)
-True if DraftTest01 else False
-True if DraftTest02 else False
-True if DraftTest03 else False
-True if DraftTest04 else False
-True if DraftTest05 else False
-True if DraftTest06 else False
-True if DraftTest07 else False
-True if DraftTest08 else False
+True if DraftTestGui01 else False
+True if DraftTestGui02 else False
+True if DraftTestGui03 else False

--- a/src/Mod/Draft/drafttests/test_import_gui.py
+++ b/src/Mod/Draft/drafttests/test_import_gui.py
@@ -24,7 +24,6 @@
 """Unit test for the Draft Workbench, GUI import tests."""
 
 import unittest
-import FreeCAD as App
 import drafttests.auxiliary as aux
 
 
@@ -39,39 +38,23 @@ class DraftGuiImport(unittest.TestCase):
     def test_import_gui_draftgui(self):
         """Import Draft TaskView GUI tools."""
         module = "DraftGui"
-        if not App.GuiUp:
-            aux._no_gui(module)
-            self.assertTrue(True)
-            return
         imported = aux._import_test(module)
         self.assertTrue(imported, "Problem importing '{}'".format(module))
 
     def test_import_gui_draft_snap(self):
         """Import Draft snapping."""
         module = "draftguitools.gui_snapper"
-        if not App.GuiUp:
-            aux._no_gui(module)
-            self.assertTrue(True)
-            return
         imported = aux._import_test(module)
         self.assertTrue(imported, "Problem importing '{}'".format(module))
 
     def test_import_gui_draft_tools(self):
         """Import Draft graphical commands."""
         module = "DraftTools"
-        if not App.GuiUp:
-            aux._no_gui(module)
-            self.assertTrue(True)
-            return
         imported = aux._import_test(module)
         self.assertTrue(imported, "Problem importing '{}'".format(module))
 
     def test_import_gui_draft_trackers(self):
         """Import Draft tracker utilities."""
         module = "draftguitools.gui_trackers"
-        if not App.GuiUp:
-            aux._no_gui(module)
-            self.assertTrue(True)
-            return
         imported = aux._import_test(module)
         self.assertTrue(imported, "Problem importing '{}'".format(module))

--- a/src/Mod/Draft/drafttests/test_import_tools.py
+++ b/src/Mod/Draft/drafttests/test_import_tools.py
@@ -24,7 +24,6 @@
 """Unit test for the Draft Workbench, tools import tests."""
 
 import unittest
-import FreeCAD as App
 import drafttests.auxiliary as aux
 
 
@@ -39,49 +38,29 @@ class DraftImportTools(unittest.TestCase):
     def test_import_gui_draftedit(self):
         """Import Draft Edit."""
         module = "draftguitools.gui_edit"
-        if not App.GuiUp:
-            aux._no_gui(module)
-            self.assertTrue(True)
-            return
         imported = aux._import_test(module)
         self.assertTrue(imported, "Problem importing '{}'".format(module))
 
     def test_import_gui_draftfillet(self):
         """Import Draft Fillet."""
         module = "DraftFillet"
-        if not App.GuiUp:
-            aux._no_gui(module)
-            self.assertTrue(True)
-            return
         imported = aux._import_test(module)
         self.assertTrue(imported, "Problem importing '{}'".format(module))
 
     def test_import_gui_draftlayer(self):
         """Import Draft Layer."""
         module = "DraftLayer"
-        if not App.GuiUp:
-            aux._no_gui(module)
-            self.assertTrue(True)
-            return
         imported = aux._import_test(module)
         self.assertTrue(imported, "Problem importing '{}'".format(module))
 
     def test_import_gui_draftplane(self):
         """Import Draft SelectPlane."""
         module = "draftguitools.gui_selectplane"
-        if not App.GuiUp:
-            aux._no_gui(module)
-            self.assertTrue(True)
-            return
         imported = aux._import_test(module)
         self.assertTrue(imported, "Problem importing '{}'".format(module))
 
     def test_import_gui_workingplane(self):
         """Import Draft WorkingPlane."""
         module = "WorkingPlane"
-        if not App.GuiUp:
-            aux._no_gui(module)
-            self.assertTrue(True)
-            return
         imported = aux._import_test(module)
         self.assertTrue(imported, "Problem importing '{}'".format(module))

--- a/src/Mod/Draft/drafttests/test_pivy.py
+++ b/src/Mod/Draft/drafttests/test_pivy.py
@@ -25,7 +25,6 @@
 
 import unittest
 import FreeCAD as App
-import FreeCADGui as Gui
 import drafttests.auxiliary as aux
 from draftutils.messages import _msg
 
@@ -53,6 +52,10 @@ class DraftPivy(unittest.TestCase):
     def test_pivy_import(self):
         """Import Coin (Pivy)."""
         module = "pivy.coin"
+        if not App.GuiUp:
+            aux._no_gui(module)
+            self.assertTrue(True)
+            return
         imported = aux._import_test(module)
         self.assertTrue(imported, "Problem importing '{}'".format(module))
 
@@ -64,8 +67,9 @@ class DraftPivy(unittest.TestCase):
             self.assertTrue(True)
             return
 
-        import pivy.coin
-        cube = pivy.coin.SoCube()
+        import FreeCADGui as Gui
+        import pivy.coin as coin
+        cube = coin.SoCube()
         _msg("  Draw cube")
         Gui.ActiveDocument.ActiveView.getSceneGraph().addChild(cube)
         _msg("  Adding cube to the active view scene")

--- a/src/Mod/Draft/drafttests/test_pivy.py
+++ b/src/Mod/Draft/drafttests/test_pivy.py
@@ -25,6 +25,7 @@
 
 import unittest
 import FreeCAD as App
+import FreeCADGui as Gui
 import drafttests.auxiliary as aux
 from draftutils.messages import _msg
 
@@ -52,22 +53,11 @@ class DraftPivy(unittest.TestCase):
     def test_pivy_import(self):
         """Import Coin (Pivy)."""
         module = "pivy.coin"
-        if not App.GuiUp:
-            aux._no_gui(module)
-            self.assertTrue(True)
-            return
         imported = aux._import_test(module)
         self.assertTrue(imported, "Problem importing '{}'".format(module))
 
     def test_pivy_draw(self):
         """Use Coin (pivy.coin) to draw a cube on the active view."""
-        module = "pivy.coin"
-        if not App.GuiUp:
-            aux._no_gui(module)
-            self.assertTrue(True)
-            return
-
-        import FreeCADGui as Gui
         import pivy.coin as coin
         cube = coin.SoCube()
         _msg("  Draw cube")


### PR DESCRIPTION
This pull request improves the way the new Draft unit tests are run (#2668, #2727).

Currently the Draft unit tests are registered in `InitGui.py` file. This means these tests are only performed when using the graphical version of FreeCAD (`FreeCAD`), and are not done when using the console version (`FreeCADCmd`).

Since the Travis system runs in console mode when doing the tests, it doesn't actually run the Draft tests.
```
FreeCAD --console --run-test 0
```

This means currently we cannot catch many problems when submitting pull requests to the Draft Workbench. In many cases, Draft fails when it is called by other modules, like FEM and Path, but we are not alerted by Draft itself; we only know errors happened due to output by these other workbenches.

This is what happened after the re-organization of the code in #2829, #2830, #2831, #2832. After these were merged the Travis tests were failing, but we couldn't see exactly where. Eventually the problem was found and it was solved with 3af513986. If the tests had run correctly in Travis, we could have solved the problem during the submission of those pull requests.

Therefore, this pull request now registers the majority of the unit tests that create objects in `Init.py`, and removes them from `InitGui.py`. This is how FEM and Path do it as well. We hope that now the unit tests will correctly run under Travis, and we will be able to catch problems in Draft more easily.

The `InitGui.py` file still registers some unit tests in a new module, `TestDraftGui.py`. At the present time these tests mostly import certain modules that require the user interface, but they don't test for a lot of actual functionality, so they aren't very critical.

---

The present pull request has to be merged after #3082 because this one makes several small changes to the import of modules in the Draft Workbench. In particular, the code is re-structured in certain places so that modules and functions that require the graphical interface are loaded or executed only when `FreeCAD.GuiUp` is `True`.

---

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists
