### PR TITLE
Fix typos [skip-ci]

### DIFF
--- a/src/App/Document.cpp
+++ b/src/App/Document.cpp
@@ -627,7 +627,7 @@ void Document::exportGraphviz(std::ostream& out) const
                 //first build up the coordinate system subgraphs
                 for (auto objectIt : d->objectArray) {
                     // do not require an empty inlist (#0003465: Groups breaking dependency graph)
-                    // App::Origin now has the GeoFeatureGroupExtension but it shoud not move its
+                    // App::Origin now has the GeoFeatureGroupExtension but it should not move its
                     // group symbol outside its parent
                     if (!objectIt->isDerivedFrom(Origin::getClassTypeId()) &&
                          objectIt->hasExtension(GeoFeatureGroupExtension::getExtensionClassTypeId()))

--- a/src/Gui/SoFCUnifiedSelection.cpp
+++ b/src/Gui/SoFCUnifiedSelection.cpp
@@ -1128,7 +1128,7 @@ SoFCSelectionContextBasePtr SoFCSelectionRoot::getNodeContext(
 
     SoFCSelectionRoot *front = stack.front();
 
-    // NOTE: _node is not necssary of type SoFCSelectionRoot, but it is safe
+    // NOTE: _node is not necessary of type SoFCSelectionRoot, but it is safe
     // here since we only use it as searching key, although it is probably not
     // a best practice.
     stack.front() = static_cast<SoFCSelectionRoot*>(node);

--- a/src/Gui/Tree.h
+++ b/src/Gui/Tree.h
@@ -416,7 +416,7 @@ public:
             std::string *topSubname=0) const;
 
     // return the top most linked group owner's name, and subname.  This method
-    // is necssary despite have getFullSubName above is because native geo group
+    // is necessary despite have getFullSubName above is because native geo group
     // cannot handle selection with sub name. So only a linked group can have
     // subname in selection
     int getSubName(std::ostringstream &str, App::DocumentObject *&topParent) const;

--- a/src/Mod/Arch/Resources/ui/preferences-ifc.ui
+++ b/src/Mod/Arch/Resources/ui/preferences-ifc.ui
@@ -104,7 +104,7 @@ One object is the base object, the others are clones.</string>
         <item>
          <widget class="Gui::PrefSpinBox" name="spinBox">
           <property name="toolTip">
-           <string>EXPERIMENAL - The number of cores to use in multicore mode. Keep 0 to disable multicore mode, or 1 to use multicore mode in single-core mode (safer if you get crashes). Max value should be your number of cores - 1, ex: 3 of you have a quad-core CPU.</string>
+           <string>EXPERIMENTAL - The number of cores to use in multicore mode. Keep 0 to disable multicore mode, or 1 to use multicore mode in single-core mode (safer if you get crashes). Max value should be your number of cores - 1, ex: 3 of you have a quad-core CPU.</string>
           </property>
           <property name="prefEntry" stdset="0">
            <cstring>ifcMulticore</cstring>

--- a/src/Mod/Arch/exportIFCStructuralTools.py
+++ b/src/Mod/Arch/exportIFCStructuralTools.py
@@ -153,7 +153,7 @@ def createStructuralMember(ifcfile,ifcbin,obj):
 
 def createStructuralGroup(ifcfile):
 
-    "Assigns all structural objects found in the file to the structual model"""
+    "Assigns all structural objects found in the file to the structural model"""
 
     import ifcopenshell
     uid = ifcopenshell.guid.new

--- a/src/Mod/Draft/draftmake/make_dimension.py
+++ b/src/Mod/Draft/draftmake/make_dimension.py
@@ -101,7 +101,7 @@ def make_dimension(p1, p2, p3=None, p4=None):
         p3 = p4
         if not p3:
             # When used from the GUI command, this will never run
-            # because p4 will always be assinged to a vector,
+            # because p4 will always be assigned to a vector,
             # so p3 will never be `None`.
             # Moreover, `new_obj.Base` doesn't exist, and certainly `Shape`
             # doesn't exist, so if this ever runs it will be an error.
@@ -522,7 +522,7 @@ def make_angular_dimension(center=App.Vector(0, 0, 0),
     angles: list of two floats, optional
         It defaults to `[0, 90]`.
         It is a list of two angles, given in degrees, that determine
-        the apperture of the dimension line, that is, of the circular arc.
+        the aperture of the dimension line, that is, of the circular arc.
         It is drawn counter-clockwise.
         ::
             angles = [0 90]

--- a/src/Mod/Draft/draftobjects/dimension.py
+++ b/src/Mod/Draft/draftobjects/dimension.py
@@ -392,7 +392,7 @@ def measure_one_obj_edge(obj, subelement, dim_point, diameter=False):
             dim_line = dim_point.sub(center)
 
             # The ray is projected to the plane on which the circle lies,
-            # but if the projection is not succesful, try in the other planes
+            # but if the projection is not successful, try in the other planes
             ray = dim_line.projectToPlane(App.Vector(0, 0, 0), axis)
 
             if ray.Length == 0:

--- a/src/Mod/Fem/femexamples/manager.py
+++ b/src/Mod/Fem/femexamples/manager.py
@@ -28,7 +28,7 @@ from femexamples.manager import *
 run_all()
 
 
-# one special exmaple
+# one special example
 from femexamples.manager import run_example as run
 
 doc = run("boxanalysis_static")

--- a/src/Mod/Import/App/ImportOCAF2.cpp
+++ b/src/Mod/Import/App/ImportOCAF2.cpp
@@ -883,7 +883,7 @@ void ExportOCAF2::setName(TDF_Label label, App::DocumentObject *obj, const char 
 }
 
 // Similar to XCAFDoc_ShapeTool::FindSHUO but return only main SHUO, i.e. SHUO
-// with no upper_usage. It should not be necssary if we strictly export from
+// with no upper_usage. It should not be necessary if we strictly export from
 // bottom up, but let's make sure of it.
 static Standard_Boolean FindSHUO (const TDF_LabelSequence& theLabels,
                                   Handle(XCAFDoc_GraphNode)& theSHUOAttr)

--- a/src/Mod/Path/App/ParamsHelper.h
+++ b/src/Mod/Path/App/ParamsHelper.h
@@ -61,9 +61,9 @@
  *     <your_build_dir>/src/Mod/Path/App.CMakeFiles/Path.dir/Area.cpp.i
  * \endcode
  *
- * \section Intrudction of Boost.Preprocessor
+ * \section Introduction of Boost.Preprocessor
  *
- * The macros here make heavy use of the awsome
+ * The macros here make heavy use of the awesome
  * [Boost.Preprocessor](http://www.boost.org/libs/preprocessor/) (short for
  * Boost.PP).  Here are is a brief introduction on Boost.PP concept in order to
  * explain why this marco library is designed the way it is.

--- a/src/Mod/Path/PathScripts/PathSurfaceSupport.py
+++ b/src/Mod/Path/PathScripts/PathSurfaceSupport.py
@@ -2471,7 +2471,7 @@ class OCL_Tool():
         LengthOffset
 
 
-        #### FreeCAD packaged ToolBit named constaints per shape files
+        #### FreeCAD packaged ToolBit named constraints per shape files
         shape = endmill
         Diameter; Endmill diameter
         Length; Overall length of the endmill


### PR DESCRIPTION
Found via codespell v1.18.0.dev0  
```
codespell -q 3 -L aci,ake,aline,alle,alledges,alocation,als,ang,anid,ba,beginn,behaviour,bloaded,byteorder,calculater,cancelled,cancelling,cas,cascade,centimetre,childs,colour,colours,commen,connexion,currenty,dof,doubleclick,dum,eiter,elemente,ende,feld,finde,findf,freez,hist,iff,indicies,initialisation,initialise,initialised,initialises,initialisiert,ist,kilometre,lod,mantatory,methode,metres,millimetre,modell,nd,noe,normale,normaly,nto,numer,oder,orgin,orginx,orginy,ot,pard,pres,programm,que,recurrance,rougly,seperator,serie,sinc,strack,substraction,te,thist,thru,tread,uint,unter,vertexes,wallthickness,whitespaces -S ./.git,*.po,*.ts,./ChangeLog.txt,./src/3rdParty,./src/Mod/Assembly/App/opendcm,./src/CXX,./src/zipios++,./src/Base/swig*,./src/Mod/Robot/App/kdl_cp,./src/Mod/Import/App/SCL,./src/WindowsInstaller,./src/Doc/FreeCAD.uml
```