### PR TITLE
[Expression] Default to current 'constant' value when editing if no e…

### DIFF
--- a/src/Gui/DlgExpressionInput.cpp
+++ b/src/Gui/DlgExpressionInput.cpp
@@ -55,14 +55,20 @@ DlgExpressionInput::DlgExpressionInput(const App::ObjectIdentifier & _path,
     // Setup UI
     ui->setupUi(this);
 
-    if (expression) {
-        ui->expression->setText(Base::Tools::fromStdString(expression->toString()));
-        textChanged(Base::Tools::fromStdString(expression->toString()));
-    }
-
     // Connect signal(s)
     connect(ui->expression, SIGNAL(textChanged(QString)), this, SLOT(textChanged(QString)));
     connect(ui->discardBtn, SIGNAL(clicked()), this, SLOT(setDiscarded()));
+    
+    if (expression) {
+        ui->expression->setText(Base::Tools::fromStdString(expression->toString()));
+    }
+    else
+    {
+        QAbstractSpinBox *sb = dynamic_cast<QAbstractSpinBox*>(parent);
+        if (sb) {
+            ui->expression->setText(sb->text());
+        }
+    }
 
     // Set document object on line edit to create auto completer
     DocumentObject * docObj = path.getDocumentObject();


### PR DESCRIPTION
if no expression set yet ; fixes #4298

- [X] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [X] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [X] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

https://forum.freecadweb.org/viewtopic.php?f=8&t=44670