### PR TITLE
[Path] - fixes/cycle time estimation

### DIFF
--- a/src/Mod/Path/App/PathPyImp.cpp
+++ b/src/Mod/Path/App/PathPyImp.cpp
@@ -193,8 +193,9 @@ PyObject* PathPy::getCycleTime(PyObject * args)
 {
     double hFeed, vFeed, hRapid, vRapid;
     if (PyArg_ParseTuple(args, "dddd", &hFeed, &vFeed, &hRapid, &vRapid)){
-    return PyFloat_FromDouble(getToolpathPtr()->getCycleTime(hFeed, vFeed, hRapid, vRapid));
+        return PyFloat_FromDouble(getToolpathPtr()->getCycleTime(hFeed, vFeed, hRapid, vRapid));
     }
+    return 0;
 }
 
 // GCode methods

--- a/src/Mod/Path/PathScripts/PathJob.py
+++ b/src/Mod/Path/PathScripts/PathJob.py
@@ -352,32 +352,31 @@ class ObjectJob:
 
     def getCycleTime(self):
         seconds = 0
-        for op in self.obj.Operations.Group:
 
-            # Skip inactive operations
-            if PathUtil.opProperty(op, 'Active') is False:
-                continue
+        if len(self.obj.Operations.Group):
+            for op in self.obj.Operations.Group:
 
-            # Skip operations that don't have a cycletime attribute
-            if not PathUtil.opProperty(op, 'CycleTime') or PathUtil.opProperty(op, 'CycleTime') is None:
-                continue
+                # Skip inactive operations
+                if PathUtil.opProperty(op, 'Active') is False:
+                    continue
 
-            formattedCycleTime = PathUtil.opProperty(op, 'CycleTime')
-            try:
-                ## convert the formatted time from HH:MM:SS to just seconds
-                opCycleTime = sum(x * int(t) for x, t in zip([1, 60, 3600], reversed(formattedCycleTime.split(":"))))
-            except:
-                FreeCAD.Console.PrintWarning("Error converting the operations cycle time. Job Cycle time may be innacturate\n")
-                continue
+                # Skip operations that don't have a cycletime attribute
+                if PathUtil.opProperty(op, 'CycleTime') is None:
+                    continue
 
-            if opCycleTime > 0:
-                seconds = seconds + opCycleTime
+                formattedCycleTime = PathUtil.opProperty(op, 'CycleTime')
+                opCycleTime = 0
+                try:
+                    ## convert the formatted time from HH:MM:SS to just seconds
+                    opCycleTime = sum(x * int(t) for x, t in zip([1, 60, 3600], reversed(formattedCycleTime.split(":"))))
+                except:
+                    FreeCAD.Console.PrintWarning("Error converting the operations cycle time. Job Cycle time may be innacturate\n")
+                    continue
 
-        if seconds > 0:
-            cycleTimeString = time.strftime("%H:%M:%S", time.gmtime(seconds)) 
-        else:
-            cycleTimeString = translate('PathGui', 'Cycle Time Error')
+                if opCycleTime > 0:
+                    seconds = seconds + opCycleTime
 
+        cycleTimeString = time.strftime("%H:%M:%S", time.gmtime(seconds)) 
         self.obj.CycleTime =  cycleTimeString
 
     def addOperation(self, op, before = None, removeBefore = False):


### PR DESCRIPTION
PR to ensure the Python implementation returns a value, removing reported compiler warning and set the job cycle duration to 00:00:00 when the cycle time is 0. 

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

Forum Thread: https://forum.freecadweb.org/viewtopic.php?f=15&t=45586&sid=532bbab369df6a820fde29ee6bbf3fbc