### PR TITLE
App: improve FunctionExpression forward compatibility

### DIFF
--- a/src/App/Expression.cpp
+++ b/src/App/Expression.cpp
@@ -1766,66 +1766,12 @@ bool OperatorExpression::isRightAssociative() const
 
 TYPESYSTEM_SOURCE(App::FunctionExpression, App::UnitExpression)
 
-FunctionExpression::FunctionExpression(const DocumentObject *_owner, Function _f, std::vector<Expression *> _args)
+FunctionExpression::FunctionExpression(const DocumentObject *_owner, Function _f, std::string &&name, std::vector<Expression *> _args)
     : UnitExpression(_owner)
     , f(_f)
+    , fname(std::move(name))
     , args(_args)
 {
-    switch (f) {
-    case ACOS:
-    case ASIN:
-    case ATAN:
-    case ABS:
-    case EXP:
-    case LOG:
-    case LOG10:
-    case SIN:
-    case SINH:
-    case TAN:
-    case TANH:
-    case SQRT:
-    case COS:
-    case COSH:
-    case ROUND:
-    case TRUNC:
-    case CEIL:
-    case FLOOR:
-    case MINVERT:
-        if (args.size() != 1)
-            EXPR_THROW("Invalid number of arguments: exactly one required.");
-        break;
-    case MOD:
-    case ATAN2:
-    case POW:
-        if (args.size() != 2)
-            EXPR_THROW("Invalid number of arguments: exactly two required.");
-        break;
-    case HYPOT:
-    case CATH:
-        if (args.size() < 2 || args.size() > 3)
-            EXPR_THROW("Invalid number of arguments: exactly two, or three required.");
-        break;
-    case STDDEV:
-    case SUM:
-    case AVERAGE:
-    case COUNT:
-    case MIN:
-    case MAX:
-    case CREATE:
-    case MSCALE:
-        if (args.size() == 0)
-            EXPR_THROW("Invalid number of arguments: at least one required.");
-        break;
-    case LIST:
-    case TUPLE:
-        break;
-    case NONE:
-    case AGGREGATES:
-    case LAST:
-    default:
-        EXPR_THROW("Unknown function");
-        break;
-    }
 }
 
 FunctionExpression::~FunctionExpression()
@@ -2392,7 +2338,7 @@ Expression *FunctionExpression::simplify() const
         return eval();
     }
     else
-        return new FunctionExpression(owner, f, a);
+        return new FunctionExpression(owner, f, std::string(fname), a);
 }
 
 /**
@@ -2473,7 +2419,7 @@ void FunctionExpression::_toString(std::ostream &ss, bool persistent,int) const
     case CREATE:
         ss << "create("; break;;
     default:
-        assert(0);
+        ss << fname << "("; break;;
     }
     for (size_t i = 0; i < args.size(); ++i) {
         ss << args[i]->toString(persistent);
@@ -2498,7 +2444,7 @@ Expression *FunctionExpression::_copy() const
         a.push_back((*i)->copy());
         ++i;
     }
-    return new FunctionExpression(owner, f, a);
+    return new FunctionExpression(owner, f, std::string(fname), a);
 }
 
 void FunctionExpression::_visit(ExpressionVisitor &v)

--- a/src/App/ExpressionParser.h
+++ b/src/App/ExpressionParser.h
@@ -287,7 +287,8 @@ public:
         LAST,
     };
 
-    FunctionExpression(const App::DocumentObject *_owner = 0, Function _f = NONE, std::vector<Expression *> _args = std::vector<Expression*>());
+    FunctionExpression(const App::DocumentObject *_owner = 0, Function _f = NONE, 
+            std::string &&name = std::string(), std::vector<Expression *> _args = std::vector<Expression*>());
 
     virtual ~FunctionExpression();
 
@@ -305,6 +306,7 @@ protected:
     virtual void _toString(std::ostream &ss, bool persistent, int indent) const override;
 
     Function f;        /**< Function to execute */
+    std::string fname;
     std::vector<Expression *> args; /** Arguments to function*/
 };
 
@@ -484,9 +486,9 @@ public:
   std::vector<Expression*> arguments;
   std::vector<Expression*> list;
   std::string string;
-  FunctionExpression::Function func;
+  std::pair<FunctionExpression::Function,std::string> func;
   ObjectIdentifier::String string_or_identifier;
-  semantic_type() : expr(0), ivalue(0), fvalue(0), func(FunctionExpression::NONE) {}
+  semantic_type() : expr(0), ivalue(0), fvalue(0), func({FunctionExpression::NONE, std::string()}) {}
 };
 
 #define YYSTYPE semantic_type

--- a/src/App/ExpressionParser.l
+++ b/src/App/ExpressionParser.l
@@ -342,9 +342,9 @@ $[A-Za-z]{1,2}{DIGIT}+       COUNTCHARS; yylval.string = yytext; return CELLADDR
                             s.erase(i + 1);
                             std::map<std::string, FunctionExpression::Function>::const_iterator j = registered_functions.find(s);
                             if (j != registered_functions.end())
-                              yylval.func = j->second;
-                            else
-                              yylval.func = FunctionExpression::NONE;
+                              yylval.func.first = j->second;
+                            else 
+                            { yylval.func.first = FunctionExpression::NONE; yylval.func.second = std::move(s); }
                             return FUNC;
                         }
 

--- a/src/App/ExpressionParser.tab.c
+++ b/src/App/ExpressionParser.tab.c
@@ -1517,7 +1517,7 @@ yyreduce:
 
   case 18:
 #line 85 "ExpressionParser.y" /* yacc.c:1646  */
-    { (yyval.expr) = new FunctionExpression(DocumentObject, (yyvsp[-2].func), (yyvsp[-1].arguments));                   }
+    { (yyval.expr) = new FunctionExpression(DocumentObject, (yyvsp[-2].func.first), std::move((yyvsp[-2].func.second)), (yyvsp[-1].arguments));                   }
 #line 1522 "ExpressionParser.tab.c" /* yacc.c:1646  */
     break;
 

--- a/src/App/ExpressionParser.y
+++ b/src/App/ExpressionParser.y
@@ -82,7 +82,7 @@ exp:      num                			{ $$ = $1;                                      
         | exp '/' unit_exp                      { $$ = new OperatorExpression(DocumentObject, $1, OperatorExpression::DIV, $3);   }
         | exp '^' exp                           { $$ = new OperatorExpression(DocumentObject, $1, OperatorExpression::POW, $3);   }
         | indexable       			    { $$ = $1;                                                                        }
-        | FUNC  args ')'  		        { $$ = new FunctionExpression(DocumentObject, $1, $2);                   }
+        | FUNC  args ')'  		        { $$ = new FunctionExpression(DocumentObject, $1.first, std::move($1.second), $2);        }
         | cond '?' exp ':' exp                  { $$ = new ConditionalExpression(DocumentObject, $1, $3, $5);                     }
         ;
 

--- a/src/App/lex.ExpressionParser.c
+++ b/src/App/lex.ExpressionParser.c
@@ -9286,9 +9286,9 @@ YY_RULE_SETUP
                             s.erase(i + 1);
                             std::map<std::string, FunctionExpression::Function>::const_iterator j = registered_functions.find(s);
                             if (j != registered_functions.end())
-                              yylval.func = j->second;
+                              yylval.func.first = j->second;
                             else
-                              yylval.func = FunctionExpression::NONE;
+                            { yylval.func.first = FunctionExpression::NONE; yylval.func.second = std::move(s); }
                             return FUNC;
                         }
 	YY_BREAK


### PR DESCRIPTION
Remove runtime check when constructing FunctionExpression (which actually cause crash in upstream), in order to support future built-in function. Exception will be thrown when evaluating the expression to inform user about the error.