### PR TITLE
[Path] Resize the Base Geometry list dynamically

### DIFF
--- a/src/Mod/Path/PathScripts/PathOpGui.py
+++ b/src/Mod/Path/PathScripts/PathOpGui.py
@@ -481,6 +481,7 @@ class TaskPanelBaseGeometryPage(TaskPanelPage):
                 item.setData(self.DataObjectSub, sub)
                 self.form.baseList.addItem(item)
         self.form.baseList.blockSignals(False)
+        self.resizeBaseList()
 
     def itemActivated(self):
         FreeCADGui.Selection.clearSelection()
@@ -566,6 +567,7 @@ class TaskPanelBaseGeometryPage(TaskPanelPage):
             self.setDirty()
         self.updateBase()
         self.updatePanelVisibility('Operation', self.obj)
+        self.resizeBaseList()
 
     def updateBase(self):
         newlist = []
@@ -586,6 +588,7 @@ class TaskPanelBaseGeometryPage(TaskPanelPage):
         self.obj.Base = []
         self.setDirty()
         self.updatePanelVisibility('Operation', self.obj)
+        self.resizeBaseList()
 
     def importBaseGeometry(self):
         opLabel = str(self.form.geometryImportList.currentText())
@@ -615,6 +618,15 @@ class TaskPanelBaseGeometryPage(TaskPanelPage):
         else:
             self.form.addBase.setEnabled(False)
 
+    def resizeBaseList(self):
+        # Set base geometry list window to resize based on contents
+        # Code reference:
+        # https://stackoverflow.com/questions/6337589/qlistwidget-adjust-size-to-content
+        qList = self.form.baseList
+        # qList.setVerticalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOff)
+        col = qList.width()  # 300
+        row = (qList.count() + qList.frameWidth()) * 15
+        qList.setFixedSize(col, row)
 
 class TaskPanelBaseLocationPage(TaskPanelPage):
     '''Page controller for base locations. Uses PathGetPoint.'''


### PR DESCRIPTION
Make the size of the Base Geometry list dynamically adjust to its contents.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
