### PR TITLE
Draft - enable toggle grid command in edit mode

### DIFF
--- a/src/Mod/Draft/DraftTools.py
+++ b/src/Mod/Draft/DraftTools.py
@@ -4906,7 +4906,8 @@ class ToggleGrid():
         return {'Pixmap'  : 'Draft_Grid',
                 'Accel' : "G,R",
                 'MenuText': QtCore.QT_TRANSLATE_NOOP("Draft_ToggleGrid", "Toggle Grid"),
-                'ToolTip' : QtCore.QT_TRANSLATE_NOOP("Draft_ToggleGrid", "Toggles the Draft grid on/off")}
+                'ToolTip' : QtCore.QT_TRANSLATE_NOOP("Draft_ToggleGrid", "Toggles the Draft grid on/off"),
+                'CmdType' : 'ForEdit'}
 
     def Activated(self):
         if hasattr(FreeCADGui,"Snapper"):


### PR DESCRIPTION
Some people would like to have more control over draft grid visibility  while in Sketcher edit mode.  Hence this PR enables the usage of Draft ToggleGrid  command in Sketcher edit mode.

Forum discussion:
https://forum.freecadweb.org/viewtopic.php?f=34&t=43265&start=20#p374747