### PR TITLE
Gui: add sWhatsThis to Std_DrawStyle

### DIFF
--- a/src/Gui/CommandView.cpp
+++ b/src/Gui/CommandView.cpp
@@ -575,8 +575,9 @@ StdCmdDrawStyle::StdCmdDrawStyle()
 {
     sGroup        = QT_TR_NOOP("Standard-View");
     sMenuText     = QT_TR_NOOP("Draw style");
-    sToolTipText  = QT_TR_NOOP("Draw style");
-    sStatusTip    = QT_TR_NOOP("Draw style");
+    sToolTipText  = QT_TR_NOOP("Change the draw style of the objects");
+    sStatusTip    = QT_TR_NOOP("Change the draw style of the objects");
+    sWhatsThis    = "Std_DrawStyle";
     sPixmap       = "DrawStyleAsIs";
     eType         = Alter3DView;
 


### PR DESCRIPTION
Add the `sWhatsThis` string.

Maybe it helps to solve the lack of documentation for this command.

See thread: [[ Bug? ] The Std_WhatsThis command does not work for 2 submenus of the View menu](https://forum.freecadweb.org/viewtopic.php?f=3&t=45135)

---

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists
