### PR TITLE
[PD] fix logic of TaskPrimitiveParameters dialog

### DIFF
--- a/src/Mod/PartDesign/Gui/TaskPrimitiveParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskPrimitiveParameters.cpp
@@ -61,54 +61,6 @@ TaskBoxPrimitives::TaskBoxPrimitives(ViewProviderPrimitive* vp, QWidget* parent)
     proxy = new QWidget(this);
     ui->setupUi(proxy);
 
-    // box
-    ui->boxLength->setMaximum(INT_MAX);
-    ui->boxWidth->setMaximum(INT_MAX);
-    ui->boxHeight->setMaximum(INT_MAX);
-
-    // cylinder
-    ui->cylinderRadius->setMaximum(INT_MAX);
-    ui->cylinderHeight->setMaximum(INT_MAX);
-
-    // cone
-    ui->coneRadius1->setMaximum(INT_MAX);
-    ui->coneRadius2->setMaximum(INT_MAX);
-    ui->coneHeight->setMaximum(INT_MAX);
-
-    // sphere
-    ui->sphereRadius->setMaximum(INT_MAX);
-
-    // ellipsoid
-    ui->ellipsoidRadius1->setMaximum(INT_MAX);
-    ui->ellipsoidRadius2->setMaximum(INT_MAX);
-    ui->ellipsoidRadius3->setMaximum(INT_MAX);
-
-    // torus
-    ui->torusRadius1->setMaximum(INT_MAX);
-    ui->torusRadius2->setMaximum(INT_MAX);
-
-    // wedge
-    ui->wedgeXmin->setMinimum(INT_MIN);
-    ui->wedgeXmin->setMaximum(INT_MAX);
-    ui->wedgeYmin->setMinimum(INT_MIN);
-    ui->wedgeYmin->setMaximum(INT_MAX);
-    ui->wedgeZmin->setMinimum(INT_MIN);
-    ui->wedgeZmin->setMaximum(INT_MAX);
-    ui->wedgeX2min->setMinimum(INT_MIN);
-    ui->wedgeX2min->setMaximum(INT_MAX);
-    ui->wedgeZ2min->setMinimum(INT_MIN);
-    ui->wedgeZ2min->setMaximum(INT_MAX);
-    ui->wedgeXmax->setMinimum(INT_MIN);
-    ui->wedgeXmax->setMaximum(INT_MAX);
-    ui->wedgeYmax->setMinimum(INT_MIN);
-    ui->wedgeYmax->setMaximum(INT_MAX);
-    ui->wedgeZmax->setMinimum(INT_MIN);
-    ui->wedgeZmax->setMaximum(INT_MAX);
-    ui->wedgeX2max->setMinimum(INT_MIN);
-    ui->wedgeX2max->setMaximum(INT_MAX);
-    ui->wedgeZ2max->setMinimum(INT_MIN);
-    ui->wedgeZ2max->setMaximum(INT_MAX);
-
     this->groupLayout()->addWidget(proxy);
 
     int index = 0;
@@ -122,6 +74,12 @@ TaskBoxPrimitives::TaskBoxPrimitives(ViewProviderPrimitive* vp, QWidget* parent)
             ui->boxHeight->bind(static_cast<PartDesign::Box*>(vp->getObject())->Height);
             ui->boxWidth->setValue(static_cast<PartDesign::Box*>(vp->getObject())->Width.getValue());
             ui->boxWidth->bind(static_cast<PartDesign::Box*>(vp->getObject())->Width);
+            ui->boxLength->setMinimum(0.0);
+            ui->boxLength->setMaximum(INT_MAX);
+            ui->boxWidth->setMinimum(0.0);
+            ui->boxWidth->setMaximum(INT_MAX);
+            ui->boxHeight->setMinimum(0.0);
+            ui->boxHeight->setMaximum(INT_MAX);
             break;
         case PartDesign::FeaturePrimitive::Cylinder:
             index = 2;
@@ -131,6 +89,12 @@ TaskBoxPrimitives::TaskBoxPrimitives(ViewProviderPrimitive* vp, QWidget* parent)
             ui->cylinderHeight->bind(static_cast<PartDesign::Cylinder*>(vp->getObject())->Height);
             ui->cylinderRadius->setValue(static_cast<PartDesign::Cylinder*>(vp->getObject())->Radius.getValue());
             ui->cylinderRadius->bind(static_cast<PartDesign::Cylinder*>(vp->getObject())->Radius);
+            ui->cylinderAngle->setMaximum(360.0);
+            ui->cylinderAngle->setMinimum(0.0);
+            ui->cylinderHeight->setMaximum(INT_MAX);
+            ui->cylinderHeight->setMinimum(0.0);
+            ui->cylinderRadius->setMaximum(INT_MAX);
+            ui->cylinderRadius->setMinimum(0.0);
             break;
         case PartDesign::FeaturePrimitive::Sphere:
             index = 4;
@@ -142,6 +106,14 @@ TaskBoxPrimitives::TaskBoxPrimitives(ViewProviderPrimitive* vp, QWidget* parent)
             ui->sphereAngle3->bind(static_cast<PartDesign::Sphere*>(vp->getObject())->Angle3);
             ui->sphereRadius->setValue(static_cast<PartDesign::Sphere*>(vp->getObject())->Radius.getValue());
             ui->sphereRadius->bind(static_cast<PartDesign::Sphere*>(vp->getObject())->Radius);
+            ui->sphereAngle1->setMaximum(ui->sphereAngle2->rawValue()); // must geometrically be <= than sphereAngle2
+            ui->sphereAngle1->setMinimum(-90.0);
+            ui->sphereAngle2->setMaximum(90);
+            ui->sphereAngle2->setMinimum(ui->sphereAngle1->rawValue());
+            ui->sphereAngle3->setMaximum(360.0);
+            ui->sphereAngle3->setMinimum(0.0);
+            ui->sphereRadius->setMaximum(INT_MAX);
+            ui->sphereRadius->setMinimum(0.0);
             break;
         case PartDesign::FeaturePrimitive::Cone:
             index = 3;
@@ -153,6 +125,14 @@ TaskBoxPrimitives::TaskBoxPrimitives(ViewProviderPrimitive* vp, QWidget* parent)
             ui->coneRadius1->bind(static_cast<PartDesign::Cone*>(vp->getObject())->Radius1);
             ui->coneRadius2->setValue(static_cast<PartDesign::Cone*>(vp->getObject())->Radius2.getValue());
             ui->coneRadius2->bind(static_cast<PartDesign::Cone*>(vp->getObject())->Radius2);
+            ui->coneAngle->setMaximum(360.0);
+            ui->coneAngle->setMinimum(0.0);
+            ui->coneHeight->setMaximum(INT_MAX);
+            ui->coneHeight->setMinimum(0.0);
+            ui->coneRadius1->setMaximum(INT_MAX);
+            ui->coneRadius1->setMinimum(0.0);
+            ui->coneRadius2->setMaximum(INT_MAX);
+            ui->coneRadius2->setMinimum(0.0);
             break;
         case PartDesign::FeaturePrimitive::Ellipsoid:
             index = 5;
@@ -168,6 +148,18 @@ TaskBoxPrimitives::TaskBoxPrimitives(ViewProviderPrimitive* vp, QWidget* parent)
             ui->ellipsoidRadius2->bind(static_cast<PartDesign::Ellipsoid*>(vp->getObject())->Radius2);
             ui->ellipsoidRadius3->setValue(static_cast<PartDesign::Ellipsoid*>(vp->getObject())->Radius3.getValue());
             ui->ellipsoidRadius3->bind(static_cast<PartDesign::Ellipsoid*>(vp->getObject())->Radius3);
+            ui->ellipsoidAngle1->setMaximum(ui->ellipsoidAngle2->rawValue()); // must geometrically be <= than sphereAngle2
+            ui->ellipsoidAngle1->setMinimum(-90.0);
+            ui->ellipsoidAngle2->setMaximum(90);
+            ui->ellipsoidAngle2->setMinimum(ui->ellipsoidAngle1->rawValue());
+            ui->ellipsoidAngle3->setMaximum(360.0);
+            ui->ellipsoidAngle3->setMinimum(0.0);
+            ui->ellipsoidRadius1->setMinimum(0.0);
+            ui->ellipsoidRadius1->setMaximum(INT_MAX);
+            ui->ellipsoidRadius2->setMinimum(0.0);
+            ui->ellipsoidRadius2->setMaximum(INT_MAX);
+            ui->ellipsoidRadius3->setMinimum(0.0);
+            ui->ellipsoidRadius3->setMaximum(INT_MAX);
             break;
         case PartDesign::FeaturePrimitive::Torus:
             index = 6;
@@ -181,6 +173,19 @@ TaskBoxPrimitives::TaskBoxPrimitives(ViewProviderPrimitive* vp, QWidget* parent)
             ui->torusRadius1->bind(static_cast<PartDesign::Torus*>(vp->getObject())->Radius1);
             ui->torusRadius2->setValue(static_cast<PartDesign::Torus*>(vp->getObject())->Radius2.getValue());
             ui->torusRadius2->bind(static_cast<PartDesign::Torus*>(vp->getObject())->Radius2);
+            ui->torusAngle1->setMaximum(ui->torusAngle2->rawValue()); // must geometrically be <= than sphereAngle2
+            ui->torusAngle1->setMinimum(-180.0);
+            ui->torusAngle2->setMaximum(180);
+            ui->torusAngle2->setMinimum(ui->torusAngle1->rawValue());
+            ui->torusAngle3->setMaximum(360.0);
+            ui->torusAngle3->setMinimum(0.0);
+            // this is the outer radius that must not be smaller than the inner one
+            // otherwise the geometry is impossible and we can even get a crash:
+            // https://forum.freecadweb.org/viewtopic.php?f=3&t=44467
+            ui->torusRadius1->setMaximum(INT_MAX);
+            ui->torusRadius1->setMinimum(ui->torusRadius2->rawValue());
+            ui->torusRadius2->setMaximum(ui->torusRadius1->rawValue());
+            ui->torusRadius2->setMinimum(0.0);
             break;
         case PartDesign::FeaturePrimitive::Prism:
             index = 7;
@@ -189,6 +194,10 @@ TaskBoxPrimitives::TaskBoxPrimitives(ViewProviderPrimitive* vp, QWidget* parent)
             ui->prismCircumradius->bind(static_cast<PartDesign::Prism*>(vp->getObject())->Circumradius);
             ui->prismHeight->setValue(static_cast<PartDesign::Prism*>(vp->getObject())->Height.getValue());
             ui->prismHeight->bind(static_cast<PartDesign::Prism*>(vp->getObject())->Height);
+            ui->prismCircumradius->setMaximum(INT_MAX);
+            ui->prismCircumradius->setMinimum(0.0);
+            ui->prismHeight->setMaximum(INT_MAX);
+            ui->prismHeight->setMinimum(0.0);
             break;
         case PartDesign::FeaturePrimitive::Wedge:
             index = 8;
@@ -212,6 +221,26 @@ TaskBoxPrimitives::TaskBoxPrimitives(ViewProviderPrimitive* vp, QWidget* parent)
             ui->wedgeZ2max->bind(static_cast<PartDesign::Wedge*>(vp->getObject())->Z2max);
             ui->wedgeZ2min->setValue(static_cast<PartDesign::Wedge*>(vp->getObject())->Z2min.getValue());
             ui->wedgeZ2min->bind(static_cast<PartDesign::Wedge*>(vp->getObject())->Z2min);
+            ui->wedgeXmin->setMinimum(INT_MIN);
+            ui->wedgeXmin->setMaximum(ui->wedgeXmax->rawValue()); // must be <= than wedgeXmax
+            ui->wedgeYmin->setMinimum(INT_MIN);
+            ui->wedgeYmin->setMaximum(ui->wedgeYmax->rawValue()); // must be <= than wedgeYmax
+            ui->wedgeZmin->setMinimum(INT_MIN);
+            ui->wedgeZmin->setMaximum(ui->wedgeZmax->rawValue()); // must be <= than wedgeZmax
+            ui->wedgeX2min->setMinimum(INT_MIN);
+            ui->wedgeX2min->setMaximum(ui->wedgeX2max->rawValue()); // must be <= than wedgeXmax
+            ui->wedgeZ2min->setMinimum(INT_MIN);
+            ui->wedgeZ2min->setMaximum(ui->wedgeZ2max->rawValue()); // must be <= than wedgeXmax
+            ui->wedgeXmax->setMinimum(ui->wedgeXmin->rawValue());
+            ui->wedgeXmax->setMaximum(INT_MAX);
+            ui->wedgeYmax->setMinimum(ui->wedgeYmin->rawValue());
+            ui->wedgeYmax->setMaximum(INT_MAX);
+            ui->wedgeZmax->setMinimum(ui->wedgeZmin->rawValue());
+            ui->wedgeZmax->setMaximum(INT_MAX);
+            ui->wedgeX2max->setMinimum(ui->wedgeX2min->rawValue());
+            ui->wedgeX2max->setMaximum(INT_MAX);
+            ui->wedgeZ2max->setMinimum(ui->wedgeZ2min->rawValue());
+            ui->wedgeZ2max->setMaximum(INT_MAX);
             break;
     }
 
@@ -283,15 +312,15 @@ TaskBoxPrimitives::TaskBoxPrimitives(ViewProviderPrimitive* vp, QWidget* parent)
 
     // wedge
     connect(ui->wedgeXmax, SIGNAL(valueChanged(double)), this, SLOT(onWedgeXmaxChanged(double)));
-    connect(ui->wedgeXmin, SIGNAL(valueChanged(double)), this, SLOT(onWedgeXinChanged(double)));
+    connect(ui->wedgeXmin, SIGNAL(valueChanged(double)), this, SLOT(onWedgeXminChanged(double)));
     connect(ui->wedgeYmax, SIGNAL(valueChanged(double)), this, SLOT(onWedgeYmaxChanged(double)));
-    connect(ui->wedgeYmin, SIGNAL(valueChanged(double)), this, SLOT(onWedgeYinChanged(double)));
+    connect(ui->wedgeYmin, SIGNAL(valueChanged(double)), this, SLOT(onWedgeYminChanged(double)));
     connect(ui->wedgeZmax, SIGNAL(valueChanged(double)), this, SLOT(onWedgeZmaxChanged(double)));
-    connect(ui->wedgeZmin, SIGNAL(valueChanged(double)), this, SLOT(onWedgeZinChanged(double)));
+    connect(ui->wedgeZmin, SIGNAL(valueChanged(double)), this, SLOT(onWedgeZminChanged(double)));
     connect(ui->wedgeX2max, SIGNAL(valueChanged(double)), this, SLOT(onWedgeX2maxChanged(double)));
-    connect(ui->wedgeX2min, SIGNAL(valueChanged(double)), this, SLOT(onWedgeX2inChanged(double)));
+    connect(ui->wedgeX2min, SIGNAL(valueChanged(double)), this, SLOT(onWedgeX2minChanged(double)));
     connect(ui->wedgeZ2max, SIGNAL(valueChanged(double)), this, SLOT(onWedgeZ2maxChanged(double)));
-    connect(ui->wedgeZ2min, SIGNAL(valueChanged(double)), this, SLOT(onWedgeZ2inChanged(double)));
+    connect(ui->wedgeZ2min, SIGNAL(valueChanged(double)), this, SLOT(onWedgeZ2minChanged(double)));
 }
 
 /*
@@ -357,12 +386,14 @@ void TaskBoxPrimitives::onCylinderRadiusChanged(double v) {
 
 void TaskBoxPrimitives::onSphereAngle1Changed(double v) {
     PartDesign::Sphere* sph = static_cast<PartDesign::Sphere*>(vp->getObject());
+    ui->sphereAngle2->setMinimum(v); // Angle1 must geometrically be <= than Angle2
     sph->Angle1.setValue(v);
     vp->getObject()->getDocument()->recomputeFeature(vp->getObject());
 }
 
 void TaskBoxPrimitives::onSphereAngle2Changed(double v) {
     PartDesign::Sphere* sph = static_cast<PartDesign::Sphere*>(vp->getObject());
+    ui->sphereAngle1->setMaximum(v); // Angle1 must geometrically be <= than Angle2
     sph->Angle2.setValue(v);
     vp->getObject()->getDocument()->recomputeFeature(vp->getObject());
 }
@@ -406,12 +437,14 @@ void TaskBoxPrimitives::onConeRadius2Changed(double v) {
 
 void TaskBoxPrimitives::onEllipsoidAngle1Changed(double v) {
     PartDesign::Ellipsoid* sph = static_cast<PartDesign::Ellipsoid*>(vp->getObject());
+    ui->ellipsoidAngle2->setMinimum(v); // Angle1 must geometrically be <= than Angle2
     sph->Angle1.setValue(v);
     vp->getObject()->getDocument()->recomputeFeature(vp->getObject());
 }
 
 void TaskBoxPrimitives::onEllipsoidAngle2Changed(double v) {
     PartDesign::Ellipsoid* sph = static_cast<PartDesign::Ellipsoid*>(vp->getObject());
+    ui->ellipsoidAngle1->setMaximum(v); // Angle1 must geometrically be <= than Angle22
     sph->Angle2.setValue(v);
     vp->getObject()->getDocument()->recomputeFeature(vp->getObject());
 }
@@ -442,12 +475,14 @@ void TaskBoxPrimitives::onEllipsoidRadius3Changed(double v) {
 
 void TaskBoxPrimitives::onTorusAngle1Changed(double v) {
     PartDesign::Torus* sph = static_cast<PartDesign::Torus*>(vp->getObject());
+    ui->torusAngle2->setMinimum(v); // Angle1 must geometrically be <= than Angle2  
     sph->Angle1.setValue(v);
     vp->getObject()->getDocument()->recomputeFeature(vp->getObject());
 }
 
 void TaskBoxPrimitives::onTorusAngle2Changed(double v) {
     PartDesign::Torus* sph = static_cast<PartDesign::Torus*>(vp->getObject());
+    ui->torusAngle1->setMaximum(v); // Angle1 must geometrically be <= than Angle2
     sph->Angle2.setValue(v);
     vp->getObject()->getDocument()->recomputeFeature(vp->getObject());
 }
@@ -460,12 +495,17 @@ void TaskBoxPrimitives::onTorusAngle3Changed(double v) {
 
 void TaskBoxPrimitives::onTorusRadius1Changed(double v) {
     PartDesign::Torus* sph = static_cast<PartDesign::Torus*>(vp->getObject());
+    // this is the outer radius that must not be smaller than the inner one
+    // otherwise the geometry is impossible and we can even get a crash:
+    // https://forum.freecadweb.org/viewtopic.php?f=3&t=44467
+    ui->torusRadius2->setMaximum(v);
     sph->Radius1.setValue(v);
     vp->getObject()->getDocument()->recomputeFeature(vp->getObject());
 }
 
 void TaskBoxPrimitives::onTorusRadius2Changed(double v) {
     PartDesign::Torus* sph = static_cast<PartDesign::Torus*>(vp->getObject());
+    ui->torusRadius1->setMinimum(v);
     sph->Radius2.setValue(v);
     vp->getObject()->getDocument()->recomputeFeature(vp->getObject());
 }
@@ -489,62 +529,72 @@ void TaskBoxPrimitives::onPrismPolygonChanged(int v) {
 }
 
 
-void TaskBoxPrimitives::onWedgeX2inChanged(double v) {
+void TaskBoxPrimitives::onWedgeX2minChanged(double v) {
     PartDesign::Wedge* sph = static_cast<PartDesign::Wedge*>(vp->getObject());
+    ui->wedgeX2max->setMinimum(v); // wedgeX2min must be <= than wedgeX2max
     sph->X2min.setValue(v);
     vp->getObject()->getDocument()->recomputeFeature(vp->getObject());
 }
 
 void TaskBoxPrimitives::onWedgeX2maxChanged(double v) {
     PartDesign::Wedge* sph = static_cast<PartDesign::Wedge*>(vp->getObject());
+    ui->wedgeX2min->setMaximum(v); // wedgeX2min must be <= than wedgeX2max
     sph->X2max.setValue(v);
     vp->getObject()->getDocument()->recomputeFeature(vp->getObject());
 }
 
-void TaskBoxPrimitives::onWedgeXinChanged(double v) {
+void TaskBoxPrimitives::onWedgeXminChanged(double v) {
     PartDesign::Wedge* sph = static_cast<PartDesign::Wedge*>(vp->getObject());
+    ui->wedgeXmax->setMinimum(v);
     sph->Xmin.setValue(v);
     vp->getObject()->getDocument()->recomputeFeature(vp->getObject());
 }
 
 void TaskBoxPrimitives::onWedgeXmaxChanged(double v) {
     PartDesign::Wedge* sph = static_cast<PartDesign::Wedge*>(vp->getObject());
+    ui->wedgeXmin->setMaximum(v); // must be <= than wedgeXmax
     sph->Xmax.setValue(v);
     vp->getObject()->getDocument()->recomputeFeature(vp->getObject());
 }
 
-void TaskBoxPrimitives::onWedgeYinChanged(double v) {
+void TaskBoxPrimitives::onWedgeYminChanged(double v) {
     PartDesign::Wedge* sph = static_cast<PartDesign::Wedge*>(vp->getObject());
+    ui->wedgeYmax->setMinimum(v);
     sph->Ymin.setValue(v);
     vp->getObject()->getDocument()->recomputeFeature(vp->getObject());
 }
 
 void TaskBoxPrimitives::onWedgeYmaxChanged(double v) {
     PartDesign::Wedge* sph = static_cast<PartDesign::Wedge*>(vp->getObject());
+    ui->wedgeYmin->setMaximum(v);
     sph->Ymax.setValue(v);
     vp->getObject()->getDocument()->recomputeFeature(vp->getObject());
 }
 
-void TaskBoxPrimitives::onWedgeZ2inChanged(double v) {
+void TaskBoxPrimitives::onWedgeZ2minChanged(double v) {
     PartDesign::Wedge* sph = static_cast<PartDesign::Wedge*>(vp->getObject());
+    ui->wedgeZ2max->setMinimum(v);
     sph->Z2min.setValue(v);
     vp->getObject()->getDocument()->recomputeFeature(vp->getObject());
 }
 
 void TaskBoxPrimitives::onWedgeZ2maxChanged(double v) {
     PartDesign::Wedge* sph = static_cast<PartDesign::Wedge*>(vp->getObject());
+    ui->wedgeZ2min->setMaximum(v); // must be <= than wedgeXmax
     sph->Z2max.setValue(v);
     vp->getObject()->getDocument()->recomputeFeature(vp->getObject());
 }
 
-void TaskBoxPrimitives::onWedgeZinChanged(double v) {
+void TaskBoxPrimitives::onWedgeZminChanged(double v) {
     PartDesign::Wedge* sph = static_cast<PartDesign::Wedge*>(vp->getObject());
+    ui->wedgeZmax->setMinimum(v);
     sph->Zmin.setValue(v);
     vp->getObject()->getDocument()->recomputeFeature(vp->getObject());
 }
 
 void TaskBoxPrimitives::onWedgeZmaxChanged(double v) {
     PartDesign::Wedge* sph = static_cast<PartDesign::Wedge*>(vp->getObject());
+    ui->wedgeZmin->setMaximum(v);
     sph->Zmax.setValue(v);
     vp->getObject()->getDocument()->recomputeFeature(vp->getObject());
 }

--- a/src/Mod/PartDesign/Gui/TaskPrimitiveParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskPrimitiveParameters.h
@@ -87,15 +87,15 @@ public Q_SLOTS:
     void onPrismHeightChanged(double);
     void onPrismPolygonChanged(int);
     void onWedgeXmaxChanged(double);
-    void onWedgeXinChanged(double);
+    void onWedgeXminChanged(double);
     void onWedgeYmaxChanged(double);
-    void onWedgeYinChanged(double);
+    void onWedgeYminChanged(double);
     void onWedgeZmaxChanged(double);
-    void onWedgeZinChanged(double);
+    void onWedgeZminChanged(double);
     void onWedgeX2maxChanged(double);
-    void onWedgeX2inChanged(double);
+    void onWedgeX2minChanged(double);
     void onWedgeZ2maxChanged(double);
-    void onWedgeZ2inChanged(double);
+    void onWedgeZ2minChanged(double);
 
 private:
     /** Notifies when the object is about to be removed. */


### PR DESCRIPTION
- only allow geometrically possible values for the different parameters
- this way also fix a crash
- fix a typo

see https://forum.freecadweb.org/viewtopic.php?f=3&t=44467