### PR TITLE
Arch: improve import and export IFC preferences pages

### DIFF
--- a/src/Mod/Arch/Resources/ui/preferences-ifc-export.ui
+++ b/src/Mod/Arch/Resources/ui/preferences-ifc-export.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>463</width>
-    <height>466</height>
+    <width>630</width>
+    <height>614</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -17,20 +17,38 @@
    <property name="spacing">
     <number>6</number>
    </property>
-   <property name="margin">
+   <property name="leftMargin">
+    <number>9</number>
+   </property>
+   <property name="topMargin">
+    <number>9</number>
+   </property>
+   <property name="rightMargin">
+    <number>9</number>
+   </property>
+   <property name="bottomMargin">
     <number>9</number>
    </property>
    <item>
-    <widget class="Gui::PrefCheckBox" name="checkBox_7">
-     <property name="text">
-      <string>Show this dialog when exporting</string>
+    <widget class="QGroupBox" name="group_box_0">
+     <property name="title">
+      <string>General options</string>
      </property>
-     <property name="prefEntry" stdset="0">
-      <cstring>ifcShowDialog</cstring>
-     </property>
-     <property name="prefPath" stdset="0">
-      <cstring>Mod/Arch</cstring>
-     </property>
+     <layout class="QVBoxLayout" name="verticalLayout">
+      <item>
+       <widget class="Gui::PrefCheckBox" name="checkBox_7">
+        <property name="text">
+         <string>Show this dialog when exporting</string>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>ifcShowDialog</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Arch</cstring>
+        </property>
+       </widget>
+      </item>
+     </layout>
     </widget>
    </item>
    <item>
@@ -43,6 +61,12 @@
        <layout class="QHBoxLayout" name="horizontalLayout_2">
         <item>
          <widget class="QLabel" name="label_2">
+          <property name="toolTip">
+           <string>The type of objects that you wish to export:
+- Standard model: solid objects.
+- Structural analysis: wireframe model for structural calculations.
+- Standard + structural: both types of models.</string>
+          </property>
           <property name="text">
            <string>Export type</string>
           </property>
@@ -51,7 +75,10 @@
         <item>
          <widget class="Gui::PrefComboBox" name="comboBox">
           <property name="toolTip">
-           <string>The type of objects you wish to export: Standard (solid objects), wireframe model for structural analysis, or both in a same model</string>
+           <string>The type of objects that you wish to export:
+- Standard model: solid objects.
+- Structural analysis: wireframe model for structural calculations.
+- Standard + structural: both types of models.</string>
           </property>
           <property name="prefEntry" stdset="0">
            <cstring>ifcExportModel</cstring>
@@ -322,6 +349,14 @@ A building storey is not mandatory but a common practice to have at least one in
        <layout class="QHBoxLayout" name="horizontalLayout">
         <item>
          <widget class="QLabel" name="label">
+          <property name="toolTip">
+           <string>The units you want your IFC file to be exported to.
+
+Note that IFC files are ALWAYS written in metric units; imperial units
+are only a conversion factor applied on top of them.
+However, some BIM applications will use this factor to choose which
+unit to work with when opening the file.</string>
+          </property>
           <property name="text">
            <string>IFC file units</string>
           </property>
@@ -330,7 +365,12 @@ A building storey is not mandatory but a common practice to have at least one in
         <item>
          <widget class="Gui::PrefComboBox" name="comboBox_3">
           <property name="toolTip">
-           <string>The units you want your IFC file to be exported to. Note that IFC file are ALWAYS written in metric units. Imperial units are only a conversion applied on top of it. But some BIM applications will use this to choose which unit to work with when opening the file.</string>
+           <string>The units you want your IFC file to be exported to.
+
+Note that IFC files are ALWAYS written in metric units; imperial units
+are only a conversion factor applied on top of them.
+However, some BIM applications will use this factor to choose which
+unit to work with when opening the file.</string>
           </property>
           <property name="prefEntry" stdset="0">
            <cstring>ifcUnit</cstring>

--- a/src/Mod/Arch/Resources/ui/preferences-ifc.ui
+++ b/src/Mod/Arch/Resources/ui/preferences-ifc.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>463</width>
-    <height>577</height>
+    <width>555</width>
+    <height>689</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -17,7 +17,16 @@
    <property name="spacing">
     <number>6</number>
    </property>
-   <property name="margin">
+   <property name="leftMargin">
+    <number>9</number>
+   </property>
+   <property name="topMargin">
+    <number>9</number>
+   </property>
+   <property name="rightMargin">
+    <number>9</number>
+   </property>
+   <property name="bottomMargin">
     <number>9</number>
    </property>
    <item>
@@ -79,6 +88,49 @@ One object is the base object, the others are clones.</string>
       <item>
        <layout class="QHBoxLayout" name="horizontalLayout">
         <item>
+         <widget class="Gui::PrefSpinBox" name="spinBox">
+          <property name="maximumSize">
+           <size>
+            <width>120</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="toolTip">
+           <string>EXPERIMENTAL
+The number of cores to use in multicore mode.
+Keep 0 to disable multicore mode.
+The maximum value should be your number of cores minus 1,
+for example, 3 if you have a 4-core CPU.
+
+Set it to 1 to use multicore mode in single-core mode; this is safer
+if you start getting crashes when you set multiple cores.</string>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>ifcMulticore</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/Arch</cstring>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="label">
+          <property name="toolTip">
+           <string>EXPERIMENTAL
+The number of cores to use in multicore mode.
+Keep 0 to disable multicore mode.
+The maximum value should be your number of cores minus 1,
+for example, 3 if you have a 4-core CPU.
+
+Set it to 1 to use multicore mode in single-core mode; this is safer
+if you start getting crashes when you set multiple cores.</string>
+          </property>
+          <property name="text">
+           <string>Number of cores to use (experimental)</string>
+          </property>
+         </widget>
+        </item>
+        <item>
          <spacer name="horizontalSpacer">
           <property name="orientation">
            <enum>Qt::Horizontal</enum>
@@ -93,26 +145,6 @@ One object is the base object, the others are clones.</string>
            </size>
           </property>
          </spacer>
-        </item>
-        <item>
-         <widget class="QLabel" name="label">
-          <property name="text">
-           <string>Number of cores to use:</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="Gui::PrefSpinBox" name="spinBox">
-          <property name="toolTip">
-           <string>EXPERIMENTAL - The number of cores to use in multicore mode. Keep 0 to disable multicore mode, or 1 to use multicore mode in single-core mode (safer if you get crashes). Max value should be your number of cores subtracted by 1, ex: 3 if you have a quad-core CPU.</string>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>ifcMulticore</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>Mod/Arch</cstring>
-          </property>
-         </widget>
         </item>
        </layout>
       </item>
@@ -428,10 +460,13 @@ FreeCAD object properties</string>
       <item>
        <widget class="Gui::PrefCheckBox" name="checkBox">
         <property name="toolTip">
-         <string>If this option is checked, the default Project, Site, Building, and Storeys objects that are usually found in an IFC file are not imported, and all objects are placed in a Group. Buildings and Storeys are still imported if there is more than one.</string>
+         <string>If this option is checked, the default 'Project', 'Site', 'Building', and 'Storeys'
+objects that are usually found in an IFC file are not imported, and all objects
+are placed in a 'Group' instead.
+'Buildings' and 'Storeys' are still imported if there is more than one.</string>
         </property>
         <property name="text">
-         <string>Replace Project, Site, Building, and Storey by Group</string>
+         <string>Replace 'Project', 'Site', 'Building', and 'Storey' with 'Group'</string>
         </property>
         <property name="prefEntry" stdset="0">
          <cstring>ifcReplaceProject</cstring>


### PR DESCRIPTION
Some tooltips are made more readable by adding newlines.

For `IFC import`, better tooltip for the `Number of cores` option; also the `Replace 'Project'...` option.

For `IFC export`, better tooltip for the `Export type`; also `IFC file units`. Also add `General options` in case other options are added.

---

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists