### PR TITLE
[PD] patterning UI: avoid whitespace

### DIFF
--- a/src/Mod/PartDesign/Gui/TaskLinearPatternParameters.ui
+++ b/src/Mod/PartDesign/Gui/TaskLinearPatternParameters.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>270</width>
-    <height>366</height>
+    <height>339</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -127,19 +127,6 @@
       <bool>true</bool>
      </property>
     </widget>
-   </item>
-   <item>
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
    </item>
   </layout>
  </widget>

--- a/src/Mod/PartDesign/Gui/TaskMirroredParameters.ui
+++ b/src/Mod/PartDesign/Gui/TaskMirroredParameters.ui
@@ -80,19 +80,6 @@
      </property>
     </widget>
    </item>
-   <item>
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
   </layout>
  </widget>
  <resources/>

--- a/src/Mod/PartDesign/Gui/TaskPolarPatternParameters.ui
+++ b/src/Mod/PartDesign/Gui/TaskPolarPatternParameters.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>253</width>
-    <height>366</height>
+    <height>339</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -133,19 +133,6 @@
       <bool>true</bool>
      </property>
     </widget>
-   </item>
-   <item>
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
    </item>
   </layout>
  </widget>


### PR DESCRIPTION
- also have a uniform list height in all patterning dialogs

Before:
![FreeCAD_4viaFORk48](https://user-images.githubusercontent.com/1828501/89089086-f1e61200-d39b-11ea-8d32-e5f1a97154a3.png)

With PR:
![FreeCAD_wHsE4qUKVu](https://user-images.githubusercontent.com/1828501/89089097-fad6e380-d39b-11ea-9809-abc07ddbf03e.png)
