### PR TITLE
Arch: Fix bug of exporting into collada file #4362

### DIFF
--- a/src/Mod/Arch/ArchCommands.py
+++ b/src/Mod/Arch/ArchCommands.py
@@ -752,6 +752,8 @@ def pruneIncluded(objectslist,strict=False):
                                 pass
                             elif hasattr(parent,"Hosts") and (obj in parent.Hosts):
                                 pass
+                            elif hasattr(parent,"TypeId") and (parent.TypeId == "Part::Mirroring"):
+                                pass
                             elif hasattr(parent,"CloneOf"):
                                 if parent.CloneOf:
                                     if parent.CloneOf.Name != obj.Name:


### PR DESCRIPTION
Enable to export mirrored part into collada file.

This is discussed in:
https://forum.freecadweb.org/viewtopic.php?f=3&t=30785
The issue is:
https://tracker.freecadweb.org/view.php?id=4362