### PR TITLE
Fix typos [skip-ci]

### DIFF
--- a/src/Mod/Arch/OfflineRenderingUtils.py
+++ b/src/Mod/Arch/OfflineRenderingUtils.py
@@ -753,7 +753,7 @@ def buildGuiDocumentFromGuiData(document,guidata):
                 # then rest of bytes represent colors value where each color
                 # is of 4 bytes in abgr order.
 
-                # convert number of colors into hexadecimal reprsentation
+                # convert number of colors into hexadecimal representation
                 hex_repr = hex(len(prop["value"]))[2:]
 
                 # if len of `hex_repr` is odd, then add 0 padding.

--- a/src/Mod/Path/PathScripts/post/heidenhain_post.py
+++ b/src/Mod/Path/PathScripts/post/heidenhain_post.py
@@ -926,7 +926,7 @@ def HEIDEN_Drill(drill_Obj, drill_Params, drill_Type, drill_feed): # create a dr
         for j in drill_Defs:
             STORED_CANNED_PARAMS[j] = drill_Defs[j]
         
-        # get the DEF template and replace the stings
+        # get the DEF template and replace the strings
         drill_CycleDef = MACHINE_CYCLE_DEF[1].format(
             DIST = str("{:.3f}".format(drill_Defs['DIST'])),
             DEPTH = str("{:.3f}".format(drill_Defs['DEPTH'])),

--- a/src/Mod/Path/PathSimulator/App/VolSim.cpp
+++ b/src/Mod/Path/PathSimulator/App/VolSim.cpp
@@ -747,7 +747,7 @@ cSimTool::cSimTool(const TopoDS_Shape& toolShape, float res){
 
 	for (int x = 0; x < radValue; x++)
 	{
-		// find the face of the tool by checking z points accross the 
+		// find the face of the tool by checking z points across the 
 		// radius to see if the point is inside the shape
 		pnt.x =  x * res;
 		bool inside = isInside(toolShape, pnt, res);

--- a/src/Mod/TechDraw/App/DrawView.cpp
+++ b/src/Mod/TechDraw/App/DrawView.cpp
@@ -103,7 +103,7 @@ App::DocumentObjectExecReturn *DrawView::execute(void)
     requestPaint();
     //documentobject::execute doesn't do anything useful for us.
     //documentObject::recompute causes an infinite loop.
-    //should not be neccessary to purgeTouched here, but it prevents a superflous feature recompute
+    //should not be necessary to purgeTouched here, but it prevents a superfluous feature recompute
     purgeTouched();                           //this should not be necessary!
     return App::DocumentObject::StdReturn;
 }


### PR DESCRIPTION
Found via codespell v1.17.0.dev0  
``` 
codespell -q 3 -L aci,ake,aline,alle,alledges,alocation,als,ang,anid,ba,beginn,behaviour,bloaded,byteorder,calculater,cancelled,cancelling,cas,cascade,centimetre,childs,colour,colours,commen,connexion,currenty,dof,doubleclick,dum,eiter,elemente,ende,feld,finde,findf,freez,hist,iff,indicies,initialisation,initialise,initialised,initialises,initialisiert,ist,kilometre,lod,mantatory,methode,metres,millimetre,modell,nd,noe,normale,normaly,nto,numer,oder,orgin,orginx,orginy,ot,pard,pres,programm,que,recurrance,rougly,seperator,serie,sinc,strack,substraction,te,thist,thru,tread,uint,unter,vertexes,wallthickness,whitespaces -S ./.git,*.po,*.ts,./ChangeLog.txt,./src/3rdParty,./src/Mod/Assembly/App/opendcm,./src/CXX,./src/zipios++,./src/Base/swig*,./src/Mod/Robot/App/kdl_cp,./src/Mod/Import/App/SCL,./src/WindowsInstaller,./src/Doc/FreeCAD.uml
```