### PR TITLE
Workaround for messy SHIBOKEN_MICRO_VERSION definition

### DIFF
--- a/src/Gui/WidgetFactory.cpp
+++ b/src/Gui/WidgetFactory.cpp
@@ -91,7 +91,8 @@ PyTypeObject** SbkPySide_QtGuiTypes=nullptr;
 // This helps to avoid to include the PySide2 headers since MSVC has a compiler bug when
 // compiling together with std::bitset (https://bugreports.qt.io/browse/QTBUG-72073)
 
-# define SHIBOKEN_FULL_VERSION QT_VERSION_CHECK(SHIBOKEN_MAJOR_VERSION, SHIBOKEN_MINOR_VERSION, SHIBOKEN_MICRO_VERSION)
+// Do not use SHIBOKEN_MICRO_VERSION; it might contain a dot
+# define SHIBOKEN_FULL_VERSION QT_VERSION_CHECK(SHIBOKEN_MAJOR_VERSION, SHIBOKEN_MINOR_VERSION, 0)
 # if (SHIBOKEN_FULL_VERSION >= QT_VERSION_CHECK(5, 12, 0))
 # define HAVE_SHIBOKEN_TYPE_FOR_TYPENAME
 # endif


### PR DESCRIPTION
I recently upgraded to `shiboken2-5.14.2.1`, and this broke preprocessing of `src/Gui/WidgetFactory.cpp` because `SHIBOKEN_MICRO_VERSION` is now defined as `2.1` (WTF?!), making it a floating-point literal which the preprocessor does not like.
It is only used for version comparison with `5.12.0`, so replacing `SHIBOKEN_MICRO_VERSION` with `0` should be OK.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
