### PR TITLE
[skip ci] fix documentation typos

### DIFF
--- a/src/Mod/Draft/draftguitools/gui_arcs.py
+++ b/src/Mod/Draft/draftguitools/gui_arcs.py
@@ -139,7 +139,7 @@ class Arc_3Points(gui_base.GuiCommandSimplest):
         Parameters
         ----------
         point: Base::Vector
-            The dynamic point pased by the callback
+            The dynamic point passed by the callback
             as we move the pointer in the 3D view.
 
         info: str

--- a/src/Mod/Draft/draftguitools/gui_groups.py
+++ b/src/Mod/Draft/draftguitools/gui_groups.py
@@ -51,7 +51,7 @@ class AddToGroup(gui_base.GuiCommandNeedsSelection):
 
     It adds selected objects to a group, or removes them from any group.
 
-    It inherits `GuiCommandNeedsSelection` to only be availbale
+    It inherits `GuiCommandNeedsSelection` to only be available
     when there is a document and a selection.
     See this class for more information.
     """
@@ -151,7 +151,7 @@ class SelectGroup(gui_base.GuiCommandNeedsSelection):
     in this case it works in an intuitive manner, selecting
     only the objects under the group.
 
-    It inherits `GuiCommandNeedsSelection` to only be availbale
+    It inherits `GuiCommandNeedsSelection` to only be available
     when there is a document and a selection.
     See this class for more information.
     """

--- a/src/Mod/Draft/draftguitools/gui_togglemodes.py
+++ b/src/Mod/Draft/draftguitools/gui_togglemodes.py
@@ -160,7 +160,7 @@ class ToggleDisplayMode(gui_base.GuiCommandNeedsSelection):
     Switches the display mode of selected objects from flatlines
     to wireframe and back.
 
-    It inherits `GuiCommandNeedsSelection` to only be availbale
+    It inherits `GuiCommandNeedsSelection` to only be available
     when there is a document and a selection.
     See this class for more information.
     """

--- a/src/Mod/Draft/draftobjects/label.py
+++ b/src/Mod/Draft/draftobjects/label.py
@@ -62,7 +62,7 @@ def make_label(targetpoint=None, target=None, direction=None,
             ["Horizontal","Vertical","Custom"]
 
     distance : Quantity
-            Lenght of the straight segment of label leader line 
+            Length of the straight segment of label leader line 
 
     labeltype : String
             Label type in

--- a/src/Mod/Mesh/App/MeshPy.xml
+++ b/src/Mod/Mesh/App/MeshPy.xml
@@ -469,7 +469,7 @@ an empty dictionary if there is no intersection.
 				<UserDocu>getPlanarSegments(dev,[min faces=0]) -> list
 Get all planes of the mesh as segment.
 In the worst case each triangle can be regarded as single
-plane if none of its neighours is coplanar.</UserDocu>
+plane if none of its neighbors are coplanar.</UserDocu>
 			</Documentation>
 		</Methode>
         <Methode Name="getSegmentsOfType" Const="true">

--- a/src/Mod/Part/App/AppPartPy.cpp
+++ b/src/Mod/Part/App/AppPartPy.cpp
@@ -750,7 +750,7 @@ private:
                     p1.Transform(loc.Transformation());
                     p2.Transform(loc.Transformation());
                     p3.Transform(loc.Transformation());
-                    // TODO: verify if tolerence should be hard coded
+                    // TODO: verify if tolerance should be hard coded
                     if (!p1.IsEqual(p2, 0.01) && !p2.IsEqual(p3, 0.01) && !p3.IsEqual(p1, 0.01)) {
                         PyObject *t1 = PyTuple_Pack(3, PyFloat_FromDouble(p1.X()), PyFloat_FromDouble(p1.Y()), PyFloat_FromDouble(p1.Z()));
                         PyObject *t2 = PyTuple_Pack(3, PyFloat_FromDouble(p2.X()), PyFloat_FromDouble(p2.Y()), PyFloat_FromDouble(p2.Z()));


### PR DESCRIPTION
Found via codespell v1.17.0.dev0  
```
codespell -q 3 -L aci,ake,aline,alle,alledges,alocation,als,ang,anid,ba,beginn,behaviour,bloaded,byteorder,calculater,cancelled,cancelling,cas,cascade,centimetre,childs,colour,colours,commen,connexion,currenty,dof,doubleclick,dum,eiter,elemente,ende,feld,finde,findf,freez,hist,iff,indicies,initialisation,initialise,initialised,initialises,initialisiert,ist,kilometre,lod,mantatory,methode,metres,millimetre,modell,nd,noe,normale,normaly,nto,numer,oder,orgin,orginx,orginy,ot,pard,pres,programm,que,recurrance,rougly,seperator,serie,sinc,strack,substraction,te,thist,thru,tread,uint,unter,vertexes,wallthickness,whitespaces -S ./.git,*.po,*.ts,./ChangeLog.txt,./src/3rdParty,./src/Mod/Assembly/App/opendcm,./src/CXX,./src/zipios++,./src/Base/swig*,./src/Mod/Robot/App/kdl_cp,./src/Mod/Import/App/SCL,./src/WindowsInstaller,./src/Doc/FreeCAD.uml
```