### PR TITLE
[TD] add spacing to ProjGroup dialog

### DIFF
--- a/src/Mod/TechDraw/Gui/TaskProjGroup.cpp
+++ b/src/Mod/TechDraw/Gui/TaskProjGroup.cpp
@@ -45,16 +45,16 @@
 #include <Mod/Part/App/PartFeature.h>
 
 #include <Mod/TechDraw/App/DrawPage.h>
+#include <Mod/TechDraw/App/DrawProjGroupItem.h>
+#include <Mod/TechDraw/App/DrawProjGroup.h>
 #include <Mod/TechDraw/App/DrawUtil.h>
 #include <Mod/TechDraw/App/DrawView.h>
 #include <Mod/TechDraw/App/DrawViewPart.h>
 
-#include <Mod/TechDraw/App/DrawProjGroupItem.h>
-#include <Mod/TechDraw/App/DrawProjGroup.h>
-
+#include "ViewProviderPage.h"
 #include "ViewProviderProjGroup.h"
 #include "ViewProviderProjGroupItem.h"
-#include "ViewProviderPage.h"
+
 #include "TaskProjGroup.h"
 #include <Mod/TechDraw/Gui/ui_TaskProjGroup.h>
 
@@ -86,6 +86,13 @@ TaskProjGroup::TaskProjGroup(TechDraw::DrawProjGroup* featView, bool mode) :
         ui->sbScaleDen->setEnabled(false);
     }
 
+    ui->cbAutoDistribute->setChecked(multiView->AutoDistribute.getValue());
+    // disable if no AutoDistribute
+    ui->sbXSpacing->setEnabled(multiView->AutoDistribute.getValue());
+    ui->sbYSpacing->setEnabled(multiView->AutoDistribute.getValue());
+    ui->sbXSpacing->setValue(multiView->spacingX.getValue());
+    ui->sbYSpacing->setValue(multiView->spacingY.getValue());
+
     // Initially toggle view checkboxes if needed
     setupViewCheckboxes(true);
 
@@ -112,6 +119,13 @@ TaskProjGroup::TaskProjGroup(TechDraw::DrawProjGroup* featView, bool mode) :
 //    connect(ui->projection, SIGNAL(currentIndexChanged(int)), this, SLOT(projectionTypeChanged(int)));
     connect(ui->projection, SIGNAL(currentIndexChanged(QString)), this, SLOT(projectionTypeChanged(QString)));
 
+    // Spacing
+    connect(ui->cbAutoDistribute, SIGNAL(clicked(bool)), this, SLOT(AutoDistributeClicked(bool)));
+    connect(ui->sbXSpacing, SIGNAL(valueChanged(double)), this, SLOT(spacingChanged(void)));
+    connect(ui->sbYSpacing, SIGNAL(valueChanged(double)), this, SLOT(spacingChanged(void)));
+    ui->sbXSpacing->setUnit(Base::Unit::Length);
+    ui->sbYSpacing->setUnit(Base::Unit::Length);
+
     m_page = multiView->findParentPage();
     Gui::Document* activeGui = Gui::Application::Instance->getDocument(m_page->getDocument());
     Gui::ViewProvider* vp = activeGui->getViewProvider(m_page);
@@ -135,6 +149,9 @@ void TaskProjGroup::saveGroupState()
         m_saveProjType = multiView->ProjectionType.getValueAsString();
         m_saveScaleType = multiView->ScaleType.getValueAsString();
         m_saveScale = multiView->Scale.getValue();
+        m_saveAutoDistribute = multiView->AutoDistribute.getValue();
+        m_saveSpacingX = multiView->spacingX.getValue();
+        m_saveSpacingY = multiView->spacingY.getValue();
         DrawProjGroupItem* anchor = multiView->getAnchor();
         m_saveDirection = anchor->Direction.getValue();
     }
@@ -154,6 +171,9 @@ void TaskProjGroup::restoreGroupState()
         multiView->ProjectionType.setValue(m_saveProjType.c_str());
         multiView->ScaleType.setValue(m_saveScaleType.c_str()); 
         multiView->Scale.setValue(m_saveScale);
+        multiView->AutoDistribute.setValue(m_saveAutoDistribute);
+        multiView->spacingX.setValue(m_saveSpacingX);
+        multiView->spacingY.setValue(m_saveSpacingY);
         multiView->purgeProjections();
         for(auto & sv : m_saveViewNames) {
             if (sv != "Front") {
@@ -267,6 +287,25 @@ void TaskProjGroup::scaleTypeChanged(int index)
         Base::Console().Log("Error - TaskProjGroup::scaleTypeChanged - unknown scale type: %d\n",index);
         return;
     }
+}
+
+void TaskProjGroup::AutoDistributeClicked(bool b)
+{
+    if (blockUpdate) {
+        return;
+    }
+    multiView->AutoDistribute.setValue(b);
+    multiView->recomputeFeature();
+}
+
+void TaskProjGroup::spacingChanged(void)
+{
+    if (blockUpdate) {
+        return;
+    }
+    multiView->spacingX.setValue(ui->sbXSpacing->value().getValue());
+    multiView->spacingY.setValue(ui->sbYSpacing->value().getValue());
+    multiView->recomputeFeature();
 }
 
 std::pair<int, int> TaskProjGroup::nearestFraction(const double val, const long int maxDenom) const

--- a/src/Mod/TechDraw/Gui/TaskProjGroup.h
+++ b/src/Mod/TechDraw/Gui/TaskProjGroup.h
@@ -85,6 +85,9 @@ protected Q_SLOTS:
 /*    void projectionTypeChanged(int index);*/
     void projectionTypeChanged(QString qText);
     void scaleTypeChanged(int index);
+    void AutoDistributeClicked(bool b);
+    /// Updates item spacing
+    void spacingChanged(void);
     void scaleManuallyChanged(int i);
 
 protected:
@@ -122,6 +125,9 @@ private:
     std::string    m_saveProjType;
     std::string    m_saveScaleType;
     double         m_saveScale;
+    bool           m_saveAutoDistribute;
+    double         m_saveSpacingX;
+    double         m_saveSpacingY;
     Base::Vector3d m_saveDirection;
     std::vector<std::string> m_saveViewNames;
 };

--- a/src/Mod/TechDraw/Gui/TaskProjGroup.ui
+++ b/src/Mod/TechDraw/Gui/TaskProjGroup.ui
@@ -688,7 +688,7 @@ using the given X/Y Spacing</string>
         </size>
        </property>
        <property name="toolTip">
-        <string>Horizontal space between center of projections</string>
+        <string>Horizontal space between border of projections</string>
        </property>
        <property name="keyboardTracking">
         <bool>false</bool>
@@ -754,7 +754,7 @@ using the given X/Y Spacing</string>
         </size>
        </property>
        <property name="toolTip">
-        <string>Vertical space between center of projections</string>
+        <string>Vertical space between border of projections</string>
        </property>
        <property name="keyboardTracking">
         <bool>false</bool>

--- a/src/Mod/TechDraw/Gui/TaskProjGroup.ui
+++ b/src/Mod/TechDraw/Gui/TaskProjGroup.ui
@@ -119,6 +119,9 @@
        <property name="toolTip">
         <string>Scale Numerator</string>
        </property>
+       <property name="keyboardTracking">
+        <bool>false</bool>
+       </property>
        <property name="minimum">
         <number>1</number>
        </property>
@@ -138,6 +141,9 @@
       <widget class="QSpinBox" name="sbScaleDen">
        <property name="toolTip">
         <string>Scale Denominator</string>
+       </property>
+       <property name="keyboardTracking">
+        <bool>false</bool>
        </property>
        <property name="minimum">
         <number>1</number>

--- a/src/Mod/TechDraw/Gui/TaskProjGroup.ui
+++ b/src/Mod/TechDraw/Gui/TaskProjGroup.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>371</width>
-    <height>511</height>
+    <width>250</width>
+    <height>477</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -25,664 +25,788 @@
   <property name="windowTitle">
    <string>Projection Group</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout_2">
+  <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <widget class="QFrame" name="frame">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="frameShape">
-      <enum>QFrame::StyledPanel</enum>
-     </property>
-     <property name="frameShadow">
-      <enum>QFrame::Raised</enum>
-     </property>
-     <layout class="QVBoxLayout" name="verticalLayout_3">
-      <item>
-       <layout class="QVBoxLayout" name="verticalLayout">
-        <property name="sizeConstraint">
-         <enum>QLayout::SetDefaultConstraint</enum>
+    <layout class="QHBoxLayout" name="horizontalLayout_3">
+     <item>
+      <widget class="QLabel" name="label_7">
+       <property name="text">
+        <string>Projection</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QComboBox" name="projection">
+       <property name="toolTip">
+        <string>First or Third Angle</string>
+       </property>
+       <item>
+        <property name="text">
+         <string>First Angle</string>
         </property>
-        <item>
-         <layout class="QHBoxLayout" name="horizontalLayout_3">
-          <item>
-           <widget class="QLabel" name="label_7">
-            <property name="text">
-             <string>Projection</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QComboBox" name="projection">
-            <property name="toolTip">
-             <string>First or Third Angle</string>
-            </property>
-            <item>
-             <property name="text">
-              <string>First Angle</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Third Angle</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Page</string>
-             </property>
-            </item>
-           </widget>
-          </item>
-         </layout>
-        </item>
-        <item>
-         <layout class="QHBoxLayout" name="horizontalLayout_5">
-          <item>
-           <widget class="QLabel" name="label">
-            <property name="text">
-             <string>Scale</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QComboBox" name="cmbScaleType">
-            <property name="toolTip">
-             <string>Scale Page/Auto/Custom</string>
-            </property>
-            <item>
-             <property name="text">
-              <string>Page</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Automatic</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Custom</string>
-             </property>
-            </item>
-           </widget>
-          </item>
-         </layout>
-        </item>
-        <item>
-         <layout class="QHBoxLayout" name="horizontalLayout_6" stretch="0,0,1,0,1">
-          <item>
-           <widget class="QLabel" name="label_2">
-            <property name="text">
-             <string>Custom Scale</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <spacer name="horizontalSpacer_3">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>40</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-          <item>
-           <widget class="QSpinBox" name="sbScaleNum">
-            <property name="toolTip">
-             <string>Scale Numerator</string>
-            </property>
-            <property name="minimum">
-             <number>1</number>
-            </property>
-            <property name="value">
-             <number>1</number>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QLabel" name="label_4">
-            <property name="text">
-             <string>:</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QSpinBox" name="sbScaleDen">
-            <property name="toolTip">
-             <string>Scale Denominator</string>
-            </property>
-            <property name="minimum">
-             <number>1</number>
-            </property>
-            <property name="maximum">
-             <number>999</number>
-            </property>
-            <property name="value">
-             <number>1</number>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </item>
-        <item>
-         <widget class="Line" name="line">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <layout class="QHBoxLayout" name="horizontalLayout_4">
-          <item>
-           <widget class="QLabel" name="label_5">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string>Adjust Primary Direction</string>
-            </property>
-            <property name="scaledContents">
-             <bool>true</bool>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignCenter</set>
-            </property>
-            <property name="indent">
-             <number>0</number>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </item>
-        <item>
-         <layout class="QGridLayout" name="gridLayout" columnstretch="0,0,0">
-          <item row="1" column="1">
-           <widget class="QLineEdit" name="lePrimary">
-            <property name="enabled">
-             <bool>false</bool>
-            </property>
-            <property name="font">
-             <font>
-              <pointsize>11</pointsize>
-              <weight>50</weight>
-              <italic>false</italic>
-              <bold>false</bold>
-             </font>
-            </property>
-            <property name="focusPolicy">
-             <enum>Qt::NoFocus</enum>
-            </property>
-            <property name="toolTip">
-             <string>Current primary view direction</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignCenter</set>
-            </property>
-            <property name="readOnly">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="2">
-           <widget class="QPushButton" name="butRightRotate">
-            <property name="toolTip">
-             <string>Rotate right</string>
-            </property>
-            <property name="text">
-             <string/>
-            </property>
-            <property name="icon">
-             <iconset>
-              <normalon>:/icons/arrow-right.svg</normalon>
-             </iconset>
-            </property>
-            <property name="iconSize">
-             <size>
-              <width>24</width>
-              <height>24</height>
-             </size>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="1">
-           <widget class="QPushButton" name="butTopRotate">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="toolTip">
-             <string>Rotate up</string>
-            </property>
-            <property name="text">
-             <string/>
-            </property>
-            <property name="icon">
-             <iconset>
-              <normalon>:/icons/arrow-up.svg</normalon>
-             </iconset>
-            </property>
-            <property name="iconSize">
-             <size>
-              <width>24</width>
-              <height>24</height>
-             </size>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="0">
-           <widget class="QPushButton" name="butLeftRotate">
-            <property name="toolTip">
-             <string>Rotate left</string>
-            </property>
-            <property name="text">
-             <string/>
-            </property>
-            <property name="icon">
-             <iconset>
-              <normalon>:/icons/arrow-left.svg</normalon>
-             </iconset>
-            </property>
-            <property name="iconSize">
-             <size>
-              <width>24</width>
-              <height>24</height>
-             </size>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="1">
-           <widget class="QPushButton" name="butDownRotate">
-            <property name="toolTip">
-             <string>Rotate down</string>
-            </property>
-            <property name="text">
-             <string/>
-            </property>
-            <property name="icon">
-             <iconset>
-              <normalon>:/icons/arrow-down.svg</normalon>
-             </iconset>
-            </property>
-            <property name="iconSize">
-             <size>
-              <width>24</width>
-              <height>24</height>
-             </size>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="2">
-           <spacer name="horizontalSpacer_7">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>40</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-          <item row="2" column="0">
-           <spacer name="horizontalSpacer_8">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>40</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-         </layout>
-        </item>
-        <item>
-         <widget class="Line" name="line_2">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <layout class="QHBoxLayout" name="horizontalLayout_8">
-          <item>
-           <widget class="QLabel" name="label_6">
-            <property name="text">
-             <string>Secondary Projections</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignCenter</set>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </item>
-        <item>
-         <layout class="QGridLayout" name="gridLayout_2">
-          <item row="5" column="2">
-           <widget class="QCheckBox" name="chkView8">
-            <property name="enabled">
-             <bool>true</bool>
-            </property>
-            <property name="toolTip">
-             <string>Bottom</string>
-            </property>
-            <property name="styleSheet">
-             <string notr="true">QCheckBox::indicator {
-width: 24px;
-height: 24px;
-}
-</string>
-            </property>
-            <property name="text">
-             <string/>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="0">
-           <spacer name="horizontalSpacer">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>40</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-          <item row="3" column="2">
-           <widget class="QCheckBox" name="chkView4">
-            <property name="enabled">
-             <bool>false</bool>
-            </property>
-            <property name="toolTip">
-             <string>Primary</string>
-            </property>
-            <property name="styleSheet">
-             <string notr="true">QCheckBox::indicator {
-width: 24px;
-height: 24px;
-}
-</string>
-            </property>
-            <property name="text">
-             <string/>
-            </property>
-            <property name="checked">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="3">
-           <widget class="QCheckBox" name="chkView5">
-            <property name="toolTip">
-             <string>Right</string>
-            </property>
-            <property name="styleSheet">
-             <string notr="true">QCheckBox::indicator {
-width: 24px;
-height: 24px;
-}
-</string>
-            </property>
-            <property name="text">
-             <string/>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="5">
-           <spacer name="horizontalSpacer_2">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>40</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-          <item row="3" column="1">
-           <widget class="QCheckBox" name="chkView3">
-            <property name="toolTip">
-             <string>Left</string>
-            </property>
-            <property name="styleSheet">
-             <string notr="true">QCheckBox::indicator {
-width: 24px;
-height: 24px;
-}
-</string>
-            </property>
-            <property name="text">
-             <string/>
-            </property>
-           </widget>
-          </item>
-          <item row="5" column="1">
-           <widget class="QCheckBox" name="chkView7">
-            <property name="toolTip">
-             <string>LeftFrontBottom</string>
-            </property>
-            <property name="styleSheet">
-             <string notr="true">QCheckBox::indicator {
-width: 24px;
-height: 24px;
-}
-</string>
-            </property>
-            <property name="text">
-             <string/>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="2">
-           <widget class="QCheckBox" name="chkView1">
-            <property name="toolTip">
-             <string>Top</string>
-            </property>
-            <property name="styleSheet">
-             <string notr="true">QCheckBox::indicator {
-width: 24px;
-height: 24px;
-}
-</string>
-            </property>
-            <property name="text">
-             <string/>
-            </property>
-           </widget>
-          </item>
-          <item row="5" column="3">
-           <widget class="QCheckBox" name="chkView9">
-            <property name="toolTip">
-             <string>RightFrontBottom</string>
-            </property>
-            <property name="styleSheet">
-             <string notr="true">QCheckBox::indicator {
-width: 24px;
-height: 24px;
-}
-</string>
-            </property>
-            <property name="text">
-             <string/>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="3">
-           <widget class="QCheckBox" name="chkView2">
-            <property name="toolTip">
-             <string>RightFrontTop</string>
-            </property>
-            <property name="styleSheet">
-             <string notr="true">QCheckBox::indicator {
-width: 24px;
-height: 24px;
-}
-</string>
-            </property>
-            <property name="text">
-             <string/>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="4">
-           <widget class="QCheckBox" name="chkView6">
-            <property name="toolTip">
-             <string>Rear</string>
-            </property>
-            <property name="styleSheet">
-             <string notr="true">QCheckBox::indicator {
-width: 24px;
-height: 24px;
-}
-</string>
-            </property>
-            <property name="text">
-             <string/>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="1">
-           <widget class="QCheckBox" name="chkView0">
-            <property name="toolTip">
-             <string>LeftFrontTop</string>
-            </property>
-            <property name="styleSheet">
-             <string notr="true">QCheckBox::indicator {
-width: 24px;
-height: 24px;
-}
-</string>
-            </property>
-            <property name="text">
-             <string/>
-            </property>
-            <property name="iconSize">
-             <size>
-              <width>24</width>
-              <height>24</height>
-             </size>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </item>
-        <item>
-         <layout class="QHBoxLayout" name="horizontalLayout">
-          <item>
-           <spacer name="horizontalSpacer_4">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>40</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-          <item>
-           <widget class="QPushButton" name="butCWRotate">
-            <property name="toolTip">
-             <string>Spin CW</string>
-            </property>
-            <property name="text">
-             <string/>
-            </property>
-            <property name="icon">
-             <iconset>
-              <normalon>:/icons/arrow-cw.svg</normalon>
-             </iconset>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <spacer name="horizontalSpacer_6">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>40</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-          <item>
-           <widget class="QPushButton" name="butCCWRotate">
-            <property name="toolTip">
-             <string>Spin CCW</string>
-            </property>
-            <property name="text">
-             <string/>
-            </property>
-            <property name="icon">
-             <iconset>
-              <normalon>:/icons/arrow-ccw.svg</normalon>
-             </iconset>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <spacer name="horizontalSpacer_5">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>40</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-         </layout>
-        </item>
-       </layout>
-      </item>
-      <item>
-       <spacer name="verticalSpacer">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
+       </item>
+       <item>
+        <property name="text">
+         <string>Third Angle</string>
         </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>20</width>
-          <height>40</height>
-         </size>
+       </item>
+       <item>
+        <property name="text">
+         <string>Page</string>
         </property>
-       </spacer>
-      </item>
-     </layout>
+       </item>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_5">
+     <item>
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>Scale</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QComboBox" name="cmbScaleType">
+       <property name="toolTip">
+        <string>Scale Page/Auto/Custom</string>
+       </property>
+       <item>
+        <property name="text">
+         <string>Page</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Automatic</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Custom</string>
+        </property>
+       </item>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_6" stretch="0,0,1,0,1">
+     <item>
+      <widget class="QLabel" name="label_2">
+       <property name="text">
+        <string>Custom Scale</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer_3">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QSpinBox" name="sbScaleNum">
+       <property name="toolTip">
+        <string>Scale Numerator</string>
+       </property>
+       <property name="minimum">
+        <number>1</number>
+       </property>
+       <property name="value">
+        <number>1</number>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_4">
+       <property name="text">
+        <string>:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QSpinBox" name="sbScaleDen">
+       <property name="toolTip">
+        <string>Scale Denominator</string>
+       </property>
+       <property name="minimum">
+        <number>1</number>
+       </property>
+       <property name="maximum">
+        <number>999</number>
+       </property>
+       <property name="value">
+        <number>1</number>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="Line" name="line">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
     </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_4">
+     <item>
+      <widget class="QLabel" name="label_5">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Adjust Primary Direction</string>
+       </property>
+       <property name="scaledContents">
+        <bool>true</bool>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+       <property name="indent">
+        <number>0</number>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QGridLayout" name="gridLayout" columnstretch="0,0,0">
+     <item row="1" column="1">
+      <widget class="QLineEdit" name="lePrimary">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="font">
+        <font>
+         <pointsize>11</pointsize>
+         <weight>50</weight>
+         <italic>false</italic>
+         <bold>false</bold>
+        </font>
+       </property>
+       <property name="focusPolicy">
+        <enum>Qt::NoFocus</enum>
+       </property>
+       <property name="toolTip">
+        <string>Current primary view direction</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+       <property name="readOnly">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="2">
+      <widget class="QPushButton" name="butRightRotate">
+       <property name="toolTip">
+        <string>Rotate right</string>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="icon">
+        <iconset>
+         <normalon>:/icons/arrow-right.svg</normalon>
+        </iconset>
+       </property>
+       <property name="iconSize">
+        <size>
+         <width>24</width>
+         <height>24</height>
+        </size>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QPushButton" name="butTopRotate">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="toolTip">
+        <string>Rotate up</string>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="icon">
+        <iconset>
+         <normalon>:/icons/arrow-up.svg</normalon>
+        </iconset>
+       </property>
+       <property name="iconSize">
+        <size>
+         <width>24</width>
+         <height>24</height>
+        </size>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QPushButton" name="butLeftRotate">
+       <property name="toolTip">
+        <string>Rotate left</string>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="icon">
+        <iconset>
+         <normalon>:/icons/arrow-left.svg</normalon>
+        </iconset>
+       </property>
+       <property name="iconSize">
+        <size>
+         <width>24</width>
+         <height>24</height>
+        </size>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="QPushButton" name="butDownRotate">
+       <property name="toolTip">
+        <string>Rotate down</string>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="icon">
+        <iconset>
+         <normalon>:/icons/arrow-down.svg</normalon>
+        </iconset>
+       </property>
+       <property name="iconSize">
+        <size>
+         <width>24</width>
+         <height>24</height>
+        </size>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="2">
+      <spacer name="horizontalSpacer_7">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item row="2" column="0">
+      <spacer name="horizontalSpacer_8">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="Line" name="line_2">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_8">
+     <item>
+      <widget class="QLabel" name="label_6">
+       <property name="text">
+        <string>Secondary Projections</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QGridLayout" name="gridLayout_2">
+     <item row="5" column="2">
+      <widget class="QCheckBox" name="chkView8">
+       <property name="enabled">
+        <bool>true</bool>
+       </property>
+       <property name="toolTip">
+        <string>Bottom</string>
+       </property>
+       <property name="styleSheet">
+        <string notr="true">QCheckBox::indicator {
+width: 24px;
+height: 24px;
+}
+</string>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="0">
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item row="3" column="2">
+      <widget class="QCheckBox" name="chkView4">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="toolTip">
+        <string>Primary</string>
+       </property>
+       <property name="styleSheet">
+        <string notr="true">QCheckBox::indicator {
+width: 24px;
+height: 24px;
+}
+</string>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="checked">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="3">
+      <widget class="QCheckBox" name="chkView5">
+       <property name="toolTip">
+        <string>Right</string>
+       </property>
+       <property name="styleSheet">
+        <string notr="true">QCheckBox::indicator {
+width: 24px;
+height: 24px;
+}
+</string>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="5">
+      <spacer name="horizontalSpacer_2">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item row="3" column="1">
+      <widget class="QCheckBox" name="chkView3">
+       <property name="toolTip">
+        <string>Left</string>
+       </property>
+       <property name="styleSheet">
+        <string notr="true">QCheckBox::indicator {
+width: 24px;
+height: 24px;
+}
+</string>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="1">
+      <widget class="QCheckBox" name="chkView7">
+       <property name="toolTip">
+        <string>LeftFrontBottom</string>
+       </property>
+       <property name="styleSheet">
+        <string notr="true">QCheckBox::indicator {
+width: 24px;
+height: 24px;
+}
+</string>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="2">
+      <widget class="QCheckBox" name="chkView1">
+       <property name="toolTip">
+        <string>Top</string>
+       </property>
+       <property name="styleSheet">
+        <string notr="true">QCheckBox::indicator {
+width: 24px;
+height: 24px;
+}
+</string>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="3">
+      <widget class="QCheckBox" name="chkView9">
+       <property name="toolTip">
+        <string>RightFrontBottom</string>
+       </property>
+       <property name="styleSheet">
+        <string notr="true">QCheckBox::indicator {
+width: 24px;
+height: 24px;
+}
+</string>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="3">
+      <widget class="QCheckBox" name="chkView2">
+       <property name="toolTip">
+        <string>RightFrontTop</string>
+       </property>
+       <property name="styleSheet">
+        <string notr="true">QCheckBox::indicator {
+width: 24px;
+height: 24px;
+}
+</string>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="4">
+      <widget class="QCheckBox" name="chkView6">
+       <property name="toolTip">
+        <string>Rear</string>
+       </property>
+       <property name="styleSheet">
+        <string notr="true">QCheckBox::indicator {
+width: 24px;
+height: 24px;
+}
+</string>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="QCheckBox" name="chkView0">
+       <property name="toolTip">
+        <string>LeftFrontTop</string>
+       </property>
+       <property name="styleSheet">
+        <string notr="true">QCheckBox::indicator {
+width: 24px;
+height: 24px;
+}
+</string>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="iconSize">
+        <size>
+         <width>24</width>
+         <height>24</height>
+        </size>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <spacer name="horizontalSpacer_4">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="butCWRotate">
+       <property name="toolTip">
+        <string>Spin CW</string>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="icon">
+        <iconset>
+         <normalon>:/icons/arrow-cw.svg</normalon>
+        </iconset>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer_6">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="butCCWRotate">
+       <property name="toolTip">
+        <string>Spin CCW</string>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="icon">
+        <iconset>
+         <normalon>:/icons/arrow-ccw.svg</normalon>
+        </iconset>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer_5">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QCheckBox" name="cbAutoDistribute">
+     <property name="toolTip">
+      <string>Distributes projections automatically
+using the given X/Y Spacing</string>
+     </property>
+     <property name="text">
+      <string>Auto Distribute</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QGridLayout" name="gridLayout_3">
+     <item row="0" column="1">
+      <spacer name="horizontalSpacer_10">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item row="0" column="2">
+      <widget class="Gui::QuantitySpinBox" name="sbXSpacing">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>150</width>
+         <height>22</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string>Horizontal space between center of projections</string>
+       </property>
+       <property name="keyboardTracking">
+        <bool>false</bool>
+       </property>
+       <property name="unit" stdset="0">
+        <string notr="true"/>
+       </property>
+       <property name="minimum">
+        <double>0.000000000000000</double>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="0">
+      <widget class="QLabel" name="label_10">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>X Spacing</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0" colspan="2">
+      <widget class="QLabel" name="label_11">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>Y Spacing</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="2">
+      <widget class="Gui::QuantitySpinBox" name="sbYSpacing">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>150</width>
+         <height>22</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string>Vertical space between center of projections</string>
+       </property>
+       <property name="keyboardTracking">
+        <bool>false</bool>
+       </property>
+       <property name="unit" stdset="0">
+        <string notr="true"/>
+       </property>
+       <property name="minimum">
+        <double>0.000000000000000</double>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>Gui::QuantitySpinBox</class>
+   <extends>QWidget</extends>
+   <header>Gui/QuantitySpinBox.h</header>
+  </customwidget>
+ </customwidgets>
  <resources>
   <include location="Resources/TechDraw.qrc"/>
  </resources>
- <connections/>
+ <connections>
+  <connection>
+   <sender>cbAutoDistribute</sender>
+   <signal>clicked(bool)</signal>
+   <receiver>sbXSpacing</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>60</x>
+     <y>407</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>164</x>
+     <y>431</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>cbAutoDistribute</sender>
+   <signal>clicked(bool)</signal>
+   <receiver>sbYSpacing</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>60</x>
+     <y>407</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>164</x>
+     <y>459</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
 </ui>


### PR DESCRIPTION
- Add the setting to auto-distribute projections to the dialog
- Also disable keyboardTracking for the scale to avoid unnecessary recomputes

Layout of changed dialog:
![FreeCAD_8O1tw9cS3F](https://user-images.githubusercontent.com/1828501/85215950-59617880-b37f-11ea-9ff1-9a01ca379f30.png)
