### PR TITLE
[TD] vertex dialog: fix vertical size

### DIFF
--- a/src/Mod/TechDraw/Gui/TaskCosVertex.ui
+++ b/src/Mod/TechDraw/Gui/TaskCosVertex.ui
@@ -7,11 +7,11 @@
     <x>0</x>
     <y>0</y>
     <width>400</width>
-    <height>200</height>
+    <height>167</height>
    </rect>
   </property>
   <property name="sizePolicy">
-   <sizepolicy hsizetype="Fixed" vsizetype="Expanding">
+   <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
     <horstretch>0</horstretch>
     <verstretch>0</verstretch>
    </sizepolicy>
@@ -175,19 +175,6 @@
       </item>
      </layout>
     </widget>
-   </item>
-   <item>
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>17</width>
-       <height>24</height>
-      </size>
-     </property>
-    </spacer>
    </item>
   </layout>
  </widget>


### PR DESCRIPTION
there was too much vertical whitespace below the actual dialog
-> remove superfluous spacer and correct size policy