### PR TITLE
Fix Crowdin typos and various other typos/grammar [skip ci]

### DIFF
--- a/src/App/DocumentObjectPy.xml
+++ b/src/App/DocumentObjectPy.xml
@@ -86,7 +86,7 @@ referencing subobject.
 
     DocAndPyObject: return a tuple (object, matrix, pyobj) for each subname
 
-    Placement: return a trasformed placement of the sub-object
+    Placement: return a transformed placement of the sub-object
 
 * matrix: the initial transformation to be applied to the sub object.
 

--- a/src/Mod/Arch/ArchBuildingPart.py
+++ b/src/Mod/Arch/ArchBuildingPart.py
@@ -537,7 +537,7 @@ class ViewProviderBuildingPart:
         if not "RestoreView" in pl:
             vobj.addProperty("App::PropertyBool","RestoreView","Interaction",QT_TRANSLATE_NOOP("App::Property","If set, the view stored in this object will be restored on double-click"))
         if not "DoubleClickActivates" in pl:
-            vobj.addProperty("App::PropertyBool","DoubleClickActivates","Interaction",QT_TRANSLATE_NOOP("App::Property","If True, double-clicking this object in the tree turns it active"))
+            vobj.addProperty("App::PropertyBool","DoubleClickActivates","Interaction",QT_TRANSLATE_NOOP("App::Property","If True, double-clicking this object in the tree activates it"))
 
         # inventor saving
         if not "SaveInventor" in pl:

--- a/src/Mod/Arch/Resources/ui/ArchSchedule.ui
+++ b/src/Mod/Arch/Resources/ui/ArchSchedule.ui
@@ -65,7 +65,7 @@
       </property>
       <property name="toolTip">
        <string>The property to retrieve from each object.
-Can be &quot;count&quot; to count the objects, or property names
+Can be &quot;Count&quot; to count the objects, or property names
 like &quot;Length&quot; or &quot;Shape.Volume&quot; to retrieve
 a certain property.</string>
       </property>
@@ -83,7 +83,10 @@ a certain property.</string>
        <string>Objects</string>
       </property>
       <property name="toolTip">
-       <string>An optional semicolon (;) separated list of object names internal names, not labels) to be considered by this operation. If the list contains groups, children will be added. Leave blank to use all objects from the document</string>
+       <string>An optional semicolon (;) separated list of object names 
+(internal names, not labels), to be considered by this operation.
+If the list contains groups, children will be added.
+Leave blank to use all objects from the document</string>
       </property>
      </column>
      <column>
@@ -91,7 +94,7 @@ a certain property.</string>
        <string>Filter</string>
       </property>
       <property name="toolTip">
-       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;An optional semicolon (;) separated list of property:value filters. Prepend ! to a property name to invert the effect of the filer (exclude objects that match the filter. Objects whose property contains the value will be matched. Examples of valid filters (everything is case-insensitive):&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Name:Wall&lt;/span&gt; - Will only consider objects with &amp;quot;wall&amp;quot; in their name (internal name)&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;!Name:Wall&lt;/span&gt; - Will only consider objects which DON'T have &amp;quot;wall&amp;quot; in their name (internal name)&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Descriptionl:Win&lt;/span&gt; - Will only consider objects with &amp;quot;win&amp;quot; in their description&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;!Label:Win&lt;/span&gt; - Will only consider objects which DON't have &amp;quot;win&amp;quot; in their label&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;IfcType:Wall&lt;/span&gt; - Will only consider objects which Ifc Type is &amp;quot;Wall&amp;quot;&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;!Tag:Wall&lt;/span&gt; - Will only consider objects which tag is NOT &amp;quot;Wall&amp;quot;&lt;/p&gt;&lt;p&gt;If you leave this field empty, no filtering is applied&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;An optional semicolon (;) separated list of property:value filters. Prepend ! to a property name to invert the effect of the filer (exclude objects that match the filter). Objects whose property contains the value will be matched. Examples of valid filters (everything is case-insensitive):&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Name:Wall&lt;/span&gt; - Will only consider objects with &amp;quot;wall&amp;quot; in their name (internal name)&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;!Name:Wall&lt;/span&gt; - Will only consider objects which DON'T have &amp;quot;wall&amp;quot; in their name (internal name)&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Descriptionl:Win&lt;/span&gt; - Will only consider objects with &amp;quot;win&amp;quot; in their description&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;!Label:Win&lt;/span&gt; - Will only consider objects which DON't have &amp;quot;win&amp;quot; in their label&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;IfcType:Wall&lt;/span&gt; - Will only consider objects which Ifc Type is &amp;quot;Wall&amp;quot;&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;!Tag:Wall&lt;/span&gt; - Will only consider objects which tag is NOT &amp;quot;Wall&amp;quot;&lt;/p&gt;&lt;p&gt;If you leave this field empty, no filtering is applied&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
       </property>
      </column>
     </widget>

--- a/src/Mod/Arch/Resources/ui/preferences-ifc-export.ui
+++ b/src/Mod/Arch/Resources/ui/preferences-ifc-export.ui
@@ -116,7 +116,7 @@ Use this to force all objects to be exported as BREP geometry.</string>
         <property name="toolTip">
          <string>Curved shapes that cannot be represented as curves in IFC
 are decomposed into flat facets.
-If this is checked, additional calculation is done to join coplanar facets.</string>
+If this is checked, an additional calculation is done to join coplanar facets.</string>
         </property>
         <property name="text">
          <string>Join coplanar facets when triangulating</string>

--- a/src/Mod/Arch/Resources/ui/preferences-ifc.ui
+++ b/src/Mod/Arch/Resources/ui/preferences-ifc.ui
@@ -104,7 +104,7 @@ One object is the base object, the others are clones.</string>
         <item>
          <widget class="Gui::PrefSpinBox" name="spinBox">
           <property name="toolTip">
-           <string>EXPERIMENTAL - The number of cores to use in multicore mode. Keep 0 to disable multicore mode, or 1 to use multicore mode in single-core mode (safer if you get crashes). Max value should be your number of cores - 1, ex: 3 of you have a quad-core CPU.</string>
+           <string>EXPERIMENTAL - The number of cores to use in multicore mode. Keep 0 to disable multicore mode, or 1 to use multicore mode in single-core mode (safer if you get crashes). Max value should be your number of cores - 1, ex: 3 if you have a quad-core CPU.</string>
           </property>
           <property name="prefEntry" stdset="0">
            <cstring>ifcMulticore</cstring>
@@ -428,10 +428,10 @@ FreeCAD object properties</string>
       <item>
        <widget class="Gui::PrefCheckBox" name="checkBox">
         <property name="toolTip">
-         <string>If this option is checked, the default Project, Site, Building and Storeys objects that are usually found in an IFC file are not imported, and all objects are placed in a Group. Buildings and Storeys are still imported if there is more than one.</string>
+         <string>If this option is checked, the default Project, Site, Building, and Storeys objects that are usually found in an IFC file are not imported, and all objects are placed in a Group. Buildings and Storeys are still imported if there is more than one.</string>
         </property>
         <property name="text">
-         <string>Replace Project, Site, Building and Storey by Group</string>
+         <string>Replace Project, Site, Building, and Storey by Group</string>
         </property>
         <property name="prefEntry" stdset="0">
          <cstring>ifcReplaceProject</cstring>

--- a/src/Mod/Draft/draftviewproviders/view_text.py
+++ b/src/Mod/Draft/draftviewproviders/view_text.py
@@ -196,7 +196,7 @@ class ViewProviderText(ViewProviderDraftAnnotation):
             # In v0.19 this code causes an `AttributeError` exception
             # during loading of the document as `ScaleMultiplier`
             # apparently isn't set immediately when the document loads.
-            # So the if condition tests for the existance
+            # So the if condition tests for the existence
             # of `ScaleMultiplier` before even changing the font size.
             # A try-except block may be used as well to catch and ignore
             # this error.

--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -7046,7 +7046,7 @@ void SketchObject::onChanged(const App::Property* prop)
             setStatus(App::PendingTransactionUpdate, true);
         }
         else {
-            if(!internaltransaction) { // internal sketchobject operations changing both geometry and constraints will explicity perform an update
+            if(!internaltransaction) { // internal sketchobject operations changing both geometry and constraints will explicitly perform an update
                 if(prop == &Geometry) {
                     if(managedoperation || isRestoring()) {
                         acceptGeometry(); // if geometry changed, the constraint geometry indices must be updated


### PR DESCRIPTION
Found via codespell v2.0.dev0  
```
codespell -q 3 -L aci,ake,aline,alle,alledges,alocation,als,ang,anid,ba,beginn,behaviour,bloaded,byteorder,calculater,cancelled,cancelling,cas,cascade,centimetre,childs,colour,colours,commen,connexion,currenty,dof,doubleclick,dum,eiter,elemente,ende,feld,finde,findf,freez,hist,iff,indicies,initialisation,initialise,initialised,initialises,initialisiert,ist,kilometre,lod,mantatory,methode,metres,millimetre,modell,nd,noe,normale,normaly,nto,numer,oder,orgin,orginx,orginy,ot,pard,pres,programm,que,recurrance,rougly,seperator,serie,sinc,strack,substraction,te,thist,thru,tread,uint,unter,vertexes,wallthickness,whitespaces -S ./.git,*.po,*.ts,./ChangeLog.txt,./src/3rdParty,./src/Mod/Assembly/App/opendcm,./src/CXX,./src/zipios++,./src/Base/swig*,./src/Mod/Robot/App/kdl_cp,./src/Mod/Import/App/SCL,./src/WindowsInstaller,./src/Doc/FreeCAD.uml
```