### PR TITLE
partdesign: fix failing tapered hole test

### DIFF
--- a/src/Mod/PartDesign/PartDesignTests/TestHole.py
+++ b/src/Mod/PartDesign/PartDesignTests/TestHole.py
@@ -68,7 +68,7 @@ class TestHole(unittest.TestCase):
     def testTaperedHole(self):
         self.Hole.Diameter = 6
         self.Hole.Depth = 5
-        self.Hole.TaperedAngle = 45
+        self.Hole.TaperedAngle = 60
         self.Hole.ThreadType = 0
         self.Hole.HoleCutType = 0
         self.Hole.DepthType = 0


### PR DESCRIPTION
The given parameters return an invalid shape. This fails with occt7.4 but doesn't with occt7.3. If the angle is 45 degree the cone is self-intersecting as Hole.Depth > Hole.Diameter/2. Changing the Hole.TaperedAngle to 60 degree solves this issue.

![Bildschirmfoto von 2020-05-03 07-32-49](https://user-images.githubusercontent.com/5084704/80902472-66b09e00-8d12-11ea-81f5-1efe6ebe81c9.png)

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
