### PR TITLE
[Sketcher] add missing minimal height for spin boxes

### DIFF
--- a/src/Mod/Sketcher/Gui/EditDatumDialog.cpp
+++ b/src/Mod/Sketcher/Gui/EditDatumDialog.cpp
@@ -122,6 +122,10 @@ void EditDatumDialog::exec(bool atCursor)
 
         init_val.setValue(datum);
 
+        // set a minimal height to avoid issues like the one reported here:
+        // https://forum.freecadweb.org/viewtopic.php?f=3&t=45344#p389271
+        ui_ins_datum->labelEdit->setMinimumHeight(20);
+
         ui_ins_datum->labelEdit->setValue(init_val);
         ui_ins_datum->labelEdit->pushToHistory();
         ui_ins_datum->labelEdit->selectNumber();

--- a/src/Mod/Sketcher/Gui/SketchOrientationDialog.ui
+++ b/src/Mod/Sketcher/Gui/SketchOrientationDialog.ui
@@ -84,6 +84,12 @@
      </item>
      <item>
       <widget class="Gui::QuantitySpinBox" name="Offset_doubleSpinBox">
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>20</height>
+        </size>
+       </property>
        <property name="unit" stdset="0">
         <string notr="true">mm</string>
        </property>

--- a/src/Mod/Sketcher/Gui/SketchRectangularArrayDialog.ui
+++ b/src/Mod/Sketcher/Gui/SketchRectangularArrayDialog.ui
@@ -28,6 +28,12 @@
      </item>
      <item>
       <widget class="Gui::PrefSpinBox" name="ColsQuantitySpinBox">
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>20</height>
+        </size>
+       </property>
        <property name="toolTip">
         <string>Number of columns of the linear array</string>
        </property>
@@ -55,6 +61,12 @@
      </item>
      <item>
       <widget class="Gui::PrefSpinBox" name="RowsQuantitySpinBox">
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>20</height>
+        </size>
+       </property>
        <property name="toolTip">
         <string>Number of rows of the linear array</string>
        </property>

--- a/src/Mod/Sketcher/Gui/SketcherRegularPolygonDialog.ui
+++ b/src/Mod/Sketcher/Gui/SketcherRegularPolygonDialog.ui
@@ -9,7 +9,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>287</width>
+    <width>250</width>
     <height>86</height>
    </rect>
   </property>
@@ -28,6 +28,12 @@
      </item>
      <item>
       <widget class="Gui::PrefSpinBox" name="sidesQuantitySpinBox">
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>20</height>
+        </size>
+       </property>
        <property name="toolTip">
         <string>Number of columns of the linear array</string>
        </property>

--- a/src/Mod/Sketcher/Gui/SketcherSettings.ui
+++ b/src/Mod/Sketcher/Gui/SketcherSettings.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>602</width>
-    <height>614</height>
+    <width>420</width>
+    <height>259</height>
    </rect>
   </property>
   <property name="windowTitle">

--- a/src/Mod/Sketcher/Gui/SketcherSettingsColors.ui
+++ b/src/Mod/Sketcher/Gui/SketcherSettingsColors.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>438</width>
-    <height>474</height>
+    <height>566</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -448,6 +448,12 @@
         </item>
         <item row="13" column="1">
          <widget class="Gui::PrefSpinBox" name="SketcherDatumWidth">
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>20</height>
+           </size>
+          </property>
           <property name="toolTip">
            <string>The default line thickness for new shapes</string>
           </property>
@@ -483,6 +489,12 @@
         </item>
         <item row="14" column="1">
          <widget class="Gui::PrefSpinBox" name="DefaultSketcherVertexWidth">
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>20</height>
+           </size>
+          </property>
           <property name="toolTip">
            <string>The default line thickness for new shapes</string>
           </property>
@@ -518,6 +530,12 @@
         </item>
         <item row="15" column="1">
          <widget class="Gui::PrefSpinBox" name="DefaultSketcherLineWidth">
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>20</height>
+           </size>
+          </property>
           <property name="toolTip">
            <string>The default line thickness for new shapes</string>
           </property>

--- a/src/Mod/Sketcher/Gui/SketcherSettingsDisplay.ui
+++ b/src/Mod/Sketcher/Gui/SketcherSettingsDisplay.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>602</width>
-    <height>608</height>
+    <width>420</width>
+    <height>443</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -267,6 +267,12 @@ Supports all unit systems except 'US customary' and 'Building US/Euro'.</string>
       </item>
       <item row="0" column="1">
        <widget class="Gui::PrefSpinBox" name="EditSketcherFontSize">
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>20</height>
+         </size>
+        </property>
         <property name="toolTip">
          <string>Font size used for labels and constraints</string>
         </property>
@@ -318,6 +324,12 @@ Supports all unit systems except 'US customary' and 'Building US/Euro'.</string>
       </item>
       <item row="2" column="1">
        <widget class="Gui::PrefSpinBox" name="SegmentsPerGeometry">
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>20</height>
+         </size>
+        </property>
         <property name="toolTip">
          <string>Number of polygons for geometry approximation</string>
         </property>

--- a/src/Mod/Sketcher/Gui/TaskSketcherGeneral.ui
+++ b/src/Mod/Sketcher/Gui/TaskSketcherGeneral.ui
@@ -38,6 +38,12 @@
      </item>
      <item>
       <widget class="Gui::PrefQuantitySpinBox" name="gridSize" native="true">
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>20</height>
+        </size>
+       </property>
        <property name="toolTip">
         <string>Distance between two subsequent grid lines</string>
        </property>
@@ -154,14 +160,17 @@ Points must be set closer than a fifth of the grid size to a grid line to snap.<
  </widget>
  <customwidgets>
   <customwidget>
-   <class>Gui::PrefQuantitySpinBox</class>
-   <extends>QWidget</extends>
-   <header>Gui/PrefWidgets.h</header>
-  </customwidget>
-  <customwidget>
    <class>Gui::PrefCheckBox</class>
    <extends>QCheckBox</extends>
    <header>Gui/PrefWidgets.h</header>
+  </customwidget>
+  <customwidget>
+   <class>Gui::PrefQuantitySpinBox</class>
+   <extends>QWidget</extends>
+   <header>Gui/PrefWidgets.h</header>
+   <slots>
+    <signal>showFormulaDialog(bool)</signal>
+   </slots>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/src/Mod/Sketcher/Gui/TaskSketcherSolverAdvanced.ui
+++ b/src/Mod/Sketcher/Gui/TaskSketcherSolverAdvanced.ui
@@ -120,6 +120,12 @@ BFGS solver uses the Broyden–Fletcher–Goldfarb–Shanno algorithm.</string>
      </item>
      <item>
       <widget class="Gui::PrefSpinBox" name="spinBoxMaxIter">
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>20</height>
+        </size>
+       </property>
        <property name="toolTip">
         <string>Maximum iterations to find convergence before solver is stopped</string>
        </property>
@@ -651,13 +657,8 @@ Eigen Sparse QR algorithm is optimized for sparse matrices; usually faster</stri
  </widget>
  <customwidgets>
   <customwidget>
-   <class>Gui::PrefLineEdit</class>
-   <extends>QLineEdit</extends>
-   <header>Gui/PrefWidgets.h</header>
-  </customwidget>
-  <customwidget>
-   <class>Gui::PrefComboBox</class>
-   <extends>QComboBox</extends>
+   <class>Gui::PrefSpinBox</class>
+   <extends>QSpinBox</extends>
    <header>Gui/PrefWidgets.h</header>
   </customwidget>
   <customwidget>
@@ -666,8 +667,13 @@ Eigen Sparse QR algorithm is optimized for sparse matrices; usually faster</stri
    <header>Gui/PrefWidgets.h</header>
   </customwidget>
   <customwidget>
-   <class>Gui::PrefSpinBox</class>
-   <extends>QSpinBox</extends>
+   <class>Gui::PrefComboBox</class>
+   <extends>QComboBox</extends>
+   <header>Gui/PrefWidgets.h</header>
+  </customwidget>
+  <customwidget>
+   <class>Gui::PrefLineEdit</class>
+   <extends>QLineEdit</extends>
    <header>Gui/PrefWidgets.h</header>
   </customwidget>
  </customwidgets>


### PR DESCRIPTION
As reported here: https://forum.freecadweb.org/viewtopic.php?f=3&t=45344
the sketcher dialogs miss a minimal height setting for spin boxes.

This PR add them.