### PR TITLE
Arch: simple cleanup to the importer, spacing, and PEP8

### DIFF
--- a/src/Mod/Arch/importIFCmulticore.py
+++ b/src/Mod/Arch/importIFCmulticore.py
@@ -18,14 +18,14 @@
 # *   USA                                                                   *
 # *                                                                         *
 # ***************************************************************************
+"""FreeCAD IFC importer - Multicore version"""
 
 from __future__ import print_function
-
-"""FreeCAD IFC importer - Multicore version"""
 
 import sys
 import time
 import os
+
 import FreeCAD
 import Draft
 import Arch


### PR DESCRIPTION
Simple cleanup of the IFC importer. Many small fixes to make sure the code is compliant with PEP8 and correctly documented.

---

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists