### PR TITLE
[AddonManager] Backout of Git Binary Lookup

### DIFF
--- a/src/Mod/AddonManager/addonmanager_utilities.py
+++ b/src/Mod/AddonManager/addonmanager_utilities.py
@@ -314,16 +314,3 @@ def getRepoUrl(text):
         return "https://framagit.org/freecad-france/mooc-workbench"
     print("Debug: addonmanager_utilities.getRepoUrl: Unkable to find repo:",text)
     return None
-
-
-def checkGitBinary():
-
-    "Checks if Git binary is available"
-
-    import platform
-    import distutils.spawn
-    if platform.system() == 'Windows':
-        git_exe = distutils.spawn.find_executable("git.exe")
-    else: #Linux or Mac
-        git_exe = 'git'
-    return git_exe


### PR DESCRIPTION
Apologies Yorik, apparently there's too many different ways to install the later Git versions certainly on Windows that there's no consistency picking up the version info, hence backing out that part of the previous https://github.com/FreeCAD/FreeCAD/pull/3420

See https://forum.freecadweb.org/viewtopic.php?f=10&t=37394&start=70#p394952

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
