### PR TITLE
App: fix missing transformation in Link::getTrueLinkedObject()

### DIFF
--- a/src/App/Link.cpp
+++ b/src/App/Link.cpp
@@ -718,7 +718,7 @@ DocumentObject *LinkBaseExtension::getTrueLinkedObject(
     if(!ret) return 0;
     bool transform = linkTransform();
     const char *subname = getSubName();
-    if(subname) {
+    if(subname || (mat && transform)) {
         ret = ret->getSubObject(subname,0,mat,transform,depth+1);
         transform = false;
     }


### PR DESCRIPTION
Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
