### PR TITLE
Path: Fix for optimizeLinearSegments

### DIFF
--- a/src/Mod/Path/PathScripts/PathSurface.py
+++ b/src/Mod/Path/PathScripts/PathSurface.py
@@ -2093,7 +2093,7 @@ class ObjectSurface(PathOp.ObjectOp):
             for nxt in line[2:]:
                 if not pnt.isOnLineSegment(prv, nxt):
                     pts.append(pnt)
-                prv = pnt
+                    prv = pnt
                 pnt = nxt
             pts.append(line[-1])
             return pts


### PR DESCRIPTION
Reduce cumulative error by holding onto the original point in a sequence
of linear optimizations. In testing, this fixes artifacts I have seen on
very finely sampled paths with very gradual curvature.

Further improvements are needed for this optimization, but at least this
change avoids a regression over the status quo.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
