### PR TITLE
Draft: different icons in the tree view to recognize the type of array

### DIFF
--- a/src/Mod/Draft/Draft.py
+++ b/src/Mod/Draft/Draft.py
@@ -4869,11 +4869,17 @@ class _ViewProviderDraftArray(_ViewProviderDraft):
         _ViewProviderDraft.__init__(self,vobj)
 
     def getIcon(self):
-        if hasattr(self.Object,"ArrayType"):
-            return ":/icons/Draft_Array.svg"
-        elif hasattr(self.Object,"PointList"):
+        if hasattr(self.Object, "ArrayType"):
+            if self.Object.ArrayType == 'ortho':
+                return ":/icons/Draft_Array.svg"
+            elif self.Object.ArrayType == 'polar':
+                return ":/icons/Draft_PolarArray.svg"
+            elif self.Object.ArrayType == 'circular':
+                return ":/icons/Draft_CircularArray.svg"
+        elif hasattr(self.Object, "PointList"):
             return ":/icons/Draft_PointArray.svg"
-        return ":/icons/Draft_PathArray.svg"
+        else:
+            return ":/icons/Draft_PathArray.svg"
 
     def resetColors(self, vobj):
         colors = []

--- a/src/Mod/Draft/Draft.py
+++ b/src/Mod/Draft/Draft.py
@@ -3297,7 +3297,12 @@ class _ViewProviderDraftLink:
     def getIcon(self):
         tp = self.Object.Proxy.Type
         if tp == 'Array':
-            return ":/icons/Draft_LinkArray.svg"
+            if self.Object.ArrayType == 'ortho':
+                return ":/icons/Draft_LinkArray.svg"
+            elif self.Object.ArrayType == 'polar':
+                return ":/icons/Draft_PolarLinkArray.svg"
+            elif self.Object.ArrayType == 'circular':
+                return ":/icons/Draft_CircularLinkArray.svg"
         elif tp == 'PathArray':
             return ":/icons/Draft_PathLinkArray.svg"
 

--- a/src/Mod/Draft/Resources/Draft.qrc
+++ b/src/Mod/Draft/Resources/Draft.qrc
@@ -19,6 +19,7 @@
         <file>icons/Draft_BSpline.svg</file>
         <file>icons/Draft_Circle.svg</file>
         <file>icons/Draft_CircularArray.svg</file>
+        <file>icons/Draft_CircularLinkArray.svg</file>
         <file>icons/Draft_Clone.svg</file>
         <file>icons/Draft_Construction.svg</file>
         <file>icons/Draft_Continue.svg</file>
@@ -62,6 +63,7 @@
         <file>icons/Draft_Point.svg</file>
         <file>icons/Draft_PointArray.svg</file>
         <file>icons/Draft_PolarArray.svg</file>
+        <file>icons/Draft_PolarLinkArray.svg</file>
         <file>icons/Draft_Polygon.svg</file>
         <file>icons/Draft_Rectangle.svg</file>
         <file>icons/Draft_Rotate.svg</file>

--- a/src/Mod/Draft/Resources/icons/Draft_CircularLinkArray.svg
+++ b/src/Mod/Draft/Resources/icons/Draft_CircularLinkArray.svg
@@ -1,0 +1,587 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   width="64px"
+   height="64px"
+   id="svg5821"
+   version="1.1">
+  <title
+     id="title903">Draft_CircularLinkArray</title>
+  <defs
+     id="defs5823">
+    <linearGradient
+       id="linearGradient6349">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop6351" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop6353" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3377">
+      <stop
+         style="stop-color:#0019a3;stop-opacity:1;"
+         offset="0"
+         id="stop3379" />
+      <stop
+         style="stop-color:#0069ff;stop-opacity:1;"
+         offset="1"
+         id="stop3381" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3377"
+       id="linearGradient3383"
+       x1="901.1875"
+       y1="1190.875"
+       x2="1267.9062"
+       y2="1190.875"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1,0,0,1,2199.356,0)" />
+    <radialGradient
+       xlink:href="#linearGradient6349"
+       id="radialGradient6355"
+       cx="1103.6399"
+       cy="1424.4465"
+       fx="1103.6399"
+       fy="1424.4465"
+       r="194.40614"
+       gradientTransform="matrix(-1.4307499,-1.3605156e-7,-1.202713e-8,0.1264801,2674.7488,1244.2826)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3791-6">
+      <stop
+         style="stop-color:#204a87;stop-opacity:1"
+         offset="0"
+         id="stop3793-7" />
+      <stop
+         style="stop-color:#729fcf;stop-opacity:1"
+         offset="1"
+         id="stop3795-5" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3791-6"
+       id="linearGradient3820"
+       x1="939.98767"
+       y1="1097.5122"
+       x2="893.2572"
+       y2="989.77716"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3791-0">
+      <stop
+         style="stop-color:#204a87;stop-opacity:1"
+         offset="0"
+         id="stop3793-6" />
+      <stop
+         style="stop-color:#729fcf;stop-opacity:1"
+         offset="1"
+         id="stop3795-2" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3791-0"
+       id="linearGradient3896"
+       x1="939.98767"
+       y1="1097.5122"
+       x2="893.2572"
+       y2="989.77716"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3791-2">
+      <stop
+         style="stop-color:#204a87;stop-opacity:1"
+         offset="0"
+         id="stop3793-9" />
+      <stop
+         style="stop-color:#729fcf;stop-opacity:1"
+         offset="1"
+         id="stop3795-3" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3791-2"
+       id="linearGradient3896-1"
+       x1="939.98767"
+       y1="1097.5122"
+       x2="893.2572"
+       y2="989.77716"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3836">
+      <stop
+         id="stop3838"
+         offset="0"
+         style="stop-color:#3465a4;stop-opacity:1;" />
+      <stop
+         id="stop3840"
+         offset="1"
+         style="stop-color:#729fcf;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3144-6">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3146-9" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0"
+         id="stop3148-2" />
+    </linearGradient>
+    <radialGradient
+       r="34.345188"
+       fy="672.79736"
+       fx="225.26402"
+       cy="672.79736"
+       cx="225.26402"
+       gradientTransform="matrix(1,0,0,0.6985294,0,202.82863)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3688"
+       xlink:href="#linearGradient3144-6" />
+    <linearGradient
+       id="linearGradient3864-0-0">
+      <stop
+         style="stop-color:#0619c0;stop-opacity:1;"
+         offset="0"
+         id="stop3866-5-7" />
+      <stop
+         style="stop-color:#379cfb;stop-opacity:1;"
+         offset="1"
+         id="stop3868-7-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3377-3">
+      <stop
+         style="stop-color:#ffaa00;stop-opacity:1;"
+         offset="0"
+         id="stop3379-6" />
+      <stop
+         style="stop-color:#faff2b;stop-opacity:1;"
+         offset="1"
+         id="stop3381-7" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5048">
+      <stop
+         id="stop5050"
+         offset="0"
+         style="stop-color:black;stop-opacity:0;" />
+      <stop
+         style="stop-color:black;stop-opacity:1;"
+         offset="0.5"
+         id="stop5056" />
+      <stop
+         id="stop5052"
+         offset="1"
+         style="stop-color:black;stop-opacity:0;" />
+    </linearGradient>
+    <radialGradient
+       id="aigrd2"
+       cx="20.892099"
+       cy="114.5684"
+       r="5.256"
+       fx="20.892099"
+       fy="114.5684"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         offset="0"
+         style="stop-color:#F0F0F0"
+         id="stop15566" />
+      <stop
+         offset="1.0000000"
+         style="stop-color:#9a9a9a;stop-opacity:1.0000000;"
+         id="stop15568" />
+    </radialGradient>
+    <radialGradient
+       id="aigrd3"
+       cx="20.892099"
+       cy="64.567902"
+       r="5.257"
+       fx="20.892099"
+       fy="64.567902"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         offset="0"
+         style="stop-color:#F0F0F0"
+         id="stop15573" />
+      <stop
+         offset="1.0000000"
+         style="stop-color:#9a9a9a;stop-opacity:1.0000000;"
+         id="stop15575" />
+    </radialGradient>
+    <linearGradient
+       id="linearGradient15662">
+      <stop
+         id="stop15664"
+         offset="0.0000000"
+         style="stop-color:#ffffff;stop-opacity:1.0000000;" />
+      <stop
+         id="stop15666"
+         offset="1.0000000"
+         style="stop-color:#f8f8f8;stop-opacity:1.0000000;" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#linearGradient259"
+       id="radialGradient4452"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.96049297,0,0,1.041132,-52.144249,-702.33158)"
+       cx="33.966679"
+       cy="35.736916"
+       fx="33.966679"
+       fy="35.736916"
+       r="86.70845" />
+    <linearGradient
+       id="linearGradient259">
+      <stop
+         id="stop260"
+         offset="0.0000000"
+         style="stop-color:#fafafa;stop-opacity:1.0000000;" />
+      <stop
+         id="stop261"
+         offset="1.0000000"
+         style="stop-color:#bbbbbb;stop-opacity:1.0000000;" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#linearGradient269"
+       id="radialGradient4454"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.96827297,0,0,1.032767,-48.790699,-701.68513)"
+       cx="8.824419"
+       cy="3.7561285"
+       fx="8.824419"
+       fy="3.7561285"
+       r="37.751713" />
+    <linearGradient
+       id="linearGradient269">
+      <stop
+         id="stop270"
+         offset="0.0000000"
+         style="stop-color:#a3a3a3;stop-opacity:1.0000000;" />
+      <stop
+         id="stop271"
+         offset="1.0000000"
+         style="stop-color:#4c4c4c;stop-opacity:1.0000000;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4095">
+      <stop
+         id="stop4097"
+         offset="0"
+         style="stop-color:#005bff;stop-opacity:1;" />
+      <stop
+         id="stop4099"
+         offset="1"
+         style="stop-color:#c1e3f7;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.94231826,0,0,0.94231826,23.727549,8.8262536)"
+       gradientUnits="userSpaceOnUse"
+       y2="140.22731"
+       x2="434.73947"
+       y1="185.1304"
+       x1="394.15784"
+       id="linearGradient4253"
+       xlink:href="#linearGradient4247" />
+    <linearGradient
+       id="linearGradient4247">
+      <stop
+         id="stop4249"
+         offset="0"
+         style="stop-color:#2e8207;stop-opacity:1;" />
+      <stop
+         id="stop4251"
+         offset="1"
+         style="stop-color:#52ff00;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="485.54004"
+       x2="54.509644"
+       y1="453.55045"
+       x1="11.390151"
+       gradientTransform="matrix(1.050705,0.0195272,0.0195272,1.0567846,61.906432,41.415953)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3922"
+       xlink:href="#linearGradient3836" />
+    <linearGradient
+       xlink:href="#linearGradient3836"
+       id="linearGradient1217"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.050705,0.0195272,0.0195272,1.0567846,61.906432,41.415953)"
+       x1="11.390151"
+       y1="453.55045"
+       x2="54.509644"
+       y2="485.54004" />
+    <linearGradient
+       xlink:href="#linearGradient3836"
+       id="linearGradient1233"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.050705,0.0195272,0.0195272,1.0567846,61.906432,41.415953)"
+       x1="11.390151"
+       y1="453.55045"
+       x2="54.509644"
+       y2="485.54004" />
+    <linearGradient
+       xlink:href="#linearGradient3836"
+       id="linearGradient1241"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.050705,0.0195272,0.0195272,1.0567846,61.906432,41.415953)"
+       x1="11.390151"
+       y1="453.55045"
+       x2="54.509644"
+       y2="485.54004" />
+    <linearGradient
+       xlink:href="#linearGradient3836"
+       id="linearGradient1259"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.050705,0.0195272,0.0195272,1.0567846,61.906432,41.415953)"
+       x1="11.390151"
+       y1="453.55045"
+       x2="54.509644"
+       y2="485.54004" />
+    <linearGradient
+       xlink:href="#linearGradient3836"
+       id="linearGradient4972"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.050705,0.0195272,0.0195272,1.0567846,61.906432,41.415953)"
+       x1="11.390151"
+       y1="453.55045"
+       x2="54.509644"
+       y2="485.54004" />
+    <linearGradient
+       xlink:href="#linearGradient3836"
+       id="linearGradient4980"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.050705,0.0195272,0.0195272,1.0567846,61.906432,41.415953)"
+       x1="11.390151"
+       y1="453.55045"
+       x2="54.509644"
+       y2="485.54004" />
+    <radialGradient
+       xlink:href="#linearGradient6349"
+       id="radialGradient6355-62"
+       cx="1103.6399"
+       cy="1424.4465"
+       fx="1103.6399"
+       fy="1424.4465"
+       r="194.40614"
+       gradientTransform="matrix(-1.4307499,-1.3605156e-7,-1.202713e-8,0.1264801,2674.7488,1244.2826)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       y2="989.77716"
+       x2="893.2572"
+       y1="1097.5122"
+       x1="939.98767"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3834-6"
+       xlink:href="#linearGradient3791-6"
+       gradientTransform="matrix(1.251547,0,0,1.2214422,104.06364,54.837797)" />
+    <linearGradient
+       xlink:href="#linearGradient3791-6"
+       id="linearGradient911"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.251547,0,0,1.2214422,104.06364,54.837797)"
+       x1="939.98767"
+       y1="1097.5122"
+       x2="893.2572"
+       y2="1049.63" />
+    <linearGradient
+       xlink:href="#linearGradient3791-6"
+       id="linearGradient926"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.251547,0,0,1.2214422,104.06352,186.42979)"
+       x1="939.98773"
+       y1="989.77716"
+       x2="893.2572"
+       y2="941.8949" />
+    <radialGradient
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1.4307499,-1.3605156e-7,-1.202713e-8,0.1264801,2674.7488,1244.2826)"
+       r="194.40614"
+       fy="1424.4465"
+       fx="1103.6399"
+       cy="1424.4465"
+       cx="1103.6399"
+       id="radialGradient6355-6"
+       xlink:href="#linearGradient6349" />
+    <linearGradient
+       y2="7.5416322"
+       x2="372.52457"
+       y1="358.15811"
+       x1="288.11227"
+       gradientTransform="matrix(-0.51964051,0,0,0.50042191,1386.3532,982.21378)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5137"
+       xlink:href="#linearGradient3774" />
+    <linearGradient
+       id="linearGradient3774">
+      <stop
+         id="stop3776"
+         offset="0"
+         style="stop-color:#4e9a06;stop-opacity:1" />
+      <stop
+         id="stop3778"
+         offset="1"
+         style="stop-color:#8ae234;stop-opacity:1" />
+    </linearGradient>
+  </defs>
+  <g
+     id="layer1">
+    <g
+       id="g3360"
+       transform="matrix(0.1367863,0,0,0.1367863,-119.15519,-134.86962)">
+      <g
+         transform="matrix(-1.0281913,-0.88047731,0.88051744,-1.0281444,734.46171,1854.2651)"
+         id="g3906"
+         style="stroke:#3465a4;stroke-width:0.8096711">
+        <path
+           style="fill:#3465a4;fill-opacity:1;stroke:#0b1521;stroke-width:10.80131626;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="path4250"
+           d="m 147.07465,535.89484 a 48.571431,48.571431 0 1 1 -97.14285,0 48.571431,48.571431 0 1 1 97.14285,0 z" />
+        <path
+           style="fill:url(#linearGradient3922);fill-opacity:1;stroke:#729fcf;stroke-width:10.80131435;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="path4250-7"
+           d="m 136.22359,535.86575 a 37.80547,37.803747 49.467268 1 1 -75.60894,-0.002 37.80547,37.803747 49.467268 0 1 75.60894,0.002 z" />
+      </g>
+      <g
+         transform="matrix(-1.0281913,-0.88047731,0.88051744,-1.0281444,891.57365,1854.2651)"
+         id="g1215"
+         style="stroke:#3465a4;stroke-width:0.8096711">
+        <path
+           style="fill:#3465a4;fill-opacity:1;stroke:#0b1521;stroke-width:10.80131626;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="path1211"
+           d="m 147.07465,535.89484 a 48.571431,48.571431 0 1 1 -97.14285,0 48.571431,48.571431 0 1 1 97.14285,0 z" />
+        <path
+           style="fill:url(#linearGradient1217);fill-opacity:1;stroke:#729fcf;stroke-width:10.80131435;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="path1213"
+           d="m 136.22359,535.86575 a 37.80547,37.803747 49.467268 1 1 -75.60894,-0.002 37.80547,37.803747 49.467268 0 1 75.60894,0.002 z" />
+      </g>
+      <g
+         transform="matrix(-1.0281913,-0.88047731,0.88051744,-1.0281444,650.32142,1707.8349)"
+         id="g1231"
+         style="stroke:#3465a4;stroke-width:0.8096711">
+        <path
+           style="fill:#3465a4;fill-opacity:1;stroke:#0b1521;stroke-width:10.80131626;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="path1227"
+           d="m 147.07465,535.89484 a 48.571431,48.571431 0 1 1 -97.14285,0 48.571431,48.571431 0 1 1 97.14285,0 z" />
+        <path
+           style="fill:url(#linearGradient1233);fill-opacity:1;stroke:#729fcf;stroke-width:10.80131435;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="path1229"
+           d="m 136.22359,535.86575 a 37.80547,37.803747 49.467268 1 1 -75.60894,-0.002 37.80547,37.803747 49.467268 0 1 75.60894,0.002 z" />
+      </g>
+      <g
+         style="stroke:#3465a4;stroke-width:0.8096711"
+         id="g1239"
+         transform="matrix(-1.0281913,-0.88047731,0.88051744,-1.0281444,650.32142,2007.5725)">
+        <path
+           d="m 147.07465,535.89484 a 48.571431,48.571431 0 1 1 -97.14285,0 48.571431,48.571431 0 1 1 97.14285,0 z"
+           id="path1235"
+           style="fill:#3465a4;fill-opacity:1;stroke:#0b1521;stroke-width:10.80131626;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <path
+           d="m 136.22359,535.86575 a 37.80547,37.803747 49.467268 1 1 -75.60894,-0.002 37.80547,37.803747 49.467268 0 1 75.60894,0.002 z"
+           id="path1237"
+           style="fill:url(#linearGradient1241);fill-opacity:1;stroke:#729fcf;stroke-width:10.80131435;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      </g>
+      <g
+         style="stroke:#3465a4;stroke-width:0.8096711"
+         id="g1257"
+         transform="matrix(-1.0281913,-0.88047731,0.88051744,-1.0281444,577.21468,1854.2651)">
+        <path
+           d="m 147.07465,535.89484 a 48.571431,48.571431 0 1 1 -97.14285,0 48.571431,48.571431 0 1 1 97.14285,0 z"
+           id="path1253"
+           style="fill:#3465a4;fill-opacity:1;stroke:#0b1521;stroke-width:10.80131626;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <path
+           d="m 136.22359,535.86575 a 37.80547,37.803747 49.467268 1 1 -75.60894,-0.002 37.80547,37.803747 49.467268 0 1 75.60894,0.002 z"
+           id="path1255"
+           style="fill:url(#linearGradient1259);fill-opacity:1;stroke:#729fcf;stroke-width:10.80131435;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      </g>
+      <g
+         style="stroke:#3465a4;stroke-width:0.8096711"
+         id="g4970"
+         transform="matrix(-1.0281913,-0.88047731,0.88051744,-1.0281444,818.46691,1707.8349)">
+        <path
+           d="m 147.07465,535.89484 a 48.571431,48.571431 0 1 1 -97.14285,0 48.571431,48.571431 0 1 1 97.14285,0 z"
+           id="path4966"
+           style="fill:#3465a4;fill-opacity:1;stroke:#0b1521;stroke-width:10.80131626;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <path
+           d="m 136.22359,535.86575 a 37.80547,37.803747 49.467268 1 1 -75.60894,-0.002 37.80547,37.803747 49.467268 0 1 75.60894,0.002 z"
+           id="path4968"
+           style="fill:url(#linearGradient4972);fill-opacity:1;stroke:#729fcf;stroke-width:10.80131435;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      </g>
+      <g
+         transform="matrix(-1.0281913,-0.88047731,0.88051744,-1.0281444,818.46691,2007.5725)"
+         id="g4978"
+         style="stroke:#3465a4;stroke-width:0.8096711">
+        <path
+           style="fill:#3465a4;fill-opacity:1;stroke:#0b1521;stroke-width:10.80131626;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="path4974"
+           d="m 147.07465,535.89484 a 48.571431,48.571431 0 1 1 -97.14285,0 48.571431,48.571431 0 1 1 97.14285,0 z" />
+        <path
+           style="fill:url(#linearGradient4980);fill-opacity:1;stroke:#729fcf;stroke-width:10.80131435;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="path4976"
+           d="m 136.22359,535.86575 a 37.80547,37.803747 49.467268 1 1 -75.60894,-0.002 37.80547,37.803747 49.467268 0 1 75.60894,0.002 z" />
+      </g>
+    </g>
+  </g>
+  <metadata
+     id="metadata3357">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>Draft_CircularLinkArray</dc:title>
+        <cc:license
+           rdf:resource="" />
+        <dc:date>Sat Dec 10 18:31:32 2011 +0000</dc:date>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>vocx</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>FreeCAD LGPL2+</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>FreeCAD</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:identifier>FreeCAD/src/Mod/Draft/Resources/icons/Draft_CircularLinkArray.svg</dc:identifier>
+        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title>agryson, yorikvanhavre</dc:title>
+          </cc:Agent>
+        </dc:contributor>
+        <dc:description>Seven circles, in a circular array, with a green arrow indicating that this array uses Link elements</dc:description>
+        <dc:subject>
+          <rdf:Bag>
+            <rdf:li>circular</rdf:li>
+            <rdf:li>array</rdf:li>
+          </rdf:Bag>
+        </dc:subject>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="g4218"
+     transform="matrix(0.1367863,0,0,0.1367863,-121.1483,-132.94258)">
+    <path
+       style="opacity:1;fill:#8ae234;fill-opacity:1;stroke:#172a04;stroke-width:14.62134743;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 1145.5648,1074.1543 c 18.5937,-18.383 48.2169,-28.9064 88.8688,-31.5737 v -37.4326 c 0,-4.0003 1.9294,-6.80966 5.7868,-8.43006 4.0547,-1.61639 7.5171,-0.95178 10.3849,2.00121 l 75.9581,73.15065 c 1.8799,1.8121 2.8184,3.9543 2.8184,6.4303 0,2.4767 -0.9389,4.6185 -2.8184,6.429 l -75.9602,73.1502 c -1.7833,1.81 -4.0064,2.7148 -6.6772,2.7148 -1.1865,0 -2.4222,-0.2382 -3.7083,-0.7141 -3.8572,-1.6204 -5.7882,-4.4273 -5.7882,-8.4296 v -35.8618 c -15.9228,1.2386 -29.1503,3.7387 -39.6881,7.5008 -10.5331,3.7627 -18.9637,9.0247 -25.2946,15.7879 -14.738,15.7158 -19.9806,42.6214 -15.7274,80.7237 0.1953,2.4775 -0.9389,4.0963 -3.4125,4.858 -0.2967,0.097 -0.7414,0.142 -1.3349,0.142 -1.9778,0 -3.361,-0.8095 -4.154,-2.4285 l -2.9667,-5.7148 c -1.3832,-2.6676 -3.3858,-6.9784 -6.007,-12.9313 -2.6194,-5.9556 -4.9969,-11.9071 -7.1237,-17.8612 -2.1269,-5.9515 -4.0298,-12.5235 -5.7119,-19.7147 -1.6805,-7.194 -2.5219,-13.5508 -2.5219,-19.074 0,-32.0039 8.3606,-56.2428 25.078,-72.7222 z"
+       id="path4228" />
+    <path
+       id="path5135"
+       d="m 1252.6459,1025.0625 c 18.4441,17.7617 37.1632,35.1962 55.3062,53.3235 -19.0906,18.0067 -37.542,36.7844 -56.7747,54.6184 -0.018,-12.2743 -0.087,-24.5491 0.032,-36.8231 -26.4463,1.6409 -53.9694,3.575 -77.8197,17.2303 -17.0095,9.5803 -28.4884,27.8106 -34.5388,47.088 -3.5743,-21.5969 -1.2897,-45.3408 10.607,-63.6609 11.0273,-16.9013 29.5358,-25.7267 47.629,-30.3404 14.7839,-4.3279 30.2561,-4.0127 45.1276,-7.7257 7.8392,-4.3982 10.4187,-14.9284 9.2176,-23.8416 -0.062,-3.7919 -0.2886,-7.6325 -0.4323,-11.451 0.5488,0.5275 1.0977,1.055 1.6465,1.5825 z"
+       style="opacity:1;fill:url(#linearGradient5137);fill-opacity:1;stroke:none;stroke-width:34.75331116;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  </g>
+</svg>

--- a/src/Mod/Draft/Resources/icons/Draft_PolarLinkArray.svg
+++ b/src/Mod/Draft/Resources/icons/Draft_PolarLinkArray.svg
@@ -1,0 +1,368 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   width="64px"
+   height="64px"
+   id="svg5821"
+   version="1.1">
+  <title
+     id="title862">Draft_PolarLinkArray</title>
+  <defs
+     id="defs5823">
+    <linearGradient
+       id="linearGradient6349">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop6351" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop6353" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3377">
+      <stop
+         style="stop-color:#0019a3;stop-opacity:1;"
+         offset="0"
+         id="stop3379" />
+      <stop
+         style="stop-color:#0069ff;stop-opacity:1;"
+         offset="1"
+         id="stop3381" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3377"
+       id="linearGradient3383"
+       x1="901.1875"
+       y1="1190.875"
+       x2="1267.9062"
+       y2="1190.875"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1,0,0,1,2199.356,0)" />
+    <radialGradient
+       xlink:href="#linearGradient6349"
+       id="radialGradient6355"
+       cx="1103.6399"
+       cy="1424.4465"
+       fx="1103.6399"
+       fy="1424.4465"
+       r="194.40614"
+       gradientTransform="matrix(-1.4307499,-1.3605156e-7,-1.202713e-8,0.1264801,2674.7488,1244.2826)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3791-6">
+      <stop
+         style="stop-color:#204a87;stop-opacity:1"
+         offset="0"
+         id="stop3793-7" />
+      <stop
+         style="stop-color:#729fcf;stop-opacity:1"
+         offset="1"
+         id="stop3795-5" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3791-6"
+       id="linearGradient3820"
+       x1="939.98767"
+       y1="1097.5122"
+       x2="893.2572"
+       y2="989.77716"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3791-0">
+      <stop
+         style="stop-color:#204a87;stop-opacity:1"
+         offset="0"
+         id="stop3793-6" />
+      <stop
+         style="stop-color:#729fcf;stop-opacity:1"
+         offset="1"
+         id="stop3795-2" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3791-0"
+       id="linearGradient3896"
+       x1="939.98767"
+       y1="1097.5122"
+       x2="893.2572"
+       y2="989.77716"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3791-6-9">
+      <stop
+         style="stop-color:#204a87;stop-opacity:1"
+         offset="0"
+         id="stop3793-7-7" />
+      <stop
+         style="stop-color:#729fcf;stop-opacity:1"
+         offset="1"
+         id="stop3795-5-3" />
+    </linearGradient>
+    <linearGradient
+       y2="989.77716"
+       x2="893.2572"
+       y1="1097.5122"
+       x1="939.98767"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3834-6"
+       xlink:href="#linearGradient3791-6-9"
+       gradientTransform="matrix(1.251547,0,0,1.2214422,104.06364,54.837797)" />
+    <linearGradient
+       id="linearGradient3791-2">
+      <stop
+         style="stop-color:#204a87;stop-opacity:1"
+         offset="0"
+         id="stop3793-9" />
+      <stop
+         style="stop-color:#729fcf;stop-opacity:1"
+         offset="1"
+         id="stop3795-3" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3791-2"
+       id="linearGradient3896-1"
+       x1="939.98767"
+       y1="1097.5122"
+       x2="893.2572"
+       y2="989.77716"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       xlink:href="#linearGradient3791-6-9"
+       id="linearGradient911"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.251547,0,0,1.2214422,104.06364,54.837797)"
+       x1="939.98767"
+       y1="1097.5122"
+       x2="893.2572"
+       y2="1049.63" />
+    <linearGradient
+       xlink:href="#linearGradient3791-6-9"
+       id="linearGradient926"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.251547,0,0,1.2214422,104.06352,186.42979)"
+       x1="939.98773"
+       y1="989.77716"
+       x2="893.2572"
+       y2="941.8949" />
+    <linearGradient
+       xlink:href="#linearGradient3791-6-9"
+       id="linearGradient934"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.251547,0,0,1.2214422,104.06352,186.42979)"
+       x1="939.98773"
+       y1="989.77716"
+       x2="893.2572"
+       y2="941.8949" />
+    <linearGradient
+       xlink:href="#linearGradient3791-6-9"
+       id="linearGradient942"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.251547,0,0,1.2214422,104.06352,186.42979)"
+       x1="939.98773"
+       y1="989.77716"
+       x2="893.2572"
+       y2="941.8949" />
+    <radialGradient
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1.4307499,-1.3605156e-7,-1.202713e-8,0.1264801,2674.7488,1244.2826)"
+       r="194.40614"
+       fy="1424.4465"
+       fx="1103.6399"
+       cy="1424.4465"
+       cx="1103.6399"
+       id="radialGradient6355-6"
+       xlink:href="#linearGradient6349" />
+    <linearGradient
+       y2="7.5416322"
+       x2="372.52457"
+       y1="358.15811"
+       x1="288.11227"
+       gradientTransform="matrix(-0.51964051,0,0,0.50042191,1386.3532,982.21378)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5137"
+       xlink:href="#linearGradient3774" />
+    <linearGradient
+       id="linearGradient3774">
+      <stop
+         id="stop3776"
+         offset="0"
+         style="stop-color:#4e9a06;stop-opacity:1" />
+      <stop
+         id="stop3778"
+         offset="1"
+         style="stop-color:#8ae234;stop-opacity:1" />
+    </linearGradient>
+  </defs>
+  <g
+     id="layer1">
+    <g
+       id="g3360"
+       transform="matrix(0.1367863,0,0,0.1367863,-119.15519,-134.86962)">
+      <path
+         style="fill:none;fill-rule:evenodd;stroke:#0c1622;stroke-width:14.62134731;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:43.86404194,14.62134731;stroke-opacity:0.50196078;stroke-dashoffset:0"
+         d="m 1002.6968,1380.7642 h 233.9416"
+         id="path864" />
+      <path
+         id="path862"
+         d="M 944.21145,1322.2788 V 1088.3372"
+         style="fill:none;fill-rule:evenodd;stroke:#0c1622;stroke-width:14.62134731;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:43.86404194,14.62134731;stroke-opacity:0.50196078;stroke-dashoffset:0" />
+      <path
+         style="fill:none;fill-rule:evenodd;stroke:#0c1622;stroke-width:14.62134731;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:43.86404194,14.62134731;stroke-opacity:0.50196078;stroke-dashoffset:0"
+         d="M 973.45414,1329.5894 1096.1609,1117.5799"
+         id="path858" />
+      <path
+         id="path860"
+         d="M 1002.6968,1351.5215 1222.017,1234.5507"
+         style="fill:none;fill-rule:evenodd;stroke:#0c1622;stroke-width:14.62134731;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:43.86404194,14.62134731;stroke-opacity:0.50196078;stroke-dashoffset:0" />
+      <path
+         style="opacity:0.5;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#0b1521;stroke-width:14.62134743;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="path944"
+         d="m 943.94776,1099.3995 a 285.37994,281.36465 0 0 1 285.37994,281.3647" />
+      <g
+         id="g903">
+        <rect
+           y="1329.5894"
+           x="1214.7063"
+           height="73.106735"
+           width="73.106735"
+           id="rect3808-6-1-20"
+           style="fill:url(#linearGradient3834-6);fill-opacity:1;fill-rule:nonzero;stroke:#729fcf;stroke-width:14.62134743;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      </g>
+      <g
+         id="g916"
+         transform="translate(0,14.621347)">
+        <rect
+           y="1314.968"
+           x="1200.0851"
+           height="102.34943"
+           width="102.34941"
+           id="rect3808-2-6"
+           style="fill:#3465a4;fill-opacity:1;fill-rule:nonzero;stroke:#0b1521;stroke-width:14.62134838;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+        <rect
+           style="fill:url(#linearGradient911);fill-opacity:1;fill-rule:nonzero;stroke:#729fcf;stroke-width:14.62134743;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           id="rect905"
+           width="73.106735"
+           height="73.106735"
+           x="1214.7063"
+           y="1329.5894" />
+      </g>
+      <g
+         id="g922"
+         transform="translate(-29.242576,-131.59199)">
+        <rect
+           style="fill:#3465a4;fill-opacity:1;fill-rule:nonzero;stroke:#0b1521;stroke-width:14.62134838;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           id="rect918"
+           width="102.34941"
+           height="102.34943"
+           x="1200.0851"
+           y="1314.968" />
+        <rect
+           y="1329.5894"
+           x="1214.7063"
+           height="73.106735"
+           width="73.106735"
+           id="rect920"
+           style="fill:url(#linearGradient926);fill-opacity:1;fill-rule:nonzero;stroke:#729fcf;stroke-width:14.62134743;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      </g>
+      <g
+         transform="translate(-153.52403,-248.56277)"
+         id="g932">
+        <rect
+           y="1314.968"
+           x="1200.0851"
+           height="102.34943"
+           width="102.34941"
+           id="rect928"
+           style="fill:#3465a4;fill-opacity:1;fill-rule:nonzero;stroke:#0b1521;stroke-width:14.62134838;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+        <rect
+           style="fill:url(#linearGradient934);fill-opacity:1;fill-rule:nonzero;stroke:#729fcf;stroke-width:14.62134743;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           id="rect930"
+           width="73.106735"
+           height="73.106735"
+           x="1214.7063"
+           y="1329.5894" />
+      </g>
+      <g
+         id="g940"
+         transform="translate(-307.04835,-292.42682)">
+        <rect
+           style="fill:#3465a4;fill-opacity:1;fill-rule:nonzero;stroke:#0b1521;stroke-width:14.62134838;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           id="rect936"
+           width="102.34941"
+           height="102.34943"
+           x="1200.0851"
+           y="1314.968" />
+        <rect
+           y="1329.5894"
+           x="1214.7063"
+           height="73.106735"
+           width="73.106735"
+           id="rect938"
+           style="fill:url(#linearGradient942);fill-opacity:1;fill-rule:nonzero;stroke:#729fcf;stroke-width:14.62134743;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      </g>
+    </g>
+  </g>
+  <metadata
+     id="metadata3357">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>Draft_PolarLinkArray</dc:title>
+        <cc:license
+           rdf:resource="" />
+        <dc:date>Dec 24 18:30:00 2019 CST</dc:date>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>[vocx]</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>FreeCAD LGPL2+</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>FreeCAD</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:identifier>FreeCAD/src/Mod/Draft/Resources/icons/Draft_PolarLinkArray.svg</dc:identifier>
+        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title>[agryson] Alexander Gryson, [yorikvanhavre]</dc:title>
+          </cc:Agent>
+        </dc:contributor>
+        <dc:description>Four rectangles in a polar pattern spanning 90 degrees, and a green arrow denoting that it uses the Link component</dc:description>
+        <dc:subject>
+          <rdf:Bag>
+            <rdf:li>rectangle</rdf:li>
+            <rdf:li>array</rdf:li>
+            <rdf:li>link</rdf:li>
+          </rdf:Bag>
+        </dc:subject>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     transform="matrix(0.1367863,0,0,0.1367863,-124.99724,-133.02985)"
+     id="g4218">
+    <path
+       id="path4228"
+       d="m 1145.5648,1074.1543 c 18.5937,-18.383 48.2169,-28.9064 88.8688,-31.5737 v -37.4326 c 0,-4.0003 1.9294,-6.80966 5.7868,-8.43006 4.0547,-1.61639 7.5171,-0.95178 10.3849,2.00121 l 75.9581,73.15065 c 1.8799,1.8121 2.8184,3.9543 2.8184,6.4303 0,2.4767 -0.9389,4.6185 -2.8184,6.429 l -75.9602,73.1502 c -1.7833,1.81 -4.0064,2.7148 -6.6772,2.7148 -1.1865,0 -2.4222,-0.2382 -3.7083,-0.7141 -3.8572,-1.6204 -5.7882,-4.4273 -5.7882,-8.4296 v -35.8618 c -15.9228,1.2386 -29.1503,3.7387 -39.6881,7.5008 -10.5331,3.7627 -18.9637,9.0247 -25.2946,15.7879 -14.738,15.7158 -19.9806,42.6214 -15.7274,80.7237 0.1953,2.4775 -0.9389,4.0963 -3.4125,4.858 -0.2967,0.097 -0.7414,0.142 -1.3349,0.142 -1.9778,0 -3.361,-0.8095 -4.154,-2.4285 l -2.9667,-5.7148 c -1.3832,-2.6676 -3.3858,-6.9784 -6.007,-12.9313 -2.6194,-5.9556 -4.9969,-11.9071 -7.1237,-17.8612 -2.1269,-5.9515 -4.0298,-12.5235 -5.7119,-19.7147 -1.6805,-7.194 -2.5219,-13.5508 -2.5219,-19.074 0,-32.0039 8.3606,-56.2428 25.078,-72.7222 z"
+       style="opacity:1;fill:#8ae234;fill-opacity:1;stroke:#172a04;stroke-width:14.62134743;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       style="opacity:1;fill:url(#linearGradient5137);fill-opacity:1;stroke:none;stroke-width:34.75331116;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 1252.6459,1025.0625 c 18.4441,17.7617 37.1632,35.1962 55.3062,53.3235 -19.0906,18.0067 -37.542,36.7844 -56.7747,54.6184 -0.018,-12.2743 -0.087,-24.5491 0.032,-36.8231 -26.4463,1.6409 -53.9694,3.575 -77.8197,17.2303 -17.0095,9.5803 -28.4884,27.8106 -34.5388,47.088 -3.5743,-21.5969 -1.2897,-45.3408 10.607,-63.6609 11.0273,-16.9013 29.5358,-25.7267 47.629,-30.3404 14.7839,-4.3279 30.2561,-4.0127 45.1276,-7.7257 7.8392,-4.3982 10.4187,-14.9284 9.2176,-23.8416 -0.062,-3.7919 -0.2886,-7.6325 -0.4323,-11.451 0.5488,0.5275 1.0977,1.055 1.6465,1.5825 z"
+       id="path5135" />
+  </g>
+</svg>


### PR DESCRIPTION
Just like with #3070 and #3170, this introduces different icons for the different arrays in the tree view, either orthogonal, polar, circular, or their `App::Link` variants.

This makes it easier to identify which array it is by quickly glancing at the tree view.

---

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists