### PR TITLE
[PD and Part] add possibility to create skew prisms

### DIFF
--- a/src/Mod/Part/App/PrimitiveFeature.cpp
+++ b/src/Mod/Part/App/PrimitiveFeature.cpp
@@ -561,10 +561,15 @@ PROPERTY_SOURCE(Part::Prism, Part::Primitive)
 
 Prism::Prism(void)
 {
-    ADD_PROPERTY_TYPE(Polygon,(6.0),"Prism",App::Prop_None,"Number of sides in the polygon, of the prism");
-    ADD_PROPERTY_TYPE(Circumradius,(2.0),"Prism",App::Prop_None,"Circumradius (centre to vertex) of the polygon, of the prism");
-    ADD_PROPERTY_TYPE(Height,(10.0f),"Prism",App::Prop_None,"The height of the prism");
+    ADD_PROPERTY_TYPE(Polygon, (6.0), "Prism", App::Prop_None, "Number of sides in the polygon, of the prism");
+    ADD_PROPERTY_TYPE(Circumradius, (2.0), "Prism", App::Prop_None, "Circumradius (centre to vertex) of the polygon, of the prism");
+    ADD_PROPERTY_TYPE(Height, (10.0f), "Prism", App::Prop_None, "The height of the prism");
+    ADD_PROPERTY_TYPE(XSkew, (10.0f), "Prism", App::Prop_None, "Angle in x-direction");
+    ADD_PROPERTY_TYPE(YSkew, (10.0f), "Prism", App::Prop_None, "Angle in y-direction");
     Polygon.setConstraints(&polygonRange);
+    static const App::PropertyQuantityConstraint::Constraints angleConstraint = { -89.99999, 89.99999, 1.0 };
+    XSkew.setConstraints(&angleConstraint);
+    YSkew.setConstraints(&angleConstraint);
 }
 
 short Prism::mustExecute() const
@@ -574,6 +579,10 @@ short Prism::mustExecute() const
     if (Circumradius.isTouched())
         return 1;
     if (Height.isTouched())
+        return 1;
+    if (XSkew.isTouched())
+        return 1;
+    if (YSkew.isTouched())
         return 1;
     return Primitive::mustExecute();
 }
@@ -602,7 +611,11 @@ App::DocumentObjectExecReturn *Prism::execute(void)
         }
         mkPoly.Add(gp_Pnt(v.x,v.y,v.z));
         BRepBuilderAPI_MakeFace mkFace(mkPoly.Wire());
-        BRepPrimAPI_MakePrism mkPrism(mkFace.Face(), gp_Vec(0,0,Height.getValue()));
+        // the direction vector for the prism is the height for z and the skew
+        BRepPrimAPI_MakePrism mkPrism(mkFace.Face(),
+            gp_Vec(tan(XSkew.getValue() * D_PI / 180) * Height.getValue(),
+                   tan(YSkew.getValue() * D_PI / 180) * Height.getValue(),
+                   Height.getValue()));
         this->Shape.setValue(mkPrism.Shape());
     }
     catch (Standard_Failure& e) {

--- a/src/Mod/Part/App/PrimitiveFeature.cpp
+++ b/src/Mod/Part/App/PrimitiveFeature.cpp
@@ -564,12 +564,12 @@ Prism::Prism(void)
     ADD_PROPERTY_TYPE(Polygon, (6.0), "Prism", App::Prop_None, "Number of sides in the polygon, of the prism");
     ADD_PROPERTY_TYPE(Circumradius, (2.0), "Prism", App::Prop_None, "Circumradius (centre to vertex) of the polygon, of the prism");
     ADD_PROPERTY_TYPE(Height, (10.0f), "Prism", App::Prop_None, "The height of the prism");
-    ADD_PROPERTY_TYPE(XSkew, (10.0f), "Prism", App::Prop_None, "Angle in x-direction");
-    ADD_PROPERTY_TYPE(YSkew, (10.0f), "Prism", App::Prop_None, "Angle in y-direction");
+    ADD_PROPERTY_TYPE(FirstSkew, (0.0f), "Prism", App::Prop_None, "Angle in first direction");
+    ADD_PROPERTY_TYPE(SecondSkew, (0.0f), "Prism", App::Prop_None, "Angle in second direction");
     Polygon.setConstraints(&polygonRange);
     static const App::PropertyQuantityConstraint::Constraints angleConstraint = { -89.99999, 89.99999, 1.0 };
-    XSkew.setConstraints(&angleConstraint);
-    YSkew.setConstraints(&angleConstraint);
+    FirstSkew.setConstraints(&angleConstraint);
+    SecondSkew.setConstraints(&angleConstraint);
 }
 
 short Prism::mustExecute() const
@@ -580,9 +580,9 @@ short Prism::mustExecute() const
         return 1;
     if (Height.isTouched())
         return 1;
-    if (XSkew.isTouched())
+    if (FirstSkew.isTouched())
         return 1;
-    if (YSkew.isTouched())
+    if (SecondSkew.isTouched())
         return 1;
     return Primitive::mustExecute();
 }
@@ -613,8 +613,8 @@ App::DocumentObjectExecReturn *Prism::execute(void)
         BRepBuilderAPI_MakeFace mkFace(mkPoly.Wire());
         // the direction vector for the prism is the height for z and the skew
         BRepPrimAPI_MakePrism mkPrism(mkFace.Face(),
-            gp_Vec(tan(XSkew.getValue() * D_PI / 180) * Height.getValue(),
-                   tan(YSkew.getValue() * D_PI / 180) * Height.getValue(),
+            gp_Vec(tan(FirstSkew.getValue() * D_PI / 180) * Height.getValue(),
+                   tan(SecondSkew.getValue() * D_PI / 180) * Height.getValue(),
                    Height.getValue()));
         this->Shape.setValue(mkPrism.Shape());
     }

--- a/src/Mod/Part/App/PrimitiveFeature.h
+++ b/src/Mod/Part/App/PrimitiveFeature.h
@@ -209,8 +209,8 @@ public:
     App::PropertyIntegerConstraint Polygon;
     App::PropertyLength Circumradius;
     App::PropertyLength Height;
-    App::PropertyAngle XSkew;
-    App::PropertyAngle YSkew;
+    App::PropertyAngle FirstSkew;
+    App::PropertyAngle SecondSkew;
 
     /** @name methods override feature */
     //@{

--- a/src/Mod/Part/App/PrimitiveFeature.h
+++ b/src/Mod/Part/App/PrimitiveFeature.h
@@ -209,6 +209,8 @@ public:
     App::PropertyIntegerConstraint Polygon;
     App::PropertyLength Circumradius;
     App::PropertyLength Height;
+    App::PropertyAngle XSkew;
+    App::PropertyAngle YSkew;
 
     /** @name methods override feature */
     //@{

--- a/src/Mod/Part/Gui/DlgPrimitives.cpp
+++ b/src/Mod/Part/Gui/DlgPrimitives.cpp
@@ -501,12 +501,16 @@ void DlgPrimitives::createPrimitive(const QString& placement)
                 "App.ActiveDocument.%1.Polygon=%2\n"
                 "App.ActiveDocument.%1.Circumradius=%3\n"
                 "App.ActiveDocument.%1.Height=%4\n"
-                "App.ActiveDocument.%1.Placement=%5\n"
-                "App.ActiveDocument.%1.Label='%6'\n")
+                "App.ActiveDocument.%1.XSkew=%5\n"
+                "App.ActiveDocument.%1.YSkew=%6\n"
+                "App.ActiveDocument.%1.Placement=%7\n"
+                "App.ActiveDocument.%1.Label='%8'\n")
                 .arg(name)
                 .arg(ui.prismPolygon->value())
                 .arg(ui.prismCircumradius->value().getValue(),0,'f',Base::UnitsApi::getDecimals())
                 .arg(ui.prismHeight->value().getValue(),0,'f',Base::UnitsApi::getDecimals())
+                .arg(ui.prismXSkew->value().getValue(), 0, 'f', Base::UnitsApi::getDecimals())
+                .arg(ui.prismYSkew->value().getValue(), 0, 'f', Base::UnitsApi::getDecimals())
                 .arg(placement)
                 .arg(tr("Prism"));
         }

--- a/src/Mod/Part/Gui/DlgPrimitives.ui
+++ b/src/Mod/Part/Gui/DlgPrimitives.ui
@@ -1294,14 +1294,14 @@
             <item row="3" column="0">
              <widget class="QLabel" name="labelPrismXSkew">
               <property name="text">
-               <string>Angle in x-direction:</string>
+               <string>Angle in first direction:</string>
               </property>
              </widget>
             </item>
             <item row="3" column="2">
              <widget class="Gui::QuantitySpinBox" name="prismXSkew">
               <property name="toolTip">
-               <string>Angle in x-direction</string>
+               <string>Angle in first direction</string>
               </property>
               <property name="unit" stdset="0">
                <string notr="true">deg</string>
@@ -1320,14 +1320,14 @@
             <item row="4" column="0">
              <widget class="QLabel" name="labelPrismYSkew">
               <property name="text">
-               <string>Angle in y-direction:</string>
+               <string>Angle in second direction:</string>
               </property>
              </widget>
             </item>
             <item row="4" column="2">
              <widget class="Gui::QuantitySpinBox" name="prismYSkew">
               <property name="toolTip">
-               <string>Angle in y-direction</string>
+               <string>Angle in second direction</string>
               </property>
               <property name="unit" stdset="0">
                <string notr="true">deg</string>

--- a/src/Mod/Part/Gui/DlgPrimitives.ui
+++ b/src/Mod/Part/Gui/DlgPrimitives.ui
@@ -180,7 +180,16 @@
       <string>Parameter</string>
      </property>
      <layout class="QGridLayout">
-      <property name="margin">
+      <property name="leftMargin">
+       <number>9</number>
+      </property>
+      <property name="topMargin">
+       <number>9</number>
+      </property>
+      <property name="rightMargin">
+       <number>9</number>
+      </property>
+      <property name="bottomMargin">
        <number>9</number>
       </property>
       <property name="spacing">
@@ -193,7 +202,16 @@
         </property>
         <widget class="QWidget" name="page0_plane">
          <layout class="QGridLayout">
-          <property name="margin">
+          <property name="leftMargin">
+           <number>9</number>
+          </property>
+          <property name="topMargin">
+           <number>9</number>
+          </property>
+          <property name="rightMargin">
+           <number>9</number>
+          </property>
+          <property name="bottomMargin">
            <number>9</number>
           </property>
           <property name="spacing">
@@ -201,7 +219,16 @@
           </property>
           <item row="0" column="0">
            <layout class="QGridLayout">
-            <property name="margin">
+            <property name="leftMargin">
+             <number>0</number>
+            </property>
+            <property name="topMargin">
+             <number>0</number>
+            </property>
+            <property name="rightMargin">
+             <number>0</number>
+            </property>
+            <property name="bottomMargin">
              <number>0</number>
             </property>
             <property name="spacing">
@@ -260,7 +287,16 @@
         </widget>
         <widget class="QWidget" name="Page1_box">
          <layout class="QGridLayout">
-          <property name="margin">
+          <property name="leftMargin">
+           <number>9</number>
+          </property>
+          <property name="topMargin">
+           <number>9</number>
+          </property>
+          <property name="rightMargin">
+           <number>9</number>
+          </property>
+          <property name="bottomMargin">
            <number>9</number>
           </property>
           <property name="spacing">
@@ -284,7 +320,16 @@
           </item>
           <item row="0" column="0">
            <layout class="QGridLayout">
-            <property name="margin">
+            <property name="leftMargin">
+             <number>0</number>
+            </property>
+            <property name="topMargin">
+             <number>0</number>
+            </property>
+            <property name="rightMargin">
+             <number>0</number>
+            </property>
+            <property name="bottomMargin">
              <number>0</number>
             </property>
             <property name="spacing">
@@ -347,7 +392,16 @@
         </widget>
         <widget class="QWidget" name="Page2_cylinder">
          <layout class="QGridLayout">
-          <property name="margin">
+          <property name="leftMargin">
+           <number>9</number>
+          </property>
+          <property name="topMargin">
+           <number>9</number>
+          </property>
+          <property name="rightMargin">
+           <number>9</number>
+          </property>
+          <property name="bottomMargin">
            <number>9</number>
           </property>
           <property name="spacing">
@@ -358,7 +412,16 @@
             <property name="spacing">
              <number>6</number>
             </property>
-            <property name="margin">
+            <property name="leftMargin">
+             <number>0</number>
+            </property>
+            <property name="topMargin">
+             <number>0</number>
+            </property>
+            <property name="rightMargin">
+             <number>0</number>
+            </property>
+            <property name="bottomMargin">
              <number>0</number>
             </property>
             <item>
@@ -408,7 +471,16 @@
           </item>
           <item row="0" column="0">
            <layout class="QGridLayout">
-            <property name="margin">
+            <property name="leftMargin">
+             <number>0</number>
+            </property>
+            <property name="topMargin">
+             <number>0</number>
+            </property>
+            <property name="rightMargin">
+             <number>0</number>
+            </property>
+            <property name="bottomMargin">
              <number>0</number>
             </property>
             <property name="spacing">
@@ -454,7 +526,16 @@
         </widget>
         <widget class="QWidget" name="Page3_cone">
          <layout class="QGridLayout">
-          <property name="margin">
+          <property name="leftMargin">
+           <number>9</number>
+          </property>
+          <property name="topMargin">
+           <number>9</number>
+          </property>
+          <property name="rightMargin">
+           <number>9</number>
+          </property>
+          <property name="bottomMargin">
            <number>9</number>
           </property>
           <property name="spacing">
@@ -465,7 +546,16 @@
             <property name="spacing">
              <number>6</number>
             </property>
-            <property name="margin">
+            <property name="leftMargin">
+             <number>0</number>
+            </property>
+            <property name="topMargin">
+             <number>0</number>
+            </property>
+            <property name="rightMargin">
+             <number>0</number>
+            </property>
+            <property name="bottomMargin">
              <number>0</number>
             </property>
             <item>
@@ -515,7 +605,16 @@
           </item>
           <item row="0" column="0">
            <layout class="QGridLayout">
-            <property name="margin">
+            <property name="leftMargin">
+             <number>0</number>
+            </property>
+            <property name="topMargin">
+             <number>0</number>
+            </property>
+            <property name="rightMargin">
+             <number>0</number>
+            </property>
+            <property name="bottomMargin">
              <number>0</number>
             </property>
             <property name="spacing">
@@ -578,7 +677,16 @@
         </widget>
         <widget class="QWidget" name="Page4_sphere">
          <layout class="QGridLayout">
-          <property name="margin">
+          <property name="leftMargin">
+           <number>9</number>
+          </property>
+          <property name="topMargin">
+           <number>9</number>
+          </property>
+          <property name="rightMargin">
+           <number>9</number>
+          </property>
+          <property name="bottomMargin">
            <number>9</number>
           </property>
           <property name="spacing">
@@ -596,7 +704,16 @@
           </item>
           <item row="2" column="0">
            <layout class="QGridLayout">
-            <property name="margin">
+            <property name="leftMargin">
+             <number>0</number>
+            </property>
+            <property name="topMargin">
+             <number>0</number>
+            </property>
+            <property name="rightMargin">
+             <number>0</number>
+            </property>
+            <property name="bottomMargin">
              <number>0</number>
             </property>
             <property name="spacing">
@@ -685,7 +802,16 @@
             <property name="spacing">
              <number>6</number>
             </property>
-            <property name="margin">
+            <property name="leftMargin">
+             <number>0</number>
+            </property>
+            <property name="topMargin">
+             <number>0</number>
+            </property>
+            <property name="rightMargin">
+             <number>0</number>
+            </property>
+            <property name="bottomMargin">
              <number>0</number>
             </property>
             <item>
@@ -711,7 +837,16 @@
         </widget>
         <widget class="QWidget" name="Page5_ellipsoid">
          <layout class="QGridLayout">
-          <property name="margin">
+          <property name="leftMargin">
+           <number>9</number>
+          </property>
+          <property name="topMargin">
+           <number>9</number>
+          </property>
+          <property name="rightMargin">
+           <number>9</number>
+          </property>
+          <property name="bottomMargin">
            <number>9</number>
           </property>
           <property name="spacing">
@@ -742,7 +877,16 @@
           </item>
           <item row="0" column="0">
            <layout class="QGridLayout">
-            <property name="margin">
+            <property name="leftMargin">
+             <number>0</number>
+            </property>
+            <property name="topMargin">
+             <number>0</number>
+            </property>
+            <property name="rightMargin">
+             <number>0</number>
+            </property>
+            <property name="bottomMargin">
              <number>0</number>
             </property>
             <property name="spacing">
@@ -803,7 +947,16 @@
           </item>
           <item row="2" column="0">
            <layout class="QGridLayout">
-            <property name="margin">
+            <property name="leftMargin">
+             <number>0</number>
+            </property>
+            <property name="topMargin">
+             <number>0</number>
+            </property>
+            <property name="rightMargin">
+             <number>0</number>
+            </property>
+            <property name="bottomMargin">
              <number>0</number>
             </property>
             <property name="spacing">
@@ -875,7 +1028,16 @@
         </widget>
         <widget class="QWidget" name="Page6_torus">
          <layout class="QGridLayout">
-          <property name="margin">
+          <property name="leftMargin">
+           <number>9</number>
+          </property>
+          <property name="topMargin">
+           <number>9</number>
+          </property>
+          <property name="rightMargin">
+           <number>9</number>
+          </property>
+          <property name="bottomMargin">
            <number>9</number>
           </property>
           <property name="spacing">
@@ -893,7 +1055,16 @@
           </item>
           <item row="2" column="0">
            <layout class="QGridLayout">
-            <property name="margin">
+            <property name="leftMargin">
+             <number>0</number>
+            </property>
+            <property name="topMargin">
+             <number>0</number>
+            </property>
+            <property name="rightMargin">
+             <number>0</number>
+            </property>
+            <property name="bottomMargin">
              <number>0</number>
             </property>
             <property name="spacing">
@@ -979,7 +1150,16 @@
           </item>
           <item row="0" column="0">
            <layout class="QGridLayout">
-            <property name="margin">
+            <property name="leftMargin">
+             <number>0</number>
+            </property>
+            <property name="topMargin">
+             <number>0</number>
+            </property>
+            <property name="rightMargin">
+             <number>0</number>
+            </property>
+            <property name="bottomMargin">
              <number>0</number>
             </property>
             <property name="spacing">
@@ -1025,7 +1205,16 @@
         </widget>
         <widget class="QWidget" name="page_prism">
          <layout class="QGridLayout">
-          <property name="margin">
+          <property name="leftMargin">
+           <number>9</number>
+          </property>
+          <property name="topMargin">
+           <number>9</number>
+          </property>
+          <property name="rightMargin">
+           <number>9</number>
+          </property>
+          <property name="bottomMargin">
            <number>9</number>
           </property>
           <property name="spacing">
@@ -1033,7 +1222,16 @@
           </property>
           <item row="0" column="0">
            <layout class="QGridLayout">
-            <property name="margin">
+            <property name="leftMargin">
+             <number>0</number>
+            </property>
+            <property name="topMargin">
+             <number>0</number>
+            </property>
+            <property name="rightMargin">
+             <number>0</number>
+            </property>
+            <property name="bottomMargin">
              <number>0</number>
             </property>
             <property name="spacing">
@@ -1090,6 +1288,58 @@
               </property>
               <property name="value">
                <double>10.000000000000000</double>
+              </property>
+             </widget>
+            </item>
+            <item row="3" column="0">
+             <widget class="QLabel" name="labelPrismXSkew">
+              <property name="text">
+               <string>Angle in x-direction:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="3" column="2">
+             <widget class="Gui::QuantitySpinBox" name="prismXSkew">
+              <property name="toolTip">
+               <string>Angle in x-direction</string>
+              </property>
+              <property name="unit" stdset="0">
+               <string notr="true">deg</string>
+              </property>
+              <property name="minimum">
+               <double>-90.000000000000000</double>
+              </property>
+              <property name="maximum">
+               <double>90.000000000000000</double>
+              </property>
+              <property name="singleStep">
+               <double>5.000000000000000</double>
+              </property>
+             </widget>
+            </item>
+            <item row="4" column="0">
+             <widget class="QLabel" name="labelPrismYSkew">
+              <property name="text">
+               <string>Angle in y-direction:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="4" column="2">
+             <widget class="Gui::QuantitySpinBox" name="prismYSkew">
+              <property name="toolTip">
+               <string>Angle in y-direction</string>
+              </property>
+              <property name="unit" stdset="0">
+               <string notr="true">deg</string>
+              </property>
+              <property name="minimum">
+               <double>-90.000000000000000</double>
+              </property>
+              <property name="maximum">
+               <double>90.000000000000000</double>
+              </property>
+              <property name="singleStep">
+               <double>5.000000000000000</double>
               </property>
              </widget>
             </item>
@@ -1160,9 +1410,6 @@
               <property name="unit" stdset="0">
                <string notr="true">mm</string>
               </property>
-              <property name="value">
-               <double>0.000000000000000</double>
-              </property>
              </widget>
             </item>
             <item row="0" column="2">
@@ -1180,9 +1427,6 @@
               <property name="unit" stdset="0">
                <string notr="true">mm</string>
               </property>
-              <property name="value">
-               <double>0.000000000000000</double>
-              </property>
              </widget>
             </item>
             <item row="1" column="2">
@@ -1199,9 +1443,6 @@
              <widget class="Gui::QuantitySpinBox" name="wedgeZmin">
               <property name="unit" stdset="0">
                <string notr="true">mm</string>
-              </property>
-              <property name="value">
-               <double>0.000000000000000</double>
               </property>
              </widget>
             </item>
@@ -1274,7 +1515,16 @@
         </widget>
         <widget class="QWidget" name="page8_helix">
          <layout class="QGridLayout">
-          <property name="margin">
+          <property name="leftMargin">
+           <number>9</number>
+          </property>
+          <property name="topMargin">
+           <number>9</number>
+          </property>
+          <property name="rightMargin">
+           <number>9</number>
+          </property>
+          <property name="bottomMargin">
            <number>9</number>
           </property>
           <property name="spacing">
@@ -1295,7 +1545,16 @@
           </item>
           <item row="0" column="0">
            <layout class="QGridLayout">
-            <property name="margin">
+            <property name="leftMargin">
+             <number>0</number>
+            </property>
+            <property name="topMargin">
+             <number>0</number>
+            </property>
+            <property name="rightMargin">
+             <number>0</number>
+            </property>
+            <property name="bottomMargin">
              <number>0</number>
             </property>
             <property name="spacing">
@@ -1355,9 +1614,6 @@
               <property name="unit" stdset="0">
                <string notr="true">deg</string>
               </property>
-              <property name="value">
-               <double>0.000000000000000</double>
-              </property>
              </widget>
             </item>
             <item row="0" column="1">
@@ -1396,7 +1652,16 @@
         </widget>
         <widget class="QWidget" name="page9_spiral">
          <layout class="QGridLayout">
-          <property name="margin">
+          <property name="leftMargin">
+           <number>9</number>
+          </property>
+          <property name="topMargin">
+           <number>9</number>
+          </property>
+          <property name="rightMargin">
+           <number>9</number>
+          </property>
+          <property name="bottomMargin">
            <number>9</number>
           </property>
           <property name="spacing">
@@ -1417,7 +1682,16 @@
           </item>
           <item row="0" column="0">
            <layout class="QGridLayout">
-            <property name="margin">
+            <property name="leftMargin">
+             <number>0</number>
+            </property>
+            <property name="topMargin">
+             <number>0</number>
+            </property>
+            <property name="rightMargin">
+             <number>0</number>
+            </property>
+            <property name="bottomMargin">
              <number>0</number>
             </property>
             <property name="spacing">
@@ -1482,7 +1756,16 @@
          <layout class="QGridLayout" name="gridLayout_3">
           <item row="0" column="0">
            <layout class="QGridLayout" name="circleParameters">
-            <property name="margin">
+            <property name="leftMargin">
+             <number>0</number>
+            </property>
+            <property name="topMargin">
+             <number>0</number>
+            </property>
+            <property name="rightMargin">
+             <number>0</number>
+            </property>
+            <property name="bottomMargin">
              <number>0</number>
             </property>
             <property name="spacing">
@@ -1513,9 +1796,6 @@
              <widget class="Gui::QuantitySpinBox" name="circleAngle0">
               <property name="unit" stdset="0">
                <string notr="true">deg</string>
-              </property>
-              <property name="value">
-               <double>0.000000000000000</double>
               </property>
              </widget>
             </item>
@@ -1637,9 +1917,6 @@
               <property name="unit" stdset="0">
                <string notr="true">deg</string>
               </property>
-              <property name="value">
-               <double>0.000000000000000</double>
-              </property>
              </widget>
             </item>
             <item row="3" column="1">
@@ -1708,9 +1985,6 @@
               <property name="unit" stdset="0">
                <string notr="true">mm</string>
               </property>
-              <property name="value">
-               <double>0.000000000000000</double>
-              </property>
              </widget>
             </item>
             <item row="1" column="1">
@@ -1718,18 +1992,12 @@
               <property name="unit" stdset="0">
                <string notr="true">mm</string>
               </property>
-              <property name="value">
-               <double>0.000000000000000</double>
-              </property>
              </widget>
             </item>
             <item row="2" column="1">
              <widget class="Gui::QuantitySpinBox" name="vertexZ">
               <property name="unit" stdset="0">
                <string notr="true">mm</string>
-              </property>
-              <property name="value">
-               <double>0.000000000000000</double>
               </property>
              </widget>
             </item>
@@ -1843,9 +2111,6 @@
               <property name="unit" stdset="0">
                <string notr="true">mm</string>
               </property>
-              <property name="value">
-               <double>0.000000000000000</double>
-              </property>
              </widget>
             </item>
             <item row="2" column="1">
@@ -1853,18 +2118,12 @@
               <property name="unit" stdset="0">
                <string notr="true">mm</string>
               </property>
-              <property name="value">
-               <double>0.000000000000000</double>
-              </property>
              </widget>
             </item>
             <item row="3" column="1">
              <widget class="Gui::QuantitySpinBox" name="edgeZ1">
               <property name="unit" stdset="0">
                <string notr="true">mm</string>
-              </property>
-              <property name="value">
-               <double>0.000000000000000</double>
               </property>
              </widget>
             </item>
@@ -1917,7 +2176,16 @@
         </widget>
         <widget class="QWidget" name="page_regularPolygon">
          <layout class="QGridLayout">
-          <property name="margin">
+          <property name="leftMargin">
+           <number>9</number>
+          </property>
+          <property name="topMargin">
+           <number>9</number>
+          </property>
+          <property name="rightMargin">
+           <number>9</number>
+          </property>
+          <property name="bottomMargin">
            <number>9</number>
           </property>
           <property name="spacing">
@@ -1925,7 +2193,16 @@
           </property>
           <item row="0" column="0">
            <layout class="QGridLayout">
-            <property name="margin">
+            <property name="leftMargin">
+             <number>0</number>
+            </property>
+            <property name="topMargin">
+             <number>0</number>
+            </property>
+            <property name="rightMargin">
+             <number>0</number>
+            </property>
+            <property name="bottomMargin">
              <number>0</number>
             </property>
             <property name="spacing">

--- a/src/Mod/PartDesign/App/FeaturePrimitive.cpp
+++ b/src/Mod/PartDesign/App/FeaturePrimitive.cpp
@@ -535,11 +535,11 @@ Prism::Prism()
     ADD_PROPERTY_TYPE(Polygon, (6.0), "Prism", App::Prop_None, "Number of sides in the polygon, of the prism");
     ADD_PROPERTY_TYPE(Circumradius, (2.0), "Prism", App::Prop_None, "Circumradius (centre to vertex) of the polygon, of the prism");
     ADD_PROPERTY_TYPE(Height, (10.0f), "Prism", App::Prop_None, "The height of the prism");
-    ADD_PROPERTY_TYPE(XSkew, (10.0f), "Prism", App::Prop_None, "Angle in x-direction");
-    ADD_PROPERTY_TYPE(YSkew, (10.0f), "Prism", App::Prop_None, "Angle in y-direction");
+    ADD_PROPERTY_TYPE(FirstSkew, (0.0f), "Prism", App::Prop_None, "Angle in first direction");
+    ADD_PROPERTY_TYPE(SecondSkew, (0.0f), "Prism", App::Prop_None, "Angle in second direction");
     static const App::PropertyQuantityConstraint::Constraints angleConstraint = { -89.99999, 89.99999, 1.0 };
-    XSkew.setConstraints(&angleConstraint);
-    YSkew.setConstraints(&angleConstraint);
+    FirstSkew.setConstraints(&angleConstraint);
+    SecondSkew.setConstraints(&angleConstraint);
 
     primitiveType = FeaturePrimitive::Prism;
 }
@@ -570,8 +570,8 @@ App::DocumentObjectExecReturn* Prism::execute(void)
         BRepBuilderAPI_MakeFace mkFace(mkPoly.Wire());
         // the direction vector for the prism is the height for z and the skew
         BRepPrimAPI_MakePrism mkPrism(mkFace.Face(),
-            gp_Vec(tan(XSkew.getValue() * D_PI / 180) * Height.getValue(),
-                   tan(YSkew.getValue() * D_PI / 180) * Height.getValue(),
+            gp_Vec(tan(FirstSkew.getValue() * D_PI / 180) * Height.getValue(),
+                   tan(SecondSkew.getValue() * D_PI / 180) * Height.getValue(),
                    Height.getValue()));
         return FeaturePrimitive::execute(mkPrism.Shape());
     }
@@ -591,9 +591,9 @@ short int Prism::mustExecute() const
         return 1;
     if (Height.isTouched())
         return 1;
-    if (XSkew.isTouched())
+    if (FirstSkew.isTouched())
         return 1;
-    if (YSkew.isTouched())
+    if (SecondSkew.isTouched())
         return 1;
 
     return FeaturePrimitive::mustExecute();

--- a/src/Mod/PartDesign/App/FeaturePrimitive.h
+++ b/src/Mod/PartDesign/App/FeaturePrimitive.h
@@ -318,8 +318,8 @@ public:
     App::PropertyIntegerConstraint Polygon;
     App::PropertyLength Circumradius;
     App::PropertyLength Height;
-    App::PropertyAngle XSkew;
-    App::PropertyAngle YSkew;
+    App::PropertyAngle FirstSkew;
+    App::PropertyAngle SecondSkew;
     
     /** @name methods override feature */
     //@{

--- a/src/Mod/PartDesign/App/FeaturePrimitive.h
+++ b/src/Mod/PartDesign/App/FeaturePrimitive.h
@@ -318,6 +318,8 @@ public:
     App::PropertyIntegerConstraint Polygon;
     App::PropertyLength Circumradius;
     App::PropertyLength Height;
+    App::PropertyAngle XSkew;
+    App::PropertyAngle YSkew;
     
     /** @name methods override feature */
     //@{

--- a/src/Mod/PartDesign/Gui/TaskPrimitiveParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskPrimitiveParameters.cpp
@@ -24,30 +24,30 @@
 #include "PreCompiled.h"
 
 #ifndef _PreComp_
-# include <sstream>
+# include <Precision.hxx>
+# include <QMessageBox>
 # include <QRegExp>
 # include <QTextStream>
-# include <QMessageBox>
-# include <Precision.hxx>
+# include <sstream>
 #endif
 
 #include "TaskPrimitiveParameters.h"
 #include "ui_TaskPrimitiveParameters.h"
 #include "ViewProviderDatumCS.h"
-#include <Mod/PartDesign/App/FeaturePrimitive.h>
-#include <Mod/PartDesign/App/DatumCS.h>
-#include <Mod/PartDesign/App/Body.h>
-#include <Mod/Part/App/DatumFeature.h>
-#include <Gui/Application.h>
-#include <Gui/Document.h>
-#include <Gui/Command.h>
-#include <Gui/BitmapFactory.h>
-#include <Gui/ViewProviderOrigin.h>
-#include <Base/Interpreter.h>
-#include <Base/Console.h>
-#include <Base/UnitsApi.h>
-#include <App/Origin.h>
 
+#include <App/Origin.h>
+#include <Base/Console.h>
+#include <Base/Interpreter.h>
+#include <Base/UnitsApi.h>
+#include <Gui/Application.h>
+#include <Gui/BitmapFactory.h>
+#include <Gui/Command.h>
+#include <Gui/Document.h>
+#include <Gui/ViewProviderOrigin.h>
+#include <Mod/Part/App/DatumFeature.h>
+#include <Mod/PartDesign/App/Body.h>
+#include <Mod/PartDesign/App/DatumCS.h>
+#include <Mod/PartDesign/App/FeaturePrimitive.h>
 
 using namespace PartDesignGui;
 
@@ -192,6 +192,10 @@ TaskBoxPrimitives::TaskBoxPrimitives(ViewProviderPrimitive* vp, QWidget* parent)
             ui->prismCircumradius->bind(static_cast<PartDesign::Prism*>(vp->getObject())->Circumradius);
             ui->prismHeight->setValue(static_cast<PartDesign::Prism*>(vp->getObject())->Height.getValue());
             ui->prismHeight->bind(static_cast<PartDesign::Prism*>(vp->getObject())->Height);
+            ui->prismXSkew->setValue(static_cast<PartDesign::Prism*>(vp->getObject())->XSkew.getValue());
+            ui->prismXSkew->bind(static_cast<PartDesign::Prism*>(vp->getObject())->XSkew);
+            ui->prismYSkew->setValue(static_cast<PartDesign::Prism*>(vp->getObject())->YSkew.getValue());
+            ui->prismYSkew->bind(static_cast<PartDesign::Prism*>(vp->getObject())->YSkew);
             ui->prismCircumradius->setMaximum(INT_MAX);
             ui->prismCircumradius->setMinimum(0.0);
             ui->prismHeight->setMaximum(INT_MAX);
@@ -306,6 +310,8 @@ TaskBoxPrimitives::TaskBoxPrimitives(ViewProviderPrimitive* vp, QWidget* parent)
     //prism
     connect(ui->prismCircumradius, SIGNAL(valueChanged(double)), this, SLOT(onPrismCircumradiusChanged(double)));
     connect(ui->prismHeight, SIGNAL(valueChanged(double)), this, SLOT(onPrismHeightChanged(double)));
+    connect(ui->prismXSkew, SIGNAL(valueChanged(double)), this, SLOT(onPrismXSkewChanged(double)));
+    connect(ui->prismYSkew, SIGNAL(valueChanged(double)), this, SLOT(onPrismYSkewChanged(double)));
     connect(ui->prismPolygon, SIGNAL(valueChanged(int)), this, SLOT(onPrismPolygonChanged(int)));
 
     // wedge
@@ -520,6 +526,38 @@ void TaskBoxPrimitives::onPrismHeightChanged(double v) {
     vp->getObject()->getDocument()->recomputeFeature(vp->getObject());
 }
 
+void TaskBoxPrimitives::onPrismXSkewChanged(double v) {
+    PartDesign::Prism* sph = static_cast<PartDesign::Prism*>(vp->getObject());
+    // we must assure that if the user incremented from e.g. 85 degree with the
+    // spin buttons he does not end at 90.0 but 89.9999 which is shown rounded to 90 degree
+    if ((v < 90.0) && (v > -90.0))
+        sph->XSkew.setValue(v);
+    else {
+        if (v == 90.0)
+            sph->XSkew.setValue(89.99999);
+        else if (v == -90.0)
+            sph->XSkew.setValue(-89.99999);
+        ui->prismYSkew->setValue(sph->XSkew.getQuantityValue());
+    }
+    vp->getObject()->getDocument()->recomputeFeature(vp->getObject());
+}
+
+void TaskBoxPrimitives::onPrismYSkewChanged(double v) {
+    PartDesign::Prism* sph = static_cast<PartDesign::Prism*>(vp->getObject());
+    // we must assure that if the user incremented from e.g. 85 degree with the
+    // spin buttons he does not end at 90.0 but 89.9999 which is shown rounded to 90 degree
+    if ((v < 90.0) && (v > -90.0))
+        sph->YSkew.setValue(v);
+    else {
+        if (v == 90.0)
+            sph->YSkew.setValue(89.99999);
+        else if (v == -90.0)
+            sph->YSkew.setValue(-89.99999);
+        ui->prismYSkew->setValue(sph->YSkew.getQuantityValue());
+    }
+    vp->getObject()->getDocument()->recomputeFeature(vp->getObject());
+}
+
 void TaskBoxPrimitives::onPrismPolygonChanged(int v) {
     PartDesign::Prism* sph = static_cast<PartDesign::Prism*>(vp->getObject());
     sph->Polygon.setValue(v);
@@ -692,11 +730,15 @@ void  TaskBoxPrimitives::setPrimitive(App::DocumentObject *obj)
                 cmd = QString::fromLatin1(
                     "%1.Polygon=%2\n"
                     "%1.Circumradius=%3\n"
-                    "%1.Height=%4\n")
+                    "%1.Height=%4\n"
+                    "%1.XSkew=%5\n"
+                    "%1.YSkew=%6\n")
                     .arg(name)
                     .arg(ui->prismPolygon->value())
-                    .arg(ui->prismCircumradius->value().getValue(),0,'f',Base::UnitsApi::getDecimals())
-                    .arg(ui->prismHeight->value().getValue(),0,'f',Base::UnitsApi::getDecimals());
+                    .arg(ui->prismCircumradius->value().getValue(), 0, 'f', Base::UnitsApi::getDecimals())
+                    .arg(ui->prismHeight->value().getValue(), 0, 'f', Base::UnitsApi::getDecimals())
+                    .arg(ui->prismXSkew->value().getValue(), 0, 'f', Base::UnitsApi::getDecimals())
+                    .arg(ui->prismYSkew->value().getValue(), 0, 'f', Base::UnitsApi::getDecimals());
                 break;
             case 8:  // wedge
                 cmd = QString::fromLatin1(

--- a/src/Mod/PartDesign/Gui/TaskPrimitiveParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskPrimitiveParameters.cpp
@@ -192,10 +192,10 @@ TaskBoxPrimitives::TaskBoxPrimitives(ViewProviderPrimitive* vp, QWidget* parent)
             ui->prismCircumradius->bind(static_cast<PartDesign::Prism*>(vp->getObject())->Circumradius);
             ui->prismHeight->setValue(static_cast<PartDesign::Prism*>(vp->getObject())->Height.getValue());
             ui->prismHeight->bind(static_cast<PartDesign::Prism*>(vp->getObject())->Height);
-            ui->prismXSkew->setValue(static_cast<PartDesign::Prism*>(vp->getObject())->XSkew.getValue());
-            ui->prismXSkew->bind(static_cast<PartDesign::Prism*>(vp->getObject())->XSkew);
-            ui->prismYSkew->setValue(static_cast<PartDesign::Prism*>(vp->getObject())->YSkew.getValue());
-            ui->prismYSkew->bind(static_cast<PartDesign::Prism*>(vp->getObject())->YSkew);
+            ui->prismXSkew->setValue(static_cast<PartDesign::Prism*>(vp->getObject())->FirstSkew.getValue());
+            ui->prismXSkew->bind(static_cast<PartDesign::Prism*>(vp->getObject())->FirstSkew);
+            ui->prismYSkew->setValue(static_cast<PartDesign::Prism*>(vp->getObject())->SecondSkew.getValue());
+            ui->prismYSkew->bind(static_cast<PartDesign::Prism*>(vp->getObject())->SecondSkew);
             ui->prismCircumradius->setMaximum(INT_MAX);
             ui->prismCircumradius->setMinimum(0.0);
             ui->prismHeight->setMaximum(INT_MAX);
@@ -531,13 +531,13 @@ void TaskBoxPrimitives::onPrismXSkewChanged(double v) {
     // we must assure that if the user incremented from e.g. 85 degree with the
     // spin buttons he does not end at 90.0 but 89.9999 which is shown rounded to 90 degree
     if ((v < 90.0) && (v > -90.0))
-        sph->XSkew.setValue(v);
+        sph->FirstSkew.setValue(v);
     else {
         if (v == 90.0)
-            sph->XSkew.setValue(89.99999);
+            sph->FirstSkew.setValue(89.99999);
         else if (v == -90.0)
-            sph->XSkew.setValue(-89.99999);
-        ui->prismYSkew->setValue(sph->XSkew.getQuantityValue());
+            sph->FirstSkew.setValue(-89.99999);
+        ui->prismYSkew->setValue(sph->FirstSkew.getQuantityValue());
     }
     vp->getObject()->getDocument()->recomputeFeature(vp->getObject());
 }
@@ -547,13 +547,13 @@ void TaskBoxPrimitives::onPrismYSkewChanged(double v) {
     // we must assure that if the user incremented from e.g. 85 degree with the
     // spin buttons he does not end at 90.0 but 89.9999 which is shown rounded to 90 degree
     if ((v < 90.0) && (v > -90.0))
-        sph->YSkew.setValue(v);
+        sph->SecondSkew.setValue(v);
     else {
         if (v == 90.0)
-            sph->YSkew.setValue(89.99999);
+            sph->SecondSkew.setValue(89.99999);
         else if (v == -90.0)
-            sph->YSkew.setValue(-89.99999);
-        ui->prismYSkew->setValue(sph->YSkew.getQuantityValue());
+            sph->SecondSkew.setValue(-89.99999);
+        ui->prismYSkew->setValue(sph->SecondSkew.getQuantityValue());
     }
     vp->getObject()->getDocument()->recomputeFeature(vp->getObject());
 }
@@ -731,8 +731,8 @@ void  TaskBoxPrimitives::setPrimitive(App::DocumentObject *obj)
                     "%1.Polygon=%2\n"
                     "%1.Circumradius=%3\n"
                     "%1.Height=%4\n"
-                    "%1.XSkew=%5\n"
-                    "%1.YSkew=%6\n")
+                    "%1.FirstSkew=%5\n"
+                    "%1.SecondSkew=%6\n")
                     .arg(name)
                     .arg(ui->prismPolygon->value())
                     .arg(ui->prismCircumradius->value().getValue(), 0, 'f', Base::UnitsApi::getDecimals())

--- a/src/Mod/PartDesign/Gui/TaskPrimitiveParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskPrimitiveParameters.h
@@ -85,6 +85,8 @@ public Q_SLOTS:
     void onTorusAngle3Changed(double);
     void onPrismCircumradiusChanged(double);
     void onPrismHeightChanged(double);
+    void onPrismXSkewChanged(double);
+    void onPrismYSkewChanged(double);
     void onPrismPolygonChanged(int);
     void onWedgeXmaxChanged(double);
     void onWedgeXminChanged(double);

--- a/src/Mod/PartDesign/Gui/TaskPrimitiveParameters.ui
+++ b/src/Mod/PartDesign/Gui/TaskPrimitiveParameters.ui
@@ -24,7 +24,16 @@
      </property>
      <widget class="QWidget" name="page0_plane">
       <layout class="QGridLayout">
-       <property name="margin">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
         <number>0</number>
        </property>
        <property name="spacing">
@@ -32,18 +41,30 @@
        </property>
        <item row="0" column="0">
         <layout class="QGridLayout" name="_2">
-         <property name="margin">
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
           <number>0</number>
          </property>
          <property name="spacing">
           <number>6</number>
          </property>
          <item row="0" column="2">
-          <widget class="Gui::QuantitySpinBox" name="planeLength" native="true">
+          <widget class="Gui::QuantitySpinBox" name="planeLength">
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
            <property name="unit" stdset="0">
             <string notr="true">mm</string>
            </property>
-           <property name="value" stdset="0">
+           <property name="value">
             <double>10.000000000000000</double>
            </property>
           </widget>
@@ -63,11 +84,14 @@
           </widget>
          </item>
          <item row="1" column="2">
-          <widget class="Gui::QuantitySpinBox" name="planeWidth" native="true">
+          <widget class="Gui::QuantitySpinBox" name="planeWidth">
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
            <property name="unit" stdset="0">
             <string notr="true">mm</string>
            </property>
-           <property name="value" stdset="0">
+           <property name="value">
             <double>10.000000000000000</double>
            </property>
           </widget>
@@ -91,7 +115,16 @@
      </widget>
      <widget class="QWidget" name="Page1_box">
       <layout class="QGridLayout" name="_3">
-       <property name="margin">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
         <number>0</number>
        </property>
        <property name="spacing">
@@ -115,28 +148,43 @@
        </item>
        <item row="0" column="0">
         <layout class="QGridLayout" name="_4">
-         <property name="margin">
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
           <number>0</number>
          </property>
          <property name="spacing">
           <number>6</number>
          </property>
          <item row="1" column="2">
-          <widget class="Gui::QuantitySpinBox" name="boxWidth" native="true">
+          <widget class="Gui::QuantitySpinBox" name="boxWidth">
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
            <property name="unit" stdset="0">
             <string notr="true">mm</string>
            </property>
-           <property name="value" stdset="0">
+           <property name="value">
             <double>10.000000000000000</double>
            </property>
           </widget>
          </item>
          <item row="2" column="2">
-          <widget class="Gui::QuantitySpinBox" name="boxHeight" native="true">
+          <widget class="Gui::QuantitySpinBox" name="boxHeight">
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
            <property name="unit" stdset="0">
             <string notr="true">mm</string>
            </property>
-           <property name="value" stdset="0">
+           <property name="value">
             <double>10.000000000000000</double>
            </property>
           </widget>
@@ -163,11 +211,14 @@
           </widget>
          </item>
          <item row="0" column="2">
-          <widget class="Gui::QuantitySpinBox" name="boxLength" native="true">
+          <widget class="Gui::QuantitySpinBox" name="boxLength">
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
            <property name="unit" stdset="0">
             <string notr="true">mm</string>
            </property>
-           <property name="value" stdset="0">
+           <property name="value">
             <double>10.000000000000000</double>
            </property>
           </widget>
@@ -178,7 +229,16 @@
      </widget>
      <widget class="QWidget" name="Page2_cylinder">
       <layout class="QGridLayout" name="_5">
-       <property name="margin">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
         <number>0</number>
        </property>
        <property name="spacing">
@@ -189,7 +249,16 @@
          <property name="spacing">
           <number>6</number>
          </property>
-         <property name="margin">
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
           <number>0</number>
          </property>
          <item>
@@ -200,11 +269,17 @@
           </widget>
          </item>
          <item>
-          <widget class="Gui::QuantitySpinBox" name="cylinderAngle" native="true">
+          <widget class="Gui::QuantitySpinBox" name="cylinderAngle">
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
            <property name="unit" stdset="0">
             <string notr="true">deg</string>
            </property>
-           <property name="value" stdset="0">
+           <property name="singleStep">
+            <double>5.000000000000000</double>
+           </property>
+           <property name="value">
             <double>360.000000000000000</double>
            </property>
           </widget>
@@ -239,7 +314,16 @@
        </item>
        <item row="0" column="0">
         <layout class="QGridLayout" name="_7">
-         <property name="margin">
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
           <number>0</number>
          </property>
          <property name="spacing">
@@ -260,21 +344,27 @@
           </widget>
          </item>
          <item row="1" column="1">
-          <widget class="Gui::QuantitySpinBox" name="cylinderHeight" native="true">
+          <widget class="Gui::QuantitySpinBox" name="cylinderHeight">
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
            <property name="unit" stdset="0">
             <string notr="true">mm</string>
            </property>
-           <property name="value" stdset="0">
+           <property name="value">
             <double>10.000000000000000</double>
            </property>
           </widget>
          </item>
          <item row="0" column="1">
-          <widget class="Gui::QuantitySpinBox" name="cylinderRadius" native="true">
+          <widget class="Gui::QuantitySpinBox" name="cylinderRadius">
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
            <property name="unit" stdset="0">
             <string notr="true">mm</string>
            </property>
-           <property name="value" stdset="0">
+           <property name="value">
             <double>2.000000000000000</double>
            </property>
           </widget>
@@ -285,7 +375,16 @@
      </widget>
      <widget class="QWidget" name="Page3_cone">
       <layout class="QGridLayout" name="_8">
-       <property name="margin">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
         <number>0</number>
        </property>
        <property name="spacing">
@@ -296,7 +395,16 @@
          <property name="spacing">
           <number>6</number>
          </property>
-         <property name="margin">
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
           <number>0</number>
          </property>
          <item>
@@ -307,11 +415,17 @@
           </widget>
          </item>
          <item>
-          <widget class="Gui::QuantitySpinBox" name="coneAngle" native="true">
+          <widget class="Gui::QuantitySpinBox" name="coneAngle">
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
            <property name="unit" stdset="0">
             <string notr="true">deg</string>
            </property>
-           <property name="value" stdset="0">
+           <property name="singleStep">
+            <double>5.000000000000000</double>
+           </property>
+           <property name="value">
             <double>360.000000000000000</double>
            </property>
           </widget>
@@ -346,28 +460,43 @@
        </item>
        <item row="0" column="0">
         <layout class="QGridLayout" name="_10">
-         <property name="margin">
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
           <number>0</number>
          </property>
          <property name="spacing">
           <number>6</number>
          </property>
          <item row="3" column="2">
-          <widget class="Gui::QuantitySpinBox" name="coneHeight" native="true">
+          <widget class="Gui::QuantitySpinBox" name="coneHeight">
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
            <property name="unit" stdset="0">
             <string notr="true">mm</string>
            </property>
-           <property name="value" stdset="0">
+           <property name="value">
             <double>10.000000000000000</double>
            </property>
           </widget>
          </item>
          <item row="0" column="2">
-          <widget class="Gui::QuantitySpinBox" name="coneRadius1" native="true">
+          <widget class="Gui::QuantitySpinBox" name="coneRadius1">
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
            <property name="unit" stdset="0">
             <string notr="true">mm</string>
            </property>
-           <property name="value" stdset="0">
+           <property name="value">
             <double>2.000000000000000</double>
            </property>
           </widget>
@@ -394,11 +523,14 @@
           </widget>
          </item>
          <item row="1" column="2">
-          <widget class="Gui::QuantitySpinBox" name="coneRadius2" native="true">
+          <widget class="Gui::QuantitySpinBox" name="coneRadius2">
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
            <property name="unit" stdset="0">
             <string notr="true">mm</string>
            </property>
-           <property name="value" stdset="0">
+           <property name="value">
             <double>4.000000000000000</double>
            </property>
           </widget>
@@ -409,7 +541,16 @@
      </widget>
      <widget class="QWidget" name="Page4_sphere">
       <layout class="QGridLayout" name="_11">
-       <property name="margin">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
         <number>0</number>
        </property>
        <property name="spacing">
@@ -427,7 +568,16 @@
        </item>
        <item row="2" column="0">
         <layout class="QGridLayout" name="_12">
-         <property name="margin">
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
           <number>0</number>
          </property>
          <property name="spacing">
@@ -464,31 +614,49 @@
           </widget>
          </item>
          <item row="1" column="2">
-          <widget class="Gui::QuantitySpinBox" name="sphereAngle1" native="true">
+          <widget class="Gui::QuantitySpinBox" name="sphereAngle1">
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
            <property name="unit" stdset="0">
             <string notr="true">deg</string>
            </property>
-           <property name="value" stdset="0">
+           <property name="singleStep">
+            <double>5.000000000000000</double>
+           </property>
+           <property name="value">
             <double>-90.000000000000000</double>
            </property>
           </widget>
          </item>
          <item row="2" column="2">
-          <widget class="Gui::QuantitySpinBox" name="sphereAngle2" native="true">
+          <widget class="Gui::QuantitySpinBox" name="sphereAngle2">
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
            <property name="unit" stdset="0">
             <string notr="true">deg</string>
            </property>
-           <property name="value" stdset="0">
+           <property name="singleStep">
+            <double>5.000000000000000</double>
+           </property>
+           <property name="value">
             <double>90.000000000000000</double>
            </property>
           </widget>
          </item>
          <item row="0" column="2">
-          <widget class="Gui::QuantitySpinBox" name="sphereAngle3" native="true">
+          <widget class="Gui::QuantitySpinBox" name="sphereAngle3">
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
            <property name="unit" stdset="0">
             <string notr="true">deg</string>
            </property>
-           <property name="value" stdset="0">
+           <property name="singleStep">
+            <double>5.000000000000000</double>
+           </property>
+           <property name="value">
             <double>360.000000000000000</double>
            </property>
           </widget>
@@ -516,7 +684,16 @@
          <property name="spacing">
           <number>6</number>
          </property>
-         <property name="margin">
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
           <number>0</number>
          </property>
          <item>
@@ -527,11 +704,14 @@
           </widget>
          </item>
          <item>
-          <widget class="Gui::QuantitySpinBox" name="sphereRadius" native="true">
+          <widget class="Gui::QuantitySpinBox" name="sphereRadius">
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
            <property name="unit" stdset="0">
             <string notr="true">mm</string>
            </property>
-           <property name="value" stdset="0">
+           <property name="value">
             <double>5.000000000000000</double>
            </property>
           </widget>
@@ -542,7 +722,16 @@
      </widget>
      <widget class="QWidget" name="Page5_ellipsoid">
       <layout class="QGridLayout" name="_14">
-       <property name="margin">
+       <property name="leftMargin">
+        <number>9</number>
+       </property>
+       <property name="topMargin">
+        <number>9</number>
+       </property>
+       <property name="rightMargin">
+        <number>9</number>
+       </property>
+       <property name="bottomMargin">
         <number>9</number>
        </property>
        <property name="spacing">
@@ -573,7 +762,16 @@
        </item>
        <item row="0" column="0">
         <layout class="QGridLayout" name="_15">
-         <property name="margin">
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
           <number>0</number>
          </property>
          <property name="spacing">
@@ -601,31 +799,40 @@
           </widget>
          </item>
          <item row="0" column="1">
-          <widget class="Gui::QuantitySpinBox" name="ellipsoidRadius1" native="true">
+          <widget class="Gui::QuantitySpinBox" name="ellipsoidRadius1">
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
            <property name="unit" stdset="0">
             <string notr="true">mm</string>
            </property>
-           <property name="value" stdset="0">
+           <property name="value">
             <double>2.000000000000000</double>
            </property>
           </widget>
          </item>
          <item row="1" column="1">
-          <widget class="Gui::QuantitySpinBox" name="ellipsoidRadius2" native="true">
+          <widget class="Gui::QuantitySpinBox" name="ellipsoidRadius2">
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
            <property name="unit" stdset="0">
             <string notr="true">mm</string>
            </property>
-           <property name="value" stdset="0">
+           <property name="value">
             <double>4.000000000000000</double>
            </property>
           </widget>
          </item>
          <item row="2" column="1">
-          <widget class="Gui::QuantitySpinBox" name="ellipsoidRadius3" native="true">
+          <widget class="Gui::QuantitySpinBox" name="ellipsoidRadius3">
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
            <property name="unit" stdset="0">
             <string notr="true">mm</string>
            </property>
-           <property name="value" stdset="0">
+           <property name="value">
             <double>4.000000000000000</double>
            </property>
           </widget>
@@ -634,7 +841,16 @@
        </item>
        <item row="2" column="0">
         <layout class="QGridLayout" name="_16">
-         <property name="margin">
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
           <number>0</number>
          </property>
          <property name="spacing">
@@ -671,31 +887,49 @@
           </widget>
          </item>
          <item row="0" column="1">
-          <widget class="Gui::QuantitySpinBox" name="ellipsoidAngle3" native="true">
+          <widget class="Gui::QuantitySpinBox" name="ellipsoidAngle3">
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
            <property name="unit" stdset="0">
             <string notr="true">deg</string>
            </property>
-           <property name="value" stdset="0">
+           <property name="singleStep">
+            <double>5.000000000000000</double>
+           </property>
+           <property name="value">
             <double>360.000000000000000</double>
            </property>
           </widget>
          </item>
          <item row="1" column="1">
-          <widget class="Gui::QuantitySpinBox" name="ellipsoidAngle1" native="true">
+          <widget class="Gui::QuantitySpinBox" name="ellipsoidAngle1">
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
            <property name="unit" stdset="0">
             <string notr="true">deg</string>
            </property>
-           <property name="value" stdset="0">
+           <property name="singleStep">
+            <double>5.000000000000000</double>
+           </property>
+           <property name="value">
             <double>-90.000000000000000</double>
            </property>
           </widget>
          </item>
          <item row="2" column="1">
-          <widget class="Gui::QuantitySpinBox" name="ellipsoidAngle2" native="true">
+          <widget class="Gui::QuantitySpinBox" name="ellipsoidAngle2">
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
            <property name="unit" stdset="0">
             <string notr="true">deg</string>
            </property>
-           <property name="value" stdset="0">
+           <property name="singleStep">
+            <double>5.000000000000000</double>
+           </property>
+           <property name="value">
             <double>90.000000000000000</double>
            </property>
           </widget>
@@ -706,7 +940,16 @@
      </widget>
      <widget class="QWidget" name="Page6_torus">
       <layout class="QGridLayout" name="_17">
-       <property name="margin">
+       <property name="leftMargin">
+        <number>9</number>
+       </property>
+       <property name="topMargin">
+        <number>9</number>
+       </property>
+       <property name="rightMargin">
+        <number>9</number>
+       </property>
+       <property name="bottomMargin">
         <number>9</number>
        </property>
        <property name="spacing">
@@ -724,7 +967,16 @@
        </item>
        <item row="2" column="0">
         <layout class="QGridLayout" name="_18">
-         <property name="margin">
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
           <number>0</number>
          </property>
          <property name="spacing">
@@ -761,31 +1013,49 @@
           </widget>
          </item>
          <item row="0" column="1">
-          <widget class="Gui::QuantitySpinBox" name="torusAngle3" native="true">
+          <widget class="Gui::QuantitySpinBox" name="torusAngle3">
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
            <property name="unit" stdset="0">
             <string notr="true">deg</string>
            </property>
-           <property name="value" stdset="0">
+           <property name="singleStep">
+            <double>5.000000000000000</double>
+           </property>
+           <property name="value">
             <double>360.000000000000000</double>
            </property>
           </widget>
          </item>
          <item row="1" column="1">
-          <widget class="Gui::QuantitySpinBox" name="torusAngle1" native="true">
+          <widget class="Gui::QuantitySpinBox" name="torusAngle1">
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
            <property name="unit" stdset="0">
             <string notr="true">deg</string>
            </property>
-           <property name="value" stdset="0">
+           <property name="singleStep">
+            <double>5.000000000000000</double>
+           </property>
+           <property name="value">
             <double>-180.000000000000000</double>
            </property>
           </widget>
          </item>
          <item row="2" column="1">
-          <widget class="Gui::QuantitySpinBox" name="torusAngle2" native="true">
+          <widget class="Gui::QuantitySpinBox" name="torusAngle2">
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
            <property name="unit" stdset="0">
             <string notr="true">deg</string>
            </property>
-           <property name="value" stdset="0">
+           <property name="singleStep">
+            <double>5.000000000000000</double>
+           </property>
+           <property name="value">
             <double>180.000000000000000</double>
            </property>
           </widget>
@@ -810,18 +1080,30 @@
        </item>
        <item row="0" column="0">
         <layout class="QGridLayout" name="_19">
-         <property name="margin">
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
           <number>0</number>
          </property>
          <property name="spacing">
           <number>6</number>
          </property>
          <item row="0" column="2">
-          <widget class="Gui::QuantitySpinBox" name="torusRadius1" native="true">
+          <widget class="Gui::QuantitySpinBox" name="torusRadius1">
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
            <property name="unit" stdset="0">
             <string notr="true">mm</string>
            </property>
-           <property name="value" stdset="0">
+           <property name="value">
             <double>10.000000000000000</double>
            </property>
           </widget>
@@ -841,11 +1123,14 @@
           </widget>
          </item>
          <item row="1" column="2">
-          <widget class="Gui::QuantitySpinBox" name="torusRadius2" native="true">
+          <widget class="Gui::QuantitySpinBox" name="torusRadius2">
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
            <property name="unit" stdset="0">
             <string notr="true">mm</string>
            </property>
-           <property name="value" stdset="0">
+           <property name="value">
             <double>2.000000000000000</double>
            </property>
           </widget>
@@ -856,7 +1141,16 @@
      </widget>
      <widget class="QWidget" name="page_prism">
       <layout class="QGridLayout" name="_20">
-       <property name="margin">
+       <property name="leftMargin">
+        <number>9</number>
+       </property>
+       <property name="topMargin">
+        <number>9</number>
+       </property>
+       <property name="rightMargin">
+        <number>9</number>
+       </property>
+       <property name="bottomMargin">
         <number>9</number>
        </property>
        <property name="spacing">
@@ -864,18 +1158,30 @@
        </property>
        <item row="0" column="0">
         <layout class="QGridLayout" name="_21">
-         <property name="margin">
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
           <number>0</number>
          </property>
          <property name="spacing">
           <number>6</number>
          </property>
          <item row="1" column="2">
-          <widget class="Gui::QuantitySpinBox" name="prismCircumradius" native="true">
+          <widget class="Gui::QuantitySpinBox" name="prismCircumradius">
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
            <property name="unit" stdset="0">
             <string notr="true">mm</string>
            </property>
-           <property name="value" stdset="0">
+           <property name="value">
             <double>2.000000000000000</double>
            </property>
           </widget>
@@ -915,12 +1221,73 @@
           </widget>
          </item>
          <item row="2" column="2">
-          <widget class="Gui::QuantitySpinBox" name="prismHeight" native="true">
+          <widget class="Gui::QuantitySpinBox" name="prismHeight">
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
            <property name="unit" stdset="0">
             <string notr="true">mm</string>
            </property>
-           <property name="value" stdset="0">
+           <property name="value">
             <double>10.000000000000000</double>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="0">
+          <widget class="QLabel" name="labelXSkew">
+           <property name="text">
+            <string>Angle in x-direction:</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="2">
+          <widget class="Gui::QuantitySpinBox" name="prismXSkew">
+           <property name="toolTip">
+            <string>Angle in x-direction</string>
+           </property>
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
+           <property name="unit" stdset="0">
+            <string notr="true">deg</string>
+           </property>
+           <property name="minimum">
+            <double>-90.000000000000000</double>
+           </property>
+           <property name="maximum">
+            <double>90.000000000000000</double>
+           </property>
+           <property name="singleStep">
+            <double>5.000000000000000</double>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="0">
+          <widget class="QLabel" name="labelYSkew">
+           <property name="text">
+            <string>Angle in y-direction:</string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="2">
+          <widget class="Gui::QuantitySpinBox" name="prismYSkew">
+           <property name="toolTip">
+            <string>Angle in y-direction</string>
+           </property>
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
+           <property name="unit" stdset="0">
+            <string notr="true">deg</string>
+           </property>
+           <property name="minimum">
+            <double>-90.000000000000000</double>
+           </property>
+           <property name="maximum">
+            <double>90.000000000000000</double>
+           </property>
+           <property name="singleStep">
+            <double>5.000000000000000</double>
            </property>
           </widget>
          </item>
@@ -987,101 +1354,122 @@
           </widget>
          </item>
          <item row="0" column="1">
-          <widget class="Gui::QuantitySpinBox" name="wedgeXmin" native="true">
+          <widget class="Gui::QuantitySpinBox" name="wedgeXmin">
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
            <property name="unit" stdset="0">
             <string notr="true">mm</string>
-           </property>
-           <property name="value" stdset="0">
-            <double>0.000000000000000</double>
            </property>
           </widget>
          </item>
          <item row="0" column="2">
-          <widget class="Gui::QuantitySpinBox" name="wedgeXmax" native="true">
+          <widget class="Gui::QuantitySpinBox" name="wedgeXmax">
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
            <property name="unit" stdset="0">
             <string notr="true">mm</string>
            </property>
-           <property name="value" stdset="0">
+           <property name="value">
             <double>10.000000000000000</double>
            </property>
           </widget>
          </item>
          <item row="1" column="1">
-          <widget class="Gui::QuantitySpinBox" name="wedgeYmin" native="true">
+          <widget class="Gui::QuantitySpinBox" name="wedgeYmin">
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
            <property name="unit" stdset="0">
             <string notr="true">mm</string>
-           </property>
-           <property name="value" stdset="0">
-            <double>0.000000000000000</double>
            </property>
           </widget>
          </item>
          <item row="1" column="2">
-          <widget class="Gui::QuantitySpinBox" name="wedgeYmax" native="true">
+          <widget class="Gui::QuantitySpinBox" name="wedgeYmax">
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
            <property name="unit" stdset="0">
             <string notr="true">mm</string>
            </property>
-           <property name="value" stdset="0">
+           <property name="value">
             <double>10.000000000000000</double>
            </property>
           </widget>
          </item>
          <item row="2" column="1">
-          <widget class="Gui::QuantitySpinBox" name="wedgeZmin" native="true">
+          <widget class="Gui::QuantitySpinBox" name="wedgeZmin">
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
            <property name="unit" stdset="0">
             <string notr="true">mm</string>
-           </property>
-           <property name="value" stdset="0">
-            <double>0.000000000000000</double>
            </property>
           </widget>
          </item>
          <item row="2" column="2">
-          <widget class="Gui::QuantitySpinBox" name="wedgeZmax" native="true">
+          <widget class="Gui::QuantitySpinBox" name="wedgeZmax">
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
            <property name="unit" stdset="0">
             <string notr="true">mm</string>
            </property>
-           <property name="value" stdset="0">
+           <property name="value">
             <double>10.000000000000000</double>
            </property>
           </widget>
          </item>
          <item row="3" column="1">
-          <widget class="Gui::QuantitySpinBox" name="wedgeX2min" native="true">
+          <widget class="Gui::QuantitySpinBox" name="wedgeX2min">
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
            <property name="unit" stdset="0">
             <string notr="true">mm</string>
            </property>
-           <property name="value" stdset="0">
+           <property name="value">
             <double>2.000000000000000</double>
            </property>
           </widget>
          </item>
          <item row="3" column="2">
-          <widget class="Gui::QuantitySpinBox" name="wedgeX2max" native="true">
+          <widget class="Gui::QuantitySpinBox" name="wedgeX2max">
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
            <property name="unit" stdset="0">
             <string notr="true">mm</string>
            </property>
-           <property name="value" stdset="0">
+           <property name="value">
             <double>8.000000000000000</double>
            </property>
           </widget>
          </item>
          <item row="4" column="1">
-          <widget class="Gui::QuantitySpinBox" name="wedgeZ2min" native="true">
+          <widget class="Gui::QuantitySpinBox" name="wedgeZ2min">
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
            <property name="unit" stdset="0">
             <string notr="true">mm</string>
            </property>
-           <property name="value" stdset="0">
+           <property name="value">
             <double>2.000000000000000</double>
            </property>
           </widget>
          </item>
          <item row="4" column="2">
-          <widget class="Gui::QuantitySpinBox" name="wedgeZ2max" native="true">
+          <widget class="Gui::QuantitySpinBox" name="wedgeZ2max">
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
            <property name="unit" stdset="0">
             <string notr="true">mm</string>
            </property>
-           <property name="value" stdset="0">
+           <property name="value">
             <double>8.000000000000000</double>
            </property>
           </widget>
@@ -1105,7 +1493,16 @@
      </widget>
      <widget class="QWidget" name="page8_helix">
       <layout class="QGridLayout" name="_22">
-       <property name="margin">
+       <property name="leftMargin">
+        <number>9</number>
+       </property>
+       <property name="topMargin">
+        <number>9</number>
+       </property>
+       <property name="rightMargin">
+        <number>9</number>
+       </property>
+       <property name="bottomMargin">
         <number>9</number>
        </property>
        <property name="spacing">
@@ -1126,7 +1523,16 @@
        </item>
        <item row="0" column="0">
         <layout class="QGridLayout" name="_23">
-         <property name="margin">
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
           <number>0</number>
          </property>
          <property name="spacing">
@@ -1182,41 +1588,53 @@
           </widget>
          </item>
          <item row="3" column="1">
-          <widget class="Gui::QuantitySpinBox" name="helixAngle" native="true">
+          <widget class="Gui::QuantitySpinBox" name="helixAngle">
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
            <property name="unit" stdset="0">
             <string notr="true">deg</string>
            </property>
-           <property name="value" stdset="0">
-            <double>0.000000000000000</double>
+           <property name="singleStep">
+            <double>5.000000000000000</double>
            </property>
           </widget>
          </item>
          <item row="0" column="1">
-          <widget class="Gui::QuantitySpinBox" name="helixPitch" native="true">
+          <widget class="Gui::QuantitySpinBox" name="helixPitch">
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
            <property name="unit" stdset="0">
             <string notr="true">mm</string>
            </property>
-           <property name="value" stdset="0">
+           <property name="value">
             <double>1.000000000000000</double>
            </property>
           </widget>
          </item>
          <item row="1" column="1">
-          <widget class="Gui::QuantitySpinBox" name="helixHeight" native="true">
+          <widget class="Gui::QuantitySpinBox" name="helixHeight">
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
            <property name="unit" stdset="0">
             <string notr="true">mm</string>
            </property>
-           <property name="value" stdset="0">
+           <property name="value">
             <double>2.000000000000000</double>
            </property>
           </widget>
          </item>
          <item row="2" column="1">
-          <widget class="Gui::QuantitySpinBox" name="helixRadius" native="true">
+          <widget class="Gui::QuantitySpinBox" name="helixRadius">
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
            <property name="unit" stdset="0">
             <string notr="true">mm</string>
            </property>
-           <property name="value" stdset="0">
+           <property name="value">
             <double>1.000000000000000</double>
            </property>
           </widget>
@@ -1227,7 +1645,16 @@
      </widget>
      <widget class="QWidget" name="page9_spiral">
       <layout class="QGridLayout" name="_24">
-       <property name="margin">
+       <property name="leftMargin">
+        <number>9</number>
+       </property>
+       <property name="topMargin">
+        <number>9</number>
+       </property>
+       <property name="rightMargin">
+        <number>9</number>
+       </property>
+       <property name="bottomMargin">
         <number>9</number>
        </property>
        <property name="spacing">
@@ -1248,7 +1675,16 @@
        </item>
        <item row="0" column="0">
         <layout class="QGridLayout" name="_25">
-         <property name="margin">
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
           <number>0</number>
          </property>
          <property name="spacing">
@@ -1276,17 +1712,23 @@
           </widget>
          </item>
          <item row="0" column="1">
-          <widget class="Gui::QuantitySpinBox" name="spiralGrowth" native="true">
+          <widget class="Gui::QuantitySpinBox" name="spiralGrowth">
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
            <property name="unit" stdset="0">
             <string notr="true">mm</string>
            </property>
-           <property name="value" stdset="0">
+           <property name="value">
             <double>1.000000000000000</double>
            </property>
           </widget>
          </item>
          <item row="1" column="1">
           <widget class="QDoubleSpinBox" name="spiralRotation">
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
            <property name="maximum">
             <double>1000.000000000000000</double>
            </property>
@@ -1296,11 +1738,14 @@
           </widget>
          </item>
          <item row="2" column="1">
-          <widget class="Gui::QuantitySpinBox" name="spiralRadius" native="true">
+          <widget class="Gui::QuantitySpinBox" name="spiralRadius">
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
            <property name="unit" stdset="0">
             <string notr="true">mm</string>
            </property>
-           <property name="value" stdset="0">
+           <property name="value">
             <double>1.000000000000000</double>
            </property>
           </widget>
@@ -1313,7 +1758,16 @@
       <layout class="QGridLayout" name="gridLayout_3">
        <item row="0" column="0">
         <layout class="QGridLayout" name="circleParameters">
-         <property name="margin">
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
           <number>0</number>
          </property>
          <property name="spacing">
@@ -1341,31 +1795,43 @@
           </widget>
          </item>
          <item row="1" column="1">
-          <widget class="Gui::QuantitySpinBox" name="circleAngle0" native="true">
+          <widget class="Gui::QuantitySpinBox" name="circleAngle0">
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
            <property name="unit" stdset="0">
             <string notr="true">deg</string>
            </property>
-           <property name="value" stdset="0">
-            <double>0.000000000000000</double>
+           <property name="singleStep">
+            <double>5.000000000000000</double>
            </property>
           </widget>
          </item>
          <item row="2" column="1">
-          <widget class="Gui::QuantitySpinBox" name="circleAngle1" native="true">
+          <widget class="Gui::QuantitySpinBox" name="circleAngle1">
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
            <property name="unit" stdset="0">
             <string notr="true">deg</string>
            </property>
-           <property name="value" stdset="0">
+           <property name="singleStep">
+            <double>5.000000000000000</double>
+           </property>
+           <property name="value">
             <double>360.000000000000000</double>
            </property>
           </widget>
          </item>
          <item row="0" column="1">
-          <widget class="Gui::QuantitySpinBox" name="circleRadius" native="true">
+          <widget class="Gui::QuantitySpinBox" name="circleRadius">
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
            <property name="unit" stdset="0">
             <string notr="true">mm</string>
            </property>
-           <property name="value" stdset="0">
+           <property name="value">
             <double>2.000000000000000</double>
            </property>
           </widget>
@@ -1444,41 +1910,62 @@
           </widget>
          </item>
          <item row="0" column="1">
-          <widget class="Gui::QuantitySpinBox" name="ellipseMajorRadius" native="true">
+          <widget class="Gui::QuantitySpinBox" name="ellipseMajorRadius">
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
            <property name="unit" stdset="0">
             <string notr="true">mm</string>
            </property>
-           <property name="value" stdset="0">
+           <property name="singleStep">
+            <double>5.000000000000000</double>
+           </property>
+           <property name="value">
             <double>4.000000000000000</double>
            </property>
           </widget>
          </item>
          <item row="1" column="1">
-          <widget class="Gui::QuantitySpinBox" name="ellipseMinorRadius" native="true">
+          <widget class="Gui::QuantitySpinBox" name="ellipseMinorRadius">
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
            <property name="unit" stdset="0">
             <string notr="true">mm</string>
            </property>
-           <property name="value" stdset="0">
+           <property name="singleStep">
+            <double>5.000000000000000</double>
+           </property>
+           <property name="value">
             <double>2.000000000000000</double>
            </property>
           </widget>
          </item>
          <item row="2" column="1">
-          <widget class="Gui::QuantitySpinBox" name="ellipseAngle0" native="true">
+          <widget class="Gui::QuantitySpinBox" name="ellipseAngle0">
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
            <property name="unit" stdset="0">
             <string notr="true">deg</string>
            </property>
-           <property name="value" stdset="0">
-            <double>0.000000000000000</double>
+           <property name="singleStep">
+            <double>5.000000000000000</double>
            </property>
           </widget>
          </item>
          <item row="3" column="1">
-          <widget class="Gui::QuantitySpinBox" name="ellipseAngle1" native="true">
+          <widget class="Gui::QuantitySpinBox" name="ellipseAngle1">
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
            <property name="unit" stdset="0">
             <string notr="true">deg</string>
            </property>
-           <property name="value" stdset="0">
+           <property name="singleStep">
+            <double>5.000000000000000</double>
+           </property>
+           <property name="value">
             <double>360.000000000000000</double>
            </property>
           </widget>
@@ -1535,32 +2022,32 @@
           </widget>
          </item>
          <item row="0" column="1">
-          <widget class="Gui::QuantitySpinBox" name="vertexX" native="true">
+          <widget class="Gui::QuantitySpinBox" name="vertexX">
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
            <property name="unit" stdset="0">
             <string notr="true">mm</string>
-           </property>
-           <property name="value" stdset="0">
-            <double>0.000000000000000</double>
            </property>
           </widget>
          </item>
          <item row="1" column="1">
-          <widget class="Gui::QuantitySpinBox" name="vertexY" native="true">
+          <widget class="Gui::QuantitySpinBox" name="vertexY">
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
            <property name="unit" stdset="0">
             <string notr="true">mm</string>
-           </property>
-           <property name="value" stdset="0">
-            <double>0.000000000000000</double>
            </property>
           </widget>
          </item>
          <item row="2" column="1">
-          <widget class="Gui::QuantitySpinBox" name="vertexZ" native="true">
+          <widget class="Gui::QuantitySpinBox" name="vertexZ">
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
            <property name="unit" stdset="0">
             <string notr="true">mm</string>
-           </property>
-           <property name="value" stdset="0">
-            <double>0.000000000000000</double>
            </property>
           </widget>
          </item>
@@ -1670,61 +2157,70 @@
           </widget>
          </item>
          <item row="1" column="1">
-          <widget class="Gui::QuantitySpinBox" name="edgeX1" native="true">
+          <widget class="Gui::QuantitySpinBox" name="edgeX1">
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
            <property name="unit" stdset="0">
             <string notr="true">mm</string>
-           </property>
-           <property name="value" stdset="0">
-            <double>0.000000000000000</double>
            </property>
           </widget>
          </item>
          <item row="2" column="1">
-          <widget class="Gui::QuantitySpinBox" name="edgeY1" native="true">
+          <widget class="Gui::QuantitySpinBox" name="edgeY1">
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
            <property name="unit" stdset="0">
             <string notr="true">mm</string>
-           </property>
-           <property name="value" stdset="0">
-            <double>0.000000000000000</double>
            </property>
           </widget>
          </item>
          <item row="3" column="1">
-          <widget class="Gui::QuantitySpinBox" name="edgeZ1" native="true">
+          <widget class="Gui::QuantitySpinBox" name="edgeZ1">
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
            <property name="unit" stdset="0">
             <string notr="true">mm</string>
-           </property>
-           <property name="value" stdset="0">
-            <double>0.000000000000000</double>
            </property>
           </widget>
          </item>
          <item row="6" column="1">
-          <widget class="Gui::QuantitySpinBox" name="edgeX2" native="true">
+          <widget class="Gui::QuantitySpinBox" name="edgeX2">
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
            <property name="unit" stdset="0">
             <string notr="true">mm</string>
            </property>
-           <property name="value" stdset="0">
+           <property name="value">
             <double>10.000000000000000</double>
            </property>
           </widget>
          </item>
          <item row="7" column="1">
-          <widget class="Gui::QuantitySpinBox" name="edgeY2" native="true">
+          <widget class="Gui::QuantitySpinBox" name="edgeY2">
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
            <property name="unit" stdset="0">
             <string notr="true">mm</string>
            </property>
-           <property name="value" stdset="0">
+           <property name="value">
             <double>10.000000000000000</double>
            </property>
           </widget>
          </item>
          <item row="8" column="1">
-          <widget class="Gui::QuantitySpinBox" name="edgeZ2" native="true">
+          <widget class="Gui::QuantitySpinBox" name="edgeZ2">
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
            <property name="unit" stdset="0">
             <string notr="true">mm</string>
            </property>
-           <property name="value" stdset="0">
+           <property name="value">
             <double>10.000000000000000</double>
            </property>
           </widget>
@@ -1748,7 +2244,16 @@
      </widget>
      <widget class="QWidget" name="page_regularPolygon">
       <layout class="QGridLayout" name="_26">
-       <property name="margin">
+       <property name="leftMargin">
+        <number>9</number>
+       </property>
+       <property name="topMargin">
+        <number>9</number>
+       </property>
+       <property name="rightMargin">
+        <number>9</number>
+       </property>
+       <property name="bottomMargin">
         <number>9</number>
        </property>
        <property name="spacing">
@@ -1756,7 +2261,16 @@
        </property>
        <item row="0" column="0">
         <layout class="QGridLayout" name="_27">
-         <property name="margin">
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
           <number>0</number>
          </property>
          <property name="spacing">
@@ -1771,6 +2285,9 @@
          </item>
          <item row="0" column="1">
           <widget class="QSpinBox" name="regularPolygonPolygon">
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
            <property name="minimum">
             <number>3</number>
            </property>
@@ -1790,11 +2307,14 @@
           </widget>
          </item>
          <item row="1" column="1">
-          <widget class="Gui::QuantitySpinBox" name="regularPolygonCircumradius" native="true">
+          <widget class="Gui::QuantitySpinBox" name="regularPolygonCircumradius">
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
            <property name="unit" stdset="0">
             <string notr="true">mm</string>
            </property>
-           <property name="value" stdset="0">
+           <property name="value">
             <double>2.000000000000000</double>
            </property>
           </widget>

--- a/src/Mod/PartDesign/Gui/TaskPrimitiveParameters.ui
+++ b/src/Mod/PartDesign/Gui/TaskPrimitiveParameters.ui
@@ -1236,14 +1236,14 @@
          <item row="3" column="0">
           <widget class="QLabel" name="labelXSkew">
            <property name="text">
-            <string>Angle in x-direction:</string>
+            <string>Angle in first direction:</string>
            </property>
           </widget>
          </item>
          <item row="3" column="2">
           <widget class="Gui::QuantitySpinBox" name="prismXSkew">
            <property name="toolTip">
-            <string>Angle in x-direction</string>
+            <string>Angle in first direction</string>
            </property>
            <property name="keyboardTracking">
             <bool>false</bool>
@@ -1265,14 +1265,14 @@
          <item row="4" column="0">
           <widget class="QLabel" name="labelYSkew">
            <property name="text">
-            <string>Angle in y-direction:</string>
+            <string>Angle in second direction:</string>
            </property>
           </widget>
          </item>
          <item row="4" column="2">
           <widget class="Gui::QuantitySpinBox" name="prismYSkew">
            <property name="toolTip">
-            <string>Angle in y-direction</string>
+            <string>Angle in second direction</string>
            </property>
            <property name="keyboardTracking">
             <bool>false</bool>


### PR DESCRIPTION
it is a valuable feature to create skew prisms. This PR add this to part/PartDesign:

![8FsyJadqPW](https://user-images.githubusercontent.com/1828501/89724027-2726db80-d9fe-11ea-8a60-a5f6c8519395.gif)

(The additional .ui changes were automatically made by Qt's designer since there is no property "margin" only left/bottom/right/topMargin and the property value does not exist for the widgets (only "rawValue") thus were never taken into account.)