### PR TITLE
[TD]fix crash loading old development models

### DIFF
--- a/src/Mod/TechDraw/Gui/QGILeaderLine.cpp
+++ b/src/Mod/TechDraw/Gui/QGILeaderLine.cpp
@@ -359,7 +359,12 @@ void QGILeaderLine::draw()
     if ( vp == nullptr ) {
         return;
     }
+
+    double scale = 1.0;
     TechDraw::DrawView* parent = featLeader->getBaseView();
+    if (parent != nullptr) {
+        scale = parent->getScale();
+    }
 
     if (m_editPath->inEdit()) {
         return;
@@ -373,7 +378,6 @@ void QGILeaderLine::draw()
     }
     m_lineStyle = (Qt::PenStyle) vp->LineStyle.getValue();
 
-    double scale = parent->getScale();
     double baseScale = featLeader->getBaseScale();
     double x = Rez::guiX(featLeader->X.getValue());
     double y = - Rez::guiX(featLeader->Y.getValue());


### PR DESCRIPTION
- LeaderLine behaviour changed during development of v19.  older models with unparented leaders may crash.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
