### PR TITLE
FEM: fix incorrect file name in tests

### DIFF
--- a/src/Mod/Fem/TestFemGui.py
+++ b/src/Mod/Fem/TestFemGui.py
@@ -25,7 +25,7 @@
 
 # Gui Unit tests for the FEM module
 # to get the right order import as is used
-from femtest.gui.test_femopen import TestObjectOpen as FemGuiTest01
+from femtest.gui.test_open import TestObjectOpen as FemGuiTest01
 
 
 # dummy usage to get flake8 and lgtm quiet


### PR DESCRIPTION
The unit tests fail because `test_femopen` is actually called `test_open.py`, so we change it in `TestFemGui.py`.

However, after making this change, there are still problems with the migration of the classes.

This is the message displayed when running the unit tests from the non-GUI version of FreeCAD. When running the GUI version, the program crashes after this.

```
======================================================================
FAIL: test_femobjects_open_de9b3fb438 (femtest.app.test_open.TestObjectOpen)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/freecad-build-debug-vocx/Mod/Fem/femtest/app/test_open.py", line 127, in test_femobjects_open_de9b3fb438
    self.compare_feature_pythons_class_app(doc)
  File "/opt/freecad-build-debug-vocx/Mod/Fem/femtest/app/test_open.py", line 161, in compare_feature_pythons_class_app
    doc.ConstraintBodyHeatSource.Proxy.__class__
AssertionError: <class 'femobjects.constraint_bodyheatsource.ConstraintBodyHeatSource'> != <class 'femobjects._FemConstraintBodyHeatSource.Proxy'>
```

---

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists