### PR TITLE
Mesh: correct display of bounding box values in the task panel

### DIFF
--- a/src/Mod/Mesh/Gui/Workbench.cpp
+++ b/src/Mod/Mesh/Gui/Workbench.cpp
@@ -120,9 +120,9 @@ public:
             numPoints->setText(QString::number(countPoints));
             numFacets->setText(QString::number(countFacets));
             numMin->setText(QString::fromLatin1("X: %1\tY: %2\tZ: %3")
-                .arg(bbox.MinX).arg(bbox.MinX).arg(bbox.MinX));
+                .arg(bbox.MinX).arg(bbox.MinY).arg(bbox.MinZ));
             numMax->setText(QString::fromLatin1("X: %1\tY: %2\tZ: %3")
-                .arg(bbox.MaxX).arg(bbox.MaxX).arg(bbox.MaxX));
+                .arg(bbox.MaxX).arg(bbox.MaxY).arg(bbox.MaxZ));
         }
         else {
             numPoints->setText(QString::fromLatin1(""));


### PR DESCRIPTION
The task panel displays incorrectly the bounding box values because it only takes the values from the X component. This fixes the display by taking the components from Y and Z as well.

Reported in the forum: [[ Bug ] Mesh WB: Wrong BoundBox in task panel.](https://forum.freecadweb.org/viewtopic.php?f=3&t=48178)

---

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists