### PR TITLE
Draft: Array class cleanup

### DIFF
--- a/src/Mod/Draft/draftguitools/gui_circulararray.py
+++ b/src/Mod/Draft/draftguitools/gui_circulararray.py
@@ -32,11 +32,12 @@ import FreeCAD as App
 import FreeCADGui as Gui
 import Draft
 import Draft_rc  # include resources, icons, ui files
+import draftutils.todo as todo
+
 from draftutils.messages import _msg, _log
 from draftutils.translate import _tr
 from draftguitools import gui_base
 from drafttaskpanels import task_circulararray
-import draftutils.todo as todo
 
 # The module is used to prevent complaints from code checkers (flake8)
 bool(Draft_rc.__name__)
@@ -58,11 +59,12 @@ class CircularArray(gui_base.GuiCommandBase):
 
     def GetResources(self):
         """Set icon, menu and tooltip."""
-        _tip = ("Creates copies of a selected object, "
-                "and places the copies in a circular pattern.\n"
-                "The properties of the array can be further modified after "
-                "the new object is created, including turning it into "
-                "a different type of array.")
+        _tip = ("Creates copies of the selected object, "
+                "and places the copies in a radial pattern\n"
+                "creating various circular layers.\n"
+                "\n"
+                "The array can be turned into an orthogonal "
+                "or a polar array by changing its type.")
 
         d = {'Pixmap': 'Draft_CircularArray',
              'MenuText': QT_TRANSLATE_NOOP("Draft", "Circular array"),

--- a/src/Mod/Draft/draftguitools/gui_orthoarray.py
+++ b/src/Mod/Draft/draftguitools/gui_orthoarray.py
@@ -32,11 +32,12 @@ import FreeCAD as App
 import FreeCADGui as Gui
 import Draft
 import Draft_rc  # include resources, icons, ui files
+import draftutils.todo as todo
+
 from draftutils.messages import _msg, _log
 from draftutils.translate import _tr
 from draftguitools import gui_base
 from drafttaskpanels import task_orthoarray
-import draftutils.todo as todo
 
 # The module is used to prevent complaints from code checkers (flake8)
 bool(Draft_rc.__name__)
@@ -58,11 +59,13 @@ class OrthoArray(gui_base.GuiCommandBase):
 
     def GetResources(self):
         """Set icon, menu and tooltip."""
-        _tip = ("Creates copies of a selected object, "
-                "and places the copies in an orthogonal pattern.\n"
-                "The properties of the array can be further modified after "
-                "the new object is created, including turning it into "
-                "a different type of array.")
+        _tip = ("Creates copies of the selected object, "
+                "and places the copies in an orthogonal pattern,\n"
+                "meaning the copies follow the specified direction "
+                "in the X, Y, Z axes.\n"
+                "\n"
+                "The array can be turned into a polar or a circular array "
+                "by changing its type.")
 
         d = {'Pixmap': 'Draft_Array',
              'MenuText': QT_TRANSLATE_NOOP("Draft", "Array"),

--- a/src/Mod/Draft/draftguitools/gui_polararray.py
+++ b/src/Mod/Draft/draftguitools/gui_polararray.py
@@ -32,11 +32,12 @@ import FreeCAD as App
 import FreeCADGui as Gui
 import Draft
 import Draft_rc  # include resources, icons, ui files
+import draftutils.todo as todo
+
 from draftutils.messages import _msg, _log
 from draftutils.translate import _tr
 from draftguitools import gui_base
 from drafttaskpanels import task_polararray
-import draftutils.todo as todo
 
 # The module is used to prevent complaints from code checkers (flake8)
 bool(Draft_rc.__name__)
@@ -58,11 +59,12 @@ class PolarArray(gui_base.GuiCommandBase):
 
     def GetResources(self):
         """Set icon, menu and tooltip."""
-        _tip = ("Creates copies of a selected object, "
-                "and places the copies in a polar pattern.\n"
-                "The properties of the array can be further modified after "
-                "the new object is created, including turning it into "
-                "a different type of array.")
+        _tip = ("Creates copies of the selected object, "
+                "and places the copies in a polar pattern\n"
+                "defined by a center of rotation and its angle.\n"
+                "\n"
+                "The array can be turned into an orthogonal "
+                "or a circular array by changing its type.")
 
         d = {'Pixmap': 'Draft_PolarArray',
              'MenuText': QT_TRANSLATE_NOOP("Draft", "Polar array"),

--- a/src/Mod/Draft/draftmake/make_orthoarray.py
+++ b/src/Mod/Draft/draftmake/make_orthoarray.py
@@ -26,14 +26,155 @@
 # \brief Provides functions for creating orthogonal arrays in 2D and 3D.
 
 import FreeCAD as App
-import Draft
-# import draftmake.make_array as make_array
+
+import draftmake.make_array as make_array
 import draftutils.utils as utils
+
 from draftutils.messages import _msg, _wrn, _err
 from draftutils.translate import _tr
 
 
-def make_ortho_array(obj,
+def _make_ortho_array(base_object,
+                      v_x=App.Vector(10, 0, 0),
+                      v_y=App.Vector(0, 10, 0),
+                      v_z=App.Vector(0, 0, 10),
+                      n_x=2,
+                      n_y=2,
+                      n_z=1,
+                      use_link=True):
+    """Create an orthogonal array from the given object.
+
+    This is a simple wrapper of the `draftmake.make_array.make_array`
+    function to be used by the different orthogonal arrays.
+
+    - `make_ortho_array`
+    - `make_ortho_array2d`, no Z direction
+    - `make_rect_array`, strictly rectangular
+    - `make_rect_array2d`, strictly rectangular, no Z direction
+
+    This function has no error checking, nor does it display messages.
+    This should be handled by the subfunctions that use this one.
+    """
+    _name = "_make_ortho_array"
+    utils.print_header(_name, _tr("Internal orthogonal array"), debug=False)
+
+    new_obj = make_array.make_array(base_object,
+                                    arg1=v_x, arg2=v_y, arg3=v_z,
+                                    arg4=n_x, arg5=n_y, arg6=n_z,
+                                    use_link=use_link)
+    return new_obj
+
+
+def _are_vectors(v_x, v_y, v_z=None, name="Unknown"):
+    """Check that the vectors are numbers."""
+    _msg("v_x: {}".format(v_x))
+    _msg("v_y: {}".format(v_y))
+    if v_z:
+        _msg("v_z: {}".format(v_z))
+
+    try:
+        if v_z:
+            utils.type_check([(v_x, (int, float, App.Vector)),
+                              (v_y, (int, float, App.Vector)),
+                              (v_z, (int, float, App.Vector))],
+                             name=name)
+        else:
+            utils.type_check([(v_x, (int, float, App.Vector)),
+                              (v_y, (int, float, App.Vector))],
+                             name=name)
+    except TypeError:
+        _err(_tr("Wrong input: must be a number or vector."))
+        return False, v_x, v_y, v_z
+
+    _text = "Input: single value expanded to vector."
+    if not isinstance(v_x, App.Vector):
+        v_x = App.Vector(v_x, 0, 0)
+        _wrn(_tr(_text))
+    if not isinstance(v_y, App.Vector):
+        v_y = App.Vector(0, v_y, 0)
+        _wrn(_tr(_text))
+    if v_z and not isinstance(v_z, App.Vector):
+        v_z = App.Vector(0, 0, v_z)
+        _wrn(_tr(_text))
+
+    return True, v_x, v_y, v_z
+
+
+def _are_integers(n_x, n_y, n_z=None, name="Unknown"):
+    """Check that the numbers are integers, with minimum value of 1."""
+    _msg("n_x: {}".format(n_x))
+    _msg("n_y: {}".format(n_y))
+    if n_z:
+        _msg("n_z: {}".format(n_z))
+
+    try:
+        if n_z:
+            utils.type_check([(n_x, int),
+                              (n_y, int),
+                              (n_z, int)], name=name)
+        else:
+            utils.type_check([(n_x, int),
+                              (n_y, int)], name=name)
+    except TypeError:
+        _err(_tr("Wrong input: must be an integer number."))
+        return False, n_x, n_y, n_z
+
+    _text = ("Input: number of elements must be at least 1. "
+             "It is set to 1.")
+    if n_x < 1:
+        _wrn(_tr(_text))
+        n_x = 1
+    if n_y < 1:
+        _wrn(_tr(_text))
+        n_y = 1
+    if n_z and n_z < 1:
+        _wrn(_tr(_text))
+        n_z = 1
+
+    return True, n_x, n_y, n_z
+
+
+def _are_numbers(d_x, d_y, d_z=None, name="Unknown"):
+    """Check that the numbers are numbers."""
+    _msg("d_x: {}".format(d_x))
+    _msg("d_y: {}".format(d_y))
+    if d_z:
+        _msg("d_z: {}".format(d_z))
+
+    try:
+        if d_z:
+            utils.type_check([(d_x, (int, float)),
+                              (d_y, (int, float)),
+                              (d_z, (int, float))], name=name)
+        else:
+            utils.type_check([(d_x, (int, float)),
+                              (d_y, (int, float))], name=name)
+    except TypeError:
+        _err(_tr("Wrong input: must be a number."))
+        return False, d_x, d_y, d_z
+
+    return True, d_x, d_y, d_z
+
+
+def _find_object_in_doc(base_object, doc=None):
+    """Check that a document is available and the object exists."""
+    FOUND = True
+    if isinstance(base_object, str):
+        base_object_str = base_object
+
+    found, base_object = utils.find_object(base_object,
+                                           doc=doc)
+    if not found:
+        _msg("base_object: {}".format(base_object_str))
+        _err(_tr("Wrong input: object not in document."))
+        return not FOUND, base_object
+
+    _msg("base_object: {}".format(base_object.Label))
+
+    return FOUND, base_object
+
+
+def make_ortho_array(base_object,
                      v_x=App.Vector(10, 0, 0),
                      v_y=App.Vector(0, 10, 0),
                      v_z=App.Vector(0, 0, 10),
@@ -45,11 +186,12 @@ def make_ortho_array(obj,
 
     Parameters
     ----------
-    obj: Part::Feature
-        Any type of object that has a `Part::TopoShape`
-        that can be duplicated.
-        This means most 2D and 3D objects produced
-        with any workbench.
+    base_object: Part::Feature or str
+        Any of object that has a `Part::TopoShape` that can be duplicated.
+        This means most 2D and 3D objects produced with any workbench.
+        If it is a string, it must be the `Label` of that object.
+        Since a label is not guaranteed to be unique in a document,
+        it will use the first object found with this label.
 
     v_x, v_y, v_z: Base::Vector3, optional
         The vector indicating the vector displacement between two elements
@@ -99,13 +241,13 @@ def make_ortho_array(obj,
 
         The values of `n_x` and `n_y` default to 2,
         while `n_z` defaults to 1.
-        This means the array by default is a planar array.
+        This means the array is a planar array by default.
 
     use_link: bool, optional
         It defaults to `True`.
         If it is `True` the produced copies are not `Part::TopoShape` copies,
         but rather `App::Link` objects.
-        The Links repeat the shape of the original `obj` exactly,
+        The Links repeat the shape of the original `base_object` exactly,
         and therefore the resulting array is more memory efficient.
 
         Also, when `use_link` is `True`, the `Fuse` property
@@ -120,75 +262,44 @@ def make_ortho_array(obj,
     Returns
     -------
     Part::FeaturePython
-        A scripted object with `Proxy.Type='Array'`.
+        A scripted object of type `'Array'`.
         Its `Shape` is a compound of the copies of the original object.
+
+    None
+        If there is a problem it will return `None`.
 
     See Also
     --------
-    make_ortho_array2d, make_rect_array, make_rect_array2d
+    make_ortho_array2d, make_rect_array, make_rect_array2d, make_polar_array,
+    make_circular_array, make_path_array, make_point_array
     """
     _name = "make_ortho_array"
     utils.print_header(_name, _tr("Orthogonal array"))
 
-    _msg("v_x: {}".format(v_x))
-    _msg("v_y: {}".format(v_y))
-    _msg("v_z: {}".format(v_z))
-
-    try:
-        utils.type_check([(v_x, (int, float, App.Vector)),
-                          (v_y, (int, float, App.Vector)),
-                          (v_z, (int, float, App.Vector))],
-                         name=_name)
-    except TypeError:
-        _err(_tr("Wrong input: must be a number or vector."))
+    found, base_object = _find_object_in_doc(base_object,
+                                             doc=App.activeDocument())
+    if not found:
         return None
 
-    _text = "Input: single value expanded to vector."
-    if not isinstance(v_x, App.Vector):
-        v_x = App.Vector(v_x, 0, 0)
-        _wrn(_tr(_text))
-    if not isinstance(v_y, App.Vector):
-        v_y = App.Vector(0, v_y, 0)
-        _wrn(_tr(_text))
-    if not isinstance(v_z, App.Vector):
-        v_z = App.Vector(0, 0, v_z)
-        _wrn(_tr(_text))
-
-    _msg("n_x: {}".format(n_x))
-    _msg("n_y: {}".format(n_y))
-    _msg("n_z: {}".format(n_z))
-
-    try:
-        utils.type_check([(n_x, int),
-                          (n_y, int),
-                          (n_z, int)], name=_name)
-    except TypeError:
-        _err(_tr("Wrong input: must be an integer number."))
+    ok, v_x, v_y, v_z = _are_vectors(v_x, v_y, v_z, name=_name)
+    if not ok:
         return None
 
-    _text = ("Input: number of elements must be at least 1. "
-             "It is set to 1.")
-    if n_x < 1:
-        _wrn(_tr(_text))
-        n_x = 1
-    if n_y < 1:
-        _wrn(_tr(_text))
-        n_y = 1
-    if n_z < 1:
-        _wrn(_tr(_text))
-        n_z = 1
+    ok, n_x, n_y, n_z = _are_integers(n_x, n_y, n_z, name=_name)
+    if not ok:
+        return None
 
-    _msg("use_link: {}".format(bool(use_link)))
+    use_link = bool(use_link)
+    _msg("use_link: {}".format(use_link))
 
-    # new_obj = make_array.make_array()
-    new_obj = Draft.makeArray(obj,
-                              arg1=v_x, arg2=v_y, arg3=v_z,
-                              arg4=n_x, arg5=n_y, arg6=n_z,
-                              use_link=use_link)
+    new_obj = _make_ortho_array(base_object,
+                                v_x=v_x, v_y=v_y, v_z=v_z,
+                                n_x=n_x, n_y=n_y, n_z=n_z,
+                                use_link=use_link)
     return new_obj
 
 
-def make_ortho_array2d(obj,
+def make_ortho_array2d(base_object,
                        v_x=App.Vector(10, 0, 0),
                        v_y=App.Vector(0, 10, 0),
                        n_x=2,
@@ -202,11 +313,12 @@ def make_ortho_array2d(obj,
 
     Parameters
     ----------
-    obj: Part::Feature
-        Any type of object that has a `Part::TopoShape`
-        that can be duplicated.
-        This means most 2D and 3D objects produced
-        with any workbench.
+    base_object: Part::Feature or str
+        Any of object that has a `Part::TopoShape` that can be duplicated.
+        This means most 2D and 3D objects produced with any workbench.
+        If it is a string, it must be the `Label` of that object.
+        Since a label is not guaranteed to be unique in a document,
+        it will use the first object found with this label.
 
     v_x, v_y: Base::Vector3, optional
         Vectorial displacement of elements
@@ -225,65 +337,44 @@ def make_ortho_array2d(obj,
     Returns
     -------
     Part::FeaturePython
-        A scripted object with `Proxy.Type='Array'`.
+        A scripted object of type `'Array'`.
         Its `Shape` is a compound of the copies of the original object.
+
+    None
+        If there is a problem it will return `None`.
 
     See Also
     --------
-    make_ortho_array, make_rect_array, make_rect_array2d
+    make_ortho_array, make_rect_array, make_rect_array2d, make_polar_array,
+    make_circular_array, make_path_array, make_point_array
     """
     _name = "make_ortho_array2d"
     utils.print_header(_name, _tr("Orthogonal array 2D"))
 
-    _msg("v_x: {}".format(v_x))
-    _msg("v_y: {}".format(v_y))
-
-    try:
-        utils.type_check([(v_x, (int, float, App.Vector)),
-                          (v_y, (int, float, App.Vector))],
-                         name=_name)
-    except TypeError:
-        _err(_tr("Wrong input: must be a number or vector."))
+    found, base_object = _find_object_in_doc(base_object,
+                                             doc=App.activeDocument())
+    if not found:
         return None
 
-    _text = "Input: single value expanded to vector."
-    if not isinstance(v_x, App.Vector):
-        v_x = App.Vector(v_x, 0, 0)
-        _wrn(_tr(_text))
-    if not isinstance(v_y, App.Vector):
-        v_y = App.Vector(0, v_y, 0)
-        _wrn(_tr(_text))
-
-    _msg("n_x: {}".format(n_x))
-    _msg("n_y: {}".format(n_y))
-
-    try:
-        utils.type_check([(n_x, int),
-                          (n_y, int)], name=_name)
-    except TypeError:
-        _err(_tr("Wrong input: must be an integer number."))
+    ok, v_x, v_y, __ = _are_vectors(v_x, v_y, v_z=None, name=_name)
+    if not ok:
         return None
 
-    _text = ("Input: number of elements must be at least 1. "
-             "It is set to 1.")
-    if n_x < 1:
-        _wrn(_tr(_text))
-        n_x = 1
-    if n_y < 1:
-        _wrn(_tr(_text))
-        n_y = 1
+    ok, n_x, n_y, __ = _are_integers(n_x, n_y, n_z=None, name=_name)
+    if not ok:
+        return None
 
-    _msg("use_link: {}".format(bool(use_link)))
+    use_link = bool(use_link)
+    _msg("use_link: {}".format(use_link))
 
-    # new_obj = make_array.make_array()
-    new_obj = Draft.makeArray(obj,
-                              arg1=v_x, arg2=v_y,
-                              arg3=n_x, arg4=n_y,
-                              use_link=use_link)
+    new_obj = _make_ortho_array(base_object,
+                                v_x=v_x, v_y=v_y,
+                                n_x=n_x, n_y=n_y,
+                                use_link=use_link)
     return new_obj
 
 
-def make_rect_array(obj,
+def make_rect_array(base_object,
                     d_x=10,
                     d_y=10,
                     d_z=10,
@@ -300,11 +391,12 @@ def make_rect_array(obj,
 
     Parameters
     ----------
-    obj: Part::Feature
-        Any type of object that has a `Part::TopoShape`
-        that can be duplicated.
-        This means most 2D and 3D objects produced
-        with any workbench.
+    base_object: Part::Feature or str
+        Any of object that has a `Part::TopoShape` that can be duplicated.
+        This means most 2D and 3D objects produced with any workbench.
+        If it is a string, it must be the `Label` of that object.
+        Since a label is not guaranteed to be unique in a document,
+        it will use the first object found with this label.
 
     d_x, d_y, d_z: Base::Vector3, optional
         Displacement of elements in the corresponding X, Y, and Z directions.
@@ -319,41 +411,48 @@ def make_rect_array(obj,
     Returns
     -------
     Part::FeaturePython
-        A scripted object with `Proxy.Type='Array'`.
+        A scripted object of type `'Array'`.
         Its `Shape` is a compound of the copies of the original object.
+
+    None
+        If there is a problem it will return `None`.
 
     See Also
     --------
-    make_ortho_array, make_ortho_array2d, make_rect_array2d
+    make_ortho_array, make_ortho_array2d, make_rect_array2d, make_polar_array,
+    make_circular_array, make_path_array, make_point_array
     """
     _name = "make_rect_array"
     utils.print_header(_name, _tr("Rectangular array"))
 
-    _msg("d_x: {}".format(d_x))
-    _msg("d_y: {}".format(d_y))
-    _msg("d_z: {}".format(d_z))
-
-    try:
-        utils.type_check([(d_x, (int, float)),
-                          (d_y, (int, float)),
-                          (d_z, (int, float))],
-                         name=_name)
-    except TypeError:
-        _err(_tr("Wrong input: must be a number."))
+    found, base_object = _find_object_in_doc(base_object,
+                                             doc=App.activeDocument())
+    if not found:
         return None
 
-    new_obj = make_ortho_array(obj,
-                               v_x=App.Vector(d_x, 0, 0),
-                               v_y=App.Vector(0, d_y, 0),
-                               v_z=App.Vector(0, 0, d_z),
-                               n_x=n_x,
-                               n_y=n_y,
-                               n_z=n_z,
-                               use_link=use_link)
+    ok, d_x, d_y, d_z = _are_numbers(d_x, d_y, d_z, name=_name)
+    if not ok:
+        return None
+
+    ok, n_x, n_y, n_z = _are_integers(n_x, n_y, n_z, _name)
+    if not ok:
+        return None
+
+    use_link = bool(use_link)
+    _msg("use_link: {}".format(use_link))
+
+    new_obj = _make_ortho_array(base_object,
+                                v_x=App.Vector(d_x, 0, 0),
+                                v_y=App.Vector(0, d_y, 0),
+                                v_z=App.Vector(0, 0, d_z),
+                                n_x=n_x,
+                                n_y=n_y,
+                                n_z=n_z,
+                                use_link=use_link)
     return new_obj
 
 
-def make_rect_array2d(obj,
+def make_rect_array2d(base_object,
                       d_x=10,
                       d_y=10,
                       n_x=2,
@@ -361,18 +460,20 @@ def make_rect_array2d(obj,
                       use_link=True):
     """Create a 2D rectangular array from the given object.
 
-    This function wraps around `make_ortho_array2d`
+    This function wraps around `make_ortho_array`,
     to produce strictly rectangular arrays, in which
     the displacement vectors `v_x` and `v_y`
     only have their respective components in X and Y.
+    The Z component is ignored.
 
     Parameters
     ----------
-    obj: Part::Feature
-        Any type of object that has a `Part::TopoShape`
-        that can be duplicated.
-        This means most 2D and 3D objects produced
-        with any workbench.
+    base_object: Part::Feature or str
+        Any of object that has a `Part::TopoShape` that can be duplicated.
+        This means most 2D and 3D objects produced with any workbench.
+        If it is a string, it must be the `Label` of that object.
+        Since a label is not guaranteed to be unique in a document,
+        it will use the first object found with this label.
 
     d_x, d_y: Base::Vector3, optional
         Displacement of elements in the corresponding X and Y directions.
@@ -387,31 +488,40 @@ def make_rect_array2d(obj,
     Returns
     -------
     Part::FeaturePython
-        A scripted object with `Proxy.Type='Array'`.
+        A scripted object of type `'Array'`.
         Its `Shape` is a compound of the copies of the original object.
+
+    None
+        If there is a problem it will return `None`.
 
     See Also
     --------
-    make_ortho_array, make_ortho_array2d, make_rect_array
+    make_ortho_array, make_ortho_array2d, make_rect_array, make_polar_array,
+    make_circular_array, make_path_array, make_point_array
     """
     _name = "make_rect_array2d"
     utils.print_header(_name, _tr("Rectangular array 2D"))
 
-    _msg("d_x: {}".format(d_x))
-    _msg("d_y: {}".format(d_y))
-
-    try:
-        utils.type_check([(d_x, (int, float)),
-                          (d_y, (int, float))],
-                         name=_name)
-    except TypeError:
-        _err(_tr("Wrong input: must be a number."))
+    found, base_object = _find_object_in_doc(base_object,
+                                             doc=App.activeDocument())
+    if not found:
         return None
 
-    new_obj = make_ortho_array2d(obj,
-                                 v_x=App.Vector(d_x, 0, 0),
-                                 v_y=App.Vector(0, d_y, 0),
-                                 n_x=n_x,
-                                 n_y=n_y,
-                                 use_link=use_link)
+    ok, d_x, d_y, __ = _are_numbers(d_x, d_y, d_z=None, name=_name)
+    if not ok:
+        return None
+
+    ok, n_x, n_y, __ = _are_integers(n_x, n_y, n_z=None, name=_name)
+    if not ok:
+        return None
+
+    use_link = bool(use_link)
+    _msg("use_link: {}".format(use_link))
+
+    new_obj = _make_ortho_array(base_object,
+                                v_x=App.Vector(d_x, 0, 0),
+                                v_y=App.Vector(0, d_y, 0),
+                                n_x=n_x,
+                                n_y=n_y,
+                                use_link=use_link)
     return new_obj

--- a/src/Mod/Draft/draftmake/make_polararray.py
+++ b/src/Mod/Draft/draftmake/make_polararray.py
@@ -26,29 +26,31 @@
 # \brief Provides functions for creating polar arrays in a plane.
 
 import FreeCAD as App
-import Draft
-# import draftmake.make_array as make_array
+
+import draftmake.make_array as make_array
 import draftutils.utils as utils
+
 from draftutils.messages import _msg, _err
 from draftutils.translate import _tr
 
 
-def make_polar_array(obj,
-                     number=4, angle=360, center=App.Vector(0, 0, 0),
+def make_polar_array(base_object,
+                     number=5, angle=360, center=App.Vector(0, 0, 0),
                      use_link=True):
     """Create a polar array from the given object.
 
     Parameters
     ----------
-    obj: Part::Feature
-        Any type of object that has a `Part::TopoShape`
-        that can be duplicated.
-        This means most 2D and 3D objects produced
-        with any workbench.
+    base_object: Part::Feature or str
+        Any of object that has a `Part::TopoShape` that can be duplicated.
+        This means most 2D and 3D objects produced with any workbench.
+        If it is a string, it must be the `Label` of that object.
+        Since a label is not guaranteed to be unique in a document,
+        it will use the first object found with this label.
 
     number: int, optional
-        It defaults to 4.
-        The number of copies produced in the circular pattern.
+        It defaults to 5.
+        The number of copies produced in the polar pattern.
 
     angle: float, optional
         It defaults to 360.
@@ -77,38 +79,56 @@ def make_polar_array(obj,
     Returns
     -------
     Part::FeaturePython
-        A scripted object with `Proxy.Type='Array'`.
+        A scripted object of type `'Array'`.
         Its `Shape` is a compound of the copies of the original object.
+
+    None
+        If there is a problem it will return `None`.
+
+    See Also
+    --------
+    make_ortho_array, make_circular_array, make_path_array, make_point_array
     """
     _name = "make_polar_array"
     utils.print_header(_name, _tr("Polar array"))
 
-    _msg("Number: {}".format(number))
-    _msg("Angle: {}".format(angle))
-    _msg("Center: {}".format(center))
+    if isinstance(base_object, str):
+        base_object_str = base_object
 
+    found, base_object = utils.find_object(base_object,
+                                           doc=App.activeDocument())
+    if not found:
+        _msg("base_object: {}".format(base_object_str))
+        _err(_tr("Wrong input: object not in document."))
+        return None
+
+    _msg("base_object: {}".format(base_object.Label))
+
+    _msg("number: {}".format(number))
     try:
         utils.type_check([(number, int)], name=_name)
     except TypeError:
         _err(_tr("Wrong input: must be an integer number."))
         return None
 
+    _msg("angle: {}".format(angle))
     try:
         utils.type_check([(angle, (int, float))], name=_name)
     except TypeError:
         _err(_tr("Wrong input: must be a number."))
         return None
 
+    _msg("center: {}".format(center))
     try:
         utils.type_check([(center, App.Vector)], name=_name)
     except TypeError:
         _err(_tr("Wrong input: must be a vector."))
         return None
 
-    _msg("use_link: {}".format(bool(use_link)))
+    use_link = bool(use_link)
+    _msg("use_link: {}".format(use_link))
 
-    # new_obj = make_array.make_array()
-    new_obj = Draft.makeArray(obj,
-                              arg1=center, arg2=angle, arg3=number,
-                              use_link=use_link)
+    new_obj = make_array.make_array(base_object,
+                                    arg1=center, arg2=angle, arg3=number,
+                                    use_link=use_link)
     return new_obj

--- a/src/Mod/Draft/draftobjects/array.py
+++ b/src/Mod/Draft/draftobjects/array.py
@@ -54,152 +54,235 @@ class Array(DraftLink):
         super(Array, self).__init__(obj, "Array")
 
     def attach(self, obj):
-        _tip = "The base object that must be duplicated"
-        obj.addProperty("App::PropertyLink",
-                        "Base",
-                        "Objects",
-                        QT_TRANSLATE_NOOP("App::Property", _tip))
+        """Set up the properties when the object is attached."""
+        self.set_properties(obj)
+        super(Array, self).attach(obj)
 
-        _tip = "The type of array to create"
-        obj.addProperty("App::PropertyEnumeration",
-                        "ArrayType",
-                        "Draft",
-                        QT_TRANSLATE_NOOP("App::Property", _tip))
+    def set_properties(self, obj):
+        """Set properties only if they don't exist."""
+        self.set_ortho_properties(obj)
+        self.set_polar_circular_properties(obj)
+        self.set_polar_properties(obj)
+        self.set_circular_properties(obj)
 
-        _tip = "The axis (e.g. DatumLine) overriding Axis/Center"
-        obj.addProperty("App::PropertyLinkGlobal",
-                        "AxisReference",
-                        "Objects",
-                        QT_TRANSLATE_NOOP("App::Property", _tip))
+        self.set_general_properties(obj)
+        self.set_link_properties(obj)
 
-        _tip = "The axis direction"
-        obj.addProperty("App::PropertyVector",
-                        "Axis",
-                        "Parameters",
-                        QT_TRANSLATE_NOOP("App::Property", _tip))
+    def set_general_properties(self, obj):
+        """Set general properties only if they don't exist."""
+        properties = obj.PropertiesList
 
-        _tip = "Number of copies in X direction"
-        obj.addProperty("App::PropertyInteger",
-                        "NumberX",
-                        "Parameters",
-                        QT_TRANSLATE_NOOP("App::Property", _tip))
+        if "Base" not in properties:
+            _tip = "The base object that will be duplicated"
+            obj.addProperty("App::PropertyLink",
+                            "Base",
+                            "Objects",
+                            QT_TRANSLATE_NOOP("App::Property", _tip))
+            obj.Base = None
 
-        _tip = "Number of copies in Y direction"
-        obj.addProperty("App::PropertyInteger",
-                        "NumberY",
-                        "Parameters",
-                        QT_TRANSLATE_NOOP("App::Property", _tip))
+        if "ArrayType" not in properties:
+            _tip = ("The type of array to create.\n"
+                    "- Ortho: places the copies in the direction "
+                    "of the global X, Y, Z axes.\n"
+                    "- Polar: places the copies along a circular arc, "
+                    "up to a specified angle, and with certain orientation "
+                    "defined by a center and an axis.\n"
+                    "- Circular: places the copies in concentric circular "
+                    "layers around the base object.")
+            obj.addProperty("App::PropertyEnumeration",
+                            "ArrayType",
+                            "Objects",
+                            QT_TRANSLATE_NOOP("App::Property", _tip))
+            obj.ArrayType = ['ortho', 'polar', 'circular']
 
-        _tip = "Number of copies in Z direction"
-        obj.addProperty("App::PropertyInteger",
-                        "NumberZ",
-                        "Parameters",
-                        QT_TRANSLATE_NOOP("App::Property", _tip))
+        if "Fuse" not in properties:
+            _tip = ("Specifies if the copies should be fused together "
+                    "if they touch each other (slower)")
+            obj.addProperty("App::PropertyBool",
+                            "Fuse",
+                            "Objects",
+                            QT_TRANSLATE_NOOP("App::Property", _tip))
+            obj.Fuse = False
 
-        _tip = "Number of copies"
-        obj.addProperty("App::PropertyInteger",
-                        "NumberPolar",
-                        "Parameters",
-                        QT_TRANSLATE_NOOP("App::Property", _tip))
+    def set_ortho_properties(self, obj):
+        """Set orthogonal properties only if they don't exist."""
+        properties = obj.PropertiesList
 
-        _tip = "Distance and orientation of intervals in X direction"
-        obj.addProperty("App::PropertyVectorDistance",
-                        "IntervalX",
-                        "Parameters",
-                        QT_TRANSLATE_NOOP("App::Property", _tip))
+        if "NumberX" not in properties:
+            _tip = "Number of copies in X direction"
+            obj.addProperty("App::PropertyInteger",
+                            "NumberX",
+                            "Orthogonal array",
+                            QT_TRANSLATE_NOOP("App::Property", _tip))
+            obj.NumberX = 2
 
-        _tip = "Distance and orientation of intervals in Y direction"
-        obj.addProperty("App::PropertyVectorDistance",
-                        "IntervalY",
-                        "Parameters",
-                        QT_TRANSLATE_NOOP("App::Property", _tip))
+        if "NumberY" not in properties:
+            _tip = "Number of copies in Y direction"
+            obj.addProperty("App::PropertyInteger",
+                            "NumberY",
+                            "Orthogonal array",
+                            QT_TRANSLATE_NOOP("App::Property", _tip))
+            obj.NumberY = 2
 
-        _tip = "Distance and orientation of intervals in Z direction"
-        obj.addProperty("App::PropertyVectorDistance",
-                        "IntervalZ",
-                        "Parameters",
-                        QT_TRANSLATE_NOOP("App::Property", _tip))
+        if "NumberZ" not in properties:
+            _tip = "Number of copies in Z direction"
+            obj.addProperty("App::PropertyInteger",
+                            "NumberZ",
+                            "Orthogonal array",
+                            QT_TRANSLATE_NOOP("App::Property", _tip))
+            obj.NumberZ = 1
 
-        _tip = "Distance and orientation of intervals in Axis direction"
-        obj.addProperty("App::PropertyVectorDistance",
-                        "IntervalAxis",
-                        "Parameters",
-                        QT_TRANSLATE_NOOP("App::Property", _tip))
+        if "IntervalX" not in properties:
+            _tip = "Distance and orientation of intervals in X direction"
+            obj.addProperty("App::PropertyVectorDistance",
+                            "IntervalX",
+                            "Orthogonal array",
+                            QT_TRANSLATE_NOOP("App::Property", _tip))
+            obj.IntervalX = App.Vector(50, 0, 0)
 
-        _tip = "Center point"
-        obj.addProperty("App::PropertyVectorDistance",
-                        "Center",
-                        "Parameters",
-                        QT_TRANSLATE_NOOP("App::Property", _tip))
+        if "IntervalY" not in properties:
+            _tip = "Distance and orientation of intervals in Y direction"
+            obj.addProperty("App::PropertyVectorDistance",
+                            "IntervalY",
+                            "Orthogonal array",
+                            QT_TRANSLATE_NOOP("App::Property", _tip))
+            obj.IntervalY = App.Vector(0, 50, 0)
 
-        _tip = "Angle to cover with copies"
-        obj.addProperty("App::PropertyAngle",
-                        "Angle",
-                        "Parameters",
-                        QT_TRANSLATE_NOOP("App::Property", _tip))
+        if "IntervalZ" not in properties:
+            _tip = "Distance and orientation of intervals in Z direction"
+            obj.addProperty("App::PropertyVectorDistance",
+                            "IntervalZ",
+                            "Orthogonal array",
+                            QT_TRANSLATE_NOOP("App::Property", _tip))
+            obj.IntervalZ = App.Vector(0, 0, 50)
 
-        _tip = "Distance between copies in a circle"
-        obj.addProperty("App::PropertyDistance",
-                        "RadialDistance",
-                        "Parameters",
-                        QT_TRANSLATE_NOOP("App::Property", _tip))
+    def set_polar_circular_properties(self, obj):
+        """Set general polar and circular properties if they don't exist."""
+        properties = obj.PropertiesList
 
-        _tip = "Distance between circles"
-        obj.addProperty("App::PropertyDistance",
-                        "TangentialDistance",
-                        "Parameters",
-                        QT_TRANSLATE_NOOP("App::Property", _tip))
+        if "Axis" not in properties:
+            _tip = ("The axis direction around which the elements in "
+                    "a polar or a circular array will be created")
+            obj.addProperty("App::PropertyVector",
+                            "Axis",
+                            "Polar/circular array",
+                            QT_TRANSLATE_NOOP("App::Property", _tip))
+            obj.Axis = App.Vector(0, 0, 1)
 
-        _tip = "number of circles"
-        obj.addProperty("App::PropertyInteger",
-                        "NumberCircles",
-                        "Parameters",
-                        QT_TRANSLATE_NOOP("App::Property", _tip))
+        if "Center" not in properties:
+            _tip = ("Center point for polar and circular arrays.\n"
+                    "The 'Axis' passes through this point.")
+            obj.addProperty("App::PropertyVectorDistance",
+                            "Center",
+                            "Polar/circular array",
+                            QT_TRANSLATE_NOOP("App::Property", _tip))
+            obj.Center = App.Vector(0, 0, 0)
 
-        _tip = "number of circles"
-        obj.addProperty("App::PropertyInteger",
-                        "Symmetry",
-                        "Parameters",
-                        QT_TRANSLATE_NOOP("App::Property", _tip))
+        # The AxisReference property must be attached after Axis and Center
+        # so that onChanged works properly
+        if "AxisReference" not in properties:
+            _tip = ("The axis object that overrides the value of 'Axis' "
+                    "and 'Center', for example, a datum line.\n"
+                    "Its placement, position and rotation, will be used "
+                    "when creating polar and circular arrays.\n"
+                    "Leave this property empty to be able to set "
+                    "'Axis' and 'Center' manually.")
+            obj.addProperty("App::PropertyLinkGlobal",
+                            "AxisReference",
+                            "Objects",
+                            QT_TRANSLATE_NOOP("App::Property", _tip))
+            obj.AxisReference = None
 
-        _tip = "Specifies if copies must be fused (slower)"
-        obj.addProperty("App::PropertyBool",
-                        "Fuse",
-                        "Parameters",
-                        QT_TRANSLATE_NOOP("App::Property", _tip))
-        obj.Fuse = False
+    def set_polar_properties(self, obj):
+        """Set polar properties only if they don't exist."""
+        properties = obj.PropertiesList
+
+        if "NumberPolar" not in properties:
+            _tip = "Number of copies in the polar direction"
+            obj.addProperty("App::PropertyInteger",
+                            "NumberPolar",
+                            "Polar array",
+                            QT_TRANSLATE_NOOP("App::Property", _tip))
+            obj.NumberPolar = 5
+
+        if "IntervalAxis" not in properties:
+            _tip = "Distance and orientation of intervals in 'Axis' direction"
+            obj.addProperty("App::PropertyVectorDistance",
+                            "IntervalAxis",
+                            "Polar array",
+                            QT_TRANSLATE_NOOP("App::Property", _tip))
+            obj.IntervalAxis = App.Vector(0, 0, 0)
+
+        if "Angle" not in properties:
+            _tip = "Angle to cover with copies"
+            obj.addProperty("App::PropertyAngle",
+                            "Angle",
+                            "Polar array",
+                            QT_TRANSLATE_NOOP("App::Property", _tip))
+            obj.Angle = 360
+
+    def set_circular_properties(self, obj):
+        """Set circular properties only if they don't exist."""
+        properties = obj.PropertiesList
+
+        if "RadialDistance" not in properties:
+            _tip = "Distance between circular layers"
+            obj.addProperty("App::PropertyDistance",
+                            "RadialDistance",
+                            "Circular array",
+                            QT_TRANSLATE_NOOP("App::Property", _tip))
+            obj.RadialDistance = 50
+
+        if "TangentialDistance" not in properties:
+            _tip = "Distance between copies in the same circular layer"
+            obj.addProperty("App::PropertyDistance",
+                            "TangentialDistance",
+                            "Circular array",
+                            QT_TRANSLATE_NOOP("App::Property", _tip))
+            obj.TangentialDistance = 25
+
+        if "NumberCircles" not in properties:
+            _tip = ("Number of circular layers. "
+                    "The 'Base' object counts as one layer.")
+            obj.addProperty("App::PropertyInteger",
+                            "NumberCircles",
+                            "Circular array",
+                            QT_TRANSLATE_NOOP("App::Property", _tip))
+            obj.NumberCircles = 3
+
+        if "Symmetry" not in properties:
+            _tip = ("A parameter that determines how many symmetry planes "
+                    " the circular array will have.")
+            obj.addProperty("App::PropertyInteger",
+                            "Symmetry",
+                            "Circular array",
+                            QT_TRANSLATE_NOOP("App::Property", _tip))
+            obj.Symmetry = 1
+
+    def set_link_properties(self, obj):
+        """Set link properties only if they don't exist."""
+        properties = obj.PropertiesList
 
         if self.use_link:
-            _tip = "Number of elements in the array, read only"
-            obj.addProperty("App::PropertyInteger",
-                            "Count",
-                            "Draft",
-                            QT_TRANSLATE_NOOP("App::Property", _tip))
+            if "Count" not in properties:
+                _tip = ("Total number of elements in the array.\n"
+                        "This property is read-only, as the number depends "
+                        "on the parameters of the array.")
+                obj.addProperty("App::PropertyInteger",
+                                "Count",
+                                "Objects",
+                                QT_TRANSLATE_NOOP("App::Property", _tip))
+                obj.Count = 0
+                obj.setEditorMode("Count", 1)  # Read only
 
-            _tip = ("Show the individual array elements "
-                    "(only for Link arrays)")
-            obj.addProperty("App::PropertyBool",
-                            "ExpandArray",
-                            "Draft",
-                            QT_TRANSLATE_NOOP("App::Property", _tip))
-            obj.ExpandArray = False
-
-        obj.ArrayType = ['ortho', 'polar', 'circular']
-        obj.NumberX = 1
-        obj.NumberY = 1
-        obj.NumberZ = 1
-        obj.NumberPolar = 1
-        obj.IntervalX = App.Vector(1, 0, 0)
-        obj.IntervalY = App.Vector(0, 1, 0)
-        obj.IntervalZ = App.Vector(0, 0, 1)
-        obj.Angle = 360
-        obj.Axis = App.Vector(0, 0, 1)
-        obj.RadialDistance = 1.0
-        obj.TangentialDistance = 1.0
-        obj.NumberCircles = 2
-        obj.Symmetry = 1
-
-        super(Array, self).attach(obj)
+            if "ExpandArray" not in properties:
+                _tip = ("Show the individual array elements "
+                        "(only for Link arrays)")
+                obj.addProperty("App::PropertyBool",
+                                "ExpandArray",
+                                "Objects",
+                                QT_TRANSLATE_NOOP("App::Property", _tip))
+                obj.ExpandArray = False
 
     def linkSetup(self, obj):
         """Set up the object as a link object."""
@@ -210,6 +293,7 @@ class Array(DraftLink):
     def onChanged(self, obj, prop):
         """Execute when a property is changed."""
         super(Array, self).onChanged(obj, prop)
+        print(prop, ": ", getattr(obj, prop))
         if prop == "AxisReference":
             if obj.AxisReference:
                 obj.setEditorMode("Center", 1)
@@ -227,8 +311,9 @@ class Array(DraftLink):
 
             if hasattr(obj, "AxisReference") and obj.AxisReference:
                 if hasattr(obj.AxisReference, "Placement"):
-                    axis = obj.AxisReference.Placement.Rotation * App.Vector(0, 0, 1)
-                    center = obj.AxisReference.Placement.Base
+                    reference = obj.AxisReference.Placement
+                    axis = reference.Rotation * App.Vector(0, 0, 1)
+                    center = reference.Base
                 else:
                     _info = ("'AxisReference' has no 'Placement' property. "
                              "Please select a different object to use as "

--- a/src/Mod/Draft/draftobjects/array.py
+++ b/src/Mod/Draft/draftobjects/array.py
@@ -1,7 +1,8 @@
 # ***************************************************************************
 # *   Copyright (c) 2009, 2010 Yorik van Havre <yorik@uncreated.net>        *
 # *   Copyright (c) 2009, 2010 Ken Cline <cline@frii.com>                   *
-# *   Copyright (c) 2020 FreeCAD Developers                                 *
+# *   Copyright (c) 2019, M G Berberich (berberic2, rynn)                   *
+# *   Copyright (c) 2020 Eliud Cabrera Castillo <e.cabrera-castillo@tum.de> *
 # *                                                                         *
 # *   This program is free software; you can redistribute it and/or modify  *
 # *   it under the terms of the GNU Lesser General Public License (LGPL)    *
@@ -20,124 +21,179 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""This module provides the object code for the Draft Array object.
+"""Provides the object code for the Draft Array object.
+
+The `Array` class currently handles three types of arrays,
+orthogonal, polar, and circular. In the future, probably they should be
+split in separate classes so that they are easier to manage.
 """
 ## @package array
 # \ingroup DRAFT
-# \brief This module provides the object code for the Draft Array object.
+# \brief Provides the object code for the Draft Array object.
 
 import math
-
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
 import FreeCAD as App
 import DraftVecUtils
 
-from draftutils.utils import get_param
-
 from draftobjects.draftlink import DraftLink
 
 
-
 class Array(DraftLink):
-    "The Draft Array object"
+    """The Draft Array object.
 
-    def __init__(self,obj):
+    To Do
+    -----
+    The `Array` class currently handles three types of arrays,
+    orthogonal, polar, and circular. In the future, probably they should be
+    split in separate classes so that they are easier to manage.
+    """
+
+    def __init__(self, obj):
         super(Array, self).__init__(obj, "Array")
 
     def attach(self, obj):
         _tip = "The base object that must be duplicated"
-        obj.addProperty("App::PropertyLink", "Base",
-                        "Objects", QT_TRANSLATE_NOOP("App::Property", _tip))
-        
+        obj.addProperty("App::PropertyLink",
+                        "Base",
+                        "Objects",
+                        QT_TRANSLATE_NOOP("App::Property", _tip))
+
         _tip = "The type of array to create"
-        obj.addProperty("App::PropertyEnumeration", "ArrayType",
-                        "Draft", QT_TRANSLATE_NOOP("App::Property", _tip))
-        
+        obj.addProperty("App::PropertyEnumeration",
+                        "ArrayType",
+                        "Draft",
+                        QT_TRANSLATE_NOOP("App::Property", _tip))
+
         _tip = "The axis (e.g. DatumLine) overriding Axis/Center"
-        obj.addProperty("App::PropertyLinkGlobal", "AxisReference",
-                        "Objects", QT_TRANSLATE_NOOP("App::Property", _tip))
-        
+        obj.addProperty("App::PropertyLinkGlobal",
+                        "AxisReference",
+                        "Objects",
+                        QT_TRANSLATE_NOOP("App::Property", _tip))
+
         _tip = "The axis direction"
-        obj.addProperty("App::PropertyVector", "Axis",
-                        "Parameters", QT_TRANSLATE_NOOP("App::Property", _tip))
-        
+        obj.addProperty("App::PropertyVector",
+                        "Axis",
+                        "Parameters",
+                        QT_TRANSLATE_NOOP("App::Property", _tip))
+
         _tip = "Number of copies in X direction"
-        obj.addProperty("App::PropertyInteger", "NumberX",
-                        "Parameters",QT_TRANSLATE_NOOP("App::Property", _tip))
-        
+        obj.addProperty("App::PropertyInteger",
+                        "NumberX",
+                        "Parameters",
+                        QT_TRANSLATE_NOOP("App::Property", _tip))
+
         _tip = "Number of copies in Y direction"
-        obj.addProperty("App::PropertyInteger", "NumberY",
-                        "Parameters",QT_TRANSLATE_NOOP("App::Property", _tip))
-        
+        obj.addProperty("App::PropertyInteger",
+                        "NumberY",
+                        "Parameters",
+                        QT_TRANSLATE_NOOP("App::Property", _tip))
+
         _tip = "Number of copies in Z direction"
-        obj.addProperty("App::PropertyInteger", "NumberZ",
-                        "Parameters",QT_TRANSLATE_NOOP("App::Property", _tip))
-        
+        obj.addProperty("App::PropertyInteger",
+                        "NumberZ",
+                        "Parameters",
+                        QT_TRANSLATE_NOOP("App::Property", _tip))
+
         _tip = "Number of copies"
-        obj.addProperty("App::PropertyInteger", "NumberPolar",
-                        "Parameters",QT_TRANSLATE_NOOP("App::Property", _tip))
-        
+        obj.addProperty("App::PropertyInteger",
+                        "NumberPolar",
+                        "Parameters",
+                        QT_TRANSLATE_NOOP("App::Property", _tip))
+
         _tip = "Distance and orientation of intervals in X direction"
-        obj.addProperty("App::PropertyVectorDistance", "IntervalX",
-                        "Parameters",QT_TRANSLATE_NOOP("App::Property", _tip))
-        
+        obj.addProperty("App::PropertyVectorDistance",
+                        "IntervalX",
+                        "Parameters",
+                        QT_TRANSLATE_NOOP("App::Property", _tip))
+
         _tip = "Distance and orientation of intervals in Y direction"
-        obj.addProperty("App::PropertyVectorDistance", "IntervalY",
-                        "Parameters",QT_TRANSLATE_NOOP("App::Property", _tip))
-        
+        obj.addProperty("App::PropertyVectorDistance",
+                        "IntervalY",
+                        "Parameters",
+                        QT_TRANSLATE_NOOP("App::Property", _tip))
+
         _tip = "Distance and orientation of intervals in Z direction"
-        obj.addProperty("App::PropertyVectorDistance", "IntervalZ",
-                        "Parameters",QT_TRANSLATE_NOOP("App::Property", _tip))
-        
+        obj.addProperty("App::PropertyVectorDistance",
+                        "IntervalZ",
+                        "Parameters",
+                        QT_TRANSLATE_NOOP("App::Property", _tip))
+
         _tip = "Distance and orientation of intervals in Axis direction"
-        obj.addProperty("App::PropertyVectorDistance", "IntervalAxis",
-                        "Parameters",QT_TRANSLATE_NOOP("App::Property", _tip))
-        
+        obj.addProperty("App::PropertyVectorDistance",
+                        "IntervalAxis",
+                        "Parameters",
+                        QT_TRANSLATE_NOOP("App::Property", _tip))
+
         _tip = "Center point"
-        obj.addProperty("App::PropertyVectorDistance", "Center",
-                        "Parameters",QT_TRANSLATE_NOOP("App::Property", _tip))
-        
+        obj.addProperty("App::PropertyVectorDistance",
+                        "Center",
+                        "Parameters",
+                        QT_TRANSLATE_NOOP("App::Property", _tip))
+
         _tip = "Angle to cover with copies"
-        obj.addProperty("App::PropertyAngle", "Angle",
-                        "Parameters",QT_TRANSLATE_NOOP("App::Property", _tip))
-        
+        obj.addProperty("App::PropertyAngle",
+                        "Angle",
+                        "Parameters",
+                        QT_TRANSLATE_NOOP("App::Property", _tip))
+
         _tip = "Distance between copies in a circle"
-        obj.addProperty("App::PropertyDistance", "RadialDistance",
-                        "Parameters",QT_TRANSLATE_NOOP("App::Property", _tip))
-        
+        obj.addProperty("App::PropertyDistance",
+                        "RadialDistance",
+                        "Parameters",
+                        QT_TRANSLATE_NOOP("App::Property", _tip))
+
         _tip = "Distance between circles"
-        obj.addProperty("App::PropertyDistance", "TangentialDistance",
-                        "Parameters",QT_TRANSLATE_NOOP("App::Property", _tip))
-        
+        obj.addProperty("App::PropertyDistance",
+                        "TangentialDistance",
+                        "Parameters",
+                        QT_TRANSLATE_NOOP("App::Property", _tip))
+
         _tip = "number of circles"
-        obj.addProperty("App::PropertyInteger", "NumberCircles",
-                        "Parameters",QT_TRANSLATE_NOOP("App::Property", _tip))
-        
+        obj.addProperty("App::PropertyInteger",
+                        "NumberCircles",
+                        "Parameters",
+                        QT_TRANSLATE_NOOP("App::Property", _tip))
+
         _tip = "number of circles"
-        obj.addProperty("App::PropertyInteger", "Symmetry",
-                        "Parameters",QT_TRANSLATE_NOOP("App::Property", _tip))
-        
+        obj.addProperty("App::PropertyInteger",
+                        "Symmetry",
+                        "Parameters",
+                        QT_TRANSLATE_NOOP("App::Property", _tip))
+
         _tip = "Specifies if copies must be fused (slower)"
-        obj.addProperty("App::PropertyBool", "Fuse",
-                        "Parameters",QT_TRANSLATE_NOOP("App::Property", _tip))
+        obj.addProperty("App::PropertyBool",
+                        "Fuse",
+                        "Parameters",
+                        QT_TRANSLATE_NOOP("App::Property", _tip))
         obj.Fuse = False
+
         if self.use_link:
-            obj.addProperty("App::PropertyInteger","Count","Draft",'')
-            obj.addProperty("App::PropertyBool","ExpandArray","Draft",
-                    QT_TRANSLATE_NOOP("App::Property","Show array element as children object"))
+            _tip = "Number of elements in the array, read only"
+            obj.addProperty("App::PropertyInteger",
+                            "Count",
+                            "Draft",
+                            QT_TRANSLATE_NOOP("App::Property", _tip))
+
+            _tip = ("Show the individual array elements "
+                    "(only for Link arrays)")
+            obj.addProperty("App::PropertyBool",
+                            "ExpandArray",
+                            "Draft",
+                            QT_TRANSLATE_NOOP("App::Property", _tip))
             obj.ExpandArray = False
 
-        obj.ArrayType = ['ortho','polar','circular']
+        obj.ArrayType = ['ortho', 'polar', 'circular']
         obj.NumberX = 1
         obj.NumberY = 1
         obj.NumberZ = 1
         obj.NumberPolar = 1
-        obj.IntervalX = App.Vector(1,0,0)
-        obj.IntervalY = App.Vector(0,1,0)
-        obj.IntervalZ = App.Vector(0,0,1)
+        obj.IntervalX = App.Vector(1, 0, 0)
+        obj.IntervalY = App.Vector(0, 1, 0)
+        obj.IntervalZ = App.Vector(0, 0, 1)
         obj.Angle = 360
-        obj.Axis = App.Vector(0,0,1)
+        obj.Axis = App.Vector(0, 0, 1)
         obj.RadialDistance = 1.0
         obj.TangentialDistance = 1.0
         obj.NumberCircles = 2
@@ -145,12 +201,14 @@ class Array(DraftLink):
 
         super(Array, self).attach(obj)
 
-    def linkSetup(self,obj):
+    def linkSetup(self, obj):
+        """Set up the object as a link object."""
         super(Array, self).linkSetup(obj)
         obj.configLinkProperty(ElementCount='Count')
-        obj.setPropertyStatus('Count','Hidden')
+        obj.setPropertyStatus('Count', 'Hidden')
 
-    def onChanged(self,obj,prop):
+    def onChanged(self, obj, prop):
+        """Execute when a property is changed."""
         super(Array, self).onChanged(obj, prop)
         if prop == "AxisReference":
             if obj.AxisReference:
@@ -160,76 +218,98 @@ class Array(DraftLink):
                 obj.setEditorMode("Center", 0)
                 obj.setEditorMode("Axis", 0)
 
-    def execute(self,obj):
+    def execute(self, obj):
+        """Execture when the object is created or recomputed."""
         if obj.Base:
             pl = obj.Placement
             axis = obj.Axis
             center = obj.Center
-            if hasattr(obj,"AxisReference") and obj.AxisReference:
-                if hasattr(obj.AxisReference,"Placement"):
-                    axis = obj.AxisReference.Placement.Rotation * App.Vector(0,0,1)
+
+            if hasattr(obj, "AxisReference") and obj.AxisReference:
+                if hasattr(obj.AxisReference, "Placement"):
+                    axis = obj.AxisReference.Placement.Rotation * App.Vector(0, 0, 1)
                     center = obj.AxisReference.Placement.Base
                 else:
-                    raise TypeError("AxisReference has no Placement attribute. Please select a different AxisReference.")
+                    _info = ("'AxisReference' has no 'Placement' property. "
+                             "Please select a different object to use as "
+                             "reference.")
+                    raise TypeError(_info)
+
             if obj.ArrayType == "ortho":
-                pls = self.rectArray(obj.Base.Placement,obj.IntervalX,obj.IntervalY,
-                                    obj.IntervalZ,obj.NumberX,obj.NumberY,obj.NumberZ)
+                pls = self.rectArray(obj.Base.Placement,
+                                     obj.IntervalX,
+                                     obj.IntervalY,
+                                     obj.IntervalZ,
+                                     obj.NumberX,
+                                     obj.NumberY,
+                                     obj.NumberZ)
+            elif obj.ArrayType == "polar":
+                av = obj.IntervalAxis if hasattr(obj, "IntervalAxis") else None
+                pls = self.polarArray(obj.Base.Placement,
+                                      center, obj.Angle.Value,
+                                      obj.NumberPolar, axis, av)
             elif obj.ArrayType == "circular":
-                pls = self.circArray(obj.Base.Placement,obj.RadialDistance,obj.TangentialDistance,
-                                     axis,center,obj.NumberCircles,obj.Symmetry)
-            else:
-                av = obj.IntervalAxis if hasattr(obj,"IntervalAxis") else None
-                pls = self.polarArray(obj.Base.Placement,center,obj.Angle.Value,obj.NumberPolar,axis,av)
+                pls = self.circArray(obj.Base.Placement,
+                                     obj.RadialDistance,
+                                     obj.TangentialDistance,
+                                     axis, center,
+                                     obj.NumberCircles, obj.Symmetry)
 
             return super(Array, self).buildShape(obj, pl, pls)
 
-    def rectArray(self,pl,xvector,yvector,zvector,xnum,ynum,znum):
+    def rectArray(self, pl, xvector, yvector, zvector, xnum, ynum, znum):
+        """Determine the placements where the rectangular copies will be."""
         base = [pl.copy()]
         for xcount in range(xnum):
-            currentxvector=App.Vector(xvector).multiply(xcount)
-            if not xcount==0:
+            currentxvector = App.Vector(xvector).multiply(xcount)
+            if not xcount == 0:
                 npl = pl.copy()
                 npl.translate(currentxvector)
                 base.append(npl)
             for ycount in range(ynum):
-                currentyvector=App.Vector(currentxvector)
-                currentyvector=currentyvector.add(App.Vector(yvector).multiply(ycount))
-                if not ycount==0:
+                currentyvector = App.Vector(currentxvector)
+                currentyvector = currentyvector.add(App.Vector(yvector).multiply(ycount))
+                if not ycount == 0:
                     npl = pl.copy()
                     npl.translate(currentyvector)
                     base.append(npl)
                 for zcount in range(znum):
-                    currentzvector=App.Vector(currentyvector)
-                    currentzvector=currentzvector.add(App.Vector(zvector).multiply(zcount))
-                    if not zcount==0:
+                    currentzvector = App.Vector(currentyvector)
+                    currentzvector = currentzvector.add(App.Vector(zvector).multiply(zcount))
+                    if not zcount == 0:
                         npl = pl.copy()
                         npl.translate(currentzvector)
                         base.append(npl)
         return base
 
-    def circArray(self,pl,rdist,tdist,axis,center,cnum,sym):
+    def circArray(self, pl, rdist, tdist, axis, center, cnum, sym):
+        """Determine the placements where the circular copies will be."""
         sym = max(1, sym)
-        lead = (0,1,0)
-        if axis.x == 0 and axis.z == 0: lead = (1,0,0)
+        lead = (0, 1, 0)
+        if axis.x == 0 and axis.z == 0:
+            lead = (1, 0, 0)
         direction = axis.cross(App.Vector(lead)).normalize()
         base = [pl.copy()]
         for xcount in range(1, cnum):
-            rc = xcount*rdist
+            rc = xcount * rdist
             c = 2 * rc * math.pi
             n = math.floor(c / tdist)
             n = int(math.floor(n / sym) * sym)
-            if n == 0: continue
+            if n == 0:
+                continue
             angle = 360.0/n
             for ycount in range(0, n):
                 npl = pl.copy()
                 trans = App.Vector(direction).multiply(rc)
                 npl.translate(trans)
-                npl.rotate(npl.Rotation.inverted().multVec(center-trans), axis, ycount*angle)
+                npl.rotate(npl.Rotation.inverted().multVec(center-trans),
+                           axis, ycount * angle)
                 base.append(npl)
         return base
 
-    def polarArray(self,spl,center,angle,num,axis,axisvector):
-        #print("angle ",angle," num ",num)
+    def polarArray(self, spl, center, angle, num, axis, axisvector):
+        """Determine the placements where the polar copies will be."""
+        # print("angle ",angle," num ",num)
         spin = App.Placement(App.Vector(), spl.Rotation)
         pl = App.Placement(spl.Base, App.Rotation())
         center = center.sub(spl.Base)

--- a/src/Mod/Draft/draftobjects/array.py
+++ b/src/Mod/Draft/draftobjects/array.py
@@ -65,6 +65,8 @@ class Array(DraftLink):
         self.set_polar_properties(obj)
         self.set_circular_properties(obj)
 
+        # The ArrayType property (general) must be attached
+        # after the other array properties so that onChanged works properly
         self.set_general_properties(obj)
         self.set_link_properties(obj)
 
@@ -293,7 +295,11 @@ class Array(DraftLink):
     def onChanged(self, obj, prop):
         """Execute when a property is changed."""
         super(Array, self).onChanged(obj, prop)
-        print(prop, ": ", getattr(obj, prop))
+        # print(prop, ": ", getattr(obj, prop))
+        self.show_and_hide(obj, prop)
+
+    def show_and_hide(self, obj, prop):
+        """Show and hide the properties depending on the touched property."""
         if prop == "AxisReference":
             if obj.AxisReference:
                 obj.setEditorMode("Center", 1)
@@ -301,6 +307,40 @@ class Array(DraftLink):
             else:
                 obj.setEditorMode("Center", 0)
                 obj.setEditorMode("Axis", 0)
+
+        if prop == "ArrayType":
+            if obj.ArrayType == "ortho":
+                for pr in ("NumberX", "NumberY", "NumberZ",
+                           "IntervalX", "IntervalY", "IntervalZ"):
+                    obj.setPropertyStatus(pr, "-Hidden")
+
+                for pr in ("Axis", "Center", "NumberPolar", "Angle",
+                           "IntervalAxis", "NumberCircles",
+                           "RadialDistance", "TangentialDistance",
+                           "Symmetry"):
+                    obj.setPropertyStatus(pr, "Hidden")
+
+            if obj.ArrayType == "polar":
+                for pr in ("Axis", "Center", "NumberPolar",
+                           "Angle", "IntervalAxis"):
+                    obj.setPropertyStatus(pr, "-Hidden")
+
+                for pr in ("NumberX", "NumberY", "NumberZ",
+                           "IntervalX", "IntervalY", "IntervalZ",
+                           "NumberCircles", "RadialDistance",
+                           "TangentialDistance", "Symmetry"):
+                    obj.setPropertyStatus(pr, "Hidden")
+
+            if obj.ArrayType == "circular":
+                for pr in ("Axis", "Center", "NumberCircles",
+                           "RadialDistance", "TangentialDistance",
+                           "Symmetry"):
+                    obj.setPropertyStatus(pr, "-Hidden")
+
+                for pr in ("NumberX", "NumberY", "NumberZ",
+                           "IntervalX", "IntervalY", "IntervalZ",
+                           "NumberPolar", "Angle", "IntervalAxis"):
+                    obj.setPropertyStatus(pr, "Hidden")
 
     def execute(self, obj):
         """Execture when the object is created or recomputed."""

--- a/src/Mod/Draft/draftobjects/draftlink.py
+++ b/src/Mod/Draft/draftobjects/draftlink.py
@@ -1,7 +1,5 @@
 # ***************************************************************************
-# *   Copyright (c) 2009, 2010 Yorik van Havre <yorik@uncreated.net>        *
-# *   Copyright (c) 2009, 2010 Ken Cline <cline@frii.com>                   *
-# *   Copyright (c) 2020 FreeCAD Developers                                 *
+# *   Copyright (c) 2019 Zheng, Lei (realthunder)<realthunder.dev@gmail.com>*
 # *                                                                         *
 # *   This program is free software; you can redistribute it and/or modify  *
 # *   it under the terms of the GNU Lesser General Public License (LGPL)    *
@@ -20,79 +18,113 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""This module provides the object code for the Draft Link object.
+"""Provides the object code for the Draft Link object.
+
+This class was created by realthunder during the `LinkMerge`
+to demonstrate how to use the `App::Link` objects to create
+Link aware arrays.
+It is used by `draftobject.array` (ortho, polar, circular)
+and `draftobject.patharray` to create respective Link arrays.
+
+NOTE: this class is a bit mysterious. We need more documentation
+on how the properties are being set, and how the code interacts with
+the arrays that use it.
 """
 ## @package draftlink
 # \ingroup DRAFT
-# \brief This module provides the object code for the Draft Link object.
+# \brief Provides the object code for the Draft Link object.
 
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
 import FreeCAD as App
-
-from draftutils.utils import get_param
+import lazy_loader.lazy_loader as lz
 
 from draftobjects.base import DraftObject
+from draftutils.messages import _wrn
+
+# Delay import of module until first use because it is heavy
+Part = lz.LazyLoader("Part", globals(), "Part")
+DraftGeomUtils = lz.LazyLoader("DraftGeomUtils", globals(), "DraftGeomUtils")
 
 
 class DraftLink(DraftObject):
-    """
-    Documentation needed.
-    DraftLink was introduced by Realthunder to allow the use of new 
-    App::Link object into Draft Array objects during version 0.19 development
-    cycle.
+    """New class to use the App::Link objects in arrays.
+
+    Introduced by realthunder.
+    This is subclassed by `draftobjects.array.Array`
+    and by `draftobjects.patharray.PathArray`.
     """
 
-    def __init__(self,obj,tp):
+    def __init__(self, obj, tp):
         self.use_link = False if obj else True
         super(DraftLink, self).__init__(obj, tp)
         if obj:
             self.attach(obj)
 
     def __getstate__(self):
+        """Return a tuple of all serializable objects or None."""
         return self.__dict__
 
-    def __setstate__(self,state):
-        if isinstance(state,dict):
+    def __setstate__(self, state):
+        """Set some internal properties for all restored objects."""
+        if isinstance(state, dict):
             self.__dict__ = state
         else:
             self.use_link = False
             super(DraftLink, self).__setstate__(state)
 
-    def attach(self,obj):
+    def attach(self, obj):
+        """Set up the properties when the object is attached."""
         if self.use_link:
             obj.addExtension('App::LinkExtensionPython', None)
             self.linkSetup(obj)
 
-    def canLinkProperties(self,_obj):
+    def canLinkProperties(self, _obj):
+        """Link properties.
+
+        TODO: add more explanation. C++ override???"""
         return False
 
-    def linkSetup(self,obj):
-        obj.configLinkProperty('Placement',LinkedObject='Base')
-        if hasattr(obj,'ShowElement'):
-            # rename 'ShowElement' property to 'ExpandArray' to avoid conflict
+    def linkSetup(self, obj):
+        """Set up the link properties on attachment."""
+        obj.configLinkProperty('Placement', LinkedObject='Base')
+        if hasattr(obj, 'ShowElement'):
+            # Rename 'ShowElement' property to 'ExpandArray' to avoid conflict
             # with native App::Link
             obj.configLinkProperty('ShowElement')
             showElement = obj.ShowElement
-            obj.addProperty("App::PropertyBool","ExpandArray","Draft",
-                    QT_TRANSLATE_NOOP("App::Property","Show array element as children object"))
+            obj.addProperty("App::PropertyBool",
+                            "ExpandArray",
+                            "Draft",
+                            QT_TRANSLATE_NOOP("App::Property",
+                                              "Show array element as "
+                                              "children object"))
             obj.ExpandArray = showElement
             obj.configLinkProperty(ShowElement='ExpandArray')
             obj.removeProperty('ShowElement')
         else:
             obj.configLinkProperty(ShowElement='ExpandArray')
-        if getattr(obj,'ExpandArray',False):
-            obj.setPropertyStatus('PlacementList','Immutable')
-        else:
-            obj.setPropertyStatus('PlacementList','-Immutable')
-        if not hasattr(obj,'LinkTransform'):
-            obj.addProperty('App::PropertyBool','LinkTransform',' Link')
-        if not hasattr(obj,'ColoredElements'):
-            obj.addProperty('App::PropertyLinkSubHidden','ColoredElements',' Link')
-            obj.setPropertyStatus('ColoredElements','Hidden')
-        obj.configLinkProperty('LinkTransform','ColoredElements')
 
-    def getViewProviderName(self,_obj):
+        if getattr(obj, 'ExpandArray', False):
+            obj.setPropertyStatus('PlacementList', 'Immutable')
+        else:
+            obj.setPropertyStatus('PlacementList', '-Immutable')
+
+        if not hasattr(obj, 'LinkTransform'):
+            obj.addProperty('App::PropertyBool',
+                            'LinkTransform',
+                            ' Link')
+
+        if not hasattr(obj, 'ColoredElements'):
+            obj.addProperty('App::PropertyLinkSubHidden',
+                            'ColoredElements',
+                            ' Link')
+            obj.setPropertyStatus('ColoredElements', 'Hidden')
+
+        obj.configLinkProperty('LinkTransform', 'ColoredElements')
+
+    def getViewProviderName(self, _obj):
+        """Override the view provider name."""
         if self.use_link:
             return 'Gui::ViewProviderLinkPython'
         return ''
@@ -109,50 +141,55 @@ class DraftLink(DraftObject):
             # all models should use 'use_link' by default
             # and this won't be run.
             self.use_link = bool(self.useLink)
-            App.Console.PrintWarning("Migrating 'useLink' to 'use_link', "
-                                         "{} ({})\n".format(obj.Label,
-                                                            obj.TypeId))
+            _wrn("Migrating 'useLink' to 'use_link', "
+                 "{} ({})\n".format(obj.Label, obj.TypeId))
             del self.useLink
 
     def onDocumentRestored(self, obj):
+        """Execute code when the document in restored."""
         self.migrate_attributes(obj)
+
         if self.use_link:
             self.linkSetup(obj)
         else:
-            obj.setPropertyStatus('Shape','-Transient')
+            obj.setPropertyStatus('Shape', '-Transient')
+
         if obj.Shape.isNull():
-            if getattr(obj,'PlacementList',None):
-                self.buildShape(obj,obj.Placement,obj.PlacementList)
+            if getattr(obj, 'PlacementList', None):
+                self.buildShape(obj, obj.Placement, obj.PlacementList)
             else:
                 self.execute(obj)
 
-    def buildShape(self,obj,pl,pls):
-        import Part
-        import DraftGeomUtils
-
+    def buildShape(self, obj, pl, pls):
+        """Build the shape of the link object."""
         if self.use_link:
-            if not getattr(obj,'ExpandArray',True) or obj.Count != len(pls):
-                obj.setPropertyStatus('PlacementList','-Immutable')
+            if not getattr(obj, 'ExpandArray', True) or obj.Count != len(pls):
+                obj.setPropertyStatus('PlacementList', '-Immutable')
                 obj.PlacementList = pls
-                obj.setPropertyStatus('PlacementList','Immutable')
+                obj.setPropertyStatus('PlacementList', 'Immutable')
                 obj.Count = len(pls)
 
         if obj.Base:
             shape = Part.getShape(obj.Base)
             if shape.isNull():
-                raise RuntimeError("'{}' cannot build shape of '{}'\n".format(
-                        obj.Name,obj.Base.Name))
+                _err_msg = ("'{}' cannot build shape "
+                            "from '{}'\n".format(obj.Label, obj.Base.Label))
+                raise RuntimeError(_err_msg)
             else:
                 shape = shape.copy()
                 shape.Placement = App.Placement()
                 base = []
-                for i,pla in enumerate(pls):
-                    vis = getattr(obj,'VisibilityList',[])
-                    if len(vis)>i and not vis[i]:
+                for i, pla in enumerate(pls):
+                    vis = getattr(obj, 'VisibilityList', [])
+                    if len(vis) > i and not vis[i]:
                         continue
-                    # 'I' is a prefix for disambiguation when mapping element names
-                    base.append(shape.transformed(pla.toMatrix(), op='I{}'.format(i)))
-                if getattr(obj,'Fuse',False) and len(base) > 1:
+
+                    # 'I' is a prefix for disambiguation
+                    # when mapping element names
+                    base.append(shape.transformed(pla.toMatrix(),
+                                                  op='I{}'.format(i)))
+
+                if getattr(obj, 'Fuse', False) and len(base) > 1:
                     obj.Shape = base[0].multiFuse(base[1:]).removeSplitter()
                 else:
                     obj.Shape = Part.makeCompound(base)
@@ -161,20 +198,24 @@ class DraftLink(DraftObject):
                     obj.Placement = pl
 
         if self.use_link:
-            return False # return False to call LinkExtension::execute()
+            return False  # return False to call LinkExtension::execute()
 
     def onChanged(self, obj, prop):
+        """Execute when a property changes."""
         if not getattr(self, 'use_link', False):
             return
+
         if prop == 'Fuse':
             if obj.Fuse:
                 obj.setPropertyStatus('Shape', '-Transient')
             else:
                 obj.setPropertyStatus('Shape', 'Transient')
         elif prop == 'ExpandArray':
-            if hasattr(obj,'PlacementList'):
-                obj.setPropertyStatus('PlacementList',
-                        '-Immutable' if obj.ExpandArray else 'Immutable')
+            if hasattr(obj, 'PlacementList'):
+                if obj.ExpandArray:
+                    obj.setPropertyStatus('PlacementList', '-Immutable')
+                else:
+                    obj.setPropertyStatus('PlacementList', 'Immutable')
 
 
 _DraftLink = DraftLink

--- a/src/Mod/Draft/drafttaskpanels/task_circulararray.py
+++ b/src/Mod/Draft/drafttaskpanels/task_circulararray.py
@@ -33,9 +33,10 @@ import FreeCADGui as Gui
 import Draft_rc  # include resources, icons, ui files
 import DraftVecUtils
 import draftutils.utils as utils
+
+from FreeCAD import Units as U
 from draftutils.messages import _msg, _wrn, _err, _log
 from draftutils.translate import _tr
-from FreeCAD import Units as U
 
 # The module is used to prevent complaints from code checkers (flake8)
 bool(Draft_rc.__name__)
@@ -198,7 +199,8 @@ class TaskPanelCircularArray:
                                                self.center)
         if self.valid_input:
             self.create_object()
-            self.print_messages()
+            # The internal function already displays messages
+            # self.print_messages()
             self.finish()
 
     def validate_input(self, selection,
@@ -266,15 +268,13 @@ class TaskPanelCircularArray:
             sel_obj = self.selection[0]
 
         # This creates the object immediately
-        # obj = Draft.makeArray(sel_obj,
-        #                       self.r_distance, self.tan_distance,
-        #                       self.axis, self.center,
-        #                       self.number, self.symmetry,
-        #                       self.use_link)
-        # if obj:
-        #     obj.Fuse = self.fuse
+        # obj = Draft.make_circular_array(sel_obj,
+        #                                 self.r_distance, self.tan_distance,
+        #                                 self.number, self.symmetry,
+        #                                 self.axis, self.center,
+        #                                 self.use_link)
 
-        # Instead, we build the commands to execute through the parent
+        # Instead, we build the commands to execute through the caller
         # of this class, the GuiCommand.
         # This is needed to schedule geometry manipulation
         # that would crash Coin3D if done in the event callback.

--- a/src/Mod/Draft/drafttaskpanels/task_orthoarray.py
+++ b/src/Mod/Draft/drafttaskpanels/task_orthoarray.py
@@ -33,9 +33,10 @@ import FreeCADGui as Gui
 import Draft_rc  # include resources, icons, ui files
 import DraftVecUtils
 import draftutils.utils as utils
+
+from FreeCAD import Units as U
 from draftutils.messages import _msg, _err, _log
 from draftutils.translate import _tr
-from FreeCAD import Units as U
 
 # The module is used to prevent complaints from code checkers (flake8)
 bool(Draft_rc.__name__)
@@ -186,7 +187,8 @@ class TaskPanelOrthoArray:
                                                self.n_x, self.n_y, self.n_z)
         if self.valid_input:
             self.create_object()
-            self.print_messages()
+            # The internal function already displays messages
+            # self.print_messages()
             self.finish()
 
     def validate_input(self, selection,
@@ -237,14 +239,12 @@ class TaskPanelOrthoArray:
             sel_obj = self.selection[0]
 
         # This creates the object immediately
-        # obj = Draft.makeArray(sel_obj,
-        #                       self.v_x, self.v_y, self.v_z,
-        #                       self.n_x, self.n_y, self.n_z,
-        #                       self.use_link)
-        # if obj:
-        #     obj.Fuse = self.fuse
+        # obj = Draft.make_ortho_array(sel_obj,
+        #                              self.v_x, self.v_y, self.v_z,
+        #                              self.n_x, self.n_y, self.n_z,
+        #                              self.use_link)
 
-        # Instead, we build the commands to execute through the parent
+        # Instead, we build the commands to execute through the caller
         # of this class, the GuiCommand.
         # This is needed to schedule geometry manipulation
         # that would crash Coin3D if done in the event callback.

--- a/src/Mod/Draft/drafttaskpanels/task_polararray.py
+++ b/src/Mod/Draft/drafttaskpanels/task_polararray.py
@@ -33,9 +33,10 @@ import FreeCADGui as Gui
 import Draft_rc  # include resources, icons, ui files
 import DraftVecUtils
 import draftutils.utils as utils
+
+from FreeCAD import Units as U
 from draftutils.messages import _msg, _wrn, _err, _log
 from draftutils.translate import _tr
-from FreeCAD import Units as U
 
 # The module is used to prevent complaints from code checkers (flake8)
 bool(Draft_rc.__name__)
@@ -173,7 +174,8 @@ class TaskPanelPolarArray:
                                                self.center)
         if self.valid_input:
             self.create_object()
-            self.print_messages()
+            # The internal function already displays messages
+            # self.print_messages()
             self.finish()
 
     def validate_input(self, selection,
@@ -232,13 +234,11 @@ class TaskPanelPolarArray:
             sel_obj = self.selection[0]
 
         # This creates the object immediately
-        # obj = Draft.makeArray(sel_obj,
-        #                       self.center, self.angle, self.number,
-        #                       self.use_link)
-        # if obj:
-        #     obj.Fuse = self.fuse
+        # obj = Draft.make_polar_array(sel_obj,
+        #                              self.number, self.angle, self.center,
+        #                              self.use_link)
 
-        # Instead, we build the commands to execute through the parent
+        # Instead, we build the commands to execute through the caller
         # of this class, the GuiCommand.
         # This is needed to schedule geometry manipulation
         # that would crash Coin3D if done in the event callback.
@@ -252,7 +252,6 @@ class TaskPanelPolarArray:
         _cmd += ")"
 
         Gui.addModule('Draft')
-        Gui.addModule('draftmake.make_polararray')
 
         _cmd_list = ["_obj_ = " + _cmd,
                      "_obj_.Fuse = " + str(self.fuse),


### PR DESCRIPTION
General cleaning of the code, PEP8 style, in the internal proxy object.

The properties are loaded now with methods. Since the class handles three types of arrays (ortho, polar, and circular) and many properties, using methods is easier to identify the properties that correspond only to one type. Also hide the properties that are not relevant for the active `ArrayType`.

The functions that create the placements are now outside of the `Array` class, so it is easier to investigate in the Python console, and improve their behavior without creating an object at all.

This must be merged after the support functions are merged, #3528, and the `make_array` cleanup, #3531.

Forum thread: [Making the creation of arrays more user friendly](https://forum.freecadweb.org/viewtopic.php?f=23&t=41816&p=403957#p403957)

---

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists