### PR TITLE
[TD]fix potential KB lockout in dialogs

### DIFF
--- a/src/Mod/TechDraw/Gui/TaskDetail.cpp
+++ b/src/Mod/TechDraw/Gui/TaskDetail.cpp
@@ -116,13 +116,16 @@ TaskDetail::TaskDetail(TechDraw::DrawViewPart* baseFeat):
 
     connect(ui->pbDragger, SIGNAL(clicked(bool)),
             this, SLOT(onDraggerClicked(bool)));
-    connect(ui->qsbX, SIGNAL(valueChanged(double)),
+
+    //use editingFinished signal instead of valueChanged to prevent keyboard lock out
+    //valueChanged fires every keystroke causing a recompute.
+    connect(ui->qsbX, SIGNAL(editingFinished()),
             this, SLOT(onXEdit()));
-    connect(ui->qsbY, SIGNAL(valueChanged(double)),
+    connect(ui->qsbY, SIGNAL(editingFinished()),
             this, SLOT(onYEdit()));
-    connect(ui->qsbRadius, SIGNAL(valueChanged(double)),
+    connect(ui->qsbRadius, SIGNAL(editingFinished()),
             this, SLOT(onRadiusEdit()));
-    connect(ui->aeReference, SIGNAL(textChanged(QString)),
+    connect(ui->aeReference, SIGNAL(editingFinished()),
         this, SLOT(onReferenceEdit()));
 
     m_ghost = new QGIGhostHighlight();
@@ -186,14 +189,17 @@ TaskDetail::TaskDetail(TechDraw::DrawViewDetail* detailFeat):
 
     connect(ui->pbDragger, SIGNAL(clicked(bool)),
             this, SLOT(onDraggerClicked(bool)));
-    connect(ui->qsbX, SIGNAL(valueChanged(double)),
+
+    //use editingFinished signal instead of valueChanged to prevent keyboard lock out
+    //valueChanged fires every keystroke causing a recompute.
+    connect(ui->qsbX, SIGNAL(editingFinished()),
             this, SLOT(onXEdit()));
-    connect(ui->qsbY, SIGNAL(valueChanged(double)),
+    connect(ui->qsbY, SIGNAL(editingFinished()),
             this, SLOT(onYEdit()));
-    connect(ui->qsbRadius, SIGNAL(valueChanged(double)),
+    connect(ui->qsbRadius, SIGNAL(editingFinished()),
             this, SLOT(onRadiusEdit()));
-    connect(ui->aeReference, SIGNAL(textChanged(QString)),
-            this, SLOT(onReferenceEdit()));
+    connect(ui->aeReference, SIGNAL(editingFinished()),
+        this, SLOT(onReferenceEdit()));
 
     m_ghost = new QGIGhostHighlight();
     m_scene->addItem(m_ghost);

--- a/src/Mod/TechDraw/Gui/TaskSectionView.cpp
+++ b/src/Mod/TechDraw/Gui/TaskSectionView.cpp
@@ -176,12 +176,13 @@ void TaskSectionView::setUiPrimary()
     this->setToolTip(QObject::tr("Select at first an orientation"));
     enableAll(false);
 
-    // now connect and not earlier to avoid premature apply() calls
-    connect(ui->leSymbol, SIGNAL(textChanged(QString)), this, SLOT(onIdentifierChanged()));
-    connect(ui->sbScale, SIGNAL(valueChanged(double)), this, SLOT(onScaleChanged()));
-    connect(ui->sbOrgX, SIGNAL(valueChanged(double)), this, SLOT(onXChanged()));
-    connect(ui->sbOrgY, SIGNAL(valueChanged(double)), this, SLOT(onYChanged()));
-    connect(ui->sbOrgZ, SIGNAL(valueChanged(double)), this, SLOT(onZChanged()));
+    //use editingFinished signal instead of valueChanged to prevent keyboard lock out
+    //valueChanged fires every keystroke causing a recompute.
+    connect(ui->leSymbol, SIGNAL(editingFinished()), this, SLOT(onIdentifierChanged()));
+    connect(ui->sbScale, SIGNAL(editingFinished()), this, SLOT(onScaleChanged()));
+    connect(ui->sbOrgX, SIGNAL(editingFinished()), this, SLOT(onXChanged()));
+    connect(ui->sbOrgY, SIGNAL(editingFinished()), this, SLOT(onYChanged()));
+    connect(ui->sbOrgZ, SIGNAL(editingFinished()), this, SLOT(onZChanged()));
 }
 
 void TaskSectionView::setUiEdit()
@@ -206,12 +207,13 @@ void TaskSectionView::setUiEdit()
     ui->sbOrgZ->setUnit(Base::Unit::Length);
     ui->sbOrgZ->setValue(origin.z);
 
-    // connect affter initializing the object values
-    connect(ui->leSymbol, SIGNAL(textChanged(QString)), this, SLOT(onIdentifierChanged()));
-    connect(ui->sbScale, SIGNAL(valueChanged(double)), this, SLOT(onScaleChanged()));
-    connect(ui->sbOrgX, SIGNAL(valueChanged(double)), this, SLOT(onXChanged()));
-    connect(ui->sbOrgY, SIGNAL(valueChanged(double)), this, SLOT(onYChanged()));
-    connect(ui->sbOrgZ, SIGNAL(valueChanged(double)), this, SLOT(onZChanged()));
+    //use editingFinished signal instead of valueChanged to prevent keyboard lock out
+    //valueChanged fires every keystroke causing a recompute.
+    connect(ui->leSymbol, SIGNAL(editingFinished()), this, SLOT(onIdentifierChanged()));
+    connect(ui->sbScale, SIGNAL(editingFinished()), this, SLOT(onScaleChanged()));
+    connect(ui->sbOrgX, SIGNAL(editingFinished()), this, SLOT(onXChanged()));
+    connect(ui->sbOrgY, SIGNAL(editingFinished()), this, SLOT(onYChanged()));
+    connect(ui->sbOrgZ, SIGNAL(editingFinished()), this, SLOT(onZChanged()));
 }
 
 //save the start conditions


### PR DESCRIPTION
- valueChanged signal is emitted for every keystroke
  causing multiple recomputes for every change of
  parameter. If the recompute is lengthy, the kb appears
 to be locked.
- use editingFinished signal instead.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
