### PR TITLE
Fix Curve2d.toshape producing bad BSpline curves over periodic surfaces

### DIFF
--- a/src/Mod/Part/App/Geom2d/Curve2dPyImp.cpp
+++ b/src/Mod/Part/App/Geom2d/Curve2dPyImp.cpp
@@ -166,16 +166,9 @@ TopoDS_Edge create3dCurve(const TopoDS_Edge& edge)
                                                 adapt_curve.LastParameter());
             edge3d =  mkBuilder3d.Edge();
         } break;
-    case GeomAbs_BSplineCurve:
-        {
-            BRepBuilderAPI_MakeEdge mkBuilder3d(adapt_curve.BSpline(),
-                                                adapt_curve.FirstParameter(),
-                                                adapt_curve.LastParameter());
-            edge3d =  mkBuilder3d.Edge();
-        } break;
     default:
         edge3d = edge;
-        BRepLib::BuildCurves3d(edge3d);
+        BRepLib::BuildCurves3d(edge3d, 1e-7, GeomAbs_Shape::GeomAbs_C2, 14, 10000);
         break;
     }
 

--- a/src/Mod/Part/App/Geom2d/Curve2dPyImp.cpp
+++ b/src/Mod/Part/App/Geom2d/Curve2dPyImp.cpp
@@ -168,7 +168,7 @@ TopoDS_Edge create3dCurve(const TopoDS_Edge& edge)
         } break;
     default:
         edge3d = edge;
-        BRepLib::BuildCurves3d(edge3d, 1e-7, GeomAbs_Shape::GeomAbs_C2, 14, 10000);
+        BRepLib::BuildCurves3d(edge3d, Precision::Confusion(), GeomAbs_Shape::GeomAbs_C1, 14, 10000);
         break;
     }
 


### PR DESCRIPTION
Example code : 
`import FreeCAD
import Part
vec2 = FreeCAD.Base.Vector2d

line = Part.Geom2d.Line2dSegment(vec2(),vec2(500,100))
edge1 = line.toShape(Part.Cylinder())
Part.show(edge1)
`
The default parameters of BuildCurves3d are :  
BRepLib::BuildCurves3d(shape, Tolerance=1e-5, Continuity=GeomAbs_Shape::GeomAbs_C1, MaxDegree=14, MaxSegments=0)
On periodic surfaces, OCC fails to compute the number of MaxSegments, so we force a high number.
I lowered the Tolerance to 1e-7, since this is what the other types of curves have.
We can restore it to default 1e-5 later, if it proves to create troubles ?


Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
