### PR TITLE
Draft: PointArray improvements

### DIFF
--- a/src/Mod/Draft/draftguitools/gui_pointarray.py
+++ b/src/Mod/Draft/draftguitools/gui_pointarray.py
@@ -1,7 +1,8 @@
 # ***************************************************************************
-# *   (c) 2009, 2010 Yorik van Havre <yorik@uncreated.net>                  *
-# *   (c) 2009, 2010 Ken Cline <cline@frii.com>                             *
-# *   (c) 2020 Eliud Cabrera Castillo <e.cabrera-castillo@tum.de>           *
+# *   Copyright (c) 2009, 2010 Yorik van Havre <yorik@uncreated.net>        *
+# *   Copyright (c) 2009, 2010 Ken Cline <cline@frii.com>                   *
+# *   Copyright (c) 2018 Benjamin Alterauge (ageeye)                        *
+# *   Copyright (c) 2020 Eliud Cabrera Castillo <e.cabrera-castillo@tum.de> *
 # *                                                                         *
 # *   This file is part of the FreeCAD CAx development system.              *
 # *                                                                         *
@@ -11,13 +12,13 @@
 # *   the License, or (at your option) any later version.                   *
 # *   for detail see the LICENCE text file.                                 *
 # *                                                                         *
-# *   FreeCAD is distributed in the hope that it will be useful,            *
+# *   This program is distributed in the hope that it will be useful,       *
 # *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
 # *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
 # *   GNU Library General Public License for more details.                  *
 # *                                                                         *
 # *   You should have received a copy of the GNU Library General Public     *
-# *   License along with FreeCAD; if not, write to the Free Software        *
+# *   License along with this program; if not, write to the Free Software   *
 # *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
 # *   USA                                                                   *
 # *                                                                         *
@@ -26,25 +27,27 @@
 
 The copies will be created where various points are located.
 
-The points need to be grouped under a compound of points
-before using this tool.
-To create this compound, select various points and then use the Upgrade tool
-to create a `Block`.
+The points need to be grouped under a compound before using this tool.
+To create this compound, select various points and then use the Draft Upgrade
+tool to create a `Block`, or use a `Part::Compound`.
+You can also create a Sketch, and place explicit points.
+
+Other geometrical objects may be contained inside the compounds but only
+the explicit point and vertex objects will be used when creating
+the point array.
 """
-## @package gui_patharray
+## @package gui_pointarray
 # \ingroup DRAFT
-# \brief Provides tools for creating path arrays with the Draft Workbench.
+# \brief Provides tools for creating point arrays with the Draft Workbench.
 
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
-import FreeCAD as App
 import FreeCADGui as Gui
-import Draft
 import Draft_rc
 import draftguitools.gui_base_original as gui_base_original
-import draftguitools.gui_tool_utils as gui_tool_utils
-from draftutils.messages import _msg
-from draftutils.translate import translate, _tr
+
+from draftutils.messages import _err
+from draftutils.translate import _tr
 
 # The module is used to prevent complaints from code checkers (flake8)
 True if Draft_rc.__name__ else False
@@ -56,14 +59,18 @@ class PointArray(gui_base_original.Modifier):
     def GetResources(self):
         """Set icon, menu and tooltip."""
         _menu = "Point array"
-        _tip = ("Creates copies of a selected object at the position "
-                "of various points.\n"
+        _tip = ("Creates copies of the selected object, "
+                "and places the copies at the position of various points.\n"
+                "\n"
                 "The points need to be grouped under a compound of points "
                 "before using this tool.\n"
                 "To create this compound, select various points "
-                "and then use the Upgrade tool to create a 'Block'.\n"
+                "and then use the Part Compound tool,\n"
+                "or use the Draft Upgrade tool to create a 'Block', "
+                "or create a Sketch and add simple points to it.\n"
+                "\n"
                 "Select the base object, and then select the compound "
-                "to create the point array.")
+                "or the sketch to create the point array.")
 
         return {'Pixmap': 'Draft_PointArray',
                 'MenuText': QT_TRANSLATE_NOOP("Draft_PointArray", _menu),
@@ -71,17 +78,25 @@ class PointArray(gui_base_original.Modifier):
 
     def Activated(self):
         """Execute when the command is called."""
-        super(PointArray, self).Activated(name=_tr("Point array"))
-        if not Gui.Selection.getSelectionEx():
-            if self.ui:
-                self.ui.selectUi()
-                _msg(translate("draft",
-                               "Please select base and pointlist objects."))
-                self.call = \
-                    self.view.addEventCallback("SoEvent",
-                                               gui_tool_utils.selectObject)
-        else:
-            self.proceed()
+        self.name = "Point array"
+        super(PointArray, self).Activated(name=_tr(self.name))
+        # This was deactivated because it doesn't work correctly;
+        # the selection needs to be made on two objects, but currently
+        # it only selects one.
+
+        # if not Gui.Selection.getSelectionEx():
+        #     if self.ui:
+        #         self.ui.selectUi()
+        #         _msg(translate("draft",
+        #                        "Please select exactly two objects, "
+        #                        "the base object and the point object, "
+        #                        "before calling this command."))
+        #         self.call = \
+        #             self.view.addEventCallback("SoEvent",
+        #                                        gui_tool_utils.selectObject)
+        # else:
+        #     self.proceed()
+        self.proceed()
 
     def proceed(self):
         """Proceed with the command if one object was selected."""
@@ -89,14 +104,28 @@ class PointArray(gui_base_original.Modifier):
             self.view.removeEventCallback("SoEvent", self.call)
 
         sel = Gui.Selection.getSelectionEx()
-        if sel:
-            base = sel[0].Object
-            ptlst = sel[1].Object
+        if len(sel) != 2:
+            _err(_tr("Please select exactly two objects, "
+                     "the base object and the point object, "
+                     "before calling this command."))
+        else:
+            base_object = sel[0].Object
+            point_object = sel[1].Object
 
-            App.ActiveDocument.openTransaction("PointArray")
-            Draft.makePointArray(base, ptlst)
-            App.ActiveDocument.commitTransaction()
-            App.ActiveDocument.recompute()
+            Gui.addModule('Draft')
+            _cmd = "Draft.make_point_array"
+            _cmd += "("
+            _cmd += "App.ActiveDocument." + base_object.Name + ", "
+            _cmd += "App.ActiveDocument." + point_object.Name + ", "
+            _cmd += ")"
+
+            _cmd_list = ["_obj_ = " + _cmd,
+                         "Draft.autogroup(_obj_)",
+                         "App.ActiveDocument.recompute()"]
+            self.commit(_tr(self.name), _cmd_list)
+
+        # Commit the transaction and execute the comamnds
+        # through the parent class
         self.finish()
 
 

--- a/src/Mod/Draft/draftguitools/gui_pointarray.py
+++ b/src/Mod/Draft/draftguitools/gui_pointarray.py
@@ -111,12 +111,14 @@ class PointArray(gui_base_original.Modifier):
         else:
             base_object = sel[0].Object
             point_object = sel[1].Object
+            extra = None
 
             Gui.addModule('Draft')
             _cmd = "Draft.make_point_array"
             _cmd += "("
             _cmd += "App.ActiveDocument." + base_object.Name + ", "
             _cmd += "App.ActiveDocument." + point_object.Name + ", "
+            _cmd += "extra=" + str(extra)
             _cmd += ")"
 
             _cmd_list = ["_obj_ = " + _cmd,

--- a/src/Mod/Draft/draftmake/make_pointarray.py
+++ b/src/Mod/Draft/draftmake/make_pointarray.py
@@ -1,7 +1,11 @@
 # ***************************************************************************
 # *   Copyright (c) 2009, 2010 Yorik van Havre <yorik@uncreated.net>        *
 # *   Copyright (c) 2009, 2010 Ken Cline <cline@frii.com>                   *
-# *   Copyright (c) 2020 FreeCAD Developers                                 *
+# *   Copyright (c) 2018 Benjamin Alterauge (ageeye)                        *
+# *   Copyright (c) 2020 Carlo Pavan <carlopav@gmail.com>                   *
+# *   Copyright (c) 2020 Eliud Cabrera Castillo <e.cabrera-castillo@tum.de> *
+# *                                                                         *
+# *   This file is part of the FreeCAD CAx development system.              *
 # *                                                                         *
 # *   This program is free software; you can redistribute it and/or modify  *
 # *   it under the terms of the GNU Lesser General Public License (LGPL)    *
@@ -20,47 +24,129 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""This module provides the code for Draft make_point_array function.
+"""Provides functions for creating point arrays.
+
+The copies will be placed along a list of points defined by a sketch,
+a `Part::Compound`, or a `Draft Block`.
 """
 ## @package make_pointarray
 # \ingroup DRAFT
 # \brief This module provides the code for Draft make_point_array function.
 
 import FreeCAD as App
-
+import draftutils.utils as utils
 import draftutils.gui_utils as gui_utils
 
+from draftutils.messages import _msg, _err
+from draftutils.translate import _tr
 from draftobjects.pointarray import PointArray
+
 if App.GuiUp:
     from draftviewproviders.view_array import ViewProviderDraftArray
 
 
-def make_point_array(base, ptlst):
-    """make_point_array(base,pointlist)
+def make_point_array(base_object, point_object):
+    """Make a Draft PointArray object.
 
-    Make a Draft PointArray object.
+    Distribute copies of a `base_object` in the points
+    defined by `point_object`.
 
     Parameters
     ----------
-    base :
-        TODO: describe
+    base_object: Part::Feature or str
+        Any of object that has a `Part::TopoShape` that can be duplicated.
+        This means most 2D and 3D objects produced with any workbench.
+        If it is a string, it must be the `Label` of that object.
+        Since a label is not guaranteed to be unique in a document,
+        it will use the first object found with this label.
 
-    plist :
-        TODO: describe
-    
+    point_object: Part::Feature or str
+        An object that is a type of container for holding points.
+        This object must have one of the following properties `Geometry`,
+        `Links`, or `Components`, which themselves must contain objects
+        with `X`, `Y`, and `Z` properties.
+
+        This object could be:
+
+        - A `Sketcher::SketchObject`, as it has a `Geometry` property.
+          The sketch can contain different elements but it must contain
+          at least one `Part::GeomPoint`.
+
+        - A `Part::Compound`, as it has a `Links` property. The compound
+          can contain different elements but it must contain at least
+          one object that has `X`, `Y`, and `Z` properties,
+          like a `Draft Point` or a `Part::Vertex`.
+
+        - A `Draft Block`, as it has a `Components` property. This `Block`
+          behaves essentially the same as a `Part::Compound`. It must
+          contain at least a point or vertex object.
+
+    Returns
+    -------
+    Part::FeaturePython
+        A scripted object of type `'PointArray'`.
+        Its `Shape` is a compound of the copies of the original object.
+
+    None
+        If there is a problem it will return `None`.
     """
-    obj = App.ActiveDocument.addObject("Part::FeaturePython", "PointArray")
-    PointArray(obj, base, ptlst)
-    obj.Base = base
-    obj.PointList = ptlst
+    _name = "make_point_array"
+    utils.print_header(_name, "Point array")
+
+    found, doc = utils.find_doc(App.activeDocument())
+    if not found:
+        _err(_tr("No active document. Aborting."))
+        return None
+
+    if isinstance(base_object, str):
+        base_object_str = base_object
+
+    found, base_object = utils.find_object(base_object, doc)
+    if not found:
+        _msg("base_object: {}".format(base_object_str))
+        _err(_tr("Wrong input: object not in document."))
+        return None
+
+    _msg("base_object: {}".format(base_object.Label))
+
+    if isinstance(point_object, str):
+        point_object_str = point_object
+
+    found, point_object = utils.find_object(point_object, doc)
+    if not found:
+        _msg("point_object: {}".format(point_object_str))
+        _err(_tr("Wrong input: object not in document."))
+        return None
+
+    _msg("point_object: {}".format(point_object.Label))
+    if (not hasattr(point_object, "Geometry")
+            and not hasattr(point_object, "Links")
+            and not hasattr(point_object, "Components")):
+        _err(_tr("Wrong input: point object doesn't have "
+                 "'Geometry', 'Links', or 'Components'."))
+        return None
+
+    new_obj = doc.addObject("Part::FeaturePython", "PointArray")
+    PointArray(new_obj)
+    new_obj.Base = base_object
+    new_obj.PointList = point_object
+
     if App.GuiUp:
-        ViewProviderDraftArray(obj.ViewObject)
-        base.ViewObject.hide()
-        gui_utils.formatObject(obj,obj.Base)
-        if len(obj.Base.ViewObject.DiffuseColor) > 1:
-            obj.ViewObject.Proxy.resetColors(obj.ViewObject)
-        gui_utils.select(obj)
-    return obj
+        ViewProviderDraftArray(new_obj.ViewObject)
+        gui_utils.formatObject(new_obj, new_obj.Base)
+
+        if hasattr(new_obj.Base.ViewObject, "DiffuseColor"):
+            if len(new_obj.Base.ViewObject.DiffuseColor) > 1:
+                new_obj.ViewObject.Proxy.resetColors(new_obj.ViewObject)
+
+        new_obj.Base.ViewObject.hide()
+        gui_utils.select(new_obj)
+
+    return new_obj
 
 
-makePointArray = make_point_array
+def makePointArray(base, ptlst):
+    """Create PointArray. DEPRECATED. Use 'make_point_array'."""
+    utils.use_instead('make_point_array')
+
+    return make_point_array(base, ptlst)

--- a/src/Mod/Draft/draftobjects/pointarray.py
+++ b/src/Mod/Draft/draftobjects/pointarray.py
@@ -1,7 +1,9 @@
 # ***************************************************************************
 # *   Copyright (c) 2009, 2010 Yorik van Havre <yorik@uncreated.net>        *
 # *   Copyright (c) 2009, 2010 Ken Cline <cline@frii.com>                   *
-# *   Copyright (c) 2020 FreeCAD Developers                                 *
+# *   Copyright (c) 2018 Benjamin Alterauge (ageeye)                        *
+# *   Copyright (c) 2020 Carlo Pavan <carlopav@gmail.com>                   *
+# *   Copyright (c) 2020 Eliud Cabrera Castillo <e.cabrera-castillo@tum.de> *
 # *                                                                         *
 # *   This program is free software; you can redistribute it and/or modify  *
 # *   it under the terms of the GNU Lesser General Public License (LGPL)    *
@@ -20,88 +22,171 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""This module provides the object code for the Draft PointArray object.
-"""
+"""Provides the object code for the Draft PointArray object."""
 ## @package pointarray
 # \ingroup DRAFT
-# \brief This module provides the object code for the Draft PointArray object.
+# \brief Provides the object code for the Draft PointArray object.
 
 import math
-
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
 import FreeCAD as App
-import DraftVecUtils
-
 import draftutils.utils as utils
+import lazy_loader.lazy_loader as lz
 
+from draftutils.messages import _err
+from draftutils.translate import translate, _tr
 from draftobjects.base import DraftObject
+
+# Delay import of module until first use because it is heavy
+Part = lz.LazyLoader("Part", globals(), "Part")
 
 
 class PointArray(DraftObject):
-    """The Draft Point Array object"""
+    """The Draft Point Array object."""
 
-    def __init__(self, obj, bobj, ptlst):
+    def __init__(self, obj):
         super(PointArray, self).__init__(obj, "PointArray")
-        
-        _tip = "Base object"
-        obj.addProperty("App::PropertyLink", "Base",
-                        "Objects", QT_TRANSLATE_NOOP("App::Property", _tip))
-        
-        _tip = "List of points used to distribute the base object"
-        obj.addProperty("App::PropertyLink", "PointList",
-                        "Objects", QT_TRANSLATE_NOOP("App::Property", _tip))
-        
-        _tip = "Number of copies" # TODO: verify description of the tooltip
-        obj.addProperty("App::PropertyInteger", "Count",
-                        "Parameters", QT_TRANSLATE_NOOP("App::Property", _tip))
+        self.set_properties(obj)
 
-        obj.Base = bobj
-        obj.PointList = ptlst
-        obj.Count = 0
+    def set_properties(self, obj):
+        """Set properties only if they don't exist."""
+        properties = obj.PropertiesList
 
-        obj.setEditorMode("Count", 1)
+        if "Base" not in properties:
+            _tip = "Base object that will be duplicated"
+            obj.addProperty("App::PropertyLink",
+                            "Base",
+                            "Objects",
+                            QT_TRANSLATE_NOOP("App::Property", _tip))
+            obj.Base = None
+
+        # TODO: this isn't a list, it should be renamed to PointObject
+        if "PointList" not in properties:
+            _tip = ("Object containing points used to distribute "
+                    "the base object, for example, a sketch or "
+                    "a Part compound.\n"
+                    "The sketch or compound must contain at least "
+                    "one explicit point or vertex object.")
+            obj.addProperty("App::PropertyLink",
+                            "PointList",
+                            "Objects",
+                            QT_TRANSLATE_NOOP("App::Property", _tip))
+            obj.PointList = None
+
+        if "Count" not in properties:
+            _tip = ("Total number of elements in the array.\n"
+                    "This property is read-only, as the number depends "
+                    "on the points contained within 'Point Object'.")
+            obj.addProperty("App::PropertyInteger",
+                            "Count",
+                            "Objects",
+                            QT_TRANSLATE_NOOP("App::Property", _tip))
+            obj.Count = 0
+            obj.setEditorMode("Count", 1)  # Read only
 
     def execute(self, obj):
-        import Part
-        pls = []
-        opl = obj.PointList
-        while utils.get_type(opl) == 'Clone':
-            opl = opl.Objects[0]
-        if hasattr(opl, 'Geometry'):
-            place = opl.Placement
-            for pts in opl.Geometry:
-                if hasattr(pts, 'X') and hasattr(pts, 'Y') and hasattr(pts, 'Z'):
-                    pn = pts.copy()
-                    pn.translate(place.Base)
-                    pn.rotate(place)
-                    pls.append(pn)
-        elif hasattr(opl, 'Links'):
-            pls = opl.Links
-        elif hasattr(opl, 'Components'):
-            pls = opl.Components
+        """Run when the object is created or recomputed."""
+        if not hasattr(obj.Base, 'Shape'):
+            _err(_tr("Base object doesn't have a 'Shape', "
+                     "it cannot be used for an array."))
+            obj.Count = 0
+            return
 
-        base = []
-        i = 0
-        if hasattr(obj.Base, 'Shape'):
-            for pts in pls:
-                #print pts # inspect the objects
-                if hasattr(pts, 'X') and hasattr(pts, 'Y') and hasattr(pts, 'Z'):
-                    nshape = obj.Base.Shape.copy()
-                    if hasattr(pts, 'Placement'):
-                        place = pts.Placement
-                        nshape.translate(place.Base)
-                        nshape.rotate(place.Base, place.Rotation.Axis, place.Rotation.Angle * 180 /  math.pi )
-                    else:
-                        nshape.translate(App.Vector(pts.X,pts.Y,pts.Z))
-                    i += 1
-                    base.append(nshape)
-        obj.Count = i
-        if i > 0:
-            obj.Shape = Part.makeCompound(base)
+        pt_list, count = get_point_list(obj.PointList)
+        shape = build_copies(obj.Base, pt_list)
+
+        obj.Shape = shape
+        obj.Count = count
+
+
+def get_point_list(point_object):
+    """Extract a list of points from a point object.
+
+    Returns
+    -------
+    list, int
+        A list of points that have `X`, `Y`, `Z` coordinates;
+        the second element is the number of elements.
+        If the list is empty, the second element is zero.
+    """
+    # If its a clone, extract the real object
+    while utils.get_type(point_object) == 'Clone':
+        point_object = point_object.Objects[0]
+
+    # If the point object doesn't have actual points
+    # the point list will remain empty
+    pt_list = list()
+
+    if hasattr(point_object, 'Geometry'):
+        # Intended for a Sketcher::SketchObject, which has this property
+        place = point_object.Placement
+        for geo in point_object.Geometry:
+            # It must contain at least one Part::GeomPoint.
+            if (hasattr(geo, 'X')
+                    and hasattr(geo, 'Y') and hasattr(geo, 'Z')):
+                point = geo.copy()
+                point.translate(place.Base)
+                point.rotate(place)
+                pt_list.append(point)
+
+        count = len(pt_list)
+        return pt_list, count
+
+    obj_list = list()
+    if hasattr(point_object, 'Links'):
+        # Intended for a Part::Compound, which has this property
+        obj_list = point_object.Links
+    elif hasattr(point_object, 'Components'):
+        # Intended for a Draft Block, which has this property
+        obj_list = point_object.Components
+
+    # These compounds should have at least one discrete point object
+    # like a Draft Point or a Part::Vertex
+    for _obj in obj_list:
+        if hasattr(_obj, 'X') and hasattr(_obj, 'Y') and hasattr(_obj, 'Z'):
+            pt_list.append(_obj)
+
+    count = len(pt_list)
+    return pt_list, count
+
+
+def build_copies(base_object, pt_list=None):
+    """Build a compound of copies from the base object and list of points.
+
+    Returns
+    -------
+    Part::TopoShape
+        The compound shape created by `Part.makeCompound`.
+    """
+    if not pt_list:
+        _err(translate("Draft",
+                       "Point object doesn't have a discrete point, "
+                       "it cannot be used for an array."))
+        shape = base_object.Shape.copy()
+        return shape
+
+    copies = list()
+
+    for point in pt_list:
+        new_shape = base_object.Shape.copy()
+
+        # If the point object has a placement, use it
+        # to displace the copy of the shape. Otherwise
+        # translate by the X, Y, Z coordinates.
+        if hasattr(point, 'Placement'):
+            place = point.Placement
+            new_shape.translate(place.Base)
+            new_shape.rotate(place.Base,
+                             place.Rotation.Axis,
+                             place.Rotation.Angle * 180 / math.pi)
         else:
-            App.Console.PrintError(QT_TRANSLATE_NOOP("draft","No point found\n"))
-            obj.Shape = obj.Base.Shape.copy()
+            new_shape.translate(App.Vector(point.X, point.Y, point.Z))
+
+        copies.append(new_shape)
+
+    shape = Part.makeCompound(copies)
+    return shape
 
 
 _PointArray = PointArray

--- a/src/Mod/Draft/drafttests/draft_test_objects.py
+++ b/src/Mod/Draft/drafttests/draft_test_objects.py
@@ -476,7 +476,7 @@ def _create_objects(doc=None,
     _msg(16 * "-")
     _msg("Path array")
     poly_h = Draft.make_polygon(3, 250)
-    poly_h.Placement.Base = Vector(10500, 3000, 0)
+    poly_h.Placement.Base = Vector(10000, 3000, 0)
     if App.GuiUp:
         poly_h.ViewObject.Visibility = False
 
@@ -494,7 +494,7 @@ def _create_objects(doc=None,
     _msg(16 * "-")
     _msg("Path link array")
     poly_h_2 = Draft.make_polygon(4, 200)
-    poly_h_2.Placement.Base = Vector(10500, 5000, 0)
+    poly_h_2.Placement.Base = Vector(10000, 5000, 0)
     if App.GuiUp:
         poly_h_2.ViewObject.Visibility = False
 
@@ -512,6 +512,7 @@ def _create_objects(doc=None,
     _msg(16 * "-")
     _msg("Point array")
     poly_h = Draft.make_polygon(3, 250)
+    poly_h.Placement.Base = Vector(12500, 2500, 0)
 
     point_1 = Draft.make_point(13000, 3000, 0)
     point_2 = Draft.make_point(13000, 3500, 0)


### PR DESCRIPTION
General cleaning of the code, PEP8 style, in the make function, Gui Command, and also the internal proxy object.

Now it includes the `ExtraPlacement` property to additionally affect the position and rotation of each element in the array.

The make function now accepts a label, and not only an object reference.
```py
Draft.make_point_array("Circle", "Compound_of_points")
```

The Gui Command now uses the `todo` class so it records the command to the Python console like most Draft commands already do.

This must be merged after the support functions are merged, #3528.

Forum thread: [Making the creation of arrays more user friendly](https://forum.freecadweb.org/viewtopic.php?f=23&t=41816&p=403957#p403957)

---

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists