### PR TITLE
Arch: Multi material wall

### DIFF
--- a/src/Mod/Arch/ArchWall.py
+++ b/src/Mod/Arch/ArchWall.py
@@ -1342,10 +1342,10 @@ class _Wall(ArchComponent.Component):
                             if curAligns == "Left":
 
                                 if layers:
-                                    curWidth = abs(layers[i])
+                                    curWidth = [abs(layers[i])]
                                     off = off+layeroffset
-                                    dvec.multiply(curWidth)
-                                    layeroffset += abs(curWidth)
+                                    dvec.multiply(curWidth[0])
+                                    layeroffset += abs(curWidth[0])
                                 else:
                                     curWidth = widths
                                     dvec.multiply(width)
@@ -1386,10 +1386,10 @@ class _Wall(ArchComponent.Component):
                                 dvec = dvec.negative()
 
                                 if layers:
-                                    curWidth = abs(layers[i])
+                                    curWidth = [abs(layers[i])]
                                     off = off+layeroffset
-                                    dvec.multiply(curWidth)
-                                    layeroffset += abs(curWidth)
+                                    dvec.multiply(curWidth[0])
+                                    layeroffset += abs(curWidth[0])
                                 else:
                                     curWidth = widths
                                     dvec.multiply(width)


### PR DESCRIPTION
Fix a bug introduced in 40600a55c2fe71ff589be677f6e427ccc937d003 by @yorikvanhavre 

**Steps to reproduce**:
Assign a multi-material to the wall and change wall align to Left

**Expected**:

Wall alignment is changed

**Actual**:

an error in console.