### PR TITLE
Fix various typos

### DIFF
--- a/src/Mod/AddonManager/addonmanager_workers.py
+++ b/src/Mod/AddonManager/addonmanager_workers.py
@@ -327,7 +327,7 @@ class FillMacroListWorker(QtCore.QThread):
                 self.info_label_signal.emit("Git binary not installed! Cannot retrieve macros from Git")
                 import platform
                 if platform.system() == 'Windows':
-                    FreeCAD.Console.PrintWarning(translate('AddonsInstaller', 'Git exectuable not found. Cannot retrieve macros using git, fallback to using the Wiki')+"\n")
+                    FreeCAD.Console.PrintWarning(translate('AddonsInstaller', 'Git executable not found. Cannot retrieve macros using git, fallback to using the Wiki')+"\n")
                 else:
                     FreeCAD.Console.PrintWarning(translate('AddonsInstaller', 'Git binary not found.  Cannot retrieve macros using git, fallback to using the Wiki')+"\n")
                 git = None

--- a/src/Mod/Part/AttachmentEditor/TaskAttachmentEditor.py
+++ b/src/Mod/Part/AttachmentEditor/TaskAttachmentEditor.py
@@ -599,7 +599,7 @@ class AttachmentEditorTaskPanel(FrozenClass):
                                               .format(  mode=   self.attacher.getModeInfo(self.getCurrentMode())['UserFriendlyName']  )    )
                 if PlacementsFuzzyCompare(self.obj.Placement, new_plm) == False:
                     # assign only if placement changed. this avoids touching the object
-                    # when entering and extiting dialog without changing anything
+                    # when entering and exiting dialog without changing anything
                     self.obj.Placement = new_plm
         except Exception as err:
             self.form.message.setText(_translate('AttachmentEditor',"Error: {err}",None).format(err= str(err)))

--- a/src/Mod/Path/Gui/Resources/panels/ToolBitLibraryEdit.ui
+++ b/src/Mod/Path/Gui/Resources/panels/ToolBitLibraryEdit.ui
@@ -346,7 +346,7 @@
      <item>
       <widget class="QPushButton" name="toolEnumerate">
        <property name="toolTip">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Assigne numbers to each Tool Bit according to its current position in the library. The first Tool Bit is assigned the ID 1.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Assign numbers to each Tool Bit according to its current position in the library. The first Tool Bit is assigned the ID 1.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
        </property>
        <property name="text">
         <string>Enumerate</string>


### PR DESCRIPTION
Found via codespell v1.17.0.dev0  
```
codespell -q 3 -L aci,ake,aline,alle,alledges,alocation,als,ang,anid,ba,beginn,behaviour,bloaded,byteorder,calculater,cancelled,cancelling,cas,cascade,centimetre,childs,colour,colours,commen,connexion,currenty,dof,doubleclick,dum,eiter,elemente,ende,feld,finde,findf,freez,hist,iff,indicies,initialisation,initialise,initialised,initialises,initialisiert,ist,kilometre,lod,mantatory,methode,metres,millimetre,modell,nd,noe,normale,normaly,nto,numer,oder,orgin,orginx,orginy,ot,pard,pres,programm,que,recurrance,rougly,seperator,serie,sinc,strack,substraction,te,thist,thru,tread,uint,unter,vertexes,wallthickness,whitespaces -S ./.git,*.po,*.ts,./ChangeLog.txt,./src/3rdParty,./src/Mod/Assembly/App/opendcm,./src/CXX,./src/zipios++,./src/Base/swig*,./src/Mod/Robot/App/kdl_cp,./src/Mod/Import/App/SCL,./src/WindowsInstaller,./src/Doc/FreeCAD.uml
```