### PR TITLE
PartDesign: fixed issues introduced in #3456

### DIFF
--- a/src/Mod/PartDesign/App/FeatureChamfer.cpp
+++ b/src/Mod/PartDesign/App/FeatureChamfer.cpp
@@ -53,7 +53,7 @@ using namespace PartDesign;
 PROPERTY_SOURCE(PartDesign::Chamfer, PartDesign::DressUp)
 
 const App::PropertyQuantityConstraint::Constraints floatSize = {0.0,FLT_MAX,0.1};
-const App::PropertyAngle::Constraints floatAngle = {0.0,89.99,0.1};
+const App::PropertyAngle::Constraints floatAngle = {0.0,180.0,0.1};
 
 Chamfer::Chamfer()
 {
@@ -61,7 +61,7 @@ Chamfer::Chamfer()
     Size.setUnit(Base::Unit::Length);
     Size.setConstraints(&floatSize);
     ADD_PROPERTY(Angle,(45.0));
-    Size.setUnit(Base::Unit::Angle);
+    Angle.setUnit(Base::Unit::Angle);
     Angle.setConstraints(&floatAngle);
 }
 
@@ -94,8 +94,8 @@ App::DocumentObjectExecReturn *Chamfer::execute(void)
         return new App::DocumentObjectExecReturn("Size must be greater than zero");
 
     double angle = Base::toRadians(Angle.getValue());
-    if (angle <= 0 || angle > 89.99)
-        return new App::DocumentObjectExecReturn("Angle must be between 0 and 89.99");
+    if (angle <= 0 || angle >= 180.0)
+        return new App::DocumentObjectExecReturn("Angle must be greater than 0 and less than 180");
 
     this->positionByBaseFeature();
     // create an untransformed copy of the basefeature shape

--- a/src/Mod/PartDesign/Gui/TaskChamferParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskChamferParameters.cpp
@@ -76,7 +76,7 @@ TaskChamferParameters::TaskChamferParameters(ViewProviderDressUp *DressUpView, Q
     ui->chamferAngle->setUnit(Base::Unit::Angle);
     ui->chamferAngle->setValue(a);
     ui->chamferAngle->setMinimum(0.0);
-    ui->chamferAngle->setMaximum(89.99);
+    ui->chamferAngle->setMaximum(180.0);
     ui->chamferAngle->selectAll();
     ui->chamferAngle->bind(pcChamfer->Angle);
     QMetaObject::invokeMethod(ui->chamferAngle, "setFocus", Qt::QueuedConnection);

--- a/src/Mod/PartDesign/Gui/TaskChamferParameters.ui
+++ b/src/Mod/PartDesign/Gui/TaskChamferParameters.ui
@@ -89,7 +89,7 @@ click again to end selection</string>
         <double>0.000000000000000</double>
        </property>
        <property name="maximum" stdset="0">
-        <double>89.999999999999986</double>
+        <double>180.000000000000000</double>
        </property>
        <property name="singleStep" stdset="0">
         <double>0.100000000000000</double>


### PR DESCRIPTION
Fixed issues introduced in #3456 as discussed in the forum: https://forum.freecadweb.org/viewtopic.php?f=17&t=46205&p=397354#p397283

- Copy-paste error when setting angle dimensions.
- Removed unnecessary max limit of 89.99 degrees.