### PR TITLE
[Path] Add icons to Tasks Window tabs

### DIFF
--- a/src/Mod/Path/Gui/Resources/panels/PageBaseGeometryEdit.ui
+++ b/src/Mod/Path/Gui/Resources/panels/PageBaseGeometryEdit.ui
@@ -7,67 +7,29 @@
     <x>0</x>
     <y>0</y>
     <width>400</width>
-    <height>400</height>
+    <height>250</height>
    </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
   </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
+  <property name="windowIcon">
+   <iconset resource="../Path.qrc">
+    <normaloff>:/icons/Path-BaseGeometry.svg</normaloff>:/icons/Path-BaseGeometry.svg</iconset>
+  </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <layout class="QGridLayout" name="gridLayout">
-     <item row="2" column="0">
-      <widget class="QPushButton" name="addBase">
-       <property name="toolTip">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Add selected features to the list of base geometries for this operation.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-       </property>
+     <item row="0" column="2">
+      <widget class="QPushButton" name="geometryImportButton">
        <property name="text">
-        <string>Add</string>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="2">
-      <widget class="QPushButton" name="clearBase">
-       <property name="toolTip">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Clears list of base geometries.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-       </property>
-       <property name="text">
-        <string>Clear</string>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="0" colspan="3">
-      <widget class="QLabel" name="label">
-       <property name="text">
-        <string>All objects will be processed using the same operation properties</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-       <property name="wordWrap">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="0" colspan="3">
-      <widget class="QListWidget" name="baseList">
-       <property name="enabled">
-        <bool>true</bool>
-       </property>
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Expanding" vsizetype="MinimumExpanding">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>0</width>
-         <height>25</height>
-        </size>
-       </property>
-       <property name="toolTip">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Select one or more features in the 3d view and press 'Add' to add them as the base items for this operation.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Selected features can be deleted entirely.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        <string>Import</string>
        </property>
       </widget>
      </item>
@@ -78,13 +40,6 @@
        </property>
        <property name="text">
         <string>Remove</string>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="2">
-      <widget class="QPushButton" name="geometryImportButton">
-       <property name="text">
-        <string>Import</string>
        </property>
       </widget>
      </item>
@@ -101,7 +56,69 @@
        </property>
       </widget>
      </item>
+     <item row="1" column="0" colspan="3">
+      <widget class="QListWidget" name="baseList">
+       <property name="enabled">
+        <bool>true</bool>
+       </property>
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="toolTip">
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Select one or more features in the 3d view and press 'Add' to add them as the base items for this operation.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Selected features can be deleted entirely.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="2">
+      <widget class="QPushButton" name="clearBase">
+       <property name="toolTip">
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Clears list of base geometries.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
+       <property name="text">
+        <string>Clear</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="QPushButton" name="addBase">
+       <property name="toolTip">
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Add selected features to the list of base geometries for this operation.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
+       <property name="text">
+        <string>Add</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="0" colspan="3">
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>All objects will be processed using the same operation properties</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+       <property name="wordWrap">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
     </layout>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
    </item>
   </layout>
  </widget>
@@ -111,6 +128,8 @@
   <tabstop>deleteBase</tabstop>
   <tabstop>clearBase</tabstop>
  </tabstops>
- <resources/>
+ <resources>
+  <include location="../Path.qrc"/>
+ </resources>
  <connections/>
 </ui>

--- a/src/Mod/Path/Gui/Resources/panels/PageDepthsEdit.ui
+++ b/src/Mod/Path/Gui/Resources/panels/PageDepthsEdit.ui
@@ -7,11 +7,15 @@
     <x>0</x>
     <y>0</y>
     <width>345</width>
-    <height>235</height>
+    <height>234</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Form</string>
+  </property>
+  <property name="windowIcon">
+   <iconset resource="../Path.qrc">
+    <normaloff>:/icons/Path-Depths.svg</normaloff>:/icons/Path-Depths.svg</iconset>
   </property>
   <layout class="QGridLayout" name="gridLayout">
    <item row="0" column="1">
@@ -78,7 +82,7 @@
       <string>...</string>
      </property>
      <property name="icon">
-      <iconset resource="../../../../../Gui/Icons/resource.qrc">
+      <iconset>
        <normaloff>:/icons/button_left.svg</normaloff>:/icons/button_left.svg</iconset>
      </property>
     </widget>
@@ -92,7 +96,7 @@
       <string>...</string>
      </property>
      <property name="icon">
-      <iconset resource="../../../../../Gui/Icons/resource.qrc">
+      <iconset>
        <normaloff>:/icons/button_left.svg</normaloff>:/icons/button_left.svg</iconset>
      </property>
     </widget>
@@ -165,7 +169,7 @@
  <customwidgets>
   <customwidget>
    <class>Gui::QuantitySpinBox</class>
-   <extends>QDoubleSpinBox</extends>
+   <extends>QWidget</extends>
    <header>Gui/QuantitySpinBox.h</header>
   </customwidget>
  </customwidgets>
@@ -178,7 +182,7 @@
   <tabstop>finalDepthSet</tabstop>
  </tabstops>
  <resources>
-  <include location="../../../../../Gui/Icons/resource.qrc"/>
+  <include location="../Path.qrc"/>
  </resources>
  <connections/>
 </ui>

--- a/src/Mod/Path/Gui/Resources/panels/PageHeightsEdit.ui
+++ b/src/Mod/Path/Gui/Resources/panels/PageHeightsEdit.ui
@@ -13,6 +13,10 @@
   <property name="windowTitle">
    <string>Form</string>
   </property>
+  <property name="windowIcon">
+   <iconset resource="../Path.qrc">
+    <normaloff>:/icons/Path-Heights.svg</normaloff>:/icons/Path-Heights.svg</iconset>
+  </property>
   <layout class="QGridLayout" name="gridLayout">
    <item row="0" column="0">
     <widget class="QLabel" name="label_7">
@@ -78,7 +82,7 @@
  <customwidgets>
   <customwidget>
    <class>Gui::QuantitySpinBox</class>
-   <extends>QDoubleSpinBox</extends>
+   <extends>QWidget</extends>
    <header>Gui/QuantitySpinBox.h</header>
   </customwidget>
  </customwidgets>

--- a/src/Mod/Path/PathScripts/PathOpGui.py
+++ b/src/Mod/Path/PathScripts/PathOpGui.py
@@ -415,6 +415,8 @@ class TaskPanelBaseGeometryPage(TaskPanelPage):
         super(TaskPanelBaseGeometryPage, self).__init__(obj, features)
 
         self.panelTitle = 'Base Geometry'
+        self.OpIcon = ":/icons/Path-BaseGeometry.svg"
+        self.setIcon(self.OpIcon)
 
     def getForm(self):
         panel = FreeCADGui.PySideUic.loadUi(":/panels/PageBaseGeometryEdit.ui")
@@ -723,6 +725,8 @@ class TaskPanelHeightsPage(TaskPanelPage):
         self.clearanceHeight = None
         self.safeHeight = None
         self.panelTitle = 'Heights'
+        self.OpIcon = ":/icons/Path-Heights.svg"
+        self.setIcon(self.OpIcon)
 
     def getForm(self):
         return FreeCADGui.PySideUic.loadUi(":/panels/PageHeightsEdit.ui")
@@ -765,6 +769,8 @@ class TaskPanelDepthsPage(TaskPanelPage):
         self.finishDepth = None
         self.stepDown = None
         self.panelTitle = 'Depths'
+        self.OpIcon = ":/icons/Path-Depths.svg"
+        self.setIcon(self.OpIcon)
 
     def getForm(self):
         return FreeCADGui.PySideUic.loadUi(":/panels/PageDepthsEdit.ui")
@@ -961,10 +967,16 @@ class TaskPanel(object):
             if taskPanelLayout == 0:
                 for page in self.featurePages:
                     toolbox.addItem(page.form, page.getTitle(obj))
+                    itemIdx = toolbox.count() - 1
+                    if page.icon:
+                        toolbox.setItemIcon(itemIdx, QtGui.QIcon(page.icon))
                 toolbox.setCurrentIndex(len(self.featurePages)-1)
             else:
                 for page in reversed(self.featurePages):
                     toolbox.addItem(page.form, page.getTitle(obj))
+                    itemIdx = toolbox.count() - 1
+                    if page.icon:
+                        toolbox.setItemIcon(itemIdx, QtGui.QIcon(page.icon))
             toolbox.setWindowTitle(opTitle)
             if opPage.getIcon(obj):
                 toolbox.setWindowIcon(QtGui.QIcon(opPage.getIcon(obj)))

--- a/src/Mod/Path/PathScripts/PathOpGui.py
+++ b/src/Mod/Path/PathScripts/PathOpGui.py
@@ -342,14 +342,16 @@ class TaskPanelPage(object):
         pass # pylint: disable=unnecessary-pass
 
     def updateSelection(self, obj, sel):
-        '''updateSelection(obj, sel) ... overwrite to customize UI depending on current selection.
+        '''updateSelection(obj, sel) ...
+        overwrite to customize UI depending on current selection.
         Can safely be overwritten by subclasses.'''
         # pylint: disable=unused-argument
         pass # pylint: disable=unnecessary-pass
 
     # helpers
     def selectInComboBox(self, name, combo):
-        '''selectInComboBox(name, combo) ... helper function to select a specific value in a combo box.'''
+        '''selectInComboBox(name, combo) ...
+        helper function to select a specific value in a combo box.'''
         index = combo.findText(name, QtCore.Qt.MatchFixedString)
         if index >= 0:
             combo.blockSignals(True)
@@ -357,7 +359,9 @@ class TaskPanelPage(object):
             combo.blockSignals(False)
 
     def setupToolController(self, obj, combo):
-        '''setupToolController(obj, combo) ... helper function to setup obj's ToolController in the given combo box.'''
+        '''setupToolController(obj, combo) ...
+        helper function to setup obj's ToolController
+        in the given combo box.'''
         controllers = PathUtils.getToolControllers(self.obj)
         labels = [c.Label for c in controllers]
         combo.blockSignals(True)
@@ -371,13 +375,16 @@ class TaskPanelPage(object):
             self.selectInComboBox(obj.ToolController.Label, combo)
 
     def updateToolController(self, obj, combo):
-        '''updateToolController(obj, combo) ... helper function to update obj's ToolController property if a different one has been selected in the combo box.'''
+        '''updateToolController(obj, combo) ...
+        helper function to update obj's ToolController property if a different
+        one has been selected in the combo box.'''
         tc = PathUtils.findToolController(obj, combo.currentText())
         if obj.ToolController != tc:
             obj.ToolController = tc
 
     def setupCoolant(self, obj, combo):
-        '''setupCoolant(obj, combo) ... helper function to setup obj's Coolant option.'''
+        '''setupCoolant(obj, combo) ...
+        helper function to setup obj's Coolant option.'''
         job = PathUtils.findParentJob(obj)
         options = job.SetupSheet.CoolantModes
         combo.blockSignals(True)
@@ -389,13 +396,18 @@ class TaskPanelPage(object):
             self.selectInComboBox(obj.CoolantMode, combo)
 
     def updateCoolant(self, obj, combo):
-        '''updateCoolant(obj, combo) ... helper function to update obj's Coolant property if a different one has been selected in the combo box.'''
+        '''updateCoolant(obj, combo) ...
+        helper function to update obj's Coolant property if a different
+        one has been selected in the combo box.'''
         option = combo.currentText()
         if hasattr(obj, 'CoolantMode'):
             if obj.CoolantMode != option:
                 obj.CoolantMode = option
 
     def updatePanelVisibility(self, panelTitle, obj):
+        '''updatePanelVisibility(panelTitle, obj) ...
+        Function to call the `updateVisibility()` GUI method of the
+        page whose panel title is as indicated.'''
         if hasattr(self, 'parent'):
             parent = getattr(self, 'parent')
             if parent and hasattr(parent, 'featurePages'):
@@ -424,7 +436,10 @@ class TaskPanelBaseGeometryPage(TaskPanelPage):
         return panel
 
     def modifyPanel(self, panel):
-        # Determine if possible operations are available
+        '''modifyPanel(self, panel) ...
+        Helper method to modify the current form immediately after
+        it is loaded.'''
+        # Determine if Job operations are available with Base Geometry
         availableOps = list()
         ops = self.job.Operations.Group
         for op in ops:
@@ -432,6 +447,7 @@ class TaskPanelBaseGeometryPage(TaskPanelPage):
                 if len(op.Base) > 0:
                     availableOps.append(op.Label)
 
+        # Load available operations into combobox
         if len(availableOps) > 0:
             # Populate the operations list
             addInputs = True


### PR DESCRIPTION
This PR adds pre-existing icons to feature tabs within the Tasks Window editor for: Base Geometry, Heights, and Depths.  It also places the operation-specific icon in the Operation tab.
![task_panel_icons_2](https://user-images.githubusercontent.com/47639332/85070541-9826e100-b17b-11ea-9b28-f36b9e6c6e44.png)

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
