### PR TITLE
[Path] Use lazyloader for deferred python imports

### DIFF
--- a/src/3rdParty/CMakeLists.txt
+++ b/src/3rdParty/CMakeLists.txt
@@ -2,3 +2,5 @@
 if (BUILD_SMESH AND NOT FREECAD_USE_EXTERNAL_SMESH)
     add_subdirectory(salomesmesh)
 endif()
+
+add_subdirectory(lazy_loader)

--- a/src/3rdParty/lazy_loader/CMakeLists.txt
+++ b/src/3rdParty/lazy_loader/CMakeLists.txt
@@ -1,0 +1,12 @@
+SET(lazy_loader
+    lazy_loader.py
+    __init__.py
+)
+add_custom_target(lazy_loader ALL SOURCES
+    ${lazy_loader}
+)
+SET_PYTHON_PREFIX_SUFFIX(lazy_loader)
+
+fc_copy_sources(lazy_loader "${CMAKE_BINARY_DIR}/Ext/lazy_loader" ${lazy_loader})
+install (FILES ${lazy_loader} DESTINATION "${CMAKE_INSTALL_PREFIX}/Ext/lazy_loader")
+

--- a/src/3rdParty/lazy_loader/__init__.py
+++ b/src/3rdParty/lazy_loader/__init__.py
@@ -1,0 +1,13 @@
+"""
+LazyLoader will defer import of a module until first usage. Usage:
+from lazy_loader.lazy_loader import LazyLoader
+numpy = LazyLoader("numpy", globals(), "numpy")
+
+or
+
+whatever = LazyLoader("module", globals(), "module.whatever")
+
+or to replicate import module as something
+
+something = LazyLoader("module", globals(), "module")
+"""

--- a/src/3rdParty/lazy_loader/lazy_loader.py
+++ b/src/3rdParty/lazy_loader/lazy_loader.py
@@ -1,0 +1,60 @@
+# Copyright 2015 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""A LazyLoader class."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import importlib
+import types
+
+
+class LazyLoader(types.ModuleType):
+  """Lazily import a module, mainly to avoid pulling in large dependencies.
+
+  `contrib`, and `ffmpeg` are examples of modules that are large and not always
+  needed, and this allows them to only be loaded when they are used.
+  """
+
+  # The lint error here is incorrect.
+  def __init__(self, local_name, parent_module_globals, name, warning=None):  # pylint: disable=super-on-old-class
+    self._local_name = local_name
+    self._parent_module_globals = parent_module_globals
+    self._warning = warning
+
+    super(LazyLoader, self).__init__(name)
+
+  def _load(self):
+    """Load the module and insert it into the parent's globals."""
+    # Import the target module and insert it into the parent's namespace
+    module = importlib.import_module(self.__name__)
+    self._parent_module_globals[self._local_name] = module
+
+    # Update this object's dict so that if someone keeps a reference to the
+    #   LazyLoader, lookups are efficient (__getattr__ is only called on lookups
+    #   that fail).
+    self.__dict__.update(module.__dict__)
+
+    return module
+
+  def __getattr__(self, item):
+    module = self._load()
+    return getattr(module, item)
+
+  def __dir__(self):
+    module = self._load()
+    return dir(module)

--- a/src/Mod/Path/PathScripts/PathAreaOp.py
+++ b/src/Mod/Path/PathScripts/PathAreaOp.py
@@ -28,9 +28,12 @@ import PathScripts.PathLog as PathLog
 import PathScripts.PathOp as PathOp
 import PathScripts.PathUtils as PathUtils
 import PathScripts.PathGeom as PathGeom
-import Draft
 import math
-import Part
+
+# lazily loaded modules
+from lazy_loader.lazy_loader import LazyLoader
+Draft = LazyLoader('Draft', globals(), 'Draft')
+Part = LazyLoader('Part', globals(), 'Part')
 
 # from PathScripts.PathUtils import waiting_effects
 from PySide import QtCore

--- a/src/Mod/Path/PathScripts/PathCircularHoleBase.py
+++ b/src/Mod/Path/PathScripts/PathCircularHoleBase.py
@@ -28,10 +28,7 @@
 # *                                                                         *
 # ***************************************************************************
 
-import ArchPanel
 import FreeCAD
-import DraftGeomUtils
-import Part
 import PathScripts.PathLog as PathLog
 import PathScripts.PathOp as PathOp
 import PathScripts.PathUtils as PathUtils
@@ -39,8 +36,14 @@ import PathScripts.PathUtils as PathUtils
 from PySide import QtCore
 import PathScripts.PathGeom as PathGeom
 
+# lazily loaded modules
+from lazy_loader.lazy_loader import LazyLoader
+ArchPanel = LazyLoader('ArchPanel', globals(), 'ArchPanel')
+Draft = LazyLoader('Draft', globals(), 'Draft')
+Part = LazyLoader('Part', globals(), 'Part')
+DraftGeomUtils = LazyLoader('DraftGeomUtils', globals(), 'DraftGeomUtils')
+
 import math
-import Draft
 if FreeCAD.GuiUp:
     import FreeCADGui
 

--- a/src/Mod/Path/PathScripts/PathDeburr.py
+++ b/src/Mod/Path/PathScripts/PathDeburr.py
@@ -24,7 +24,6 @@
 # ***************************************************************************
 
 import FreeCAD
-import Part
 import PathScripts.PathEngraveBase as PathEngraveBase
 import PathScripts.PathLog as PathLog
 import PathScripts.PathOp as PathOp
@@ -32,6 +31,10 @@ import PathScripts.PathOpTools as PathOpTools
 import math
 
 from PySide import QtCore
+
+# lazily loaded modules
+from lazy_loader.lazy_loader import LazyLoader
+Part = LazyLoader('Part', globals(), 'Part')
 
 __title__ = "Path Deburr Operation"
 __author__ = "sliptonic (Brad Collette), Schildkroet"

--- a/src/Mod/Path/PathScripts/PathDressupDogbone.py
+++ b/src/Mod/Path/PathScripts/PathDressupDogbone.py
@@ -22,10 +22,8 @@
 # *                                                                         *
 # ***************************************************************************
 from __future__ import print_function
-import DraftGeomUtils
 import FreeCAD
 import math
-import Part
 import Path
 import PathScripts.PathDressup as PathDressup
 import PathScripts.PathGeom as PathGeom
@@ -34,6 +32,11 @@ import PathScripts.PathUtil as PathUtil
 import PathScripts.PathUtils as PathUtils
 
 from PySide import QtCore
+
+# lazily loaded modules
+from lazy_loader.lazy_loader import LazyLoader
+DraftDraftGeomUtils = LazyLoader('DraftDraftGeomUtils', globals(), 'DraftDraftGeomUtils')
+Part = LazyLoader('Part', globals(), 'Part')
 
 LOG_MODULE = PathLog.thisModule()
 

--- a/src/Mod/Path/PathScripts/PathDressupDragknife.py
+++ b/src/Mod/Path/PathScripts/PathDressupDragknife.py
@@ -27,8 +27,11 @@ import FreeCAD
 import Path
 from PySide import QtCore
 import math
-import DraftVecUtils as D
 import PathScripts.PathUtils as PathUtils
+
+# lazily loaded modules
+from lazy_loader.lazy_loader import LazyLoader
+D = LazyLoader('DraftVecUtils', globals(), 'DraftVecUtils')
 
 __doc__ = """Dragknife Dressup object and FreeCAD command"""
 

--- a/src/Mod/Path/PathScripts/PathDressupHoldingTags.py
+++ b/src/Mod/Path/PathScripts/PathDressupHoldingTags.py
@@ -22,7 +22,6 @@
 # *                                                                         *
 # ***************************************************************************
 import FreeCAD
-import Part
 import Path
 import PathScripts.PathDressup as PathDressup
 import PathScripts.PathGeom as PathGeom
@@ -35,6 +34,10 @@ import math
 from PathScripts.PathDressupTagPreferences import HoldingTagPreferences
 from PathScripts.PathUtils import waiting_effects
 from PySide import QtCore
+
+# lazily loaded modules
+from lazy_loader.lazy_loader import LazyLoader
+Part = LazyLoader('Part', globals(), 'Part')
 
 PathLog.setLevel(PathLog.Level.INFO, PathLog.thisModule())
 #PathLog.trackModule()

--- a/src/Mod/Path/PathScripts/PathDressupRampEntry.py
+++ b/src/Mod/Path/PathScripts/PathDressupRampEntry.py
@@ -23,7 +23,6 @@
 # ***************************************************************************
 import FreeCAD
 import Path
-import Part
 import PathScripts.PathDressup as PathDressup
 import PathScripts.PathGeom as PathGeom
 import PathScripts.PathLog as PathLog
@@ -31,6 +30,10 @@ import math
 
 from PathScripts import PathUtils
 from PySide import QtCore
+
+# lazily loaded modules
+from lazy_loader.lazy_loader import LazyLoader
+Part = LazyLoader('Part', globals(), 'Part')
 
 if FreeCAD.GuiUp:
     import FreeCADGui

--- a/src/Mod/Path/PathScripts/PathDressupTag.py
+++ b/src/Mod/Path/PathScripts/PathDressupTag.py
@@ -22,13 +22,16 @@
 # *                                                                         *
 # ***************************************************************************
 import FreeCAD
-import DraftGeomUtils
-import Part
 import PathScripts.PathDressup as PathDressup
 import PathScripts.PathGeom as PathGeom
 import PathScripts.PathLog as PathLog
 import PathScripts.PathUtils as PathUtils
 import math
+
+# lazily loaded modules
+from lazy_loader.lazy_loader import LazyLoader
+DraftGeomUtils = LazyLoader('DraftGeomUtils', globals(), 'DraftGeomUtils')
+Part = LazyLoader('Part', globals(), 'Part')
 
 from PathScripts.PathDressupTagPreferences import HoldingTagPreferences
 from PySide import QtCore

--- a/src/Mod/Path/PathScripts/PathDressupZCorrect.py
+++ b/src/Mod/Path/PathScripts/PathDressupZCorrect.py
@@ -27,13 +27,16 @@
 # ***************************************************************************
 import FreeCAD
 import FreeCADGui
-import Part
 import Path
 import PathScripts.PathGeom as PathGeom
 import PathScripts.PathLog as PathLog
 import PathScripts.PathUtils as PathUtils
 
 from PySide import QtCore, QtGui
+
+# lazily loaded modules
+from lazy_loader.lazy_loader import LazyLoader
+Part = LazyLoader('Part', globals(), 'Part')
 
 """Z Depth Correction Dressup.  This dressup takes a probe file as input and does bilinear interpolation of the Zdepths to correct for a surface which is not parallel to the milling table/bed.  The probe file should conform to the format specified by the linuxcnc G38 probe logging: 9-number coordinate consisting of XYZABCUVW http://linuxcnc.org/docs/html/gcode/g-code.html#gcode:g38
 """

--- a/src/Mod/Path/PathScripts/PathEngrave.py
+++ b/src/Mod/Path/PathScripts/PathEngrave.py
@@ -22,9 +22,7 @@
 # *                                                                         *
 # ***************************************************************************
 
-import ArchPanel
 import FreeCAD
-import Part
 import Path
 import PathScripts.PathEngraveBase as PathEngraveBase
 import PathScripts.PathLog as PathLog
@@ -32,6 +30,11 @@ import PathScripts.PathOp as PathOp
 import PathScripts.PathUtils as PathUtils
 
 from PySide import QtCore
+
+# lazily loaded modules
+from lazy_loader.lazy_loader import LazyLoader
+ArchPanel = LazyLoader('ArchPanel', globals(), 'ArchPanel')
+Part = LazyLoader('Part', globals(), 'Part')
 
 __doc__ = "Class and implementation of Path Engrave operation"
 

--- a/src/Mod/Path/PathScripts/PathEngraveBase.py
+++ b/src/Mod/Path/PathScripts/PathEngraveBase.py
@@ -22,13 +22,16 @@
 # *                                                                         *
 # ***************************************************************************
 
-import DraftGeomUtils
 import Path
 import PathScripts.PathGeom as PathGeom
 import PathScripts.PathLog as PathLog
 import PathScripts.PathOp as PathOp
 import PathScripts.PathOpTools as PathOpTools
 import copy
+
+# lazily loaded modules
+from lazy_loader.lazy_loader import LazyLoader
+DraftGeomUtils = LazyLoader('DraftGeomUtils', globals(), 'DraftGeomUtils')
 
 from PySide import QtCore
 

--- a/src/Mod/Path/PathScripts/PathGeom.py
+++ b/src/Mod/Path/PathScripts/PathGeom.py
@@ -23,13 +23,16 @@
 # ***************************************************************************
 
 import FreeCAD
-import Part
 import Path
 import PathScripts.PathLog as PathLog
 import math
 
 from FreeCAD import Vector
 from PySide import QtCore
+
+# lazily loaded modules
+from lazy_loader.lazy_loader import LazyLoader
+Part = LazyLoader('Part', globals(), 'Part')
 
 __title__ = "PathGeom - geometry utilities for Path"
 __author__ = "sliptonic (Brad Collette)"

--- a/src/Mod/Path/PathScripts/PathGetPoint.py
+++ b/src/Mod/Path/PathScripts/PathGetPoint.py
@@ -22,10 +22,13 @@
 # *                                                                         *
 # ***************************************************************************
 
-import Draft
 import FreeCAD
 import FreeCADGui
 import PathScripts.PathLog as PathLog
+
+# lazily loaded modules
+from lazy_loader.lazy_loader import LazyLoader
+Draft = LazyLoader('Draft', globals(), 'Draft')
 
 from PySide import QtCore, QtGui
 from pivy import coin

--- a/src/Mod/Path/PathScripts/PathJob.py
+++ b/src/Mod/Path/PathScripts/PathJob.py
@@ -22,8 +22,6 @@
 # *                                                                         *
 # ***************************************************************************
 
-import ArchPanel
-import Draft
 import FreeCAD
 import PathScripts.PathIconViewProvider as PathIconViewProvider
 import PathScripts.PathLog as PathLog
@@ -33,6 +31,11 @@ import PathScripts.PathStock as PathStock
 import PathScripts.PathToolController as PathToolController
 import PathScripts.PathUtil as PathUtil
 import json
+
+# lazily loaded modules
+from lazy_loader.lazy_loader import LazyLoader
+ArchPanel = LazyLoader('ArchPanel', globals(), 'ArchPanel')
+Draft = LazyLoader('Draft', globals(), 'Draft')
 
 from PathScripts.PathPostProcessor import PostProcessor
 from PySide import QtCore

--- a/src/Mod/Path/PathScripts/PathJobGui.py
+++ b/src/Mod/Path/PathScripts/PathJobGui.py
@@ -22,8 +22,6 @@
 # *                                                                         *
 # ***************************************************************************
 
-import Draft
-import DraftVecUtils
 import FreeCAD
 import FreeCADGui
 import PathScripts.PathJob as PathJob
@@ -41,6 +39,11 @@ import PathScripts.PathUtil as PathUtil
 import PathScripts.PathUtils as PathUtils
 import math
 import traceback
+
+# lazily loaded modules
+from lazy_loader.lazy_loader import LazyLoader
+Draft = LazyLoader('Draft', globals(), 'Draft')
+DraftVecUtils = LazyLoader('DraftVecUtils', globals(), 'DraftVecUtils')
 
 from PySide import QtCore, QtGui
 from collections import Counter

--- a/src/Mod/Path/PathScripts/PathMillFace.py
+++ b/src/Mod/Path/PathScripts/PathMillFace.py
@@ -25,13 +25,16 @@
 from __future__ import print_function
 
 import FreeCAD
-import Part
 import PathScripts.PathLog as PathLog
 import PathScripts.PathPocketBase as PathPocketBase
 import PathScripts.PathUtils as PathUtils
 
 from PySide import QtCore
 import numpy
+
+# lazily loaded modules
+from lazy_loader.lazy_loader import LazyLoader
+Part = LazyLoader('Part', globals(), 'Part')
 
 __title__ = "Path Mill Face Operation"
 __author__ = "sliptonic (Brad Collette)"

--- a/src/Mod/Path/PathScripts/PathOp.py
+++ b/src/Mod/Path/PathScripts/PathOp.py
@@ -23,7 +23,6 @@
 # ***************************************************************************
 
 import FreeCAD
-import Part
 import Path
 import PathScripts.PathGeom as PathGeom
 import PathScripts.PathLog as PathLog
@@ -32,6 +31,10 @@ import PathScripts.PathUtils as PathUtils
 
 from PathScripts.PathUtils import waiting_effects
 from PySide import QtCore
+
+# lazily loaded modules
+from lazy_loader.lazy_loader import LazyLoader
+Part = LazyLoader('Part', globals(), 'Part')
 
 __title__ = "Base class for all operations."
 __author__ = "sliptonic (Brad Collette)"

--- a/src/Mod/Path/PathScripts/PathOpTools.py
+++ b/src/Mod/Path/PathScripts/PathOpTools.py
@@ -23,12 +23,15 @@
 # ***************************************************************************
 
 import FreeCAD
-import Part
 import PathScripts.PathGeom as PathGeom
 import PathScripts.PathLog as PathLog
 import math
 
 from PySide import QtCore
+
+# lazily loaded modules
+from lazy_loader.lazy_loader import LazyLoader
+Part = LazyLoader('Part', globals(), 'Part')
 
 __title__ = "PathOpTools - Tools for Path operations."
 __author__ = "sliptonic (Brad Collette)"

--- a/src/Mod/Path/PathScripts/PathPocket.py
+++ b/src/Mod/Path/PathScripts/PathPocket.py
@@ -23,13 +23,16 @@
 # ***************************************************************************
 
 import FreeCAD
-import Part
 import PathScripts.PathLog as PathLog
 import PathScripts.PathOp as PathOp
 import PathScripts.PathPocketBase as PathPocketBase
 import PathScripts.PathUtils as PathUtils
 
 from PySide import QtCore
+
+# lazily loaded modules
+from lazy_loader.lazy_loader import LazyLoader
+Part = LazyLoader('Part', globals(), 'Part')
 
 __title__ = "Path 3D Pocket Operation"
 __author__ = "Yorik van Havre <yorik@uncreated.net>"

--- a/src/Mod/Path/PathScripts/PathPocketShape.py
+++ b/src/Mod/Path/PathScripts/PathPocketShape.py
@@ -24,15 +24,18 @@
 # ***************************************************************************
 
 import FreeCAD
-import Part
 import PathScripts.PathGeom as PathGeom
 import PathScripts.PathLog as PathLog
 import PathScripts.PathOp as PathOp
 import PathScripts.PathPocketBase as PathPocketBase
 import PathScripts.PathUtils as PathUtils
-import TechDraw
 import math
-import Draft
+
+# lazily loaded modules
+from lazy_loader.lazy_loader import LazyLoader
+Draft = LazyLoader('Draft', globals(), 'Draft')
+Part = LazyLoader('Part', globals(), 'Part')
+TechDraw = LazyLoader('TechDraw', globals(), 'TechDraw')
 
 from PySide import QtCore
 

--- a/src/Mod/Path/PathScripts/PathPocketShapeGui.py
+++ b/src/Mod/Path/PathScripts/PathPocketShapeGui.py
@@ -24,7 +24,6 @@
 
 import FreeCAD
 import FreeCADGui
-import Part
 import PathScripts.PathGeom as PathGeom
 import PathScripts.PathGui as PathGui
 import PathScripts.PathLog as PathLog
@@ -34,6 +33,10 @@ import PathScripts.PathPocketBaseGui as PathPocketBaseGui
 
 from PySide import QtCore, QtGui
 from pivy import coin
+
+# lazily loaded modules
+from lazy_loader.lazy_loader import LazyLoader
+Part = LazyLoader('Part', globals(), 'Part')
 
 __title__ = "Path Pocket Shape Operation UI"
 __author__ = "sliptonic (Brad Collette)"

--- a/src/Mod/Path/PathScripts/PathProfileContour.py
+++ b/src/Mod/Path/PathScripts/PathProfileContour.py
@@ -24,15 +24,18 @@
 
 from __future__ import print_function
 
-import ArchPanel
 import FreeCAD
-import Part
 import Path
 import PathScripts.PathProfileBase as PathProfileBase
 import PathScripts.PathLog as PathLog
 
 from PathScripts import PathUtils
 from PySide import QtCore
+
+# lazily loaded modules
+from lazy_loader.lazy_loader import LazyLoader
+ArchPanel = LazyLoader('ArchPanel', globals(), 'ArchPanel')
+Part = LazyLoader('Part', globals(), 'Part')
 
 FreeCAD.setLogLevel('Path.Area', 0)
 

--- a/src/Mod/Path/PathScripts/PathProfileEdges.py
+++ b/src/Mod/Path/PathScripts/PathProfileEdges.py
@@ -23,17 +23,20 @@
 # ***************************************************************************
 
 import FreeCAD
-import Part
 import Path
 import PathScripts.PathLog as PathLog
 import PathScripts.PathOp as PathOp
 import PathScripts.PathProfileBase as PathProfileBase
 import PathScripts.PathUtils as PathUtils
 
-import DraftGeomUtils
-import Draft
 import math
 import PySide
+
+# lazily loaded modules
+from lazy_loader.lazy_loader import LazyLoader
+Draft = LazyLoader('Draft', globals(), 'Draft')
+Part = LazyLoader('Part', globals(), 'Part')
+DraftGeomUtils = LazyLoader('DraftGeomUtils', globals(), 'DraftGeomUtils')
 
 PathLog.setLevel(PathLog.Level.INFO, PathLog.thisModule())
 # PathLog.trackModule(PathLog.thisModule())

--- a/src/Mod/Path/PathScripts/PathProfileFaces.py
+++ b/src/Mod/Path/PathScripts/PathProfileFaces.py
@@ -23,9 +23,7 @@
 # *                                                                         *
 # ***************************************************************************
 
-import ArchPanel
 import FreeCAD
-import Part
 import Path
 import PathScripts.PathLog as PathLog
 import PathScripts.PathOp as PathOp
@@ -34,6 +32,11 @@ import PathScripts.PathUtils as PathUtils
 import numpy
 
 from PySide import QtCore
+
+# lazily loaded modules
+from lazy_loader.lazy_loader import LazyLoader
+ArchPanel = LazyLoader('ArchPanel', globals(), 'ArchPanel')
+Part = LazyLoader('Part', globals(), 'Part')
 
 __title__ = "Path Profile Faces Operation"
 __author__ = "sliptonic (Brad Collette), Schildkroet"

--- a/src/Mod/Path/PathScripts/PathSimulatorGui.py
+++ b/src/Mod/Path/PathScripts/PathSimulatorGui.py
@@ -1,6 +1,4 @@
 import FreeCAD
-import Mesh
-import Part
 import Path
 import PathScripts.PathDressup as PathDressup
 import PathScripts.PathGeom as PathGeom
@@ -12,6 +10,11 @@ import os
 from FreeCAD import Vector, Base
 
 _filePath = os.path.dirname(os.path.abspath(__file__))
+
+# lazily loaded modules
+from lazy_loader.lazy_loader import LazyLoader
+Mesh = LazyLoader('Mesh', globals(), 'Mesh')
+Part = LazyLoader('Part', globals(), 'Part')
 
 if FreeCAD.GuiUp:
     import FreeCADGui

--- a/src/Mod/Path/PathScripts/PathStock.py
+++ b/src/Mod/Path/PathScripts/PathStock.py
@@ -23,12 +23,15 @@
 '''used to create material stock around a machined part- for visualization '''
 
 import FreeCAD
-import Part
 import PathScripts.PathIconViewProvider as PathIconViewProvider
 import PathScripts.PathLog as PathLog
 import math
 
 from PySide import QtCore
+
+# lazily loaded modules
+from lazy_loader.lazy_loader import LazyLoader
+Part = LazyLoader('Part', globals(), 'Part')
 
 PathLog.setLevel(PathLog.Level.INFO, PathLog.thisModule())
 #PathLog.trackModule(PathLog.thisModule())

--- a/src/Mod/Path/PathScripts/PathSurface.py
+++ b/src/Mod/Path/PathScripts/PathSurface.py
@@ -30,7 +30,6 @@
 from __future__ import print_function
 
 import FreeCAD
-import MeshPart
 import Path
 import PathScripts.PathLog as PathLog
 import PathScripts.PathUtils as PathUtils
@@ -39,8 +38,12 @@ import PathScripts.PathOp as PathOp
 from PySide import QtCore
 import time
 import math
-import Part
-import Draft
+
+# lazily loaded modules
+from lazy_loader.lazy_loader import LazyLoader
+MeshPart = LazyLoader('MeshPart', globals(), 'MeshPart')
+Draft = LazyLoader('Draft', globals(), 'Draft')
+Part = LazyLoader('Part', globals(), 'Part')
 
 if FreeCAD.GuiUp:
     import FreeCADGui

--- a/src/Mod/Path/PathScripts/PathToolBit.py
+++ b/src/Mod/Path/PathScripts/PathToolBit.py
@@ -23,7 +23,6 @@
 # ***************************************************************************
 
 import FreeCAD
-import Part
 import PathScripts.PathGeom as PathGeom
 import PathScripts.PathLog as PathLog
 import PathScripts.PathPreferences as PathPreferences
@@ -35,6 +34,10 @@ import json
 import math
 import os
 import zipfile
+
+# lazily loaded modules
+from lazy_loader.lazy_loader import LazyLoader
+Part = LazyLoader('Part', globals(), 'Part')
 
 __title__ = "Tool bits."
 __author__ = "sliptonic (Brad Collette)"

--- a/src/Mod/Path/PathScripts/PathToolControllerGui.py
+++ b/src/Mod/Path/PathScripts/PathToolControllerGui.py
@@ -24,7 +24,6 @@
 
 import FreeCAD
 import FreeCADGui
-import Part
 import PathScripts
 import PathScripts.PathGui as PathGui
 import PathScripts.PathLog as PathLog
@@ -33,6 +32,10 @@ import PathScripts.PathToolEdit as PathToolEdit
 import PathScripts.PathUtil as PathUtil
 
 from PySide import QtCore, QtGui
+
+# lazily loaded modules
+from lazy_loader.lazy_loader import LazyLoader
+Part = LazyLoader('Part', globals(), 'Part')
 
 # Qt translation handling
 def translate(context, text, disambig=None):

--- a/src/Mod/Path/PathScripts/PathUtils.py
+++ b/src/Mod/Path/PathScripts/PathUtils.py
@@ -23,20 +23,23 @@
 # ***************************************************************************
 '''PathUtils -common functions used in PathScripts for filtering, sorting, and generating gcode toolpath data '''
 import FreeCAD
-import Part
 import Path
 import PathScripts
 import PathScripts.PathGeom as PathGeom
-import TechDraw
 import math
 import numpy
 
-from DraftGeomUtils import geomType
 from FreeCAD import Vector
 from PathScripts import PathJob
 from PathScripts import PathLog
 from PySide import QtCore
 from PySide import QtGui
+
+# lazily loaded modules
+from lazy_loader.lazy_loader import LazyLoader
+geomType = LazyLoader('DraftDraftGeomUtils', globals(), 'DraftDraftGeomUtils.geomType')
+Part = LazyLoader('Part', globals(), 'Part')
+TechDraw = LazyLoader('TechDraw', globals(), 'TechDraw')
 
 PathLog.setLevel(PathLog.Level.INFO, PathLog.thisModule())
 #PathLog.trackModule(PathLog.thisModule())

--- a/src/Mod/Path/PathScripts/PathWaterline.py
+++ b/src/Mod/Path/PathScripts/PathWaterline.py
@@ -26,7 +26,6 @@
 from __future__ import print_function
 
 import FreeCAD
-import MeshPart
 import Path
 import PathScripts.PathLog as PathLog
 import PathScripts.PathUtils as PathUtils
@@ -35,8 +34,12 @@ import PathScripts.PathOp as PathOp
 from PySide import QtCore
 import time
 import math
-import Part
-import Draft
+
+# lazily loaded modules
+from lazy_loader.lazy_loader import LazyLoader
+MeshPart = LazyLoader('MeshPart', globals(), 'MeshPart')
+Draft = LazyLoader('Draft', globals(), 'Draft')
+Part = LazyLoader('Part', globals(), 'Part')
 
 if FreeCAD.GuiUp:
     import FreeCADGui

--- a/src/Mod/TechDraw/Gui/QGIViewAnnotation.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewAnnotation.cpp
@@ -158,10 +158,19 @@ void QGIViewAnnotation::drawAnnotation()
         if (it != annoText.begin()) {
             ss << "<br>";
         }
-        std::string u8String = Base::Tools::escapedUnicodeToUtf8(*it);
-//                                                                   what madness turns \' into \\\\\'?
-        std::string apos = std::regex_replace((u8String), std::regex("\\\\\'"), "'");
-        ss << apos;
+    //TODO: there is still a bug here.  entering "'" works, save and restore works, but edit after
+    //      save and restore brings "\'" back into text.  manually deleting the "\" fixes it until the next
+    //      save/restore/edit cycle.
+    //      a guess is that the editor for propertyStringList is too enthusiastic about substituting. 
+    //      the substituting might be necessary for using the strings in Python.
+    //      &apos; doesn't seem to help in this case.  
+
+        std::string u8String = Base::Tools::escapedUnicodeToUtf8(*it); //from \x??\x?? to real utf8
+        std::string apos = std::regex_replace((u8String), std::regex("\\\\"), "");  //remove doubles.
+        apos = std::regex_replace((apos), std::regex("\\'"), "'");  //replace escaped apos
+        //"less than" symbol chops off line.  need to use html sub. 
+        std::string lt   = std::regex_replace((apos), std::regex("<"), "&lt;");
+        ss << lt;
     }
     ss << "<br></p>\n</body>\n</html> ";
 


### PR DESCRIPTION
Path workbench has been taking a long time to load, after investigation it was mostly caused by importing other workbenches. Deferred loading would work in most cases, but a few modules used the imports in multiple places. I found the lazyloader class from tensorflow which allows you to defer loading at the top of the file. It is apache licensed which should be compatible with lgpl. I put the class in 3rdPArty, but have it install to Ext so it is in the python path. Need someone to verify the CMakeLists.txt I created is correct, I'm not very familiar with it.