### PR TITLE
Draft: improvements in working plane and plane proxy creation

### DIFF
--- a/src/Mod/Draft/CMakeLists.txt
+++ b/src/Mod/Draft/CMakeLists.txt
@@ -95,6 +95,7 @@ SET(Draft_task_panels
     drafttaskpanels/task_orthoarray.py
     drafttaskpanels/task_polararray.py
     drafttaskpanels/task_scale.py
+    drafttaskpanels/task_selectplane.py
     drafttaskpanels/task_shapestring.py
     drafttaskpanels/README.md
 )

--- a/src/Mod/Draft/CMakeLists.txt
+++ b/src/Mod/Draft/CMakeLists.txt
@@ -80,6 +80,7 @@ SET(Draft_GUI_tools
     draftguitools/gui_circulararray.py
     draftguitools/gui_orthoarray.py
     draftguitools/gui_polararray.py
+    draftguitools/gui_planeproxy.py
     draftguitools/gui_selectplane.py
     draftguitools/gui_arrays.py
     draftguitools/gui_snaps.py

--- a/src/Mod/Draft/DraftTools.py
+++ b/src/Mod/Draft/DraftTools.py
@@ -76,6 +76,7 @@ if not hasattr(FreeCAD, "DraftWorkingPlane"):
 # ---------------------------------------------------------------------------
 import draftguitools.gui_edit
 import draftguitools.gui_selectplane
+import draftguitools.gui_planeproxy
 # import DraftFillet
 import drafttaskpanels.task_shapestring as task_shapestring
 import drafttaskpanels.task_scale as task_scale

--- a/src/Mod/Draft/Resources/Draft.qrc
+++ b/src/Mod/Draft/Resources/Draft.qrc
@@ -55,6 +55,7 @@
         <file>icons/Draft_Offset.svg</file>
         <file>icons/Draft_PathArray.svg</file>
         <file>icons/Draft_PathLinkArray.svg</file>
+        <file>icons/Draft_PlaneProxy.svg</file>
         <file>icons/Draft_Point.svg</file>
         <file>icons/Draft_PointArray.svg</file>
         <file>icons/Draft_PolarArray.svg</file>

--- a/src/Mod/Draft/Resources/icons/Draft_PlaneProxy.svg
+++ b/src/Mod/Draft/Resources/icons/Draft_PlaneProxy.svg
@@ -1,0 +1,436 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   version="1.1"
+   id="svg3612"
+   height="64px"
+   width="64px">
+  <defs
+     id="defs3614">
+    <linearGradient
+       id="linearGradient3809">
+      <stop
+         id="stop3811"
+         offset="0"
+         style="stop-color:#06989a;stop-opacity:1" />
+      <stop
+         id="stop3813"
+         offset="1"
+         style="stop-color:#34e0e2;stop-opacity:1" />
+    </linearGradient>
+    <radialGradient
+       r="34.345188"
+       fy="672.79736"
+       fx="225.26402"
+       cy="672.79736"
+       cx="225.26402"
+       gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3684"
+       xlink:href="#linearGradient3144-6" />
+    <linearGradient
+       id="linearGradient3144-6">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3146-9" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0"
+         id="stop3148-2" />
+    </linearGradient>
+    <radialGradient
+       r="34.345188"
+       fy="672.79736"
+       fx="225.26402"
+       cy="672.79736"
+       cx="225.26402"
+       gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3686"
+       xlink:href="#linearGradient3144-6" />
+    <linearGradient
+       id="linearGradient3701">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3703" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0"
+         id="stop3705" />
+    </linearGradient>
+    <radialGradient
+       r="34.345188"
+       fy="672.79736"
+       fx="225.26402"
+       cy="672.79736"
+       cx="225.26402"
+       gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3688"
+       xlink:href="#linearGradient3144-6" />
+    <linearGradient
+       id="linearGradient3708">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3710" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0"
+         id="stop3712" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#linearGradient3144-6"
+       id="radialGradient3723"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)"
+       cx="225.26402"
+       cy="672.79736"
+       fx="225.26402"
+       fy="672.79736"
+       r="34.345188" />
+    <linearGradient
+       y2="115.01974"
+       x2="654.80023"
+       y1="77.046234"
+       x1="696.67322"
+       gradientTransform="matrix(0.2210246,-0.5789261,-0.71699693,-0.35346705,519.98085,464.19243)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3934"
+       xlink:href="#linearGradient3864-0-0" />
+    <linearGradient
+       id="linearGradient3864-0-0">
+      <stop
+         style="stop-color:#0619c0;stop-opacity:1;"
+         offset="0"
+         id="stop3866-5-7" />
+      <stop
+         style="stop-color:#379cfb;stop-opacity:1;"
+         offset="1"
+         id="stop3868-7-6" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="30.27434"
+       x2="619.30328"
+       y1="44.024342"
+       x1="597.77283"
+       id="linearGradient3942"
+       xlink:href="#linearGradient3377" />
+    <linearGradient
+       id="linearGradient3377">
+      <stop
+         style="stop-color:#ffaa00;stop-opacity:1;"
+         offset="0"
+         id="stop3379" />
+      <stop
+         style="stop-color:#faff2b;stop-opacity:1;"
+         offset="1"
+         id="stop3381" />
+    </linearGradient>
+    <linearGradient
+       y2="139.40982"
+       x2="650.70459"
+       y1="77.046234"
+       x1="696.67322"
+       gradientTransform="matrix(0.2210246,-0.5789261,-0.71699693,-0.35346705,536.41251,472.3612)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3657"
+       xlink:href="#linearGradient3864-0" />
+    <linearGradient
+       id="linearGradient3864-0">
+      <stop
+         style="stop-color:#0619c0;stop-opacity:1;"
+         offset="0"
+         id="stop3866-5" />
+      <stop
+         style="stop-color:#379cfb;stop-opacity:1;"
+         offset="1"
+         id="stop3868-7" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="10"
+       x2="22"
+       y1="52"
+       x1="34"
+       id="linearGradient3815"
+       xlink:href="#linearGradient3791-6" />
+    <linearGradient
+       id="linearGradient6349">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop6351" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop6353" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3377-3">
+      <stop
+         style="stop-color:#0019a3;stop-opacity:1;"
+         offset="0"
+         id="stop3379-6" />
+      <stop
+         style="stop-color:#0069ff;stop-opacity:1;"
+         offset="1"
+         id="stop3381-7" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3377-3"
+       id="linearGradient3383"
+       x1="901.1875"
+       y1="1190.875"
+       x2="1267.9062"
+       y2="1190.875"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1,0,0,1,2199.356,0)" />
+    <radialGradient
+       xlink:href="#linearGradient6349"
+       id="radialGradient6355"
+       cx="1103.6399"
+       cy="1424.4465"
+       fx="1103.6399"
+       fy="1424.4465"
+       r="194.40614"
+       gradientTransform="matrix(-1.4307499,-1.3605156e-7,-1.202713e-8,0.1264801,2674.7488,1244.2826)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3791-6">
+      <stop
+         style="stop-color:#204a87;stop-opacity:1"
+         offset="0"
+         id="stop3793-7" />
+      <stop
+         style="stop-color:#729fcf;stop-opacity:1"
+         offset="1"
+         id="stop3795-5" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3791-6"
+       id="linearGradient3820"
+       x1="939.98767"
+       y1="1097.5122"
+       x2="893.2572"
+       y2="989.77716"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       y2="989.77716"
+       x2="893.2572"
+       y1="1097.5122"
+       x1="939.98767"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3834-6"
+       xlink:href="#linearGradient3791-6"
+       gradientTransform="matrix(1.251547,0,0,1.2214422,104.06364,54.837797)" />
+    <linearGradient
+       xlink:href="#linearGradient3791-6"
+       id="linearGradient911"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.17119448,0,0,0.16707656,-190.70037,-126.91093)"
+       x1="939.98767"
+       y1="1097.5122"
+       x2="893.2572"
+       y2="1049.63" />
+    <linearGradient
+       xlink:href="#linearGradient3791-6"
+       id="linearGradient926"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.251547,0,0,1.2214422,104.06352,186.42979)"
+       x1="939.98773"
+       y1="989.77716"
+       x2="893.2572"
+       y2="941.8949" />
+    <linearGradient
+       id="linearGradient3354">
+      <stop
+         style="stop-color:#2157c7;stop-opacity:1;"
+         offset="0"
+         id="stop3356" />
+      <stop
+         style="stop-color:#6daaff;stop-opacity:1;"
+         offset="1"
+         id="stop3358" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0,-1.4500001,1.4705882,0,-15.05882,91.45)"
+       y2="36.079998"
+       x2="21.689653"
+       y1="29.279999"
+       x1="56.172409"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3036"
+       xlink:href="#linearGradient3895" />
+    <linearGradient
+       id="linearGradient3895">
+      <stop
+         style="stop-color:#729fcf;stop-opacity:1;"
+         offset="0"
+         id="stop3897" />
+      <stop
+         style="stop-color:#204a87;stop-opacity:1;"
+         offset="1"
+         id="stop3899" />
+    </linearGradient>
+    <linearGradient
+       y2="36.079998"
+       x2="21.689653"
+       y1="29.279999"
+       x1="56.172409"
+       gradientTransform="matrix(0,-0.58000003,0.58823527,0,13.176471,38.379999)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3918-3"
+       xlink:href="#linearGradient3895" />
+    <linearGradient
+       y2="36.079998"
+       x2="21.689653"
+       y1="29.279999"
+       x1="56.172409"
+       gradientTransform="matrix(0.58000003,0,0,0.58823527,25.620001,13.176471)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3029-6"
+       xlink:href="#linearGradient3895" />
+    <linearGradient
+       xlink:href="#linearGradient3895"
+       id="linearGradient3154"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-0.58000003,0.58823527,0,-64.65713,39.527336)"
+       x1="45.482754"
+       y1="11.599999"
+       x2="-23.482759"
+       y2="52.400002" />
+    <linearGradient
+       xlink:href="#linearGradient3895"
+       id="linearGradient3156"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.58000003,0,0,0.58823527,-39.453602,14.323808)"
+       x1="31.689651"
+       y1="-2.0000007"
+       x2="-9.6896563"
+       y2="66" />
+    <linearGradient
+       xlink:href="#linearGradient3895"
+       id="linearGradient3158"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.58000003,0,0,0.58823527,-52.2136,14.323808)"
+       x1="-9.6896563"
+       y1="-2.0000007"
+       x2="31.689651"
+       y2="66" />
+    <linearGradient
+       xlink:href="#linearGradient3895"
+       id="linearGradient3160"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,0.58000003,0.58823527,0,-64.65713,26.767338)"
+       x1="-23.482759"
+       y1="11.599999"
+       x2="45.482754"
+       y2="52.400002" />
+    <linearGradient
+       xlink:href="#linearGradient3895"
+       id="linearGradient3936"
+       x1="20"
+       y1="12"
+       x2="44"
+       y2="52"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-77.833601,1.147337)" />
+  </defs>
+  <path
+     style="fill:url(#linearGradient3815);fill-opacity:1;stroke:#0b1521;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 35,3 9,16 v 45 h 4 L 51.020744,40.40543 51,3 Z"
+     id="path3305" />
+  <path
+     style="fill:#16d0d2;stroke:#0b1521;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 3,19 35,3"
+     id="path3190" />
+  <path
+     style="fill:none;stroke:#729fcf;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 35.5,5 11,17.2 V 59 h 1.5 L 49,39.2 V 5 Z"
+     id="path3305-1" />
+  <path
+     style="fill:#16d0d2;stroke:#0b1521;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 3,43 61,11"
+     id="path3190-7" />
+  <path
+     style="fill:#16d0d2;stroke:#0b1521;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 13,61 61,35"
+     id="path3190-9" />
+  <path
+     style="fill:#16d0d2;stroke:#0b1521;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 51,61 61,55"
+     id="path3190-1" />
+  <path
+     style="fill:#16d0d2;stroke:#0b1521;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 9,3 V 61"
+     id="path3224" />
+  <path
+     style="fill:#16d0d2;stroke:#0b1521;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 31,3 V 61"
+     id="path3224-4" />
+  <path
+     id="rect3170"
+     d="M 19,25 43,13 V 33 L 19,45 Z"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#0b1521;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+  <path
+     style="fill:#16d0d2;stroke:#0b1521;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 51,3 V 61"
+     id="path3224-7" />
+  <metadata
+     id="metadata5520">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+        <cc:license
+           rdf:resource="" />
+        <dc:date>Mon Oct 10 13:44:52 2011 +0000</dc:date>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>[wmayer]</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>FreeCAD LGPL2+</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>FreeCAD</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:identifier>FreeCAD/src/Mod/Draft/Resources/icons/Draft_PlaneProxy.svg</dc:identifier>
+        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title>[agryson] Alexander Gryson, vocx</dc:title>
+          </cc:Agent>
+        </dc:contributor>
+        <dc:subject>
+          <rdf:Bag>
+            <rdf:li>rectangle</rdf:li>
+            <rdf:li>grid</rdf:li>
+            <rdf:li>plane</rdf:li>
+          </rdf:Bag>
+        </dc:subject>
+        <dc:description>A rectangle sitting on a plane aligned to a grid that is going into the page from the left to the right; color variation</dc:description>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     transform="matrix(0.1378133,0,0,0.1378133,-299.23059,-137.20541)"
+     id="g4351" />
+</svg>

--- a/src/Mod/Draft/draftguitools/gui_planeproxy.py
+++ b/src/Mod/Draft/draftguitools/gui_planeproxy.py
@@ -1,0 +1,79 @@
+# ***************************************************************************
+# *   Copyright (c) 2019 Yorik van Havre <yorik@uncreated.net>              *
+# *                                                                         *
+# *   This program is free software; you can redistribute it and/or modify  *
+# *   it under the terms of the GNU Lesser General Public License (LGPL)    *
+# *   as published by the Free Software Foundation; either version 2 of     *
+# *   the License, or (at your option) any later version.                   *
+# *   for detail see the LICENCE text file.                                 *
+# *                                                                         *
+# *   This program is distributed in the hope that it will be useful,       *
+# *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+# *   GNU Library General Public License for more details.                  *
+# *                                                                         *
+# *   You should have received a copy of the GNU Library General Public     *
+# *   License along with this program; if not, write to the Free Software   *
+# *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
+# *   USA                                                                   *
+# *                                                                         *
+# ***************************************************************************
+"""Provides the Draft WorkingPlaneProxy tool."""
+## @package gui_planeproxy
+# \ingroup DRAFT
+# \brief This module provides the Draft WorkingPlaneProxy tool.
+
+from PySide.QtCore import QT_TRANSLATE_NOOP
+
+import FreeCAD as App
+import FreeCADGui as Gui
+import Draft_rc
+
+# The module is used to prevent complaints from code checkers (flake8)
+True if Draft_rc.__name__ else False
+
+__title__ = "FreeCAD Draft Workbench GUI Tools - Working plane-related tools"
+__author__ = ("Yorik van Havre, Werner Mayer, Martin Burbaum, Ken Cline, "
+              "Dmitry Chigrin")
+__url__ = "https://www.freecadweb.org"
+
+
+class Draft_WorkingPlaneProxy:
+    """The Draft_WorkingPlaneProxy command definition."""
+
+    def GetResources(self):
+        """Set icon, menu and tooltip."""
+        _menu = "Create working plane proxy"
+        _tip = ("Creates a proxy object from the current working plane.\n"
+                "Once the object is created double click it in the tree view "
+                "to restore the camera position and objects' visibilities.\n"
+                "Then you can use it to save a different camera position "
+                "and objects' states any time you need.")
+        d = {'Pixmap': 'Draft_PlaneProxy',
+             'MenuText': QT_TRANSLATE_NOOP("Draft_SetWorkingPlaneProxy",
+                                           _menu),
+             'ToolTip': QT_TRANSLATE_NOOP("Draft_SetWorkingPlaneProxy",
+                                          _tip)}
+        return d
+
+    def IsActive(self):
+        """Return True when this command should be available."""
+        if Gui.ActiveDocument:
+            return True
+        else:
+            return False
+
+    def Activated(self):
+        """Execute when the command is called."""
+        if hasattr(App, "DraftWorkingPlane"):
+            App.ActiveDocument.openTransaction("Create WP proxy")
+            Gui.addModule("Draft")
+            _cmd = "Draft.makeWorkingPlaneProxy("
+            _cmd += "FreeCAD.DraftWorkingPlane.getPlacement()"
+            _cmd += ")"
+            Gui.doCommand(_cmd)
+            App.ActiveDocument.commitTransaction()
+            App.ActiveDocument.recompute()
+
+
+Gui.addCommand('Draft_WorkingPlaneProxy', Draft_WorkingPlaneProxy())

--- a/src/Mod/Draft/draftguitools/gui_selectplane.py
+++ b/src/Mod/Draft/draftguitools/gui_selectplane.py
@@ -33,6 +33,7 @@ import FreeCADGui
 import Draft
 import Draft_rc
 import DraftVecUtils
+import drafttaskpanels.task_selectplane as task_selectplane
 from draftutils.todo import todo
 from draftutils.messages import _msg
 from draftutils.translate import translate
@@ -91,7 +92,7 @@ class Draft_SelectPlane:
 
         # Create task panel
         FreeCADGui.Control.closeDialog()
-        self.taskd = SelectPlane_TaskPanel()
+        self.taskd = task_selectplane.SelectPlaneTaskPanel()
 
         # Fill values
         self.taskd.form.checkCenter.setChecked(self.param.GetBool("CenterPlaneOnView", False))
@@ -491,17 +492,6 @@ class Draft_SelectPlane:
         p = FreeCAD.DraftWorkingPlane
         self.states.append([p.u, p.v, p.axis, p.position])
         FreeCADGui.doCommandGui("FreeCADGui.Snapper.setGrid()")
-
-
-class SelectPlane_TaskPanel:
-    """The task panel definition of the Draft_SelectPlane command."""
-
-    def __init__(self):
-        self.form = FreeCADGui.PySideUic.loadUi(":/ui/TaskSelectPlane.ui")
-
-    def getStandardButtons(self):
-        """Execute to set the standard buttons."""
-        return 2097152  # int(QtGui.QDialogButtonBox.Close)
 
 
 class Draft_SetWorkingPlaneProxy:

--- a/src/Mod/Draft/draftguitools/gui_selectplane.py
+++ b/src/Mod/Draft/draftguitools/gui_selectplane.py
@@ -494,44 +494,4 @@ class Draft_SelectPlane:
         FreeCADGui.doCommandGui("FreeCADGui.Snapper.setGrid()")
 
 
-class Draft_WorkingPlaneProxy:
-    """The Draft_WorkingPlaneProxy command definition."""
-
-    def GetResources(self):
-        """Set icon, menu and tooltip."""
-        _menu = "Create working plane proxy"
-        _tip = ("Creates a proxy object from the current working plane.\n"
-                "Once the object is created double click it in the tree view "
-                "to restore the camera position and objects' visibilities.\n"
-                "Then you can use it to save a different camera position "
-                "and objects' states any time you need.")
-        d = {'Pixmap': 'Draft_PlaneProxy',
-             'MenuText': QT_TRANSLATE_NOOP("Draft_SetWorkingPlaneProxy",
-                                           _menu),
-             'ToolTip': QT_TRANSLATE_NOOP("Draft_SetWorkingPlaneProxy",
-                                          _tip)}
-        return d
-
-    def IsActive(self):
-        """Return True when this command should be available."""
-        if FreeCADGui.ActiveDocument:
-            return True
-        else:
-            return False
-
-    def Activated(self):
-        """Execute when the command is called."""
-        if hasattr(FreeCAD, "DraftWorkingPlane"):
-            FreeCAD.ActiveDocument.openTransaction("Create WP proxy")
-            FreeCADGui.addModule("Draft")
-            _cmd = "Draft.makeWorkingPlaneProxy("
-            _cmd += "FreeCAD.DraftWorkingPlane.getPlacement()"
-            _cmd += ")"
-            FreeCADGui.doCommand(_cmd)
-            FreeCAD.ActiveDocument.commitTransaction()
-            FreeCAD.ActiveDocument.recompute()
-
-
 FreeCADGui.addCommand('Draft_SelectPlane', Draft_SelectPlane())
-FreeCADGui.addCommand('Draft_WorkingPlaneProxy',
-                      Draft_WorkingPlaneProxy())

--- a/src/Mod/Draft/draftguitools/gui_selectplane.py
+++ b/src/Mod/Draft/draftguitools/gui_selectplane.py
@@ -494,14 +494,18 @@ class Draft_SelectPlane:
         FreeCADGui.doCommandGui("FreeCADGui.Snapper.setGrid()")
 
 
-class Draft_SetWorkingPlaneProxy:
-    """The Draft_SetWorkingPlaneProxy FreeCAD command definition."""
+class Draft_WorkingPlaneProxy:
+    """The Draft_WorkingPlaneProxy command definition."""
 
     def GetResources(self):
         """Set icon, menu and tooltip."""
-        _menu = "Create Working Plane Proxy"
-        _tip = "Creates a proxy object from the current working plane"
-        d = {'Pixmap': 'Draft_SelectPlane',
+        _menu = "Create working plane proxy"
+        _tip = ("Creates a proxy object from the current working plane.\n"
+                "Once the object is created double click it in the tree view "
+                "to restore the camera position and objects' visibilities.\n"
+                "Then you can use it to save a different camera position "
+                "and objects' states any time you need.")
+        d = {'Pixmap': 'Draft_PlaneProxy',
              'MenuText': QT_TRANSLATE_NOOP("Draft_SetWorkingPlaneProxy",
                                            _menu),
              'ToolTip': QT_TRANSLATE_NOOP("Draft_SetWorkingPlaneProxy",
@@ -524,10 +528,10 @@ class Draft_SetWorkingPlaneProxy:
             _cmd += "FreeCAD.DraftWorkingPlane.getPlacement()"
             _cmd += ")"
             FreeCADGui.doCommand(_cmd)
-            FreeCAD.ActiveDocument.recompute()
             FreeCAD.ActiveDocument.commitTransaction()
+            FreeCAD.ActiveDocument.recompute()
 
 
 FreeCADGui.addCommand('Draft_SelectPlane', Draft_SelectPlane())
-FreeCADGui.addCommand('Draft_SetWorkingPlaneProxy',
-                      Draft_SetWorkingPlaneProxy())
+FreeCADGui.addCommand('Draft_WorkingPlaneProxy',
+                      Draft_WorkingPlaneProxy())

--- a/src/Mod/Draft/drafttaskpanels/task_selectplane.py
+++ b/src/Mod/Draft/drafttaskpanels/task_selectplane.py
@@ -1,0 +1,50 @@
+# ***************************************************************************
+# *   Copyright (c) 2019 Yorik van Havre <yorik@uncreated.net>              *
+# *                                                                         *
+# *   This file is part of the FreeCAD CAx development system.              *
+# *                                                                         *
+# *   This program is free software; you can redistribute it and/or modify  *
+# *   it under the terms of the GNU Lesser General Public License (LGPL)    *
+# *   as published by the Free Software Foundation; either version 2 of     *
+# *   the License, or (at your option) any later version.                   *
+# *   for detail see the LICENCE text file.                                 *
+# *                                                                         *
+# *   FreeCAD is distributed in the hope that it will be useful,            *
+# *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+# *   GNU Library General Public License for more details.                  *
+# *                                                                         *
+# *   You should have received a copy of the GNU Library General Public     *
+# *   License along with FreeCAD; if not, write to the Free Software        *
+# *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
+# *   USA                                                                   *
+# *                                                                         *
+# ***************************************************************************
+"""Provides the task panel for the Draft SelectPlane tool."""
+## @package task_selectplane
+# \ingroup DRAFT
+# \brief This module provides the task panel code for the SelectPlane tool.
+
+import FreeCADGui as Gui
+
+# As it is right now this code only loads the task panel .ui file.
+# All logic on how to use the widgets is located in the GuiCommand class
+# itself.
+# On the other hand, the newer tools introduced in v0.19 like OrthoArray,
+# PolarArray, and CircularArray include the logic and manipulation
+# of the widgets in this task panel class.
+# In addition, the task panel code launches the actual function
+# using the delayed mechanism defined by the `todo.ToDo` class.
+# Therefore, at some point this class should be refactored
+# to be more similar to OrthoArray and the new tools.
+
+
+class SelectPlaneTaskPanel:
+    """The task panel definition of the Draft_SelectPlane command."""
+
+    def __init__(self):
+        self.form = Gui.PySideUic.loadUi(":/ui/TaskSelectPlane.ui")
+
+    def getStandardButtons(self):
+        """Execute to set the standard buttons."""
+        return 2097152  # int(QtGui.QDialogButtonBox.Close)

--- a/src/Mod/Draft/draftutils/init_tools.py
+++ b/src/Mod/Draft/draftutils/init_tools.py
@@ -74,7 +74,8 @@ def get_draft_modification_commands():
             "Separator",
             "Draft_WireToBSpline", "Draft_Draft2Sketch",
             "Separator",
-            "Draft_Shape2DView", "Draft_Drawing"]
+            "Draft_Shape2DView", "Draft_Drawing",
+            "Draft_WorkingPlaneProxy"]
     return lst
 
 
@@ -97,7 +98,7 @@ def get_draft_utility_commands():
     return ["Draft_Layer", "Draft_Heal", "Draft_FlipDimension",
             "Draft_ToggleConstructionMode",
             "Draft_ToggleContinueMode", "Draft_Edit",
-            "Draft_Slope", "Draft_SetWorkingPlaneProxy",
+            "Draft_Slope", "Draft_WorkingPlaneProxy",
             "Draft_AddConstruction"]
 
 


### PR DESCRIPTION
Various improvements in the GuiCommands to create a working plane and a working plane proxy.
* The taskpanel code is moved to its own module.
* A dedicated button to create plane proxies is placed in the toolbar. Previously, this command was only accessible from the menu, so it was a bit hidden.
* It has its own icon, which is just a color variation of the normal plane icon.

This has to be merged after #3156 because it assumes many things are already in place introduced by that request and also by #3082.

Forum thread: [[Discussion] Splitting Draft tools into their own modules](https://forum.freecadweb.org/viewtopic.php?f=23&t=38593&p=375838#p375838)

---

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists