### PR TITLE
Fix saving of DXF files (python3)

### DIFF
--- a/src/Mod/Draft/importDXF.py
+++ b/src/Mod/Draft/importDXF.py
@@ -3932,7 +3932,7 @@ def exportPage(page, filename):
     c = dxfcounter()
     pat = re.compile("(_handle_)")
     template = pat.sub(c.incr, template)
-    f = pythonopen(filename, "wb")
+    f = pythonopen(filename, "w")
     f.write(template)
     f.close()
 


### PR DESCRIPTION
- Python3 does not allow to write strings to a file opened as "wb"; it
  expects bytes instead. Since ASCII DXF files are written using strings,
  the file should be opened as "w". Should be ok for python2 as well.
- See also issue 003862, https://tracker.freecadweb.org/view.php?id=3862

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [x] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

I'm not the first to notice, but it seems to still be broken.
---
