### PR TITLE
Use relative path to stylesheet fix #4130

### DIFF
--- a/src/Gui/Application.cpp
+++ b/src/Gui/Application.cpp
@@ -2100,8 +2100,25 @@ void Application::runApplication(void)
             style = it->second;
     }
     if (!style.empty()) {
-        QFile f(QLatin1String(style.c_str()));
-        if (f.open(QFile::ReadOnly)) {
+        // Search for stylesheet in user, system and resources location
+        QString user = QString::fromUtf8((App::Application::getUserAppDataDir() + "Gui/Stylesheets/").c_str());
+        QString system = QString::fromUtf8((App::Application::getResourceDir() + "Gui/Stylesheets/").c_str());
+        QString resources = QLatin1String(":/stylesheets/");
+
+        QFile f;
+        if (QFile::exists(user + QLatin1String(style.c_str()))) {
+            f.setFileName(user + QLatin1String(style.c_str()));
+        }
+        else if (QFile::exists(system + QLatin1String(style.c_str()))) {
+            f.setFileName(system + QLatin1String(style.c_str()));
+        }
+        else if (QFile::exists(resources + QLatin1String(style.c_str()))) {
+            f.setFileName(resources + QLatin1String(style.c_str()));
+        }
+        else {
+        }
+
+        if (f.open(QFile::ReadOnly | QFile::Text)) {
             mdi->setBackground(QBrush(Qt::NoBrush));
             QTextStream str(&f);
             qApp->setStyleSheet(str.readAll());

--- a/src/Gui/DlgGeneralImp.cpp
+++ b/src/Gui/DlgGeneralImp.cpp
@@ -171,7 +171,24 @@ void DlgGeneralImp::saveSettings()
         hGrp->SetASCII("StyleSheet", (const char*)sheet.toByteArray());
 
         if (!sheet.toString().isEmpty()) {
-            QFile f(sheet.toString());
+            // Search for stylesheet in user, system and resources location
+            QString user = QString::fromUtf8((App::Application::getUserAppDataDir() + "Gui/Stylesheets/").c_str());
+            QString system = QString::fromUtf8((App::Application::getResourceDir() + "Gui/Stylesheets/").c_str());
+            QString resources = QLatin1String(":/stylesheets/");
+
+            QFile f;
+            if (QFile::exists(user + sheet.toString())) {
+                f.setFileName(user + sheet.toString());
+            }
+            else if (QFile::exists(system + sheet.toString())) {
+                f.setFileName(system + sheet.toString());
+            }
+            else if (QFile::exists(resources + sheet.toString())) {
+                f.setFileName(resources + sheet.toString());
+            }
+            else {
+            }
+
             if (f.open(QFile::ReadOnly)) {
                 mdi->setBackground(QBrush(Qt::NoBrush));
                 QTextStream str(&f);
@@ -307,7 +324,7 @@ void DlgGeneralImp::loadSettings()
         fileNames = dir.entryInfoList(filter, QDir::Files, QDir::Name);
         for (QFileInfoList::iterator jt = fileNames.begin(); jt != fileNames.end(); ++jt) {
             if (cssFiles.find(jt->baseName()) == cssFiles.end()) {
-                cssFiles[jt->baseName()] = jt->absoluteFilePath();
+                cssFiles[jt->baseName()] = jt->fileName();
             }
         }
     }


### PR DESCRIPTION
Currently an absolute path is being set, when enabling a stylesheet. Absolute path causes issues with the AppImage, whenever one of the default stylesheets is set. This pull request changes that and a relative path to stylesheet is now used instead. Hierarchy being to check in user, system and resources location in that order.

https://tracker.freecadweb.org/view.php?id=4130