### PR TITLE
Arch: importIFCHelper: Fix crash on unsupported entity

### DIFF
--- a/src/Mod/Arch/importIFCHelper.py
+++ b/src/Mod/Arch/importIFCHelper.py
@@ -631,6 +631,10 @@ def get2DShape(representation,scaling=1000):
             elts = ent.Elements
         elif ent.is_a() in ["IfcLine","IfcPolyline","IfcCircle","IfcTrimmedCurve"]:
             elts = [ent]
+        else:
+            print("getCurveSet: unhandled entity: ", ent)
+            return []
+
         for el in elts:
             if el.is_a("IfcPolyline"):
                 result.append(getPolyline(el))


### PR DESCRIPTION
When getCurveSet() is called on an unsupported entity, it runs into a
NameError exception because elts is not defined. Instead print a message
and return gracefully.

This is in line with overall behaviour of the importer: Ignore
unsupported elements instead of thowing errors.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
