### PR TITLE
[Path] - Don't reset the operations visibility state during document recompute

### DIFF
--- a/src/Mod/Path/PathCommands.py
+++ b/src/Mod/Path/PathCommands.py
@@ -150,7 +150,10 @@ class _ToggleOperation:
 
     def Activated(self):
         for sel in FreeCADGui.Selection.getSelectionEx():
-            PathScripts.PathDressup.baseOp(sel.Object).Active = not(PathScripts.PathDressup.baseOp(sel.Object).Active)
+            op = PathScripts.PathDressup.baseOp(sel.Object)
+            op.Active = not op.Active
+            op.ViewObject.Visibility = op.Active
+
         FreeCAD.ActiveDocument.recompute()
 
 

--- a/src/Mod/Path/PathScripts/PathOp.py
+++ b/src/Mod/Path/PathScripts/PathOp.py
@@ -472,9 +472,6 @@ class ObjectOp(object):
         '''
         PathLog.track()
 
-        if obj.ViewObject:
-            obj.ViewObject.Visibility = obj.Active
-
         if not obj.Active:
             path = Path.Path("(inactive operation)")
             obj.Path = path


### PR DESCRIPTION
This PR attempts to prevents the op visibility from becoming reset to true when the document is recomputed.

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT]

Forum Thread: https://forum.freecadweb.org/viewtopic.php?f=15&t=37960&hilit=visibility&start=20
