### PR TITLE
[TD]Oblique Section Line etc

### DIFF
--- a/src/Mod/TechDraw/App/DrawGeomHatch.cpp
+++ b/src/Mod/TechDraw/App/DrawGeomHatch.cpp
@@ -557,9 +557,7 @@ void DrawGeomHatch::onDocumentRestored()
             std::string patFileName = FilePattern.getValue();
             Base::FileInfo tfi(patFileName);
             if (tfi.isReadable()) {
-                if (PatIncluded.isEmpty()) {
-                    setupPatIncluded();
-                }
+                setupPatIncluded();
             }
         }
     }

--- a/src/Mod/TechDraw/App/DrawProjGroup.cpp
+++ b/src/Mod/TechDraw/App/DrawProjGroup.cpp
@@ -461,10 +461,10 @@ App::DocumentObject * DrawProjGroup::addProjection(const char *viewProjType)
             } else {  //Front
                 Anchor.setValue(view);
                 Anchor.purgeTouched();
+                requestPaint();   //make sure the group object is on the Gui page
                 view->LockPosition.setValue(true);  //lock "Front" position within DPG (note not Page!).
                 view->LockPosition.setStatus(App::Property::ReadOnly,true); //Front should stay locked.
                 view->LockPosition.purgeTouched();
-                requestPaint();   //make sure the group object is on the Gui page
             }
         //        addView(view);                            //from DrawViewCollection
         //        if (view != getAnchor()) {                //anchor is done elsewhere
@@ -1004,6 +1004,8 @@ void DrawProjGroup::updateChildrenLock(void)
             Base::Console().Log("PROBLEM - DPG::updateChildrenLock - non DPGI entry in Views! %s\n",
                                     getNameInDocument());
             throw Base::TypeError("Error: projection in DPG list is not a DPGI!");
+        } else {
+            view->requestPaint();
         }
     }
 }

--- a/src/Mod/TechDraw/App/DrawProjGroupItem.cpp
+++ b/src/Mod/TechDraw/App/DrawProjGroupItem.cpp
@@ -103,16 +103,10 @@ void DrawProjGroupItem::onChanged(const App::Property *prop)
 
 bool DrawProjGroupItem::isLocked(void) const
 {
-    bool isLocked = DrawView::isLocked();
-
     if (isAnchor()) {                             //Anchor view is always locked to DPG
         return true;
     }
-    DrawProjGroup* parent = getPGroup();
-    if (parent != nullptr) {
-        isLocked = isLocked || parent->LockPosition.getValue();
-    }
-    return isLocked;
+    return DrawView::isLocked();
 }
 
 bool DrawProjGroupItem::showLock(void) const

--- a/src/Mod/TechDraw/App/DrawUtil.cpp
+++ b/src/Mod/TechDraw/App/DrawUtil.cpp
@@ -284,6 +284,62 @@ bool DrawUtil::fpCompare(const double& d1, const double& d2, double tolerance)
     return result;
 }
 
+//brute force intersection points of line(point, dir) with box(xRange, yRange)
+std::pair<Base::Vector3d, Base::Vector3d> DrawUtil::boxIntersect2d(Base::Vector3d point,
+                                                                   Base::Vector3d dirIn,
+                                                                   double xRange,
+                                                                   double yRange) 
+{
+    std::pair<Base::Vector3d, Base::Vector3d> result;
+    Base::Vector3d p1, p2;
+    Base::Vector3d dir = dirIn;
+    dir.Normalize();
+    // y = mx + b
+    // m = (y1 - y0) / (x1 - x0)
+    if (DrawUtil::fpCompare(dir.x, 0.0) ) {
+        p1 = Base::Vector3d(0.0, - yRange / 2.0, 0.0);  
+        p2 = Base::Vector3d(0.0, yRange / 2.0, 0.0);
+    } else {
+        double slope = dir.y / dir.x;
+        double left = -xRange / 2.0;
+        double right = xRange / 2.0;
+        double top = yRange / 2.0;
+        double bottom = -yRange / 2.0;
+        double yLeft   = point.y - slope * (point.x - left) ;
+        double yRight  = point.y - slope * (point.x - right);
+        double xTop    = point.x - ( (point.y - top) / slope );
+        double xBottom = point.x - ( (point.y - bottom) / slope );
+
+        if ( (bottom < yLeft) &&
+             (top > yLeft) )  {
+            p1 = Base::Vector3d(left, yLeft);
+        } else if (yLeft <= bottom) {
+            p1 = Base::Vector3d(xBottom, bottom);
+        } else if (yLeft >= top) {
+            p1 = Base::Vector3d(xTop, top);
+        }
+
+        if ( (bottom < yRight) &&
+             (top > yRight) )  {
+            p2 = Base::Vector3d(right, yRight);
+        } else if (yRight <= bottom) {
+            p2 = Base::Vector3d(xBottom, bottom);
+        } else if (yRight >= top) {
+            p2 = Base::Vector3d(xTop, top);
+        }
+    }
+    result.first = p1;
+    result.second = p2;
+    Base::Vector3d dirCheck = p2 - p1;
+    dirCheck.Normalize();
+    if (!dir.IsEqual(dirCheck, 0.00001)) {
+        result.first = p2;
+        result.second = p1;
+    }
+
+    return result;
+}
+
 Base::Vector3d DrawUtil::vertex2Vector(const TopoDS_Vertex& v)
 {
     gp_Pnt gp  = BRep_Tool::Pnt(v);

--- a/src/Mod/TechDraw/App/DrawUtil.h
+++ b/src/Mod/TechDraw/App/DrawUtil.h
@@ -79,6 +79,10 @@ class TechDrawExport DrawUtil {
         static bool isFirstVert(TopoDS_Edge e, TopoDS_Vertex v, double tolerance = VERTEXTOLERANCE);
         static bool isLastVert(TopoDS_Edge e, TopoDS_Vertex v, double tolerance = VERTEXTOLERANCE);
         static bool fpCompare(const double& d1, const double& d2, double tolerance = FLT_EPSILON);
+        static std::pair<Base::Vector3d, Base::Vector3d> boxIntersect2d(Base::Vector3d point,
+                                                                        Base::Vector3d dir,
+                                                                        double xRange,
+                                                                        double yRange) ;
         static Base::Vector3d vertex2Vector(const TopoDS_Vertex& v);
         static std::string formatVector(const Base::Vector3d& v);
         static std::string formatVector(const gp_Dir& v);

--- a/src/Mod/TechDraw/App/DrawView.cpp
+++ b/src/Mod/TechDraw/App/DrawView.cpp
@@ -76,17 +76,17 @@ DrawView::DrawView(void):
     mouseMove(false)
 {
     static const char *group = "Base";
-    ADD_PROPERTY_TYPE(X, (0.0), group, App::Prop_None, "X position");
-    ADD_PROPERTY_TYPE(Y, (0.0), group, App::Prop_None, "Y position");
-    ADD_PROPERTY_TYPE(LockPosition, (false), group, App::Prop_None, "Lock View position to parent Page or Group");
-    ADD_PROPERTY_TYPE(Rotation, (0.0), group, App::Prop_None, "Rotation in degrees counterclockwise");
+    ADD_PROPERTY_TYPE(X, (0.0), group, (App::PropertyType)(App::Prop_Output | App::Prop_NoRecompute), "X position");
+    ADD_PROPERTY_TYPE(Y, (0.0), group, (App::PropertyType)(App::Prop_Output | App::Prop_NoRecompute), "Y position");
+    ADD_PROPERTY_TYPE(LockPosition, (false), group, App::Prop_Output, "Lock View position to parent Page or Group");
+    ADD_PROPERTY_TYPE(Rotation, (0.0), group, App::Prop_Output, "Rotation in degrees counterclockwise");
 
     ScaleType.setEnums(ScaleTypeEnums);
-    ADD_PROPERTY_TYPE(ScaleType, (prefScaleType()), group, App::Prop_None, "Scale Type");
-    ADD_PROPERTY_TYPE(Scale, (prefScale()), group, App::Prop_None, "Scale factor of the view");
+    ADD_PROPERTY_TYPE(ScaleType, (prefScaleType()), group, App::Prop_Output, "Scale Type");
+    ADD_PROPERTY_TYPE(Scale, (prefScale()), group, App::Prop_Output, "Scale factor of the view");
     Scale.setConstraints(&scaleRange);
 
-    ADD_PROPERTY_TYPE(Caption, (""), group, App::Prop_None, "Short text about the view");
+    ADD_PROPERTY_TYPE(Caption, (""), group, App::Prop_Output, "Short text about the view");
 }
 
 DrawView::~DrawView()
@@ -95,10 +95,17 @@ DrawView::~DrawView()
 
 App::DocumentObjectExecReturn *DrawView::execute(void)
 {
-//    Base::Console().Message("DV::execute() - %s\n", getNameInDocument());
+//    Base::Console().Message("DV::execute() - %s touched: %d\n", getNameInDocument(), isTouched());
+    if (findParentPage() == nullptr) {
+        return App::DocumentObject::execute();
+    }
     handleXYLock();
     requestPaint();
-    return App::DocumentObject::execute();
+    //documentobject::execute doesn't do anything useful for us.
+    //documentObject::recompute causes an infinite loop.
+    //should not be neccessary to purgeTouched here, but it prevents a superflous feature recompute
+    purgeTouched();                           //this should not be necessary!
+    return App::DocumentObject::StdReturn;
 }
 
 void DrawView::checkScale(void)
@@ -146,11 +153,15 @@ void DrawView::onChanged(const App::Property* prop)
             }
         } else if (prop == &LockPosition) {
             handleXYLock();
+            requestPaint();         //change lock icon
             LockPosition.purgeTouched(); 
-        }
-        if ((prop == &Caption) ||
+        } else if ((prop == &Caption) ||
             (prop == &Label)) {
             requestPaint();
+        } else if ((prop == &X) ||
+            (prop == &Y)) {
+            X.purgeTouched();
+            Y.purgeTouched();
         }
     }
     App::DocumentObject::onChanged(prop);
@@ -195,11 +206,7 @@ short DrawView::mustExecute() const
     short result = 0;
     if (!isRestoring()) {
         result  =  (Scale.isTouched()  ||
-                    ScaleType.isTouched() ||
-                    Caption.isTouched() ||
-                    X.isTouched() ||
-                    Y.isTouched() ||
-                    LockPosition.isTouched());
+                    ScaleType.isTouched());
     }
     if ((bool) result) {
         return result;

--- a/src/Mod/TechDraw/App/DrawViewPart.cpp
+++ b/src/Mod/TechDraw/App/DrawViewPart.cpp
@@ -248,14 +248,10 @@ std::vector<App::DocumentObject*> DrawViewPart::getAllSources(void) const
 
 App::DocumentObjectExecReturn *DrawViewPart::execute(void)
 {
-//    Base::Console().Message("DVP::execute() - %s\n", Label.getValue());
     if (!keepUpdated()) {
         return App::DocumentObject::StdReturn;
     }
     
-//    Base::Console().Message("DVP::execute - Source: %d XSource: %d\n",
-//                         Source.getValues().size(), XSource.getValues().size());
-
     App::Document* doc = getDocument();
     bool isRestoring = doc->testStatus(App::Document::Status::Restoring);
     const std::vector<App::DocumentObject*>& links = getAllSources();
@@ -291,7 +287,6 @@ App::DocumentObjectExecReturn *DrawViewPart::execute(void)
         XDirection.purgeTouched();  //don't trigger updates!
         //unblock
     }
-    auto start = std::chrono::high_resolution_clock::now();
 
     m_saveShape = shape;
     partExec(shape);
@@ -312,14 +307,7 @@ App::DocumentObjectExecReturn *DrawViewPart::execute(void)
         }
     }
 
-    auto end   = std::chrono::high_resolution_clock::now();
-    auto diff  = end - start;
-    double diffOut = std::chrono::duration <double, std::milli> (diff).count();
-    Base::Console().Log("TIMING - %s DVP spent: %.3f millisecs handling Faces\n",
-                        getNameInDocument(),diffOut);
-
 //#endif //#if MOD_TECHDRAW_HANDLE_FACES
-//    Base::Console().Message("DVP::execute - exits\n");
     return DrawView::execute();
 }
 
@@ -366,7 +354,6 @@ void DrawViewPart::partExec(TopoDS_Shape shape)
     }
 
 #if MOD_TECHDRAW_HANDLE_FACES
-//    auto start = std::chrono::high_resolution_clock::now();
     if (handleFaces() && !geometryObject->usePolygonHLR()) {
         try {
             extractFaces();
@@ -463,8 +450,6 @@ TechDraw::GeometryObject* DrawViewPart::buildGeometryObject(TopoDS_Shape shape, 
             viewAxis);
     }
 
-    auto start = std::chrono::high_resolution_clock::now();
-
     go->extractGeometry(TechDraw::ecHARD,                   //always show the hard&outline visible lines
                         true);
     go->extractGeometry(TechDraw::ecOUTLINE,
@@ -499,10 +484,6 @@ TechDraw::GeometryObject* DrawViewPart::buildGeometryObject(TopoDS_Shape shape, 
         go->extractGeometry(TechDraw::ecUVISO,
                             false);
     }
-    auto end   = std::chrono::high_resolution_clock::now();
-    auto diff  = end - start;
-    double diffOut = std::chrono::duration <double, std::milli> (diff).count();
-    Base::Console().Log("TIMING - %s DVP spent: %.3f millisecs in GO::extractGeometry\n",getNameInDocument(),diffOut);
 
     const std::vector<TechDraw::BaseGeom  *> & edges = go->getEdgeGeometry();
     if (edges.empty()) {
@@ -533,34 +514,32 @@ void DrawViewPart::extractFaces()
         if (!DrawUtil::isZeroEdge(e)) {
             nonZero.push_back(e);
         } else {
-            Base::Console().Message("INFO - DVP::extractFaces for %s found ZeroEdge!\n",getNameInDocument());
+            Base::Console().Log("INFO - DVP::extractFaces for %s found ZeroEdge!\n",getNameInDocument());
         }
     }
-    faceEdges = nonZero;
-    origEdges = nonZero;
 
     //HLR algo does not provide all edge intersections for edge endpoints.
     //need to split long edges touched by Vertex of another edge
     std::vector<splitPoint> splits;
-    std::vector<TopoDS_Edge>::iterator itOuter = origEdges.begin();
+    std::vector<TopoDS_Edge>::iterator itOuter = nonZero.begin();
     int iOuter = 0;
-    for (; itOuter != origEdges.end(); ++itOuter, iOuter++) {
+    for (; itOuter != nonZero.end(); ++itOuter, iOuter++) {    //*** itOuter != nonZero.end() - 1
         TopoDS_Vertex v1 = TopExp::FirstVertex((*itOuter));
         TopoDS_Vertex v2 = TopExp::LastVertex((*itOuter));
         Bnd_Box sOuter;
         BRepBndLib::Add(*itOuter, sOuter);
         sOuter.SetGap(0.1);
         if (sOuter.IsVoid()) {
-            Base::Console().Message("DVP::Extract Faces - outer Bnd_Box is void for %s\n",getNameInDocument());
+            Base::Console().Log("DVP::Extract Faces - outer Bnd_Box is void for %s\n",getNameInDocument());
             continue;
         }
         if (DrawUtil::isZeroEdge(*itOuter)) {
-            Base::Console().Message("DVP::extractFaces - outerEdge: %d is ZeroEdge\n",iOuter);   //this is not finding ZeroEdges
+            Base::Console().Log("DVP::extractFaces - outerEdge: %d is ZeroEdge\n",iOuter);   //this is not finding ZeroEdges
             continue;  //skip zero length edges. shouldn't happen ;)
         }
         int iInner = 0;
-        std::vector<TopoDS_Edge>::iterator itInner = faceEdges.begin();
-        for (; itInner != faceEdges.end(); ++itInner,iInner++) {
+        std::vector<TopoDS_Edge>::iterator itInner = nonZero.begin();   //***sb itOuter + 1;
+        for (; itInner != nonZero.end(); ++itInner,iInner++) {
             if (iInner == iOuter) {
                 continue;
             }
@@ -602,10 +581,10 @@ void DrawViewPart::extractFaces()
     std::vector<splitPoint> sorted = DrawProjectSplit::sortSplits(splits,true);
     auto last = std::unique(sorted.begin(), sorted.end(), DrawProjectSplit::splitEqual);  //duplicates to back
     sorted.erase(last, sorted.end());                         //remove dupl splits
-    std::vector<TopoDS_Edge> newEdges = DrawProjectSplit::splitEdges(faceEdges,sorted);
+    std::vector<TopoDS_Edge> newEdges = DrawProjectSplit::splitEdges(nonZero,sorted);
 
     if (newEdges.empty()) {
-        Base::Console().Log("LOG - DVP::extractFaces - no newEdges\n");
+        Base::Console().Log("DVP::extractFaces - no newEdges\n");
         return;
     }
 
@@ -1242,15 +1221,11 @@ int DrawViewPart::getCVIndex(std::string tag)
 //    Base::Console().Message("DVP::getCVIndex(%s)\n", tag.c_str());
     int result = -1;
     std::vector<TechDraw::Vertex *> gVerts = getVertexGeometry();
-    Base::Console().Message("DVP::getCVIndex - gVerts: %d\n", gVerts.size());
     std::vector<TechDraw::CosmeticVertex*> cVerts = CosmeticVertexes.getValues();
-    Base::Console().Message("DVP::getCVIndex - cVerts: %d\n", cVerts.size());
 
     int i = 0;
     bool found = false;
     for (auto& gv :gVerts) {
-        Base::Console().Message("DVP::getCVIndex - gv cosmetic: %d ctag: %s\n", 
-                                gv->cosmetic, gv->cosmeticTag.c_str());
         if (gv->cosmeticTag == tag) {
             result = i;
             found = true;

--- a/src/Mod/TechDraw/App/DrawViewSection.cpp
+++ b/src/Mod/TechDraw/App/DrawViewSection.cpp
@@ -230,13 +230,12 @@ void DrawViewSection::onChanged(const App::Property* prop)
 void DrawViewSection::makeLineSets(void) 
 {
 //    Base::Console().Message("DVS::makeLineSets()\n");
-    if (!FileGeomPattern.isEmpty()) {
-        std::string fileSpec = FileGeomPattern.getValue();
+    if (!PatIncluded.isEmpty())  {
+        std::string fileSpec = PatIncluded.getValue();
         Base::FileInfo fi(fileSpec);
         std::string ext = fi.extension();
         if (!fi.isReadable()) {
             Base::Console().Message("%s can not read hatch file: %s\n", getNameInDocument(), fileSpec.c_str());
-            Base::Console().Message("%s using included hatch file.\n", getNameInDocument());
         } else {
             if ( (ext == "pat") ||
                  (ext == "PAT") ) {
@@ -842,6 +841,7 @@ gp_Ax2 DrawViewSection::rotateCSArbitrary(gp_Ax2 oldCS,
 
 std::vector<LineSet> DrawViewSection::getDrawableLines(int i)
 {
+//    Base::Console().Message("DVS::getDrawableLines(%d) - lineSets: %d\n", i, m_lineSets.size());
     std::vector<LineSet> result;
     result = DrawGeomHatch::getTrimmedLines(this,m_lineSets,i,HatchScale.getValue());
     return result;
@@ -919,26 +919,27 @@ int DrawViewSection::prefCutSurface(void) const
 void DrawViewSection::onDocumentRestored() 
 {
 //    Base::Console().Message("DVS::onDocumentRestored()\n");
-    if (!FileHatchPattern.isEmpty()) {
-        std::string svgFileName = FileHatchPattern.getValue();
-        Base::FileInfo tfi(svgFileName);
-        if (tfi.isReadable()) {
-            if (SvgIncluded.isEmpty()) {
+    if (SvgIncluded.isEmpty()) {
+        if (!FileHatchPattern.isEmpty()) {
+            std::string svgFileName = FileHatchPattern.getValue();
+            Base::FileInfo tfi(svgFileName);
+            if (tfi.isReadable()) {
                 setupSvgIncluded();
             }
         }
     }
 
-    if (!FileGeomPattern.isEmpty()) {
-        std::string patFileName = FileGeomPattern.getValue();
-        Base::FileInfo tfi(patFileName);
-        if (tfi.isReadable()) {
-            if (PatIncluded.isEmpty()) {
-                setupPatIncluded();
+    if (PatIncluded.isEmpty()) {
+        if (!FileGeomPattern.isEmpty()) {
+            std::string patFileName = FileGeomPattern.getValue();
+            Base::FileInfo tfi(patFileName);
+            if (tfi.isReadable()) {
+                    setupPatIncluded();
             }
-        makeLineSets();
         }
     }
+
+    makeLineSets();
     DrawViewPart::onDocumentRestored();
 }
 

--- a/src/Mod/TechDraw/App/DrawViewSection.h
+++ b/src/Mod/TechDraw/App/DrawViewSection.h
@@ -119,6 +119,8 @@ public:
     static const char* SectionDirEnums[];
     static const char* CutSurfaceEnums[];
 
+    std::pair<Base::Vector3d, Base::Vector3d> sectionLineEnds(void);
+
 protected:
     TopoDS_Compound sectionFaces;
     std::vector<TopoDS_Wire> sectionFaceWires;

--- a/src/Mod/TechDraw/Gui/Command.cpp
+++ b/src/Mod/TechDraw/Gui/Command.cpp
@@ -348,6 +348,8 @@ void CmdTechDrawView::activated(int iMsg)
     openCommand("Create view");
     std::string FeatName = getUniqueObjectName("View");
     doCommand(Doc,"App.activeDocument().addObject('TechDraw::DrawViewPart','%s')",FeatName.c_str());
+    doCommand(Doc,"App.activeDocument().%s.addView(App.activeDocument().%s)",PageName.c_str(),FeatName.c_str());
+
     App::DocumentObject *docObj = getDocument()->getObject(FeatName.c_str());
     TechDraw::DrawViewPart* dvp = dynamic_cast<TechDraw::DrawViewPart *>(docObj);
     if (!dvp) {
@@ -355,7 +357,6 @@ void CmdTechDrawView::activated(int iMsg)
     }
     dvp->Source.setValues(shapes);
     dvp->XSource.setValues(xShapes);
-    doCommand(Doc,"App.activeDocument().%s.addView(App.activeDocument().%s)",PageName.c_str(),FeatName.c_str());
     if (faceName.size()) {
         std::pair<Base::Vector3d,Base::Vector3d> dirs = DrawGuiUtil::getProjDirFromFace(partObj,faceName);
         projDir = dirs.first;

--- a/src/Mod/TechDraw/Gui/QGISectionLine.cpp
+++ b/src/Mod/TechDraw/Gui/QGISectionLine.cpp
@@ -75,6 +75,13 @@ QGISectionLine::QGISectionLine()
 void QGISectionLine::draw()
 {
     prepareGeometryChange();
+    int format = getPrefSectionStandard();
+    if (format == ANSISTANDARD) {                           //"ASME"/"ANSI"
+        extensionEndsTrad();
+    } else {
+        extensionEndsISO();
+    }
+
     makeLine();
     makeArrows();
     makeSymbols();
@@ -84,37 +91,15 @@ void QGISectionLine::draw()
 void QGISectionLine::makeLine()
 {
     QPainterPath pp;
-    QPointF beginExtLine1,beginExtLine2;   //ext line start pts for measure Start side and measure End side
-    QPointF endExtLine1, endExtLine2;
-    QPointF offsetDir(m_arrowDir.x,-m_arrowDir.y);
-    int format = getPrefSectionStandard();
-    if (format == ANSISTANDARD) {                           //"ASME"/"ANSI"
-        //draw from section line endpoint
-        QPointF offsetBegin = m_extLen * offsetDir;
-        beginExtLine1 = m_start;           //from
-        beginExtLine2 = m_end;             //to
-        endExtLine1 = m_start + offsetBegin;
-        endExtLine2   = m_end + offsetBegin;
-        pp.moveTo(beginExtLine1);
-        pp.lineTo(endExtLine1);
-        pp.moveTo(beginExtLine2);
-        pp.lineTo(endExtLine2);
-    } else {                                     //"ISO"
-        //draw from just short of section line away from section line
-        QPointF offsetBegin = Rez::guiX(QGIArrow::getOverlapAdjust(0,QGIArrow::getPrefArrowSize())) * offsetDir;
-        QPointF offsetEnd   = offsetBegin + (m_extLen * offsetDir);
-        beginExtLine1 = m_start - offsetBegin;
-        beginExtLine2 = m_end - offsetBegin;
-        endExtLine1 = m_start - offsetEnd;
-        endExtLine2   = m_end - offsetEnd;
-        pp.moveTo(beginExtLine1);
-        pp.lineTo(endExtLine1);
-        pp.moveTo(beginExtLine2);
-        pp.lineTo(endExtLine2);
-    }
 
-    pp.moveTo(m_end);
-    pp.lineTo(m_start);          //sectionLine
+    pp.moveTo(m_beginExt1);
+    pp.lineTo(m_endExt1);
+
+    pp.moveTo(m_beginExt2);
+    pp.lineTo(m_endExt2);
+
+    pp.moveTo(m_start);
+    pp.lineTo(m_end);
     m_line->setPath(pp);
 }
 
@@ -165,8 +150,14 @@ void QGISectionLine::makeArrowsTrad()
 
     QPointF posArrow1,posArrow2;
     QPointF offsetDir(m_arrowDir.x,-m_arrowDir.y);              //remember Y dir is flipped
-    double offsetLength = m_extLen + Rez::guiX(QGIArrow::getOverlapAdjust(0,QGIArrow::getPrefArrowSize()));
+
+    double oblique = 1.0;
+    if ( !DrawUtil::fpCompare((m_arrowDir.x + m_arrowDir.y), 1.0) ) {
+        oblique = 1.25;
+    }
+    double offsetLength = (m_extLen * oblique) + Rez::guiX(QGIArrow::getPrefArrowSize());
     QPointF offsetVec = offsetLength * offsetDir;
+
     posArrow1 = m_start + offsetVec;
     posArrow2 = m_end + offsetVec;
 
@@ -195,58 +186,114 @@ void QGISectionLine::makeSymbols()
 
 void QGISectionLine::makeSymbolsTrad()
 {
-    QPointF extLineStart,extLineEnd;
-    QPointF offset(m_arrowDir.x,-m_arrowDir.y);
-    offset = 1.5 * m_extLen * offset;
-    extLineStart = m_start + offset;
-    extLineEnd = m_end + offset;
     prepareGeometryChange();
     m_symFont.setPixelSize(QGIView::calculateFontPixelSize(m_symSize));
     m_symbol1->setFont(m_symFont);
     m_symbol1->setPlainText(QString::fromUtf8(m_symbol));
+    m_symbol2->setFont(m_symFont);
+    m_symbol2->setPlainText(QString::fromUtf8(m_symbol));
 
     QRectF symRect = m_symbol1->boundingRect();
     double symWidth = symRect.width();
     double symHeight = symRect.height();
-    double symbolFudge = 1.0;
+    double symbolFudge = 0.75;
     double angle = atan2f(m_arrowDir.y,m_arrowDir.x);
     if (angle < 0.0) {
         angle = 2 * M_PI + angle;
     }
     Base::Vector3d adjustVector(cos(angle) * symWidth, sin(angle) * symHeight, 0.0);
-    adjustVector = (DrawUtil::invertY(adjustVector) / 2.0) * symbolFudge;
+    adjustVector = DrawUtil::invertY(adjustVector) * symbolFudge;
     QPointF qAdjust(adjustVector.x, adjustVector.y);
 
-    extLineStart += qAdjust;
-    m_symbol1->centerAt(extLineStart);
+    QPointF posSymbol1 = m_arrow1->pos() + qAdjust;
+    m_symbol1->centerAt(posSymbol1);
 
-    m_symbol2->setFont(m_symFont);
-    m_symbol2->setPlainText(QString::fromUtf8(m_symbol));
-    extLineEnd += qAdjust;
-    m_symbol2->centerAt(extLineEnd);
+    QPointF posSymbol2 = m_arrow2->pos() + qAdjust;
+    m_symbol2->centerAt(posSymbol2);
 }
 
 void QGISectionLine::makeSymbolsISO()
 {
-    QPointF symPosStart, symPosEnd;
-    QPointF dist = (m_start - m_end);
-    double lenDist = sqrt(dist.x()*dist.x() + dist.y()*dist.y());
-    QPointF distDir = dist / lenDist;
-
-    QPointF offset = m_extLen * distDir;
-    symPosStart = m_start + offset;
-    symPosEnd = m_end - offset;
-
     prepareGeometryChange();
     m_symFont.setPixelSize(QGIView::calculateFontPixelSize(m_symSize));
     m_symbol1->setFont(m_symFont);
     m_symbol1->setPlainText(QString::fromUtf8(m_symbol));
-    m_symbol1->centerAt(symPosStart);
-
     m_symbol2->setFont(m_symFont);
     m_symbol2->setPlainText(QString::fromUtf8(m_symbol));
-    m_symbol2->centerAt(symPosEnd);
 
+    QPointF symPosStart, symPosEnd;
+    //no normalize() for QPointF
+    QPointF dist = (m_start - m_end);
+    double lenDist = sqrt(dist.x()*dist.x() + dist.y()*dist.y());
+    QPointF offsetDir = dist / lenDist;
+
+    QRectF symRect = m_symbol1->boundingRect();
+    double symWidth = symRect.width();
+    double symHeight = symRect.height();
+
+    double symbolFudge = 0.75;
+    double angle = atan2f(offsetDir.y(), offsetDir.x());
+    if (angle < 0.0) {
+        angle = 2.0 * M_PI + angle;
+    }
+    Base::Vector3d adjustVector(cos(angle) * symWidth, sin(angle) * symHeight, 0.0);
+    adjustVector = adjustVector * symbolFudge;
+    QPointF qAdjust(adjustVector.x, adjustVector.y);
+
+    symPosStart = m_start + qAdjust;
+    symPosEnd = m_end - qAdjust;
+
+    m_symbol1->centerAt(symPosStart);
+    m_symbol2->centerAt(symPosEnd);
+}
+
+void QGISectionLine::extensionEndsTrad()
+{
+    QPointF offsetDir(m_arrowDir.x,-m_arrowDir.y);
+
+    //extensions for oblique section line needs to be a bit longer
+    double oblique = 1.0;
+    if ( !DrawUtil::fpCompare((m_arrowDir.x + m_arrowDir.y), 1.0) ) {
+        oblique = 1.25;
+    }
+
+    //draw from section line endpoint 
+    QPointF offsetEnd = oblique * m_extLen * offsetDir;
+    m_beginExt1 = m_start;
+    m_endExt1   = m_start + offsetEnd;
+    m_beginExt2 = m_end;
+    m_endExt2   = m_end + offsetEnd;
+}
+
+void QGISectionLine::extensionEndsISO()
+{
+    //lines are offset to other side of section line!
+    QPointF offsetDir(m_arrowDir.x,-m_arrowDir.y);
+    offsetDir = offsetDir * -1.0;
+
+    //extensions for oblique section line needs to be a bit longer?
+    //this is just esthetics
+    double oblique = 1.0;
+    if ( !DrawUtil::fpCompare((m_arrowDir.x + m_arrowDir.y), 1.0) ) {
+        oblique = 1.10;
+    }
+
+    //draw from section line endpoint less arrow length 
+    QPointF offsetStart =  offsetDir * Rez::guiX(QGIArrow::getPrefArrowSize());
+    QPointF offsetEnd = oblique * m_extLen * offsetDir;
+
+    m_beginExt1 = m_start + offsetStart;
+    m_endExt1   = m_start + offsetStart + offsetEnd;
+    m_beginExt2 = m_end + offsetStart;
+    m_endExt2   = m_end + offsetStart + offsetEnd;
+}
+
+void QGISectionLine::setEnds(Base::Vector3d l1, Base::Vector3d l2)
+{
+    m_l1 = l1;
+    m_start = QPointF(l1.x, l1.y);
+    m_l2 = l2;
+    m_end = QPointF(l2.x, l2.y);
 }
 
 void QGISectionLine::setBounds(double x1,double y1,double x2,double y2)
@@ -269,6 +316,7 @@ void QGISectionLine::setDirection(double xDir,double yDir)
 void QGISectionLine::setDirection(Base::Vector3d dir)
 {
     m_arrowDir = dir;
+    m_arrowDir.Normalize();
 }
 
 void QGISectionLine::setFont(QFont f, double fsize)

--- a/src/Mod/TechDraw/Gui/QGISectionLine.h
+++ b/src/Mod/TechDraw/Gui/QGISectionLine.h
@@ -49,6 +49,7 @@ public:
 
     virtual void paint(QPainter * painter, const QStyleOptionGraphicsItem * option, QWidget * widget = 0 );
 
+    void setEnds(Base::Vector3d l1, Base::Vector3d l2);
     void setBounds(double x1,double y1,double x2,double y2);
     void setSymbol(char* sym);
     void setDirection(double xDir,double yDir);
@@ -71,6 +72,9 @@ protected:
     void makeSymbolsISO();
     void setTools();
     int  getPrefSectionStandard();
+    void extensionEndsISO();
+    void extensionEndsTrad();
+
 
 private:
     char* m_symbol;
@@ -89,6 +93,12 @@ private:
     //QColor             m_color;
     double             m_extLen;
 //    int                m_sectionFormat;     //0 = ASME, 1 = ISO
+    Base::Vector3d     m_l1;            //end of main section line
+    Base::Vector3d     m_l2;            //end of main section line
+    QPointF            m_beginExt1;     //start of extension line 1
+    QPointF            m_endExt1;       //end of extension line 1
+    QPointF            m_beginExt2;     //start of extension line 2
+    QPointF            m_endExt2;       //end of extension line 1
 };
 
 }

--- a/src/Mod/TechDraw/Gui/QGIViewImage.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewImage.cpp
@@ -43,6 +43,7 @@
 #include <Mod/TechDraw/App/DrawViewImage.h>
 
 #include "Rez.h"
+#include "ViewProviderImage.h"
 #include "QGCustomImage.h"
 #include "QGCustomClip.h"
 #include "QGIViewImage.h"
@@ -117,9 +118,21 @@ void QGIViewImage::draw()
     auto viewImage( dynamic_cast<TechDraw::DrawViewImage*>(getViewObject()) );
     if (!viewImage)
         return;
-    QRectF newRect(0.0,0.0,viewImage->Width.getValue(),viewImage->Height.getValue());
-    m_cliparea->setRect(newRect);
+
+    auto vp = static_cast<ViewProviderImage*>(getViewProvider(getViewObject()));
+    if ( vp == nullptr ) {
+        return;
+    }
+    bool crop = vp->Crop.getValue();
+
     drawImage();
+    if (crop) {
+        QRectF cropRect(0.0,0.0,Rez::guiX(viewImage->Width.getValue()),Rez::guiX(viewImage->Height.getValue()));
+        m_cliparea->setRect(cropRect);
+    } else {
+        QRectF cropRect(0.0, 0.0, m_imageItem->imageSize().width(), m_imageItem->imageSize().height());
+        m_cliparea->setRect(cropRect);
+    }
     m_cliparea->centerAt(0.0,0.0);
 
     QGIView::draw();

--- a/src/Mod/TechDraw/Gui/QGIViewPart.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewPart.cpp
@@ -838,88 +838,31 @@ void QGIViewPart::drawSectionLine(TechDraw::DrawViewSection* viewSection, bool b
         sectionLine->setSectionStyle(vp->SectionLineStyle.getValue());
         sectionLine->setSectionColor(vp->SectionLineColor.getValue().asValue<QColor>());
 
-        //TODO: handle oblique section lines?
-        //find smallest internal angle(normalDir,get?Dir()) and use -1*get?Dir() +/- angle
-        //Base::Vector3d normalDir = viewSection->SectionNormal.getValue();
-        Base::Vector3d arrowDir(0,1,0);                //for drawing only, not geom
-        Base::Vector3d lineDir(1,0,0);
-        bool horiz = false;
-
-        //this is a hack we can use since we don't support oblique section lines yet.
-        //better solution will be need if oblique is ever implemented
-        double rot = viewPart->Rotation.getValue();
-        bool switchWH = false;
-        if (TechDraw::DrawUtil::fpCompare(fabs(rot), 90.0)) {
-            switchWH = true;
-        }
-
-        if (viewSection->SectionDirection.isValue("Right")) {
-            arrowDir = Base::Vector3d(1,0,0);
-            lineDir = Base::Vector3d(0,1,0);
-        } else if (viewSection->SectionDirection.isValue("Left")) {
-            arrowDir = Base::Vector3d(-1,0,0);
-            lineDir = Base::Vector3d(0,-1,0);
-        } else if (viewSection->SectionDirection.isValue("Up")) {
-            arrowDir = Base::Vector3d(0,1,0);
-            lineDir = Base::Vector3d(1,0,0);
-            horiz = true;
-        } else if (viewSection->SectionDirection.isValue("Down")) {
-            arrowDir = Base::Vector3d(0,-1,0);
-            lineDir = Base::Vector3d(-1,0,0);
-            horiz = true;
-        }
-        sectionLine->setDirection(arrowDir.x,arrowDir.y);
-
-        //dvp is centered on centroid looking along dvp direction
-        //dvs is centered on SO looking along section normal
-        //dvp view origin is 000 + centroid
-        Base::Vector3d org = viewSection->SectionOrigin.getValue();
-        Base::Vector3d cent = viewPart->getOriginalCentroid();
-        Base::Vector3d adjOrg = org - cent;
+        //find the ends of the section line
         double scale = viewPart->getScale();
+        std::pair<Base::Vector3d, Base::Vector3d> sLineEnds = viewSection->sectionLineEnds();
+        Base::Vector3d l1 = Rez::guiX(sLineEnds.first) * scale;
+        Base::Vector3d l2 = Rez::guiX(sLineEnds.second) * scale;
 
-        Base::Vector3d pAdjOrg = scale * viewPart->projectPoint(adjOrg);
+        //which way to the arrows point?
+        Base::Vector3d lineDir = l2 - l1;
+        lineDir.Normalize();
+        Base::Vector3d normalDir = viewSection->SectionNormal.getValue();
+        Base::Vector3d projNormal = viewPart->projectPoint(normalDir);
+        projNormal.Normalize();
+        Base::Vector3d arrowDir = viewSection->SectionNormal.getValue();
+        arrowDir = - viewPart->projectPoint(arrowDir);  //arrows point reverse of sectionNormal(extrusion dir)
+        sectionLine->setDirection(arrowDir.x, -arrowDir.y);           //invert Y
 
-        //now project pOrg onto arrowDir
-        Base::Vector3d displace;
-        displace.ProjectToLine(pAdjOrg, arrowDir);
-        Base::Vector3d offset = pAdjOrg + displace;
+        //make the section line a little longer
+        double fudge = Rez::guiX(2.0 * Preferences::dimFontSizeMM());
+        sectionLine->setEnds(l1 - lineDir * fudge, 
+                             l2 + lineDir * fudge);
 
-//        makeMark(0.0, 0.0);   //red
-//        makeMark(Rez::guiX(offset.x),
-//                 Rez::guiX(offset.y),
-//                 Qt::green);
-
-        sectionLine->setPos(Rez::guiX(offset.x),Rez::guiX(offset.y));
-        double sectionSpan;
-        double sectionFudge = Rez::guiX(10.0);
-        double xVal, yVal;
-//        double fontSize = getPrefFontSize();
-//        double fontSize = getDimFontSize();
-        double fontSize = Preferences::dimFontSizeMM();
-        if (horiz)  {
-            double width = Rez::guiX(viewPart->getBoxX());
-            double height = Rez::guiX(viewPart->getBoxY());
-            if (switchWH) {
-                sectionSpan = height + sectionFudge;
-            } else {
-                sectionSpan = width + sectionFudge;
-            }
-            xVal = sectionSpan / 2.0;
-            yVal = 0.0;
-        } else {
-            double width = Rez::guiX(viewPart->getBoxX());
-            double height = Rez::guiX(viewPart->getBoxY());
-            if (switchWH) {
-                sectionSpan = width + sectionFudge;
-            } else {
-                sectionSpan = height + sectionFudge;
-            }
-            xVal = 0.0;
-            yVal = sectionSpan / 2.0;
-        }
-        sectionLine->setBounds(-xVal,-yVal,xVal,yVal);
+        //set the general parameters
+        sectionLine->setPos(0.0, 0.0);
         sectionLine->setWidth(Rez::guiX(vp->LineWidth.getValue()));
+        double fontSize = Preferences::dimFontSizeMM();
         sectionLine->setFont(m_font, fontSize);
         sectionLine->setZValue(ZVALUE::SECTIONLINE);
         sectionLine->setRotation(viewPart->Rotation.getValue());

--- a/src/Mod/TechDraw/Gui/QGIViewPart.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewPart.cpp
@@ -84,6 +84,7 @@
 
 using namespace TechDraw;
 using namespace TechDrawGui;
+using namespace std;
 
 #define GEOMETRYEDGE 0
 #define COSMETICEDGE 1
@@ -407,7 +408,6 @@ QPainterPath QGIViewPart::geomToPainterPath(TechDraw::BaseGeom *baseGeom, double
 void QGIViewPart::updateView(bool update)
 {
 //    Base::Console().Message("QGIVP::updateView()\n");
-    auto start = std::chrono::high_resolution_clock::now();
     auto viewPart( dynamic_cast<TechDraw::DrawViewPart *>(getViewObject()) );
     if( viewPart == nullptr ) {
         return;
@@ -421,11 +421,6 @@ void QGIViewPart::updateView(bool update)
         draw();
     }
     QGIView::updateView(update);
-
-    auto end   = std::chrono::high_resolution_clock::now();
-    auto diff  = end - start;
-    double diffOut = std::chrono::duration <double, std::milli> (diff).count();
-    Base::Console().Log("TIMING - QGIVP::updateView - %s - total %.3f millisecs\n",getViewName(),diffOut);
 }
 
 void QGIViewPart::draw() {
@@ -458,7 +453,6 @@ void QGIViewPart::drawViewPart()
     if ( vp == nullptr ) {
         return;
     }
-
 
     float lineWidth = vp->LineWidth.getValue() * lineScaleFactor;
     float lineWidthHid = vp->HiddenWidth.getValue() * lineScaleFactor;

--- a/src/Mod/TechDraw/Gui/ViewProviderImage.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderImage.cpp
@@ -49,6 +49,8 @@ PROPERTY_SOURCE(TechDrawGui::ViewProviderImage, TechDrawGui::ViewProviderDrawing
 ViewProviderImage::ViewProviderImage()
 {
     sPixmap = "actions/techdraw-image";
+
+    ADD_PROPERTY_TYPE(Crop ,(false),"Image", App::Prop_None, "Crop image to Width x Height");
 }
 
 ViewProviderImage::~ViewProviderImage()
@@ -78,6 +80,25 @@ void ViewProviderImage::updateData(const App::Property* prop)
 {
     ViewProviderDrawingView::updateData(prop);
 }
+
+void ViewProviderImage::onChanged(const App::Property *prop)
+{
+    App::DocumentObject* obj = getObject();
+    if (!obj || obj->isRestoring()) {
+            Gui::ViewProviderDocumentObject::onChanged(prop);
+            return;
+    }
+
+    if (prop == &Crop) {
+        QGIView* qgiv = getQView();
+        if (qgiv) {
+            qgiv->updateView(true);
+        }
+    }
+
+    Gui::ViewProviderDocumentObject::onChanged(prop);
+}
+
 
 TechDraw::DrawViewImage* ViewProviderImage::getViewObject() const
 {

--- a/src/Mod/TechDraw/Gui/ViewProviderImage.h
+++ b/src/Mod/TechDraw/Gui/ViewProviderImage.h
@@ -41,6 +41,7 @@ public:
     /// destructor
     virtual ~ViewProviderImage();
 
+    App::PropertyBool  Crop;              //crop to feature width x height
 
     virtual void attach(App::DocumentObject *);
     virtual void setDisplayMode(const char* ModeName);
@@ -48,6 +49,7 @@ public:
     /// returns a list of all possible modes
     virtual std::vector<std::string> getDisplayModes(void) const;
     virtual void updateData(const App::Property*);
+    virtual void onChanged(const App::Property *prop);
 
     virtual TechDraw::DrawViewImage* getViewObject() const;
 };


### PR DESCRIPTION
- draw oblique section line when required 
- prevent superfluous recompute on X/Y change
- load bitmaps at default size
- apply section face PAT hatch at restore


Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
