### PR TITLE
[TD] Fix label of angular dimensions

### DIFF
--- a/src/Mod/TechDraw/Gui/QGIViewDimension.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewDimension.cpp
@@ -807,8 +807,8 @@ int QGIViewDimension::compareAngleStraightness(double straightAngle, double left
 
 double QGIViewDimension::getIsoStandardLinePlacement(double labelAngle)
 {
-    // According to ISO 129-1 Standard Figure 23, the bordering angle is 2/3 PI, resp. -1/3 PI
-    return labelAngle < -M_PI/3.0 || labelAngle > +2.0*M_PI/3.0
+    // According to ISO 129-1 Standard Figure 23, the bordering angle is 1/2 PI, resp. -1/2 PI
+    return labelAngle < -M_PI/2.0 || labelAngle > +M_PI/2.0
            ? +1.0 : -1.0;
 }
 


### PR DESCRIPTION
According to ISO 129-1 labels of angular dimensions may never be upside
down (that is also true for other labels but not relevant for this
commit).
I am not sure where else that function I changed gets used, but in my tests I couldn't find any problems cause by the change.