### PR TITLE
Fix qt5:5.15.0 build.

### DIFF
--- a/src/Mod/Image/Gui/OpenGLImageBox.cpp
+++ b/src/Mod/Image/Gui/OpenGLImageBox.cpp
@@ -26,6 +26,7 @@
 # include <QSurfaceFormat>
 # include <QMessageBox>
 # include <QPainter>
+# include <QPainterPath>
 #endif
 
 #if defined(__MINGW32__)


### PR DESCRIPTION
Small fix to allow build against latest qt5=5.15.0. {os:linux,distro:Arch,qt5-base:5.15.0,gcc:10.1.0}
`error message:`
```cpp
/build/freecad-git/src/FreeCAD/src/Mod/Image/Gui/OpenGLImageBox.cpp:906:18: error: aggregate ‘QPainterPath textPath’ has incomplete type and cannot be defined
  906 |     QPainterPath textPath;
      |                  ^~~~~~~~
```