### PR TITLE
Part: fix typos in source function names and variables

### DIFF
--- a/src/Mod/Part/Gui/Command.cpp
+++ b/src/Mod/Part/Gui/Command.cpp
@@ -2424,18 +2424,18 @@ bool CmdBoxSelection::isActive(void)
 }
 
 //===========================================================================
-// Part_projectionOnSurface
+// Part_ProjectionOnSurface
 //===========================================================================
 DEF_STD_CMD_A(CmdPartProjectionOnSurface)
 
 CmdPartProjectionOnSurface::CmdPartProjectionOnSurface()
-  :Command("Part_projectionOnSurface")
+  :Command("Part_ProjectionOnSurface")
 {
   sAppModule = "Part";
   sGroup = QT_TR_NOOP("Part");
   sMenuText = QT_TR_NOOP("Create projection on surface...");
   sToolTipText = QT_TR_NOOP("Create projection on surface...");
-  sWhatsThis = "Part_projectionOnSurface";
+  sWhatsThis = "Part_ProjectionOnSurface";
   sStatusTip = sToolTipText;
   sPixmap = "Part_ProjectionOnSurface";
 }

--- a/src/Mod/Part/Gui/DlgProjectionOnSurface.cpp
+++ b/src/Mod/Part/Gui/DlgProjectionOnSurface.cpp
@@ -367,7 +367,7 @@ void PartGui::DlgProjectionOnSurface::store_current_selected_parts(std::vector<S
             std::string parentName = aPart->getNameInDocument();
             auto currentShape =  aPart->Shape.getShape().getSubShape(itName->c_str());
 
-            transform_shape_to_global_postion(currentShape, aPart);
+            transform_shape_to_global_position(currentShape, aPart);
 
             currentShapeStore.inputShape = currentShape;
             currentShapeStore.partName = *itName;
@@ -378,7 +378,7 @@ void PartGui::DlgProjectionOnSurface::store_current_selected_parts(std::vector<S
         }
         else
         {
-          transform_shape_to_global_postion(currentShapeStore.inputShape,currentShapeStore.partFeature);
+          transform_shape_to_global_position(currentShapeStore.inputShape,currentShapeStore.partFeature);
           auto store = store_part_in_vector(currentShapeStore, iStoreVec);
           higlight_object(aPart, aPart->Shape.getName(), store, iColor);
         }
@@ -918,12 +918,12 @@ void PartGui::DlgProjectionOnSurface::set_xyz_dir_spinbox(QDoubleSpinBox* icurre
   icurrentSpinBox->setValue(newVal);
 }
 
-void PartGui::DlgProjectionOnSurface::transform_shape_to_global_postion(TopoDS_Shape& ioShape, Part::Feature* iPart)
+void PartGui::DlgProjectionOnSurface::transform_shape_to_global_position(TopoDS_Shape& ioShape, Part::Feature* iPart)
 {
   auto currentPos = iPart->Placement.getValue().getPosition();
   auto currentRotation = iPart->Placement.getValue().getRotation();
   auto globalPlacement = iPart->globalPlacement();
-  auto globalPostion = globalPlacement.getPosition();
+  auto globalPosition = globalPlacement.getPosition();
   auto globalRotation = globalPlacement.getRotation();
 
   if (currentRotation != globalRotation)
@@ -939,10 +939,10 @@ void PartGui::DlgProjectionOnSurface::transform_shape_to_global_postion(TopoDS_S
     ioShape = BRepBuilderAPI_Transform(ioShape, aAngleTransform, true).Shape();
   }
 
-  if (currentPos != globalPostion)
+  if (currentPos != globalPosition)
   {
     gp_Trsf aPosTransform;
-    aPosTransform.SetTranslation(gp_Pnt(currentPos.x, currentPos.y, currentPos.z), gp_Pnt(globalPostion.x, globalPostion.y, globalPostion.z));
+    aPosTransform.SetTranslation(gp_Pnt(currentPos.x, currentPos.y, currentPos.z), gp_Pnt(globalPosition.x, globalPosition.y, globalPosition.z));
     ioShape = BRepBuilderAPI_Transform(ioShape, aPosTransform, true).Shape();
   }
 }

--- a/src/Mod/Part/Gui/DlgProjectionOnSurface.h
+++ b/src/Mod/Part/Gui/DlgProjectionOnSurface.h
@@ -116,7 +116,7 @@ private:
   void create_face_extrude(std::vector<SShapeStore>& iCurrentShape);
   void store_wire_in_vector(const SShapeStore& iCurrentShape, const TopoDS_Shape& iParentShape, std::vector<SShapeStore>& iStoreVec, const unsigned int iColor);
   void set_xyz_dir_spinbox(QDoubleSpinBox* icurrentSpinBox);
-  void transform_shape_to_global_postion(TopoDS_Shape& ioShape, Part::Feature* iPart);
+  void transform_shape_to_global_position(TopoDS_Shape& ioShape, Part::Feature* iPart);
 
 private:
   /** Checks if the given document is about to be closed */

--- a/src/Mod/Part/Gui/Workbench.cpp
+++ b/src/Mod/Part/Gui/Workbench.cpp
@@ -141,7 +141,7 @@ Gui::MenuItem* Workbench::setupMenuBar() const
           << "Part_Offset"
           << "Part_Offset2D"
           << "Part_Thickness"
-          << "Part_projectionOnSurface"
+          << "Part_ProjectionOnSurface"
           << "Separator"
           << "Part_EditAttachment";
 
@@ -198,7 +198,7 @@ Gui::ToolBarItem* Workbench::setupToolBars() const
           << "Part_Sweep"
           << "Part_CompOffset"
           << "Part_Thickness"
-          << "Part_projectionOnSurface";
+          << "Part_ProjectionOnSurface";
 
     Gui::ToolBarItem* boolop = new Gui::ToolBarItem(root);
     boolop->setCommand("Boolean");


### PR DESCRIPTION
Found via `codespell`