### PR TITLE
[Arch] Clean up ArchSectionPlane: hiddenshape, sectionshape, baseshape

### DIFF
--- a/src/Mod/Arch/ArchSectionPlane.py
+++ b/src/Mod/Arch/ArchSectionPlane.py
@@ -1245,27 +1245,6 @@ class _ArchDrawingView:
 
         return mode
 
-    def getDXF(self,obj):
-
-        "returns a DXF representation of the view"
-        if obj.RenderingMode == "Solid":
-            print("Unable to get DXF from Solid mode: ",obj.Label)
-            return ""
-        result = []
-        import Drawing
-        if not hasattr(self,"baseshape"):
-            self.onChanged(obj,"Source")
-        if hasattr(self,"baseshape"):
-            if self.baseshape:
-                result.append(Drawing.projectToDXF(self.baseshape,self.direction))
-        if hasattr(self,"sectionshape"):
-            if self.sectionshape:
-                result.append(Drawing.projectToDXF(self.sectionshape,self.direction))
-        if hasattr(self,"hiddenshape"):
-            if self.hiddenshape:
-                result.append(Drawing.projectToDXF(self.hiddenshape,self.direction))
-        return result
-
 
 class SectionPlaneTaskPanel:
 


### PR DESCRIPTION
The properties were removed in 54a8e856cceef5096502ed3cd9c12d916bd54096

They don't appear to be serialized. Nor I can see they are being used in the BIM workbench.

Forum: https://forum.freecadweb.org/viewtopic.php?f=23&t=49523