### PR TITLE
Arch: fix calculation of fence objects

### DIFF
--- a/src/Mod/Arch/ArchFence.py
+++ b/src/Mod/Arch/ArchFence.py
@@ -3,6 +3,7 @@ import math
 import FreeCAD
 import ArchComponent
 import Draft
+import draftobjects.patharray as patharray
 
 if FreeCAD.GuiUp:
     import FreeCADGui
@@ -134,8 +135,9 @@ class _Fence(ArchComponent.Component):
         # We want to center the posts on the path. So move them the half width in
         transformationVector = FreeCAD.Vector(0, - postWidth / 2, 0)
 
-        placements = Draft.calculatePlacementsOnPath(
-            rotation, pathwire, obj.NumberOfSections + 1, transformationVector, True)
+        placements = patharray.placements_on_path(rotation, pathwire,
+                                                  obj.NumberOfSections + 1,
+                                                  transformationVector, True)
 
         # The placement of the last object is always the second entry in the list.
         # So we move it to the end


### PR DESCRIPTION
In the past it used the `Draft.calculatePlacementsOnPath` function but this function was moved and modified when the `PathArray` was improved. The `calculatePlacementsOnPath` function was moved to `draftobjects.patharray` and renamed `placements_on_path`.

This doesn't completely fix the Fence object because some other modifications need to be done in the calculation of the paths. It just prevents an error appearing when calling the Arch Fence command.

Forum thread: [Arch Fence Object Sample File Request](https://forum.freecadweb.org/viewtopic.php?f=3&t=47828)

---

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists