### PR TITLE
Draft: migrate prototype Fillet objects to new structure

### DIFF
--- a/src/Mod/Draft/CMakeLists.txt
+++ b/src/Mod/Draft/CMakeLists.txt
@@ -153,6 +153,7 @@ SET(Draft_view_providers
 
 SET(Creator_tools
     draftguitools/gui_lines.py
+    draftguitools/gui_fillets.py
     draftguitools/gui_splines.py
     draftguitools/gui_beziers.py
     draftguitools/gui_rectangles.py

--- a/src/Mod/Draft/CMakeLists.txt
+++ b/src/Mod/Draft/CMakeLists.txt
@@ -88,6 +88,7 @@ SET(Draft_make_functions
     draftmake/make_copy.py
     draftmake/make_ellipse.py
     draftmake/make_facebinder.py
+    draftmake/make_fillet.py
     draftmake/make_line.py
     draftmake/make_polygon.py
     draftmake/make_point.py
@@ -114,6 +115,7 @@ SET(Draft_objects
     draftobjects/orthoarray.py
     draftobjects/polararray.py
     draftobjects/draft_annotation.py
+    draftobjects/fillet.py
     draftobjects/label.py
     draftobjects/dimension.py
     draftobjects/point.py
@@ -138,6 +140,7 @@ SET(Draft_view_providers
     draftviewproviders/view_orthoarray.py
     draftviewproviders/view_polararray.py
     draftviewproviders/view_draft_annotation.py
+    draftviewproviders/view_fillet.py
     draftviewproviders/view_label.py
     draftviewproviders/view_dimension.py
     draftviewproviders/view_point.py

--- a/src/Mod/Draft/Draft.py
+++ b/src/Mod/Draft/Draft.py
@@ -76,10 +76,6 @@ from DraftLayer import Layer as _VisGroup
 from DraftLayer import ViewProviderLayer as _ViewProviderVisGroup
 from DraftLayer import makeLayer
 
-# import DraftFillet
-# Fillet = DraftFillet.Fillet
-# makeFillet = DraftFillet.makeFillet
-
 # ---------------------------------------------------------------------------
 # General functions
 # ---------------------------------------------------------------------------

--- a/src/Mod/Draft/Draft.py
+++ b/src/Mod/Draft/Draft.py
@@ -322,6 +322,11 @@ from draftobjects.wpproxy import WorkingPlaneProxy
 if FreeCAD.GuiUp:
     from draftviewproviders.view_wpproxy import ViewProviderWorkingPlaneProxy
 
+from draftmake.make_fillet import make_fillet
+from draftobjects.fillet import Fillet
+if FreeCAD.GuiUp:
+    from draftviewproviders.view_fillet import ViewProviderFillet
+
 #---------------------------------------------------------------------------
 # Draft annotation objects
 #---------------------------------------------------------------------------

--- a/src/Mod/Draft/DraftFillet.py
+++ b/src/Mod/Draft/DraftFillet.py
@@ -101,8 +101,90 @@ class Fillet(base.DraftObject):
         _wrn("v0.19, {0}, '{1}' object ".format(obj.Label, _module)
              + "will be migrated to 'draftobjects.fillet.Fillet'")
 
+        # Save the old properties and delete them
+        old_dict = _save_properties0_19_to_0_19(obj)
+
+        # We assign the new class, which could have different properties
+        # from the older class. Since we removed the older properties
+        # we know the new properties will not collide with the old properties.
+        # The new class itself should handle some logic so that it does not
+        # add already existing properties of the same name and type.
         draftobjects.fillet.Fillet(obj)
 
+        # Assign the old properties
+        obj = _assign_properties0_19_to_0_19(obj, old_dict)
+
+        # The same is done for the viewprovider.
         if App.GuiUp:
             vobj = obj.ViewObject
+            old_dict = _save_vproperties0_19_to_0_19(vobj)
             view_fillet.ViewProviderFillet(vobj)
+            _assign_vproperties0_19_to_0_19(vobj, old_dict)
+
+
+def _save_properties0_19_to_0_19(obj):
+    """Save the old property values and remove the old properties.
+
+    Since we know the structure of the older Proxy class,
+    we can take its old values and store them before
+    we remove the property.
+
+    We do not need to save the old properties if these
+    can be recalculated from the new data.
+    """
+    _wrn("Old property values saved, old properties removed.")
+    old_dict = dict()
+    if hasattr(obj, "Length"):
+        old_dict["Length"] = obj.Length
+        obj.removeProperty("Length")
+    if hasattr(obj, "Start"):
+        old_dict["Start"] = obj.Start
+        obj.removeProperty("Start")
+    if hasattr(obj, "End"):
+        old_dict["End"] = obj.End
+        obj.removeProperty("End")
+    if hasattr(obj, "FilletRadius"):
+        old_dict["FilletRadius"] = obj.FilletRadius
+        obj.removeProperty("FilletRadius")
+    return old_dict
+
+
+def _assign_properties0_19_to_0_19(obj, old_dict):
+    """Assign the new properties from the old properties.
+
+    If new properties are named differently than the older properties
+    or if the old values need to be transformed because the class
+    now manages differently the data, this can be done here.
+    Otherwise simple assigning the old values is possible.
+    """
+    _wrn("New property values added.")
+    if hasattr(obj, "Length"):
+        obj.Length = old_dict["Length"]
+    if hasattr(obj, "Start"):
+        obj.Start = old_dict["Start"]
+    if hasattr(obj, "End"):
+        obj.End = old_dict["End"]
+    if hasattr(obj, "FilletRadius"):
+        obj.FilletRadius = old_dict["FilletRadius"]
+    return obj
+
+
+def _save_vproperties0_19_to_0_19(vobj):
+    """Save the old property values and remove the old properties.
+
+    The view provider didn't add new properties so this just returns
+    an empty element.
+    """
+    _wrn("Old view property values saved, old view properties removed. NONE.")
+    old_dict = dict()
+    return old_dict
+
+
+def _assign_vproperties0_19_to_0_19(vobj, old_dict):
+    """Assign the new properties from the old properties.
+
+    The view provider didn't add new properties so this just returns
+    the same viewprovider.
+    """
+    _wrn("New view property values added. NONE.")
+    return vobj

--- a/src/Mod/Draft/DraftFillet.py
+++ b/src/Mod/Draft/DraftFillet.py
@@ -1,319 +1,76 @@
-"""This module provides the Draft fillet tool.
+# ***************************************************************************
+# *   Copyright (c) 2020 Eliud Cabrera Castillo <e.cabrera-castillo@tum.de> *
+# *                                                                         *
+# *   This program is free software; you can redistribute it and/or modify  *
+# *   it under the terms of the GNU Lesser General Public License (LGPL)    *
+# *   as published by the Free Software Foundation; either version 2 of     *
+# *   the License, or (at your option) any later version.                   *
+# *   for detail see the LICENCE text file.                                 *
+# *                                                                         *
+# *   This program is distributed in the hope that it will be useful,       *
+# *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+# *   GNU Library General Public License for more details.                  *
+# *                                                                         *
+# *   You should have received a copy of the GNU Library General Public     *
+# *   License along with this program; if not, write to the Free Software   *
+# *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
+# *   USA                                                                   *
+# *                                                                         *
+# ***************************************************************************
+"""Provides the Fillet class for objects created with a prototype version.
+
+The original Fillet object and Gui Command was introduced
+in the development cycle of 0.19, in commit d5ca09c77b, 2019-08-22.
+
+However, when this class was implemented, the reorganization
+of the workbench was not advanced.
+
+When the reorganization was on its way it was clear that this tool
+also needed to be broken into different modules; however, this was done
+only at the end of the reorganization.
+
+In commit 01df7c0a63, 2020-02-10, the Gui Command was removed from
+the graphical interface so that the user cannot create this object
+graphically any more. The object class was still kept
+so that previous objects created between August 2019 and February 2020
+would open correctly.
+
+Now in this module the older class is redirected to the new class
+in order to migrate the object.
+
+A new Gui Command in `draftguitools` and new make function in `draftmake`
+are now used to create `Fillet` objects. Therefore, this module
+is only required to migrate old objects created in that time
+with the 0.19 development version.
+
+Since this module is only used to migrate older objects, it is only temporary,
+and will be removed after one year of the original introduction of the tool,
+that is, in August 2020.
 """
 ## @package DraftFillet
 # \ingroup DRAFT
-# \brief This module provides the Draft fillet tool.
+# \brief Provides Fillet class for objects created with a prototype version.
+#
+# This module is only required to migrate old objects created
+# from August 2019 to February 2020. It will be removed definitely
+# in August 2020, as the new Fillet object should be available.
 
-import FreeCAD
-from FreeCAD import Console as FCC
-import Draft
-import DraftGeomUtils
-import Part
+import draftobjects.fillet
 
-if FreeCAD.GuiUp:
-    import FreeCADGui
-    from PySide.QtCore import QT_TRANSLATE_NOOP
-    from PySide import QtCore
-    import DraftTools
-    import draftguitools.gui_trackers as trackers
-    from DraftGui import translate
-else:
-    def QT_TRANSLATE_NOOP(context, text):
-        return text
+# -----------------------------------------------------------------------------
+# Removed definitions
+# def _extract_edges(objs):
 
-    def translate(context, text):
-        return text
+# def makeFillet(objs, radius=100, chamfer=False, delete=False):
 
+# class Fillet(Draft._DraftObject):
 
-def _extract_edges(objs):
-    """Extract the edges from the given objects (Draft lines or Edges).
+# class CommandFillet(DraftTools.Creator):
+# -----------------------------------------------------------------------------
 
-    objs : list of Draft Lines or Part.Edges
-        The list of edges from which to create the fillet.
-    """
-    o1, o2 = objs
-    if hasattr(o1, "PropertiesList"):
-        if "Proxy" in o1.PropertiesList:
-            if hasattr(o1.Proxy, "Type"):
-                if o1.Proxy.Type in ("Wire", "Fillet"):
-                    e1 = o1.Shape.Edges[0]
-        elif "Shape" in o1.PropertiesList:
-            if o1.Shape.ShapeType in ("Wire", "Edge"):
-                e1 = o1.Shape
-    elif hasattr(o1, "ShapeType"):
-        if o1.ShapeType in "Edge":
-            e1 = o1
-
-    if hasattr(o1, "Label"):
-        FCC.PrintMessage("o1: " + o1.Label)
-    else:
-        FCC.PrintMessage("o1: 1")
-    FCC.PrintMessage(", length: " + str(e1.Length) + "\n")
-
-    if hasattr(o2, "PropertiesList"):
-        if "Proxy" in o2.PropertiesList:
-            if hasattr(o2.Proxy, "Type"):
-                if o2.Proxy.Type in ("Wire", "Fillet"):
-                    e2 = o2.Shape.Edges[0]
-        elif "Shape" in o2.PropertiesList:
-            if o2.Shape.ShapeType in ("Wire", "Edge"):
-                e2 = o2.Shape
-    elif hasattr(o2, "ShapeType"):
-        if o2.ShapeType in "Edge":
-            e2 = o2
-
-    if hasattr(o2, "Label"):
-        FCC.PrintMessage("o2: " + o2.Label)
-    else:
-        FCC.PrintMessage("o2: 2")
-    FCC.PrintMessage(", length: " + str(e2.Length) + "\n")
-
-    return e1, e2
-
-
-def makeFillet(objs, radius=100, chamfer=False, delete=False):
-    """Create a fillet between two lines or edges.
-
-    Parameters
-    ----------
-    objs : list
-        List of two objects of type wire, or edges.
-    radius : float, optional
-        It defaults to 100 mm. The curvature of the fillet.
-    chamfer : bool, optional
-        It defaults to `False`. If it is `True` it no longer produces
-        a rounded fillet but a chamfer (straight edge)
-        with the value of the `radius`.
-    delete : bool, optional
-        It defaults to `False`. If it is `True` it will delete
-        the pair of objects that are used to create the fillet.
-        Otherwise, the original objects will still be there.
-
-    Returns
-    -------
-    Part::Part2DObject
-        The object of type `'Fillet'`.
-        It returns `None` if it fails producing the object.
-    """
-    if len(objs) != 2:
-        FCC.PrintError("makeFillet: "
-                       + translate("draft", "two elements needed") + "\n")
-        return None
-
-    e1, e2 = _extract_edges(objs)
-
-    edges = DraftGeomUtils.fillet([e1, e2], radius, chamfer)
-    if len(edges) < 3:
-        FCC.PrintError("makeFillet: "
-                       + translate("draft", "radius too large"))
-        FCC.PrintError(", r=" + str(radius) + "\n")
-        return None
-
-    _d = translate("draft", "length: ")
-    FCC.PrintMessage("e1, " + _d + str(edges[0].Length) + "\n")
-    FCC.PrintMessage("e2, " + _d + str(edges[1].Length) + "\n")
-    FCC.PrintMessage("e3, " + _d + str(edges[2].Length) + "\n")
-
-    try:
-        wire = Part.Wire(edges)
-    except Part.OCCError:
-        return None
-
-    obj = FreeCAD.ActiveDocument.addObject("Part::Part2DObjectPython",
-                                           "Fillet")
-    Fillet(obj)
-    obj.Shape = wire
-    obj.Length = wire.Length
-    obj.Start = wire.Vertexes[0].Point
-    obj.End = wire.Vertexes[-1].Point
-    obj.FilletRadius = radius
-
-    if delete:
-        FreeCAD.ActiveDocument.removeObject(objs[0].Name)
-        FreeCAD.ActiveDocument.removeObject(objs[1].Name)
-        _r = translate("draft", "removed original objects")
-        FCC.PrintMessage("makeFillet: " + _r + "\n")
-    if FreeCAD.GuiUp:
-        Draft._ViewProviderWire(obj.ViewObject)
-        Draft.formatObject(obj)
-        Draft.select(obj)
-    return obj
-
-
-class Fillet(Draft._DraftObject):
-    """The fillet object"""
-
-    def __init__(self, obj):
-        Draft._DraftObject.__init__(self, obj, "Fillet")
-        obj.addProperty("App::PropertyVectorDistance", "Start", "Draft", QT_TRANSLATE_NOOP("App::Property", "The start point of this line"))
-        obj.addProperty("App::PropertyVectorDistance", "End", "Draft", QT_TRANSLATE_NOOP("App::Property", "The end point of this line"))
-        obj.addProperty("App::PropertyLength", "Length", "Draft", QT_TRANSLATE_NOOP("App::Property", "The length of this line"))
-        obj.addProperty("App::PropertyLength", "FilletRadius", "Draft", QT_TRANSLATE_NOOP("App::Property", "Radius to use to fillet the corners"))
-        obj.setEditorMode("Start", 1)
-        obj.setEditorMode("End", 1)
-        obj.setEditorMode("Length", 1)
-        # Change to 0 to make it editable
-        obj.setEditorMode("FilletRadius", 1)
-
-    def execute(self, obj):
-        if hasattr(obj, "Length"):
-            obj.Length = obj.Shape.Length
-        if hasattr(obj, "Start"):
-            obj.Start = obj.Shape.Vertexes[0].Point
-        if hasattr(obj, "End"):
-            obj.End = obj.Shape.Vertexes[-1].Point
-
-    def onChanged(self, obj, prop):
-        # Change the radius of fillet. NOT IMPLEMENTED.
-        if prop in "FilletRadius":
-            pass
-
-
-class CommandFillet(DraftTools.Creator):
-    """The Fillet GUI command definition"""
-
-    def __init__(self):
-        DraftTools.Creator.__init__(self)
-        self.featureName = "Fillet"
-
-    def GetResources(self):
-        return {'Pixmap': 'Draft_Fillet.svg',
-                'MenuText': QT_TRANSLATE_NOOP("draft", "Fillet"),
-                'ToolTip': QT_TRANSLATE_NOOP("draft", "Creates a fillet between two wires or edges.")
-                }
-
-    def Activated(self, name=translate("draft", "Fillet")):
-        DraftTools.Creator.Activated(self, name)
-        if not self.doc:
-            FCC.PrintWarning(translate("draft", "No active document") + "\n")
-            return
-        if self.ui:
-            self.rad = 100
-            self.chamfer = False
-            self.delete = False
-            label = translate("draft", "Fillet radius")
-            tooltip = translate("draft", "Radius of fillet")
-
-            # Call the Task panel for a radius
-            # The graphical widgets are defined in DraftGui
-            self.ui.taskUi(title=name, icon="Draft_Fillet")
-            self.ui.radiusUi()
-            self.ui.sourceCmd = self
-            self.ui.labelRadius.setText(label)
-            self.ui.radiusValue.setToolTip(tooltip)
-            self.ui.setRadiusValue(self.rad, "Length")
-            self.ui.check_delete = self.ui._checkbox("isdelete",
-                                                     self.ui.layout,
-                                                     checked=self.delete)
-            self.ui.check_delete.setText(translate("draft",
-                                                   "Delete original objects"))
-            self.ui.check_delete.show()
-            self.ui.check_chamfer = self.ui._checkbox("ischamfer",
-                                                      self.ui.layout,
-                                                      checked=self.chamfer)
-            self.ui.check_chamfer.setText(translate("draft",
-                                                    "Create chamfer"))
-            self.ui.check_chamfer.show()
-
-            QtCore.QObject.connect(self.ui.check_delete,
-                                   QtCore.SIGNAL("stateChanged(int)"),
-                                   self.set_delete)
-            QtCore.QObject.connect(self.ui.check_chamfer,
-                                   QtCore.SIGNAL("stateChanged(int)"),
-                                   self.set_chamfer)
-            self.linetrack = trackers.lineTracker(dotted=True)
-            self.arctrack = trackers.arcTracker()
-            # self.call = self.view.addEventCallback("SoEvent", self.action)
-            FCC.PrintMessage(translate("draft", "Enter radius") + "\n")
-
-    def action(self, arg):
-        """Scene event handler. CURRENTLY NOT USED.
-
-        Here the displaying of the trackers (previews)
-        should be implemented by considering the current value of the
-        `ui.radiusValue`.
-        """
-        if arg["Type"] == "SoKeyboardEvent":
-            if arg["Key"] == "ESCAPE":
-                self.finish()
-        elif arg["Type"] == "SoLocation2Event":
-            self.point, ctrlPoint, info = DraftTools.getPoint(self, arg)
-            DraftTools.redraw3DView()
-
-    def set_delete(self):
-        """This function is called when the delete checkbox changes"""
-        self.delete = self.ui.check_delete.isChecked()
-        FCC.PrintMessage(translate("draft", "Delete original objects: ")
-                         + str(self.delete) + "\n")
-
-    def set_chamfer(self):
-        """This function is called when the chamfer checkbox changes"""
-        self.chamfer = self.ui.check_chamfer.isChecked()
-        FCC.PrintMessage(translate("draft", "Chamfer mode: ")
-                         + str(self.chamfer) + "\n")
-
-    def numericRadius(self, rad):
-        """This function is called when a valid radius is entered"""
-        self.rad = rad
-        self.draw_arc(rad, self.chamfer, self.delete)
-        self.finish()
-
-    def draw_arc(self, rad, chamfer, delete):
-        """Processes the selection and draws the actual object"""
-        wires = FreeCADGui.Selection.getSelection()
-        _two = translate("draft", "two elements needed")
-        if not wires:
-            FCC.PrintError("CommandFillet: " + _two + "\n")
-            return
-        if len(wires) != 2:
-            FCC.PrintError("CommandFillet: " + _two + "\n")
-            return
-
-        for o in wires:
-            FCC.PrintMessage("CommandFillet: " + Draft.getType(o) + "\n")
-
-        _test = translate("draft", "Test object")
-        _test_off = translate("draft", "Test object removed")
-        _cant = translate("draft", "fillet cannot be created")
-
-        FCC.PrintMessage(4*"=" + _test + "\n")
-        arc = makeFillet(wires, rad)
-        if not arc:
-            FCC.PrintError("CommandFillet: " + _cant + "\n")
-            return
-        self.doc.removeObject(arc.Name)
-        FCC.PrintMessage(4*"=" + _test_off + "\n")
-
-        doc = 'FreeCAD.ActiveDocument.'
-        _wires = '[' + doc + wires[0].Name + ', ' + doc + wires[1].Name + ']'
-
-        FreeCADGui.addModule("DraftFillet")
-        name = translate("draft", "Create fillet")
-
-        args = _wires + ', radius=' + str(rad)
-        if chamfer:
-            args += ', chamfer=' + str(chamfer)
-        if delete:
-            args += ', delete=' + str(delete)
-        func = ['arc = DraftFillet.makeFillet(' + args + ')']
-        func.append('Draft.autogroup(arc)')
-
-        # Here we could remove the old objects, but the makeFillet()
-        # command already includes an option to remove them.
-        # Therefore, the following is not necessary
-        # rems = [doc + 'removeObject("' + o.Name + '")' for o in wires]
-        # func.extend(rems)
-        func.append('FreeCAD.ActiveDocument.recompute()')
-        self.commit(name, func)
-
-    def finish(self, close=False):
-        """Terminates the operation."""
-        DraftTools.Creator.finish(self)
-        if self.ui:
-            self.linetrack.finalize()
-            self.arctrack.finalize()
-            self.doc.recompute()
-
-
-if FreeCAD.GuiUp:
-    FreeCADGui.addCommand('Draft_Fillet', CommandFillet())
+# When an old object is opened it will reconstruct the object
+# by searching for the class `DraftFillet.Fillet`.
+# So we redirect this class to the new class in the new module.
+# This migrates the old object to the new object.
+Fillet = draftobjects.fillet.Fillet

--- a/src/Mod/Draft/DraftTools.py
+++ b/src/Mod/Draft/DraftTools.py
@@ -150,6 +150,7 @@ from draftguitools.gui_base_original import Creator
 
 from draftguitools.gui_lines import Line
 from draftguitools.gui_lines import Wire
+from draftguitools.gui_fillets import Fillet
 from draftguitools.gui_splines import BSpline
 from draftguitools.gui_beziers import BezCurve
 from draftguitools.gui_beziers import CubicBezCurve

--- a/src/Mod/Draft/draftguitools/gui_fillets.py
+++ b/src/Mod/Draft/draftguitools/gui_fillets.py
@@ -201,4 +201,4 @@ class Fillet(gui_base_original.Creator):
             self.doc.recompute()
 
 
-Gui.addCommand('Draft_Fillet_new', Fillet())
+Gui.addCommand('Draft_Fillet', Fillet())

--- a/src/Mod/Draft/draftguitools/gui_fillets.py
+++ b/src/Mod/Draft/draftguitools/gui_fillets.py
@@ -1,0 +1,204 @@
+# ***************************************************************************
+# *   (c) 2020 Eliud Cabrera Castillo <e.cabrera-castillo@tum.de>           *
+# *                                                                         *
+# *   This file is part of the FreeCAD CAx development system.              *
+# *                                                                         *
+# *   This program is free software; you can redistribute it and/or modify  *
+# *   it under the terms of the GNU Lesser General Public License (LGPL)    *
+# *   as published by the Free Software Foundation; either version 2 of     *
+# *   the License, or (at your option) any later version.                   *
+# *   for detail see the LICENCE text file.                                 *
+# *                                                                         *
+# *   FreeCAD is distributed in the hope that it will be useful,            *
+# *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+# *   GNU Library General Public License for more details.                  *
+# *                                                                         *
+# *   You should have received a copy of the GNU Library General Public     *
+# *   License along with FreeCAD; if not, write to the Free Software        *
+# *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
+# *   USA                                                                   *
+# *                                                                         *
+# ***************************************************************************
+"""Provides tools for creating fillets between two lines.
+
+TODO: Currently this tool uses the DraftGui widgets. We want to avoid using
+this big module because it creates manually the interface.
+Instead we should provide its own .ui file and task panel,
+similar to the Ortho Array tool.
+"""
+## @package gui_fillet
+# \ingroup DRAFT
+# \brief Provides tools for creating fillets between two lines.
+
+import PySide.QtCore as QtCore
+from PySide.QtCore import QT_TRANSLATE_NOOP
+
+import FreeCADGui as Gui
+import Draft
+import Draft_rc
+import draftutils.utils as utils
+import draftguitools.gui_base_original as gui_base_original
+import draftguitools.gui_tool_utils as gui_tool_utils
+# import draftguitools.gui_trackers as trackers
+from draftutils.messages import _msg, _err
+from draftutils.translate import translate, _tr
+
+# The module is used to prevent complaints from code checkers (flake8)
+True if Draft_rc.__name__ else False
+
+
+class Fillet(gui_base_original.Creator):
+    """Gui command for the Fillet tool."""
+
+    def __init__(self):
+        super(Fillet, self).__init__()
+        self.featureName = "Fillet"
+
+    def GetResources(self):
+        """Set icon, menu and tooltip."""
+        _tip = "Creates a fillet between two selected wires or edges."
+
+        return {'Pixmap': 'Draft_Fillet',
+                'MenuText': QT_TRANSLATE_NOOP("Draft", "Fillet"),
+                'ToolTip': QT_TRANSLATE_NOOP("Draft", _tip)}
+
+    def Activated(self, name=translate("Draft", "Fillet")):
+        """Execute when the command is called."""
+        super(Fillet, self).Activated(name=name)
+
+        if self.ui:
+            self.rad = 100
+            self.chamfer = False
+            self.delete = False
+            label = translate("draft", "Fillet radius")
+            tooltip = translate("draft", "Radius of fillet")
+
+            # Call the task panel defined in DraftGui to enter a radius.
+            self.ui.taskUi(title=name, icon="Draft_Fillet")
+            self.ui.radiusUi()
+            self.ui.sourceCmd = self
+            self.ui.labelRadius.setText(label)
+            self.ui.radiusValue.setToolTip(tooltip)
+            self.ui.setRadiusValue(self.rad, "Length")
+            self.ui.check_delete = self.ui._checkbox("isdelete",
+                                                     self.ui.layout,
+                                                     checked=self.delete)
+            self.ui.check_delete.setText(translate("Draft",
+                                                   "Delete original objects"))
+            self.ui.check_delete.show()
+            self.ui.check_chamfer = self.ui._checkbox("ischamfer",
+                                                      self.ui.layout,
+                                                      checked=self.chamfer)
+            self.ui.check_chamfer.setText(translate("Draft",
+                                                    "Create chamfer"))
+            self.ui.check_chamfer.show()
+
+            # TODO: change to Qt5 style
+            QtCore.QObject.connect(self.ui.check_delete,
+                                   QtCore.SIGNAL("stateChanged(int)"),
+                                   self.set_delete)
+            QtCore.QObject.connect(self.ui.check_chamfer,
+                                   QtCore.SIGNAL("stateChanged(int)"),
+                                   self.set_chamfer)
+
+            # TODO: somehow we need to set up the trackers
+            # to show a preview of the fillet.
+
+            # self.linetrack = trackers.lineTracker(dotted=True)
+            # self.arctrack = trackers.arcTracker()
+            # self.call = self.view.addEventCallback("SoEvent", self.action)
+            _msg(_tr("Enter radius."))
+
+    def action(self, arg):
+        """Scene event handler. CURRENTLY NOT USED.
+
+        Here the displaying of the trackers (previews)
+        should be implemented by considering the current value of the
+        `ui.radiusValue`.
+        """
+        if arg["Type"] == "SoKeyboardEvent":
+            if arg["Key"] == "ESCAPE":
+                self.finish()
+        elif arg["Type"] == "SoLocation2Event":
+            self.point, ctrlPoint, info = gui_tool_utils.getPoint(self, arg)
+            gui_tool_utils.redraw3DView()
+
+    def set_delete(self):
+        """Execute as a callback when the delete checkbox changes."""
+        self.delete = self.ui.check_delete.isChecked()
+        _msg(_tr("Delete original objects: ") + str(self.delete))
+
+    def set_chamfer(self):
+        """Execute as a callback when the chamfer checkbox changes."""
+        self.chamfer = self.ui.check_chamfer.isChecked()
+        _msg(_tr("Chamfer mode: ") + str(self.chamfer))
+
+    def numericRadius(self, rad):
+        """Validate the entry radius in the user interface.
+
+        This function is called by the toolbar or taskpanel interface
+        when a valid radius has been entered in the input field.
+        """
+        self.rad = rad
+        self.draw_arc(rad, self.chamfer, self.delete)
+        self.finish()
+
+    def draw_arc(self, rad, chamfer, delete):
+        """Process the selection and draw the actual object."""
+        wires = Gui.Selection.getSelection()
+
+        if not wires or len(wires) != 2:
+            _err(_tr("Two elements needed."))
+            return
+
+        for o in wires:
+            _msg(utils.get_type(o))
+
+        _test = translate("draft", "Test object")
+        _test_off = translate("draft", "Test object removed")
+        _cant = translate("draft", "Fillet cannot be created")
+
+        _msg(4*"=" + _test)
+        arc = Draft.make_fillet(wires, rad)
+        if not arc:
+            _err(_cant)
+            return
+        self.doc.removeObject(arc.Name)
+        _msg(4*"=" + _test_off)
+
+        _doc = 'FreeCAD.ActiveDocument.'
+
+        _wires = '['
+        _wires += _doc + wires[0].Name + ', '
+        _wires += _doc + wires[1].Name
+        _wires += ']'
+
+        Gui.addModule("Draft")
+
+        _cmd = 'Draft.make_fillet'
+        _cmd += '('
+        _cmd += _wires + ', '
+        _cmd += 'radius=' + str(rad)
+        if chamfer:
+            _cmd += ', chamfer=' + str(chamfer)
+        if delete:
+            _cmd += ', delete=' + str(delete)
+        _cmd += ')'
+        _cmd_list = ['arc = ' + _cmd,
+                     'Draft.autogroup(arc)',
+                     'FreeCAD.ActiveDocument.recompute()']
+
+        self.commit(translate("draft", "Create fillet"),
+                    _cmd_list)
+
+    def finish(self, close=False):
+        """Terminate the operation."""
+        super(Fillet, self).finish()
+        if self.ui:
+            # self.linetrack.finalize()
+            # self.arctrack.finalize()
+            self.doc.recompute()
+
+
+Gui.addCommand('Draft_Fillet_new', Fillet())

--- a/src/Mod/Draft/draftmake/make_fillet.py
+++ b/src/Mod/Draft/draftmake/make_fillet.py
@@ -1,0 +1,173 @@
+# ***************************************************************************
+# *   Copyright (c) 2019 Eliud Cabrera Castillo <e.cabrera-castillo@tum.de> *
+# *                                                                         *
+# *   This program is free software; you can redistribute it and/or modify  *
+# *   it under the terms of the GNU Lesser General Public License (LGPL)    *
+# *   as published by the Free Software Foundation; either version 2 of     *
+# *   the License, or (at your option) any later version.                   *
+# *   for detail see the LICENCE text file.                                 *
+# *                                                                         *
+# *   This program is distributed in the hope that it will be useful,       *
+# *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+# *   GNU Library General Public License for more details.                  *
+# *                                                                         *
+# *   You should have received a copy of the GNU Library General Public     *
+# *   License along with this program; if not, write to the Free Software   *
+# *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
+# *   USA                                                                   *
+# *                                                                         *
+# ***************************************************************************
+"""Provides the code to create Fillet objects.
+
+This creates a `Part::Part2DObjectPython`, and then assigns the Proxy class
+`Fillet`, and the `ViewProviderFillet` for the view provider.
+"""
+## @package make_fillet
+# \ingroup DRAFT
+# \brief Provides the code to create Fillet objects.
+
+import lazy_loader.lazy_loader as lz
+
+import FreeCAD as App
+import Draft_rc
+import DraftGeomUtils
+import draftutils.utils as utils
+import draftutils.gui_utils as gui_utils
+import draftobjects.fillet as fillet
+from draftutils.messages import _msg, _err
+from draftutils.translate import _tr
+
+if App.GuiUp:
+    import draftviewproviders.view_fillet as view_fillet
+
+# Delay import of Part module until first use because it is heavy
+Part = lz.LazyLoader("Part", globals(), "Part")
+
+# The module is used to prevent complaints from code checkers (flake8)
+True if Draft_rc.__name__ else False
+
+
+def _print_obj_length(obj, edge, num=1):
+    if hasattr(obj, "Label"):
+        name = obj.Label
+    else:
+        name = num
+
+    _msg("({0}): {1}; {2} {3}".format(num, name,
+                                      _tr("length:"), edge.Length))
+
+
+def _extract_edges(objs):
+    """Extract the edges from the list of objects, Draft lines or Part.Edges.
+
+    Parameters
+    ----------
+    objs: list of Draft Lines or Part.Edges
+        The list of edges from which to create the fillet.
+    """
+    o1, o2 = objs
+    if hasattr(o1, "PropertiesList"):
+        if "Proxy" in o1.PropertiesList:
+            if hasattr(o1.Proxy, "Type"):
+                if o1.Proxy.Type in ("Wire", "Fillet"):
+                    e1 = o1.Shape.Edges[0]
+        elif "Shape" in o1.PropertiesList:
+            if o1.Shape.ShapeType in ("Wire", "Edge"):
+                e1 = o1.Shape
+    elif hasattr(o1, "ShapeType"):
+        if o1.ShapeType in "Edge":
+            e1 = o1
+
+    _print_obj_length(o1, e1, num=1)
+
+    if hasattr(o2, "PropertiesList"):
+        if "Proxy" in o2.PropertiesList:
+            if hasattr(o2.Proxy, "Type"):
+                if o2.Proxy.Type in ("Wire", "Fillet"):
+                    e2 = o2.Shape.Edges[0]
+        elif "Shape" in o2.PropertiesList:
+            if o2.Shape.ShapeType in ("Wire", "Edge"):
+                e2 = o2.Shape
+    elif hasattr(o2, "ShapeType"):
+        if o2.ShapeType in "Edge":
+            e2 = o2
+
+    _print_obj_length(o2, e2, num=2)
+
+    return e1, e2
+
+
+def make_fillet(objs, radius=100, chamfer=False, delete=False):
+    """Create a fillet between two lines or Part.Edges.
+
+    Parameters
+    ----------
+    objs: list
+        List of two objects of type wire, or edges.
+
+    radius: float, optional
+        It defaults to 100. The curvature of the fillet.
+
+    chamfer: bool, optional
+        It defaults to `False`. If it is `True` it no longer produces
+        a rounded fillet but a chamfer (straight edge)
+        with the value of the `radius`.
+
+    delete: bool, optional
+        It defaults to `False`. If it is `True` it will delete
+        the pair of objects that are used to create the fillet.
+        Otherwise, the original objects will still be there.
+
+    Returns
+    -------
+    Part::Part2DObjectPython
+        The object of Proxy type `'Fillet'`.
+        It returns `None` if it fails producing the object.
+    """
+    _name = "make_fillet"
+    utils.print_header(_name, "Fillet")
+
+    if len(objs) != 2:
+        _err(_tr("Two elements are needed."))
+        return None
+
+    e1, e2 = _extract_edges(objs)
+
+    edges = DraftGeomUtils.fillet([e1, e2], radius, chamfer)
+    if len(edges) < 3:
+        _err(_tr("Radius is too large") + ", r={}".format(radius))
+        return None
+
+    lengths = [edges[0].Length, edges[1].Length, edges[2].Length]
+    _msg(_tr("Segment") + " 1, " + _tr("length:") + " {}".format(lengths[0]))
+    _msg(_tr("Segment") + " 2, " + _tr("length:") + " {}".format(lengths[1]))
+    _msg(_tr("Segment") + " 3, " + _tr("length:") + " {}".format(lengths[2]))
+
+    try:
+        wire = Part.Wire(edges)
+    except Part.OCCError:
+        return None
+
+    _doc = App.activeDocument()
+    obj = _doc.addObject("Part::Part2DObjectPython",
+                         "Fillet")
+    fillet.Fillet(obj)
+    obj.Shape = wire
+    obj.Length = wire.Length
+    obj.Start = wire.Vertexes[0].Point
+    obj.End = wire.Vertexes[-1].Point
+    obj.FilletRadius = radius
+
+    if delete:
+        _doc.removeObject(objs[0].Name)
+        _doc.removeObject(objs[1].Name)
+        _msg(_tr("Removed original objects."))
+
+    if App.GuiUp:
+        view_fillet.ViewProviderFillet(obj.ViewObject)
+        gui_utils.format_object(obj)
+        gui_utils.select(obj)
+        gui_utils.autogroup(obj)
+
+    return obj

--- a/src/Mod/Draft/draftobjects/fillet.py
+++ b/src/Mod/Draft/draftobjects/fillet.py
@@ -1,0 +1,123 @@
+# ***************************************************************************
+# *   Copyright (c) 2020 Eliud Cabrera Castillo <e.cabrera-castillo@tum.de> *
+# *                                                                         *
+# *   This program is free software; you can redistribute it and/or modify  *
+# *   it under the terms of the GNU Lesser General Public License (LGPL)    *
+# *   as published by the Free Software Foundation; either version 2 of     *
+# *   the License, or (at your option) any later version.                   *
+# *   for detail see the LICENCE text file.                                 *
+# *                                                                         *
+# *   This program is distributed in the hope that it will be useful,       *
+# *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+# *   GNU Library General Public License for more details.                  *
+# *                                                                         *
+# *   You should have received a copy of the GNU Library General Public     *
+# *   License along with this program; if not, write to the Free Software   *
+# *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
+# *   USA                                                                   *
+# *                                                                         *
+# ***************************************************************************
+"""Provides the object code for the Fillet object."""
+## @package fillet
+# \ingroup DRAFT
+# \brief Provides the object code for the Fillet object.
+
+from PySide.QtCore import QT_TRANSLATE_NOOP
+
+import FreeCAD as App
+import draftobjects.base as base
+from draftutils.messages import _msg
+
+
+class Fillet(base.DraftObject):
+    """Proxy class for the Fillet object."""
+
+    def __init__(self, obj):
+        super(Fillet, self).__init__(obj, "Fillet")
+        self._set_properties(obj)
+
+    def _set_properties(self, obj):
+        """Set the properties of objects if they don't exist."""
+        if not hasattr(obj, "Start"):
+            _tip = "The start point of this line."
+            obj.addProperty("App::PropertyVectorDistance",
+                            "Start",
+                            "Draft",
+                            QT_TRANSLATE_NOOP("App::Property", _tip))
+            obj.Start = App.Vector(0, 0, 0)
+
+        if not hasattr(obj, "End"):
+            _tip = "The end point of this line."
+            obj.addProperty("App::PropertyVectorDistance",
+                            "End",
+                            "Draft",
+                            QT_TRANSLATE_NOOP("App::Property", _tip))
+            obj.End = App.Vector(0, 0, 0)
+
+        if not hasattr(obj, "Length"):
+            _tip = "The length of this line."
+            obj.addProperty("App::PropertyLength",
+                            "Length",
+                            "Draft",
+                            QT_TRANSLATE_NOOP("App::Property", _tip))
+            obj.Length = 0
+
+        if not hasattr(obj, "FilletRadius"):
+            _tip = "Radius to use to fillet the corner."
+            obj.addProperty("App::PropertyLength",
+                            "FilletRadius",
+                            "Draft",
+                            QT_TRANSLATE_NOOP("App::Property", _tip))
+            obj.FilletRadius = 0
+
+        # TODO: these two properties should link two straight lines
+        # or edges so we can use them to build a fillet from them.
+        # if not hasattr(obj, "Edge1"):
+        #    _tip = "First line used as reference."
+        #    obj.addProperty("App::PropertyLinkGlobal",
+        #                    "Edge1",
+        #                    "Draft",
+        #                    QT_TRANSLATE_NOOP("App::Property", _tip))
+
+        # if not hasattr(obj, "Edge2"):
+        #    _tip = "Second line used as reference."
+        #    obj.addProperty("App::PropertyLinkGlobal",
+        #                    "Edge2",
+        #                    "Draft",
+        #                    QT_TRANSLATE_NOOP("App::Property", _tip))
+
+        # Read only, change to 0 to make it editable.
+        # The Fillet Radius should be made editable
+        # when we are able to recalculate the arc of the fillet.
+        obj.setEditorMode("Start", 1)
+        obj.setEditorMode("End", 1)
+        obj.setEditorMode("Length", 1)
+        obj.setEditorMode("FilletRadius", 1)
+        # obj.setEditorMode("Edge1", 1)
+        # obj.setEditorMode("Edge2", 1)
+
+    def execute(self, obj):
+        """Run when the object is created or recomputed."""
+        if hasattr(obj, "Length"):
+            obj.Length = obj.Shape.Length
+        if hasattr(obj, "Start"):
+            obj.Start = obj.Shape.Vertexes[0].Point
+        if hasattr(obj, "End"):
+            obj.End = obj.Shape.Vertexes[-1].Point
+
+    def _update_radius(self, obj, radius):
+        if (hasattr(obj, "Line1") and hasattr(obj, "Line2")
+                and obj.Line1 and obj.Line2):
+            _msg("Recalculate the radius with objects.")
+
+        _msg("Update radius currently not implemented: r={}".format(radius))
+
+    def onChanged(self, obj, prop):
+        """Change the radius of fillet. NOT IMPLEMENTED.
+
+        This should automatically recalculate the new fillet
+        based on the new value of `FilletRadius`.
+        """
+        if prop in "FilletRadius":
+            self._update_radius(obj, obj.FilletRadius)

--- a/src/Mod/Draft/drafttests/draft_test_objects.py
+++ b/src/Mod/Draft/drafttests/draft_test_objects.py
@@ -35,11 +35,11 @@ import math
 
 import FreeCAD as App
 import Draft
-from FreeCAD import Vector
+
 from draftutils.messages import _msg, _wrn
+from FreeCAD import Vector
 
 if App.GuiUp:
-    import DraftFillet
     import FreeCADGui as Gui
 
 
@@ -141,13 +141,7 @@ def create_test_file(file_name="draft_test_objects",
         line_h_2.ViewObject.DrawStyle = "Dotted"
     App.ActiveDocument.recompute()
 
-    try:
-        DraftFillet.makeFillet([line_h_1, line_h_2], 400)
-    except Exception:
-        _wrn("Fillet could not be created")
-        _wrn("Possible cause: at this moment it may need the interface")
-        rect = Draft.makeRectangle(500, 100)
-        rect.Placement.Base = Vector(14000, 500)
+    Draft.make_fillet([line_h_1, line_h_2], 400)
 
     t_xpos += 900
     _t = Draft.makeText(["Fillet"], Vector(t_xpos, t_ypos, 0))

--- a/src/Mod/Draft/drafttests/test_creation.py
+++ b/src/Mod/Draft/drafttests/test_creation.py
@@ -88,16 +88,10 @@ class DraftCreation(unittest.TestCase):
         L2 = Draft.makeLine(b, c)
         self.doc.recompute()
 
-        if not App.GuiUp:
-            aux._no_gui("DraftFillet")
-            self.assertTrue(True)
-            return
-
-        import DraftFillet
         radius = 4
         _msg("  Fillet")
         _msg("  radius={}".format(radius))
-        obj = DraftFillet.makeFillet([L1, L2], radius)
+        obj = Draft.make_fillet([L1, L2], radius)
         self.assertTrue(obj, "'{}' failed".format(operation))
 
     def test_circle(self):

--- a/src/Mod/Draft/draftutils/init_tools.py
+++ b/src/Mod/Draft/draftutils/init_tools.py
@@ -38,7 +38,7 @@ from PySide.QtCore import QT_TRANSLATE_NOOP
 
 def get_draft_drawing_commands():
     """Return the drawing commands list."""
-    return ["Draft_Line", "Draft_Wire",  # "Draft_Fillet",
+    return ["Draft_Line", "Draft_Wire", "Draft_Fillet", "Draft_Fillet_new",
             "Draft_ArcTools",
             "Draft_Circle", "Draft_Ellipse", "Draft_Rectangle",
             "Draft_Polygon", "Draft_BSpline", "Draft_BezierTools",

--- a/src/Mod/Draft/draftutils/init_tools.py
+++ b/src/Mod/Draft/draftutils/init_tools.py
@@ -38,7 +38,7 @@ from PySide.QtCore import QT_TRANSLATE_NOOP
 
 def get_draft_drawing_commands():
     """Return the drawing commands list."""
-    return ["Draft_Line", "Draft_Wire", "Draft_Fillet", "Draft_Fillet_new",
+    return ["Draft_Line", "Draft_Wire", "Draft_Fillet",
             "Draft_ArcTools",
             "Draft_Circle", "Draft_Ellipse", "Draft_Rectangle",
             "Draft_Polygon", "Draft_BSpline", "Draft_BezierTools",

--- a/src/Mod/Draft/draftviewproviders/view_fillet.py
+++ b/src/Mod/Draft/draftviewproviders/view_fillet.py
@@ -1,0 +1,38 @@
+# ***************************************************************************
+# *   Copyright (c) 2020 Eliud Cabrera Castillo <e.cabrera-castillo@tum.de> *
+# *                                                                         *
+# *   This program is free software; you can redistribute it and/or modify  *
+# *   it under the terms of the GNU Lesser General Public License (LGPL)    *
+# *   as published by the Free Software Foundation; either version 2 of     *
+# *   the License, or (at your option) any later version.                   *
+# *   for detail see the LICENCE text file.                                 *
+# *                                                                         *
+# *   This program is distributed in the hope that it will be useful,       *
+# *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+# *   GNU Library General Public License for more details.                  *
+# *                                                                         *
+# *   You should have received a copy of the GNU Library General Public     *
+# *   License along with this program; if not, write to the Free Software   *
+# *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
+# *   USA                                                                   *
+# *                                                                         *
+# ***************************************************************************
+"""Provides the view provider code for Fillet objects.
+
+At the moment this view provider subclasses the Wire view provider,
+and behaves the same as it. In the future this could change
+if another behavior is desired.
+"""
+## @package view_fillet
+# \ingroup DRAFT
+# \brief Provides the view provider code for Fillet objects.
+
+from draftviewproviders.view_wire import ViewProviderWire
+
+
+class ViewProviderFillet(ViewProviderWire):
+    """The view provider for the Fillet object."""
+
+    def __init__(self, vobj):
+        super(ViewProviderFillet, self).__init__(vobj)


### PR DESCRIPTION
This migrates the code from the older `DraftFillet.Fillet` class to the newer `draftobjects.fillet.Fillet` class that uses the new workbench structure. The object, viewprovider, Gui Command, and unit tests are all updated to use the new code.

This class was introduced in August 2019, #2441, and it was hidden in February 2020, 01df7c0a63, so it was available only in the 0.19 development version for a short period of time.

This code migrates the objects as described in the wiki, [Scripted objects migration](https://wiki.freecadweb.org/Scripted_objects_migration), method 3.

Although the object is not very complex, and thus a complex process of migration is not needed, we do it anyway to have record of it. We can refer to this in the future, if we need to migrate more complex objects.

This must be merged after #3448.

---

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists