### PR TITLE
[Gui Commands] new command: listCommandsByShortcut(string) -- returns…

### DIFF
--- a/src/Gui/Application.h
+++ b/src/Gui/Application.h
@@ -260,6 +260,7 @@ public:
     static PyObject* sAddCommand               (PyObject *self,PyObject *args);
     static PyObject* sGetCommandInfo           (PyObject *self,PyObject *args);
     static PyObject* sListCommands             (PyObject *self,PyObject *args);
+    static PyObject* sListCommandsByShortcut   (PyObject *self,PyObject *args);
     static PyObject* sGetCommandShortcut       (PyObject *self,PyObject *args);
     static PyObject* sSetCommandShortcut       (PyObject *self,PyObject *args);
     static PyObject* sIsCommandActive          (PyObject *self,PyObject *args);


### PR DESCRIPTION
… a python list of all commands that are using the shortcut.  Search is case-insensitive and ignores spaces

Passing an empty string will produce all commands currently loaded that do not have shortcuts.

Example: 

listCommandsByShortcut('A,C')
['Std_AxisCross']

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
