### PR TITLE
Part.EdgePy : get access to stored Pcurves

### DIFF
--- a/src/Mod/Part/App/TopoShapeEdgePy.xml
+++ b/src/Mod/Part/App/TopoShapeEdgePy.xml
@@ -528,6 +528,15 @@ coordinate system.</UserDocu>
         </Documentation>
         <Parameter Name="Continuity" Type="String"/>
     </Attribute>
+		<Methode Name="curveOnSurface" Const="true">
+			<Documentation>
+				<UserDocu>curveOnSurface(idx) -> None or tuple
+Returns the 2D curve, the surface and the parameter range of index idx.
+Returns None if index idx is out of range.
+Returns a 4-items tuple of a curve, a surface, first parameter and last parameter.
+				</UserDocu>
+			</Documentation>
+		</Methode>
         <ClassDeclarations>
 		</ClassDeclarations>
 	</PythonExport>

--- a/src/Mod/Part/App/TopoShapeEdgePy.xml
+++ b/src/Mod/Part/App/TopoShapeEdgePy.xml
@@ -531,9 +531,9 @@ coordinate system.</UserDocu>
 		<Methode Name="curveOnSurface" Const="true">
 			<Documentation>
 				<UserDocu>curveOnSurface(idx) -> None or tuple
-Returns the 2D curve, the surface and the parameter range of index idx.
+Returns the 2D curve, the surface, the placement and the parameter range of index idx.
 Returns None if index idx is out of range.
-Returns a 4-items tuple of a curve, a surface, first parameter and last parameter.
+Returns a 5-items tuple of a curve, a surface, a placement, first parameter and last parameter.
 				</UserDocu>
 			</Documentation>
 		</Methode>

--- a/src/Mod/Part/App/TopoShapeEdgePyImp.cpp
+++ b/src/Mod/Part/App/TopoShapeEdgePyImp.cpp
@@ -1071,12 +1071,21 @@ PyObject* TopoShapeEdgePy::curveOnSurface(PyObject *args)
         Part::GeomSurface* geosurf = makeFromSurface(surf);
         if (!geosurf)
             Py_Return;
-
-        Py::Tuple tuple(4);
+        
+        gp_Trsf trsf = loc.Transformation();
+        gp_XYZ pos = trsf.TranslationPart();
+        gp_XYZ axis;
+        Standard_Real angle;
+        trsf.GetRotation(axis, angle);
+        Base::Rotation rot(Base::Vector3d(axis.X(), axis.Y(), axis.Z()), angle);
+        Base::Placement placement(Base::Vector3d(pos.X(), pos.Y(), pos.Z()), rot);
+        
+        Py::Tuple tuple(5);
         tuple.setItem(0, Py::asObject(geo2d->getPyObject()));
         tuple.setItem(1, Py::asObject(geosurf->getPyObject()));
-        tuple.setItem(2, Py::Float(first));
-        tuple.setItem(3, Py::Float(last));
+        tuple.setItem(2, Py::Object(new Base::PlacementPy(placement), true));
+        tuple.setItem(3, Py::Float(first));
+        tuple.setItem(4, Py::Float(last));
         return Py::new_reference_to(tuple);
     }
     catch (Standard_Failure& e) {


### PR DESCRIPTION
Gives access to all pcurves stored in an edge.
Example on a cylinder's circle edge : 
> anEdge.curveOnSurface(0)
(&lt;Line2d object&gt;, &lt;Cylinder object&gt;, 0.0, 6.283185307179586)
> anEdge.curveOnSurface(1)
(&lt;Circle2d object&gt;, &lt;Plane object&gt;, 0.0, 6.283185307179586)

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [x] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
