### PR TITLE
[PD] disable keyboardTracking for dressup dialogs

### DIFF
--- a/src/Mod/PartDesign/Gui/TaskChamferParameters.ui
+++ b/src/Mod/PartDesign/Gui/TaskChamferParameters.ui
@@ -121,7 +121,10 @@ click again to end selection</string>
       </widget>
      </item>
      <item row="0" column="1">
-      <widget class="Gui::QuantitySpinBox" name="chamferSize" native="true">
+      <widget class="Gui::QuantitySpinBox" name="chamferSize">
+       <property name="keyboardTracking">
+        <bool>false</bool>
+       </property>
        <property name="value">
         <double>1.000000000000000</double>
        </property>
@@ -157,7 +160,10 @@ click again to end selection</string>
         </widget>
        </item>
        <item row="0" column="1">
-        <widget class="Gui::QuantitySpinBox" name="chamferSize2" native="true">
+        <widget class="Gui::QuantitySpinBox" name="chamferSize2">
+         <property name="keyboardTracking">
+          <bool>false</bool>
+         </property>
          <property name="value">
           <double>1.000000000000000</double>
          </property>
@@ -187,7 +193,10 @@ click again to end selection</string>
         </widget>
        </item>
        <item row="0" column="1">
-        <widget class="Gui::QuantitySpinBox" name="chamferAngle" native="true">
+        <widget class="Gui::QuantitySpinBox" name="chamferAngle">
+         <property name="keyboardTracking">
+          <bool>false</bool>
+         </property>
          <property name="minimum">
           <double>0.000000000000000</double>
          </property>

--- a/src/Mod/PartDesign/Gui/TaskDraftParameters.ui
+++ b/src/Mod/PartDesign/Gui/TaskDraftParameters.ui
@@ -67,21 +67,24 @@ click again to end selection</string>
       </widget>
      </item>
      <item>
-      <widget class="Gui::QuantitySpinBox" name="draftAngle" native="true">
+      <widget class="Gui::QuantitySpinBox" name="draftAngle">
+       <property name="keyboardTracking">
+        <bool>false</bool>
+       </property>
        <property name="unit" stdset="0">
         <string notr="true">deg</string>
        </property>
-       <property name="minimum" stdset="0">
+       <property name="minimum">
         <double>0.000000000000000</double>
        </property>
-       <property name="maximum" stdset="0">
+       <property name="maximum">
         <double>89.999999999999986</double>
        </property>
-       <property name="singleStep" stdset="0">
-        <double>0.100000000000000</double>
+       <property name="singleStep">
+        <double>1.000000000000000</double>
        </property>
-       <property name="value" stdset="0">
-        <double>1.500000000000000</double>
+       <property name="value">
+        <double>10.000000000000000</double>
        </property>
       </widget>
      </item>

--- a/src/Mod/PartDesign/Gui/TaskFilletParameters.ui
+++ b/src/Mod/PartDesign/Gui/TaskFilletParameters.ui
@@ -67,7 +67,11 @@ click again to end selection</string>
       </widget>
      </item>
      <item>
-      <widget class="Gui::QuantitySpinBox" name="filletRadius" native="true"/>
+      <widget class="Gui::QuantitySpinBox" name="filletRadius">
+       <property name="keyboardTracking">
+        <bool>false</bool>
+       </property>
+      </widget>
      </item>
     </layout>
    </item>

--- a/src/Mod/PartDesign/Gui/TaskThicknessParameters.ui
+++ b/src/Mod/PartDesign/Gui/TaskThicknessParameters.ui
@@ -67,23 +67,26 @@ click again to end selection</string>
       </widget>
      </item>
      <item row="0" column="1">
-      <widget class="Gui::QuantitySpinBox" name="Value" native="true">
+      <widget class="Gui::QuantitySpinBox" name="Value">
        <property name="focusPolicy">
         <enum>Qt::TabFocus</enum>
+       </property>
+       <property name="keyboardTracking">
+        <bool>false</bool>
        </property>
        <property name="unit" stdset="0">
         <string notr="true">mm</string>
        </property>
-       <property name="minimum" stdset="0">
+       <property name="minimum">
         <double>0.000000000000000</double>
        </property>
-       <property name="maximum" stdset="0">
+       <property name="maximum">
         <double>999999999.000000000000000</double>
        </property>
-       <property name="singleStep" stdset="0">
+       <property name="singleStep">
         <double>0.100000000000000</double>
        </property>
-       <property name="value" stdset="0">
+       <property name="value">
         <double>1.000000000000000</double>
        </property>
       </widget>


### PR DESCRIPTION
- At the moment using e.g. the thickness dialog and change from the default "1.0" to e.g. "21.3" triggers 4 recomputes. This takes a lot of time and is unnecessary. Qt offers therefore to disable keyboardTracking (and we use it already in the TechDraw workbench).

- also change the default draft angle from 1.5° to more common 10° and the step to 1° so that one can quickly get usual angles for drafts