### PR TITLE
Sketcher: Fix for failure of constraint substitution

### DIFF
--- a/src/Mod/Sketcher/Gui/CommandConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/CommandConstraints.cpp
@@ -2237,6 +2237,7 @@ void CmdSketcherConstrainCoincident::activated(int iMsg)
                 doEndpointTangency(Obj, selection[0], GeoId1, GeoId2, PosId1, PosId2);
 
                 commitCommand();
+                Obj->solve(); // The substitution requires a solve() so that the autoremove redundants works when Autorecompute not active.
                 tryAutoRecomputeIfNotSolve(Obj);
 
                 ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Mod/Sketcher/General");
@@ -4432,6 +4433,7 @@ void CmdSketcherConstrainTangent::activated(int iMsg)
                     Gui::cmdAppObjectArgs(Obj, "delConstraintOnPoint(%i,%i)", first, firstpos);
 
                     commitCommand();
+                    Obj->solve(); // The substitution requires a solve() so that the autoremove redundants works when Autorecompute not active.
                     tryAutoRecomputeIfNotSolve(Obj);
 
                     ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Mod/Sketcher/General");


### PR DESCRIPTION
====================================================

fixes #4105

When a constraint substitution is present, a solve must precede any call to the redundant removal to update the solver information.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [x] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
