### PR TITLE
build: fix Coin 3d documentation discovering

### DIFF
--- a/cMake/FindCoin3DDoc.cmake
+++ b/cMake/FindCoin3DDoc.cmake
@@ -23,18 +23,19 @@ IF (COIN3D_FOUND)
       find_path(COIN3D_DOC_PATH index.html 
                 /usr/share/doc/libcoin80-doc/html
                 /usr/share/doc/coin/html
+                /usr/share/doc/Coin/html
       )
       IF( EXISTS ${COIN3D_DOC_PATH})
         message(STATUS "Coin3D doc is installed")
-        find_file(COIN3D_DOC_TAGFILE coin.tag Coin.tag 
-            ${COIN3D_DOC_PATH}
+        find_file(COIN3D_DOC_TAGFILE NAMES coin.tag Coin.tag 
+            PATHS ${COIN3D_DOC_PATH}
         )
         IF( EXISTS ${COIN3D_DOC_TAGFILE})
           SET( COIN3D_DOC_FOUND "YES"
           )
         ELSE( EXISTS ${COIN3D_DOC_TAGFILE})
-          find_file(COIN3D_DOC_TAGFILE_GZ coin.tag.gz Coin.tag.gz 
-              ${COIN3D_DOC_PATH}
+          find_file(COIN3D_DOC_TAGFILE_GZ NAMES coin.tag.gz Coin.tag.gz 
+              PATHS ${COIN3D_DOC_PATH}
           )
           IF( EXISTS ${COIN3D_DOC_TAGFILE_GZ})
             message(STATUS "  Found ${COIN3D_DOC_TAGFILE_GZ}")
@@ -85,4 +86,5 @@ if(COIN3D_DOC_FOUND)
   message(STATUS "  Location: ${COIN3D_DOC_PATH}")
 endif(COIN3D_DOC_FOUND)
 
-
+# export for others
+SET( COIN3D_DOC_FOUND "${COIN3D_DOC_FOUND}" CACHE BOOL "Coin3d documentation available")


### PR DESCRIPTION
* coin3d 4.0.0 default location is /usr/share/doc/Coin/html/
* misuses of find_files() if several candidates for filename
* export variable COIN3D_DOC_FOUND that is used by cMake/FreeCAD_Helpers/PrintFinalReport.cmake

Related to https://forum.freecadweb.org/viewtopic.php?f=4&t=48390&sid=fbb163e3d19729595bdabde03c879cea

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
