### PR TITLE
App: change Link array behavior

### DIFF
--- a/src/App/Link.cpp
+++ b/src/App/Link.cpp
@@ -301,7 +301,8 @@ int LinkBaseExtension::_getElementCountValue() const {
 }
 
 bool LinkBaseExtension::extensionHasChildElement() const {
-    if(_getElementListProperty() || _getElementCountValue())
+    if(_getElementListValue().size() 
+            || (_getElementCountValue() && _getShowElementValue()))
         return true;
     DocumentObject *linked = getTrueLinkedObject(false);
     if(linked) {


### PR DESCRIPTION
Do not behave as group when Link array is collapsed (i.e. ShowElement is false)

Requested at https://forum.freecadweb.org/viewtopic.php?p=376673#p376576