### PR TITLE
Path: LinuxCNC postprocessor scalability

### DIFF
--- a/src/Mod/Path/PathScripts/post/linuxcnc_post.py
+++ b/src/Mod/Path/PathScripts/post/linuxcnc_post.py
@@ -64,7 +64,7 @@ OUTPUT_HEADER = True
 OUTPUT_LINE_NUMBERS = False
 SHOW_EDITOR = True
 MODAL = False  # if true commands are suppressed if the same as previous line.
-USE_TLO = True # if true G43 will be output following tool changes 
+USE_TLO = True # if true G43 will be output following tool changes
 OUTPUT_DOUBLES = True  # if false duplicate axis values are suppressed if the same as previous line.
 COMMAND_SPACE = " "
 LINENR = 100  # line number starting value
@@ -185,7 +185,7 @@ def export(objectslist, filename, argstring):
     for obj in objectslist:
 
         # Skip inactive operations
-        if hasattr(obj, 'Active'): 
+        if hasattr(obj, 'Active'):
             if not obj.Active:
                 continue
         if hasattr(obj, 'Base') and hasattr(obj.Base, 'Active'):
@@ -246,7 +246,7 @@ def export(objectslist, filename, argstring):
         # turn coolant off if required
         if not coolantMode == 'None':
             if OUTPUT_COMMENTS:
-                gcode += linenumber() + '(Coolant Off:' + coolantMode + ')\n'    
+                gcode += linenumber() + '(Coolant Off:' + coolantMode + ')\n'
             gcode  += linenumber() +'M9' + '\n'
 
     # do the post_amble
@@ -256,13 +256,15 @@ def export(objectslist, filename, argstring):
         gcode += linenumber() + line
 
     if FreeCAD.GuiUp and SHOW_EDITOR:
-        dia = PostUtils.GCodeEditorDialog()
-        dia.editor.setText(gcode)
-        result = dia.exec_()
-        if result:
-            final = dia.editor.toPlainText()
+        final = gcode
+        if len(gcode) > 100000:
+            print("Skipping editor since output is greater than 100kb")
         else:
-            final = gcode
+            dia = PostUtils.GCodeEditorDialog()
+            dia.editor.setText(gcode)
+            result = dia.exec_()
+            if result:
+                final = dia.editor.toPlainText()
     else:
         final = gcode
 
@@ -389,7 +391,9 @@ def parse(pathobj):
                 # append the line to the final output
                 for w in outstring:
                     out += w + COMMAND_SPACE
-                out = out.strip() + "\n"
+                # Note: Do *not* strip `out`, since that forces the allocation
+                # of a contiguous string & thus quadratic complexity.
+                out += "\n"
 
         return out
 


### PR DESCRIPTION
- Do not show editor when gcode size exceeds 100kb. The poor editor
  widget cannot handle that much output, and will hang FreeCAD.
- Avoid quadratic behavior in output accumulator. While Python greater
  than 2.7 avoids quadratic behavior in string accumulators, this optimization
  is defeated when the string is forced to be materialized to contiguous
  memory, as was done by the `.trim()`. As a result, we got quadratic complexity,
  ensuring that large jobs would never successfully be post-processed.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
