### PR TITLE
Path: Fix `extrude()` fails with zero vector

### DIFF
--- a/src/Mod/Path/PathScripts/PathProfileEdges.py
+++ b/src/Mod/Path/PathScripts/PathProfileEdges.py
@@ -197,6 +197,11 @@ class ObjectProfile(PathProfileBase.ObjectProfile):
         sdv = wBB.ZMax
         fdv = obj.FinalDepth.Value
         extLenFwd = sdv - fdv
+        if extLenFwd <= 0.0:
+            msg = translate('PathProfile',
+                            'For open edges, select top edge and set Final Depth manually.')
+            FreeCAD.Console.PrintError(msg + '\n')
+            return False
         WIRE = flatWire.Wires[0]
         numEdges = len(WIRE.Edges)
 


### PR DESCRIPTION
Add error message and return empty path for ProfileEdges open-edge case. 

Fix for `extrude()` vector is zero as identified in multiple forum threads, [OCC Problem with Ubuntu](https://forum.freecadweb.org/viewtopic.php?f=10&t=45721) and [What causes BRepSweep_Translation::Constructor errors](https://forum.freecadweb.org/viewtopic.php?style=3&f=15&t=45622).  There might be a third thread tangent to this error.  

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
