### PR TITLE
[Arch] ignore extrusion direction vector length

### DIFF
--- a/src/Mod/Arch/ArchComponent.py
+++ b/src/Mod/Arch/ArchComponent.py
@@ -537,7 +537,7 @@ class Component(ArchIFC.IfcProduct):
             elif obj.Base.isDerivedFrom("Part::Extrusion"):
                 if obj.Base.Base:
                     base,placement = self.rebase(obj.Base.Base.Shape)
-                    extrusion = FreeCAD.Vector(obj.Base.Dir)
+                    extrusion = FreeCAD.Vector(obj.Base.Dir).normalize()
                     if extrusion.Length == 0:
                         extrusion = FreeCAD.Vector(0,0,1)
                     else:
@@ -557,7 +557,7 @@ class Component(ArchIFC.IfcProduct):
                     if sub.isDerivedFrom("Part::Extrusion"):
                         if sub.Base:
                             base,placement = self.rebase(sub.Base.Shape)
-                            extrusion = FreeCAD.Vector(sub.Dir)
+                            extrusion = FreeCAD.Vector(sub.Dir).normalize()
                             if extrusion.Length == 0:
                                 extrusion = FreeCAD.Vector(0,0,1)
                             else:

--- a/src/Mod/Arch/ArchStructure.py
+++ b/src/Mod/Arch/ArchStructure.py
@@ -818,7 +818,7 @@ class _Structure(ArchComponent.Component):
                         extrusion = obj.Tool.Shape.copy()
             else:
                 if obj.Normal.Length:
-                    normal = Vector(obj.Normal)
+                    normal = Vector(obj.Normal).normalize()
                     if isinstance(placement,list):
                         normal = placement[0].inverse().Rotation.multVec(normal)
                     else:

--- a/src/Mod/Arch/ArchWall.py
+++ b/src/Mod/Arch/ArchWall.py
@@ -1508,6 +1508,7 @@ class _Wall(ArchComponent.Component):
                 base = Part.Face(Part.makePolygon([v1,v2,v3,v4,v1]))
             placement = FreeCAD.Placement()
         if base and placement:
+            normal.normalize()
             extrusion = normal.multiply(height)
             if placement.Rotation.Angle > 0:
                 extrusion = placement.inverse().Rotation.multVec(extrusion)


### PR DESCRIPTION
Fix issue with die length of extrusion direction vector as described here: https://forum.freecadweb.org/viewtopic.php?f=39&t=47276 - harmonized with IFC and general FreeCAD interpretation of extrusion direction vectors. 
