### PR TITLE
Path: Area based unified projection implementation

### DIFF
--- a/src/Mod/Path/PathScripts/PathMillFace.py
+++ b/src/Mod/Path/PathScripts/PathMillFace.py
@@ -189,7 +189,9 @@ class ObjectFace(PathPocketBase.ObjectPocket):
         elif obj.BoundaryShape == 'Perimeter':
             if obj.ClearEdges:
                 psZMin = planeshape.BoundBox.ZMin
-                ofstShape = PathSurfaceSupport.extractFaceOffset(planeshape, self.radius * 1.25, planeshape)
+                ofstShape = PathUtils.getOffsetArea(planeshape,
+                                                    self.radius * 1.25,
+                                                    plane=planeshape)
                 ofstShape.translate(FreeCAD.Vector(0.0, 0.0, psZMin - ofstShape.BoundBox.ZMin))
                 env = PathUtils.getEnvelope(partshape=ofstShape, depthparams=self.depthparams)
             else:
@@ -198,7 +200,9 @@ class ObjectFace(PathPocketBase.ObjectPocket):
             import PathScripts.PathSurfaceSupport as PathSurfaceSupport
             baseShape = oneBase[0].Shape
             psZMin = planeshape.BoundBox.ZMin
-            ofstShape = PathSurfaceSupport.extractFaceOffset(planeshape, self.tool.Diameter * 1.1, planeshape)
+            ofstShape = PathUtils.getOffsetArea(planeshape,
+                                                self.tool.Diameter * 1.1,
+                                                plane=planeshape)
             ofstShape.translate(FreeCAD.Vector(0.0, 0.0, psZMin - ofstShape.BoundBox.ZMin))
 
             custDepthparams = self._customDepthParams(obj, obj.StartDepth.Value + 0.1, obj.FinalDepth.Value - 0.1)  # only an envelope

--- a/src/Mod/Path/PathScripts/PathWaterline.py
+++ b/src/Mod/Path/PathScripts/PathWaterline.py
@@ -951,7 +951,7 @@ class ObjectWaterline(PathOp.ObjectOp):
         return commands
 
     def _waterlineDropCutScan(self, stl, smplInt, xmin, xmax, ymin, fd, numScanLines):
-        '''_waterlineDropCutScan(stl, smplInt, xmin, xmax, ymin, fd, numScanLines) ... 
+        '''_waterlineDropCutScan(stl, smplInt, xmin, xmax, ymin, fd, numScanLines) ...
         Perform OCL scan for waterline purpose.'''
         pdc = ocl.PathDropCutter()   # create a pdc
         pdc.setSTL(stl)
@@ -1299,7 +1299,10 @@ class ObjectWaterline(PathOp.ObjectOp):
                 activeArea = area.cut(trimFace)
                 activeAreaWireCnt = len(activeArea.Wires)  # first wire is boundFace wire
                 self.showDebugObject(activeArea, 'ActiveArea_{}'.format(caCnt))
-                ofstArea = PathSurfaceSupport.extractFaceOffset(activeArea, ofst, self.wpc, makeComp=False)
+                ofstArea = PathUtils.getOffsetArea(activeArea,
+                                                   ofst,
+                                                   self.wpc,
+                                                   makeComp=False)
                 if not ofstArea:
                     data = FreeCAD.Units.Quantity(csHght, FreeCAD.Units.Length).UserString
                     PathLog.debug('No offset area returned for cut area depth at {}.'.format(data))
@@ -1359,7 +1362,7 @@ class ObjectWaterline(PathOp.ObjectOp):
         CUTAREAS = list()
         isFirst = True
         lenDP = len(depthparams)
-        
+
         # Cycle through layer depths
         for dp in range(0, lenDP):
             csHght = depthparams[dp]
@@ -1472,7 +1475,10 @@ class ObjectWaterline(PathOp.ObjectOp):
         cont = True
         cnt = 0
         while cont:
-            ofstArea = PathSurfaceSupport.extractFaceOffset(shape, ofst, self.wpc, makeComp=True)
+            ofstArea = PathUtils.getOffsetArea(shape,
+                                               ofst,
+                                               self.wpc,
+                                               makeComp=True)
             if not ofstArea:
                 break
             for F in ofstArea.Faces:
@@ -1584,7 +1590,7 @@ class ObjectWaterline(PathOp.ObjectOp):
                 li = fIds.pop()
                 low = csFaces[li]  # senior face
                 pIds = self._idInternalFeature(csFaces, fIds, pIds, li, low)
-            
+
             for af in range(lenCsF - 1, -1, -1):  # cycle from last item toward first
                 prnt = pIds[af]
                 if prnt == -1:


### PR DESCRIPTION
Generalize the `extractFaceOffset` method to `getOffsetArea`, which can
handle both face offsetting and projection. Another difference is that
the new method exposes Area's ability to preserve internal holes,
defaulting to preserving. The method is moved to the PathUtils module,
reflecting its generality and fairly wide used across Path.

This method is then used to provide a drop-in alternative to
`FindUnifiedRegions` via a small wrapper in PathSurfaceSupport. The Area
implementation is generally quick, but can fail (throw) in some cases,
so the wrapper is trying the Area method as an optimization first, and
falls back to the full `FindUnifiedRegions` logic if that fails.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
