### PR TITLE
Draft: move several geometrical functions to individual modules, part 5

### DIFF
--- a/src/Mod/Draft/DraftGeomUtils.py
+++ b/src/Mod/Draft/DraftGeomUtils.py
@@ -34,292 +34,128 @@ and on their subelements, that is, vertices, edges, and faces.
 
 ## \addtogroup DRAFTGEOMUTILS
 #  @{
-import cmath
-import math
-
-import FreeCAD
-import Part
-import DraftVecUtils
-from FreeCAD import Vector
 
 __title__ = "FreeCAD Draft Workbench - Geometry library"
 __author__ = "Yorik van Havre, Jacques-Antoine Gaudin, Ken Cline"
 __url__ = ["https://www.freecadweb.org"]
 
-from draftgeoutils.general import PARAMGRP as params
+# Doesn't need requisites
+from draftgeoutils.linear_algebra import (linearFromPoints,
+                                          determinant)
 
+# Needs math, Part, and vector tools
+from draftgeoutils.general import PARAMGRP as params
 from draftgeoutils.general import NORM
 
-# Generic functions *********************************************************
+from draftgeoutils.general import (precision,
+                                   vec,
+                                   edg,
+                                   getVerts,
+                                   v1,
+                                   isNull,
+                                   isPtOnEdge,
+                                   hasCurves,
+                                   isAligned,
+                                   getQuad,
+                                   areColinear,
+                                   hasOnlyWires,
+                                   geomType,
+                                   isValidPath,
+                                   findClosest,
+                                   getBoundaryAngles)
+
+# Needs general functions
+from draftgeoutils.geometry import (findPerpendicular,
+                                    findDistance,
+                                    getSplineNormal,
+                                    getNormal,
+                                    getRotation,
+                                    isPlanar,
+                                    calculatePlacement,
+                                    mirror)
+
+from draftgeoutils.edges import (findEdge,
+                                 orientEdge,
+                                 isSameLine,
+                                 isLine,
+                                 invert,
+                                 findMidpoint,
+                                 getTangent)
+
+from draftgeoutils.faces import (concatenate,
+                                 getBoundary,
+                                 isCoplanar,
+                                 bind,
+                                 cleanFaces,
+                                 removeSplitter)
+
+from draftgeoutils.arcs import (isClockwise,
+                                isWideAngle,
+                                arcFrom2Pts,
+                                arcFromSpline)
+
+from draftgeoutils.cuboids import (isCubic,
+                                   getCubicDimensions)
+
+# Needs geometry functions
+from draftgeoutils.circle_inversion import (pointInversion,
+                                            polarInversion,
+                                            circleInversion)
+
+# Needs edges functions
+from draftgeoutils.sort_edges import (sortEdges,
+                                      sortEdgesOld)
+
+from draftgeoutils.intersections import (findIntersection,
+                                         wiresIntersect,
+                                         connect,
+                                         angleBisection)
+
+from draftgeoutils.wires import (findWires,
+                                 findWiresOld,
+                                 findWiresOld2,
+                                 flattenWire,
+                                 superWire,
+                                 isReallyClosed,
+                                 curvetowire,
+                                 curvetosegment,
+                                 rebaseWire,
+                                 removeInterVertices,
+                                 cleanProjection,
+                                 tessellateProjection)
+
+# Needs wires functions
+from draftgeoutils.fillets import (fillet,
+                                   filletWire)
+
+# Needs intersections functions
+from draftgeoutils.offsets import (pocket2d,
+                                   offset,
+                                   offsetWire)
+
+from draftgeoutils.circles import (findClosestCircle,
+                                   getCircleFromSpline,
+                                   circlefrom1Line2Points,
+                                   circlefrom2Lines1Point,
+                                   circleFrom2LinesRadius,
+                                   circleFrom3LineTangents,
+                                   circleFromPointLineRadius,
+                                   circleFrom2PointsRadius,
+                                   findHomotheticCenterOfCircles,
+                                   findRadicalAxis,
+                                   findRadicalCenter)
+
+from draftgeoutils.circles_apollonius import (outerSoddyCircle,
+                                              innerSoddyCircle,
+                                              circleFrom3CircleTangents)
 
-
-from draftgeoutils.general import precision
-
-
-from draftgeoutils.general import vec
-
-
-from draftgeoutils.general import edg
-
-
-from draftgeoutils.general import getVerts
-
-
-from draftgeoutils.general import v1
-
-
-from draftgeoutils.general import isNull
-
-
-from draftgeoutils.general import isPtOnEdge
-
-
-from draftgeoutils.general import hasCurves
-
-
-from draftgeoutils.general import isAligned
-
-
-from draftgeoutils.general import getQuad
-
-
-from draftgeoutils.general import areColinear
-
-
-from draftgeoutils.general import hasOnlyWires
-
-
-from draftgeoutils.general import geomType
-
-
-from draftgeoutils.general import isValidPath
-
-
-# edge functions *************************************************************
-
-
-from draftgeoutils.edges import findEdge
-
-
-from draftgeoutils.intersections import findIntersection
-
-
-from draftgeoutils.intersections import wiresIntersect
-
-
-from draftgeoutils.offsets import pocket2d
-
-
-from draftgeoutils.edges import orientEdge
-
-
-from draftgeoutils.geometry import mirror
-
-
-from draftgeoutils.arcs import isClockwise
-
-
-from draftgeoutils.edges import isSameLine
-
-
-from draftgeoutils.arcs import isWideAngle
-
-
-from draftgeoutils.general import findClosest
-
-
-from draftgeoutils.faces import concatenate
-
-
-from draftgeoutils.faces import getBoundary
-
-
-from draftgeoutils.edges import isLine
-
-
-from draftgeoutils.sort_edges import sortEdges
-
-
-from draftgeoutils.sort_edges import sortEdgesOld
-
-
-from draftgeoutils.edges import invert
-
-
-from draftgeoutils.wires import flattenWire
-
-
-from draftgeoutils.wires import findWires
-
-
-from draftgeoutils.wires import findWiresOld2
-
-
-from draftgeoutils.wires import superWire
-
-
-from draftgeoutils.edges import findMidpoint
-
-
-from draftgeoutils.geometry import findPerpendicular
-
-
-from draftgeoutils.offsets import offset
-
-
-from draftgeoutils.wires import isReallyClosed
-
-
-from draftgeoutils.geometry import getSplineNormal
-
-
-from draftgeoutils.geometry import getNormal
-
-
-from draftgeoutils.geometry import getRotation
-
-
-from draftgeoutils.geometry import calculatePlacement
-
-
-from draftgeoutils.offsets import offsetWire
-
-
-from draftgeoutils.intersections import connect
-
-
-from draftgeoutils.geometry import findDistance
-
-
-from draftgeoutils.intersections import angleBisection
-
-
-from draftgeoutils.circles import findClosestCircle
-
-
-from draftgeoutils.faces import isCoplanar
-
-
-from draftgeoutils.geometry import isPlanar
-
-
-from draftgeoutils.wires import findWiresOld
-
-
-from draftgeoutils.edges import getTangent
-
-
-from draftgeoutils.faces import bind
-
-
-from draftgeoutils.faces import cleanFaces
-
-
-from draftgeoutils.cuboids import isCubic
-
-
-from draftgeoutils.cuboids import getCubicDimensions
-
-
-from draftgeoutils.wires import removeInterVertices
-
-
-from draftgeoutils.arcs import arcFromSpline
-
-
-from draftgeoutils.fillets import fillet
-
-
-from draftgeoutils.fillets import filletWire
-
-
-from draftgeoutils.circles import getCircleFromSpline
-
-
-from draftgeoutils.wires import curvetowire
-
-
-from draftgeoutils.wires import cleanProjection
-
-
-from draftgeoutils.wires import curvetosegment
-
-
-from draftgeoutils.wires import tessellateProjection
-
-
-from draftgeoutils.wires import rebaseWire
-
-
-from draftgeoutils.faces import removeSplitter
-
-
-# circle functions *********************************************************
-
-
-from draftgeoutils.general import getBoundaryAngles
-
-
+# Needs circles_apollonius functions
 # These functions are not imported because they are incomplete;
 # they require pre-requisite functions that haven't been written
-# from draftgeoutils.circles_incomplete import circleFrom2tan1pt
-# from draftgeoutils.circles_incomplete import circleFrom2tan1rad
-# from draftgeoutils.circles_incomplete import circleFrom1tan2pt
-# from draftgeoutils.circles_incomplete import circleFrom1tan1pt1rad
-# from draftgeoutils.circles_incomplete import circleFrom3tan
-
-
-from draftgeoutils.circles import circlefrom2Lines1Point
-
-
-from draftgeoutils.circles import circlefrom1Line2Points
-
-
-from draftgeoutils.circles import circleFrom2LinesRadius
-
-
-from draftgeoutils.circles import circleFrom3LineTangents
-
-
-from draftgeoutils.circles import circleFromPointLineRadius
-
-
-from draftgeoutils.circles import circleFrom2PointsRadius
-
-
-from draftgeoutils.arcs import arcFrom2Pts
-
-
-from draftgeoutils.circles_apollonius import outerSoddyCircle
-
-
-from draftgeoutils.circles_apollonius import innerSoddyCircle
-
-
-from draftgeoutils.circles_apollonius import circleFrom3CircleTangents
-
-
-from draftgeoutils.linear_algebra import linearFromPoints
-
-
-from draftgeoutils.linear_algebra import determinant
-
-
-from draftgeoutils.circles import findHomotheticCenterOfCircles
-
-
-from draftgeoutils.circles import findRadicalAxis
-
-
-from draftgeoutils.circles import findRadicalCenter
-
-
-from draftgeoutils.circle_inversion import pointInversion
-
-
-from draftgeoutils.circle_inversion import polarInversion
-
-
-from draftgeoutils.circle_inversion import circleInversion
+# from draftgeoutils.circles_incomplete import (circleFrom2tan1pt,
+#                                               circleFrom2tan1rad,
+#                                               circleFrom1tan2pt,
+#                                               circleFrom1tan1pt1rad,
+#                                               circleFrom3tan)
 
 ##  @}

--- a/src/Mod/Draft/draftgeoutils/arcs.py
+++ b/src/Mod/Draft/draftgeoutils/arcs.py
@@ -26,10 +26,10 @@
 # \ingroup DRAFTGEOUTILS
 # \brief Provides various functions for arc operations.
 
-import lazy_loader.lazy_loader as lz
 import math
+import lazy_loader.lazy_loader as lz
 
-import FreeCAD
+import FreeCAD as App
 import DraftVecUtils
 
 from draftgeoutils.general import geomType
@@ -53,7 +53,7 @@ def isClockwise(edge, ref=None):
     n = edge.Curve.Axis
     # if that axis points "the wrong way" from the reference, we invert it
     if not ref:
-        ref = FreeCAD.Vector(0, 0, 1)
+        ref = App.Vector(0, 0, 1)
     if n.getAngle(ref) > math.pi/2:
         n = n.negative()
 
@@ -89,7 +89,7 @@ def arcFrom2Pts(firstPt, lastPt, center, axis=None):
     if round(radius1-radius2, 4) != 0:
         return None
 
-    thirdPt = FreeCAD.Vector(firstPt.sub(center).add(lastPt).sub(center))
+    thirdPt = App.Vector(firstPt.sub(center).add(lastPt).sub(center))
     thirdPt.normalize()
     thirdPt.scale(radius1, radius1, radius1)
     thirdPt = thirdPt.add(center)
@@ -125,7 +125,7 @@ def arcFromSpline(edge):
         p3 = edge.valueAt(ml)
         try:
             return Part.Arc(p1, p3, p2).toShape()
-        except:
+        except Part.OCCError:
             print("Couldn't make an arc out of this edge")
             return None
     else:
@@ -139,6 +139,6 @@ def arcFromSpline(edge):
         radius = ray.Length
         try:
             return Part.makeCircle(radius, center)
-        except:
+        except Part.OCCError:
             print("couldn't make a circle out of this edge")
             return None

--- a/src/Mod/Draft/draftgeoutils/circles.py
+++ b/src/Mod/Draft/draftgeoutils/circles.py
@@ -37,7 +37,6 @@ from draftgeoutils.geometry import mirror, findDistance
 from draftgeoutils.edges import findMidpoint
 from draftgeoutils.intersections import findIntersection, angleBisection
 
-
 # Delay import of module until first use because it is heavy
 Part = lz.LazyLoader("Part", globals(), "Part")
 

--- a/src/Mod/Draft/draftgeoutils/circles_apollonius.py
+++ b/src/Mod/Draft/draftgeoutils/circles_apollonius.py
@@ -48,11 +48,9 @@ import math
 import lazy_loader.lazy_loader as lz
 
 import FreeCAD as App
-import DraftVecUtils
 
-from draftgeoutils.general import geomType, vec, NORM
+from draftgeoutils.general import geomType, NORM
 from draftgeoutils.intersections import findIntersection
-
 
 # Delay import of module until first use because it is heavy
 Part = lz.LazyLoader("Part", globals(), "Part")

--- a/src/Mod/Draft/draftgeoutils/edges.py
+++ b/src/Mod/Draft/draftgeoutils/edges.py
@@ -28,7 +28,7 @@
 
 import lazy_loader.lazy_loader as lz
 
-import FreeCAD
+import FreeCAD as App
 import DraftVecUtils
 
 from draftgeoutils.general import geomType, vec
@@ -58,17 +58,17 @@ def orientEdge(edge, normal=None, make_arc=False):
     """
     # This 'normalizes' the placement to the xy plane
     edge = edge.copy()
-    xyDir = FreeCAD.Vector(0, 0, 1)
-    base = FreeCAD.Vector(0, 0, 0)
+    xyDir = App.Vector(0, 0, 1)
+    base = App.Vector(0, 0, 0)
 
     if normal:
-        angle = DraftVecUtils.angle(normal, xyDir) * FreeCAD.Units.Radian
+        angle = DraftVecUtils.angle(normal, xyDir) * App.Units.Radian
         axis = normal.cross(xyDir)
     else:
         axis = edge.Placement.Rotation.Axis
-        angle = -1*edge.Placement.Rotation.Angle*FreeCAD.Units.Radian
-    if axis == FreeCAD.Vector(0.0, 0.0, 0.0):
-        axis = FreeCAD.Vector(0.0, 0.0, 1.0)
+        angle = -1 * edge.Placement.Rotation.Angle * App.Units.Radian
+    if axis == App.Vector(0.0, 0.0, 0.0):
+        axis = App.Vector(0.0, 0.0, 1.0)
     if angle:
         edge.rotate(base, axis, angle)
     if isinstance(edge.Curve, Part.Line):
@@ -169,13 +169,13 @@ def findMidpoint(edge):
         ray = first.sub(center)
         apothem = ray.dot(perp)
         sagitta = radius - apothem
-        startpoint = FreeCAD.Vector.add(first, chord.multiply(0.5))
+        startpoint = App.Vector.add(first, chord.multiply(0.5))
         endpoint = DraftVecUtils.scaleTo(perp, sagitta)
-        return FreeCAD.Vector.add(startpoint, endpoint)
+        return App.Vector.add(startpoint, endpoint)
 
     elif geomType(edge) == "Line":
         halfedge = (last.sub(first)).multiply(0.5)
-        return FreeCAD.Vector.add(first, halfedge)
+        return App.Vector.add(first, halfedge)
 
     else:
         return None

--- a/src/Mod/Draft/draftgeoutils/faces.py
+++ b/src/Mod/Draft/draftgeoutils/faces.py
@@ -250,7 +250,7 @@ def removeSplitter(shape):
 
     try:
         face = Part.Face(Part.Wire(edges))
-    except:
+    except Part.OCCError:
         # operation failed
         return None
     else:

--- a/src/Mod/Draft/draftgeoutils/fillets.py
+++ b/src/Mod/Draft/draftgeoutils/fillets.py
@@ -26,10 +26,10 @@
 # \ingroup DRAFTGEOUTILS
 # \brief Provides various functions for working with fillets.
 
-import lazy_loader.lazy_loader as lz
 import math
+import lazy_loader.lazy_loader as lz
 
-import FreeCAD
+import FreeCAD as App
 
 from draftgeoutils.general import precision
 from draftgeoutils.arcs import arcFrom2Pts
@@ -102,7 +102,7 @@ def fillet(lEdges, r, chamfer=False):
 
         dToCenter = r / math.sin(alpha/2.0)
         dToTangent = (dToCenter**2-r**2)**(0.5)
-        dirVect = FreeCAD.Vector(U1)
+        dirVect = App.Vector(U1)
         dirVect.scale(dToTangent, dToTangent, dToTangent)
         arcPt1 = lVertexes[1].Point.add(dirVect)
 
@@ -111,7 +111,7 @@ def fillet(lEdges, r, chamfer=False):
         dirVect.scale(dToCenter - r, dToCenter - r, dToCenter - r)
         arcPt2 = lVertexes[1].Point.add(dirVect)
 
-        dirVect = FreeCAD.Vector(U2)
+        dirVect = App.Vector(U2)
         dirVect.scale(dToTangent, dToTangent, dToTangent)
         arcPt3 = lVertexes[1].Point.add(dirVect)
 
@@ -166,7 +166,7 @@ def fillet(lEdges, r, chamfer=False):
         if round(abs(projCenter), precision()) > 0:
             normToLine = U1.cross(T).cross(U1)
         else:
-            normToLine = FreeCAD.Vector(toCenter)
+            normToLine = App.Vector(toCenter)
         normToLine.normalize()
 
         dCenterToLine = toCenter.dot(normToLine) - r

--- a/src/Mod/Draft/draftgeoutils/general.py
+++ b/src/Mod/Draft/draftgeoutils/general.py
@@ -29,16 +29,16 @@
 import math
 import lazy_loader.lazy_loader as lz
 
-import FreeCAD
+import FreeCAD as App
 import DraftVecUtils
 
 # Delay import of module until first use because it is heavy
 Part = lz.LazyLoader("Part", globals(), "Part")
 
-PARAMGRP = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/Draft")
+PARAMGRP = App.ParamGet("User parameter:BaseApp/Preferences/Mod/Draft")
 
 # Default normal direction for all geometry operations
-NORM = FreeCAD.Vector(0, 0, 1)
+NORM = App.Vector(0, 0, 1)
 
 
 def precision():
@@ -70,7 +70,7 @@ def vec(edge):
 
 def edg(p1, p2):
     """Return an edge from 2 vectors."""
-    if isinstance(p1, FreeCAD.Vector) and isinstance(p2, FreeCAD.Vector):
+    if isinstance(p1, App.Vector) and isinstance(p2, App.Vector):
         if DraftVecUtils.equals(p1, p2):
             return None
 
@@ -100,13 +100,13 @@ def isNull(something):
     """
     if isinstance(something, Part.Shape):
         return something.isNull()
-    elif isinstance(something, FreeCAD.Vector):
-        if something == FreeCAD.Vector(0, 0, 0):
+    elif isinstance(something, App.Vector):
+        if something == App.Vector(0, 0, 0):
             return True
         else:
             return False
-    elif isinstance(something, FreeCAD.Placement):
-        if (something.Base == FreeCAD.Vector(0, 0, 0)
+    elif isinstance(something, App.Placement):
+        if (something.Base == App.Vector(0, 0, 0)
                 and something.Rotation.Q == (0, 0, 0, 1)):
             return True
         else:
@@ -183,7 +183,7 @@ def getQuad(face):
     if len(face.Edges) != 4:
         return None
 
-    v1 = vec(face.Edges[0])
+    v1 = vec(face.Edges[0])  # Warning redefinition of function v1
     v2 = vec(face.Edges[1])
     v3 = vec(face.Edges[2])
     v4 = vec(face.Edges[3])

--- a/src/Mod/Draft/draftgeoutils/geometry.py
+++ b/src/Mod/Draft/draftgeoutils/geometry.py
@@ -26,11 +26,12 @@
 # \ingroup DRAFTGEOUTILS
 # \brief Provides various functions for working with geometry.
 
-import lazy_loader.lazy_loader as lz
 import math
+import lazy_loader.lazy_loader as lz
 
-import FreeCAD
+import FreeCAD as App
 import DraftVecUtils
+
 import draftutils.gui_utils as gui_utils
 
 from draftgeoutils.general import geomType, vec
@@ -88,7 +89,7 @@ def findDistance(point, edge, strict=False):
     only if its endpoint lies on the `edge`.
     Edge can also be a list of 2 points.
     """
-    if isinstance(point, FreeCAD.Vector):
+    if isinstance(point, App.Vector):
         if isinstance(edge, list):
             segment = edge[1].sub(edge[0])
             chord = edge[0].sub(point)
@@ -155,7 +156,7 @@ def findDistance(point, edge, strict=False):
 
             ratio = (segment.Length - edge.Curve.Radius) / segment.Length
             dist = segment.multiply(ratio)
-            newpoint = FreeCAD.Vector.add(point, dist)
+            newpoint = App.Vector.add(point, dist)
 
             if dist.Length == 0:
                 return None
@@ -217,7 +218,7 @@ def getNormal(shape):
                 return n
         return None
 
-    n = FreeCAD.Vector(0, 0, 1)
+    n = App.Vector(0, 0, 1)
     if shape.isNull():
         return n
 
@@ -247,7 +248,7 @@ def getNormal(shape):
                     break
 
     # Check the 3D view to flip the normal if the GUI is available
-    if FreeCAD.GuiUp:
+    if App.GuiUp:
         vdir = gui_utils.get_3d_view().getViewDirection()
         if n.getAngle(vdir) < 0.78:
             n = n.negative()
@@ -258,7 +259,7 @@ def getNormal(shape):
     return n
 
 
-def getRotation(v1, v2=FreeCAD.Vector(0, 0, 1)):
+def getRotation(v1, v2=App.Vector(0, 0, 1)):
     """Get the rotation Quaternion between 2 vectors."""
     if (v1.dot(v2) > 0.999999) or (v1.dot(v2) < -0.999999):
         # vectors are opposite
@@ -268,7 +269,7 @@ def getRotation(v1, v2=FreeCAD.Vector(0, 0, 1)):
     axis.normalize()
     # angle = math.degrees(math.sqrt(v1.Length^2 * v2.Length^2) + v1.dot(v2))
     angle = math.degrees(DraftVecUtils.angle(v1, v2, axis))
-    return FreeCAD.Rotation(axis, angle)
+    return App.Rotation(axis, angle)
 
 
 def isPlanar(shape):
@@ -307,11 +308,11 @@ def calculatePlacement(shape):
     Otherwise, it returns a null placement.
     """
     if not isPlanar(shape):
-        return FreeCAD.Placement()
+        return App.Placement()
 
     pos = shape.BoundBox.Center
     norm = getNormal(shape)
-    pla = FreeCAD.Placement()
+    pla = App.Placement()
     pla.Base = pos
     r = getRotation(norm)
 
@@ -326,9 +327,9 @@ def mirror(point, edge):
     normPoint = point.add(findDistance(point, edge, False))
 
     if normPoint:
-        normPoint_point = FreeCAD.Vector.sub(point, normPoint)
+        normPoint_point = App.Vector.sub(point, normPoint)
         normPoint_refl = normPoint_point.negative()
-        refl = FreeCAD.Vector.add(normPoint, normPoint_refl)
+        refl = App.Vector.add(normPoint, normPoint_refl)
         return refl
     else:
         return None

--- a/src/Mod/Draft/draftgeoutils/intersections.py
+++ b/src/Mod/Draft/draftgeoutils/intersections.py
@@ -28,7 +28,7 @@
 
 import lazy_loader.lazy_loader as lz
 
-import FreeCAD
+import FreeCAD as App
 import DraftVecUtils
 
 from draftgeoutils.general import precision, vec, geomType, isPtOnEdge
@@ -120,7 +120,7 @@ def findIntersection(edge1, edge2,
 
     pt1 = None
 
-    if isinstance(edge1, FreeCAD.Vector) and isinstance(edge2, FreeCAD.Vector):
+    if isinstance(edge1, App.Vector) and isinstance(edge2, App.Vector):
         # we got points directly
         pt1 = edge1
         pt2 = edge2
@@ -174,16 +174,16 @@ def findIntersection(edge1, edge2,
             # Line and Arc are on same plane
 
             dOnLine = center.sub(pt1).dot(dirVec)
-            onLine = FreeCAD.Vector(dirVec)
+            onLine = App.Vector(dirVec)
             onLine.scale(dOnLine, dOnLine, dOnLine)
             toLine = pt1.sub(center).add(onLine)
 
             if toLine.Length < arc.Curve.Radius:
                 dOnLine = (arc.Curve.Radius**2 - toLine.Length**2)**(0.5)
-                onLine = FreeCAD.Vector(dirVec)
+                onLine = App.Vector(dirVec)
                 onLine.scale(dOnLine, dOnLine, dOnLine)
                 int += [center.add(toLine).add(onLine)]
-                onLine = FreeCAD.Vector(dirVec)
+                onLine = App.Vector(dirVec)
                 onLine.scale(-dOnLine, -dOnLine, -dOnLine)
                 int += [center.add(toLine).add(onLine)]
             elif round(toLine.Length - arc.Curve.Radius, precision()) == 0:
@@ -194,13 +194,13 @@ def findIntersection(edge1, edge2,
         else:
             # Line isn't on Arc's plane
             if dirVec.dot(arc.Curve.Axis) != 0:
-                toPlane = FreeCAD.Vector(arc.Curve.Axis)
+                toPlane = App.Vector(arc.Curve.Axis)
                 toPlane.normalize()
                 d = pt1.dot(toPlane)
                 if not d:
                     return []
                 dToPlane = center.sub(pt1).dot(toPlane)
-                toPlane = FreeCAD.Vector(pt1)
+                toPlane = App.Vector(pt1)
                 toPlane.scale(dToPlane/d, dToPlane/d, dToPlane/d)
                 ptOnPlane = toPlane.add(pt1)
                 if round(ptOnPlane.sub(center).Length - arc.Curve.Radius,
@@ -377,7 +377,7 @@ def connect(edges, closed=False):
                                        v2).toShape())
     try:
         return Part.Wire(nedges)
-    except:
+    except Part.OCCError:
         print("DraftGeomUtils.connect: unable to connect edges")
         for e in nedges:
             print(e.Curve, " ",

--- a/src/Mod/Draft/draftgeoutils/offsets.py
+++ b/src/Mod/Draft/draftgeoutils/offsets.py
@@ -28,13 +28,13 @@
 
 import lazy_loader.lazy_loader as lz
 
-import FreeCAD
+import FreeCAD as App
 import DraftVecUtils
 
 from draftgeoutils.general import geomType, vec
-from draftgeoutils.intersections import wiresIntersect, connect
 from draftgeoutils.geometry import getNormal
 from draftgeoutils.wires import isReallyClosed
+from draftgeoutils.intersections import wiresIntersect, connect
 
 # Delay import of module until first use because it is heavy
 Part = lz.LazyLoader("Part", globals(), "Part")
@@ -134,18 +134,18 @@ def offset(edge, vector, trim=False):
     None if there is a problem.
     """
     if (not isinstance(edge, Part.Shape)
-            or not isinstance(vector, FreeCAD.Vector)):
+            or not isinstance(vector, App.Vector)):
         return None
 
     if geomType(edge) == "Line":
-        v1 = FreeCAD.Vector.add(edge.Vertexes[0].Point, vector)
-        v2 = FreeCAD.Vector.add(edge.Vertexes[-1].Point, vector)
+        v1 = App.Vector.add(edge.Vertexes[0].Point, vector)
+        v2 = App.Vector.add(edge.Vertexes[-1].Point, vector)
         return Part.LineSegment(v1, v2).toShape()
 
     elif geomType(edge) == "Circle":
         rad = edge.Vertexes[0].Point.sub(edge.Curve.Center)
         curve = Part.Circle(edge.Curve)
-        curve.Radius = FreeCAD.Vector.add(rad, vector).Length
+        curve.Radius = App.Vector.add(rad, vector).Length
         if trim:
             return Part.ArcOfCircle(curve,
                                     edge.FirstParameter,

--- a/src/Mod/Draft/draftgeoutils/wires.py
+++ b/src/Mod/Draft/draftgeoutils/wires.py
@@ -26,15 +26,15 @@
 # \ingroup DRAFTGEOUTILS
 # \brief Provides various functions for working with wires.
 
-import lazy_loader.lazy_loader as lz
 import math
+import lazy_loader.lazy_loader as lz
 
 import DraftVecUtils
 import WorkingPlane
 
 from draftgeoutils.general import geomType, vec, precision
-from draftgeoutils.edges import findMidpoint, isLine
 from draftgeoutils.geometry import getNormal
+from draftgeoutils.edges import findMidpoint, isLine
 
 # Delay import of module until first use because it is heavy
 Part = lz.LazyLoader("Part", globals(), "Part")
@@ -400,7 +400,7 @@ def cleanProjection(shape, tessellate=True, seglength=0.05):
                                                         e.LastParameter))
             else:
                 newedges.append(e)
-        except Exception:
+        except Part.OCCError:
             print("Debug: error cleaning edge ", e)
 
     return Part.makeCompound(newedges)
@@ -425,7 +425,7 @@ def tessellateProjection(shape, seglen):
                 newedges.append(Part.Wire(curvetosegment(e, seglen)))
             else:
                 newedges.append(e)
-        except Exception:
+        except Part.OCCError:
             print("Debug: error cleaning edge ", e)
 
     return Part.makeCompound(newedges)


### PR DESCRIPTION
Various functions in `DraftGeomUtils.py` were moved to individual modules, so that the code is more structured and maintainable.

In this pull request we just do small cleanup of the imported functions in `DraftGeomUtils.py` and in the individual modules.

This pull request follows after #3494, #3498, #3553, and #3554.

---

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists
