### PR TITLE
[Win installer] add missing translations

### DIFF
--- a/src/WindowsInstaller/setup/install.nsh
+++ b/src/WindowsInstaller/setup/install.nsh
@@ -28,22 +28,30 @@ Section -ProgramFiles SecProgramFiles
   InitPluginsDir
   
   # Binaries
-  SetOutPath "$INSTDIR"
+  SetOutPath "$INSTDIR\bin"
   # recursively copy all files under bin
-  File /r "${FILES_FREECAD}\bin"
+  File /r "${FILES_FREECAD}\bin\*.*"
   
   # MSVC redistributable DLLs
   SetOutPath "$INSTDIR\bin"
   File "${FILES_DEPS}\*.*"
   
   # Others
+  SetOutPath "$INSTDIR\data"
+  File /r "${FILES_FREECAD}\data\*.*"
+  SetOutPath "$INSTDIR\doc"
+  File /r "${FILES_FREECAD}\doc\*.*"
+  SetOutPath "$INSTDIR\Ext"
+  File /r "${FILES_FREECAD}\Ext\*.*"
+  SetOutPath "$INSTDIR\lib"
+  File /r "${FILES_FREECAD}\lib\*.*"
+  SetOutPath "$INSTDIR\Mod"
+  File /r "${FILES_FREECAD}\Mod\*.*"
+  SetOutPath "$INSTDIR\resources"
+  File /r "${FILES_FREECAD}\resources\*.*"
+  SetOutPath "$INSTDIR\translations"
+  File /r "${FILES_FREECAD}\translations\*.*"
   SetOutPath "$INSTDIR"
-  File /r "${FILES_FREECAD}\data"
-  File /r "${FILES_FREECAD}\doc"
-  File /r "${FILES_FREECAD}\Ext"
-  File /r "${FILES_FREECAD}\lib"
-  File /r "${FILES_FREECAD}\Mod"
-  File /r "${FILES_FREECAD}\resources"
   File /r "${FILES_THUMBS}"
     
   # Create uninstaller


### PR DESCRIPTION
the translation folder (the one with the *.pak files) was missing

- also add safe guards that really only the desired subfolders will be part of the installer not also files that may exist in the base folder