### PR TITLE
Part: move Shape view properties to Part design preferences

### DIFF
--- a/src/Mod/Part/Gui/AppPartGui.cpp
+++ b/src/Mod/Part/Gui/AppPartGui.cpp
@@ -214,9 +214,9 @@ PyMOD_INIT_FUNC(PartGui)
     // register preferences pages
     (void)new Gui::PrefPageProducer<PartGui::DlgSettingsGeneral>      ( QT_TRANSLATE_NOOP("QObject","Part design") );
     (void)new Gui::PrefPageProducer<PartGui::DlgSettings3DViewPart>   ( QT_TRANSLATE_NOOP("QObject","Part design") );
+    (void)new Gui::PrefPageProducer<PartGui::DlgSettingsObjectColor>  ( QT_TRANSLATE_NOOP("QObject","Part design") );
     (void)new Gui::PrefPageProducer<PartGui::DlgImportExportIges>     ( QT_TRANSLATE_NOOP("QObject","Import-Export") );
     (void)new Gui::PrefPageProducer<PartGui::DlgImportExportStep>     ( QT_TRANSLATE_NOOP("QObject","Import-Export") );
-    (void)new Gui::PrefPageProducer<PartGui::DlgSettingsObjectColor>  ( QT_TRANSLATE_NOOP("QObject","Display") );
     Gui::ViewProviderBuilder::add(
         Part::PropertyPartShape::getClassTypeId(),
         PartGui::ViewProviderPart::getClassTypeId());

--- a/src/Mod/Part/Gui/DlgSettingsObjectColor.ui
+++ b/src/Mod/Part/Gui/DlgSettingsObjectColor.ui
@@ -7,17 +7,17 @@
     <x>0</x>
     <y>0</y>
     <width>476</width>
-    <height>336</height>
+    <height>378</height>
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Part colors</string>
+   <string>Shape appearance</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <widget class="QGroupBox" name="groupBoxDefaultColors">
      <property name="title">
-      <string>Default Part colors</string>
+      <string>Default Shape view properties</string>
      </property>
      <layout class="QHBoxLayout" name="horizontalLayout">
       <item>


### PR DESCRIPTION
Currently the default visual properties, line width, line color, vertex size, vertex color, and others, of new Shapes are "hidden" in the last tab under the "Display" category in the program's Preferences.

We move this last tab to the "Part design" category, which only appears after the Part or PartDesign workbenches have been loaded for the first time. The second and third tab should probably be merged so that there isn't much empty space in the page, as all these properties belong to the basic viewprovider of every `Part::Feature` object.

This means that of the three preferences pages
* `DlgSettingsGeneral.ui`
* `DlgSettings3DViewPart.ui`
* `DlgSettingsObjectColor.ui`

the last two should probably become only one, `DlgSettingsObjectViewProperties.ui`, perhaps. We notice that the name "ObjectColor" is misleading as the properties also include widths and sizes, not only colors.

Forum discussion: [[ Bug ] BIM_Setup: LineWidth not handled properly](https://forum.freecadweb.org/viewtopic.php?f=23&t=48911)

---

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists