### PR TITLE
Use reproducible SOURCE_DATE_EPOCH instead of TIMESTAMP when available

### DIFF
--- a/src/XDGData/CMakeLists.txt
+++ b/src/XDGData/CMakeLists.txt
@@ -7,7 +7,11 @@ if(NOT DEFINED APPDATA_RELEASE_DATE)
             WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
             OUTPUT_STRIP_TRAILING_WHITESPACE)
     else()
-        file(TIMESTAMP "${CMAKE_SOURCE_DIR}/CMakeLists.txt" APPDATA_RELEASE_DATE "%Y-%m-%d")
+        if(NOT (CMAKE_VERSION VERSION_LESS 3.8.0))
+            set(APPDATA_RELEASE_DATE ENV{SOURCE_DATE_EPOCH})
+        else()
+            file(TIMESTAMP "${CMAKE_SOURCE_DIR}/CMakeLists.txt" APPDATA_RELEASE_DATE "%Y-%m-%d")
+        endif()
     endif()
 endif()
 


### PR DESCRIPTION
Refer to https://reproducible-builds.org/docs/source-date-epoch/:

"SOURCE_DATE_EPOCH is a standardised environment variable that
distributions can set centrally and have build tools consume this in
order to produce reproducible output."
