### PR TITLE
FEM: fix unit tests, skip import of examplesgui when there is no GUI

### DIFF
--- a/src/Mod/Fem/femtest/app/test_common.py
+++ b/src/Mod/Fem/femtest/app/test_common.py
@@ -133,6 +133,7 @@ class TestFemCommon(unittest.TestCase):
 
             if (
                 mod == "femsolver.solver_taskpanel"
+                or mod == "femexamples.examplesgui"
                 or mod == "TestFemGui"
             ) and not FreeCAD.GuiUp:
                 continue


### PR DESCRIPTION
In ff3ce49139, a new module was added to showcase the FEM graphical tests. This module is imported in the unit tests, `femtest.app.test_common.TestFemCommon.test_pyimport_all_FEM_modules`. Currently this causes the Travis unit tests to fail because it uses the graphical module `FreeCADGui`, which is not available when performing the unit tests in Windows.

In this pull request we skip importing the new module added, `femexamples.examplesgui`.

---

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists