### PR TITLE
Draft: add a few supporting functions for Draft functions

### DIFF
--- a/src/Mod/Draft/draftutils/utils.py
+++ b/src/Mod/Draft/draftutils/utils.py
@@ -1335,3 +1335,39 @@ def find_object(obj, doc=None):
         return not FOUND, None
 
     return FOUND, obj
+
+
+def use_instead(function, version=""):
+    """Print a deprecation message and suggest another function.
+
+    This function must be used inside the definition of a function
+    that has been considered for deprecation, so we must provide
+    an alternative.
+    ::
+        def old_function():
+            use_instead('new_function', 1.0)
+
+        def someFunction():
+            use_instead('some_function')
+
+    Parameters
+    ----------
+    function: str
+        The name of the function to use instead of the current one.
+
+    version: float or str, optional
+        It defaults to the empty string `''`.
+        The version where this command is to be deprecated, if it is known.
+        If we don't know when this command will be deprecated
+        then we should not give a version.
+    """
+    text = "This function will be deprected in "
+    text2 = "This function will be deprected. "
+    text3 = "Please use "
+
+    if version:
+        _wrn(_tr(text) + "{}. ".format(version)
+             + _tr(text3) + "'{}'.".format(function))
+    else:
+        _wrn(_tr(text2)
+             + _tr(text3) + "'{}'.".format(function))

--- a/src/Mod/Draft/draftutils/utils.py
+++ b/src/Mod/Draft/draftutils/utils.py
@@ -1249,3 +1249,89 @@ def print_header(name, description, debug=True):
     if debug:
         _msg(16 * "-")
         _msg(description)
+
+
+def find_doc(doc=None):
+    """Return the active document or find a document by name.
+
+    Parameters
+    ----------
+    doc: App::Document or str, optional
+        The document that will be searched in the session.
+        It defaults to `None`, in which case it tries to find
+        the active document.
+        If `doc` is a string, it will try to get the document by `Name`.
+
+    Returns
+    -------
+    bool, App::Document
+        A tuple containing the information on whether the search
+        was successful. In this case, the boolean is `True`,
+        and the second value is the document instance.
+
+    False, None
+        If there is no active document, or the string in `doc`
+        doesn't correspond to an open document in the session.
+    """
+    FOUND = True
+
+    if not doc:
+        doc = App.activeDocument()
+    if not doc:
+        return not FOUND, None
+
+    if isinstance(doc, str):
+        try:
+            doc = App.getDocument(doc)
+        except NameError:
+            _msg("document: {}".format(doc))
+            _err(_tr("Wrong input: unknown document."))
+            return not FOUND, None
+
+    return FOUND, doc
+
+
+def find_object(obj, doc=None):
+    """Find object in the document, inclusive by Label.
+
+    Parameters
+    ----------
+    obj: App::DocumentObject or str
+        The object to search in `doc`.
+        Or if the `obj` is a string, it will search the object by `Label`.
+        Since Labels are not guaranteed to be unique, it will get the first
+        object with that label in the document.
+
+    doc: App::Document or str, optional
+        The document in which the object will be searched.
+        It defaults to `None`, in which case it tries to search in the
+        active document.
+        If `doc` is a string, it will search the document by `Name`.
+
+    Returns
+    -------
+    bool, App::DocumentObject
+        A tuple containing the information on whether the search
+        was successful. In this case, the boolean is `True`,
+        and the second value is the object found.
+
+    False, None
+        If the object doesn't exist in the document.
+    """
+    FOUND = True
+
+    found, doc = find_doc(doc)
+    if not found:
+        _err(_tr("No active document. Aborting."))
+        return not FOUND, None
+
+    if isinstance(obj, str):
+        try:
+            obj = doc.getObjectsByLabel(obj)[0]
+        except IndexError:
+            return not FOUND, None
+
+    if obj not in doc.Objects:
+        return not FOUND, None
+
+    return FOUND, obj


### PR DESCRIPTION
Cleanup of the `draftutils.utils` module. Also new functions added, `use_instead` function to indicate older functions, `find_doc` function to find a document by `Name`, `find_object` function to find an object by `Label`, searching in a specific document or in the active document.

These will be used by different Draft make functions.

Forum thread: [Making the creation of arrays more user friendly](https://forum.freecadweb.org/viewtopic.php?f=23&t=41816&p=403957#p403957)

---

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists
