### PR TITLE
Draft: small updates to unit tests and test script

### DIFF
--- a/src/Mod/Draft/TestDraft.py
+++ b/src/Mod/Draft/TestDraft.py
@@ -105,8 +105,8 @@ from drafttests.test_modification import DraftModification as DraftTest03
 from drafttests.test_svg import DraftSVG as DraftTest04
 from drafttests.test_dxf import DraftDXF as DraftTest05
 from drafttests.test_dwg import DraftDWG as DraftTest06
-from drafttests.test_oca import DraftOCA as DraftTest07
-from drafttests.test_airfoildat import DraftAirfoilDAT as DraftTest08
+# from drafttests.test_oca import DraftOCA as DraftTest07
+# from drafttests.test_airfoildat import DraftAirfoilDAT as DraftTest08
 
 # Use the modules so that code checkers don't complain (flake8)
 True if DraftTest01 else False
@@ -115,5 +115,5 @@ True if DraftTest03 else False
 True if DraftTest04 else False
 True if DraftTest05 else False
 True if DraftTest06 else False
-True if DraftTest07 else False
-True if DraftTest08 else False
+# True if DraftTest07 else False
+# True if DraftTest08 else False

--- a/src/Mod/Draft/drafttests/auxiliary.py
+++ b/src/Mod/Draft/drafttests/auxiliary.py
@@ -27,13 +27,13 @@ import traceback
 from draftutils.messages import _msg
 
 
-def _draw_header():
+def draw_header():
     """Draw a header for the tests."""
     _msg("")
     _msg(78*"-")
 
 
-def _import_test(module):
+def import_test(module):
     """Try importing a module."""
     _msg("  Try importing '{}'".format(module))
     try:
@@ -45,7 +45,7 @@ def _import_test(module):
     return imported
 
 
-def _no_gui(module):
+def no_gui(module):
     """Print a message that there is no user interface."""
     _msg("  #-----------------------------------------------------#\n"
          "  #    No GUI; cannot test for '{}'\n"
@@ -53,7 +53,7 @@ def _no_gui(module):
          "  Automatic PASS".format(module))
 
 
-def _no_test():
+def no_test():
     """Print a message that the test is not currently implemented."""
     _msg("  #-----------------------------------------------------#\n"
          "  #    This test is not implemented currently\n"
@@ -61,11 +61,11 @@ def _no_test():
          "  Automatic PASS")
 
 
-def _fake_function(p1=None, p2=None, p3=None, p4=None, p5=None):
+def fake_function(p1=None, p2=None, p3=None, p4=None, p5=None):
     """Print a message for a test that doesn't actually exist."""
     _msg("  Arguments to placeholder function")
     _msg("  p1={0}; p2={1}".format(p1, p2))
     _msg("  p3={0}; p4={1}".format(p3, p4))
     _msg("  p5={}".format(p5))
-    _no_test()
+    no_test()
     return True

--- a/src/Mod/Draft/drafttests/draft_test_objects.py
+++ b/src/Mod/Draft/drafttests/draft_test_objects.py
@@ -1,12 +1,3 @@
-"""Run this file to create a standard test document for Draft objects.
-
-Use as input to the freecad executable.
-    freecad draft_test_objects.py
-
-Or load it as a module and use the defined function.
-    import drafttests.draft_test_objects as dt
-    dt.create_test_file()
-"""
 # ***************************************************************************
 # *   (c) 2020 Eliud Cabrera Castillo <e.cabrera-castillo@tum.de>           *
 # *                                                                         *
@@ -29,9 +20,27 @@ Or load it as a module and use the defined function.
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-import os
+"""Run this file to create a standard test document for Draft objects.
+
+Use it as input to the program executable.
+
+::
+
+    freecad draft_test_objects.py
+
+Or load it as a module and use the defined function.
+
+>>> import drafttests.draft_test_objects as dt
+>>> dt.create_test_file()
+"""
+## @package draft_test_objects
+# \ingroup DRAFT
+# \brief Run this file to create a standard test document for Draft objects.
+# @{
+
 import datetime
 import math
+import os
 
 import FreeCAD as App
 import Draft
@@ -49,7 +58,7 @@ def _set_text(obj):
         obj.ViewObject.FontSize = 75
 
 
-def create_frame():
+def _create_frame():
     """Draw a frame with information on the version of the software.
 
     It includes the date created, the version, the release type,
@@ -71,12 +80,13 @@ def create_frame():
 
     frame = Draft.makeRectangle(21000, 12000)
     frame.Placement.Base = Vector(-1000, -3500)
+    frame.MakeFace = False
 
 
 def create_test_file(file_name="draft_test_objects",
-                     font_file="/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
-                     file_path="",
-                     save=False):
+                     file_path=os.environ["HOME"],
+                     save=False,
+                     font_file="/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf"):
     """Create a complete test file of Draft objects.
 
     It draws a frame with information on the software used to create
@@ -86,33 +96,46 @@ def create_test_file(file_name="draft_test_objects",
     ----------
     file_name: str, optional
         It defaults to `'draft_test_objects'`.
-        It is the name of document that is created.
-
-    font_file: str, optional
-        It defaults to `"/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf"`.
-        It is the full path of a font in the system to be used
-        with `Draft_ShapeString`.
-        If the font is not found, this object is not created.
-
-    file_path: str, optional
-        It defaults to the empty string `''`, in which case,
-        it will use the value returned by `App.getUserAppDataDir()`,
-        for example, `'/home/user/.FreeCAD/'`.
+        It is the name of the document that is created.
 
         The `file_name` will be appended to `file_path`
         to determine the actual path to save. The extension `.FCStd`
         will be added automatically.
 
+    file_path: str, optional
+        It defaults to the value of `os.environ['HOME']`
+        which in Linux is usually `'/home/user'`.
+
+        If it is the empty string `''` it will use the value
+        returned by `App.getUserAppDataDir()`,
+        for example, `'/home/user/.FreeCAD/'`.
+
     save: bool, optional
         It defaults to `False`. If it is `True` the new document
         will be saved to disk after creating all objects.
+
+    font_file: str, optional
+        It defaults to `'/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf'`.
+        It is the full path of a font in the system to be used
+        to create a `Draft ShapeString`.
+        If the font is not found, this object is not created.
+
+    Returns
+    -------
+    App::Document
+        A reference to the test document that was created.
+
+    To Do
+    -----
+    Find a reliable way of getting a default font to be able to create
+    the `Draft ShapeString`.
     """
     doc = App.newDocument(file_name)
     _msg(16 * "-")
     _msg("Filename: {}".format(file_name))
     _msg("If the units tests fail, this script may fail as well")
 
-    create_frame()
+    _create_frame()
 
     # Line, wire, and fillet
     _msg(16 * "-")
@@ -142,7 +165,6 @@ def create_test_file(file_name="draft_test_objects",
     App.ActiveDocument.recompute()
 
     Draft.make_fillet([line_h_1, line_h_2], 400)
-
     t_xpos += 900
     _t = Draft.makeText(["Fillet"], Vector(t_xpos, t_ypos, 0))
     _set_text(_t)
@@ -585,6 +607,8 @@ def create_test_file(file_name="draft_test_objects",
         _msg("Saved: {}".format(out_name))
 
     return doc
+
+## @}
 
 
 if __name__ == "__main__":

--- a/src/Mod/Draft/drafttests/draft_test_objects.py
+++ b/src/Mod/Draft/drafttests/draft_test_objects.py
@@ -67,18 +67,18 @@ def _create_frame():
     version = App.Version()
     now = datetime.datetime.now().strftime("%Y/%m/%dT%H:%M:%S")
 
-    record = Draft.makeText(["Draft test file",
-                             "Created: {}".format(now),
-                             "\n",
-                             "Version: " + ".".join(version[0:3]),
-                             "Release: " + " ".join(version[3:5]),
-                             "Branch: " + " ".join(version[5:])],
-                            Vector(0, -1000, 0))
+    record = Draft.make_text(["Draft test file",
+                              "Created: {}".format(now),
+                              "\n",
+                              "Version: " + ".".join(version[0:3]),
+                              "Release: " + " ".join(version[3:5]),
+                              "Branch: " + " ".join(version[5:])],
+                             Vector(0, -1000, 0))
 
     if App.GuiUp:
         record.ViewObject.FontSize = 400
 
-    frame = Draft.makeRectangle(21000, 12000)
+    frame = Draft.make_rectangle(21000, 12000)
     frame.Placement.Base = Vector(-1000, -3500)
     frame.MakeFace = False
 
@@ -140,50 +140,50 @@ def create_test_file(file_name="draft_test_objects",
     # Line, wire, and fillet
     _msg(16 * "-")
     _msg("Line")
-    Draft.makeLine(Vector(0, 0, 0), Vector(500, 500, 0))
+    Draft.make_line(Vector(0, 0, 0), Vector(500, 500, 0))
     t_xpos = -50
     t_ypos = -200
-    _t = Draft.makeText(["Line"], Vector(t_xpos, t_ypos, 0))
+    _t = Draft.make_text(["Line"], Vector(t_xpos, t_ypos, 0))
     _set_text(_t)
 
     _msg(16 * "-")
     _msg("Wire")
-    Draft.makeWire([Vector(500, 0, 0),
-                    Vector(1000, 500, 0),
-                    Vector(1000, 1000, 0)])
+    Draft.make_wire([Vector(500, 0, 0),
+                     Vector(1000, 500, 0),
+                     Vector(1000, 1000, 0)])
     t_xpos += 500
-    _t = Draft.makeText(["Wire"], Vector(t_xpos, t_ypos, 0))
+    _t = Draft.make_text(["Wire"], Vector(t_xpos, t_ypos, 0))
     _set_text(_t)
 
     _msg(16 * "-")
     _msg("Fillet")
-    line_h_1 = Draft.makeLine(Vector(1500, 0, 0), Vector(1500, 500, 0))
-    line_h_2 = Draft.makeLine(Vector(1500, 500, 0), Vector(2000, 500, 0))
+    line_h_1 = Draft.make_line(Vector(1500, 0, 0), Vector(1500, 500, 0))
+    line_h_2 = Draft.make_line(Vector(1500, 500, 0), Vector(2000, 500, 0))
     if App.GuiUp:
         line_h_1.ViewObject.DrawStyle = "Dotted"
         line_h_2.ViewObject.DrawStyle = "Dotted"
-    App.ActiveDocument.recompute()
+    doc.recompute()
 
     Draft.make_fillet([line_h_1, line_h_2], 400)
     t_xpos += 900
-    _t = Draft.makeText(["Fillet"], Vector(t_xpos, t_ypos, 0))
+    _t = Draft.make_text(["Fillet"], Vector(t_xpos, t_ypos, 0))
     _set_text(_t)
 
     # Circle, arc, arc by 3 points
     _msg(16 * "-")
     _msg("Circle")
-    circle = Draft.makeCircle(350)
+    circle = Draft.make_circle(350)
     circle.Placement.Base = Vector(2500, 500, 0)
     t_xpos += 1050
-    _t = Draft.makeText(["Circle"], Vector(t_xpos, t_ypos, 0))
+    _t = Draft.make_text(["Circle"], Vector(t_xpos, t_ypos, 0))
     _set_text(_t)
 
     _msg(16 * "-")
     _msg("Circular arc")
-    arc = Draft.makeCircle(350, startangle=0, endangle=100)
+    arc = Draft.make_circle(350, startangle=0, endangle=100)
     arc.Placement.Base = Vector(3200, 500, 0)
     t_xpos += 800
-    _t = Draft.makeText(["Circular arc"], Vector(t_xpos, t_ypos, 0))
+    _t = Draft.make_text(["Circular arc"], Vector(t_xpos, t_ypos, 0))
     _set_text(_t)
 
     _msg(16 * "-")
@@ -192,50 +192,50 @@ def create_test_file(file_name="draft_test_objects",
                             Vector(4600, 800, 0),
                             Vector(4000, 1000, 0)])
     t_xpos += 600
-    _t = Draft.makeText(["Circular arc 3 points"], Vector(t_xpos, t_ypos, 0))
+    _t = Draft.make_text(["Circular arc 3 points"], Vector(t_xpos, t_ypos, 0))
     _set_text(_t)
 
     # Ellipse, polygon, rectangle
     _msg(16 * "-")
     _msg("Ellipse")
-    ellipse = Draft.makeEllipse(500, 300)
+    ellipse = Draft.make_ellipse(500, 300)
     ellipse.Placement.Base = Vector(5500, 250, 0)
     t_xpos += 1600
-    _t = Draft.makeText(["Ellipse"], Vector(t_xpos, t_ypos, 0))
+    _t = Draft.make_text(["Ellipse"], Vector(t_xpos, t_ypos, 0))
     _set_text(_t)
 
     _msg(16 * "-")
     _msg("Polygon")
-    polygon = Draft.makePolygon(5, 250)
+    polygon = Draft.make_polygon(5, 250)
     polygon.Placement.Base = Vector(6500, 500, 0)
     t_xpos += 950
-    _t = Draft.makeText(["Polygon"], Vector(t_xpos, t_ypos, 0))
+    _t = Draft.make_text(["Polygon"], Vector(t_xpos, t_ypos, 0))
     _set_text(_t)
 
     _msg(16 * "-")
     _msg("Rectangle")
-    rectangle = Draft.makeRectangle(500, 1000, 0)
+    rectangle = Draft.make_rectangle(500, 1000, 0)
     rectangle.Placement.Base = Vector(7000, 0, 0)
     t_xpos += 650
-    _t = Draft.makeText(["Rectangle"], Vector(t_xpos, t_ypos, 0))
+    _t = Draft.make_text(["Rectangle"], Vector(t_xpos, t_ypos, 0))
     _set_text(_t)
 
     # Text
     _msg(16 * "-")
     _msg("Text")
-    text = Draft.makeText(["Testing"], Vector(7700, 500, 0))
+    text = Draft.make_text(["Testing"], Vector(7700, 500, 0))
     if App.GuiUp:
         text.ViewObject.FontSize = 100
     t_xpos += 700
-    _t = Draft.makeText(["Text"], Vector(t_xpos, t_ypos, 0))
+    _t = Draft.make_text(["Text"], Vector(t_xpos, t_ypos, 0))
     _set_text(_t)
 
     # Linear dimension
     _msg(16 * "-")
     _msg("Linear dimension")
-    dimension = Draft.makeDimension(Vector(8500, 500, 0),
-                                    Vector(8500, 1000, 0),
-                                    Vector(9000, 750, 0))
+    dimension = Draft.make_dimension(Vector(8500, 500, 0),
+                                     Vector(8500, 1000, 0),
+                                     Vector(9000, 750, 0))
     if App.GuiUp:
         dimension.ViewObject.ArrowSize = 15
         dimension.ViewObject.ExtLines = 1000
@@ -243,98 +243,100 @@ def create_test_file(file_name="draft_test_objects",
         dimension.ViewObject.FontSize = 100
         dimension.ViewObject.ShowUnit = False
     t_xpos += 680
-    _t = Draft.makeText(["Dimension"], Vector(t_xpos, t_ypos, 0))
+    _t = Draft.make_text(["Dimension"], Vector(t_xpos, t_ypos, 0))
     _set_text(_t)
 
     # Radius and diameter dimension
     _msg(16 * "-")
     _msg("Radius and diameter dimension")
-    arc_h = Draft.makeCircle(500, startangle=0, endangle=90)
+    arc_h = Draft.make_circle(500, startangle=0, endangle=90)
     arc_h.Placement.Base = Vector(9500, 0, 0)
-    App.ActiveDocument.recompute()
+    doc.recompute()
 
-    dimension_r = Draft.makeDimension(arc_h, 0, "radius",
-                                      Vector(9750, 200, 0))
+    dimension_r = Draft.make_dimension(arc_h, 0,
+                                       "radius",
+                                       Vector(9750, 200, 0))
     if App.GuiUp:
         dimension_r.ViewObject.ArrowSize = 15
         dimension_r.ViewObject.FontSize = 100
         dimension_r.ViewObject.ShowUnit = False
 
-    arc_h2 = Draft.makeCircle(450, startangle=-120, endangle=80)
+    arc_h2 = Draft.make_circle(450, startangle=-120, endangle=80)
     arc_h2.Placement.Base = Vector(10000, 1000, 0)
-    App.ActiveDocument.recompute()
+    doc.recompute()
 
-    dimension_d = Draft.makeDimension(arc_h2, 0, "diameter",
-                                      Vector(10750, 900, 0))
+    dimension_d = Draft.make_dimension(arc_h2, 0,
+                                       "diameter",
+                                       Vector(10750, 900, 0))
     if App.GuiUp:
         dimension_d.ViewObject.ArrowSize = 15
         dimension_d.ViewObject.FontSize = 100
         dimension_d.ViewObject.ShowUnit = False
     t_xpos += 950
-    _t = Draft.makeText(["Radius dimension",
-                         "Diameter dimension"], Vector(t_xpos, t_ypos, 0))
+    _t = Draft.make_text(["Radius dimension",
+                          "Diameter dimension"], Vector(t_xpos, t_ypos, 0))
     _set_text(_t)
 
     # Angular dimension
     _msg(16 * "-")
     _msg("Angular dimension")
-    Draft.makeLine(Vector(10500, 300, 0), Vector(11500, 1000, 0))
-    Draft.makeLine(Vector(10500, 300, 0), Vector(11500, 0, 0))
+    Draft.make_line(Vector(10500, 300, 0), Vector(11500, 1000, 0))
+    Draft.make_line(Vector(10500, 300, 0), Vector(11500, 0, 0))
     angle1 = math.radians(40)
     angle2 = math.radians(-20)
-    dimension_a = Draft.makeAngularDimension(Vector(10500, 300, 0),
-                                             [angle1, angle2],
-                                             Vector(11500, 300, 0))
+    dimension_a = Draft.make_angular_dimension(Vector(10500, 300, 0),
+                                               [angle1, angle2],
+                                               Vector(11500, 300, 0))
     if App.GuiUp:
         dimension_a.ViewObject.ArrowSize = 15
         dimension_a.ViewObject.FontSize = 100
     t_xpos += 1700
-    _t = Draft.makeText(["Angle dimension"], Vector(t_xpos, t_ypos, 0))
+    _t = Draft.make_text(["Angle dimension"], Vector(t_xpos, t_ypos, 0))
     _set_text(_t)
 
     # BSpline
     _msg(16 * "-")
     _msg("BSpline")
-    Draft.makeBSpline([Vector(12500, 0, 0),
-                       Vector(12500, 500, 0),
-                       Vector(13000, 500, 0),
-                       Vector(13000, 1000, 0)])
+    Draft.make_bspline([Vector(12500, 0, 0),
+                        Vector(12500, 500, 0),
+                        Vector(13000, 500, 0),
+                        Vector(13000, 1000, 0)])
     t_xpos += 1500
-    _t = Draft.makeText(["BSpline"], Vector(t_xpos, t_ypos, 0))
+    _t = Draft.make_text(["BSpline"], Vector(t_xpos, t_ypos, 0))
     _set_text(_t)
 
     # Point
     _msg(16 * "-")
     _msg("Point")
-    point = Draft.makePoint(13500, 500, 0)
+    point = Draft.make_point(13500, 500, 0)
     if App.GuiUp:
         point.ViewObject.PointSize = 10
     t_xpos += 900
-    _t = Draft.makeText(["Point"], Vector(t_xpos, t_ypos, 0))
+    _t = Draft.make_text(["Point"], Vector(t_xpos, t_ypos, 0))
     _set_text(_t)
 
     # Shapestring
     _msg(16 * "-")
     _msg("Shapestring")
     try:
-        shape_string = Draft.makeShapeString("Testing",
-                                             font_file,
-                                             100)
+        shape_string = Draft.make_shapestring("Testing",
+                                              font_file,
+                                              100)
         shape_string.Placement.Base = Vector(14000, 500)
     except Exception:
         _wrn("Shapestring could not be created")
         _wrn("Possible cause: the font file may not exist")
         _wrn(font_file)
-        rect = Draft.makeRectangle(500, 100)
+        rect = Draft.make_rectangle(500, 100)
         rect.Placement.Base = Vector(14000, 500)
     t_xpos += 600
-    _t = Draft.makeText(["Shapestring"], Vector(t_xpos, t_ypos, 0))
+    _t = Draft.make_text(["Shapestring"], Vector(t_xpos, t_ypos, 0))
     _set_text(_t)
 
     # Facebinder
     _msg(16 * "-")
     _msg("Facebinder")
-    box = App.ActiveDocument.addObject("Part::Box", "Cube")
+    box = doc.addObject("Part::Box", "Cube")
     box.Length = 200
     box.Width = 500
     box.Height = 100
@@ -342,61 +344,61 @@ def create_test_file(file_name="draft_test_objects",
     if App.GuiUp:
         box.ViewObject.Visibility = False
 
-    facebinder = Draft.makeFacebinder([(box, ("Face1", "Face3", "Face6"))])
+    facebinder = Draft.make_facebinder([(box, ("Face1", "Face3", "Face6"))])
     facebinder.Extrusion = 10
     t_xpos += 780
-    _t = Draft.makeText(["Facebinder"], Vector(t_xpos, t_ypos, 0))
+    _t = Draft.make_text(["Facebinder"], Vector(t_xpos, t_ypos, 0))
     _set_text(_t)
 
     # Cubic bezier curve, n-degree bezier curve
     _msg(16 * "-")
     _msg("Cubic bezier")
-    Draft.makeBezCurve([Vector(15500, 0, 0),
-                        Vector(15578, 485, 0),
-                        Vector(15879, 154, 0),
-                        Vector(15975, 400, 0),
-                        Vector(16070, 668, 0),
-                        Vector(16423, 925, 0),
-                        Vector(16500, 500, 0)], degree=3)
+    Draft.make_bezcurve([Vector(15500, 0, 0),
+                         Vector(15578, 485, 0),
+                         Vector(15879, 154, 0),
+                         Vector(15975, 400, 0),
+                         Vector(16070, 668, 0),
+                         Vector(16423, 925, 0),
+                         Vector(16500, 500, 0)], degree=3)
     t_xpos += 680
-    _t = Draft.makeText(["Cubic bezier"], Vector(t_xpos, t_ypos, 0))
+    _t = Draft.make_text(["Cubic bezier"], Vector(t_xpos, t_ypos, 0))
     _set_text(_t)
 
     _msg(16 * "-")
     _msg("N-degree bezier")
-    Draft.makeBezCurve([Vector(16500, 0, 0),
-                        Vector(17000, 500, 0),
-                        Vector(17500, 500, 0),
-                        Vector(17500, 1000, 0),
-                        Vector(17000, 1000, 0),
-                        Vector(17063, 1256, 0),
-                        Vector(17732, 1227, 0),
-                        Vector(17790, 720, 0),
-                        Vector(17702, 242, 0)])
+    Draft.make_bezcurve([Vector(16500, 0, 0),
+                         Vector(17000, 500, 0),
+                         Vector(17500, 500, 0),
+                         Vector(17500, 1000, 0),
+                         Vector(17000, 1000, 0),
+                         Vector(17063, 1256, 0),
+                         Vector(17732, 1227, 0),
+                         Vector(17790, 720, 0),
+                         Vector(17702, 242, 0)])
     t_xpos += 1200
-    _t = Draft.makeText(["n-Bezier"], Vector(t_xpos, t_ypos, 0))
+    _t = Draft.make_text(["n-Bezier"], Vector(t_xpos, t_ypos, 0))
     _set_text(_t)
 
     # Label
     _msg(16 * "-")
     _msg("Label")
     place = App.Placement(Vector(18500, 500, 0), App.Rotation())
-    label = Draft.makeLabel(targetpoint=Vector(18000, 0, 0),
-                            distance=-250,
-                            placement=place)
+    label = Draft.make_label(targetpoint=Vector(18000, 0, 0),
+                             distance=-250,
+                             placement=place)
     label.Text = "Testing"
     if App.GuiUp:
         label.ViewObject.ArrowSize = 15
         label.ViewObject.TextSize = 100
-    App.ActiveDocument.recompute()
+    doc.recompute()
     t_xpos += 1200
-    _t = Draft.makeText(["Label"], Vector(t_xpos, t_ypos, 0))
+    _t = Draft.make_text(["Label"], Vector(t_xpos, t_ypos, 0))
     _set_text(_t)
 
     # Orthogonal array and orthogonal link array
     _msg(16 * "-")
     _msg("Orthogonal array")
-    rect_h = Draft.makeRectangle(500, 500)
+    rect_h = Draft.make_rectangle(500, 500)
     rect_h.Placement.Base = Vector(1500, 2500, 0)
     if App.GuiUp:
         rect_h.ViewObject.Visibility = False
@@ -408,10 +410,10 @@ def create_test_file(file_name="draft_test_objects",
                     3, 2, 1)
     t_xpos = 1700
     t_ypos = 2200
-    _t = Draft.makeText(["Array"], Vector(t_xpos, t_ypos, 0))
+    _t = Draft.make_text(["Array"], Vector(t_xpos, t_ypos, 0))
     _set_text(_t)
 
-    rect_h_2 = Draft.makeRectangle(500, 100)
+    rect_h_2 = Draft.make_rectangle(500, 100)
     rect_h_2.Placement.Base = Vector(1500, 5000, 0)
     if App.GuiUp:
         rect_h_2.ViewObject.Visibility = False
@@ -425,16 +427,16 @@ def create_test_file(file_name="draft_test_objects",
                     2, 4, 1,
                     use_link=True)
     t_ypos += 2600
-    _t = Draft.makeText(["Link array"], Vector(t_xpos, t_ypos, 0))
+    _t = Draft.make_text(["Link array"], Vector(t_xpos, t_ypos, 0))
     _set_text(_t)
 
     # Polar array and polar link array
     _msg(16 * "-")
     _msg("Polar array")
-    wire_h = Draft.makeWire([Vector(5500, 3000, 0),
-                             Vector(6000, 3500, 0),
-                             Vector(6000, 3200, 0),
-                             Vector(5800, 3200, 0)])
+    wire_h = Draft.make_wire([Vector(5500, 3000, 0),
+                              Vector(6000, 3500, 0),
+                              Vector(6000, 3200, 0),
+                              Vector(5800, 3200, 0)])
     if App.GuiUp:
         wire_h.ViewObject.Visibility = False
 
@@ -444,15 +446,15 @@ def create_test_file(file_name="draft_test_objects",
                     8)
     t_xpos = 4600
     t_ypos = 2200
-    _t = Draft.makeText(["Polar array"], Vector(t_xpos, t_ypos, 0))
+    _t = Draft.make_text(["Polar array"], Vector(t_xpos, t_ypos, 0))
     _set_text(_t)
 
     _msg(16 * "-")
     _msg("Polar link array")
-    wire_h_2 = Draft.makeWire([Vector(5500, 6000, 0),
-                               Vector(6000, 6000, 0),
-                               Vector(5800, 5700, 0),
-                               Vector(5800, 5750, 0)])
+    wire_h_2 = Draft.make_wire([Vector(5500, 6000, 0),
+                                Vector(6000, 6000, 0),
+                                Vector(5800, 5700, 0),
+                                Vector(5800, 5750, 0)])
     if App.GuiUp:
         wire_h_2.ViewObject.Visibility = False
 
@@ -462,13 +464,13 @@ def create_test_file(file_name="draft_test_objects",
                     8,
                     use_link=True)
     t_ypos += 3200
-    _t = Draft.makeText(["Polar link array"], Vector(t_xpos, t_ypos, 0))
+    _t = Draft.make_text(["Polar link array"], Vector(t_xpos, t_ypos, 0))
     _set_text(_t)
 
     # Circular array and circular link array
     _msg(16 * "-")
     _msg("Circular array")
-    poly_h = Draft.makePolygon(5, 200)
+    poly_h = Draft.make_polygon(5, 200)
     poly_h.Placement.Base = Vector(8000, 3000, 0)
     if App.GuiUp:
         poly_h.ViewObject.Visibility = False
@@ -481,12 +483,12 @@ def create_test_file(file_name="draft_test_objects",
                     1)
     t_xpos = 7700
     t_ypos = 1700
-    _t = Draft.makeText(["Circular array"], Vector(t_xpos, t_ypos, 0))
+    _t = Draft.make_text(["Circular array"], Vector(t_xpos, t_ypos, 0))
     _set_text(_t)
 
     _msg(16 * "-")
     _msg("Circular link array")
-    poly_h_2 = Draft.makePolygon(6, 150)
+    poly_h_2 = Draft.make_polygon(6, 150)
     poly_h_2.Placement.Base = Vector(8000, 6250, 0)
     if App.GuiUp:
         poly_h_2.ViewObject.Visibility = False
@@ -499,55 +501,55 @@ def create_test_file(file_name="draft_test_objects",
                     1,
                     use_link=True)
     t_ypos += 3100
-    _t = Draft.makeText(["Circular link array"], Vector(t_xpos, t_ypos, 0))
+    _t = Draft.make_text(["Circular link array"], Vector(t_xpos, t_ypos, 0))
     _set_text(_t)
 
     # Path array and path link array
     _msg(16 * "-")
     _msg("Path array")
-    poly_h = Draft.makePolygon(3, 250)
+    poly_h = Draft.make_polygon(3, 250)
     poly_h.Placement.Base = Vector(10500, 3000, 0)
     if App.GuiUp:
         poly_h.ViewObject.Visibility = False
 
-    bspline_path = Draft.makeBSpline([Vector(10500, 2500, 0),
-                                      Vector(11000, 3000, 0),
-                                      Vector(11500, 3200, 0),
-                                      Vector(12000, 4000, 0)])
+    bspline_path = Draft.make_bspline([Vector(10500, 2500, 0),
+                                       Vector(11000, 3000, 0),
+                                       Vector(11500, 3200, 0),
+                                       Vector(12000, 4000, 0)])
 
     Draft.makePathArray(poly_h, bspline_path, 5)
     t_xpos = 10400
     t_ypos = 2200
-    _t = Draft.makeText(["Path array"], Vector(t_xpos, t_ypos, 0))
+    _t = Draft.make_text(["Path array"], Vector(t_xpos, t_ypos, 0))
     _set_text(_t)
 
     _msg(16 * "-")
     _msg("Path link array")
-    poly_h_2 = Draft.makePolygon(4, 200)
+    poly_h_2 = Draft.make_polygon(4, 200)
     poly_h_2.Placement.Base = Vector(10500, 5000, 0)
     if App.GuiUp:
         poly_h_2.ViewObject.Visibility = False
 
-    bspline_path_2 = Draft.makeBSpline([Vector(10500, 4500, 0),
-                                        Vector(11000, 6800, 0),
-                                        Vector(11500, 6000, 0),
-                                        Vector(12000, 5200, 0)])
+    bspline_path_2 = Draft.make_bspline([Vector(10500, 4500, 0),
+                                         Vector(11000, 6800, 0),
+                                         Vector(11500, 6000, 0),
+                                         Vector(12000, 5200, 0)])
 
     Draft.makePathArray(poly_h_2, bspline_path_2, 6,
                         use_link=True)
     t_ypos += 2000
-    _t = Draft.makeText(["Path link array"], Vector(t_xpos, t_ypos, 0))
+    _t = Draft.make_text(["Path link array"], Vector(t_xpos, t_ypos, 0))
     _set_text(_t)
 
     # Point array
     _msg(16 * "-")
     _msg("Point array")
-    poly_h = Draft.makePolygon(3, 250)
+    poly_h = Draft.make_polygon(3, 250)
 
-    point_1 = Draft.makePoint(13000, 3000, 0)
-    point_2 = Draft.makePoint(13000, 3500, 0)
-    point_3 = Draft.makePoint(14000, 2500, 0)
-    point_4 = Draft.makePoint(14000, 3000, 0)
+    point_1 = Draft.make_point(13000, 3000, 0)
+    point_2 = Draft.make_point(13000, 3500, 0)
+    point_3 = Draft.make_point(14000, 2500, 0)
+    point_4 = Draft.make_point(14000, 3000, 0)
 
     add_list, delete_list = Draft.upgrade([point_1, point_2,
                                            point_3, point_4])
@@ -558,40 +560,40 @@ def create_test_file(file_name="draft_test_objects",
     Draft.makePointArray(poly_h, compound)
     t_xpos = 13000
     t_ypos = 2200
-    _t = Draft.makeText(["Point array"], Vector(t_xpos, t_ypos, 0))
+    _t = Draft.make_text(["Point array"], Vector(t_xpos, t_ypos, 0))
     _set_text(_t)
 
     # Clone and mirror
     _msg(16 * "-")
     _msg("Clone")
-    wire_h = Draft.makeWire([Vector(15000, 2500, 0),
-                             Vector(15200, 3000, 0),
-                             Vector(15500, 2500, 0),
-                             Vector(15200, 2300, 0)])
+    wire_h = Draft.make_wire([Vector(15000, 2500, 0),
+                              Vector(15200, 3000, 0),
+                              Vector(15500, 2500, 0),
+                              Vector(15200, 2300, 0)])
 
     Draft.clone(wire_h, Vector(0, 1000, 0))
     t_xpos = 15000
     t_ypos = 2100
-    _t = Draft.makeText(["Clone"], Vector(t_xpos, t_ypos, 0))
+    _t = Draft.make_text(["Clone"], Vector(t_xpos, t_ypos, 0))
     _set_text(_t)
 
     _msg(16 * "-")
     _msg("Mirror")
-    wire_h = Draft.makeWire([Vector(17000, 2500, 0),
-                             Vector(16500, 4000, 0),
-                             Vector(16000, 2700, 0),
-                             Vector(16500, 2500, 0),
-                             Vector(16700, 2700, 0)])
+    wire_h = Draft.make_wire([Vector(17000, 2500, 0),
+                              Vector(16500, 4000, 0),
+                              Vector(16000, 2700, 0),
+                              Vector(16500, 2500, 0),
+                              Vector(16700, 2700, 0)])
 
     Draft.mirror(wire_h,
                  Vector(17100, 2000, 0),
                  Vector(17100, 4000, 0))
     t_xpos = 17000
     t_ypos = 2200
-    _t = Draft.makeText(["Mirror"], Vector(t_xpos, t_ypos, 0))
+    _t = Draft.make_text(["Mirror"], Vector(t_xpos, t_ypos, 0))
     _set_text(_t)
 
-    App.ActiveDocument.recompute()
+    doc.recompute()
 
     if App.GuiUp:
         Gui.runCommand("Std_ViewFitAll")

--- a/src/Mod/Draft/drafttests/test_airfoildat.py
+++ b/src/Mod/Draft/drafttests/test_airfoildat.py
@@ -40,7 +40,7 @@ class DraftAirfoilDAT(unittest.TestCase):
         This is executed before every test, so we create a document
         to hold the objects.
         """
-        aux._draw_header()
+        aux.draw_header()
         self.doc_name = self.__class__.__name__
         if App.ActiveDocument:
             if App.ActiveDocument.Name != self.doc_name:
@@ -62,8 +62,8 @@ class DraftAirfoilDAT(unittest.TestCase):
         _msg("  file={}".format(in_file))
         _msg("  exists={}".format(os.path.exists(in_file)))
 
-        Draft.import_AirfoilDAT = aux._fake_function
-        obj = Draft.import_AirfoilDAT(in_file)
+        Draft.import_airfoildat = aux.fake_function
+        obj = Draft.import_airfoildat(in_file)
         self.assertTrue(obj, "'{}' failed".format(operation))
 
     def test_export_airfoildat(self):
@@ -76,8 +76,8 @@ class DraftAirfoilDAT(unittest.TestCase):
         _msg("  file={}".format(out_file))
         _msg("  exists={}".format(os.path.exists(out_file)))
 
-        Draft.export_importAirfoilDAT = aux._fake_function
-        obj = Draft.export_importAirfoilDAT(out_file)
+        Draft.export_airfoildat = aux.fake_function
+        obj = Draft.export_airfoildat(out_file)
         self.assertTrue(obj, "'{}' failed".format(operation))
 
     def tearDown(self):

--- a/src/Mod/Draft/drafttests/test_creation.py
+++ b/src/Mod/Draft/drafttests/test_creation.py
@@ -25,9 +25,11 @@
 
 import unittest
 import math
+
 import FreeCAD as App
 import Draft
 import drafttests.auxiliary as aux
+
 from FreeCAD import Vector
 from draftutils.messages import _msg
 
@@ -41,7 +43,7 @@ class DraftCreation(unittest.TestCase):
         This is executed before every test, so we create a document
         to hold the objects.
         """
-        aux._draw_header()
+        aux.draw_header()
         doc_name = self.__class__.__name__
         if App.ActiveDocument:
             if App.ActiveDocument.Name != doc_name:
@@ -59,7 +61,7 @@ class DraftCreation(unittest.TestCase):
         a = Vector(0, 0, 0)
         b = Vector(2, 0, 0)
         _msg("  a={0}, b={1}".format(a, b))
-        obj = Draft.makeLine(a, b)
+        obj = Draft.make_line(a, b)
         self.assertTrue(obj, "'{}' failed".format(operation))
 
     def test_polyline(self):
@@ -71,7 +73,7 @@ class DraftCreation(unittest.TestCase):
         c = Vector(2, 2, 0)
         _msg("  a={0}, b={1}".format(a, b))
         _msg("  c={}".format(c))
-        obj = Draft.makeWire([a, b, c])
+        obj = Draft.make_wire([a, b, c])
         self.assertTrue(obj, "'{}' failed".format(operation))
 
     def test_fillet(self):
@@ -84,8 +86,8 @@ class DraftCreation(unittest.TestCase):
         _msg("  Lines")
         _msg("  a={0}, b={1}".format(a, b))
         _msg("  b={0}, c={1}".format(b, c))
-        L1 = Draft.makeLine(a, b)
-        L2 = Draft.makeLine(b, c)
+        L1 = Draft.make_line(a, b)
+        L2 = Draft.make_line(b, c)
         self.doc.recompute()
 
         radius = 4
@@ -100,7 +102,7 @@ class DraftCreation(unittest.TestCase):
         _msg("  Test '{}'".format(operation))
         radius = 3
         _msg("  radius={}".format(radius))
-        obj = Draft.makeCircle(radius)
+        obj = Draft.make_circle(radius)
         self.assertTrue(obj, "'{}' failed".format(operation))
 
     def test_arc(self):
@@ -113,8 +115,8 @@ class DraftCreation(unittest.TestCase):
         _msg("  radius={}".format(radius))
         _msg("  startangle={0}, endangle={1}".format(start_angle,
                                                      end_angle))
-        obj = Draft.makeCircle(radius,
-                               startangle=start_angle, endangle=end_angle)
+        obj = Draft.make_circle(radius,
+                                startangle=start_angle, endangle=end_angle)
         self.assertTrue(obj, "'{}' failed".format(operation))
 
     def test_arc_3points(self):
@@ -137,7 +139,7 @@ class DraftCreation(unittest.TestCase):
         a = 5
         b = 3
         _msg("  major_axis={0}, minor_axis={1}".format(a, b))
-        obj = Draft.makeEllipse(a, b)
+        obj = Draft.make_ellipse(a, b)
         self.assertTrue(obj, "'{}' failed".format(operation))
 
     def test_polygon(self):
@@ -147,7 +149,7 @@ class DraftCreation(unittest.TestCase):
         n_faces = 6
         radius = 5
         _msg("  n_faces={0}, radius={1}".format(n_faces, radius))
-        obj = Draft.makePolygon(n_faces, radius)
+        obj = Draft.make_polygon(n_faces, radius)
         self.assertTrue(obj, "'{}' failed".format(operation))
 
     def test_rectangle(self):
@@ -157,7 +159,7 @@ class DraftCreation(unittest.TestCase):
         length = 5
         width = 2
         _msg("  length={0}, width={1}".format(length, width))
-        obj = Draft.makeRectangle(length, width)
+        obj = Draft.make_rectangle(length, width)
         self.assertTrue(obj, "'{}' failed".format(operation))
 
     def test_text(self):
@@ -166,7 +168,7 @@ class DraftCreation(unittest.TestCase):
         _msg("  Test '{}'".format(operation))
         text = "Testing testing"
         _msg("  text='{}'".format(text))
-        obj = Draft.makeText(text)
+        obj = Draft.make_text(text)
         self.assertTrue(obj, "'{}' failed".format(operation))
 
     def test_dimension_linear(self):
@@ -179,7 +181,7 @@ class DraftCreation(unittest.TestCase):
         c = Vector(4, -1, 0)
         _msg("  a={0}, b={1}".format(a, b))
         _msg("  c={}".format(c))
-        obj = Draft.makeDimension(a, b, c)
+        obj = Draft.make_dimension(a, b, c)
         self.assertTrue(obj, "'{}' failed".format(operation))
 
     def test_dimension_radial(self):
@@ -192,14 +194,14 @@ class DraftCreation(unittest.TestCase):
         _msg("  radius={}".format(radius))
         _msg("  startangle={0}, endangle={1}".format(start_angle,
                                                      end_angle))
-        circ = Draft.makeCircle(radius,
-                                startangle=start_angle, endangle=end_angle)
+        circ = Draft.make_circle(radius,
+                                 startangle=start_angle, endangle=end_angle)
         self.doc.recompute()
 
-        obj1 = Draft.makeDimension(circ, 0,
-                                   p3="radius", p4=Vector(1, 1, 0))
-        obj2 = Draft.makeDimension(circ, 0,
-                                   p3="diameter", p4=Vector(3, 1, 0))
+        obj1 = Draft.make_dimension(circ, 0,
+                                    p3="radius", p4=Vector(1, 1, 0))
+        obj2 = Draft.make_dimension(circ, 0,
+                                    p3="diameter", p4=Vector(3, 1, 0))
         self.assertTrue(obj1 and obj2, "'{}' failed".format(operation))
 
     def test_dimension_angular(self):
@@ -215,7 +217,7 @@ class DraftCreation(unittest.TestCase):
         _msg("  angle1={0}, angle2={1}".format(math.degrees(angle1),
                                                math.degrees(angle2)))
         _msg("  point={}".format(p3))
-        obj = Draft.makeAngularDimension(center, [angle1, angle2], p3)
+        obj = Draft.make_angular_dimension(center, [angle1, angle2], p3)
         self.assertTrue(obj, "'{}' failed".format(operation))
 
     def test_bspline(self):
@@ -227,7 +229,7 @@ class DraftCreation(unittest.TestCase):
         c = Vector(2, 2, 0)
         _msg("  a={0}, b={1}".format(a, b))
         _msg("  c={}".format(c))
-        obj = Draft.makeBSpline([a, b, c])
+        obj = Draft.make_bspline([a, b, c])
         self.assertTrue(obj, "'{}' failed".format(operation))
 
     def test_point(self):
@@ -236,7 +238,7 @@ class DraftCreation(unittest.TestCase):
         _msg("  Test '{}'".format(operation))
         p = Vector(5, 3, 2)
         _msg("  p.x={0}, p.y={1}, p.z={2}".format(p.x, p.y, p.z))
-        obj = Draft.makePoint(p.x, p.y, p.z)
+        obj = Draft.make_point(p.x, p.y, p.z)
         self.assertTrue(obj, "'{}' failed".format(operation))
 
     def test_shapestring(self):
@@ -248,9 +250,9 @@ class DraftCreation(unittest.TestCase):
         # TODO: find a reliable way to always get a font file here
         font = None
         _msg("  text='{0}', font='{1}'".format(text, font))
-        Draft.makeShapeString = aux._fake_function
-        obj = Draft.makeShapeString("Text", font)
-        # Draft.makeShapeString("Text", FontFile="")
+        Draft.make_shapestring = aux.fake_function
+        obj = Draft.make_shapestring("Text", font)
+        # Draft.make_shapestring("Text", FontFile="")
         self.assertTrue(obj, "'{}' failed".format(operation))
 
     def test_facebinder(self):
@@ -276,7 +278,7 @@ class DraftCreation(unittest.TestCase):
         elements = selection_set[0][1]
         _msg("  object='{0}' ({1})".format(box.Shape.ShapeType, box.TypeId))
         _msg("  sub-elements={}".format(elements))
-        obj = Draft.makeFacebinder(selection_set)
+        obj = Draft.make_facebinder(selection_set)
         self.assertTrue(obj, "'{}' failed".format(operation))
 
     def test_cubicbezcurve(self):
@@ -289,7 +291,7 @@ class DraftCreation(unittest.TestCase):
         d = Vector(9, 0, 0)
         _msg("  a={0}, b={1}".format(a, b))
         _msg("  c={0}, d={1}".format(c, d))
-        obj = Draft.makeBezCurve([a, b, c, d], degree=3)
+        obj = Draft.make_bezcurve([a, b, c, d], degree=3)
         self.assertTrue(obj, "'{}' failed".format(operation))
 
     def test_bezcurve(self):
@@ -305,7 +307,7 @@ class DraftCreation(unittest.TestCase):
         _msg("  a={0}, b={1}".format(a, b))
         _msg("  c={0}, d={1}".format(c, d))
         _msg("  e={0}, f={1}".format(e, f))
-        obj = Draft.makeBezCurve([a, b, c, d, e, f])
+        obj = Draft.make_bezcurve([a, b, c, d, e, f])
         self.assertTrue(obj, "'{}' failed".format(operation))
 
     def test_label(self):
@@ -319,9 +321,9 @@ class DraftCreation(unittest.TestCase):
         _msg("  target_point={0}, "
              "distance={1}".format(target_point, distance))
         _msg("  placement={}".format(placement))
-        obj = Draft.makeLabel(targetpoint=target_point,
-                              distance=distance,
-                              placement=placement)
+        obj = Draft.make_label(targetpoint=target_point,
+                               distance=distance,
+                               placement=placement)
         self.doc.recompute()
         self.assertTrue(obj, "'{}' failed".format(operation))
 

--- a/src/Mod/Draft/drafttests/test_dwg.py
+++ b/src/Mod/Draft/drafttests/test_dwg.py
@@ -40,7 +40,7 @@ class DraftDWG(unittest.TestCase):
         This is executed before every test, so we create a document
         to hold the objects.
         """
-        aux._draw_header()
+        aux.draw_header()
         self.doc_name = self.__class__.__name__
         if App.ActiveDocument:
             if App.ActiveDocument.Name != self.doc_name:
@@ -62,8 +62,8 @@ class DraftDWG(unittest.TestCase):
         _msg("  file={}".format(in_file))
         _msg("  exists={}".format(os.path.exists(in_file)))
 
-        Draft.import_DWG = aux._fake_function
-        obj = Draft.import_DWG(in_file)
+        Draft.import_dwg = aux.fake_function
+        obj = Draft.import_dwg(in_file)
         self.assertTrue(obj, "'{}' failed".format(operation))
 
     def test_export_dwg(self):
@@ -76,8 +76,8 @@ class DraftDWG(unittest.TestCase):
         _msg("  file={}".format(out_file))
         _msg("  exists={}".format(os.path.exists(out_file)))
 
-        Draft.export_DWG = aux._fake_function
-        obj = Draft.export_DWG(out_file)
+        Draft.export_dwg = aux.fake_function
+        obj = Draft.export_dwg(out_file)
         self.assertTrue(obj, "'{}' failed".format(operation))
 
     def tearDown(self):

--- a/src/Mod/Draft/drafttests/test_dxf.py
+++ b/src/Mod/Draft/drafttests/test_dxf.py
@@ -40,7 +40,7 @@ class DraftDXF(unittest.TestCase):
         This is executed before every test, so we create a document
         to hold the objects.
         """
-        aux._draw_header()
+        aux.draw_header()
         self.doc_name = self.__class__.__name__
         if App.ActiveDocument:
             if App.ActiveDocument.Name != self.doc_name:
@@ -62,8 +62,8 @@ class DraftDXF(unittest.TestCase):
         _msg("  file={}".format(in_file))
         _msg("  exists={}".format(os.path.exists(in_file)))
 
-        Draft.import_DXF = aux._fake_function
-        obj = Draft.import_DXF(in_file)
+        Draft.import_dxf = aux.fake_function
+        obj = Draft.import_dxf(in_file)
         self.assertTrue(obj, "'{}' failed".format(operation))
 
     def test_export_dxf(self):
@@ -76,8 +76,8 @@ class DraftDXF(unittest.TestCase):
         _msg("  file={}".format(out_file))
         _msg("  exists={}".format(os.path.exists(out_file)))
 
-        Draft.export_DXF = aux._fake_function
-        obj = Draft.export_DXF(out_file)
+        Draft.export_dxf = aux.fake_function
+        obj = Draft.export_dxf(out_file)
         self.assertTrue(obj, "'{}' failed".format(operation))
 
     def tearDown(self):

--- a/src/Mod/Draft/drafttests/test_import.py
+++ b/src/Mod/Draft/drafttests/test_import.py
@@ -33,28 +33,28 @@ class DraftImport(unittest.TestCase):
     # No document is needed to test 'import Draft' or other modules
     # thus 'setUp' just draws a line, and 'tearDown' isn't defined.
     def setUp(self):
-        aux._draw_header()
+        aux.draw_header()
 
     def test_import_draft(self):
         """Import the Draft module."""
         module = "Draft"
-        imported = aux._import_test(module)
+        imported = aux.import_test(module)
         self.assertTrue(imported, "Problem importing '{}'".format(module))
 
     def test_import_draft_geomutils(self):
         """Import Draft geometrical utilities."""
         module = "DraftGeomUtils"
-        imported = aux._import_test(module)
+        imported = aux.import_test(module)
         self.assertTrue(imported, "Problem importing '{}'".format(module))
 
     def test_import_draft_vecutils(self):
         """Import Draft vector utilities."""
         module = "DraftVecUtils"
-        imported = aux._import_test(module)
+        imported = aux.import_test(module)
         self.assertTrue(imported, "Problem importing '{}'".format(module))
 
     def test_import_draft_svg(self):
         """Import Draft SVG utilities."""
         module = "getSVG"
-        imported = aux._import_test(module)
+        imported = aux.import_test(module)
         self.assertTrue(imported, "Problem importing '{}'".format(module))

--- a/src/Mod/Draft/drafttests/test_import_gui.py
+++ b/src/Mod/Draft/drafttests/test_import_gui.py
@@ -33,28 +33,28 @@ class DraftGuiImport(unittest.TestCase):
     # No document is needed to test 'import DraftGui' or other modules
     # thus 'setUp' just draws a line, and 'tearDown' isn't defined.
     def setUp(self):
-        aux._draw_header()
+        aux.draw_header()
 
     def test_import_gui_draftgui(self):
         """Import Draft TaskView GUI tools."""
         module = "DraftGui"
-        imported = aux._import_test(module)
+        imported = aux.import_test(module)
         self.assertTrue(imported, "Problem importing '{}'".format(module))
 
     def test_import_gui_draft_snap(self):
         """Import Draft snapping."""
         module = "draftguitools.gui_snapper"
-        imported = aux._import_test(module)
+        imported = aux.import_test(module)
         self.assertTrue(imported, "Problem importing '{}'".format(module))
 
     def test_import_gui_draft_tools(self):
         """Import Draft graphical commands."""
         module = "DraftTools"
-        imported = aux._import_test(module)
+        imported = aux.import_test(module)
         self.assertTrue(imported, "Problem importing '{}'".format(module))
 
     def test_import_gui_draft_trackers(self):
         """Import Draft tracker utilities."""
         module = "draftguitools.gui_trackers"
-        imported = aux._import_test(module)
+        imported = aux.import_test(module)
         self.assertTrue(imported, "Problem importing '{}'".format(module))

--- a/src/Mod/Draft/drafttests/test_import_tools.py
+++ b/src/Mod/Draft/drafttests/test_import_tools.py
@@ -33,34 +33,28 @@ class DraftImportTools(unittest.TestCase):
     # No document is needed to test 'import' of other modules
     # thus 'setUp' just draws a line, and 'tearDown' isn't defined.
     def setUp(self):
-        aux._draw_header()
+        aux.draw_header()
 
     def test_import_gui_draftedit(self):
         """Import Draft Edit."""
         module = "draftguitools.gui_edit"
-        imported = aux._import_test(module)
-        self.assertTrue(imported, "Problem importing '{}'".format(module))
-
-    def test_import_gui_draftfillet(self):
-        """Import Draft Fillet."""
-        module = "DraftFillet"
-        imported = aux._import_test(module)
+        imported = aux.import_test(module)
         self.assertTrue(imported, "Problem importing '{}'".format(module))
 
     def test_import_gui_draftlayer(self):
         """Import Draft Layer."""
         module = "DraftLayer"
-        imported = aux._import_test(module)
+        imported = aux.import_test(module)
         self.assertTrue(imported, "Problem importing '{}'".format(module))
 
     def test_import_gui_draftplane(self):
         """Import Draft SelectPlane."""
         module = "draftguitools.gui_selectplane"
-        imported = aux._import_test(module)
+        imported = aux.import_test(module)
         self.assertTrue(imported, "Problem importing '{}'".format(module))
 
     def test_import_gui_workingplane(self):
         """Import Draft WorkingPlane."""
         module = "WorkingPlane"
-        imported = aux._import_test(module)
+        imported = aux.import_test(module)
         self.assertTrue(imported, "Problem importing '{}'".format(module))

--- a/src/Mod/Draft/drafttests/test_modification.py
+++ b/src/Mod/Draft/drafttests/test_modification.py
@@ -40,7 +40,7 @@ class DraftModification(unittest.TestCase):
         This is executed before every test, so we create a document
         to hold the objects.
         """
-        aux._draw_header()
+        aux.draw_header()
         self.doc_name = self.__class__.__name__
         if App.ActiveDocument:
             if App.ActiveDocument.Name != self.doc_name:
@@ -59,7 +59,7 @@ class DraftModification(unittest.TestCase):
         b = Vector(2, 2, 0)
         _msg("  Line")
         _msg("  a={0}, b={1}".format(a, b))
-        obj = Draft.makeLine(a, b)
+        obj = Draft.make_line(a, b)
 
         c = Vector(3, 1, 0)
         _msg("  Translation vector")
@@ -76,7 +76,7 @@ class DraftModification(unittest.TestCase):
         b = Vector(2, 3, 0)
         _msg("  Line")
         _msg("  a={0}, b={1}".format(a, b))
-        line = Draft.makeLine(a, b)
+        line = Draft.make_line(a, b)
 
         c = Vector(2, 2, 0)
         _msg("  Translation vector (copy)")
@@ -92,7 +92,7 @@ class DraftModification(unittest.TestCase):
         b = Vector(3, 1, 0)
         _msg("  Line")
         _msg("  a={0}, b={1}".format(a, b))
-        obj = Draft.makeLine(a, b)
+        obj = Draft.make_line(a, b)
         App.ActiveDocument.recompute()
 
         c = Vector(-1, 1, 0)
@@ -113,7 +113,7 @@ class DraftModification(unittest.TestCase):
         _msg("  Wire")
         _msg("  a={0}, b={1}".format(a, b))
         _msg("  c={0}".format(c))
-        wire = Draft.makeWire([a, b, c])
+        wire = Draft.make_wire([a, b, c])
         App.ActiveDocument.recompute()
 
         offset = Vector(-1, 1, 0)
@@ -130,7 +130,7 @@ class DraftModification(unittest.TestCase):
         width = 2
         _msg("  Rectangle")
         _msg("  length={0}, width={1}".format(length, width))
-        rect = Draft.makeRectangle(length, width)
+        rect = Draft.make_rectangle(length, width)
         App.ActiveDocument.recompute()
 
         offset = Vector(-1, -1, 0)
@@ -148,16 +148,16 @@ class DraftModification(unittest.TestCase):
 
         _msg("  Line")
         _msg("  a={0}, b={1}".format(a, b))
-        line = Draft.makeLine(a, b)
+        line = Draft.make_line(a, b)
 
         c = Vector(2, 2, 0)
         d = Vector(4, 2, 0)
         _msg("  Line 2")
         _msg("  c={0}, d={1}".format(c, d))
-        line2 = Draft.makeLine(c, d)
+        line2 = Draft.make_line(c, d)
         App.ActiveDocument.recompute()
 
-        Draft.trim_objects = aux._fake_function
+        Draft.trim_objects = aux.fake_function
         obj = Draft.trim_objects(line, line2)
         self.assertTrue(obj, "'{}' failed".format(operation))
 
@@ -169,16 +169,16 @@ class DraftModification(unittest.TestCase):
         b = Vector(1, 1, 0)
         _msg("  Line")
         _msg("  a={0}, b={1}".format(a, b))
-        line = Draft.makeLine(a, b)
+        line = Draft.make_line(a, b)
 
         c = Vector(2, 2, 0)
         d = Vector(4, 2, 0)
         _msg("  Line 2")
         _msg("  c={0}, d={1}".format(c, d))
-        line2 = Draft.makeLine(c, d)
+        line2 = Draft.make_line(c, d)
         App.ActiveDocument.recompute()
 
-        Draft.extrude = aux._fake_function
+        Draft.extrude = aux.fake_function
         obj = Draft.extrude(line, line2)
         self.assertTrue(obj, "'{}' failed".format(operation))
 
@@ -193,11 +193,11 @@ class DraftModification(unittest.TestCase):
         _msg("  a={0}, b={1}".format(a, b))
         _msg("  Line 2")
         _msg("  b={0}, c={1}".format(b, c))
-        line_1 = Draft.makeLine(a, b)
-        line_2 = Draft.makeLine(b, c)
+        line_1 = Draft.make_line(a, b)
+        line_2 = Draft.make_line(b, c)
 
-        # obj = Draft.joinWires([line_1, line_2])  # Multiple wires
-        obj = Draft.joinTwoWires(line_1, line_2)
+        # obj = Draft.join_wires([line_1, line_2])  # Multiple wires
+        obj = Draft.join_two_wires(line_1, line_2)
         self.assertTrue(obj, "'{}' failed".format(operation))
 
     def test_split(self):
@@ -211,7 +211,7 @@ class DraftModification(unittest.TestCase):
         _msg("  Wire")
         _msg("  a={0}, b={1}".format(a, b))
         _msg("  c={0}, d={1}".format(c, d))
-        wire = Draft.makeWire([a, b, c, d])
+        wire = Draft.make_wire([a, b, c, d])
 
         index = 1
         _msg("  Split at")
@@ -234,8 +234,8 @@ class DraftModification(unittest.TestCase):
         _msg("  a={0}, b={1}".format(a, b))
         _msg("  Line 2")
         _msg("  b={0}, c={1}".format(b, c))
-        line_1 = Draft.makeLine(a, b)
-        line_2 = Draft.makeLine(b, c)
+        line_1 = Draft.make_line(a, b)
+        line_2 = Draft.make_line(b, c)
         App.ActiveDocument.recompute()
 
         obj = Draft.upgrade([line_1, line_2], delete=True)
@@ -274,7 +274,7 @@ class DraftModification(unittest.TestCase):
         _msg("  Closed wire")
         _msg("  a={0}, b={1}".format(a, b))
         _msg("  c={0}, a={1}".format(c, a))
-        wire = Draft.makeWire([a, b, c, a])
+        wire = Draft.make_wire([a, b, c, a])
         App.ActiveDocument.recompute()
 
         obj = Draft.downgrade(wire, delete=True)
@@ -313,14 +313,14 @@ class DraftModification(unittest.TestCase):
         _msg("  Wire")
         _msg("  a={0}, b={1}".format(a, b))
         _msg("  c={}".format(c))
-        wire = Draft.makeWire([a, b, c])
+        wire = Draft.make_wire([a, b, c])
 
-        obj = Draft.makeBSpline(wire.Points)
+        obj = Draft.make_bspline(wire.Points)
         App.ActiveDocument.recompute()
         _msg("  1: Result '{0}' ({1})".format(obj.Proxy.Type, obj.TypeId))
         self.assertTrue(obj, "'{}' failed".format(operation))
 
-        obj2 = Draft.makeWire(obj.Points)
+        obj2 = Draft.make_wire(obj.Points)
         _msg("  2: Result '{0}' ({1})".format(obj2.Proxy.Type, obj2.TypeId))
         self.assertTrue(obj2, "'{}' failed".format(operation))
 
@@ -340,7 +340,7 @@ class DraftModification(unittest.TestCase):
         direction = Vector(0, 0, 1)
         _msg("  Projection 2D view")
         _msg("  direction={}".format(direction))
-        obj = Draft.makeShape2DView(prism, direction)
+        obj = Draft.make_shape2dview(prism, direction)
         self.assertTrue(obj, "'{}' failed".format(operation))
 
     def test_draft_to_sketch(self):
@@ -353,10 +353,10 @@ class DraftModification(unittest.TestCase):
         _msg("  Wire")
         _msg("  a={0}, b={1}".format(a, b))
         _msg("  c={}".format(c))
-        wire = Draft.makeWire([a, b, c])
+        wire = Draft.make_wire([a, b, c])
         App.ActiveDocument.recompute()
 
-        obj = Draft.makeSketch(wire, autoconstraints=True)
+        obj = Draft.make_sketch(wire, autoconstraints=True)
         App.ActiveDocument.recompute()
         _msg("  1: Result '{0}' ({1})".format(obj.Shape.ShapeType,
                                               obj.TypeId))
@@ -376,7 +376,7 @@ class DraftModification(unittest.TestCase):
         width = 2
         _msg("  Rectangle")
         _msg("  length={0}, width={1}".format(length, width))
-        rect = Draft.makeRectangle(length, width)
+        rect = Draft.make_rectangle(length, width)
         App.ActiveDocument.recompute()
 
         dir_x = Vector(5, 0, 0)
@@ -400,7 +400,7 @@ class DraftModification(unittest.TestCase):
         width = 2
         _msg("  Rectangle")
         _msg("  length={0}, width={1}".format(length, width))
-        rect = Draft.makeRectangle(length, width)
+        rect = Draft.make_rectangle(length, width)
         App.ActiveDocument.recompute()
 
         center = Vector(-4, 0, 0)
@@ -421,7 +421,7 @@ class DraftModification(unittest.TestCase):
         width = 2
         _msg("  Rectangle")
         _msg("  length={0}, width={1}".format(length, width))
-        rect = Draft.makeRectangle(length, width)
+        rect = Draft.make_rectangle(length, width)
         App.ActiveDocument.recompute()
 
         rad_distance = 10
@@ -453,13 +453,13 @@ class DraftModification(unittest.TestCase):
         _msg("  Wire")
         _msg("  a={0}, b={1}".format(a, b))
         _msg("  c={0}, d={1}".format(c, d))
-        wire = Draft.makeWire([a, b, c, d])
+        wire = Draft.make_wire([a, b, c, d])
 
         n_faces = 3
         radius = 1
         _msg("  Polygon")
         _msg("  n_faces={0}, radius={1}".format(n_faces, radius))
-        poly = Draft.makePolygon(n_faces, radius)
+        poly = Draft.make_polygon(n_faces, radius)
 
         number = 4
         translation = Vector(0, 1, 0)
@@ -481,10 +481,10 @@ class DraftModification(unittest.TestCase):
         _msg("  Points")
         _msg("  a={0}, b={1}".format(a, b))
         _msg("  c={0}, d={1}".format(c, d))
-        points = [Draft.makePoint(a),
-                  Draft.makePoint(b),
-                  Draft.makePoint(c),
-                  Draft.makePoint(d)]
+        points = [Draft.make_point(a),
+                  Draft.make_point(b),
+                  Draft.make_point(c),
+                  Draft.make_point(d)]
 
         _msg("  Upgrade")
         add, delete = Draft.upgrade(points)
@@ -494,7 +494,7 @@ class DraftModification(unittest.TestCase):
         radius = 1
         _msg("  Polygon")
         _msg("  n_faces={0}, radius={1}".format(n_faces, radius))
-        poly = Draft.makePolygon(n_faces, radius)
+        poly = Draft.make_polygon(n_faces, radius)
 
         _msg("  Point Array")
         obj = Draft.makePointArray(poly, compound)
@@ -511,7 +511,7 @@ class DraftModification(unittest.TestCase):
         App.ActiveDocument.recompute()
         _msg("  object: '{0}' ({1})".format(box.Shape.ShapeType, box.TypeId))
 
-        obj = Draft.clone(box)
+        obj = Draft.make_clone(box)
         _msg("  clone: '{0}' ({1})".format(obj.Proxy.Type, obj.TypeId))
         self.assertTrue(obj, "'{}' failed".format(operation))
         self.assertTrue(obj.hasExtension("Part::AttachExtension"),
@@ -533,8 +533,8 @@ class DraftModification(unittest.TestCase):
         _msg("  placement={}".format(prism.Placement))
 
         svg_template = 'Mod/Drawing/Templates/A3_Landscape.svg'
-        template = Draft.getParam("template",
-                                  App.getResourceDir() + svg_template)
+        template = Draft.get_param("template",
+                                   App.getResourceDir() + svg_template)
         page = App.ActiveDocument.addObject('Drawing::FeaturePage')
         page.Template = template
         _msg("  Drawing view")
@@ -551,7 +551,7 @@ class DraftModification(unittest.TestCase):
         width = 2
         _msg("  Rectangle")
         _msg("  length={0}, width={1}".format(length, width))
-        rect = Draft.makeRectangle(length, width)
+        rect = Draft.make_rectangle(length, width)
         # App.ActiveDocument.recompute()
 
         p1 = Vector(6, -2, 0)
@@ -571,10 +571,10 @@ class DraftModification(unittest.TestCase):
         b = Vector(1, 1, 0)
         _msg("  Line")
         _msg("  a={0}, b={1}".format(a, b))
-        line = Draft.makeLine(a, b)
+        line = Draft.make_line(a, b)
         direction = Vector(4, 1, 0)
 
-        Draft.stretch = aux._fake_function
+        Draft.stretch = aux.fake_function
         obj = Draft.stretch(line, direction)
         self.assertTrue(obj, "'{}' failed".format(operation))
 

--- a/src/Mod/Draft/drafttests/test_oca.py
+++ b/src/Mod/Draft/drafttests/test_oca.py
@@ -40,7 +40,7 @@ class DraftOCA(unittest.TestCase):
         This is executed before every test, so we create a document
         to hold the objects.
         """
-        aux._draw_header()
+        aux.draw_header()
         self.doc_name = self.__class__.__name__
         if App.ActiveDocument:
             if App.ActiveDocument.Name != self.doc_name:
@@ -62,8 +62,8 @@ class DraftOCA(unittest.TestCase):
         _msg("  file={}".format(in_file))
         _msg("  exists={}".format(os.path.exists(in_file)))
 
-        Draft.import_OCA = aux._fake_function
-        obj = Draft.import_OCA(in_file)
+        Draft.import_oca = aux.fake_function
+        obj = Draft.import_oca(in_file)
         self.assertTrue(obj, "'{}' failed".format(operation))
 
     def test_export_oca(self):
@@ -76,8 +76,8 @@ class DraftOCA(unittest.TestCase):
         _msg("  file={}".format(out_file))
         _msg("  exists={}".format(os.path.exists(out_file)))
 
-        Draft.export_OCA = aux._fake_function
-        obj = Draft.export_OCA(out_file)
+        Draft.export_oca = aux.fake_function
+        obj = Draft.export_oca(out_file)
         self.assertTrue(obj, "'{}' failed".format(operation))
 
     def tearDown(self):

--- a/src/Mod/Draft/drafttests/test_pivy.py
+++ b/src/Mod/Draft/drafttests/test_pivy.py
@@ -39,7 +39,7 @@ class DraftPivy(unittest.TestCase):
         This is executed before every test, so we create a document
         to hold the objects.
         """
-        aux._draw_header()
+        aux.draw_header()
         self.doc_name = self.__class__.__name__
         if App.ActiveDocument:
             if App.ActiveDocument.Name != self.doc_name:
@@ -53,7 +53,7 @@ class DraftPivy(unittest.TestCase):
     def test_pivy_import(self):
         """Import Coin (Pivy)."""
         module = "pivy.coin"
-        imported = aux._import_test(module)
+        imported = aux.import_test(module)
         self.assertTrue(imported, "Problem importing '{}'".format(module))
 
     def test_pivy_draw(self):

--- a/src/Mod/Draft/drafttests/test_svg.py
+++ b/src/Mod/Draft/drafttests/test_svg.py
@@ -40,7 +40,7 @@ class DraftSVG(unittest.TestCase):
         This is executed before every test, so we create a document
         to hold the objects.
         """
-        aux._draw_header()
+        aux.draw_header()
         self.doc_name = self.__class__.__name__
         if App.ActiveDocument:
             if App.ActiveDocument.Name != self.doc_name:
@@ -62,8 +62,8 @@ class DraftSVG(unittest.TestCase):
         _msg("  file={}".format(in_file))
         _msg("  exists={}".format(os.path.exists(in_file)))
 
-        Draft.import_SVG = aux._fake_function
-        obj = Draft.import_SVG(in_file)
+        Draft.import_svg = aux.fake_function
+        obj = Draft.import_svg(in_file)
         self.assertTrue(obj, "'{}' failed".format(operation))
 
     def test_export_svg(self):
@@ -76,8 +76,8 @@ class DraftSVG(unittest.TestCase):
         _msg("  file={}".format(out_file))
         _msg("  exists={}".format(os.path.exists(out_file)))
 
-        Draft.export_SVG = aux._fake_function
-        obj = Draft.export_SVG(out_file)
+        Draft.export_svg = aux.fake_function
+        obj = Draft.export_svg(out_file)
         self.assertTrue(obj, "'{}' failed".format(operation))
 
     def tearDown(self):


### PR DESCRIPTION
Now we test for the `snake_case` style of functions in the `Draft` namespace. Small fixes here and there.

Remove import of `DraftFillet` as it is only use for migrating older objects. Also remove tests of OCA and AirfoilDAT because they won't be used much.

---

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists