### PR TITLE
[Draft]Fix a typo in draft snapping

### DIFF
--- a/src/Mod/Draft/draftguitools/gui_snapper.py
+++ b/src/Mod/Draft/draftguitools/gui_snapper.py
@@ -435,7 +435,7 @@ class Snapper:
                         snaps.append(self.snapToVertex(self.snapInfo, active=True))
                     else:
                         # all other cases (face, etc...) default to passive snap
-                        snapArray = [self.snapToVertex(self.snapInfo)]
+                        snaps = [self.snapToVertex(self.snapInfo)]
 
             elif Draft.getType(obj) == "Dimension":
                 # for dimensions we snap to their 2 points:


### PR DESCRIPTION
Not sure how it impacts the behavior, but definitely a typo.

Introduced here: https://github.com/FreeCAD/FreeCAD/commit/4748657016c76765fc99c20db2606475e0ebebdc
by @yorikvanhavre 