### PR TITLE
[Path] 3D Surface: various fixes

### DIFF
--- a/src/Mod/Path/PathScripts/PathSurface.py
+++ b/src/Mod/Path/PathScripts/PathSurface.py
@@ -418,6 +418,20 @@ class ObjectSurface(PathOp.ObjectOp):
             obj.AvoidLastX_Faces = 100
             PathLog.error(translate('PathSurface', 'AvoidLastX_Faces: Avoid last X faces count limited to 100.'))
 
+    def opUpdateDepths(self, obj):
+        if hasattr(obj, 'Base') and obj.Base:
+            base, sublist = obj.Base[0]
+            fbb = base.Shape.getElement(sublist[0]).BoundBox
+            zmin = fbb.ZMax
+            for base, sublist in obj.Base:
+                for sub in sublist:
+                    try:
+                        fbb = base.Shape.getElement(sub).BoundBox
+                        zmin = min(zmin, fbb.ZMin)
+                    except Part.OCCError as e:
+                        PathLog.error(e)
+            obj.OpFinalDepth = zmin
+
     def opExecute(self, obj):
         '''opExecute(obj) ... process surface operation'''
         PathLog.track()
@@ -661,7 +675,7 @@ class ObjectSurface(PathOp.ObjectOp):
         else:
             exTime = str(round(execTime, 5)) + ' sec.'
         msg = translate('PathSurface', 'operation time is')
-        FreeCAD.Console.PrintMessage('3D Surface ' + msg + '{}\n'.format(exTime))
+        FreeCAD.Console.PrintMessage('3D Surface ' + msg + ' {}\n'.format(exTime))
 
         if self.cancelOperation:
             FreeCAD.ActiveDocument.openTransaction(translate("PathSurface", "Canceled 3D Surface operation."))


### PR DESCRIPTION
1.  Fix handling of single vertical face (was throwing an error)
2.  Fix FindUnifiedRegion class (failed without error if selected faces formed a loop, creating an internal region to be avoided)
3.  Fix `if … is not False:` clauses
4.  Fix initial guess of FinalDepth by way of adding `opUpdateDepths()` method.  Mentioned in the forum at [Re: Error at 3D Surfaceing](https://forum.freecadweb.org/viewtopic.php?style=3&f=15&t=47198&p=405548#p405337).
5.  Remove unnecessary comments and code
6.  Add a few debug statements for following code execution when debugging.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
