### PR TITLE
Arch: fix incorrect indentation in the OBJ exporter

### DIFF
--- a/src/Mod/Arch/importOBJ.py
+++ b/src/Mod/Arch/importOBJ.py
@@ -84,15 +84,15 @@ def getIndices(obj,shape,offsetv,offsetvn):
                         break
             except: # unimplemented curve type
                 if obj.isDerivedFrom("App::Link"):
-                  if obj.Shape:
-                      myshape = obj.Shape.copy(False)
-                      myshape.Placement=obj.LinkPlacement
-                  else:
-                      myshape = obj.Shape.copy(False)
-                      myshape.Placement=obj.getGlobalPlacement()
-                mesh = MeshPart.meshFromShape(Shape=myshape, LinearDeflection=0.1, AngularDeflection=0.7, Relative=True)
-                FreeCAD.Console.PrintWarning(translate("Arch","Found a shape containing curves, triangulating")+"\n")
-                break
+                    if obj.Shape:
+                        myshape = obj.Shape.copy(False)
+                        myshape.Placement=obj.LinkPlacement
+                    else:
+                        myshape = obj.Shape.copy(False)
+                        myshape.Placement=obj.getGlobalPlacement()
+                    mesh = MeshPart.meshFromShape(Shape=myshape, LinearDeflection=0.1, AngularDeflection=0.7, Relative=True)
+                    FreeCAD.Console.PrintWarning(translate("Arch","Found a shape containing curves, triangulating")+"\n")
+                    break
     elif isinstance(shape,Mesh.Mesh):
         mesh = shape
         curves = shape.Topology


### PR DESCRIPTION
Preliminary support for App::Link was added in 16d44f115b and 1aa5b755a.

However, the indentation is not correct, so `myshape` is not assigned properly. This corrects the issue.

Reported in the forum: [[Arch | importOBJ] local variable 'myshape' referenced before assignment](https://forum.freecadweb.org/viewtopic.php?f=23&t=48592)

---

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists