### PR TITLE
[TD] TaskCenterLine add missing unit initialization

### DIFF
--- a/src/Mod/TechDraw/Gui/TaskCenterLine.cpp
+++ b/src/Mod/TechDraw/Gui/TaskCenterLine.cpp
@@ -307,7 +307,7 @@ void TaskCenterLine::onColorChanged()
 
 void TaskCenterLine::onWeightChanged()
 {
-    m_cl->m_format.m_weight = ui->dsbWeight->value();
+    m_cl->m_format.m_weight = ui->dsbWeight->value().getValue();
     m_partFeat->recomputeFeature();
 }
 
@@ -357,7 +357,7 @@ void TaskCenterLine::createCenterLine(void)
         App::Color ac;
         ac.setValue<QColor>(ui->cpLineColor->color());
         cl->m_format.m_color = ac;
-        cl->m_format.m_weight = ui->dsbWeight->value();
+        cl->m_format.m_weight = ui->dsbWeight->value().getValue();
         cl->m_format.m_style = ui->cboxStyle->currentIndex() + 1;  //Qt Styles start at 0:NoLine
         cl->m_format.m_visible = true;
         m_partFeat->addCenterLine(cl);
@@ -375,7 +375,7 @@ void TaskCenterLine::updateCenterLine(void)
 //    Base::Console().Message("TCL::updateCenterLine()\n");
     Gui::Command::openCommand("Edit CenterLine");
     m_cl->m_format.m_color.setValue<QColor>(ui->cpLineColor->color() );
-    m_cl->m_format.m_weight = ui->dsbWeight->value();
+    m_cl->m_format.m_weight = ui->dsbWeight->value().getValue();
     m_cl->m_format.m_style = ui->cboxStyle->currentIndex() + 1;
     m_cl->m_format.m_visible = true;
 

--- a/src/Mod/TechDraw/Gui/TaskCenterLine.cpp
+++ b/src/Mod/TechDraw/Gui/TaskCenterLine.cpp
@@ -173,6 +173,8 @@ void TaskCenterLine::setUiPrimary()
     ui->dsbWeight->setValue(getCenterWidth());
     ui->cboxStyle->setCurrentIndex(getCenterStyle() - 1);
 
+    ui->qsbVertShift->setUnit(Base::Unit::Length);
+    ui->qsbHorizShift->setUnit(Base::Unit::Length);
     Base::Quantity qVal;
     qVal.setUnit(Base::Unit::Length);
     qVal.setValue(getExtendBy());

--- a/src/Mod/TechDraw/Gui/TaskCenterLine.ui
+++ b/src/Mod/TechDraw/Gui/TaskCenterLine.ui
@@ -159,7 +159,7 @@
       </widget>
      </item>
      <item row="0" column="1">
-      <widget class="Gui::QuantitySpinBox" name="qsbHorizShift" native="true">
+      <widget class="Gui::QuantitySpinBox" name="qsbHorizShift">
        <property name="minimumSize">
         <size>
          <width>0</width>
@@ -168,6 +168,9 @@
        </property>
        <property name="toolTip">
         <string>Move line -Left or +Right</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
        </property>
        <property name="unit" stdset="0">
         <string notr="true"/>
@@ -182,7 +185,7 @@
       </widget>
      </item>
      <item row="1" column="1">
-      <widget class="Gui::QuantitySpinBox" name="qsbVertShift" native="true">
+      <widget class="Gui::QuantitySpinBox" name="qsbVertShift">
        <property name="minimumSize">
         <size>
          <width>0</width>
@@ -191,6 +194,9 @@
        </property>
        <property name="toolTip">
         <string>Move line +Up or -Down</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
        </property>
        <property name="unit" stdset="0">
         <string notr="true"/>
@@ -205,7 +211,7 @@
       </widget>
      </item>
      <item row="2" column="1">
-      <widget class="Gui::QuantitySpinBox" name="qsbRotate" native="true">
+      <widget class="Gui::QuantitySpinBox" name="qsbRotate">
        <property name="minimumSize">
         <size>
          <width>0</width>
@@ -215,10 +221,13 @@
        <property name="toolTip">
         <string>Rotate line +CCW or -CW</string>
        </property>
-       <property name="minimum" stdset="0">
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+       <property name="minimum">
         <double>-360.000000000000000</double>
        </property>
-       <property name="maximum" stdset="0">
+       <property name="maximum">
         <double>360.000000000000000</double>
        </property>
       </widget>
@@ -242,7 +251,7 @@
       </widget>
      </item>
      <item row="0" column="1">
-      <widget class="Gui::QuantitySpinBox" name="qsbExtend" native="true">
+      <widget class="Gui::QuantitySpinBox" name="qsbExtend">
        <property name="minimumSize">
         <size>
          <width>0</width>
@@ -252,10 +261,13 @@
        <property name="toolTip">
         <string>Make the line a little longer.</string>
        </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
        <property name="unit" stdset="0">
         <string>mm</string>
        </property>
-       <property name="value" stdset="0">
+       <property name="value">
         <double>3.000000000000000</double>
        </property>
       </widget>
@@ -269,7 +281,7 @@
      </item>
      <item row="1" column="1">
       <widget class="Gui::ColorButton" name="cpLineColor">
-       <property name="color" stdset="0">
+       <property name="color">
         <color>
          <red>0</red>
          <green>0</green>
@@ -286,7 +298,10 @@
       </widget>
      </item>
      <item row="2" column="1">
-      <widget class="QDoubleSpinBox" name="dsbWeight">
+      <widget class="Gui::QuantitySpinBox" name="dsbWeight">
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
        <property name="singleStep">
         <double>0.100000000000000</double>
        </property>


### PR DESCRIPTION
(for the editing dialog this is already set)

- also use Gui::QuantitySpinBox as recently discussed
- also add alignment properties