### PR TITLE
Draft: move several geometrical functions to individual modules, part 3

### DIFF
--- a/src/Mod/Draft/CMakeLists.txt
+++ b/src/Mod/Draft/CMakeLists.txt
@@ -41,6 +41,7 @@ SET (Draft_geoutils
     draftgeoutils/fillets.py
     draftgeoutils/offsets.py
     draftgeoutils/linear_algebra.py
+    draftgeoutils/cuboids.py
 )
 
 SET(Draft_tests

--- a/src/Mod/Draft/DraftGeomUtils.py
+++ b/src/Mod/Draft/DraftGeomUtils.py
@@ -113,16 +113,7 @@ from draftgeoutils.offsets import pocket2d
 from draftgeoutils.edges import orientEdge
 
 
-def mirror(point, edge):
-    """Find mirror point relative to an edge."""
-    normPoint = point.add(findDistance(point, edge, False))
-    if normPoint:
-        normPoint_point = Vector.sub(point, normPoint)
-        normPoint_refl = normPoint_point.negative()
-        refl = Vector.add(normPoint, normPoint_refl)
-        return refl
-    else:
-        return None
+from draftgeoutils.geometry import mirror
 
 
 from draftgeoutils.arcs import isClockwise

--- a/src/Mod/Draft/DraftGeomUtils.py
+++ b/src/Mod/Draft/DraftGeomUtils.py
@@ -223,73 +223,10 @@ from draftgeoutils.faces import bind
 from draftgeoutils.faces import cleanFaces
 
 
-def isCubic(shape):
-    """isCubic(shape): verifies if a shape is cubic, that is, has
-    8 vertices, 6 faces, and all angles are 90 degrees."""
-    # first we try fast methods
-    if len(shape.Vertexes) != 8:
-        return False
-    if len(shape.Faces) != 6:
-        return False
-    if len(shape.Edges) != 12:
-        return False
-    for e in shape.Edges:
-        if geomType(e) != "Line":
-            return False
-    # if ok until now, let's do more advanced testing
-    for f in shape.Faces:
-        if len(f.Edges) != 4: return False
-        for i in range(4):
-            e1 = vec(f.Edges[i])
-            if i < 3:
-                e2 = vec(f.Edges[i+1])
-            else: e2 = vec(f.Edges[0])
-            rpi = [0.0,round(math.pi/2,precision())]
-            if not round(e1.getAngle(e2),precision()) in rpi:
-                return False
-    return True
+from draftgeoutils.cuboids import isCubic
 
 
-def getCubicDimensions(shape):
-    """getCubicDimensions(shape): returns a list containing the placement,
-    the length, the width and the height of a cubic shape. If not cubic, nothing
-    is returned. The placement point is the lowest corner of the shape."""
-    if not isCubic(shape): return None
-    # determine lowest face, which will be our base
-    z = [10,1000000000000]
-    for i in range(len(shape.Faces)):
-        if shape.Faces[i].CenterOfMass.z < z[1]:
-            z = [i,shape.Faces[i].CenterOfMass.z]
-    if z[0] > 5: return None
-    base = shape.Faces[z[0]]
-    basepoint = base.Edges[0].Vertexes[0].Point
-    plpoint = base.CenterOfMass
-    basenorm = base.normalAt(0.5,0.5)
-    # getting length and width
-    vx = vec(base.Edges[0])
-    vy = vec(base.Edges[1])
-    # getting rotations
-    rotZ = DraftVecUtils.angle(vx)
-    rotY = DraftVecUtils.angle(vx,FreeCAD.Vector(vx.x,vx.y,0))
-    rotX = DraftVecUtils.angle(vy,FreeCAD.Vector(vy.x,vy.y,0))
-    # getting height
-    vz = None
-    rpi = round(math.pi/2,precision())
-    for i in range(1,6):
-        for e in shape.Faces[i].Edges:
-            if basepoint in [e.Vertexes[0].Point,e.Vertexes[1].Point]:
-                vtemp = vec(e)
-                # print(vtemp)
-                if round(vtemp.getAngle(vx),precision()) == rpi:
-                    if round(vtemp.getAngle(vy),precision()) == rpi:
-                        vz = vtemp
-    if not vz: return None
-    mat = FreeCAD.Matrix()
-    mat.move(plpoint)
-    mat.rotateX(rotX)
-    mat.rotateY(rotY)
-    mat.rotateZ(rotZ)
-    return [FreeCAD.Placement(mat),round(vx.Length,precision()),round(vy.Length,precision()),round(vz.Length,precision())]
+from draftgeoutils.cuboids import getCubicDimensions
 
 
 from draftgeoutils.wires import removeInterVertices

--- a/src/Mod/Draft/DraftGeomUtils.py
+++ b/src/Mod/Draft/DraftGeomUtils.py
@@ -244,26 +244,7 @@ from draftgeoutils.geometry import isPlanar
 from draftgeoutils.wires import findWiresOld
 
 
-def getTangent(edge, frompoint=None):
-        """
-        returns the tangent to an edge. If from point is given, it is used to
-        calculate the tangent (only useful for an arc of course).
-        """
-        if geomType(edge) == "Line":
-                return vec(edge)
-        elif geomType(edge) == "BSplineCurve" or \
-            geomType(edge) == "BezierCurve":
-                if not frompoint:
-                        return None
-                cp = edge.Curve.parameter(frompoint)
-                return edge.Curve.tangent(cp)[0]
-        elif geomType(edge) == "Circle":
-                if not frompoint:
-                        v1 = edge.Vertexes[0].Point.sub(edge.Curve.Center)
-                else:
-                        v1 = frompoint.sub(edge.Curve.Center)
-                return v1.cross(edge.Curve.Axis)
-        return None
+from draftgeoutils.edges import getTangent
 
 
 from draftgeoutils.faces import bind

--- a/src/Mod/Draft/DraftGeomUtils.py
+++ b/src/Mod/Draft/DraftGeomUtils.py
@@ -191,29 +191,8 @@ from draftgeoutils.intersections import connect
 from draftgeoutils.geometry import findDistance
 
 
-def angleBisection(edge1, edge2):
-    """angleBisection(edge,edge) - Returns an edge that bisects the angle between the 2 edges."""
-    if (geomType(edge1) == "Line") and (geomType(edge2) == "Line"):
-        p1 = edge1.Vertexes[0].Point
-        p2 = edge1.Vertexes[-1].Point
-        p3 = edge2.Vertexes[0].Point
-        p4 = edge2.Vertexes[-1].Point
-        int = findIntersection(edge1, edge2, True, True)
-        if int:
-            line1Dir = p2.sub(p1)
-            angleDiff = DraftVecUtils.angle(line1Dir, p4.sub(p3))
-            ang = angleDiff * 0.5
-            origin = int[0]
-            line1Dir.normalize()
-            dir = DraftVecUtils.rotate(line1Dir, ang)
-            return Part.LineSegment(origin,origin.add(dir)).toShape()
-        else:
-            diff = p3.sub(p1)
-            origin = p1.add(diff.multiply(0.5))
-            dir = p2.sub(p1); dir.normalize()
-            return Part.LineSegment(origin,origin.add(dir)).toShape()
-    else:
-        return None
+from draftgeoutils.intersections import angleBisection
+
 
 def findClosestCircle(point, circles):
     """Return the circle with closest center."""

--- a/src/Mod/Draft/DraftGeomUtils.py
+++ b/src/Mod/Draft/DraftGeomUtils.py
@@ -380,27 +380,7 @@ from draftgeoutils.wires import tessellateProjection
 from draftgeoutils.wires import rebaseWire
 
 
-def removeSplitter(shape):
-    """an alternative, shared edge-based version of Part.removeSplitter. Returns a
-    face or None if the operation failed"""
-    lut = {}
-    for f in shape.Faces:
-        for e in f.Edges:
-            h = e.hashCode()
-            if h in lut:
-                lut[h].append(e)
-            else:
-                lut[h] = [e]
-    edges = [e[0] for e in lut.values() if len(e) == 1]
-    try:
-        face = Part.Face(Part.Wire(edges))
-    except:
-        # operation failed
-        return None
-    else:
-        if face.isValid():
-            return face
-    return None
+from draftgeoutils.faces import removeSplitter
 
 
 # circle functions *********************************************************

--- a/src/Mod/Draft/DraftGeomUtils.py
+++ b/src/Mod/Draft/DraftGeomUtils.py
@@ -46,9 +46,9 @@ __title__ = "FreeCAD Draft Workbench - Geometry library"
 __author__ = "Yorik van Havre, Jacques-Antoine Gaudin, Ken Cline"
 __url__ = ["https://www.freecadweb.org"]
 
-NORM = Vector(0, 0, 1)  # provisory normal direction for all geometry ops.
+from draftgeoutils.general import PARAMGRP as params
 
-params = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/Draft")
+from draftgeoutils.general import NORM
 
 # Generic functions *********************************************************
 
@@ -134,22 +134,7 @@ from draftgeoutils.edges import isSameLine
 from draftgeoutils.arcs import isWideAngle
 
 
-def findClosest(basepoint, pointslist):
-    """
-    findClosest(vector,list)
-    in a list of 3d points, finds the closest point to the base point.
-    an index from the list is returned.
-    """
-    npoint = None
-    if not pointslist:
-        return None
-    smallest = 1000000
-    for n in range(len(pointslist)):
-        new = basepoint.sub(pointslist[n]).Length
-        if new < smallest:
-            smallest = new
-            npoint = n
-    return npoint
+from draftgeoutils.general import findClosest
 
 
 from draftgeoutils.faces import concatenate

--- a/src/Mod/Draft/draftgeoutils/cuboids.py
+++ b/src/Mod/Draft/draftgeoutils/cuboids.py
@@ -1,0 +1,130 @@
+# ***************************************************************************
+# *   Copyright (c) 2009, 2010 Yorik van Havre <yorik@uncreated.net>        *
+# *   Copyright (c) 2009, 2010 Ken Cline <cline@frii.com>                   *
+# *                                                                         *
+# *   This file is part of the FreeCAD CAx development system.              *
+# *                                                                         *
+# *   This program is free software; you can redistribute it and/or modify  *
+# *   it under the terms of the GNU Lesser General Public License (LGPL)    *
+# *   as published by the Free Software Foundation; either version 2 of     *
+# *   the License, or (at your option) any later version.                   *
+# *   for detail see the LICENCE text file.                                 *
+# *                                                                         *
+# *   FreeCAD is distributed in the hope that it will be useful,            *
+# *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+# *   GNU Library General Public License for more details.                  *
+# *                                                                         *
+# *   You should have received a copy of the GNU Library General Public     *
+# *   License along with FreeCAD; if not, write to the Free Software        *
+# *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
+# *   USA                                                                   *
+# *                                                                         *
+# ***************************************************************************
+"""Provides various functions for cubic shapes (parallelepipeds)."""
+## @package cuboids
+# \ingroup DRAFTGEOUTILS
+# \brief Provides various functions for cubic shapes (parallelepipeds).
+
+import math
+
+import FreeCAD as App
+import DraftVecUtils
+
+from draftgeoutils.general import geomType, vec, precision
+
+
+def isCubic(shape):
+    """Return True if the shape is a parallelepiped (cuboid).
+
+    A parallelepiped of cube-like shape has 8 vertices, 6 faces, 12 edges,
+    and all angles are 90 degrees between its edges.
+    """
+    # first we try fast methods
+    if (len(shape.Vertexes) != 8
+            or len(shape.Faces) != 6
+            or len(shape.Edges) != 12):
+        return False
+
+    for e in shape.Edges:
+        if geomType(e) != "Line":
+            return False
+
+    # if ok until now, let's do more advanced testing
+    for f in shape.Faces:
+        if len(f.Edges) != 4:
+            return False
+
+        for i in range(4):
+            e1 = vec(f.Edges[i])
+            if i < 3:
+                e2 = vec(f.Edges[i+1])
+            else:
+                e2 = vec(f.Edges[0])
+            rpi = [0.0, round(math.pi/2, precision())]
+            if round(e1.getAngle(e2), precision()) not in rpi:
+                return False
+
+    return True
+
+
+def getCubicDimensions(shape):
+    """Return a list containing the placement, and dimensions of the shape.
+
+    The dimensios are length, width and height of a the parallelepiped,
+    rounded to the value indicated by `precision`.
+    The placement point is the lowest corner of the shape.
+
+    If it is not a parallelepiped (cuboid), return None.
+    """
+    if not isCubic(shape):
+        return None
+
+    # determine lowest face, which will be our base
+    z = [10, 1000000000000]
+    for i in range(len(shape.Faces)):
+        if shape.Faces[i].CenterOfMass.z < z[1]:
+            z = [i, shape.Faces[i].CenterOfMass.z]
+
+    if z[0] > 5:
+        return None
+
+    base = shape.Faces[z[0]]
+    basepoint = base.Edges[0].Vertexes[0].Point
+    plpoint = base.CenterOfMass
+    # basenorm = base.normalAt(0.5, 0.5)
+
+    # getting length and width
+    vx = vec(base.Edges[0])
+    vy = vec(base.Edges[1])
+
+    # getting rotations
+    rotZ = DraftVecUtils.angle(vx)
+    rotY = DraftVecUtils.angle(vx, App.Vector(vx.x, vx.y, 0))
+    rotX = DraftVecUtils.angle(vy, App.Vector(vy.x, vy.y, 0))
+
+    # getting height
+    vz = None
+    rpi = round(math.pi/2, precision())
+    for i in range(1, 6):
+        for e in shape.Faces[i].Edges:
+            if basepoint in [e.Vertexes[0].Point, e.Vertexes[1].Point]:
+                vtemp = vec(e)
+                # print(vtemp)
+                if round(vtemp.getAngle(vx), precision()) == rpi:
+                    if round(vtemp.getAngle(vy), precision()) == rpi:
+                        vz = vtemp
+
+    if not vz:
+        return None
+
+    mat = App.Matrix()
+    mat.move(plpoint)
+    mat.rotateX(rotX)
+    mat.rotateY(rotY)
+    mat.rotateZ(rotZ)
+
+    return [App.Placement(mat),
+            round(vx.Length, precision()),
+            round(vy.Length, precision()),
+            round(vz.Length, precision())]

--- a/src/Mod/Draft/draftgeoutils/edges.py
+++ b/src/Mod/Draft/draftgeoutils/edges.py
@@ -31,7 +31,7 @@ import lazy_loader.lazy_loader as lz
 import FreeCAD
 import DraftVecUtils
 
-from draftgeoutils.general import geomType
+from draftgeoutils.general import geomType, vec
 
 # Delay import of module until first use because it is heavy
 Part = lz.LazyLoader("Part", globals(), "Part")
@@ -179,3 +179,29 @@ def findMidpoint(edge):
 
     else:
         return None
+
+
+def getTangent(edge, from_point=None):
+    """Return the tangent to an edge, including BSpline and circular arcs.
+
+    If from_point is given, it is used to calculate the tangent,
+    only useful for a circular arc.
+    """
+    if geomType(edge) == "Line":
+        return vec(edge)
+
+    elif (geomType(edge) == "BSplineCurve"
+          or geomType(edge) == "BezierCurve"):
+        if not from_point:
+            return None
+        cp = edge.Curve.parameter(from_point)
+        return edge.Curve.tangent(cp)[0]
+
+    elif geomType(edge) == "Circle":
+        if not from_point:
+            v1 = edge.Vertexes[0].Point.sub(edge.Curve.Center)
+        else:
+            v1 = from_point.sub(edge.Curve.Center)
+        return v1.cross(edge.Curve.Axis)
+
+    return None

--- a/src/Mod/Draft/draftgeoutils/faces.py
+++ b/src/Mod/Draft/draftgeoutils/faces.py
@@ -229,3 +229,32 @@ def cleanFaces(shape):
     if shape.isClosed():
         fshape = Part.makeSolid(fshape)
     return fshape
+
+
+def removeSplitter(shape):
+    """Return a face from removing the splitter in a list of faces.
+
+    This is an alternative, shared edge-based version of Part.removeSplitter.
+    Returns a face, or `None` if the operation failed.
+    """
+    lookup = dict()
+    for f in shape.Faces:
+        for e in f.Edges:
+            h = e.hashCode()
+            if h in lookup:
+                lookup[h].append(e)
+            else:
+                lookup[h] = [e]
+
+    edges = [e[0] for e in lookup.values() if len(e) == 1]
+
+    try:
+        face = Part.Face(Part.Wire(edges))
+    except:
+        # operation failed
+        return None
+    else:
+        if face.isValid():
+            return face
+
+    return None

--- a/src/Mod/Draft/draftgeoutils/general.py
+++ b/src/Mod/Draft/draftgeoutils/general.py
@@ -35,7 +35,10 @@ import DraftVecUtils
 # Delay import of module until first use because it is heavy
 Part = lz.LazyLoader("Part", globals(), "Part")
 
-params = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/Draft")
+PARAMGRP = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/Draft")
+
+# Default normal direction for all geometry operations
+NORM = FreeCAD.Vector(0, 0, 1)
 
 
 def precision():
@@ -49,9 +52,9 @@ def precision():
     #      15 that the code would never consider 2 points are coincident
     #      as internal float is not that precise)
     precisionMax = 10
-    precisionInt = params.GetInt("precision", 6)
+    precisionInt = PARAMGRP.GetInt("precision", 6)
     precisionInt = (precisionInt if precisionInt <= 10 else precisionMax)
-    return precisionInt	 # return params.GetInt("precision",6)
+    return precisionInt  # return PARAMGRP.GetInt("precision", 6)
 
 
 def vec(edge):
@@ -265,3 +268,28 @@ def isValidPath(shape):
     if shape.isClosed():
         return False
     return True
+
+
+def findClosest(base_point, point_list):
+    """Find closest point in a list of points to the base point.
+
+    Returns
+    -------
+    int
+        An index from the list of points is returned.
+
+    None
+        If point_list is empty.
+    """
+    npoint = None
+    if not point_list:
+        return None
+
+    smallest = 1000000
+    for n in range(len(point_list)):
+        new = base_point.sub(point_list[n]).Length
+        if new < smallest:
+            smallest = new
+            npoint = n
+
+    return npoint

--- a/src/Mod/Draft/draftgeoutils/geometry.py
+++ b/src/Mod/Draft/draftgeoutils/geometry.py
@@ -319,3 +319,16 @@ def calculatePlacement(shape):
         pla.Rotation = r
 
     return pla
+
+
+def mirror(point, edge):
+    """Find mirror point relative to an edge."""
+    normPoint = point.add(findDistance(point, edge, False))
+
+    if normPoint:
+        normPoint_point = FreeCAD.Vector.sub(point, normPoint)
+        normPoint_refl = normPoint_point.negative()
+        refl = FreeCAD.Vector.add(normPoint, normPoint_refl)
+        return refl
+    else:
+        return None

--- a/src/Mod/Draft/draftgeoutils/intersections.py
+++ b/src/Mod/Draft/draftgeoutils/intersections.py
@@ -384,3 +384,30 @@ def connect(edges, closed=False):
                   e.Vertexes[0].Point, " ",
                   e.Vertexes[-1].Point)
         return None
+
+
+def angleBisection(edge1, edge2):
+    """Return an edge that bisects the angle between the 2 straight edges."""
+    if geomType(edge1) != "Line" or geomType(edge2) != "Line":
+        return None
+
+    p1 = edge1.Vertexes[0].Point
+    p2 = edge1.Vertexes[-1].Point
+    p3 = edge2.Vertexes[0].Point
+    p4 = edge2.Vertexes[-1].Point
+    intersect = findIntersection(edge1, edge2, True, True)
+
+    if intersect:
+        line1Dir = p2.sub(p1)
+        angleDiff = DraftVecUtils.angle(line1Dir, p4.sub(p3))
+        ang = angleDiff * 0.5
+        origin = intersect[0]
+        line1Dir.normalize()
+        direction = DraftVecUtils.rotate(line1Dir, ang)
+    else:
+        diff = p3.sub(p1)
+        origin = p1.add(diff.multiply(0.5))
+        direction = p2.sub(p1)
+        direction.normalize()
+
+    return Part.LineSegment(origin, origin.add(direction)).toShape()

--- a/src/Mod/Draft/draftgeoutils/wires.py
+++ b/src/Mod/Draft/draftgeoutils/wires.py
@@ -27,12 +27,13 @@
 # \brief Provides various functions for working with wires.
 
 import lazy_loader.lazy_loader as lz
+import math
 
 import DraftVecUtils
 import WorkingPlane
 
-from draftgeoutils.general import geomType
-from draftgeoutils.edges import findMidpoint
+from draftgeoutils.general import geomType, vec, precision
+from draftgeoutils.edges import findMidpoint, isLine
 from draftgeoutils.geometry import getNormal
 
 # Delay import of module until first use because it is heavy
@@ -312,3 +313,119 @@ def rebaseWire(wire, vidx=0):
 
     # This can be done in one step
     return Part.Wire(wire.Edges[vidx-1:] + wire.Edges[:vidx-1])
+
+
+def removeInterVertices(wire):
+    """Remove middle vertices from a straight wire and return a new wire.
+
+    Remove unneeded vertices, those that are in the middle of a straight line,
+    from a wire, return a new wire.
+    """
+    _pre = precision()
+    edges = Part.__sortEdges__(wire.Edges)
+    nverts = []
+
+    def getvec(v1, v2):
+        if not abs(round(v1.getAngle(v2), _pre) in [0, round(math.pi, _pre)]):
+            nverts.append(edges[i].Vertexes[-1].Point)
+
+    for i in range(len(edges) - 1):
+        vA = vec(edges[i])
+        vB = vec(edges[i + 1])
+        getvec(vA, vB)
+
+    vA = vec(edges[-1])
+    vB = vec(edges[0])
+    getvec(vA, vB)
+
+    if nverts:
+        if wire.isClosed():
+            nverts.append(nverts[0])
+        w = Part.makePolygon(nverts)
+        return w
+    else:
+        return wire
+
+
+def cleanProjection(shape, tessellate=True, seglength=0.05):
+    """Return a valid compound of edges, by recreating them.
+
+    This is because the projection algorithm somehow creates wrong shapes.
+    They display fine, but on loading the file the shape is invalid.
+
+    Now with tanderson's fix to `ProjectionAlgos`, that isn't the case,
+    but this function can be used for tessellating ellipses and splines
+    for DXF output-DF.
+    """
+    oldedges = shape.Edges
+    newedges = []
+    for e in oldedges:
+        try:
+            if geomType(e) == "Line":
+                newedges.append(e.Curve.toShape())
+
+            elif geomType(e) == "Circle":
+                if len(e.Vertexes) > 1:
+                    mp = findMidpoint(e)
+                    a = Part.Arc(e.Vertexes[0].Point,
+                                 mp,
+                                 e.Vertexes[-1].Point).toShape()
+                    newedges.append(a)
+                else:
+                    newedges.append(e.Curve.toShape())
+
+            elif geomType(e) == "Ellipse":
+                if tessellate:
+                    newedges.append(Part.Wire(curvetowire(e, seglength)))
+                else:
+                    if len(e.Vertexes) > 1:
+                        a = Part.Arc(e.Curve,
+                                     e.FirstParameter,
+                                     e.LastParameter).toShape()
+                        newedges.append(a)
+                    else:
+                        newedges.append(e.Curve.toShape())
+
+            elif (geomType(e) == "BSplineCurve"
+                  or geomType(e) == "BezierCurve"):
+                if tessellate:
+                    newedges.append(Part.Wire(curvetowire(e, seglength)))
+                else:
+                    if isLine(e.Curve):
+                        line = Part.LineSegment(e.Vertexes[0].Point,
+                                                e.Vertexes[-1].Point).toShape()
+                        newedges.append(line)
+                    else:
+                        newedges.append(e.Curve.toShape(e.FirstParameter,
+                                                        e.LastParameter))
+            else:
+                newedges.append(e)
+        except Exception:
+            print("Debug: error cleaning edge ", e)
+
+    return Part.makeCompound(newedges)
+
+
+def tessellateProjection(shape, seglen):
+    """Return projection with BSplines and Ellipses broken into line segments.
+
+    Useful for exporting projected views to DXF files.
+    """
+    oldedges = shape.Edges
+    newedges = []
+    for e in oldedges:
+        try:
+            if geomType(e) == "Line":
+                newedges.append(e.Curve.toShape())
+            elif geomType(e) == "Circle":
+                newedges.append(e.Curve.toShape())
+            elif geomType(e) == "Ellipse":
+                newedges.append(Part.Wire(curvetosegment(e, seglen)))
+            elif geomType(e) == "BSplineCurve":
+                newedges.append(Part.Wire(curvetosegment(e, seglen)))
+            else:
+                newedges.append(e)
+        except Exception:
+            print("Debug: error cleaning edge ", e)
+
+    return Part.makeCompound(newedges)


### PR DESCRIPTION
Various functions in `DraftGeomUtils.py` will be moved to individual modules, so that the code is more structured and maintainable.

In this pull request we move more functions about edges, wires, geometry, intersections, faces, and cuboids (parallelepipeds).

This pull request follows after #3494 and #3498.

---

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists
