### PR TITLE
Draft: small fix for older PathArray objects

### DIFF
--- a/src/Mod/Draft/draftobjects/patharray.py
+++ b/src/Mod/Draft/draftobjects/patharray.py
@@ -119,7 +119,7 @@ class PathArray(DraftLink):
             obj.addProperty("App::PropertyVector","VerticalVector","Alignment", _tip)
             obj.VerticalVector = App.Vector(0,0,1)
 
-        if self.use_link:
+        if self.use_link and "ExpandArray" not in pl:
             _tip = _tr("Show array element as children object")
             obj.addProperty("App::PropertyBool","ExpandArray", "Parameters", _tip)
             obj.ExpandArray = False
@@ -173,9 +173,9 @@ class PathArray(DraftLink):
         return Part.Wire(sl)
 
     def onDocumentRestored(self, obj):
+        self.migrate_attributes(obj)
         self.setProperties(obj)
 
-        self.migrate_attributes(obj)
         if self.use_link:
             self.linkSetup(obj)
         else:


### PR DESCRIPTION
Older PathLinkArray objects had a `useLink` attribute which was migrated to `use_link`. A recent commit, ff323ebdb5, made some improvements to the PathArray object, but broke the migration of the property.

This fixes the migration, so that now all objects should open correctly.

A previous attempt was #3508.

---

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists