### PR TITLE
Fix crash on removing dynamic property 

### DIFF
--- a/src/App/Document.cpp
+++ b/src/App/Document.cpp
@@ -1010,7 +1010,7 @@ bool Document::redo(int id)
 
 void Document::addOrRemovePropertyOfObject(TransactionalObject* obj, Property *prop, bool add)
 {
-    if (!prop || !obj) 
+    if (!prop || !obj || !obj->isAttachedToDocument()) 
         return;
     if(d->iUndoMode && !isPerformingTransaction() && !d->activeUndoTransaction) {
         if(!testStatus(Restoring) || testStatus(Importing)) {

--- a/src/App/DynamicProperty.cpp
+++ b/src/App/DynamicProperty.cpp
@@ -215,7 +215,7 @@ bool DynamicProperty::removeDynamicProperty(const char* name)
             throw Base::RuntimeError("property is not dynamic");
         Property *prop = it->property;
         GetApplication().signalRemoveDynamicProperty(*prop);
-        delete prop;
+        Property::destroy(prop);
         index.erase(it);
         return true;
     }

--- a/src/App/Property.h
+++ b/src/App/Property.h
@@ -104,6 +104,9 @@ public:
     Property();
     virtual ~Property();
 
+    /// For safe deleting of a dynamic property
+    static void destroy(Property *p);
+
     /** This method is used to get the size of objects
      * It is not meant to have the exact size, it is more or less an estimation
      * which runs fast! Is it two bytes or a GB?

--- a/src/Gui/propertyeditor/PropertyItem.h
+++ b/src/Gui/propertyeditor/PropertyItem.h
@@ -182,7 +182,6 @@ protected:
     virtual QVariant value(const App::Property*) const;
     virtual void setValue(const QVariant&);
     virtual void initialize();
-    QString pythonIdentifier(const App::Property*) const;
 
     //gets called when the bound expression is changed
     virtual void onChange();


### PR DESCRIPTION
The cause of crash is removing dynamic property at the wrong time. These two commits are splitted out from another PR #2862, because I've encountered crash during other test.