### PR TITLE
[PATH] don't generate gcode if op isn't valid. Don't plunge to start height if safe and clearance height are the same.

### DIFF
--- a/src/Mod/Path/App/Area.cpp
+++ b/src/Mod/Path/App/Area.cpp
@@ -3217,6 +3217,9 @@ void Area::toPath(Toolpath &path, const std::list<TopoDS_Shape> &shapes,
     wires = sortWires(shapes,_pstart!=0,&pstart,pend,&stepdown_hint,
             PARAM_REF(PARAM_FARG,AREA_PARAMS_ARC_PLANE),
             PARAM_FIELDS(PARAM_FARG,AREA_PARAMS_SORT));
+    
+    if (wires.size() == 0)
+        return;
 
     short currentArcPlane = arc_plane;
     if (preamble) {
@@ -3269,17 +3272,14 @@ void Area::toPath(Toolpath &path, const std::list<TopoDS_Shape> &shapes,
     p = pstart;
 
     // rapid horizontal move to start point
-    if(fabs((p.*getter)()-retraction) > Precision::Confusion()) {
-        // check if last is equal to current, if it is change last so the initial G0 is still emitted
-        gp_Pnt tmpPlast = plast;
-        (tmpPlast.*setter)((p.*getter)());
-        if(_pstart && p.IsEqual(tmpPlast, Precision::Confusion())){
-            plast.SetCoord(10.0, 10.0, 10.0);
-            (plast.*setter)(retraction);
-        }
-        (p.*setter)(retraction);
-        addGCode(false,path,plast,p,"G0");
+    gp_Pnt tmpPlast = plast;
+    (tmpPlast.*setter)((p.*getter)());
+    if(_pstart && p.IsEqual(tmpPlast, Precision::Confusion())){
+        plast.SetCoord(10.0, 10.0, 10.0);
+        (plast.*setter)(retraction);
     }
+    (p.*setter)(retraction);
+    addGCode(false,path,plast,p,"G0");
 
 
     plast = p;

--- a/src/Mod/Path/PathScripts/PathAreaOp.py
+++ b/src/Mod/Path/PathScripts/PathAreaOp.py
@@ -487,7 +487,7 @@ class ObjectOp(PathOp.ObjectOp):
                 sims.append(sim)
             # Eif
 
-            if self.areaOpRetractTool(obj) and self.endVector is not None:
+            if self.areaOpRetractTool(obj) and self.endVector is not None and len(self.commandlist) > 1:
                 self.endVector[2] = obj.ClearanceHeight.Value
                 self.commandlist.append(Path.Command('G0', {'Z': obj.ClearanceHeight.Value, 'F': self.vertRapid}))
 

--- a/src/Mod/Path/PathScripts/PathOp.py
+++ b/src/Mod/Path/PathScripts/PathOp.py
@@ -514,10 +514,6 @@ class ObjectOp(object):
 
         result = self.opExecute(obj)  # pylint: disable=assignment-from-no-return
 
-        if FeatureHeights & self.opFeatures(obj):
-            # Let's finish by rapid to clearance...just for safety
-            self.commandlist.append(Path.Command("G0", {"Z": obj.ClearanceHeight.Value}))
-
         path = Path.Path(self.commandlist)
         obj.Path = path
         obj.CycleTime = self.getCycleTimeEstimate(obj)


### PR DESCRIPTION
…if safe and clearance height are the same.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
