### PR TITLE
Draft: improvements in the task panels code and .ui files

### DIFF
--- a/src/Mod/Draft/Resources/ui/TaskPanel_CircularArray.ui
+++ b/src/Mod/Draft/Resources/ui/TaskPanel_CircularArray.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>445</width>
-    <height>488</height>
+    <height>511</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -54,7 +54,8 @@
       <item row="5" column="0">
        <widget class="QGroupBox" name="group_center">
         <property name="toolTip">
-         <string>The coordinates of the point through which the axis of rotation passes.</string>
+         <string>The coordinates of the point through which the axis of rotation passes.
+Change the direction of the axis itself in the property editor.</string>
         </property>
         <property name="title">
          <string>Center of rotation</string>
@@ -127,7 +128,7 @@
          <item row="1" column="0">
           <widget class="QPushButton" name="button_reset">
            <property name="toolTip">
-            <string>Reset the coordinates of the center of rotation</string>
+            <string>Reset the coordinates of the center of rotation.</string>
            </property>
            <property name="text">
             <string>Reset point</string>
@@ -142,7 +143,8 @@
         <item>
          <widget class="QCheckBox" name="checkbox_fuse">
           <property name="toolTip">
-           <string>If checked, the resulting objects in the array will be fused if they touch each other</string>
+           <string>If checked, the resulting objects in the array will be fused if they touch each other.
+This only works if &quot;Link array&quot; is off.</string>
           </property>
           <property name="text">
            <string>Fuse</string>
@@ -152,10 +154,14 @@
         <item>
          <widget class="QCheckBox" name="checkbox_link">
           <property name="toolTip">
-           <string>If checked, the resulting objects in the array will be Links instead of simple copies</string>
+           <string>If checked, the resulting object will be a &quot;Link array&quot; instead of a regular array.
+A Link array is more efficient when creating multiple copies, but it cannot be fused together.</string>
           </property>
           <property name="text">
-           <string>Use Links</string>
+           <string>Link array</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
           </property>
          </widget>
         </item>
@@ -166,7 +172,8 @@
         <item row="1" column="0">
          <widget class="QLabel" name="label_tan_distance">
           <property name="toolTip">
-           <string>Distance from one element in the array to the next element in the same layer. It cannot be zero.</string>
+           <string>Distance from one element in one ring of the array to the next element in the same ring.
+It cannot be zero.</string>
           </property>
           <property name="text">
            <string>Tangential distance</string>
@@ -176,7 +183,8 @@
         <item row="1" column="1">
          <widget class="Gui::QuantitySpinBox" name="spinbox_tan_distance">
           <property name="toolTip">
-           <string>Distance from one element in the array to the next element in the same layer. It cannot be zero.</string>
+           <string>Distance from one element in one ring of the array to the next element in the same ring.
+It cannot be zero.</string>
           </property>
           <property name="unit" stdset="0">
            <string notr="true"/>
@@ -189,7 +197,7 @@
         <item row="0" column="0">
          <widget class="QLabel" name="label_r_distance">
           <property name="toolTip">
-           <string>Distance from the center of the array to the outer layers</string>
+           <string>Distance from one layer of objects to the next layer of objects.</string>
           </property>
           <property name="text">
            <string>Radial distance</string>
@@ -199,7 +207,7 @@
         <item row="0" column="1">
          <widget class="Gui::QuantitySpinBox" name="spinbox_r_distance">
           <property name="toolTip">
-           <string>Distance from the center of the array to the outer layers</string>
+           <string>Distance from one layer of objects to the next layer of objects.</string>
           </property>
           <property name="unit" stdset="0">
            <string notr="true"/>
@@ -212,7 +220,10 @@
         <item row="3" column="1">
          <widget class="QSpinBox" name="spinbox_symmetry">
           <property name="toolTip">
-           <string>Number that controls how the objects will be distributed</string>
+           <string>The number of symmetry lines in the circular array.</string>
+          </property>
+          <property name="minimum">
+           <number>1</number>
           </property>
           <property name="value">
            <number>1</number>
@@ -222,7 +233,11 @@
         <item row="2" column="1">
          <widget class="QSpinBox" name="spinbox_number">
           <property name="toolTip">
-           <string>Number of circular arrays to create, including a copy of the original object. It must be at least 2.</string>
+           <string>Number of circular layers or rings to create, including a copy of the original object.
+It must be at least 2.</string>
+          </property>
+          <property name="minimum">
+           <number>2</number>
           </property>
           <property name="value">
            <number>3</number>
@@ -232,7 +247,8 @@
         <item row="2" column="0">
          <widget class="QLabel" name="label_number">
           <property name="toolTip">
-           <string>Number of circular arrays to create, including a copy of the original object. It must be at least 2.</string>
+           <string>Number of circular layers or rings to create, including a copy of the original object.
+It must be at least 2.</string>
           </property>
           <property name="text">
            <string>Number of circular layers</string>
@@ -242,7 +258,7 @@
         <item row="3" column="0">
          <widget class="QLabel" name="label_symmetry">
           <property name="toolTip">
-           <string>Number that controls how the objects will be distributed</string>
+           <string>The number of symmetry lines in the circular array.</string>
           </property>
           <property name="text">
            <string>Symmetry</string>

--- a/src/Mod/Draft/Resources/ui/TaskPanel_OrthoArray.ui
+++ b/src/Mod/Draft/Resources/ui/TaskPanel_OrthoArray.ui
@@ -41,10 +41,12 @@
       <item row="6" column="0">
        <widget class="QGroupBox" name="group_Z">
         <property name="toolTip">
-         <string>Distance between the elements in the Z direction. Normally, only the Z value is necessary; the other two values can give an additional shift in their respective directions.</string>
+         <string>Distance between the elements in the Z direction.
+Normally, only the Z value is necessary; the other two values can give an additional shift in their respective directions.
+Negative values will result in copies produced in the negative direction.</string>
         </property>
         <property name="title">
-         <string>Interval Z</string>
+         <string>Z intervals</string>
         </property>
         <layout class="QGridLayout" name="gridLayout">
          <item row="0" column="0">
@@ -117,7 +119,7 @@
          <item row="1" column="0">
           <widget class="QPushButton" name="button_reset_Z">
            <property name="toolTip">
-            <string>Reset the distances</string>
+            <string>Reset the distances.</string>
            </property>
            <property name="text">
             <string>Reset Z</string>
@@ -132,7 +134,8 @@
         <item>
          <widget class="QCheckBox" name="checkbox_fuse">
           <property name="toolTip">
-           <string>If checked, the resulting objects in the array will be fused if they touch each other</string>
+           <string>If checked, the resulting objects in the array will be fused if they touch each other.
+This only works if &quot;Link array&quot; is off.</string>
           </property>
           <property name="text">
            <string>Fuse</string>
@@ -142,10 +145,14 @@
         <item>
          <widget class="QCheckBox" name="checkbox_link">
           <property name="toolTip">
-           <string>If checked, the resulting objects in the array will be Links instead of simple copies</string>
+           <string>If checked, the resulting object will be a &quot;Link array&quot; instead of a regular array.
+A Link array is more efficient when creating multiple copies, but it cannot be fused together.</string>
           </property>
           <property name="text">
-           <string>Use Links</string>
+           <string>Link array</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
           </property>
          </widget>
         </item>
@@ -164,73 +171,6 @@
         </property>
        </spacer>
       </item>
-      <item row="7" column="0">
-       <widget class="QGroupBox" name="group_copies">
-        <property name="toolTip">
-         <string>Number of elements in the array in the specified direction, including a copy of the original object. The number must be at least 1 in each direction.</string>
-        </property>
-        <property name="title">
-         <string>Number of elements</string>
-        </property>
-        <layout class="QGridLayout" name="gridLayout_5">
-         <item row="0" column="0">
-          <layout class="QGridLayout" name="grid_number">
-           <item row="0" column="0">
-            <widget class="QLabel" name="label_n_X">
-             <property name="text">
-              <string>X</string>
-             </property>
-            </widget>
-           </item>
-           <item row="2" column="0">
-            <widget class="QLabel" name="label_n_Z">
-             <property name="text">
-              <string>Z</string>
-             </property>
-            </widget>
-           </item>
-           <item row="1" column="0">
-            <widget class="QLabel" name="label_n_Y">
-             <property name="text">
-              <string>Y</string>
-             </property>
-            </widget>
-           </item>
-           <item row="0" column="1">
-            <widget class="QSpinBox" name="spinbox_n_X">
-             <property name="minimum">
-              <number>1</number>
-             </property>
-             <property name="value">
-              <number>2</number>
-             </property>
-            </widget>
-           </item>
-           <item row="1" column="1">
-            <widget class="QSpinBox" name="spinbox_n_Y">
-             <property name="minimum">
-              <number>1</number>
-             </property>
-             <property name="value">
-              <number>2</number>
-             </property>
-            </widget>
-           </item>
-           <item row="2" column="1">
-            <widget class="QSpinBox" name="spinbox_n_Z">
-             <property name="minimum">
-              <number>1</number>
-             </property>
-             <property name="value">
-              <number>1</number>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </item>
-        </layout>
-       </widget>
-      </item>
       <item row="0" column="0">
        <widget class="QLabel" name="label_icon">
         <property name="text">
@@ -241,10 +181,12 @@
       <item row="4" column="0">
        <widget class="QGroupBox" name="group_X">
         <property name="toolTip">
-         <string>Distance between the elements in the X direction. Normally, only the X value is necessary; the other two values can give an additional shift in their respective directions.</string>
+         <string>Distance between the elements in the X direction.
+Normally, only the X value is necessary; the other two values can give an additional shift in their respective directions.
+Negative values will result in copies produced in the negative direction.</string>
         </property>
         <property name="title">
-         <string>Interval X</string>
+         <string>X intervals</string>
         </property>
         <layout class="QGridLayout" name="gridLayout_2">
          <item row="0" column="0">
@@ -317,7 +259,7 @@
          <item row="1" column="0">
           <widget class="QPushButton" name="button_reset_X">
            <property name="toolTip">
-            <string>Reset the distances</string>
+            <string>Reset the distances.</string>
            </property>
            <property name="text">
             <string>Reset X</string>
@@ -330,10 +272,12 @@
       <item row="5" column="0">
        <widget class="QGroupBox" name="group_Y">
         <property name="toolTip">
-         <string>Distance between the elements in the Y direction. Normally, only the Y value is necessary; the other two values can give an additional shift in their respective directions.</string>
+         <string>Distance between the elements in the Y direction.
+Normally, only the Y value is necessary; the other two values can give an additional shift in their respective directions.
+Negative values will result in copies produced in the negative direction.</string>
         </property>
         <property name="title">
-         <string>Interval Y</string>
+         <string>Y intervals</string>
         </property>
         <layout class="QGridLayout" name="gridLayout_6">
          <item row="0" column="0">
@@ -406,12 +350,80 @@
          <item row="1" column="0">
           <widget class="QPushButton" name="button_reset_Y">
            <property name="toolTip">
-            <string>Reset the distances</string>
+            <string>Reset the distances.</string>
            </property>
            <property name="text">
             <string>Reset Y</string>
            </property>
           </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QGroupBox" name="group_copies">
+        <property name="toolTip">
+         <string>Number of elements in the array in the specified direction, including a copy of the original object.
+The number must be at least 1 in each direction.</string>
+        </property>
+        <property name="title">
+         <string>Number of elements</string>
+        </property>
+        <layout class="QGridLayout" name="gridLayout_5">
+         <item row="0" column="0">
+          <layout class="QGridLayout" name="grid_number">
+           <item row="0" column="0">
+            <widget class="QLabel" name="label_n_X">
+             <property name="text">
+              <string>X</string>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="0">
+            <widget class="QLabel" name="label_n_Z">
+             <property name="text">
+              <string>Z</string>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="0">
+            <widget class="QLabel" name="label_n_Y">
+             <property name="text">
+              <string>Y</string>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="1">
+            <widget class="QSpinBox" name="spinbox_n_X">
+             <property name="minimum">
+              <number>1</number>
+             </property>
+             <property name="value">
+              <number>2</number>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="1">
+            <widget class="QSpinBox" name="spinbox_n_Y">
+             <property name="minimum">
+              <number>1</number>
+             </property>
+             <property name="value">
+              <number>2</number>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="1">
+            <widget class="QSpinBox" name="spinbox_n_Z">
+             <property name="minimum">
+              <number>1</number>
+             </property>
+             <property name="value">
+              <number>1</number>
+             </property>
+            </widget>
+           </item>
+          </layout>
          </item>
         </layout>
        </widget>
@@ -429,10 +441,21 @@
   </customwidget>
  </customwidgets>
  <tabstops>
+  <tabstop>spinbox_n_X</tabstop>
+  <tabstop>spinbox_n_Y</tabstop>
+  <tabstop>spinbox_n_Z</tabstop>
   <tabstop>input_X_x</tabstop>
   <tabstop>input_X_y</tabstop>
   <tabstop>input_X_z</tabstop>
   <tabstop>button_reset_X</tabstop>
+  <tabstop>input_Y_x</tabstop>
+  <tabstop>input_Y_y</tabstop>
+  <tabstop>input_Y_z</tabstop>
+  <tabstop>button_reset_Y</tabstop>
+  <tabstop>input_Z_x</tabstop>
+  <tabstop>input_Z_y</tabstop>
+  <tabstop>input_Z_z</tabstop>
+  <tabstop>button_reset_Z</tabstop>
   <tabstop>checkbox_fuse</tabstop>
   <tabstop>checkbox_link</tabstop>
  </tabstops>

--- a/src/Mod/Draft/Resources/ui/TaskPanel_PolarArray.ui
+++ b/src/Mod/Draft/Resources/ui/TaskPanel_PolarArray.ui
@@ -54,7 +54,8 @@
       <item row="5" column="0">
        <widget class="QGroupBox" name="group_center">
         <property name="toolTip">
-         <string>The coordinates of the point through which the axis of rotation passes.</string>
+         <string>The coordinates of the point through which the axis of rotation passes.
+Change the direction of the axis itself in the property editor.</string>
         </property>
         <property name="title">
          <string>Center of rotation</string>
@@ -127,7 +128,7 @@
          <item row="1" column="0">
           <widget class="QPushButton" name="button_reset">
            <property name="toolTip">
-            <string>Reset the coordinates of the center of rotation</string>
+            <string>Reset the coordinates of the center of rotation.</string>
            </property>
            <property name="text">
             <string>Reset point</string>
@@ -142,7 +143,8 @@
         <item>
          <widget class="QCheckBox" name="checkbox_fuse">
           <property name="toolTip">
-           <string>If checked, the resulting objects in the array will be fused if they touch each other</string>
+           <string>If checked, the resulting objects in the array will be fused if they touch each other.
+This only works if &quot;Link array&quot; is off.</string>
           </property>
           <property name="text">
            <string>Fuse</string>
@@ -152,10 +154,14 @@
         <item>
          <widget class="QCheckBox" name="checkbox_link">
           <property name="toolTip">
-           <string>If checked, the resulting objects in the array will be Links instead of simple copies</string>
+           <string>If checked, the resulting object will be a &quot;Link array&quot; instead of a regular array.
+A Link array is more efficient when creating multiple copies, but it cannot be fused together.</string>
           </property>
           <property name="text">
-           <string>Use Links</string>
+           <string>Link array</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
           </property>
          </widget>
         </item>
@@ -166,7 +172,9 @@
         <item row="0" column="0">
          <widget class="QLabel" name="label_angle">
           <property name="toolTip">
-           <string>Sweeping angle of the polar distribution</string>
+           <string>Sweeping angle of the polar distribution.
+A negative angle produces a polar pattern in the opposite direction.
+The maximum absolute value is 360 degrees.</string>
           </property>
           <property name="text">
            <string>Polar angle</string>
@@ -176,20 +184,29 @@
         <item row="0" column="1">
          <widget class="Gui::QuantitySpinBox" name="spinbox_angle">
           <property name="toolTip">
-           <string>Sweeping angle of the polar distribution</string>
+           <string>Sweeping angle of the polar distribution.
+A negative angle produces a polar pattern in the opposite direction.
+The maximum absolute value is 360 degrees.</string>
           </property>
           <property name="unit" stdset="0">
            <string notr="true"/>
           </property>
+          <property name="minimum">
+           <double>-360.000000000000000</double>
+          </property>
+          <property name="maximum">
+           <double>360.000000000000000</double>
+          </property>
           <property name="value">
-           <double>180.000000000000000</double>
+           <double>360.000000000000000</double>
           </property>
          </widget>
         </item>
         <item row="1" column="0">
          <widget class="QLabel" name="label_number">
           <property name="toolTip">
-           <string>Number of elements in the array, including a copy of the original object. It must be at least 2.</string>
+           <string>Number of elements in the array, including a copy of the original object.
+It must be at least 2.</string>
           </property>
           <property name="text">
            <string>Number of elements</string>
@@ -199,10 +216,14 @@
         <item row="1" column="1">
          <widget class="QSpinBox" name="spinbox_number">
           <property name="toolTip">
-           <string>Number of elements in the array, including a copy of the original object. It must be at least 2.</string>
+           <string>Number of elements in the array, including a copy of the original object.
+It must be at least 2.</string>
+          </property>
+          <property name="minimum">
+           <number>2</number>
           </property>
           <property name="value">
-           <number>4</number>
+           <number>5</number>
           </property>
          </widget>
         </item>

--- a/src/Mod/Draft/draftguitools/gui_circulararray.py
+++ b/src/Mod/Draft/draftguitools/gui_circulararray.py
@@ -20,7 +20,7 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides the Draft CircularArray tool."""
+"""Provides the Draft CircularArray GuiCommand."""
 ## @package gui_circulararray
 # \ingroup DRAFT
 # \brief This module provides the Draft CircularArray tool.
@@ -31,13 +31,15 @@ from PySide.QtCore import QT_TRANSLATE_NOOP
 import FreeCAD as App
 import FreeCADGui as Gui
 import Draft
-import Draft_rc
+import Draft_rc  # include resources, icons, ui files
+from draftutils.messages import _msg, _log
+from draftutils.translate import _tr
 from draftguitools import gui_base
 from drafttaskpanels import task_circulararray
 import draftutils.todo as todo
 
 # The module is used to prevent complaints from code checkers (flake8)
-True if Draft_rc.__name__ else False
+bool(Draft_rc.__name__)
 
 
 class GuiCommandCircularArray(gui_base.GuiCommandBase):
@@ -45,7 +47,7 @@ class GuiCommandCircularArray(gui_base.GuiCommandBase):
 
     def __init__(self):
         super().__init__()
-        self.command_name = "CircularArray"
+        self.command_name = "Circular array"
         self.location = None
         self.mouse_event = None
         self.view = None
@@ -56,14 +58,15 @@ class GuiCommandCircularArray(gui_base.GuiCommandBase):
 
     def GetResources(self):
         """Set icon, menu and tooltip."""
-        _msg = ("Creates copies of a selected object, "
+        _tip = ("Creates copies of a selected object, "
                 "and places the copies in a circular pattern.\n"
                 "The properties of the array can be further modified after "
                 "the new object is created, including turning it into "
                 "a different type of array.")
+
         d = {'Pixmap': 'Draft_CircularArray',
              'MenuText': QT_TRANSLATE_NOOP("Draft", "Circular array"),
-             'ToolTip': QT_TRANSLATE_NOOP("Draft", _msg)}
+             'ToolTip': QT_TRANSLATE_NOOP("Draft", _tip)}
         return d
 
     def Activated(self):
@@ -72,6 +75,10 @@ class GuiCommandCircularArray(gui_base.GuiCommandBase):
         We add callbacks that connect the 3D view with
         the widgets of the task panel.
         """
+        _log("GuiCommand: {}".format(_tr(self.command_name)))
+        _msg("{}".format(16*"-"))
+        _msg("GuiCommand: {}".format(_tr(self.command_name)))
+
         self.location = coin.SoLocation2Event.getClassTypeId()
         self.mouse_event = coin.SoMouseButtonEvent.getClassTypeId()
         self.view = Draft.get3DView()

--- a/src/Mod/Draft/draftguitools/gui_orthoarray.py
+++ b/src/Mod/Draft/draftguitools/gui_orthoarray.py
@@ -31,13 +31,15 @@ from PySide.QtCore import QT_TRANSLATE_NOOP
 import FreeCAD as App
 import FreeCADGui as Gui
 import Draft
-import Draft_rc
+import Draft_rc  # include resources, icons, ui files
+from draftutils.messages import _msg, _log
+from draftutils.translate import _tr
 from draftguitools import gui_base
 from drafttaskpanels import task_orthoarray
 import draftutils.todo as todo
 
 # The module is used to prevent complaints from code checkers (flake8)
-True if Draft_rc.__name__ else False
+bool(Draft_rc.__name__)
 
 
 class GuiCommandOrthoArray(gui_base.GuiCommandBase):
@@ -45,7 +47,7 @@ class GuiCommandOrthoArray(gui_base.GuiCommandBase):
 
     def __init__(self):
         super().__init__()
-        self.command_name = "OrthoArray"
+        self.command_name = "Orthogonal array"
         # self.location = None
         self.mouse_event = None
         self.view = None
@@ -56,14 +58,15 @@ class GuiCommandOrthoArray(gui_base.GuiCommandBase):
 
     def GetResources(self):
         """Set icon, menu and tooltip."""
-        _msg = ("Creates copies of a selected object, "
+        _tip = ("Creates copies of a selected object, "
                 "and places the copies in an orthogonal pattern.\n"
                 "The properties of the array can be further modified after "
                 "the new object is created, including turning it into "
                 "a different type of array.")
+
         d = {'Pixmap': 'Draft_Array',
              'MenuText': QT_TRANSLATE_NOOP("Draft", "Array"),
-             'ToolTip': QT_TRANSLATE_NOOP("Draft", _msg)}
+             'ToolTip': QT_TRANSLATE_NOOP("Draft", _tip)}
         return d
 
     def Activated(self):
@@ -72,6 +75,10 @@ class GuiCommandOrthoArray(gui_base.GuiCommandBase):
         We add callbacks that connect the 3D view with
         the widgets of the task panel.
         """
+        _log("GuiCommand: {}".format(_tr(self.command_name)))
+        _msg("{}".format(16*"-"))
+        _msg("GuiCommand: {}".format(_tr(self.command_name)))
+
         # self.location = coin.SoLocation2Event.getClassTypeId()
         self.mouse_event = coin.SoMouseButtonEvent.getClassTypeId()
         self.view = Draft.get3DView()

--- a/src/Mod/Draft/draftguitools/gui_polararray.py
+++ b/src/Mod/Draft/draftguitools/gui_polararray.py
@@ -20,7 +20,7 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides the Draft PolarArray tool."""
+"""Provides the Draft PolarArray GuiCommand."""
 ## @package gui_polararray
 # \ingroup DRAFT
 # \brief This module provides the Draft PolarArray tool.
@@ -31,13 +31,15 @@ from PySide.QtCore import QT_TRANSLATE_NOOP
 import FreeCAD as App
 import FreeCADGui as Gui
 import Draft
-import Draft_rc
+import Draft_rc  # include resources, icons, ui files
+from draftutils.messages import _msg, _log
+from draftutils.translate import _tr
 from draftguitools import gui_base
 from drafttaskpanels import task_polararray
 import draftutils.todo as todo
 
 # The module is used to prevent complaints from code checkers (flake8)
-True if Draft_rc.__name__ else False
+bool(Draft_rc.__name__)
 
 
 class GuiCommandPolarArray(gui_base.GuiCommandBase):
@@ -45,7 +47,7 @@ class GuiCommandPolarArray(gui_base.GuiCommandBase):
 
     def __init__(self):
         super().__init__()
-        self.command_name = "PolarArray"
+        self.command_name = "Polar array"
         self.location = None
         self.mouse_event = None
         self.view = None
@@ -56,14 +58,15 @@ class GuiCommandPolarArray(gui_base.GuiCommandBase):
 
     def GetResources(self):
         """Set icon, menu and tooltip."""
-        _msg = ("Creates copies of a selected object, "
+        _tip = ("Creates copies of a selected object, "
                 "and places the copies in a polar pattern.\n"
                 "The properties of the array can be further modified after "
                 "the new object is created, including turning it into "
                 "a different type of array.")
+
         d = {'Pixmap': 'Draft_PolarArray',
              'MenuText': QT_TRANSLATE_NOOP("Draft", "Polar array"),
-             'ToolTip': QT_TRANSLATE_NOOP("Draft", _msg)}
+             'ToolTip': QT_TRANSLATE_NOOP("Draft", _tip)}
         return d
 
     def Activated(self):
@@ -72,6 +75,10 @@ class GuiCommandPolarArray(gui_base.GuiCommandBase):
         We add callbacks that connect the 3D view with
         the widgets of the task panel.
         """
+        _log("GuiCommand: {}".format(_tr(self.command_name)))
+        _msg("{}".format(16*"-"))
+        _msg("GuiCommand: {}".format(_tr(self.command_name)))
+
         self.location = coin.SoLocation2Event.getClassTypeId()
         self.mouse_event = coin.SoMouseButtonEvent.getClassTypeId()
         self.view = Draft.get3DView()

--- a/src/Mod/Draft/drafttaskpanels/task_circulararray.py
+++ b/src/Mod/Draft/drafttaskpanels/task_circulararray.py
@@ -1,9 +1,3 @@
-"""This module provides the task panel for the Draft CircularArray tool.
-"""
-## @package task_circulararray
-# \ingroup DRAFT
-# \brief This module provides the task panel code for the CircularArray tool.
-
 # ***************************************************************************
 # *   (c) 2019 Eliud Cabrera Castillo <e.cabrera-castillo@tum.de>           *
 # *                                                                         *
@@ -26,183 +20,256 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
+"""Provides the task panel code for the Draft CircularArray tool."""
+## @package task_circulararray
+# \ingroup DRAFT
+# \brief This module provides the task panel code for the CircularArray tool.
+
+import PySide.QtGui as QtGui
+from PySide.QtCore import QT_TRANSLATE_NOOP
 
 import FreeCAD as App
 import FreeCADGui as Gui
-# import Draft
-import Draft_rc
+import Draft_rc  # include resources, icons, ui files
 import DraftVecUtils
+from draftutils.messages import _msg, _wrn, _err, _log
+from draftutils.translate import _tr
+from FreeCAD import Units as U
 
-import PySide.QtCore as QtCore
-import PySide.QtGui as QtGui
-from PySide.QtCore import QT_TRANSLATE_NOOP
-# import DraftTools
-from DraftGui import translate
-# from DraftGui import displayExternal
-
-_Quantity = App.Units.Quantity
-
-
-def _Msg(text, end="\n"):
-    """Print message with newline"""
-    App.Console.PrintMessage(text + end)
-
-
-def _Wrn(text, end="\n"):
-    """Print warning with newline"""
-    App.Console.PrintWarning(text + end)
-
-
-def _tr(text):
-    """Function to translate with the context set"""
-    return translate("Draft", text)
-
-
-# So the resource file doesn't trigger errors from code checkers (flake8)
-True if Draft_rc.__name__ else False
+# The module is used to prevent complaints from code checkers (flake8)
+bool(Draft_rc.__name__)
 
 
 class TaskPanelCircularArray:
     """TaskPanel code for the CircularArray command.
 
     The names of the widgets are defined in the `.ui` file.
-    In this class all those widgets are automatically created
-    under the name `self.form.<name>`
+    This `.ui` file `must` be loaded into an attribute
+    called `self.form` so that it is loaded into the task panel correctly.
+
+    In this class all widgets are automatically created
+    as `self.form.<widget_name>`.
 
     The `.ui` file may use special FreeCAD widgets such as
     `Gui::InputField` (based on `QLineEdit`) and
     `Gui::QuantitySpinBox` (based on `QAbstractSpinBox`).
     See the Doxygen documentation of the corresponding files in `src/Gui/`,
     for example, `InputField.h` and `QuantitySpinBox.h`.
+
+    Attributes
+    ----------
+    source_command: gui_base.GuiCommandBase
+        This attribute holds a reference to the calling class
+        of this task panel.
+        This parent class, which is derived from `gui_base.GuiCommandBase`,
+        is responsible for calling this task panel, for installing
+        certain callbacks, and for removing them.
+
+        It also delays the execution of the internal creation commands
+        by using the `draftutils.todo.ToDo` class.
+
+    See Also
+    --------
+    * https://forum.freecadweb.org/viewtopic.php?f=10&t=40007
+    * https://forum.freecadweb.org/viewtopic.php?t=5374#p43038
     """
 
     def __init__(self):
+        self.name = "Circular array"
+        _log(_tr("Task panel:") + "{}".format(_tr(self.name)))
+
+        # The .ui file must be loaded into an attribute
+        # called `self.form` so that it is displayed in the task panel.
         ui_file = ":/ui/TaskPanel_CircularArray.ui"
         self.form = Gui.PySideUic.loadUi(ui_file)
-        self.name = self.form.windowTitle()
 
         icon_name = "Draft_CircularArray"
         svg = ":/icons/" + icon_name
         pix = QtGui.QPixmap(svg)
         icon = QtGui.QIcon.fromTheme(icon_name, QtGui.QIcon(svg))
         self.form.setWindowIcon(icon)
+        self.form.setWindowTitle(_tr(self.name))
+
         self.form.label_icon.setPixmap(pix.scaled(32, 32))
 
-        start_distance = _Quantity(1000.0, App.Units.Length)
-        distance_unit = start_distance.getUserPreferred()[2]
-        self.form.spinbox_r_distance.setProperty('rawValue',
-                                                 2 * start_distance.Value)
-        self.form.spinbox_r_distance.setProperty('unit', distance_unit)
-        self.form.spinbox_tan_distance.setProperty('rawValue',
-                                                   start_distance.Value)
-        self.form.spinbox_tan_distance.setProperty('unit', distance_unit)
+        # -------------------------------------------------------------------
+        # Default values for the internal function,
+        # and for the task panel interface
+        start_distance = U.Quantity(50.0, App.Units.Length)
+        length_unit = start_distance.getUserPreferred()[2]
 
         self.r_distance = 2 * start_distance.Value
         self.tan_distance = start_distance.Value
 
-        self.form.spinbox_number.setValue(3)
-        self.form.spinbox_symmetry.setValue(1)
+        self.form.spinbox_r_distance.setProperty('rawValue',
+                                                 self.r_distance)
+        self.form.spinbox_r_distance.setProperty('unit', length_unit)
+        self.form.spinbox_tan_distance.setProperty('rawValue',
+                                                   self.tan_distance)
+        self.form.spinbox_tan_distance.setProperty('unit', length_unit)
 
-        self.number = self.form.spinbox_number.value()
-        self.symmetry = self.form.spinbox_symmetry.value()
+        self.number = 3
+        self.symmetry = 1
 
+        self.form.spinbox_number.setValue(self.number)
+        self.form.spinbox_symmetry.setValue(self.symmetry)
+
+        # TODO: the axis is currently fixed, it should be editable
+        # or selectable from the task panel
         self.axis = App.Vector(0, 0, 1)
 
-        start_point = _Quantity(0.0, App.Units.Length)
+        start_point = U.Quantity(0.0, App.Units.Length)
         length_unit = start_point.getUserPreferred()[2]
-        self.form.input_c_x.setProperty('rawValue', start_point.Value)
+
+        self.center = App.Vector(start_point.Value,
+                                 start_point.Value,
+                                 start_point.Value)
+
+        self.form.input_c_x.setProperty('rawValue', self.center.x)
         self.form.input_c_x.setProperty('unit', length_unit)
-        self.form.input_c_y.setProperty('rawValue', start_point.Value)
+        self.form.input_c_y.setProperty('rawValue', self.center.y)
         self.form.input_c_y.setProperty('unit', length_unit)
-        self.form.input_c_z.setProperty('rawValue', start_point.Value)
+        self.form.input_c_z.setProperty('rawValue', self.center.z)
         self.form.input_c_z.setProperty('unit', length_unit)
-        self.valid_input = True
 
-        self.c_x_str = ""
-        self.c_y_str = ""
-        self.c_z_str = ""
-        self.center = App.Vector(0, 0, 0)
+        self.fuse = False
+        self.use_link = True
 
-        # Old style for Qt4
-        # QtCore.QObject.connect(self.form.button_reset,
-        #                        QtCore.SIGNAL("clicked()"),
-        #                        self.reset_point)
-        # New style for Qt5
-        self.form.button_reset.clicked.connect(self.reset_point)
+        self.form.checkbox_fuse.setChecked(self.fuse)
+        self.form.checkbox_link.setChecked(self.use_link)
+        # -------------------------------------------------------------------
+
+        # Some objects need to be selected before we can execute the function.
+        self.selection = None
+
+        # This is used to test the input of the internal function.
+        # It should be changed to True before we can execute the function.
+        self.valid_input = False
+
+        self.set_widget_callbacks()
+
+        self.tr_true = QT_TRANSLATE_NOOP("Draft", "True")
+        self.tr_false = QT_TRANSLATE_NOOP("Draft", "False")
 
         # The mask is not used at the moment, but could be used in the future
         # by a callback to restrict the coordinates of the pointer.
         self.mask = ""
 
-        # When the checkbox changes, change the fuse value
-        self.fuse = False
-        QtCore.QObject.connect(self.form.checkbox_fuse,
-                               QtCore.SIGNAL("stateChanged(int)"),
-                               self.set_fuse)
+    def set_widget_callbacks(self):
+        """Set up the callbacks (slots) for the widget signals."""
+        # New style for Qt5
+        self.form.button_reset.clicked.connect(self.reset_point)
 
-        self.use_link = False
-        QtCore.QObject.connect(self.form.checkbox_link,
-                               QtCore.SIGNAL("stateChanged(int)"),
-                               self.set_link)
+        # When the checkbox changes, change the internal value
+        self.form.checkbox_fuse.stateChanged.connect(self.set_fuse)
+        self.form.checkbox_link.stateChanged.connect(self.set_link)
+
+        # Old style for Qt4, avoid!
+        # QtCore.QObject.connect(self.form.button_reset,
+        #                        QtCore.SIGNAL("clicked()"),
+        #                        self.reset_point)
+        # QtCore.QObject.connect(self.form.checkbox_fuse,
+        #                        QtCore.SIGNAL("stateChanged(int)"),
+        #                        self.set_fuse)
+        # QtCore.QObject.connect(self.form.checkbox_link,
+        #                        QtCore.SIGNAL("stateChanged(int)"),
+        #                        self.set_link)
 
     def accept(self):
-        """Function that executes when clicking the OK button"""
-        selection = Gui.Selection.getSelection()
-        self.number = self.form.spinbox_number.value()
+        """Execute when clicking the OK button or Enter key."""
+        self.selection = Gui.Selection.getSelection()
 
-        tan_d_str = self.form.spinbox_tan_distance.text()
-        self.tan_distance = _Quantity(tan_d_str).Value
-        self.valid_input = self.validate_input(selection,
+        (self.r_distance,
+         self.tan_distance) = self.get_distances()
+
+        (self.number,
+         self.symmetry) = self.get_number_symmetry()
+
+        self.axis = self.get_axis()
+        self.center = self.get_center()
+
+        self.valid_input = self.validate_input(self.selection,
+                                               self.r_distance,
+                                               self.tan_distance,
                                                self.number,
-                                               self.tan_distance)
+                                               self.symmetry,
+                                               self.axis,
+                                               self.center)
         if self.valid_input:
-            self.create_object(selection)
-            self.print_messages(selection)
+            self.create_object()
+            self.print_messages()
             self.finish()
 
-    def validate_input(self, selection, number, tan_distance):
-        """Check that the input is valid"""
+    def validate_input(self, selection,
+                       r_distance, tan_distance,
+                       number, symmetry,
+                       axis, center):
+        """Check that the input is valid.
+
+        Some values may not need to be checked because
+        the interface may not allow to input wrong data.
+        """
         if not selection:
-            _Wrn(_tr("At least one element must be selected"))
+            _err(_tr("At least one element must be selected."))
             return False
+
         if number < 2:
-            _Wrn(_tr("Number of elements must be at least 2"))
+            _err(_tr("Number of layers must be at least 2."))
             return False
-        # Todo: each of the elements of the selection could be tested,
-        # not only the first one.
-        if selection[0].isDerivedFrom("App::FeaturePython"):
-            _Wrn(_tr("Selection is not suitable for array"))
-            _Wrn(_tr("Object:") + " {}".format(selection[0].Label))
+
+        # TODO: this should handle multiple objects.
+        # Each of the elements of the selection should be tested.
+        obj = selection[0]
+        if obj.isDerivedFrom("App::FeaturePython"):
+            _err(_tr("Selection is not suitable for array."))
+            _err(_tr("Object:") + " {}".format(selection[0].Label))
             return False
+
+        if r_distance == 0:
+            _wrn(_tr("Radial distance is zero. "
+                     "Resulting array may not look correct."))
+        elif r_distance < 0:
+            _wrn(_tr("Radial distance is negative. "
+                     "It is made positive to proceed."))
+            self.r_distance = abs(r_distance)
+
         if tan_distance == 0:
-            _Wrn(_tr("Tangential distance cannot be zero"))
+            _err(_tr("Tangential distance cannot be zero."))
             return False
-        return True
+        elif tan_distance < 0:
+            _wrn(_tr("Tangential distance is negative. "
+                     "It is made positive to proceed."))
+            self.tan_distance = abs(tan_distance)
 
-    def create_object(self, selection):
-        """Create the actual object"""
-        r_d_str = self.form.spinbox_r_distance.text()
-        tan_d_str = self.form.spinbox_tan_distance.text()
-        self.r_distance = _Quantity(r_d_str).Value
-        self.tan_distance = _Quantity(tan_d_str).Value
-
-        self.number = self.form.spinbox_number.value()
-        self.symmetry = self.form.spinbox_symmetry.value()
-        self.center = self.set_point()
-
-        if len(selection) == 1:
-            sel_obj = selection[0]
-        else:
-            # This can be changed so a compound of multiple
-            # selected objects is produced
-            sel_obj = selection[0]
+        # The other arguments are not tested but they should be present.
+        if symmetry and axis and center:
+            pass
 
         self.fuse = self.form.checkbox_fuse.isChecked()
         self.use_link = self.form.checkbox_link.isChecked()
+        return True
+
+    def create_object(self):
+        """Create the new object.
+
+        At this stage we already tested that the input is correct
+        so the necessary attributes are already set.
+        Then we proceed with the internal function to create the new object.
+        """
+        if len(self.selection) == 1:
+            sel_obj = self.selection[0]
+        else:
+            # TODO: this should handle multiple objects.
+            # For example, it could take the shapes of all objects,
+            # make a compound and then use it as input for the array function.
+            sel_obj = self.selection[0]
 
         # This creates the object immediately
         # obj = Draft.makeArray(sel_obj,
-        #                       self.center, self.angle, self.number)
+        #                       self.r_distance, self.tan_distance,
+        #                       self.axis, self.center,
+        #                       self.number, self.symmetry,
+        #                       self.use_link)
         # if obj:
         #     obj.Fuse = self.fuse
 
@@ -210,96 +277,120 @@ class TaskPanelCircularArray:
         # of this class, the GuiCommand.
         # This is needed to schedule geometry manipulation
         # that would crash Coin3D if done in the event callback.
-        _cmd = "obj = Draft.makeArray("
-        _cmd += "FreeCAD.ActiveDocument." + sel_obj.Name + ", "
-        _cmd += "arg1=" + str(self.r_distance) + ", "
-        _cmd += "arg2=" + str(self.tan_distance) + ", "
-        _cmd += "arg3=" + DraftVecUtils.toString(self.axis) + ", "
-        _cmd += "arg4=" + DraftVecUtils.toString(self.center) + ", "
-        _cmd += "arg5=" + str(self.number) + ", "
-        _cmd += "arg6=" + str(self.symmetry) + ", "
+        _cmd = "draftobjects.circulararray.make_circular_array"
+        _cmd += "("
+        _cmd += "App.ActiveDocument." + sel_obj.Name + ", "
+        _cmd += "r_distance=" + str(self.r_distance) + ", "
+        _cmd += "tan_distance=" + str(self.tan_distance) + ", "
+        _cmd += "number=" + str(self.number) + ", "
+        _cmd += "symmetry=" + str(self.symmetry) + ", "
+        _cmd += "axis=" + DraftVecUtils.toString(self.axis) + ", "
+        _cmd += "center=" + DraftVecUtils.toString(self.center) + ", "
         _cmd += "use_link=" + str(self.use_link)
         _cmd += ")"
 
-        _cmd_list = ["FreeCADGui.addModule('Draft')",
-                     _cmd,
+        _cmd_list = ["Gui.addModule('Draft')",
+                     "Gui.addModule('draftobjects.circulararray')",
+                     "obj = " + _cmd,
                      "obj.Fuse = " + str(self.fuse),
                      "Draft.autogroup(obj)",
-                     "FreeCAD.ActiveDocument.recompute()"]
-        self.source_command.commit("Circular array", _cmd_list)
+                     "App.ActiveDocument.recompute()"]
 
-    def set_point(self):
-        """Assign the values to the center"""
-        self.c_x_str = self.form.input_c_x.text()
-        self.c_y_str = self.form.input_c_y.text()
-        self.c_z_str = self.form.input_c_z.text()
-        center = App.Vector(_Quantity(self.c_x_str).Value,
-                            _Quantity(self.c_y_str).Value,
-                            _Quantity(self.c_z_str).Value)
+        # We commit the command list through the parent command
+        self.source_command.commit(_tr(self.name), _cmd_list)
+
+    def get_distances(self):
+        """Get the distance parameters from the widgets."""
+        r_d_str = self.form.spinbox_r_distance.text()
+        tan_d_str = self.form.spinbox_tan_distance.text()
+        return (U.Quantity(r_d_str).Value,
+                U.Quantity(tan_d_str).Value)
+
+    def get_number_symmetry(self):
+        """Get the number and symmetry parameters from the widgets."""
+        number = self.form.spinbox_number.value()
+        symmetry = self.form.spinbox_symmetry.value()
+        return number, symmetry
+
+    def get_center(self):
+        """Get the value of the center from the widgets."""
+        c_x_str = self.form.input_c_x.text()
+        c_y_str = self.form.input_c_y.text()
+        c_z_str = self.form.input_c_z.text()
+        center = App.Vector(U.Quantity(c_x_str).Value,
+                            U.Quantity(c_y_str).Value,
+                            U.Quantity(c_z_str).Value)
         return center
 
+    def get_axis(self):
+        """Get the axis that will be used for the array. NOT IMPLEMENTED.
+
+        It should consider a second selection of an edge or wire to use
+        as an axis.
+        """
+        return self.axis
+
     def reset_point(self):
-        """Reset the point to the original distance"""
+        """Reset the center point to the original distance."""
         self.form.input_c_x.setProperty('rawValue', 0)
         self.form.input_c_y.setProperty('rawValue', 0)
         self.form.input_c_z.setProperty('rawValue', 0)
 
-        self.center = self.set_point()
-        _Msg(_tr("Center reset:")
+        self.center = self.get_center()
+        _msg(_tr("Center reset:")
              + " ({0}, {1}, {2})".format(self.center.x,
                                          self.center.y,
                                          self.center.z))
 
-    def print_fuse_state(self):
-        """Print the state translated"""
-        if self.fuse:
-            translated_state = QT_TRANSLATE_NOOP("Draft", "True")
+    def print_fuse_state(self, fuse):
+        """Print the fuse state translated."""
+        if fuse:
+            state = self.tr_true
         else:
-            translated_state = QT_TRANSLATE_NOOP("Draft", "False")
-        _Msg(_tr("Fuse:") + " {}".format(translated_state))
+            state = self.tr_false
+        _msg(_tr("Fuse:") + " {}".format(state))
 
     def set_fuse(self):
-        """This function is called when the fuse checkbox changes"""
+        """Execute as a callback when the fuse checkbox changes."""
         self.fuse = self.form.checkbox_fuse.isChecked()
-        self.print_fuse_state()
+        self.print_fuse_state(self.fuse)
 
-    def print_link_state(self):
-        """Print the state translated"""
-        if self.use_link:
-            translated_state = QT_TRANSLATE_NOOP("Draft", "True")
+    def print_link_state(self, use_link):
+        """Print the link state translated."""
+        if use_link:
+            state = self.tr_true
         else:
-            translated_state = QT_TRANSLATE_NOOP("Draft", "False")
-        _Msg(_tr("Use Link object:") + " {}".format(translated_state))
+            state = self.tr_false
+        _msg(_tr("Create Link array:") + " {}".format(state))
 
     def set_link(self):
-        """This function is called when the fuse checkbox changes"""
+        """Execute as a callback when the link checkbox changes."""
         self.use_link = self.form.checkbox_link.isChecked()
-        self.print_link_state()
+        self.print_link_state(self.use_link)
 
-    def print_messages(self, selection):
-        """Print messages about the operation"""
-        if len(selection) == 1:
-            sel_obj = selection[0]
+    def print_messages(self):
+        """Print messages about the operation."""
+        if len(self.selection) == 1:
+            sel_obj = self.selection[0]
         else:
-            # This can be changed so a compound of multiple
-            # selected objects is produced
-            sel_obj = selection[0]
-        _Msg("{}".format(16*"-"))
-        _Msg("{}".format(self.name))
-        _Msg(_tr("Object:") + " {}".format(sel_obj.Label))
-        _Msg(_tr("Radial distance:") + " {}".format(self.r_distance))
-        _Msg(_tr("Tangential distance:") + " {}".format(self.tan_distance))
-        _Msg(_tr("Number of circular layers:") + " {}".format(self.number))
-        _Msg(_tr("Symmetry parameter:") + " {}".format(self.symmetry))
-        _Msg(_tr("Center of rotation:")
+            # TODO: this should handle multiple objects.
+            # For example, it could take the shapes of all objects,
+            # make a compound and then use it as input for the array function.
+            sel_obj = self.selection[0]
+        _msg(_tr("Object:") + " {}".format(sel_obj.Label))
+        _msg(_tr("Radial distance:") + " {}".format(self.r_distance))
+        _msg(_tr("Tangential distance:") + " {}".format(self.tan_distance))
+        _msg(_tr("Number of circular layers:") + " {}".format(self.number))
+        _msg(_tr("Symmetry parameter:") + " {}".format(self.symmetry))
+        _msg(_tr("Center of rotation:")
              + " ({0}, {1}, {2})".format(self.center.x,
                                          self.center.y,
                                          self.center.z))
-        self.print_fuse_state()
-        self.print_link_state()
+        self.print_fuse_state(self.fuse)
+        self.print_link_state(self.use_link)
 
     def display_point(self, point=None, plane=None, mask=None):
-        """Displays the coordinates in the x, y, and z widgets.
+        """Display the coordinates in the x, y, and z widgets.
 
         This function should be used in a Coin callback so that
         the coordinate values are automatically updated when the
@@ -307,21 +398,21 @@ class TaskPanelCircularArray:
         This was copied from `DraftGui.py` but needs to be improved
         for this particular command.
 
-        point :
+        point: Base::Vector3
             is a vector that arrives by the callback.
-        plane :
+        plane: WorkingPlane
             is a `WorkingPlane` instance, for example,
             `App.DraftWorkingPlane`. It is not used at the moment,
             but could be used to set up the grid.
-        mask :
+        mask: str
             is a string that specifies which coordinate is being
             edited. It is used to restrict edition of a single coordinate.
             It is not used at the moment but could be used with a callback.
         """
         # Get the coordinates to display
-        dp = None
+        d_p = None
         if point:
-            dp = point
+            d_p = point
 
         # Set the widgets to the value of the mouse pointer.
         #
@@ -336,25 +427,28 @@ class TaskPanelCircularArray:
         # sbx = self.form.spinbox_c_x
         # sby = self.form.spinbox_c_y
         # sbz = self.form.spinbox_c_z
-        if dp:
+        if d_p:
             if self.mask in ('y', 'z'):
-                # sbx.setText(displayExternal(dp.x, None, 'Length'))
-                self.form.input_c_x.setProperty('rawValue', dp.x)
+                # sbx.setText(displayExternal(d_p.x, None, 'Length'))
+                self.form.input_c_x.setProperty('rawValue', d_p.x)
             else:
-                # sbx.setText(displayExternal(dp.x, None, 'Length'))
-                self.form.input_c_x.setProperty('rawValue', dp.x)
+                # sbx.setText(displayExternal(d_p.x, None, 'Length'))
+                self.form.input_c_x.setProperty('rawValue', d_p.x)
             if self.mask in ('x', 'z'):
-                # sby.setText(displayExternal(dp.y, None, 'Length'))
-                self.form.input_c_y.setProperty('rawValue', dp.y)
+                # sby.setText(displayExternal(d_p.y, None, 'Length'))
+                self.form.input_c_y.setProperty('rawValue', d_p.y)
             else:
-                # sby.setText(displayExternal(dp.y, None, 'Length'))
-                self.form.input_c_y.setProperty('rawValue', dp.y)
+                # sby.setText(displayExternal(d_p.y, None, 'Length'))
+                self.form.input_c_y.setProperty('rawValue', d_p.y)
             if self.mask in ('x', 'y'):
-                # sbz.setText(displayExternal(dp.z, None, 'Length'))
-                self.form.input_c_z.setProperty('rawValue', dp.z)
+                # sbz.setText(displayExternal(d_p.z, None, 'Length'))
+                self.form.input_c_z.setProperty('rawValue', d_p.z)
             else:
-                # sbz.setText(displayExternal(dp.z, None, 'Length'))
-                self.form.input_c_z.setProperty('rawValue', dp.z)
+                # sbz.setText(displayExternal(d_p.z, None, 'Length'))
+                self.form.input_c_z.setProperty('rawValue', d_p.z)
+
+        if plane:
+            pass
 
         # Set masks
         if (mask == "x") or (self.mask == "x"):
@@ -379,7 +473,7 @@ class TaskPanelCircularArray:
             self.set_focus()
 
     def set_focus(self, key=None):
-        """Set the focus on the widget that receives the key signal"""
+        """Set the focus on the widget that receives the key signal."""
         if key is None or key == "x":
             self.form.input_c_x.setFocus()
             self.form.input_c_x.selectAll()
@@ -391,12 +485,16 @@ class TaskPanelCircularArray:
             self.form.input_c_z.selectAll()
 
     def reject(self):
-        """Function that executes when clicking the Cancel button"""
-        _Msg(_tr("Aborted:") + " {}".format(self.name))
+        """Execute when clicking the Cancel button or pressing Escape."""
+        _msg(_tr("Aborted:") + " {}".format(_tr(self.name)))
         self.finish()
 
     def finish(self):
-        """Function that runs at the end after OK or Cancel"""
+        """Finish the command, after accept or reject.
+
+        It finally calls the parent class to execute
+        the delayed functions, and perform cleanup.
+        """
         # App.ActiveDocument.commitTransaction()
         Gui.ActiveDocument.resetEdit()
         # Runs the parent command to complete the call

--- a/src/Mod/Draft/drafttaskpanels/task_circulararray.py
+++ b/src/Mod/Draft/drafttaskpanels/task_circulararray.py
@@ -32,6 +32,7 @@ import FreeCAD as App
 import FreeCADGui as Gui
 import Draft_rc  # include resources, icons, ui files
 import DraftVecUtils
+import draftutils.utils as utils
 from draftutils.messages import _msg, _wrn, _err, _log
 from draftutils.translate import _tr
 from FreeCAD import Units as U
@@ -132,8 +133,8 @@ class TaskPanelCircularArray:
         self.form.input_c_z.setProperty('rawValue', self.center.z)
         self.form.input_c_z.setProperty('unit', length_unit)
 
-        self.fuse = False
-        self.use_link = True
+        self.fuse = utils.get_param("Draft_array_fuse", False)
+        self.use_link = utils.get_param("Draft_array_Link", True)
 
         self.form.checkbox_fuse.setChecked(self.fuse)
         self.form.checkbox_link.setChecked(self.use_link)
@@ -354,6 +355,7 @@ class TaskPanelCircularArray:
         """Execute as a callback when the fuse checkbox changes."""
         self.fuse = self.form.checkbox_fuse.isChecked()
         self.print_fuse_state(self.fuse)
+        utils.set_param("Draft_array_fuse", self.fuse)
 
     def print_link_state(self, use_link):
         """Print the link state translated."""
@@ -367,6 +369,7 @@ class TaskPanelCircularArray:
         """Execute as a callback when the link checkbox changes."""
         self.use_link = self.form.checkbox_link.isChecked()
         self.print_link_state(self.use_link)
+        utils.set_param("Draft_array_Link", self.use_link)
 
     def print_messages(self):
         """Print messages about the operation."""

--- a/src/Mod/Draft/drafttaskpanels/task_orthoarray.py
+++ b/src/Mod/Draft/drafttaskpanels/task_orthoarray.py
@@ -1,8 +1,3 @@
-"""Provide the task panel for the Draft OrthoArray tool."""
-## @package task_orthoarray
-# \ingroup DRAFT
-# \brief Provide the task panel for the Draft OrthoArray tool.
-
 # ***************************************************************************
 # *   (c) 2020 Eliud Cabrera Castillo <e.cabrera-castillo@tum.de>           *
 # *                                                                         *
@@ -25,175 +20,226 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-
-import FreeCAD as App
-import FreeCADGui as Gui
-# import Draft
-import Draft_rc
-import DraftVecUtils
+"""Provides the task panel for the Draft OrthoArray tool."""
+## @package task_orthoarray
+# \ingroup DRAFT
+# \brief Provide the task panel for the Draft OrthoArray tool.
 
 import PySide.QtGui as QtGui
 from PySide.QtCore import QT_TRANSLATE_NOOP
-# import DraftTools
-from draftutils.translate import translate
-# from DraftGui import displayExternal
 
-_Quantity = App.Units.Quantity
+import FreeCAD as App
+import FreeCADGui as Gui
+import Draft_rc  # include resources, icons, ui files
+import DraftVecUtils
+from draftutils.messages import _msg, _err, _log
+from draftutils.translate import _tr
+from FreeCAD import Units as U
 
-
-def _Msg(text, end="\n"):
-    """Print message with newline."""
-    App.Console.PrintMessage(text + end)
-
-
-def _Wrn(text, end="\n"):
-    """Print warning with newline."""
-    App.Console.PrintWarning(text + end)
-
-
-def _tr(text):
-    """Translate with the context set."""
-    return translate("Draft", text)
-
-
-# So the resource file doesn't trigger errors from code checkers (flake8)
-True if Draft_rc else False
+# The module is used to prevent complaints from code checkers (flake8)
+bool(Draft_rc.__name__)
 
 
 class TaskPanelOrthoArray:
-    """TaskPanel for the OrthoArray command.
+    """TaskPanel code for the OrthoArray command.
 
     The names of the widgets are defined in the `.ui` file.
-    In this class all those widgets are automatically created
-    under the name `self.form.<name>`
+    This `.ui` file `must` be loaded into an attribute
+    called `self.form` so that it is loaded into the task panel correctly.
+
+    In this class all widgets are automatically created
+    as `self.form.<widget_name>`.
 
     The `.ui` file may use special FreeCAD widgets such as
     `Gui::InputField` (based on `QLineEdit`) and
     `Gui::QuantitySpinBox` (based on `QAbstractSpinBox`).
     See the Doxygen documentation of the corresponding files in `src/Gui/`,
     for example, `InputField.h` and `QuantitySpinBox.h`.
+
+    Attributes
+    ----------
+    source_command: gui_base.GuiCommandBase
+        This attribute holds a reference to the calling class
+        of this task panel.
+        This parent class, which is derived from `gui_base.GuiCommandBase`,
+        is responsible for calling this task panel, for installing
+        certain callbacks, and for removing them.
+
+        It also delays the execution of the internal creation commands
+        by using the `draftutils.todo.ToDo` class.
+
+    See Also
+    --------
+    * https://forum.freecadweb.org/viewtopic.php?f=10&t=40007
+    * https://forum.freecadweb.org/viewtopic.php?t=5374#p43038
     """
 
     def __init__(self):
+        self.name = "Orthogonal array"
+        _log(_tr("Task panel:") + "{}".format(_tr(self.name)))
+
+        # The .ui file must be loaded into an attribute
+        # called `self.form` so that it is displayed in the task panel.
         ui_file = ":/ui/TaskPanel_OrthoArray.ui"
         self.form = Gui.PySideUic.loadUi(ui_file)
-        self.name = self.form.windowTitle()
 
         icon_name = "Draft_Array"
         svg = ":/icons/" + icon_name
         pix = QtGui.QPixmap(svg)
         icon = QtGui.QIcon.fromTheme(icon_name, QtGui.QIcon(svg))
         self.form.setWindowIcon(icon)
+        self.form.setWindowTitle(_tr(self.name))
+
         self.form.label_icon.setPixmap(pix.scaled(32, 32))
 
-        start_x = _Quantity(100.0, App.Units.Length)
+        # -------------------------------------------------------------------
+        # Default values for the internal function,
+        # and for the task panel interface
+        start_x = U.Quantity(100.0, App.Units.Length)
         start_y = start_x
         start_z = start_x
-        start_zero = _Quantity(0.0, App.Units.Length)
         length_unit = start_x.getUserPreferred()[2]
 
-        self.form.input_X_x.setProperty('rawValue', start_x.Value)
+        self.v_x = App.Vector(start_x.Value, 0, 0)
+        self.v_y = App.Vector(0, start_y.Value, 0)
+        self.v_z = App.Vector(0, 0, start_z.Value)
+
+        self.form.input_X_x.setProperty('rawValue', self.v_x.x)
         self.form.input_X_x.setProperty('unit', length_unit)
-        self.form.input_X_y.setProperty('rawValue', start_zero.Value)
+        self.form.input_X_y.setProperty('rawValue', self.v_x.y)
         self.form.input_X_y.setProperty('unit', length_unit)
-        self.form.input_X_z.setProperty('rawValue', start_zero.Value)
+        self.form.input_X_z.setProperty('rawValue', self.v_x.z)
         self.form.input_X_z.setProperty('unit', length_unit)
 
-        self.form.input_Y_x.setProperty('rawValue', start_zero.Value)
+        self.form.input_Y_x.setProperty('rawValue', self.v_y.x)
         self.form.input_Y_x.setProperty('unit', length_unit)
-        self.form.input_Y_y.setProperty('rawValue', start_y.Value)
+        self.form.input_Y_y.setProperty('rawValue', self.v_y.y)
         self.form.input_Y_y.setProperty('unit', length_unit)
-        self.form.input_Y_z.setProperty('rawValue', start_zero.Value)
+        self.form.input_Y_z.setProperty('rawValue', self.v_y.z)
         self.form.input_Y_z.setProperty('unit', length_unit)
 
-        self.form.input_Z_x.setProperty('rawValue', start_zero.Value)
+        self.form.input_Z_x.setProperty('rawValue', self.v_z.x)
         self.form.input_Z_x.setProperty('unit', length_unit)
-        self.form.input_Z_y.setProperty('rawValue', start_zero.Value)
+        self.form.input_Z_y.setProperty('rawValue', self.v_z.y)
         self.form.input_Z_y.setProperty('unit', length_unit)
-        self.form.input_Z_z.setProperty('rawValue', start_z.Value)
+        self.form.input_Z_z.setProperty('rawValue', self.v_z.z)
         self.form.input_Z_z.setProperty('unit', length_unit)
 
-        self.v_X = App.Vector(100, 0, 0)
-        self.v_Y = App.Vector(0, 100, 0)
-        self.v_Z = App.Vector(0, 0, 100)
+        self.n_x = 2
+        self.n_y = 2
+        self.n_z = 1
 
-        # Old style for Qt4, avoid!
-        # QtCore.QObject.connect(self.form.button_reset,
-        #                        QtCore.SIGNAL("clicked()"),
-        #                        self.reset_point)
+        self.form.spinbox_n_X.setValue(self.n_x)
+        self.form.spinbox_n_Y.setValue(self.n_y)
+        self.form.spinbox_n_Z.setValue(self.n_z)
+
+        self.fuse = False
+        self.use_link = True
+
+        self.form.checkbox_fuse.setChecked(self.fuse)
+        self.form.checkbox_link.setChecked(self.use_link)
+        # -------------------------------------------------------------------
+
+        # Some objects need to be selected before we can execute the function.
+        self.selection = None
+
+        # This is used to test the input of the internal function.
+        # It should be changed to True before we can execute the function.
+        self.valid_input = False
+
+        self.set_widget_callbacks()
+
+        self.tr_true = QT_TRANSLATE_NOOP("Draft", "True")
+        self.tr_false = QT_TRANSLATE_NOOP("Draft", "False")
+
+    def set_widget_callbacks(self):
+        """Set up the callbacks (slots) for the widget signals."""
         # New style for Qt5
         self.form.button_reset_X.clicked.connect(lambda: self.reset_v("X"))
         self.form.button_reset_Y.clicked.connect(lambda: self.reset_v("Y"))
         self.form.button_reset_Z.clicked.connect(lambda: self.reset_v("Z"))
 
-        self.n_X = 2
-        self.n_Y = 2
-        self.n_Z = 1
-
-        self.form.spinbox_n_X.setValue(self.n_X)
-        self.form.spinbox_n_Y.setValue(self.n_Y)
-        self.form.spinbox_n_Z.setValue(self.n_Z)
-
-        self.valid_input = False
-
-        # When the checkbox changes, change the fuse value
-        self.fuse = False
+        # When the checkbox changes, change the internal value
         self.form.checkbox_fuse.stateChanged.connect(self.set_fuse)
-
-        self.use_link = False
         self.form.checkbox_link.stateChanged.connect(self.set_link)
 
+        # Old style for Qt4, avoid!
+        # QtCore.QObject.connect(self.form.button_reset,
+        #                        QtCore.SIGNAL("clicked()"),
+        #                        self.reset_point)
+
     def accept(self):
-        """Execute when clicking the OK button."""
-        selection = Gui.Selection.getSelection()
-        n_X = self.form.spinbox_n_X.value()
-        n_Y = self.form.spinbox_n_Y.value()
-        n_Z = self.form.spinbox_n_Z.value()
-        self.valid_input = self.validate_input(selection,
-                                               n_X,
-                                               n_Y,
-                                               n_Z)
+        """Execute when clicking the OK button or Enter key."""
+        self.selection = Gui.Selection.getSelection()
+
+        (self.v_x,
+         self.v_y,
+         self.v_z) = self.get_intervals()
+
+        (self.n_x,
+         self.n_y,
+         self.n_z) = self.get_numbers()
+
+        self.valid_input = self.validate_input(self.selection,
+                                               self.v_x, self.v_y, self.v_z,
+                                               self.n_x, self.n_y, self.n_z)
         if self.valid_input:
-            self.create_object(selection)
-            self.print_messages(selection)
+            self.create_object()
+            self.print_messages()
             self.finish()
 
-    def validate_input(self, selection, n_X, n_Y, n_Z):
-        """Check that the input is valid."""
+    def validate_input(self, selection,
+                       v_x, v_y, v_z,
+                       n_x, n_y, n_z):
+        """Check that the input is valid.
+
+        Some values may not need to be checked because
+        the interface may not allow to input wrong data.
+        """
         if not selection:
-            _Wrn(_tr("At least one element must be selected"))
+            _err(_tr("At least one element must be selected."))
             return False
-        if n_X < 1 or n_Y < 1 or n_Z < 1:
-            _Wrn(_tr("Number of elements must be at least 1"))
+
+        if n_x < 1 or n_y < 1 or n_z < 1:
+            _err(_tr("Number of elements must be at least 1."))
             return False
-        # Todo: each of the elements of the selection could be tested,
-        # not only the first one.
+
+        # TODO: this should handle multiple objects.
+        # Each of the elements of the selection should be tested.
         obj = selection[0]
         if obj.isDerivedFrom("App::FeaturePython"):
-            _Wrn(_tr("Selection is not suitable for array"))
-            _Wrn(_tr("Object:") + " {0} ({1})".format(obj.Label, obj.TypeId))
+            _err(_tr("Selection is not suitable for array."))
+            _err(_tr("Object:") + " {0} ({1})".format(obj.Label, obj.TypeId))
             return False
-        return True
 
-    def create_object(self, selection):
-        """Create the actual object."""
-        self.v_X, self.v_Y, self.v_Z = self.set_intervals()
-        self.n_X, self.n_Y, self.n_Z = self.set_numbers()
-
-        if len(selection) == 1:
-            sel_obj = selection[0]
-        else:
-            # This can be changed so a compound of multiple
-            # selected objects is produced
-            sel_obj = selection[0]
+        # The other arguments are not tested but they should be present.
+        if v_x and v_y and v_z:
+            pass
 
         self.fuse = self.form.checkbox_fuse.isChecked()
         self.use_link = self.form.checkbox_link.isChecked()
+        return True
+
+    def create_object(self):
+        """Create the new object.
+
+        At this stage we already tested that the input is correct
+        so the necessary attributes are already set.
+        Then we proceed with the internal function to create the new object.
+        """
+        if len(self.selection) == 1:
+            sel_obj = self.selection[0]
+        else:
+            # TODO: this should handle multiple objects.
+            # For example, it could take the shapes of all objects,
+            # make a compound and then use it as input for the array function.
+            sel_obj = self.selection[0]
 
         # This creates the object immediately
         # obj = Draft.makeArray(sel_obj,
-        #                       self.v_X, self.v_Y, self.v_Z,
-        #                       self.n_X, self.n_Y, self.n_Z)
+        #                       self.v_x, self.v_y, self.v_z,
+        #                       self.n_x, self.n_y, self.n_z,
+        #                       self.use_link)
         # if obj:
         #     obj.Fuse = self.fuse
 
@@ -201,146 +247,160 @@ class TaskPanelOrthoArray:
         # of this class, the GuiCommand.
         # This is needed to schedule geometry manipulation
         # that would crash Coin3D if done in the event callback.
-        _cmd = "obj = Draft.makeArray("
-        _cmd += "FreeCAD.ActiveDocument." + sel_obj.Name + ", "
-        _cmd += "arg1=" + DraftVecUtils.toString(self.v_X) + ", "
-        _cmd += "arg2=" + DraftVecUtils.toString(self.v_Y) + ", "
-        _cmd += "arg3=" + DraftVecUtils.toString(self.v_Z) + ", "
-        _cmd += "arg4=" + str(self.n_X) + ", "
-        _cmd += "arg5=" + str(self.n_Y) + ", "
-        _cmd += "arg6=" + str(self.n_Z) + ", "
+        _cmd = "draftobjects.orthoarray.make_ortho_array"
+        _cmd += "("
+        _cmd += "App.ActiveDocument." + sel_obj.Name + ", "
+        _cmd += "v_x=" + DraftVecUtils.toString(self.v_x) + ", "
+        _cmd += "v_y=" + DraftVecUtils.toString(self.v_y) + ", "
+        _cmd += "v_z=" + DraftVecUtils.toString(self.v_z) + ", "
+        _cmd += "n_x=" + str(self.n_x) + ", "
+        _cmd += "n_y=" + str(self.n_y) + ", "
+        _cmd += "n_z=" + str(self.n_z) + ", "
         _cmd += "use_link=" + str(self.use_link)
         _cmd += ")"
 
-        _cmd_list = ["FreeCADGui.addModule('Draft')",
-                     _cmd,
+        _cmd_list = ["Gui.addModule('Draft')",
+                     "Gui.addModule('draftobjects.orthoarray')",
+                     "obj = " + _cmd,
                      "obj.Fuse = " + str(self.fuse),
                      "Draft.autogroup(obj)",
-                     "FreeCAD.ActiveDocument.recompute()"]
-        self.source_command.commit("Ortho array", _cmd_list)
+                     "App.ActiveDocument.recompute()"]
 
-    def set_numbers(self):
-        """Assign the number of elements."""
-        self.n_X = self.form.spinbox_n_X.value()
-        self.n_Y = self.form.spinbox_n_Y.value()
-        self.n_Z = self.form.spinbox_n_Z.value()
-        return self.n_X, self.n_Y, self.n_Z
+        # We commit the command list through the parent command
+        self.source_command.commit(_tr(self.name), _cmd_list)
 
-    def set_intervals(self):
-        """Assign the interval vectors."""
-        v_X_x_str = self.form.input_X_x.text()
-        v_X_y_str = self.form.input_X_y.text()
-        v_X_z_str = self.form.input_X_z.text()
-        self.v_X = App.Vector(_Quantity(v_X_x_str).Value,
-                              _Quantity(v_X_y_str).Value,
-                              _Quantity(v_X_z_str).Value)
+    def get_numbers(self):
+        """Get the number of elements from the widgets."""
+        return (self.form.spinbox_n_X.value(),
+                self.form.spinbox_n_Y.value(),
+                self.form.spinbox_n_Z.value())
 
-        v_Y_x_str = self.form.input_Y_x.text()
-        v_Y_y_str = self.form.input_Y_y.text()
-        v_Y_z_str = self.form.input_Y_z.text()
-        self.v_Y = App.Vector(_Quantity(v_Y_x_str).Value,
-                              _Quantity(v_Y_y_str).Value,
-                              _Quantity(v_Y_z_str).Value)
+    def get_intervals(self):
+        """Get the interval vectors from the widgets."""
+        v_x_x_str = self.form.input_X_x.text()
+        v_x_y_str = self.form.input_X_y.text()
+        v_x_z_str = self.form.input_X_z.text()
+        v_x = App.Vector(U.Quantity(v_x_x_str).Value,
+                         U.Quantity(v_x_y_str).Value,
+                         U.Quantity(v_x_z_str).Value)
 
-        v_Z_x_str = self.form.input_Z_x.text()
-        v_Z_y_str = self.form.input_Z_y.text()
-        v_Z_z_str = self.form.input_Z_z.text()
-        self.v_Z = App.Vector(_Quantity(v_Z_x_str).Value,
-                              _Quantity(v_Z_y_str).Value,
-                              _Quantity(v_Z_z_str).Value)
-        return self.v_X, self.v_Y, self.v_Z
+        v_y_x_str = self.form.input_Y_x.text()
+        v_y_y_str = self.form.input_Y_y.text()
+        v_y_z_str = self.form.input_Y_z.text()
+        v_y = App.Vector(U.Quantity(v_y_x_str).Value,
+                         U.Quantity(v_y_y_str).Value,
+                         U.Quantity(v_y_z_str).Value)
+
+        v_z_x_str = self.form.input_Z_x.text()
+        v_z_y_str = self.form.input_Z_y.text()
+        v_z_z_str = self.form.input_Z_z.text()
+        v_z = App.Vector(U.Quantity(v_z_x_str).Value,
+                         U.Quantity(v_z_y_str).Value,
+                         U.Quantity(v_z_z_str).Value)
+        return v_x, v_y, v_z
 
     def reset_v(self, interval):
-        """Reset the interval to zero distance."""
+        """Reset the interval to zero distance.
+
+        Parameters
+        ----------
+        interval: str
+            Either "X", "Y", "Z", to reset the interval vector
+            for that direction.
+        """
         if interval == "X":
             self.form.input_X_x.setProperty('rawValue', 100)
             self.form.input_X_y.setProperty('rawValue', 0)
             self.form.input_X_z.setProperty('rawValue', 0)
-            _Msg(_tr("Interval X reset:")
-                 + " ({0}, {1}, {2})".format(self.v_X.x,
-                                             self.v_X.y,
-                                             self.v_X.z))
+            self.v_x, self.v_y, self.v_z = self.get_intervals()
+            _msg(_tr("Interval X reset:")
+                 + " ({0}, {1}, {2})".format(self.v_x.x,
+                                             self.v_x.y,
+                                             self.v_x.z))
         elif interval == "Y":
             self.form.input_Y_x.setProperty('rawValue', 0)
             self.form.input_Y_y.setProperty('rawValue', 100)
             self.form.input_Y_z.setProperty('rawValue', 0)
-            _Msg(_tr("Interval Y reset:")
-                 + " ({0}, {1}, {2})".format(self.v_Y.x,
-                                             self.v_Y.y,
-                                             self.v_Y.z))
+            self.v_x, self.v_y, self.v_z = self.get_intervals()
+            _msg(_tr("Interval Y reset:")
+                 + " ({0}, {1}, {2})".format(self.v_y.x,
+                                             self.v_y.y,
+                                             self.v_y.z))
         elif interval == "Z":
             self.form.input_Z_x.setProperty('rawValue', 0)
             self.form.input_Z_y.setProperty('rawValue', 0)
             self.form.input_Z_z.setProperty('rawValue', 100)
-            _Msg(_tr("Interval Z reset:")
-                 + " ({0}, {1}, {2})".format(self.v_Z.x,
-                                             self.v_Z.y,
-                                             self.v_Z.z))
+            self.v_x, self.v_y, self.v_z = self.get_intervals()
+            _msg(_tr("Interval Z reset:")
+                 + " ({0}, {1}, {2})".format(self.v_z.x,
+                                             self.v_z.y,
+                                             self.v_z.z))
 
-        self.n_X, self.n_Y, self.n_Z = self.set_intervals()
-
-    def print_fuse_state(self):
-        """Print the state translated."""
-        if self.fuse:
-            translated_state = QT_TRANSLATE_NOOP("Draft", "True")
+    def print_fuse_state(self, fuse):
+        """Print the fuse state translated."""
+        if fuse:
+            state = self.tr_true
         else:
-            translated_state = QT_TRANSLATE_NOOP("Draft", "False")
-        _Msg(_tr("Fuse:") + " {}".format(translated_state))
+            state = self.tr_false
+        _msg(_tr("Fuse:") + " {}".format(state))
 
     def set_fuse(self):
-        """Run callback when the fuse checkbox changes."""
+        """Execute as a callback when the fuse checkbox changes."""
         self.fuse = self.form.checkbox_fuse.isChecked()
-        self.print_fuse_state()
+        self.print_fuse_state(self.fuse)
 
-    def print_link_state(self):
-        """Print the state translated."""
-        if self.use_link:
-            translated_state = QT_TRANSLATE_NOOP("Draft", "True")
+    def print_link_state(self, use_link):
+        """Print the link state translated."""
+        if use_link:
+            state = self.tr_true
         else:
-            translated_state = QT_TRANSLATE_NOOP("Draft", "False")
-        _Msg(_tr("Use Link object:") + " {}".format(translated_state))
+            state = self.tr_false
+        _msg(_tr("Create Link array:") + " {}".format(state))
 
     def set_link(self):
-        """Run callback when the link checkbox changes."""
+        """Execute as a callback when the link checkbox changes."""
         self.use_link = self.form.checkbox_link.isChecked()
-        self.print_link_state()
+        self.print_link_state(self.use_link)
 
-    def print_messages(self, selection):
+    def print_messages(self):
         """Print messages about the operation."""
-        if len(selection) == 1:
-            sel_obj = selection[0]
+        if len(self.selection) == 1:
+            sel_obj = self.selection[0]
         else:
-            # This can be changed so a compound of multiple
-            # selected objects is produced
-            sel_obj = selection[0]
-        _Msg("{}".format(16*"-"))
-        _Msg("{}".format(self.name))
-        _Msg(_tr("Object:") + " {}".format(sel_obj.Label))
-        _Msg(_tr("Number of X elements:") + " {}".format(self.n_X))
-        _Msg(_tr("Interval X:")
-             + " ({0}, {1}, {2})".format(self.v_X.x,
-                                         self.v_X.y,
-                                         self.v_X.z))
-        _Msg(_tr("Number of Y elements:") + " {}".format(self.n_Y))
-        _Msg(_tr("Interval Y:")
-             + " ({0}, {1}, {2})".format(self.v_Y.x,
-                                         self.v_Y.y,
-                                         self.v_Y.z))
-        _Msg(_tr("Number of Z elements:") + " {}".format(self.n_Z))
-        _Msg(_tr("Interval Z:")
-             + " ({0}, {1}, {2})".format(self.v_Z.x,
-                                         self.v_Z.y,
-                                         self.v_Z.z))
-        self.print_fuse_state()
-        self.print_link_state()
+            # TODO: this should handle multiple objects.
+            # For example, it could take the shapes of all objects,
+            # make a compound and then use it as input for the array function.
+            sel_obj = self.selection[0]
+        _msg(_tr("Object:") + " {}".format(sel_obj.Label))
+        _msg(_tr("Number of X elements:") + " {}".format(self.n_x))
+        _msg(_tr("Interval X:")
+             + " ({0}, {1}, {2})".format(self.v_x.x,
+                                         self.v_x.y,
+                                         self.v_x.z))
+        _msg(_tr("Number of Y elements:") + " {}".format(self.n_y))
+        _msg(_tr("Interval Y:")
+             + " ({0}, {1}, {2})".format(self.v_y.x,
+                                         self.v_y.y,
+                                         self.v_y.z))
+        _msg(_tr("Number of Z elements:") + " {}".format(self.n_z))
+        _msg(_tr("Interval Z:")
+             + " ({0}, {1}, {2})".format(self.v_z.x,
+                                         self.v_z.y,
+                                         self.v_z.z))
+        self.print_fuse_state(self.fuse)
+        self.print_link_state(self.use_link)
 
     def reject(self):
-        """Run when clicking the Cancel button."""
-        _Msg(_tr("Aborted:") + " {}".format(self.name))
+        """Execute when clicking the Cancel button or pressing Escape."""
+        _msg(_tr("Aborted:") + " {}".format(_tr(self.name)))
         self.finish()
 
     def finish(self):
-        """Run at the end after OK or Cancel."""
+        """Finish the command, after accept or reject.
+
+        It finally calls the parent class to execute
+        the delayed functions, and perform cleanup.
+        """
         # App.ActiveDocument.commitTransaction()
         Gui.ActiveDocument.resetEdit()
         # Runs the parent command to complete the call

--- a/src/Mod/Draft/drafttaskpanels/task_orthoarray.py
+++ b/src/Mod/Draft/drafttaskpanels/task_orthoarray.py
@@ -32,6 +32,7 @@ import FreeCAD as App
 import FreeCADGui as Gui
 import Draft_rc  # include resources, icons, ui files
 import DraftVecUtils
+import draftutils.utils as utils
 from draftutils.messages import _msg, _err, _log
 from draftutils.translate import _tr
 from FreeCAD import Units as U
@@ -133,8 +134,8 @@ class TaskPanelOrthoArray:
         self.form.spinbox_n_Y.setValue(self.n_y)
         self.form.spinbox_n_Z.setValue(self.n_z)
 
-        self.fuse = False
-        self.use_link = True
+        self.fuse = utils.get_param("Draft_array_fuse", False)
+        self.use_link = utils.get_param("Draft_array_Link", True)
 
         self.form.checkbox_fuse.setChecked(self.fuse)
         self.form.checkbox_link.setChecked(self.use_link)
@@ -348,6 +349,7 @@ class TaskPanelOrthoArray:
         """Execute as a callback when the fuse checkbox changes."""
         self.fuse = self.form.checkbox_fuse.isChecked()
         self.print_fuse_state(self.fuse)
+        utils.set_param("Draft_array_fuse", self.fuse)
 
     def print_link_state(self, use_link):
         """Print the link state translated."""
@@ -361,6 +363,7 @@ class TaskPanelOrthoArray:
         """Execute as a callback when the link checkbox changes."""
         self.use_link = self.form.checkbox_link.isChecked()
         self.print_link_state(self.use_link)
+        utils.set_param("Draft_array_Link", self.use_link)
 
     def print_messages(self):
         """Print messages about the operation."""

--- a/src/Mod/Draft/drafttaskpanels/task_polararray.py
+++ b/src/Mod/Draft/drafttaskpanels/task_polararray.py
@@ -32,6 +32,7 @@ import FreeCAD as App
 import FreeCADGui as Gui
 import Draft_rc  # include resources, icons, ui files
 import DraftVecUtils
+import draftutils.utils as utils
 from draftutils.messages import _msg, _wrn, _err, _log
 from draftutils.translate import _tr
 from FreeCAD import Units as U
@@ -120,8 +121,8 @@ class TaskPanelPolarArray:
         self.form.input_c_z.setProperty('rawValue', self.center.z)
         self.form.input_c_z.setProperty('unit', length_unit)
 
-        self.fuse = False
-        self.use_link = True
+        self.fuse = utils.get_param("Draft_array_fuse", False)
+        self.use_link = utils.get_param("Draft_array_Link", True)
 
         self.form.checkbox_fuse.setChecked(self.fuse)
         self.form.checkbox_link.setChecked(self.use_link)
@@ -302,6 +303,7 @@ class TaskPanelPolarArray:
         """Execute as a callback when the fuse checkbox changes."""
         self.fuse = self.form.checkbox_fuse.isChecked()
         self.print_fuse_state(self.fuse)
+        utils.set_param("Draft_array_fuse", self.fuse)
 
     def print_link_state(self, use_link):
         """Print the link state translated."""
@@ -315,6 +317,7 @@ class TaskPanelPolarArray:
         """Execute as a callback when the link checkbox changes."""
         self.use_link = self.form.checkbox_link.isChecked()
         self.print_link_state(self.use_link)
+        utils.set_param("Draft_array_Link", self.use_link)
 
     def print_messages(self):
         """Print messages about the operation."""

--- a/src/Mod/Draft/drafttaskpanels/task_polararray.py
+++ b/src/Mod/Draft/drafttaskpanels/task_polararray.py
@@ -1,9 +1,3 @@
-"""This module provides the task panel for the Draft PolarArray tool.
-"""
-## @package task_polararray
-# \ingroup DRAFT
-# \brief This module provides the task panel code for the PolarArray tool.
-
 # ***************************************************************************
 # *   (c) 2019 Eliud Cabrera Castillo <e.cabrera-castillo@tum.de>           *
 # *                                                                         *
@@ -26,163 +20,220 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
+"""Provides the task panel for the Draft PolarArray tool."""
+## @package task_polararray
+# \ingroup DRAFT
+# \brief This module provides the task panel code for the PolarArray tool.
+
+import PySide.QtGui as QtGui
+from PySide.QtCore import QT_TRANSLATE_NOOP
 
 import FreeCAD as App
 import FreeCADGui as Gui
-# import Draft
-import Draft_rc
+import Draft_rc  # include resources, icons, ui files
 import DraftVecUtils
+from draftutils.messages import _msg, _wrn, _err, _log
+from draftutils.translate import _tr
+from FreeCAD import Units as U
 
-import PySide.QtCore as QtCore
-import PySide.QtGui as QtGui
-from PySide.QtCore import QT_TRANSLATE_NOOP
-# import DraftTools
-from DraftGui import translate
-# from DraftGui import displayExternal
-
-_Quantity = App.Units.Quantity
-
-
-def _Msg(text, end="\n"):
-    """Print message with newline"""
-    App.Console.PrintMessage(text + end)
-
-
-def _Wrn(text, end="\n"):
-    """Print warning with newline"""
-    App.Console.PrintWarning(text + end)
-
-
-def _tr(text):
-    """Function to translate with the context set"""
-    return translate("Draft", text)
-
-
-# So the resource file doesn't trigger errors from code checkers (flake8)
-True if Draft_rc.__name__ else False
+# The module is used to prevent complaints from code checkers (flake8)
+bool(Draft_rc.__name__)
 
 
 class TaskPanelPolarArray:
-    """TaskPanel for the PolarArray command.
+    """TaskPanel code for the PolarArray command.
 
     The names of the widgets are defined in the `.ui` file.
-    In this class all those widgets are automatically created
-    under the name `self.form.<name>`
+    This `.ui` file `must` be loaded into an attribute
+    called `self.form` so that it is loaded into the task panel correctly.
+
+    In this class all widgets are automatically created
+    as `self.form.<widget_name>`.
 
     The `.ui` file may use special FreeCAD widgets such as
     `Gui::InputField` (based on `QLineEdit`) and
     `Gui::QuantitySpinBox` (based on `QAbstractSpinBox`).
     See the Doxygen documentation of the corresponding files in `src/Gui/`,
     for example, `InputField.h` and `QuantitySpinBox.h`.
+
+    Attributes
+    ----------
+    source_command: gui_base.GuiCommandBase
+        This attribute holds a reference to the calling class
+        of this task panel.
+        This parent class, which is derived from `gui_base.GuiCommandBase`,
+        is responsible for calling this task panel, for installing
+        certain callbacks, and for removing them.
+
+        It also delays the execution of the internal creation commands
+        by using the `draftutils.todo.ToDo` class.
+
+    See Also
+    --------
+    * https://forum.freecadweb.org/viewtopic.php?f=10&t=40007
+    * https://forum.freecadweb.org/viewtopic.php?t=5374#p43038
     """
 
     def __init__(self):
+        self.name = "Polar array"
+        _log(_tr("Task panel:") + "{}".format(_tr(self.name)))
+
+        # The .ui file must be loaded into an attribute
+        # called `self.form` so that it is displayed in the task panel.
         ui_file = ":/ui/TaskPanel_PolarArray.ui"
         self.form = Gui.PySideUic.loadUi(ui_file)
-        self.name = self.form.windowTitle()
 
         icon_name = "Draft_PolarArray"
         svg = ":/icons/" + icon_name
         pix = QtGui.QPixmap(svg)
         icon = QtGui.QIcon.fromTheme(icon_name, QtGui.QIcon(svg))
         self.form.setWindowIcon(icon)
+        self.form.setWindowTitle(_tr(self.name))
+
         self.form.label_icon.setPixmap(pix.scaled(32, 32))
 
-        start_angle = _Quantity(180.0, App.Units.Angle)
+        # -------------------------------------------------------------------
+        # Default values for the internal function,
+        # and for the task panel interface
+        start_angle = U.Quantity(360.0, App.Units.Angle)
         angle_unit = start_angle.getUserPreferred()[2]
-        self.form.spinbox_angle.setProperty('rawValue', start_angle.Value)
-        self.form.spinbox_angle.setProperty('unit', angle_unit)
-        self.form.spinbox_number.setValue(4)
 
-        self.angle_str = self.form.spinbox_angle.text()
         self.angle = start_angle.Value
+        self.number = 5
 
-        self.number = self.form.spinbox_number.value()
+        self.form.spinbox_angle.setProperty('rawValue', self.angle)
+        self.form.spinbox_angle.setProperty('unit', angle_unit)
 
-        start_point = _Quantity(0.0, App.Units.Length)
+        self.form.spinbox_number.setValue(self.number)
+
+        start_point = U.Quantity(0.0, App.Units.Length)
         length_unit = start_point.getUserPreferred()[2]
-        self.form.input_c_x.setProperty('rawValue', start_point.Value)
+
+        self.center = App.Vector(start_point.Value,
+                                 start_point.Value,
+                                 start_point.Value)
+
+        self.form.input_c_x.setProperty('rawValue', self.center.x)
         self.form.input_c_x.setProperty('unit', length_unit)
-        self.form.input_c_y.setProperty('rawValue', start_point.Value)
+        self.form.input_c_y.setProperty('rawValue', self.center.y)
         self.form.input_c_y.setProperty('unit', length_unit)
-        self.form.input_c_z.setProperty('rawValue', start_point.Value)
+        self.form.input_c_z.setProperty('rawValue', self.center.z)
         self.form.input_c_z.setProperty('unit', length_unit)
-        self.valid_input = True
 
-        self.c_x_str = ""
-        self.c_y_str = ""
-        self.c_z_str = ""
-        self.center = App.Vector(0, 0, 0)
+        self.fuse = False
+        self.use_link = True
 
-        # Old style for Qt4
-        # QtCore.QObject.connect(self.form.button_reset,
-        #                        QtCore.SIGNAL("clicked()"),
-        #                        self.reset_point)
-        # New style for Qt5
-        self.form.button_reset.clicked.connect(self.reset_point)
+        self.form.checkbox_fuse.setChecked(self.fuse)
+        self.form.checkbox_link.setChecked(self.use_link)
+        # -------------------------------------------------------------------
+
+        # Some objects need to be selected before we can execute the function.
+        self.selection = None
+
+        # This is used to test the input of the internal function.
+        # It should be changed to True before we can execute the function.
+        self.valid_input = False
+
+        self.set_widget_callbacks()
+
+        self.tr_true = QT_TRANSLATE_NOOP("Draft", "True")
+        self.tr_false = QT_TRANSLATE_NOOP("Draft", "False")
 
         # The mask is not used at the moment, but could be used in the future
         # by a callback to restrict the coordinates of the pointer.
         self.mask = ""
 
-        # When the checkbox changes, change the fuse value
-        self.fuse = False
-        QtCore.QObject.connect(self.form.checkbox_fuse,
-                               QtCore.SIGNAL("stateChanged(int)"),
-                               self.set_fuse)
+    def set_widget_callbacks(self):
+        """Set up the callbacks (slots) for the widget signals."""
+        # New style for Qt5
+        self.form.button_reset.clicked.connect(self.reset_point)
 
-        self.use_link = False
-        QtCore.QObject.connect(self.form.checkbox_link,
-                               QtCore.SIGNAL("stateChanged(int)"),
-                               self.set_link)
+        # When the checkbox changes, change the internal value
+        self.form.checkbox_fuse.stateChanged.connect(self.set_fuse)
+        self.form.checkbox_link.stateChanged.connect(self.set_link)
+
+        # Old style for Qt4, avoid!
+        # QtCore.QObject.connect(self.form.button_reset,
+        #                        QtCore.SIGNAL("clicked()"),
+        #                        self.reset_point)
 
     def accept(self):
-        """Function that executes when clicking the OK button"""
-        selection = Gui.Selection.getSelection()
-        self.number = self.form.spinbox_number.value()
-        self.valid_input = self.validate_input(selection,
-                                               self.number)
+        """Execute when clicking the OK button or Enter key."""
+        self.selection = Gui.Selection.getSelection()
+
+        (self.number,
+         self.angle) = self.get_number_angle()
+
+        self.center = self.get_center()
+
+        self.valid_input = self.validate_input(self.selection,
+                                               self.number,
+                                               self.angle,
+                                               self.center)
         if self.valid_input:
-            self.create_object(selection)
-            self.print_messages(selection)
+            self.create_object()
+            self.print_messages()
             self.finish()
 
-    def validate_input(self, selection, number):
-        """Check that the input is valid"""
+    def validate_input(self, selection,
+                       number, angle, center):
+        """Check that the input is valid.
+
+        Some values may not need to be checked because
+        the interface may not allow to input wrong data.
+        """
         if not selection:
-            _Wrn(_tr("At least one element must be selected"))
+            _err(_tr("At least one element must be selected."))
             return False
+
+        # TODO: this should handle multiple objects.
+        # Each of the elements of the selection should be tested.
+        obj = selection[0]
+        if obj.isDerivedFrom("App::FeaturePython"):
+            _err(_tr("Selection is not suitable for array."))
+            _err(_tr("Object:") + " {}".format(selection[0].Label))
+            return False
+
         if number < 2:
-            _Wrn(_tr("Number of elements must be at least 2"))
+            _err(_tr("Number of elements must be at least 2."))
             return False
-        # Todo: each of the elements of the selection could be tested,
-        # not only the first one.
-        if selection[0].isDerivedFrom("App::FeaturePython"):
-            _Wrn(_tr("Selection is not suitable for array"))
-            _Wrn(_tr("Object:") + " {}".format(selection[0].Label))
-            return False
-        return True
 
-    def create_object(self, selection):
-        """Create the actual object"""
-        self.angle_str = self.form.spinbox_angle.text()
-        self.angle = _Quantity(self.angle_str).Value
+        if angle > 360:
+            _wrn(_tr("The angle is above 360 degrees. "
+                     "It is set to this value to proceed."))
+            self.angle = 360
+        elif angle < -360:
+            _wrn(_tr("The angle is below -360 degrees. "
+                     "It is set to this value to proceed."))
+            self.angle = -360
 
-        self.center = self.set_point()
-
-        if len(selection) == 1:
-            sel_obj = selection[0]
-        else:
-            # This can be changed so a compound of multiple
-            # selected objects is produced
-            sel_obj = selection[0]
+        # The other arguments are not tested but they should be present.
+        if center:
+            pass
 
         self.fuse = self.form.checkbox_fuse.isChecked()
         self.use_link = self.form.checkbox_link.isChecked()
+        return True
+
+    def create_object(self):
+        """Create the new object.
+
+        At this stage we already tested that the input is correct
+        so the necessary attributes are already set.
+        Then we proceed with the internal function to create the new object.
+        """
+        if len(self.selection) == 1:
+            sel_obj = self.selection[0]
+        else:
+            # TODO: this should handle multiple objects.
+            # For example, it could take the shapes of all objects,
+            # make a compound and then use it as input for the array function.
+            sel_obj = self.selection[0]
 
         # This creates the object immediately
         # obj = Draft.makeArray(sel_obj,
-        #                       self.center, self.angle, self.number)
+        #                       self.center, self.angle, self.number,
+        #                       self.use_link)
         # if obj:
         #     obj.Fuse = self.fuse
 
@@ -190,91 +241,102 @@ class TaskPanelPolarArray:
         # of this class, the GuiCommand.
         # This is needed to schedule geometry manipulation
         # that would crash Coin3D if done in the event callback.
-        _cmd = "obj = Draft.makeArray("
-        _cmd += "FreeCAD.ActiveDocument." + sel_obj.Name + ", "
-        _cmd += "arg1=" + DraftVecUtils.toString(self.center) + ", "
-        _cmd += "arg2=" + str(self.angle) + ", "
-        _cmd += "arg3=" + str(self.number) + ", "
+        _cmd = "draftobjects.polararray.make_polar_array"
+        _cmd += "("
+        _cmd += "App.ActiveDocument." + sel_obj.Name + ", "
+        _cmd += "number=" + str(self.number) + ", "
+        _cmd += "angle=" + str(self.angle) + ", "
+        _cmd += "center=" + DraftVecUtils.toString(self.center) + ", "
         _cmd += "use_link=" + str(self.use_link)
         _cmd += ")"
 
-        _cmd_list = ["FreeCADGui.addModule('Draft')",
-                     _cmd,
+        _cmd_list = ["Gui.addModule('Draft')",
+                     "Gui.addModule('draftobjects.polararray')",
+                     "obj = " + _cmd,
                      "obj.Fuse = " + str(self.fuse),
                      "Draft.autogroup(obj)",
-                     "FreeCAD.ActiveDocument.recompute()"]
-        self.source_command.commit("Polar array", _cmd_list)
+                     "App.ActiveDocument.recompute()"]
 
-    def set_point(self):
-        """Assign the values to the center"""
-        self.c_x_str = self.form.input_c_x.text()
-        self.c_y_str = self.form.input_c_y.text()
-        self.c_z_str = self.form.input_c_z.text()
-        center = App.Vector(_Quantity(self.c_x_str).Value,
-                            _Quantity(self.c_y_str).Value,
-                            _Quantity(self.c_z_str).Value)
+        # We commit the command list through the parent command
+        self.source_command.commit(_tr(self.name), _cmd_list)
+
+    def get_number_angle(self):
+        """Get the number and angle parameters from the widgets."""
+        number = self.form.spinbox_number.value()
+
+        angle_str = self.form.spinbox_angle.text()
+        angle = U.Quantity(angle_str).Value
+        return number, angle
+
+    def get_center(self):
+        """Get the value of the center from the widgets."""
+        c_x_str = self.form.input_c_x.text()
+        c_y_str = self.form.input_c_y.text()
+        c_z_str = self.form.input_c_z.text()
+        center = App.Vector(U.Quantity(c_x_str).Value,
+                            U.Quantity(c_y_str).Value,
+                            U.Quantity(c_z_str).Value)
         return center
 
     def reset_point(self):
-        """Reset the point to the original distance"""
+        """Reset the center point to the original distance."""
         self.form.input_c_x.setProperty('rawValue', 0)
         self.form.input_c_y.setProperty('rawValue', 0)
         self.form.input_c_z.setProperty('rawValue', 0)
 
-        self.center = self.set_point()
-        _Msg(_tr("Center reset:")
+        self.center = self.get_center()
+        _msg(_tr("Center reset:")
              + " ({0}, {1}, {2})".format(self.center.x,
                                          self.center.y,
                                          self.center.z))
 
-    def print_fuse_state(self):
-        """Print the state translated"""
-        if self.fuse:
-            translated_state = QT_TRANSLATE_NOOP("Draft", "True")
+    def print_fuse_state(self, fuse):
+        """Print the fuse state translated."""
+        if fuse:
+            state = self.tr_true
         else:
-            translated_state = QT_TRANSLATE_NOOP("Draft", "False")
-        _Msg(_tr("Fuse:") + " {}".format(translated_state))
+            state = self.tr_false
+        _msg(_tr("Fuse:") + " {}".format(state))
 
     def set_fuse(self):
-        """This function is called when the fuse checkbox changes"""
+        """Execute as a callback when the fuse checkbox changes."""
         self.fuse = self.form.checkbox_fuse.isChecked()
-        self.print_fuse_state()
+        self.print_fuse_state(self.fuse)
 
-    def print_link_state(self):
-        """Print the state translated"""
-        if self.use_link:
-            translated_state = QT_TRANSLATE_NOOP("Draft", "True")
+    def print_link_state(self, use_link):
+        """Print the link state translated."""
+        if use_link:
+            state = self.tr_true
         else:
-            translated_state = QT_TRANSLATE_NOOP("Draft", "False")
-        _Msg(_tr("Use Link object:") + " {}".format(translated_state))
+            state = self.tr_false
+        _msg(_tr("Create Link array:") + " {}".format(state))
 
     def set_link(self):
-        """This function is called when the fuse checkbox changes"""
+        """Execute as a callback when the link checkbox changes."""
         self.use_link = self.form.checkbox_link.isChecked()
-        self.print_link_state()
+        self.print_link_state(self.use_link)
 
-    def print_messages(self, selection):
-        """Print messages about the operation"""
-        if len(selection) == 1:
-            sel_obj = selection[0]
+    def print_messages(self):
+        """Print messages about the operation."""
+        if len(self.selection) == 1:
+            sel_obj = self.selection[0]
         else:
-            # This can be changed so a compound of multiple
-            # selected objects is produced
-            sel_obj = selection[0]
-        _Msg("{}".format(16*"-"))
-        _Msg("{}".format(self.name))
-        _Msg(_tr("Object:") + " {}".format(sel_obj.Label))
-        _Msg(_tr("Start angle:") + " {}".format(self.angle_str))
-        _Msg(_tr("Number of elements:") + " {}".format(self.number))
-        _Msg(_tr("Center of rotation:")
+            # TODO: this should handle multiple objects.
+            # For example, it could take the shapes of all objects,
+            # make a compound and then use it as input for the array function.
+            sel_obj = self.selection[0]
+        _msg(_tr("Object:") + " {}".format(sel_obj.Label))
+        _msg(_tr("Number of elements:") + " {}".format(self.number))
+        _msg(_tr("Polar angle:") + " {}".format(self.angle))
+        _msg(_tr("Center of rotation:")
              + " ({0}, {1}, {2})".format(self.center.x,
                                          self.center.y,
                                          self.center.z))
-        self.print_fuse_state()
-        self.print_link_state()
+        self.print_fuse_state(self.fuse)
+        self.print_link_state(self.use_link)
 
     def display_point(self, point=None, plane=None, mask=None):
-        """Displays the coordinates in the x, y, and z widgets.
+        """Display the coordinates in the x, y, and z widgets.
 
         This function should be used in a Coin callback so that
         the coordinate values are automatically updated when the
@@ -331,6 +393,9 @@ class TaskPanelPolarArray:
                 # sbz.setText(displayExternal(dp.z, None, 'Length'))
                 self.form.input_c_z.setProperty('rawValue', dp.z)
 
+        if plane:
+            pass
+
         # Set masks
         if (mask == "x") or (self.mask == "x"):
             self.form.input_c_x.setEnabled(True)
@@ -354,7 +419,7 @@ class TaskPanelPolarArray:
             self.set_focus()
 
     def set_focus(self, key=None):
-        """Set the focus on the widget that receives the key signal"""
+        """Set the focus on the widget that receives the key signal."""
         if key is None or key == "x":
             self.form.input_c_x.setFocus()
             self.form.input_c_x.selectAll()
@@ -366,12 +431,16 @@ class TaskPanelPolarArray:
             self.form.input_c_z.selectAll()
 
     def reject(self):
-        """Function that executes when clicking the Cancel button"""
-        _Msg(_tr("Aborted:") + " {}".format(self.name))
+        """Execute when clicking the Cancel button or pressing Escape."""
+        _msg(_tr("Aborted:") + " {}".format(_tr(self.name)))
         self.finish()
 
     def finish(self):
-        """Function that runs at the end after OK or Cancel"""
+        """Finish the command, after accept or reject.
+
+        It finally calls the parent class to execute
+        the delayed functions, and perform cleanup.
+        """
         # App.ActiveDocument.commitTransaction()
         Gui.ActiveDocument.resetEdit()
         # Runs the parent command to complete the call

--- a/src/Mod/Draft/draftutils/utils.py
+++ b/src/Mod/Draft/draftutils/utils.py
@@ -157,7 +157,8 @@ def get_param_type(param):
                    "SvgLinesBlack", "dxfStdSize", "showSnapBar",
                    "hideSnapBar", "alwaysShowGrid", "renderPolylineWidth",
                    "showPlaneTracker", "UsePartPrimitives",
-                   "DiscretizeEllipses", "showUnit"):
+                   "DiscretizeEllipses", "showUnit",
+                   "Draft_array_fuse", "Draft_array_Link"):
         return "bool"
     elif param in ("color", "constructioncolor",
                    "snapcolor", "gridColor"):


### PR DESCRIPTION
Cleanup of the task panel code for the new arrays in `drafttaskpanels/` and the corresponding `.ui` file in `Resources/ui/`. Also small tweaks to the GuiCommand code in the `draftguitools/`.

In the task panel interface, the Link array is set to be created by default. This will allow more users to test the `App::Link` functionality (#2350, #2989). The traditional array object can be created by deactivating the "Link array" checkbox.

This has to be merged after #3157 because it assumes many things are already in place introduced by that request and also by #3082.

Forum thread: [[Discussion] Splitting Draft tools into their own modules](https://forum.freecadweb.org/viewtopic.php?f=23&t=38593&p=375838#p375838)

---

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists