### PR TITLE
Part: add more tessellation parameters to 'Shape view' preference page

### DIFF
--- a/src/Mod/Part/Gui/CMakeLists.txt
+++ b/src/Mod/Part/Gui/CMakeLists.txt
@@ -64,6 +64,7 @@ set(PartGui_MOC_HDRS
     TaskDimension.h
     TaskCheckGeometry.h
     TaskAttacher.h
+    PartParams.h
 )
 fc_wrap_cpp(PartGui_MOC_SRCS ${PartGui_MOC_HDRS})
 SOURCE_GROUP("Moc" FILES ${PartGui_MOC_SRCS})
@@ -258,6 +259,8 @@ SET(PartGui_SRCS
     TaskCheckGeometry.h
     TaskAttacher.h 
     TaskAttacher.cpp 
+    PartParams.h 
+    PartParams.cpp 
 )
 
 if(FREECAD_USE_PCH)

--- a/src/Mod/Part/Gui/DlgSettings3DViewPart.ui
+++ b/src/Mod/Part/Gui/DlgSettings3DViewPart.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>539</width>
-    <height>339</height>
+    <width>564</width>
+    <height>465</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -20,19 +20,6 @@
    <property name="spacing">
     <number>6</number>
    </property>
-   <item row="1" column="0">
-    <spacer>
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>61</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
    <item row="0" column="0">
     <widget class="QGroupBox" name="GroupBox12">
      <property name="title">
@@ -53,6 +40,19 @@
         <property name="spacing">
          <number>6</number>
         </property>
+        <item row="0" column="0">
+         <widget class="QLabel" name="textLabel1">
+          <property name="toolTip">
+           <string>Defines the deviation of tessellation to the actual surface. This will be used to set the 'Deviation' property of any new view object.</string>
+          </property>
+          <property name="whatsThis">
+           <string>&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;/head&gt;&lt;body style=&quot; white-space: pre-wrap; font-family:MS Shell Dlg 2; font-size:7.8pt; font-weight:400; font-style:normal; text-decoration:none;&quot;&gt;&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Tessellation&lt;/span&gt;&lt;/p&gt;&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-weight:600;&quot;&gt;&lt;/p&gt;&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-weight:600;&quot;&gt;&lt;span style=&quot; font-weight:400;&quot;&gt;Defines the maximum deviation of the tessellated mesh to the surface. The smaller the value is the slower the render speed which results in increased detail/resolution.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
+          <property name="text">
+           <string>Maximum deviation depending on the model bounding box</string>
+          </property>
+         </widget>
+        </item>
         <item row="0" column="1">
          <widget class="Gui::PrefDoubleSpinBox" name="maxDeviation">
           <property name="suffix">
@@ -62,7 +62,7 @@
            <number>4</number>
           </property>
           <property name="minimum">
-           <double>0.0100000000000</double>
+           <double>0.010000000000000</double>
           </property>
           <property name="maximum">
            <double>100.000000000000000</double>
@@ -81,27 +81,36 @@
           </property>
          </widget>
         </item>
-        <item row="0" column="0">
-         <widget class="QLabel" name="textLabel1">
-          <property name="toolTip">
-           <string>Defines the deviation of tessellation to the actual surface</string>
+        <item row="1" column="1">
+         <widget class="Gui::PrefDoubleSpinBox" name="deviationLowerBound">
+          <property name="suffix">
+           <string>%</string>
           </property>
-          <property name="whatsThis">
-           <string>&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;/head&gt;&lt;body style=&quot; white-space: pre-wrap; font-family:MS Shell Dlg 2; font-size:7.8pt; font-weight:400; font-style:normal; text-decoration:none;&quot;&gt;&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Tessellation&lt;/span&gt;&lt;/p&gt;&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-weight:600;&quot;&gt;&lt;/p&gt;&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-weight:600;&quot;&gt;&lt;span style=&quot; font-weight:400;&quot;&gt;Defines the maximum deviation of the tessellated mesh to the surface. The smaller the value is the slower the render speed which results in increased detail/resolution.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          <property name="decimals">
+           <number>4</number>
           </property>
-          <property name="text">
-           <string>Maximum deviation depending on the model bounding box</string>
+          <property name="maximum">
+           <double>100.000000000000000</double>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <string>MinimumDeviation</string>
+          </property>
+          <property name="prefPath" stdset="0">
+           <string>Mod/Part</string>
           </property>
          </widget>
         </item>
         <item row="1" column="0">
-         <widget class="QLabel" name="label">
+         <widget class="QLabel" name="label_2">
+          <property name="toolTip">
+           <string>Runtime lower bound of the deviation setting. This is used to limit the 'Deviation' for any existing view object.</string>
+          </property>
           <property name="text">
-           <string>Maximum angular deflection</string>
+           <string>Deviation lower bound</string>
           </property>
          </widget>
         </item>
-        <item row="1" column="1">
+        <item row="2" column="1">
          <widget class="Gui::PrefDoubleSpinBox" name="maxAngularDeflection">
           <property name="suffix">
            <string> °</string>
@@ -110,16 +119,16 @@
            <number>2</number>
           </property>
           <property name="minimum">
-           <double>0.0</double>
+           <double>0.000000000000000</double>
           </property>
           <property name="maximum">
            <double>180.000000000000000</double>
           </property>
           <property name="singleStep">
-           <double>0.5</double>
+           <double>0.500000000000000</double>
           </property>
           <property name="value">
-           <double>28.5</double>
+           <double>28.500000000000000</double>
           </property>
           <property name="prefEntry" stdset="0">
            <cstring>MeshAngularDeflection</cstring>
@@ -129,10 +138,78 @@
           </property>
          </widget>
         </item>
+        <item row="2" column="0">
+         <widget class="QLabel" name="label">
+          <property name="toolTip">
+           <string>Defines the maximum angular deflection when tessellating the actual surface. This will be used to set the 'AngularDeflection' property of any new view object.</string>
+          </property>
+          <property name="text">
+           <string>Maximum angular deflection</string>
+          </property>
+         </widget>
+        </item>
+        <item row="4" column="0">
+         <widget class="Gui::PrefCheckBox" name="checkBoxOverride">
+          <property name="toolTip">
+           <string>Override view object tessellation settings in the document using the settings here.</string>
+          </property>
+          <property name="text">
+           <string>Override document settings</string>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <string>OverrideTessellation</string>
+          </property>
+          <property name="prefPath" stdset="0">
+           <string>Mod/Part</string>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="0">
+         <widget class="QLabel" name="label_3">
+          <property name="toolTip">
+           <string>Runtime lower bound of angular deflection. This is used to limited the 'AngularDeflection' property of all existing view object.</string>
+          </property>
+          <property name="text">
+           <string>Angular deflection lower bound</string>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="1">
+         <widget class="Gui::PrefDoubleSpinBox" name="angularDeflectionLowerBound">
+          <property name="suffix">
+           <string>°</string>
+          </property>
+          <property name="maximum">
+           <double>180.000000000000000</double>
+          </property>
+          <property name="singleStep">
+           <double>1.000000000000000</double>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <string>MinimumAngularDeflection</string>
+          </property>
+          <property name="prefPath" stdset="0">
+           <string>Mod/Part</string>
+          </property>
+         </widget>
+        </item>
        </layout>
       </item>
      </layout>
     </widget>
+   </item>
+   <item row="1" column="0">
+    <spacer>
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>61</height>
+      </size>
+     </property>
+    </spacer>
    </item>
   </layout>
  </widget>
@@ -141,6 +218,11 @@
   <customwidget>
    <class>Gui::PrefDoubleSpinBox</class>
    <extends>QDoubleSpinBox</extends>
+   <header>Gui/PrefWidgets.h</header>
+  </customwidget>
+  <customwidget>
+   <class>Gui::PrefCheckBox</class>
+   <extends>QCheckBox</extends>
    <header>Gui/PrefWidgets.h</header>
   </customwidget>
  </customwidgets>

--- a/src/Mod/Part/Gui/DlgSettings3DViewPartImp.h
+++ b/src/Mod/Part/Gui/DlgSettings3DViewPartImp.h
@@ -49,6 +49,7 @@ protected:
 
 private Q_SLOTS:
     void on_maxDeviation_valueChanged(double);
+    void onLowerBoundChanged();
 
 private:
     std::unique_ptr<Ui_DlgSettings3DViewPart> ui;

--- a/src/Mod/Part/Gui/PartParams.cpp
+++ b/src/Mod/Part/Gui/PartParams.cpp
@@ -1,0 +1,102 @@
+/****************************************************************************
+ *   Copyright (c) 2020 Zheng, Lei (realthunder) <realthunder.dev@gmail.com>*
+ *                                                                          *
+ *   This file is part of the FreeCAD CAx development system.               *
+ *                                                                          *
+ *   This library is free software; you can redistribute it and/or          *
+ *   modify it under the terms of the GNU Library General Public            *
+ *   License as published by the Free Software Foundation; either           *
+ *   version 2 of the License, or (at your option) any later version.       *
+ *                                                                          *
+ *   This library  is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *   GNU Library General Public License for more details.                   *
+ *                                                                          *
+ *   You should have received a copy of the GNU Library General Public      *
+ *   License along with this library; see the file COPYING.LIB. If not,     *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,          *
+ *   Suite 330, Boston, MA  02111-1307, USA                                 *
+ *                                                                          *
+ ****************************************************************************/
+
+#include "PreCompiled.h"
+#include <App/Application.h>
+#include <App/Document.h>
+#include <Gui/Application.h>
+#include <Gui/Document.h>
+#include "ViewProvider.h"
+#include "PartParams.h"
+
+using namespace PartGui;
+
+PartParams::PartParams() {
+    handle = App::GetApplication().GetParameterGroupByPath(
+            "User parameter:BaseApp/Preferences/Mod/Part");
+    handle->Attach(this);
+#undef FC_PART_PARAM
+#define FC_PART_PARAM(_name,_ctype,_type,_def) \
+    _##_name = handle->Get##_type(#_name,_def);\
+    funcs[#_name] = &PartParams::update##_name;
+
+#undef FC_PART_PARAM2
+#define FC_PART_PARAM2 FC_PART_PARAM
+    FC_PART_PARAMS
+
+    timer.setSingleShot(true);
+    connect(&timer, SIGNAL(timeout()), this, SLOT(updateVisual()));
+}
+
+PartParams::~PartParams() {
+}
+
+void PartParams::OnChange(Base::Subject<const char*> &, const char* sReason) {
+    if(!sReason)
+        return;
+    auto it = funcs.find(sReason);
+    if(it == funcs.end())
+        return;
+    it->second(this);
+}
+
+PartParams *PartParams::instance() {
+    static PartParams *inst;
+    if(!inst)
+        inst = new PartParams;
+    return inst;
+}
+
+void PartParams::onMeshDeviationChanged() {
+    timer.start(100);
+}
+
+void PartParams::onMeshAngularDeflectionChanged() {
+    timer.start(100);
+}
+
+void PartParams::onMinimumDeviationChanged() {
+    timer.start(100);
+}
+
+void PartParams::onMinimumAngularDeflectionChanged() {
+    timer.start(100);
+}
+
+void PartParams::onOverrideTessellationChanged() {
+    timer.start(100);
+}
+
+void PartParams::updateVisual() {
+    timer.stop();
+    // search for Part view providers and apply the new settings
+    std::vector<App::Document*> docs = App::GetApplication().getDocuments();
+    for (std::vector<App::Document*>::iterator it = docs.begin(); it != docs.end(); ++it) {
+        Gui::Document* doc = Gui::Application::Instance->getDocument(*it);
+        std::vector<Gui::ViewProvider*> views = doc->getViewProvidersOfType(ViewProviderPart::getClassTypeId());
+        for (std::vector<Gui::ViewProvider*>::iterator jt = views.begin(); jt != views.end(); ++jt) {
+            static_cast<ViewProviderPart*>(*jt)->reload();
+        }
+    }
+}
+
+#include "moc_PartParams.cpp"

--- a/src/Mod/Part/Gui/PartParams.h
+++ b/src/Mod/Part/Gui/PartParams.h
@@ -1,0 +1,115 @@
+/****************************************************************************
+ *   Copyright (c) 2020 Zheng, Lei (realthunder) <realthunder.dev@gmail.com>*
+ *                                                                          *
+ *   This file is part of the FreeCAD CAx development system.               *
+ *                                                                          *
+ *   This library is free software; you can redistribute it and/or          *
+ *   modify it under the terms of the GNU Library General Public            *
+ *   License as published by the Free Software Foundation; either           *
+ *   version 2 of the License, or (at your option) any later version.       *
+ *                                                                          *
+ *   This library  is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *   GNU Library General Public License for more details.                   *
+ *                                                                          *
+ *   You should have received a copy of the GNU Library General Public      *
+ *   License along with this library; see the file COPYING.LIB. If not,     *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,          *
+ *   Suite 330, Boston, MA  02111-1307, USA                                 *
+ *                                                                          *
+ ****************************************************************************/
+
+#ifndef PART_PARAMS_H
+#define PART_PARAMS_H
+
+#include <QTimer>
+#include <Base/Parameter.h>
+#include <App/DynamicProperty.h>
+
+namespace PartGui {
+
+/** Convenient class to obtain Mod/Part related parameters 
+ *
+ * The parameters are under group "User parameter:BaseApp/Preferences/Mod/Part"
+ *
+ * To add a new parameter, add a new line under FC_PART_PARAMS using macro
+ *
+ * @code
+ *      FC_PART_PARAM(parameter_name, c_type, parameter_type, default_value)
+ * @endcode
+ *
+ * If there is special handling on parameter change, use FC_PART_PARAM2()
+ * instead, and add a function with the following signature in PartParams.cpp,
+ *
+ * @code
+ *      void PartParams:on<ParamName>Changed()
+ * @endcode
+ */
+class PartGuiExport PartParams: public QObject, public ParameterGrp::ObserverType
+{
+    Q_OBJECT
+public:
+    PartParams();
+    virtual ~PartParams();
+    void OnChange(Base::Subject<const char*> &, const char* sReason);
+    static PartParams *instance();
+
+    ParameterGrp::handle getHandle() {
+        return handle;
+    }
+
+#define FC_PART_PARAMS \
+    FC_PART_PARAM(NormalsFromUVNodes, bool, Bool, true) \
+    FC_PART_PARAM(TwoSideRendering, bool, Bool, true) \
+    FC_PART_PARAM2(MinimumDeviation, double, Float, 0.05) \
+    FC_PART_PARAM2(MeshDeviation, double, Float, 0.2) \
+    FC_PART_PARAM2(MeshAngularDeflection, double, Float, 28.65) \
+    FC_PART_PARAM2(MinimumAngularDeflection, double, Float, 5.0) \
+    FC_PART_PARAM2(OverrideTessellation, bool, Bool, false) \
+    FC_PART_PARAM(MapFaceColor, bool, Bool, true) \
+    FC_PART_PARAM(MapLineColor, bool, Bool, false) \
+    FC_PART_PARAM(MapPointColor, bool, Bool, false) \
+    FC_PART_PARAM(MapTransparency, bool, Bool, false) \
+
+#undef FC_PART_PARAM
+#define FC_PART_PARAM(_name,_ctype,_type,_def) \
+    static const _ctype & _name() { return instance()->_##_name; }\
+    static void set_##_name(_ctype _v) { instance()->handle->Set##_type(#_name,_v); instance()->_##_name=_v; }\
+    static void update##_name(PartParams *self) { self->_##_name = self->handle->Get##_type(#_name,_def); }\
+
+#undef FC_PART_PARAM2
+#define FC_PART_PARAM2(_name,_ctype,_type,_def) \
+    static const _ctype & _name() { return instance()->_##_name; }\
+    static void set_##_name(_ctype _v) { instance()->handle->Set##_type(#_name,_v); instance()->_##_name=_v; }\
+    void on##_name##Changed();\
+    static void update##_name(PartParams *self) { \
+        self->_##_name = self->handle->Get##_type(#_name,_def); \
+        self->on##_name##Changed();\
+    }\
+
+    FC_PART_PARAMS
+
+private Q_SLOTS:
+    void updateVisual();
+
+private:
+#undef FC_PART_PARAM
+#define FC_PART_PARAM(_name,_ctype,_type,_def) \
+    _ctype _##_name;
+
+#undef FC_PART_PARAM2
+#define FC_PART_PARAM2 FC_PART_PARAM
+
+    FC_PART_PARAMS
+    ParameterGrp::handle handle;
+    std::unordered_map<const char *,void(*)(PartParams*),App::CStringHasher,App::CStringHasher> funcs;
+    QTimer timer;
+};
+
+#undef FC_PART_PARAM
+#undef FC_PART_PARAM2
+
+} // namespace PartGui
+
+#endif // PART_PARAMS_H

--- a/src/Mod/Part/Gui/ViewProviderExt.h
+++ b/src/Mod/Part/Gui/ViewProviderExt.h
@@ -154,7 +154,6 @@ protected:
 protected:
     /// get called by the container whenever a property has been changed
     virtual void onChanged(const App::Property* prop) override;
-    bool loadParameter();
     void updateVisual();
     void getNormals(const TopoDS_Face&  theFace, const Handle(Poly_Triangulation)& aPolyTri,
                     TColgp_Array1OfDir& theNormals);


### PR DESCRIPTION
Introduce new parameters 'OverrideTessellation', 'MinimumAngularDeflection', 'MinimumDeviation' to restrict runtime tessellation settings. This is to work around OCC 7.4 freeze up when
loading document with a too small deviation and/or angular deflection. It seems that with certain combination of small AngularDeflection and Deviation OCC 7.3 behaves normal, while OCC 7.4 takes extra long time.