### PR TITLE
[TD] Section dialog overhaul

### DIFF
--- a/src/Mod/TechDraw/Gui/TaskSectionView.cpp
+++ b/src/Mod/TechDraw/Gui/TaskSectionView.cpp
@@ -94,19 +94,12 @@ TaskSectionView::TaskSectionView(TechDraw::DrawViewPart* base) :
     m_saveBaseName = m_base->getNameInDocument();
     m_savePageName = m_base->findParentPage()->getNameInDocument();
 
- 
-   ui->setupUi(this);
+    ui->setupUi(this);
 
-    connect(ui->pbUp, SIGNAL(clicked(bool)),
-            this, SLOT(onUpClicked(bool)));
-    connect(ui->pbDown, SIGNAL(clicked(bool)),
-            this, SLOT(onDownClicked(bool)));
-    connect(ui->pbRight, SIGNAL(clicked(bool)),
-            this, SLOT(onRightClicked(bool)));
-    connect(ui->pbLeft, SIGNAL(clicked(bool)),
-            this, SLOT(onLeftClicked(bool)));
-    connect(ui->pbApply, SIGNAL(clicked(bool)),
-            this, SLOT(onApplyClicked(bool)));
+    connect(ui->pbUp, SIGNAL(clicked(bool)), this, SLOT(onUpClicked()));
+    connect(ui->pbDown, SIGNAL(clicked(bool)), this, SLOT(onDownClicked()));
+    connect(ui->pbRight, SIGNAL(clicked(bool)), this, SLOT(onRightClicked()));
+    connect(ui->pbLeft, SIGNAL(clicked(bool)), this, SLOT(onLeftClicked()));
 
     setUiPrimary();
 }
@@ -143,16 +136,10 @@ TaskSectionView::TaskSectionView(TechDraw::DrawViewSection* section) :
 
     ui->setupUi(this);
 
-    connect(ui->pbUp, SIGNAL(clicked(bool)),
-            this, SLOT(onUpClicked(bool)));
-    connect(ui->pbDown, SIGNAL(clicked(bool)),
-            this, SLOT(onDownClicked(bool)));
-    connect(ui->pbRight, SIGNAL(clicked(bool)),
-            this, SLOT(onRightClicked(bool)));
-    connect(ui->pbLeft, SIGNAL(clicked(bool)),
-            this, SLOT(onLeftClicked(bool)));
-    connect(ui->pbApply, SIGNAL(clicked(bool)),
-            this, SLOT(onApplyClicked(bool)));
+    connect(ui->pbUp, SIGNAL(clicked(bool)), this, SLOT(onUpClicked()));
+    connect(ui->pbDown, SIGNAL(clicked(bool)), this, SLOT(onDownClicked()));
+    connect(ui->pbRight, SIGNAL(clicked(bool)), this, SLOT(onRightClicked()));
+    connect(ui->pbLeft, SIGNAL(clicked(bool)), this, SLOT(onLeftClicked()));
 
     m_dirName = m_section->SectionDirection.getValueAsString();
     saveSectionState();
@@ -180,6 +167,18 @@ void TaskSectionView::setUiPrimary()
     ui->sbOrgX->setValue(origin.x);
     ui->sbOrgY->setValue(origin.y);
     ui->sbOrgZ->setValue(origin.z);
+
+    // before the user did not select an orientation,
+    // the section properties cannot be changed
+    this->setToolTip(QObject::tr("Select at first an orientation"));
+    enableAll(false);
+
+    // now connect and not earlier to avoid premature apply() calls
+    connect(ui->leSymbol, SIGNAL(textChanged(QString)), this, SLOT(onIdentifierChanged()));
+    connect(ui->sbScale, SIGNAL(valueChanged(double)), this, SLOT(onScaleChanged()));
+    connect(ui->sbOrgX, SIGNAL(valueChanged(double)), this, SLOT(onXChanged()));
+    connect(ui->sbOrgY, SIGNAL(valueChanged(double)), this, SLOT(onYChanged()));
+    connect(ui->sbOrgZ, SIGNAL(valueChanged(double)), this, SLOT(onZChanged()));
 }
 
 void TaskSectionView::setUiEdit()
@@ -200,6 +199,13 @@ void TaskSectionView::setUiEdit()
     ui->sbOrgX->setValue(origin.x);
     ui->sbOrgY->setValue(origin.y);
     ui->sbOrgZ->setValue(origin.z);
+
+    // connect affter initializing the object values
+    connect(ui->leSymbol, SIGNAL(textChanged(QString)), this, SLOT(onIdentifierChanged()));
+    connect(ui->sbScale, SIGNAL(valueChanged(double)), this, SLOT(onScaleChanged()));
+    connect(ui->sbOrgX, SIGNAL(valueChanged(double)), this, SLOT(onXChanged()));
+    connect(ui->sbOrgY, SIGNAL(valueChanged(double)), this, SLOT(onYChanged()));
+    connect(ui->sbOrgZ, SIGNAL(valueChanged(double)), this, SLOT(onZChanged()));
 }
 
 //save the start conditions
@@ -231,51 +237,64 @@ void TaskSectionView::restoreSectionState()
     }
 }
 
-void TaskSectionView::blockButtons(bool b)
-{
-    Q_UNUSED(b);
-}
-
-void TaskSectionView::onUpClicked(bool b)
+void TaskSectionView::onUpClicked()
 {
 //    Base::Console().Message("TSV::onUpClicked()\n");
-    Q_UNUSED(b);
     checkAll(false);
     ui->pbUp->setChecked(true);
     applyQuick("Up");
 }
 
-void TaskSectionView::onDownClicked(bool b)
+void TaskSectionView::onDownClicked()
 {
 //    Base::Console().Message("TSV::onDownClicked()\n");
-    Q_UNUSED(b);
     checkAll(false);
     ui->pbDown->setChecked(true);
     applyQuick("Down");
 }
 
-void TaskSectionView::onLeftClicked(bool b)
+void TaskSectionView::onLeftClicked()
 {
 //    Base::Console().Message("TSV::onLeftClicked()\n");
     checkAll(false);
     ui->pbLeft->setChecked(true);
-    Q_UNUSED(b);
     applyQuick("Left");
 }
 
-void TaskSectionView::onRightClicked(bool b)
+void TaskSectionView::onRightClicked()
 {
 //    Base::Console().Message("TSV::onRightClicked()\n");
-    Q_UNUSED(b);
     checkAll(false);
     ui->pbRight->setChecked(true);
     applyQuick("Right");
 }
 
-void TaskSectionView::onApplyClicked(bool b)
+void TaskSectionView::onIdentifierChanged()
 {
-//    Base::Console().Message("TSV::onApplyClicked()\n");
-    Q_UNUSED(b);
+    checkAll(false);
+    apply();
+}
+
+void TaskSectionView::onScaleChanged()
+{
+    checkAll(false);
+    apply();
+}
+
+void TaskSectionView::onXChanged()
+{
+    checkAll(false);
+    apply();
+}
+
+void TaskSectionView::onYChanged()
+{
+    checkAll(false);
+    apply();
+}
+
+void TaskSectionView::onZChanged()
+{
     checkAll(false);
     apply();
 }
@@ -288,13 +307,22 @@ void TaskSectionView::checkAll(bool b)
     ui->pbLeft->setChecked(b);
 }
 
+void TaskSectionView::enableAll(bool b)
+{
+    ui->leSymbol->setEnabled(b);
+    ui->sbScale->setEnabled(b);
+    ui->sbOrgX->setEnabled(b);
+    ui->sbOrgY->setEnabled(b);
+    ui->sbOrgZ->setEnabled(b);
+}
+
 //******************************************************************************
 bool TaskSectionView::apply(void)
 {
 //    Base::Console().Message("TSV::apply() - m_dirName: %s\n", m_dirName.c_str());
     if (m_dirName.empty()) {
         std::string msg = 
-            Base::Tools::toStdString(tr("TSV::apply - Nothing to apply. No section direction picked yet"));
+            Base::Tools::toStdString(tr("Nothing to apply. No section direction picked yet"));
         Base::Console().Error((msg + "\n").c_str());
         return false;
     }
@@ -318,6 +346,11 @@ void TaskSectionView::applyQuick(std::string dir)
     if (isSectionValid()) {
         updateSectionView();
         m_section->recomputeFeature();
+        this->setToolTip(QObject::tr("Select at first an orientation"));
+        // we can in any case enable all objects in the dialog
+        // and remove the dialog-wide tooltip if there was one
+        enableAll(true);
+        this->setToolTip(QString());
     } else {
         failNoObject(m_sectionName);
     }
@@ -420,7 +453,7 @@ void TaskSectionView::updateSectionView(void)
                            lblText.c_str());
         Command::doCommand(Command::Doc,"App.activeDocument().%s.Scale = %0.6f",
                            m_sectionName.c_str(),
-                           ui->sbScale->value());
+                           ui->sbScale->value().getValue());
         m_section->setCSFromBase(m_dirName.c_str());
     }
 }

--- a/src/Mod/TechDraw/Gui/TaskSectionView.cpp
+++ b/src/Mod/TechDraw/Gui/TaskSectionView.cpp
@@ -164,8 +164,11 @@ void TaskSectionView::setUiPrimary()
 
     ui->sbScale->setValue(m_base->getScale());
     Base::Vector3d origin = m_base->getOriginalCentroid();
+    ui->sbOrgX->setUnit(Base::Unit::Length);
     ui->sbOrgX->setValue(origin.x);
+    ui->sbOrgY->setUnit(Base::Unit::Length);
     ui->sbOrgY->setValue(origin.y);
+    ui->sbOrgZ->setUnit(Base::Unit::Length);
     ui->sbOrgZ->setValue(origin.z);
 
     // before the user did not select an orientation,
@@ -191,13 +194,16 @@ void TaskSectionView::setUiEdit()
     ui->leBaseView->setText(qTemp);
 
     temp = m_section->SectionSymbol.getValue();
-    qTemp    = Base::Tools::fromStdString(temp);
+    qTemp = Base::Tools::fromStdString(temp);
     ui->leSymbol->setText(qTemp);
     ui->sbScale->setValue(m_section->getScale());
     
     Base::Vector3d origin = m_section->SectionOrigin.getValue();
+    ui->sbOrgX->setUnit(Base::Unit::Length);
     ui->sbOrgX->setValue(origin.x);
+    ui->sbOrgY->setUnit(Base::Unit::Length);
     ui->sbOrgY->setValue(origin.y);
+    ui->sbOrgZ->setUnit(Base::Unit::Length);
     ui->sbOrgZ->setValue(origin.z);
 
     // connect affter initializing the object values

--- a/src/Mod/TechDraw/Gui/TaskSectionView.cpp
+++ b/src/Mod/TechDraw/Gui/TaskSectionView.cpp
@@ -154,7 +154,7 @@ TaskSectionView::~TaskSectionView()
 void TaskSectionView::setUiPrimary()
 {
 //    Base::Console().Message("TSV::setUiPrimary()\n");
-    setWindowTitle(QObject::tr("Create SectionView"));
+    setWindowTitle(QObject::tr("Create Section View"));
     std::string temp = m_base->getNameInDocument();
     QString qTemp    = Base::Tools::fromStdString(temp);
     ui->leBaseView->setText(qTemp);
@@ -184,7 +184,7 @@ void TaskSectionView::setUiPrimary()
 void TaskSectionView::setUiEdit()
 {
 //    Base::Console().Message("TSV::setUiEdit()\n");
-    setWindowTitle(QObject::tr("Edit SectionView"));
+    setWindowTitle(QObject::tr("Edit Section View"));
 
     std::string temp = m_base->getNameInDocument();
     QString qTemp    = Base::Tools::fromStdString(temp);

--- a/src/Mod/TechDraw/Gui/TaskSectionView.h
+++ b/src/Mod/TechDraw/Gui/TaskSectionView.h
@@ -51,15 +51,17 @@ public:
     virtual bool reject();
 
 protected Q_SLOTS:
-    void onUpClicked(bool b);
-    void onDownClicked(bool b);
-    void onLeftClicked(bool b);
-    void onRightClicked(bool b);
-    void onApplyClicked(bool b);
+    void onUpClicked();
+    void onDownClicked();
+    void onLeftClicked();
+    void onRightClicked();
+    void onIdentifierChanged();
+    void onScaleChanged();
+    void onXChanged();
+    void onYChanged();
+    void onZChanged();
 
 protected:
-    void blockButtons(bool b);
-
     void changeEvent(QEvent *e);
     void saveSectionState();
     void restoreSectionState();
@@ -75,6 +77,7 @@ protected:
     void setUiEdit();
 
     void checkAll(bool b);
+    void enableAll(bool b);
 
     void failNoObject(std::string objName);
     bool isBaseValid(void);

--- a/src/Mod/TechDraw/Gui/TaskSectionView.ui
+++ b/src/Mod/TechDraw/Gui/TaskSectionView.ui
@@ -6,165 +6,144 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>368</width>
-    <height>450</height>
+    <width>370</width>
+    <height>326</height>
    </rect>
   </property>
   <property name="sizePolicy">
-   <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
+   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
     <horstretch>0</horstretch>
     <verstretch>0</verstretch>
    </sizepolicy>
   </property>
-  <property name="minimumSize">
-   <size>
-    <width>250</width>
-    <height>450</height>
-   </size>
-  </property>
   <property name="windowTitle">
    <string>Section Parameters</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout_2">
+  <layout class="QVBoxLayout" name="verticalLayout_3">
    <item>
-    <widget class="QFrame" name="frame">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
+    <layout class="QGridLayout" name="gridLayout_4">
+     <item row="0" column="0">
+      <widget class="QLabel" name="label_7">
+       <property name="text">
+        <string>BaseView</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <spacer name="horizontalSpacer_4">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item row="0" column="2">
+      <widget class="QLineEdit" name="leBaseView">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>22</height>
+        </size>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="label_2">
+       <property name="text">
+        <string>Identifier</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="2">
+      <widget class="QLineEdit" name="leSymbol">
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>22</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string>Identifier for this section</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>Scale</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="2">
+      <widget class="Gui::QuantitySpinBox" name="sbScale">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>22</height>
+        </size>
+       </property>
+       <property name="baseSize">
+        <size>
+         <width>0</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string>Scale factor for the section view</string>
+       </property>
+       <property name="minimum">
+        <double>0.000000000000000</double>
+       </property>
+       <property name="maximum">
+        <double>999.000000000000000</double>
+       </property>
+       <property name="value">
+        <double>1.000000000000000</double>
+       </property>
+       <property name="decimals" stdset="0">
+        <number>4</number>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="Line" name="line">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
      </property>
-     <property name="minimumSize">
-      <size>
-       <width>350</width>
-       <height>400</height>
-      </size>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="groupBox_2">
+     <property name="title">
+      <string>Section Orientation</string>
      </property>
-     <property name="frameShape">
-      <enum>QFrame::StyledPanel</enum>
-     </property>
-     <property name="frameShadow">
-      <enum>QFrame::Raised</enum>
-     </property>
-     <layout class="QVBoxLayout" name="verticalLayout">
-      <item>
-       <layout class="QFormLayout" name="formLayout_2">
-        <property name="fieldGrowthPolicy">
-         <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
-        </property>
-        <item row="1" column="0">
-         <widget class="QLabel" name="label_7">
-          <property name="text">
-           <string>BaseView</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="1">
-         <widget class="QLineEdit" name="leBaseView">
-          <property name="enabled">
-           <bool>false</bool>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="0">
-         <widget class="QLabel" name="label_2">
-          <property name="text">
-           <string>Identifier</string>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="1">
-         <widget class="QLineEdit" name="leSymbol">
-          <property name="minimumSize">
-           <size>
-            <width>0</width>
-            <height>32</height>
-           </size>
-          </property>
-          <property name="toolTip">
-           <string>Identifier for this section</string>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="1">
-         <widget class="QDoubleSpinBox" name="sbScale">
-          <property name="minimumSize">
-           <size>
-            <width>0</width>
-            <height>32</height>
-           </size>
-          </property>
-          <property name="baseSize">
-           <size>
-            <width>0</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="decimals">
-           <number>4</number>
-          </property>
-          <property name="minimum">
-           <double>0.000000000000000</double>
-          </property>
-          <property name="maximum">
-           <double>999.000000000000000</double>
-          </property>
-          <property name="value">
-           <double>1.000000000000000</double>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="0">
-         <widget class="QLabel" name="label">
-          <property name="text">
-           <string>Scale</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item>
-       <widget class="Line" name="line">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QLabel" name="label_4">
-        <property name="text">
-         <string>Section Orientation</string>
-        </property>
-       </widget>
-      </item>
+     <layout class="QVBoxLayout" name="verticalLayout_2">
       <item>
        <layout class="QGridLayout" name="gridLayout_3">
-        <item row="0" column="3">
-         <widget class="QPushButton" name="pbRight">
-          <property name="toolTip">
-           <string>Looking right</string>
-          </property>
-          <property name="text">
-           <string/>
-          </property>
-          <property name="icon">
-           <iconset>
-            <normalon>:/icons/actions/section-right.svg</normalon>
-           </iconset>
-          </property>
-          <property name="iconSize">
-           <size>
-            <width>48</width>
-            <height>48</height>
-           </size>
-          </property>
-          <property name="checkable">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
         <item row="0" column="0">
          <widget class="QPushButton" name="pbUp">
+          <property name="maximumSize">
+           <size>
+            <width>50</width>
+            <height>50</height>
+           </size>
+          </property>
           <property name="toolTip">
            <string>Looking up</string>
           </property>
@@ -193,32 +172,14 @@
           </property>
          </widget>
         </item>
-        <item row="0" column="2">
-         <widget class="QPushButton" name="pbLeft">
-          <property name="toolTip">
-           <string>Looking left</string>
-          </property>
-          <property name="text">
-           <string/>
-          </property>
-          <property name="icon">
-           <iconset>
-            <normalon>:/icons/actions/section-left.svg</normalon>
-           </iconset>
-          </property>
-          <property name="iconSize">
-           <size>
-            <width>48</width>
-            <height>48</height>
-           </size>
-          </property>
-          <property name="checkable">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
         <item row="0" column="1">
          <widget class="QPushButton" name="pbDown">
+          <property name="maximumSize">
+           <size>
+            <width>50</width>
+            <height>50</height>
+           </size>
+          </property>
           <property name="toolTip">
            <string>Looking down</string>
           </property>
@@ -241,175 +202,110 @@
           </property>
          </widget>
         </item>
+        <item row="0" column="2">
+         <widget class="QPushButton" name="pbLeft">
+          <property name="maximumSize">
+           <size>
+            <width>50</width>
+            <height>50</height>
+           </size>
+          </property>
+          <property name="toolTip">
+           <string>Looking left</string>
+          </property>
+          <property name="text">
+           <string/>
+          </property>
+          <property name="icon">
+           <iconset>
+            <normalon>:/icons/actions/section-left.svg</normalon>
+           </iconset>
+          </property>
+          <property name="iconSize">
+           <size>
+            <width>48</width>
+            <height>48</height>
+           </size>
+          </property>
+          <property name="checkable">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="3">
+         <widget class="QPushButton" name="pbRight">
+          <property name="maximumSize">
+           <size>
+            <width>50</width>
+            <height>50</height>
+           </size>
+          </property>
+          <property name="toolTip">
+           <string>Looking right</string>
+          </property>
+          <property name="text">
+           <string/>
+          </property>
+          <property name="icon">
+           <iconset>
+            <normalon>:/icons/actions/section-right.svg</normalon>
+           </iconset>
+          </property>
+          <property name="iconSize">
+           <size>
+            <width>48</width>
+            <height>48</height>
+           </size>
+          </property>
+          <property name="checkable">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
        </layout>
       </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="Line" name="line_2">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="groupBox">
+     <property name="toolTip">
+      <string>Position from the 3D origin of the object in the view</string>
+     </property>
+     <property name="title">
+      <string>Section Plane Location</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout">
       <item>
-       <widget class="Line" name="line_2">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QLabel" name="label_3">
-        <property name="text">
-         <string>Section Plane Location</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <layout class="QFormLayout" name="formLayout">
-        <property name="fieldGrowthPolicy">
-         <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
-        </property>
+       <layout class="QGridLayout" name="gridLayout_2">
         <item row="0" column="0">
          <widget class="QLabel" name="label_10">
           <property name="sizePolicy">
-           <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
             <horstretch>0</horstretch>
             <verstretch>0</verstretch>
            </sizepolicy>
           </property>
           <property name="minimumSize">
            <size>
-            <width>150</width>
+            <width>0</width>
             <height>0</height>
            </size>
           </property>
           <property name="text">
            <string>X</string>
           </property>
-          <property name="alignment">
-           <set>Qt::AlignCenter</set>
-          </property>
          </widget>
         </item>
         <item row="0" column="1">
-         <widget class="Gui::QuantitySpinBox" name="sbOrgX">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>150</width>
-            <height>32</height>
-           </size>
-          </property>
-          <property name="toolTip">
-           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Location of section plane in 3D coordinates&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-          </property>
-          <property name="unit" stdset="0">
-           <string notr="true"/>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="label_11">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>150</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>Y</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignCenter</set>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="1">
-         <widget class="Gui::QuantitySpinBox" name="sbOrgY">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>150</width>
-            <height>32</height>
-           </size>
-          </property>
-          <property name="toolTip">
-           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Location of section plane in 3D coordinates&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-          </property>
-          <property name="unit" stdset="0">
-           <string notr="true"/>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="0">
-         <widget class="QLabel" name="label_12">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>150</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>Z</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignCenter</set>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="1">
-         <widget class="Gui::QuantitySpinBox" name="sbOrgZ">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>150</width>
-            <height>32</height>
-           </size>
-          </property>
-          <property name="toolTip">
-           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Location of section plane in 3D coordinates&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-          </property>
-          <property name="unit" stdset="0">
-           <string notr="true"/>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item>
-       <layout class="QGridLayout" name="gridLayout">
-        <item row="0" column="1">
-         <widget class="QPushButton" name="pbApply">
-          <property name="text">
-           <string>Apply</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="0">
-         <spacer name="horizontalSpacer">
+         <spacer name="horizontalSpacer_3">
           <property name="orientation">
            <enum>Qt::Horizontal</enum>
           </property>
@@ -422,32 +318,101 @@
          </spacer>
         </item>
         <item row="0" column="2">
-         <spacer name="horizontalSpacer_2">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
+         <widget class="Gui::QuantitySpinBox" name="sbOrgX">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
           </property>
-          <property name="sizeHint" stdset="0">
+          <property name="minimumSize">
            <size>
-            <width>40</width>
-            <height>20</height>
+            <width>150</width>
+            <height>22</height>
            </size>
           </property>
-         </spacer>
+          <property name="unit" stdset="0">
+           <string notr="true"/>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="0" colspan="2">
+         <widget class="QLabel" name="label_11">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>Y</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="2">
+         <widget class="Gui::QuantitySpinBox" name="sbOrgY">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>150</width>
+            <height>22</height>
+           </size>
+          </property>
+          <property name="unit" stdset="0">
+           <string notr="true"/>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="0" colspan="2">
+         <widget class="QLabel" name="label_12">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>Z</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="2">
+         <widget class="Gui::QuantitySpinBox" name="sbOrgZ">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>150</width>
+            <height>22</height>
+           </size>
+          </property>
+          <property name="unit" stdset="0">
+           <string notr="true"/>
+          </property>
+         </widget>
         </item>
        </layout>
-      </item>
-      <item>
-       <spacer name="verticalSpacer">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>20</width>
-          <height>40</height>
-         </size>
-        </property>
-       </spacer>
       </item>
      </layout>
     </widget>


### PR DESCRIPTION
- use uniformly Gui::QuantitySpinBox
- fix and uniform size of all objects in the dialog
- apply changes immediately once the section is created because this speeds up the workflow a lot, especially for when changing the plane position
- add missing tooltips
- some code cleanup: remove unused void, avoid unused variables

New dialog layout:
![FreeCAD_O2Ld1p4nhI](https://user-images.githubusercontent.com/1828501/77854329-f16d1d00-71e9-11ea-8c4b-64e446a5aa87.png)