### PR TITLE
[PD] allow multiselection on creation of pattern

### DIFF
--- a/src/Mod/PartDesign/Gui/Command.cpp
+++ b/src/Mod/PartDesign/Gui/Command.cpp
@@ -123,7 +123,7 @@ void UnifiedDatumCommand(Gui::Command &cmd, Base::Type type, std::string name)
             support.removeValue(pcActiveBody);
 
             auto Feat = pcActiveBody->getDocument()->getObject(FeatName.c_str());
-            if(!Feat) return;
+            if (!Feat) return;
 
             //test if current selection fits a mode.
             if (support.getSize() > 0) {
@@ -313,7 +313,7 @@ void CmdPartDesignShapeBinder::activated(int iMsg)
         support.removeValue(pcActiveBody);
 
         auto Feat = pcActiveBody->getObject(FeatName.c_str());
-        if(!Feat) return;
+        if (!Feat) return;
 
         //test if current selection fits a mode.
         if (support.getSize() > 0) {
@@ -355,30 +355,30 @@ void CmdPartDesignSubShapeBinder::activated(int iMsg)
     App::DocumentObject *parent = 0;
     std::string parentSub;
     std::map<App::DocumentObject *, std::vector<std::string> > values;
-    for(auto &sel : Gui::Selection().getCompleteSelection(0)) {
-        if(!sel.pObject) continue;
+    for (auto &sel : Gui::Selection().getCompleteSelection(0)) {
+        if (!sel.pObject) continue;
         auto &subs = values[sel.pObject];
-        if(sel.SubName && sel.SubName[0])
+        if (sel.SubName && sel.SubName[0])
             subs.emplace_back(sel.SubName);
     }
 
     std::string FeatName;
     PartDesign::Body *pcActiveBody = PartDesignGui::getBody(false,true,true,&parent,&parentSub);
     FeatName = getUniqueObjectName("Binder",pcActiveBody);
-    if(parent) {
+    if (parent) {
         decltype(values) links;
-        for(auto &v : values) {
+        for (auto &v : values) {
             App::DocumentObject *obj = v.first;
-            if(obj != parent) {
+            if (obj != parent) {
                 auto &subs = links[obj];
                 subs.insert(subs.end(),v.second.begin(),v.second.end());
                 continue;
             }
-            for(auto &sub : v.second) {
+            for (auto &sub : v.second) {
                 auto link = obj;
                 auto linkSub = parentSub;
                 parent->resolveRelativeLink(linkSub,link,sub);
-                if(link && link != pcActiveBody)
+                if (link && link != pcActiveBody)
                     links[link].push_back(sub);
             }
         }
@@ -388,7 +388,7 @@ void CmdPartDesignSubShapeBinder::activated(int iMsg)
     PartDesign::SubShapeBinder *binder = 0;
     try {
         openCommand("Create SubShapeBinder");
-        if(pcActiveBody) {
+        if (pcActiveBody) {
             FCMD_OBJ_CMD(pcActiveBody,"newObject('PartDesign::SubShapeBinder','" << FeatName << "')");
             binder = dynamic_cast<PartDesign::SubShapeBinder*>(pcActiveBody->getObject(FeatName.c_str()));
         } else {
@@ -397,11 +397,11 @@ void CmdPartDesignSubShapeBinder::activated(int iMsg)
             binder = dynamic_cast<PartDesign::SubShapeBinder*>(
                     App::GetApplication().getActiveDocument()->getObject(FeatName.c_str()));
         }
-        if(!binder) return;
+        if (!binder) return;
         binder->setLinks(std::move(values));
         updateActive();
         commitCommand();
-    }catch(Base::Exception &e) {
+    } catch (Base::Exception &e) {
         e.ReportException();
         QMessageBox::critical(Gui::getMainWindow(), 
                 QObject::tr("Sub-Shape Binder"), QString::fromUtf8(e.what()));
@@ -637,7 +637,7 @@ void CmdPartDesignNewSketch::activated(int iMsg)
                 else if (!dlg.radioXRef->isChecked()) {
                     openCommand("Make copy");
                     std::string sub;
-                    if(FaceFilter.match())
+                    if (FaceFilter.match())
                         sub = FaceFilter.Result[0][0].getSubNames()[0];
                     auto copy = PartDesignGui::TaskFeaturePick::makeCopy(obj, sub, dlg.radioIndependent->isChecked());
 
@@ -646,7 +646,7 @@ void CmdPartDesignNewSketch::activated(int iMsg)
                     else if (pcActivePart)
                         pcActivePart->addObject(copy);
 
-                    if(PlaneFilter.match())
+                    if (PlaneFilter.match())
                         supportString = getObjectCmd(copy,"(",",'')");
                     else
                         //it is ensured that only a single face is selected, hence it must always be Face1 of the shapebinder
@@ -817,7 +817,7 @@ void CmdPartDesignNewSketch::activated(int iMsg)
                 }
             }
 
-            if(dlg)
+            if (dlg)
                 Gui::Control().closeDialog();
 
             Gui::Selection().clearSelection();
@@ -858,10 +858,10 @@ void finishFeature(const Gui::Command* cmd, App::DocumentObject *Feat,
         cmd->updateActive();
 
     auto base = dynamic_cast<PartDesign::Feature*>(Feat);
-    if(base)
+    if (base)
         base = dynamic_cast<PartDesign::Feature*>(base->getBaseObject(true));
     App::DocumentObject *obj = base;
-    if(!obj)
+    if (!obj)
         obj = pcActiveBody;
 
     // Do this before calling setEdit to avoid to override the 'Shape preview' mode (#0003621)
@@ -911,9 +911,9 @@ unsigned validateSketches(std::vector<App::DocumentObject*>& sketches,
         } else if (!pcActiveBody->hasObject(*s)) {
             // Check whether this plane belongs to a body of the same part
             PartDesign::Body* b = PartDesign::Body::findBodyOf(*s);
-            if(!b)
+            if (!b)
                 status.push_back(PartDesignGui::TaskFeaturePick::notInBody);
-            else if(pcActivePart && pcActivePart->hasObject(b, true))
+            else if (pcActivePart && pcActivePart->hasObject(b, true))
                 status.push_back(PartDesignGui::TaskFeaturePick::otherBody);
             else
                 status.push_back(PartDesignGui::TaskFeaturePick::otherPart);
@@ -1001,7 +1001,7 @@ void prepareProfileBased(PartDesign::Body *pcActiveBody, Gui::Command* cmd, cons
         }
         else {
             std::ostringstream ss;
-            for(auto &s : subs)
+            for (auto &s : subs)
                 ss << "'" << s << "',";
             FCMD_OBJ_CMD(Feat,"Profile = (" << objCmd << ", [" << ss.str() << "])");   
         }         
@@ -1039,7 +1039,7 @@ void prepareProfileBased(PartDesign::Body *pcActiveBody, Gui::Command* cmd, cons
 
     auto accepter = [=](const std::vector<App::DocumentObject*>& features) -> bool {
 
-        if(features.empty())
+        if (features.empty())
             return false;
 
         return true;
@@ -1114,7 +1114,7 @@ void prepareProfileBased(PartDesign::Body *pcActiveBody, Gui::Command* cmd, cons
                 return;
         }
 
-        if(dlg)
+        if (dlg)
             Gui::Control().closeDialog();
 
         Gui::Selection().clearSelection();
@@ -1138,7 +1138,7 @@ void prepareProfileBased(PartDesign::Body *pcActiveBody, Gui::Command* cmd, cons
 
 void finishProfileBased(const Gui::Command* cmd, const Part::Feature* sketch, App::DocumentObject *Feat)
 {
-    if(sketch && sketch->isDerivedFrom(Part::Part2DObject::getClassTypeId()))
+    if (sketch && sketch->isDerivedFrom(Part::Part2DObject::getClassTypeId()))
         FCMD_OBJ_HIDE(sketch);
     finishFeature(cmd, Feat);
 }
@@ -1273,7 +1273,7 @@ void CmdPartDesignHole::activated(int iMsg)
     Gui::Command* cmd = this;
     auto worker = [cmd](Part::Feature* sketch, App::DocumentObject *Feat) {
 
-        if(!Feat) return;
+        if (!Feat) return;
 
         finishProfileBased(cmd, sketch, Feat);
         cmd->adjustCameraPosition();
@@ -1679,7 +1679,7 @@ void finishDressupFeature(const Gui::Command* cmd, const std::string& which,
 
     std::ostringstream str;
     str << '(' << Gui::Command::getObjectCmd(base) << ",[";
-    for(std::vector<std::string>::const_iterator it = SubNames.begin();it!=SubNames.end();++it){
+    for (std::vector<std::string>::const_iterator it = SubNames.begin();it!=SubNames.end();++it){
         str << "'" << *it << "',";
     }
     str << "])";
@@ -1687,7 +1687,7 @@ void finishDressupFeature(const Gui::Command* cmd, const std::string& which,
     std::string FeatName = cmd->getUniqueObjectName(which.c_str(),base);
 
     auto body = PartDesignGui::getBodyFor(base,false);
-    if(!body) return;
+    if (!body) return;
     cmd->openCommand((std::string("Make ") + which).c_str());
     FCMD_OBJ_CMD(body,"newObject('PartDesign::"<<which<<"','"<<FeatName<<"')");
     auto Feat = body->getDocument()->getObject(FeatName.c_str());
@@ -1800,7 +1800,7 @@ void CmdPartDesignDraft::activated(int iMsg)
     {
         std::string aSubName = static_cast<std::string>(SubNames.at(i));
 
-        if(aSubName.size() > 4 && aSubName.substr(0,4) == "Face") {
+        if (aSubName.size() > 4 && aSubName.substr(0,4) == "Face") {
             // Check for valid face types
             TopoDS_Face face = TopoDS::Face(TopShape.getSubShape(aSubName.c_str()));
             BRepAdaptor_Surface sf(face);
@@ -1856,7 +1856,7 @@ void CmdPartDesignThickness::activated(int iMsg)
     {
         std::string aSubName = static_cast<std::string>(SubNames.at(i));
 
-        if(aSubName.size() > 4 && aSubName.substr(0,4) != "Face") {
+        if (aSubName.size() > 4 && aSubName.substr(0,4) != "Face") {
             // empty name or any other sub-element
             SubNames.erase(SubNames.begin()+i);
         }
@@ -1876,13 +1876,13 @@ bool CmdPartDesignThickness::isActive(void)
 //===========================================================================
 
 void prepareTransformed(PartDesign::Body *pcActiveBody, Gui::Command* cmd, const std::string& which,
-                        boost::function<void(App::DocumentObject *, std::vector<App::DocumentObject*>)> func)
+    boost::function<void(App::DocumentObject*, std::vector<App::DocumentObject*>)> func)
 {
-    std::string FeatName = cmd->getUniqueObjectName(which.c_str(),pcActiveBody);
+    std::string FeatName = cmd->getUniqueObjectName(which.c_str(), pcActiveBody);
 
-    auto accepter = [=](std::vector<App::DocumentObject*> features) -> bool{
+    auto accepter = [=](std::vector<App::DocumentObject*> features) -> bool {
 
-        if(features.empty())
+        if (features.empty())
             return false;
 
         return true;
@@ -1890,8 +1890,8 @@ void prepareTransformed(PartDesign::Body *pcActiveBody, Gui::Command* cmd, const
 
     auto worker = [=](std::vector<App::DocumentObject*> features) {
         std::stringstream str;
-        str << cmd->getObjectCmd(FeatName.c_str(),pcActiveBody->getDocument()) << ".Originals = [";
-        for (std::vector<App::DocumentObject*>::iterator it = features.begin(); it != features.end(); ++it){
+        str << cmd->getObjectCmd(FeatName.c_str(), pcActiveBody->getDocument()) << ".Originals = [";
+        for (std::vector<App::DocumentObject*>::iterator it = features.begin(); it != features.end(); ++it) {
             str << cmd->getObjectCmd(*it) << ",";
         }
         str << "]";
@@ -1899,7 +1899,7 @@ void prepareTransformed(PartDesign::Body *pcActiveBody, Gui::Command* cmd, const
         std::string msg("Make ");
         msg += which;
         Gui::Command::openCommand(msg.c_str());
-        FCMD_OBJ_CMD(pcActiveBody,"newObject('PartDesign::"<<which<<"','"<<FeatName<<"')");
+        FCMD_OBJ_CMD(pcActiveBody, "newObject('PartDesign::" << which << "','" << FeatName << "')");
         // FIXME: There seems to be kind of a race condition here, leading to sporadic errors like
         // Exception (Thu Sep  6 11:52:01 2012): 'App.Document' object has no attribute 'Mirrored'
         Gui::Command::updateActive(); // Helps to ensure that the object already exists when the next command comes up
@@ -1911,7 +1911,7 @@ void prepareTransformed(PartDesign::Body *pcActiveBody, Gui::Command* cmd, const
         func(Feat, features);
 
         // Set the tip of the body
-        FCMD_OBJ_CMD(pcActiveBody,"Tip = " << Gui::Command::getObjectCmd(Feat));
+        FCMD_OBJ_CMD(pcActiveBody, "Tip = " << Gui::Command::getObjectCmd(Feat));
         Gui::Command::updateActive();
     };
 
@@ -1927,8 +1927,8 @@ void prepareTransformed(PartDesign::Body *pcActiveBody, Gui::Command* cmd, const
             for (unsigned i = 0; i < features.size(); i++)
                 status.push_back(PartDesignGui::TaskFeaturePick::validFeature);
 
-            Gui::TaskView::TaskDialog *dlg = Gui::Control().activeDialog();
-            PartDesignGui::TaskDlgFeaturePick *pickDlg = qobject_cast<PartDesignGui::TaskDlgFeaturePick *>(dlg);
+            Gui::TaskView::TaskDialog* dlg = Gui::Control().activeDialog();
+            PartDesignGui::TaskDlgFeaturePick* pickDlg = qobject_cast<PartDesignGui::TaskDlgFeaturePick*>(dlg);
             if (dlg && !pickDlg) {
                 QMessageBox msgBox;
                 msgBox.setText(QObject::tr("A dialog is already open in the task panel"));
@@ -1942,32 +1942,27 @@ void prepareTransformed(PartDesign::Body *pcActiveBody, Gui::Command* cmd, const
                     return;
             }
 
-            if(dlg)
+            if (dlg)
                 Gui::Control().closeDialog();
 
             Gui::Selection().clearSelection();
             Gui::Control().showDialog(new PartDesignGui::TaskDlgFeaturePick(features, status, accepter, worker));
             return;
-        } else if(features.empty()) {
+        } else if (features.empty()) {
             QMessageBox::warning(Gui::getMainWindow(), QObject::tr("No valid features in this document"),
                 QObject::tr("Please create a feature first."));
             return;
         }
     }
-    if (features.size() > 1) {
-        QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Multiple Features Selected"),
-            QObject::tr("Please select only one feature first."));
-        return;
-    }
-    else {
-        PartDesign::Body *pcActiveBody = PartDesignGui::getBody(true);
-        if (pcActiveBody != PartDesignGui::getBodyFor(features[0], false)) {
+    PartDesign::Body* pcActiveBodySelect = PartDesignGui::getBody(true);
+    for (int i = 0; i < features.size(); i++) {
+        if (pcActiveBodySelect != PartDesignGui::getBodyFor(features[i], false)) {
             QMessageBox::warning(Gui::getMainWindow(), QObject::tr("Selection is not in Active Body"),
                 QObject::tr("Please select only one feature in an active body."));
             return;
         }
-        worker(features);
     }
+    worker(features);
 }
 
 void finishTransformed(Gui::Command* cmd, App::DocumentObject *Feat)
@@ -2012,16 +2007,16 @@ void CmdPartDesignMirrored::activated(int iMsg)
             return;
 
         bool direction = false;
-        if(features.front()->isDerivedFrom(PartDesign::ProfileBased::getClassTypeId())) {
+        if (features.front()->isDerivedFrom(PartDesign::ProfileBased::getClassTypeId())) {
             Part::Part2DObject *sketch = (static_cast<PartDesign::ProfileBased*>(features.front()))->getVerifiedSketch(/* silent =*/ true);
             if (sketch) {
                 FCMD_OBJ_CMD(Feat,"MirrorPlane = ("<<getObjectCmd(sketch)<<", ['V_Axis'])");
                 direction = true;
             }
         }
-        if(!direction) {
+        if (!direction) {
             auto body = static_cast<PartDesign::Body*>(Part::BodyBase::findBodyOf(features.front()));
-            if(body) {                
+            if (body) {                
                 FCMD_OBJ_CMD(Feat,"MirrorPlane = ("<<getObjectCmd(body->getOrigin()->getXY())<<", [''])");
             }
         }
@@ -2074,16 +2069,16 @@ void CmdPartDesignLinearPattern::activated(int iMsg)
             return;
 
         bool direction = false;
-        if(features.front()->isDerivedFrom(PartDesign::ProfileBased::getClassTypeId())) {
+        if (features.front()->isDerivedFrom(PartDesign::ProfileBased::getClassTypeId())) {
             Part::Part2DObject *sketch = (static_cast<PartDesign::ProfileBased*>(features.front()))->getVerifiedSketch(/* silent =*/ true);
             if (sketch) {
                 FCMD_OBJ_CMD(Feat,"Direction = ("<<Gui::Command::getObjectCmd(sketch)<<", ['H_Axis'])");
                 direction = true;
             }
         }
-        if(!direction) {
+        if (!direction) {
             auto body = static_cast<PartDesign::Body*>(Part::BodyBase::findBodyOf(features.front()));
-            if(body) {                
+            if (body) {                
                 FCMD_OBJ_CMD(Feat,"Direction = ("<<Gui::Command::getObjectCmd(body->getOrigin()->getX())<<",[''])");
             }
         }
@@ -2138,16 +2133,16 @@ void CmdPartDesignPolarPattern::activated(int iMsg)
             return;
 
         bool direction = false;
-        if(features.front()->isDerivedFrom(PartDesign::ProfileBased::getClassTypeId())) {
+        if (features.front()->isDerivedFrom(PartDesign::ProfileBased::getClassTypeId())) {
             Part::Part2DObject *sketch = (static_cast<PartDesign::ProfileBased*>(features.front()))->getVerifiedSketch(/* silent =*/ true);
             if (sketch) {
                 FCMD_OBJ_CMD(Feat,"Axis = ("<<Gui::Command::getObjectCmd(sketch)<<",['N_Axis'])");
                 direction = true;
             }
         }
-        if(!direction) {
+        if (!direction) {
             auto body = static_cast<PartDesign::Body*>(Part::BodyBase::findBodyOf(features.front()));
-            if(body) {                
+            if (body) {                
                 FCMD_OBJ_CMD(Feat,"Axis = ("<<Gui::Command::getObjectCmd(body->getOrigin()->getZ())<<",[''])");
             }
         }
@@ -2286,7 +2281,7 @@ void CmdPartDesignMultiTransform::activated(int iMsg)
         // #0003509
 #if 0
         // Remove the Transformed feature from the Body
-        if(pcActiveBody)
+        if (pcActiveBody)
             FCMD_OBJ_CMD(pcActiveBody,"removeObject("<<getObjectCmd(trFeat)<<")");
 #endif
 
@@ -2377,7 +2372,7 @@ void CmdPartDesignBoolean::activated(int iMsg)
         std::vector<std::vector<Gui::SelectionObject> >::iterator i = BodyFilter.Result.begin();
         for (; i != BodyFilter.Result.end(); i++) {
             for (std::vector<Gui::SelectionObject>::iterator j = i->begin(); j != i->end(); j++) {
-                if(j->getObject() != pcActiveBody)
+                if (j->getObject() != pcActiveBody)
                     bodies.push_back(j->getObject());
             }
         }

--- a/src/Mod/PartDesign/Gui/TaskLinearPatternParameters.ui
+++ b/src/Mod/PartDesign/Gui/TaskLinearPatternParameters.ui
@@ -72,11 +72,14 @@
       </widget>
      </item>
      <item>
-      <widget class="Gui::QuantitySpinBox" name="spinLength" native="true">
+      <widget class="Gui::QuantitySpinBox" name="spinLength">
+       <property name="keyboardTracking">
+        <bool>false</bool>
+       </property>
        <property name="unit" stdset="0">
         <string notr="true">mm</string>
        </property>
-       <property name="value" stdset="0">
+       <property name="value">
         <double>100.000000000000000</double>
        </property>
       </widget>
@@ -93,7 +96,7 @@
       </widget>
      </item>
      <item>
-      <widget class="Gui::UIntSpinBox" name="spinOccurrences" native="true"/>
+      <widget class="Gui::UIntSpinBox" name="spinOccurrences"/>
      </item>
     </layout>
    </item>
@@ -141,11 +144,44 @@
   </customwidget>
   <customwidget>
    <class>Gui::UIntSpinBox</class>
-   <extends>QWidget</extends>
-   <header location="global">Gui/SpinBox.h</header>
+   <extends>QSpinBox</extends>
+   <header>Gui/SpinBox.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>
  <resources/>
- <connections/>
+ <connections>
+  <connection>
+   <sender>buttonAddFeature</sender>
+   <signal>clicked(bool)</signal>
+   <receiver>buttonRemoveFeature</receiver>
+   <slot>setDisabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>70</x>
+     <y>21</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>198</x>
+     <y>21</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonRemoveFeature</sender>
+   <signal>clicked(bool)</signal>
+   <receiver>buttonAddFeature</receiver>
+   <slot>setDisabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>198</x>
+     <y>21</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>70</x>
+     <y>21</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
 </ui>

--- a/src/Mod/PartDesign/Gui/TaskMirroredParameters.ui
+++ b/src/Mod/PartDesign/Gui/TaskMirroredParameters.ui
@@ -92,5 +92,38 @@
   </layout>
  </widget>
  <resources/>
- <connections/>
+ <connections>
+  <connection>
+   <sender>buttonAddFeature</sender>
+   <signal>clicked(bool)</signal>
+   <receiver>buttonRemoveFeature</receiver>
+   <slot>setDisabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>66</x>
+     <y>21</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>186</x>
+     <y>21</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonRemoveFeature</sender>
+   <signal>clicked(bool)</signal>
+   <receiver>buttonAddFeature</receiver>
+   <slot>setDisabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>186</x>
+     <y>21</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>66</x>
+     <y>21</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
 </ui>

--- a/src/Mod/PartDesign/Gui/TaskMultiTransformParameters.ui
+++ b/src/Mod/PartDesign/Gui/TaskMultiTransformParameters.ui
@@ -71,5 +71,38 @@
   </layout>
  </widget>
  <resources/>
- <connections/>
+ <connections>
+  <connection>
+   <sender>buttonAddFeature</sender>
+   <signal>clicked(bool)</signal>
+   <receiver>buttonRemoveFeature</receiver>
+   <slot>setDisabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>67</x>
+     <y>21</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>188</x>
+     <y>21</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonRemoveFeature</sender>
+   <signal>clicked(bool)</signal>
+   <receiver>buttonAddFeature</receiver>
+   <slot>setDisabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>188</x>
+     <y>21</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>67</x>
+     <y>21</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
 </ui>

--- a/src/Mod/PartDesign/Gui/TaskPolarPatternParameters.ui
+++ b/src/Mod/PartDesign/Gui/TaskPolarPatternParameters.ui
@@ -72,17 +72,20 @@
       </widget>
      </item>
      <item>
-      <widget class="Gui::QuantitySpinBox" name="polarAngle" native="true">
+      <widget class="Gui::QuantitySpinBox" name="polarAngle">
+       <property name="keyboardTracking">
+        <bool>false</bool>
+       </property>
        <property name="unit" stdset="0">
         <string notr="true">deg</string>
        </property>
-       <property name="minimum" stdset="0">
+       <property name="minimum">
         <double>0.000000000000000</double>
        </property>
-       <property name="maximum" stdset="0">
+       <property name="maximum">
         <double>360.000000000000000</double>
        </property>
-       <property name="value" stdset="0">
+       <property name="value">
         <double>360.000000000000000</double>
        </property>
       </widget>
@@ -99,7 +102,7 @@
       </widget>
      </item>
      <item>
-      <widget class="Gui::UIntSpinBox" name="spinOccurrences" native="true"/>
+      <widget class="Gui::UIntSpinBox" name="spinOccurrences"/>
      </item>
     </layout>
    </item>
@@ -147,11 +150,44 @@
   </customwidget>
   <customwidget>
    <class>Gui::UIntSpinBox</class>
-   <extends>QWidget</extends>
-   <header location="global">Gui/SpinBox.h</header>
+   <extends>QSpinBox</extends>
+   <header>Gui/SpinBox.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>
  <resources/>
- <connections/>
+ <connections>
+  <connection>
+   <sender>buttonAddFeature</sender>
+   <signal>clicked(bool)</signal>
+   <receiver>buttonRemoveFeature</receiver>
+   <slot>setDisabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>66</x>
+     <y>21</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>186</x>
+     <y>21</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonRemoveFeature</sender>
+   <signal>clicked(bool)</signal>
+   <receiver>buttonAddFeature</receiver>
+   <slot>setDisabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>186</x>
+     <y>21</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>66</x>
+     <y>21</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
 </ui>


### PR DESCRIPTION
- Since realthunder's contributions some months ago, the 4 pattern features (mirror, linear, polar, mulitransform) can handle several features at once.
This PR allows to select multiple features when creating a pattern.
(This speeds up the workflow because at the moment one has to create the pattern with one feature and subsequently add more.)

- fix dialog issue that Add and Remove button could be active the same time

- use the keyboardTracking feature to avoid unnecessary recomputes (e.g. currently 3 recomputes when inserting "12.5" to the length field of linear pattern)

- fix wrong <extends> statement in .ui files (automatically spotted and fixed by Qt's Designer)

- some code style fixes

Forum thread: https://forum.freecadweb.org/viewtopic.php?f=17&t=48998