### PR TITLE
[skip ci] Fix typos 

### DIFF
--- a/src/Gui/Control.cpp
+++ b/src/Gui/Control.cpp
@@ -110,7 +110,7 @@ void ControlSingleton::showDialog(Gui::TaskView::TaskDialog *dlg)
         return;
     }
 
-    // Since the caller sets up a modeless task panel, it indicates intension
+    // Since the caller sets up a modeless task panel, it indicates intention
     // for prolonged editing. So disable auto transaction in the current call
     // stack.
     // Do this before showing the dialog because its open() function is called

--- a/src/Gui/DocumentRecovery.cpp
+++ b/src/Gui/DocumentRecovery.cpp
@@ -230,7 +230,7 @@ QString DocumentRecovery::createProjectFile(const QString& documentXml)
 void DocumentRecovery::closeEvent(QCloseEvent* e)
 {
     // Do not disable the X button in the title bar
-    // #0004281: Close Documant Recovery
+    // #0004281: Close Document Recovery
     e->accept();
 }
 

--- a/src/Mod/AddonManager/addonmanager_workers.py
+++ b/src/Mod/AddonManager/addonmanager_workers.py
@@ -231,7 +231,7 @@ class CheckWBWorker(QtCore.QThread):
 
 
 class FillMacroListWorker(QtCore.QThread):
-    """This worker opulates the list of macros"""
+    """This worker populates the list of macros"""
 
     add_macro_signal = QtCore.Signal(Macro)
     info_label_signal = QtCore.Signal(str)

--- a/src/Mod/Draft/coding_conventions.md
+++ b/src/Mod/Draft/coding_conventions.md
@@ -30,7 +30,7 @@
 
 ## Python
 
-### Code formating
+### Code formatting
 
 - In general, code should follow [PEP 8](https://www.python.org/dev/peps/pep-0008/)
   and [PEP 257](https://www.python.org/dev/peps/pep-0257/) (docstrings).
@@ -72,7 +72,7 @@
   and not meant to be part of the public interface should start
   with an underscore like `_MyInternalClass` or `_my_small_variable`.
 
-### Python code formating tools
+### Python code formatting tools
 
 - Using a code editor that automatically checks compliance with PEP 8
   is recommended.

--- a/src/Mod/Import/InitGui.py
+++ b/src/Mod/Import/InitGui.py
@@ -1,3 +1,4 @@
+# -*- coding: utf8 -*-
 # Import gui init module
 # (c) 2003 Jürgen Riegel
 #

--- a/src/Mod/Material/Material.py
+++ b/src/Mod/Material/Material.py
@@ -24,18 +24,18 @@ import sys
 import FreeCAD
 
 
-# here the usage description if you use this tool from the command line ("__main__")
+# The usage description if you use this tool from the command line ("__main__")
 CommandlineUsage = """Material - Tool to work with FreeCAD Material definition cards
 
 Usage:
    Material [Options] card-file-name
 
 Options:
- -c, --output-csv=file-name     write a comma separated grid with the material data
+ -c, --output-csv=filename     write a comma separated grid with the material data
 
 Exit:
  0      No Error or Warning found
- 1      Argument error, wrong or less Arguments given
+ 1      Argument error, wrong or too few Arguments given
 
 Tool to work with FreeCAD Material definition cards
 

--- a/src/Mod/Path/PathScripts/PathSurface.py
+++ b/src/Mod/Path/PathScripts/PathSurface.py
@@ -111,7 +111,7 @@ class ObjectSurface(PathOp.ObjectOp):
         obj.addProperty("App::PropertyPercent", "StepOver", "Surface", QtCore.QT_TRANSLATE_NOOP("App::Property", "Step over percentage of the drop cutter path"))
 
         obj.addProperty("App::PropertyVectorDistance", "CircularCenterCustom", "Surface Cut Options", QtCore.QT_TRANSLATE_NOOP("PathOp", "The start point of this path"))
-        obj.addProperty("App::PropertyEnumeration", "CircularCenterAt", "Surface Cut Options", QtCore.QT_TRANSLATE_NOOP("PathOp", "Choose what point to start the ciruclar pattern: Center Of Mass, Center Of Boundbox, Xmin Ymin of boundbox, Custom."))
+        obj.addProperty("App::PropertyEnumeration", "CircularCenterAt", "Surface Cut Options", QtCore.QT_TRANSLATE_NOOP("PathOp", "Choose what point to start the circular pattern: Center Of Mass, Center Of Boundbox, Xmin Ymin of boundbox, Custom."))
         obj.addProperty("App::PropertyEnumeration", "CutMode", "Surface Cut Options", QtCore.QT_TRANSLATE_NOOP("App::Property", "The direction that the toolpath should go around the part: Climb(ClockWise) or Conventional(CounterClockWise)"))
         obj.addProperty("App::PropertyEnumeration", "CutPattern", "Surface Cut Options", QtCore.QT_TRANSLATE_NOOP("App::Property", "Clearing pattern to use"))
         obj.addProperty("App::PropertyFloat", "CutPatternAngle", "Surface Cut Options", QtCore.QT_TRANSLATE_NOOP("App::Property", "Yaw angle for certain clearing patterns"))
@@ -507,7 +507,7 @@ class ObjectSurface(PathOp.ObjectOp):
                     PathLog.error('No data for model base: {}'.format(JOB.Model.Group[m].Label))
                 else:
                     if m > 0:
-                        # Raise to clearance between moddels
+                        # Raise to clearance between models
                         CMDS.append(Path.Command('N (Transition to base: {}.)'.format(Mdl.Label)))
                         CMDS.append(Path.Command('G0', {'Z': obj.ClearanceHeight.Value, 'F': self.vertRapid}))
                         PathLog.info('Working on Model.Group[{}]: {}'.format(m, Mdl.Label))
@@ -1171,7 +1171,7 @@ class ObjectSurface(PathOp.ObjectOp):
 
     def _isPocket(self, b, f, w):
         '''_isPocket(b, f, w)... 
-        Attempts to determing if the wire(w) in face(f) of base(b) is a pocket or raised protrusion.
+        Attempts to determine if the wire(w) in face(f) of base(b) is a pocket or raised protrusion.
         Returns True if pocket, False if raised protrusion.'''
         e = w.Edges[0]
         for fi in range(0, len(b.Shape.Faces)):
@@ -1907,7 +1907,7 @@ class ObjectSurface(PathOp.ObjectOp):
 
     def _planarPerformOclScan(self, obj, pdc, pathGeom, offsetPoints=False):
         '''_planarPerformOclScan(obj, pdc, pathGeom, offsetPoints=False)...
-        Switching fuction for calling the appropriate path-geometry to OCL points conversion fucntion
+        Switching function for calling the appropriate path-geometry to OCL points conversion function
         for the various cut patterns.'''
         PathLog.debug('_planarPerformOclScan()')
         SCANS = list()

--- a/src/Mod/Raytracing/Init.py
+++ b/src/Mod/Raytracing/Init.py
@@ -1,3 +1,4 @@
+# -*- coding: utf8 -*-
 # FreeCAD init script of the Raytracing module
 # (c) 2001 Jürgen Riegel
 

--- a/src/Mod/ReverseEngineering/Init.py
+++ b/src/Mod/ReverseEngineering/Init.py
@@ -1,3 +1,4 @@
+# -*- coding: utf8 -*-
 # FreeCAD init script of the ReverseEngineering module
 # (c) 2001 Jürgen Riegel
 

--- a/src/Mod/Sketcher/Gui/Command.cpp
+++ b/src/Mod/Sketcher/Gui/Command.cpp
@@ -762,7 +762,7 @@ void CmdSketcherMirrorSketch::activated(int iMsg)
         std::vector<Part::Geometry *> tempgeo = tempsketch->getInternalGeometry();
         std::vector<Sketcher::Constraint *> tempconstr = tempsketch->Constraints.getValues();
 
-        // If value of addedGeometries or addedConstraints is -1, it gets added to vector begin iterator and that is invlid
+        // If value of addedGeometries or addedConstraints is -1, it gets added to vector begin iterator and that is invalid
         std::vector<Part::Geometry *> mirrorgeo(tempgeo.begin() + (addedGeometries + 1), tempgeo.end());
         std::vector<Sketcher::Constraint *> mirrorconstr(tempconstr.begin() + (addedConstraints + 1), tempconstr.end());
 


### PR DESCRIPTION
Found via 
```
codespell -q 3 -L aci,ake,aline,alle,alledges,alocation,als,ang,anid,ba,beginn,behaviour,bloaded,byteorder,calculater,cancelled,cancelling,cas,cascade,centimetre,childs,colour,colours,commen,connexion,currenty,dof,doubleclick,dum,eiter,elemente,ende,feld,finde,findf,freez,hist,iff,indicies,initialisation,initialise,initialised,initialises,initialisiert,ist,kilometre,lod,mantatory,methode,metres,millimetre,modell,nd,noe,normale,normaly,nto,numer,oder,orgin,orginx,orginy,ot,pard,pres,programm,que,recurrance,rougly,seperator,serie,sinc,strack,substraction,te,thist,thru,tread,uint,unter,vertexes,wallthickness,whitespaces -S ./.git,*.po,*.ts,./ChangeLog.txt,./src/3rdParty,./src/Mod/Assembly/App/opendcm,./src/CXX,./src/zipios++,./src/Base/swig*,./src/Mod/Robot/App/kdl_cp,./src/Mod/Import/App/SCL,./src/WindowsInstaller,./src/Doc/FreeCAD.uml
```