### PR TITLE
[Path] Fix failed Job creation due `EnableRotation` property error

### DIFF
--- a/src/Mod/Path/PathScripts/PathAreaOp.py
+++ b/src/Mod/Path/PathScripts/PathAreaOp.py
@@ -968,3 +968,8 @@ class ObjectOp(PathOp.ObjectOp):
             final_depth=finDep,
             user_depths=None)
         return cdp
+
+
+def SetupProperties():
+    setup = ['EnableRotation']
+    return setup

--- a/src/Mod/Path/PathScripts/PathPocketBase.py
+++ b/src/Mod/Path/PathScripts/PathPocketBase.py
@@ -135,7 +135,7 @@ class ObjectPocket(PathAreaOp.ObjectOp):
 
 
 def SetupProperties():
-    setup = []
+    setup = PathAreaOp.SetupProperties()
     setup.append('CutMode')
     setup.append('ExtraOffset')
     setup.append('StepOver')

--- a/src/Mod/Path/PathScripts/PathPocketShape.py
+++ b/src/Mod/Path/PathScripts/PathPocketShape.py
@@ -62,14 +62,14 @@ def endPoints(edgeOrWire):
             cnt = len([p2 for p2 in pts if PathGeom.pointsCoincide(p, p2)])
             if 1 == cnt:
                 unique.append(p)
-            
+
         return unique
-    
+
     pfirst = edgeOrWire.valueAt(edgeOrWire.FirstParameter)
     plast = edgeOrWire.valueAt(edgeOrWire.LastParameter)
     if PathGeom.pointsCoincide(pfirst, plast):
         return None
-    
+
     return [pfirst, plast]
 
 
@@ -78,7 +78,7 @@ def includesPoint(p, pts):
     for pt in pts:
         if PathGeom.pointsCoincide(p, pt):
             return True
-        
+
     return False
 
 
@@ -89,10 +89,10 @@ def selectOffsetWire(feature, wires):
         dist = feature.distToShape(w)[0]
         if closest is None or dist > closest[0]:  # pylint: disable=unsubscriptable-object
             closest = (dist, w)
-        
+
     if closest is not None:
         return closest[1]
-    
+
     return None
 
 
@@ -119,7 +119,7 @@ def extendWire(feature, wire, length):
                     edges.append(Part.Edge(Part.LineSegment(endPts[1], ePts[0])))
                     edges.extend(offset.Edges)
                     edges.append(Part.Edge(Part.LineSegment(endPts[0], ePts[1])))
-                
+
                 return Part.Wire(edges)
     return None
 
@@ -154,7 +154,7 @@ class Extension(object):
             wire = Part.Wire([e0, e1, e2, e3])
             self.wire = wire
             return wire
-        
+
         return extendWire(feature, Part.Wire([e0]), self.length.Value)
 
     def _getEdgeNumbers(self):
@@ -162,7 +162,7 @@ class Extension(object):
             numbers = [nr for nr in self.sub[5:-1].split(',')]
         else:
             numbers = [self.sub[4:]]
-        
+
         PathLog.debug("_getEdgeNumbers() -> %s" % numbers)
         return numbers
 
@@ -177,10 +177,10 @@ class Extension(object):
         poffMinus = p0 - 0.01 * normal
         if not self.obj.Shape.isInside(poffPlus, 0.005, True):
             return normal
-        
+
         if not self.obj.Shape.isInside(poffMinus, 0.005, True):
             return normal.negative()
-        
+
         return None
 
     def _getDirection(self, wire):
@@ -191,7 +191,7 @@ class Extension(object):
         normal = tangent.cross(FreeCAD.Vector(0, 0, 1))
         if PathGeom.pointsCoincide(normal, FreeCAD.Vector(0, 0, 0)):
             return None
-        
+
         return self._getDirectedNormal(e0.valueAt(midparam), normal.normalize())
 
     def getWire(self):
@@ -220,7 +220,7 @@ class Extension(object):
                     r = circle.Radius - self.length.Value
                 else:
                     r = circle.Radius + self.length.Value
-                
+
                 # assuming the offset produces a valid circle - go for it
                 if r > 0:
                     e3 = Part.makeCircle(r, circle.Center, circle.Axis, edge.FirstParameter * 180 / math.pi, edge.LastParameter * 180 / math.pi)
@@ -229,9 +229,9 @@ class Extension(object):
                         e0 = Part.makeLine(edge.valueAt(edge.FirstParameter), e3.valueAt(e3.FirstParameter))
                         e2 = Part.makeLine(edge.valueAt(edge.LastParameter), e3.valueAt(e3.LastParameter))
                         return Part.Wire([e0, edge, e2, e3])
-                    
+
                     return Part.Wire([e3])
-                
+
                 # the extension is bigger than the hole - so let's just cover the whole hole
                 if endPoints(edge):
                     # if the resulting arc is smaller than the radius, create a pie slice
@@ -240,7 +240,7 @@ class Extension(object):
                     e0 = Part.makeLine(center, edge.valueAt(edge.FirstParameter))
                     e2 = Part.makeLine(edge.valueAt(edge.LastParameter), center)
                     return Part.Wire([e0, edge, e2])
-                
+
                 PathLog.track()
                 return Part.Wire([edge])
 
@@ -249,10 +249,10 @@ class Extension(object):
                 direction = self._getDirection(sub)
                 if direction is None:
                     return None
-                
+
             #    return self._extendEdge(feature, edge, direction)
             return self._extendEdge(feature, edges[0], direction)
-        
+
         return extendWire(feature, sub, self.length.Value)
 
 
@@ -334,7 +334,7 @@ class ObjectPocket(PathPocketBase.ObjectPocket):
                     PathLog.debug('  -e.isClosed()')
                     clsd.append(edg)
                     planar = True
-                
+
             # Attempt to create planar faces and select that with smallest area for use as pocket base
             if planar is True:
                 planar = False
@@ -348,14 +348,14 @@ class ObjectPocket(PathPocketBase.ObjectPocket):
                     else:
                         if trans is True:
                             mFF.translate(FreeCAD.Vector(0, 0, face.BoundBox.ZMin - mFF.BoundBox.ZMin))
-                        
+
                         if FreeCAD.ActiveDocument.getObject(fName):
                             FreeCAD.ActiveDocument.removeObject(fName)
-                        
+
                         tmpFace = FreeCAD.ActiveDocument.addObject('Part::Feature', fName).Shape = mFF
                         tmpFace = FreeCAD.ActiveDocument.getObject(fName)
                         tmpFace.purgeTouched()
-                        
+
                         if minArea == 0.0:
                             minArea = tmpFace.Shape.Face1.Area
                             useFace = fName
@@ -366,10 +366,10 @@ class ObjectPocket(PathPocketBase.ObjectPocket):
                             useFace = fName
                         else:
                             FreeCAD.ActiveDocument.removeObject(fName)
-                        
+
             if useFace != 'useFaceName':
                 self.useTempJobClones(useFace)
-            
+
             return (planar, useFace)
 
         def clasifySub(self, bs, sub):
@@ -382,15 +382,15 @@ class ObjectPocket(PathPocketBase.ObjectPocket):
                     # it's a flat horizontal face
                     self.horiz.append(face)
                     return True
-                
+
                 elif PathGeom.isHorizontal(face.Surface.Axis):
                     PathLog.debug('  -isHorizontal()')
                     self.vert.append(face)
                     return True
-                
+
                 else:
                     return False
-                
+
             elif type(face.Surface) == Part.Cylinder and PathGeom.isVertical(face.Surface.Axis):
                 PathLog.debug('type() == Part.Cylinder')
                 # vertical cylinder wall
@@ -402,13 +402,13 @@ class ObjectPocket(PathPocketBase.ObjectPocket):
                     disk.translate(FreeCAD.Vector(0, 0, face.BoundBox.ZMin - disk.BoundBox.ZMin))
                     self.horiz.append(disk)
                     return True
-                
+
                 else:
                     PathLog.debug('  -none isClosed()')
                     # partial cylinder wall
                     self.vert.append(face)
                     return True
-                
+
             elif type(face.Surface) == Part.SurfaceOfExtrusion:
                 # extrusion wall
                 PathLog.debug('type() == Part.SurfaceOfExtrusion')
@@ -427,7 +427,7 @@ class ObjectPocket(PathPocketBase.ObjectPocket):
                     # self.guiMessage(title, msg, False)
                 else:
                     PathLog.error(translate("Path", "Failed to create a planar face from edges in {}.".format(sub)))
-                
+
             else:
                 PathLog.debug('  -type(face.Surface): {}'.format(type(face.Surface)))
                 return False
@@ -448,7 +448,7 @@ class ObjectPocket(PathPocketBase.ObjectPocket):
                     # First, check all subs collectively for loop of faces
                     if len(subsList) > 2:
                         (isLoop, norm, surf) = self.checkForFacesLoop(base, subsList)
-                    
+
                     if isLoop is True:
                         PathLog.info("Common Surface.Axis or normalAt() value found for loop faces.")
                         rtn = False
@@ -491,7 +491,7 @@ class ObjectPocket(PathPocketBase.ObjectPocket):
                             stock = PathUtils.findParentJob(obj).Stock
                             tup = base, subsList, angle, axis, stock
                         # Eif
-                        
+
                         allTuples.append(tup)
                         baseSubsTuples.append(tup)
                     # Eif

--- a/src/Mod/Path/PathScripts/PathProfileBase.py
+++ b/src/Mod/Path/PathScripts/PathProfileBase.py
@@ -92,7 +92,7 @@ class ObjectProfile(PathAreaOp.ObjectOp):
     def areaOpOnDocumentRestored(self, obj):
         for prop in ['UseComp', 'JoinType']:
             self.areaOpOnChanged(obj, prop)
-        
+
         self.setOpEditorProperties(obj)
 
     def areaOpAreaParams(self, obj, isHole):
@@ -135,7 +135,7 @@ class ObjectProfile(PathAreaOp.ObjectOp):
             params['orientation'] = 0
         else:
             params['orientation'] = 1
-        
+
         if not obj.UseComp:
             if direction == 'CCW':
                 params['orientation'] = 1
@@ -160,7 +160,7 @@ class ObjectProfile(PathAreaOp.ObjectOp):
 
 
 def SetupProperties():
-    setup = []
+    setup = PathAreaOp.SetupProperties()
     setup.append('Side')
     setup.append('OffsetExtra')
     setup.append('Direction')

--- a/src/Mod/Path/PathScripts/PathProfileFaces.py
+++ b/src/Mod/Path/PathScripts/PathProfileFaces.py
@@ -71,12 +71,11 @@ class ObjectProfile(PathProfileBase.ObjectProfile):
 
         if not hasattr(obj, 'HandleMultipleFeatures'):
             obj.addProperty('App::PropertyEnumeration', 'HandleMultipleFeatures', 'Profile', QtCore.QT_TRANSLATE_NOOP('PathPocket', 'Choose how to process multiple Base Geometry features.'))
-        
+
         obj.HandleMultipleFeatures = ['Collectively', 'Individually']
 
         self.initRotationOp(obj)
         self.baseObject().initAreaOp(obj)
-        self.setOpEditorProperties(obj)
 
     def initRotationOp(self, obj):
         '''initRotationOp(obj) ... setup receiver for rotation'''


### PR DESCRIPTION
PathAreaOp:   Add SetupProperties() function
PathPocketBase:   Modify SetupProperties() function to include return from same in PathAreaOp.
PathPocketShape:  remove blank indents
PathProfileBase:  Modify SetupProperties() function to include return from same in PathAreaOp.
PathProfileFaces:  fix `EnableRotation` issue

Error reported in forum at [Path workbench - Cannot create a Path Job](https://forum.freecadweb.org/viewtopic.php?f=15&t=44345)

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
