### PR TITLE
[PATH] fix pocket attribute error if edge cannot be flipped

### DIFF
--- a/src/Mod/Path/PathScripts/PathPocketShapeGui.py
+++ b/src/Mod/Path/PathScripts/PathPocketShapeGui.py
@@ -261,7 +261,11 @@ class TaskPanelExtensionPage(PathOpGui.TaskPanelPage):
 
         if extendCorners:
             def edgesMatchShape(e0, e1):
-                return PathGeom.edgesMatch(e0, e1) or PathGeom.edgesMatch(e0, PathGeom.flipEdge(e1))
+                flipped = PathGeom.flipEdge(e1)
+                if flipped:
+                    return PathGeom.edgesMatch(e0, e1) or PathGeom.edgesMatch(e0, flipped)
+                else:
+                    return PathGeom.edgesMatch(e0, e1)
 
             self.extensionEdges = extensionEdges # pylint: disable=attribute-defined-outside-init
             for edgeList in Part.sortEdges(list(extensionEdges.keys())):


### PR DESCRIPTION
While trying to pocket a shape that contains an edge with geometry that cannot be flipped you receive the following error:

```
PathGeom.WARNING: <class 'Part.Ellipse'> not support for flipping
Traceback (most recent call last):
  File "/home/eric/squashfs-root/usr/Mod/Path/PathScripts/PathOpGui.py", line 109, in setEdit
    self.setupTaskPanel(TaskPanel(vobj.Object, self.deleteObjectsOnReject(), page, selection))
  File "/home/eric/squashfs-root/usr/Mod/Path/PathScripts/PathOpGui.py", line 120, in setupTaskPanel
    panel.setupUi()
  File "/home/eric/squashfs-root/usr/Mod/Path/PathScripts/PathOpGui.py", line 1140, in setupUi
    self.panelSetFields()
  File "/home/eric/squashfs-root/usr/Mod/Path/PathScripts/PathOpGui.py", line 1112, in panelSetFields
    page.pageSetFields()
  File "/home/eric/squashfs-root/usr/Mod/Path/PathScripts/PathOpGui.py", line 246, in pageSetFields
    self.setFields(self.obj)
  File "/home/eric/squashfs-root/usr/Mod/Path/PathScripts/PathPocketShapeGui.py", line 222, in setFields
    self.setExtensions(self.extensions)
  File "/home/eric/squashfs-root/usr/Mod/Path/PathScripts/PathPocketShapeGui.py", line 314, in setExtensions
    baseItem.appendRow(self.createItemForBaseModel(base[0], sub, edges, extensions))
  File "/home/eric/squashfs-root/usr/Mod/Path/PathScripts/PathPocketShapeGui.py", line 271, in createItemForBaseModel
    label = "Wire(%s)" % ','.join(sorted([extensionEdges[keyEdge] for e in edgeList for keyEdge in extensionEdges.keys() if edgesMatchShape(e, keyEdge)], key=lambda s: int(s))) # pylint: disable=unnecessary-lambda
  File "/home/eric/squashfs-root/usr/Mod/Path/PathScripts/PathPocketShapeGui.py", line 271, in <listcomp>
    label = "Wire(%s)" % ','.join(sorted([extensionEdges[keyEdge] for e in edgeList for keyEdge in extensionEdges.keys() if edgesMatchShape(e, keyEdge)], key=lambda s: int(s))) # pylint: disable=unnecessary-lambda
  File "/home/eric/squashfs-root/usr/Mod/Path/PathScripts/PathPocketShapeGui.py", line 262, in edgesMatchShape
    return PathGeom.edgesMatch(e0, e1) or PathGeom.edgesMatch(e0, PathGeom.flipEdge(e1))
  File "/home/eric/squashfs-root/usr/Mod/Path/PathScripts/PathGeom.py", line 104, in edgesMatch
    if type(e0<class 'AttributeError'>: 'NoneType' object has no attribute 'Curve'
```
