### PR TITLE
Fix typos [skip ci]

### DIFF
--- a/src/Mod/Draft/draftgeoutils/circles.py
+++ b/src/Mod/Draft/draftgeoutils/circles.py
@@ -144,7 +144,7 @@ def circlefrom2Lines1Point(edge1, edge2, point):
 
 
 def circleFrom2LinesRadius(edge1, edge2, radius):
-    """Retun a list of circles from two edges and one radius.
+    """Return a list of circles from two edges and one radius.
 
     It calculates 4 centers.
     """

--- a/src/Mod/Draft/draftgeoutils/offsets.py
+++ b/src/Mod/Draft/draftgeoutils/offsets.py
@@ -41,7 +41,7 @@ Part = lz.LazyLoader("Part", globals(), "Part")
 
 
 def pocket2d(shape, offset):
-    """Return a list of wires obtained from offseting wires from the shape.
+    """Return a list of wires obtained from offsetting wires from the shape.
 
     Return a list of wires obtained from offsetting the wires
     from the given shape by the given offset, and intersection if needed.

--- a/src/Mod/Draft/draftguitools/gui_edit_draft_objects.py
+++ b/src/Mod/Draft/draftguitools/gui_edit_draft_objects.py
@@ -383,7 +383,7 @@ def recomputePointsBezier(obj, pts, idx, v,
             if idx >= 1: #move left pole
                 knotidx = idx if idx < len(pts) else 0
                 pts[idx-1] = pts[idx-1] + v - pts[knotidx]
-                #if moveTrackers: # trackers are reseted after editing
+                #if moveTrackers: # trackers are reset after editing
                 #    self.trackers[obj.Name][idx-1].set(pts[idx-1])
             if idx < len(pts)-1: #move right pole
                 pts[idx+1] = pts[idx+1] + v - pts[idx]

--- a/src/Mod/Draft/draftguitools/gui_patharray.py
+++ b/src/Mod/Draft/draftguitools/gui_patharray.py
@@ -81,7 +81,7 @@ class PathArray(gui_base_original.Modifier):
         """Execute when the command is called."""
         super(PathArray, self).Activated(name=name)
         self.name = name
-        # This was deactivated becuase it doesn't work correctly;
+        # This was deactivated because it doesn't work correctly;
         # the selection needs to be made on two objects, but currently
         # it only selects one.
 

--- a/src/Mod/Draft/draftguitools/gui_pointarray.py
+++ b/src/Mod/Draft/draftguitools/gui_pointarray.py
@@ -126,7 +126,7 @@ class PointArray(gui_base_original.Modifier):
                          "App.ActiveDocument.recompute()"]
             self.commit(_tr(self.name), _cmd_list)
 
-        # Commit the transaction and execute the comamnds
+        # Commit the transaction and execute the commands
         # through the parent class
         self.finish()
 

--- a/src/Mod/Draft/draftmake/make_patharray.py
+++ b/src/Mod/Draft/draftmake/make_patharray.py
@@ -114,7 +114,7 @@ def make_path_array(base_object, path_object, count=4,
           `X` is curve tangent, `Y` is normal parameter, Z is the cross
           product `X` x `Y`.
         - Frenet. It defines a local coordinate system along the path.
-          `X` is tanget to curve, `Y` is curve normal, `Z` is curve binormal.
+          `X` is tangent to curve, `Y` is curve normal, `Z` is curve binormal.
           If normal cannot be computed, for example, in a straight path,
           a default is used.
         - Tangent. It is similar to `'Original'` but includes a pre-rotation

--- a/src/Mod/Draft/draftutils/utils.py
+++ b/src/Mod/Draft/draftutils/utils.py
@@ -1361,8 +1361,8 @@ def use_instead(function, version=""):
         If we don't know when this command will be deprecated
         then we should not give a version.
     """
-    text = "This function will be deprected in "
-    text2 = "This function will be deprected. "
+    text = "This function will be deprecated in "
+    text2 = "This function will be deprecated. "
     text3 = "Please use "
 
     if version:

--- a/src/Mod/Idf/Idf.py
+++ b/src/Mod/Idf/Idf.py
@@ -76,7 +76,7 @@ def insert(filename,docname):
 def process_emn(doc,filename):
    """process_emn(document, filename)-> adds emn geometry from emn file"""
    emnfile=pythonopen(filename, "r")
-   emn_unit=1.0 #presume milimeter like emn unit
+   emn_unit=1.0 #presume millimeter like emn unit
    emn_version=2 #presume emn_version 2
    board_thickness=0 #presume 0 board height
    board_outline=[] #no outline

--- a/src/Mod/Path/PathScripts/PathSurfaceSupport.py
+++ b/src/Mod/Path/PathScripts/PathSurfaceSupport.py
@@ -57,7 +57,7 @@ class PathGeometryGenerator:
     PathGeometryGenerator(obj, shape, pattern)
     `obj` is the operation object, `shape` is the horizontal planar shape object,
     and `pattern` is the name of the geometric pattern to apply.
-    Frist, call the getCenterOfPattern() method for the CenterOfMass for patterns allowing a custom center.
+    First, call the getCenterOfPattern() method for the CenterOfMass for patterns allowing a custom center.
     Next, call the generatePathGeometry() method to request the path geometry shape.'''
 
     # Register valid patterns here by name

--- a/src/Mod/TechDraw/App/CosmeticEdgePyImp.cpp
+++ b/src/Mod/TechDraw/App/CosmeticEdgePyImp.cpp
@@ -284,7 +284,7 @@ Py::Object CosmeticEdgePy::getRadius(void) const
     TechDraw::GeomType gt = getCosmeticEdgePtr()->m_geometry->geomType;
     if ( (gt != TechDraw::GeomType::CIRCLE) &&
          (gt != TechDraw::GeomType::ARCOFCIRCLE) ) {
-        std::string error = "not a cirle. Can not set radius";
+        std::string error = "not a circle. Can not set radius";
         throw Py::TypeError(error);
     }
     double r = getCosmeticEdgePtr()->permaRadius;
@@ -298,7 +298,7 @@ void CosmeticEdgePy::setRadius(Py::Object arg)
     if ( (gt != TechDraw::GeomType::CIRCLE) &&
          (gt != TechDraw::GeomType::ARCOFCIRCLE) ) {
         std::string error = std::string(p->ob_type->tp_name);
-        error += " is not a cirle. Can not set radius";
+        error += " is not a circle. Can not set radius";
         throw Py::TypeError(error);
     }
 
@@ -326,7 +326,7 @@ Py::Object CosmeticEdgePy::getCenter(void) const
     TechDraw::GeomType gt = getCosmeticEdgePtr()->m_geometry->geomType;
     if ( (gt != TechDraw::GeomType::CIRCLE) &&
          (gt != TechDraw::GeomType::ARCOFCIRCLE) ) {
-        std::string error = "not a cirle. Can not get center";
+        std::string error = "not a circle. Can not get center";
         throw Py::TypeError(error);
     }
     Base::Vector3d point = getCosmeticEdgePtr()->permaStart;
@@ -340,7 +340,7 @@ void CosmeticEdgePy::setCenter(Py::Object arg)
     if ( (gt != TechDraw::GeomType::CIRCLE) &&
          (gt != TechDraw::GeomType::ARCOFCIRCLE) ) {
         std::string error = std::string(p->ob_type->tp_name);
-        error += " is not a cirle. Can not set center";
+        error += " is not a circle. Can not set center";
         throw Py::TypeError(error);
     }
 

--- a/src/Mod/TechDraw/App/PropertyCosmeticEdgeList.cpp
+++ b/src/Mod/TechDraw/App/PropertyCosmeticEdgeList.cpp
@@ -78,7 +78,7 @@ int PropertyCosmeticEdgeList::getSize(void) const
 }
 
 
-//_lValueList is not const. so why do we pass a const paramter?
+//_lValueList is not const. so why do we pass a const parameter?
 void PropertyCosmeticEdgeList::setValue(CosmeticEdge* lValue)
 {
     if (lValue) {


### PR DESCRIPTION
Found via codespell v1.18.0.dev0  
```
codespell -q 3 -L aci,ake,aline,alle,alledges,alocation,als,ang,anid,ba,beginn,behaviour,bloaded,byteorder,calculater,cancelled,cancelling,cas,cascade,centimetre,childs,colour,colours,commen,connexion,currenty,dof,doubleclick,dum,eiter,elemente,ende,feld,finde,findf,freez,hist,iff,indicies,initialisation,initialise,initialised,initialises,initialisiert,ist,kilometre,lod,mantatory,methode,metres,millimetre,modell,nd,noe,normale,normaly,nto,numer,oder,orgin,orginx,orginy,ot,pard,pres,programm,que,recurrance,rougly,seperator,serie,sinc,strack,substraction,te,thist,thru,tread,uint,unter,vertexes,wallthickness,whitespaces -S ./.git,*.po,*.ts,./ChangeLog.txt,./src/3rdParty,./src/Mod/Assembly/App/opendcm,./src/CXX,./src/zipios++,./src/Base/swig*,./src/Mod/Robot/App/kdl_cp,./src/Mod/Import/App/SCL,./src/WindowsInstaller,./src/Doc/FreeCAD.uml
```