### PR TITLE
Boost 1.73 fix for placeholders

### DIFF
--- a/src/Gui/DAGView/DAGView.cpp
+++ b/src/Gui/DAGView/DAGView.cpp
@@ -36,11 +36,14 @@
 #include <Gui/Document.h>
 #include <Gui/Application.h>
 
+#include <boost/bind/bind.hpp>
+
 #include "DAGModel.h"
 #include "DAGView.h"
 
 using namespace Gui;
 using namespace DAG;
+using namespace boost::placeholders;
 
 DAG::DockWindow::DockWindow(Gui::Document* gDocumentIn, QWidget* parent): Gui::DockWindow(gDocumentIn, parent)
 {

--- a/src/Mod/Sketcher/Gui/TaskSketcherGeneral.cpp
+++ b/src/Mod/Sketcher/Gui/TaskSketcherGeneral.cpp
@@ -40,8 +40,11 @@
 
 #include "ViewProviderSketch.h"
 
+#include <boost/bind/bind.hpp>
+
 using namespace SketcherGui;
 using namespace Gui::TaskView;
+using namespace boost::placeholders;
 
 SketcherGeneralWidget::SketcherGeneralWidget(QWidget *parent)
   : QWidget(parent), ui(new Ui_TaskSketcherGeneral)


### PR DESCRIPTION
Should be backwards compatible to Boost 1.60.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists