### PR TITLE
[Path] 3D Surface and Waterline: FinalDepth guess and `InternalFeaturesCut` fixes

### DIFF
--- a/src/Mod/Path/PathScripts/PathSurface.py
+++ b/src/Mod/Path/PathScripts/PathSurface.py
@@ -436,6 +436,17 @@ class ObjectSurface(PathOp.ObjectOp):
                     except Part.OCCError as e:
                         PathLog.error(e)
             obj.OpFinalDepth = zmin
+        elif self.job:
+            if hasattr(obj, 'BoundBox'):
+                if obj.BoundBox == 'BaseBoundBox':
+                    models = self.job.Model.Group
+                    zmin = models[0].Shape.BoundBox.ZMin
+                    for M in models:
+                        zmin = min(zmin, M.Shape.BoundBox.ZMin)
+                    obj.OpFinalDepth = zmin
+                if obj.BoundBox == 'Stock':
+                    models = self.job.Stock
+                    obj.OpFinalDepth = self.job.Stock.Shape.BoundBox.ZMin
 
     def opExecute(self, obj):
         '''opExecute(obj) ... process surface operation'''

--- a/src/Mod/Path/PathScripts/PathSurfaceGui.py
+++ b/src/Mod/Path/PathScripts/PathSurfaceGui.py
@@ -40,7 +40,7 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
     '''Page controller class for the Surface operation.'''
 
     def initPage(self, obj):
-        self.setTitle("3D Surface")
+        self.setTitle("3D Surface - " + obj.Label)
         # self.updateVisibility()
         # retrieve property enumerations
         self.propEnums = PathSurface.ObjectSurface.opPropertyEnumerations(False)

--- a/src/Mod/Path/PathScripts/PathSurfaceSupport.py
+++ b/src/Mod/Path/PathScripts/PathSurfaceSupport.py
@@ -1813,37 +1813,43 @@ class FindUnifiedRegions:
             cutBox.translate(FreeCAD.Vector(efBB.XMin - 1.0, efBB.YMin - 1.0, zHght))
             base = ef.cut(cutBox)
 
-            # Identify top face of base
-            fIdx = 0
-            zMin = base.Faces[fIdx].BoundBox.ZMin
-            for bfi in range(0, len(base.Faces)):
-                fzmin = base.Faces[bfi].BoundBox.ZMin
-                if fzmin > zMin:
-                    fIdx = bfi
-                    zMin = fzmin
+            if base.Volume == 0:
+                PathLog.debug('Ignoring Face{}.  It is likely vertical with no horizontal exposure.'.format(fcIdx))
+                cont = False
 
-            # Translate top face to Z=0.0 and save to topFaces list
-            topFace = base.Faces[fIdx]
-            # self._showShape(topFace, 'topFace_{}'.format(fNum))
-            tfBB = topFace.BoundBox
-            tfBB_Area = tfBB.XLength * tfBB.YLength
-            fBB_Area = fBB.XLength * fBB.YLength
-            if tfBB_Area < (fBB_Area * 0.9):
-                # attempt alternate methods
-                topFace = self._getCompleteCrossSection(ef)
+            if cont:
+                # Identify top face of base
+                fIdx = 0
+                zMin = base.Faces[fIdx].BoundBox.ZMin
+                for bfi in range(0, len(base.Faces)):
+                    fzmin = base.Faces[bfi].BoundBox.ZMin
+                    if fzmin > zMin:
+                        fIdx = bfi
+                        zMin = fzmin
+
+                # Translate top face to Z=0.0 and save to topFaces list
+                topFace = base.Faces[fIdx]
+                # self._showShape(topFace, 'topFace_{}'.format(fNum))
                 tfBB = topFace.BoundBox
                 tfBB_Area = tfBB.XLength * tfBB.YLength
-                # self._showShape(topFace, 'topFaceAlt_1_{}'.format(fNum))
+                fBB_Area = fBB.XLength * fBB.YLength
                 if tfBB_Area < (fBB_Area * 0.9):
-                    topFace = getShapeSlice(ef)
+                    # attempt alternate methods
+                    topFace = self._getCompleteCrossSection(ef)
                     tfBB = topFace.BoundBox
                     tfBB_Area = tfBB.XLength * tfBB.YLength
-                    # self._showShape(topFace, 'topFaceAlt_2_{}'.format(fNum))
+                    # self._showShape(topFace, 'topFaceAlt_1_{}'.format(fNum))
                     if tfBB_Area < (fBB_Area * 0.9):
-                        msg = translate('PathSurfaceSupport',
-                            'Faild to extract processing region for Face')
-                        FreeCAD.Console.PrintError(msg + '{}.\n'.format(fNum))
-                        cont = False
+                        topFace = getShapeSlice(ef)
+                        tfBB = topFace.BoundBox
+                        tfBB_Area = tfBB.XLength * tfBB.YLength
+                        # self._showShape(topFace, 'topFaceAlt_2_{}'.format(fNum))
+                        if tfBB_Area < (fBB_Area * 0.9):
+                            msg = translate('PathSurfaceSupport',
+                                'Faild to extract processing region for Face')
+                            FreeCAD.Console.PrintError(msg + '{}.\n'.format(fNum))
+                            cont = False
+            # Eif
 
             if cont:
                 topFace.translate(FreeCAD.Vector(0.0, 0.0, 0.0 - zMin))

--- a/src/Mod/Path/PathScripts/PathWaterlineGui.py
+++ b/src/Mod/Path/PathScripts/PathWaterlineGui.py
@@ -41,7 +41,7 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
     '''Page controller class for the Waterline operation.'''
 
     def initPage(self, obj):
-        # self.setTitle("Waterline")
+        self.setTitle("Waterline - " + obj.Label)
         self.updateVisibility()
 
     def getForm(self):


### PR DESCRIPTION
1.  This PR addresses the second part of a previous PR that improved the initial guess for OpFinalDepth.  This part addresses the case when no Base Geometry is selected and the entire model is surfaced.
2.  This PR also fixes the broken processing of the existing `InternalFeaturesCut` feature.
3.  This PR clones the updated `opUpdateDepths()` from 3D Surface and places the same in the Waterline operation.
4.  This PR fixes and error in the FindUnifiedRegions class when dealing with vertical faces.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
