### PR TITLE
Arch: add missing translate function in window module

### DIFF
--- a/src/Mod/Arch/ArchWindowPresets.py
+++ b/src/Mod/Arch/ArchWindowPresets.py
@@ -20,7 +20,10 @@
 #***************************************************************************
 
 import FreeCAD
+
 from FreeCAD import Vector
+from draftutils.translate import translate
+
 
 WindowPresets =  ["Fixed", "Open 1-pane", "Open 2-pane", "Sash 2-pane",
                   "Sliding 2-pane", "Simple door", "Glass door", "Sliding 4-pane"]


### PR DESCRIPTION
The code was moved to a separate module, `ArchWindowPresets.py`, in be0c8eab25, but the `translate` function was not imported in this new module.

Reported: [Arch Wall Window placement seems broken](https://forum.freecadweb.org/viewtopic.php?f=3&t=47940)

---

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists