### PR TITLE
Draft: show the error message of the ToDo class in the terminal

### DIFF
--- a/src/Mod/Draft/draftutils/todo.py
+++ b/src/Mod/Draft/draftutils/todo.py
@@ -23,10 +23,11 @@
 # ***************************************************************************
 """Provides the ToDo class for the Draft Workbench.
 
-The ToDo class is used to delay the commit of commands for later execution.
+The `ToDo` class is used to delay the commit of commands for later execution.
 This is necessary when a GUI command needs to manipulate the 3D view
-in such a way that a callback would crash Coin.
-The ToDo class essentially calls `QtCore.QTimer.singleShot`
+in such a way that a callback would crash `Coin`.
+
+The `ToDo` class essentially calls `QtCore.QTimer.singleShot`
 to execute the instructions stored in internal lists.
 """
 ## @package todo
@@ -38,8 +39,8 @@ import sys
 import traceback
 from PySide import QtCore
 
-import FreeCAD
-import FreeCADGui
+import FreeCAD as App
+import FreeCADGui as Gui
 from draftutils.messages import _msg, _wrn, _err, _log
 
 __title__ = "FreeCAD Draft Workbench, Todo class"
@@ -59,7 +60,7 @@ class ToDo:
 
     Attributes
     ----------
-    itinerary : list of tuples
+    itinerary: list of tuples
         Each tuple is of the form `(name, arg)`.
         The `name` is a reference (pointer) to a function,
         and `arg` is the corresponding argument that is passed
@@ -70,7 +71,7 @@ class ToDo:
             name(arg)
             name()
 
-    commitlist : list of tuples
+    commitlist: list of tuples
         Each tuple is of the form `(name, command_list)`.
         The `name` is a string identifier or description of the commands
         that will be run, and `command_list` is a list of strings
@@ -82,21 +83,21 @@ class ToDo:
         and finally commits the transaction.
         ::
             command_list = ["command1", "command2", "..."]
-            FreeCAD.ActiveDocument.openTransaction(name)
-            FreeCADGui.doCommand("command1")
-            FreeCADGui.doCommand("command2")
-            FreeCADGui.doCommand("...")
-            FreeCAD.ActiveDocument.commitTransaction()
+            App.activeDocument().openTransaction(name)
+            Gui.doCommand("command1")
+            Gui.doCommand("command2")
+            Gui.doCommand("...")
+            App.activeDocument().commitTransaction()
 
         If `command_list` is a reference to a function
         the function is executed directly.
         ::
             command_list = function
-            FreeCAD.ActiveDocument.openTransaction(name)
+            App.activeDocument().openTransaction(name)
             function()
-            FreeCAD.ActiveDocument.commitTransaction()
+            App.activeDocument().commitTransaction()
 
-    afteritinerary : list of tuples
+    afteritinerary: list of tuples
         Each tuple is of the form `(name, arg)`.
         This list is used just like `itinerary`.
 
@@ -125,7 +126,7 @@ class ToDo:
                                                 todo.commitlist,
                                                 todo.afteritinerary))
         try:
-            for f, arg in todo.itinerary:
+            for f, arg in ToDo.itinerary:
                 try:
                     if _DEBUG_inner:
                         _msg("Debug: executing.\n"
@@ -144,10 +145,10 @@ class ToDo:
         except ReferenceError:
             _wrn("Debug: ToDo.doTasks: "
                  "queue contains a deleted object, skipping")
-        todo.itinerary = []
+        ToDo.itinerary = []
 
-        if todo.commitlist:
-            for name, func in todo.commitlist:
+        if ToDo.commitlist:
+            for name, func in ToDo.commitlist:
                 if six.PY2:
                     if isinstance(name, six.text_type):
                         name = name.encode("utf8")
@@ -156,13 +157,13 @@ class ToDo:
                          "name: {}\n".format(name))
                 try:
                     name = str(name)
-                    FreeCAD.ActiveDocument.openTransaction(name)
+                    App.activeDocument().openTransaction(name)
                     if isinstance(func, list):
                         for string in func:
-                            FreeCADGui.doCommand(string)
+                            Gui.doCommand(string)
                     else:
                         func()
-                    FreeCAD.ActiveDocument.commitTransaction()
+                    App.activeDocument().commitTransaction()
                 except Exception:
                     _log(traceback.format_exc())
                     _err(traceback.format_exc())
@@ -171,11 +172,11 @@ class ToDo:
                            "in {1}".format(sys.exc_info()[0], func))
                     _wrn(wrn)
             # Restack Draft screen widgets after creation
-            if hasattr(FreeCADGui, "Snapper"):
-                FreeCADGui.Snapper.restack()
-        todo.commitlist = []
+            if hasattr(Gui, "Snapper"):
+                Gui.Snapper.restack()
+        ToDo.commitlist = []
 
-        for f, arg in todo.afteritinerary:
+        for f, arg in ToDo.afteritinerary:
             try:
                 if _DEBUG_inner:
                     _msg("Debug: executing after.\n"
@@ -191,7 +192,7 @@ class ToDo:
                        "{0}\n"
                        "in {1}({2})".format(sys.exc_info()[0], f, arg))
                 _wrn(wrn)
-        todo.afteritinerary = []
+        ToDo.afteritinerary = []
 
     @staticmethod
     def delay(f, arg):
@@ -209,13 +210,13 @@ class ToDo:
 
         Parameters
         ----------
-        f : function reference
+        f: function reference
             A reference (pointer) to a Python command
             which can be executed directly.
             ::
                 f()
 
-        arg : argument reference
+        arg: argument reference
             A reference (pointer) to the argument to the `f` function.
             ::
                 f(arg)
@@ -223,9 +224,9 @@ class ToDo:
         if _DEBUG:
             _msg("Debug: delaying.\n"
                  "function: {}\n".format(f))
-        if todo.itinerary == []:
-            QtCore.QTimer.singleShot(0, todo.doTasks)
-        todo.itinerary.append((f, arg))
+        if ToDo.itinerary == []:
+            QtCore.QTimer.singleShot(0, ToDo.doTasks)
+        ToDo.itinerary.append((f, arg))
 
     @staticmethod
     def delayCommit(cl):
@@ -242,7 +243,7 @@ class ToDo:
 
         Parameters
         ----------
-        cl : list of tuples
+        cl: list of tuples
             Each tuple is of the form `(name, command_list)`.
             The `name` is a string identifier or description of the commands
             that will be run, and `command_list` is a list of strings
@@ -253,8 +254,8 @@ class ToDo:
         if _DEBUG:
             _msg("Debug: delaying commit.\n"
                  "commitlist: {}\n".format(cl))
-        QtCore.QTimer.singleShot(0, todo.doTasks)
-        todo.commitlist = cl
+        QtCore.QTimer.singleShot(0, ToDo.doTasks)
+        ToDo.commitlist = cl
 
     @staticmethod
     def delayAfter(f, arg):
@@ -275,9 +276,11 @@ class ToDo:
         if _DEBUG:
             _msg("Debug: delaying after.\n"
                  "function: {}\n".format(f))
-        if todo.afteritinerary == []:
-            QtCore.QTimer.singleShot(0, todo.doTasks)
-        todo.afteritinerary.append((f, arg))
+        if ToDo.afteritinerary == []:
+            QtCore.QTimer.singleShot(0, ToDo.doTasks)
+        ToDo.afteritinerary.append((f, arg))
 
 
+# In the past, the class was in lowercase, so we provide a reference
+# to it in lowercase, to satisfy the usage of older modules.
 todo = ToDo

--- a/src/Mod/Draft/draftutils/todo.py
+++ b/src/Mod/Draft/draftutils/todo.py
@@ -40,7 +40,7 @@ from PySide import QtCore
 
 import FreeCAD
 import FreeCADGui
-from draftutils.messages import _msg, _wrn, _log
+from draftutils.messages import _msg, _wrn, _err, _log
 
 __title__ = "FreeCAD Draft Workbench, Todo class"
 __author__ = "Yorik van Havre <yorik@uncreated.net>"
@@ -136,6 +136,7 @@ class ToDo:
                         f()
                 except Exception:
                     _log(traceback.format_exc())
+                    _err(traceback.format_exc())
                     wrn = ("ToDo.doTasks, Unexpected error:\n"
                            "{0}\n"
                            "in {1}({2})".format(sys.exc_info()[0], f, arg))
@@ -164,6 +165,7 @@ class ToDo:
                     FreeCAD.ActiveDocument.commitTransaction()
                 except Exception:
                     _log(traceback.format_exc())
+                    _err(traceback.format_exc())
                     wrn = ("ToDo.doTasks, Unexpected error:\n"
                            "{0}\n"
                            "in {1}".format(sys.exc_info()[0], func))
@@ -184,6 +186,7 @@ class ToDo:
                     f()
             except Exception:
                 _log(traceback.format_exc())
+                _err(traceback.format_exc())
                 wrn = ("ToDo.doTasks, Unexpected error:\n"
                        "{0}\n"
                        "in {1}({2})".format(sys.exc_info()[0], f, arg))


### PR DESCRIPTION
The error is both sent to the log file and to the console instead of only the log.

This is helpful to troubleshoot problems with the delayed execution of commands, such as when testing a relatively broken version like d7a9f2ebf9.

---

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists