### PR TITLE
[Draft] Fixed scale multiplier for text object

### DIFF
--- a/src/Mod/Draft/draftviewproviders/view_text.py
+++ b/src/Mod/Draft/draftviewproviders/view_text.py
@@ -54,10 +54,6 @@ class ViewProviderText(ViewProviderDraftAnnotation):
 
     def set_properties(self, vobj):
 
-        vobj.addProperty("App::PropertyFloat","ScaleMultiplier",
-                         "Annotation",QT_TRANSLATE_NOOP("App::Property",
-                         "Dimension size overall multiplier"))
-
         vobj.addProperty("App::PropertyLength","FontSize",
                          "Text",QT_TRANSLATE_NOOP("App::Property",
                          "The size of the text"))


### PR DESCRIPTION
The annotation scale property was duplicated in text object.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
