### PR TITLE
Draft: fix Label display

### DIFF
--- a/src/Mod/Draft/draftutils/gui_utils.py
+++ b/src/Mod/Draft/draftutils/gui_utils.py
@@ -357,6 +357,8 @@ def format_object(target, origin=None):
         if not origin or not hasattr(origin, 'ViewObject'):
             if "FontSize" in obrep.PropertiesList:
                 obrep.FontSize = fs
+            if "TextSize" in obrep.PropertiesList:
+                obrep.TextSize = fs
             if "TextColor" in obrep.PropertiesList:
                 obrep.TextColor = col
             if "LineWidth" in obrep.PropertiesList:

--- a/src/Mod/Draft/draftviewproviders/view_label.py
+++ b/src/Mod/Draft/draftviewproviders/view_label.py
@@ -210,15 +210,17 @@ class ViewProviderLabel(ViewProviderDraftAnnotation):
             else:
                 self.text2d.justification = coin.SoText2.LEFT
                 self.text3d.justification = coin.SoAsciiText.LEFT
-        elif prop == "Text":
-            if obj.Text:
-                if sys.version_info.major >= 3:
-                    self.text2d.string.setValues([l for l in obj.Text if l])
-                    self.text3d.string.setValues([l for l in obj.Text if l])
-                else:
-                    self.text2d.string.setValues([l.encode("utf8") for l in obj.Text if l])
-                    self.text3d.string.setValues([l.encode("utf8") for l in obj.Text if l])
-                self.onChanged(obj.ViewObject,"TextAlignment")
+        elif prop == "Text" and obj.Text:
+            self.text2d.string.setValue("")
+            self.text3d.string.setValue("")
+
+            if sys.version_info.major >= 3:
+                self.text2d.string.setValues([l for l in obj.Text if l])
+                self.text3d.string.setValues([l for l in obj.Text if l])
+            else:
+                self.text2d.string.setValues([l.encode("utf8") for l in obj.Text if l])
+                self.text3d.string.setValues([l.encode("utf8") for l in obj.Text if l])
+            self.onChanged(obj.ViewObject, "TextAlignment")
 
     def getTextSize(self,vobj):
         if vobj.DisplayMode == "3D text":


### PR DESCRIPTION
Fix the viewprovider of the Label in order to display correctly the text list when the list changes.

When the value of the `Text` is changed, in the Coin node only the first element in the list of strings is updated, the other elements remain the same, resulting in an incorrect label.

So we empty the value of the Coin string with `self.text3d.string.setValue("")`, and then we can assign the new string list, producing the correct expected result.

We also update `draftutils.gui_utils.format_object` to be able to update the text size of `Label` objects with the size defined by the `DraftToolBar`.

---

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists