### PR TITLE
[Arch] Adding several docstrings

### DIFF
--- a/src/Mod/Arch/ArchCommands.py
+++ b/src/Mod/Arch/ArchCommands.py
@@ -1242,9 +1242,37 @@ def rebuildArchShape(objects=None):
 
 
 def getExtrusionData(shape,sortmethod="area"):
-    """getExtrusionData(shape,sortmethod): returns a base face and an extrusion vector
-    if this shape can be described as a perpendicular extrusion, or None if not.
-    sortmethod can be "area" (default) or "z"."""
+    """If a shape has been extruded, returns the base face, and extrusion vector.
+
+Determines if a shape appears to have been extruded from some base face, and
+extruded at the normal from that base face. IE: it looks like a cuboid.
+https://en.wikipedia.org/wiki/Cuboid#Rectangular_cuboid
+
+If this is the case, returns what appears to be the base face, and the vector
+used to make that extrusion.
+
+The base face is determined based on the sortmethod parameter, which can either
+be:
+
+"area" = Of the faces with the smallest area, the one with the lowest z coordinate.
+"z" = The face with the lowest z coordinate.
+
+Parameters
+----------
+shape: <Part.Shape>
+    Shape to examine.
+sortmethod: {"area", "z"}
+    Which sorting algorithm to use to determine the base face.
+
+Returns
+-------
+Extrusion data: list
+    Two item list containing the base face, and the vector used to create the
+    extrusion. In that order.
+Failure: None
+    Returns None if the object does not appear to be an extrusion.
+"""
+
     if shape.isNull():
         return None
     if not shape.Solids:

--- a/src/Mod/Arch/ArchCommands.py
+++ b/src/Mod/Arch/ArchCommands.py
@@ -1244,34 +1244,34 @@ def rebuildArchShape(objects=None):
 def getExtrusionData(shape,sortmethod="area"):
     """If a shape has been extruded, returns the base face, and extrusion vector.
 
-Determines if a shape appears to have been extruded from some base face, and
-extruded at the normal from that base face. IE: it looks like a cuboid.
-https://en.wikipedia.org/wiki/Cuboid#Rectangular_cuboid
+    Determines if a shape appears to have been extruded from some base face, and
+    extruded at the normal from that base face. IE: it looks like a cuboid.
+    https://en.wikipedia.org/wiki/Cuboid#Rectangular_cuboid
 
-If this is the case, returns what appears to be the base face, and the vector
-used to make that extrusion.
+    If this is the case, returns what appears to be the base face, and the vector
+    used to make that extrusion.
 
-The base face is determined based on the sortmethod parameter, which can either
-be:
+    The base face is determined based on the sortmethod parameter, which can either
+    be:
 
-"area" = Of the faces with the smallest area, the one with the lowest z coordinate.
-"z" = The face with the lowest z coordinate.
+    "area" = Of the faces with the smallest area, the one with the lowest z coordinate.
+    "z" = The face with the lowest z coordinate.
 
-Parameters
-----------
-shape: <Part.Shape>
-    Shape to examine.
-sortmethod: {"area", "z"}
-    Which sorting algorithm to use to determine the base face.
+    Parameters
+    ----------
+    shape: <Part.Shape>
+        Shape to examine.
+    sortmethod: {"area", "z"}
+        Which sorting algorithm to use to determine the base face.
 
-Returns
--------
-Extrusion data: list
-    Two item list containing the base face, and the vector used to create the
-    extrusion. In that order.
-Failure: None
-    Returns None if the object does not appear to be an extrusion.
-"""
+    Returns
+    -------
+    Extrusion data: list
+        Two item list containing the base face, and the vector used to create the
+        extrusion. In that order.
+    Failure: None
+        Returns None if the object does not appear to be an extrusion.
+    """
 
     if shape.isNull():
         return None

--- a/src/Mod/Arch/ArchComponent.py
+++ b/src/Mod/Arch/ArchComponent.py
@@ -139,15 +139,19 @@ structures. It's properties and behaviours are common to all Arch objects.
 
 You can learn more about Arch Components, and the purpose of Arch Components
 here: https://wiki.freecadweb.org/Arch_Component
+""" 
+
+    def __init__(self, obj):
+        """Initialises the Component.
+
+Registers the Proxy as this class object. Sets the object to have the
+properties of an Arch component.
 
 Parameters
 ----------
 obj: <App::FeaturePython>
     The object to turn into an Arch Component
-""" 
-
-    def __init__(self, obj):
-        """Sets the object to have the properties of an Arch component"""
+"""
 
         obj.Proxy = self
         Component.setProperties(self, obj)
@@ -1000,22 +1004,53 @@ bool
 
 
 class ViewProviderComponent:
+    """A default View Provider for Component objects.
 
-    "A default View Provider for Component objects"
+Acts as a base for all other Arch view providers. It’s properties and
+behaviours are common to all Arch view providers.
+""" 
 
     def __init__(self,vobj):
+        """Initialises the Component view provider.
+
+Registers the Proxy as this class object. Registers the Object, as the view
+provider's object. Sets the view provider to have the
+properties of an Arch component.
+
+Parameters
+----------
+vobj: <Gui.ViewProviderDocumentObject>
+    The view provider to turn into an Component view provider.
+"""
 
         vobj.Proxy = self
         self.Object = vobj.Object
         self.setProperties(vobj)
         
     def setProperties(self,vobj):
+        """Gives the component view provider it's component view provider specific properties.
+
+You can learn more about properties here: https://wiki.freecadweb.org/property
+"""
 
         if not "UseMaterialColor" in vobj.PropertiesList:
             vobj.addProperty("App::PropertyBool","UseMaterialColor","Component",QT_TRANSLATE_NOOP("App::Property","Use the material color as this object's shape color, if available"))
             vobj.UseMaterialColor = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/Arch").GetBool("UseMaterialColor",True)
 
     def updateData(self,obj,prop):
+        """Method called when the host object has a property changed.
+
+If the object has a Material associated with it, matches the view object's
+ShapeColor and Transparency to match the Material.
+
+If the object is now cloned, or is part of a compound, the view object inherits
+the DiffuseColor.
+
+Parameters
+----------
+prop: string
+    The name of the property that has changed.
+"""
 
         #print(obj.Name," : updating ",prop)
         if prop == "Material":
@@ -1055,6 +1090,16 @@ class ViewProviderComponent:
         return
 
     def getIcon(self):
+        """Returns the path to the appropriate icon.
+
+If a clone, returns the cloned component icon path. Otherwise returns the Arch Component
+icon.
+
+Returns
+-------
+str
+    Path to the appropriate icon .svg file.
+"""
 
         import Arch_rc
         if hasattr(self,"Object"):
@@ -1064,6 +1109,21 @@ class ViewProviderComponent:
         return ":/icons/Arch_Component.svg"
 
     def onChanged(self,vobj,prop):
+        """Method called when the view provider has a property changed.
+
+If DiffuseColor changes, change DiffuseColor to copy the host object's clone,
+if it exists.
+
+If ShapeColor changes, overwrite it with DiffuseColor.
+
+If Visibility changes, propagate the change to all view objects that are also
+hosted by this view object's host.
+
+Parameters
+----------
+prop: string
+    The name of the property that has changed.
+"""
 
         #print(vobj.Object.Name, " : changing ",prop)
         #if prop == "Visibility":

--- a/src/Mod/Arch/ArchComponent.py
+++ b/src/Mod/Arch/ArchComponent.py
@@ -1047,12 +1047,12 @@ class ViewProviderComponent:
 
         Registers the Proxy as this class object. Registers the Object, as the view
         provider's object. Sets the view provider to have the
-        properties of an Arch component.
+        properties of a component view provider.
 
         Parameters
         ----------
         vobj: <Gui.ViewProviderDocumentObject>
-            The view provider to turn into an Component view provider.
+            The view provider to turn into a component view provider.
         """
 
         vobj.Proxy = self
@@ -1062,7 +1062,8 @@ class ViewProviderComponent:
     def setProperties(self,vobj):
         """Gives the component view provider it's component view provider specific properties.
 
-        You can learn more about properties here: https://wiki.freecadweb.org/property
+        You can learn more about properties here:
+        https://wiki.freecadweb.org/property
         """
 
         if not "UseMaterialColor" in vobj.PropertiesList:

--- a/src/Mod/Arch/ArchComponent.py
+++ b/src/Mod/Arch/ArchComponent.py
@@ -400,7 +400,7 @@ With this copy, it gets the <Part.Face> the shape was originally extruded from, 
 <Base.Vector> of the extrusion, and the <Base.Placement> needed to move the copy back to it's
 original location/orientation. It will return this data as a tuple.
 
-If it encouters an object derived from a <Part::Multifuse>, it will return this data
+If it encounters an object derived from a <Part::Multifuse>, it will return this data
 as a tuple containing lists. The lists will contain the same data as above, from each
 of the objects within the multifuse.
 

--- a/src/Mod/Arch/ArchComponent.py
+++ b/src/Mod/Arch/ArchComponent.py
@@ -1052,7 +1052,7 @@ class Component(ArchIFC.IfcProduct):
 class ViewProviderComponent:
     """A default View Provider for Component objects.
 
-    Acts as a base for all other Arch view providers. It’s properties and
+    Acts as a base for all other Arch view providers. It's properties and
     behaviours are common to all Arch view providers.
     """ 
 

--- a/src/Mod/Arch/ArchComponent.py
+++ b/src/Mod/Arch/ArchComponent.py
@@ -1248,7 +1248,7 @@ class ViewProviderComponent:
         the mesh associated as the HiRes property of the host object. See
         ArchComponent.Component's properties. 
 
-        If no shape is set in the HiRes propery, just displays the object as
+        If no shape is set in the HiRes property, just displays the object as
         the Flat Lines display mode.
 
         Parameters
@@ -1454,7 +1454,7 @@ class ViewProviderComponent:
         obj: <Part::Feature>
             The object to change the color of.
         force: bool
-            If true, forces the colorisation even if the two objects have very
+            If true, forces the colourisation even if the two objects have very
             similar colors.
         """
 
@@ -1509,7 +1509,7 @@ class ArchSelectionObserver:
     """
 
     def __init__(self,origin=None,watched=None,hide=True,nextCommand=None):
-        """Initalises the ArchSelectionObserver object.
+        """Initialises the ArchSelectionObserver object.
 
         Parameters
         ----------
@@ -1718,7 +1718,7 @@ class ComponentTaskPanel:
         on what the user has selected.
 
         If they have selected one of the root attribute folders, it disables
-        the remove button. If they have seperately selected an object in the 3D
+        the remove button. If they have separately selected an object in the 3D
         view, the add button is enabled, allowing the user to add that object
         to the root attribute folder.
 
@@ -2185,7 +2185,7 @@ if FreeCAD.GuiUp:
 
 
         def __init__(self, parent=None, dialog=None, ptypes=[], plabels=[], *args):
-            """This method initalises the class.
+            """This method initialises the class.
 
             Parameters
             ----------

--- a/src/Mod/Arch/ArchComponent.py
+++ b/src/Mod/Arch/ArchComponent.py
@@ -134,24 +134,24 @@ def removeFromComponent(compobject,subobject):
 class Component(ArchIFC.IfcProduct):
     """The Arch Component object.
 
-Acts as a base for all other Arch objects, such as Arch walls and Arch
-structures. It's properties and behaviours are common to all Arch objects.
+    Acts as a base for all other Arch objects, such as Arch walls and Arch
+    structures. It's properties and behaviours are common to all Arch objects.
 
-You can learn more about Arch Components, and the purpose of Arch Components
-here: https://wiki.freecadweb.org/Arch_Component
-""" 
+    You can learn more about Arch Components, and the purpose of Arch Components
+    here: https://wiki.freecadweb.org/Arch_Component
+    """ 
 
     def __init__(self, obj):
         """Initialises the Component.
 
-Registers the Proxy as this class object. Sets the object to have the
-properties of an Arch component.
+        Registers the Proxy as this class object. Sets the object to have the
+        properties of an Arch component.
 
-Parameters
-----------
-obj: <App::FeaturePython>
-    The object to turn into an Arch Component
-"""
+        Parameters
+        ----------
+        obj: <App::FeaturePython>
+            The object to turn into an Arch Component
+        """
 
         obj.Proxy = self
         Component.setProperties(self, obj)
@@ -160,8 +160,8 @@ obj: <App::FeaturePython>
     def setProperties(self, obj):
         """Gives the component it's component specific properties, such as material.
 
-You can learn more about properties here: https://wiki.freecadweb.org/property
-"""
+        You can learn more about properties here: https://wiki.freecadweb.org/property
+        """
 
         ArchIFC.IfcProduct.setProperties(self, obj)
 
@@ -236,29 +236,29 @@ You can learn more about properties here: https://wiki.freecadweb.org/property
     def onBeforeChange(self,obj,prop):
         """Method called before the object has a property changed. 
 
-Specifically, this method is called before the value changes.
+        Specifically, this method is called before the value changes.
 
-If "Placement" has changed, it records the old placement, so that .onChanged()
-can compare between the old and new placement, and move it's children
-accordingly.
-"""
+        If "Placement" has changed, it records the old placement, so that .onChanged()
+        can compare between the old and new placement, and move it's children
+        accordingly.
+        """
         if prop == "Placement":
             self.oldPlacement = FreeCAD.Placement(obj.Placement)
 
     def onChanged(self, obj, prop):
         """Method called when the object has a property changed.
 
-If "Placement" has changed, the component moves any children components that
-have been set to move with their host, such that they stay in the same location
-to this component.
+        If "Placement" has changed, the component moves any children components that
+        have been set to move with their host, such that they stay in the same location
+        to this component.
 
-Also calls ArchIFC.IfcProduct.onChanged().
+        Also calls ArchIFC.IfcProduct.onChanged().
 
-Parameters
-----------
-prop: string
-    The name of the property that has changed.
-"""
+        Parameters
+        ----------
+        prop: string
+            The name of the property that has changed.
+        """
 
         ArchIFC.IfcProduct.onChanged(self, obj, prop)
 
@@ -293,15 +293,15 @@ prop: string
     def getMovableChildren(self,obj):
         """Finds the component's children set to move with their host.
 
-In this case, children refer to Additions, Subtractions, and objects linked to
-this object that refer to it as a host in the "Host" or "Hosts" properties.
-Objects are set to move with their host via the MoveWithHost property.
+        In this case, children refer to Additions, Subtractions, and objects linked to
+        this object that refer to it as a host in the "Host" or "Hosts" properties.
+        Objects are set to move with their host via the MoveWithHost property.
 
-Returns
--------
-list of <App::FeaturePython>
-    List of child objects set to move with their host.
-"""
+        Returns
+        -------
+        list of <App::FeaturePython>
+            List of child objects set to move with their host.
+        """
 
         ilist = obj.Additions + obj.Subtractions
         for o in obj.InList:
@@ -323,14 +323,14 @@ list of <App::FeaturePython>
     def getParentHeight(self,obj):
         """Gets a height value from hosts.
 
-Recursively crawls hosts until it finds a Floor or BuildingPart, then returns
-the value of it's Height property.
+        Recursively crawls hosts until it finds a Floor or BuildingPart, then returns
+        the value of it's Height property.
 
-Returns
--------
-<App::PropertyLength>
-    The Height value of the found Floor or BuildingPart.
-"""
+        Returns
+        -------
+        <App::PropertyLength>
+            The Height value of the found Floor or BuildingPart.
+        """
         
         for parent in obj.InList:
             if Draft.getType(parent) in ["Floor","BuildingPart"]:
@@ -348,17 +348,17 @@ Returns
     def clone(self,obj):
         """If the object is a clone, copies the shape.
 
-If the object is a clone according to the "CloneOf" property, it copies the object's
-shape and several properties relating to shape, such as "Length" and "Thickness".
+        If the object is a clone according to the "CloneOf" property, it copies the object's
+        shape and several properties relating to shape, such as "Length" and "Thickness".
 
-Will only perform the copy if this object and the object it's a clone of are of the same
-type, or if the object has the type "Component" or "BuildingPart".
+        Will only perform the copy if this object and the object it's a clone of are of the same
+        type, or if the object has the type "Component" or "BuildingPart".
 
-Returns
--------
-bool
-    True if the copy occurs, False if otherwise.
-"""
+        Returns
+        -------
+        bool
+            True if the copy occurs, False if otherwise.
+        """
 
         if hasattr(obj,"CloneOf"):
             if obj.CloneOf:
@@ -375,14 +375,14 @@ bool
     def getSiblings(self,obj):
         """Finds objects that have the same Base object, and type.
 
-Looks to base object, and finds other objects that are based off this base
-object. If these objects are the same type, returns them.
+        Looks to base object, and finds other objects that are based off this base
+        object. If these objects are the same type, returns them.
 
-Returns
--------
-list of <App::FeaturePython>
-    List of objects that have the same Base and type as this component.
-"""
+        Returns
+        -------
+        list of <App::FeaturePython>
+            List of objects that have the same Base and type as this component.
+        """
 
         if not hasattr(obj,"Base"):
             return []
@@ -401,27 +401,27 @@ list of <App::FeaturePython>
     def getExtrusionData(self,obj):
         """Gets the object's extrusion data.
 
-This method recursively scrapes the Bases of the object, until it finds a Base
-that is derived from a <Part::Extrusion>. From there, it copies the extrusion
-to the (0,0,0) origin. 
+        This method recursively scrapes the Bases of the object, until it finds a Base
+        that is derived from a <Part::Extrusion>. From there, it copies the extrusion
+        to the (0,0,0) origin. 
 
-With this copy, it gets the <Part.Face> the shape was originally extruded from, the
-<Base.Vector> of the extrusion, and the <Base.Placement> needed to move the copy back to it's
-original location/orientation. It will return this data as a tuple.
+        With this copy, it gets the <Part.Face> the shape was originally extruded from, the
+        <Base.Vector> of the extrusion, and the <Base.Placement> needed to move the copy back to it's
+        original location/orientation. It will return this data as a tuple.
 
-If it encounters an object derived from a <Part::Multifuse>, it will return this data
-as a tuple containing lists. The lists will contain the same data as above, from each
-of the objects within the multifuse.
+        If it encouters an object derived from a <Part::Multifuse>, it will return this data
+        as a tuple containing lists. The lists will contain the same data as above, from each
+        of the objects within the multifuse.
 
-Returns
--------
-tuple
-    Tuple containing:
+        Returns
+        -------
+        tuple
+            Tuple containing:
 
-    1) The <Part.Face> the object was extruded from.
-    2) The <Base.Vector> of the extrusion.
-    3) The <Base.Placement> of the extrusion.
-"""
+            1) The <Part.Face> the object was extruded from.
+            2) The <Base.Vector> of the extrusion.
+            3) The <Base.Placement> of the extrusion.
+        """
 
         if hasattr(obj,"CloneOf"):
             if obj.CloneOf:
@@ -506,22 +506,22 @@ tuple
     def rebase(self,shape,hint=None):
         """Copies a shape to the (0,0,0) origin.
 
-Creates a copy of a shape, such that it's center of mass is in the (0,0,0)
-origin.
+        Creates a copy of a shape, such that it's center of mass is in the (0,0,0)
+        origin.
 
-TODO Determine the way the shape is rotated by this method.
+        TODO Determine the way the shape is rotated by this method.
 
-Returns the copy of the shape, and the <Base.Placement> needed to move the copy
-back to it's original location/orientation.
+        Returns the copy of the shape, and the <Base.Placement> needed to move the copy
+        back to it's original location/orientation.
 
-Parameters
-----------
-shape: <Part.Shape>
-    The shape to copy.
-hint: <Base.Vector>, optional
-    If the angle between the normal vector of the shape, and the hint vector is
-    greater than 90 degrees, the normal will be reversed before being rotated.
-"""
+        Parameters
+        ----------
+        shape: <Part.Shape>
+            The shape to copy.
+        hint: <Base.Vector>, optional
+            If the angle between the normal vector of the shape, and the hint vector is
+            greater than 90 degrees, the normal will be reversed before being rotated.
+        """
 
         import DraftGeomUtils,math
 
@@ -541,10 +541,7 @@ hint: <Base.Vector>, optional
         if hint and hint.getAngle(n) > 1.58:
             n = n.negative()
 
-        r = FreeCAD.Rotation(
-                FreeCAD.Vector(0,0,1),
-                n
-                )
+        r = FreeCAD.Rotation(FreeCAD.Vector(0, 0, 1), n)
         if round(abs(r.Angle),8) == round(math.pi,8):
             r = FreeCAD.Rotation()
 
@@ -552,11 +549,9 @@ hint: <Base.Vector>, optional
         for s in shape:
             s = s.copy()
             s.translate(v.negative())
-            s.rotate(
-                    FreeCAD.Vector(0,0,0),
-                    r.Axis,
-                    math.degrees(-r.Angle)
-                    )
+            s.rotate(FreeCAD.Vector(0, 0, 0),
+                     r.Axis,
+                     math.degrees(-r.Angle))
             shapes.append(s)
         p = FreeCAD.Placement()
         p.Base = v
@@ -569,19 +564,19 @@ hint: <Base.Vector>, optional
     def hideSubobjects(self,obj,prop):
         """Hides Additions and Subtractions of this Component when that list changes.
 
-Intended to be used in conjunction with the .onChanged() method, to access the
-property that has changed.  
+        Intended to be used in conjunction with the .onChanged() method, to access the
+        property that has changed.  
 
-When an object loses or gains an Addition, this method hides all Additions.
-When it gains or loses a Subtraction, this method hides all Subtractions.
+        When an object loses or gains an Addition, this method hides all Additions.
+        When it gains or loses a Subtraction, this method hides all Subtractions.
 
-Does not effect objects of type Window, or clones of Windows.
+        Does not effect objects of type Window, or clones of Windows.
 
-Parameters
-----------
-prop: string
-    The name of the property that has changed.
-"""
+        Parameters
+        ----------
+        prop: string
+            The name of the property that has changed.
+        """
 
         if FreeCAD.GuiUp:
             if prop in ["Additions","Subtractions"]:
@@ -602,28 +597,28 @@ prop: string
     def processSubShapes(self,obj,base,placement=None):
         """Adds Additions and Subtractions to a base shape.
 
-If Additions exist, fuses then to the base shape. If no base is provided, it
-will just fuse other additions to the first addition.
+        If Additions exist, fuses then to the base shape. If no base is provided, it
+        will just fuse other additions to the first addition.
 
-If Subtractions exist, it will cut them from the base shape. Roofs and Windows
-are treated uniquely, as they define their own Shape to subtract from parent
-shapes using their .getSubVolume() methods.
+        If Subtractions exist, it will cut them from the base shape. Roofs and Windows
+        are treated uniquely, as they define their own Shape to subtract from parent
+        shapes using their .getSubVolume() methods.
 
-TODO determine what the purpose of the placement argument is.
+        TODO determine what the purpose of the placement argument is.
 
-Parameters
-----------
-base: <Part.Shape>, optional
-    The base shape to add Additions and Subtractions to.
-placement: <Base.Placement>, optional
-    Prior to adding or subtracting subshapes, the <Base.Placement> of the
-    subshapes are multiplied by the inverse of this parameter. 
+        Parameters
+        ----------
+        base: <Part.Shape>, optional
+            The base shape to add Additions and Subtractions to.
+        placement: <Base.Placement>, optional
+            Prior to adding or subtracting subshapes, the <Base.Placement> of the
+            subshapes are multiplied by the inverse of this parameter. 
 
-Returns
--------
-<Part.Shape>
-    The base shape, with the additions and subtractions performed.
-"""
+        Returns
+        -------
+        <Part.Shape>
+            The base shape, with the additions and subtractions performed.
+        """
 
         import Draft,Part
         #print("Processing subshapes of ",obj.Label, " : ",obj.Additions)
@@ -726,26 +721,25 @@ Returns
     def spread(self,obj,shape,placement=None):
         """Copies the object to it's Axis's points.
 
-If the object has the "Axis" property assigned, this method creates a copy of
-the shape for each point on the object assigned as the "Axis". Each of these
-copies are then translated, equal to the displacement of the points from the
-(0,0,0) origin.
+        If the object has the "Axis" property assigned, this method creates a copy of
+        the shape for each point on the object assigned as the "Axis". Each of these
+        copies are then translated, equal to the displacement of the points from the
+        (0,0,0) origin.
 
-If the object's "Axis" is unassigned, returns the original shape unchanged.
+        If the object's "Axis" is unassigned, returns the original shape unchanged.
 
-Parameters
-----------
-shape: <Part.Shape>
-    The shape to copy.
-placement:
-    Does nothing.
+        Parameters
+        ----------
+        shape: <Part.Shape>
+            The shape to copy.
+        placement:
+            Does nothing.
 
-Returns
--------
-<Part.Shape>
-    The shape, either spread to the axis points, or unchanged.
-
-"""
+        Returns
+        -------
+        <Part.Shape>
+            The shape, either spread to the axis points, or unchanged.
+        """
 
         points = None
         if hasattr(obj,"Axis"):
@@ -769,19 +763,19 @@ Returns
     def isIdentity(self,placement):
         """Checks if a placement is *almost* zero.
 
-Check if a <Base.Placement>'s displacement from (0,0,0) is almost zero, and if
-the angle of it's rotation about it's axis is almost zero.
+        Check if a <Base.Placement>'s displacement from (0,0,0) is almost zero, and if
+        the angle of it's rotation about it's axis is almost zero.
 
-Parameters
-----------
-placement: <Base.Placement>
-    The placement to examine.
+        Parameters
+        ----------
+        placement: <Base.Placement>
+            The placement to examine.
 
-Returns
--------
-bool
-    Returns true if angle and displacement are almost zero, false it otherwise.
-"""
+        Returns
+        -------
+        bool
+            Returns true if angle and displacement are almost zero, false it otherwise.
+        """
 
         if (placement.Base.Length < 0.000001) and (placement.Rotation.Angle < 0.000001):
             return True
@@ -790,26 +784,26 @@ bool
     def applyShape(self,obj,shape,placement,allowinvalid=False,allownosolid=False):
         """Checks the given shape, then assigns it to the object.
 
-Checks if the shape is valid, isn't null, and if it has volume. Removes
-redundant edges from the shape. Spreads shape to the "Axis" with method
-.spread().
+        Checks if the shape is valid, isn't null, and if it has volume. Removes
+        redundant edges from the shape. Spreads shape to the "Axis" with method
+        .spread().
 
-Sets the object's Shape and Placement to the values given, if successful.
+        Sets the object's Shape and Placement to the values given, if successful.
 
-Finally, runs .computeAreas() method, to calculate the horizontal and vertical
-area of the shape.
+        Finally, runs .computeAreas() method, to calculate the horizontal and vertical
+        area of the shape.
 
-Parameters
-----------
-shape: <Part.Shape>
-    The shape to check and apply to the object.
-placement: <Base.Placement>
-    The placement to apply to the object.
-allowinvalid: bool, optional
-    Whether to allow invalid shapes, or to throw an error.
-allownosolid: bool, optional
-    Whether to allow non-solid shapes, or to throw an error.
-"""
+        Parameters
+        ----------
+        shape: <Part.Shape>
+            The shape to check and apply to the object.
+        placement: <Base.Placement>
+            The placement to apply to the object.
+        allowinvalid: bool, optional
+            Whether to allow invalid shapes, or to throw an error.
+        allownosolid: bool, optional
+            Whether to allow non-solid shapes, or to throw an error.
+        """
 
         if shape:
             if not shape.isNull():
@@ -854,19 +848,19 @@ allownosolid: bool, optional
     def computeAreas(self,obj):
         """Computes the area properties of the object's shape.
 
-Computes the vertical area, horizontal area, and perimeter length of the
-object's shape. 
+        Computes the vertical area, horizontal area, and perimeter length of the
+        object's shape. 
 
-The vertical area is the surface area of the faces perpendicular to the ground.
+        The vertical area is the surface area of the faces perpendicular to the ground.
 
-The horizontal area is the area of the shape, when projected onto a hyperplane
-across the XY axises, IE: the area when viewed from a bird's eye view.
+        The horizontal area is the area of the shape, when projected onto a hyperplane
+        across the XY axises, IE: the area when viewed from a bird's eye view.
 
-The perimeter length is the length of the outside edges of this bird's eye view.
+        The perimeter length is the length of the outside edges of this bird's eye view.
 
-These values are assigned to the object's "VerticalArea", "HorizontalArea", and
-"PerimeterLength" properties.
-"""
+        These values are assigned to the object's "VerticalArea", "HorizontalArea", and
+        "PerimeterLength" properties.
+        """
 
 
         if (not obj.Shape) or obj.Shape.isNull() or (not obj.Shape.isValid()) or (not obj.Shape.Faces):
@@ -937,22 +931,22 @@ These values are assigned to the object's "VerticalArea", "HorizontalArea", and
     def isStandardCase(self,obj):
         """Determines if the component is a standard case of it's IFC type.
 
-Not all IFC types have a standard case.
+        Not all IFC types have a standard case.
 
-If an object is a standard case or not varies between the different types. Each
-type has it's own rules to define what is a standard case.
+        If an object is a standard case or not varies between the different types. Each
+        type has it's own rules to define what is a standard case.
 
-Rotated objects, or objects with Additions or Subtractions are not standard
-cases.
+        Rotated objects, or objects with Additions or Subtractions are not standard
+        cases.
 
-All objects whose IfcType is suffixed with the string " Sandard Case" is
-automatically a standard case.
+        All objects whose IfcType is suffixed with the string " Sandard Case" is
+        automatically a standard case.
 
-Returns
--------
-bool
-    Whether the object is a standard case or not.
-"""
+        Returns
+        -------
+        bool
+            Whether the object is a standard case or not.
+        """
 
         # Standard Case has been set manually by the user
         if obj.IfcType.endswith("Standard Case"):
@@ -1006,22 +1000,22 @@ bool
 class ViewProviderComponent:
     """A default View Provider for Component objects.
 
-Acts as a base for all other Arch view providers. It’s properties and
-behaviours are common to all Arch view providers.
-""" 
+    Acts as a base for all other Arch view providers. It’s properties and
+    behaviours are common to all Arch view providers.
+    """ 
 
     def __init__(self,vobj):
         """Initialises the Component view provider.
 
-Registers the Proxy as this class object. Registers the Object, as the view
-provider's object. Sets the view provider to have the
-properties of an Arch component.
+        Registers the Proxy as this class object. Registers the Object, as the view
+        provider's object. Sets the view provider to have the
+        properties of an Arch component.
 
-Parameters
-----------
-vobj: <Gui.ViewProviderDocumentObject>
-    The view provider to turn into an Component view provider.
-"""
+        Parameters
+        ----------
+        vobj: <Gui.ViewProviderDocumentObject>
+            The view provider to turn into an Component view provider.
+        """
 
         vobj.Proxy = self
         self.Object = vobj.Object
@@ -1030,8 +1024,8 @@ vobj: <Gui.ViewProviderDocumentObject>
     def setProperties(self,vobj):
         """Gives the component view provider it's component view provider specific properties.
 
-You can learn more about properties here: https://wiki.freecadweb.org/property
-"""
+        You can learn more about properties here: https://wiki.freecadweb.org/property
+        """
 
         if not "UseMaterialColor" in vobj.PropertiesList:
             vobj.addProperty("App::PropertyBool","UseMaterialColor","Component",QT_TRANSLATE_NOOP("App::Property","Use the material color as this object's shape color, if available"))
@@ -1040,17 +1034,17 @@ You can learn more about properties here: https://wiki.freecadweb.org/property
     def updateData(self,obj,prop):
         """Method called when the host object has a property changed.
 
-If the object has a Material associated with it, matches the view object's
-ShapeColor and Transparency to match the Material.
+        If the object has a Material associated with it, matches the view object's
+        ShapeColor and Transparency to match the Material.
 
-If the object is now cloned, or is part of a compound, the view object inherits
-the DiffuseColor.
+        If the object is now cloned, or is part of a compound, the view object inherits
+        the DiffuseColor.
 
-Parameters
-----------
-prop: string
-    The name of the property that has changed.
-"""
+        Parameters
+        ----------
+        prop: string
+            The name of the property that has changed.
+        """
 
         #print(obj.Name," : updating ",prop)
         if prop == "Material":
@@ -1092,14 +1086,14 @@ prop: string
     def getIcon(self):
         """Returns the path to the appropriate icon.
 
-If a clone, returns the cloned component icon path. Otherwise returns the Arch Component
-icon.
+        If a clone, returns the cloned component icon path. Otherwise returns the Arch Component
+        icon.
 
-Returns
--------
-str
-    Path to the appropriate icon .svg file.
-"""
+        Returns
+        -------
+        str
+            Path to the appropriate icon .svg file.
+        """
 
         import Arch_rc
         if hasattr(self,"Object"):
@@ -1111,19 +1105,19 @@ str
     def onChanged(self,vobj,prop):
         """Method called when the view provider has a property changed.
 
-If DiffuseColor changes, change DiffuseColor to copy the host object's clone,
-if it exists.
+        If DiffuseColor changes, change DiffuseColor to copy the host object's clone,
+        if it exists.
 
-If ShapeColor changes, overwrite it with DiffuseColor.
+        If ShapeColor changes, overwrite it with DiffuseColor.
 
-If Visibility changes, propagate the change to all view objects that are also
-hosted by this view object's host.
+        If Visibility changes, propagate the change to all view objects that are also
+        hosted by this view object's host.
 
-Parameters
-----------
-prop: string
-    The name of the property that has changed.
-"""
+        Parameters
+        ----------
+        prop: string
+            The name of the property that has changed.
+        """
 
         #print(vobj.Object.Name, " : changing ",prop)
         #if prop == "Visibility":

--- a/src/Mod/Arch/ArchComponent.py
+++ b/src/Mod/Arch/ArchComponent.py
@@ -241,6 +241,13 @@ class Component(ArchIFC.IfcProduct):
         Component.setProperties(self, obj)
 
     def execute(self,obj):
+        """Method run when the object is recomputed.
+
+        If the object is a clone, just copies the shape it's cloned from.
+
+        Processes subshapes of the object to add additions, and subtract
+        subtractions from the object's shape.
+        """
 
         if self.clone(obj):
             return
@@ -267,6 +274,11 @@ class Component(ArchIFC.IfcProduct):
         If "Placement" has changed, it records the old placement, so that .onChanged()
         can compare between the old and new placement, and move it's children
         accordingly.
+
+        Parameters
+        ----------
+        prop: string
+            The name of the property that has changed.
         """
         if prop == "Placement":
             self.oldPlacement = FreeCAD.Placement(obj.Placement)
@@ -1068,6 +1080,8 @@ class ViewProviderComponent:
 
         Parameters
         ----------
+        obj: <App::FeaturePython>
+            The host object that has changed.
         prop: string
             The name of the property that has changed.
         """

--- a/src/Mod/Arch/ArchComponent.py
+++ b/src/Mod/Arch/ArchComponent.py
@@ -54,7 +54,7 @@ else:
 #  is shared by all of the Arch BIM objects
 
 def addToComponent(compobject,addobject,mod=None):
-    """Adds an object to a component's properties.
+    """Add an object to a component's properties.
 
     Does not run if the addobject already exists in the component's properties.
     Adds the object to the first property found of Base, Group, or Hosts.
@@ -114,12 +114,12 @@ def addToComponent(compobject,addobject,mod=None):
 
 
 def removeFromComponent(compobject,subobject):
-    """Removes the object from the given component.
+    """Remove the object from the given component.
 
-    Tries to find the object in the component's properties. If it finds it,
-    removes the object.
+    Try to find the object in the component's properties. If found, remove the
+    object.
 
-    If the object is not found, adds the object in the component's Subtractions
+    If the object is not found, add the object in the component's Subtractions
     property.
 
     Parameters
@@ -180,7 +180,7 @@ class Component(ArchIFC.IfcProduct):
         self.Type = "Component"
 
     def setProperties(self, obj):
-        """Gives the component its component specific properties, such as material.
+        """Give the component its component specific properties, such as material.
 
         You can learn more about properties here:
         https://wiki.freecadweb.org/property
@@ -234,15 +234,15 @@ class Component(ArchIFC.IfcProduct):
         self.Type = "Component"
 
     def onDocumentRestored(self, obj):
-        """Method run when the document is restored. Re-adds the Arch component properties."""
+        """Method run when the document is restored. Re-add the Arch component properties."""
         Component.setProperties(self, obj)
 
     def execute(self,obj):
         """Method run when the object is recomputed.
 
-        If the object is a clone, just copies the shape it's cloned from.
+        If the object is a clone, just copy the shape it's cloned from.
 
-        Processes subshapes of the object to add additions, and subtract
+        Process subshapes of the object to add additions, and subtract
         subtractions from the object's shape.
         """
 
@@ -268,7 +268,7 @@ class Component(ArchIFC.IfcProduct):
 
         Specifically, this method is called before the value changes.
 
-        If "Placement" has changed, it records the old placement, so that
+        If "Placement" has changed, record the old placement, so that
         .onChanged() can compare between the old and new placement, and move
         its children accordingly.
 
@@ -283,11 +283,11 @@ class Component(ArchIFC.IfcProduct):
     def onChanged(self, obj, prop):
         """Method called when the object has a property changed.
 
-        If "Placement" has changed, the component moves any children components
-        that have been set to move with their host, such that they stay in the
-        same location to this component.
+        If "Placement" has changed, move any children components that have been
+        set to move with their host, such that they stay in the same location
+        to this component.
 
-        Also calls ArchIFC.IfcProduct.onChanged().
+        Also call ArchIFC.IfcProduct.onChanged().
 
         Parameters
         ----------
@@ -326,7 +326,7 @@ class Component(ArchIFC.IfcProduct):
                             child.Placement.move(deltap)
 
     def getMovableChildren(self,obj):
-        """Finds the component's children set to move with their host.
+        """Find the component's children set to move with their host.
 
         In this case, children refer to Additions, Subtractions, and objects
         linked to this object that refer to it as a host in the "Host" or
@@ -357,10 +357,10 @@ class Component(ArchIFC.IfcProduct):
         return ilist2
 
     def getParentHeight(self,obj):
-        """Gets a height value from hosts.
+        """Get a height value from hosts.
 
-        Recursively crawls hosts until it finds a Floor or BuildingPart, then
-        returns the value of its Height property.
+        Recursively crawl hosts until a Floor or BuildingPart is found, then
+        return the value of its Height property.
 
         Returns
         -------
@@ -382,14 +382,14 @@ class Component(ArchIFC.IfcProduct):
         return 0
 
     def clone(self,obj):
-        """If the object is a clone, copies the shape.
+        """If the object is a clone, copy the shape.
 
-        If the object is a clone according to the "CloneOf" property, it copies
-        the object's shape and several properties relating to shape, such as
+        If the object is a clone according to the "CloneOf" property, copy the
+        object's shape and several properties relating to shape, such as
         "Length" and "Thickness".
 
-        Will only perform the copy if this object and the object it's a clone
-        of are of the same type, or if the object has the type "Component" or
+        Only perform the copy if this object and the object it's a clone of are
+        of the same type, or if the object has the type "Component" or
         "BuildingPart".
 
         Returns
@@ -411,10 +411,10 @@ class Component(ArchIFC.IfcProduct):
         return False
 
     def getSiblings(self,obj):
-        """Finds objects that have the same Base object, and type.
+        """Find objects that have the same Base object, and type.
 
-        Looks to base object, and finds other objects that are based off this
-        base object. If these objects are the same type, returns them.
+        Look to base object, and find other objects that are based off this
+        base object. If these objects are the same type, return them.
 
         Returns
         -------
@@ -437,20 +437,20 @@ class Component(ArchIFC.IfcProduct):
         return siblings
 
     def getExtrusionData(self,obj):
-        """Gets the object's extrusion data.
+        """Get the object's extrusion data.
 
-        This method recursively scrapes the Bases of the object, until it finds
-        a Base that is derived from a <Part::Extrusion>. From there, it copies
-        the extrusion to the (0,0,0) origin. 
+        Recursively scrape the Bases of the object, until a Base that is
+        derived from a <Part::Extrusion> is found. From there, copy the
+        extrusion to the (0,0,0) origin. 
 
-        With this copy, it gets the <Part.Face> the shape was originally
+        With this copy, get the <Part.Face> the shape was originally
         extruded from, the <Base.Vector> of the extrusion, and the
         <Base.Placement> needed to move the copy back to its original
-        location/orientation. It will return this data as a tuple.
+        location/orientation. Return this data as a tuple.
 
-        If it encounters an object derived from a <Part::Multifuse>, it will
-        return this data as a tuple containing lists. The lists will contain
-        the same data as above, from each of the objects within the multifuse.
+        If an object derived from a <Part::Multifuse> is encountered, return
+        this data as a tuple containing lists. The lists will contain the same
+        data as above, from each of the objects within the multifuse.
 
         Returns
         -------
@@ -543,14 +543,14 @@ class Component(ArchIFC.IfcProduct):
         return None
 
     def rebase(self,shape,hint=None):
-        """Copies a shape to the (0,0,0) origin.
+        """Copy a shape to the (0,0,0) origin.
 
-        Creates a copy of a shape, such that its center of mass is in the
+        Create a copy of a shape, such that its center of mass is in the
         (0,0,0) origin.
 
         TODO Determine the way the shape is rotated by this method.
 
-        Returns the copy of the shape, and the <Base.Placement> needed to move
+        Return the copy of the shape, and the <Base.Placement> needed to move
         the copy back to its original location/orientation.
 
         Parameters
@@ -636,14 +636,14 @@ class Component(ArchIFC.IfcProduct):
 
 
     def processSubShapes(self,obj,base,placement=None):
-        """Adds Additions and Subtractions to a base shape.
+        """Add Additions and Subtractions to a base shape.
 
-        If Additions exist, fuses then to the base shape. If no base is
-        provided, it will just fuse other additions to the first addition.
+        If Additions exist, fuse them to the base shape. If no base is
+        provided, just fuse other additions to the first addition.
 
-        If Subtractions exist, it will cut them from the base shape. Roofs and
-        Windows are treated uniquely, as they define their own Shape to
-        subtract from parent shapes using their .getSubVolume() methods.
+        If Subtractions exist, cut them from the base shape. Roofs and Windows
+        are treated uniquely, as they define their own Shape to subtract from
+        parent shapes using their .getSubVolume() methods.
 
         TODO determine what the purpose of the placement argument is.
 
@@ -760,14 +760,14 @@ class Component(ArchIFC.IfcProduct):
         return base
 
     def spread(self,obj,shape,placement=None):
-        """Copies the object to its Axis's points.
+        """Copy the object to its Axis's points.
 
-        If the object has the "Axis" property assigned, this method creates a
-        copy of the shape for each point on the object assigned as the "Axis".
-        Each of these copies are then translated, equal to the displacement of
-        the points from the (0,0,0) origin.
+        If the object has the "Axis" property assigned, create a copy of the
+        shape for each point on the object assigned as the "Axis".  Translate
+        each of these copies equal to the displacement of the points from the
+        (0,0,0) origin.
 
-        If the object's "Axis" is unassigned, returns the original shape
+        If the object's "Axis" is unassigned, return the original shape
         unchanged.
 
         Parameters
@@ -803,7 +803,7 @@ class Component(ArchIFC.IfcProduct):
         return shape
 
     def isIdentity(self,placement):
-        """Checks if a placement is *almost* zero.
+        """Check if a placement is *almost* zero.
 
         Check if a <Base.Placement>'s displacement from (0,0,0) is almost zero,
         and if the angle of its rotation about its axis is almost zero.
@@ -825,16 +825,16 @@ class Component(ArchIFC.IfcProduct):
         return False
 
     def applyShape(self,obj,shape,placement,allowinvalid=False,allownosolid=False):
-        """Checks the given shape, then assigns it to the object.
+        """Check the given shape, then assign it to the object.
 
-        Checks if the shape is valid, isn't null, and if it has volume. Removes
-        redundant edges from the shape. Spreads shape to the "Axis" with method
-        .spread().
+        Check if the shape is valid, isn't null, and if it has volume. Remove
+        redundant edges from the shape. Spread the shape to the "Axis" with
+        method .spread().
 
-        Sets the object's Shape and Placement to the values given, if
+        Set the object's Shape and Placement to the values given, if
         successful.
 
-        Finally, runs .computeAreas() method, to calculate the horizontal and
+        Finally, run .computeAreas() method, to calculate the horizontal and
         vertical area of the shape.
 
         Parameters
@@ -890,9 +890,9 @@ class Component(ArchIFC.IfcProduct):
         self.computeAreas(obj)
 
     def computeAreas(self,obj):
-        """Computes the area properties of the object's shape.
+        """Compute the area properties of the object's shape.
 
-        Computes the vertical area, horizontal area, and perimeter length of
+        Compute the vertical area, horizontal area, and perimeter length of
         the object's shape. 
 
         The vertical area is the surface area of the faces perpendicular to the
@@ -905,8 +905,8 @@ class Component(ArchIFC.IfcProduct):
         The perimeter length is the length of the outside edges of this bird's
         eye view.
 
-        These values are assigned to the object's "VerticalArea",
-        "HorizontalArea", and "PerimeterLength" properties.
+        Assign these values to the object's "VerticalArea", "HorizontalArea",
+        and "PerimeterLength" properties.
         """
 
 
@@ -976,7 +976,7 @@ class Component(ArchIFC.IfcProduct):
                         obj.PerimeterLength = self.flatarea.Faces[0].OuterWire.Length
 
     def isStandardCase(self,obj):
-        """Determines if the component is a standard case of its IFC type.
+        """Determine if the component is a standard case of its IFC type.
 
         Not all IFC types have a standard case.
 
@@ -987,7 +987,7 @@ class Component(ArchIFC.IfcProduct):
         standard cases.
 
         All objects whose IfcType is suffixed with the string " Sandard Case"
-        is automatically a standard case.
+        are automatically a standard case.
 
         Returns
         -------
@@ -1049,27 +1049,20 @@ class ViewProviderComponent:
 
     Acts as a base for all other Arch view providers. It's properties and
     behaviours are common to all Arch view providers.
+
+    Parameters
+    ----------
+    vobj: <Gui.ViewProviderDocumentObject>
+        The view provider to turn into a component view provider.
     """ 
 
     def __init__(self,vobj):
-        """Initialises the Component view provider.
-
-        Registers the Proxy as this class object. Registers the Object, as the
-        view provider's object. Sets the view provider to have the properties
-        of a component view provider.
-
-        Parameters
-        ----------
-        vobj: <Gui.ViewProviderDocumentObject>
-            The view provider to turn into a component view provider.
-        """
-
         vobj.Proxy = self
         self.Object = vobj.Object
         self.setProperties(vobj)
         
     def setProperties(self,vobj):
-        """Gives the component view provider its component view provider specific properties.
+        """Give the component view provider its component view provider specific properties.
 
         You can learn more about properties here:
         https://wiki.freecadweb.org/property
@@ -1082,11 +1075,11 @@ class ViewProviderComponent:
     def updateData(self,obj,prop):
         """Method called when the host object has a property changed.
 
-        If the object has a Material associated with it, matches the view
+        If the object has a Material associated with it, match the view
         object's ShapeColor and Transparency to match the Material.
 
-        If the object is now cloned, or is part of a compound, the view object
-        inherits the DiffuseColor.
+        If the object is now cloned, or is part of a compound, have the view
+        object inherit the DiffuseColor.
 
         Parameters
         ----------
@@ -1134,10 +1127,10 @@ class ViewProviderComponent:
         return
 
     def getIcon(self):
-        """Returns the path to the appropriate icon.
+        """Return the path to the appropriate icon.
 
-        If a clone, returns the cloned component icon path. Otherwise returns
-        the Arch Component icon.
+        If a clone, return the cloned component icon path. Otherwise return the
+        Arch Component icon.
 
         Returns
         -------
@@ -1196,9 +1189,9 @@ class ViewProviderComponent:
         return
 
     def attach(self,vobj):
-        """Adds display modes' data to the coin scenegraph.
+        """Add display modes' data to the coin scenegraph.
 
-        Adds each display mode as a coin node, whose parent is this view
+        Add each display mode as a coin node, whose parent is this view
         provider. 
 
         Each display mode's node includes the data needed to display the object
@@ -1206,7 +1199,7 @@ class ViewProviderComponent:
         lines. This data is stored as additional coin nodes which are children
         of the display mode node.
 
-        Adds the HiRes display mode.
+        Add the HiRes display mode.
         """
 
         from pivy import coin
@@ -1219,9 +1212,9 @@ class ViewProviderComponent:
         return
 
     def getDisplayModes(self,vobj):
-        """Defines the display modes unique to the Arch Component.
+        """Define the display modes unique to the Arch Component.
 
-        Defines mode HiRes, which displays the component as a mesh, intended as
+        Define mode HiRes, which displays the component as a mesh, intended as
         a more visually appealing version of the component.
 
         Returns
@@ -1239,11 +1232,11 @@ class ViewProviderComponent:
         Called when the display mode changes, this method can be used to set
         data that wasn't available when .attach() was called.
 
-        When HiRes is set as display mode, displays the component as a copy of
+        When HiRes is set as display mode, display the component as a copy of
         the mesh associated as the HiRes property of the host object. See
         ArchComponent.Component's properties. 
 
-        If no shape is set in the HiRes property, just displays the object as
+        If no shape is set in the HiRes property, just display the object as
         the Flat Lines display mode.
 
         Parameters
@@ -1306,10 +1299,10 @@ class ViewProviderComponent:
         return None
 
     def claimChildren(self):
-        """Defines which objects will appear as children in the tree view.
+        """Define which objects will appear as children in the tree view.
 
-        Sets the host object's Base object as a child, and sets any additions
-        or subtractions as children.
+        Set the host object's Base object as a child, and set any additions or
+        subtractions as children.
 
         Returns
         -------
@@ -1351,8 +1344,7 @@ class ViewProviderComponent:
         return []
 
     def setEdit(self,vobj,mode):
-        """Method called when the document requests the object to enter edit
-        mode.
+        """Method called when the document requests the object to enter edit mode.
 
         Edit mode is entered when a user double clicks on an object in the tree
         view, or when they use the menu option [Edit -> Toggle Edit Mode].
@@ -1389,12 +1381,12 @@ class ViewProviderComponent:
         return False
 
     def setupContextMenu(self,vobj,menu):
-        """Adds the component specific options to the context menu.
+        """Add the component specific options to the context menu.
 
         The context menu is the drop down menu that opens when the user right
         clicks on the component in the tree view.
 
-        Adds a menu choice to call the Arch_ToggleSubs Gui command. See
+        Add a menu choice to call the Arch_ToggleSubs Gui command. See
         ArchCommands._ToggleSubs
 
         Parameters
@@ -1416,7 +1408,7 @@ class ViewProviderComponent:
         FreeCADGui.runCommand("Arch_ToggleSubs")
 
     def areDifferentColors(self,a,b):
-        """Checks if two diffuse colors are almost the same.
+        """Check if two diffuse colors are almost the same.
 
         Parameters
         ----------
@@ -1439,10 +1431,10 @@ class ViewProviderComponent:
         return False
 
     def colorize(self,obj,force=False):
-        """If an object is a clone, sets it it to copy the color of its parent.
+        """If an object is a clone, set it it to copy the color of its parent.
 
-        Will only change the color of the clone if the clone and its parent
-        have colors that are distinguishably different from each other.
+        Only change the color of the clone if the clone and its parent have
+        colors that are distinguishably different from each other.
 
         Parameters
         ----------
@@ -1461,7 +1453,7 @@ class ViewProviderComponent:
                 obj.ViewObject.DiffuseColor = obj.CloneOf.ViewObject.DiffuseColor
     
     def getHosts(self):
-        """Returns the hosts of the view provider's host object.
+        """Return the hosts of the view provider's host object.
 
         Note that in this case, the hosts are the objects referenced by Arch
         Rebar's "Host" and/or "Hosts" properties specifically. Only Arch Rebar
@@ -1530,11 +1522,11 @@ class ArchSelectionObserver:
     def addSelection(self,document, object, element, position):
         """Method called when a selection is made on the Gui.
 
-        When a nextCommand is specified, the observer fires a Gui command when
-        anything is selected.
+        When a nextCommand is specified, fire a Gui command when anything is
+        selected.
 
-        When a watched object is specified, the observer will only fire when
-        this watched object is selected.
+        When a watched object is specified, only fire when this watched object
+        is selected.
 
         Parameters
         ----------
@@ -1661,8 +1653,8 @@ class ComponentTaskPanel:
         self.update()
 
     def isAllowedAlterSelection(self):
-        """This method indicates whether this task dialog allows other commands
-        to modify the selection while it is open.
+        """Indicate whether this task dialog allows other commands to modify
+        the selection while it is open.
 
         Returns
         -------
@@ -1673,8 +1665,8 @@ class ComponentTaskPanel:
         return True
 
     def isAllowedAlterView(self):
-        """This method indicates whether this task dialog allows other commands
-        to modify the 3D view while it is open.
+        """Indicate whether this task dialog allows other commands to modify
+        the 3D view while it is open.
 
         Returns
         -------
@@ -1685,25 +1677,24 @@ class ComponentTaskPanel:
         return True
 
     def getStandardButtons(self):
-        """Adds the standard ok button."""
+        """Add the standard ok button."""
 
         return int(QtGui.QDialogButtonBox.Ok)
 
     def check(self,wid,col):
-        """This method is run as the callback when the user selects an item in
-        the tree.
+        """This method is run as the callback when the user selects an item in the tree.
 
-        This method enables and disables the add and remove buttons depending
-        on what the user has selected.
+        Enable and disable the add and remove buttons depending on what the
+        user has selected.
 
-        If they have selected one of the root attribute folders, it disables
-        the remove button. If they have separately selected an object in the 3D
-        view, the add button is enabled, allowing the user to add that object
-        to the root attribute folder.
+        If they have selected one of the root attribute folders, disable the
+        remove button. If they have separately selected an object in the 3D
+        view, enable the add button, allowing the user to add that object to
+        the root attribute folder.
 
         If they have selected one of the items inside a root attribute folder,
-        it enables the remove button, allowing the user to remove the object
-        from that attribute.
+        enable the remove button, allowing the user to remove the object from
+        that attribute.
 
         Parameters
         ----------
@@ -1723,7 +1714,7 @@ class ComponentTaskPanel:
             self.addButton.setEnabled(False)
 
     def getIcon(self,obj):
-        """Gets the path to the icons, of the items that fill the tree widget.
+        """Get the path to the icons, of the items that fill the tree widget.
         """
 
         if hasattr(obj.ViewObject,"Proxy"):
@@ -1736,15 +1727,15 @@ class ComponentTaskPanel:
         return QtGui.QIcon(":/icons/Tree_Part.svg")
 
     def update(self):
-        """Populates the treewidget with its various items.
+        """Populate the treewidget with its various items.
 
-        Checks if the object being edited has attributes relevant to
-        subobjects. IE: Additions, Subtractions, etc.
+        Check if the object being edited has attributes relevant to subobjects.
+        IE: Additions, Subtractions, etc.
 
-        Populates the tree with these subobjects, under folders named after the
+        Populate the tree with these subobjects, under folders named after the
         attributes they are listed in.
 
-        Finally, runs method .retranslateUi().
+        Finally, run method .retranslateUi().
         """
 
         self.tree.clear()
@@ -1780,14 +1771,13 @@ class ComponentTaskPanel:
         self.retranslateUi(self.baseform)
 
     def addElement(self):
-        """This method is run as a callback when the user selects the add
-        button.
+        """This method is run as a callback when the user selects the add button.
 
-        Gets the object selected in the 3D view, and gets the attribute folder
+        Get the object selected in the 3D view, and get the attribute folder
         selected in the tree widget.
 
-        Adds the object selected in the 3D view to the attribute associated
-        with the selected folder, by using function addToComponent().
+        Add the object selected in the 3D view to the attribute associated with
+        the selected folder, by using function addToComponent().
         """
 
         it = self.tree.currentItem()
@@ -1801,12 +1791,11 @@ class ComponentTaskPanel:
         self.update()
 
     def removeElement(self):
-        """This method is run as a callback when the user selects the remove
-        button.
+        """This method is run as a callback when the user selects the remove button.
 
-        Gets the object selected in the tree widget. If there is an object in
-        the document with the same Name as the selected item in the tree, it is
-        removed from the object being edited, with the removeFromComponent()
+        Get the object selected in the tree widget. If there is an object in
+        the document with the same Name as the selected item in the tree,
+        remove it from the object being edited, with the removeFromComponent()
         function.
         """
 
@@ -1819,7 +1808,7 @@ class ComponentTaskPanel:
     def accept(self):
         """This method runs as a callback when the user selects the ok button.
 
-        It recomputes the document, and leaves edit mode.
+        Recomputes the document, and leave edit mode.
         """
 
         FreeCAD.ActiveDocument.recompute()
@@ -1829,10 +1818,10 @@ class ComponentTaskPanel:
     def editObject(self,wid,col):
         """This method is run when the user double clicks on an item in the tree widget.
 
-        If the item in the tree has a corresponding object in the document, it
-        enters edit mode for that associated object.
+        If the item in the tree has a corresponding object in the document,
+        enter edit mode for that associated object.
 
-        At the same time, it makes the object this task panel was opened for
+        At the same time, make the object this task panel was opened for
         transparent and unselectable.
 
         Parameters
@@ -1855,7 +1844,7 @@ class ComponentTaskPanel:
                 FreeCADGui.ActiveDocument.setEdit(obj.Name,0)
 
     def retranslateUi(self, TaskPanel):
-        """Adds the text of the task panel, in translated form.
+        """Add the text of the task panel, in translated form.
         """
 
         self.baseform.setWindowTitle(QtGui.QApplication.translate("Arch", "Component", None))
@@ -1875,13 +1864,13 @@ class ComponentTaskPanel:
         self.classButton.setText(QtGui.QApplication.translate("Arch", "Edit standard code", None))
 
     def editIfcProperties(self):
-        """Opens the IFC editor dialog box.
+        """Open the IFC editor dialog box.
 
         This is the method that runs as a callback when the Edit IFC properties
         button is selected by the user.
 
-        It defines the editor's structure, fills it with data, adds callback
-        for the buttons and other interactions, and shows it.
+        Defines the editor's structure, fill it with data, add a callback for
+        the buttons and other interactions, and show it.
         """
 
         if hasattr(self,"ifcEditor"):
@@ -1989,10 +1978,9 @@ class ComponentTaskPanel:
     def acceptIfcProperties(self):
         """This method runs as a callback when the user selects the ok button in the IFC editor.
         
-        This method scrapes through the rows of the IFC editor's items, and
-        compares them to the object being edited's .IfcData. If the two are
-        different, it changes the object's .IfcData to match the editor's
-        items.
+        Scrape through the rows of the IFC editor's items, and compare them to
+        the object being edited's .IfcData. If the two are different, change
+        the object's .IfcData to match the editor's items.
         """
 
         if hasattr(self,"ifcEditor") and self.ifcEditor:
@@ -2026,7 +2014,7 @@ class ComponentTaskPanel:
             del self.ifcEditor
 
     def addIfcProperty(self,idx=0,pset=None,prop=None,ptype=None):
-        """Adds an IFC property to the object, within the IFC editor.
+        """Add an IFC property to the object, within the IFC editor.
 
         This method runs as a callback when the user selects an option in the
         Add Property dropdown box in the IFC editor. When used via the
@@ -2085,14 +2073,14 @@ class ComponentTaskPanel:
                 self.ifcEditor.comboProperty.setCurrentIndex(0)
 
     def addIfcPset(self,idx=0):
-        """Adds a IFC property set to the object, within the IFC editor.
+        """Add an IFC property set to the object, within the IFC editor.
         
         This method runs as a callback when the user selects a property set
         within the Add property set dropdown.
 
-        Adds the property set selected in the dropdown, then checks the
-        property set definitions for the property set's standard properties,
-        and adds them with blank values to the new property set.
+        Add the property set selected in the dropdown, then check the property
+        set definitions for the property set's standard properties, and add
+        them with blank values to the new property set.
 
         Parameters
         ----------
@@ -2127,13 +2115,13 @@ class ComponentTaskPanel:
                 self.ifcEditor.comboPset.setCurrentIndex(0)
 
     def removeIfcProperty(self):
-        """Removes an IFC property or property set from the object, within the IFC editor.
+        """Remove an IFC property or property set from the object, within the IFC editor.
 
         This method runs as a callback when the user selects the Delete
         selected property/set button within the IFC editor.
 
-        It finds the selected property, and deletes it. If it's a property set,
-        it deletes the children properties as well.
+        Find the selected property, and delete it. If it's a property set,
+        delete the children properties as well.
         """
 
         if hasattr(self,"ifcEditor") and self.ifcEditor:
@@ -2181,11 +2169,11 @@ if FreeCAD.GuiUp:
             self.plabels = plabels
 
         def createEditor(self,parent,option,index):
-            """Returns the widget used to change data.
+            """Return the widget used to change data.
 
-            Returns a text line editor if editing the property name.  Returns a
+            Return a text line editor if editing the property name.  Return a
             dropdown to change property type if editing property type.  If
-            editing the property's value, returns an appropriate widget
+            editing the property's value, return an appropriate widget
             depending on the datatype of the value.
 
             Parameters
@@ -2226,11 +2214,11 @@ if FreeCAD.GuiUp:
             return editor
 
         def setEditorData(self, editor, index):
-            """Gives data to the edit widget.
+            """Give data to the edit widget.
 
-            This method extracts the data already present in the table, and
-            writes it to the editor. This means the user starts the editor with
-            their previous data already present, instead of a blank slate.
+            Extract the data already present in the table, and write it to the
+            editor. This means the user starts the editor with their previous
+            data already present, instead of a blank slate.
 
             Parameters
             ----------
@@ -2272,7 +2260,7 @@ if FreeCAD.GuiUp:
                     editor.setText(index.data())
 
         def setModelData(self, editor, model, index):
-            """Writes the data in the editor to the IFC editor's table.
+            """Write the data in the editor to the IFC editor's table.
 
             Parameters
             ----------

--- a/src/Mod/Arch/ArchComponent.py
+++ b/src/Mod/Arch/ArchComponent.py
@@ -55,8 +55,8 @@ else:
 def addToComponent(compobject,addobject,mod=None):
     """Adds an object to a component's properties.
 
-    Does not run if the addobject already exists in the component's properties. Adds
-    the object to the first property found of Base, Group, or Hosts.
+    Does not run if the addobject already exists in the component's properties.
+    Adds the object to the first property found of Base, Group, or Hosts.
 
     If mod is provided, adds the object to that property instead.
 
@@ -118,7 +118,8 @@ def removeFromComponent(compobject,subobject):
     Tries to find the object in the component's properties. If it finds it,
     removes the object.
 
-    If the object is not found, adds the object in the component's Subtractions property.
+    If the object is not found, adds the object in the component's Subtractions
+    property.
 
     Parameters
     ----------
@@ -163,8 +164,8 @@ class Component(ArchIFC.IfcProduct):
     Acts as a base for all other Arch objects, such as Arch walls and Arch
     structures. It's properties and behaviours are common to all Arch objects.
 
-    You can learn more about Arch Components, and the purpose of Arch Components
-    here: https://wiki.freecadweb.org/Arch_Component
+    You can learn more about Arch Components, and the purpose of Arch
+    Components here: https://wiki.freecadweb.org/Arch_Component
     """ 
 
     def __init__(self, obj):
@@ -186,7 +187,8 @@ class Component(ArchIFC.IfcProduct):
     def setProperties(self, obj):
         """Gives the component it's component specific properties, such as material.
 
-        You can learn more about properties here: https://wiki.freecadweb.org/property
+        You can learn more about properties here:
+        https://wiki.freecadweb.org/property
         """
 
         ArchIFC.IfcProduct.setProperties(self, obj)
@@ -271,9 +273,9 @@ class Component(ArchIFC.IfcProduct):
 
         Specifically, this method is called before the value changes.
 
-        If "Placement" has changed, it records the old placement, so that .onChanged()
-        can compare between the old and new placement, and move it's children
-        accordingly.
+        If "Placement" has changed, it records the old placement, so that
+        .onChanged() can compare between the old and new placement, and move
+        it's children accordingly.
 
         Parameters
         ----------
@@ -286,9 +288,9 @@ class Component(ArchIFC.IfcProduct):
     def onChanged(self, obj, prop):
         """Method called when the object has a property changed.
 
-        If "Placement" has changed, the component moves any children components that
-        have been set to move with their host, such that they stay in the same location
-        to this component.
+        If "Placement" has changed, the component moves any children components
+        that have been set to move with their host, such that they stay in the
+        same location to this component.
 
         Also calls ArchIFC.IfcProduct.onChanged().
 
@@ -331,9 +333,10 @@ class Component(ArchIFC.IfcProduct):
     def getMovableChildren(self,obj):
         """Finds the component's children set to move with their host.
 
-        In this case, children refer to Additions, Subtractions, and objects linked to
-        this object that refer to it as a host in the "Host" or "Hosts" properties.
-        Objects are set to move with their host via the MoveWithHost property.
+        In this case, children refer to Additions, Subtractions, and objects
+        linked to this object that refer to it as a host in the "Host" or
+        "Hosts" properties. Objects are set to move with their host via the
+        MoveWithHost property.
 
         Returns
         -------
@@ -361,8 +364,8 @@ class Component(ArchIFC.IfcProduct):
     def getParentHeight(self,obj):
         """Gets a height value from hosts.
 
-        Recursively crawls hosts until it finds a Floor or BuildingPart, then returns
-        the value of it's Height property.
+        Recursively crawls hosts until it finds a Floor or BuildingPart, then
+        returns the value of it's Height property.
 
         Returns
         -------
@@ -386,11 +389,13 @@ class Component(ArchIFC.IfcProduct):
     def clone(self,obj):
         """If the object is a clone, copies the shape.
 
-        If the object is a clone according to the "CloneOf" property, it copies the object's
-        shape and several properties relating to shape, such as "Length" and "Thickness".
+        If the object is a clone according to the "CloneOf" property, it copies
+        the object's shape and several properties relating to shape, such as
+        "Length" and "Thickness".
 
-        Will only perform the copy if this object and the object it's a clone of are of the same
-        type, or if the object has the type "Component" or "BuildingPart".
+        Will only perform the copy if this object and the object it's a clone
+        of are of the same type, or if the object has the type "Component" or
+        "BuildingPart".
 
         Returns
         -------
@@ -413,8 +418,8 @@ class Component(ArchIFC.IfcProduct):
     def getSiblings(self,obj):
         """Finds objects that have the same Base object, and type.
 
-        Looks to base object, and finds other objects that are based off this base
-        object. If these objects are the same type, returns them.
+        Looks to base object, and finds other objects that are based off this
+        base object. If these objects are the same type, returns them.
 
         Returns
         -------
@@ -439,17 +444,18 @@ class Component(ArchIFC.IfcProduct):
     def getExtrusionData(self,obj):
         """Gets the object's extrusion data.
 
-        This method recursively scrapes the Bases of the object, until it finds a Base
-        that is derived from a <Part::Extrusion>. From there, it copies the extrusion
-        to the (0,0,0) origin. 
+        This method recursively scrapes the Bases of the object, until it finds
+        a Base that is derived from a <Part::Extrusion>. From there, it copies
+        the extrusion to the (0,0,0) origin. 
 
-        With this copy, it gets the <Part.Face> the shape was originally extruded from, the
-        <Base.Vector> of the extrusion, and the <Base.Placement> needed to move the copy back to it's
-        original location/orientation. It will return this data as a tuple.
+        With this copy, it gets the <Part.Face> the shape was originally
+        extruded from, the <Base.Vector> of the extrusion, and the
+        <Base.Placement> needed to move the copy back to it's original
+        location/orientation. It will return this data as a tuple.
 
-        If it encouters an object derived from a <Part::Multifuse>, it will return this data
-        as a tuple containing lists. The lists will contain the same data as above, from each
-        of the objects within the multifuse.
+        If it encounters an object derived from a <Part::Multifuse>, it will
+        return this data as a tuple containing lists. The lists will contain
+        the same data as above, from each of the objects within the multifuse.
 
         Returns
         -------
@@ -544,21 +550,22 @@ class Component(ArchIFC.IfcProduct):
     def rebase(self,shape,hint=None):
         """Copies a shape to the (0,0,0) origin.
 
-        Creates a copy of a shape, such that it's center of mass is in the (0,0,0)
-        origin.
+        Creates a copy of a shape, such that it's center of mass is in the
+        (0,0,0) origin.
 
         TODO Determine the way the shape is rotated by this method.
 
-        Returns the copy of the shape, and the <Base.Placement> needed to move the copy
-        back to it's original location/orientation.
+        Returns the copy of the shape, and the <Base.Placement> needed to move
+        the copy back to it's original location/orientation.
 
         Parameters
         ----------
         shape: <Part.Shape>
             The shape to copy.
         hint: <Base.Vector>, optional
-            If the angle between the normal vector of the shape, and the hint vector is
-            greater than 90 degrees, the normal will be reversed before being rotated.
+            If the angle between the normal vector of the shape, and the hint
+            vector is greater than 90 degrees, the normal will be reversed
+            before being rotated.
         """
 
         import DraftGeomUtils,math
@@ -602,11 +609,12 @@ class Component(ArchIFC.IfcProduct):
     def hideSubobjects(self,obj,prop):
         """Hides Additions and Subtractions of this Component when that list changes.
 
-        Intended to be used in conjunction with the .onChanged() method, to access the
-        property that has changed.  
+        Intended to be used in conjunction with the .onChanged() method, to
+        access the property that has changed.  
 
-        When an object loses or gains an Addition, this method hides all Additions.
-        When it gains or loses a Subtraction, this method hides all Subtractions.
+        When an object loses or gains an Addition, this method hides all
+        Additions.  When it gains or loses a Subtraction, this method hides all
+        Subtractions.
 
         Does not effect objects of type Window, or clones of Windows.
 
@@ -635,12 +643,12 @@ class Component(ArchIFC.IfcProduct):
     def processSubShapes(self,obj,base,placement=None):
         """Adds Additions and Subtractions to a base shape.
 
-        If Additions exist, fuses then to the base shape. If no base is provided, it
-        will just fuse other additions to the first addition.
+        If Additions exist, fuses then to the base shape. If no base is
+        provided, it will just fuse other additions to the first addition.
 
-        If Subtractions exist, it will cut them from the base shape. Roofs and Windows
-        are treated uniquely, as they define their own Shape to subtract from parent
-        shapes using their .getSubVolume() methods.
+        If Subtractions exist, it will cut them from the base shape. Roofs and
+        Windows are treated uniquely, as they define their own Shape to
+        subtract from parent shapes using their .getSubVolume() methods.
 
         TODO determine what the purpose of the placement argument is.
 
@@ -649,8 +657,8 @@ class Component(ArchIFC.IfcProduct):
         base: <Part.Shape>, optional
             The base shape to add Additions and Subtractions to.
         placement: <Base.Placement>, optional
-            Prior to adding or subtracting subshapes, the <Base.Placement> of the
-            subshapes are multiplied by the inverse of this parameter. 
+            Prior to adding or subtracting subshapes, the <Base.Placement> of
+            the subshapes are multiplied by the inverse of this parameter. 
 
         Returns
         -------
@@ -759,12 +767,13 @@ class Component(ArchIFC.IfcProduct):
     def spread(self,obj,shape,placement=None):
         """Copies the object to it's Axis's points.
 
-        If the object has the "Axis" property assigned, this method creates a copy of
-        the shape for each point on the object assigned as the "Axis". Each of these
-        copies are then translated, equal to the displacement of the points from the
-        (0,0,0) origin.
+        If the object has the "Axis" property assigned, this method creates a
+        copy of the shape for each point on the object assigned as the "Axis".
+        Each of these copies are then translated, equal to the displacement of
+        the points from the (0,0,0) origin.
 
-        If the object's "Axis" is unassigned, returns the original shape unchanged.
+        If the object's "Axis" is unassigned, returns the original shape
+        unchanged.
 
         Parameters
         ----------
@@ -801,8 +810,8 @@ class Component(ArchIFC.IfcProduct):
     def isIdentity(self,placement):
         """Checks if a placement is *almost* zero.
 
-        Check if a <Base.Placement>'s displacement from (0,0,0) is almost zero, and if
-        the angle of it's rotation about it's axis is almost zero.
+        Check if a <Base.Placement>'s displacement from (0,0,0) is almost zero,
+        and if the angle of it's rotation about it's axis is almost zero.
 
         Parameters
         ----------
@@ -812,7 +821,8 @@ class Component(ArchIFC.IfcProduct):
         Returns
         -------
         bool
-            Returns true if angle and displacement are almost zero, false it otherwise.
+            Returns true if angle and displacement are almost zero, false it
+            otherwise.
         """
 
         if (placement.Base.Length < 0.000001) and (placement.Rotation.Angle < 0.000001):
@@ -826,10 +836,11 @@ class Component(ArchIFC.IfcProduct):
         redundant edges from the shape. Spreads shape to the "Axis" with method
         .spread().
 
-        Sets the object's Shape and Placement to the values given, if successful.
+        Sets the object's Shape and Placement to the values given, if
+        successful.
 
-        Finally, runs .computeAreas() method, to calculate the horizontal and vertical
-        area of the shape.
+        Finally, runs .computeAreas() method, to calculate the horizontal and
+        vertical area of the shape.
 
         Parameters
         ----------
@@ -886,18 +897,21 @@ class Component(ArchIFC.IfcProduct):
     def computeAreas(self,obj):
         """Computes the area properties of the object's shape.
 
-        Computes the vertical area, horizontal area, and perimeter length of the
-        object's shape. 
+        Computes the vertical area, horizontal area, and perimeter length of
+        the object's shape. 
 
-        The vertical area is the surface area of the faces perpendicular to the ground.
+        The vertical area is the surface area of the faces perpendicular to the
+        ground.
 
-        The horizontal area is the area of the shape, when projected onto a hyperplane
-        across the XY axises, IE: the area when viewed from a bird's eye view.
+        The horizontal area is the area of the shape, when projected onto a
+        hyperplane across the XY axises, IE: the area when viewed from a bird's
+        eye view.
 
-        The perimeter length is the length of the outside edges of this bird's eye view.
+        The perimeter length is the length of the outside edges of this bird's
+        eye view.
 
-        These values are assigned to the object's "VerticalArea", "HorizontalArea", and
-        "PerimeterLength" properties.
+        These values are assigned to the object's "VerticalArea",
+        "HorizontalArea", and "PerimeterLength" properties.
         """
 
 
@@ -971,14 +985,14 @@ class Component(ArchIFC.IfcProduct):
 
         Not all IFC types have a standard case.
 
-        If an object is a standard case or not varies between the different types. Each
-        type has it's own rules to define what is a standard case.
+        If an object is a standard case or not varies between the different
+        types. Each type has it's own rules to define what is a standard case.
 
-        Rotated objects, or objects with Additions or Subtractions are not standard
-        cases.
+        Rotated objects, or objects with Additions or Subtractions are not
+        standard cases.
 
-        All objects whose IfcType is suffixed with the string " Sandard Case" is
-        automatically a standard case.
+        All objects whose IfcType is suffixed with the string " Sandard Case"
+        is automatically a standard case.
 
         Returns
         -------
@@ -1045,9 +1059,9 @@ class ViewProviderComponent:
     def __init__(self,vobj):
         """Initialises the Component view provider.
 
-        Registers the Proxy as this class object. Registers the Object, as the view
-        provider's object. Sets the view provider to have the
-        properties of a component view provider.
+        Registers the Proxy as this class object. Registers the Object, as the
+        view provider's object. Sets the view provider to have the properties
+        of a component view provider.
 
         Parameters
         ----------
@@ -1073,11 +1087,11 @@ class ViewProviderComponent:
     def updateData(self,obj,prop):
         """Method called when the host object has a property changed.
 
-        If the object has a Material associated with it, matches the view object's
-        ShapeColor and Transparency to match the Material.
+        If the object has a Material associated with it, matches the view
+        object's ShapeColor and Transparency to match the Material.
 
-        If the object is now cloned, or is part of a compound, the view object inherits
-        the DiffuseColor.
+        If the object is now cloned, or is part of a compound, the view object
+        inherits the DiffuseColor.
 
         Parameters
         ----------
@@ -1127,8 +1141,8 @@ class ViewProviderComponent:
     def getIcon(self):
         """Returns the path to the appropriate icon.
 
-        If a clone, returns the cloned component icon path. Otherwise returns the Arch Component
-        icon.
+        If a clone, returns the cloned component icon path. Otherwise returns
+        the Arch Component icon.
 
         Returns
         -------
@@ -1146,13 +1160,13 @@ class ViewProviderComponent:
     def onChanged(self,vobj,prop):
         """Method called when the view provider has a property changed.
 
-        If DiffuseColor changes, change DiffuseColor to copy the host object's clone,
-        if it exists.
+        If DiffuseColor changes, change DiffuseColor to copy the host object's
+        clone, if it exists.
 
         If ShapeColor changes, overwrite it with DiffuseColor.
 
-        If Visibility changes, propagate the change to all view objects that are also
-        hosted by this view object's host.
+        If Visibility changes, propagate the change to all view objects that
+        are also hosted by this view object's host.
 
         Parameters
         ----------
@@ -1342,7 +1356,8 @@ class ViewProviderComponent:
         return []
 
     def setEdit(self,vobj,mode):
-        """Method called when the document requests the object to enter edit mode.
+        """Method called when the document requests the object to enter edit
+        mode.
 
         Edit mode is entered when a user double clicks on an object in the tree
         view, or when they use the menu option [Edit -> Toggle Edit Mode].
@@ -1526,8 +1541,8 @@ class ArchSelectionObserver:
         When a nextCommand is specified, the observer fires a Gui command when
         anything is selected.
 
-        When a watched object is specified, the observer will only fire when this
-        watched object is selected.
+        When a watched object is specified, the observer will only fire when
+        this watched object is selected.
 
         Parameters
         ----------
@@ -1667,8 +1682,8 @@ class ComponentTaskPanel:
         self.update()
 
     def isAllowedAlterSelection(self):
-        """This method indicates whether this task dialog allows other commands to
-        modify the selection while it is open.
+        """This method indicates whether this task dialog allows other commands
+        to modify the selection while it is open.
 
         Returns
         -------
@@ -1696,10 +1711,11 @@ class ComponentTaskPanel:
         return int(QtGui.QDialogButtonBox.Ok)
 
     def check(self,wid,col):
-        """This method is run as the callback when the user selects an item in the tree.
+        """This method is run as the callback when the user selects an item in
+        the tree.
 
-        This method enables and disables the add and remove buttons depending on what
-        the user has selected.
+        This method enables and disables the add and remove buttons depending
+        on what the user has selected.
 
         If they have selected one of the root attribute folders, it disables
         the remove button. If they have seperately selected an object in the 3D
@@ -1785,7 +1801,8 @@ class ComponentTaskPanel:
         self.retranslateUi(self.baseform)
 
     def addElement(self):
-        """This method is run as a callback when the user selects the add button.
+        """This method is run as a callback when the user selects the add
+        button.
 
         Gets the object selected in the 3D view, and gets the attribute folder
         selected in the tree widget.
@@ -1805,7 +1822,8 @@ class ComponentTaskPanel:
         self.update()
 
     def removeElement(self):
-        """This method is run as a callback when the user selects the remove button.
+        """This method is run as a callback when the user selects the remove
+        button.
 
         Gets the object selected in the tree widget. If there is an object in
         the document with the same Name as the selected item in the tree, it is
@@ -1832,8 +1850,8 @@ class ComponentTaskPanel:
     def editObject(self,wid,col):
         """This method is run when the user double clicks on an item in the tree widget.
 
-        If the item in the tree has a corresponding object in the document,
-        it enters edit mode for that associated object.
+        If the item in the tree has a corresponding object in the document, it
+        enters edit mode for that associated object.
 
         At the same time, it makes the object this task panel was opened for
         transparent and unselectable.
@@ -2056,8 +2074,9 @@ class ComponentTaskPanel:
             The name of the property to be created. If left blank, will be set to
             "New Property".
         ptype: str, optional
-            The name of the property type the new property will be set as. If not
-            specified, the the property's type will be determined using the idx parameter.
+            The name of the property type the new property will be set as. If
+            not specified, the the property's type will be determined using the
+            idx parameter.
         """
 
         if hasattr(self,"ifcEditor") and self.ifcEditor:

--- a/src/Mod/Arch/ArchComponent.py
+++ b/src/Mod/Arch/ArchComponent.py
@@ -167,20 +167,14 @@ class Component(ArchIFC.IfcProduct):
 
     You can learn more about Arch Components, and the purpose of Arch
     Components here: https://wiki.freecadweb.org/Arch_Component
+
+    Parameters
+    ----------
+    obj: <App::FeaturePython>
+        The object to turn into an Arch Component
     """ 
 
     def __init__(self, obj):
-        """Initialises the Component.
-
-        Registers the Proxy as this class object. Sets the object to have the
-        properties of an Arch component.
-
-        Parameters
-        ----------
-        obj: <App::FeaturePython>
-            The object to turn into an Arch Component
-        """
-
         obj.Proxy = self
         Component.setProperties(self, obj)
         self.Type = "Component"
@@ -1507,30 +1501,27 @@ class ArchSelectionObserver:
     TODO: This could probably use a rework. Most of the functionality isn't
     used. It does not work correctly to reset the appearance of parent object
     in ComponentTaskPanel.editObject(), for example.
+
+    Parameters
+    ----------
+    watched: <App::DocumentObject>, optional
+        If no watched value is provided, functionality relating to origin
+        and hide parameters will not occur. Only the nextCommand will fire.
+
+        When a watched value is provided, the selection observer will only
+        fire when the watched object has been selected.
+    hide: bool
+        Sets if the watched object should be hidden.
+    origin: <App::DocumentObject, optional
+        If provided, and hide is True, will make the origin object
+        selectable, and opaque (set transparency to 0).
+    nextCommand: str
+        Name of Gui command to run when the watched object is selected, (if
+        one is specified), or when anything is selected (if no watched
+        object is specified).
     """
 
     def __init__(self,origin=None,watched=None,hide=True,nextCommand=None):
-        """Initialises the ArchSelectionObserver object.
-
-        Parameters
-        ----------
-        watched: <App::DocumentObject>, optional
-            If no watched value is provided, functionality relating to origin
-            and hide parameters will not occur. Only the nextCommand will fire.
-
-            When a watched value is provided, the selection observer will only
-            fire when the watched object has been selected.
-        hide: bool
-            Sets if the watched object should be hidden.
-        origin: <App::DocumentObject, optional
-            If provided, and hide is True, will make the origin object
-            selectable, and opaque (set transparency to 0).
-        nextCommand: str
-            Name of Gui command to run when the watched object is selected, (if
-            one is specified), or when anything is selected (if no watched
-            object is specified).
-        """
-
         self.origin = origin
         self.watched = watched
         self.hide = hide
@@ -1587,13 +1578,6 @@ class SelectionTaskPanel:
     """
 
     def __init__(self):
-        """Initialises the task panel.
-
-        Adds a label.
-
-        TODO: Label does not seem to appear?
-        """
-
         self.baseform = QtGui.QLabel()
         self.baseform.setText(QtGui.QApplication.translate("Arch", "Please select a base object", None))
 
@@ -1618,12 +1602,6 @@ class ComponentTaskPanel:
     """
 
     def __init__(self):
-        """Initialises the task panel.
-
-        Defines the layout of the task panel, and setups callbacks for when
-        buttons and menu items are clicked.
-        """
-
         # the panel has a tree widget that contains categories
         # for the subcomponents, such as additions, subtractions.
         # the categories are shown only if they are not empty.
@@ -2182,24 +2160,21 @@ if FreeCAD.GuiUp:
 
     class IfcEditorDelegate(QtGui.QStyledItemDelegate):
         """This class manages the editing of the individual table cells in the IFC editor.
+
+        Parameters
+        ----------
+        parent: <PySide2.QtWidgets.QWidget>
+            Unclear.
+        dialog: <ArchComponent.ComponentTaskPanel>
+            The dialog box this delegate was created in.
+        ptypes: list of str
+            A list of the names of IFC property types.
+        plables: list of str
+            A list of the human readable names of IFC property types.
         """
 
 
         def __init__(self, parent=None, dialog=None, ptypes=[], plabels=[], *args):
-            """This method initialises the class.
-
-            Parameters
-            ----------
-            parent: <PySide2.QtWidgets.QWidget>
-                Unclear.
-            dialog: <ArchComponent.ComponentTaskPanel>
-                The dialog box this delegate was created in.
-            ptypes: list of str
-                A list of the names of IFC property types.
-            plables: list of str
-                A list of the human readable names of IFC property types.
-            """
-
             self.dialog = dialog
             QtGui.QStyledItemDelegate.__init__(self, parent, *args)
             self.ptypes = ptypes

--- a/src/Mod/Arch/ArchComponent.py
+++ b/src/Mod/Arch/ArchComponent.py
@@ -163,7 +163,7 @@ class Component(ArchIFC.IfcProduct):
     """The Arch Component object.
 
     Acts as a base for all other Arch objects, such as Arch walls and Arch
-    structures. It's properties and behaviours are common to all Arch objects.
+    structures. Its properties and behaviours are common to all Arch objects.
 
     You can learn more about Arch Components, and the purpose of Arch
     Components here: https://wiki.freecadweb.org/Arch_Component
@@ -186,7 +186,7 @@ class Component(ArchIFC.IfcProduct):
         self.Type = "Component"
 
     def setProperties(self, obj):
-        """Gives the component it's component specific properties, such as material.
+        """Gives the component its component specific properties, such as material.
 
         You can learn more about properties here:
         https://wiki.freecadweb.org/property
@@ -276,7 +276,7 @@ class Component(ArchIFC.IfcProduct):
 
         If "Placement" has changed, it records the old placement, so that
         .onChanged() can compare between the old and new placement, and move
-        it's children accordingly.
+        its children accordingly.
 
         Parameters
         ----------
@@ -366,7 +366,7 @@ class Component(ArchIFC.IfcProduct):
         """Gets a height value from hosts.
 
         Recursively crawls hosts until it finds a Floor or BuildingPart, then
-        returns the value of it's Height property.
+        returns the value of its Height property.
 
         Returns
         -------
@@ -451,7 +451,7 @@ class Component(ArchIFC.IfcProduct):
 
         With this copy, it gets the <Part.Face> the shape was originally
         extruded from, the <Base.Vector> of the extrusion, and the
-        <Base.Placement> needed to move the copy back to it's original
+        <Base.Placement> needed to move the copy back to its original
         location/orientation. It will return this data as a tuple.
 
         If it encounters an object derived from a <Part::Multifuse>, it will
@@ -551,13 +551,13 @@ class Component(ArchIFC.IfcProduct):
     def rebase(self,shape,hint=None):
         """Copies a shape to the (0,0,0) origin.
 
-        Creates a copy of a shape, such that it's center of mass is in the
+        Creates a copy of a shape, such that its center of mass is in the
         (0,0,0) origin.
 
         TODO Determine the way the shape is rotated by this method.
 
         Returns the copy of the shape, and the <Base.Placement> needed to move
-        the copy back to it's original location/orientation.
+        the copy back to its original location/orientation.
 
         Parameters
         ----------
@@ -766,7 +766,7 @@ class Component(ArchIFC.IfcProduct):
         return base
 
     def spread(self,obj,shape,placement=None):
-        """Copies the object to it's Axis's points.
+        """Copies the object to its Axis's points.
 
         If the object has the "Axis" property assigned, this method creates a
         copy of the shape for each point on the object assigned as the "Axis".
@@ -812,7 +812,7 @@ class Component(ArchIFC.IfcProduct):
         """Checks if a placement is *almost* zero.
 
         Check if a <Base.Placement>'s displacement from (0,0,0) is almost zero,
-        and if the angle of it's rotation about it's axis is almost zero.
+        and if the angle of its rotation about its axis is almost zero.
 
         Parameters
         ----------
@@ -982,12 +982,12 @@ class Component(ArchIFC.IfcProduct):
                         obj.PerimeterLength = self.flatarea.Faces[0].OuterWire.Length
 
     def isStandardCase(self,obj):
-        """Determines if the component is a standard case of it's IFC type.
+        """Determines if the component is a standard case of its IFC type.
 
         Not all IFC types have a standard case.
 
         If an object is a standard case or not varies between the different
-        types. Each type has it's own rules to define what is a standard case.
+        types. Each type has its own rules to define what is a standard case.
 
         Rotated objects, or objects with Additions or Subtractions are not
         standard cases.
@@ -1075,7 +1075,7 @@ class ViewProviderComponent:
         self.setProperties(vobj)
         
     def setProperties(self,vobj):
-        """Gives the component view provider it's component view provider specific properties.
+        """Gives the component view provider its component view provider specific properties.
 
         You can learn more about properties here:
         https://wiki.freecadweb.org/property
@@ -1445,9 +1445,9 @@ class ViewProviderComponent:
         return False
 
     def colorize(self,obj,force=False):
-        """If an object is a clone, sets it it to copy the color of it's parent.
+        """If an object is a clone, sets it it to copy the color of its parent.
 
-        Will only change the color of the clone if the clone and it's parent
+        Will only change the color of the clone if the clone and its parent
         have colors that are distinguishably different from each other.
 
         Parameters
@@ -1758,7 +1758,7 @@ class ComponentTaskPanel:
         return QtGui.QIcon(":/icons/Tree_Part.svg")
 
     def update(self):
-        """Populates the treewidget with it's various items.
+        """Populates the treewidget with its various items.
 
         Checks if the object being edited has attributes relevant to
         subobjects. IE: Additions, Subtractions, etc.
@@ -2055,7 +2055,7 @@ class ComponentTaskPanel:
         dropdown, it adds a property with the property type selected in the
         dropdown.
 
-        This method can also be run standalone, outside it's function as a
+        This method can also be run standalone, outside its function as a
         callback.
 
         Unless otherwise specified, the property will be called "New property".

--- a/src/Mod/Arch/ArchComponent.py
+++ b/src/Mod/Arch/ArchComponent.py
@@ -19,16 +19,17 @@
 #*                                                                         *
 #***************************************************************************
 
-__title__="FreeCAD Arch Component"
-__author__ = "Yorik van Havre"
-__url__ = "http://www.freecadweb.org"
-__doc__ = """This module provides the base Arch component class, that is shared
+"""This module provides the base Arch component class, that is shared
 by all of the Arch BIM objects.
 
 Examples
 --------
 TODO put examples here.
 """
+
+__title__="FreeCAD Arch Component"
+__author__ = "Yorik van Havre"
+__url__ = "http://www.freecadweb.org"
 
 import FreeCAD,Draft,ArchCommands,math,sys,json,os,ArchIFC,ArchIFCSchema
 from FreeCAD import Vector

--- a/src/Mod/Arch/ArchComponent.py
+++ b/src/Mod/Arch/ArchComponent.py
@@ -234,7 +234,13 @@ class Component(ArchIFC.IfcProduct):
         self.Type = "Component"
 
     def onDocumentRestored(self, obj):
-        """Method run when the document is restored. Re-add the Arch component properties."""
+        """Method run when the document is restored. Re-add the Arch component properties.
+
+        Parameters
+        ----------
+        obj: <App::FeaturePython>
+            The component object.
+        """
         Component.setProperties(self, obj)
 
     def execute(self,obj):
@@ -244,6 +250,11 @@ class Component(ArchIFC.IfcProduct):
 
         Process subshapes of the object to add additions, and subtract
         subtractions from the object's shape.
+
+        Parameters
+        ----------
+        obj: <App::FeaturePython>
+            The component object.
         """
 
         if self.clone(obj):
@@ -274,6 +285,8 @@ class Component(ArchIFC.IfcProduct):
 
         Parameters
         ----------
+        obj: <App::FeaturePython>
+            The component object.
         prop: string
             The name of the property that has changed.
         """
@@ -291,6 +304,8 @@ class Component(ArchIFC.IfcProduct):
 
         Parameters
         ----------
+        obj: <App::FeaturePython>
+            The component object.
         prop: string
             The name of the property that has changed.
         """
@@ -333,6 +348,11 @@ class Component(ArchIFC.IfcProduct):
         "Hosts" properties. Objects are set to move with their host via the
         MoveWithHost property.
 
+        Parameters
+        ----------
+        obj: <App::FeaturePython>
+            The component object.
+
         Returns
         -------
         list of <App::FeaturePython>
@@ -361,6 +381,11 @@ class Component(ArchIFC.IfcProduct):
 
         Recursively crawl hosts until a Floor or BuildingPart is found, then
         return the value of its Height property.
+
+        Paramters
+        ---------
+        obj: <App::FeaturePython>
+            The component object.
 
         Returns
         -------
@@ -392,6 +417,11 @@ class Component(ArchIFC.IfcProduct):
         of the same type, or if the object has the type "Component" or
         "BuildingPart".
 
+        Parameters
+        ----------
+        obj: <App::FeaturePython>
+            The component object.
+
         Returns
         -------
         bool
@@ -415,6 +445,11 @@ class Component(ArchIFC.IfcProduct):
 
         Look to base object, and find other objects that are based off this
         base object. If these objects are the same type, return them.
+
+        Parameters
+        ----------
+        obj: <App::FeaturePython>
+            The component object.
 
         Returns
         -------
@@ -451,6 +486,11 @@ class Component(ArchIFC.IfcProduct):
         If an object derived from a <Part::Multifuse> is encountered, return
         this data as a tuple containing lists. The lists will contain the same
         data as above, from each of the objects within the multifuse.
+
+        Parameters
+        ----------
+        obj: <App::FeaturePython>
+            The component object.
 
         Returns
         -------
@@ -615,6 +655,8 @@ class Component(ArchIFC.IfcProduct):
 
         Parameters
         ----------
+        obj: <App::FeaturePython>
+            The component object.
         prop: string
             The name of the property that has changed.
         """
@@ -649,6 +691,8 @@ class Component(ArchIFC.IfcProduct):
 
         Parameters
         ----------
+        obj: <App::FeaturePython>
+            The component object.
         base: <Part.Shape>, optional
             The base shape to add Additions and Subtractions to.
         placement: <Base.Placement>, optional
@@ -772,6 +816,8 @@ class Component(ArchIFC.IfcProduct):
 
         Parameters
         ----------
+        obj: <App::FeaturePython>
+            The component object.
         shape: <Part.Shape>
             The shape to copy.
         placement:
@@ -839,6 +885,8 @@ class Component(ArchIFC.IfcProduct):
 
         Parameters
         ----------
+        obj: <App::FeaturePython>
+            The component object.
         shape: <Part.Shape>
             The shape to check and apply to the object.
         placement: <Base.Placement>
@@ -907,6 +955,11 @@ class Component(ArchIFC.IfcProduct):
 
         Assign these values to the object's "VerticalArea", "HorizontalArea",
         and "PerimeterLength" properties.
+
+        Parameters
+        ----------
+        obj: <App::FeaturePython>
+            The component object.
         """
 
 
@@ -988,6 +1041,11 @@ class Component(ArchIFC.IfcProduct):
 
         All objects whose IfcType is suffixed with the string " Sandard Case"
         are automatically a standard case.
+
+        Parameters
+        ----------
+        obj: <App::FeaturePython>
+            The component object.
 
         Returns
         -------
@@ -1158,6 +1216,8 @@ class ViewProviderComponent:
 
         Parameters
         ----------
+        vobj: <Gui.ViewProviderDocumentObject>
+            The component's view provider object.
         prop: string
             The name of the property that has changed.
         """
@@ -1200,6 +1260,11 @@ class ViewProviderComponent:
         of the display mode node.
 
         Add the HiRes display mode.
+
+        Parameters
+        ----------
+        vobj: <Gui.ViewProviderDocumentObject>
+            The component's view provider object.
         """
 
         from pivy import coin
@@ -1216,6 +1281,11 @@ class ViewProviderComponent:
 
         Define mode HiRes, which displays the component as a mesh, intended as
         a more visually appealing version of the component.
+
+        Parameters
+        ----------
+        vobj: <Gui.ViewProviderDocumentObject>
+            The component's view provider object.
 
         Returns
         -------
@@ -1241,6 +1311,8 @@ class ViewProviderComponent:
 
         Parameters
         ----------
+        vobj: <Gui.ViewProviderDocumentObject>
+            The component's view provider object.
         mode: str
             The name of the display mode the view provider has switched to.
 
@@ -1304,6 +1376,11 @@ class ViewProviderComponent:
         Set the host object's Base object as a child, and set any additions or
         subtractions as children.
 
+        Parameters
+        ----------
+        vobj: <Gui.ViewProviderDocumentObject>
+            The component's view provider object.
+
         Returns
         -------
         list of <App::DocumentObject>s:
@@ -1351,6 +1428,8 @@ class ViewProviderComponent:
 
         Parameters
         ----------
+        vobj: <Gui.ViewProviderDocumentObject>
+            The component's view provider object.
         mode: int or str
             The edit mode the document has requested. Set to 0 when requested via
             a double click or [Edit -> Toggle Edit Mode].
@@ -1391,6 +1470,8 @@ class ViewProviderComponent:
 
         Parameters
         ----------
+        vobj: <Gui.ViewProviderDocumentObject>
+            The component's view provider object.
         menu: <PySide2.QtWidgets.QMenu>
             The context menu already assembled prior to this method being
             called.
@@ -1590,7 +1671,6 @@ class ComponentTaskPanel:
     """The default TaskPanel for all Arch components.
 
     TODO: outline the purpose of this taskpanel.
-
     """
 
     def __init__(self):
@@ -1715,6 +1795,11 @@ class ComponentTaskPanel:
 
     def getIcon(self,obj):
         """Get the path to the icons, of the items that fill the tree widget.
+
+        Paramters
+        ---------
+        obj: <App::DocumentObject>
+            The object being edited.
         """
 
         if hasattr(obj.ViewObject,"Proxy"):

--- a/src/Mod/Arch/ArchFloor.py
+++ b/src/Mod/Arch/ArchFloor.py
@@ -176,22 +176,19 @@ class _Floor(ArchIFC.IfcProduct):
 
     Turns a <App::DocumentObjectGroupPython> into a floor object, then
     takes a list of objects to own as its children.
+        
+    The floor can be based off either a group, or a python feature. Learn more
+    about groups here: https://wiki.freecadweb.org/Std_Group
+
+    Adds the properties of a floor, and sets its IFC type.
+
+    Parameters
+    ----------
+    obj: <App::DocumentObjectGroupPython> or <App::FeaturePython>
+        The object to turn into a Floor.
     """
 
     def __init__(self,obj):
-        """Initialises the floor.
-
-        The floor can be based off either a group, or a python feature. Learn more
-        about groups here: https://wiki.freecadweb.org/Std_Group
-
-        Adds the properties of a floor, and sets its IFC type.
-
-        Parameters
-        ----------
-        obj: <App::DocumentObjectGroupPython> or <App::FeaturePython>
-            The object to turn into a Floor.
-        """
-
         obj.Proxy = self
         self.Object = obj
         _Floor.setProperties(self,obj)
@@ -316,19 +313,15 @@ class _Floor(ArchIFC.IfcProduct):
 class _ViewProviderFloor:
     """Obselete, superceeded by the ViewProviderBuildingPart class.
 
-    A View Provider for the Floor object."""
+    A View Provider for the Floor object.
+
+    Parameters
+    ----------
+    vobj: <Gui.ViewProviderDocumentObject>
+        The view provider to turn into a floor view provider.
+    """
 
     def __init__(self,vobj):
-        """Initialises the floor view provider.
-
-        Registers the Proxy as this class object.
-
-        Parameters
-        ----------
-        vobj: <Gui.ViewProviderDocumentObject>
-            The view provider to turn into a floor view provider.
-        """
-
         vobj.Proxy = self
 
     def getIcon(self):

--- a/src/Mod/Arch/ArchFloor.py
+++ b/src/Mod/Arch/ArchFloor.py
@@ -60,13 +60,19 @@ def makeFloor(objectslist=None,baseobj=None,name="Floor"):
 
     Parameters
     ----------
-    objectslist: list of <App::DocumentObject>
+    objectslist: list of <App::DocumentObject>, optional
         The objects to add to the new floor.
     baseobj:
         Unused.
-    name: str
+    name: str, optional
         The Label for the new floor.
+
+    Returns
+    -------
+    <App::DocumentObjectGroupPython>
+        The created floor.
     """
+
 
     if not FreeCAD.ActiveDocument:
         FreeCAD.Console.PrintError("No active document. Aborting\n")
@@ -86,18 +92,18 @@ class _CommandFloor:
 
     A tool for creating Arch floors.
 
-    Creates a floor from the objects selected by the user. Excludes objects
-    that appear higher in the object heirarchy, such as sites or buildings. If
-    free linking is enabled in the Arch preferenecs, allows higher heirarchy
-    objects to be part of floors.
+    Creates a floor from the objects selected by the user, if any. Excludes
+    objects that appear higher in the object heirarchy, such as sites or
+    buildings. If free linking is enabled in the Arch preferenecs, allows
+    higher heirarchy objects to be part of floors.
 
-    Find documentation on the end user usage of Arch Wall here:
+    Find documentation on the end user usage of Arch Floor here:
     https://wiki.freecadweb.org/Arch_Floor
     """
 
 
     def GetResources(self):
-        """Returns a dictionary with the visual aspects of the Arch Wall tool."""
+        """Returns a dictionary with the visual aspects of the Arch Floor tool."""
 
         return {'Pixmap'  : 'Arch_Floor',
                 'MenuText': QT_TRANSLATE_NOOP("Arch_Floor","Level"),
@@ -105,7 +111,7 @@ class _CommandFloor:
                 'ToolTip': QT_TRANSLATE_NOOP("Arch_Floor","Creates a Building Part object that represents a level, including selected objects")}
 
     def IsActive(self):
-        """Determines whether or not the Arch Wall tool is active. 
+        """Determines whether or not the Arch Floor tool is active. 
 
         Inactive commands are indicated by a greyed-out icon in the menus and toolbars.
         """
@@ -115,7 +121,7 @@ class _CommandFloor:
     def Activated(self):
         """Executed when Arch Floor is called.
 
-        Creates a floor from the objects selected by the user. Excludes
+        Creates a floor from the objects selected by the user, if any. Excludes
         objects that appear higher in the object heirarchy, such as sites or
         buildings. If free linking is enabled in the Arch preferenecs, allows
         higher heirarchy objects to be part of floors.
@@ -159,7 +165,11 @@ Floor creation aborted.") + "\n"
 
 
 class _Floor(ArchIFC.IfcProduct):
-    """The Floor object."""
+    """The Floor object.
+
+    Turns a <App::DocumentObjectGroupPython> into a floor object, then
+    takes a list of objects to own as it's children.
+    """
 
     def __init__(self,obj):
         """Initalises the floor.
@@ -167,7 +177,7 @@ class _Floor(ArchIFC.IfcProduct):
         The floor can be based off either a group, or a python feature. Learn more
         about groups here: https://wiki.freecadweb.org/Std_Group
 
-        Adds the parameters of a floor, and sets it's IFC type.
+        Adds the properties of a floor, and sets it's IFC type.
 
         Parameters
         ----------
@@ -297,17 +307,17 @@ class _Floor(ArchIFC.IfcProduct):
 
 
 class _ViewProviderFloor:
-    """A View Provider for the Floor object"""
+    """A View Provider for the Floor object."""
 
     def __init__(self,vobj):
-        """Initialises the Component view provider.
+        """Initialises the floor view provider.
 
         Registers the Proxy as this class object.
 
         Parameters
         ----------
         vobj: <Gui.ViewProviderDocumentObject>
-            The view provider to turn into an Component view provider.
+            The view provider to turn into a floor view provider.
         """
 
         vobj.Proxy = self
@@ -366,10 +376,10 @@ class _ViewProviderFloor:
         return None
 
     def setupContextMenu(self,vobj,menu):
-        """Adds the component specific options to the context menu.
+        """Adds the floor specific options to the context menu.
 
         The context menu is the drop down menu that opens when the user right
-        clicks on the component in the tree view.
+        clicks on the floor in the tree view.
 
         Adds a menu choice to convert the floor to an Arch Building Part with
         the ArchBuildingPart.convertFloors function.

--- a/src/Mod/Arch/ArchFloor.py
+++ b/src/Mod/Arch/ArchFloor.py
@@ -93,9 +93,9 @@ class _CommandFloor:
     A tool for creating Arch floors.
 
     Creates a floor from the objects selected by the user, if any. Excludes
-    objects that appear higher in the object heirarchy, such as sites or
-    buildings. If free linking is enabled in the Arch preferenecs, allows
-    higher heirarchy objects to be part of floors.
+    objects that appear higher in the object hierarchy, such as sites or
+    buildings. If free linking is enabled in the Arch preferences, allows
+    higher hierarchy objects to be part of floors.
 
     Find documentation on the end user usage of Arch Floor here:
     https://wiki.freecadweb.org/Arch_Floor
@@ -122,9 +122,9 @@ class _CommandFloor:
         """Executed when Arch Floor is called.
 
         Creates a floor from the objects selected by the user, if any. Excludes
-        objects that appear higher in the object heirarchy, such as sites or
-        buildings. If free linking is enabled in the Arch preferenecs, allows
-        higher heirarchy objects to be part of floors.
+        objects that appear higher in the object hierarchy, such as sites or
+        buildings. If free linking is enabled in the Arch preferences, allows
+        higher hierarchy objects to be part of floors.
         """
 
         sel = FreeCADGui.Selection.getSelection()
@@ -172,7 +172,7 @@ class _Floor(ArchIFC.IfcProduct):
     """
 
     def __init__(self,obj):
-        """Initalises the floor.
+        """Initialises the floor.
 
         The floor can be based off either a group, or a python feature. Learn more
         about groups here: https://wiki.freecadweb.org/Std_Group

--- a/src/Mod/Arch/ArchFloor.py
+++ b/src/Mod/Arch/ArchFloor.py
@@ -175,7 +175,7 @@ class _Floor(ArchIFC.IfcProduct):
     The Floor object.
 
     Turns a <App::DocumentObjectGroupPython> into a floor object, then
-    takes a list of objects to own as it's children.
+    takes a list of objects to own as its children.
     """
 
     def __init__(self,obj):
@@ -184,7 +184,7 @@ class _Floor(ArchIFC.IfcProduct):
         The floor can be based off either a group, or a python feature. Learn more
         about groups here: https://wiki.freecadweb.org/Std_Group
 
-        Adds the properties of a floor, and sets it's IFC type.
+        Adds the properties of a floor, and sets its IFC type.
 
         Parameters
         ----------
@@ -257,7 +257,7 @@ class _Floor(ArchIFC.IfcProduct):
     def execute(self,obj):
         """Method run when the object is recomputed.
         
-        Moves it's children if it's placement has changed since the previous
+        Moves its children if its placement has changed since the previous
         recompute. Sets any child Walls and Structures to have the height of
         the floor if they have not Height value set.
         """

--- a/src/Mod/Arch/ArchFloor.py
+++ b/src/Mod/Arch/ArchFloor.py
@@ -21,8 +21,12 @@
 #*                                                                         *
 #***************************************************************************
 
-"""This module provides tools to build Floor objects. Floors are used
-to group different Arch objects situated at a same level.
+"""This module provides tools to build Floor objects. Floors are used to group
+different Arch objects situated at a same level.
+
+The _Floor object and this module as a whole is now obselete. It has been
+superseded by the use of the BuildingPart class, set to the "Building Storey"
+IfcType.
 """
 
 import FreeCAD,Draft,ArchCommands, DraftVecUtils, ArchIFC
@@ -51,10 +55,10 @@ __title__="FreeCAD Arch Floor"
 __author__ = "Yorik van Havre"
 __url__ = "http://www.freecadweb.org"
 
-
-
 def makeFloor(objectslist=None,baseobj=None,name="Floor"):
-    """Creates a _Floor from a list of objects.
+    """Obselete, superceeded by ArchBuildingPart.makeFloor.
+
+    Creates a floor.
 
     Creates a new floor based on a group, and then adds the objects in
     objectslist to the new floor.
@@ -166,7 +170,9 @@ Floor creation aborted.") + "\n"
 
 
 class _Floor(ArchIFC.IfcProduct):
-    """The Floor object.
+    """Obselete, superceeded by the BuildingPart class, with IfcType set to "Building Storey".
+
+    The Floor object.
 
     Turns a <App::DocumentObjectGroupPython> into a floor object, then
     takes a list of objects to own as it's children.
@@ -308,7 +314,9 @@ class _Floor(ArchIFC.IfcProduct):
 
 
 class _ViewProviderFloor:
-    """A View Provider for the Floor object."""
+    """Obselete, superceeded by the ViewProviderBuildingPart class.
+
+    A View Provider for the Floor object."""
 
     def __init__(self,vobj):
         """Initialises the floor view provider.

--- a/src/Mod/Arch/ArchFloor.py
+++ b/src/Mod/Arch/ArchFloor.py
@@ -58,9 +58,9 @@ __url__ = "http://www.freecadweb.org"
 def makeFloor(objectslist=None,baseobj=None,name="Floor"):
     """Obselete, superceeded by ArchBuildingPart.makeFloor.
 
-    Creates a floor.
+    Create a floor.
 
-    Creates a new floor based on a group, and then adds the objects in
+    Create a new floor based on a group, and then adds the objects in
     objectslist to the new floor.
 
     Parameters
@@ -97,10 +97,10 @@ class _CommandFloor:
 
     A tool for creating Arch floors.
 
-    Creates a floor from the objects selected by the user, if any. Excludes
+    Create a floor from the objects selected by the user, if any. Exclude
     objects that appear higher in the object hierarchy, such as sites or
-    buildings. If free linking is enabled in the Arch preferences, allows
-    higher hierarchy objects to be part of floors.
+    buildings. If free linking is enabled in the Arch preferences, allow higher
+    hierarchy objects to be part of floors.
 
     Find documentation on the end user usage of Arch Floor here:
     https://wiki.freecadweb.org/Arch_Floor
@@ -108,7 +108,7 @@ class _CommandFloor:
 
 
     def GetResources(self):
-        """Returns a dictionary with the visual aspects of the Arch Floor tool."""
+        """Return a dictionary with the visual aspects of the Arch Floor tool."""
 
         return {'Pixmap'  : 'Arch_Floor',
                 'MenuText': QT_TRANSLATE_NOOP("Arch_Floor","Level"),
@@ -116,7 +116,7 @@ class _CommandFloor:
                 'ToolTip': QT_TRANSLATE_NOOP("Arch_Floor","Creates a Building Part object that represents a level, including selected objects")}
 
     def IsActive(self):
-        """Determines whether or not the Arch Floor tool is active. 
+        """Determine whether or not the Arch Floor tool is active. 
 
         Inactive commands are indicated by a greyed-out icon in the menus and toolbars.
         """
@@ -126,9 +126,9 @@ class _CommandFloor:
     def Activated(self):
         """Executed when Arch Floor is called.
 
-        Creates a floor from the objects selected by the user, if any. Excludes
+        Create a floor from the objects selected by the user, if any. Exclude
         objects that appear higher in the object hierarchy, such as sites or
-        buildings. If free linking is enabled in the Arch preferences, allows
+        buildings. If free linking is enabled in the Arch preferences, allow
         higher hierarchy objects to be part of floors.
         """
 
@@ -195,9 +195,9 @@ class _Floor(ArchIFC.IfcProduct):
         self.IfcType = "Building Storey"
 
     def setProperties(self,obj):
-        """Gives the object properties unique to floors.
+        """Give the object properties unique to floors.
 
-        Adds the IFC product properties, and the floor's height and area.
+        Add the IFC product properties, and the floor's height and area.
         """
 
         ArchIFC.IfcProduct.setProperties(self, obj)
@@ -227,7 +227,7 @@ class _Floor(ArchIFC.IfcProduct):
     def onChanged(self,obj,prop):
         """Method called when the object has a property changed.
 
-        If the objects grouped under the floor object changes, it recomputes
+        If the objects grouped under the floor object changes, recompute
         the Area property.
 
         Also calls ArchIFC.IfcProduct.onChanged().
@@ -254,8 +254,8 @@ class _Floor(ArchIFC.IfcProduct):
     def execute(self,obj):
         """Method run when the object is recomputed.
         
-        Moves its children if its placement has changed since the previous
-        recompute. Sets any child Walls and Structures to have the height of
+        Move its children if its placement has changed since the previous
+        recompute. Set any child Walls and Structures to have the height of
         the floor if they have not Height value set.
         """
 
@@ -280,7 +280,7 @@ class _Floor(ArchIFC.IfcProduct):
                         o.Proxy.execute(o)
 
     def addObject(self,child):
-        """Adds the object to the floor's group.
+        """Add the object to the floor's group.
 
         Parameters
         ----------
@@ -295,7 +295,7 @@ class _Floor(ArchIFC.IfcProduct):
                 self.Object.Group = g
 
     def removeObject(self,child):
-        """Removes the object from the floor's group, if it's present.
+        """Remove the object from the floor's group, if it's present.
 
         Parameters
         ----------
@@ -325,7 +325,7 @@ class _ViewProviderFloor:
         vobj.Proxy = self
 
     def getIcon(self):
-        """Returns the path to the appropriate icon.
+        """Return the path to the appropriate icon.
 
         Returns
         -------
@@ -337,9 +337,9 @@ class _ViewProviderFloor:
         return ":/icons/Arch_Floor_Tree.svg"
 
     def attach(self,vobj):
-        """Adds display modes' data to the coin scenegraph.
+        """Add display modes' data to the coin scenegraph.
 
-        Adds each display mode as a coin node, whose parent is this view
+        Add each display mode as a coin node, whose parent is this view
         provider. 
 
         Each display mode's node includes the data needed to display the object
@@ -347,16 +347,16 @@ class _ViewProviderFloor:
         lines. This data is stored as additional coin nodes which are children
         of the display mode node.
 
-        Does not add any new display modes.
+        Do not add any new display modes.
         """
 
         self.Object = vobj.Object
         return
 
     def claimChildren(self):
-        """Defines which objects will appear as children in the tree view.
+        """Define which objects will appear as children in the tree view.
 
-        Claims all the objects that appear in the floor's group.
+        Claim all the objects that appear in the floor's group.
 
         Returns
         -------
@@ -378,12 +378,12 @@ class _ViewProviderFloor:
         return None
 
     def setupContextMenu(self,vobj,menu):
-        """Adds the floor specific options to the context menu.
+        """Add the floor specific options to the context menu.
 
         The context menu is the drop down menu that opens when the user right
         clicks on the floor in the tree view.
 
-        Adds a menu choice to convert the floor to an Arch Building Part with
+        Add a menu choice to convert the floor to an Arch Building Part with
         the ArchBuildingPart.convertFloors function.
 
         Parameters

--- a/src/Mod/Arch/ArchFloor.py
+++ b/src/Mod/Arch/ArchFloor.py
@@ -21,6 +21,10 @@
 #*                                                                         *
 #***************************************************************************
 
+"""This module provides tools to build Floor objects. Floors are used
+to group different Arch objects situated at a same level.
+"""
+
 import FreeCAD,Draft,ArchCommands, DraftVecUtils, ArchIFC
 if FreeCAD.GuiUp:
     import FreeCADGui
@@ -47,9 +51,6 @@ __title__="FreeCAD Arch Floor"
 __author__ = "Yorik van Havre"
 __url__ = "http://www.freecadweb.org"
 
-__doc__ = """This module provides tools to build Floor objects. Floors are used
-to group different Arch objects situated at a same level.
-"""
 
 
 def makeFloor(objectslist=None,baseobj=None,name="Floor"):

--- a/src/Mod/Arch/ArchIFC.py
+++ b/src/Mod/Arch/ArchIFC.py
@@ -18,9 +18,9 @@ class IfcRoot:
     """This class defines the common methods and properties for managing IFC data.
 
     IFC, or Industry Foundation Classes are a standardised way to digitally
-    describe the built enviroment.  The ultimate goal of IFC is to provide
+    describe the built environment.  The ultimate goal of IFC is to provide
     better interoperability between software that deals with the built
-    enviroment. You can learn more here:
+    environment. You can learn more here:
     https://technical.buildingsmart.org/standards/ifc/
 
     You can learn more about the technical details of the IFC schema here:
@@ -78,7 +78,7 @@ class IfcRoot:
         Adds the attributes specified in the object's IFC type schema, to the
         object's properties. Does not re-add them if they're already present.
         Also removes old IFC attribute properties that no longer appear in the
-        schema for backwards compatability.
+        schema for backwards compatibility.
 
         Does so using the .addIfcAttributes() and
         .purgeUnusedIfcAttributesFromPropertiesList() methods.
@@ -389,7 +389,7 @@ class IfcRoot:
         Removes the property representing an IFC attribute, if it does not
         appear in the schema of the IFC type provided. Also, removes the
         property if it's attribute is an enum type, presumably for backwards
-        compatability.
+        compatibility.
 
         Learn more about IFC enums here:
         https://standards.buildingsmart.org/IFC/RELEASE/IFC4/FINAL/HTML/schema/chapter-3.htm#enumeration

--- a/src/Mod/Arch/ArchIFC.py
+++ b/src/Mod/Arch/ArchIFC.py
@@ -215,7 +215,7 @@ class IfcRoot:
         https://wiki.freecadweb.org/Expressions
 
         Does not add the attribute if the object has a property with the
-        attribute's name. Also does not add the attribute if it's name is
+        attribute's name. Also does not add the attribute if its name is
         RefLatitude, RefLongitude, or Name.
 
         Parameters
@@ -234,10 +234,10 @@ class IfcRoot:
             self.addIfcAttributeValueExpressions(obj, attribute)
 
     def addIfcAttribute(self, obj, attribute):
-        """Adds an IFC type's attribute to the object, within it's properties.
+        """Adds an IFC type's attribute to the object, within its properties.
 
         Adds the attribute's schema to the object's IfcData property, as an
-        item under it's "attributes" array.
+        item under its "attributes" array.
 
         Also adds the attribute as a property of the object.
 
@@ -388,7 +388,7 @@ class IfcRoot:
 
         Removes the property representing an IFC attribute, if it does not
         appear in the schema of the IFC type provided. Also, removes the
-        property if it's attribute is an enum type, presumably for backwards
+        property if its attribute is an enum type, presumably for backwards
         compatibility.
 
         Learn more about IFC enums here:

--- a/src/Mod/Arch/ArchIFC.py
+++ b/src/Mod/Arch/ArchIFC.py
@@ -1,8 +1,8 @@
-import FreeCAD, os, json
-
-__doc__="""This modules sets up and manages the IFC-related properties, types
+"""This modules sets up and manages the IFC-related properties, types
 and attributes of Arch/BIM objects.
 """
+
+import FreeCAD, os, json
 
 if FreeCAD.GuiUp:
     from PySide.QtCore import QT_TRANSLATE_NOOP

--- a/src/Mod/Arch/ArchIFC.py
+++ b/src/Mod/Arch/ArchIFC.py
@@ -30,9 +30,9 @@ class IfcRoot:
     """
 
     def setProperties(self, obj):
-        """Gives the object properties for storing IFC data.
+        """Give the object properties for storing IFC data.
 
-        Also migrates old versions of IFC properties to the new property names
+        Also migrate old versions of IFC properties to the new property names
         using the .migrateDeprecatedAttributes() method.
         """
 
@@ -51,13 +51,12 @@ class IfcRoot:
     def onChanged(self, obj, prop):
         """Method called when the object has a property changed.
 
-        If the object's IfcType has changed, this method changes the object's
-        properties that relate to IFC attributes in order to match the IFC
-        schema definition of the new IFC type.
+        If the object's IfcType has changed, change the object's properties
+        that relate to IFC attributes in order to match the IFC schema
+        definition of the new IFC type.
 
-        If a property changes that is in the "IFC Attributes" group, this
-        method will also change the value stored in the IfcData property's
-        JSON.
+        If a property changes that is in the "IFC Attributes" group, also
+        change the value stored in the IfcData property's JSON.
 
         Parameters
         ----------
@@ -73,14 +72,14 @@ class IfcRoot:
                 self.setObjIfcAttributeValue(obj, prop, obj.getPropertyByName(prop))
 
     def setupIfcAttributes(self, obj):
-        """Sets up the IFC attributes in the object's properties.
+        """Set up the IFC attributes in the object's properties.
 
-        Adds the attributes specified in the object's IFC type schema, to the
-        object's properties. Does not re-add them if they're already present.
-        Also removes old IFC attribute properties that no longer appear in the
+        Add the attributes specified in the object's IFC type schema, to the
+        object's properties. Do not re-add them if they're already present.
+        Also remove old IFC attribute properties that no longer appear in the
         schema for backwards compatibility.
 
-        Does so using the .addIfcAttributes() and
+        Do so using the .addIfcAttributes() and
         .purgeUnusedIfcAttributesFromPropertiesList() methods.
 
         Learn more about IFC attributes here:
@@ -94,9 +93,9 @@ class IfcRoot:
         self.addIfcAttributes(ifcTypeSchema, obj)
 
     def setupIfcComplexAttributes(self, obj):
-        """Adds the IFC type's complex attributes to the object.
+        """Add the IFC type's complex attributes to the object.
 
-        Gets the object's IFC type schema, and adds the schema for the type's
+        Get the object's IFC type schema, and add the schema for the type's
         complex attributes within the IfcData property.
         """
 
@@ -114,9 +113,9 @@ class IfcRoot:
         obj.IfcData = IfcData
 
     def getIfcTypeSchema(self, IfcType):
-        """Gets the schema of the IFC type provided.
+        """Get the schema of the IFC type provided.
 
-        If the IFC type is undefined, returns the schema of the
+        If the IFC type is undefined, return the schema of the
         IfcBuildingElementProxy.
 
         Parameter
@@ -139,7 +138,7 @@ class IfcRoot:
         return None
 
     def getIfcSchema(self):
-        """Gets the IFC schema of all types relevant to this class.
+        """Get the IFC schema of all types relevant to this class.
 
         Intended to be overwritten by the classes that inherit this class.
 
@@ -152,12 +151,12 @@ class IfcRoot:
         return {}
 
     def getCanonicalisedIfcTypes(self):
-        """This method gets the names of IFC types, converted to the form used in Arch.
+        """Get the names of IFC types, converted to the form used in Arch.
 
-        This method changes the names of all IFC types to a more human readable
-        form which is used instead throughout Arch instead of the raw type
-        names. The names have the "Ifc" stripped from  the start of their
-        name, and spaces inserted between the words.
+        Change the names of all IFC types to a more human readable form which
+        is used instead throughout Arch instead of the raw type names. The
+        names have the "Ifc" stripped from the start of their name, and spaces
+        inserted between the words.
 
         Returns
         -------
@@ -171,11 +170,11 @@ class IfcRoot:
         return [''.join(map(lambda x: x if x.islower() else " "+x, t[3:]))[1:] for t in schema.keys()]
 
     def getIfcAttributeSchema(self, ifcTypeSchema, name):
-        """Gets the schema of an IFC attribute with the given name.
+        """Get the schema of an IFC attribute with the given name.
         
-        This method does so by converting the IFC attribute's name from the
-        human readable version Arch uses, and converting it to the less
-        readable name it has in the IFC schema.
+        Convert the IFC attribute's name from the human readable version Arch
+        uses, and convert it to the less readable name it has in the IFC
+        schema.
 
         Parameters
         ----------
@@ -199,23 +198,22 @@ class IfcRoot:
         return None
 
     def addIfcAttributes(self, ifcTypeSchema, obj):
-        """Adds the attributes of the IFC type's schema to the object's properties.
+        """Add the attributes of the IFC type's schema to the object's properties.
 
-        Adds the attributes as properties of the object. Also adds the
-        attribute's schema within the object's IfcData property. It does so
-        using the .addIfcAttribute() method.
+        Add the attributes as properties of the object. Also add the
+        attribute's schema within the object's IfcData property. Do so using
+        the .addIfcAttribute() method.
 
-        Also adds expressions to copy data from the object's editable
+        Also add expressions to copy data from the object's editable
         properties.  This means the IFC properties will remain accurate with
-        the actual values of the object. This is not done for all IFC
-        properties. It does so using the .addIfcAttributeValueExpressions()
-        method.
+        the actual values of the object. Do not do so for all IFC properties.
+        Do so using the .addIfcAttributeValueExpressions() method.
 
         Learn more about expressions here:
         https://wiki.freecadweb.org/Expressions
 
-        Does not add the attribute if the object has a property with the
-        attribute's name. Also does not add the attribute if its name is
+        Do not add the attribute if the object has a property with the
+        attribute's name. Also do not add the attribute if its name is
         RefLatitude, RefLongitude, or Name.
 
         Parameters
@@ -234,12 +232,12 @@ class IfcRoot:
             self.addIfcAttributeValueExpressions(obj, attribute)
 
     def addIfcAttribute(self, obj, attribute):
-        """Adds an IFC type's attribute to the object, within its properties.
+        """Add an IFC type's attribute to the object, within its properties.
 
-        Adds the attribute's schema to the object's IfcData property, as an
+        Add the attribute's schema to the object's IfcData property, as an
         item under its "attributes" array.
 
-        Also adds the attribute as a property of the object.
+        Also add the attribute as a property of the object.
 
         Parameters
         ----------
@@ -273,13 +271,13 @@ class IfcRoot:
                             QT_TRANSLATE_NOOP("App::Property", "Description of IFC attributes are not yet implemented"))
 
     def addIfcAttributeValueExpressions(self, obj, attribute):
-        """Adds expressions for IFC attributes, so they stay accurate with the object.
+        """Add expressions for IFC attributes, so they stay accurate with the object.
 
-        Adds expressions to the object that copy data from the editable
+        Add expressions to the object that copy data from the editable
         properties of the object. This ensures that the IFC attributes will
         remain accurate with the actual values of the object.
 
-        Currently adds expressions for the following IFC attributes:
+        Currently, add expressions for the following IFC attributes:
 
         - OverallWidth
         - OverallHeight
@@ -330,7 +328,7 @@ class IfcRoot:
             obj.LongName = obj.Label
 
     def setObjIfcAttributeValue(self, obj, attributeName, value):
-        """Changes the value of an IFC attribute within the IfcData property's json.
+        """Change the value of an IFC attribute within the IfcData property's json.
 
         Parameters
         ----------
@@ -369,7 +367,7 @@ class IfcRoot:
         obj.IfcData = IfcData
 
     def getObjIfcComplexAttribute(self, obj, attributeName):
-        """Gets the value of the complex attribute, as stored in the IfcData JSON.
+        """Get the value of the complex attribute, as stored in the IfcData JSON.
 
         Parameters
         ----------
@@ -384,10 +382,10 @@ class IfcRoot:
         return json.loads(obj.IfcData["complex_attributes"])[attributeName]
 
     def purgeUnusedIfcAttributesFromPropertiesList(self, ifcTypeSchema, obj):
-        """Removes properties representing IFC attributes if they no longer appear.
+        """Remove properties representing IFC attributes if they no longer appear.
 
-        Removes the property representing an IFC attribute, if it does not
-        appear in the schema of the IFC type provided. Also, removes the
+        Remove the property representing an IFC attribute, if it does not
+        appear in the schema of the IFC type provided. Also, remove the
         property if its attribute is an enum type, presumably for backwards
         compatibility.
 
@@ -403,7 +401,7 @@ class IfcRoot:
                 obj.removeProperty(property)
 
     def migrateDeprecatedAttributes(self, obj):
-        """Updates the object to use the newer property names for IFC related properties.
+        """Update the object to use the newer property names for IFC related properties.
         """
 
         if "Role" in obj.PropertiesList:
@@ -436,7 +434,7 @@ class IfcProduct(IfcRoot):
     """
 
     def getIfcSchema(self):
-        """Gets the IFC schema of all IFC types that inherit from IfcProducts.
+        """Get the IFC schema of all IFC types that inherit from IfcProducts.
 
         Returns
         -------
@@ -455,7 +453,7 @@ class IfcContext(IfcRoot):
     """
 
     def getIfcSchema(self):
-        """Gets the IFC schema of all IFC types that inherit from IfcContexts.
+        """Get the IFC schema of all IFC types that inherit from IfcContexts.
 
         Returns
         -------

--- a/src/Mod/Arch/ArchIFC.py
+++ b/src/Mod/Arch/ArchIFC.py
@@ -1,6 +1,8 @@
 import FreeCAD, os, json
 
-"This modules sets up and manages the IFC-related properties, types and attributes of Arch/BIM objects"
+__doc__="""This modules sets up and manages the IFC-related properties, types
+and attributes of Arch/BIM objects.
+"""
 
 if FreeCAD.GuiUp:
     from PySide.QtCore import QT_TRANSLATE_NOOP
@@ -13,7 +15,27 @@ import ArchIFCSchema
 IfcTypes = [''.join(map(lambda x: x if x.islower() else " "+x, t[3:]))[1:] for t in ArchIFCSchema.IfcProducts.keys()]
 
 class IfcRoot:
+    """This class defines the common methods and properties for managing IFC data.
+
+    IFC, or Industry Foundation Classes are a standardised way to digitally
+    describe the built enviroment.  The ultimate goal of IFC is to provide
+    better interoperability between software that deals with the built
+    enviroment. You can learn more here:
+    https://technical.buildingsmart.org/standards/ifc/
+
+    You can learn more about the technical details of the IFC schema here:
+    https://standards.buildingsmart.org/IFC/RELEASE/IFC4/FINAL/HTML/
+
+    This class is further segmented down into IfcProduct and IfcContext.
+    """
+
     def setProperties(self, obj):
+        """Gives the object properties for storing IFC data.
+
+        Also migrates old versions of IFC properties to the new property names
+        using the .migrateDeprecatedAttributes() method.
+        """
+
         if not "IfcData" in obj.PropertiesList:
             obj.addProperty("App::PropertyMap","IfcData","IFC",QT_TRANSLATE_NOOP("App::Property","IFC data"))
 
@@ -27,6 +49,22 @@ class IfcRoot:
         self.migrateDeprecatedAttributes(obj)
 
     def onChanged(self, obj, prop):
+        """Method called when the object has a property changed.
+
+        If the object's IfcType has changed, this method changes the object's
+        properties that relate to IFC attributes in order to match the IFC
+        schema definition of the new IFC type.
+
+        If a property changes that is in the "IFC Attributes" group, this
+        method will also change the value stored in the IfcData property's
+        JSON.
+
+        Parameters
+        ----------
+        prop: string
+            The name of the property that has changed.
+        """
+
         if prop == "IfcType":
             self.setupIfcAttributes(obj)
             self.setupIfcComplexAttributes(obj)
@@ -35,6 +73,20 @@ class IfcRoot:
                 self.setObjIfcAttributeValue(obj, prop, obj.getPropertyByName(prop))
 
     def setupIfcAttributes(self, obj):
+        """Sets up the IFC attributes in the object's properties.
+
+        Adds the attributes specified in the object's IFC type schema, to the
+        object's properties. Does not re-add them if they're already present.
+        Also removes old IFC attribute properties that no longer appear in the
+        schema for backwards compatability.
+
+        Does so using the .addIfcAttributes() and
+        .purgeUnusedIfcAttributesFromPropertiesList() methods.
+
+        Learn more about IFC attributes here:
+        https://standards.buildingsmart.org/IFC/RELEASE/IFC4/FINAL/HTML/schema/chapter-3.htm#attribute
+        """
+
         ifcTypeSchema = self.getIfcTypeSchema(obj.IfcType)
         if ifcTypeSchema is None:
             return
@@ -42,6 +94,12 @@ class IfcRoot:
         self.addIfcAttributes(ifcTypeSchema, obj)
 
     def setupIfcComplexAttributes(self, obj):
+        """Adds the IFC type's complex attributes to the object.
+
+        Gets the object's IFC type schema, and adds the schema for the type's
+        complex attributes within the IfcData property.
+        """
+
         ifcTypeSchema = self.getIfcTypeSchema(obj.IfcType)
         if ifcTypeSchema is None:
             return
@@ -56,6 +114,23 @@ class IfcRoot:
         obj.IfcData = IfcData
 
     def getIfcTypeSchema(self, IfcType):
+        """Gets the schema of the IFC type provided.
+
+        If the IFC type is undefined, returns the schema of the
+        IfcBuildingElementProxy.
+
+        Parameter
+        ---------
+        IfcType: str
+            The IFC type whose schema you want.
+
+        Returns
+        -------
+        dict
+            Returns the schema of the type as a dict.
+        None
+            Returns None if the IFC type does not exist.
+        """
         name = "Ifc" + IfcType.replace(" ", "")
         if IfcType == "Undefined":
             name = "IfcBuildingElementProxy"
@@ -64,19 +139,91 @@ class IfcRoot:
         return None
 
     def getIfcSchema(self):
+        """Gets the IFC schema of all types relevant to this class.
+
+        Intended to be overwritten by the classes that inherit this class.
+
+        Returns
+        -------
+        dict
+            The schema of all the types relevant to this class.
+        """
+
         return {}
 
     def getCanonicalisedIfcTypes(self):
+        """This method gets the names of IFC types, converted to the form used in Arch.
+
+        This method changes the names of all IFC types to a more human readable
+        form which is used instead throughout Arch instead of the raw type
+        names. The names have the "Ifc" stripped from  the start of their
+        name, and spaces inserted between the words.
+
+        Returns
+        -------
+        list of str
+            The list of every IFC type name in their form used in Arch. List
+            will have names in the same order as they appear in the schema's
+            JSON, as per the .keys() method of dicts.
+
+        """
         schema = self.getIfcSchema()
         return [''.join(map(lambda x: x if x.islower() else " "+x, t[3:]))[1:] for t in schema.keys()]
 
     def getIfcAttributeSchema(self, ifcTypeSchema, name):
+        """Gets the schema of an IFC attribute with the given name.
+        
+        This method does so by converting the IFC attribute's name from the
+        human readable version Arch uses, and converting it to the less
+        readable name it has in the IFC schema.
+
+        Parameters
+        ----------
+        ifcTypeSchema: dict
+            The schema of the IFC type to access the attribute of.
+        name: str
+            The name the attribute has in Arch.
+
+        Returns
+        -------
+        dict:
+            Returns the schema of the attribute.
+        None:
+            Returns None if the IFC type does not have the attribute requested.
+
+        """
+
         for attribute in ifcTypeSchema["attributes"]:
             if attribute["name"].replace(' ', '') == name:
                 return attribute
         return None
 
     def addIfcAttributes(self, ifcTypeSchema, obj):
+        """Adds the attributes of the IFC type's schema to the object's properties.
+
+        Adds the attributes as properties of the object. Also adds the
+        attribute's schema within the object's IfcData property. It does so
+        using the .addIfcAttribute() method.
+
+        Also adds expressions to copy data from the object's editable
+        properties.  This means the IFC properties will remain accurate with
+        the actual values of the object. This is not done for all IFC
+        properties. It does so using the .addIfcAttributeValueExpressions()
+        method.
+
+        Learn more about expressions here:
+        https://wiki.freecadweb.org/Expressions
+
+        Does not add the attribute if the object has a property with the
+        attribute's name. Also does not add the attribute if it's name is
+        RefLatitude, RefLongitude, or Name.
+
+        Parameters
+        ----------
+        ifcTypeSchema: dict
+            The schema of the IFC type.
+        """
+
         for attribute in ifcTypeSchema["attributes"]:
             if attribute["name"] in obj.PropertiesList \
                 or attribute["name"] == "RefLatitude" \
@@ -87,24 +234,71 @@ class IfcRoot:
             self.addIfcAttributeValueExpressions(obj, attribute)
 
     def addIfcAttribute(self, obj, attribute):
+        """Adds an IFC type's attribute to the object, within it's properties.
+
+        Adds the attribute's schema to the object's IfcData property, as an
+        item under it's "attributes" array.
+
+        Also adds the attribute as a property of the object.
+
+        Parameters
+        ----------
+        attribute: dict
+            The attribute to add. Should have the structure of an attribute
+            found within the IFC schemas.
+        """
         if not hasattr(obj, "IfcData"):
             return
         IfcData = obj.IfcData
+
         if "attributes" not in IfcData:
             IfcData["attributes"] = "{}"
         IfcAttributes = json.loads(IfcData["attributes"])
         IfcAttributes[attribute["name"]] = attribute
         IfcData["attributes"] = json.dumps(IfcAttributes)
+
         obj.IfcData = IfcData
         if attribute["is_enum"]:
-            obj.addProperty("App::PropertyEnumeration", attribute["name"], "IFC Attributes", QT_TRANSLATE_NOOP("App::Property", "Description of IFC attributes are not yet implemented"))
+            obj.addProperty("App::PropertyEnumeration", 
+                            attribute["name"], 
+                            "IFC Attributes", 
+                            QT_TRANSLATE_NOOP("App::Property", "Description of IFC attributes are not yet implemented"))
             setattr(obj, attribute["name"], attribute["enum_values"])
         else:
             import ArchIFCSchema
             propertyType = "App::" + ArchIFCSchema.IfcTypes[attribute["type"]]["property"]
-            obj.addProperty(propertyType, attribute["name"], "IFC Attributes", QT_TRANSLATE_NOOP("App::Property", "Description of IFC attributes are not yet implemented"))
+            obj.addProperty(propertyType, 
+                            attribute["name"], 
+                            "IFC Attributes", 
+                            QT_TRANSLATE_NOOP("App::Property", "Description of IFC attributes are not yet implemented"))
 
     def addIfcAttributeValueExpressions(self, obj, attribute):
+        """Adds expressions for IFC attributes, so they stay accurate with the object.
+
+        Adds expressions to the object that copy data from the editable
+        properties of the object. This ensures that the IFC attributes will
+        remain accurate with the actual values of the object.
+
+        Currently adds expressions for the following IFC attributes:
+
+        - OverallWidth
+        - OverallHeight
+        - ElevationWithFlooring
+        - Elevation
+        - NominalDiameter
+        - BarLength
+        - RefElevation
+        - LongName
+
+        Learn more about expressions here:
+        https://wiki.freecadweb.org/Expressions
+
+        Parameters
+        ----------
+        attribute: dict
+            The schema of the attribute to add the expression for.
+        """
+
         if obj.getGroupOfProperty(attribute["name"]) != "IFC Attributes" \
             or attribute["name"] not in obj.PropertiesList:
             return
@@ -136,6 +330,15 @@ class IfcRoot:
             obj.LongName = obj.Label
 
     def setObjIfcAttributeValue(self, obj, attributeName, value):
+        """Changes the value of an IFC attribute within the IfcData property's json.
+
+        Parameters
+        ----------
+        attributeName: str
+            The name of the attribute to change.
+        value:
+            The new value to set.
+        """
         IfcData = obj.IfcData
         if "attributes" not in IfcData:
             IfcData["attributes"] = "{}"
@@ -149,6 +352,16 @@ class IfcRoot:
         obj.IfcData = IfcData
 
     def setObjIfcComplexAttributeValue(self, obj, attributeName, value):
+        """Changes the value of the complex attribute in the IfcData property JSON.
+
+        Parameters
+        ----------
+        attributeName: str
+            The name of the attribute to change.
+        value:
+            The new value to set.
+        """
+
         IfcData = obj.IfcData
         IfcAttributes = json.loads(IfcData["complex_attributes"])
         IfcAttributes[attributeName] = value
@@ -156,9 +369,32 @@ class IfcRoot:
         obj.IfcData = IfcData
 
     def getObjIfcComplexAttribute(self, obj, attributeName):
+        """Gets the value of the complex attribute, as stored in the IfcData JSON.
+
+        Parameters
+        ----------
+        attributeName: str
+            The name of the complex attribute to access.
+
+        Returns
+        -------
+        The value of the complex attribute.
+        """
+
         return json.loads(obj.IfcData["complex_attributes"])[attributeName]
 
     def purgeUnusedIfcAttributesFromPropertiesList(self, ifcTypeSchema, obj):
+        """Removes properties representing IFC attributes if they no longer appear.
+
+        Removes the property representing an IFC attribute, if it does not
+        appear in the schema of the IFC type provided. Also, removes the
+        property if it's attribute is an enum type, presumably for backwards
+        compatability.
+
+        Learn more about IFC enums here:
+        https://standards.buildingsmart.org/IFC/RELEASE/IFC4/FINAL/HTML/schema/chapter-3.htm#enumeration
+        """
+
         for property in obj.PropertiesList:
             if obj.getGroupOfProperty(property) != "IFC Attributes":
                 continue
@@ -167,6 +403,9 @@ class IfcRoot:
                 obj.removeProperty(property)
 
     def migrateDeprecatedAttributes(self, obj):
+        """Updates the object to use the newer property names for IFC related properties.
+        """
+
         if "Role" in obj.PropertiesList:
             r = obj.Role
             obj.removeProperty("Role")
@@ -186,9 +425,41 @@ class IfcRoot:
             obj.removeProperty("IfcAttributes")
 
 class IfcProduct(IfcRoot):
+    """This class is subclassed by classes that have a specific location in space.
+
+    The obvious example are actual structures, such as the _Wall class, but it
+    also includes the _Floor class, which is just a grouping of all the
+    structures that make up one floor of a building.
+
+    You can learn more about how products fit into the IFC schema here:
+    https://standards.buildingsmart.org/IFC/RELEASE/IFC4/FINAL/HTML/schema/ifckernel/lexical/ifcproduct.htm
+    """
+
     def getIfcSchema(self):
+        """Gets the IFC schema of all IFC types that inherit from IfcProducts.
+
+        Returns
+        -------
+        dict
+            The schema of all the types relevant to this class.
+        """
         return ArchIFCSchema.IfcProducts
 
 class IfcContext(IfcRoot):
+    """This class is subclassed by classes that define a particular context.
+
+    Currently, only the _Project inherits this class.
+
+    You can learn more about how contexts fit into the IFC schema here:
+    https://standards.buildingsmart.org/IFC/RELEASE/IFC4/FINAL/HTML/schema/ifckernel/lexical/ifccontext.htm
+    """
+
     def getIfcSchema(self):
+        """Gets the IFC schema of all IFC types that inherit from IfcContexts.
+
+        Returns
+        -------
+        dict
+            The schema of all the types relevant to this class.
+        """
         return ArchIFCSchema.IfcContexts

--- a/src/Mod/Arch/ArchIFC.py
+++ b/src/Mod/Arch/ArchIFC.py
@@ -186,9 +186,9 @@ class IfcRoot:
 
         Returns
         -------
-        dict:
+        dict
             Returns the schema of the attribute.
-        None:
+        None
             Returns None if the IFC type does not have the attribute requested.
 
         """

--- a/src/Mod/Arch/ArchIFCSchema.py
+++ b/src/Mod/Arch/ArchIFCSchema.py
@@ -1,9 +1,9 @@
-import FreeCAD, os, json
-
-__doc__ = """Provides the IFC schema data as dicts, by loading the JSON schema files.
+"""Provides the IFC schema data as dicts, by loading the JSON schema files.
 
 Provides the data as IfcContexts, IfcProducts and IfcTypes.
 """
+
+import FreeCAD, os, json
 
 ifcVersions = ["IFC4", "IFC2X3"] 
 IfcVersion = ifcVersions[FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/Arch").GetInt("IfcVersion",0)]

--- a/src/Mod/Arch/ArchIFCSchema.py
+++ b/src/Mod/Arch/ArchIFCSchema.py
@@ -1,10 +1,15 @@
 import FreeCAD, os, json
 
-ifcVersions = ["IFC4", "IFC2X3"]
+__doc__ = """Provides the IFC schema data as dicts, by loading the JSON schema files.
+
+Provides the data as IfcContexts, IfcProducts and IfcTypes.
+"""
+
+ifcVersions = ["IFC4", "IFC2X3"] 
 IfcVersion = ifcVersions[FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/Arch").GetInt("IfcVersion",0)]
 
 with open(os.path.join(FreeCAD.getResourceDir(), "Mod", "Arch", "Presets",
-"ifc_contexts_" + IfcVersion + ".json")) as f:
+"ifc_contexts_" + IfcVersion + ".json")) as f: 
     IfcContexts = json.load(f)
 
 with open(os.path.join(FreeCAD.getResourceDir(), "Mod", "Arch", "Presets",

--- a/src/Mod/Arch/ArchIFCView.py
+++ b/src/Mod/Arch/ArchIFCView.py
@@ -113,7 +113,7 @@ class IfcContextUI:
         ----------
         name: str
             The name of the datapoint within the RepresentationContexts
-            attribute being editied.
+            attribute being edited.
         label: str
             A human readable version of the name.
 
@@ -153,7 +153,7 @@ class IfcContextUI:
         ----------
         name: str
             The name of the datapoint within the RepresentationContexts
-            attribute being editied.
+            attribute being edited.
         
         Returns
         -------

--- a/src/Mod/Arch/ArchIFCView.py
+++ b/src/Mod/Arch/ArchIFCView.py
@@ -4,14 +4,45 @@ if FreeCAD.GuiUp:
     import FreeCADGui
     from PySide import QtGui
 
+__doc__ = """View providers and UI elements for the Ifc classes."""
+
 class IfcContextView:
+    """A default view provider for IfcContext objects."""
+
     def setEdit(self, viewObject, mode):
+        """Method called when the document requests the object to enter edit mode.
+
+        Opens the IfcContextUi as the task panel.
+
+        Edit mode is entered when a user double clicks on an object in the tree
+        view, or when they use the menu option [Edit -> Toggle Edit Mode].
+
+        Parameters
+        ----------
+        mode: int or str
+            The edit mode the document has requested. Set to 0 when requested via
+            a double click or [Edit -> Toggle Edit Mode].
+
+        Returns
+        -------
+        bool
+            If edit mode was entered.
+        """
+
         # What does mode do?
         FreeCADGui.Control.showDialog(IfcContextUI(viewObject.Object))
         return True
 
 class IfcContextUI:
+    """A default task panel for editing context objects."""
+
     def __init__(self, object):
+        """Initialises the task panel.
+
+        Defines the layout, and prefills the form with the 
+        data already written to the object.
+        """
+
         self.object = object
         self.lineEditObjects = []
         self.createBaseLayout()
@@ -20,6 +51,11 @@ class IfcContextUI:
         self.form = self.baseWidget
 
     def accept(self):
+        """This method runs as a callback when the user selects the ok button.
+
+        It writes the data entered into the forms to the object's IfcData
+        property.
+        """
         data = {}
         for lineEdit in self.lineEditObjects:
             data[lineEdit.objectName()] = lineEdit.text()
@@ -27,10 +63,18 @@ class IfcContextUI:
         return True
 
     def createBaseLayout(self):
+        """Defines the basic layout of the task panel."""
+
         self.baseWidget = QtGui.QWidget()
         self.baseLayout = QtGui.QVBoxLayout(self.baseWidget)
 
     def createMapConversionFormLayout(self):
+        """Creates form entries for the data being edited.
+
+        Creates form entries for each of the data points being edited within
+        the IFC complex attribute, RepresentationContexts.
+        """
+
         self.baseLayout.addWidget(self.createLabel("Target Coordinate Reference System"))
         self.baseLayout.addLayout(self.createFormEntry("name", "Name"))
         self.baseLayout.addLayout(self.createFormEntry("description", "Description"))
@@ -46,25 +90,77 @@ class IfcContextUI:
         self.baseLayout.addLayout(self.createFormEntry("orthogonal_height", "Orthogonal height"))
         self.baseLayout.addLayout(self.createFormEntry("true_north", "True north (anti-clockwise from +Y)"))
         self.baseLayout.addLayout(self.createFormEntry("scale", "Scale"))
-        
+
     def prefillMapConversionForm(self):
+        """Prefills each of the form entries with the exising value.
+
+        Gets the existing value from the object's IfcData, specifically the complex
+        attribute, RepresentationContexts.
+        """
         data = ArchIFC.IfcRoot.getObjIfcComplexAttribute(self, self.object, "RepresentationContexts")
         for lineEdit in self.lineEditObjects:
             if lineEdit.objectName() in data.keys():
                 lineEdit.setText(data[lineEdit.objectName()])
 
     def createFormEntry(self, name, label):
+        """Creates a form entry.
+
+        The name corresponds to the data point being edited in the
+        RepresentationContexts complex attribute. The label is a human readable
+        version of the name.
+
+        Parameters
+        ----------
+        name: str
+            The name of the datapoint within the RepresentationContexts
+            attribute being editied.
+        label: str
+            A human readable version of the name.
+
+        Returns
+        -------
+        <PySide2.QtWidgets.QWidget>
+            Widget containing the label and form.
+        """
+
         layout = QtGui.QHBoxLayout(self.baseWidget)
         layout.addWidget(self.createLabel(label))
         layout.addWidget(self.createLineEdit(name))
         return layout
 
     def createLabel(self, value):
+        """Creates a translated label.
+
+        Parameters
+        ----------
+        value: str
+            The human readable label text.
+
+        Returns
+        -------
+        <PySide2.QtWidgets.QWidget>
+            The label Qt widget.
+        """
+
         label = QtGui.QLabel(self.baseWidget)
         label.setText(QtGui.QApplication.translate("Arch", value, None))
         return label
 
     def createLineEdit(self, name):
+        """Creates a form with the name specified.
+        
+        Parameters
+        ----------
+        name: str
+            The name of the datapoint within the RepresentationContexts
+            attribute being editied.
+        
+        Returns
+        -------
+        <PySide2.QtWidgets.QWidget>
+            The form Qt widget.
+        """
+
         lineEdit = QtGui.QLineEdit(self.baseWidget)
         lineEdit.setObjectName(name)
         self.lineEditObjects.append(lineEdit)

--- a/src/Mod/Arch/ArchIFCView.py
+++ b/src/Mod/Arch/ArchIFCView.py
@@ -1,10 +1,10 @@
+"""View providers and UI elements for the Ifc classes."""
+
 import FreeCAD, ArchIFC
 
 if FreeCAD.GuiUp:
     import FreeCADGui
     from PySide import QtGui
-
-__doc__ = """View providers and UI elements for the Ifc classes."""
 
 class IfcContextView:
     """A default view provider for IfcContext objects."""

--- a/src/Mod/Arch/ArchIFCView.py
+++ b/src/Mod/Arch/ArchIFCView.py
@@ -37,12 +37,6 @@ class IfcContextUI:
     """A default task panel for editing context objects."""
 
     def __init__(self, object):
-        """Initialises the task panel.
-
-        Defines the layout, and prefills the form with the 
-        data already written to the object.
-        """
-
         self.object = object
         self.lineEditObjects = []
         self.createBaseLayout()

--- a/src/Mod/Arch/ArchProject.py
+++ b/src/Mod/Arch/ArchProject.py
@@ -49,9 +49,9 @@ __author__ = "Yorik van Havre"
 __url__ = "http://www.freecadweb.org"
 
 def makeProject(sites=None, name="Project"):
-    """Creates an Arch project.
+    """Create an Arch project.
 
-    If sites are provided, will add them as children of the new project.
+    If sites are provided, add them as children of the new project.
 
     Parameters
     ----------
@@ -93,14 +93,14 @@ class _CommandProject:
     """
 
     def GetResources(self):
-        """Returns a dictionary with the visual aspects of the Arch Project tool."""
+        """Return a dictionary with the visual aspects of the Arch Project tool."""
         return {'Pixmap'  : 'Arch_Project',
                 'MenuText': QT_TRANSLATE_NOOP("Arch_Project", "Project"),
                 'Accel': "P, O",
                 'ToolTip': QT_TRANSLATE_NOOP("Arch_Project", "Creates a project entity aggregating the selected sites.")}
 
     def IsActive(self):
-        """Determines whether or not the Arch Project tool is active. 
+        """Determine whether or not the Arch Project tool is active. 
 
         Inactive commands are indicated by a greyed-out icon in the menus and toolbars.
         """
@@ -109,7 +109,7 @@ class _CommandProject:
     def Activated(self):
         """Executed when Arch Project is called.
 
-        Creates a project from the objects selected by the user that have the
+        Create a project from the objects selected by the user that have the
         Site IfcType, if any. 
         """
 
@@ -150,9 +150,9 @@ class _Project(ArchIFC.IfcContext):
         obj.IfcType = "Project"
 
     def setProperties(self, obj):
-        """Gives the object properties unique to projects.
+        """Give the object properties unique to projects.
 
-        Adds the IFC context properties, and the group extension if it does not
+        Add the IFC context properties, and the group extension if it does not
         already exist.
         """
 
@@ -163,7 +163,7 @@ class _Project(ArchIFC.IfcContext):
         self.Type = "Project"
 
     def onDocumentRestored(self, obj):
-        """Method run when the document is restored. Re-adds the properties."""
+        """Method run when the document is restored. Re-add the properties."""
         self.setProperties(obj)
 
 class _viewproviderproject(ArchIFCView.IfcContextView):
@@ -180,7 +180,7 @@ class _viewproviderproject(ArchIFCView.IfcContextView):
         vobj.addExtension("Gui::ViewProviderGroupExtensionPython", self)
 
     def getIcon(self):
-        """Returns the path to the appropriate icon.
+        """Return the path to the appropriate icon.
 
         Returns
         -------

--- a/src/Mod/Arch/ArchProject.py
+++ b/src/Mod/Arch/ArchProject.py
@@ -137,19 +137,14 @@ class _Project(ArchIFC.IfcContext):
 
     Takes a <Part::FeaturePython>, and turns it into a Project. Then takes a
     list of Arch sites to own as its children.
+
+    Parameters
+    ----------
+    obj: <App::DocumentObjectGroupPython> or <App::FeaturePython>
+        The object to turn into a Project.
     """
 
     def __init__(self, obj):
-        """Initialises the project.
-
-        Adds the properties of a project, and sets its IFC type.
-
-        Parameters
-        ----------
-        obj: <App::DocumentObjectGroupPython> or <App::FeaturePython>
-            The object to turn into a Project.
-        """
-
         obj.Proxy = self
         self.setProperties(obj)
         obj.IfcType = "Project"
@@ -172,19 +167,15 @@ class _Project(ArchIFC.IfcContext):
         self.setProperties(obj)
 
 class _viewproviderproject(ArchIFCView.IfcContextView):
-    """A View Provider for the project object."""
+    """A View Provider for the project object.
+
+    Parameters
+    ----------
+    vobj: <Gui.ViewProviderDocumentObject>
+        The view provider to turn into a project view provider.
+    """
 
     def __init__(self,vobj):
-        """Initialises the project view provider.
-
-        Registers the Proxy as this class object.
-
-        Parameters
-        ----------
-        vobj: <Gui.ViewProviderDocumentObject>
-            The view provider to turn into a project view provider.
-        """
-
         vobj.Proxy = self
         vobj.addExtension("Gui::ViewProviderGroupExtensionPython", self)
 

--- a/src/Mod/Arch/ArchProject.py
+++ b/src/Mod/Arch/ArchProject.py
@@ -136,13 +136,13 @@ class _Project(ArchIFC.IfcContext):
     """The project object.
 
     Takes a <Part::FeaturePython>, and turns it into a Project. Then takes a
-    list of Arch sites to own as it's children.
+    list of Arch sites to own as its children.
     """
 
     def __init__(self, obj):
         """Initialises the project.
 
-        Adds the properties of a project, and sets it's IFC type.
+        Adds the properties of a project, and sets its IFC type.
 
         Parameters
         ----------

--- a/src/Mod/Arch/ArchProject.py
+++ b/src/Mod/Arch/ArchProject.py
@@ -21,6 +21,11 @@
 #*                                                                         *
 #***************************************************************************
 
+"""This module provides tools to build Project objects.  Project objects are
+objects specifically for better IFC compatability, allowing the user to tweak
+certain IFC relevant values.
+"""
+
 import FreeCAD,Draft,ArchComponent,ArchCommands,math,re,datetime,ArchIFC,ArchIFCView
 if FreeCAD.GuiUp:
     import FreeCADGui
@@ -42,11 +47,6 @@ else:
 __title__="FreeCAD Project"
 __author__ = "Yorik van Havre"
 __url__ = "http://www.freecadweb.org"
-__doc__ = """This module provides tools to build Project objects.
-          Project objects are objects specifically for better IFC
-          compatability, allowing the user to tweak certain IFC
-          relevant values.
-          """
 
 def makeProject(sites=None, name="Project"):
     """Creates an Arch project.

--- a/src/Mod/Arch/ArchProject.py
+++ b/src/Mod/Arch/ArchProject.py
@@ -42,10 +42,30 @@ else:
 __title__="FreeCAD Project"
 __author__ = "Yorik van Havre"
 __url__ = "http://www.freecadweb.org"
+__doc__ = """This module provides tools to build Project objects.
+          Project objects are objects specifically for better IFC
+          compatability, allowing the user to tweak certain IFC
+          relevant values.
+          """
 
 def makeProject(sites=None, name="Project"):
+    """Creates an Arch project.
 
-    '''makeProject(sites): creates a project aggregating the list of sites.'''
+    If sites are provided, will add them as children of the new project.
+
+    Parameters
+    ----------
+    sites: list of <Part::FeaturePython>, optional
+        Sites to add as children of the project. Ultimately this could be
+        anything, however.
+    name: str, optional
+        The label for the project.
+
+    Returns
+    -------
+    <Part::FeaturePython>
+        The created project.
+    """
 
     if not FreeCAD.ActiveDocument:
         return FreeCAD.Console.PrintError("No active document. Aborting\n")
@@ -61,19 +81,38 @@ def makeProject(sites=None, name="Project"):
     return obj
 
 class _CommandProject:
+    """The command definition for the Arch workbench's gui tool, Arch Project. 
 
-    "the Arch Project command definition"
+    A tool for creating Arch projects.
+
+    Creates a project from the objects selected by the user that have the Site
+    IfcType, if any. 
+
+    Find documentation on the end user usage of Arch Project here:
+    https://wiki.freecadweb.org/Arch_Project
+    """
 
     def GetResources(self):
+        """Returns a dictionary with the visual aspects of the Arch Project tool."""
         return {'Pixmap'  : 'Arch_Project',
                 'MenuText': QT_TRANSLATE_NOOP("Arch_Project", "Project"),
                 'Accel': "P, O",
                 'ToolTip': QT_TRANSLATE_NOOP("Arch_Project", "Creates a project entity aggregating the selected sites.")}
 
     def IsActive(self):
+        """Determines whether or not the Arch Project tool is active. 
+
+        Inactive commands are indicated by a greyed-out icon in the menus and toolbars.
+        """
         return not FreeCAD.ActiveDocument is None
 
     def Activated(self):
+        """Executed when Arch Project is called.
+
+        Creates a project from the objects selected by the user that have the
+        Site IfcType, if any. 
+        """
+
         selection = FreeCADGui.Selection.getSelection()
         siteobj = []
 
@@ -94,13 +133,34 @@ class _CommandProject:
         FreeCAD.ActiveDocument.recompute()
 
 class _Project(ArchIFC.IfcContext):
+    """The project object.
+
+    Takes a <Part::FeaturePython>, and turns it into a Project. Then takes a
+    list of Arch sites to own as it's children.
+    """
 
     def __init__(self, obj):
+        """Initalises the project.
+
+        Adds the properties of a project, and sets it's IFC type.
+
+        Parameters
+        ----------
+        obj: <App::DocumentObjectGroupPython> or <App::FeaturePython>
+            The object to turn into a Project.
+        """
+
         obj.Proxy = self
         self.setProperties(obj)
         obj.IfcType = "Project"
 
     def setProperties(self, obj):
+        """Gives the object properties unique to projects.
+
+        Adds the IFC context properties, and the group extension if it does not
+        already exist.
+        """
+
         ArchIFC.IfcContext.setProperties(self, obj)
         pl = obj.PropertiesList
         if not hasattr(obj,"Group"):
@@ -108,15 +168,35 @@ class _Project(ArchIFC.IfcContext):
         self.Type = "Project"
 
     def onDocumentRestored(self, obj):
+        """Method run when the document is restored. Re-adds the properties."""
         self.setProperties(obj)
 
-class _ViewProviderProject(ArchIFCView.IfcContextView):
+class _viewproviderproject(ArchIFCView.IfcContextView):
+    """A View Provider for the project object."""
 
     def __init__(self,vobj):
+        """Initialises the project view provider.
+
+        Registers the Proxy as this class object.
+
+        Parameters
+        ----------
+        vobj: <Gui.ViewProviderDocumentObject>
+            The view provider to turn into a project view provider.
+        """
+
         vobj.Proxy = self
         vobj.addExtension("Gui::ViewProviderGroupExtensionPython", self)
 
     def getIcon(self):
+        """Returns the path to the appropriate icon.
+
+        Returns
+        -------
+        str
+            Path to the appropriate icon .svg file.
+        """
+
         import Arch_rc
         return ":/icons/Arch_Project_Tree.svg"
 

--- a/src/Mod/Arch/ArchProject.py
+++ b/src/Mod/Arch/ArchProject.py
@@ -140,7 +140,7 @@ class _Project(ArchIFC.IfcContext):
     """
 
     def __init__(self, obj):
-        """Initalises the project.
+        """Initialises the project.
 
         Adds the properties of a project, and sets it's IFC type.
 

--- a/src/Mod/Arch/ArchSite.py
+++ b/src/Mod/Arch/ArchSite.py
@@ -538,7 +538,7 @@ class _Site(ArchIFC.IfcProduct):
 
         The site must be based off a <Part::FeaturePython> object.
 
-        Adds the properties of a site, and sets it's IFC type.
+        Adds the properties of a site, and sets its IFC type.
 
         Parameters
         ----------
@@ -793,10 +793,10 @@ class _ViewProviderSite:
         self.setProperties(vobj)
 
     def setProperties(self,vobj):
-        """Gives the site view provider it's site view provider specific properties.
+        """Gives the site view provider its site view provider specific properties.
 
         These include solar diagram and compass data, dealing the orientation
-        of the site, and it's orientation to the sun.
+        of the site, and its orientation to the sun.
 
         You can learn more about properties here: https://wiki.freecadweb.org/property
         """

--- a/src/Mod/Arch/ArchSite.py
+++ b/src/Mod/Arch/ArchSite.py
@@ -532,7 +532,7 @@ class _Site(ArchIFC.IfcProduct):
     """
 
     def __init__(self,obj):
-        """Initalises the site.
+        """Initialises the site.
 
         The site must be based off a <Part::FeaturePython> object.
 

--- a/src/Mod/Arch/ArchSite.py
+++ b/src/Mod/Arch/ArchSite.py
@@ -620,10 +620,10 @@ class _Site(ArchIFC.IfcProduct):
     def execute(self,obj):
         """Method run when the object is recomputed.
         
-        If the site has no Shape or Terrain property assigned, does nothing.
+        If the site has no Shape or Terrain property assigned, do nothing.
 
-        Performs additions and subtractions on terrain, and assigns to the
-        site's Shape.
+        Perform additions and subtractions on terrain, and assign to the site's
+        Shape.
         """
 
         if not hasattr(obj,'Shape'): # old-style Site
@@ -669,10 +669,10 @@ class _Site(ArchIFC.IfcProduct):
     def onChanged(self,obj,prop):
         """Method called when the object has a property changed.
 
-        If Terrain has changed, hides the base object terrain, then runs
+        If Terrain has changed, hide the base object terrain, then run
         .execute().
 
-        Also calls ArchIFC.IfcProduct.onChanged().
+        Also call ArchIFC.IfcProduct.onChanged().
 
         Parameters
         ----------
@@ -688,17 +688,17 @@ class _Site(ArchIFC.IfcProduct):
                 self.execute(obj)
 
     def computeAreas(self,obj):
-        """Computes the area, perimeter length, and volume of the terrain shape.
+        """Compute the area, perimeter length, and volume of the terrain shape.
 
-        Computes the area of the terrain projected onto an XY hyperplane, IE:
+        Compute the area of the terrain projected onto an XY hyperplane, IE:
         the area of the terrain if viewed from a birds eye view.
 
-        Computes the length of the perimeter of this birds eye view area.
+        Compute the length of the perimeter of this birds eye view area.
 
-        Computes the volume of the terrain that needs to be subtracted and
+        Compute the volume of the terrain that needs to be subtracted and
         added on account of the Additions and Subtractions to the site.
 
-        These values are assigned to their respective site properties.
+        Assign these values to their respective site properties.
         """
 
         if not obj.Shape:
@@ -783,7 +783,7 @@ class _ViewProviderSite:
         self.setProperties(vobj)
 
     def setProperties(self,vobj):
-        """Gives the site view provider its site view provider specific properties.
+        """Give the site view provider its site view provider specific properties.
 
         These include solar diagram and compass data, dealing the orientation
         of the site, and its orientation to the sun.
@@ -817,11 +817,11 @@ class _ViewProviderSite:
             vobj.addProperty("App::PropertyBool", "UpdateDeclination", "Compass", QT_TRANSLATE_NOOP("App::Property", "Update the Declination value based on the compass rotation"))
 
     def onDocumentRestored(self,vobj):
-        """Method run when the document is restored. Re-adds the Arch component properties."""
+        """Method run when the document is restored. Re-add the Arch component properties."""
         self.setProperties(vobj)
 
     def getIcon(self):
-        """Returns the path to the appropriate icon.
+        """Return the path to the appropriate icon.
 
         Returns
         -------
@@ -833,12 +833,12 @@ class _ViewProviderSite:
         return ":/icons/Arch_Site_Tree.svg"
 
     def claimChildren(self):
-        """Defines which objects will appear as children in the tree view.
+        """Define which objects will appear as children in the tree view.
 
-        Sets objects within the site group, and the terrain object as children.
+        Set objects within the site group, and the terrain object as children.
 
-        If the Arch preference swallowSubtractions is true, the additions and
-        subtractions to the terrain are set as children.
+        If the Arch preference swallowSubtractions is true, set the additions
+        and subtractions to the terrain as children.
 
         Returns
         -------
@@ -862,7 +862,7 @@ class _ViewProviderSite:
         Edit mode is entered when a user double clicks on an object in the tree
         view, or when they use the menu option [Edit -> Toggle Edit Mode].
 
-        Just dispays the standard Arch component task panel.
+        Just dispay the standard Arch component task panel.
 
         Parameters
         ----------
@@ -888,7 +888,7 @@ class _ViewProviderSite:
     def unsetEdit(self,vobj,mode):
         """Method called when the document requests the object exit edit mode.
 
-        Closes the Arch component edit task panel.
+        Close the Arch component edit task panel.
 
         Returns
         -------
@@ -899,9 +899,9 @@ class _ViewProviderSite:
         return False
 
     def attach(self,vobj):
-        """Adds display modes' data to the coin scenegraph.
+        """Add display modes' data to the coin scenegraph.
 
-        Adds each display mode as a coin node, whose parent is this view
+        Add each display mode as a coin node, whose parent is this view
         provider. 
 
         Each display mode's node includes the data needed to display the object
@@ -909,8 +909,8 @@ class _ViewProviderSite:
         lines. This data is stored as additional coin nodes which are children
         of the display mode node.
 
-        Does not add display modes, but does add the solar diagram and compass
-        to the scenegraph.
+        Doe not add display modes, but do add the solar diagram and compass to
+        the scenegraph.
         """
 
         self.Object = vobj.Object
@@ -933,10 +933,10 @@ class _ViewProviderSite:
     def updateData(self,obj,prop):
         """Method called when the host object has a property changed.
 
-        If the Longitude or Lattitude has changed, the SolarDiagram is
-        set to update.
+        If the Longitude or Lattitude has changed, set the SolarDiagram to
+        update.
 
-        If Terrain or Placement has changed, the compass is moved to follow it.
+        If Terrain or Placement has changed, move the compass to follow it.
 
         Parameters
         ----------
@@ -1010,10 +1010,10 @@ class _ViewProviderSite:
             self.updateCompassLocation(vobj)
 
     def updateDeclination(self,vobj):
-        """Updates the declination of the compass 
+        """Update the declination of the compass 
 
-        Updates the declination by adding together how the
-        site has been rotated within the document, and the rotation of the site compass.
+        Update the declination by adding together how the site has been rotated
+        within the document, and the rotation of the site compass.
         """
 
         if not hasattr(vobj, 'UpdateDeclination') or not vobj.UpdateDeclination:

--- a/src/Mod/Arch/ArchSite.py
+++ b/src/Mod/Arch/ArchSite.py
@@ -531,21 +531,16 @@ class _Site(ArchIFC.IfcProduct):
     with additions and subtractions as earthmoving, calculating volumes of
     terrain that have been moved by the additions and subtractions. Unlike most
     Arch objects, the Terrain object works well as a mesh.
+
+    The site must be based off a <Part::FeaturePython> object.
+
+    Parameters
+    ----------
+    obj: <Part::FeaturePython>
+        The object to turn into a site.
     """
 
     def __init__(self,obj):
-        """Initialises the site.
-
-        The site must be based off a <Part::FeaturePython> object.
-
-        Adds the properties of a site, and sets its IFC type.
-
-        Parameters
-        ----------
-        obj: <Part::FeaturePython>
-            The object to turn into a site.
-        """
-
         obj.Proxy = self
         self.setProperties(obj)
         obj.IfcType = "Site"
@@ -774,20 +769,15 @@ class _Site(ArchIFC.IfcProduct):
             obj.AdditionVolume = addvol
 
 class _ViewProviderSite:
-    """A View Provider for the Site object"""
+    """A View Provider for the Site object.
+
+    Parameters
+    ----------
+    vobj: <Gui.ViewProviderDocumentObject>
+        The view provider to turn into a site view provider.
+    """
 
     def __init__(self,vobj):
-        """Initialises the site view provider.
-
-        Registers the Proxy as this class object. Sets the view provider to have the
-        properties of a site view provider.
-
-        Parameters
-        ----------
-        vobj: <Gui.ViewProviderDocumentObject>
-            The view provider to turn into a site view provider.
-        """
-
         vobj.Proxy = self
         vobj.addExtension("Gui::ViewProviderGroupExtensionPython", self)
         self.setProperties(vobj)

--- a/src/Mod/Arch/ArchSite.py
+++ b/src/Mod/Arch/ArchSite.py
@@ -21,6 +21,10 @@
 #*                                                                         *
 #***************************************************************************
 
+"""This module provides tools to build Site objects. Sites are
+containers for Arch objects, and also define a terrain surface.
+"""
+
 import FreeCAD,Draft,ArchCommands,math,re,datetime,ArchIFC
 if FreeCAD.GuiUp:
     import FreeCADGui
@@ -46,8 +50,6 @@ else:
 __title__="FreeCAD Site"
 __author__ = "Yorik van Havre"
 __url__ = "http://www.freecadweb.org"
-__doc__ = """This module provides tools to build Site objects. Sites are
-containers for Arch objects, and also define a terrain surface."""
 
 
 def makeSite(objectslist=None,baseobj=None,name="Site"):

--- a/src/Mod/Arch/ArchWall.py
+++ b/src/Mod/Arch/ArchWall.py
@@ -1328,7 +1328,7 @@ obj: <part::featurepython>
                                     w2 = DraftGeomUtils.offsetWire(wire,d1)
                                 else:
                                     dvec.multiply(width)
-                                    w2 = DraftGeomUtils.offsetWire(wire,
+                                    w2 = DraftGeomUtils.offsetWire(
                                         wire, dvec,
                                         bind=False,
                                         occ=False,
@@ -1337,7 +1337,7 @@ obj: <part::featurepython>
                                         alignList=aligns,
                                         normal=normal
                                         )
-                                    w1 = DraftGeomUtils.offsetWire(wire,
+                                    w1 = DraftGeomUtils.offsetWire(
                                         wire, dvec,
                                         bind=False,
                                         occ=False,

--- a/src/Mod/Arch/ArchWall.py
+++ b/src/Mod/Arch/ArchWall.py
@@ -58,7 +58,7 @@ __author__ = "Yorik van Havre"
 __url__ = "http://www.freecadweb.org"
 
 def makeWall(baseobj=None,height=None,length=None,width=None,align="Center",face=None,name="Wall"):
-    """Creates a wall based on a given object, and returns the generated wall.
+    """Create a wall based on a given object, and returns the generated wall.
 
     TODO: It is unclear what defines which units this function uses.
 
@@ -132,12 +132,12 @@ def makeWall(baseobj=None,height=None,length=None,width=None,align="Center",face
     return obj
 
 def joinWalls(walls,delete=False):
-    """Joins the given list of walls into one sketch-based wall.
+    """Join the given list of walls into one sketch-based wall.
 
-    Takes the first wall in the list, and adds on the other walls in the list.
-    Returns the modified first wall. 
+    Take the first wall in the list, and adds on the other walls in the list.
+    Return the modified first wall. 
 
-    Setting delete to True, will delete the other walls. Will only join walls
+    Setting delete to True, will delete the other walls. Only join walls
     if the walls have the same width, height and alignment.
 
     Parameters
@@ -190,7 +190,7 @@ def joinWalls(walls,delete=False):
 def mergeShapes(w1,w2):
     """Not currently implemented. 
 
-    Returns a Shape built on two walls that share same properties and have a
+    Return a Shape built on two walls that share same properties and have a
     coincident endpoint.
     """
 
@@ -217,7 +217,7 @@ def mergeShapes(w1,w2):
     return None
 
 def areSameWallTypes(walls):
-    """Checks if a list of walls have the same height, width and alignment.
+    """Check if a list of walls have the same height, width and alignment.
 
     Parameters
     ----------
@@ -253,8 +253,8 @@ class _CommandWall:
 
     A tool for creating Arch walls.
 
-    Creates a wall from the object selected by the user. If no objects are
-    selected, enters an interactive mode to create a wall using selected points
+    Create a wall from the object selected by the user. If no objects are
+    selected, enter an interactive mode to create a wall using selected points
     to create a base.
 
     Find documentation on the end user usage of Arch Wall here:
@@ -404,8 +404,7 @@ class _CommandWall:
                 self.Activated()
 
     def addDefault(self):
-        """Creates a wall using a line segment, with all parameters as the
-        default.
+        """Create a wall using a line segment, with all parameters as the default.
 
         Used solely by _CommandWall.getPoint() when the interactive mode has
         selected two points.
@@ -431,9 +430,9 @@ class _CommandWall:
     def update(self,point):
         """Callback for the mouse moving during the interactive mode.
 
-        Updates the active dialog box to show the coordinates of the location
-        of the cursor. It also shows the length the line would take, if the
-        user selected that point.
+        Update the active dialog box to show the coordinates of the location of
+        the cursor. Also show the length the line would take, if the user
+        selected that point.
 
         Parameters
         ----------
@@ -458,7 +457,7 @@ class _CommandWall:
                 self.Length.setText(FreeCAD.Units.Quantity(bv.Length,FreeCAD.Units.Length).UserString)
 
     def taskbox(self):
-        """Sets up a simple gui widget for the interactive mode."""
+        """Set up a simple gui widget for the interactive mode."""
 
         w = QtGui.QWidget()
         ui = FreeCADGui.UiLoader()
@@ -611,7 +610,7 @@ class _CommandMergeWalls:
 
     A tool for merging walls.
 
-    Joins two or more walls by using the ArchWall.joinWalls() function.
+    Join two or more walls by using the ArchWall.joinWalls() function.
 
     Find documentation on the end user usage of Arch Wall here:
     https://wiki.freecadweb.org/Arch_MergeWalls
@@ -636,7 +635,7 @@ class _CommandMergeWalls:
     def Activated(self):
         """Executed when Arch MergeWalls is called.
 
-        Calls ArchWall.joinWalls() on walls selected by the user, with the
+        Call ArchWall.joinWalls() on walls selected by the user, with the
         delete option enabled. If the user has selected a single wall, check to
         see if the wall has any Additions that are walls. If so, merges these
         additions to the wall, deleting the additions.
@@ -694,7 +693,7 @@ class _Wall(ArchComponent.Component):
         obj.IfcType = "Wall"
 
     def setProperties(self, obj):
-        """Gives the wall its wall specific properties, such as its alignment.
+        """Give the wall its wall specific properties, such as its alignment.
 
         You can learn more about properties here:
         https://wiki.freecadweb.org/property
@@ -768,11 +767,11 @@ class _Wall(ArchComponent.Component):
     def execute(self,obj):
         """Method run when the object is recomputed.
 
-        Extrudes the wall from the Base shape if possible. Processes additions
-        and subtractions. Assigns the resulting shape as the shape of the wall.
+        Extrude the wall from the Base shape if possible. Processe additions
+        and subtractions. Assign the resulting shape as the shape of the wall.
 
-        Adds blocks if the MakeBlocks property is assigned. If the Base shape
-        is a mesh, just copies the mesh.
+        Add blocks if the MakeBlocks property is assigned. If the Base shape is
+        a mesh, just copy the mesh.
         """
 
         if self.clone(obj):
@@ -968,8 +967,8 @@ class _Wall(ArchComponent.Component):
 
         Specifically, this method is called before the value changes.
 
-        If "Length" has changed, it records the old length so that .onChanged()
-        can be sure that the base needs to be changed.
+        If "Length" has changed, record the old length so that .onChanged() can
+        be sure that the base needs to be changed.
 
         Parameters
         ----------
@@ -983,12 +982,12 @@ class _Wall(ArchComponent.Component):
     def onChanged(self, obj, prop):
         """Method called when the object has a property changed.
 
-        If length has changed, will extend the length of the Base object, if
-        the Base object only has a single edge to extend.
+        If length has changed, extend the length of the Base object, if the
+        Base object only has a single edge to extend.
 
-        Also hides subobjects.
+        Also hide subobjects.
 
-        Also calls ArchComponent.Component.onChanged().
+        Also call ArchComponent.Component.onChanged().
 
         Parameters
         ----------
@@ -1026,7 +1025,7 @@ class _Wall(ArchComponent.Component):
         ArchComponent.Component.onChanged(self,obj,prop)
 
     def getFootprint(self,obj):
-        """Gets the faces that make up the base/foot of the wall.
+        """Get the faces that make up the base/foot of the wall.
         
         Returns
         -------
@@ -1043,14 +1042,14 @@ class _Wall(ArchComponent.Component):
         return faces
 
     def getExtrusionData(self,obj):
-        """Gets data needed to extrude the wall from a base object.
+        """Get data needed to extrude the wall from a base object.
         
-        This method takes the Base object, and finds a base face to extrude
+        take the Base object, and find a base face to extrude
         out, a vector to define the extrusion direction and distance.
 
-        The base face is rebased to the (0,0,0) origin.
+        Rebase the base face to the (0,0,0) origin.
 
-        The base face is returned, rebased, with the extrusion vector, and the
+        Return the base face, rebased, with the extrusion vector, and the
         <Base.Placement> needed to return the face back to its original
         position.
 
@@ -1510,9 +1509,9 @@ class _ViewProviderWall(ArchComponent.ViewProviderComponent):
         vobj.ShapeColor = ArchCommands.getDefaultColor("Wall")
 
     def getIcon(self):
-        """Returns the path to the appropriate icon.
+        """Return the path to the appropriate icon.
 
-        If a clone, returns the cloned wall icon path. Otherwise returns the
+        If a clone, return the cloned wall icon path. Otherwise return the
         Arch wall icon.
 
         Returns
@@ -1530,9 +1529,9 @@ class _ViewProviderWall(ArchComponent.ViewProviderComponent):
         return ":/icons/Arch_Wall_Tree.svg"
 
     def attach(self,vobj):
-        """Adds display modes' data to the coin scenegraph.
+        """Add display modes' data to the coin scenegraph.
 
-        Adds each display mode as a coin node, whose parent is this view
+        Add each display mode as a coin node, whose parent is this view
         provider. 
 
         Each display mode's node includes the data needed to display the object
@@ -1540,7 +1539,7 @@ class _ViewProviderWall(ArchComponent.ViewProviderComponent):
         lines. This data is stored as additional coin nodes which are children
         of the display mode node.
 
-        Adds the textures used in the Footprint display mode.
+        Add the textures used in the Footprint display mode.
         """
 
         self.Object = vobj.Object
@@ -1567,7 +1566,7 @@ class _ViewProviderWall(ArchComponent.ViewProviderComponent):
         """Method called when the host object has a property changed.
 
         If the host object's Placement, Shape, or Material has changed, and the
-        host object has a Material assigned, gives the shape the color and
+        host object has a Material assigned, give the shape the color and
         transparency of the Material.
 
         Parameters
@@ -1603,10 +1602,10 @@ class _ViewProviderWall(ArchComponent.ViewProviderComponent):
             obj.ViewObject.DiffuseColor = obj.ViewObject.DiffuseColor
 
     def getDisplayModes(self,vobj):
-        """Defines the display modes unique to the Arch Wall.
+        """Define the display modes unique to the Arch Wall.
 
-        Defines mode Footprint, which only displays the footprint of the wall.
-        Also adds the display modes of the Arch Component.
+        Define mode Footprint, which only displays the footprint of the wall.
+        Also add the display modes of the Arch Component.
 
         Returns
         -------
@@ -1623,11 +1622,11 @@ class _ViewProviderWall(ArchComponent.ViewProviderComponent):
         Called when the display mode changes, this method can be used to set
         data that wasn't available when .attach() was called.
 
-        When Footprint is set as display mode, finds the faces that make up the
-        footprint of the wall, and gives them a lined texture. Then displays
+        When Footprint is set as display mode, find the faces that make up the
+        footprint of the wall, and give them a lined texture. Then display
         the wall as a wireframe.
 
-        Then passes the displaymode onto Arch Component's .setDisplayMode().
+        Then pass the displaymode onto Arch Component's .setDisplayMode().
 
         Parameters
         ----------

--- a/src/Mod/Arch/ArchWall.py
+++ b/src/Mod/Arch/ArchWall.py
@@ -48,56 +48,56 @@ __author__ = "Yorik van Havre"
 __url__ = "http://www.freecadweb.org"
 
 __doc__="""This module provides tools to build Wall objects.  Walls are simple
-objects, usually vertical, typically obtained by giving a thickness to a base
-line, then extruding it vertically.
+        objects, usually vertical, typically obtained by giving a thickness to a base
+        line, then extruding it vertically.
 
-Examples
---------
-TODO put examples here.
+        Examples
+        --------
+        TODO put examples here.
 
-"""
+        """
 
 def makeWall(baseobj=None,height=None,length=None,width=None,align="Center",face=None,name="Wall"):
-    '''Creates a wall based on a given object, and returns the generated wall.
+    """Creates a wall based on a given object, and returns the generated wall.
 
-TODO: It is unclear what defines which units this function uses.
+    TODO: It is unclear what defines which units this function uses.
 
-Parameters
-----------
-baseobj: <Part::PartFeature>, optional
-    The base object with which to build the wall. This can be a sketch, a draft
-    object, a face, or a solid. It can also be left as None.
-height: float, optional
-    The height of the wall.
-length: float, optional
-    The length of the wall. Not used if the wall is based off an object.
-    Will use Arch default if left empty.
-width: float, optional
-    The width of the wall. Not used if the base object is a face.  Will
-    use Arch default if left empty.
-align: str, optional
-    Either "Center", "Left", or "Right". Effects the alignment of the wall on
-    it's baseline.
-face: int, optional
-    The index number of a face on the given baseobj, to base the wall on.
-name: str, optional
-    The name to give to the created wall.
+    Parameters
+    ----------
+    baseobj: <Part::PartFeature>, optional
+        The base object with which to build the wall. This can be a sketch, a draft
+        object, a face, or a solid. It can also be left as None.
+    height: float, optional
+        The height of the wall.
+    length: float, optional
+        The length of the wall. Not used if the wall is based off an object.
+        Will use Arch default if left empty.
+    width: float, optional
+        The width of the wall. Not used if the base object is a face.  Will
+        use Arch default if left empty.
+    align: str, optional
+        Either "Center", "Left", or "Right". Effects the alignment of the wall on
+        it's baseline.
+    face: int, optional
+        The index number of a face on the given baseobj, to base the wall on.
+    name: str, optional
+        The name to give to the created wall.
 
-Returns
--------
-<Part::FeaturePython>
-    Returns the generated wall.
+    Returns
+    -------
+    <Part::FeaturePython>
+        Returns the generated wall.
 
-Notes
------
-Creates a new <Part::FeaturePython> object, and turns it into a parametric wall
-object. This <Part::FeaturePython> object does not yet have any shape.
+    Notes
+    -----
+    Creates a new <Part::FeaturePython> object, and turns it into a parametric wall
+    object. This <Part::FeaturePython> object does not yet have any shape.
 
-The wall then uses the baseobj.Shape as the basis to extrude out a wall shape,
-giving the new <Part::FeaturePython> object a shape.
+    The wall then uses the baseobj.Shape as the basis to extrude out a wall shape,
+    giving the new <Part::FeaturePython> object a shape.
 
-It then hides the original baseobj.
-'''
+    It then hides the original baseobj.
+    """
 
     if not FreeCAD.ActiveDocument:
         FreeCAD.Console.PrintError("No active document. Aborting\n")
@@ -134,24 +134,24 @@ It then hides the original baseobj.
 def joinWalls(walls,delete=False):
     """ Joins the given list of walls into one sketch-based wall.
 
-Takes the first wall in the list, and adds on the other walls in the list.
-Returns the modified first wall. 
+    Takes the first wall in the list, and adds on the other walls in the list.
+    Returns the modified first wall. 
 
-Setting delete to True, will delete the other walls. Will only join walls if
-the walls have the same width, height and alignment.
+    Setting delete to True, will delete the other walls. Will only join walls if
+    the walls have the same width, height and alignment.
 
-Parameters
-----------
-walls: list of <Part::FeaturePython>
-    List containing the walls to add to the first wall in the list. Walls must
-    be based off a base object.
-delete: bool, optional
-    If True, deletes the other walls in the list.
+    Parameters
+    ----------
+    walls: list of <Part::FeaturePython>
+        List containing the walls to add to the first wall in the list. Walls must
+        be based off a base object.
+    delete: bool, optional
+        If True, deletes the other walls in the list.
 
-Returns
--------
-<Part::FeaturePython>
-"""
+    Returns
+    -------
+    <Part::FeaturePython>
+    """
 
     import Part
     if not walls:
@@ -190,9 +190,9 @@ Returns
 def mergeShapes(w1,w2):
     """Not currently implemented. 
 
-Returns a Shape built on two walls that share same properties and have a
-coincident endpoint.
-"""
+    Returns a Shape built on two walls that share same properties and have a
+    coincident endpoint.
+    """
 
     if not areSameWallTypes([w1,w2]):
         return None
@@ -219,15 +219,15 @@ coincident endpoint.
 def areSameWallTypes(walls):
     """Checks if a list of walls have the same height, width and alignment.
 
-Parameters
-----------
-walls: list of <class 'ArchComponent.Component'>
+    Parameters
+    ----------
+    walls: list of <class 'ArchComponent.Component'>
 
-Returns
--------
-bool
-    True if the walls have the same height, width and alignment, false if otherwise.
-"""
+    Returns
+    -------
+    bool
+        True if the walls have the same height, width and alignment, false if otherwise.
+    """
 
     for att in ["Width","Height","Align"]:
         value = None
@@ -250,13 +250,13 @@ bool
 class _CommandWall:
     """The command definition for the Arch workbench's gui tool, Arch Wall. A tool for creating Arch walls.
 
-Creates a wall from the object selected by the user. If no objects are
-selected, enters an interactive mode to create a wall using selected points
-to create a base.
+    Creates a wall from the object selected by the user. If no objects are
+    selected, enters an interactive mode to create a wall using selected points
+    to create a base.
 
-Find documentation on the end user usage of Arch Wall here:
-https://wiki.freecadweb.org/Arch_Wall
-"""
+    Find documentation on the end user usage of Arch Wall here:
+    https://wiki.freecadweb.org/Arch_Wall
+    """
 
     def GetResources(self):
         """Returns a dictionary with the visual aspects of the Arch Wall tool."""
@@ -277,10 +277,10 @@ https://wiki.freecadweb.org/Arch_Wall
     def Activated(self):
         """Executed when Arch Wall is called.
 
-Creates a wall from the object selected by the user. If no objects are
-selected, enters an interactive mode to create a wall using selected points
-to create a base.
-"""
+        Creates a wall from the object selected by the user. If no objects are
+        selected, enters an interactive mode to create a wall using selected points
+        to create a base.
+        """
 
         p = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/Arch")
         self.Align = ["Center","Left","Right"][p.GetInt("WallAlignment",0)]
@@ -327,25 +327,23 @@ to create a base.
             self.tracker = DraftTrackers.boxTracker()
             if hasattr(FreeCAD,"DraftWorkingPlane"):
                 FreeCAD.DraftWorkingPlane.setup()
-            FreeCADGui.Snapper.getPoint(
-                    callback=self.getPoint,
-                    extradlg=self.taskbox(),
-                    title=translate("Arch","First point of wall")+":"
-                    )
+            FreeCADGui.Snapper.getPoint(callback=self.getPoint,
+                                        extradlg=self.taskbox(),
+                                        title=translate("Arch","First point of wall")+":")
 
     def getPoint(self,point=None,obj=None):
         """Callback for clicks during interactive mode.
 
-When method _CommandWall.Activated() has entered the interactive mode, this
-callback runs when the user clicks.
+        When method _CommandWall.Activated() has entered the interactive mode, this
+        callback runs when the user clicks.
 
-Parameters
-----------
-point: <class 'Base.Vector'>
-    The point the user has selected.
-obj: <Part::PartFeature>, optional
-    The object the user's cursor snapped to, if any.
-"""
+        Parameters
+        ----------
+        point: <class 'Base.Vector'>
+            The point the user has selected.
+        obj: <Part::PartFeature>, optional
+            The object the user's cursor snapped to, if any.
+        """
 
         if obj:
             if Draft.getType(obj) == "Wall":
@@ -359,20 +357,16 @@ obj: <Part::PartFeature>, optional
             self.tracker.width(self.Width)
             self.tracker.height(self.Height)
             self.tracker.on()
-            FreeCADGui.Snapper.getPoint(
-                    last=self.points[0],
-                    callback=self.getPoint,
-                    movecallback=self.update,
-                    extradlg=self.taskbox(),
-                    title=translate("Arch","Next point")+":",mode="line"
-                    )
+            FreeCADGui.Snapper.getPoint(last=self.points[0],
+                                        callback=self.getPoint,
+                                        movecallback=self.update,
+                                        extradlg=self.taskbox(),
+                                        title=translate("Arch","Next point")+":",mode="line")
 
         elif len(self.points) == 2:
             import Part
-            l = Part.LineSegment(
-                    FreeCAD.DraftWorkingPlane.getLocalCoords(self.points[0]),
-                    FreeCAD.DraftWorkingPlane.getLocalCoords(self.points[1])
-                    )
+            l = Part.LineSegment(FreeCAD.DraftWorkingPlane.getLocalCoords(self.points[0]),
+                                 FreeCAD.DraftWorkingPlane.getLocalCoords(self.points[1])
             self.tracker.finalize()
             FreeCAD.ActiveDocument.openTransaction(translate("Arch","Create Wall"))
             FreeCADGui.addModule("Arch")
@@ -408,12 +402,12 @@ obj: <Part::PartFeature>, optional
     def addDefault(self):
         """Creates a wall using a line segment, with all parameters as the default.
 
-Used solely by _CommandWall.getPoint() when the interactive mode has selected
-two points.
+        Used solely by _CommandWall.getPoint() when the interactive mode has selected
+        two points.
 
-Relies on the assumption that FreeCADGui.doCommand() has already created a
-Part.LineSegment assigned as the variable "trace"
-"""
+        Relies on the assumption that FreeCADGui.doCommand() has already created a
+        Part.LineSegment assigned as the variable "trace"
+        """
 
         FreeCADGui.addModule("Draft")
         if FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/Arch").GetBool("WallSketches",True):
@@ -432,15 +426,15 @@ Part.LineSegment assigned as the variable "trace"
     def update(self,point):
         """Callback for the mouse moving during the interactive mode.
 
-Updates the active dialog box to show the coordinates of the location of the
-cursor. It also shows the length the line would take, if the user selected that
-point.
+        Updates the active dialog box to show the co-ordinates of the location of the
+        cursor. It also shows the length the line would take, if the user selected that
+        point.
 
-Parameters
-----------
-point: <class 'Base.Vector'>
-    The point the cursor is currently at, or has snapped to.
-"""
+        Parameters
+        ----------
+        point: <class 'Base.Vector'>
+            The point the cursor is currently at, or has snapped to.
+        """
 
         if FreeCADGui.Control.activeDialog():
             b = self.points[0]
@@ -581,8 +575,8 @@ point: <class 'Base.Vector'>
     def setContinue(self,i):
         """Simple callback to set if the interactive mode will restart when finished. 
 
-This allows for several walls to be placed one after another.
-"""
+        This allows for several walls to be placed one after another.
+        """
 
         self.continueCmd = bool(i)
         if hasattr(FreeCADGui,"draftToolBar"):
@@ -610,11 +604,11 @@ This allows for several walls to be placed one after another.
 class _CommandMergeWalls:
     """The command definition for the Arch workbench's gui tool, Arch MergeWalls. A tool for merging walls.
 
-Joins two or more walls by using the ArchWall.joinWalls() function.
+    Joins two or more walls by using the ArchWall.joinWalls() function.
 
-Find documentation on the end user usage of Arch Wall here:
-https://wiki.freecadweb.org/Arch_MergeWalls
-"""
+    Find documentation on the end user usage of Arch Wall here:
+    https://wiki.freecadweb.org/Arch_MergeWalls
+    """
 
     def GetResources(self):
         """Returns a dictionary with the visual aspects of the Arch MergeWalls tool."""
@@ -634,11 +628,12 @@ https://wiki.freecadweb.org/Arch_MergeWalls
     def Activated(self):
         """Executed when Arch MergeWalls is called.
 
-Calls ArchWall.joinWalls() on walls selected by the user, with the delete
-option enabled. If the user has selected a single wall, check to see if the
-wall has any Additions that are walls. If so, merges these additions to the
-wall, deleting the additions.
-"""
+        Calls ArchWall.joinWalls() on walls selected by the user, with the delete
+        option enabled. If the user has selected a single wall, check to see if the
+        wall has any Additions that are walls. If so, merges these additions to the
+        wall, deleting the additions.
+        """
+
         walls = FreeCADGui.Selection.getSelection()
         if len(walls) == 1:
             if Draft.getType(walls[0]) == "Wall":
@@ -672,21 +667,21 @@ wall, deleting the additions.
 class _Wall(ArchComponent.Component):
     """The Wall object. Takes a <App::FeaturePython> and turns it into a wall.
 
-Walls are simple objects, usually vertical, typically obtained by giving a
-thickness to a base line, then extruding it vertically.
+    Walls are simple objects, usually vertical, typically obtained by giving a
+    thickness to a base line, then extruding it vertically.
 
-Parameters
-----------
-obj: <App::FeaturePython>
-    The object to turn into a wall. Note that this is not the object that forms
-    the basis for the new wall's shape. That is given later.
-"""
+    Parameters
+    ----------
+    obj: <App::FeaturePython>
+        The object to turn into a wall. Note that this is not the object that forms
+        the basis for the new wall's shape. That is given later.
+    """
 
     def __init__(self, obj):
         """Initialises the object's properties.
 
-Sets the object to have the properties of an Arch component, and Arch wall.
-"""
+        Sets the object to have the properties of an Arch component, and Arch wall.
+        """
 
         ArchComponent.Component.__init__(self, obj)
         self.setProperties(obj)
@@ -695,13 +690,13 @@ Sets the object to have the properties of an Arch component, and Arch wall.
     def setProperties(self, obj):
         """Gives the wall it's wall specific properties, such as it's alignment.
 
-You can learn more about properties here: https://wiki.freecadweb.org/property
+        You can learn more about properties here: https://wiki.freecadweb.org/property
 
-parameters
-----------
-obj: <part::featurepython>
-    The object to turn into a wall.
-"""
+        parameters
+        ----------
+        obj: <part::featurepython>
+            The object to turn into a wall.
+        """
 
         lp = obj.PropertiesList
         if not "Length" in lp:
@@ -1257,29 +1252,25 @@ obj: <part::featurepython>
                                 # Get the 'offseted' wire taking into account
                                 # of Width and Align of each edge, and overall
                                 # Offset
-                                w2 = DraftGeomUtils.offsetWire(
-                                        wire,dvec,
-                                        bind=False,
-                                        occ=False,
-                                        widthList=widths,
-                                        offsetMode=None,
-                                        alignList=aligns,
-                                        normal=normal,
-                                        basewireOffset=off
-                                        )
+                                w2 = DraftGeomUtils.offsetWire(wire, dvec,
+                                                               bind=False,
+                                                               occ=False,
+                                                               widthList=widths,
+                                                               offsetMode=None,
+                                                               alignList=aligns,
+                                                               normal=normal,
+                                                               basewireOffset=off)
 
                                 # Get the 'base' wire taking into account of
                                 # width and align of each edge
-                                w1 = DraftGeomUtils.offsetWire(
-                                        wire, dvec,
-                                        bind=False,
-                                        occ=False,
-                                        widthList=widths,
-                                        offsetMode="BasewireMode",
-                                        alignList=aligns,
-                                        normal=normal,
-                                        basewireOffset=off
-                                        )
+                                w1 = DraftGeomUtils.offsetWire(wire, dvec,
+                                                               bind=False,
+                                                               occ=False,
+                                                               widthList=widths,
+                                                               offsetMode="BasewireMode",
+                                                               alignList=aligns,
+                                                               normal=normal,
+                                                               basewireOffset=off)
                                 sh = DraftGeomUtils.bind(w1,w2)
 
                             elif curAligns == "Right":
@@ -1298,20 +1289,23 @@ obj: <part::featurepython>
                                 #    dvec2 = DraftVecUtils.scaleTo(dvec,off)
                                 #    wire = DraftGeomUtils.offsetWire(wire,dvec2)
 
-                                w2 = DraftGeomUtils.offsetWire(
-                                        wire, dvec,
-                                        bind=False,
-                                        occ=False,
-                                        widthList=widths,
-                                        offsetMode=None,
-                                        alignList=aligns,
-                                        normal=normal,
-                                        basewireOffset=off
-                                        )
+                                w2 = DraftGeomUtils.offsetWire(wire, dvec,
+                                                               bind=False,
+                                                               occ=False,
+                                                               widthList=widths,
+                                                               offsetMode=None,
+                                                               alignList=aligns,
+                                                               normal=normal,
+                                                               basewireOffset=off)
 
-                                w1 = DraftGeomUtils.offsetWire(
-                                        basewireOffset=off
-                                        )
+                                w1 = DraftGeomUtils.offsetWire(wire, dvec,
+                                                               bind=False,
+                                                               occ=False,
+                                                               widthList=widths,
+                                                               offsetMode="BasewireMode",
+                                                               alignList=aligns,
+                                                               normal=normal,
+                                                               basewireOffset=off)
 
                                 sh = DraftGeomUtils.bind(w1,w2)
 
@@ -1328,24 +1322,24 @@ obj: <part::featurepython>
                                     w2 = DraftGeomUtils.offsetWire(wire,d1)
                                 else:
                                     dvec.multiply(width)
-                                    w2 = DraftGeomUtils.offsetWire(
-                                        wire, dvec,
-                                        bind=False,
-                                        occ=False,
-                                        widthList=widths,
-                                        offsetMode=None,
-                                        alignList=aligns,
-                                        normal=normal
-                                        )
-                                    w1 = DraftGeomUtils.offsetWire(
-                                        wire, dvec,
-                                        bind=False,
-                                        occ=False,
-                                        widthList=widths,
-                                        offsetMode="BasewireMode",
-                                        alignList=aligns,
-                                        normal=normal
-                                        )
+
+                                    w2 = DraftGeomUtils.offsetWire(wire, dvec,
+                                                                   bind=False,
+                                                                   occ=False,
+                                                                   widthList=widths,
+                                                                   offsetMode=None,
+                                                                   alignList=aligns,
+                                                                   normal=normal)
+
+                                    w1 = DraftGeomUtils.offsetWire(wire, dvec,
+                                                                   bind=False,
+                                                                   occ=False,
+                                                                   widthList=widths,
+                                                                   offsetMode="BasewireMode",
+                                                                   alignList=aligns,
+                                                                   normal=normal)
+                                        
+
                                 sh = DraftGeomUtils.bind(w1,w2)
 
                             del widths[0:edgeNum]

--- a/src/Mod/Arch/ArchWall.py
+++ b/src/Mod/Arch/ArchWall.py
@@ -366,7 +366,7 @@ class _CommandWall:
         elif len(self.points) == 2:
             import Part
             l = Part.LineSegment(FreeCAD.DraftWorkingPlane.getLocalCoords(self.points[0]),
-                                 FreeCAD.DraftWorkingPlane.getLocalCoords(self.points[1])
+                                 FreeCAD.DraftWorkingPlane.getLocalCoords(self.points[1]))
             self.tracker.finalize()
             FreeCAD.ActiveDocument.openTransaction(translate("Arch","Create Wall"))
             FreeCADGui.addModule("Arch")

--- a/src/Mod/Arch/ArchWall.py
+++ b/src/Mod/Arch/ArchWall.py
@@ -19,6 +19,16 @@
 #*                                                                         *
 #***************************************************************************
 
+"""This module provides tools to build Wall objects.  Walls are simple
+objects, usually vertical, typically obtained by giving a thickness to a base
+line, then extruding it vertically.
+
+Examples
+--------
+TODO put examples here.
+
+"""
+
 import FreeCAD,Draft,ArchComponent,DraftVecUtils,ArchCommands,math
 from FreeCAD import Vector
 if FreeCAD.GuiUp:
@@ -46,16 +56,6 @@ else:
 __title__="FreeCAD Wall"
 __author__ = "Yorik van Havre"
 __url__ = "http://www.freecadweb.org"
-
-__doc__="""This module provides tools to build Wall objects.  Walls are simple
-        objects, usually vertical, typically obtained by giving a thickness to a base
-        line, then extruding it vertically.
-
-        Examples
-        --------
-        TODO put examples here.
-
-        """
 
 def makeWall(baseobj=None,height=None,length=None,width=None,align="Center",face=None,name="Wall"):
     """Creates a wall based on a given object, and returns the generated wall.

--- a/src/Mod/Arch/ArchWall.py
+++ b/src/Mod/Arch/ArchWall.py
@@ -248,7 +248,9 @@ def areSameWallTypes(walls):
 
 
 class _CommandWall:
-    """The command definition for the Arch workbench's gui tool, Arch Wall. A tool for creating Arch walls.
+    """The command definition for the Arch workbench's gui tool, Arch Wall.
+
+    A tool for creating Arch walls.
 
     Creates a wall from the object selected by the user. If no objects are
     selected, enters an interactive mode to create a wall using selected points

--- a/src/Mod/Arch/ArchWall.py
+++ b/src/Mod/Arch/ArchWall.py
@@ -689,12 +689,6 @@ class _Wall(ArchComponent.Component):
     """
 
     def __init__(self, obj):
-        """Initialises the object's properties.
-
-        Sets the object to have the properties of an Arch component, and Arch
-        wall.
-        """
-
         ArchComponent.Component.__init__(self, obj)
         self.setProperties(obj)
         obj.IfcType = "Wall"
@@ -1503,20 +1497,15 @@ class _Wall(ArchComponent.Component):
         return None
 
 class _ViewProviderWall(ArchComponent.ViewProviderComponent):
-    """The view provider for the wall object."""
+    """The view provider for the wall object.
+
+    Parameters
+    ----------
+    vobj: <Gui.ViewProviderDocumentObject>
+        The view provider to turn into a wall view provider.
+    """
 
     def __init__(self,vobj):
-        """Initialises the wall view provider.
-
-        Runs the Arch Component view provider initialisation, and sets the color
-        to the default for walls.
-
-        Parameters
-        ----------
-        vobj: <Gui.ViewProviderDocumentObject>
-            The view provider to turn into a wall view provider.
-        """
-
         ArchComponent.ViewProviderComponent.__init__(self,vobj)
         vobj.ShapeColor = ArchCommands.getDefaultColor("Wall")
 

--- a/src/Mod/Arch/ArchWall.py
+++ b/src/Mod/Arch/ArchWall.py
@@ -1508,7 +1508,7 @@ class _ViewProviderWall(ArchComponent.ViewProviderComponent):
     def __init__(self,vobj):
         """Initialises the wall view provider.
 
-        Runs the Arch Component view provider initalisation, and sets the color
+        Runs the Arch Component view provider initialisation, and sets the color
         to the default for walls.
 
         Parameters

--- a/src/Mod/Arch/ArchWall.py
+++ b/src/Mod/Arch/ArchWall.py
@@ -77,7 +77,7 @@ def makeWall(baseobj=None,height=None,length=None,width=None,align="Center",face
         Arch default if left empty.
     align: str, optional
         Either "Center", "Left", or "Right". Effects the alignment of the wall
-        on it's baseline.
+        on its baseline.
     face: int, optional
         The index number of a face on the given baseobj, to base the wall on.
     name: str, optional
@@ -700,7 +700,7 @@ class _Wall(ArchComponent.Component):
         obj.IfcType = "Wall"
 
     def setProperties(self, obj):
-        """Gives the wall it's wall specific properties, such as it's alignment.
+        """Gives the wall its wall specific properties, such as its alignment.
 
         You can learn more about properties here:
         https://wiki.freecadweb.org/property
@@ -1201,7 +1201,7 @@ class _Wall(ArchComponent.Component):
                     # If the user has defined a specific face of the Base
                     # object to build the wall from, extrude from that face,
                     # and return the extrusion moved to (0,0,0), normal of the
-                    # face, and placement to move the extrusion back to it's
+                    # face, and placement to move the extrusion back to its
                     # original position.
                     elif obj.Face > 0:
                         if len(obj.Base.Shape.Faces) >= obj.Face:

--- a/src/Mod/Arch/ArchWall.py
+++ b/src/Mod/Arch/ArchWall.py
@@ -1004,7 +1004,7 @@ class _Wall(ArchComponent.Component):
 
         if prop == "Length":
             if (obj.Base and obj.Length.Value 
-                    and hasattr(self,"oldLength") and (self.oldLength != None) 
+                    and hasattr(self,"oldLength") and (self.oldLength is not None) 
                     and (self.oldLength != obj.Length.Value)):
 
                 if hasattr(obj.Base,'Shape'):

--- a/src/Mod/Arch/ArchWall.py
+++ b/src/Mod/Arch/ArchWall.py
@@ -667,8 +667,10 @@ class _CommandMergeWalls:
         FreeCAD.ActiveDocument.commitTransaction()
 
 class _Wall(ArchComponent.Component):
-    """The Wall object. Takes a <App::FeaturePython> and turns it into a wall,
-    then uses a <Part::Feature> to create the wall's shape.
+    """The Wall object. 
+
+    Turns a <App::FeaturePython> into a wall object, then uses a <Part::Feature> to
+    create the wall's shape.
 
     Walls are simple objects, usually vertical, typically obtained by giving a
     thickness to a base line, then extruding it vertically.

--- a/src/Mod/Arch/ArchWall.py
+++ b/src/Mod/Arch/ArchWall.py
@@ -259,7 +259,7 @@ https://wiki.freecadweb.org/Arch_Wall
 """
 
     def GetResources(self):
-        """Returns a dictonary with the visual aspects of the Arch Wall tool."""
+        """Returns a dictionary with the visual aspects of the Arch Wall tool."""
 
         return {'Pixmap'  : 'Arch_Wall',
                 'MenuText': QT_TRANSLATE_NOOP("Arch_Wall","Wall"),
@@ -406,7 +406,7 @@ obj: <Part::PartFeature>, optional
                 self.Activated()
 
     def addDefault(self):
-        """Creates a wall using a line segment, with all paramters as the default.
+        """Creates a wall using a line segment, with all parameters as the default.
 
 Used solely by _CommandWall.getPoint() when the interactive mode has selected
 two points.
@@ -432,7 +432,7 @@ Part.LineSegment assigned as the variable "trace"
     def update(self,point):
         """Callback for the mouse moving during the interactive mode.
 
-Updates the active dialog box to show the co-ordinates of the location of the
+Updates the active dialog box to show the coordinates of the location of the
 cursor. It also shows the length the line would take, if the user selected that
 point.
 
@@ -617,7 +617,7 @@ https://wiki.freecadweb.org/Arch_MergeWalls
 """
 
     def GetResources(self):
-        """Returns a dictonary with the visual aspects of the Arch MergeWalls tool."""
+        """Returns a dictionary with the visual aspects of the Arch MergeWalls tool."""
 
         return {'Pixmap'  : 'Arch_MergeWalls',
                 'MenuText': QT_TRANSLATE_NOOP("Arch_MergeWalls","Merge Walls"),

--- a/src/Mod/Arch/ArchWall.py
+++ b/src/Mod/Arch/ArchWall.py
@@ -39,24 +39,28 @@ else:
 #  \ingroup ARCH
 #  \brief The Wall object and tools
 #
-#  This module provides tools to build Wall objects.
-#  Walls are simple objects, usually vertical, obtained
-#  by giving a thickness to a base line, then extruding it
-#  vertically.
+#  This module provides tools to build Wall objects.  Walls are simple objects,
+#  usually vertical, typically obtained by giving a thickness to a base line,
+#  then extruding it vertically.
 
 __title__="FreeCAD Wall"
 __author__ = "Yorik van Havre"
 __url__ = "http://www.freecadweb.org"
 
+__doc__="""This module provides tools to build Wall objects.  Walls are simple
+objects, usually vertical, typically obtained by giving a thickness to a base
+line, then extruding it vertically.
 
+Examples
+--------
+TODO put examples here.
+
+"""
 
 def makeWall(baseobj=None,height=None,length=None,width=None,align="Center",face=None,name="Wall"):
     '''Creates a wall based on a given object, and returns the generated wall.
 
-Notes
------
-TODO: It is unclear what defines which units this function uses, or what
-defines which units this function uses.
+TODO: It is unclear what defines which units this function uses.
 
 Parameters
 ----------
@@ -81,8 +85,18 @@ name: str, optional
 
 Returns
 -------
-<class 'ArchComponent.Component'>
+<Part::FeaturePython>
     Returns the generated wall.
+
+Notes
+-----
+Creates a new <Part::FeaturePython> object, and turns it into a parametric wall
+object. This <Part::FeaturePython> object does not yet have any shape.
+
+The wall then uses the baseobj.Shape as the basis to extrude out a wall shape,
+giving the new <Part::FeaturePython> object a shape.
+
+It then hides the original baseobj.
 '''
 
     if not FreeCAD.ActiveDocument:
@@ -128,7 +142,7 @@ the walls have the same width, height and alignment.
 
 Parameters
 ----------
-walls: list of <class 'ArchComponent.Component'>
+walls: list of <Part::FeaturePython>
     List containing the walls to add to the first wall in the list. Walls must
     be based off a base object.
 delete: bool, optional
@@ -136,7 +150,7 @@ delete: bool, optional
 
 Returns
 -------
-<class 'ArchComponent.Component'>
+<Part::FeaturePython>
 """
 
     import Part
@@ -237,7 +251,8 @@ class _CommandWall:
     """The command definition for the Arch workbench's gui tool, Arch Wall. A tool for creating Arch walls.
 
 Creates a wall from the object selected by the user. If no objects are
-selected, enters interactive mode to create a wall using selected points.
+selected, enters an interactive mode to create a wall using selected points
+to create a base.
 
 Find documentation on the end user usage of Arch Wall here:
 https://wiki.freecadweb.org/Arch_Wall
@@ -263,7 +278,7 @@ https://wiki.freecadweb.org/Arch_Wall
         """Executed when Arch Wall is called.
 
 Creates a wall from the object selected by the user. If no objects are
-selected, enters interactive mode to create a wall using selected points
+selected, enters an interactive mode to create a wall using selected points
 to create a base.
 """
 
@@ -321,7 +336,7 @@ to create a base.
     def getPoint(self,point=None,obj=None):
         """Callback for clicks during interactive mode.
 
-When method _CommandWall.Activated() has entered the interactive mode this
+When method _CommandWall.Activated() has entered the interactive mode, this
 callback runs when the user clicks.
 
 Parameters
@@ -444,8 +459,7 @@ point: <class 'Base.Vector'>
                 self.Length.setText(FreeCAD.Units.Quantity(bv.Length,FreeCAD.Units.Length).UserString)
 
     def taskbox(self):
-
-        "sets up a taskbox widget"
+        """Sets up a simple gui widget for the interactive mode."""
 
         w = QtGui.QWidget()
         ui = FreeCADGui.UiLoader()
@@ -529,6 +543,7 @@ point: <class 'Base.Vector'>
         return w
 
     def setMat(self,d):
+        """Simple callback for the interactive mode gui widget to set material."""
 
         if d == 0:
             self.MultiMat = None
@@ -538,10 +553,12 @@ point: <class 'Base.Vector'>
             FreeCAD.LastArchMultiMaterial = self.MultiMat.Name
 
     def setLength(self,d):
+        """Simple callback for the interactive mode gui widget to set length."""
 
         self.lengthValue = d
 
     def setWidth(self,d):
+        """Simple callback for the interactive mode gui widget to set width."""
 
         self.Width = d
         self.tracker.width(d)
@@ -549,27 +566,35 @@ point: <class 'Base.Vector'>
 
 
     def setHeight(self,d):
+        """Simple callback for the interactive mode gui widget to set height."""
 
         self.Height = d
         self.tracker.height(d)
         FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/Arch").SetFloat("WallHeight",d)
 
     def setAlign(self,i):
+        """Simple callback for the interactive mode gui widget to set alignment."""
 
         self.Align = ["Center","Left","Right"][i]
         FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/Arch").SetInt("WallAlignment",i)
 
     def setContinue(self,i):
+        """Simple callback to set if the interactive mode will restart when finished. 
+
+This allows for several walls to be placed one after another.
+"""
 
         self.continueCmd = bool(i)
         if hasattr(FreeCADGui,"draftToolBar"):
             FreeCADGui.draftToolBar.continueMode = bool(i)
 
     def setUseSketch(self,i):
+        """Simple callback to set if walls should join their base sketches when possible."""
 
-        FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/Arch").SetBool("WallSketches",bool(i))
+        FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/Arch").SetBool("joinWallSketches",bool(i))
 
     def createFromGUI(self):
+        """Callback to create wall by using the _CommandWall.taskbox()"""
 
         FreeCAD.ActiveDocument.openTransaction(translate("Arch","Create Wall"))
         FreeCADGui.addModule("Arch")
@@ -582,23 +607,38 @@ point: <class 'Base.Vector'>
             FreeCADGui.draftToolBar.escape()
 
 
-
 class _CommandMergeWalls:
+    """The command definition for the Arch workbench's gui tool, Arch MergeWalls. A tool for merging walls.
 
-    "the Arch Merge Walls command definition"
+Joins two or more walls by using the ArchWall.joinWalls() function.
+
+Find documentation on the end user usage of Arch Wall here:
+https://wiki.freecadweb.org/Arch_MergeWalls
+"""
 
     def GetResources(self):
+        """Returns a dictonary with the visual aspects of the Arch MergeWalls tool."""
 
         return {'Pixmap'  : 'Arch_MergeWalls',
                 'MenuText': QT_TRANSLATE_NOOP("Arch_MergeWalls","Merge Walls"),
                 'ToolTip': QT_TRANSLATE_NOOP("Arch_MergeWalls","Merges the selected walls, if possible")}
 
     def IsActive(self):
+        """Determines whether or not the Arch MergeWalls tool is active. 
+
+        Inactive commands are indicated by a greyed-out icon in the menus and toolbars.
+        """
 
         return bool(FreeCADGui.Selection.getSelection())
 
     def Activated(self):
+        """Executed when Arch MergeWalls is called.
 
+Calls ArchWall.joinWalls() on walls selected by the user, with the delete
+option enabled. If the user has selected a single wall, check to see if the
+wall has any Additions that are walls. If so, merges these additions to the
+wall, deleting the additions.
+"""
         walls = FreeCADGui.Selection.getSelection()
         if len(walls) == 1:
             if Draft.getType(walls[0]) == "Wall":
@@ -629,19 +669,39 @@ class _CommandMergeWalls:
         FreeCADGui.doCommand("Arch.joinWalls(FreeCADGui.Selection.getSelection(),delete=True)")
         FreeCAD.ActiveDocument.commitTransaction()
 
-
-
 class _Wall(ArchComponent.Component):
+    """The Wall object. Takes a <App::FeaturePython> and turns it into a wall.
 
-    "The Wall object"
+Walls are simple objects, usually vertical, typically obtained by giving a
+thickness to a base line, then extruding it vertically.
+
+Parameters
+----------
+obj: <App::FeaturePython>
+    The object to turn into a wall. Note that this is not the object that forms
+    the basis for the new wall's shape. That is given later.
+"""
 
     def __init__(self, obj):
+        """Initialises the object's properties.
+
+Sets the object to have the properties of an Arch component, and Arch wall.
+"""
 
         ArchComponent.Component.__init__(self, obj)
         self.setProperties(obj)
         obj.IfcType = "Wall"
 
     def setProperties(self, obj):
+        """Gives the wall it's wall specific properties, such as it's alignment.
+
+You can learn more about properties here: https://wiki.freecadweb.org/property
+
+parameters
+----------
+obj: <part::featurepython>
+    The object to turn into a wall.
+"""
 
         lp = obj.PropertiesList
         if not "Length" in lp:
@@ -698,6 +758,7 @@ class _Wall(ArchComponent.Component):
         self.Type = "Wall"
 
     def onDocumentRestored(self,obj):
+        """Method run when the document is restored. Re-adds the Arch component, and Arch wall properties."""
 
         ArchComponent.Component.onDocumentRestored(self,obj)
         self.setProperties(obj)
@@ -938,6 +999,9 @@ class _Wall(ArchComponent.Component):
 
         """returns (shape,extrusion vector,placement) or None"""
         import Part,DraftGeomUtils
+
+        # If ArchComponent.Component.getExtrusionData() can successfully get
+        # extrusion data, just use that.
         data = ArchComponent.Component.getExtrusionData(self,obj)
         if data:
             if not isinstance(data[0],list):
@@ -948,17 +1012,19 @@ class _Wall(ArchComponent.Component):
         # TODO currently layers were not supported when len(basewires) > 0	##( or 1 ? )
         width = 0
 
-        # Get width of each edge segment from Base Objects if they store it (Adding support in SketchFeaturePython, DWire...)
+        # Get width of each edge segment from Base Objects if they store it
+        # (Adding support in SketchFeaturePython, DWire...)
         widths = []  # [] or None are both False
         if obj.Base:
             if hasattr(obj.Base, 'Proxy'):
                 if hasattr(obj.Base.Proxy, 'getWidths'):
-                    widths = obj.Base.Proxy.getWidths(obj.Base)  # return a list of Width corresponds to indexes of sorted edges of Sketch
+                    # Return a list of Width corresponding to indexes of sorted
+                    # edges of Sketch.
+                    widths = obj.Base.Proxy.getWidths(obj.Base)  
 
-        # Get width of each edge/wall segment from ArchWall.OverrideWidth if Base Object does not provide it
-
+        # Get width of each edge/wall segment from ArchWall.OverrideWidth if
+        # Base Object does not provide it
         if not widths:
-
             if obj.OverrideWidth:
                 if obj.Base.isDerivedFrom("Sketcher::SketchObject"):
                     # If Base Object is ordinary Sketch (or when ArchSketch.getWidth() not implemented yet):-
@@ -972,7 +1038,9 @@ class _Wall(ArchComponent.Component):
                     except:
                         widths = obj.OverrideWidth
                 else:
-                    # If Base Object is not Sketch, but e.g. DWire, the width list in OverrrideWidth just correspond to sequential order of edges
+                    # If Base Object is not Sketch, but e.g. DWire, the width
+                    # list in OverrrideWidth just correspond to sequential
+                    # order of edges
                     widths = obj.OverrideWidth
             elif obj.Width:
                 widths = [obj.Width.Value]
@@ -980,25 +1048,30 @@ class _Wall(ArchComponent.Component):
                 print ("Width & OverrideWidth & base.getWidths() should not be all 0 or None or [] empty list ")
                 return None
 
-        # set 'default' width - for filling in any item in the list == 0 or None
+        # Set 'default' width - for filling in any item in the list == 0 or None
         if obj.Width.Value:
             width = obj.Width.Value
         else:
             width = 200  # 'Default' width value
 
-        # Get align of each edge segment from Base Objects if they store it (Adding support in SketchFeaturePython, DWire...)
+        # Get align of each edge segment from Base Objects if they store it.
+        # (Adding support in SketchFeaturePython, DWire...)
         aligns = []
         if obj.Base:
             if hasattr(obj.Base, 'Proxy'):
                 if hasattr(obj.Base.Proxy, 'getAligns'):
-                    aligns = obj.Base.Proxy.getAligns(obj.Base)  # return a list of Align corresponds to indexes of sorted edges of Sketch
-
-        # Get align of each edge/wall segment from ArchWall.OverrideAlign if Base Object does not provide it
+                    # Return a list of Align corresponds to indexes of sorted
+                    # edges of Sketch.
+                    aligns = obj.Base.Proxy.getAligns(obj.Base)  
+        # Get align of each edge/wall segment from ArchWall.OverrideAlign if
+        # Base Object does not provide it
         if not aligns:
             if obj.OverrideAlign:
                 if obj.Base.isDerivedFrom("Sketcher::SketchObject"):
-                    # If Base Object is ordinary Sketch (or when ArchSketch.getAligns() not implemented yet):-
-                    # sort the align list in OverrideAlign to correspond to indexes of sorted edges of Sketch
+                    # If Base Object is ordinary Sketch (or when
+                    # ArchSketch.getAligns() not implemented yet):- sort the
+                    # align list in OverrideAlign to correspond to indexes of
+                    # sorted edges of Sketch
                     try:
                         import ArchSketchObject
                     except:
@@ -1008,7 +1081,9 @@ class _Wall(ArchComponent.Component):
                     except:
                         aligns = obj.OverrideAlign
                 else:
-                    # If Base Object is not Sketch, but e.g. DWire, the align list in OverrideAlign just correspond to sequential order of edges
+                    # If Base Object is not Sketch, but e.g. DWire, the align
+                    # list in OverrideAlign just correspond to sequential order
+                    # of edges
                     aligns = obj.OverrideAlign
             else:
                 aligns = [obj.Align]
@@ -1078,7 +1153,9 @@ class _Wall(ArchComponent.Component):
                     elif len(obj.Base.Shape.Edges) == 1:
                         self.basewires = [Part.Wire(obj.Base.Shape.Edges)]
 
-                    # Sort Sketch edges consistently with below procedures without using Sketch.Shape.Edges - found the latter order in some corner case != getSortedClusters()
+                    # Sort Sketch edges consistently with below procedures
+                    # without using Sketch.Shape.Edges - found the latter order
+                    # in some corner case != getSortedClusters()
                     elif obj.Base.isDerivedFrom("Sketcher::SketchObject"):
                         self.basewires = []
                         skGeom = obj.Base.Geometry
@@ -1093,9 +1170,14 @@ class _Wall(ArchComponent.Component):
                             for edge in cluster:
                                 edge.Placement = edge.Placement.multiply(skPlacement)  ## TODO add attribute to skip Transform...
                                 clusterTransformed.append(edge)
-                            self.basewires.append(clusterTransformed)  # Only use cluster of edges rather than turning into wire
-                        # Use Sketch's Normal for all edges/wires generated from sketch for consistency
-                        # Discussion on checking normal of sketch.Placement vs sketch.getGlobalPlacement() - https://forum.freecadweb.org/viewtopic.php?f=22&t=39341&p=334275#p334275
+                            # Only use cluster of edges rather than turning into wire
+                            self.basewires.append(clusterTransformed)
+
+                        # Use Sketch's Normal for all edges/wires generated
+                        # from sketch for consistency Discussion on checking
+                        # normal of sketch.Placement vs
+                        # sketch.getGlobalPlacement() -
+                        # https://forum.freecadweb.org/viewtopic.php?f=22&t=39341&p=334275#p334275
                         # normal = obj.Base.Placement.Rotation.multVec(FreeCAD.Vector(0,0,1))
                         normal = obj.Base.getGlobalPlacement().Rotation.multVec(FreeCAD.Vector(0,0,1))
 
@@ -1105,8 +1187,11 @@ class _Wall(ArchComponent.Component):
                         for cluster in Part.getSortedClusters(obj.Base.Shape.Edges):
                             for c in Part.sortEdges(cluster):
                                 self.basewires.append(Part.Wire(c))
-                        # if not sketch, e.g. Dwire, can have wire which is 3d so not on the placement's working plane - below applied to Sketch not applicable here
-                        #normal = obj.Base.getGlobalPlacement().Rotation.multVec(FreeCAD.Vector(0,0,1))  #normal = obj.Base.Placement.Rotation.multVec(FreeCAD.Vector(0,0,1))
+                        # if not sketch, e.g. Dwire, can have wire which is 3d
+                        # so not on the placement's working plane - below
+                        # applied to Sketch not applicable here
+                        #normal = obj.Base.getGlobalPlacement().Rotation.multVec(FreeCAD.Vector(0,0,1))  
+                        #normal = obj.Base.Placement.Rotation.multVec(FreeCAD.Vector(0,0,1))
 
                     if self.basewires: # and width: # width already tested earlier...
                         if (len(self.basewires) == 1) and layers:
@@ -1125,14 +1210,18 @@ class _Wall(ArchComponent.Component):
 
                             for n in range(0,edgeNum,1):  # why these not work - range(edgeNum), range(0,edgeNum) ...
 
-                                # Fill the aligns list with ArchWall's default align entry and with same number of items as number of edges
+                                # Fill the aligns list with ArchWall's default
+                                # align entry and with same number of items as
+                                # number of edges
                                 try:
                                     if aligns[n] not in ['Left', 'Right', 'Center']:
                                         aligns[n] = align
                                 except:
                                     aligns.append(align)
 
-                                # Fill the widths List with ArchWall's default width entry and with same number of items as number of edges
+                                # Fill the widths List with ArchWall's default
+                                # width entry and with same number of items as
+                                # number of edges
                                 try:
                                     if not widths[n]:
                                         widths[n] = width
@@ -1165,11 +1254,32 @@ class _Wall(ArchComponent.Component):
                                 #    dvec2 = DraftVecUtils.scaleTo(dvec,off)
                                 #    wire = DraftGeomUtils.offsetWire(wire,dvec2)
 
-                                # Get the 'offseted' wire taking into account of Width and Align of each edge, and overall Offset
-                                w2 = DraftGeomUtils.offsetWire(wire,dvec,False,False,widths,None,aligns,normal,off)
+                                # Get the 'offseted' wire taking into account
+                                # of Width and Align of each edge, and overall
+                                # Offset
+                                w2 = DraftGeomUtils.offsetWire(
+                                        wire,dvec,
+                                        bind=False,
+                                        occ=False,
+                                        widthList=widths,
+                                        offsetMode=None,
+                                        alignList=aligns,
+                                        normal=normal,
+                                        basewireOffset=off
+                                        )
 
-                                # Get the 'base' wire taking into account of width and align of each edge
-                                w1 = DraftGeomUtils.offsetWire(wire,dvec,False,False,widths,"BasewireMode",aligns,normal,off)
+                                # Get the 'base' wire taking into account of
+                                # width and align of each edge
+                                w1 = DraftGeomUtils.offsetWire(
+                                        wire, dvec,
+                                        bind=False,
+                                        occ=False,
+                                        widthList=widths,
+                                        offsetMode="BasewireMode",
+                                        alignList=aligns,
+                                        normal=normal,
+                                        basewireOffset=off
+                                        )
                                 sh = DraftGeomUtils.bind(w1,w2)
 
                             elif curAligns == "Right":
@@ -1188,9 +1298,23 @@ class _Wall(ArchComponent.Component):
                                 #    dvec2 = DraftVecUtils.scaleTo(dvec,off)
                                 #    wire = DraftGeomUtils.offsetWire(wire,dvec2)
 
-                                w2 = DraftGeomUtils.offsetWire(wire,dvec,False,False,widths,None,aligns,normal,off)
-                                w1 = DraftGeomUtils.offsetWire(wire,dvec,False,False,widths,"BasewireMode",aligns,normal,off)
+                                w2 = DraftGeomUtils.offsetWire(
+                                        wire, dvec,
+                                        bind=False,
+                                        occ=False,
+                                        widthList=widths,
+                                        offsetMode=None,
+                                        alignList=aligns,
+                                        normal=normal,
+                                        basewireOffset=off
+                                        )
+
+                                w1 = DraftGeomUtils.offsetWire(
+                                        basewireOffset=off
+                                        )
+
                                 sh = DraftGeomUtils.bind(w1,w2)
+
 
                             #elif obj.Align == "Center":
                             elif curAligns == "Center":
@@ -1204,8 +1328,24 @@ class _Wall(ArchComponent.Component):
                                     w2 = DraftGeomUtils.offsetWire(wire,d1)
                                 else:
                                     dvec.multiply(width)
-                                    w2 = DraftGeomUtils.offsetWire(wire,dvec,False,False,widths,None,aligns,normal)
-                                    w1 = DraftGeomUtils.offsetWire(wire,dvec,False,False,widths,"BasewireMode",aligns,normal)
+                                    w2 = DraftGeomUtils.offsetWire(wire,
+                                        wire, dvec,
+                                        bind=False,
+                                        occ=False,
+                                        widthList=widths,
+                                        offsetMode=None,
+                                        alignList=aligns,
+                                        normal=normal
+                                        )
+                                    w1 = DraftGeomUtils.offsetWire(wire,
+                                        wire, dvec,
+                                        bind=False,
+                                        occ=False,
+                                        widthList=widths,
+                                        offsetMode="BasewireMode",
+                                        alignList=aligns,
+                                        normal=normal
+                                        )
                                 sh = DraftGeomUtils.bind(w1,w2)
 
                             del widths[0:edgeNum]
@@ -1217,8 +1357,13 @@ class _Wall(ArchComponent.Component):
                                 f = Part.Face(sh)
                                 if baseface:
 
-                                    # To allow exportIFC.py to work properly on sketch, which use only 1st face / wire, do not fuse baseface here
-                                    # So for a sketch with multiple wires, each returns individual face (rather than fusing together) for exportIFC.py to work properly
+                                    # To allow exportIFC.py to work properly on
+                                    # sketch, which use only 1st face / wire,
+                                    # do not fuse baseface here So for a sketch
+                                    # with multiple wires, each returns
+                                    # individual face (rather than fusing
+                                    # together) for exportIFC.py to work
+                                    # properly
                                     # "ArchWall - Based on Sketch Issues" - https://forum.freecadweb.org/viewtopic.php?f=39&t=31235
 
                                     # "Bug #2408: [PartDesign] .fuse is splitting edges it should not"

--- a/src/Mod/Arch/ArchWall.py
+++ b/src/Mod/Arch/ArchWall.py
@@ -65,19 +65,19 @@ def makeWall(baseobj=None,height=None,length=None,width=None,align="Center",face
     Parameters
     ----------
     baseobj: <Part::PartFeature>, optional
-        The base object with which to build the wall. This can be a sketch, a draft
-        object, a face, or a solid. It can also be left as None.
+        The base object with which to build the wall. This can be a sketch, a
+        draft object, a face, or a solid. It can also be left as None.
     height: float, optional
         The height of the wall.
     length: float, optional
         The length of the wall. Not used if the wall is based off an object.
         Will use Arch default if left empty.
     width: float, optional
-        The width of the wall. Not used if the base object is a face.  Will
-        use Arch default if left empty.
+        The width of the wall. Not used if the base object is a face.  Will use
+        Arch default if left empty.
     align: str, optional
-        Either "Center", "Left", or "Right". Effects the alignment of the wall on
-        it's baseline.
+        Either "Center", "Left", or "Right". Effects the alignment of the wall
+        on it's baseline.
     face: int, optional
         The index number of a face on the given baseobj, to base the wall on.
     name: str, optional
@@ -137,8 +137,8 @@ def joinWalls(walls,delete=False):
     Takes the first wall in the list, and adds on the other walls in the list.
     Returns the modified first wall. 
 
-    Setting delete to True, will delete the other walls. Will only join walls if
-    the walls have the same width, height and alignment.
+    Setting delete to True, will delete the other walls. Will only join walls
+    if the walls have the same width, height and alignment.
 
     Parameters
     ----------
@@ -226,7 +226,8 @@ def areSameWallTypes(walls):
     Returns
     -------
     bool
-        True if the walls have the same height, width and alignment, False if otherwise.
+        True if the walls have the same height, width and alignment, False if
+        otherwise.
     """
 
     for att in ["Width","Height","Align"]:
@@ -271,7 +272,8 @@ class _CommandWall:
     def IsActive(self):
         """Determines whether or not the Arch Wall tool is active. 
 
-        Inactive commands are indicated by a greyed-out icon in the menus and toolbars.
+        Inactive commands are indicated by a greyed-out icon in the menus and
+        toolbars.
         """
 
         return not FreeCAD.ActiveDocument is None
@@ -280,8 +282,8 @@ class _CommandWall:
         """Executed when Arch Wall is called.
 
         Creates a wall from the object selected by the user. If no objects are
-        selected, enters an interactive mode to create a wall using selected points
-        to create a base.
+        selected, enters an interactive mode to create a wall using selected
+        points to create a base.
         """
 
         p = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/Arch")
@@ -336,8 +338,8 @@ class _CommandWall:
     def getPoint(self,point=None,obj=None):
         """Callback for clicks during interactive mode.
 
-        When method _CommandWall.Activated() has entered the interactive mode, this
-        callback runs when the user clicks.
+        When method _CommandWall.Activated() has entered the interactive mode,
+        this callback runs when the user clicks.
 
         Parameters
         ----------
@@ -402,13 +404,14 @@ class _CommandWall:
                 self.Activated()
 
     def addDefault(self):
-        """Creates a wall using a line segment, with all parameters as the default.
+        """Creates a wall using a line segment, with all parameters as the
+        default.
 
-        Used solely by _CommandWall.getPoint() when the interactive mode has selected
-        two points.
+        Used solely by _CommandWall.getPoint() when the interactive mode has
+        selected two points.
 
-        Relies on the assumption that FreeCADGui.doCommand() has already created a
-        Part.LineSegment assigned as the variable "trace"
+        Relies on the assumption that FreeCADGui.doCommand() has already
+        created a Part.LineSegment assigned as the variable "trace"
         """
 
         FreeCADGui.addModule("Draft")
@@ -428,9 +431,9 @@ class _CommandWall:
     def update(self,point):
         """Callback for the mouse moving during the interactive mode.
 
-        Updates the active dialog box to show the co-ordinates of the location of the
-        cursor. It also shows the length the line would take, if the user selected that
-        point.
+        Updates the active dialog box to show the coordinates of the location
+        of the cursor. It also shows the length the line would take, if the
+        user selected that point.
 
         Parameters
         ----------
@@ -604,7 +607,9 @@ class _CommandWall:
 
 
 class _CommandMergeWalls:
-    """The command definition for the Arch workbench's gui tool, Arch MergeWalls. A tool for merging walls.
+    """The command definition for the Arch workbench's gui tool, Arch MergeWalls. 
+
+    A tool for merging walls.
 
     Joins two or more walls by using the ArchWall.joinWalls() function.
 
@@ -622,7 +627,8 @@ class _CommandMergeWalls:
     def IsActive(self):
         """Determines whether or not the Arch MergeWalls tool is active. 
 
-        Inactive commands are indicated by a greyed-out icon in the menus and toolbars.
+        Inactive commands are indicated by a greyed-out icon in the menus and
+        toolbars.
         """
 
         return bool(FreeCADGui.Selection.getSelection())
@@ -630,10 +636,10 @@ class _CommandMergeWalls:
     def Activated(self):
         """Executed when Arch MergeWalls is called.
 
-        Calls ArchWall.joinWalls() on walls selected by the user, with the delete
-        option enabled. If the user has selected a single wall, check to see if the
-        wall has any Additions that are walls. If so, merges these additions to the
-        wall, deleting the additions.
+        Calls ArchWall.joinWalls() on walls selected by the user, with the
+        delete option enabled. If the user has selected a single wall, check to
+        see if the wall has any Additions that are walls. If so, merges these
+        additions to the wall, deleting the additions.
         """
 
         walls = FreeCADGui.Selection.getSelection()
@@ -669,8 +675,8 @@ class _CommandMergeWalls:
 class _Wall(ArchComponent.Component):
     """The Wall object. 
 
-    Turns a <App::FeaturePython> into a wall object, then uses a <Part::Feature> to
-    create the wall's shape.
+    Turns a <App::FeaturePython> into a wall object, then uses a
+    <Part::Feature> to create the wall's shape.
 
     Walls are simple objects, usually vertical, typically obtained by giving a
     thickness to a base line, then extruding it vertically.
@@ -685,7 +691,8 @@ class _Wall(ArchComponent.Component):
     def __init__(self, obj):
         """Initialises the object's properties.
 
-        Sets the object to have the properties of an Arch component, and Arch wall.
+        Sets the object to have the properties of an Arch component, and Arch
+        wall.
         """
 
         ArchComponent.Component.__init__(self, obj)
@@ -695,7 +702,8 @@ class _Wall(ArchComponent.Component):
     def setProperties(self, obj):
         """Gives the wall it's wall specific properties, such as it's alignment.
 
-        You can learn more about properties here: https://wiki.freecadweb.org/property
+        You can learn more about properties here:
+        https://wiki.freecadweb.org/property
 
         parameters
         ----------
@@ -1626,8 +1634,8 @@ class _ViewProviderWall(ArchComponent.ViewProviderComponent):
         Called when the display mode changes, this method can be used to set
         data that wasn't available when .attach() was called.
 
-        When Footprint is set as display mode, finds the faces that make up
-        the footprint of the wall, and gives them a lined texture. Then displays
+        When Footprint is set as display mode, finds the faces that make up the
+        footprint of the wall, and gives them a lined texture. Then displays
         the wall as a wireframe.
 
         Then passes the displaymode onto Arch Component's .setDisplayMode().


### PR DESCRIPTION
This branch adds several docstrings to the Arch module.

The docstrings are written in the [numpy docstrings style](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard).

Related forum thread: https://forum.freecadweb.org/viewtopic.php?f=23&t=44612&start=30

This is my first contribution, so please be cautious of errors I may have made. I am quite uncertain of the types specified in the docstrings, as they may be too specific, and could instead specify a type further up the inheritance chain. (Specifying a Part::Feature where an App::DocumentObject would be acceptable) I made the best choices I could, given my limited expertise.

Branch has been reabased to master, unit tests resulted in the following failures which do not appear to be related to this branch:

```
======================================================================
FAIL: testTaperedHole (PartDesignTests.TestHole.TestHole)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/mnt/build/Mod/PartDesign/PartDesignTests/TestHole.py", line 78, in testTaperedHole
    self.assertEqual(len(self.Hole.Shape.Faces), 8)
AssertionError: 7 != 8

======================================================================
FAIL: testApplyFiles (Document.DocumentFileIncludeCases)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/mnt/build/Mod/Test/Document.py", line 1312, in testApplyFiles
    self.failUnless(os.path.exists(L5.File))
AssertionError: False is not true
```
