### PR TITLE
[Path] Add new `Slot` operation to PathWB 2D tool group

### DIFF
--- a/src/Mod/Path/CMakeLists.txt
+++ b/src/Mod/Path/CMakeLists.txt
@@ -103,6 +103,8 @@ SET(PathScripts_SRCS
     PathScripts/PathSetupSheetOpPrototypeGui.py
     PathScripts/PathSimpleCopy.py
     PathScripts/PathSimulatorGui.py
+    PathScripts/PathSlot.py
+    PathScripts/PathSlotGui.py
     PathScripts/PathStock.py
     PathScripts/PathStop.py
     PathScripts/PathSurface.py

--- a/src/Mod/Path/Gui/Resources/Path.qrc
+++ b/src/Mod/Path/Gui/Resources/Path.qrc
@@ -57,6 +57,7 @@
         <file>icons/Path-Shape.svg</file>
         <file>icons/Path-SimpleCopy.svg</file>
         <file>icons/Path-Simulator.svg</file>
+        <file>icons/Path-Slot.svg</file>
         <file>icons/Path-Speed.svg</file>
         <file>icons/Path-Stock.svg</file>
         <file>icons/Path-Stop.svg</file>
@@ -106,6 +107,7 @@
         <file>panels/PageOpPocketFullEdit.ui</file>
         <file>panels/PageOpProbeEdit.ui</file>
         <file>panels/PageOpProfileFullEdit.ui</file>
+        <file>panels/PageOpSlotEdit.ui</file>
         <file>panels/PageOpSurfaceEdit.ui</file>
         <file>panels/PageOpWaterlineEdit.ui</file>
         <file>panels/PathEdit.ui</file>

--- a/src/Mod/Path/Gui/Resources/icons/Path-Slot.svg
+++ b/src/Mod/Path/Gui/Resources/icons/Path-Slot.svg
@@ -1,0 +1,754 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   sodipodi:docname="Path-Slot.svg"
+   inkscape:version="1.0 (4035a4fb49, 2020-05-01)"
+   version="1.1"
+   id="svg2816"
+   height="64px"
+   width="64px">
+  <defs
+     id="defs2818">
+    <linearGradient
+       id="linearGradient1830">
+      <stop
+         id="stop1826"
+         offset="0"
+         style="stop-color:#729fcf;stop-opacity:1" />
+      <stop
+         id="stop1828"
+         offset="1"
+         style="stop-color:#204a87;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient1816">
+      <stop
+         style="stop-color:#729fcf;stop-opacity:1"
+         offset="0"
+         id="stop1812" />
+      <stop
+         style="stop-color:#204a87;stop-opacity:1"
+         offset="1"
+         id="stop1814" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient1802">
+      <stop
+         id="stop1798"
+         offset="0"
+         style="stop-color:#729fcf;stop-opacity:1" />
+      <stop
+         id="stop1800"
+         offset="1"
+         style="stop-color:#204a87;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient1796">
+      <stop
+         id="stop1792"
+         offset="0"
+         style="stop-color:#729fcf;stop-opacity:1" />
+      <stop
+         id="stop1794"
+         offset="1"
+         style="stop-color:#204a87;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient1105">
+      <stop
+         style="stop-color:#729fcf;stop-opacity:1"
+         offset="0"
+         id="stop1101" />
+      <stop
+         style="stop-color:#204a87;stop-opacity:1"
+         offset="1"
+         id="stop1103" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4513">
+      <stop
+         id="stop4515"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="stop4517"
+         offset="1"
+         style="stop-color:#999999;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3681">
+      <stop
+         style="stop-color:#fff110;stop-opacity:1;"
+         offset="0"
+         id="stop3697" />
+      <stop
+         id="stop3685"
+         offset="1"
+         style="stop-color:#cf7008;stop-opacity:1;" />
+    </linearGradient>
+    <inkscape:perspective
+       id="perspective2824"
+       inkscape:persp3d-origin="32 : 21.333333 : 1"
+       inkscape:vp_z="64 : 32 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 32 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       id="perspective3622" />
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       id="perspective3622-9" />
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       id="perspective3653" />
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       id="perspective3675" />
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       id="perspective3697" />
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       id="perspective3720" />
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       id="perspective3742" />
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       id="perspective3764" />
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       id="perspective3785" />
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       id="perspective3806" />
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       id="perspective3806-3" />
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       id="perspective3835" />
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       id="perspective3614" />
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       id="perspective3614-8" />
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       id="perspective3643" />
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       id="perspective3643-3" />
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       id="perspective3672" />
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       id="perspective3672-5" />
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       id="perspective3701" />
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       id="perspective3701-8" />
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       id="perspective3746" />
+    <pattern
+       inkscape:collect="always"
+       xlink:href="#Strips1_1-4"
+       id="pattern5231"
+       patternTransform="matrix(0.67643728,-0.81829155,2.4578314,1.8844554,-26.450606,18.294947)" />
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       id="perspective5224" />
+    <pattern
+       inkscape:collect="always"
+       patternUnits="userSpaceOnUse"
+       width="2"
+       height="1"
+       patternTransform="matrix(0.66772843,-1.0037085,2.4261878,2.3114548,3.4760987,3.534923)"
+       id="Strips1_1-4"
+       inkscape:stockid="Stripes 1:1">
+      <rect
+         style="fill:black;stroke:none"
+         x="0"
+         y="-0.5"
+         width="1"
+         height="2"
+         id="rect4483-4" />
+    </pattern>
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       id="perspective5224-9" />
+    <pattern
+       inkscape:collect="always"
+       xlink:href="#Strips1_1-6"
+       id="pattern5231-4"
+       patternTransform="matrix(0.66772843,-1.0037085,2.4261878,2.3114548,39.618381,8.9692804)" />
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       id="perspective5224-3" />
+    <pattern
+       inkscape:collect="always"
+       patternUnits="userSpaceOnUse"
+       width="2"
+       height="1"
+       patternTransform="matrix(0.66772843,-1.0037085,2.4261878,2.3114548,3.4760987,3.534923)"
+       id="Strips1_1-6"
+       inkscape:stockid="Stripes 1:1">
+      <rect
+         style="fill:black;stroke:none"
+         x="0"
+         y="-0.5"
+         width="1"
+         height="2"
+         id="rect4483-0" />
+    </pattern>
+    <pattern
+       inkscape:collect="always"
+       xlink:href="#pattern5231-3"
+       id="pattern5296"
+       patternTransform="matrix(0.66513382,-1.0631299,2.4167603,2.4482973,-49.762569,2.9546807)" />
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       id="perspective5288" />
+    <pattern
+       inkscape:collect="always"
+       xlink:href="#Strips1_1-4-3"
+       id="pattern5231-3"
+       patternTransform="matrix(0.66772843,-1.0037085,2.4261878,2.3114548,-26.336284,10.887197)" />
+    <pattern
+       inkscape:collect="always"
+       patternUnits="userSpaceOnUse"
+       width="2"
+       height="1"
+       patternTransform="matrix(0.66772843,-1.0037085,2.4261878,2.3114548,3.4760987,3.534923)"
+       id="Strips1_1-4-3"
+       inkscape:stockid="Stripes 1:1">
+      <rect
+         style="fill:black;stroke:none"
+         x="0"
+         y="-0.5"
+         width="1"
+         height="2"
+         id="rect4483-4-6" />
+    </pattern>
+    <pattern
+       inkscape:collect="always"
+       xlink:href="#Strips1_1-9"
+       id="pattern5330"
+       patternTransform="matrix(0.42844886,-0.62155849,1.5567667,1.431396,27.948414,13.306456)" />
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       id="perspective5323" />
+    <pattern
+       inkscape:collect="always"
+       patternUnits="userSpaceOnUse"
+       width="2"
+       height="1"
+       patternTransform="matrix(0.66772843,-1.0037085,2.4261878,2.3114548,3.4760987,3.534923)"
+       id="Strips1_1-9"
+       inkscape:stockid="Stripes 1:1">
+      <rect
+         style="fill:black;stroke:none"
+         x="0"
+         y="-0.5"
+         width="1"
+         height="2"
+         id="rect4483-3" />
+    </pattern>
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       id="perspective5361" />
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       id="perspective5383" />
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       id="perspective5411" />
+    <linearGradient
+       gradientTransform="translate(127.27273,-51.272729)"
+       gradientUnits="userSpaceOnUse"
+       y2="40.168594"
+       x2="4.0605712"
+       y1="41.087898"
+       x1="37.89756"
+       id="linearGradient3687"
+       xlink:href="#linearGradient3681"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(127.27273,-51.272729)"
+       gradientUnits="userSpaceOnUse"
+       y2="43.558987"
+       x2="59.811455"
+       y1="40.484772"
+       x1="37.894287"
+       id="linearGradient3695"
+       xlink:href="#linearGradient3681"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3681-3">
+      <stop
+         style="stop-color:#fff110;stop-opacity:1;"
+         offset="0"
+         id="stop3697-3" />
+      <stop
+         id="stop3685-4"
+         offset="1"
+         style="stop-color:#cf7008;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3681-3"
+       id="linearGradient3608"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-37.00068,-20.487365)"
+       x1="37.894287"
+       y1="40.484772"
+       x2="59.811455"
+       y2="43.558987" />
+    <linearGradient
+       id="linearGradient4513-2">
+      <stop
+         id="stop4515-2"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="stop4517-4"
+         offset="1"
+         style="stop-color:#999999;stop-opacity:1;" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4513-2"
+       id="radialGradient4538"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,1.1841158,-8.5173246,-3.4097568)"
+       cx="32.151962"
+       cy="7.9319997"
+       fx="32.151962"
+       fy="7.9319997"
+       r="23.634638" />
+    <linearGradient
+       id="linearGradient4513-1">
+      <stop
+         id="stop4515-8"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="stop4517-6"
+         offset="1"
+         style="stop-color:#999999;stop-opacity:1;" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4513-1"
+       id="radialGradient4538-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,1.1841158,-8.5173246,-3.4097568)"
+       cx="32.151962"
+       cy="7.9319997"
+       fx="32.151962"
+       fy="7.9319997"
+       r="23.634638" />
+    <linearGradient
+       id="linearGradient4513-1-3">
+      <stop
+         id="stop4515-8-7"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="stop4517-6-5"
+         offset="1"
+         style="stop-color:#999999;stop-opacity:1;" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4513-1-3"
+       id="radialGradient3069"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.39497909,0,0,1.1841158,-2.716491,-26.067007)"
+       cx="32.151962"
+       cy="35.869175"
+       fx="32.151962"
+       fy="35.869175"
+       r="23.634638" />
+    <linearGradient
+       id="linearGradient4513-1-2">
+      <stop
+         id="stop4515-8-6"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="stop4517-6-6"
+         offset="1"
+         style="stop-color:#999999;stop-opacity:1;" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4513-1-2"
+       id="radialGradient3102"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.39497909,0,0,1.1841158,-2.716491,-26.067007)"
+       cx="32.151962"
+       cy="35.869175"
+       fx="32.151962"
+       fy="35.869175"
+       r="23.634638" />
+    <linearGradient
+       y2="54.227272"
+       x2="36"
+       y1="7.9999995"
+       x1="30.000002"
+       gradientTransform="translate(71.494719,-3.1982556)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4055"
+       xlink:href="#linearGradient4031"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4031">
+      <stop
+         style="stop-color:#d3d7cf;stop-opacity:1"
+         offset="0"
+         id="stop4033" />
+      <stop
+         style="stop-color:#888a85;stop-opacity:1"
+         offset="1"
+         id="stop4035" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1802"
+       id="linearGradient1782"
+       gradientUnits="userSpaceOnUse"
+       x1="-11.999959"
+       y1="49.999989"
+       x2="22"
+       y2="49.999989" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1796"
+       id="linearGradient1790"
+       x1="0"
+       y1="32"
+       x2="54.999825"
+       y2="32.499985"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1816"
+       id="linearGradient1810"
+       x1="43"
+       y1="15"
+       x2="44"
+       y2="63"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1830"
+       id="linearGradient1824"
+       x1="24"
+       y1="-4"
+       x2="26"
+       y2="42"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <sodipodi:namedview
+     inkscape:document-rotation="0"
+     inkscape:window-maximized="1"
+     inkscape:window-y="-8"
+     inkscape:window-x="54"
+     inkscape:window-height="745"
+     inkscape:window-width="1304"
+     inkscape:object-nodes="true"
+     inkscape:object-paths="true"
+     inkscape:snap-bbox-midpoints="true"
+     inkscape:snap-bbox-edge-midpoints="true"
+     inkscape:bbox-nodes="true"
+     inkscape:bbox-paths="true"
+     inkscape:snap-bbox="true"
+     inkscape:grid-bbox="true"
+     inkscape:document-units="px"
+     showgrid="true"
+     inkscape:current-layer="layer1"
+     inkscape:cy="32.924615"
+     inkscape:cx="49.939903"
+     inkscape:zoom="5.6568543"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     borderopacity="1.0"
+     bordercolor="#666666"
+     pagecolor="#ffffff"
+     id="base">
+    <inkscape:grid
+       snapvisiblegridlinesonly="true"
+       enabled="true"
+       visible="true"
+       empspacing="2"
+       id="grid3206"
+       type="xygrid" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata2821">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+        <dc:title>Path-Drilling</dc:title>
+        <dc:date>2015-07-04</dc:date>
+        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>FreeCAD</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:identifier>FreeCAD/src/Mod/Path/Gui/Resources/icons/Path-Drilling.svg</dc:identifier>
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>FreeCAD LGPL2+</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <cc:license>https://www.gnu.org/copyleft/lesser.html</cc:license>
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title>[agryson] Alexander Gryson</dc:title>
+          </cc:Agent>
+        </dc:contributor>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     inkscape:label="Layer 1"
+     id="layer1">
+    <path
+       style="fill:url(#linearGradient1810);fill-opacity:1;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 21,63 62,45 V 16 l -8,3.5 V 41 l -19,8 v -6 l -14,6 z"
+       id="path1065"
+       sodipodi:nodetypes="ccccccccc" />
+    <path
+       style="fill:url(#linearGradient1782);fill-opacity:1;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 21,63 2,54 V 40 l 19,9 z"
+       id="path1067"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="fill:#729fcf;fill-opacity:1;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 54,20 16,2 h 17 l 29,14 z"
+       id="path1071"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="fill:url(#linearGradient1824);fill-opacity:1;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 54,41 2,18 V 2 h 14 l 38,18 z"
+       id="path1073"
+       sodipodi:nodetypes="cccccc" />
+    <path
+       style="fill:url(#linearGradient1790);fill-opacity:1;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 34,44 2,28 V 16 l 52,25 -20,8 z"
+       id="path1075"
+       sodipodi:nodetypes="cccccc" />
+    <path
+       style="fill:none;stroke:#729fcf;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 23,50 v 9.9 L 60,44 V 19.2 l -4,2 0,20.8 -24,10 v -5.6 z"
+       id="path1954"
+       sodipodi:nodetypes="ccccccccc" />
+    <path
+       sodipodi:nodetypes="cccccc"
+       id="path951"
+       d="M 4,14.7 4,4 H 15.6 L 52,21.2 52,38 Z"
+       style="fill:none;stroke:#729fcf;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="cccccc"
+       id="path953"
+       d="M 35.5,46.8 V 43 L 3.5,27 v -8.7 l 46.8,22.6 z"
+       style="fill:none;stroke:#729fcf;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       style="fill:#73d216;stroke:#73d216;stroke-width:2.40001;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 4.2000048,21.199992 48.4,42.8 43.4,44.9 4.2000048,25.2 Z"
+       id="path1832"
+       sodipodi:nodetypes="ccccc" />
+    <g
+       transform="matrix(1.3102844,0,0,1.0580737,-92.493731,-16.026037)"
+       id="g3908-1-4">
+      <g
+         id="g3135">
+        <g
+           id="g1950"
+           transform="translate(45.11237,6.084045)">
+          <path
+             sodipodi:nodetypes="ccccc"
+             id="path1908"
+             d="m 47.276881,18.999999 h 12.112717 l -8.88266,28 h -3.230057 z"
+             style="fill:#d3d7cf;stroke:#2e3436;stroke-width:1.79724;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+          <path
+             sodipodi:nodetypes="cccc"
+             id="path1910"
+             d="m 59.389597,18.999999 -8.882659,28 h 8.88266 z"
+             style="fill:#d3d7cf;stroke:#2e3436;stroke-width:1.79724;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+          <path
+             style="fill:#888a85;stroke:#d3d7cf;stroke-width:1.79724;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="m 49.053412,20.898619 v 23.10138 h 0.484509 l 7.429133,-23.2 z"
+             id="path3906-7-4"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="ccccc" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path3906-7-4-1"
+             d="m 52.929482,45.199999 h 4.683584 l -0.08075,-14.4 z"
+             style="fill:#555753;stroke:#d3d7cf;stroke-width:1.79724;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+          <path
+             sodipodi:nodetypes="ccccc"
+             id="path1927"
+             d="m 47.276881,18.999999 v -8 h 12.112716 l 10e-7,8 z"
+             style="fill:#888a85;stroke:#2e3436;stroke-width:1.79724;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+          <path
+             sodipodi:nodetypes="ccccc"
+             inkscape:connector-curvature="0"
+             id="path3906-7-4-0"
+             d="m 49.00035,12.915954 v 4.168092 h 8.665778 v -4.168092 z"
+             style="fill:none;stroke:#d3d7cf;stroke-width:1.83191;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+        </g>
+      </g>
+    </g>
+    <path
+       style="fill:#729fcf;fill-opacity:1;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 34,44 2,28 v 12 l 19,9 z"
+       id="path1069"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="fill:none;stroke:#729fcf;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 4,43 v 9.7 L 19,60 v -9.8 z"
+       id="path1952"
+       sodipodi:nodetypes="ccccc" />
+  </g>
+</svg>

--- a/src/Mod/Path/Gui/Resources/panels/PageOpSlotEdit.ui
+++ b/src/Mod/Path/Gui/Resources/panels/PageOpSlotEdit.ui
@@ -1,0 +1,440 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>350</width>
+    <height>400</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <property name="styleSheet">
+   <string notr="true"/>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QFrame" name="toolOptions">
+     <property name="frameShape">
+      <enum>QFrame::StyledPanel</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Raised</enum>
+     </property>
+     <layout class="QFormLayout" name="formLayout">
+      <property name="bottomMargin">
+       <number>3</number>
+      </property>
+      <item row="0" column="0">
+       <widget class="QLabel" name="toolController_label">
+        <property name="text">
+         <string>ToolController</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QComboBox" name="toolController">
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The tool and its settings to be used for this operation.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QComboBox" name="coolantController"/>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="coolantController_label">
+        <property name="text">
+         <string>Coolant Mode</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QFrame" name="featureReferences">
+     <layout class="QGridLayout" name="gridLayout_3">
+      <property name="topMargin">
+       <number>3</number>
+      </property>
+      <property name="bottomMargin">
+       <number>3</number>
+      </property>
+      <item row="0" column="1">
+       <widget class="QComboBox" name="geo1Reference">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Choose what point to use on the first selected feature.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="editable">
+         <bool>true</bool>
+        </property>
+        <item>
+         <property name="text">
+          <string>Center of Mass</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Center of BoundBox</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Lowest Point</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Highest Point</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Long Edge</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Short Edge</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Vertex</string>
+         </property>
+        </item>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="geo1Reference_label">
+        <property name="text">
+         <string>Start Feature Reference</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="geo2Reference_label">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>End Feature Reference</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QComboBox" name="geo2Reference">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="font">
+         <font>
+          <pointsize>8</pointsize>
+         </font>
+        </property>
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Choose what point to use on the second selected feature.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="editable">
+         <bool>true</bool>
+        </property>
+        <item>
+         <property name="text">
+          <string>Center of Mass</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Center of BoundBox</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Lowest Point</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Highest Point</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Vertex</string>
+         </property>
+        </item>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QFrame" name="customPoints">
+     <property name="frameShape">
+      <enum>QFrame::StyledPanel</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Raised</enum>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_2">
+      <property name="topMargin">
+       <number>3</number>
+      </property>
+      <property name="bottomMargin">
+       <number>3</number>
+      </property>
+      <item>
+       <widget class="QLabel" name="noBaseGeometry">
+        <property name="font">
+         <font>
+          <pointsize>9</pointsize>
+          <weight>50</weight>
+          <bold>false</bold>
+         </font>
+        </property>
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;No Base Geometry selected.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="styleSheet">
+         <string notr="true">color:blue</string>
+        </property>
+        <property name="text">
+         <string>No Base Geometry selected.</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignCenter</set>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="usingCustomPoints">
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Currently using custom point inputs in the Property View of the Data tab.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="text">
+         <string>Currently using custom point inputs available in the Property View of the Data tab.</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignCenter</set>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QFrame" name="extendPath">
+     <layout class="QGridLayout" name="gridLayout_2">
+      <property name="topMargin">
+       <number>3</number>
+      </property>
+      <property name="bottomMargin">
+       <number>3</number>
+      </property>
+      <item row="3" column="0">
+       <widget class="QLabel" name="geo2Extensionlabel">
+        <property name="text">
+         <string>Extend Path End</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="Gui::InputField" name="geo2Extension">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Positive extends the end of the path, negative shortens.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="unit" stdset="0">
+         <string notr="true"/>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="Gui::InputField" name="geo1Extension">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Positive extends the beginning of the path, negative shortens.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="unit" stdset="0">
+         <string notr="true"/>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="geo1Extension_label">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Extend Path Start</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QFrame" name="pathOptions">
+     <property name="frameShape">
+      <enum>QFrame::StyledPanel</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Raised</enum>
+     </property>
+     <layout class="QGridLayout" name="gridLayout">
+      <property name="topMargin">
+       <number>3</number>
+      </property>
+      <property name="bottomMargin">
+       <number>3</number>
+      </property>
+      <item row="0" column="0">
+       <widget class="QLabel" name="layerMode_label">
+        <property name="text">
+         <string>Layer Mode</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QComboBox" name="pathOrientation">
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Choose the path orientation with regard to the feature(s) selected.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <item>
+         <property name="text">
+          <string>Start to End</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Perpendicular</string>
+         </property>
+        </item>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="pathOrientation_label">
+        <property name="text">
+         <string>Path Orientation</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QComboBox" name="layerMode">
+        <property name="font">
+         <font>
+          <pointsize>8</pointsize>
+         </font>
+        </property>
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Complete the operation in a single pass at depth, or mulitiple passes to final depth.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <item>
+         <property name="text">
+          <string>Single-pass</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Multi-pass</string>
+         </property>
+        </item>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QCheckBox" name="reverseDirection">
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enable to reverse the cut direction of the slot path.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="text">
+         <string>Reverse cut direction</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>Gui::InputField</class>
+   <extends>QLineEdit</extends>
+   <header>Gui/InputField.h</header>
+  </customwidget>
+ </customwidgets>
+ <tabstops>
+  <tabstop>toolController</tabstop>
+  <tabstop>coolantController</tabstop>
+  <tabstop>geo1Reference</tabstop>
+  <tabstop>geo2Reference</tabstop>
+  <tabstop>geo1Extension</tabstop>
+  <tabstop>geo2Extension</tabstop>
+  <tabstop>layerMode</tabstop>
+  <tabstop>pathOrientation</tabstop>
+  <tabstop>reverseDirection</tabstop>
+ </tabstops>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/Mod/Path/InitGui.py
+++ b/src/Mod/Path/InitGui.py
@@ -88,14 +88,21 @@ class PathWorkbench (Workbench):
 
         # build commands list
         projcmdlist = ["Path_Job", "Path_Post"]
-        toolcmdlist = ["Path_Inspect", "Path_Simulator", "Path_ToolLibraryEdit", "Path_SelectLoop", "Path_OpActiveToggle"]
-        prepcmdlist = ["Path_Fixture", "Path_Comment", "Path_Stop", "Path_Custom", "Path_Probe"]
-        # twodopcmdlist = ["Path_Profile", "Path_Contour", "Path_Profile_Faces", "Path_Profile_Edges", "Path_Pocket_Shape", "Path_Drilling", "Path_MillFace", "Path_Helix", "Path_Adaptive"]
-        twodopcmdlist = ["Path_Profile", "Path_Pocket_Shape", "Path_Drilling", "Path_MillFace", "Path_Helix", "Path_Adaptive"]
+        toolcmdlist = ["Path_Inspect", "Path_Simulator",
+                       "Path_ToolLibraryEdit", "Path_SelectLoop",
+                       "Path_OpActiveToggle"]
+        prepcmdlist = ["Path_Fixture", "Path_Comment", "Path_Stop",
+                       "Path_Custom", "Path_Probe"]
+        twodopcmdlist = ["Path_Profile", "Path_Pocket_Shape", "Path_Drilling",
+                         "Path_MillFace", "Path_Helix", "Path_Adaptive",
+                         "Path_Slot"]
         threedopcmdlist = ["Path_Pocket_3D"]
         engravecmdlist = ["Path_Engrave", "Path_Deburr"]
         modcmdlist = ["Path_OperationCopy", "Path_Array", "Path_SimpleCopy"]
-        dressupcmdlist = ["Path_DressupAxisMap", "Path_DressupPathBoundary", "Path_DressupDogbone", "Path_DressupDragKnife", "Path_DressupLeadInOut", "Path_DressupRampEntry", "Path_DressupTag", "Path_DressupZCorrect"]
+        dressupcmdlist = ["Path_DressupAxisMap", "Path_DressupPathBoundary",
+                          "Path_DressupDogbone", "Path_DressupDragKnife",
+                          "Path_DressupLeadInOut", "Path_DressupRampEntry",
+                          "Path_DressupTag", "Path_DressupZCorrect"]
         extracmdlist = []
         # modcmdmore = ["Path_Hop",]
         # remotecmdlist = ["Path_Remote"]

--- a/src/Mod/Path/PathScripts/PathGuiInit.py
+++ b/src/Mod/Path/PathScripts/PathGuiInit.py
@@ -72,6 +72,7 @@ def Startup():
         from PathScripts import PathSetupSheetGui
         from PathScripts import PathSimpleCopy
         from PathScripts import PathSimulatorGui
+        from PathScripts import PathSlotGui
         from PathScripts import PathStop
         # from PathScripts import PathSurfaceGui  # Added in initGui.py due to OCL dependency
         from PathScripts import PathToolController

--- a/src/Mod/Path/PathScripts/PathOpGui.py
+++ b/src/Mod/Path/PathScripts/PathOpGui.py
@@ -542,10 +542,8 @@ class TaskPanelBaseGeometryPage(TaskPanelPage):
         for item in selected:
             self.form.baseList.takeItem(self.form.baseList.row(item))
             self.setDirty()
-            self.updatePanelVisibility('Operation', self.obj)
         self.updateBase()
-        # self.obj.Proxy.execute(self.obj)
-        # FreeCAD.ActiveDocument.recompute()
+        self.updatePanelVisibility('Operation', self.obj)
 
     def updateBase(self):
         newlist = []

--- a/src/Mod/Path/PathScripts/PathSelection.py
+++ b/src/Mod/Path/PathScripts/PathSelection.py
@@ -233,6 +233,17 @@ class PROBEGate:
         pass
 
 
+class ALLGate(PathBaseGate):
+    def allow(self, doc, obj, sub): # pylint: disable=unused-argument
+        if sub and sub[0:6] == 'Vertex':
+            return True
+        if sub and sub[0:4] == 'Edge':
+            return True
+        if sub and sub[0:4] == 'Face':
+            return True
+        return False
+
+
 def contourselect():
     FreeCADGui.Selection.addSelectionGate(CONTOURGate())
     FreeCAD.Console.PrintWarning("Contour Select Mode\n")
@@ -278,6 +289,10 @@ def adaptiveselect():
     FreeCAD.Console.PrintWarning("Adaptive Select Mode\n")
 
 
+def slotselect():
+    FreeCADGui.Selection.addSelectionGate(ALLGate())
+    FreeCAD.Console.PrintWarning("Slot Cutter Select Mode\n")
+
 def surfaceselect():
     gate = False
     if(MESHGate() or FACEGate()):
@@ -305,6 +320,7 @@ def select(op):
     opsel['Profile Edges'] = eselect  # (depreciated)
     opsel['Profile Faces'] = fselect  # (depreciated)
     opsel['Profile'] = profileselect
+    opsel['Slot'] = slotselect
     opsel['Surface'] = surfaceselect
     opsel['Waterline'] = surfaceselect
     opsel['Adaptive'] = adaptiveselect

--- a/src/Mod/Path/PathScripts/PathSlot.py
+++ b/src/Mod/Path/PathScripts/PathSlot.py
@@ -1,0 +1,1275 @@
+# -*- coding: utf-8 -*-
+
+# ***************************************************************************
+# *                                                                         *
+# *   Copyright (c) 2020 Russell Johnson (russ4262) <russ4262@gmail.com>    *
+# *                                                                         *
+# *   This program is free software; you can redistribute it and/or modify  *
+# *   it under the terms of the GNU Lesser General Public License (LGPL)    *
+# *   as published by the Free Software Foundation; either version 2 of     *
+# *   the License, or (at your option) any later version.                   *
+# *   for detail see the LICENCE text file.                                 *
+# *                                                                         *
+# *   This program is distributed in the hope that it will be useful,       *
+# *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+# *   GNU Library General Public License for more details.                  *
+# *                                                                         *
+# *   You should have received a copy of the GNU Library General Public     *
+# *   License along with this program; if not, write to the Free Software   *
+# *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
+# *   USA                                                                   *
+# *                                                                         *
+# ***************************************************************************
+
+
+from __future__ import print_function
+
+__title__ = "Path Slot Operation"
+__author__ = "russ4262 (Russell Johnson)"
+__url__ = "http://www.freecadweb.org"
+__doc__ = "Class and implementation of Slot operation."
+__contributors__ = ""
+
+import FreeCAD
+from PySide import QtCore
+import Path
+import PathScripts.PathLog as PathLog
+import PathScripts.PathUtils as PathUtils
+import PathScripts.PathOp as PathOp
+import math
+
+# lazily loaded modules
+from lazy_loader.lazy_loader import LazyLoader
+Part = LazyLoader('Part', globals(), 'Part')
+
+if FreeCAD.GuiUp:
+    import FreeCADGui
+
+PathLog.setLevel(PathLog.Level.INFO, PathLog.thisModule())
+# PathLog.trackModule(PathLog.thisModule())
+
+
+# Qt translation handling
+def translate(context, text, disambig=None):
+    return QtCore.QCoreApplication.translate(context, text, disambig)
+
+
+class ObjectSlot(PathOp.ObjectOp):
+    '''Proxy object for Surfacing operation.'''
+
+    def opFeatures(self, obj):
+        '''opFeatures(obj) ... return all standard features'''
+        return PathOp.FeatureTool | PathOp.FeatureDepths \
+            | PathOp.FeatureHeights | PathOp.FeatureStepDown \
+            | PathOp.FeatureCoolant | PathOp.FeatureBaseVertexes \
+            | PathOp.FeatureBaseEdges | PathOp.FeatureBaseFaces
+
+    def initOperation(self, obj):
+        '''initOperation(obj) ... Initialize the operation by
+        managing property creation and property editor status.'''
+        self.propertiesReady = False
+
+        self.initOpProperties(obj)  # Initialize operation-specific properties
+
+        # For debugging
+        if PathLog.getLevel(PathLog.thisModule()) != 4:
+            obj.setEditorMode('ShowTempObjects', 2)  # hide
+
+        if not hasattr(obj, 'DoNotSetDefaultValues'):
+            self.setEditorProperties(obj)
+
+    def initOpProperties(self, obj, warn=False):
+        '''initOpProperties(obj) ... create operation specific properties'''
+        self.addNewProps = list()
+
+        for (prtyp, nm, grp, tt) in self.opPropertyDefinitions():
+            if not hasattr(obj, nm):
+                obj.addProperty(prtyp, nm, grp, tt)
+                self.addNewProps.append(nm)
+
+        # Set enumeration lists for enumeration properties
+        if len(self.addNewProps) > 0:
+            ENUMS = self.opPropertyEnumerations()
+            for n in ENUMS:
+                if n in self.addNewProps:
+                    setattr(obj, n, ENUMS[n])
+
+            if warn:
+                newPropMsg = translate('PathSlot', 'New property added to')
+                newPropMsg += ' "{}": {}'.format(obj.Label, self.addNewProps) + '. '
+                newPropMsg += translate('PathSlot', 'Check default value(s).')
+                FreeCAD.Console.PrintWarning(newPropMsg + '\n')
+
+        self.propertiesReady = True
+
+    def opPropertyDefinitions(self):
+        '''opPropertyDefinitions(obj) ... Store operation specific properties'''
+
+        return [
+            ("App::PropertyBool", "ShowTempObjects", "Debug",
+                QtCore.QT_TRANSLATE_NOOP("App::Property", "Show the temporary path construction objects when module is in DEBUG mode.")),
+
+            ("App::PropertyVectorDistance", "CustomPoint1", "Slot",
+                QtCore.QT_TRANSLATE_NOOP("App::Property", "Enter custom start point for slot path.")),
+            ("App::PropertyVectorDistance", "CustomPoint2", "Slot",
+                QtCore.QT_TRANSLATE_NOOP("App::Property", "Enter custom end point for slot path.")),
+            ("App::PropertyDistance", "ExtendPathStart", "Slot",
+                QtCore.QT_TRANSLATE_NOOP("App::Property", "Positive extends the beginning of the path, negative shortens.")),
+            ("App::PropertyDistance", "ExtendPathEnd", "Slot",
+                QtCore.QT_TRANSLATE_NOOP("App::Property", "Positive extends the end of the path, negative shortens.")),
+            ("App::PropertyEnumeration", "LayerMode", "Slot",
+                QtCore.QT_TRANSLATE_NOOP("App::Property", "Complete the operation in a single pass at depth, or mulitiple passes to final depth.")),
+            ("App::PropertyEnumeration", "PathOrientation", "Slot",
+                QtCore.QT_TRANSLATE_NOOP("App::Property", "Choose the path orientation with regard to the feature(s) selected.")),
+            ("App::PropertyEnumeration", "Reference1", "Slot",
+                QtCore.QT_TRANSLATE_NOOP("App::Property", "Choose what point to use on the first selected feature.")),
+            ("App::PropertyEnumeration", "Reference2", "Slot",
+                QtCore.QT_TRANSLATE_NOOP("App::Property", "Choose what point to use on the second selected feature.")),
+            ("App::PropertyBool", "ReverseDirection", "Slot",
+                QtCore.QT_TRANSLATE_NOOP("App::Property", "Enable to reverse the cut direction of the slot path.")),
+
+            ("App::PropertyVectorDistance", "StartPoint", "Start Point",
+                QtCore.QT_TRANSLATE_NOOP("App::Property", "The custom start point for the path of this operation")),
+            ("App::PropertyBool", "UseStartPoint", "Start Point",
+                QtCore.QT_TRANSLATE_NOOP("App::Property", "Make True, if specifying a Start Point"))
+        ]
+
+    def opPropertyEnumerations(self):
+        # Enumeration lists for App::PropertyEnumeration properties
+        return {
+            'LayerMode': ['Single-pass', 'Multi-pass'],
+            'PathOrientation': ['Start to End', 'Perpendicular'],
+            'Reference1': ['Center of Mass', 'Center of BoundBox',
+                           'Lowest Point', 'Highest Point', 'Long Edge',
+                           'Short Edge', 'Vertex'],
+            'Reference2': ['Center of Mass', 'Center of BoundBox',
+                           'Lowest Point', 'Highest Point', 'Vertex']
+        }
+
+    def opPropertyDefaults(self, obj, job):
+        '''opPropertyDefaults(obj, job) ... returns a dictionary of default values
+        for the operation's properties.'''
+        defaults = {
+            'CustomPoint1': FreeCAD.Vector(0.0, 0.0, 0.0),
+            'ExtendPathStart': 0.0,
+            'Reference1': 'Center of Mass',
+            'CustomPoint2': FreeCAD.Vector(10.0, 10.0, 0.0),
+            'ExtendPathEnd': 0.0,
+            'Reference2': 'Center of Mass',
+            'LayerMode': 'Single-pass',
+            'PathOrientation': 'Start to End',
+            'ReverseDirection': False,
+
+            # For debugging
+            'ShowTempObjects': False
+        }
+
+        return defaults
+
+    def setEditorProperties(self, obj):
+        # Used to hide inputs in properties list
+        A = B = 2
+        if hasattr(obj, 'Base'):
+            enums2 = self.opPropertyEnumerations()['Reference2']
+            if obj.Base:
+                (base, subsList) = obj.Base[0]
+                subCnt = len(subsList)
+                if subCnt == 1:
+                    # Adjust available enumerations
+                    obj.Reference1 = self._getReference1Enums(subsList[0], True)
+                    A = 0
+                elif subCnt == 2:
+                    # Adjust available enumerations
+                    obj.Reference1 = self._getReference1Enums(subsList[0])
+                    obj.Reference2 = self._getReference2Enums(subsList[1])
+                    A = B = 0
+            else:
+                ENUMS = self.opPropertyEnumerations()
+                obj.Reference1 = ENUMS['Reference1']
+                obj.Reference2 = ENUMS['Reference2']
+
+        obj.setEditorMode('Reference1', A)
+        obj.setEditorMode('Reference2', B)
+
+    def onChanged(self, obj, prop):
+        if hasattr(self, 'propertiesReady'):
+            if self.propertiesReady:
+                if prop in ['Base']:
+                    self.setEditorProperties(obj)
+
+    def opOnDocumentRestored(self, obj):
+        self.propertiesReady = False
+        job = PathUtils.findParentJob(obj)
+
+        self.initOpProperties(obj, warn=True)
+        self.opApplyPropertyDefaults(obj, job, self.addNewProps)
+
+        mode = 2 if PathLog.getLevel(PathLog.thisModule()) != 4 else 0
+        obj.setEditorMode('ShowTempObjects', mode)
+
+        # Repopulate enumerations in case of changes
+        ENUMS = self.opPropertyEnumerations()
+        for n in ENUMS:
+            restore = False
+            if hasattr(obj, n):
+                val = obj.getPropertyByName(n)
+                restore = True
+            setattr(obj, n, ENUMS[n])
+            if restore:
+                setattr(obj, n, val)
+
+        self.setEditorProperties(obj)
+
+    def opApplyPropertyDefaults(self, obj, job, propList):
+        # Set standard property defaults
+        PROP_DFLTS = self.opPropertyDefaults(obj, job)
+        for n in PROP_DFLTS:
+            if n in propList:
+                prop = getattr(obj, n)
+                val = PROP_DFLTS[n]
+                setVal = False
+                if hasattr(prop, 'Value'):
+                    if isinstance(val, int) or isinstance(val, float):
+                        setVal = True
+                if setVal:
+                    propVal = getattr(prop, 'Value')
+                    setattr(prop, 'Value', val)
+                else:
+                    setattr(obj, n, val)
+
+    def opSetDefaultValues(self, obj, job):
+        '''opSetDefaultValues(obj, job) ... initialize defaults'''
+        job = PathUtils.findParentJob(obj)
+
+        self.opApplyPropertyDefaults(obj, job, self.addNewProps)
+
+        # need to overwrite the default depth calculations for facing
+        d = None
+        if job:
+            if job.Stock:
+                d = PathUtils.guessDepths(job.Stock.Shape, None)
+                PathLog.debug("job.Stock exists")
+            else:
+                PathLog.debug("job.Stock NOT exist")
+        else:
+            PathLog.debug("job NOT exist")
+
+        if d is not None:
+            obj.OpFinalDepth.Value = d.final_depth
+            obj.OpStartDepth.Value = d.start_depth
+        else:
+            obj.OpFinalDepth.Value = -10
+            obj.OpStartDepth.Value = 10
+
+        PathLog.debug('Default OpFinalDepth: {}'.format(obj.OpFinalDepth.Value))
+        PathLog.debug('Defualt OpStartDepth: {}'.format(obj.OpStartDepth.Value))
+
+    def opApplyPropertyLimits(self, obj):
+        '''opApplyPropertyLimits(obj) ... Apply necessary limits to user input property values before performing main operation.'''
+        pass
+
+    def opUpdateDepths(self, obj):
+        if hasattr(obj, 'Base') and obj.Base:
+            base, sublist = obj.Base[0]
+            fbb = base.Shape.getElement(sublist[0]).BoundBox
+            zmin = fbb.ZMax
+            for base, sublist in obj.Base:
+                for sub in sublist:
+                    try:
+                        fbb = base.Shape.getElement(sub).BoundBox
+                        zmin = min(zmin, fbb.ZMin)
+                    except Part.OCCError as e:
+                        PathLog.error(e)
+            obj.OpFinalDepth = zmin
+
+    def opExecute(self, obj):
+        '''opExecute(obj) ... process surface operation'''
+        PathLog.track()
+
+        self.cancelOperation = False
+        self.base = None
+        self.shape1 = None
+        self.shape2 = None
+        self.shapeType1 = None
+        self.shapeType2 = None
+        self.shapeLength1 = None
+        self.shapeLength2 = None
+        self.dYdX1 = None
+        self.dYdX2 = None
+        self.bottomEdges = None
+        self.isDebug = False if PathLog.getLevel(PathLog.thisModule()) != 4 else True
+        self.showTempObjects = obj.ShowTempObjects
+        CMDS = list()
+        FCAD = FreeCAD.ActiveDocument
+
+        try:
+            dotIdx = __name__.index('.') + 1
+        except Exception:
+            dotIdx = 0
+        self.module = __name__[dotIdx:]
+
+        if not self.isDebug:
+            self.showTempObjects = False
+        if self.showTempObjects:
+            for grpNm in ['tmpDebugGrp', 'tmpDebugGrp001']:
+                if hasattr(FreeCAD.ActiveDocument, grpNm):
+                    for go in FreeCAD.ActiveDocument.getObject(grpNm).Group:
+                        FreeCAD.ActiveDocument.removeObject(go.Name)
+                    FreeCAD.ActiveDocument.removeObject(grpNm)
+            self.tmpGrp = FreeCAD.ActiveDocument.addObject('App::DocumentObjectGroup', 'tmpDebugGrp')
+            tmpGrpNm = self.tmpGrp.Name
+
+        # Identify parent Job
+        JOB = PathUtils.findParentJob(obj)
+        self.JOB = JOB
+        if JOB is None:
+            PathLog.error(translate('PathSlot', "No JOB"))
+            return
+        self.stockZMin = JOB.Stock.Shape.BoundBox.ZMin
+
+        # Begin GCode for operation with basic information
+        # ... and move cutter to clearance height and startpoint
+        tool = obj.ToolController.Tool
+        toolType = tool.ToolType if hasattr(tool, 'ToolType') else tool.ShapeName
+        output = ''
+        if obj.Comment != '':
+            self.commandlist.append(Path.Command('N ({})'.format(obj.Comment), {}))
+        self.commandlist.append(Path.Command('N ({})'.format(obj.Label), {}))
+        self.commandlist.append(Path.Command('N (Tool type: {})'.format(toolType), {}))
+        self.commandlist.append(Path.Command('N (Compensated Tool Path. Diameter: {})'.format(tool.Diameter), {}))
+        self.commandlist.append(Path.Command('N ({})'.format(output), {}))
+        self.commandlist.append(Path.Command('G0', {'Z': obj.ClearanceHeight.Value, 'F': self.vertRapid}))
+        if obj.UseStartPoint is True:
+            self.commandlist.append(Path.Command('G0', {'X': obj.StartPoint.x, 'Y': obj.StartPoint.y, 'F': self.horizRapid}))
+
+        # Impose property limits
+        self.opApplyPropertyLimits(obj)
+
+        # Calculate default depthparams for operation
+        self.depthParams = PathUtils.depth_params(obj.ClearanceHeight.Value, obj.SafeHeight.Value, obj.StartDepth.Value, obj.StepDown.Value, 0.0, obj.FinalDepth.Value)
+
+        # ######  MAIN COMMANDS FOR OPERATION ######
+
+        cmds = self._makeOperation(obj)
+        if cmds:
+            CMDS.extend(cmds)
+
+        # Save gcode produced
+        CMDS.append(Path.Command('G0', {'Z': obj.ClearanceHeight.Value, 'F': self.vertRapid}))
+        self.commandlist.extend(CMDS)
+
+        # ######  CLOSING COMMANDS FOR OPERATION ######
+
+        # Hide the temporary objects
+        if self.showTempObjects:
+            if FreeCAD.GuiUp:
+                import FreeCADGui
+                FreeCADGui.ActiveDocument.getObject(tmpGrpNm).Visibility = False
+            self.tmpGrp.purgeTouched()
+
+        if self.cancelOperation:
+            FreeCAD.ActiveDocument.openTransaction(translate("PathSlot", "Canceled the Slot operation."))
+            FreeCAD.ActiveDocument.removeObject(obj.Name)
+            FreeCAD.ActiveDocument.commitTransaction()
+
+        return True
+
+    # Control method for operation
+    def _makeOperation(self, obj):
+        """This method controls the overall slot creation process."""
+        pnts = False
+        featureCnt = 0
+
+        def eLen(E):
+            return E.Length
+
+        if not hasattr(obj, 'Base'):
+            msg = translate('PathSlot',
+                    'No Base Geometry object in the operation.')
+            FreeCAD.Console.PrintError(msg + '\n')
+            return False
+
+        # Calculate extensions to slot path
+        begExt, endExt = 0, 0
+        if obj.ExtendPathStart.Value != 0:
+            begExt = obj.ExtendPathStart.Value
+        if obj.ExtendPathEnd.Value != 0:
+            endExt = obj.ExtendPathEnd.Value
+
+        if not obj.Base:
+            # Use custom inputs here
+            p1 = obj.CustomPoint1
+            p2 = obj.CustomPoint2
+            if p1.z == p2.z:
+                pnts = (p1, p2)
+            else:
+                msg = translate('PathSlot',
+                        'Custom points not at same Z height.')
+                FreeCAD.Console.PrintError(msg + '\n')
+                return False
+
+        if pnts:
+            (p1, p2) = pnts
+        else:
+            baseGeom = obj.Base[0]
+            base, subsList = baseGeom
+            self.base = base
+            lenSL = len(subsList)
+            featureCnt = lenSL
+            if lenSL == 1:
+                sub1 = subsList[0]
+                shape_1 = getattr(base.Shape, sub1)
+                self.shape1 = shape_1
+                pnts = self._processSingle(obj, shape_1, sub1)
+            else:
+                sub1 = subsList[0]
+                sub2 = subsList[1]
+                shape_1 = getattr(base.Shape, sub1)
+                shape_2 = getattr(base.Shape, sub2)
+                self.shape1 = shape_1
+                self.shape2 = shape_2
+                pnts = self._processDouble(obj, shape_1, sub1, shape_2, sub2)
+
+        if not pnts:
+            return False
+
+        # Apply perpendicular rotation if requested
+        perpZero = True
+        if obj.PathOrientation == 'Perpendicular':
+            if featureCnt == 2:
+                if self.shapeType1 == 'Face' and self.shapeType2 == 'Face':
+                    if self.bottomEdges:
+                        self.bottomEdges.sort(key=lambda edg: edg.Length, reverse=True)
+                        BE = self.bottomEdges[0]
+                        pnts = self._processSingleVertFace(obj, BE)
+                        perpZero = False
+            if perpZero:
+                (p1, p2) = pnts
+                pnts = self._makePerpendicular(p1, p2, 10.0)
+        else:
+            perpZero = False
+
+        # Reverse direction of path if requested
+        if obj.ReverseDirection:
+            (p2, p1) = pnts
+        else:
+            (p1, p2) = pnts
+
+        # Apply extensions to slot path
+        if perpZero:
+            begExt -= 5.0
+            endExt -= 5.0
+        pnts = self._extendSlot(p1, p2, begExt, endExt)
+
+        if not pnts:
+            return False
+
+        (p1, p2) = pnts
+        if self.isDebug:
+            PathLog.debug('p1, p2: {}, {}'.format(p1, p2))
+            if p1.sub(p2).Length != 0 and self.showTempObjects:
+                O = FreeCAD.ActiveDocument.addObject('Part::Feature', 'tmp_Path')
+                O.Shape = Part.makeLine(p1, p2)
+                O.purgeTouched()
+                self.tmpGrp.addObject(O)
+
+        if featureCnt:
+            obj.CustomPoint1 = p1
+            obj.CustomPoint2 = p2
+
+        if self._lineCollisionCheck(obj, p1, p2):
+            msg = obj.Label + ' '
+            msg += translate('PathSlot',
+                    'operation collides with model.')
+            FreeCAD.Console.PrintWarning(msg + '\n')
+
+        cmds = self._makeGCode(obj, p1, p2)
+        return cmds
+
+    def _makeGCode(self, obj, p1, p2):
+        """This method is the last in the overall slot creation process.
+        It accepts the operation object and two end points for the path.
+        It returns the slot gcode for the operation."""
+        CMDS = list()
+
+        def layerPass(p1, p2, depth):
+            cmds = list()
+            # cmds.append(Path.Command('N (Tool type: {})'.format(toolType), {}))
+            cmds.append(Path.Command('G0', {'X': p1.x, 'Y': p1.y, 'F': self.horizRapid}))
+            cmds.append(Path.Command('G1', {'Z': depth, 'F': self.vertFeed}))
+            cmds.append(Path.Command('G1', {'X': p2.x, 'Y': p2.y, 'F': self.horizFeed}))
+            return cmds
+
+        # CMDS.append(Path.Command('N (Tool type: {})'.format(toolType), {}))
+        # CMDS.append(Path.Command('G0', {'Z': obj.ClearanceHeight.Value, 'F': self.vertRapid}))
+        if obj.LayerMode == 'Single-pass':
+            CMDS.extend(layerPass(p1, p2, obj.FinalDepth.Value))
+            CMDS.append(Path.Command('G0', {'Z': obj.SafeHeight.Value, 'F': self.vertRapid}))
+        else:
+            prvDep = obj.StartDepth.Value
+            for dep in self.depthParams:
+                CMDS.extend(layerPass(p1, p2, dep))
+                CMDS.append(Path.Command('G0', {'Z': prvDep, 'F': self.vertRapid}))
+                prvDep = dep
+            CMDS.append(Path.Command('G0', {'Z': obj.SafeHeight.Value, 'F': self.vertRapid}))
+
+        return CMDS
+
+    # Methods for processing single geometry
+    def _processSingle(self, obj, shape_1, sub1):
+        """This is the control method for slots based on a
+        single Base Geometry feature."""
+        cmds = False
+        make = False
+        cat1 = sub1[:4]
+
+        if cat1 == 'Face':
+            pnts = False
+
+            norm = shape_1.normalAt(0.0, 0.0)
+            PathLog.debug('Face.normalAt(): {}'.format(norm))
+            if norm.z == 1 or norm.z == -1:
+                pnts = self._processSingleHorizFace(obj, shape_1)
+            elif norm.z == 0:
+                faceType = self._getVertFaceType(shape_1)
+                if faceType:
+                    (geo, shp) = faceType
+                    if geo == 'Face':
+                        pnts = self._processSingleComplexFace(obj, shape_1)
+                    if geo == 'Wire':
+                        pnts = self._processSingleVertFace(obj, shp)
+                    if geo == 'Edge':
+                        pnts = self._processSingleVertFace(obj, shp)
+            else:
+                msg = translate('PathSlot',
+                    'The selected face is not oriented horizontally or vertically.')
+                FreeCAD.Console.PrintError(msg + '\n')
+                return False
+
+            if pnts:
+                (p1, p2) = pnts
+                make = True
+
+        elif cat1 == 'Edge':
+            PathLog.debug('Single edge')
+            V1 = shape_1.Vertexes[0]
+            V2 = shape_1.Vertexes[1]
+            p1 = FreeCAD.Vector(V1.X, V1.Y, 0.0)
+            p2 = FreeCAD.Vector(V2.X, V2.Y, 0.0)
+            make = True
+
+        elif cat1 == 'Vert':
+            msg = translate('PathSlot',
+                'Only a vertex selected. Add another feature to the Base Geometry.')
+            FreeCAD.Console.PrintError(msg + '\n')
+
+        if make:
+            return (p1, p2)
+
+        return False
+
+    def _processSingleHorizFace(self, obj, shape):
+        """Determine slot path endpoints from a single horizontally oriented face."""
+        lineTypes = ['Part::GeomLine']
+
+        def getRadians(self, E):
+            vect = self._dXdYdZ(E)
+            norm = self._normalizeVector(vect)
+            rads = self._xyToRadians(norm)
+            deg = math.degrees(rads)
+            if deg >= 180.0:
+                deg -= 180.0
+            return deg
+
+        # Reject triangular faces
+        if len(shape.Edges) < 4:
+            msg = translate('PathSlot',
+                'A single selected face must have four edges minimum.')
+            FreeCAD.Console.PrintError(msg + '\n')
+            return False
+
+        # Create tuples as (edge index, length, angle)
+        eTups = list()
+        for i in range(0, 4):
+            eTups.append((i,
+                             shape.Edges[i].Length,
+                             getRadians(self, shape.Edges[i]))
+                            )
+
+        # Sort tuples by edge angle
+        eTups.sort(key=lambda tup: tup[2])
+        # Identify parallel edges
+        pairs = list()
+        eCnt = len(shape.Edges)
+        lstE = eCnt - 1
+        I = [i for i in range(0, eCnt)]
+        I.append(0)
+        for i in range(0, eCnt):
+            if i < lstE:
+                ni = i + 1
+                A = eTups[i]
+                B = eTups[ni]
+                if abs(A[2] - B[2]) < 0.00000001:  # test slopes(yaw angles)
+                    debug = False
+                    eA = shape.Edges[A[0]]
+                    eB = shape.Edges[B[0]]
+                    if eA.Curve.TypeId not in lineTypes:
+                        debug = eA.Curve.TypeId
+                    if not debug:
+                        if eB.Curve.TypeId not in lineTypes:
+                            debug = eB.Curve.TypeId
+                        else:
+                            pairs.append((eA, eB))
+                    if debug:
+                        msg = 'Erroneous Curve.TypeId: {}'.format(debug)
+                        PathLog.debug(msg)
+
+        pairCnt = len(pairs)
+        if pairCnt > 1:
+            pairs.sort(key=lambda tup: tup[0].Length, reverse=True)
+
+        if pairCnt == 0:
+            msg = translate('PathSlot',
+                'No parallel edges identified.')
+            FreeCAD.Console.PrintError(msg + '\n')
+            return False
+        elif pairCnt == 1:
+            same = pairs[0]
+        else:
+            if obj.Reference1 == 'Long Edge':
+                same = pairs[0]
+            elif obj.Reference1 == 'Short Edge':
+                same = pairs[1]
+            else:
+                msg = 'Reference1 '
+                msg += translate('PathSlot',
+                    'value error.')
+                FreeCAD.Console.PrintError(msg + '\n')
+                return False
+
+        (p1, p2) = self._getOppMidPoints(same)
+        return (p1, p2)
+
+    def _processSingleComplexFace(self, obj, shape):
+        """Determine slot path endpoints from a single complex face."""
+        PNTS = list()
+
+        def zVal(V):
+            return V.z
+
+        for E in shape.Wires[0].Edges:
+            p = self._findLowestEdgePoint(E)
+            PNTS.append(p)
+        PNTS.sort(key=zVal)
+        return (PNTS[0], PNTS[1])
+
+    def _processSingleVertFace(self, obj, shape):
+        """Determine slot path endpoints from a single vertically oriented face
+        with no single bottom edge."""
+        eCnt = len(shape.Edges)
+        V0 = shape.Edges[0].Vertexes[0]
+        V1 = shape.Edges[eCnt - 1].Vertexes[1]
+        v0 = FreeCAD.Vector(V0.X, V0.Y, V0.Z)
+        v1 = FreeCAD.Vector(V1.X, V1.Y, V1.Z)
+
+        dX = V1.X - V0.X
+        dY = V1.Y - V0.Y
+        dZ = V1.Z - V0.Z
+        temp = FreeCAD.Vector(dX, dY, dZ)
+        slope = self._normalizeVector(temp)
+        perpVect = FreeCAD.Vector(-1 * slope.y, slope.x, slope.z)
+        perpVect.multiply(self.tool.Diameter / 2.0)
+
+        # Create offset endpoints for raw slot path
+        a1 = v0.add(perpVect)
+        a2 = v1.add(perpVect)
+        b1 = v0.sub(perpVect)
+        b2 = v1.sub(perpVect)
+        (p1, p2) = self._getCutSidePoints(obj, v0, v1, a1, a2, b1, b2)
+        return (p1, p2)
+
+    # Methods for processing double geometry
+    def _processDouble(self, obj, shape_1, sub1, shape_2, sub2):
+        """This is the control method for slots based on a
+        two Base Geometry features."""
+        cmds = False
+        make = False
+        cat2 = sub2[:4]
+        p1 = None
+        p2 = None
+        dYdX1 = None
+        dYdX2 = None
+        self.bottomEdges = list()
+
+        feature1 = self._processFeature(obj, shape_1, sub1, 1)
+        if not feature1:
+            msg = translate('PathSlot',
+                'Failed to determine point 1 from')
+            FreeCAD.Console.PrintError(msg + ' {}.\n'.format(sub1))
+            return False
+        (p1, dYdX1, shpType) = feature1
+        self.shapeType1 = shpType
+        if dYdX1:
+            self.dYdX1 = dYdX1
+
+        feature2 = self._processFeature(obj, shape_2, sub2, 2)
+        if not feature2:
+            msg = translate('PathSlot',
+                'Failed to determine point 2 from')
+            FreeCAD.Console.PrintError(msg + ' {}.\n'.format(sub2))
+            return False
+        (p2, dYdX2, shpType) = feature2
+        self.shapeType2 = shpType
+        if dYdX2:
+            self.dYdX2 = dYdX2
+
+        # Parallel check for twin face, and face-edge cases
+        if dYdX1 and dYdX2:
+            if not self._isParallel(dYdX1, dYdX2):
+                PathLog.debug('dYdX1, dYdX2: {}, {}'.format(dYdX1, dYdX2))
+                msg = translate('PathSlot',
+                    'Selected geometry not parallel.')
+                FreeCAD.Console.PrintError(msg + '\n')
+                return False
+
+        if p2:
+            return (p1, p2)
+
+        return False
+
+    # Support methods
+    def _dXdYdZ(self, E):
+        v1 = E.Vertexes[0]
+        v2 = E.Vertexes[1]
+        dX = v2.X - v1.X
+        dY = v2.Y - v1.Y
+        dZ = v2.Z - v1.Z
+        return FreeCAD.Vector(dX, dY, dZ)
+
+    def _normalizeVector(self, v):
+        posTol = 0.0000000001
+        negTol = -1 * posTol
+        V = FreeCAD.Vector(v.x, v.y, v.z)
+        V.normalize()
+        x = V.x
+        y = V.y
+        z = V.z
+
+        if V.x != 0 and abs(V.x) < posTol:
+            x = 0.0
+        if V.x != 1 and 1.0 - V.x < posTol:
+            x = 1.0
+        if V.x != -1 and -1.0 - V.x > negTol:
+            x = -1.0
+
+        if V.y != 0 and abs(V.y) < posTol:
+            y = 0.0
+        if V.y != 1 and 1.0 - V.y < posTol:
+            y = 1.0
+        if V.y != -1 and -1.0 - V.y > negTol:
+            y = -1.0
+
+        if V.z != 0 and abs(V.z) < posTol:
+            z = 0.0
+        if V.z != 1 and 1.0 - V.z < posTol:
+            z = 1.0
+        if V.z != -1 and -1.0 - V.z > negTol:
+            z = -1.0
+
+        return FreeCAD.Vector(x, y, z)
+
+    def _getLowestPoint(self, shape_1):
+        # find lowest vertex
+        vMin = shape_1.Vertexes[0]
+        zmin = vMin.Z
+        same = [vMin]
+        for V in shape_1.Vertexes:
+            if V.Z < zmin:
+                zmin = V.Z
+                vMin = V
+            elif V.Z == zmin:
+                same.append(V)
+        if len(same) > 1:
+            X = [E.X for E in same]
+            Y = [E.Y for E in same]
+            avgX = sum(X) / len(X)
+            avgY = sum(Y) / len(Y)
+            return FreeCAD.Vector(avgX, avgY, zmin)
+        else:
+            return FreeCAD.Vector(V.X, V.Y, V.Z)
+
+    def _getHighestPoint(self, shape_1):
+        # find highest vertex
+        vMax = shape_1.Vertexes[0]
+        zmax = vMax.Z
+        same = [vMax]
+        for V in shape_1.Vertexes:
+            if V.Z > zmax:
+                zmax = V.Z
+                vMax = V
+            elif V.Z == zmax:
+                same.append(V)
+        if len(same) > 1:
+            X = [E.X for E in same]
+            Y = [E.Y for E in same]
+            avgX = sum(X) / len(X)
+            avgY = sum(Y) / len(Y)
+            return FreeCAD.Vector(avgX, avgY, zmax)
+        else:
+            return FreeCAD.Vector(V.X, V.Y, V.Z)
+
+    def _processFeature(self, obj, shape, sub, pNum):
+        p = None
+        dYdX = None
+        cat = sub[:4]
+        Ref = getattr(obj, 'Reference' + str(pNum))
+        if cat == 'Face':
+            BE = self._getBottomEdge(shape)
+            if BE:
+                self.bottomEdges.append(BE)
+            # calculate slope of face
+            V0 = shape.Vertexes[0]
+            v1 = shape.CenterOfMass
+            temp = FreeCAD.Vector(v1.x - V0.X, v1.y - V0.Y, 0.0)
+            dYdX = self._normalizeVector(temp)
+
+            # Determine normal vector for face
+            norm = shape.normalAt(0.0, 0.0)
+            # FreeCAD.Console.PrintMessage('{} normal {}.\n'.format(sub, norm))
+            if norm.z != 0:
+                msg = translate('PathSlot',
+                    'The selected face is not oriented vertically:')
+                FreeCAD.Console.PrintError(msg + ' {}.\n'.format(sub))
+                return False
+
+            if Ref == 'Center of Mass':
+                comS = shape.CenterOfMass
+                p = FreeCAD.Vector(comS.x, comS.y, 0.0)
+            elif Ref == 'Center of BoundBox':
+                comS = shape.BoundBox.Center
+                p = FreeCAD.Vector(comS.x, comS.y, 0.0)
+            elif Ref == 'Lowest Point':
+                p = self._getLowestPoint(shape)
+            elif Ref == 'Highest Point':
+                p = self._getHighestPoint(shape)
+
+        elif cat == 'Edge':
+            # calculate slope between end vertexes
+            v0 = shape.Edges[0].Vertexes[0]
+            v1 = shape.Edges[0].Vertexes[1]
+            temp = FreeCAD.Vector(v1.X - v0.X, v1.Y - v0.Y, 0.0)
+            dYdX = self._normalizeVector(temp)
+
+            if Ref == 'Center of Mass':
+                comS = shape.CenterOfMass
+                p = FreeCAD.Vector(comS.x, comS.y, 0.0)
+            elif Ref == 'Center of BoundBox':
+                comS = shape.BoundBox.Center
+                p = FreeCAD.Vector(comS.x, comS.y, 0.0)
+            elif Ref == 'Lowest Point':
+                p = self._findLowestPointOnEdge(shape)
+            elif Ref == 'Highest Point':
+                p = self._findHighestPointOnEdge(shape)
+
+        elif cat == 'Vert':
+            V = shape.Vertexes[0]
+            p = FreeCAD.Vector(V.X, V.Y, 0.0)
+
+        if p:
+            return (p, dYdX, cat)
+
+        return False
+
+    def _extendSlot(self, p1, p2, begExt, endExt):
+        if begExt:
+            beg = p1.sub(p2)
+            beg.normalize()
+            beg.multiply(begExt)
+            n1 = p1.add(beg)
+        else:
+            n1 = p1
+        if endExt:
+            end = p2.sub(p1)
+            end.normalize()
+            end.multiply(endExt)
+            n2 = p2.add(end)
+        else:
+            n2 = p2
+        return (n1, n2)
+
+    def _getEndMidPoints(self, same):
+        # Find mid-points between ends of equal, oppossing edges
+        e0va = same[0].Vertexes[0]
+        e0vb = same[0].Vertexes[1]
+        e1va = same[1].Vertexes[0]
+        e1vb = same[1].Vertexes[1]
+
+        if False:
+            midX1 = (e0va.X + e0vb.X) / 2.0
+            midY1 = (e0va.Y + e0vb.Y) / 2.0
+            midX2 = (e1va.X + e1vb.X) / 2.0
+            midY2 = (e1va.Y + e1vb.Y) / 2.0
+            m1 = FreeCAD.Vector(midX1, midY1, e0va.Z)
+            m2 = FreeCAD.Vector(midX2, midY2, e0va.Z)
+
+        p1 = FreeCAD.Vector(e0va.X, e0va.Y, e0va.Z)
+        p2 = FreeCAD.Vector(e0vb.X, e0vb.Y, e0vb.Z)
+        p3 = FreeCAD.Vector(e1va.X, e1va.Y, e1va.Z)
+        p4 = FreeCAD.Vector(e1vb.X, e1vb.Y, e1vb.Z)
+
+        L0 = Part.makeLine(p1, p2)
+        L1 = Part.makeLine(p3, p4)
+        comL0 = L0.CenterOfMass
+        comL1 = L1.CenterOfMass
+        m1 = FreeCAD.Vector(comL0.x, comL0.y, 0.0)
+        m2 = FreeCAD.Vector(comL1.x, comL1.y, 0.0)
+
+        return (m1, m2)
+
+    def _getOppMidPoints(self, same):
+        # Find mid-points between ends of equal, oppossing edges
+        v1 = same[0].Vertexes[0]
+        v2 = same[0].Vertexes[1]
+        a1 = same[1].Vertexes[0]
+        a2 = same[1].Vertexes[1]
+        midX1 = (v1.X + a2.X) / 2.0
+        midY1 = (v1.Y + a2.Y) / 2.0
+        midX2 = (v2.X + a1.X) / 2.0
+        midY2 = (v2.Y + a1.Y) / 2.0
+        p1 = FreeCAD.Vector(midX1, midY1, v1.Z)
+        p2 = FreeCAD.Vector(midX2, midY2, v1.Z)
+        return (p1, p2)
+
+    def _isParallel(self, dYdX1, dYdX2):
+        if dYdX1.add(dYdX2).Length == 0:
+            return True
+        if ((dYdX1.x + dYdX2.x) / 2.0 == dYdX1.x and
+                (dYdX1.y + dYdX2.y) / 2.0 == dYdX1.y):
+            return True
+        return False
+
+    def _makePerpendicular(self, p1, p2, length):
+        line = Part.makeLine(p1, p2)
+        midPnt = line.CenterOfMass
+
+        halfDist = length / 2.0
+        if self.dYdX1:
+            half = FreeCAD.Vector(self.dYdX1.x, self.dYdX1.y, 0.0).multiply(halfDist)
+            n1 = midPnt.add(half)
+            n2 = midPnt.sub(half)
+            return (n1, n2)
+        elif self.dYdX2:
+            half = FreeCAD.Vector(self.dYdX2.x, self.dYdX2.y, 0.0).multiply(halfDist)
+            n1 = midPnt.add(half)
+            n2 = midPnt.sub(half)
+            return (n1, n2)
+        else:
+            toEnd = p2.sub(p1)
+            factor = halfDist / toEnd.Length
+            perp = FreeCAD.Vector(-1 * toEnd.y, toEnd.x, 0.0)
+            perp.normalize()
+            perp.multiply(halfDist)
+            n1 = midPnt.add(perp)
+            n2 = midPnt.sub(perp)
+            return (n1, n2)
+
+    def _findLowestPointOnEdge(self, E):
+        tol = 0.0000001
+        zMin = E.BoundBox.ZMin
+        # Test first vertex
+        v = E.Vertexes[0]
+        if abs(v.Z - zMin) < tol:
+            return FreeCAD.Vector(v.X, v.Y, v.Z)
+        # Test second vertex
+        v = E.Vertexes[1]
+        if abs(v.Z - zMin) < tol:
+            return FreeCAD.Vector(v.X, v.Y, v.Z)
+        # Test middle point of edge
+        eMidLen = E.Length / 2.0
+        eMidPnt = E.valueAt(E.getParameterByLength(eMidLen))
+        if abs(eMidPnt.z - zMin) < tol:
+            return eMidPnt
+        if E.BoundBox.ZLength < 0.000000001:  # roughly horizontal edge
+            return eMidPnt
+        return self._findLowestEdgePoint(E)
+
+    def _findLowestEdgePoint(self, E):
+        zMin = E.BoundBox.ZMin
+        eLen = E.Length
+        L0 = 0
+        L1 = eLen
+        p0 = None
+        p1 = None
+        cnt = 0
+        while L1 - L0 > 0.00001 and cnt < 2000:
+            adj = (L1 - L0) * 0.1
+            # Get points at L0 and L1 along edge
+            p0 = E.valueAt(E.getParameterByLength(L0))
+            p1 = E.valueAt(E.getParameterByLength(L1))
+            # Adjust points based on proximity to target depth
+            diff0 = p0.z - zMin
+            diff1 = p1.z - zMin
+            if diff0 < diff1:
+                L1 -= adj
+            elif diff0 > diff1:
+                L0 += adj
+            else:
+                L0 += adj
+                L1 -= adj
+            cnt += 1
+        midLen = (L0 + L1) / 2.0
+        return E.valueAt(E.getParameterByLength(midLen))
+
+    def _findHighestPointOnEdge(self, E):
+        tol = 0.0000001
+        zMax = E.BoundBox.ZMax
+        # Test first vertex
+        v = E.Vertexes[0]
+        if abs(zMax - v.Z) < tol:
+            return FreeCAD.Vector(v.X, v.Y, v.Z)
+        # Test second vertex
+        v = E.Vertexes[1]
+        if abs(zMax - v.Z) < tol:
+            return FreeCAD.Vector(v.X, v.Y, v.Z)
+        # Test middle point of edge
+        eMidLen = E.Length / 2.0
+        eMidPnt = E.valueAt(E.getParameterByLength(eMidLen))
+        if abs(zMax - eMidPnt.z) < tol:
+            return eMidPnt
+        if E.BoundBox.ZLength < 0.000000001:  # roughly horizontal edge
+            return eMidPnt
+        return self._findHighestEdgePoint(E)
+
+    def _findHighestEdgePoint(self, E):
+        zMax = E.BoundBox.ZMax
+        eLen = E.Length
+        L0 = 0
+        L1 = eLen
+        p0 = None
+        p1 = None
+        cnt = 0
+        while L1 - L0 > 0.00001 and cnt < 2000:
+            adj = (L1 - L0) * 0.1
+            # Get points at L0 and L1 along edge
+            p0 = E.valueAt(E.getParameterByLength(L0))
+            p1 = E.valueAt(E.getParameterByLength(L1))
+            # Adjust points based on proximity to target depth
+            diff0 = zMax - p0.z
+            diff1 = zMax - p1.z
+            if diff0 < diff1:
+                L1 -= adj
+            elif diff0 > diff1:
+                L0 += adj
+            else:
+                L0 += adj
+                L1 -= adj
+            cnt += 1
+        midLen = (L0 + L1) / 2.0
+        return E.valueAt(E.getParameterByLength(midLen))
+
+    def _xyToRadians(self, v):
+        # Assumes Z value of vector is zero
+        halfPi = math.pi / 2
+
+        if v.y == 1 and v.x == 0:
+            return halfPi
+        if v.y == -1 and v.x == 0:
+            return math.pi + halfPi
+        if v.y == 0 and v.x == 1:
+            return 0.0
+        if v.y == 0 and v.x == -1:
+            return math.pi
+
+        x = abs(v.x)
+        y = abs(v.y)
+        rads = math.atan(y/x)
+        if v.x > 0:
+            if v.y > 0:
+                return rads
+            else:
+                return (2 * math.pi) - rads
+        if v.x < 0:
+            if v.y > 0:
+                return math.pi - rads
+            else:
+                return math.pi + rads
+
+    def _getCutSidePoints(self, obj, v0, v1, a1, a2, b1, b2):
+        ea1 = Part.makeLine(v0, a1)
+        ea2 = Part.makeLine(a1, a2)
+        ea3 = Part.makeLine(a2, v1)
+        ea4 = Part.makeLine(v1, v0)
+        boxA = Part.Face(Part.Wire([ea1, ea2, ea3, ea4]))
+        cubeA = boxA.extrude(FreeCAD.Vector(0.0, 0.0, 1.0))
+        cmnA = self.base.Shape.common(cubeA)
+        eb1 = Part.makeLine(v0, b1)
+        eb2 = Part.makeLine(b1, b2)
+        eb3 = Part.makeLine(b2, v1)
+        eb4 = Part.makeLine(v1, v0)
+        boxB = Part.Face(Part.Wire([eb1, eb2, eb3, eb4]))
+        cubeB = boxB.extrude(FreeCAD.Vector(0.0, 0.0, 1.0))
+        cmnB = self.base.Shape.common(cubeB)
+        if cmnA.Volume > cmnB.Volume:
+            return (b1, b2)
+        return (a1, a2)
+
+    def _getBottomEdge(self, shape):
+        EDGES = list()
+        # Determine if selected face has a single bottom horizontal edge
+        eCnt = len(shape.Edges)
+        eZMin = shape.BoundBox.ZMin
+        for ei in range(0, eCnt):
+            E = shape.Edges[ei]
+            if abs(E.BoundBox.ZMax - eZMin) < 0.00000001:
+                EDGES.append(E)
+        if len(EDGES) == 1:  # single bottom horiz. edge
+            return EDGES[0]
+        return False
+
+    def _getVertFaceType(self, shape):
+        wires = list()
+
+        bottomEdge = self._getBottomEdge(shape)
+        if bottomEdge:
+            return ('Edge', bottomEdge)
+
+        # Extract cross-section of face
+        extFwd = (shape.BoundBox.ZLength * 2.2) + 10
+        extShp = shape.extrude(FreeCAD.Vector(0.0, 0.0, extFwd))
+        sliceZ = shape.BoundBox.ZMin + (extFwd / 2.0)
+        slcs = extShp.slice(FreeCAD.Vector(0, 0, 1), sliceZ)
+        for i in slcs:
+            wires.append(i)
+        if len(wires) > 0:
+            isFace = False
+            csWire = wires[0]
+            if wires[0].isClosed():
+                csWire = Part.Face(wires[0])
+                if csWire.Area > 0:
+                    csWire.translate(FreeCAD.Vector(0.0, 0.0, shape.BoundBox.ZMin - csWire.BoundBox.ZMin))
+                    return ('Face', csWire)
+            return ('Wire', wires[0])
+        return False
+
+    def _getReference1Enums(self, sub, single=False):
+        # Adjust available enumerations
+        enums1 = self.opPropertyEnumerations()['Reference1']
+        for ri in removeIndexesFromReference_1(sub, single):
+            enums1.pop(ri)
+        return enums1
+
+    def _getReference2Enums(self, sub):
+        # Adjust available enumerations
+        enums2 = self.opPropertyEnumerations()['Reference2']
+        for ri in removeIndexesFromReference_2(sub):
+            enums2.pop(ri)
+        return enums2
+
+    def _lineCollisionCheck(self, obj, p1, p2):
+        """Make simple circle with diameter of tool, at start point.
+        Extrude it latterally along path.
+        Extrude it vertically.
+        Check for collision with model."""
+        # Make path travel of tool as 3D solid.
+        rad = self.tool.Diameter / 2.0
+
+        def getPerp(p1, p2, dist):
+            toEnd = p2.sub(p1)
+            factor = dist / toEnd.Length
+            perp = FreeCAD.Vector(-1 * toEnd.y, toEnd.x, 0.0)
+            perp.normalize()
+            perp.multiply(dist)
+            return perp
+
+        ce1 = Part.Wire(Part.makeCircle(rad, p1).Edges)
+        ce2 = Part.Wire(Part.makeCircle(rad, p2).Edges)
+        C1 = Part.Face(ce1)
+        C2 = Part.Face(ce2)
+
+        zTrans = obj.FinalDepth.Value - C1.BoundBox.ZMin
+        C1.translate(FreeCAD.Vector(0.0, 0.0, zTrans))
+        zTrans = obj.FinalDepth.Value - C2.BoundBox.ZMin
+        C2.translate(FreeCAD.Vector(0.0, 0.0, zTrans))
+
+        extFwd = obj.StartDepth.Value - obj.FinalDepth.Value
+        extVect = FreeCAD.Vector(0.0, 0.0, extFwd)
+        startShp = C1.extrude(extVect)
+        endShp = C2.extrude(extVect)
+
+        perp = getPerp(p1, p2, rad)
+        v1 = p1.add(perp)
+        v2 = p1.sub(perp)
+        v3 = p2.sub(perp)
+        v4 = p2.add(perp)
+        e1 = Part.makeLine(v1, v2)
+        e2 = Part.makeLine(v2, v3)
+        e3 = Part.makeLine(v3, v4)
+        e4 = Part.makeLine(v4, v1)
+        edges = Part.__sortEdges__([e1, e2, e3, e4])
+        rectFace = Part.Face(Part.Wire(edges))
+        zTrans = obj.FinalDepth.Value - rectFace.BoundBox.ZMin
+        rectFace.translate(FreeCAD.Vector(0.0, 0.0, zTrans))
+        boxShp = rectFace.extrude(extVect)
+
+        part1 = startShp.fuse(boxShp)
+        pathTravel = part1.fuse(endShp)
+
+        if self.showTempObjects:
+            O = FreeCAD.ActiveDocument.addObject('Part::Feature', 'tmp_PathTravel')
+            O.Shape = pathTravel
+            O.purgeTouched()
+            self.tmpGrp.addObject(O)
+
+        # Check for collision with model
+        try:
+            cmn = self.base.Shape.common(pathTravel)
+            if cmn.Volume > 0.000001:
+                return True
+        except Exception:
+            PathLog.debug('Failed to complete path collision check.')
+
+        return False
+# Eclass
+
+
+# Determine applicable enumerations
+def removeIndexesFromReference_1(sub, single=False):
+    """Determine which enumerations to remove for Reference1 input
+    based upon the feature type(category)."""
+    cat = sub[:4]
+    remIdxs = [6, 5, 4]
+    if cat == 'Face':
+        if single:
+            remIdxs = [6, 3, 2, 1, 0]
+    elif cat == 'Edge':
+        if single:
+            remIdxs = [6, 5, 3, 2, 1, 0]
+    elif cat == 'Vert':
+        remIdxs = [5, 4, 3, 2, 1, 0]
+    return remIdxs
+
+
+def removeIndexesFromReference_2(sub):
+    """Determine which enumerations to remove for Reference2 input
+    based upon the feature type(category)."""
+    cat = sub[:4]
+    remIdxs = [4]
+    # Customize Reference combobox options
+    if cat == 'Vert':
+        remIdxs = [3, 2, 1, 0]
+    return remIdxs
+
+
+
+def SetupProperties():
+    ''' SetupProperties() ... Return list of properties required for operation.'''
+    return [tup[1] for tup in ObjectSlot.opPropertyDefinitions(False)]
+
+
+def Create(name, obj=None):
+    '''Create(name) ... Creates and returns a Slot operation.'''
+    if obj is None:
+        obj = FreeCAD.ActiveDocument.addObject("Path::FeaturePython", name)
+    obj.Proxy = ObjectSlot(obj, name)
+    return obj

--- a/src/Mod/Path/PathScripts/PathSlotGui.py
+++ b/src/Mod/Path/PathScripts/PathSlotGui.py
@@ -1,0 +1,241 @@
+# -*- coding: utf-8 -*-
+
+# ***************************************************************************
+# *                                                                         *
+# *   Copyright (c) 2020 Russell Johnson (russ4262) <russ4262@gmail.com>    *
+# *                                                                         *
+# *   This program is free software; you can redistribute it and/or modify  *
+# *   it under the terms of the GNU Lesser General Public License (LGPL)    *
+# *   as published by the Free Software Foundation; either version 2 of     *
+# *   the License, or (at your option) any later version.                   *
+# *   for detail see the LICENCE text file.                                 *
+# *                                                                         *
+# *   This program is distributed in the hope that it will be useful,       *
+# *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+# *   GNU Library General Public License for more details.                  *
+# *                                                                         *
+# *   You should have received a copy of the GNU Library General Public     *
+# *   License along with this program; if not, write to the Free Software   *
+# *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
+# *   USA                                                                   *
+# *                                                                         *
+# ***************************************************************************
+
+import FreeCAD
+import FreeCADGui
+import PathScripts.PathSlot as PathSlot
+import PathScripts.PathGui as PathGui
+import PathScripts.PathOpGui as PathOpGui
+
+from PySide import QtCore
+
+__title__ = "Path Slot Operation UI"
+__author__ = "russ4262 (Russell Johnson)"
+__url__ = "http://www.freecadweb.org"
+__doc__ = "Slot operation page controller and command implementation."
+__contributors__ = ""
+
+
+class TaskPanelOpPage(PathOpGui.TaskPanelPage):
+    '''Page controller class for the Slot operation.'''
+
+    def initPage(self, obj):
+        # pylint: disable=attribute-defined-outside-init
+        self.CATS = [None, None]
+        self.setTitle("Slot - " + obj.Label)
+        # retrieve property enumerations
+        self.propEnums = PathSlot.ObjectSlot.opPropertyEnumerations(False)
+        # Requirements due to Gui::QuantitySpinBox class use in UI panel
+        self.geo1Extension = PathGui.QuantitySpinBox(self.form.geo1Extension, obj, 'ExtendPathStart')
+        self.geo2Extension = PathGui.QuantitySpinBox(self.form.geo2Extension, obj, 'ExtendPathEnd')
+        # self.updateVisibility()
+
+    def getForm(self):
+        '''getForm() ... returns UI'''
+        # FreeCAD.Console.PrintMessage('getForm()\n')
+        return FreeCADGui.PySideUic.loadUi(":/panels/PageOpSlotEdit.ui")
+
+    def updateQuantitySpinBoxes(self):
+        # FreeCAD.Console.PrintMessage('updateQuantitySpinBoxes()\n')
+        self.geo1Extension.updateSpinBox()
+        self.geo2Extension.updateSpinBox()
+
+    def getFields(self, obj):
+        '''getFields(obj) ... transfers values from UI to obj's proprties'''
+        # FreeCAD.Console.PrintMessage('getFields()\n')
+        self.updateToolController(obj, self.form.toolController)
+        self.updateCoolant(obj, self.form.coolantController)
+
+        obj.Reference1 = str(self.form.geo1Reference.currentText())
+        self.geo1Extension.updateProperty()
+
+        obj.Reference2 = str(self.form.geo2Reference.currentText())
+        self.geo2Extension.updateProperty()
+
+        val = self.propEnums['LayerMode'][self.form.layerMode.currentIndex()]
+        obj.LayerMode = val
+
+        val = self.propEnums['PathOrientation'][self.form.pathOrientation.currentIndex()]
+        obj.PathOrientation = val
+
+        if hasattr(self.form, 'reverseDirection'):
+            obj.ReverseDirection = self.form.reverseDirection.isChecked()
+
+    def setFields(self, obj):
+        '''setFields(obj) ... transfers obj's property values to UI'''
+        # FreeCAD.Console.PrintMessage('setFields()\n')
+        self.updateQuantitySpinBoxes()
+
+        self.setupToolController(obj, self.form.toolController)
+        self.setupCoolant(obj, self.form.coolantController)
+
+        idx = self.propEnums['Reference1'].index(obj.Reference1)
+        self.form.geo1Reference.setCurrentIndex(idx)
+        idx = self.propEnums['Reference2'].index(obj.Reference2)
+        self.form.geo2Reference.setCurrentIndex(idx)
+
+        self.selectInComboBox(obj.LayerMode, self.form.layerMode)
+        self.selectInComboBox(obj.PathOrientation, self.form.pathOrientation)
+
+        if obj.ReverseDirection:
+            self.form.reverseDirection.setCheckState(QtCore.Qt.Checked)
+        else:
+            self.form.reverseDirection.setCheckState(QtCore.Qt.Unchecked)
+
+        # FreeCAD.Console.PrintMessage('... calling updateVisibility()\n')
+        self.updateVisibility()
+
+    def getSignalsForUpdate(self, obj):
+        '''getSignalsForUpdate(obj) ... return list of signals for updating obj'''
+        # FreeCAD.Console.PrintMessage('getSignalsForUpdate()\n')
+        signals = []
+        signals.append(self.form.toolController.currentIndexChanged)
+        signals.append(self.form.coolantController.currentIndexChanged)
+        signals.append(self.form.geo1Extension.editingFinished)
+        signals.append(self.form.geo1Reference.currentIndexChanged)
+        signals.append(self.form.geo2Extension.editingFinished)
+        signals.append(self.form.geo2Reference.currentIndexChanged)
+        signals.append(self.form.layerMode.currentIndexChanged)
+        signals.append(self.form.pathOrientation.currentIndexChanged)
+        signals.append(self.form.reverseDirection.stateChanged)
+        return signals
+
+    def updateVisibility(self, sentObj=None):
+        '''updateVisibility(sentObj=None)... Updates visibility of Tasks panel objects.'''
+        # FreeCAD.Console.PrintMessage('updateVisibility()\n')
+        hideFeatures = True
+        if hasattr(self.obj, 'Base'):
+            if self.obj.Base:
+                self.form.customPoints.hide()
+                self.form.featureReferences.show()
+                self.form.pathOrientation_label.show()
+                self.form.pathOrientation.show()
+                hideFeatures = False
+                base, sublist = self.obj.Base[0]
+                subCnt = len(sublist)
+
+                if subCnt == 1:
+                    # Save value, then reset choices
+                    self.resetRef1Choices()
+                    n1 = sublist[0]
+                    s1 = getattr(base.Shape, n1)
+                    # Show Reference1 and cusomize options within
+                    self.form.geo1Reference.show()
+                    self.form.geo1Reference_label.show()
+                    self.form.geo1Reference_label.setText('Reference:  {}'.format(n1))
+                    self.customizeReference_1(n1, single=True)
+                    # Hide Reference2
+                    self.form.geo2Reference.hide()
+                    self.form.geo2Reference_label.hide()
+                    self.form.geo2Reference_label.setText('End Reference')
+                    if self.CATS[1]:
+                        self.CATS[1] = None
+                elif subCnt == 2:
+                    self.resetRef1Choices()
+                    self.resetRef2Choices()
+                    n1 = sublist[0]
+                    n2 = sublist[1]
+                    s1 = getattr(base.Shape, n1)
+                    s2 = getattr(base.Shape, n2)
+                    # Show Reference1 and cusomize options within
+                    self.form.geo1Reference.show()
+                    self.form.geo1Reference_label.show()
+                    self.form.geo1Reference_label.setText('Start Reference:  {}'.format(n1))
+                    self.customizeReference_1(n1)
+                    # Show Reference2 and cusomize options within
+                    self.form.geo2Reference.show()
+                    self.form.geo2Reference_label.show()
+                    self.form.geo2Reference_label.setText('End Reference:  {}'.format(n2))
+                    self.customizeReference_2(n2)
+            else:
+                self.form.pathOrientation_label.hide()
+                self.form.pathOrientation.hide()
+        if hideFeatures:
+            self.form.featureReferences.hide()
+            self.form.customPoints.show()
+
+    """
+    'Reference1': ['Center of Mass', 'Center of BoundBox',
+                    'Lowest Point', 'Highest Point', 'Long Edge',
+                    'Short Edge', 'Vertex'],
+    'Reference2': ['Center of Mass', 'Center of BoundBox',
+                    'Lowest Point', 'Highest Point', 'Vertex']
+    """
+
+    def customizeReference_1(self, sub, single=False):
+        # Customize Reference1 combobox options
+        # by removing unavailable choices
+        cat = sub[:4]
+        if cat != self.CATS[0]:
+            self.CATS[0] = cat
+            cBox = self.form.geo1Reference
+            cBox.blockSignals(True)
+            for ri in PathSlot.removeIndexesFromReference_1(sub, single):
+                cBox.removeItem(ri)
+            cBox.blockSignals(False)
+
+    def customizeReference_2(self, sub):
+        # Customize Reference2 combobox options
+        # by removing unavailable choices
+        cat = sub[:4]
+        if cat != self.CATS[1]:
+            self.CATS[1] = cat
+            cBox = self.form.geo2Reference
+            cBox.blockSignals(True)
+            for ri in PathSlot.removeIndexesFromReference_2(sub):
+                cBox.removeItem(ri)
+            cBox.blockSignals(False)
+            cBox.setCurrentIndex(0)
+
+    def resetRef1Choices(self):
+        # Reset Reference1 choices
+        ref1 = self.form.geo1Reference
+        ref1.blockSignals(True)
+        ref1.clear()  # Empty the combobox
+        ref1.addItems(self.propEnums['Reference1'])
+        ref1.blockSignals(False)
+
+    def resetRef2Choices(self):
+        # Reset Reference2 choices
+        ref2 = self.form.geo2Reference
+        ref2.blockSignals(True)
+        ref2.clear()  # Empty the combobox
+        ref2.addItems(self.propEnums['Reference2'])
+        ref2.blockSignals(False)
+
+    def registerSignalHandlers(self, obj):
+        # FreeCAD.Console.PrintMessage('registerSignalHandlers()\n')
+        # self.form.pathOrientation.currentIndexChanged.connect(self.updateVisibility)
+        pass
+
+
+Command = PathOpGui.SetupOperation('Slot',
+        PathSlot.Create,
+        TaskPanelOpPage,
+        'Path-Slot',
+        QtCore.QT_TRANSLATE_NOOP("Slot", "Slot"),
+        QtCore.QT_TRANSLATE_NOOP("Slot", "Create a Slot operation from selected geometry or custom points."),
+        PathSlot.SetupProperties)
+
+FreeCAD.Console.PrintLog("Loading PathSlotGui... done\n")


### PR DESCRIPTION
New slotting operation:
- Accepts selection of up to two features.
- Selectable features include: faces, edges, and vertices.
- User may select a single face or edge, or a pair of features.
- The path may be extended at the start and end.
- The path may be reversed.
- The path may be altered to the perpendicular in some cases.
- A unique Slot icon is included.
- Includes simple collision detection with warning message.
![Slot_operation_1-640x480](https://user-images.githubusercontent.com/47639332/84984161-e72f3080-b0ff-11ea-829c-2515b621a49a.png)
![Slot_operation_2-640x480](https://user-images.githubusercontent.com/47639332/84984168-eb5b4e00-b0ff-11ea-9173-04f46f6addc7.png)
![Slot_operation_TasksPanel](https://user-images.githubusercontent.com/47639332/84984174-ef876b80-b0ff-11ea-9729-be3d79d53be5.png)

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
