### PR TITLE
[Arch] ViewProviderPanelSheet: Too many arguments

### DIFF
--- a/src/Mod/Arch/ArchPanel.py
+++ b/src/Mod/Arch/ArchPanel.py
@@ -1383,7 +1383,7 @@ class ViewProviderPanelSheet(Draft._ViewProviderDraft):
     def __init__(self,vobj):
 
         Draft._ViewProviderDraft.__init__(self,vobj)
-        self.setProperties(self,vobj)
+        self.setProperties(vobj)
         vobj.PatternSize = 0.0035
 
     def setProperties(self,vobj):


### PR DESCRIPTION
Minor fix:
setProperties was called incorrectly

--

found via mypy