### PR TITLE
Draft: improvements in the make_functions to create objects

### DIFF
--- a/src/Mod/Draft/Draft.py
+++ b/src/Mod/Draft/Draft.py
@@ -714,7 +714,7 @@ def makeArray(baseobject,arg1,arg2,arg3,arg4=None,arg5=None,arg6=None,name="Arra
         _Array(obj)
     obj.Base = baseobject
     if arg6:
-        if isinstance(arg1, (int, float)):
+        if isinstance(arg1, (int, float, FreeCAD.Units.Quantity)):
             obj.ArrayType = "circular"
             obj.RadialDistance = arg1
             obj.TangentialDistance = arg2

--- a/src/Mod/Draft/draftobjects/circulararray.py
+++ b/src/Mod/Draft/draftobjects/circulararray.py
@@ -1,9 +1,3 @@
-"""This module provides the object code for Draft CircularArray.
-"""
-## @package circulararray
-# \ingroup DRAFT
-# \brief This module provides the object code for Draft CircularArray.
-
 # ***************************************************************************
 # *   (c) 2019 Eliud Cabrera Castillo <e.cabrera-castillo@tum.de>           *
 # *                                                                         *
@@ -26,20 +20,130 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
+"""Provides the object code for Draft CircularArray."""
+## @package circulararray
+# \ingroup DRAFT
+# \brief This module provides the object code for Draft CircularArray.
 
 import FreeCAD as App
 import Draft
+import draftutils.utils as utils
+from draftutils.messages import _msg, _err
+from draftutils.translate import _tr
 
 
 def make_circular_array(obj,
                         r_distance=100, tan_distance=100,
-                        axis=App.Vector(0, 0, 1), center=App.Vector(0, 0, 0),
                         number=2, symmetry=1,
-                        use_link=False):
+                        axis=App.Vector(0, 0, 1), center=App.Vector(0, 0, 0),
+                        use_link=True):
     """Create a circular array from the given object.
+
+    Parameters
+    ----------
+    obj: Part::Feature
+        Any type of object that has a `Part::TopoShape`
+        that can be duplicated.
+
+    r_distance: float, optional
+        It defaults to `100`.
+        Radial distance to the next ring of circular arrays.
+
+    tan_distance: float, optional
+        It defaults to `100`.
+        The tangential distance between two elements located
+        in the same circular ring.
+        The tangential distance together with the radial distance
+        determine how many copies are created.
+
+    number: int, optional
+        It defaults to 2.
+        The number of layers or rings of repeated objects.
+        The original object stays at the center, and is counted
+        as a layer itself. So, if you want at least one layer of circular
+        copies, this number must be at least 2.
+
+    symmetry: int, optional
+        It defaults to 1.
+        It indicates how many lines of symmetry the entire circular pattern
+        has. That is, with 1, the array is symmetric only after a full
+        360 degrees rotation.
+
+        When it is 2, the array is symmetric at 0 and 180 degrees.
+        When it is 3, the array is symmetric at 0, 120, and 240 degrees.
+        When it is 4, the array is symmetric at 0, 90, 180, and 270 degrees.
+        Et cetera.
+
+    axis: Base::Vector3, optional
+        It defaults to `App.Vector(0, 0, 1)` or the `+Z` axis.
+        The unit vector indicating the axis of rotation.
+
+    center: Base::Vector3, optional
+        It defaults to `App.Vector(0, 0, 0)` or the global origin.
+        The point through which the `axis` passes to define
+        the axis of rotation.
+
+    use_link: bool, optional
+        It defaults to `True`.
+        If it is `True` the produced copies are not `Part::TopoShape` copies,
+        but rather `App::Link` objects.
+        The Links repeat the shape of the original `obj` exactly,
+        and therefore the resulting array is more memory efficient.
+
+        Also, when `use_link` is `True`, the `Fuse` property
+        of the resulting array does not work; the array doesn't
+        contain separate shapes, it only has the original shape repeated
+        many times, so there is nothing to fuse together.
+
+        If `use_link` is `False` the original shape is copied many times.
+        In this case the `Fuse` property is able to fuse
+        all copies into a single object, if they touch each other.
+
+    Returns
+    -------
+    Part::FeaturePython
+        A scripted object with `Proxy.Type='Array'`.
+        Its `Shape` is a compound of the copies of the original object.
     """
-    obj = Draft.makeArray(obj,
-                          arg1=r_distance, arg2=tan_distance,
-                          arg3=axis, arg4=center, arg5=number, arg6=symmetry,
-                          use_link=use_link)
-    return obj
+    _name = "make_circular_array"
+    utils.print_header(_name, _tr("Circular array"))
+
+    _msg("r_distance: {}".format(r_distance))
+    _msg("tan_distance: {}".format(tan_distance))
+
+    try:
+        utils.type_check([(r_distance, (int, float, App.Units.Quantity)),
+                          (tan_distance, (int, float, App.Units.Quantity))],
+                         name=_name)
+    except TypeError:
+        _err(_tr("Wrong input: must be a number or quantity."))
+        return None
+
+    _msg("number: {}".format(number))
+    _msg("symmetry: {}".format(symmetry))
+
+    try:
+        utils.type_check([(number, int),
+                          (symmetry, int)], name=_name)
+    except TypeError:
+        _err(_tr("Wrong input: must be an integer number."))
+        return None
+
+    _msg("axis: {}".format(axis))
+    _msg("center: {}".format(center))
+
+    try:
+        utils.type_check([(axis, App.Vector),
+                          (center, App.Vector)], name=_name)
+    except TypeError:
+        _err(_tr("Wrong input: must be a vector."))
+        return None
+
+    _msg("use_link: {}".format(bool(use_link)))
+
+    new_obj = Draft.makeArray(obj,
+                              arg1=r_distance, arg2=tan_distance,
+                              arg3=axis, arg4=center,
+                              arg5=number, arg6=symmetry,
+                              use_link=use_link)
+    return new_obj

--- a/src/Mod/Draft/draftobjects/orthoarray.py
+++ b/src/Mod/Draft/draftobjects/orthoarray.py
@@ -1,8 +1,3 @@
-"""Provide the object code for Draft Array."""
-## @package orthoarray
-# \ingroup DRAFT
-# \brief Provide the object code for Draft Array.
-
 # ***************************************************************************
 # *   (c) 2020 Eliud Cabrera Castillo <e.cabrera-castillo@tum.de>           *
 # *                                                                         *
@@ -25,9 +20,16 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
+"""Provide the object code for Draft Array."""
+## @package orthoarray
+# \ingroup DRAFT
+# \brief Provide the object code for Draft Array.
 
 import FreeCAD as App
 import Draft
+import draftutils.utils as utils
+from draftutils.messages import _msg, _wrn, _err
+from draftutils.translate import _tr
 
 
 def make_ortho_array(obj,
@@ -37,24 +39,242 @@ def make_ortho_array(obj,
                      n_x=2,
                      n_y=2,
                      n_z=1,
-                     use_link=False):
-    """Create an orthogonal array from the given object."""
-    obj = Draft.makeArray(obj,
-                          arg1=v_x, arg2=v_y, arg3=v_z,
-                          arg4=n_x, arg5=n_y, arg6=n_z,
-                          use_link=use_link)
-    return obj
+                     use_link=True):
+    """Create an orthogonal array from the given object.
+
+    Parameters
+    ----------
+    obj: Part::Feature
+        Any type of object that has a `Part::TopoShape`
+        that can be duplicated.
+        This means most 2D and 3D objects produced
+        with any workbench.
+
+    v_x, v_y, v_z: Base::Vector3, optional
+        The vector indicating the vector displacement between two elements
+        in the specified orthogonal direction X, Y, Z.
+
+        By default:
+        ::
+            v_x = App.Vector(10, 0, 0)
+            v_y = App.Vector(0, 10, 0)
+            v_z = App.Vector(0, 0, 10)
+
+        Given that this is a vectorial displacement
+        the next object can appear displaced in one, two or three axes
+        at the same time.
+
+        For example
+        ::
+            v_x = App.Vector(10, 5, 0)
+
+        means that the next element in the X direction will be displaced
+        10 mm in X, 5 mm in Y, and 0 mm in Z.
+
+        A traditional "rectangular" array is obtained when
+        the displacement vector only has its corresponding component,
+        like in the default case.
+
+        If these values are entered as single numbers instead
+        of vectors, the single value is expanded into a vector
+        of the corresponding direction, and the other components are assumed
+        to be zero.
+
+        For example
+        ::
+            v_x = 15
+            v_y = 10
+            v_z = 1
+        becomes
+        ::
+            v_x = App.Vector(15, 0, 0)
+            v_y = App.Vector(0, 10, 0)
+            v_z = App.Vector(0, 0, 1)
+
+    n_x, n_y, n_z: int, optional
+        The number of copies in the specified orthogonal direction X, Y, Z.
+        This number includes the original object, therefore, it must be
+        at least 1.
+
+        The values of `n_x` and `n_y` default to 2,
+        while `n_z` defaults to 1.
+        This means the array by default is a planar array.
+
+    use_link: bool, optional
+        It defaults to `True`.
+        If it is `True` the produced copies are not `Part::TopoShape` copies,
+        but rather `App::Link` objects.
+        The Links repeat the shape of the original `obj` exactly,
+        and therefore the resulting array is more memory efficient.
+
+        Also, when `use_link` is `True`, the `Fuse` property
+        of the resulting array does not work; the array doesn't
+        contain separate shapes, it only has the original shape repeated
+        many times, so there is nothing to fuse together.
+
+        If `use_link` is `False` the original shape is copied many times.
+        In this case the `Fuse` property is able to fuse
+        all copies into a single object, if they touch each other.
+
+    Returns
+    -------
+    Part::FeaturePython
+        A scripted object with `Proxy.Type='Array'`.
+        Its `Shape` is a compound of the copies of the original object.
+
+    See Also
+    --------
+    make_ortho_array2d
+    """
+    _name = "make_ortho_array"
+    utils.print_header(_name, _tr("Orthogonal array"))
+
+    _msg("v_x: {}".format(v_x))
+    _msg("v_y: {}".format(v_y))
+    _msg("v_z: {}".format(v_z))
+
+    try:
+        utils.type_check([(v_x, (int, float, App.Vector)),
+                          (v_y, (int, float, App.Vector)),
+                          (v_z, (int, float, App.Vector))],
+                         name=_name)
+    except TypeError:
+        _err(_tr("Wrong input: must be a number or vector."))
+        return None
+
+    _text = "Input: single value expanded to vector."
+    if not isinstance(v_x, App.Vector):
+        v_x = App.Vector(v_x, 0, 0)
+        _wrn(_tr(_text))
+    if not isinstance(v_y, App.Vector):
+        v_y = App.Vector(0, v_y, 0)
+        _wrn(_tr(_text))
+    if not isinstance(v_z, App.Vector):
+        v_z = App.Vector(0, 0, v_z)
+        _wrn(_tr(_text))
+
+    _msg("n_x: {}".format(n_x))
+    _msg("n_y: {}".format(n_y))
+    _msg("n_z: {}".format(n_z))
+
+    try:
+        utils.type_check([(n_x, int),
+                          (n_y, int),
+                          (n_z, int)], name=_name)
+    except TypeError:
+        _err(_tr("Wrong input: must be an integer number."))
+        return None
+
+    _text = ("Input: number of elements must be at least 1. "
+             "It is set to 1.")
+    if n_x < 1:
+        _wrn(_tr(_text))
+        n_x = 1
+    if n_y < 1:
+        _wrn(_tr(_text))
+        n_y = 1
+    if n_z < 1:
+        _wrn(_tr(_text))
+        n_z = 1
+
+    _msg("use_link: {}".format(bool(use_link)))
+
+    new_obj = Draft.makeArray(obj,
+                              arg1=v_x, arg2=v_y, arg3=v_z,
+                              arg4=n_x, arg5=n_y, arg6=n_z,
+                              use_link=use_link)
+    return new_obj
 
 
-def make_ortho_array2(obj,
-                      v_x=App.Vector(10, 0, 0),
-                      v_y=App.Vector(0, 10, 0),
-                      n_x=2,
-                      n_y=2,
-                      use_link=False):
-    """Create a 2D orthogonal array from the given object."""
-    obj = Draft.makeArray(obj,
-                          arg1=v_x, arg2=v_y,
-                          arg3=n_x, arg4=n_y,
-                          use_link=use_link)
-    return obj
+def make_ortho_array2d(obj,
+                       v_x=App.Vector(10, 0, 0),
+                       v_y=App.Vector(0, 10, 0),
+                       n_x=2,
+                       n_y=2,
+                       use_link=True):
+    """Create a 2D orthogonal array from the given object.
+
+    This works the same as `make_ortho_array`.
+    The Z component is ignored so it only considers vector displacements
+    in X and Y directions.
+
+    Parameters
+    ----------
+    obj: Part::Feature
+        Any type of object that has a `Part::TopoShape`
+        that can be duplicated.
+        This means most 2D and 3D objects produced
+        with any workbench.
+
+    v_x, v_y: Base::Vector3, optional
+        Vectorial displacement of elements
+        in the corresponding X and Y directions.
+        See `make_ortho_array`.
+
+    n_x, n_y: int, optional
+        Number of elements
+        in the corresponding X and Y directions.
+        See `make_ortho_array`.
+
+    use_link: bool, optional
+        If it is `True`, create `App::Link` array.
+        See `make_ortho_array`.
+
+    Returns
+    -------
+    Part::FeaturePython
+        A scripted object with `Proxy.Type='Array'`.
+        Its `Shape` is a compound of the copies of the original object.
+
+    See Also
+    --------
+    make_ortho_array
+    """
+    _name = "make_ortho_array2d"
+    utils.print_header(_name, _tr("Orthogonal array 2D"))
+
+    _msg("v_x: {}".format(v_x))
+    _msg("v_y: {}".format(v_y))
+
+    try:
+        utils.type_check([(v_x, (int, float, App.Vector)),
+                          (v_y, (int, float, App.Vector))],
+                         name=_name)
+    except TypeError:
+        _err(_tr("Wrong input: must be a number or vector."))
+        return None
+
+    _text = "Input: single value expanded to vector."
+    if not isinstance(v_x, App.Vector):
+        v_x = App.Vector(v_x, 0, 0)
+        _wrn(_tr(_text))
+    if not isinstance(v_y, App.Vector):
+        v_y = App.Vector(0, v_y, 0)
+        _wrn(_tr(_text))
+
+    _msg("n_x: {}".format(n_x))
+    _msg("n_y: {}".format(n_y))
+
+    try:
+        utils.type_check([(n_x, int),
+                          (n_y, int)], name=_name)
+    except TypeError:
+        _err(_tr("Wrong input: must be an integer number."))
+        return None
+
+    _text = ("Input: number of elements must be at least 1. "
+             "It is set to 1.")
+    if n_x < 1:
+        _wrn(_tr(_text))
+        n_x = 1
+    if n_y < 1:
+        _wrn(_tr(_text))
+        n_y = 1
+
+    _msg("use_link: {}".format(bool(use_link)))
+
+    new_obj = Draft.makeArray(obj,
+                              arg1=v_x, arg2=v_y,
+                              arg3=n_x, arg4=n_y,
+                              use_link=use_link)
+    return new_obj

--- a/src/Mod/Draft/draftobjects/orthoarray.py
+++ b/src/Mod/Draft/draftobjects/orthoarray.py
@@ -124,7 +124,7 @@ def make_ortho_array(obj,
 
     See Also
     --------
-    make_ortho_array2d
+    make_ortho_array2d, make_rect_array, make_rect_array2d
     """
     _name = "make_ortho_array"
     utils.print_header(_name, _tr("Orthogonal array"))
@@ -228,7 +228,7 @@ def make_ortho_array2d(obj,
 
     See Also
     --------
-    make_ortho_array
+    make_ortho_array, make_rect_array, make_rect_array2d
     """
     _name = "make_ortho_array2d"
     utils.print_header(_name, _tr("Orthogonal array 2D"))
@@ -277,4 +277,138 @@ def make_ortho_array2d(obj,
                               arg1=v_x, arg2=v_y,
                               arg3=n_x, arg4=n_y,
                               use_link=use_link)
+    return new_obj
+
+
+def make_rect_array(obj,
+                    d_x=10,
+                    d_y=10,
+                    d_z=10,
+                    n_x=2,
+                    n_y=2,
+                    n_z=1,
+                    use_link=True):
+    """Create a rectangular array from the given object.
+
+    This function wraps around `make_ortho_array`
+    to produce strictly rectangular arrays, in which
+    the displacement vectors `v_x`, `v_y`, and `v_z`
+    only have their respective components in X, Y, and Z.
+
+    Parameters
+    ----------
+    obj: Part::Feature
+        Any type of object that has a `Part::TopoShape`
+        that can be duplicated.
+        This means most 2D and 3D objects produced
+        with any workbench.
+
+    d_x, d_y, d_z: Base::Vector3, optional
+        Displacement of elements in the corresponding X, Y, and Z directions.
+
+    n_x, n_y, n_z: int, optional
+        Number of elements in the corresponding X, Y, and Z directions.
+
+    use_link: bool, optional
+        If it is `True`, create `App::Link` array.
+        See `make_ortho_array`.
+
+    Returns
+    -------
+    Part::FeaturePython
+        A scripted object with `Proxy.Type='Array'`.
+        Its `Shape` is a compound of the copies of the original object.
+
+    See Also
+    --------
+    make_ortho_array, make_ortho_array2d, make_rect_array2d
+    """
+    _name = "make_rect_array"
+    utils.print_header(_name, _tr("Rectangular array"))
+
+    _msg("d_x: {}".format(d_x))
+    _msg("d_y: {}".format(d_y))
+    _msg("d_z: {}".format(d_z))
+
+    try:
+        utils.type_check([(d_x, (int, float)),
+                          (d_y, (int, float)),
+                          (d_z, (int, float))],
+                         name=_name)
+    except TypeError:
+        _err(_tr("Wrong input: must be a number."))
+        return None
+
+    new_obj = make_ortho_array(obj,
+                               v_x=App.Vector(d_x, 0, 0),
+                               v_y=App.Vector(0, d_y, 0),
+                               v_z=App.Vector(0, 0, d_z),
+                               n_x=n_x,
+                               n_y=n_y,
+                               n_z=n_z,
+                               use_link=use_link)
+    return new_obj
+
+
+def make_rect_array2d(obj,
+                      d_x=10,
+                      d_y=10,
+                      n_x=2,
+                      n_y=2,
+                      use_link=True):
+    """Create a 2D rectangular array from the given object.
+
+    This function wraps around `make_ortho_array2d`
+    to produce strictly rectangular arrays, in which
+    the displacement vectors `v_x` and `v_y`
+    only have their respective components in X and Y.
+
+    Parameters
+    ----------
+    obj: Part::Feature
+        Any type of object that has a `Part::TopoShape`
+        that can be duplicated.
+        This means most 2D and 3D objects produced
+        with any workbench.
+
+    d_x, d_y: Base::Vector3, optional
+        Displacement of elements in the corresponding X and Y directions.
+
+    n_x, n_y: int, optional
+        Number of elements in the corresponding X and Y directions.
+
+    use_link: bool, optional
+        If it is `True`, create `App::Link` array.
+        See `make_ortho_array`.
+
+    Returns
+    -------
+    Part::FeaturePython
+        A scripted object with `Proxy.Type='Array'`.
+        Its `Shape` is a compound of the copies of the original object.
+
+    See Also
+    --------
+    make_ortho_array, make_ortho_array2d, make_rect_array
+    """
+    _name = "make_rect_array2d"
+    utils.print_header(_name, _tr("Rectangular array 2D"))
+
+    _msg("d_x: {}".format(d_x))
+    _msg("d_y: {}".format(d_y))
+
+    try:
+        utils.type_check([(d_x, (int, float)),
+                          (d_y, (int, float))],
+                         name=_name)
+    except TypeError:
+        _err(_tr("Wrong input: must be a number."))
+        return None
+
+    new_obj = make_ortho_array2d(obj,
+                                 v_x=App.Vector(d_x, 0, 0),
+                                 v_y=App.Vector(0, d_y, 0),
+                                 n_x=n_x,
+                                 n_y=n_y,
+                                 use_link=use_link)
     return new_obj

--- a/src/Mod/Draft/draftobjects/polararray.py
+++ b/src/Mod/Draft/draftobjects/polararray.py
@@ -1,9 +1,3 @@
-"""This module provides the object code for Draft PolarArray.
-"""
-## @package polararray
-# \ingroup DRAFT
-# \brief This module provides the object code for Draft PolarArray.
-
 # ***************************************************************************
 # *   (c) 2019 Eliud Cabrera Castillo <e.cabrera-castillo@tum.de>           *
 # *                                                                         *
@@ -26,17 +20,93 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
+"""Provide the object code for Draft PolarArray."""
+## @package polararray
+# \ingroup DRAFT
+# \brief This module provides the object code for Draft PolarArray.
 
 import FreeCAD as App
 import Draft
+import draftutils.utils as utils
+from draftutils.messages import _msg, _err
+from draftutils.translate import _tr
 
 
 def make_polar_array(obj,
-                     center=App.Vector(0, 0, 0), angle=180, number=4,
-                     use_link=False):
+                     number=4, angle=360, center=App.Vector(0, 0, 0),
+                     use_link=True):
     """Create a polar array from the given object.
+
+    Parameters
+    ----------
+    obj: Part::Feature
+        Any type of object that has a `Part::TopoShape`
+        that can be duplicated.
+        This means most 2D and 3D objects produced
+        with any workbench.
+
+    number: int, optional
+        It defaults to 4.
+        The number of copies produced in the circular pattern.
+
+    angle: float, optional
+        It defaults to 360.
+        The magnitude in degrees swept by the polar pattern.
+
+    center: Base::Vector3, optional
+        It defaults to the origin `App.Vector(0, 0, 0)`.
+        The vector indicating the center of rotation of the array.
+
+    use_link: bool, optional
+        It defaults to `True`.
+        If it is `True` the produced copies are not `Part::TopoShape` copies,
+        but rather `App::Link` objects.
+        The Links repeat the shape of the original `obj` exactly,
+        and therefore the resulting array is more memory efficient.
+
+        Also, when `use_link` is `True`, the `Fuse` property
+        of the resulting array does not work; the array doesn't
+        contain separate shapes, it only has the original shape repeated
+        many times, so there is nothing to fuse together.
+
+        If `use_link` is `False` the original shape is copied many times.
+        In this case the `Fuse` property is able to fuse
+        all copies into a single object, if they touch each other.
+
+    Returns
+    -------
+    Part::FeaturePython
+        A scripted object with `Proxy.Type='Array'`.
+        Its `Shape` is a compound of the copies of the original object.
     """
-    obj = Draft.makeArray(obj,
-                          arg1=center, arg2=angle, arg3=number,
-                          use_link=use_link)
-    return obj
+    _name = "make_polar_array"
+    utils.print_header(_name, _tr("Polar array"))
+
+    _msg("Number: {}".format(number))
+    _msg("Angle: {}".format(angle))
+    _msg("Center: {}".format(center))
+
+    try:
+        utils.type_check([(number, int)], name=_name)
+    except TypeError:
+        _err(_tr("Wrong input: must be an integer number."))
+        return None
+
+    try:
+        utils.type_check([(angle, (int, float))], name=_name)
+    except TypeError:
+        _err(_tr("Wrong input: must be a number."))
+        return None
+
+    try:
+        utils.type_check([(center, App.Vector)], name=_name)
+    except TypeError:
+        _err(_tr("Wrong input: must be a vector."))
+        return None
+
+    _msg("use_link: {}".format(bool(use_link)))
+
+    new_obj = Draft.makeArray(obj,
+                              arg1=center, arg2=angle, arg3=number,
+                              use_link=use_link)
+    return new_obj

--- a/src/Mod/Draft/drafttests/test_modification.py
+++ b/src/Mod/Draft/drafttests/test_modification.py
@@ -433,9 +433,9 @@ class DraftModification(unittest.TestCase):
         _msg("  Array")
         _msg("  radial_distance={0}, "
              "tangential_distance={1}".format(rad_distance, tan_distance))
+        _msg("  number={0}, symmetry={1}".format(number, symmetry))
         _msg("  axis={}".format(axis))
         _msg("  center={}".format(center))
-        _msg("  number={0}, symmetry={1}".format(number, symmetry))
         obj = Draft.makeArray(rect,
                               rad_distance, tan_distance,
                               axis, center,

--- a/src/Mod/Draft/draftutils/utils.py
+++ b/src/Mod/Draft/draftutils/utils.py
@@ -38,7 +38,7 @@ from PySide import QtCore
 
 import FreeCAD
 import Draft_rc
-from draftutils.messages import _msg
+from draftutils.messages import _msg, _log
 from draftutils.translate import _tr
 
 App = FreeCAD
@@ -1019,3 +1019,29 @@ def utf8_decode(text):
         return text.decode("utf-8")
     except AttributeError:
         return text
+
+
+def print_header(name, description, debug=True):
+    """Print a line to the console when something is called, and log it.
+
+    Parameters
+    ----------
+    name: str
+        The name of the function or class that is being called.
+        This `name` will be logged in the log file, so if there are problems
+        the log file can be investigated for clues.
+
+    description: str
+        Arbitrary text that will be printed to the console
+        when the function or class is called.
+
+    debug: bool, optional
+        It defaults to `True`.
+        If it is `False` the `description` will not be printed
+        to the console.
+        On the other hand the `name` will always be logged.
+    """
+    _log(name)
+    if debug:
+        _msg(16 * "-")
+        _msg(description)


### PR DESCRIPTION
Various small improvements and cleanup of the new `make_` functions located in `draftobjects/`.

This includes arc by 3 points, circular array, orthogonal array, and polar array.

These functions are internally used by the corresponding GuiCommands in `draftguitools/`.

This has to be merged after #3082 because it assumes many things are already in place.

Forum thread: [[Discussion] Splitting Draft tools into their own modules](https://forum.freecadweb.org/viewtopic.php?f=23&t=38593&p=375838#p375838)

---

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists
