### PR TITLE
Draft: improvements to the getSVG code; separate the individual functions

### DIFF
--- a/src/Mod/Draft/Draft.py
+++ b/src/Mod/Draft/Draft.py
@@ -95,7 +95,8 @@ from draftutils.utils import (string_encode_coin,
                               get_DXF,
                               getDXF)
 
-from getSVG import getSVG
+from getSVG import (get_svg,
+                    getSVG)
 
 from draftutils.gui_utils import (get3DView,
                                   get_3d_view,

--- a/src/Mod/Draft/getSVG.py
+++ b/src/Mod/Draft/getSVG.py
@@ -148,11 +148,19 @@ def getDiscretized(edge, plane):
     return get_discretized(edge, plane)
 
 
-def getPattern(pat):
+def get_pattern(pat):
     """Get an SVG pattern."""
-    if pat in utils.svg_patterns():
-        return utils.svg_patterns()[pat][0]
+    patterns = utils.svg_patterns()
+
+    if pat in patterns:
+        return patterns[pat][0]
     return ''
+
+
+def getPattern(pat):
+    """Get an SVG pattern. DEPRECATED."""
+    utils.use_instead("get_pattern")
+    return get_pattern(pat)
 
 
 def getSVG(obj,
@@ -969,7 +977,7 @@ def getSVG(obj,
                         fill_opacity = 1 - (obj.ViewObject.Transparency / 100.0)
                     else:
                         fill = 'url(#'+fillstyle+')'
-                        svg += getPattern(fillstyle)
+                        svg += get_pattern(fillstyle)
                 else:
                     fill = "none"
             else:

--- a/src/Mod/Draft/getSVG.py
+++ b/src/Mod/Draft/getSVG.py
@@ -79,7 +79,7 @@ def getLineStyle(linestyle, scale):
     return get_line_style(linestyle, scale)
 
 
-def getProj(vec, plane=None):
+def get_proj(vec, plane=None):
     """Get a projection of the vector in the plane's u and v directions.
 
     Parameters
@@ -110,6 +110,12 @@ def getProj(vec, plane=None):
     return Vector(lx, ly, 0)
 
 
+def getProj(vec, plane=None):
+    """Get a projection of a vector. DEPRECATED."""
+    utils.use_instead("get_proj")
+    return get_proj(vec, plane)
+
+
 def getDiscretized(edge, plane):
     """Get discretization of the edge."""
     pieces = param.GetFloat("svgDiscretization", 10.0)
@@ -126,7 +132,7 @@ def getDiscretized(edge, plane):
         _length = edge.LastParameter - edge.FirstParameter
         _point = edge.FirstParameter + float(i)/d * _length
         _vec = edge.valueAt(_point)
-        v = getProj(_vec, plane)
+        v = get_proj(_vec, plane)
 
         if not edata:
             edata += 'M ' + str(v.x) + ' ' + str(v.y) + ' '
@@ -294,7 +300,7 @@ def getSVG(obj,
                     if (vs[0].Point-previousvs[-1].Point).Length > 1e-6:
                         vs.reverse()
                 if edgeindex == 0:
-                    v = getProj(vs[0].Point, plane)
+                    v = get_proj(vs[0].Point, plane)
                     edata += 'M '+ str(v.x) +' '+ str(v.y) + ' '
                 else:
                     if (vs[0].Point-previousvs[-1].Point).Length > 1e-6:
@@ -331,10 +337,10 @@ def getSVG(obj,
                             elif len(e.Vertexes) == 1 and isellipse:
                                 #svg = getEllipse(e)
                                 #return svg
-                                endpoints = [getProj(c.value((c.LastParameter-c.FirstParameter)/2.0), plane),
-                                             getProj(vs[-1].Point, plane)]
+                                endpoints = [get_proj(c.value((c.LastParameter-c.FirstParameter)/2.0), plane),
+                                             get_proj(vs[-1].Point, plane)]
                             else:
-                                endpoints = [getProj(vs[-1].Point, plane)]
+                                endpoints = [get_proj(vs[-1].Point, plane)]
                             # arc
                             if iscircle:
                                 rx = ry = c.Radius
@@ -366,7 +372,7 @@ def getSVG(obj,
                     else:
                         edata += getDiscretized(e, plane)
                 elif DraftGeomUtils.geomType(e) == "Line":
-                    v = getProj(vs[-1].Point, plane)
+                    v = get_proj(vs[-1].Point, plane)
                     edata += 'L '+ str(v.x) +' '+ str(v.y) + ' '
                 else:
                     bspline=e.Curve.toBSpline(e.FirstParameter,e.LastParameter)
@@ -386,13 +392,13 @@ def getSVG(obj,
                             elif bezierseg.Degree==3:
                                 edata +='C '
                             for pole in bezierseg.getPoles()[1:]:
-                                v = getProj(pole, plane)
+                                v = get_proj(pole, plane)
                                 edata += str(v.x) +' '+ str(v.y) + ' '
                     else:
                         print("Debug: one edge (hash ",e.hashCode(),\
                                 ") has been discretized with parameter 0.1")
                         for linepoint in bspline.discretize(0.1)[1:]:
-                            v = getProj(linepoint, plane)
+                            v = get_proj(linepoint, plane)
                             edata += 'L '+ str(v.x) +' '+ str(v.y) + ' '
             if fill != 'none':
                 edata += 'Z '
@@ -418,7 +424,7 @@ def getSVG(obj,
         return svg
 
     def getCircle(edge):
-        cen = getProj(edge.Curve.Center, plane)
+        cen = get_proj(edge.Curve.Center, plane)
         rad = edge.Curve.Radius
         if hasattr(FreeCAD,"DraftWorkingPlane"):
             drawing_plane_normal = FreeCAD.DraftWorkingPlane.axis
@@ -445,7 +451,7 @@ def getSVG(obj,
         return svg
 
     def getEllipse(edge):
-        cen = getProj(edge.Curve.Center, plane)
+        cen = get_proj(edge.Curve.Center, plane)
         mir = edge.Curve.MinorRadius
         mar = edge.Curve.MajorRadius
         svg = '<ellipse cx="' + str(cen.x)
@@ -625,16 +631,16 @@ def getSVG(obj,
                     prx = obj.ViewObject.Proxy
                     ts = (len(prx.string)*obj.ViewObject.FontSize.Value)/4.0
                     rm = ((prx.p3.sub(prx.p2)).Length/2.0)-ts
-                    p2a = getProj(prx.p2.add(DraftVecUtils.scaleTo(prx.p3.sub(prx.p2),rm)), plane)
-                    p2b = getProj(prx.p3.add(DraftVecUtils.scaleTo(prx.p2.sub(prx.p3),rm)), plane)
-                    p1 = getProj(prx.p1, plane)
-                    p2 = getProj(prx.p2, plane)
-                    p3 = getProj(prx.p3, plane)
-                    p4 = getProj(prx.p4, plane)
-                    tbase = getProj(prx.tbase, plane)
+                    p2a = get_proj(prx.p2.add(DraftVecUtils.scaleTo(prx.p3.sub(prx.p2),rm)), plane)
+                    p2b = get_proj(prx.p3.add(DraftVecUtils.scaleTo(prx.p2.sub(prx.p3),rm)), plane)
+                    p1 = get_proj(prx.p1, plane)
+                    p2 = get_proj(prx.p2, plane)
+                    p3 = get_proj(prx.p3, plane)
+                    p4 = get_proj(prx.p4, plane)
+                    tbase = get_proj(prx.tbase, plane)
                     r = prx.textpos.rotation.getValue().getValue()
                     rv = FreeCAD.Rotation(r[0],r[1],r[2],r[3]).multVec(FreeCAD.Vector(1,0,0))
-                    angle = -DraftVecUtils.angle(getProj(rv, plane))
+                    angle = -DraftVecUtils.angle(get_proj(rv, plane))
                     #angle = -DraftVecUtils.angle(p3.sub(p2))
 
                     svg = ''
@@ -731,12 +737,12 @@ def getSVG(obj,
 
                     # drawing arrows
                     if hasattr(obj.ViewObject,"ArrowType"):
-                        p2 = getProj(prx.p2, plane)
-                        p3 = getProj(prx.p3, plane)
+                        p2 = get_proj(prx.p2, plane)
+                        p3 = get_proj(prx.p3, plane)
                         arrowsize = obj.ViewObject.ArrowSize.Value/pointratio
                         arrowlength = 4*obj.ViewObject.ArrowSize.Value
-                        u1 = getProj((prx.circle.valueAt(prx.circle.FirstParameter+arrowlength)).sub(prx.circle.valueAt(prx.circle.FirstParameter)), plane)
-                        u2 = getProj((prx.circle.valueAt(prx.circle.LastParameter-arrowlength)).sub(prx.circle.valueAt(prx.circle.LastParameter)), plane)
+                        u1 = get_proj((prx.circle.valueAt(prx.circle.FirstParameter+arrowlength)).sub(prx.circle.valueAt(prx.circle.FirstParameter)), plane)
+                        u2 = get_proj((prx.circle.valueAt(prx.circle.LastParameter-arrowlength)).sub(prx.circle.valueAt(prx.circle.LastParameter)), plane)
                         angle1 = -DraftVecUtils.angle(u1)
                         angle2 = -DraftVecUtils.angle(u2)
                         if hasattr(obj.ViewObject,"FlipArrows"):
@@ -749,16 +755,16 @@ def getSVG(obj,
                     # drawing text
                     if obj.ViewObject.DisplayMode == "2D":
                         t = prx.circle.tangentAt(prx.circle.FirstParameter+(prx.circle.LastParameter-prx.circle.FirstParameter)/2.0)
-                        t = getProj(t, plane)
+                        t = get_proj(t, plane)
                         tangle = DraftVecUtils.angle(t)
                         if (tangle <= -math.pi/2) or (tangle > math.pi/2):
                             tangle = tangle + math.pi
-                        tbase = getProj(prx.circle.valueAt(prx.circle.FirstParameter+(prx.circle.LastParameter-prx.circle.FirstParameter)/2.0), plane)
+                        tbase = get_proj(prx.circle.valueAt(prx.circle.FirstParameter+(prx.circle.LastParameter-prx.circle.FirstParameter)/2.0), plane)
                         tbase = tbase.add(DraftVecUtils.rotate(Vector(0,2.0/scale,0),tangle))
                         #print(tbase)
                     else:
                         tangle = 0
-                        tbase = getProj(prx.tbase, plane)
+                        tbase = get_proj(prx.tbase, plane)
                     svg += getText(stroke,fontsize,obj.ViewObject.FontName,tangle,tbase,prx.string)
 
     elif utils.get_type(obj) == "Label":
@@ -769,7 +775,7 @@ def getSVG(obj,
                 )
 
             # Draw multisegment line
-            proj_points = list(map(lambda x: getProj(x, plane), obj.Points))
+            proj_points = list(map(lambda x: get_proj(x, plane), obj.Points))
             path_dir_list = [format_point(proj_points[0], action='M')]
             path_dir_list += map(format_point, proj_points[1:])
             path_dir_str = " ".join(path_dir_list)
@@ -785,7 +791,7 @@ def getSVG(obj,
             # if Line is set to 'off', no arrow is drawn
             if hasattr(obj.ViewObject, "ArrowType") and len(obj.Points) >= 2:
                 last_segment = FreeCAD.Vector(obj.Points[-1] - obj.Points[-2])
-                angle = -DraftVecUtils.angle(getProj(last_segment, plane)) + math.pi
+                angle = -DraftVecUtils.angle(get_proj(last_segment, plane)) + math.pi
                 svg += getArrow(
                     arrowtype=obj.ViewObject.ArrowType,
                     point=proj_points[-1],
@@ -801,7 +807,7 @@ def getSVG(obj,
                 print("export of texts to SVG is only available in GUI mode")
             else:
                 fontname = obj.ViewObject.TextFont
-                position = getProj(obj.Placement.Base, plane)
+                position = get_proj(obj.Placement.Base, plane)
                 rotation = obj.Placement.Rotation
                 justification = obj.ViewObject.TextAlignment
                 text = obj.Text
@@ -816,11 +822,11 @@ def getSVG(obj,
             else:
                 n = obj.ViewObject.FontName
                 if utils.get_type(obj) == "Annotation":
-                    p = getProj(obj.Position, plane)
+                    p = get_proj(obj.Position, plane)
                     r = obj.ViewObject.Rotation.getValueAs("rad")
                     t = obj.LabelText
                 else:  # DraftText (old) or Text (new, 0.19)
-                    p = getProj(obj.Placement.Base, plane)
+                    p = get_proj(obj.Placement.Base, plane)
                     r = obj.Placement.Rotation
                     t = obj.Text
                 j = obj.ViewObject.Justification
@@ -931,13 +937,13 @@ def getSVG(obj,
                 lspc = FreeCAD.Vector(obj.ViewObject.Proxy.header.translation.getValue().getValue())
                 p1 = p2.add(lspc)
                 j = obj.ViewObject.TextAlign
-                t3 = getText(c,f1,n,a,getProj(p1, plane),t1,linespacing,j,flip=True)
+                t3 = getText(c,f1,n,a,get_proj(p1, plane),t1,linespacing,j,flip=True)
                 svg += t3
                 if t2:
                     ofs = FreeCAD.Vector(0,-lspc.Length,0)
                     if a:
                         ofs = FreeCAD.Rotation(FreeCAD.Vector(0,0,1),-rotation).multVec(ofs)
-                    t4 = getText(c,fontsize,n,a,getProj(p1, plane).add(ofs),t2,linespacing,j,flip=True)
+                    t4 = getText(c,fontsize,n,a,get_proj(p1, plane).add(ofs),t2,linespacing,j,flip=True)
                     svg += t4
 
     elif obj.isDerivedFrom('Part::Feature'):
@@ -995,8 +1001,8 @@ def getSVG(obj,
         if FreeCAD.GuiUp:
             if hasattr(obj.ViewObject,"EndArrow") and hasattr(obj.ViewObject,"ArrowType") and (len(obj.Shape.Vertexes) > 1):
                 if obj.ViewObject.EndArrow:
-                    p1 = getProj(obj.Shape.Vertexes[-1].Point, plane)
-                    p2 = getProj(obj.Shape.Vertexes[-2].Point, plane)
+                    p1 = get_proj(obj.Shape.Vertexes[-1].Point, plane)
+                    p2 = get_proj(obj.Shape.Vertexes[-2].Point, plane)
                     angle = -DraftVecUtils.angle(p2.sub(p1))
                     arrowsize = obj.ViewObject.ArrowSize.Value/pointratio
                     svg += getArrow(obj.ViewObject.ArrowType,p1,arrowsize,stroke,linewidth,angle)

--- a/src/Mod/Draft/getSVG.py
+++ b/src/Mod/Draft/getSVG.py
@@ -25,8 +25,6 @@
 #  \ingroup DRAFT
 #  \brief Provides functions to return the SVG representation of shapes.
 
-## \addtogroup getSVG
-# @{
 import math
 import six
 import lazy_loader.lazy_loader as lz
@@ -37,12 +35,17 @@ import WorkingPlane
 import draftutils.utils as utils
 
 from FreeCAD import Vector
+from draftutils.messages import _msg, _wrn
 
 # Delay import of module until first use because it is heavy
 Part = lz.LazyLoader("Part", globals(), "Part")
 DraftGeomUtils = lz.LazyLoader("DraftGeomUtils", globals(), "DraftGeomUtils")
+Drawing = lz.LazyLoader("Drawing", globals(), "Drawing")
 
 param = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/Draft")
+
+## \addtogroup getSVG
+# @{
 
 
 def get_line_style(line_style, scale):
@@ -163,6 +166,222 @@ def getPattern(pat):
     return get_pattern(pat)
 
 
+def get_path(obj, plane,
+             fill, pathdata, stroke, linewidth, lstyle,
+             fill_opacity=None,
+             edges=[], wires=[], pathname=None):
+    """Get the SVG representation from an object's edges or wires."""
+    svg = "<path "
+
+    if pathname is None:
+        svg += 'id="{}" '.format(obj.Name)
+    elif pathname != "":
+        svg += 'id="{}" '.format(pathname)
+
+    svg += ' d="'
+    if not wires:
+        egroups = Part.sortEdges(edges)
+    else:
+        egroups = []
+        first = True
+        for w in wires:
+            w1 = w.copy()
+            if first:
+                first = False
+            else:
+                # invert further wires to create holes
+                w1 = DraftGeomUtils.invert(w1)
+
+            w1.fixWire()
+            egroups.append(Part.__sortEdges__(w1.Edges))
+
+    for egroupindex, edges in enumerate(egroups):
+        edata = ""
+        vs = ()  # skipped for the first edge
+
+        for edgeindex, e in enumerate(edges):
+            previousvs = vs
+            # vertexes of an edge (reversed if needed)
+            vs = e.Vertexes
+            if previousvs:
+                if (vs[0].Point - previousvs[-1].Point).Length > 1e-6:
+                    vs.reverse()
+
+            if edgeindex == 0:
+                v = get_proj(vs[0].Point, plane)
+                edata += 'M {} {} '.format(v.x, v.y)
+            else:
+                if (vs[0].Point - previousvs[-1].Point).Length > 1e-6:
+                    raise ValueError('edges not ordered')
+
+            iscircle = DraftGeomUtils.geomType(e) == "Circle"
+            isellipse = DraftGeomUtils.geomType(e) == "Ellipse"
+
+            if iscircle or isellipse:
+                if hasattr(FreeCAD, "DraftWorkingPlane"):
+                    drawing_plane_normal = FreeCAD.DraftWorkingPlane.axis
+                else:
+                    drawing_plane_normal = FreeCAD.Vector(0, 0, 1)
+
+                if plane:
+                    drawing_plane_normal = plane.axis
+
+                c = e.Curve
+                ax = c.Axis
+                if round(ax.getAngle(drawing_plane_normal), 2) in [0, 3.14]:
+                    occversion = Part.OCC_VERSION.split(".")
+                    done = False
+                    if int(occversion[0]) >= 7 and int(occversion[1]) >= 1:
+                        # if using occ >= 7.1, use HLR algorithm
+                        snip = Drawing.projectToSVG(e, drawing_plane_normal)
+
+                        if snip:
+                            try:
+                                _a = snip.split('path d="')[1]
+                                _a = _a.split('"')[0]
+                                _a = _a.split("A")[1]
+                                A = "A " + _a
+                            except:
+                                _wrn("Circle or ellipse: "
+                                     "error spliting the projection snip")
+                            else:
+                                edata += A
+                                done = True
+
+                    if not done:
+                        if len(e.Vertexes) == 1 and iscircle:
+                            # Complete circle not only arc
+                            svg = getCircle(e)
+                            return svg
+                        elif len(e.Vertexes) == 1 and isellipse:
+                            # Complete ellipse not only arc
+                            # svg = getEllipse(e)
+                            # return svg
+
+                            # Difference in angles
+                            _diff = (c.LastParameter - c.FirstParameter)/2.0
+                            endpoints = [get_proj(c.value(_diff), plane),
+                                         get_proj(vs[-1].Point, plane)]
+                        else:
+                            endpoints = [get_proj(vs[-1].Point, plane)]
+
+                        # Arc with more than one vertex
+                        if iscircle:
+                            rx = ry = c.Radius
+                            rot = 0
+                        else:  # ellipse
+                            rx = c.MajorRadius
+                            ry = c.MinorRadius
+                            rot = math.degrees(c.AngleXU
+                                               * c.Axis * Vector(0, 0, 1))
+                            if rot > 90:
+                                rot -= 180
+                            if rot < -90:
+                                rot += 180
+
+                        # Be careful with the sweep flag
+                        _diff = e.ParameterRange[1] - e.ParameterRange[0]
+                        _diff = _diff / math.pi
+                        flag_large_arc = (_diff % 2) > 1
+
+                        # flag_sweep = (c.Axis * drawing_plane_normal >= 0) \
+                        #     == (e.LastParameter > e.FirstParameter)
+                        #     == (e.Orientation == "Forward")
+
+                        # Another method: check the direction of the angle
+                        # between tangents
+                        _diff = e.LastParameter - e.FirstParameter
+                        t1 = e.tangentAt(e.FirstParameter)
+                        t2 = e.tangentAt(e.FirstParameter + _diff/10)
+                        flag_sweep = DraftVecUtils.angle(t1, t2,
+                                                         drawing_plane_normal) < 0
+
+                        for v in endpoints:
+                            edata += ('A {} {} {} '
+                                      '{} {} '
+                                      '{} {} '.format(rx, ry, rot,
+                                                      int(flag_large_arc),
+                                                      int(flag_sweep),
+                                                      v.x, v.y))
+                else:
+                    edata += get_discretized(e, plane)
+
+            elif DraftGeomUtils.geomType(e) == "Line":
+                v = get_proj(vs[-1].Point, plane)
+                edata += 'L {} {} '.format(v.x, v.y)
+            else:
+                # If it's not a circle nor ellipse nor straight line
+                # convert the curve to BSpline
+                bspline = e.Curve.toBSpline(e.FirstParameter, e.LastParameter)
+                if bspline.Degree > 3 or bspline.isRational():
+                    try:
+                        bspline = bspline.approximateBSpline(0.05, 50, 3, 'C0')
+                    except RuntimeError:
+                        _wrn("Debug: unable to approximate bspline from edge")
+
+                if bspline.Degree <= 3 and not bspline.isRational():
+                    for bezierseg in bspline.toBezier():
+                        if bezierseg.Degree > 3:  # should not happen
+                            _wrn("Bezier segment of degree > 3")
+                            raise AssertionError
+                        elif bezierseg.Degree == 1:
+                            edata += 'L '
+                        elif bezierseg.Degree == 2:
+                            edata += 'Q '
+                        elif bezierseg.Degree == 3:
+                            edata += 'C '
+
+                        for pole in bezierseg.getPoles()[1:]:
+                            v = get_proj(pole, plane)
+                            edata += '{} {} '.format(v.x, v.y)
+                else:
+                    _msg("Debug: one edge (hash {}) "
+                         "has been discretized "
+                         "with parameter 0.1".format(e.hashCode()))
+
+                    for linepoint in bspline.discretize(0.1)[1:]:
+                        v = get_proj(linepoint, plane)
+                        edata += 'L {} {} '.format(v.x, v.y)
+
+        if fill != 'none':
+            edata += 'Z '
+
+        if edata in pathdata:
+            # do not draw a path on another identical path
+            return ""
+        else:
+            svg += edata
+            pathdata.append(edata)
+
+    svg += '" '
+    svg += 'stroke="{}" '.format(stroke)
+    svg += 'stroke-width="{} px" '.format(linewidth)
+    svg += 'style="'
+    svg += 'stroke-width:{};'.format(linewidth)
+    svg += 'stroke-miterlimit:4;'
+    svg += 'stroke-dasharray:{};'.format(lstyle)
+    svg += 'fill:{};'.format(fill)
+    # fill_opacity must be a number, but if it's `None` it is omitted
+    if fill_opacity is not None:
+        svg += 'fill-opacity:{};'.format(fill_opacity)
+
+    svg += 'fill-rule: evenodd"'
+    svg += '/>\n'
+    return svg
+
+
+def getPath(obj, plane,
+            fill, pathdata, stroke, linewidth, lstyle,
+            fill_opacity,
+            edges=[], wires=[], pathname=None):
+    """Get the SVG representation from a path. DEPRECATED."""
+    utils.use_instead("get_path")
+    return get_path(obj, plane,
+                    fill, pathdata, stroke, linewidth, lstyle,
+                    fill_opacity,
+                    edges=edges, wires=wires, pathname=pathname)
+
+
 def getSVG(obj,
            scale=1, linewidth=0.35, fontsize=12,
            fillstyle="shape color", direction=None, linestyle=None,
@@ -280,162 +499,6 @@ def getSVG(obj,
     else:
         if hasattr(obj, "ViewObject") and hasattr(obj.ViewObject, "DrawStyle"):
             lstyle = get_line_style(obj.ViewObject.DrawStyle, scale)
-
-    def getPath(edges=[],wires=[],pathname=None):
-
-        svg = "<path "
-        if pathname is None:
-            svg += 'id="%s" ' % obj.Name
-        elif pathname != "":
-            svg += 'id="%s" ' % pathname
-        svg += ' d="'
-        if not wires:
-            egroups = Part.sortEdges(edges)
-        else:
-            egroups = []
-            first = True
-            for w in wires:
-                w1=w.copy()
-                if first:
-                    first = False
-                else:
-                    # invert further wires to create holes
-                    w1 = DraftGeomUtils.invert(w1)
-                w1.fixWire()
-                egroups.append(Part.__sortEdges__(w1.Edges))
-        for egroupindex, edges in enumerate(egroups):
-            edata = ""
-            vs=() #skipped for the first edge
-            for edgeindex,e in enumerate(edges):
-                previousvs = vs
-                # vertexes of an edge (reversed if needed)
-                vs = e.Vertexes
-                if previousvs:
-                    if (vs[0].Point-previousvs[-1].Point).Length > 1e-6:
-                        vs.reverse()
-                if edgeindex == 0:
-                    v = get_proj(vs[0].Point, plane)
-                    edata += 'M '+ str(v.x) +' '+ str(v.y) + ' '
-                else:
-                    if (vs[0].Point-previousvs[-1].Point).Length > 1e-6:
-                        raise ValueError('edges not ordered')
-                iscircle = DraftGeomUtils.geomType(e) == "Circle"
-                isellipse = DraftGeomUtils.geomType(e) == "Ellipse"
-                if iscircle or isellipse:
-                    import math
-                    if hasattr(FreeCAD,"DraftWorkingPlane"):
-                        drawing_plane_normal = FreeCAD.DraftWorkingPlane.axis
-                    else:
-                        drawing_plane_normal = FreeCAD.Vector(0,0,1)
-                    if plane: drawing_plane_normal = plane.axis
-                    c = e.Curve
-                    if round(c.Axis.getAngle(drawing_plane_normal),2) in [0,3.14]:
-                        occversion = Part.OCC_VERSION.split(".")
-                        done = False
-                        if (int(occversion[0]) >= 7) and (int(occversion[1]) >= 1):
-                            # if using occ >= 7.1, use HLR algorithm
-                            import Drawing
-                            snip = Drawing.projectToSVG(e,drawing_plane_normal)
-                            if snip:
-                                try:
-                                    a = "A " + snip.split("path d=\"")[1].split("\"")[0].split("A")[1]
-                                except:
-                                    pass
-                                else:
-                                    edata += a
-                                    done = True
-                        if not done:
-                            if len(e.Vertexes) == 1 and iscircle: #complete curve
-                                svg = getCircle(e)
-                                return svg
-                            elif len(e.Vertexes) == 1 and isellipse:
-                                #svg = getEllipse(e)
-                                #return svg
-                                endpoints = [get_proj(c.value((c.LastParameter-c.FirstParameter)/2.0), plane),
-                                             get_proj(vs[-1].Point, plane)]
-                            else:
-                                endpoints = [get_proj(vs[-1].Point, plane)]
-                            # arc
-                            if iscircle:
-                                rx = ry = c.Radius
-                                rot = 0
-                            else: #ellipse
-                                rx = c.MajorRadius
-                                ry = c.MinorRadius
-                                rot = math.degrees(c.AngleXU * (c.Axis * \
-                                    FreeCAD.Vector(0,0,1)))
-                                if rot > 90:
-                                    rot -=180
-                                if rot < -90:
-                                    rot += 180
-                                #be careful with the sweep flag
-                            flag_large_arc = (((e.ParameterRange[1] - \
-                                    e.ParameterRange[0]) / math.pi) % 2) > 1
-                            #flag_sweep = (c.Axis * drawing_plane_normal >= 0) \
-                            #         == (e.LastParameter > e.FirstParameter)
-                            #        == (e.Orientation == "Forward")
-                            # other method: check the direction of the angle between tangents
-                            t1 = e.tangentAt(e.FirstParameter)
-                            t2 = e.tangentAt(e.FirstParameter + (e.LastParameter-e.FirstParameter)/10)
-                            flag_sweep = (DraftVecUtils.angle(t1,t2,drawing_plane_normal) < 0)
-                            for v in endpoints:
-                                edata += 'A %s %s %s %s %s %s %s ' % \
-                                        (str(rx),str(ry),str(rot),\
-                                        str(int(flag_large_arc)),\
-                                        str(int(flag_sweep)),str(v.x),str(v.y))
-                    else:
-                        edata += get_discretized(e, plane)
-                elif DraftGeomUtils.geomType(e) == "Line":
-                    v = get_proj(vs[-1].Point, plane)
-                    edata += 'L '+ str(v.x) +' '+ str(v.y) + ' '
-                else:
-                    bspline=e.Curve.toBSpline(e.FirstParameter,e.LastParameter)
-                    if bspline.Degree > 3 or bspline.isRational():
-                        try:
-                            bspline=bspline.approximateBSpline(0.05,50, 3,'C0')
-                        except RuntimeError:
-                            print("Debug: unable to approximate bspline")
-                    if bspline.Degree <= 3 and not bspline.isRational():
-                        for bezierseg in bspline.toBezier():
-                            if bezierseg.Degree>3: #should not happen
-                                raise AssertionError
-                            elif bezierseg.Degree==1:
-                                edata +='L '
-                            elif bezierseg.Degree==2:
-                                edata +='Q '
-                            elif bezierseg.Degree==3:
-                                edata +='C '
-                            for pole in bezierseg.getPoles()[1:]:
-                                v = get_proj(pole, plane)
-                                edata += str(v.x) +' '+ str(v.y) + ' '
-                    else:
-                        print("Debug: one edge (hash ",e.hashCode(),\
-                                ") has been discretized with parameter 0.1")
-                        for linepoint in bspline.discretize(0.1)[1:]:
-                            v = get_proj(linepoint, plane)
-                            edata += 'L '+ str(v.x) +' '+ str(v.y) + ' '
-            if fill != 'none':
-                edata += 'Z '
-            if edata in pathdata:
-                # do not draw a path on another identical path
-                return ""
-            else:
-                svg += edata
-                pathdata.append(edata)
-        svg += '" '
-        svg += 'stroke="' + stroke + '" '
-        svg += 'stroke-width="' + str(linewidth) + ' px" '
-        svg += 'style="stroke-width:'+ str(linewidth)
-        svg += ';stroke-miterlimit:4'
-        svg += ';stroke-dasharray:' + lstyle
-        svg += ';fill:' + fill
-        try:
-            svg += ';fill-opacity:' + str(fill_opacity)
-        except NameError:
-            pass
-        svg += ';fill-rule: evenodd "'
-        svg += '/>\n'
-        return svg
 
     def getCircle(edge):
         cen = get_proj(edge.Curve.Center, plane)
@@ -622,7 +685,6 @@ def getSVG(obj,
             svg += '</text>\n'
         return svg
 
-
     if not obj:
         pass
 
@@ -633,8 +695,10 @@ def getSVG(obj,
             fill = "#888888"
         else:
             fill = 'url(#'+fillstyle+')'
-        svg += getPath(obj.Edges,pathname="")
-
+        svg += get_path(obj, plane,
+                        fill, pathdata, stroke, linewidth, lstyle,
+                        fill_opacity=None,
+                        edges=obj.Edges, pathname="")
 
     elif utils.get_type(obj) in ["Dimension", "LinearDimension"]:
         if FreeCAD.GuiUp:
@@ -741,13 +805,25 @@ def getSVG(obj,
                     # drawing arc
                     fill= "none"
                     if obj.ViewObject.DisplayMode == "2D":
-                        svg += getPath([prx.circle])
+                        svg += get_path(obj, plane,
+                                        fill, pathdata, stroke, linewidth,
+                                        lstyle, fill_opacity=None,
+                                        edges=[prx.circle])
                     else:
                         if hasattr(prx,"circle1"):
-                            svg += getPath([prx.circle1])
-                            svg += getPath([prx.circle2])
+                            svg += get_path(obj, plane,
+                                            fill, pathdata, stroke, linewidth,
+                                            lstyle, fill_opacity=None,
+                                            edges=[prx.circle1])
+                            svg += get_path(obj, plane,
+                                            fill, pathdata, stroke, linewidth,
+                                            lstyle, fill_opacity=None,
+                                            edges=[prx.circle2])
                         else:
-                            svg += getPath([prx.circle])
+                            svg += get_path(obj, plane,
+                                            fill, pathdata, stroke, linewidth,
+                                            lstyle, fill_opacity=None,
+                                            edges=[prx.circle])
 
                     # drawing arrows
                     if hasattr(obj.ViewObject,"ArrowType"):
@@ -859,7 +935,10 @@ def getSVG(obj,
                 n = 0
                 for e in obj.Shape.Edges:
                     lstyle = lorig
-                    svg += getPath([e])
+                    svg += get_path(obj, plane,
+                                    fill, pathdata, stroke, linewidth, lstyle,
+                                    fill_opacity=None,
+                                    edges=[e])
                     lstyle = "none"
                     pos = ["Start"]
                     if hasattr(vobj,"BubblePosition"):
@@ -895,7 +974,10 @@ def getSVG(obj,
     elif utils.get_type(obj) == "Pipe":
         fill = stroke
         if obj.Base and obj.Diameter:
-            svg += getPath(obj.Base.Shape.Edges)
+            svg += get_path(obj, plane,
+                            fill, pathdata, stroke, linewidth, lstyle,
+                            fill_opacity=None,
+                            edges=obj.Base.Shape.Edges)
         for f in obj.Shape.Faces:
             if len(f.Edges) == 1:
                 if isinstance(f.Edges[0].Curve,Part.Circle):
@@ -914,12 +996,17 @@ def getSVG(obj,
             wire = basewire.copy()
             wire.Placement = placement.multiply(basewire.Placement)
             wires.append(wire)
-        svg += getPath(wires=wires)
+        svg += get_path(obj, plane,
+                        fill, pathdata, stroke, linewidth, lstyle,
+                        fill_opacity=None,
+                        wires=wires)
 
     elif utils.get_type(obj) == "PipeConnector":
         pass
 
     elif utils.get_type(obj) == "Space":
+        fill_opacity = 1
+
         # returns an SVG fragment for the text of a space
         if FreeCAD.GuiUp:
             if not obj.ViewObject:
@@ -937,7 +1024,10 @@ def getSVG(obj,
                                 fill_opacity = 1 - (obj.ViewObject.Transparency / 100.0)
                             else:
                                 fill = "#888888"
-                            svg += getPath(wires=[obj.Proxy.face.OuterWire])
+                            svg += get_path(obj, plane,
+                                            fill, pathdata, stroke, linewidth,
+                                            lstyle, fill_opacity=fill_opacity,
+                                            wires=[obj.Proxy.face.OuterWire])
                 c = utils.get_rgb(obj.ViewObject.TextColor)
                 n = obj.ViewObject.FontName
                 a = 0
@@ -963,6 +1053,8 @@ def getSVG(obj,
     elif obj.isDerivedFrom('Part::Feature'):
         if obj.Shape.isNull():
             return ''
+
+        fill_opacity = 1
         # setting fill
         if obj.Shape.Faces:
             if FreeCAD.GuiUp:
@@ -992,26 +1084,38 @@ def getSVG(obj,
                     # place outer wire first
                     wires = [f.OuterWire]
                     wires.extend([w for w in f.Wires if w.hashCode() != f.OuterWire.hashCode()])
-                    svg += getPath(wires=f.Wires,pathname='%s_f%04d' % \
-                            (obj.Name,i))
+                    svg += get_path(obj, plane,
+                                    fill, pathdata, stroke, linewidth, lstyle,
+                                    fill_opacity=fill_opacity,
+                                    wires=f.Wires,
+                                    pathname='%s_f%04d' % (obj.Name, i))
                     wiredEdges.extend(f.Edges)
             else:
                 for i,w in enumerate(obj.Shape.Wires):
-                    svg += getPath(w.Edges,pathname='%s_w%04d' % \
-                            (obj.Name,i))
+                    svg += get_path(obj, plane,
+                                    fill, pathdata, stroke, linewidth, lstyle,
+                                    fill_opacity=fill_opacity,
+                                    edges=w.Edges,
+                                    pathname='%s_w%04d' % (obj.Name, i))
                     wiredEdges.extend(w.Edges)
             if len(wiredEdges) != len(obj.Shape.Edges):
                 for i,e in enumerate(obj.Shape.Edges):
                     if (DraftGeomUtils.findEdge(e,wiredEdges) is None):
-                        svg += getPath([e],pathname='%s_nwe%04d' % \
-                                (obj.Name,i))
+                        svg += get_path(obj, plane,
+                                        fill, pathdata, stroke, linewidth,
+                                        lstyle, fill_opacity=fill_opacity,
+                                        edges=[e],
+                                        pathname='%s_nwe%04d' % (obj.Name, i))
         else:
             # closed circle or spline
             if obj.Shape.Edges:
                 if isinstance(obj.Shape.Edges[0].Curve,Part.Circle):
                     svg = getCircle(obj.Shape.Edges[0])
                 else:
-                    svg = getPath(obj.Shape.Edges)
+                    svg = get_path(obj, plane,
+                                   fill, pathdata, stroke, linewidth, lstyle,
+                                   fill_opacity=fill_opacity,
+                                   edges=obj.Shape.Edges)
         if FreeCAD.GuiUp:
             if hasattr(obj.ViewObject,"EndArrow") and hasattr(obj.ViewObject,"ArrowType") and (len(obj.Shape.Vertexes) > 1):
                 if obj.ViewObject.EndArrow:

--- a/src/Mod/Draft/getSVG.py
+++ b/src/Mod/Draft/getSVG.py
@@ -116,8 +116,8 @@ def getProj(vec, plane=None):
     return get_proj(vec, plane)
 
 
-def getDiscretized(edge, plane):
-    """Get discretization of the edge."""
+def get_discretized(edge, plane):
+    """Get a discretized edge on a plane."""
     pieces = param.GetFloat("svgDiscretization", 10.0)
 
     if pieces == 0:
@@ -140,6 +140,12 @@ def getDiscretized(edge, plane):
             edata += 'L ' + str(v.x) + ' ' + str(v.y) + ' '
 
     return edata
+
+
+def getDiscretized(edge, plane):
+    """Get a discretized edge on a plane. DEPRECATED."""
+    utils.use_instead("get_discretized")
+    return get_discretized(edge, plane)
 
 
 def getPattern(pat):
@@ -370,7 +376,7 @@ def getSVG(obj,
                                         str(int(flag_large_arc)),\
                                         str(int(flag_sweep)),str(v.x),str(v.y))
                     else:
-                        edata += getDiscretized(e, plane)
+                        edata += get_discretized(e, plane)
                 elif DraftGeomUtils.geomType(e) == "Line":
                     v = get_proj(vs[-1].Point, plane)
                     edata += 'L '+ str(v.x) +' '+ str(v.y) + ' '
@@ -439,7 +445,7 @@ def getSVG(obj,
         else:
             # any other projection: ellipse
             svg = '<path d="'
-            svg += getDiscretized(edge, plane)
+            svg += get_discretized(edge, plane)
             svg += '" '
         svg += 'stroke="' + stroke + '" '
         svg += 'stroke-width="' + str(linewidth) + ' px" '

--- a/src/Mod/Draft/getSVG.py
+++ b/src/Mod/Draft/getSVG.py
@@ -210,6 +210,35 @@ def getCircle(plane,
     return get_circle(plane, fill, stroke, linewidth, lstyle, edge)
 
 
+def get_ellipse(plane,
+                fill, stroke, linewidth, lstyle,
+                edge):
+    """Get the SVG representation from an elliptical edge."""
+    cen = get_proj(edge.Curve.Center, plane)
+    mir = edge.Curve.MinorRadius
+    mar = edge.Curve.MajorRadius
+    svg = '<ellipse '
+    svg += 'cx="{}" cy="{}" '.format(cen.x, cen.y)
+    svg += 'rx="{}" ry="{}" '.format(mar, mir)
+    svg += 'stroke="{}" '.format(stroke)
+    svg += 'stroke-width="{} px" '.format(linewidth)
+    svg += 'style="'
+    svg += 'stroke-width:{};'.format(linewidth)
+    svg += 'stroke-miterlimit:4;'
+    svg += 'stroke-dasharray:{};'.format(lstyle)
+    svg += 'fill:{}'.format(fill) + '"'
+    svg += '/>\n'
+    return svg
+
+
+def getEllipse(plane,
+               fill, stroke, linewidth, lstyle,
+               edge):
+    """Get the SVG representation from an elliptical edge. DEPRECATED."""
+    utils.use_instead("get_ellipse")
+    return get_ellipse(plane, fill, stroke, linewidth, lstyle, edge)
+
+
 def get_path(obj, plane,
              fill, pathdata, stroke, linewidth, lstyle,
              fill_opacity=None,
@@ -301,7 +330,9 @@ def get_path(obj, plane,
                             return svg
                         elif len(e.Vertexes) == 1 and isellipse:
                             # Complete ellipse not only arc
-                            # svg = getEllipse(e)
+                            # svg = get_ellipse(plane,
+                            #                   fill, stroke, linewidth,
+                            #                   lstyle, edge)
                             # return svg
 
                             # Difference in angles
@@ -545,23 +576,6 @@ def getSVG(obj,
     else:
         if hasattr(obj, "ViewObject") and hasattr(obj.ViewObject, "DrawStyle"):
             lstyle = get_line_style(obj.ViewObject.DrawStyle, scale)
-
-    def getEllipse(edge):
-        cen = get_proj(edge.Curve.Center, plane)
-        mir = edge.Curve.MinorRadius
-        mar = edge.Curve.MajorRadius
-        svg = '<ellipse cx="' + str(cen.x)
-        svg += '" cy="' + str(cen.y)
-        svg += '" rx="' + str(mar)
-        svg += '" ry="' + str(mir)+'" '
-        svg += 'stroke="' + stroke + '" '
-        svg += 'stroke-width="' + str(linewidth) + ' px" '
-        svg += 'style="stroke-width:'+ str(linewidth)
-        svg += ';stroke-miterlimit:4'
-        svg += ';stroke-dasharray:' + lstyle
-        svg += ';fill:' + fill + '"'
-        svg += '/>\n'
-        return svg
 
     def getArrow(arrowtype,point,arrowsize,color,linewidth,angle=0):
         svg = ""

--- a/src/Mod/Draft/getSVG.py
+++ b/src/Mod/Draft/getSVG.py
@@ -239,6 +239,85 @@ def getEllipse(plane,
     return get_ellipse(plane, fill, stroke, linewidth, lstyle, edge)
 
 
+def get_arrow(obj,
+              arrowtype, point, arrowsize, color, linewidth, angle=0):
+    """Get the SVG representation from an arrow."""
+    svg = ""
+
+    if not FreeCAD.GuiUp or not obj.ViewObject:
+        return svg
+
+    _cx_cy_r = 'cx="{}" cy="{}" r="{}"'.format(point.x, point.y, arrowsize)
+    _rotate = 'rotate({},{},{})'.format(math.degrees(angle),
+                                        point.x, point.y)
+    _transl = 'translate({},{})'.format(point.x, point.y)
+    _scale = 'scale({},{})'.format(arrowsize, arrowsize)
+    _style = 'style="stroke-miterlimit:4;stroke-dasharray:none"'
+
+    if obj.ViewObject.ArrowType == "Circle":
+        svg += '<circle '
+        svg += _cx_cy_r + ' '
+        svg += 'fill="{}" stroke="{}" '.format("none", color)
+        svg += 'style="stroke-width:{};'.format(linewidth)
+        svg += 'stroke-miterlimit:4;stroke-dasharray:none" '
+        svg += 'freecad:skip="1"'
+        svg += '/>\n'
+    elif obj.ViewObject.ArrowType == "Dot":
+        svg += '<circle '
+        svg += _cx_cy_r + ' '
+        svg += 'fill="{}" stroke="{}" '.format(color, "none")
+        svg += _style + ' '
+        svg += 'freecad:skip="1"'
+        svg += '/>\n'
+    elif obj.ViewObject.ArrowType == "Arrow":
+        svg += '<path '
+        svg += 'transform="'
+        svg += _rotate + ' '
+        svg += _transl + ' '
+        svg += _scale + '" '
+        svg += 'freecad:skip="1" '
+        svg += 'fill="{}" stroke="{}" '.format(color, "none")
+        svg += _style + ' '
+        svg += 'd="M 0 0 L 4 1 L 4 -1 Z"'
+        svg += '/>\n'
+    elif obj.ViewObject.ArrowType == "Tick":
+        svg += '<path '
+        svg += 'transform="'
+        svg += _rotate + ' '
+        svg += _transl + ' '
+        svg += _scale + '" '
+        svg += 'freecad:skip="1" '
+        svg += 'fill="{}" stroke="{}" '.format(color, "none")
+        svg += _style + ' '
+        svg += 'd="M -1 -2 L 0 2 L 1 2 L 0 -2 Z"'
+        svg += '/>\n'
+    elif obj.ViewObject.ArrowType == "Tick-2":
+        svg += '<line '
+        svg += 'transform="'
+        svg += 'rotate({},{},{}) '.format(math.degrees(angle) + 45,
+                                          point.x, point.y)
+        svg += _transl + '" '
+        svg += 'freecad:skip="1" '
+        svg += 'fill="{}" stroke="{}" '.format("none", color)
+        svg += 'style="stroke-dasharray:none;stroke-linecap:square;'
+        svg += 'stroke-width:{}" '.format(linewidth)
+        svg += 'x1="-{}" y1="0" '.format(2 * arrowsize)
+        svg += 'x2="{}" y2="0"'.format(2 * arrowsize)
+        svg += '/>\n'
+    else:
+        _wrn("getSVG: arrow type not implemented")
+
+    return svg
+
+
+def getArrow(obj,
+             arrowtype, point, arrowsize, color, linewidth, angle=0):
+    """Get the SVG representation from an arrow. DEPRECATED."""
+    utils.use_instead("get_arrow")
+    return get_arrow(obj,
+                     arrowtype, point, arrowsize, color, linewidth, angle)
+
+
 def get_path(obj, plane,
              fill, pathdata, stroke, linewidth, lstyle,
              fill_opacity=None,
@@ -577,55 +656,6 @@ def getSVG(obj,
         if hasattr(obj, "ViewObject") and hasattr(obj.ViewObject, "DrawStyle"):
             lstyle = get_line_style(obj.ViewObject.DrawStyle, scale)
 
-    def getArrow(arrowtype,point,arrowsize,color,linewidth,angle=0):
-        svg = ""
-        if FreeCAD.GuiUp:
-            if not obj.ViewObject:
-                return svg
-            if obj.ViewObject.ArrowType == "Circle":
-                svg += '<circle cx="'+str(point.x)+'" cy="'+str(point.y)
-                svg += '" r="'+str(arrowsize)+'" '
-                svg += 'fill="none" stroke="'+ color + '" '
-                svg += 'style="stroke-width:'+ str(linewidth) + ';stroke-miterlimit:4;stroke-dasharray:none" '
-                svg += 'freecad:skip="1"'
-                svg += '/>\n'
-            elif obj.ViewObject.ArrowType == "Dot":
-                svg += '<circle cx="'+str(point.x)+'" cy="'+str(point.y)
-                svg += '" r="'+str(arrowsize)+'" '
-                svg += 'fill="'+ color +'" stroke="none" '
-                svg += 'style="stroke-miterlimit:4;stroke-dasharray:none" '
-                svg += 'freecad:skip="1"'
-                svg += '/>\n'
-            elif obj.ViewObject.ArrowType == "Arrow":
-                svg += '<path transform="rotate('+str(math.degrees(angle))
-                svg += ','+ str(point.x) + ',' + str(point.y) + ') '
-                svg += 'translate(' + str(point.x) + ',' + str(point.y) + ') '
-                svg += 'scale('+str(arrowsize)+','+str(arrowsize)+')" freecad:skip="1" '
-                svg += 'fill="'+ color +'" stroke="none" '
-                svg += 'style="stroke-miterlimit:4;stroke-dasharray:none" '
-                svg += 'd="M 0 0 L 4 1 L 4 -1 Z"/>\n'
-            elif obj.ViewObject.ArrowType == "Tick":
-                svg += '<path transform="rotate('+str(math.degrees(angle))
-                svg += ','+ str(point.x) + ',' + str(point.y) + ') '
-                svg += 'translate(' + str(point.x) + ',' + str(point.y) + ') '
-                svg += 'scale('+str(arrowsize)+','+str(arrowsize)+')" freecad:skip="1" '
-                svg += 'fill="'+ color +'" stroke="none" '
-                svg += 'style="stroke-miterlimit:4;stroke-dasharray:none" '
-                svg += 'd="M -1 -2 L 0 2 L 1 2 L 0 -2 Z"/>\n'
-            elif obj.ViewObject.ArrowType == "Tick-2":
-                svg += '<line transform="rotate('+str(math.degrees(angle)+45)
-                svg += ','+ str(point.x) + ',' + str(point.y) + ') '
-                svg += 'translate(' + str(point.x) + ',' + str(point.y) + ') '
-                svg += '" freecad:skip="1" '
-                svg += 'fill="none" stroke="'+ color +'" '
-                svg += 'style="stroke-dasharray:none;stroke-linecap:square;'
-                svg += 'stroke-width:'+ str(linewidth) +'" '
-                svg += 'x1="-'+ str(arrowsize*2) +'" y1="0" '
-                svg += 'x2="' + str(arrowsize*2) +'" y2="0" />\n'
-            else:
-                print("getSVG: arrow type not implemented")
-        return svg
-
     def getOvershoot(point,shootsize,color,linewidth,angle=0):
         svg = '<line transform="rotate('+str(math.degrees(angle))
         svg += ','+ str(point.x) + ',' + str(point.y) + ') '
@@ -821,8 +851,14 @@ def getSVG(obj,
                             if hasattr(obj.ViewObject,"FlipArrows"):
                                 if obj.ViewObject.FlipArrows:
                                     angle = angle+math.pi
-                            svg += getArrow(obj.ViewObject.ArrowType,p2,arrowsize,stroke,linewidth,angle)
-                            svg += getArrow(obj.ViewObject.ArrowType,p3,arrowsize,stroke,linewidth,angle+math.pi)
+                            svg += get_arrow(obj,
+                                             obj.ViewObject.ArrowType,
+                                             p2, arrowsize, stroke, linewidth,
+                                             angle)
+                            svg += get_arrow(obj,
+                                             obj.ViewObject.ArrowType,
+                                             p3, arrowsize, stroke, linewidth,
+                                             angle + math.pi)
 
                     # drawing text
                     svg += getText(stroke,fontsize,obj.ViewObject.FontName,tangle,tbase,prx.string)
@@ -872,8 +908,14 @@ def getSVG(obj,
                             if obj.ViewObject.FlipArrows:
                                 angle1 = angle1+math.pi
                                 angle2 = angle2+math.pi
-                        svg += getArrow(obj.ViewObject.ArrowType,p2,arrowsize,stroke,linewidth,angle1)
-                        svg += getArrow(obj.ViewObject.ArrowType,p3,arrowsize,stroke,linewidth,angle2)
+                        svg += get_arrow(obj,
+                                         obj.ViewObject.ArrowType,
+                                         p2, arrowsize, stroke, linewidth,
+                                         angle1)
+                        svg += get_arrow(obj,
+                                         obj.ViewObject.ArrowType,
+                                         p3, arrowsize, stroke, linewidth,
+                                         angle2)
 
                     # drawing text
                     if obj.ViewObject.DisplayMode == "2D":
@@ -915,14 +957,11 @@ def getSVG(obj,
             if hasattr(obj.ViewObject, "ArrowType") and len(obj.Points) >= 2:
                 last_segment = FreeCAD.Vector(obj.Points[-1] - obj.Points[-2])
                 angle = -DraftVecUtils.angle(get_proj(last_segment, plane)) + math.pi
-                svg += getArrow(
-                    arrowtype=obj.ViewObject.ArrowType,
-                    point=proj_points[-1],
-                    arrowsize=obj.ViewObject.ArrowSize.Value/pointratio,
-                    color=stroke,
-                    linewidth=linewidth,
-                    angle=angle
-                )
+                svg += get_arrow(obj,
+                                 obj.ViewObject.ArrowType,
+                                 proj_points[-1],
+                                 obj.ViewObject.ArrowSize.Value/pointratio,
+                                 stroke, linewidth, angle)
 
         # print text
         if FreeCAD.GuiUp:
@@ -1162,7 +1201,9 @@ def getSVG(obj,
                     p2 = get_proj(obj.Shape.Vertexes[-2].Point, plane)
                     angle = -DraftVecUtils.angle(p2.sub(p1))
                     arrowsize = obj.ViewObject.ArrowSize.Value/pointratio
-                    svg += getArrow(obj.ViewObject.ArrowType,p1,arrowsize,stroke,linewidth,angle)
+                    svg += get_arrow(obj,
+                                     obj.ViewObject.ArrowType,
+                                     p1, arrowsize, stroke, linewidth, angle)
 
     # techdraw expects bottom-to-top coordinates
     if techdraw:

--- a/src/Mod/Draft/getSVG.py
+++ b/src/Mod/Draft/getSVG.py
@@ -478,6 +478,11 @@ def getText(plane, techdraw,
                     linespacing, align, flip)
 
 
+def format_point(coords, action='L'):
+    """Return a string with a formatted point."""
+    return "{action}{x},{y}".format(x=coords.x, y=coords.y, action=action)
+
+
 def get_path(obj, plane,
              fill, pathdata, stroke, linewidth, lstyle,
              fill_opacity=None,
@@ -1010,11 +1015,6 @@ def getSVG(obj,
 
     elif utils.get_type(obj) == "Label":
         if getattr(obj.ViewObject, "Line", True):  # some Labels may have no Line property
-            def format_point(coords, action='L'):
-                return "{action}{x},{y}".format(
-                    x=coords.x, y=coords.y, action=action
-                )
-
             # Draw multisegment line
             proj_points = list(map(lambda x: get_proj(x, plane), obj.Points))
             path_dir_list = [format_point(proj_points[0], action='M')]

--- a/src/Mod/Draft/getSVG.py
+++ b/src/Mod/Draft/getSVG.py
@@ -318,6 +318,29 @@ def getArrow(obj,
                      arrowtype, point, arrowsize, color, linewidth, angle)
 
 
+def get_overshoot(point, shootsize, color, linewidth, angle=0):
+    """Get the SVG representation of a dimension line overshoot."""
+    svg = '<line '
+    svg += 'transform="'
+    svg += 'rotate({},{},{}) '.format(math.degrees(angle),
+                                      point.x, point.y)
+    svg += 'translate({},{})" '.format(point.x, point.y)
+    svg += 'freecad:skip="1" '
+    svg += 'fill="{}" stroke="{}" '.format("none", color)
+    svg += 'style="stroke-dasharray:none;stroke-linecap:square;'
+    svg += 'stroke-width:{}" '.format(linewidth)
+    svg += 'x1="0" y1="0" '
+    svg += 'x2="{}" y2="0"'.format(-1 * shootsize)
+    svg += '/>\n'
+    return svg
+
+
+def getOvershoot(point, shootsize, color, linewidth, angle=0):
+    """Get the SVG representation of a dimension line overshoot. DEPRECATED."""
+    utils.use_instead("get_overshoot")
+    return get_overshoot(point, shootsize, color, linewidth, angle)
+
+
 def get_path(obj, plane,
              fill, pathdata, stroke, linewidth, lstyle,
              fill_opacity=None,
@@ -656,18 +679,6 @@ def getSVG(obj,
         if hasattr(obj, "ViewObject") and hasattr(obj.ViewObject, "DrawStyle"):
             lstyle = get_line_style(obj.ViewObject.DrawStyle, scale)
 
-    def getOvershoot(point,shootsize,color,linewidth,angle=0):
-        svg = '<line transform="rotate('+str(math.degrees(angle))
-        svg += ','+ str(point.x) + ',' + str(point.y) + ') '
-        svg += 'translate(' + str(point.x) + ',' + str(point.y) + ') '
-        svg += '" freecad:skip="1" '
-        svg += 'fill="none" stroke="'+ color +'" '
-        svg += 'style="stroke-dasharray:none;stroke-linecap:square;'
-        svg += 'stroke-width:'+ str(linewidth) +'" '
-        svg += 'x1="0" y1="0" '
-        svg += 'x2="'+ str(shootsize*-1) +'" y2="0" />\n'
-        return svg
-
     def getText(tcolor,fontsize,fontname,angle,base,text,linespacing=0.5,align="center",flip=True):
         if isinstance(angle,FreeCAD.Rotation):
             if not plane:
@@ -837,13 +848,17 @@ def getSVG(obj,
                         # drawing dimension and extension lines overshoots
                         if hasattr(obj.ViewObject,"DimOvershoot") and obj.ViewObject.DimOvershoot.Value:
                             shootsize = obj.ViewObject.DimOvershoot.Value/pointratio
-                            svg += getOvershoot(p2,shootsize,stroke,linewidth,angle)
-                            svg += getOvershoot(p3,shootsize,stroke,linewidth,angle+math.pi)
+                            svg += get_overshoot(p2, shootsize, stroke,
+                                                 linewidth, angle)
+                            svg += get_overshoot(p3, shootsize, stroke,
+                                                 linewidth, angle + math.pi)
                         if hasattr(obj.ViewObject,"ExtOvershoot") and obj.ViewObject.ExtOvershoot.Value:
                             shootsize = obj.ViewObject.ExtOvershoot.Value/pointratio
                             shootangle = -DraftVecUtils.angle(p1.sub(p2))
-                            svg += getOvershoot(p2,shootsize,stroke,linewidth,shootangle)
-                            svg += getOvershoot(p3,shootsize,stroke,linewidth,shootangle)
+                            svg += get_overshoot(p2, shootsize, stroke,
+                                                 linewidth, shootangle)
+                            svg += get_overshoot(p3, shootsize, stroke,
+                                                 linewidth, shootangle)
 
                         # drawing arrows
                         if hasattr(obj.ViewObject,"ArrowType"):

--- a/src/Mod/Draft/importSVG.py
+++ b/src/Mod/Draft/importSVG.py
@@ -1876,7 +1876,7 @@ def export(exportList, filename):
         else:
             # raw-style exports do not translate the sketch
             svg.write('<g id="%s" transform="scale(1,-1)">\n' % ob.Name)
-        svg.write(Draft.getSVG(ob))
+        svg.write(Draft.get_svg(ob))
         _label_enc = str(ob.Label.encode('utf8'))
         _label = _label_enc.replace('<', '&lt;').replace('>', '&gt;')
         # replace('"', "&quot;")


### PR DESCRIPTION
Previously the `getSVG.getSVG` function had many nested functions which meant the individual functions could not be tested by themselves, as they would need to inherit the environment (variables) of the topmost function.

Now each subfuction can be called by itself, which means that it can be tested and improved individually.

The code can be further split into more functions, which will be done at another time to solve some pending issues. For example, currently the SVG representation of "Arch Pipes" seems to be broken. Also, more complete documentation strings should be added to explain the input parameters.

Instead of testing `obj.isDerivedFrom('Part::Feature')` we test for a Shape, `hasattr(obj, 'Shape')`. This is to support generating the SVG strings from `App::Links`. Forum thread: [[ArchView - Link to Part Object] Link objects missin in ArchView](https://forum.freecadweb.org/viewtopic.php?f=35&t=49026)

Forum discussion: [Improvements in SVG](https://forum.freecadweb.org/viewtopic.php?f=23&t=49096)

---

The first commit in this pull request corresponds to the commit in #3740, therefore that request needs to be merged first before merging this one.

---

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists