### PR TITLE
[Win installer] remove FindProc plugin

### DIFF
--- a/src/WindowsInstaller/Settings.nsh
+++ b/src/WindowsInstaller/Settings.nsh
@@ -25,7 +25,7 @@ SetCompressor /SOLID lzma
 
 !define APP_VERSION "${APP_VERSION_MAJOR}.${APP_VERSION_MINOR}.${APP_VERSION_REVISION}${APP_EMERGENCY_DOT}${APP_VERSION_EMERGENCY}" # Version to display
 
-!define COPYRIGHT_YEAR 2019
+!define COPYRIGHT_YEAR 2020
 
 #--------------------------------
 # Installer file name

--- a/src/WindowsInstaller/include/init.nsh
+++ b/src/WindowsInstaller/include/init.nsh
@@ -161,11 +161,14 @@ Function un.onInit
   !insertmacro MULTIUSER_UNINIT
 
   # Check that FreeCAD is not currently running
-  FindProcDLL::FindProc "${BIN_FREECAD}"
-  ${if} $R0 == "1"
+  ${nsProcess::FindProcess} ${BIN_FREECAD} $R0
+  # if running result is '0', if not running it is '603'
+  ${if} $R0 == "0"
    MessageBox MB_OK|MB_ICONSTOP "$(UnInstallRunning)" /SD IDOK
    Abort
   ${endif}
+  # plugin must be unloaded
+  ${nsProcess::Unload}
   
   # check if it is a 64bit system
   ${if} ${RunningX64}

--- a/src/WindowsInstaller/setup/configure.nsh
+++ b/src/WindowsInstaller/setup/configure.nsh
@@ -43,7 +43,7 @@ Section -InstallData
   
   WriteRegStr SHCTX ${APP_UNINST_KEY} "UninstallString" '"$INSTDIR\${SETUP_UNINSTALLER}"'
   WriteRegStr SHCTX ${APP_UNINST_KEY} "DisplayVersion" "${APP_VERSION}"
-  WriteRegStr SHCTX ${APP_UNINST_KEY} "DisplayIcon" "$INSTDIR\bin\${APP_NAME}.exe"
+  WriteRegStr SHCTX ${APP_UNINST_KEY} "DisplayIcon" "$INSTDIR\${APP_RUN}"
   WriteRegStr SHCTX ${APP_UNINST_KEY} "URLUpdateInfo" "${APP_WEBPAGE}"
   WriteRegStr SHCTX ${APP_UNINST_KEY} "URLInfoAbout" "https://www.freecadweb.org/"
   WriteRegStr SHCTX ${APP_UNINST_KEY} "Publisher" "${APP_NAME} Team"


### PR DESCRIPTION
there is no need to have 2 plugins doing the same

moreover FindProc does no longer work with recent Windows 10 versions, so it must be removed anyway.
The plugin "nsProcess" is already used when installing, so use it also for uninstalling.

- configure.nsh: small code optimization
- Settings.nsh: update year