### PR TITLE
Draft: Offset save and restore the value of OCC checkbox

### DIFF
--- a/src/Mod/Draft/draftguitools/gui_offset.py
+++ b/src/Mod/Draft/draftguitools/gui_offset.py
@@ -100,7 +100,11 @@ class Offset(gui_base_original.Modifier):
             self.dvec = None
             self.npts = None
             self.constrainSeg = None
+
             self.ui.offsetUi()
+            occmode = utils.param.GetBool("Offset_OCC", False)
+            self.ui.occOffset.setChecked(occmode)
+
             self.linetrack = trackers.lineTracker()
             self.faces = False
             self.shape = self.sel.Shape
@@ -180,6 +184,7 @@ class Offset(gui_base_original.Modifier):
                     a = -DraftVecUtils.angle(v1, v2)
                     self.dvec = DraftVecUtils.rotate(d, a, plane.axis)
                     occmode = self.ui.occOffset.isChecked()
+                    utils.param.SetBool("Offset_OCC", occmode)
                     _wire = DraftGeomUtils.offsetWire(self.shape,
                                                       self.dvec,
                                                       occ=occmode)
@@ -220,6 +225,7 @@ class Offset(gui_base_original.Modifier):
             if (arg["State"] == "DOWN") and (arg["Button"] == "BUTTON1"):
                 copymode = False
                 occmode = self.ui.occOffset.isChecked()
+                utils.param.SetBool("Offset_OCC", occmode)
                 if (gui_tool_utils.hasMod(arg, gui_tool_utils.MODALT)
                         or self.ui.isCopy.isChecked()):
                     copymode = True
@@ -294,6 +300,7 @@ class Offset(gui_base_original.Modifier):
                 delta = DraftVecUtils.toString(self.dvec)
             copymode = False
             occmode = self.ui.occOffset.isChecked()
+            utils.param.SetBool("Offset_OCC", occmode)
             if self.ui.isCopy.isChecked():
                 copymode = True
             Gui.addModule("Draft")


### PR DESCRIPTION
The Draft Offset tool can perform a simple offset or an "OCC-offset" which rounds the sharp corners of the shape.

A checkbox in the task panel controls this. The state of this checkbox is saved in a parameter when the command is executed, so that when the command is launched again the value used in the previous run is restored.

Requested in the forum: [[Draft] Offset setting not stored](https://forum.freecadweb.org/viewtopic.php?f=23&t=49125)

---

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).