### PR TITLE
Fix typos

### DIFF
--- a/package/fedora/freecad.spec
+++ b/package/fedora/freecad.spec
@@ -142,7 +142,7 @@ Recommends:	python3-pysolar
 FreeCAD is a general purpose Open Source 3D CAD/MCAD/CAx/CAE/PLM modeler, aimed
 directly at mechanical engineering and product design but also fits a wider
 range of uses in engineering, such as architecture or other engineering
-specialties. It is a feature-based parametric modeler with a modular software
+specialities. It is a feature-based parametric modeler with a modular software
 architecture which makes it easy to provide additional functionality without
 modifying the core system.
 

--- a/package/makepkg
+++ b/package/makepkg
@@ -4,7 +4,7 @@
 pkgname=freecad-svn 
 pkgver=2152 
 pkgrel=2 
-pkgdesc="A general purpose 3D CAD modeler, aimed directly at mechanical engineering and product design but also architecture or other engineering specialties" 
+pkgdesc="A general purpose 3D CAD modeler, aimed directly at mechanical engineering and product design but also architecture or other engineering specialities" 
 arch=('x86_64') 
 url="https://sourceforge.net/apps/mediawiki/free-cad/" 
 license=('GPL') 

--- a/src/App/Application.cpp
+++ b/src/App/Application.cpp
@@ -707,8 +707,8 @@ std::vector<Document*> Application::openDocuments(const std::vector<std::string>
     std::vector<Document*> docs;
     docs.reserve(newDocs.size());
     for (auto &v : newDocs) {
-        // Notify ProeprtyXLink to attach newly opened documents and restore
-        // relavant external links
+        // Notify PropertyXLink to attach newly opened documents and restore
+        // relevant external links
         PropertyXLink::restoreDocument(*v.first);
         docs.push_back(v.first);
     }

--- a/src/App/FreeCADInit.py
+++ b/src/App/FreeCADInit.py
@@ -456,7 +456,7 @@ class FCADLogger(object):
                          function, and you want to show the callers source
                          location, then set frame to one.
 
-            * args: tuple for postiional arguments to be passed to
+            * args: tuple for positional arguments to be passed to
                     string.format()
 
             * kargs: dictionary for keyword arguments to be passed to

--- a/src/Gui/CommandView.cpp
+++ b/src/Gui/CommandView.cpp
@@ -1816,7 +1816,7 @@ void StdViewScreenShot::activated(int iMsg)
 
             QString comment = opt->comment();
             if (!comment.isEmpty()) {
-                // Replace newline escape sequence trough '\\n' string to build one big string,
+                // Replace newline escape sequence through '\\n' string to build one big string,
                 // otherwise Python would interpret it as an invalid command.
                 // Python does the decoding for us.
                 QStringList lines = comment.split(QLatin1String("\n"), QString::KeepEmptyParts );

--- a/src/Gui/DlgPropertyLink.ui
+++ b/src/Gui/DlgPropertyLink.ui
@@ -96,7 +96,7 @@
      <item>
       <widget class="QCheckBox" name="checkSubObject">
        <property name="toolTip">
-        <string>If enabled, then 3D view selection will be syncrhonize with full object hierarchy.</string>
+        <string>If enabled, then 3D view selection will be sychronize with full object hierarchy.</string>
        </property>
        <property name="text">
         <string>Sync sub-object selection</string>

--- a/src/Gui/PythonConsole.cpp
+++ b/src/Gui/PythonConsole.cpp
@@ -490,7 +490,7 @@ PythonConsole::~PythonConsole()
     delete d;
 }
 
-/** Set new font and colors according to the paramerts. */  
+/** Set new font and colors according to the parameters. */  
 void PythonConsole::OnChange( Base::Subject<const char*> &rCaller,const char* sReason )
 {
     Q_UNUSED(rCaller); 

--- a/src/Mod/.gitattributes
+++ b/src/Mod/.gitattributes
@@ -4,7 +4,7 @@ JtReader    export-ignore
 # ****************************************************************************
 # line endings
 
-# to surpress line ending changes in github, add ?w=1 at link end of a diff
+# to suppress line ending changes in github, add ?w=1 at link end of a diff
 
 # for more information see forum topic and a specific pull request
 # https://forum.freecadweb.org/viewtopic.php?f=17&t=41117

--- a/src/Mod/Arch/ArchBuildingPart.py
+++ b/src/Mod/Arch/ArchBuildingPart.py
@@ -532,7 +532,7 @@ class ViewProviderBuildingPart:
 
         # inventor saving
         if not "SaveInventor" in pl:
-            vobj.addProperty("App::PropertyBool","SaveInventor","Interaction",QT_TRANSLATE_NOOP("App::Property","If this is enabled, the inventor representation of this object will be saved in the FreeCAD file, allowing to reference it in other file sin lightweight mode."))
+            vobj.addProperty("App::PropertyBool","SaveInventor","Interaction",QT_TRANSLATE_NOOP("App::Property","If this is enabled, the inventor representation of this object will be saved in the FreeCAD file, allowing to reference it in other files in lightweight mode."))
         if not "SavedInventor" in pl:
             vobj.addProperty("App::PropertyFileIncluded","SavedInventor","Interaction",QT_TRANSLATE_NOOP("App::Property","A slot to save the inventor representation of this object, if enabled"))
             vobj.setEditorMode("SavedInventor",2)

--- a/src/Mod/Arch/ArchSpace.py
+++ b/src/Mod/Arch/ArchSpace.py
@@ -350,7 +350,7 @@ class _Space(ArchComponent.Component):
 
     def getShape(self,obj):
 
-        "computes a shape from a base shape and/or bounday faces"
+        "computes a shape from a base shape and/or boundary faces"
         import Part
         shape = None
         faces = []

--- a/src/Mod/Assembly/Gui/TaskAssemblyConstraints.cpp
+++ b/src/Mod/Assembly/Gui/TaskAssemblyConstraints.cpp
@@ -486,7 +486,7 @@ void TaskAssemblyConstraints::setPossibleOptions() {
 
 void TaskAssemblyConstraints::setPossibleConstraints()
 {
-    ////diasble all constraints for easier enabling
+    ////disable all constraints for easier enabling
     //ui->fix->setEnabled(false);
     //ui->distance->setEnabled(false);
     //ui->orientation->setEnabled(false);

--- a/src/Mod/Assembly/Gui/TaskAssemblyConstraints.ui
+++ b/src/Mod/Assembly/Gui/TaskAssemblyConstraints.ui
@@ -192,7 +192,7 @@
          </sizepolicy>
         </property>
         <property name="toolTip">
-         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Fixes the first geometry in its rotation and translation. Note that fix only works its the direct parent assembly. If you stack assemblys, the parent assembly will not be fixed inside the other ones.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Fixes the first geometry in its rotation and translation. Note that fix only works its the direct parent assembly. If you stack assemblies, the parent assembly will not be fixed inside the other ones.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
         </property>
         <property name="text">
          <string>Fix</string>

--- a/src/Mod/Draft/DraftEdit.py
+++ b/src/Mod/Draft/DraftEdit.py
@@ -75,7 +75,7 @@ class Edit():
         self._mouseMovedCB      -> self._mouseMovedCB
         if self._mousePressedCB -> self.mousePressed
         when trackers are displayed for selected objects,
-        theese callbacks capture user events and forward 
+        these callbacks capture user events and forward 
         them to related functions
 
 
@@ -133,7 +133,7 @@ class Edit():
         populates the menu with custom actions
     
     evaluate_menu_action
-        evaluate user choosen action and launch corresponding
+        evaluate user chosen action and launch corresponding
         function.
 
 
@@ -160,7 +160,7 @@ class Edit():
         self.pl, self.invpl.
         Due to multiple object editing, i'm planning to keep
         just self.trackers. Any other object will be identified
-        and processed starting from editTracker informations.
+        and processed starting from editTracker information.
     
     editing : Int
         Index of the editTracker that has been clicked by the 
@@ -363,7 +363,7 @@ class Edit():
 
     def unregister_selection_callback(self):
         """
-        remove selection callback if it exhists
+        remove selection callback if it exists
         """
         if self.selection_callback:
             self.view.removeEventCallback("SoEvent",self.selection_callback)
@@ -389,7 +389,7 @@ class Edit():
 
     def unregister_editing_callbacks(self):
         """
-        remove callbacks used during editing if they exhist
+        remove callbacks used during editing if they exist
         """
         view = Gui.ActiveDocument.ActiveView
         if self._keyPressedCB:

--- a/src/Mod/Draft/DraftEdit.py
+++ b/src/Mod/Draft/DraftEdit.py
@@ -633,7 +633,7 @@ class Edit():
         return node
     
     def sendRay(self, mouse_pos):
-        "sends a ray trough the scene and return the nearest entity"
+        "sends a ray through the scene and return the nearest entity"
         ray_pick = coin.SoRayPickAction(self.render_manager.getViewportRegion())
         ray_pick.setPoint(coin.SbVec2s(*mouse_pos))
         ray_pick.setRadius(self.pick_radius)

--- a/src/Mod/Draft/DraftGeomUtils.py
+++ b/src/Mod/Draft/DraftGeomUtils.py
@@ -2867,7 +2867,7 @@ def circleFrom3CircleTangents(circle1, circle2, circle3):
             # @todo Create 3 lines from the inner and 4 from the outer h. center.
             # @todo Calc. the 4 inversion poles of these lines for each circle.
             # @todo Calc. the radical center of the 3 circles.
-            # @todo Calc. the intersection points (max. 8) of 4 lines (trough each inversion pole and the radical center) with the circle.
+            # @todo Calc. the intersection points (max. 8) of 4 lines (through each inversion pole and the radical center) with the circle.
             #       This gives us all the tangent points.
         else:
             # Some circles are inside each other or an error has occurred.

--- a/src/Mod/Draft/DraftGeomUtils.py
+++ b/src/Mod/Draft/DraftGeomUtils.py
@@ -1227,7 +1227,7 @@ def offsetWire(wire,dvec,bind=False,occ=False,widthList=None, offsetMode=None, a
     elif isinstance(wire, list):
         if isinstance(wire[0],Part.Edge):
             edges = wire.copy()
-            wire = Part.Wire( Part.__sortEdges__(edges) )			# How to avoid __sortEdges__ again?  Make getNormal direclty tackle edges ?
+            wire = Part.Wire( Part.__sortEdges__(edges) )			# How to avoid __sortEdges__ again?  Make getNormal directly tackle edges ?
     else:
         print ("Either Part.Wire or Part.Edges should be provided, returning None ")
         return None
@@ -1346,7 +1346,7 @@ def offsetWire(wire,dvec,bind=False,occ=False,widthList=None, offsetMode=None, a
         if i == 0:
             if alignListC[0] == 'Center':
                 delta = DraftVecUtils.scaleTo(delta, delta.Length/2)
-            #No need to do anything for 'Left' and 'Rigtht' as orginal dvec have set both the direction and amount of offset correct
+            #No need to do anything for 'Left' and 'Rigtht' as original dvec have set both the direction and amount of offset correct
             #elif alignListC[i] == 'Left':  #elif alignListC[i] == 'Right':
         if i != 0:
             try:
@@ -1385,7 +1385,7 @@ def offsetWire(wire,dvec,bind=False,occ=False,widthList=None, offsetMode=None, a
                     delta = DraftVecUtils.scaleTo(delta, delta.Length+basewireOffset)
                 nedge = offset(curredge,delta,trim=True)
 
-            if curOrientation == "Reversed": # TODO arc alway in counter-clockwise directinon ... ( not necessarily 'reversed')
+            if curOrientation == "Reversed": # TODO arc always in counter-clockwise directinon ... ( not necessarily 'reversed')
                 if not isinstance(curredge.Curve,Part.Circle):  # need to test against Part.Circle, not Part.ArcOfCircle
                     # if not arc/circle, assume straight line, reverse it
                     nedge = Part.Edge(nedge.Vertexes[1],nedge.Vertexes[0])

--- a/src/Mod/Draft/DraftSnap.py
+++ b/src/Mod/Draft/DraftSnap.py
@@ -667,7 +667,7 @@ class Snapper:
         return point
 
     def snapToEndpoints(self,shape):
-        "returns a list of enpoints snap locations"
+        "returns a list of endpoints snap locations"
         snaps = []
         if self.isEnabled("endpoint"):
             if hasattr(shape,"Vertexes"):

--- a/src/Mod/Draft/Resources/icons/Draft_Join.svg
+++ b/src/Mod/Draft/Resources/icons/Draft_Join.svg
@@ -385,7 +385,7 @@
             <rdf:li>arrows</rdf:li>
           </rdf:Bag>
         </dc:subject>
-        <dc:description>A line. Two arrows placed in the middle of the line, pointing at each othe.</dc:description>
+        <dc:description>A line. Two arrows placed in the middle of the line, pointing at each other.</dc:description>
       </cc:Work>
     </rdf:RDF>
   </metadata>

--- a/src/Mod/Draft/drafttests/test_creation.py
+++ b/src/Mod/Draft/drafttests/test_creation.py
@@ -181,7 +181,7 @@ class DraftCreation(unittest.TestCase):
         """Create a linear dimension."""
         operation = "Draft Dimension"
         _msg("  Test '{}'".format(operation))
-        _msg("  Occasionaly crashes")
+        _msg("  Occasionally crashes")
         a = Vector(0, 0, 0)
         b = Vector(9, 0, 0)
         c = Vector(4, -1, 0)
@@ -296,7 +296,7 @@ class DraftCreation(unittest.TestCase):
         """Create a label."""
         operation = "Draft Label"
         _msg("  Test '{}'".format(operation))
-        _msg("  Occasionaly crashes")
+        _msg("  Occasionally crashes")
         target_point = Vector(0, 0, 0)
         distance = -25
         placement = App.Placement(Vector(50, 50, 0), App.Rotation())

--- a/src/Mod/Draft/draftutils/init_tools.py
+++ b/src/Mod/Draft/draftutils/init_tools.py
@@ -1,7 +1,7 @@
 """Provides lists of commands for the Draft Workbench.
 
 This module returns lists of commands, so that the toolbars
-can be initilized by Draft, and by other workbenches.
+can be initialized by Draft, and by other workbenches.
 These commands should be defined in `DraftTools`, and in the individual
 modules in `draftguitools`.
 """

--- a/src/Mod/Draft/draftutils/utils.py
+++ b/src/Mod/Draft/draftutils/utils.py
@@ -196,7 +196,7 @@ getParamType = get_param_type
 
 
 def get_param(param, default=None):
-    """Return a paramater value from the current parameter database.
+    """Return a parameter value from the current parameter database.
 
     The parameter database is located in the tree
     ::
@@ -318,7 +318,7 @@ setParam = set_param
 
 
 def precision():
-    """Return the precision value from the paramater database.
+    """Return the precision value from the parameter database.
 
     It is the number of decimal places that a float will have.
     Example
@@ -378,7 +378,7 @@ def epsilon():
 def get_real_name(name):
     """Strip the trailing numbers from a string to get only the letters.
 
-    Paramaters
+    Parameters
     ----------
     name : str
         A string that may have a number at the end, `Line001`.
@@ -402,7 +402,7 @@ getRealName = get_real_name
 def get_type(obj):
     """Return a string indicating the type of the given object.
 
-    Paramaters
+    Parameters
     ----------
     obj : App::DocumentObject
         Any type of scripted object created with Draft,

--- a/src/Mod/Draft/importDXF.py
+++ b/src/Mod/Draft/importDXF.py
@@ -3941,7 +3941,7 @@ def getViewBlock(geom, view, blockcount):
     If the global variable `dxfExportBlocks` exists, it will create
     the appropriate strings for `BLOCK` and `INSERT` sections,
     and increment the `blockcount`.
-    Otherwise, it will just creaate an insert by changing the layer,
+    Otherwise, it will just create an insert by changing the layer,
     and setting a handle.
 
     Parameters
@@ -4020,7 +4020,7 @@ def getViewDXF(view, blocks=True):
     and if the global variable `dxfExportBlocks` exists, it will create
     the appropriate strings for `BLOCK` and `INSERT` sections,
     and increment the `blockcount`.
-    Otherwise, it will just creaate an insert by changing the layer,
+    Otherwise, it will just create an insert by changing the layer,
     and setting a handle
 
     Parameters

--- a/src/Mod/Draft/importDXF.py
+++ b/src/Mod/Draft/importDXF.py
@@ -83,7 +83,7 @@ dxfColorMap = None
 dxfLibrary = None
 
 # Save the native open function to avoid collisions
-# with the function declated here
+# with the function declared here
 if open.__module__ in ['__builtin__', 'io']:
     pythonopen = open
 

--- a/src/Mod/Fem/Gui/ViewProviderFemPostFunction.h
+++ b/src/Mod/Fem/Gui/ViewProviderFemPostFunction.h
@@ -111,7 +111,7 @@ public:
     std::vector<std::string> getDisplayModes() const;
 
     //creates the widget used in the task dalogs, either for the function itself or for
-    //the fiter using it
+    //the filter using it
     virtual FunctionWidget* createControlWidget() {return NULL;}
 
 protected:

--- a/src/Mod/Fem/femexamples/constraint_contact_solid_solid.py
+++ b/src/Mod/Fem/femexamples/constraint_contact_solid_solid.py
@@ -22,7 +22,7 @@
 # ***************************************************************************
 
 
-# connstraint contact for solid to solid mesh
+# constraint contact for solid to solid mesh
 # https://forum.freecadweb.org/viewtopic.php?f=18&t=20276
 # to run the example use:
 """

--- a/src/Mod/Fem/femexamples/constraint_tie.py
+++ b/src/Mod/Fem/femexamples/constraint_tie.py
@@ -22,7 +22,7 @@
 # ***************************************************************************
 
 
-# connstraint tie, bond tow surfaces together (solid mesh only)
+# constraint tie, bond two surfaces together (solid mesh only)
 # https://forum.freecadweb.org/viewtopic.php?f=18&t=42783
 # to run the example use:
 """

--- a/src/Mod/Fem/femmesh/meshtools.py
+++ b/src/Mod/Fem/femmesh/meshtools.py
@@ -1349,7 +1349,7 @@ def get_ref_facenodes_areas(
             node_area_table.append((face_table[mf][5], middle_node_area))
 
         elif femmesh_facetype == 8:  # 8 node femmesh face quad
-            # corner_node_area = -mesh_face_area / 12.0  (negativ!)
+            # corner_node_area = -mesh_face_area / 12.0  (negative!)
             # mid-side nodes = mesh_face_area / 3.0
             #  P4_________P7________P3
             #    |      / |  \      |

--- a/src/Mod/Fem/femsolver/calculix/writer.py
+++ b/src/Mod/Fem/femsolver/calculix/writer.py
@@ -1160,7 +1160,7 @@ class FemInputWriterCcx(writerbase.FemInputWriter):
             f.write("*DLOAD\n")
             for ref_shape in femobj["PressureFaces"]:
                 # the loop is needed for compatibility reason
-                # in depretiated method get_pressure_obj_faces_depreciated
+                # in depreciated method get_pressure_obj_faces_depreciated
                 # the face ids where per ref_shape
                 f.write("** " + ref_shape[0] + "\n")
                 for face, fno in ref_shape[1]:

--- a/src/Mod/Fem/femtools/femutils.py
+++ b/src/Mod/Fem/femtools/femutils.py
@@ -120,7 +120,7 @@ def is_derived_from(obj, t):
 def get_pref_working_dir(solver_obj):
     """ Return working directory for solver honoring user settings.
 
-    :throws femtools.erros.MustSaveError:
+    :throws femtools.errors.MustSaveError:
      If user setting is set to BESIDE and the document isn't saved.
 
     :note:

--- a/src/Mod/Part/App/AttachEnginePy.xml
+++ b/src/Mod/Part/App/AttachEnginePy.xml
@@ -14,7 +14,7 @@
     <Documentation>
       <Author Licence="LGPL" Name="DeepSOIC" EMail="vv.titov@gmail.com" />
       <DeveloperDocu>AttachEngine abstract class</DeveloperDocu>
-      <UserDocu>AttachEngine abstract class - the functinality of AttachableObject, but outside of DocumentObject</UserDocu>
+      <UserDocu>AttachEngine abstract class - the functionality of AttachableObject, but outside of DocumentObject</UserDocu>
     </Documentation>
     <Attribute Name="AttacherType" ReadOnly="true">
       <Documentation>

--- a/src/Mod/Part/CompoundTools/CompoundFilter.py
+++ b/src/Mod/Part/CompoundTools/CompoundFilter.py
@@ -207,7 +207,7 @@ class _ViewProviderCompoundFilter:
         if not self.ViewObject.DontUnhideOnDelete:
             try:
                 if self.Object.Base:
-                    # the base object migt be deleted be the user
+                    # the base object might be deleted be the user
                     # https://forum.freecadweb.org/viewtopic.php?f=3&t=42242
                     self.Object.Base.ViewObject.show()
                 if self.Object.Stencil:

--- a/src/Mod/PartDesign/App/ShapeBinder.cpp
+++ b/src/Mod/PartDesign/App/ShapeBinder.cpp
@@ -507,7 +507,7 @@ void SubShapeBinder::update(SubShapeBinder::UpdateOption options) {
         Shape.setValue(result);
     }
 
-    // collect transformation matrix cache entires
+    // collect transformation matrix cache entries
     std::unordered_set<std::string> caches;
     for(const auto &name : getDynamicPropertyNames()) {
         if(boost::starts_with(name,"Cache_"))

--- a/src/Mod/PartDesign/Gui/TaskDressUpParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskDressUpParameters.cpp
@@ -173,7 +173,7 @@ void TaskDressUpParameters::doubleClicked(QListWidgetItem* item) {
 
     // assure the fillets are shown
     showObject();
-    // remove any highlights andd selections
+    // remove any highlights and selections
     DressUpView->highlightReferences(false);
     Gui::Selection().clearSelection();
 

--- a/src/Mod/PartDesign/Gui/TaskSketchBasedParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskSketchBasedParameters.h
@@ -55,7 +55,7 @@ protected:
     void exitSelectionMode();
     QVariant setUpToFace(const QString& text);
     /// Try to find the name of a feature with the given label.
-    /// For faster access a suggeted name can be tested, first.
+    /// For faster access a suggested name can be tested, first.
     QVariant objectNameByLabel(const QString& label, const QVariant& suggest) const;
 
     static QString getFaceReference(const QString& obj, const QString& sub);

--- a/src/Mod/Path/Gui/Resources/panels/PathEdit.ui
+++ b/src/Mod/Path/Gui/Resources/panels/PathEdit.ui
@@ -1331,7 +1331,7 @@
               </sizepolicy>
              </property>
              <property name="toolTip">
-              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Rapid vertical speed assigne to VertRapid of new ToolController.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Rapid vertical speed assigned to VertRapid of new ToolController.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
              </property>
             </widget>
            </item>

--- a/src/Mod/Path/Gui/Resources/panels/SetupGlobal.ui
+++ b/src/Mod/Path/Gui/Resources/panels/SetupGlobal.ui
@@ -208,7 +208,7 @@
              </sizepolicy>
             </property>
             <property name="toolTip">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Rapid vertical speed assigne to VertRapid of new ToolController.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Rapid vertical speed assigned to VertRapid of new ToolController.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
            </widget>
           </item>

--- a/src/Mod/Path/Gui/Resources/panels/ToolBitLibraryEdit.ui
+++ b/src/Mod/Path/Gui/Resources/panels/ToolBitLibraryEdit.ui
@@ -198,7 +198,7 @@
          <item>
           <widget class="QPushButton" name="toolEnumerate">
            <property name="toolTip">
-            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Assigne numbers to each Tool Bit according to its current position in the library. The first Tool Bit is assigned the ID 1.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Assigned numbers to each Tool Bit according to its current position in the library. The first Tool Bit is assigned the ID 1.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="text">
             <string>Enumerate</string>

--- a/src/Mod/Path/PathScripts/PathDressupHoldingTags.py
+++ b/src/Mod/Path/PathScripts/PathDressupHoldingTags.py
@@ -939,7 +939,7 @@ class ObjectTagDressup:
                 PathLog.debug("previousTag = %d [%s]" % (i, prev))
             else:
                 disabled.append(i)
-            tag.nr = i  # assigne final nr
+            tag.nr = i  # assign final nr
             tags.append(tag)
             positions.append(tag.originAt(self.pathData.minZ))
         return (tags, positions, disabled)

--- a/src/Mod/Path/PathScripts/PathDressupPathBoundary.py
+++ b/src/Mod/Path/PathScripts/PathDressupPathBoundary.py
@@ -163,7 +163,7 @@ class DressupPathBoundary(object):
                                     flip = PathGeom.pointsCoincide(pos, ptL)
                                     newPos = e.valueAt(e.FirstParameter) if flip else ptL
                                     # outside edges are never taken at this point (see swap of
-                                    # inside/oustide above) - so just move along ...
+                                    # inside/outside above) - so just move along ...
                                     outside.remove(e)
                                     pos = newPos
                                 else:

--- a/src/Mod/Path/PathScripts/PathOpTools.py
+++ b/src/Mod/Path/PathScripts/PathOpTools.py
@@ -212,7 +212,7 @@ def offsetWire(wire, base, offset, forward):
     # Of the remaining edges we take the longest wire to be the engraving side
     # Looking for a circle with the start vertex as center marks and end
     #  starting from there follow the edges until a circle with the end vertex as center is found
-    #  if the traversed edges include any oof the remainig from above, all those edges are remaining
+    #  if the traversed edges include any of the remaining from above, all those edges are remaining
     #  this is to also include edges which might partially be inside shape
     #  if they need to be discarded, split, that should happen in a post process
     # Depending on the Axis of the circle, and which side remains we know if the wire needs to be flipped

--- a/src/Mod/Path/PathScripts/PathUtil.py
+++ b/src/Mod/Path/PathScripts/PathUtil.py
@@ -64,7 +64,7 @@ def getProperty(obj, prop):
     return attr
 
 def getPropertyValueString(obj, prop):
-    '''getPropertyValueString(obj, prop) ... answer a string represntation of an object's property's value.'''
+    '''getPropertyValueString(obj, prop) ... answer a string representation of an object's property's value.'''
     attr = getProperty(obj, prop)
     if hasattr(attr, 'UserString'):
         return attr.UserString

--- a/src/Mod/Path/PathScripts/PathUtils.py
+++ b/src/Mod/Path/PathScripts/PathUtils.py
@@ -21,7 +21,7 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-'''PathUtils -common functions used in PathScripts for filterig, sorting, and generating gcode toolpath data '''
+'''PathUtils -common functions used in PathScripts for filtering, sorting, and generating gcode toolpath data '''
 import FreeCAD
 import Part
 import Path

--- a/src/Mod/Sketcher/App/Sketch.h
+++ b/src/Mod/Sketcher/App/Sketch.h
@@ -365,7 +365,7 @@ public:
         Line    = 2, // 2 Points(start,end), 4 Parameters(x1,y1,x2,y2)
         Arc     = 3, // 3 Points(start,end,mid), (4)+5 Parameters((x1,y1,x2,y2),x,y,r,a1,a2)
         Circle  = 4, // 1 Point(mid), 3 Parameters(x,y,r)
-        Ellipse = 5,  // 1 Point(mid), 5 Parameters(x,y,r1,r2,phi)  phi=angle xaxis of elipse with respect of sketch xaxis
+        Ellipse = 5,  // 1 Point(mid), 5 Parameters(x,y,r1,r2,phi)  phi=angle xaxis of ellipse with respect of sketch xaxis
         ArcOfEllipse = 6,
         ArcOfHyperbola = 7,
         ArcOfParabola = 8,

--- a/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp
+++ b/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp
@@ -6637,10 +6637,10 @@ namespace SketcherGui {
                         this->notAllowedReason = QT_TR_NOOP("This object is in another document.");
                         break;
                     case Sketcher::SketchObject::rlOtherBody:
-                        this->notAllowedReason = QT_TR_NOOP("This object belongs to another body. Hold Ctrl to allow crossreferences.");
+                        this->notAllowedReason = QT_TR_NOOP("This object belongs to another body. Hold Ctrl to allow cross-references.");
                         break;
                     case Sketcher::SketchObject::rlOtherBodyWithLinks:
-                        this->notAllowedReason = QT_TR_NOOP("This object belongs to another body and it contains external geometry. Crossreference not allowed.");
+                        this->notAllowedReason = QT_TR_NOOP("This object belongs to another body and it contains external geometry. Cross-reference not allowed.");
                         break;
                     case Sketcher::SketchObject::rlOtherPart:
                         this->notAllowedReason = QT_TR_NOOP("This object belongs to another part.");

--- a/src/Mod/Surface/App/FeatureGeomFillSurface.cpp
+++ b/src/Mod/Surface/App/FeatureGeomFillSurface.cpp
@@ -116,7 +116,7 @@ void ShapeValidator::checkAndAdd(const Part::TopoShape &ts, const char *subName,
             checkAndAdd(ts.getShape(), aWD);
         }
     }
-    catch (Standard_Failure&) { // any OCC exception means an unappropriate shape in the selection
+    catch (Standard_Failure&) { // any OCC exception means an inappropriate shape in the selection
         Standard_Failure::Raise("Wrong shape type.\n");
     }
 }

--- a/src/Mod/TechDraw/App/DrawProjGroupItem.h
+++ b/src/Mod/TechDraw/App/DrawProjGroupItem.h
@@ -56,7 +56,7 @@ public:
     virtual ~DrawProjGroupItem();
 
     App::PropertyEnumeration Type;
-    App::PropertyVector      RotationVector;    //this is superceded by dvp xdirection
+    App::PropertyVector      RotationVector;    //this is superseded by dvp xdirection
 
     short mustExecute() const override;
     virtual void onDocumentRestored() override;

--- a/src/Mod/TechDraw/Gui/DlgPrefsTechDraw5.ui
+++ b/src/Mod/TechDraw/Gui/DlgPrefsTechDraw5.ui
@@ -135,7 +135,7 @@
            <enum>Qt::NoFocus</enum>
           </property>
           <property name="toolTip">
-           <string>Show Hard and Outline Edges (alway shown)</string>
+           <string>Show Hard and Outline Edges (always shown)</string>
           </property>
           <property name="text">
            <string>Show Hard Lines</string>

--- a/src/Mod/TechDraw/Gui/TaskWeldingSymbol.cpp
+++ b/src/Mod/TechDraw/Gui/TaskWeldingSymbol.cpp
@@ -86,7 +86,7 @@ TaskWeldingSymbol::TaskWeldingSymbol(TechDraw::DrawLeaderLine* leader) :
     m_arrowDirty(false),
     m_otherDirty(false)
 {
-//TODO: why does DWS nedd DLL as parent?
+//TODO: why does DWS need DLL as parent?
 //    Base::Console().Message("TWS::TWS() - create mode\n");
     if  (m_leadFeat == nullptr)  {
         //should be caught in CMD caller

--- a/src/Mod/TechDraw/Gui/ViewProviderPage.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderPage.cpp
@@ -463,7 +463,7 @@ void ViewProviderPage::setGraphicsView(QGVPage* gv)
 
 bool ViewProviderPage::canDelete(App::DocumentObject *obj) const
 {
-    // deletions from a page don't necesarily destroy anything
+    // deletions from a page don't necessarily destroy anything
     // thus we can pass this action
     // if an object could break something, like e.g. the template object
     // its ViewProvider handles this in the onDelete() function

--- a/src/Mod/TechDraw/Gui/ViewProviderProjGroup.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderProjGroup.cpp
@@ -217,7 +217,7 @@ bool ViewProviderProjGroup::onDelete(const std::vector<std::string> &)
 
 bool ViewProviderProjGroup::canDelete(App::DocumentObject *obj) const
 {
-    // deletions of views from a ProjGroup don't necesarily destroy anything
+    // deletions of views from a ProjGroup don't necessarily destroy anything
     // thus we can pass this action
     // we can warn the user if necessary in the object's ViewProvider in the onDelete() function
     Q_UNUSED(obj)

--- a/src/Mod/TechDraw/Gui/ViewProviderProjGroupItem.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderProjGroupItem.cpp
@@ -212,7 +212,7 @@ bool ViewProviderProjGroupItem::onDelete(const std::vector<std::string> &)
 
 bool ViewProviderProjGroupItem::canDelete(App::DocumentObject *obj) const
 {
-    // deletions of objects from a ProjGroupItem don't necesarily destroy anything
+    // deletions of objects from a ProjGroupItem don't necessarily destroy anything
     // thus we can pass this action
     // we can warn the user if necessary in the object's ViewProvider in the onDelete() function
     Q_UNUSED(obj)


### PR DESCRIPTION
Found via  
```
codespell -q 3 -L aci,ake,aline,alle,alledges,alocation,als,ang,anid,ba,beginn,behaviour,bloaded,byteorder,calculater,cancelled,cancelling,cas,cascade,centimetre,childs,colour,colours,commen,connexion,currenty,dof,doubleclick,dum,eiter,elemente,ende,feld,finde,findf,freez,hist,iff,indicies,initialisation,initialise,initialised,initialises,initialisiert,ist,kilometre,lod,mantatory,methode,metres,millimetre,modell,nd,noe,normale,normaly,nto,numer,oder,orgin,orginx,orginy,ot,pard,pres,programm,que,recurrance,rougly,seperator,serie,sinc,strack,substraction,te,thist,thru,tread,uint,unter,vertexes,wallthickness,whitespaces -S ./.git,*.po,*.ts,./ChangeLog.txt,./src/3rdParty,./src/Mod/Assembly/App/opendcm,./src/CXX,./src/zipios++,./src/Base/swig*,./src/Mod/Robot/App/kdl_cp,./src/Mod/Import/App/SCL,./src/WindowsInstaller,./src/Doc/FreeCAD.uml
```