### PR TITLE
[TD] remove frame from pref dialogs

### DIFF
--- a/src/Mod/TechDraw/Gui/DlgPrefsTechDrawAdvanced.ui
+++ b/src/Mod/TechDraw/Gui/DlgPrefsTechDrawAdvanced.ui
@@ -429,15 +429,6 @@ can be a performance penalty in complex models.</string>
        <italic>false</italic>
       </font>
      </property>
-     <property name="frameShape">
-      <enum>QFrame::NoFrame</enum>
-     </property>
-     <property name="frameShadow">
-      <enum>QFrame::Plain</enum>
-     </property>
-     <property name="lineWidth">
-      <number>1</number>
-     </property>
      <property name="text">
       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Note:&lt;/span&gt; Items in &lt;span style=&quot; font-style:italic;&quot;&gt;italics&lt;/span&gt; are default values for new objects. They have no effect on existing objects.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>

--- a/src/Mod/TechDraw/Gui/DlgPrefsTechDrawAdvanced.ui
+++ b/src/Mod/TechDraw/Gui/DlgPrefsTechDrawAdvanced.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>460</width>
-    <height>330</height>
+    <height>318</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -425,15 +425,24 @@ can be a performance penalty in complex models.</string>
     <widget class="QLabel" name="label_17">
      <property name="font">
       <font>
-       <pointsize>12</pointsize>
-       <italic>true</italic>
+       <pointsize>10</pointsize>
+       <italic>false</italic>
       </font>
      </property>
      <property name="frameShape">
-      <enum>QFrame::Box</enum>
+      <enum>QFrame::NoFrame</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Plain</enum>
+     </property>
+     <property name="lineWidth">
+      <number>1</number>
      </property>
      <property name="text">
-      <string>Items in italics are default values for new objects.  They have no effect on existing objects.</string>
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Note:&lt;/span&gt; Items in &lt;span style=&quot; font-style:italic;&quot;&gt;italics&lt;/span&gt; are default values for new objects. They have no effect on existing objects.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="textFormat">
+      <enum>Qt::RichText</enum>
      </property>
      <property name="wordWrap">
       <bool>true</bool>

--- a/src/Mod/TechDraw/Gui/DlgPrefsTechDrawAnnotation.ui
+++ b/src/Mod/TechDraw/Gui/DlgPrefsTechDrawAnnotation.ui
@@ -844,9 +844,6 @@
        <italic>false</italic>
       </font>
      </property>
-     <property name="frameShape">
-      <enum>QFrame::NoFrame</enum>
-     </property>
      <property name="text">
       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Note:&lt;/span&gt; Items in &lt;span style=&quot; font-style:italic;&quot;&gt;italics&lt;/span&gt; are default values for new objects. They have no effect on existing objects.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>

--- a/src/Mod/TechDraw/Gui/DlgPrefsTechDrawAnnotation.ui
+++ b/src/Mod/TechDraw/Gui/DlgPrefsTechDrawAnnotation.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>460</width>
-    <height>478</height>
+    <height>447</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -840,15 +840,15 @@
     <widget class="QLabel" name="label_17">
      <property name="font">
       <font>
-       <pointsize>12</pointsize>
-       <italic>true</italic>
+       <pointsize>10</pointsize>
+       <italic>false</italic>
       </font>
      </property>
      <property name="frameShape">
-      <enum>QFrame::Box</enum>
+      <enum>QFrame::NoFrame</enum>
      </property>
      <property name="text">
-      <string>Items in italics are default values for new objects.  They have no effect on existing objects.</string>
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Note:&lt;/span&gt; Items in &lt;span style=&quot; font-style:italic;&quot;&gt;italics&lt;/span&gt; are default values for new objects. They have no effect on existing objects.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
      <property name="wordWrap">
       <bool>true</bool>

--- a/src/Mod/TechDraw/Gui/DlgPrefsTechDrawColors.ui
+++ b/src/Mod/TechDraw/Gui/DlgPrefsTechDrawColors.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>460</width>
-    <height>369</height>
+    <height>343</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -15,12 +15,6 @@
     <horstretch>0</horstretch>
     <verstretch>0</verstretch>
    </sizepolicy>
-  </property>
-  <property name="minimumSize">
-   <size>
-    <width>0</width>
-    <height>0</height>
-   </size>
   </property>
   <property name="windowTitle">
    <string>Colors</string>
@@ -549,15 +543,15 @@
     <widget class="QLabel" name="label_12">
      <property name="font">
       <font>
-       <pointsize>12</pointsize>
-       <italic>true</italic>
+       <pointsize>10</pointsize>
+       <italic>false</italic>
       </font>
      </property>
      <property name="frameShape">
-      <enum>QFrame::Box</enum>
+      <enum>QFrame::NoFrame</enum>
      </property>
      <property name="text">
-      <string>Items in italics are default values for new objects.  They have no effect on existing objects.</string>
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Note:&lt;/span&gt; Items in &lt;span style=&quot; font-style:italic;&quot;&gt;italics&lt;/span&gt; are default values for new objects. They have no effect on existing objects.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
      <property name="wordWrap">
       <bool>true</bool>

--- a/src/Mod/TechDraw/Gui/DlgPrefsTechDrawColors.ui
+++ b/src/Mod/TechDraw/Gui/DlgPrefsTechDrawColors.ui
@@ -547,9 +547,6 @@
        <italic>false</italic>
       </font>
      </property>
-     <property name="frameShape">
-      <enum>QFrame::NoFrame</enum>
-     </property>
      <property name="text">
       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Note:&lt;/span&gt; Items in &lt;span style=&quot; font-style:italic;&quot;&gt;italics&lt;/span&gt; are default values for new objects. They have no effect on existing objects.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>

--- a/src/Mod/TechDraw/Gui/DlgPrefsTechDrawDimensions.ui
+++ b/src/Mod/TechDraw/Gui/DlgPrefsTechDrawDimensions.ui
@@ -540,9 +540,6 @@
        <italic>false</italic>
       </font>
      </property>
-     <property name="frameShape">
-      <enum>QFrame::NoFrame</enum>
-     </property>
      <property name="text">
       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Note:&lt;/span&gt; Items in &lt;span style=&quot; font-style:italic;&quot;&gt;italics&lt;/span&gt; are default values for new objects. They have no effect on existing objects.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>

--- a/src/Mod/TechDraw/Gui/DlgPrefsTechDrawDimensions.ui
+++ b/src/Mod/TechDraw/Gui/DlgPrefsTechDrawDimensions.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>460</width>
-    <height>440</height>
+    <height>403</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -536,15 +536,15 @@
     <widget class="QLabel" name="label_17">
      <property name="font">
       <font>
-       <pointsize>12</pointsize>
-       <italic>true</italic>
+       <pointsize>10</pointsize>
+       <italic>false</italic>
       </font>
      </property>
      <property name="frameShape">
-      <enum>QFrame::Box</enum>
+      <enum>QFrame::NoFrame</enum>
      </property>
      <property name="text">
-      <string>Items in italics are default values for new objects.  They have no effect on existing objects.</string>
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Note:&lt;/span&gt; Items in &lt;span style=&quot; font-style:italic;&quot;&gt;italics&lt;/span&gt; are default values for new objects. They have no effect on existing objects.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
      <property name="wordWrap">
       <bool>true</bool>

--- a/src/Mod/TechDraw/Gui/DlgPrefsTechDrawGeneral.ui
+++ b/src/Mod/TechDraw/Gui/DlgPrefsTechDrawGeneral.ui
@@ -645,9 +645,6 @@ for ProjectionGroups</string>
        <italic>false</italic>
       </font>
      </property>
-     <property name="frameShape">
-      <enum>QFrame::NoFrame</enum>
-     </property>
      <property name="text">
       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Note:&lt;/span&gt; Items in &lt;span style=&quot; font-style:italic;&quot;&gt;italics&lt;/span&gt; are default values for new objects. They have no effect on existing objects.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>

--- a/src/Mod/TechDraw/Gui/DlgPrefsTechDrawGeneral.ui
+++ b/src/Mod/TechDraw/Gui/DlgPrefsTechDrawGeneral.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>496</width>
-    <height>531</height>
+    <height>495</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -15,12 +15,6 @@
     <horstretch>0</horstretch>
     <verstretch>0</verstretch>
    </sizepolicy>
-  </property>
-  <property name="minimumSize">
-   <size>
-    <width>0</width>
-    <height>0</height>
-   </size>
   </property>
   <property name="windowTitle">
    <string>General</string>
@@ -647,15 +641,15 @@ for ProjectionGroups</string>
     <widget class="QLabel" name="label_12">
      <property name="font">
       <font>
-       <pointsize>12</pointsize>
-       <italic>true</italic>
+       <pointsize>10</pointsize>
+       <italic>false</italic>
       </font>
      </property>
      <property name="frameShape">
-      <enum>QFrame::Box</enum>
+      <enum>QFrame::NoFrame</enum>
      </property>
      <property name="text">
-      <string>Items in italics are default values for new objects.  They have no effect on existing objects.</string>
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Note:&lt;/span&gt; Items in &lt;span style=&quot; font-style:italic;&quot;&gt;italics&lt;/span&gt; are default values for new objects. They have no effect on existing objects.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
      <property name="wordWrap">
       <bool>true</bool>

--- a/src/Mod/TechDraw/Gui/DlgPrefsTechDrawHLR.ui
+++ b/src/Mod/TechDraw/Gui/DlgPrefsTechDrawHLR.ui
@@ -384,9 +384,6 @@ Fast, but result is a collection of short straight lines.</string>
        <italic>false</italic>
       </font>
      </property>
-     <property name="frameShape">
-      <enum>QFrame::NoFrame</enum>
-     </property>
      <property name="text">
       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Note:&lt;/span&gt; Items in &lt;span style=&quot; font-style:italic;&quot;&gt;italics&lt;/span&gt; are default values for new objects. They have no effect on existing objects.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>

--- a/src/Mod/TechDraw/Gui/DlgPrefsTechDrawHLR.ui
+++ b/src/Mod/TechDraw/Gui/DlgPrefsTechDrawHLR.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>441</width>
-    <height>354</height>
+    <height>307</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -16,20 +16,14 @@
     <verstretch>0</verstretch>
    </sizepolicy>
   </property>
-  <property name="minimumSize">
-   <size>
-    <width>0</width>
-    <height>0</height>
-   </size>
-  </property>
   <property name="windowTitle">
    <string>HLR</string>
   </property>
   <property name="toolTip">
    <string/>
   </property>
-  <layout class="QGridLayout" name="gridLayout">
-   <item row="0" column="0">
+  <layout class="QVBoxLayout" name="verticalLayout_2">
+   <item>
     <widget class="QGroupBox" name="gbMisc">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
@@ -382,26 +376,26 @@ Fast, but result is a collection of short straight lines.</string>
      </layout>
     </widget>
    </item>
-   <item row="1" column="0">
+   <item>
     <widget class="QLabel" name="label_20">
      <property name="font">
       <font>
-       <pointsize>12</pointsize>
-       <italic>true</italic>
+       <pointsize>10</pointsize>
+       <italic>false</italic>
       </font>
      </property>
      <property name="frameShape">
-      <enum>QFrame::Box</enum>
+      <enum>QFrame::NoFrame</enum>
      </property>
      <property name="text">
-      <string>Items in italics are default values for new objects.  They have no effect on existing objects.</string>
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Note:&lt;/span&gt; Items in &lt;span style=&quot; font-style:italic;&quot;&gt;italics&lt;/span&gt; are default values for new objects. They have no effect on existing objects.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
      <property name="wordWrap">
       <bool>true</bool>
      </property>
     </widget>
    </item>
-   <item row="2" column="0">
+   <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -409,7 +403,7 @@ Fast, but result is a collection of short straight lines.</string>
      <property name="sizeHint" stdset="0">
       <size>
        <width>20</width>
-       <height>40</height>
+       <height>20</height>
       </size>
      </property>
     </spacer>

--- a/src/Mod/TechDraw/Gui/DlgPrefsTechDrawScale.ui
+++ b/src/Mod/TechDraw/Gui/DlgPrefsTechDrawScale.ui
@@ -639,9 +639,6 @@ Each unit is approx. 0.1 mm wide</string>
        <italic>false</italic>
       </font>
      </property>
-     <property name="frameShape">
-      <enum>QFrame::NoFrame</enum>
-     </property>
      <property name="text">
       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Note:&lt;/span&gt; Items in &lt;span style=&quot; font-style:italic;&quot;&gt;italics&lt;/span&gt; are default values for new objects. They have no effect on existing objects.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>

--- a/src/Mod/TechDraw/Gui/DlgPrefsTechDrawScale.ui
+++ b/src/Mod/TechDraw/Gui/DlgPrefsTechDrawScale.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>440</width>
-    <height>532</height>
+    <height>447</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -15,12 +15,6 @@
     <horstretch>0</horstretch>
     <verstretch>0</verstretch>
    </sizepolicy>
-  </property>
-  <property name="minimumSize">
-   <size>
-    <width>0</width>
-    <height>0</height>
-   </size>
   </property>
   <property name="windowTitle">
    <string>Scale</string>
@@ -641,15 +635,15 @@ Each unit is approx. 0.1 mm wide</string>
     <widget class="QLabel" name="label_12">
      <property name="font">
       <font>
-       <pointsize>12</pointsize>
-       <italic>true</italic>
+       <pointsize>10</pointsize>
+       <italic>false</italic>
       </font>
      </property>
      <property name="frameShape">
-      <enum>QFrame::Box</enum>
+      <enum>QFrame::NoFrame</enum>
      </property>
      <property name="text">
-      <string>Items in italics are default values for new objects.  They have no effect on existing objects.</string>
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Note:&lt;/span&gt; Items in &lt;span style=&quot; font-style:italic;&quot;&gt;italics&lt;/span&gt; are default values for new objects. They have no effect on existing objects.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
      <property name="wordWrap">
       <bool>true</bool>
@@ -663,8 +657,8 @@ Each unit is approx. 0.1 mm wide</string>
      </property>
      <property name="sizeHint" stdset="0">
       <size>
-       <width>17</width>
-       <height>48</height>
+       <width>20</width>
+       <height>20</height>
       </size>
      </property>
     </spacer>


### PR DESCRIPTION
as discussed here: https://forum.freecadweb.org/viewtopic.php?f=35&t=47458

This PR gets rid of the frame. The result is:
![FreeCAD_gwnYrP38Gt](https://user-images.githubusercontent.com/1828501/84603380-4be35480-ae8e-11ea-86e8-ea2ac914c943.png)
