### PR TITLE
[skip-ci] Fix typos in Draft, Mesh, and src/Tools

### DIFF
--- a/src/Mod/Draft/draftguitools/gui_drawing.py
+++ b/src/Mod/Draft/draftguitools/gui_drawing.py
@@ -30,7 +30,7 @@ that is displayed in a drawing page in the Drawing Workbench.
 This command should be considered obsolete as the Drawing Workbench
 is obsolete since 0.17.
 
-A similar command is not planed for the TechDraw Workbench because
+A similar command is not planned for the TechDraw Workbench because
 it is not really necessary. TechDraw has its own set of tools
 to create 2D projections of 2D and 3D objects.
 """

--- a/src/Mod/Draft/draftguitools/gui_move.py
+++ b/src/Mod/Draft/draftguitools/gui_move.py
@@ -134,7 +134,7 @@ class Move(gui_base_original.Modifier):
             self.handle_mouse_click_event(arg)
 
     def handle_mouse_move_event(self, arg):
-        """Hande the mouse when moving."""
+        """Handle the mouse when moving."""
         for ghost in self.ghosts:
             ghost.off()
         self.point, ctrlPoint, info = gui_tool_utils.getPoint(self, arg)
@@ -150,7 +150,7 @@ class Move(gui_base_original.Modifier):
         gui_tool_utils.redraw3DView()
 
     def handle_mouse_click_event(self, arg):
-        """Hande the mouse when the first button is clicked."""
+        """Handle the mouse when the first button is clicked."""
         if not self.ghosts:
             self.set_ghosts()
         if not self.point:

--- a/src/Mod/Draft/draftguitools/gui_offset.py
+++ b/src/Mod/Draft/draftguitools/gui_offset.py
@@ -22,14 +22,14 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides tools for offseting objects with the Draft Workbench.
+"""Provides tools for offsetting objects with the Draft Workbench.
 
 It mostly works on lines, polylines, and similar objects with
 regular geometrical shapes, like rectangles.
 """
 ## @package gui_offset
 # \ingroup DRAFT
-# \brief Provides tools for offseting objects with the Draft Workbench.
+# \brief Provides tools for offsetting objects with the Draft Workbench.
 
 import math
 from PySide.QtCore import QT_TRANSLATE_NOOP

--- a/src/Mod/Draft/draftguitools/gui_rotate.py
+++ b/src/Mod/Draft/draftguitools/gui_rotate.py
@@ -123,7 +123,7 @@ class Rotate(gui_base_original.Modifier):
             self.handle_mouse_click_event(arg)
 
     def handle_mouse_move_event(self, arg):
-        """Hande the mouse when moving."""
+        """Handle the mouse when moving."""
         plane = App.DraftWorkingPlane
 
         for ghost in self.ghosts:
@@ -175,7 +175,7 @@ class Rotate(gui_base_original.Modifier):
         gui_tool_utils.redraw3DView()
 
     def handle_mouse_click_event(self, arg):
-        """Hande the mouse when the first button is clicked."""
+        """Handle the mouse when the first button is clicked."""
         if not self.point:
             return
         if self.step == 0:

--- a/src/Mod/Draft/draftguitools/gui_scale.py
+++ b/src/Mod/Draft/draftguitools/gui_scale.py
@@ -79,7 +79,7 @@ class Scale(gui_base_original.Modifier):
         self.get_object_selection()
 
     def get_object_selection(self):
-        """Get object selection and proceed if succesful."""
+        """Get object selection and proceed if successful."""
         if Gui.Selection.getSelection():
             return self.proceed()
         self.ui.selectUi()

--- a/src/Mod/Draft/draftobjects/base.py
+++ b/src/Mod/Draft/draftobjects/base.py
@@ -124,7 +124,7 @@ class DraftObject(object):
 
         By default it does nothing.
 
-        Paramaters
+        Parameters
         ----------
         obj : the scripted object.
             This commonly may be of types `Part::Part2DObjectPython`,
@@ -140,7 +140,7 @@ class DraftObject(object):
 
         By default it does nothing.
 
-        Paramaters
+        Parameters
         ----------
         obj : the scripted object.
             This commonly may be of types `Part::Part2DObjectPython`,

--- a/src/Mod/Draft/draftviewproviders/view_base.py
+++ b/src/Mod/Draft/draftviewproviders/view_base.py
@@ -155,7 +155,7 @@ class ViewProviderDraft(object):
 
         Override this method to set up a custom scene.
 
-        Paramaters
+        Parameters
         ----------
         vobj : the view provider of the scripted object.
             This is `obj.ViewObject`.
@@ -196,7 +196,7 @@ class ViewProviderDraft(object):
 
         By default it returns an empty list.
 
-        Paramaters
+        Parameters
         ----------
         vobj : the view provider of the scripted object.
             This is `obj.ViewObject`.
@@ -232,7 +232,7 @@ class ViewProviderDraft(object):
         By default since they have the same names nothing needs to be done,
         and it just returns the input `mode`.
 
-        Paramaters
+        Parameters
         ----------
         str
             A string defining a display mode such as
@@ -252,7 +252,7 @@ class ViewProviderDraft(object):
         the properties `TextureImage`, `Pattern`, `DiffuseColor`,
         and `PatternSize` change.
 
-        Paramaters
+        Parameters
         ----------
         vobj : the view provider of the scripted object.
             This is `obj.ViewObject`.
@@ -341,7 +341,7 @@ class ViewProviderDraft(object):
 
         By default it does nothing.
 
-        Paramaters
+        Parameters
         ----------
         vobj : the view provider of the scripted object.
             This is `obj.ViewObject`.
@@ -361,7 +361,7 @@ class ViewProviderDraft(object):
         ::
             Gui.runCommand('Draft_Edit')
 
-        Paramaters
+        Parameters
         ----------
         vobj : the view provider of the scripted object.
             This is `obj.ViewObject`.
@@ -374,7 +374,7 @@ class ViewProviderDraft(object):
         Returns
         -------
         bool
-            It is `True` if `mode` is 0, and `Draft_Edit` ran succesfully.
+            It is `True` if `mode` is 0, and `Draft_Edit` ran successfully.
             It is `False` otherwise.
         """
         if mode == 0 and App.GuiUp: #remove guard after splitting every viewprovider
@@ -401,7 +401,7 @@ class ViewProviderDraft(object):
             App.activeDraftCommand.finish()
             Gui.Control.closeDialog()
 
-        Paramaters
+        Parameters
         ----------
         vobj : the view provider of the scripted object.
             This is `obj.ViewObject`.
@@ -487,7 +487,7 @@ _ViewProviderDraft = ViewProviderDraft
 class ViewProviderDraftAlt(ViewProviderDraft):
     """A view provider that doesn't absorb its base object in the tree view.
 
-    The `claimChildren` method is overriden to return an empty list.
+    The `claimChildren` method is overridden to return an empty list.
     """
 
     def __init__(self, vobj):
@@ -504,7 +504,7 @@ _ViewProviderDraftAlt = ViewProviderDraftAlt
 class ViewProviderDraftPart(ViewProviderDraftAlt):
     """A view provider that displays a Part icon instead of a Draft icon.
 
-    The `getIcon` method is overriden to provide `Tree_Part.svg`.
+    The `getIcon` method is overridden to provide `Tree_Part.svg`.
     """
 
     def __init__(self, vobj):

--- a/src/Mod/Fem/femsolver/calculix/writer.py
+++ b/src/Mod/Fem/femsolver/calculix/writer.py
@@ -187,7 +187,7 @@ class FemInputWriterCcx(writerbase.FemInputWriter):
     # mesh
     def write_mesh(self, inpfile_split=None):
         # write mesh to file
-        element_param = 1  # hightest element order only
+        element_param = 1  # highest element order only
         group_param = False  # do not write mesh group data
         if inpfile_split is True:
             write_name = "femesh"

--- a/src/Mod/Mesh/App/Core/Segmentation.cpp
+++ b/src/Mod/Mesh/App/Core/Segmentation.cpp
@@ -201,7 +201,7 @@ CylinderSurfaceFit::CylinderSurfaceFit()
 
 /*!
  * \brief CylinderSurfaceFit::CylinderSurfaceFit
- * Set a pre-defined cylinder. Internal cylinder fits are not done, then.
+ * Set a predefined cylinder. Internal cylinder fits are not done, then.
  */
 CylinderSurfaceFit::CylinderSurfaceFit(const Base::Vector3f& b, const Base::Vector3f& a, float r)
     : basepoint(b)

--- a/src/Mod/Mesh/App/MeshTexture.h
+++ b/src/Mod/Mesh/App/MeshTexture.h
@@ -37,7 +37,7 @@ namespace Mesh
 /*! The MeshTexture class.
   This algorithm is useful to update the material after a mesh has been modified
   by removing points or facets. If the coordinates of points have changed or if
-  new points have been added then a pre-defined color will be set.
+  new points have been added then a predefined color will be set.
   @author Werner Mayer
  */
 class MeshExport MeshTexture

--- a/src/Tools/generateBase/generateDS.py
+++ b/src/Tools/generateBase/generateDS.py
@@ -3205,7 +3205,7 @@ Usage: python generateDS.py [ options ] <in_xsd_file>
 Options:
     -o <outfilename>         Output file name for data representation classes
     -s <subclassfilename>    Output file name for subclasses
-    -p <prefix>              Prefix string to be pre-pended to the class names
+    -p <prefix>              Prefix string to be prepended to the class names
     -n <mappingfilename>     Transform names with table in mappingfilename.
     -f                       Force creation of output files.  Do not ask.
     -a <namespaceabbrev>     Namespace abbreviation, e.g. "xsd:". Default = 'xs:'.


### PR DESCRIPTION
Found via codespell v1.17.0.dev0  
```
codespell -q 3 -L aci,ake,aline,alle,alledges,alocation,als,ang,anid,ba,beginn,behaviour,bloaded,byteorder,calculater,cancelled,cancelling,cas,cascade,centimetre,childs,colour,colours,commen,connexion,currenty,dof,doubleclick,dum,eiter,elemente,ende,feld,finde,findf,freez,hist,iff,indicies,initialisation,initialise,initialised,initialises,initialisiert,ist,kilometre,lod,mantatory,methode,metres,millimetre,modell,nd,noe,normale,normaly,nto,numer,oder,orgin,orginx,orginy,ot,pard,pres,programm,que,recurrance,rougly,seperator,serie,sinc,strack,substraction,te,thist,thru,tread,uint,unter,vertexes,wallthickness,whitespaces -S ./.git,*.po,*.ts,./ChangeLog.txt,./src/3rdParty,./src/Mod/Assembly/App/opendcm,./src/CXX,./src/zipios++,./src/Base/swig*,./src/Mod/Robot/App/kdl_cp,./src/Mod/Import/App/SCL,./src/WindowsInstaller,./src/Doc/FreeCAD.uml
```
