### PR TITLE
Draft: compatible super() for Python 2

### DIFF
--- a/src/Mod/Draft/draftguitools/gui_arcs.py
+++ b/src/Mod/Draft/draftguitools/gui_arcs.py
@@ -67,7 +67,7 @@ class Arc(gui_base_original.Creator):
 
     def Activated(self):
         """Execute when the command is called."""
-        super().Activated(name=_tr(self.featureName))
+        super(Arc, self).Activated(name=_tr(self.featureName))
         if self.ui:
             self.step = 0
             self.center = None
@@ -94,7 +94,7 @@ class Arc(gui_base_original.Creator):
         closed: bool, optional
             Close the line if `True`.
         """
-        super().finish(self)
+        super(Arc, self).finish()
         if self.ui:
             self.linetrack.finalize()
             self.arctrack.finalize()
@@ -477,7 +477,7 @@ class Arc_3Points(gui_base.GuiCommandSimplest):
     """GuiCommand for the Draft_Arc_3Points tool."""
 
     def __init__(self):
-        super().__init__(name=_tr("Arc by 3 points"))
+        super(Arc_3Points, self).__init__(name=_tr("Arc by 3 points"))
 
     def GetResources(self):
         """Set icon, menu and tooltip."""
@@ -493,7 +493,7 @@ class Arc_3Points(gui_base.GuiCommandSimplest):
 
     def Activated(self):
         """Execute when the command is called."""
-        super().Activated()
+        super(Arc_3Points, self).Activated()
 
         # Reset the values
         self.points = []

--- a/src/Mod/Draft/draftguitools/gui_array_simple.py
+++ b/src/Mod/Draft/draftguitools/gui_array_simple.py
@@ -56,7 +56,7 @@ class Array(gui_base_original.Modifier):
     """
 
     def __init__(self, use_link=False):
-        super().__init__()
+        super(Array, self).__init__()
         self.use_link = use_link
 
     def GetResources(self):
@@ -72,7 +72,7 @@ class Array(gui_base_original.Modifier):
 
     def Activated(self, name=_tr("Array")):
         """Execute when the command is called."""
-        super().Activated(name=name)
+        super(Array, self).Activated(name=name)
         if not Gui.Selection.getSelection():
             if self.ui:
                 self.ui.selectUi()
@@ -114,7 +114,7 @@ class LinkArray(Array):
     """Gui Command for the LinkArray tool based on the simple Array tool."""
 
     def __init__(self):
-        super().__init__(use_link=True)
+        super(LinkArray, self).__init__(use_link=True)
 
     def GetResources(self):
         """Set icon, menu and tooltip."""
@@ -128,7 +128,7 @@ class LinkArray(Array):
 
     def Activated(self):
         """Execute when the command is called."""
-        super().Activated(name=_tr("Link array"))
+        super(LinkArray, self).Activated(name=_tr("Link array"))
 
 
 Gui.addCommand('Draft_LinkArray', LinkArray())

--- a/src/Mod/Draft/draftguitools/gui_base.py
+++ b/src/Mod/Draft/draftguitools/gui_base.py
@@ -32,6 +32,8 @@ import FreeCADGui as Gui
 import draftutils.todo as todo
 from draftutils.messages import _msg, _log
 
+__metaclass__ = type  # to support Python 2 use of `super()`
+
 
 class GuiCommandSimplest:
     """Simplest base class for GuiCommands.

--- a/src/Mod/Draft/draftguitools/gui_base_original.py
+++ b/src/Mod/Draft/draftguitools/gui_base_original.py
@@ -41,6 +41,8 @@ import draftguitools.gui_trackers as trackers
 import draftguitools.gui_tool_utils as gui_tool_utils
 from draftutils.messages import _msg, _log
 
+__metaclass__ = type  # to support Python 2 use of `super()`
+
 
 class DraftTool:
     """The base class of all Draft Tools.
@@ -266,7 +268,7 @@ class Creator(DraftTool):
     """
 
     def __init__(self):
-        super().__init__()
+        super(Creator, self).__init__()
 
     def Activated(self, name="None", noplanesetup=False):
         """Execute when the command is called.
@@ -282,7 +284,7 @@ class Creator(DraftTool):
             If it is `False` it will set up the working plane
             by running `App.DraftWorkingPlane.setup()`.
         """
-        super().Activated(name, noplanesetup)
+        super(Creator, self).Activated(name, noplanesetup)
         if not noplanesetup:
             self.support = gui_tool_utils.get_support()
 
@@ -298,5 +300,5 @@ class Modifier(DraftTool):
     """
 
     def __init__(self):
-        super().__init__()
+        super(Modifier, self).__init__()
         self.copymode = False

--- a/src/Mod/Draft/draftguitools/gui_beziers.py
+++ b/src/Mod/Draft/draftguitools/gui_beziers.py
@@ -50,7 +50,7 @@ class BezCurve(gui_lines.Line):
     """Gui command for the Bezier Curve tool."""
 
     def __init__(self):
-        super().__init__(wiremode=True)
+        super(BezCurve, self).__init__(wiremode=True)
         self.degree = None
 
     def GetResources(self):
@@ -70,7 +70,7 @@ class BezCurve(gui_lines.Line):
 
         Activate the specific bezier curve tracker.
         """
-        super().Activated(name=translate("draft", "BezCurve"))
+        super(BezCurve, self).Activated(name=translate("draft", "BezCurve"))
         if self.doc:
             self.bezcurvetrack = trackers.bezcurveTracker()
 
@@ -231,7 +231,7 @@ class CubicBezCurve(gui_lines.Line):
     """Gui command for the 3rd degree Bezier Curve tool."""
 
     def __init__(self):
-        super().__init__(wiremode=True)
+        super(CubicBezCurve, self).__init__(wiremode=True)
         self.degree = 3
 
     def GetResources(self):
@@ -254,7 +254,7 @@ class CubicBezCurve(gui_lines.Line):
 
         Activate the specific BezCurve tracker.
         """
-        super().Activated(name=translate("draft", "CubicBezCurve"))
+        super(CubicBezCurve, self).Activated(name=translate("draft", "CubicBezCurve"))
         if self.doc:
             self.bezcurvetrack = trackers.bezcurveTracker()
 

--- a/src/Mod/Draft/draftguitools/gui_circulararray.py
+++ b/src/Mod/Draft/draftguitools/gui_circulararray.py
@@ -46,7 +46,7 @@ class CircularArray(gui_base.GuiCommandBase):
     """Gui command for the CircularArray tool."""
 
     def __init__(self):
-        super().__init__()
+        super(CircularArray, self).__init__()
         self.command_name = "Circular array"
         self.location = None
         self.mouse_event = None
@@ -136,7 +136,7 @@ class CircularArray(gui_base.GuiCommandBase):
                                           self.callback_click)
         if Gui.Control.activeDialog():
             Gui.Control.closeDialog()
-            super().finish()
+            super(CircularArray, self).finish()
 
 
 Gui.addCommand('Draft_CircularArray', CircularArray())

--- a/src/Mod/Draft/draftguitools/gui_clone.py
+++ b/src/Mod/Draft/draftguitools/gui_clone.py
@@ -57,7 +57,7 @@ class Clone(gui_base_original.Modifier):
     """Gui Command for the Clone tool."""
 
     def __init__(self):
-        super().__init__()
+        super(Clone, self).__init__()
         self.moveAfterCloning = False
 
     def GetResources(self):
@@ -73,7 +73,7 @@ class Clone(gui_base_original.Modifier):
 
     def Activated(self):
         """Execute when the command is called."""
-        super().Activated(name=_tr("Clone"))
+        super(Clone, self).Activated(name=_tr("Clone"))
         if not Gui.Selection.getSelection():
             if self.ui:
                 self.ui.selectUi()
@@ -116,7 +116,7 @@ class Clone(gui_base_original.Modifier):
 
     def finish(self, close=False):
         """Terminate the operation of the tool."""
-        super().finish(close=False)
+        super(Clone, self).finish(close=False)
         if self.moveAfterCloning:
             todo.ToDo.delay(Gui.runCommand, "Draft_Move")
 

--- a/src/Mod/Draft/draftguitools/gui_dimension_ops.py
+++ b/src/Mod/Draft/draftguitools/gui_dimension_ops.py
@@ -49,7 +49,7 @@ class FlipDimension(gui_base.GuiCommandNeedsSelection):
     """
 
     def __init__(self):
-        super().__init__(name=_tr("Flip dimension"))
+        super(Draft_FlipDimension, self).__init__(name=_tr("Flip dimension"))
 
     def GetResources(self):
         """Set icon, menu and tooltip."""
@@ -65,7 +65,7 @@ class FlipDimension(gui_base.GuiCommandNeedsSelection):
 
     def Activated(self):
         """Execute when the command is called."""
-        super().Activated()
+        super(Draft_FlipDimension, self).Activated()
 
         for o in Gui.Selection.getSelection():
             if utils.get_type(o) in ("Dimension", "AngularDimension"):

--- a/src/Mod/Draft/draftguitools/gui_dimensions.py
+++ b/src/Mod/Draft/draftguitools/gui_dimensions.py
@@ -91,13 +91,13 @@ class Dimension(gui_base_original.Creator):
         if self.cont:
             self.finish()
         elif self.hasMeasures():
-            super().Activated(name)
+            super(Dimension, self).Activated(name)
             self.dimtrack = trackers.dimTracker()
             self.arctrack = trackers.arcTracker()
             self.createOnMeasures()
             self.finish()
         else:
-            super().Activated(name)
+            super(Dimension, self).Activated(name)
             if self.ui:
                 self.ui.pointUi(name)
                 self.ui.continueCmd.show()
@@ -165,7 +165,7 @@ class Dimension(gui_base_original.Creator):
         """Terminate the operation."""
         self.cont = None
         self.dir = None
-        super().finish()
+        super(Dimension, self).finish()
         if self.ui:
             self.dimtrack.finalize()
             self.arctrack.finalize()

--- a/src/Mod/Draft/draftguitools/gui_downgrade.py
+++ b/src/Mod/Draft/draftguitools/gui_downgrade.py
@@ -64,7 +64,7 @@ class Downgrade(gui_base_original.Modifier):
 
     def Activated(self):
         """Execute when the command is called."""
-        super().Activated(name=_tr("Downgrade"))
+        super(Downgrade, self).Activated(name=_tr("Downgrade"))
         if self.ui:
             if not Gui.Selection.getSelection():
                 self.ui.selectUi()

--- a/src/Mod/Draft/draftguitools/gui_draft2sketch.py
+++ b/src/Mod/Draft/draftguitools/gui_draft2sketch.py
@@ -65,7 +65,7 @@ class Draft2Sketch(gui_base_original.Modifier):
 
     def Activated(self):
         """Execute when the command is called."""
-        super().Activated(name=_tr("Convert Draft/Sketch"))
+        super(Draft2Sketch, self).Activated(name=_tr("Convert Draft/Sketch"))
         if not Gui.Selection.getSelection():
             if self.ui:
                 self.ui.selectUi()

--- a/src/Mod/Draft/draftguitools/gui_drawing.py
+++ b/src/Mod/Draft/draftguitools/gui_drawing.py
@@ -77,7 +77,7 @@ class Drawing(gui_base_original.Modifier):
 
     def Activated(self):
         """Execute when the command is called."""
-        super().Activated(name=_tr("Drawing"))
+        super(Drawing, self).Activated(name=_tr("Drawing"))
         _wrn(_tr("The Drawing Workbench is obsolete since 0.17, "
                  "consider using the TechDraw Workbench instead."))
         if not Gui.Selection.getSelection():

--- a/src/Mod/Draft/draftguitools/gui_ellipses.py
+++ b/src/Mod/Draft/draftguitools/gui_ellipses.py
@@ -60,7 +60,7 @@ class Ellipse(gui_base_original.Creator):
     def Activated(self):
         """Execute when the command is called."""
         name = translate("draft", "Ellipse")
-        super().Activated(name)
+        super(Ellipse, self).Activated(name)
         if self.ui:
             self.refpoint = None
             self.ui.pointUi(name)
@@ -71,7 +71,7 @@ class Ellipse(gui_base_original.Creator):
 
     def finish(self, closed=False, cont=False):
         """Terminate the operation."""
-        super().finish(self)
+        super(Ellipse, self).finish(self)
         if self.ui:
             self.rect.off()
             self.rect.finalize()

--- a/src/Mod/Draft/draftguitools/gui_facebinders.py
+++ b/src/Mod/Draft/draftguitools/gui_facebinders.py
@@ -61,7 +61,7 @@ class Facebinder(gui_base_original.Creator):
 
     def Activated(self):
         """Execute when the command is called."""
-        super().Activated(name=_tr("Facebinder"))
+        super(Facebinder, self).Activated(name=_tr("Facebinder"))
 
         if not Gui.Selection.getSelection():
             if self.ui:

--- a/src/Mod/Draft/draftguitools/gui_grid.py
+++ b/src/Mod/Draft/draftguitools/gui_grid.py
@@ -45,7 +45,7 @@ class ToggleGrid(gui_base.GuiCommandSimplest):
     """
 
     def __init__(self):
-        super().__init__(name=_tr("Toggle grid"))
+        super(ToggleGrid, self).__init__(name=_tr("Toggle grid"))
 
     def GetResources(self):
         """Set icon, menu and tooltip."""
@@ -63,7 +63,7 @@ class ToggleGrid(gui_base.GuiCommandSimplest):
 
     def Activated(self):
         """Execute when the command is called."""
-        super().Activated()
+        super(ToggleGrid, self).Activated()
 
         if hasattr(Gui, "Snapper"):
             Gui.Snapper.setTrackers()

--- a/src/Mod/Draft/draftguitools/gui_groups.py
+++ b/src/Mod/Draft/draftguitools/gui_groups.py
@@ -57,7 +57,7 @@ class AddToGroup(gui_base.GuiCommandNeedsSelection):
     """
 
     def __init__(self):
-        super().__init__(name=_tr("Add to group"))
+        super(AddToGroup, self).__init__(name=_tr("Add to group"))
         self.ungroup = QT_TRANSLATE_NOOP("Draft_AddToGroup",
                                          "Ungroup")
 
@@ -76,7 +76,7 @@ class AddToGroup(gui_base.GuiCommandNeedsSelection):
 
     def Activated(self):
         """Execute when the command is called."""
-        super().Activated()
+        super(AddToGroup, self).Activated()
 
         self.groups = [self.ungroup]
         self.groups.extend(utils.get_group_names())
@@ -157,7 +157,7 @@ class SelectGroup(gui_base.GuiCommandNeedsSelection):
     """
 
     def __init__(self):
-        super().__init__(name=_tr("Select group"))
+        super(SelectGroup, self).__init__(name=_tr("Select group"))
 
     def GetResources(self):
         """Set icon, menu and tooltip."""
@@ -188,7 +188,7 @@ class SelectGroup(gui_base.GuiCommandNeedsSelection):
         in the InList of this object.
         For all parents, it also selects the children of these.
         """
-        super().Activated()
+        super(SelectGroup, self).Activated()
 
         sel = Gui.Selection.getSelection()
         if len(sel) == 1:
@@ -240,7 +240,7 @@ class SetAutoGroup(gui_base.GuiCommandSimplest):
     """GuiCommand for the Draft_AutoGroup tool."""
 
     def __init__(self):
-        super().__init__(name=_tr("Autogroup"))
+        super(SetAutoGroup, self).__init__(name=_tr("Autogroup"))
 
     def GetResources(self):
         """Set icon, menu and tooltip."""
@@ -256,7 +256,7 @@ class SetAutoGroup(gui_base.GuiCommandSimplest):
         It calls the `setAutogroup` method of the `DraftToolBar` class
         installed inside the global `Gui` namespace.
         """
-        super().Activated()
+        super(SetAutoGroup, self).Activated()
 
         if not hasattr(Gui, "draftToolBar"):
             return
@@ -345,7 +345,7 @@ class AddToConstruction(gui_base.GuiCommandSimplest):
     """
 
     def __init__(self):
-        super().__init__(name=_tr("Add to construction group"))
+        super(AddToConstruction, self).__init__(name=_tr("Add to construction group"))
 
     def GetResources(self):
         """Set icon, menu and tooltip."""
@@ -361,7 +361,7 @@ class AddToConstruction(gui_base.GuiCommandSimplest):
 
     def Activated(self):
         """Execute when the command is called."""
-        super().Activated()
+        super(AddToConstruction, self).Activated()
 
         if not hasattr(Gui, "draftToolBar"):
             return

--- a/src/Mod/Draft/draftguitools/gui_heal.py
+++ b/src/Mod/Draft/draftguitools/gui_heal.py
@@ -45,7 +45,7 @@ class Heal(gui_base.GuiCommandSimplest):
     """
 
     def __init__(self):
-        super().__init__(name=_tr("Heal"))
+        super(Heal, self).__init__(name=_tr("Heal"))
 
     def GetResources(self):
         """Set icon, menu and tooltip."""
@@ -62,7 +62,7 @@ class Heal(gui_base.GuiCommandSimplest):
 
     def Activated(self):
         """Execute when the command is called."""
-        super().Activated()
+        super(Heal, self).Activated()
 
         s = Gui.Selection.getSelection()
         self.doc.openTransaction("Heal")

--- a/src/Mod/Draft/draftguitools/gui_join.py
+++ b/src/Mod/Draft/draftguitools/gui_join.py
@@ -69,7 +69,7 @@ class Join(gui_base_original.Modifier):
 
     def Activated(self):
         """Execute when the command is called."""
-        super().Activated(name=_tr("Join"))
+        super(Join, self).Activated(name=_tr("Join"))
         if not self.ui:
             return
         if not Gui.Selection.getSelection():

--- a/src/Mod/Draft/draftguitools/gui_labels.py
+++ b/src/Mod/Draft/draftguitools/gui_labels.py
@@ -66,7 +66,7 @@ class Label(gui_base_original.Creator):
     def Activated(self):
         """Execute when the command is called."""
         self.name = translate("draft", "Label")
-        super().Activated(self.name, noplanesetup=True)
+        super(Label, self).Activated(self.name, noplanesetup=True)
         self.ghost = None
         self.labeltype = utils.getParam("labeltype", "Custom")
         self.sel = Gui.Selection.getSelectionEx()
@@ -90,7 +90,7 @@ class Label(gui_base_original.Creator):
         """Finish the command."""
         if self.ghost:
             self.ghost.finalize()
-        super().finish()
+        super(Label, self).finish()
 
     def create(self):
         """Create the actual object."""

--- a/src/Mod/Draft/draftguitools/gui_lineops.py
+++ b/src/Mod/Draft/draftguitools/gui_lineops.py
@@ -85,7 +85,7 @@ class FinishLine(LineAction):
     """GuiCommand to finish any running line drawing operation."""
 
     def __init__(self):
-        super().__init__(name=_tr("Finish line"))
+        super(FinishLine, self).__init__(name=_tr("Finish line"))
 
     def GetResources(self):
         """Set icon, menu and tooltip."""
@@ -102,7 +102,7 @@ class FinishLine(LineAction):
 
         It calls the `finish(False)` method of the active Draft command.
         """
-        super().Activated(action="finish")
+        super(FinishLine, self).Activated(action="finish")
 
 
 Gui.addCommand('Draft_FinishLine', FinishLine())
@@ -112,7 +112,7 @@ class CloseLine(LineAction):
     """GuiCommand to close the line being drawn and finish the operation."""
 
     def __init__(self):
-        super().__init__(name=_tr("Close line"))
+        super(CloseLine, self).__init__(name=_tr("Close line"))
 
     def GetResources(self):
         """Set icon, menu and tooltip."""
@@ -129,7 +129,7 @@ class CloseLine(LineAction):
 
         It calls the `finish(True)` method of the active Draft command.
         """
-        super().Activated(action="close")
+        super(CloseLine, self).Activated(action="close")
 
 
 Gui.addCommand('Draft_CloseLine', CloseLine())
@@ -139,7 +139,7 @@ class UndoLine(LineAction):
     """GuiCommand to undo the last drawn segment of a line."""
 
     def __init__(self):
-        super().__init__(name=_tr("Undo line"))
+        super(UndoLine, self).__init__(name=_tr("Undo line"))
 
     def GetResources(self):
         """Set icon, menu and tooltip."""
@@ -157,7 +157,7 @@ class UndoLine(LineAction):
 
         It calls the `undolast` method of the active Draft command.
         """
-        super().Activated(action="undo")
+        super(UndoLine, self).Activated(action="undo")
 
 
 Gui.addCommand('Draft_UndoLine', UndoLine())

--- a/src/Mod/Draft/draftguitools/gui_lines.py
+++ b/src/Mod/Draft/draftguitools/gui_lines.py
@@ -50,7 +50,7 @@ class Line(gui_base_original.Creator):
     """Gui command for the Line tool."""
 
     def __init__(self, wiremode=False):
-        super().__init__()
+        super(Line, self).__init__()
         self.isWire = wiremode
 
     def GetResources(self):
@@ -64,7 +64,7 @@ class Line(gui_base_original.Creator):
 
     def Activated(self, name=translate("draft", "Line")):
         """Execute when the command is called."""
-        super().Activated(name)
+        super(Line, self).Activated(name)
 
         if not self.doc:
             return
@@ -184,7 +184,7 @@ class Line(gui_base_original.Creator):
                              'FreeCAD.ActiveDocument.recompute()']
                 self.commit(translate("draft", "Create Wire"),
                             _cmd_list)
-        super().finish()
+        super(Line, self).finish()
         if self.ui and self.ui.continueMode:
             self.Activated()
 
@@ -296,7 +296,7 @@ class Wire(Line):
     """
 
     def __init__(self):
-        super().__init__(wiremode=True)
+        super(Wire, self).__init__(wiremode=True)
 
     def GetResources(self):
         """Set icon, menu and tooltip."""
@@ -357,7 +357,7 @@ class Wire(Line):
         # If there was no selection or the selection was just one object
         # then we proceed with the normal line creation functions,
         # only this time we will be able to input more than two points
-        super().Activated(name=translate("draft", "Polyline"))
+        super(Wire, self).Activated(name=translate("draft", "Polyline"))
 
 
 Gui.addCommand('Draft_Wire', Wire())

--- a/src/Mod/Draft/draftguitools/gui_lineslope.py
+++ b/src/Mod/Draft/draftguitools/gui_lineslope.py
@@ -58,7 +58,7 @@ class LineSlope(gui_base.GuiCommandNeedsSelection):
     """
 
     def __init__(self):
-        super().__init__(name=_tr("Change slope"))
+        super(LineSlope, self).__init__(name=_tr("Change slope"))
 
     def GetResources(self):
         """Set icon, menu and tooltip."""
@@ -78,7 +78,7 @@ class LineSlope(gui_base.GuiCommandNeedsSelection):
 
     def Activated(self):
         """Execute when the command is called."""
-        super().Activated()
+        super(LineSlope, self).Activated()
 
         # for obj in Gui.Selection.getSelection():
         #     if utils.get_type(obj) != "Wire":

--- a/src/Mod/Draft/draftguitools/gui_mirror.py
+++ b/src/Mod/Draft/draftguitools/gui_mirror.py
@@ -65,7 +65,7 @@ class Mirror(gui_base_original.Modifier):
     def Activated(self):
         """Execute when the command is called."""
         self.name = translate("draft", "Mirror")
-        super().Activated(name=self.name)
+        super(Mirror, self).Activated(name=self.name)
         self.ghost = None
         if self.ui:
             if not Gui.Selection.getSelection():
@@ -97,7 +97,7 @@ class Mirror(gui_base_original.Modifier):
         """Terminate the operation of the tool."""
         if self.ghost:
             self.ghost.finalize()
-        super().finish()
+        super(Mirror, self).finish()
         if cont and self.ui:
             if self.ui.continueMode:
                 Gui.Selection.clearSelection()

--- a/src/Mod/Draft/draftguitools/gui_move.py
+++ b/src/Mod/Draft/draftguitools/gui_move.py
@@ -50,7 +50,7 @@ class Move(gui_base_original.Modifier):
     """Gui Command for the Move tool."""
 
     def __init__(self):
-        super().__init__()
+        super(Move, self).__init__()
 
     def GetResources(self):
         """Set icon, menu and tooltip."""
@@ -68,9 +68,9 @@ class Move(gui_base_original.Modifier):
     def Activated(self):
         """Execute when the command is called."""
         self.name = translate("draft", "Move")
-        super().Activated(self.name,
-                          is_subtool=isinstance(App.activeDraftCommand,
-                                                SubelementHighlight))
+        super(Move, self).Activated(self.name,
+                                    is_subtool=isinstance(App.activeDraftCommand,
+                                                          SubelementHighlight))
         if not self.ui:
             return
         self.ghosts = []
@@ -111,7 +111,7 @@ class Move(gui_base_original.Modifier):
         if cont and self.ui:
             if self.ui.continueMode:
                 todo.ToDo.delayAfter(self.Activated, [])
-        super().finish()
+        super(Move, self).finish()
 
     def action(self, arg):
         """Handle the 3D scene events.

--- a/src/Mod/Draft/draftguitools/gui_offset.py
+++ b/src/Mod/Draft/draftguitools/gui_offset.py
@@ -67,7 +67,7 @@ class Offset(gui_base_original.Modifier):
     def Activated(self):
         """Execute when the command is called."""
         self.running = False
-        super().Activated(name=_tr("Offset"))
+        super(Offset, self).Activated(name=_tr("Offset"))
         self.ghost = None
         self.linetrack = None
         self.arctrack = None
@@ -263,7 +263,7 @@ class Offset(gui_base_original.Modifier):
                 self.linetrack.finalize()
             if self.ghost:
                 self.ghost.finalize()
-        super().finish()
+        super(Offset, self).finish()
 
     def numericRadius(self, rad):
         """Validate the radius entry field in the user interface.

--- a/src/Mod/Draft/draftguitools/gui_orthoarray.py
+++ b/src/Mod/Draft/draftguitools/gui_orthoarray.py
@@ -46,7 +46,7 @@ class OrthoArray(gui_base.GuiCommandBase):
     """Gui command for the OrthoArray tool."""
 
     def __init__(self):
-        super().__init__()
+        super(OrthoArray, self).__init__()
         self.command_name = "Orthogonal array"
         # self.location = None
         self.mouse_event = None
@@ -123,7 +123,7 @@ class OrthoArray(gui_base.GuiCommandBase):
                                           self.callback_click)
         if Gui.Control.activeDialog():
             Gui.Control.closeDialog()
-            super().finish()
+            super(OrthoArray, self).finish()
 
 
 Gui.addCommand('Draft_OrthoArray', OrthoArray())

--- a/src/Mod/Draft/draftguitools/gui_patharray.py
+++ b/src/Mod/Draft/draftguitools/gui_patharray.py
@@ -57,7 +57,7 @@ class PathArray(gui_base_original.Modifier):
     """
 
     def __init__(self, use_link=False):
-        super().__init__()
+        super(PathArray, self).__init__()
         self.use_link = use_link
 
     def GetResources(self):
@@ -73,7 +73,7 @@ class PathArray(gui_base_original.Modifier):
 
     def Activated(self, name=_tr("Path array")):
         """Execute when the command is called."""
-        super().Activated(name=name)
+        super(PathArray, self).Activated(name=name)
         if not Gui.Selection.getSelectionEx():
             if self.ui:
                 self.ui.selectUi()
@@ -115,7 +115,7 @@ class PathLinkArray(PathArray):
     """Gui Command for the PathLinkArray tool based on the PathArray tool."""
 
     def __init__(self):
-        super().__init__(use_link=True)
+        super(PathLinkArray, self).__init__(use_link=True)
 
     def GetResources(self):
         """Set icon, menu and tooltip."""
@@ -131,7 +131,7 @@ class PathLinkArray(PathArray):
 
     def Activated(self):
         """Execute when the command is called."""
-        super().Activated(name=_tr("Link path array"))
+        super(PathLinkArray, self).Activated(name=_tr("Link path array"))
 
 
 Gui.addCommand('Draft_PathLinkArray', PathLinkArray())

--- a/src/Mod/Draft/draftguitools/gui_pointarray.py
+++ b/src/Mod/Draft/draftguitools/gui_pointarray.py
@@ -71,7 +71,7 @@ class PointArray(gui_base_original.Modifier):
 
     def Activated(self):
         """Execute when the command is called."""
-        super().Activated(name=_tr("Point array"))
+        super(PointArray, self).Activated(name=_tr("Point array"))
         if not Gui.Selection.getSelectionEx():
             if self.ui:
                 self.ui.selectUi()

--- a/src/Mod/Draft/draftguitools/gui_points.py
+++ b/src/Mod/Draft/draftguitools/gui_points.py
@@ -62,7 +62,7 @@ class Point(gui_base_original.Creator):
 
     def Activated(self):
         """Execute when the command is called."""
-        super().Activated(name=_tr("Point"))
+        super(Point, self).Activated(name=_tr("Point"))
         self.view = gui_utils.get3DView()
         self.stack = []
         rot = self.view.getCameraNode().getField("orientation").getValue()
@@ -150,7 +150,7 @@ class Point(gui_base_original.Creator):
 
     def finish(self, cont=False):
         """Terminate the operation and restart if needed."""
-        super().finish()
+        super(Point, self).finish()
         if self.ui:
             if self.ui.continueMode:
                 self.Activated()

--- a/src/Mod/Draft/draftguitools/gui_polararray.py
+++ b/src/Mod/Draft/draftguitools/gui_polararray.py
@@ -46,7 +46,7 @@ class PolarArray(gui_base.GuiCommandBase):
     """Gui command for the PolarArray tool."""
 
     def __init__(self):
-        super().__init__()
+        super(PolarArray, self).__init__()
         self.command_name = "Polar array"
         self.location = None
         self.mouse_event = None
@@ -136,7 +136,7 @@ class PolarArray(gui_base.GuiCommandBase):
                                           self.callback_click)
         if Gui.Control.activeDialog():
             Gui.Control.closeDialog()
-            super().finish()
+            super(PolarArray, self).finish()
 
 
 Gui.addCommand('Draft_PolarArray', PolarArray())

--- a/src/Mod/Draft/draftguitools/gui_polygons.py
+++ b/src/Mod/Draft/draftguitools/gui_polygons.py
@@ -61,7 +61,7 @@ class Polygon(gui_base_original.Creator):
     def Activated(self):
         """Execute when the command is called."""
         name = translate("draft", "Polygon")
-        super().Activated(name)
+        super(Polygon, self).Activated(name)
         if self.ui:
             self.step = 0
             self.center = None
@@ -80,7 +80,7 @@ class Polygon(gui_base_original.Creator):
 
     def finish(self, closed=False, cont=False):
         """Terminate the operation."""
-        super().finish(self)
+        super(Polygon, self).finish(self)
         if self.ui:
             self.arctrack.finalize()
             self.doc.recompute()

--- a/src/Mod/Draft/draftguitools/gui_rectangles.py
+++ b/src/Mod/Draft/draftguitools/gui_rectangles.py
@@ -55,7 +55,7 @@ class Rectangle(gui_base_original.Creator):
     def Activated(self):
         """Execute when the command is called."""
         name = translate("draft", "Rectangle")
-        super().Activated(name)
+        super(Rectangle, self).Activated(name)
         if self.ui:
             self.refpoint = None
             self.ui.pointUi(name)
@@ -72,7 +72,7 @@ class Rectangle(gui_base_original.Creator):
 
         The arguments of this function are not used and should be removed.
         """
-        super().finish()
+        super(Rectangle, self).finish()
         if self.ui:
             if hasattr(self, "fillstate"):
                 self.ui.hasFill.setChecked(self.fillstate)

--- a/src/Mod/Draft/draftguitools/gui_rotate.py
+++ b/src/Mod/Draft/draftguitools/gui_rotate.py
@@ -67,7 +67,7 @@ class Rotate(gui_base_original.Modifier):
 
     def Activated(self):
         """Execute when the command is called."""
-        super().Activated(name=_tr("Rotate"))
+        super(Rotate, self).Activated(name=_tr("Rotate"))
         if not self.ui:
             return
         self.ghosts = []
@@ -264,7 +264,7 @@ class Rotate(gui_base_original.Modifier):
         if cont and self.ui:
             if self.ui.continueMode:
                 todo.ToDo.delayAfter(self.Activated, [])
-        super().finish()
+        super(Rotate, self).finish()
         if self.doc:
             self.doc.recompute()
 

--- a/src/Mod/Draft/draftguitools/gui_scale.py
+++ b/src/Mod/Draft/draftguitools/gui_scale.py
@@ -72,7 +72,7 @@ class Scale(gui_base_original.Modifier):
     def Activated(self):
         """Execute when the command is called."""
         self.name = translate("draft", "Scale")
-        super().Activated(name=self.name)
+        super(Scale, self).Activated(name=self.name)
         if not self.ui:
             return
         self.ghosts = []
@@ -399,7 +399,7 @@ class Scale(gui_base_original.Modifier):
 
     def finish(self, closed=False, cont=False):
         """Terminate the operation."""
-        super().finish()
+        super(Scale, self).finish()
         for ghost in self.ghosts:
             ghost.finalize()
 

--- a/src/Mod/Draft/draftguitools/gui_shape2dview.py
+++ b/src/Mod/Draft/draftguitools/gui_shape2dview.py
@@ -67,7 +67,7 @@ class Shape2DView(gui_base_original.Modifier):
 
     def Activated(self):
         """Execute when the command is called."""
-        super().Activated(name=_tr("Project 2D view"))
+        super(Shape2DView, self).Activated(name=_tr("Project 2D view"))
         if not Gui.Selection.getSelection():
             if self.ui:
                 self.ui.selectUi()

--- a/src/Mod/Draft/draftguitools/gui_shapestrings.py
+++ b/src/Mod/Draft/draftguitools/gui_shapestrings.py
@@ -74,7 +74,7 @@ class ShapeString(gui_base_original.Creator):
     def Activated(self):
         """Execute when the command is called."""
         name = translate("draft", "ShapeString")
-        super().Activated(name)
+        super(ShapeString, self).Activated(name)
         self.creator = gui_base_original.Creator
         if self.ui:
             self.ui.sourceCmd = self
@@ -222,7 +222,7 @@ class ShapeString(gui_base_original.Creator):
 
     def finish(self, finishbool=False):
         """Terminate the operation."""
-        super().finish()
+        super(ShapeString, self).finish()
         if self.ui:
             # del self.dialog  # what does this do??
             if self.ui.continueMode:

--- a/src/Mod/Draft/draftguitools/gui_snaps.py
+++ b/src/Mod/Draft/draftguitools/gui_snaps.py
@@ -121,7 +121,7 @@ class Draft_Snap_Lock(gui_base.GuiCommandSimplest):
     def Activated(self):
         """Execute when the command is called."""
         super(Draft_Snap_Lock, self).Activated()
-        
+
         if hasattr(Gui, "Snapper"):
             status = Gui.Snapper.toggle_snap('Lock')
             # change interface consistently

--- a/src/Mod/Draft/draftguitools/gui_splines.py
+++ b/src/Mod/Draft/draftguitools/gui_splines.py
@@ -47,7 +47,7 @@ class BSpline(gui_lines.Line):
     """Gui command for the BSpline tool."""
 
     def __init__(self):
-        super().__init__(wiremode=True)
+        super(BSpline, self).__init__(wiremode=True)
 
     def GetResources(self):
         """Set icon, menu and tooltip."""
@@ -64,7 +64,7 @@ class BSpline(gui_lines.Line):
 
         Activate the specific BSpline tracker.
         """
-        super().Activated(name=translate("draft", "BSpline"))
+        super(BSpline, self).Activated(name=translate("draft", "BSpline"))
         if self.doc:
             self.bsplinetrack = trackers.bsplineTracker()
 

--- a/src/Mod/Draft/draftguitools/gui_split.py
+++ b/src/Mod/Draft/draftguitools/gui_split.py
@@ -61,7 +61,7 @@ class Split(gui_base_original.Modifier):
 
     def Activated(self):
         """Execute when the command is called."""
-        super().Activated(name=_tr("Split"))
+        super(Split, self).Activated(name=_tr("Split"))
         if not self.ui:
             return
         _msg(translate("draft", "Click anywhere on a line to split it."))

--- a/src/Mod/Draft/draftguitools/gui_stretch.py
+++ b/src/Mod/Draft/draftguitools/gui_stretch.py
@@ -68,7 +68,7 @@ class Stretch(gui_base_original.Modifier):
 
     def Activated(self):
         """Execute when the command is called."""
-        super().Activated(name=_tr("Stretch"))
+        super(Stretch, self).Activated(name=_tr("Stretch"))
         if self.ui:
             if not Gui.Selection.getSelection():
                 self.ui.selectUi()
@@ -258,7 +258,7 @@ class Stretch(gui_base_original.Modifier):
         if hasattr(self, "nodetracker") and self.nodetracker:
             for n in self.nodetracker:
                 n.finalize()
-        super().finish()
+        super(Stretch, self).finish()
 
     def doStretch(self):
         """Do the actual stretching once the points are selected."""

--- a/src/Mod/Draft/draftguitools/gui_styles.py
+++ b/src/Mod/Draft/draftguitools/gui_styles.py
@@ -53,7 +53,7 @@ class ApplyStyle(gui_base_original.Modifier):
 
         Activate the specific BSpline tracker.
         """
-        super().Activated(name=_tr("Apply style"))
+        super(ApplyStyle, self).Activated(name=_tr("Apply style"))
         if self.ui:
             self.sel = Gui.Selection.getSelection()
             if len(self.sel) > 0:
@@ -75,7 +75,7 @@ class ApplyStyle(gui_base_original.Modifier):
                         _cmd_list.append(_cmd)
                 self.commit(translate("draft", "Change Style"),
                             _cmd_list)
-            super().finish()
+            super(ApplyStyle, self).finish()
 
     def formatGroup(self, group):
         """Format a group instead of simple object."""

--- a/src/Mod/Draft/draftguitools/gui_subelements.py
+++ b/src/Mod/Draft/draftguitools/gui_subelements.py
@@ -69,7 +69,7 @@ class SubelementHighlight(gui_base_original.Modifier):
         if self.is_running:
             return self.finish()
         self.is_running = True
-        super().Activated(name=_tr("Subelement highlight"))
+        super(SubelementHighlight, self).Activated(name=_tr("Subelement highlight"))
         self.get_selection()
 
     def proceed(self):
@@ -86,7 +86,7 @@ class SubelementHighlight(gui_base_original.Modifier):
 
         Re-initialize by running __init__ again at the end.
         """
-        super().finish()
+        super(SubelementHighlight, self).finish()
         self.remove_view_callback()
         self.restore_editable_objects_graphics()
         self.__init__()

--- a/src/Mod/Draft/draftguitools/gui_texts.py
+++ b/src/Mod/Draft/draftguitools/gui_texts.py
@@ -61,7 +61,7 @@ class Text(gui_base_original.Creator):
     def Activated(self):
         """Execute when the command is called."""
         name = translate("draft", "Text")
-        super().Activated(name)
+        super(Text, self).Activated(name)
         if self.ui:
             self.dialog = None
             self.text = ''
@@ -76,7 +76,7 @@ class Text(gui_base_original.Creator):
 
     def finish(self, closed=False, cont=False):
         """Terminate the operation."""
-        super().finish(self)
+        super(Text, self).finish(self)
         if self.ui:
             del self.dialog
             if self.ui.continueMode:

--- a/src/Mod/Draft/draftguitools/gui_togglemodes.py
+++ b/src/Mod/Draft/draftguitools/gui_togglemodes.py
@@ -61,7 +61,7 @@ class BaseMode(gui_base.GuiCommandSimplest):
             Indicates the type of mode to switch to.
             It can be `'construction'` or `'continue'`.
         """
-        super().Activated()
+        super(BaseMode, self).Activated()
 
         if hasattr(Gui, "draftToolBar"):
             _ui = Gui.draftToolBar
@@ -85,7 +85,7 @@ class ToggleConstructionMode(BaseMode):
     """
 
     def __init__(self):
-        super().__init__(name=_tr("Construction mode"))
+        super(ToggleConstructionMode, self).__init__(name=_tr("Construction mode"))
 
     def GetResources(self):
         """Set icon, menu and tooltip."""
@@ -110,7 +110,7 @@ class ToggleConstructionMode(BaseMode):
         It calls the `toggle()` method of the construction button
         in the `DraftToolbar` class.
         """
-        super().Activated(mode="construction")
+        super(ToggleConstructionMode, self).Activated(mode="construction")
 
 
 Gui.addCommand('Draft_ToggleConstructionMode', ToggleConstructionMode())
@@ -125,7 +125,7 @@ class ToggleContinueMode(BaseMode):
     """
 
     def __init__(self):
-        super().__init__(name=_tr("Continue mode"))
+        super(ToggleContinueMode, self).__init__(name=_tr("Continue mode"))
 
     def GetResources(self):
         """Set icon, menu and tooltip."""
@@ -148,7 +148,7 @@ class ToggleContinueMode(BaseMode):
 
         It calls the `toggleContinue()` method of the `DraftToolbar` class.
         """
-        super().Activated(mode="continue")
+        super(ToggleContinueMode, self).Activated(mode="continue")
 
 
 Gui.addCommand('Draft_ToggleContinueMode', ToggleContinueMode())
@@ -166,7 +166,7 @@ class ToggleDisplayMode(gui_base.GuiCommandNeedsSelection):
     """
 
     def __init__(self):
-        super().__init__(name=_tr("Toggle display mode"))
+        super(ToggleDisplayMode, self).__init__(name=_tr("Toggle display mode"))
 
     def GetResources(self):
         """Set icon, menu and tooltip."""
@@ -193,7 +193,7 @@ class ToggleDisplayMode(gui_base.GuiCommandNeedsSelection):
         and changes their `DisplayMode` from `'Wireframe'`
         to `'Flat Lines'`, and the other way around, if possible.
         """
-        super().Activated()
+        super(ToggleDisplayMode, self).Activated()
 
         for obj in Gui.Selection.getSelection():
             if obj.ViewObject.DisplayMode == "Flat Lines":

--- a/src/Mod/Draft/draftguitools/gui_trimex.py
+++ b/src/Mod/Draft/draftguitools/gui_trimex.py
@@ -79,7 +79,7 @@ class Trimex(gui_base_original.Modifier):
 
     def Activated(self):
         """Execute when the command is called."""
-        super().Activated(name=_tr("Trimex"))
+        super(Trimex, self).Activated(name=_tr("Trimex"))
         self.edges = []
         self.placement = None
         self.ghost = []
@@ -541,7 +541,7 @@ class Trimex(gui_base_original.Modifier):
 
     def finish(self, closed=False):
         """Terminate the operation of the Trimex tool."""
-        super().finish()
+        super(Trimex, self).finish()
         self.force = None
         if self.ui:
             if self.linetrack:

--- a/src/Mod/Draft/draftguitools/gui_upgrade.py
+++ b/src/Mod/Draft/draftguitools/gui_upgrade.py
@@ -65,7 +65,7 @@ class Upgrade(gui_base_original.Modifier):
 
     def Activated(self):
         """Execute when the command is called."""
-        super().Activated(name=_tr("Upgrade"))
+        super(Upgrade, self).Activated(name=_tr("Upgrade"))
         if self.ui:
             if not Gui.Selection.getSelection():
                 self.ui.selectUi()

--- a/src/Mod/Draft/draftguitools/gui_wire2spline.py
+++ b/src/Mod/Draft/draftguitools/gui_wire2spline.py
@@ -76,7 +76,7 @@ class WireToBSpline(gui_base_original.Modifier):
         selection = Gui.Selection.getSelection()
         if selection:
             if utils.getType(selection[0]) in ['Wire', 'BSpline']:
-                super().Activated(name=_tr("Convert polyline/B-spline"))
+                super(WireToBSpline, self).Activated(name=_tr("Convert polyline/B-spline"))
                 if self.doc:
                     self.obj = Gui.Selection.getSelection()
                     if self.obj:


### PR DESCRIPTION
The pull requests that re-organize the Gui Commands #3182, #3291, #3299, and #3308, introduce the `super()` function to reference the parent class of a given class. However, those requests use the Python 3 syntax, which means that after these requests the tools will no longer work with Python 2.

This requests has to be merged after #3308 in order to use a `super()` syntax that is valid for Python 2 and 3: `super(ThisClass, self)`.

This is only done to maintain Python 2 compatibility. If we want to use Python 3 exclusively, then this doesn't need to be merged, or this commit can be reverted once Python 2 support is completely dropped.

---

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists