### PR TITLE
Resolve SyntaxWarning literal comparison in py3.8

### DIFF
--- a/src/Mod/Fem/femexamples/manager.py
+++ b/src/Mod/Fem/femexamples/manager.py
@@ -67,7 +67,7 @@ def run_analysis(doc, base_name, filepath=""):
     # print([obj.Name for obj in doc.Objects])
 
     # filepath
-    if filepath is "":
+    if filepath == "":
         filepath = join(gettmp(), "FEM_examples")
     if not exists(filepath):
         makedirs(filepath)
@@ -78,7 +78,7 @@ def run_analysis(doc, base_name, filepath=""):
         from femtools.femutils import is_derived_from
         if (
             is_derived_from(m, "Fem::FemSolverObjectPython")
-            and m.Proxy.Type is not "Fem::FemSolverCalculixCcxTools"
+            and m.Proxy.Type != "Fem::FemSolverCalculixCcxTools"
         ):
             solver = m
             break

--- a/src/Mod/Fem/feminout/importFenicsMesh.py
+++ b/src/Mod/Fem/feminout/importFenicsMesh.py
@@ -186,7 +186,7 @@ def export(objectslist, fileString, group_values_dict_nogui=None):
             writeFenicsXML.write_fenics_mesh_xml(obj, fileString)
         elif fileExtension.lower() == ".xdmf":
             mesh_groups = importToolsFem.get_FemMeshObjectMeshGroups(obj)
-            if mesh_groups is not ():
+            if mesh_groups != ():
                 # if there are groups found, make task panel available if GuiUp
                 if FreeCAD.GuiUp == 1:
                     panel = WriteXDMFTaskPanel(obj, fileString)

--- a/src/Mod/Fem/feminout/writeFenicsXDMF.py
+++ b/src/Mod/Fem/feminout/writeFenicsXDMF.py
@@ -317,7 +317,7 @@ def write_fenics_mesh_xdmf(
     fem_mesh = fem_mesh_obj.FemMesh
     gmshgroups = get_FemMeshObjectMeshGroups(fem_mesh_obj)
 
-    if gmshgroups is not ():
+    if gmshgroups != ():
         Console.PrintMessage("found mesh groups\n")
 
     for g in gmshgroups:


### PR DESCRIPTION
Comparison with literals should be done using != and == and not 'is
not' and 'is'.
Found the files using:
find . -name \*.py -exec pylint --disable=all --enable=R0123 --score=no {} \;

Python 3.8 prints out SyntaxWarnings when reading the files, this
would happen for example on every installation.

See also https://forum.freecadweb.org/viewtopic.php?f=3&t=42855&start=20#p385168

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
