### PR TITLE
Draft: set a space before the Link group

### DIFF
--- a/src/Mod/Draft/draftobjects/draftlink.py
+++ b/src/Mod/Draft/draftobjects/draftlink.py
@@ -117,12 +117,12 @@ class DraftLink(DraftObject):
         if not hasattr(obj, 'LinkTransform'):
             obj.addProperty('App::PropertyBool',
                             'LinkTransform',
-                            'Link')
+                            ' Link')
 
         if not hasattr(obj, 'ColoredElements'):
             obj.addProperty('App::PropertyLinkSubHidden',
                             'ColoredElements',
-                            'Link')
+                            ' Link')
             obj.setPropertyStatus('ColoredElements', 'Hidden')
 
         obj.configLinkProperty('LinkTransform', 'ColoredElements')


### PR DESCRIPTION
For some reason all `App::Link` properties are in a group that starts with a space, so `' Link'`, not just `'Link'`.

This was changed in 927379c175. We revert this change so that the Link properties are correctly placed in the corresponding groups in the property editor.

---

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists