### PR TITLE
Add collection tab to About FreeCAD

### DIFF
--- a/src/Gui/Splashscreen.cpp
+++ b/src/Gui/Splashscreen.cpp
@@ -268,6 +268,7 @@ AboutDialog::AboutDialog(bool showLic, QWidget* parent)
     ui->tabWidget->setCurrentIndex(0); // always start on the About tab
     setupLabels();
     showLicenseInformation();
+    showCollectionInformation();
 }
 
 /**
@@ -693,6 +694,24 @@ void AboutDialog::showLicenseInformation()
     textField->setHtml(html);
 
     connect(textField, SIGNAL(anchorClicked(QUrl)), this, SLOT(linkActivated(QUrl)));
+}
+
+void AboutDialog::showCollectionInformation()
+{
+    QString doc = QString::fromUtf8(App::Application::getHelpDir().c_str());
+    QString path = doc + QLatin1String("Collection.html");
+    if (!QFile::exists(path))
+    {
+      return;
+    }
+    QWidget *tab_collection = new QWidget();
+    tab_collection->setObjectName(QString::fromLatin1("tab_collection"));
+    ui->tabWidget->addTab(tab_collection, tr("Collection"));
+    QVBoxLayout* hlayout = new QVBoxLayout(tab_collection);
+    QTextBrowser* textField = new QTextBrowser(tab_collection);
+    textField->setOpenExternalLinks(true);
+    hlayout->addWidget(textField);
+    textField->setSource(path);
 }
 
 void AboutDialog::linkActivated(const QUrl& link)

--- a/src/Gui/Splashscreen.h
+++ b/src/Gui/Splashscreen.h
@@ -102,6 +102,7 @@ public:
 protected:
     void setupLabels();
     void showLicenseInformation();
+    void showCollectionInformation();
 
 protected Q_SLOTS:
     virtual void on_copyButton_clicked();


### PR DESCRIPTION
People doing packaging expressed the desire, for being able to add a bit of an additional information, about the software used, such as:

https://github.com/FreeCAD/FreeCAD-AppImage/issues/31

This PR adds a collection tab to the About FreeCAD dialog. The tab is added only if an actual Collection.html file is provided.