### PR TITLE
[Draft]PathArray Colours and Angle Fix

### DIFF
--- a/src/Mod/Draft/draftobjects/patharray.py
+++ b/src/Mod/Draft/draftobjects/patharray.py
@@ -159,7 +159,17 @@ class PathArray(DraftLink):
                 base = calculatePlacementsOnPath(
                         obj.Base.Shape.Placement.Rotation,w,obj.Count,obj.Xlate,obj.Align, obj.AlignMode,
                             obj.ForceVertical, obj.VerticalVector)
-            return super(PathArray, self).buildShape(obj, pl, base)
+
+            #shape needs to be built before colors assigned
+            rc = super(PathArray, self).buildShape(obj, pl, base)
+            #match count of DiffuseColor entries to count of copies
+            vobdc = obj.Base.ViewObject.DiffuseColor
+            dc = vobdc
+            for x in range(obj.Count - 1):
+                dc =  dc + vobdc
+            obj.ViewObject.DiffuseColor = dc
+
+            return rc
 
     def getWireFromSubs(self,obj):
         '''Make a wire from PathObj subelements'''

--- a/src/Mod/Draft/draftobjects/patharray.py
+++ b/src/Mod/Draft/draftobjects/patharray.py
@@ -148,7 +148,7 @@ class PathArray(DraftLink):
                 baseRotation = basePlacement.Rotation
                 stdX = App.Vector(1.0, 0.0, 0.0)                          #default TangentVector
                 if (not DraftVecUtils.equals(stdX, obj.TangentVector)):
-                    preRotation = App.Rotation(stdX, obj.TangentVector)   #make rotation from X to TangentVector
+                    preRotation = App.Rotation(obj.TangentVector, stdX)   #make rotation from TangentVector to X
                     netRotation = baseRotation.multiply(preRotation)
                 else:
                     netRotation = baseRotation


### PR DESCRIPTION
- the prerotation for Tangent mode was reversed.
- face colours in the Base object were not propagated to the copies.


Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
