### PR TITLE
fixed xlsx alias encoding issue

### DIFF
--- a/src/Mod/Spreadsheet/importXLSX.py
+++ b/src/Mod/Spreadsheet/importXLSX.py
@@ -321,7 +321,10 @@ def getText(nodelist):
   for node in nodelist:
     if node.nodeType == node.TEXT_NODE:
       rc.append(node.data)
-  return ''.join(rc)
+    if sys.version_info.major >= 3:
+      return ''.join(rc)
+    else:
+      return ''.join(rc).encode('utf8')
 
 
 def handleWorkSheet(theDom, actSheet, strList):
@@ -352,7 +355,7 @@ def handleCells(cellList, actCellSheet, sList):
         theString = getText(tElement.childNodes)
         
         #print('theString: ', theString)
-        actCellSheet.set(ref, theString.encode('utf8'))
+        actCellSheet.set(ref, theString)
 
     formulaRef = cell.getElementsByTagName("f")
     if len(formulaRef)==1:
@@ -372,10 +375,7 @@ def handleCells(cellList, actCellSheet, sList):
           if cellType == 'n':
             actCellSheet.set(ref, theValue)
           if cellType == 's':
-            if sys.version_info.major >= 3:
-                actCellSheet.set(ref, (sList[int(theValue)]))
-            else:
-                actCellSheet.set(ref, (sList[int(theValue)]).encode('utf8'))
+            actCellSheet.set(ref, (sList[int(theValue)]))
 
 
 def handleWorkBook(theBook, sheetDict, Doc):

--- a/src/Mod/Spreadsheet/importXLSX.py
+++ b/src/Mod/Spreadsheet/importXLSX.py
@@ -407,7 +407,7 @@ def handleWorkBook(theBook, sheetDict, Doc):
       #print('Sheet Name: ', refList[0])
       #print('Adress: ', adressList[0] + adressList[1])
       actSheet, sheetFile = sheetDict[refList[0]]
-      actSheet.setAlias(adressList[0]+adressList[1], aliasName.encode('utf8'))
+      actSheet.setAlias(adressList[0]+adressList[1], aliasName)
 
 def handleStrings(theStr, sList):
   print('process Strings: ')


### PR DESCRIPTION
Since `getText()` already returns a string, the `encode()` function (called on this string) results in a byte object which is not compatible with `setAlias()`.


- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
