### PR TITLE
[skip-ci] Fix typos

### DIFF
--- a/src/Mod/Arch/ArchComponent.py
+++ b/src/Mod/Arch/ArchComponent.py
@@ -382,7 +382,7 @@ class Component(ArchIFC.IfcProduct):
         Recursively crawl hosts until a Floor or BuildingPart is found, then
         return the value of its Height property.
 
-        Paramters
+        Parameters
         ---------
         obj: <App::FeaturePython>
             The component object.
@@ -947,7 +947,7 @@ class Component(ArchIFC.IfcProduct):
         ground.
 
         The horizontal area is the area of the shape, when projected onto a
-        hyperplane across the XY axises, IE: the area when viewed from a bird's
+        hyperplane across the XY axes, IE: the area when viewed from a bird's
         eye view.
 
         The perimeter length is the length of the outside edges of this bird's
@@ -1538,7 +1538,7 @@ class ViewProviderComponent:
 
         Note that in this case, the hosts are the objects referenced by Arch
         Rebar's "Host" and/or "Hosts" properties specifically. Only Arch Rebar
-        has these properies.
+        has these properties.
 
         Returns
         -------
@@ -1796,7 +1796,7 @@ class ComponentTaskPanel:
     def getIcon(self,obj):
         """Get the path to the icons, of the items that fill the tree widget.
 
-        Paramters
+        Parameters
         ---------
         obj: <App::DocumentObject>
             The object being edited.

--- a/src/Mod/Arch/ArchFloor.py
+++ b/src/Mod/Arch/ArchFloor.py
@@ -24,7 +24,7 @@
 """This module provides tools to build Floor objects. Floors are used to group
 different Arch objects situated at a same level.
 
-The _Floor object and this module as a whole is now obselete. It has been
+The _Floor object and this module as a whole is now obsolete. It has been
 superseded by the use of the BuildingPart class, set to the "Building Storey"
 IfcType.
 """
@@ -56,7 +56,7 @@ __author__ = "Yorik van Havre"
 __url__ = "http://www.freecadweb.org"
 
 def makeFloor(objectslist=None,baseobj=None,name="Floor"):
-    """Obselete, superceeded by ArchBuildingPart.makeFloor.
+    """Obsolete, superseded by ArchBuildingPart.makeFloor.
 
     Create a floor.
 
@@ -170,7 +170,7 @@ Floor creation aborted.") + "\n"
 
 
 class _Floor(ArchIFC.IfcProduct):
-    """Obselete, superceeded by the BuildingPart class, with IfcType set to "Building Storey".
+    """Obsolete, superseded by the BuildingPart class, with IfcType set to "Building Storey".
 
     The Floor object.
 
@@ -311,7 +311,7 @@ class _Floor(ArchIFC.IfcProduct):
 
 
 class _ViewProviderFloor:
-    """Obselete, superceeded by the ViewProviderBuildingPart class.
+    """Obsolete, superseded by the ViewProviderBuildingPart class.
 
     A View Provider for the Floor object.
 

--- a/src/Mod/Arch/ArchIFCView.py
+++ b/src/Mod/Arch/ArchIFCView.py
@@ -86,7 +86,7 @@ class IfcContextUI:
         self.baseLayout.addLayout(self.createFormEntry("scale", "Scale"))
 
     def prefillMapConversionForm(self):
-        """Prefills each of the form entries with the exising value.
+        """Prefills each of the form entries with the existing value.
 
         Gets the existing value from the object's IfcData, specifically the complex
         attribute, RepresentationContexts.

--- a/src/Mod/Arch/ArchProject.py
+++ b/src/Mod/Arch/ArchProject.py
@@ -22,7 +22,7 @@
 #***************************************************************************
 
 """This module provides tools to build Project objects.  Project objects are
-objects specifically for better IFC compatability, allowing the user to tweak
+objects specifically for better IFC compatibility, allowing the user to tweak
 certain IFC relevant values.
 """
 

--- a/src/Mod/Arch/ArchSite.py
+++ b/src/Mod/Arch/ArchSite.py
@@ -862,7 +862,7 @@ class _ViewProviderSite:
         Edit mode is entered when a user double clicks on an object in the tree
         view, or when they use the menu option [Edit -> Toggle Edit Mode].
 
-        Just dispay the standard Arch component task panel.
+        Just display the standard Arch component task panel.
 
         Parameters
         ----------
@@ -933,7 +933,7 @@ class _ViewProviderSite:
     def updateData(self,obj,prop):
         """Method called when the host object has a property changed.
 
-        If the Longitude or Lattitude has changed, set the SolarDiagram to
+        If the Longitude or Latitude has changed, set the SolarDiagram to
         update.
 
         If Terrain or Placement has changed, move the compass to follow it.

--- a/src/Mod/Arch/Resources/ui/preferences-ifc.ui
+++ b/src/Mod/Arch/Resources/ui/preferences-ifc.ui
@@ -388,10 +388,10 @@ FreeCAD object properties</string>
       <item>
        <widget class="Gui::PrefCheckBox" name="checkBox">
         <property name="toolTip">
-         <string>If this option is checked, the default Project, Site, Building and Storeys objects that are usually found in an IFC file are not imported, and all objects are placed in a Group. Buildins ans storeys are still imported if there is more than one.</string>
+         <string>If this option is checked, the default Project, Site, Building and Storeys objects that are usually found in an IFC file are not imported, and all objects are placed in a Group. Buildings and Storeys are still imported if there is more than one.</string>
         </property>
         <property name="text">
-         <string>Replace Project, Site, Buiding and Storey by Group</string>
+         <string>Replace Project, Site, Building and Storey by Group</string>
         </property>
         <property name="prefEntry" stdset="0">
          <cstring>ifcReplaceProject</cstring>

--- a/src/Mod/Draft/draftguitools/gui_arcs.py
+++ b/src/Mod/Draft/draftguitools/gui_arcs.py
@@ -298,7 +298,7 @@ class Arc(gui_base_original.Creator):
         if self.closedCircle:
             try:
                 # The command to run is built as a series of text strings
-                # to be commited through the `draftutils.todo.ToDo` class.
+                # to be committed through the `draftutils.todo.ToDo` class.
                 if utils.getParam("UsePartPrimitives", False):
                     # Insert a Part::Primitive object
                     _base = DraftVecUtils.toString(self.center)
@@ -336,7 +336,7 @@ class Arc(gui_base_original.Creator):
             except Exception:
                 _err("Draft: error delaying commit")
         else:
-            # Not a closed circle, therfore a circular arc
+            # Not a closed circle, therefore a circular arc
             sta = math.degrees(self.firstangle)
             end = math.degrees(self.firstangle + self.angle)
             if end < sta:

--- a/src/Mod/Draft/draftguitools/gui_base_original.py
+++ b/src/Mod/Draft/draftguitools/gui_base_original.py
@@ -198,7 +198,7 @@ class DraftTool:
         Parameters
         ----------
         name: str
-            An arbitraty string that indicates the name of the operation
+            An arbitrary string that indicates the name of the operation
             to run.
 
         func: list of str

--- a/src/Mod/Draft/draftguitools/gui_beziers.py
+++ b/src/Mod/Draft/draftguitools/gui_beziers.py
@@ -193,7 +193,7 @@ class BezCurve(gui_lines.Line):
             todo.ToDo.delay(self.doc.removeObject, old)
         if len(self.node) > 1:
             # The command to run is built as a series of text strings
-            # to be commited through the `draftutils.todo.ToDo` class.
+            # to be committed through the `draftutils.todo.ToDo` class.
             try:
                 rot, sup, pts, fil = self.getStrings()
                 Gui.addModule("Draft")
@@ -440,7 +440,7 @@ class CubicBezCurve(gui_lines.Line):
         if len(self.node) > 1:
             try:
                 # The command to run is built as a series of text strings
-                # to be commited through the `draftutils.todo.ToDo` class.
+                # to be committed through the `draftutils.todo.ToDo` class.
                 rot, sup, pts, fil = self.getStrings()
                 Gui.addModule("Draft")
                 _cmd = 'Draft.makeBezCurve'

--- a/src/Mod/Draft/draftguitools/gui_ellipses.py
+++ b/src/Mod/Draft/draftguitools/gui_ellipses.py
@@ -92,7 +92,7 @@ class Ellipse(gui_base_original.Creator):
         r2 = (p2.sub(p1).Length)/2
         try:
             # The command to run is built as a series of text strings
-            # to be commited through the `draftutils.todo.ToDo` class.
+            # to be committed through the `draftutils.todo.ToDo` class.
             rot, sup, pts, fil = self.getStrings()
             if r2 > r1:
                 r1, r2 = r2, r1

--- a/src/Mod/Draft/draftguitools/gui_lines.py
+++ b/src/Mod/Draft/draftguitools/gui_lines.py
@@ -142,7 +142,7 @@ class Line(gui_base_original.Creator):
         if len(self.node) > 1:
             Gui.addModule("Draft")
             # The command to run is built as a series of text strings
-            # to be commited through the `draftutils.todo.ToDo` class.
+            # to be committed through the `draftutils.todo.ToDo` class.
             if (len(self.node) == 2
                     and utils.getParam("UsePartPrimitives", False)):
                 # Insert a Part::Primitive object
@@ -344,7 +344,7 @@ class Wire(Line):
 
                     Gui.addModule("Draft")
                     # The command to run is built as a series of text strings
-                    # to be commited through the `draftutils.todo.ToDo` class
+                    # to be committed through the `draftutils.todo.ToDo` class
                     _cmd_list = ['wire = Draft.makeWire([' + pts + '])']
                     _cmd_list.extend(rems)
                     _cmd_list.append('Draft.autogroup(wire)')

--- a/src/Mod/Draft/draftguitools/gui_points.py
+++ b/src/Mod/Draft/draftguitools/gui_points.py
@@ -116,7 +116,7 @@ class Point(gui_base_original.Creator):
                 self.view.removeEventCallbackPivy(coin.SoMouseButtonEvent.getClassTypeId(), self.callbackClick)
                 self.view.removeEventCallbackPivy(coin.SoLocation2Event.getClassTypeId(), self.callbackMove)
                 # The command to run is built as a series of text strings
-                # to be commited through the `draftutils.todo.ToDo` class.
+                # to be committed through the `draftutils.todo.ToDo` class.
                 commitlist = []
                 if utils.getParam("UsePartPrimitives", False):
                     # Insert a Part::Primitive object

--- a/src/Mod/Draft/draftguitools/gui_rectangles.py
+++ b/src/Mod/Draft/draftguitools/gui_rectangles.py
@@ -98,7 +98,7 @@ class Rectangle(gui_base_original.Creator):
             height = -height
         try:
             # The command to run is built as a series of text strings
-            # to be commited through the `draftutils.todo.ToDo` class.
+            # to be committed through the `draftutils.todo.ToDo` class.
             rot, sup, pts, fil = self.getStrings()
             base = p1
             if length < 0:

--- a/src/Mod/Draft/draftguitools/gui_snapper.py
+++ b/src/Mod/Draft/draftguitools/gui_snapper.py
@@ -124,8 +124,8 @@ class Snapper:
         self.callbackMove = None
         self.snapObjectIndex = 0
 
-        # snap keys, it's important tha they are in this order for
-        # saving in preferences and for properly restore the toolbar
+        # snap keys, it's important that they are in this order for
+        # saving in preferences and for properly restoring the toolbar
         self.snaps = ['Lock',           # 0 
                       'Near',           # 1 former "passive" snap
                       'Extension',      # 2
@@ -1514,7 +1514,7 @@ class Snapper:
 
 
     def get_snap_toolbar(self):
-        """Retuns snap toolbar object."""
+        """Returns snap toolbar object."""
         mw = Gui.getMainWindow()
         if mw:
             toolbar = mw.findChild(QtGui.QToolBar, "Draft Snap")

--- a/src/Mod/Draft/draftguitools/gui_splines.py
+++ b/src/Mod/Draft/draftguitools/gui_splines.py
@@ -163,7 +163,7 @@ class BSpline(gui_lines.Line):
             todo.ToDo.delay(self.doc.removeObject, old)
         if len(self.node) > 1:
             # The command to run is built as a series of text strings
-            # to be commited through the `draftutils.todo.ToDo` class.
+            # to be committed through the `draftutils.todo.ToDo` class.
             try:
                 rot, sup, pts, fil = self.getStrings()
                 Gui.addModule("Draft")

--- a/src/Mod/Path/PathScripts/PathSurfaceSupport.py
+++ b/src/Mod/Path/PathScripts/PathSurfaceSupport.py
@@ -54,7 +54,7 @@ class PathGeometryGenerator:
     PathGeometryGenerator(obj, shape, pattern)
     `obj` is the operation object, `shape` is the horizontal planar shape object,
     and `pattern` is the name of the geometric pattern to apply.
-    Frist, call the getCenterOfPattern() method for the CenterOfMass for patterns allowing a custom center.
+    First, call the getCenterOfPattern() method for the CenterOfMass for patterns allowing a custom center.
     Next, call the generatePathGeometry() method to request the path geometry shape.'''
 
     # Register valid patterns here by name


### PR DESCRIPTION
Found via codespell v1.17.0.dev0  
```
codespell -q 3 -L aci,ake,aline,alle,alledges,alocation,als,ang,anid,ba,beginn,behaviour,bloaded,byteorder,calculater,cancelled,cancelling,cas,cascade,centimetre,childs,colour,colours,commen,connexion,currenty,dof,doubleclick,dum,eiter,elemente,ende,feld,finde,findf,freez,hist,iff,indicies,initialisation,initialise,initialised,initialises,initialisiert,ist,kilometre,lod,mantatory,methode,metres,millimetre,modell,nd,noe,normale,normaly,nto,numer,oder,orgin,orginx,orginy,ot,pard,pres,programm,que,recurrance,rougly,seperator,serie,sinc,strack,substraction,te,thist,thru,tread,uint,unter,vertexes,wallthickness,whitespaces -S ./.git,*.po,*.ts,./ChangeLog.txt,./src/3rdParty,./src/Mod/Assembly/App/opendcm,./src/CXX,./src/zipios++,./src/Base/swig*,./src/Mod/Robot/App/kdl_cp,./src/Mod/Import/App/SCL,./src/WindowsInstaller,./src/Doc/FreeCAD.uml
```