### PR TITLE
Gui: change string from Document to Documentation

### DIFF
--- a/src/Gui/DlgAddProperty.ui
+++ b/src/Gui/DlgAddProperty.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>354</width>
+    <width>418</width>
     <height>258</height>
    </rect>
   </property>
@@ -15,7 +15,7 @@
   </property>
   <layout class="QFormLayout" name="formLayout">
    <item row="0" column="0">
-    <widget class="QLabel" name="label">
+    <widget class="QLabel" name="label_type">
      <property name="text">
       <string>Type</string>
      </property>
@@ -25,7 +25,7 @@
     <widget class="QComboBox" name="comboType"/>
    </item>
    <item row="1" column="0">
-    <widget class="QLabel" name="label_2">
+    <widget class="QLabel" name="label_group">
      <property name="text">
       <string>Group</string>
      </property>
@@ -35,7 +35,7 @@
     <widget class="QLineEdit" name="edtGroup"/>
    </item>
    <item row="2" column="0">
-    <widget class="QLabel" name="label_3">
+    <widget class="QLabel" name="label_name">
      <property name="text">
       <string>Name</string>
      </property>
@@ -45,22 +45,33 @@
     <widget class="QLineEdit" name="edtName"/>
    </item>
    <item row="3" column="0">
-    <widget class="QLabel" name="label_4">
+    <widget class="QLabel" name="label_doc">
+     <property name="toolTip">
+      <string>Verbose description of the new property.</string>
+     </property>
      <property name="text">
-      <string>Document</string>
+      <string>Documentation</string>
      </property>
     </widget>
    </item>
    <item row="3" column="1">
-    <widget class="QPlainTextEdit" name="edtDoc"/>
+    <widget class="QPlainTextEdit" name="edtDoc">
+     <property name="toolTip">
+      <string>Verbose description of the new property.</string>
+     </property>
+    </widget>
    </item>
    <item row="4" column="1">
     <widget class="QCheckBox" name="chkAppend">
      <property name="toolTip">
-      <string>Append the group name in front of the property name in the form of 'group'_'name' to avoid conflict with existing property. The prefixed group name will be auto trimmed when shown in the property editor.</string>
+      <string>Prefix the property name with the group name in the form 'Group_Name' to avoid conflicts with an existing property.
+In this case the prefix will be automatically trimmed when shown in the property editor.
+However, the property is still used in a script with the full name, like 'obj.Group_Name'.
+
+If this is not ticked, then the property must be uniquely named, and it is accessed like 'obj.Name'.</string>
      </property>
      <property name="text">
-      <string>Append group name</string>
+      <string>Prefix group name</string>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
The LinkMerge introduced the concept of dynamically added properties. The add property dialog previously showed "Document" which is confusing. In reality, it must say "Documentation".

Also improve the tooltips. Also change "Append" to "Prefix" in the checkbox as it's more clear that the `Group` is added at the beginning to form the full name of the property.

---

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists
