### PR TITLE
Draft: move make functions to create arrays

### DIFF
--- a/src/Mod/Draft/CMakeLists.txt
+++ b/src/Mod/Draft/CMakeLists.txt
@@ -86,6 +86,7 @@ SET(Draft_make_functions
     draftmake/make_block.py
     draftmake/make_bspline.py
     draftmake/make_circle.py
+    draftmake/make_circulararray.py
     draftmake/make_clone.py
     draftmake/make_copy.py
     draftmake/make_drawingview.py
@@ -93,13 +94,15 @@ SET(Draft_make_functions
     draftmake/make_facebinder.py
     draftmake/make_fillet.py
     draftmake/make_line.py
+    draftmake/make_orthoarray.py
     draftmake/make_patharray.py
-    draftmake/make_polygon.py
     draftmake/make_point.py
     draftmake/make_pointarray.py
+    draftmake/make_polararray.py
+    draftmake/make_polygon.py
     draftmake/make_rectangle.py
-    draftmake/make_shapestring.py
     draftmake/make_shape2dview.py
+    draftmake/make_shapestring.py
     draftmake/make_sketch.py
     draftmake/make_wire.py
     draftmake/make_wpproxy.py
@@ -113,14 +116,11 @@ SET(Draft_objects
     draftobjects/bezcurve.py
     draftobjects/block.py
     draftobjects/bspline.py
-    draftobjects/circulararray.py
     draftobjects/circle.py
     draftobjects/clone.py
     draftobjects/drawingview.py
     draftobjects/ellipse.py
     draftobjects/facebinder.py
-    draftobjects/orthoarray.py
-    draftobjects/polararray.py
     draftobjects/draft_annotation.py
     draftobjects/fillet.py
     draftobjects/draftlink.py

--- a/src/Mod/Draft/Draft.py
+++ b/src/Mod/Draft/Draft.py
@@ -338,12 +338,12 @@ if FreeCAD.GuiUp:
     from draftviewproviders.view_array import ViewProviderDraftArray
     from draftviewproviders.view_array import _ViewProviderDraftArray
 
-# from draftmake.make_circulararray import make_circular_array
-# from draftmake.make_orthoarray import make_ortho_array
-# from draftmake.make_orthoarray import make_ortho_array2d
-# from draftmake.make_orthoarray import make_rect_array
-# from draftmake.make_orthoarray import make_rect_array2d
-# from draftmake.make_polararray import make_polar_array
+from draftmake.make_circulararray import make_circular_array
+from draftmake.make_orthoarray import make_ortho_array
+from draftmake.make_orthoarray import make_ortho_array2d
+from draftmake.make_orthoarray import make_rect_array
+from draftmake.make_orthoarray import make_rect_array2d
+from draftmake.make_polararray import make_polar_array
 
 # facebinder
 from draftmake.make_facebinder import make_facebinder, makeFacebinder

--- a/src/Mod/Draft/Draft.py
+++ b/src/Mod/Draft/Draft.py
@@ -338,6 +338,13 @@ if FreeCAD.GuiUp:
     from draftviewproviders.view_array import ViewProviderDraftArray
     from draftviewproviders.view_array import _ViewProviderDraftArray
 
+# from draftmake.make_circulararray import make_circular_array
+# from draftmake.make_orthoarray import make_ortho_array
+# from draftmake.make_orthoarray import make_ortho_array2d
+# from draftmake.make_orthoarray import make_rect_array
+# from draftmake.make_orthoarray import make_rect_array2d
+# from draftmake.make_polararray import make_polar_array
+
 # facebinder
 from draftmake.make_facebinder import make_facebinder, makeFacebinder
 from draftobjects.facebinder import Facebinder, _Facebinder

--- a/src/Mod/Draft/draftmake/make_circulararray.py
+++ b/src/Mod/Draft/draftmake/make_circulararray.py
@@ -20,13 +20,14 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides the object code for Draft CircularArray."""
-## @package circulararray
+"""Provides functions for creating circular arrays in a plane."""
+## @package make_circulararray
 # \ingroup DRAFT
-# \brief This module provides the object code for Draft CircularArray.
+# \brief Provides functions for creating circular arrays in a plane.
 
 import FreeCAD as App
 import Draft
+# import draftmake.make_array as make_array
 import draftutils.utils as utils
 from draftutils.messages import _msg, _err
 from draftutils.translate import _tr
@@ -141,6 +142,7 @@ def make_circular_array(obj,
 
     _msg("use_link: {}".format(bool(use_link)))
 
+    # new_obj = make_array.make_array()
     new_obj = Draft.makeArray(obj,
                               arg1=r_distance, arg2=tan_distance,
                               arg3=axis, arg4=center,

--- a/src/Mod/Draft/draftmake/make_orthoarray.py
+++ b/src/Mod/Draft/draftmake/make_orthoarray.py
@@ -20,13 +20,14 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provide the object code for Draft Array."""
-## @package orthoarray
+"""Provides functions for creating orthogonal arrays in 2D and 3D."""
+## @package make_orthoarray
 # \ingroup DRAFT
-# \brief Provide the object code for Draft Array.
+# \brief Provides functions for creating orthogonal arrays in 2D and 3D.
 
 import FreeCAD as App
 import Draft
+# import draftmake.make_array as make_array
 import draftutils.utils as utils
 from draftutils.messages import _msg, _wrn, _err
 from draftutils.translate import _tr
@@ -179,6 +180,7 @@ def make_ortho_array(obj,
 
     _msg("use_link: {}".format(bool(use_link)))
 
+    # new_obj = make_array.make_array()
     new_obj = Draft.makeArray(obj,
                               arg1=v_x, arg2=v_y, arg3=v_z,
                               arg4=n_x, arg5=n_y, arg6=n_z,
@@ -273,6 +275,7 @@ def make_ortho_array2d(obj,
 
     _msg("use_link: {}".format(bool(use_link)))
 
+    # new_obj = make_array.make_array()
     new_obj = Draft.makeArray(obj,
                               arg1=v_x, arg2=v_y,
                               arg3=n_x, arg4=n_y,

--- a/src/Mod/Draft/draftmake/make_polararray.py
+++ b/src/Mod/Draft/draftmake/make_polararray.py
@@ -20,13 +20,14 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provide the object code for Draft PolarArray."""
-## @package polararray
+"""Provides functions for creating polar arrays in a plane."""
+## @package make_polararray
 # \ingroup DRAFT
-# \brief This module provides the object code for Draft PolarArray.
+# \brief Provides functions for creating polar arrays in a plane.
 
 import FreeCAD as App
 import Draft
+# import draftmake.make_array as make_array
 import draftutils.utils as utils
 from draftutils.messages import _msg, _err
 from draftutils.translate import _tr
@@ -106,6 +107,7 @@ def make_polar_array(obj,
 
     _msg("use_link: {}".format(bool(use_link)))
 
+    # new_obj = make_array.make_array()
     new_obj = Draft.makeArray(obj,
                               arg1=center, arg2=angle, arg3=number,
                               use_link=use_link)

--- a/src/Mod/Draft/drafttaskpanels/task_circulararray.py
+++ b/src/Mod/Draft/drafttaskpanels/task_circulararray.py
@@ -278,7 +278,7 @@ class TaskPanelCircularArray:
         # of this class, the GuiCommand.
         # This is needed to schedule geometry manipulation
         # that would crash Coin3D if done in the event callback.
-        _cmd = "draftobjects.circulararray.make_circular_array"
+        _cmd = "DD.make_circular_array"
         _cmd += "("
         _cmd += "App.ActiveDocument." + sel_obj.Name + ", "
         _cmd += "r_distance=" + str(self.r_distance) + ", "
@@ -290,8 +290,11 @@ class TaskPanelCircularArray:
         _cmd += "use_link=" + str(self.use_link)
         _cmd += ")"
 
-        _cmd_list = ["Gui.addModule('Draft')",
-                     "Gui.addModule('draftobjects.circulararray')",
+        Gui.addModule('Draft')
+        Gui.addModule('draftmake.make_circulararray')
+
+        _cmd_list = ["# DD = Draft  # in the future",
+                     "DD = draftmake.make_circulararray",
                      "obj = " + _cmd,
                      "obj.Fuse = " + str(self.fuse),
                      "Draft.autogroup(obj)",

--- a/src/Mod/Draft/drafttaskpanels/task_circulararray.py
+++ b/src/Mod/Draft/drafttaskpanels/task_circulararray.py
@@ -278,7 +278,7 @@ class TaskPanelCircularArray:
         # of this class, the GuiCommand.
         # This is needed to schedule geometry manipulation
         # that would crash Coin3D if done in the event callback.
-        _cmd = "DD.make_circular_array"
+        _cmd = "Draft.make_circular_array"
         _cmd += "("
         _cmd += "App.ActiveDocument." + sel_obj.Name + ", "
         _cmd += "r_distance=" + str(self.r_distance) + ", "
@@ -291,13 +291,10 @@ class TaskPanelCircularArray:
         _cmd += ")"
 
         Gui.addModule('Draft')
-        Gui.addModule('draftmake.make_circulararray')
 
-        _cmd_list = ["# DD = Draft  # in the future",
-                     "DD = draftmake.make_circulararray",
-                     "obj = " + _cmd,
-                     "obj.Fuse = " + str(self.fuse),
-                     "Draft.autogroup(obj)",
+        _cmd_list = ["_obj_ = " + _cmd,
+                     "_obj_.Fuse = " + str(self.fuse),
+                     "Draft.autogroup(_obj_)",
                      "App.ActiveDocument.recompute()"]
 
         # We commit the command list through the parent command

--- a/src/Mod/Draft/drafttaskpanels/task_orthoarray.py
+++ b/src/Mod/Draft/drafttaskpanels/task_orthoarray.py
@@ -248,7 +248,7 @@ class TaskPanelOrthoArray:
         # of this class, the GuiCommand.
         # This is needed to schedule geometry manipulation
         # that would crash Coin3D if done in the event callback.
-        _cmd = "DD.make_ortho_array"
+        _cmd = "Draft.make_ortho_array"
         _cmd += "("
         _cmd += "App.ActiveDocument." + sel_obj.Name + ", "
         _cmd += "v_x=" + DraftVecUtils.toString(self.v_x) + ", "
@@ -261,13 +261,10 @@ class TaskPanelOrthoArray:
         _cmd += ")"
 
         Gui.addModule('Draft')
-        Gui.addModule('draftmake.make_orthoarray')
 
-        _cmd_list = ["# DD = Draft  # in the future",
-                     "DD = draftmake.make_orthoarray",
-                     "obj = " + _cmd,
-                     "obj.Fuse = " + str(self.fuse),
-                     "Draft.autogroup(obj)",
+        _cmd_list = ["_obj_ = " + _cmd,
+                     "_obj_.Fuse = " + str(self.fuse),
+                     "Draft.autogroup(_obj_)",
                      "App.ActiveDocument.recompute()"]
 
         # We commit the command list through the parent command

--- a/src/Mod/Draft/drafttaskpanels/task_orthoarray.py
+++ b/src/Mod/Draft/drafttaskpanels/task_orthoarray.py
@@ -248,7 +248,7 @@ class TaskPanelOrthoArray:
         # of this class, the GuiCommand.
         # This is needed to schedule geometry manipulation
         # that would crash Coin3D if done in the event callback.
-        _cmd = "draftobjects.orthoarray.make_ortho_array"
+        _cmd = "DD.make_ortho_array"
         _cmd += "("
         _cmd += "App.ActiveDocument." + sel_obj.Name + ", "
         _cmd += "v_x=" + DraftVecUtils.toString(self.v_x) + ", "
@@ -260,8 +260,11 @@ class TaskPanelOrthoArray:
         _cmd += "use_link=" + str(self.use_link)
         _cmd += ")"
 
-        _cmd_list = ["Gui.addModule('Draft')",
-                     "Gui.addModule('draftobjects.orthoarray')",
+        Gui.addModule('Draft')
+        Gui.addModule('draftmake.make_orthoarray')
+
+        _cmd_list = ["# DD = Draft  # in the future",
+                     "DD = draftmake.make_orthoarray",
                      "obj = " + _cmd,
                      "obj.Fuse = " + str(self.fuse),
                      "Draft.autogroup(obj)",

--- a/src/Mod/Draft/drafttaskpanels/task_polararray.py
+++ b/src/Mod/Draft/drafttaskpanels/task_polararray.py
@@ -242,7 +242,7 @@ class TaskPanelPolarArray:
         # of this class, the GuiCommand.
         # This is needed to schedule geometry manipulation
         # that would crash Coin3D if done in the event callback.
-        _cmd = "draftobjects.polararray.make_polar_array"
+        _cmd = "DD.make_polar_array"
         _cmd += "("
         _cmd += "App.ActiveDocument." + sel_obj.Name + ", "
         _cmd += "number=" + str(self.number) + ", "
@@ -251,8 +251,11 @@ class TaskPanelPolarArray:
         _cmd += "use_link=" + str(self.use_link)
         _cmd += ")"
 
-        _cmd_list = ["Gui.addModule('Draft')",
-                     "Gui.addModule('draftobjects.polararray')",
+        Gui.addModule('Draft')
+        Gui.addModule('draftmake.make_polararray')
+
+        _cmd_list = ["# DD = Draft  # in the future",
+                     "DD = draftmake.make_polararray",
                      "obj = " + _cmd,
                      "obj.Fuse = " + str(self.fuse),
                      "Draft.autogroup(obj)",

--- a/src/Mod/Draft/drafttaskpanels/task_polararray.py
+++ b/src/Mod/Draft/drafttaskpanels/task_polararray.py
@@ -242,7 +242,7 @@ class TaskPanelPolarArray:
         # of this class, the GuiCommand.
         # This is needed to schedule geometry manipulation
         # that would crash Coin3D if done in the event callback.
-        _cmd = "DD.make_polar_array"
+        _cmd = "Draft.make_polar_array"
         _cmd += "("
         _cmd += "App.ActiveDocument." + sel_obj.Name + ", "
         _cmd += "number=" + str(self.number) + ", "
@@ -254,11 +254,9 @@ class TaskPanelPolarArray:
         Gui.addModule('Draft')
         Gui.addModule('draftmake.make_polararray')
 
-        _cmd_list = ["# DD = Draft  # in the future",
-                     "DD = draftmake.make_polararray",
-                     "obj = " + _cmd,
-                     "obj.Fuse = " + str(self.fuse),
-                     "Draft.autogroup(obj)",
+        _cmd_list = ["_obj_ = " + _cmd,
+                     "_obj_.Fuse = " + str(self.fuse),
+                     "Draft.autogroup(_obj_)",
                      "App.ActiveDocument.recompute()"]
 
         # We commit the command list through the parent command

--- a/src/Mod/Draft/drafttests/draft_test_objects.py
+++ b/src/Mod/Draft/drafttests/draft_test_objects.py
@@ -43,6 +43,7 @@ import math
 import os
 
 import FreeCAD as App
+import Part
 import Draft
 
 from draftutils.messages import _msg, _wrn
@@ -52,35 +53,505 @@ if App.GuiUp:
     import FreeCADGui as Gui
 
 
-def _set_text(obj):
-    """Set properties of text object."""
+def _set_text(text_list, position):
+    """Set a text annotation with properties."""
+    obj = App.ActiveDocument.addObject("App::Annotation", "Annotation")
+    obj.LabelText = text_list
+    obj.Position = position
+
     if App.GuiUp:
+        obj.ViewObject.DisplayMode = "World"
         obj.ViewObject.FontSize = 75
+        obj.ViewObject.TextColor = (0.0, 0.0, 0.0)
 
 
-def _create_frame():
+def _create_frame(doc=None):
     """Draw a frame with information on the version of the software.
 
     It includes the date created, the version, the release type,
     and the branch.
+
+    Parameters
+    ----------
+    doc: App::Document, optional
+        It defaults to `None`, which then defaults to the current
+        active document, or creates a new document.
     """
+    if not doc:
+        doc = App.activeDocument()
+    if not doc:
+        doc = App.newDocument()
+
     version = App.Version()
     now = datetime.datetime.now().strftime("%Y/%m/%dT%H:%M:%S")
 
-    record = Draft.make_text(["Draft test file",
-                              "Created: {}".format(now),
-                              "\n",
-                              "Version: " + ".".join(version[0:3]),
-                              "Release: " + " ".join(version[3:5]),
-                              "Branch: " + " ".join(version[5:])],
-                             Vector(0, -1000, 0))
+    _text = ["Draft test file",
+             "Created: {}".format(now),
+             "\n",
+             "Version: " + ".".join(version[0:3]),
+             "Release: " + " ".join(version[3:5]),
+             "Branch: " + " ".join(version[5:])]
+
+    record = doc.addObject("App::Annotation", "Description")
+    record.LabelText = _text
+    record.Position = Vector(0, -1000, 0)
 
     if App.GuiUp:
+        record.ViewObject.DisplayMode = "World"
         record.ViewObject.FontSize = 400
+        record.ViewObject.TextColor = (0.0, 0.0, 0.0)
 
-    frame = Draft.make_rectangle(21000, 12000)
-    frame.Placement.Base = Vector(-1000, -3500)
-    frame.MakeFace = False
+    p1 = Vector(-1000, -3500, 0)
+    p2 = Vector(20000, -3500, 0)
+    p3 = Vector(20000, 8500, 0)
+    p4 = Vector(-1000, 8500, 0)
+
+    poly = Part.makePolygon([p1, p2, p3, p4, p1])
+    frame = doc.addObject("Part::Feature", "Frame")
+    frame.Shape = poly
+
+
+def _create_objects(doc=None,
+                    font_file="/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf"):
+    """Create the objects of the test file.
+
+    Parameters
+    ----------
+    doc: App::Document, optional
+        It defaults to `None`, which then defaults to the current
+        active document, or creates a new document.
+    """
+    if not doc:
+        doc = App.activeDocument()
+    if not doc:
+        doc = App.newDocument()
+
+    # Line, wire, and fillet
+    _msg(16 * "-")
+    _msg("Line")
+    Draft.make_line(Vector(0, 0, 0), Vector(500, 500, 0))
+    t_xpos = -50
+    t_ypos = -200
+    _set_text(["Line"], Vector(t_xpos, t_ypos, 0))
+
+    _msg(16 * "-")
+    _msg("Wire")
+    Draft.make_wire([Vector(500, 0, 0),
+                     Vector(1000, 500, 0),
+                     Vector(1000, 1000, 0)])
+    t_xpos += 500
+    _set_text(["Wire"], Vector(t_xpos, t_ypos, 0))
+
+    _msg(16 * "-")
+    _msg("Fillet")
+    line_h_1 = Draft.make_line(Vector(1500, 0, 0), Vector(1500, 500, 0))
+    line_h_2 = Draft.make_line(Vector(1500, 500, 0), Vector(2000, 500, 0))
+    if App.GuiUp:
+        line_h_1.ViewObject.DrawStyle = "Dotted"
+        line_h_2.ViewObject.DrawStyle = "Dotted"
+    doc.recompute()
+
+    Draft.make_fillet([line_h_1, line_h_2], 400)
+    t_xpos += 900
+    _set_text(["Fillet"], Vector(t_xpos, t_ypos, 0))
+
+    # Circle, arc, arc by 3 points
+    _msg(16 * "-")
+    _msg("Circle")
+    circle = Draft.make_circle(350)
+    circle.Placement.Base = Vector(2500, 500, 0)
+    t_xpos += 1050
+    _set_text(["Circle"], Vector(t_xpos, t_ypos, 0))
+
+    _msg(16 * "-")
+    _msg("Circular arc")
+    arc = Draft.make_circle(350, startangle=0, endangle=100)
+    arc.Placement.Base = Vector(3200, 500, 0)
+    t_xpos += 800
+    _set_text(["Circular arc"], Vector(t_xpos, t_ypos, 0))
+
+    _msg(16 * "-")
+    _msg("Circular arc 3 points")
+    Draft.make_arc_3points([Vector(4600, 0, 0),
+                            Vector(4600, 800, 0),
+                            Vector(4000, 1000, 0)])
+    t_xpos += 600
+    _set_text(["Circular arc 3 points"], Vector(t_xpos, t_ypos, 0))
+
+    # Ellipse, polygon, rectangle
+    _msg(16 * "-")
+    _msg("Ellipse")
+    ellipse = Draft.make_ellipse(500, 300)
+    ellipse.Placement.Base = Vector(5500, 250, 0)
+    t_xpos += 1600
+    _set_text(["Ellipse"], Vector(t_xpos, t_ypos, 0))
+
+    _msg(16 * "-")
+    _msg("Polygon")
+    polygon = Draft.make_polygon(5, 250)
+    polygon.Placement.Base = Vector(6500, 500, 0)
+    t_xpos += 950
+    _set_text(["Polygon"], Vector(t_xpos, t_ypos, 0))
+
+    _msg(16 * "-")
+    _msg("Rectangle")
+    rectangle = Draft.make_rectangle(500, 1000, 0)
+    rectangle.Placement.Base = Vector(7000, 0, 0)
+    t_xpos += 650
+    _set_text(["Rectangle"], Vector(t_xpos, t_ypos, 0))
+
+    # Text
+    _msg(16 * "-")
+    _msg("Text")
+    text = Draft.make_text(["Testing", "text"], Vector(7700, 500, 0))
+    if App.GuiUp:
+        text.ViewObject.FontSize = 100
+    t_xpos += 700
+    _set_text(["Text"], Vector(t_xpos, t_ypos, 0))
+
+    # Linear dimension
+    _msg(16 * "-")
+    _msg("Linear dimension")
+    dimension = Draft.make_dimension(Vector(8500, 500, 0),
+                                     Vector(8500, 1000, 0),
+                                     Vector(9000, 750, 0))
+    if App.GuiUp:
+        dimension.ViewObject.ArrowSize = 15
+        dimension.ViewObject.ExtLines = 1000
+        dimension.ViewObject.ExtOvershoot = 100
+        dimension.ViewObject.DimOvershoot = 50
+        dimension.ViewObject.FontSize = 100
+        dimension.ViewObject.ShowUnit = False
+    t_xpos += 680
+    _set_text(["Dimension"], Vector(t_xpos, t_ypos, 0))
+
+    # Radius and diameter dimension
+    _msg(16 * "-")
+    _msg("Radius and diameter dimension")
+    arc_h = Draft.make_circle(500, startangle=0, endangle=90)
+    arc_h.Placement.Base = Vector(9500, 0, 0)
+    doc.recompute()
+
+    dimension_r = Draft.make_dimension(arc_h, 0,
+                                       "radius",
+                                       Vector(9750, 200, 0))
+    if App.GuiUp:
+        dimension_r.ViewObject.ArrowSize = 15
+        dimension_r.ViewObject.FontSize = 100
+        dimension_r.ViewObject.ShowUnit = False
+
+    arc_h2 = Draft.make_circle(450, startangle=-120, endangle=80)
+    arc_h2.Placement.Base = Vector(10000, 1000, 0)
+    doc.recompute()
+
+    dimension_d = Draft.make_dimension(arc_h2, 0,
+                                       "diameter",
+                                       Vector(10750, 900, 0))
+    if App.GuiUp:
+        dimension_d.ViewObject.ArrowSize = 15
+        dimension_d.ViewObject.FontSize = 100
+        dimension_d.ViewObject.ShowUnit = False
+    t_xpos += 950
+    _set_text(["Radius dimension",
+               "Diameter dimension"], Vector(t_xpos, t_ypos, 0))
+
+    # Angular dimension
+    _msg(16 * "-")
+    _msg("Angular dimension")
+    Draft.make_line(Vector(10500, 300, 0), Vector(11500, 1000, 0))
+    Draft.make_line(Vector(10500, 300, 0), Vector(11500, 0, 0))
+    angle1 = math.radians(40)
+    angle2 = math.radians(-20)
+    dimension_a = Draft.make_angular_dimension(Vector(10500, 300, 0),
+                                               [angle1, angle2],
+                                               Vector(11500, 300, 0))
+    if App.GuiUp:
+        dimension_a.ViewObject.ArrowSize = 15
+        dimension_a.ViewObject.FontSize = 100
+    t_xpos += 1700
+    _set_text(["Angle dimension"], Vector(t_xpos, t_ypos, 0))
+
+    # BSpline
+    _msg(16 * "-")
+    _msg("BSpline")
+    Draft.make_bspline([Vector(12500, 0, 0),
+                        Vector(12500, 500, 0),
+                        Vector(13000, 500, 0),
+                        Vector(13000, 1000, 0)])
+    t_xpos += 1500
+    _set_text(["BSpline"], Vector(t_xpos, t_ypos, 0))
+
+    # Point
+    _msg(16 * "-")
+    _msg("Point")
+    point = Draft.make_point(13500, 500, 0)
+    if App.GuiUp:
+        point.ViewObject.PointSize = 10
+    t_xpos += 900
+    _set_text(["Point"], Vector(t_xpos, t_ypos, 0))
+
+    # Shapestring
+    _msg(16 * "-")
+    _msg("Shapestring")
+    try:
+        shape_string = Draft.make_shapestring("Testing",
+                                              font_file,
+                                              100)
+        shape_string.Placement.Base = Vector(14000, 500)
+    except Exception:
+        _wrn("Shapestring could not be created")
+        _wrn("Possible cause: the font file may not exist")
+        _wrn(font_file)
+        rect = Draft.make_rectangle(500, 100)
+        rect.Placement.Base = Vector(14000, 500)
+    t_xpos += 600
+    _set_text(["Shapestring"], Vector(t_xpos, t_ypos, 0))
+
+    # Facebinder
+    _msg(16 * "-")
+    _msg("Facebinder")
+    box = doc.addObject("Part::Box", "Cube")
+    box.Length = 200
+    box.Width = 500
+    box.Height = 100
+    box.Placement.Base = Vector(15000, 0, 0)
+    if App.GuiUp:
+        box.ViewObject.Visibility = False
+
+    facebinder = Draft.make_facebinder([(box, ("Face1", "Face3", "Face6"))])
+    facebinder.Extrusion = 10
+    t_xpos += 780
+    _set_text(["Facebinder"], Vector(t_xpos, t_ypos, 0))
+
+    # Cubic bezier curve, n-degree bezier curve
+    _msg(16 * "-")
+    _msg("Cubic bezier")
+    Draft.make_bezcurve([Vector(15500, 0, 0),
+                         Vector(15578, 485, 0),
+                         Vector(15879, 154, 0),
+                         Vector(15975, 400, 0),
+                         Vector(16070, 668, 0),
+                         Vector(16423, 925, 0),
+                         Vector(16500, 500, 0)], degree=3)
+    t_xpos += 680
+    _set_text(["Cubic bezier"], Vector(t_xpos, t_ypos, 0))
+
+    _msg(16 * "-")
+    _msg("N-degree bezier")
+    Draft.make_bezcurve([Vector(16500, 0, 0),
+                         Vector(17000, 500, 0),
+                         Vector(17500, 500, 0),
+                         Vector(17500, 1000, 0),
+                         Vector(17000, 1000, 0),
+                         Vector(17063, 1256, 0),
+                         Vector(17732, 1227, 0),
+                         Vector(17790, 720, 0),
+                         Vector(17702, 242, 0)])
+    t_xpos += 1200
+    _set_text(["n-Bezier"], Vector(t_xpos, t_ypos, 0))
+
+    # Label
+    _msg(16 * "-")
+    _msg("Label")
+    place = App.Placement(Vector(18500, 500, 0), App.Rotation())
+    label = Draft.make_label(targetpoint=Vector(18000, 0, 0),
+                             distance=-250,
+                             placement=place)
+    label.Text = "Testing"
+    if App.GuiUp:
+        label.ViewObject.ArrowSize = 15
+        label.ViewObject.TextSize = 100
+    doc.recompute()
+    t_xpos += 1200
+    _set_text(["Label"], Vector(t_xpos, t_ypos, 0))
+
+    # Orthogonal array and orthogonal link array
+    _msg(16 * "-")
+    _msg("Orthogonal array")
+    rect_h = Draft.make_rectangle(500, 500)
+    rect_h.Placement.Base = Vector(1500, 2500, 0)
+    if App.GuiUp:
+        rect_h.ViewObject.Visibility = False
+
+    Draft.makeArray(rect_h,
+                    Vector(600, 0, 0),
+                    Vector(0, 600, 0),
+                    Vector(0, 0, 0),
+                    3, 2, 1)
+    t_xpos = 1700
+    t_ypos = 2200
+    _set_text(["Array"], Vector(t_xpos, t_ypos, 0))
+
+    rect_h_2 = Draft.make_rectangle(500, 100)
+    rect_h_2.Placement.Base = Vector(1500, 5000, 0)
+    if App.GuiUp:
+        rect_h_2.ViewObject.Visibility = False
+
+    _msg(16 * "-")
+    _msg("Orthogonal link array")
+    Draft.makeArray(rect_h_2,
+                    Vector(800, 0, 0),
+                    Vector(0, 500, 0),
+                    Vector(0, 0, 0),
+                    2, 4, 1,
+                    use_link=True)
+    t_ypos += 2600
+    _set_text(["Link array"], Vector(t_xpos, t_ypos, 0))
+
+    # Polar array and polar link array
+    _msg(16 * "-")
+    _msg("Polar array")
+    wire_h = Draft.make_wire([Vector(5500, 3000, 0),
+                              Vector(6000, 3500, 0),
+                              Vector(6000, 3200, 0),
+                              Vector(5800, 3200, 0)])
+    if App.GuiUp:
+        wire_h.ViewObject.Visibility = False
+
+    Draft.makeArray(wire_h,
+                    Vector(5000, 3000, 0),
+                    200,
+                    8)
+    t_xpos = 4600
+    t_ypos = 2200
+    _set_text(["Polar array"], Vector(t_xpos, t_ypos, 0))
+
+    _msg(16 * "-")
+    _msg("Polar link array")
+    wire_h_2 = Draft.make_wire([Vector(5500, 6000, 0),
+                                Vector(6000, 6000, 0),
+                                Vector(5800, 5700, 0),
+                                Vector(5800, 5750, 0)])
+    if App.GuiUp:
+        wire_h_2.ViewObject.Visibility = False
+
+    Draft.makeArray(wire_h_2,
+                    Vector(5000, 6000, 0),
+                    200,
+                    8,
+                    use_link=True)
+    t_ypos += 3200
+    _set_text(["Polar link array"], Vector(t_xpos, t_ypos, 0))
+
+    # Circular array and circular link array
+    _msg(16 * "-")
+    _msg("Circular array")
+    poly_h = Draft.make_polygon(5, 200)
+    poly_h.Placement.Base = Vector(8000, 3000, 0)
+    if App.GuiUp:
+        poly_h.ViewObject.Visibility = False
+
+    Draft.makeArray(poly_h,
+                    500, 600,
+                    Vector(0, 0, 1),
+                    Vector(0, 0, 0),
+                    3,
+                    1)
+    t_xpos = 7700
+    t_ypos = 1700
+    _set_text(["Circular array"], Vector(t_xpos, t_ypos, 0))
+
+    _msg(16 * "-")
+    _msg("Circular link array")
+    poly_h_2 = Draft.make_polygon(6, 150)
+    poly_h_2.Placement.Base = Vector(8000, 6250, 0)
+    if App.GuiUp:
+        poly_h_2.ViewObject.Visibility = False
+
+    Draft.makeArray(poly_h_2,
+                    550, 450,
+                    Vector(0, 0, 1),
+                    Vector(0, 0, 0),
+                    3,
+                    1,
+                    use_link=True)
+    t_ypos += 3100
+    _set_text(["Circular link array"], Vector(t_xpos, t_ypos, 0))
+
+    # Path array and path link array
+    _msg(16 * "-")
+    _msg("Path array")
+    poly_h = Draft.make_polygon(3, 250)
+    poly_h.Placement.Base = Vector(10500, 3000, 0)
+    if App.GuiUp:
+        poly_h.ViewObject.Visibility = False
+
+    bspline_path = Draft.make_bspline([Vector(10500, 2500, 0),
+                                       Vector(11000, 3000, 0),
+                                       Vector(11500, 3200, 0),
+                                       Vector(12000, 4000, 0)])
+
+    Draft.makePathArray(poly_h, bspline_path, 5)
+    t_xpos = 10400
+    t_ypos = 2200
+    _set_text(["Path array"], Vector(t_xpos, t_ypos, 0))
+
+    _msg(16 * "-")
+    _msg("Path link array")
+    poly_h_2 = Draft.make_polygon(4, 200)
+    poly_h_2.Placement.Base = Vector(10500, 5000, 0)
+    if App.GuiUp:
+        poly_h_2.ViewObject.Visibility = False
+
+    bspline_path_2 = Draft.make_bspline([Vector(10500, 4500, 0),
+                                         Vector(11000, 6800, 0),
+                                         Vector(11500, 6000, 0),
+                                         Vector(12000, 5200, 0)])
+
+    Draft.makePathArray(poly_h_2, bspline_path_2, 6,
+                        use_link=True)
+    t_ypos += 2000
+    _set_text(["Path link array"], Vector(t_xpos, t_ypos, 0))
+
+    # Point array
+    _msg(16 * "-")
+    _msg("Point array")
+    poly_h = Draft.make_polygon(3, 250)
+
+    point_1 = Draft.make_point(13000, 3000, 0)
+    point_2 = Draft.make_point(13000, 3500, 0)
+    point_3 = Draft.make_point(14000, 2500, 0)
+    point_4 = Draft.make_point(14000, 3000, 0)
+
+    add_list, delete_list = Draft.upgrade([point_1, point_2,
+                                           point_3, point_4])
+    compound = add_list[0]
+    if App.GuiUp:
+        compound.ViewObject.PointSize = 5
+
+    Draft.makePointArray(poly_h, compound)
+    t_xpos = 13000
+    t_ypos = 2200
+    _set_text(["Point array"], Vector(t_xpos, t_ypos, 0))
+
+    # Clone and mirror
+    _msg(16 * "-")
+    _msg("Clone")
+    wire_h = Draft.make_wire([Vector(15000, 2500, 0),
+                              Vector(15200, 3000, 0),
+                              Vector(15500, 2500, 0),
+                              Vector(15200, 2300, 0)])
+
+    Draft.clone(wire_h, Vector(0, 1000, 0))
+    t_xpos = 15000
+    t_ypos = 2100
+    _set_text(["Clone"], Vector(t_xpos, t_ypos, 0))
+
+    _msg(16 * "-")
+    _msg("Mirror")
+    wire_h = Draft.make_wire([Vector(17000, 2500, 0),
+                              Vector(16500, 4000, 0),
+                              Vector(16000, 2700, 0),
+                              Vector(16500, 2500, 0),
+                              Vector(16700, 2700, 0)])
+
+    Draft.mirror(wire_h,
+                 Vector(17100, 2000, 0),
+                 Vector(17100, 4000, 0))
+    t_xpos = 17000
+    t_ypos = 2200
+    _set_text(["Mirror"], Vector(t_xpos, t_ypos, 0))
+    doc.recompute()
 
 
 def create_test_file(file_name="draft_test_objects",
@@ -135,465 +606,8 @@ def create_test_file(file_name="draft_test_objects",
     _msg("Filename: {}".format(file_name))
     _msg("If the units tests fail, this script may fail as well")
 
-    _create_frame()
-
-    # Line, wire, and fillet
-    _msg(16 * "-")
-    _msg("Line")
-    Draft.make_line(Vector(0, 0, 0), Vector(500, 500, 0))
-    t_xpos = -50
-    t_ypos = -200
-    _t = Draft.make_text(["Line"], Vector(t_xpos, t_ypos, 0))
-    _set_text(_t)
-
-    _msg(16 * "-")
-    _msg("Wire")
-    Draft.make_wire([Vector(500, 0, 0),
-                     Vector(1000, 500, 0),
-                     Vector(1000, 1000, 0)])
-    t_xpos += 500
-    _t = Draft.make_text(["Wire"], Vector(t_xpos, t_ypos, 0))
-    _set_text(_t)
-
-    _msg(16 * "-")
-    _msg("Fillet")
-    line_h_1 = Draft.make_line(Vector(1500, 0, 0), Vector(1500, 500, 0))
-    line_h_2 = Draft.make_line(Vector(1500, 500, 0), Vector(2000, 500, 0))
-    if App.GuiUp:
-        line_h_1.ViewObject.DrawStyle = "Dotted"
-        line_h_2.ViewObject.DrawStyle = "Dotted"
-    doc.recompute()
-
-    Draft.make_fillet([line_h_1, line_h_2], 400)
-    t_xpos += 900
-    _t = Draft.make_text(["Fillet"], Vector(t_xpos, t_ypos, 0))
-    _set_text(_t)
-
-    # Circle, arc, arc by 3 points
-    _msg(16 * "-")
-    _msg("Circle")
-    circle = Draft.make_circle(350)
-    circle.Placement.Base = Vector(2500, 500, 0)
-    t_xpos += 1050
-    _t = Draft.make_text(["Circle"], Vector(t_xpos, t_ypos, 0))
-    _set_text(_t)
-
-    _msg(16 * "-")
-    _msg("Circular arc")
-    arc = Draft.make_circle(350, startangle=0, endangle=100)
-    arc.Placement.Base = Vector(3200, 500, 0)
-    t_xpos += 800
-    _t = Draft.make_text(["Circular arc"], Vector(t_xpos, t_ypos, 0))
-    _set_text(_t)
-
-    _msg(16 * "-")
-    _msg("Circular arc 3 points")
-    Draft.make_arc_3points([Vector(4600, 0, 0),
-                            Vector(4600, 800, 0),
-                            Vector(4000, 1000, 0)])
-    t_xpos += 600
-    _t = Draft.make_text(["Circular arc 3 points"], Vector(t_xpos, t_ypos, 0))
-    _set_text(_t)
-
-    # Ellipse, polygon, rectangle
-    _msg(16 * "-")
-    _msg("Ellipse")
-    ellipse = Draft.make_ellipse(500, 300)
-    ellipse.Placement.Base = Vector(5500, 250, 0)
-    t_xpos += 1600
-    _t = Draft.make_text(["Ellipse"], Vector(t_xpos, t_ypos, 0))
-    _set_text(_t)
-
-    _msg(16 * "-")
-    _msg("Polygon")
-    polygon = Draft.make_polygon(5, 250)
-    polygon.Placement.Base = Vector(6500, 500, 0)
-    t_xpos += 950
-    _t = Draft.make_text(["Polygon"], Vector(t_xpos, t_ypos, 0))
-    _set_text(_t)
-
-    _msg(16 * "-")
-    _msg("Rectangle")
-    rectangle = Draft.make_rectangle(500, 1000, 0)
-    rectangle.Placement.Base = Vector(7000, 0, 0)
-    t_xpos += 650
-    _t = Draft.make_text(["Rectangle"], Vector(t_xpos, t_ypos, 0))
-    _set_text(_t)
-
-    # Text
-    _msg(16 * "-")
-    _msg("Text")
-    text = Draft.make_text(["Testing"], Vector(7700, 500, 0))
-    if App.GuiUp:
-        text.ViewObject.FontSize = 100
-    t_xpos += 700
-    _t = Draft.make_text(["Text"], Vector(t_xpos, t_ypos, 0))
-    _set_text(_t)
-
-    # Linear dimension
-    _msg(16 * "-")
-    _msg("Linear dimension")
-    dimension = Draft.make_dimension(Vector(8500, 500, 0),
-                                     Vector(8500, 1000, 0),
-                                     Vector(9000, 750, 0))
-    if App.GuiUp:
-        dimension.ViewObject.ArrowSize = 15
-        dimension.ViewObject.ExtLines = 1000
-        dimension.ViewObject.ExtOvershoot = 100
-        dimension.ViewObject.FontSize = 100
-        dimension.ViewObject.ShowUnit = False
-    t_xpos += 680
-    _t = Draft.make_text(["Dimension"], Vector(t_xpos, t_ypos, 0))
-    _set_text(_t)
-
-    # Radius and diameter dimension
-    _msg(16 * "-")
-    _msg("Radius and diameter dimension")
-    arc_h = Draft.make_circle(500, startangle=0, endangle=90)
-    arc_h.Placement.Base = Vector(9500, 0, 0)
-    doc.recompute()
-
-    dimension_r = Draft.make_dimension(arc_h, 0,
-                                       "radius",
-                                       Vector(9750, 200, 0))
-    if App.GuiUp:
-        dimension_r.ViewObject.ArrowSize = 15
-        dimension_r.ViewObject.FontSize = 100
-        dimension_r.ViewObject.ShowUnit = False
-
-    arc_h2 = Draft.make_circle(450, startangle=-120, endangle=80)
-    arc_h2.Placement.Base = Vector(10000, 1000, 0)
-    doc.recompute()
-
-    dimension_d = Draft.make_dimension(arc_h2, 0,
-                                       "diameter",
-                                       Vector(10750, 900, 0))
-    if App.GuiUp:
-        dimension_d.ViewObject.ArrowSize = 15
-        dimension_d.ViewObject.FontSize = 100
-        dimension_d.ViewObject.ShowUnit = False
-    t_xpos += 950
-    _t = Draft.make_text(["Radius dimension",
-                          "Diameter dimension"], Vector(t_xpos, t_ypos, 0))
-    _set_text(_t)
-
-    # Angular dimension
-    _msg(16 * "-")
-    _msg("Angular dimension")
-    Draft.make_line(Vector(10500, 300, 0), Vector(11500, 1000, 0))
-    Draft.make_line(Vector(10500, 300, 0), Vector(11500, 0, 0))
-    angle1 = math.radians(40)
-    angle2 = math.radians(-20)
-    dimension_a = Draft.make_angular_dimension(Vector(10500, 300, 0),
-                                               [angle1, angle2],
-                                               Vector(11500, 300, 0))
-    if App.GuiUp:
-        dimension_a.ViewObject.ArrowSize = 15
-        dimension_a.ViewObject.FontSize = 100
-    t_xpos += 1700
-    _t = Draft.make_text(["Angle dimension"], Vector(t_xpos, t_ypos, 0))
-    _set_text(_t)
-
-    # BSpline
-    _msg(16 * "-")
-    _msg("BSpline")
-    Draft.make_bspline([Vector(12500, 0, 0),
-                        Vector(12500, 500, 0),
-                        Vector(13000, 500, 0),
-                        Vector(13000, 1000, 0)])
-    t_xpos += 1500
-    _t = Draft.make_text(["BSpline"], Vector(t_xpos, t_ypos, 0))
-    _set_text(_t)
-
-    # Point
-    _msg(16 * "-")
-    _msg("Point")
-    point = Draft.make_point(13500, 500, 0)
-    if App.GuiUp:
-        point.ViewObject.PointSize = 10
-    t_xpos += 900
-    _t = Draft.make_text(["Point"], Vector(t_xpos, t_ypos, 0))
-    _set_text(_t)
-
-    # Shapestring
-    _msg(16 * "-")
-    _msg("Shapestring")
-    try:
-        shape_string = Draft.make_shapestring("Testing",
-                                              font_file,
-                                              100)
-        shape_string.Placement.Base = Vector(14000, 500)
-    except Exception:
-        _wrn("Shapestring could not be created")
-        _wrn("Possible cause: the font file may not exist")
-        _wrn(font_file)
-        rect = Draft.make_rectangle(500, 100)
-        rect.Placement.Base = Vector(14000, 500)
-    t_xpos += 600
-    _t = Draft.make_text(["Shapestring"], Vector(t_xpos, t_ypos, 0))
-    _set_text(_t)
-
-    # Facebinder
-    _msg(16 * "-")
-    _msg("Facebinder")
-    box = doc.addObject("Part::Box", "Cube")
-    box.Length = 200
-    box.Width = 500
-    box.Height = 100
-    box.Placement.Base = Vector(15000, 0, 0)
-    if App.GuiUp:
-        box.ViewObject.Visibility = False
-
-    facebinder = Draft.make_facebinder([(box, ("Face1", "Face3", "Face6"))])
-    facebinder.Extrusion = 10
-    t_xpos += 780
-    _t = Draft.make_text(["Facebinder"], Vector(t_xpos, t_ypos, 0))
-    _set_text(_t)
-
-    # Cubic bezier curve, n-degree bezier curve
-    _msg(16 * "-")
-    _msg("Cubic bezier")
-    Draft.make_bezcurve([Vector(15500, 0, 0),
-                         Vector(15578, 485, 0),
-                         Vector(15879, 154, 0),
-                         Vector(15975, 400, 0),
-                         Vector(16070, 668, 0),
-                         Vector(16423, 925, 0),
-                         Vector(16500, 500, 0)], degree=3)
-    t_xpos += 680
-    _t = Draft.make_text(["Cubic bezier"], Vector(t_xpos, t_ypos, 0))
-    _set_text(_t)
-
-    _msg(16 * "-")
-    _msg("N-degree bezier")
-    Draft.make_bezcurve([Vector(16500, 0, 0),
-                         Vector(17000, 500, 0),
-                         Vector(17500, 500, 0),
-                         Vector(17500, 1000, 0),
-                         Vector(17000, 1000, 0),
-                         Vector(17063, 1256, 0),
-                         Vector(17732, 1227, 0),
-                         Vector(17790, 720, 0),
-                         Vector(17702, 242, 0)])
-    t_xpos += 1200
-    _t = Draft.make_text(["n-Bezier"], Vector(t_xpos, t_ypos, 0))
-    _set_text(_t)
-
-    # Label
-    _msg(16 * "-")
-    _msg("Label")
-    place = App.Placement(Vector(18500, 500, 0), App.Rotation())
-    label = Draft.make_label(targetpoint=Vector(18000, 0, 0),
-                             distance=-250,
-                             placement=place)
-    label.Text = "Testing"
-    if App.GuiUp:
-        label.ViewObject.ArrowSize = 15
-        label.ViewObject.TextSize = 100
-    doc.recompute()
-    t_xpos += 1200
-    _t = Draft.make_text(["Label"], Vector(t_xpos, t_ypos, 0))
-    _set_text(_t)
-
-    # Orthogonal array and orthogonal link array
-    _msg(16 * "-")
-    _msg("Orthogonal array")
-    rect_h = Draft.make_rectangle(500, 500)
-    rect_h.Placement.Base = Vector(1500, 2500, 0)
-    if App.GuiUp:
-        rect_h.ViewObject.Visibility = False
-
-    Draft.makeArray(rect_h,
-                    Vector(600, 0, 0),
-                    Vector(0, 600, 0),
-                    Vector(0, 0, 0),
-                    3, 2, 1)
-    t_xpos = 1700
-    t_ypos = 2200
-    _t = Draft.make_text(["Array"], Vector(t_xpos, t_ypos, 0))
-    _set_text(_t)
-
-    rect_h_2 = Draft.make_rectangle(500, 100)
-    rect_h_2.Placement.Base = Vector(1500, 5000, 0)
-    if App.GuiUp:
-        rect_h_2.ViewObject.Visibility = False
-
-    _msg(16 * "-")
-    _msg("Orthogonal link array")
-    Draft.makeArray(rect_h_2,
-                    Vector(800, 0, 0),
-                    Vector(0, 500, 0),
-                    Vector(0, 0, 0),
-                    2, 4, 1,
-                    use_link=True)
-    t_ypos += 2600
-    _t = Draft.make_text(["Link array"], Vector(t_xpos, t_ypos, 0))
-    _set_text(_t)
-
-    # Polar array and polar link array
-    _msg(16 * "-")
-    _msg("Polar array")
-    wire_h = Draft.make_wire([Vector(5500, 3000, 0),
-                              Vector(6000, 3500, 0),
-                              Vector(6000, 3200, 0),
-                              Vector(5800, 3200, 0)])
-    if App.GuiUp:
-        wire_h.ViewObject.Visibility = False
-
-    Draft.makeArray(wire_h,
-                    Vector(5000, 3000, 0),
-                    200,
-                    8)
-    t_xpos = 4600
-    t_ypos = 2200
-    _t = Draft.make_text(["Polar array"], Vector(t_xpos, t_ypos, 0))
-    _set_text(_t)
-
-    _msg(16 * "-")
-    _msg("Polar link array")
-    wire_h_2 = Draft.make_wire([Vector(5500, 6000, 0),
-                                Vector(6000, 6000, 0),
-                                Vector(5800, 5700, 0),
-                                Vector(5800, 5750, 0)])
-    if App.GuiUp:
-        wire_h_2.ViewObject.Visibility = False
-
-    Draft.makeArray(wire_h_2,
-                    Vector(5000, 6000, 0),
-                    200,
-                    8,
-                    use_link=True)
-    t_ypos += 3200
-    _t = Draft.make_text(["Polar link array"], Vector(t_xpos, t_ypos, 0))
-    _set_text(_t)
-
-    # Circular array and circular link array
-    _msg(16 * "-")
-    _msg("Circular array")
-    poly_h = Draft.make_polygon(5, 200)
-    poly_h.Placement.Base = Vector(8000, 3000, 0)
-    if App.GuiUp:
-        poly_h.ViewObject.Visibility = False
-
-    Draft.makeArray(poly_h,
-                    500, 600,
-                    Vector(0, 0, 1),
-                    Vector(0, 0, 0),
-                    3,
-                    1)
-    t_xpos = 7700
-    t_ypos = 1700
-    _t = Draft.make_text(["Circular array"], Vector(t_xpos, t_ypos, 0))
-    _set_text(_t)
-
-    _msg(16 * "-")
-    _msg("Circular link array")
-    poly_h_2 = Draft.make_polygon(6, 150)
-    poly_h_2.Placement.Base = Vector(8000, 6250, 0)
-    if App.GuiUp:
-        poly_h_2.ViewObject.Visibility = False
-
-    Draft.makeArray(poly_h_2,
-                    550, 450,
-                    Vector(0, 0, 1),
-                    Vector(0, 0, 0),
-                    3,
-                    1,
-                    use_link=True)
-    t_ypos += 3100
-    _t = Draft.make_text(["Circular link array"], Vector(t_xpos, t_ypos, 0))
-    _set_text(_t)
-
-    # Path array and path link array
-    _msg(16 * "-")
-    _msg("Path array")
-    poly_h = Draft.make_polygon(3, 250)
-    poly_h.Placement.Base = Vector(10500, 3000, 0)
-    if App.GuiUp:
-        poly_h.ViewObject.Visibility = False
-
-    bspline_path = Draft.make_bspline([Vector(10500, 2500, 0),
-                                       Vector(11000, 3000, 0),
-                                       Vector(11500, 3200, 0),
-                                       Vector(12000, 4000, 0)])
-
-    Draft.makePathArray(poly_h, bspline_path, 5)
-    t_xpos = 10400
-    t_ypos = 2200
-    _t = Draft.make_text(["Path array"], Vector(t_xpos, t_ypos, 0))
-    _set_text(_t)
-
-    _msg(16 * "-")
-    _msg("Path link array")
-    poly_h_2 = Draft.make_polygon(4, 200)
-    poly_h_2.Placement.Base = Vector(10500, 5000, 0)
-    if App.GuiUp:
-        poly_h_2.ViewObject.Visibility = False
-
-    bspline_path_2 = Draft.make_bspline([Vector(10500, 4500, 0),
-                                         Vector(11000, 6800, 0),
-                                         Vector(11500, 6000, 0),
-                                         Vector(12000, 5200, 0)])
-
-    Draft.makePathArray(poly_h_2, bspline_path_2, 6,
-                        use_link=True)
-    t_ypos += 2000
-    _t = Draft.make_text(["Path link array"], Vector(t_xpos, t_ypos, 0))
-    _set_text(_t)
-
-    # Point array
-    _msg(16 * "-")
-    _msg("Point array")
-    poly_h = Draft.make_polygon(3, 250)
-
-    point_1 = Draft.make_point(13000, 3000, 0)
-    point_2 = Draft.make_point(13000, 3500, 0)
-    point_3 = Draft.make_point(14000, 2500, 0)
-    point_4 = Draft.make_point(14000, 3000, 0)
-
-    add_list, delete_list = Draft.upgrade([point_1, point_2,
-                                           point_3, point_4])
-    compound = add_list[0]
-    if App.GuiUp:
-        compound.ViewObject.PointSize = 5
-
-    Draft.makePointArray(poly_h, compound)
-    t_xpos = 13000
-    t_ypos = 2200
-    _t = Draft.make_text(["Point array"], Vector(t_xpos, t_ypos, 0))
-    _set_text(_t)
-
-    # Clone and mirror
-    _msg(16 * "-")
-    _msg("Clone")
-    wire_h = Draft.make_wire([Vector(15000, 2500, 0),
-                              Vector(15200, 3000, 0),
-                              Vector(15500, 2500, 0),
-                              Vector(15200, 2300, 0)])
-
-    Draft.clone(wire_h, Vector(0, 1000, 0))
-    t_xpos = 15000
-    t_ypos = 2100
-    _t = Draft.make_text(["Clone"], Vector(t_xpos, t_ypos, 0))
-    _set_text(_t)
-
-    _msg(16 * "-")
-    _msg("Mirror")
-    wire_h = Draft.make_wire([Vector(17000, 2500, 0),
-                              Vector(16500, 4000, 0),
-                              Vector(16000, 2700, 0),
-                              Vector(16500, 2500, 0),
-                              Vector(16700, 2700, 0)])
-
-    Draft.mirror(wire_h,
-                 Vector(17100, 2000, 0),
-                 Vector(17100, 4000, 0))
-    t_xpos = 17000
-    t_ypos = 2200
-    _t = Draft.make_text(["Mirror"], Vector(t_xpos, t_ypos, 0))
-    _set_text(_t)
-
-    doc.recompute()
+    _create_frame(doc=doc)
+    _create_objects(doc=doc, font_file=font_file)
 
     if App.GuiUp:
         Gui.runCommand("Std_ViewFitAll")
@@ -601,6 +615,7 @@ def create_test_file(file_name="draft_test_objects",
     # Export
     if not file_path:
         file_path = App.getUserAppDataDir()
+
     out_name = os.path.join(file_path, file_name + ".FCStd")
     doc.FileName = out_name
     if save:

--- a/src/Mod/Draft/drafttests/draft_test_objects.py
+++ b/src/Mod/Draft/drafttests/draft_test_objects.py
@@ -373,11 +373,12 @@ def _create_objects(doc=None,
     if App.GuiUp:
         rect_h.ViewObject.Visibility = False
 
-    Draft.makeArray(rect_h,
-                    Vector(600, 0, 0),
-                    Vector(0, 600, 0),
-                    Vector(0, 0, 0),
-                    3, 2, 1)
+    Draft.make_ortho_array(rect_h,
+                           Vector(600, 0, 0),
+                           Vector(0, 600, 0),
+                           Vector(0, 0, 0),
+                           3, 2, 1,
+                           use_link=False)
     t_xpos = 1700
     t_ypos = 2200
     _set_text(["Array"], Vector(t_xpos, t_ypos, 0))
@@ -389,12 +390,12 @@ def _create_objects(doc=None,
 
     _msg(16 * "-")
     _msg("Orthogonal link array")
-    Draft.makeArray(rect_h_2,
-                    Vector(800, 0, 0),
-                    Vector(0, 500, 0),
-                    Vector(0, 0, 0),
-                    2, 4, 1,
-                    use_link=True)
+    Draft.make_ortho_array(rect_h_2,
+                           Vector(800, 0, 0),
+                           Vector(0, 500, 0),
+                           Vector(0, 0, 0),
+                           2, 4, 1,
+                           use_link=True)
     t_ypos += 2600
     _set_text(["Link array"], Vector(t_xpos, t_ypos, 0))
 
@@ -408,10 +409,12 @@ def _create_objects(doc=None,
     if App.GuiUp:
         wire_h.ViewObject.Visibility = False
 
-    Draft.makeArray(wire_h,
-                    Vector(5000, 3000, 0),
-                    200,
-                    8)
+    Draft.make_polar_array(wire_h,
+                           8,
+                           200,
+                           Vector(5000, 3000, 0),
+                           use_link=False)
+
     t_xpos = 4600
     t_ypos = 2200
     _set_text(["Polar array"], Vector(t_xpos, t_ypos, 0))
@@ -425,11 +428,11 @@ def _create_objects(doc=None,
     if App.GuiUp:
         wire_h_2.ViewObject.Visibility = False
 
-    Draft.makeArray(wire_h_2,
-                    Vector(5000, 6000, 0),
-                    200,
-                    8,
-                    use_link=True)
+    Draft.make_polar_array(wire_h_2,
+                           8,
+                           200,
+                           Vector(5000, 6000, 0),
+                           use_link=True)
     t_ypos += 3200
     _set_text(["Polar link array"], Vector(t_xpos, t_ypos, 0))
 
@@ -441,12 +444,13 @@ def _create_objects(doc=None,
     if App.GuiUp:
         poly_h.ViewObject.Visibility = False
 
-    Draft.makeArray(poly_h,
-                    500, 600,
-                    Vector(0, 0, 1),
-                    Vector(0, 0, 0),
-                    3,
-                    1)
+    Draft.make_circular_array(poly_h,
+                              500, 600,
+                              3,
+                              1,
+                              Vector(0, 0, 1),
+                              Vector(0, 0, 0),
+                              use_link=False)
     t_xpos = 7700
     t_ypos = 1700
     _set_text(["Circular array"], Vector(t_xpos, t_ypos, 0))
@@ -458,13 +462,13 @@ def _create_objects(doc=None,
     if App.GuiUp:
         poly_h_2.ViewObject.Visibility = False
 
-    Draft.makeArray(poly_h_2,
-                    550, 450,
-                    Vector(0, 0, 1),
-                    Vector(0, 0, 0),
-                    3,
-                    1,
-                    use_link=True)
+    Draft.make_circular_array(poly_h_2,
+                              550, 450,
+                              3,
+                              1,
+                              Vector(0, 0, 1),
+                              Vector(0, 0, 0),
+                              use_link=True)
     t_ypos += 3100
     _set_text(["Circular link array"], Vector(t_xpos, t_ypos, 0))
 
@@ -481,7 +485,8 @@ def _create_objects(doc=None,
                                        Vector(11500, 3200, 0),
                                        Vector(12000, 4000, 0)])
 
-    Draft.makePathArray(poly_h, bspline_path, 5)
+    Draft.make_path_array(poly_h, bspline_path, 5,
+                          use_link=False)
     t_xpos = 10400
     t_ypos = 2200
     _set_text(["Path array"], Vector(t_xpos, t_ypos, 0))
@@ -498,8 +503,8 @@ def _create_objects(doc=None,
                                          Vector(11500, 6000, 0),
                                          Vector(12000, 5200, 0)])
 
-    Draft.makePathArray(poly_h_2, bspline_path_2, 6,
-                        use_link=True)
+    Draft.make_path_array(poly_h_2, bspline_path_2, 6,
+                          use_link=True)
     t_ypos += 2000
     _set_text(["Path link array"], Vector(t_xpos, t_ypos, 0))
 
@@ -519,7 +524,7 @@ def _create_objects(doc=None,
     if App.GuiUp:
         compound.ViewObject.PointSize = 5
 
-    Draft.makePointArray(poly_h, compound)
+    Draft.make_point_array(poly_h, compound)
     t_xpos = 13000
     t_ypos = 2200
     _set_text(["Point array"], Vector(t_xpos, t_ypos, 0))
@@ -532,7 +537,7 @@ def _create_objects(doc=None,
                               Vector(15500, 2500, 0),
                               Vector(15200, 2300, 0)])
 
-    Draft.clone(wire_h, Vector(0, 1000, 0))
+    Draft.make_clone(wire_h, Vector(0, 1000, 0))
     t_xpos = 15000
     t_ypos = 2100
     _set_text(["Clone"], Vector(t_xpos, t_ypos, 0))

--- a/src/Mod/Draft/drafttests/test_modification.py
+++ b/src/Mod/Draft/drafttests/test_modification.py
@@ -370,7 +370,7 @@ class DraftModification(unittest.TestCase):
 
     def test_rectangular_array(self):
         """Create a rectangle, and a rectangular array."""
-        operation = "Draft Array"
+        operation = "Draft OrthoArray"
         _msg("  Test '{}'".format(operation))
         length = 4
         width = 2
@@ -381,15 +381,20 @@ class DraftModification(unittest.TestCase):
 
         dir_x = Vector(5, 0, 0)
         dir_y = Vector(0, 4, 0)
+        dir_z = Vector(0, 0, 6)
         number_x = 3
         number_y = 4
+        number_z = 6
         _msg("  Array")
         _msg("  direction_x={}".format(dir_x))
         _msg("  direction_y={}".format(dir_y))
-        _msg("  number_x={0}, number_y={1}".format(number_x, number_y))
-        obj = Draft.makeArray(rect,
-                              dir_x, dir_y,
-                              number_x, number_y)
+        _msg("  direction_z={}".format(dir_z))
+        _msg("  number_x={0}, number_y={1}, number_z={2}".format(number_x,
+                                                                 number_y,
+                                                                 number_z))
+        obj = Draft.make_ortho_array(rect,
+                                     dir_x, dir_y, dir_z,
+                                     number_x, number_y, number_z)
         self.assertTrue(obj, "'{}' failed".format(operation))
 
     def test_polar_array(self):
@@ -407,10 +412,10 @@ class DraftModification(unittest.TestCase):
         angle = 180
         number = 5
         _msg("  Array")
+        _msg("  number={0}, polar_angle={1}".format(number, angle))
         _msg("  center={}".format(center))
-        _msg("  polar_angle={0}, number={1}".format(angle, number))
-        obj = Draft.makeArray(rect,
-                              center, angle, number)
+        obj = Draft.make_polar_array(rect,
+                                     number, angle, center)
         self.assertTrue(obj, "'{}' failed".format(operation))
 
     def test_circular_array(self):
@@ -436,10 +441,10 @@ class DraftModification(unittest.TestCase):
         _msg("  number={0}, symmetry={1}".format(number, symmetry))
         _msg("  axis={}".format(axis))
         _msg("  center={}".format(center))
-        obj = Draft.makeArray(rect,
-                              rad_distance, tan_distance,
-                              axis, center,
-                              number, symmetry)
+        obj = Draft.make_circular_array(rect,
+                                        rad_distance, tan_distance,
+                                        number, symmetry,
+                                        axis, center)
         self.assertTrue(obj, "'{}' failed".format(operation))
 
     def test_path_array(self):
@@ -467,7 +472,7 @@ class DraftModification(unittest.TestCase):
         _msg("  Path Array")
         _msg("  number={}, translation={}".format(number, translation))
         _msg("  align={}".format(align))
-        obj = Draft.makePathArray(poly, wire, number, translation, align)
+        obj = Draft.make_path_array(poly, wire, number, translation, align)
         self.assertTrue(obj, "'{}' failed".format(operation))
 
     def test_point_array(self):
@@ -497,7 +502,7 @@ class DraftModification(unittest.TestCase):
         poly = Draft.make_polygon(n_faces, radius)
 
         _msg("  Point Array")
-        obj = Draft.makePointArray(poly, compound)
+        obj = Draft.make_point_array(poly, compound)
         self.assertTrue(obj, "'{}' failed".format(operation))
 
     def test_clone(self):


### PR DESCRIPTION
The new make functions for ortho array, polar array, and circular array are moved from `draftobjects` to `draftmake`.

Also import these functions inside `Draft.py`, so that they can be used from the `Draft` namespace as `Draft.make_ortho_array`, `Draft.make_polar_array`, and `Draft.make_circular_array`. Internally these functions still use the general `Draft.make_array` with different arguments.

Also adjust the Gui Commands, unit tests, and the test script appropriately.

This has to be merged after #3481.

---

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists