### PR TITLE
[Draft] Update gui_stretch.py

### DIFF
--- a/src/Mod/Draft/draftguitools/gui_stretch.py
+++ b/src/Mod/Draft/draftguitools/gui_stretch.py
@@ -447,12 +447,12 @@ class Stretch(gui_base_original.Modifier):
                             # otherwise create a wire copy and stretch it instead
                             _msg(translate("draft", "Turning one Rectangle into a Wire"))
                             pts = []
-                            opts = [p1, p2, p3, p4]
+                            vts = ops[0].Shape.Vertexes
                             for i in range(4):
                                 if ops[1][i] == False:
-                                    pts.append(opts[i])
+                                    pts.append(vts[i].Point)
                                 else:
-                                    pts.append(opts[i].add(self.displacement))
+                                    pts.append(vts[i].Point.add(self.displacement))
                             pts = str(pts).replace("Vector ", "FreeCAD.Vector")
                             _cmd = "Draft.makeWire"
                             _cmd += "(" + pts + ", closed=True)"
@@ -464,15 +464,6 @@ class Stretch(gui_base_original.Modifier):
                             commitops.append("w = " + _cmd)
                             commitops.append(_format)
                             commitops.append(_hide)
-                            # BUG: at this step the produced wire
-                            # doesn't seem to be in the correct position
-                            # compared to the original rectangle.
-                            # The base placement needs to be adjusted
-                            # just like with the other objects.
-                            for par in ops[0].InList:
-                                if hasattr(par, "Base") and par.Base == ops[0]:
-                                    _base = _doc + par.Name + ".Base = w"
-                                    commitops.append(_base)
                     else:
                         _pl = _doc + ops[0].Name
                         _pl += ".Placement.Base=FreeCAD."


### PR DESCRIPTION
Use the vertex points of the shape of the rectangle to create the wire copy to ensure correct coordinates.

Forum topic:
https://forum.freecadweb.org/posting.php?mode=reply&f=23&t=38318#pr426390