### PR TITLE
Arch: import the os module to find the resource paths correctly

### DIFF
--- a/src/Mod/Arch/ArchWindow.py
+++ b/src/Mod/Arch/ArchWindow.py
@@ -19,6 +19,8 @@
 #*                                                                         *
 #***************************************************************************
 
+import os
+
 import FreeCAD,Draft,ArchComponent,DraftVecUtils,ArchCommands
 from FreeCAD import Units
 from FreeCAD import Vector
@@ -771,7 +773,6 @@ class _CommandWindow:
         self.librarypresets = []
         librarypath = FreeCAD.ParamGet('User parameter:Plugins/parts_library').GetString('destination','')
         if librarypath:
-            import os
             if os.path.exists(librarypath):
                 for wtype in ["Windows","Doors"]:
                     wdir = os.path.join(librarypath,"Architectural Parts",wtype)


### PR DESCRIPTION
Properly add the `os` module at the beginning so that it is found by any function that requires operating system facilities, such as `os.path` methods.

This solves a problem reported in the forum: [0.19 Appimage Many Errors pointing to /temp/.mount](https://forum.freecadweb.org/viewtopic.php?f=23&t=45742).

---

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists