### PR TITLE
Sketcher: Fix trim

### DIFF
--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -1939,6 +1939,17 @@ int SketchObject::trim(int GeoId, const Base::Vector3d& point)
             secondPos = constr->FirstPos;
         }
     };
+    
+    auto isPointAtPosition = [this] (int GeoId1, PointPos pos1, Base::Vector3d point) {
+       
+        Base::Vector3d pp = getPoint(GeoId1,pos1);
+
+        if( (point-pp).Length() < Precision::Confusion() )
+            return true;
+        
+        return false;
+        
+    };
 
     Part::Geometry *geo = geomlist[GeoId];
     if (geo->getTypeId() == Part::GeomLineSegment::getClassTypeId()) {
@@ -2128,6 +2139,26 @@ int SketchObject::trim(int GeoId, const Base::Vector3d& point)
 
             PointPos secondPos1 = Sketcher::none, secondPos2 = Sketcher::none;
             ConstraintType constrType1 = Sketcher::PointOnObject, constrType2 = Sketcher::PointOnObject;
+            
+            // check first if start and end points are within a confusion tolerance
+            if(isPointAtPosition(GeoId1, Sketcher::start, point1)) {
+                    constrType1 = Sketcher::Coincident;
+                    secondPos1 = Sketcher::start;
+            }
+            else if(isPointAtPosition(GeoId1, Sketcher::end, point1)) {
+                    constrType1 = Sketcher::Coincident;
+                    secondPos1 = Sketcher::end;
+            }
+            
+            if(isPointAtPosition(GeoId2, Sketcher::start, point2)) {
+                    constrType2 = Sketcher::Coincident;
+                    secondPos2 = Sketcher::start;
+            }
+            else if(isPointAtPosition(GeoId2, Sketcher::end, point2)) {
+                    constrType2 = Sketcher::Coincident;
+                    secondPos2 = Sketcher::end;
+            }            
+            
             for (std::vector<Constraint *>::const_iterator it=constraints.begin();
                  it != constraints.end(); ++it) {
                 Constraint *constr = *(it);
@@ -2162,6 +2193,7 @@ int SketchObject::trim(int GeoId, const Base::Vector3d& point)
             newConstr->SecondPos = Sketcher::none;
 
             // Add Second Constraint
+            newConstr->Type = constrType2;
             newConstr->First = GeoId;
             newConstr->FirstPos = end;
             newConstr->Second = GeoId2;


### PR DESCRIPTION
==================

https://forum.freecadweb.org/viewtopic.php?p=387303#p387303

1. Trim had a bug that the type of the constraint on the second point was equal to the first one regardless of the situation.

2. Trim did not have support for checking whether points were close to the edge and relied on preexisting constraints.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
