### PR TITLE
Draft: Draft_Text split lines by newline characters

### DIFF
--- a/src/Mod/Draft/DraftGui.py
+++ b/src/Mod/Draft/DraftGui.py
@@ -1619,7 +1619,7 @@ class DraftToolBar:
         """this function sends the entered text to the active draft command
         if enter has been pressed twice. Otherwise it blanks the line.
         """
-        self.sourceCmd.text = self.textValue.toPlainText().split()
+        self.sourceCmd.text = self.textValue.toPlainText().splitlines()
         self.sourceCmd.createObject()
 
     def displayPoint(self, point=None, last=None, plane=None, mask=None):


### PR DESCRIPTION
In 1350da3f22, the Draft Text command was augmented with a `QTextEdit` widget, in order to enter full paragraphs of text.

However, currently the code splits the entire string by whitespace, including inter-word spaces, so it creates many lines of text.

In this pull request we use `splitlines()` to only split the lines by newline characters, so the resulting string is as we see it in the text box.

---

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists