### PR TITLE
Add SVG icons for MeshWB

### DIFF
--- a/src/Mod/Mesh/Gui/Command.cpp
+++ b/src/Mod/Mesh/Gui/Command.cpp
@@ -229,6 +229,7 @@ CmdMeshUnion::CmdMeshUnion()
     sToolTipText  = sMenuText;
     sWhatsThis    = "Mesh_Union";
     sStatusTip    = sMenuText;
+    sPixmap       = "Mesh_Union";
 }
 
 void CmdMeshUnion::activated(int)
@@ -299,6 +300,7 @@ CmdMeshDifference::CmdMeshDifference()
     sToolTipText  = sMenuText;
     sWhatsThis    = "Mesh_Difference";
     sStatusTip    = sMenuText;
+    sPixmap       = "Mesh_Difference";
 }
 
 void CmdMeshDifference::activated(int)
@@ -369,6 +371,7 @@ CmdMeshIntersection::CmdMeshIntersection()
     sToolTipText  = sMenuText;
     sWhatsThis    = "Mesh_Intersection";
     sStatusTip    = sMenuText;
+    sPixmap       = "Mesh_Intersection";
 }
 
 void CmdMeshIntersection::activated(int)
@@ -688,6 +691,7 @@ CmdMeshVertexCurvatureInfo::CmdMeshVertexCurvatureInfo()
     sToolTipText  = QT_TR_NOOP("Information about curvature");
     sWhatsThis    = "Mesh_CurvatureInfo";
     sStatusTip    = QT_TR_NOOP("Information about curvature");
+    sPixmap       = "Mesh_Curvature_Info";
 }
 
 void CmdMeshVertexCurvatureInfo::activated(int)
@@ -842,6 +846,7 @@ CmdMeshAddFacet::CmdMeshAddFacet()
     sToolTipText  = QT_TR_NOOP("Add triangle manually to a mesh");
     sWhatsThis    = "Mesh_AddFacet";
     sStatusTip    = QT_TR_NOOP("Add triangle manually to a mesh");
+    sPixmap       = "Mesh_Add_Facet";
 }
 
 void CmdMeshAddFacet::activated(int)
@@ -949,6 +954,7 @@ CmdMeshPolyTrim::CmdMeshPolyTrim()
     sToolTipText  = QT_TR_NOOP("Trims a mesh with a picked polygon");
     sWhatsThis    = "Mesh_PolyTrim";
     sStatusTip    = QT_TR_NOOP("Trims a mesh with a picked polygon");
+    sPixmap       = "Mesh_Poly_Trim";
 }
 
 void CmdMeshPolyTrim::activated(int)
@@ -1008,6 +1014,7 @@ CmdMeshTrimByPlane::CmdMeshTrimByPlane()
     sMenuText     = QT_TR_NOOP("Trim mesh with a plane");
     sToolTipText  = QT_TR_NOOP("Trims a mesh with a plane");
     sStatusTip    = QT_TR_NOOP("Trims a mesh with a plane");
+    sPixmap       = "Mesh_Trim_by_Plane";
 }
 
 void CmdMeshTrimByPlane::activated(int)
@@ -1036,6 +1043,7 @@ CmdMeshSectionByPlane::CmdMeshSectionByPlane()
     sMenuText     = QT_TR_NOOP("Create section from mesh and plane");
     sToolTipText  = QT_TR_NOOP("Section from mesh and plane");
     sStatusTip    = QT_TR_NOOP("Section from mesh and plane");
+    sPixmap       = "Mesh_Section_by_Plane";
 }
 
 void CmdMeshSectionByPlane::activated(int)
@@ -1064,6 +1072,7 @@ CmdMeshCrossSections::CmdMeshCrossSections()
     sMenuText     = QT_TR_NOOP("Cross-sections...");
     sToolTipText  = QT_TR_NOOP("Cross-sections");
     sStatusTip    = QT_TR_NOOP("Cross-sections");
+    sPixmap       = "Mesh_Cross_Sections";
 }
 
 void CmdMeshCrossSections::activated(int)
@@ -1145,6 +1154,7 @@ CmdMeshEvaluation::CmdMeshEvaluation()
     sToolTipText  = QT_TR_NOOP("Opens a dialog to analyze and repair a mesh");
     sWhatsThis    = "Mesh_Evaluation";
     sStatusTip    = QT_TR_NOOP("Opens a dialog to analyze and repair a mesh");
+    sPixmap       = "Mesh_Evaluation";
 }
 
 void CmdMeshEvaluation::activated(int)
@@ -1274,7 +1284,7 @@ CmdMeshRemeshGmsh::CmdMeshRemeshGmsh()
     sToolTipText  = QT_TR_NOOP("Refine existing mesh");
     sStatusTip    = QT_TR_NOOP("Refine existing mesh");
     sWhatsThis    = "Mesh_RemeshGmsh";
-  //sPixmap       = "Mesh_RemeshGmsh";
+    sPixmap       = "Mesh_Remesh_Gmsh";
 }
 
 void CmdMeshRemeshGmsh::activated(int)
@@ -1307,6 +1317,7 @@ CmdMeshRemoveCompByHand::CmdMeshRemoveCompByHand()
     sToolTipText  = QT_TR_NOOP("Mark a component to remove it from the mesh");
     sWhatsThis    = "Mesh_RemoveCompByHand";
     sStatusTip    = QT_TR_NOOP("Mark a component to remove it from the mesh");
+    sPixmap       = "Mesh_Remove_Comp_by_Hand";
 }
 
 void CmdMeshRemoveCompByHand::activated(int)
@@ -1350,6 +1361,7 @@ CmdMeshEvaluateSolid::CmdMeshEvaluateSolid()
     sToolTipText  = QT_TR_NOOP("Checks whether the mesh is a solid");
     sWhatsThis    = "Mesh_EvaluateSolid";
     sStatusTip    = QT_TR_NOOP("Checks whether the mesh is a solid");
+    sPixmap       = "Mesh_Evaluate_Solid";
 }
 
 void CmdMeshEvaluateSolid::activated(int)
@@ -1387,6 +1399,7 @@ CmdMeshSmoothing::CmdMeshSmoothing()
     sToolTipText  = QT_TR_NOOP("Smooth the selected meshes");
     sWhatsThis    = "Mesh_Smoothing";
     sStatusTip    = QT_TR_NOOP("Smooth the selected meshes");
+    sPixmap       = "Mesh_Smoothing";
 }
 
 void CmdMeshSmoothing::activated(int)
@@ -1449,6 +1462,7 @@ CmdMeshDecimating::CmdMeshDecimating()
     sToolTipText  = QT_TR_NOOP("Decimates a mesh");
     sWhatsThis    = QT_TR_NOOP("Decimates a mesh");
     sStatusTip    = QT_TR_NOOP("Decimates a mesh");
+    sPixmap       = "Mesh_Decimating";
 }
 
 void CmdMeshDecimating::activated(int)
@@ -1547,6 +1561,7 @@ CmdMeshBoundingBox::CmdMeshBoundingBox()
     sToolTipText  = QT_TR_NOOP("Shows the boundings of the selected mesh");
     sWhatsThis    = "Mesh_BoundingBox";
     sStatusTip    = QT_TR_NOOP("Shows the boundings of the selected mesh");
+    sPixmap       = "Mesh_Bounding_Box";
 }
 
 void CmdMeshBoundingBox::activated(int)
@@ -1699,6 +1714,7 @@ CmdMeshSegmentation::CmdMeshSegmentation()
     sToolTipText  = QT_TR_NOOP("Create mesh segments");
     sWhatsThis    = "Mesh_Segmentation";
     sStatusTip    = QT_TR_NOOP("Create mesh segments");
+    sPixmap       = "Mesh_Segmentation";
 }
 
 void CmdMeshSegmentation::activated(int)
@@ -1734,6 +1750,7 @@ CmdMeshSegmentationBestFit::CmdMeshSegmentationBestFit()
     sToolTipText  = QT_TR_NOOP("Create mesh segments from best-fit surfaces");
     sWhatsThis    = "Mesh_SegmentationBestFit";
     sStatusTip    = QT_TR_NOOP("Create mesh segments from best-fit surfaces");
+    sPixmap       = "Mesh_Segmentation_Best_Fit";
 }
 
 void CmdMeshSegmentationBestFit::activated(int)
@@ -1769,6 +1786,7 @@ CmdMeshMerge::CmdMeshMerge()
     sToolTipText  = QT_TR_NOOP("Merges selected meshes into one");
     sWhatsThis    = "Mesh_Merge";
     sStatusTip    = sToolTipText;
+    sPixmap       = "Mesh_Merge";
 }
 
 void CmdMeshMerge::activated(int)
@@ -1811,6 +1829,7 @@ CmdMeshScale::CmdMeshScale()
     sToolTipText  = QT_TR_NOOP("Scale selected meshes");
     sWhatsThis    = "Mesh_Scale";
     sStatusTip    = sToolTipText;
+    sPixmap       = "Mesh_Scale";
 }
 
 void CmdMeshScale::activated(int)

--- a/src/Mod/Mesh/Gui/Resources/Mesh.qrc
+++ b/src/Mod/Mesh/Gui/Resources/Mesh.qrc
@@ -15,6 +15,26 @@
         <file>icons/Mesh_Tree_Curvature_Plot.svg</file>
         <file>icons/MeshWorkbench.svg</file>
         <file>icons/Mesh_Fill_up_Holes.svg</file>
+        <file>icons/Mesh_Union.svg</file>
+        <file>icons/Mesh_Smoothing.svg</file>
+        <file>icons/Mesh_Segmentation_Best_Fit.svg</file>
+        <file>icons/Mesh_Segmentation.svg</file>
+        <file>icons/Mesh_Section_by_Plane.svg</file>
+        <file>icons/Mesh_Scale.svg</file>
+        <file>icons/Mesh_Remove_Comp_by_Hand.svg</file>
+        <file>icons/Mesh_Remesh_Gmsh.svg</file>
+        <file>icons/Mesh_Poly_Trim.svg</file>
+        <file>icons/Mesh_Merge.svg</file>
+        <file>icons/Mesh_Intersection.svg</file>
+        <file>icons/Mesh_Evaluation.svg</file>
+        <file>icons/Mesh_Evaluate_Solid.svg</file>
+        <file>icons/Mesh_Difference.svg</file>
+        <file>icons/Mesh_Decimating.svg</file>
+        <file>icons/Mesh_Curvature_Info.svg</file>
+        <file>icons/Mesh_Cross_Sections.svg</file>
+        <file>icons/Mesh_Bounding_Box.svg</file>
+        <file>icons/Mesh_Add_Facet.svg</file>
+        <file>icons/Mesh_Trim_by_Plane.svg</file>
         <file>icons/RegularSolids/Mesh_Cone.svg</file>
         <file>icons/RegularSolids/Mesh_Cube.svg</file>
         <file>icons/RegularSolids/Mesh_Cylinder.svg</file>

--- a/src/Mod/Mesh/Gui/Resources/icons/Mesh_Add_Facet.svg
+++ b/src/Mod/Mesh/Gui/Resources/icons/Mesh_Add_Facet.svg
@@ -1,0 +1,178 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   version="1.1"
+   id="svg9484"
+   height="64"
+   width="64">
+  <title
+     id="title3749">Mesh_Add_Facet</title>
+  <defs
+     id="defs9486">
+    <linearGradient
+       id="linearGradient1909">
+      <stop
+         id="stop1905"
+         offset="0"
+         style="stop-color:#4e9a06;stop-opacity:1" />
+      <stop
+         id="stop1907"
+         offset="1"
+         style="stop-color:#8ae234;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient1347">
+      <stop
+         id="stop1343"
+         offset="0"
+         style="stop-color:#4e9a06;stop-opacity:1" />
+      <stop
+         id="stop1345"
+         offset="1"
+         style="stop-color:#8ae234;stop-opacity:1" />
+    </linearGradient>
+    <marker
+       style="overflow:visible"
+       id="Arrow1Lstart"
+       refX="0.0"
+       refY="0.0"
+       orient="auto">
+      <path
+         transform="scale(0.8) translate(12.5,0)"
+         style="fill-rule:evenodd;stroke:none;stroke-width:1pt;stroke-opacity:1;fill:#8ae234;fill-opacity:1"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         id="path1067" />
+    </marker>
+    <linearGradient
+       id="linearGradient12537">
+      <stop
+         id="stop12539"
+         offset="0"
+         style="stop-color:#00fd00;stop-opacity:1;" />
+      <stop
+         id="stop12541"
+         offset="1"
+         style="stop-color:#00fd00;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(35,-2)"
+       gradientUnits="userSpaceOnUse"
+       y2="14.755193"
+       x2="30.5"
+       y1="14.755193"
+       x1="4.5"
+       id="linearGradient12547"
+       xlink:href="#linearGradient12537" />
+    <linearGradient
+       xlink:href="#linearGradient1014"
+       id="linearGradient951"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.47516502,-0.46153841,0.47516502,0.46153841,20.184848,13.625688)"
+       x1="29"
+       y1="47"
+       x2="15"
+       y2="17" />
+    <linearGradient
+       id="linearGradient1014">
+      <stop
+         id="stop1010"
+         offset="0"
+         style="stop-color:#204a87;stop-opacity:1" />
+      <stop
+         id="stop1012"
+         offset="1"
+         style="stop-color:#729fcf;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="-19.181715"
+       x2="11.196301"
+       y1="-1.0932833"
+       x1="25.894817"
+       id="linearGradient1349"
+       xlink:href="#linearGradient1347" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="-18.27072"
+       x2="12.52975"
+       y1="0.75593823"
+       x1="23.388866"
+       id="linearGradient1911"
+       xlink:href="#linearGradient1909" />
+  </defs>
+  <metadata
+     id="metadata9489">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <cc:license
+           rdf:resource="https://www.gnu.org/copyleft/lesser.html" />
+        <dc:title>Mesh_Add_Facet</dc:title>
+        <dc:description>Triangular mesh face</dc:description>
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title>Icon based on a wmayer' s design</dc:title>
+          </cc:Agent>
+        </dc:contributor>
+        <dc:subject>
+          <rdf:Bag>
+            <rdf:li>mesh</rdf:li>
+            <rdf:li>triangle</rdf:li>
+            <rdf:li>face</rdf:li>
+          </rdf:Bag>
+        </dc:subject>
+        <dc:relation />
+        <dc:identifier />
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>FreeCAD</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>FreeCAD LGPL2+</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <dc:date>11-06-2020</dc:date>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>[bitacovir]</dc:title>
+          </cc:Agent>
+        </dc:creator>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     style="opacity:1"
+     transform="translate(0,32)"
+     id="layer1">
+    <path
+       id="path1903"
+       d="M 7.1155185,-25.238729 56.894347,-12.973343 4,19 Z"
+       style="fill:url(#linearGradient1911);fill-opacity:1" />
+    <path
+       id="path1049"
+       d="M 59.924202,-13.754931 4,19 5.4759648,-27.173726 Z"
+       style="fill:none;stroke:#172a04;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient951);fill-opacity:1;fill-rule:evenodd;stroke:#0b1521;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       d="m 34.439798,13.625688 v 5.538461 h 9.503301 v 9.230768 h 5.70198 v -9.230768 l 9.503301,-10e-7 v -5.538461 l -9.503301,1e-6 V 4.3949187 h -5.70198 v 9.2307693 z"
+       id="rect3761" />
+    <path
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#729fcf;stroke-width:1.32456;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       d="m 35.865293,15.010303 v 2.769231 h 9.503301 v 9.230767 h 2.85099 v -9.230767 l 9.503301,-1e-6 v -2.769231 l -9.503301,1e-6 1e-6,-9.2307683 h -2.85099 l -10e-7,9.2307683 z"
+       id="rect3761-3" />
+    <path
+       style="fill:none;stroke:#8ae234;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 8.3067602,-23.368394 7.1698014,13.640775 52.021666,-12.602091 Z"
+       id="path1338" />
+  </g>
+</svg>

--- a/src/Mod/Mesh/Gui/Resources/icons/Mesh_Bounding_Box.svg
+++ b/src/Mod/Mesh/Gui/Resources/icons/Mesh_Bounding_Box.svg
@@ -1,0 +1,238 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   version="1.1"
+   id="svg9484"
+   height="64"
+   width="64">
+  <title
+     id="title3749">Mesh_Bounding_Box</title>
+  <defs
+     id="defs9486">
+    <linearGradient
+       id="linearGradient898">
+      <stop
+         id="stop894"
+         offset="0"
+         style="stop-color:#4e9a06;stop-opacity:1" />
+      <stop
+         id="stop896"
+         offset="1"
+         style="stop-color:#8ae234;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient890">
+      <stop
+         id="stop886"
+         offset="0"
+         style="stop-color:#4e9a06;stop-opacity:1" />
+      <stop
+         id="stop888"
+         offset="1"
+         style="stop-color:#8ae234;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient1347">
+      <stop
+         id="stop1343"
+         offset="0"
+         style="stop-color:#4e9a06;stop-opacity:1" />
+      <stop
+         id="stop1345"
+         offset="1"
+         style="stop-color:#8ae234;stop-opacity:1" />
+    </linearGradient>
+    <marker
+       style="overflow:visible"
+       id="Arrow1Lstart"
+       refX="0.0"
+       refY="0.0"
+       orient="auto">
+      <path
+         transform="scale(0.8) translate(12.5,0)"
+         style="fill-rule:evenodd;stroke:none;stroke-width:1pt;stroke-opacity:1;fill:#8ae234;fill-opacity:1"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         id="path1067" />
+    </marker>
+    <linearGradient
+       id="linearGradient12537">
+      <stop
+         id="stop12539"
+         offset="0"
+         style="stop-color:#00fd00;stop-opacity:1;" />
+      <stop
+         id="stop12541"
+         offset="1"
+         style="stop-color:#00fd00;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(35,-2)"
+       gradientUnits="userSpaceOnUse"
+       y2="14.755193"
+       x2="30.5"
+       y1="14.755193"
+       x1="4.5"
+       id="linearGradient12547"
+       xlink:href="#linearGradient12537" />
+    <linearGradient
+       id="linearGradient1014">
+      <stop
+         id="stop1010"
+         offset="0"
+         style="stop-color:#204a87;stop-opacity:1" />
+      <stop
+         id="stop1012"
+         offset="1"
+         style="stop-color:#729fcf;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="-19.181715"
+       x2="11.196301"
+       y1="-1.0932833"
+       x1="25.894817"
+       id="linearGradient1349"
+       xlink:href="#linearGradient1347" />
+    <linearGradient
+       gradientTransform="translate(2.1001176)"
+       gradientUnits="userSpaceOnUse"
+       y2="-10.21135"
+       x2="23.182476"
+       y1="7.1146197"
+       x1="27.745445"
+       id="linearGradient892"
+       xlink:href="#linearGradient890" />
+    <linearGradient
+       gradientTransform="translate(2.1001176)"
+       gradientUnits="userSpaceOnUse"
+       y2="-5.9454432"
+       x2="10.581533"
+       y1="9.1491518"
+       x1="18.163582"
+       id="linearGradient900"
+       xlink:href="#linearGradient898" />
+  </defs>
+  <metadata
+     id="metadata9489">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <cc:license
+           rdf:resource="https://www.gnu.org/copyleft/lesser.html" />
+        <dc:title>Mesh_Bounding_Box</dc:title>
+        <dc:description>Boundingbox of a mesh with red and blue levels</dc:description>
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title />
+          </cc:Agent>
+        </dc:contributor>
+        <dc:subject>
+          <rdf:Bag>
+            <rdf:li>mesh</rdf:li>
+            <rdf:li>triangles</rdf:li>
+            <rdf:li>frame</rdf:li>
+          </rdf:Bag>
+        </dc:subject>
+        <dc:relation />
+        <dc:identifier />
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>FreeCAD</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>FreeCAD LGPL2+</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <dc:date>21-06-2020</dc:date>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>[bitacovir]</dc:title>
+          </cc:Agent>
+        </dc:creator>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     style="opacity:1"
+     transform="translate(0,32)"
+     id="layer1">
+    <path
+       id="path878"
+       d="M 9.1880148,6.064632 9.3192719,22.078029 39,10 Z"
+       style="fill:#4e9a06;stroke:#172a04;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       id="path880"
+       d="M 9.1880148,6.064632 11.41939,-9.817508 38,10 Z"
+       style="fill:url(#linearGradient900);fill-opacity:1;stroke:#172a04;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       id="path882"
+       d="M 11.41939,-9.817508 41,-12 39,10 Z"
+       style="fill:url(#linearGradient892);fill-opacity:1;stroke:#172a04;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       id="path884"
+       d="M 41,-12 8.8445128,-21.780349 11.41939,-9.817508 Z"
+       style="fill:#8ae234;stroke:#172a04;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       id="path902"
+       d="m 4.5077849,-22.525029 v -5 h 7.0000001"
+       style="fill:none;stroke:#ce5c00;stroke-width:5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       id="path904"
+       d="m 61,-29 -9,6 9,6 z"
+       style="fill:#ef2929;stroke:#280000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       style="opacity:1;fill:#729fcf;stroke:#0b1521;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 61,17 -9,6 9,6 z"
+       id="path904-8" />
+    <path
+       style="opacity:1;fill:none;stroke:#fcaf3e;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 4.5077849,-22.525029 v -5 h 7.0000001"
+       id="path902-6" />
+    <path
+       style="opacity:1;fill:none;stroke:#ce5c00;stroke-width:5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 44,-22.550288 v -5 h -7"
+       id="path902-0" />
+    <path
+       id="path902-6-3"
+       d="m 44,-22.550288 v -5 h -7"
+       style="opacity:1;fill:none;stroke:#fcaf3e;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       style="opacity:1;fill:none;stroke:#ce5c00;stroke-width:5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 43.969003,22.469468 v 5 h -7"
+       id="path902-3" />
+    <path
+       id="path902-6-4"
+       d="m 43.969003,22.469468 v 5 h -7"
+       style="opacity:1;fill:none;stroke:#fcaf3e;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       id="path902-0-7"
+       d="m 4.4767874,22.494727 v 5 h 7.0000006"
+       style="opacity:1;fill:none;stroke:#ce5c00;stroke-width:5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       style="opacity:1;fill:none;stroke:#fcaf3e;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 4.4767874,22.494727 v 5 h 7.0000006"
+       id="path902-6-3-3" />
+    <path
+       id="path1068"
+       d="M 17.322244,-8.1826978 38.73019,-9.8453692 37.332365,6.3027209 Z"
+       style="fill:none;stroke:#8ae234;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       id="path1070"
+       d="M 12.912604,-6.2211991 30.674684,6.9814441 11.439398,4.3986053 Z"
+       style="fill:none;stroke:#8ae234;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       id="path1072"
+       d="M 11.178574,8.3370847 11.311583,19.116739 31.065079,11.056087 Z"
+       style="fill:none;stroke:#8ae234;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  </g>
+</svg>

--- a/src/Mod/Mesh/Gui/Resources/icons/Mesh_Cross_Sections.svg
+++ b/src/Mod/Mesh/Gui/Resources/icons/Mesh_Cross_Sections.svg
@@ -1,0 +1,171 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:osb="http://www.openswatchbook.org/uri/2009/osb"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   version="1.1"
+   id="svg2943"
+   height="64px"
+   width="64px">
+  <title
+     id="title3265">Mesh_Cross_Sections</title>
+  <defs
+     id="defs2945">
+    <linearGradient
+       id="linearGradient3811">
+      <stop
+         id="stop3813"
+         offset="0"
+         style="stop-color:#8ae234;stop-opacity:1;" />
+      <stop
+         id="stop3815"
+         offset="1"
+         style="stop-color:#4e9a06;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3805"
+       osb:paint="gradient">
+      <stop
+         style="stop-color:#8ae234;stop-opacity:1;"
+         offset="0"
+         id="stop3807" />
+      <stop
+         style="stop-color:#4e9a06;stop-opacity:1;"
+         offset="1"
+         id="stop3809" />
+    </linearGradient>
+    <linearGradient
+       osb:paint="gradient"
+       id="linearGradient3377">
+      <stop
+         style="stop-color:#faff2b;stop-opacity:1;"
+         offset="0"
+         id="stop3379" />
+      <stop
+         style="stop-color:#ffaa00;stop-opacity:1;"
+         offset="1"
+         id="stop3381" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="100.78592"
+       x2="99.153984"
+       y1="98.785927"
+       x1="72.473869"
+       id="linearGradient4397"
+       xlink:href="#linearGradient4391" />
+    <linearGradient
+       osb:paint="gradient"
+       id="linearGradient4391">
+      <stop
+         id="stop4393"
+         offset="0"
+         style="stop-color:#00ff00;stop-opacity:1;" />
+      <stop
+         id="stop4395"
+         offset="1"
+         style="stop-color:#0f7d0f;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="94.195724"
+       x2="285.59393"
+       y1="94.013901"
+       x1="277.25064"
+       id="linearGradient4368"
+       xlink:href="#linearGradient4391" />
+    <radialGradient
+       xlink:href="#linearGradient2269"
+       id="radialGradient3113"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.32526,0,28.08607)"
+       cx="25.1875"
+       cy="41.625"
+       fx="25.1875"
+       fy="41.625"
+       r="18.0625" />
+    <linearGradient
+       id="linearGradient2269">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         id="stop2271"
+         offset="0" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         id="stop2273"
+         offset="1" />
+    </linearGradient>
+  </defs>
+  <metadata
+     id="metadata2948">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>Mesh_Cross_Sections</dc:title>
+        <cc:license
+           rdf:resource="" />
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title />
+          </cc:Agent>
+        </dc:contributor>
+        <dc:description>Intersection of cross lines</dc:description>
+        <dc:subject>
+          <rdf:Bag />
+        </dc:subject>
+        <dc:relation />
+        <dc:identifier />
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>FreeCAD</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>FreeCAD LGPL2+</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <dc:date>25-06-2020</dc:date>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>[bitacovir]</dc:title>
+          </cc:Agent>
+        </dc:creator>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1">
+    <path
+       id="path868"
+       d="M 41.277841,39.798899 V 4.056764 L 20.253056,26.132788 v 33.639657 z"
+       style="fill:none;stroke:#280000;stroke-width:4;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       id="path870"
+       d="M 12.894381,7.0231466 V 43.957009 L 49.687756,57.218921 V 19.22516 Z"
+       style="fill:none;stroke:#280000;stroke-width:4;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       id="path872"
+       d="M 4.2875524,35.122448 39.403893,48.277373 58.943232,27.709648 23.272761,15.479926 Z"
+       style="fill:none;stroke:#280000;stroke-width:4;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       id="path888"
+       d="M 12.894381,7.0231466 49.687756,19.22516 V 57.218921 L 12.894381,43.957009 Z"
+       style="fill:none;stroke:#ef2929;stroke-width:1.5;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       id="path890"
+       d="M 58.943232,27.709648 39.403893,48.277373 4.2875524,35.122448 23.272761,15.479926 Z"
+       style="fill:none;stroke:#ef2929;stroke-width:1.5;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       id="path892"
+       d="M 20.253056,59.772445 V 26.132788 L 41.277841,4.056764 v 35.742135 z"
+       style="fill:none;stroke:#ef2929;stroke-width:1.5;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  </g>
+</svg>

--- a/src/Mod/Mesh/Gui/Resources/icons/Mesh_Curvature_Info.svg
+++ b/src/Mod/Mesh/Gui/Resources/icons/Mesh_Curvature_Info.svg
@@ -1,0 +1,259 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   version="1.1"
+   id="svg2"
+   height="64"
+   width="64">
+  <title
+     id="title3733">Mesh_Curvature_Info</title>
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient3820">
+      <stop
+         id="stop3822"
+         offset="0"
+         style="stop-color:#babdb6;stop-opacity:1;" />
+      <stop
+         id="stop3824"
+         offset="1"
+         style="stop-color:#eeeeec;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3757">
+      <stop
+         id="stop3759"
+         offset="0"
+         style="stop-color:#555753;stop-opacity:1;" />
+      <stop
+         id="stop3761"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="33.977303"
+       x2="22.936319"
+       y1="39.303909"
+       x1="28.796343"
+       id="linearGradient3763"
+       xlink:href="#linearGradient3757" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="1045.3622"
+       x2="35"
+       y1="1043.3622"
+       x1="49"
+       id="linearGradient3842"
+       xlink:href="#linearGradient3820" />
+    <linearGradient
+       gradientTransform="rotate(45,36.156813,1003.8708)"
+       y2="1042.3622"
+       x2="39"
+       y1="1040.3622"
+       x1="49"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3854"
+       xlink:href="#linearGradient3820" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="1025.3622"
+       x2="51"
+       y1="1005.3622"
+       x1="40"
+       id="linearGradient3870"
+       xlink:href="#linearGradient3757" />
+    <radialGradient
+       xlink:href="#linearGradient2269"
+       id="radialGradient3062"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.32526,0,28.08607)"
+       cx="25.1875"
+       cy="41.625"
+       fx="25.1875"
+       fy="41.625"
+       r="18.0625" />
+    <linearGradient
+       id="linearGradient2269">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         id="stop2271"
+         offset="0" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         id="stop2273"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#linearGradient2269"
+       id="radialGradient3113"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.32526,0,28.08607)"
+       cx="25.1875"
+       cy="41.625"
+       fx="25.1875"
+       fy="41.625"
+       r="18.0625" />
+  </defs>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>Mesh_Curvature_Info</dc:title>
+        <cc:license
+           rdf:resource="https://www.gnu.org/copyleft/lesser.html" />
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>FreeCAD LGPL2+</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>FreeCAD</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:identifier />
+        <dc:relation />
+        <dc:subject>
+          <rdf:Bag>
+            <rdf:li>mesh</rdf:li>
+            <rdf:li>colors</rdf:li>
+            <rdf:li>pipet</rdf:li>
+          </rdf:Bag>
+        </dc:subject>
+        <dc:description>Mesh, with colors and pipet</dc:description>
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title>Based on a jmaustpc's design</dc:title>
+          </cc:Agent>
+        </dc:contributor>
+        <dc:date>21-06-2020</dc:date>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>[bitacovir]</dc:title>
+          </cc:Agent>
+        </dc:creator>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     transform="translate(0,-988.36218)"
+     id="layer1">
+    <g
+       id="g3844">
+      <g
+         transform="translate(-1)"
+         id="g898">
+        <g
+           style="stroke-width:1.93189"
+           transform="matrix(1,0,0,1.0717579,4.427026,995.61294)"
+           id="g3033">
+          <path
+             id="path4460"
+             d="m 19.572974,49.217497 4,-29.857489 16,-3.732186 z"
+             style="fill:#cc0000;fill-opacity:1;stroke:#280000;stroke-width:1.93189;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+          <path
+             transform="matrix(1,0,0,0.93304654,-4.427026,-6.7652953)"
+             id="path3788"
+             d="M 24,56 42,24"
+             style="fill:none;stroke:#ef2929;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
+          <path
+             style="fill:#fce94f;fill-opacity:1;stroke:#2c2700;stroke-width:1.93189;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             d="m 19.572974,-3.0331087 20,18.6609317 -16,3.732185 z"
+             id="path4452" />
+          <path
+             id="path3788-4"
+             d="m 23.572974,21.226101 14,-3.732186"
+             style="fill:none;stroke:#ef2929;stroke-width:1.93189;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
+          <path
+             id="path3024"
+             d="M 25.572974,19.360008 22.408646,43.039711"
+             style="fill:none;stroke:#ef2929;stroke-width:1.93189;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+          <path
+             id="path4460-1"
+             d="m 19.572974,49.217498 4,-29.85749 16,-3.732186 z"
+             style="fill:none;stroke:#280000;stroke-width:1.93189;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        </g>
+        <path
+           id="path4460-3"
+           d="m 24,1048.3622 -20,-40 24,8 z"
+           style="fill:#3465a4;fill-opacity:1;stroke:#0b1521;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <path
+           id="path3801-1"
+           d="m 6,1010.3622 22,8"
+           style="fill:none;stroke:#729fcf;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+        <path
+           id="path3801"
+           d="m 24,1044.3622 -18,-36"
+           style="fill:none;stroke:#729fcf;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
+        <path
+           id="path3004"
+           d="m 26,1016.3622 -3.550023,27.9502"
+           style="fill:none;stroke:#729fcf;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+        <path
+           id="path4460-3-7"
+           d="m 24,1048.3622 -20,-40 24,8 z"
+           style="fill:none;stroke:#0b1521;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <path
+           id="path3029"
+           d="m 4,1008.3622 20,-16.00002 4,24.00002 z"
+           style="fill:#8ae234;fill-opacity:1;stroke:#172a04;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      </g>
+      <ellipse
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.267045;fill:url(#radialGradient3113);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none"
+         transform="matrix(1.256055,0,0,0.819149,-3.6368853,1011.4526)"
+         id="path2267"
+         cx="25.1875"
+         cy="41.625"
+         rx="18.0625"
+         ry="5.875" />
+      <g
+         transform="matrix(0.65581481,0,0,0.65581481,20.992573,341.27397)"
+         id="g933">
+        <g
+           id="g922">
+          <g
+             id="g908">
+            <path
+               id="path3798-7"
+               d="m 26.506083,1014.714 c 0,0 -16.970563,16.9706 -19.79899,19.799 -2.828427,2.8284 0,5.6569 0,5.6569 l -3.535534,6.3639 2.828427,2.8284 6.363961,-3.5355 c 0,0 2.828427,2.8284 5.656855,0 2.828427,-2.8284 19.798989,-19.799 19.798989,-19.799 z"
+               style="fill:url(#linearGradient3854);fill-opacity:1;stroke:none" />
+            <path
+               id="path3800"
+               d="m 27.213204,1016.8353 c 0,0 -19.091883,19.0919 -19.79899,19.799 -0.707107,0.7071 1.337236,2.9054 1.337236,2.9054 l -4.165663,8.4083"
+               style="fill:none;stroke:#ffffff;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+            <path
+               id="path3798"
+               d="m 26.506097,1014.714 c 0,0 -16.970563,16.9706 -19.79899,19.799 -2.828427,2.8284 0,5.6568 0,5.6568 l -3.535534,6.364 2.828427,2.8284 6.363961,-3.5355 c 0,0 2.828428,2.8284 5.656855,0 2.828427,-2.8284 19.79899,-19.799 19.79899,-19.799 z"
+               style="fill:none;stroke:#555753;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+          </g>
+        </g>
+        <g
+           id="g903">
+          <path
+             style="fill:url(#linearGradient3870);fill-opacity:1;stroke:none"
+             d="m 24.384763,1011.1785 c 1.414213,-1.4142 4.24264,0 5.656854,0 1.414213,0 1.414213,0 2.828427,-2.8284 1.414213,-2.8285 -2.828427,-8.48535 1.414228,-12.728 4.24264,-4.24264 12.727936,-7.07108 21.213217,1.4142 8.485282,8.4853 5.65684,16.9706 1.4142,21.2132 -4.242655,4.2427 -9.899509,10e-5 -12.727937,1.4143 -2.828427,1.4142 -2.828427,1.4142 -2.828427,2.8284 0,1.4142 1.414214,4.2426 0,5.6568 -1.414213,1.4143 -2.12132,2.1214 -4.24264,1.4143 -2.121321,-0.7071 0,-2.8285 -5.656855,-8.4853 -5.656854,-5.6569 -7.778174,-3.5356 -8.485281,-5.6569 -0.707107,-2.1213 0,-2.8284 1.414214,-4.2426 z"
+             id="path2992" />
+          <path
+             style="fill:none;stroke:#888a85;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="m 25.798976,1012.5927 c 1.414214,-1.4142 4.461915,0.035 5.656854,0 1.19494,-0.035 0.707107,0.7071 2.828427,-2.8284 2.121321,-3.5356 -2.828427,-8.4853 1.414228,-12.72799 4.242641,-4.24264 11.426846,-5.54371 18.384776,1.41422 6.957931,6.95797 5.656855,14.14217 1.414214,18.38477 -4.242655,4.2427 -9.192402,-0.7071 -12.727936,1.4143 -3.535534,2.1213 -2.828427,1.4142 -2.828427,2.8284 0,1.4142 1.414213,4.2426 0,5.6568 -1.414214,1.4142 -1.414214,1.4142 -2.121321,0.7071 -0.707106,-0.7071 -0.636537,-3.0969 -5.275158,-7.7356 -4.63862,-4.6386 -6.745657,-4.2852 -7.452764,-4.9923 -0.707106,-0.7071 -0.707106,-0.7071 0.707107,-2.1213 z"
+             id="path2992-3-6" />
+          <path
+             style="fill:none;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+             d="m 24.384763,1011.1785 c 1.414213,-1.4142 4.24264,0 5.656854,0 1.414213,0 1.414213,0 2.828427,-2.8284 1.414213,-2.8285 -2.828427,-8.48535 1.414228,-12.728 4.24264,-4.24264 12.727936,-7.07108 21.213217,1.4142 8.485282,8.4853 5.65684,16.9706 1.4142,21.2132 -4.242655,4.2427 -9.899509,10e-5 -12.727937,1.4143 -2.828427,1.4142 -2.828427,1.4142 -2.828427,2.8284 0,1.4142 1.414214,4.2426 0,5.6568 -1.414213,1.4143 -2.12132,2.1214 -4.24264,1.4143 -2.121321,-0.7071 0,-2.8285 -5.656855,-8.4853 -5.656854,-5.6569 -7.778174,-3.5356 -8.485281,-5.6569 -0.707107,-2.1213 0,-2.8284 1.414214,-4.2426 z"
+             id="path2992-3" />
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/src/Mod/Mesh/Gui/Resources/icons/Mesh_Decimating.svg
+++ b/src/Mod/Mesh/Gui/Resources/icons/Mesh_Decimating.svg
@@ -1,0 +1,206 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   width="64"
+   height="64"
+   id="svg9484"
+   version="1.1">
+  <title
+     id="title3749">Mesh_Decimating</title>
+  <defs
+     id="defs9486">
+    <linearGradient
+       id="linearGradient1347">
+      <stop
+         style="stop-color:#4e9a06;stop-opacity:1"
+         offset="0"
+         id="stop1343" />
+      <stop
+         style="stop-color:#8ae234;stop-opacity:1"
+         offset="1"
+         id="stop1345" />
+    </linearGradient>
+    <marker
+       orient="auto"
+       refY="0.0"
+       refX="0.0"
+       id="Arrow1Lstart"
+       style="overflow:visible">
+      <path
+         id="path1067"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         style="fill-rule:evenodd;stroke:none;stroke-width:1pt;stroke-opacity:1;fill:#8ae234;fill-opacity:1"
+         transform="scale(0.8) translate(12.5,0)" />
+    </marker>
+    <linearGradient
+       id="linearGradient12537">
+      <stop
+         style="stop-color:#00fd00;stop-opacity:1;"
+         offset="0"
+         id="stop12539" />
+      <stop
+         style="stop-color:#00fd00;stop-opacity:0;"
+         offset="1"
+         id="stop12541" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient12537"
+       id="linearGradient12547"
+       x1="4.5"
+       y1="14.755193"
+       x2="30.5"
+       y2="14.755193"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(35,-2)" />
+    <linearGradient
+       id="linearGradient1014">
+      <stop
+         style="stop-color:#204a87;stop-opacity:1"
+         offset="0"
+         id="stop1010" />
+      <stop
+         style="stop-color:#729fcf;stop-opacity:1"
+         offset="1"
+         id="stop1012" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient1347"
+       id="linearGradient1349"
+       x1="25.894817"
+       y1="-1.0932833"
+       x2="11.196301"
+       y2="-19.181715"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <metadata
+     id="metadata9489">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <cc:license
+           rdf:resource="https://www.gnu.org/copyleft/lesser.html" />
+        <dc:title>Mesh_Decimating</dc:title>
+        <dc:description>Green diamond faces</dc:description>
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title />
+          </cc:Agent>
+        </dc:contributor>
+        <dc:subject>
+          <rdf:Bag>
+            <rdf:li>mesh</rdf:li>
+            <rdf:li>triangles</rdf:li>
+            <rdf:li>diamond</rdf:li>
+          </rdf:Bag>
+        </dc:subject>
+        <dc:relation />
+        <dc:identifier />
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>FreeCAD</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>FreeCAD LGPL2+</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <dc:date>21-06-2020</dc:date>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>[bitacovir]</dc:title>
+          </cc:Agent>
+        </dc:creator>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     transform="translate(0,32)"
+     style="opacity:1">
+    <path
+       id="path877"
+       d="M 3.8064632,-10.211279 23,-10 32,28 Z"
+       style="fill:#4e9a06;stroke:#172a04;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       id="path879"
+       d="M 32,28 60,-10 H 41 Z"
+       style="fill:#4e9a06;stroke:#172a04;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       id="path881"
+       d="M 23,-10 H 41 L 32,28 Z"
+       style="fill:#73d216;stroke:#172a04;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       id="path883"
+       d="M 3.8064632,-10.211279 10,-26 23,-10 Z"
+       style="fill:#73d216;stroke:#172a04;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       id="path885"
+       d="m 23,-10 9,-16 9,16 z"
+       style="fill:#73d216;stroke:#172a04;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       id="path887"
+       d="m 41,-10 13,-16 6,16 z"
+       style="fill:#73d216;stroke:#172a04;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       id="path889"
+       d="m 10,-26 13,16 9,-16 z"
+       style="fill:#4e9a06;stroke:#172a04;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       id="path891"
+       d="m 32,-26 9,16 13,-16 z"
+       style="fill:#4e9a06;stroke:#172a04;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       id="path893"
+       d="m 6.7521431,-12.161229 3.8517379,-9.884581 8.16754,10.070206 z"
+       style="fill:none;stroke:#8ae234;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       style="opacity:1;fill:none;stroke:#8ae234;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 57.109387,-11.993453 -3.735722,-10.0122 -8.155938,10.000597 z"
+       id="path893-0" />
+    <path
+       id="path910"
+       d="M 7.7673869,-8.1343652 21.406208,-8.0143693 27.809951,19.002349 Z"
+       style="fill:none;stroke:#8ae234;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       id="path912"
+       d="m 28.732934,18.646115 -1.80877,0.806767 2.969698,3.986942 z"
+       style="fill:#8ae234;stroke:none;stroke-width:0.1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       style="opacity:1;fill:none;stroke:#8ae234;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 55.940111,-8.0226002 42.672542,-7.9954172 36.219577,18.873636 Z"
+       id="path910-7" />
+    <path
+       style="opacity:1;fill:#8ae234;stroke:none;stroke-width:0.1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 35.263229,18.581894 1.80877,0.806767 -2.969698,3.986942 z"
+       id="path912-1" />
+    <path
+       id="path944"
+       d="M 25.522276,-8.018349 38.469664,-7.979905 31.99398,19.223182 Z"
+       style="fill:none;stroke:#8ae234;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       style="opacity:1;fill:#8ae234;stroke:none;stroke-width:0.1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 32.955365,19.441922 -1.936387,-0.01695 1.009024,4.126161 z"
+       id="path912-4" />
+    <path
+       style="opacity:1;fill:none;stroke:#8ae234;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 26.13166,-11.550201 5.87042,-10.348647 5.940029,10.348646 z"
+       id="path893-4" />
+    <path
+       style="opacity:1;fill:none;stroke:#8ae234;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 14.213265,-23.962597 14.352326,0.02535 -5.844182,10.595236 z"
+       id="path893-2" />
+    <path
+       id="path893-2-4"
+       d="m 49.818586,-24.004219 -14.401548,7.39e-4 5.893404,10.488589 z"
+       style="opacity:1;fill:none;stroke:#8ae234;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  </g>
+</svg>

--- a/src/Mod/Mesh/Gui/Resources/icons/Mesh_Difference.svg
+++ b/src/Mod/Mesh/Gui/Resources/icons/Mesh_Difference.svg
@@ -1,0 +1,261 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   width="64px"
+   height="64px"
+   id="svg2568"
+   version="1.1">
+  <title
+     id="title875">Mesh_Difference</title>
+  <defs
+     id="defs2570">
+    <linearGradient
+       id="linearGradient877">
+      <stop
+         id="stop873"
+         offset="0"
+         style="stop-color:#4e9a06;stop-opacity:1;" />
+      <stop
+         id="stop875"
+         offset="1"
+         style="stop-color:#8ae234;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient869">
+      <stop
+         id="stop865"
+         offset="0"
+         style="stop-color:#4e9a06;stop-opacity:1" />
+      <stop
+         id="stop867"
+         offset="1"
+         style="stop-color:#8ae234;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3864">
+      <stop
+         id="stop3866"
+         offset="0"
+         style="stop-color:#71b2f8;stop-opacity:1;" />
+      <stop
+         id="stop3868"
+         offset="1"
+         style="stop-color:#002795;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3593">
+      <stop
+         style="stop-color:#c8e0f9;stop-opacity:1;"
+         offset="0"
+         id="stop3595" />
+      <stop
+         style="stop-color:#637dca;stop-opacity:1;"
+         offset="1"
+         id="stop3597" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3143">
+      <stop
+         style="stop-color:#4e9a06;stop-opacity:1"
+         offset="0"
+         id="stop3145" />
+      <stop
+         style="stop-color:#8ae234;stop-opacity:1"
+         offset="1"
+         id="stop3147" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3143-7">
+      <stop
+         style="stop-color:#729fcf;stop-opacity:1"
+         offset="0"
+         id="stop3145-0" />
+      <stop
+         style="stop-color:#204a87;stop-opacity:1"
+         offset="1"
+         id="stop3147-9" />
+    </linearGradient>
+    <radialGradient
+       r="19.571428"
+       fy="26.281744"
+       fx="46.534134"
+       cy="26.281744"
+       cx="46.534134"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3090-3"
+       xlink:href="#linearGradient3143-6"
+       gradientTransform="matrix(1.1486088,1.8477617,-3.056673,1.900094,73.257745,-112.1016)" />
+    <linearGradient
+       id="linearGradient3143-6">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0"
+         id="stop3145-7" />
+      <stop
+         style="stop-color:#d3d7cf;stop-opacity:1"
+         offset="1"
+         id="stop3147-5" />
+    </linearGradient>
+    <radialGradient
+       r="19.571428"
+       fy="26.281744"
+       fx="46.534134"
+       cy="26.281744"
+       cx="46.534134"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3090-5"
+       xlink:href="#linearGradient3143-62"
+       gradientTransform="matrix(1.1486088,1.8477617,-3.056673,1.900094,73.257745,-112.1016)" />
+    <linearGradient
+       id="linearGradient3143-62">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0"
+         id="stop3145-9" />
+      <stop
+         style="stop-color:#d3d7cf;stop-opacity:1"
+         offset="1"
+         id="stop3147-1" />
+    </linearGradient>
+    <radialGradient
+       r="19.571428"
+       fy="26.281744"
+       fx="46.534134"
+       cy="26.281744"
+       cx="46.534134"
+       gradientTransform="matrix(1.1486088,1.8477617,-3.056673,1.900094,73.257745,-112.1016)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3017-2"
+       xlink:href="#linearGradient3143-62" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="21.120804"
+       x2="44.20533"
+       y1="46.366589"
+       x1="59.119251"
+       id="linearGradient879"
+       xlink:href="#linearGradient877" />
+  </defs>
+  <metadata
+     id="metadata2573">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>Mesh_Difference</dc:title>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>[bitacovir]</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:title>Part_Common</dc:title>
+        <dc:date>04-07-2020</dc:date>
+        <dc:relation />
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>FreeCAD</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:identifier />
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>FreeCAD LGPL2+</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <cc:license>https://www.gnu.org/copyleft/lesser.html</cc:license>
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title>Based on a [wmayer]'s work</dc:title>
+          </cc:Agent>
+        </dc:contributor>
+        <dc:subject>
+          <rdf:Bag>
+            <rdf:li>sphere</rdf:li>
+            <rdf:li>mesh</rdf:li>
+            <rdf:li>plane</rdf:li>
+          </rdf:Bag>
+        </dc:subject>
+        <dc:description>A sphere being trimmed by another sphere </dc:description>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1">
+    <g
+       id="g3560"
+       transform="matrix(0.91273618,0,0,0.90349515,105.85374,2.800363)">
+      <circle
+         r="18.571428"
+         cx="53.214287"
+         cy="34.571426"
+         transform="matrix(1.1209541,0,0,1.1324194,-131.80058,-13.472896)"
+         id="path3550-3-3"
+         style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient879);fill-opacity:1;fill-rule:evenodd;stroke:#172a04;stroke-width:1.95265;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+      <ellipse
+         ry="18.79788"
+         rx="18.607559"
+         style="display:inline;overflow:visible;visibility:visible;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#8ae234;stroke-width:2.30383;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+         id="path3550-3-3-5"
+         cy="25.721622"
+         cx="-72.191147" />
+      <path
+         id="path1581"
+         d="m -90.099621,17.944367 c 16.313988,2.49821 22.490687,13.91866 20.598316,29.008266"
+         style="fill:none;stroke:#8ae234;stroke-width:2.20239;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <g
+         transform="translate(-64.816804,-15.040179)"
+         id="g1579">
+        <path
+           style="fill:none;stroke:#172a04;stroke-width:2.20239;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="M -7.2973111,20.16951 V 60.968848"
+           id="path1612-8" />
+        <path
+           style="fill:none;stroke:#172a04;stroke-width:2.20239;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m -24.827022,37.725779 c 8.81087,0.907084 21.4454229,-9.326081 24.10335192,-16.602192"
+           id="path1666-8" />
+        <path
+           id="path1666-8-7"
+           d="M -21.540202,43.259843 C -11.833069,45.075747 4.0118939,32.551475 5.8499709,24.444026"
+           style="fill:none;stroke:#172a04;stroke-width:2.20239;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <path
+           style="fill:none;stroke:#172a04;stroke-width:2.20239;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="M -16.062162,51.007534 C -6.3550351,52.823437 9.4899279,40.299165 11.328006,32.191715"
+           id="path1666-8-7-4" />
+        <path
+           style="fill:none;stroke:#172a04;stroke-width:2.20239;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="M -9.8042051,58.163888 C -0.09707408,59.979791 11.578628,48.32517 13.416706,40.217719"
+           id="path1666-8-7-7" />
+        <path
+           style="fill:none;stroke:#172a04;stroke-width:2.20239;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m -6.2017041,20.016775 c 11.625899,16.007154 8.751306,32.556688 0,42.058887"
+           id="path1755-1" />
+        <path
+           id="path1755-6-6"
+           d="M -1.8192761,21.123587 C 14.525036,35.334551 9.7262529,50.853902 -3.6004351,61.495712"
+           style="fill:none;stroke:#172a04;stroke-width:2.20239;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <path
+           style="fill:none;stroke:#172a04;stroke-width:2.20239;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="M -8.3929171,20.016775 C -16.906582,30.557607 -16.590302,42.659503 -12.916177,56.10013"
+           id="path1755-4" />
+        <path
+           id="path1755-6-8"
+           d="m -9.4885241,20.016775 c 0.177162,0.520796 -14.5825579,4.805646 -10.9560679,22.136255"
+           style="fill:none;stroke:#172a04;stroke-width:2.20239;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      </g>
+      <circle
+         transform="matrix(1.1209221,0,0,1.1323546,-151.52039,2.02592)"
+         id="path3550-3-7"
+         style="display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient3017-2);fill-opacity:1;fill-rule:evenodd;stroke:#172a04;stroke-width:1.95274;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+         cx="53.214287"
+         cy="34.571426"
+         r="18.571428" />
+    </g>
+  </g>
+</svg>

--- a/src/Mod/Mesh/Gui/Resources/icons/Mesh_Evaluate_Solid.svg
+++ b/src/Mod/Mesh/Gui/Resources/icons/Mesh_Evaluate_Solid.svg
@@ -1,0 +1,883 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   version="1.1"
+   id="svg2816"
+   height="64px"
+   width="64px">
+  <title
+     id="title1624">Mesh_Evaluate_Solid</title>
+  <defs
+     id="defs2818">
+    <linearGradient
+       id="linearGradient4114">
+      <stop
+         id="stop4116"
+         offset="0"
+         style="stop-color:#a40000;stop-opacity:1;" />
+      <stop
+         id="stop4118"
+         offset="1"
+         style="stop-color:#cc0000;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3330">
+      <stop
+         style="stop-color:#729fcf;stop-opacity:1"
+         offset="0"
+         id="stop3332" />
+      <stop
+         style="stop-color:#3465a4;stop-opacity:1"
+         offset="1"
+         id="stop3334" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3324">
+      <stop
+         id="stop3326"
+         offset="0"
+         style="stop-color:#fce94f;stop-opacity:1" />
+      <stop
+         id="stop3328"
+         offset="1"
+         style="stop-color:#73d216;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3318">
+      <stop
+         id="stop3320"
+         offset="0"
+         style="stop-color:#fce94f;stop-opacity:1" />
+      <stop
+         id="stop3322"
+         offset="1"
+         style="stop-color:#73d216;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3312">
+      <stop
+         id="stop3314"
+         offset="0"
+         style="stop-color:#fce94f;stop-opacity:1" />
+      <stop
+         id="stop3316"
+         offset="1"
+         style="stop-color:#73d216;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3306">
+      <stop
+         id="stop3308"
+         offset="0"
+         style="stop-color:#fce94f;stop-opacity:1" />
+      <stop
+         id="stop3310"
+         offset="1"
+         style="stop-color:#73d216;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3300">
+      <stop
+         id="stop3302"
+         offset="0"
+         style="stop-color:#fce94f;stop-opacity:1" />
+      <stop
+         id="stop3304"
+         offset="1"
+         style="stop-color:#73d216;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3294">
+      <stop
+         id="stop3296"
+         offset="0"
+         style="stop-color:#73d216;stop-opacity:1" />
+      <stop
+         id="stop3298"
+         offset="1"
+         style="stop-color:#729fcf;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3288">
+      <stop
+         id="stop3290"
+         offset="0"
+         style="stop-color:#73d216;stop-opacity:1" />
+      <stop
+         id="stop3292"
+         offset="1"
+         style="stop-color:#729fcf;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3282">
+      <stop
+         id="stop3284"
+         offset="0"
+         style="stop-color:#73d216;stop-opacity:1" />
+      <stop
+         id="stop3286"
+         offset="1"
+         style="stop-color:#729fcf;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3276">
+      <stop
+         id="stop3278"
+         offset="0"
+         style="stop-color:#cc0000;stop-opacity:1" />
+      <stop
+         id="stop3280"
+         offset="1"
+         style="stop-color:#fce94f;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3270">
+      <stop
+         id="stop3272"
+         offset="0"
+         style="stop-color:#cc0000;stop-opacity:1" />
+      <stop
+         id="stop3274"
+         offset="1"
+         style="stop-color:#fce94f;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5722">
+      <stop
+         id="stop5724"
+         offset="0"
+         style="stop-color:#73d216;stop-opacity:1" />
+      <stop
+         id="stop5726"
+         offset="1"
+         style="stop-color:#3465a4;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5676">
+      <stop
+         style="stop-color:#fce94f;stop-opacity:1"
+         offset="0"
+         id="stop5678" />
+      <stop
+         style="stop-color:#73d216;stop-opacity:1"
+         offset="1"
+         id="stop5680" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5652">
+      <stop
+         id="stop5654"
+         offset="0"
+         style="stop-color:#fce94f;stop-opacity:1" />
+      <stop
+         id="stop5656"
+         offset="1"
+         style="stop-color:#73d216;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5646">
+      <stop
+         style="stop-color:#cc0000;stop-opacity:1"
+         offset="0"
+         id="stop5648" />
+      <stop
+         style="stop-color:#fce94f;stop-opacity:1"
+         offset="1"
+         id="stop5650" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5606">
+      <stop
+         id="stop5608"
+         offset="0"
+         style="stop-color:#729fcf;stop-opacity:1" />
+      <stop
+         id="stop5610"
+         offset="1"
+         style="stop-color:#3465a4;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5576">
+      <stop
+         style="stop-color:#73d216;stop-opacity:1"
+         offset="0"
+         id="stop5578" />
+      <stop
+         style="stop-color:#729fcf;stop-opacity:1"
+         offset="1"
+         id="stop5580" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2269">
+      <stop
+         id="stop5538"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         id="stop5540"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#linearGradient2269"
+       id="radialGradient3049"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.1991353,0,0,0.18727682,9.60253,47.497421)"
+       cx="25.1875"
+       cy="41.625"
+       fx="25.1875"
+       fy="41.625"
+       r="18.0625" />
+    <linearGradient
+       gradientTransform="translate(2,2)"
+       gradientUnits="userSpaceOnUse"
+       y2="33.097897"
+       x2="21.638357"
+       y1="38.57375"
+       x1="19.728148"
+       id="linearGradient5550"
+       xlink:href="#linearGradient3276" />
+    <linearGradient
+       gradientTransform="translate(2,2)"
+       gradientUnits="userSpaceOnUse"
+       y2="31.730888"
+       x2="16.813908"
+       y1="38.213882"
+       x1="19.145359"
+       id="linearGradient5558"
+       xlink:href="#linearGradient3270" />
+    <linearGradient
+       gradientTransform="translate(2,2)"
+       gradientUnits="userSpaceOnUse"
+       y2="39.196541"
+       x2="26.189007"
+       y1="38.502609"
+       x1="19.881519"
+       id="linearGradient5566"
+       xlink:href="#linearGradient5646" />
+    <linearGradient
+       gradientTransform="translate(2,2)"
+       gradientUnits="userSpaceOnUse"
+       y2="36.145401"
+       x2="31.672956"
+       y1="38.921127"
+       x1="29.10784"
+       id="linearGradient5574"
+       xlink:href="#linearGradient3294" />
+    <linearGradient
+       gradientTransform="translate(2,2)"
+       gradientUnits="userSpaceOnUse"
+       y2="39.562164"
+       x2="34.239601"
+       y1="41.789768"
+       x1="32.311722"
+       id="linearGradient5588"
+       xlink:href="#linearGradient3288" />
+    <linearGradient
+       gradientTransform="translate(2,2)"
+       gradientUnits="userSpaceOnUse"
+       y2="42.322491"
+       x2="36.356281"
+       y1="44.436687"
+       x1="34.10231"
+       id="linearGradient5596"
+       xlink:href="#linearGradient3282" />
+    <linearGradient
+       gradientTransform="translate(2,2)"
+       gradientUnits="userSpaceOnUse"
+       y2="32.980549"
+       x2="31.261166"
+       y1="34.843632"
+       x1="27.345615"
+       id="linearGradient5604"
+       xlink:href="#linearGradient5576" />
+    <linearGradient
+       gradientTransform="translate(2,2)"
+       gradientUnits="userSpaceOnUse"
+       y2="33.275246"
+       x2="34.970161"
+       y1="35.084328"
+       x1="31.979929"
+       id="linearGradient5612"
+       xlink:href="#linearGradient5606" />
+    <linearGradient
+       gradientTransform="translate(2,2)"
+       gradientUnits="userSpaceOnUse"
+       y2="35.175659"
+       x2="36.115841"
+       y1="37.152149"
+       x1="33.611019"
+       id="linearGradient5620"
+       xlink:href="#linearGradient3330" />
+    <linearGradient
+       gradientTransform="translate(2,2)"
+       gradientUnits="userSpaceOnUse"
+       y2="39.22818"
+       x2="29.432671"
+       y1="40.265026"
+       x1="27.153559"
+       id="linearGradient5658"
+       xlink:href="#linearGradient5652" />
+    <linearGradient
+       gradientTransform="translate(2,2)"
+       gradientUnits="userSpaceOnUse"
+       y2="28.801535"
+       x2="20.5632"
+       y1="31.54216"
+       x1="19.64187"
+       id="linearGradient5666"
+       xlink:href="#linearGradient3300" />
+    <linearGradient
+       gradientTransform="translate(2,2)"
+       gradientUnits="userSpaceOnUse"
+       y2="28.666885"
+       x2="15.030108"
+       y1="30.556971"
+       x1="17.048548"
+       id="linearGradient5674"
+       xlink:href="#linearGradient3312" />
+    <linearGradient
+       gradientTransform="translate(2,2)"
+       gradientUnits="userSpaceOnUse"
+       y2="30.274158"
+       x2="14.456498"
+       y1="32.223648"
+       x1="15.841824"
+       id="linearGradient5688"
+       xlink:href="#linearGradient3318" />
+    <linearGradient
+       gradientTransform="translate(2,2)"
+       gradientUnits="userSpaceOnUse"
+       y2="27.200634"
+       x2="17.149237"
+       y1="30.243673"
+       x1="17.666838"
+       id="linearGradient5696"
+       xlink:href="#linearGradient3306" />
+    <linearGradient
+       gradientTransform="translate(2,2)"
+       gradientUnits="userSpaceOnUse"
+       y2="29.058939"
+       x2="24.214138"
+       y1="33.487141"
+       x1="24.720701"
+       id="linearGradient5704"
+       xlink:href="#linearGradient5676" />
+    <linearGradient
+       gradientTransform="translate(2,2)"
+       gradientUnits="userSpaceOnUse"
+       y2="30.132702"
+       x2="28.001352"
+       y1="33.891273"
+       x1="24.752634"
+       id="linearGradient5712"
+       xlink:href="#linearGradient3324" />
+    <linearGradient
+       gradientTransform="translate(2,2)"
+       gradientUnits="userSpaceOnUse"
+       y2="42.779541"
+       x2="40.381905"
+       y1="45.2005"
+       x1="37.336205"
+       id="linearGradient5720"
+       xlink:href="#linearGradient5722" />
+    <linearGradient
+       gradientTransform="translate(68,2)"
+       gradientUnits="userSpaceOnUse"
+       y2="14"
+       x2="-52"
+       y1="30"
+       x1="-46"
+       id="linearGradient4120"
+       xlink:href="#linearGradient4114" />
+    <radialGradient
+       r="12.458333"
+       fy="41.446495"
+       fx="43.783218"
+       cy="41.446495"
+       cx="43.783218"
+       gradientTransform="matrix(1.0434787,1.0434783,-1.6856187,1.6856188,40.630437,-98.746773)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3163-3"
+       xlink:href="#linearGradient3857" />
+    <linearGradient
+       id="linearGradient3857">
+      <stop
+         id="stop3859"
+         offset="0"
+         style="stop-color:#34e0e2;stop-opacity:1" />
+      <stop
+         id="stop3861"
+         offset="1"
+         style="stop-color:#06989a;stop-opacity:1" />
+    </linearGradient>
+    <radialGradient
+       r="15.644737"
+       fy="36.421127"
+       fx="24.837126"
+       cy="36.421127"
+       cx="24.837126"
+       gradientTransform="matrix(0.98996505,0,0,0.35413451,-47.950702,-44.576876)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient1503-3"
+       xlink:href="#linearGradient2269" />
+    <linearGradient
+       xlink:href="#linearGradient3330"
+       id="linearGradient5620-1"
+       x1="33.611019"
+       y1="37.152149"
+       x2="36.115841"
+       y2="35.175659"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3636363,0,0,1.3636363,-92.776126,1.2727273)" />
+    <linearGradient
+       xlink:href="#linearGradient3330"
+       id="linearGradient5612-5"
+       x1="31.979929"
+       y1="35.084328"
+       x2="34.970161"
+       y2="33.275246"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3636363,0,0,1.3636363,-92.776126,1.2727273)" />
+    <linearGradient
+       xlink:href="#linearGradient3294"
+       id="linearGradient5604-4"
+       x1="27.345615"
+       y1="34.843632"
+       x2="31.261166"
+       y2="32.980549"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3636363,0,0,1.3636363,-92.776126,1.2727273)" />
+    <linearGradient
+       xlink:href="#linearGradient3294"
+       id="linearGradient5574-9"
+       x1="29.10784"
+       y1="38.921127"
+       x2="31.672956"
+       y2="36.145401"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3636363,0,0,1.3636363,-92.776126,1.2727273)" />
+    <linearGradient
+       xlink:href="#linearGradient3294"
+       id="linearGradient5588-3"
+       x1="32.311722"
+       y1="41.789768"
+       x2="34.239601"
+       y2="39.562164"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3636363,0,0,1.3636363,-92.776126,1.2727273)" />
+    <linearGradient
+       xlink:href="#linearGradient3324"
+       id="linearGradient5658-9"
+       x1="27.153559"
+       y1="40.265026"
+       x2="29.432671"
+       y2="39.22818"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3636363,0,0,1.3636363,-92.776126,1.2727273)" />
+    <linearGradient
+       xlink:href="#linearGradient3294"
+       id="linearGradient5596-2"
+       x1="34.10231"
+       y1="44.436687"
+       x2="36.356281"
+       y2="42.322491"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3636363,0,0,1.3636363,-92.776126,1.2727273)" />
+    <linearGradient
+       xlink:href="#linearGradient5722"
+       id="linearGradient5720-0"
+       x1="37.336205"
+       y1="45.2005"
+       x2="40.381905"
+       y2="42.779541"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3636363,0,0,1.3636363,-92.776126,1.2727273)" />
+    <linearGradient
+       xlink:href="#linearGradient3276"
+       id="linearGradient5566-1"
+       x1="19.881519"
+       y1="38.502609"
+       x2="26.189007"
+       y2="39.196541"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3636363,0,0,1.3636363,-92.776126,1.2727273)" />
+    <linearGradient
+       xlink:href="#linearGradient3276"
+       id="linearGradient5550-7"
+       x1="19.728148"
+       y1="38.57375"
+       x2="21.638357"
+       y2="33.097897"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3636363,0,0,1.3636363,-92.776126,1.2727273)" />
+    <linearGradient
+       xlink:href="#linearGradient3276"
+       id="linearGradient5558-4"
+       x1="19.145359"
+       y1="38.213882"
+       x2="16.813908"
+       y2="31.730888"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3636363,0,0,1.3636363,-92.776126,1.2727273)" />
+    <linearGradient
+       xlink:href="#linearGradient3324"
+       id="linearGradient5688-9"
+       x1="15.841824"
+       y1="32.223648"
+       x2="14.456498"
+       y2="30.274158"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3636363,0,0,1.3636363,-92.776126,1.2727273)" />
+    <linearGradient
+       xlink:href="#linearGradient3324"
+       id="linearGradient5674-6"
+       x1="17.048548"
+       y1="30.556971"
+       x2="15.030108"
+       y2="28.666885"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3636363,0,0,1.3636363,-92.776126,1.2727273)" />
+    <linearGradient
+       xlink:href="#linearGradient3324"
+       id="linearGradient5696-4"
+       x1="17.666838"
+       y1="30.243673"
+       x2="17.149237"
+       y2="27.200634"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3636363,0,0,1.3636363,-92.776126,1.2727273)" />
+    <linearGradient
+       xlink:href="#linearGradient3324"
+       id="linearGradient5666-7"
+       x1="19.64187"
+       y1="31.54216"
+       x2="20.5632"
+       y2="28.801535"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3636363,0,0,1.3636363,-92.776126,1.2727273)" />
+    <linearGradient
+       xlink:href="#linearGradient3324"
+       id="linearGradient5704-2"
+       x1="24.720701"
+       y1="33.487141"
+       x2="24.214138"
+       y2="29.058939"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3636363,0,0,1.3636363,-92.776126,1.2727273)" />
+    <linearGradient
+       xlink:href="#linearGradient3324"
+       id="linearGradient5712-0"
+       x1="24.752634"
+       y1="33.891273"
+       x2="28.001352"
+       y2="30.132702"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3636363,0,0,1.3636363,-92.776126,1.2727273)" />
+  </defs>
+  <metadata
+     id="metadata2821">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>Mesh_Evaluate_Solid</dc:title>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>[bitacovir]</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:title>FemWorkbench</dc:title>
+        <dc:date>21-06-2020</dc:date>
+        <dc:relation />
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>FreeCAD</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:identifier />
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>FreeCAD LGPL2+</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <cc:license>https://www.gnu.org/copyleft/lesser.html</cc:license>
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title>Based on a triplus' design</dc:title>
+          </cc:Agent>
+        </dc:contributor>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer4"
+     style="display:inline" />
+  <g
+     id="layer5"
+     style="display:inline" />
+  <path
+     style="fill:#0000ff;fill-opacity:1;stroke:#0000ff;stroke-width:0.097569;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d=""
+     id="path5141" />
+  <path
+     style="fill:#0000ff;fill-opacity:1;stroke:#0000ff;stroke-width:0.097569;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d=""
+     id="path5143" />
+  <g
+     id="g1074">
+    <g
+       transform="matrix(-1,0,0,1,-18.048856,-9.9999995)"
+       id="g1622">
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#8ae234;fill-opacity:1;fill-rule:nonzero;stroke:#555753;stroke-width:0.681818;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
+         d="m -50.503401,40.81818 12.272727,-1.363636 -4.090909,6.818181 z"
+         id="path4836-7" />
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#8ae234;fill-opacity:1;fill-rule:nonzero;stroke:#555753;stroke-width:0.681818;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
+         d="m -38.230674,39.454544 12.272726,-1.363637 -16.363635,8.181818 z"
+         id="path4838-9" />
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#8ae234;fill-opacity:1;fill-rule:nonzero;stroke:#555753;stroke-width:0.681818;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
+         d="m -38.230674,39.454544 4.090908,-6.818182 8.181818,5.454545 z"
+         id="path4840-6" />
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#8ae234;fill-opacity:1;fill-rule:nonzero;stroke:#555753;stroke-width:0.681818;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
+         d="m -34.139766,32.636362 -4.090908,6.818182 -12.272727,1.363636 z"
+         id="path4842-8" />
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#4e9a06;fill-opacity:1;fill-rule:nonzero;stroke:#505050;stroke-width:0.681818;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
+         d="m -42.321583,46.272725 16.363635,-8.181818 -8.181818,16.363636 z"
+         id="path4844-9" />
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#4e9a06;fill-opacity:1;fill-rule:nonzero;stroke:#505050;stroke-width:0.681818;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
+         d="m -42.553715,51.679123 0.232132,-5.406398 8.172299,8.111302 z"
+         id="path4846-1" />
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#4e9a06;fill-opacity:1;fill-rule:nonzero;stroke:#505050;stroke-width:0.681818;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
+         d="m -49.139765,50.363634 6.818182,-4.090909 v 12.272727 z"
+         id="path4848-8" />
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#4e9a06;fill-opacity:1;fill-rule:nonzero;stroke:#505050;stroke-width:0.681818;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
+         d="m -50.503401,40.81818 8.181818,5.454545 -6.818182,4.090909 z"
+         id="path4850-5" />
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#4e9a06;fill-opacity:1;fill-rule:nonzero;stroke:#505050;stroke-width:0.681818;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
+         d="m -58.685219,48.999998 8.181818,-8.181818 1.363636,9.545454 z"
+         id="path4852-1" />
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#4e9a06;fill-opacity:1;fill-rule:nonzero;stroke:#505050;stroke-width:0.681818;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
+         d="m -58.685219,48.999998 9.545454,1.363636 1.363637,9.545454 z"
+         id="path4854-3" />
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#4e9a06;fill-opacity:1;fill-rule:nonzero;stroke:#505050;stroke-width:0.681818;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
+         d="m -49.139765,50.363634 6.818182,8.181818 -5.454545,1.363636 z"
+         id="path4856-7" />
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#4e9a06;fill-opacity:1;fill-rule:nonzero;stroke:#505050;stroke-width:0.681818;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
+         d="m -58.685219,48.999998 10.909091,10.90909 -6.818182,1.363637 z"
+         id="path4858-4" />
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#4e9a06;fill-opacity:1;fill-rule:nonzero;stroke:#505050;stroke-width:0.681818;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
+         d="m -54.59431,61.272725 6.818182,-1.363637 5.454545,8.181818 z"
+         id="path4860-3" />
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#4e9a06;fill-opacity:1;fill-rule:nonzero;stroke:#505050;stroke-width:0.681818;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
+         d="m -47.776128,59.909088 5.454545,-1.363636 v 9.545454 z"
+         id="path4862-4" />
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#4e9a06;fill-opacity:1;fill-rule:nonzero;stroke:#505050;stroke-width:0.681818;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
+         d="m -42.321583,51.72727 8.181817,2.727273 -8.181817,4.090909 z"
+         id="path4864-2" />
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#4e9a06;fill-opacity:1;fill-rule:nonzero;stroke:#505050;stroke-width:0.681818;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
+         d="m -42.321583,58.545452 16.363635,-8.181818 v 9.545454 l -16.363635,8.181818 z"
+         id="path4866-6" />
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#4e9a06;fill-opacity:1;fill-rule:nonzero;stroke:#505050;stroke-width:0.681818;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
+         d="m -25.957948,38.090907 v 12.272727 l -8.181818,4.090909 z"
+         id="path4868-3" />
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#4e9a06;fill-opacity:1;fill-rule:nonzero;stroke:#505050;stroke-width:0.681818;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
+         d="m -65.5034,54.454543 6.818181,-5.454545 4.090909,12.272727 z"
+         id="path4870-4" />
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#4e9a06;fill-opacity:1;fill-rule:nonzero;stroke:#505050;stroke-width:0.681818;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
+         d="m -68.230673,43.545453 9.545454,5.454545 -6.818181,5.454545 z"
+         id="path4872-7" />
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#4e9a06;fill-opacity:1;fill-rule:nonzero;stroke:#505050;stroke-width:0.681818;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
+         d="m -75.048855,48.999998 6.818182,-5.454545 2.727273,10.90909 z"
+         id="path4874-2" />
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#4e9a06;fill-opacity:1;fill-rule:nonzero;stroke:#505050;stroke-width:0.681818;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
+         d="m -75.048855,40.81818 6.818182,2.727273 -6.818182,5.454545 z"
+         id="path4876-4" />
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#4e9a06;fill-opacity:1;fill-rule:nonzero;stroke:#505050;stroke-width:0.681818;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
+         d="M -75.048855,40.81818 V 27.181817 l 6.818182,16.363636 z"
+         id="path4878-4" />
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#4e9a06;fill-opacity:1;fill-rule:nonzero;stroke:#505050;stroke-width:0.681818;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
+         d="m -75.048855,27.181817 8.181818,5.454545 -1.363636,10.909091 z"
+         id="path4880-8" />
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#4e9a06;fill-opacity:1;fill-rule:nonzero;stroke:#505050;stroke-width:0.681818;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
+         d="m -68.230673,43.545453 1.363636,-10.909091 8.181818,16.363636 v 0 z"
+         id="path4882-9" />
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#73d216;fill-opacity:1;fill-rule:nonzero;stroke:#555753;stroke-width:0.681818;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
+         d="m -66.867037,32.636362 10.909091,5.454545 -2.727273,10.909091 z"
+         id="path4884-8" />
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#73d216;fill-opacity:1;fill-rule:nonzero;stroke:#555753;stroke-width:0.681818;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
+         d="m -58.361914,47.55767 2.403968,-9.466763 5.454545,2.727273 z"
+         id="path4886-3" />
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#73d216;fill-opacity:1;fill-rule:nonzero;stroke:#555753;stroke-width:0.681818;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
+         d="m -55.957946,38.090907 5.454545,-4.090908 0.32415,7.613842 z"
+         id="path4888-6" />
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#73d216;fill-opacity:1;fill-rule:nonzero;stroke:#555753;stroke-width:0.681818;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
+         d="m -50.503401,33.999999 8.181818,2.727272 -7.93485,5.077623 z"
+         id="path4890-2" />
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#73d216;fill-opacity:1;fill-rule:nonzero;stroke:#555753;stroke-width:0.681818;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
+         d="m -50.503401,33.999999 v -9.545455 l 8.181818,12.272727 z"
+         id="path4892-0" />
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#73d216;fill-opacity:1;fill-rule:nonzero;stroke:#555753;stroke-width:0.681818;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
+         d="m -58.685219,28.545453 8.181818,-4.090909 v 9.545455 z"
+         id="path4894-7" />
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#73d216;fill-opacity:1;fill-rule:nonzero;stroke:#555753;stroke-width:0.681818;marker:none;enable-background:accumulate"
+         d="m -58.685219,28.545453 8.181818,5.454546 -5.454545,4.090908 z"
+         id="path4896-5" />
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#73d216;fill-opacity:1;fill-rule:nonzero;stroke:#555753;stroke-width:0.681818;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
+         d="m -66.867037,32.636362 8.181818,-4.090909 2.727273,9.545454 z"
+         id="path4898-9" />
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#8ae234;fill-opacity:1;fill-rule:nonzero;stroke:#555753;stroke-width:0.681818;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
+         d="m -62.776128,25.818181 12.272727,-1.363637 -8.181818,4.090909 z"
+         id="path4900-1" />
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#8ae234;fill-opacity:1;fill-rule:nonzero;stroke:#555753;stroke-width:0.681818;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
+         d="m -58.685219,18.999999 8.181818,5.454545 -12.272727,1.363637 z"
+         id="path4902-7" />
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#8ae234;fill-opacity:1;fill-rule:nonzero;stroke:#555753;stroke-width:0.681818;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
+         d="m -58.685219,18.999999 -4.090909,6.818182 -12.272727,1.363636 z"
+         id="path4904-3" />
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#8ae234;fill-opacity:1;fill-rule:nonzero;stroke:#555753;stroke-width:0.681818;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
+         d="m -66.867037,32.636362 4.090909,-6.818181 4.090909,2.727272 z"
+         id="path4906-9" />
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#8ae234;fill-opacity:1;fill-rule:nonzero;stroke:#555753;stroke-width:0.681818;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
+         d="m -75.048855,27.181817 12.272727,-1.363636 -4.090909,6.818181 z"
+         id="path4908-8" />
+    </g>
+    <path
+       style="fill:none;stroke:#505050;stroke-width:0.7;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none"
+       d="M 24,48 8,50"
+       id="path998" />
+    <path
+       id="path998-5"
+       d="M 24,58 8,41"
+       style="fill:none;stroke:#505050;stroke-width:0.7;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <g
+       transform="matrix(-1.3636363,0,0,1.3636363,77.454544,-11.454545)"
+       style="display:inline;stroke-width:1.46667;stroke-miterlimit:4;stroke-dasharray:none"
+       id="layer7">
+      <path
+         id="path3100"
+         d="M 15,21 V 37"
+         style="display:inline;fill:none;stroke:#2e3436;stroke-width:1.46667;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         id="path3108"
+         d="m 45,25 -12,6 6,4 12,-6 z m 6,4 V 42.530433 45 Z"
+         style="display:inline;fill:none;stroke:#2e3436;stroke-width:1.46667;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         id="path3114"
+         d="M 39,51 51,45"
+         style="display:inline;fill:none;stroke:#2e3436;stroke-width:1.46667;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         id="path3120"
+         d="M 39,51 15,37"
+         style="display:inline;fill:none;stroke:#2e3436;stroke-width:1.46667;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         id="path3122"
+         d="m 15,21 6,4"
+         style="display:inline;fill:none;stroke:#2e3436;stroke-width:1.46667;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         id="path3134"
+         d="M 15,21 27,15"
+         style="display:inline;fill:none;stroke:#2e3436;stroke-width:1.46667;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         id="path3136"
+         d="M 33,19 27,15"
+         style="display:inline;fill:none;stroke:#2e3436;stroke-width:1.46667;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         id="path3116"
+         d="m 21,25 6,12"
+         style="display:inline;fill:none;stroke:#2e3436;stroke-width:1.46667;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         id="path3118"
+         d="m 33,31 -6,6"
+         style="display:inline;fill:none;stroke:#2e3436;stroke-width:1.46667;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         id="path3126"
+         d="M 39,51 V 35"
+         style="display:inline;fill:none;stroke:#2e3436;stroke-width:1.46667;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         id="path3130"
+         d="M 33,19 21,25"
+         style="display:inline;fill:none;stroke:#2e3436;stroke-width:1.46667;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         id="path3106"
+         d="m 33,19 6,9"
+         style="display:inline;fill:none;stroke:#2e3436;stroke-width:1.46667;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <ellipse
+       ry="20.999998"
+       rx="21"
+       cy="23.803055"
+       cx="23.454304"
+       id="path3055-5"
+       style="opacity:0.205;fill:url(#radialGradient3163-3);fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:2.04;stroke-opacity:1" />
+    <path
+       id="rect3057"
+       d="m 32.13132,39.304207 7.172892,-7.172891 21.518673,21.518702 -7.172891,7.172868 z"
+       style="fill:#babdb6;fill-opacity:1;stroke:#042a2a;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:2.04;stroke-opacity:1" />
+    <path
+       id="path3865"
+       d="M 58.680934,54.332829 40.748706,36.40061"
+       style="fill:none;stroke:#eeeeec;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       style="fill:#eeeeec;fill-opacity:1;stroke:#042a2a;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:2.04;stroke-opacity:1"
+       d="M 24,3 A 21,20.999998 0 0 0 3,24 21,20.999998 0 0 0 24,45 21,20.999998 0 0 0 45,24 21,20.999998 0 0 0 24,3 Z m -0.01563,5.255859 a 16,16 0 0 1 16,16 16,16 0 0 1 -16,16 16,16 0 0 1 -16,-16 16,16 0 0 1 16,-16 z"
+       id="path3055" />
+    <circle
+       r="19"
+       cy="23.999367"
+       cx="23.999359"
+       id="path3055-1"
+       style="fill:none;stroke:#babdb6;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:2.04;stroke-opacity:1" />
+    <ellipse
+       ry="5.5403438"
+       rx="15.487742"
+       cy="-31.678894"
+       cx="-23.362816"
+       transform="scale(-1)"
+       id="path8660"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.255;fill:url(#radialGradient1503-3);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none" />
+  </g>
+</svg>

--- a/src/Mod/Mesh/Gui/Resources/icons/Mesh_Evaluation.svg
+++ b/src/Mod/Mesh/Gui/Resources/icons/Mesh_Evaluation.svg
@@ -1,0 +1,274 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   version="1.1"
+   id="svg3052"
+   height="64px"
+   width="64px">
+  <title
+     id="title3725">Mesh_Evaluation</title>
+  <defs
+     id="defs3054">
+    <radialGradient
+       fx="25.1875"
+       fy="41.625"
+       xlink:href="#linearGradient2269-0"
+       gradientUnits="userSpaceOnUse"
+       cy="41.625"
+       cx="25.1875"
+       gradientTransform="matrix(1,0,0,0.32526,0,28.08607)"
+       r="18.0625"
+       id="radialGradient2275-5" />
+    <linearGradient
+       id="linearGradient2269-0">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         id="stop2271-4"
+         offset="0" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         id="stop2273-87"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#linearGradient2269-0"
+       id="radialGradient3169"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.32526,0,28.08607)"
+       cx="25.1875"
+       cy="41.625"
+       fx="25.1875"
+       fy="41.625"
+       r="18.0625" />
+    <linearGradient
+       xlink:href="#linearGradient3049"
+       id="linearGradient3055"
+       x1="19.648342"
+       y1="42.253601"
+       x2="20.631224"
+       y2="6.7758031"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.18527593,0.94946283,0.85850506,0.20490577,146.5709,139.94717)" />
+    <linearGradient
+       id="linearGradient3049">
+      <stop
+         style="stop-color:#b6b6b6;stop-opacity:1;"
+         offset="0"
+         id="stop3051" />
+      <stop
+         id="stop2262"
+         offset="0.5"
+         style="stop-color:#f2f2f2;stop-opacity:1;" />
+      <stop
+         style="stop-color:#fafafa;stop-opacity:1;"
+         offset="0.67612958"
+         id="stop2264" />
+      <stop
+         id="stop2268"
+         offset="0.84051722"
+         style="stop-color:#d8d8d8;stop-opacity:1;" />
+      <stop
+         id="stop2266"
+         offset="0.875"
+         style="stop-color:#f2f2f2;stop-opacity:1;" />
+      <stop
+         style="stop-color:#dbdbdb;stop-opacity:1;"
+         offset="1"
+         id="stop3053" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3061"
+       id="linearGradient3067"
+       x1="50.152931"
+       y1="-3.6324477"
+       x2="25.291086"
+       y2="-4.3002653"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.94385939,0,0,0.9077189,200.39852,53.93624)" />
+    <linearGradient
+       id="linearGradient3061">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop3063" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="1"
+         id="stop3065" />
+    </linearGradient>
+  </defs>
+  <metadata
+     id="metadata3057">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>Mesh_Evaluation</dc:title>
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title>Based on a wmayer's design</dc:title>
+          </cc:Agent>
+        </dc:contributor>
+        <cc:license
+           rdf:resource="https://www.gnu.org/copyleft/lesser.html" />
+        <dc:date>17-06-2020</dc:date>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>[bitacovir]</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>FreeCAD LGPL2+</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>FreeCAD</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:identifier />
+        <dc:relation />
+        <dc:subject>
+          <rdf:Bag>
+            <rdf:li>mesh</rdf:li>
+            <rdf:li>plane</rdf:li>
+            <rdf:li>tool</rdf:li>
+          </rdf:Bag>
+        </dc:subject>
+        <dc:description>Folded plane, lit from top, with spanner</dc:description>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1">
+    <g
+       transform="matrix(-0.2109556,0.9774957,0.8838524,0.1907462,-82.022362,-158.02055)"
+       id="g3884">
+      <g
+         id="g1636">
+        <ellipse
+           id="path2267"
+           transform="matrix(-0.34490802,1.7675115,1.0422728,0.24876696,148.23989,117.79495)"
+           style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.267045;fill:url(#radialGradient3169);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none"
+           cx="25.1875"
+           cy="41.625"
+           rx="18.0625"
+           ry="5.875" />
+        <path
+           style="fill:#8ae234;stroke:#172a04;stroke-width:2.10328;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+           d="m 139.57372,149.87368 12.30643,-10.63966 33.65676,5.77029 -14.68333,12.33517 z"
+           id="path2993" />
+        <path
+           style="fill:#73d216;stroke:none"
+           d="m 139.57372,149.87368 1.37852,13.90595 29.32487,6.99918 0.57647,-13.43933 z"
+           id="path2995" />
+        <path
+           style="fill:#4e9a06;stroke:none"
+           d="m 140.95224,163.77963 13.53037,14.5435 27.36988,6.53257 -11.57538,-14.07689 z"
+           id="path2997" />
+        <path
+           style="fill:#73d216;stroke:#172a04;stroke-width:2.10328;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+           d="m 181.85249,184.8557 -11.19525,15.43052 -24.99298,-8.22808 8.81835,-13.73501 z"
+           id="path2999" />
+        <path
+           style="fill:#4e9a06;stroke:none"
+           d="m 170.65724,200.28622 -9.6204,-13.61028 -26.94796,-8.69469 11.57538,14.07689 z"
+           id="path3001" />
+        <path
+           style="fill:none;stroke:#8ae234;stroke-width:2.10328;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="m 141.52871,150.34029 1.37852,13.90595"
+           id="path3771" />
+        <path
+           style="fill:none;stroke:#8ae234;stroke-width:2.10328;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="m 141.37415,161.61751 28.34737,6.76588"
+           id="path3773" />
+        <path
+           style="fill:none;stroke:#8ae234;stroke-width:2.10328;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="m 168.32212,170.3122 0.57647,-13.43933"
+           id="path3775" />
+        <path
+           style="fill:none;stroke:#8ae234;stroke-width:2.10328;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="m 170.43167,159.5016 -30.30236,-7.23249"
+           id="path3777" />
+        <path
+           style="fill:none;stroke:#172a04;stroke-width:2.10328;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+           d="m 139.57372,149.87369 1.37852,13.90594 29.32486,6.99919 0.57648,-13.43934 z"
+           id="path2995-3" />
+        <path
+           style="fill:none;stroke:#73d216;stroke-width:2.10328;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="m 147.3728,167.57489 24.43739,5.83266"
+           id="path3797" />
+        <path
+           style="fill:none;stroke:#73d216;stroke-width:2.10328;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="M 178.92,184.15578 167.34462,170.0789"
+           id="path3799" />
+        <path
+           style="fill:none;stroke:#73d216;stroke-width:2.10328;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="m 176.40943,181.29374 -23.4599,-5.59934"
+           id="path3801" />
+        <path
+           style="fill:none;stroke:#73d216;stroke-width:2.10328;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="M 157.4151,179.02305 144.56558,164.56491"
+           id="path3803" />
+        <path
+           style="fill:none;stroke:#172a04;stroke-width:2.10328;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+           d="m 140.95224,163.77963 13.53037,14.5435 27.36988,6.53257 -11.57538,-14.07689 z"
+           id="path2997-6" />
+        <path
+           style="fill:none;stroke:#73d216;stroke-width:2.10328;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="m 136.59945,180.84329 25.97047,8.46138"
+           id="path3823" />
+        <path
+           style="fill:none;stroke:#73d216;stroke-width:2.10328;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="m 158.51905,186.56593 8.60928,12.35073"
+           id="path3825" />
+        <path
+           style="fill:none;stroke:#73d216;stroke-width:2.10328;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="m 168.14666,197.42418 -24.01548,-7.99477"
+           id="path3827" />
+        <path
+           style="fill:none;stroke:#73d216;stroke-width:2.10328;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="M 148.74858,192.57573 137.62751,178.85155"
+           id="path3829" />
+        <path
+           style="fill:none;stroke:#172a04;stroke-width:2.10328;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+           d="m 170.65724,200.28622 -9.62039,-13.61027 -26.94797,-8.69469 11.57538,14.07688 z"
+           id="path3001-7" />
+      </g>
+      <path
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3055);fill-opacity:1;fill-rule:nonzero;stroke:#2e3436;stroke-width:1.57746;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none"
+         d="m 159.21092,160.35352 14.98783,25.06568 c 0.69639,1.03568 0.84622,3.82646 -1.01902,5.22204 -1.80121,1.34768 -3.79608,0.46028 -4.97424,-1.55987 l -15.25726,-24.2605 c -6.58399,0.97422 -10.75476,-5.17357 -8.41571,-11.26233 l 1.39312,-1.09591 2.81491,5.14343 3.17308,1.00576 3.25548,-2.5616 0.3645,-3.90281 -2.56244,-4.71054 c 0,0 1.4946,-1.0803 1.4946,-1.0803 5.63899,0.6775 9.32312,8.23043 4.74515,13.99695 z"
+         id="path2140" />
+      <path
+         id="path3057"
+         d="m 157.91961,160.28367 15.52595,25.43204 c 0.53909,0.80175 0.65508,2.96217 -0.78885,4.04253 -1.39437,1.04328 -2.93866,0.35631 -3.8507,-1.20754 l -15.2787,-24.56819 c -6.67016,0.1051 -9.38737,-4.34361 -8.21041,-9.71975 l 0.32421,-0.22824 2.40338,4.65001 4.06023,1.11636 3.98663,-3.13731 0.44704,-4.69309 -2.25404,-4.13201 0.49477,-0.28088 c 5.90035,1.05471 7.11985,9.04415 3.14049,12.72607 z"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.426136;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:1.05164;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none" />
+      <rect
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.170455;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3067);stroke-width:1.0539;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none"
+         id="rect3059"
+         width="25.005957"
+         height="2.124413"
+         x="224.96252"
+         y="49.524414"
+         rx="0.94988912"
+         ry="0.91351777"
+         transform="matrix(0.51439253,0.85755485,0.8062741,-0.59154211,0,0)" />
+      <ellipse
+         ry="1.2136019"
+         rx="1.3301352"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#2e3436;stroke-width:1.05209;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none"
+         id="path2146"
+         transform="matrix(-0.19152519,0.9814877,0.97267847,0.23215639,0,0)"
+         cx="142.57228"
+         cy="204.01714" />
+    </g>
+  </g>
+</svg>

--- a/src/Mod/Mesh/Gui/Resources/icons/Mesh_Intersection.svg
+++ b/src/Mod/Mesh/Gui/Resources/icons/Mesh_Intersection.svg
@@ -1,0 +1,229 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   version="1.1"
+   id="svg2568"
+   height="64px"
+   width="64px">
+  <title
+     id="title865">Mesh_Intersection</title>
+  <defs
+     id="defs2570">
+    <linearGradient
+       id="linearGradient3864">
+      <stop
+         style="stop-color:#71b2f8;stop-opacity:1;"
+         offset="0"
+         id="stop3866" />
+      <stop
+         style="stop-color:#002795;stop-opacity:1;"
+         offset="1"
+         id="stop3868" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3593">
+      <stop
+         id="stop3595"
+         offset="0"
+         style="stop-color:#c8e0f9;stop-opacity:1;" />
+      <stop
+         id="stop3597"
+         offset="1"
+         style="stop-color:#637dca;stop-opacity:1;" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(-0.51094884,-0.61313857,0.25133659,-0.20944716,57.452467,81.167084)"
+       xlink:href="#linearGradient3143"
+       id="radialGradient3090"
+       gradientUnits="userSpaceOnUse"
+       cx="56.831726"
+       cy="30.181183"
+       fx="56.831726"
+       fy="30.181183"
+       r="19.571428" />
+    <linearGradient
+       id="linearGradient3143">
+      <stop
+         id="stop3145"
+         offset="0"
+         style="stop-color:#4e9a06;stop-opacity:1" />
+      <stop
+         id="stop3147"
+         offset="1"
+         style="stop-color:#8ae234;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3143-7">
+      <stop
+         id="stop3145-0"
+         offset="0"
+         style="stop-color:#729fcf;stop-opacity:1" />
+      <stop
+         id="stop3147-9"
+         offset="1"
+         style="stop-color:#204a87;stop-opacity:1" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(1.1486088,1.8477617,-3.056673,1.900094,73.257745,-112.1016)"
+       xlink:href="#linearGradient3143-6"
+       id="radialGradient3090-3"
+       gradientUnits="userSpaceOnUse"
+       cx="46.534134"
+       cy="26.281744"
+       fx="46.534134"
+       fy="26.281744"
+       r="19.571428" />
+    <linearGradient
+       id="linearGradient3143-6">
+      <stop
+         id="stop3145-7"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1" />
+      <stop
+         id="stop3147-5"
+         offset="1"
+         style="stop-color:#d3d7cf;stop-opacity:1" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#linearGradient3143-6"
+       id="radialGradient3017"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.1486088,1.8477617,-3.056673,1.900094,73.257745,-112.1016)"
+       cx="46.534134"
+       cy="26.281744"
+       fx="46.534134"
+       fy="26.281744"
+       r="19.571428" />
+    <radialGradient
+       gradientTransform="matrix(1.1486088,1.8477617,-3.056673,1.900094,73.257745,-112.1016)"
+       xlink:href="#linearGradient3143-62"
+       id="radialGradient3090-5"
+       gradientUnits="userSpaceOnUse"
+       cx="46.534134"
+       cy="26.281744"
+       fx="46.534134"
+       fy="26.281744"
+       r="19.571428" />
+    <linearGradient
+       id="linearGradient3143-62">
+      <stop
+         id="stop3145-9"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1" />
+      <stop
+         id="stop3147-1"
+         offset="1"
+         style="stop-color:#d3d7cf;stop-opacity:1" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#linearGradient3143-62"
+       id="radialGradient3017-2"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.1486088,1.8477617,-3.056673,1.900094,73.257745,-112.1016)"
+       cx="46.534134"
+       cy="26.281744"
+       fx="46.534134"
+       fy="26.281744"
+       r="19.571428" />
+  </defs>
+  <metadata
+     id="metadata2573">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>Mesh_Intersection</dc:title>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>[bitacovir]</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:title>Part_Common</dc:title>
+        <dc:date>04-07-2020</dc:date>
+        <dc:relation />
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>FreeCAD</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:identifier />
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>FreeCAD LGPL2+</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <cc:license>https://www.gnu.org/copyleft/lesser.html</cc:license>
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title>Based on a wmayer's work</dc:title>
+          </cc:Agent>
+        </dc:contributor>
+        <dc:subject>
+          <rdf:Bag>
+            <rdf:li>sphere</rdf:li>
+            <rdf:li>mesh</rdf:li>
+          </rdf:Bag>
+        </dc:subject>
+        <dc:description>Intersection of two spheres</dc:description>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1">
+    <g
+       transform="matrix(0.91273618,0,0,0.90349515,105.85374,2.800363)"
+       id="g3560">
+      <circle
+         style="display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient3017-2);fill-opacity:1;fill-rule:evenodd;stroke:#172a04;stroke-width:1.95274;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+         id="path3550-3-7"
+         transform="matrix(1.1209221,0,0,1.1323546,-151.52039,2.02592)"
+         cx="53.214287"
+         cy="34.571426"
+         r="18.571428" />
+      <circle
+         r="18.571428"
+         cy="34.571426"
+         cx="53.214287"
+         style="display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient3017);fill-opacity:1;fill-rule:evenodd;stroke:#172a04;stroke-width:1.95265;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+         id="path3550-3-3"
+         transform="matrix(1.1209541,0,0,1.1324194,-131.80058,-13.472896)" />
+      <path
+         id="path3550-3"
+         transform="matrix(1.0956068,0,0,1.1068128,-115.97408,-3.0994776)"
+         d="m 22,21 c -0.116604,0 -0.227646,0.02916 -0.34375,0.03125 C 21.228852,22.614131 21,24.282004 21,26 c 0,10.49401 8.505991,19 19,19 0.116604,0 0.227646,-0.02916 0.34375,-0.03125 C 40.771148,43.385869 41,41.717996 41,40 41,29.50599 32.494009,21 22,21 Z"
+         style="display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient3090);fill-opacity:1;fill-rule:evenodd;stroke:#172a04;stroke-width:1.99783;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+      <path
+         id="path3550-3-1"
+         transform="matrix(1.0956068,0,0,1.1068128,-115.97408,-3.0994776)"
+         d="M 23.28125,23.0625 C 23.115498,24.015468 23,24.999615 23,26 23,34.959899 29.925717,42.284587 38.71875,42.9375 38.884502,41.984532 39,41.000385 39,40 39,31.040101 32.074283,23.715413 23.28125,23.0625 Z"
+         style="display:inline;overflow:visible;visibility:visible;fill:none;stroke:#8ae234;stroke-width:1.99783;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+      <path
+         id="path2633"
+         d="m -81.59191,23.997559 -11.309348,5.026244"
+         style="fill:none;stroke:#172a04;stroke-width:2.20239;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         id="path2639"
+         d="M -82.674488,39.715722 -79.756602,26.56252"
+         style="fill:none;stroke:#8ae234;stroke-width:2.20239;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         id="path2641"
+         d="m -81.504924,23.060221 -3.72744,18.130889"
+         style="fill:none;stroke:#172a04;stroke-width:2.20239;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         id="path2635"
+         d="M -71.727412,36.369348 -85.232364,41.19111"
+         style="fill:none;stroke:#172a04;stroke-width:2.20239;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         id="path2643"
+         d="m -82.774514,37.967655 8.785561,-3.134225"
+         style="fill:none;stroke:#8ae234;stroke-width:2.20239;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+  </g>
+</svg>

--- a/src/Mod/Mesh/Gui/Resources/icons/Mesh_Merge.svg
+++ b/src/Mod/Mesh/Gui/Resources/icons/Mesh_Merge.svg
@@ -1,0 +1,368 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:osb="http://www.openswatchbook.org/uri/2009/osb"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   width="64px"
+   height="64px"
+   id="svg2943"
+   version="1.1">
+  <title
+     id="title3265">Mesh_Merge</title>
+  <defs
+     id="defs2945">
+    <linearGradient
+       id="linearGradient1605">
+      <stop
+         id="stop1601"
+         offset="0"
+         style="stop-color:#4e9a06;stop-opacity:1" />
+      <stop
+         id="stop1603"
+         offset="1"
+         style="stop-color:#8ae234;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient1597">
+      <stop
+         id="stop1593"
+         offset="0"
+         style="stop-color:#4e9a06;stop-opacity:1" />
+      <stop
+         id="stop1595"
+         offset="1"
+         style="stop-color:#8ae234;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient1589">
+      <stop
+         id="stop1585"
+         offset="0"
+         style="stop-color:#4e9a06;stop-opacity:1" />
+      <stop
+         id="stop1587"
+         offset="1"
+         style="stop-color:#8ae234;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3811">
+      <stop
+         style="stop-color:#8ae234;stop-opacity:1;"
+         offset="0"
+         id="stop3813" />
+      <stop
+         style="stop-color:#4e9a06;stop-opacity:1;"
+         offset="1"
+         id="stop3815" />
+    </linearGradient>
+    <linearGradient
+       osb:paint="gradient"
+       id="linearGradient3805">
+      <stop
+         id="stop3807"
+         offset="0"
+         style="stop-color:#8ae234;stop-opacity:1;" />
+      <stop
+         id="stop3809"
+         offset="1"
+         style="stop-color:#4e9a06;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3377"
+       osb:paint="gradient">
+      <stop
+         id="stop3379"
+         offset="0"
+         style="stop-color:#faff2b;stop-opacity:1;" />
+      <stop
+         id="stop3381"
+         offset="1"
+         style="stop-color:#ffaa00;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient4391"
+       id="linearGradient4397"
+       x1="72.473869"
+       y1="98.785927"
+       x2="99.153984"
+       y2="100.78592"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient4391"
+       osb:paint="gradient">
+      <stop
+         style="stop-color:#00ff00;stop-opacity:1;"
+         offset="0"
+         id="stop4393" />
+      <stop
+         style="stop-color:#0f7d0f;stop-opacity:1;"
+         offset="1"
+         id="stop4395" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient4391"
+       id="linearGradient4368"
+       x1="277.25064"
+       y1="94.013901"
+       x2="285.59393"
+       y2="94.195724"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       r="18.0625"
+       fy="41.625"
+       fx="25.1875"
+       cy="41.625"
+       cx="25.1875"
+       gradientTransform="matrix(1,0,0,0.32526,0,28.08607)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3113"
+       xlink:href="#linearGradient2269" />
+    <linearGradient
+       id="linearGradient2269">
+      <stop
+         offset="0"
+         id="stop2271"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         offset="1"
+         id="stop2273"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient1014"
+       id="linearGradient951"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.47516502,-0.46153841,0.47516502,0.46153841,6.7679762,28.616002)"
+       x1="29"
+       y1="47"
+       x2="15"
+       y2="17" />
+    <linearGradient
+       id="linearGradient1014">
+      <stop
+         id="stop1010"
+         offset="0"
+         style="stop-color:#204a87;stop-opacity:1" />
+      <stop
+         id="stop1012"
+         offset="1"
+         style="stop-color:#729fcf;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="-4.9436636"
+       x2="-2.4792964"
+       y1="6.852284"
+       x1="3.1338437"
+       id="linearGradient1591"
+       xlink:href="#linearGradient1589" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="-2.9383526"
+       x2="-14.576011"
+       y1="9.9192305"
+       x1="-8.5983715"
+       id="linearGradient1599"
+       xlink:href="#linearGradient1597" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="3.0616474"
+       x2="14.850124"
+       y1="18.868217"
+       x1="16.68325"
+       id="linearGradient1607"
+       xlink:href="#linearGradient1605" />
+    <linearGradient
+       y2="-4.9436636"
+       x2="-2.4792964"
+       y1="6.852284"
+       x1="3.1338437"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient1623"
+       xlink:href="#linearGradient1589" />
+    <linearGradient
+       xlink:href="#linearGradient1605"
+       id="linearGradient1599-0"
+       x1="-8.5983715"
+       y1="9.9192305"
+       x2="-14.576011"
+       y2="-2.9383526"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       xlink:href="#linearGradient1605"
+       id="linearGradient1607-6"
+       x1="16.68325"
+       y1="18.868217"
+       x2="14.850124"
+       y2="3.0616474"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       y2="-4.9436636"
+       x2="-2.4792964"
+       y1="6.852284"
+       x1="3.1338437"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient1702"
+       xlink:href="#linearGradient1589" />
+  </defs>
+  <metadata
+     id="metadata2948">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>Mesh_Merge</dc:title>
+        <cc:license
+           rdf:resource="" />
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title>Based on an Agryson's design</dc:title>
+          </cc:Agent>
+        </dc:contributor>
+        <dc:description>Meshes with plus symbol</dc:description>
+        <dc:subject>
+          <rdf:Bag />
+        </dc:subject>
+        <dc:relation />
+        <dc:identifier />
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>FreeCAD</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>FreeCAD LGPL2+</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <dc:date>25-06-2020</dc:date>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>[bitacovir]</dc:title>
+          </cc:Agent>
+        </dc:creator>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1">
+    <g
+       id="g1621-9"
+       transform="rotate(97.41324,7.3234504,42.11787)">
+      <path
+         style="fill:none;stroke:#8ae234;stroke-width:4;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m -1.4825091,17.021256 -6,-26.9999995"
+         id="path3820-7" />
+      <path
+         style="fill:url(#linearGradient1599-0);fill-opacity:1;stroke:none"
+         d="m -31.48251,2.0212564 24.0000009,-11.9999999 6,27.9999995 z"
+         id="path3016-3-0" />
+      <path
+         style="fill:none;stroke:#8ae234;stroke-width:4;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="M -1.4825091,17.021256 17.517491,-4.9787435"
+         id="path3820-5-8" />
+      <path
+         style="fill:url(#linearGradient1607-6);fill-opacity:1;stroke:none"
+         d="m -1.4825091,18.021256 24.0000001,8 -4,-31.9999995 z"
+         id="path3018-6-4" />
+      <path
+         style="fill:url(#linearGradient1702);fill-opacity:1;stroke:none"
+         d="m 18.517491,-5.9787435 -26.0000001,-4 6,27.9999995 z"
+         id="path3020-7-2" />
+      <path
+         style="fill:none;stroke:#8ae234;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="M -28.849697,2.9196944 -7.1543841,-7.9240565 16.728428,-4.2365555 20.158116,23.122818 -0.87313414,16.130631 -29.13876,1.0134444"
+         id="path3818-6" />
+      <path
+         style="fill:none;stroke:#172a04;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+         d="m -31.48251,2.0212564 24.0000009,-11.9999999 6,27.9999995 z"
+         id="path3016-8" />
+      <path
+         style="fill:none;stroke:#172a04;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+         d="m -1.4825091,18.021256 24.0000001,8 -4,-31.9999995 z"
+         id="path3018-7" />
+      <path
+         style="fill:none;stroke:#172a04;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+         d="m 18.517491,-5.9787435 -26.0000001,-4 6,27.9999995 z"
+         id="path3020-5" />
+      <path
+         style="fill:none;stroke:#8ae234;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m -8.8887591,-6.9474935 4.585937,21.4296875"
+         id="path3840-6" />
+      <path
+         style="fill:none;stroke:#8ae234;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="M -4.8340721,-7.2131185 -0.34188414,13.630631 14.900303,-4.7834305"
+         id="path3842-6" />
+      <path
+         style="fill:none;stroke:#8ae234;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="M 17.064366,-1.1115555 1.9315529,17.075943"
+         id="path3844-1" />
+    </g>
+    <g
+       transform="rotate(-82.58676,19.773529,2.9239626)"
+       id="g1621">
+      <path
+         id="path3820"
+         d="m -1.4825091,17.021256 -6,-26.9999995"
+         style="fill:none;stroke:#8ae234;stroke-width:4;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      <path
+         id="path3016-3"
+         d="m -31.48251,2.0212564 24.0000009,-11.9999999 6,27.9999995 z"
+         style="fill:url(#linearGradient1599);fill-opacity:1;stroke:none" />
+      <path
+         id="path3820-5"
+         d="M -1.4825091,17.021256 17.517491,-4.9787435"
+         style="fill:none;stroke:#8ae234;stroke-width:4;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      <path
+         id="path3018-6"
+         d="m -1.4825091,18.021256 24.0000001,8 -4,-31.9999995 z"
+         style="fill:url(#linearGradient1607);fill-opacity:1;stroke:none" />
+      <path
+         id="path3020-7"
+         d="m 18.517491,-5.9787435 -26.0000001,-4 6,27.9999995 z"
+         style="fill:url(#linearGradient1623);fill-opacity:1;stroke:none" />
+      <path
+         id="path3818"
+         d="M -28.849697,2.9196944 -7.1543841,-7.9240565 16.728428,-4.2365555 20.158116,23.122818 -0.87313414,16.130631 -29.13876,1.0134444"
+         style="fill:none;stroke:#8ae234;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      <path
+         id="path3016"
+         d="m -31.48251,2.0212564 24.0000009,-11.9999999 6,27.9999995 z"
+         style="fill:none;stroke:#172a04;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+      <path
+         id="path3018"
+         d="m -1.4825091,18.021256 24.0000001,8 -4,-31.9999995 z"
+         style="fill:none;stroke:#172a04;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+      <path
+         id="path3020"
+         d="m 18.517491,-5.9787435 -26.0000001,-4 6,27.9999995 z"
+         style="fill:none;stroke:#172a04;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+      <path
+         id="path3840"
+         d="m -8.8887591,-6.9474935 4.585937,21.4296875"
+         style="fill:none;stroke:#8ae234;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      <path
+         id="path3842"
+         d="M -4.8340721,-7.2131185 -0.34188414,13.630631 14.900303,-4.7834305"
+         style="fill:none;stroke:#8ae234;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      <path
+         id="path3844"
+         d="M 17.064366,-1.1115555 1.9315529,17.075943"
+         style="fill:none;stroke:#8ae234;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    </g>
+    <path
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:url(#linearGradient951);fill-opacity:1;fill-rule:evenodd;stroke:#0b1521;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       d="m 21.022926,28.616002 v 5.538461 h 9.503301 v 9.230768 h 5.70198 v -9.230768 l 9.503301,-10e-7 v -5.538461 l -9.503301,1e-6 v -9.230769 h -5.70198 v 9.230769 z"
+       id="rect3761" />
+    <path
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:none;stroke:#729fcf;stroke-width:1.32456;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       d="m 22.448421,30.000617 v 2.769231 h 9.503301 v 9.230767 h 2.85099 v -9.230767 l 9.503301,-1e-6 v -2.769231 l -9.503301,10e-7 10e-7,-9.230768 h -2.85099 l -1e-6,9.230768 z"
+       id="rect3761-3" />
+  </g>
+</svg>

--- a/src/Mod/Mesh/Gui/Resources/icons/Mesh_Poly_Trim.svg
+++ b/src/Mod/Mesh/Gui/Resources/icons/Mesh_Poly_Trim.svg
@@ -1,0 +1,397 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   version="1.1"
+   id="svg2860"
+   height="64px"
+   width="64px">
+  <title
+     id="title915">Mesh_Poly_Trim</title>
+  <defs
+     id="defs2862">
+    <linearGradient
+       id="linearGradient2035">
+      <stop
+         id="stop2031"
+         offset="0"
+         style="stop-color:#babdb6;stop-opacity:1" />
+      <stop
+         id="stop2033"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient1995">
+      <stop
+         style="stop-color:#888a85;stop-opacity:1"
+         offset="0"
+         id="stop1991" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="1"
+         id="stop1993" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient1985">
+      <stop
+         id="stop1981"
+         offset="0"
+         style="stop-color:#729fcf;stop-opacity:1;" />
+      <stop
+         id="stop1983"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient1900">
+      <stop
+         id="stop1896"
+         offset="0"
+         style="stop-color:#4e9a06;stop-opacity:1" />
+      <stop
+         id="stop1898"
+         offset="1"
+         style="stop-color:#8ae234;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient916">
+      <stop
+         style="stop-color:#2e3436;stop-opacity:1"
+         offset="0"
+         id="stop912" />
+      <stop
+         style="stop-color:#eeeeec;stop-opacity:1"
+         offset="1"
+         id="stop914" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient982">
+      <stop
+         id="stop978"
+         offset="0"
+         style="stop-color:#a40000;stop-opacity:1" />
+      <stop
+         id="stop980"
+         offset="1"
+         style="stop-color:#ef2929;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4009">
+      <stop
+         id="stop4011"
+         offset="0"
+         style="stop-color:#204a87;stop-opacity:1;" />
+      <stop
+         id="stop4013"
+         offset="1"
+         style="stop-color:#3465a4;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4072">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop4074" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop4076" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3864">
+      <stop
+         id="stop3866"
+         offset="0"
+         style="stop-color:#ff0000;stop-opacity:1;" />
+      <stop
+         id="stop3868"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3377">
+      <stop
+         style="stop-color:#71b2f8;stop-opacity:1;"
+         offset="0"
+         id="stop3379" />
+      <stop
+         style="stop-color:#002795;stop-opacity:1;"
+         offset="1"
+         id="stop3381" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3377-7">
+      <stop
+         id="stop3379-7"
+         offset="0"
+         style="stop-color:#71b2f8;stop-opacity:1;" />
+      <stop
+         id="stop3381-9"
+         offset="1"
+         style="stop-color:#002795;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="39.259701"
+       x2="46.087074"
+       y1="39.259701"
+       x1="2.4857161"
+       id="linearGradient4082"
+       xlink:href="#linearGradient3377" />
+    <linearGradient
+       id="linearGradient3377-73">
+      <stop
+         style="stop-color:#71b2f8;stop-opacity:1;"
+         offset="0"
+         id="stop3379-3" />
+      <stop
+         style="stop-color:#002795;stop-opacity:1;"
+         offset="1"
+         id="stop3381-96" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4112">
+      <stop
+         style="stop-color:#71b2f8;stop-opacity:1;"
+         offset="0"
+         id="stop4114" />
+      <stop
+         style="stop-color:#002795;stop-opacity:1;"
+         offset="1"
+         id="stop4116" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4119">
+      <stop
+         style="stop-color:#71b2f8;stop-opacity:1;"
+         offset="0"
+         id="stop4121" />
+      <stop
+         style="stop-color:#002795;stop-opacity:1;"
+         offset="1"
+         id="stop4123" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4126">
+      <stop
+         style="stop-color:#71b2f8;stop-opacity:1;"
+         offset="0"
+         id="stop4128" />
+      <stop
+         style="stop-color:#002795;stop-opacity:1;"
+         offset="1"
+         id="stop4130" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4133">
+      <stop
+         style="stop-color:#71b2f8;stop-opacity:1;"
+         offset="0"
+         id="stop4135" />
+      <stop
+         style="stop-color:#002795;stop-opacity:1;"
+         offset="1"
+         id="stop4137" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4140">
+      <stop
+         style="stop-color:#71b2f8;stop-opacity:1;"
+         offset="0"
+         id="stop4142" />
+      <stop
+         style="stop-color:#002795;stop-opacity:1;"
+         offset="1"
+         id="stop4144" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1.3367742,0,0,1.3462145,-0.83476916,-19.403123)"
+       y2="39.259701"
+       x2="46.087074"
+       y1="39.259701"
+       x1="2.4857161"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4094-0"
+       xlink:href="#linearGradient3377-73" />
+    <linearGradient
+       id="linearGradient4147">
+      <stop
+         style="stop-color:#71b2f8;stop-opacity:1;"
+         offset="0"
+         id="stop4149" />
+      <stop
+         style="stop-color:#002795;stop-opacity:1;"
+         offset="1"
+         id="stop4151" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="26.591185"
+       x2="33.639343"
+       y1="49.757175"
+       x1="38.450821"
+       id="linearGradient4015"
+       xlink:href="#linearGradient4009" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="9"
+       x2="13"
+       y1="56"
+       x1="55"
+       id="linearGradient984"
+       xlink:href="#linearGradient982" />
+    <linearGradient
+       y2="9"
+       x2="13"
+       y1="56"
+       x1="55"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient1720"
+       xlink:href="#linearGradient916" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="21"
+       x2="9"
+       y1="49"
+       x1="26"
+       id="linearGradient1902"
+       xlink:href="#linearGradient1900" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="6.171968"
+       x2="33.889954"
+       y1="52"
+       x1="32"
+       id="linearGradient1987"
+       xlink:href="#linearGradient1985" />
+    <linearGradient
+       y2="6.171968"
+       x2="33.889954"
+       y1="52"
+       x1="32"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient1997"
+       xlink:href="#linearGradient1995" />
+    <linearGradient
+       y2="13.814957"
+       x2="32.396496"
+       y1="52"
+       x1="34.020561"
+       gradientTransform="translate(1e-6)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient2023"
+       xlink:href="#linearGradient1995" />
+    <linearGradient
+       gradientTransform="translate(-53.566338,-4.063557)"
+       gradientUnits="userSpaceOnUse"
+       y2="14.276645"
+       x2="85.523819"
+       y1="58.553272"
+       x1="86.223808"
+       id="linearGradient2037"
+       xlink:href="#linearGradient2035" />
+  </defs>
+  <metadata
+     id="metadata2865">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>Mesh_Poly_Trim</dc:title>
+        <cc:license
+           rdf:resource="http://creativecommons.org/licenses/by/4.0/" />
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>[bitacovir]</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:title>Arch_CutPlane</dc:title>
+        <dc:date>2020-06-23</dc:date>
+        <dc:relation />
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>FreeCAD</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:identifier />
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>FreeCAD LGPL2+</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title />
+          </cc:Agent>
+        </dc:contributor>
+        <dc:description>Mesh object being cut by a trimming line</dc:description>
+      </cc:Work>
+      <cc:License
+         rdf:about="http://creativecommons.org/licenses/by/4.0/">
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Reproduction" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Distribution" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Notice" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Attribution" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#DerivativeWorks" />
+      </cc:License>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1">
+    <g
+       id="g2047">
+      <path
+         style="fill:url(#linearGradient1902);fill-opacity:1;stroke:#172a04;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 32,14 3,22 v 39 l 29,-9 z"
+         id="path1894" />
+      <path
+         style="fill:none;stroke:#8ae234;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 27.504722,17.324449 5.0465897,23.580692 5.0109813,58.25257 28.027453,51.137266"
+         id="path1904" />
+      <path
+         style="fill:none;stroke:#172a04;stroke-width:6;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:2, 8;stroke-dashoffset:6.8;stroke-opacity:1"
+         d="M 32.72364,13.556999 59.097371,7.7005054 59.061611,42.300207 32.723639,49.618681 Z"
+         id="path4019-7-0-3-9-4" />
+      <path
+         style="fill:none;stroke:#8ae234;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:2, 8;stroke-dashoffset:6.8;stroke-opacity:1"
+         d="m 32.72364,13.556999 c 0,0 17.582487,-3.084391 26.373731,-5.8564936 l -0.03576,34.5997016 -24.668812,7.450252 z"
+         id="path4019-7-3-7-9" />
+      <path
+         id="path907"
+         d="M 3,22 16.399587,56.52888"
+         style="fill:none;stroke:#172a04;stroke-width:1.2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         id="path909"
+         d="m 11.305776,43.359515 3.975658,-24.599381 6.087725,18.635894 z"
+         style="fill:none;stroke:#172a04;stroke-width:1.2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         id="path911"
+         d="m 29.320474,31.432542 -5.590768,-15.032955 -2.360547,20.996441 8.075554,5.590769"
+         style="fill:none;stroke:#172a04;stroke-width:1.2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         id="path913"
+         d="M 11.305776,43.359515 28.699277,47.83213"
+         style="fill:none;stroke:#172a04;stroke-width:1.2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         style="fill:none;stroke:#000000;stroke-width:8;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 32,7 V 15.0673 57"
+         id="path961-5" />
+      <path
+         style="fill:url(#linearGradient2023);fill-opacity:1;stroke:url(#linearGradient2037);stroke-width:3.78;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 32,7 V 57"
+         id="path961-3-9-2" />
+    </g>
+  </g>
+</svg>

--- a/src/Mod/Mesh/Gui/Resources/icons/Mesh_Remesh_Gmsh.svg
+++ b/src/Mod/Mesh/Gui/Resources/icons/Mesh_Remesh_Gmsh.svg
@@ -1,0 +1,207 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:osb="http://www.openswatchbook.org/uri/2009/osb"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   width="64px"
+   height="64px"
+   id="svg2943"
+   version="1.1">
+  <title
+     id="title3265">Mesh_Remesh_Gmsh</title>
+  <defs
+     id="defs2945">
+    <linearGradient
+       id="linearGradient864">
+      <stop
+         style="stop-color:#2e3436;stop-opacity:1"
+         offset="0"
+         id="stop860" />
+      <stop
+         style="stop-color:#babdb6;stop-opacity:1"
+         offset="1"
+         id="stop862" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3811">
+      <stop
+         style="stop-color:#8ae234;stop-opacity:1;"
+         offset="0"
+         id="stop3813" />
+      <stop
+         style="stop-color:#4e9a06;stop-opacity:1;"
+         offset="1"
+         id="stop3815" />
+    </linearGradient>
+    <linearGradient
+       osb:paint="gradient"
+       id="linearGradient3805">
+      <stop
+         id="stop3807"
+         offset="0"
+         style="stop-color:#8ae234;stop-opacity:1;" />
+      <stop
+         id="stop3809"
+         offset="1"
+         style="stop-color:#4e9a06;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3377"
+       osb:paint="gradient">
+      <stop
+         id="stop3379"
+         offset="0"
+         style="stop-color:#faff2b;stop-opacity:1;" />
+      <stop
+         id="stop3381"
+         offset="1"
+         style="stop-color:#ffaa00;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient4391"
+       id="linearGradient4397"
+       x1="72.473869"
+       y1="98.785927"
+       x2="99.153984"
+       y2="100.78592"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient4391"
+       osb:paint="gradient">
+      <stop
+         style="stop-color:#00ff00;stop-opacity:1;"
+         offset="0"
+         id="stop4393" />
+      <stop
+         style="stop-color:#0f7d0f;stop-opacity:1;"
+         offset="1"
+         id="stop4395" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient4391"
+       id="linearGradient4368"
+       x1="277.25064"
+       y1="94.013901"
+       x2="285.59393"
+       y2="94.195724"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       r="18.0625"
+       fy="41.625"
+       fx="25.1875"
+       cy="41.625"
+       cx="25.1875"
+       gradientTransform="matrix(1,0,0,0.32526,0,28.08607)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3113"
+       xlink:href="#linearGradient2269" />
+    <linearGradient
+       id="linearGradient2269">
+      <stop
+         offset="0"
+         id="stop2271"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         offset="1"
+         id="stop2273"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <radialGradient
+       r="18.0625"
+       fy="41.625"
+       fx="25.1875"
+       cy="41.625"
+       cx="25.1875"
+       gradientTransform="matrix(1,0,0,0.32526,0,28.08607)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3043"
+       xlink:href="#linearGradient2269" />
+    <linearGradient
+       gradientTransform="translate(0,2)"
+       xlink:href="#linearGradient864"
+       id="linearGradient866"
+       x1="50"
+       y1="45"
+       x2="11"
+       y2="42"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <metadata
+     id="metadata2948">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>Mesh_Remesh_Gmsh</dc:title>
+        <cc:license
+           rdf:resource="" />
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title />
+          </cc:Agent>
+        </dc:contributor>
+        <dc:description />
+        <dc:subject>
+          <rdf:Bag>
+            <rdf:li>prism</rdf:li>
+            <rdf:li>gmsh</rdf:li>
+          </rdf:Bag>
+        </dc:subject>
+        <dc:relation />
+        <dc:identifier />
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>FreeCAD</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>FreeCAD LGPL2+</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <dc:date>26-06-2020</dc:date>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>[bitacovir]</dc:title>
+          </cc:Agent>
+        </dc:creator>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1">
+    <g
+       id="g866">
+      <path
+         id="path876"
+         d="M 32,5 6.547169,49.820065 57,50 Z"
+         style="fill:none;stroke:#888a85;stroke-width:4;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <ellipse
+         ry="5.875"
+         rx="18.0625"
+         cy="41.625"
+         cx="25.1875"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.267045;fill:url(#radialGradient3043);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none"
+         transform="matrix(1.652249,0,0,1.1276596,-9.6160217,10.436169)"
+         id="path2267" />
+      <path
+         id="path2999"
+         d="M 32,5 7,50 H 57 L 32,5"
+         style="fill:url(#linearGradient866);fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+      <path
+         id="path872"
+         d="M 6.547169,49.820065 32,43 V 5 Z"
+         style="fill:#eeeeec;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1" />
+      <path
+         id="path874"
+         d="M 32,43 57,50 32,5 Z"
+         style="fill:#000000;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1" />
+    </g>
+  </g>
+</svg>

--- a/src/Mod/Mesh/Gui/Resources/icons/Mesh_Remove_Comp_by_Hand.svg
+++ b/src/Mod/Mesh/Gui/Resources/icons/Mesh_Remove_Comp_by_Hand.svg
@@ -1,0 +1,220 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   width="64"
+   height="64"
+   id="svg9484"
+   version="1.1">
+  <title
+     id="title3749">Mesh_Remove_Comp_by_Hand</title>
+  <defs
+     id="defs9486">
+    <linearGradient
+       id="linearGradient1909">
+      <stop
+         style="stop-color:#4e9a06;stop-opacity:1"
+         offset="0"
+         id="stop1905" />
+      <stop
+         style="stop-color:#8ae234;stop-opacity:1"
+         offset="1"
+         id="stop1907" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient1347">
+      <stop
+         style="stop-color:#4e9a06;stop-opacity:1"
+         offset="0"
+         id="stop1343" />
+      <stop
+         style="stop-color:#8ae234;stop-opacity:1"
+         offset="1"
+         id="stop1345" />
+    </linearGradient>
+    <marker
+       orient="auto"
+       refY="0.0"
+       refX="0.0"
+       id="Arrow1Lstart"
+       style="overflow:visible">
+      <path
+         id="path1067"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         style="fill-rule:evenodd;stroke:none;stroke-width:1pt;stroke-opacity:1;fill:#8ae234;fill-opacity:1"
+         transform="scale(0.8) translate(12.5,0)" />
+    </marker>
+    <linearGradient
+       id="linearGradient12537">
+      <stop
+         style="stop-color:#00fd00;stop-opacity:1;"
+         offset="0"
+         id="stop12539" />
+      <stop
+         style="stop-color:#00fd00;stop-opacity:0;"
+         offset="1"
+         id="stop12541" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient12537"
+       id="linearGradient12547"
+       x1="4.5"
+       y1="14.755193"
+       x2="30.5"
+       y2="14.755193"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(35,-2)" />
+    <linearGradient
+       id="linearGradient1014">
+      <stop
+         style="stop-color:#204a87;stop-opacity:1"
+         offset="0"
+         id="stop1010" />
+      <stop
+         style="stop-color:#729fcf;stop-opacity:1"
+         offset="1"
+         id="stop1012" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient1347"
+       id="linearGradient1349"
+       x1="25.894817"
+       y1="-1.0932833"
+       x2="11.196301"
+       y2="-19.181715"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       xlink:href="#linearGradient1909"
+       id="linearGradient1911"
+       x1="23.388866"
+       y1="0.75593823"
+       x2="12.52975"
+       y2="-18.27072"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <metadata
+     id="metadata9489">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <cc:license
+           rdf:resource="https://www.gnu.org/copyleft/lesser.html" />
+        <dc:title>Mesh_Remove_Comp_by_Hand</dc:title>
+        <dc:description>Triangular mesh, faces and plus symbol</dc:description>
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title>Icon based on a wmayer' s design</dc:title>
+          </cc:Agent>
+        </dc:contributor>
+        <dc:subject>
+          <rdf:Bag>
+            <rdf:li>mesh</rdf:li>
+            <rdf:li>triangles</rdf:li>
+            <rdf:li>faces</rdf:li>
+            <rdf:li>cross</rdf:li>
+          </rdf:Bag>
+        </dc:subject>
+        <dc:relation />
+        <dc:identifier />
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>FreeCAD</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>FreeCAD LGPL2+</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <dc:date>12-06-2020</dc:date>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>[bitacovir]</dc:title>
+          </cc:Agent>
+        </dc:creator>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     transform="translate(0,32)"
+     style="opacity:1">
+    <path
+       id="path1903-0"
+       d="M 23.50984,-24.628277 53.207297,-12.71033 22.632579,15.299236 Z"
+       style="fill:#75507b;fill-opacity:1" />
+    <path
+       id="path1049-9"
+       d="M 53.207297,-12.71033 20.67196,18.930845 22.147925,-27.242881 Z"
+       style="fill:none;stroke:#171018;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       style="fill:none;stroke:#ad7fa8;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 24.873268,-22.680728 23.134108,10.861546 -24.151353,23.52788 z"
+       id="path875" />
+    <path
+       style="fill:url(#linearGradient1911);fill-opacity:1"
+       d="M 7.0227055,-24.589038 36.535335,-12.641175 5.4759649,15.241798 Z"
+       id="path1903" />
+    <path
+       style="fill:none;stroke:#172a04;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 36.535335,-12.641175 4,19 5.4759648,-27.173726 Z"
+       id="path1049" />
+    <path
+       style="fill:none;stroke:#8ae234;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 8.2603537,-22.672297 7.1930047,11.714906 31.370781,-11.720367 Z"
+       id="path873" />
+    <g
+       id="g1658">
+      <g
+         transform="translate(-34.434687,-64.167468)"
+         id="g3890">
+        <rect
+           style="fill:#cc0000;fill-opacity:1;stroke:#280000;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="rect3839"
+           width="36.76955"
+           height="6"
+           x="-19.97056"
+           y="110.13708"
+           ry="2"
+           transform="matrix(-0.70710678,0.70710678,0.70710678,0.70710678,0,0)" />
+        <rect
+           style="fill:#cc0000;fill-opacity:1;stroke:#280000;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="rect3839-5"
+           width="36.76955"
+           height="6"
+           x="94.752312"
+           y="-4.5857863"
+           ry="2"
+           transform="rotate(45)" />
+        <rect
+           style="fill:#cc0000;stroke:#cc0000;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="rect3888"
+           width="13"
+           height="2"
+           x="-4.8928065"
+           y="112.14682"
+           ry="0"
+           transform="rotate(-45)" />
+      </g>
+      <path
+         id="path3922"
+         d="m 43.938752,16.025893 -9.498595,9.5422"
+         style="fill:none;stroke:#ef2929;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
+      <path
+         id="path3922-2"
+         d="m 57.528242,2.4681521 -9.564,9.6075979"
+         style="fill:none;stroke:#ef2929;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
+      <path
+         id="path3922-7"
+         d="m 35.837201,2.4027521 -1.476185,1.476185"
+         style="fill:none;stroke:#ef2929;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
+    </g>
+  </g>
+</svg>

--- a/src/Mod/Mesh/Gui/Resources/icons/Mesh_Scale.svg
+++ b/src/Mod/Mesh/Gui/Resources/icons/Mesh_Scale.svg
@@ -1,0 +1,248 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   version="1.1"
+   id="svg2766"
+   height="64px"
+   width="64px">
+  <title
+     id="title870">Mesh_Scale</title>
+  <defs
+     id="defs2768">
+    <linearGradient
+       id="linearGradient3856">
+      <stop
+         id="stop3858"
+         offset="0"
+         style="stop-color:#4e9a06;stop-opacity:1" />
+      <stop
+         id="stop3860"
+         offset="1"
+         style="stop-color:#8ae234;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3824">
+      <stop
+         id="stop3826"
+         offset="0"
+         style="stop-color:#8ae234;stop-opacity:1" />
+      <stop
+         id="stop3828"
+         offset="1"
+         style="stop-color:#4e9a06;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3787">
+      <stop
+         style="stop-color:#0619c0;stop-opacity:1;"
+         offset="0"
+         id="stop3789" />
+      <stop
+         style="stop-color:#379cfb;stop-opacity:1;"
+         offset="1"
+         id="stop3791" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3864">
+      <stop
+         style="stop-color:#0619c0;stop-opacity:1;"
+         offset="0"
+         id="stop3866" />
+      <stop
+         style="stop-color:#379cfb;stop-opacity:1;"
+         offset="1"
+         id="stop3868" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3895"
+       id="linearGradient3036"
+       gradientUnits="userSpaceOnUse"
+       x1="56.172409"
+       y1="29.279999"
+       x2="21.689653"
+       y2="36.079998"
+       gradientTransform="matrix(0,-1.4500001,1.4705882,0,-15.05882,91.45)" />
+    <linearGradient
+       id="linearGradient3895">
+      <stop
+         id="stop3897"
+         offset="0"
+         style="stop-color:#729fcf;stop-opacity:1;" />
+      <stop
+         id="stop3899"
+         offset="1"
+         style="stop-color:#204a87;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3895"
+       id="linearGradient3012"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.38366341,-0.38366341,0.41875298,0.41875298,12.196434,25.003375)"
+       x1="44.058071"
+       y1="18.865765"
+       x2="32.329041"
+       y2="43.940212" />
+    <linearGradient
+       gradientTransform="translate(-0.9420628,1.000004)"
+       gradientUnits="userSpaceOnUse"
+       y2="128.1946"
+       x2="599.1272"
+       y1="103.1946"
+       x1="591.59064"
+       id="linearGradient3830"
+       xlink:href="#linearGradient3824" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="68.194603"
+       x2="595.35895"
+       y1="135.1946"
+       x1="613.25824"
+       id="linearGradient3862"
+       xlink:href="#linearGradient3856" />
+  </defs>
+  <g
+     id="layer1">
+    <g
+       transform="matrix(1.0614931,0,0,1,-612.96941,-69.194602)"
+       id="g3518">
+      <path
+         style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3862);fill-opacity:1;fill-rule:nonzero;stroke:#172a04;stroke-width:1.94121;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+         d="m 580.28581,72.194602 3e-5,14 h 5.65241 v -8 h 1.88414 v -6 z m 11.30486,0 v 6 h 7.53655 v -6 z m 11.30483,0 v 6 h 7.53655 v -6 z m 11.30483,0 v 6 h 7.53655 v -6 z m 11.30483,0 v 6 h 3.76828 v 4 h 5.65241 v -10 z m 3.76828,14 v 8 h 5.65241 v -8 z m -48.9876,4 v 8 h 5.65241 v -8 z m 48.9876,8 v 7.999998 h 5.65241 v -7.999998 z m 0,11.999998 v 8 h 5.65241 v -8 z m 0,12 v 2 h -3.76828 v 6 h 9.42069 v -8 z m -18.84139,2 v 6 h 11.30483 v -6 z"
+         id="rect3446" />
+      <path
+         id="path3018"
+         d="m 581.09443,102.94082 v 26.48566 h 24.84408 v -26.48566 z"
+         style="fill:#4e9a06;stroke:#172a04;stroke-width:3.49797;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         transform="matrix(0.94206924,0,0,1,577.45963,69.194602)"
+         id="path3832"
+         d="M 36,57 H 46"
+         style="fill:none;stroke:#8ae234;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      <path
+         transform="matrix(0.94206924,0,0,1,577.45963,69.194602)"
+         id="path3834"
+         d="m 52,57 h 5 v -2 h 3"
+         style="fill:none;stroke:#8ae234;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1" />
+      <path
+         transform="matrix(0.94206924,0,0,1,577.45963,69.194602)"
+         id="path3836"
+         d="M 57,48 V 42"
+         style="fill:none;stroke:#8ae234;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      <path
+         transform="matrix(0.94206924,0,0,1,577.45963,69.194602)"
+         id="path3838"
+         d="M 57,36 V 30"
+         style="fill:none;stroke:#8ae234;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      <path
+         transform="matrix(0.94206924,0,0,1,577.45963,69.194602)"
+         id="path3840"
+         d="M 57,24 V 18"
+         style="fill:none;stroke:#8ae234;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      <path
+         transform="matrix(0.94206924,0,0,1,577.45963,69.194602)"
+         id="path3842"
+         d="M 53,8 V 5 h 7"
+         style="fill:none;stroke:#8ae234;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      <path
+         transform="matrix(0.94206924,0,0,1,577.45963,69.194602)"
+         id="path3844"
+         d="M 46,5 H 40"
+         style="fill:none;stroke:#8ae234;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      <path
+         transform="matrix(0.94206924,0,0,1,577.45963,69.194602)"
+         id="path3846"
+         d="M 34,5 H 28"
+         style="fill:none;stroke:#8ae234;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      <path
+         transform="matrix(0.94206924,0,0,1,577.45963,69.194602)"
+         id="path3848"
+         d="M 22,5 H 16"
+         style="fill:none;stroke:#8ae234;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      <path
+         transform="matrix(0.94206924,0,0,1,577.45963,69.194602)"
+         id="path3850"
+         d="M 10,5 H 5 v 11"
+         style="fill:none;stroke:#8ae234;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      <path
+         transform="matrix(0.94206924,0,0,1,577.45963,69.194602)"
+         id="path3852"
+         d="m 5,22 v 6"
+         style="fill:none;stroke:#8ae234;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      <path
+         transform="matrix(0.94206924,0,0,1,577.45963,69.194602)"
+         id="path3854"
+         d="M 57,12 V 9"
+         style="fill:none;stroke:#8ae234;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      <path
+         id="path889"
+         d="m 581.09443,102.94082 24.84408,26.48566"
+         style="fill:#172a04;stroke:#172a04;stroke-width:2.42651;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         id="path924"
+         d="m 587.76414,106.15385 14.97158,-0.0736 0.0693,16.11295 z"
+         style="fill:none;stroke:#8ae234;stroke-width:2.91181;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         id="path926"
+         d="m 584.25789,110.23022 0.0654,16.02995 14.96994,-0.0326 z"
+         style="fill:none;stroke:#8ae234;stroke-width:2.91181;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <path
+       id="path3343"
+       d="M 35,15 39.062816,19.37832 31,27 l 6,6 7.71967,-7.964826 4.24264,4.242641 L 49,15 Z"
+       style="fill:url(#linearGradient3012);fill-opacity:1;fill-rule:evenodd;stroke:#0b1521;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       id="path3343-2"
+       d="m 39.550023,17 2.32515,2.37832 -7.987667,7.653821 3.080353,3.112494 7.751811,-7.937888 2.221642,2.240472 L 47.000002,17 Z"
+       style="fill:none;stroke:#729fcf;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  </g>
+  <metadata
+     id="metadata5370">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>Mesh_Scale</dc:title>
+        <cc:license
+           rdf:resource="" />
+        <dc:date>12-06-2020</dc:date>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>[bitacovir]</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>FreeCAD LGPL2+</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>FreeCAD</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:identifier />
+        <dc:relation />
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title>Based on a wmayer's design</dc:title>
+          </cc:Agent>
+        </dc:contributor>
+        <dc:subject>
+          <rdf:Bag>
+            <rdf:li>green square</rdf:li>
+            <rdf:li>arrow</rdf:li>
+            <rdf:li>dotted line</rdf:li>
+          </rdf:Bag>
+        </dc:subject>
+        <dc:description>A small square in the bottom left corner of a large dotted box ith an arrow pointing from the top left corner of the inner box to the top left corner of the</dc:description>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+</svg>

--- a/src/Mod/Mesh/Gui/Resources/icons/Mesh_Section_by_Plane.svg
+++ b/src/Mod/Mesh/Gui/Resources/icons/Mesh_Section_by_Plane.svg
@@ -1,0 +1,351 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   version="1.1"
+   id="svg2784"
+   height="64px"
+   width="64px">
+  <title
+     id="title3262">Mesh_Section_by_Plane</title>
+  <defs
+     id="defs2786">
+    <linearGradient
+       id="linearGradient2498">
+      <stop
+         id="stop2494"
+         offset="0"
+         style="stop-color:#204a87;stop-opacity:1" />
+      <stop
+         id="stop2496"
+         offset="1"
+         style="stop-color:#729fcf;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2490">
+      <stop
+         id="stop2486"
+         offset="0"
+         style="stop-color:#204a87;stop-opacity:1" />
+      <stop
+         id="stop2488"
+         offset="1"
+         style="stop-color:#729fcf;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2364">
+      <stop
+         id="stop2360"
+         offset="0"
+         style="stop-color:#204a87;stop-opacity:1;" />
+      <stop
+         id="stop2362"
+         offset="1"
+         style="stop-color:#729fcf;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2356">
+      <stop
+         id="stop2352"
+         offset="0"
+         style="stop-color:#204a87;stop-opacity:1" />
+      <stop
+         id="stop2354"
+         offset="1"
+         style="stop-color:#729fcf;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3935">
+      <stop
+         style="stop-color:#8ae234;stop-opacity:1;"
+         offset="0"
+         id="stop3937" />
+      <stop
+         id="stop3951"
+         offset="1"
+         style="stop-color:#4e9a06;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3919">
+      <stop
+         id="stop3921"
+         offset="0"
+         style="stop-color:#4e9a06;stop-opacity:1;" />
+      <stop
+         id="stop3923"
+         offset="1"
+         style="stop-color:#8ae234;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3377">
+      <stop
+         style="stop-color:#faff2b;stop-opacity:1;"
+         offset="0"
+         id="stop3379" />
+      <stop
+         style="stop-color:#ffaa00;stop-opacity:1;"
+         offset="1"
+         id="stop3381" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(0.69820836,0.90688615,-0.80234164,0.6177199,36.829014,-29.491992)"
+       gradientUnits="userSpaceOnUse"
+       r="19.467436"
+       fy="28.42197"
+       fx="42.871357"
+       cy="28.42197"
+       cx="42.871357"
+       id="radialGradient3692"
+       xlink:href="#linearGradient4391" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="100.78592"
+       x2="99.153984"
+       y1="98.785927"
+       x1="72.473869"
+       id="linearGradient4397"
+       xlink:href="#linearGradient4391" />
+    <linearGradient
+       id="linearGradient4391">
+      <stop
+         id="stop4393"
+         offset="0"
+         style="stop-color:#00ff00;stop-opacity:1;" />
+      <stop
+         id="stop4395"
+         offset="1"
+         style="stop-color:#0f7d0f;stop-opacity:1;" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#linearGradient2269"
+       id="radialGradient3060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.32526,0,28.08607)"
+       cx="25.1875"
+       cy="41.625"
+       fx="25.1875"
+       fy="41.625"
+       r="18.0625" />
+    <linearGradient
+       id="linearGradient2269">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         id="stop2271"
+         offset="0" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         id="stop2273"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(-0.83983183,0.60780128,-0.55112025,-0.76372925,73.403753,7.3013018)"
+       gradientUnits="userSpaceOnUse"
+       r="30.115385"
+       fy="27.062101"
+       fx="43.679794"
+       cy="27.062101"
+       cx="43.679794"
+       id="radialGradient3949"
+       xlink:href="#linearGradient3935" />
+    <linearGradient
+       gradientTransform="translate(0,3)"
+       gradientUnits="userSpaceOnUse"
+       y2="6"
+       x2="12"
+       y1="50"
+       x1="32"
+       id="linearGradient2358"
+       xlink:href="#linearGradient2356" />
+    <linearGradient
+       gradientTransform="translate(0,3)"
+       gradientUnits="userSpaceOnUse"
+       y2="4.1379309"
+       x2="22"
+       y1="42.137932"
+       x1="48"
+       id="linearGradient2366"
+       xlink:href="#linearGradient2364" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="6"
+       x2="10"
+       y1="46"
+       x1="28"
+       id="linearGradient2492"
+       xlink:href="#linearGradient2490" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="7"
+       x2="13"
+       y1="47"
+       x1="34"
+       id="linearGradient2500"
+       xlink:href="#linearGradient2498" />
+    <radialGradient
+       r="18.0625"
+       fy="41.625"
+       fx="25.1875"
+       cy="41.625"
+       cx="25.1875"
+       gradientTransform="matrix(1.652249,0,0,0.36678256,-9.1863791,41.945968)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3042"
+       xlink:href="#linearGradient2269" />
+  </defs>
+  <metadata
+     id="metadata2789">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>Mesh_Section_by_Plane</dc:title>
+        <cc:license
+           rdf:resource="" />
+        <dc:date>04-07-2020</dc:date>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>[bitacovir]</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>FreeCAD LGPL2+</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>FreeCAD</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:identifier />
+        <dc:relation />
+        <dc:subject>
+          <rdf:Bag>
+            <rdf:li>sphere</rdf:li>
+            <rdf:li>mesh</rdf:li>
+            <rdf:li>plane</rdf:li>
+            <rdf:li>red line</rdf:li>
+          </rdf:Bag>
+        </dc:subject>
+        <dc:description>Red section of a sphere by a plane </dc:description>
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title>Based on a jmaustpc's work</dc:title>
+          </cc:Agent>
+        </dc:contributor>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1">
+    <ellipse
+       id="path2267"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.267045;fill:url(#radialGradient3042);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.36498;marker:none"
+       cx="32.429642"
+       cy="57.213272"
+       rx="29.843748"
+       ry="6.625" />
+    <path
+       id="path2484"
+       d="M 60,26 V 3 L 8,12 5,43 h 48 z"
+       style="fill:url(#linearGradient2492);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       id="path2504"
+       d="M 7,43 9.8945377,13.644065 58,5 57,26"
+       style="fill:none;stroke:#729fcf;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <circle
+       r="23"
+       cy="32"
+       cx="32"
+       id="path3025-2"
+       style="fill:url(#radialGradient3949);fill-opacity:1;stroke:#8ae234;stroke-width:2.08276;stroke-opacity:1" />
+    <circle
+       r="25"
+       cy="32"
+       cx="32"
+       id="path3025"
+       style="fill:none;stroke:#172a04;stroke-width:2.08334;stroke-opacity:1" />
+    <path
+       id="path3795"
+       d="M 32,7.0000006 V 57"
+       style="fill:none;stroke:#172a04;stroke-width:2.08333;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       id="path3797"
+       d="M 32,57 C 16.482758,52.689655 16.482758,11.310345 32,7.0000006"
+       style="fill:none;stroke:#172a04;stroke-width:2.08333;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       id="path3799"
+       d="m 25.965517,7.8620694 c -19.8275862,10.3448276 -18.1034483,37.9310336 0,48.2758616"
+       style="fill:none;stroke:#172a04;stroke-width:2.08333;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+    <path
+       id="path3797-3"
+       d="M 32,57 C 47.517241,52.689655 47.517241,11.310345 32,7.0000006"
+       style="fill:none;stroke:#172a04;stroke-width:2.08333;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       id="path3799-6"
+       d="m 38.034482,7.8620694 c 19.827586,10.3448276 18.103449,37.9310336 0,48.2758616"
+       style="fill:none;stroke:#172a04;stroke-width:2.08333;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+    <g
+       style="stroke-width:2.41667"
+       transform="matrix(0,0.86206896,-0.86206896,0,67.344826,-14.551723)"
+       id="g3854">
+      <path
+         style="fill:none;stroke:#172a04;stroke-width:2.41667;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="M 53,12 V 70"
+         id="path3795-7" />
+      <path
+         transform="rotate(-90,47.5,25.5)"
+         id="path3861"
+         d="M 6,45 H 58"
+         style="fill:none;stroke:#172a04;stroke-width:2.41667;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      <path
+         transform="rotate(-90,47.5,25.5)"
+         id="path3863"
+         d="M 7,17 H 57"
+         style="fill:none;stroke:#172a04;stroke-width:2.41667;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      <path
+         transform="rotate(-90,47.5,25.5)"
+         id="path3865"
+         d="M 3,31 C 21,31 44,21 50,9"
+         style="fill:none;stroke:#172a04;stroke-width:2.41667;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      <path
+         id="path3865-2"
+         d="M 67,67 C 67,49 59,19 47,13"
+         style="fill:none;stroke:#172a04;stroke-width:2.41667;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      <path
+         id="path3865-9"
+         d="M 39,66 C 39,48 31,35 27,32"
+         style="fill:none;stroke:#172a04;stroke-width:2.41667;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      <path
+         id="path3865-1"
+         d="M 80,54 C 80,36 71,20 67,15"
+         style="fill:none;stroke:#172a04;stroke-width:2.41667;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    </g>
+    <path
+       id="path2482"
+       d="M 5,43 H 9 C 31.707568,42.051303 47.415374,35.984429 56,26 h 4 L 58,51 5,61 Z"
+       style="fill:url(#linearGradient2500);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       id="path2506"
+       d="M 57,26 56.027106,48.297954 7.0372865,57.433965 7.9321634,42.850854"
+       style="fill:none;stroke:#729fcf;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       id="path2508"
+       d="M 9,43 C 26.936461,43.147931 43.197569,38.265295 57,26"
+       style="fill:none;stroke:#280000;stroke-width:5;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       style="fill:none;stroke:#ef2929;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 9,43 C 26.936461,43.147931 43.197569,38.265295 57,26"
+       id="path2508-7" />
+    <path
+       id="path2502"
+       d="m 8,12 52,-9 -2,46.91869 -53.1118596,10 z"
+       style="fill:none;stroke:#0b1521;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  </g>
+</svg>

--- a/src/Mod/Mesh/Gui/Resources/icons/Mesh_Segmentation.svg
+++ b/src/Mod/Mesh/Gui/Resources/icons/Mesh_Segmentation.svg
@@ -1,0 +1,272 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   width="64px"
+   height="64px"
+   id="svg2784"
+   version="1.1">
+  <title
+     id="title3262">Mesh_Segmentation</title>
+  <defs
+     id="defs2786">
+    <linearGradient
+       id="linearGradient1178">
+      <stop
+         id="stop1174"
+         offset="0"
+         style="stop-color:#4e9a06;stop-opacity:1" />
+      <stop
+         id="stop1176"
+         offset="1"
+         style="stop-color:#8ae234;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3935">
+      <stop
+         id="stop3937"
+         offset="0"
+         style="stop-color:#8ae234;stop-opacity:1;" />
+      <stop
+         style="stop-color:#4e9a06;stop-opacity:1;"
+         offset="1"
+         id="stop3951" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3919">
+      <stop
+         style="stop-color:#4e9a06;stop-opacity:1;"
+         offset="0"
+         id="stop3921" />
+      <stop
+         style="stop-color:#8ae234;stop-opacity:1;"
+         offset="1"
+         id="stop3923" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3377">
+      <stop
+         id="stop3379"
+         offset="0"
+         style="stop-color:#faff2b;stop-opacity:1;" />
+      <stop
+         id="stop3381"
+         offset="1"
+         style="stop-color:#ffaa00;stop-opacity:1;" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#linearGradient4391"
+       id="radialGradient3692"
+       cx="42.871357"
+       cy="28.42197"
+       fx="42.871357"
+       fy="28.42197"
+       r="19.467436"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.69820836,0.90688615,-0.80234164,0.6177199,36.829014,-29.491992)" />
+    <linearGradient
+       xlink:href="#linearGradient4391"
+       id="linearGradient4397"
+       x1="72.473869"
+       y1="98.785927"
+       x2="99.153984"
+       y2="100.78592"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient4391">
+      <stop
+         style="stop-color:#00ff00;stop-opacity:1;"
+         offset="0"
+         id="stop4393" />
+      <stop
+         style="stop-color:#0f7d0f;stop-opacity:1;"
+         offset="1"
+         id="stop4395" />
+    </linearGradient>
+    <radialGradient
+       r="18.0625"
+       fy="41.625"
+       fx="25.1875"
+       cy="41.625"
+       cx="25.1875"
+       gradientTransform="matrix(1,0,0,0.32526,0,28.08607)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3060"
+       xlink:href="#linearGradient2269" />
+    <linearGradient
+       id="linearGradient2269">
+      <stop
+         offset="0"
+         id="stop2271"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         offset="1"
+         id="stop2273"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <radialGradient
+       r="18.0625"
+       fy="41.625"
+       fx="25.1875"
+       cy="41.625"
+       cx="25.1875"
+       gradientTransform="matrix(1,0,0,0.32526,0,28.08607)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3042"
+       xlink:href="#linearGradient2269" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="11.535625"
+       x2="15.384269"
+       y1="24.085632"
+       x1="29.415243"
+       id="linearGradient1180"
+       xlink:href="#linearGradient1178" />
+  </defs>
+  <metadata
+     id="metadata2789">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>Mesh_Segmentation</dc:title>
+        <cc:license
+           rdf:resource="" />
+        <dc:date>19-06-2020</dc:date>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>[bitacovir]</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>FreeCAD LGPL2+</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>FreeCAD</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:identifier />
+        <dc:relation />
+        <dc:subject>
+          <rdf:Bag>
+            <rdf:li>mesh</rdf:li>
+            <rdf:li>sphere</rdf:li>
+          </rdf:Bag>
+        </dc:subject>
+        <dc:description>Incomplete sphere mesh</dc:description>
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title>Based on a jmaustpc's design</dc:title>
+          </cc:Agent>
+        </dc:contributor>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1">
+    <ellipse
+       id="path2267"
+       transform="matrix(1.652249,0,0,1.1276596,-7.6160217,8.436169)"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.267045;fill:url(#radialGradient3042);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none"
+       cx="25.1875"
+       cy="41.625"
+       rx="18.0625"
+       ry="5.875" />
+    <path
+       id="path1132"
+       d="m 45.808816,12.701581 c -5.56195,1.982198 -11.47566,2.205557 -17.59924,1.379602 l 0.74573,26.585301 16.85351,4.325238 z"
+       style="fill:#172a04;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       id="path883-3"
+       d="m 15.800476,9.912751 c -12.542637,10.97984 -10.098553,27.784018 -2.40828,35.667811 1.94945,-3.625233 14.99208,-4.71808 21.98793,-4.270584 l -3.04237,-4.770506 -0.0682,-8.721302 -2.75591,-4.37093 6.6902,-3.437401 -5.33837,-5.626065 3.05045,-6.955748 C 24.689366,6.839582 20.054362,7.8287557 15.800476,9.912751 Z"
+       style="fill:url(#linearGradient1180);fill-opacity:1;stroke:#172a04;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       id="path885-9"
+       d="m 43.802206,8.85589 5.10453,1.744637 c 12.33593,11.339534 8.68218,28.437941 1.78256,34.877748 -0.29293,-0.580503 -1.83978,-1.693183 -3.221,-2.180074 -1.56914,-0.553134 -2.37269,-0.677799 -3.53824,-0.93411 l 2.2033,-2.27082 -3.093,-6.674026 4.460031,-4.251888 -3.580031,-1.041857 -1.9488,-11.859542 2.90291,-3.019892 z"
+       style="fill:#4e9a06;stroke:#172a04;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       id="path893-3"
+       style="fill:#172a04;fill-rule:evenodd;stroke:none;stroke-width:3.1406;stroke-linejoin:round"
+       d="m 50.599012,46.348274 a 18.635927,4.8066263 0 0 1 -18.635114,4.806627 18.635927,4.8066263 0 0 1 -18.63674,-4.806207 18.635927,4.8066263 0 0 1 18.633488,-4.807046 18.635927,4.8066263 0 0 1 18.638366,4.805787 l -18.635927,8.39e-4 z" />
+    <g
+       style="stroke-width:1.74;stroke-miterlimit:4;stroke-dasharray:none"
+       transform="matrix(0,0.86206896,-0.86206896,0,67.344826,-17.551723)"
+       id="g3854-5">
+      <path
+         id="path1188"
+         d="m 49.280102,45.477118 3.894437,-2.49597 9.875562,0.01792"
+         style="fill:none;stroke:#8ae234;stroke-width:2.32;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         style="fill:none;stroke:#172a04;stroke-width:1.74;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 53,12 V 70"
+         id="path3795-7-0" />
+      <path
+         id="path1186"
+         d="m 31.329726,42.347204 7.001638,3.160499"
+         style="fill:none;stroke:#8ae234;stroke-width:2.32;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         id="path1192"
+         d="M 57.739914,67.364766 C 61.216844,66.774 66.012849,65.514846 69.830867,62.377482 67.081568,57.497059 66.862351,52.952327 66.207525,49.184154"
+         style="fill:none;stroke:#8ae234;stroke-width:2.32;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         transform="rotate(-90,47.5,25.5)"
+         id="path3865-6"
+         d="m 3,31 c 11.061592,0 24.011437,-3.776507 33.743803,-9.47289"
+         style="fill:none;stroke:#172a04;stroke-width:1.74;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         id="path1190"
+         d="m 65.796627,41.441978 -2.249124,1.405703"
+         style="fill:none;stroke:#8ae234;stroke-width:2.32;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         id="path3865-2-7"
+         d="M 67,67 C 67,49 59,19 47,13"
+         style="fill:none;stroke:#172a04;stroke-width:1.74;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         id="path3865-9-1"
+         d="M 39,66 C 39,55.392064 36.221523,46.520676 33.120728,40.409235"
+         style="fill:none;stroke:#172a04;stroke-width:1.74;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         id="path3865-1-3"
+         d="M 77.357279,36.440254 C 74.380924,26.262227 69.618845,18.273556 67,15"
+         style="fill:none;stroke:#172a04;stroke-width:1.74;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         id="path1182"
+         d="M 67.159078,24.551923 C 65.146235,20.189745 61.546943,15.577884 57.124525,11.900601"
+         style="fill:none;stroke:#172a04;stroke-width:1.74;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         id="path1196"
+         d="m 36.829513,23.909764 3.073697,3.058405 5.428668,-0.932813"
+         style="fill:none;stroke:#8ae234;stroke-width:2.32;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         transform="rotate(-90,47.5,25.5)"
+         id="path3863-0"
+         d="M 7,17 H 57"
+         style="fill:none;stroke:#172a04;stroke-width:1.74;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <path
+       id="path3797-7"
+       d="M 22.483746,42.909878 C 18.566976,31.40229 20.073176,14.363311 27.002326,7.109917"
+       style="fill:none;stroke:#172a04;stroke-width:1.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       id="path3799-3"
+       d="M 21.231536,7.967433 C 9.947255,17.169162 9.055757,33.370682 16.768646,44.649382"
+       style="fill:none;stroke:#172a04;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       id="path1198"
+       d="m 50.93341,30.780036 c -1.300121,0.946668 -4.207503,2.451391 -5.453156,3.07614 l 1.50318,3.240172"
+       style="fill:none;stroke:#8ae234;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       id="path3799-6-6"
+       d="m 43.802206,8.85589 c 10.27626,9.307564 10.8969,24.803586 3.47654,35.723951"
+       style="fill:none;stroke:#172a04;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  </g>
+</svg>

--- a/src/Mod/Mesh/Gui/Resources/icons/Mesh_Segmentation_Best_Fit.svg
+++ b/src/Mod/Mesh/Gui/Resources/icons/Mesh_Segmentation_Best_Fit.svg
@@ -1,0 +1,352 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   width="64px"
+   height="64px"
+   id="svg2784"
+   version="1.1">
+  <title
+     id="title3262">Mesh_Segmentation_Best_Fit</title>
+  <defs
+     id="defs2786">
+    <linearGradient
+       id="linearGradient992">
+      <stop
+         style="stop-color:#4e9a06;stop-opacity:1"
+         offset="0"
+         id="stop988" />
+      <stop
+         style="stop-color:#8ae234;stop-opacity:1"
+         offset="1"
+         id="stop990" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3935">
+      <stop
+         id="stop3937"
+         offset="0"
+         style="stop-color:#8ae234;stop-opacity:1;" />
+      <stop
+         style="stop-color:#4e9a06;stop-opacity:1;"
+         offset="1"
+         id="stop3951" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3919">
+      <stop
+         style="stop-color:#4e9a06;stop-opacity:1;"
+         offset="0"
+         id="stop3921" />
+      <stop
+         style="stop-color:#8ae234;stop-opacity:1;"
+         offset="1"
+         id="stop3923" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3377">
+      <stop
+         id="stop3379"
+         offset="0"
+         style="stop-color:#faff2b;stop-opacity:1;" />
+      <stop
+         id="stop3381"
+         offset="1"
+         style="stop-color:#ffaa00;stop-opacity:1;" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#linearGradient4391"
+       id="radialGradient3692"
+       cx="42.871357"
+       cy="28.42197"
+       fx="42.871357"
+       fy="28.42197"
+       r="19.467436"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.69820836,0.90688615,-0.80234164,0.6177199,36.829014,-29.491992)" />
+    <linearGradient
+       xlink:href="#linearGradient4391"
+       id="linearGradient4397"
+       x1="72.473869"
+       y1="98.785927"
+       x2="99.153984"
+       y2="100.78592"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient4391">
+      <stop
+         style="stop-color:#00ff00;stop-opacity:1;"
+         offset="0"
+         id="stop4393" />
+      <stop
+         style="stop-color:#0f7d0f;stop-opacity:1;"
+         offset="1"
+         id="stop4395" />
+    </linearGradient>
+    <radialGradient
+       r="18.0625"
+       fy="41.625"
+       fx="25.1875"
+       cy="41.625"
+       cx="25.1875"
+       gradientTransform="matrix(1,0,0,0.32526,0,28.08607)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3060"
+       xlink:href="#linearGradient2269" />
+    <linearGradient
+       id="linearGradient2269">
+      <stop
+         offset="0"
+         id="stop2271"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         offset="1"
+         id="stop2273"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient992"
+       id="linearGradient994"
+       x1="55.113289"
+       y1="48.923363"
+       x2="32.31292"
+       y2="61.018528"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.6677666,0,0,1.6677666,-15.21598,-47.013101)" />
+    <radialGradient
+       r="18.0625"
+       fy="41.625"
+       fx="25.1875"
+       cy="41.625"
+       cx="25.1875"
+       gradientTransform="matrix(1.652249,0,0,0.36678256,-9.1383502,41.933993)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3043"
+       xlink:href="#linearGradient2269" />
+    <linearGradient
+       gradientTransform="matrix(0,1.3936145,-1.4377298,0,107.28831,-27.752566)"
+       gradientUnits="userSpaceOnUse"
+       y2="61.018528"
+       x2="32.31292"
+       y1="48.923363"
+       x1="55.113289"
+       id="linearGradient994-7"
+       xlink:href="#linearGradient992" />
+  </defs>
+  <metadata
+     id="metadata2789">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>Mesh_Segmentation_Best_Fit</dc:title>
+        <cc:license
+           rdf:resource="" />
+        <dc:date>05-07-2020</dc:date>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>[bitacovir]</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>FreeCAD LGPL2+</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>FreeCAD</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:identifier />
+        <dc:relation />
+        <dc:subject>
+          <rdf:Bag>
+            <rdf:li>mesh puzzle</rdf:li>
+          </rdf:Bag>
+        </dc:subject>
+        <dc:description />
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title />
+          </cc:Agent>
+        </dc:contributor>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1">
+    <path
+       style="fill:url(#linearGradient994-7);fill-opacity:1;stroke:none;stroke-width:1.96908;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 11.595602,24.626768 V 14.003164 h 15.414743 c -2.936799,-5.8600153 0.683838,-9.0591699 4.304267,-9.1339435 3.53229,-0.072958 7.064382,2.8281982 4.506011,9.1339375 l 15.334492,6e-6 0.585054,12.868717 C 34.387514,19.586821 34.893283,43.540235 51.155115,38.113154 l 0.585265,10.949692 -13.705055,5e-6 c 2.630327,5.868786 -2.98174,12.044107 -6.591852,12.060921 -3.676872,0.01712 -6.629614,-6.231481 -3.782161,-12.060919 l -15.334487,-7e-6 -0.731223,-7.517654 c 13.27014,-0.594873 23.059498,-15.398463 0,-16.918424 z"
+       id="path939-6" />
+    <ellipse
+       ry="6.625"
+       rx="29.843748"
+       cy="57.201294"
+       cx="32.477673"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.267045;fill:url(#radialGradient3043);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.36498;stroke-miterlimit:4;stroke-dasharray:none;marker:none"
+       id="path2267" />
+    <g
+       id="g1076"
+       style="stroke:#8ae234">
+      <path
+         id="path1002-0"
+         d="M 36.989997,32.044279 C 36.924371,28.11643 41.426417,20.318984 50.37183,23.749952"
+         style="fill:none;stroke:#8ae234;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <g
+         id="g1045"
+         style="stroke:#8ae234">
+        <path
+           style="fill:none;stroke:#8ae234;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="M 35.540779,16.979423 H 49.778183 V 25.01297"
+           id="path1019" />
+        <path
+           id="path1002"
+           d="m 31.981427,4.9962743 c 3.358087,0.016431 7.02494,3.5962077 2.598172,9.1058957"
+           style="fill:none;stroke:#8ae234;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <path
+           style="fill:none;stroke:#8ae234;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m 34.918842,13.684159 c -1.070225,1.164661 -0.425628,3.465351 1.70586,3.337145"
+           id="path1021" />
+      </g>
+    </g>
+    <g
+       id="g1076-9"
+       transform="matrix(-1,0,0,1,63.962854,0)"
+       style="stroke:#8ae234">
+      <path
+         style="fill:none;stroke:#8ae234;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 36.989997,32.044279 C 36.924371,28.11643 41.426417,20.318984 50.37183,23.749952"
+         id="path1002-0-0" />
+      <g
+         id="g1045-5"
+         style="stroke:#8ae234">
+        <path
+           id="path1019-4"
+           d="M 35.540779,16.979423 H 49.778183 V 25.01297"
+           style="fill:none;stroke:#8ae234;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <path
+           style="fill:none;stroke:#8ae234;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m 31.981427,4.9962743 c 3.358087,0.016431 7.02494,3.5962077 2.598172,9.1058957"
+           id="path1002-7" />
+        <path
+           id="path1021-2"
+           d="m 34.918842,13.684159 c -1.070225,1.164661 -0.425628,3.465351 1.70586,3.337145"
+           style="fill:none;stroke:#8ae234;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      </g>
+    </g>
+    <g
+       id="g1076-0"
+       transform="matrix(1,0,0,-1,0,64.088558)"
+       style="stroke:#8ae234">
+      <path
+         style="fill:none;stroke:#8ae234;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 36.989997,32.044279 C 36.924371,28.11643 41.426417,20.318984 50.37183,23.749952"
+         id="path1002-0-7" />
+      <g
+         id="g1045-4"
+         style="stroke:#8ae234">
+        <path
+           id="path1019-0"
+           d="M 35.540779,16.979423 H 49.778183 V 25.01297"
+           style="fill:none;stroke:#8ae234;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <path
+           style="fill:none;stroke:#8ae234;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m 31.981427,4.9962743 c 3.358087,0.016431 7.02494,3.5962077 2.598172,9.1058957"
+           id="path1002-9" />
+        <path
+           id="path1021-8"
+           d="m 34.918842,13.684159 c -1.070225,1.164661 -0.425628,3.465351 1.70586,3.337145"
+           style="fill:none;stroke:#8ae234;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      </g>
+    </g>
+    <g
+       id="g1076-4"
+       transform="rotate(180,31.981427,32.044279)"
+       style="stroke:#8ae234">
+      <path
+         style="fill:none;stroke:#8ae234;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 36.989997,32.044279 C 36.924371,28.11643 41.426417,20.318984 50.37183,23.749952"
+         id="path1002-0-4" />
+      <g
+         id="g1045-6"
+         style="stroke:#8ae234">
+        <path
+           id="path1019-40"
+           d="M 35.540779,16.979423 H 49.778183 V 25.01297"
+           style="fill:none;stroke:#8ae234;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+        <path
+           style="fill:none;stroke:#8ae234;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="m 31.981427,4.9962743 c 3.358087,0.016431 7.02494,3.5962077 2.598172,9.1058957"
+           id="path1002-96" />
+        <path
+           id="path1021-7"
+           d="m 34.918842,13.684159 c -1.070225,1.164661 -0.425628,3.465351 1.70586,3.337145"
+           style="fill:none;stroke:#8ae234;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      </g>
+    </g>
+    <path
+       id="path948-5"
+       style="fill:none;fill-opacity:1;stroke:#172a04;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 32.033602,2.9841088 C 27.723004,2.8150631 22.302292,7.8125174 27.661524,15.045123 l -15.334488,7e-6 v 11.826751 c 6.95017,-5.300119 12.750656,0.70187 12.710066,5.20564" />
+    <path
+       d="m 32.033603,2.9841088 c 4.257867,0.09461 9.73131,4.8284082 4.372078,12.0610142 l 15.334488,7e-6 v 11.826751 c -6.95017,-5.300119 -12.750656,0.70187 -12.710066,5.205639"
+       style="fill:none;fill-opacity:1;stroke:#172a04;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path948" />
+    <path
+       id="path948-0"
+       style="fill:none;fill-opacity:1;stroke:#172a04;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 32.033814,61.123867 c 4.363872,0 9.73131,-4.828409 4.372079,-12.061015 l 15.334487,-6e-6 V 37.236095 c -6.95017,5.300119 -12.750656,-0.70187 -12.710066,-5.20564" />
+    <path
+       d="m 32.033391,61.123868 c -4.363329,0.248138 -9.73131,-4.828409 -4.372079,-12.061015 l -15.334487,-7e-6 v -11.82675 c 6.95017,5.300119 12.750656,-0.701871 12.710066,-5.205641"
+       style="fill:none;fill-opacity:1;stroke:#172a04;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path948-0-3" />
+    <path
+       style="fill:none;stroke:#172a04;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 12.326825,49.062846 19.628237,-6.66702 19.785318,6.66702"
+       id="path1538" />
+    <path
+       style="fill:none;stroke:#172a04;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 27.661312,49.062853 4.29375,-6.667027 4.450831,6.667026"
+       id="path1542" />
+    <path
+       id="path1538-0"
+       d="m 51.740169,15.04513 -19.686198,6.9357 -19.726935,-6.9357"
+       style="fill:none;stroke:#172a04;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       id="path1542-5"
+       d="M 36.405681,15.045123 32.053972,21.98083 27.661524,15.045123"
+       style="fill:none;stroke:#172a04;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       style="fill:none;stroke:#172a04;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 32.053972,21.98083 -0.09891,20.414996"
+       id="path1565" />
+    <path
+       style="fill:none;stroke:#172a04;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 32.060525,31.955063 44.536487,24.905834"
+       id="path1567" />
+    <path
+       style="fill:none;stroke:#172a04;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 32.060525,31.955063 19.183437,24.777616"
+       id="path1571" />
+    <path
+       style="fill:none;stroke:#172a04;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 44.806008,39.373889 32.060525,31.955063 20.068017,39.150503"
+       id="path1569" />
+    <path
+       style="fill:none;stroke:#172a04;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 46.305057,39.310995 31.955062,42.395826 17.762147,39.310996"
+       id="path1540" />
+    <path
+       id="path1540-7"
+       d="M 17.762359,24.796981 32.053972,21.98083 46.304846,24.796981"
+       style="fill:none;stroke:#172a04;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  </g>
+</svg>

--- a/src/Mod/Mesh/Gui/Resources/icons/Mesh_Smoothing.svg
+++ b/src/Mod/Mesh/Gui/Resources/icons/Mesh_Smoothing.svg
@@ -1,0 +1,254 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   version="1.1"
+   id="svg2784"
+   height="64px"
+   width="64px">
+  <title
+     id="title3262">Mesh_Smoothing</title>
+  <defs
+     id="defs2786">
+    <linearGradient
+       id="linearGradient920">
+      <stop
+         id="stop916"
+         offset="0"
+         style="stop-color:#4e9a06;stop-opacity:1" />
+      <stop
+         id="stop918"
+         offset="1"
+         style="stop-color:#4e9a06;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient879">
+      <stop
+         id="stop875"
+         offset="0"
+         style="stop-color:#4e9a06;stop-opacity:1" />
+      <stop
+         id="stop877"
+         offset="1"
+         style="stop-color:#8ae234;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3935">
+      <stop
+         style="stop-color:#8ae234;stop-opacity:1;"
+         offset="0"
+         id="stop3937" />
+      <stop
+         id="stop3951"
+         offset="1"
+         style="stop-color:#4e9a06;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3919">
+      <stop
+         id="stop3921"
+         offset="0"
+         style="stop-color:#4e9a06;stop-opacity:1;" />
+      <stop
+         id="stop3923"
+         offset="1"
+         style="stop-color:#8ae234;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3377">
+      <stop
+         style="stop-color:#faff2b;stop-opacity:1;"
+         offset="0"
+         id="stop3379" />
+      <stop
+         style="stop-color:#ffaa00;stop-opacity:1;"
+         offset="1"
+         id="stop3381" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(0.69820836,0.90688615,-0.80234164,0.6177199,36.829014,-29.491992)"
+       gradientUnits="userSpaceOnUse"
+       r="19.467436"
+       fy="28.42197"
+       fx="42.871357"
+       cy="28.42197"
+       cx="42.871357"
+       id="radialGradient3692"
+       xlink:href="#linearGradient4391" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="100.78592"
+       x2="99.153984"
+       y1="98.785927"
+       x1="72.473869"
+       id="linearGradient4397"
+       xlink:href="#linearGradient4391" />
+    <linearGradient
+       id="linearGradient4391">
+      <stop
+         id="stop4393"
+         offset="0"
+         style="stop-color:#00ff00;stop-opacity:1;" />
+      <stop
+         id="stop4395"
+         offset="1"
+         style="stop-color:#0f7d0f;stop-opacity:1;" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#linearGradient2269"
+       id="radialGradient3060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.32526,0,28.08607)"
+       cx="25.1875"
+       cy="41.625"
+       fx="25.1875"
+       fy="41.625"
+       r="18.0625" />
+    <linearGradient
+       id="linearGradient2269">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         id="stop2271"
+         offset="0" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         id="stop2273"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#linearGradient2269"
+       id="radialGradient3042"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99000492,0.01464491,-0.00224111,0.32524342,0.34503629,27.717891)"
+       cx="25.1875"
+       cy="41.625"
+       fx="25.1875"
+       fy="41.625"
+       r="18.0625" />
+    <linearGradient
+       gradientTransform="translate(-70,-3.1693557)"
+       gradientUnits="userSpaceOnUse"
+       y2="16"
+       x2="85"
+       y1="48"
+       x1="114"
+       id="linearGradient881"
+       xlink:href="#linearGradient879" />
+    <radialGradient
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.73786708,-1.1428001,0.62917489,0.46786298,-1.2023177,24.495914)"
+       r="10.454545"
+       fy="19.289801"
+       fx="10.691192"
+       cy="19.289801"
+       cx="10.691192"
+       id="radialGradient3982"
+       xlink:href="#linearGradient3976" />
+    <linearGradient
+       id="linearGradient3976">
+      <stop
+         id="stop3978"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="stop3980"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <radialGradient
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.5858277,0.12704705,-0.05201727,0.64929042,-19.590582,-10.036784)"
+       r="5.5"
+       fy="26.030619"
+       fx="36.08353"
+       cy="26.030619"
+       cx="36.08353"
+       id="radialGradient922"
+       xlink:href="#linearGradient920" />
+  </defs>
+  <metadata
+     id="metadata2789">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>Mesh_Smoothing</dc:title>
+        <cc:license
+           rdf:resource="" />
+        <dc:date>20-06-2020</dc:date>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>[bitacovir]</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>FreeCAD LGPL2+</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>FreeCAD</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:identifier />
+        <dc:relation />
+        <dc:subject>
+          <rdf:Bag>
+            <rdf:li>mesh</rdf:li>
+            <rdf:li>apple</rdf:li>
+            <rdf:li>smooth</rdf:li>
+          </rdf:Bag>
+        </dc:subject>
+        <dc:description>Green smooth apple, lit from top</dc:description>
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title />
+          </cc:Agent>
+        </dc:contributor>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1">
+    <ellipse
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.267045;fill:url(#radialGradient3042);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none"
+       transform="matrix(1.652249,0,0,1.1276596,-7.6160217,8.436169)"
+       id="path2267"
+       cx="25.1875"
+       cy="41.625"
+       rx="18.0625"
+       ry="5.875" />
+    <path
+       id="path869"
+       d="M 30,6.8306443 C 14.015326,5.1225635 6,15 6,26.830644 6,47 21,57 32,56.830644 c 10.84507,0.01318 26,-10 26,-28 C 57.84648,18.269726 53.99654,9.0084543 30,6.8306443 Z"
+       style="fill:url(#linearGradient881);fill-opacity:1;stroke:#172a04;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.844828;fill:url(#radialGradient3982);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:4.35519;marker:none;enable-background:accumulate"
+       id="path3608"
+       d="M 26.805381,9.2769314 A 12.201916,13.864714 26.595265 1 1 12.338232,32.898949 12.201916,13.864714 26.595265 1 1 26.805381,9.2769314 Z" />
+    <path
+       transform="rotate(8.4842316)"
+       d="m 44.893475,9.7913542 a 8.75,2.9166667 0 0 1 -8.749619,2.9166668 8.75,2.9166667 0 0 1 -8.750381,-2.9164123 8.75,2.9166667 0 0 1 8.748854,-2.9169212 8.75,2.9166667 0 0 1 8.751145,2.9161577 l -8.749999,5.09e-4 z"
+       id="path914"
+       style="fill:url(#radialGradient922);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3.88889;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none" />
+    <path
+       id="path871"
+       d="m 26.881404,15.477988 c 5.04137,2.776079 10.624598,3.355967 13.386338,2.08131"
+       style="fill:none;stroke:#172a04;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       style="fill:none;fill-opacity:1;stroke:#8ae234;stroke-width:1.99105;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 30.104676,8.8393062 C 15.422195,7.2703748 8.0598394,16.343145 8.0598394,27.210004 c 0,18.526256 13.7780226,27.711603 23.8819056,27.556045 9.96158,0.0121 23.881908,-9.185349 23.881908,-25.718977 C 55.682647,19.346501 52.146338,10.839701 30.104676,8.8393062 Z"
+       id="path869-1" />
+    <path
+       id="path873"
+       d="M 33,17 C 34.73848,7.1959373 39.98429,2.8288018 49,3 V 7 C 33.39517,7.040832 35.7379,12.381093 33,17 Z"
+       style="fill:#4e9a06;stroke:#172a04;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  </g>
+</svg>

--- a/src/Mod/Mesh/Gui/Resources/icons/Mesh_Trim_by_Plane.svg
+++ b/src/Mod/Mesh/Gui/Resources/icons/Mesh_Trim_by_Plane.svg
@@ -1,0 +1,357 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   version="1.1"
+   id="svg2860"
+   height="64px"
+   width="64px">
+  <title
+     id="title1134">Mesh_ Trim_by_Plane</title>
+  <defs
+     id="defs2862">
+    <linearGradient
+       id="linearGradient4009">
+      <stop
+         id="stop4011"
+         offset="0"
+         style="stop-color:#4e9a06;stop-opacity:1" />
+      <stop
+         id="stop4013"
+         offset="1"
+         style="stop-color:#8ae234;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4001">
+      <stop
+         id="stop4003"
+         offset="0"
+         style="stop-color:#4e9a06;stop-opacity:1" />
+      <stop
+         id="stop4005"
+         offset="1"
+         style="stop-color:#8ae234;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4072">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop4074" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop4076" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3864">
+      <stop
+         id="stop3866"
+         offset="0"
+         style="stop-color:#ff0000;stop-opacity:1;" />
+      <stop
+         id="stop3868"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3377">
+      <stop
+         style="stop-color:#71b2f8;stop-opacity:1;"
+         offset="0"
+         id="stop3379" />
+      <stop
+         style="stop-color:#002795;stop-opacity:1;"
+         offset="1"
+         id="stop3381" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3377-7">
+      <stop
+         id="stop3379-7"
+         offset="0"
+         style="stop-color:#71b2f8;stop-opacity:1;" />
+      <stop
+         id="stop3381-9"
+         offset="1"
+         style="stop-color:#002795;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="39.259701"
+       x2="46.087074"
+       y1="39.259701"
+       x1="2.4857161"
+       id="linearGradient4082"
+       xlink:href="#linearGradient3377" />
+    <linearGradient
+       id="linearGradient3377-73">
+      <stop
+         style="stop-color:#71b2f8;stop-opacity:1;"
+         offset="0"
+         id="stop3379-3" />
+      <stop
+         style="stop-color:#002795;stop-opacity:1;"
+         offset="1"
+         id="stop3381-96" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4112">
+      <stop
+         style="stop-color:#71b2f8;stop-opacity:1;"
+         offset="0"
+         id="stop4114" />
+      <stop
+         style="stop-color:#002795;stop-opacity:1;"
+         offset="1"
+         id="stop4116" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4119">
+      <stop
+         style="stop-color:#71b2f8;stop-opacity:1;"
+         offset="0"
+         id="stop4121" />
+      <stop
+         style="stop-color:#002795;stop-opacity:1;"
+         offset="1"
+         id="stop4123" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4126">
+      <stop
+         style="stop-color:#71b2f8;stop-opacity:1;"
+         offset="0"
+         id="stop4128" />
+      <stop
+         style="stop-color:#002795;stop-opacity:1;"
+         offset="1"
+         id="stop4130" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4133">
+      <stop
+         style="stop-color:#71b2f8;stop-opacity:1;"
+         offset="0"
+         id="stop4135" />
+      <stop
+         style="stop-color:#002795;stop-opacity:1;"
+         offset="1"
+         id="stop4137" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4140">
+      <stop
+         style="stop-color:#71b2f8;stop-opacity:1;"
+         offset="0"
+         id="stop4142" />
+      <stop
+         style="stop-color:#002795;stop-opacity:1;"
+         offset="1"
+         id="stop4144" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1.3367742,0,0,1.3462145,-0.83476916,-19.403123)"
+       y2="39.259701"
+       x2="46.087074"
+       y1="39.259701"
+       x1="2.4857161"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4094-0"
+       xlink:href="#linearGradient3377-73" />
+    <linearGradient
+       id="linearGradient4147">
+      <stop
+         style="stop-color:#71b2f8;stop-opacity:1;"
+         offset="0"
+         id="stop4149" />
+      <stop
+         style="stop-color:#002795;stop-opacity:1;"
+         offset="1"
+         id="stop4151" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="23.8043"
+       x2="15.368849"
+       y1="52.195702"
+       x1="19.766397"
+       id="linearGradient4007"
+       xlink:href="#linearGradient4001" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="26.591185"
+       x2="33.639343"
+       y1="49.757175"
+       x1="38.450821"
+       id="linearGradient4015"
+       xlink:href="#linearGradient4009" />
+  </defs>
+  <metadata
+     id="metadata2865">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>Mesh_ Trim_by_Plane</dc:title>
+        <cc:license
+           rdf:resource="http://creativecommons.org/licenses/by/4.0/" />
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>[bitacovir]</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:title>Arch_CutPlane</dc:title>
+        <dc:date>24-06-2020</dc:date>
+        <dc:relation />
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>FreeCAD</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:identifier />
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>FreeCAD LGPL2+</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title>Based on a wood galaxy's design</dc:title>
+          </cc:Agent>
+        </dc:contributor>
+        <dc:subject>
+          <rdf:Bag>
+            <rdf:li>mesh</rdf:li>
+            <rdf:li>red plane</rdf:li>
+          </rdf:Bag>
+        </dc:subject>
+        <dc:description>Mesh, trimmed with a plane</dc:description>
+      </cc:Work>
+      <cc:License
+         rdf:about="http://creativecommons.org/licenses/by/4.0/">
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Reproduction" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Distribution" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Notice" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Attribution" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#DerivativeWorks" />
+      </cc:License>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1">
+    <g
+       transform="translate(-8,6)"
+       id="g3950">
+      <path
+         style="fill:#cc0000;stroke:#280000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 57,7 17,1 v 48 l 40,6 z"
+         id="path3854" />
+      <path
+         style="fill:none;stroke:#ef2929;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 55,8.68 19.021773,3.3701333 V 47.211137 l 36,5.484047 z"
+         id="path3854-6" />
+    </g>
+    <g
+       style="stroke:#172a04;stroke-width:6;stroke-miterlimit:4;stroke-dasharray:none"
+       id="g4070-3">
+      <path
+         style="fill:none;stroke:#172a04;stroke-width:6;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:2, 8;stroke-dashoffset:6.8;stroke-opacity:1"
+         d="M 17,17 41,9 59,13 41,21 Z"
+         id="path4017-2-6" />
+      <path
+         style="fill:none;stroke:#172a04;stroke-width:6;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:2, 8;stroke-dashoffset:6.8;stroke-opacity:1"
+         d="M 41,21 59,13 V 43 L 41,51 Z"
+         id="path4019-7-0" />
+      <path
+         style="fill:none;stroke:#172a04;stroke-width:6;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:2, 8;stroke-dashoffset:6.8;stroke-opacity:1"
+         d="m 17,47 24,-8 18,4"
+         id="path4017-2-9-6" />
+    </g>
+    <g
+       id="g1157">
+      <g
+         id="g1148">
+        <path
+           id="path4017-2"
+           d="M 17,17 41,9 59,13 41,21 Z"
+           style="fill:none;stroke:#8ae234;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:2, 8;stroke-dashoffset:6.8;stroke-opacity:1" />
+      </g>
+      <g
+         id="g1151">
+        <path
+           id="path4019-7"
+           d="M 41,21 59,13 V 43 L 41,51 Z"
+           style="fill:none;stroke:#8ae234;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:2, 8;stroke-dashoffset:6.8;stroke-opacity:1" />
+      </g>
+    </g>
+    <path
+       id="path4017-2-9"
+       d="m 17,47 24,-8 18,4"
+       style="fill:none;stroke:#8ae234;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:2, 8;stroke-dashoffset:6.8;stroke-opacity:1" />
+    <g
+       style="opacity:0.6"
+       transform="translate(-8,6)"
+       id="g3950-2">
+      <path
+         style="fill:#cc0000;stroke:#280000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 57,7 17,1 v 48 l 40,6 z"
+         id="path3854-61" />
+      <path
+         style="fill:none;stroke:#ef2929;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 55,8.68 19.021773,3.3701333 V 47.211137 l 36,5.484047 z"
+         id="path3854-6-8" />
+    </g>
+    <path
+       id="path3044"
+       d="m 3,21 v 30 l 26,4 V 25 Z"
+       style="fill:url(#linearGradient4007);fill-opacity:1;stroke:#172a04;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1" />
+    <path
+       id="path3832"
+       d="m 3,21 14,-4 24,4 -12,4 z"
+       style="fill:#8ae234;stroke:#172a04;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1" />
+    <path
+       id="path3852"
+       d="M 29,25 V 55 L 41,51 V 21 Z"
+       style="fill:url(#linearGradient4015);fill-opacity:1;stroke:#172a04;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       id="path3997"
+       d="M 4.9846045,23.354097 5.030791,49.246328 27,52.645903 26.984604,26.738276 Z"
+       style="fill:none;stroke:#8ae234;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       id="path3999"
+       d="m 30.976418,26.471657 0.0075,25.765208 8.014631,-2.625294 0.02615,-25.872258 z"
+       style="fill:none;stroke:#8ae234;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       id="path1159"
+       d="M 3,21 29,55 41,21"
+       style="fill:none;stroke:#172a04;stroke-width:1.5;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       id="path1161"
+       d="m 17,17 12,8"
+       style="fill:none;stroke:#172a04;stroke-width:1.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       id="path1163"
+       d="M 21,45 3,51"
+       style="fill:#172a04;stroke:#172a04;stroke-width:1.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       id="path1165"
+       d="M 15,37 28,25"
+       style="fill:none;stroke:#172a04;stroke-width:1.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       id="path1167"
+       d="m 29,25 6,12"
+       style="fill:none;stroke:#172a04;stroke-width:1.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  </g>
+</svg>

--- a/src/Mod/Mesh/Gui/Resources/icons/Mesh_Union.svg
+++ b/src/Mod/Mesh/Gui/Resources/icons/Mesh_Union.svg
@@ -1,0 +1,286 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   version="1.1"
+   id="svg2568"
+   height="64px"
+   width="64px">
+  <title
+     id="title880">Mesh_Union</title>
+  <defs
+     id="defs2570">
+    <linearGradient
+       id="linearGradient1610">
+      <stop
+         style="stop-color:#4e9a06;stop-opacity:1"
+         offset="0"
+         id="stop1606" />
+      <stop
+         style="stop-color:#4e9a06;stop-opacity:0"
+         offset="1"
+         id="stop1608" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient1518">
+      <stop
+         style="stop-color:#8ae234;stop-opacity:1"
+         offset="0"
+         id="stop1514" />
+      <stop
+         style="stop-color:#4e9a06;stop-opacity:1"
+         offset="1"
+         id="stop1516" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3805">
+      <stop
+         id="stop3807"
+         offset="0"
+         style="stop-color:#3465a4;stop-opacity:1;" />
+      <stop
+         id="stop3809"
+         offset="1"
+         style="stop-color:#3465a4;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3864">
+      <stop
+         style="stop-color:#71b2f8;stop-opacity:1;"
+         offset="0"
+         id="stop3866" />
+      <stop
+         style="stop-color:#002795;stop-opacity:1;"
+         offset="1"
+         id="stop3868" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3593">
+      <stop
+         id="stop3595"
+         offset="0"
+         style="stop-color:#c8e0f9;stop-opacity:1;" />
+      <stop
+         id="stop3597"
+         offset="1"
+         style="stop-color:#637dca;stop-opacity:1;" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(1.1486088,1.8477617,-3.056673,1.900094,73.257745,-112.1016)"
+       xlink:href="#linearGradient3143"
+       id="radialGradient3090"
+       gradientUnits="userSpaceOnUse"
+       cx="46.534134"
+       cy="26.281744"
+       fx="46.534134"
+       fy="26.281744"
+       r="19.571428" />
+    <linearGradient
+       id="linearGradient3143">
+      <stop
+         id="stop3145"
+         offset="0"
+         style="stop-color:#729fcf;stop-opacity:1" />
+      <stop
+         id="stop3147"
+         offset="1"
+         style="stop-color:#3465a4;stop-opacity:1" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#linearGradient3143-7"
+       id="radialGradient3165"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.63294029,0.93089132,-0.82695376,0.56227002,38.653022,-34.275496)"
+       cx="48.645836"
+       cy="25.149042"
+       fx="48.645836"
+       fy="25.149042"
+       r="19.571428" />
+    <linearGradient
+       id="linearGradient3143-7">
+      <stop
+         id="stop3145-0"
+         offset="0"
+         style="stop-color:#729fcf;stop-opacity:1" />
+      <stop
+         id="stop3147-9"
+         offset="1"
+         style="stop-color:#204a87;stop-opacity:1" />
+    </linearGradient>
+    <radialGradient
+       r="19.571428"
+       fy="26.281744"
+       fx="46.534134"
+       cy="26.281744"
+       cx="46.534134"
+       gradientTransform="matrix(1.1751823,1.8905104,-3.1273904,1.9440534,60.507183,-124.06637)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3023"
+       xlink:href="#linearGradient1518" />
+    <radialGradient
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22188004,-0.16641004,0.69230766,0.92307688,55.253687,-1.536415)"
+       r="13"
+       fy="32.826664"
+       fx="22.625563"
+       cy="32.826664"
+       cx="22.625563"
+       id="radialGradient3811"
+       xlink:href="#linearGradient3805" />
+    <radialGradient
+       xlink:href="#linearGradient3805"
+       id="radialGradient3811-8"
+       cx="22.625563"
+       cy="32.826664"
+       fx="22.625563"
+       fy="32.826664"
+       r="13"
+       gradientTransform="matrix(0.22188004,-0.16641004,0.69230766,0.92307688,-15.69073,-12.978501)"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       r="13"
+       fy="32.826664"
+       fx="22.625563"
+       cy="32.826664"
+       cx="22.625563"
+       gradientTransform="matrix(0.22188004,-0.16641004,0.69230766,0.92307688,4.253688,7.463585)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient1604"
+       xlink:href="#linearGradient1610" />
+  </defs>
+  <metadata
+     id="metadata2573">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>Mesh_Union</dc:title>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>[bitacovir]</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:title>Part_Fuse</dc:title>
+        <dc:date>10-07-2020</dc:date>
+        <dc:relation />
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>FreeCAD</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:identifier />
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>FreeCAD LGPL2+</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <cc:license>https://www.gnu.org/copyleft/lesser.html</cc:license>
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title />
+          </cc:Agent>
+        </dc:contributor>
+        <dc:subject>
+          <rdf:Bag>
+            <rdf:li>sphere</rdf:li>
+            <rdf:li>mesh</rdf:li>
+          </rdf:Bag>
+        </dc:subject>
+        <dc:description>Union of two spheres </dc:description>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1">
+    <path
+       id="path3550-3"
+       d="M 40,7 C 31.223986,7 23.839523,12.945441 21.65625,21.03125 11.323305,21.217406 3,29.622594 3,40 3,50.49401 11.50599,59 22,59 30.776014,59 38.160477,53.054559 40.34375,44.96875 50.676695,44.782594 59,36.377406 59,26 59,15.50599 50.49401,7 40,7 Z"
+       style="display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient3023);fill-opacity:1;fill-rule:evenodd;stroke:#172a04;stroke-width:1.99783;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+    <path
+       id="path3550-3-1"
+       d="M 40,9 C 31.610943,9 24.671219,15.071076 23.28125,23.0625 22.859709,23.031199 22.429541,23 22,23 12.610558,23 5,30.61056 5,40 5,49.38944 12.610558,57 22,57 30.389057,57 37.328781,50.928924 38.71875,42.9375 39.140291,42.968801 39.570459,43 40,43 49.389442,43 57,35.38944 57,26 57,16.61056 49.389442,9 40,9 Z"
+       style="display:inline;overflow:visible;visibility:visible;fill:none;stroke:#8ae234;stroke-width:1.99783;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+    <path
+       style="fill:none;stroke:url(#radialGradient1604);stroke-width:10;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 22,25 c 5.79937,2.615469 10.296259,7.638903 16,20"
+       id="path3027-7" />
+    <path
+       id="path1612"
+       d="M 21.449126,21 V 59"
+       style="fill:none;stroke:#172a04;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       style="fill:none;stroke:#172a04;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 40,7.1379958 V 44"
+       id="path1612-8" />
+    <path
+       id="path1666"
+       d="m 6,30 c 6.685576,-0.303071 13.544891,-1.990312 18,-7"
+       style="fill:none;stroke:#172a04;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       style="fill:none;stroke:#172a04;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 24,23 C 32.041999,23.819546 43.574012,14.573931 46,8"
+       id="path1666-8" />
+    <path
+       style="fill:none;stroke:#172a04;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 3,40 c 7.634126,1.61084 22.103541,-4.845387 25,-13"
+       id="path1666-9" />
+    <path
+       id="path1666-9-8"
+       d="M 5.2432767,48.962573 C 12.877403,50.573413 28.972546,42.92187 31.869005,34.767257"
+       style="fill:none;stroke:#172a04;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       id="path1666-9-3"
+       d="m 12,56 c 7.634126,1.61084 22.51564,-6.586408 25.412099,-14.741021"
+       style="fill:none;stroke:#172a04;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       id="path1666-8-7"
+       d="m 27,28 c 8.860049,1.64066 23.32232,-9.674959 25,-17"
+       style="fill:none;stroke:#172a04;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       style="fill:none;stroke:#172a04;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 32,35.000001 C 40.860049,36.640661 55.32232,25.325042 57,18"
+       id="path1666-8-7-4" />
+    <path
+       style="fill:none;stroke:#172a04;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 37.711867,41.465732 c 8.860049,1.64066 19.516885,-8.889234 21.194565,-16.214276"
+       id="path1666-8-7-7" />
+    <path
+       id="path1755"
+       d="M 21,21 C 10.388622,35.462386 13.012367,50.414809 21,59"
+       style="fill:none;stroke:#172a04;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       style="fill:none;stroke:#172a04;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 17,22 C 2.0819547,34.839537 6.6865408,49.123186 18.850291,58.73801"
+       id="path1755-6" />
+    <path
+       style="fill:none;stroke:#172a04;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 41,7 c 10.611378,14.462387 7.987633,29.41481 0,38.000001"
+       id="path1755-1" />
+    <path
+       id="path1755-6-6"
+       d="M 45,8 C 59.918045,20.839537 55.538022,34.861195 43.374272,44.476019"
+       style="fill:none;stroke:#172a04;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       style="fill:none;stroke:#172a04;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 39,7 c -7.770727,9.523591 -7.482046,20.457596 -4.128543,32.601137"
+       id="path1755-4" />
+    <path
+       id="path1755-6-8"
+       d="M 38,7 C 38.161702,7.4705367 24.68997,11.341878 28,27"
+       style="fill:none;stroke:#172a04;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       id="path1755-1-8"
+       d="m 28,27 c 2.451397,10.476922 -0.439741,25.781401 -7,32"
+       style="fill:none;stroke:#172a04;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       style="fill:none;stroke:#172a04;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 34.854442,39.10586 C 37.081579,53.410297 24,57 22,59"
+       id="path1755-6-6-6" />
+  </g>
+</svg>


### PR DESCRIPTION
Many Mesh Design Workbench commands do not have icons for the FreeCAD UI.

This commit adds SVG files with icons for these commands. Also, it makes the necessary changes on Command.cpp and Mesh.qrc files.

The new SVG icons follow the FreeCAD Artwork Guidelines and were saved as Plain SVG format.

The icon designs keep the style of the existing icons in the Mesh Workbench:
https://wiki.freecadweb.org/Mesh_Workbench

The discussion with the project for a set of SVG icons for the Mesh Design Workbench can be found in the UX/UI Design FreeCAD Forum:
https://forum.freecadweb.org/viewtopic.php?f=34&t=47494