### PR TITLE
Draft: fix rotate function; use get_param instead of get_type

### DIFF
--- a/src/Mod/Draft/draftfunctions/rotate.py
+++ b/src/Mod/Draft/draftfunctions/rotate.py
@@ -143,7 +143,8 @@ def rotate(objectslist, angle, center=App.Vector(0,0,0),
                     break
 
     gui_utils.select(newobjlist)
-    if len(newobjlist) == 1: return newobjlist[0]
+    if len(newobjlist) == 1:
+        return newobjlist[0]
     return newobjlist
 
 


### PR DESCRIPTION
When the `Draft.rotate` function was moved to a separate module (ac13cced02), the `utils.get_param` function was incorrectly replaced by `utils.get_type`, so the function fails in certain conditions.

This restores the correct function.

---

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists
