### PR TITLE
Draft: add proper Doxygen groups for Draft documentation

### DIFF
--- a/src/Mod/Draft/Draft.py
+++ b/src/Mod/Draft/Draft.py
@@ -30,19 +30,6 @@ These functions can be used as the backend for the graphical commands
 defined in `DraftTools.py`.
 """
 ## \addtogroup DRAFT
-#  \brief Create and manipulate basic 2D objects
-#
-#  This module offers tools to create and manipulate basic 2D objects
-#
-#  The module allows to create 2D geometric objects such as line, rectangle,
-#  circle, etc., modify these objects by moving, scaling or rotating them,
-#  and offers a couple of other utilities to manipulate further these objects,
-#  such as decompose them (downgrade) into smaller elements.
-#
-#  The functionality of the module is divided into GUI tools, usable from the
-#  visual interface, and corresponding python functions, that can perform
-#  the same operation programmatically.
-#
 #  @{
 
 import FreeCAD as App

--- a/src/Mod/Draft/draft.dox
+++ b/src/Mod/Draft/draft.dox
@@ -1,5 +1,42 @@
 /** \defgroup DRAFT Draft
- *  \ingroup PYTHONWORKBENCHES 
- *  \brief Basic 2D drawing tools and other generic tools 
- */
+\ingroup PYTHONWORKBENCHES
+\brief Basic 2D drawing tools and other generic tools
 
+The Draft workbench provides many tools for building geometrical
+objects in a two-dimensional space, normally supported by a working plane
+that includes a grid.
+
+The grid serves as visual feedback of the coordinates and dimensions
+of the geometrical elements that are created. Moreover, the vertices
+of the elements can be attached to the grid intersections to precisely
+position them in the plane.
+
+The Draft workbench also includes many "Modifier" tools that can be used
+by most objects in the software because these tools work on the internal
+Part::TopoShape property that most 2D and 3D objects have.
+
+The Draft workbench is similar to the Sketcher workbench in that both
+can be used to create 2D objects in a planar surface. However, there is
+an import difference:
+- The Sketcher defines a local coordinate system; all geometrical elements
+  created within it are referenced to this local origin. In addition,
+  the position of those elements, as well as various relationships,
+  are kept through the use of mathematical constraints (verticla, horizontal,
+  parallelism, etc.).
+- On the other hand, the elements created with Draft are placed in the global
+  coordinate system. The elements in Draft don't have constraints, they are
+  freely placed in the 3D space.
+
+The Sketcher Workbench is intended to be used together with the Part
+and PartDesign workbenches to create very fine profiles that can be extruded
+to create complex 3D solids.
+
+The Draft Workbench is more intended to draw exclusively in a 2D plane
+placing points in a grid. Often this behavior is better suited for
+drawing architectural plans, or for quick "drafting" that doesn't need
+to keep mathematical constraints between its elements.
+
+Due to this reason, the Draft Workbench is the foundation on which
+the Arch Workbench sits. All tools of the Draft Workbench are available
+in the Arch Workbench.
+*/

--- a/src/Mod/Draft/draftfunctions/__init__.py
+++ b/src/Mod/Draft/draftfunctions/__init__.py
@@ -39,3 +39,6 @@ represent the public application programming interface (API)
 of the Draft Workbench, and should be made available in the `Draft`
 namespace by importing them in the `Draft` module.
 """
+## \defgroup draftfuctions draftfuctions
+# \ingroup DRAFT
+# \brief Modules with functions for use with scripted objects and GuiCommands.

--- a/src/Mod/Draft/draftfunctions/array.py
+++ b/src/Mod/Draft/draftfunctions/array.py
@@ -22,17 +22,17 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides the object code for Draft array function."""
+"""Provides functions to create non-parametric arrayed copies."""
 ## @package array
-# \ingroup DRAFT
-# \brief Provides the object code for Draft array.
+# \ingroup draftfuctions
+# \brief Provides functions to create non-parametric arrayed copies.
 
+## \addtogroup draftfuctions
+# @{
 import FreeCAD as App
-
 import draftutils.utils as utils
-
-from draftfunctions.move import move
-from draftfunctions.rotate import rotate
+import draftfunctions.move as move
+import draftfunctions.rotate as rotate
 
 
 def array(objectslist, arg1, arg2, arg3, arg4=None, arg5=None, arg6=None):
@@ -77,12 +77,12 @@ def rectArray(objectslist,xvector,yvector,xnum,ynum):
     for xcount in range(xnum):
         currentxvector=App.Vector(xvector).multiply(xcount)
         if not xcount==0:
-            move(objectslist,currentxvector,True)
+            move.move(objectslist,currentxvector,True)
         for ycount in range(ynum):
             currentxvector=App.Vector(currentxvector)
             currentyvector=currentxvector.add(App.Vector(yvector).multiply(ycount))
             if not ycount==0:
-                move(objectslist,currentyvector,True)
+                move.move(objectslist,currentyvector,True)
 
 
 def rectArray2(objectslist,xvector,yvector,zvector,xnum,ynum,znum):
@@ -91,16 +91,16 @@ def rectArray2(objectslist,xvector,yvector,zvector,xnum,ynum,znum):
     for xcount in range(xnum):
         currentxvector=App.Vector(xvector).multiply(xcount)
         if not xcount==0:
-            move(objectslist,currentxvector,True)
+            move.move(objectslist,currentxvector,True)
         for ycount in range(ynum):
             currentxvector=App.Vector(currentxvector)
             currentyvector=currentxvector.add(App.Vector(yvector).multiply(ycount))
             if not ycount==0:
-                move(objectslist,currentyvector,True)
+                move.move(objectslist,currentyvector,True)
             for zcount in range(znum):
                 currentzvector=currentyvector.add(App.Vector(zvector).multiply(zcount))
                 if not zcount==0:
-                    move(objectslist,currentzvector,True)
+                    move.move(objectslist,currentzvector,True)
 
 
 def polarArray(objectslist,center,angle,num):
@@ -109,4 +109,6 @@ def polarArray(objectslist,center,angle,num):
     fraction = float(angle)/num
     for i in range(num):
         currangle = fraction + (i*fraction)
-        rotate(objectslist,currangle,center,copy=True)
+        rotate.rotate(objectslist,currangle,center,copy=True)
+
+## @}

--- a/src/Mod/Draft/draftfunctions/cut.py
+++ b/src/Mod/Draft/draftfunctions/cut.py
@@ -20,13 +20,16 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides provides the code for Draft cut function."""
+"""Provides functions to create a cut object from two objects."""
 ## @package cut
-# \ingroup DRAFT
-# \brief Provides provides the code for Draft cut function.
+# \ingroup draftfuctions
+# \brief Provides functions to create a cut object from two objects.
 
+## \addtogroup draftfuctions
+# @{
 import FreeCAD as App
 import draftutils.gui_utils as gui_utils
+
 from draftutils.translate import _tr
 from draftutils.messages import _err
 
@@ -65,3 +68,5 @@ def cut(object1, object2):
         object2.ViewObject.Visibility = False
 
     return obj
+
+## @}

--- a/src/Mod/Draft/draftfunctions/downgrade.py
+++ b/src/Mod/Draft/draftfunctions/downgrade.py
@@ -20,19 +20,21 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides the code for Draft downgrade function.
+"""Provides functions to downgrade objects by different methods.
 
 See also the `upgrade` function.
 """
 ## @package downgrade
-# \ingroup DRAFT
-# \brief Provides the code for Draft downgrade function.
+# \ingroup draftfuctions
+# \brief Provides functions to downgrade objects by different methods.
 
+## \addtogroup draftfuctions
+# @{
 import FreeCAD as App
-
-import draftutils.gui_utils as gui_utils
 import draftutils.utils as utils
+import draftutils.gui_utils as gui_utils
 import draftfunctions.cut as cut
+
 from draftutils.messages import _msg
 from draftutils.translate import _tr
 
@@ -297,3 +299,5 @@ def downgrade(objects, delete=False, force=None):
 
     gui_utils.select(add_list)
     return add_list, delete_list
+
+## @}

--- a/src/Mod/Draft/draftfunctions/draftify.py
+++ b/src/Mod/Draft/draftfunctions/draftify.py
@@ -20,20 +20,18 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""This module provides the code for Draft draftify function.
-"""
+"""Provides functions to transform sketches into Draft objects."""
 ## @package draftify
-# \ingroup DRAFT
-# \brief This module provides the code for Draft draftify function.
+# \ingroup draftfuctions
+# \brief Provides functions to transform sketches into Draft objects.
 
+## \addtogroup draftfuctions
+# @{
 import FreeCAD as App
-
 import draftutils.gui_utils as gui_utils
-import draftutils.utils as utils
-
-from draftmake.make_block import makeBlock
-from draftmake.make_wire import makeWire
-from draftmake.make_circle import makeCircle
+import draftmake.make_block as make_block
+import draftmake.make_wire as make_wire
+import draftmake.make_circle as make_circle
 
 
 def draftify(objectslist, makeblock=False, delete=True):
@@ -66,12 +64,12 @@ def draftify(objectslist, makeblock=False, delete=True):
                 w = Part.Wire(cluster)
                 if DraftGeomUtils.hasCurves(w):
                     if (len(w.Edges) == 1) and (DraftGeomUtils.geomType(w.Edges[0]) == "Circle"):
-                        nobj = makeCircle(w.Edges[0])
+                        nobj = make_circle.make_circle(w.Edges[0])
                     else:
                         nobj = App.ActiveDocument.addObject("Part::Feature", obj.Name)
                         nobj.Shape = w
                 else:
-                    nobj = makeWire(w)
+                    nobj = make_wire.make_wire(w)
                 newobjlist.append(nobj)
                 gui_utils.format_object(nobj, obj)
                 # sketches are always in wireframe mode. In Draft we don't like that!
@@ -81,8 +79,10 @@ def draftify(objectslist, makeblock=False, delete=True):
                 App.ActiveDocument.removeObject(obj.Name)
 
     if makeblock:
-        return makeBlock(newobjlist)
+        return make_block.make_block(newobjlist)
     else:
         if len(newobjlist) == 1:
             return newobjlist[0]
         return newobjlist
+
+## @}

--- a/src/Mod/Draft/draftfunctions/extrude.py
+++ b/src/Mod/Draft/draftfunctions/extrude.py
@@ -20,14 +20,14 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""This module provides the code for Draft extrude function.
-"""
+"""Provides functions to create an extrusion object from a profile."""
 ## @package extrude
-# \ingroup DRAFT
-# \brief This module provides the code for Draft extrude function.
+# \ingroup draftfuctions
+# \brief Provides functions to create an extrusion object from a profile.
 
+## \addtogroup draftfuctions
+# @{
 import FreeCAD as App
-
 import draftutils.gui_utils as gui_utils
 
 
@@ -59,3 +59,5 @@ def extrude(obj, vector, solid=False):
         gui_utils.select(newobj)
 
     return newobj
+
+## @}

--- a/src/Mod/Draft/draftfunctions/fuse.py
+++ b/src/Mod/Draft/draftfunctions/fuse.py
@@ -20,18 +20,18 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""This module provides the code for Draft fuse function.
-"""
+"""Provides functions to create a fusion of two shapes."""
 ## @package fuse
-# \ingroup DRAFT
-# \brief This module provides the code for Draft fuse function.
+# \ingroup draftfuctions
+# \brief Provides functions to create a fusion of two shapes.
 
+## \addtogroup draftfuctions
+# @{
 import FreeCAD as App
-
 import draftutils.gui_utils as gui_utils
-import draftutils.utils as utils
 
 from draftmake.make_wire import Wire
+
 if App.GuiUp:
     from draftviewproviders.view_wire import ViewProviderWire
 
@@ -78,3 +78,5 @@ def fuse(object1, object2):
         gui_utils.select(obj)
 
     return obj
+
+## @}

--- a/src/Mod/Draft/draftfunctions/heal.py
+++ b/src/Mod/Draft/draftfunctions/heal.py
@@ -20,15 +20,14 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""This module provides the code for Draft heal function.
-"""
+"""Provides functions to repair certain objects created with old versions."""
 ## @package heal
-# \ingroup DRAFT
-# \brief This module provides the code for Draft heal function.
+# \ingroup draftfuctions
+# \brief Provides functions to repair certain objects from old versions.
 
+## \addtogroup draftfuctions
+# @{
 import FreeCAD as App
-
-import draftutils.gui_utils as gui_utils
 import draftutils.utils as utils
 
 from draftmake.make_copy import make_copy
@@ -113,3 +112,5 @@ def heal(objlist=None, delete=True, reparent=True):
     if dellist and delete:
         for n in dellist:
             App.ActiveDocument.removeObject(n)
+
+## @}

--- a/src/Mod/Draft/draftfunctions/join.py
+++ b/src/Mod/Draft/draftfunctions/join.py
@@ -20,12 +20,13 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""This module provides the code for Draft join functions.
-"""
+"""Provides functions to join wires together into a single wire."""
 ## @package join
-# \ingroup DRAFT
-# \brief This module provides the code for Draft join functions.
+# \ingroup draftfuctions
+# \brief Provides functions to join wires together into a single wire.
 
+## \addtogroup draftfuctions
+# @{
 import FreeCAD as App
 
 
@@ -89,3 +90,5 @@ def join_two_wires(wire1, wire2):
 
 
 joinTwoWires = join_two_wires
+
+## @}

--- a/src/Mod/Draft/draftfunctions/mirror.py
+++ b/src/Mod/Draft/draftfunctions/mirror.py
@@ -21,19 +21,21 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides the code for the mirror operation.
+"""Provides functions to produce a mirrored object.
 
 It just creates a `Part::Mirroring` object, and sets the appropriate
 `Source` and `Normal` properties.
 """
 ## @package mirror
-# \ingroup DRAFT
-# \brief Provides the code for the mirror operation.
+# \ingroup draftfunctions
+# \brief Provides functions to produce a mirrored object.
 
+## \addtogroup draftfuctions
+# @{
 import FreeCAD as App
-
 import draftutils.utils as utils
 import draftutils.gui_utils as gui_utils
+
 from draftutils.messages import _err
 from draftutils.translate import _tr
 
@@ -120,3 +122,5 @@ def mirror(objlist, p1, p2):
         gui_utils.select(result)
 
     return result
+
+## @}

--- a/src/Mod/Draft/draftfunctions/move.py
+++ b/src/Mod/Draft/draftfunctions/move.py
@@ -20,21 +20,20 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""This module provides the code for Draft move function.
-"""
+"""Provides functions to move objects from one position to another."""
 ## @package move
-# \ingroup DRAFT
-# \brief This module provides the code for Draft move function.
+# \ingroup draftfuctions
+# \brief Provides functions to move objects from one position to another.
 
+## \addtogroup draftfuctions
+# @{
 import FreeCAD as App
-
 import draftutils.utils as utils
-import draftutils.groups as groups
 import draftutils.gui_utils as gui_utils
-
-from draftmake.make_copy import make_copy
-from draftmake.make_line import make_line
-from draftfunctions.join import join_wires
+import draftutils.groups as groups
+import draftfunctions.join as join
+import draftmake.make_copy as make_copy
+import draftmake.make_line as make_line
 
 
 def move(objectslist, vector, copy=False):
@@ -81,7 +80,7 @@ def move(objectslist, vector, copy=False):
 
         if utils.get_type(obj) == "Point":
             if copy:
-                newobj = make_copy(obj)
+                newobj = make_copy.make_copy(obj)
             else:
                 newobj = obj
             newobj.X = obj.X + real_vector.x
@@ -93,7 +92,7 @@ def move(objectslist, vector, copy=False):
 
         elif hasattr(obj,'Shape'):
             if copy:
-                newobj = make_copy(obj)
+                newobj = make_copy.make_copy(obj)
             else:
                 newobj = obj
             pla = newobj.Placement
@@ -101,21 +100,21 @@ def move(objectslist, vector, copy=False):
 
         elif utils.get_type(obj) == "Annotation":
             if copy:
-                newobj = make_copy(obj)
+                newobj = make_copy.make_copy(obj)
             else:
                 newobj = obj
             newobj.Position = obj.Position.add(real_vector)
 
         elif utils.get_type(obj) in ("Text", "DraftText"):
             if copy:
-                newobj = make_copy(obj)
+                newobj = make_copy.make_copy(obj)
             else:
                 newobj = obj
             newobj.Placement.Base = obj.Placement.Base.add(real_vector)
 
         elif utils.get_type(obj) in ["Dimension", "LinearDimension"]:
             if copy:
-                newobj = make_copy(obj)
+                newobj = make_copy.make_copy(obj)
             else:
                 newobj = obj
             newobj.Start = obj.Start.add(real_vector)
@@ -124,14 +123,14 @@ def move(objectslist, vector, copy=False):
 
         elif utils.get_type(obj) in ["AngularDimension"]:
             if copy:
-                newobj = make_copy(obj)
+                newobj = make_copy.make_copy(obj)
             else:
                 newobj = obj
             newobj.Center = obj.Start.add(real_vector)
 
         elif "Placement" in obj.PropertiesList:
             if copy:
-                newobj = make_copy(obj)
+                newobj = make_copy.make_copy(obj)
             else:
                 newobj = obj
             pla = obj.Placement
@@ -198,7 +197,7 @@ def copy_moved_edges(arguments):
     copied_edges = []
     for argument in arguments:
         copied_edges.append(copy_moved_edge(argument[0], argument[1], argument[2]))
-    join_wires(copied_edges)
+    join.join_wires(copied_edges)
 
 
 copyMovedEdges = copy_moved_edges
@@ -214,4 +213,6 @@ def copy_moved_edge(object, edge_index, vector):
         vertex2 = object.Placement.multVec(object.Points[0]).add(vector)
     else:
         vertex2 = object.Placement.multVec(object.Points[edge_index+1]).add(vector)
-    return make_line(vertex1, vertex2)
+    return make_line.make_line(vertex1, vertex2)
+
+## @}

--- a/src/Mod/Draft/draftfunctions/offset.py
+++ b/src/Mod/Draft/draftfunctions/offset.py
@@ -20,23 +20,21 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""This module provides the code for Draft offset function.
-"""
+"""Provides functions to create offsets of different shapes."""
 ## @package offset
-# \ingroup DRAFT
-# \brief This module provides the code for Draft offset function.
+# \ingroup draftfuctions
+# \brief Provides functions to create offsets of different shapes.
 
+## \addtogroup draftfuctions
+# @{
 import math
 
 import FreeCAD as App
-
 import DraftVecUtils
-
 import draftutils.gui_utils as gui_utils
 import draftutils.utils as utils
 
 from draftmake.make_copy import make_copy
-
 from draftmake.make_rectangle import makeRectangle
 from draftmake.make_wire import makeWire
 from draftmake.make_polygon import makePolygon
@@ -244,3 +242,5 @@ def offset(obj, delta, copy=False, bind=False, sym=False, occ=False):
     if delete:
         App.ActiveDocument.removeObject(delete)
     return newobj
+
+## @}

--- a/src/Mod/Draft/draftfunctions/rotate.py
+++ b/src/Mod/Draft/draftfunctions/rotate.py
@@ -20,24 +20,23 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""This module provides the code for Draft rotate function.
-"""
+"""Provides functions to rotate shapes around a center and axis."""
 ## @package rotate
-# \ingroup DRAFT
-# \brief This module provides the code for Draft rotate function.
+# \ingroup draftfuctions
+# \brief Provides functions to rotate shapes around a center and axis.
 
+## \addtogroup draftfuctions
+# @{
 import math
 
 import FreeCAD as App
 import DraftVecUtils
-
 import draftutils.utils as utils
-import draftutils.groups as groups
 import draftutils.gui_utils as gui_utils
-
-from draftfunctions.join import join_wires
-from draftmake.make_line import make_line
-from draftmake.make_copy import make_copy
+import draftutils.groups as groups
+import draftfunctions.join as join
+import draftmake.make_line as make_line
+import draftmake.make_copy as make_copy
 
 
 def rotate(objectslist, angle, center=App.Vector(0,0,0),
@@ -91,7 +90,7 @@ def rotate(objectslist, angle, center=App.Vector(0,0,0),
             real_axis = axis
 
         if copy:
-            newobj = make_copy(obj)
+            newobj = make_copy.make_copy(obj)
         else:
             newobj = obj
         if obj.isDerivedFrom("App::Annotation"):
@@ -207,7 +206,7 @@ def copy_rotated_edges(arguments):
     for argument in arguments:
         copied_edges.append(copy_rotated_edge(argument[0], argument[1],
             argument[2], argument[3], argument[4]))
-    join_wires(copied_edges)
+    join.join_wires(copied_edges)
 
 
 copyRotatedEdges = copy_rotated_edges
@@ -229,5 +228,6 @@ def copy_rotated_edge(object, edge_index, angle, center, axis):
         vertex2 = rotate_vector_from_center(
             object.Placement.multVec(object.Points[edge_index+1]),
             angle, axis, center)
-    return make_line(vertex1, vertex2)
-    
+    return make_line.make_line(vertex1, vertex2)
+
+## @}

--- a/src/Mod/Draft/draftfunctions/scale.py
+++ b/src/Mod/Draft/draftfunctions/scale.py
@@ -20,24 +20,19 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""This module provides the code for Draft scale function.
-"""
+"""Provides functions to scale shapes."""
 ## @package scale
-# \ingroup DRAFT
-# \brief This module provides the code for Draft scale function.
+# \ingroup draftfuctions
+# \brief Provides functions to scale shapes.
 
-import math
-
+## \addtogroup draftfuctions
+# @{
 import FreeCAD as App
-
 import DraftVecUtils
-
-import draftutils.gui_utils as gui_utils
 import draftutils.utils as utils
-
-from draftfunctions.join import join_wires
-
-from draftmake.make_copy import make_copy
+import draftutils.gui_utils as gui_utils
+import draftfunctions.join as join
+import draftmake.make_copy as make_copy
 
 
 def scale(objectslist, scale=App.Vector(1,1,1),
@@ -70,7 +65,7 @@ def scale(objectslist, scale=App.Vector(1,1,1),
     newobjlist = []
     for obj in objectslist:
         if copy:
-            newobj = make_copy(obj)
+            newobj = make_copy.make_copy(obj)
         else:
             newobj = obj
         if hasattr(obj,'Shape'):
@@ -202,7 +197,9 @@ def copy_scaled_edges(arguments):
     for argument in arguments:
         copied_edges.append(copyScaledEdge(argument[0], argument[1],
             argument[2], argument[3]))
-    join_wires(copied_edges)
+    join.join_wires(copied_edges)
 
 
 copyScaledEdges = copy_scaled_edges
+
+## @}

--- a/src/Mod/Draft/draftfunctions/split.py
+++ b/src/Mod/Draft/draftfunctions/split.py
@@ -20,15 +20,15 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""This module provides the code for Draft split functions.
-"""
+"""Provides functions to split wires into separate wire objects."""
 ## @package split
-# \ingroup DRAFT
-# \brief This module provides the code for Draft split functions.
+# \ingroup draftfuctions
+# \brief Provides functions to split wires into separate wire objects.
 
+## \addtogroup draftfuctions
+# @{
 import draftutils.utils as utils
-
-from draftmake.make_wire import make_wire
+import draftmake.make_wire as make_wire
 
 
 def split(wire, newPoint, edgeIndex):
@@ -43,10 +43,10 @@ def split(wire, newPoint, edgeIndex):
 def split_closed_wire(wire, edgeIndex):
     wire.Closed = False
     if edgeIndex == len(wire.Points):
-        make_wire([wire.Placement.multVec(wire.Points[0]),
+        make_wire.make_wire([wire.Placement.multVec(wire.Points[0]),
             wire.Placement.multVec(wire.Points[-1])], placement=wire.Placement)
     else:
-        make_wire([wire.Placement.multVec(wire.Points[edgeIndex-1]),
+        make_wire.make_wire([wire.Placement.multVec(wire.Points[edgeIndex-1]),
             wire.Placement.multVec(wire.Points[edgeIndex])], placement=wire.Placement)
         wire.Points = list(reversed(wire.Points[0:edgeIndex])) + list(reversed(wire.Points[edgeIndex:]))
 
@@ -67,7 +67,9 @@ def split_open_wire(wire, newPoint, edgeIndex):
         elif index > edgeIndex:
             wire2Points.append(wire.Placement.multVec(point))
     wire.Points = wire1Points
-    make_wire(wire2Points, placement=wire.Placement)
+    make_wire.make_wire(wire2Points, placement=wire.Placement)
 
 
 splitOpenWire = split_open_wire
+
+## @}

--- a/src/Mod/Draft/draftfunctions/upgrade.py
+++ b/src/Mod/Draft/draftfunctions/upgrade.py
@@ -20,21 +20,20 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides the code for Draft upgrade function.
+"""Provides functions to upgrade objects by different methods.
 
 See also the `downgrade` function.
 """
 ## @package downgrade
-# \ingroup DRAFT
-# \brief Provides the code for Draft upgrade function.
+# \ingroup draftfuctions
+# \brief Provides functions to upgrade objects by different methods.
 
 import re
+import lazy_loader.lazy_loader as lz
 
 import FreeCAD as App
-
-import lazy_loader.lazy_loader as lz
-import draftutils.gui_utils as gui_utils
 import draftutils.utils as utils
+import draftutils.gui_utils as gui_utils
 import draftfunctions.draftify as ext_draftify
 import draftfunctions.fuse as fuse
 import draftmake.make_line as make_line
@@ -48,7 +47,11 @@ from draftutils.translate import _tr
 Part = lz.LazyLoader("Part", globals(), "Part")
 DraftGeomUtils = lz.LazyLoader("DraftGeomUtils", globals(), "DraftGeomUtils")
 Arch = lz.LazyLoader("Arch", globals(), "Arch")
+
 _DEBUG = False
+
+## \addtogroup draftfuctions
+# @{
 
 
 def upgrade(objects, delete=False, force=None):
@@ -505,3 +508,5 @@ def upgrade(objects, delete=False, force=None):
 
     gui_utils.select(add_list)
     return add_list, delete_list
+
+## @}

--- a/src/Mod/Draft/draftgeoutils/__init__.py
+++ b/src/Mod/Draft/draftgeoutils/__init__.py
@@ -38,3 +38,6 @@ part of the Draft workbench programming interface yet.
 
 These functions were previously defined in the big `DraftGeomUtils` module.
 """
+## \defgroup draftgeoutils draftgeoutils
+# \ingroup DRAFT
+# \brief Functions that are meant to handle different geometrical operations

--- a/src/Mod/Draft/draftgeoutils/arcs.py
+++ b/src/Mod/Draft/draftgeoutils/arcs.py
@@ -21,10 +21,10 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides various functions for arc operations."""
+"""Provides various functions to work with arcs."""
 ## @package arcs
-# \ingroup DRAFTGEOUTILS
-# \brief Provides various functions for arc operations.
+# \ingroup draftgeoutils
+# \brief Provides various functions to work with arcs.
 
 import math
 import lazy_loader.lazy_loader as lz
@@ -36,6 +36,9 @@ from draftgeoutils.general import geomType
 
 # Delay import of module until first use because it is heavy
 Part = lz.LazyLoader("Part", globals(), "Part")
+
+## \addtogroup draftgeoutils
+# @{
 
 
 def isClockwise(edge, ref=None):
@@ -142,3 +145,5 @@ def arcFromSpline(edge):
         except Part.OCCError:
             print("couldn't make a circle out of this edge")
             return None
+
+## @}

--- a/src/Mod/Draft/draftgeoutils/circle_inversion.py
+++ b/src/Mod/Draft/draftgeoutils/circle_inversion.py
@@ -26,7 +26,7 @@
 http://en.wikipedia.org/wiki/Inversive_geometry
 """
 ## @package circle_inversion
-# \ingroup DRAFTGEOUTILS
+# \ingroup draftgeoutils
 # \brief Provides various functions for inversive geometry operations.
 
 import lazy_loader.lazy_loader as lz
@@ -39,6 +39,9 @@ from draftgeoutils.geometry import findDistance
 
 # Delay import of module until first use because it is heavy
 Part = lz.LazyLoader("Part", globals(), "Part")
+
+## \addtogroup draftgeoutils
+# @{
 
 
 def pointInversion(circle, point):
@@ -117,3 +120,5 @@ def circleInversion(circle, circle2):
     return Part.Circle(invCen2,
                        NORM,
                        DraftVecUtils.dist(invCen2, invPointOnCircle2))
+
+## @}

--- a/src/Mod/Draft/draftgeoutils/circles.py
+++ b/src/Mod/Draft/draftgeoutils/circles.py
@@ -21,10 +21,10 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides various functions for circle operations."""
+"""Provides various functions to work with circles."""
 ## @package circles
-# \ingroup DRAFTGEOUTILS
-# \brief Provides various functions for circle operations.
+# \ingroup draftgeoutils
+# \brief Provides various functions to work with circles.
 
 import math
 import lazy_loader.lazy_loader as lz
@@ -39,6 +39,9 @@ from draftgeoutils.intersections import findIntersection, angleBisection
 
 # Delay import of module until first use because it is heavy
 Part = lz.LazyLoader("Part", globals(), "Part")
+
+## \addtogroup draftgeoutils
+# @{
 
 
 def findClosestCircle(point, circles):
@@ -490,3 +493,5 @@ def findRadicalCenter(circle1, circle2, circle3):
     else:
         # No radical center could be calculated.
         return None
+
+## @}

--- a/src/Mod/Draft/draftgeoutils/circles_apollonius.py
+++ b/src/Mod/Draft/draftgeoutils/circles_apollonius.py
@@ -21,7 +21,7 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides various functions for Appollonius and Soddy circle operations.
+"""Provides various functions for Apollonius and Soddy circle operations.
 
 The 'problem of Appollonius' consists of finding a circle that is
 simultaneously tangent to three circles on a plane.
@@ -40,8 +40,8 @@ and an outer circle.
 - http://mathworld.wolfram.com/OuterSoddyCenter.html
 """
 ## @package circles_apollonius
-# \ingroup DRAFTGEOUTILS
-# \brief Provides various functions for Appollonius and Soddy circles.
+# \ingroup draftgeoutils
+# \brief Provides various functions for Apollonius and Soddy circles.
 
 import cmath
 import math
@@ -54,6 +54,9 @@ from draftgeoutils.intersections import findIntersection
 
 # Delay import of module until first use because it is heavy
 Part = lz.LazyLoader("Part", globals(), "Part")
+
+## \addtogroup draftgeoutils
+# @{
 
 
 def outerSoddyCircle(circle1, circle2, circle3):
@@ -218,3 +221,5 @@ def circleFrom3CircleTangents(circle1, circle2, circle3):
     else:
         # Some circles are inside each other or an error has occurred.
         return None
+
+## @}

--- a/src/Mod/Draft/draftgeoutils/circles_incomplete.py
+++ b/src/Mod/Draft/draftgeoutils/circles_incomplete.py
@@ -48,9 +48,11 @@ or to a circular edge, so even more combinations are possible.
 And so on, with the other combinations.
 """
 ## @package circles_incomplete
-# \ingroup DRAFTGEOUTILS
+# \ingroup draftgeoutils
 # \brief Provides various incomplete functions for creating circles.
 
+## \addtogroup draftgeoutils
+# @{
 import FreeCAD
 
 from draftutils.messages import _wrn
@@ -216,3 +218,5 @@ def circleFrom3tan(tan1, tan2, tan3):
 
     elif tan1IsCircle and tan2IsCircle and tan3IsLine:
         return circleFrom2Circle1Lines(tan1, tan2, tan3)
+
+## @}

--- a/src/Mod/Draft/draftgeoutils/cuboids.py
+++ b/src/Mod/Draft/draftgeoutils/cuboids.py
@@ -21,11 +21,13 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides various functions for cubic shapes (parallelepipeds)."""
+"""Provides various functions to work with cubic shapes (parallelepipeds)."""
 ## @package cuboids
-# \ingroup DRAFTGEOUTILS
+# \ingroup draftgeoutils
 # \brief Provides various functions for cubic shapes (parallelepipeds).
 
+## \addtogroup draftgeoutils
+# @{
 import math
 
 import FreeCAD as App
@@ -128,3 +130,5 @@ def getCubicDimensions(shape):
             round(vx.Length, precision()),
             round(vy.Length, precision()),
             round(vz.Length, precision())]
+
+## @}

--- a/src/Mod/Draft/draftgeoutils/edges.py
+++ b/src/Mod/Draft/draftgeoutils/edges.py
@@ -21,10 +21,10 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides various functions for using edges."""
+"""Provides various functions to work with edges."""
 ## @package edges
-# \ingroup DRAFTGEOUTILS
-# \brief Provides various functions for using edges.
+# \ingroup draftgeoutils
+# \brief Provides various functions to work with edges.
 
 import lazy_loader.lazy_loader as lz
 
@@ -35,6 +35,9 @@ from draftgeoutils.general import geomType, vec
 
 # Delay import of module until first use because it is heavy
 Part = lz.LazyLoader("Part", globals(), "Part")
+
+## \addtogroup draftgeoutils
+# @{
 
 
 def findEdge(anEdge, aList):
@@ -205,3 +208,5 @@ def getTangent(edge, from_point=None):
         return v1.cross(edge.Curve.Axis)
 
     return None
+
+## @}

--- a/src/Mod/Draft/draftgeoutils/faces.py
+++ b/src/Mod/Draft/draftgeoutils/faces.py
@@ -21,10 +21,10 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides various functions for working with faces."""
+"""Provides various functions to work with faces."""
 ## @package faces
-# \ingroup DRAFTGEOUTILS
-# \brief Provides various functions for working with faces.
+# \ingroup draftgeoutils
+# \brief Provides various functions to work with faces.
 
 import lazy_loader.lazy_loader as lz
 
@@ -34,6 +34,9 @@ from draftgeoutils.general import precision
 
 # Delay import of module until first use because it is heavy
 Part = lz.LazyLoader("Part", globals(), "Part")
+
+## \addtogroup draftgeoutils
+# @{
 
 
 def concatenate(shape):
@@ -258,3 +261,5 @@ def removeSplitter(shape):
             return face
 
     return None
+
+## @}

--- a/src/Mod/Draft/draftgeoutils/fillets.py
+++ b/src/Mod/Draft/draftgeoutils/fillets.py
@@ -21,10 +21,10 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides various functions for working with fillets."""
+"""Provides various functions to work with fillets."""
 ## @package fillets
-# \ingroup DRAFTGEOUTILS
-# \brief Provides various functions for working with fillets.
+# \ingroup draftgeoutils
+# \brief Provides various functions to work with fillets.
 
 import math
 import lazy_loader.lazy_loader as lz
@@ -37,6 +37,9 @@ from draftgeoutils.wires import isReallyClosed
 
 # Delay import of module until first use because it is heavy
 Part = lz.LazyLoader("Part", globals(), "Part")
+
+## \addtogroup draftgeoutils
+# @{
 
 
 def fillet(lEdges, r, chamfer=False):
@@ -393,3 +396,5 @@ def filletWire(aWire, r, chamfer=False):
             filEdges[0] = result[2]
 
     return Part.Wire(filEdges)
+
+## @}

--- a/src/Mod/Draft/draftgeoutils/general.py
+++ b/src/Mod/Draft/draftgeoutils/general.py
@@ -21,10 +21,10 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides general functions for shape operations."""
+"""Provides general functions to work with topological shapes."""
 ## @package general
-# \ingroup DRAFTGEOUTILS
-# \brief Provides basic functions for shape operations.
+# \ingroup draftgeoutils
+# \brief Provides general functions to work with topological shapes.
 
 import math
 import lazy_loader.lazy_loader as lz
@@ -35,6 +35,8 @@ import DraftVecUtils
 # Delay import of module until first use because it is heavy
 Part = lz.LazyLoader("Part", globals(), "Part")
 
+## \addtogroup draftgeoutils
+# @{
 PARAMGRP = App.ParamGet("User parameter:BaseApp/Preferences/Mod/Draft")
 
 # Default normal direction for all geometry operations
@@ -339,3 +341,5 @@ def getBoundaryAngles(angle, alist):
                 higher = a
 
     return lower, higher
+
+## @}

--- a/src/Mod/Draft/draftgeoutils/geometry.py
+++ b/src/Mod/Draft/draftgeoutils/geometry.py
@@ -21,10 +21,10 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides various functions for working with geometrical elements."""
+"""Provides various functions for general geometrical calculations."""
 ## @package geometry
-# \ingroup DRAFTGEOUTILS
-# \brief Provides various functions for working with geometry.
+# \ingroup draftgeoutils
+# \brief Provides various functions for general geometrical calculations.
 
 import math
 import lazy_loader.lazy_loader as lz
@@ -38,6 +38,9 @@ from draftgeoutils.general import geomType, vec
 
 # Delay import of module until first use because it is heavy
 Part = lz.LazyLoader("Part", globals(), "Part")
+
+## \addtogroup draftgeoutils
+# @{
 
 
 def findPerpendicular(point, edgeslist, force=None):
@@ -333,3 +336,5 @@ def mirror(point, edge):
         return refl
     else:
         return None
+
+## @}

--- a/src/Mod/Draft/draftgeoutils/intersections.py
+++ b/src/Mod/Draft/draftgeoutils/intersections.py
@@ -21,10 +21,10 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides basic functions for calculating intersections of shapes."""
+"""Provides various functions to calculate intersections of shapes."""
 ## @package intersections
-# \ingroup DRAFTGEOUTILS
-# \brief Provides basic functions for calculating intersections of shapes.
+# \ingroup draftgeoutils
+# \brief Provides various functions to calculate intersections of shapes.
 
 import lazy_loader.lazy_loader as lz
 
@@ -36,6 +36,9 @@ from draftgeoutils.edges import findMidpoint
 
 # Delay import of module until first use because it is heavy
 Part = lz.LazyLoader("Part", globals(), "Part")
+
+## \addtogroup draftgeoutils
+# @{
 
 
 def findIntersection(edge1, edge2,
@@ -411,3 +414,5 @@ def angleBisection(edge1, edge2):
         direction.normalize()
 
     return Part.LineSegment(origin, origin.add(direction)).toShape()
+
+## @}

--- a/src/Mod/Draft/draftgeoutils/linear_algebra.py
+++ b/src/Mod/Draft/draftgeoutils/linear_algebra.py
@@ -21,14 +21,16 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides various functions for linear algebraic operations.
+"""Provides various functions for linear algebra.
 
 This includes calculating linear equation parameters, and matrix determinants.
 """
 ## @package linear_algebra
-# \ingroup DRAFTGEOUTILS
-# \brief Provides various functions for linear algebraic operations.
+# \ingroup draftgeoutils
+# \brief Provides various functions for linear algebra.
 
+## \addtogroup draftgeoutils
+# @{
 import FreeCAD as App
 
 
@@ -82,3 +84,5 @@ def determinant(mat, n):
         return d
     else:
         return 0
+
+## @}

--- a/src/Mod/Draft/draftgeoutils/offsets.py
+++ b/src/Mod/Draft/draftgeoutils/offsets.py
@@ -21,10 +21,10 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides various functions for offset operations."""
+"""Provides various functions to work with offsets."""
 ## @package offsets
-# \ingroup DRAFTGEOUTILS
-# \brief Provides various functions for offset operations.
+# \ingroup draftgeoutils
+# \brief Provides various functions to work with offsets.
 
 import lazy_loader.lazy_loader as lz
 
@@ -38,6 +38,9 @@ from draftgeoutils.intersections import wiresIntersect, connect
 
 # Delay import of module until first use because it is heavy
 Part = lz.LazyLoader("Part", globals(), "Part")
+
+## \addtogroup draftgeoutils
+# @{
 
 
 def pocket2d(shape, offset):
@@ -493,3 +496,5 @@ def offsetWire(wire, dvec, bind=False, occ=False,
         return w
     else:
         return nedges
+
+## @}

--- a/src/Mod/Draft/draftgeoutils/sort_edges.py
+++ b/src/Mod/Draft/draftgeoutils/sort_edges.py
@@ -21,10 +21,10 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides various functions for sorting edges."""
+"""Provides various functions to sort lists of edges."""
 ## @package sort_edges
-# \ingroup DRAFTGEOUTILS
-# \brief Provides various functions for sorting edges.
+# \ingroup draftgeoutils
+# \brief Provides various functions to sort lists of edges.
 
 import lazy_loader.lazy_loader as lz
 
@@ -33,6 +33,9 @@ from draftgeoutils.edges import findMidpoint, isLine, invert
 
 # Delay import of module until first use because it is heavy
 Part = lz.LazyLoader("Part", globals(), "Part")
+
+## \addtogroup draftgeoutils
+# @{
 
 
 def sortEdges(edges):
@@ -221,3 +224,5 @@ def sortEdgesOld(lEdges, aVertex=None):
             return olEdges
         else:
             return []
+
+## @}

--- a/src/Mod/Draft/draftgeoutils/wires.py
+++ b/src/Mod/Draft/draftgeoutils/wires.py
@@ -21,10 +21,10 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides various functions for working with wires."""
+"""Provides various functions to work with wires."""
 ## @package wires
-# \ingroup DRAFTGEOUTILS
-# \brief Provides various functions for working with wires.
+# \ingroup draftgeoutils
+# \brief Provides various functions to work with wires.
 
 import math
 import lazy_loader.lazy_loader as lz
@@ -38,6 +38,9 @@ from draftgeoutils.edges import findMidpoint, isLine
 
 # Delay import of module until first use because it is heavy
 Part = lz.LazyLoader("Part", globals(), "Part")
+
+## \addtogroup draftgeoutils
+# @{
 
 
 def findWires(edgeslist):
@@ -429,3 +432,5 @@ def tessellateProjection(shape, seglen):
             print("Debug: error cleaning edge ", e)
 
     return Part.makeCompound(newedges)
+
+## @}

--- a/src/Mod/Draft/draftguitools/__init__.py
+++ b/src/Mod/Draft/draftguitools/__init__.py
@@ -63,3 +63,6 @@ namespaces, so they are accessible at all times.
 These classes can be imported and initialized individually
 but it is easier to set them up just by importing `DraftTools`.
 """
+## \defgroup draftguitools draftguitools
+# \ingroup DRAFT
+# \brief Modules that define the workbench GuiCommands to perform actions.

--- a/src/Mod/Draft/draftguitools/gui_annotationstyleeditor.py
+++ b/src/Mod/Draft/draftguitools/gui_annotationstyleeditor.py
@@ -19,8 +19,13 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides all gui and tools to create and edit annotation styles."""
+"""Provides GUI tools to create and edit annotation styles."""
+## @package gui_annotationstyleeditor
+# \ingroup draftguitools
+# \brief Provides GUI tools to create and edit annotation styles.
 
+## \addtogroup draftguitools
+# @{
 import json
 import PySide.QtGui as QtGui
 from PySide.QtCore import QT_TRANSLATE_NOOP
@@ -348,3 +353,5 @@ class AnnotationStyleEditor(gui_base.GuiCommandSimplest):
 
 
 Gui.addCommand('Draft_AnnotationStyleEditor', AnnotationStyleEditor())
+
+## @}

--- a/src/Mod/Draft/draftguitools/gui_arcs.py
+++ b/src/Mod/Draft/draftguitools/gui_arcs.py
@@ -22,11 +22,13 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides tools for creating circular arcs with the Draft Workbench."""
+"""Provides GUI tools to create circular arc objects."""
 ## @package gui_arcs
-# \ingroup DRAFT
-# \brief Provides tools for creating circular arcs with the Draft Workbench.
+# \ingroup draftguitools
+# \brief Provides GUI tools to create circular arc objects.
 
+## \addtogroup draftguitools
+# @{
 import math
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
@@ -616,3 +618,5 @@ class ArcGroup:
 
 
 Gui.addCommand('Draft_ArcTools', ArcGroup())
+
+## @}

--- a/src/Mod/Draft/draftguitools/gui_array_simple.py
+++ b/src/Mod/Draft/draftguitools/gui_array_simple.py
@@ -22,16 +22,18 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides simple tools for creating arrays with the Draft Workbench.
+"""Provides GUI tools to create parametric Array objects (OBSOLETE).
 
 These commands were replaced by individual commands `Draft_OrthoArray`,
 `Draft_PolarArray`, and `Draft_CircularArray` which launch their own
 task panel, and provide a more useful way of creating the desired array.
 """
 ## @package gui_array_simple
-# \ingroup DRAFT
-# \brief Provides simple tools for creating arrays with the Draft Workbench.
+# \ingroup draftguitools
+# \brief Provides GUI tools to create parametric Array objects (OBSOLETE).
 
+## \addtogroup draftguitools
+# @{
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
 import FreeCADGui as Gui
@@ -132,3 +134,5 @@ class LinkArray(Array):
 
 
 Gui.addCommand('Draft_LinkArray', LinkArray())
+
+## @}

--- a/src/Mod/Draft/draftguitools/gui_arrays.py
+++ b/src/Mod/Draft/draftguitools/gui_arrays.py
@@ -20,11 +20,13 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provide the Draft ArrayTools command to group the other array tools."""
+"""Provides GUI tools to create parametric Array objects. Grouping command."""
 ## @package gui_arrays
-# \ingroup DRAFT
-# \brief Provide the Draft ArrayTools command to group the other array tools.
+# \ingroup draftguitools
+# \brief Provides GUI tools to create parametric Array objects.
 
+## \addtogroup draftguitools
+# @{
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
 import FreeCADGui as Gui
@@ -73,3 +75,5 @@ class ArrayGroup:
 
 
 Gui.addCommand('Draft_ArrayTools', ArrayGroup())
+
+## @}

--- a/src/Mod/Draft/draftguitools/gui_base.py
+++ b/src/Mod/Draft/draftguitools/gui_base.py
@@ -22,14 +22,17 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provide the Base object for all Draft Gui commands."""
+"""Provides the base classes for newer Draft Gui Commands."""
 ## @package gui_base
-# \ingroup DRAFT
-# \brief This module provides the Base object for all Draft Gui commands.
+# \ingroup draftguitools
+# \brief Provides the base classes for newer Draft Gui Commands.
 
+## \addtogroup draftguitools
+# @{
 import FreeCAD as App
 import FreeCADGui as Gui
 import draftutils.todo as todo
+
 from draftutils.messages import _msg, _log
 
 __metaclass__ = type  # to support Python 2 use of `super()`
@@ -214,3 +217,5 @@ class GuiCommandBase:
             that will be executed.
         """
         self.commit_list.append((name, func))
+
+## @}

--- a/src/Mod/Draft/draftguitools/gui_base_original.py
+++ b/src/Mod/Draft/draftguitools/gui_base_original.py
@@ -22,15 +22,17 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides the Base object for most old Draft Gui Commands.
+"""Provides the base classes for most old Draft Gui Commands.
 
 This class is used by Gui Commands to set up some properties
 of the DraftToolBar, the Snapper, and the working plane.
 """
 ## @package gui_base_original
-# \ingroup DRAFT
-# \brief Provides the Base object for most old Draft Gui Commands.
+# \ingroup draftguitools
+# \brief Provides the base classes for most old Draft Gui Commands.
 
+## \addtogroup draftguitools
+# @{
 import FreeCAD as App
 import FreeCADGui as Gui
 import DraftVecUtils
@@ -39,6 +41,7 @@ import draftutils.gui_utils as gui_utils
 import draftutils.todo as todo
 import draftguitools.gui_trackers as trackers
 import draftguitools.gui_tool_utils as gui_tool_utils
+
 from draftutils.messages import _msg, _log
 
 __metaclass__ = type  # to support Python 2 use of `super()`
@@ -302,3 +305,5 @@ class Modifier(DraftTool):
     def __init__(self):
         super(Modifier, self).__init__()
         self.copymode = False
+
+## @}

--- a/src/Mod/Draft/draftguitools/gui_beziers.py
+++ b/src/Mod/Draft/draftguitools/gui_beziers.py
@@ -22,7 +22,7 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides tools for creating Bezier curves with the Draft Workbench.
+"""Provides GUI tools to create BezCurve objects.
 
 In particular, a cubic Bezier curve is defined, as it is one of the most
 useful curves for many applications.
@@ -30,9 +30,11 @@ useful curves for many applications.
 See https://en.wikipedia.org/wiki/B%C3%A9zier_curve
 """
 ## @package gui_beziers
-# \ingroup DRAFT
-# \brief Provides tools for creating Bezier curves with the Draft Workbench.
+# \ingroup draftguitools
+# \brief Provides GUI tools to create BezCurve objects.
 
+## \addtogroup draftguitools
+# @{
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
 import FreeCADGui as Gui
@@ -42,6 +44,7 @@ import draftguitools.gui_base_original as gui_base_original
 import draftguitools.gui_tool_utils as gui_tool_utils
 import draftguitools.gui_lines as gui_lines
 import draftguitools.gui_trackers as trackers
+
 from draftutils.messages import _msg, _err
 from draftutils.translate import translate
 
@@ -500,3 +503,5 @@ class BezierGroup:
 
 
 Gui.addCommand('Draft_BezierTools', BezierGroup())
+
+## @}

--- a/src/Mod/Draft/draftguitools/gui_circles.py
+++ b/src/Mod/Draft/draftguitools/gui_circles.py
@@ -22,11 +22,13 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides tools for creating circles with the Draft Workbench."""
+"""Provides GUI tools to create Circle objects."""
 ## @package gui_circles
-# \ingroup DRAFT
-# \brief Provides tools for creating circlres with the Draft Workbench.
+# \ingroup draftguitools
+# \brief Provides GUI tools to create Circle objects.
 
+## \addtogroup draftguitools
+# @{
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
 import FreeCADGui as Gui
@@ -81,3 +83,5 @@ class Circle(gui_arcs.Arc):
 
 
 Gui.addCommand('Draft_Circle', Circle())
+
+## @}

--- a/src/Mod/Draft/draftguitools/gui_circulararray.py
+++ b/src/Mod/Draft/draftguitools/gui_circulararray.py
@@ -20,11 +20,13 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides the Draft CircularArray GuiCommand."""
+"""Provides GUI tools to create circular Array objects."""
 ## @package gui_circulararray
-# \ingroup DRAFT
-# \brief This module provides the Draft CircularArray tool.
+# \ingroup draftguitools
+# \brief Provides GUI tools to create circular Array objects.
 
+## \addtogroup draftguitools
+# @{
 from pivy import coin
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
@@ -142,3 +144,5 @@ class CircularArray(gui_base.GuiCommandBase):
 
 
 Gui.addCommand('Draft_CircularArray', CircularArray())
+
+## @}

--- a/src/Mod/Draft/draftguitools/gui_clone.py
+++ b/src/Mod/Draft/draftguitools/gui_clone.py
@@ -22,7 +22,7 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides tools for creating clones of objects with the Draft Workbench.
+"""Provides GUI tools to create Clone objects.
 
 The clone is basically a simple copy of the `Shape` of another object,
 whether that is a Draft object or any other 3D object.
@@ -35,9 +35,11 @@ more memory efficient as it reuses the same internal `Shape`
 instead of creating a copy of it.
 """
 ## @package gui_clone
-# \ingroup DRAFT
-# \brief Provides tools for creating clones of objects.
+# \ingroup draftguitools
+# \brief Provides GUI tools to create Clone objects.
 
+## \addtogroup draftguitools
+# @{
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
 import FreeCAD as App
@@ -123,3 +125,5 @@ class Clone(gui_base_original.Modifier):
 
 Draft_Clone = Clone
 Gui.addCommand('Draft_Clone', Clone())
+
+## @}

--- a/src/Mod/Draft/draftguitools/gui_dimension_ops.py
+++ b/src/Mod/Draft/draftguitools/gui_dimension_ops.py
@@ -22,20 +22,23 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides tools to modify Draft dimensions.
+"""Provides GUI tools to modify dimension objects.
 
 For example, a tool to flip the direction of the text in the dimension
 as the normal is sometimes not correctly calculated automatically.
 """
 ## @package gui_dimension_ops
-# \ingroup DRAFT
-# \brief Provides tools to modify Draft dimensions.
+# \ingroup draftguitools
+# \brief Provides GUI tools to modify dimension objects.
 
+## \addtogroup draftguitools
+# @{
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
 import FreeCADGui as Gui
 import draftutils.utils as utils
 import draftguitools.gui_base as gui_base
+
 from draftutils.translate import _tr
 
 
@@ -81,3 +84,5 @@ class FlipDimension(gui_base.GuiCommandNeedsSelection):
 
 Draft_FlipDimension = FlipDimension
 Gui.addCommand('Draft_FlipDimension', FlipDimension())
+
+## @}

--- a/src/Mod/Draft/draftguitools/gui_dimensions.py
+++ b/src/Mod/Draft/draftguitools/gui_dimensions.py
@@ -22,7 +22,7 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides tools for creating dimension objects with the Draft Workbench.
+"""Provides GUI tools to create dimension objects.
 
 The objects can be simple linear dimensions that measure between two arbitrary
 points, or linear dimensions linked to an edge.
@@ -32,8 +32,8 @@ And it can also be an angular dimension measuring the angle between
 two straight lines.
 """
 ## @package gui_dimensions
-# \ingroup DRAFT
-# \brief Provides tools for creating dimensions with the Draft Workbench.
+# \ingroup draftguitools
+# \brief Provides GUI tools to create dimension objects.
 
 import math
 import lazy_loader.lazy_loader as lz
@@ -54,6 +54,9 @@ DraftGeomUtils = lz.LazyLoader("DraftGeomUtils", globals(), "DraftGeomUtils")
 
 # The module is used to prevent complaints from code checkers (flake8)
 True if Draft_rc.__name__ else False
+
+## \addtogroup draftguitools
+# @{
 
 
 class Dimension(gui_base_original.Creator):
@@ -578,3 +581,5 @@ class Dimension(gui_base_original.Creator):
 
 
 Gui.addCommand('Draft_Dimension', Dimension())
+
+## @}

--- a/src/Mod/Draft/draftguitools/gui_downgrade.py
+++ b/src/Mod/Draft/draftguitools/gui_downgrade.py
@@ -22,16 +22,18 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides tools for downgrading objects with the Draft Workbench.
+"""Provides GUI tools to downgrade objects.
 
 Downgrades 2D objects to simpler objects until it reaches
 simple Edge primitives. For example, a Draft Line to wire, and then
 to a series of edges.
 """
 ## @package gui_downgrade
-# \ingroup DRAFT
-# \brief Provides tools for downgrading objects with the Draft Workbench.
+# \ingroup draftguitools
+# \brief Provides GUI tools to downgrade objects.
 
+## \addtogroup draftguitools
+# @{
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
 import FreeCADGui as Gui
@@ -95,3 +97,5 @@ class Downgrade(gui_base_original.Modifier):
 
 
 Gui.addCommand('Draft_Downgrade', Downgrade())
+
+## @}

--- a/src/Mod/Draft/draftguitools/gui_draft2sketch.py
+++ b/src/Mod/Draft/draftguitools/gui_draft2sketch.py
@@ -22,7 +22,7 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides tools for converting Draft objects to Sketches and back.
+"""Provides GUI tools to convert Draft objects to Sketches and back.
 
 Many Draft objects will be converted to a single non-contrainted Sketch.
 
@@ -30,9 +30,11 @@ However, a single sketch with disconnected traces will be converted
 into several individual Draft objects.
 """
 ## @package gui_draft2sketch
-# \ingroup DRAFT
-# \brief Provides tools for converting Draft objects to Sketches and back.
+# \ingroup draftguitools
+# \brief Provides GUI tools to convert Draft objects to Sketches and back.
 
+## \addtogroup draftguitools
+# @{
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
 import FreeCADGui as Gui
@@ -153,3 +155,5 @@ class Draft2Sketch(gui_base_original.Modifier):
 
 
 Gui.addCommand('Draft_Draft2Sketch', Draft2Sketch())
+
+## @}

--- a/src/Mod/Draft/draftguitools/gui_drawing.py
+++ b/src/Mod/Draft/draftguitools/gui_drawing.py
@@ -22,7 +22,7 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides tools for sending projections to a Drawing Workbench page.
+"""Provides GUI tools to project an object into a Drawing Workbench page.
 
 This commands takes a 2D geometrical element and creates a projection
 that is displayed in a drawing page in the Drawing Workbench.
@@ -35,9 +35,11 @@ it is not really necessary. TechDraw has its own set of tools
 to create 2D projections of 2D and 3D objects.
 """
 ## @package gui_drawing
-# \ingroup DRAFT
-# \brief Provides tools for sending projections to a Drawing Workbench page.
+# \ingroup draftguitools
+# \brief Provides GUI tools to project an object into a Drawing Workbench page.
 
+## \addtogroup draftguitools
+# @{
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
 import FreeCAD as App
@@ -149,3 +151,5 @@ class Drawing(gui_base_original.Modifier):
 
 
 Gui.addCommand('Draft_Drawing', Drawing())
+
+## @}

--- a/src/Mod/Draft/draftguitools/gui_edit.py
+++ b/src/Mod/Draft/draftguitools/gui_edit.py
@@ -20,41 +20,37 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provide the Draft_Edit command used by the Draft workbench."""
+"""Provides GUI tools to start the edit mode of different objects."""
 ## @package gui_edit
-# \ingroup DRAFT
-# \brief Provide the Draft_Edit command used by the Draft workbench
+# \ingroup draftguitools
+# \brief Provides GUI tools to start the edit mode of different objects.
 
 __title__ = "FreeCAD Draft Edit Tool"
 __author__ = ("Yorik van Havre, Werner Mayer, Martin Burbaum, Ken Cline, "
               "Dmitry Chigrin, Carlo Pavan")
 __url__ = "https://www.freecadweb.org"
 
-
+## \addtogroup draftguitools
+# @{
 import math
-from pivy import coin
-from PySide import QtCore, QtGui
+import pivy.coin as coin
+import PySide.QtCore as QtCore
+import PySide.QtGui as QtGui
 
 import FreeCAD as App
 import FreeCADGui as Gui
-
+import DraftVecUtils
 import draftutils.utils as utils
-
+import draftutils.gui_utils as gui_utils
 import draftguitools.gui_base_original as gui_base_original
 import draftguitools.gui_tool_utils as gui_tool_utils
-import draftutils.gui_utils as gui_utils
-
-import DraftVecUtils
-import DraftGeomUtils
-
-from draftutils.translate import translate
 import draftguitools.gui_trackers as trackers
-
 import draftguitools.gui_edit_draft_objects as edit_draft
 import draftguitools.gui_edit_arch_objects as edit_arch
 import draftguitools.gui_edit_part_objects as edit_part
 import draftguitools.gui_edit_sketcher_objects as edit_sketcher
 
+from draftutils.translate import translate
 
 COLORS = {
     "default": Gui.draftToolBar.getDefaultColor("snap"),
@@ -1234,3 +1230,5 @@ class Edit(gui_base_original.Modifier):
 
 
 Gui.addCommand('Draft_Edit', Edit())
+
+## @}

--- a/src/Mod/Draft/draftguitools/gui_edit_arch_objects.py
+++ b/src/Mod/Draft/draftguitools/gui_edit_arch_objects.py
@@ -20,23 +20,25 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provide the support functions to Draft_Edit for Arch objects."""
+"""Provides support functions to edit Arch objects."""
 ## @package gui_edit_arch_objects
-# \ingroup DRAFT
-# \brief Provide the support functions to Draft_Edit for Arch objects.
+# \ingroup draftguitools
+# \brief Provides support functions to edit Arch objects.
 
 __title__ = "FreeCAD Draft Edit Tool"
 __author__ = ("Yorik van Havre, Werner Mayer, Martin Burbaum, Ken Cline, "
               "Dmitry Chigrin, Carlo Pavan")
 __url__ = "https://www.freecadweb.org"
 
-
+## \addtogroup draftguitools
+# @{
 import math
 import FreeCAD as App
 import DraftVecUtils
 
 from draftutils.translate import translate
 import draftutils.utils as utils
+
 
 def get_supported_arch_objects():
     return ["Wall", "Window", "Structure", "Space", "PanelCut", "PanelSheet"]
@@ -174,3 +176,5 @@ def updatePanelSheet(obj, nodeIndex, v):
         obj.TagPosition = v
     else:
         obj.Group[nodeIndex-1].Placement.Base = v
+
+## @}

--- a/src/Mod/Draft/draftguitools/gui_edit_draft_objects.py
+++ b/src/Mod/Draft/draftguitools/gui_edit_draft_objects.py
@@ -20,7 +20,7 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provide the support functions to Draft_Edit for Draft objects.
+"""Provides support functions to edit Draft objects.
 
 All functions in this module work with Object coordinate space.
 No conversion to global coordinate system is needed.
@@ -34,15 +34,16 @@ TODO: Abstract the code that handles the preview and move the object specific
     code to this module from main Draft_Edit module
 """
 ## @package gui_edit_draft_objects
-# \ingroup DRAFT
-# \brief Provide the support functions to Draft_Edit for Draft objects.
+# \ingroup draftguitools
+# \brief Provides support functions to edit Draft objects.
 
 __title__ = "FreeCAD Draft Edit Tool"
 __author__ = ("Yorik van Havre, Werner Mayer, Martin Burbaum, Ken Cline, "
               "Dmitry Chigrin, Carlo Pavan")
 __url__ = "https://www.freecadweb.org"
 
-
+## \addtogroup draftguitools
+# @{
 import math
 import FreeCAD as App
 import DraftVecUtils
@@ -511,3 +512,4 @@ def smoothBezPoint(obj, point, style='Symmetric'):
     obj.Points = pts
     obj.Continuity = newcont
 
+## @}

--- a/src/Mod/Draft/draftguitools/gui_edit_part_objects.py
+++ b/src/Mod/Draft/draftguitools/gui_edit_part_objects.py
@@ -18,17 +18,18 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provide the support functions to Draft_Edit for Part objects."""
+"""Provides support functions to edit Part objects."""
 ## @package gui_edit_part_objects
-# \ingroup DRAFT
-# \brief Provide the support functions to Draft_Edit for Part objects.
+# \ingroup draftguitools
+# \brief Provides support functions to edit Part objects.
 
 __title__ = "FreeCAD Draft Edit Tool"
 __author__ = ("Yorik van Havre, Werner Mayer, Martin Burbaum, Ken Cline, "
               "Dmitry Chigrin, Carlo Pavan")
 __url__ = "https://www.freecadweb.org"
 
-
+## \addtogroup draftguitools
+# @{
 import FreeCAD as App
 import DraftVecUtils
 
@@ -136,3 +137,5 @@ def updatePartSphere(obj, nodeIndex, v):
     elif nodeIndex == 1:
         if v.Length > 0.0:
             obj.Radius = v.Length # TODO: Perhaps better to project on the face?
+
+## @}

--- a/src/Mod/Draft/draftguitools/gui_edit_sketcher_objects.py
+++ b/src/Mod/Draft/draftguitools/gui_edit_sketcher_objects.py
@@ -20,18 +20,18 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provide the support functions to Draft_Edit for Arch objects."""
-## @package gui_edit_arch_objects
-# \ingroup DRAFT
-# \brief Provide the support functions to Draft_Edit for Arch objects.
+"""Provides support functions to edit Sketch objects."""
+## @package gui_edit_sketcher_objects
+# \ingroup draftguitools
+# \brief Provides support functions to edit Sketch objects.
 
 __title__ = "FreeCAD Draft Edit Tool"
 __author__ = ("Yorik van Havre, Werner Mayer, Martin Burbaum, Ken Cline, "
               "Dmitry Chigrin, Carlo Pavan")
 __url__ = "https://www.freecadweb.org"
 
-
-import math
+## \addtogroup draftguitools
+# @{
 import FreeCAD as App
 
 from draftutils.translate import translate
@@ -75,3 +75,5 @@ def updateSketch(obj, nodeIndex, v):
     elif nodeIndex == 1:
         obj.movePoint(0, 2, v)
     obj.recompute()
+
+## @}

--- a/src/Mod/Draft/draftguitools/gui_ellipses.py
+++ b/src/Mod/Draft/draftguitools/gui_ellipses.py
@@ -22,11 +22,13 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides tools for creating ellipses with the Draft Workbench."""
+"""Provides GUI tools to create Ellipse objects."""
 ## @package gui_ellipses
-# \ingroup DRAFT
-# \brief Provides tools for creating ellipses with the Draft Workbench.
+# \ingroup draftguitools
+# \brief Provides GUI tools to create Ellipse objects.
 
+## \addtogroup draftguitools
+# @{
 import math
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
@@ -38,6 +40,7 @@ import draftutils.utils as utils
 import draftguitools.gui_base_original as gui_base_original
 import draftguitools.gui_tool_utils as gui_tool_utils
 import draftguitools.gui_trackers as trackers
+
 from draftutils.translate import translate
 from draftutils.messages import _msg, _err
 
@@ -202,3 +205,5 @@ class Ellipse(gui_base_original.Creator):
 
 
 Gui.addCommand('Draft_Ellipse', Ellipse())
+
+## @}

--- a/src/Mod/Draft/draftguitools/gui_facebinders.py
+++ b/src/Mod/Draft/draftguitools/gui_facebinders.py
@@ -22,16 +22,18 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides tools for creating facebinders with the Draft Workbench.
+"""Provides GUI tools to create Facebinder objects.
 
 A facebinder is a surface or shell created from the face of a solid object.
 This tool allows extracting such faces to be used for other purposes
 including extruding solids from faces.
 """
 ## @package gui_facebinders
-# \ingroup DRAFT
-# \brief Provides tools for creating facebinders with the Draft Workbench.
+# \ingroup draftguitools
+# \brief Provides GUI tools to create Facebinder objects.
 
+## \addtogroup draftguitools
+# @{
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
 import FreeCAD as App
@@ -39,6 +41,7 @@ import FreeCADGui as Gui
 import Draft_rc
 import draftguitools.gui_base_original as gui_base_original
 import draftguitools.gui_tool_utils as gui_tool_utils
+
 from draftutils.messages import _msg
 from draftutils.translate import translate, _tr
 
@@ -91,3 +94,5 @@ class Facebinder(gui_base_original.Creator):
 
 Draft_Facebinder = Facebinder
 Gui.addCommand('Draft_Facebinder', Facebinder())
+
+## @}

--- a/src/Mod/Draft/draftguitools/gui_fillets.py
+++ b/src/Mod/Draft/draftguitools/gui_fillets.py
@@ -20,17 +20,19 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides tools for creating fillets between two lines.
+"""Provides GUI tools to create Fillet objects between two lines.
 
 TODO: Currently this tool uses the DraftGui widgets. We want to avoid using
 this big module because it creates manually the interface.
 Instead we should provide its own .ui file and task panel,
-similar to the Ortho Array tool.
+similar to the OrthoArray tool.
 """
 ## @package gui_fillet
-# \ingroup DRAFT
-# \brief Provides tools for creating fillets between two lines.
+# \ingroup draftguitools
+# \brief Provides GUI tools to create Fillet objects between two lines.
 
+## \addtogroup draftguitools
+# @{
 import PySide.QtCore as QtCore
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
@@ -40,7 +42,7 @@ import Draft_rc
 import draftutils.utils as utils
 import draftguitools.gui_base_original as gui_base_original
 import draftguitools.gui_tool_utils as gui_tool_utils
-# import draftguitools.gui_trackers as trackers
+
 from draftutils.messages import _msg, _err
 from draftutils.translate import translate, _tr
 
@@ -202,3 +204,5 @@ class Fillet(gui_base_original.Creator):
 
 
 Gui.addCommand('Draft_Fillet', Fillet())
+
+## @}

--- a/src/Mod/Draft/draftguitools/gui_grid.py
+++ b/src/Mod/Draft/draftguitools/gui_grid.py
@@ -22,15 +22,18 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provide the Draft_ToggleGrid command to show the Draft grid."""
+"""Provides GUI tools to enable and disable the working plane grid."""
 ## @package gui_grid
-# \ingroup DRAFT
-# \brief Provide the Draft_ToggleGrid command to show the Draft grid.
+# \ingroup draftguitools
+# \brief Provides GUI tools to enable and disable the working plane grid.
 
+## \addtogroup draftguitools
+# @{
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
 import FreeCADGui as Gui
 import draftguitools.gui_base as gui_base
+
 from draftutils.translate import _tr
 
 
@@ -77,3 +80,5 @@ class ToggleGrid(gui_base.GuiCommandSimplest):
 
 
 Gui.addCommand('Draft_ToggleGrid', ToggleGrid())
+
+## @}

--- a/src/Mod/Draft/draftguitools/gui_groups.py
+++ b/src/Mod/Draft/draftguitools/gui_groups.py
@@ -22,16 +22,18 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides tools to do various operations with groups.
+"""Provides GUI tools to do various operations with groups.
 
 For example, add objects to groups, select objects inside groups,
 set the automatic group in which to create objects, and add objects
 to the construction group.
 """
 ## @package gui_groups
-# \ingroup DRAFT
-# \brief Provides tools to do various operations with groups.
+# \ingroup draftguitools
+# \brief Provides GUI tools to do various operations with groups.
 
+## \addtogroup draftguitools
+# @{
 import PySide.QtCore as QtCore
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
@@ -41,6 +43,7 @@ import Draft_rc
 import draftutils.utils as utils
 import draftutils.groups as groups
 import draftguitools.gui_base as gui_base
+
 from draftutils.translate import _tr, translate
 
 # The module is used to prevent complaints from code checkers (flake8)
@@ -395,3 +398,5 @@ class AddToConstruction(gui_base.GuiCommandSimplest):
 
 Draft_AddConstruction = AddToConstruction
 Gui.addCommand('Draft_AddConstruction', AddToConstruction())
+
+## @}

--- a/src/Mod/Draft/draftguitools/gui_heal.py
+++ b/src/Mod/Draft/draftguitools/gui_heal.py
@@ -22,16 +22,19 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides the Draft_Heal command to heal older Draft files."""
-## @package gui_health
-# \ingroup DRAFT
-# \brief Provides the Draft_Heal command to heal older Draft files.
+"""Provides GUI tools to repair objects created with older versions."""
+## @package gui_heal
+# \ingroup draftguitools
+# \brief Provides GUI tools to repair objects created with older versions.
 
+## \addtogroup draftguitools
+# @{
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
 import FreeCADGui as Gui
 import Draft
 import draftguitools.gui_base as gui_base
+
 from draftutils.translate import _tr
 
 
@@ -74,3 +77,5 @@ class Heal(gui_base.GuiCommandSimplest):
 
 
 Gui.addCommand('Draft_Heal', Heal())
+
+## @}

--- a/src/Mod/Draft/draftguitools/gui_join.py
+++ b/src/Mod/Draft/draftguitools/gui_join.py
@@ -22,7 +22,7 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides tools for joining lines with the Draft Workbench.
+"""Provides GUI tools to join lines and wires.
 
 It occasionally fails to join lines even if the lines
 visually share a point. This is due to the underlying `joinWires` method
@@ -36,15 +36,18 @@ Test properly using `DraftVecUtils.equals` because then it will consider
 the precision set in the Draft preferences.
 """
 ## @package gui_join
-# \ingroup DRAFT
-# \brief Provides tools for joining lines with the Draft Workbench.
+# \ingroup draftguitools
+# \brief Provides GUI tools to join lines and wires.
 
+## \addtogroup draftguitools
+# @{
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
 import FreeCADGui as Gui
 import Draft_rc
 import draftguitools.gui_base_original as gui_base_original
 import draftguitools.gui_tool_utils as gui_tool_utils
+
 from draftutils.messages import _msg
 from draftutils.translate import translate, _tr
 
@@ -113,3 +116,5 @@ class Join(gui_base_original.Modifier):
 
 
 Gui.addCommand('Draft_Join', Join())
+
+## @}

--- a/src/Mod/Draft/draftguitools/gui_labels.py
+++ b/src/Mod/Draft/draftguitools/gui_labels.py
@@ -22,16 +22,18 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides tools for creating labels with the Draft Workbench.
+"""Provides GUI tools to create Label objects.
 
 Labels are similar to text annotations but include a leader line
 and an arrow in order to point to an object and indicate some of its
 properties.
 """
 ## @package gui_labels
-# \ingroup DRAFT
-# \brief Provides tools for creating labels with the Draft Workbench.
+# \ingroup draftguitools
+# \brief Provides GUI tools to create Label objects.
 
+## \addtogroup draftguitools
+# @{
 import math
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
@@ -247,3 +249,5 @@ class Label(gui_base_original.Creator):
 
 Draft_Label = Label
 Gui.addCommand('Draft_Label', Label())
+
+## @}

--- a/src/Mod/Draft/draftguitools/gui_line_add_delete.py
+++ b/src/Mod/Draft/draftguitools/gui_line_add_delete.py
@@ -22,14 +22,17 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides certain add and remove line operations of the Draft Workbench.
+"""Provides GUI tools to do certain add and remove line operations.
 
 These GuiCommands aren't really used anymore, as the same actions
 are implemented directly in the Draft_Edit command.
 """
 ## @package gui_line_add_delete
-# \ingroup DRAFT
-# \brief Provides certain add and remove line operations.
+# \ingroup draftguitools
+# \brief Provides GUI tools to do certain add and remove line operations.
+
+## \addtogroup draftguitools
+# @{
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
 import FreeCADGui as Gui
@@ -107,3 +110,5 @@ class DelPoint(DraftTools.Modifier):
 
 
 Gui.addCommand('Draft_DelPoint', DelPoint())
+
+## @}

--- a/src/Mod/Draft/draftguitools/gui_lineops.py
+++ b/src/Mod/Draft/draftguitools/gui_lineops.py
@@ -22,20 +22,24 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides certain line operations of the Draft Workbench.
+"""Provides GUI tools to do certain line operations.
 
 These GuiCommands aren't really used anymore, as the same actions
 are called from the task panel interface by other methods.
 """
 ## @package gui_lineops
-# \ingroup DRAFT
-# \brief Provides certain line operations in the Draft Workbench.
+# \ingroup draftguitools
+# \brief Provides GUI tools to do certain line operations.
+
+## \addtogroup draftguitools
+# @{
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
 import FreeCAD as App
 import FreeCADGui as Gui
 import Draft_rc
 import draftguitools.gui_base as gui_base
+
 from draftutils.messages import _msg
 from draftutils.translate import _tr
 
@@ -161,3 +165,5 @@ class UndoLine(LineAction):
 
 
 Gui.addCommand('Draft_UndoLine', UndoLine())
+
+## @}

--- a/src/Mod/Draft/draftguitools/gui_lines.py
+++ b/src/Mod/Draft/draftguitools/gui_lines.py
@@ -22,17 +22,19 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides tools for creating straight lines with the Draft Workbench.
+"""Provides GUI tools to create straight Line and Wire objects.
 
 The Line class is used by other Gui Commands that behave in a similar way
 like Wire, BSpline, and BezCurve.
 """
 ## @package gui_lines
-# \ingroup DRAFT
-# \brief Provides tools for creating straight lines with the Draft Workbench.
+# \ingroup draftguitools
+# \brief Provides GUI tools to create straight Line and Wire objects.
 
-from PySide.QtCore import QT_TRANSLATE_NOOP
+## \addtogroup draftguitools
+# @{
 import sys
+from PySide.QtCore import QT_TRANSLATE_NOOP
 
 import FreeCAD as App
 import FreeCADGui as Gui
@@ -42,6 +44,7 @@ import draftutils.gui_utils as gui_utils
 import draftutils.todo as todo
 import draftguitools.gui_base_original as gui_base_original
 import draftguitools.gui_tool_utils as gui_tool_utils
+
 from draftutils.messages import _msg, _err
 from draftutils.translate import translate
 
@@ -361,3 +364,5 @@ class Wire(Line):
 
 
 Gui.addCommand('Draft_Wire', Wire())
+
+## @}

--- a/src/Mod/Draft/draftguitools/gui_lineslope.py
+++ b/src/Mod/Draft/draftguitools/gui_lineslope.py
@@ -22,15 +22,17 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides tools to change the slope of a line over the working plane.
+"""Provides GUI tools to change the slope of a line.
 
 It currently only works for a line in the XY plane, it changes the height
 of one of its points in the Z direction to create a sloped line.
 """
 ## @package gui_lineslope
-# \ingroup DRAFT
-# \brief Provides tools to change the slope of a line over the working plane.
+# \ingroup draftguitools
+# \brief Provides GUI tools to change the slope of a line.
 
+## \addtogroup draftguitools
+# @{
 import PySide.QtGui as QtGui
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
@@ -39,6 +41,7 @@ import FreeCADGui as Gui
 import Draft_rc
 import draftutils.utils as utils
 import draftguitools.gui_base as gui_base
+
 from draftutils.translate import _tr, translate
 
 # The module is used to prevent complaints from code checkers (flake8)
@@ -154,3 +157,5 @@ class LineSlope(gui_base.GuiCommandNeedsSelection):
 
 Draft_Slope = LineSlope
 Gui.addCommand('Draft_Slope', LineSlope())
+
+## @}

--- a/src/Mod/Draft/draftguitools/gui_mirror.py
+++ b/src/Mod/Draft/draftguitools/gui_mirror.py
@@ -22,7 +22,7 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides tools for creating mirrored objects with the Draft Workbench.
+"""Provides GUI tools to create mirrored objects.
 
 The mirror tool creates a `Part::Mirroring` object, which is the same
 as the one created by the Part module.
@@ -30,9 +30,11 @@ as the one created by the Part module.
 Perhaps in the future a specific Draft `Mirror` object can be defined.
 """
 ## @package gui_mirror
-# \ingroup DRAFT
-# \brief Provides tools for creating mirrored objects with the Draft Workbench.
+# \ingroup draftguitools
+# \brief Provides GUI tools to create mirrored objects.
 
+## \addtogroup draftguitools
+# @{
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
 import FreeCAD as App
@@ -42,6 +44,7 @@ import DraftVecUtils
 import WorkingPlane
 import draftguitools.gui_base_original as gui_base_original
 import draftguitools.gui_tool_utils as gui_tool_utils
+
 from draftutils.messages import _msg
 from draftutils.translate import translate
 
@@ -212,3 +215,5 @@ class Mirror(gui_base_original.Modifier):
 
 
 Gui.addCommand('Draft_Mirror', Mirror())
+
+## @}

--- a/src/Mod/Draft/draftguitools/gui_move.py
+++ b/src/Mod/Draft/draftguitools/gui_move.py
@@ -22,28 +22,28 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides tools for moving objects in the 3D space."""
+"""Provides GUI tools to move objects in the 3D space."""
 ## @package gui_move
-# \ingroup DRAFT
-# \brief Provides tools for moving objects in the 3D space.
+# \ingroup draftguitools
+# \brief Provides GUI tools to move objects in the 3D space.
 
+## \addtogroup draftguitools
+# @{
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
 import FreeCAD as App
 import FreeCADGui as Gui
 import Draft_rc
 import DraftVecUtils
-
 import draftutils.groups as groups
 import draftutils.todo as todo
-
 import draftguitools.gui_base_original as gui_base_original
 import draftguitools.gui_tool_utils as gui_tool_utils
 import draftguitools.gui_trackers as trackers
 
-from draftguitools.gui_subelements import SubelementHighlight
 from draftutils.messages import _msg, _err
 from draftutils.translate import translate
+from draftguitools.gui_subelements import SubelementHighlight
 
 # The module is used to prevent complaints from code checkers (flake8)
 True if Draft_rc.__name__ else False
@@ -314,3 +314,5 @@ class Move(gui_base_original.Modifier):
 
 
 Gui.addCommand('Draft_Move', Move())
+
+## @}

--- a/src/Mod/Draft/draftguitools/gui_offset.py
+++ b/src/Mod/Draft/draftguitools/gui_offset.py
@@ -22,15 +22,17 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides tools for offsetting objects with the Draft Workbench.
+"""Provides GUI tools to create offsets from objects.
 
 It mostly works on lines, polylines, and similar objects with
 regular geometrical shapes, like rectangles.
 """
 ## @package gui_offset
-# \ingroup DRAFT
-# \brief Provides tools for offsetting objects with the Draft Workbench.
+# \ingroup draftguitools
+# \brief Provides GUI tools to create offsets from objects.
 
+## \addtogroup draftguitools
+# @{
 import math
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
@@ -42,6 +44,7 @@ import draftutils.utils as utils
 import draftguitools.gui_base_original as gui_base_original
 import draftguitools.gui_tool_utils as gui_tool_utils
 import draftguitools.gui_trackers as trackers
+
 from draftutils.messages import _msg, _wrn, _err
 from draftutils.translate import translate, _tr
 
@@ -315,3 +318,5 @@ class Offset(gui_base_original.Modifier):
 
 
 Gui.addCommand('Draft_Offset', Offset())
+
+## @}

--- a/src/Mod/Draft/draftguitools/gui_orthoarray.py
+++ b/src/Mod/Draft/draftguitools/gui_orthoarray.py
@@ -20,11 +20,13 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides the Draft OrthoArray GuiCommand."""
+"""Provides GUI tools to create orthogonal Array objects."""
 ## @package gui_orthoarray
-# \ingroup DRAFT
-# \brief Provides the Draft OrthoArray GuiCommand.
+# \ingroup draftguitools
+# \brief Provides GUI tools to create orthogonal Array objects.
 
+## \addtogroup draftguitools
+# @{
 from pivy import coin
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
@@ -130,3 +132,5 @@ class OrthoArray(gui_base.GuiCommandBase):
 
 
 Gui.addCommand('Draft_OrthoArray', OrthoArray())
+
+## @}

--- a/src/Mod/Draft/draftguitools/gui_patharray.py
+++ b/src/Mod/Draft/draftguitools/gui_patharray.py
@@ -25,15 +25,17 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides tools for creating path arrays with the Draft Workbench.
+"""Provides GUI tools to create PathArray objects.
 
 The copies will be created along a path, like a polyline, B-spline,
 or Bezier curve.
 """
 ## @package gui_patharray
-# \ingroup DRAFT
-# \brief Provides tools for creating path arrays with the Draft Workbench.
+# \ingroup draftguitools
+# \brief Provides GUI tools to create PathArray objects.
 
+## \addtogroup draftguitools
+# @{
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
 import FreeCAD as App
@@ -183,3 +185,5 @@ class PathLinkArray(PathArray):
 
 
 Gui.addCommand('Draft_PathLinkArray', PathLinkArray())
+
+## @}

--- a/src/Mod/Draft/draftguitools/gui_planeproxy.py
+++ b/src/Mod/Draft/draftguitools/gui_planeproxy.py
@@ -18,11 +18,13 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides the Draft WorkingPlaneProxy tool."""
+"""Provides GUI tools to create WorkingPlaneProxy objects."""
 ## @package gui_planeproxy
-# \ingroup DRAFT
-# \brief This module provides the Draft WorkingPlaneProxy tool.
+# \ingroup draftguitools
+# \brief Provides GUI tools to create WorkingPlaneProxy objects.
 
+## \addtogroup draftguitools
+# @{
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
 import FreeCAD as App
@@ -77,3 +79,5 @@ class Draft_WorkingPlaneProxy:
 
 
 Gui.addCommand('Draft_WorkingPlaneProxy', Draft_WorkingPlaneProxy())
+
+## @}

--- a/src/Mod/Draft/draftguitools/gui_pointarray.py
+++ b/src/Mod/Draft/draftguitools/gui_pointarray.py
@@ -23,7 +23,7 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides tools for creating point arrays with the Draft Workbench.
+"""Provides GUI tools to create PointArray objects.
 
 The copies will be created where various points are located.
 
@@ -37,9 +37,11 @@ the explicit point and vertex objects will be used when creating
 the point array.
 """
 ## @package gui_pointarray
-# \ingroup DRAFT
-# \brief Provides tools for creating point arrays with the Draft Workbench.
+# \ingroup draftguitools
+# \brief Provides GUI tools to create PointArray objects.
 
+## \addtogroup draftguitools
+# @{
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
 import FreeCADGui as Gui
@@ -132,3 +134,5 @@ class PointArray(gui_base_original.Modifier):
 
 
 Gui.addCommand('Draft_PointArray', PointArray())
+
+## @}

--- a/src/Mod/Draft/draftguitools/gui_points.py
+++ b/src/Mod/Draft/draftguitools/gui_points.py
@@ -22,7 +22,7 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides tools for creating simple points with the Draft Workbench.
+"""Provides GUI tools to create simple Point objects.
 
 A point is just a simple vertex with a position in 3D space.
 
@@ -30,9 +30,11 @@ Its visual properties can be changed, like display size on screen
 and color.
 """
 ## @package gui_points
-# \ingroup DRAFT
-# \brief Provides tools for creating simple points with the Draft Workbench.
+# \ingroup draftguitools
+# \brief Provides GUI tools to create simple Point objects.
 
+## \addtogroup draftguitools
+# @{
 import pivy.coin as coin
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
@@ -43,6 +45,7 @@ import draftutils.utils as utils
 import draftutils.gui_utils as gui_utils
 import draftguitools.gui_base_original as gui_base_original
 import draftutils.todo as todo
+
 from draftutils.translate import translate, _tr
 
 # The module is used to prevent complaints from code checkers (flake8)
@@ -161,3 +164,5 @@ class Point(gui_base_original.Creator):
 
 
 Gui.addCommand('Draft_Point', Point())
+
+## @}

--- a/src/Mod/Draft/draftguitools/gui_polararray.py
+++ b/src/Mod/Draft/draftguitools/gui_polararray.py
@@ -20,11 +20,13 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides the Draft PolarArray GuiCommand."""
+"""Provides GUI tools to create polar Array objects."""
 ## @package gui_polararray
-# \ingroup DRAFT
-# \brief This module provides the Draft PolarArray tool.
+# \ingroup draftguitools
+# \brief Provides GUI tools to create polar Array objects.
 
+## \addtogroup draftguitools
+# @{
 from pivy import coin
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
@@ -142,3 +144,5 @@ class PolarArray(gui_base.GuiCommandBase):
 
 
 Gui.addCommand('Draft_PolarArray', PolarArray())
+
+## @}

--- a/src/Mod/Draft/draftguitools/gui_polygons.py
+++ b/src/Mod/Draft/draftguitools/gui_polygons.py
@@ -22,14 +22,16 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides tools for creating regular polygons with the Draft Workbench.
+"""Provides GUI tools to create regular Polygon objects.
 
 Minimum number of sides is three (equilateral triangles).
 """
 ## @package gui_polygons
-# \ingroup DRAFT
-# \brief Provides tools for creating regular polygons with the Draft Workbench.
+# \ingroup draftguitools
+# \brief Provides GUI tools to create regular Polygon objects.
 
+## \addtogroup draftguitools
+# @{
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
 import FreeCAD as App
@@ -39,6 +41,7 @@ import draftutils.utils as utils
 import draftguitools.gui_base_original as gui_base_original
 import draftguitools.gui_tool_utils as gui_tool_utils
 import draftguitools.gui_trackers as trackers
+
 from draftutils.messages import _msg
 from draftutils.translate import translate
 
@@ -291,3 +294,5 @@ class Polygon(gui_base_original.Creator):
 
 
 Gui.addCommand('Draft_Polygon', Polygon())
+
+## @}

--- a/src/Mod/Draft/draftguitools/gui_rectangles.py
+++ b/src/Mod/Draft/draftguitools/gui_rectangles.py
@@ -22,11 +22,13 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides tools for creating rectangles with the Draft Workbench."""
+"""Provides GUI tools to create Rectangle objects."""
 ## @package gui_rectangles
-# \ingroup DRAFT
-# \brief Provides tools for creating rectangles with the Draft Workbench.
+# \ingroup draftguitools
+# \brief Provides GUI tools to create Rectangle objects.
 
+## \addtogroup draftguitools
+# @{
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
 import FreeCAD as App
@@ -36,6 +38,7 @@ import draftutils.utils as utils
 import draftguitools.gui_base_original as gui_base_original
 import draftguitools.gui_tool_utils as gui_tool_utils
 import draftguitools.gui_trackers as trackers
+
 from draftutils.messages import _msg, _err
 from draftutils.translate import translate
 
@@ -207,3 +210,5 @@ class Rectangle(gui_base_original.Creator):
 
 
 Gui.addCommand('Draft_Rectangle', Rectangle())
+
+## @}

--- a/src/Mod/Draft/draftguitools/gui_rotate.py
+++ b/src/Mod/Draft/draftguitools/gui_rotate.py
@@ -22,11 +22,13 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides tools for rotating objects in the 3D space."""
+"""Provides GUI tools to rotate objects in the 3D space."""
 ## @package gui_rotate
-# \ingroup DRAFT
-# \brief Provides tools for rotating objects in the 3D space.
+# \ingroup draftguitools
+# \brief Provides GUI tools to rotate objects in the 3D space.
 
+## \addtogroup draftguitools
+# @{
 import math
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
@@ -34,7 +36,6 @@ import FreeCAD as App
 import FreeCADGui as Gui
 import Draft_rc
 import DraftVecUtils
-
 import draftutils.groups as groups
 import draftutils.todo as todo
 import draftguitools.gui_base_original as gui_base_original
@@ -429,3 +430,5 @@ class Rotate(gui_base_original.Modifier):
 
 
 Gui.addCommand('Draft_Rotate', Rotate())
+
+## @}

--- a/src/Mod/Draft/draftguitools/gui_scale.py
+++ b/src/Mod/Draft/draftguitools/gui_scale.py
@@ -22,7 +22,7 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides tools for scaling objects with the Draft Workbench.
+"""Provides GUI tools to scale objects in the 3D space.
 
 The scale operation can also be done with subelements.
 
@@ -31,16 +31,17 @@ because internally the functions `scaleVertex` and `scaleEdge`
 only work with polylines that have a `Points` property.
 """
 ## @package gui_scale
-# \ingroup DRAFT
-# \brief Provides tools for scaling objects with the Draft Workbench.
+# \ingroup draftguitools
+# \brief Provides GUI tools to scale objects in the 3D space.
 
+## \addtogroup draftguitools
+# @{
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
 import FreeCAD as App
 import FreeCADGui as Gui
 import Draft_rc
 import DraftVecUtils
-
 import draftutils.utils as utils
 import draftutils.groups as groups
 import draftutils.todo as todo
@@ -409,3 +410,5 @@ class Scale(gui_base_original.Modifier):
 
 
 Gui.addCommand('Draft_Scale', Scale())
+
+## @}

--- a/src/Mod/Draft/draftguitools/gui_selectplane.py
+++ b/src/Mod/Draft/draftguitools/gui_selectplane.py
@@ -18,14 +18,16 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides the Draft SelectPlane tool."""
+"""Provides GUI tools to set up the working plane and its grid."""
 ## @package gui_selectplane
-# \ingroup DRAFT
-# \brief This module provides the Draft SelectPlane tool.
+# \ingroup draftguitools
+# \brief Provides GUI tools to set up the working plane and its grid.
 
+## \addtogroup draftguitools
+# @{
 import math
-from pivy import coin
-from PySide import QtGui
+import pivy.coin as coin
+import PySide.QtGui as QtGui
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
 import FreeCAD
@@ -34,6 +36,7 @@ import Draft
 import Draft_rc
 import DraftVecUtils
 import drafttaskpanels.task_selectplane as task_selectplane
+
 from draftutils.todo import todo
 from draftutils.messages import _msg
 from draftutils.translate import translate
@@ -521,3 +524,5 @@ class Draft_SelectPlane:
 
 
 FreeCADGui.addCommand('Draft_SelectPlane', Draft_SelectPlane())
+
+## @}

--- a/src/Mod/Draft/draftguitools/gui_shape2dview.py
+++ b/src/Mod/Draft/draftguitools/gui_shape2dview.py
@@ -22,16 +22,18 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides tools for projecting objects into a 2D plane.
+"""Provides GUI tools to project an object into a 2D plane.
 
 This creates a 2D shape in the 3D view itself. This projection
 can be further used to create a technical drawing using
 the TechDraw Workbench.
 """
 ## @package gui_shape2dview
-# \ingroup DRAFT
-# \brief Provides tools for projecting objects into a 2D plane.
+# \ingroup draftguitools
+# \brief Provides GUI tools to project an object into a 2D plane.
 
+## \addtogroup draftguitools
+# @{
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
 import FreeCADGui as Gui
@@ -39,6 +41,7 @@ import DraftVecUtils
 import Draft_rc
 import draftguitools.gui_base_original as gui_base_original
 import draftguitools.gui_tool_utils as gui_tool_utils
+
 from draftutils.messages import _msg
 from draftutils.translate import translate, _tr
 
@@ -121,3 +124,5 @@ class Shape2DView(gui_base_original.Modifier):
 
 
 Gui.addCommand('Draft_Shape2DView', Shape2DView())
+
+## @}

--- a/src/Mod/Draft/draftguitools/gui_shapestrings.py
+++ b/src/Mod/Draft/draftguitools/gui_shapestrings.py
@@ -22,7 +22,7 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides tools for creating text shapes with the Draft Workbench.
+"""Provides GUI tools to create text shapes with a particular font.
 
 These text shapes are made of various edges and closed faces, and therefore
 can be extruded to create solid bodies that can be used in boolean
@@ -32,9 +32,11 @@ into solid bodies.
 They are more complex that simple text annotations.
 """
 ## @package gui_shapestrings
-# \ingroup DRAFT
-# \brief Provides tools for creating text shapes with the Draft Workbench.
+# \ingroup draftguitools
+# \brief Provides GUI tools to create text shapes with a particular font.
 
+## \addtogroup draftguitools
+# @{
 from PySide.QtCore import QT_TRANSLATE_NOOP
 import sys
 
@@ -47,6 +49,7 @@ import draftguitools.gui_base_original as gui_base_original
 import draftguitools.gui_tool_utils as gui_tool_utils
 import drafttaskpanels.task_shapestring as task_shapestring
 import draftutils.todo as todo
+
 from draftutils.translate import translate
 from draftutils.messages import _msg, _err
 
@@ -230,3 +233,5 @@ class ShapeString(gui_base_original.Creator):
 
 
 Gui.addCommand('Draft_ShapeString', ShapeString())
+
+## @}

--- a/src/Mod/Draft/draftguitools/gui_snapper.py
+++ b/src/Mod/Draft/draftguitools/gui_snapper.py
@@ -18,7 +18,7 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provide the Snapper class to control snapping in the Draft Workbench.
+"""Provides the Snapper class to define the snapping tools and modes.
 
 This module provides tools to handle point snapping and
 everything that goes with it (toolbar buttons, cursor icons, etc.).
@@ -26,33 +26,32 @@ It also creates the Draft grid, which is actually a tracker
 defined by `gui_trackers.gridTracker`.
 """
 ## @package gui_snapper
-#  \ingroup DRAFT
-#  \brief Snapper class to control snapping in the Draft Workbench.
+#  \ingroup draftguitools
+#  \brief Provides the Snapper class to define the snapping tools and modes.
 #
 #  This module provides tools to handle point snapping and
 #  everything that goes with it (toolbar buttons, cursor icons, etc.).
 
-from pivy import coin
-from PySide import QtCore, QtGui
-
+## \addtogroup draftguitools
+# @{
 import collections as coll
 import inspect
 import itertools
 import math
-
-import Draft
-import DraftVecUtils
-import DraftGeomUtils
+import pivy.coin as coin
+import PySide.QtCore as QtCore
+import PySide.QtGui as QtGui
 
 import FreeCAD as App
 import FreeCADGui as Gui
-
 import Part
-
+import Draft
+import DraftVecUtils
+import DraftGeomUtils
 import draftguitools.gui_trackers as trackers
+
 from draftutils.init_tools import get_draft_snap_commands
 from draftutils.messages import _msg, _wrn
-
 
 __title__ = "FreeCAD Draft Snap tools"
 __author__ = "Yorik van Havre"
@@ -1681,3 +1680,5 @@ class Snapper:
                 self.holdTracker.addCoords(self.spoint)
                 self.holdTracker.on()
             self.holdPoints.append(self.spoint)
+
+## @}

--- a/src/Mod/Draft/draftguitools/gui_snaps.py
+++ b/src/Mod/Draft/draftguitools/gui_snaps.py
@@ -22,18 +22,19 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provide the Draft_Snap commands used by the snapping mechanism in Draft."""
+"""Provides GUI tools to activate the different snapping methods."""
 ## @package gui_snaps
-# \ingroup DRAFT
-# \brief Provide the Draft_Snap commands used by the snapping mechanism
-# in Draft.
+# \ingroup draftguitools
+# \brief Provides GUI tools to activate the different snapping methods.
 
-from PySide import QtGui
+## \addtogroup draftguitools
+# @{
+import PySide.QtGui as QtGui
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
 import FreeCADGui as Gui
-
 import draftguitools.gui_base as gui_base
+
 from draftutils.translate import _tr
 
 
@@ -625,3 +626,5 @@ class ShowSnapBar(gui_base.GuiCommandSimplest):
 
 
 Gui.addCommand('Draft_ShowSnapBar', ShowSnapBar())
+
+## @}

--- a/src/Mod/Draft/draftguitools/gui_splines.py
+++ b/src/Mod/Draft/draftguitools/gui_splines.py
@@ -22,14 +22,16 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides tools for creating B-Splines with the Draft Workbench.
+"""Provides GUI tools to create BSpline objects.
 
 See https://en.wikipedia.org/wiki/B-spline
 """
 ## @package gui_splines
-# \ingroup DRAFT
-# \brief Provides tools for creating B-Splines with the Draft Workbench.
+# \ingroup draftguitools
+# \brief Provides GUI tools to create BSpline objects.
 
+## \addtogroup draftguitools
+# @{
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
 import FreeCADGui as Gui
@@ -39,6 +41,7 @@ import draftguitools.gui_base_original as gui_base_original
 import draftguitools.gui_tool_utils as gui_tool_utils
 import draftguitools.gui_lines as gui_lines
 import draftguitools.gui_trackers as trackers
+
 from draftutils.messages import _msg, _err
 from draftutils.translate import translate
 
@@ -196,3 +199,5 @@ class BSpline(gui_lines.Line):
 
 
 Gui.addCommand('Draft_BSpline', BSpline())
+
+## @}

--- a/src/Mod/Draft/draftguitools/gui_split.py
+++ b/src/Mod/Draft/draftguitools/gui_split.py
@@ -22,11 +22,13 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides tools for splitting lines with the Draft Workbench."""
+"""Provides GUI tools to split line and wire objects."""
 ## @package gui_split
-# \ingroup DRAFT
-# \brief Provides tools for splitting lines with the Draft Workbench.
+# \ingroup draftguitools
+# \brief Provides GUI tools to split line and wire objects.
 
+## \addtogroup draftguitools
+# @{
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
 import FreeCAD as App
@@ -35,6 +37,7 @@ import Draft_rc
 import DraftVecUtils
 import draftguitools.gui_base_original as gui_base_original
 import draftguitools.gui_tool_utils as gui_tool_utils
+
 from draftutils.messages import _msg
 from draftutils.translate import translate, _tr
 
@@ -115,3 +118,5 @@ class Split(gui_base_original.Modifier):
 
 
 Gui.addCommand('Draft_Split', Split())
+
+## @}

--- a/src/Mod/Draft/draftguitools/gui_stretch.py
+++ b/src/Mod/Draft/draftguitools/gui_stretch.py
@@ -22,7 +22,7 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides tools for stretching objects with the Draft Workbench.
+"""Provides GUI tools to stretch Draft objects.
 
 It works with rectangles, wires, b-splines, bezier curves, and sketches.
 It essentially moves the points that are located within a selection area,
@@ -30,9 +30,11 @@ while keeping other points intact. This means the lines tied by the points
 that were moved are 'stretched'.
 """
 ## @package gui_stretch
-# \ingroup DRAFT
-# \brief Provides tools for stretching objects with the Draft Workbench.
+# \ingroup draftguitools
+# \brief Provides GUI tools to stretch Draft objects.
 
+## \addtogroup draftguitools
+# @{
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
 import FreeCAD as App
@@ -43,6 +45,7 @@ import draftutils.utils as utils
 import draftguitools.gui_base_original as gui_base_original
 import draftguitools.gui_tool_utils as gui_tool_utils
 import draftguitools.gui_trackers as trackers
+
 from draftutils.messages import _msg
 from draftutils.translate import translate, _tr
 
@@ -483,3 +486,5 @@ class Stretch(gui_base_original.Modifier):
 
 
 Gui.addCommand('Draft_Stretch', Stretch())
+
+## @}

--- a/src/Mod/Draft/draftguitools/gui_styles.py
+++ b/src/Mod/Draft/draftguitools/gui_styles.py
@@ -22,15 +22,18 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides tools for applying styles to objects in the Draft Workbench."""
+"""Provides GUI tools to apply styles to objects."""
 ## @package gui_styles
-# \ingroup DRAFT
-# \brief Provides tools for applying styles to objects in the Draft Workbench.
+# \ingroup draftguitools
+# \brief Provides GUI tools to apply styles to objects.
 
+## \addtogroup draftguitools
+# @{
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
 import FreeCADGui as Gui
 import draftguitools.gui_base_original as gui_base_original
+
 from draftutils.translate import translate, _tr
 
 
@@ -94,3 +97,5 @@ class ApplyStyle(gui_base_original.Modifier):
 
 
 Gui.addCommand('Draft_ApplyStyle', ApplyStyle())
+
+## @}

--- a/src/Mod/Draft/draftguitools/gui_subelements.py
+++ b/src/Mod/Draft/draftguitools/gui_subelements.py
@@ -22,21 +22,24 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides tools for highlighting subelements in the Draft Workbench.
+"""Provides GUI tools to highlight subelements of objects.
 
 The highlighting can be used to manipulate shapes with other tools
 such as Move, Rotate, and Scale.
 """
 ## @package gui_subelements
-# \ingroup DRAFT
-# \brief Provides tools for highlighting subelements in the Draft Workbench.
+# \ingroup draftguitools
+# \brief Provides GUI tools to highlight subelements of objects.
 
+## \addtogroup draftguitools
+# @{
 import pivy.coin as coin
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
 import FreeCADGui as Gui
 import draftguitools.gui_base_original as gui_base_original
 import draftguitools.gui_tool_utils as gui_tool_utils
+
 from draftutils.messages import _msg
 from draftutils.translate import translate, _tr
 
@@ -159,3 +162,5 @@ class SubelementHighlight(gui_base_original.Modifier):
 
 
 Gui.addCommand('Draft_SubelementHighlight', SubelementHighlight())
+
+## @}

--- a/src/Mod/Draft/draftguitools/gui_texts.py
+++ b/src/Mod/Draft/draftguitools/gui_texts.py
@@ -22,16 +22,18 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides tools for creating text annotations with the Draft Workbench.
+"""Provides GUI tools to create simple Text objects.
 
 The textual block can consist of multiple lines.
 """
 ## @package gui_texts
-# \ingroup DRAFT
-# \brief Provides tools for creating text annotations with the Draft Workbench.
+# \ingroup draftguitools
+# \brief Provides GUI tools to create simple Text objects.
 
-from PySide.QtCore import QT_TRANSLATE_NOOP
+## \addtogroup draftguitools
+# @{
 import sys
+from PySide.QtCore import QT_TRANSLATE_NOOP
 
 import FreeCAD as App
 import FreeCADGui as Gui
@@ -157,3 +159,5 @@ class Text(gui_base_original.Creator):
 
 
 Gui.addCommand('Draft_Text', Text())
+
+## @}

--- a/src/Mod/Draft/draftguitools/gui_togglemodes.py
+++ b/src/Mod/Draft/draftguitools/gui_togglemodes.py
@@ -22,19 +22,23 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides tools to control the mode of other tools in the Draft Workbench.
+"""Provides GUI tools to set different modes of other tools.
 
 For example, a construction mode, a continue mode to repeat commands,
 and to toggle the appearance of certain shapes to wireframe.
 """
 ## @package gui_togglemodes
-# \ingroup DRAFT
-# \brief Provides certain mode operations of the Draft Workbench.
+# \ingroup draftguitools
+# \brief Provides GUI tools to set different modes of other tools.
+
+## \addtogroup draftguitools
+# @{
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
 import FreeCADGui as Gui
 import Draft_rc
 import draftguitools.gui_base as gui_base
+
 from draftutils.messages import _msg
 from draftutils.translate import _tr
 
@@ -85,7 +89,8 @@ class ToggleConstructionMode(BaseMode):
     """
 
     def __init__(self):
-        super(ToggleConstructionMode, self).__init__(name=_tr("Construction mode"))
+        super(ToggleConstructionMode,
+              self).__init__(name=_tr("Construction mode"))
 
     def GetResources(self):
         """Set icon, menu and tooltip."""
@@ -166,7 +171,8 @@ class ToggleDisplayMode(gui_base.GuiCommandNeedsSelection):
     """
 
     def __init__(self):
-        super(ToggleDisplayMode, self).__init__(name=_tr("Toggle display mode"))
+        super(ToggleDisplayMode,
+              self).__init__(name=_tr("Toggle display mode"))
 
     def GetResources(self):
         """Set icon, menu and tooltip."""
@@ -205,3 +211,5 @@ class ToggleDisplayMode(gui_base.GuiCommandNeedsSelection):
 
 
 Gui.addCommand('Draft_ToggleDisplayMode', ToggleDisplayMode())
+
+## @}

--- a/src/Mod/Draft/draftguitools/gui_tool_utils.py
+++ b/src/Mod/Draft/draftguitools/gui_tool_utils.py
@@ -22,20 +22,23 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides the utility functions for Draft Gui Commands.
+"""Provides utility functions that are used by many Draft Gui Commands.
 
 These functions are used by different command classes in the `DraftTools`
 module. We assume that the graphical interface was already loaded
 as they operate on selections and graphical properties.
 """
 ## @package gui_tool_utils
-# \ingroup DRAFT
-# \brief Provides the utility functions for Draft Gui Commands.
+# \ingroup draftguitools
+# \brief Provides utility functions that are used by many Draft Gui Commands.
 
+## \addtogroup draftguitools
+# @{
 import FreeCAD as App
 import FreeCADGui as Gui
 import draftutils.gui_utils as gui_utils
 import draftutils.utils as utils
+
 from draftutils.messages import _wrn
 
 # Set modifier keys from the parameter database
@@ -387,3 +390,5 @@ def redraw_3d_view():
 
 
 redraw3DView = redraw_3d_view
+
+## @}

--- a/src/Mod/Draft/draftguitools/gui_trackers.py
+++ b/src/Mod/Draft/draftguitools/gui_trackers.py
@@ -18,29 +18,31 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provide Coin based objects used for previews in the Draft Workbench.
+"""Provides Coin based objects used to preview objects being built.
 
 This module provides Coin (pivy) based objects
 that are used by the Draft Workbench to draw temporary geometry,
 that is, previews, of the real objects that will be created on the 3D view.
 """
-## @package DraftTrackers
-#  \ingroup DRAFT
-#  \brief Provide Coin based objects used for previews in the Draft Workbench.
+## @package gui_trackers
+# \ingroup draftguitools
+# \brief Provides Coin based objects used to preview objects being built.
 #
 # This module provides Coin (pivy) based objects
 # that are used by the Draft Workbench to draw temporary geometry,
 # that is, previews, of the real objects that will be created on the 3D view.
 
-import os
+## \addtogroup draftguitools
+# @{
 import math
-from pivy import coin
 import re
+import pivy.coin as coin
 
 import FreeCAD
 import FreeCADGui
 import Draft
 import DraftVecUtils
+
 from FreeCAD import Vector
 from draftutils.todo import ToDo
 from draftutils.messages import _msg
@@ -1317,3 +1319,5 @@ class archDimTracker(Tracker):
             self.setString()
         else:
             return Vector(self.dimnode.pnts.getValues()[-1].getValue())
+
+## @}

--- a/src/Mod/Draft/draftguitools/gui_trimex.py
+++ b/src/Mod/Draft/draftguitools/gui_trimex.py
@@ -22,7 +22,7 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides tools for trimming and extending lines with the Draft Workbench.
+"""Provides GUI tools to trim and extend lines.
 
 It also extends closed faces to create solids, that is, it can be used
 to extrude a closed profile.
@@ -32,9 +32,11 @@ the direction of a line, and up to the distance specified
 by the snapping point.
 """
 ## @package gui_trimex
-# \ingroup DRAFT
-# \brief Provides tools for trimming and extending lines.
+# \ingroup draftguitools
+# \brief Provides GUI tools to trim and extend lines.
 
+## \addtogroup draftguitools
+# @{
 import math
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
@@ -48,6 +50,7 @@ import draftutils.gui_utils as gui_utils
 import draftguitools.gui_base_original as gui_base_original
 import draftguitools.gui_tool_utils as gui_tool_utils
 import draftguitools.gui_trackers as trackers
+
 from draftutils.messages import _msg, _err
 from draftutils.translate import translate, _tr
 
@@ -569,3 +572,5 @@ class Trimex(gui_base_original.Modifier):
 
 
 Gui.addCommand('Draft_Trimex', Trimex())
+
+## @}

--- a/src/Mod/Draft/draftguitools/gui_upgrade.py
+++ b/src/Mod/Draft/draftguitools/gui_upgrade.py
@@ -22,21 +22,24 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides tools for upgrading objects with the Draft Workbench.
+"""Provides GUI tools to upgrade objects.
 
 Upgrades simple 2D objects to more complex objects until it reaches
 Draft scripted objects. For example, an edge to a wire, and to a Draft Line.
 """
 ## @package gui_upgrade
-# \ingroup DRAFT
-# \brief Provides tools for upgrading objects with the Draft Workbench.
+# \ingroup draftguitools
+# \brief Provides GUI tools to upgrade objects.
 
+## \addtogroup draftguitools
+# @{
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
 import FreeCADGui as Gui
 import Draft_rc
 import draftguitools.gui_base_original as gui_base_original
 import draftguitools.gui_tool_utils as gui_tool_utils
+
 from draftutils.messages import _msg
 from draftutils.translate import translate, _tr
 
@@ -96,3 +99,5 @@ class Upgrade(gui_base_original.Modifier):
 
 
 Gui.addCommand('Draft_Upgrade', Upgrade())
+
+## @}

--- a/src/Mod/Draft/draftguitools/gui_wire2spline.py
+++ b/src/Mod/Draft/draftguitools/gui_wire2spline.py
@@ -22,7 +22,7 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides tools for converting polylines to B-splines and back.
+"""Provides GUI tools to convert polylines to B-splines and back.
 
 These tools work on polylines and B-splines which have multiple points.
 
@@ -31,9 +31,11 @@ and passed to the `makeWire` or `makeBSpline` functions,
 depending on the desired result.
 """
 ## @package gui_wire2spline
-# \ingroup DRAFT
-# \brief Provides tools for converting polylines to B-splines.
+# \ingroup draftguitools
+# \brief Provides GUI tools to convert polylines to B-splines and back.
 
+## \addtogroup draftguitools
+# @{
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
 import FreeCADGui as Gui
@@ -41,6 +43,7 @@ import Draft_rc
 import Draft
 import draftutils.utils as utils
 import draftguitools.gui_base_original as gui_base_original
+
 from draftutils.translate import translate, _tr
 
 # The module is used to prevent complaints from code checkers (flake8)
@@ -107,3 +110,5 @@ class WireToBSpline(gui_base_original.Modifier):
 
 
 Gui.addCommand('Draft_WireToBSpline', WireToBSpline())
+
+## @}

--- a/src/Mod/Draft/draftmake/__init__.py
+++ b/src/Mod/Draft/draftmake/__init__.py
@@ -80,3 +80,6 @@ can have other properties like `App::PropertyPlacement`,
 or which can interact with the 3D view through Coin,
 can be based on the simple `App::FeaturePython` object.
 """
+## \defgroup draftmake draftmake
+# \ingroup DRAFT
+# \brief Modules with functions to create the custom scripted objects.

--- a/src/Mod/Draft/draftmake/make_arc_3points.py
+++ b/src/Mod/Draft/draftmake/make_arc_3points.py
@@ -20,11 +20,13 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides the object code for Draft Arc_3Points."""
-## @package arc_3points
-# \ingroup DRAFT
-# \brief Provides the object code for Draft Arc_3Points.
+"""Provides functions to create Arc objects by using 3 points."""
+## @package make_arc_3points
+# \ingroup draftmake
+# \brief Provides functions to create Arc objects by using 3 points.
 
+## \addtogroup draftmake
+# @{
 import math
 
 import FreeCAD as App
@@ -204,3 +206,5 @@ def make_arc_3points(points, placement=None, face=False,
         _msg(_tr("Final placement: ") + "{}".format(obj.Placement))
 
     return obj
+
+## @}

--- a/src/Mod/Draft/draftmake/make_array.py
+++ b/src/Mod/Draft/draftmake/make_array.py
@@ -20,11 +20,16 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provide the code for the Draft make_array function."""
-## @package make_array
-# \ingroup DRAFT
-# \brief This module provides the code for Draft make_array function.
+"""Provides functions to create Array objects.
 
+This includes orthogonal arrays, polar arrays, and circular arrays.
+"""
+## @package make_array
+# \ingroup draftmake
+# \brief Provides functions to create Array objects.
+
+## \addtogroup draftmake
+# @{
 import FreeCAD as App
 import draftutils.utils as utils
 import draftutils.gui_utils as gui_utils
@@ -148,3 +153,5 @@ def makeArray(baseobject,
     return make_array(baseobject,
                       arg1, arg2, arg3,
                       arg4, arg5, arg6, use_link)
+
+## @}

--- a/src/Mod/Draft/draftmake/make_bezcurve.py
+++ b/src/Mod/Draft/draftmake/make_bezcurve.py
@@ -20,26 +20,27 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""This module provides the code for Draft make_bezcurve function.
-"""
+"""Provides functions to create BezCurve objects."""
 ## @package make_bezcurve
-# \ingroup DRAFT
-# \brief This module provides the code for Draft make_bezcurve function.
+# \ingroup draftmake
+# \brief Provides functions to create BezCurve objects.
 
+## \addtogroup draftmake
+# @{
 import FreeCAD as App
+import draftutils.utils as utils
+import draftutils.gui_utils as gui_utils
 
-from draftutils.gui_utils import format_object
-from draftutils.gui_utils import select
-
-from draftutils.utils import type_check
 from draftutils.translate import translate
-
 from draftobjects.bezcurve import BezCurve
+
 if App.GuiUp:
     from draftviewproviders.view_bezcurve import ViewProviderBezCurve
 
 
-def make_bezcurve(pointslist, closed=False, placement=None, face=None, support=None, degree=None):
+def make_bezcurve(pointslist,
+                  closed=False, placement=None, face=None, support=None,
+                  degree=None):
     """make_bezcurve(pointslist, [closed], [placement])
     
     Creates a Bezier Curve object from the given list of vectors.
@@ -76,7 +77,8 @@ def make_bezcurve(pointslist, closed=False, placement=None, face=None, support=N
         for v in pointslist.Vertexes:
             nlist.append(v.Point)
         pointslist = nlist
-    if placement: type_check([(placement,App.Placement)], "make_bezcurve")
+    if placement:
+        utils.type_check([(placement,App.Placement)], "make_bezcurve")
     if len(pointslist) == 2: fname = "Line"
     else: fname = "BezCurve"
     obj = App.ActiveDocument.addObject("Part::Part2DObjectPython",fname)
@@ -98,10 +100,12 @@ def make_bezcurve(pointslist, closed=False, placement=None, face=None, support=N
         ViewProviderBezCurve(obj.ViewObject)
 #        if not face: obj.ViewObject.DisplayMode = "Wireframe"
 #        obj.ViewObject.DisplayMode = "Wireframe"
-        format_object(obj)
-        select(obj)
+        gui_utils.format_object(obj)
+        gui_utils.select(obj)
 
     return obj
 
 
 makeBezCurve = make_bezcurve
+
+## @}

--- a/src/Mod/Draft/draftmake/make_block.py
+++ b/src/Mod/Draft/draftmake/make_block.py
@@ -20,17 +20,18 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""This module provides the code for Draft make_block function.
-"""
+"""Provides functions to create Block objects."""
 ## @package make_block
-# \ingroup DRAFT
-# \brief This module provides the code for Draft make_block function.
+# \ingroup draftmake
+# \brief Provides functions to create Block objects.
 
+## \addtogroup draftmake
+# @{
 import FreeCAD as App
-
-from draftutils.gui_utils import select
+import draftutils.gui_utils as gui_utils
 
 from draftobjects.block import Block
+
 if App.GuiUp:
     from draftviewproviders.view_base import ViewProviderDraftPart
 
@@ -56,8 +57,10 @@ def make_block(objectslist):
         ViewProviderDraftPart(obj.ViewObject)
         for o in objectslist:
             o.ViewObject.Visibility = False
-        select(obj)
+        gui_utils.select(obj)
     return obj
 
 
 makeBlock = make_block
+
+## @}

--- a/src/Mod/Draft/draftmake/make_bspline.py
+++ b/src/Mod/Draft/draftmake/make_bspline.py
@@ -20,20 +20,18 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""This module provides the code for Draft make_bspline function.
-"""
+"""Provides functions to create BSpline objects."""
 ## @package make_bspline
-# \ingroup DRAFT
-# \brief This module provides the code for Draft make_bspline function.
+# \ingroup draftmake
+# \brief Provides functions to create BSpline objects.
 
+## \addtogroup draftmake
+# @{
 import FreeCAD as App
+import draftutils.utils as utils
+import draftutils.gui_utils as gui_utils
 
-from draftutils.gui_utils import format_object
-from draftutils.gui_utils import select
-
-from draftutils.utils import type_check
 from draftutils.translate import translate
-
 from draftobjects.bspline import BSpline
 
 if App.GuiUp:
@@ -90,7 +88,8 @@ def make_bspline(pointslist, closed=False, placement=None, face=None, support=No
             App.Console.PrintError(translate("Draft", _err)+"\n")
             return
     # should have sensible parms from here on
-    if placement: type_check([(placement,App.Placement)], "make_bspline")
+    if placement:
+        utils.type_check([(placement,App.Placement)], "make_bspline")
     if len(pointslist) == 2: fname = "Line"
     else: fname = "BSpline"
     obj = App.ActiveDocument.addObject("Part::Part2DObjectPython",fname)
@@ -103,10 +102,12 @@ def make_bspline(pointslist, closed=False, placement=None, face=None, support=No
     if placement: obj.Placement = placement
     if App.GuiUp:
         ViewProviderBSpline(obj.ViewObject)
-        format_object(obj)
-        select(obj)
+        gui_utils.format_object(obj)
+        gui_utils.select(obj)
 
     return obj
 
 
 makeBSpline = make_bspline
+
+## @}

--- a/src/Mod/Draft/draftmake/make_circle.py
+++ b/src/Mod/Draft/draftmake/make_circle.py
@@ -20,26 +20,23 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""This module provides the code for Draft make_circle function.
-"""
-## @package make circle
-# \ingroup DRAFT
-# \brief This module provides the code for Draft make_circle.
+"""Provides functions to create Circle objects."""
+## @package make_circle
+# \ingroup draftmake
+# \brief Provides functions to create Circle objects.
 
-
+## \addtogroup draftmake
+# @{
 import math
 
 import FreeCAD as App
-
 import Part
 import DraftGeomUtils
-
-from draftutils.gui_utils import format_object
-from draftutils.gui_utils import select
-
-from draftutils.utils import type_check
+import draftutils.utils as utils
+import draftutils.gui_utils as gui_utils
 
 from draftobjects.circle import Circle
+
 if App.GuiUp:
     from draftviewproviders.view_base import ViewProviderDraft
 
@@ -78,7 +75,8 @@ def make_circle(radius, placement=None, face=None, startangle=None, endangle=Non
         App.Console.PrintError("No active document. Aborting\n")
         return
 
-    if placement: type_check([(placement,App.Placement)], "make_circle")
+    if placement:
+        utils.type_check([(placement,App.Placement)], "make_circle")
 
     if startangle != endangle:
         _name = "Arc"
@@ -126,10 +124,12 @@ def make_circle(radius, placement=None, face=None, startangle=None, endangle=Non
 
     if App.GuiUp:
         ViewProviderDraft(obj.ViewObject)
-        format_object(obj)
-        select(obj)
+        gui_utils.format_object(obj)
+        gui_utils.select(obj)
 
     return obj
 
 
 makeCircle = make_circle
+
+## @}

--- a/src/Mod/Draft/draftmake/make_circulararray.py
+++ b/src/Mod/Draft/draftmake/make_circulararray.py
@@ -20,13 +20,14 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides functions for creating circular arrays in a plane."""
+"""Provides functions to create circular Array objects."""
 ## @package make_circulararray
-# \ingroup DRAFT
-# \brief Provides functions for creating circular arrays in a plane.
+# \ingroup draftmake
+# \brief Provides functions to create circular Array objects.
 
+## \addtogroup draftmake
+# @{
 import FreeCAD as App
-
 import draftmake.make_array as make_array
 import draftutils.utils as utils
 
@@ -172,3 +173,5 @@ def make_circular_array(base_object,
                                     arg5=number, arg6=symmetry,
                                     use_link=use_link)
     return new_obj
+
+## @}

--- a/src/Mod/Draft/draftmake/make_clone.py
+++ b/src/Mod/Draft/draftmake/make_clone.py
@@ -20,22 +20,19 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""This module provides the code for Draft make_clone function.
-"""
+"""Provides functions to create Clone objects."""
 ## @package make_clone
-# \ingroup DRAFT
-# \brief This module provides the code for Draft make_clone function.
+# \ingroup draftmake
+# \brief Provides functions to create Clone objects.
 
+## \addtogroup draftmake
+# @{
 import FreeCAD as App
-
-import DraftGeomUtils
-
 import draftutils.utils as utils
-
-from draftutils.gui_utils import format_object
-from draftutils.gui_utils import select
+import draftutils.gui_utils as gui_utils
 
 from draftobjects.clone import Clone
+
 if App.GuiUp:
     from draftutils.todo import ToDo
     from draftviewproviders.view_clone import ViewProviderClone
@@ -102,11 +99,11 @@ def make_clone(obj, delta=None, forcedraft=False):
             except:
                 pass
             if App.GuiUp:
-                format_object(cl,base)
+                gui_utils.format_object(cl,base)
                 cl.ViewObject.DiffuseColor = base.ViewObject.DiffuseColor
                 if utils.get_type(obj[0]) in ["Window","BuildingPart"]:
                     ToDo.delay(Arch.recolorize,cl)
-            select(cl)
+            gui_utils.select(cl)
             return cl
     # fall back to Draft clone mode
     if not cl:
@@ -121,13 +118,15 @@ def make_clone(obj, delta=None, forcedraft=False):
         cl.Placement.move(delta)
     elif (len(obj) == 1) and hasattr(obj[0],"Placement"):
         cl.Placement = obj[0].Placement
-    format_object(cl,obj[0])
+    gui_utils.format_object(cl,obj[0])
     if hasattr(cl,"LongName") and hasattr(obj[0],"LongName"):
         cl.LongName = obj[0].LongName
     if App.GuiUp and (len(obj) > 1):
         cl.ViewObject.Proxy.resetColors(cl.ViewObject)
-    select(cl)
+    gui_utils.select(cl)
     return cl
 
 
 clone = make_clone
+
+## @}

--- a/src/Mod/Draft/draftmake/make_copy.py
+++ b/src/Mod/Draft/draftmake/make_copy.py
@@ -20,17 +20,16 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""This module provides the code for Draft make_copy function.
-"""
+"""Provides functions to create copies of objects."""
 ## @package make_copy
-# \ingroup DRAFT
-# \brief This module provides the code for Draft make_copy function.
+# \ingroup draftmake
+# \brief Provides functions to create copies of objects.
 
+## \addtogroup draftmake
+# @{
 import FreeCAD as App
-
 import draftutils.utils as utils
 import draftutils.gui_utils as gui_utils
-
 
 
 def make_copy(obj, force=None, reparent=False, simple_copy=False):
@@ -85,4 +84,5 @@ def make_copy(obj, force=None, reparent=False, simple_copy=False):
                             par.Group = group
 
     return newobj
-    
+
+## @}

--- a/src/Mod/Draft/draftmake/make_dimension.py
+++ b/src/Mod/Draft/draftmake/make_dimension.py
@@ -23,11 +23,16 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides functions to crate dimension objects."""
-## @package make_dimension
-# \ingroup DRAFT
-# \brief Provides functions to crate dimension objects.
+"""Provides functions to create LinearDimension or AngularDinemsion objects.
 
+This includes linear dimensions, radial dimensions, and angular dimensions.
+"""
+## @package make_dimension
+# \ingroup draftmake
+# \brief Provides functions to create Linear or AngularDimension objects.
+
+## \addtogroup draftmake
+# @{
 import math
 
 import FreeCAD as App
@@ -40,8 +45,9 @@ from draftobjects.dimension import (LinearDimension,
                                     AngularDimension)
 
 if App.GuiUp:
-    from draftviewproviders.view_dimension import ViewProviderLinearDimension
-    from draftviewproviders.view_dimension import ViewProviderAngularDimension
+    from draftviewproviders.view_dimension \
+        import (ViewProviderLinearDimension,
+                ViewProviderAngularDimension)
 
 
 def make_dimension(p1, p2, p3=None, p4=None):
@@ -646,3 +652,5 @@ def makeAngularDimension(center, angles, p3, normal=None):
 
     return make_angular_dimension(center=center, angles=angles,
                                   dim_line=p3, normal=normal)
+
+## @}

--- a/src/Mod/Draft/draftmake/make_drawingview.py
+++ b/src/Mod/Draft/draftmake/make_drawingview.py
@@ -20,15 +20,18 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""This module provides the code for Draft make_drawing_view function.
-OBSOLETE: Drawing Workbench was substituted by TechDraw.
+"""Provides functions to create DrawingView objects.
+
+These functions must be considered obsolete as the Drawing Workbench
+is obsolete since v0.17.
 """
 ## @package make_drawingview
-# \ingroup DRAFT
-# \brief This module provides the code for Draft make_drawing_view function
+# \ingroup draftmake
+# \brief Provides functions to create DrawingView objects.
 
+## \addtogroup draftmake
+# @{
 import FreeCAD as App
-
 import draftutils.utils as utils
 
 from draftobjects.drawingview import DrawingView
@@ -104,3 +107,5 @@ def make_drawing_view(obj, page, lwmod=None, tmod=None, otherProjection=None):
 
 
 makeDrawingView = make_drawing_view
+
+## @}

--- a/src/Mod/Draft/draftmake/make_ellipse.py
+++ b/src/Mod/Draft/draftmake/make_ellipse.py
@@ -20,18 +20,18 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""This module provides the code for Draft make_ellipse function.
-"""
+"""Provides functions to create Ellipse objects."""
 ## @package make_ellipse
-# \ingroup DRAFT
-# \brief This module provides the code for Draft make_ellipse function.
+# \ingroup draftmake
+# \brief Provides functions to create Ellipse objects.
 
+## \addtogroup draftmake
+# @{
 import FreeCAD as App
-
-from draftutils.gui_utils import format_object
-from draftutils.gui_utils import select
+import draftutils.gui_utils as gui_utils
 
 from draftobjects.ellipse import Ellipse
+
 if App.GuiUp:
     from draftviewproviders.view_base import ViewProviderDraft
 
@@ -76,10 +76,12 @@ def make_ellipse(majradius, minradius, placement=None, face=True, support=None):
         ViewProviderDraft(obj.ViewObject)
         #if not face:
         #    obj.ViewObject.DisplayMode = "Wireframe"
-        format_object(obj)
-        select(obj)
+        gui_utils.format_object(obj)
+        gui_utils.select(obj)
 
     return obj
 
 
 makeEllipse = make_ellipse
+
+## @}

--- a/src/Mod/Draft/draftmake/make_facebinder.py
+++ b/src/Mod/Draft/draftmake/make_facebinder.py
@@ -20,17 +20,18 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""This module provides the code for Draft make_facebinder function.
-"""
+"""Provides functions to create Facebinder objects."""
 ## @package make_facebinder
-# \ingroup DRAFT
-# \brief This module provides the code for Draft make_facebinder function.
+# \ingroup draftmake
+# \brief Provides functions to create Facebinder objects.
 
+## \addtogroup draftmake
+# @{
 import FreeCAD as App
-
-from draftutils.gui_utils import select
+import draftutils.gui_utils as gui_utils
 
 from draftobjects.facebinder import Facebinder
+
 if App.GuiUp:
     from draftviewproviders.view_facebinder import ViewProviderFacebinder
 
@@ -59,8 +60,10 @@ def make_facebinder(selectionset, name="Facebinder"):
         ViewProviderFacebinder(fb.ViewObject)
     faces = [] # unused variable?
     fb.Proxy.addSubobjects(fb, selectionset)
-    select(fb)
+    gui_utils.select(fb)
     return fb
 
 
 makeFacebinder = make_facebinder
+
+## @}

--- a/src/Mod/Draft/draftmake/make_fillet.py
+++ b/src/Mod/Draft/draftmake/make_fillet.py
@@ -18,34 +18,34 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides the code to create Fillet objects.
+"""Provides functions to create Fillet objects between two lines.
 
 This creates a `Part::Part2DObjectPython`, and then assigns the Proxy class
 `Fillet`, and the `ViewProviderFillet` for the view provider.
 """
 ## @package make_fillet
-# \ingroup DRAFT
-# \brief Provides the code to create Fillet objects.
+# \ingroup draftmake
+# \brief Provides functions to create Fillet objects between two lines.
 
 import lazy_loader.lazy_loader as lz
 
 import FreeCAD as App
-import Draft_rc
-import DraftGeomUtils
 import draftutils.utils as utils
 import draftutils.gui_utils as gui_utils
 import draftobjects.fillet as fillet
+
 from draftutils.messages import _msg, _err
 from draftutils.translate import _tr
 
 if App.GuiUp:
     import draftviewproviders.view_fillet as view_fillet
 
-# Delay import of Part module until first use because it is heavy
+# Delay import of module until first use because it is heavy
 Part = lz.LazyLoader("Part", globals(), "Part")
+DraftGeomUtils = lz.LazyLoader("DraftGeomUtils", globals(), "DraftGeomUtils")
 
-# The module is used to prevent complaints from code checkers (flake8)
-True if Draft_rc.__name__ else False
+## \addtogroup draftmake
+# @{
 
 
 def _print_obj_length(obj, edge, num=1):
@@ -171,3 +171,5 @@ def make_fillet(objs, radius=100, chamfer=False, delete=False):
         gui_utils.autogroup(obj)
 
     return obj
+
+## @}

--- a/src/Mod/Draft/draftmake/make_label.py
+++ b/src/Mod/Draft/draftmake/make_label.py
@@ -23,11 +23,13 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides the make function to create Draft Label objects."""
+"""Provides functions to create Label objects."""
 ## @package make_label
-# \ingroup DRAFT
-# \brief Provides the make function to create Draft Label objects.
+# \ingroup draftmake
+# \brief Provides functions to create Label objects.
 
+## \addtogroup draftmake
+# @{
 import FreeCAD as App
 import draftutils.gui_utils as gui_utils
 import draftutils.utils as utils
@@ -408,3 +410,5 @@ def makeLabel(targetpoint=None, target=None, direction=None,
                       label_type=labeltype,
                       direction=direction,
                       distance=distance)
+
+## @}

--- a/src/Mod/Draft/draftmake/make_line.py
+++ b/src/Mod/Draft/draftmake/make_line.py
@@ -20,18 +20,15 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""This module provides the code for Draft make_line function.
-"""
+"""Provides functions to create two-point Wire objects."""
 ## @package make_line
-# \ingroup DRAFT
-# \brief This module provides the code for Draft make_line function.
+# \ingroup draftmake
+# \brief Provides functions to create two-point Wire objects.
 
+## \addtogroup draftmake
+# @{
 import FreeCAD as App
-
-from draftutils.gui_utils import format_object
-from draftutils.gui_utils import select
-
-from draftmake.make_wire import make_wire
+import draftmake.make_wire as make_wire
 
 
 def make_line(first_param, last_param=None):
@@ -65,9 +62,11 @@ def make_line(first_param, last_param=None):
             App.Console.PrintError(_err + "\n")
             return
 
-    obj = make_wire([p1,p2])
+    obj = make_wire.make_wire([p1,p2])
 
     return obj
 
 
 makeLine = make_line
+
+## @}

--- a/src/Mod/Draft/draftmake/make_orthoarray.py
+++ b/src/Mod/Draft/draftmake/make_orthoarray.py
@@ -20,15 +20,16 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides functions for creating orthogonal arrays in 2D and 3D."""
+"""Provides functions to create orthogonal 2D and 3D Array objects."""
 ## @package make_orthoarray
-# \ingroup DRAFT
-# \brief Provides functions for creating orthogonal arrays in 2D and 3D.
+# \ingroup draftmake
+# \brief Provides functions to create orthogonal 2D and 3D Arrays.
 
+## \addtogroup draftmake
+# @{
 import FreeCAD as App
-
-import draftmake.make_array as make_array
 import draftutils.utils as utils
+import draftmake.make_array as make_array
 
 from draftutils.messages import _msg, _wrn, _err
 from draftutils.translate import _tr
@@ -525,3 +526,5 @@ def make_rect_array2d(base_object,
                                 n_y=n_y,
                                 use_link=use_link)
     return new_obj
+
+## @}

--- a/src/Mod/Draft/draftmake/make_patharray.py
+++ b/src/Mod/Draft/draftmake/make_patharray.py
@@ -25,15 +25,17 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides functions for creating path arrays.
+"""Provides functions to create PathArray objects.
 
 The copies will be placed along a path like a polyline, spline, or bezier
 curve.
 """
 ## @package make_patharray
-# \ingroup DRAFT
-# \brief Provides functions for creating path arrays.
+# \ingroup draftmake
+# \brief Provides functions to create PathArray objects.
 
+## \addtogroup draftmake
+# @{
 import FreeCAD as App
 import draftutils.utils as utils
 import draftutils.gui_utils as gui_utils
@@ -315,3 +317,5 @@ def makePathArray(baseobject, pathobject, count,
                            xlate, pathobjsubs,
                            align,
                            use_link)
+
+## @}

--- a/src/Mod/Draft/draftmake/make_point.py
+++ b/src/Mod/Draft/draftmake/make_point.py
@@ -20,18 +20,18 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""This module provides the code for Draft make_point function.
-"""
+"""Provides functions to create Point objects."""
 ## @package make_point
-# \ingroup DRAFT
-# \brief This module provides the code for Draft make_point function.
+# \ingroup draftmake
+# \brief Provides functions to create Point objects.
 
+## \addtogroup draftmake
+# @{
 import FreeCAD as App
-
-from draftutils.gui_utils import format_object
-from draftutils.gui_utils import select
+import draftutils.gui_utils as gui_utils
 
 from draftobjects.point import Point
+
 if App.GuiUp:
     import FreeCADGui as Gui
     from draftviewproviders.view_point import ViewProviderPoint
@@ -88,9 +88,11 @@ def make_point(X=0, Y=0, Z=0, color=None, name = "Point", point_size= 5):
         obj.ViewObject.PointColor = (float(color[0]), float(color[1]), float(color[2]))
         obj.ViewObject.PointSize = point_size
         obj.ViewObject.Visibility = True
-        select(obj)
+        gui_utils.select(obj)
 
     return obj
 
 
 makePoint = make_point
+
+## @}

--- a/src/Mod/Draft/draftmake/make_pointarray.py
+++ b/src/Mod/Draft/draftmake/make_pointarray.py
@@ -24,15 +24,17 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides functions for creating point arrays.
+"""Provides functions to create PointArray objects.
 
 The copies will be placed along a list of points defined by a sketch,
 a `Part::Compound`, or a `Draft Block`.
 """
 ## @package make_pointarray
-# \ingroup DRAFT
-# \brief This module provides the code for Draft make_point_array function.
+# \ingroup draftmake
+# \brief Provides functions to create PointArray objects.
 
+## \addtogroup draftmake
+# @{
 import FreeCAD as App
 import draftutils.utils as utils
 import draftutils.gui_utils as gui_utils
@@ -177,3 +179,5 @@ def makePointArray(base, ptlst):
     utils.use_instead('make_point_array')
 
     return make_point_array(base, ptlst)
+
+## @}

--- a/src/Mod/Draft/draftmake/make_polararray.py
+++ b/src/Mod/Draft/draftmake/make_polararray.py
@@ -20,15 +20,16 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides functions for creating polar arrays in a plane."""
+"""Provides functions to create polar Array objects."""
 ## @package make_polararray
-# \ingroup DRAFT
-# \brief Provides functions for creating polar arrays in a plane.
+# \ingroup draftmake
+# \brief Provides functions to create polar Array objects.
 
+## \addtogroup draftmake
+# @{
 import FreeCAD as App
-
-import draftmake.make_array as make_array
 import draftutils.utils as utils
+import draftmake.make_array as make_array
 
 from draftutils.messages import _msg, _err
 from draftutils.translate import _tr
@@ -132,3 +133,5 @@ def make_polar_array(base_object,
                                     arg1=center, arg2=angle, arg3=number,
                                     use_link=use_link)
     return new_obj
+
+## @}

--- a/src/Mod/Draft/draftmake/make_polygon.py
+++ b/src/Mod/Draft/draftmake/make_polygon.py
@@ -20,22 +20,18 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""This module provides the object code for Draft make_rectangle function.
-"""
-## @package make_rectangle
-# \ingroup DRAFT
-# \brief This module provides the code for Draft make_rectangle function.
+"""Provides functions to create Polygon objects."""
+## @package make_polygon
+# \ingroup draftmake
+# \brief Provides functions to create Polygon objects.
 
+## \addtogroup draftmake
+# @{
 import FreeCAD as App
-
-from draftutils.gui_utils import format_object
-from draftutils.gui_utils import select
-
-from draftutils.utils import type_check
+import draftutils.gui_utils as gui_utils
 
 from draftobjects.polygon import Polygon
 from draftviewproviders.view_base import ViewProviderDraft
-
 
 
 def make_polygon(nfaces, radius=1, inscribed=True, placement=None, face=None, support=None):
@@ -82,10 +78,12 @@ def make_polygon(nfaces, radius=1, inscribed=True, placement=None, face=None, su
     if placement: obj.Placement = placement
     if App.GuiUp:
         ViewProviderDraft(obj.ViewObject)
-        format_object(obj)
-        select(obj)
+        gui_utils.format_object(obj)
+        gui_utils.select(obj)
 
     return obj
 
 
 makePolygon = make_polygon
+
+## @}

--- a/src/Mod/Draft/draftmake/make_rectangle.py
+++ b/src/Mod/Draft/draftmake/make_rectangle.py
@@ -20,20 +20,19 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""This module provides the code for Draft make_rectangle function.
-"""
+"""Provides functions to create Rectangle objects."""
 ## @package make_rectangle
-# \ingroup DRAFT
+# \ingroup draftmake
 # \brief This module provides the code for Draft make_rectangle function.
 
+## \addtogroup draftmake
+# @{
 import FreeCAD as App
-
-from draftutils.gui_utils import format_object
-from draftutils.gui_utils import select
-
-from draftutils.utils import type_check
+import draftutils.utils as utils
+import draftutils.gui_utils as gui_utils
 
 from draftobjects.rectangle import Rectangle
+
 if App.GuiUp:
     from draftviewproviders.view_rectangle import ViewProviderRectangle
 
@@ -75,7 +74,8 @@ def make_rectangle(length, height=0, placement=None, face=None, support=None):
         rp = App.Placement(verts[0],rr)
         return makeRectangle(xv.Length,yv.Length,rp,face,support)
 
-    if placement: type_check([(placement,App.Placement)], "make_rectangle")
+    if placement:
+        utils.type_check([(placement,App.Placement)], "make_rectangle")
 
     obj = App.ActiveDocument.addObject("Part::Part2DObjectPython","Rectangle")
     Rectangle(obj)
@@ -91,10 +91,12 @@ def make_rectangle(length, height=0, placement=None, face=None, support=None):
 
     if App.GuiUp:
         ViewProviderRectangle(obj.ViewObject)
-        format_object(obj)
-        select(obj)
+        gui_utils.format_object(obj)
+        gui_utils.select(obj)
 
     return obj
 
 
 makeRectangle = make_rectangle
+
+## @}

--- a/src/Mod/Draft/draftmake/make_shape2dview.py
+++ b/src/Mod/Draft/draftmake/make_shape2dview.py
@@ -20,17 +20,18 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""This module provides the code for Draft make_shape2dview function.
-"""
+"""Provides functions to create Shape2DView objects."""
 ## @package make_shape2dview
-# \ingroup DRAFT
-# \brief This module provides the code for Draft make_shape2dview function.
+# \ingroup draftmake
+# \brief Provides functions to create Shape2DView objects.
 
+## \addtogroup draftmake
+# @{
 import FreeCAD as App
-
-from draftutils.gui_utils import select
+import draftutils.gui_utils as gui_utils
 
 from draftobjects.shape2dview import Shape2DView
+
 if App.GuiUp:
     from draftviewproviders.view_base import ViewProviderDraftAlt
 
@@ -63,9 +64,11 @@ def make_shape2dview(baseobj,projectionVector=None,facenumbers=[]):
         obj.Projection = projectionVector
     if facenumbers:
         obj.FaceNumbers = facenumbers
-    select(obj)
+    gui_utils.select(obj)
 
     return obj
 
 
 makeShape2DView = make_shape2dview
+
+## @}

--- a/src/Mod/Draft/draftmake/make_shapestring.py
+++ b/src/Mod/Draft/draftmake/make_shapestring.py
@@ -20,18 +20,18 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""This module provides the code for Draft make_shapestring function.
-"""
+"""Provides functions to create ShapeString objects."""
 ## @package make_shapestring
-# \ingroup DRAFT
-# \brief This module provides the code for Draft make_shapestring function.
+# \ingroup draftmake
+# \brief Provides functions to create ShapeString objects.
 
+## \addtogroup draftmake
+# @{
 import FreeCAD as App
-
-from draftutils.gui_utils import format_object
-from draftutils.gui_utils import select
+import draftutils.gui_utils as gui_utils
 
 from draftobjects.shapestring import ShapeString
+
 if App.GuiUp:
     from draftviewproviders.view_base import ViewProviderDraft
 
@@ -61,12 +61,14 @@ def make_shapestring(String, FontFile, Size=100, Tracking=0):
 
     if App.GuiUp:
         ViewProviderDraft(obj.ViewObject)
-        format_object(obj)
+        gui_utils.format_object(obj)
         obrep = obj.ViewObject
         if "PointSize" in obrep.PropertiesList: obrep.PointSize = 1 # hide the segment end points
-        select(obj)
+        gui_utils.select(obj)
     obj.recompute()
     return obj
 
 
 makeShapeString = make_shapestring
+
+## @}

--- a/src/Mod/Draft/draftmake/make_sketch.py
+++ b/src/Mod/Draft/draftmake/make_sketch.py
@@ -20,28 +20,22 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""This module provides the code for Draft make_sketch function.
-"""
+"""Provides functions to create Sketch objects from Draft objects."""
 ## @package make_sketch
-# \ingroup DRAFT
-# \brief This module provides the code for Draft make_sketch function.
+# \ingroup draftmake
+# \brief Provides functions to create Sketch objects from Draft objects.
 
+## \addtogroup draftmake
+# @{
 import math
 
 import FreeCAD as App
-
 import DraftVecUtils
 import DraftGeomUtils
-
 import draftutils.utils as utils
+import draftutils.gui_utils as gui_utils
+
 from draftutils.translate import translate
-
-from draftutils.gui_utils import format_object
-from draftutils.gui_utils import select
-
-from draftobjects.ellipse import Ellipse
-if App.GuiUp:
-    from draftviewproviders.view_base import ViewProviderDraft
 
 
 def make_sketch(objectslist, autoconstraints=False, addTo=None,
@@ -303,7 +297,7 @@ def make_sketch(objectslist, autoconstraints=False, addTo=None,
                         nobj.addGeometry(DraftGeomUtils.orientEdge(
                                                 newedge,norm,make_arc=True))
             ok = True
-        format_object(nobj,obj)
+        gui_utils.format_object(nobj,obj)
         if ok and delete and hasattr(obj,'Shape'):
             doc = obj.Document
             def delObj(obj):
@@ -334,3 +328,5 @@ def make_sketch(objectslist, autoconstraints=False, addTo=None,
 
 
 makeSketch = make_sketch
+
+## @}

--- a/src/Mod/Draft/draftmake/make_text.py
+++ b/src/Mod/Draft/draftmake/make_text.py
@@ -22,11 +22,13 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides the make function to create Draft Text objects."""
+"""Provides functions to create Text objects."""
 ## @package make_text
-# \ingroup DRAFT
-# \brief Provides the make function to create Draft Text objects.
+# \ingroup draftmake
+# \brief Provides functions to create Text objects.
 
+## \addtogroup draftmake
+# @{
 import FreeCAD as App
 import draftutils.utils as utils
 import draftutils.gui_utils as gui_utils
@@ -216,5 +218,6 @@ def convert_draft_texts(textslist=None):
 def convertDraftTexts(textslist=[]):
     """Convert Text. DEPRECATED. Use 'convert_draft_texts'."""
     utils.use_instead("convert_draft_texts")
-
     return convert_draft_texts(textslist)
+
+## @}

--- a/src/Mod/Draft/draftmake/make_wire.py
+++ b/src/Mod/Draft/draftmake/make_wire.py
@@ -19,22 +19,20 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""This module provides the code for Draft make_wire function.
-"""
+"""Provides functions to create multipoint Wire objects."""
 ## @package make_wire
-# \ingroup DRAFT
-# \brief This module provides the code for Draft make_wire function.
+# \ingroup draftmake
+# \brief Provides functions to create multipoint Wire objects.
 
+## \addtogroup draftmake
+# @{
 import FreeCAD as App
-
 import DraftGeomUtils
-
-from draftutils.gui_utils import format_object
-from draftutils.gui_utils import select
-
-from draftutils.utils import type_check
+import draftutils.utils as utils
+import draftutils.gui_utils as gui_utils
 
 from draftobjects.wire import Wire
+
 if App.GuiUp:
     from draftviewproviders.view_wire import ViewProviderWire
 
@@ -90,7 +88,7 @@ def make_wire(pointslist, closed=False, placement=None, face=None, support=None,
     #print(closed)
     
     if placement:
-        type_check([(placement, App.Placement)], "make_wire")
+        utils.type_check([(placement, App.Placement)], "make_wire")
         ipl = placement.inverse()
         if not bs2wire:
             pointslist = [ipl.multVec(p) for p in pointslist]
@@ -114,10 +112,12 @@ def make_wire(pointslist, closed=False, placement=None, face=None, support=None,
 
     if App.GuiUp:
         ViewProviderWire(obj.ViewObject)
-        format_object(obj)
-        select(obj)
+        gui_utils.format_object(obj)
+        gui_utils.select(obj)
 
     return obj
 
 
 makeWire = make_wire
+
+## @}

--- a/src/Mod/Draft/draftmake/make_wpproxy.py
+++ b/src/Mod/Draft/draftmake/make_wpproxy.py
@@ -20,12 +20,13 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""This module provides the code for Draft make_workingplaneproxy function.
-"""
+"""Provides functions to create WorkingPlaneProxy objects."""
 ## @package make_wpproxy
-# \ingroup DRAFT
-# \brief This module provides the code for Draft makeworkingplane_proxy function.
+# \ingroup draftmake
+# \brief Provides functions to create WorkingPlaneProxy objects.
 
+## \addtogroup draftmake
+# @{
 import FreeCAD as App
 
 from draftobjects.wpproxy import WorkingPlaneProxy
@@ -56,3 +57,5 @@ def make_workingplaneproxy(placement):
 
 
 makeWorkingPlaneProxy = make_workingplaneproxy
+
+## @}

--- a/src/Mod/Draft/draftobjects/__init__.py
+++ b/src/Mod/Draft/draftobjects/__init__.py
@@ -53,3 +53,6 @@ as the older class.
 
     old_module.Rectangle = new_module.Rectangle
 """
+## \defgroup draftobjects draftobjects
+# \ingroup DRAFT
+# \brief Modules that contain classes that define custom scripted objects.

--- a/src/Mod/Draft/draftobjects/array.py
+++ b/src/Mod/Draft/draftobjects/array.py
@@ -21,16 +21,18 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides the object code for the Draft Array object.
+"""Provides the object code for the Array object.
 
 The `Array` class currently handles three types of arrays,
 orthogonal, polar, and circular. In the future, probably they should be
 split in separate classes so that they are easier to manage.
 """
 ## @package array
-# \ingroup DRAFT
-# \brief Provides the object code for the Draft Array object.
+# \ingroup draftobjects
+# \brief Provides the object code for the Array object.
 
+## \addtogroup draftobjects
+# @{
 import math
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
@@ -527,3 +529,5 @@ def circ_placements(base_placement,
             placements.append(npl)
 
     return placements
+
+## @}

--- a/src/Mod/Draft/draftobjects/base.py
+++ b/src/Mod/Draft/draftobjects/base.py
@@ -20,11 +20,14 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""This module provides the object code for the basic Draft object.
-"""
+"""Provides the object code for the base Draft object."""
 ## @package base
-# \ingroup DRAFT
-# \brief This module provides the object code for the basic Draft object.
+# \ingroup draftobjects
+# \brief Provides the object code for the base Draft object.
+
+## \addtogroup draftobjects
+# @{
+
 
 class DraftObject(object):
     """The base class for Draft objects.
@@ -71,6 +74,7 @@ class DraftObject(object):
     This class attribute is accessible through the `Proxy` object:
     `obj.Proxy.Type`.
     """
+
     def __init__(self, obj, tp="Unknown"):
         # This class is assigned to the Proxy attribute
         if obj:
@@ -109,7 +113,7 @@ class DraftObject(object):
             self.Type = state
 
         Parameters
-        ---------
+        ----------
         state : state
             A serialized object.
         """
@@ -117,7 +121,7 @@ class DraftObject(object):
             self.Type = state
 
     def execute(self, obj):
-        """This method is run when the object is created or recomputed.
+        """Run this method when the object is created or recomputed.
 
         Override this method to produce effects when the object
         is newly created, and whenever the document is recomputed.
@@ -133,7 +137,7 @@ class DraftObject(object):
         pass
 
     def onChanged(self, obj, prop):
-        """This method is run when a property is changed.
+        """Run this method when a property is changed.
 
         Override this method to handle the behavior
         of the object depending on changes that occur to its properties.
@@ -152,4 +156,7 @@ class DraftObject(object):
         pass
 
 
+# Alias for compatibility with v0.18 and earlier
 _DraftObject = DraftObject
+
+## @}

--- a/src/Mod/Draft/draftobjects/bezcurve.py
+++ b/src/Mod/Draft/draftobjects/bezcurve.py
@@ -20,17 +20,17 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""This module provides the object code for Draft BezCurve.
-"""
+"""Provides the object code for the BezCurve object."""
 ## @package bezcurve
-# \ingroup DRAFT
-# \brief This module provides the object code for Draft BezCurve.
+# \ingroup draftobjects
+# \brief Provides the object code for the BezCurve object.
 
+## \addtogroup draftobjects
+# @{
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
 import FreeCAD as App
-
-from draftutils.utils import get_param
+import draftutils.utils as utils
 
 from draftobjects.base import DraftObject
 
@@ -69,7 +69,7 @@ class BezCurve(DraftObject):
                 "The area of this object")
         obj.addProperty("App::PropertyArea", "Area", "Draft", _tip)
 
-        obj.MakeFace = get_param("fillmode", True)
+        obj.MakeFace = utils.get_param("fillmode", True)
         obj.Closed = False
         obj.Degree = 3
         obj.Continuity = []
@@ -193,4 +193,7 @@ class BezCurve(DraftObject):
         return pn + knot
 
 
+# Alias for compatibility with v0.18 and earlier
 _BezCurve = BezCurve
+
+## @}

--- a/src/Mod/Draft/draftobjects/block.py
+++ b/src/Mod/Draft/draftobjects/block.py
@@ -20,12 +20,13 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""This module provides the object code for Draft Block.
-"""
+"""Provides the object code for the Block object."""
 ## @package block
-# \ingroup DRAFT
-# \brief This module provides the object code for Draft Block.
+# \ingroup draftobjects
+# \brief Provides the object code for the Block object.
 
+## \addtogroup draftobjects
+# @{
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
 from draftobjects.base import DraftObject
@@ -53,4 +54,8 @@ class Block(DraftObject):
         obj.Placement = plm
         obj.positionBySupport()
 
+
+# Alias for compatibility with v0.18 and earlier
 _Block = Block
+
+## @}

--- a/src/Mod/Draft/draftobjects/bspline.py
+++ b/src/Mod/Draft/draftobjects/bspline.py
@@ -20,17 +20,17 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""This module provides the object code for Draft BSpline.
-"""
+"""Provides the object code for the BSpline object."""
 ## @package bspline
-# \ingroup DRAFT
-# \brief This module provides the object code for Draft BSpline.
+# \ingroup draftobjects
+# \brief Provides the object code for the BSpline object.
 
+## \addtogroup draftobjects
+# @{
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
 import FreeCAD as App
-
-from draftutils.utils import get_param
+import draftutils.utils as utils
 
 from draftobjects.base import DraftObject
 
@@ -56,7 +56,7 @@ class BSpline(DraftObject):
         _tip = QT_TRANSLATE_NOOP("App::Property", "The area of this object")
         obj.addProperty("App::PropertyArea","Area", "Draft", _tip)
 
-        obj.MakeFace = get_param("fillmode",True)
+        obj.MakeFace = utils.get_param("fillmode",True)
         obj.Closed = False
         obj.Points = []
         self.assureProperties(obj)
@@ -133,4 +133,7 @@ class BSpline(DraftObject):
         obj.positionBySupport()
 
 
+# Alias for compatibility with v0.18 and earlier
 _BSpline = BSpline
+
+## @}

--- a/src/Mod/Draft/draftobjects/circle.py
+++ b/src/Mod/Draft/draftobjects/circle.py
@@ -20,17 +20,17 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""This module provides the object code for Draft Circle.
-"""
+"""Provides the object code for the Circle object."""
 ## @package circle
-# \ingroup DRAFT
-# \brief This module provides the object code for Draft Circle.
+# \ingroup draftobjects
+# \brief Provides the object code for the Circle object.
 
+## \addtogroup draftobjects
+# @{
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
 import FreeCAD as App
-
-from draftutils.utils import get_param
+import draftutils.utils as utils
 
 from draftobjects.base import DraftObject
 
@@ -62,7 +62,7 @@ class Circle(DraftObject):
         obj.addProperty("App::PropertyArea", "Area",
                         "Draft", _tip)
 
-        obj.MakeFace = get_param("fillmode", True)
+        obj.MakeFace = utils.get_param("fillmode", True)
 
 
     def execute(self, obj):
@@ -95,4 +95,7 @@ class Circle(DraftObject):
         obj.positionBySupport()
 
 
+# Alias for compatibility with v0.18 and earlier
 _Circle = Circle
+
+## @}

--- a/src/Mod/Draft/draftobjects/clone.py
+++ b/src/Mod/Draft/draftobjects/clone.py
@@ -20,16 +20,16 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""This module provides the object code for Draft Clone.
-"""
+"""Provides the object code for the Clone object."""
 ## @package clone
-# \ingroup DRAFT
-# \brief This module provides the object code for Draft Clone.
+# \ingroup draftobjects
+# \brief Provides the object code for the Clone object.
 
+## \addtogroup draftobjects
+# @{
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
 import FreeCAD as App
-
 import DraftVecUtils
 
 from draftobjects.base import DraftObject
@@ -131,4 +131,7 @@ class Clone(DraftObject):
         return None
 
 
+# Alias for compatibility with v0.18 and earlier
 _Clone = Clone
+
+## @}

--- a/src/Mod/Draft/draftobjects/dimension.py
+++ b/src/Mod/Draft/draftobjects/dimension.py
@@ -23,7 +23,7 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides the object code for the Draft Dimensions.
+"""Provides the object code for the dimension objects.
 
 This includes the `LinearDimension` and `AgularDimension`.
 The first one measures a distance between two points or vertices
@@ -95,9 +95,11 @@ a more generic base class, while at the same time improve the way
 the link properties are used.
 """
 ## @package dimension
-# \ingroup DRAFT
-# \brief Provides the object code for the Draft Dimensions.
+# \ingroup draftobjects
+# \brief Provides the object code for the dimension objects.
 
+## \addtogroup draftobjects
+# @{
 import math
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
@@ -659,3 +661,5 @@ def measure_two_obj_angles(link_sub_1, link_sub_2):
 
 # Alias for compatibility with v0.18 and earlier
 _AngularDimension = AngularDimension
+
+## @}

--- a/src/Mod/Draft/draftobjects/draft_annotation.py
+++ b/src/Mod/Draft/draftobjects/draft_annotation.py
@@ -21,7 +21,7 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provide the basic object code for all Draft annotation objects.
+"""Provides the object code for all annotation type objects.
 
 This is used by many objects that show dimensions and text created on screen
 through Coin (pivy).
@@ -32,9 +32,11 @@ through Coin (pivy).
 - Text
 """
 ## @package draft_annotation
-# \ingroup DRAFT
-# \brief Provide the basic object code for all Draft annotation objects.
+# \ingroup draftobjects
+# \brief Provides the object code for all annotation type objects.
 
+## \addtogroup draftobjects
+# @{
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
 from draftutils.messages import _wrn
@@ -152,3 +154,5 @@ class DraftAnnotation(object):
         Does nothing.
         """
         return
+
+## @}

--- a/src/Mod/Draft/draftobjects/draftlink.py
+++ b/src/Mod/Draft/draftobjects/draftlink.py
@@ -18,7 +18,7 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides the object code for the Draft Link object.
+"""Provides the base class for Link objects used by other objects.
 
 This class was created by realthunder during the `LinkMerge`
 to demonstrate how to use the `App::Link` objects to create
@@ -31,8 +31,8 @@ on how the properties are being set, and how the code interacts with
 the arrays that use it.
 """
 ## @package draftlink
-# \ingroup DRAFT
-# \brief Provides the object code for the Draft Link object.
+# \ingroup draftobjects
+# \brief Provides the base class for Link objects used by other objects.
 
 import lazy_loader.lazy_loader as lz
 from PySide.QtCore import QT_TRANSLATE_NOOP
@@ -45,6 +45,9 @@ from draftobjects.base import DraftObject
 # Delay import of module until first use because it is heavy
 Part = lz.LazyLoader("Part", globals(), "Part")
 DraftGeomUtils = lz.LazyLoader("DraftGeomUtils", globals(), "DraftGeomUtils")
+
+## \addtogroup draftobjects
+# @{
 
 
 class DraftLink(DraftObject):
@@ -224,3 +227,5 @@ class DraftLink(DraftObject):
 
 # Alias for compatibility with old versions of v0.19
 _DraftLink = DraftLink
+
+## @}

--- a/src/Mod/Draft/draftobjects/drawingview.py
+++ b/src/Mod/Draft/draftobjects/drawingview.py
@@ -20,19 +20,29 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""This module provides the object code for the Draft DrawingView object.
-This module is obsolete, since Drawing was substituted by TechDraw.
+"""Provides the object code for the DrawingView object (OBSOLETE).
+
+This module is obsolete, since the Drawing Workbench stopped
+being developed in v0.17.
+The TechDraw Workbench replaces Drawing, and it no longer requires
+a `DrawingView` object to display objects in a drawing sheet.
+
+This module is still provided in order to be able to open older files
+that use this `DrawingView` object. However, a GUI tool to create
+this object should no longer be available.
 """
 ## @package drawingview
-# \ingroup DRAFT
-# \brief This module provides the object code for the Draft DrawingView object.
+# \ingroup draftobjects
+# \brief Provides the object code for the DrawingView object (OBSOLETE).
 
+## \addtogroup draftobjects
+# @{
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
 import getSVG
-
 import draftutils.utils as utils
 import draftutils.groups as groups
+
 from draftobjects.base import DraftObject
 
 
@@ -124,4 +134,7 @@ class DrawingView(DraftObject):
         return utils.getDXF(obj)
 
 
+# Alias for compatibility with v0.18 and earlier
 _DrawingView = DrawingView
+
+## @}

--- a/src/Mod/Draft/draftobjects/ellipse.py
+++ b/src/Mod/Draft/draftobjects/ellipse.py
@@ -20,17 +20,17 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""This module provides the object code for Draft Ellipse.
-"""
+"""Provides the object code for the Ellipse object."""
 ## @package ellipse
-# \ingroup DRAFT
-# \brief This module provides the object code for Draft Ellipse.
+# \ingroup draftobjects
+# \brief Provides the object code for the Ellipse object.
 
+## \addtogroup draftobjects
+# @{
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
 import FreeCAD as App
-
-from draftutils.utils import get_param
+import draftutils.utils as utils
 
 from draftobjects.base import DraftObject
 
@@ -60,7 +60,7 @@ class Ellipse(DraftObject):
         _tip = QT_TRANSLATE_NOOP("App::Property","Area of this object")
         obj.addProperty("App::PropertyArea", "Area","Draft", _tip)
 
-        obj.MakeFace = get_param("fillmode",True)
+        obj.MakeFace = utils.get_param("fillmode",True)
 
     def execute(self, obj):
         import Part
@@ -93,4 +93,7 @@ class Ellipse(DraftObject):
         obj.positionBySupport()
 
 
+# Alias for compatibility with v0.18 and earlier
 _Ellipse = Ellipse
+
+## @}

--- a/src/Mod/Draft/draftobjects/facebinder.py
+++ b/src/Mod/Draft/draftobjects/facebinder.py
@@ -20,15 +20,16 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""This module provides the object code for Draft Facebinder.
-"""
+"""Provides the object code for the Facebinder object."""
 ## @package facebinder
-# \ingroup DRAFT
-# \brief This module provides the object code for Draft Facebinder.
+# \ingroup draftobjects
+# \brief Provides the object code for the Facebinder object.
+
+## \addtogroup draftobjects
+# @{
+from PySide.QtCore import QT_TRANSLATE_NOOP
 
 import FreeCAD as App
-
-from PySide.QtCore import QT_TRANSLATE_NOOP
 
 from draftobjects.base import DraftObject
 
@@ -133,4 +134,7 @@ class Facebinder(DraftObject):
         self.execute(obj)
 
 
+# Alias for compatibility with v0.18 and earlier
 _Facebinder = Facebinder
+
+## @}

--- a/src/Mod/Draft/draftobjects/fillet.py
+++ b/src/Mod/Draft/draftobjects/fillet.py
@@ -20,13 +20,16 @@
 # ***************************************************************************
 """Provides the object code for the Fillet object."""
 ## @package fillet
-# \ingroup DRAFT
+# \ingroup draftobjects
 # \brief Provides the object code for the Fillet object.
 
+## \addtogroup draftobjects
+# @{
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
 import FreeCAD as App
 import draftobjects.base as base
+
 from draftutils.messages import _msg
 
 
@@ -121,3 +124,5 @@ class Fillet(base.DraftObject):
         """
         if prop in "FilletRadius":
             self._update_radius(obj, obj.FilletRadius)
+
+## @}

--- a/src/Mod/Draft/draftobjects/label.py
+++ b/src/Mod/Draft/draftobjects/label.py
@@ -23,11 +23,13 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provide the object code for Draft Label objects."""
+"""Provides the object code for the Label object."""
 ## @package label
-# \ingroup DRAFT
-# \brief Provide the object code for Draft Label objects.
+# \ingroup draftobjects
+# \brief Provides the object code for the Label object.
 
+## \addtogroup draftobjects
+# @{
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
 import FreeCAD as App
@@ -425,3 +427,6 @@ def _get_area(target, subelement):
 def _get_volume(target):
     volume = U.Quantity(target.Shape.Volume, U.Volume).UserString
     return [volume.replace("^3", "³")]
+
+
+## @}

--- a/src/Mod/Draft/draftobjects/patharray.py
+++ b/src/Mod/Draft/draftobjects/patharray.py
@@ -25,7 +25,7 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides the object code for the Draft PathArray object.
+"""Provides the object code for the PathArray object.
 
 The copies will be placed along a path like a polyline, spline, or bezier
 curve, and along the selected subelements.
@@ -60,8 +60,8 @@ objects. Therefore, the first solution is simpler, that is, using
 a single property of type `App::PropertyLinkSub`.
 """
 ## @package patharray
-# \ingroup DRAFT
-# \brief Provides the object code for the Draft PathArray object.
+# \ingroup draftobjects
+# \brief Provides the object code for the PathArray object.
 
 import FreeCAD as App
 import DraftVecUtils
@@ -75,6 +75,9 @@ from draftobjects.draftlink import DraftLink
 # Delay import of module until first use because it is heavy
 Part = lz.LazyLoader("Part", globals(), "Part")
 DraftGeomUtils = lz.LazyLoader("DraftGeomUtils", globals(), "DraftGeomUtils")
+
+## \addtogroup draftobjects
+# @{
 
 
 class PathArray(DraftLink):
@@ -428,6 +431,7 @@ class PathArray(DraftLink):
             _wrn("v0.19, " + obj.Label + ", " + _tr(_info))
 
 
+# Alias for compatibility with v0.18 and earlier
 _PathArray = PathArray
 
 
@@ -617,3 +621,5 @@ def get_parameter_from_v0(edge, offset):
 
 
 getParameterFromV0 = get_parameter_from_v0
+
+## @}

--- a/src/Mod/Draft/draftobjects/point.py
+++ b/src/Mod/Draft/draftobjects/point.py
@@ -20,26 +20,24 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""This module provides the object code for Draft Point.
-"""
+"""Provides the object code for the Point object."""
 ## @package point
-# \ingroup DRAFT
-# \brief This module provides the object code for Draft Point.
+# \ingroup draftobjects
+# \brief Provides the object code for the Point object.
 
+## \addtogroup draftobjects
+# @{
 import math
-
-import FreeCAD as App
-
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
-from draftutils.utils import get_param
+import FreeCAD as App
 
 from draftobjects.base import DraftObject
 
 
 class Point(DraftObject):
-    """The Draft Point object.
-    """
+    """The Draft Point object."""
+
     def __init__(self, obj, x=0, y=0, z=0):
         super(Point, self).__init__(obj, "Point")
 
@@ -51,13 +49,12 @@ class Point(DraftObject):
 
         _tip = QT_TRANSLATE_NOOP("App::Property", "Z Location")
         obj.addProperty("App::PropertyDistance", "Z", "Draft", _tip)
-        
+
         obj.X = x
         obj.Y = y
         obj.Z = z
 
-        mode = 2
-        obj.setEditorMode('Placement',mode)
+        obj.setPropertyStatus('Placement', 'Hidden')
 
     def execute(self, obj):
         import Part
@@ -68,4 +65,7 @@ class Point(DraftObject):
                                         obj.Z.Value)
 
 
+# Alias for compatibility with v0.18 and earlier
 _Point = Point
+
+## @}

--- a/src/Mod/Draft/draftobjects/pointarray.py
+++ b/src/Mod/Draft/draftobjects/pointarray.py
@@ -22,7 +22,7 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides the object code for the Draft PointArray object.
+"""Provides the object code for the PointArray object.
 
 To Do
 -----
@@ -34,14 +34,14 @@ from the vertices of any object with a `Part::TopoShape` (2D or 3D).
 See the `get_point_list` function for more information.
 """
 ## @package pointarray
-# \ingroup DRAFT
-# \brief Provides the object code for the Draft PointArray object.
+# \ingroup draftobjects
+# \brief Provides the object code for the PointArray object.
 
+import lazy_loader.lazy_loader as lz
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
 import FreeCAD as App
 import draftutils.utils as utils
-import lazy_loader.lazy_loader as lz
 
 from draftutils.messages import _wrn, _err
 from draftutils.translate import translate, _tr
@@ -49,6 +49,9 @@ from draftobjects.base import DraftObject
 
 # Delay import of module until first use because it is heavy
 Part = lz.LazyLoader("Part", globals(), "Part")
+
+## \addtogroup draftobjects
+# @{
 
 
 class PointArray(DraftObject):
@@ -293,4 +296,7 @@ def build_copies(base_object, pt_list=None, placement=App.Placement()):
     return shape
 
 
+# Alias for compatibility with v0.18 and earlier
 _PointArray = PointArray
+
+## @}

--- a/src/Mod/Draft/draftobjects/polygon.py
+++ b/src/Mod/Draft/draftobjects/polygon.py
@@ -20,22 +20,20 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""This module provides the object code for Draft Polygon.
-"""
+"""Provides the object code for the Polygon object."""
 ## @package polygon
-# \ingroup DRAFT
-# \brief This module provides the object code for Draft Polygon.
+# \ingroup draftobjects
+# \brief Provides the object code for the Polygon object.
 
+## \addtogroup draftobjects
+# @{
 import math
-
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
 import FreeCAD as App
-
 import DraftGeomUtils
 
 from draftutils.utils import get_param
-
 from draftobjects.base import DraftObject
 
 
@@ -119,4 +117,7 @@ class Polygon(DraftObject):
         obj.positionBySupport()
 
 
+# Alias for compatibility with v0.18 and earlier
 _Polygon = Polygon
+
+## @}

--- a/src/Mod/Draft/draftobjects/rectangle.py
+++ b/src/Mod/Draft/draftobjects/rectangle.py
@@ -20,20 +20,19 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""This module provides the object code for Draft Rectangle.
-"""
+"""Provides the object code for the Rectangle object."""
 ## @package rectangle
-# \ingroup DRAFT
-# \brief This module provides the object code for Draft Rectangle.
+# \ingroup draftobjects
+# \brief Provides the object code for the Rectangle object.
 
+## \addtogroup draftobjects
+# @{
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
 import FreeCAD as App
-
 import DraftGeomUtils
 
 from draftutils.utils import get_param
-
 from draftobjects.base import DraftObject
 
 
@@ -169,4 +168,7 @@ class Rectangle(DraftObject):
         obj.positionBySupport()
 
 
+# Alias for compatibility with v0.18 and earlier
 _Rectangle = Rectangle
+
+## @}

--- a/src/Mod/Draft/draftobjects/shape2dview.py
+++ b/src/Mod/Draft/draftobjects/shape2dview.py
@@ -1,4 +1,4 @@
-2# ***************************************************************************
+# ***************************************************************************
 # *   Copyright (c) 2009, 2010 Yorik van Havre <yorik@uncreated.net>        *
 # *   Copyright (c) 2009, 2010 Ken Cline <cline@frii.com>                   *
 # *   Copyright (c) 2020 FreeCAD Developers                                 *
@@ -20,22 +20,22 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""This module provides the object code for Draft Shape2dView.
-"""
+"""Provides the object code for the Shape2dView object."""
 ## @package shape2dview
-# \ingroup DRAFT
-# \brief This module provides the object code for Draft Shape2dView.
+# \ingroup draftobjects
+# \brief Provides the object code for the Shape2dView object.
 
+## \addtogroup draftobjects
+# @{
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
 import FreeCAD as App
-
 import DraftVecUtils
 import draftutils.utils as utils
-import draftutils.groups as u_groups
 import draftutils.gui_utils as gui_utils
-from draftutils.translate import translate
+import draftutils.groups as groups
 
+from draftutils.translate import translate
 from draftobjects.base import DraftObject
 
 
@@ -111,13 +111,13 @@ class Shape2DView(DraftObject):
         "returns projected edges from a shape and a direction"
         import Part, Drawing, DraftGeomUtils
         edges = []
-        groups = Drawing.projectEx(shape, direction)
-        for g in groups[0:5]:
+        _groups = Drawing.projectEx(shape, direction)
+        for g in _groups[0:5]:
             if g:
                 edges.append(g)
         if hasattr(obj,"HiddenLines"):
             if obj.HiddenLines:
-                for g in groups[5:]:
+                for g in _groups[5:]:
                     edges.append(g)
         #return Part.makeCompound(edges)
         if hasattr(obj,"Tessellation") and obj.Tessellation:
@@ -156,7 +156,7 @@ class Shape2DView(DraftObject):
                     if hasattr(obj.Base,"OnlySolids"):
                         onlysolids = obj.Base.OnlySolids
                     import Arch, Part, Drawing
-                    objs = u_groups.get_group_contents(objs, walls=True)
+                    objs = groups.get_group_contents(objs, walls=True)
                     objs = gui_utils.remove_hidden(objs)
                     shapes = []
                     if hasattr(obj,"FuseArch") and obj.FuseArch:
@@ -247,7 +247,7 @@ class Shape2DView(DraftObject):
 
             elif obj.Base.isDerivedFrom("App::DocumentObjectGroup"):
                 shapes = []
-                objs = u_groups.get_group_contents(obj.Base)
+                objs = groups.get_group_contents(obj.Base)
                 for o in objs:
                     if hasattr(o,'Shape'):
                         if o.Shape:
@@ -280,4 +280,7 @@ class Shape2DView(DraftObject):
             obj.Placement = pl
 
 
+# Alias for compatibility with v0.18 and earlier
 _Shape2DView = Shape2DView
+
+## @}

--- a/src/Mod/Draft/draftobjects/shapestring.py
+++ b/src/Mod/Draft/draftobjects/shapestring.py
@@ -20,22 +20,20 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""This module provides the object code for Draft Shapestring.
-"""
+"""Provides the object code for the ShapeString object."""
 ## @package shapestring
-# \ingroup DRAFT
-# \brief This module provides the object code for Draft Shapestring.
+# \ingroup draftobjects
+# \brief Provides the object code for the ShapeString object.
 
+## \addtogroup draftobjects
+# @{
 import sys
-
-import FreeCAD as App
-
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
-from draftutils.utils import epsilon
+import FreeCAD as App
+import draftutils.utils as utils
 
 from draftutils.translate import translate
-
 from draftobjects.base import DraftObject
 
 
@@ -174,7 +172,7 @@ class ShapeString(DraftObject):
             bcfA = biggest.common(face).Area
             fA = face.Area
             difA = abs(bcfA - fA)
-            eps = epsilon()
+            eps = utils.epsilon()
             # if biggest.common(face).Area == face.Area:
             if difA <= eps:                              # close enough to zero
                 # biggest completely overlaps current face ==> cut
@@ -196,4 +194,7 @@ class ShapeString(DraftObject):
         return ret
 
 
+# Alias for compatibility with v0.18 and earlier
 _ShapeString = ShapeString
+
+## @}

--- a/src/Mod/Draft/draftobjects/text.py
+++ b/src/Mod/Draft/draftobjects/text.py
@@ -21,11 +21,13 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provide the object code for Draft Text objects."""
+"""Provides the object code for the Text object."""
 ## @package text
-# \ingroup DRAFT
-# \brief Provide the object code for Draft Text objects.
+# \ingroup draftobjects
+# \brief Provides the object code for the Text object.
 
+## \addtogroup draftobjects
+# @{
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
 import FreeCAD as App
@@ -77,3 +79,5 @@ class Text(DraftAnnotation):
 
 # Alias for compatibility with v0.18 and earlier
 DraftText = Text
+
+## @}

--- a/src/Mod/Draft/draftobjects/wire.py
+++ b/src/Mod/Draft/draftobjects/wire.py
@@ -20,25 +20,22 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""This module provides the object code for Draft Wire.
-"""
+"""Provides the object code for the Wire (Polyline) object."""
 ## @package wire
-# \ingroup DRAFT
-# \brief This module provides the object code for Draft Wire.
+# \ingroup draftobjects
+# \brief Provides the object code for the Wire (Polyline) object.
 
+## \addtogroup draftobjects
+# @{
 import math
+from PySide.QtCore import QT_TRANSLATE_NOOP
 
 import FreeCAD as App
-
 import DraftGeomUtils
 import DraftVecUtils
 
-from PySide.QtCore import QT_TRANSLATE_NOOP
-
 from draftutils.utils import get_param
-
 from draftobjects.base import DraftObject
-
 
 
 class Wire(DraftObject):
@@ -248,4 +245,7 @@ class Wire(DraftObject):
                     obj.End = displayfpend
 
 
+# Alias for compatibility with v0.18 and earlier
 _Wire = Wire
+
+## @}

--- a/src/Mod/Draft/draftobjects/wpproxy.py
+++ b/src/Mod/Draft/draftobjects/wpproxy.py
@@ -20,12 +20,13 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""This module provides the object code for Draft WorkingPlaneProxy.
-"""
+"""Provides the object code for the WorkingPlaneProxy object."""
 ## @package wpproxy
-# \ingroup DRAFT
-# \brief This module provides the object code for Draft WorkingPlaneProxy.
+# \ingroup draftobjects
+# \brief Provides the object code for the WorkingPlaneProxy object.
 
+## \addtogroup draftobjects
+# @{
 import FreeCAD as App
 
 from PySide.QtCore import QT_TRANSLATE_NOOP
@@ -72,3 +73,5 @@ class WorkingPlaneProxy:
     def __setstate__(self,state):
         if state:
             self.Type = state
+
+## @}

--- a/src/Mod/Draft/drafttaskpanels/__init__.py
+++ b/src/Mod/Draft/drafttaskpanels/__init__.py
@@ -53,3 +53,6 @@ Individual task panel classes and `.ui` files are more maintainable
 because changes can be done to a single tool without affecting the rest,
 and the module size is kept small.
 """
+## \defgroup drafttaskpanels drafttaskpanels
+# \ingroup DRAFT
+# \brief Modules with classes that handle task panels of the GuiCommands.

--- a/src/Mod/Draft/drafttaskpanels/task_circulararray.py
+++ b/src/Mod/Draft/drafttaskpanels/task_circulararray.py
@@ -22,9 +22,11 @@
 # ***************************************************************************
 """Provides the task panel code for the Draft CircularArray tool."""
 ## @package task_circulararray
-# \ingroup DRAFT
-# \brief This module provides the task panel code for the CircularArray tool.
+# \ingroup drafttaskpanels
+# \brief Provides the task panel code for the Draft CircularArray tool.
 
+## \addtogroup drafttaskpanels
+# @{
 import PySide.QtGui as QtGui
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
@@ -502,3 +504,5 @@ class TaskPanelCircularArray:
         Gui.ActiveDocument.resetEdit()
         # Runs the parent command to complete the call
         self.source_command.completed()
+
+## @}

--- a/src/Mod/Draft/drafttaskpanels/task_orthoarray.py
+++ b/src/Mod/Draft/drafttaskpanels/task_orthoarray.py
@@ -20,11 +20,13 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides the task panel for the Draft OrthoArray tool."""
+"""Provides the task panel code for the Draft OrthoArray tool."""
 ## @package task_orthoarray
-# \ingroup DRAFT
-# \brief Provide the task panel for the Draft OrthoArray tool.
+# \ingroup drafttaskpanels
+# \brief Provides the task panel code for the Draft OrthoArray tool.
 
+## \addtogroup drafttaskpanels
+# @{
 import PySide.QtGui as QtGui
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
@@ -408,3 +410,5 @@ class TaskPanelOrthoArray:
         Gui.ActiveDocument.resetEdit()
         # Runs the parent command to complete the call
         self.source_command.completed()
+
+## @}

--- a/src/Mod/Draft/drafttaskpanels/task_polararray.py
+++ b/src/Mod/Draft/drafttaskpanels/task_polararray.py
@@ -20,11 +20,13 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides the task panel for the Draft PolarArray tool."""
+"""Provides the task panel code for the Draft PolarArray tool."""
 ## @package task_polararray
-# \ingroup DRAFT
-# \brief This module provides the task panel code for the PolarArray tool.
+# \ingroup drafttaskpanels
+# \brief Provides the task panel code for the Draft PolarArray tool.
 
+## \addtogroup drafttaskpanels
+# @{
 import PySide.QtGui as QtGui
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
@@ -448,3 +450,5 @@ class TaskPanelPolarArray:
         Gui.ActiveDocument.resetEdit()
         # Runs the parent command to complete the call
         self.source_command.completed()
+
+## @}

--- a/src/Mod/Draft/drafttaskpanels/task_scale.py
+++ b/src/Mod/Draft/drafttaskpanels/task_scale.py
@@ -1,8 +1,3 @@
-"""Provide the task panel for the Draft Scale tool."""
-## @package task_scale
-# \ingroup DRAFT
-# \brief Provide the task panel for the Draft Scale tool.
-
 # ***************************************************************************
 # *   (c) 2009 Yorik van Havre <yorik@uncreated.net>                        *
 # *   (c) 2020 Eliud Cabrera Castillo <e.cabrera-castillo@tum.de>           *
@@ -26,16 +21,22 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
+"""Provides the task panel code for the Draft Scale tool."""
+## @package task_scale
+# \ingroup drafttaskpanels
+# \brief Provides the task panel code for the Draft Scale tool.
+
+## \addtogroup drafttaskpanels
+# @{
+import PySide.QtCore as QtCore
+import PySide.QtGui as QtGui
 
 import FreeCAD as App
 import FreeCADGui as Gui
 import Draft
 import Draft_rc
-import PySide.QtCore as QtCore
-import PySide.QtGui as QtGui
-from draftutils.translate import translate
-_Quantity = App.Units.Quantity
 
+from draftutils.translate import translate
 
 # So the resource file doesn't trigger errors from code checkers (flake8)
 True if Draft_rc.__name__ else False
@@ -155,3 +156,5 @@ class ScaleTaskPanel:
             self.sourceCmd.finish()
         Gui.ActiveDocument.resetEdit()
         return True
+
+## @}

--- a/src/Mod/Draft/drafttaskpanels/task_selectplane.py
+++ b/src/Mod/Draft/drafttaskpanels/task_selectplane.py
@@ -20,23 +20,26 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides the task panel for the Draft SelectPlane tool."""
+"""Provides the task panel code for the Draft SelectPlane tool.
+
+As it is right now this code only loads the task panel .ui file.
+All logic on how to use the widgets is located in the GuiCommand class
+itself.
+On the other hand, the newer tools introduced in v0.19 like OrthoArray,
+PolarArray, and CircularArray include the logic and manipulation
+of the widgets in this task panel class.
+In addition, the task panel code launches the actual function
+using the delayed mechanism defined by the `todo.ToDo` class.
+Therefore, at some point this class should be refactored
+to be more similar to OrthoArray and the new tools.
+"""
 ## @package task_selectplane
-# \ingroup DRAFT
-# \brief This module provides the task panel code for the SelectPlane tool.
+# \ingroup drafttaskpanels
+# \brief Provides the task panel code for the Draft SelectPlane tool.
 
+## \addtogroup drafttaskpanels
+# @{
 import FreeCADGui as Gui
-
-# As it is right now this code only loads the task panel .ui file.
-# All logic on how to use the widgets is located in the GuiCommand class
-# itself.
-# On the other hand, the newer tools introduced in v0.19 like OrthoArray,
-# PolarArray, and CircularArray include the logic and manipulation
-# of the widgets in this task panel class.
-# In addition, the task panel code launches the actual function
-# using the delayed mechanism defined by the `todo.ToDo` class.
-# Therefore, at some point this class should be refactored
-# to be more similar to OrthoArray and the new tools.
 
 
 class SelectPlaneTaskPanel:
@@ -48,3 +51,5 @@ class SelectPlaneTaskPanel:
     def getStandardButtons(self):
         """Execute to set the standard buttons."""
         return 2097152  # int(QtGui.QDialogButtonBox.Close)
+
+## @}

--- a/src/Mod/Draft/drafttaskpanels/task_shapestring.py
+++ b/src/Mod/Draft/drafttaskpanels/task_shapestring.py
@@ -1,8 +1,3 @@
-"""Provide the task panel for the Draft ShapeString tool."""
-## @package task_shapestring
-# \ingroup DRAFT
-# \brief Provide the task panel for the Draft ShapeString tool.
-
 # ***************************************************************************
 # *   (c) 2009 Yorik van Havre <yorik@uncreated.net>                        *
 # *   (c) 2020 Eliud Cabrera Castillo <e.cabrera-castillo@tum.de>           *
@@ -26,20 +21,27 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
+"""Provides the task panel code for the Draft ShapeString tool."""
+## @package task_shapestring
+# \ingroup drafttaskpanels
+# \brief Provides the task panel code for the Draft ShapeString tool.
+
+## \addtogroup drafttaskpanels
+# @{
 import sys
+import PySide.QtCore as QtCore
+import PySide.QtGui as QtGui
+
 import FreeCAD as App
 import FreeCADGui as Gui
 import Draft
 import Draft_rc
 import DraftVecUtils
-import DraftTools
-import PySide.QtCore as QtCore
-import PySide.QtGui as QtGui
+import draftguitools.gui_tool_utils as gui_tool_utils
+
+from FreeCAD import Units as U
 from draftutils.translate import translate
 from draftutils.messages import _msg, _err
-
-_Quantity = App.Units.Quantity
-
 
 # So the resource file doesn't trigger errors from code checkers (flake8)
 True if Draft_rc.__name__ else False
@@ -60,7 +62,7 @@ class ShapeStringTaskPanel:
         self.task = loader.load(uiFile)
         layout.addWidget(self.task)
 
-        qStart = _Quantity(0.0, App.Units.Length)
+        qStart = U.Quantity(0.0, U.Length)
         self.task.sbX.setProperty('rawValue', qStart.Value)
         self.task.sbX.setProperty('unit', qStart.getUserPreferred()[2])
         self.task.sbY.setProperty('rawValue', qStart.Value)
@@ -101,7 +103,7 @@ class ShapeStringTaskPanel:
             if arg["Key"] == "ESCAPE":
                 self.reject()
         elif arg["Type"] == "SoLocation2Event":  # mouse movement detection
-            self.point,ctrlPoint,info = DraftTools.getPoint(self.sourceCmd, arg, noTracker=True)
+            self.point,ctrlPoint,info = gui_tool_utils.getPoint(self.sourceCmd, arg, noTracker=True)
             if not self.pointPicked:
                 self.setPoint(self.point)
         elif arg["Type"] == "SoMouseButtonEvent":
@@ -124,11 +126,11 @@ class ShapeStringTaskPanel:
             String = dquote + self.task.leString.text() + dquote
         FFile = dquote + str(self.fileSpec) + dquote
 
-        Size = str(_Quantity(self.task.sbHeight.text()).Value)
+        Size = str(U.Quantity(self.task.sbHeight.text()).Value)
         Tracking = str(0.0)
-        x = _Quantity(self.task.sbX.text()).Value
-        y = _Quantity(self.task.sbY.text()).Value
-        z = _Quantity(self.task.sbZ.text()).Value
+        x = U.Quantity(self.task.sbX.text()).Value
+        y = U.Quantity(self.task.sbY.text()).Value
+        z = U.Quantity(self.task.sbZ.text()).Value
         ssBase = App.Vector(x, y, z)
         # this try block is almost identical to the one in DraftTools
         try:
@@ -188,3 +190,5 @@ class ShapeStringTaskPanel:
         self.sourceCmd.creator.finish(self.sourceCmd)
         self.platWinDialog("Restore")
         return True
+
+## @}

--- a/src/Mod/Draft/drafttests/__init__.py
+++ b/src/Mod/Draft/drafttests/__init__.py
@@ -39,3 +39,6 @@ on how to write unit tests.
         def test_new_tool(self):
             pass
 """
+## \defgroup drafttests drafttests
+# \ingroup DRAFT
+# \brief Modules that define classes used for unit testing the workbench.

--- a/src/Mod/Draft/drafttests/auxiliary.py
+++ b/src/Mod/Draft/drafttests/auxiliary.py
@@ -22,8 +22,14 @@
 # *                                                                         *
 # ***************************************************************************
 """Auxiliary functions for the unit tests of the Draft Workbench."""
+## @package auxiliary
+# \ingroup drafttests
+# \brief Auxiliary functions for the unit tests of the Draft Workbench.
 
+## \addtogroup drafttests
+# @{
 import traceback
+
 from draftutils.messages import _msg
 
 
@@ -69,3 +75,5 @@ def fake_function(p1=None, p2=None, p3=None, p4=None, p5=None):
     _msg("  p5={}".format(p5))
     no_test()
     return True
+
+## @}

--- a/src/Mod/Draft/drafttests/draft_test_objects.py
+++ b/src/Mod/Draft/drafttests/draft_test_objects.py
@@ -34,10 +34,11 @@ Or load it as a module and use the defined function.
 >>> dt.create_test_file()
 """
 ## @package draft_test_objects
-# \ingroup DRAFT
+# \ingroup drafttests
 # \brief Run this file to create a standard test document for Draft objects.
-# @{
 
+## \addtogroup drafttests
+# @{
 import datetime
 import os
 

--- a/src/Mod/Draft/drafttests/test_airfoildat.py
+++ b/src/Mod/Draft/drafttests/test_airfoildat.py
@@ -21,13 +21,20 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Unit test for the Draft Workbench, Airfoil DAT import and export tests."""
+"""Unit tests for the Draft Workbench, Airfoil DAT import and export tests."""
+## @package test_airfoildat
+# \ingroup drafttests
+# \brief Unit tests for the Draft Workbench, Airfoil DAT tests.
 
+## \addtogroup drafttests
+# @{
 import os
 import unittest
+
 import FreeCAD as App
 import Draft
 import drafttests.auxiliary as aux
+
 from draftutils.messages import _msg
 
 
@@ -86,3 +93,5 @@ class DraftAirfoilDAT(unittest.TestCase):
         This is executed after each test, so we close the document.
         """
         App.closeDocument(self.doc_name)
+
+## @}

--- a/src/Mod/Draft/drafttests/test_creation.py
+++ b/src/Mod/Draft/drafttests/test_creation.py
@@ -21,8 +21,13 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Unit test for the Draft Workbench, object creation tests."""
+"""Unit tests for the Draft Workbench, object creation tests."""
+## @package test_creation
+# \ingroup drafttests
+# \brief Unit tests for the Draft Workbench, object creation tests.
 
+## \addtogroup drafttests
+# @{
 import unittest
 
 import FreeCAD as App
@@ -349,3 +354,5 @@ class DraftCreation(unittest.TestCase):
         This is executed after each test, so we close the document.
         """
         App.closeDocument(self.doc.Name)
+
+## @}

--- a/src/Mod/Draft/drafttests/test_dwg.py
+++ b/src/Mod/Draft/drafttests/test_dwg.py
@@ -21,13 +21,20 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Unit test for the Draft Workbench, DWG import and export tests."""
+"""Unit tests for the Draft Workbench, DWG import and export tests."""
+## @package test_dwg
+# \ingroup drafttests
+# \brief Unit tests for the Draft Workbench, DWG import and export tests.
 
+## \addtogroup drafttests
+# @{
 import os
 import unittest
+
 import FreeCAD as App
 import Draft
 import drafttests.auxiliary as aux
+
 from draftutils.messages import _msg
 
 
@@ -86,3 +93,5 @@ class DraftDWG(unittest.TestCase):
         This is executed after each test, so we close the document.
         """
         App.closeDocument(self.doc_name)
+
+## @}

--- a/src/Mod/Draft/drafttests/test_dxf.py
+++ b/src/Mod/Draft/drafttests/test_dxf.py
@@ -21,13 +21,20 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Unit test for the Draft Workbench, DXF import and export tests."""
+"""Unit tests for the Draft Workbench, DXF import and export tests."""
+## @package test_dxf
+# \ingroup drafttests
+# \brief Unit tests for the Draft Workbench, DXF import and export tests.
 
+## \addtogroup drafttests
+# @{
 import os
 import unittest
+
 import FreeCAD as App
 import Draft
 import drafttests.auxiliary as aux
+
 from draftutils.messages import _msg
 
 
@@ -86,3 +93,5 @@ class DraftDXF(unittest.TestCase):
         This is executed after each test, so we close the document.
         """
         App.closeDocument(self.doc_name)
+
+## @}

--- a/src/Mod/Draft/drafttests/test_import.py
+++ b/src/Mod/Draft/drafttests/test_import.py
@@ -21,18 +21,28 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Unit test for the Draft Workbench, import tests."""
+"""Unit tests for the Draft Workbench, import tests."""
+## @package test_import
+# \ingroup drafttests
+# \brief Unit tests for the Draft Workbench, import tests.
 
+## \addtogroup drafttests
+# @{
 import unittest
+
 import drafttests.auxiliary as aux
 
 
 class DraftImport(unittest.TestCase):
     """Import the Draft modules."""
 
-    # No document is needed to test 'import Draft' or other modules
-    # thus 'setUp' just draws a line, and 'tearDown' isn't defined.
     def setUp(self):
+        """Draw the header.
+
+        This is executed before every test.
+        No document is needed to test the import of modules so no document
+        is created, and `tearDown` isn't defined.
+        """
         aux.draw_header()
 
     def test_import_draft(self):
@@ -58,3 +68,5 @@ class DraftImport(unittest.TestCase):
         module = "getSVG"
         imported = aux.import_test(module)
         self.assertTrue(imported, "Problem importing '{}'".format(module))
+
+## @}

--- a/src/Mod/Draft/drafttests/test_import_gui.py
+++ b/src/Mod/Draft/drafttests/test_import_gui.py
@@ -21,18 +21,28 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Unit test for the Draft Workbench, GUI import tests."""
+"""Unit tests for the Draft Workbench, GUI import tests."""
+## @package test_import_gui
+# \ingroup drafttests
+# \brief Unit tests for the Draft Workbench, GUI import tests.
 
+## \addtogroup drafttests
+# @{
 import unittest
+
 import drafttests.auxiliary as aux
 
 
 class DraftGuiImport(unittest.TestCase):
     """Import the Draft graphical modules."""
 
-    # No document is needed to test 'import DraftGui' or other modules
-    # thus 'setUp' just draws a line, and 'tearDown' isn't defined.
     def setUp(self):
+        """Draw the header.
+
+        This is executed before every test.
+        No document is needed to test the import of modules so no document
+        is created, and `tearDown` isn't defined.
+        """
         aux.draw_header()
 
     def test_import_gui_draftgui(self):
@@ -58,3 +68,5 @@ class DraftGuiImport(unittest.TestCase):
         module = "draftguitools.gui_trackers"
         imported = aux.import_test(module)
         self.assertTrue(imported, "Problem importing '{}'".format(module))
+
+## @}

--- a/src/Mod/Draft/drafttests/test_import_tools.py
+++ b/src/Mod/Draft/drafttests/test_import_tools.py
@@ -21,18 +21,28 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Unit test for the Draft Workbench, tools import tests."""
+"""Unit tests for the Draft Workbench, tools import tests."""
+## @package test_import_tools
+# \ingroup drafttests
+# \brief Unit tests for the Draft Workbench, tools import tests.
 
+## \addtogroup drafttests
+# @{
 import unittest
+
 import drafttests.auxiliary as aux
 
 
 class DraftImportTools(unittest.TestCase):
     """Test for each individual module that defines a tool."""
 
-    # No document is needed to test 'import' of other modules
-    # thus 'setUp' just draws a line, and 'tearDown' isn't defined.
     def setUp(self):
+        """Draw the header.
+
+        This is executed before every test.
+        No document is needed to test the import of modules so no document
+        is created, and `tearDown` isn't defined.
+        """
         aux.draw_header()
 
     def test_import_gui_draftedit(self):
@@ -58,3 +68,5 @@ class DraftImportTools(unittest.TestCase):
         module = "WorkingPlane"
         imported = aux.import_test(module)
         self.assertTrue(imported, "Problem importing '{}'".format(module))
+
+## @}

--- a/src/Mod/Draft/drafttests/test_modification.py
+++ b/src/Mod/Draft/drafttests/test_modification.py
@@ -21,12 +21,19 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Unit test for the Draft Workbench, object modification tests."""
+"""Unit tests for the Draft Workbench, object modification tests."""
+## @package test_modification
+# \ingroup drafttests
+# \brief Unit tests for the Draft Workbench, object modification tests.
 
+## \addtogroup drafttests
+# @{
 import unittest
+
 import FreeCAD as App
 import Draft
 import drafttests.auxiliary as aux
+
 from FreeCAD import Vector
 from draftutils.messages import _msg, _wrn
 
@@ -591,3 +598,5 @@ class DraftModification(unittest.TestCase):
         This is executed after each test, so we close the document.
         """
         App.closeDocument(self.doc_name)
+
+## @}

--- a/src/Mod/Draft/drafttests/test_oca.py
+++ b/src/Mod/Draft/drafttests/test_oca.py
@@ -21,13 +21,20 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Unit test for the Draft Workbench, OCA import and export tests."""
+"""Unit tests for the Draft Workbench, OCA import and export tests."""
+## @package test_oca
+# \ingroup drafttests
+# \brief Unit tests for the Draft Workbench, OCA import and export tests.
 
+## \addtogroup drafttests
+# @{
 import os
 import unittest
+
 import FreeCAD as App
 import Draft
 import drafttests.auxiliary as aux
+
 from draftutils.messages import _msg
 
 
@@ -86,3 +93,5 @@ class DraftOCA(unittest.TestCase):
         This is executed after each test, so we close the document.
         """
         App.closeDocument(self.doc_name)
+
+## @}

--- a/src/Mod/Draft/drafttests/test_pivy.py
+++ b/src/Mod/Draft/drafttests/test_pivy.py
@@ -21,12 +21,19 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Unit test for the Draft Workbench, Coin (Pivy) tests."""
+"""Unit tests for the Draft Workbench, Coin (Pivy) tests."""
+## @package test_pivy
+# \ingroup drafttests
+# \brief Unit tests for the Draft Workbench, Coin (Pivy) tests.
 
+## \addtogroup drafttests
+# @{
 import unittest
+
 import FreeCAD as App
 import FreeCADGui as Gui
 import drafttests.auxiliary as aux
+
 from draftutils.messages import _msg
 
 
@@ -71,3 +78,5 @@ class DraftPivy(unittest.TestCase):
         This is executed after each test, so we close the document.
         """
         App.closeDocument(self.doc_name)
+
+## @}

--- a/src/Mod/Draft/drafttests/test_svg.py
+++ b/src/Mod/Draft/drafttests/test_svg.py
@@ -21,13 +21,20 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Unit test for the Draft Workbench, SVG import and export tests."""
+"""Unit tests for the Draft Workbench, SVG import and export tests."""
+## @package test_svg
+# \ingroup drafttests
+# \brief Unit tests for the Draft Workbench, SVG import and export tests.
 
+## \addtogroup drafttests
+# @{
 import os
 import unittest
+
 import FreeCAD as App
 import Draft
 import drafttests.auxiliary as aux
+
 from draftutils.messages import _msg
 
 
@@ -86,3 +93,5 @@ class DraftSVG(unittest.TestCase):
         This is executed after each test, so we close the document.
         """
         App.closeDocument(self.doc_name)
+
+## @}

--- a/src/Mod/Draft/draftutils/__init__.py
+++ b/src/Mod/Draft/draftutils/__init__.py
@@ -48,3 +48,6 @@ Initialization modules for the GUI
 - `init_tools`, initialize toolbars and menus of the workbench
 - `init_draft_statusbar`, initialize the status bar of the workbench
 """
+## \defgroup draftutils draftutils
+# \ingroup DRAFT
+# \brief Utility modules that are used throughout the workbench.

--- a/src/Mod/Draft/draftutils/groups.py
+++ b/src/Mod/Draft/draftutils/groups.py
@@ -23,18 +23,20 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides utility functions for managing groups in the Draft Workbench.
+"""Provides utility functions to do operations with groups.
 
 The functions here are also used in the Arch Workbench as some of
 the objects created with this workbench work like groups.
 """
 ## @package groups
-# \ingroup DRAFT
-# \brief Provides utility functions for managing groups in the Draft Workbench.
+# \ingroup draftutils
+# \brief Provides utility functions to do operations with groups.
 
+## \addtogroup draftutils
+# @{
 import FreeCAD as App
-
 import draftutils.utils as utils
+
 from draftutils.translate import _tr
 from draftutils.messages import _msg, _err
 
@@ -326,3 +328,5 @@ def getMovableChildren(objectslist, recursive=True):
     """Return a list of objects with child objects. DEPRECATED."""
     utils.use_instead("get_movable_children")
     return get_movable_children(objectslist, recursive)
+
+## @}

--- a/src/Mod/Draft/draftutils/gui_utils.py
+++ b/src/Mod/Draft/draftutils/gui_utils.py
@@ -23,7 +23,7 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides GUI utility functions for the Draft Workbench.
+"""Provides utility functions that deal with GUI interactions.
 
 This module contains auxiliary functions which can be used
 in other modules of the workbench, and which require
@@ -31,9 +31,11 @@ the graphical user interface (GUI), as they access the view providers
 of the objects or the 3D view.
 """
 ## @package gui_utils
-# \ingroup DRAFT
-# \brief This module provides GUI utility functions for the Draft Workbench
+# \ingroup draftutils
+# \brief Provides utility functions that deal with GUI interactions.
 
+## \addtogroup draftutils
+# @{
 import math
 import os
 import six
@@ -674,3 +676,5 @@ def migrate_text_display_mode(obj_type="Text", mode="3D text", doc=None):
     for obj in doc.Objects:
         if utils.get_type(obj) == obj_type:
             obj.ViewObject.DisplayMode = mode
+
+## @}

--- a/src/Mod/Draft/draftutils/init_draft_statusbar.py
+++ b/src/Mod/Draft/draftutils/init_draft_statusbar.py
@@ -21,16 +21,19 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Draft Statusbar commands.
+"""Provides the initialization code for the workbench's status bar.
 
-This module provide the code for the Draft Statusbar, activated by initGui
+The status bar is activated by `InitGui.py` when the workbench is started,
+and is populated by various widgets, buttons and menus.
 """
 ## @package init_draft_statusbar
-# \ingroup DRAFT
-# \brief This module provides the code for the Draft Statusbar.
+# \ingroup draftutils
+# \brief Provides the initialization code for the workbench's status bar.
 
-from PySide import QtCore
-from PySide import QtGui
+## \addtogroup draftutils
+# @{
+import PySide.QtCore as QtCore
+import PySide.QtGui as QtGui
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
 import FreeCAD as App
@@ -413,4 +416,6 @@ def hide_draft_statusbar():
         # out of the status bar to any other dock area...
         snap_widget = mw.findChild(QtGui.QToolBar,"draft_snap_widget")
         if snap_widget:
-            snap_widget.hide()                
+            snap_widget.hide()
+
+## @}

--- a/src/Mod/Draft/draftutils/init_tools.py
+++ b/src/Mod/Draft/draftutils/init_tools.py
@@ -20,7 +20,7 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides lists of commands for the Draft Workbench.
+"""Provides lists of commands in order to set up toolbars of the workbench.
 
 This module returns lists of commands, so that the toolbars
 can be initialized by Draft, and by other workbenches.
@@ -28,9 +28,11 @@ These commands should be defined in `DraftTools`, and in the individual
 modules in `draftguitools`.
 """
 ## @package init_tools
-# \ingroup DRAFT
-# \brief This module provides lists of commands for the Draft Workbench.
+# \ingroup draftutils
+# \brief Provides lists of commands to set up toolbars of the workbench.
 
+## \addtogroup draftutils
+# @{
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
 # Comment out commands that aren't ready to be used
@@ -49,7 +51,7 @@ def get_draft_drawing_commands():
 def get_draft_annotation_commands():
     """Return the annotation commands list."""
     return ["Draft_Text", "Draft_Dimension",
-            "Draft_Label","Draft_AnnotationStyleEditor"]
+            "Draft_Label", "Draft_AnnotationStyleEditor"]
 
 
 def get_draft_array_commands():
@@ -132,7 +134,7 @@ def init_draft_toolbars(workbench):
 
     Parameters
     ----------
-    workbench : Gui.Workbench
+    workbench: Gui.Workbench
         The workbench class on which the commands have to be available.
         If called from within the `Initialize` method
         of a workbench class defined inside `InitGui.py`,
@@ -154,7 +156,7 @@ def init_draft_menus(workbench):
 
     Parameters
     ----------
-    workbench : Gui.Workbench
+    workbench: Gui.Workbench
         The workbench class on which the commands have to be available.
         If called from within the `Initialize` method
         of a workbench class defined inside `InitGui.py`,
@@ -169,3 +171,5 @@ def init_draft_menus(workbench):
     workbench.appendMenu(QT_TRANSLATE_NOOP("Draft", "&Utilities"),
                          get_draft_utility_commands()
                          + get_draft_context_commands())
+
+## @}

--- a/src/Mod/Draft/draftutils/messages.py
+++ b/src/Mod/Draft/draftutils/messages.py
@@ -20,7 +20,7 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provide message utility functions for the Draft Workbench.
+"""Provides utility functions that wrap around the Console methods.
 
 The Console module has long function names, so we define some shorthands
 that are suitable for use in every workbench. These shorthands also include
@@ -28,27 +28,31 @@ a newline character at the end of the string, so it doesn't have to be
 added manually.
 """
 ## @package messages
-# \ingroup DRAFT
-# \brief Provide message utility functions for the Draft Workbench.
+# \ingroup draftutils
+# \brief Provides utility functions that wrap around the Console methods.
 
+## \addtogroup draftutils
+# @{
 import FreeCAD as App
 
 
 def _msg(text, end="\n"):
-    """Write messages to console including the line ending."""
+    """Write messages to the console including the line ending."""
     App.Console.PrintMessage(text + end)
 
 
 def _wrn(text, end="\n"):
-    """Write warnings to console including the line ending."""
+    """Write warnings to the console including the line ending."""
     App.Console.PrintWarning(text + end)
 
 
 def _err(text, end="\n"):
-    """Write errors to console including the line ending."""
+    """Write errors to the console including the line ending."""
     App.Console.PrintError(text + end)
 
 
 def _log(text, end="\n"):
     """Write messages to the log file including the line ending."""
     App.Console.PrintLog(text + end)
+
+## @}

--- a/src/Mod/Draft/draftutils/todo.py
+++ b/src/Mod/Draft/draftutils/todo.py
@@ -21,7 +21,7 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides the ToDo class for the Draft Workbench.
+"""Provides the ToDo static class to run commands with a time delay.
 
 The `ToDo` class is used to delay the commit of commands for later execution.
 This is necessary when a GUI command needs to manipulate the 3D view
@@ -31,16 +31,17 @@ The `ToDo` class essentially calls `QtCore.QTimer.singleShot`
 to execute the instructions stored in internal lists.
 """
 ## @package todo
-# \ingroup DRAFT
-# \brief This module provides the ToDo class for the Draft Workbench.
+# \ingroup draftutils
+# \brief Provides the ToDo static class to run commands with a time delay.
 
 import six
 import sys
 import traceback
-from PySide import QtCore
+import PySide.QtCore as QtCore
 
 import FreeCAD as App
 import FreeCADGui as Gui
+
 from draftutils.messages import _msg, _wrn, _err, _log
 
 __title__ = "FreeCAD Draft Workbench, Todo class"
@@ -49,6 +50,9 @@ __url__ = ["http://www.freecadweb.org"]
 
 _DEBUG = 0
 _DEBUG_inner = 0
+
+## \addtogroup draftutils
+# @{
 
 
 class ToDo:
@@ -281,6 +285,7 @@ class ToDo:
         ToDo.afteritinerary.append((f, arg))
 
 
-# In the past, the class was in lowercase, so we provide a reference
-# to it in lowercase, to satisfy the usage of older modules.
+# Alias for compatibility with v0.18 and earlier
 todo = ToDo
+
+## @}

--- a/src/Mod/Draft/draftutils/translate.py
+++ b/src/Mod/Draft/draftutils/translate.py
@@ -1,12 +1,3 @@
-"""Provide translate functions for the Draft Workbench.
-
-This module contains auxiliary functions to translate strings
-using the QtCore module.
-"""
-## @package translate
-# \ingroup DRAFT
-# \brief Provide translate functions for the Draft Workbench.
-
 # ***************************************************************************
 # *   (c) 2009 Yorik van Havre <yorik@uncreated.net>                        *
 # *   (c) 2019 Eliud Cabrera Castillo <e.cabrera-castillo@tum.de>           *
@@ -30,11 +21,22 @@ using the QtCore module.
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-from PySide import QtCore
-from PySide import QtGui
+"""Provides utility functions that wrap around the Qt translate functions.
+
+This module contains auxiliary functions to translate strings
+using the QtCore module.
+"""
+## @package translate
+# \ingroup draftutils
+# \brief Provides utility functions that wrap around the Qt translate function.
+
+## \addtogroup draftutils
+# @{
+import PySide.QtCore as QtCore
+import PySide.QtGui as QtGui
 import six
 
-Qtranslate = QtGui.QApplication.translate
+Qtranslate = QtCore.QCoreApplication.translate
 
 # This property only exists in Qt4, which is normally paired
 # with Python 2.
@@ -246,3 +248,5 @@ def _qtr(text):
         Returns the translated string at runtime.
     """
     return QT_TRANSLATE_NOOP("Draft", text)
+
+## @}

--- a/src/Mod/Draft/draftutils/units.py
+++ b/src/Mod/Draft/draftutils/units.py
@@ -21,12 +21,14 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides utility functions related to unit handling."""
+"""Provides utility functions to handle quantities and units."""
 ## @package units
-# \ingroup DRAFT
-# \brief Provides utility functions related to unit handling.
+# \ingroup draftutils
+# \brief Provides utility functions to handle quantities and units.
 
-from PySide import QtCore
+## \addtogroup draftutils
+# @{
+import PySide.QtCore as QtCore
 
 import FreeCAD as App
 
@@ -122,3 +124,5 @@ def display_external(internal_value,
 
 
 displayExternal = display_external
+
+## @}

--- a/src/Mod/Draft/draftutils/utils.py
+++ b/src/Mod/Draft/draftutils/utils.py
@@ -23,21 +23,22 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides utility functions for the Draft Workbench.
+"""Provides general utility functions used throughout the workbench.
 
 This module contains auxiliary functions which can be used
 in other modules of the workbench, and which don't require
 the graphical user interface (GUI).
 """
 ## @package utils
-# \ingroup DRAFT
-# \brief This module provides utility functions for the Draft Workbench
+# \ingroup draftutils
+# \brief Provides general utility functions used throughout the workbench.
 
+## \addtogroup draftutils
+# @{
 import os
-from PySide import QtCore
+import PySide.QtCore as QtCore
 
 import FreeCAD as App
-import Draft_rc
 
 from draftutils.messages import _msg, _wrn, _err, _log
 from draftutils.translate import _tr
@@ -47,9 +48,10 @@ from draftutils.translate import _tr
 # in gui_utils
 if App.GuiUp:
     import FreeCADGui as Gui
+    import Draft_rc
 
-# The module is used to prevent complaints from code checkers (flake8)
-True if Draft_rc else False
+    # The module is used to prevent complaints from code checkers (flake8)
+    True if Draft_rc else False
 
 param = App.ParamGet("User parameter:BaseApp/Preferences/Mod/Draft")
 
@@ -1122,3 +1124,5 @@ def use_instead(function, version=""):
     else:
         _wrn(_tr(text2)
              + _tr(text3) + "'{}'.".format(function))
+
+## @}

--- a/src/Mod/Draft/draftviewproviders/__init__.py
+++ b/src/Mod/Draft/draftviewproviders/__init__.py
@@ -54,3 +54,6 @@ as the older class.
 
     old_module.ViewProviderRectangle = new_module.ViewProviderRectangle
 """
+## \defgroup draftviewproviders draftviewproviders
+# \ingroup DRAFT
+# \brief Classes that define viewproviders for the scripted objects.

--- a/src/Mod/Draft/draftviewproviders/view_array.py
+++ b/src/Mod/Draft/draftviewproviders/view_array.py
@@ -20,12 +20,13 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides the view provider code for the Draft Array objects.
-"""
+"""Provides the viewprovider code for the Array object."""
 ## @package view_array
-# \ingroup DRAFT
-# \brief Provides the view provider code for the Draft Array objects.
+# \ingroup draftviewproviders
+# \brief Provides the viewprovider code for the Array object.
 
+## \addtogroup draftviewproviders
+# @{
 from draftviewproviders.view_base import ViewProviderDraft
 
 
@@ -72,4 +73,7 @@ class ViewProviderDraftArray(ViewProviderDraft):
             vobj.DiffuseColor = colors
 
 
+# Alias for compatibility with v0.18 and earlier
 _ViewProviderDraftArray = ViewProviderDraftArray
+
+## @}

--- a/src/Mod/Draft/draftviewproviders/view_base.py
+++ b/src/Mod/Draft/draftviewproviders/view_base.py
@@ -20,31 +20,30 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""This module provides the view provider code for the base Draft object.
-"""
+"""Provides the viewprovider code for the base Draft object.
+
+Many viewprovider classes may inherit this class in order to have
+the same basic behavior."""
 ## @package view_base
-# \ingroup DRAFT
-# \brief This module provides the view provider code for the base Draft object.
+# \ingroup draftviewproviders
+# \brief Provides the viewprovider code for the base Draft object.
 
-
+## \addtogroup draftviewproviders
+# @{
 import PySide.QtCore as QtCore
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
 import FreeCAD as App
+import draftutils.utils as utils
+import draftutils.gui_utils as gui_utils
 
 if App.GuiUp:
     from pivy import coin
     import FreeCADGui as Gui
+    import Draft_rc
+    # The module is used to prevent complaints from code checkers (flake8)
+    bool(Draft_rc.__name__)
 
-import draftutils.utils as utils
-import draftutils.gui_utils as gui_utils
-
-#import Draft_rc
-# from DraftGui import translate
-# from DraftGui import displayExternal
-
-# So the resource file doesn't trigger errors from code checkers (flake8)
-#True if Draft_rc.__name__ else False
 
 class ViewProviderDraft(object):
     """The base class for Draft view providers.
@@ -491,6 +490,7 @@ class ViewProviderDraft(object):
         return objs
 
 
+# Alias for compatibility with v0.18 and earlier
 _ViewProviderDraft = ViewProviderDraft
 
 
@@ -508,6 +508,7 @@ class ViewProviderDraftAlt(ViewProviderDraft):
         return objs
 
 
+# Alias for compatibility with v0.18 and earlier
 _ViewProviderDraftAlt = ViewProviderDraftAlt
 
 
@@ -524,4 +525,7 @@ class ViewProviderDraftPart(ViewProviderDraftAlt):
         return ":/icons/Tree_Part.svg"
 
 
+# Alias for compatibility with v0.18 and earlier
 _ViewProviderDraftPart = ViewProviderDraftPart
+
+## @}

--- a/src/Mod/Draft/draftviewproviders/view_bezcurve.py
+++ b/src/Mod/Draft/draftviewproviders/view_bezcurve.py
@@ -18,16 +18,18 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides the view provider code for Bezier curve objects.
+"""Provides the viewprovider code for the BezCurve object.
 
 At the moment this view provider subclasses the Wire view provider,
 and behaves the same as it. In the future this could change
 if another behavior is desired.
 """
-## @package view_bezier
-# \ingroup DRAFT
-# \brief Provides the view provider code for Bezier curve objects.
+## @package view_bezcurve
+# \ingroup draftviewproviders
+# \brief Provides the viewprovider code for the BezCurve object.
 
+## \addtogroup draftviewproviders
+# @{
 from draftviewproviders.view_wire import ViewProviderWire
 
 
@@ -38,4 +40,7 @@ class ViewProviderBezCurve(ViewProviderWire):
         super(ViewProviderBezCurve, self).__init__(vobj)
 
 
+# Alias for compatibility with v0.18 and earlier
 _ViewProviderBezCurve = ViewProviderBezCurve
+
+## @}

--- a/src/Mod/Draft/draftviewproviders/view_bspline.py
+++ b/src/Mod/Draft/draftviewproviders/view_bspline.py
@@ -18,16 +18,18 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides the view provider code for BSpline objects.
+"""Provides the viewprovider code for the BSpline object.
 
 At the moment this view provider subclasses the Wire view provider,
 and behaves the same as it. In the future this could change
 if another behavior is desired.
 """
 ## @package view_bspline
-# \ingroup DRAFT
+# \ingroup draftviewproviders
 # \brief Provides the view provider code for BSpline objects.
 
+## \addtogroup draftviewproviders
+# @{
 from draftviewproviders.view_wire import ViewProviderWire
 
 
@@ -38,4 +40,7 @@ class ViewProviderBSpline(ViewProviderWire):
         super(ViewProviderBSpline, self).__init__(vobj)
 
 
+# Alias for compatibility with v0.18 and earlier
 _ViewProviderBSpline = ViewProviderBSpline
+
+## @}

--- a/src/Mod/Draft/draftviewproviders/view_circulararray.py
+++ b/src/Mod/Draft/draftviewproviders/view_circulararray.py
@@ -20,16 +20,19 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides the view provider code for the circular array object.
+"""Provides the viewprovider code for the circular Array object.
 
 Currently unused.
 """
 ## @package view_circulararray
-# \ingroup DRAFT
-# \brief Provides the view provider code for the circular array object.
+# \ingroup draftviewproviders
+# \brief Provides the viewprovider code for the circular Array object.
 
+## \addtogroup draftviewproviders
+# @{
 import Draft_rc
-from Draft import _ViewProviderDraftArray as ViewProviderDraftArray
+
+from draftviewproviders.view_array import ViewProviderDraftArray
 
 # The module is used to prevent complaints from code checkers (flake8)
 True if Draft_rc.__name__ else False
@@ -44,3 +47,5 @@ class ViewProviderCircularArray(ViewProviderDraftArray):
     def getIcon(self):
         """Set the icon in the tree view."""
         return ":/icons/Draft_CircularArray"
+
+## @}

--- a/src/Mod/Draft/draftviewproviders/view_clone.py
+++ b/src/Mod/Draft/draftviewproviders/view_clone.py
@@ -20,12 +20,13 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""This module provides the view provider code for the Draft Clone object.
-"""
+"""Provides the viewprovider code for the Clone object."""
 ## @package view_clone
-# \ingroup DRAFT
-# \brief This module provides the view provider code for the Draft Clone object.
+# \ingroup draftviewproviders
+# \brief Provides the viewprovider code for the Clone object.
 
+## \addtogroup draftviewproviders
+# @{
 import draftutils.groups as groups
 
 
@@ -77,4 +78,7 @@ class ViewProviderClone:
             vobj.DiffuseColor = colors
 
 
+# Alias for compatibility with v0.18 and earlier
 _ViewProviderClone = ViewProviderClone
+
+## @}

--- a/src/Mod/Draft/draftviewproviders/view_dimension.py
+++ b/src/Mod/Draft/draftviewproviders/view_dimension.py
@@ -22,15 +22,15 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides the Draft Dimension viewprovider classes.
+"""Provides the viewprovider code for the Dimension objects.
 
 These include linear dimensions, including radius and diameter,
 as well as angular dimensions.
 They inherit their behavior from the base Annotation viewprovider.
 """
 ## @package view_dimension
-# \ingroup DRAFT
-# \brief Provides the Draft Dimension viewprovider classes.
+# \ingroup draftviewproviders
+# \brief Provides the viewprovider code for the Dimension objects.
 
 import pivy.coin as coin
 import lazy_loader.lazy_loader as lz
@@ -48,6 +48,9 @@ from draftviewproviders.view_draft_annotation \
 # Delay import of module until first use because it is heavy
 Part = lz.LazyLoader("Part", globals(), "Part")
 DraftGeomUtils = lz.LazyLoader("DraftGeomUtils", globals(), "DraftGeomUtils")
+
+## \addtogroup draftviewproviders
+# @{
 
 
 class ViewProviderDimensionBase(ViewProviderDraftAnnotation):
@@ -1273,3 +1276,5 @@ class ViewProviderAngularDimension(ViewProviderDimensionBase):
 
 # Alias for compatibility with v0.18 and earlier
 _ViewProviderAngularDimension = ViewProviderAngularDimension
+
+## @}

--- a/src/Mod/Draft/draftviewproviders/view_draft_annotation.py
+++ b/src/Mod/Draft/draftviewproviders/view_draft_annotation.py
@@ -21,7 +21,7 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides the base class for many annotation viewproviders.
+"""Provides the viewprovider code for all annotation type objects.
 
 This is inherited and used by many viewproviders that show dimensions
 and text created on screen through Coin (pivy).
@@ -34,9 +34,11 @@ and text created on screen through Coin (pivy).
 Its edit mode launches the `Draft_Edit` command.
 """
 ## @package view_draft_annotation
-# \ingroup DRAFT
-# \brief Provides the base class for many annotation viewproviders.
+# \ingroup draftviewproviders
+# \brief Provides the viewprovider code for all annotation type objects.
 
+## \addtogroup draftviewproviders
+# @{
 import json
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
@@ -233,3 +235,5 @@ class ViewProviderDraftAnnotation(object):
             objs.extend(self.Object.Group)
 
         return objs
+
+## @}

--- a/src/Mod/Draft/draftviewproviders/view_draftlink.py
+++ b/src/Mod/Draft/draftviewproviders/view_draftlink.py
@@ -20,11 +20,13 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""This module provides the view provider code for the Draft Link object.
-"""
+"""Provides the base viewprovider code for the Link objects."""
 ## @package view_draftlink
-# \ingroup DRAFT
-# \brief This module provides the view provider code for the Draft Link object.
+# \ingroup draftviewproviders
+# \brief Provides the base viewprovider code for the Link objects.
+
+## \addtogroup draftviewproviders
+# @{
 
 
 class ViewProviderDraftLink:
@@ -66,6 +68,9 @@ class ViewProviderDraftLink:
             return [obj.Base]
         else:
             return obj.ElementList
-            
 
+
+# Alias for compatibility with old versions of v0.19
 _ViewProviderDraftLink = ViewProviderDraftLink
+
+## @}

--- a/src/Mod/Draft/draftviewproviders/view_facebinder.py
+++ b/src/Mod/Draft/draftviewproviders/view_facebinder.py
@@ -20,12 +20,13 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""This module provides the view provider code for Draft Facebinder object.
-"""
+"""Provides the viewprovider code for the Facebinder object."""
 ## @package view_facebinder
-# \ingroup DRAFT
-# \brief This module provides the view provider code for Draft Facebinder
+# \ingroup draftviewproviders
+# \brief Provides the viewprovider code for the Facebinder object.
 
+## \addtogroup draftviewproviders
+# @{
 import FreeCAD as App
 import FreeCADGui as Gui
 
@@ -53,4 +54,7 @@ class ViewProviderFacebinder(ViewProviderDraft):
         return False
 
 
+# Alias for compatibility with v0.18 and earlier
 _ViewProviderFacebinder = ViewProviderFacebinder
+
+## @}

--- a/src/Mod/Draft/draftviewproviders/view_fillet.py
+++ b/src/Mod/Draft/draftviewproviders/view_fillet.py
@@ -18,16 +18,18 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides the view provider code for Fillet objects.
+"""Provides the viewprovider code for the Fillet object.
 
 At the moment this view provider subclasses the Wire view provider,
 and behaves the same as it. In the future this could change
 if another behavior is desired.
 """
 ## @package view_fillet
-# \ingroup DRAFT
-# \brief Provides the view provider code for Fillet objects.
+# \ingroup draftviewproviders
+# \brief Provides the viewprovider code for the Fillet object.
 
+## \addtogroup draftviewproviders
+# @{
 from draftviewproviders.view_wire import ViewProviderWire
 
 
@@ -36,3 +38,5 @@ class ViewProviderFillet(ViewProviderWire):
 
     def __init__(self, vobj):
         super(ViewProviderFillet, self).__init__(vobj)
+
+## @}

--- a/src/Mod/Draft/draftviewproviders/view_label.py
+++ b/src/Mod/Draft/draftviewproviders/view_label.py
@@ -22,11 +22,13 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides the viewprovider class for the Draft Label object."""
+"""Provides the viewprovider code for the Label object."""
 ## @package view_label
-# \ingroup DRAFT
-# \brief Provides the viewprovider class for the Draft Label object.
+# \ingroup draftviewproviders
+# \brief Provides the viewprovider code for the Label object.
 
+## \addtogroup draftviewproviders
+# @{
 import math
 import sys
 import pivy.coin as coin
@@ -527,3 +529,5 @@ class ViewProviderLabel(ViewProviderDraftAnnotation):
 
 # Alias for compatibility with v0.18 and earlier
 ViewProviderDraftLabel = ViewProviderLabel
+
+## @}

--- a/src/Mod/Draft/draftviewproviders/view_orthoarray.py
+++ b/src/Mod/Draft/draftviewproviders/view_orthoarray.py
@@ -20,16 +20,19 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides the view provider code for the ortho array object.
+"""Provides the viewprovider code for the orthogonal Array object.
 
 Currently unused.
 """
 ## @package view_orthoarray
-# \ingroup DRAFT
-# \brief Provides the view provider code for the ortho array object.
+# \ingroup draftviewproviders
+# \brief Provides the viewprovider code for the orthogonal Array object.
 
+## \addtogroup draftviewproviders
+# @{
 import Draft_rc
-from Draft import _ViewProviderDraftArray as ViewProviderDraftArray
+
+from draftviewproviders.view_array import ViewProviderDraftArray
 
 # The module is used to prevent complaints from code checkers (flake8)
 True if Draft_rc.__name__ else False
@@ -44,3 +47,5 @@ class ViewProviderOrthoArray(ViewProviderDraftArray):
     def getIcon(self):
         """Set the icon in the tree view."""
         return ":/icons/Draft_Array"
+
+## @}

--- a/src/Mod/Draft/draftviewproviders/view_point.py
+++ b/src/Mod/Draft/draftviewproviders/view_point.py
@@ -20,12 +20,13 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""This module provides the view provider code for Draft Point.
-"""
+"""Provides the viewprovider code for the Point object."""
 ## @package view_point
-# \ingroup DRAFT
-# \brief This module provides the view provider code for Draft Point.
+# \ingroup draftviewproviders
+# \brief Provides the viewprovider code for the Point object.
 
+## \addtogroup draftviewproviders
+# @{
 from draftviewproviders.view_base import ViewProviderDraft
 
 
@@ -52,4 +53,7 @@ class ViewProviderPoint(ViewProviderDraft):
         return ":/icons/Draft_Dot.svg"
 
 
+# Alias for compatibility with v0.18 and earlier
 _ViewProviderPoint = ViewProviderPoint
+
+## @}

--- a/src/Mod/Draft/draftviewproviders/view_polararray.py
+++ b/src/Mod/Draft/draftviewproviders/view_polararray.py
@@ -20,16 +20,19 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides the view provider code for the polar array object.
+"""Provides the viewprovider code for the polar Array object.
 
 Currently unused.
 """
 ## @package view_polararray
-# \ingroup DRAFT
-# \brief Provides the view provider code for the polar array object.
+# \ingroup draftviewproviders
+# \brief Provides the viewprovider code for the polar Array object.
 
+## \addtogroup draftviewproviders
+# @{
 import Draft_rc
-from Draft import _ViewProviderDraftArray as ViewProviderDraftArray
+
+from draftviewproviders.view_array import ViewProviderDraftArray
 
 # The module is used to prevent complaints from code checkers (flake8)
 True if Draft_rc.__name__ else False
@@ -44,3 +47,5 @@ class ViewProviderPolarArray(ViewProviderDraftArray):
     def getIcon(self):
         """Set the icon in the tree view."""
         return ":/icons/Draft_PolarArray"
+
+## @}

--- a/src/Mod/Draft/draftviewproviders/view_rectangle.py
+++ b/src/Mod/Draft/draftviewproviders/view_rectangle.py
@@ -20,12 +20,13 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""This module provides the view provider code for the Draft Rectangle object.
-"""
+"""Provides the viewprovider code for the Rectangle object."""
 ## @package view_rectangle
-# \ingroup DRAFT
-# \brief This module provides the view provider code for the Draft Rectangle object.
+# \ingroup draftviewproviders
+# \brief Provides the viewprovider code for the Rectangle object.
 
+## \addtogroup draftviewproviders
+# @{
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
 from draftviewproviders.view_base import ViewProviderDraft
@@ -41,4 +42,7 @@ class ViewProviderRectangle(ViewProviderDraft):
                          "Draft", QT_TRANSLATE_NOOP("App::Property", _tip))
 
 
+# Alias for compatibility with v0.18 and earlier
 _ViewProviderRectangle = ViewProviderRectangle
+
+## @}

--- a/src/Mod/Draft/draftviewproviders/view_text.py
+++ b/src/Mod/Draft/draftviewproviders/view_text.py
@@ -22,22 +22,21 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides the Draft Text viewprovider class."""
+"""Provides the viewprovider code for the Text object."""
 ## @package view_text
-# \ingroup DRAFT
-# \brief Provides the Draft Text viewprovider class.
+# \ingroup draftviewproviders
+# \brief Provides the viewprovider code for the Text object.
 
+## \addtogroup draftviewproviders
+# @{
 import pivy.coin as coin
 import sys
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
-import FreeCAD as App
-
 import draftutils.utils as utils
+
 from draftviewproviders.view_draft_annotation \
     import ViewProviderDraftAnnotation
-
-param = App.ParamGet("User parameter:BaseApp/Preferences/Mod/Draft")
 
 
 class ViewProviderText(ViewProviderDraftAnnotation):
@@ -226,3 +225,5 @@ class ViewProviderText(ViewProviderDraftAnnotation):
 
 # Alias for compatibility with v0.18 and earlier
 ViewProviderDraftText = ViewProviderText
+
+## @}

--- a/src/Mod/Draft/draftviewproviders/view_wire.py
+++ b/src/Mod/Draft/draftviewproviders/view_wire.py
@@ -20,15 +20,17 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""Provides the viewprovider code for polyline and similar objects.
+"""Provides the viewprovider code for the Wire (polyline) object.
 
 This viewprovider is also used by simple lines, B-splines, bezier curves,
 and similar objects.
 """
-## @package view_base
-# \ingroup DRAFT
-# \brief Provides the viewprovider code for polyline and similar objects.
+## @package view_wire
+# \ingroup draftviewproviders
+# \brief Provides the viewprovider code for the Wire (polyline) object.
 
+## \addtogroup draftviewproviders
+# @{
 import pivy.coin as coin
 import PySide.QtCore as QtCore
 import PySide.QtGui as QtGui
@@ -36,13 +38,12 @@ from PySide.QtCore import QT_TRANSLATE_NOOP
 
 import FreeCAD as App
 import FreeCADGui as Gui
-
-import draftutils.utils as utils
-import draftutils.gui_utils as gui_utils
 import DraftVecUtils
 import DraftGeomUtils
-from draftutils.messages import _msg
+import draftutils.utils as utils
+import draftutils.gui_utils as gui_utils
 
+from draftutils.messages import _msg
 from draftviewproviders.view_base import ViewProviderDraft
 
 
@@ -173,4 +174,7 @@ class ViewProviderWire(ViewProviderDraft):
                         _msg(QT_TRANSLATE_NOOP("Draft", _flat))
 
 
+# Alias for compatibility with v0.18 and earlier
 _ViewProviderWire = ViewProviderWire
+
+## @}

--- a/src/Mod/Draft/draftviewproviders/view_wpproxy.py
+++ b/src/Mod/Draft/draftviewproviders/view_wpproxy.py
@@ -20,17 +20,16 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
-"""This module provides the view provider code for Draft WorkingPlaneProxy
-object.
-"""
+"""Provides the viewprovider code for the WorkingPlaneProxy object."""
 ## @package view_wpproxy
-# \ingroup DRAFT
-# \brief This module provides the view provider code for Draft WorkingPlaneProxy.
+# \ingroup draftviewproviders
+# \brief Provides the viewprovider code for the WorkingPlaneProxy object.
 
-from pivy import coin
-from PySide import QtCore
-from PySide import QtGui
-
+## \addtogroup draftviewproviders
+# @{
+import pivy.coin as coin
+import PySide.QtCore as QtCore
+import PySide.QtGui as QtGui
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
 import FreeCAD as App
@@ -232,3 +231,5 @@ class ViewProviderWorkingPlaneProxy:
 
     def __setstate__(self,state):
         return None
+
+## @}

--- a/src/Mod/Draft/getSVG.py
+++ b/src/Mod/Draft/getSVG.py
@@ -1,3 +1,10 @@
+"""Provides functions to return the SVG representation of various shapes."""
+## @defgroup getSVG getSVG
+#  \ingroup DRAFT
+#  \brief Provides functions to return the SVG representation of shapes.
+
+## \addtogroup getSVG
+# @{
 import six
 
 import FreeCAD, math, os, DraftVecUtils, WorkingPlane
@@ -865,3 +872,5 @@ def getSVG(obj,scale=1,linewidth=0.35,fontsize=12,fillstyle="shape color",direct
     if techdraw:
         svg = '<g transform ="scale(1,-1)">\n    '+svg+'</g>\n'
     return svg
+
+## @}


### PR DESCRIPTION
After the re-organization of the Draft modules, the Doxygen documentation placed each module in the `DRAFT` group. This pull request adds proper groups under this main group so that each module is correctly categorized, and it's easier to find the documentation for all functions and classes.

This pull request essentially modifies all modules in the workbench so it will probably cause conflicts with other pull requests; they will need to be resolved before merging.

---

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists
