### PR TITLE
[PD] bind expression to pad offset

### DIFF
--- a/src/Mod/PartDesign/Gui/TaskPadParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskPadParameters.cpp
@@ -96,6 +96,7 @@ TaskPadParameters::TaskPadParameters(ViewProviderPad *PadView, QWidget *parent, 
     // Bind input fields to properties
     ui->lengthEdit->bind(pcPad->Length);
     ui->lengthEdit2->bind(pcPad->Length2);
+    ui->offsetEdit->bind(pcPad->Offset);
     ui->checkBoxMidplane->setChecked(midplane);
     // According to bug #0000521 the reversed option
     // shouldn't be de-activated if the pad has a support face


### PR DESCRIPTION
It is strangely not possible to use an expression for a pad offset, but this works fine, see the forum for an example:
https://forum.freecadweb.org/viewtopic.php?f=17&t=49314

Thus allow an expression.