### PR TITLE
[Sketcher] add python command sketch.getGeoVertexIndex(int index) -- …

### DIFF
--- a/src/Mod/Sketcher/App/SketchObjectPy.xml
+++ b/src/Mod/Sketcher/App/SketchObjectPy.xml
@@ -178,6 +178,13 @@ If there is no such constraint an exception is raised.
         </UserDocu>
       </Documentation>
     </Methode>
+    <Methode Name="getGeoVertexIndex" Const="true">
+      <Documentation>
+        <UserDocu>
+          (geoId, posId) = getGeoVertexIndex(index) - retrieve the GeoId and PosId of a point in the sketch
+        </UserDocu>
+      </Documentation>
+    </Methode>
     <Methode Name="getAxis" Const="true">
       <Documentation>
         <UserDocu>

--- a/src/Mod/Sketcher/App/SketchObjectPyImp.cpp
+++ b/src/Mod/Sketcher/App/SketchObjectPyImp.cpp
@@ -941,6 +941,22 @@ PyObject* SketchObjectPy::movePoint(PyObject *args)
 
 }
 
+PyObject* SketchObjectPy::getGeoVertexIndex(PyObject *args)
+{
+    int index;
+    if (!PyArg_ParseTuple(args, "i", &index))
+        return 0;
+
+    SketchObject* obj = this->getSketchObjectPtr();
+    int geoId;
+    PointPos posId;
+    obj->getGeoVertexIndex(index, geoId, posId);
+    Py::Tuple tuple(2);
+    tuple.setItem(0, Py::Long(geoId));
+    tuple.setItem(1, Py::Long(posId));
+    return Py::new_reference_to(tuple);
+}
+
 PyObject* SketchObjectPy::getPoint(PyObject *args)
 {
     int GeoId, PointType;


### PR DESCRIPTION
…returns tuple (geoId, posId) of vertex at that index in the sketch. usage example: (geoId, posId) = App.ActiveDocument.Sketch.getGeoVertexIndex(int(Gui.Selection.getSelectionEx()[0].SubElementNames[0][6:])-1)

https://forum.freecadweb.org/viewtopic.php?f=8&t=48707&sid=df3795eac5f179451a7b0dce89d728c6

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
