### PR TITLE
Gui: Add missing SoSubEvent.h header to SoMouseWheelEvent.h

### DIFF
--- a/src/Gui/SoMouseWheelEvent.h
+++ b/src/Gui/SoMouseWheelEvent.h
@@ -29,6 +29,7 @@
 //#endif
 
 #include <Inventor/events/SoEvent.h>
+#include <Inventor/events/SoSubEvent.h>
 
 /**
  * @brief The SoMouseWheelEvent class is a temporary replacement for


### PR DESCRIPTION
Compile failed due to missing header file in SoMouseWheelEvent.h.
Added missing SoSubEvent.h to SoMouseWheelEvent.h.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
