### PR TITLE
[Path] - Fixes/toolbit simulation

### DIFF
--- a/src/Mod/Path/PathScripts/PathSimulatorGui.py
+++ b/src/Mod/Path/PathScripts/PathSimulatorGui.py
@@ -125,13 +125,17 @@ class PathSimulation:
         except Exception:
             self.tool = None
 
-        # if hasattr(self.operation, "ToolController"):
-        #     self.tool = self.operation.ToolController.Tool
         if (self.tool is not None):
-            toolProf = self.CreateToolProfile(self.tool, Vector(0, 1, 0), Vector(0, 0, 0), float(self.tool.Diameter) / 2.0)
-            self.cutTool.Shape = Part.makeSolid(toolProf.revolve(Vector(0, 0, 0), Vector(0, 0, 1)))
+            if isinstance(self.tool, Path.Tool):
+                # handle legacy tools
+                toolProf = self.CreateToolProfile(self.tool, Vector(0, 1, 0), Vector(0, 0, 0), float(self.tool.Diameter) / 2.0)
+                self.cutTool.Shape = Part.makeSolid(toolProf.revolve(Vector(0, 0, 0), Vector(0, 0, 1)))
+            else:
+                # handle tool bits
+                self.cutTool.Shape = self.tool.Shape
+
             self.cutTool.ViewObject.show()
-            self.voxSim.SetCurrentTool(self.tool)
+            self.voxSim.SetToolShape(self.cutTool.Shape, 0.05 * self.accuracy)
         self.icmd = 0
         self.curpos = FreeCAD.Placement(self.initialPos, self.stdrot)
         # self.cutTool.Placement = FreeCAD.Placement(self.curpos, self.stdrot)

--- a/src/Mod/Path/PathScripts/PathSimulatorGui.py
+++ b/src/Mod/Path/PathScripts/PathSimulatorGui.py
@@ -134,6 +134,10 @@ class PathSimulation:
                 # handle tool bits
                 self.cutTool.Shape = self.tool.Shape
 
+            if not self.cutTool.Shape.isValid() or self.cutTool.Shape.isNull():
+                self.EndSimulation()
+                raise RuntimeError("Path Simulation: Error in tool geometry - {}".format(self.tool.Name)) 
+
             self.cutTool.ViewObject.show()
             self.voxSim.SetToolShape(self.cutTool.Shape, 0.05 * self.accuracy)
         self.icmd = 0

--- a/src/Mod/Path/PathSimulator/App/PathSim.cpp
+++ b/src/Mod/Path/PathSimulator/App/PathSim.cpp
@@ -33,7 +33,6 @@
 #include <Base/Console.h>
 
 #include "PathSim.h"
-//#include "VolSim.h"
 
 using namespace Base;
 using namespace PathSimulator;
@@ -54,69 +53,15 @@ PathSim::~PathSim()
 		delete m_tool;
 }
 
-
 void PathSim::BeginSimulation(Part::TopoShape * stock, float resolution)
 {
 	Base::BoundBox3d bbox = stock->getBoundBox();
 	m_stock = new cStock(bbox.MinX, bbox.MinY, bbox.MinZ, bbox.LengthX(), bbox.LengthY(), bbox.LengthZ(), resolution);
 }
 
-void PathSim::SetCurrentTool(Tool * tool)
+void PathSim::SetToolShape(const TopoDS_Shape& toolShape, float resolution)
 {
-	cSimTool::Type tp = cSimTool::FLAT;
-	float angle = 180;
-	switch (tool->Type)
-	{
-	case Tool::BALLENDMILL:
-		tp = cSimTool::ROUND;
-		break;
-
-	case Tool::CHAMFERMILL:
-		tp = cSimTool::CHAMFER;
-		angle = tool->CuttingEdgeAngle;
-		break;
-
-	case Tool::UNDEFINED:
-	case Tool::DRILL:
-		tp = cSimTool::CHAMFER;
-		angle = tool->CuttingEdgeAngle;
-        if (angle > 180)
-        {
-            angle = 180;
-        }
-		break;
-	case Tool::CENTERDRILL:
-		tp = cSimTool::CHAMFER;
-		angle = tool->CuttingEdgeAngle;
-        if (angle > 180)
-        {
-            angle = 180;
-        }
-		break;
-	case Tool::COUNTERSINK:
-	case Tool::COUNTERBORE:
-	case Tool::REAMER:
-	case Tool::TAP:
-	case Tool::ENDMILL:
-		tp = cSimTool::FLAT;
-		angle = 180;
-		break;
-	case Tool::SLOTCUTTER:
-	case Tool::CORNERROUND:
-	case Tool::ENGRAVER:
-		tp = cSimTool::CHAMFER;
-		angle = tool->CuttingEdgeAngle;
-        if (angle > 180)
-        {
-            angle = 180;
-        }
-		break;
-	default:
-		tp = cSimTool::FLAT;
-		angle = 180;
-		break;
-	}
-	m_tool = new cSimTool(tp, tool->Diameter / 2.0, angle);
+	m_tool = new cSimTool(toolShape, resolution);	
 }
 
 Base::Placement * PathSim::ApplyCommand(Base::Placement * pos, Command * cmd)

--- a/src/Mod/Path/PathSimulator/App/PathSim.h
+++ b/src/Mod/Path/PathSimulator/App/PathSim.h
@@ -31,7 +31,6 @@
 #include <TopoDS.hxx>
 #include <TopoDS_Shape.hxx>
 #include <Mod/Path/App/Command.h>
-#include <Mod/Path/App/Tooltable.h>
 #include <Mod/Part/App/TopoShape.h>
 #include "VolSim.h"
 
@@ -51,7 +50,7 @@ namespace PathSimulator
 			~PathSim();
             
 			void BeginSimulation(Part::TopoShape * stock, float resolution);
-			void SetCurrentTool(Tool * tool);
+			void SetToolShape(const TopoDS_Shape& toolShape, float resolution);
 			Base::Placement * ApplyCommand(Base::Placement * pos, Command * cmd);
 
 		public:

--- a/src/Mod/Path/PathSimulator/App/PathSimPy.xml
+++ b/src/Mod/Path/PathSimulator/App/PathSimPy.xml
@@ -23,12 +23,10 @@ Create a path simulator object\n</UserDocu>
 Start a simulation process on a box shape stock with given resolution\n</UserDocu>
       </Documentation>
     </Methode>
-    <Methode Name="SetCurrentTool">
+    <Methode Name="SetToolShape">
       <Documentation>
-        <UserDocu>
-          SetCurrentTool(tool):\n
-          Set the current Path Tool for the subsequent simulator operations.\n
-        </UserDocu>
+          <UserDocu>SetToolShape(shape):\n
+Set the shape of the tool to be used for simulation\n</UserDocu>
       </Documentation>
     </Methode>
     <Methode Name="GetResultMesh">

--- a/src/Mod/Path/PathSimulator/App/PathSimPyImp.cpp
+++ b/src/Mod/Path/PathSimulator/App/PathSimPyImp.cpp
@@ -69,13 +69,15 @@ PyObject* PathSimPy::BeginSimulation(PyObject * args, PyObject * kwds)
 	return Py_None;
 }
 
-PyObject* PathSimPy::SetCurrentTool(PyObject * args)
+PyObject* PathSimPy::SetToolShape(PyObject * args)
 {
-	PyObject *pObjTool;
-	if (!PyArg_ParseTuple(args, "O!", &(Path::ToolPy::Type), &pObjTool))
+	PyObject *pObjToolShape;
+	float resolution;
+	if (!PyArg_ParseTuple(args, "O!f", &(Part::TopoShapePy::Type), &pObjToolShape, &resolution))
 		return 0;
 	PathSim *sim = getPathSimPtr();
-	sim->SetCurrentTool(static_cast<Path::ToolPy*>(pObjTool)->getToolPtr());
+	const TopoDS_Shape& toolShape = static_cast<Part::TopoShapePy*>(pObjToolShape)->getTopoShapePtr()->getShape();
+	sim->SetToolShape(toolShape, resolution);
 	Py_IncRef(Py_None);
 	return Py_None;
 }

--- a/src/Mod/Path/PathSimulator/App/VolSim.cpp
+++ b/src/Mod/Path/PathSimulator/App/VolSim.cpp
@@ -731,34 +731,8 @@ cSimTool::cSimTool(const TopoDS_Shape& toolShape, float res){
 	pnt.x = 0; 
 	pnt.y = 0;
 	pnt.z = 0;
- 	
-	int radValue = (int)(radius / res) + 1;
-
-	// Measure the performance of the profile extraction
-	auto start = std::chrono::high_resolution_clock::now(); 
-
-	for (int x = 0; x < radValue; x++)
-	{
-		// find the face of the tool by checking z points accross the 
-		// radius to see if the point is inside the shape
-		pnt.x =  x * res;
-		bool inside = isInside(toolShape, pnt, res);
-
-		// move down until the point is outside the shape
-		while(inside && std::abs(pnt.z) < length ){
-			//Base::Console().Log("PathSim::BeginSimulation: Pnt Inside: X Pos %f\n", pnt.x);
-			pnt.z -= res;
-			inside = isInside(toolShape, pnt, res);
-		}
-		
-		// move up until the point is first inside the shape and record the position
-		while (!inside && pnt.z < length)
-		{
-			pnt.z += res;
-			inside = isInside(toolShape, pnt, res);
-
-			if (inside){
-				toolShapePoint shapePoint;
+	//float res = 0.025; // resolution
+	Base::Console().Log("PathSim::SetToolShape: res: %f\n", res);
 				shapePoint.radiusPos = pnt.x;
 				shapePoint.heightPos = pnt.z;
 				m_toolShape.push_back(shapePoint);
@@ -780,24 +754,25 @@ float cSimTool::GetToolProfileAt(float pos)  // pos is -1..1 location along the 
 	float radPos = std::abs(pos) * radius;
 	toolShapePoint test; test.radiusPos = radPos;
 	auto it = std::lower_bound(m_toolShape.begin(), m_toolShape.end(), test, toolShapePoint::less_than());
-	//float diff = std::abs(radPos - it->radiusPos);
+	float diff = std::abs(radPos - it->radiusPos);
 	
-	//if (diff > 0.05){
-	//	Base::Console().Log("requested pos: %f rad: %f diff: %f\n", radPos, it->radiusPos, diff);
-	//}
+	if (diff > 0.05){
+		Base::Console().Log("requested pos: %f rad: %f diff: %f\n", radPos, it->radiusPos, diff);
+	}
 
 	return it->heightPos;
 }
 
-bool cSimTool::isInside(const TopoDS_Shape& toolShape, Base::Vector3d pnt, float res)
+bool cSimTool::isInside(const TopoDS_Shape& toolShape, Base::Vector3d pnt)
 {
+    double tolerance = 0.011;
     bool checkFace = true;
     TopAbs_State stateIn = TopAbs_IN;
 
     try {
         BRepClass3d_SolidClassifier solidClassifier(toolShape);
         gp_Pnt vertex = gp_Pnt(pnt.x, pnt.y, pnt.z);
-        solidClassifier.Perform(vertex, res);
+        solidClassifier.Perform(vertex, tolerance);
         bool inside = (solidClassifier.State() == stateIn);
         if (checkFace && solidClassifier.IsOnAFace()){
             inside = true;
@@ -806,8 +781,6 @@ bool cSimTool::isInside(const TopoDS_Shape& toolShape, Base::Vector3d pnt, float
     	return inside;
    	 }catch (...) {
         return false;
-    }	
-
 }
 
 cVolSim::cVolSim() : stock(nullptr)

--- a/src/Mod/Path/PathSimulator/App/VolSim.cpp
+++ b/src/Mod/Path/PathSimulator/App/VolSim.cpp
@@ -731,8 +731,34 @@ cSimTool::cSimTool(const TopoDS_Shape& toolShape, float res){
 	pnt.x = 0; 
 	pnt.y = 0;
 	pnt.z = 0;
-	//float res = 0.025; // resolution
-	Base::Console().Log("PathSim::SetToolShape: res: %f\n", res);
+ 	
+	int radValue = (int)(radius / res) + 1;
+
+	// Measure the performance of the profile extraction
+	auto start = std::chrono::high_resolution_clock::now(); 
+
+	for (int x = 0; x < radValue; x++)
+	{
+		// find the face of the tool by checking z points accross the 
+		// radius to see if the point is inside the shape
+		pnt.x =  x * res;
+		bool inside = isInside(toolShape, pnt);
+
+		// move down until the point is outside the shape
+		while(inside && std::abs(pnt.z) < length ){
+			//Base::Console().Log("PathSim::BeginSimulation: Pnt Inside: X Pos %f\n", pnt.x);
+			pnt.z -= res;
+			inside = isInside(toolShape, pnt);
+		}
+		
+		// move up until the point is first inside the shape and record the position
+		while (!inside && pnt.z < length)
+		{
+			pnt.z += res;
+			inside = isInside(toolShape, pnt);
+
+			if (inside){
+				toolShapePoint shapePoint;
 				shapePoint.radiusPos = pnt.x;
 				shapePoint.heightPos = pnt.z;
 				m_toolShape.push_back(shapePoint);
@@ -754,11 +780,11 @@ float cSimTool::GetToolProfileAt(float pos)  // pos is -1..1 location along the 
 	float radPos = std::abs(pos) * radius;
 	toolShapePoint test; test.radiusPos = radPos;
 	auto it = std::lower_bound(m_toolShape.begin(), m_toolShape.end(), test, toolShapePoint::less_than());
-	float diff = std::abs(radPos - it->radiusPos);
+	//float diff = std::abs(radPos - it->radiusPos);
 	
-	if (diff > 0.05){
-		Base::Console().Log("requested pos: %f rad: %f diff: %f\n", radPos, it->radiusPos, diff);
-	}
+	//if (diff > 0.05){
+	//	Base::Console().Log("requested pos: %f rad: %f diff: %f\n", radPos, it->radiusPos, diff);
+	//}
 
 	return it->heightPos;
 }

--- a/src/Mod/Path/PathSimulator/App/VolSim.cpp
+++ b/src/Mod/Path/PathSimulator/App/VolSim.cpp
@@ -743,7 +743,7 @@ cSimTool::cSimTool(const TopoDS_Shape& toolShape, float res){
 	int radValue = (int)(radius / res) + 1;
 
 	// Measure the performance of the profile extraction
-	auto start = std::chrono::high_resolution_clock::now(); 
+	//auto start = std::chrono::high_resolution_clock::now(); 
 
 	for (int x = 0; x < radValue; x++)
 	{
@@ -754,7 +754,6 @@ cSimTool::cSimTool(const TopoDS_Shape& toolShape, float res){
 
 		// move down until the point is outside the shape
 		while(inside && std::abs(pnt.z) < length ){
-			//Base::Console().Log("PathSim::BeginSimulation: Pnt Inside: X Pos %f\n", pnt.x);
 			pnt.z -= res;
 			inside = isInside(toolShape, pnt, res);
 		}
@@ -770,16 +769,15 @@ cSimTool::cSimTool(const TopoDS_Shape& toolShape, float res){
 				shapePoint.radiusPos = pnt.x;
 				shapePoint.heightPos = pnt.z;
 				m_toolShape.push_back(shapePoint);
-				//Base::Console().Log("PathSim::BeginSimulation: Add height profile X: radius: %f height:  %f\n", pnt.x, pnt.z);
 				break;
 			}
 		}
 	}
 
 	// Report the performance of the profile extraction
-	auto stop = std::chrono::high_resolution_clock::now(); 
-	auto duration = std::chrono::duration_cast<std::chrono::microseconds>(stop - start);
-	Base::Console().Log("cSimTool::cSimTool - Tool Profile Extraction Took: %i ms\n", duration.count() / 1000);
+	//auto stop = std::chrono::high_resolution_clock::now(); 
+	//auto duration = std::chrono::duration_cast<std::chrono::microseconds>(stop - start);
+	//Base::Console().Log("cSimTool::cSimTool - Tool Profile Extraction Took: %i ms\n", duration.count() / 1000);
 
 }
 
@@ -788,11 +786,6 @@ float cSimTool::GetToolProfileAt(float pos)  // pos is -1..1 location along the 
 	float radPos = std::abs(pos) * radius;
 	toolShapePoint test; test.radiusPos = radPos;
 	auto it = std::lower_bound(m_toolShape.begin(), m_toolShape.end(), test, toolShapePoint::less_than());
-	//float diff = std::abs(radPos - it->radiusPos);
-	
-	//if (diff > 0.05){
-	//	Base::Console().Log("requested pos: %f rad: %f diff: %f\n", radPos, it->radiusPos, diff);
-	//}
 
 	return it->heightPos;
 }
@@ -809,11 +802,11 @@ bool cSimTool::isInside(const TopoDS_Shape& toolShape, Base::Vector3d pnt, float
         bool inside = (solidClassifier.State() == stateIn);
         if (checkFace && solidClassifier.IsOnAFace()){
             inside = true;
-			//Base::Console().Log("PathSim::isInside: Touching Face: True\n");
 		}
     	return inside;
    	 }catch (...) {
         return false;
+	}
 }
 
 cVolSim::cVolSim() : stock(nullptr)

--- a/src/Mod/Path/PathSimulator/App/VolSim.cpp
+++ b/src/Mod/Path/PathSimulator/App/VolSim.cpp
@@ -789,16 +789,15 @@ float cSimTool::GetToolProfileAt(float pos)  // pos is -1..1 location along the 
 	return it->heightPos;
 }
 
-bool cSimTool::isInside(const TopoDS_Shape& toolShape, Base::Vector3d pnt)
+bool cSimTool::isInside(const TopoDS_Shape& toolShape, Base::Vector3d pnt, float res)
 {
-    double tolerance = 0.011;
     bool checkFace = true;
     TopAbs_State stateIn = TopAbs_IN;
 
     try {
         BRepClass3d_SolidClassifier solidClassifier(toolShape);
         gp_Pnt vertex = gp_Pnt(pnt.x, pnt.y, pnt.z);
-        solidClassifier.Perform(vertex, tolerance);
+        solidClassifier.Perform(vertex, res);
         bool inside = (solidClassifier.State() == stateIn);
         if (checkFace && solidClassifier.IsOnAFace()){
             inside = true;

--- a/src/Mod/Path/PathSimulator/App/VolSim.cpp
+++ b/src/Mod/Path/PathSimulator/App/VolSim.cpp
@@ -780,11 +780,11 @@ float cSimTool::GetToolProfileAt(float pos)  // pos is -1..1 location along the 
 	float radPos = std::abs(pos) * radius;
 	toolShapePoint test; test.radiusPos = radPos;
 	auto it = std::lower_bound(m_toolShape.begin(), m_toolShape.end(), test, toolShapePoint::less_than());
-	float diff = std::abs(radPos - it->radiusPos);
+	//float diff = std::abs(radPos - it->radiusPos);
 	
-	if (diff > 0.05){
-		Base::Console().Log("requested pos: %f rad: %f diff: %f\n", radPos, it->radiusPos, diff);
-	}
+	//if (diff > 0.05){
+	//	Base::Console().Log("requested pos: %f rad: %f diff: %f\n", radPos, it->radiusPos, diff);
+	//}
 
 	return it->heightPos;
 }

--- a/src/Mod/Path/PathSimulator/App/VolSim.cpp
+++ b/src/Mod/Path/PathSimulator/App/VolSim.cpp
@@ -783,11 +783,14 @@ cSimTool::cSimTool(const TopoDS_Shape& toolShape, float res){
 
 float cSimTool::GetToolProfileAt(float pos)  // pos is -1..1 location along the radius of the tool (0 is center)
 {
-	float radPos = std::abs(pos) * radius;
-	toolShapePoint test; test.radiusPos = radPos;
-	auto it = std::lower_bound(m_toolShape.begin(), m_toolShape.end(), test, toolShapePoint::less_than());
-
-	return it->heightPos;
+	try{
+		float radPos = std::abs(pos) * radius;
+		toolShapePoint test; test.radiusPos = radPos;
+		auto it = std::lower_bound(m_toolShape.begin(), m_toolShape.end(), test, toolShapePoint::less_than());
+		return it->heightPos;
+	}catch(...){
+		return 0;
+	}
 }
 
 bool cSimTool::isInside(const TopoDS_Shape& toolShape, Base::Vector3d pnt, float res)

--- a/src/Mod/Path/PathSimulator/App/VolSim.cpp
+++ b/src/Mod/Path/PathSimulator/App/VolSim.cpp
@@ -23,6 +23,7 @@
 #include "PreCompiled.h"
 #include <Base/Console.h>
 
+#include <BRepCheck_Analyzer.hxx>
 #include <BRepClass3d_SolidClassifier.hxx>
 #include <gp_Pnt.hxx>
 
@@ -717,7 +718,14 @@ void Point3D::UpdateCmd(Path::Command & cmd)
 // Simulation tool
 //************************************************************************************************************
 cSimTool::cSimTool(const TopoDS_Shape& toolShape, float res){ 
-	
+
+	BRepCheck_Analyzer aChecker(toolShape);
+    bool shapeIsValid = aChecker.IsValid() ? true : false;
+
+	if(!shapeIsValid){
+		throw Base::RuntimeError("Path Simulation: Error in tool geometry");
+	}
+
 	Bnd_Box boundBox;
     BRepBndLib::Add(toolShape, boundBox);
 

--- a/src/Mod/Path/PathSimulator/App/VolSim.cpp
+++ b/src/Mod/Path/PathSimulator/App/VolSim.cpp
@@ -780,24 +780,25 @@ float cSimTool::GetToolProfileAt(float pos)  // pos is -1..1 location along the 
 	float radPos = std::abs(pos) * radius;
 	toolShapePoint test; test.radiusPos = radPos;
 	auto it = std::lower_bound(m_toolShape.begin(), m_toolShape.end(), test, toolShapePoint::less_than());
-	//float diff = std::abs(radPos - it->radiusPos);
+	float diff = std::abs(radPos - it->radiusPos);
 	
-	//if (diff > 0.05){
-	//	Base::Console().Log("requested pos: %f rad: %f diff: %f\n", radPos, it->radiusPos, diff);
-	//}
+	if (diff > 0.05){
+		Base::Console().Log("requested pos: %f rad: %f diff: %f\n", radPos, it->radiusPos, diff);
+	}
 
 	return it->heightPos;
 }
 
-bool cSimTool::isInside(const TopoDS_Shape& toolShape, Base::Vector3d pnt, float res)
+bool cSimTool::isInside(const TopoDS_Shape& toolShape, Base::Vector3d pnt)
 {
+    double tolerance = 0.011;
     bool checkFace = true;
     TopAbs_State stateIn = TopAbs_IN;
 
     try {
         BRepClass3d_SolidClassifier solidClassifier(toolShape);
         gp_Pnt vertex = gp_Pnt(pnt.x, pnt.y, pnt.z);
-        solidClassifier.Perform(vertex, res);
+        solidClassifier.Perform(vertex, tolerance);
         bool inside = (solidClassifier.State() == stateIn);
         if (checkFace && solidClassifier.IsOnAFace()){
             inside = true;

--- a/src/Mod/Path/PathSimulator/App/VolSim.cpp
+++ b/src/Mod/Path/PathSimulator/App/VolSim.cpp
@@ -726,15 +726,11 @@ cSimTool::cSimTool(const TopoDS_Shape& toolShape, float res){
 	boundBox.Get(xMin, yMin, zMin, xMax, yMax, zMax);
 	radius = (xMax - xMin) / 2;
 	length = zMax - zMin;
-	// Report the size of the bounding box
-	//Base::Console().Log("PathSim::SetToolShape: radius: %f  length: %f\n", radius, length);
 
 	Base::Vector3d pnt; 
 	pnt.x = 0; 
 	pnt.y = 0;
 	pnt.z = 0;
-	//float res = 0.025; // resolution
-	Base::Console().Log("PathSim::SetToolShape: res: %f\n", res);
  	
 	int radValue = (int)(radius / res) + 1;
 
@@ -784,11 +780,11 @@ float cSimTool::GetToolProfileAt(float pos)  // pos is -1..1 location along the 
 	float radPos = std::abs(pos) * radius;
 	toolShapePoint test; test.radiusPos = radPos;
 	auto it = std::lower_bound(m_toolShape.begin(), m_toolShape.end(), test, toolShapePoint::less_than());
-	float diff = std::abs(radPos - it->radiusPos);
+	//float diff = std::abs(radPos - it->radiusPos);
 	
-	if (diff > 0.05){
-		Base::Console().Log("requested pos: %f rad: %f diff: %f\n", radPos, it->radiusPos, diff);
-	}
+	//if (diff > 0.05){
+	//	Base::Console().Log("requested pos: %f rad: %f diff: %f\n", radPos, it->radiusPos, diff);
+	//}
 
 	return it->heightPos;
 }

--- a/src/Mod/Path/PathSimulator/App/VolSim.cpp
+++ b/src/Mod/Path/PathSimulator/App/VolSim.cpp
@@ -742,20 +742,20 @@ cSimTool::cSimTool(const TopoDS_Shape& toolShape, float res){
 		// find the face of the tool by checking z points accross the 
 		// radius to see if the point is inside the shape
 		pnt.x =  x * res;
-		bool inside = isInside(toolShape, pnt);
+		bool inside = isInside(toolShape, pnt, res);
 
 		// move down until the point is outside the shape
 		while(inside && std::abs(pnt.z) < length ){
 			//Base::Console().Log("PathSim::BeginSimulation: Pnt Inside: X Pos %f\n", pnt.x);
 			pnt.z -= res;
-			inside = isInside(toolShape, pnt);
+			inside = isInside(toolShape, pnt, res);
 		}
 		
 		// move up until the point is first inside the shape and record the position
 		while (!inside && pnt.z < length)
 		{
 			pnt.z += res;
-			inside = isInside(toolShape, pnt);
+			inside = isInside(toolShape, pnt, res);
 
 			if (inside){
 				toolShapePoint shapePoint;
@@ -789,16 +789,15 @@ float cSimTool::GetToolProfileAt(float pos)  // pos is -1..1 location along the 
 	return it->heightPos;
 }
 
-bool cSimTool::isInside(const TopoDS_Shape& toolShape, Base::Vector3d pnt)
+bool cSimTool::isInside(const TopoDS_Shape& toolShape, Base::Vector3d pnt, float res)
 {
-    double tolerance = 0.011;
     bool checkFace = true;
     TopAbs_State stateIn = TopAbs_IN;
 
     try {
         BRepClass3d_SolidClassifier solidClassifier(toolShape);
         gp_Pnt vertex = gp_Pnt(pnt.x, pnt.y, pnt.z);
-        solidClassifier.Perform(vertex, tolerance);
+        solidClassifier.Perform(vertex, res);
         bool inside = (solidClassifier.State() == stateIn);
         if (checkFace && solidClassifier.IsOnAFace()){
             inside = true;

--- a/src/Mod/Path/PathSimulator/App/VolSim.h
+++ b/src/Mod/Path/PathSimulator/App/VolSim.h
@@ -104,7 +104,7 @@ public:
 	~cSimTool() {}
 
 	float GetToolProfileAt(float pos);
-	bool isInside(const TopoDS_Shape& toolShape, Base::Vector3d pnt);
+	bool isInside(const TopoDS_Shape& toolShape, Base::Vector3d pnt, float res);
 
 	std::vector< toolShapePoint > m_toolShape;
 	float radius;

--- a/src/Mod/Path/PathSimulator/App/VolSim.h
+++ b/src/Mod/Path/PathSimulator/App/VolSim.h
@@ -34,6 +34,18 @@
 #define SIM_TESSEL_TOP		1
 #define SIM_TESSEL_BOT		2
 #define SIM_WALK_RES		0.6   // step size in pixel units (to make sure all pixels in the path are visited)
+
+struct toolShapePoint {
+  float radiusPos;
+  float heightPos;
+  
+  struct less_than{
+  	bool operator()(const toolShapePoint &a, const toolShapePoint &b){
+    	return a.radiusPos < b.radiusPos;
+			}
+	};
+};
+
 struct Point3D
 {
 	Point3D() : x(0), y(0), z(0), sina(0), cosa(0) {}
@@ -88,22 +100,15 @@ struct cLineSegment
 class cSimTool
 {
 public:
-	enum Type {
-		FLAT = 0,
-		CHAMFER,
-		ROUND
-	};
-	cSimTool() : type(FLAT), radius(0), tipAngle(0), dradius(0), chamRatio(0) {}
-	cSimTool(Type t, float rad, float tipang = 180) : type(t), radius(rad), tipAngle(tipang) { InitTool(); }
+    cSimTool(const TopoDS_Shape& toolShape, float res);
 	~cSimTool() {}
-	void InitTool();
 
-	Type type;
-	float radius;
-	float tipAngle;
-	float dradius;
-	float chamRatio;
 	float GetToolProfileAt(float pos);
+	bool isInside(const TopoDS_Shape& toolShape, Base::Vector3d pnt);
+
+	std::vector< toolShapePoint > m_toolShape;
+	float radius;
+	float length;
 };
 
 template <class T>
@@ -130,7 +135,6 @@ private:
 	T *data;
 	int height;
 };
-
 
 class cStock
 {


### PR DESCRIPTION
This PR adds the ability to use toolbits for Path Simulation.

Legacy tools of type Path.Tool are represented mathematically in simulation, by describing the height of the tool face at -1 to 1 of the tool radius. This PR adds a method to extract the shape data from the tool and toolbit shape by testing if points on the face are inside or outside the shape.

The performance of the shape extraction is currently printed to the report view for testing. This will be removed in a further PR, prior to release of 0.19

fixes #4326 - https://tracker.freecadweb.org/view.php?id=4326
