### PR TITLE
FEM: fix failing unit test in Elmer meshing (SecondOrderLinear)

### DIFF
--- a/src/Mod/Fem/femtest/data/elmer/group_mesh.geo
+++ b/src/Mod/Fem/femtest/data/elmer/group_mesh.geo
@@ -22,7 +22,7 @@ Mesh.HighOrderOptimize = 0;  // for more HighOrderOptimize parameter check http:
 
 // mesh order
 Mesh.ElementOrder = 2;
-Mesh.SecondOrderLinear = 1; // Second order nodes are created by linear interpolation instead by curvilinear
+Mesh.SecondOrderLinear = 0; // Second order nodes are created by linear interpolation instead by curvilinear
 
 // mesh algorithm, only a few algorithms are usable with 3D boundary layer generation
 // 2D mesh algorithm (1=MeshAdapt, 2=Automatic, 5=Delaunay, 6=Frontal, 7=BAMG, 8=DelQuad)


### PR DESCRIPTION
Since f4736e0dd5 unit tests with Elmer have been failing in every case. This should solve the issue but I'm not sure if it's the right thing to do.

---

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists