### PR TITLE
App: Support path separator in program option "python-path"

### DIFF
--- a/src/App/Application.cpp
+++ b/src/App/Application.cpp
@@ -120,6 +120,7 @@
 #include <Build/Version.h>
 #include "Branding.h"
 
+#include <boost/algorithm/string.hpp>
 #include <boost/tokenizer.hpp>
 #include <boost/token_functions.hpp>
 #include <boost/bind.hpp>
@@ -2573,9 +2574,13 @@ void Application::ParseOptions(int ac, char ** av)
     }
 
     if (vm.count("python-path")) {
-        vector<string> Paths = vm["python-path"].as< vector<string> >();
-        for (vector<string>::const_iterator It= Paths.begin();It != Paths.end();++It)
-            Base::Interpreter().addPythonPath(It->c_str());
+        vector<string> paths = vm["python-path"].as<vector<string>>();
+        for (const auto &it : paths) {
+            vector<string> splitPaths;
+            split(splitPaths, it, is_any_of(PYPATHSEP));
+            for (const auto &path : splitPaths)
+                Base::Interpreter().addPythonPath(path.c_str());
+        }
     }
 
     if (vm.count("input-file")) {

--- a/src/FCConfig.h
+++ b/src/FCConfig.h
@@ -119,8 +119,10 @@
 
 #ifdef FC_OS_WIN32
 #   define PATHSEP '\\'
+#   define PYPATHSEP ";"
 #else
 #   define PATHSEP '/'
+#   define PYPATHSEP ":"
 #endif
 
 //**************************************************************************


### PR DESCRIPTION
Use the established python path separators (";" on Windows, ":" on POSIX)
to support adding multiple python paths on launch via the -P cmd line argument or
via FreeCAD.cfg.

The paths can be joined in the same way as in the env variable PYTHONPATH,
e.g. "PATH1:PATH2:PATH3" on POSIX.

See forum: https://forum.freecadweb.org/viewtopic.php?f=10&t=47335

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists
---
