### PR TITLE
Gui: automatically activate the DlgExpressionInput dialog; fixes #4384

### DIFF
--- a/src/Gui/DlgExpressionInput.cpp
+++ b/src/Gui/DlgExpressionInput.cpp
@@ -107,7 +107,6 @@ DlgExpressionInput::DlgExpressionInput(const App::ObjectIdentifier & _path,
             this->resize(ui->expression->width()+18,this->height());
     }
     ui->expression->setFocus();
-    ui->expression->activateWindow();
 }
 
 DlgExpressionInput::~DlgExpressionInput()
@@ -266,6 +265,13 @@ void DlgExpressionInput::mousePressEvent(QMouseEvent* ev)
         if (!on)
             this->reject();
     }
+}
+
+void DlgExpressionInput::show()
+{
+    QDialog::show();
+    this->activateWindow();
+    ui->expression->selectAll();
 }
 
 void DlgExpressionInput::showEvent(QShowEvent* ev)

--- a/src/Gui/DlgExpressionInput.h
+++ b/src/Gui/DlgExpressionInput.h
@@ -63,6 +63,9 @@ public:
 
     bool eventFilter(QObject *obj, QEvent *event);
 
+public Q_SLOTS:
+    void show();
+
 protected:
     void showEvent(QShowEvent*);
     void mouseReleaseEvent(QMouseEvent*);


### PR DESCRIPTION
This PR fixes issue #4384 on MacOS by overriding the QDialog::show method and calling activateWindow and ui->expression->selectAll. On other platforms this maybe redundant. Please check if that call does not have any side effects on those platforms.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [x] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists


---
