### PR TITLE
[Part] Gui TaskCheckGeometry change Error to Log..

### DIFF
--- a/src/Mod/Part/Gui/TaskCheckGeometry.cpp
+++ b/src/Mod/Part/Gui/TaskCheckGeometry.cpp
@@ -704,7 +704,7 @@ BOPCheck.Perform();
 
       /*log BOPCheck errors to report view*/
       if (logErrors){
-          std::cerr << faultyEntry->parent->name.toStdString().c_str() << " : "
+          std::clog << faultyEntry->parent->name.toStdString().c_str() << " : "
                     << faultyEntry->name.toStdString().c_str() << " : "
                     << faultyEntry->type.toStdString().c_str() << " : "
                     << faultyEntry->error.toStdString().c_str()
@@ -737,7 +737,7 @@ void TaskCheckGeometryResults::dispatchError(ResultEntry *entry, const BRepCheck
 
     /*log BRepCheck errors to report view*/
     if (logErrors){
-        std::cerr << entry->parent->name.toStdString().c_str() << " : "
+        std::clog << entry->parent->name.toStdString().c_str() << " : "
                   << entry->name.toStdString().c_str() << " : "
                   << entry->type.toStdString().c_str() << " : "
                   << entry->error.toStdString().c_str() << " (BRepCheck)"


### PR DESCRIPTION
for faulty geometry output, The user can still see all the error output in the task panel but by default they will see nothing in the Report View as Log is not Enabled for new users. See discussion https://forum.freecadweb.org/viewtopic.php?f=15&t=46803#p402533

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
