### PR TITLE
Draft: Label improvements, PEP8, and make_label

### DIFF
--- a/src/Mod/Draft/CMakeLists.txt
+++ b/src/Mod/Draft/CMakeLists.txt
@@ -113,6 +113,7 @@ SET(Draft_make_functions
     draftmake/make_ellipse.py
     draftmake/make_facebinder.py
     draftmake/make_fillet.py
+    draftmake/make_label.py
     draftmake/make_line.py
     draftmake/make_orthoarray.py
     draftmake/make_patharray.py

--- a/src/Mod/Draft/Draft.py
+++ b/src/Mod/Draft/Draft.py
@@ -398,16 +398,15 @@ if gui:
     _ViewProviderAngularDimension = ViewProviderAngularDimension
 
 
-from draftobjects.label import make_label
-from draftobjects.label import Label
+from draftobjects.label import (Label,
+                                DraftLabel)
 
-makeLabel = make_label
-DraftLabel = Label
+from draftmake.make_label import (make_label,
+                                  makeLabel)
 
 if gui:
     from draftviewproviders.view_label import ViewProviderLabel
     ViewProviderDraftLabel = ViewProviderLabel
-
 
 from draftobjects.text import (Text,
                                DraftText)

--- a/src/Mod/Draft/draftguitools/gui_labels.py
+++ b/src/Mod/Draft/draftguitools/gui_labels.py
@@ -133,16 +133,14 @@ class Label(gui_base_original.Creator):
                 dist = -dist
 
             tp = DraftVecUtils.toString(targetpoint)
-            sel = ""
+            sel = None
             if self.sel:
+                sel = "FreeCAD.ActiveDocument." + self.sel.Object.Name
+
                 if self.sel.SubElementNames:
                     sub = "'" + self.sel.SubElementNames[0] + "'"
                 else:
-                    sub = "[]"
-                sel = "["
-                sel += "FreeCAD.ActiveDocument." + self.sel.Object.Name + ", "
-                sel += sub
-                sel += "]"
+                    sub = "None"
 
             pl = "FreeCAD.Placement"
             pl += "("
@@ -156,7 +154,8 @@ class Label(gui_base_original.Creator):
             _cmd += "target_point=" + tp + ", "
             _cmd += "placement=" + pl + ", "
             if sel:
-                _cmd += "target=" + sel + ", "
+                _cmd += "target_object=" + sel + ", "
+                _cmd += "subelements=" + sub + ", "
             _cmd += "label_type=" + "'" + self.labeltype + "'" + ", "
             # _cmd += "custom_text=" + "'Label'" + ", "
             _cmd += "direction=" + "'" + direction + "'" + ", "

--- a/src/Mod/Draft/draftmake/make_label.py
+++ b/src/Mod/Draft/draftmake/make_label.py
@@ -1,0 +1,336 @@
+# -*- coding: utf-8 -*-
+# ***************************************************************************
+# *   Copyright (c) 2009, 2010 Yorik van Havre <yorik@uncreated.net>        *
+# *   Copyright (c) 2009, 2010 Ken Cline <cline@frii.com>                   *
+# *   Copyright (c) 2020 Eliud Cabrera Castillo <e.cabrera-castillo@tum.de> *
+# *                                                                         *
+# *   This file is part of the FreeCAD CAx development system.              *
+# *                                                                         *
+# *   This program is free software; you can redistribute it and/or modify  *
+# *   it under the terms of the GNU Lesser General Public License (LGPL)    *
+# *   as published by the Free Software Foundation; either version 2 of     *
+# *   the License, or (at your option) any later version.                   *
+# *   for detail see the LICENCE text file.                                 *
+# *                                                                         *
+# *   FreeCAD is distributed in the hope that it will be useful,            *
+# *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+# *   GNU Library General Public License for more details.                  *
+# *                                                                         *
+# *   You should have received a copy of the GNU Library General Public     *
+# *   License along with FreeCAD; if not, write to the Free Software        *
+# *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
+# *   USA                                                                   *
+# *                                                                         *
+# ***************************************************************************
+"""Provides the make function to create Draft Label objects."""
+## @package make_label
+# \ingroup DRAFT
+# \brief Provides the make function to create Draft Label objects.
+
+import FreeCAD as App
+import draftutils.gui_utils as gui_utils
+import draftutils.utils as utils
+
+from draftutils.messages import _msg, _wrn, _err
+from draftutils.translate import _tr
+from draftobjects.label import Label
+
+if App.GuiUp:
+    from draftviewproviders.view_label import ViewProviderLabel
+
+
+def make_label(target_point=App.Vector(0, 0, 0),
+               placement=App.Vector(30, 30, 0),
+               target=None,
+               label_type="Custom", custom_text="Label",
+               direction="Horizontal", distance=-10,
+               points=None):
+    """Create a Label object containing different types of information.
+
+    The current color and text height and font specified in preferences
+    are used.
+
+    Parameters
+    ----------
+    target_point: Base::Vector3, optional
+        It defaults to the origin `App.Vector(0, 0, 0)`.
+        This is the point which is pointed to by the label's leader line.
+        This point can be adorned with a marker like an arrow or circle.
+
+    placement: Base::Placement, Base::Vector3, or Base::Rotation, optional
+        It defaults to `App.Vector(30, 30, 0)`.
+        If it is provided, it defines the base point of the textual
+        label.
+        The input could be a full placement, just a vector indicating
+        the translation, or just a rotation.
+
+    target: list, optional
+        It defaults to `None`.
+        The list should be a `LinkSubList`, that is, it should contain
+        two elements; the first element should be an object which will be used
+        to provide information to the label; the second element should be
+        a string indicating a subelement name, either `'VertexN'`, `'EdgeN'`,
+        or `'FaceN'` which exists within the first element.
+        In this case `'N'` is a number that starts with `1`
+        and goes up to the maximum number of vertices, edges, or faces.
+        ::
+            target = [Part::Feature, 'Edge1']
+
+        The target may not need a subelement, in which case the second
+        element of the list may be empty.
+        ::
+            target = [Part::Feature, ]
+
+        This `LinkSubList` can be obtained from the `Gui::Selection`
+        module.
+        ::
+            sel_object = Gui.Selection.getSelectionEx()[0]
+            object = sel_object.Object
+            subelement = sel_object.SubElementNames[0]
+            target = [object, subelement]
+
+    label_type: str, optional
+        It defaults to `'Custom'`.
+        It can be `'Custom'`, `'Name'`, `'Label'`, `'Position'`,
+        `'Length'`, `'Area'`, `'Volume'`, `'Tag'`, or `'Material'`.
+        It indicates the type of information that will be shown in the label.
+
+        Only `'Custom'` allows you to manually set the text
+        by defining `custom_text`. The other types take their information
+        from the object included in `target`.
+
+        - `'Position'` will show the base position of the target object,
+          or of the indicated `'VertexN'` in `target`.
+        - `'Length'` will show the `Length` of the target object's `Shape`,
+          or of the indicated `'EdgeN'` in `target`.
+        - `'Area'` will show the `Area` of the target object's `Shape`,
+          or of the indicated `'FaceN'` in `target`.
+
+    custom_text: str, optional
+        It defaults to `'Label'`.
+        It is the text that will be displayed by the label when
+        `label_type` is `'Custom'`.
+
+    direction: str, optional
+        It defaults to `'Horizontal'`.
+        It can be `'Horizontal'`, `'Vertical'`, or `'Custom'`.
+        It indicates the direction of the straight segment of the leader line
+        that ends up next to the textual label.
+
+        If `'Custom'` is selected, the leader line can be manually drawn
+        by specifying the value of `points`.
+        Normally, the leader line has only three points, but with `'Custom'`
+        you can specify as many points as needed.
+
+    distance: int, float, Base::Quantity, optional
+        It defaults to -10.
+        It indicates the length of the horizontal or vertical segment
+        of the leader line.
+
+        The leader line is composed of two segments, the first segment is
+        inclined, while the second segment is either horizontal or vertical
+        depending on the value of `direction`.
+        ::
+            T
+            |
+            |
+            o------- L text
+
+        The `oL` segment's length is defined by `distance`
+        while the `oT` segment is automatically calculated depending
+        on the values of `placement` (L) and `distance` (o).
+
+        This `distance` is oriented, meaning that if it is positive
+        the segment will be to the right and above of the textual
+        label, depending on if `direction` is `'Horizontal'` or `'Vertical'`,
+        respectively.
+        If it is negative, the segment will be to the left
+        and below of the text.
+
+    points: list of Base::Vector3, optional
+        It defaults to `None`.
+        It is a list of vectors defining the shape of the leader line;
+        the list must have at least two points.
+        This argument must be used together with `direction='Custom'`
+        to display this custom leader.
+
+        However, notice that if the Label's `StraightDirection` property
+        is later changed to `'Horizontal'` or `'Vertical'`,
+        the custom point list will be overwritten with a new,
+        automatically calculated three-point list.
+
+        For the object to use custom points, `StraightDirection`
+        must remain `'Custom'`, and then the `Points` property
+        can be overwritten by a suitable list of points.
+
+    Returns
+    -------
+    App::FeaturePython
+        A scripted object of type `'Label'`.
+        This object does not have a `Shape` attribute, as the text and lines
+        are created on screen by Coin (pivy).
+
+    None
+        If there is a problem it will return `None`.
+    """
+    _name = "make_label"
+    utils.print_header(_name, "Label")
+
+    found, doc = utils.find_doc(App.activeDocument())
+    if not found:
+        _err(_tr("No active document. Aborting."))
+        return None
+
+    _msg("target_point: {}".format(target_point))
+    if not target_point:
+        target_point = App.Vector(0, 0, 0)
+    try:
+        utils.type_check([(target_point, App.Vector)], name=_name)
+    except TypeError:
+        _err(_tr("Wrong input: must be a vector."))
+        return None
+
+    _msg("placement: {}".format(placement))
+    if not placement:
+        placement = App.Placement()
+    try:
+        utils.type_check([(placement, (App.Placement,
+                                       App.Vector,
+                                       App.Rotation))], name=_name)
+    except TypeError:
+        _err(_tr("Wrong input: must be a placement, a vector, "
+                 "or a rotation."))
+        return None
+
+    # Convert the vector or rotation to a full placement
+    if isinstance(placement, App.Vector):
+        placement = App.Placement(placement, App.Rotation())
+    elif isinstance(placement, App.Rotation):
+        placement = App.Placement(App.Vector(), placement)
+
+    _msg("target: {}".format(target))
+    if target:
+        try:
+            utils.type_check([(target, (tuple, list))],
+                             name=_name)
+        except TypeError:
+            _err(_tr("Wrong input: must be a LinkSubList of two elements. "
+                     "For example, [object, 'Edge1']"))
+            return None
+
+        target = list(target)
+        if len(target) == 1:
+            target.append([])
+
+    _msg("label_type: {}".format(label_type))
+    if not label_type:
+        label_type = "Custom"
+    try:
+        utils.type_check([(label_type, str)], name=_name)
+    except TypeError:
+        _err(_tr("Wrong input: must be a string, "
+                 "'Custom', 'Name', 'Label', 'Position', "
+                 "'Length', 'Area', 'Volume', 'Tag', or 'Material'."))
+        return None
+
+    if label_type not in ("Custom", "Name", "Label", "Position",
+                          "Length", "Area", "Volume", "Tag", "Material"):
+        _err(_tr("Wrong input: must be a string, "
+                 "'Custom', 'Name', 'Label', 'Position', "
+                 "'Length', 'Area', 'Volume', 'Tag', or 'Material'."))
+        return None
+
+    _msg("custom_text: {}".format(custom_text))
+    if not custom_text:
+        custom_text = "Label"
+    try:
+        utils.type_check([(custom_text, str)], name=_name)
+    except TypeError:
+        _err(_tr("Wrong input: must be a string."))
+        return None
+
+    _msg("direction: {}".format(direction))
+    if not direction:
+        direction = "Horizontal"
+    try:
+        utils.type_check([(direction, str)], name=_name)
+    except TypeError:
+        _err(_tr("Wrong input: must be a string, "
+                 "'Horizontal', 'Vertical', or 'Custom'."))
+        return None
+
+    if direction not in ("Horizontal", "Vertical", "Custom"):
+        _err(_tr("Wrong input: must be a string, "
+                 "'Horizontal', 'Vertical', or 'Custom'."))
+        return None
+
+    _msg("distance: {}".format(distance))
+    if not distance:
+        distance = 1
+    try:
+        utils.type_check([(distance, (int, float))], name=_name)
+    except TypeError:
+        _err(_tr("Wrong input: must be a number."))
+        return None
+
+    if points:
+        _msg("points: {}".format(points))
+
+        _err_msg = _tr("Wrong input: must be a list of at least two vectors.")
+        try:
+            utils.type_check([(points, (tuple, list))], name=_name)
+        except TypeError:
+            _err(_err_msg)
+            return None
+
+        if len(points) < 2:
+            _err(_err_msg)
+            return None
+
+        if not all(isinstance(p, App.Vector) for p in points):
+            _err(_err_msg)
+            return None
+
+    new_obj = doc.addObject("App::FeaturePython",
+                            "dLabel")
+    Label(new_obj)
+
+    new_obj.TargetPoint = target_point
+    new_obj.Placement = placement
+    if target:
+        new_obj.Target = target
+
+    new_obj.LabelType = label_type
+    new_obj.CustomText = custom_text
+
+    new_obj.StraightDirection = direction
+    new_obj.StraightDistance = distance
+    if points:
+        if direction != "Custom":
+            _wrn(_tr("Direction is not 'Custom'; "
+                     "points won't be used."))
+        new_obj.Points = points
+
+    if App.GuiUp:
+        ViewProviderLabel(new_obj.ViewObject)
+        h = utils.get_param("textheight", 0.20)
+        new_obj.ViewObject.TextSize = h
+
+        gui_utils.format_object(new_obj)
+        gui_utils.select(new_obj)
+
+    return new_obj
+
+
+def makeLabel(targetpoint=None, target=None, direction=None,
+              distance=None, labeltype=None, placement=None):
+    """Create a Label. DEPRECATED. Use 'make_label'."""
+    utils.use_instead("make_label")
+
+    return make_label(target_point=targetpoint,
+                      placement=placement,
+                      target=target,
+                      label_type=labeltype,
+                      direction=direction,
+                      distance=distance)

--- a/src/Mod/Draft/draftobjects/label.py
+++ b/src/Mod/Draft/draftobjects/label.py
@@ -29,95 +29,25 @@
 # \ingroup DRAFT
 # \brief This module provides the object code for Draft Label.
 
-import FreeCAD as App
-import math
 from PySide.QtCore import QT_TRANSLATE_NOOP
-import DraftGeomUtils
-import draftutils.gui_utils as gui_utils
-import draftutils.utils as utils
+
+import FreeCAD as App
+
 from draftobjects.draft_annotation import DraftAnnotation
-
-if App.GuiUp:
-    from draftviewproviders.view_label import ViewProviderLabel
-
-
-
-def make_label(targetpoint=None, target=None, direction=None,
-               distance=None, labeltype=None, placement=None):
-    """
-    make_label(targetpoint, target, direction, distance, labeltype, placement)
-    
-    Function to create a Draft Label annotation object
-
-    Parameters
-    ----------
-    targetpoint : App::Vector
-            To be completed
-
-    target  : LinkSub
-            To be completed
-
-    direction : String
-            Straight direction of the label
-            ["Horizontal","Vertical","Custom"]
-
-    distance : Quantity
-            Length of the straight segment of label leader line 
-
-    labeltype : String
-            Label type in
-            ["Custom","Name","Label","Position",
-            "Length","Area","Volume","Tag","Material"]
-
-    placement : Base::Placement
-            To be completed
-
-    Returns
-    -------
-    obj :   App::DocumentObject
-            Newly created label object
-    """
-    obj = App.ActiveDocument.addObject("App::FeaturePython", 
-                                       "dLabel")
-    Label(obj)
-    if App.GuiUp:
-        ViewProviderLabel(obj.ViewObject)
-    if targetpoint:
-        obj.TargetPoint = targetpoint
-    if target:
-        obj.Target = target
-    if direction:
-        obj.StraightDirection = direction
-    if distance:
-        obj.StraightDistance = distance
-    if labeltype:
-        obj.LabelType = labeltype
-    if placement:
-        obj.Placement = placement
-
-    if App.GuiUp:
-        gui_utils.format_object(obj)
-        gui_utils.select(obj)
-
-    return obj
-
 
 
 class Label(DraftAnnotation):
     """The Draft Label object"""
 
     def __init__(self, obj):
-
         super(Label, self).__init__(obj, "Label")
 
         self.init_properties(obj)
 
         obj.Proxy = self
 
-
     def init_properties(self, obj):
         """Add properties to the object and set them"""
-
         _tip = QT_TRANSLATE_NOOP("App::Property",
                 "The placement of this object")
         obj.addProperty("App::PropertyPlacement", "Placement", "Base", _tip)
@@ -213,3 +143,7 @@ class Label(DraftAnnotation):
         '''Do something when a property has changed'''
 
         return
+
+
+# Alias for compatibility with v0.18 and earlier
+DraftLabel = Label

--- a/src/Mod/Draft/draftobjects/label.py
+++ b/src/Mod/Draft/draftobjects/label.py
@@ -2,6 +2,7 @@
 # ***************************************************************************
 # *   Copyright (c) 2009, 2010 Yorik van Havre <yorik@uncreated.net>        *
 # *   Copyright (c) 2009, 2010 Ken Cline <cline@frii.com>                   *
+# *   Copyright (c) 2020 Eliud Cabrera Castillo <e.cabrera-castillo@tum.de> *
 # *                                                                         *
 # *   This file is part of the FreeCAD CAx development system.              *
 # *                                                                         *
@@ -22,127 +23,251 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-
-"""This module provides the object code for Draft Label.
-"""
+"""Provide the object code for Draft Label objects."""
 ## @package label
 # \ingroup DRAFT
-# \brief This module provides the object code for Draft Label.
+# \brief Provide the object code for Draft Label objects.
 
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
 import FreeCAD as App
 
+from FreeCAD import Units as U
 from draftobjects.draft_annotation import DraftAnnotation
 
 
 class Label(DraftAnnotation):
-    """The Draft Label object"""
+    """The Draft Label object."""
 
     def __init__(self, obj):
         super(Label, self).__init__(obj, "Label")
-
-        self.init_properties(obj)
-
+        self.set_properties(obj)
         obj.Proxy = self
 
-    def init_properties(self, obj):
-        """Add properties to the object and set them"""
-        _tip = QT_TRANSLATE_NOOP("App::Property",
-                "The placement of this object")
-        obj.addProperty("App::PropertyPlacement", "Placement", "Base", _tip)
+    def set_properties(self, obj):
+        """Set properties only if they don't exist."""
+        self.set_target_properties(obj)
+        self.set_leader_properties(obj)
+        self.set_label_properties(obj)
 
-        _tip = QT_TRANSLATE_NOOP("App::Property","The length of the straight segment")
-        obj.addProperty("App::PropertyDistance", "StraightDistance", "Base", _tip)
+    def set_target_properties(self, obj):
+        """Set position properties only if they don't exist."""
+        properties = obj.PropertiesList
 
-        _tip = QT_TRANSLATE_NOOP("App::Property", "The point indicated by this label")
-        obj.addProperty("App::PropertyVector", "TargetPoint", "Base", _tip)
+        if "TargetPoint" not in properties:
+            _tip = QT_TRANSLATE_NOOP("App::Property",
+                                     "The position of the tip of the leader "
+                                     "line.\n"
+                                     "This point can be decorated "
+                                     "with an arrow or another symbol.")
+            obj.addProperty("App::PropertyVector",
+                            "TargetPoint",
+                            "Target",
+                            _tip)
+            obj.TargetPoint = App.Vector(2, -1, 0)
 
-        _tip = QT_TRANSLATE_NOOP("App::Property", "The points defining the label polyline")
-        obj.addProperty("App::PropertyVectorList", "Points", "Base", _tip)
+        if "Target" not in properties:
+            _tip = QT_TRANSLATE_NOOP("App::Property",
+                                     "Object, and optionally subelement, "
+                                     "whose properties will be displayed\n"
+                                     "as 'Text', depending on 'Label Type'.\n"
+                                     "\n"
+                                     "'Target' won't be used "
+                                     "if 'Label Type' is set to 'Custom'.")
+            obj.addProperty("App::PropertyLinkSub",
+                            "Target",
+                            "Target",
+                            _tip)
+            obj.Target = None
 
-        _tip = QT_TRANSLATE_NOOP("App::Property", "The direction of the straight segment")
-        obj.addProperty("App::PropertyEnumeration", "StraightDirection", "Base", _tip)
+    def set_leader_properties(self, obj):
+        """Set leader properties only if they don't exist."""
+        properties = obj.PropertiesList
 
-        _tip = QT_TRANSLATE_NOOP("App::Property","The type of information shown by this label")
-        obj.addProperty("App::PropertyEnumeration", "LabelType", "Base", _tip)
+        if "Points" not in properties:
+            _tip = QT_TRANSLATE_NOOP("App::Property",
+                                     "The list of points defining the leader "
+                                     "line; normally a list of three points.\n"
+                                     "\n"
+                                     "The first point should be the position "
+                                     "of the text, that is, the 'Placement',\n"
+                                     "and the last point should be "
+                                     "the tip of the line, that is, "
+                                     "the 'Target Point'.\n"
+                                     "The middle point is calculated "
+                                     "automatically depending on the chosen\n"
+                                     "'Straight Direction' "
+                                     "and the 'Straight Distance' value "
+                                     "and sign.\n"
+                                     "\n"
+                                     "If 'Straight Direction' is set to "
+                                     "'Custom', the 'Points' property\n"
+                                     "can be set as a list "
+                                     "of arbitrary points.")
+            obj.addProperty("App::PropertyVectorList",
+                            "Points",
+                            "Leader",
+                            _tip)
+            obj.Points = []
 
-        _tip = QT_TRANSLATE_NOOP("App::Property","The target object of this label")
-        obj.addProperty("App::PropertyLinkSub", "Target", "Base", _tip)
+        if "StraightDirection" not in properties:
+            _tip = QT_TRANSLATE_NOOP("App::Property",
+                                     "The direction of the straight segment "
+                                     "of the leader line.\n"
+                                     "\n"
+                                     "If 'Custom' is chosen, the points "
+                                     "of the leader can be specified by\n"
+                                     "assigning a custom list "
+                                     "to the 'Points' attribute.")
+            obj.addProperty("App::PropertyEnumeration",
+                            "StraightDirection",
+                            "Leader",
+                            _tip)
+            obj.StraightDirection = ["Horizontal", "Vertical", "Custom"]
 
-        _tip = QT_TRANSLATE_NOOP("App::Property", "The text to display when type is set to custom")
-        obj.addProperty("App::PropertyStringList", "CustomText", "Base", _tip)
+        if "StraightDistance" not in properties:
+            _tip = QT_TRANSLATE_NOOP("App::Property",
+                                     "The length of the straight segment "
+                                     "of the leader line.\n"
+                                     "\n"
+                                     "This is an oriented distance; "
+                                     "if it is negative, the line will "
+                                     "be drawn\n"
+                                     "to the left or below the 'Text', "
+                                     "otherwise to the right or above it,\n"
+                                     "depending on the value of "
+                                     "'Straight Direction'.")
+            obj.addProperty("App::PropertyDistance",
+                            "StraightDistance",
+                            "Leader",
+                            _tip)
+            obj.StraightDistance = 1
 
-        _tip = QT_TRANSLATE_NOOP("App::Property", "The text displayed by this label")
-        obj.addProperty("App::PropertyStringList", "Text", "Base", _tip)
+    def set_label_properties(self, obj):
+        """Set label properties only if they don't exist."""
+        properties = obj.PropertiesList
 
-        obj.StraightDirection = ["Horizontal","Vertical","Custom"]
-        obj.LabelType = ["Custom","Name","Label","Position",
-                         "Length","Area","Volume","Tag","Material"]
-        obj.setEditorMode("Text",1)
-        obj.StraightDistance = 1
-        obj.TargetPoint = App.Vector(2,-1,0)
-        obj.CustomText = "Label"
+        if "Placement" not in properties:
+            _tip = QT_TRANSLATE_NOOP("App::Property",
+                                     "The placement of the 'Text' element "
+                                     "in 3D space")
+            obj.addProperty("App::PropertyPlacement",
+                            "Placement",
+                            "Label",
+                            _tip)
+            obj.Placement = App.Placement()
+
+        if "CustomText" not in properties:
+            _tip = QT_TRANSLATE_NOOP("App::Property",
+                                     "The text to display when 'Label Type' "
+                                     "is set to 'Custom'")
+            obj.addProperty("App::PropertyStringList",
+                            "CustomText",
+                            "Label",
+                            _tip)
+            obj.CustomText = "Label"
+
+        if "Text" not in properties:
+            _tip = QT_TRANSLATE_NOOP("App::Property",
+                                     "The text displayed by this label.\n"
+                                     "\n"
+                                     "This property is read-only, as the "
+                                     "final text depends on 'Label Type',\n"
+                                     "and the object defined in 'Target'.\n"
+                                     "The 'Custom Text' is displayed only "
+                                     "if 'Label Type' is set to 'Custom'.")
+            obj.addProperty("App::PropertyStringList",
+                            "Text",
+                            "Label",
+                            _tip)
+            obj.setEditorMode("Text", 1)  # Read only
+
+        if "LabelType" not in properties:
+            _tip = QT_TRANSLATE_NOOP("App::Property",
+                                     "The type of information displayed "
+                                     "by this label.\n"
+                                     "\n"
+                                     "If 'Custom' is chosen, the contents of "
+                                     "'Custom Text' will be used.\n"
+                                     "For other types, the string will be "
+                                     "calculated automatically from the "
+                                     "object defined in 'Target'.\n"
+                                     "'Tag' and 'Material' only work "
+                                     "for objects that have these properties, "
+                                     "like Arch objects.\n"
+                                     "\n"
+                                     "For 'Position', 'Length', and 'Area' "
+                                     "these properties will be extracted "
+                                     "from the main object in 'Target',\n"
+                                     "or from the subelement "
+                                     "'VertexN', 'EdgeN', or 'FaceN', "
+                                     "respectively, if it is specified.")
+            obj.addProperty("App::PropertyEnumeration",
+                            "LabelType",
+                            "Label",
+                            _tip)
+            obj.LabelType = ["Custom", "Name", "Label", "Position",
+                             "Length", "Area", "Volume", "Tag", "Material"]
 
     def onDocumentRestored(self, obj):
+        """Execute code when the document is restored.
+
+        It calls the parent class to add missing annotation properties.
+        """
         super(Label, self).onDocumentRestored(obj)
 
-    def execute(self,obj):
-        '''Do something when recompute object'''
-
+    def execute(self, obj):
+        """Execute when the object is created or recomputed."""
         if obj.StraightDirection != "Custom":
             p1 = obj.Placement.Base
             if obj.StraightDirection == "Horizontal":
-                p2 = App.Vector(obj.StraightDistance.Value,0,0)
+                p2 = App.Vector(obj.StraightDistance.Value, 0, 0)
             else:
-                p2 = App.Vector(0,obj.StraightDistance.Value,0)
+                p2 = App.Vector(0, obj.StraightDistance.Value, 0)
+
             p2 = obj.Placement.multVec(p2)
             # p3 = obj.Placement.multVec(obj.TargetPoint)
             p3 = obj.TargetPoint
-            obj.Points = [p1,p2,p3]
+            obj.Points = [p1, p2, p3]
+
         if obj.LabelType == "Custom":
             if obj.CustomText:
                 obj.Text = obj.CustomText
+
         elif obj.Target and obj.Target[0]:
             if obj.LabelType == "Name":
                 obj.Text = [obj.Target[0].Name]
             elif obj.LabelType == "Label":
                 obj.Text = [obj.Target[0].Label]
             elif obj.LabelType == "Tag":
-                if hasattr(obj.Target[0],"Tag"):
+                if hasattr(obj.Target[0], "Tag"):
                     obj.Text = [obj.Target[0].Tag]
             elif obj.LabelType == "Material":
-                if hasattr(obj.Target[0],"Material"):
-                    if hasattr(obj.Target[0].Material,"Label"):
+                if hasattr(obj.Target[0], "Material"):
+                    if hasattr(obj.Target[0].Material, "Label"):
                         obj.Text = [obj.Target[0].Material.Label]
             elif obj.LabelType == "Position":
                 p = obj.Target[0].Placement.Base
                 if obj.Target[1]:
                     if "Vertex" in obj.Target[1][0]:
                         p = obj.Target[0].Shape.Vertexes[int(obj.Target[1][0][6:])-1].Point
-                obj.Text = [App.Units.Quantity(x,App.Units.Length).UserString for x in tuple(p)]
+                obj.Text = [U.Quantity(x, U.Length).UserString for x in tuple(p)]
             elif obj.LabelType == "Length":
-                if hasattr(obj.Target[0],'Shape'):
-                    if hasattr(obj.Target[0].Shape,"Length"):
-                        obj.Text = [App.Units.Quantity(obj.Target[0].Shape.Length,App.Units.Length).UserString]
+                if hasattr(obj.Target[0], 'Shape'):
+                    if hasattr(obj.Target[0].Shape, "Length"):
+                        obj.Text = [U.Quantity(obj.Target[0].Shape.Length, U.Length).UserString]
                     if obj.Target[1] and ("Edge" in obj.Target[1][0]):
-                        obj.Text = [App.Units.Quantity(obj.Target[0].Shape.Edges[int(obj.Target[1][0][4:])-1].Length,App.Units.Length).UserString]
+                        obj.Text = [U.Quantity(obj.Target[0].Shape.Edges[int(obj.Target[1][0][4:]) - 1].Length, U.Length).UserString]
             elif obj.LabelType == "Area":
-                if hasattr(obj.Target[0],'Shape'):
-                    if hasattr(obj.Target[0].Shape,"Area"):
-                        obj.Text = [App.Units.Quantity(obj.Target[0].Shape.Area,App.Units.Area).UserString.replace("^2","²")]
+                if hasattr(obj.Target[0], 'Shape'):
+                    if hasattr(obj.Target[0].Shape, "Area"):
+                        obj.Text = [U.Quantity(obj.Target[0].Shape.Area, U.Area).UserString.replace("^2", "²")]
                     if obj.Target[1] and ("Face" in obj.Target[1][0]):
-                        obj.Text = [App.Units.Quantity(obj.Target[0].Shape.Faces[int(obj.Target[1][0][4:])-1].Area,App.Units.Area).UserString]
+                        obj.Text = [U.Quantity(obj.Target[0].Shape.Faces[int(obj.Target[1][0][4:])-1].Area, U.Area).UserString]
             elif obj.LabelType == "Volume":
-                if hasattr(obj.Target[0],'Shape'):
-                    if hasattr(obj.Target[0].Shape,"Volume"):
-                        obj.Text = [App.Units.Quantity(obj.Target[0].Shape.Volume,App.Units.Volume).UserString.replace("^3","³")]
-
-
-    def onChanged(self,obj,prop):
-        '''Do something when a property has changed'''
-
-        return
+                if hasattr(obj.Target[0], 'Shape'):
+                    if hasattr(obj.Target[0].Shape, "Volume"):
+                        obj.Text = [U.Quantity(obj.Target[0].Shape.Volume, U.Volume).UserString.replace("^3", "³")]
 
 
 # Alias for compatibility with v0.18 and earlier

--- a/src/Mod/Draft/draftobjects/label.py
+++ b/src/Mod/Draft/draftobjects/label.py
@@ -229,6 +229,22 @@ class Label(DraftAnnotation):
         """
         super(Label, self).onDocumentRestored(obj)
 
+    def onChanged(self, obj, prop):
+        """Execute when a property is changed."""
+        super(Label, self).onChanged(obj, prop)
+        self.show_and_hide(obj, prop)
+
+    def show_and_hide(self, obj, prop):
+        """Show and hide the properties depending on the touched property."""
+        # The minus sign removes the Hidden property (show)
+        if prop == "LabelType":
+            if obj.LabelType != "Custom":
+                obj.setPropertyStatus("CustomText", "Hidden")
+                obj.setPropertyStatus("Target", "-Hidden")
+            else:
+                obj.setPropertyStatus("CustomText", "-Hidden")
+                obj.setPropertyStatus("Target", "Hidden")
+
     def execute(self, obj):
         """Execute when the object is created or recomputed."""
         if obj.StraightDirection != "Custom":

--- a/src/Mod/Draft/drafttests/draft_test_objects.py
+++ b/src/Mod/Draft/drafttests/draft_test_objects.py
@@ -354,9 +354,10 @@ def _create_objects(doc=None,
     _msg(16 * "-")
     _msg("Label")
     place = App.Placement(Vector(18500, 500, 0), App.Rotation())
-    label = Draft.make_label(targetpoint=Vector(18000, 0, 0),
-                             distance=-250,
-                             placement=place)
+    label = Draft.make_label(target_point=Vector(18000, 0, 0),
+                             placement=place,
+                             custom_text="Example label",
+                             distance=-250)
     label.Text = "Testing"
     if App.GuiUp:
         label.ViewObject.ArrowSize = 15

--- a/src/Mod/Draft/drafttests/test_creation.py
+++ b/src/Mod/Draft/drafttests/test_creation.py
@@ -321,7 +321,7 @@ class DraftCreation(unittest.TestCase):
         _msg("  target_point={0}, "
              "distance={1}".format(target_point, distance))
         _msg("  placement={}".format(placement))
-        obj = Draft.make_label(targetpoint=target_point,
+        obj = Draft.make_label(target_point=target_point,
                                distance=distance,
                                placement=placement)
         self.doc.recompute()


### PR DESCRIPTION
General cleanup for the `make_label` function, which now has separate, `target_object` and `subelements` parameters. Type checking is made in all parameters to make sure the user enters the correct information. The older `makeLabel` is considered deprecated but still works the same as before.

The internal class was updated to clearly structure the properties, and more complete tooltips were provided. The `execute` method was updated to use smaller functions to show how the text can be generated from the information of the target object and its subelements. It is possible to combine two or more sets of labels by concatenating the lists of strings produced by those functions, which is seen in action in the new "label types".

General cleanup for PEP8 style, for the Gui Command, and for the unit tests and the test script.

Pull request #3592 also improves the Label object by fixing an issue in the viewprovider, specifically in the Coin node that displays the text.

---

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists