### PR TITLE
Part: GeometryExtensions

### DIFF
--- a/src/Mod/Part/App/Geometry.cpp
+++ b/src/Mod/Part/App/Geometry.cpp
@@ -316,6 +316,7 @@ void Geometry::setExtension(std::unique_ptr<GeometryExtension> && geo)
             ext->getName() == geo->getName()){
             ext = std::move(geo);
             hasext = true;
+            break;
         }
     }
 


### PR DESCRIPTION
========================

fixes #4087

Missing "break" in loop after finding the extension was causing segfault because of null pointer access, as the unique pointer had been std:move-d when found and was thus no longer valid.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [x] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
