### PR TITLE
Draft: import the missing Gui module in the mirror function

### DIFF
--- a/src/Mod/Draft/draftfunctions/mirror.py
+++ b/src/Mod/Draft/draftfunctions/mirror.py
@@ -1,7 +1,8 @@
 # ***************************************************************************
 # *   Copyright (c) 2009, 2010 Yorik van Havre <yorik@uncreated.net>        *
 # *   Copyright (c) 2009, 2010 Ken Cline <cline@frii.com>                   *
-# *   Copyright (c) 2020 FreeCAD Developers                                 *
+# *   Copyright (c) 2020 Carlo Pavan <carlopav@gmail.com>                   *
+# *   Copyright (c) 2020 Eliud Cabrera Castillo <e.cabrera-castillo@tum.de> *
 # *                                                                         *
 # *   This program is free software; you can redistribute it and/or modify  *
 # *   it under the terms of the GNU Lesser General Public License (LGPL)    *
@@ -20,70 +21,94 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""This module provides the code for Draft mirror function.
+"""Provides the code for the mirror operation.
+
+It just creates a `Part::Mirroring` object, and sets the appropriate
+`Source` and `Normal` properties.
 """
 ## @package mirror
 # \ingroup DRAFT
-# \brief This module provides the code for Draft mirror function.
-
-import math
+# \brief Provides the code for the mirror operation.
 
 import FreeCAD as App
 
-import DraftVecUtils
-
-import draftutils.gui_utils as gui_utils
 import draftutils.utils as utils
-
+import draftutils.gui_utils as gui_utils
+from draftutils.messages import _err
 from draftutils.translate import _tr
+
+if App.GuiUp:
+    import FreeCADGui as Gui
 
 
 def mirror(objlist, p1, p2):
-    """mirror(objlist, p1, p2)
+    """Create a mirror object from the provided list and line.
 
-    Create a Part::Mirror of the given object(s) along a plane defined
-    by the 2 given points and the draft working plane normal.
+    It creates a `Part::Mirroring` object from the given `objlist` using
+    a plane that is defined by the two given points `p1` and `p2`,
+    and either
 
-    TODO: Implement a proper Draft mirror tool that do not create a 
-          Part object but works similar to offset
+    - the Draft working plane normal, or
+    - the negative normal provided by the camera direction
+      if the working plane normal does not exist and the graphical interface
+      is available.
+
+    If neither of these two is available, it uses as normal the +Z vector.
 
     Parameters
     ----------
-    objlist :
+    objlist: single object or a list of objects
+        A single object or a list of objects.
 
-    p1 : Base.Vector
-        Point 1 of the mirror plane
+    p1: Base::Vector3
+        Point 1 of the mirror plane. It is also used as the `Placement.Base`
+        of the resulting object.
 
-    p2 : Base.Vector
-        Point 1 of the mirror plane
+    p2: Base::Vector3
+        Point 1 of the mirror plane.
 
+    Returns
+    -------
+    None
+        If the operation fails.
+
+    list
+        List of `Part::Mirroring` objects, or a single one
+        depending on the input `objlist`.
+
+    To Do
+    -----
+    Implement a mirror tool specific to the workbench that does not
+    just use `Part::Mirroring`. It should create a derived object,
+    that is, it should work similar to `Draft.offset`.
     """
+    utils.print_header('mirror', "Create mirror")
 
     if not objlist:
-        _err = "No object given"
-        App.Console.PrintError(_tr(_err) + "\n")
+        _err(_tr("No object given"))
         return
+
     if p1 == p2:
-        _err = "The two points are coincident"
-        App.Console.PrintError(_tr(_err) + "\n")
+        _err(_tr("The two points are coincident"))
         return
-    if not isinstance(objlist,list):
+
+    if not isinstance(objlist, list):
         objlist = [objlist]
 
     if hasattr(App, "DraftWorkingPlane"):
         norm = App.DraftWorkingPlane.getNormal()
     elif App.GuiUp:
-        norm = FreeCADGui.ActiveDocument.ActiveView.getViewDirection().negative()
+        norm = Gui.ActiveDocument.ActiveView.getViewDirection().negative()
     else:
-        norm = App.Vector(0,0,1)
-    
+        norm = App.Vector(0, 0, 1)
+
     pnorm = p2.sub(p1).cross(norm).normalize()
 
     result = []
 
     for obj in objlist:
-        mir = App.ActiveDocument.addObject("Part::Mirroring","mirror")
-        mir.Label = "Mirror of " + obj.Label
+        mir = App.ActiveDocument.addObject("Part::Mirroring", "mirror")
+        mir.Label = obj.Label + _tr(" (mirrored)")
         mir.Source = obj
         mir.Base = p1
         mir.Normal = pnorm


### PR DESCRIPTION
When the reorganization happened fd6d3da0be, the required `FreeCADGui` was not imported.

Import the missing `FreeCADGui` module, otherwise the `Draft.mirror` function will not work in a terminal only session without the graphical user interface (GUI).

Also small changes for style, documentation, and removing unused modules.

---

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists