### PR TITLE
[TD] weld symbols cannot be rotated

### DIFF
--- a/src/Mod/TechDraw/App/DrawWeldSymbol.cpp
+++ b/src/Mod/TechDraw/App/DrawWeldSymbol.cpp
@@ -62,6 +62,7 @@ DrawWeldSymbol::DrawWeldSymbol(void)
     Caption.setStatus(App::Property::Hidden,true);
     Scale.setStatus(App::Property::Hidden,true);
     ScaleType.setStatus(App::Property::Hidden,true);
+    Rotation.setStatus(App::Property::Hidden, true);
 }
 
 DrawWeldSymbol::~DrawWeldSymbol()


### PR DESCRIPTION
- therefore hide the Rotation property