### PR TITLE
Draft: improve descriptions in READMEs and __init__ files

### DIFF
--- a/src/Mod/Draft/CMakeLists.txt
+++ b/src/Mod/Draft/CMakeLists.txt
@@ -95,6 +95,7 @@ SET(Draft_make_functions
     draftmake/make_sketch.py
     draftmake/make_wire.py
     draftmake/make_wpproxy.py
+    draftmake/README.md
 )
 
 SET(Draft_objects

--- a/src/Mod/Draft/CMakeLists.txt
+++ b/src/Mod/Draft/CMakeLists.txt
@@ -67,13 +67,14 @@ SET(Draft_functions
     draftfunctions/fuse.py
     draftfunctions/heal.py
     draftfunctions/join.py
-    draftfunctions/mirror.py    
-    draftfunctions/move.py    
-    draftfunctions/offset.py    
-    draftfunctions/rotate.py    
-    draftfunctions/scale.py    
-    draftfunctions/split.py    
-    draftfunctions/upgrade.py    
+    draftfunctions/mirror.py
+    draftfunctions/move.py
+    draftfunctions/offset.py
+    draftfunctions/rotate.py
+    draftfunctions/scale.py
+    draftfunctions/split.py
+    draftfunctions/upgrade.py
+    draftfunctions/README.md
 )
 
 SET(Draft_make_functions

--- a/src/Mod/Draft/draftfunctions/README.md
+++ b/src/Mod/Draft/draftfunctions/README.md
@@ -1,0 +1,16 @@
+2020 May
+
+These modules provide supporting functions for dealing
+with the custom "scripted objects" defined within the workbench.
+
+The functions are meant to be used in the creation step of the objects,
+by the "make functions" in `draftmake/`, but also by the graphical
+"Gui Commands" modules in `draftguitools/` and `drafttaskpanels/`.
+
+These functions should deal with the internal shapes of the objects,
+or other special properties. They should not be very generic;
+if they are very generic then they are more appropriate to be included
+in the modules in `draftutils/`.
+
+For more information see the thread:
+[[Discussion] Splitting Draft tools into their own modules](https://forum.freecadweb.org/viewtopic.php?f=23&t=38593&start=10#p341298)

--- a/src/Mod/Draft/draftfunctions/__init__.py
+++ b/src/Mod/Draft/draftfunctions/__init__.py
@@ -1,3 +1,41 @@
-"""Generic functions of the Draft Workbench.
+# ***************************************************************************
+# *   (c) 2020 Carlo Pavan <carlopav@gmail.com>                             *
+# *   (c) 2020 Eliud Cabrera Castillo <e.cabrera-castillo@tum.de>           *
+# *                                                                         *
+# *   This file is part of the FreeCAD CAx development system.              *
+# *                                                                         *
+# *   This program is free software; you can redistribute it and/or modify  *
+# *   it under the terms of the GNU Lesser General Public License (LGPL)    *
+# *   as published by the Free Software Foundation; either version 2 of     *
+# *   the License, or (at your option) any later version.                   *
+# *   for detail see the LICENCE text file.                                 *
+# *                                                                         *
+# *   FreeCAD is distributed in the hope that it will be useful,            *
+# *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+# *   GNU Library General Public License for more details.                  *
+# *                                                                         *
+# *   You should have received a copy of the GNU Library General Public     *
+# *   License along with FreeCAD; if not, write to the Free Software        *
+# *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
+# *   USA                                                                   *
+# *                                                                         *
+# ***************************************************************************
+"""Modules that contain functions for use with scripted objects and commands.
 
+These functions provide support for dealing with the custom objects
+defined within the workbench.
+The functions are meant to be used in the creation step of the objects,
+by the functions in the `draftmake` package, but also by the graphical
+GuiCommands in the `draftguitools` and `drafttaskpanels` packages.
+
+These functions should deal with the internal shapes of the objects,
+and their special properties. They should not be very generic;
+if they are very generic then they are more appropriate to be included
+in the `draftutils` package.
+
+These functions, together with those defined in the `draftmake` package,
+represent the public application programming interface (API)
+of the Draft Workbench, and should be made available in the `Draft`
+namespace by importing them in the `Draft` module.
 """

--- a/src/Mod/Draft/draftguitools/README.md
+++ b/src/Mod/Draft/draftguitools/README.md
@@ -1,20 +1,45 @@
-2020 February
+# General
+
+2020 May
 
 These files define the "GuiCommands", that is, classes called in a graphical
 way through either buttons, menu entries, or context actions.
-They don't define the graphical interfaces themselves, they just setup
-tools that connect with FreeCAD's C++ code.
+They don't define the graphical interfaces themselves, but set up
+the interactions that allow running Python functions
+when graphical data is provided, for example, when points or objects
+are selected in the 3D view.
 
-These tools should be split from the big `DraftTools.py` module.
-The classes defined here internally use the GUI-less functions
-defined in `Draft.py`, or in the newer modules under `draftobjects/`.
+There is no need to check for the existence of the graphical interface (GUI)
+when loading these classes as these classes only work with the GUI
+so we must assume the interface is already available.
+These command classes are normally loaded by `InitGui.py`
+during the initialization of the workbench.
 
-These tools are loaded by `InitGui.py`, and thus require the graphical
-interface to exist.
+These tools were previously defined in the `DraftTools.py` module,
+which was very large. Now `DraftTools.py` is an auxiliary module
+which just loads the individual tool classes; therefore, importing
+`DraftTools.py` in `InitGui.py` is sufficient to make all commands
+of the Draft Workbench accessible to the system.
+Then the toolbars can be defined with the command names.
 
-Those commands that require a "task panel" call the respective module
-and class in `drafttaskpanels/`. The task panel interfaces themselves
-are defined inside the `Resources/ui/` files created with QtCreator.
+The classes defined here internally use the public functions provided
+by `Draft.py`, which are ultimately defined in the modules
+under `draftutils/`, `draftfunctions/`, and `draftmake/`.
+
+Those GUI commands that launch a "task panel" set up the respective widgets
+in two different ways typically.
+- "Old" commands set up the task panel from the `DraftGui.py` module.
+- "New" commands call the respective class from a module in `drafttaskpanels/`,
+which itself loads a `.ui` file (created with Qt Designer)
+from `Resources/ui/`.
 
 For more information see the thread:
 [[Discussion] Splitting Draft tools into their own modules](https://forum.freecadweb.org/viewtopic.php?f=23&t=38593&start=10#p341298)
+
+# To do
+
+In the future each tool should have its own individual task panel file,
+and its own `.ui` file.
+
+This should be done by breaking `DraftGui.py`, creating many `.ui` files,
+and making sure these GUI commands use them properly.

--- a/src/Mod/Draft/draftguitools/__init__.py
+++ b/src/Mod/Draft/draftguitools/__init__.py
@@ -1,6 +1,65 @@
-"""Commands that require the graphical user interface to work.
+# ***************************************************************************
+# *   (c) 2020 Eliud Cabrera Castillo <e.cabrera-castillo@tum.de>           *
+# *                                                                         *
+# *   This file is part of the FreeCAD CAx development system.              *
+# *                                                                         *
+# *   This program is free software; you can redistribute it and/or modify  *
+# *   it under the terms of the GNU Lesser General Public License (LGPL)    *
+# *   as published by the Free Software Foundation; either version 2 of     *
+# *   the License, or (at your option) any later version.                   *
+# *   for detail see the LICENCE text file.                                 *
+# *                                                                         *
+# *   FreeCAD is distributed in the hope that it will be useful,            *
+# *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+# *   GNU Library General Public License for more details.                  *
+# *                                                                         *
+# *   You should have received a copy of the GNU Library General Public     *
+# *   License along with FreeCAD; if not, write to the Free Software        *
+# *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
+# *   USA                                                                   *
+# *                                                                         *
+# ***************************************************************************
+"""Modules that define the workbench GuiCommands to perform graphical actions.
 
-These GUI commands are called by buttons, menus, contextual menus,
-toolbars, or other ways that require graphical widgets.
-They are normally loaded in the workbench's `InitGui.py`.
+These GUI Commands or tools are called by buttons, menus, contextual menus,
+toolbars, and other graphical widgets.
+They are normally loaded by the workbench's `InitGui` module.
+In this workbench these GUI tools are loaded by the `DraftTools`
+module, which itself is loaded by `InitGui.DraftWorkbench.Initialize`.
+
+This means that any script or workbench that wishes to use
+this workbench's tools can import the individual modules,
+or just `DraftTools`, to have access to them.
+
+::
+
+    import draftguitools.gui_rectangles
+    import draftguitools.gui_circles
+    import draftguitools.gui_arcs
+    import DraftTools
+
+These modules should not be imported in a console-only session,
+as they are not intended to be used without the graphical interface (GUI).
+They are also not generally suitable for scripting
+as they normally require graphical input in the task panel or a selection
+in the 3D view (`Gui.Selection`).
+
+Most of these GUI tools require certain components of Draft to exist
+like the `gui_snapper.Snapper`, the `WorkingPlane.Plane`,
+and the `DraftGui.DraftToolBar` classes.
+These classes are normally installed in the global `App` or `Gui`
+namespaces, so they are accessible at all times.
+
+::
+
+    import DraftGui
+    import draftguitools.gui_snapper
+    import WorkingPlane
+    Gui.draftToolBar = DraftGui.DraftToolBar()
+    Gui.Snapper = draftguitools.gui_snapper.Snapper()
+    App.DraftWorkingPlane = WorkingPlane.Plane()
+
+These classes can be imported and initialized individually
+but it is easier to set them up just by importing `DraftTools`.
 """

--- a/src/Mod/Draft/draftmake/README.md
+++ b/src/Mod/Draft/draftmake/README.md
@@ -1,0 +1,38 @@
+2020 May
+
+These modules contain the basic functions to create custom "scripted objects"
+defined within the workbench.
+
+Each scripted object has a "make function" like `make_rectangle`,
+a proxy class like `Rectangle`, and a viewprovider class
+like `ViewProviderRectangle`.
+Each make function should import the two corresponding classes
+in order to create a new object with the correct data
+and visual properties for that object.
+These classes should be defined in the modules in `draftobjects/`
+and `draftviewproviders/`.
+
+The make functions can be used in both graphical and non-graphical
+modes (terminal only); in the latter case the viewprovider is not used.
+The functions are also used internally by the graphical "GuiCommands"
+(buttons, menu actions) defined in the modules in `draftguitools/`
+and `drafttaskpanels/`.
+
+These make functions were previously defined in the `Draft.py` module,
+which was very large. Now `Draft.py` just loads the individual modules
+in order to provide these functions under the `Draft` namespace.
+
+```py
+import Draft
+
+new_obj1 = Draft.make_rectangle(...)
+new_obj2 = Draft.make_circle(...)
+new_obj3 = Draft.make_line(...)
+```
+
+The functions in the `Draft` namespace are considered to be the public
+application programming interface (API) of the workbench, and should be
+usable in scripts, macros, and other workbenches.
+
+For more information see the thread:
+[[Discussion] Splitting Draft tools into their own modules](https://forum.freecadweb.org/viewtopic.php?f=23&t=38593&start=10#p341298)

--- a/src/Mod/Draft/draftmake/__init__.py
+++ b/src/Mod/Draft/draftmake/__init__.py
@@ -1,3 +1,82 @@
-"""Functions that to create custom scripted Draft objects.
+# ***************************************************************************
+# *   (c) 2020 Carlo Pavan <carlopav@gmail.com>                             *
+# *   (c) 2020 Eliud Cabrera Castillo <e.cabrera-castillo@tum.de>           *
+# *                                                                         *
+# *   This file is part of the FreeCAD CAx development system.              *
+# *                                                                         *
+# *   This program is free software; you can redistribute it and/or modify  *
+# *   it under the terms of the GNU Lesser General Public License (LGPL)    *
+# *   as published by the Free Software Foundation; either version 2 of     *
+# *   the License, or (at your option) any later version.                   *
+# *   for detail see the LICENCE text file.                                 *
+# *                                                                         *
+# *   FreeCAD is distributed in the hope that it will be useful,            *
+# *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+# *   GNU Library General Public License for more details.                  *
+# *                                                                         *
+# *   You should have received a copy of the GNU Library General Public     *
+# *   License along with FreeCAD; if not, write to the Free Software        *
+# *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
+# *   USA                                                                   *
+# *                                                                         *
+# ***************************************************************************
+"""Modules that contain functions to create custom scripted objects.
 
+These functions represent the basic application programming interface (API)
+of the Draft Workbench to create custom objects.
+
+These functions first create a simple, extensible object defined in C++,
+for example, `Part::FeaturePython` or `Part::Part2DObjectPython`,
+and then assign a custom proxy class to define its data properties,
+and a custom viewprovider class to define its visual properties.
+
+The proxy class is imported from `draftobjects` and the corresponding
+viewprovider from `draftviewproviders`.
+
+::
+
+    import FreeCAD as App
+    import draftobjects.my_obj as my_obj
+    import draftviewproviders.view_my_obj as view_my_obj
+
+    def make_function(input_data):
+        doc = App.ActiveDocument
+        new_obj = doc.addObject("Part::Part2DObjectPython",
+                                "New_obj")
+        my_obj.Obj(new_obj)
+
+        if App.GuiUp:
+            view_my_obj.ViewProviderObj(new_obj.ViewObject)
+
+        return new_obj
+
+Assigning the viewprovider class is only possible if the graphical interface
+is available. In a terminal-only session the viewproviders are not accessible
+because the `ViewObject` attribute does not exist.
+
+If an object is created and saved in a console-only session,
+the object will not have the custom viewprovider when the file is opened
+in the GUI version of the program; it will only have a basic viewprovider
+associated to the base C++ object.
+
+If needed, the custom viewprovider can be assigned after opening
+the GUI version of the program; then the object will have access
+to additional visual properties.
+
+::
+
+    import Draft
+    Draft.ViewProviderDraft(new_obj.ViewObject)
+
+Most Draft objects are based on two base `Part` objects
+that are able to handle a `Part::TopoShape`.
+
+- `Part::Part2DObjectPython` if they should handle only 2D shapes, and
+- `Part::FeaturePython` if they should handle any type of shape (2D or 3D).
+
+Generic objects that don't need to handle shapes but which
+can have other properties like `App::PropertyPlacement`,
+or which can interact with the 3D view through Coin,
+can be based on the simple `App::FeaturePython` object.
 """

--- a/src/Mod/Draft/draftobjects/README.md
+++ b/src/Mod/Draft/draftobjects/README.md
@@ -1,20 +1,43 @@
-2020 February
+2020 May
 
-These files define modules to create specific "scripted objects"
-from the terminal, that is, without requiring the graphical interface.
-They define both a creation command such as `make_arc`, and the corresponding
-proxy class, such as `Arc`. The corresponding view provider class
+These files define the proxy classes for "scripted objects"
+defined within the workbench. The corresponding viewprovider classes
 should be defined in the modules in `draftviewproviders/`.
 
-These modules should be split from the big `Draft.py` module.
+Each scripted object has a creation function like `make_rectangle`,
+a proxy class like `Rectangle`, and a viewprovider class
+like `ViewProviderRectangle`.
+The proxy classes define the code that manipulates the internal properties
+of the objects, determining how the internal shape is calculated.
+These properties are "real" information because they affect the actual
+geometrical shape of the object.
+Each make function in `draftmake/` should import its corresponding
+proxy class from this package in order to build the new scripted object.
 
-At the moment the files in this directory aren't really used,
-but are used as placeholders for when the migration of classes and functions
-happens.
+These classes were previously defined in the `Draft.py` module,
+which was very large. Now `Draft.py` is an auxiliary module
+which just loads the individual classes in order to provide backwards
+compatibility for older files.
+Other workbenches can import these classes for their own use,
+including creating derived classes.
+```py
+import Draft
 
-The creation functions should be used internally by the "GuiCommands"
-defined in `DraftTools.py` or in the newer modules under `draftguitools/`
-and `drafttaskpanels/`.
+new_obj = App.ActiveDocument.addObject("Part::Part2DObjectPython", "New")
+Draft.Rectangle(new_obj)
+
+
+# Subclass
+class NewObject(Draft.Rectangle):
+   ...
+```
+
+As the scripted objects are rebuilt every time a document is loaded,
+this means that, in general, these modules cannot be renamed
+without risking breaking previously saved files. They can be renamed
+only if the old class can be migrated to point to a new class,
+for example, by creating a reference to the new class named the same
+as the older class.
 
 For more information see the thread:
 [[Discussion] Splitting Draft tools into their own modules](https://forum.freecadweb.org/viewtopic.php?f=23&t=38593&start=10#p341298)

--- a/src/Mod/Draft/draftobjects/__init__.py
+++ b/src/Mod/Draft/draftobjects/__init__.py
@@ -1,8 +1,55 @@
-"""Functions and classes that define custom scripted objects.
+# ***************************************************************************
+# *   (c) 2020 Carlo Pavan <carlopav@gmail.com>                             *
+# *   (c) 2020 Eliud Cabrera Castillo <e.cabrera-castillo@tum.de>           *
+# *                                                                         *
+# *   This file is part of the FreeCAD CAx development system.              *
+# *                                                                         *
+# *   This program is free software; you can redistribute it and/or modify  *
+# *   it under the terms of the GNU Lesser General Public License (LGPL)    *
+# *   as published by the Free Software Foundation; either version 2 of     *
+# *   the License, or (at your option) any later version.                   *
+# *   for detail see the LICENCE text file.                                 *
+# *                                                                         *
+# *   FreeCAD is distributed in the hope that it will be useful,            *
+# *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+# *   GNU Library General Public License for more details.                  *
+# *                                                                         *
+# *   You should have received a copy of the GNU Library General Public     *
+# *   License along with FreeCAD; if not, write to the Free Software        *
+# *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
+# *   USA                                                                   *
+# *                                                                         *
+# ***************************************************************************
+"""Modules that contain classes that define custom scripted objects.
 
-These classes define a custom object which is based on one of the core
-objects defined in C++. The custom object inherits some basic properties,
-and new properties are added.
+These proxy classes are used to extend one of the core classes
+defined in C++, for example, `Part::FeaturePython`
+or `Part::Part2DObjectPython`, thus creating a custom object type
+tied to a Python class.
+A new object that uses one of these classes inherits some basic properties
+from the parent C++ class, and new properties and behavior
+are added by the Python class.
 
-Most Draft objects are based on Part::Part2DObject.
+These classes are not normally used by themselves, but are used at creation
+time by the make functions defined in the `draftmake` package.
+
+Once an object is assigned one of these proxy classes, and it is saved
+in a document, the object will be rebuilt with the same class every time
+the document is opened. In order to do this, the object module must exist
+with the same name as when the object was saved.
+
+For example, when creating a `Rectangle`, the object uses
+the `draftobjects.rectangle.Rectangle` class. This class must exist
+when the document is opened again.
+
+This means that, in general, these modules cannot be renamed or moved
+without risking breaking previously saved files. They can be renamed
+only if the old class can be migrated to point to a new class,
+for example, by creating a reference to the new class named the same
+as the older class.
+
+::
+
+    old_module.Rectangle = new_module.Rectangle
 """

--- a/src/Mod/Draft/drafttaskpanels/README.md
+++ b/src/Mod/Draft/drafttaskpanels/README.md
@@ -1,19 +1,36 @@
-2020 February
+# General
 
-These files provide the logic behind the task panels of the "GuiCommands"
+2020 May
+
+These files provide the logic behind the "task panels" of the "GuiCommands"
 defined in `draftguitools/`.
 
-These files should not have code to create the task panel windows
-and widgets manually. These interfaces should be properly defined
-in the `.ui` files made with QtCreator and placed inside
-the `Resources/ui/` directory.
+These files should not have code to create the task panel widgets manually.
+These interfaces should be properly defined in `.ui` files
+made with Qt Designer and placed inside the `Resources/ui/` directory.
 
-There are many commands which aren't defined in `draftguitools/`,
-and which therefore don't have an individual task panel.
-These commands are defined in the big `DraftTools.py` file,
-and their task panels are manually written in the large `DraftGui.py` module.
-Therefore, these commands should be split into individual files,
-and each should have its own `.ui` file.
+There are many GUI commands which are "old style" and thus don't have
+an individual task panel. These commands use the task panel defined
+in the big `DraftGui.py` module. This module defines many widgets
+for many tools, and selectively chooses the widgets to show and to hide
+depending on the command that is activated.
+
+A big file that controls many widgets at the same time is difficult
+to handle and to maintain because changing the behavior of one widget
+may affect the operation of various GUI commands.
+This must be changed so that in the future each tool has its own
+individual task panel file, and its own `.ui` file.
+Individual files are more maintainable because changes can be done
+to a single tool without affecting the rest.
 
 For more information see the thread:
 [[Discussion] Splitting Draft tools into their own modules](https://forum.freecadweb.org/viewtopic.php?f=23&t=38593&start=10#p341298)
+
+# To do
+
+In the future each tool should have its own individual task panel file,
+and its own `.ui` file.
+
+This should be done by breaking `DraftGui.py`, creating many `.ui` files,
+creating many task panel modules, and making sure these modules
+are used correctly by the GUI commands.

--- a/src/Mod/Draft/drafttaskpanels/__init__.py
+++ b/src/Mod/Draft/drafttaskpanels/__init__.py
@@ -1,7 +1,55 @@
-"""Classes that define the task panels of GUI commands.
+# ***************************************************************************
+# *   (c) 2020 Eliud Cabrera Castillo <e.cabrera-castillo@tum.de>           *
+# *                                                                         *
+# *   This file is part of the FreeCAD CAx development system.              *
+# *                                                                         *
+# *   This program is free software; you can redistribute it and/or modify  *
+# *   it under the terms of the GNU Lesser General Public License (LGPL)    *
+# *   as published by the Free Software Foundation; either version 2 of     *
+# *   the License, or (at your option) any later version.                   *
+# *   for detail see the LICENCE text file.                                 *
+# *                                                                         *
+# *   FreeCAD is distributed in the hope that it will be useful,            *
+# *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+# *   GNU Library General Public License for more details.                  *
+# *                                                                         *
+# *   You should have received a copy of the GNU Library General Public     *
+# *   License along with FreeCAD; if not, write to the Free Software        *
+# *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
+# *   USA                                                                   *
+# *                                                                         *
+# ***************************************************************************
+"""Modules that define classes that handle task panels of the GuiCommands.
 
-These classes load `.ui` files that will be used in the task panel
-of the graphical commands.
-The classes define the behavior and callbacks of the different widgets
-included in the `.ui` file.
+These classes load `.ui` files that will be used in the task panels
+of the graphical commands defined in the `draftguitools` submodules.
+These classes also define the callbacks and interactions of the widgets
+in the `.ui` files.
+
+The task panel interface should be, in the possible, not manually written
+in Python. Rather a `.ui` file should be built using Qt Designer,
+and should be placed in the `Resources/ui/` directory so that it is loaded
+by the respective task panel class.
+
+::
+
+    class CommandTaskPanel:
+        def __init__(self):
+            ui_file = ":/ui/TaskPanel_OrthoArray.ui"
+            self.form = Gui.PySideUic.loadUi(ui_file)
+
+At the moment, most GuiCommands don't have their own `.ui` file,
+nor task panel class. Instead their task panels are completely defined
+by the `DraftGui` module.
+
+This should be changed in the future because `DraftGui`
+is a very large module, and creates many different widgets
+and handles many callbacks, making it difficult to extend and maintain.
+This module selectively chooses the widgets to show and to hide
+depending on the command that is activated.
+
+Individual task panel classes and `.ui` files are more maintainable
+because changes can be done to a single tool without affecting the rest,
+and the module size is kept small.
 """

--- a/src/Mod/Draft/drafttests/README.md
+++ b/src/Mod/Draft/drafttests/README.md
@@ -1,23 +1,53 @@
-2020 February
+# General
+
+2020 May
 
 These files provide the unit tests classes based on the standard Python
 `unittest` module.
 
-These files should be imported from the main `TestDraft.py` module
-which is the one registered in the program in `InitGui.py`.
+These files should be imported from the main `TestDraft.py`
+and `TestDraftGui.py` modules which are registered in the program
+in `Init.py` and `InitGui.py` depending on if they require
+the graphical interface or not.
 
 Each module should define a class derived from `unittest.TestCase`,
 and the individual methods of the class correspond to the individual
 unit tests which try a specific function in the workbench.
 
 The tests should be callable from the terminal.
-```
-program -t TestDraft  # all tests
-program -t drafttests.test_creation  # only creation functions
+```bash
+# All tests that don't require the graphical interface
+program --console -t TestDraft
 
-# A specific test
-program -t drafttests.test_creation.DraftCreation.test_line
+# Only creation tests
+program --console -t drafttests.test_creation
+
+# A specific test inside a module and class
+program --console -t drafttests.test_creation.DraftCreation.test_line
+```
+
+Where `program` is the name of the FreeCAD executable.
+
+Most tests should be designed to pass even without the graphical interface,
+meaning that they should run in console mode.
+
+The exception to this are particular tests that explicitly use
+the graphical interface.
+```bash
+# All tests that require the graphical interface
+program -t TestDraftGui
 ```
 
 For more information see the thread:
 [New unit tests for Draft Workbench](https://forum.freecadweb.org/viewtopic.php?f=23&t=40405)
+
+# To do
+
+Not every single function in the workbench is tested, so new unit tests
+can be written. This will improve reliability of the workbench,
+making it easier to discover bugs and regressions.
+
+See the individual modules to check what is missing.
+
+In particular, unit tests for the import and export modules (SVG, DXF, DWG)
+are required.

--- a/src/Mod/Draft/drafttests/__init__.py
+++ b/src/Mod/Draft/drafttests/__init__.py
@@ -1,7 +1,41 @@
-"""Classes and functions used to test the workbench.
+# ***************************************************************************
+# *   (c) 2019 Eliud Cabrera Castillo <e.cabrera-castillo@tum.de>           *
+# *                                                                         *
+# *   This file is part of the FreeCAD CAx development system.              *
+# *                                                                         *
+# *   This program is free software; you can redistribute it and/or modify  *
+# *   it under the terms of the GNU Lesser General Public License (LGPL)    *
+# *   as published by the Free Software Foundation; either version 2 of     *
+# *   the License, or (at your option) any later version.                   *
+# *   for detail see the LICENCE text file.                                 *
+# *                                                                         *
+# *   FreeCAD is distributed in the hope that it will be useful,            *
+# *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+# *   GNU Library General Public License for more details.                  *
+# *                                                                         *
+# *   You should have received a copy of the GNU Library General Public     *
+# *   License along with FreeCAD; if not, write to the Free Software        *
+# *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
+# *   USA                                                                   *
+# *                                                                         *
+# ***************************************************************************
+"""Modules that define classes used for unit testing the workbench.
 
-These classes are called by the unit test launcher
-that is defined in `Init.py` and `InitGui.py`.
+These modules contain classes and functions that are called
+by the unit test module that is defined in `Init.py` and `InitGui.py`.
 
-The unit tests are based on the standard `unittest` module.
+The unit tests are placed in separate modules in order to test features
+that do not require the graphical user interface (GUI), from those
+that do require it.
+
+The unit tests are based on the standard Python `unittest` module.
+See this module and `unittest.TestCase` for more information
+on how to write unit tests.
+
+::
+
+    class NewTestType(unittest.TestCase):
+        def test_new_tool(self):
+            pass
 """

--- a/src/Mod/Draft/draftutils/README.md
+++ b/src/Mod/Draft/draftutils/README.md
@@ -1,14 +1,18 @@
-2020 February
+2020 May
 
 These files provide auxiliary functions used by the Draft workbench.
-Previously most of these were in `Draft.py`, `DraftTools.py`
-and `DraftGui.py`.
+
+Previously most of these functions were defined in `Draft.py`,
+`DraftTools.py`, and `DraftGui.py`. However, due to being defined in these
+big modules, it was impossible to use them individually without importing
+the entire modules. So a decision was made to split the functions
+into smaller modules.
 
 In here we want modules with generic functions that can be used everywhere
-in the workbench. We want these tools to depend only on standard modules
-so that there are no circular dependencies, and so that they can be used
-by all functions and graphical commands in this workbench
-and possibly other workbenches.
+in the workbench. We want these tools to depend only on standard Python
+modules and basic FreeCAD methods so that there are no circular dependencies,
+and so that they can be used by all functions and graphical commands
+in this workbench, and others if possible.
 - `utils`: basic functions
 - `messages`: used to print messages
 - `translate`: used to translate texts
@@ -18,6 +22,7 @@ and possibly other workbenches.
 Some auxiliary functions require that the graphical interface is loaded
 as they deal with scripted objects' view providers or the 3D view.
 - `gui_utils`: basic functions dealing with the graphical interface
+- `init_draft_statusbar`: functions to initialize the status bar
 
 For more information see the thread:
 [[Discussion] Splitting Draft tools into their own modules](https://forum.freecadweb.org/viewtopic.php?f=23&t=38593&start=10#p341298)

--- a/src/Mod/Draft/draftutils/__init__.py
+++ b/src/Mod/Draft/draftutils/__init__.py
@@ -1,6 +1,50 @@
-"""Utility functions that do not require the graphical user interface.
+# ***************************************************************************
+# *   (c) 2019 Eliud Cabrera Castillo <e.cabrera-castillo@tum.de>           *
+# *                                                                         *
+# *   This file is part of the FreeCAD CAx development system.              *
+# *                                                                         *
+# *   This program is free software; you can redistribute it and/or modify  *
+# *   it under the terms of the GNU Lesser General Public License (LGPL)    *
+# *   as published by the Free Software Foundation; either version 2 of     *
+# *   the License, or (at your option) any later version.                   *
+# *   for detail see the LICENCE text file.                                 *
+# *                                                                         *
+# *   FreeCAD is distributed in the hope that it will be useful,            *
+# *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+# *   GNU Library General Public License for more details.                  *
+# *                                                                         *
+# *   You should have received a copy of the GNU Library General Public     *
+# *   License along with FreeCAD; if not, write to the Free Software        *
+# *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
+# *   USA                                                                   *
+# *                                                                         *
+# ***************************************************************************
+"""Utility modules that are used throughout the workbench.
 
-These functions are used throughout the Draft Workbench.
-They can be called from any module, whether it uses the graphical
-user interface or not.
+These modules include functions intended to be quite general,
+so they should be useful in all other modules in the workbench
+and even other workbenches.
+Since they are not meant to be very complex, they shouldn't require
+a lot of prerequisites, and shouldn't cause problems of circular imports.
+
+They include modules that don't require the graphical interface (GUI),
+as well as functions that do require it because they interact
+with the view providers or with the 3D view.
+
+Non GUI modules
+---------------
+- `utils`, generic functions
+- `messages`, shorthands to print to the console
+- `translate`, translate text using QtCore
+
+GUI modules
+-----------
+- `gui_utils`, generic functions that deal with the graphical interface
+- `todo`, delay execution of Python code through Qt
+
+Initialization modules for the GUI
+----------------------------------
+- `init_tools`, initialize toolbars and menus of the workbench
+- `init_draft_statusbar`, initialize the status bar of the workbench
 """

--- a/src/Mod/Draft/draftviewproviders/README.md
+++ b/src/Mod/Draft/draftviewproviders/README.md
@@ -1,25 +1,50 @@
-2020 February
+2020 May
 
-These files define the view provider classes of the "scripted objects"
-defined by the workbench. These scripted objects are originally
-defined in the big `Draft.py` file.
+These files define the viewprovider classes for "scripted objects"
+defined within the workbench. The corresponding proxy object classes
+should be defined in the modules in `draftobjects/`.
 
-Each scripted object has a creation command like `make_arc`, 
-a proxy class like `Arc`, and a view provider like `ViewProviderArc`.
-The view providers define the code that indicates how they are displayed
-in the tree view and in the 3D view, and visual properties
-such as line thickness, line color, face color, and transparency.
-These properties are only available when the graphical interface exists,
-otherwise they are ignored.
-
-Each scripted object in `draftobjects/` should import its corresponding
-view provider from this directory as long the graphical interface
+Each scripted object has a creation function like `make_rectangle`,
+a proxy class like `Rectangle`, and a viewprovider class
+like `ViewProviderRectangle`.
+The view providers define how they are displayed in the tree view
+and in the 3D view, that is, visual properties such as line thickness,
+line color, face color, and transparency.
+These properties are only available when the graphical interface is loaded;
+in a console only session, these properties cannot be read nor set.
+These properties aren't very "real" because they don't affect the actual
+geometrical shape of the object.
+Each make function in `draftmake/` should import its corresponding
+viewprovider from this package in order to set the visual properties
+of the new scripted object, as long the graphical interface
 is available.
 
-These modules should be split from the big `Draft.py` module.
+These classes were previously defined in the `Draft.py` module,
+which was very large. Now `Draft.py` is an auxiliary module
+which just loads the individual classes in order to provide backwards
+compatibility for older files.
+Other workbenches can import these classes for their own use,
+including creating derived classes.
+```py
+import Draft
 
-At the moment the files in this directory aren't really used,
-but are used as placeholders for when the migration of classes happens.
+new_obj = App.ActiveDocument.addObject("Part::Part2DObjectPython", "New")
+
+if App.GuiUp:
+    Draft.ViewProviderRectangle(new_obj.ViewObject)
+
+
+# Subclass
+class NewViewProvider(Draft.ViewProviderRectangle):
+   ...
+```
+
+As the scripted objects are rebuilt every time a document is loaded,
+this means that, in general, these modules cannot be renamed
+without risking breaking previously saved files. They can be renamed
+only if the old class can be migrated to point to a new class,
+for example, by creating a reference to the new class named the same
+as the older class.
 
 For more information see the thread:
 [[Discussion] Splitting Draft tools into their own modules](https://forum.freecadweb.org/viewtopic.php?f=23&t=38593&start=10#p341298)

--- a/src/Mod/Draft/draftviewproviders/__init__.py
+++ b/src/Mod/Draft/draftviewproviders/__init__.py
@@ -1,7 +1,56 @@
-"""Classes that define the viewproviders of custom scripted objects.
+# ***************************************************************************
+# *   (c) 2020 Carlo Pavan <carlopav@gmail.com>                             *
+# *   (c) 2020 Eliud Cabrera Castillo <e.cabrera-castillo@tum.de>           *
+# *                                                                         *
+# *   This file is part of the FreeCAD CAx development system.              *
+# *                                                                         *
+# *   This program is free software; you can redistribute it and/or modify  *
+# *   it under the terms of the GNU Lesser General Public License (LGPL)    *
+# *   as published by the Free Software Foundation; either version 2 of     *
+# *   the License, or (at your option) any later version.                   *
+# *   for detail see the LICENCE text file.                                 *
+# *                                                                         *
+# *   FreeCAD is distributed in the hope that it will be useful,            *
+# *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+# *   GNU Library General Public License for more details.                  *
+# *                                                                         *
+# *   You should have received a copy of the GNU Library General Public     *
+# *   License along with FreeCAD; if not, write to the Free Software        *
+# *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
+# *   USA                                                                   *
+# *                                                                         *
+# ***************************************************************************
+"""Modules that contain classes that define viewproviders for scripted objects.
 
 These classes define viewproviders for the custom objects
-defined in `draftobjects`.
-The viewproviders can be used only when the graphical interface
-is available; in console mode the viewproviders are not available.
+defined in the `draftobjects` package.
+They extend the basic viewprovider that is installed by default
+with the creation of a base object defined in C++.
+
+These classes are not normally used by themselves, but are used at creation
+time by the make functions defined in the `draftmake` package.
+These viewproviders are installed only when the graphical interface
+is available; in console-only mode the viewproviders are not available
+so the make functions ignore them.
+
+Similar to the object classes, once a viewprovider class is assigned
+to an object, and it is saved in a document, the object's viewprovider
+will be rebuilt with the same class every time the document
+is opened. In order to do this, the viewprovider module must exist
+with the same name as when the object was saved.
+
+For example, when creating a `Rectangle`, the object uses
+the `draftviewproviders.view_rectangle.ViewProviderRectangle` class.
+This class must exist when the document is opened again.
+
+This means that, in general, these modules cannot be renamed or moved
+without risking breaking previously saved files. They can be renamed
+only if the old class can be migrated to point to a new class,
+for example, by creating a reference to the new class named the same
+as the older class.
+
+::
+
+    old_module.ViewProviderRectangle = new_module.ViewProviderRectangle
 """


### PR DESCRIPTION
Improve the text in the `README.md` to explain better how the code is structured.

Also the docstrings in `__init__.py`, which are more programmer oriented.

---

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists