### PR TITLE
Draft: Dimension improvements, PEP8, and make_dimension functions

### DIFF
--- a/src/Mod/Draft/CMakeLists.txt
+++ b/src/Mod/Draft/CMakeLists.txt
@@ -109,6 +109,7 @@ SET(Draft_make_functions
     draftmake/make_circulararray.py
     draftmake/make_clone.py
     draftmake/make_copy.py
+    draftmake/make_dimension.py
     draftmake/make_drawingview.py
     draftmake/make_ellipse.py
     draftmake/make_facebinder.py

--- a/src/Mod/Draft/Draft.py
+++ b/src/Mod/Draft/Draft.py
@@ -390,6 +390,8 @@ from draftobjects.dimension import (LinearDimension,
 
 from draftmake.make_dimension import (make_dimension,
                                       makeDimension,
+                                      make_linear_dimension,
+                                      make_linear_dimension_obj,
                                       make_angular_dimension,
                                       makeAngularDimension)
 

--- a/src/Mod/Draft/Draft.py
+++ b/src/Mod/Draft/Draft.py
@@ -392,6 +392,7 @@ from draftmake.make_dimension import (make_dimension,
                                       makeDimension,
                                       make_linear_dimension,
                                       make_linear_dimension_obj,
+                                      make_radial_dimension_obj,
                                       make_angular_dimension,
                                       makeAngularDimension)
 

--- a/src/Mod/Draft/Draft.py
+++ b/src/Mod/Draft/Draft.py
@@ -383,20 +383,21 @@ if FreeCAD.GuiUp:
 # Draft annotation objects
 #---------------------------------------------------------------------------
 
-from draftobjects.dimension import make_dimension, make_angular_dimension
-from draftobjects.dimension import LinearDimension, AngularDimension
+from draftobjects.dimension import (LinearDimension,
+                                    _Dimension,
+                                    AngularDimension,
+                                    _AngularDimension)
 
-makeDimension = make_dimension
-makeAngularDimension = make_angular_dimension
-_Dimension = LinearDimension
-_AngularDimension = AngularDimension
+from draftmake.make_dimension import (make_dimension,
+                                      makeDimension,
+                                      make_angular_dimension,
+                                      makeAngularDimension)
 
-if gui:
+if FreeCAD.GuiUp:
     from draftviewproviders.view_dimension import ViewProviderLinearDimension
     from draftviewproviders.view_dimension import ViewProviderAngularDimension
     _ViewProviderDimension = ViewProviderLinearDimension
     _ViewProviderAngularDimension = ViewProviderAngularDimension
-
 
 from draftobjects.label import (Label,
                                 DraftLabel)

--- a/src/Mod/Draft/draftguitools/gui_dimension_ops.py
+++ b/src/Mod/Draft/draftguitools/gui_dimension_ops.py
@@ -68,7 +68,8 @@ class FlipDimension(gui_base.GuiCommandNeedsSelection):
         super(Draft_FlipDimension, self).Activated()
 
         for o in Gui.Selection.getSelection():
-            if utils.get_type(o) in ("Dimension", "AngularDimension"):
+            if utils.get_type(o) in ("Dimension",
+                                     "LinearDimension", "AngularDimension"):
                 self.doc.openTransaction("Flip dimension")
                 _cmd = "App.activeDocument()." + o.Name + ".Normal"
                 _cmd += " = "

--- a/src/Mod/Draft/draftguitools/gui_dimensions.py
+++ b/src/Mod/Draft/draftguitools/gui_dimensions.py
@@ -305,12 +305,12 @@ class Dimension(gui_base_original.Creator):
 
     def create_radial_dimension_obj(self):
         """Create a radial dimension linked to a circular edge."""
-        _cmd = 'Draft.make_dimension'
+        _cmd = 'Draft.make_radial_dimension_obj'
         _cmd += '('
         _cmd += 'FreeCAD.ActiveDocument.' + self.link[0].Name + ', '
-        _cmd += str(self.link[1]) + ', '
-        _cmd += '"' + str(self.arcmode) + '", '
-        _cmd += DraftVecUtils.toString(self.node[2])
+        _cmd += 'index=' + str(self.link[1] + 1) + ', '
+        _cmd += 'mode="' + str(self.arcmode) + '", '
+        _cmd += 'dim_line=' + DraftVecUtils.toString(self.node[2])
         _cmd += ')'
         _cmd_list = ['_dim_ = ' + _cmd,
                      'Draft.autogroup(_dim_)',

--- a/src/Mod/Draft/draftguitools/gui_dimensions.py
+++ b/src/Mod/Draft/draftguitools/gui_dimensions.py
@@ -46,6 +46,7 @@ import DraftVecUtils
 import draftguitools.gui_base_original as gui_base_original
 import draftguitools.gui_tool_utils as gui_tool_utils
 import draftguitools.gui_trackers as trackers
+
 from draftutils.translate import translate
 from draftutils.messages import _msg
 
@@ -102,11 +103,11 @@ class Dimension(gui_base_original.Creator):
         name = translate("draft", "Dimension")
         if self.cont:
             self.finish()
-        elif self.hasMeasures():
+        elif self.selected_app_measure():
             super(Dimension, self).Activated(name)
             self.dimtrack = trackers.dimTracker()
             self.arctrack = trackers.arcTracker()
-            self.createOnMeasures()
+            self.create_with_app_measure()
             self.finish()
         else:
             super(Dimension, self).Activated(name)
@@ -129,40 +130,52 @@ class Dimension(gui_base_original.Creator):
                 self.force = None
                 self.info = None
                 self.selectmode = False
-                self.setFromSelection()
+                self.set_selection()
                 _msg(translate("draft", "Pick first point"))
                 Gui.draftToolBar.show()
 
-    def setFromSelection(self):
+    def set_selection(self):
         """Fill the nodes according to the selected geometry."""
         sel = Gui.Selection.getSelectionEx()
-        if len(sel) == 1:
-            if len(sel[0].SubElementNames) == 1:
-                if "Edge" in sel[0].SubElementNames[0]:
-                    edge = sel[0].SubObjects[0]
-                    n = int(sel[0].SubElementNames[0].lstrip("Edge")) - 1
-                    self.indices.append(n)
-                    if DraftGeomUtils.geomType(edge) == "Line":
-                        self.node.extend([edge.Vertexes[0].Point,
-                                          edge.Vertexes[1].Point])
-                        v1 = None
-                        v2 = None
-                        for i, v in enumerate(sel[0].Object.Shape.Vertexes):
-                            if v.Point == edge.Vertexes[0].Point:
-                                v1 = i
-                            if v.Point == edge.Vertexes[1].Point:
-                                v2 = i
-                        if (v1 is not None) and (v2 is not None):
-                            self.link = [sel[0].Object, v1, v2]
-                    elif DraftGeomUtils.geomType(edge) == "Circle":
-                        self.node.extend([edge.Curve.Center,
-                                          edge.Vertexes[0].Point])
-                        self.edges = [edge]
-                        self.arcmode = "diameter"
-                        self.link = [sel[0].Object, n]
+        if (len(sel) == 1
+                and len(sel[0].SubElementNames) == 1
+                and "Edge" in sel[0].SubElementNames[0]):
+            # The selection is just a single `Edge`
+            sel_object = sel[0]
+            edge = sel_object.SubObjects[0]
 
-    def hasMeasures(self):
-        """Check if measurement objects are selected."""
+            # `n` is the edge number starting from 0 not from 1.
+            # The reason is lists in Python start from 0, although
+            # in the object's `Shape`, they start from 1
+            n = int(sel_object.SubElementNames[0].lstrip("Edge")) - 1
+            self.indices.append(n)
+
+            if DraftGeomUtils.geomType(edge) == "Line":
+                self.node.extend([edge.Vertexes[0].Point,
+                                  edge.Vertexes[1].Point])
+
+                # Iterate over the vertices of the parent `Object`;
+                # when the vertices match those of the selected `edge`
+                # save the index of vertex in the parent object
+                v1 = None
+                v2 = None
+                for i, v in enumerate(sel_object.Object.Shape.Vertexes):
+                    if v.Point == edge.Vertexes[0].Point:
+                        v1 = i
+                    if v.Point == edge.Vertexes[1].Point:
+                        v2 = i
+
+                if v1 and v2:
+                    self.link = [sel_object.Object, v1, v2]
+            elif DraftGeomUtils.geomType(edge) == "Circle":
+                self.node.extend([edge.Curve.Center,
+                                  edge.Vertexes[0].Point])
+                self.edges = [edge]
+                self.arcmode = "diameter"
+                self.link = [sel_object.Object, n]
+
+    def selected_app_measure(self):
+        """Check if App::MeasureDistance objects are selected."""
         sel = Gui.Selection.getSelection()
         if not sel:
             return False
@@ -180,8 +193,14 @@ class Dimension(gui_base_original.Creator):
             self.dimtrack.finalize()
             self.arctrack.finalize()
 
-    def createOnMeasures(self):
-        """Create on measurement objects."""
+    def create_with_app_measure(self):
+        """Create on measurement objects.
+
+        This is used when the selection is an `'App::MeasureDistance'`,
+        which is created with the basic tool `Std_MeasureDistance`.
+        This object is removed and in its place a `Draft Dimension`
+        is created.
+        """
         for o in Gui.Selection.getSelection():
             p1 = o.P1
             p2 = o.P2
@@ -189,12 +208,13 @@ class Dimension(gui_base_original.Creator):
             _ch = _root.getChildren()[1].getChildren()[0].getChildren()[0]
             pt = _ch.getChildren()[3]
             p3 = App.Vector(pt.point.getValues()[2].getValue())
+
             Gui.addModule("Draft")
-            _cmd = 'Draft.make_dimension'
+            _cmd = 'Draft.make_linear_dimension'
             _cmd += '('
             _cmd += DraftVecUtils.toString(p1) + ', '
             _cmd += DraftVecUtils.toString(p2) + ', '
-            _cmd += DraftVecUtils.toString(p3)
+            _cmd += 'dim_line=' + DraftVecUtils.toString(p3)
             _cmd += ')'
             _rem = 'FreeCAD.ActiveDocument.removeObject("' + o.Name + '")'
             _cmd_list = ['_dim_ = ' + _cmd,
@@ -204,106 +224,121 @@ class Dimension(gui_base_original.Creator):
             self.commit(translate("draft", "Create Dimension"),
                         _cmd_list)
 
+    def create_angle_dimension(self):
+        """Create an angular dimension from a center and two angles."""
+        normal_str = "None"
+        if len(self.edges) == 2:
+            v1 = DraftGeomUtils.vec(self.edges[0])
+            v2 = DraftGeomUtils.vec(self.edges[1])
+            norm = v1.cross(v2)
+            norm.normalize()
+            normal_str = DraftVecUtils.toString(norm)
+
+        ang1 = math.degrees(self.angledata[1])
+        ang2 = math.degrees(self.angledata[0])
+
+        if ang1 > 360:
+            ang1 = ang1 - 360
+        if ang2 > 360:
+            ang2 = ang2 - 360
+
+        _cmd = 'Draft.make_angular_dimension'
+        _cmd += '('
+        _cmd += 'center=' + DraftVecUtils.toString(self.center) + ', '
+        _cmd += 'angles='
+        _cmd += '['
+        _cmd += str(ang1) + ', '
+        _cmd += str(ang2)
+        _cmd += '], '
+        _cmd += 'dim_line=' + DraftVecUtils.toString(self.node[-1]) + ', '
+        _cmd += 'normal=' + normal_str
+        _cmd += ')'
+        _cmd_list = ['_dim_ = ' + _cmd,
+                     'Draft.autogroup(_dim_)',
+                     'FreeCAD.ActiveDocument.recompute()']
+        self.commit(translate("draft", "Create Dimension"),
+                    _cmd_list)
+
+    def create_linear_dimension(self):
+        """Create a simple linear dimension, not linked to an edge."""
+        _cmd = 'Draft.make_linear_dimension'
+        _cmd += '('
+        _cmd += DraftVecUtils.toString(self.node[0]) + ', '
+        _cmd += DraftVecUtils.toString(self.node[1]) + ', '
+        _cmd += 'dim_line=' + DraftVecUtils.toString(self.node[2])
+        _cmd += ')'
+        _cmd_list = ['_dim_ = ' + _cmd,
+                     'Draft.autogroup(_dim_)',
+                     'FreeCAD.ActiveDocument.recompute()']
+        self.commit(translate("draft", "Create Dimension"),
+                    _cmd_list)
+
+    def create_linear_dimension_obj(self, direction=None):
+        """Create a linear dimension linked to an edge.
+
+        The `link` attribute has indices of vertices as they appear
+        in the list `Shape.Vertexes`, so they start as zero 0.
+
+        The `LinearDimension` class, created by `make_linear_dimension_obj`,
+        considers the vertices of a `Shape` which are numbered to start
+        with 1, that is, `Vertex1`.
+        Therefore the value in `link` has to be incremented by 1.
+        """
+        _cmd = 'Draft.make_linear_dimension_obj'
+        _cmd += '('
+        _cmd += 'FreeCAD.ActiveDocument.' + self.link[0].Name + ', '
+        _cmd += 'i1=' + str(self.link[1] + 1) + ', '
+        _cmd += 'i2=' + str(self.link[2] + 1) + ', '
+        _cmd += 'dim_line=' + DraftVecUtils.toString(self.node[2])
+        _cmd += ')'
+        _cmd_list = ['_dim_ = ' + _cmd]
+
+        if direction == "X":
+            _cmd_list += ['_dim_.Direction = FreeCAD.Vector(1, 0, 0)']
+        elif direction == "Y":
+            _cmd_list += ['_dim_.Direction = FreeCAD.Vector(0, 1, 0)']
+
+        _cmd_list += ['Draft.autogroup(_dim_)',
+                      'FreeCAD.ActiveDocument.recompute()']
+        self.commit(translate("draft", "Create Dimension"),
+                    _cmd_list)
+
+    def create_radial_dimension_obj(self):
+        """Create a radial dimension linked to a circular edge."""
+        _cmd = 'Draft.make_dimension'
+        _cmd += '('
+        _cmd += 'FreeCAD.ActiveDocument.' + self.link[0].Name + ', '
+        _cmd += str(self.link[1]) + ', '
+        _cmd += '"' + str(self.arcmode) + '", '
+        _cmd += DraftVecUtils.toString(self.node[2])
+        _cmd += ')'
+        _cmd_list = ['_dim_ = ' + _cmd,
+                     'Draft.autogroup(_dim_)',
+                     'FreeCAD.ActiveDocument.recompute()']
+        self.commit(translate("draft", "Create Dimension (radial)"),
+                    _cmd_list)
+
     def createObject(self):
         """Create the actual object in the current document."""
         Gui.addModule("Draft")
 
         if self.angledata:
-            normal = "None"
-            if len(self.edges) == 2:
-                v1 = DraftGeomUtils.vec(self.edges[0])
-                v2 = DraftGeomUtils.vec(self.edges[1])
-                normal = DraftVecUtils.toString((v1.cross(v2)).normalize())
-
-            _cmd = 'Draft.make_angular_dimension'
-            _cmd += '('
-            _cmd += 'center=' + DraftVecUtils.toString(self.center) + ', '
-            _cmd += 'angles='
-            _cmd += '['
-            _cmd += str(math.degrees(self.angledata[1])) + ', '
-            _cmd += str(math.degrees(self.angledata[0]))
-            _cmd += '], '
-            _cmd += 'dim_line=' + DraftVecUtils.toString(self.node[-1]) + ', '
-            _cmd += 'normal=' + normal
-            _cmd += ')'
-            _cmd_list = ['_dim_ = ' + _cmd,
-                         'Draft.autogroup(_dim_)',
-                         'FreeCAD.ActiveDocument.recompute()']
-            self.commit(translate("draft", "Create Dimension"),
-                        _cmd_list)
-
+            # Angle dimension, with two angles provided
+            self.create_angle_dimension()
         elif self.link and not self.arcmode:
-            # Linear dimension, linked
+            # Linear dimension, linked to a straight edge
             if self.force == 1:
-                _cmd = 'Draft.make_dimension'
-                _cmd += '('
-                _cmd += 'FreeCAD.ActiveDocument.' + self.link[0].Name + ', '
-                _cmd += str(self.link[1]) + ', '
-                _cmd += str(self.link[2]) + ', '
-                _cmd += DraftVecUtils.toString(self.node[2])
-                _cmd += ')'
-                _cmd_list = ['_dim_ = ' + _cmd,
-                             '_dim_.Direction = FreeCAD.Vector(0, 1, 0)',
-                             'Draft.autogroup(_dim_)',
-                             'FreeCAD.ActiveDocument.recompute()']
-                self.commit(translate("draft", "Create Dimension"),
-                            _cmd_list)
+                self.create_linear_dimension_obj("Y")
             elif self.force == 2:
-                _cmd = 'Draft.make_dimension'
-                _cmd += '('
-                _cmd += 'FreeCAD.ActiveDocument.' + self.link[0].Name + ', '
-                _cmd += str(self.link[1]) + ', '
-                _cmd += str(self.link[2]) + ', '
-                _cmd += DraftVecUtils.toString(self.node[2])
-                _cmd += ')'
-                _cmd_list = ['_dim_ = ' + _cmd,
-                             '_dim_.Direction = FreeCAD.Vector(1, 0, 0)',
-                             'Draft.autogroup(_dim_)',
-                             'FreeCAD.ActiveDocument.recompute()']
-                self.commit(translate("draft", "Create Dimension"),
-                            _cmd_list)
+                self.create_linear_dimension_obj("X")
             else:
-                _cmd = 'Draft.make_dimension'
-                _cmd += '('
-                _cmd += 'FreeCAD.ActiveDocument.' + self.link[0].Name + ', '
-                _cmd += str(self.link[1]) + ', '
-                _cmd += str(self.link[2]) + ', '
-                _cmd += DraftVecUtils.toString(self.node[2])
-                _cmd += ')'
-                _cmd_list = ['_dim_ = ' + _cmd,
-                             'Draft.autogroup(_dim_)',
-                             'FreeCAD.ActiveDocument.recompute()']
-                self.commit(translate("draft", "Create Dimension"),
-                            _cmd_list)
-
+                self.create_linear_dimension_obj()
         elif self.arcmode:
-            # Radius or dimeter dimension, linked
-            _cmd = 'Draft.make_dimension'
-            _cmd += '('
-            _cmd += 'FreeCAD.ActiveDocument.' + self.link[0].Name + ', '
-            _cmd += str(self.link[1]) + ', '
-            _cmd += '"' + str(self.arcmode) + '", '
-            _cmd += DraftVecUtils.toString(self.node[2])
-            _cmd += ')'
-            _cmd_list = ['_dim_ = ' + _cmd,
-                         'Draft.autogroup(_dim_)',
-                         'FreeCAD.ActiveDocument.recompute()']
-            self.commit(translate("draft", "Create Dimension"),
-                        _cmd_list)
-
+            # Radius or dimeter dimension, linked to a circular edge
+            self.create_radial_dimension_obj()
         else:
-            # Linear dimension, non-linked
-            _cmd = 'Draft.make_dimension'
-            _cmd += '('
-            _cmd += DraftVecUtils.toString(self.node[0]) + ', '
-            _cmd += DraftVecUtils.toString(self.node[1]) + ', '
-            _cmd += DraftVecUtils.toString(self.node[2])
-            _cmd += ')'
-            _cmd_list = ['_dim_ = ' + _cmd,
-                         'Draft.autogroup(_dim_)',
-                         'FreeCAD.ActiveDocument.recompute()']
-            self.commit(translate("draft", "Create Dimension"),
-                        _cmd_list)
+            # Linear dimension, not linked to any edge
+            self.create_linear_dimension()
 
         if self.ui.continueMode:
             self.cont = self.node[2]
@@ -314,12 +349,14 @@ class Dimension(gui_base_original.Creator):
                     self.dir = v2.sub(v1)
                 else:
                     self.dir = self.node[1].sub(self.node[0])
+
             self.node = [self.node[1]]
+
         self.link = None
 
     def selectEdge(self):
         """Toggle the select mode to the opposite state."""
-        self.selectmode = not(self.selectmode)
+        self.selectmode = not self.selectmode
 
     def action(self, arg):
         """Handle the 3D scene events.

--- a/src/Mod/Draft/draftmake/make_dimension.py
+++ b/src/Mod/Draft/draftmake/make_dimension.py
@@ -1,0 +1,311 @@
+# -*- coding: utf-8 -*-
+# ***************************************************************************
+# *   Copyright (c) 2009, 2010 Yorik van Havre <yorik@uncreated.net>        *
+# *   Copyright (c) 2009, 2010 Ken Cline <cline@frii.com>                   *
+# *   Copyright (c) 2020 Eliud Cabrera Castillo <e.cabrera-castillo@tum.de> *
+# *                                                                         *
+# *   This file is part of the FreeCAD CAx development system.              *
+# *                                                                         *
+# *   This program is free software; you can redistribute it and/or modify  *
+# *   it under the terms of the GNU Lesser General Public License (LGPL)    *
+# *   as published by the Free Software Foundation; either version 2 of     *
+# *   the License, or (at your option) any later version.                   *
+# *   for detail see the LICENCE text file.                                 *
+# *                                                                         *
+# *   FreeCAD is distributed in the hope that it will be useful,            *
+# *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+# *   GNU Library General Public License for more details.                  *
+# *                                                                         *
+# *   You should have received a copy of the GNU Library General Public     *
+# *   License along with FreeCAD; if not, write to the Free Software        *
+# *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
+# *   USA                                                                   *
+# *                                                                         *
+# ***************************************************************************
+"""Provides functions to crate dimension objects."""
+## @package make_dimension
+# \ingroup DRAFT
+# \brief Provides functions to crate dimension objects.
+
+import math
+
+import FreeCAD as App
+import draftutils.utils as utils
+import draftutils.gui_utils as gui_utils
+
+from draftutils.messages import _msg, _wrn, _err
+from draftutils.translate import _tr
+from draftobjects.dimension import (LinearDimension,
+                                    AngularDimension)
+
+if App.GuiUp:
+    from draftviewproviders.view_dimension import ViewProviderLinearDimension
+    from draftviewproviders.view_dimension import ViewProviderAngularDimension
+
+
+def make_dimension(p1, p2, p3=None, p4=None):
+    """Create one of three types of dimension objects.
+
+    In all dimensions the p3 parameter defines a point through which
+    the dimension line will go through.
+
+    The current line width and color will be used.
+
+    Linear dimension
+    ----------------
+    - (p1, p2, p3): a simple linear dimension from p1 to p2
+
+    - (object, i1, i2, p3): creates a linked dimension to the provided
+      object (edge), measuring the distance between its vertices
+      indexed i1 and i2
+
+    Circular dimension
+    ------------------
+    - (arc, i1, mode, p3): creates a linked dimension to the given arc
+      object, i1 is the index of the arc edge that will be measured;
+      mode is either "radius" or "diameter".
+    """
+    if not App.ActiveDocument:
+        _err("No active document. Aborting")
+        return None
+
+    new_obj = App.ActiveDocument.addObject("App::FeaturePython",
+                                           "Dimension")
+    LinearDimension(new_obj)
+
+    if App.GuiUp:
+        ViewProviderLinearDimension(new_obj.ViewObject)
+
+    if isinstance(p1, App.Vector) and isinstance(p2, App.Vector):
+        # Measure a straight distance between p1 and p2
+        new_obj.Start = p1
+        new_obj.End = p2
+        if not p3:
+            p3 = p2.sub(p1)
+            p3.multiply(0.5)
+            p3 = p1.add(p3)
+
+    elif isinstance(p2, int) and isinstance(p3, int):
+        # p1 is an object, and measure the distance between vertices p2 and p3
+        # of this object
+        linked = []
+        idx = (p2, p3)
+        linked.append((p1, "Vertex" + str(p2 + 1)))
+        linked.append((p1, "Vertex" + str(p3 + 1)))
+        new_obj.LinkedGeometry = linked
+        new_obj.Support = p1
+
+        # p4, and now p3, is the point through which the dimension line
+        # will go through
+        p3 = p4
+        if not p3:
+            # When used from the GUI command, this will never run
+            # because p4 will always be assinged to a vector,
+            # so p3 will never be `None`.
+            # Moreover, `new_obj.Base` doesn't exist, and certainly `Shape`
+            # doesn't exist, so if this ever runs it will be an error.
+            v1 = new_obj.Base.Shape.Vertexes[idx[0]].Point
+            v2 = new_obj.Base.Shape.Vertexes[idx[1]].Point
+            p3 = v2.sub(v1)
+            p3.multiply(0.5)
+            p3 = v1.add(p3)
+
+    elif isinstance(p3, str):
+        # If the original p3 is a string, we are measuring a circular arc
+        # p2 should be an integer number starting from 0
+        linked = []
+        linked.append((p1, "Edge" + str(p2 + 1)))
+
+        if p3 == "radius":
+            # linked.append((p1, "Center"))
+            if App.GuiUp:
+                new_obj.ViewObject.Override = "R $dim"
+            new_obj.Diameter = False
+        elif p3 == "diameter":
+            # linked.append((p1, "Diameter"))
+            if App.GuiUp:
+                new_obj.ViewObject.Override = "Ø $dim"
+            new_obj.Diameter = True
+        new_obj.LinkedGeometry = linked
+        new_obj.Support = p1
+
+        # p4, and now p3, is the point through which the dimension line
+        # will go through
+        p3 = p4
+        if not p3:
+            p3 = p1.Shape.Edges[p2].Curve.Center.add(App.Vector(1, 0, 0))
+
+    # This p3 is the point through which the dimension line will pass,
+    # but this may not be the original p3, it could have been p4
+    # depending on the first three parameter values
+    new_obj.Dimline = p3
+
+    if hasattr(App, "DraftWorkingPlane"):
+        normal = App.DraftWorkingPlane.axis
+    else:
+        normal = App.Vector(0, 0, 1)
+
+    if App.GuiUp:
+        # invert the normal if we are viewing it from the back
+        vnorm = gui_utils.get3DView().getViewDirection()
+
+        if vnorm.getAngle(normal) < math.pi/2:
+            normal = normal.negative()
+
+    new_obj.Normal = normal
+
+    if App.GuiUp:
+        gui_utils.format_object(new_obj)
+        gui_utils.select(new_obj)
+
+    return new_obj
+
+
+def makeDimension(p1, p2, p3=None, p4=None):
+    """Create a dimension. DEPRECATED. Use 'make_dimension'."""
+    _wrn(_tr("This function is deprecated. "
+             "Do not use this function directly."))
+    _wrn(_tr("Use one of 'make_linear_dimension', or "
+             "'make_linear_dimension_obj'."))
+
+    return make_dimension(p1, p2, p3, p4)
+
+
+def make_angular_dimension(center=App.Vector(0, 0, 0),
+                           angles=[0, 90],
+                           dim_line=App.Vector(3, 3, 0), normal=None):
+    """Create an angular dimension from the given center and angles.
+
+    Parameters
+    ----------
+    center: Base::Vector3, optional
+        It defaults to the origin `Vector(0, 0, 0)`.
+        Center of the dimension line, which is a circular arc.
+
+    angles: list of two floats, optional
+        It defaults to `[0, 90]`.
+        It is a list of two angles, given in degrees, that determine
+        the apperture of the dimension line, that is, of the circular arc.
+        It is drawn counter-clockwise.
+        ::
+            angles = [0 90]
+            angles = [330 60]  # the arc crosses the X axis
+            angles = [-30 60]  # same angle
+
+    dim_line: Base::Vector3, optional
+        It defaults to `Vector(3, 3, 0)`.
+        Point through which the dimension line will pass.
+        This defines the radius of the dimension line, the circular arc.
+
+    normal: Base::Vector3, optional
+        It defaults to `None`, in which case the `normal` is taken
+        from the currently active `App.DraftWorkingPlane.axis`.
+
+        If the working plane is not available, then the `normal`
+        defaults to +Z or `Vector(0, 0, 1)`.
+
+    Returns
+    -------
+    App::FeaturePython
+        A scripted object of type `'AngularDimension'`.
+        This object does not have a `Shape` attribute, as the text and lines
+        are created on screen by Coin (pivy).
+
+    None
+        If there is a problem it will return `None`.
+    """
+    _name = "make_angular_dimension"
+    utils.print_header(_name, "Angular dimension")
+
+    found, doc = utils.find_doc(App.activeDocument())
+    if not found:
+        _err(_tr("No active document. Aborting."))
+        return None
+
+    _msg("center: {}".format(center))
+    try:
+        utils.type_check([(center, App.Vector)], name=_name)
+    except TypeError:
+        _err(_tr("Wrong input: must be a vector."))
+        return None
+
+    _msg("angles: {}".format(angles))
+    try:
+        utils.type_check([(angles, (tuple, list))], name=_name)
+
+        if len(angles) != 2:
+            _err(_tr("Wrong input: must be a list with two angles."))
+            return None
+
+        ang1, ang2 = angles
+        utils.type_check([(ang1, (int, float)),
+                          (ang2, (int, float))], name=_name)
+    except TypeError:
+        _err(_tr("Wrong input: must be a list with two angles."))
+        return None
+
+    # If the angle is larger than 360 degrees, make sure
+    # it is smaller than 360
+    for n in range(len(angles)):
+        if angles[n] > 360:
+            angles[n] = angles[n] - 360
+
+    _msg("dim_line: {}".format(dim_line))
+    try:
+        utils.type_check([(dim_line, App.Vector)], name=_name)
+    except TypeError:
+        _err(_tr("Wrong input: must be a vector."))
+        return None
+
+    _msg("normal: {}".format(normal))
+    if normal:
+        try:
+            utils.type_check([(dim_line, App.Vector)], name=_name)
+        except TypeError:
+            _err(_tr("Wrong input: must be a vector."))
+            return None
+
+    if not normal:
+        if hasattr(App, "DraftWorkingPlane"):
+            normal = App.DraftWorkingPlane.axis
+        else:
+            normal = App.Vector(0, 0, 1)
+
+    new_obj = App.ActiveDocument.addObject("App::FeaturePython",
+                                           "Dimension")
+    AngularDimension(new_obj)
+
+    new_obj.Center = center
+    new_obj.FirstAngle = angles[0]
+    new_obj.LastAngle = angles[1]
+    new_obj.Dimline = dim_line
+
+    if App.GuiUp:
+        ViewProviderAngularDimension(new_obj.ViewObject)
+
+        # Invert the normal if we are viewing it from the back.
+        # This is determined by the angle between the current
+        # 3D view and the provided normal being below 90 degrees
+        vnorm = gui_utils.get3DView().getViewDirection()
+        if vnorm.getAngle(normal) < math.pi/2:
+            normal = normal.negative()
+
+    new_obj.Normal = normal
+
+    if App.GuiUp:
+        gui_utils.format_object(new_obj)
+        gui_utils.select(new_obj)
+
+    return new_obj
+
+
+def makeAngularDimension(center, angles, p3, normal=None):
+    """Create an angle dimension. DEPRECATED. Use 'make_angular_dimension'."""
+    utils.use_instead("make_angular_dimension")
+
+    ang1, ang2 = angles
+    angles = [math.degrees(ang2), math.degrees(ang1)]
+
+    return make_angular_dimension(center=center, angles=angles,
+                                  dim_line=p3, normal=normal)

--- a/src/Mod/Draft/draftobjects/dimension.py
+++ b/src/Mod/Draft/draftobjects/dimension.py
@@ -22,10 +22,17 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""This module provides the object code for Draft Dimension."""
+"""Provides the object code for the Draft Dimensions.
+
+This includes the `LinearDimension` and `AgularDimension`.
+The first one measures a distance between two points or vertices
+in an object; it includes radial dimensions of circular arcs.
+The second one creates an arc between two straight lines to measure
+the angle between both.
+"""
 ## @package dimension
 # \ingroup DRAFT
-# \brief This module provides the object code for Draft Dimension.
+# \brief Provides the object code for the Draft Dimensions.
 
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
@@ -49,25 +56,81 @@ class DimensionBase(DraftAnnotation):
 
     def __init__(self, obj, tp="Dimension"):
         super(DimensionBase, self).__init__(obj, tp)
+        self.set_properties(obj)
+        obj.Proxy = self
 
-        # Draft
-        _tip = QT_TRANSLATE_NOOP("App::Property", "The normal direction of this dimension")
-        obj.addProperty("App::PropertyVector", "Normal", "Draft", _tip)
+    def set_properties(self, obj):
+        """Set basic properties only if they don't exist."""
+        properties = obj.PropertiesList
 
-        _tip = QT_TRANSLATE_NOOP("App::Property", "The object measured by this dimension")
-        obj.addProperty("App::PropertyLink", "Support", "Draft",_tip)
+        if "Normal" not in properties:
+            _tip = QT_TRANSLATE_NOOP("App::Property",
+                                     "The normal direction of the text "
+                                     "of the dimension")
+            obj.addProperty("App::PropertyVector",
+                            "Normal",
+                            "Dimension",
+                            _tip)
+            obj.Normal = App.Vector(0, 0, 1)
 
-        _tip = QT_TRANSLATE_NOOP("App::Property", "The geometry this dimension is linked to")
-        obj.addProperty("App::PropertyLinkSubList", "LinkedGeometry", "Draft", _tip)
-                                          
-        _tip = QT_TRANSLATE_NOOP("App::Property",
-                "Point on which the dimension\nline is placed.")
-        obj.addProperty("App::PropertyVectorDistance", "Dimline", "Draft", _tip)
-                                          
-        obj.Dimline = App.Vector(0,1,0)
-        obj.Normal = App.Vector(0,0,1)
+        # TODO: remove Support property as it is not used at all.
+        # It is just set at creation time by the make_dimension function
+        # but it is not used.
+        if "Support" not in properties:
+            _tip = QT_TRANSLATE_NOOP("App::Property",
+                                     "The object measured by this dimension "
+                                     "object")
+            obj.addProperty("App::PropertyLink",
+                            "Support",
+                            "Dimension",
+                            _tip)
+            obj.Support = None
+
+        if "LinkedGeometry" not in properties:
+            _tip = QT_TRANSLATE_NOOP("App::Property",
+                                     "The object, and specific subelements "
+                                     "of it,\n"
+                                     "that this dimension object "
+                                     "is measuring.\n"
+                                     "\n"
+                                     "There are various possibilities:\n"
+                                     "- An object, and one of its edges.\n"
+                                     "- An object, and two of its vertices.\n"
+                                     "- An arc object, and its edge.\n")
+            obj.addProperty("App::PropertyLinkSubList",
+                            "LinkedGeometry",
+                            "Dimension",
+                            _tip)
+            obj.LinkedGeometry = []
+
+        if "Dimline" not in properties:
+            _tip = QT_TRANSLATE_NOOP("App::Property",
+                                     "A point through which the dimension "
+                                     "line, or an extrapolation of it, "
+                                     "will pass.\n"
+                                     "\n"
+                                     "- For linear dimensions, this property "
+                                     "controls how close the dimension line\n"
+                                     "is to the measured object.\n"
+                                     "- For radial dimensions, this controls "
+                                     "the direction of the dimension line\n"
+                                     "that displays the measured radius or "
+                                     "diameter.\n"
+                                     "- For angular dimensions, "
+                                     "this controls the radius of the "
+                                     "dimension arc\n"
+                                     "that displays the measured angle.")
+            obj.addProperty("App::PropertyVectorDistance",
+                            "Dimline",
+                            "Dimension",
+                            _tip)
+            obj.Dimline = App.Vector(0, 1, 0)
 
     def onDocumentRestored(self, obj):
+        """Execute code when the document is restored.
+
+        It calls the parent class to add missing annotation properties.
+        """
         super(DimensionBase, self).onDocumentRestored(obj)
 
 
@@ -76,60 +139,123 @@ class LinearDimension(DimensionBase):
 
     This inherits `DimensionBase` to provide the basic functionality of
     a dimension.
+
+    This linear dimension includes measurements between two vertices,
+    but also a radial dimension of a circular edge or arc.
     """
 
     def __init__(self, obj):
-
         super(LinearDimension, self).__init__(obj, "LinearDimension")
-
+        super(LinearDimension, self).set_properties(obj)
+        self.set_properties(obj)
         obj.Proxy = self
 
-        self.init_properties(obj)
+    def set_properties(self, obj):
+        """Set basic properties only if they don't exist."""
+        properties = obj.PropertiesList
 
+        if "Start" not in properties:
+            _tip = QT_TRANSLATE_NOOP("App::Property",
+                                     "Starting point of the dimension line.\n"
+                                     "\n"
+                                     "If it is a radius dimension it will be "
+                                     "the center of the arc.\n"
+                                     "If it is a diameter dimension "
+                                     "it will be a point that lies "
+                                     "on the arc.")
+            obj.addProperty("App::PropertyVectorDistance",
+                            "Start",
+                            "Linear/radial dimension",
+                            _tip)
+            obj.Start = App.Vector(0, 0, 0)
 
-    def init_properties(self, obj):
-        """Add Linear Dimension specific properties to the object and set them"""
+        if "End" not in properties:
+            _tip = QT_TRANSLATE_NOOP("App::Property",
+                                     "Ending point of the dimension line.\n"
+                                     "\n"
+                                     "If it is a radius or diameter "
+                                     "dimension\n"
+                                     "it will be a point that lies "
+                                     "on the arc.")
+            obj.addProperty("App::PropertyVectorDistance",
+                            "End",
+                            "Linear/radial dimension",
+                            _tip)
+            obj.End = App.Vector(1, 0, 0)
 
-        # Draft
-        _tip = QT_TRANSLATE_NOOP("App::Property", "Startpoint of dimension")
-        obj.addProperty("App::PropertyVectorDistance", "Start", "Draft", _tip)
+        if "Direction" not in properties:
+            _tip = QT_TRANSLATE_NOOP("App::Property",
+                                     "The direction of the dimension line.\n"
+                                     "If this remains '(0,0,0)', "
+                                     "the direction will be calculated "
+                                     "automatically.")
+            obj.addProperty("App::PropertyVector",
+                            "Direction",
+                            "Linear/radial dimension",
+                            _tip)
 
-        _tip = QT_TRANSLATE_NOOP("App::Property", "Endpoint of dimension")
-        obj.addProperty("App::PropertyVectorDistance", "End", "Draft", _tip)
+        if "Distance" not in properties:
+            _tip = QT_TRANSLATE_NOOP("App::Property",
+                                     "The value of the measurement.\n"
+                                     "\n"
+                                     "This property is read-only because "
+                                     "the value is calculated\n"
+                                     "from the 'Start' and 'End' properties.\n"
+                                     "\n"
+                                     "If the 'Linked Geometry' "
+                                     "is an arc or circle, this 'Distance'\n"
+                                     "is the radius or diameter, depending "
+                                     "on the 'Diameter' property.")
+            obj.addProperty("App::PropertyLength",
+                            "Distance",
+                            "Linear/radial dimension",
+                            _tip)
+            obj.Distance = 0
 
-        _tip = QT_TRANSLATE_NOOP("App::Property", "The normal direction of this dimension")
-        obj.addProperty("App::PropertyVector", "Direction", "Draft", _tip)
-
-        _tip = QT_TRANSLATE_NOOP("App::Property", "The measurement of this dimension")
-        obj.addProperty("App::PropertyLength", "Distance", "Draft", _tip)
-
-        _tip = QT_TRANSLATE_NOOP("App::Property", "For arc/circle measurements, false = radius, true = diameter")
-        obj.addProperty("App::PropertyBool", "Diameter", "Draft", _tip)
-
-        obj.Start = App.Vector(0,0,0)
-        obj.End = App.Vector(1,0,0)
+        if "Diameter" not in properties:
+            _tip = QT_TRANSLATE_NOOP("App::Property",
+                                     "When measuring circular arcs, "
+                                     "it determines whether to display\n"
+                                     "the radius or the diameter value")
+            obj.addProperty("App::PropertyBool",
+                            "Diameter",
+                            "Radial dimension",
+                            _tip)
+            obj.Diameter = False
 
     def onDocumentRestored(self, obj):
+        """Execute code when the document is restored.
+
+        It calls the parent class to add missing dimension properties.
+        """
         super(LinearDimension, self).onDocumentRestored(obj)
 
-    def onChanged(self,obj,prop):
-        '''Do something when a property has changed'''
+    def onChanged(self, obj, prop):
+        """Execute when a property is changed.
+
+        It just sets some properties to be read-only or hidden,
+        as they aren't used.
+        """
         if hasattr(obj, "Distance"):
-            obj.setEditorMode('Distance', 1)
-        #if hasattr(obj,"Normal"):
-        #    obj.setEditorMode('Normal', 2)
+            obj.setPropertyStatus('Distance', 'ReadOnly')
+
+        # if hasattr(obj, "Normal"):
+        #    obj.setPropertyStatus('Normal', 'Hidden')
         if hasattr(obj, "Support"):
-            obj.setEditorMode('Support', 2)
+            obj.setPropertyStatus('Support', 'Hidden')
 
     def execute(self, obj):
-        """ Set start point and end point according to the linked geometry"""
+        """Execute when the object is created or recomputed.
+
+        Set start point and end point according to the linked geometry.
+        """
         if obj.LinkedGeometry:
             if len(obj.LinkedGeometry) == 1:
                 lobj = obj.LinkedGeometry[0][0]
                 lsub = obj.LinkedGeometry[0][1]
                 if len(lsub) == 1:
                     if "Edge" in lsub[0]:
-                        n = int(lsub[0][4:])-1
+                        n = int(lsub[0][4:]) - 1
                         edge = lobj.Shape.Edges[n]
                         if DraftGeomUtils.geomType(edge) == "Line":
                             obj.Start = edge.Vertexes[0].Point
@@ -138,13 +264,13 @@ class LinearDimension(DimensionBase):
                             c = edge.Curve.Center
                             r = edge.Curve.Radius
                             a = edge.Curve.Axis
-                            ray = obj.Dimline.sub(c).projectToPlane(App.Vector(0,0,0),a)
-                            if (ray.Length == 0):
-                                ray = a.cross(App.Vector(1,0,0))
-                                if (ray.Length == 0):
-                                    ray = a.cross(App.Vector(0,1,0))
-                            ray = DraftVecUtils.scaleTo(ray,r)
-                            if hasattr(obj,"Diameter"):
+                            ray = obj.Dimline.sub(c).projectToPlane(App.Vector(0, 0, 0), a)
+                            if ray.Length == 0:
+                                ray = a.cross(App.Vector(1, 0, 0))
+                                if ray.Length == 0:
+                                    ray = a.cross(App.Vector(0, 1, 0))
+                            ray = DraftVecUtils.scaleTo(ray, r)
+                            if hasattr(obj, "Diameter"):
                                 if obj.Diameter:
                                     obj.Start = c.add(ray.negative())
                                     obj.End = c.add(ray)
@@ -153,8 +279,8 @@ class LinearDimension(DimensionBase):
                                     obj.End = c.add(ray)
                 elif len(lsub) == 2:
                     if ("Vertex" in lsub[0]) and ("Vertex" in lsub[1]):
-                        n1 = int(lsub[0][6:])-1
-                        n2 = int(lsub[1][6:])-1
+                        n1 = int(lsub[0][6:]) - 1
+                        n2 = int(lsub[1][6:]) - 1
                         obj.Start = lobj.Shape.Vertexes[n1].Point
                         obj.End = lobj.Shape.Vertexes[n2].Point
             elif len(obj.LinkedGeometry) == 2:
@@ -164,17 +290,20 @@ class LinearDimension(DimensionBase):
                 lsub2 = obj.LinkedGeometry[1][1]
                 if (len(lsub1) == 1) and (len(lsub2) == 1):
                     if ("Vertex" in lsub1[0]) and ("Vertex" in lsub2[1]):
-                        n1 = int(lsub1[0][6:])-1
-                        n2 = int(lsub2[0][6:])-1
+                        n1 = int(lsub1[0][6:]) - 1
+                        n2 = int(lsub2[0][6:]) - 1
                         obj.Start = lobj1.Shape.Vertexes[n1].Point
                         obj.End = lobj2.Shape.Vertexes[n2].Point
+
         # set the distance property
         total_len = (obj.Start.sub(obj.End)).Length
         if round(obj.Distance.Value, utils.precision()) != round(total_len, utils.precision()):
             obj.Distance = total_len
-        if App.GuiUp:
-            if obj.ViewObject:
-                obj.ViewObject.update()
+
+        # The lines and text are created in the viewprovider, so we should
+        # update it whenever the object is recomputed
+        if App.GuiUp and obj.ViewObject:
+            obj.ViewObject.update()
 
 
 # Alias for compatibility with v0.18 and earlier
@@ -190,47 +319,100 @@ class AngularDimension(DimensionBase):
 
     def __init__(self, obj):
         super(AngularDimension, self).__init__(obj, "AngularDimension")
-        self.init_properties(obj)
+        super(AngularDimension, self).set_properties(obj)
+        self.set_properties(obj)
         obj.Proxy = self
 
-    def init_properties(self, obj):
-        """Add Angular Dimension specific properties to the object and set them"""
+        # Inherited properties from the parent class
+        obj.Normal = App.Vector(0, 0, 1)
+        obj.Dimline = App.Vector(0, 1, 0)
 
-        _tip = QT_TRANSLATE_NOOP("App::Property","Start angle of the dimension")
-        obj.addProperty("App::PropertyAngle", "FirstAngle", "Draft", )
+    def set_properties(self, obj):
+        """Set basic properties only if they don't exist."""
+        properties = obj.PropertiesList
 
-        _tip = QT_TRANSLATE_NOOP("App::Property","End angle of the dimension")
-        obj.addProperty("App::PropertyAngle", "LastAngle", "Draft", _tip)
+        if "FirstAngle" not in properties:
+            _tip = QT_TRANSLATE_NOOP("App::Property",
+                                     "Starting angle of the dimension line "
+                                     "(circular arc).\n"
+                                     "The arc is drawn counter-clockwise.")
+            obj.addProperty("App::PropertyAngle",
+                            "FirstAngle",
+                            "Angular dimension",
+                            _tip)
+            obj.FirstAngle = 0
 
-        _tip = QT_TRANSLATE_NOOP("App::Property", "The center point of this dimension")
-        obj.addProperty("App::PropertyVectorDistance", "Center", "Draft", _tip)
+        if "LastAngle" not in properties:
+            _tip = QT_TRANSLATE_NOOP("App::Property",
+                                     "Ending angle of the dimension line "
+                                     "(circular arc).\n"
+                                     "The arc is drawn counter-clockwise.")
+            obj.addProperty("App::PropertyAngle",
+                            "LastAngle",
+                            "Angular dimension",
+                            _tip)
+            obj.LastAngle = 90
 
-        _tip = QT_TRANSLATE_NOOP("App::Property", "The measurement of this dimension")
-        obj.addProperty("App::PropertyAngle", "Angle", "Draft", _tip)
+        if "Center" not in properties:
+            _tip = QT_TRANSLATE_NOOP("App::Property",
+                                     "The center point of the dimension "
+                                     "line, which is a circular arc.\n"
+                                     "\n"
+                                     "This is normally the point where two "
+                                     "line segments, or their extensions\n"
+                                     "intersect, resulting in the "
+                                     "measured 'Angle' between them.")
+            obj.addProperty("App::PropertyVectorDistance",
+                            "Center",
+                            "Angular dimension",
+                            _tip)
+            obj.Center = App.Vector(0, 0, 0)
 
-        obj.FirstAngle = 0
-        obj.LastAngle = 90
-        obj.Dimline = App.Vector(0,1,0)
-        obj.Center = App.Vector(0,0,0)
-        obj.Normal = App.Vector(0,0,1)
+        if "Angle" not in properties:
+            _tip = QT_TRANSLATE_NOOP("App::Property",
+                                     "The value of the measurement.\n"
+                                     "\n"
+                                     "This property is read-only because "
+                                     "the value is calculated from\n"
+                                     "the 'First Angle' and "
+                                     "'Last Angle' properties.")
+            obj.addProperty("App::PropertyAngle",
+                            "Angle",
+                            "Angular dimension",
+                            _tip)
+            obj.Angle = 0
 
     def onDocumentRestored(self, obj):
+        """Execute code when the document is restored.
+
+        It calls the parent class to add missing dimension properties.
+        """
         super(AngularDimension, self).onDocumentRestored(obj)
 
-    def execute(self, fp):
-        '''Do something when recompute object'''
-        if fp.ViewObject:
-            fp.ViewObject.update()
+    def execute(self, obj):
+        """Execute when the object is created or recomputed.
 
-    def onChanged(self,obj,prop):
-        '''Do something when a property has changed'''
-        super(AngularDimension, self).onChanged(obj, prop)
-        if hasattr(obj,"Angle"):
-            obj.setEditorMode('Angle',1)
-        if hasattr(obj,"Normal"):
-            obj.setEditorMode('Normal',2)
-        if hasattr(obj,"Support"):
-            obj.setEditorMode('Support',2)
+        Nothing is actually done here, except update the viewprovider,
+        as the lines and text are created in the viewprovider.
+        """
+        if App.GuiUp and obj.ViewObject:
+            obj.ViewObject.update()
+
+    def onChanged(self, obj, prop):
+        """Execute when a property is changed.
+
+        It just sets some properties to be read-only or hidden,
+        as they aren't used.
+        """
+        if hasattr(obj, "Angle"):
+            obj.setPropertyStatus('Angle', 'ReadOnly')
+
+        if hasattr(obj, "Normal"):
+            obj.setPropertyStatus('Normal', 'Hidden')
+        if hasattr(obj, "Support"):
+            obj.setPropertyStatus('Support', 'Hidden')
+        if hasattr(obj, "LinkedGeometry"):
+            obj.setPropertyStatus('LinkedGeometry', 'Hidden')
 
 
 # Alias for compatibility with v0.18 and earlier

--- a/src/Mod/Draft/draftobjects/dimension.py
+++ b/src/Mod/Draft/draftobjects/dimension.py
@@ -22,152 +22,32 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""This module provides the object code for Draft Dimension.
-"""
+"""This module provides the object code for Draft Dimension."""
 ## @package dimension
 # \ingroup DRAFT
 # \brief This module provides the object code for Draft Dimension.
 
-import FreeCAD as App
-import math
 from PySide.QtCore import QT_TRANSLATE_NOOP
-import DraftGeomUtils, DraftVecUtils
-import draftutils.gui_utils as gui_utils
+
+import FreeCAD as App
+import DraftVecUtils
+import DraftGeomUtils
 import draftutils.utils as utils
+
 from draftobjects.draft_annotation import DraftAnnotation
-
-if App.GuiUp:
-    from draftviewproviders.view_dimension import ViewProviderDimensionBase
-    from draftviewproviders.view_dimension import ViewProviderLinearDimension
-    from draftviewproviders.view_dimension import ViewProviderAngularDimension
-
-def make_dimension(p1,p2,p3=None,p4=None):
-    """makeDimension(p1,p2,[p3]) or makeDimension(object,i1,i2,p3)
-    or makeDimension(objlist,indices,p3): Creates a Dimension object with
-    the dimension line passign through p3.The current line width and color
-    will be used. There are multiple  ways to create a dimension, depending on
-    the arguments you pass to it:
-    - (p1,p2,p3): creates a standard dimension from p1 to p2
-    - (object,i1,i2,p3): creates a linked dimension to the given object,
-    measuring the distance between its vertices indexed i1 and i2
-    - (object,i1,mode,p3): creates a linked dimension
-    to the given object, i1 is the index of the (curved) edge to measure,
-    and mode is either "radius" or "diameter".
-    """
-    if not App.ActiveDocument:
-        App.Console.PrintError("No active document. Aborting\n")
-        return
-    obj = App.ActiveDocument.addObject("App::FeaturePython","Dimension")
-    LinearDimension(obj)
-    if App.GuiUp:
-        ViewProviderLinearDimension(obj.ViewObject)
-    if isinstance(p1,App.Vector) and isinstance(p2,App.Vector):
-        obj.Start = p1
-        obj.End = p2
-        if not p3:
-            p3 = p2.sub(p1)
-            p3.multiply(0.5)
-            p3 = p1.add(p3)
-    elif isinstance(p2,int) and isinstance(p3,int):
-        l = []
-        idx = (p2,p3)
-        l.append((p1,"Vertex"+str(p2+1)))
-        l.append((p1,"Vertex"+str(p3+1)))
-        obj.LinkedGeometry = l
-        obj.Support = p1
-        p3 = p4
-        if not p3:
-            v1 = obj.Base.Shape.Vertexes[idx[0]].Point
-            v2 = obj.Base.Shape.Vertexes[idx[1]].Point
-            p3 = v2.sub(v1)
-            p3.multiply(0.5)
-            p3 = v1.add(p3)
-    elif isinstance(p3,str):
-        l = []
-        l.append((p1,"Edge"+str(p2+1)))
-        if p3 == "radius":
-            #l.append((p1,"Center"))
-            if App.GuiUp:
-                obj.ViewObject.Override = "R $dim"
-            obj.Diameter = False
-        elif p3 == "diameter":
-            #l.append((p1,"Diameter"))
-            if App.GuiUp:
-                obj.ViewObject.Override = "Ø $dim"
-            obj.Diameter = True
-        obj.LinkedGeometry = l
-        obj.Support = p1
-        p3 = p4
-        if not p3:
-            p3 = p1.Shape.Edges[p2].Curve.Center.add(App.Vector(1,0,0))
-    obj.Dimline = p3
-    if hasattr(App,"DraftWorkingPlane"):
-        normal = App.DraftWorkingPlane.axis
-    else:
-        normal = App.Vector(0,0,1)
-    if App.GuiUp:
-        # invert the normal if we are viewing it from the back
-        vnorm = gui_utils.get3DView().getViewDirection()
-        if vnorm.getAngle(normal) < math.pi/2:
-            normal = normal.negative()
-    obj.Normal = normal
-
-    if App.GuiUp:
-        gui_utils.format_object(obj)
-        gui_utils.select(obj)
-
-    return obj
-
-
-def make_angular_dimension(center,angles,p3,normal=None):
-    """makeAngularDimension(center,angle1,angle2,p3,[normal]): creates an angular Dimension
-    from the given center, with the given list of angles, passing through p3.
-    """
-    if not App.ActiveDocument:
-        App.Console.PrintError("No active document. Aborting\n")
-        return
-    obj = App.ActiveDocument.addObject("App::FeaturePython","Dimension")
-    AngularDimension(obj)
-    if App.GuiUp:
-        ViewProviderAngularDimension(obj.ViewObject)
-    obj.Center = center
-    for a in range(len(angles)):
-        if angles[a] > 2*math.pi:
-            angles[a] = angles[a]-(2*math.pi)
-    obj.FirstAngle = math.degrees(angles[1])
-    obj.LastAngle = math.degrees(angles[0])
-    obj.Dimline = p3
-    if not normal:
-        if hasattr(App,"DraftWorkingPlane"):
-            normal = App.DraftWorkingPlane.axis
-        else:
-            normal = App.Vector(0,0,1)
-    if App.GuiUp:
-        # invert the normal if we are viewing it from the back
-        vnorm = gui_utils.get3DView().getViewDirection()
-        if vnorm.getAngle(normal) < math.pi/2:
-            normal = normal.negative()
-
-    obj.Normal = normal
-            
-    if App.GuiUp:
-        gui_utils.format_object(obj)
-        gui_utils.select(obj)
-
-    return obj
-
 
 
 class DimensionBase(DraftAnnotation):
-    """
-    The Draft Dimension Base object
+    """The base objects for dimension objects.
+
+    This class inherits `DraftAnnotation` to define the basic properties
+    of all annotation type objects, like a scaling multiplier.
+
     This class is not used directly, but inherited by all dimension
     objects.
     """
 
-    def __init__(self, obj, tp = "Dimension"):
-        """Add common dimension properties to the object and set them"""
-        
+    def __init__(self, obj, tp="Dimension"):
         super(DimensionBase, self).__init__(obj, tp)
 
         # Draft
@@ -190,21 +70,12 @@ class DimensionBase(DraftAnnotation):
     def onDocumentRestored(self, obj):
         super(DimensionBase, self).onDocumentRestored(obj)
 
-    def execute(self, obj):
-        '''Do something when recompute object'''
-        
-        return
-
-
-    def onChanged(self,obj,prop):
-        '''Do something when a property has changed'''
-
-        return
-
 
 class LinearDimension(DimensionBase):
-    """
-    The Draft Linear Dimension object
+    """The linear dimension object.
+
+    This inherits `DimensionBase` to provide the basic functionality of
+    a dimension.
     """
 
     def __init__(self, obj):
@@ -238,7 +109,6 @@ class LinearDimension(DimensionBase):
         obj.Start = App.Vector(0,0,0)
         obj.End = App.Vector(1,0,0)
 
-
     def onDocumentRestored(self, obj):
         super(LinearDimension, self).onDocumentRestored(obj)
 
@@ -250,7 +120,6 @@ class LinearDimension(DimensionBase):
         #    obj.setEditorMode('Normal', 2)
         if hasattr(obj, "Support"):
             obj.setEditorMode('Support', 2)
-
 
     def execute(self, obj):
         """ Set start point and end point according to the linked geometry"""
@@ -308,20 +177,21 @@ class LinearDimension(DimensionBase):
                 obj.ViewObject.update()
 
 
+# Alias for compatibility with v0.18 and earlier
+_Dimension = LinearDimension
+
 
 class AngularDimension(DimensionBase):
-    """
-    The Draft AngularDimension object
+    """The angular dimension object.
+
+    This inherits `DimensionBase` to provide the basic functionality of
+    a dimension.
     """
 
     def __init__(self, obj):
-
         super(AngularDimension, self).__init__(obj, "AngularDimension")
-        
         self.init_properties(obj)
-
-        obj.Proxy = self    
-
+        obj.Proxy = self
 
     def init_properties(self, obj):
         """Add Angular Dimension specific properties to the object and set them"""
@@ -352,7 +222,6 @@ class AngularDimension(DimensionBase):
         if fp.ViewObject:
             fp.ViewObject.update()
 
-
     def onChanged(self,obj,prop):
         '''Do something when a property has changed'''
         super(AngularDimension, self).onChanged(obj, prop)
@@ -362,3 +231,7 @@ class AngularDimension(DimensionBase):
             obj.setEditorMode('Normal',2)
         if hasattr(obj,"Support"):
             obj.setEditorMode('Support',2)
+
+
+# Alias for compatibility with v0.18 and earlier
+_AngularDimension = AngularDimension

--- a/src/Mod/Draft/draftobjects/draft_annotation.py
+++ b/src/Mod/Draft/draftobjects/draft_annotation.py
@@ -1,5 +1,6 @@
 # ***************************************************************************
-# *   (c) 2020 Carlo Pavan                                                  *
+# *   Copyright (c) 2020 Carlo Pavan <carlopav@gmail.com>                   *
+# *   Copyright (c) 2020 Eliud Cabrera Castillo <e.cabrera-castillo@tum.de> *
 # *                                                                         *
 # *   This file is part of the FreeCAD CAx development system.              *
 # *                                                                         *
@@ -20,11 +21,19 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""This module provides the object code for Draft Annotation.
+"""Provide the basic object code for all Draft annotation objects.
+
+This is used by many objects that show dimensions and text created on screen
+through Coin (pivy).
+- DimensionBase
+- LinearDimension
+- AngularDimension
+- Label
+- Text
 """
-## @package annotation
+## @package draft_annotation
 # \ingroup DRAFT
-# \brief This module provides the object code for Draft Annotation.
+# \brief Provide the basic object code for all Draft annotation objects.
 
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
@@ -44,31 +53,46 @@ class DraftAnnotation(object):
     Text
     """
 
-    def __init__(self, obj, tp="Annotation"):
-        self.Type = tp
+    def __init__(self, obj, typ="Annotation"):
+        self.Type = typ
+        obj.Proxy = self
 
     def onDocumentRestored(self, obj):
-        """Run when the document that is using this class is restored.
+        """Execute code when the document is restored.
 
         Check if new properties are present after the object is restored
         in order to migrate older objects.
         """
-        if hasattr(obj, "ViewObject") and obj.ViewObject:
-            if not hasattr(obj.ViewObject, 'ScaleMultiplier'):
-                # annotation properties
-                vobj = obj.ViewObject
-                _tip = QT_TRANSLATE_NOOP("App::Property",
-                        "Dimension size overall multiplier")
-                vobj.addProperty("App::PropertyFloat", "ScaleMultiplier", "Annotation", _tip)
-                vobj.ScaleMultiplier = 1.00
+        self.add_missing_properties_0v19(obj)
 
-                _info = "added view property 'ScaleMultiplier'"
-                _wrn("v0.19, " + obj.Label + ", " + _tr(_info))
+    def add_missing_properties_0v19(self, obj):
+        """Provide missing annotation properties, if they don't exist."""
+        if (hasattr(obj, "ViewObject") and obj.ViewObject
+                and not hasattr(obj.ViewObject, 'ScaleMultiplier')):
+            vobj = obj.ViewObject
+            _tip = QT_TRANSLATE_NOOP("App::Property",
+                                     "Dimension size overall multiplier")
+            vobj.addProperty("App::PropertyFloat",
+                             "ScaleMultiplier",
+                             "Annotation",
+                             _tip)
+            vobj.ScaleMultiplier = 1.00
+
+            _info = "added view property 'ScaleMultiplier'"
+            _wrn("v0.19, " + obj.Label + ", " + _tr(_info))
 
     def __getstate__(self):
+        """Return a tuple of objects to save or None.
+
+        Save the Type.
+        """
         return self.Type
 
     def __setstate__(self, state):
+        """Set the internal properties from the restored state.
+
+        Restore the Type of the object.
+        """
         if state:
             if isinstance(state, dict) and ("Type" in state):
                 self.Type = state["Type"]
@@ -76,9 +100,15 @@ class DraftAnnotation(object):
                 self.Type = state
 
     def execute(self, obj):
-        """Do something when recompute object."""
+        """Execute when the object is created or recomputed.
+
+        Does nothing.
+        """
         return
 
     def onChanged(self, obj, prop):
-        """Do something when a property has changed."""
+        """Execute when a property is changed.
+
+        Does nothing.
+        """
         return

--- a/src/Mod/Draft/drafttests/draft_test_objects.py
+++ b/src/Mod/Draft/drafttests/draft_test_objects.py
@@ -247,9 +247,9 @@ def _create_objects(doc=None,
     arc_h.Placement.Base = Vector(9500, 0, 0)
     doc.recompute()
 
-    dimension_r = Draft.make_dimension(arc_h, 0,
-                                       "radius",
-                                       Vector(9750, 200, 0))
+    dimension_r = Draft.make_radial_dimension_obj(arc_h, 1,
+                                                  "radius",
+                                                  Vector(9750, 200, 0))
     if App.GuiUp:
         dimension_r.ViewObject.ArrowSize = 15
         dimension_r.ViewObject.FontSize = 100
@@ -259,9 +259,9 @@ def _create_objects(doc=None,
     arc_h2.Placement.Base = Vector(10000, 1000, 0)
     doc.recompute()
 
-    dimension_d = Draft.make_dimension(arc_h2, 0,
-                                       "diameter",
-                                       Vector(10750, 900, 0))
+    dimension_d = Draft.make_radial_dimension_obj(arc_h2, 1,
+                                                  "diameter",
+                                                  Vector(10750, 900, 0))
     if App.GuiUp:
         dimension_d.ViewObject.ArrowSize = 15
         dimension_d.ViewObject.FontSize = 100

--- a/src/Mod/Draft/drafttests/draft_test_objects.py
+++ b/src/Mod/Draft/drafttests/draft_test_objects.py
@@ -39,7 +39,6 @@ Or load it as a module and use the defined function.
 # @{
 
 import datetime
-import math
 import os
 
 import FreeCAD as App
@@ -260,8 +259,8 @@ def _create_objects(doc=None,
     _msg("Angular dimension")
     Draft.make_line(Vector(10500, 300, 0), Vector(11500, 1000, 0))
     Draft.make_line(Vector(10500, 300, 0), Vector(11500, 0, 0))
-    angle1 = math.radians(40)
-    angle2 = math.radians(-20)
+    angle1 = -20
+    angle2 = 40
     dimension_a = Draft.make_angular_dimension(Vector(10500, 300, 0),
                                                [angle1, angle2],
                                                Vector(11500, 300, 0))

--- a/src/Mod/Draft/drafttests/draft_test_objects.py
+++ b/src/Mod/Draft/drafttests/draft_test_objects.py
@@ -211,9 +211,12 @@ def _create_objects(doc=None,
     # Linear dimension
     _msg(16 * "-")
     _msg("Linear dimension")
-    dimension = Draft.make_dimension(Vector(8500, 500, 0),
-                                     Vector(8500, 1000, 0),
-                                     Vector(9000, 750, 0))
+    line = Draft.make_wire([Vector(8700, 200, 0),
+                            Vector(8700, 1200, 0)])
+
+    dimension = Draft.make_linear_dimension(Vector(8600, 200, 0),
+                                            Vector(8600, 1000, 0),
+                                            Vector(8400, 750, 0))
     if App.GuiUp:
         dimension.ViewObject.ArrowSize = 15
         dimension.ViewObject.ExtLines = 1000
@@ -221,6 +224,19 @@ def _create_objects(doc=None,
         dimension.ViewObject.DimOvershoot = 50
         dimension.ViewObject.FontSize = 100
         dimension.ViewObject.ShowUnit = False
+    doc.recompute()
+
+    dim_obj = Draft.make_linear_dimension_obj(line, 1, 2,
+                                              Vector(9000, 750, 0))
+    if App.GuiUp:
+        dim_obj.ViewObject.ArrowSize = 15
+        dim_obj.ViewObject.ArrowType = "Arrow"
+        dim_obj.ViewObject.ExtLines = 100
+        dim_obj.ViewObject.ExtOvershoot = 100
+        dim_obj.ViewObject.DimOvershoot = 50
+        dim_obj.ViewObject.FontSize = 100
+        dim_obj.ViewObject.ShowUnit = False
+
     t_xpos += 680
     _set_text(["Dimension"], Vector(t_xpos, t_ypos, 0))
 

--- a/src/Mod/Draft/drafttests/test_creation.py
+++ b/src/Mod/Draft/drafttests/test_creation.py
@@ -170,8 +170,8 @@ class DraftCreation(unittest.TestCase):
         obj = Draft.make_text(text)
         self.assertTrue(obj, "'{}' failed".format(operation))
 
-    def test_dimension_linear(self):
-        """Create a linear dimension."""
+    def test_dimension_linear_simple(self):
+        """Create a simple linear dimension not linked to an object."""
         operation = "Draft Dimension"
         _msg("  Test '{}'".format(operation))
         _msg("  Occasionally crashes")
@@ -180,7 +180,23 @@ class DraftCreation(unittest.TestCase):
         c = Vector(4, -1, 0)
         _msg("  a={0}, b={1}".format(a, b))
         _msg("  c={}".format(c))
-        obj = Draft.make_dimension(a, b, c)
+        obj = Draft.make_linear_dimension(a, b, c)
+        self.assertTrue(obj, "'{}' failed".format(operation))
+
+    def test_dimension_linear_obj(self):
+        """Create a linear dimension linked to an object."""
+        operation = "Draft Dimension"
+        _msg("  Test '{}'".format(operation))
+        _msg("  Occasionally crashes")
+        a = Vector(0, 0, 0)
+        b = Vector(9, 0, 0)
+        _msg("  a={0}, b={1}".format(a, b))
+        line = Draft.make_line(a, b)
+        self.doc.recompute()
+
+        obj = Draft.make_linear_dimension_obj(line,
+                                              i1=1, i2=2,
+                                              dim_line=Vector(5, 3, 0))
         self.assertTrue(obj, "'{}' failed".format(operation))
 
     def test_dimension_radial(self):

--- a/src/Mod/Draft/drafttests/test_creation.py
+++ b/src/Mod/Draft/drafttests/test_creation.py
@@ -24,7 +24,6 @@
 """Unit test for the Draft Workbench, object creation tests."""
 
 import unittest
-import math
 
 import FreeCAD as App
 import Draft
@@ -210,14 +209,13 @@ class DraftCreation(unittest.TestCase):
         _msg("  Test '{}'".format(operation))
         _msg("  Occasionally crashes")
         center = Vector(0, 0, 0)
-        angle1 = math.radians(60)
-        angle2 = math.radians(10)
-        p3 = Vector(3, 1, 0)
+        angle1 = 20
+        angle2 = 70
+        dim_line = Vector(3, 1, 0)
         _msg("  center={}".format(center))
-        _msg("  angle1={0}, angle2={1}".format(math.degrees(angle1),
-                                               math.degrees(angle2)))
-        _msg("  point={}".format(p3))
-        obj = Draft.make_angular_dimension(center, [angle1, angle2], p3)
+        _msg("  angle1={0}, angle2={1}".format(angle1, angle2))
+        _msg("  dim_line={}".format(dim_line))
+        obj = Draft.make_angular_dimension(center, [angle1, angle2], dim_line)
         self.assertTrue(obj, "'{}' failed".format(operation))
 
     def test_bspline(self):

--- a/src/Mod/Draft/drafttests/test_creation.py
+++ b/src/Mod/Draft/drafttests/test_creation.py
@@ -199,11 +199,11 @@ class DraftCreation(unittest.TestCase):
                                               dim_line=Vector(5, 3, 0))
         self.assertTrue(obj, "'{}' failed".format(operation))
 
-    def test_dimension_radial(self):
-        """Create a circle and then a radial dimension."""
+    def test_dimension_radial_obj(self):
+        """Create a circle and then a radial and a diameter dimension."""
         operation = "Draft Dimension Radial"
         _msg("  Test '{}'".format(operation))
-        radius = 3
+        radius = 10
         start_angle = 0
         end_angle = 90
         _msg("  radius={}".format(radius))
@@ -213,10 +213,12 @@ class DraftCreation(unittest.TestCase):
                                  startangle=start_angle, endangle=end_angle)
         self.doc.recompute()
 
-        obj1 = Draft.make_dimension(circ, 0,
-                                    p3="radius", p4=Vector(1, 1, 0))
-        obj2 = Draft.make_dimension(circ, 0,
-                                    p3="diameter", p4=Vector(3, 1, 0))
+        obj1 = Draft.make_radial_dimension_obj(circ, index=1,
+                                               mode="radius",
+                                               dim_line=Vector(1, 1, 0))
+        obj2 = Draft.make_radial_dimension_obj(circ, index=1,
+                                               mode="diameter",
+                                               dim_line=Vector(3, 1, 0))
         self.assertTrue(obj1 and obj2, "'{}' failed".format(operation))
 
     def test_dimension_angular(self):


### PR DESCRIPTION
The `make_dimension` functions were moved from the `draftobjects` package to the `draftmake` package.

General cleanup for the `make_dimension` function, which now has been expanded into four new functions, `make_linear_dimension`, `make_linear_dimension_obj`, `make_radial_dimension_obj`, `make_angular_dimension`.

These functions allow us to create specific dimensions with clearly defined inputs instead of using the generic `make_dimension` function which had to juggle different types of inputs to produce the correct measurement. For example, now we can input a specific object to measure by object reference or by `Label`; in the case of angular dimensions, we enter the angles in degrees instead of radians, and the `FirstAngle` comes first as it is logically expected. The Gui Command was updated accordingly.

Type checking is made in all parameters to make sure the user enters the correct information. The older `makeDimension` is considered deprecated but still works the same as before.

The internal classes were updated to clearly structure the properties, and more complete tooltips were provided. The execute method of `LinearDimension` was updated to use smaller functions to show how the dimensions can be generated from the information of the `LinkedGeometry` property, which could have one element in the case of linear dimensions of lines and circular arcs, or two elements in the case of measuring the distance between two arbitrary vertices in two different objects. The latter case is rare and not well documented, so we add corresponding documentation.

We add a "To do" list of things that need attention in the future. For example, similar to the case described in the `PathArray` class #3586 , we may have to migrate the `LinkedGeometry` property to a `LinkSub`, instead of the current `LinkSubList`. Other improvements could be done as well.

General cleanup for PEP8 style, for the Gui Command, and for the unit tests and the test script.

---

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists