### PR TITLE
Draft: fix assignment of annotation styles in the different annotation objects

### DIFF
--- a/src/Mod/Draft/Draft.py
+++ b/src/Mod/Draft/Draft.py
@@ -397,10 +397,10 @@ from draftmake.make_dimension import (make_dimension,
                                       makeAngularDimension)
 
 if FreeCAD.GuiUp:
-    from draftviewproviders.view_dimension import ViewProviderLinearDimension
-    from draftviewproviders.view_dimension import ViewProviderAngularDimension
-    _ViewProviderDimension = ViewProviderLinearDimension
-    _ViewProviderAngularDimension = ViewProviderAngularDimension
+    from draftviewproviders.view_dimension import (ViewProviderLinearDimension,
+                                                   _ViewProviderDimension,
+                                                   ViewProviderAngularDimension,
+                                                   _ViewProviderAngularDimension)
 
 from draftobjects.label import (Label,
                                 DraftLabel)
@@ -408,9 +408,9 @@ from draftobjects.label import (Label,
 from draftmake.make_label import (make_label,
                                   makeLabel)
 
-if gui:
-    from draftviewproviders.view_label import ViewProviderLabel
-    ViewProviderDraftLabel = ViewProviderLabel
+if FreeCAD.GuiUp:
+    from draftviewproviders.view_label import (ViewProviderLabel,
+                                               ViewProviderDraftLabel)
 
 from draftobjects.text import (Text,
                                DraftText)

--- a/src/Mod/Draft/draftguitools/gui_annotationstyleeditor.py
+++ b/src/Mod/Draft/draftguitools/gui_annotationstyleeditor.py
@@ -28,27 +28,12 @@ from PySide.QtCore import QT_TRANSLATE_NOOP
 import FreeCAD as App
 import FreeCADGui as Gui
 import draftguitools.gui_base as gui_base
+
+from FreeCAD import Units as U
 from draftutils.translate import _tr
+from draftutils.utils import ANNOTATION_STYLE as DEFAULT
 
 param = App.ParamGet("User parameter:BaseApp/Preferences/Mod/Draft")
-
-DEFAULT = {
-    "FontName": ("font", param.GetString("textfont", "Sans")),
-    "FontSize": ("str", str(param.GetFloat("textheight", 100))),
-    "LineSpacing": ("float", 1),
-    "ScaleMultiplier": ("float", 1),
-    "ShowUnit": ("bool", False),
-    "UnitOverride": ("str", ""),
-    "Decimals": ("int", 2),
-    "ShowLines": ("bool", True),
-    "LineWidth": ("int", param.GetInt("linewidth", 1)),
-    "LineColor": ("color", param.GetInt("color", 255)),
-    "ArrowType": ("index", param.GetInt("dimsymbol", 0)),
-    "ArrowSize": ("str", str(param.GetFloat("arrowsize", 20))),
-    "DimensionOvershoot": ("str", str(param.GetFloat("dimovershoot", 20))),
-    "ExtensionLines": ("str", str(param.GetFloat("extlines", 300))),
-    "ExtensionOvershoot": ("str", str(param.GetFloat("extovershoot", 20))),
-    }
 
 
 class AnnotationStyleEditor(gui_base.GuiCommandSimplest):
@@ -211,7 +196,7 @@ class AnnotationStyleEditor(gui_base.GuiCommandSimplest):
                                     try:
                                         setattr(vobj,attr,attrvalue)
                                     except:
-                                        unitvalue = FreeCAD.Units.Quantity(attrvalue,FreeCAD.Units.Length).Value
+                                        unitvalue = U.Quantity(attrvalue, U.Length).Value
                                         setattr(vobj,attr,unitvalue)
                 else:
                     # the style has been removed

--- a/src/Mod/Draft/draftutils/utils.py
+++ b/src/Mod/Draft/draftutils/utils.py
@@ -51,8 +51,28 @@ if App.GuiUp:
 # The module is used to prevent complaints from code checkers (flake8)
 True if Draft_rc else False
 
+param = App.ParamGet("User parameter:BaseApp/Preferences/Mod/Draft")
+
 ARROW_TYPES = ["Dot", "Circle", "Arrow", "Tick", "Tick-2"]
 arrowtypes = ARROW_TYPES
+
+ANNOTATION_STYLE = {
+    "FontName": ("font", param.GetString("textfont", "Sans")),
+    "FontSize": ("str", str(param.GetFloat("textheight", 100))),
+    "LineSpacing": ("float", 1),
+    "ScaleMultiplier": ("float", 1),
+    "ShowUnit": ("bool", False),
+    "UnitOverride": ("str", ""),
+    "Decimals": ("int", 2),
+    "ShowLines": ("bool", True),
+    "LineWidth": ("int", param.GetInt("linewidth", 1)),
+    "LineColor": ("color", param.GetInt("color", 255)),
+    "ArrowType": ("index", param.GetInt("dimsymbol", 0)),
+    "ArrowSize": ("str", str(param.GetFloat("arrowsize", 20))),
+    "DimensionOvershoot": ("str", str(param.GetFloat("dimovershoot", 20))),
+    "ExtensionLines": ("str", str(param.GetFloat("extlines", 300))),
+    "ExtensionOvershoot": ("str", str(param.GetFloat("extovershoot", 20))),
+}
 
 
 def string_encode_coin(ustr):

--- a/src/Mod/Draft/draftviewproviders/view_dimension.py
+++ b/src/Mod/Draft/draftviewproviders/view_dimension.py
@@ -265,8 +265,8 @@ class ViewProviderDimensionBase(ViewProviderDraftAnnotation):
         return
 
     def onChanged(self, vobj, prop):
-        """called when a view property has changed"""
-        return
+        """Execute when a view property is changed."""
+        super(ViewProviderDimensionBase, self).onChanged(vobj, prop)
 
     def doubleClicked(self,vobj):
         self.setEdit(vobj)
@@ -559,7 +559,9 @@ class ViewProviderLinearDimension(ViewProviderDimensionBase):
                 self.line.coordIndex.setValues(0,4,(0,1,2,3))
 
     def onChanged(self, vobj, prop):
-        """called when a view property has changed"""
+        """Execute when a view property is changed."""
+        super(ViewProviderLinearDimension, self).onChanged(vobj, prop)
+
         if prop == "ScaleMultiplier" and hasattr(vobj, "ScaleMultiplier"):
             # update all dimension values
             if hasattr(self,"font"):
@@ -936,6 +938,9 @@ class ViewProviderAngularDimension(ViewProviderDimensionBase):
                 obj.Angle = a
 
     def onChanged(self, vobj, prop):
+        """Execute when a view property is changed."""
+        super(ViewProviderAngularDimension, self).onChanged(vobj, prop)
+
         if hasattr(vobj, "ScaleMultiplier"):
             if vobj.ScaleMultiplier == 0:
                 return

--- a/src/Mod/Draft/draftviewproviders/view_dimension.py
+++ b/src/Mod/Draft/draftviewproviders/view_dimension.py
@@ -86,92 +86,179 @@ class ViewProviderDimensionBase(ViewProviderDraftAnnotation):
     
     """
     def __init__(self, vobj):
-
         super(ViewProviderDimensionBase, self).__init__(vobj)
 
-        # text properties
-        vobj.addProperty("App::PropertyFont","FontName",
-                         "Text",
-                         QT_TRANSLATE_NOOP("App::Property","Font name"))
-        vobj.addProperty("App::PropertyLength","FontSize",
-                         "Text",
-                         QT_TRANSLATE_NOOP("App::Property","Font size"))
-        vobj.addProperty("App::PropertyLength","TextSpacing",
-                         "Text",
-                         QT_TRANSLATE_NOOP("App::Property",
-                         "Spacing between text and dimension line"))
-        vobj.addProperty("App::PropertyBool","FlipText",
-                         "Text",
-                         QT_TRANSLATE_NOOP("App::Property",
-                         "Rotate the dimension text 180 degrees"))
-        vobj.addProperty("App::PropertyVectorDistance","TextPosition",
-                         "Text",
-                         QT_TRANSLATE_NOOP("App::Property",
-                         "Text Position. \n"
-                         "Leave (0,0,0) for automatic position"))
-        vobj.addProperty("App::PropertyString","Override",
-                         "Text",
-                         QT_TRANSLATE_NOOP("App::Property",
-                         "Text override. \n"
-                         "Use $dim to insert the dimension length"))
+        self.set_properties(vobj)
+        self.Object = vobj.Object
+        vobj.Proxy = self
 
-        # units properties
-        vobj.addProperty("App::PropertyInteger","Decimals",
-                         "Units",
-                         QT_TRANSLATE_NOOP("App::Property",
-                         "The number of decimals to show"))
-        vobj.addProperty("App::PropertyBool","ShowUnit",
-                         "Units",
-                         QT_TRANSLATE_NOOP("App::Property",
-                         "Show the unit suffix"))
-        vobj.addProperty("App::PropertyString","UnitOverride",
-                         "Units",
-                         QT_TRANSLATE_NOOP("App::Property",
-                         "A unit to express the measurement. \n"
-                         "Leave blank for system default"))
+    def set_properties(self, vobj):
+        """Set the properties only if they don't already exist."""
+        super(ViewProviderDimensionBase, self).set_properties(vobj)
 
-        # graphics properties
-        vobj.addProperty("App::PropertyLength","ArrowSize",
-                         "Graphics",
-                         QT_TRANSLATE_NOOP("App::Property","Arrow size"))
-        vobj.addProperty("App::PropertyEnumeration","ArrowType",
-                         "Graphics",
-                         QT_TRANSLATE_NOOP("App::Property","Arrow type"))
-        vobj.addProperty("App::PropertyBool","FlipArrows",
-                        "Graphics",
-                        QT_TRANSLATE_NOOP("App::Property",
-                        "Rotate the dimension arrows 180 degrees"))        
-        vobj.addProperty("App::PropertyDistance","DimOvershoot",
-                         "Graphics",
-                         QT_TRANSLATE_NOOP("App::Property",
-                         "The distance the dimension line is extended\n"
-                         "past the extension lines"))        
-        vobj.addProperty("App::PropertyDistance","ExtLines",
-                         "Graphics",
-                         QT_TRANSLATE_NOOP("App::Property",
-                         "Length of the extension lines"))
-        vobj.addProperty("App::PropertyDistance","ExtOvershoot",
-                         "Graphics",
-                         QT_TRANSLATE_NOOP("App::Property",
-                         "Length of the extension line \n"
-                         "above the dimension line"))
-        vobj.addProperty("App::PropertyBool","ShowLine",
-                         "Graphics",
-                         QT_TRANSLATE_NOOP("App::Property",
-                         "Shows the dimension line and arrows"))
-        
-        vobj.FontSize = utils.get_param("textheight",0.20)
-        vobj.TextSpacing = utils.get_param("dimspacing",0.05)
-        vobj.FontName = utils.get_param("textfont","")
-        vobj.ArrowSize = utils.get_param("arrowsize",0.1)
-        vobj.ArrowType = utils.ARROW_TYPES
-        vobj.ArrowType = utils.ARROW_TYPES[utils.get_param("dimsymbol",0)]
-        vobj.ExtLines = utils.get_param("extlines",0.3)
-        vobj.DimOvershoot = utils.get_param("dimovershoot",0)
-        vobj.ExtOvershoot = utils.get_param("extovershoot",0)
-        vobj.Decimals = utils.get_param("dimPrecision",2)
-        vobj.ShowUnit = utils.get_param("showUnit",True)
-        vobj.ShowLine = True
+        properties = vobj.PropertiesList
+        self.set_text_properties(vobj, properties)
+        self.set_units_properties(vobj, properties)
+        self.set_graphics_properties(vobj, properties)
+
+    def set_text_properties(self, vobj, properties):
+        """Set text properties only if they don't already exist."""
+        if "FontName" not in properties:
+            _tip = QT_TRANSLATE_NOOP("App::Property",
+                                     "Font name")
+            vobj.addProperty("App::PropertyFont",
+                             "FontName",
+                             "Text",
+                             _tip)
+            vobj.FontName = utils.get_param("textfont", "")
+
+        if "FontSize" not in properties:
+            _tip = QT_TRANSLATE_NOOP("App::Property",
+                                     "Font size")
+            vobj.addProperty("App::PropertyLength",
+                             "FontSize",
+                             "Text",
+                             _tip)
+            vobj.FontSize = utils.get_param("textheight", 0.20)
+
+        if "TextSpacing" not in properties:
+            _tip = QT_TRANSLATE_NOOP("App::Property",
+                                     "Spacing between text and dimension line")
+            vobj.addProperty("App::PropertyLength",
+                             "TextSpacing",
+                             "Text",
+                             _tip)
+            vobj.TextSpacing = utils.get_param("dimspacing", 0.05)
+
+        if "FlipText" not in properties:
+            _tip = QT_TRANSLATE_NOOP("App::Property",
+                                     "Rotate the dimension text 180 degrees")
+            vobj.addProperty("App::PropertyBool",
+                             "FlipText",
+                             "Text",
+                             _tip)
+            vobj.FlipText = False
+
+        if "TextPosition" not in properties:
+            _tip = QT_TRANSLATE_NOOP("App::Property",
+                                     "Text Position.\n"
+                                     "Leave '(0,0,0)' for automatic position")
+            vobj.addProperty("App::PropertyVectorDistance",
+                             "TextPosition",
+                             "Text",
+                             _tip)
+            vobj.TextPosition = App.Vector(0, 0, 0)
+
+        if "Override" not in properties:
+            _tip = QT_TRANSLATE_NOOP("App::Property",
+                                     "Text override.\n"
+                                     "Use '$dim' so that it is replaced by "
+                                     "the dimension length.")
+            vobj.addProperty("App::PropertyString",
+                             "Override",
+                             "Text",
+                             _tip)
+            vobj.Override = ''
+
+    def set_units_properties(self, vobj, properties):
+        """Set unit properties only if they don't already exist."""
+        if "Decimals" not in properties:
+            _tip = QT_TRANSLATE_NOOP("App::Property",
+                                     "The number of decimals to show")
+            vobj.addProperty("App::PropertyInteger",
+                             "Decimals",
+                             "Units",
+                             _tip)
+            vobj.Decimals = utils.get_param("dimPrecision", 2)
+
+        if "ShowUnit" not in properties:
+            _tip = QT_TRANSLATE_NOOP("App::Property",
+                                     "Show the unit suffix")
+            vobj.addProperty("App::PropertyBool",
+                             "ShowUnit",
+                             "Units",
+                             _tip)
+            vobj.ShowUnit = utils.get_param("showUnit", True)
+
+        if "UnitOverride" not in properties:
+            _tip = QT_TRANSLATE_NOOP("App::Property",
+                                     "A unit to express the measurement.\n"
+                                     "Leave blank for system default")
+            vobj.addProperty("App::PropertyString",
+                             "UnitOverride",
+                             "Units",
+                             _tip)
+
+    def set_graphics_properties(self, vobj, properties):
+        """Set graphics properties only if they don't already exist."""
+        super(ViewProviderDimensionBase, self).set_graphics_properties(vobj, properties)
+
+        if "ArrowSize" not in properties:
+            _tip = QT_TRANSLATE_NOOP("App::Property",
+                                     "Arrow size")
+            vobj.addProperty("App::PropertyLength",
+                             "ArrowSize",
+                             "Graphics",
+                             _tip)
+            vobj.ArrowSize = utils.get_param("arrowsize", 1)
+
+        if "ArrowType" not in properties:
+            _tip = QT_TRANSLATE_NOOP("App::Property",
+                                     "Arrow type")
+            vobj.addProperty("App::PropertyEnumeration",
+                             "ArrowType",
+                             "Graphics",
+                             _tip)
+            vobj.ArrowType = utils.ARROW_TYPES
+            vobj.ArrowType = utils.ARROW_TYPES[utils.get_param("dimsymbol", 0)]
+
+        if "FlipArrows" not in properties:
+            _tip = QT_TRANSLATE_NOOP("App::Property",
+                                     "Rotate the dimension arrows 180 degrees")
+            vobj.addProperty("App::PropertyBool",
+                             "FlipArrows",
+                             "Graphics",
+                             _tip)
+            vobj.FlipArrows = False
+
+        if "DimOvershoot" not in properties:
+            _tip = QT_TRANSLATE_NOOP("App::Property",
+                                     "The distance the dimension line "
+                                     "is extended\n"
+                                     "past the extension lines")
+            vobj.addProperty("App::PropertyDistance",
+                             "DimOvershoot",
+                             "Graphics",
+                             _tip)
+            vobj.DimOvershoot = utils.get_param("dimovershoot", 0)
+
+        if "ExtLines" not in properties:
+            _tip = QT_TRANSLATE_NOOP("App::Property",
+                                     "Length of the extension lines")
+            vobj.addProperty("App::PropertyDistance",
+                             "ExtLines",
+                             "Graphics",
+                             _tip)
+            vobj.ExtLines = utils.get_param("extlines", 0.3)
+
+        if "ExtOvershoot" not in properties:
+            _tip = QT_TRANSLATE_NOOP("App::Property",
+                                     "Length of the extension line\n"
+                                     "above the dimension line")
+            vobj.addProperty("App::PropertyDistance",
+                             "ExtOvershoot",
+                             "Graphics",
+                             _tip)
+            vobj.ExtOvershoot = utils.get_param("extovershoot", 0)
+
+        if "ShowLine" not in properties:
+            _tip = QT_TRANSLATE_NOOP("App::Property",
+                                     "Shows the dimension line and arrows")
+            vobj.addProperty("App::PropertyBool",
+                             "ShowLine",
+                             "Graphics",
+                             _tip)
+            vobj.ShowLine = True
 
     def updateData(self, obj, prop):
         """called when the base object is changed"""
@@ -216,9 +303,9 @@ class ViewProviderLinearDimension(ViewProviderDimensionBase):
     A View Provider for the Draft Linear Dimension object
     """
     def __init__(self, vobj):
-
         super(ViewProviderLinearDimension, self).__init__(vobj)
-           
+        super(ViewProviderLinearDimension, self).set_properties(vobj)
+
         self.Object = vobj.Object
         vobj.Proxy = self
 
@@ -658,16 +745,16 @@ class ViewProviderLinearDimension(ViewProviderDimensionBase):
         return ":/icons/Draft_Dimension_Tree.svg"
 
 
+# Alias for compatibility with v0.18 and earlier
+_ViewProviderDimension = ViewProviderLinearDimension
+
+
 class ViewProviderAngularDimension(ViewProviderDimensionBase):
     """A View Provider for the Draft Angular Dimension object"""
     def __init__(self, vobj):
-
         super(ViewProviderAngularDimension, self).__init__(vobj)
+        super(ViewProviderAngularDimension, self).set_properties(vobj)
 
-        vobj.addProperty("App::PropertyBool","FlipArrows",
-                        "Graphics",QT_TRANSLATE_NOOP("App::Property",
-                        "Rotate the dimension arrows 180 degrees"))
-        
         self.Object = vobj.Object
         vobj.Proxy = self
 
@@ -926,3 +1013,7 @@ class ViewProviderAngularDimension(ViewProviderDimensionBase):
 
     def getIcon(self):
         return ":/icons/Draft_DimensionAngular.svg"
+
+
+# Alias for compatibility with v0.18 and earlier
+_ViewProviderAngularDimension = ViewProviderAngularDimension

--- a/src/Mod/Draft/draftviewproviders/view_draft_annotation.py
+++ b/src/Mod/Draft/draftviewproviders/view_draft_annotation.py
@@ -1,4 +1,6 @@
 # ***************************************************************************
+# *   Copyright (c) 2020 Carlo Pavan <carlopav@gmail.com>                   *
+# *   Copyright (c) 2020 Eliud Cabrera Castillo <e.cabrera-castillo@tum.de> *
 # *                                                                         *
 # *   This file is part of the FreeCAD CAx development system.              *
 # *                                                                         *
@@ -19,127 +21,215 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""This module provides the Draft Annotations view provider base class
-"""
-## @package annotation
-# \ingroup DRAFT
-# \brief This module provides the Draft Annotations view provider base class
+"""Provides the base class for many annotation viewproviders.
 
+This is inherited and used by many viewproviders that show dimensions
+and text created on screen through Coin (pivy).
+- DimensionBase
+- LinearDimension
+- AngularDimension
+- Label
+- Text
+
+Its edit mode launches the `Draft_Edit` command.
+"""
+## @package view_draft_annotation
+# \ingroup DRAFT
+# \brief Provides the base class for many annotation viewproviders.
+
+import json
+from PySide.QtCore import QT_TRANSLATE_NOOP
 
 import FreeCAD as App
-from PySide.QtCore import QT_TRANSLATE_NOOP
+import draftutils.utils as utils
+from draftutils.messages import _msg
 
 if App.GuiUp:
     import FreeCADGui as Gui
 
+param = App.ParamGet("User parameter:BaseApp/Preferences/Mod/Draft")
+
 
 class ViewProviderDraftAnnotation(object):
-    """
-    The base class for Draft Annotation Viewproviders
-    This class is not used directly, but inherited by all annotation
-    view providers.
+    """The base class for Draft Annotation viewproviders.
+
+    This class is intended to be inherited by more specialized viewproviders,
+    for example, `Text`, `LinearDimension`, `RadialDimension`, and `Label`.
     """
 
     def __init__(self, vobj):
-        #vobj.Proxy = self
-        #self.Object = vobj.Object
+        self.set_properties(vobj)
+        self.Object = vobj.Object
+        vobj.Proxy = self
 
-        # annotation properties
-        vobj.addProperty("App::PropertyFloat","ScaleMultiplier",
-                        "Annotation",QT_TRANSLATE_NOOP("App::Property",
-                        "Dimension size overall multiplier"))
-        vobj.addProperty("App::PropertyEnumeration", "AnnotationStyle", 
-                         "Annotation", QT_TRANSLATE_NOOP("App::Property",
-                         "Annotation style"))
+    def set_properties(self, vobj):
+        """Set the properties only if they don't already exist."""
+        properties = vobj.PropertiesList
+        self.set_annotation_properties(vobj, properties)
+        self.set_graphics_properties(vobj, properties)
 
-        # graphics properties
-        vobj.addProperty("App::PropertyFloat","LineWidth",
-                         "Graphics",QT_TRANSLATE_NOOP("App::Property","Line width"))
-        vobj.addProperty("App::PropertyColor","LineColor",
-                         "Graphics",QT_TRANSLATE_NOOP("App::Property","Line color"))  
+    def set_annotation_properties(self, vobj, properties):
+        """Set annotation properties only if they don't already exist."""
+        if "ScaleMultiplier" not in properties:
+            _tip = QT_TRANSLATE_NOOP("App::Property",
+                                     "General scaling factor that affects "
+                                     "the annotation consistently\n"
+                                     "because it scales the text, "
+                                     "and the line decorations, if any,\n"
+                                     "in the same proportion.")
+            vobj.addProperty("App::PropertyFloat",
+                             "ScaleMultiplier",
+                             "Annotation",
+                             _tip)
+            annotation_scale = param.GetFloat("DraftAnnotationScale", 1.0)
+            if annotation_scale != 0:
+                vobj.ScaleMultiplier = 1 / annotation_scale
 
-        param = App.ParamGet("User parameter:BaseApp/Preferences/Mod/Draft")
-        annotation_scale = param.GetFloat("DraftAnnotationScale", 1.0)
-        if annotation_scale != 0:
-            vobj.ScaleMultiplier = 1 / annotation_scale
-        styles =  [key[12:] for key in vobj.Object.Document.Meta.keys() if key.startswith("Draft_Style_")]
-        vobj.AnnotationStyle = [""] + styles
+        if "AnnotationStyle" not in properties:
+            _tip = QT_TRANSLATE_NOOP("App::Property",
+                                     "Annotation style to apply "
+                                     "to this object.\n"
+                                     "When using a saved style "
+                                     "some of the view properties "
+                                     "will become read-only;\n"
+                                     "they will only be editable by changing "
+                                     "the style through "
+                                     "the 'Annotation style editor' tool.")
+            vobj.addProperty("App::PropertyEnumeration",
+                             "AnnotationStyle",
+                             "Annotation",
+                             _tip)
+            styles = []
+            for key in vobj.Object.Document.Meta.keys():
+                if key.startswith("Draft_Style_"):
+                    styles.append(key[12:])
 
+            vobj.AnnotationStyle = [""] + styles
+
+    def set_graphics_properties(self, vobj, properties):
+        """Set graphics properties only if they don't already exist."""
+        if "LineWidth" not in properties:
+            _tip = QT_TRANSLATE_NOOP("App::Property", "Line width")
+            vobj.addProperty("App::PropertyFloat",
+                             "LineWidth",
+                             "Graphics",
+                             _tip)
+
+        if "LineColor" not in properties:
+            _tip = QT_TRANSLATE_NOOP("App::Property", "Line color")
+            vobj.addProperty("App::PropertyColor",
+                             "LineColor",
+                             "Graphics",
+                             _tip)
 
     def __getstate__(self):
+        """Return a tuple of objects to save or None."""
         return None
 
     def __setstate__(self, state):
+        """Set the internal properties from the restored state."""
         return None
 
-    def attach(self,vobj):
+    def attach(self, vobj):
+        """Set up the scene sub-graph of the view provider."""
         self.Object = vobj.Object
-        return
 
     def updateData(self, obj, prop):
+        """Execute when a property from the Proxy class is changed."""
         return
 
     def getDisplayModes(self, vobj):
-        modes=[]
+        """Return the display modes that this viewprovider supports."""
+        modes = []
         return modes
 
     def setDisplayMode(self, mode):
+        """Return the saved display mode."""
         return mode
 
     def onChanged(self, vobj, prop):
-        if (prop == "AnnotationStyle") and hasattr(vobj,"AnnotationStyle"):
-            import gui_annotationstyleeditor
-            if (not vobj.AnnotationStyle) or (vobj.AnnotationStyle == " "):
+        """Execute when a view property is changed."""
+        properties = vobj.PropertiesList
+        meta = vobj.Object.Document.Meta
+
+        if prop == "AnnotationStyle" and "AnnotationStyle" in properties:
+            if not vobj.AnnotationStyle or vobj.AnnotationStyle == " ":
                 # unset style
-                for visprop in gui_annotationstyleeditor.DEFAULT.keys():
-                    if visprop in vobj.PropertiesList:
+                _msg(16 * "-")
+                _msg("Unset style")
+                for visprop in utils.ANNOTATION_STYLE.keys():
+                    if visprop in properties:
                         # make property writable
-                        vobj.setEditorMode(visprop,0)
+                        vobj.setPropertyStatus(visprop, '-ReadOnly')
             else:
                 # set style
-                import json
                 styles = {}
-                for key, value in vobj.Object.Document.Meta.items():
+                for key, value in meta.items():
                     if key.startswith("Draft_Style_"):
-                        styles[key[12:]] = json.loads(value)  
-                if prop.AnnotationStyle in styles:
-                    style = styles[prop.AnnotationStyle]
-                    for visprop in style.keys():
-                        if visprop in vobj.PropertiesList:
-                            try:
-                                getattr(vobj,visprop).setValue(style[visprop])
-                            except:
-                                setattr(vobj,visprop,style[visprop])
-                            # make property read-only
-                            vobj.setEditorMode(visprop,1)
+                        styles[key[12:]] = json.loads(value)
 
-    def execute(self,vobj):
+                if vobj.AnnotationStyle in styles:
+                    _msg(16 * "-")
+                    _msg("Style: {}".format(vobj.AnnotationStyle))
+                    style = styles[vobj.AnnotationStyle]
+                    for visprop in style.keys():
+                        if visprop in properties:
+                            try:
+                                getattr(vobj, visprop).setValue(style[visprop])
+                                _msg("setValue: "
+                                     "'{}', '{}'".format(visprop,
+                                                         style[visprop]))
+                            except AttributeError:
+                                setattr(vobj, visprop, style[visprop])
+                                _msg("setattr: "
+                                     "'{}', '{}'".format(visprop,
+                                                         style[visprop]))
+                            # make property read-only
+                            vobj.setPropertyStatus(visprop, 'ReadOnly')
+
+    def execute(self, vobj):
+        """Execute when the object is created or recomputed."""
         return
 
-    def setEdit(self,vobj,mode=0):
+    def setEdit(self, vobj, mode=0):
+        """Execute the code when entering the specific edit mode.
+
+        Currently only mode 0 works.
+        """
         if mode == 0:
             Gui.runCommand("Draft_Edit")
             return True
         return False
 
-    def unsetEdit(self,vobj,mode=0):
+    def unsetEdit(self, vobj, mode=0):
+        """Execute the code when leaving the specific edit mode.
+
+        Currently only mode 0 works.
+        It runs the finish method of the currently active command, and close
+        the task panel if any.
+        """
         if App.activeDraftCommand:
             App.activeDraftCommand.finish()
         Gui.Control.closeDialog()
         return False
 
     def getIcon(self):
-        return ":/icons/Draft_Draft.svg"
+        """Return the path to the icon used by the view provider."""
+        return ":/icons/Draft_Text.svg"
 
     def claimChildren(self):
-        """perhaps this is not useful???"""
+        """Return objects that will be placed under it in the tree view.
+
+        Editor: perhaps this is not useful???
+        """
         objs = []
-        if hasattr(self.Object,"Base"):
+        if hasattr(self.Object, "Base"):
             objs.append(self.Object.Base)
-        if hasattr(self.Object,"Objects"):
+        if hasattr(self.Object, "Objects"):
             objs.extend(self.Object.Objects)
-        if hasattr(self.Object,"Components"):
+        if hasattr(self.Object, "Components"):
             objs.extend(self.Object.Components)
-        if hasattr(self.Object,"Group"):
+        if hasattr(self.Object, "Group"):
             objs.extend(self.Object.Group)
+
         return objs

--- a/src/Mod/Draft/draftviewproviders/view_label.py
+++ b/src/Mod/Draft/draftviewproviders/view_label.py
@@ -45,79 +45,123 @@ class ViewProviderLabel(ViewProviderDraftAnnotation):
     """A View Provider for the Label annotation object"""
 
     def __init__(self,vobj):
-
         super(ViewProviderLabel, self).__init__(vobj)
 
         self.set_properties(vobj)
-
         self.Object = vobj.Object
         vobj.Proxy = self
 
     def set_properties(self, vobj):
+        """Set the properties only if they don't already exist."""
+        super(ViewProviderLabel, self).set_properties(vobj)
 
-        # Text properties
+        properties = vobj.PropertiesList
+        self.set_text_properties(vobj, properties)
+        self.set_graphics_properties(vobj, properties)
 
-        vobj.addProperty("App::PropertyLength","TextSize",
-                         "Text",QT_TRANSLATE_NOOP("App::Property",
-                         "The size of the text"))
+    def set_text_properties(self, vobj, properties):
+        """Set text properties only if they don't already exist."""
+        if "TextSize" not in properties:
+            _tip = QT_TRANSLATE_NOOP("App::Property",
+                                     "The size of the text")
+            vobj.addProperty("App::PropertyLength",
+                             "TextSize",
+                             "Text",
+                             _tip)
+            vobj.TextSize = utils.get_param("textheight", 1)
 
-        vobj.addProperty("App::PropertyFont","TextFont",
-                         "Text",QT_TRANSLATE_NOOP("App::Property",
-                         "The font of the text"))
+        if "TextFont" not in properties:
+            _tip = QT_TRANSLATE_NOOP("App::Property",
+                                     "The font of the text")
+            vobj.addProperty("App::PropertyFont",
+                             "TextFont",
+                             "Text",
+                             _tip)
+            vobj.TextFont = utils.get_param("textfont")
 
-        vobj.addProperty("App::PropertyEnumeration","TextAlignment",
-                         "Text",QT_TRANSLATE_NOOP("App::Property",
-                         "The vertical alignment of the text"))
+        if "TextAlignment" not in properties:
+            _tip = QT_TRANSLATE_NOOP("App::Property",
+                                     "The vertical alignment of the text")
+            vobj.addProperty("App::PropertyEnumeration",
+                             "TextAlignment",
+                             "Text",
+                             _tip)
+            vobj.TextAlignment = ["Top", "Middle", "Bottom"]
+            vobj.TextAlignment = "Bottom"
 
-        vobj.addProperty("App::PropertyColor","TextColor",
-                         "Text",QT_TRANSLATE_NOOP("App::Property",
-                         "Text color"))
+        if "TextColor" not in properties:
+            _tip = QT_TRANSLATE_NOOP("App::Property",
+                                     "Text color")
+            vobj.addProperty("App::PropertyColor",
+                             "TextColor",
+                             "Text",
+                             _tip)
 
-        vobj.addProperty("App::PropertyInteger","MaxChars",
-                         "Text",QT_TRANSLATE_NOOP("App::Property",
-                         "The maximum number of characters on each line of the text box"))
+        if "MaxChars" not in properties:
+            _tip = QT_TRANSLATE_NOOP("App::Property",
+                                     "The maximum number of characters "
+                                     "on each line of the text box")
+            vobj.addProperty("App::PropertyInteger",
+                             "MaxChars",
+                             "Text",
+                             _tip)
 
-        # Graphics properties
+    def set_graphics_properties(self, vobj, properties):
+        """Set graphics properties only if they don't already exist."""
+        if "ArrowSize" not in properties:
+            _tip = QT_TRANSLATE_NOOP("App::Property",
+                                     "The size of the arrow")
+            vobj.addProperty("App::PropertyLength",
+                             "ArrowSize",
+                             "Graphics",
+                             _tip)
+            vobj.ArrowSize = utils.get_param("arrowsize", 1)
 
-        vobj.addProperty("App::PropertyLength","ArrowSize",
-                         "Graphics",QT_TRANSLATE_NOOP("App::Property",
-                         "The size of the arrow"))
+        if "ArrowType" not in properties:
+            _tip = QT_TRANSLATE_NOOP("App::Property",
+                                     "The type of arrow of this label")
+            vobj.addProperty("App::PropertyEnumeration",
+                             "ArrowType",
+                             "Graphics",
+                             _tip)
+            vobj.ArrowType = utils.ARROW_TYPES
+            vobj.ArrowType = utils.ARROW_TYPES[utils.get_param("dimsymbol")]
 
-        vobj.addProperty("App::PropertyEnumeration","ArrowType",
-                         "Graphics",QT_TRANSLATE_NOOP("App::Property",
-                         "The type of arrow of this label"))
+        if "Frame" not in properties:
+            _tip = QT_TRANSLATE_NOOP("App::Property",
+                                     "The type of frame around the text "
+                                     "of this object")
+            vobj.addProperty("App::PropertyEnumeration",
+                             "Frame",
+                             "Graphics",
+                             _tip)
+            vobj.Frame = ["None", "Rectangle"]
 
-        vobj.addProperty("App::PropertyEnumeration","Frame",
-                         "Graphics",QT_TRANSLATE_NOOP("App::Property",
-                         "The type of frame around the text of this object"))
+        if "Line" not in properties:
+            _tip = QT_TRANSLATE_NOOP("App::Property",
+                                     "Display a leader line or not")
+            vobj.addProperty("App::PropertyBool",
+                             "Line",
+                             "Graphics",
+                             _tip)
+            vobj.Line = True
 
-        vobj.addProperty("App::PropertyBool","Line",
-                         "Graphics",QT_TRANSLATE_NOOP("App::Property",
-                         "Display a leader line or not"))
+        if "LineWidth" not in properties:
+            _tip = QT_TRANSLATE_NOOP("App::Property",
+                                     "Line width")
+            vobj.addProperty("App::PropertyFloat",
+                             "LineWidth",
+                             "Graphics",
+                             _tip)
+            vobj.LineWidth = utils.get_param("linewidth", 1)
 
-        vobj.addProperty("App::PropertyFloat","LineWidth",
-                         "Graphics",QT_TRANSLATE_NOOP("App::Property",
-                         "Line width"))
-
-        vobj.addProperty("App::PropertyColor","LineColor",
-                         "Graphics",QT_TRANSLATE_NOOP("App::Property",
-                         "Line color"))
-
-        self.Object = vobj.Object
-        vobj.TextAlignment = ["Top","Middle","Bottom"]
-        vobj.TextAlignment = "Middle"
-        vobj.LineWidth = utils.get_param("linewidth",1)
-        vobj.TextFont = utils.get_param("textfont")
-        vobj.TextSize = utils.get_param("textheight",1)
-        vobj.ArrowSize = utils.get_param("arrowsize",1)
-        vobj.ArrowType = utils.ARROW_TYPES
-        vobj.ArrowType = utils.ARROW_TYPES[utils.get_param("dimsymbol")]
-        vobj.Frame = ["None","Rectangle"]
-        vobj.Line = True
-        param = App.ParamGet("User parameter:BaseApp/Preferences/Mod/Draft")
-        annotation_scale = param.GetFloat("DraftAnnotationScale", 1.0)
-        vobj.ScaleMultiplier = 1 / annotation_scale
-
+        if "LineColor" not in properties:
+            _tip = QT_TRANSLATE_NOOP("App::Property",
+                                     "Line color")
+            vobj.addProperty("App::PropertyColor",
+                             "LineColor",
+                             "Graphics",
+                             _tip)
 
     def getIcon(self):
         return ":/icons/Draft_Label.svg"
@@ -322,3 +366,7 @@ class ViewProviderLabel(ViewProviderDraftAnnotation):
         pos = vobj.Object.Placement.Base.add(v)
         self.textpos.translation.setValue(pos)
         self.textpos.rotation.setValue(vobj.Object.Placement.Rotation.Q)
+
+
+# Alias for compatibility with v0.18 and earlier
+ViewProviderDraftLabel = ViewProviderLabel

--- a/src/Mod/Draft/draftviewproviders/view_label.py
+++ b/src/Mod/Draft/draftviewproviders/view_label.py
@@ -276,7 +276,10 @@ class ViewProviderLabel(ViewProviderDraftAnnotation):
         text.getBoundingBox(b)
         return b.getBoundingBox().getSize().getValue()
 
-    def onChanged(self,vobj,prop):
+    def onChanged(self, vobj, prop):
+        """Execute when a view property is changed."""
+        super(ViewProviderLabel, self).onChanged(vobj, prop)
+
         if prop == "ScaleMultiplier":
             if not hasattr(vobj,"ScaleMultiplier"):
                 return

--- a/src/Mod/Draft/draftviewproviders/view_text.py
+++ b/src/Mod/Draft/draftviewproviders/view_text.py
@@ -43,41 +43,59 @@ class ViewProviderText(ViewProviderDraftAnnotation):
 
 
     def __init__(self,vobj):
-
         super(ViewProviderText, self).__init__(vobj)
 
         self.set_properties(vobj)
-
         self.Object = vobj.Object
         vobj.Proxy = self
 
-
     def set_properties(self, vobj):
+        """Set the properties only if they don't already exist."""
+        super(ViewProviderText, self).set_properties(vobj)
+        properties = vobj.PropertiesList
 
-        vobj.addProperty("App::PropertyLength","FontSize",
-                         "Text",QT_TRANSLATE_NOOP("App::Property",
-                         "The size of the text"))
-        vobj.addProperty("App::PropertyFont","FontName",
-                         "Text",QT_TRANSLATE_NOOP("App::Property",
-                         "The font of the text"))
-        vobj.addProperty("App::PropertyEnumeration","Justification",
-                         "Text",QT_TRANSLATE_NOOP("App::Property",
-                         "The vertical alignment of the text"))
-        vobj.addProperty("App::PropertyColor","TextColor",
-                         "Text",QT_TRANSLATE_NOOP("App::Property",
-                         "Text color"))
-        vobj.addProperty("App::PropertyFloat","LineSpacing",
-                         "Text",QT_TRANSLATE_NOOP("App::Property",
-                         "Line spacing (relative to font size)"))
+        if "FontSize" not in properties:
+            _tip = QT_TRANSLATE_NOOP("App::Property",
+                                     "The size of the text")
+            vobj.addProperty("App::PropertyLength",
+                             "FontSize",
+                             "Text",
+                             _tip)
+            vobj.FontSize = utils.get_param("textheight", 1)
 
-        param = App.ParamGet("User parameter:BaseApp/Preferences/Mod/Draft")
-        annotation_scale = param.GetFloat("DraftAnnotationScale", 1.0)
-        vobj.ScaleMultiplier = 1 / annotation_scale
+        if "FontName" not in properties:
+            _tip = QT_TRANSLATE_NOOP("App::Property",
+                                     "The font of the text")
+            vobj.addProperty("App::PropertyFont",
+                             "FontName",
+                             "Text",
+                             _tip)
+            vobj.FontName = utils.get_param("textfont", "sans")
 
-        vobj.Justification = ["Left","Center","Right"]
-        vobj.FontName = utils.get_param("textfont","sans")
-        vobj.FontSize = utils.get_param("textheight",1)
+        if "Justification" not in properties:
+            _tip = QT_TRANSLATE_NOOP("App::Property",
+                                     "The vertical alignment of the text")
+            vobj.addProperty("App::PropertyEnumeration",
+                             "Justification",
+                             "Text",
+                             _tip)
+            vobj.Justification = ["Left", "Center", "Right"]
 
+        if "TextColor" not in properties:
+            _tip = QT_TRANSLATE_NOOP("App::Property",
+                                     "Text color")
+            vobj.addProperty("App::PropertyColor",
+                             "TextColor",
+                             "Text",
+                             _tip)
+
+        if "LineSpacing" not in properties:
+            _tip = QT_TRANSLATE_NOOP("App::Property",
+                                     "Line spacing (relative to font size)")
+            vobj.addProperty("App::PropertyFloat",
+                             "LineSpacing",
+                             "Text",
+                             _tip)
 
     def getIcon(self):
         return ":/icons/Draft_Text.svg"

--- a/src/Mod/Draft/draftviewproviders/view_text.py
+++ b/src/Mod/Draft/draftviewproviders/view_text.py
@@ -162,8 +162,10 @@ class ViewProviderText(ViewProviderDraftAnnotation):
             self.trans.translation.setValue(obj.Placement.Base)
             self.trans.rotation.setValue(obj.Placement.Rotation.Q)
 
+    def onChanged(self, vobj, prop):
+        """Execute when a view property is changed."""
+        super(ViewProviderText, self).onChanged(vobj, prop)
 
-    def onChanged(self,vobj,prop):
         if prop == "ScaleMultiplier":
             if "ScaleMultiplier" in vobj.PropertiesList:
                 if vobj.ScaleMultiplier:


### PR DESCRIPTION
In 15c9489885 the `AnnotationStyle` property was added to each `ViewProviderDraftAnnotation` object.

However, that code doesn't work perfectly because the `onChanged` method is not propagated to the derived classes, `ViewProviderDimensionBase`, `ViewProviderLinearDimension`, `ViewProviderAngularDimension`, `ViewProviderLabel`, and `ViewProviderText`.

The property is also added to existing objects by using the `onDocumentRestored` method of the proxy object class.

A bug is fixed in `ViewProviderDraftAnnotation` in order to pick correctly the annotation style.

This follows after #3621.

---

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists