### PR TITLE
Draft: use functions to set the properties in the base classes

### DIFF
--- a/src/Mod/Draft/CMakeLists.txt
+++ b/src/Mod/Draft/CMakeLists.txt
@@ -79,6 +79,7 @@ SET(Draft_functions
 
 SET(Draft_make_functions
     draftmake/__init__.py
+    draftmake/make_arc_3points.py
     draftmake/make_bezcurve.py
     draftmake/make_block.py
     draftmake/make_bspline.py
@@ -112,7 +113,6 @@ SET(Draft_objects
     draftobjects/facebinder.py
     draftobjects/orthoarray.py
     draftobjects/polararray.py
-    draftobjects/arc_3points.py
     draftobjects/draft_annotation.py
     draftobjects/label.py
     draftobjects/dimension.py

--- a/src/Mod/Draft/Draft.py
+++ b/src/Mod/Draft/Draft.py
@@ -893,9 +893,6 @@ def calculatePlacementsOnPath(shapeRotation, pathwire, count, xlate, align):
 #---------------------------------------------------------------------------
 # Python Features definitions
 #---------------------------------------------------------------------------
-import draftobjects.base
-_DraftObject = draftobjects.base.DraftObject
-
 class _ViewProviderDraftLink:
     "a view provider for link type object"
 

--- a/src/Mod/Draft/Draft.py
+++ b/src/Mod/Draft/Draft.py
@@ -232,6 +232,9 @@ from draftviewproviders.view_base import _ViewProviderDraftPart
 from draftmake.make_circle import make_circle, makeCircle
 from draftobjects.circle import Circle, _Circle
 
+# arcs
+from draftmake.make_arc_3points import make_arc_3points
+
 # ellipse
 from draftmake.make_ellipse import make_ellipse, makeEllipse
 from draftobjects.ellipse import Ellipse, _Ellipse

--- a/src/Mod/Draft/draftguitools/gui_arcs.py
+++ b/src/Mod/Draft/draftguitools/gui_arcs.py
@@ -32,15 +32,16 @@ from PySide.QtCore import QT_TRANSLATE_NOOP
 
 import FreeCAD as App
 import FreeCADGui as Gui
-from FreeCAD import Units as U
+import Draft
 import Draft_rc
 import DraftVecUtils
 import draftguitools.gui_base_original as gui_base_original
 import draftguitools.gui_base as gui_base
 import draftguitools.gui_tool_utils as gui_tool_utils
 import draftguitools.gui_trackers as trackers
-import draftobjects.arc_3points as arc3
 import draftutils.utils as utils
+
+from FreeCAD import Units as U
 from draftutils.messages import _msg, _err
 from draftutils.translate import translate, _tr
 
@@ -553,13 +554,13 @@ class Arc_3Points(gui_base.GuiCommandSimplest):
             # proceed with creating the final object.
             # Draw a simple `Part::Feature` if the parameter is `True`.
             if utils.get_param("UsePartPrimitives", False):
-                arc3.make_arc_3points([self.points[0],
-                                       self.points[1],
-                                       self.points[2]], primitive=True)
+                Draft.make_arc_3points([self.points[0],
+                                        self.points[1],
+                                        self.points[2]], primitive=True)
             else:
-                arc3.make_arc_3points([self.points[0],
-                                       self.points[1],
-                                       self.points[2]], primitive=False)
+                Draft.make_arc_3points([self.points[0],
+                                        self.points[1],
+                                        self.points[2]], primitive=False)
             self.tracker.off()
             self.doc.recompute()
 

--- a/src/Mod/Draft/draftmake/make_arc_3points.py
+++ b/src/Mod/Draft/draftmake/make_arc_3points.py
@@ -110,6 +110,9 @@ def make_arc_3points(points, placement=None, face=False,
         The new arc object.
         Normally it returns a parametric Draft object (`Part::Part2DObject`).
         If `primitive` is `True`, it returns a basic `Part::Feature`.
+
+    None
+        Returns `None` if there is a problem and the object cannot be created.
     """
     _name = "make_arc_3points"
     utils.print_header(_name, "Arc by 3 points")

--- a/src/Mod/Draft/draftobjects/draft_annotation.py
+++ b/src/Mod/Draft/draftobjects/draft_annotation.py
@@ -26,60 +26,61 @@
 # \ingroup DRAFT
 # \brief This module provides the object code for Draft Annotation.
 
-import FreeCAD as App
 from PySide.QtCore import QT_TRANSLATE_NOOP
-from draftutils import gui_utils
+
+from draftutils.messages import _wrn
+from draftutils.translate import _tr
+
 
 class DraftAnnotation(object):
     """The Draft Annotation Base object.
 
     This class is not used directly, but inherited by all Draft annotation
     objects.
-    
+
     LinearDimension through DimensionBase
     AngularDimension through DimensionBase
     Label
     Text
     """
-    def __init__(self, obj, tp="Annotation"):
-        """Add general Annotation properties to the object"""
 
+    def __init__(self, obj, tp="Annotation"):
         self.Type = tp
 
-
     def onDocumentRestored(self, obj):
-        '''Check if new properties are present after object is recreated.'''
+        """Run when the document that is using this class is restored.
+
+        Check if new properties are present after the object is restored
+        in order to migrate older objects.
+        """
         if hasattr(obj, "ViewObject") and obj.ViewObject:
-            if not 'ScaleMultiplier' in obj.ViewObject.PropertiesList:
+            if not hasattr(obj.ViewObject, 'ScaleMultiplier'):
                 # annotation properties
-                _msg = QT_TRANSLATE_NOOP("Draft", 
-                                         "Adding property ScaleMultiplier to ")
-                App.Console.PrintMessage(_msg + obj.Name + "\n")
-                obj.ViewObject.addProperty("App::PropertyFloat","ScaleMultiplier",
-                                "Annotation",QT_TRANSLATE_NOOP("App::Property",
-                                "Dimension size overall multiplier"))
-                obj.ViewObject.ScaleMultiplier = 1.00
+                vobj = obj.ViewObject
+                _tip = "Dimension size overall multiplier"
+                vobj.addProperty("App::PropertyFloat",
+                                 "ScaleMultiplier",
+                                 "Annotation",
+                                 QT_TRANSLATE_NOOP("App::Property", _tip))
+                vobj.ScaleMultiplier = 1.00
+
+                _info = "added view property 'ScaleMultiplier'"
+                _wrn("v0.19, " + obj.Label + ", " + _tr(_info))
 
     def __getstate__(self):
         return self.Type
 
-
-    def __setstate__(self,state):
+    def __setstate__(self, state):
         if state:
-            if isinstance(state,dict) and ("Type" in state):
+            if isinstance(state, dict) and ("Type" in state):
                 self.Type = state["Type"]
             else:
                 self.Type = state
 
-
-    def execute(self,obj):
-        '''Do something when recompute object'''
-
+    def execute(self, obj):
+        """Do something when recompute object."""
         return
-
 
     def onChanged(self, obj, prop):
-        '''Do something when a property has changed'''
-                
+        """Do something when a property has changed."""
         return
-

--- a/src/Mod/Draft/drafttests/draft_test_objects.py
+++ b/src/Mod/Draft/drafttests/draft_test_objects.py
@@ -32,11 +32,11 @@ Or load it as a module and use the defined function.
 import os
 import datetime
 import math
+
 import FreeCAD as App
-from FreeCAD import Vector
 import Draft
+from FreeCAD import Vector
 from draftutils.messages import _msg, _wrn
-import draftobjects.arc_3points
 
 if App.GuiUp:
     import DraftFillet
@@ -172,9 +172,9 @@ def create_test_file(file_name="draft_test_objects",
 
     _msg(16 * "-")
     _msg("Circular arc 3 points")
-    draftobjects.arc_3points.make_arc_3points([Vector(4600, 0, 0),
-                                               Vector(4600, 800, 0),
-                                               Vector(4000, 1000, 0)])
+    Draft.make_arc_3points([Vector(4600, 0, 0),
+                            Vector(4600, 800, 0),
+                            Vector(4000, 1000, 0)])
     t_xpos += 600
     _t = Draft.makeText(["Circular arc 3 points"], Vector(t_xpos, t_ypos, 0))
     _set_text(_t)

--- a/src/Mod/Draft/drafttests/test_creation.py
+++ b/src/Mod/Draft/drafttests/test_creation.py
@@ -133,8 +133,7 @@ class DraftCreation(unittest.TestCase):
         _msg("  a={0}, b={1}".format(a, b))
         _msg("  c={}".format(c))
 
-        import draftobjects.arc_3points as arc3
-        obj = arc3.make_arc_3points([a, b, c])
+        obj = Draft.make_arc_3points([a, b, c])
         self.assertTrue(obj, "'{}' failed".format(operation))
 
     def test_ellipse(self):

--- a/src/Mod/Draft/draftviewproviders/view_base.py
+++ b/src/Mod/Draft/draftviewproviders/view_base.py
@@ -93,17 +93,27 @@ class ViewProviderDraft(object):
         self.texture = None
         self.texcoords = None
 
-        vobj.addProperty("App::PropertyEnumeration", "Pattern", "Draft",
-                         QT_TRANSLATE_NOOP("App::Property",
-                                           "Defines a hatch pattern"))
-        vobj.addProperty("App::PropertyFloat", "PatternSize", "Draft",
-                         QT_TRANSLATE_NOOP("App::Property",
-                                           "Sets the size of the pattern"))
-        vobj.Pattern = ["None"] + list(utils.svg_patterns().keys())
-        vobj.PatternSize = 1
-
+        self._set_properties(vobj)
         # This class is assigned to the Proxy attribute
         vobj.Proxy = self
+
+    def _set_properties(self, vobj):
+        """Set the properties of objects if they don't exist."""
+        if not hasattr(vobj, "Pattern"):
+            _tip = "Defines a hatch pattern."
+            vobj.addProperty("App::PropertyEnumeration",
+                             "Pattern",
+                             "Draft",
+                             QT_TRANSLATE_NOOP("App::Property", _tip))
+            vobj.Pattern = ["None"] + list(utils.svg_patterns().keys())
+
+        if not hasattr(vobj, "PatternSize"):
+            _tip = "Defines the size of the hatch pattern."
+            vobj.addProperty("App::PropertyFloat",
+                             "PatternSize",
+                             "Draft",
+                             QT_TRANSLATE_NOOP("App::Property", _tip))
+            vobj.PatternSize = 1
 
     def __getstate__(self):
         """Return a tuple of all serializable objects or None.
@@ -138,7 +148,7 @@ class ViewProviderDraft(object):
         so nothing needs to be done here, and it returns `None`.
 
         Parameters
-        ---------
+        ----------
         state : state
             A serialized object.
 
@@ -167,7 +177,7 @@ class ViewProviderDraft(object):
         return
 
     def updateData(self, obj, prop):
-        """This method is run when an object property is changed.
+        """Run when an object property is changed.
 
         Override this method to handle the behavior of the view provider
         depending on changes that occur to the real object's properties.
@@ -241,7 +251,7 @@ class ViewProviderDraft(object):
         return mode
 
     def onChanged(self, vobj, prop):
-        """This method is run when a view property is changed.
+        """Run when a view property is changed.
 
         Override this method to handle the behavior
         of the view provider depending on changes that occur to its properties
@@ -334,7 +344,7 @@ class ViewProviderDraft(object):
             self.texcoords.directionT.setValue(vT.x, vT.y, vT.z)
 
     def execute(self, vobj):
-        """This method is run when the object is created or recomputed.
+        """Run when the object is created or recomputed.
 
         Override this method to produce effects when the object
         is newly created, and whenever the document is recomputed.

--- a/src/Mod/Draft/draftviewproviders/view_wire.py
+++ b/src/Mod/Draft/draftviewproviders/view_wire.py
@@ -20,18 +20,18 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""This module provides the view provider code for Draft wire related objects.
+"""Provides the viewprovider code for polyline and similar objects.
+
+This viewprovider is also used by simple lines, B-splines, bezier curves,
+and similar objects.
 """
 ## @package view_base
 # \ingroup DRAFT
-# \brief This module provides the view provider code for Draft objects like\
-# Line, Polyline, BSpline, BezCurve.
+# \brief Provides the viewprovider code for polyline and similar objects.
 
-
-from pivy import coin
-from PySide import QtCore
-from PySide import QtGui
-
+import pivy.coin as coin
+import PySide.QtCore as QtCore
+import PySide.QtGui as QtGui
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
 import FreeCAD as App
@@ -41,30 +41,46 @@ import draftutils.utils as utils
 import draftutils.gui_utils as gui_utils
 import DraftVecUtils
 import DraftGeomUtils
+from draftutils.messages import _msg
 
 from draftviewproviders.view_base import ViewProviderDraft
 
 
 class ViewProviderWire(ViewProviderDraft):
-    """A base View Provider for the Wire object"""
+    """A base View Provider for the Wire object."""
+
     def __init__(self, vobj):
         super(ViewProviderWire, self).__init__(vobj)
+        self._set_properties(vobj)
 
-        _tip = "Displays a Dimension symbol at the end of the wire"
-        vobj.addProperty("App::PropertyBool", "EndArrow",
-                         "Draft", QT_TRANSLATE_NOOP("App::Property", _tip))
+    def _set_properties(self, vobj):
+        """Set the properties of objects if they don't exist."""
+        super(ViewProviderWire, self)._set_properties(vobj)
 
-        _tip = "Arrow size"
-        vobj.addProperty("App::PropertyLength", "ArrowSize",
-                         "Draft", QT_TRANSLATE_NOOP("App::Property", _tip))
+        if not hasattr(vobj, "EndArrow"):
+            _tip = "Displays a Dimension symbol at the end of the wire."
+            vobj.addProperty("App::PropertyBool",
+                             "EndArrow",
+                             "Draft",
+                             QT_TRANSLATE_NOOP("App::Property", _tip))
+            vobj.EndArrow = False
 
-        _tip = "Arrow type"
-        vobj.addProperty("App::PropertyEnumeration", "ArrowType",
-                         "Draft", QT_TRANSLATE_NOOP("App::Property", _tip))
+        if not hasattr(vobj, "ArrowSize"):
+            _tip = "Arrow size"
+            vobj.addProperty("App::PropertyLength",
+                             "ArrowSize",
+                             "Draft",
+                             QT_TRANSLATE_NOOP("App::Property", _tip))
+            vobj.ArrowSize = utils.get_param("arrowsize", 0.1)
 
-        vobj.ArrowSize = utils.get_param("arrowsize",0.1)
-        vobj.ArrowType = utils.ARROW_TYPES
-        vobj.ArrowType = utils.ARROW_TYPES[utils.get_param("dimsymbol",0)]
+        if not hasattr(vobj, "ArrowType"):
+            _tip = "Arrow type"
+            vobj.addProperty("App::PropertyEnumeration",
+                             "ArrowType",
+                             "Draft",
+                             QT_TRANSLATE_NOOP("App::Property", _tip))
+            vobj.ArrowType = utils.ARROW_TYPES
+            vobj.ArrowType = utils.ARROW_TYPES[utils.get_param("dimsymbol", 0)]
 
     def attach(self, vobj):
         self.Object = vobj.Object
@@ -153,8 +169,8 @@ class ViewProviderWire(ViewProviderDraft):
                         App.ActiveDocument.commitTransaction()
 
                     else:
-                        _msg = "This Wire is already flat"
-                        App.Console.PrintMessage(QT_TRANSLATE_NOOP("Draft", _msg) + "\n")
+                        _flat = "This Wire is already flat"
+                        _msg(QT_TRANSLATE_NOOP("Draft", _flat))
 
 
 _ViewProviderWire = ViewProviderWire


### PR DESCRIPTION
Implement the `_set_properties` method to set the properties of the `ViewProviderDraft` and `ViewProviderWire` so that the properties are added only if they do not exist already. This is done in part to improve the migration of the `Fillet` class in #3449.

Also small changes to the Annotation class.

This must be merged after #3447.

---

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists
