### PR TITLE
Path: Fix for `BoundaryDressup` and fix for `Profile` when extrude vector is roughly zero

### DIFF
--- a/src/Mod/Path/PathScripts/PathJobGui.py
+++ b/src/Mod/Path/PathScripts/PathJobGui.py
@@ -404,7 +404,8 @@ class StockFromBaseBoundBoxEdit(StockEdit):
         self.form.stockExtXpos.textChanged.connect(self.checkXpos)
         self.form.stockExtYpos.textChanged.connect(self.checkYpos)
         self.form.stockExtZpos.textChanged.connect(self.checkZpos)
-        self.form.linkStockAndModel.setChecked(True)
+        if hasattr(self.form, 'linkStockAndModel'):
+            self.form.linkStockAndModel.setChecked(True)
 
     def checkXpos(self):
         self.trackXpos = self.form.stockExtXneg.text() == self.form.stockExtXpos.text()

--- a/src/Mod/Path/PathScripts/PathProfile.py
+++ b/src/Mod/Path/PathScripts/PathProfile.py
@@ -627,7 +627,7 @@ class ObjectProfile(PathAreaOp.ObjectOp):
             PathLog.debug('Wire is not horizontally co-planar. Flattening it.')
 
             # Extrude non-horizontal wire
-            extFwdLen = wBB.ZLength * 2.2
+            extFwdLen = (wBB.ZLength + 2.0) * 2.0
             mbbEXT = wire.extrude(FreeCAD.Vector(0, 0, extFwdLen))
 
             # Create cross-section of shape and translate


### PR DESCRIPTION
The StockEdit class is reused by BoundaryDressup, and this checkbox does not exist in its UI panel.  This fixes that problem.  A separate issue was identified when the parent Job of a BoundaryDressup is edited, causing the child BoundaryDressup to fail after the Job edit.  Identified and fixed in collaboration with @sliptonic .  BoundaryDressup fix includes `if edge:` clause to check for `NoneType` values to be ignored.

Fix for `Profile` operation when `.extrude()` vector is roughly zero, causing a Part.OCCError of type BRepSweep_Translation::Constructor error.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
