### PR TITLE
[TD] some wording fixes

### DIFF
--- a/src/Mod/TechDraw/Gui/DlgPrefsTechDrawGeneral.ui
+++ b/src/Mod/TechDraw/Gui/DlgPrefsTechDrawGeneral.ui
@@ -95,7 +95,7 @@
            </size>
           </property>
           <property name="toolTip">
-           <string>Whether or not a page's 'Keep Update' property
+           <string>Whether or not a page's 'Keep Updated' property
 can override the global 'Update With 3D' parameter</string>
           </property>
           <property name="text">
@@ -278,7 +278,7 @@ for ProjectionGroups</string>
           </property>
           <property name="currentFont">
            <font>
-            <family>osifont</family>
+            <family>MS Shell Dlg 2</family>
             <pointsize>10</pointsize>
            </font>
           </property>

--- a/src/Mod/TechDraw/Gui/DlgPrefsTechDrawGeneral.ui
+++ b/src/Mod/TechDraw/Gui/DlgPrefsTechDrawGeneral.ui
@@ -278,7 +278,6 @@ for ProjectionGroups</string>
           </property>
           <property name="currentFont">
            <font>
-            <family>MS Shell Dlg 2</family>
             <pointsize>10</pointsize>
            </font>
           </property>

--- a/src/Mod/TechDraw/Gui/TaskActiveView.ui
+++ b/src/Mod/TechDraw/Gui/TaskActiveView.ui
@@ -214,32 +214,32 @@ the top and left view border</string>
        </property>
        <item>
         <property name="text">
-         <string>AS_IS</string>
+         <string>As is</string>
         </property>
        </item>
        <item>
         <property name="text">
-         <string>WIREFRAME</string>
+         <string>Wireframe</string>
         </property>
        </item>
        <item>
         <property name="text">
-         <string>POINTS</string>
+         <string>Points</string>
         </property>
        </item>
        <item>
         <property name="text">
-         <string>WIREFRAME_OVERLAY</string>
+         <string>Wireframe overlay</string>
         </property>
        </item>
        <item>
         <property name="text">
-         <string>HIDDEN_LINE</string>
+         <string>Hidden Line</string>
         </property>
        </item>
        <item>
         <property name="text">
-         <string>BOUNDING_BOX</string>
+         <string>Bounding box</string>
         </property>
        </item>
       </widget>


### PR DESCRIPTION
- I had a look at Crowdin and saw that the translators don't know what to do with the uppercase letter words. And in fact we can use "normal" terms
- I also fixed a typo (missing 'd') to be consistent
- get rid of explicit font family statement