### PR TITLE
[PartDesign] Remove 'Set tip' from Body contextual menu ; fixes #4304

### DIFF
--- a/src/Mod/PartDesign/Gui/Workbench.cpp
+++ b/src/Mod/PartDesign/Gui/Workbench.cpp
@@ -175,7 +175,6 @@ void Workbench::setupContextMenu(const char* recipient, Gui::MenuItem* item) con
         body = PartDesignGui::getBodyFor (feature, false, false, assertModern);
         // lote of assertion so feature should be marked as a tip
         if ( selection.size () == 1 && feature && (
-            feature->isDerivedFrom ( PartDesign::Body::getClassTypeId () ) ||
             ( feature->isDerivedFrom ( PartDesign::Feature::getClassTypeId () ) && body ) ||
             ( feature->isDerivedFrom ( Part::Feature::getClassTypeId () ) && body &&
               body->BaseFeature.getValue() == feature )


### PR DESCRIPTION
- [X] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [X] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [X] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

https://forum.freecadweb.org/viewtopic.php?f=3&t=44969