### PR TITLE
Gui: do not drop unhandled key events in *SpinBox::keyPressedEvent() handlers

### DIFF
--- a/src/Gui/QuantitySpinBox.cpp
+++ b/src/Gui/QuantitySpinBox.cpp
@@ -513,7 +513,7 @@ void Gui::QuantitySpinBox::keyPressEvent(QKeyEvent *event)
 {
     if (event->text() == QString::fromUtf8("=") && isBound())
         openFormulaDialog();
-    else if (!hasExpression())
+    else
         QAbstractSpinBox::keyPressEvent(event);
 }
 

--- a/src/Gui/SpinBox.cpp
+++ b/src/Gui/SpinBox.cpp
@@ -405,10 +405,8 @@ void UIntSpinBox::keyPressEvent(QKeyEvent *event)
 {
     if (event->text() == QString::fromUtf8("=") && isBound())
         openFormulaDialog();
-    else {
-        if (!hasExpression())
-            QAbstractSpinBox::keyPressEvent(event);
-    }
+    else
+        QAbstractSpinBox::keyPressEvent(event);
 }
 
 
@@ -584,10 +582,8 @@ void IntSpinBox::keyPressEvent(QKeyEvent *event)
 {
     if (event->text() == QString::fromUtf8("=") && isBound())
         openFormulaDialog();
-    else {
-        if (!hasExpression())
-            QAbstractSpinBox::keyPressEvent(event);
-    }
+    else
+        QAbstractSpinBox::keyPressEvent(event);
 }
 
 
@@ -762,10 +758,8 @@ void DoubleSpinBox::keyPressEvent(QKeyEvent *event)
 {
     if (event->text() == QString::fromUtf8("=") && isBound())
         openFormulaDialog();
-    else {
-        if (!hasExpression())
-            QAbstractSpinBox::keyPressEvent(event);
-    }
+    else
+        QAbstractSpinBox::keyPressEvent(event);
 }
 
 #include "moc_SpinBox.cpp"


### PR DESCRIPTION
This PR fixes an annoying behaviour of the spin boxes, if they are bound to an expression. Currently in that case the dialog containing the spin box does not accept the Enter or ESC keys as long as the spin box has the focus. This is caused by the keyPressedEvent handlers as they drop all events other than the "=" key, if the spin box is bound to an expression. According to the [discussion](https://forum.freecadweb.org/viewtopic.php?f=10&t=48549) the extra check !hasExpression() was introduced to prevent the user from entering a value into the spin box. Anyway this is not possible, because the spin box is already read-only. So, I removed that check so that the Enter and ESC key are passed to the spin box and can find their way to the accepted() respectively rejected() signals of the dialog. 


- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

---
