### PR TITLE
Fix various typos [skip-ci]

### DIFF
--- a/src/Mod/Draft/draftguitools/gui_annotationstyleeditor.py
+++ b/src/Mod/Draft/draftguitools/gui_annotationstyleeditor.py
@@ -180,7 +180,7 @@ class AnnotationStyleEditor(gui_base.GuiCommandSimplest):
         for obj in self.get_annotations():
             vobj = obj.ViewObject
             try:
-                curent = vobj.AnnotationStyle
+                current = vobj.AnnotationStyle
             except AssertionError:
                 # empty annotation styles list
                 pass

--- a/src/Mod/Path/PathScripts/PathDressupPathBoundary.py
+++ b/src/Mod/Path/PathScripts/PathDressupPathBoundary.py
@@ -110,7 +110,7 @@ class DressupPathBoundary(object):
 
             boundary = obj.Stock.Shape
             cmd = obj.Base.Path.Commands[0] 
-            pos = cmd.Placement.Base # bogus m/c postion to create first edge 
+            pos = cmd.Placement.Base # bogus m/c position to create first edge 
             bogusX = True
             bogusY = True
             commands = [cmd]

--- a/src/Mod/Sketcher/Gui/DrawSketchHandler.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandler.h
@@ -113,7 +113,7 @@ protected:
     void setCrosshairCursor(const char* svgName);
 
     /**
-     * Returns contraints icons scaled to width.
+     * Returns constraints icons scaled to width.
      **/
     std::vector<QPixmap> suggestedConstraintsPixmaps(
             std::vector<AutoConstraint> &suggestedConstraints);

--- a/src/Mod/TechDraw/Gui/MDIViewPage.h
+++ b/src/Mod/TechDraw/Gui/MDIViewPage.h
@@ -64,7 +64,7 @@ public:
     void onSelectionChanged(const Gui::SelectionChanges& msg);
     void preSelectionChanged(const QPoint &pos);
 
-    /// QGraphicsScene seletion routines
+    /// QGraphicsScene selection routines
     void selectQGIView(App::DocumentObject *obj, bool state);
     void clearSceneSelection();
     void blockSelection(bool isBlocked);


### PR DESCRIPTION
Found via `codespell` v2.0.dev0
```
codespell -q 3 -L aci,ake,aline,alle,alledges,alocation,als,ang,anid,ba,beginn,behaviour,bloaded,byteorder,calculater,cancelled,cancelling,cas,cascade,centimetre,childs,colour,colours,commen,connexion,currenty,dof,doubleclick,dum,eiter,elemente,ende,feld,finde,findf,freez,hist,iff,indicies,initialisation,initialise,initialised,initialises,initialisiert,ist,kilometre,lod,mantatory,methode,metres,millimetre,modell,nd,noe,normale,normaly,nto,numer,oder,orgin,orginx,orginy,ot,pard,pres,programm,que,recurrance,rougly,seperator,serie,sinc,strack,substraction,te,thist,thru,tread,uint,unter,vertexes,wallthickness,whitespaces -S ./.git,*.po,*.ts,./ChangeLog.txt,./src/3rdParty,./src/Mod/Assembly/App/opendcm,./src/CXX,./src/zipios++,./src/Base/swig*,./src/Mod/Robot/App/kdl_cp,./src/Mod/Import/App/SCL,./src/WindowsInstaller,./src/Doc/FreeCAD.uml
``` 