### PR TITLE
[FC] Status bar preselection coordinates are aware of user unit setting

### DIFF
--- a/src/Gui/Selection.cpp
+++ b/src/Gui/Selection.cpp
@@ -44,6 +44,7 @@
 #include <Base/Console.h>
 #include <Base/Tools.h>
 #include <Base/Interpreter.h>
+#include <Base/UnitsApi.h>
 #include <App/Application.h>
 #include <App/Document.h>
 #include <App/DocumentObject.h>
@@ -853,11 +854,45 @@ void SelectionSingleton::setPreselectCoord( float x, float y, float z)
     CurrentPreselection.x = x;
     CurrentPreselection.y = y;
     CurrentPreselection.z = z;
+    
+    Base::Quantity mmx(Base::Quantity::MilliMetre);
+    mmx.setValue((double)x);
+    Base::Quantity mmy(Base::Quantity::MilliMetre);
+    mmy.setValue((double)y);
+    Base::Quantity mmz(Base::Quantity::MilliMetre);
+    mmz.setValue((double)z);
+    
+    double xfactor, yfactor, zfactor, factor;
+    QString xunit, yunit, zunit, unit;
+    
+    QString xval = Base::UnitsApi::schemaTranslate(mmx, xfactor, xunit);
+    QString yval = Base::UnitsApi::schemaTranslate(mmy, yfactor, yunit);
+    QString zval = Base::UnitsApi::schemaTranslate(mmz, zfactor, zunit);
+    
+    if (xfactor <= yfactor && xfactor <= zfactor)
+    {
+        factor = xfactor;
+        unit = xunit;
+    }
+    else if (yfactor <= xfactor && yfactor <= zfactor)
+    {
+        factor = yfactor;
+        unit = yunit;
+    }
+    else
+    {
+        factor = zfactor;
+        unit = zunit;
+    }
+    
+    float xuser = x / factor;
+    float yuser = y / factor;
+    float zuser = z / factor;
 
-    snprintf(buf,512,"Preselected: %s.%s.%s (%f,%f,%f)",CurrentPreselection.pDocName
+    snprintf(buf,512,"Preselected: %s.%s.%s (%f,%f,%f) %s",CurrentPreselection.pDocName
                                                        ,CurrentPreselection.pObjectName
                                                        ,CurrentPreselection.pSubName
-                                                       ,x,y,z);
+                                                       ,xuser,yuser,zuser,unit.toLatin1().data());
 
     if (getMainWindow())
         getMainWindow()->showMessage(QString::fromLatin1(buf));

--- a/src/Gui/SoFCUnifiedSelection.cpp
+++ b/src/Gui/SoFCUnifiedSelection.cpp
@@ -79,6 +79,7 @@
 
 #include <Base/Console.h>
 #include <Base/Tools.h>
+#include <Base/UnitsApi.h>
 #include <App/Application.h>
 #include <App/Document.h>
 #include <Gui/Document.h>
@@ -479,14 +480,46 @@ bool SoFCUnifiedSelection::setHighlight(SoFullPath *path, const SoDetail *det,
     {
         const char *docname = vpd->getObject()->getDocument()->getName();
         const char *objname = vpd->getObject()->getNameInDocument();
-
+        
+        Base::Quantity mmx(Base::Quantity::MilliMetre);
+        mmx.setValue(fabs(x)>1e-7?(double)x:0.0);
+        Base::Quantity mmy(Base::Quantity::MilliMetre);
+        mmy.setValue(fabs(y)>1e-7?(double)y:0.0);
+        Base::Quantity mmz(Base::Quantity::MilliMetre);
+        mmz.setValue(fabs(z)>1e-7?(double)z:0.0);
+        
+        double xfactor, yfactor, zfactor, factor;
+        QString xunit, yunit, zunit, unit;
+        
+        QString xval = Base::UnitsApi::schemaTranslate(mmx, xfactor, xunit);
+        QString yval = Base::UnitsApi::schemaTranslate(mmy, yfactor, yunit);
+        QString zval = Base::UnitsApi::schemaTranslate(mmz, zfactor, zunit);
+        
+        if (xfactor <= yfactor && xfactor <= zfactor)
+        {
+            factor = xfactor;
+            unit = xunit;
+        }
+        else if (yfactor <= xfactor && yfactor <= zfactor)
+        {
+            factor = yfactor;
+            unit = yunit;
+        }
+        else
+        {
+            factor = zfactor;
+            unit = zunit;
+        }
+        
+        float xuser = fabs(x)>1e-7 ? x / factor : 0.0;
+        float yuser = fabs(y)>1e-7 ? y / factor : 0.0;
+        float zuser = fabs(z)>1e-7 ? z / factor : 0.0;
+    
         this->preSelection = 1;
         static char buf[513];
-        snprintf(buf,512,"Preselected: %s.%s.%s (%g, %g, %g)"
+        snprintf(buf,512,"Preselected: %s.%s.%s (%f, %f, %f) %s"
                 ,docname,objname,element
-                ,fabs(x)>1e-7?x:0.0
-                ,fabs(y)>1e-7?y:0.0
-                ,fabs(z)>1e-7?z:0.0);
+                ,xuser,yuser,zuser,unit.toLatin1().data());
 
         getMainWindow()->showMessage(QString::fromLatin1(buf));
 


### PR DESCRIPTION
Fixes #4148

- [X] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [X] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [X] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

https://forum.freecadweb.org/viewtopic.php?f=3&t=39654