### PR TITLE
Draft: move getSVG to draftfunctions submodule

### DIFF
--- a/src/Mod/Arch/ArchSectionPlane.py
+++ b/src/Mod/Arch/ArchSectionPlane.py
@@ -562,7 +562,7 @@ def getSVG(source,
                                  color=lineColor,
                                  techdraw=techdraw,
                                  rotation=rotation,
-                                 fillSpaces=fillSpaces)
+                                 fillspaces=fillSpaces)
         if not techdraw:
             svg += '</g>'
 

--- a/src/Mod/Arch/ArchSectionPlane.py
+++ b/src/Mod/Arch/ArchSectionPlane.py
@@ -307,6 +307,7 @@ def update_svg_cache(source, renderMode, showHidden, showFill, fillSpaces, joinA
                 source.Proxy.shapecache = None
     return svgcache
 
+
 def getSVG(source,
            renderMode="Wireframe",
            allOn=False,
@@ -314,33 +315,49 @@ def getSVG(source,
            scale=1,
            rotation=0,
            linewidth=1,
-           lineColor=(0.0,0.0,0.0),
+           lineColor=(0.0, 0.0, 0.0),
            fontsize=1,
            showFill=False,
-           fillColor=(0.8,0.8,0.8),
+           fillColor=(0.8, 0.8, 0.8),
            techdraw=False,
            fillSpaces=False,
            cutlinewidth=0,
            joinArch=False):
-
     """
-    returns an SVG fragment from an Arch SectionPlane or BuildingPart. If
-    allOn is True, all cut objects are shown, regardless if they are visible or not.
-    renderMode can be Wireframe (default) or Solid to use the Arch solid renderer. If
-    showHidden is True, the hidden geometry above the section plane is shown in dashed line.
-    If showFill is True, the cut areas get filled with a pattern.
-    lineColor -- Color of lines for the renderMode "Wireframe".
-    fillColor -- If showFill is True and renderMode is "Wireframe",
-                 the cut areas are filled with fillColor.
-    fillSpaces - If True, shows space objects as filled surfaces
-    """
+    Return an SVG fragment from an Arch SectionPlane or BuildingPart.
 
-    import Part,DraftGeomUtils
+    allOn
+        If it is `True`, all cut objects are shown, regardless of if they are
+        visible or not.
+
+    renderMode
+        Can be `'Wireframe'` (default) or `'Solid'` to use the Arch solid
+        renderer.
+
+    showHidden
+        If it is `True`, the hidden geometry above the section plane
+        is shown in dashed line.
+
+    showFill
+        If it is `True`, the cut areas get filled with a pattern.
+
+    lineColor
+        Color of lines for the `renderMode` is `'Wireframe'`.
+
+    fillColor
+        If `showFill` is `True` and `renderMode` is `'Wireframe'`,
+        the cut areas are filled with `fillColor`.
+
+    fillSpaces
+        If `True`, shows space objects as filled surfaces.
+    """
+    import Part
+
     objs, cutplane, onlySolids, clip, direction = getSectionData(source)
     if not objs:
         return ""
     if not allOn:
-            objs = Draft.removeHidden(objs)
+        objs = Draft.removeHidden(objs)
 
     # separate spaces and Draft objects
     spaces = []
@@ -482,12 +499,17 @@ def getSVG(source,
                         for s in shapes:
                             if s.Edges:
                                 objectFill = getFillForObject(o, fillColor, source)
-                                #svg += Draft.getSVG(s,direction=direction.negative(),linewidth=0,fillstyle="sectionfill",color=(0,0,0))
+                                # svg += Draft.get_svg(s,
+                                #                      direction=direction.negative(),
+                                #                      linewidth=0,
+                                #                      fillstyle="sectionfill",
+                                #                      color=(0,0,0))
                                 # temporarily disabling fill patterns
-                                svgcache += Draft.getSVG(s, direction=direction.negative(),
-                                    linewidth=0,
-                                    fillstyle=Draft.getrgb(objectFill),
-                                    color=lineColor)
+                                svgcache += Draft.get_svg(s,
+                                                          linewidth=0,
+                                                          fillstyle=Draft.getrgb(objectFill),
+                                                          direction=direction.negative(),
+                                                          color=lineColor)
                     svgcache += "</g>\n"
                 sshapes = Part.makeCompound(sshapes)
                 style = {'stroke':       "SVGLINECOLOR",
@@ -510,9 +532,14 @@ def getSVG(source,
         if not techdraw:
             svg += '<g transform="scale(1,-1)">'
         for d in drafts:
-            svg += Draft.getSVG(d, scale=scale, linewidth=svgSymbolLineWidth,
-                                fontsize=fontsize, direction=direction, color=lineColor,
-                                techdraw=techdraw, rotation=rotation)
+            svg += Draft.get_svg(d,
+                                 scale=scale,
+                                 linewidth=svgSymbolLineWidth,
+                                 fontsize=fontsize,
+                                 direction=direction,
+                                 color=lineColor,
+                                 techdraw=techdraw,
+                                 rotation=rotation)
         if not techdraw:
             svg += '</g>'
 
@@ -527,9 +554,15 @@ def getSVG(source,
         if not techdraw:
             svg += '<g transform="scale(1,-1)">'
         for s in spaces:
-            svg += Draft.getSVG(s, scale=scale, linewidth=svgSymbolLineWidth,
-                                fontsize=fontsize, direction=direction, color=lineColor,
-                                techdraw=techdraw, rotation=rotation, fillSpaces=fillSpaces)
+            svg += Draft.get_svg(s,
+                                 scale=scale,
+                                 linewidth=svgSymbolLineWidth,
+                                 fontsize=fontsize,
+                                 direction=direction,
+                                 color=lineColor,
+                                 techdraw=techdraw,
+                                 rotation=rotation,
+                                 fillSpaces=fillSpaces)
         if not techdraw:
             svg += '</g>'
 
@@ -557,11 +590,15 @@ def getSVG(source,
             if not techdraw:
                 svg += '<g transform="scale(1,-1)">'
             for s in sh:
-                svg += Draft.getSVG(s, scale=scale,
-                                    linewidth=svgSymbolLineWidth,
-                                    fontsize=fontsize, fillstyle="none",
-                                    direction=direction, color=lineColor,
-                                    techdraw=techdraw, rotation=rotation)
+                svg += Draft.get_svg(s,
+                                     scale=scale,
+                                     linewidth=svgSymbolLineWidth,
+                                     fontsize=fontsize,
+                                     fillstyle="none",
+                                     direction=direction,
+                                     color=lineColor,
+                                     techdraw=techdraw,
+                                     rotation=rotation)
             if not techdraw:
                 svg += '</g>'
 
@@ -569,9 +606,7 @@ def getSVG(source,
 
 
 def getDXF(obj):
-
-    """returns a DXF representation from a TechDraw/Drawing view"""
-    
+    """Return a DXF representation from a TechDraw/Drawing view."""
     allOn = True
     if hasattr(obj,"AllOn"):
         allOn = obj.AllOn

--- a/src/Mod/Draft/CMakeLists.txt
+++ b/src/Mod/Draft/CMakeLists.txt
@@ -15,7 +15,6 @@ SET(Draft_SRCS_base
     DraftLayer.py
     DraftFillet.py
     WorkingPlane.py
-    getSVG.py
     TestDraft.py
     TestDraftGui.py
 )
@@ -97,6 +96,7 @@ SET(Draft_functions
     draftfunctions/rotate.py
     draftfunctions/scale.py
     draftfunctions/split.py
+    draftfunctions/svg.py
     draftfunctions/upgrade.py
     draftfunctions/README.md
 )

--- a/src/Mod/Draft/Draft.py
+++ b/src/Mod/Draft/Draft.py
@@ -95,8 +95,8 @@ from draftutils.utils import (string_encode_coin,
                               get_DXF,
                               getDXF)
 
-from getSVG import (get_svg,
-                    getSVG)
+from draftfunctions.svg import (get_svg,
+                                getSVG)
 
 from draftutils.gui_utils import (get3DView,
                                   get_3d_view,

--- a/src/Mod/Draft/draftfunctions/svg.py
+++ b/src/Mod/Draft/draftfunctions/svg.py
@@ -2,7 +2,7 @@
 # ***************************************************************************
 # *   Copyright (c) 2009 Yorik van Havre <yorik@uncreated.net>              *
 # *   Copyright (c) 2018 George Shuklin (amarao)                            *
-# *   Copyright (c) 2019 Eliud Cabrera Castillo <e.cabrera-castillo@tum.de> *
+# *   Copyright (c) 2020 Eliud Cabrera Castillo <e.cabrera-castillo@tum.de> *
 # *                                                                         *
 # *   This program is free software; you can redistribute it and/or modify  *
 # *   it under the terms of the GNU Lesser General Public License (LGPL)    *
@@ -22,9 +22,9 @@
 # *                                                                         *
 # ***************************************************************************
 """Provides functions to return the SVG representation of various shapes."""
-## @defgroup getSVG getSVG
-#  \ingroup DRAFT
-#  \brief Provides functions to return the SVG representation of shapes.
+## @package svg
+# \ingroup draftfuctions
+# \brief Provides functions to return the SVG representation of shapes.
 
 import math
 import six
@@ -45,7 +45,7 @@ Drawing = lz.LazyLoader("Drawing", globals(), "Drawing")
 
 param = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/Draft")
 
-## \addtogroup getSVG
+## \addtogroup draftfuctions
 # @{
 
 

--- a/src/Mod/Draft/draftfunctions/svg.py
+++ b/src/Mod/Draft/draftfunctions/svg.py
@@ -707,7 +707,7 @@ def get_svg(obj,
             scale=1, linewidth=0.35, fontsize=12,
             fillstyle="shape color", direction=None, linestyle=None,
             color=None, linespacing=None, techdraw=False, rotation=0,
-            fillSpaces=False, override=True):
+            fillspaces=False, override=True):
     """Return a string containing an SVG representation of the object.
 
     Paramaeters
@@ -748,7 +748,7 @@ def get_svg(obj,
     rotation: float, optional
         It defaults to 0.
 
-    fillSpaces: bool, optional
+    fillspaces: bool, optional
         It defaults to `False`.
 
     override: bool, optional
@@ -765,7 +765,7 @@ def get_svg(obj,
                                scale, linewidth, fontsize,
                                fillstyle, direction, linestyle,
                                color, linespacing, techdraw,
-                               rotation, fillSpaces, override)
+                               rotation, fillspaces, override)
             return svg
 
     pathdata = []
@@ -1224,7 +1224,7 @@ def get_svg(obj,
 
         if App.GuiUp:
             vobj = obj.ViewObject
-            if fillSpaces and hasattr(obj, "Proxy"):
+            if fillspaces and hasattr(obj, "Proxy"):
                 if not hasattr(obj.Proxy, "face"):
                     obj.Proxy.getArea(obj, notouch=True)
                 if hasattr(obj.Proxy, "face"):
@@ -1373,15 +1373,19 @@ def get_svg(obj,
 
 def getSVG(obj,
            scale=1, linewidth=0.35, fontsize=12,
-           fillstyle="shape color", direction=None, linestyle=None,
-           color=None, linespacing=None, techdraw=False, rotation=0,
+           fillstyle="shape color", direction=None,
+           linestyle=None,
+           color=None, linespacing=None,
+           techdraw=False, rotation=0,
            fillSpaces=False, override=True):
     """Return SVG string of the object. DEPRECATED. Use 'get_svg'."""
     utils.use_instead("get_svg")
     return get_svg(obj,
-                   scale, linewidth, fontsize,
-                   fillstyle, direction, linestyle,
-                   color, linespacing, techdraw, rotation,
-                   fillSpaces, override)
+                   scale=scale, linewidth=linewidth, fontsize=fontsize,
+                   fillstyle=fillstyle, direction=direction,
+                   linestyle=linestyle,
+                   color=color, linespacing=linespacing,
+                   techdraw=techdraw, rotation=rotation,
+                   fillspaces=fillSpaces, override=override)
 
 ## @}

--- a/src/Mod/Draft/draftfunctions/svg.py
+++ b/src/Mod/Draft/draftfunctions/svg.py
@@ -30,12 +30,12 @@ import math
 import six
 import lazy_loader.lazy_loader as lz
 
-import FreeCAD
+import FreeCAD as App
 import DraftVecUtils
 import WorkingPlane
 import draftutils.utils as utils
 
-from FreeCAD import Vector
+from draftutils.utils import param
 from draftutils.messages import _msg, _wrn
 
 # Delay import of module until first use because it is heavy
@@ -43,7 +43,6 @@ Part = lz.LazyLoader("Part", globals(), "Part")
 DraftGeomUtils = lz.LazyLoader("DraftGeomUtils", globals(), "DraftGeomUtils")
 Drawing = lz.LazyLoader("Drawing", globals(), "Drawing")
 
-param = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/Draft")
 
 ## \addtogroup draftfuctions
 # @{
@@ -111,7 +110,7 @@ def get_proj(vec, plane=None):
 
     # if techdraw: buggy - we now simply do it at the end
     #    ly = -ly
-    return Vector(lx, ly, 0)
+    return App.Vector(lx, ly, 0)
 
 
 def getProj(vec, plane=None):
@@ -174,10 +173,10 @@ def get_circle(plane,
     cen = get_proj(edge.Curve.Center, plane)
     rad = edge.Curve.Radius
 
-    if hasattr(FreeCAD, "DraftWorkingPlane"):
-        drawing_plane_normal = FreeCAD.DraftWorkingPlane.axis
+    if hasattr(App, "DraftWorkingPlane"):
+        drawing_plane_normal = App.DraftWorkingPlane.axis
     else:
-        drawing_plane_normal = FreeCAD.Vector(0, 0, 1)
+        drawing_plane_normal = App.Vector(0, 0, 1)
 
     if plane:
         drawing_plane_normal = plane.axis
@@ -245,7 +244,7 @@ def get_arrow(obj,
     """Get the SVG representation from an arrow."""
     svg = ""
 
-    if not FreeCAD.GuiUp or not obj.ViewObject:
+    if not App.GuiUp or not obj.ViewObject:
         return svg
 
     _cx_cy_r = 'cx="{}" cy="{}" r="{}"'.format(point.x, point.y, arrowsize)
@@ -347,7 +346,7 @@ def get_text(plane, techdraw,
              angle, base, text,
              linespacing=0.5, align="center", flip=True):
     """Get the SVG representation of a textual element."""
-    if isinstance(angle, FreeCAD.Rotation):
+    if isinstance(angle, App.Rotation):
         if not plane:
             angle = angle.Angle
         else:
@@ -536,10 +535,10 @@ def get_path(obj, plane,
             isellipse = DraftGeomUtils.geomType(e) == "Ellipse"
 
             if iscircle or isellipse:
-                if hasattr(FreeCAD, "DraftWorkingPlane"):
-                    drawing_plane_normal = FreeCAD.DraftWorkingPlane.axis
+                if hasattr(App, "DraftWorkingPlane"):
+                    drawing_plane_normal = App.DraftWorkingPlane.axis
                 else:
-                    drawing_plane_normal = FreeCAD.Vector(0, 0, 1)
+                    drawing_plane_normal = App.Vector(0, 0, 1)
 
                 if plane:
                     drawing_plane_normal = plane.axis
@@ -595,7 +594,7 @@ def get_path(obj, plane,
                             rx = c.MajorRadius
                             ry = c.MinorRadius
                             rot = math.degrees(c.AngleXU
-                                               * c.Axis * Vector(0, 0, 1))
+                                               * c.Axis * App.Vector(0, 0, 1))
                             if rot > 90:
                                 rot -= 180
                             if rot < -90:
@@ -793,10 +792,10 @@ def get_svg(obj,
     plane = None
 
     if direction:
-        if isinstance(direction, FreeCAD.Vector):
-            if direction != Vector(0, 0, 0):
+        if isinstance(direction, App.Vector):
+            if direction != App.Vector(0, 0, 0):
                 plane = WorkingPlane.plane()
-                plane.alignToPointAndAxis_SVG(Vector(0, 0, 0),
+                plane.alignToPointAndAxis_SVG(App.Vector(0, 0, 0),
                                               direction.negative().negative(),
                                               0)
         elif isinstance(direction, WorkingPlane.plane):
@@ -808,7 +807,7 @@ def get_svg(obj,
             stroke = color
         else:
             stroke = utils.get_rgb(color)
-    elif FreeCAD.GuiUp:
+    elif App.GuiUp:
         if hasattr(obj, "ViewObject"):
             if hasattr(obj.ViewObject, "LineColor"):
                 stroke = utils.get_rgb(obj.ViewObject.LineColor)
@@ -838,10 +837,10 @@ def get_svg(obj,
                         edges=obj.Edges, pathname="")
 
     elif utils.get_type(obj) in ["Dimension", "LinearDimension"]:
-        if not FreeCAD.GuiUp:
+        if not App.GuiUp:
             _wrn("Export of dimensions to SVG is only available in GUI mode")
 
-        if FreeCAD.GuiUp and obj.ViewObject.Proxy:
+        if App.GuiUp and obj.ViewObject.Proxy:
             vobj = obj.ViewObject
 
             if hasattr(vobj.Proxy, "p1"):
@@ -864,8 +863,8 @@ def get_svg(obj,
 
                 tbase = get_proj(prx.tbase, plane)
                 r = prx.textpos.rotation.getValue().getValue()
-                _rv = FreeCAD.Rotation(r[0], r[1], r[2], r[3])
-                rv = _rv.multVec(FreeCAD.Vector(1, 0, 0))
+                _rv = App.Rotation(r[0], r[1], r[2], r[3])
+                rv = _rv.multVec(App.Vector(1, 0, 0))
                 angle = -DraftVecUtils.angle(get_proj(rv, plane))
                 # angle = -DraftVecUtils.angle(p3.sub(p2))
 
@@ -892,7 +891,7 @@ def get_svg(obj,
                         #       " text: ", prx.string)
                         if abs(tangle + math.radians(rotation)) < 0.0001:
                             tangle += math.pi
-                            _v = Vector(0, 2.0/scale, 0)
+                            _v = App.Vector(0, 2.0/scale, 0)
                             _rot = DraftVecUtils.rotate(_v, tangle)
                             tbase = tbase + _rot
 
@@ -906,7 +905,7 @@ def get_svg(obj,
                     if rotation != 0:
                         tangle = -math.radians(rotation)
 
-                    tbase = tbase + Vector(0, -2.0/scale, 0)
+                    tbase = tbase + App.Vector(0, -2.0/scale, 0)
                     if not nolines:
                         svg += 'd="M ' + str(p1.x) + ' ' + str(p1.y) + ' '
                         svg += 'L ' + str(p2.x) + ' ' + str(p2.y) + ' '
@@ -964,10 +963,10 @@ def get_svg(obj,
                                 tangle, tbase, prx.string)
 
     elif utils.get_type(obj) == "AngularDimension":
-        if not FreeCAD.GuiUp:
+        if not App.GuiUp:
             _wrn("Export of dimensions to SVG is only available in GUI mode")
 
-        if FreeCAD.GuiUp:
+        if App.GuiUp:
             if obj.ViewObject.Proxy:
                 if hasattr(obj.ViewObject.Proxy, "circle"):
                     prx = obj.ViewObject.Proxy
@@ -1046,7 +1045,7 @@ def get_svg(obj,
                                                  + _diff/2.0)
                         tbase = get_proj(_va, plane)
 
-                        _v = Vector(0, 2.0/scale, 0)
+                        _v = App.Vector(0, 2.0/scale, 0)
                         tbase = tbase + DraftVecUtils.rotate(_v, tangle)
                         # print(tbase)
                     else:
@@ -1078,7 +1077,7 @@ def get_svg(obj,
             # We are different here from 3D view
             # if Line is set to 'off', no arrow is drawn
             if hasattr(obj.ViewObject, "ArrowType") and len(obj.Points) >= 2:
-                last_segment = FreeCAD.Vector(obj.Points[-1] - obj.Points[-2])
+                last_segment = App.Vector(obj.Points[-1] - obj.Points[-2])
                 _v = get_proj(last_segment, plane)
                 angle = -DraftVecUtils.angle(_v) + math.pi
                 svg += get_arrow(obj,
@@ -1087,11 +1086,11 @@ def get_svg(obj,
                                  obj.ViewObject.ArrowSize.Value/pointratio,
                                  stroke, linewidth, angle)
 
-        if not FreeCAD.GuiUp:
+        if not App.GuiUp:
             _wrn("Export of texts to SVG is only available in GUI mode")
 
         # print text
-        if FreeCAD.GuiUp:
+        if App.GuiUp:
             fontname = obj.ViewObject.TextFont
             position = get_proj(obj.Placement.Base, plane)
             rotation = obj.Placement.Rotation
@@ -1104,10 +1103,10 @@ def get_svg(obj,
 
     elif utils.get_type(obj) in ["Annotation", "DraftText", "Text"]:
         # returns an svg representation of a document annotation
-        if not FreeCAD.GuiUp:
+        if not App.GuiUp:
             _wrn("Export of texts to SVG is only available in GUI mode")
 
-        if FreeCAD.GuiUp:
+        if App.GuiUp:
             n = obj.ViewObject.FontName
             if utils.get_type(obj) == "Annotation":
                 p = get_proj(obj.Position, plane)
@@ -1126,10 +1125,10 @@ def get_svg(obj,
 
     elif utils.get_type(obj) == "Axis":
         # returns the SVG representation of an Arch Axis system
-        if not FreeCAD.GuiUp:
+        if not App.GuiUp:
             _wrn("Export of axes to SVG is only available in GUI mode")
 
-        if FreeCAD.GuiUp:
+        if App.GuiUp:
             vobj = obj.ViewObject
             lorig = lstyle
             fill = 'none'
@@ -1220,17 +1219,17 @@ def get_svg(obj,
         fill_opacity = 1
 
         # returns an SVG fragment for the text of a space
-        if not FreeCAD.GuiUp:
+        if not App.GuiUp:
             _wrn("Export of spaces to SVG is only available in GUI mode")
 
-        if FreeCAD.GuiUp:
+        if App.GuiUp:
             vobj = obj.ViewObject
             if fillSpaces and hasattr(obj, "Proxy"):
                 if not hasattr(obj.Proxy, "face"):
                     obj.Proxy.getArea(obj, notouch=True)
                 if hasattr(obj.Proxy, "face"):
                     # setting fill
-                    if FreeCAD.GuiUp:
+                    if App.GuiUp:
                         fill = utils.get_rgb(vobj.ShapeColor,
                                              testbw=False)
                         fill_opacity = 1 - vobj.Transparency / 100.0
@@ -1252,10 +1251,10 @@ def get_svg(obj,
             f1 = fontsize * scale
 
             _v = vobj.Proxy.coords.translation.getValue().getValue()
-            p2 = obj.Placement.multVec(FreeCAD.Vector(_v))
+            p2 = obj.Placement.multVec(App.Vector(_v))
 
             _h = vobj.Proxy.header.translation.getValue().getValue()
-            lspc = FreeCAD.Vector(_h)
+            lspc = App.Vector(_h)
             p1 = p2 + lspc
             j = vobj.TextAlign
             t3 = get_text(plane, techdraw,
@@ -1264,10 +1263,10 @@ def get_svg(obj,
                           linespacing, j, flip=True)
             svg += t3
             if t2:
-                ofs = FreeCAD.Vector(0, -lspc.Length, 0)
+                ofs = App.Vector(0, -lspc.Length, 0)
                 if a:
-                    Z = FreeCAD.Vector(0, 0, 1)
-                    ofs = FreeCAD.Rotation(Z, -rotation).multVec(ofs)
+                    Z = App.Vector(0, 0, 1)
+                    ofs = App.Rotation(Z, -rotation).multVec(ofs)
                 t4 = get_text(plane, techdraw,
                               c, fontsize, n,
                               a, get_proj(p1, plane).add(ofs), t2,
@@ -1287,7 +1286,7 @@ def get_svg(obj,
         fill_opacity = 1
         # setting fill
         if obj.Shape.Faces:
-            if FreeCAD.GuiUp:
+            if App.GuiUp:
                 try:
                     m = obj.ViewObject.DisplayMode
                 except AttributeError:
@@ -1351,7 +1350,7 @@ def get_svg(obj,
                                    fill_opacity=fill_opacity,
                                    edges=obj.Shape.Edges)
 
-        if (FreeCAD.GuiUp
+        if (App.GuiUp
                 and hasattr(obj.ViewObject, "EndArrow")
                 and obj.ViewObject.EndArrow
                 and hasattr(obj.ViewObject, "ArrowType")

--- a/src/Mod/Draft/draftobjects/drawingview.py
+++ b/src/Mod/Draft/draftobjects/drawingview.py
@@ -1,7 +1,7 @@
 # ***************************************************************************
 # *   Copyright (c) 2009, 2010 Yorik van Havre <yorik@uncreated.net>        *
 # *   Copyright (c) 2009, 2010 Ken Cline <cline@frii.com>                   *
-# *   Copyright (c) 2020 FreeCAD Developers                                 *
+# *   Copyright (c) 2020 Eliud Cabrera Castillo <e.cabrera-castillo@tum.de> *
 # *                                                                         *
 # *   This program is free software; you can redistribute it and/or modify  *
 # *   it under the terms of the GNU Lesser General Public License (LGPL)    *
@@ -39,7 +39,7 @@ this object should no longer be available.
 # @{
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
-import getSVG
+import draftfunctions.svg as get_svg
 import draftutils.utils as utils
 import draftutils.groups as groups
 
@@ -47,90 +47,141 @@ from draftobjects.base import DraftObject
 
 
 class DrawingView(DraftObject):
-    """The Draft DrawingView object
-    
-    OBSOLETE: this class is obsolete, since Drawing was substituted by TechDraw.
+    """The DrawingView object. This class is OBSOLETE.
+
+    This object was used with the Drawing Workbench, but since this workbench
+    because obsolete in v0.17, the object should no longer be used.
+    It is retained for compatibility purposes, that is, to open older
+    files that may contain this object.
+
+    To produce 2D drawings, use TechDraw Workbench.
     """
 
     def __init__(self, obj):
         super(DrawingView, self).__init__(obj, "DrawingView")
-        
-        _tip = QT_TRANSLATE_NOOP("App::Property", "The linked object")
-        obj.addProperty("App::PropertyLink", "Source", "Base", _tip)
-        
-        _tip = QT_TRANSLATE_NOOP("App::Property", "Projection direction")
-        obj.addProperty("App::PropertyVector", "Direction", "Shape View", _tip)
-        
-        _tip = QT_TRANSLATE_NOOP("App::Property", "The width of the lines inside this object")
-        obj.addProperty("App::PropertyFloat", "LineWidth", "View Style", _tip)
-                
-        _tip = QT_TRANSLATE_NOOP("App::Property", "The size of the texts inside this object")
-        obj.addProperty("App::PropertyLength", "FontSize", "View Style", _tip)
-                
-        _tip = QT_TRANSLATE_NOOP("App::Property", "The spacing between lines of text")
-        obj.addProperty("App::PropertyLength", "LineSpacing", "View Style", _tip)
-                
-        _tip = QT_TRANSLATE_NOOP("App::Property", "The color of the projected objects")
-        obj.addProperty("App::PropertyColor", "LineColor", "View Style", _tip)
-                
-        _tip = QT_TRANSLATE_NOOP("App::Property", "Shape Fill Style")
-        obj.addProperty("App::PropertyEnumeration", "FillStyle", "View Style", _tip)
-                
-        _tip = QT_TRANSLATE_NOOP("App::Property", "Line Style")
-        obj.addProperty("App::PropertyEnumeration", "LineStyle", "View Style", _tip)
-                
-        _tip = QT_TRANSLATE_NOOP("App::Property", 
-                "If checked, source objects are displayed regardless of being \
-                visible in the 3D model")
-        obj.addProperty("App::PropertyBool", "AlwaysOn", "View Style", _tip)
 
-        obj.FillStyle = ['shape color'] + list(utils.svgpatterns().keys())
-        obj.LineStyle = ['Solid','Dashed','Dotted','Dashdot']
+        _tip = QT_TRANSLATE_NOOP("App::Property",
+                                 "The linked object")
+        obj.addProperty("App::PropertyLink",
+                        "Source",
+                        "Base",
+                        _tip)
+
+        _tip = QT_TRANSLATE_NOOP("App::Property",
+                                 "Projection direction")
+        obj.addProperty("App::PropertyVector",
+                        "Direction",
+                        "Shape View",
+                        _tip)
+
+        _tip = QT_TRANSLATE_NOOP("App::Property",
+                                 "The width of the lines inside this object")
+        obj.addProperty("App::PropertyFloat",
+                        "LineWidth",
+                        "View Style",
+                        _tip)
         obj.LineWidth = 0.35
+
+        _tip = QT_TRANSLATE_NOOP("App::Property",
+                                 "The size of the texts inside this object")
+        obj.addProperty("App::PropertyLength",
+                        "FontSize",
+                        "View Style",
+                        _tip)
         obj.FontSize = 12
 
+        _tip = QT_TRANSLATE_NOOP("App::Property",
+                                 "The spacing between lines of text")
+        obj.addProperty("App::PropertyLength",
+                        "LineSpacing",
+                        "View Style",
+                        _tip)
+
+        _tip = QT_TRANSLATE_NOOP("App::Property",
+                                 "The color of the projected objects")
+        obj.addProperty("App::PropertyColor",
+                        "LineColor",
+                        "View Style",
+                        _tip)
+
+        _tip = QT_TRANSLATE_NOOP("App::Property",
+                                 "Shape Fill Style")
+        obj.addProperty("App::PropertyEnumeration",
+                        "FillStyle",
+                        "View Style",
+                        _tip)
+        obj.FillStyle = ['shape color'] + list(utils.svgpatterns().keys())
+
+        _tip = QT_TRANSLATE_NOOP("App::Property",
+                                 "Line Style")
+        obj.addProperty("App::PropertyEnumeration",
+                        "LineStyle",
+                        "View Style",
+                        _tip)
+        obj.LineStyle = ['Solid', 'Dashed', 'Dotted', 'Dashdot']
+
+        _tip = QT_TRANSLATE_NOOP("App::Property",
+                                 "If checked, source objects are displayed "
+                                 "regardless of being visible in the 3D model")
+        obj.addProperty("App::PropertyBool",
+                        "AlwaysOn",
+                        "View Style",
+                        _tip)
+
     def execute(self, obj):
+        """Execute when the object is created or recomputed."""
         result = ""
-        if hasattr(obj,"Source"):
-            if obj.Source:
-                if hasattr(obj,"LineStyle"):
-                    ls = obj.LineStyle
-                else:
-                    ls = None
-                if hasattr(obj,"LineColor"):
-                    lc = obj.LineColor
-                else:
-                    lc = None
-                if hasattr(obj,"LineSpacing"):
-                    lp = obj.LineSpacing
-                else:
-                    lp = None
-                if obj.Source.isDerivedFrom("App::DocumentObjectGroup"):
-                    svg = ""
-                    shapes = []
-                    others = []
-                    objs = groups.get_group_contents([obj.Source])
-                    for o in objs:
-                        v = o.ViewObject.isVisible()
-                        if hasattr(obj,"AlwaysOn"):
-                            if obj.AlwaysOn:
-                                v = True
-                        if v:
-                            svg += getSVG.getSVG(o,obj.Scale,obj.LineWidth,obj.FontSize.Value,obj.FillStyle,obj.Direction,ls,lc,lp)
-                else:
-                    svg = getSVG.getSVG(obj.Source,obj.Scale,obj.LineWidth,obj.FontSize.Value,obj.FillStyle,obj.Direction,ls,lc,lp)
-                result += '<g id="' + obj.Name + '"'
-                result += ' transform="'
-                result += 'rotate('+str(obj.Rotation)+','+str(obj.X)+','+str(obj.Y)+') '
-                result += 'translate('+str(obj.X)+','+str(obj.Y)+') '
-                result += 'scale('+str(obj.Scale)+','+str(-obj.Scale)+')'
-                result += '">'
-                result += svg
-                result += '</g>'
+        if hasattr(obj, "Source") and obj.Source:
+            if hasattr(obj, "LineStyle"):
+                ls = obj.LineStyle
+            else:
+                ls = None
+            if hasattr(obj, "LineColor"):
+                lc = obj.LineColor
+            else:
+                lc = None
+            if hasattr(obj, "LineSpacing"):
+                lp = obj.LineSpacing
+            else:
+                lp = None
+
+            if obj.Source.isDerivedFrom("App::DocumentObjectGroup"):
+                svg = ""
+                objs = groups.get_group_contents([obj.Source])
+                for o in objs:
+                    v = o.ViewObject.isVisible()
+                    if hasattr(obj, "AlwaysOn") and obj.AlwaysOn:
+                        v = True
+                    if v:
+                        svg += get_svg.get_svg(o,
+                                               obj.Scale,
+                                               obj.LineWidth,
+                                               obj.FontSize.Value,
+                                               obj.FillStyle,
+                                               obj.Direction, ls, lc, lp)
+            else:
+                svg = get_svg.get_svg(obj.Source,
+                                      obj.Scale,
+                                      obj.LineWidth,
+                                      obj.FontSize.Value,
+                                      obj.FillStyle,
+                                      obj.Direction, ls, lc, lp)
+
+            result += '<g id="' + obj.Name + '"'
+            result += ' transform="'
+            result += 'rotate(' + str(obj.Rotation) + ','
+            result += str(obj.X) + ',' + str(obj.Y)
+            result += ') '
+            result += 'translate(' + str(obj.X) + ',' + str(obj.Y) + ') '
+            result += 'scale(' + str(obj.Scale) + ',' + str(-obj.Scale)
+            result += ')'
+            result += '">'
+            result += svg
+            result += '</g>'
         obj.ViewResult = result
 
-    def getDXF(self,obj):
-        "returns a DXF fragment"
+    def getDXF(self, obj):
+        """Return a DXF fragment."""
         return utils.getDXF(obj)
 
 

--- a/src/Mod/Draft/drafttests/test_import.py
+++ b/src/Mod/Draft/drafttests/test_import.py
@@ -65,7 +65,7 @@ class DraftImport(unittest.TestCase):
 
     def test_import_draft_svg(self):
         """Import Draft SVG utilities."""
-        module = "getSVG"
+        module = "draftfunctions.svg"
         imported = aux.import_test(module)
         self.assertTrue(imported, "Problem importing '{}'".format(module))
 


### PR DESCRIPTION
After the major update to the SVG generation code in #3749, the module is moved inside the `draftfunctions` submodule.

Also, small fixes where the `Draft.get_svg` function is used, for example, in the (obsolete) `DrawingView` class and `Arch_SectionPlane`.

Also update the unit tests accordingly.

---

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists