### PR TITLE
[fedora.spec] Replace qt5-devel metapackage with direct package names

### DIFF
--- a/package/fedora/freecad.spec
+++ b/package/fedora/freecad.spec
@@ -80,8 +80,10 @@ BuildRequires:  python3-pycxx-devel
 %endif
 BuildRequires:  python3-pyside2-devel
 BuildRequires:  python3-shiboken2-devel
-BuildRequires:  qt5-devel
 BuildRequires:  qt5-qtwebkit-devel
+BuildRequires:  qt5-qtsvg-devel
+BuildRequires:  qt5-qttools-static
+BuildRequires:  qt5-qtxmlpatterns-devel
 %if ! %{bundled_smesh}
 BuildRequires:  smesh-devel
 %endif


### PR DESCRIPTION
Metapackages are not supported on rawhide, so it ws breaking COPR
builds.

Signed-off-by: Przemo Firszt <przemo@firszt.eu>

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [X] Branch rebased on latest master `git pull --rebase upstream master`
- [X] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [X] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [-] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
