### PR TITLE
LGTM: Fix 'testing equality to None' 

### DIFF
--- a/src/Mod/Draft/DraftGeomUtils.py
+++ b/src/Mod/Draft/DraftGeomUtils.py
@@ -1428,7 +1428,7 @@ def offsetWire(wire, dvec, bind=False, occ=False,
                     delta = DraftVecUtils.scaleTo(delta, delta.Length/2)
 
         # Consider whether generating the 'offset wire' or the 'base wire'
-        if offsetMode == None:
+        if offsetMode is None:
             # Consider if curOrientation and/or curDir match their firstOrientation/firstDir - to determine whether and how to offset the current edge 
             if (curOrientation == firstOrientation) != (curDir == firstDir):	# i.e. xor
                 if curAlign in ['Left', 'Right']:

--- a/src/Mod/Draft/draftguitools/gui_edit.py
+++ b/src/Mod/Draft/draftguitools/gui_edit.py
@@ -160,7 +160,7 @@ class Edit:
     editing: Int
         Index of the editTracker that has been clicked by the
         user. Tracker selection mechanism is based on it.
-        if self.editing == None :
+        if self.editing is None :
             the user didn't click any node, and next click will
             be processed as an attempt to start editing operation
         if self.editing == o or 1 or 2 or 3 etc :


### PR DESCRIPTION
Testing whether an object is `None` using the `==` operator is inefficient and potentially incorrect.