### PR TITLE
[Sketcher] Remove 'Hexagonal profile' menu ; fixes #4290

### DIFF
--- a/src/Mod/Sketcher/Gui/Workbench.cpp
+++ b/src/Mod/Sketcher/Gui/Workbench.cpp
@@ -58,16 +58,17 @@ Gui::MenuItem* Workbench::setupMenuBar() const
     Gui::MenuItem* item = root->findItem("&Windows");
 
 // == Profile menu ==========================================
-    Gui::MenuItem* profile = new Gui::MenuItem;
+/*    Gui::MenuItem* profile = new Gui::MenuItem;
     root->insertItem(item, profile);
     profile->setCommand("P&rofiles");
 
-    *profile << "Sketcher_ProfilesHexagon1";
+    *profile << "Sketcher_ProfilesHexagon1";*/
 
 // == Sketcher menu ==========================================
 
     Gui::MenuItem* sketch = new Gui::MenuItem;
-    root->insertItem(profile, sketch);
+//    root->insertItem(profile, sketch);
+    root->insertItem(item, sketch);
     sketch->setCommand("S&ketch");
     Gui::MenuItem* geom = new Gui::MenuItem();
     geom->setCommand("Sketcher geometries");


### PR DESCRIPTION
 Menu creation has been removed (commented) but all other profile feature are kept
 for compatibility.

- [X] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [X] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [X] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists
