### PR TITLE
Sketcher: fix crash, when cloning element having a non-driving distance, radius, diameter or angle constraint

### DIFF
--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -3762,6 +3762,7 @@ int SketchObject::addCopy(const std::vector<int> &geoIdList, const Base::Vector3
                                         // Distances on a single Element are mapped to equality constraints in clone mode
                                         Constraint *constNew = (*it)->copy();
                                         constNew->Type = Sketcher::Equal;
+                                        constNew->isDriving = true;
                                         constNew->Second = geoIdMap[(*it)->First]; // first is already (*it->First)
                                         newconstrVals.push_back(constNew);
                                     }
@@ -3769,6 +3770,7 @@ int SketchObject::addCopy(const std::vector<int> &geoIdList, const Base::Vector3
                                         // Angles on a single Element are mapped to parallel constraints in clone mode
                                         Constraint *constNew = (*it)->copy();
                                         constNew->Type = Sketcher::Parallel;
+                                        constNew->isDriving = true;
                                         constNew->Second = geoIdMap[(*it)->First]; // first is already (*it->First)
                                         newconstrVals.push_back(constNew);
                                     }
@@ -3791,6 +3793,7 @@ int SketchObject::addCopy(const std::vector<int> &geoIdList, const Base::Vector3
                                         // Distances on a two Elements, which must be points of the same line are mapped to equality constraints in clone mode
                                         Constraint *constNew = (*it)->copy();
                                         constNew->Type = Sketcher::Equal;
+                                        constNew->isDriving = true;
                                         constNew->FirstPos = Sketcher::none;
                                         constNew->Second = geoIdMap[(*it)->First]; // first is already (*it->First)
                                         constNew->SecondPos = Sketcher::none;


### PR DESCRIPTION
This pull request fixes issue #4393. The crash was caused by creating an equality/parallel constraint between the original and the cloned sketch element. That equality/parallel constraint was created by copying an existing distance, radius, diameter or angle constraint and patching its type. If the original constraint was a non-driving constraint, then this property was taken over into the equality/parallel constraint. The crash happened later in Sketch::updateNonDrivingConstraints() when the constraint value was read from the equality/parallel constraint, which was a NULL pointer in that case. 

- [x ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists
