### PR TITLE
Path: Area based unified projection implementation

### DIFF
--- a/src/Mod/Path/PathScripts/PathMillFace.py
+++ b/src/Mod/Path/PathScripts/PathMillFace.py
@@ -185,7 +185,9 @@ class ObjectFace(PathPocketBase.ObjectPocket):
         elif obj.BoundaryShape == 'Perimeter':
             if obj.ClearEdges:
                 psZMin = planeshape.BoundBox.ZMin
-                ofstShape = PathSurfaceSupport.extractFaceOffset(planeshape, self.radius * 1.25, planeshape)
+                ofstShape = PathUtils.getOffsetArea(planeshape,
+                                                    self.radius * 1.25,
+                                                    plane=planeshape)
                 ofstShape.translate(FreeCAD.Vector(0.0, 0.0, psZMin - ofstShape.BoundBox.ZMin))
                 env = PathUtils.getEnvelope(partshape=ofstShape, depthparams=self.depthparams)
             else:
@@ -194,7 +196,9 @@ class ObjectFace(PathPocketBase.ObjectPocket):
             import PathScripts.PathSurfaceSupport as PathSurfaceSupport
             baseShape = oneBase[0].Shape
             psZMin = planeshape.BoundBox.ZMin
-            ofstShape = PathSurfaceSupport.extractFaceOffset(planeshape, self.tool.Diameter * 1.1, planeshape)
+            ofstShape = PathUtils.getOffsetArea(planeshape,
+                                                self.tool.Diameter * 1.1,
+                                                plane=planeshape)
             ofstShape.translate(FreeCAD.Vector(0.0, 0.0, psZMin - ofstShape.BoundBox.ZMin))
             # custDepthparams = self._customDepthParams(obj, obj.StartDepth.Value, obj.FinalDepth.Value)  # only an envelope
             # ofstShapeEnv = PathUtils.getEnvelope(partshape=ofstShape, depthparams=self.depthparams)

--- a/src/Mod/Path/PathScripts/PathProfile.py
+++ b/src/Mod/Path/PathScripts/PathProfile.py
@@ -887,7 +887,7 @@ class ObjectProfile(PathAreaOp.ObjectOp):
         cent1 = FreeCAD.Vector(lstVrt.X, lstVrt.Y, fdv)
 
         # Calculate offset shape, containing cut region
-        ofstShp = self._extractFaceOffset(obj, cutShp, False)
+        ofstShp = self._getOffsetArea(obj, cutShp, False)
 
         # CHECK for ZERO area of offset shape
         try:
@@ -1005,15 +1005,13 @@ class ObjectProfile(PathAreaOp.ObjectOp):
 
         return rtnWIRES
 
-    def _extractFaceOffset(self, obj, fcShape, isHole):
-        '''_extractFaceOffset(obj, fcShape, isHole) ... internal function.
-            Original _buildPathArea() version copied from PathAreaOp.py module.  This version is modified.
-            Adjustments made based on notes by @sliptonic - https://github.com/sliptonic/FreeCAD/wiki/PathArea-notes.'''
-        PathLog.debug('_extractFaceOffset()')
+    def _getOffsetArea(self, obj, fcShape, isHole):
+        '''Get an offset area for a shape. Wrapper around
+        PathUtils.getOffsetArea.'''
+        PathLog.debug('_getOffsetArea()')
 
-        areaParams = {}
         JOB = PathUtils.findParentJob(obj)
-        tolrnc = JOB.GeometryTolerance.Value
+        tolerance = JOB.GeometryTolerance.Value
         if self.useComp is True:
             offset = self.ofstRadius  # + tolrnc
         else:
@@ -1022,22 +1020,10 @@ class ObjectProfile(PathAreaOp.ObjectOp):
         if isHole is False:
             offset = 0 - offset
 
-        areaParams['Offset'] = offset
-        areaParams['Fill'] = 1
-        areaParams['Coplanar'] = 0
-        areaParams['SectionCount'] = 1  # -1 = full(all per depthparams??) sections
-        areaParams['Reorient'] = True
-        areaParams['OpenMode'] = 0
-        areaParams['MaxArcPoints'] = 400  # 400
-        areaParams['Project'] = True
-        # areaParams['JoinType'] = 1
-
-        area = Path.Area()  # Create instance of Area() class object
-        area.setPlane(PathUtils.makeWorkplane(fcShape))  # Set working plane
-        area.add(fcShape)  # obj.Shape to use for extracting offset
-        area.setParams(**areaParams)  # set parameters
-
-        return area.getShape()
+        return PathUtils.getOffsetArea(fcShape,
+                                       offset,
+                                       plane=fcShape,
+                                       tolerance=tolerance)
 
     def _findNearestVertex(self, shape, point):
         PathLog.debug('_findNearestVertex()')
@@ -1202,7 +1188,7 @@ class ObjectProfile(PathAreaOp.ObjectOp):
         return (wireIdxs[0], wireIdxs[1])
 
     def _makeCrossSection(self, shape, sliceZ, zHghtTrgt=False):
-        '''_makeCrossSection(shape, sliceZ, zHghtTrgt=None)... 
+        '''_makeCrossSection(shape, sliceZ, zHghtTrgt=None)...
         Creates cross-section objectc from shape.  Translates cross-section to zHghtTrgt if available.
         Makes face shape from cross-section object. Returns face shape at zHghtTrgt.'''
         PathLog.debug('_makeCrossSection()')
@@ -1331,7 +1317,7 @@ class ObjectProfile(PathAreaOp.ObjectOp):
             # 2   6
             # |   |
             # |   ----5----|
-            # |            4  
+            # |            4
             # -----3-------|
             # positive dist in _makePerp2DVector() is CCW rotation
             p1 = E

--- a/src/Mod/Path/PathScripts/PathWaterline.py
+++ b/src/Mod/Path/PathScripts/PathWaterline.py
@@ -925,7 +925,7 @@ class ObjectWaterline(PathOp.ObjectOp):
         return commands
 
     def _waterlineDropCutScan(self, stl, smplInt, xmin, xmax, ymin, fd, numScanLines):
-        '''_waterlineDropCutScan(stl, smplInt, xmin, xmax, ymin, fd, numScanLines) ... 
+        '''_waterlineDropCutScan(stl, smplInt, xmin, xmax, ymin, fd, numScanLines) ...
         Perform OCL scan for waterline purpose.'''
         pdc = ocl.PathDropCutter()   # create a pdc
         pdc.setSTL(stl)
@@ -1273,7 +1273,10 @@ class ObjectWaterline(PathOp.ObjectOp):
                 activeArea = area.cut(trimFace)
                 activeAreaWireCnt = len(activeArea.Wires)  # first wire is boundFace wire
                 self.showDebugObject(activeArea, 'ActiveArea_{}'.format(caCnt))
-                ofstArea = PathSurfaceSupport.extractFaceOffset(activeArea, ofst, self.wpc, makeComp=False)
+                ofstArea = PathUtils.getOffsetArea(activeArea,
+                                                   ofst,
+                                                   self.wpc,
+                                                   makeComp=False)
                 if not ofstArea:
                     data = FreeCAD.Units.Quantity(csHght, FreeCAD.Units.Length).UserString
                     PathLog.debug('No offset area returned for cut area depth at {}.'.format(data))
@@ -1333,7 +1336,7 @@ class ObjectWaterline(PathOp.ObjectOp):
         CUTAREAS = list()
         isFirst = True
         lenDP = len(depthparams)
-        
+
         # Cycle through layer depths
         for dp in range(0, lenDP):
             csHght = depthparams[dp]
@@ -1446,7 +1449,10 @@ class ObjectWaterline(PathOp.ObjectOp):
         cont = True
         cnt = 0
         while cont:
-            ofstArea = PathSurfaceSupport.extractFaceOffset(shape, ofst, self.wpc, makeComp=True)
+            ofstArea = PathUtils.getOffsetArea(shape,
+                                               ofst,
+                                               self.wpc,
+                                               makeComp=True)
             if not ofstArea:
                 break
             for F in ofstArea.Faces:
@@ -1558,7 +1564,7 @@ class ObjectWaterline(PathOp.ObjectOp):
                 li = fIds.pop()
                 low = csFaces[li]  # senior face
                 pIds = self._idInternalFeature(csFaces, fIds, pIds, li, low)
-            
+
             for af in range(lenCsF - 1, -1, -1):  # cycle from last item toward first
                 prnt = pIds[af]
                 if prnt == -1:
@@ -1797,7 +1803,7 @@ class ObjectWaterline(PathOp.ObjectOp):
             diam_1 += 4.0
             if FR != 0.0:
                 FR += 2.0
-            
+
         PathLog.debug('ToolType: {}'.format(obj.ToolController.Tool.ToolType))
         if obj.ToolController.Tool.ToolType == 'EndMill':
             # Standard End Mill


### PR DESCRIPTION
Add a `getProjectionArea` implementation using Area's projection and
area merging capabilities to directly generate shape projections onto
the working plane. In tests, this implementation looks more robust
especially on discretized curved shapes, which could lock up the edge
based FindUnifiedRegions implementation.

If we fully adopt this, we can potentially simplify some of the surface
code:
- The implementation can optionally preserve internal holes, which can
  eliminate the need to handle avoid faces separately.
- We can replace getEnvelope() with this simpler and likely numerically
  more stable implementation.

The current implementation is wrapped into a FindUnifiedRegions
work-alike wrapper, which allows easy switching between the
implementations.

I also moved the former extractFaceOffset method to
PathUtils.getOffsetArea, so that the more generally useful Area wrappers
are grouped in PathUtils.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
