### PR TITLE
[Arch] split IFC dialog

### DIFF
--- a/src/Mod/Arch/InitGui.py
+++ b/src/Mod/Arch/InitGui.py
@@ -180,6 +180,7 @@ FreeCADGui.addWorkbench(ArchWorkbench)
 import Arch_rc
 from PySide.QtCore import QT_TRANSLATE_NOOP
 FreeCADGui.addPreferencePage(":/ui/preferences-ifc.ui", QT_TRANSLATE_NOOP("Draft", "Import-Export"))
+FreeCADGui.addPreferencePage(":/ui/preferences-ifc-export.ui", QT_TRANSLATE_NOOP("Draft", "Import-Export"))
 FreeCADGui.addPreferencePage(":/ui/preferences-dae.ui", QT_TRANSLATE_NOOP("Draft", "Import-Export"))
 
 FreeCAD.__unit_test__ += ["TestArch"]

--- a/src/Mod/Arch/Resources/Arch.qrc
+++ b/src/Mod/Arch/Resources/Arch.qrc
@@ -112,6 +112,7 @@
         <file>ui/preferences-archdefaults.ui</file>
         <file>ui/preferences-dae.ui</file>
         <file>ui/preferences-ifc.ui</file>
+        <file>ui/preferences-ifc-export.ui</file>
         <file>translations/Arch_af.qm</file>
         <file>translations/Arch_ar.qm</file>
         <file>translations/Arch_ca.qm</file>

--- a/src/Mod/Arch/Resources/ui/preferences-ifc-export.ui
+++ b/src/Mod/Arch/Resources/ui/preferences-ifc-export.ui
@@ -1,0 +1,359 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Gui::Dialog::DlgSettingsArch</class>
+ <widget class="QWidget" name="Gui::Dialog::DlgSettingsArch">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>463</width>
+    <height>421</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>IFC-Export</string>
+  </property>
+  <layout class="QVBoxLayout">
+   <property name="spacing">
+    <number>6</number>
+   </property>
+   <property name="leftMargin">
+    <number>9</number>
+   </property>
+   <property name="topMargin">
+    <number>9</number>
+   </property>
+   <property name="rightMargin">
+    <number>9</number>
+   </property>
+   <property name="bottomMargin">
+    <number>9</number>
+   </property>
+   <item>
+    <widget class="Gui::PrefCheckBox" name="checkBox_7">
+     <property name="text">
+      <string>Show this dialog when exporting</string>
+     </property>
+     <property name="prefEntry" stdset="0">
+      <cstring>ifcShowDialog</cstring>
+     </property>
+     <property name="prefPath" stdset="0">
+      <cstring>Mod/Arch</cstring>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="groupBox">
+     <property name="title">
+      <string>Export options</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_2">
+      <item>
+       <widget class="Gui::PrefCheckBox" name="checkBox">
+        <property name="toolTip">
+         <string>Some IFC viewers don't like objects exported as extrusions.
+Use this to force all objects to be exported as BREP geometry.</string>
+        </property>
+        <property name="text">
+         <string>Force export as Brep</string>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>ifcExportAsBrep</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Arch</cstring>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="Gui::PrefCheckBox" name="checkBox_4">
+        <property name="toolTip">
+         <string>Use triangulation options set in the DAE options page</string>
+        </property>
+        <property name="text">
+         <string>Use DAE triangulation options</string>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>ifcUseDaeOptions</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Arch</cstring>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="Gui::PrefCheckBox" name="checkBox_5">
+        <property name="toolTip">
+         <string>Curved shapes that cannot be represented as curves in IFC
+are decomposed into flat facets.
+If this is checked, additional calculation is done to join coplanar facets.</string>
+        </property>
+        <property name="text">
+         <string>Join coplanar facets when triangulating</string>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>ifcJoinCoplanarFacets</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Arch</cstring>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="Gui::PrefCheckBox" name="checkBox_9">
+        <property name="toolTip">
+         <string>When exporting objects without unique ID (UID), the generated UID
+will be stored inside the FreeCAD object for reuse next time that object
+is exported. This leads to smaller differences between file versions.</string>
+        </property>
+        <property name="text">
+         <string>Store IFC unique ID in FreeCAD objects</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>ifcStoreUid</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Arch</cstring>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="Gui::PrefCheckBox" name="checkBox_10">
+        <property name="toolTip">
+         <string>IFCOpenShell is a library that allows to import IFC files.
+Its serializer functionality allows to give it an OCC shape and it will
+produce adequate IFC geometry: NURBS, faceted, or anything else.
+Note: The serializer is still an experimental feature!</string>
+        </property>
+        <property name="text">
+         <string>Use IfcOpenShell serializer if available</string>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>ifcSerialize</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Arch</cstring>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="Gui::PrefCheckBox" name="checkBox_12">
+        <property name="toolTip">
+         <string>2D objects will be exported as IfcAnnotation</string>
+        </property>
+        <property name="text">
+         <string>Export 2D objects as IfcAnnotations</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>ifcExport2D</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Arch</cstring>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="Gui::PrefCheckBox" name="checkBox_13">
+        <property name="toolTip">
+         <string>All FreeCAD object properties will be stored inside the exported objects,
+allowing to recreate a full parametric model on reimport.</string>
+        </property>
+        <property name="text">
+         <string>Export full FreeCAD parametric model</string>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>IfcExportFreeCADProperties</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Arch</cstring>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="Gui::PrefCheckBox" name="checkBox_15">
+        <property name="toolTip">
+         <string>When possible, similar entities will be used only once in the file if possible.
+This can reduce the file size a lot, but will make it less easily readable.</string>
+        </property>
+        <property name="text">
+         <string>Reuse similar entities</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>ifcCompress</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Arch</cstring>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="Gui::PrefCheckBox" name="checkBox_16">
+        <property name="toolTip">
+         <string>When possible, IFC objects that are extruded rectangles will be
+exported as IfcRectangleProfileDef.
+However, some other applications might have problems importing that entity.
+If this is your case, you can disable this and then all profiles will be exported as IfcArbitraryClosedProfileDef.</string>
+        </property>
+        <property name="text">
+         <string>Disable IfcRectangleProfileDef</string>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>DisableIfcRectangleProfileDef</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Arch</cstring>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="Gui::PrefCheckBox" name="checkBox_17">
+        <property name="toolTip">
+         <string>Some IFC types such as IfcWall or IfcBeam have special standard versions
+like IfcWallStandardCase or IfcBeamStandardCase.
+If this option is turned on, FreeCAD will automatically export such objects
+as standard cases when the necessary conditions are met.</string>
+        </property>
+        <property name="text">
+         <string>Auto-detect and export as standard cases when applicable</string>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>getStandardCase</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Arch</cstring>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="Gui::PrefCheckBox" name="checkBox_19">
+        <property name="toolTip">
+         <string>If no site is found in the FreeCAD document, a default one will be added.
+A site is not mandatory but a common practice is to have at least one in the file.</string>
+        </property>
+        <property name="text">
+         <string>Add default site if one is not found in the document</string>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>IfcAddDefaultSite</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Arch</cstring>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="Gui::PrefCheckBox" name="checkBox_21">
+        <property name="toolTip">
+         <string>If no building is found in the FreeCAD document, a default one will be added.
+Warning: The IFC standard asks for at least one building in each file. By turning this option off, you will produce a non-standard IFC file.
+However, at FreeCAD, we believe having a building should not be mandatory, and this option is there to have a chance to demonstrate our point of view.</string>
+        </property>
+        <property name="text">
+         <string>Add default building if one is not found in the document (no standard)</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>IfcAddDefaultBuilding</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Arch</cstring>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="Gui::PrefCheckBox" name="checkBox_20">
+        <property name="toolTip">
+         <string>If no building storey is found in the FreeCAD document, a default one will be added.
+A building storey is not mandatory but a common practice to have at least one in the file.</string>
+        </property>
+        <property name="text">
+         <string>Add default building storey if one is not found in the document</string>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>IfcAddDefaultStorey</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Arch</cstring>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout">
+        <item>
+         <widget class="QLabel" name="label">
+          <property name="text">
+           <string>IFC file units</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="Gui::PrefComboBox" name="comboBox_3">
+          <property name="toolTip">
+           <string>The units you want your IFC file to be exported to. Note that IFC file are ALWAYS written in metric units. Imperial units are only a conversion applied on top of it. But some BIM applications will use this to choose which unit to work with when opening the file.</string>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>ifcUnit</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/Arch</cstring>
+          </property>
+          <item>
+           <property name="text">
+            <string>Metric</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Imperial</string>
+           </property>
+          </item>
+         </widget>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+  </layout>
+ </widget>
+ <layoutdefault spacing="6" margin="11"/>
+ <pixmapfunction>qPixmapFromMimeSource</pixmapfunction>
+ <customwidgets>
+  <customwidget>
+   <class>Gui::PrefCheckBox</class>
+   <extends>QCheckBox</extends>
+   <header>Gui/PrefWidgets.h</header>
+  </customwidget>
+  <customwidget>
+   <class>Gui::PrefComboBox</class>
+   <extends>QComboBox</extends>
+   <header>Gui/PrefWidgets.h</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/Mod/Arch/Resources/ui/preferences-ifc.ui
+++ b/src/Mod/Arch/Resources/ui/preferences-ifc.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>463</width>
-    <height>937</height>
+    <height>495</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -17,13 +17,22 @@
    <property name="spacing">
     <number>6</number>
    </property>
-   <property name="margin">
+   <property name="leftMargin">
+    <number>9</number>
+   </property>
+   <property name="topMargin">
+    <number>9</number>
+   </property>
+   <property name="rightMargin">
+    <number>9</number>
+   </property>
+   <property name="bottomMargin">
     <number>9</number>
    </property>
    <item>
     <widget class="Gui::PrefCheckBox" name="checkBox_7">
      <property name="text">
-      <string>Show this dialog when importing and exporting</string>
+      <string>Show this dialog when importing</string>
      </property>
      <property name="prefEntry" stdset="0">
       <cstring>ifcShowDialog</cstring>
@@ -384,289 +393,6 @@ FreeCAD object properties</string>
          <cstring>Mod/Arch</cstring>
         </property>
        </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
-    <widget class="QGroupBox" name="groupBox">
-     <property name="title">
-      <string>Export options</string>
-     </property>
-     <layout class="QVBoxLayout" name="verticalLayout_2">
-      <item>
-       <widget class="Gui::PrefCheckBox" name="checkBox">
-        <property name="toolTip">
-         <string>Some IFC viewers don't like objects exported as extrusions.
-Use this to force all objects to be exported as BREP geometry.</string>
-        </property>
-        <property name="text">
-         <string>Force export as Brep</string>
-        </property>
-        <property name="prefEntry" stdset="0">
-         <cstring>ifcExportAsBrep</cstring>
-        </property>
-        <property name="prefPath" stdset="0">
-         <cstring>Mod/Arch</cstring>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="Gui::PrefCheckBox" name="checkBox_4">
-        <property name="toolTip">
-         <string>Use triangulation options set in the DAE options page</string>
-        </property>
-        <property name="text">
-         <string>Use DAE triangulation options</string>
-        </property>
-        <property name="prefEntry" stdset="0">
-         <cstring>ifcUseDaeOptions</cstring>
-        </property>
-        <property name="prefPath" stdset="0">
-         <cstring>Mod/Arch</cstring>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="Gui::PrefCheckBox" name="checkBox_5">
-        <property name="toolTip">
-         <string>Curved shapes that cannot be represented as curves in IFC
-are decomposed into flat facets.
-If this is checked, additional calculation is done to join coplanar facets.</string>
-        </property>
-        <property name="text">
-         <string>Join coplanar facets when triangulating</string>
-        </property>
-        <property name="prefEntry" stdset="0">
-         <cstring>ifcJoinCoplanarFacets</cstring>
-        </property>
-        <property name="prefPath" stdset="0">
-         <cstring>Mod/Arch</cstring>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="Gui::PrefCheckBox" name="checkBox_9">
-        <property name="toolTip">
-         <string>When exporting objects without unique ID (UID), the generated UID
-will be stored inside the FreeCAD object for reuse next time that object
-is exported. This leads to smaller differences between file versions.</string>
-        </property>
-        <property name="text">
-         <string>Store IFC unique ID in FreeCAD objects</string>
-        </property>
-        <property name="checked">
-         <bool>true</bool>
-        </property>
-        <property name="prefEntry" stdset="0">
-         <cstring>ifcStoreUid</cstring>
-        </property>
-        <property name="prefPath" stdset="0">
-         <cstring>Mod/Arch</cstring>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="Gui::PrefCheckBox" name="checkBox_10">
-        <property name="toolTip">
-         <string>IFCOpenShell is a library that allows to import IFC files.
-Its serializer functionality allows to give it an OCC shape and it will
-produce adequate IFC geometry: NURBS, faceted, or anything else.
-Note: The serializer is still an experimental feature!</string>
-        </property>
-        <property name="text">
-         <string>Use IfcOpenShell serializer if available</string>
-        </property>
-        <property name="prefEntry" stdset="0">
-         <cstring>ifcSerialize</cstring>
-        </property>
-        <property name="prefPath" stdset="0">
-         <cstring>Mod/Arch</cstring>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="Gui::PrefCheckBox" name="checkBox_12">
-        <property name="toolTip">
-         <string>2D objects will be exported as IfcAnnotation</string>
-        </property>
-        <property name="text">
-         <string>Export 2D objects as IfcAnnotations</string>
-        </property>
-        <property name="checked">
-         <bool>true</bool>
-        </property>
-        <property name="prefEntry" stdset="0">
-         <cstring>ifcExport2D</cstring>
-        </property>
-        <property name="prefPath" stdset="0">
-         <cstring>Mod/Arch</cstring>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="Gui::PrefCheckBox" name="checkBox_13">
-        <property name="toolTip">
-         <string>All FreeCAD object properties will be stored inside the exported objects,
-allowing to recreate a full parametric model on reimport.</string>
-        </property>
-        <property name="text">
-         <string>Export full FreeCAD parametric model</string>
-        </property>
-        <property name="prefEntry" stdset="0">
-         <cstring>IfcExportFreeCADProperties</cstring>
-        </property>
-        <property name="prefPath" stdset="0">
-         <cstring>Mod/Arch</cstring>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="Gui::PrefCheckBox" name="checkBox_15">
-        <property name="toolTip">
-         <string>When possible, similar entities will be used only once in the file if possible.
-This can reduce the file size a lot, but will make it less easily readable.</string>
-        </property>
-        <property name="text">
-         <string>Reuse similar entities</string>
-        </property>
-        <property name="checked">
-         <bool>true</bool>
-        </property>
-        <property name="prefEntry" stdset="0">
-         <cstring>ifcCompress</cstring>
-        </property>
-        <property name="prefPath" stdset="0">
-         <cstring>Mod/Arch</cstring>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="Gui::PrefCheckBox" name="checkBox_16">
-        <property name="toolTip">
-         <string>When possible, IFC objects that are extruded rectangles will be
-exported as IfcRectangleProfileDef.
-However, some other applications might have problems importing that entity.
-If this is your case, you can disable this and then all profiles will be exported as IfcArbitraryClosedProfileDef.</string>
-        </property>
-        <property name="text">
-         <string>Disable IfcRectangleProfileDef</string>
-        </property>
-        <property name="prefEntry" stdset="0">
-         <cstring>DisableIfcRectangleProfileDef</cstring>
-        </property>
-        <property name="prefPath" stdset="0">
-         <cstring>Mod/Arch</cstring>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="Gui::PrefCheckBox" name="checkBox_17">
-        <property name="toolTip">
-         <string>Some IFC types such as IfcWall or IfcBeam have special standard versions
-like IfcWallStandardCase or IfcBeamStandardCase.
-If this option is turned on, FreeCAD will automatically export such objects
-as standard cases when the necessary conditions are met.</string>
-        </property>
-        <property name="text">
-         <string>Auto-detect and export as standard cases when applicable</string>
-        </property>
-        <property name="prefEntry" stdset="0">
-         <cstring>getStandardCase</cstring>
-        </property>
-        <property name="prefPath" stdset="0">
-         <cstring>Mod/Arch</cstring>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="Gui::PrefCheckBox" name="checkBox_19">
-        <property name="toolTip">
-         <string>If no site is found in the FreeCAD document, a default one will be added.
-A site is not mandatory but a common practice is to have at least one in the file.</string>
-        </property>
-        <property name="text">
-         <string>Add default site if one is not found in the document</string>
-        </property>
-        <property name="prefEntry" stdset="0">
-         <cstring>IfcAddDefaultSite</cstring>
-        </property>
-        <property name="prefPath" stdset="0">
-         <cstring>Mod/Arch</cstring>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="Gui::PrefCheckBox" name="checkBox_21">
-        <property name="toolTip">
-         <string>If no building is found in the FreeCAD document, a default one will be added.
-Warning: The IFC standard asks for at least one building in each file. By turning this option off, you will produce a non-standard IFC file.
-However, at FreeCAD, we believe having a building should not be mandatory, and this option is there to have a chance to demonstrate our point of view.</string>
-        </property>
-        <property name="text">
-         <string>Add default building if one is not found in the document (no standard)</string>
-        </property>
-        <property name="checked">
-         <bool>true</bool>
-        </property>
-        <property name="prefEntry" stdset="0">
-         <cstring>IfcAddDefaultBuilding</cstring>
-        </property>
-        <property name="prefPath" stdset="0">
-         <cstring>Mod/Arch</cstring>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="Gui::PrefCheckBox" name="checkBox_20">
-        <property name="toolTip">
-         <string>If no building storey is found in the FreeCAD document, a default one will be added.
-A building storey is not mandatory but a common practice to have at least one in the file.</string>
-        </property>
-        <property name="text">
-         <string>Add default building storey if one is not found in the document</string>
-        </property>
-        <property name="prefEntry" stdset="0">
-         <cstring>IfcAddDefaultStorey</cstring>
-        </property>
-        <property name="prefPath" stdset="0">
-         <cstring>Mod/Arch</cstring>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout">
-        <item>
-         <widget class="QLabel" name="label">
-          <property name="text">
-           <string>IFC file units</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="Gui::PrefComboBox" name="comboBox_3">
-          <property name="toolTip">
-           <string>The units you want your IFC file to be exported to. Note that IFC file are ALWAYS written in metric units. Imperial units are only a conversion applied on top of it. But some BIM applications will use this to choose which unit to work with when opening the file.</string>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>ifcUnit</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Arch</cstring>
-          </property>
-          <item>
-           <property name="text">
-            <string>Metric</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Imperial</string>
-           </property>
-          </item>
-         </widget>
-        </item>
-       </layout>
       </item>
      </layout>
     </widget>

--- a/src/Mod/Arch/exportIFC.py
+++ b/src/Mod/Arch/exportIFC.py
@@ -113,7 +113,7 @@ def getPreferences():
 
     if FreeCAD.GuiUp and p.GetBool("ifcShowDialog",False):
         import FreeCADGui
-        FreeCADGui.showPreferences("Import-Export",0)
+        FreeCADGui.showPreferences("Import-Export",1)
     ifcunit = p.GetInt("ifcUnit",0)
     f = 0.001
     u = "metre"

--- a/src/Mod/Draft/importDXF.py
+++ b/src/Mod/Draft/importDXF.py
@@ -4169,7 +4169,7 @@ def readPreferences():
     # reading parameters
     p = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/Draft")
     if FreeCAD.GuiUp and p.GetBool("dxfShowDialog", False):
-        FreeCADGui.showPreferences("Import-Export", 2)
+        FreeCADGui.showPreferences("Import-Export", 3)
     global dxfCreatePart, dxfCreateDraft, dxfCreateSketch
     global dxfDiscretizeCurves, dxfStarBlocks
     global dxfMakeBlocks, dxfJoin, dxfRenderPolylineWidth


### PR DESCRIPTION
As discussed here:
https://forum.freecadweb.org/viewtopic.php?p=383197#p383197
the dialog is too large for smaller screens, thus divide it into 2.
 @yorikvanhavre , please check that everythig works as expected since I am no python programmer.

I tested of course and im-/exporting works in my opinion as it should.