### PR TITLE
Draft: PathArray improvements

### DIFF
--- a/src/Mod/Draft/draftguitools/gui_patharray.py
+++ b/src/Mod/Draft/draftguitools/gui_patharray.py
@@ -1,7 +1,10 @@
 # ***************************************************************************
-# *   (c) 2009, 2010 Yorik van Havre <yorik@uncreated.net>                  *
-# *   (c) 2009, 2010 Ken Cline <cline@frii.com>                             *
-# *   (c) 2020 Eliud Cabrera Castillo <e.cabrera-castillo@tum.de>           *
+# *   Copyright (c) 2009, 2010 Yorik van Havre <yorik@uncreated.net>        *
+# *   Copyright (c) 2009, 2010 Ken Cline <cline@frii.com>                   *
+# *   Copyright (c) 2013 Wandererfan <wandererfan@gmail.com>                *
+# *   Copyright (c) 2019 Zheng, Lei (realthunder)<realthunder.dev@gmail.com>*
+# *   Copyright (c) 2020 Carlo Pavan <carlopav@gmail.com>                   *
+# *   Copyright (c) 2020 Eliud Cabrera Castillo <e.cabrera-castillo@tum.de> *
 # *                                                                         *
 # *   This file is part of the FreeCAD CAx development system.              *
 # *                                                                         *
@@ -11,13 +14,13 @@
 # *   the License, or (at your option) any later version.                   *
 # *   for detail see the LICENCE text file.                                 *
 # *                                                                         *
-# *   FreeCAD is distributed in the hope that it will be useful,            *
+# *   This program is distributed in the hope that it will be useful,       *
 # *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
 # *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
 # *   GNU Library General Public License for more details.                  *
 # *                                                                         *
 # *   You should have received a copy of the GNU Library General Public     *
-# *   License along with FreeCAD; if not, write to the Free Software        *
+# *   License along with this program; if not, write to the Free Software   *
 # *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
 # *   USA                                                                   *
 # *                                                                         *
@@ -35,12 +38,12 @@ from PySide.QtCore import QT_TRANSLATE_NOOP
 
 import FreeCAD as App
 import FreeCADGui as Gui
-import Draft
 import Draft_rc
+import DraftVecUtils
 import draftguitools.gui_base_original as gui_base_original
-import draftguitools.gui_tool_utils as gui_tool_utils
-from draftutils.messages import _msg
-from draftutils.translate import translate, _tr
+
+from draftutils.messages import _err
+from draftutils.translate import _tr
 
 # The module is used to prevent complaints from code checkers (flake8)
 True if Draft_rc.__name__ else False
@@ -59,13 +62,16 @@ class PathArray(gui_base_original.Modifier):
     def __init__(self, use_link=False):
         super(PathArray, self).__init__()
         self.use_link = use_link
+        self.call = None
 
     def GetResources(self):
         """Set icon, menu and tooltip."""
         _menu = "Path array"
-        _tip = ("Creates copies of a selected object along a selected path.\n"
+        _tip = ("Creates copies of the selected object "
+                "along a selected path.\n"
                 "First select the object, and then select the path.\n"
-                "The path can be a polyline, B-spline or Bezier curve.")
+                "The path can be a polyline, B-spline, Bezier curve, "
+                "or even edges from other objects.")
 
         return {'Pixmap': 'Draft_PathArray',
                 'MenuText': QT_TRANSLATE_NOOP("Draft_PathArray", _menu),
@@ -74,15 +80,24 @@ class PathArray(gui_base_original.Modifier):
     def Activated(self, name=_tr("Path array")):
         """Execute when the command is called."""
         super(PathArray, self).Activated(name=name)
-        if not Gui.Selection.getSelectionEx():
-            if self.ui:
-                self.ui.selectUi()
-                _msg(translate("draft", "Please select base and path objects"))
-                self.call = \
-                    self.view.addEventCallback("SoEvent",
-                                               gui_tool_utils.selectObject)
-        else:
-            self.proceed()
+        self.name = name
+        # This was deactivated becuase it doesn't work correctly;
+        # the selection needs to be made on two objects, but currently
+        # it only selects one.
+
+        # if not Gui.Selection.getSelectionEx():
+        #     if self.ui:
+        #         self.ui.selectUi()
+        #         _msg(translate("draft",
+        #                        "Please select exactly two objects, "
+        #                        "the base object and the path object, "
+        #                        "before calling this command."))
+        #         self.call = \
+        #             self.view.addEventCallback("SoEvent",
+        #                                        gui_tool_utils.selectObject)
+        # else:
+        #     self.proceed()
+        self.proceed()
 
     def proceed(self):
         """Proceed with the command if one object was selected."""
@@ -90,21 +105,54 @@ class PathArray(gui_base_original.Modifier):
             self.view.removeEventCallback("SoEvent", self.call)
 
         sel = Gui.Selection.getSelectionEx()
-        if sel:
-            base = sel[0].Object
-            path = sel[1].Object
+        if len(sel) != 2:
+            _err(_tr("Please select exactly two objects, "
+                     "the base object and the path object, "
+                     "before calling this command."))
+        else:
+            base_object = sel[0].Object
+            path_object = sel[1].Object
 
-            defCount = 4
-            defXlate = App.Vector(0, 0, 0)
-            defAlign = False
-            pathsubs = list(sel[1].SubElementNames)
+            count = 4
+            xlate = App.Vector(0, 0, 0)
+            subelements = list(sel[1].SubElementNames)
+            align = False
+            align_mode = "Original"
+            tan_vector = App.Vector(1, 0, 0)
+            force_vertical = False
+            vertical_vector = App.Vector(0, 0, 1)
+            use_link = self.use_link
 
-            App.ActiveDocument.openTransaction("PathArray")
-            Draft.makePathArray(base, path,
-                                defCount, defXlate, defAlign, pathsubs,
-                                use_link=self.use_link)
-            App.ActiveDocument.commitTransaction()
-            App.ActiveDocument.recompute()
+            _edge_list_str = list()
+            _edge_list_str = ["'" + edge + "'" for edge in subelements]
+            _sub_str = ", ".join(_edge_list_str)
+            subelements_list_str = "[" + _sub_str + "]"
+
+            vertical_vector_str = DraftVecUtils.toString(vertical_vector)
+
+            Gui.addModule("Draft")
+            _cmd = "Draft.make_path_array"
+            _cmd += "("
+            _cmd += "App.ActiveDocument." + base_object.Name + ", "
+            _cmd += "App.ActiveDocument." + path_object.Name + ", "
+            _cmd += "count=" + str(count) + ", "
+            _cmd += "xlate=" + DraftVecUtils.toString(xlate) + ", "
+            _cmd += "subelements=" + subelements_list_str + ", "
+            _cmd += "align=" + str(align) + ", "
+            _cmd += "align_mode=" + "'" + align_mode + "', "
+            _cmd += "tan_vector=" + DraftVecUtils.toString(tan_vector) + ", "
+            _cmd += "force_vertical=" + str(force_vertical) + ", "
+            _cmd += "vertical_vector=" + vertical_vector_str + ", "
+            _cmd += "use_link=" + str(use_link)
+            _cmd += ")"
+
+            _cmd_list = ["_obj_ = " + _cmd,
+                         "Draft.autogroup(_obj_)",
+                         "App.ActiveDocument.recompute()"]
+            self.commit(_tr(self.name), _cmd_list)
+
+        # Commit the transaction and execute the commands
+        # through the parent class
         self.finish()
 
 
@@ -131,7 +179,7 @@ class PathLinkArray(PathArray):
 
     def Activated(self):
         """Execute when the command is called."""
-        super(PathLinkArray, self).Activated(name=_tr("Link path array"))
+        super(PathLinkArray, self).Activated(name=_tr("Path link array"))
 
 
 Gui.addCommand('Draft_PathLinkArray', PathLinkArray())

--- a/src/Mod/Draft/draftguitools/gui_patharray.py
+++ b/src/Mod/Draft/draftguitools/gui_patharray.py
@@ -114,7 +114,7 @@ class PathArray(gui_base_original.Modifier):
             path_object = sel[1].Object
 
             count = 4
-            xlate = App.Vector(0, 0, 0)
+            extra = App.Vector(0, 0, 0)
             subelements = list(sel[1].SubElementNames)
             align = False
             align_mode = "Original"
@@ -136,7 +136,7 @@ class PathArray(gui_base_original.Modifier):
             _cmd += "App.ActiveDocument." + base_object.Name + ", "
             _cmd += "App.ActiveDocument." + path_object.Name + ", "
             _cmd += "count=" + str(count) + ", "
-            _cmd += "xlate=" + DraftVecUtils.toString(xlate) + ", "
+            _cmd += "extra=" + DraftVecUtils.toString(extra) + ", "
             _cmd += "subelements=" + subelements_list_str + ", "
             _cmd += "align=" + str(align) + ", "
             _cmd += "align_mode=" + "'" + align_mode + "', "

--- a/src/Mod/Draft/draftmake/make_patharray.py
+++ b/src/Mod/Draft/draftmake/make_patharray.py
@@ -48,7 +48,7 @@ if App.GuiUp:
 
 
 def make_path_array(base_object, path_object, count=4,
-                    xlate=App.Vector(0, 0, 0), subelements=None,
+                    extra=App.Vector(0, 0, 0), subelements=None,
                     align=False, align_mode="Original",
                     tan_vector=App.Vector(1, 0, 0),
                     force_vertical=False,
@@ -79,9 +79,9 @@ def make_path_array(base_object, path_object, count=4,
         It must be at least 2.
         If a `float` is provided, it will be truncated by `int(count)`.
 
-    xlate: Base.Vector3, optional
+    extra: Base.Vector3, optional
         It defaults to `App.Vector(0, 0, 0)`.
-        It translates each copy by the value of `xlate`.
+        It translates each copy by the value of `extra`.
         This is useful to adjust for the difference between shape centre
         and shape reference point.
 
@@ -189,9 +189,9 @@ def make_path_array(base_object, path_object, count=4,
         return None
     count = int(count)
 
-    _msg("xlate: {}".format(xlate))
+    _msg("extra: {}".format(extra))
     try:
-        utils.type_check([(xlate, App.Vector)],
+        utils.type_check([(extra, App.Vector)],
                          name=_name)
     except TypeError:
         _err(_tr("Wrong input: must be a vector."))
@@ -277,10 +277,10 @@ def make_path_array(base_object, path_object, count=4,
         PathArray(new_obj)
 
     new_obj.Base = base_object
-    new_obj.PathObj = path_object
+    new_obj.PathObject = path_object
     new_obj.Count = count
-    new_obj.Xlate = xlate
-    new_obj.PathSubs = sub_list
+    new_obj.ExtraTranslation = extra
+    new_obj.PathSubelements = sub_list
     new_obj.Align = align
     new_obj.AlignMode = align_mode
     new_obj.TangentVector = tan_vector

--- a/src/Mod/Draft/draftmake/make_patharray.py
+++ b/src/Mod/Draft/draftmake/make_patharray.py
@@ -1,7 +1,12 @@
 # ***************************************************************************
 # *   Copyright (c) 2009, 2010 Yorik van Havre <yorik@uncreated.net>        *
 # *   Copyright (c) 2009, 2010 Ken Cline <cline@frii.com>                   *
-# *   Copyright (c) 2020 FreeCAD Developers                                 *
+# *   Copyright (c) 2013 Wandererfan <wandererfan@gmail.com>                *
+# *   Copyright (c) 2019 Zheng, Lei (realthunder)<realthunder.dev@gmail.com>*
+# *   Copyright (c) 2020 Carlo Pavan <carlopav@gmail.com>                   *
+# *   Copyright (c) 2020 Eliud Cabrera Castillo <e.cabrera-castillo@tum.de> *
+# *                                                                         *
+# *   This file is part of the FreeCAD CAx development system.              *
 # *                                                                         *
 # *   This program is free software; you can redistribute it and/or modify  *
 # *   it under the terms of the GNU Lesser General Public License (LGPL)    *
@@ -20,98 +25,293 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""This module provides the code for Draft make_path_array function.
+"""Provides functions for creating path arrays.
+
+The copies will be placed along a path like a polyline, spline, or bezier
+curve.
 """
 ## @package make_patharray
 # \ingroup DRAFT
-# \brief This module provides the code for Draft make_path_array function.
+# \brief Provides functions for creating path arrays.
 
 import FreeCAD as App
-
 import draftutils.utils as utils
 import draftutils.gui_utils as gui_utils
 
-from draftutils.translate import _tr, translate
+from draftutils.messages import _msg, _err
+from draftutils.translate import _tr
 from draftobjects.patharray import PathArray
 
-from draftviewproviders.view_draftlink import ViewProviderDraftLink
 if App.GuiUp:
     from draftviewproviders.view_array import ViewProviderDraftArray
+    from draftviewproviders.view_draftlink import ViewProviderDraftLink
 
 
-def make_path_array(baseobject,pathobject,count,xlate=None,align=False,pathobjsubs=[],use_link=False):
-    """make_path_array(docobj, path, count, xlate, align, pathobjsubs, use_link)
-    
-    Make a Draft PathArray object.
-    
-    Distribute count copies of a document baseobject along a pathobject 
-    or subobjects of a pathobject. 
+def make_path_array(base_object, path_object, count=4,
+                    xlate=App.Vector(0, 0, 0), subelements=None,
+                    align=False, align_mode="Original",
+                    tan_vector=App.Vector(1, 0, 0),
+                    force_vertical=False,
+                    vertical_vector=App.Vector(0, 0, 1),
+                    use_link=True):
+    """Make a Draft PathArray object.
 
-    
+    Distribute copies of a `base_object` along `path_object`
+    or `subelements` from `path_object`.
+
     Parameters
     ----------
-    docobj : 
-        Object to array
+    base_object: Part::Feature or str
+        Any of object that has a `Part::TopoShape` that can be duplicated.
+        This means most 2D and 3D objects produced with any workbench.
+        If it is a string, it must be the `Label` of that object.
+        Since a label is not guaranteed to be unique in a document,
+        it will use the first object found with this label.
 
-    path : 
-        Path object
+    path_object: Part::Feature or str
+        Path object like a polyline, B-Spline, or bezier curve that should
+        contain edges.
+        Just like `base_object` it can also be `Label`.
 
-    pathobjsubs : 
-        TODO: Complete documentation
+    count: int, float, optional
+        It defaults to 4.
+        Number of copies to create along the `path_object`.
+        It must be at least 2.
+        If a `float` is provided, it will be truncated by `int(count)`.
 
-    align : 
-        Optionally aligns baseobject to tangent/normal/binormal of path. TODO: verify
+    xlate: Base.Vector3, optional
+        It defaults to `App.Vector(0, 0, 0)`.
+        It translates each copy by the value of `xlate`.
+        This is useful to adjust for the difference between shape centre
+        and shape reference point.
 
-    count : 
-        TODO: Complete documentation
+    subelements: list or tuple of str, optional
+        It defaults to `None`.
+        It should be a list of names of edges that must exist in `path_object`.
+        Then the path array will be created along these edges only,
+        and not the entire `path_object`.
+        ::
+            subelements = ['Edge1', 'Edge2']
 
-    xlate : Base.Vector
-        Optionally translates each copy by FreeCAD.Vector xlate direction
-        and distance to adjust for difference in shape centre vs shape reference point.
-        
-    use_link :
-        TODO: Complete documentation
+        The edges must be contiguous, meaning that it is not allowed to
+        input `'Edge1'` and `'Edge3'` if they do not touch each other.
+
+        A single string value is also allowed.
+        ::
+            subelements = 'Edge1'
+
+    align: bool, optional
+        It defaults to `False`.
+        If it is `True` it will align `base_object` to tangent, normal,
+        or binormal to the `path_object`, depending on the value
+        of `tan_vector`.
+
+    align_mode: str, optional
+        It defaults to `'Original'` which is the traditional alignment.
+        It can also be `'Frenet'` or `'Tangent'`.
+
+        - Original. It does not calculate curve normal.
+          `X` is curve tangent, `Y` is normal parameter, Z is the cross
+          product `X` x `Y`.
+        - Frenet. It defines a local coordinate system along the path.
+          `X` is tanget to curve, `Y` is curve normal, `Z` is curve binormal.
+          If normal cannot be computed, for example, in a straight path,
+          a default is used.
+        - Tangent. It is similar to `'Original'` but includes a pre-rotation
+          to align the base object's `X` to the value of `tan_vector`,
+          then `X` follows curve tangent.
+
+    tan_vector: Base::Vector3, optional
+        It defaults to `App.Vector(1, 0, 0)` or the +X axis.
+        It aligns the tangent of the path to this local unit vector
+        of the object.
+
+    force_vertical: Base::Vector3, optional
+        It defaults to `False`.
+        If it is `True`, the value of `vertical_vector`
+        will be used when `align_mode` is `'Original'` or `'Tangent'`.
+
+    vertical_vector: Base::Vector3, optional
+        It defaults to `App.Vector(0, 0, 1)` or the +Z axis.
+        It will force this vector to be the vertical direction
+        when `force_vertical` is `True`.
+
+    use_link: bool, optional
+        It defaults to `True`, in which case the copies are `App::Link`
+        elements. Otherwise, the copies are shape copies which makes
+        the resulting array heavier.
+
+    Returns
+    -------
+    Part::FeaturePython
+        The scripted object of type `'PathArray'`.
+        Its `Shape` is a compound of the copies of the original object.
+
+    None
+        If there is a problem it will return `None`.
     """
+    _name = "make_path_array"
+    utils.print_header(_name, "Path array")
 
-    if not App.ActiveDocument:
-        App.Console.PrintError("No active document. Aborting\n")
-        return
+    found, doc = utils.find_doc(App.activeDocument())
+    if not found:
+        _err(_tr("No active document. Aborting."))
+        return None
+
+    if isinstance(base_object, str):
+        base_object_str = base_object
+
+    found, base_object = utils.find_object(base_object, doc)
+    if not found:
+        _msg("base_object: {}".format(base_object_str))
+        _err(_tr("Wrong input: object not in document."))
+        return None
+
+    _msg("base_object: {}".format(base_object.Label))
+
+    if isinstance(path_object, str):
+        path_object_str = path_object
+
+    found, path_object = utils.find_object(path_object, doc)
+    if not found:
+        _msg("path_object: {}".format(path_object_str))
+        _err(_tr("Wrong input: object not in document."))
+        return None
+
+    _msg("path_object: {}".format(path_object.Label))
+
+    _msg("count: {}".format(count))
+    try:
+        utils.type_check([(count, (int, float))],
+                         name=_name)
+    except TypeError:
+        _err(_tr("Wrong input: must be a number."))
+        return None
+    count = int(count)
+
+    _msg("xlate: {}".format(xlate))
+    try:
+        utils.type_check([(xlate, App.Vector)],
+                         name=_name)
+    except TypeError:
+        _err(_tr("Wrong input: must be a vector."))
+        return None
+
+    _msg("subelements: {}".format(subelements))
+    if subelements:
+        try:
+            # Make a list
+            if isinstance(subelements, str):
+                subelements = [subelements]
+
+            utils.type_check([(subelements, (list, tuple, str))],
+                             name=_name)
+        except TypeError:
+            _err(_tr("Wrong input: must be a list or tuple of strings. "
+                     "Or a single string."))
+            return None
+
+        # The subelements list is used to build a special list
+        # called a LinkSubList, which includes the path_object.
+        # Old style: [(path_object, "Edge1"), (path_object, "Edge2")]
+        # New style: [(path_object, ("Edge1", "Edge2"))]
+        #
+        # If a simple list is given ["a", "b"], this will create an old-style
+        # SubList.
+        # If a nested list is given [["a", "b"]], this will create a new-style
+        # SubList.
+        # In any case, the property of the object accepts both styles.
+        #
+        # If the old style is deprecated then this code should be updated
+        # to create new style lists exclusively.
+        sub_list = list()
+        for sub in subelements:
+            sub_list.append((path_object, sub))
+    else:
+        sub_list = None
+
+    align = bool(align)
+    _msg("align: {}".format(align))
+
+    _msg("align_mode: {}".format(align_mode))
+    try:
+        utils.type_check([(align_mode, str)],
+                         name=_name)
+
+        if align_mode not in ("Original", "Frenet", "Tangent"):
+            raise TypeError
+    except TypeError:
+        _err(_tr("Wrong input: must be "
+                 "'Original', 'Frenet', or 'Tangent'."))
+        return None
+
+    _msg("tan_vector: {}".format(tan_vector))
+    try:
+        utils.type_check([(tan_vector, App.Vector)],
+                         name=_name)
+    except TypeError:
+        _err(_tr("Wrong input: must be a vector."))
+        return None
+
+    force_vertical = bool(force_vertical)
+    _msg("force_vertical: {}".format(force_vertical))
+
+    _msg("vertical_vector: {}".format(vertical_vector))
+    try:
+        utils.type_check([(vertical_vector, App.Vector)],
+                         name=_name)
+    except TypeError:
+        _err(_tr("Wrong input: must be a vector."))
+        return None
+
+    use_link = bool(use_link)
+    _msg("use_link: {}".format(use_link))
 
     if use_link:
-        obj = App.ActiveDocument.addObject("Part::FeaturePython","PathArray", PathArray(None), None, True)
+        # The PathArray class must be called in this special way
+        # to make it a PathLinkArray
+        new_obj = doc.addObject("Part::FeaturePython", "PathArray",
+                                PathArray(None), None, True)
     else:
-        obj = App.ActiveDocument.addObject("Part::FeaturePython","PathArray")
-        PathArray(obj)
+        new_obj = doc.addObject("Part::FeaturePython", "PathArray")
+        PathArray(new_obj)
 
-    obj.Base = baseobject
-    obj.PathObj = pathobject
-
-    if pathobjsubs:
-        sl = []
-        for sub in pathobjsubs:
-            sl.append((obj.PathObj,sub))
-        obj.PathSubs = list(sl)
-
-    if count > 1:
-        obj.Count = count
-
-    if xlate:
-        obj.Xlate = xlate
-
-    obj.Align = align
+    new_obj.Base = base_object
+    new_obj.PathObj = path_object
+    new_obj.Count = count
+    new_obj.Xlate = xlate
+    new_obj.PathSubs = sub_list
+    new_obj.Align = align
+    new_obj.AlignMode = align_mode
+    new_obj.TangentVector = tan_vector
+    new_obj.ForceVertical = force_vertical
+    new_obj.VerticalVector = vertical_vector
 
     if App.GuiUp:
         if use_link:
-            ViewProviderDraftLink(obj.ViewObject)
+            ViewProviderDraftLink(new_obj.ViewObject)
         else:
-            ViewProviderDraftArray(obj.ViewObject)
-            gui_utils.formatObject(obj,obj.Base)
-            if hasattr(obj.Base.ViewObject, "DiffuseColor"):
-                if len(obj.Base.ViewObject.DiffuseColor) > 1:
-                    obj.ViewObject.Proxy.resetColors(obj.ViewObject)
-        baseobject.ViewObject.hide()
-        gui_utils.select(obj)
-    return obj
+            ViewProviderDraftArray(new_obj.ViewObject)
+            gui_utils.formatObject(new_obj, new_obj.Base)
+
+            if hasattr(new_obj.Base.ViewObject, "DiffuseColor"):
+                if len(new_obj.Base.ViewObject.DiffuseColor) > 1:
+                    new_obj.ViewObject.Proxy.resetColors(new_obj.ViewObject)
+
+        new_obj.Base.ViewObject.hide()
+        gui_utils.select(new_obj)
+
+    return new_obj
 
 
-makePathArray = make_path_array
+def makePathArray(baseobject, pathobject, count,
+                  xlate=None, align=False,
+                  pathobjsubs=[],
+                  use_link=False):
+    """Create PathArray. DEPRECATED. Use 'make_path_array'."""
+    utils.use_instead('make_path_array')
+
+    return make_path_array(baseobject, pathobject, count,
+                           xlate, pathobjsubs,
+                           align,
+                           use_link)

--- a/src/Mod/Draft/draftobjects/patharray.py
+++ b/src/Mod/Draft/draftobjects/patharray.py
@@ -126,6 +126,11 @@ class PathArray(DraftLink):
         else:
             properties = []
 
+        self.set_general_properties(obj, properties)
+        self.set_align_properties(obj, properties)
+
+    def set_general_properties(self, obj, properties):
+        """Set general properties only if they don't exist."""
         if "Base" not in properties:
             _tip = _tr("The base object that will be duplicated")
             obj.addProperty("App::PropertyLinkGlobal",
@@ -160,38 +165,22 @@ class PathArray(DraftLink):
             _tip = _tr("Number of copies to create")
             obj.addProperty("App::PropertyInteger",
                             "Count",
-                            "General",
+                            "Objects",
                             _tip)
             obj.Count = 4
 
-        if "Align" not in properties:
-            _tip = _tr("Orient the copies along the path depending "
-                       "on the 'Align Mode'.\n"
-                       "Otherwise the copies will have the same orientation "
-                       "as the original Base object.")
+        if self.use_link and "ExpandArray" not in properties:
+            _tip = _tr("Show the individual array elements "
+                       "(only for Link arrays)")
             obj.addProperty("App::PropertyBool",
-                            "Align",
-                            "Alignment",
+                            "ExpandArray",
+                            "Objects",
                             _tip)
-            obj.Align = False
+            obj.ExpandArray = False
+            obj.setPropertyStatus('Shape', 'Transient')
 
-        if "AlignMode" not in properties:
-            _tip = _tr("Method to orient the copies along the path.\n"
-                       "- Original, X is curve tangent, Y is normal, "
-                       "and Z is the cross product.\n"
-                       "- Frenet uses a local coordinate system along "
-                       "the path.\n"
-                       "- Tangent is similar to 'Original' but the local X "
-                       "axis is pre-aligned to 'Tangent Vector'.\n"
-                       "To get better results with 'Original' and 'Tangent' "
-                       "you may have to set 'Force Vertical' to true.")
-            obj.addProperty("App::PropertyEnumeration",
-                            "AlignMode",
-                            "Alignment",
-                            _tip)
-            obj.AlignMode = ['Original', 'Frenet', 'Tangent']
-            obj.AlignMode = 'Original'
-
+    def set_align_properties(self, obj, properties):
+        """Set general properties only if they don't exist."""
         if "Xlate" not in properties:
             _tip = _tr("Additional translation "
                        "that will be applied to each copy.\n"
@@ -212,8 +201,8 @@ class PathArray(DraftLink):
             obj.TangentVector = App.Vector(1, 0, 0)
 
         if "ForceVertical" not in properties:
-            _tip = _tr("Force use of 'Vertical Vector' as Z direction "
-                       "when using 'Original' or 'Tangent' align mode")
+            _tip = _tr("Force use of 'Vertical Vector' as local Z direction "
+                       "when using 'Original' or 'Tangent' alignment mode")
             obj.addProperty("App::PropertyBool",
                             "ForceVertical",
                             "Alignment",
@@ -229,15 +218,34 @@ class PathArray(DraftLink):
                             _tip)
             obj.VerticalVector = App.Vector(0, 0, 1)
 
-        if self.use_link and "ExpandArray" not in properties:
-            _tip = _tr("Show the individual array elements "
-                       "(only for Link arrays)")
-            obj.addProperty("App::PropertyBool",
-                            "ExpandArray",
-                            "General",
+        if "AlignMode" not in properties:
+            _tip = _tr("Method to orient the copies along the path.\n"
+                       "- Original: X is curve tangent, Y is normal, "
+                       "and Z is the cross product.\n"
+                       "- Frenet: aligns the object following the local "
+                       "coordinate system along the path.\n"
+                       "- Tangent: similar to 'Original' but the local X "
+                       "axis is pre-aligned to 'Tangent Vector'.\n"
+                       "\n"
+                       "To get better results with 'Original' or 'Tangent' "
+                       "you may have to set 'Force Vertical' to true.")
+            obj.addProperty("App::PropertyEnumeration",
+                            "AlignMode",
+                            "Alignment",
                             _tip)
-            obj.ExpandArray = False
-            obj.setPropertyStatus('Shape', 'Transient')
+            obj.AlignMode = ['Original', 'Frenet', 'Tangent']
+            obj.AlignMode = 'Original'
+
+        if "Align" not in properties:
+            _tip = _tr("Orient the copies along the path depending "
+                       "on the 'Align Mode'.\n"
+                       "Otherwise the copies will have the same orientation "
+                       "as the original Base object.")
+            obj.addProperty("App::PropertyBool",
+                            "Align",
+                            "Alignment",
+                            _tip)
+            obj.Align = False
 
     def linkSetup(self, obj):
         """Set up the object as a link object."""

--- a/src/Mod/Draft/draftobjects/patharray.py
+++ b/src/Mod/Draft/draftobjects/patharray.py
@@ -354,8 +354,9 @@ class PathArray(DraftLink):
 
         Add properties that don't exist.
         """
-        self.migrate_attributes(obj)
+        super(PathArray, self).migrate_attributes(obj)
         self.set_properties(obj)
+        self.migrate_properties_0v19(obj)
 
         if self.use_link:
             self.linkSetup(obj)
@@ -367,6 +368,28 @@ class PathArray(DraftLink):
                 self.buildShape(obj, obj.Placement, obj.PlacementList)
             else:
                 self.execute(obj)
+
+    def migrate_properties_0v19(self, obj):
+        """Migrate properties of this class, not from the parent class."""
+        properties = obj.PropertiesList
+
+        if "PathObj" in properties:
+            obj.PathObject = obj.PathObj
+            obj.removeProperty("PathObj")
+            _info = "'PathObj' property will be migrated to 'PathObject'"
+            _wrn("v0.19, " + obj.Label + ", " + _tr(_info))
+
+        if "PathSubs" in properties:
+            obj.PathSubelements = obj.PathSubs
+            obj.removeProperty("PathSubs")
+            _info = "'PathSubs' property will be migrated to 'PathSubelements'"
+            _wrn("v0.19, " + obj.Label + ", " + _tr(_info))
+
+        if "Xlate" in properties:
+            obj.ExtraTranslation = obj.Xlate
+            obj.removeProperty("Xlate")
+            _info = "'Xlate' property will be migrated to 'ExtraTranslation'"
+            _wrn("v0.19, " + obj.Label + ", " + _tr(_info))
 
 
 _PathArray = PathArray

--- a/src/Mod/Draft/draftobjects/patharray.py
+++ b/src/Mod/Draft/draftobjects/patharray.py
@@ -236,6 +236,8 @@ class PathArray(DraftLink):
             obj.AlignMode = ['Original', 'Frenet', 'Tangent']
             obj.AlignMode = 'Original'
 
+        # The Align property must be attached after other align properties
+        # so that onChanged works properly
         if "Align" not in properties:
             _tip = _tr("Orient the copies along the path depending "
                        "on the 'Align Mode'.\n"
@@ -311,6 +313,41 @@ class PathArray(DraftLink):
                 e = sub[0].Shape.getElement(n)
                 sl.append(e)
         return Part.Wire(sl)
+
+    def onChanged(self, obj, prop):
+        """Execute when a property is changed."""
+        super(PathArray, self).onChanged(obj, prop)
+        self.show_and_hide(obj, prop)
+
+    def show_and_hide(self, obj, prop):
+        """Show and hide the properties depending on the touched property."""
+        # The minus sign removes the Hidden property (show)
+        if prop == "Align":
+            if obj.Align:
+                for pr in ("AlignMode", "ForceVertical", "VerticalVector",
+                           "TangentVector"):
+                    obj.setPropertyStatus(pr, "-Hidden")
+            else:
+                for pr in ("AlignMode", "ForceVertical", "VerticalVector",
+                           "TangentVector"):
+                    obj.setPropertyStatus(pr, "Hidden")
+
+        if prop == "AlignMode":
+            if obj.AlignMode == "Original":
+                for pr in ("ForceVertical", "VerticalVector"):
+                    obj.setPropertyStatus(pr, "-Hidden")
+
+                obj.setPropertyStatus("TangentVector", "Hidden")
+
+            elif obj.AlignMode == "Frenet":
+                for pr in ("ForceVertical", "VerticalVector",
+                           "TangentVector"):
+                    obj.setPropertyStatus(pr, "Hidden")
+
+            elif obj.AlignMode == "Tangent":
+                for pr in ("ForceVertical", "VerticalVector",
+                           "TangentVector"):
+                    obj.setPropertyStatus(pr, "-Hidden")
 
     def onDocumentRestored(self, obj):
         """Execute code when the document is restored.

--- a/src/Mod/Draft/draftobjects/patharray.py
+++ b/src/Mod/Draft/draftobjects/patharray.py
@@ -139,27 +139,27 @@ class PathArray(DraftLink):
                             _tip)
             obj.Base = None
 
-        if "PathObj" not in properties:
+        if "PathObject" not in properties:
             _tip = _tr("The object along which "
                        "the copies will be distributed. "
                        "It must contain 'Edges'.")
             obj.addProperty("App::PropertyLinkGlobal",
-                            "PathObj",
+                            "PathObject",
                             "Objects",
                             _tip)
-            obj.PathObj = None
+            obj.PathObject = None
 
-        if "PathSubs" not in properties:
+        if "PathSubelements" not in properties:
             _tip = _tr("List of connected edges in the 'Path Object'.\n"
                        "If these are present, the copies will be created "
                        "along these subelements only.\n"
                        "Leave this property empty to create copies along "
                        "the entire 'Path Object'.")
             obj.addProperty("App::PropertyLinkSubListGlobal",
-                            "PathSubs",
+                            "PathSubelements",
                             "Objects",
                             _tip)
-            obj.PathSubs = []
+            obj.PathSubelements = []
 
         if "Count" not in properties:
             _tip = _tr("Number of copies to create")
@@ -181,16 +181,16 @@ class PathArray(DraftLink):
 
     def set_align_properties(self, obj, properties):
         """Set general properties only if they don't exist."""
-        if "Xlate" not in properties:
+        if "ExtraTranslation" not in properties:
             _tip = _tr("Additional translation "
                        "that will be applied to each copy.\n"
                        "This is useful to adjust for the difference "
                        "between shape centre and shape reference point.")
             obj.addProperty("App::PropertyVectorDistance",
-                            "Xlate",
+                            "ExtraTranslation",
                             "Alignment",
                             _tip)
-            obj.Xlate = App.Vector(0, 0, 0)
+            obj.ExtraTranslation = App.Vector(0, 0, 0)
 
         if "TangentVector" not in properties:
             _tip = _tr("Alignment vector for 'Tangent' mode")
@@ -256,15 +256,15 @@ class PathArray(DraftLink):
 
     def execute(self, obj):
         """Execute when the object is created or recomputed."""
-        if not obj.Base or not obj.PathObj:
+        if not obj.Base or not obj.PathObject:
             return
 
         # placement of entire PathArray object
         array_placement = obj.Placement
 
-        w = self.get_wires(obj.PathObj, obj.PathSubs)
+        w = self.get_wires(obj.PathObject, obj.PathSubelements)
         if not w:
-            _err(obj.PathObj.Label
+            _err(obj.PathObject.Label
                  + _tr(", path object doesn't have 'Edges'."))
             return
 
@@ -282,7 +282,7 @@ class PathArray(DraftLink):
 
         copy_placements = placements_on_path(final_rotation,
                                              w, obj.Count,
-                                             obj.Xlate,
+                                             obj.ExtraTranslation,
                                              obj.Align, obj.AlignMode,
                                              obj.ForceVertical,
                                              obj.VerticalVector)
@@ -305,7 +305,7 @@ class PathArray(DraftLink):
         return w
 
     def get_wire_from_subelements(self, subelements):
-        """Make a wire from PathObj subelements."""
+        """Make a wire from the path object subelements."""
         sl = []
         for sub in subelements:
             edgeNames = sub[1]

--- a/src/Mod/Draft/drafttests/test_modification.py
+++ b/src/Mod/Draft/drafttests/test_modification.py
@@ -468,11 +468,13 @@ class DraftModification(unittest.TestCase):
 
         number = 4
         translation = Vector(0, 1, 0)
+        subelements = "Edge1"
         align = False
         _msg("  Path Array")
         _msg("  number={}, translation={}".format(number, translation))
-        _msg("  align={}".format(align))
-        obj = Draft.make_path_array(poly, wire, number, translation, align)
+        _msg("  subelements={}, align={}".format(subelements, align))
+        obj = Draft.make_path_array(poly, wire, number,
+                                    translation, subelements, align)
         self.assertTrue(obj, "'{}' failed".format(operation))
 
     def test_point_array(self):


### PR DESCRIPTION
General cleaning of the code, PEP8 style, in the make function, Gui Command, and also the internal proxy object. This continues the improvements done in #3488 and #3519.

The properties were renamed to be more verbose and self explanatory. The properties are migrated from older files. The tooltips were also improved to give more information to the user.

The update logic (`execute`) was modified a little in order to avoid repeating the code. The rotation is changed once depending on the options, but the same function is called in all situations to build the array.

The proxy object hides the properties that are not relevant for the selected `AlignMode`.

The make function now accepts a label, and not only an object reference. All parameters that you can pass to the make function have type checking to make sure that only valid input goes to the internal proxy object.
```py
Draft.make_path_array("Circle", "BSpline", ...)
```

The Gui Command now uses the `todo` class so it records the command to the Python console like most Draft commands already do.

This must be merged after the support functions are merged, #3528.

Forum thread: [Making the creation of arrays more user friendly](https://forum.freecadweb.org/viewtopic.php?f=23&t=41816&p=403957#p403957)

---

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists