### PR TITLE
Fix Cloud module MacOS build and add self signed certificate support at build time

### DIFF
--- a/src/Mod/Cloud/App/AppCloud.cpp
+++ b/src/Mod/Cloud/App/AppCloud.cpp
@@ -212,6 +212,11 @@ void Cloud::CloudWriter::createBucket()
         // Let's build the Header and call to curl
         curl_global_init(CURL_GLOBAL_ALL);
         curl = curl_easy_init();
+#ifdef ALLOW_SELF_SIGNED_CERTIFICATE
+	curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0);
+	curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 0);
+#endif
+
         if ( curl )
         {
                 struct curl_slist *chunk = NULL;
@@ -390,6 +395,10 @@ Cloud::CloudWriter::CloudWriter(const char* Url, const char* AccessKey, const ch
         // Let's build the Header and call to curl
         curl_global_init(CURL_GLOBAL_ALL);
         curl = curl_easy_init();
+#ifdef ALLOW_SELF_SIGNED_CERTIFICATE
+        curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0);
+	curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 0);
+#endif
         if ( curl )
         {
                 // Let's build our own header
@@ -577,6 +586,10 @@ Cloud::CloudReader::CloudReader(const char* Url, const char* AccessKey, const ch
         	std::string s;
 	        RequestData = Cloud::ComputeDigestAmzS3v2("GET", "application/xml", path, this->SecretKey, NULL, 0);
 	        curl = curl_easy_init();
+#ifdef ALLOW_SELF_SIGNED_CERTIFICATE
+     		curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0);
+		curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 0);
+#endif
 	        if ( curl )
 	        {
 			// Let's build our own header
@@ -661,6 +674,10 @@ void Cloud::CloudReader::DownloadFile(Cloud::CloudReader::FileEntry *entry)
         // Let's build the Header and call to curl
         curl_global_init(CURL_GLOBAL_ALL);
         curl = curl_easy_init();
+#ifdef ALLOW_SELF_SIGNED_CERTIFICATE
+        curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0);
+	curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 0);
+#endif
         if ( curl )
         {
                 struct curl_slist *chunk = NULL;
@@ -771,6 +788,10 @@ void Cloud::CloudWriter::pushCloud(const char *FileName, const char *data, long 
         // Let's build the Header and call to curl
         curl_global_init(CURL_GLOBAL_ALL);
         curl = curl_easy_init();
+#ifdef ALLOW_SELF_SIGNED_CERTIFICATE
+        curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0);
+	curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 0);
+#endif
         if ( curl )
         {
                 struct curl_slist *chunk = NULL;

--- a/src/Mod/Cloud/App/CMakeLists.txt
+++ b/src/Mod/Cloud/App/CMakeLists.txt
@@ -11,7 +11,7 @@ include_directories(
 
 set(Cloud_LIBS
     FreeCADApp
-    ${OPENSSL_LIBRARIES}
+    ${OPENSSL_LINK_LIBRARIES}
     ${CURL_LIBRARIES}
     ${XercesC_LIBRARIES}
     ${Boost_LIBRARIES}

--- a/src/Mod/Cloud/CMakeLists.txt
+++ b/src/Mod/Cloud/CMakeLists.txt
@@ -1,8 +1,10 @@
+#----------------------------- Control certificate validation ------------
+option(ALLOW_SELF_SIGNED_CERTIFICATE "Allow self signed certificate" OFF)
+if (ALLOW_SELF_SIGNED_CERTIFICATE)
+add_compile_options("-DALLOW_SELF_SIGNED_CERTIFICATE")
+endif ()
 #------------------------------ OpenSSL and CURL -------------------------
-if (APPLE)
-    set(OPENSSL_ROOT_DIR ${HOMEBREW_PREFIX}/Cellar/openssl/*)
-endif(APPLE)
-if (UNIX AND NOT APPLE)
+if (UNIX AND APPLE)
     find_package(PkgConfig REQUIRED)
     pkg_search_module(OPENSSL REQUIRED openssl)
 elseif(WIN32 AND LIBPACK_FOUND)


### PR DESCRIPTION
Fix MacOS build with Catalina and latest homebrew
Add support for self signed certificate in the case the end user wants to use minio or any other self hosted s3 storage. This option is a build time option as it is UNSAFE but pretty useful for testing, debugging and self hosting.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
