### PR TITLE
[Draft] Improved Snapper Toolbar Behaviour

### DIFF
--- a/src/Mod/Draft/DraftGui.py
+++ b/src/Mod/Draft/DraftGui.py
@@ -1893,8 +1893,7 @@ class DraftToolBar:
         return str(a)
 
     def togglesnap(self):
-        if hasattr(FreeCADGui,"Snapper"):
-            FreeCADGui.Snapper.toggle()
+        FreeCADGui.doCommand('FreeCADGui.runCommand("Draft_Snap_Lock")')
 
     def togglenearsnap(self):
         if hasattr(FreeCADGui,"Snapper"):

--- a/src/Mod/Draft/draftguitools/gui_snapper.py
+++ b/src/Mod/Draft/draftguitools/gui_snapper.py
@@ -31,11 +31,13 @@ __url__ = "https://www.freecadweb.org"
 #  everything that goes with it (toolbar buttons, cursor icons, etc)
 
 
-import FreeCAD, FreeCADGui, math, Draft, DraftGui, DraftTrackers, DraftVecUtils, itertools
+import FreeCAD as App
+import FreeCADGui as Gui
+import math, Draft, DraftTrackers, DraftVecUtils, itertools
 from collections import OrderedDict
-from FreeCAD import Vector
 from pivy import coin
-from PySide import QtCore,QtGui
+from PySide import QtCore, QtGui
+from draftutils.init_tools import get_draft_snap_commands
 
 class Snapper:
     """The Snapper objects contains all the functionality used by draft
@@ -97,6 +99,27 @@ class Snapper:
         self.callbackMove = None
         self.snapObjectIndex = 0
 
+        # snap keys, it's important tha they are in this order for
+        # saving in preferences and for properly restore the toolbar
+        self.snaps = ['Lock',           # 0 
+                      'Near',           # 1 former "passive" snap
+                      'Extension',      # 2
+                      'Parallel',       # 3
+                      'Grid',           # 4
+                      "Endpoint",       # 5
+                      'Midpoint',       # 6
+                      'Perpendicular',  # 7
+                      'Angle',          # 8
+                      'Center',         # 9
+                      'Ortho',          # 10
+                      'Intersection',   # 11
+                      'Special',        # 12
+                      'Dimensions',     # 13
+                      'WorkingPlane'    # 14
+                     ]
+
+        self.init_active_snaps()
+
         # the snapmarker has "dot","circle" and "square" available styles
         if self.snapStyle:
             self.mk = OrderedDict([('passive',      'empty'),
@@ -138,6 +161,19 @@ class Snapper:
                                     ('intersection',    ':/icons/Snap_Intersection.svg'),
                                     ('special',         ':/icons/Snap_Special.svg')])
 
+    def init_active_snaps(self):
+        """
+        set self.active_snaps according to user prefs
+        """
+        self.active_snaps = []
+        param = App.ParamGet("User parameter:BaseApp/Preferences/Mod/Draft")
+        snap_modes = param.GetString("snapModes")
+        i = 0
+        for snap in snap_modes:
+            if bool(int(snap)):
+                self.active_snaps.append(self.snaps[i])
+            i += 1
+
     def cstr(self, lastpoint, constrain, point):
         "constrains if needed"
         if constrain or self.mask:
@@ -170,7 +206,7 @@ class Snapper:
 
         if not hasattr(self,"toolbar"):
             self.makeSnapToolBar()
-        mw = FreeCADGui.getMainWindow()
+        mw = Gui.getMainWindow()
         bt = mw.findChild(QtGui.QToolBar,"Draft Snap")
         if not bt:
             mw.addToolBar(self.toolbar)
@@ -277,7 +313,7 @@ class Snapper:
             subname = self.snapInfo['SubName']
             obj = parent.getSubObject(subname,retType=1)
         else:
-            obj = FreeCAD.ActiveDocument.getObject(self.snapInfo['Object'])
+            obj = App.ActiveDocument.getObject(self.snapInfo['Object'])
             parent = obj
             subname = self.snapInfo['Component']
         if not obj:
@@ -401,7 +437,7 @@ class Snapper:
 
         # calculating the nearest snap point
         shortest = 1000000000000000000
-        origin = Vector(self.snapInfo['x'],self.snapInfo['y'],self.snapInfo['z'])
+        origin = App.Vector(self.snapInfo['x'],self.snapInfo['y'],self.snapInfo['z'])
         winner = None
         fp = point
         for snap in snaps:
@@ -419,7 +455,7 @@ class Snapper:
             if self.radius:
                 dv = point.sub(winner[2])
                 if (dv.Length > self.radius):
-                    if (not oldActive) and self.isEnabled("passive"):
+                    if (not oldActive) and self.isEnabled("Near"):
                         winner = self.snapToVertex(self.snapInfo)
 
             # setting the cursors
@@ -447,8 +483,8 @@ class Snapper:
     def toWP(self,point):
         "projects the given point on the working plane, if needed"
         if self.isEnabled("WorkingPlane"):
-            if hasattr(FreeCAD,"DraftWorkingPlane"):
-                return FreeCAD.DraftWorkingPlane.projectPoint(point)
+            if hasattr(App,"DraftWorkingPlane"):
+                return App.DraftWorkingPlane.projectPoint(point)
         return point
 
     def getApparentPoint(self,x,y):
@@ -456,14 +492,14 @@ class Snapper:
         view = Draft.get3DView()
         pt = view.getPoint(x,y)
         if self.mask != "z":
-            if hasattr(FreeCAD,"DraftWorkingPlane"):
+            if hasattr(App,"DraftWorkingPlane"):
                 if view.getCameraType() == "Perspective":
                     camera = view.getCameraNode()
                     p = camera.getField("position").getValue()
-                    dv = pt.sub(Vector(p[0],p[1],p[2]))
+                    dv = pt.sub(App.Vector(p[0],p[1],p[2]))
                 else:
                     dv = view.getViewDirection()
-                return FreeCAD.DraftWorkingPlane.projectPoint(pt,dv)
+                return App.DraftWorkingPlane.projectPoint(pt,dv)
         return pt
 
     def snapToDim(self,obj):
@@ -489,7 +525,7 @@ class Snapper:
                 self.extLine.on()
             self.setCursor(tsnap[1])
             return tsnap[2],eline
-        if self.isEnabled("extension"):
+        if self.isEnabled("Extension"):
             tsnap = self.snapToExtOrtho(last,constrain,eline)
             if tsnap:
                 if (tsnap[0].sub(point)).Length < self.radius:
@@ -517,8 +553,8 @@ class Snapper:
                         return tsnap[2],eline
 
         for o in [self.lastObj[1],self.lastObj[0]]:
-            if o and (self.isEnabled('extension') or self.isEnabled('parallel')):
-                ob = FreeCAD.ActiveDocument.getObject(o)
+            if o and (self.isEnabled('Extension') or self.isEnabled('Parallel')):
+                ob = App.ActiveDocument.getObject(o)
                 if ob:
                     if ob.isDerivedFrom("Part::Feature"):
                         edges = ob.Shape.Edges
@@ -534,7 +570,7 @@ class Snapper:
                                     np = self.getPerpendicular(e,point)
                                     if not DraftGeomUtils.isPtOnEdge(np,e):
                                         if (np.sub(point)).Length < self.radius:
-                                            if self.isEnabled('extension'):
+                                            if self.isEnabled('Extension'):
                                                 if np != e.Vertexes[0].Point:
                                                     p0 = e.Vertexes[0].Point
                                                     if self.tracker and not self.selectMode:
@@ -565,7 +601,7 @@ class Snapper:
                                                                 self.lastExtensions[0] = ne
                                                     return np,ne
                                         else:
-                                            if self.isEnabled('parallel'):
+                                            if self.isEnabled('Parallel'):
                                                 if last:
                                                     ve = DraftGeomUtils.vec(e)
                                                     if not DraftVecUtils.isNull(ve):
@@ -582,7 +618,7 @@ class Snapper:
 
     def snapToCrossExtensions(self,point):
         "snaps to the intersection of the last 2 extension lines"
-        if self.isEnabled('extension'):
+        if self.isEnabled('Extension'):
             if len(self.lastExtensions) == 2:
                 np = DraftGeomUtils.findIntersection(self.lastExtensions[0],self.lastExtensions[1],True,True)
                 if np:
@@ -612,17 +648,17 @@ class Snapper:
 
     def snapToPolar(self,point,last):
         "snaps to polar lines from the given point"
-        if self.isEnabled('ortho') and (not self.mask):
+        if self.isEnabled('Ortho') and (not self.mask):
             if last:
                 vecs = []
-                if hasattr(FreeCAD,"DraftWorkingPlane"):
-                    ax = [FreeCAD.DraftWorkingPlane.u,
-                           FreeCAD.DraftWorkingPlane.v,
-                           FreeCAD.DraftWorkingPlane.axis]
+                if hasattr(App,"DraftWorkingPlane"):
+                    ax = [App.DraftWorkingPlane.u,
+                           App.DraftWorkingPlane.v,
+                           App.DraftWorkingPlane.axis]
                 else:
-                    ax = [FreeCAD.Vector(1,0,0),
-                          FreeCAD.Vector(0,1,0),
-                          FreeCAD.Vector(0,0,1)]
+                    ax = [App.Vector(1,0,0),
+                          App.Vector(0,1,0),
+                          App.Vector(0,0,1)]
                 for a in self.polarAngles:
                         if a == 90:
                             vecs.extend([ax[0],ax[0].negative()])
@@ -653,7 +689,7 @@ class Snapper:
         "returns a grid snap point if available"
         if self.grid:
             if self.grid.Visible:
-                if self.isEnabled("grid"):
+                if self.isEnabled("Grid"):
                     np = self.grid.getClosestNode(point)
                     if np:
                         dv = point.sub(np)
@@ -669,7 +705,7 @@ class Snapper:
     def snapToEndpoints(self,shape):
         "returns a list of endpoints snap locations"
         snaps = []
-        if self.isEnabled("endpoint"):
+        if self.isEnabled("Endpoint"):
             if hasattr(shape,"Vertexes"):
                 for v in shape.Vertexes:
                     snaps.append([v.Point,'endpoint',self.toWP(v.Point)])
@@ -687,7 +723,7 @@ class Snapper:
     def snapToMidpoint(self,shape):
         "returns a list of midpoints snap locations"
         snaps = []
-        if self.isEnabled("midpoint"):
+        if self.isEnabled("Midpoint"):
             if isinstance(shape,Part.Edge):
                 mp = DraftGeomUtils.findMidpoint(shape)
                 if mp:
@@ -697,7 +733,7 @@ class Snapper:
     def snapToPerpendicular(self,shape,last):
         "returns a list of perpendicular snap locations"
         snaps = []
-        if self.isEnabled("perpendicular"):
+        if self.isEnabled("Perpendicular"):
             if last:
                 if isinstance(shape,Part.Edge):
                     if DraftGeomUtils.geomType(shape) == "Line":
@@ -720,7 +756,7 @@ class Snapper:
     def snapToOrtho(self,shape,last,constrain):
         "returns a list of ortho snap locations"
         snaps = []
-        if self.isEnabled("ortho"):
+        if self.isEnabled("Ortho"):
             if constrain:
                 if isinstance(shape,Part.Edge):
                     if last:
@@ -736,7 +772,7 @@ class Snapper:
 
     def snapToExtOrtho(self,last,constrain,eline):
         "returns an ortho X extension snap location"
-        if self.isEnabled("extension") and self.isEnabled("ortho"):
+        if self.isEnabled("Extension") and self.isEnabled("Ortho"):
             if constrain and last and self.constraintAxis and self.extLine:
                 tmpEdge1 = Part.LineSegment(last,last.add(self.constraintAxis)).toShape()
                 tmpEdge2 = Part.LineSegment(self.extLine.p1(),self.extLine.p2()).toShape()
@@ -759,15 +795,15 @@ class Snapper:
         "returns a snap location that is orthogonal to hold points or, if possible, at crossings"
         if not self.holdPoints:
             return None
-        if hasattr(FreeCAD,"DraftWorkingPlane"):
-            u = FreeCAD.DraftWorkingPlane.u
-            v = FreeCAD.DraftWorkingPlane.v
+        if hasattr(App,"DraftWorkingPlane"):
+            u = App.DraftWorkingPlane.u
+            v = App.DraftWorkingPlane.v
         else:
-            u = FreeCAD.Vector(1,0,0)
-            v = FreeCAD.Vector(0,1,0)
+            u = App.Vector(1,0,0)
+            v = App.Vector(0,1,0)
         if len(self.holdPoints) > 1:
             # first try mid points
-            if self.isEnabled("midpoint"):
+            if self.isEnabled("Midpoint"):
                 l = list(self.holdPoints)
                 for p1,p2 in itertools.combinations(l,2):
                     p3 = p1.add((p2.sub(p1)).multiply(0.5))
@@ -804,7 +840,7 @@ class Snapper:
 
     def snapToExtPerpendicular(self,last):
         "returns a perpendicular X extension snap location"
-        if self.isEnabled("extension") and self.isEnabled("perpendicular"):
+        if self.isEnabled("Extension") and self.isEnabled("Perpendicular"):
             if last and self.extLine:
                 if self.extLine.p1() != self.extLine.p2():
                     tmpEdge = Part.LineSegment(self.extLine.p1(),self.extLine.p2()).toShape()
@@ -815,7 +851,7 @@ class Snapper:
     def snapToElines(self,e1,e2):
         "returns a snap location at the infinite intersection of the given edges"
         snaps = []
-        if self.isEnabled("intersection") and self.isEnabled("extension"):
+        if self.isEnabled("Intersection") and self.isEnabled("Extension"):
             if e1 and e2:
                 # get the intersection points
                 pts = DraftGeomUtils.findIntersection(e1,e2,True,True)
@@ -827,26 +863,26 @@ class Snapper:
     def snapToAngles(self,shape):
         "returns a list of angle snap locations"
         snaps = []
-        if self.isEnabled("angle"):
+        if self.isEnabled("Angle"):
             rad = shape.Curve.Radius
             pos = shape.Curve.Center
             for i in [0,30,45,60,90,120,135,150,180,210,225,240,270,300,315,330]:
                 ang = math.radians(i)
-                cur = Vector(math.sin(ang)*rad+pos.x,math.cos(ang)*rad+pos.y,pos.z)
+                cur = App.Vector(math.sin(ang)*rad+pos.x,math.cos(ang)*rad+pos.y,pos.z)
                 snaps.append([cur,'angle',self.toWP(cur)])
         return snaps
 
     def snapToCenter(self,shape):
         "returns a list of center snap locations"
         snaps = []
-        if self.isEnabled("center"):
+        if self.isEnabled("Center"):
             pos = shape.Curve.Center
             c = self.toWP(pos)
             if hasattr(shape.Curve,"Radius"):
                 rad = shape.Curve.Radius
                 for i in [15,37.5,52.5,75,105,127.5,142.5,165,195,217.5,232.5,255,285,307.5,322.5,345]:
                     ang = math.radians(i)
-                    cur = Vector(math.sin(ang)*rad+pos.x,math.cos(ang)*rad+pos.y,pos.z)
+                    cur = App.Vector(math.sin(ang)*rad+pos.x,math.cos(ang)*rad+pos.y,pos.z)
                     snaps.append([cur,'center',c])
             else:
                 snaps.append([c,'center',c])
@@ -855,7 +891,7 @@ class Snapper:
     def snapToFace(self,shape):
         "returns a face center snap location"
         snaps = []
-        if self.isEnabled("center"):
+        if self.isEnabled("Center"):
             pos = shape.CenterOfMass
             c = self.toWP(pos)
             snaps.append([pos,'center',c])
@@ -864,10 +900,10 @@ class Snapper:
     def snapToIntersection(self,shape):
         "returns a list of intersection snap locations"
         snaps = []
-        if self.isEnabled("intersection"):
+        if self.isEnabled("Intersection"):
             # get the stored objects to calculate intersections
             if self.lastObj[0]:
-                obj = FreeCAD.ActiveDocument.getObject(self.lastObj[0])
+                obj = App.ActiveDocument.getObject(self.lastObj[0])
                 if obj:
                     if obj.isDerivedFrom("Part::Feature") or (Draft.getType(obj) == "Axis"):
                         if (not self.maxEdges) or (len(obj.Shape.Edges) <= self.maxEdges):
@@ -895,7 +931,7 @@ class Snapper:
     def snapToPolygon(self,obj):
         "returns a list of polygon center snap locations"
         snaps = []
-        if self.isEnabled("center"):
+        if self.isEnabled("Center"):
             c = obj.Placement.Base
             for edge in obj.Shape.Edges:
                 p1 = edge.Vertexes[0].Point
@@ -907,13 +943,13 @@ class Snapper:
         return snaps
 
     def snapToVertex(self,info,active=False):
-        p = Vector(info['x'],info['y'],info['z'])
+        p = App.Vector(info['x'],info['y'],info['z'])
         if active:
-            if self.isEnabled("passive"):
+            if self.isEnabled("Near"):
                 return [p,'endpoint',self.toWP(p)]
             else:
                 return []
-        elif self.isEnabled("passive"):
+        elif self.isEnabled("Near"):
             return [p,'passive',p]
         else:
             return []
@@ -921,7 +957,7 @@ class Snapper:
     def snapToSpecials(self,obj,lastpoint=None,eline=None):
         "returns special snap locations, if any"
         snaps = []
-        if self.isEnabled("special"):
+        if self.isEnabled("Special"):
 
             if (Draft.getType(obj) == "Wall"):
                 # special snapping for wall: snap to its base shape if it is linear
@@ -987,13 +1023,13 @@ class Snapper:
     def setCursor(self,mode=None):
         "setCursor(self,mode=None): sets or resets the cursor to the given mode or resets"
         if self.selectMode:
-            mw = FreeCADGui.getMainWindow()
+            mw = Gui.getMainWindow()
             for w in mw.findChild(QtGui.QMdiArea).findChildren(QtGui.QWidget):
                 if w.metaObject().className() == "SIM::Coin3D::Quarter::QuarterWidget":
                     w.unsetCursor()
             self.cursorMode = None
         elif not mode:
-            mw = FreeCADGui.getMainWindow()
+            mw = Gui.getMainWindow()
             for w in mw.findChild(QtGui.QMdiArea).findChildren(QtGui.QWidget):
                 if w.metaObject().className() == "SIM::Coin3D::Quarter::QuarterWidget":
                     w.unsetCursor()
@@ -1011,7 +1047,7 @@ class Snapper:
                     qp.drawPixmap(QtCore.QPoint(16, 8), tp);
                 qp.end()
                 cur = QtGui.QCursor(newicon,8,8)
-                mw = FreeCADGui.getMainWindow()
+                mw = Gui.getMainWindow()
                 for w in mw.findChild(QtGui.QMdiArea).findChildren(QtGui.QWidget):
                     if w.metaObject().className() == "SIM::Coin3D::Quarter::QuarterWidget":
                         w.setCursor(cur)
@@ -1067,7 +1103,7 @@ class Snapper:
         "keeps the current angle"
         if delta:
             self.mask = delta
-        elif isinstance(self.mask,FreeCAD.Vector):
+        elif isinstance(self.mask,App.Vector):
             self.mask = None
         elif self.trackLine:
             if self.trackLine.Visible:
@@ -1082,15 +1118,15 @@ class Snapper:
         used as basepoint.'''
 
         # without the Draft module fully loaded, no axes system!"
-        if not hasattr(FreeCAD,"DraftWorkingPlane"):
+        if not hasattr(App,"DraftWorkingPlane"):
             return point
 
-        point = Vector(point)
+        point = App.Vector(point)
 
         # setup trackers if needed
         if not self.constrainLine:
             if self.snapStyle:
-                self.constrainLine = DraftTrackers.lineTracker(scolor=FreeCADGui.draftToolBar.getDefaultColor("snap"))
+                self.constrainLine = DraftTrackers.lineTracker(scolor=Gui.draftToolBar.getDefaultColor("snap"))
             else:
                 self.constrainLine = DraftTrackers.lineTracker(dotted=True)
 
@@ -1106,23 +1142,23 @@ class Snapper:
         if self.mask:
             self.affinity = self.mask
         if not self.affinity:
-            self.affinity = FreeCAD.DraftWorkingPlane.getClosestAxis(delta)
-        if isinstance(axis,FreeCAD.Vector):
+            self.affinity = App.DraftWorkingPlane.getClosestAxis(delta)
+        if isinstance(axis,App.Vector):
             self.constraintAxis = axis
         elif axis == "x":
-            self.constraintAxis = FreeCAD.DraftWorkingPlane.u
+            self.constraintAxis = App.DraftWorkingPlane.u
         elif axis == "y":
-            self.constraintAxis = FreeCAD.DraftWorkingPlane.v
+            self.constraintAxis = App.DraftWorkingPlane.v
         elif axis == "z":
-            self.constraintAxis = FreeCAD.DraftWorkingPlane.axis
+            self.constraintAxis = App.DraftWorkingPlane.axis
         else:
             if self.affinity == "x":
-                self.constraintAxis = FreeCAD.DraftWorkingPlane.u
+                self.constraintAxis = App.DraftWorkingPlane.u
             elif self.affinity == "y":
-                self.constraintAxis = FreeCAD.DraftWorkingPlane.v
+                self.constraintAxis = App.DraftWorkingPlane.v
             elif self.affinity == "z":
-                self.constraintAxis = FreeCAD.DraftWorkingPlane.axis
-            elif isinstance(self.affinity,FreeCAD.Vector):
+                self.constraintAxis = App.DraftWorkingPlane.axis
+            elif isinstance(self.affinity,App.Vector):
                 self.constraintAxis = self.affinity
             else:
                 self.constraintAxis = None
@@ -1169,7 +1205,7 @@ class Snapper:
             if point:
                 print "got a 3D point: ",point
 
-        FreeCADGui.Snapper.getPoint(callback=cb)
+        Gui.Snapper.getPoint(callback=cb)
 
         If the callback function accepts more than one argument, it will also receive
         the last snapped object. Finally, a qt widget can be passed as an extra taskbox.
@@ -1185,7 +1221,7 @@ class Snapper:
         self.pt = None
         self.lastSnappedObject = None
         self.holdPoints = []
-        self.ui = FreeCADGui.draftToolBar
+        self.ui = Gui.draftToolBar
         self.view = Draft.get3DView()
 
         # remove any previous leftover callbacks
@@ -1201,16 +1237,16 @@ class Snapper:
             mousepos = event.getPosition()
             ctrl = event.wasCtrlDown()
             shift = event.wasShiftDown()
-            self.pt = FreeCADGui.Snapper.snap(mousepos,lastpoint=last,active=ctrl,constrain=shift)
-            if hasattr(FreeCAD,"DraftWorkingPlane"):
-                self.ui.displayPoint(self.pt,last,plane=FreeCAD.DraftWorkingPlane,mask=FreeCADGui.Snapper.affinity)
+            self.pt = Gui.Snapper.snap(mousepos,lastpoint=last,active=ctrl,constrain=shift)
+            if hasattr(App,"DraftWorkingPlane"):
+                self.ui.displayPoint(self.pt,last,plane=App.DraftWorkingPlane,mask=Gui.Snapper.affinity)
             if movecallback:
                 movecallback(self.pt,self.snapInfo)
 
         def getcoords(point,relative=False):
             self.pt = point
-            if relative and last and hasattr(FreeCAD,"DraftWorkingPlane"):
-                v = FreeCAD.DraftWorkingPlane.getGlobalCoords(point)
+            if relative and last and hasattr(App,"DraftWorkingPlane"):
+                v = App.DraftWorkingPlane.getGlobalCoords(point)
                 self.pt = last.add(v)
             accept()
 
@@ -1227,8 +1263,8 @@ class Snapper:
                 self.view.removeEventCallbackPivy(coin.SoLocation2Event.getClassTypeId(),self.callbackMove)
             self.callbackClick = None
             self.callbackMove = None
-            obj = FreeCADGui.Snapper.lastSnappedObject
-            FreeCADGui.Snapper.off()
+            obj = Gui.Snapper.lastSnappedObject
+            Gui.Snapper.off()
             self.ui.offUi()
             if callback:
                 if len(inspect.getargspec(callback).args) > 1:
@@ -1244,7 +1280,7 @@ class Snapper:
                 self.view.removeEventCallbackPivy(coin.SoLocation2Event.getClassTypeId(),self.callbackMove)
             self.callbackClick = None
             self.callbackMove = None
-            FreeCADGui.Snapper.off()
+            Gui.Snapper.off()
             self.ui.offUi()
             if callback:
                 if len(inspect.getargspec(callback).args) > 1:
@@ -1269,112 +1305,90 @@ class Snapper:
 
     def makeSnapToolBar(self):
         "builds the Snap toolbar"
-        mw = FreeCADGui.getMainWindow()
+        mw = Gui.getMainWindow()
         self.toolbar = QtGui.QToolBar(mw)
         mw.addToolBar(QtCore.Qt.TopToolBarArea, self.toolbar)
         self.toolbar.setObjectName("Draft Snap")
         self.toolbar.setWindowTitle(QtCore.QCoreApplication.translate("Workbench", "Draft Snap"))
-        self.toolbarButtons = []
-        # grid button
-        self.gridbutton = QtGui.QAction(mw)
-        self.gridbutton.setIcon(QtGui.QIcon.fromTheme("Draft_Grid", QtGui.QIcon(":/icons/Draft_Grid.svg")))
-        self.gridbutton.setText(QtCore.QCoreApplication.translate("Draft_ToggleGrid","Grid"))
-        self.gridbutton.setToolTip(QtCore.QCoreApplication.translate("Draft_ToggleGrid","Toggles the Draft grid On/Off"))
-        self.gridbutton.setObjectName("GridButton")
-        self.gridbutton.setWhatsThis("Draft_ToggleGrid")
-        QtCore.QObject.connect(self.gridbutton,QtCore.SIGNAL("triggered()"),self.toggleGrid)
-        self.toolbar.addAction(self.gridbutton)
-        # master button
-        self.masterbutton = QtGui.QAction(mw)
-        self.masterbutton.setIcon(QtGui.QIcon.fromTheme("Snap_Lock", QtGui.QIcon(":/icons/Snap_Lock.svg")))
-        self.masterbutton.setText(QtCore.QCoreApplication.translate("Draft_Snap_Lock","Lock"))
-        self.masterbutton.setToolTip(QtCore.QCoreApplication.translate("Draft_Snap_Lock","Toggle On/Off"))
-        self.masterbutton.setObjectName("SnapButtonMain")
-        self.masterbutton.setWhatsThis("Draft_ToggleSnap")
-        self.masterbutton.setCheckable(True)
-        self.masterbutton.setChecked(True)
-        QtCore.QObject.connect(self.masterbutton,QtCore.SIGNAL("toggled(bool)"),self.toggle)
-        self.toolbar.addAction(self.masterbutton)
-        for c,i in self.cursors.items():
-            if i:
-                b = QtGui.QAction(mw)
-                b.setIcon(QtGui.QIcon.fromTheme(i.replace(':/icons/', '').replace('.svg', ''), QtGui.QIcon(i)))
-                if c == "passive":
-                    b.setText(QtCore.QCoreApplication.translate("Draft_Snap_Near","Nearest"))
-                    b.setToolTip(QtCore.QCoreApplication.translate("Draft_Snap_Near","Nearest"))
-                else:
-                    b.setText(QtCore.QCoreApplication.translate("Draft_Snap_"+c.capitalize(),c.capitalize()))
-                    b.setToolTip(QtCore.QCoreApplication.translate("Draft_Snap_"+c.capitalize(),c.capitalize()))
-                b.setObjectName("SnapButton"+c)
-                b.setWhatsThis("Draft_"+c.capitalize())
-                b.setCheckable(True)
-                b.setChecked(True)
-                self.toolbar.addAction(b)
-                self.toolbarButtons.append(b)
-                QtCore.QObject.connect(b,QtCore.SIGNAL("toggled(bool)"),self.saveSnapModes)
-        # adding non-snap button
-        for n in ["Dimensions","WorkingPlane"]:
-            b = QtGui.QAction(mw)
-            b.setIcon(QtGui.QIcon.fromTheme("Snap_" + n, QtGui.QIcon(":/icons/Snap_"+n+".svg")))
-            b.setText(QtCore.QCoreApplication.translate("Draft_Snap_"+n,n))
-            b.setToolTip(QtCore.QCoreApplication.translate("Draft_Snap_"+n,n))
-            b.setObjectName("SnapButton"+n)
-            b.setWhatsThis("Draft_"+n)
-            b.setCheckable(True)
-            b.setChecked(True)
-            self.toolbar.addAction(b)
-            QtCore.QObject.connect(b,QtCore.SIGNAL("toggled(bool)"),self.saveSnapModes)
-            self.toolbarButtons.append(b)
-        # set status tip where needed
-        for b in self.toolbar.actions():
-            if len(b.statusTip()) == 0:
-                b.setStatusTip(b.toolTip())
-        # restoring states
-        t = Draft.getParam("snapModes","111111111101111")
-        if t:
-            c = 0
-            for b in [self.masterbutton]+self.toolbarButtons:
-                if len(t) > c:
-                    state = bool(int(t[c]))
-                    b.setChecked(state)
-                    if state:
-                        b.setToolTip(b.toolTip()+" (ON)")
-                    else:
-                        b.setToolTip(b.toolTip()+" (OFF)")
-                    c += 1
+
+        snap_gui_commands = get_draft_snap_commands()
+        self.init_draft_snap_buttons(snap_gui_commands, self.toolbar, "_Button")
+        self.restore_snap_buttons_state(self.toolbar,"_Button")
+
         if not Draft.getParam("showSnapBar",True):
             self.toolbar.hide()
 
+    def init_draft_snap_buttons(self, commands, context, button_suffix):
+        """
+        Init Draft Snap toolbar buttons.
+
+        Parameters:
+        commands        Snap command list,
+                        use: get_draft_snap_commands():
+        context         The toolbar or action group the buttons have 
+                        to be added to    
+        button_suffix   The suffix that have to be applied to the command name
+                        to define the button name
+        """
+        for gc in commands:
+            # setup toolbar buttons
+            command = 'Gui.runCommand("' + gc + '")'
+            b = QtGui.QAction(context)
+            b.setIcon(QtGui.QIcon(':/icons/' + gc[6:] + '.svg'))
+            b.setText(QtCore.QCoreApplication.translate("Draft_Snap", "Snap " + gc[11:]))
+            b.setToolTip(QtCore.QCoreApplication.translate("Draft_Snap", "Snap " + gc[11:]))
+            b.setObjectName(gc + button_suffix)
+            b.setWhatsThis("Draft_"+gc[11:].capitalize())
+            b.setCheckable(True)
+            b.setChecked(True)
+            context.addAction(b)
+            QtCore.QObject.connect(b,
+                                   QtCore.SIGNAL("triggered()"),
+                                   lambda f=Gui.doCommand, 
+                                   arg=command:f(arg))
+
+        for b in context.actions():
+            if len(b.statusTip()) == 0:
+                b.setStatusTip(b.toolTip())
+
+    def restore_snap_buttons_state(self, toolbar, button_suffix):
+        """
+        Restore toolbar button's checked state according to 
+        "snapModes" saved in preferences
+        """
+        # set status tip where needed
+        param = App.ParamGet("User parameter:BaseApp/Preferences/Mod/Draft")
+        snap_modes = param.GetString("snapModes")
+
+        for b in toolbar.actions():
+            if len(b.statusTip()) == 0:
+                b.setStatusTip(b.toolTip())
+
+        # restore toolbar buttons state
+        if snap_modes:
+            for a in toolbar.findChildren(QtGui.QAction):
+                snap = a.objectName()[11:].replace(button_suffix,"")
+                if snap in Gui.Snapper.snaps:
+                    i = Gui.Snapper.snaps.index(snap)
+                    state = bool(int(snap_modes[i]))
+                    a.setChecked(state)
+                    if state:
+                        a.setToolTip(a.toolTip()+" (ON)")
+                    else:
+                        a.setToolTip(a.toolTip()+" (OFF)")
+
+    def get_snap_toolbar(self):
+        """retuns snap toolbar object"""
+        mw = Gui.getMainWindow()
+        if mw:
+            toolbar = mw.findChild(QtGui.QToolBar,"Draft Snap")
+            if toolbar:
+                return toolbar
+        return None
+
     def toggleGrid(self):
-        FreeCADGui.runCommand("Draft_ToggleGrid")
-
-    def saveSnapModes(self):
-        "saves the snap modes for next sessions"
-        t = ''
-        for b in [self.masterbutton]+self.toolbarButtons:
-            t += str(int(b.isChecked()))
-            if b.isChecked():
-                b.setToolTip(b.toolTip().replace("OFF","ON"))
-            else:
-                b.setToolTip(b.toolTip().replace("ON","OFF"))
-        Draft.setParam("snapModes",t)
-
-    def toggle(self,checked=None):
-        "toggles the snap mode"
-        if hasattr(self,"toolbarButtons"):
-            if checked is None:
-                self.masterbutton.toggle()
-            elif checked:
-                if hasattr(self,"savedButtonStates"):
-                    for i in range(len(self.toolbarButtons)):
-                        self.toolbarButtons[i].setEnabled(True)
-                        self.toolbarButtons[i].setChecked(self.savedButtonStates[i])
-            else:
-                self.savedButtonStates = []
-                for i in range(len(self.toolbarButtons)):
-                    self.savedButtonStates.append(self.toolbarButtons[i].isChecked())
-                    self.toolbarButtons[i].setEnabled(False)
-        self.saveSnapModes()
+        "toggle FreeCAD Draft Grid"
+        Gui.runCommand("Draft_ToggleGrid")
 
     def showradius(self):
         "shows the snap radius indicator"
@@ -1383,32 +1397,65 @@ class Snapper:
             self.radiusTracker.update(self.radius)
             self.radiusTracker.on()
 
-    def isEnabled(self,but):
-        "returns true if the given button is turned on"
-        for b in self.toolbarButtons:
-            if str(b.objectName()) == "SnapButton" + but:
-                return (b.isEnabled() and b.isChecked())
-        return False
+    def isEnabled(self, snap):
+        "Returns true if the given snap on"
+        if "Lock" in self.active_snaps and snap in self.active_snaps:
+            return True
+        else:
+            return False
+
+    def toggle_snap(self, snap, set_to = None):
+        "Sets the given snap on/off according to the given parameter"
+        if set_to: # set mode
+            if set_to is True:
+                if not snap in self.active_snaps:
+                    self.active_snaps.append(snap)
+                status = True
+            elif set_to is False:
+                if snap in self.active_snaps:
+                    self.active_snaps.remove(snap)
+                status = False
+        else: # toggle mode, default
+            if not snap in self.active_snaps:
+                self.active_snaps.append(snap)
+                status = True
+            elif snap in self.active_snaps:
+                self.active_snaps.remove(snap)
+                status = False
+        self.save_snap_state()
+        return status
+
+    def save_snap_state(self):
+        """
+        save snap state to user preferences to be restored in next session
+        """
+        param = App.ParamGet("User parameter:BaseApp/Preferences/Mod/Draft")
+        snap_modes = ""
+        for snap in self.snaps:
+            if snap in self.active_snaps:
+                snap_modes += "1"
+            else:
+                snap_modes += "0"
+        param.SetString("snapModes",snap_modes)
 
     def show(self):
         "shows the toolbar and the grid"
         if not hasattr(self,"toolbar"):
             self.makeSnapToolBar()
-        mw = FreeCADGui.getMainWindow()
-        bt = mw.findChild(QtGui.QToolBar,"Draft Snap")
+        bt = self.get_snap_toolbar()
         if not bt:
             mw.addToolBar(self.toolbar)
             self.toolbar.setParent(mw)
         self.toolbar.show()
         self.toolbar.toggleViewAction().setVisible(True)
-        if FreeCADGui.ActiveDocument:
+        if Gui.ActiveDocument:
             self.setTrackers()
-            if not FreeCAD.ActiveDocument.Objects:
-                if FreeCADGui.ActiveDocument.ActiveView:
-                    if FreeCADGui.ActiveDocument.ActiveView.getCameraType() == 'Orthographic':
-                        c = FreeCADGui.ActiveDocument.ActiveView.getCameraNode()
+            if not App.ActiveDocument.Objects:
+                if Gui.ActiveDocument.ActiveView:
+                    if Gui.ActiveDocument.ActiveView.getCameraType() == 'Orthographic':
+                        c = Gui.ActiveDocument.ActiveView.getCameraNode()
                         if c.orientation.getValue().getValue() == (0.0, 0.0, 0.0, 1.0):
-                            p = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/Draft")
+                            p = App.ParamGet("User parameter:BaseApp/Preferences/Mod/Draft")
                             h = p.GetInt("defaultCameraHeight",0)
                             if h:
                                 c.height.setValue(h)
@@ -1448,7 +1495,7 @@ class Snapper:
                 self.tracker = DraftTrackers.snapTracker()
                 self.trackLine = DraftTrackers.lineTracker()
                 if self.snapStyle:
-                    c = FreeCADGui.draftToolBar.getDefaultColor("snap")
+                    c = Gui.draftToolBar.getDefaultColor("snap")
                     self.extLine = DraftTrackers.lineTracker(scolor=c)
                     self.extLine2 = DraftTrackers.lineTracker(scolor = c)
                 else:

--- a/src/Mod/Draft/draftguitools/gui_snaps.py
+++ b/src/Mod/Draft/draftguitools/gui_snaps.py
@@ -28,9 +28,35 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-import FreeCADGui
+import FreeCADGui as Gui
+from PySide import QtGui
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
+# UTILITIES -----------------------------------------------------------------
+
+def sync_snap_toolbar_button(button, status):
+    """set snap toolbar button to given state"""
+    snap_toolbar = Gui.Snapper.get_snap_toolbar()
+    #print(snap_toolbar)
+    if not snap_toolbar:
+        return
+    for a in snap_toolbar.actions():
+        if a.objectName() == button:
+            if button == "Draft_Snap_Lock_Button":
+                # for lock button
+                snap_toolbar.actions()[0].setChecked(status)
+                for a in snap_toolbar.actions()[1:]:
+                    a.setEnabled(status)
+            else:
+                # for every other button
+                a.setChecked(status)
+                if a.isChecked():
+                    a.setToolTip(a.toolTip().replace("OFF","ON"))
+                else:
+                    a.setToolTip(a.toolTip().replace("ON","OFF"))
+
+
+# SNAP GUI TOOLS ------------------------------------------------------------
 
 class Draft_Snap_Lock:
     """Command to activate or deactivate all snap commands."""
@@ -47,12 +73,14 @@ class Draft_Snap_Lock:
 
     def Activated(self):
         """Execute this when the command is called."""
-        if hasattr(FreeCADGui, "Snapper"):
-            if hasattr(FreeCADGui.Snapper, "masterbutton"):
-                FreeCADGui.Snapper.masterbutton.toggle()
+        if hasattr(Gui, "Snapper"):
+            # toggle the corresponding snap_index in Preferences/Mod/Draft/snapModes
+            status = Gui.Snapper.toggle_snap('Lock')
+            # change interface consistently
+            sync_snap_toolbar_button("Draft_Snap_Lock"+"_Button", status)
 
 
-FreeCADGui.addCommand('Draft_Snap_Lock', Draft_Snap_Lock())
+Gui.addCommand('Draft_Snap_Lock', Draft_Snap_Lock())
 
 
 class Draft_Snap_Midpoint:
@@ -68,14 +96,14 @@ class Draft_Snap_Midpoint:
 
     def Activated(self):
         """Execute this when the command is called."""
-        if hasattr(FreeCADGui, "Snapper"):
-            if hasattr(FreeCADGui.Snapper, "toolbarButtons"):
-                for b in FreeCADGui.Snapper.toolbarButtons:
-                    if b.objectName() == "SnapButtonmidpoint":
-                        b.toggle()
+        if hasattr(Gui, "Snapper"):
+            # toggle the corresponding snap_index in Preferences/Mod/Draft/snapModes
+            status = Gui.Snapper.toggle_snap('Midpoint')
+            # change interface consistently
+            sync_snap_toolbar_button("Draft_Snap_Midpoint"+"_Button", status)
 
 
-FreeCADGui.addCommand('Draft_Snap_Midpoint', Draft_Snap_Midpoint())
+Gui.addCommand('Draft_Snap_Midpoint', Draft_Snap_Midpoint())
 
 
 class Draft_Snap_Perpendicular:
@@ -93,14 +121,14 @@ class Draft_Snap_Perpendicular:
 
     def Activated(self):
         """Execute this when the command is called."""
-        if hasattr(FreeCADGui, "Snapper"):
-            if hasattr(FreeCADGui.Snapper, "toolbarButtons"):
-                for b in FreeCADGui.Snapper.toolbarButtons:
-                    if b.objectName() == "SnapButtonperpendicular":
-                        b.toggle()
+        if hasattr(Gui, "Snapper"):
+            # toggle the corresponding snap_index in Preferences/Mod/Draft/snapModes
+            status = Gui.Snapper.toggle_snap('Perpendicular')
+            # change interface consistently
+            sync_snap_toolbar_button("Draft_Snap_Perpendicular"+"_Button", status)
 
 
-FreeCADGui.addCommand('Draft_Snap_Perpendicular', Draft_Snap_Perpendicular())
+Gui.addCommand('Draft_Snap_Perpendicular', Draft_Snap_Perpendicular())
 
 
 class Draft_Snap_Grid:
@@ -115,14 +143,14 @@ class Draft_Snap_Grid:
 
     def Activated(self):
         """Execute this when the command is called."""
-        if hasattr(FreeCADGui, "Snapper"):
-            if hasattr(FreeCADGui.Snapper, "toolbarButtons"):
-                for b in FreeCADGui.Snapper.toolbarButtons:
-                    if b.objectName() == "SnapButtongrid":
-                        b.toggle()
+        if hasattr(Gui, "Snapper"):
+            # toggle the corresponding snap_index in Preferences/Mod/Draft/snapModes
+            status = Gui.Snapper.toggle_snap('Grid')
+            # change interface consistently
+            sync_snap_toolbar_button("Draft_Snap_Grid"+"_Button", status)
 
 
-FreeCADGui.addCommand('Draft_Snap_Grid', Draft_Snap_Grid())
+Gui.addCommand('Draft_Snap_Grid', Draft_Snap_Grid())
 
 
 class Draft_Snap_Intersection:
@@ -140,14 +168,14 @@ class Draft_Snap_Intersection:
 
     def Activated(self):
         """Execute this when the command is called."""
-        if hasattr(FreeCADGui, "Snapper"):
-            if hasattr(FreeCADGui.Snapper, "toolbarButtons"):
-                for b in FreeCADGui.Snapper.toolbarButtons:
-                    if b.objectName() == "SnapButtonintersection":
-                        b.toggle()
+        if hasattr(Gui, "Snapper"):
+            # toggle the corresponding snap_index in Preferences/Mod/Draft/snapModes
+            status = Gui.Snapper.toggle_snap('Intersection')
+            # change interface consistently
+            sync_snap_toolbar_button("Draft_Snap_Intersection"+"_Button", status)
 
 
-FreeCADGui.addCommand('Draft_Snap_Intersection', Draft_Snap_Intersection())
+Gui.addCommand('Draft_Snap_Intersection', Draft_Snap_Intersection())
 
 
 class Draft_Snap_Parallel:
@@ -163,14 +191,14 @@ class Draft_Snap_Parallel:
 
     def Activated(self):
         """Execute this when the command is called."""
-        if hasattr(FreeCADGui, "Snapper"):
-            if hasattr(FreeCADGui.Snapper, "toolbarButtons"):
-                for b in FreeCADGui.Snapper.toolbarButtons:
-                    if b.objectName() == "SnapButtonparallel":
-                        b.toggle()
+        if hasattr(Gui, "Snapper"):
+            # toggle the corresponding snap_index in Preferences/Mod/Draft/snapModes
+            status = Gui.Snapper.toggle_snap('Parallel')
+            # change interface consistently
+            sync_snap_toolbar_button("Draft_Snap_Parallel"+"_Button", status)
 
 
-FreeCADGui.addCommand('Draft_Snap_Parallel', Draft_Snap_Parallel())
+Gui.addCommand('Draft_Snap_Parallel', Draft_Snap_Parallel())
 
 
 class Draft_Snap_Endpoint:
@@ -186,14 +214,14 @@ class Draft_Snap_Endpoint:
 
     def Activated(self):
         """Execute this when the command is called."""
-        if hasattr(FreeCADGui, "Snapper"):
-            if hasattr(FreeCADGui.Snapper, "toolbarButtons"):
-                for b in FreeCADGui.Snapper.toolbarButtons:
-                    if b.objectName() == "SnapButtonendpoint":
-                        b.toggle()
+        if hasattr(Gui, "Snapper"):
+            # toggle the corresponding snap_index in Preferences/Mod/Draft/snapModes
+            status = Gui.Snapper.toggle_snap('Endpoint')
+            # change interface consistently
+            sync_snap_toolbar_button("Draft_Snap_Endpoint"+"_Button", status)
 
 
-FreeCADGui.addCommand('Draft_Snap_Endpoint', Draft_Snap_Endpoint())
+Gui.addCommand('Draft_Snap_Endpoint', Draft_Snap_Endpoint())
 
 
 class Draft_Snap_Angle:
@@ -208,14 +236,14 @@ class Draft_Snap_Angle:
 
     def Activated(self):
         """Execute this when the command is called."""
-        if hasattr(FreeCADGui, "Snapper"):
-            if hasattr(FreeCADGui.Snapper, "toolbarButtons"):
-                for b in FreeCADGui.Snapper.toolbarButtons:
-                    if b.objectName() == "SnapButtonangle":
-                        b.toggle()
+        if hasattr(Gui, "Snapper"):
+            # toggle the corresponding snap_index in Preferences/Mod/Draft/snapModes
+            status = Gui.Snapper.toggle_snap('Angle')
+            # change interface consistently
+            sync_snap_toolbar_button("Draft_Snap_Angle"+"_Button", status)
 
 
-FreeCADGui.addCommand('Draft_Snap_Angle', Draft_Snap_Angle())
+Gui.addCommand('Draft_Snap_Angle', Draft_Snap_Angle())
 
 
 class Draft_Snap_Center:
@@ -230,14 +258,14 @@ class Draft_Snap_Center:
 
     def Activated(self):
         """Execute this when the command is called."""
-        if hasattr(FreeCADGui, "Snapper"):
-            if hasattr(FreeCADGui.Snapper, "toolbarButtons"):
-                for b in FreeCADGui.Snapper.toolbarButtons:
-                    if b.objectName() == "SnapButtoncenter":
-                        b.toggle()
+        if hasattr(Gui, "Snapper"):
+            # toggle the corresponding snap_index in Preferences/Mod/Draft/snapModes
+            status = Gui.Snapper.toggle_snap('Center')
+            # change interface consistently
+            sync_snap_toolbar_button("Draft_Snap_Center"+"_Button", status)
 
 
-FreeCADGui.addCommand('Draft_Snap_Center', Draft_Snap_Center())
+Gui.addCommand('Draft_Snap_Center', Draft_Snap_Center())
 
 
 class Draft_Snap_Extension:
@@ -253,14 +281,14 @@ class Draft_Snap_Extension:
 
     def Activated(self):
         """Execute this when the command is called."""
-        if hasattr(FreeCADGui, "Snapper"):
-            if hasattr(FreeCADGui.Snapper, "toolbarButtons"):
-                for b in FreeCADGui.Snapper.toolbarButtons:
-                    if b.objectName() == "SnapButtonextension":
-                        b.toggle()
+        if hasattr(Gui, "Snapper"):
+            # toggle the corresponding snap_index in Preferences/Mod/Draft/snapModes
+            status = Gui.Snapper.toggle_snap('Extension')
+            # change interface consistently
+            sync_snap_toolbar_button("Draft_Snap_Extension"+"_Button", status)
 
 
-FreeCADGui.addCommand('Draft_Snap_Extension', Draft_Snap_Extension())
+Gui.addCommand('Draft_Snap_Extension', Draft_Snap_Extension())
 
 
 class Draft_Snap_Near:
@@ -275,14 +303,14 @@ class Draft_Snap_Near:
 
     def Activated(self):
         """Execute this when the command is called."""
-        if hasattr(FreeCADGui, "Snapper"):
-            if hasattr(FreeCADGui.Snapper, "toolbarButtons"):
-                for b in FreeCADGui.Snapper.toolbarButtons:
-                    if b.objectName() == "SnapButtonpassive":
-                        b.toggle()
+        if hasattr(Gui, "Snapper"):
+            # toggle the corresponding snap_index in Preferences/Mod/Draft/snapModes
+            status = Gui.Snapper.toggle_snap('Near')
+            # change interface consistently
+            sync_snap_toolbar_button("Draft_Snap_Near"+"_Button", status)
 
 
-FreeCADGui.addCommand('Draft_Snap_Near', Draft_Snap_Near())
+Gui.addCommand('Draft_Snap_Near', Draft_Snap_Near())
 
 
 class Draft_Snap_Ortho:
@@ -297,14 +325,14 @@ class Draft_Snap_Ortho:
 
     def Activated(self):
         """Execute this when the command is called."""
-        if hasattr(FreeCADGui, "Snapper"):
-            if hasattr(FreeCADGui.Snapper, "toolbarButtons"):
-                for b in FreeCADGui.Snapper.toolbarButtons:
-                    if b.objectName() == "SnapButtonortho":
-                        b.toggle()
+        if hasattr(Gui, "Snapper"):
+            # toggle the corresponding snap_index in Preferences/Mod/Draft/snapModes
+            status = Gui.Snapper.toggle_snap('Ortho')
+            # change interface consistently
+            sync_snap_toolbar_button("Draft_Snap_Ortho"+"_Button", status)
 
 
-FreeCADGui.addCommand('Draft_Snap_Ortho', Draft_Snap_Ortho())
+Gui.addCommand('Draft_Snap_Ortho', Draft_Snap_Ortho())
 
 
 class Draft_Snap_Special:
@@ -320,14 +348,14 @@ class Draft_Snap_Special:
 
     def Activated(self):
         """Execute this when the command is called."""
-        if hasattr(FreeCADGui, "Snapper"):
-            if hasattr(FreeCADGui.Snapper, "toolbarButtons"):
-                for b in FreeCADGui.Snapper.toolbarButtons:
-                    if b.objectName() == "SnapButtonspecial":
-                        b.toggle()
+        if hasattr(Gui, "Snapper"):
+            # toggle the corresponding snap_index in Preferences/Mod/Draft/snapModes
+            status = Gui.Snapper.toggle_snap('Special')
+            # change interface consistently
+            sync_snap_toolbar_button("Draft_Snap_Special"+"_Button", status)
 
 
-FreeCADGui.addCommand('Draft_Snap_Special', Draft_Snap_Special())
+Gui.addCommand('Draft_Snap_Special', Draft_Snap_Special())
 
 
 class Draft_Snap_Dimensions:
@@ -343,14 +371,14 @@ class Draft_Snap_Dimensions:
 
     def Activated(self):
         """Execute this when the command is called."""
-        if hasattr(FreeCADGui, "Snapper"):
-            if hasattr(FreeCADGui.Snapper, "toolbarButtons"):
-                for b in FreeCADGui.Snapper.toolbarButtons:
-                    if b.objectName() == "SnapButtonDimensions":
-                        b.toggle()
+        if hasattr(Gui, "Snapper"):
+            # toggle the corresponding snap_index in Preferences/Mod/Draft/snapModes
+            status = Gui.Snapper.toggle_snap('Dimensions')
+            # change interface consistently
+            sync_snap_toolbar_button("Draft_Snap_Dimensions"+"_Button", status)
 
 
-FreeCADGui.addCommand('Draft_Snap_Dimensions', Draft_Snap_Dimensions())
+Gui.addCommand('Draft_Snap_Dimensions', Draft_Snap_Dimensions())
 
 
 class Draft_Snap_WorkingPlane:
@@ -368,11 +396,11 @@ class Draft_Snap_WorkingPlane:
 
     def Activated(self):
         """Execute this when the command is called."""
-        if hasattr(FreeCADGui, "Snapper"):
-            if hasattr(FreeCADGui.Snapper, "toolbarButtons"):
-                for b in FreeCADGui.Snapper.toolbarButtons:
-                    if b.objectName() == "SnapButtonWorkingPlane":
-                        b.toggle()
+        if hasattr(Gui, "Snapper"):
+            # toggle the corresponding snap_index in Preferences/Mod/Draft/snapModes
+            status = Gui.Snapper.toggle_snap('WorkingPlane')
+            # change interface consistently
+            sync_snap_toolbar_button("Draft_Snap_WorkingPlane"+"_Button", status)
 
 
-FreeCADGui.addCommand('Draft_Snap_WorkingPlane', Draft_Snap_WorkingPlane())
+Gui.addCommand('Draft_Snap_WorkingPlane', Draft_Snap_WorkingPlane())

--- a/src/Mod/Draft/draftutils/init_tools.py
+++ b/src/Mod/Draft/draftutils/init_tools.py
@@ -96,15 +96,15 @@ def get_draft_utility_commands():
 
 def get_draft_snap_commands():
     """Return the snapping commands list."""
-    return ['Draft_Snap_Lock', 'Draft_Snap_Midpoint',
-            'Draft_Snap_Perpendicular',
-            'Draft_Snap_Grid', 'Draft_Snap_Intersection',
-            'Draft_Snap_Parallel',
-            'Draft_Snap_Endpoint', 'Draft_Snap_Angle',
-            'Draft_Snap_Center',
-            'Draft_Snap_Extension', 'Draft_Snap_Near',
-            'Draft_Snap_Ortho', 'Draft_Snap_Special',
-            'Draft_Snap_Dimensions', 'Draft_Snap_WorkingPlane']
+    return ['Draft_Snap_Lock',   
+            'Draft_Snap_Endpoint', 'Draft_Snap_Midpoint',    
+            'Draft_Snap_Center', 'Draft_Snap_Angle', 
+            'Draft_Snap_Intersection', 'Draft_Snap_Perpendicular',
+            'Draft_Snap_Extension', 'Draft_Snap_Parallel',  
+            'Draft_Snap_Special', 'Draft_Snap_Near',     
+            'Draft_Snap_Ortho', 'Draft_Snap_Grid',          
+            'Draft_Snap_WorkingPlane', 'Draft_Snap_Dimensions',
+            ]
 
 
 def init_draft_toolbars(workbench):


### PR DESCRIPTION
Changed snap toolbar behaviour:
- create a list of available snaps (Gui.Snapper.snaps)
- make it consistent with Snap Gui Commands (in gui_snaps module)
- create a list of active snaps (Gui.Snapper.active_snaps)
- refactor the isEnabled() method to allow it to check if the given snap is in Gui.Snapper.active_snaps and not if the snap toolbar button isChecked()
- updated and reordered the new list of gui snap commands in draftutils.init_tools and used it as a base to refactor the creation of draft toolbar
- updated all the draft snap gui tools to make them control the toolbar buttons directly
.


.


.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
