### PR TITLE
Arch: fix invalid print syntax for Python 2, in importIFCHelper

### DIFF
--- a/src/Mod/Arch/importIFCHelper.py
+++ b/src/Mod/Arch/importIFCHelper.py
@@ -27,6 +27,7 @@ import FreeCAD
 import Arch
 import ArchIFC
 
+from draftutils.messages import _wrn
 
 # ************************************************************************************************
 # ********** some helper, used in import and export, or should stay together
@@ -568,7 +569,7 @@ def getPlacement(entity,scaling=1000):
         if loc:
             pl.move(loc)
     elif entity.is_a("IfcAxis2Placement2D"):
-        print("not implemented IfcAxis2Placement2D, ")
+        _wrn("not implemented IfcAxis2Placement2D, ", end="")
     elif entity.is_a("IfcLocalPlacement"):
         pl = getPlacement(entity.PlacementRelTo,1)  # original placement
         relpl = getPlacement(entity.RelativePlacement,1)  # relative transf


### PR DESCRIPTION
In 9de5f54dae a print statement was added when a condition is met. Currently this causes the Travis unit tests to fail with a Python 2 syntax error as in this version `print` doesn't have the `end` parameter.

In this pull request we substitute `print` with the `_wrn` function from `draftutils.messages` which internally use the `FreeCAD.Console` methods.

---

The failing unit test was fixed in 6c15e174d2, but still I think using the `_wrn` function is better because it includes the original line ending and it should not fail.

---

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists
