### PR TITLE
Draft: move GuiCommands to separate modules from DraftTools.py

### DIFF
--- a/src/Mod/Draft/CMakeLists.txt
+++ b/src/Mod/Draft/CMakeLists.txt
@@ -89,6 +89,7 @@ SET(Draft_GUI_tools
     draftguitools/gui_edit.py
     draftguitools/gui_lineops.py
     draftguitools/gui_togglemodes.py
+    draftguitools/gui_groups.py
     draftguitools/README.md
 )
 

--- a/src/Mod/Draft/CMakeLists.txt
+++ b/src/Mod/Draft/CMakeLists.txt
@@ -94,6 +94,7 @@ SET(Draft_GUI_tools
     draftguitools/gui_heal.py
     draftguitools/gui_dimension_ops.py
     draftguitools/gui_lineslope.py
+    draftguitools/gui_arcs.py
     draftguitools/README.md
 )
 

--- a/src/Mod/Draft/CMakeLists.txt
+++ b/src/Mod/Draft/CMakeLists.txt
@@ -92,6 +92,7 @@ SET(Draft_GUI_tools
     draftguitools/gui_groups.py
     draftguitools/gui_grid.py
     draftguitools/gui_heal.py
+    draftguitools/gui_dimension_ops.py
     draftguitools/README.md
 )
 

--- a/src/Mod/Draft/CMakeLists.txt
+++ b/src/Mod/Draft/CMakeLists.txt
@@ -88,6 +88,7 @@ SET(Draft_GUI_tools
     draftguitools/gui_trackers.py
     draftguitools/gui_edit.py
     draftguitools/gui_lineops.py
+    draftguitools/gui_togglemodes.py
     draftguitools/README.md
 )
 

--- a/src/Mod/Draft/CMakeLists.txt
+++ b/src/Mod/Draft/CMakeLists.txt
@@ -90,6 +90,7 @@ SET(Draft_GUI_tools
     draftguitools/gui_lineops.py
     draftguitools/gui_togglemodes.py
     draftguitools/gui_groups.py
+    draftguitools/gui_grid.py
     draftguitools/README.md
 )
 

--- a/src/Mod/Draft/CMakeLists.txt
+++ b/src/Mod/Draft/CMakeLists.txt
@@ -91,6 +91,7 @@ SET(Draft_GUI_tools
     draftguitools/gui_togglemodes.py
     draftguitools/gui_groups.py
     draftguitools/gui_grid.py
+    draftguitools/gui_heal.py
     draftguitools/README.md
 )
 

--- a/src/Mod/Draft/CMakeLists.txt
+++ b/src/Mod/Draft/CMakeLists.txt
@@ -87,6 +87,7 @@ SET(Draft_GUI_tools
     draftguitools/gui_snapper.py
     draftguitools/gui_trackers.py
     draftguitools/gui_edit.py
+    draftguitools/gui_lineops.py
     draftguitools/README.md
 )
 

--- a/src/Mod/Draft/CMakeLists.txt
+++ b/src/Mod/Draft/CMakeLists.txt
@@ -93,6 +93,7 @@ SET(Draft_GUI_tools
     draftguitools/gui_grid.py
     draftguitools/gui_heal.py
     draftguitools/gui_dimension_ops.py
+    draftguitools/gui_lineslope.py
     draftguitools/README.md
 )
 

--- a/src/Mod/Draft/DraftTools.py
+++ b/src/Mod/Draft/DraftTools.py
@@ -82,6 +82,7 @@ from draftguitools.gui_lineops import CloseLine
 from draftguitools.gui_lineops import UndoLine
 from draftguitools.gui_togglemodes import ToggleConstructionMode
 from draftguitools.gui_togglemodes import ToggleContinueMode
+from draftguitools.gui_togglemodes import ToggleDisplayMode
 # import DraftFillet
 import drafttaskpanels.task_shapestring as task_shapestring
 import drafttaskpanels.task_scale as task_scale
@@ -4198,30 +4199,6 @@ class Drawing(Modifier):
         return page
 
 
-class ToggleDisplayMode():
-    """The ToggleDisplayMode FreeCAD command definition"""
-
-    def GetResources(self):
-        return {'Pixmap'  : 'Draft_SwitchMode',
-                'Accel' : "Shift+Space",
-                'MenuText': QtCore.QT_TRANSLATE_NOOP("Draft_ToggleDisplayMode", "Toggle display mode"),
-                'ToolTip' : QtCore.QT_TRANSLATE_NOOP("Draft_ToggleDisplayMode", "Swaps display mode of selected objects between wireframe and flatlines")}
-
-    def IsActive(self):
-        if FreeCADGui.Selection.getSelection():
-            return True
-        else:
-            return False
-
-    def Activated(self):
-        for obj in FreeCADGui.Selection.getSelection():
-            if obj.ViewObject.DisplayMode == "Flat Lines":
-                if "Wireframe" in obj.ViewObject.listDisplayModes():
-                    obj.ViewObject.DisplayMode = "Wireframe"
-            elif obj.ViewObject.DisplayMode == "Wireframe":
-                if "Flat Lines" in obj.ViewObject.listDisplayModes():
-                    obj.ViewObject.DisplayMode = "Flat Lines"
-
 class SubelementHighlight(Modifier):
     """The Draft_SubelementHighlight FreeCAD command definition"""
 
@@ -5422,7 +5399,6 @@ FreeCADGui.addCommand('Draft_Stretch',Stretch())
 
 # context commands
 FreeCADGui.addCommand('Draft_ApplyStyle',ApplyStyle())
-FreeCADGui.addCommand('Draft_ToggleDisplayMode',ToggleDisplayMode())
 FreeCADGui.addCommand('Draft_AddToGroup',AddToGroup())
 FreeCADGui.addCommand('Draft_SelectGroup',SelectGroup())
 FreeCADGui.addCommand('Draft_Shape2DView',Shape2DView())

--- a/src/Mod/Draft/DraftTools.py
+++ b/src/Mod/Draft/DraftTools.py
@@ -86,6 +86,7 @@ from draftguitools.gui_togglemodes import ToggleDisplayMode
 from draftguitools.gui_groups import AddToGroup
 from draftguitools.gui_groups import SelectGroup
 from draftguitools.gui_groups import SetAutoGroup
+from draftguitools.gui_groups import Draft_AddConstruction
 from draftguitools.gui_grid import ToggleGrid
 from draftguitools.gui_heal import Heal
 from draftguitools.gui_dimension_ops import Draft_FlipDimension
@@ -5001,37 +5002,6 @@ class Draft_Label(Creator):
             self.create()
 
 
-class Draft_AddConstruction():
-
-    def GetResources(self):
-        return {'Pixmap'  : 'Draft_Construction',
-                'MenuText': QtCore.QT_TRANSLATE_NOOP("Draft_AddConstruction", "Add to Construction group"),
-                'ToolTip' : QtCore.QT_TRANSLATE_NOOP("Draft_AddConstruction", "Adds the selected objects to the Construction group")}
-
-    def Activated(self):
-        import FreeCADGui
-        if hasattr(FreeCADGui,"draftToolBar"):
-            col = FreeCADGui.draftToolBar.getDefaultColor("constr")
-            col = (float(col[0]),float(col[1]),float(col[2]),0.0)
-            gname = Draft.getParam("constructiongroupname","Construction")
-            grp = FreeCAD.ActiveDocument.getObject(gname)
-            if not grp:
-                grp = FreeCAD.ActiveDocument.addObject("App::DocumentObjectGroup",gname)
-            for obj in FreeCADGui.Selection.getSelection():
-                grp.addObject(obj)
-                obrep = obj.ViewObject
-                if "TextColor" in obrep.PropertiesList:
-                    obrep.TextColor = col
-                if "PointColor" in obrep.PropertiesList:
-                    obrep.PointColor = col
-                if "LineColor" in obrep.PropertiesList:
-                    obrep.LineColor = col
-                if "ShapeColor" in obrep.PropertiesList:
-                    obrep.ShapeColor = col
-                if hasattr(obrep,"Transparency"):
-                    obrep.Transparency = 80
-
-
 class Draft_Arc_3Points:
 
 
@@ -5178,7 +5148,6 @@ FreeCADGui.addCommand('Draft_Stretch',Stretch())
 # context commands
 FreeCADGui.addCommand('Draft_ApplyStyle',ApplyStyle())
 FreeCADGui.addCommand('Draft_Shape2DView',Shape2DView())
-FreeCADGui.addCommand('Draft_AddConstruction',Draft_AddConstruction())
 
 # a global place to look for active draft Command
 FreeCAD.activeDraftCommand = None

--- a/src/Mod/Draft/DraftTools.py
+++ b/src/Mod/Draft/DraftTools.py
@@ -85,6 +85,7 @@ from draftguitools.gui_togglemodes import ToggleContinueMode
 from draftguitools.gui_togglemodes import ToggleDisplayMode
 from draftguitools.gui_groups import AddToGroup
 from draftguitools.gui_groups import SelectGroup
+from draftguitools.gui_grid import ToggleGrid
 # import DraftFillet
 import drafttaskpanels.task_shapestring as task_shapestring
 import drafttaskpanels.task_scale as task_scale
@@ -4704,27 +4705,6 @@ class Draft_Clone(Modifier):
             ToDo.delay(FreeCADGui.runCommand, "Draft_Move")
 
 
-class ToggleGrid():
-    """The Draft ToggleGrid command definition"""
-
-    def GetResources(self):
-        return {'Pixmap'  : 'Draft_Grid',
-                'Accel' : "G,R",
-                'MenuText': QtCore.QT_TRANSLATE_NOOP("Draft_ToggleGrid", "Toggle Grid"),
-                'ToolTip' : QtCore.QT_TRANSLATE_NOOP("Draft_ToggleGrid", "Toggles the Draft grid on/off"),
-                'CmdType' : 'ForEdit'}
-
-    def Activated(self):
-        if hasattr(FreeCADGui,"Snapper"):
-            FreeCADGui.Snapper.setTrackers()
-            if FreeCADGui.Snapper.grid:
-                if FreeCADGui.Snapper.grid.Visible:
-                    FreeCADGui.Snapper.grid.off()
-                    FreeCADGui.Snapper.forceGridOff=True
-                else:
-                    FreeCADGui.Snapper.grid.on()
-                    FreeCADGui.Snapper.forceGridOff=False
-
 class Heal():
     """The Draft Heal command definition"""
 
@@ -5339,7 +5319,6 @@ FreeCADGui.addCommand('Draft_Stretch',Stretch())
 # context commands
 FreeCADGui.addCommand('Draft_ApplyStyle',ApplyStyle())
 FreeCADGui.addCommand('Draft_Shape2DView',Shape2DView())
-FreeCADGui.addCommand('Draft_ToggleGrid',ToggleGrid())
 FreeCADGui.addCommand('Draft_FlipDimension',Draft_FlipDimension())
 FreeCADGui.addCommand('Draft_AutoGroup',SetAutoGroup())
 FreeCADGui.addCommand('Draft_AddConstruction',Draft_AddConstruction())

--- a/src/Mod/Draft/DraftTools.py
+++ b/src/Mod/Draft/DraftTools.py
@@ -80,6 +80,8 @@ import draftguitools.gui_planeproxy
 from draftguitools.gui_lineops import FinishLine
 from draftguitools.gui_lineops import CloseLine
 from draftguitools.gui_lineops import UndoLine
+from draftguitools.gui_togglemodes import ToggleConstructionMode
+from draftguitools.gui_togglemodes import ToggleContinueMode
 # import DraftFillet
 import drafttaskpanels.task_shapestring as task_shapestring
 import drafttaskpanels.task_scale as task_scale
@@ -4124,30 +4126,6 @@ class Scale(Modifier):
         for ghost in self.ghosts:
             ghost.finalize()
 
-class ToggleConstructionMode():
-    """The Draft_ToggleConstructionMode FreeCAD command definition"""
-
-    def GetResources(self):
-        return {'Pixmap'  : 'Draft_Construction',
-                'MenuText': QtCore.QT_TRANSLATE_NOOP("Draft_ToggleConstructionMode", "Toggle Construction Mode"),
-                'Accel' : "C, M",
-                'ToolTip': QtCore.QT_TRANSLATE_NOOP("Draft_ToggleConstructionMode", "Toggles the Construction Mode for next objects.")}
-
-    def Activated(self):
-        FreeCADGui.draftToolBar.constrButton.toggle()
-
-
-class ToggleContinueMode():
-    """The Draft_ToggleContinueMode FreeCAD command definition"""
-
-    def GetResources(self):
-        return {'Pixmap'  : 'Draft_Rotate',
-                'MenuText': QtCore.QT_TRANSLATE_NOOP("Draft_ToggleContinueMode", "Toggle Continue Mode"),
-                'ToolTip': QtCore.QT_TRANSLATE_NOOP("Draft_ToggleContinueMode", "Toggles the Continue Mode for next commands.")}
-
-    def Activated(self):
-        FreeCADGui.draftToolBar.toggleContinue()
-
 
 class Drawing(Modifier):
     """The Draft Drawing command definition"""
@@ -5443,8 +5421,6 @@ FreeCADGui.addCommand('Draft_Slope',Draft_Slope())
 FreeCADGui.addCommand('Draft_Stretch',Stretch())
 
 # context commands
-FreeCADGui.addCommand('Draft_ToggleConstructionMode',ToggleConstructionMode())
-FreeCADGui.addCommand('Draft_ToggleContinueMode',ToggleContinueMode())
 FreeCADGui.addCommand('Draft_ApplyStyle',ApplyStyle())
 FreeCADGui.addCommand('Draft_ToggleDisplayMode',ToggleDisplayMode())
 FreeCADGui.addCommand('Draft_AddToGroup',AddToGroup())

--- a/src/Mod/Draft/DraftTools.py
+++ b/src/Mod/Draft/DraftTools.py
@@ -83,6 +83,7 @@ from draftguitools.gui_lineops import UndoLine
 from draftguitools.gui_togglemodes import ToggleConstructionMode
 from draftguitools.gui_togglemodes import ToggleContinueMode
 from draftguitools.gui_togglemodes import ToggleDisplayMode
+from draftguitools.gui_groups import AddToGroup
 # import DraftFillet
 import drafttaskpanels.task_shapestring as task_shapestring
 import drafttaskpanels.task_scale as task_scale
@@ -4288,49 +4289,6 @@ class SubelementHighlight(Modifier):
                 # This can occur if objects have had graph changing operations
                 pass
 
-class AddToGroup():
-    """The AddToGroup FreeCAD command definition"""
-
-    def GetResources(self):
-        return {'Pixmap'  : 'Draft_AddToGroup',
-                'MenuText': QtCore.QT_TRANSLATE_NOOP("Draft_AddToGroup", "Move to group..."),
-                'ToolTip': QtCore.QT_TRANSLATE_NOOP("Draft_AddToGroup", "Moves the selected object(s) to an existing group")}
-
-    def IsActive(self):
-        if FreeCADGui.Selection.getSelection():
-            return True
-        else:
-            return False
-
-    def Activated(self):
-        self.groups = ["Ungroup"]
-        self.groups.extend(Draft.getGroupNames())
-        self.labels = ["Ungroup"]
-        for g in self.groups:
-            o = FreeCAD.ActiveDocument.getObject(g)
-            if o: self.labels.append(o.Label)
-        self.ui = FreeCADGui.draftToolBar
-        self.ui.sourceCmd = self
-        self.ui.popupMenu(self.labels)
-
-    def proceed(self,labelname):
-        self.ui.sourceCmd = None
-        if labelname == "Ungroup":
-            for obj in FreeCADGui.Selection.getSelection():
-                try:
-                    Draft.ungroup(obj)
-                except:
-                    pass
-        else:
-            if labelname in self.labels:
-                i = self.labels.index(labelname)
-                g = FreeCAD.ActiveDocument.getObject(self.groups[i])
-                for obj in FreeCADGui.Selection.getSelection():
-                    try:
-                        g.addObject(obj)
-                    except:
-                        pass
-
 
 class WireToBSpline(Modifier):
     """The Draft_Wire2BSpline FreeCAD command definition"""
@@ -5399,7 +5357,6 @@ FreeCADGui.addCommand('Draft_Stretch',Stretch())
 
 # context commands
 FreeCADGui.addCommand('Draft_ApplyStyle',ApplyStyle())
-FreeCADGui.addCommand('Draft_AddToGroup',AddToGroup())
 FreeCADGui.addCommand('Draft_SelectGroup',SelectGroup())
 FreeCADGui.addCommand('Draft_Shape2DView',Shape2DView())
 FreeCADGui.addCommand('Draft_ShowSnapBar',ShowSnapBar())

--- a/src/Mod/Draft/DraftTools.py
+++ b/src/Mod/Draft/DraftTools.py
@@ -5250,6 +5250,21 @@ class Draft_Arc_3Points:
 #---------------------------------------------------------------------------
 # Snap tools
 #---------------------------------------------------------------------------
+from draftguitools.gui_snaps import Draft_Snap_Lock
+from draftguitools.gui_snaps import Draft_Snap_Midpoint
+from draftguitools.gui_snaps import Draft_Snap_Perpendicular
+from draftguitools.gui_snaps import Draft_Snap_Grid
+from draftguitools.gui_snaps import Draft_Snap_Intersection
+from draftguitools.gui_snaps import Draft_Snap_Parallel
+from draftguitools.gui_snaps import Draft_Snap_Endpoint
+from draftguitools.gui_snaps import Draft_Snap_Angle
+from draftguitools.gui_snaps import Draft_Snap_Center
+from draftguitools.gui_snaps import Draft_Snap_Extension
+from draftguitools.gui_snaps import Draft_Snap_Near
+from draftguitools.gui_snaps import Draft_Snap_Ortho
+from draftguitools.gui_snaps import Draft_Snap_Special
+from draftguitools.gui_snaps import Draft_Snap_Dimensions
+from draftguitools.gui_snaps import Draft_Snap_WorkingPlane
 from draftguitools.gui_snaps import ShowSnapBar
 
 #---------------------------------------------------------------------------

--- a/src/Mod/Draft/DraftTools.py
+++ b/src/Mod/Draft/DraftTools.py
@@ -84,6 +84,7 @@ from draftguitools.gui_togglemodes import ToggleConstructionMode
 from draftguitools.gui_togglemodes import ToggleContinueMode
 from draftguitools.gui_togglemodes import ToggleDisplayMode
 from draftguitools.gui_groups import AddToGroup
+from draftguitools.gui_groups import SelectGroup
 # import DraftFillet
 import drafttaskpanels.task_shapestring as task_shapestring
 import drafttaskpanels.task_scale as task_scale
@@ -4337,38 +4338,6 @@ class WireToBSpline(Modifier):
                             self.finish()
 
 
-class SelectGroup():
-    """The SelectGroup FreeCAD command definition"""
-
-    def GetResources(self):
-        return {'Pixmap'  : 'Draft_SelectGroup',
-                'MenuText': QtCore.QT_TRANSLATE_NOOP("Draft_SelectGroup", "Select group"),
-                'ToolTip': QtCore.QT_TRANSLATE_NOOP("Draft_SelectGroup", "Selects all objects with the same parents as this group")}
-
-    def IsActive(self):
-        if FreeCADGui.Selection.getSelection():
-            return True
-        else:
-            return False
-
-    def Activated(self):
-        sellist = []
-        sel = FreeCADGui.Selection.getSelection()
-        if len(sel) == 1:
-            if sel[0].isDerivedFrom("App::DocumentObjectGroup"):
-                cts = Draft.getGroupContents(FreeCADGui.Selection.getSelection())
-                for o in cts:
-                    FreeCADGui.Selection.addSelection(o)
-                return
-        for ob in sel:
-            for child in ob.OutList:
-                FreeCADGui.Selection.addSelection(child)
-            for parent in ob.InList:
-                FreeCADGui.Selection.addSelection(parent)
-                for child in parent.OutList:
-                    FreeCADGui.Selection.addSelection(child)
-
-
 class Shape2DView(Modifier):
     """The Shape2DView FreeCAD command definition"""
 
@@ -5357,7 +5326,6 @@ FreeCADGui.addCommand('Draft_Stretch',Stretch())
 
 # context commands
 FreeCADGui.addCommand('Draft_ApplyStyle',ApplyStyle())
-FreeCADGui.addCommand('Draft_SelectGroup',SelectGroup())
 FreeCADGui.addCommand('Draft_Shape2DView',Shape2DView())
 FreeCADGui.addCommand('Draft_ShowSnapBar',ShowSnapBar())
 FreeCADGui.addCommand('Draft_ToggleGrid',ToggleGrid())

--- a/src/Mod/Draft/DraftTools.py
+++ b/src/Mod/Draft/DraftTools.py
@@ -77,6 +77,9 @@ if not hasattr(FreeCAD, "DraftWorkingPlane"):
 import draftguitools.gui_edit
 import draftguitools.gui_selectplane
 import draftguitools.gui_planeproxy
+from draftguitools.gui_lineops import FinishLine
+from draftguitools.gui_lineops import CloseLine
+from draftguitools.gui_lineops import UndoLine
 # import DraftFillet
 import drafttaskpanels.task_shapestring as task_shapestring
 import drafttaskpanels.task_scale as task_scale
@@ -978,66 +981,6 @@ class CubicBezCurve(Line):
         if self.ui:
             if self.ui.continueMode:
                 self.Activated()
-
-
-class FinishLine:
-    """a FreeCAD command to finish any running Line drawing operation"""
-
-    def Activated(self):
-        if (FreeCAD.activeDraftCommand != None):
-            if (FreeCAD.activeDraftCommand.featureName == "Line"):
-                FreeCAD.activeDraftCommand.finish(False)
-
-    def GetResources(self):
-        return {'Pixmap'  : 'Draft_Finish',
-                'MenuText': QtCore.QT_TRANSLATE_NOOP("Draft_FinishLine", "Finish line"),
-                'ToolTip': QtCore.QT_TRANSLATE_NOOP("Draft_FinishLine", "Finishes a line without closing it")}
-
-    def IsActive(self):
-        if FreeCADGui.ActiveDocument:
-            return True
-        else:
-            return False
-
-
-class CloseLine:
-    """a FreeCAD command to close any running Line drawing operation"""
-
-    def Activated(self):
-        if (FreeCAD.activeDraftCommand != None):
-            if (FreeCAD.activeDraftCommand.featureName == "Line"):
-                FreeCAD.activeDraftCommand.finish(True)
-
-    def GetResources(self):
-        return {'Pixmap'  : 'Draft_Lock',
-                'MenuText': QtCore.QT_TRANSLATE_NOOP("Draft_CloseLine", "Close Line"),
-                'ToolTip': QtCore.QT_TRANSLATE_NOOP("Draft_CloseLine", "Closes the line being drawn")}
-
-    def IsActive(self):
-        if FreeCADGui.ActiveDocument:
-            return True
-        else:
-            return False
-
-
-class UndoLine:
-    """a FreeCAD command to undo last drawn segment of a line"""
-
-    def Activated(self):
-        if (FreeCAD.activeDraftCommand != None):
-            if (FreeCAD.activeDraftCommand.featureName == "Line"):
-                FreeCAD.activeDraftCommand.undolast()
-
-    def GetResources(self):
-        return {'Pixmap'  : 'Draft_Rotate',
-                'MenuText': QtCore.QT_TRANSLATE_NOOP("Draft_UndoLine", "Undo last segment"),
-                'ToolTip': QtCore.QT_TRANSLATE_NOOP("Draft_UndoLine", "Undoes the last drawn segment of the line being drawn")}
-
-    def IsActive(self):
-        if FreeCADGui.ActiveDocument:
-            return True
-        else:
-            return False
 
 
 class Rectangle(Creator):
@@ -5500,9 +5443,6 @@ FreeCADGui.addCommand('Draft_Slope',Draft_Slope())
 FreeCADGui.addCommand('Draft_Stretch',Stretch())
 
 # context commands
-FreeCADGui.addCommand('Draft_FinishLine',FinishLine())
-FreeCADGui.addCommand('Draft_CloseLine',CloseLine())
-FreeCADGui.addCommand('Draft_UndoLine',UndoLine())
 FreeCADGui.addCommand('Draft_ToggleConstructionMode',ToggleConstructionMode())
 FreeCADGui.addCommand('Draft_ToggleContinueMode',ToggleContinueMode())
 FreeCADGui.addCommand('Draft_ApplyStyle',ApplyStyle())

--- a/src/Mod/Draft/DraftTools.py
+++ b/src/Mod/Draft/DraftTools.py
@@ -86,6 +86,7 @@ from draftguitools.gui_togglemodes import ToggleDisplayMode
 from draftguitools.gui_groups import AddToGroup
 from draftguitools.gui_groups import SelectGroup
 from draftguitools.gui_grid import ToggleGrid
+from draftguitools.gui_heal import Heal
 # import DraftFillet
 import drafttaskpanels.task_shapestring as task_shapestring
 import drafttaskpanels.task_scale as task_scale
@@ -4705,24 +4706,6 @@ class Draft_Clone(Modifier):
             ToDo.delay(FreeCADGui.runCommand, "Draft_Move")
 
 
-class Heal():
-    """The Draft Heal command definition"""
-
-    def GetResources(self):
-        return {'Pixmap'  : 'Draft_Heal',
-                'MenuText': QtCore.QT_TRANSLATE_NOOP("Draft_Heal", "Heal"),
-                'ToolTip' : QtCore.QT_TRANSLATE_NOOP("Draft_Heal", "Heal faulty Draft objects saved from an earlier FreeCAD version")}
-
-    def Activated(self):
-        s = FreeCADGui.Selection.getSelection()
-        FreeCAD.ActiveDocument.openTransaction("Heal")
-        if s:
-            Draft.heal(s)
-        else:
-            Draft.heal()
-        FreeCAD.ActiveDocument.commitTransaction()
-
-
 class Draft_Facebinder(Creator):
     """The Draft Facebinder command definition"""
 
@@ -5311,7 +5294,6 @@ FreeCADGui.addCommand('Draft_Clone',Draft_Clone())
 FreeCADGui.addCommand('Draft_PathArray',PathArray())
 FreeCADGui.addCommand('Draft_PathLinkArray',PathLinkArray())
 FreeCADGui.addCommand('Draft_PointArray',PointArray())
-FreeCADGui.addCommand('Draft_Heal',Heal())
 FreeCADGui.addCommand('Draft_Mirror',Mirror())
 FreeCADGui.addCommand('Draft_Slope',Draft_Slope())
 FreeCADGui.addCommand('Draft_Stretch',Stretch())

--- a/src/Mod/Draft/DraftTools.py
+++ b/src/Mod/Draft/DraftTools.py
@@ -85,6 +85,7 @@ from draftguitools.gui_togglemodes import ToggleContinueMode
 from draftguitools.gui_togglemodes import ToggleDisplayMode
 from draftguitools.gui_groups import AddToGroup
 from draftguitools.gui_groups import SelectGroup
+from draftguitools.gui_groups import SetAutoGroup
 from draftguitools.gui_grid import ToggleGrid
 from draftguitools.gui_heal import Heal
 from draftguitools.gui_dimension_ops import Draft_FlipDimension
@@ -4866,63 +4867,6 @@ class Mirror(Modifier):
             self.finish()
 
 
-class SetAutoGroup():
-    """The SetAutoGroup FreeCAD command definition"""
-
-    def GetResources(self):
-        return {'Pixmap'  : 'Draft_AutoGroup',
-                'MenuText': QtCore.QT_TRANSLATE_NOOP("Draft_AutoGroup", "AutoGroup"),
-                'ToolTip': QtCore.QT_TRANSLATE_NOOP("Draft_AutoGroup", "Select a group to automatically add all Draft & Arch objects to")}
-
-    def IsActive(self):
-        if FreeCADGui.ActiveDocument:
-            return True
-        else:
-            return False
-
-    def Activated(self):
-        if hasattr(FreeCADGui,"draftToolBar"):
-            self.ui = FreeCADGui.draftToolBar
-            s = FreeCADGui.Selection.getSelection()
-            if len(s) == 1:
-                if (Draft.getType(s[0]) == "Layer") or \
-                ( FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/BIM").GetBool("AutogroupAddGroups",False) and \
-                (s[0].isDerivedFrom("App::DocumentObjectGroup") or (Draft.getType(s[0]) in ["Site","Building","Floor","BuildingPart",]))):
-                    self.ui.setAutoGroup(s[0].Name)
-                    return
-            self.groups = ["None"]
-            gn = [o.Name for o in FreeCAD.ActiveDocument.Objects if Draft.getType(o) == "Layer"]
-            if FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/BIM").GetBool("AutogroupAddGroups",False):
-                gn.extend(Draft.getGroupNames())
-            if gn:
-                self.groups.extend(gn)
-                self.labels = [translate("draft","None")]
-                self.icons = [self.ui.getIcon(":/icons/button_invalid.svg")]
-                for g in gn:
-                    o = FreeCAD.ActiveDocument.getObject(g)
-                    if o:
-                        self.labels.append(o.Label)
-                        self.icons.append(o.ViewObject.Icon)
-                self.labels.append(translate("draft","Add new Layer"))
-                self.icons.append(self.ui.getIcon(":/icons/document-new.svg"))
-                self.ui.sourceCmd = self
-                from PySide import QtCore
-                pos = self.ui.autoGroupButton.mapToGlobal(QtCore.QPoint(0,self.ui.autoGroupButton.geometry().height()))
-                self.ui.popupMenu(self.labels,self.icons,pos)
-
-    def proceed(self,labelname):
-        self.ui.sourceCmd = None
-        if labelname in self.labels:
-            if labelname == self.labels[0]:
-                self.ui.setAutoGroup(None)
-            elif labelname == self.labels[-1]:
-                FreeCADGui.runCommand("Draft_Layer")
-            else:
-                i = self.labels.index(labelname)
-                self.ui.setAutoGroup(self.groups[i])
-
-
-
 class Draft_Label(Creator):
     """The Draft_Label command definition"""
 
@@ -5234,7 +5178,6 @@ FreeCADGui.addCommand('Draft_Stretch',Stretch())
 # context commands
 FreeCADGui.addCommand('Draft_ApplyStyle',ApplyStyle())
 FreeCADGui.addCommand('Draft_Shape2DView',Shape2DView())
-FreeCADGui.addCommand('Draft_AutoGroup',SetAutoGroup())
 FreeCADGui.addCommand('Draft_AddConstruction',Draft_AddConstruction())
 
 # a global place to look for active draft Command

--- a/src/Mod/Draft/DraftTools.py
+++ b/src/Mod/Draft/DraftTools.py
@@ -87,6 +87,7 @@ from draftguitools.gui_groups import AddToGroup
 from draftguitools.gui_groups import SelectGroup
 from draftguitools.gui_grid import ToggleGrid
 from draftguitools.gui_heal import Heal
+from draftguitools.gui_dimension_ops import Draft_FlipDimension
 # import DraftFillet
 import drafttaskpanels.task_shapestring as task_shapestring
 import drafttaskpanels.task_scale as task_scale
@@ -4739,20 +4740,6 @@ class Draft_Facebinder(Creator):
             FreeCAD.ActiveDocument.recompute()
         self.finish()
 
-class Draft_FlipDimension():
-    def GetResources(self):
-        return {'Pixmap'  : 'Draft_FlipDimension',
-                'MenuText': QtCore.QT_TRANSLATE_NOOP("Draft_FlipDimension", "Flip Dimension"),
-                'ToolTip' : QtCore.QT_TRANSLATE_NOOP("Draft_FlipDimension", "Flip the normal direction of a dimension")}
-
-    def Activated(self):
-        for o in FreeCADGui.Selection.getSelection():
-            if Draft.getType(o) in ["Dimension","AngularDimension"]:
-                FreeCAD.ActiveDocument.openTransaction("Flip dimension")
-                FreeCADGui.doCommand("FreeCAD.ActiveDocument."+o.Name+".Normal = FreeCAD.ActiveDocument."+o.Name+".Normal.negative()")
-                FreeCAD.ActiveDocument.commitTransaction()
-                FreeCAD.ActiveDocument.recompute()
-
 
 class Mirror(Modifier):
     """The Draft_Mirror FreeCAD command definition"""
@@ -5301,7 +5288,6 @@ FreeCADGui.addCommand('Draft_Stretch',Stretch())
 # context commands
 FreeCADGui.addCommand('Draft_ApplyStyle',ApplyStyle())
 FreeCADGui.addCommand('Draft_Shape2DView',Shape2DView())
-FreeCADGui.addCommand('Draft_FlipDimension',Draft_FlipDimension())
 FreeCADGui.addCommand('Draft_AutoGroup',SetAutoGroup())
 FreeCADGui.addCommand('Draft_AddConstruction',Draft_AddConstruction())
 

--- a/src/Mod/Draft/DraftTools.py
+++ b/src/Mod/Draft/DraftTools.py
@@ -92,6 +92,7 @@ from draftguitools.gui_heal import Heal
 from draftguitools.gui_dimension_ops import Draft_FlipDimension
 from draftguitools.gui_lineslope import Draft_Slope
 from draftguitools.gui_arcs import Draft_Arc_3Points
+import draftguitools.gui_arrays
 # import DraftFillet
 import drafttaskpanels.task_shapestring as task_shapestring
 import drafttaskpanels.task_scale as task_scale

--- a/src/Mod/Draft/DraftTools.py
+++ b/src/Mod/Draft/DraftTools.py
@@ -91,6 +91,7 @@ from draftguitools.gui_grid import ToggleGrid
 from draftguitools.gui_heal import Heal
 from draftguitools.gui_dimension_ops import Draft_FlipDimension
 from draftguitools.gui_lineslope import Draft_Slope
+from draftguitools.gui_arcs import Draft_Arc_3Points
 # import DraftFillet
 import drafttaskpanels.task_shapestring as task_shapestring
 import drafttaskpanels.task_scale as task_scale
@@ -5002,62 +5003,6 @@ class Draft_Label(Creator):
             self.create()
 
 
-class Draft_Arc_3Points:
-
-
-    def GetResources(self):
-
-        return {'Pixmap'  : "Draft_Arc_3Points.svg",
-                'MenuText': QtCore.QT_TRANSLATE_NOOP("Draft_Arc_3Points", "Arc 3 points"),
-                'ToolTip' : QtCore.QT_TRANSLATE_NOOP("Draft_Arc_3Points", "Creates an arc by 3 points"),
-                'Accel'   : 'A,T'}
-
-    def IsActive(self):
-
-        if FreeCAD.ActiveDocument:
-            return True
-        else:
-            return False
-
-    def Activated(self):
-
-        self.points = []
-        self.normal = None
-        self.tracker = trackers.arcTracker()
-        self.tracker.autoinvert = False
-        if hasattr(FreeCAD,"DraftWorkingPlane"):
-            FreeCAD.DraftWorkingPlane.setup()
-        FreeCADGui.Snapper.getPoint(callback=self.getPoint,movecallback=self.drawArc)
-
-    def getPoint(self,point,info):
-        if not point: # cancelled
-            self.tracker.off()
-            return
-        if not(point in self.points): # avoid same point twice
-            self.points.append(point)
-        if len(self.points) < 3:
-            if len(self.points) == 2:
-                self.tracker.on()
-            FreeCADGui.Snapper.getPoint(last=self.points[-1],callback=self.getPoint,movecallback=self.drawArc)
-        else:
-            import draftobjects.arc_3points as arc3
-            if Draft.getParam("UsePartPrimitives",False):
-                arc3.make_arc_3points([self.points[0],
-                                       self.points[1],
-                                       self.points[2]], primitive=True)
-            else:
-                arc3.make_arc_3points([self.points[0],
-                                       self.points[1],
-                                       self.points[2]], primitive=False)
-            self.tracker.off()
-            FreeCAD.ActiveDocument.recompute()
-
-    def drawArc(self,point,info):
-        if len(self.points) == 2:
-            if point.sub(self.points[1]).Length > 0.001:
-                self.tracker.setBy3Points(self.points[0],self.points[1],point)
-
-
 #---------------------------------------------------------------------------
 # Snap tools
 #---------------------------------------------------------------------------
@@ -5097,7 +5042,6 @@ class CommandArcGroup:
     def IsActive(self):
         return not FreeCAD.ActiveDocument is None
 FreeCADGui.addCommand('Draft_Arc',Arc())
-FreeCADGui.addCommand('Draft_Arc_3Points',Draft_Arc_3Points())
 FreeCADGui.addCommand('Draft_ArcTools', CommandArcGroup())
 FreeCADGui.addCommand('Draft_Text',Text())
 FreeCADGui.addCommand('Draft_Rectangle',Rectangle())

--- a/src/Mod/Draft/DraftTools.py
+++ b/src/Mod/Draft/DraftTools.py
@@ -4441,9 +4441,16 @@ class Draft2Sketch(Modifier):
 
 
 class Array(Modifier):
-    """The Shape2DView FreeCAD command definition"""
+    """GuiCommand for the Draft_Array tool.
 
-    def __init__(self,use_link=False):
+    Parameters
+    ----------
+    use_link: bool, optional
+        It defaults to `False`. If it is `True`, the created object
+        will be a `Link array`.
+    """
+
+    def __init__(self, use_link=False):
         Modifier.__init__(self)
         self.use_link = use_link
 
@@ -4474,11 +4481,12 @@ class Array(Modifier):
                          'FreeCAD.ActiveDocument.recompute()'])
         self.finish()
 
+
 class LinkArray(Array):
-    "The Shape2DView FreeCAD command definition"
+    """GuiCommand for the Draft_LinkArray tool."""
 
     def __init__(self):
-        Array.__init__(self,True)
+        Array.__init__(self, use_link=True)
 
     def GetResources(self):
         return {'Pixmap'  : 'Draft_LinkArray',

--- a/src/Mod/Draft/DraftTools.py
+++ b/src/Mod/Draft/DraftTools.py
@@ -4655,17 +4655,6 @@ class Point(Creator):
             if self.ui.continueMode:
                 self.Activated()
 
-class ShowSnapBar():
-    """The ShowSnapBar FreeCAD command definition"""
-
-    def GetResources(self):
-        return {'MenuText': QtCore.QT_TRANSLATE_NOOP("Draft_ShowSnapBar", "Show Snap Bar"),
-                'ToolTip' : QtCore.QT_TRANSLATE_NOOP("Draft_ShowSnapBar", "Shows Draft snap toolbar")}
-
-    def Activated(self):
-        if hasattr(FreeCADGui,"Snapper"):
-            FreeCADGui.Snapper.show()
-
 
 class Draft_Clone(Modifier):
     """The Draft Clone command definition"""
@@ -5261,7 +5250,7 @@ class Draft_Arc_3Points:
 #---------------------------------------------------------------------------
 # Snap tools
 #---------------------------------------------------------------------------
-import draftguitools.gui_snaps
+from draftguitools.gui_snaps import ShowSnapBar
 
 #---------------------------------------------------------------------------
 # Adds the icons & commands to the FreeCAD command manager, and sets defaults
@@ -5335,7 +5324,6 @@ FreeCADGui.addCommand('Draft_Stretch',Stretch())
 # context commands
 FreeCADGui.addCommand('Draft_ApplyStyle',ApplyStyle())
 FreeCADGui.addCommand('Draft_Shape2DView',Shape2DView())
-FreeCADGui.addCommand('Draft_ShowSnapBar',ShowSnapBar())
 FreeCADGui.addCommand('Draft_ToggleGrid',ToggleGrid())
 FreeCADGui.addCommand('Draft_FlipDimension',Draft_FlipDimension())
 FreeCADGui.addCommand('Draft_AutoGroup',SetAutoGroup())

--- a/src/Mod/Draft/DraftTools.py
+++ b/src/Mod/Draft/DraftTools.py
@@ -88,6 +88,7 @@ from draftguitools.gui_groups import SelectGroup
 from draftguitools.gui_grid import ToggleGrid
 from draftguitools.gui_heal import Heal
 from draftguitools.gui_dimension_ops import Draft_FlipDimension
+from draftguitools.gui_lineslope import Draft_Slope
 # import DraftFillet
 import drafttaskpanels.task_shapestring as task_shapestring
 import drafttaskpanels.task_scale as task_scale
@@ -4865,60 +4866,6 @@ class Mirror(Modifier):
             self.finish()
 
 
-class Draft_Slope():
-
-    def GetResources(self):
-        return {'Pixmap'  : 'Draft_Slope',
-                'MenuText': QtCore.QT_TRANSLATE_NOOP("Draft_Slope", "Set Slope"),
-                'ToolTip' : QtCore.QT_TRANSLATE_NOOP("Draft_Slope", "Sets the slope of a selected Line or Wire")}
-
-    def Activated(self):
-        if not FreeCADGui.Selection.getSelection():
-            return
-        for obj in FreeCADGui.Selection.getSelection():
-            if Draft.getType(obj) != "Wire":
-                FreeCAD.Console.PrintMessage(translate("draft", "This tool only works with Wires and Lines")+"\n")
-                return
-        w = QtGui.QWidget()
-        w.setWindowTitle(translate("Draft","Slope"))
-        layout = QtGui.QHBoxLayout(w)
-        label = QtGui.QLabel(w)
-        label.setText(translate("Draft", "Slope")+":")
-        layout.addWidget(label)
-        self.spinbox = QtGui.QDoubleSpinBox(w)
-        self.spinbox.setMinimum(-9999.99)
-        self.spinbox.setMaximum(9999.99)
-        self.spinbox.setSingleStep(0.01)
-        self.spinbox.setToolTip(translate("Draft", "Slope to give selected Wires/Lines: 0 = horizontal, 1 = 45deg up, -1 = 45deg down"))
-        layout.addWidget(self.spinbox)
-        taskwidget = QtGui.QWidget()
-        taskwidget.form = w
-        taskwidget.accept = self.accept
-        FreeCADGui.Control.showDialog(taskwidget)
-
-    def accept(self):
-        if hasattr(self,"spinbox"):
-            pc = self.spinbox.value()
-            FreeCAD.ActiveDocument.openTransaction("Change slope")
-            for obj in FreeCADGui.Selection.getSelection():
-                if Draft.getType(obj) == "Wire":
-                    if len(obj.Points) > 1:
-                        lp = None
-                        np = []
-                        for p in obj.Points:
-                            if not lp:
-                                lp = p
-                            else:
-                                v = p.sub(lp)
-                                z = pc*FreeCAD.Vector(v.x,v.y,0).Length
-                                lp = FreeCAD.Vector(p.x,p.y,lp.z+z)
-                            np.append(lp)
-                        obj.Points = np
-            FreeCAD.ActiveDocument.commitTransaction()
-        FreeCADGui.Control.closeDialog()
-        FreeCAD.ActiveDocument.recompute()
-
-
 class SetAutoGroup():
     """The SetAutoGroup FreeCAD command definition"""
 
@@ -5282,7 +5229,6 @@ FreeCADGui.addCommand('Draft_PathArray',PathArray())
 FreeCADGui.addCommand('Draft_PathLinkArray',PathLinkArray())
 FreeCADGui.addCommand('Draft_PointArray',PointArray())
 FreeCADGui.addCommand('Draft_Mirror',Mirror())
-FreeCADGui.addCommand('Draft_Slope',Draft_Slope())
 FreeCADGui.addCommand('Draft_Stretch',Stretch())
 
 # context commands

--- a/src/Mod/Draft/InitGui.py
+++ b/src/Mod/Draft/InitGui.py
@@ -102,11 +102,13 @@ class DraftWorkbench(FreeCADGui.Workbench):
         self.context_commands = it.get_draft_context_commands()
         self.line_commands = it.get_draft_line_commands()
         self.utility_commands = it.get_draft_utility_commands()
+        self.utility_small = it.get_draft_small_commands()
 
         # Set up toolbars
         self.appendToolbar(QT_TRANSLATE_NOOP("Draft", "Draft creation tools"), self.drawing_commands)
         self.appendToolbar(QT_TRANSLATE_NOOP("Draft", "Draft annotation tools"), self.annotation_commands)
         self.appendToolbar(QT_TRANSLATE_NOOP("Draft", "Draft modification tools"), self.modification_commands)
+        self.appendToolbar(QT_TRANSLATE_NOOP("Draft", "Draft utility tools"), self.utility_small)
 
         # Set up menus
         self.appendMenu(QT_TRANSLATE_NOOP("Draft", "&Drafting"), self.drawing_commands)

--- a/src/Mod/Draft/InitGui.py
+++ b/src/Mod/Draft/InitGui.py
@@ -152,8 +152,15 @@ class DraftWorkbench(FreeCADGui.Workbench):
                 else:
                     self.appendContextMenu("Draft", self.drawing_commands)
             else:
-                if FreeCAD.activeDraftCommand.featureName == translate("draft","Line"):
-                    # BUG: line subcommands are not usable while another command is active
+                if FreeCAD.activeDraftCommand.featureName in (translate("draft", "Line"),
+                                                              translate("draft", "Wire"),
+                                                              translate("draft", "Polyline"),
+                                                              translate("draft", "BSpline"),
+                                                              translate("draft", "BezCurve"),
+                                                              translate("draft", "CubicBezCurve")):
+                    # BUG: the line subcommands are in fact listed
+                    # in the context menu, but they are de-activated
+                    # so they don't work.
                     self.appendContextMenu("", self.line_commands)
         else:
             if FreeCADGui.Selection.getSelection():

--- a/src/Mod/Draft/InitGui.py
+++ b/src/Mod/Draft/InitGui.py
@@ -82,10 +82,6 @@ class DraftWorkbench(FreeCADGui.Workbench):
             import DraftTools
             import DraftGui
             import DraftFillet
-            from draftguitools import gui_circulararray
-            from draftguitools import gui_polararray
-            from draftguitools import gui_orthoarray
-            from draftguitools import gui_arrays
             FreeCADGui.addLanguagePath(":/translations")
             FreeCADGui.addIconPath(":/icons")
         except Exception as exc:

--- a/src/Mod/Draft/Resources/Draft.qrc
+++ b/src/Mod/Draft/Resources/Draft.qrc
@@ -1,6 +1,7 @@
 <RCC>
     <qresource> 
         <file>icons/Draft_2DShapeView.svg</file>
+        <file>icons/Draft_AddConstruction.svg</file>
         <file>icons/Draft_AddPoint.svg</file>
         <file>icons/Draft_AddToGroup.svg</file>
         <file>icons/Draft_Apply.svg</file>

--- a/src/Mod/Draft/Resources/Draft.qrc
+++ b/src/Mod/Draft/Resources/Draft.qrc
@@ -19,6 +19,7 @@
         <file>icons/Draft_CircularArray.svg</file>
         <file>icons/Draft_Clone.svg</file>
         <file>icons/Draft_Construction.svg</file>
+        <file>icons/Draft_Continue.svg</file>
         <file>icons/Draft_CubicBezCurve.svg</file>
         <file>icons/Draft_Cursor.svg</file>
         <file>icons/Draft_DelPoint.svg</file>

--- a/src/Mod/Draft/Resources/icons/Draft_AddConstruction.svg
+++ b/src/Mod/Draft/Resources/icons/Draft_AddConstruction.svg
@@ -1,0 +1,227 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   width="64px"
+   height="64px"
+   id="svg3611"
+   version="1.1">
+  <defs
+     id="defs3613">
+    <linearGradient
+       id="linearGradient3825">
+      <stop
+         style="stop-color:#34e0e2;stop-opacity:1;"
+         offset="0"
+         id="stop3827" />
+      <stop
+         style="stop-color:#34e0e2;stop-opacity:0;"
+         offset="1"
+         id="stop3829" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3817">
+      <stop
+         style="stop-color:#06989a;stop-opacity:1;"
+         offset="0"
+         id="stop3819" />
+      <stop
+         style="stop-color:#06989a;stop-opacity:0;"
+         offset="1"
+         id="stop3821" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient4292"
+       id="linearGradient4125"
+       gradientUnits="userSpaceOnUse"
+       x1="657.42859"
+       y1="92.117249"
+       x2="696.53217"
+       y2="92.117249" />
+    <linearGradient
+       id="linearGradient4292">
+      <stop
+         style="stop-color:#62d9c5;stop-opacity:1;"
+         offset="0"
+         id="stop4294" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="stop4296" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient4300"
+       id="linearGradient4127"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99534433,0.09638295,-0.09638295,0.99534433,12.979471,-62.75841)"
+       x1="651.69366"
+       y1="108.379"
+       x2="677.37708"
+       y2="108.379" />
+    <linearGradient
+       id="linearGradient4300">
+      <stop
+         style="stop-color:#dd4100;stop-opacity:1;"
+         offset="0"
+         id="stop4302" />
+      <stop
+         style="stop-color:#a80101;stop-opacity:1;"
+         offset="1"
+         id="stop4304" />
+    </linearGradient>
+    <linearGradient
+       y2="108.379"
+       x2="677.37708"
+       y1="108.379"
+       x1="651.69366"
+       gradientTransform="matrix(0.99534433,0.09638295,-0.09638295,0.99534433,12.979471,-62.75841)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3609"
+       xlink:href="#linearGradient4300" />
+    <linearGradient
+       xlink:href="#linearGradient4292-4"
+       id="linearGradient3001-0"
+       gradientUnits="userSpaceOnUse"
+       x1="657.42859"
+       y1="92.117249"
+       x2="696.53217"
+       y2="92.117249"
+       gradientTransform="matrix(0.93342445,0.4455918,-0.45023909,0.92378981,-552.52671,-364.08327)" />
+    <linearGradient
+       id="linearGradient4292-4">
+      <stop
+         style="stop-color:#62d9c5;stop-opacity:1;"
+         offset="0"
+         id="stop4294-4" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="stop4296-4" />
+    </linearGradient>
+    <linearGradient
+       y2="92.117249"
+       x2="696.53217"
+       y1="92.117249"
+       x1="657.42859"
+       gradientTransform="matrix(0.93342445,0.4455918,-0.45023909,0.92378981,-527.86118,-368.62645)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3807"
+       xlink:href="#linearGradient4292-4" />
+    <linearGradient
+       xlink:href="#linearGradient3817"
+       id="linearGradient3823"
+       x1="17"
+       y1="37"
+       x2="15"
+       y2="32"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       xlink:href="#linearGradient3825"
+       id="linearGradient3831"
+       x1="40"
+       y1="21"
+       x2="47"
+       y2="38"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <g
+     transform="translate(0,6)"
+     id="layer1">
+    <path
+       style="fill:#06989a;fill-opacity:1;stroke:#042a2a;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 59.662253,17.123968 C 54.202538,10.619145 19,23 19,23 l 20,22 c 0,0 27.92132,-19.227416 20.662253,-27.876032 z"
+       id="path3498" />
+    <path
+       style="fill:url(#linearGradient3831);fill-opacity:1;stroke:#34e0e2;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 58,18 C 54.434171,13.753987 22.586852,23.947813 22.586852,23.947813 L 39.287029,42.334868 C 39.287029,42.334868 63.5322,24.58747 58,18 Z"
+       id="path3498-3" />
+    <rect
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#16d0d2;fill-opacity:1;fill-rule:nonzero;stroke:#042a2a;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       id="rect3772"
+       width="3"
+       height="8"
+       x="30"
+       y="25" />
+    <path
+       style="fill:#34e0e2;fill-opacity:1;stroke:#042a2a;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 33,25 c -3,-1 -20,4 -24,6 -4,2 -6,5 -6,8 0,3 4,4 10,2 6,-2 20,-11 20,-16 z"
+       id="path3500" />
+    <path
+       style="fill:url(#linearGradient3823);fill-opacity:1;stroke:#34e0e2;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 29.98637,26.883398 c -4.889547,0.05412 -16.07494,4.168831 -19.314168,5.536675 -3.2392271,1.367845 -5.7198849,4.18225 -5.7198849,6.234016 0,2.051766 3.2515281,1.923846 7.8889579,0.285389 4.637429,-1.638458 15.312301,-8.882481 17.145095,-12.05608 z"
+       id="path3500-6" />
+  </g>
+  <metadata
+     id="metadata3867">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+        <cc:license
+           rdf:resource="" />
+        <dc:date>Mon Oct 10 13:44:52 2011 +0000</dc:date>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>[vocx]</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>FreeCAD LGPL2+</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>FreeCAD</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:identifier>FreeCAD/src/Mod/Draft/Resources/icons/Draft_AddConstruction.svg</dc:identifier>
+        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title>[agryson] Alexander Gryson, [wmayer]</dc:title>
+          </cc:Agent>
+        </dc:contributor>
+        <dc:subject>
+          <rdf:Bag>
+            <rdf:li>trowel</rdf:li>
+            <rdf:li>tool</rdf:li>
+            <rdf:li>plus sign</rdf:li>
+          </rdf:Bag>
+        </dc:subject>
+        <dc:description>A trowel, and a plus sign</dc:description>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <path
+     style="fill:none;stroke:#042a2a;stroke-width:8;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 6.05697,18.049229 H 29.844572"
+     id="path853" />
+  <path
+     id="path851"
+     d="M 17.950771,6.1554283 V 29.94303"
+     style="fill:none;stroke:#042a2a;stroke-width:8;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  <path
+     id="path847"
+     d="M 6.05697,18.049229 H 29.844572"
+     style="fill:none;stroke:#34e0e2;stroke-width:4;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  <path
+     style="fill:none;stroke:#34e0e2;stroke-width:4;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 17.950771,6.1554283 V 29.94303"
+     id="path849" />
+  <path
+     id="path855"
+     d="M 17.950771,6.1554283 V 29.94303"
+     style="fill:none;stroke:#179a9b;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  <path
+     style="fill:none;stroke:#0aa0a2;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 6.05697,18.049229 H 29.844572"
+     id="path857" />
+</svg>

--- a/src/Mod/Draft/Resources/icons/Draft_Continue.svg
+++ b/src/Mod/Draft/Resources/icons/Draft_Continue.svg
@@ -1,0 +1,146 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   width="64px"
+   height="64px"
+   id="svg3074"
+   version="1.1">
+  <defs
+     id="defs3076">
+    <linearGradient
+       id="linearGradient3841">
+      <stop
+         style="stop-color:#0619c0;stop-opacity:1;"
+         offset="0"
+         id="stop3843" />
+      <stop
+         style="stop-color:#379cfb;stop-opacity:1;"
+         offset="1"
+         id="stop3845" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3841"
+       id="linearGradient3863"
+       gradientUnits="userSpaceOnUse"
+       x1="3709.3296"
+       y1="1286.7291"
+       x2="3935.5251"
+       y2="1076.6174" />
+    <linearGradient
+       xlink:href="#linearGradient3895"
+       id="linearGradient3909"
+       x1="43"
+       y1="22"
+       x2="48"
+       y2="44"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3895">
+      <stop
+         style="stop-color:#729fcf;stop-opacity:1;"
+         offset="0"
+         id="stop3897" />
+      <stop
+         style="stop-color:#204a87;stop-opacity:1;"
+         offset="1"
+         id="stop3899" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0,-1.4500001,1.4705882,0,-15.05882,91.45)"
+       y2="36.079998"
+       x2="21.689653"
+       y1="29.279999"
+       x1="56.172409"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3036"
+       xlink:href="#linearGradient3895" />
+    <linearGradient
+       y2="36.079998"
+       x2="34.103447"
+       y1="29.279999"
+       x1="56.172409"
+       gradientTransform="matrix(0,-1.4500001,1.4705882,0,-15.05882,91.45)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient869"
+       xlink:href="#linearGradient3895" />
+    <linearGradient
+       y2="36.079998"
+       x2="34.103447"
+       y1="29.279999"
+       x1="56.172409"
+       gradientTransform="matrix(0,-1.4500001,1.4705882,0,-15.05882,78.450001)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient896"
+       xlink:href="#linearGradient3895" />
+  </defs>
+  <metadata
+     id="metadata5801">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+        <cc:license
+           rdf:resource="" />
+        <dc:date>Mon Oct 10 13:44:52 2011 +0000</dc:date>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>[vocx]</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>FreeCAD LGPL2+</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>FreeCAD</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:identifier>FreeCAD/src/Mod/Draft/Resources/icons/Draft_Continue.svg</dc:identifier>
+        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title>[agryson] Alexander Gryson, [wmayer]</dc:title>
+          </cc:Agent>
+        </dc:contributor>
+        <dc:subject>
+          <rdf:Bag>
+            <rdf:li>arrow</rdf:li>
+            <rdf:li>double</rdf:li>
+            <rdf:li>right</rdf:li>
+          </rdf:Bag>
+        </dc:subject>
+        <dc:description>A large blue arrow pointing to the right, and another one following it.</dc:description>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="g867"
+     transform="rotate(90,24.500001,24.5)">
+    <path
+       id="path892"
+       d="m 7.0000006,16.100001 14.0000004,-0.1 v 15 h 22 v -15 L 57,16.100001 32,-9.9999989 Z"
+       style="fill:url(#linearGradient896);fill-opacity:1;fill-rule:evenodd;stroke:#0b1521;stroke-width:1.99999988;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       id="path894"
+       d="m 12.000001,14.000001 h 11 v 15 h 18 v -15 h 11 L 32.172062,-6.9999924 Z"
+       style="fill:none;stroke:#729fcf;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       style="fill:url(#linearGradient869);fill-opacity:1;fill-rule:evenodd;stroke:#0b1521;stroke-width:1.99999988;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 7.0000006,29.1 21.000001,29 v 15 h 22 V 29 L 57,29.1 32,3 Z"
+       id="path863" />
+    <path
+       style="fill:none;stroke:#729fcf;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 12.000001,27 h 11 v 15 h 18 V 27 h 11 L 32.172062,6.000006 Z"
+       id="path865" />
+  </g>
+</svg>

--- a/src/Mod/Draft/draftguitools/gui_arcs.py
+++ b/src/Mod/Draft/draftguitools/gui_arcs.py
@@ -1,0 +1,156 @@
+# ***************************************************************************
+# *   (c) 2009, 2010 Yorik van Havre <yorik@uncreated.net>                  *
+# *   (c) 2009, 2010 Ken Cline <cline@frii.com>                             *
+# *   (c) 2020 Eliud Cabrera Castillo <e.cabrera-castillo@tum.de>           *
+# *                                                                         *
+# *   This file is part of the FreeCAD CAx development system.              *
+# *                                                                         *
+# *   This program is free software; you can redistribute it and/or modify  *
+# *   it under the terms of the GNU Lesser General Public License (LGPL)    *
+# *   as published by the Free Software Foundation; either version 2 of     *
+# *   the License, or (at your option) any later version.                   *
+# *   for detail see the LICENCE text file.                                 *
+# *                                                                         *
+# *   FreeCAD is distributed in the hope that it will be useful,            *
+# *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+# *   GNU Library General Public License for more details.                  *
+# *                                                                         *
+# *   You should have received a copy of the GNU Library General Public     *
+# *   License along with FreeCAD; if not, write to the Free Software        *
+# *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
+# *   USA                                                                   *
+# *                                                                         *
+# ***************************************************************************
+"""Provides tools for creating arcs with the Draft Workbench."""
+## @package gui_arcs
+# \ingroup DRAFT
+# \brief Provides tools for creating arcs with the Draft Workbench.
+from PySide.QtCore import QT_TRANSLATE_NOOP
+
+import FreeCAD as App
+import FreeCADGui as Gui
+import Draft_rc
+import draftobjects.arc_3points as arc3
+import draftguitools.gui_base as gui_base
+import draftguitools.gui_trackers as trackers
+import draftutils.utils as utils
+from draftutils.translate import _tr
+
+# The module is used to prevent complaints from code checkers (flake8)
+True if Draft_rc.__name__ else False
+
+
+class Arc_3Points(gui_base.GuiCommandSimplest):
+    """GuiCommand for the Draft_Arc_3Points tool."""
+
+    def __init__(self):
+        super().__init__(name=_tr("Arc by 3 points"))
+
+    def GetResources(self):
+        """Set icon, menu and tooltip."""
+        _menu = "Arc by 3 points"
+        _tip = ("Creates a circular arc by picking 3 points.\n"
+                "CTRL to snap, SHIFT to constrain.")
+
+        d = {'Pixmap': "Draft_Arc_3Points",
+             'MenuText': QT_TRANSLATE_NOOP("Draft_Arc_3Points", _menu),
+             'ToolTip': QT_TRANSLATE_NOOP("Draft_Arc_3Points", _tip),
+             'Accel': 'A,T'}
+        return d
+
+    def Activated(self):
+        """Execute when the command is called."""
+        super().Activated()
+
+        # Reset the values
+        self.points = []
+        self.normal = None
+        self.tracker = trackers.arcTracker()
+        self.tracker.autoinvert = False
+
+        # Set up the working plane and launch the Snapper
+        # with the indicated callbacks: one for when the user clicks
+        # on the 3D view, and another for when the user moves the pointer.
+        if hasattr(App, "DraftWorkingPlane"):
+            App.DraftWorkingPlane.setup()
+
+        Gui.Snapper.getPoint(callback=self.getPoint,
+                             movecallback=self.drawArc)
+
+    def getPoint(self, point, info):
+        """Get the point by clicking on the 3D view.
+
+        Every time the user clicks on the 3D view this method is run.
+        In this case, a point is appended to the list of points,
+        and the tracker is updated.
+        The object is finally created when three points are picked.
+
+        Parameters
+        ----------
+        point: Base::Vector
+            The point selected in the 3D view.
+
+        info: str
+            Some information obtained about the point passed by the Snapper.
+        """
+        # If there is not point, the command was cancelled
+        # so the command exits.
+        if not point:
+            self.tracker.off()
+            return
+
+        # Avoid adding the same point twice
+        if point not in self.points:
+            self.points.append(point)
+
+        if len(self.points) < 3:
+            # If one or two points were picked, set up again the Snapper
+            # to get further points, but update the `last` property
+            # with the last selected point.
+            #
+            # When two points are selected then we can turn on
+            # the arc tracker to show the preview of the final curve.
+            if len(self.points) == 2:
+                self.tracker.on()
+            Gui.Snapper.getPoint(last=self.points[-1],
+                                 callback=self.getPoint,
+                                 movecallback=self.drawArc)
+        else:
+            # If three points were already picked in the 3D view
+            # proceed with creating the final object.
+            # Draw a simple `Part::Feature` if the parameter is `True`.
+            if utils.get_param("UsePartPrimitives", False):
+                arc3.make_arc_3points([self.points[0],
+                                       self.points[1],
+                                       self.points[2]], primitive=True)
+            else:
+                arc3.make_arc_3points([self.points[0],
+                                       self.points[1],
+                                       self.points[2]], primitive=False)
+            self.tracker.off()
+            self.doc.recompute()
+
+    def drawArc(self, point, info):
+        """Draw preview arc when we move the pointer in the 3D view.
+
+        It uses the `gui_trackers.arcTracker.setBy3Points` method.
+
+        Parameters
+        ----------
+        point: Base::Vector
+            The dynamic point pased by the callback
+            as we move the pointer in the 3D view.
+
+        info: str
+            Some information obtained from the point by the Snapper.
+        """
+        if len(self.points) == 2:
+            if point.sub(self.points[1]).Length > 0.001:
+                self.tracker.setBy3Points(self.points[0],
+                                          self.points[1],
+                                          point)
+
+
+Draft_Arc_3Points = Arc_3Points
+Gui.addCommand('Draft_Arc_3Points', Arc_3Points())

--- a/src/Mod/Draft/draftguitools/gui_arrays.py
+++ b/src/Mod/Draft/draftguitools/gui_arrays.py
@@ -28,6 +28,16 @@ from PySide.QtCore import QT_TRANSLATE_NOOP
 
 import FreeCAD as App
 import FreeCADGui as Gui
+import Draft_rc
+import draftguitools.gui_circulararray
+import draftguitools.gui_polararray
+import draftguitools.gui_orthoarray
+
+# The module is used to prevent complaints from code checkers (flake8)
+True if Draft_rc.__name__ else False
+True if draftguitools.gui_circulararray.__name__ else False
+True if draftguitools.gui_polararray.__name__ else False
+True if draftguitools.gui_orthoarray.__name__ else False
 
 
 class ArrayGroupCommand:
@@ -35,22 +45,24 @@ class ArrayGroupCommand:
 
     def GetCommands(self):
         """Tuple of array commands."""
-        return tuple(["Draft_OrthoArray",
-                      "Draft_PolarArray", "Draft_CircularArray",
-                      "Draft_PathArray", "Draft_PathLinkArray",
-                      "Draft_PointArray"])
+        return ("Draft_OrthoArray",
+                "Draft_PolarArray", "Draft_CircularArray",
+                "Draft_PathArray", "Draft_PathLinkArray",
+                "Draft_PointArray")
 
     def GetResources(self):
-        """Add menu and tooltip."""
+        """Set icon, menu and tooltip."""
         _tooltip = ("Create various types of arrays, "
                     "including rectangular, polar, circular, "
                     "path, and point")
-        return {'MenuText': QT_TRANSLATE_NOOP("Draft", "Array tools"),
-                'ToolTip': QT_TRANSLATE_NOOP("Arch", _tooltip)}
+
+        return {'Pixmap': 'Draft_Array',
+                'MenuText': QT_TRANSLATE_NOOP("Draft", "Array tools"),
+                'ToolTip': QT_TRANSLATE_NOOP("Draft", _tooltip)}
 
     def IsActive(self):
         """Return True when this command should be available."""
-        if App.ActiveDocument:
+        if App.activeDocument():
             return True
         else:
             return False

--- a/src/Mod/Draft/draftguitools/gui_base.py
+++ b/src/Mod/Draft/draftguitools/gui_base.py
@@ -30,6 +30,100 @@
 import FreeCAD as App
 import FreeCADGui as Gui
 import draftutils.todo as todo
+from draftutils.messages import _msg, _log
+
+
+class GuiCommandSimplest:
+    """Simplest base class for GuiCommands.
+
+    This class only sets up the command name and the document object
+    to use for the command.
+    When it is executed, it logs the command name to the log file,
+    and prints the command name to the console.
+
+    It implements the `IsActive` method, which must return `True`
+    when the command should be available.
+    It should return `True` when there is an active document,
+    otherwise the command (button or menu) should be disabled.
+
+    This class is meant to be inherited by other GuiCommand classes
+    to quickly log the command name, and set the correct document object.
+
+    Parameter
+    ---------
+    name: str, optional
+        It defaults to `'None'`.
+        The name of the action that is being run,
+        for example, `'Heal'`, `'Flip dimensions'`,
+        `'Line'`, `'Circle'`, etc.
+
+    doc: App::Document, optional
+        It defaults to the value of `App.activeDocument()`.
+        The document object itself, which indicates where the actions
+        of the command will be executed.
+
+    Attributes
+    ----------
+    command_name: str
+        This is the command name, which is assigned by `name`.
+
+    doc: App::Document
+        This is the document object itself, which is assigned by `doc`.
+
+        This attribute should be used by functions to make sure
+        that the operations are performed in the correct document
+        and not in other documents.
+        To set the active document we can use
+
+        >>> App.setActiveDocument(self.doc.Name)
+    """
+
+    def __init__(self, name="None", doc=App.activeDocument()):
+        self.command_name = name
+        self.doc = doc
+
+    def IsActive(self):
+        """Return True when this command should be available.
+
+        It is `True` when there is a document.
+        """
+        if App.activeDocument():
+            return True
+        else:
+            return False
+
+    def Activated(self):
+        """Execute when the command is called.
+
+        Log the command name to the log file and console.
+        Also update the `doc` attribute.
+        """
+        self.doc = App.activeDocument()
+        _log("Document: {}".format(self.doc.Label))
+        _log("GuiCommand: {}".format(self.command_name))
+        _msg("{}".format(16*"-"))
+        _msg("GuiCommand: {}".format(self.command_name))
+
+
+class GuiCommandNeedsSelection(GuiCommandSimplest):
+    """Base class for GuiCommands that need a selection to be available.
+
+    It re-implements the `IsActive` method to return `True`
+    when there is both an active document and an active selection.
+
+    It inherits `GuiCommandSimplest` to set up the document
+    and other behavior. See this class for more information.
+    """
+
+    def IsActive(self):
+        """Return True when this command should be available.
+
+        It is `True` when there is a selection.
+        """
+        if App.activeDocument() and Gui.Selection.getSelection():
+            return True
+        else:
+            return False
 
 
 class GuiCommandBase:

--- a/src/Mod/Draft/draftguitools/gui_dimension_ops.py
+++ b/src/Mod/Draft/draftguitools/gui_dimension_ops.py
@@ -1,0 +1,82 @@
+# ***************************************************************************
+# *   (c) 2009, 2010 Yorik van Havre <yorik@uncreated.net>                  *
+# *   (c) 2009, 2010 Ken Cline <cline@frii.com>                             *
+# *   (c) 2020 Eliud Cabrera Castillo <e.cabrera-castillo@tum.de>           *
+# *                                                                         *
+# *   This file is part of the FreeCAD CAx development system.              *
+# *                                                                         *
+# *   This program is free software; you can redistribute it and/or modify  *
+# *   it under the terms of the GNU Lesser General Public License (LGPL)    *
+# *   as published by the Free Software Foundation; either version 2 of     *
+# *   the License, or (at your option) any later version.                   *
+# *   for detail see the LICENCE text file.                                 *
+# *                                                                         *
+# *   FreeCAD is distributed in the hope that it will be useful,            *
+# *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+# *   GNU Library General Public License for more details.                  *
+# *                                                                         *
+# *   You should have received a copy of the GNU Library General Public     *
+# *   License along with FreeCAD; if not, write to the Free Software        *
+# *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
+# *   USA                                                                   *
+# *                                                                         *
+# ***************************************************************************
+"""Provides tools to modify Draft dimensions.
+
+For example, a tool to flip the direction of the text in the dimension
+as the normal is sometimes not correctly calculated automatically.
+"""
+## @package gui_dimension_ops
+# \ingroup DRAFT
+# \brief Provides tools to modify Draft dimensions.
+
+from PySide.QtCore import QT_TRANSLATE_NOOP
+
+import FreeCADGui as Gui
+import draftutils.utils as utils
+import draftguitools.gui_base as gui_base
+from draftutils.translate import _tr
+
+
+class FlipDimension(gui_base.GuiCommandNeedsSelection):
+    """The Draft FlipDimension command definition.
+
+    Flip the normal direction of the selected dimensions.
+
+    It inherits `GuiCommandNeedsSelection` to set up the document
+    and other behavior. See this class for more information.
+    """
+
+    def __init__(self):
+        super().__init__(name=_tr("Flip dimension"))
+
+    def GetResources(self):
+        """Set icon, menu and tooltip."""
+        _tip = ("Flip the normal direction of the selected dimensions "
+                "(linear, radial, angular).\n"
+                "If other objects are selected they are ignored.")
+
+        return {'Pixmap': 'Draft_FlipDimension',
+                'MenuText': QT_TRANSLATE_NOOP("Draft_FlipDimension",
+                                              "Flip dimension"),
+                'ToolTip': QT_TRANSLATE_NOOP("Draft_FlipDimension",
+                                             _tip)}
+
+    def Activated(self):
+        """Execute when the command is called."""
+        super().Activated()
+
+        for o in Gui.Selection.getSelection():
+            if utils.get_type(o) in ("Dimension", "AngularDimension"):
+                self.doc.openTransaction("Flip dimension")
+                _cmd = "App.activeDocument()." + o.Name + ".Normal"
+                _cmd += " = "
+                _cmd += "App.activeDocument()." + o.Name + ".Normal.negative()"
+                Gui.doCommand(_cmd)
+                self.doc.commitTransaction()
+                self.doc.recompute()
+
+
+Draft_FlipDimension = FlipDimension
+Gui.addCommand('Draft_FlipDimension', FlipDimension())

--- a/src/Mod/Draft/draftguitools/gui_grid.py
+++ b/src/Mod/Draft/draftguitools/gui_grid.py
@@ -1,0 +1,79 @@
+# ***************************************************************************
+# *   (c) 2009, 2010 Yorik van Havre <yorik@uncreated.net>                  *
+# *   (c) 2009, 2010 Ken Cline <cline@frii.com>                             *
+# *   (c) 2020 Eliud Cabrera Castillo <e.cabrera-castillo@tum.de>           *
+# *                                                                         *
+# *   This file is part of the FreeCAD CAx development system.              *
+# *                                                                         *
+# *   This program is free software; you can redistribute it and/or modify  *
+# *   it under the terms of the GNU Lesser General Public License (LGPL)    *
+# *   as published by the Free Software Foundation; either version 2 of     *
+# *   the License, or (at your option) any later version.                   *
+# *   for detail see the LICENCE text file.                                 *
+# *                                                                         *
+# *   FreeCAD is distributed in the hope that it will be useful,            *
+# *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+# *   GNU Library General Public License for more details.                  *
+# *                                                                         *
+# *   You should have received a copy of the GNU Library General Public     *
+# *   License along with FreeCAD; if not, write to the Free Software        *
+# *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
+# *   USA                                                                   *
+# *                                                                         *
+# ***************************************************************************
+"""Provide the Draft_ToggleGrid command to show the Draft grid."""
+## @package gui_grid
+# \ingroup DRAFT
+# \brief Provide the Draft_ToggleGrid command to show the Draft grid.
+
+from PySide.QtCore import QT_TRANSLATE_NOOP
+
+import FreeCADGui as Gui
+import draftguitools.gui_base as gui_base
+from draftutils.translate import _tr
+
+
+class ToggleGrid(gui_base.GuiCommandSimplest):
+    """The Draft ToggleGrid command definition.
+
+    If the grid tracker is invisible (hidden), it makes it visible (shown);
+    and if it is visible, it hides it.
+
+    It inherits `GuiCommandSimplest` to set up the document
+    and other behavior. See this class for more information.
+    """
+
+    def __init__(self):
+        super().__init__(name=_tr("Toggle grid"))
+
+    def GetResources(self):
+        """Set icon, menu and tooltip."""
+        _tip = "Toggles the Draft grid on and off."
+
+        d = {'Pixmap': 'Draft_Grid',
+             'Accel': "G,R",
+             'MenuText': QT_TRANSLATE_NOOP("Draft_ToggleGrid",
+                                           "Toggle grid"),
+             'ToolTip': QT_TRANSLATE_NOOP("Draft_ToggleGrid",
+                                          _tip),
+             'CmdType': 'ForEdit'}
+
+        return d
+
+    def Activated(self):
+        """Execute when the command is called."""
+        super().Activated()
+
+        if hasattr(Gui, "Snapper"):
+            Gui.Snapper.setTrackers()
+            if Gui.Snapper.grid:
+                if Gui.Snapper.grid.Visible:
+                    Gui.Snapper.grid.off()
+                    Gui.Snapper.forceGridOff = True
+                else:
+                    Gui.Snapper.grid.on()
+                    Gui.Snapper.forceGridOff = False
+
+
+Gui.addCommand('Draft_ToggleGrid', ToggleGrid())

--- a/src/Mod/Draft/draftguitools/gui_groups.py
+++ b/src/Mod/Draft/draftguitools/gui_groups.py
@@ -1,0 +1,128 @@
+# ***************************************************************************
+# *   (c) 2009, 2010 Yorik van Havre <yorik@uncreated.net>                  *
+# *   (c) 2009, 2010 Ken Cline <cline@frii.com>                             *
+# *   (c) 2020 Eliud Cabrera Castillo <e.cabrera-castillo@tum.de>           *
+# *                                                                         *
+# *   This file is part of the FreeCAD CAx development system.              *
+# *                                                                         *
+# *   This program is free software; you can redistribute it and/or modify  *
+# *   it under the terms of the GNU Lesser General Public License (LGPL)    *
+# *   as published by the Free Software Foundation; either version 2 of     *
+# *   the License, or (at your option) any later version.                   *
+# *   for detail see the LICENCE text file.                                 *
+# *                                                                         *
+# *   FreeCAD is distributed in the hope that it will be useful,            *
+# *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+# *   GNU Library General Public License for more details.                  *
+# *                                                                         *
+# *   You should have received a copy of the GNU Library General Public     *
+# *   License along with FreeCAD; if not, write to the Free Software        *
+# *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
+# *   USA                                                                   *
+# *                                                                         *
+# ***************************************************************************
+"""Provides tools to do various operations with groups.
+
+For example, add objects to groups.
+"""
+## @package gui_groups
+# \ingroup DRAFT
+# \brief Provides tools to do various operations with groups.
+from PySide.QtCore import QT_TRANSLATE_NOOP
+
+import FreeCADGui as Gui
+import Draft_rc
+import draftutils.utils as utils
+import draftguitools.gui_base as gui_base
+from draftutils.translate import _tr
+
+# The module is used to prevent complaints from code checkers (flake8)
+True if Draft_rc.__name__ else False
+
+
+class AddToGroup(gui_base.GuiCommandNeedsSelection):
+    """GuiCommand for the Draft_AddToGroup tool.
+
+    It adds selected objects to a group, or removes them from any group.
+
+    It inherits `GuiCommandNeedsSelection` to only be availbale
+    when there is a document and a selection.
+    See this class for more information.
+    """
+
+    def __init__(self):
+        super().__init__(name=_tr("Add to group"))
+        self.ungroup = QT_TRANSLATE_NOOP("Draft_AddToGroup",
+                                         "Ungroup")
+
+    def GetResources(self):
+        """Set icon, menu and tooltip."""
+        _tooltip = ("Moves the selected objects to an existing group, "
+                    "or removes them from any group.\n"
+                    "Create a group first to use this tool.")
+
+        d = {'Pixmap': 'Draft_AddToGroup',
+             'MenuText': QT_TRANSLATE_NOOP("Draft_AddToGroup",
+                                           "Move to group"),
+             'ToolTip': QT_TRANSLATE_NOOP("Draft_AddToGroup",
+                                          _tooltip)}
+        return d
+
+    def Activated(self):
+        """Execute when the command is called."""
+        super().Activated()
+
+        self.groups = [self.ungroup]
+        self.groups.extend(utils.get_group_names())
+
+        self.labels = [self.ungroup]
+        for group in self.groups:
+            obj = self.doc.getObject(group)
+            if obj:
+                self.labels.append(obj.Label)
+
+        # It uses the `DraftToolBar` class defined in the `DraftGui` module
+        # and globally initialized in the `Gui` namespace,
+        # in order to pop up a menu with group labels
+        # or the default `Ungroup` text.
+        # Once the desired option is chosen
+        # it launches the `proceed` method.
+        self.ui = Gui.draftToolBar
+        self.ui.sourceCmd = self
+        self.ui.popupMenu(self.labels)
+
+    def proceed(self, labelname):
+        """Place the selected objects in the chosen group or ungroup them.
+
+        Parameters
+        ----------
+        labelname: str
+            The passed string with the name of the group.
+            It puts the selected objects inside this group.
+        """
+        # Deactivate the source command of the `DraftToolBar` class
+        # so that it doesn't do more with this command.
+        self.ui.sourceCmd = None
+
+        # If the selected group matches the ungroup label,
+        # remove the selection from all groups.
+        if labelname == self.ungroup:
+            for obj in Gui.Selection.getSelection():
+                try:
+                    utils.ungroup(obj)
+                except Exception:
+                    pass
+        else:
+            # Otherwise try to add all selected objects to the chosen group
+            if labelname in self.labels:
+                i = self.labels.index(labelname)
+                g = self.doc.getObject(self.groups[i])
+                for obj in Gui.Selection.getSelection():
+                    try:
+                        g.addObject(obj)
+                    except Exception:
+                        pass
+
+
+Gui.addCommand('Draft_AddToGroup', AddToGroup())

--- a/src/Mod/Draft/draftguitools/gui_heal.py
+++ b/src/Mod/Draft/draftguitools/gui_heal.py
@@ -1,0 +1,76 @@
+# ***************************************************************************
+# *   (c) 2009, 2010 Yorik van Havre <yorik@uncreated.net>                  *
+# *   (c) 2009, 2010 Ken Cline <cline@frii.com>                             *
+# *   (c) 2020 Eliud Cabrera Castillo <e.cabrera-castillo@tum.de>           *
+# *                                                                         *
+# *   This file is part of the FreeCAD CAx development system.              *
+# *                                                                         *
+# *   This program is free software; you can redistribute it and/or modify  *
+# *   it under the terms of the GNU Lesser General Public License (LGPL)    *
+# *   as published by the Free Software Foundation; either version 2 of     *
+# *   the License, or (at your option) any later version.                   *
+# *   for detail see the LICENCE text file.                                 *
+# *                                                                         *
+# *   FreeCAD is distributed in the hope that it will be useful,            *
+# *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+# *   GNU Library General Public License for more details.                  *
+# *                                                                         *
+# *   You should have received a copy of the GNU Library General Public     *
+# *   License along with FreeCAD; if not, write to the Free Software        *
+# *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
+# *   USA                                                                   *
+# *                                                                         *
+# ***************************************************************************
+"""Provides the Draft_Heal command to heal older Draft files."""
+## @package gui_health
+# \ingroup DRAFT
+# \brief Provides the Draft_Heal command to heal older Draft files.
+
+from PySide.QtCore import QT_TRANSLATE_NOOP
+
+import FreeCADGui as Gui
+import Draft
+import draftguitools.gui_base as gui_base
+from draftutils.translate import _tr
+
+
+class Heal(gui_base.GuiCommandSimplest):
+    """The Draft Heal command definition.
+
+    Heal faulty Draft objects saved with an earlier version of the program.
+
+    It inherits `GuiCommandSimplest` to set up the document
+    and other behavior. See this class for more information.
+    """
+
+    def __init__(self):
+        super().__init__(name=_tr("Heal"))
+
+    def GetResources(self):
+        """Set icon, menu and tooltip."""
+        _tip = ("Heal faulty Draft objects saved with an earlier version "
+                "of the program.\n"
+                "If an object is selected it will try to heal that object "
+                "in particular,\n"
+                "otherwise it will try to heal all objects "
+                "in the active document.")
+
+        return {'Pixmap': 'Draft_Heal',
+                'MenuText': QT_TRANSLATE_NOOP("Draft_Heal", "Heal"),
+                'ToolTip': QT_TRANSLATE_NOOP("Draft_Heal", _tip)}
+
+    def Activated(self):
+        """Execute when the command is called."""
+        super().Activated()
+
+        s = Gui.Selection.getSelection()
+        self.doc.openTransaction("Heal")
+        if s:
+            Draft.heal(s)
+        else:
+            Draft.heal()
+        self.doc.commitTransaction()
+
+
+Gui.addCommand('Draft_Heal', Heal())

--- a/src/Mod/Draft/draftguitools/gui_line_add_delete.py
+++ b/src/Mod/Draft/draftguitools/gui_line_add_delete.py
@@ -1,0 +1,109 @@
+# ***************************************************************************
+# *   (c) 2009, 2010 Yorik van Havre <yorik@uncreated.net>                  *
+# *   (c) 2009, 2010 Ken Cline <cline@frii.com>                             *
+# *   (c) 2020 Eliud Cabrera Castillo <e.cabrera-castillo@tum.de>           *
+# *                                                                         *
+# *   This file is part of the FreeCAD CAx development system.              *
+# *                                                                         *
+# *   This program is free software; you can redistribute it and/or modify  *
+# *   it under the terms of the GNU Lesser General Public License (LGPL)    *
+# *   as published by the Free Software Foundation; either version 2 of     *
+# *   the License, or (at your option) any later version.                   *
+# *   for detail see the LICENCE text file.                                 *
+# *                                                                         *
+# *   FreeCAD is distributed in the hope that it will be useful,            *
+# *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+# *   GNU Library General Public License for more details.                  *
+# *                                                                         *
+# *   You should have received a copy of the GNU Library General Public     *
+# *   License along with FreeCAD; if not, write to the Free Software        *
+# *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
+# *   USA                                                                   *
+# *                                                                         *
+# ***************************************************************************
+"""Provides certain add and remove line operations of the Draft Workbench.
+
+These GuiCommands aren't really used anymore, as the same actions
+are implemented directly in the Draft_Edit command.
+"""
+## @package gui_line_add_delete
+# \ingroup DRAFT
+# \brief Provides certain add and remove line operations.
+from PySide.QtCore import QT_TRANSLATE_NOOP
+
+import FreeCADGui as Gui
+import Draft_rc
+import DraftTools
+import draftutils.utils as utils
+
+# The module is used to prevent complaints from code checkers (flake8)
+True if Draft_rc.__name__ else False
+
+
+class AddPoint(DraftTools.Modifier):
+    """GuiCommand to add a point to a line being drawn."""
+
+    def __init__(self):
+        self.running = False
+
+    def GetResources(self):
+        """Set icon, menu and tooltip."""
+        _menu = "Add point"
+        _tip = "Adds a point to an existing Wire or B-spline."
+
+        return {'Pixmap': 'Draft_AddPoint',
+                'MenuText': QT_TRANSLATE_NOOP("Draft_AddPoint", _menu),
+                'ToolTip': QT_TRANSLATE_NOOP("Draft_AddPoint", _tip)}
+
+    def IsActive(self):
+        """Return True when there is selection and the command is active."""
+        if Gui.Selection.getSelection():
+            return True
+        else:
+            return False
+
+    def Activated(self):
+        """Execute when the command is called."""
+        selection = Gui.Selection.getSelection()
+        if selection:
+            if (utils.get_type(selection[0]) in ['Wire', 'BSpline']):
+                Gui.runCommand("Draft_Edit")
+                Gui.draftToolBar.vertUi(True)
+
+
+Gui.addCommand('Draft_AddPoint', AddPoint())
+
+
+class DelPoint(DraftTools.Modifier):
+    """GuiCommand to delete a point to a line being drawn."""
+
+    def __init__(self):
+        self.running = False
+
+    def GetResources(self):
+        """Set icon, menu and tooltip."""
+        _menu = "Remove point"
+        _tip = "Removes a point from an existing Wire or B-spline."
+
+        return {'Pixmap': 'Draft_DelPoint',
+                'MenuText': QT_TRANSLATE_NOOP("Draft_DelPoint", _menu),
+                'ToolTip': QT_TRANSLATE_NOOP("Draft_DelPoint", _tip)}
+
+    def IsActive(self):
+        """Return True when there is selection and the command is active."""
+        if Gui.Selection.getSelection():
+            return True
+        else:
+            return False
+
+    def Activated(self):
+        """Execute when the command is called."""
+        selection = Gui.Selection.getSelection()
+        if selection:
+            if (utils.get_type(selection[0]) in ['Wire', 'BSpline']):
+                Gui.runCommand("Draft_Edit")
+                Gui.draftToolBar.vertUi(False)
+
+
+Gui.addCommand('Draft_DelPoint', DelPoint())

--- a/src/Mod/Draft/draftguitools/gui_lineops.py
+++ b/src/Mod/Draft/draftguitools/gui_lineops.py
@@ -1,0 +1,163 @@
+# ***************************************************************************
+# *   (c) 2009, 2010 Yorik van Havre <yorik@uncreated.net>                  *
+# *   (c) 2009, 2010 Ken Cline <cline@frii.com>                             *
+# *   (c) 2020 Eliud Cabrera Castillo <e.cabrera-castillo@tum.de>           *
+# *                                                                         *
+# *   This file is part of the FreeCAD CAx development system.              *
+# *                                                                         *
+# *   This program is free software; you can redistribute it and/or modify  *
+# *   it under the terms of the GNU Lesser General Public License (LGPL)    *
+# *   as published by the Free Software Foundation; either version 2 of     *
+# *   the License, or (at your option) any later version.                   *
+# *   for detail see the LICENCE text file.                                 *
+# *                                                                         *
+# *   FreeCAD is distributed in the hope that it will be useful,            *
+# *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+# *   GNU Library General Public License for more details.                  *
+# *                                                                         *
+# *   You should have received a copy of the GNU Library General Public     *
+# *   License along with FreeCAD; if not, write to the Free Software        *
+# *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
+# *   USA                                                                   *
+# *                                                                         *
+# ***************************************************************************
+"""Provides certain line operations of the Draft Workbench.
+
+These GuiCommands aren't really used anymore, as the same actions
+are called from the task panel interface by other methods.
+"""
+## @package gui_lineops
+# \ingroup DRAFT
+# \brief Provides certain line operations in the Draft Workbench.
+from PySide.QtCore import QT_TRANSLATE_NOOP
+
+import FreeCAD as App
+import FreeCADGui as Gui
+import Draft_rc
+import draftguitools.gui_base as gui_base
+from draftutils.messages import _msg
+from draftutils.translate import _tr
+
+# The module is used to prevent complaints from code checkers (flake8)
+True if Draft_rc.__name__ else False
+
+
+class LineAction(gui_base.GuiCommandSimplest):
+    """Base class for Line context GuiCommands.
+
+    This is inherited by the other GuiCommand classes to run
+    a set of similar actions when editing a line, wire, spline,
+    or bezier curve.
+
+    It inherits `GuiCommandSimplest` to set up the document
+    and other behavior. See this class for more information.
+    """
+
+    def Activated(self, action="None"):
+        """Execute when the command is called.
+
+        Parameters
+        ----------
+        action: str
+            Indicates the type of action to perform with the line object.
+            It can be `'finish'`, `'close'`, or `'undo'`.
+        """
+        if hasattr(App, "activeDraftCommand"):
+            _command = App.activeDraftCommand
+        else:
+            _msg(_tr("No active command."))
+            return
+
+        if (_command is not None
+                and _command.featureName in ("Line", "Polyline",
+                                             "BSpline", "BezCurve",
+                                             "CubicBezCurve")):
+            if action == "finish":
+                _command.finish(False)
+            elif action == "close":
+                _command.finish(True)
+            elif action == "undo":
+                _command.undolast()
+
+
+class FinishLine(LineAction):
+    """GuiCommand to finish any running line drawing operation."""
+
+    def __init__(self):
+        super().__init__(name=_tr("Finish line"))
+
+    def GetResources(self):
+        """Set icon, menu and tooltip."""
+        _tip = "Finishes a line without closing it."
+
+        d = {'Pixmap': 'Draft_Finish',
+             'MenuText': QT_TRANSLATE_NOOP("Draft_FinishLine", "Finish line"),
+             'ToolTip': QT_TRANSLATE_NOOP("Draft_FinishLine", _tip),
+             'CmdType': 'ForEdit'}
+        return d
+
+    def Activated(self):
+        """Execute when the command is called.
+
+        It calls the `finish(False)` method of the active Draft command.
+        """
+        super().Activated(action="finish")
+
+
+Gui.addCommand('Draft_FinishLine', FinishLine())
+
+
+class CloseLine(LineAction):
+    """GuiCommand to close the line being drawn and finish the operation."""
+
+    def __init__(self):
+        super().__init__(name=_tr("Close line"))
+
+    def GetResources(self):
+        """Set icon, menu and tooltip."""
+        _tip = "Closes the line being drawn, and finishes the operation."
+
+        d = {'Pixmap': 'Draft_Lock',
+             'MenuText': QT_TRANSLATE_NOOP("Draft_CloseLine", "Close Line"),
+             'ToolTip': QT_TRANSLATE_NOOP("Draft_CloseLine", _tip),
+             'CmdType': 'ForEdit'}
+        return d
+
+    def Activated(self):
+        """Execute when the command is called.
+
+        It calls the `finish(True)` method of the active Draft command.
+        """
+        super().Activated(action="close")
+
+
+Gui.addCommand('Draft_CloseLine', CloseLine())
+
+
+class UndoLine(LineAction):
+    """GuiCommand to undo the last drawn segment of a line."""
+
+    def __init__(self):
+        super().__init__(name=_tr("Undo line"))
+
+    def GetResources(self):
+        """Set icon, menu and tooltip."""
+        _tip = "Undoes the last drawn segment of the line being drawn."
+
+        d = {'Pixmap': 'Draft_Rotate',
+             'MenuText': QT_TRANSLATE_NOOP("Draft_UndoLine",
+                                           "Undo last segment"),
+             'ToolTip': QT_TRANSLATE_NOOP("Draft_UndoLine", _tip),
+             'CmdType': 'ForEdit'}
+        return d
+
+    def Activated(self):
+        """Execute when the command is called.
+
+        It calls the `undolast` method of the active Draft command.
+        """
+        super().Activated(action="undo")
+
+
+Gui.addCommand('Draft_UndoLine', UndoLine())

--- a/src/Mod/Draft/draftguitools/gui_lineslope.py
+++ b/src/Mod/Draft/draftguitools/gui_lineslope.py
@@ -1,0 +1,156 @@
+# ***************************************************************************
+# *   (c) 2009, 2010 Yorik van Havre <yorik@uncreated.net>                  *
+# *   (c) 2009, 2010 Ken Cline <cline@frii.com>                             *
+# *   (c) 2020 Eliud Cabrera Castillo <e.cabrera-castillo@tum.de>           *
+# *                                                                         *
+# *   This file is part of the FreeCAD CAx development system.              *
+# *                                                                         *
+# *   This program is free software; you can redistribute it and/or modify  *
+# *   it under the terms of the GNU Lesser General Public License (LGPL)    *
+# *   as published by the Free Software Foundation; either version 2 of     *
+# *   the License, or (at your option) any later version.                   *
+# *   for detail see the LICENCE text file.                                 *
+# *                                                                         *
+# *   FreeCAD is distributed in the hope that it will be useful,            *
+# *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+# *   GNU Library General Public License for more details.                  *
+# *                                                                         *
+# *   You should have received a copy of the GNU Library General Public     *
+# *   License along with FreeCAD; if not, write to the Free Software        *
+# *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
+# *   USA                                                                   *
+# *                                                                         *
+# ***************************************************************************
+"""Provides tools to change the slope of a line over the working plane.
+
+It currently only works for a line in the XY plane, it changes the height
+of one of its points in the Z direction to create a sloped line.
+"""
+## @package gui_lineslope
+# \ingroup DRAFT
+# \brief Provides tools to change the slope of a line over the working plane.
+
+import PySide.QtGui as QtGui
+from PySide.QtCore import QT_TRANSLATE_NOOP
+
+import FreeCAD as App
+import FreeCADGui as Gui
+import Draft_rc
+import draftutils.utils as utils
+import draftguitools.gui_base as gui_base
+from draftutils.translate import _tr, translate
+
+# The module is used to prevent complaints from code checkers (flake8)
+True if Draft_rc.__name__ else False
+
+
+class LineSlope(gui_base.GuiCommandNeedsSelection):
+    """Gui Command for the Line slope tool.
+
+    For a line in the XY plane, it changes the height of one of its points
+    to create a sloped line.
+
+    To Do
+    -----
+    Make it work also with lines lying on the YZ and XZ planes,
+    or in an arbitrary plane, for which the normal is known.
+    """
+
+    def __init__(self):
+        super().__init__(name=_tr("Change slope"))
+
+    def GetResources(self):
+        """Set icon, menu and tooltip."""
+        _menu = "Set slope"
+        _tip = ("Sets the slope of the selected line "
+                "by changing the value of the Z value of one of its points.\n"
+                "If a polyline is selected, it will apply the slope "
+                "transformation to each of its segments.\n\n"
+                "The slope will always change the Z value, therefore "
+                "this command only works well for\n"
+                "straight Draft lines that are drawn in the XY plane. "
+                "Selected objects that aren't single lines will be ignored.")
+
+        return {'Pixmap': 'Draft_Slope',
+                'MenuText': QT_TRANSLATE_NOOP("Draft_Slope", _menu),
+                'ToolTip': QT_TRANSLATE_NOOP("Draft_Slope", _tip)}
+
+    def Activated(self):
+        """Execute when the command is called."""
+        super().Activated()
+
+        # for obj in Gui.Selection.getSelection():
+        #     if utils.get_type(obj) != "Wire":
+        #         _msg(translate("draft",
+        #                        "This tool only works with "
+        #                        "Draft Lines and Wires"))
+        #         return
+
+        # TODO: create a .ui file with QtCreator and import it here
+        # instead of creating the interface programmatically,
+        # see the `gui_othoarray` module for an example.
+        w = QtGui.QWidget()
+        w.setWindowTitle(translate("Draft", "Slope"))
+        layout = QtGui.QHBoxLayout(w)
+        label = QtGui.QLabel(w)
+        label.setText(translate("Draft", "Slope")+":")
+        layout.addWidget(label)
+        self.spinbox = QtGui.QDoubleSpinBox(w)
+        self.spinbox.setMinimum(-9999.99)
+        self.spinbox.setMaximum(9999.99)
+        self.spinbox.setSingleStep(0.01)
+        _tip = ("New slope of the selected lines.\n"
+                "This is the tangent of the horizontal angle:\n"
+                "0 = horizontal\n"
+                "1 = 45 deg up\n"
+                "-1 = 45deg down\n")
+        label.setToolTip(translate("Draft", _tip))
+        self.spinbox.setToolTip(translate("Draft", _tip))
+        layout.addWidget(self.spinbox)
+
+        # In order to display our interface inside the task panel
+        # we must contain our interface inside a parent widget.
+        # Then our interface must be installed in this parent widget
+        # inside the attribute called "form".
+        taskwidget = QtGui.QWidget()
+        taskwidget.form = w
+
+        # The "accept" attribute of the parent widget
+        # should also contain a reference to a function that will be called
+        # when we press the "OK" button.
+        # Then we must show the container widget.
+        taskwidget.accept = self.accept
+        Gui.Control.showDialog(taskwidget)
+
+    def accept(self):
+        """Execute when clicking the OK button or pressing Enter key.
+
+        It changes the slope of the line that lies on the XY plane.
+
+        TODO: make it work also with lines lying on the YZ and XZ planes.
+        """
+        if hasattr(self, "spinbox"):
+            pc = self.spinbox.value()
+            self.doc.openTransaction("Change slope")
+            for obj in Gui.Selection.getSelection():
+                if utils.get_type(obj) == "Wire":
+                    if len(obj.Points) > 1:
+                        lp = None
+                        np = []
+                        for p in obj.Points:
+                            if not lp:
+                                lp = p
+                            else:
+                                v = p.sub(lp)
+                                z = pc * App.Vector(v.x, v.y, 0).Length
+                                lp = App.Vector(p.x, p.y, lp.z + z)
+                            np.append(lp)
+                        obj.Points = np
+            self.doc.commitTransaction()
+        Gui.Control.closeDialog()
+        self.doc.recompute()
+
+
+Draft_Slope = LineSlope
+Gui.addCommand('Draft_Slope', LineSlope())

--- a/src/Mod/Draft/draftguitools/gui_snaps.py
+++ b/src/Mod/Draft/draftguitools/gui_snaps.py
@@ -31,23 +31,34 @@
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
 import FreeCADGui as Gui
+import draftguitools.gui_base as gui_base
+from draftutils.translate import _tr
 
 
-class Draft_Snap_Lock:
-    """Command to activate or deactivate all snap commands."""
+class Draft_Snap_Lock(gui_base.GuiCommandSimplest):
+    """GuiCommand for the Draft_Snap_Lock tool.
+
+    Activate or deactivate all snap methods at once.
+    """
+
+    def __init__(self):
+        super().__init__(name=_tr("Main toggle snap"))
 
     def GetResources(self):
         """Set icon, menu and tooltip."""
-        _menu = "Toggle On/Off"
+        _menu = "Main snapping toggle On/Off"
         _tip = ("Activates or deactivates "
-                "all snap tools at once")
+                "all snap methods at once.")
+
         return {'Pixmap': 'Snap_Lock',
                 'Accel': "Shift+S",
                 'MenuText': QT_TRANSLATE_NOOP("Draft_Snap_Lock", _menu),
                 'ToolTip': QT_TRANSLATE_NOOP("Draft_Snap_Lock", _tip)}
 
     def Activated(self):
-        """Execute this when the command is called."""
+        """Execute when the command is called."""
+        super().Activated()
+
         if hasattr(Gui, "Snapper"):
             if hasattr(Gui.Snapper, "masterbutton"):
                 Gui.Snapper.masterbutton.toggle()
@@ -56,19 +67,28 @@ class Draft_Snap_Lock:
 Gui.addCommand('Draft_Snap_Lock', Draft_Snap_Lock())
 
 
-class Draft_Snap_Midpoint:
-    """Command to snap to the midpoint of an edge."""
+class Draft_Snap_Midpoint(gui_base.GuiCommandSimplest):
+    """GuiCommand for the Draft_Snap_Midpoint tool.
+
+    Set snapping to the midpoint of an edge.
+    """
+
+    def __init__(self):
+        super().__init__(name=_tr("Midpoint snap"))
 
     def GetResources(self):
         """Set icon, menu and tooltip."""
         _menu = "Midpoint"
-        _tip = "Snaps to midpoints of edges"
+        _tip = "Set snapping to the midpoint of an edge."
+
         return {'Pixmap': 'Snap_Midpoint',
                 'MenuText': QT_TRANSLATE_NOOP("Draft_Snap_Midpoint", _menu),
                 'ToolTip': QT_TRANSLATE_NOOP("Draft_Snap_Midpoint", _tip)}
 
     def Activated(self):
-        """Execute this when the command is called."""
+        """Execute when the command is called."""
+        super().Activated()
+
         if hasattr(Gui, "Snapper"):
             if hasattr(Gui.Snapper, "toolbarButtons"):
                 for b in Gui.Snapper.toolbarButtons:
@@ -79,13 +99,20 @@ class Draft_Snap_Midpoint:
 Gui.addCommand('Draft_Snap_Midpoint', Draft_Snap_Midpoint())
 
 
-class Draft_Snap_Perpendicular:
-    """Command to snap to perdendicular of an edge."""
+class Draft_Snap_Perpendicular(gui_base.GuiCommandSimplest):
+    """GuiCommand for the Draft_Snap_Perpendicular tool.
+
+    Set snapping to a direction that is perpendicular to an edge.
+    """
+
+    def __init__(self):
+        super().__init__(name=_tr("Perpendicular snap"))
 
     def GetResources(self):
         """Set icon, menu and tooltip."""
         _menu = "Perpendicular"
-        _tip = "Snaps to perpendicular points on edges"
+        _tip = "Set snapping to a direction that is perpendicular to an edge."
+
         return {'Pixmap': 'Snap_Perpendicular',
                 'MenuText': QT_TRANSLATE_NOOP("Draft_Snap_Perpendicular",
                                               _menu),
@@ -93,7 +120,9 @@ class Draft_Snap_Perpendicular:
                                              _tip)}
 
     def Activated(self):
-        """Execute this when the command is called."""
+        """Execute when the command is called."""
+        super().Activated()
+
         if hasattr(Gui, "Snapper"):
             if hasattr(Gui.Snapper, "toolbarButtons"):
                 for b in Gui.Snapper.toolbarButtons:
@@ -104,18 +133,27 @@ class Draft_Snap_Perpendicular:
 Gui.addCommand('Draft_Snap_Perpendicular', Draft_Snap_Perpendicular())
 
 
-class Draft_Snap_Grid:
-    """Command to snap to the intersection of grid lines."""
+class Draft_Snap_Grid(gui_base.GuiCommandSimplest):
+    """GuiCommand for the Draft_Snap_Grid tool.
+
+    Set snapping to the intersection of grid lines.
+    """
+
+    def __init__(self):
+        super().__init__(name=_tr("Grid snap"))
 
     def GetResources(self):
         """Set icon, menu and tooltip."""
-        _tip = "Snaps to grid points"
+        _tip = "Set snapping to the intersection of grid lines."
+
         return {'Pixmap': 'Snap_Grid',
                 'MenuText': QT_TRANSLATE_NOOP("Draft_Snap_Grid", "Grid"),
                 'ToolTip': QT_TRANSLATE_NOOP("Draft_Snap_Grid", _tip)}
 
     def Activated(self):
-        """Execute this when the command is called."""
+        """Execute when the command is called."""
+        super().Activated()
+
         if hasattr(Gui, "Snapper"):
             if hasattr(Gui.Snapper, "toolbarButtons"):
                 for b in Gui.Snapper.toolbarButtons:
@@ -126,13 +164,20 @@ class Draft_Snap_Grid:
 Gui.addCommand('Draft_Snap_Grid', Draft_Snap_Grid())
 
 
-class Draft_Snap_Intersection:
-    """Command to snap to the intersection of two edges."""
+class Draft_Snap_Intersection(gui_base.GuiCommandSimplest):
+    """GuiCommand for the Draft_Snap_Intersection tool.
+
+    Set snapping to the intersection of edges.
+    """
+
+    def __init__(self):
+        super().__init__(name=_tr("Intersection snap"))
 
     def GetResources(self):
         """Set icon, menu and tooltip."""
         _menu = "Intersection"
-        _tip = "Snaps to edges intersections"
+        _tip = "Set snapping to the intersection of edges."
+
         return {'Pixmap': 'Snap_Intersection',
                 'MenuText': QT_TRANSLATE_NOOP("Draft_Snap_Intersection",
                                               _menu),
@@ -140,7 +185,9 @@ class Draft_Snap_Intersection:
                                              _tip)}
 
     def Activated(self):
-        """Execute this when the command is called."""
+        """Execute when the command is called."""
+        super().Activated()
+
         if hasattr(Gui, "Snapper"):
             if hasattr(Gui.Snapper, "toolbarButtons"):
                 for b in Gui.Snapper.toolbarButtons:
@@ -151,19 +198,28 @@ class Draft_Snap_Intersection:
 Gui.addCommand('Draft_Snap_Intersection', Draft_Snap_Intersection())
 
 
-class Draft_Snap_Parallel:
-    """Command to snap to the parallel of an edge."""
+class Draft_Snap_Parallel(gui_base.GuiCommandSimplest):
+    """GuiCommand for the Draft_Snap_Parallel tool.
+
+    Set snapping to a direction that is parallel to an edge.
+    """
+
+    def __init__(self):
+        super().__init__(name=_tr("Parallel snap"))
 
     def GetResources(self):
         """Set icon, menu and tooltip."""
         _menu = "Parallel"
-        _tip = "Snaps to parallel directions of edges"
+        _tip = "Set snapping to a direction that is parallel to an edge."
+
         return {'Pixmap': 'Snap_Parallel',
                 'MenuText': QT_TRANSLATE_NOOP("Draft_Snap_Parallel", _menu),
                 'ToolTip': QT_TRANSLATE_NOOP("Draft_Snap_Parallel", _tip)}
 
     def Activated(self):
-        """Execute this when the command is called."""
+        """Execute when the command is called."""
+        super().Activated()
+
         if hasattr(Gui, "Snapper"):
             if hasattr(Gui.Snapper, "toolbarButtons"):
                 for b in Gui.Snapper.toolbarButtons:
@@ -174,19 +230,28 @@ class Draft_Snap_Parallel:
 Gui.addCommand('Draft_Snap_Parallel', Draft_Snap_Parallel())
 
 
-class Draft_Snap_Endpoint:
-    """Command to snap to an endpoint of an edge."""
+class Draft_Snap_Endpoint(gui_base.GuiCommandSimplest):
+    """GuiCommand for the Draft_Snap_Endpoint tool.
+
+    Set snapping to endpoints of an edge.
+    """
+
+    def __init__(self):
+        super().__init__(name=_tr("Endpoint snap"))
 
     def GetResources(self):
         """Set icon, menu and tooltip."""
         _menu = "Endpoint"
-        _tip = "Snaps to endpoints of edges"
+        _tip = "Set snapping to endpoints of an edge."
+
         return {'Pixmap': 'Snap_Endpoint',
                 'MenuText': QT_TRANSLATE_NOOP("Draft_Snap_Endpoint", _menu),
                 'ToolTip': QT_TRANSLATE_NOOP("Draft_Snap_Endpoint", _tip)}
 
     def Activated(self):
-        """Execute this when the command is called."""
+        """Execute when the command is called."""
+        super().Activated()
+
         if hasattr(Gui, "Snapper"):
             if hasattr(Gui.Snapper, "toolbarButtons"):
                 for b in Gui.Snapper.toolbarButtons:
@@ -197,18 +262,30 @@ class Draft_Snap_Endpoint:
 Gui.addCommand('Draft_Snap_Endpoint', Draft_Snap_Endpoint())
 
 
-class Draft_Snap_Angle:
-    """Command to snap to 90 degree angles."""
+class Draft_Snap_Angle(gui_base.GuiCommandSimplest):
+    """GuiCommand for the Draft_Snap_Angle tool.
+
+    Set snapping to points in a circular arc located at multiples
+    of 30 and 45 degree angles.
+    """
+
+    def __init__(self):
+        super().__init__(name=_tr("Angle snap (30 and 45 degrees)"))
 
     def GetResources(self):
         """Set icon, menu and tooltip."""
-        _tip = "Snaps to 45 and 90 degrees points on arcs and circles"
+        _menu = "Angles (30 and 45 degrees)"
+        _tip = ("Set snapping to points in a circular arc located "
+                "at multiples of 30 and 45 degree angles.")
+
         return {'Pixmap': 'Snap_Angle',
-                'MenuText': QT_TRANSLATE_NOOP("Draft_Snap_Angle", "Angles"),
+                'MenuText': QT_TRANSLATE_NOOP("Draft_Snap_Angle", _menu),
                 'ToolTip': QT_TRANSLATE_NOOP("Draft_Snap_Angle", _tip)}
 
     def Activated(self):
-        """Execute this when the command is called."""
+        """Execute when the command is called."""
+        super().Activated()
+
         if hasattr(Gui, "Snapper"):
             if hasattr(Gui.Snapper, "toolbarButtons"):
                 for b in Gui.Snapper.toolbarButtons:
@@ -219,18 +296,27 @@ class Draft_Snap_Angle:
 Gui.addCommand('Draft_Snap_Angle', Draft_Snap_Angle())
 
 
-class Draft_Snap_Center:
-    """Command to snap to the centers of arcs and circumferences."""
+class Draft_Snap_Center(gui_base.GuiCommandSimplest):
+    """GuiCommand for the Draft_Snap_Center tool.
+
+    Set snapping to the center of a circular arc.
+    """
+
+    def __init__(self):
+        super().__init__(name=_tr("Arc center snap"))
 
     def GetResources(self):
         """Set icon, menu and tooltip."""
-        _tip = "Snaps to center of circles and arcs"
+        _tip = "Set snapping to the center of a circular arc."
+
         return {'Pixmap': 'Snap_Center',
                 'MenuText': QT_TRANSLATE_NOOP("Draft_Snap_Center", "Center"),
                 'ToolTip': QT_TRANSLATE_NOOP("Draft_Snap_Center", _tip)}
 
     def Activated(self):
-        """Execute this when the command is called."""
+        """Execute when the command is called."""
+        super().Activated()
+
         if hasattr(Gui, "Snapper"):
             if hasattr(Gui.Snapper, "toolbarButtons"):
                 for b in Gui.Snapper.toolbarButtons:
@@ -241,19 +327,28 @@ class Draft_Snap_Center:
 Gui.addCommand('Draft_Snap_Center', Draft_Snap_Center())
 
 
-class Draft_Snap_Extension:
-    """Command to snap to the extension of an edge."""
+class Draft_Snap_Extension(gui_base.GuiCommandSimplest):
+    """GuiCommand for the Draft_Snap_Extension tool.
+
+    Set snapping to the extension of an edge.
+    """
+
+    def __init__(self):
+        super().__init__(name=_tr("Edge extension snap"))
 
     def GetResources(self):
         """Set icon, menu and tooltip."""
         _menu = "Extension"
-        _tip = "Snaps to extension of edges"
+        _tip = "Set snapping to the extension of an edge."
+
         return {'Pixmap': 'Snap_Extension',
                 'MenuText': QT_TRANSLATE_NOOP("Draft_Snap_Extension", _menu),
                 'ToolTip': QT_TRANSLATE_NOOP("Draft_Snap_Extension", _tip)}
 
     def Activated(self):
-        """Execute this when the command is called."""
+        """Execute when the command is called."""
+        super().Activated()
+
         if hasattr(Gui, "Snapper"):
             if hasattr(Gui.Snapper, "toolbarButtons"):
                 for b in Gui.Snapper.toolbarButtons:
@@ -264,18 +359,27 @@ class Draft_Snap_Extension:
 Gui.addCommand('Draft_Snap_Extension', Draft_Snap_Extension())
 
 
-class Draft_Snap_Near:
-    """Command to snap to the nearest point of an edge."""
+class Draft_Snap_Near(gui_base.GuiCommandSimplest):
+    """GuiCommand for the Draft_Snap_Near tool.
+
+    Set snapping to the nearest point of an edge.
+    """
+
+    def __init__(self):
+        super().__init__(name=_tr("Near snap"))
 
     def GetResources(self):
         """Set icon, menu and tooltip."""
-        _tip = "Snaps to nearest point on edges"
+        _tip = "Set snapping to the nearest point of an edge."
+
         return {'Pixmap': 'Snap_Near',
                 'MenuText': QT_TRANSLATE_NOOP("Draft_Snap_Near", "Nearest"),
                 'ToolTip': QT_TRANSLATE_NOOP("Draft_Snap_Near", _tip)}
 
     def Activated(self):
-        """Execute this when the command is called."""
+        """Execute when the command is called."""
+        super().Activated()
+
         if hasattr(Gui, "Snapper"):
             if hasattr(Gui.Snapper, "toolbarButtons"):
                 for b in Gui.Snapper.toolbarButtons:
@@ -286,18 +390,30 @@ class Draft_Snap_Near:
 Gui.addCommand('Draft_Snap_Near', Draft_Snap_Near())
 
 
-class Draft_Snap_Ortho:
-    """Command to snap to the orthogonal directions."""
+class Draft_Snap_Ortho(gui_base.GuiCommandSimplest):
+    """GuiCommand for the Draft_Snap_Ortho tool.
+
+    Set snapping to a direction that is a multiple of 45 degrees
+    from a point.
+    """
+
+    def __init__(self):
+        super().__init__(name=_tr("Orthogonal snap"))
 
     def GetResources(self):
         """Set icon, menu and tooltip."""
-        _tip = "Snaps to orthogonal and 45 degrees directions"
+        _menu = "Orthogonal angles (45 degrees)"
+        _tip = ("Set snapping to a direction that is a multiple "
+                "of 45 degrees from a point.")
+
         return {'Pixmap': 'Snap_Ortho',
-                'MenuText': QT_TRANSLATE_NOOP("Draft_Snap_Ortho", "Ortho"),
+                'MenuText': QT_TRANSLATE_NOOP("Draft_Snap_Ortho", _menu),
                 'ToolTip': QT_TRANSLATE_NOOP("Draft_Snap_Ortho", _tip)}
 
     def Activated(self):
-        """Execute this when the command is called."""
+        """Execute when the command is called."""
+        super().Activated()
+
         if hasattr(Gui, "Snapper"):
             if hasattr(Gui.Snapper, "toolbarButtons"):
                 for b in Gui.Snapper.toolbarButtons:
@@ -308,19 +424,28 @@ class Draft_Snap_Ortho:
 Gui.addCommand('Draft_Snap_Ortho', Draft_Snap_Ortho())
 
 
-class Draft_Snap_Special:
-    """Command to snap to the special point of an object."""
+class Draft_Snap_Special(gui_base.GuiCommandSimplest):
+    """GuiCommand for the Draft_Snap_Special tool.
+
+    Set snapping to the special points defined inside an object.
+    """
+
+    def __init__(self):
+        super().__init__(name=_tr("Special point snap"))
 
     def GetResources(self):
         """Set icon, menu and tooltip."""
         _menu = "Special"
-        _tip = "Snaps to special locations of objects"
+        _tip = "Set snapping to the special points defined inside an object."
+
         return {'Pixmap': 'Snap_Special',
                 'MenuText': QT_TRANSLATE_NOOP("Draft_Snap_Special", _menu),
                 'ToolTip': QT_TRANSLATE_NOOP("Draft_Snap_Special", _tip)}
 
     def Activated(self):
-        """Execute this when the command is called."""
+        """Execute when the command is called."""
+        super().Activated()
+
         if hasattr(Gui, "Snapper"):
             if hasattr(Gui.Snapper, "toolbarButtons"):
                 for b in Gui.Snapper.toolbarButtons:
@@ -331,19 +456,30 @@ class Draft_Snap_Special:
 Gui.addCommand('Draft_Snap_Special', Draft_Snap_Special())
 
 
-class Draft_Snap_Dimensions:
-    """Command to temporary show dimensions when snapping."""
+class Draft_Snap_Dimensions(gui_base.GuiCommandSimplest):
+    """GuiCommand for the Draft_Snap_Dimensions tool.
+
+    Show temporary linear dimensions when editing an object
+    and using other snapping methods.
+    """
+
+    def __init__(self):
+        super().__init__(name=_tr("Dimension display"))
 
     def GetResources(self):
         """Set icon, menu and tooltip."""
-        _menu = "Dimensions"
-        _tip = "Shows temporary dimensions when snapping to Arch objects"
+        _menu = "Show dimensions"
+        _tip = ("Show temporary linear dimensions when editing an object "
+                "and using other snapping methods.")
+
         return {'Pixmap': 'Snap_Dimensions',
                 'MenuText': QT_TRANSLATE_NOOP("Draft_Snap_Dimensions", _menu),
                 'ToolTip': QT_TRANSLATE_NOOP("Draft_Snap_Dimensions", _tip)}
 
     def Activated(self):
-        """Execute this when the command is called."""
+        """Execute when the command is called."""
+        super().Activated()
+
         if hasattr(Gui, "Snapper"):
             if hasattr(Gui.Snapper, "toolbarButtons"):
                 for b in Gui.Snapper.toolbarButtons:
@@ -354,13 +490,28 @@ class Draft_Snap_Dimensions:
 Gui.addCommand('Draft_Snap_Dimensions', Draft_Snap_Dimensions())
 
 
-class Draft_Snap_WorkingPlane:
-    """Command to snap to a point in the current working plane."""
+class Draft_Snap_WorkingPlane(gui_base.GuiCommandSimplest):
+    """GuiCommand for the Draft_Snap_WorkingPlane tool.
+
+    Restricts snapping to a point in the current working plane.
+    If you select a point outside the working plane, for example,
+    by using other snapping methods, it will snap to that point's
+    projection in the current working plane.
+    """
+
+    def __init__(self):
+        super().__init__(name=_tr("Working plane snap"))
 
     def GetResources(self):
         """Set icon, menu and tooltip."""
         _menu = "Working plane"
-        _tip = "Restricts the snapped point to the current working plane"
+        _tip = ("Restricts snapping to a point in the current "
+                "working plane.\n"
+                "If you select a point outside the working plane, "
+                "for example, by using other snapping methods,\n"
+                "it will snap to that point's projection "
+                "in the current working plane.")
+
         return {'Pixmap': 'Snap_WorkingPlane',
                 'MenuText': QT_TRANSLATE_NOOP("Draft_Snap_WorkingPlane",
                                               _menu),
@@ -368,7 +519,9 @@ class Draft_Snap_WorkingPlane:
                                              _tip)}
 
     def Activated(self):
-        """Execute this when the command is called."""
+        """Execute when the command is called."""
+        super().Activated()
+
         if hasattr(Gui, "Snapper"):
             if hasattr(Gui.Snapper, "toolbarButtons"):
                 for b in Gui.Snapper.toolbarButtons:
@@ -379,22 +532,29 @@ class Draft_Snap_WorkingPlane:
 Gui.addCommand('Draft_Snap_WorkingPlane', Draft_Snap_WorkingPlane())
 
 
-class ShowSnapBar:
+class ShowSnapBar(gui_base.GuiCommandSimplest):
     """GuiCommand for the Draft_ShowSnapBar tool.
 
-    Show the snap toolbar if it's hidden.
+    Show the snap toolbar if it is hidden.
     """
+
+    def __init__(self):
+        super().__init__(name=_tr("Show snap toolbar"))
 
     def GetResources(self):
         """Set icon, menu and tooltip."""
+        _tip = "Show the snap toolbar if it is hidden."
+
         return {'Pixmap': 'Draft_Snap',
                 'MenuText': QT_TRANSLATE_NOOP("Draft_ShowSnapBar",
                                               "Show snap toolbar"),
                 'ToolTip': QT_TRANSLATE_NOOP("Draft_ShowSnapBar",
-                                             "Shows Draft snap toolbar.")}
+                                             _tip)}
 
     def Activated(self):
         """Execute when the command is called."""
+        super().Activated()
+
         if hasattr(Gui, "Snapper"):
             Gui.Snapper.show()
 

--- a/src/Mod/Draft/draftguitools/gui_snaps.py
+++ b/src/Mod/Draft/draftguitools/gui_snaps.py
@@ -377,3 +377,26 @@ class Draft_Snap_WorkingPlane:
 
 
 Gui.addCommand('Draft_Snap_WorkingPlane', Draft_Snap_WorkingPlane())
+
+
+class ShowSnapBar:
+    """GuiCommand for the Draft_ShowSnapBar tool.
+
+    Show the snap toolbar if it's hidden.
+    """
+
+    def GetResources(self):
+        """Set icon, menu and tooltip."""
+        return {'Pixmap': 'Draft_Snap',
+                'MenuText': QT_TRANSLATE_NOOP("Draft_ShowSnapBar",
+                                              "Show snap toolbar"),
+                'ToolTip': QT_TRANSLATE_NOOP("Draft_ShowSnapBar",
+                                             "Shows Draft snap toolbar.")}
+
+    def Activated(self):
+        """Execute when the command is called."""
+        if hasattr(Gui, "Snapper"):
+            Gui.Snapper.show()
+
+
+Gui.addCommand('Draft_ShowSnapBar', ShowSnapBar())

--- a/src/Mod/Draft/draftguitools/gui_togglemodes.py
+++ b/src/Mod/Draft/draftguitools/gui_togglemodes.py
@@ -24,7 +24,8 @@
 # ***************************************************************************
 """Provides tools to control the mode of other tools in the Draft Workbench.
 
-For example, a construction mode, and a continue mode to repeat commands.
+For example, a construction mode, a continue mode to repeat commands,
+and to toggle the appearance of certain shapes to wireframe.
 """
 ## @package gui_togglemodes
 # \ingroup DRAFT
@@ -151,3 +152,56 @@ class ToggleContinueMode(BaseMode):
 
 
 Gui.addCommand('Draft_ToggleContinueMode', ToggleContinueMode())
+
+
+class ToggleDisplayMode(gui_base.GuiCommandNeedsSelection):
+    """GuiCommand for the Draft_ToggleDisplayMode tool.
+
+    Switches the display mode of selected objects from flatlines
+    to wireframe and back.
+
+    It inherits `GuiCommandNeedsSelection` to only be availbale
+    when there is a document and a selection.
+    See this class for more information.
+    """
+
+    def __init__(self):
+        super().__init__(name=_tr("Toggle display mode"))
+
+    def GetResources(self):
+        """Set icon, menu and tooltip."""
+        _menu = "Toggle normal/wireframe display"
+        _tip = ("Switches the display mode of selected objects "
+                "from flatlines to wireframe and back.\n"
+                "This is helpful to quickly visualize objects "
+                "that are hidden by other objects.\n"
+                "This is intended to be used with closed shapes "
+                "and solids, and doesn't affect open wires.")
+
+        d = {'Pixmap': 'Draft_SwitchMode',
+             'Accel': "Shift+Space",
+             'MenuText': QT_TRANSLATE_NOOP("Draft_ToggleDisplayMode",
+                                           _menu),
+             'ToolTip': QT_TRANSLATE_NOOP("Draft_ToggleDisplayMode",
+                                          _tip)}
+        return d
+
+    def Activated(self):
+        """Execute when the command is called.
+
+        It tests the view provider of the selected objects
+        and changes their `DisplayMode` from `'Wireframe'`
+        to `'Flat Lines'`, and the other way around, if possible.
+        """
+        super().Activated()
+
+        for obj in Gui.Selection.getSelection():
+            if obj.ViewObject.DisplayMode == "Flat Lines":
+                if "Wireframe" in obj.ViewObject.listDisplayModes():
+                    obj.ViewObject.DisplayMode = "Wireframe"
+            elif obj.ViewObject.DisplayMode == "Wireframe":
+                if "Flat Lines" in obj.ViewObject.listDisplayModes():
+                    obj.ViewObject.DisplayMode = "Flat Lines"
+
+
+Gui.addCommand('Draft_ToggleDisplayMode', ToggleDisplayMode())

--- a/src/Mod/Draft/draftguitools/gui_togglemodes.py
+++ b/src/Mod/Draft/draftguitools/gui_togglemodes.py
@@ -1,0 +1,153 @@
+# ***************************************************************************
+# *   (c) 2009, 2010 Yorik van Havre <yorik@uncreated.net>                  *
+# *   (c) 2009, 2010 Ken Cline <cline@frii.com>                             *
+# *   (c) 2020 Eliud Cabrera Castillo <e.cabrera-castillo@tum.de>           *
+# *                                                                         *
+# *   This file is part of the FreeCAD CAx development system.              *
+# *                                                                         *
+# *   This program is free software; you can redistribute it and/or modify  *
+# *   it under the terms of the GNU Lesser General Public License (LGPL)    *
+# *   as published by the Free Software Foundation; either version 2 of     *
+# *   the License, or (at your option) any later version.                   *
+# *   for detail see the LICENCE text file.                                 *
+# *                                                                         *
+# *   FreeCAD is distributed in the hope that it will be useful,            *
+# *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+# *   GNU Library General Public License for more details.                  *
+# *                                                                         *
+# *   You should have received a copy of the GNU Library General Public     *
+# *   License along with FreeCAD; if not, write to the Free Software        *
+# *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
+# *   USA                                                                   *
+# *                                                                         *
+# ***************************************************************************
+"""Provides tools to control the mode of other tools in the Draft Workbench.
+
+For example, a construction mode, and a continue mode to repeat commands.
+"""
+## @package gui_togglemodes
+# \ingroup DRAFT
+# \brief Provides certain mode operations of the Draft Workbench.
+from PySide.QtCore import QT_TRANSLATE_NOOP
+
+import FreeCADGui as Gui
+import Draft_rc
+import draftguitools.gui_base as gui_base
+from draftutils.messages import _msg
+from draftutils.translate import _tr
+
+# The module is used to prevent complaints from code checkers (flake8)
+True if Draft_rc.__name__ else False
+
+
+class BaseMode(gui_base.GuiCommandSimplest):
+    """Base class for mode context GuiCommands.
+
+    This is inherited by the other GuiCommand classes to run
+    a set of similar actions when changing modes.
+
+    It inherits `GuiCommandSimplest` to set up the document
+    and other behavior. See this class for more information.
+    """
+
+    def Activated(self, mode="None"):
+        """Execute when the command is called.
+
+        Parameters
+        ----------
+        action: str
+            Indicates the type of mode to switch to.
+            It can be `'construction'` or `'continue'`.
+        """
+        super().Activated()
+
+        if hasattr(Gui, "draftToolBar"):
+            _ui = Gui.draftToolBar
+        else:
+            _msg(_tr("No active Draft Toolbar."))
+            return
+
+        if _ui is not None:
+            if mode == "construction" and hasattr(_ui, "constrButton"):
+                _ui.constrButton.toggle()
+            elif mode == "continue":
+                _ui.toggleContinue()
+
+
+class ToggleConstructionMode(BaseMode):
+    """GuiCommand for the Draft_ToggleConstructionMode tool.
+
+    When construction mode is active, the following objects created
+    will be included in the construction group, and will be drawn
+    with the specified color and properties.
+    """
+
+    def __init__(self):
+        super().__init__(name=_tr("Construction mode"))
+
+    def GetResources(self):
+        """Set icon, menu and tooltip."""
+        _menu = "Toggle construction mode"
+        _tip = ("Toggles the Construction mode.\n"
+                "When this is active, the following objects created "
+                "will be included in the construction group, "
+                "and will be drawn with the specified color "
+                "and properties.")
+
+        d = {'Pixmap': 'Draft_Construction',
+             'MenuText': QT_TRANSLATE_NOOP("Draft_ToggleConstructionMode",
+                                           _menu),
+             'Accel': "C, M",
+             'ToolTip': QT_TRANSLATE_NOOP("Draft_ToggleConstructionMode",
+                                          _tip)}
+        return d
+
+    def Activated(self):
+        """Execute when the command is called.
+
+        It calls the `toggle()` method of the construction button
+        in the `DraftToolbar` class.
+        """
+        super().Activated(mode="construction")
+
+
+Gui.addCommand('Draft_ToggleConstructionMode', ToggleConstructionMode())
+
+
+class ToggleContinueMode(BaseMode):
+    """GuiCommand for the Draft_ToggleContinueMode tool.
+
+    When continue mode is active, any drawing tool that is terminated
+    will automatically start again. This can be used to draw several
+    objects one after the other in succession.
+    """
+
+    def __init__(self):
+        super().__init__(name=_tr("Continue mode"))
+
+    def GetResources(self):
+        """Set icon, menu and tooltip."""
+        _menu = "Toggle continue mode"
+        _tip = ("Toggles the Continue mode.\n"
+                "When this is active, any drawing tool that is terminated "
+                "will automatically start again.\n"
+                "This can be used to draw several objects "
+                "one after the other in succession.")
+
+        d = {'Pixmap': 'Draft_Continue',
+             'MenuText': QT_TRANSLATE_NOOP("Draft_ToggleContinueMode",
+                                           _menu),
+             'ToolTip': QT_TRANSLATE_NOOP("Draft_ToggleContinueMode",
+                                          _tip)}
+        return d
+
+    def Activated(self):
+        """Execute when the command is called.
+
+        It calls the `toggleContinue()` method of the `DraftToolbar` class.
+        """
+        super().Activated(mode="continue")
+
+
+Gui.addCommand('Draft_ToggleContinueMode', ToggleContinueMode())

--- a/src/Mod/Draft/draftutils/init_tools.py
+++ b/src/Mod/Draft/draftutils/init_tools.py
@@ -63,7 +63,8 @@ def get_draft_small_commands():
             "Draft_WorkingPlaneProxy",
             "Draft_ToggleDisplayMode",
             "Draft_AddToGroup",
-            "Draft_SelectGroup"]
+            "Draft_SelectGroup",
+            "Draft_Heal"]
 
 
 def get_draft_modification_commands():

--- a/src/Mod/Draft/draftutils/init_tools.py
+++ b/src/Mod/Draft/draftutils/init_tools.py
@@ -57,6 +57,13 @@ def get_draft_array_commands():
     return ["Draft_ArrayTools"]
 
 
+def get_draft_small_commands():
+    """Return a list with only some utilities."""
+    return ["Draft_Layer",
+            "Draft_WorkingPlaneProxy",
+            "Draft_ToggleDisplayMode"]
+
+
 def get_draft_modification_commands():
     """Return the modification commands list."""
     lst = ["Draft_Move", "Draft_Rotate",
@@ -74,8 +81,7 @@ def get_draft_modification_commands():
             "Separator",
             "Draft_WireToBSpline", "Draft_Draft2Sketch",
             "Separator",
-            "Draft_Shape2DView", "Draft_Drawing",
-            "Draft_WorkingPlaneProxy"]
+            "Draft_Shape2DView", "Draft_Drawing"]
     return lst
 
 

--- a/src/Mod/Draft/draftutils/init_tools.py
+++ b/src/Mod/Draft/draftutils/init_tools.py
@@ -64,6 +64,7 @@ def get_draft_small_commands():
             "Draft_ToggleDisplayMode",
             "Draft_AddToGroup",
             "Draft_SelectGroup",
+            "Draft_AddConstruction",
             "Draft_Heal"]
 
 

--- a/src/Mod/Draft/draftutils/init_tools.py
+++ b/src/Mod/Draft/draftutils/init_tools.py
@@ -83,6 +83,7 @@ def get_draft_modification_commands():
             "Draft_Upgrade", "Draft_Downgrade",
             "Separator",
             "Draft_WireToBSpline", "Draft_Draft2Sketch",
+            "Draft_FlipDimension",
             "Separator",
             "Draft_Shape2DView", "Draft_Drawing"]
     return lst

--- a/src/Mod/Draft/draftutils/init_tools.py
+++ b/src/Mod/Draft/draftutils/init_tools.py
@@ -61,7 +61,8 @@ def get_draft_small_commands():
     """Return a list with only some utilities."""
     return ["Draft_Layer",
             "Draft_WorkingPlaneProxy",
-            "Draft_ToggleDisplayMode"]
+            "Draft_ToggleDisplayMode",
+            "Draft_AddToGroup"]
 
 
 def get_draft_modification_commands():

--- a/src/Mod/Draft/draftutils/init_tools.py
+++ b/src/Mod/Draft/draftutils/init_tools.py
@@ -62,7 +62,8 @@ def get_draft_small_commands():
     return ["Draft_Layer",
             "Draft_WorkingPlaneProxy",
             "Draft_ToggleDisplayMode",
-            "Draft_AddToGroup"]
+            "Draft_AddToGroup",
+            "Draft_SelectGroup"]
 
 
 def get_draft_modification_commands():

--- a/src/Mod/Draft/draftutils/init_tools.py
+++ b/src/Mod/Draft/draftutils/init_tools.py
@@ -83,7 +83,7 @@ def get_draft_modification_commands():
             "Draft_Upgrade", "Draft_Downgrade",
             "Separator",
             "Draft_WireToBSpline", "Draft_Draft2Sketch",
-            "Draft_FlipDimension",
+            "Draft_Slope", "Draft_FlipDimension",
             "Separator",
             "Draft_Shape2DView", "Draft_Drawing"]
     return lst


### PR DESCRIPTION
To continue the restructuring of the code we move various tools to their own modules.

These are Gui Commands that don't depend on the `Modifier` or `Creator` classes inside `DraftTools.py`, and therefore are relatively simple to relocate without breaking dependencies.

These include:
* [Draft_FinishLine](https://wiki.freecadweb.org/Draft_FinishLine)
* [Draft_CloseLine](https://wiki.freecadweb.org/Draft_CloseLine)
* [Draft_UndoLine](https://wiki.freecadweb.org/Draft_UndoLine)
* [Draft_ToggleConstructionMode](https://wiki.freecadweb.org/Draft_ToggleConstructionMode)
* [Draft_ToggleContinueMode](https://wiki.freecadweb.org/Draft_ToggleContinueMode)
* [Draft_ToggleDisplayMode](https://wiki.freecadweb.org/Draft_ToggleDisplayMode)
* [Draft_AddToGroup](https://wiki.freecadweb.org/Draft_AddToGroup)
* [Draft_SelectGroup](https://wiki.freecadweb.org/Draft_SelectGroup)
* [Draft_ShowSnapBar](https://wiki.freecadweb.org/Draft_ShowSnapBar)
* [Draft_ToggleGrid](https://wiki.freecadweb.org/Draft_ToggleGrid)
* [Draft_Heal](https://wiki.freecadweb.org/Draft_Heal)
* [Draft_FlipDimension](https://wiki.freecadweb.org/Draft_FlipDimension)
* [Draft_Slope](https://wiki.freecadweb.org/Draft_Slope)
* [Draft_AutoGroup](https://wiki.freecadweb.org/Draft_AutoGroup)
* [Draft_AddConstruction](https://wiki.freecadweb.org/Draft_AddConstruction)
* [Draft_Arc_3Points](https://wiki.freecadweb.org/Draft_Arc_3Points)
* [Draft_AddPoint](https://wiki.freecadweb.org/Draft_AddPoint)
* [Draft_DelPoint](https://wiki.freecadweb.org/Draft_DelPoint)

[Draft_AddPoint](https://wiki.freecadweb.org/Draft_AddPoint) and [Draft_DelPoint](https://wiki.freecadweb.org/Draft_DelPoint) were removed in f5f43913e0 and 8fd55eb6ff. They are restored and placed in their own module. The code is there for historical purposes but it is not imported nor used.

All array commands are now imported from the single `gui_arrays` module, so that it is easy to import from `DraftTools.py`.

Finally, a new utility toolbar is defined in `InitGui.py` that includes useful commands like Layer, WorkingPlaneProxy, ToggleDisplayMode, AddToGroup, SelectGroup, AddConstruction, and Heal. And Slope and FlipDimension are move to the modification toolbar.

This pull request follows #3158 because it assumes that the taskpanels and Gui Command classes of other commands are already in their respective files.

* Forum thread: [[Discussion] Splitting Draft tools into their own modules](https://forum.freecadweb.org/viewtopic.php?f=23&t=38593&p=385444#p385448)
* Reorganization [diagram](https://forum.freecadweb.org/viewtopic.php?f=23&t=38593&start=40#p368890).

---

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists
