### PR TITLE
Draft: fixed wrong QT_TRANSLATE_NOOP usage in Draft Objects

### DIFF
--- a/src/Mod/Draft/draftobjects/array.py
+++ b/src/Mod/Draft/draftobjects/array.py
@@ -75,15 +75,13 @@ class Array(DraftLink):
         properties = obj.PropertiesList
 
         if "Base" not in properties:
-            _tip = "The base object that will be duplicated"
-            obj.addProperty("App::PropertyLink",
-                            "Base",
-                            "Objects",
-                            QT_TRANSLATE_NOOP("App::Property", _tip))
+            _tip = QT_TRANSLATE_NOOP("App::Property", "The base object that will be duplicated")
+            obj.addProperty("App::PropertyLink", "Base", "Objects", _tip)
             obj.Base = None
 
         if "ArrayType" not in properties:
-            _tip = ("The type of array to create.\n"
+            _tip = QT_TRANSLATE_NOOP("App::Property", 
+                    "The type of array to create.\n"
                     "- Ortho: places the copies in the direction "
                     "of the global X, Y, Z axes.\n"
                     "- Polar: places the copies along a circular arc, "
@@ -94,16 +92,17 @@ class Array(DraftLink):
             obj.addProperty("App::PropertyEnumeration",
                             "ArrayType",
                             "Objects",
-                            QT_TRANSLATE_NOOP("App::Property", _tip))
+                             _tip)
             obj.ArrayType = ['ortho', 'polar', 'circular']
 
         if "Fuse" not in properties:
-            _tip = ("Specifies if the copies should be fused together "
+            _tip = QT_TRANSLATE_NOOP("App::Property", 
+                    "Specifies if the copies should be fused together "
                     "if they touch each other (slower)")
             obj.addProperty("App::PropertyBool",
                             "Fuse",
                             "Objects",
-                            QT_TRANSLATE_NOOP("App::Property", _tip))
+                            _tip)
             obj.Fuse = False
 
     def set_ortho_properties(self, obj):
@@ -111,51 +110,55 @@ class Array(DraftLink):
         properties = obj.PropertiesList
 
         if "NumberX" not in properties:
-            _tip = "Number of copies in X direction"
+            _tip = QT_TRANSLATE_NOOP("App::Property", 
+                                     "Number of copies in X direction")
             obj.addProperty("App::PropertyInteger",
                             "NumberX",
                             "Orthogonal array",
-                            QT_TRANSLATE_NOOP("App::Property", _tip))
+                            _tip)
             obj.NumberX = 2
 
         if "NumberY" not in properties:
-            _tip = "Number of copies in Y direction"
+            _tip = QT_TRANSLATE_NOOP("App::Property", 
+                                     "Number of copies in Y direction")
             obj.addProperty("App::PropertyInteger",
                             "NumberY",
                             "Orthogonal array",
-                            QT_TRANSLATE_NOOP("App::Property", _tip))
+                            _tip)
             obj.NumberY = 2
 
         if "NumberZ" not in properties:
-            _tip = "Number of copies in Z direction"
-            obj.addProperty("App::PropertyInteger",
-                            "NumberZ",
-                            "Orthogonal array",
-                            QT_TRANSLATE_NOOP("App::Property", _tip))
+            _tip = QT_TRANSLATE_NOOP("App::Property", 
+                                     "Number of copies in Z direction")
+            obj.addProperty("App::PropertyInteger", "NumberZ",
+                            "Orthogonal array", _tip)
             obj.NumberZ = 1
 
         if "IntervalX" not in properties:
-            _tip = "Distance and orientation of intervals in X direction"
+            _tip = QT_TRANSLATE_NOOP("App::Property", 
+                    "Distance and orientation of intervals in X direction")
             obj.addProperty("App::PropertyVectorDistance",
                             "IntervalX",
                             "Orthogonal array",
-                            QT_TRANSLATE_NOOP("App::Property", _tip))
+                            _tip)
             obj.IntervalX = App.Vector(50, 0, 0)
 
         if "IntervalY" not in properties:
-            _tip = "Distance and orientation of intervals in Y direction"
+            _tip = QT_TRANSLATE_NOOP("App::Property", 
+                    "Distance and orientation of intervals in Y direction")
             obj.addProperty("App::PropertyVectorDistance",
                             "IntervalY",
                             "Orthogonal array",
-                            QT_TRANSLATE_NOOP("App::Property", _tip))
+                            _tip)
             obj.IntervalY = App.Vector(0, 50, 0)
 
         if "IntervalZ" not in properties:
-            _tip = "Distance and orientation of intervals in Z direction"
+            _tip = QT_TRANSLATE_NOOP("App::Property", 
+                    "Distance and orientation of intervals in Z direction")
             obj.addProperty("App::PropertyVectorDistance",
                             "IntervalZ",
                             "Orthogonal array",
-                            QT_TRANSLATE_NOOP("App::Property", _tip))
+                            _tip)
             obj.IntervalZ = App.Vector(0, 0, 50)
 
     def set_polar_circular_properties(self, obj):
@@ -163,27 +166,30 @@ class Array(DraftLink):
         properties = obj.PropertiesList
 
         if "Axis" not in properties:
-            _tip = ("The axis direction around which the elements in "
+            _tip = QT_TRANSLATE_NOOP("App::Property", 
+                    "The axis direction around which the elements in "
                     "a polar or a circular array will be created")
             obj.addProperty("App::PropertyVector",
                             "Axis",
                             "Polar/circular array",
-                            QT_TRANSLATE_NOOP("App::Property", _tip))
+                            _tip)
             obj.Axis = App.Vector(0, 0, 1)
 
         if "Center" not in properties:
-            _tip = ("Center point for polar and circular arrays.\n"
+            _tip = QT_TRANSLATE_NOOP("App::Property", 
+                    "Center point for polar and circular arrays.\n"
                     "The 'Axis' passes through this point.")
             obj.addProperty("App::PropertyVectorDistance",
                             "Center",
                             "Polar/circular array",
-                            QT_TRANSLATE_NOOP("App::Property", _tip))
+                            _tip)
             obj.Center = App.Vector(0, 0, 0)
 
         # The AxisReference property must be attached after Axis and Center
         # so that onChanged works properly
         if "AxisReference" not in properties:
-            _tip = ("The axis object that overrides the value of 'Axis' "
+            _tip = QT_TRANSLATE_NOOP("App::Property", 
+                    "The axis object that overrides the value of 'Axis' "
                     "and 'Center', for example, a datum line.\n"
                     "Its placement, position and rotation, will be used "
                     "when creating polar and circular arrays.\n"
@@ -192,7 +198,7 @@ class Array(DraftLink):
             obj.addProperty("App::PropertyLinkGlobal",
                             "AxisReference",
                             "Objects",
-                            QT_TRANSLATE_NOOP("App::Property", _tip))
+                            _tip)
             obj.AxisReference = None
 
     def set_polar_properties(self, obj):
@@ -200,27 +206,29 @@ class Array(DraftLink):
         properties = obj.PropertiesList
 
         if "NumberPolar" not in properties:
-            _tip = "Number of copies in the polar direction"
+            _tip = QT_TRANSLATE_NOOP("App::Property", 
+                    "Number of copies in the polar direction")
             obj.addProperty("App::PropertyInteger",
                             "NumberPolar",
                             "Polar array",
-                            QT_TRANSLATE_NOOP("App::Property", _tip))
+                            _tip)
             obj.NumberPolar = 5
 
         if "IntervalAxis" not in properties:
-            _tip = "Distance and orientation of intervals in 'Axis' direction"
+            _tip = QT_TRANSLATE_NOOP("App::Property", 
+                    "Distance and orientation of intervals in 'Axis' direction")
             obj.addProperty("App::PropertyVectorDistance",
                             "IntervalAxis",
                             "Polar array",
-                            QT_TRANSLATE_NOOP("App::Property", _tip))
+                            _tip)
             obj.IntervalAxis = App.Vector(0, 0, 0)
 
         if "Angle" not in properties:
-            _tip = "Angle to cover with copies"
+            _tip = QT_TRANSLATE_NOOP("App::Property", "Angle to cover with copies")
             obj.addProperty("App::PropertyAngle",
                             "Angle",
                             "Polar array",
-                            QT_TRANSLATE_NOOP("App::Property", _tip))
+                            _tip)
             obj.Angle = 360
 
     def set_circular_properties(self, obj):
@@ -228,37 +236,40 @@ class Array(DraftLink):
         properties = obj.PropertiesList
 
         if "RadialDistance" not in properties:
-            _tip = "Distance between circular layers"
+            _tip = QT_TRANSLATE_NOOP("App::Property", "Distance between circular layers")
             obj.addProperty("App::PropertyDistance",
                             "RadialDistance",
                             "Circular array",
-                            QT_TRANSLATE_NOOP("App::Property", _tip))
+                            _tip)
             obj.RadialDistance = 50
 
         if "TangentialDistance" not in properties:
-            _tip = "Distance between copies in the same circular layer"
+            _tip = QT_TRANSLATE_NOOP("App::Property", 
+                    "Distance between copies in the same circular layer")
             obj.addProperty("App::PropertyDistance",
                             "TangentialDistance",
                             "Circular array",
-                            QT_TRANSLATE_NOOP("App::Property", _tip))
+                            _tip)
             obj.TangentialDistance = 25
 
         if "NumberCircles" not in properties:
-            _tip = ("Number of circular layers. "
+            _tip = QT_TRANSLATE_NOOP("App::Property", 
+                    "Number of circular layers. "
                     "The 'Base' object counts as one layer.")
             obj.addProperty("App::PropertyInteger",
                             "NumberCircles",
                             "Circular array",
-                            QT_TRANSLATE_NOOP("App::Property", _tip))
+                            _tip)
             obj.NumberCircles = 3
 
         if "Symmetry" not in properties:
-            _tip = ("A parameter that determines how many symmetry planes "
+            _tip = QT_TRANSLATE_NOOP("App::Property", 
+                    "A parameter that determines how many symmetry planes "
                     " the circular array will have.")
             obj.addProperty("App::PropertyInteger",
                             "Symmetry",
                             "Circular array",
-                            QT_TRANSLATE_NOOP("App::Property", _tip))
+                            _tip)
             obj.Symmetry = 1
 
     def set_link_properties(self, obj):
@@ -267,23 +278,25 @@ class Array(DraftLink):
 
         if self.use_link:
             if "Count" not in properties:
-                _tip = ("Total number of elements in the array.\n"
+                _tip = QT_TRANSLATE_NOOP("App::Property", 
+                        "Total number of elements in the array.\n"
                         "This property is read-only, as the number depends "
                         "on the parameters of the array.")
                 obj.addProperty("App::PropertyInteger",
                                 "Count",
                                 "Objects",
-                                QT_TRANSLATE_NOOP("App::Property", _tip))
+                                _tip)
                 obj.Count = 0
                 obj.setEditorMode("Count", 1)  # Read only
 
             if "ExpandArray" not in properties:
-                _tip = ("Show the individual array elements "
+                _tip = QT_TRANSLATE_NOOP("App::Property", 
+                        "Show the individual array elements "
                         "(only for Link arrays)")
                 obj.addProperty("App::PropertyBool",
                                 "ExpandArray",
                                 "Objects",
-                                QT_TRANSLATE_NOOP("App::Property", _tip))
+                                _tip)
                 obj.ExpandArray = False
 
     def linkSetup(self, obj):

--- a/src/Mod/Draft/draftobjects/bezcurve.py
+++ b/src/Mod/Draft/draftobjects/bezcurve.py
@@ -41,39 +41,39 @@ class BezCurve(DraftObject):
     def __init__(self, obj):
         super(BezCurve, self).__init__(obj, "BezCurve")
 
-        _tip = "The points of the Bezier curve"
-        obj.addProperty("App::PropertyVectorList", "Points",
-                        "Draft",QT_TRANSLATE_NOOP("App::Property", _tip))
+        _tip = QT_TRANSLATE_NOOP("App::Property",
+                "The points of the Bezier curve")
+        obj.addProperty("App::PropertyVectorList", "Points", "Draft", _tip)
 
-        _tip = "The degree of the Bezier function"
-        obj.addProperty("App::PropertyInteger", "Degree",
-                        "Draft",QT_TRANSLATE_NOOP("App::Property", _tip))
+        _tip = QT_TRANSLATE_NOOP("App::Property", 
+                "The degree of the Bezier function")
+        obj.addProperty("App::PropertyInteger", "Degree", "Draft", _tip)
 
-        _tip = "Continuity"
-        obj.addProperty("App::PropertyIntegerList", "Continuity",
-                        "Draft",QT_TRANSLATE_NOOP("App::Property", _tip))
+        _tip = QT_TRANSLATE_NOOP("App::Property",
+                "Continuity")
+        obj.addProperty("App::PropertyIntegerList", "Continuity", "Draft", _tip)
 
-        _tip = "If the Bezier curve should be closed or not"
-        obj.addProperty("App::PropertyBool", "Closed",
-                        "Draft",QT_TRANSLATE_NOOP("App::Property", _tip))
+        _tip = QT_TRANSLATE_NOOP("App::Property",
+                "If the Bezier curve should be closed or not")
+        obj.addProperty("App::PropertyBool", "Closed", "Draft", _tip)
 
-        _tip = "Create a face if this curve is closed"
-        obj.addProperty("App::PropertyBool", "MakeFace",
-                        "Draft",QT_TRANSLATE_NOOP("App::Property", _tip))
+        _tip = QT_TRANSLATE_NOOP("App::Property",
+                "Create a face if this curve is closed")
+        obj.addProperty("App::PropertyBool", "MakeFace", "Draft", _tip)
 
-        _tip = "The length of this object"
-        obj.addProperty("App::PropertyLength", "Length",
-                        "Draft",QT_TRANSLATE_NOOP("App::Property", _tip))
+        _tip = QT_TRANSLATE_NOOP("App::Property",
+                "The length of this object")
+        obj.addProperty("App::PropertyLength", "Length", "Draft", _tip)
 
-        _tip = "The area of this object"
-        obj.addProperty("App::PropertyArea", "Area",
-                        "Draft",QT_TRANSLATE_NOOP("App::Property", _tip))
+        _tip = QT_TRANSLATE_NOOP("App::Property",
+                "The area of this object")
+        obj.addProperty("App::PropertyArea", "Area", "Draft", _tip)
 
         obj.MakeFace = get_param("fillmode", True)
         obj.Closed = False
         obj.Degree = 3
         obj.Continuity = []
-        #obj.setEditorMode("Degree",2)
+        #obj.setEditorMode("Degree", 2)
         obj.setEditorMode("Continuity", 1)
 
     def execute(self, fp):

--- a/src/Mod/Draft/draftobjects/block.py
+++ b/src/Mod/Draft/draftobjects/block.py
@@ -37,9 +37,9 @@ class Block(DraftObject):
     def __init__(self, obj):
         super(Block, self).__init__(obj, "Block")
 
-        _tip = "The components of this block"
-        obj.addProperty("App::PropertyLinkList","Components",
-                        "Draft",QT_TRANSLATE_NOOP("App::Property", _tip))
+        _tip = QT_TRANSLATE_NOOP("App::Property",
+                "The components of this block")
+        obj.addProperty("App::PropertyLinkList","Components", "Draft", _tip)
 
     def execute(self, obj):
         import Part

--- a/src/Mod/Draft/draftobjects/bspline.py
+++ b/src/Mod/Draft/draftobjects/bspline.py
@@ -41,21 +41,20 @@ class BSpline(DraftObject):
     def __init__(self, obj):
         super(BSpline, self).__init__(obj, "BSpline")
 
-        _tip = "The points of the B-spline"
-        obj.addProperty("App::PropertyVectorList","Points",
-                        "Draft", QT_TRANSLATE_NOOP("App::Property", _tip))
+        _tip =  QT_TRANSLATE_NOOP("App::Property",
+                "The points of the B-spline")
+        obj.addProperty("App::PropertyVectorList","Points", "Draft", _tip)
 
-        _tip = "If the B-spline is closed or not"
-        obj.addProperty("App::PropertyBool","Closed",
-                        "Draft",QT_TRANSLATE_NOOP("App::Property", _tip))
+        _tip = QT_TRANSLATE_NOOP("App::Property",
+                "If the B-spline is closed or not")
+        obj.addProperty("App::PropertyBool","Closed", "Draft", _tip)
 
-        _tip = "Create a face if this spline is closed"
-        obj.addProperty("App::PropertyBool","MakeFace",
-                        "Draft",QT_TRANSLATE_NOOP("App::Property", _tip))
+        _tip = QT_TRANSLATE_NOOP("App::Property", 
+                "Create a face if this spline is closed")
+        obj.addProperty("App::PropertyBool","MakeFace", "Draft",_tip)
 
-        _tip = "The area of this object"
-        obj.addProperty("App::PropertyArea","Area",
-                        "Draft",QT_TRANSLATE_NOOP("App::Property", _tip))
+        _tip = QT_TRANSLATE_NOOP("App::Property", "The area of this object")
+        obj.addProperty("App::PropertyArea","Area", "Draft", _tip)
 
         obj.MakeFace = get_param("fillmode",True)
         obj.Closed = False
@@ -64,7 +63,8 @@ class BSpline(DraftObject):
 
     def assureProperties(self, obj): # for Compatibility with older versions
         if not hasattr(obj, "Parameterization"):
-            obj.addProperty("App::PropertyFloat","Parameterization","Draft",QT_TRANSLATE_NOOP("App::Property","Parameterization factor"))
+            _tip = QT_TRANSLATE_NOOP("App::Property","Parameterization factor")
+            obj.addProperty("App::PropertyFloat", "Parameterization", "Draft", _tip)
             obj.Parameterization = 1.0
             self.knotSeq = []
 
@@ -101,9 +101,9 @@ class BSpline(DraftObject):
         plm = obj.Placement
         if obj.Closed and (len(obj.Points) > 2):
             if obj.Points[0] == obj.Points[-1]:  # should not occur, but OCC will crash
-                _err = "_BSpline.createGeometry: \
-                        Closed with same first/last Point. Geometry not updated."
-                App.Console.PrintError(QT_TRANSLATE_NOOP('Draft', _err)+"\n")
+                _err = QT_TRANSLATE_NOOP('Draft', "_BSpline.createGeometry: "
+                        "Closed with same first/last Point. Geometry not updated.")
+                App.Console.PrintError(_err+"\n")
                 return
             spline = Part.BSplineCurve()
             spline.interpolate(obj.Points, PeriodicFlag = True, Parameters = self.knotSeq)

--- a/src/Mod/Draft/draftobjects/circle.py
+++ b/src/Mod/Draft/draftobjects/circle.py
@@ -41,26 +41,26 @@ class Circle(DraftObject):
     def __init__(self, obj):
         super(Circle, self).__init__(obj, "Circle")
 
-        _tip = "Start angle of the arc"
+        _tip = QT_TRANSLATE_NOOP("App::Property", "Start angle of the arc")
         obj.addProperty("App::PropertyAngle", "FirstAngle", 
-                        "Draft", QT_TRANSLATE_NOOP("App::Property", _tip))
+                        "Draft", _tip)
 
-        _tip = "End angle of the arc (for a full circle, \
-                give it same value as First Angle)"
+        _tip = QT_TRANSLATE_NOOP("App::Property", "End angle of the arc (for a full circle, \
+                give it same value as First Angle)")
         obj.addProperty("App::PropertyAngle","LastAngle",
-                        "Draft", QT_TRANSLATE_NOOP("App::Property", _tip))
+                        "Draft", _tip)
 
-        _tip = "Radius of the circle"
+        _tip = QT_TRANSLATE_NOOP("App::Property", "Radius of the circle")
         obj.addProperty("App::PropertyLength", "Radius",
-                        "Draft", QT_TRANSLATE_NOOP("App::Property", _tip))
+                        "Draft", _tip)
 
-        _tip = "Create a face"
+        _tip = QT_TRANSLATE_NOOP("App::Property", "Create a face")
         obj.addProperty("App::PropertyBool", "MakeFace",
-                        "Draft", QT_TRANSLATE_NOOP("App::Property", _tip))
+                        "Draft", _tip)
 
-        _tip = "The area of this object"
+        _tip = QT_TRANSLATE_NOOP("App::Property", "The area of this object")
         obj.addProperty("App::PropertyArea", "Area",
-                        "Draft", QT_TRANSLATE_NOOP("App::Property", _tip))
+                        "Draft", _tip)
 
         obj.MakeFace = get_param("fillmode", True)
 

--- a/src/Mod/Draft/draftobjects/clone.py
+++ b/src/Mod/Draft/draftobjects/clone.py
@@ -41,18 +41,21 @@ class Clone(DraftObject):
     def __init__(self,obj):
         super(Clone, self).__init__(obj, "Clone")
 
-        _tip = "The objects included in this clone"
+        _tip = QT_TRANSLATE_NOOP("App::Property",
+                "The objects included in this clone")
         obj.addProperty("App::PropertyLinkListGlobal", "Objects",
-                        "Draft", QT_TRANSLATE_NOOP("App::Property", _tip))
+                        "Draft", _tip)
 
-        _tip = "The scale factor of this clone"
+        _tip = QT_TRANSLATE_NOOP("App::Property",
+                "The scale factor of this clone")
         obj.addProperty("App::PropertyVector", "Scale",
-                        "Draft", QT_TRANSLATE_NOOP("App::Property", _tip))
+                        "Draft", _tip)
 
-        _tip = "If Clones includes several objects,\n\
-                set True for fusion or False for compound"
+        _tip = QT_TRANSLATE_NOOP("App::Property",
+                "If Clones includes several objects,\n"
+                "set True for fusion or False for compound")
         obj.addProperty("App::PropertyBool", "Fuse",
-                        "Draft", QT_TRANSLATE_NOOP("App::Property", _tip))
+                        "Draft", _tip)
         
         obj.Scale = App.Vector(1,1,1)
 

--- a/src/Mod/Draft/draftobjects/dimension.py
+++ b/src/Mod/Draft/draftobjects/dimension.py
@@ -171,30 +171,18 @@ class DimensionBase(DraftAnnotation):
         super(DimensionBase, self).__init__(obj, tp)
 
         # Draft
-        obj.addProperty("App::PropertyVector",
-                        "Normal",
-                        "Draft",
-                        QT_TRANSLATE_NOOP("App::Property",
-                                          "The normal direction of this dimension"))
+        _tip = QT_TRANSLATE_NOOP("App::Property", "The normal direction of this dimension")
+        obj.addProperty("App::PropertyVector", "Normal", "Draft", _tip)
 
-        obj.addProperty("App::PropertyLink",
-                        "Support",
-                        "Draft",
-                        QT_TRANSLATE_NOOP("App::Property",
-                                          "The object measured by this dimension"))
+        _tip = QT_TRANSLATE_NOOP("App::Property", "The object measured by this dimension")
+        obj.addProperty("App::PropertyLink", "Support", "Draft",_tip)
 
-        obj.addProperty("App::PropertyLinkSubList",
-                        "LinkedGeometry",
-                        "Draft",
-                        QT_TRANSLATE_NOOP("App::Property",
-                                          "The geometry this dimension is linked to"))
+        _tip = QT_TRANSLATE_NOOP("App::Property", "The geometry this dimension is linked to")
+        obj.addProperty("App::PropertyLinkSubList", "LinkedGeometry", "Draft", _tip)
                                           
-        obj.addProperty("App::PropertyVectorDistance",
-                        "Dimline",
-                        "Draft",
-                        QT_TRANSLATE_NOOP("App::Property",
-                                          "Point on which the dimension \n"
-                                          "line is placed."))
+        _tip = QT_TRANSLATE_NOOP("App::Property",
+                "Point on which the dimension\nline is placed.")
+        obj.addProperty("App::PropertyVectorDistance", "Dimline", "Draft", _tip)
                                           
         obj.Dimline = App.Vector(0,1,0)
         obj.Normal = App.Vector(0,0,1)
@@ -232,35 +220,20 @@ class LinearDimension(DimensionBase):
         """Add Linear Dimension specific properties to the object and set them"""
 
         # Draft
-        obj.addProperty("App::PropertyVectorDistance",
-                        "Start",
-                        "Draft",
-                        QT_TRANSLATE_NOOP("App::Property",
-                                          "Startpoint of dimension"))
+        _tip = QT_TRANSLATE_NOOP("App::Property", "Startpoint of dimension")
+        obj.addProperty("App::PropertyVectorDistance", "Start", "Draft", _tip)
 
-        obj.addProperty("App::PropertyVectorDistance",
-                        "End",
-                        "Draft",
-                        QT_TRANSLATE_NOOP("App::Property",
-                                          "Endpoint of dimension"))
+        _tip = QT_TRANSLATE_NOOP("App::Property", "Endpoint of dimension")
+        obj.addProperty("App::PropertyVectorDistance", "End", "Draft", _tip)
 
-        obj.addProperty("App::PropertyVector",
-                        "Direction",
-                        "Draft",
-                        QT_TRANSLATE_NOOP("App::Property",
-                                          "The normal direction of this dimension"))
+        _tip = QT_TRANSLATE_NOOP("App::Property", "The normal direction of this dimension")
+        obj.addProperty("App::PropertyVector", "Direction", "Draft", _tip)
 
-        obj.addProperty("App::PropertyLength",
-                        "Distance",
-                        "Draft",
-                        QT_TRANSLATE_NOOP("App::Property",
-                                          "The measurement of this dimension"))
+        _tip = QT_TRANSLATE_NOOP("App::Property", "The measurement of this dimension")
+        obj.addProperty("App::PropertyLength", "Distance", "Draft", _tip)
 
-        obj.addProperty("App::PropertyBool",
-                        "Diameter",
-                        "Draft",
-                        QT_TRANSLATE_NOOP("App::Property",
-                                          "For arc/circle measurements, false = radius, true = diameter"))
+        _tip = QT_TRANSLATE_NOOP("App::Property", "For arc/circle measurements, false = radius, true = diameter")
+        obj.addProperty("App::PropertyBool", "Diameter", "Draft", _tip)
 
         obj.Start = App.Vector(0,0,0)
         obj.End = App.Vector(1,0,0)
@@ -353,29 +326,17 @@ class AngularDimension(DimensionBase):
     def init_properties(self, obj):
         """Add Angular Dimension specific properties to the object and set them"""
 
-        obj.addProperty("App::PropertyAngle",
-                        "FirstAngle",
-                        "Draft",
-                        QT_TRANSLATE_NOOP("App::Property",
-                                          "Start angle of the dimension"))
+        _tip = QT_TRANSLATE_NOOP("App::Property","Start angle of the dimension")
+        obj.addProperty("App::PropertyAngle", "FirstAngle", "Draft", )
 
-        obj.addProperty("App::PropertyAngle",
-                        "LastAngle",
-                        "Draft",
-                        QT_TRANSLATE_NOOP("App::Property",
-                                          "End angle of the dimension"))
+        _tip = QT_TRANSLATE_NOOP("App::Property","End angle of the dimension")
+        obj.addProperty("App::PropertyAngle", "LastAngle", "Draft", _tip)
 
-        obj.addProperty("App::PropertyVectorDistance",
-                        "Center",
-                        "Draft",
-                        QT_TRANSLATE_NOOP("App::Property",
-                                          "The center point of this dimension"))
+        _tip = QT_TRANSLATE_NOOP("App::Property", "The center point of this dimension")
+        obj.addProperty("App::PropertyVectorDistance", "Center", "Draft", _tip)
 
-        obj.addProperty("App::PropertyAngle",
-                        "Angle",
-                        "Draft",
-                        QT_TRANSLATE_NOOP("App::Property",
-                                          "The measurement of this dimension"))
+        _tip = QT_TRANSLATE_NOOP("App::Property", "The measurement of this dimension")
+        obj.addProperty("App::PropertyAngle", "Angle", "Draft", _tip)
 
         obj.FirstAngle = 0
         obj.LastAngle = 90

--- a/src/Mod/Draft/draftobjects/draft_annotation.py
+++ b/src/Mod/Draft/draftobjects/draft_annotation.py
@@ -57,11 +57,9 @@ class DraftAnnotation(object):
             if not hasattr(obj.ViewObject, 'ScaleMultiplier'):
                 # annotation properties
                 vobj = obj.ViewObject
-                _tip = "Dimension size overall multiplier"
-                vobj.addProperty("App::PropertyFloat",
-                                 "ScaleMultiplier",
-                                 "Annotation",
-                                 QT_TRANSLATE_NOOP("App::Property", _tip))
+                _tip = QT_TRANSLATE_NOOP("App::Property",
+                        "Dimension size overall multiplier")
+                vobj.addProperty("App::PropertyFloat", "ScaleMultiplier", "Annotation", _tip)
                 vobj.ScaleMultiplier = 1.00
 
                 _info = "added view property 'ScaleMultiplier'"

--- a/src/Mod/Draft/draftobjects/draftlink.py
+++ b/src/Mod/Draft/draftobjects/draftlink.py
@@ -93,12 +93,9 @@ class DraftLink(DraftObject):
             # with native App::Link
             obj.configLinkProperty('ShowElement')
             showElement = obj.ShowElement
-            obj.addProperty("App::PropertyBool",
-                            "ExpandArray",
-                            "Draft",
-                            QT_TRANSLATE_NOOP("App::Property",
-                                              "Show array element as "
-                                              "children object"))
+            _tip = QT_TRANSLATE_NOOP("App::Property",
+                    "Show array element as children object")
+            obj.addProperty("App::PropertyBool", "ExpandArray", "Draft", _tip)
             obj.ExpandArray = showElement
             obj.configLinkProperty(ShowElement='ExpandArray')
             obj.removeProperty('ShowElement')

--- a/src/Mod/Draft/draftobjects/drawingview.py
+++ b/src/Mod/Draft/draftobjects/drawingview.py
@@ -51,42 +51,34 @@ class DrawingView(DraftObject):
     def __init__(self, obj):
         super(DrawingView, self).__init__(obj, "DrawingView")
         
-        _tip = "The linked object"
-        obj.addProperty("App::PropertyLink", "Source",
-                        "Base", QT_TRANSLATE_NOOP("App::Property", _tip))
+        _tip = QT_TRANSLATE_NOOP("App::Property", "The linked object")
+        obj.addProperty("App::PropertyLink", "Source", "Base", _tip)
         
-        _tip ="Projection direction"
-        obj.addProperty("App::PropertyVector", "Direction",
-                        "Shape View", QT_TRANSLATE_NOOP("App::Property", _tip))
+        _tip = QT_TRANSLATE_NOOP("App::Property", "Projection direction")
+        obj.addProperty("App::PropertyVector", "Direction", "Shape View", _tip)
         
-        _tip = "The width of the lines inside this object"
-        obj.addProperty("App::PropertyFloat", "LineWidth",
-                        "View Style", QT_TRANSLATE_NOOP("App::Property", _tip))
+        _tip = QT_TRANSLATE_NOOP("App::Property", "The width of the lines inside this object")
+        obj.addProperty("App::PropertyFloat", "LineWidth", "View Style", _tip)
                 
-        _tip = "The size of the texts inside this object"
-        obj.addProperty("App::PropertyLength", "FontSize",
-                        "View Style", QT_TRANSLATE_NOOP("App::Property", _tip))
+        _tip = QT_TRANSLATE_NOOP("App::Property", "The size of the texts inside this object")
+        obj.addProperty("App::PropertyLength", "FontSize", "View Style", _tip)
                 
-        _tip = "The spacing between lines of text"
-        obj.addProperty("App::PropertyLength", "LineSpacing",
-                        "View Style", QT_TRANSLATE_NOOP("App::Property", _tip))
+        _tip = QT_TRANSLATE_NOOP("App::Property", "The spacing between lines of text")
+        obj.addProperty("App::PropertyLength", "LineSpacing", "View Style", _tip)
                 
-        _tip = "The color of the projected objects"
-        obj.addProperty("App::PropertyColor", "LineColor",
-                        "View Style", QT_TRANSLATE_NOOP("App::Property", _tip))
+        _tip = QT_TRANSLATE_NOOP("App::Property", "The color of the projected objects")
+        obj.addProperty("App::PropertyColor", "LineColor", "View Style", _tip)
                 
-        _tip = "Shape Fill Style"
-        obj.addProperty("App::PropertyEnumeration", "FillStyle",
-                        "View Style", QT_TRANSLATE_NOOP("App::Property", _tip))
+        _tip = QT_TRANSLATE_NOOP("App::Property", "Shape Fill Style")
+        obj.addProperty("App::PropertyEnumeration", "FillStyle", "View Style", _tip)
                 
-        _tip = "Line Style"
-        obj.addProperty("App::PropertyEnumeration", "LineStyle",
-                        "View Style", QT_TRANSLATE_NOOP("App::Property", _tip))
+        _tip = QT_TRANSLATE_NOOP("App::Property", "Line Style")
+        obj.addProperty("App::PropertyEnumeration", "LineStyle", "View Style", _tip)
                 
-        _tip = "If checked, source objects are displayed regardless of being \
-                visible in the 3D model"
-        obj.addProperty("App::PropertyBool", "AlwaysOn",
-                        "View Style", QT_TRANSLATE_NOOP("App::Property", _tip))
+        _tip = QT_TRANSLATE_NOOP("App::Property", 
+                "If checked, source objects are displayed regardless of being \
+                visible in the 3D model")
+        obj.addProperty("App::PropertyBool", "AlwaysOn", "View Style", _tip)
 
         obj.FillStyle = ['shape color'] + list(utils.svgpatterns().keys())
         obj.LineStyle = ['Solid','Dashed','Dotted','Dashdot']

--- a/src/Mod/Draft/draftobjects/ellipse.py
+++ b/src/Mod/Draft/draftobjects/ellipse.py
@@ -41,30 +41,24 @@ class Ellipse(DraftObject):
     def __init__(self, obj):
         super(Ellipse, self).__init__(obj, "Ellipse")
 
-        _tip = "Start angle of the elliptical arc"
-        obj.addProperty("App::PropertyAngle", "FirstAngle",
-                        "Draft",QT_TRANSLATE_NOOP("App::Property", _tip))
+        _tip = QT_TRANSLATE_NOOP("App::Property","Start angle of the elliptical arc")
+        obj.addProperty("App::PropertyAngle", "FirstAngle", "Draft", _tip)
 
-        _tip = "End angle of the elliptical arc \n\
-                (for a full circle, give it same value as First Angle)"
-        obj.addProperty("App::PropertyAngle", "LastAngle",
-                        "Draft",QT_TRANSLATE_NOOP("App::Property", _tip))
+        _tip = QT_TRANSLATE_NOOP("App::Property","End angle of the elliptical arc \n\
+                (for a full circle, give it same value as First Angle)")
+        obj.addProperty("App::PropertyAngle", "LastAngle", "Draft", _tip)
 
-        _tip = "Minor radius of the ellipse"
-        obj.addProperty("App::PropertyLength", "MinorRadius",
-                        "Draft",QT_TRANSLATE_NOOP("App::Property", _tip))
+        _tip = QT_TRANSLATE_NOOP("App::Property","Minor radius of the ellipse")
+        obj.addProperty("App::PropertyLength", "MinorRadius", "Draft", _tip)
 
-        _tip = "Major radius of the ellipse"
-        obj.addProperty("App::PropertyLength", "MajorRadius",
-                        "Draft",QT_TRANSLATE_NOOP("App::Property", _tip))
+        _tip = QT_TRANSLATE_NOOP("App::Property","Major radius of the ellipse")
+        obj.addProperty("App::PropertyLength", "MajorRadius", "Draft", _tip)
 
-        _tip = "Create a face"
-        obj.addProperty("App::PropertyBool", "MakeFace",
-                        "Draft",QT_TRANSLATE_NOOP("App::Property", _tip))
+        _tip = QT_TRANSLATE_NOOP("App::Property","Create a face")
+        obj.addProperty("App::PropertyBool", "MakeFace", "Draft", _tip)
 
-        _tip = "Area of this object"
-        obj.addProperty("App::PropertyArea", "Area",
-                        "Draft",QT_TRANSLATE_NOOP("App::Property", _tip))
+        _tip = QT_TRANSLATE_NOOP("App::Property","Area of this object")
+        obj.addProperty("App::PropertyArea", "Area","Draft", _tip)
 
         obj.MakeFace = get_param("fillmode",True)
 

--- a/src/Mod/Draft/draftobjects/facebinder.py
+++ b/src/Mod/Draft/draftobjects/facebinder.py
@@ -39,28 +39,22 @@ class Facebinder(DraftObject):
         super(Facebinder, self).__init__(obj, "Facebinder")
 
         _tip = QT_TRANSLATE_NOOP("App::Property","Linked faces")
-        obj.addProperty("App::PropertyLinkSubList", "Faces",
-                        "Draft",  _tip)
+        obj.addProperty("App::PropertyLinkSubList", "Faces", "Draft",  _tip)
 
         _tip = QT_TRANSLATE_NOOP("App::Property","Specifies if splitter lines must be removed")
-        obj.addProperty("App::PropertyBool","RemoveSplitter",
-                        "Draft",  _tip)
+        obj.addProperty("App::PropertyBool","RemoveSplitter", "Draft",  _tip)
 
         _tip = QT_TRANSLATE_NOOP("App::Property","An optional extrusion value to be applied to all faces")
-        obj.addProperty("App::PropertyDistance","Extrusion",
-                        "Draft" , _tip)
+        obj.addProperty("App::PropertyDistance","Extrusion", "Draft" , _tip)
 
         _tip = QT_TRANSLATE_NOOP("App::Property","An optional offset value to be applied to all faces")
-        obj.addProperty("App::PropertyDistance","Offset",
-                        "Draft" , _tip)
+        obj.addProperty("App::PropertyDistance","Offset", "Draft" , _tip)
 
         _tip = QT_TRANSLATE_NOOP("App::Property","This specifies if the shapes sew")
-        obj.addProperty("App::PropertyBool","Sew",
-                        "Draft", _tip)
+        obj.addProperty("App::PropertyBool","Sew", "Draft", _tip)
 
         _tip = QT_TRANSLATE_NOOP("App::Property","The area of the faces of this Facebinder")
-        obj.addProperty("App::PropertyArea","Area",
-                        "Draft", _tip)
+        obj.addProperty("App::PropertyArea","Area", "Draft", _tip)
         obj.setEditorMode("Area",1)
 
     def execute(self,obj):

--- a/src/Mod/Draft/draftobjects/fillet.py
+++ b/src/Mod/Draft/draftobjects/fillet.py
@@ -40,35 +40,35 @@ class Fillet(base.DraftObject):
     def _set_properties(self, obj):
         """Set the properties of objects if they don't exist."""
         if not hasattr(obj, "Start"):
-            _tip = "The start point of this line."
+            _tip = QT_TRANSLATE_NOOP("App::Property", "The start point of this line.")
             obj.addProperty("App::PropertyVectorDistance",
                             "Start",
                             "Draft",
-                            QT_TRANSLATE_NOOP("App::Property", _tip))
+                            _tip)
             obj.Start = App.Vector(0, 0, 0)
 
         if not hasattr(obj, "End"):
-            _tip = "The end point of this line."
+            _tip = QT_TRANSLATE_NOOP("App::Property", "The end point of this line.")
             obj.addProperty("App::PropertyVectorDistance",
                             "End",
                             "Draft",
-                            QT_TRANSLATE_NOOP("App::Property", _tip))
+                            _tip)
             obj.End = App.Vector(0, 0, 0)
 
         if not hasattr(obj, "Length"):
-            _tip = "The length of this line."
+            _tip = QT_TRANSLATE_NOOP("App::Property", "The length of this line.")
             obj.addProperty("App::PropertyLength",
                             "Length",
                             "Draft",
-                            QT_TRANSLATE_NOOP("App::Property", _tip))
+                            _tip)
             obj.Length = 0
 
         if not hasattr(obj, "FilletRadius"):
-            _tip = "Radius to use to fillet the corner."
+            _tip = QT_TRANSLATE_NOOP("App::Property", "Radius to use to fillet the corner.")
             obj.addProperty("App::PropertyLength",
                             "FilletRadius",
                             "Draft",
-                            QT_TRANSLATE_NOOP("App::Property", _tip))
+                            _tip)
             obj.FilletRadius = 0
 
         # TODO: these two properties should link two straight lines
@@ -78,14 +78,14 @@ class Fillet(base.DraftObject):
         #    obj.addProperty("App::PropertyLinkGlobal",
         #                    "Edge1",
         #                    "Draft",
-        #                    QT_TRANSLATE_NOOP("App::Property", _tip))
+        #                    _tip))
 
         # if not hasattr(obj, "Edge2"):
         #    _tip = "Second line used as reference."
         #    obj.addProperty("App::PropertyLinkGlobal",
         #                    "Edge2",
         #                    "Draft",
-        #                    QT_TRANSLATE_NOOP("App::Property", _tip))
+        #                    _tip))
 
         # Read only, change to 0 to make it editable.
         # The Fillet Radius should be made editable

--- a/src/Mod/Draft/draftobjects/label.py
+++ b/src/Mod/Draft/draftobjects/label.py
@@ -118,59 +118,33 @@ class Label(DraftAnnotation):
     def init_properties(self, obj):
         """Add properties to the object and set them"""
 
-        obj.addProperty("App::PropertyPlacement",
-                        "Placement",
-                        "Base",
-                        QT_TRANSLATE_NOOP("App::Property",
-                                          "The placement of this object"))
+        _tip = QT_TRANSLATE_NOOP("App::Property",
+                "The placement of this object")
+        obj.addProperty("App::PropertyPlacement", "Placement", "Base", _tip)
 
-        obj.addProperty("App::PropertyDistance",
-                        "StraightDistance",
-                        "Base",
-                        QT_TRANSLATE_NOOP("App::Property",
-                                          "The length of the straight segment"))
+        _tip = QT_TRANSLATE_NOOP("App::Property","The length of the straight segment")
+        obj.addProperty("App::PropertyDistance", "StraightDistance", "Base", _tip)
 
-        obj.addProperty("App::PropertyVector",
-                        "TargetPoint",
-                        "Base",
-                        QT_TRANSLATE_NOOP("App::Property",
-                                          "The point indicated by this label"))
+        _tip = QT_TRANSLATE_NOOP("App::Property", "The point indicated by this label")
+        obj.addProperty("App::PropertyVector", "TargetPoint", "Base", _tip)
 
-        obj.addProperty("App::PropertyVectorList",
-                        "Points",
-                        "Base",
-                        QT_TRANSLATE_NOOP("App::Property",
-                                          "The points defining the label polyline"))
+        _tip = QT_TRANSLATE_NOOP("App::Property", "The points defining the label polyline")
+        obj.addProperty("App::PropertyVectorList", "Points", "Base", _tip)
 
-        obj.addProperty("App::PropertyEnumeration",
-                        "StraightDirection",
-                        "Base",
-                        QT_TRANSLATE_NOOP("App::Property",
-                                          "The direction of the straight segment"))
+        _tip = QT_TRANSLATE_NOOP("App::Property", "The direction of the straight segment")
+        obj.addProperty("App::PropertyEnumeration", "StraightDirection", "Base", _tip)
 
-        obj.addProperty("App::PropertyEnumeration",
-                        "LabelType",
-                        "Base",
-                        QT_TRANSLATE_NOOP("App::Property",
-                                          "The type of information shown by this label"))
+        _tip = QT_TRANSLATE_NOOP("App::Property","The type of information shown by this label")
+        obj.addProperty("App::PropertyEnumeration", "LabelType", "Base", _tip)
 
-        obj.addProperty("App::PropertyLinkSub",
-                        "Target",
-                        "Base",
-                        QT_TRANSLATE_NOOP("App::Property",
-                                          "The target object of this label"))
+        _tip = QT_TRANSLATE_NOOP("App::Property","The target object of this label")
+        obj.addProperty("App::PropertyLinkSub", "Target", "Base", _tip)
 
-        obj.addProperty("App::PropertyStringList",
-                        "CustomText",
-                        "Base",
-                        QT_TRANSLATE_NOOP("App::Property",
-                                          "The text to display when type is set to custom"))
+        _tip = QT_TRANSLATE_NOOP("App::Property", "The text to display when type is set to custom")
+        obj.addProperty("App::PropertyStringList", "CustomText", "Base", _tip)
 
-        obj.addProperty("App::PropertyStringList",
-                        "Text",
-                        "Base",
-                        QT_TRANSLATE_NOOP("App::Property",
-                                          "The text displayed by this label"))
+        _tip = QT_TRANSLATE_NOOP("App::Property", "The text displayed by this label")
+        obj.addProperty("App::PropertyStringList", "Text", "Base", _tip)
 
         obj.StraightDirection = ["Horizontal","Vertical","Custom"]
         obj.LabelType = ["Custom","Name","Label","Position",

--- a/src/Mod/Draft/draftobjects/point.py
+++ b/src/Mod/Draft/draftobjects/point.py
@@ -43,20 +43,14 @@ class Point(DraftObject):
     def __init__(self, obj, x=0, y=0, z=0):
         super(Point, self).__init__(obj, "Point")
 
-        obj.addProperty("App::PropertyDistance", 
-                        "X",
-                        "Draft",
-                        QT_TRANSLATE_NOOP("App::Property","X Location"))
+        _tip = QT_TRANSLATE_NOOP("App::Property", "X Location")
+        obj.addProperty("App::PropertyDistance", "X", "Draft", _tip)
 
-        obj.addProperty("App::PropertyDistance",
-                        "Y",
-                        "Draft",
-                        QT_TRANSLATE_NOOP("App::Property","Y Location"))
+        _tip = QT_TRANSLATE_NOOP("App::Property", "Y Location")
+        obj.addProperty("App::PropertyDistance", "Y", "Draft", _tip)
 
-        obj.addProperty("App::PropertyDistance",
-                        "Z",
-                        "Draft", 
-                        QT_TRANSLATE_NOOP("App::Property","Z Location"))
+        _tip = QT_TRANSLATE_NOOP("App::Property", "Z Location")
+        obj.addProperty("App::PropertyDistance", "Z", "Draft", _tip)
         
         obj.X = x
         obj.Y = y

--- a/src/Mod/Draft/draftobjects/pointarray.py
+++ b/src/Mod/Draft/draftobjects/pointarray.py
@@ -63,43 +63,47 @@ class PointArray(DraftObject):
         properties = obj.PropertiesList
 
         if "Base" not in properties:
-            _tip = "Base object that will be duplicated"
+            _tip = QT_TRANSLATE_NOOP("App::Property", 
+                    "Base object that will be duplicated")
             obj.addProperty("App::PropertyLink",
                             "Base",
                             "Objects",
-                            QT_TRANSLATE_NOOP("App::Property", _tip))
+                            _tip)
             obj.Base = None
 
         if "PointObject" not in properties:
-            _tip = ("Object containing points used to distribute "
+            _tip = QT_TRANSLATE_NOOP("App::Property", 
+                    ("Object containing points used to distribute "
                     "the base object, for example, a sketch or "
                     "a Part compound.\n"
                     "The sketch or compound must contain at least "
-                    "one explicit point or vertex object.")
+                    "one explicit point or vertex object."))
             obj.addProperty("App::PropertyLink",
                             "PointObject",
                             "Objects",
-                            QT_TRANSLATE_NOOP("App::Property", _tip))
+                            _tip)
             obj.PointObject = None
 
         if "Count" not in properties:
-            _tip = ("Total number of elements in the array.\n"
+            _tip = QT_TRANSLATE_NOOP("App::Property", 
+                    "Total number of elements in the array.\n"
                     "This property is read-only, as the number depends "
                     "on the points contained within 'Point Object'.")
             obj.addProperty("App::PropertyInteger",
                             "Count",
                             "Objects",
-                            QT_TRANSLATE_NOOP("App::Property", _tip))
+                            _tip)
             obj.Count = 0
             obj.setEditorMode("Count", 1)  # Read only
 
         if "ExtraPlacement" not in properties:
-            _tip = ("Additional placement, shift and rotation, "
+            _tip = QT_TRANSLATE_NOOP("App::Property", 
+                    "Additional placement, shift and rotation, "
                     "that will be applied to each copy")
             obj.addProperty("App::PropertyPlacement",
                             "ExtraPlacement",
                             "Objects",
-                            QT_TRANSLATE_NOOP("App::Property", _tip))
+                            _tip)
             obj.ExtraPlacement = App.Placement()
 
     def execute(self, obj):
@@ -128,12 +132,12 @@ class PointArray(DraftObject):
         properties = obj.PropertiesList
 
         if "ExtraPlacement" not in properties:
-            _tip = ("Additional placement, shift and rotation, "
+            _tip = QT_TRANSLATE_NOOP("App::Property", "Additional placement, shift and rotation, "
                     "that will be applied to each copy")
             obj.addProperty("App::PropertyPlacement",
                             "ExtraPlacement",
                             "Objects",
-                            QT_TRANSLATE_NOOP("App::Property", _tip))
+                            _tip)
             obj.ExtraPlacement.Base = obj.Base.Placement.Base
             _info = "added property 'ExtraPlacement'"
             _wrn("v0.19, " + obj.Label + ", " + _tr(_info))

--- a/src/Mod/Draft/draftobjects/polygon.py
+++ b/src/Mod/Draft/draftobjects/polygon.py
@@ -45,33 +45,33 @@ class Polygon(DraftObject):
     def __init__(self, obj):
         super(Polygon, self).__init__(obj, "Polygon")
 
-        _tip = "Number of faces"
-        obj.addProperty("App::PropertyInteger", "FacesNumber",
-                        "Draft",QT_TRANSLATE_NOOP("App::Property", _tip))
+        _tip = QT_TRANSLATE_NOOP("App::Property",
+                "Number of faces")
+        obj.addProperty("App::PropertyInteger", "FacesNumber", "Draft", _tip)
 
-        _tip = "Radius of the control circle"
-        obj.addProperty("App::PropertyLength", "Radius",
-                        "Draft",QT_TRANSLATE_NOOP("App::Property", _tip))
+        _tip = QT_TRANSLATE_NOOP("App::Property",
+                "Radius of the control circle")
+        obj.addProperty("App::PropertyLength", "Radius", "Draft", _tip)
         
-        _tip = "How the polygon must be drawn from the control circle"
-        obj.addProperty("App::PropertyEnumeration", "DrawMode",
-                        "Draft",QT_TRANSLATE_NOOP("App::Property", _tip))
+        _tip = QT_TRANSLATE_NOOP("App::Property",
+                "How the polygon must be drawn from the control circle")
+        obj.addProperty("App::PropertyEnumeration", "DrawMode", "Draft", _tip)
         
-        _tip = "Radius to use to fillet the corners"
-        obj.addProperty("App::PropertyLength", "FilletRadius",
-                        "Draft",QT_TRANSLATE_NOOP("App::Property", _tip))
+        _tip = QT_TRANSLATE_NOOP("App::Property",
+                "Radius to use to fillet the corners")
+        obj.addProperty("App::PropertyLength", "FilletRadius", "Draft", _tip)
         
-        _tip = "Size of the chamfer to give to the corners"
-        obj.addProperty("App::PropertyLength", "ChamferSize",
-                        "Draft",QT_TRANSLATE_NOOP("App::Property", _tip))
+        _tip = QT_TRANSLATE_NOOP("App::Property",
+                "Size of the chamfer to give to the corners")
+        obj.addProperty("App::PropertyLength", "ChamferSize", "Draft", _tip)
         
-        _tip = "Create a face"
-        obj.addProperty("App::PropertyBool", "MakeFace",
-                        "Draft",QT_TRANSLATE_NOOP("App::Property", _tip))
+        _tip = QT_TRANSLATE_NOOP("App::Property",
+                "Create a face")
+        obj.addProperty("App::PropertyBool", "MakeFace", "Draft", _tip)
         
-        _tip = "The area of this object"
-        obj.addProperty("App::PropertyArea", "Area",
-                        "Draft",QT_TRANSLATE_NOOP("App::Property", _tip))
+        _tip = QT_TRANSLATE_NOOP("App::Property",
+                "The area of this object")
+        obj.addProperty("App::PropertyArea", "Area", "Draft", _tip)
         
         obj.MakeFace = get_param("fillmode",True)
         obj.DrawMode = ['inscribed','circumscribed']

--- a/src/Mod/Draft/draftobjects/rectangle.py
+++ b/src/Mod/Draft/draftobjects/rectangle.py
@@ -43,37 +43,29 @@ class Rectangle(DraftObject):
     def __init__(self, obj):
         super(Rectangle, self).__init__(obj, "Rectangle")
 
-        _tip = "Length of the rectangle"
-        obj.addProperty("App::PropertyDistance", "Length",
-                        "Draft",QT_TRANSLATE_NOOP("App::Property",_tip))
+        _tip = QT_TRANSLATE_NOOP("App::Property", "Length of the rectangle")
+        obj.addProperty("App::PropertyDistance", "Length", "Draft", _tip)
 
-        _tip = "Height of the rectangle"
-        obj.addProperty("App::PropertyDistance", "Height",
-                        "Draft",QT_TRANSLATE_NOOP("App::Property", _tip))
+        _tip = QT_TRANSLATE_NOOP("App::Property", "Height of the rectangle")
+        obj.addProperty("App::PropertyDistance", "Height", "Draft", _tip)
 
-        _tip = "Radius to use to fillet the corners"
-        obj.addProperty("App::PropertyLength", "FilletRadius",
-                        "Draft",QT_TRANSLATE_NOOP("App::Property", _tip))
+        _tip = QT_TRANSLATE_NOOP("App::Property", "Radius to use to fillet the corners")
+        obj.addProperty("App::PropertyLength", "FilletRadius", "Draft", _tip)
         
-        _tip = "Size of the chamfer to give to the corners"
-        obj.addProperty("App::PropertyLength", "ChamferSize",
-                        "Draft",QT_TRANSLATE_NOOP("App::Property", _tip))
+        _tip = QT_TRANSLATE_NOOP("App::Property", "Size of the chamfer to give to the corners")
+        obj.addProperty("App::PropertyLength", "ChamferSize", "Draft", _tip)
 
-        _tip = "Create a face"
-        obj.addProperty("App::PropertyBool", "MakeFace",
-                        "Draft",QT_TRANSLATE_NOOP("App::Property", _tip))
+        _tip = QT_TRANSLATE_NOOP("App::Property", "Create a face")
+        obj.addProperty("App::PropertyBool", "MakeFace", "Draft", _tip)
         
-        _tip = "Horizontal subdivisions of this rectangle"
-        obj.addProperty("App::PropertyInteger", "Rows",
-                        "Draft",QT_TRANSLATE_NOOP("App::Property", _tip))
+        _tip = QT_TRANSLATE_NOOP("App::Property", "Horizontal subdivisions of this rectangle")
+        obj.addProperty("App::PropertyInteger", "Rows", "Draft", _tip)
         
-        _tip = "Vertical subdivisions of this rectangle"
-        obj.addProperty("App::PropertyInteger", "Columns",
-                        "Draft",QT_TRANSLATE_NOOP("App::Property", _tip))
+        _tip = QT_TRANSLATE_NOOP("App::Property", "Vertical subdivisions of this rectangle")
+        obj.addProperty("App::PropertyInteger", "Columns", "Draft", _tip)
         
-        _tip = "The area of this object"
-        obj.addProperty("App::PropertyArea", "Area",
-                        "Draft",QT_TRANSLATE_NOOP("App::Property", _tip))
+        _tip = QT_TRANSLATE_NOOP("App::Property", "The area of this object")
+        obj.addProperty("App::PropertyArea", "Area", "Draft", _tip)
         
         obj.MakeFace = get_param("fillmode",True)
         obj.Length=1

--- a/src/Mod/Draft/draftobjects/shape2dview.py
+++ b/src/Mod/Draft/draftobjects/shape2dview.py
@@ -43,48 +43,58 @@ class Shape2DView(DraftObject):
 
     def __init__(self,obj):
 
-        _tip = "The base object this 2D view must represent"
+        _tip = QT_TRANSLATE_NOOP("App::Property",
+                "The base object this 2D view must represent")
         obj.addProperty("App::PropertyLink", "Base",
-                        "Draft", QT_TRANSLATE_NOOP("App::Property", _tip))
+                        "Draft", _tip)
 
-        _tip = "The projection vector of this object"
+        _tip = QT_TRANSLATE_NOOP("App::Property",
+                "The projection vector of this object")
         obj.addProperty("App::PropertyVector", "Projection",
-                        "Draft", QT_TRANSLATE_NOOP("App::Property", _tip))
+                        "Draft", _tip)
 
-        _tip = "The way the viewed object must be projected"
+        _tip = QT_TRANSLATE_NOOP("App::Property",
+                "The way the viewed object must be projected")
         obj.addProperty("App::PropertyEnumeration", "ProjectionMode",
-                        "Draft", QT_TRANSLATE_NOOP("App::Property", _tip))
+                        "Draft", _tip)
 
-        _tip = "The indices of the faces to be projected in Individual Faces mode"
+        _tip = QT_TRANSLATE_NOOP("App::Property",
+                "The indices of the faces to be projected in Individual Faces mode")
         obj.addProperty("App::PropertyIntegerList", "FaceNumbers",
-                        "Draft", QT_TRANSLATE_NOOP("App::Property", _tip))
+                        "Draft", _tip)
 
-        _tip = "Show hidden lines"
+        _tip = QT_TRANSLATE_NOOP("App::Property",
+                "Show hidden lines")
         obj.addProperty("App::PropertyBool", "HiddenLines",
-                        "Draft", QT_TRANSLATE_NOOP("App::Property", _tip))
+                        "Draft", _tip)
 
-        _tip = "Fuse wall and structure objects of same type and material"
+        _tip = QT_TRANSLATE_NOOP("App::Property",
+                "Fuse wall and structure objects of same type and material")
         obj.addProperty("App::PropertyBool", "FuseArch",
-                        "Draft", QT_TRANSLATE_NOOP("App::Property", _tip))
+                        "Draft", _tip)
 
-        _tip = "Tessellate Ellipses and B-splines into line segments"
+        _tip = QT_TRANSLATE_NOOP("App::Property",
+                "Tessellate Ellipses and B-splines into line segments")
         obj.addProperty("App::PropertyBool", "Tessellation",
-                        "Draft", QT_TRANSLATE_NOOP("App::Property", _tip))
+                        "Draft", _tip)
 
-        _tip = "For Cutlines and Cutfaces modes, \
-                this leaves the faces at the cut location"
+        _tip = QT_TRANSLATE_NOOP("App::Property",
+                "For Cutlines and Cutfaces modes, \
+                this leaves the faces at the cut location")
         obj.addProperty("App::PropertyBool", "InPlace",
-                        "Draft", QT_TRANSLATE_NOOP("App::Property", _tip))
+                        "Draft", _tip)
 
-        _tip = "Length of line segments if tessellating Ellipses or B-splines \
-                into line segments"
+        _tip = QT_TRANSLATE_NOOP("App::Property",
+                "Length of line segments if tessellating Ellipses or B-splines \
+                into line segments")
         obj.addProperty("App::PropertyFloat", "SegmentLength",
-                        "Draft", QT_TRANSLATE_NOOP("App::Property", _tip))
+                        "Draft", _tip)
 
-        _tip = "If this is True, this object will be recomputed only if it is \
-                visible"
+        _tip = QT_TRANSLATE_NOOP("App::Property", 
+                "If this is True, this object will be recomputed only if it is \
+                visible")
         obj.addProperty("App::PropertyBool", "VisibleOnly",
-                        "Draft", QT_TRANSLATE_NOOP("App::Property", _tip))
+                        "Draft", _tip)
         
         obj.Projection = App.Vector(0,0,1)
         obj.ProjectionMode = ["Solid", "Individual Faces",

--- a/src/Mod/Draft/draftobjects/shapestring.py
+++ b/src/Mod/Draft/draftobjects/shapestring.py
@@ -45,21 +45,17 @@ class ShapeString(DraftObject):
     def __init__(self, obj):
         super(ShapeString, self).__init__(obj, "ShapeString")
 
-        _tip = "Text string"
-        obj.addProperty("App::PropertyString", "String",
-                        "Draft", QT_TRANSLATE_NOOP("App::Property", _tip))
+        _tip = QT_TRANSLATE_NOOP("App::Property", "Text string")
+        obj.addProperty("App::PropertyString", "String", "Draft", _tip)
 
-        _tip = "Font file name"
-        obj.addProperty("App::PropertyFile", "FontFile",
-                        "Draft", QT_TRANSLATE_NOOP("App::Property", _tip))
+        _tip = QT_TRANSLATE_NOOP("App::Property", "Font file name")
+        obj.addProperty("App::PropertyFile", "FontFile", "Draft", _tip)
 
-        _tip = "Height of text"
-        obj.addProperty("App::PropertyLength", "Size",
-                        "Draft", QT_TRANSLATE_NOOP("App::Property", _tip))
+        _tip = QT_TRANSLATE_NOOP("App::Property", "Height of text")
+        obj.addProperty("App::PropertyLength", "Size", "Draft", _tip)
 
-        _tip = "Inter-character spacing"
-        obj.addProperty("App::PropertyLength", "Tracking",
-                        "Draft", QT_TRANSLATE_NOOP("App::Property", _tip))
+        _tip = QT_TRANSLATE_NOOP("App::Property", "Inter-character spacing")
+        obj.addProperty("App::PropertyLength", "Tracking", "Draft", _tip)
 
     def execute(self, obj):
         import Part

--- a/src/Mod/Draft/draftobjects/wire.py
+++ b/src/Mod/Draft/draftobjects/wire.py
@@ -47,53 +47,53 @@ class Wire(DraftObject):
     def __init__(self, obj):
         super(Wire, self).__init__(obj, "Wire")
 
-        _tip = "The vertices of the wire"
-        obj.addProperty("App::PropertyVectorList","Points",
-                        "Draft",QT_TRANSLATE_NOOP("App::Property", _tip))
+        _tip = QT_TRANSLATE_NOOP("App::Property",
+                "The vertices of the wire")
+        obj.addProperty("App::PropertyVectorList","Points", "Draft",_tip)
 
-        _tip = "If the wire is closed or not"
-        obj.addProperty("App::PropertyBool","Closed",
-                        "Draft",QT_TRANSLATE_NOOP("App::Property", _tip))
+        _tip = QT_TRANSLATE_NOOP("App::Property",
+                "If the wire is closed or not")
+        obj.addProperty("App::PropertyBool","Closed", "Draft",_tip)
 
-        _tip = "The base object is the wire, it's formed from 2 objects"
-        obj.addProperty("App::PropertyLink","Base",
-                        "Draft",QT_TRANSLATE_NOOP("App::Property", _tip))
+        _tip = QT_TRANSLATE_NOOP("App::Property",
+                "The base object is the wire, it's formed from 2 objects")
+        obj.addProperty("App::PropertyLink","Base", "Draft",_tip)
 
-        _tip = "The tool object is the wire, it's formed from 2 objects"
-        obj.addProperty("App::PropertyLink","Tool",
-                        "Draft",QT_TRANSLATE_NOOP("App::Property", _tip))
+        _tip = QT_TRANSLATE_NOOP("App::Property",
+                "The tool object is the wire, it's formed from 2 objects")
+        obj.addProperty("App::PropertyLink","Tool", "Draft",_tip)
 
-        _tip = "The start point of this line"
-        obj.addProperty("App::PropertyVectorDistance","Start",
-                        "Draft",QT_TRANSLATE_NOOP("App::Property", _tip))
+        _tip = QT_TRANSLATE_NOOP("App::Property",
+                "The start point of this line")
+        obj.addProperty("App::PropertyVectorDistance","Start", "Draft",_tip)
 
-        _tip = "The end point of this line"
-        obj.addProperty("App::PropertyVectorDistance","End",
-                        "Draft",QT_TRANSLATE_NOOP("App::Property", _tip))
+        _tip = QT_TRANSLATE_NOOP("App::Property",
+                "The end point of this line")
+        obj.addProperty("App::PropertyVectorDistance","End", "Draft",_tip)
 
-        _tip = "The length of this line"
-        obj.addProperty("App::PropertyLength","Length",
-                        "Draft",QT_TRANSLATE_NOOP("App::Property", _tip))
+        _tip = QT_TRANSLATE_NOOP("App::Property",
+                "The length of this line")
+        obj.addProperty("App::PropertyLength","Length", "Draft",_tip)
 
-        _tip = "Radius to use to fillet the corners"
-        obj.addProperty("App::PropertyLength","FilletRadius",
-                        "Draft",QT_TRANSLATE_NOOP("App::Property", _tip))
+        _tip = QT_TRANSLATE_NOOP("App::Property",
+                "Radius to use to fillet the corners")
+        obj.addProperty("App::PropertyLength","FilletRadius", "Draft",_tip)
 
-        _tip = "Size of the chamfer to give to the corners"
-        obj.addProperty("App::PropertyLength","ChamferSize",
-                        "Draft",QT_TRANSLATE_NOOP("App::Property", _tip))
+        _tip = QT_TRANSLATE_NOOP("App::Property",
+                "Size of the chamfer to give to the corners")
+        obj.addProperty("App::PropertyLength","ChamferSize", "Draft",_tip)
 
-        _tip = "Create a face if this object is closed"
-        obj.addProperty("App::PropertyBool","MakeFace",
-                        "Draft",QT_TRANSLATE_NOOP("App::Property", _tip))
+        _tip = QT_TRANSLATE_NOOP("App::Property",
+                "Create a face if this object is closed")
+        obj.addProperty("App::PropertyBool","MakeFace", "Draft",_tip)
 
-        _tip = "The number of subdivisions of each edge"
-        obj.addProperty("App::PropertyInteger","Subdivisions",
-                        "Draft",QT_TRANSLATE_NOOP("App::Property", _tip))
+        _tip = QT_TRANSLATE_NOOP("App::Property",
+                "The number of subdivisions of each edge")
+        obj.addProperty("App::PropertyInteger","Subdivisions", "Draft",_tip)
 
-        _tip = "The area of this object"
-        obj.addProperty("App::PropertyArea","Area",
-                        "Draft",QT_TRANSLATE_NOOP("App::Property", _tip))
+        _tip = QT_TRANSLATE_NOOP("App::Property",
+                "The area of this object")
+        obj.addProperty("App::PropertyArea","Area", "Draft",_tip)
         
         obj.MakeFace = get_param("fillmode",True)
         obj.Closed = False

--- a/src/Mod/Draft/draftobjects/wpproxy.py
+++ b/src/Mod/Draft/draftobjects/wpproxy.py
@@ -37,9 +37,8 @@ class WorkingPlaneProxy:
     def __init__(self,obj):
         obj.Proxy = self
 
-        _tip = "The placement of this object"
-        obj.addProperty("App::PropertyPlacement", "Placement",
-                        "Base", QT_TRANSLATE_NOOP("App::Property", _tip))
+        _tip = QT_TRANSLATE_NOOP("App::Property", "The placement of this object")
+        obj.addProperty("App::PropertyPlacement", "Placement", "Base", _tip)
 
         obj.addProperty("Part::PropertyPartShape","Shape","Base","")
 


### PR DESCRIPTION
Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
