### PR TITLE
FEM: fix Python 2 error with UTF8 character

### DIFF
--- a/src/Mod/Fem/femexamples/equation_electrostatics_electricforce_elmer_nongui6.py
+++ b/src/Mod/Fem/femexamples/equation_electrostatics_electricforce_elmer_nongui6.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # ***************************************************************************
 # *   Copyright (c) 2020 Sudhanshu Dubey <sudhanshu.thethunder@gmail.com>   *
 # *                                                                         *


### PR DESCRIPTION
Following 64c9fa0, we add the `utf8` encoding for a Python file, so that the unit tests of FEM pass with Python 2.

---

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists