### PR TITLE
Part: remove excessive spacing in strings

### DIFF
--- a/src/Mod/Part/Gui/AttacherTexts.cpp
+++ b/src/Mod/Part/Gui/AttacherTexts.cpp
@@ -52,13 +52,13 @@ TextSet getUIStrings(Base::Type attacherType, eMapMode mmode)
             return TwoStrings(qApp->translate("Attacher3D", "Translate origin","Attachment3D mode caption"),
                               qApp->translate("Attacher3D", "Origin is aligned to match Vertex. Orientation is controlled by Placement property.","Attachment3D mode tooltip"));
         case mmObjectXY:
-            return TwoStrings(qApp->translate("Attacher3D", "Object's  X Y Z","Attachment3D mode caption"),
+            return TwoStrings(qApp->translate("Attacher3D", "Object's X Y Z","Attachment3D mode caption"),
                               qApp->translate("Attacher3D", "Placement is made equal to Placement of linked object.","Attachment3D mode tooltip"));
         case mmObjectXZ:
-            return TwoStrings(qApp->translate("Attacher3D", "Object's  X Z-Y","Attachment3D mode caption"),
+            return TwoStrings(qApp->translate("Attacher3D", "Object's X Z Y","Attachment3D mode caption"),
                               qApp->translate("Attacher3D", "X', Y', Z' axes are matched with object's local X, Z, -Y, respectively.","Attachment3D mode tooltip"));
         case mmObjectYZ:
-            return TwoStrings(qApp->translate("Attacher3D", "Object's  Y Z X","Attachment3D mode caption"),
+            return TwoStrings(qApp->translate("Attacher3D", "Object's Y Z X","Attachment3D mode caption"),
                               qApp->translate("Attacher3D", "X', Y', Z' axes are matched with object's local Y, Z, X, respectively.","Attachment3D mode tooltip"));
         case mmFlatFace:
             return TwoStrings(qApp->translate("Attacher3D", "XY on plane","Attachment3D mode caption"),
@@ -133,7 +133,7 @@ TextSet getUIStrings(Base::Type attacherType, eMapMode mmode)
             return TwoStrings(qApp->translate("Attacher2D", "Object's XZ","AttachmentPlane mode caption"),
                               qApp->translate("Attacher2D", "Plane is aligned to XZ local plane of linked object.","AttachmentPlane mode tooltip"));
         case mmObjectYZ:
-            return TwoStrings(qApp->translate("Attacher2D", "Object's  YZ","AttachmentPlane mode caption"),
+            return TwoStrings(qApp->translate("Attacher2D", "Object's YZ","AttachmentPlane mode caption"),
                               qApp->translate("Attacher2D", "Plane is aligned to YZ local plane of linked object.","AttachmentPlane mode tooltip"));
         case mmFlatFace:
             return TwoStrings(qApp->translate("Attacher2D", "Plane face","AttachmentPlane mode caption"),


### PR DESCRIPTION
Extra spaces make the strings look ugly in the interface.

Reported in the forum, [Minor issue extra space in "Object's YZ"](https://forum.freecadweb.org/viewtopic.php?f=3&t=44511).

---

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)