### PR TITLE
[Gui.command] 2 new python Gui commands: Gui.getCommandDefaultShortcu…

### DIFF
--- a/src/Gui/Application.h
+++ b/src/Gui/Application.h
@@ -261,7 +261,9 @@ public:
     static PyObject* sGetCommandInfo           (PyObject *self,PyObject *args);
     static PyObject* sListCommands             (PyObject *self,PyObject *args);
     static PyObject* sGetCommandShortcut       (PyObject *self,PyObject *args);
+    static PyObject* sGetCommandDefaultShortcut(PyObject *self,PyObject *args);
     static PyObject* sSetCommandShortcut       (PyObject *self,PyObject *args);
+    static PyObject* sResetCommandShortcut     (PyObject *self,PyObject *args); //back to default value
     static PyObject* sIsCommandActive          (PyObject *self,PyObject *args);
     static PyObject* sUpdateCommands           (PyObject *self,PyObject *args);
 


### PR DESCRIPTION
…t() and Gui.resetCommandShortcut()

example:

Gui.getCommandDefaultShortcut('Std_AxisCross') -> 'A,C'
Gui.resetCommandShortcut('Std_AxisCross') -> True (and resets shortcut to the default 'A,C')

related forum topic:

https://forum.freecadweb.org/viewtopic.php?f=8&t=44973&start=40

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
