### PR TITLE
[Path] Fix failed open edge path for zero GeometryTolerance case

### DIFF
--- a/src/Mod/Path/PathScripts/PathProfileEdges.py
+++ b/src/Mod/Path/PathScripts/PathProfileEdges.py
@@ -112,18 +112,23 @@ class ObjectProfile(PathProfileBase.ObjectProfile):
                         else:
                             PathLog.error(translate('PathProfileEdges', 'The selected edge(s) are inaccessible.'))
                     else:
-                        cutWireObjs = False
-                        (origWire, flatWire) = self._flattenWire(obj, wire, obj.FinalDepth.Value)
-                        cutShp = self._getCutAreaCrossSection(obj, base, origWire, flatWire)
-                        if cutShp is not False:
-                            cutWireObjs = self._extractPathWire(obj, base, flatWire, cutShp)
-
-                        if cutWireObjs is not False:
-                            for cW in cutWireObjs:
-                                shapes.append((cW, False))
-                                self.profileEdgesIsOpen = True
+                        if self.JOB.GeometryTolerance.Value == 0.0:
+                            msg = self.JOB.Label + '.GeometryTolerance = 0.0.'
+                            msg += translate('PathProfileEdges', 'Please set to an acceptable value greater than zero.')
+                            PathLog.error(msg)
                         else:
-                            PathLog.error(translate('PathProfileEdges', 'The selected edge(s) are inaccessible.'))
+                            cutWireObjs = False
+                            (origWire, flatWire) = self._flattenWire(obj, wire, obj.FinalDepth.Value)
+                            cutShp = self._getCutAreaCrossSection(obj, base, origWire, flatWire)
+                            if cutShp is not False:
+                                cutWireObjs = self._extractPathWire(obj, base, flatWire, cutShp)
+
+                            if cutWireObjs is not False:
+                                for cW in cutWireObjs:
+                                    shapes.append((cW, False))
+                                    self.profileEdgesIsOpen = True
+                            else:
+                                PathLog.error(translate('PathProfileEdges', 'The selected edge(s) are inaccessible.'))
 
             # Delete the temporary objects
             if PathLog.getLevel(PathLog.thisModule()) != 4:
@@ -179,13 +184,13 @@ class ObjectProfile(PathProfileBase.ObjectProfile):
 
         return (OW, FW)
 
+    # Open-edges methods
     def _getCutAreaCrossSection(self, obj, base, origWire, flatWireObj):
         PathLog.debug('_getCutAreaCrossSection()')
         tmpGrp = self.tmpGrp
         FCAD = FreeCAD.ActiveDocument
         tolerance = self.JOB.GeometryTolerance.Value
-        # toolDiam = float(obj.ToolController.Tool.Diameter)
-        toolDiam = 2 * self.radius  # self.radius defined in PathAreaOp or PathprofileBase modules
+        toolDiam = 2 * self.radius  # self.radius defined in PathAreaOp or PathProfileBase modules
         minBfr = toolDiam * 1.25
         bbBfr = (self.ofstRadius * 2) * 1.25
         if bbBfr < minBfr:
@@ -243,34 +248,33 @@ class ObjectProfile(PathProfileBase.ObjectProfile):
 
         # Cut model(selected edges) from extended edges boundbox
         cutArea = extBndboxEXT.Shape.cut(base.Shape)
-        CA = FCAD.addObject('Part::Feature', 'tmpBndboxCutByBase')
-        CA.Shape = cutArea
-        CA.purgeTouched()
-        tmpGrp.addObject(CA)
 
         # Get top and bottom faces of cut area (CA), and combine faces when necessary
         topFc = list()
         botFc = list()
-        bbZMax = CA.Shape.BoundBox.ZMax
-        bbZMin = CA.Shape.BoundBox.ZMin
-        for f in range(0, len(CA.Shape.Faces)):
-            Fc = CA.Shape.Faces[f]
-            if abs(Fc.BoundBox.ZMax - bbZMax) < tolerance and abs(Fc.BoundBox.ZMin - bbZMax) < tolerance:
+        bbZMax = cutArea.BoundBox.ZMax
+        bbZMin = cutArea.BoundBox.ZMin
+        for f in range(0, len(cutArea.Faces)):
+            FcBB = cutArea.Faces[f].BoundBox
+            if abs(FcBB.ZMax - bbZMax) < tolerance and abs(FcBB.ZMin - bbZMax) < tolerance:
                 topFc.append(f)
-            if abs(Fc.BoundBox.ZMax - bbZMin) < tolerance and abs(Fc.BoundBox.ZMin - bbZMin) < tolerance:
+            if abs(FcBB.ZMax - bbZMin) < tolerance and abs(FcBB.ZMin - bbZMin) < tolerance:
                 botFc.append(f)
-        topComp = Part.makeCompound([CA.Shape.Faces[f] for f in topFc])
+        if len(topFc) == 0:
+            PathLog.error('Failed to identify top faces of cut area.')
+            return False
+        topComp = Part.makeCompound([cutArea.Faces[f] for f in topFc])
         topComp.translate(FreeCAD.Vector(0, 0, fdv - topComp.BoundBox.ZMin))  # Translate face to final depth
         if len(botFc) > 1:
             PathLog.debug('len(botFc) > 1')
             bndboxFace = Part.Face(extBndbox.Shape.Wires[0])
             tmpFace = Part.Face(extBndbox.Shape.Wires[0])
             for f in botFc:
-                Q = tmpFace.cut(CA.Shape.Faces[f])
+                Q = tmpFace.cut(cutArea.Faces[f])
                 tmpFace = Q
             botComp = bndboxFace.cut(tmpFace)
         else:
-            botComp = Part.makeCompound([CA.Shape.Faces[f] for f in botFc])
+            botComp = Part.makeCompound([cutArea.Faces[f] for f in botFc])  # Part.makeCompound([CA.Shape.Faces[f] for f in botFc])
         botComp.translate(FreeCAD.Vector(0, 0, fdv - botComp.BoundBox.ZMin))  # Translate face to final depth
 
         # Convert compound shapes to FC objects for use in multicommon operation


### PR DESCRIPTION
Add error message to inform user to set Job.GeometryTolerance to an acceptable value.
Remove creation of docObject in lieu of geometry shape usage.

Forum discussion begins at [Re: New feature: ProfileEdges - Cut open edges [Merged]](https://forum.freecadweb.org/viewtopic.php?style=3&f=15&t=43434&p=380954#p380909)

This fix does not produce a path, rather informs the user with an error message that the Job.GeometryTolerance property is zero and should be set to an acceptable value greater than zero.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
