### PR TITLE
Change Std Bottom orientation (x ->right; y ->down)

### DIFF
--- a/src/Gui/View3DPy.cpp
+++ b/src/Gui/View3DPy.cpp
@@ -413,7 +413,7 @@ SbRotation Camera::rotation(Camera::Orientation view)
     case Top:
         return SbRotation(0, 0, 0, 1);
     case Bottom:
-        return SbRotation(0, 1, 0, 0);
+        return SbRotation(1, 0, 0, 0);
     case Front: {
         float root = (float)(sqrt(2.0)/2.0);
         return SbRotation(root, 0, 0, root);


### PR DESCRIPTION
Camera::rotation(Camera::Bottom) was upside-down compared to industry standards and other FreeCAD bottom views

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---

forum thread: https://forum.freecadweb.org/viewtopic.php?f=34&t=44561