### PR TITLE
[PATH] remove hard coded locale from path ui

### DIFF
--- a/src/Mod/Path/Gui/Resources/panels/PageOpPocketFullEdit.ui
+++ b/src/Mod/Path/Gui/Resources/panels/PageOpPocketFullEdit.ui
@@ -131,9 +131,6 @@
         <property name="toolTip">
          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Pattern the tool bit is moved in to clear the material.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
         </property>
-        <property name="locale">
-         <locale language="English" country="Germany"/>
-        </property>
         <property name="currentText">
          <string notr="true">ZigZag</string>
         </property>

--- a/src/Mod/Path/Gui/Resources/panels/PageOpProfileFullEdit.ui
+++ b/src/Mod/Path/Gui/Resources/panels/PageOpProfileFullEdit.ui
@@ -56,9 +56,6 @@
    </item>
    <item row="1" column="0">
     <widget class="QWidget" name="widget" native="true">
-     <property name="locale">
-      <locale language="English" country="Germany"/>
-     </property>
      <layout class="QGridLayout" name="gridLayout">
       <item row="0" column="0">
        <widget class="QLabel" name="cutSideLabel">


### PR DESCRIPTION
Pocket and Profile dialogs had hardcoded locale, causing conversion errors in numbers.