### PR TITLE
[Path] Fixes #4433 - `Cut Side` reset with certain Base Geometry changes

### DIFF
--- a/src/Mod/Path/PathScripts/PathProfileGui.py
+++ b/src/Mod/Path/PathScripts/PathProfileGui.py
@@ -154,21 +154,6 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
             self.form.processHoles.hide()
             self.form.processPerimeter.hide()
 
-        side = False
-        if self.form.useCompensation.isChecked() is True:
-            if not fullModel:
-                side = True
-
-        if side:
-            self.form.cutSide.show()
-            self.form.cutSideLabel.show()
-        else:
-            # Reset cutSide to 'Outside' for full model before hiding cutSide input
-            if self.form.cutSide.currentText() == 'Inside':
-                self.selectInComboBox('Outside', self.form.cutSide)
-            self.form.cutSide.hide()
-            self.form.cutSideLabel.hide()
-
     def registerSignalHandlers(self, obj):
         self.form.useCompensation.stateChanged.connect(self.updateVisibility)
 # Eclass


### PR DESCRIPTION
`Cut Side` value was hard-coded to reset when Base Geometry was empty.  This disallowed retention of the current value with changes to selected Base Geometry involving the clearing thereof.
Also restored fixed visibility to `Cut Side` option in Task panel editor per forum mention.

Fixes #4433
Forum discussion at [Ticket #4433 - profile operation cut side reset](https://forum.freecadweb.org/viewtopic.php?style=3&f=15&t=49459)

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
