### PR TITLE
[TD] make dimension DLG shorter

### DIFF
--- a/src/Mod/TechDraw/Gui/DlgPrefsTechDraw2.ui
+++ b/src/Mod/TechDraw/Gui/DlgPrefsTechDraw2.ui
@@ -317,7 +317,7 @@
           </property>
           <property name="toolTip">
            <string>Selection area around center marks
-Each unit means is approx. 0.1 mm</string>
+Each unit is approx. 0.1 mm wide</string>
           </property>
           <property name="statusTip">
            <string/>
@@ -358,7 +358,7 @@ Each unit means is approx. 0.1 mm</string>
           </property>
           <property name="toolTip">
            <string>Size of selection area around edges
-Each unit means is approx. 0.1 mm</string>
+Each unit is approx. 0.1 mm wide</string>
           </property>
           <property name="statusTip">
            <string/>

--- a/src/Mod/TechDraw/Gui/DlgPrefsTechDraw3.ui
+++ b/src/Mod/TechDraw/Gui/DlgPrefsTechDraw3.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>448</width>
-    <height>952</height>
+    <height>856</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -338,7 +338,7 @@
           </property>
          </spacer>
         </item>
-        <item row="2" column="0">
+        <item row="1" column="2">
          <widget class="Gui::PrefCheckBox" name="cbShowUnits">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
@@ -498,31 +498,6 @@
              <normaloff>:/icons/rectangle.svg</normaloff>:/icons/rectangle.svg</iconset>
            </property>
           </item>
-         </widget>
-        </item>
-        <item row="10" column="0">
-         <widget class="Gui::PrefCheckBox" name="cbAutoHoriz">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="toolTip">
-           <string>Forces last leader line segment to be horizontal</string>
-          </property>
-          <property name="text">
-           <string>Leader Line Auto Horizontal</string>
-          </property>
-          <property name="checked">
-           <bool>true</bool>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>AutoHorizontal</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/TechDraw/LeaderLines</cstring>
-          </property>
          </widget>
         </item>
         <item row="5" column="2">
@@ -940,28 +915,6 @@
           </property>
          </widget>
         </item>
-        <item row="12" column="0">
-         <widget class="Gui::PrefCheckBox" name="cbPrintCenterMarks">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="toolTip">
-           <string>Show arc centers in printed output</string>
-          </property>
-          <property name="text">
-           <string>Print Center Marks</string>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>PrintCenterMarks</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/TechDraw/Decorations</cstring>
-          </property>
-         </widget>
-        </item>
         <item row="2" column="0">
          <widget class="QLabel" name="label_19">
           <property name="font">
@@ -1000,7 +953,7 @@
           </item>
           <item>
            <property name="text">
-            <string>Svg Hatch</string>
+            <string>SVG Hatch</string>
            </property>
           </item>
           <item>
@@ -1008,6 +961,53 @@
             <string>PAT Hatch</string>
            </property>
           </item>
+         </widget>
+        </item>
+        <item row="9" column="2">
+         <widget class="Gui::PrefCheckBox" name="cbAutoHoriz">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="toolTip">
+           <string>Forces last leader line segment to be horizontal</string>
+          </property>
+          <property name="text">
+           <string>Leader Line Auto Horizontal</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>AutoHorizontal</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/TechDraw/LeaderLines</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="11" column="2">
+         <widget class="Gui::PrefCheckBox" name="cbPrintCenterMarks">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="toolTip">
+           <string>Show arc centers in printed output</string>
+          </property>
+          <property name="text">
+           <string>Print Center Marks</string>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>PrintCenterMarks</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/TechDraw/Decorations</cstring>
+          </property>
          </widget>
         </item>
        </layout>


### PR DESCRIPTION
This is a proposal because  I saw that the dialog was now too large vertically for my laptop screen. Now it is at least no longer than the IFC export settings dialog. To achieve this, I shifted some options to the second column

- also use "SVG" since this is the official abbreviation and used in the other TD dialogs
- also fix a typo in a tooltip

new layout:

![FreeCAD_kwrRJPjEFl](https://user-images.githubusercontent.com/1828501/77486624-7fcf5080-6e30-11ea-9af3-d87894d737f4.png)