### PR TITLE
Draft: fix viewproviders for BSpline and Bezier curve

### DIFF
--- a/src/Mod/Draft/CMakeLists.txt
+++ b/src/Mod/Draft/CMakeLists.txt
@@ -113,6 +113,7 @@ SET(Draft_objects
 SET(Draft_view_providers
     draftviewproviders/__init__.py
     draftviewproviders/view_base.py
+    draftviewproviders/view_bezier.py
     draftviewproviders/view_bspline.py
     draftviewproviders/view_circulararray.py
     draftviewproviders/view_clone.py

--- a/src/Mod/Draft/CMakeLists.txt
+++ b/src/Mod/Draft/CMakeLists.txt
@@ -113,6 +113,7 @@ SET(Draft_objects
 SET(Draft_view_providers
     draftviewproviders/__init__.py
     draftviewproviders/view_base.py
+    draftviewproviders/view_bspline.py
     draftviewproviders/view_circulararray.py
     draftviewproviders/view_clone.py
     draftviewproviders/view_facebinder.py

--- a/src/Mod/Draft/draftmake/make_bezcurve.py
+++ b/src/Mod/Draft/draftmake/make_bezcurve.py
@@ -36,8 +36,7 @@ from draftutils.translate import translate
 
 from draftobjects.bezcurve import BezCurve
 if App.GuiUp:
-    # from draftviewproviders.view_bezcurve import ViewProviderBezCurve
-    from draftviewproviders.view_wire import ViewProviderWire
+    from draftviewproviders.view_bezier import ViewProviderBezCurve
 
 
 def make_bezcurve(pointslist, closed=False, placement=None, face=None, support=None, degree=None):

--- a/src/Mod/Draft/draftmake/make_bspline.py
+++ b/src/Mod/Draft/draftmake/make_bspline.py
@@ -35,9 +35,9 @@ from draftutils.utils import type_check
 from draftutils.translate import translate
 
 from draftobjects.bspline import BSpline
+
 if App.GuiUp:
-    # from draftviewproviders.view_bspline import ViewProviderBSpline
-    from draftviewproviders.view_wire import ViewProviderWire
+    from draftviewproviders.view_bspline import ViewProviderBSpline
 
 
 def make_bspline(pointslist, closed=False, placement=None, face=None, support=None):

--- a/src/Mod/Draft/draftviewproviders/view_bezier.py
+++ b/src/Mod/Draft/draftviewproviders/view_bezier.py
@@ -1,0 +1,38 @@
+# ***************************************************************************
+# *   Copyright (c) 2020 Eliud Cabrera Castillo <e.cabrera-castillo@tum.de> *
+# *                                                                         *
+# *   This program is free software; you can redistribute it and/or modify  *
+# *   it under the terms of the GNU Lesser General Public License (LGPL)    *
+# *   as published by the Free Software Foundation; either version 2 of     *
+# *   the License, or (at your option) any later version.                   *
+# *   for detail see the LICENCE text file.                                 *
+# *                                                                         *
+# *   This program is distributed in the hope that it will be useful,       *
+# *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+# *   GNU Library General Public License for more details.                  *
+# *                                                                         *
+# *   You should have received a copy of the GNU Library General Public     *
+# *   License along with this program; if not, write to the Free Software   *
+# *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
+# *   USA                                                                   *
+# *                                                                         *
+# ***************************************************************************
+"""Provides the view provider code for Bezier curve objects.
+
+At the moment this view provider subclasses the Wire view provider,
+and behaves the same as it. In the future this could change
+if another behavior is desired.
+"""
+## @package view_bezier
+# \ingroup DRAFT
+# \brief Provides the view provider code for Bezier curve objects.
+
+from draftviewproviders.view_wire import ViewProviderWire
+
+
+class ViewProviderBezCurve(ViewProviderWire):
+    """The view provider for the Bezier curve object."""
+
+    def __init__(self, vobj):
+        super(ViewProviderBezCurve, self).__init__(vobj)

--- a/src/Mod/Draft/draftviewproviders/view_bspline.py
+++ b/src/Mod/Draft/draftviewproviders/view_bspline.py
@@ -1,0 +1,38 @@
+# ***************************************************************************
+# *   Copyright (c) 2020 Eliud Cabrera Castillo <e.cabrera-castillo@tum.de> *
+# *                                                                         *
+# *   This program is free software; you can redistribute it and/or modify  *
+# *   it under the terms of the GNU Lesser General Public License (LGPL)    *
+# *   as published by the Free Software Foundation; either version 2 of     *
+# *   the License, or (at your option) any later version.                   *
+# *   for detail see the LICENCE text file.                                 *
+# *                                                                         *
+# *   This program is distributed in the hope that it will be useful,       *
+# *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+# *   GNU Library General Public License for more details.                  *
+# *                                                                         *
+# *   You should have received a copy of the GNU Library General Public     *
+# *   License along with this program; if not, write to the Free Software   *
+# *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
+# *   USA                                                                   *
+# *                                                                         *
+# ***************************************************************************
+"""Provides the view provider code for BSpline objects.
+
+At the moment this view provider subclasses the Wire view provider,
+and behaves the same as it. In the future this could change
+if another behavior is desired.
+"""
+## @package view_bspline
+# \ingroup DRAFT
+# \brief Provides the view provider code for BSpline objects.
+
+from draftviewproviders.view_wire import ViewProviderWire
+
+
+class ViewProviderBSpline(ViewProviderWire):
+    """The view provider for the BSpline object."""
+
+    def __init__(self, vobj):
+        super(ViewProviderBSpline, self).__init__(vobj)


### PR DESCRIPTION
After #3388 some view providers for BSpline objects and Bezier curves weren't properly updated. This should solve the issues.

Older objects will load the `_ViewProviderWire` class (its new name is `ViewProviderWire`).

Newer objects will use `ViewProviderBSpline` and `ViewProviderBezCurve`, which currently just subclass `ViewProviderWire`.

It partially reverses the quick fix in d7a9f2ebf9.

Forum thread: [Draft broken on latest master](https://forum.freecadweb.org/viewtopic.php?f=23&t=45838), [[Discussion] Splitting Draft tools into their own modules](https://forum.freecadweb.org/viewtopic.php?f=23&t=38593&start=60#p393152).

---

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists