### PR TITLE
Travis exclude Clang build job for PR

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,8 @@ jobs:
 #      - python: 3.7
     fast_finish: true  # https://blog.travis-ci.com/2013-11-27-fast-finishing-builds
     include:
-      - os: linux
+      - if: type != pull_request
+        os: linux
         dist: bionic
         language: cpp
         compiler: clang


### PR DESCRIPTION
With this change Clang build job should only start when merging the PR (master branch). Rationale being Clang currently isn't using ccache for PRs, no real idea on why, and running both GCC and Clang for each PR is a bit excessive.