### PR TITLE
Path: movement of stock and model when setting origin

### DIFF
--- a/src/Mod/Path/Gui/Resources/panels/PathEdit.ui
+++ b/src/Mod/Path/Gui/Resources/panels/PathEdit.ui
@@ -719,7 +719,7 @@
             </widget>
            </item>
            <item row="2" column="0">
-            <widget class="QRadioButton" name="linkStockAndModel">
+            <widget class="QCheckBox" name="linkStockAndModel">
              <property name="text">
               <string>Link Stock and Model</string>
              </property>

--- a/src/Mod/Path/Gui/Resources/panels/PathEdit.ui
+++ b/src/Mod/Path/Gui/Resources/panels/PathEdit.ui
@@ -718,6 +718,13 @@
              </property>
             </widget>
            </item>
+           <item row="2" column="0">
+            <widget class="QRadioButton" name="linkStockAndModel">
+             <property name="text">
+              <string>Link Stock and Model</string>
+             </property>
+            </widget>
+           </item>
           </layout>
          </widget>
         </item>


### PR DESCRIPTION
Added radio button that links the movement of stock and model when using the set x, y, or z to 0 in Path workbench.

Forum discussion at: [Moving part in z-axis?](https://forum.freecadweb.org/viewtopic.php?f=15&t=44921)

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
