### PR TITLE
Draft: move the arc by 3 points code

### DIFF
--- a/src/Mod/Draft/CMakeLists.txt
+++ b/src/Mod/Draft/CMakeLists.txt
@@ -79,6 +79,7 @@ SET(Draft_functions
 
 SET(Draft_make_functions
     draftmake/__init__.py
+    draftmake/make_arc_3points.py
     draftmake/make_bezcurve.py
     draftmake/make_block.py
     draftmake/make_bspline.py
@@ -112,7 +113,6 @@ SET(Draft_objects
     draftobjects/facebinder.py
     draftobjects/orthoarray.py
     draftobjects/polararray.py
-    draftobjects/arc_3points.py
     draftobjects/draft_annotation.py
     draftobjects/label.py
     draftobjects/dimension.py

--- a/src/Mod/Draft/Draft.py
+++ b/src/Mod/Draft/Draft.py
@@ -893,9 +893,6 @@ def calculatePlacementsOnPath(shapeRotation, pathwire, count, xlate, align):
 #---------------------------------------------------------------------------
 # Python Features definitions
 #---------------------------------------------------------------------------
-import draftobjects.base
-_DraftObject = draftobjects.base.DraftObject
-
 class _ViewProviderDraftLink:
     "a view provider for link type object"
 

--- a/src/Mod/Draft/Draft.py
+++ b/src/Mod/Draft/Draft.py
@@ -232,6 +232,9 @@ from draftviewproviders.view_base import _ViewProviderDraftPart
 from draftmake.make_circle import make_circle, makeCircle
 from draftobjects.circle import Circle, _Circle
 
+# arcs
+from draftmake.make_arc_3points import make_arc_3points
+
 # ellipse
 from draftmake.make_ellipse import make_ellipse, makeEllipse
 from draftobjects.ellipse import Ellipse, _Ellipse

--- a/src/Mod/Draft/draftguitools/gui_arcs.py
+++ b/src/Mod/Draft/draftguitools/gui_arcs.py
@@ -32,15 +32,16 @@ from PySide.QtCore import QT_TRANSLATE_NOOP
 
 import FreeCAD as App
 import FreeCADGui as Gui
-from FreeCAD import Units as U
+import Draft
 import Draft_rc
 import DraftVecUtils
 import draftguitools.gui_base_original as gui_base_original
 import draftguitools.gui_base as gui_base
 import draftguitools.gui_tool_utils as gui_tool_utils
 import draftguitools.gui_trackers as trackers
-import draftobjects.arc_3points as arc3
 import draftutils.utils as utils
+
+from FreeCAD import Units as U
 from draftutils.messages import _msg, _err
 from draftutils.translate import translate, _tr
 
@@ -553,13 +554,13 @@ class Arc_3Points(gui_base.GuiCommandSimplest):
             # proceed with creating the final object.
             # Draw a simple `Part::Feature` if the parameter is `True`.
             if utils.get_param("UsePartPrimitives", False):
-                arc3.make_arc_3points([self.points[0],
-                                       self.points[1],
-                                       self.points[2]], primitive=True)
+                Draft.make_arc_3points([self.points[0],
+                                        self.points[1],
+                                        self.points[2]], primitive=True)
             else:
-                arc3.make_arc_3points([self.points[0],
-                                       self.points[1],
-                                       self.points[2]], primitive=False)
+                Draft.make_arc_3points([self.points[0],
+                                        self.points[1],
+                                        self.points[2]], primitive=False)
             self.tracker.off()
             self.doc.recompute()
 

--- a/src/Mod/Draft/draftmake/make_arc_3points.py
+++ b/src/Mod/Draft/draftmake/make_arc_3points.py
@@ -110,6 +110,9 @@ def make_arc_3points(points, placement=None, face=False,
         The new arc object.
         Normally it returns a parametric Draft object (`Part::Part2DObject`).
         If `primitive` is `True`, it returns a basic `Part::Feature`.
+
+    None
+        Returns `None` if there is a problem and the object cannot be created.
     """
     _name = "make_arc_3points"
     utils.print_header(_name, "Arc by 3 points")

--- a/src/Mod/Draft/drafttests/draft_test_objects.py
+++ b/src/Mod/Draft/drafttests/draft_test_objects.py
@@ -32,11 +32,11 @@ Or load it as a module and use the defined function.
 import os
 import datetime
 import math
+
 import FreeCAD as App
-from FreeCAD import Vector
 import Draft
+from FreeCAD import Vector
 from draftutils.messages import _msg, _wrn
-import draftobjects.arc_3points
 
 if App.GuiUp:
     import DraftFillet
@@ -172,9 +172,9 @@ def create_test_file(file_name="draft_test_objects",
 
     _msg(16 * "-")
     _msg("Circular arc 3 points")
-    draftobjects.arc_3points.make_arc_3points([Vector(4600, 0, 0),
-                                               Vector(4600, 800, 0),
-                                               Vector(4000, 1000, 0)])
+    Draft.make_arc_3points([Vector(4600, 0, 0),
+                            Vector(4600, 800, 0),
+                            Vector(4000, 1000, 0)])
     t_xpos += 600
     _t = Draft.makeText(["Circular arc 3 points"], Vector(t_xpos, t_ypos, 0))
     _set_text(_t)

--- a/src/Mod/Draft/drafttests/test_creation.py
+++ b/src/Mod/Draft/drafttests/test_creation.py
@@ -133,8 +133,7 @@ class DraftCreation(unittest.TestCase):
         _msg("  a={0}, b={1}".format(a, b))
         _msg("  c={}".format(c))
 
-        import draftobjects.arc_3points as arc3
-        obj = arc3.make_arc_3points([a, b, c])
+        obj = Draft.make_arc_3points([a, b, c])
         self.assertTrue(obj, "'{}' failed".format(operation))
 
     def test_ellipse(self):


### PR DESCRIPTION
When it was introduced, #3004, the make function was placed in `draftobjects`, but after the reorganization it should be in `draftmake`.

Also import it in `Draft.py`, and update the unit tests and test script.

---

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists