### PR TITLE
PartDesign: closing task dialog when exiting edit mode for Primitives

### DIFF
--- a/src/Mod/PartDesign/Gui/ViewProviderPrimitive.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderPrimitive.cpp
@@ -123,8 +123,12 @@ bool ViewProviderPrimitive::setEdit(int ModNum)
 
 void ViewProviderPrimitive::unsetEdit(int ModNum)
 {
-    Q_UNUSED(ModNum);
     setPreviewDisplayMode(false);
+
+    // Rely on parent class to:
+    // restitute old workbench (set setEdit above) and close the dialog if exiting editing
+    PartDesignGui::ViewProvider::unsetEdit(ModNum);
+
 }
 
 void ViewProviderPrimitive::updateData(const App::Property* p) {


### PR DESCRIPTION
=====================================================================

fixes #4241

Problem:

PartDesignGui::ViewProvider is responsible for closing the tasks for most of PD features when exiting edit mode
(i.e. unsetEdit()).

For primitives, PartDesignGui::ViewProviderPrimitive is responsible, and neither does it or relies on its parent
VP to do it when calling unsetEdit().

Solution:

Make PartDesignGui::ViewProviderPrimitive::unsetEdit() rely on parent PartDesignGui::ViewProvider to tidy up,
including closing the task dialog.

Reference:

This is the default stack call when closing a document while a PD task using PartDesignGui::Viewprovider is active:

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [x] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
