### PR TITLE
Fix typos in various files [skip-ci]

### DIFF
--- a/BUILD_OSX.md
+++ b/BUILD_OSX.md
@@ -34,5 +34,5 @@ Output binaries will be in the `./build/bin/FreeCAD` *and*
 `${CONDA_PREFIX}/bin/FreeCAD` directories.
 
 You can code/build/test using the cmake configuration folder `./build` in
-the standard way *from withing the freecad_dev conda enviroment*.
+the standard way *from within the freecad_dev conda environment*.
 

--- a/build_unix_dev_conda.sh
+++ b/build_unix_dev_conda.sh
@@ -23,7 +23,7 @@ HOST=$(uname)
 # Env Checks
 ###########################################################################
 if [[ ${HOST} =~ "Linux" ]]; then
-  # Linux specifc checks here
+  # Linux specific checks here
   echo "Linux specific checks..."
 elif [[ ${HOST} =~ "Darwin" ]]; then
   # OSX specific checks here.

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -102,7 +102,7 @@ about:
         FreeCAD is a general purpose feature-based, parametric 3D modeler for
         CAD, MCAD, CAx, CAE and PLM, aimed directly at mechanical engineering
         and product design but also fits a wider range of uses in engineering,
-        such as architecture or other engineering specialties. It is 100% Open
+        such as architecture or other engineering specialities. It is 100% Open
         Source (LGPL2+ license) and extremely modular, allowing for very
         advanced extension and customization.
         FreeCAD is based on OpenCASCADE, a powerful geometry kernel, features an

--- a/src/Gui/Document.cpp
+++ b/src/Gui/Document.cpp
@@ -1068,7 +1068,7 @@ static bool checkCanonicalPath(const std::map<App::Document*, bool> &docs)
         if (v.second.size() <= 1) continue;
         for (auto doc : v.second) {
             if (docs.count(doc)) {
-                FC_WARN("Pyhsical path: " << v.first.toUtf8().constData());
+                FC_WARN("Physical path: " << v.first.toUtf8().constData());
                 for (auto d : v.second)
                     FC_WARN("  Document: " << docName(d).toUtf8().constData()
                             << ": " << d->FileName.getValue());

--- a/src/Gui/QSint/actionpanel/actionbox.h
+++ b/src/Gui/QSint/actionpanel/actionbox.h
@@ -86,7 +86,7 @@ namespace QSint
     // create a spacer after two actions added before
     box1->createSpacer(hbl1);
     // create another action which will be preceded by the empty space (i.e. right-aligned)
-    ActionLabel *action5 = box1->createItem("3nd action in row", hbl1);
+    ActionLabel *action5 = box1->createItem("3rd action in row", hbl1);
     \endcode
 
     6. You can insert arbitrary layout items and widgets into ActionBox using

--- a/src/Gui/Tree.cpp
+++ b/src/Gui/Tree.cpp
@@ -1710,7 +1710,7 @@ void TreeWidget::dropEvent(QDropEvent *event)
                 vp = Base::freecad_dynamic_cast<ViewProviderDocumentObject>(
                         Application::Instance->getViewProvider(targetObj));
                 if(!vp) {
-                    FC_ERR("Cannot find drop traget object " << target);
+                    FC_ERR("Cannot find drop target object " << target);
                     break;
                 }
 

--- a/src/Mod/Draft/getSVG.py
+++ b/src/Mod/Draft/getSVG.py
@@ -561,7 +561,7 @@ def get_path(obj, plane,
                                 A = "A " + _a
                             except:
                                 _wrn("Circle or ellipse: "
-                                     "error spliting the projection snip")
+                                     "error splitting the projection snip")
                             else:
                                 edata += A
                                 done = True

--- a/src/Mod/Import/App/dxf.cpp
+++ b/src/Mod/Import/App/dxf.cpp
@@ -30,7 +30,7 @@ Base::Vector3d toVector3d(const double* a)
 }
 
 CDxfWrite::CDxfWrite(const char* filepath) :
-//TODO: these should probably be parms in config file
+//TODO: these should probably be parameters in config file
 //handles:
 //boilerplate 0 - A00
 //used by dxf.cpp A01 - FFFE

--- a/src/Mod/Path/PathScripts/PathSurfaceGui.py
+++ b/src/Mod/Path/PathScripts/PathSurfaceGui.py
@@ -69,7 +69,7 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
         The requirement is that the enumeration lists must
             be in the same order in both the opPropertyEnumerations() method
             and the UI panel QComboBox list.
-        Another step to ensure sychronization of the two lists is to
+        Another step to ensure synchronization of the two lists is to
             populate the list dynamically in this Gui module in `initPage()`
             using the property enumerations list when loading the UI panel.
             This type of dynamic combobox population is done for the


### PR DESCRIPTION
Found via `codespell 2.0.dev0`  
```
codespell -q 2 -L aci,ake,aline,alle,alledges,alocation,als,ang,anid,ba,beginn,behaviour,bloaded,byteorder,calculater,cancelled,cancelling,cas,cascade,centimetre,childs,colour,colours,commen,currenty,dof,doubleclick,dum,eiter,elemente,feld,freez,hist,iff,indicies,initialisation,initialise,initialised,initialises,initialisiert,ist,kilometre,lod,mantatory,methode,metres,millimetre,modell,nd,noe,normale,normaly,nto,numer,oder,orgin,orginx,orginy,ot,pard,pres,programm,que,recurrance,rougly,seperator,serie,sinc,strack,substraction,te,thist,thru,tread,uint,unter,vertexes,wallthickness,whitespaces -S ./.git,*.po,*.ts,./ChangeLog.txt,./src/3rdParty,./src/Mod/Assembly/App/opendcm,./src/CXX,./src/zipios++,./src/Base/swig*,./src/Mod/Robot/App/kdl_cp,./src/Mod/Import/App/SCL,./src/WindowsInstaller,./src/Doc/FreeCAD.uml
```