### PR TITLE
[TD] get rid of trailing newlines

### DIFF
--- a/src/Mod/TechDraw/Gui/ViewProviderPage.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderPage.cpp
@@ -222,10 +222,11 @@ bool ViewProviderPage::onDelete(const std::vector<std::string> &)
         QString bodyMessage;
         QTextStream bodyMessageStream(&bodyMessage);
         bodyMessageStream << qApp->translate("Std_Delete",
-            "The page is not empty, therefore the\nfollowing referencing objects might be lost.\n\n"
-            "Are you sure you want to continue?");
+            "The page is not empty, therefore the\nfollowing referencing objects might be lost:");
+        bodyMessageStream << '\n';
         for (auto ObjIterator : objs)
             bodyMessageStream << '\n' << QString::fromUtf8(ObjIterator->Label.getValue());
+        bodyMessageStream << "\n\nAre you sure you want to continue?";
         // show and evaluate the dialog
         int DialogResult = QMessageBox::warning(Gui::getMainWindow(),
             qApp->translate("Std_Delete", "Object dependencies"), bodyMessage,

--- a/src/Mod/TechDraw/Gui/ViewProviderPage.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderPage.cpp
@@ -226,7 +226,7 @@ bool ViewProviderPage::onDelete(const std::vector<std::string> &)
         bodyMessageStream << '\n';
         for (auto ObjIterator : objs)
             bodyMessageStream << '\n' << QString::fromUtf8(ObjIterator->Label.getValue());
-        bodyMessageStream << "\n\nAre you sure you want to continue?";
+        bodyMessageStream << QObject::tr("\n\nAre you sure you want to continue?");
         // show and evaluate the dialog
         int DialogResult = QMessageBox::warning(Gui::getMainWindow(),
             qApp->translate("Std_Delete", "Object dependencies"), bodyMessage,

--- a/src/Mod/TechDraw/Gui/ViewProviderPage.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderPage.cpp
@@ -166,7 +166,7 @@ void ViewProviderPage::removeMDIView(void)
 void ViewProviderPage::updateData(const App::Property* prop)
 {
     auto page = getDrawPage();
-    if(!page) {
+    if (!page) {
         Gui::ViewProviderDocumentObject::updateData(prop);
         return;
     }
@@ -179,18 +179,18 @@ void ViewProviderPage::updateData(const App::Property* prop)
        signalChangeIcon();
     //if the template is changed, rebuild the visual
     } else if (prop == &(page->Template)) {
-       if(m_mdiView && 
+       if (m_mdiView && 
           !page->isUnsetting()) {
             m_mdiView->matchSceneRectToTemplate();
             m_mdiView->updateTemplate();
         }
     } else if (prop == &(page->Label)) {
-       if(m_mdiView && 
+       if (m_mdiView && 
           !page->isUnsetting()) {
            m_mdiView->setTabText(page->Label.getValue());
        }
     } else if (prop == &page->Views) {
-        if(m_mdiView && !page->isUnsetting()) 
+        if (m_mdiView && !page->isUnsetting()) 
             m_mdiView->fixOrphans();
     }
 
@@ -319,7 +319,7 @@ std::vector<App::DocumentObject*> ViewProviderPage::claimChildren(void) const
     App::DocumentObject *templateFeat = 0;
     templateFeat = getDrawPage()->Template.getValue();
 
-    if(templateFeat) {
+    if (templateFeat) {
         temp.push_back(templateFeat);
     }
 
@@ -336,7 +336,7 @@ std::vector<App::DocumentObject*> ViewProviderPage::claimChildren(void) const
     const std::vector<App::DocumentObject *> &views = getDrawPage()->Views.getValues();
 
     try {
-      for(std::vector<App::DocumentObject *>::const_iterator it = views.begin(); it != views.end(); ++it) {
+      for (std::vector<App::DocumentObject *>::const_iterator it = views.begin(); it != views.end(); ++it) {
           TechDraw::DrawView* featView = dynamic_cast<TechDraw::DrawView*> (*it);
           App::DocumentObject *docObj = *it;
           //DrawRichAnno with no parent is child of Page
@@ -351,14 +351,14 @@ std::vector<App::DocumentObject*> ViewProviderPage::claimChildren(void) const
           }
 
           // Don't collect if dimension, projection group item, hatch or member of ClipGroup as these should be grouped elsewhere
-          if(docObj->isDerivedFrom(TechDraw::DrawProjGroupItem::getClassTypeId())    ||
-             docObj->isDerivedFrom(TechDraw::DrawViewDimension::getClassTypeId())    ||
-             docObj->isDerivedFrom(TechDraw::DrawHatch::getClassTypeId())            ||
-             docObj->isDerivedFrom(TechDraw::DrawViewBalloon::getClassTypeId())      ||
-             docObj->isDerivedFrom(TechDraw::DrawRichAnno::getClassTypeId())         ||
-             docObj->isDerivedFrom(TechDraw::DrawLeaderLine::getClassTypeId())       ||
-             docObj->isDerivedFrom(TechDraw::DrawWeldSymbol::getClassTypeId())       ||
-             (featView && featView->isInClip()) )
+          if (docObj->isDerivedFrom(TechDraw::DrawProjGroupItem::getClassTypeId())    ||
+              docObj->isDerivedFrom(TechDraw::DrawViewDimension::getClassTypeId())    ||
+              docObj->isDerivedFrom(TechDraw::DrawHatch::getClassTypeId())            ||
+              docObj->isDerivedFrom(TechDraw::DrawViewBalloon::getClassTypeId())      ||
+              docObj->isDerivedFrom(TechDraw::DrawRichAnno::getClassTypeId())         ||
+              docObj->isDerivedFrom(TechDraw::DrawLeaderLine::getClassTypeId())       ||
+              docObj->isDerivedFrom(TechDraw::DrawWeldSymbol::getClassTypeId())       ||
+              (featView && featView->isInClip()) )
               continue;
           else
               temp.push_back(*it);
@@ -392,7 +392,7 @@ MDIViewPage* ViewProviderPage::getMDIViewPage() const
 void ViewProviderPage::onChanged(const App::Property *prop)
 {
 //    if (prop == &(getDrawPage()->Template)) {
-//       if(m_mdiView) {
+//       if (m_mdiView) {
 //            m_mdiView->updateTemplate();
 //        }
 //    }
@@ -479,7 +479,7 @@ bool ViewProviderPage::canDelete(App::DocumentObject *obj) const
 void ViewProviderPage::onGuiRepaint(const TechDraw::DrawPage* dp) 
 {
     if (dp == getDrawPage()) {
-        if(!m_mdiView.isNull() &&
+        if (!m_mdiView.isNull() &&
            !getDrawPage()->isUnsetting()) {
             m_mdiView->fixOrphans();
         }

--- a/src/Mod/TechDraw/Gui/ViewProviderPage.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderPage.cpp
@@ -226,7 +226,7 @@ bool ViewProviderPage::onDelete(const std::vector<std::string> &)
         bodyMessageStream << '\n';
         for (auto ObjIterator : objs)
             bodyMessageStream << '\n' << QString::fromUtf8(ObjIterator->Label.getValue());
-        bodyMessageStream << QObject::tr("\n\nAre you sure you want to continue?");
+        bodyMessageStream << "\n\n" << QObject::tr("Are you sure you want to continue?");
         // show and evaluate the dialog
         int DialogResult = QMessageBox::warning(Gui::getMainWindow(),
             qApp->translate("Std_Delete", "Object dependencies"), bodyMessage,

--- a/src/Mod/TechDraw/Gui/ViewProviderProjGroup.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderProjGroup.cpp
@@ -240,7 +240,7 @@ std::vector<App::DocumentObject*> ViewProviderProjGroup::claimChildren(void) con
     std::vector<App::DocumentObject*> temp;
     const std::vector<App::DocumentObject *> &views = getObject()->Views.getValues();
     try {
-      for(std::vector<App::DocumentObject *>::const_iterator it = views.begin(); it != views.end(); ++it) {
+      for (std::vector<App::DocumentObject *>::const_iterator it = views.begin(); it != views.end(); ++it) {
           temp.push_back(*it);
       }
       return temp;

--- a/src/Mod/TechDraw/Gui/ViewProviderProjGroup.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderProjGroup.cpp
@@ -211,7 +211,7 @@ bool ViewProviderProjGroup::onDelete(const std::vector<std::string> &)
         bodyMessageStream << '\n';
         for (auto ObjIterator : objs)
             bodyMessageStream << '\n' << QString::fromUtf8(ObjIterator->Label.getValue());
-        bodyMessageStream << "\n\nAre you sure you want to continue?";
+        bodyMessageStream << QObject::tr("\n\nAre you sure you want to continue?");
         // show and evaluate dialog
         int DialogResult = QMessageBox::warning(Gui::getMainWindow(),
             qApp->translate("Std_Delete", "Object dependencies"), bodyMessage,

--- a/src/Mod/TechDraw/Gui/ViewProviderProjGroup.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderProjGroup.cpp
@@ -193,7 +193,8 @@ bool ViewProviderProjGroup::onDelete(const std::vector<std::string> &)
     // if there are section or detail views we cannot delete because this would break them
     if (!ViewList.empty()) {
         bodyMessageStream << qApp->translate("Std_Delete",
-            "The group cannot be deleted because its items have the following\nsection or detail views, or leader lines that would get broken:\n");
+            "The group cannot be deleted because its items have the following\nsection or detail views, or leader lines that would get broken:");
+        bodyMessageStream << '\n';
         for (auto ListIterator : ViewList)
             bodyMessageStream << '\n' << QString::fromUtf8(ListIterator.c_str());
         QMessageBox::warning(Gui::getMainWindow(),
@@ -206,10 +207,11 @@ bool ViewProviderProjGroup::onDelete(const std::vector<std::string> &)
     {
         // generate dialog
         bodyMessageStream << qApp->translate("Std_Delete",
-            "The projection group is not empty, therefore\nthe following referencing objects might be lost.\n\n"
-            "Are you sure you want to continue?\n");
+            "The projection group is not empty, therefore\nthe following referencing objects might be lost:");
+        bodyMessageStream << '\n';
         for (auto ObjIterator : objs)
             bodyMessageStream << '\n' << QString::fromUtf8(ObjIterator->Label.getValue());
+        bodyMessageStream << "\n\nAre you sure you want to continue?";
         // show and evaluate dialog
         int DialogResult = QMessageBox::warning(Gui::getMainWindow(),
             qApp->translate("Std_Delete", "Object dependencies"), bodyMessage,

--- a/src/Mod/TechDraw/Gui/ViewProviderProjGroup.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderProjGroup.cpp
@@ -211,7 +211,7 @@ bool ViewProviderProjGroup::onDelete(const std::vector<std::string> &)
         bodyMessageStream << '\n';
         for (auto ObjIterator : objs)
             bodyMessageStream << '\n' << QString::fromUtf8(ObjIterator->Label.getValue());
-        bodyMessageStream << QObject::tr("\n\nAre you sure you want to continue?");
+        bodyMessageStream << "\n\n" << QObject::tr("Are you sure you want to continue?");
         // show and evaluate dialog
         int DialogResult = QMessageBox::warning(Gui::getMainWindow(),
             qApp->translate("Std_Delete", "Object dependencies"), bodyMessage,

--- a/src/Mod/TechDraw/Gui/ViewProviderTemplate.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderTemplate.cpp
@@ -118,7 +118,7 @@ void ViewProviderTemplate::onChanged(const App::Property *prop)
     }
 
     if (prop == &Visibility) {
-        if(Visibility.getValue()) {
+        if (Visibility.getValue()) {
             show();
         } else {
             hide();

--- a/src/Mod/TechDraw/Gui/ViewProviderTemplate.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderTemplate.cpp
@@ -195,9 +195,9 @@ bool ViewProviderTemplate::onDelete(const std::vector<std::string> &)
     QString bodyMessage;
     QTextStream bodyMessageStream(&bodyMessage);
     bodyMessageStream << qApp->translate("Std_Delete",
-        "The following referencing objects might break.\n\n"
-        "Are you sure you want to continue?\n");
-    bodyMessageStream << '\n' << QString::fromUtf8(page->Label.getValue());
+        "The following referencing objects might break:");
+    bodyMessageStream << "\n\n" << QString::fromUtf8(page->Label.getValue());
+    bodyMessageStream << "\n\nAre you sure you want to continue?";
 
     // show and evaluate dialog
     int DialogResult = QMessageBox::warning(Gui::getMainWindow(),

--- a/src/Mod/TechDraw/Gui/ViewProviderTemplate.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderTemplate.cpp
@@ -197,7 +197,7 @@ bool ViewProviderTemplate::onDelete(const std::vector<std::string> &)
     bodyMessageStream << qApp->translate("Std_Delete",
         "The following referencing object might break:");
     bodyMessageStream << "\n\n" << QString::fromUtf8(page->Label.getValue());
-    bodyMessageStream << QObject::tr("\n\nAre you sure you want to continue?");
+    bodyMessageStream << "\n\n" << QObject::tr("Are you sure you want to continue?");
 
     // show and evaluate dialog
     int DialogResult = QMessageBox::warning(Gui::getMainWindow(),

--- a/src/Mod/TechDraw/Gui/ViewProviderTemplate.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderTemplate.cpp
@@ -195,9 +195,9 @@ bool ViewProviderTemplate::onDelete(const std::vector<std::string> &)
     QString bodyMessage;
     QTextStream bodyMessageStream(&bodyMessage);
     bodyMessageStream << qApp->translate("Std_Delete",
-        "The following referencing objects might break:");
+        "The following referencing object might break:");
     bodyMessageStream << "\n\n" << QString::fromUtf8(page->Label.getValue());
-    bodyMessageStream << "\n\nAre you sure you want to continue?";
+    bodyMessageStream << QObject::tr("\n\nAre you sure you want to continue?");
 
     // show and evaluate dialog
     int DialogResult = QMessageBox::warning(Gui::getMainWindow(),


### PR DESCRIPTION
as discussed with luzpaz in https://github.com/FreeCAD/FreeCAD/pull/3735
there shouldn't be trailing newlines in translated strings.

- Moreover fix the logic of the output dialog text. This is the new look: 
![FreeCAD_IQ7shVw8EE](https://user-images.githubusercontent.com/1828501/88482296-a4fbd900-cf60-11ea-92e1-86c325f2e4c3.png)
