### PR TITLE
[Gui]fix canConvert for Qt4

### DIFF
--- a/src/Gui/DlgExpressionInput.cpp
+++ b/src/Gui/DlgExpressionInput.cpp
@@ -64,7 +64,11 @@ DlgExpressionInput::DlgExpressionInput(const App::ObjectIdentifier & _path,
     }
     else {
         QVariant text = parent->property("text");
+#if QT_VERSION >= 0x050000
         if (text.canConvert(QMetaType::QString)) {
+#else
+        if (text.canConvert(QVariant::String)) {
+#endif
             ui->expression->setText(text.toString());
         }
     }


### PR DESCRIPTION
Qt4 compiles fail with" DlgExpressionInput.cpp:67:47: error: no matching function for call to ‘QVariant::canConvert(QMetaType::Type)’
         if (text.canConvert(QMetaType::QString)) {"

Add conditional compile test to use QVariant::String on Qt4.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
