### PR TITLE
Part: fix handling of attachment offset rotation changes in attachment editor

### DIFF
--- a/src/Mod/Part/AttachmentEditor/TaskAttachmentEditor.py
+++ b/src/Mod/Part/AttachmentEditor/TaskAttachmentEditor.py
@@ -388,15 +388,10 @@ class AttachmentEditorTaskPanel(FrozenClass):
         if index >= 0  and  index <= 2:
             plm.Base = pos
 
-        rot = plm.Rotation;
-        (yaw, pitch, roll) = rot.toEuler()
-        if index==3:
-            yaw = Q(self.form.attachmentOffsetYaw.text()).getValueAs(deg)
-        if index==4:
-            pitch = Q(self.form.attachmentOffsetPitch.text()).getValueAs(deg)
-        if index==5:
-            roll = Q(self.form.attachmentOffsetRoll.text()).getValueAs(deg)
         if index >= 3  and  index <= 5:
+            yaw = Q(self.form.attachmentOffsetYaw.text()).getValueAs(deg)
+            pitch = Q(self.form.attachmentOffsetPitch.text()).getValueAs(deg)
+            roll = Q(self.form.attachmentOffsetRoll.text()).getValueAs(deg)
             rot = App.Rotation(yaw,pitch,roll)
             plm.Rotation = rot
 

--- a/src/Mod/Part/Gui/TaskAttacher.cpp
+++ b/src/Mod/Part/Gui/TaskAttacher.cpp
@@ -455,19 +455,12 @@ void TaskAttacher::onAttachmentOffsetChanged(double /*val*/, int idx)
         pl.setPosition(pos);
     }
 
-    Base::Rotation rot = pl.getRotation();
-    double yaw, pitch, roll;
-    rot.getYawPitchRoll(yaw, pitch, roll);
-    if (idx == 3) {
-        yaw = ui->attachmentOffsetYaw->value().getValueAs(Base::Quantity::Degree);
-    }
-    if (idx == 4) {
-        pitch = ui->attachmentOffsetPitch->value().getValueAs(Base::Quantity::Degree);
-    }
-    if (idx == 5) {
-        roll = ui->attachmentOffsetRoll->value().getValueAs(Base::Quantity::Degree);
-    }
     if (idx >= 3  &&  idx <= 5){
+        double yaw, pitch, roll;
+        yaw = ui->attachmentOffsetYaw->value().getValueAs(Base::Quantity::Degree);
+        pitch = ui->attachmentOffsetPitch->value().getValueAs(Base::Quantity::Degree);
+        roll = ui->attachmentOffsetRoll->value().getValueAs(Base::Quantity::Degree);
+        Base::Rotation rot;
         rot.setYawPitchRoll(yaw,pitch,roll);
         pl.setRotation(rot);
     }


### PR DESCRIPTION
This pull request fixes the non-deterministic behaviour of the rotation controls in the attachment editor(s) as discussed [here](https://forum.freecadweb.org/viewtopic.php?f=3&t=48028). The problem was caused the way how the internal quaternion representation of the rotation was updated from the Euler angels representation in the GUI. When the user changed a single component of the Euler angle, then the event handler first converted the internal quaternion representation back into Euler angles and then replaced only that component by the new value provided by the user. The problem with this approach is that the quaternion-Euler transformation is ambiguous. So, it can happen that the transformation leads to other Euler angles than shown in the GUI. In that case one cannot simply replace one component of the Euler angles.
Now the proposed fix always reads all Euler angles components and transforms them into the quaternion.

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists
