### PR TITLE
Part: fix dangerous static_cast usage in view provider

### DIFF
--- a/src/Mod/Part/Gui/ViewProviderBoolean.cpp
+++ b/src/Mod/Part/Gui/ViewProviderBoolean.cpp
@@ -102,15 +102,17 @@ void ViewProviderBoolean::updateData(const App::Property* prop)
             TopExp::MapShapes(toolShape, TopAbs_FACE, toolMap);
             TopExp::MapShapes(boolShape, TopAbs_FACE, boolMap);
 
-            Gui::ViewProvider* vpBase = Gui::Application::Instance->getViewProvider(objBase);
-            Gui::ViewProvider* vpTool = Gui::Application::Instance->getViewProvider(objTool);
+            auto vpBase = dynamic_cast<PartGui::ViewProviderPart*>(
+                    Gui::Application::Instance->getViewProvider(objBase));
+            auto vpTool = dynamic_cast<PartGui::ViewProviderPart*>(
+                    Gui::Application::Instance->getViewProvider(objTool));
             if (vpBase && vpTool) {
-                std::vector<App::Color> colBase = static_cast<PartGui::ViewProviderPart*>(vpBase)->DiffuseColor.getValues();
-                std::vector<App::Color> colTool = static_cast<PartGui::ViewProviderPart*>(vpTool)->DiffuseColor.getValues();
+                std::vector<App::Color> colBase = vpBase->DiffuseColor.getValues();
+                std::vector<App::Color> colTool = vpTool->DiffuseColor.getValues();
                 std::vector<App::Color> colBool;
                 colBool.resize(boolMap.Extent(), this->ShapeColor.getValue());
-                applyTransparency(static_cast<PartGui::ViewProviderPart*>(vpBase)->Transparency.getValue(),colBase);
-                applyTransparency(static_cast<PartGui::ViewProviderPart*>(vpTool)->Transparency.getValue(),colTool);
+                applyTransparency(vpBase->Transparency.getValue(),colBase);
+                applyTransparency(vpTool->Transparency.getValue(),colTool);
 
                 if (static_cast<int>(colBase.size()) == baseMap.Extent()) {
                     applyColor(hist[0], colBase, colBool);
@@ -202,10 +204,10 @@ void ViewProviderMultiFuse::updateData(const App::Property* prop)
             TopTools_IndexedMapOfShape baseMap;
             TopExp::MapShapes(baseShape, TopAbs_FACE, baseMap);
 
-            Gui::ViewProvider* vpBase = Gui::Application::Instance->getViewProvider(objBase);
+            auto vpBase = dynamic_cast<PartGui::ViewProviderPart*>(Gui::Application::Instance->getViewProvider(objBase));
             if (vpBase) {
-                std::vector<App::Color> colBase = static_cast<PartGui::ViewProviderPart*>(vpBase)->DiffuseColor.getValues();
-                applyTransparency(static_cast<PartGui::ViewProviderPart*>(vpBase)->Transparency.getValue(),colBase);
+                std::vector<App::Color> colBase = vpBase->DiffuseColor.getValues();
+                applyTransparency(vpBase->Transparency.getValue(),colBase);
                 if (static_cast<int>(colBase.size()) == baseMap.Extent()) {
                     applyColor(hist[index], colBase, colBool);
                 }
@@ -333,10 +335,10 @@ void ViewProviderMultiCommon::updateData(const App::Property* prop)
             TopTools_IndexedMapOfShape baseMap;
             TopExp::MapShapes(baseShape, TopAbs_FACE, baseMap);
 
-            Gui::ViewProvider* vpBase = Gui::Application::Instance->getViewProvider(objBase);
+            auto vpBase = dynamic_cast<PartGui::ViewProviderPart*>(Gui::Application::Instance->getViewProvider(objBase));
             if (vpBase) {
-                std::vector<App::Color> colBase = static_cast<PartGui::ViewProviderPart*>(vpBase)->DiffuseColor.getValues();
-                applyTransparency(static_cast<PartGui::ViewProviderPart*>(vpBase)->Transparency.getValue(),colBase);
+                std::vector<App::Color> colBase = vpBase->DiffuseColor.getValues();
+                applyTransparency(vpBase->Transparency.getValue(),colBase);
                 if (static_cast<int>(colBase.size()) == baseMap.Extent()) {
                     applyColor(hist[index], colBase, colBool);
                 }

--- a/src/Mod/Part/Gui/ViewProviderCompound.cpp
+++ b/src/Mod/Part/Gui/ViewProviderCompound.cpp
@@ -111,15 +111,17 @@ void ViewProviderCompound::updateData(const App::Property* prop)
             TopTools_IndexedMapOfShape baseMap;
             TopExp::MapShapes(baseShape, TopAbs_FACE, baseMap);
 
-            Gui::ViewProvider* vpBase = Gui::Application::Instance->getViewProvider(objBase);
-            std::vector<App::Color> baseCol = static_cast<PartGui::ViewProviderPart*>(vpBase)->DiffuseColor.getValues();
-            applyTransparency(static_cast<PartGui::ViewProviderPart*>(vpBase)->Transparency.getValue(),baseCol);
-            if (static_cast<int>(baseCol.size()) == baseMap.Extent()) {
-                applyColor(hist[index], baseCol, compCol);
-            }
-            else if (!baseCol.empty() && baseCol[0] != this->ShapeColor.getValue()) {
-                baseCol.resize(baseMap.Extent(), baseCol[0]);
-                applyColor(hist[index], baseCol, compCol);
+            auto vpBase = dynamic_cast<PartGui::ViewProviderPart*>(Gui::Application::Instance->getViewProvider(objBase));
+            if (vpBase) {
+                std::vector<App::Color> baseCol = vpBase->DiffuseColor.getValues();
+                applyTransparency(vpBase->Transparency.getValue(),baseCol);
+                if (static_cast<int>(baseCol.size()) == baseMap.Extent()) {
+                    applyColor(hist[index], baseCol, compCol);
+                }
+                else if (!baseCol.empty() && baseCol[0] != this->ShapeColor.getValue()) {
+                    baseCol.resize(baseMap.Extent(), baseCol[0]);
+                    applyColor(hist[index], baseCol, compCol);
+                }
             }
         }
 

--- a/src/Mod/Part/Gui/ViewProviderMirror.cpp
+++ b/src/Mod/Part/Gui/ViewProviderMirror.cpp
@@ -252,21 +252,23 @@ void ViewProviderFillet::updateData(const App::Property* prop)
             TopExp::MapShapes(baseShape, TopAbs_FACE, baseMap);
             TopExp::MapShapes(fillShape, TopAbs_FACE, fillMap);
 
-            Gui::ViewProvider* vpBase = Gui::Application::Instance->getViewProvider(objBase);
-            std::vector<App::Color> colBase = static_cast<PartGui::ViewProviderPart*>(vpBase)->DiffuseColor.getValues();
-            std::vector<App::Color> colFill;
-            colFill.resize(fillMap.Extent(), static_cast<PartGui::ViewProviderPart*>(vpBase)->ShapeColor.getValue());
-            applyTransparency(static_cast<PartGui::ViewProviderPart*>(vpBase)->Transparency.getValue(),colBase);
+            auto vpBase = dynamic_cast<PartGui::ViewProviderPart*>(Gui::Application::Instance->getViewProvider(objBase));
+            if (vpBase) {
+                std::vector<App::Color> colBase = vpBase->DiffuseColor.getValues();
+                std::vector<App::Color> colFill;
+                colFill.resize(fillMap.Extent(), vpBase->ShapeColor.getValue());
+                applyTransparency(vpBase->Transparency.getValue(),colBase);
 
-            if (static_cast<int>(colBase.size()) == baseMap.Extent()) {
-                applyColor(hist[0], colBase, colFill);
-            }
-            else if (!colBase.empty() && colBase[0] != this->ShapeColor.getValue()) {
-                colBase.resize(baseMap.Extent(), colBase[0]);
-                applyColor(hist[0], colBase, colFill);
-            }
+                if (static_cast<int>(colBase.size()) == baseMap.Extent()) {
+                    applyColor(hist[0], colBase, colFill);
+                }
+                else if (!colBase.empty() && colBase[0] != this->ShapeColor.getValue()) {
+                    colBase.resize(baseMap.Extent(), colBase[0]);
+                    applyColor(hist[0], colBase, colFill);
+                }
 
-            this->DiffuseColor.setValues(colFill);
+                this->DiffuseColor.setValues(colFill);
+            }
         }
     }
 }


### PR DESCRIPTION
Reported in https://forum.freecadweb.org/viewtopic.php?f=3&t=50002

Because Gui::ViewProviderLink can be used to override the view provider of any object, it is not safe to assume view provider type without explicit checking.