### PR TITLE
Gui: fix crash on selecting removing object

### DIFF
--- a/src/Gui/Selection.cpp
+++ b/src/Gui/Selection.cpp
@@ -1623,6 +1623,8 @@ int SelectionSingleton::checkSelection(const char *pDocName, const char *pObject
             FC_ERR("Object not found");
         return -1;
     }
+    if(sel.pObject->testStatus(App::ObjectStatus::Remove))
+        return -1;
     if(pSubName)
        sel.SubName = pSubName;
     if(!resolve)
@@ -1638,6 +1640,8 @@ int SelectionSingleton::checkSelection(const char *pDocName, const char *pObject
             FC_ERR("Sub-object " << sel.DocName << '#' << sel.FeatName << '.' << sel.SubName << " not found");
         return -1;
     }
+    if(sel.pResolvedObject->testStatus(App::ObjectStatus::Remove))
+        return -1;
     std::string subname;
     std::string prefix;
     if(pSubName && element) {


### PR DESCRIPTION
The crash happens if some code calls Gui::Selection().addSelect() of a removing object in response to App::Document::signalDeletedObject. The added selection will have no chance to be cleared because SelectionSingleton::slotDeletedObject() has already been called.