### PR TITLE
[PATH] fix Cannot access attribute 'Document' of deleted object when cancelling PathPocket operation

### DIFF
--- a/src/Mod/Path/PathScripts/PathPocketShapeGui.py
+++ b/src/Mod/Path/PathScripts/PathPocketShapeGui.py
@@ -173,16 +173,8 @@ class TaskPanelExtensionPage(PathOpGui.TaskPanelPage):
         self.blockUpdateData = False # pylint: disable=attribute-defined-outside-init
 
     def cleanupPage(self, obj):
-        # If the object was already destroyed we can't access obj.Name.
-        # This is the case if this was a new op and the user hit Cancel.
-        # Unfortunately there's no direct way to determine the object's
-        # livelihood without causing an error so we look for the object
-        # in the document and clean up if it still exists.
         try:
-            for o in self.obj.Document.getObjectsByLabel(self.obj.Label):
-                if o == obj:
-                    self.obj.ViewObject.RootNode.removeChild(self.switch)
-                    return
+            self.obj.ViewObject.RootNode.removeChild(self.switch)
         except ReferenceError:
             PathLog.debug("obj already destroyed - no cleanup required")
 

--- a/src/Mod/Path/PathScripts/PathPocketShapeGui.py
+++ b/src/Mod/Path/PathScripts/PathPocketShapeGui.py
@@ -178,11 +178,13 @@ class TaskPanelExtensionPage(PathOpGui.TaskPanelPage):
         # Unfortunately there's no direct way to determine the object's
         # livelihood without causing an error so we look for the object
         # in the document and clean up if it still exists.
-        for o in self.obj.Document.getObjectsByLabel(self.obj.Label):
-            if o == obj:
-                self.obj.ViewObject.RootNode.removeChild(self.switch)
-                return
-        PathLog.debug("%s already destroyed - no cleanup required" % (obj.Label))
+        try:
+            for o in self.obj.Document.getObjectsByLabel(self.obj.Label):
+                if o == obj:
+                    self.obj.ViewObject.RootNode.removeChild(self.switch)
+                    return
+        except ReferenceError:
+            PathLog.debug("obj already destroyed - no cleanup required")
 
     def getForm(self):
         return FreeCADGui.PySideUic.loadUi(":/panels/PageOpPocketExtEdit.ui")


### PR DESCRIPTION
Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
