### PR TITLE
Gui: automatically activate the DlgExpressionInput dialog; fixes #4384

### DIFF
--- a/src/Gui/DlgExpressionInput.cpp
+++ b/src/Gui/DlgExpressionInput.cpp
@@ -107,6 +107,7 @@ DlgExpressionInput::DlgExpressionInput(const App::ObjectIdentifier & _path,
             this->resize(ui->expression->width()+18,this->height());
     }
     ui->expression->setFocus();
+    ui->expression->activateWindow();
 }
 
 DlgExpressionInput::~DlgExpressionInput()


### PR DESCRIPTION
This PR fixes [ issue #4384](https://tracker.freecadweb.org/view.php?id=4384) on MacOS by simply calling activateWindow() for the expression widget. On other platforms this call maybe redundant. Please check if that call does not have any side effects on those platforms.

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [x] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists
---
