### PR TITLE
[Path] Fix broken `Gui::QuantitySpinBox` class issues

### DIFF
--- a/src/Mod/Path/PathScripts/PathGui.py
+++ b/src/Mod/Path/PathScripts/PathGui.py
@@ -45,15 +45,16 @@ if LOGLEVEL:
 else:
     PathLog.setLevel(PathLog.Level.INFO, PathLog.thisModule())
 
+
 def updateInputField(obj, prop, widget, onBeforeChange=None):
     '''updateInputField(obj, prop, widget) ... update obj's property prop with the value of widget.
-The property's value is only assigned if the new value differs from the current value.
-This prevents onChanged notifications where the value didn't actually change.
-Gui::InputField and Gui::QuantitySpinBox widgets are supported - and the property can
-be of type Quantity or Float.
-If onBeforeChange is specified it is called before a new value is assigned to the property.
-Returns True if a new value was assigned, False otherwise (new value is the same as the current).
-'''
+    The property's value is only assigned if the new value differs from the current value.
+    This prevents onChanged notifications where the value didn't actually change.
+    Gui::InputField and Gui::QuantitySpinBox widgets are supported - and the property can
+    be of type Quantity or Float.
+    If onBeforeChange is specified it is called before a new value is assigned to the property.
+    Returns True if a new value was assigned, False otherwise (new value is the same as the current).
+    '''
     value = FreeCAD.Units.Quantity(widget.text()).Value
     attr = PathUtil.getProperty(obj, prop)
     attrValue = attr.Value if hasattr(attr, 'Value') else attr
@@ -86,17 +87,19 @@ Returns True if a new value was assigned, False otherwise (new value is the same
             onBeforeChange(obj)
         PathUtil.setProperty(obj, prop, value)
         return True
+
     return False
+
 
 class QuantitySpinBox:
     '''Controller class to interface a Gui::QuantitySpinBox.
-The spin box gets bound to a given property and supports update in both directions.
-   QuatitySpinBox(widget, obj, prop, onBeforeChange=None)
-        widget ... expected to be reference to a Gui::QuantitySpinBox
-        obj    ... document object
-        prop   ... canonical name of the (sub-) property
-        onBeforeChange ... an optional callback being executed before the value of the property is changed
-'''
+    The spin box gets bound to a given property and supports update in both directions.
+    QuatitySpinBox(widget, obj, prop, onBeforeChange=None)
+            widget ... expected to be reference to a Gui::QuantitySpinBox
+            obj    ... document object
+            prop   ... canonical name of the (sub-) property
+            onBeforeChange ... an optional callback being executed before the value of the property is changed
+    '''
 
     def __init__(self, widget, obj, prop, onBeforeChange=None):
         self.obj = obj
@@ -119,7 +122,7 @@ The spin box gets bound to a given property and supports update in both directio
         if self.valid:
             return self.widget.property('expression')
         return ''
-    
+
     def setMinimum(self, quantity):
         if self.valid:
             value = quantity.Value if hasattr(quantity, 'Value') else quantity
@@ -127,8 +130,8 @@ The spin box gets bound to a given property and supports update in both directio
 
     def updateSpinBox(self, quantity=None):
         '''updateSpinBox(quantity=None) ... update the display value of the spin box.
-If no value is provided the value of the bound property is used.
-quantity can be of type Quantity or Float.'''
+        If no value is provided the value of the bound property is used.
+        quantity can be of type Quantity or Float.'''
         if self.valid:
             if quantity is None:
                 quantity = PathUtil.getProperty(self.obj, self.prop)
@@ -140,4 +143,3 @@ quantity can be of type Quantity or Float.'''
         if self.valid:
             return updateInputField(self.obj, self.prop, self.widget, self.onBeforeChange)
         return None
-

--- a/src/Mod/Path/PathScripts/PathOpGui.py
+++ b/src/Mod/Path/PathScripts/PathOpGui.py
@@ -157,8 +157,6 @@ class ViewProvider(object):
         else:
             return ":/icons/Path-OpActive.svg"
 
-        #return self.OpIcon
-
     def getTaskPanelOpPage(self, obj):
         '''getTaskPanelOpPage(obj) ... use the stored information to instantiate the receiver op's page controller.'''
         mod = importlib.import_module(self.OpPageModule)
@@ -189,6 +187,7 @@ class ViewProvider(object):
         action = QtGui.QAction(translate('Path', 'Edit'), menu)
         action.triggered.connect(self.setEdit)
         menu.addAction(action)
+
 
 class TaskPanelPage(object):
     '''Base class for all task panel pages.'''
@@ -377,7 +376,7 @@ class TaskPanelPage(object):
         combo.clear()
         combo.addItems(options)
         combo.blockSignals(False)
-        
+
         if hasattr(obj, 'CoolantMode'):
             self.selectInComboBox(obj.CoolantMode, combo)
 
@@ -704,10 +703,13 @@ class TaskPanelDepthsPage(TaskPanelPage):
 
     def haveStartDepth(self):
         return PathOp.FeatureDepths & self.features
+
     def haveFinalDepth(self):
         return PathOp.FeatureDepths & self.features and not PathOp.FeatureNoFinalDepth & self.features
+
     def haveFinishDepth(self):
         return PathOp.FeatureDepths & self.features and PathOp.FeatureFinishDepth & self.features
+
     def haveStepDown(self):
         return PathOp.FeatureStepDown & self. features
 


### PR DESCRIPTION
Really, it is the associated `updateInputField()` function within the PathGui module that was the problem. It was not aware of changes to the expression, only the spinbox, as best I can tell.  Also, I added some PEP8 cleanup discovered during the troubleshooting process.

Forum discussion of problems at [It*s not possible to set Start Depth manualy](https://forum.freecadweb.org/viewtopic.php?style=3&f=15&t=44408).

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
