### PR TITLE
[skip-ci] Various typo fixes

### DIFF
--- a/src/App/Part.h
+++ b/src/App/Part.h
@@ -70,7 +70,7 @@ public:
     //@{
     /** Base color of the Item
     If the transparency value is 1.0
-    the color or the next hierachy is used
+    the color or the next hierarchy is used
     */
     App::PropertyColor Color;
     //@}

--- a/src/Mod/Assembly/App/AppAssembly.cpp
+++ b/src/Mod/Assembly/App/AppAssembly.cpp
@@ -77,12 +77,12 @@ void AssemblyExport initAssembly()
     // call PyType_Ready, otherwise we run into a segmentation fault, later on.
     // This function is responsible for adding inherited slots from a type's base class.
  
-    // Item hirachy
+    // Item hierarchy
     Assembly::Item          ::init();
     Assembly::Product       ::init();
     Assembly::ProductRef    ::init();
 
-    // constraint hirachy
+    // constraint hierarchy
     Assembly::Constraint        ::init();
     Assembly::ConstraintGroup   ::init();
 }

--- a/src/Mod/Assembly/App/Product.h
+++ b/src/Mod/Assembly/App/Product.h
@@ -68,7 +68,7 @@ public:
     //@{
     /** Base color of the Item
         If the transparency value is 1.0
-        the color or the next hierachy is used
+        the color or the next hierarchy is used
         */
     App::PropertyColor Color;
     /// Visibility

--- a/src/Mod/PartDesign/Gui/ViewProviderDatum.h
+++ b/src/Mod/PartDesign/Gui/ViewProviderDatum.h
@@ -94,7 +94,7 @@ public:
      * Computes appropriate bounding box for the given list of objects to be passed to setExtents ()
      * @param bboxAction  a coin action for traverse the given objects views.
      * @param objs        the list of objects to traverse, due to we traverse the scene graph, the geo children
-     *                    will likely be traveresed too.
+     *                    will likely be traversed too.
      */
     static SbBox3f getRelevantBoundBox (
             SoGetBoundingBoxAction &bboxAction,

--- a/src/Mod/Path/App/ParamsHelper.h
+++ b/src/Mod/Path/App/ParamsHelper.h
@@ -119,7 +119,7 @@
  *
  * - \c default is the default value of this parameter. Right now, you must
  *   supply a default value. Boost.PP has trouble dealing with empty values.
- *   Remember that a sequence cannot be empty. Neight can tuple. Only array,
+ *   Remember that a sequence cannot be empty. Neither can tuple. Only array,
  *   something like <tt>(0,())</tt> for an empty array. It is awkward to write,
  *   and didn't add much functionality I want, hence the restriction of
  *   non-empty defaults here.

--- a/src/Mod/Spreadsheet/App/PropertySheet.cpp
+++ b/src/Mod/Spreadsheet/App/PropertySheet.cpp
@@ -1067,7 +1067,7 @@ void PropertySheet::removeDependencies(CellAddress key)
 void PropertySheet::recomputeDependants(const App::DocumentObject *owner, const char *propName)
 {
     // First, search without actual property name for sub-object/link
-    // references, i.e indirect references. The depenedecies of these
+    // references, i.e indirect references. The dependencies of these
     // references are too complex to track exactly, so we only track the
     // top parent object instead, and mark the involved expression
     // whenever the top parent changes.

--- a/src/Mod/TechDraw/Gui/TaskWeldingSymbol.cpp
+++ b/src/Mod/TechDraw/Gui/TaskWeldingSymbol.cpp
@@ -376,7 +376,7 @@ void TaskWeldingSymbol::onFlipSidesClicked()
     ui->leOtherTextR->setText(ui->leArrowTextR->text());
     ui->leArrowTextR->setText(tempText);
 
-    // one cannot get the path from the icon therfore read out
+    // one cannot get the path from the icon therefore read out
     // the path property
     auto tempPathArrow = m_arrowFeat->SymbolFile.getValue();
     auto tempPathOther = m_otherFeat->SymbolFile.getValue();


### PR DESCRIPTION
Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
---
Found via codespell  v1.17.0.dev0  
```
codespell -q 3 -L aci,ake,aline,alle,alledges,alocation,als,ang,anid,ba,beginn,behaviour,bloaded,byteorder,calculater,cancelled,cancelling,cas,cascade,centimetre,childs,colour,colours,commen,connexion,currenty,dof,doubleclick,dum,eiter,elemente,ende,feld,finde,findf,freez,hist,iff,indicies,initialisation,initialise,initialised,initialises,initialisiert,ist,kilometre,lod,mantatory,methode,metres,millimetre,modell,nd,noe,normale,normaly,nto,numer,oder,orgin,orginx,orginy,ot,pard,pres,programm,que,recurrance,rougly,seperator,serie,sinc,strack,substraction,te,thist,thru,tread,uint,unter,vertexes,wallthickness,whitespaces -S ./.git,*.po,*.ts,./ChangeLog.txt,./src/3rdParty,./src/Mod/Assembly/App/opendcm,./src/CXX,./src/zipios++,./src/Base/swig*,./src/Mod/Robot/App/kdl_cp,./src/Mod/Import/App/SCL,./src/WindowsInstaller,./src/Doc/FreeCAD.uml
```
