### PR TITLE
[Path] Fixed DeburrOp not moving to safe height

### DIFF
--- a/src/Mod/Path/PathScripts/PathDeburr.py
+++ b/src/Mod/Path/PathScripts/PathDeburr.py
@@ -145,10 +145,7 @@ class ObjectDeburr(PathEngraveBase.ObjectOp):
         
         self.wires = wires # pylint: disable=attribute-defined-outside-init
         self.buildpathocc(obj, wires, zValues, True, forward, obj.EntryPoint)
-
-        # the last command is a move to clearance, which is automatically added by PathOp
-        if self.commandlist:
-            self.commandlist.pop()
+        
 
     def opRejectAddBase(self, obj, base, sub):
         '''The chamfer op can only deal with features of the base model, all others are rejected.'''


### PR DESCRIPTION
With #3706 the "rapid to clearance" command  in PathOp.py was removed, but DeburrOp relied on it to clear Z. This resulted in the DeburrOp not moving to clearance/safe height. DeburrOp now inserts clearance cmd itself.