### PR TITLE
fix typo in src/Gui/DlgPropertyLink.ui [skip-ci]

### DIFF
--- a/src/Gui/DlgPropertyLink.ui
+++ b/src/Gui/DlgPropertyLink.ui
@@ -96,7 +96,7 @@
      <item>
       <widget class="QCheckBox" name="checkSubObject">
        <property name="toolTip">
-        <string>If enabled, then 3D view selection will be sychronize with full object hierarchy.</string>
+        <string>If enabled, then 3D view selection will be synchronized with full object hierarchy.</string>
        </property>
        <property name="text">
         <string>Sync sub-object selection</string>


### PR DESCRIPTION
Found via `codespell v2.0.dev0`  
```
codespell -q 3 -L aci,ake,aline,alle,alledges,alocation,als,ang,anid,ba,beginn,behaviour,bloaded,byteorder,calculater,cancelled,cancelling,cas,cascade,centimetre,childs,colour,colours,commen,connexion,currenty,dof,doubleclick,dum,eiter,elemente,ende,feld,finde,findf,freez,hist,iff,indicies,initialisation,initialise,initialised,initialises,initialisiert,ist,kilometre,lod,mantatory,methode,metres,millimetre,modell,nd,noe,normale,normaly,nto,numer,oder,orgin,orginx,orginy,ot,pard,pres,programm,que,recurrance,rougly,seperator,serie,sinc,strack,substraction,te,thist,thru,tread,uint,unter,vertexes,wallthickness,whitespaces -S ./.git,*.po,*.ts,./ChangeLog.txt,./src/3rdParty,./src/Mod/Assembly/App/opendcm,./src/CXX,./src/zipios++,./src/Base/swig*,./src/Mod/Robot/App/kdl_cp,./src/Mod/Import/App/SCL,./src/WindowsInstaller,./src/Doc/FreeCAD.uml 
```