### PR TITLE
Arch: IFC import, implementation of IfcIndexedPolyCurve

### DIFF
--- a/src/Mod/Arch/importIFCHelper.py
+++ b/src/Mod/Arch/importIFCHelper.py
@@ -677,6 +677,27 @@ def get2DShape(representation,scaling=1000):
                         a = -DraftVecUtils.angle(v)
                         e.rotate(bc.Curve.Center,FreeCAD.Vector(0,0,1),math.degrees(a))
                         result.append(e)
+            elif el.is_a("IfcIndexedPolyCurve"):
+                coords = el.Points.CoordList
+                def index2points(segment):
+                    pts = []
+                    for i in segment.wrappedValue:
+                        c = coords[i-1]
+                        c = FreeCAD.Vector(c[0],c[1],c[2] if len(c) > 2 else 0)
+                        c.multiply(scaling)
+                        pts.append(c)
+                    return pts
+
+                for s in el.Segments:
+                    if s.is_a("IfcLineIndex"):
+                        result.append(Part.makePolygon(index2points(s)))
+                    elif s.is_a("IfcArcIndex"):
+                        [p1, p2, p3] = index2points(s)
+                        result.append(Part.Arc(p1, p2, p3))
+                    else:
+                        raise RuntimeError("Illegal IfcIndexedPolyCurve segment")
+            else:
+                print("getCurveSet: unhandled element: ", el)
 
         return result
 


### PR DESCRIPTION
ArchiCAD uses this entity for footprint annotations even if there are no
arc segments. Thus I need this, but couldn't test the arc part of the
patch.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
