### PR TITLE
[Path] Profile: Fix `_makeIntersectionTags()` for very short edges

### DIFF
--- a/src/Mod/Path/PathScripts/PathProfile.py
+++ b/src/Mod/Path/PathScripts/PathProfile.py
@@ -1266,8 +1266,14 @@ class ObjectProfile(PathAreaOp.ObjectOp):
                             begExt = extTObj
                 else:
                     d = i * mid
-                    cp1 = E.valueAt(E.getParameterByLength(d - spc))
-                    cp2 = E.valueAt(E.getParameterByLength(d + spc))
+                    negTestLen = d - spc
+                    if negTestLen < 0:
+                        negTestLen = d - (LE * 0.25)
+                    posTestLen = d + spc
+                    if posTestLen > LE:
+                        posTestLen = d + (LE * 0.25)
+                    cp1 = E.valueAt(E.getParameterByLength(negTestLen))
+                    cp2 = E.valueAt(E.getParameterByLength(posTestLen))
                     (intTObj, extTObj) = self._makeOffsetCircleTag(cp1, cp2, tagRad, fdv, 'Edge[{}]_'.format(e))
                     if intTObj and extTObj:
                         tagCnt += nt


### PR DESCRIPTION
This error was identified during collaboration with @Schildkroet on Gitter.im on 4 June 2020.

The 0.25 constant used might need to be modified later.  Or, the entire `_makeIntersectionTags()` method might need to be improved if other micro-edge use cases cause failure.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
