### PR TITLE
Sketcher refactor 2

### DIFF
--- a/src/Mod/Part/App/PropertyGeometryList.cpp
+++ b/src/Mod/Part/App/PropertyGeometryList.cpp
@@ -95,14 +95,22 @@ void PropertyGeometryList::setValue(const Geometry* lValue)
 
 void PropertyGeometryList::setValues(const std::vector<Geometry*>& lValue)
 {
+    auto copy = lValue;
+    for(auto &geo : copy) // copy of the individual geometry pointers
+        geo = geo->clone();
+
+    setValues(std::move(copy));
+}
+
+void PropertyGeometryList::setValues(const std::vector<Geometry*>&& rValue)
+{
     aboutToSetValue();
     std::vector<Geometry*> oldVals(_lValueList);
-    _lValueList.resize(lValue.size());
-    // copy all objects
-    for (unsigned int i = 0; i < lValue.size(); i++)
-        _lValueList[i] = lValue[i]->clone();
-    for (unsigned int i = 0; i < oldVals.size(); i++)
-        delete oldVals[i];
+    _lValueList = std::move(rValue);
+
+    for(auto &ov : oldVals)
+        delete ov;
+
     hasSetValue();
 }
 

--- a/src/Mod/Part/App/PropertyGeometryList.h
+++ b/src/Mod/Part/App/PropertyGeometryList.h
@@ -64,6 +64,7 @@ public:
      */
     void setValue(const Geometry*);
     void setValues(const std::vector<Geometry*>&);
+    void setValues(const std::vector<Geometry*>&&);
 
     /// index operator
     const Geometry *operator[] (const int idx) const {

--- a/src/Mod/Sketcher/App/PropertyConstraintList.cpp
+++ b/src/Mod/Sketcher/App/PropertyConstraintList.cpp
@@ -61,6 +61,7 @@ PropertyConstraintList::PropertyConstraintList()
   : validGeometryKeys(0)
   , invalidGeometry(true)
   , restoreFromTransaction(false)
+  , invalidIndices(false)
 {
 
 }
@@ -398,6 +399,41 @@ bool PropertyConstraintList::checkGeometry(const std::vector<Part::Geometry *> &
     }
 
     return invalidGeometry;
+}
+
+bool PropertyConstraintList::checkConstraintIndices(int geomax, int geomin)
+{
+    int mininternalgeoid = std::numeric_limits<int>::max();
+    int maxinternalgeoid = Constraint::GeoUndef;
+
+    auto cmin = [] (int previousmin, int cindex) {
+        if( cindex == Constraint::GeoUndef )
+            return previousmin;
+
+        return ( cindex < previousmin )? cindex : previousmin;
+    };
+
+    auto cmax = [] (int previousmax, int cindex) {
+        return ( cindex > previousmax )? cindex : previousmax;
+    };
+
+    for (const auto &v : _lValueList) {
+
+        mininternalgeoid = cmin(mininternalgeoid, v->First);
+        mininternalgeoid = cmin(mininternalgeoid, v->Second);
+        mininternalgeoid = cmin(mininternalgeoid, v->Third);
+
+        maxinternalgeoid = cmax(maxinternalgeoid, v->First);
+        maxinternalgeoid = cmax(maxinternalgeoid, v->Second);
+        maxinternalgeoid = cmax(maxinternalgeoid, v->Third);
+    }
+
+    if(maxinternalgeoid > geomax || mininternalgeoid < geomin)
+        invalidIndices = true;
+    else
+        invalidIndices = false;
+
+    return invalidIndices;
 }
 
 /*!

--- a/src/Mod/Sketcher/App/PropertyConstraintList.cpp
+++ b/src/Mod/Sketcher/App/PropertyConstraintList.cpp
@@ -183,9 +183,8 @@ void PropertyConstraintList::setValues(const std::vector<Constraint*>& lValue)
     auto copy = lValue;
     for(auto &cstr : copy)
         cstr = cstr->clone();
-    aboutToSetValue();
-    applyValues(std::move(copy));
-    hasSetValue();
+
+    setValues(std::move(copy));
 }
 
 void PropertyConstraintList::setValues(std::vector<Constraint*>&& lValue) {

--- a/src/Mod/Sketcher/App/PropertyConstraintList.cpp
+++ b/src/Mod/Sketcher/App/PropertyConstraintList.cpp
@@ -200,7 +200,7 @@ void PropertyConstraintList::applyValues(std::vector<Constraint*>&& lValue)
     std::map<App::ObjectIdentifier, App::ObjectIdentifier> renamed;
     std::set<App::ObjectIdentifier> removed;
     boost::unordered_map<boost::uuids::uuid, std::size_t> newValueMap;
-    
+
     /* Check for renames */
     for (unsigned int i = 0; i < lValue.size(); i++) {
         boost::unordered_map<boost::uuids::uuid, std::size_t>::const_iterator j = valueMap.find(lValue[i]->tag);
@@ -221,7 +221,7 @@ void PropertyConstraintList::applyValues(std::vector<Constraint*>&& lValue)
     }
 
     /* Collect info about removed elements */
-    for(auto &v : valueMap) 
+    for(auto &v : valueMap)
         removed.insert(makePath(v.second,_lValueList[v.second]));
 
     /* Update value map with new tags from new array */
@@ -234,7 +234,7 @@ void PropertyConstraintList::applyValues(std::vector<Constraint*>&& lValue)
     /* Signal renames */
     if (renamed.size() > 0 && !restoreFromTransaction)
         signalConstraintsRenamed(renamed);
-    
+
     _lValueList = std::move(lValue);
 
     /* Clean-up; remove old values */
@@ -258,7 +258,7 @@ bool PropertyConstraintList::getPyPathValue(const App::ObjectIdentifier &path, P
 
     const Constraint *cstr = 0;
 
-    if (c1.isArray()) 
+    if (c1.isArray())
         cstr = _lValueList[c1.getIndex(_lValueList.size())];
     else if (c1.isSimple()) {
         ObjectIdentifier::Component c1 = path.getPropertyComponent(1);
@@ -384,11 +384,11 @@ void PropertyConstraintList::applyValidGeometryKeys(const std::vector<unsigned i
     validGeometryKeys = keys;
 }
 
-void PropertyConstraintList::checkGeometry(const std::vector<Part::Geometry *> &GeoList)
+bool PropertyConstraintList::checkGeometry(const std::vector<Part::Geometry *> &GeoList)
 {
     if (!scanGeometry(GeoList)) {
         invalidGeometry = true;
-        return;
+        return invalidGeometry;
     }
 
     //if we made it here, geometry is OK
@@ -397,6 +397,8 @@ void PropertyConstraintList::checkGeometry(const std::vector<Part::Geometry *> &
         invalidGeometry = false;
         touch();
     }
+
+    return invalidGeometry;
 }
 
 /*!

--- a/src/Mod/Sketcher/App/PropertyConstraintList.h
+++ b/src/Mod/Sketcher/App/PropertyConstraintList.h
@@ -62,7 +62,7 @@ public:
 
     virtual void setSize(int newSize) override;
     virtual int getSize(void) const override;
-    
+
     const char* getEditorName(void) const override {
         return "SketcherGui::PropertyConstraintListItem";
     }
@@ -121,7 +121,7 @@ public:
     virtual unsigned int getMemSize(void) const override;
 
     void acceptGeometry(const std::vector<Part::Geometry *> &GeoList);
-    void checkGeometry(const std::vector<Part::Geometry *> &GeoList);
+    bool checkGeometry(const std::vector<Part::Geometry *> &GeoList);
     bool scanGeometry(const std::vector<Part::Geometry *> &GeoList) const;
 
     /// Return status of geometry for better error reporting

--- a/src/Mod/Sketcher/App/PropertyConstraintList.h
+++ b/src/Mod/Sketcher/App/PropertyConstraintList.h
@@ -99,11 +99,11 @@ public:
            returns null. This must be checked by the caller.
     */
     const Constraint *operator[] (const int idx) const {
-        return invalidGeometry ? 0 : _lValueList[idx];
+        return (invalidGeometry || invalidIndices) ? 0 : _lValueList[idx];
     }
 
     const std::vector<Constraint*> &getValues(void) const {
-        return invalidGeometry ? _emptyValueList : _lValueList;
+        return (invalidGeometry || invalidIndices) ? _emptyValueList : _lValueList;
     }
     const std::vector<Constraint*> &getValuesForce(void) const {//to suppress check for invalid geometry, to be used for sketch repairing.
         return  _lValueList;
@@ -123,6 +123,8 @@ public:
     void acceptGeometry(const std::vector<Part::Geometry *> &GeoList);
     bool checkGeometry(const std::vector<Part::Geometry *> &GeoList);
     bool scanGeometry(const std::vector<Part::Geometry *> &GeoList) const;
+
+    bool checkConstraintIndices(int geomax, int geomin);
 
     /// Return status of geometry for better error reporting
     bool hasInvalidGeometry() const { return invalidGeometry; }
@@ -162,6 +164,7 @@ private:
     std::vector<unsigned int> validGeometryKeys;
     bool invalidGeometry;
     bool restoreFromTransaction;
+    bool invalidIndices;
 
     void applyValues(std::vector<Constraint*>&&);
     void applyValidGeometryKeys(const std::vector<unsigned int> &keys);

--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -143,6 +143,7 @@ SketchObject::SketchObject()
     analyser = new SketchAnalysis(this);
 
     internaltransaction=false;
+    managedoperation=false;
 }
 
 SketchObject::~SketchObject()
@@ -230,6 +231,8 @@ int SketchObject::hasConflicts(void) const
 
 int SketchObject::solve(bool updateGeoAfterSolving/*=true*/)
 {
+    Base::StateLocker lock(managedoperation, true); // no need to check input data validity as this is an sketchobject managed operation.
+
     // Reset the initial movement in case of a dragging operation was ongoing on the solver.
     solvedSketch.resetInitMove();
 
@@ -303,6 +306,8 @@ int SketchObject::solve(bool updateGeoAfterSolving/*=true*/)
 
 int SketchObject::setDatum(int ConstrId, double Datum)
 {
+    Base::StateLocker lock(managedoperation, true); // no need to check input data validity as this is an sketchobject managed operation.
+
     // set the changed value for the constraint
     if (this->Constraints.hasInvalidGeometry())
         return -6;
@@ -341,6 +346,8 @@ int SketchObject::setDatum(int ConstrId, double Datum)
 
 int SketchObject::setDriving(int ConstrId, bool isdriving)
 {
+    Base::StateLocker lock(managedoperation, true); // no need to check input data validity as this is an sketchobject managed operation.
+
     const std::vector<Constraint *> &vals = this->Constraints.getValues();
 
     int ret = testDrivingChange(ConstrId, isdriving);
@@ -387,6 +394,8 @@ int SketchObject::getDriving(int ConstrId, bool &isdriving)
 
 int SketchObject::toggleDriving(int ConstrId)
 {
+    Base::StateLocker lock(managedoperation, true); // no need to check input data validity as this is an sketchobject managed operation.
+
     const std::vector<Constraint *> &vals = this->Constraints.getValues();
 
     int ret = testDrivingChange(ConstrId,!vals[ConstrId]->isDriving);
@@ -449,6 +458,8 @@ int SketchObject::testDrivingChange(int ConstrId, bool isdriving)
 
 int SketchObject::setActive(int ConstrId, bool isactive)
 {
+    Base::StateLocker lock(managedoperation, true); // no need to check input data validity as this is an sketchobject managed operation.
+
     const std::vector<Constraint *> &vals = this->Constraints.getValues();
 
     if (ConstrId < 0 || ConstrId >= int(vals.size()))
@@ -488,6 +499,8 @@ int SketchObject::getActive(int ConstrId, bool &isactive)
 
 int SketchObject::toggleActive(int ConstrId)
 {
+    Base::StateLocker lock(managedoperation, true); // no need to check input data validity as this is an sketchobject managed operation.
+
     const std::vector<Constraint *> &vals = this->Constraints.getValues();
 
     if (ConstrId < 0 || ConstrId >= int(vals.size()))
@@ -517,6 +530,8 @@ int SketchObject::toggleActive(int ConstrId)
 /// Make all dimensionals Driving/non-Driving
 int SketchObject::setDatumsDriving(bool isdriving)
 {
+    Base::StateLocker lock(managedoperation, true); // no need to check input data validity as this is an sketchobject managed operation.
+
     const std::vector<Constraint *> &vals = this->Constraints.getValues();
     std::vector<Constraint *> newVals(vals);
 
@@ -544,6 +559,8 @@ int SketchObject::setDatumsDriving(bool isdriving)
 
 int SketchObject::moveDatumsToEnd(void)
 {
+    Base::StateLocker lock(managedoperation, true); // no need to check input data validity as this is an sketchobject managed operation.
+
     const std::vector<Constraint *> &vals = this->Constraints.getValues();
 
     std::vector<Constraint *> copy(vals);
@@ -577,6 +594,8 @@ int SketchObject::moveDatumsToEnd(void)
 
 int SketchObject::setVirtualSpace(int ConstrId, bool isinvirtualspace)
 {
+    Base::StateLocker lock(managedoperation, true); // no need to check input data validity as this is an sketchobject managed operation.
+
     const std::vector<Constraint *> &vals = this->Constraints.getValues();
 
     if (ConstrId < 0 || ConstrId >= int(vals.size()))
@@ -612,6 +631,8 @@ int SketchObject::getVirtualSpace(int ConstrId, bool &isinvirtualspace) const
 
 int SketchObject::toggleVirtualSpace(int ConstrId)
 {
+    Base::StateLocker lock(managedoperation, true); // no need to check input data validity as this is an sketchobject managed operation.
+
     const std::vector<Constraint *> &vals = this->Constraints.getValues();
 
     if (ConstrId < 0 || ConstrId >= int(vals.size()))
@@ -654,6 +675,8 @@ int SketchObject::setUpSketch()
 
 int SketchObject::movePoint(int GeoId, PointPos PosId, const Base::Vector3d& toPoint, bool relative, bool updateGeoBeforeMoving)
 {
+    Base::StateLocker lock(managedoperation, true); // no need to check input data validity as this is an sketchobject managed operation.
+
     // if we are moving a point at SketchObject level, we need to start from a solved sketch
     // if we have conflicts we can forget about moving. However, there is the possibility that we
     // need to do programmatically moves of new geometry that has not been solved yet and that because
@@ -849,6 +872,8 @@ std::vector<Part::Geometry *> SketchObject::supportedGeometry(const std::vector<
 
 int SketchObject::addGeometry(const std::vector<Part::Geometry *> &geoList, bool construction/*=false*/)
 {
+    Base::StateLocker lock(managedoperation, true); // no need to check input data validity as this is an sketchobject managed operation.
+
     const std::vector< Part::Geometry * > &vals = getInternalGeometry();
 
     std::vector< Part::Geometry * > newVals;
@@ -876,6 +901,8 @@ int SketchObject::addGeometry(const std::vector<Part::Geometry *> &geoList, bool
 
 int SketchObject::addGeometry(const Part::Geometry *geo, bool construction/*=false*/)
 {
+    Base::StateLocker lock(managedoperation, true); // no need to check input data validity as this is an sketchobject managed operation.
+
     const std::vector< Part::Geometry * > &vals = getInternalGeometry();
 
     std::vector< Part::Geometry * > newVals;
@@ -900,6 +927,8 @@ int SketchObject::addGeometry(const Part::Geometry *geo, bool construction/*=fal
 
 int SketchObject::delGeometry(int GeoId, bool deleteinternalgeo)
 {
+    Base::StateLocker lock(managedoperation, true); // no need to check input data validity as this is an sketchobject managed operation.
+
     const std::vector< Part::Geometry * > &vals = getInternalGeometry();
     if (GeoId < 0 || GeoId >= int(vals.size()))
         return -1;
@@ -966,6 +995,8 @@ int SketchObject::delGeometry(int GeoId, bool deleteinternalgeo)
 
 int SketchObject::deleteAllGeometry()
 {
+    Base::StateLocker lock(managedoperation, true); // no need to check input data validity as this is an sketchobject managed operation.
+
     std::vector< Part::Geometry * > newVals(0);
     std::vector< Constraint * > newConstraints(0);
 
@@ -986,6 +1017,8 @@ int SketchObject::deleteAllGeometry()
 
 int SketchObject::deleteAllConstraints()
 {
+    Base::StateLocker lock(managedoperation, true); // no need to check input data validity as this is an sketchobject managed operation.
+
     std::vector< Constraint * > newConstraints(0);
 
     this->Constraints.setValues(newConstraints);
@@ -998,6 +1031,8 @@ int SketchObject::deleteAllConstraints()
 
 int SketchObject::toggleConstruction(int GeoId)
 {
+    Base::StateLocker lock(managedoperation, true); // no need to check input data validity as this is an sketchobject managed operation.
+
     const std::vector< Part::Geometry * > &vals = getInternalGeometry();
     if (GeoId < 0 || GeoId >= int(vals.size()))
         return -1;
@@ -1029,6 +1064,8 @@ int SketchObject::toggleConstruction(int GeoId)
 
 int SketchObject::setConstruction(int GeoId, bool on)
 {
+    Base::StateLocker lock(managedoperation, true); // no need to check input data validity as this is an sketchobject managed operation.
+
     const std::vector< Part::Geometry * > &vals = getInternalGeometry();
     if (GeoId < 0 || GeoId >= int(vals.size()))
         return -1;
@@ -1061,6 +1098,8 @@ int SketchObject::setConstruction(int GeoId, bool on)
 //ConstraintList is used only to make copies.
 int SketchObject::addConstraints(const std::vector<Constraint *> &ConstraintList)
 {
+    Base::StateLocker lock(managedoperation, true); // no need to check input data validity as this is an sketchobject managed operation.
+
     const std::vector< Constraint * > &vals = this->Constraints.getValues();
 
     std::vector< Constraint * > newVals;
@@ -1090,6 +1129,8 @@ int SketchObject::addConstraints(const std::vector<Constraint *> &ConstraintList
 
 int SketchObject::addCopyOfConstraints(const SketchObject &orig)
 {
+    Base::StateLocker lock(managedoperation, true); // no need to check input data validity as this is an sketchobject managed operation.
+
     const std::vector< Constraint * > &vals = this->Constraints.getValues();
 
     const std::vector< Constraint * > &origvals = orig.Constraints.getValues();
@@ -1129,6 +1170,8 @@ int SketchObject::addCopyOfConstraints(const SketchObject &orig)
 
 int SketchObject::addConstraint(const Constraint *constraint)
 {
+    Base::StateLocker lock(managedoperation, true); // no need to check input data validity as this is an sketchobject managed operation.
+
     const std::vector< Constraint * > &vals = this->Constraints.getValues();
 
     std::vector< Constraint * > newVals;
@@ -1154,6 +1197,8 @@ int SketchObject::addConstraint(const Constraint *constraint)
 
 int SketchObject::delConstraint(int ConstrId)
 {
+    Base::StateLocker lock(managedoperation, true); // no need to check input data validity as this is an sketchobject managed operation.
+
     const std::vector< Constraint * > &vals = this->Constraints.getValues();
     if (ConstrId < 0 || ConstrId >= int(vals.size()))
         return -1;
@@ -1170,6 +1215,8 @@ int SketchObject::delConstraint(int ConstrId)
 
 int SketchObject::delConstraints(std::vector<int> ConstrIds, bool updategeometry)
 {
+    Base::StateLocker lock(managedoperation, true); // no need to check input data validity as this is an sketchobject managed operation.
+
     const std::vector< Constraint * > &vals = this->Constraints.getValues();
 
     std::vector< Constraint * > newVals(vals);
@@ -1205,6 +1252,8 @@ int SketchObject::delConstraintOnPoint(int VertexId, bool onlyCoincident)
 
 int SketchObject::delConstraintOnPoint(int GeoId, PointPos PosId, bool onlyCoincident)
 {
+    Base::StateLocker lock(managedoperation, true); // no need to check input data validity as this is an sketchobject managed operation.
+
     const std::vector<Constraint *> &vals = this->Constraints.getValues();
 
     // check if constraints can be redirected to some other point
@@ -1314,6 +1363,8 @@ int SketchObject::delConstraintOnPoint(int GeoId, PointPos PosId, bool onlyCoinc
 
 int SketchObject::transferConstraints(int fromGeoId, PointPos fromPosId, int toGeoId, PointPos toPosId)
 {
+    Base::StateLocker lock(managedoperation, true); // no need to check input data validity as this is an sketchobject managed operation.
+
     const std::vector<Constraint *> &vals = this->Constraints.getValues();
     std::vector<Constraint *> newVals(vals);
     std::vector<Constraint *> changed;
@@ -1991,6 +2042,8 @@ int SketchObject::extend(int GeoId, double increment, int endpoint) {
 
 int SketchObject::trim(int GeoId, const Base::Vector3d& point)
 {
+    Base::StateLocker lock(managedoperation, true); // no need to check input data validity as this is an sketchobject managed operation.
+
     if (GeoId < 0 || GeoId > getHighestCurveIndex())
         return -1;
 
@@ -3109,6 +3162,8 @@ bool SketchObject::isCarbonCopyAllowed(App::Document *pDoc, App::DocumentObject 
 
 int SketchObject::addSymmetric(const std::vector<int> &geoIdList, int refGeoId, Sketcher::PointPos refPosId/*=Sketcher::none*/)
 {
+    Base::StateLocker lock(managedoperation, true); // no need to check input data validity as this is an sketchobject managed operation.
+
     const std::vector< Part::Geometry * > &geovals = getInternalGeometry();
     const std::vector< Constraint * > &constrvals = this->Constraints.getValues();
 
@@ -3658,6 +3713,8 @@ int SketchObject::addCopy(const std::vector<int> &geoIdList, const Base::Vector3
                           bool clone /*=false*/, int csize/*=2*/, int rsize/*=1*/, bool constraindisplacement /*= false*/,
                           double perpscale /*= 1.0*/)
 {
+    Base::StateLocker lock(managedoperation, true); // no need to check input data validity as this is an sketchobject managed operation.
+
     const std::vector< Part::Geometry * > &geovals = getInternalGeometry();
 
     const std::vector< Constraint * > &constrvals = this->Constraints.getValues();
@@ -5004,6 +5061,8 @@ int SketchObject::deleteUnusedInternalGeometry(int GeoId, bool delgeoid)
 
 bool SketchObject::convertToNURBS(int GeoId)
 {
+    Base::StateLocker lock(managedoperation, true); // no need to check input data validity as this is an sketchobject managed operation.
+
     if (GeoId > getHighestCurveIndex() ||
         (GeoId < 0 && -GeoId > static_cast<int>(ExternalGeo.size())) ||
         GeoId == -1 || GeoId == -2)
@@ -5080,6 +5139,8 @@ bool SketchObject::convertToNURBS(int GeoId)
 
 bool SketchObject::increaseBSplineDegree(int GeoId, int degreeincrement /*= 1*/)
 {
+    Base::StateLocker lock(managedoperation, true); // no need to check input data validity as this is an sketchobject managed operation.
+
     if (GeoId < 0 || GeoId > getHighestCurveIndex())
         return false;
 
@@ -5118,6 +5179,8 @@ bool SketchObject::increaseBSplineDegree(int GeoId, int degreeincrement /*= 1*/)
 
 bool SketchObject::modifyBSplineKnotMultiplicity(int GeoId, int knotIndex, int multiplicityincr)
 {
+    Base::StateLocker lock(managedoperation, true); // no need to check input data validity as this is an sketchobject managed operation.
+
     #if OCC_VERSION_HEX < 0x060900
         THROWMT(Base::NotImplementedError, QT_TRANSLATE_NOOP("Exceptions", "This version of OCE/OCC does not support knot operation. You need 6.9.0 or higher."))
     #endif
@@ -5306,6 +5369,8 @@ bool SketchObject::modifyBSplineKnotMultiplicity(int GeoId, int knotIndex, int m
 
 int SketchObject::carbonCopy(App::DocumentObject * pObj, bool construction)
 {
+    Base::StateLocker lock(managedoperation, true); // no need to check input data validity as this is an sketchobject managed operation.
+
     // so far only externals to the support of the sketch and datum features
     bool xinv = false, yinv = false;
 
@@ -5459,6 +5524,8 @@ int SketchObject::carbonCopy(App::DocumentObject * pObj, bool construction)
 
 int SketchObject::addExternal(App::DocumentObject *Obj, const char* SubName)
 {
+    Base::StateLocker lock(managedoperation, true); // no need to check input data validity as this is an sketchobject managed operation.
+
     // so far only externals to the support of the sketch and datum features
     if (!isExternalAllowed(Obj->getDocument(), Obj))
        return -1;
@@ -5507,6 +5574,8 @@ int SketchObject::addExternal(App::DocumentObject *Obj, const char* SubName)
 
 int SketchObject::delExternal(int ExtGeoId)
 {
+    Base::StateLocker lock(managedoperation, true); // no need to check input data validity as this is an sketchobject managed operation.
+
     // get the actual lists of the externals
     std::vector<DocumentObject*> Objects     = ExternalGeometry.getValues();
     std::vector<std::string>     SubElements = ExternalGeometry.getSubValues();
@@ -5562,6 +5631,8 @@ int SketchObject::delExternal(int ExtGeoId)
 
 int SketchObject::delAllExternal()
 {
+    Base::StateLocker lock(managedoperation, true); // no need to check input data validity as this is an sketchobject managed operation.
+
     // get the actual lists of the externals
     std::vector<DocumentObject*> Objects     = ExternalGeometry.getValues();
     std::vector<std::string>     SubElements = ExternalGeometry.getSubValues();
@@ -5607,6 +5678,8 @@ int SketchObject::delAllExternal()
 
 int SketchObject::delConstraintsToExternal()
 {
+    Base::StateLocker lock(managedoperation, true); // no need to check input data validity as this is an sketchobject managed operation.
+
     const std::vector< Constraint * > &constraints = Constraints.getValuesForce();
     std::vector< Constraint * > newConstraints(0);
     int GeoId = GeoEnum::RefExt, NullId = Constraint::GeoUndef;
@@ -5736,6 +5809,8 @@ bool SketchObject::evaluateSupport(void)
 
 void SketchObject::validateExternalLinks(void)
 {
+    Base::StateLocker lock(managedoperation, true); // no need to check input data validity as this is an sketchobject managed operation.
+
     std::vector<DocumentObject*> Objects     = ExternalGeometry.getValues();
     std::vector<std::string>     SubElements = ExternalGeometry.getSubValues();
 
@@ -6744,6 +6819,8 @@ bool SketchObject::evaluateConstraints() const
 
 void SketchObject::validateConstraints()
 {
+    Base::StateLocker lock(managedoperation, true); // no need to check input data validity as this is an sketchobject managed operation.
+
     std::vector<Part::Geometry *> geometry = getCompleteGeometry();
     const std::vector<Sketcher::Constraint *>& constraints = Constraints.getValuesForce();
 
@@ -6953,18 +7030,51 @@ void SketchObject::onChanged(const App::Property* prop)
             return;
         }
     }
+
     if (prop == &Geometry || prop == &Constraints) {
-        if(getDocument()->isPerformingTransaction()) {
+
+        if(getDocument()->isPerformingTransaction()) { // undo/redo
             setStatus(App::PendingTransactionUpdate, true);
         }
         else {
             if(!internaltransaction) { // internal sketchobject operations changing both geometry and constraints will explicity perform an update
                 if(prop == &Geometry) {
-                    acceptGeometry(); // if geometry changed, the constraint geometry indices must be updated
+                    if(managedoperation || isRestoring()) {
+                        acceptGeometry(); // if geometry changed, the constraint geometry indices must be updated
+                    }
+                    else { // this change was not effect via SketchObject, but using direct access to properties, check input data
+
+                        // declares constraint invalid if indices go beyond the geometry and any call to getValues with return an empty list until this is fixed.
+                        bool invalidinput = Constraints.checkConstraintIndices(getHighestCurveIndex(),-getExternalGeometryCount());
+
+                        if(!invalidinput) {
+                            acceptGeometry();
+                        }
+                        else {
+                            Base::Console().Error("SketchObject::onChanged(): Unmanaged change of Geometry Property results in invalid constraint indices\n");
+                        }
+                    }
                 }
                 else { // Change is in Constraints
-                    if (Constraints.checkGeometry(getCompleteGeometry())) // if there are invalid geometry indices in the constraints, we need to update them
-                        acceptGeometry();
+
+                    if(managedoperation || isRestoring()) {
+                        Constraints.checkGeometry(getCompleteGeometry());
+                    }
+                    else { // this change was not effect via SketchObject, but using direct access to properties, check input data
+
+                        // declares constraint invalid if indices go beyond the geometry and any call to getValues with return an empty list until this is fixed.
+                        bool invalidinput = Constraints.checkConstraintIndices(getHighestCurveIndex(),-getExternalGeometryCount());
+
+                        if(!invalidinput) {
+                            if (Constraints.checkGeometry(getCompleteGeometry())) { // if there are invalid geometry indices in the constraints, we need to update them
+                                acceptGeometry();
+                            }
+                        }
+                        else {
+                            Base::Console().Error("SketchObject::onChanged(): Unmanaged change of Constraint Property results in invalid constraint indices\n");
+                        }
+
+                    }
                 }
             }
         }
@@ -7004,6 +7114,7 @@ void SketchObject::onUndoRedoFinished()
     //
     // Historically this was "solved" by issuing a recompute, which is absolutely unnecessary and prevents solve() from working before
     // such a recompute
+    Constraints.checkConstraintIndices(getHighestCurveIndex(),-getExternalGeometryCount()); // in case it is redoing an operation with invalid data.
     acceptGeometry();
     solve();
 }
@@ -7076,6 +7187,8 @@ int SketchObject::getVertexIndexGeoPos(int GeoId, PointPos PosId) const
 /// unlocked.
 int SketchObject::changeConstraintsLocking(bool bLock)
 {
+    Base::StateLocker lock(managedoperation, true); // no need to check input data validity as this is an sketchobject managed operation.
+
     int cntSuccess = 0;
     int cntToBeAffected = 0;//==cntSuccess+cntFail
     const std::vector< Constraint * > &vals = this->Constraints.getValues();
@@ -7126,6 +7239,8 @@ bool SketchObject::constraintHasExpression(int constrid) const
  */
 int SketchObject::port_reversedExternalArcs(bool justAnalyze)
 {
+    Base::StateLocker lock(managedoperation, true); // no need to check input data validity as this is an sketchobject managed operation.
+
     int cntToBeAffected = 0;//==cntSuccess+cntFail
     const std::vector< Constraint * > &vals = this->Constraints.getValues();
 

--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -921,8 +921,8 @@ int SketchObject::delGeometry(int GeoId, bool deleteinternalgeo)
         this->Geometry.setValues(newVals);
         this->Constraints.setValues(std::move(newConstraints));
     }
-    // Update geometry indices and rebuild vertexindex now
-    acceptGeometry();
+    // Update geometry indices and rebuild vertexindex now via onChanged, so that ViewProvider::UpdateData is triggered.
+    Geometry.touch();
 
     if(noRecomputes) // if we do not have a recompute, the sketch must be solved to update the DoF of the solver
         solve();
@@ -941,8 +941,8 @@ int SketchObject::deleteAllGeometry()
         this->Geometry.setValues(newVals);
         this->Constraints.setValues(newConstraints);
     }
-
-    acceptGeometry();
+    // Update geometry indices and rebuild vertexindex now via onChanged, so that ViewProvider::UpdateData is triggered.
+    Geometry.touch();
 
     if(noRecomputes) // if we do not have a recompute, the sketch must be solved to update the DoF of the solver
         solve();
@@ -3579,7 +3579,8 @@ int SketchObject::addSymmetric(const std::vector<int> &geoIdList, int refGeoId, 
     }
 
     // we delayed update, so trigger it now.
-    acceptGeometry();
+    // Update geometry indices and rebuild vertexindex now via onChanged, so that ViewProvider::UpdateData is triggered.
+    Geometry.touch();
 
     return Geometry.getSize()-1;
 }
@@ -4004,7 +4005,8 @@ int SketchObject::addCopy(const std::vector<int> &geoIdList, const Base::Vector3
     }
 
     // we inhibited update, so we trigger it now
-    acceptGeometry();
+    // Update geometry indices and rebuild vertexindex now via onChanged, so that ViewProvider::UpdateData is triggered.
+    Geometry.touch();
 
     return Geometry.getSize()-1;
 
@@ -4973,7 +4975,8 @@ bool SketchObject::convertToNURBS(int GeoId)
     }
 
     // trigger update now
-    acceptGeometry();
+    // Update geometry indices and rebuild vertexindex now via onChanged, so that ViewProvider::UpdateData is triggered.
+    Geometry.touch();
 
     delete bspline;
 
@@ -5166,7 +5169,8 @@ bool SketchObject::modifyBSplineKnotMultiplicity(int GeoId, int knotIndex, int m
         this->Constraints.setValues(newcVals);
     }
     // Trigger update now
-    acceptGeometry();
+    // Update geometry indices and rebuild vertexindex now via onChanged, so that ViewProvider::UpdateData is triggered.
+    Geometry.touch();
 
     std::sort (delGeoId.begin(), delGeoId.end());
 
@@ -5307,7 +5311,8 @@ int SketchObject::carbonCopy(App::DocumentObject * pObj, bool construction)
         this->Constraints.setValues(newcVals);
     }
     // we trigger now the update (before dealing with expressions)
-    acceptGeometry();
+    // Update geometry indices and rebuild vertexindex now via onChanged, so that ViewProvider::UpdateData is triggered.
+    Geometry.touch();
 
     int sourceid = 0;
     for (std::vector< Sketcher::Constraint * >::const_iterator it= scvals.begin(); it != scvals.end(); ++it,nextcid++,sourceid++) {

--- a/src/Mod/Sketcher/App/SketchObject.h
+++ b/src/Mod/Sketcher/App/SketchObject.h
@@ -378,6 +378,8 @@ public:
     bool isExternalAllowed(App::Document *pDoc, App::DocumentObject *pObj, eReasonList* rsn = 0) const;
 
     bool isCarbonCopyAllowed(App::Document *pDoc, App::DocumentObject *pObj, bool & xinv, bool & yinv, eReasonList* rsn = 0) const;
+
+    bool isPerformingInternalTransaction() const {return internaltransaction;};
 public:
     // Analyser functions
     int autoConstraint(double precision = Precision::Confusion() * 1000, double angleprecision = M_PI/20, bool includeconstruction = true);

--- a/src/Mod/Sketcher/App/SketchObject.h
+++ b/src/Mod/Sketcher/App/SketchObject.h
@@ -468,6 +468,8 @@ private:
     bool AutoLockTangencyAndPerpty(Constraint* cstr, bool bForce = false, bool bLock = true);
 
     SketchAnalysis * analyser;
+
+    bool internaltransaction;
 };
 
 typedef App::FeaturePythonT<SketchObject> SketchObjectPython;

--- a/src/Mod/Sketcher/App/SketchObject.h
+++ b/src/Mod/Sketcher/App/SketchObject.h
@@ -472,6 +472,8 @@ private:
     SketchAnalysis * analyser;
 
     bool internaltransaction;
+
+    bool managedoperation; // indicates whether changes to properties are the deed of SketchObject or not (for input validation)
 };
 
 typedef App::FeaturePythonT<SketchObject> SketchObjectPython;

--- a/src/Mod/Sketcher/App/planegcs/GCS.cpp
+++ b/src/Mod/Sketcher/App/planegcs/GCS.cpp
@@ -4249,6 +4249,11 @@ SolverReportingManager::Manager().LogToFile("GCS::System::diagnose()\n");
                     for (std::size_t j=0; j < conflictGroupsOrig[i].size(); j++) {
                         if (redundant.count(conflictGroupsOrig[i][j]) > 0) {
                             isRedundant = true;
+
+                            if(debugMode==IterationLevel) {
+                                Base::Console().Log("(Partially) Redundant, Group %d, index %d, Tag: %d\n", i,j, (conflictGroupsOrig[i][j])->getTag());
+                            }
+
                             break;
                         }
                     }

--- a/src/Mod/Sketcher/App/planegcs/GCS.cpp
+++ b/src/Mod/Sketcher/App/planegcs/GCS.cpp
@@ -4204,7 +4204,7 @@ SolverReportingManager::Manager().LogToFile("GCS::System::diagnose()\n");
             clistTmp.reserve(clist.size());
             for (std::vector<Constraint *>::iterator constr=clist.begin();
                 constr != clist.end(); ++constr) {
-                if (skipped.count(*constr) == 0)
+                if ((*constr)->isDriving() && skipped.count(*constr) == 0)
                     clistTmp.push_back(*constr);
             }
 

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -5564,8 +5564,12 @@ void ViewProviderSketch::updateData(const App::Property *prop)
 {
     ViewProvider2DObject::updateData(prop);
 
+    // In the case of an undo/redo transaction, updateData is triggered by SketchObject::onUndoRedoFinished() in the solve()
+    // In the case of an internal transaction, touching the geometry results in a call to updateData.
     if ( edit && !getSketchObject()->getDocument()->isPerformingTransaction() &&
+         !getSketchObject()->isPerformingInternalTransaction() &&
          (prop == &(getSketchObject()->Geometry) || prop == &(getSketchObject()->Constraints))) {
+
         edit->FullyConstrained = false;
         // At this point, we do not need to solve the Sketch
         // If we are adding geometry an update can be triggered before the sketch is actually solved.


### PR DESCRIPTION
Several sketchObject internal improvements and refactors and some GCS bug fixes and improved solver information.

The SketchObject part seeks:
- To avoid unnecessary ViewProvider updates.
- Avoid update operations in a sketch with invalid constraint indices as a result of unmanaged operations.
- Leverage move semantics.