### PR TITLE
Improve Axis Cross behavior and expose parameter to 3D View preferences

### DIFF
--- a/src/Gui/AboutApplication.ui
+++ b/src/Gui/AboutApplication.ui
@@ -308,6 +308,7 @@ p, li { white-space: pre-wrap; }
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:12pt; font-weight:600;&quot;&gt;People&lt;/span&gt;&lt;/p&gt;
 &lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Abdullah Tahiriyo&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Adrián Insaurralde&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Ajinkya Dahale&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Alexander Golubev (fat-zer)&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Alexander Gryson&lt;/p&gt;

--- a/src/Gui/CommandView.cpp
+++ b/src/Gui/CommandView.cpp
@@ -1908,10 +1908,6 @@ void StdCmdViewCreate::activated(int iMsg)
     Q_UNUSED(iMsg);
     getActiveGuiDocument()->createView(View3DInventor::getClassTypeId());
     getActiveGuiDocument()->getActiveView()->viewAll();
-
-    ParameterGrp::handle hViewGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/View");
-    if (hViewGrp->GetBool("ShowAxisCross"))
-        doCommand(Command::Gui,"Gui.ActiveDocument.ActiveView.setAxisCross(True)");
 }
 
 bool StdCmdViewCreate::isActive(void)
@@ -2067,6 +2063,7 @@ StdCmdAxisCross::StdCmdAxisCross()
         sToolTipText  = QT_TR_NOOP("Toggle axis cross");
         sStatusTip    = QT_TR_NOOP("Toggle axis cross");
         sWhatsThis    = "Std_AxisCross";
+        sAccel        = "A,C";
 }
 
 void StdCmdAxisCross::activated(int iMsg)
@@ -2078,9 +2075,6 @@ void StdCmdAxisCross::activated(int iMsg)
             doCommand(Command::Gui,"Gui.ActiveDocument.ActiveView.setAxisCross(True)");
         else
             doCommand(Command::Gui,"Gui.ActiveDocument.ActiveView.setAxisCross(False)");
-
-        ParameterGrp::handle hViewGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/View");
-        hViewGrp->SetBool("ShowAxisCross", view->getViewer()->hasAxisCross());
     }
 }
 

--- a/src/Gui/DlgSettings3DView.ui
+++ b/src/Gui/DlgSettings3DView.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>477</width>
-    <height>407</height>
+    <width>499</width>
+    <height>520</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -37,6 +37,22 @@ lower right corner within opened files</string>
         </property>
         <property name="prefEntry" stdset="0">
          <cstring>CornerCoordSystem</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>View</cstring>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="Gui::PrefCheckBox" name="CheckBox_ShowAxisCross">
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Axis cross will be shown by default at file&lt;/p&gt;&lt;p&gt;open or creation.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="text">
+         <string>Show axis cross by default</string>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>ShowAxisCross</cstring>
         </property>
         <property name="prefPath" stdset="0">
          <cstring>View</cstring>

--- a/src/Gui/DlgSettings3DViewImp.cpp
+++ b/src/Gui/DlgSettings3DViewImp.cpp
@@ -89,6 +89,7 @@ void DlgSettings3DViewImp::saveSettings()
     hGrp->SetInt("MarkerSize", vBoxMarkerSize.toInt());
 
     ui->CheckBox_CornerCoordSystem->onSave();
+    ui->CheckBox_ShowAxisCross->onSave();
     ui->CheckBox_WbByTab->onSave();
     ui->CheckBox_ShowFPS->onSave();
     ui->CheckBox_useVBO->onSave();
@@ -103,6 +104,7 @@ void DlgSettings3DViewImp::saveSettings()
 void DlgSettings3DViewImp::loadSettings()
 {
     ui->CheckBox_CornerCoordSystem->onRestore();
+    ui->CheckBox_ShowAxisCross->onRestore();
     ui->CheckBox_WbByTab->onRestore();
     ui->CheckBox_ShowFPS->onRestore();
     ui->CheckBox_useVBO->onRestore();

--- a/src/Gui/Document.cpp
+++ b/src/Gui/Document.cpp
@@ -1648,6 +1648,10 @@ MDIView *Document::createView(const Base::Type& typeId)
             const char *ppReturn = 0;
             view3D->onMsg(cameraSettings.c_str(),&ppReturn);
         }
+        ParameterGrp::handle hViewGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/View");
+        if (hViewGrp->GetBool("ShowAxisCross",false)){
+            view3D->getViewer()->setAxisCross(true);
+        }
         getMainWindow()->addWindow(view3D);
         return view3D;
     }
@@ -1665,6 +1669,8 @@ Gui::MDIView* Document::cloneView(Gui::MDIView* oldview)
         View3DInventor* firstView = static_cast<View3DInventor*>(oldview);
         std::string overrideMode = firstView->getViewer()->getOverrideMode();
         view3D->getViewer()->setOverrideMode(overrideMode);
+
+        view3D->getViewer()->setAxisCross(firstView->getViewer()->hasAxisCross());
 
         // attach the viewproviders. we need to make sure that we only attach the toplevel ones
         // and not viewproviders which are claimed by other providers. To ensure this we first

--- a/src/Mod/Mesh/App/MeshTestsApp.py
+++ b/src/Mod/Mesh/App/MeshTestsApp.py
@@ -124,6 +124,7 @@ class PivyTestCases(unittest.TestCase):
 		from pivy import coin; import FreeCADGui
 		Mesh.show(planarMeshObject)
 		view=FreeCADGui.ActiveDocument.ActiveView
+		view.setAxisCross(False)
 		pc=coin.SoGetPrimitiveCountAction()
 		pc.apply(view.getSceneGraph())
 		self.failUnless(pc.getTriangleCount() == 2)


### PR DESCRIPTION
Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---

forum thread: https://forum.freecadweb.org/viewtopic.php?f=8&t=46332

With these changes ShowAxisCross parameter is read and used at 3DView creation, giving a much more consistent behavior. Toggle axis cross no longer controls the parameter but only toggles the current view, parameter is controlled by a checkbox in preferences.

cloneView (used for docking, undocking and fullscreen) checks if the cloned view has active axis cross and sets it in the clone accordingly.

MeshTestApp.py updated so it doesn't fail due to axis cross being present.

A,C accelerator for toggle axis cross added, is this ok or is it better to leave it without accelerator?

I also added myself in the contributor list, is this ok? I'll remove that if it isn't appropriate.