### PR TITLE
Fix typos in Path WB

### DIFF
--- a/src/Mod/Path/PathScripts/PathAreaOp.py
+++ b/src/Mod/Path/PathScripts/PathAreaOp.py
@@ -511,7 +511,7 @@ class ObjectOp(PathOp.ObjectOp):
 
             # Raise to safe height if rotation activated
             self.commandlist.append(Path.Command('G0', {'Z': obj.SafeHeight.Value, 'F': self.vertRapid}))
-            # reset rotational axises if necessary
+            # reset rotational axes if necessary
             if resetAxis is True:
                 self.commandlist.append(Path.Command('G0', {'A': 0.0, 'F': self.axialRapid}))
                 self.commandlist.append(Path.Command('G0', {'B': 0.0, 'F': self.axialRapid}))

--- a/src/Mod/Path/PathScripts/PathDressupZCorrect.py
+++ b/src/Mod/Path/PathScripts/PathDressupZCorrect.py
@@ -47,7 +47,7 @@ else:
     PathLog.setLevel(PathLog.Level.NOTICE, LOG_MODULE)
 
 
-# Qt tanslation handling
+# Qt translation handling
 def translate(context, text, disambig=None):
     return QtCore.QCoreApplication.translate(context, text, disambig)
 

--- a/src/Mod/Path/PathScripts/PathProbe.py
+++ b/src/Mod/Path/PathScripts/PathProbe.py
@@ -44,7 +44,7 @@ else:
     PathLog.setLevel(PathLog.Level.INFO, PathLog.thisModule())
 
 
-# Qt tanslation handling
+# Qt translation handling
 def translate(context, text, disambig=None):
     return QtCore.QCoreApplication.translate(context, text, disambig)
 

--- a/src/Mod/Path/PathScripts/PathProbeGui.py
+++ b/src/Mod/Path/PathScripts/PathProbeGui.py
@@ -36,7 +36,7 @@ __url__ = "http://www.freecadweb.org"
 __doc__ = "Probing operation page controller and command implementation."
 
 
-# Qt tanslation handling
+# Qt translation handling
 def translate(context, text, disambig=None):
     return QtCore.QCoreApplication.translate(context, text, disambig)
 

--- a/src/Mod/Path/PathScripts/PathSurface.py
+++ b/src/Mod/Path/PathScripts/PathSurface.py
@@ -140,7 +140,7 @@ class ObjectSurface(PathOp.ObjectOp):
             ("App::PropertyVectorDistance", "CircularCenterCustom", "Clearing Options",
                 QtCore.QT_TRANSLATE_NOOP("App::Property", "Set the start point for circular cut patterns.")),
             ("App::PropertyEnumeration", "CircularCenterAt", "Clearing Options",
-                QtCore.QT_TRANSLATE_NOOP("App::Property", "Choose location of the center point for starting the ciruclar pattern.")),
+                QtCore.QT_TRANSLATE_NOOP("App::Property", "Choose location of the center point for starting the circular pattern.")),
             ("App::PropertyEnumeration", "CutMode", "Clearing Options",
                 QtCore.QT_TRANSLATE_NOOP("App::Property", "Set the direction for the cutting tool to engage the material: Climb (ClockWise) or Conventional (CounterClockWise)")),
             ("App::PropertyEnumeration", "CutPattern", "Clearing Options",

--- a/src/Mod/Path/PathScripts/PathWaterline.py
+++ b/src/Mod/Path/PathScripts/PathWaterline.py
@@ -122,7 +122,7 @@ class ObjectWaterline(PathOp.ObjectOp):
             ("App::PropertyVectorDistance", "CircularCenterCustom", "Clearing Options",
                 QtCore.QT_TRANSLATE_NOOP("App::Property", "Set the start point for circular cut patterns.")),
             ("App::PropertyEnumeration", "CircularCenterAt", "Clearing Options",
-                QtCore.QT_TRANSLATE_NOOP("App::Property", "Choose location of the center point for starting the ciruclar pattern.")),
+                QtCore.QT_TRANSLATE_NOOP("App::Property", "Choose location of the center point for starting the circular pattern.")),
             ("App::PropertyEnumeration", "ClearLastLayer", "Clearing Options",
                 QtCore.QT_TRANSLATE_NOOP("App::Property", "Set to clear last layer in a `Multi-pass` operation.")),
             ("App::PropertyEnumeration", "CutMode", "Clearing Options",
@@ -505,7 +505,7 @@ class ObjectWaterline(PathOp.ObjectOp):
                     PathLog.error('No data for model base: {}'.format(JOB.Model.Group[m].Label))
                 else:
                     if m > 0:
-                        # Raise to clearance between moddels
+                        # Raise to clearance between models
                         CMDS.append(Path.Command('N (Transition to base: {}.)'.format(Mdl.Label)))
                         CMDS.append(Path.Command('G0', {'Z': obj.ClearanceHeight.Value, 'F': self.vertRapid}))
                         PathLog.info('Working on Model.Group[{}]: {}'.format(m, Mdl.Label))
@@ -1168,7 +1168,7 @@ class ObjectWaterline(PathOp.ObjectOp):
 
     def _isPocket(self, b, f, w):
         '''_isPocket(b, f, w)... 
-        Attempts to determing if the wire(w) in face(f) of base(b) is a pocket or raised protrusion.
+        Attempts to determine if the wire(w) in face(f) of base(b) is a pocket or raised protrusion.
         Returns True if pocket, False if raised protrusion.'''
         e = w.Edges[0]
         for fi in range(0, len(b.Shape.Faces)):
@@ -2199,7 +2199,7 @@ class ObjectWaterline(PathOp.ObjectOp):
 
     def _getExperimentalWaterlinePaths(self, obj, PNTSET, csHght):
         '''_getExperimentalWaterlinePaths(obj, PNTSET, csHght)...
-        Switching fuction for calling the appropriate path-geometry to OCL points conversion fucntion
+        Switching function for calling the appropriate path-geometry to OCL points conversion function
         for the various cut patterns.'''
         PathLog.debug('_getExperimentalWaterlinePaths()')
         SCANS = list()

--- a/src/Mod/Path/libarea/kurve/geometry.h
+++ b/src/Mod/Path/libarea/kurve/geometry.h
@@ -604,7 +604,7 @@ inline bool FNEZ(double a, double tolerance = TIGHT_TOLERANCE) {return fabs(a) >
 	double	atn360(double dx, double dy);									// angle 0 to 2pi
 
 	// distance functions
-	//double Dist(double px, double py, double p1x, double p1y);				// diatance between 2 points (2d)
+	//double Dist(double px, double py, double p1x, double p1y);				// distance between 2 points (2d)
 	//double Dist(Point& p0, Point& p1);										// distance between 2 points (3d)
 	//double Dist(CLine& s, Point& p1);											// distance between cline & point
 


### PR DESCRIPTION
Found via  codespell v1.17.0.dev0
```
codespell -q 3 -L aci,ake,aline,alle,alledges,alocation,als,ang,anid,ba,beginn,behaviour,bloaded,byteorder,calculater,cancelled,cancelling,cas,cascade,centimetre,childs,colour,colours,commen,connexion,currenty,dof,doubleclick,dum,eiter,elemente,ende,feld,finde,findf,freez,hist,iff,indicies,initialisation,initialise,initialised,initialises,initialisiert,ist,kilometre,lod,mantatory,methode,metres,millimetre,modell,nd,noe,normale,normaly,nto,numer,oder,orgin,orginx,orginy,ot,pard,pres,programm,que,recurrance,rougly,seperator,serie,sinc,strack,substraction,te,thist,thru,tread,uint,unter,vertexes,wallthickness,whitespaces -S ./.git,*.po,*.ts,./ChangeLog.txt,./src/3rdParty,./src/Mod/Assembly/App/opendcm,./src/CXX,./src/zipios++,./src/Base/swig*,./src/Mod/Robot/App/kdl_cp,./src/Mod/Import/App/SCL,./src/WindowsInstaller,./src/Doc/FreeCAD.uml
```