### PR TITLE
[Not tested with Python 2.7] [AddonManager] Support for UTF8 characters in macros

### DIFF
--- a/src/Mod/AddonManager/AddonManager.py
+++ b/src/Mod/AddonManager/AddonManager.py
@@ -468,7 +468,7 @@ class CommandAddonManager:
                 macro_path = macro_path.replace("\\","/")
 
                 FreeCADGui.open(str(macro_path))
-                self.hide()
+                self.dialog.hide()
                 FreeCADGui.SendMsgToActiveView("Run")
         else:
             self.dialog.buttonExecute.setEnabled(False)

--- a/src/Mod/AddonManager/addonmanager_utilities.py
+++ b/src/Mod/AddonManager/addonmanager_utilities.py
@@ -23,6 +23,7 @@
 
 import os
 import sys
+import codecs
 import FreeCAD
 import shutil
 import re
@@ -173,13 +174,8 @@ def install_macro(macro, macro_repo_dir):
         except OSError:
             return False
     macro_path = os.path.join(macro_dir, macro.filename)
-    if sys.version_info.major < 3:
-        # In python2 the code is a bytes object.
-        mode = 'wb'
-    else:
-        mode = 'w'
     try:
-        with open(macro_path, mode) as macrofile:
+        with codecs.open(macro_path, 'w', 'utf-8') as macrofile:
             macrofile.write(macro.code)
     except IOError:
         return False


### PR DESCRIPTION
- [X] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [X] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

Add support for macros with UTF8 encoded characters by always writing macro code in an UTF8 file.
Also fix a bug in Execute function

I can't test with Python 2.7. Best if one can do it before merging.