### PR TITLE
Path: MillFace - Add `Face Region` method to boundary shape options

### DIFF
--- a/src/Mod/Path/Gui/Resources/panels/PageOpPocketFullEdit.ui
+++ b/src/Mod/Path/Gui/Resources/panels/PageOpPocketFullEdit.ui
@@ -24,7 +24,7 @@
      </property>
      <layout class="QGridLayout" name="gridLayout_3">
       <item row="0" column="0">
-       <widget class="QLabel" name="label">
+       <widget class="QLabel" name="toolController_label">
         <property name="text">
          <string>Tool Controller</string>
         </property>
@@ -38,7 +38,7 @@
        </widget>
       </item>
       <item row="1" column="0">
-       <widget class="QLabel" name="label_5">
+       <widget class="QLabel" name="coolantController_label">
         <property name="text">
          <string>Coolant Mode</string>
         </property>
@@ -64,12 +64,17 @@
         </property>
         <item>
          <property name="text">
-          <string>Perimeter</string>
+          <string>Boundbox</string>
          </property>
         </item>
         <item>
          <property name="text">
-          <string>Boundbox</string>
+          <string>Face Region</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Perimeter</string>
          </property>
         </item>
         <item>
@@ -80,7 +85,7 @@
        </widget>
       </item>
       <item row="0" column="0">
-       <widget class="QLabel" name="label_12">
+       <widget class="QLabel" name="boundaryShape_label">
         <property name="text">
          <string>Boundary Shape</string>
         </property>
@@ -96,7 +101,7 @@
        <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
       </property>
       <item row="0" column="0">
-       <widget class="QLabel" name="label_2">
+       <widget class="QLabel" name="cutMode_label">
         <property name="text">
          <string>Cut Mode</string>
         </property>
@@ -120,7 +125,7 @@
        </widget>
       </item>
       <item row="1" column="0">
-       <widget class="QLabel" name="label_3">
+       <widget class="QLabel" name="offsetPattern_label">
         <property name="text">
          <string>Pattern</string>
         </property>
@@ -172,7 +177,7 @@
        </widget>
       </item>
       <item row="2" column="0">
-       <widget class="QLabel" name="label_4">
+       <widget class="QLabel" name="zigZagAngle_label">
         <property name="text">
          <string>Angle</string>
         </property>
@@ -186,7 +191,7 @@
        </widget>
       </item>
       <item row="3" column="0">
-       <widget class="QLabel" name="label_6">
+       <widget class="QLabel" name="stepOverPercent_label">
         <property name="text">
          <string>Step Over Percent</string>
         </property>
@@ -212,7 +217,7 @@
        </widget>
       </item>
       <item row="4" column="0">
-       <widget class="QLabel" name="extraOffsetLabel">
+       <widget class="QLabel" name="extraOffset_label">
         <property name="text">
          <string>Material Allowance</string>
         </property>
@@ -226,7 +231,7 @@
        </widget>
       </item>
       <item row="5" column="0">
-       <widget class="QLabel" name="label_7">
+       <widget class="QLabel" name="enableRotation_label">
         <property name="text">
          <string>Enable Rotation</string>
         </property>

--- a/src/Mod/Path/PathScripts/PathMillFace.py
+++ b/src/Mod/Path/PathScripts/PathMillFace.py
@@ -182,8 +182,14 @@ class ObjectFace(PathPocketBase.ObjectPocket):
                     includedShape = Part.makeCompound(includedFaces)
                     includedEnv = PathUtils.getEnvelope(oneBase[0].Shape, subshape=includedShape, depthparams=self.depthparams)
                     env = stockEnv.cut(includedEnv)
-        else:
-            env = PathUtils.getEnvelope(partshape=planeshape, depthparams=self.depthparams)
+        elif obj.BoundaryShape == 'Perimeter':
+            if obj.ClearEdges:
+                psZMin = planeshape.BoundBox.ZMin
+                ofstShape = PathSurfaceSupport.extractFaceOffset(planeshape, self.radius * 1.25, planeshape)
+                ofstShape.translate(FreeCAD.Vector(0.0, 0.0, psZMin - ofstShape.BoundBox.ZMin))
+                env = PathUtils.getEnvelope(partshape=ofstShape, depthparams=self.depthparams)
+            else:
+                env = PathUtils.getEnvelope(partshape=planeshape, depthparams=self.depthparams)
 
         if holeShape:
             PathLog.info("Processing holes...")

--- a/src/Mod/Path/PathScripts/PathMillFace.py
+++ b/src/Mod/Path/PathScripts/PathMillFace.py
@@ -41,13 +41,10 @@ __author__ = "sliptonic (Brad Collette)"
 __url__ = "http://www.freecadweb.org"
 __doc__ = "Class and implementation of Mill Facing operation."
 __contributors__ = "russ4262 (Russell Johnson)"
-__created__ = "2014"
-__scriptVersion__ = "1d usable"
-__lastModified__ = "2019-07-22 23:49 CST"
 
 
 PathLog.setLevel(PathLog.Level.INFO, PathLog.thisModule())
-#PathLog.trackModule(PathLog.thisModule())
+# PathLog.trackModule(PathLog.thisModule())
 
 
 # Qt translation handling
@@ -61,7 +58,7 @@ class ObjectFace(PathPocketBase.ObjectPocket):
     def initPocketOp(self, obj):
         '''initPocketOp(obj) ... create facing specific properties'''
         obj.addProperty("App::PropertyEnumeration", "BoundaryShape", "Face", QtCore.QT_TRANSLATE_NOOP("App::Property", "Shape to use for calculating Boundary"))
-        obj.BoundaryShape = ['Perimeter', 'Boundbox', 'Stock']
+        obj.BoundaryShape = ['Perimeter', 'Boundbox', 'Stock', 'Available']
         obj.addProperty("App::PropertyBool", "ClearEdges", "Face", QtCore.QT_TRANSLATE_NOOP("App::Property", "Clear edges of surface (Only applicable to BoundBox)"))
 
         if not hasattr(obj, 'ExcludeRaisedAreas'):
@@ -103,6 +100,8 @@ class ObjectFace(PathPocketBase.ObjectPocket):
         # Facing is done either against base objects
         holeShape = None
 
+        PathLog.debug('depthparams: {}'.format([i for i in self.depthparams]))
+
         if obj.Base:
             PathLog.debug("obj.Base: {}".format(obj.Base))
             faces = []
@@ -119,20 +118,22 @@ class ObjectFace(PathPocketBase.ObjectPocket):
                         faces.append(shape)
                         if shape.BoundBox.ZMin < minHeight:
                             minHeight = shape.BoundBox.ZMin
+                        # Limit to one model base per operation
                         if oneBase[0] is not b[0]:
                             oneBase[1] = False
                         if numpy.isclose(abs(shape.normalAt(0, 0).z), 1):  # horizontal face
+                            # Analyze internal closed wires to determine if raised or a recess
                             for wire in shape.Wires[1:]:
-                                if obj.ExcludeRaisedAreas is True:
+                                if obj.ExcludeRaisedAreas:
                                     ip = self.isPocket(b[0], shape, wire)
                                     if ip is False:
                                         holes.append((b[0].Shape, wire))
                                 else:
                                     holes.append((b[0].Shape, wire))
                     else:
-                        PathLog.error('The base subobject, "{0}," is not a face. Ignoring "{0}."'.format(sub))
+                        PathLog.warning('The base subobject, "{0}," is not a face. Ignoring "{0}."'.format(sub))
 
-            if obj.ExcludeRaisedAreas is True and len(holes) > 0:
+            if obj.ExcludeRaisedAreas and len(holes) > 0:
                 for shape, wire in holes:
                     f = Part.makeFace(wire, 'Part::FaceMakerSimple')
                     env = PathUtils.getEnvelope(shape, subshape=f, depthparams=self.depthparams)
@@ -152,8 +153,8 @@ class ObjectFace(PathPocketBase.ObjectPocket):
         bb = planeshape.BoundBox
 
         # Apply offset for clearing edges
-        offset = 0;
-        if obj.ClearEdges == True:
+        offset = 0
+        if obj.ClearEdges:
             offset = self.radius + 0.1
 
         bb.XMin = bb.XMin - offset
@@ -164,7 +165,7 @@ class ObjectFace(PathPocketBase.ObjectPocket):
         if obj.BoundaryShape == 'Boundbox':
             bbperim = Part.makeBox(bb.XLength, bb.YLength, 1, FreeCAD.Vector(bb.XMin, bb.YMin, bb.ZMin), FreeCAD.Vector(0, 0, 1))
             env = PathUtils.getEnvelope(partshape=bbperim, depthparams=self.depthparams)
-            if obj.ExcludeRaisedAreas is True and oneBase[1] is True:
+            if obj.ExcludeRaisedAreas and oneBase[1]:
                 includedFaces = self.getAllIncludedFaces(oneBase[0], env, faceZ=minHeight)
                 if len(includedFaces) > 0:
                     includedShape = Part.makeCompound(includedFaces)
@@ -174,7 +175,7 @@ class ObjectFace(PathPocketBase.ObjectPocket):
             stock = PathUtils.findParentJob(obj).Stock.Shape
             env = stock
 
-            if obj.ExcludeRaisedAreas is True and oneBase[1] is True:
+            if obj.ExcludeRaisedAreas and oneBase[1]:
                 includedFaces = self.getAllIncludedFaces(oneBase[0], stock, faceZ=minHeight)
                 if len(includedFaces) > 0:
                     stockEnv = PathUtils.getEnvelope(partshape=stock, depthparams=self.depthparams)
@@ -184,13 +185,14 @@ class ObjectFace(PathPocketBase.ObjectPocket):
         else:
             env = PathUtils.getEnvelope(partshape=planeshape, depthparams=self.depthparams)
 
-        if holeShape is not None:
+        if holeShape:
             PathLog.info("Processing holes...")
             holeEnv = PathUtils.getEnvelope(partshape=holeShape, depthparams=self.depthparams)
             newEnv = env.cut(holeEnv)
-            return [(newEnv, False)]
+            tup = newEnv, False, 'pathMillFace', 0.0, 'X', obj.StartDepth.Value, obj.FinalDepth.Value
         else:
-            return [(env, False)]
+            tup = env, False, 'pathMillFace', 0.0, 'X', obj.StartDepth.Value, obj.FinalDepth.Value
+        return [tup]
 
     def areaOpSetDefaultValues(self, obj, job):
         '''areaOpSetDefaultValues(obj, job) ... initialize mill facing properties'''
@@ -215,7 +217,7 @@ class ObjectFace(PathPocketBase.ObjectPocket):
             face = b.Shape.Faces[fi]
             for ei in range(0, len(face.Edges)):
                 edge = face.Edges[ei]
-                if e.isSame(edge) is True:
+                if e.isSame(edge):
                     if f is face:
                         # Alternative: run loop to see if all edges are same
                         pass  # same source face, look for another
@@ -226,7 +228,7 @@ class ObjectFace(PathPocketBase.ObjectPocket):
 
     def getAllIncludedFaces(self, base, env, faceZ):
         included = []
-        
+
         eXMin = env.BoundBox.XMin
         eXMax = env.BoundBox.XMax
         eYMin = env.BoundBox.YMin
@@ -257,12 +259,12 @@ class ObjectFace(PathPocketBase.ObjectPocket):
             fYMax = face.BoundBox.YMax
             # fZMin = face.BoundBox.ZMin
             fZMax = face.BoundBox.ZMax
-            
+
             if fZMax > eZMin:
-                if isOverlap(fXMin, fXMax, eXMin, eXMax) is True:
-                    if isOverlap(fYMin, fYMax, eYMin, eYMax) is True:
+                if isOverlap(fXMin, fXMax, eXMin, eXMax):
+                    if isOverlap(fYMin, fYMax, eYMin, eYMax):
                         incl = True
-            if incl is True:
+            if incl:
                 included.append(face)
         return included
 

--- a/src/Mod/Path/PathScripts/PathPocketBase.py
+++ b/src/Mod/Path/PathScripts/PathPocketBase.py
@@ -71,16 +71,17 @@ class ObjectPocket(PathAreaOp.ObjectOp):
 
         # Pocket Properties
         obj.addProperty("App::PropertyEnumeration", "CutMode", "Pocket", QtCore.QT_TRANSLATE_NOOP("App::Property", "The direction that the toolpath should go around the part ClockWise (CW) or CounterClockWise (CCW)"))
-        obj.CutMode = ['Climb', 'Conventional']
         obj.addProperty("App::PropertyDistance", "ExtraOffset", "Pocket", QtCore.QT_TRANSLATE_NOOP("App::Property", "Extra offset to apply to the operation. Direction is operation dependent."))
         obj.addProperty("App::PropertyEnumeration", "StartAt", "Pocket", QtCore.QT_TRANSLATE_NOOP("App::Property", "Start pocketing at center or boundary"))
-        obj.StartAt = ['Center', 'Edge']
         obj.addProperty("App::PropertyPercent", "StepOver", "Pocket", QtCore.QT_TRANSLATE_NOOP("App::Property", "Percent of cutter diameter to step over on each pass"))
         obj.addProperty("App::PropertyFloat", "ZigZagAngle", "Pocket", QtCore.QT_TRANSLATE_NOOP("App::Property", "Angle of the zigzag pattern"))
         obj.addProperty("App::PropertyEnumeration", "OffsetPattern", "Face", QtCore.QT_TRANSLATE_NOOP("App::Property", "Clearing pattern to use"))
-        obj.OffsetPattern = ['ZigZag', 'Offset', 'Spiral', 'ZigZagOffset', 'Line', 'Grid', 'Triangle']
         obj.addProperty("App::PropertyBool", "MinTravel", "Pocket", QtCore.QT_TRANSLATE_NOOP("App::Property", "Use 3D Sorting of Path"))
         obj.addProperty("App::PropertyBool", "KeepToolDown", "Pocket", QtCore.QT_TRANSLATE_NOOP("App::Property", "Attempts to avoid unnecessary retractions."))
+
+        obj.CutMode = ['Climb', 'Conventional']
+        obj.StartAt = ['Center', 'Edge']
+        obj.OffsetPattern = ['ZigZag', 'Offset', 'Spiral', 'ZigZagOffset', 'Line', 'Grid', 'Triangle']
 
         self.initPocketOp(obj)
 
@@ -141,4 +142,7 @@ def SetupProperties():
     setup.append('StepOver')
     setup.append('ZigZagAngle')
     setup.append('OffsetPattern')
+    setup.append('StartAt')
+    setup.append('MinTravel')
+    setup.append('KeepToolDown')
     return setup


### PR DESCRIPTION
A long ***overdue*** fix/improvement for MillFace.  Allows access to faces where actual geometry would allow access with no problem, whether cutter will fit in face area or not.

Recent mention of need for such access, to tops of posts in recessed areas of model, in forum at [Help with Generating Tool Paths for a Specific Model](https://forum.freecadweb.org/viewtopic.php?style=3&f=15&t=46881).

![MillFace_BoundaryShape-FaceRegion_1small](https://user-images.githubusercontent.com/47639332/83342817-57912180-a2b9-11ea-8165-297533ab95f8.png)

![MillFace_BoundaryShape-FaceRegion_2small](https://user-images.githubusercontent.com/47639332/83342821-5f50c600-a2b9-11ea-953b-567ac4044b05.png)


 
Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm 
the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
