### PR TITLE
Arch: fix wall's addDefault call

### DIFF
--- a/src/Mod/Arch/ArchWall.py
+++ b/src/Mod/Arch/ArchWall.py
@@ -392,10 +392,10 @@ class _CommandWall:
                             if self.AUTOJOIN:
                                 FreeCADGui.doCommand('Arch.addComponents(FreeCAD.ActiveDocument.'+FreeCAD.ActiveDocument.Objects[-1].Name+',FreeCAD.ActiveDocument.'+w.Name+')')
                     else:
-                        self.addDefault(l)
+                        self.addDefault()
                 else:
                     # add new wall as addition to the first existing one
-                    self.addDefault(l)
+                    self.addDefault()
                     if self.AUTOJOIN:
                         FreeCADGui.doCommand('Arch.addComponents(FreeCAD.ActiveDocument.'+FreeCAD.ActiveDocument.Objects[-1].Name+',FreeCAD.ActiveDocument.'+self.existing[0].Name+')')
             FreeCAD.ActiveDocument.commitTransaction()


### PR DESCRIPTION
A previous fix was in 8d4ed61782, but some calls to `addDefault` were not changed.

Forum thread: [[ Bug ] Problem with Arch_Wall when hovering a wall: gui_snapper.py issue?](https://forum.freecadweb.org/viewtopic.php?f=23&t=45918)

---

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists
