### PR TITLE
Add Mark property to ArchRebar object

### DIFF
--- a/src/Mod/Arch/ArchRebar.py
+++ b/src/Mod/Arch/ArchRebar.py
@@ -198,6 +198,13 @@ class _Rebar(ArchComponent.Component):
         if not "TotalLength" in pl:
             obj.addProperty("App::PropertyDistance", "TotalLength", "Rebar", QT_TRANSLATE_NOOP("App::Property","Total length of all rebars"))
             obj.setEditorMode("TotalLength", 1)
+        if not "Mark" in pl:
+            obj.addProperty(
+                "App::PropertyString",
+                "Mark",
+                "Rebar",
+                QT_TRANSLATE_NOOP("App::Property", "The rebar mark"),
+            )
         self.Type = "Rebar"
 
     def onDocumentRestored(self,obj):


### PR DESCRIPTION
As discussed here:
https://forum.freecadweb.org/viewtopic.php?f=23&t=44580&p=418377#p418630
And required for reinforcement drawing/dimensioning.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
