### PR TITLE
Draft: makeLayer, small adjustments to keep compatibility with old behavior

### DIFF
--- a/src/Mod/Draft/draftmake/make_layer.py
+++ b/src/Mod/Draft/draftmake/make_layer.py
@@ -249,8 +249,14 @@ def makeLayer(name=None, linecolor=None, drawstyle=None,
     """Create a Layer. DEPRECATED. Use 'make_layer'."""
     utils.use_instead("make_layer")
 
+    if not drawstyle:
+        drawstyle = "Solid"
+
+    if not transparency:
+        transparency = 0
+
     return make_layer(name,
-                      linecolor, shapecolor,
+                      line_color=linecolor, shape_color=shapecolor,
                       draw_style=drawstyle, transparency=transparency)
 
 ## @}


### PR DESCRIPTION
This is missing from the migration of the `Layer` code done in #3719 (831e517717).

In the older `makeLayer` function, the parameters `drawstyle` and `transparency` could be `None`. In the new `make_layer` function, `drawstyle` must be an explicit string, and `transparency` must be a number. If not provided, they use default values.

Without these changes, empty arguments in the old function will fail, because the default `None` values of `drawstyle` and `transparency` are passed to `make_layer`, which doesn't accept them.
```py
new_layer = Draft.makeLayer()
```

Incidentally, this affects the BIM Workbench, as explained in the thread [Using Layers, "Draft" is not defined](https://forum.freecadweb.org/viewtopic.php?f=23&t=48933), and in yorikvanhavre/BIM_Workbench#57.

---

This only affects the old function; empty argument in the new function do not produce an error.
```py
new_layer = Draft.make_layer()
```

---

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).