### PR TITLE
Draft: added 5 scale unit tests to test_modifications

### DIFF
--- a/src/Mod/Draft/drafttests/test_modification.py
+++ b/src/Mod/Draft/drafttests/test_modification.py
@@ -37,7 +37,6 @@ import drafttests.auxiliary as aux
 import Part
 
 from FreeCAD import Vector
-from draftfunctions.scale import scale_vector_from_center
 from draftutils.messages import _msg, _wrn
 
 
@@ -600,17 +599,17 @@ class DraftModification(unittest.TestCase):
         operation = "Draft Scale part feature (arcs)"
         _msg("  Test '{}'".format(operation))
 
-        base = App.Vector(3.5, 2.5, 0)
-        cen = App.Vector(2, 1, 0) # center for scaling
-        sca = App.Vector(2, 3, 1)
-        ends = [App.Vector(0, 0, 0),
-                App.Vector(4, 0, 0),
-                App.Vector(4, 3, 0),
-                App.Vector(0, 3, 0)]
-        mids = [App.Vector( 2.0, -0.5, 0),
-                App.Vector( 4.5,  1.5, 0),
-                App.Vector( 2.0,  3.5, 0),
-                App.Vector(-0.5,  1.5, 0)] # arc midpoints
+        base = Vector(3.5, 2.5, 0.0)
+        cen = Vector(2.0, 1.0, 0.0) # center for scaling
+        sca = Vector(2.0, 3.0, 1.0)
+        ends = [Vector(0.0, 0.0, 0.0),
+                Vector(4.0, 0.0, 0.0),
+                Vector(4.0, 3.0, 0.0),
+                Vector(0.0, 3.0, 0.0)]
+        mids = [Vector( 2.0, -0.5, 0.0),
+                Vector( 4.5,  1.5, 0.0),
+                Vector( 2.0,  3.5, 0.0),
+                Vector(-0.5,  1.5, 0.0)] # arc midpoints
 
         shp = Part.Shape([Part.Arc(ends[0], mids[0], ends[1]),
                           Part.Arc(ends[1], mids[1], ends[2]),
@@ -620,30 +619,33 @@ class DraftModification(unittest.TestCase):
         obj.Shape = shp
         obj.Placement.Base = base
         App.ActiveDocument.recompute()
-
-        _msg("  Scale")
-        _msg("  vector={}".format(sca))
-        _msg("  center={}".format(cen))
         Draft.scale([obj], sca, cen, False)
         App.ActiveDocument.recompute()
 
         # check endpoints of arcs:
+        newEnds = [Vector( 5.0,  5.5, 0.0),
+                   Vector(13.0,  5.5, 0.0),
+                   Vector(13.0, 14.5, 0.0),
+                   Vector( 5.0, 14.5, 0.0)]
         vrts = obj.Shape.Vertexes
         result = True
         for i in range(4):
-            ptNew = scale_vector_from_center(ends[i].add(base), sca, cen)
-            if not vrts[i].Point.isEqual(ptNew, 1e-8):
+            if not vrts[i].Point.isEqual(newEnds[i], 1e-8):
                 result = False
                 break
         # check midpoints of arcs:
         if result == True:
+            newMids = [Vector( 9.0,  4.0, 0.0),
+                       Vector(14.0, 10.0, 0.0),
+                       Vector( 9.0, 16.0, 0.0),
+                       Vector( 4.0, 10.0, 0.0)]
             for i in range(4):
-                ptNew = scale_vector_from_center(mids[i].add(base), sca, cen)
                 edge = obj.Shape.Edges[i]
-                par = (edge.LastParameter - edge.FirstParameter) / 2
-                if not edge.valueAt(par).isEqual(ptNew, 1e-8):
+                par = (edge.LastParameter - edge.FirstParameter) / 2.0
+                if not edge.valueAt(par).isEqual(newMids[i], 1e-8):
                     result = False
                     break
+
         self.assertTrue(result, "'{}' failed".format(operation))
 
     def test_scale_part_feature_lines(self):
@@ -651,13 +653,13 @@ class DraftModification(unittest.TestCase):
         operation = "Draft Scale part feature (lines)"
         _msg("  Test '{}'".format(operation))
 
-        base = App.Vector(3.5, 2.5, 0)
-        cen = App.Vector(2, 1, 0) # center for scaling
-        sca = App.Vector(2, 3, 1)
-        pts = [App.Vector(0, 0, 0),
-               App.Vector(4, 0, 0),
-               App.Vector(4, 3, 0),
-               App.Vector(0, 3, 0)]
+        base = Vector(3.5, 2.5, 0.0)
+        cen = Vector(2.0, 1.0, 0.0) # center for scaling
+        sca = Vector(2.0, 3.0, 1.0)
+        pts = [Vector(0.0, 0.0, 0.0),
+               Vector(4.0, 0.0, 0.0),
+               Vector(4.0, 3.0, 0.0),
+               Vector(0.0, 3.0, 0.0)]
 
         shp = Part.Shape([Part.LineSegment(pts[0], pts[1]),
                           Part.LineSegment(pts[1], pts[2]),
@@ -667,20 +669,20 @@ class DraftModification(unittest.TestCase):
         obj.Shape = shp
         obj.Placement.Base = base
         App.ActiveDocument.recompute()
-
-        _msg("  Scale")
-        _msg("  vector={}".format(sca))
-        _msg("  center={}".format(cen))
         Draft.scale([obj], sca, cen, False)
         App.ActiveDocument.recompute()
 
+        newPts = [Vector( 5.0,  5.5, 0.0),
+                  Vector(13.0,  5.5, 0.0),
+                  Vector(13.0, 14.5, 0.0),
+                  Vector( 5.0, 14.5, 0.0)]
         vrts = obj.Shape.Vertexes
         result = True
         for i in range(4):
-            ptNew = scale_vector_from_center(pts[i].add(base), sca, cen)
-            if not vrts[i].Point.isEqual(ptNew, 1e-8):
+            if not vrts[i].Point.isEqual(newPts[i], 1e-8):
                 result = False
                 break
+
         self.assertTrue(result, "'{}' failed".format(operation))
 
     def test_scale_rectangle(self):
@@ -688,28 +690,27 @@ class DraftModification(unittest.TestCase):
         operation = "Draft Scale rectangle"
         _msg("  Test '{}'".format(operation))
 
-        base = App.Vector(3.5, 2.5, 0)
-        cen = App.Vector(2, 1, 0) # center for scaling
-        sca = App.Vector(2, 3, 1)
-        len = 4
-        hgt = 3
+        base = Vector(3.5, 2.5, 0.0)
+        cen = Vector(2.0, 1.0, 0.0) # center for scaling
+        sca = Vector(2.0, 3.0, 1.0)
+        len = 4.0
+        hgt = 3.0
 
         obj = Draft.make_rectangle(len, hgt)
         obj.Placement.Base = base
         App.ActiveDocument.recompute()
-
-        _msg("  Scale")
-        _msg("  vector={}".format(sca))
-        _msg("  center={}".format(cen))
         Draft.scale([obj], sca, cen, False)
         App.ActiveDocument.recompute()
 
-        ptNew = scale_vector_from_center(base, sca, cen)
-        result = obj.Placement.Base.isEqual(ptNew, 1e-8)
+        newBase = Vector(5.0, 5.5, 0.0)
+        newLen = 8.0
+        newHgt = 9.0
+        result = obj.Placement.Base.isEqual(newBase, 1e-8)
         if result == True:
-            result = math.isclose(obj.Length, len * sca.x, abs_tol = 1e-8)
+            result = math.isclose(obj.Length, newLen, abs_tol = 1e-8)
         if result == True:
-            result = math.isclose(obj.Height, hgt * sca.y, abs_tol = 1e-8)
+            result = math.isclose(obj.Height, newHgt, abs_tol = 1e-8)
+
         self.assertTrue(result, "'{}' failed".format(operation))
 
     def test_scale_spline(self):
@@ -717,29 +718,28 @@ class DraftModification(unittest.TestCase):
         operation = "Draft Scale spline"
         _msg("  Test '{}'".format(operation))
 
-        base = App.Vector(3.5, 2.5, 0)
-        cen = App.Vector(2, 1, 0) # center for scaling
-        sca = App.Vector(2, 3, 1)
-        pts = [App.Vector(0, 0, 0),
-               App.Vector(2, 3, 0),
-               App.Vector(4, 0, 0)]
+        base = Vector(3.5, 2.5, 0.0)
+        cen = Vector(2.0, 1.0, 0.0) # center for scaling
+        sca = Vector(2.0, 3.0, 1.0)
+        pts = [Vector(0.0, 0.0, 0.0),
+               Vector(2.0, 3.0, 0.0),
+               Vector(4.0, 0.0, 0.0)]
 
         obj = Draft.make_bspline(pts, False)
         obj.Placement.Base = base
         App.ActiveDocument.recompute()
-
-        _msg("  Scale")
-        _msg("  vector={}".format(sca))
-        _msg("  center={}".format(cen))
         Draft.scale([obj], sca, cen, False)
         App.ActiveDocument.recompute()
 
+        newPts = [Vector( 5.0,  5.5, 0.0),
+                  Vector( 9.0, 14.5, 0.0),
+                  Vector(13.0,  5.5, 0.0)]
         result = True
         for i in range(3):
-            ptNew = scale_vector_from_center(pts[i].add(base), sca, cen)
-            if not obj.Points[i].add(base).isEqual(ptNew, 1e-8):
+            if not obj.Points[i].add(base).isEqual(newPts[i], 1e-8):
                 result = False
                 break
+
         self.assertTrue(result, "'{}' failed".format(operation))
 
     def test_scale_wire(self):
@@ -747,33 +747,33 @@ class DraftModification(unittest.TestCase):
         operation = "Draft Scale wire"
         _msg("  Test '{}'".format(operation))
 
-        base = App.Vector(3.5, 2.5, 0)
-        cen = App.Vector(2, 1, 0) # center for scaling
-        sca = App.Vector(2, 3, 1)
-        pts = [App.Vector(0, 0, 0),
-               App.Vector(4, 0, 0),
-               App.Vector(4, 3, 0),
-               App.Vector(0, 3, 0)]
+        base = Vector(3.5, 2.5, 0.0)
+        cen = Vector(2.0, 1.0, 0.0) # center for scaling
+        sca = Vector(2.0, 3.0, 1.0)
+        pts = [Vector(0.0, 0.0, 0.0),
+               Vector(4.0, 0.0, 0.0),
+               Vector(4.0, 3.0, 0.0),
+               Vector(0.0, 3.0, 0.0)]
 
         obj = Draft.make_wire(pts, True)
         obj.Placement.Base = base
         App.ActiveDocument.recompute()
-
-        _msg("  Scale")
-        _msg("  vector={}".format(sca))
-        _msg("  center={}".format(cen))
         Draft.scale([obj], sca, cen, False)
         App.ActiveDocument.recompute()
 
+        newPts = [Vector( 5.0,  5.5, 0.0),
+                  Vector(13.0,  5.5, 0.0),
+                  Vector(13.0, 14.5, 0.0),
+                  Vector( 5.0, 14.5, 0.0)]
         vrts = obj.Shape.Vertexes
         result = True
         for i in range(4):
-            ptNew = scale_vector_from_center(pts[i].add(base), sca, cen)
-            if not vrts[i].Point.isEqual(ptNew, 1e-8):
+            if not vrts[i].Point.isEqual(newPts[i], 1e-8):
                 result = False
                 break
-        self.assertTrue(result, "'{}' failed".format(operation))
 
+        self.assertTrue(result, "'{}' failed".format(operation))
+        
     def tearDown(self):
         """Finish the test.
 

--- a/src/Mod/Draft/drafttests/test_modification.py
+++ b/src/Mod/Draft/drafttests/test_modification.py
@@ -28,7 +28,6 @@
 
 ## \addtogroup drafttests
 # @{
-import math
 import unittest
 
 import FreeCAD as App
@@ -628,25 +627,19 @@ class DraftModification(unittest.TestCase):
                    Vector(13.0, 14.5, 0.0),
                    Vector( 5.0, 14.5, 0.0)]
         vrts = obj.Shape.Vertexes
-        result = True
         for i in range(4):
-            if not vrts[i].Point.isEqual(newEnds[i], 1e-8):
-                result = False
-                break
+            self.assertTrue(vrts[i].Point.isEqual(newEnds[i], 1e-8),
+                            "'{}' failed".format(operation))
         # check midpoints of arcs:
-        if result == True:
-            newMids = [Vector( 9.0,  4.0, 0.0),
-                       Vector(14.0, 10.0, 0.0),
-                       Vector( 9.0, 16.0, 0.0),
-                       Vector( 4.0, 10.0, 0.0)]
-            for i in range(4):
-                edge = obj.Shape.Edges[i]
-                par = (edge.LastParameter - edge.FirstParameter) / 2.0
-                if not edge.valueAt(par).isEqual(newMids[i], 1e-8):
-                    result = False
-                    break
-
-        self.assertTrue(result, "'{}' failed".format(operation))
+        newMids = [Vector( 9.0,  4.0, 0.0),
+                   Vector(14.0, 10.0, 0.0),
+                   Vector( 9.0, 16.0, 0.0),
+                   Vector( 4.0, 10.0, 0.0)]
+        for i in range(4):
+            edge = obj.Shape.Edges[i]
+            par = (edge.LastParameter - edge.FirstParameter) / 2.0
+            self.assertTrue(edge.valueAt(par).isEqual(newMids[i], 1e-8),
+                            "'{}' failed".format(operation))
 
     def test_scale_part_feature_lines(self):
         """Create and scale a part feature (lines)."""
@@ -677,13 +670,9 @@ class DraftModification(unittest.TestCase):
                   Vector(13.0, 14.5, 0.0),
                   Vector( 5.0, 14.5, 0.0)]
         vrts = obj.Shape.Vertexes
-        result = True
         for i in range(4):
-            if not vrts[i].Point.isEqual(newPts[i], 1e-8):
-                result = False
-                break
-
-        self.assertTrue(result, "'{}' failed".format(operation))
+            self.assertTrue(vrts[i].Point.isEqual(newPts[i], 1e-8),
+                            "'{}' failed".format(operation))
 
     def test_scale_rectangle(self):
         """Create and scale a rectangle."""
@@ -705,13 +694,16 @@ class DraftModification(unittest.TestCase):
         newBase = Vector(5.0, 5.5, 0.0)
         newLen = 8.0
         newHgt = 9.0
-        result = obj.Placement.Base.isEqual(newBase, 1e-8)
-        if result == True:
-            result = math.isclose(obj.Length, newLen, abs_tol = 1e-8)
-        if result == True:
-            result = math.isclose(obj.Height, newHgt, abs_tol = 1e-8)
-
-        self.assertTrue(result, "'{}' failed".format(operation))
+        self.assertTrue(obj.Placement.Base.isEqual(newBase, 1e-8),
+                        "'{}' failed".format(operation))
+        self.assertAlmostEqual(obj.Length,
+                               newLen,
+                               delta = 1e-8,
+                               msg = "'{}' failed".format(operation))
+        self.assertAlmostEqual(obj.Height,
+                               newHgt,
+                               delta = 1e-8,
+                               msg = "'{}' failed".format(operation))
 
     def test_scale_spline(self):
         """Create and scale a spline."""
@@ -734,13 +726,9 @@ class DraftModification(unittest.TestCase):
         newPts = [Vector( 5.0,  5.5, 0.0),
                   Vector( 9.0, 14.5, 0.0),
                   Vector(13.0,  5.5, 0.0)]
-        result = True
         for i in range(3):
-            if not obj.Points[i].add(base).isEqual(newPts[i], 1e-8):
-                result = False
-                break
-
-        self.assertTrue(result, "'{}' failed".format(operation))
+            self.assertTrue(obj.Points[i].add(base).isEqual(newPts[i], 1e-8),
+                            "'{}' failed".format(operation))
 
     def test_scale_wire(self):
         """Create and scale a wire."""
@@ -766,14 +754,10 @@ class DraftModification(unittest.TestCase):
                   Vector(13.0, 14.5, 0.0),
                   Vector( 5.0, 14.5, 0.0)]
         vrts = obj.Shape.Vertexes
-        result = True
         for i in range(4):
-            if not vrts[i].Point.isEqual(newPts[i], 1e-8):
-                result = False
-                break
+            self.assertTrue(vrts[i].Point.isEqual(newPts[i], 1e-8),
+                            "'{}' failed".format(operation))
 
-        self.assertTrue(result, "'{}' failed".format(operation))
-        
     def tearDown(self):
         """Finish the test.
 


### PR DESCRIPTION
The added functions are test_scale_part_feature_arcs, test_scale_part_feature_lines, test_scale_rectangle, test_scale_spline and test_scale_wire.
When comparing vectors and floats a tolerance of 1e-8 is used, but only for the midpoints of the arcs in test_scale_part_feature_arcs is this tolerance required. Scaling a part feature is not possible with the Draft_Scale command, but Draft.scale does support it.