### PR TITLE
[GUI] don't show by default report view for warnings

### DIFF
--- a/src/Gui/DlgReportView.ui
+++ b/src/Gui/DlgReportView.ui
@@ -116,7 +116,7 @@ on-screen while displaying the warning</string>
          <string>Show report view on warning</string>
         </property>
         <property name="checked">
-         <bool>true</bool>
+         <bool>false</bool>
         </property>
         <property name="prefEntry" stdset="0">
          <cstring>checkShowReportViewOnWarning</cstring>

--- a/src/Gui/ReportView.cpp
+++ b/src/Gui/ReportView.cpp
@@ -269,7 +269,7 @@ bool ReportOutputObserver::eventFilter(QObject *obj, QEvent *event)
                     GetGroup("BaseApp")->GetGroup("Preferences")->GetGroup("OutputWindow");
             ReportHighlighter::Paragraph msgType = cr->messageType();
             if (msgType == ReportHighlighter::Warning){
-                if (group->GetBool("checkShowReportViewOnWarning", true)) {
+                if (group->GetBool("checkShowReportViewOnWarning", false)) {
                     showReportView();
                 }
             } else if (msgType == ReportHighlighter::Error){
@@ -563,7 +563,7 @@ void ReportOutput::onToggleError()
 }
 
 void ReportOutput::onToggleShowReportViewOnWarning(){
-    bool show = getWindowParameter()->GetBool("checkShowReportViewOnWarning", true);
+    bool show = getWindowParameter()->GetBool("checkShowReportViewOnWarning", false);
     getWindowParameter()->SetBool("checkShowReportViewOnWarning", !show);
 }
 
@@ -573,12 +573,12 @@ void ReportOutput::onToggleShowReportViewOnError(){
 }
 
 void ReportOutput::onToggleShowReportViewOnNormalMessage(){
-    bool show = getWindowParameter()->GetBool("checkShowReportViewOnNormalMessage", true);
+    bool show = getWindowParameter()->GetBool("checkShowReportViewOnNormalMessage", false);
     getWindowParameter()->SetBool("checkShowReportViewOnNormalMessage", !show);
 }
 
 void ReportOutput::onToggleShowReportViewOnLogMessage(){
-    bool show = getWindowParameter()->GetBool("checkShowReportViewOnLogMessage", true);
+    bool show = getWindowParameter()->GetBool("checkShowReportViewOnLogMessage", false);
     getWindowParameter()->SetBool("checkShowReportViewOnLogMessage", !show);
 }
 


### PR DESCRIPTION
don't show by default report view for warnings, see this forum thread: 
https://forum.freecadweb.org/viewtopic.php?f=17&t=48962