### PR TITLE
[TD] GeomHatch dialog: use sensible scale limits

### DIFF
--- a/src/Mod/TechDraw/Gui/TaskGeomHatch.ui
+++ b/src/Mod/TechDraw/Gui/TaskGeomHatch.ui
@@ -145,6 +145,12 @@
           <property name="alignment">
            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
           </property>
+          <property name="keyboardTracking">
+           <bool>false</bool>
+          </property>
+          <property name="minimum">
+           <double>0.100000000000000</double>
+          </property>
           <property name="singleStep">
            <double>0.100000000000000</double>
           </property>
@@ -166,6 +172,12 @@
           </property>
           <property name="alignment">
            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          </property>
+          <property name="keyboardTracking">
+           <bool>false</bool>
+          </property>
+          <property name="minimum">
+           <double>0.001000000000000</double>
           </property>
           <property name="singleStep">
            <double>0.100000000000000</double>


### PR DESCRIPTION
- negative scale and line width is not sensible and lead to strange effects thus set a minimum
- set the minimum reasonably above 0 since e.g. a hatch scale of 0.01 fills 8 GB RAM -> out of RAM error
- disable KeyboardTracking since we don't want a time-consuming recomputation while the user changes a value