### PR TITLE
[Path] PocketShape - fix improper path generation

### DIFF
--- a/src/Mod/Path/PathScripts/PathPocketShape.py
+++ b/src/Mod/Path/PathScripts/PathPocketShape.py
@@ -665,7 +665,8 @@ class ObjectPocket(PathPocketBase.ObjectPocket):
                     shpZMin = face.BoundBox.ZMin
                     shpZMinVal = shpZMin
                     PathLog.debug('self.horizontal pre-shpZMin: {}'.format(shpZMin))
-                    if self.isFaceUp(subBase, face) is False:
+                    isFaceUp = self.isFaceUp(subBase, face)
+                    if not isFaceUp:
                         useAngle += 180.0
                         invZ = (-2 * shpZMin) - clrnc
                         face.translate(FreeCAD.Vector(0.0, 0.0, invZ))
@@ -684,9 +685,16 @@ class ObjectPocket(PathPocketBase.ObjectPocket):
                                 PathLog.warning(msg + ' {} mm.'.format(start_dep))
                             PathLog.debug('LimitDepthToFace adj_final_dep: {}'.format(adj_final_dep))
                     else:
-                        face.translate(FreeCAD.Vector(0, 0, obj.FinalDepth.Value - shpZMin))
+                        translation = obj.FinalDepth.Value - shpZMin
+                        if not isFaceUp:
+                            # Check if the `isFaceUp` returned correctly
+                            zDestination = face.BoundBox.ZMin + translation
+                            if (round(start_dep - obj.FinalDepth.Value, 6) !=
+                                round(start_dep - zDestination, 6)):
+                                shpZMin = -1 * shpZMin
+                        face.translate(FreeCAD.Vector(0, 0, translation))
                     
-                    extent = FreeCAD.Vector(0, 0, start_dep - shpZMin + clrnc)  # adj_final_dep + clrnc)
+                    extent = FreeCAD.Vector(0, 0, abs(start_dep - shpZMin) + clrnc)  # adj_final_dep + clrnc)
                     extShp = face.removeSplitter().extrude(extent)
                     self.removalshapes.append((extShp, False, 'pathPocketShape', useAngle, axis, start_dep, adj_final_dep))
                     PathLog.debug("Extent values are strDep: {}, finDep: {},  extrd: {}".format(start_dep, adj_final_dep, extent))


### PR DESCRIPTION
Forum identification and discussion at [Pocket path generated only on face depth if object is reversed or origin moved](https://forum.freecadweb.org/viewtopic.php?style=3&f=15&t=49513).

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
