### PR TITLE
[Report View] fix inconsistencies

### DIFF
--- a/src/Gui/ReportView.cpp
+++ b/src/Gui/ReportView.cpp
@@ -632,13 +632,13 @@ void ReportOutput::onToggleShowReportViewOnError()
 
 void ReportOutput::onToggleShowReportViewOnNormalMessage()
 {
-    bool show = getWindowParameter()->GetBool("checkShowReportViewOnNormalMessage", true);
+    bool show = getWindowParameter()->GetBool("checkShowReportViewOnNormalMessage", false);
     getWindowParameter()->SetBool("checkShowReportViewOnNormalMessage", !show);
 }
 
 void ReportOutput::onToggleShowReportViewOnLogMessage()
 {
-    bool show = getWindowParameter()->GetBool("checkShowReportViewOnLogMessage", true);
+    bool show = getWindowParameter()->GetBool("checkShowReportViewOnLogMessage", false);
     getWindowParameter()->SetBool("checkShowReportViewOnLogMessage", !show);
 }
 


### PR DESCRIPTION
Make default values consistent for whether to show report view on log and normal messages.  Default values should be warnings: true, errors: true, normals: false, logs: false.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
