### PR TITLE
Add SVG icon for Part Reverse Shape command

### DIFF
--- a/src/Mod/Part/Gui/Command.cpp
+++ b/src/Mod/Part/Gui/Command.cpp
@@ -1228,6 +1228,7 @@ CmdPartReverseShape::CmdPartReverseShape()
     sToolTipText  = QT_TR_NOOP("Reverse orientation of shapes");
     sWhatsThis    = "Part_ReverseShape";
     sStatusTip    = sToolTipText;
+    sPixmap       = "Part_Reverse_Shape";
 }
 
 void CmdPartReverseShape::activated(int iMsg)

--- a/src/Mod/Part/Gui/Resources/Part.qrc
+++ b/src/Mod/Part/Gui/Resources/Part.qrc
@@ -49,6 +49,7 @@
         <file>icons/Part_Polygon_Parametric.svg</file>
         <file>icons/Part_ProjectionOnSurface.svg</file>
         <file>icons/Part_Refine_Shape.svg</file>
+        <file>icons/Part_Reverse_Shape.svg</file>
         <file>icons/Part_Revolve.svg</file>
         <file>icons/Part_RuledSurface.svg</file>
         <file>icons/Part_Section.svg</file>

--- a/src/Mod/Part/Gui/Resources/icons/Part_Reverse_Shape.svg
+++ b/src/Mod/Part/Gui/Resources/icons/Part_Reverse_Shape.svg
@@ -1,0 +1,348 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   version="1.1"
+   id="svg2985"
+   height="64px"
+   width="64px">
+  <defs
+     id="defs2987">
+    <linearGradient
+       id="linearGradient3924">
+      <stop
+         id="stop3926"
+         offset="0"
+         style="stop-color:#ef2929;stop-opacity:1" />
+      <stop
+         id="stop3928"
+         offset="1"
+         style="stop-color:#cc0000;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3916">
+      <stop
+         id="stop3918"
+         offset="0"
+         style="stop-color:#ef2929;stop-opacity:1" />
+      <stop
+         id="stop3920"
+         offset="1"
+         style="stop-color:#cc0000;stop-opacity:1" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(1.2966028,0.17711231,-0.14092861,1.0317094,-32.689929,-29.109274)"
+       r="19.467436"
+       fy="83.989143"
+       fx="147.05713"
+       cy="83.989143"
+       cx="147.05713"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3705"
+       xlink:href="#linearGradient4387" />
+    <linearGradient
+       id="linearGradient4387">
+      <stop
+         id="stop4389"
+         offset="0"
+         style="stop-color:#71b2f8;stop-opacity:1;" />
+      <stop
+         id="stop4391"
+         offset="1"
+         style="stop-color:#002795;stop-opacity:1;" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(0.52711064,1.8158874,-1.4534843,0.42191331,203.23405,-187.6583)"
+       r="19.467436"
+       fy="93.557289"
+       fx="131.48187"
+       cy="93.557289"
+       cx="131.48187"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3703"
+       xlink:href="#linearGradient4387" />
+    <linearGradient
+       id="linearGradient6321">
+      <stop
+         id="stop6323"
+         offset="0"
+         style="stop-color:#71b2f8;stop-opacity:1;" />
+      <stop
+         id="stop6325"
+         offset="1"
+         style="stop-color:#002795;stop-opacity:1;" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="translate(-0.23443224,0.23443198)"
+       gradientUnits="userSpaceOnUse"
+       r="19.467436"
+       fy="28.869568"
+       fx="45.883327"
+       cy="28.869568"
+       cx="45.883327"
+       id="radialGradient3692"
+       xlink:href="#linearGradient3377" />
+    <linearGradient
+       id="linearGradient3377">
+      <stop
+         style="stop-color:#faff2b;stop-opacity:1;"
+         offset="0"
+         id="stop3379" />
+      <stop
+         style="stop-color:#ffaa00;stop-opacity:1;"
+         offset="1"
+         id="stop3381" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3377-3">
+      <stop
+         style="stop-color:#faff2b;stop-opacity:1;"
+         offset="0"
+         id="stop3379-8" />
+      <stop
+         style="stop-color:#ffaa00;stop-opacity:1;"
+         offset="1"
+         id="stop3381-3" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#linearGradient3377"
+       id="radialGradient6347"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-0.23443224,0.23443198)"
+       cx="45.883327"
+       cy="28.869568"
+       fx="45.883327"
+       fy="28.869568"
+       r="19.467436" />
+    <radialGradient
+       r="19.467436"
+       fy="28.869568"
+       fx="45.883327"
+       cy="28.869568"
+       cx="45.883327"
+       gradientTransform="matrix(0.67067175,0,0,0.64145918,-63.380792,0.83845403)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient6412"
+       xlink:href="#linearGradient3377-3" />
+    <radialGradient
+       r="19.467436"
+       fy="28.869568"
+       fx="45.883327"
+       cy="28.869568"
+       cx="45.883327"
+       gradientTransform="matrix(0.67067175,0,0,0.64145918,-87.325356,-15.679193)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient6412-7"
+       xlink:href="#linearGradient3377-3-9" />
+    <linearGradient
+       id="linearGradient3377-3-9">
+      <stop
+         style="stop-color:#faff2b;stop-opacity:1;"
+         offset="0"
+         id="stop3379-8-0" />
+      <stop
+         style="stop-color:#ffaa00;stop-opacity:1;"
+         offset="1"
+         id="stop3381-3-5" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(1)"
+       gradientUnits="userSpaceOnUse"
+       y2="34"
+       x2="58"
+       y1="13"
+       x1="43"
+       id="linearGradient3922"
+       xlink:href="#linearGradient3916" />
+    <linearGradient
+       gradientTransform="translate(1)"
+       gradientUnits="userSpaceOnUse"
+       y2="34"
+       x2="55"
+       y1="49"
+       x1="43"
+       id="linearGradient3930"
+       xlink:href="#linearGradient3924" />
+  </defs>
+  <metadata
+     id="metadata2990">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+        <cc:license
+           rdf:resource="https://www.gnu.org/copyleft/lesser.html" />
+        <dc:description>Shape with arrow pointing upwards and a double pointed curved arrow pointing from inside of the shape to the other side</dc:description>
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title>Based on Renovatorio's work</dc:title>
+          </cc:Agent>
+        </dc:contributor>
+        <dc:subject>
+          <rdf:Bag>
+            <rdf:li>shape</rdf:li>
+            <rdf:li>face</rdf:li>
+            <rdf:li>arrow</rdf:li>
+          </rdf:Bag>
+        </dc:subject>
+        <dc:relation />
+        <dc:identifier />
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>FreeCAD</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>FreeCAD LGPL2+</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>[bitacovir]</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:date>2020/03/18</dc:date>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1">
+    <g
+       transform="translate(-19.586948,-2.6850777)"
+       id="g3931" />
+    <g
+       id="g3118">
+      <g
+         style="stroke-width:3.5;stroke-miterlimit:4;stroke-dasharray:none"
+         id="g3060"
+         transform="matrix(0.67067175,0,0,0.55048347,-90.90697,-12.04625)">
+        <path
+           id="path3150-7"
+           d="M 181.76846,74.564006 V 110.8957 l -17.89251,14.53268 v -36.3317 z"
+           style="fill:#204a87;stroke:none" />
+        <path
+           id="path3930"
+           d="m 163.87595,121.79521 17.89251,-14.53268"
+           style="fill:none;stroke:#3465a4;stroke-width:3.29157;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+        <path
+           id="path3932-1"
+           d="M 178.78637,114.52887 V 78.197173"
+           style="fill:none;stroke:#3465a4;stroke-width:3.29157;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+        <path
+           id="path3934"
+           d="m 181.76846,78.197173 -17.89251,14.53268"
+           style="fill:none;stroke:#3465a4;stroke-width:3.29157;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+        <path
+           id="path3936"
+           d="M 166.85803,85.463513 V 121.79521"
+           style="fill:none;stroke:#3465a4;stroke-width:3.29157;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+        <path
+           id="path3152-1"
+           d="M 163.87595,125.42838 140.01927,110.8957 V 74.564003 l 23.85668,14.532677 z"
+           style="fill:#3465a4;stroke:none" />
+        <path
+           id="path3938"
+           d="M 160.89386,89.096683 V 121.79521"
+           style="fill:none;stroke:#729fcf;stroke-width:3.29157;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+        <path
+           id="path3940"
+           d="m 140.01927,107.26253 23.85668,14.53268"
+           style="fill:none;stroke:#729fcf;stroke-width:3.29157;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+        <path
+           id="path3942"
+           d="M 143.00136,110.8957 V 78.197173"
+           style="fill:none;stroke:#729fcf;stroke-width:3.29157;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+        <path
+           id="path3150"
+           d="M 181.76846,74.564003 V 110.8957 l -17.89251,14.53268 V 89.096683 Z"
+           style="fill:none;stroke:#0b1521;stroke-width:3.29157;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+        <path
+           id="path3944"
+           d="M 163.87595,92.729853 140.01927,78.197173"
+           style="fill:none;stroke:#729fcf;stroke-width:3.29157;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+        <path
+           id="path3152"
+           d="M 163.87595,125.42838 140.01927,110.8957 V 74.564003 l 23.85668,14.53268 z"
+           style="fill:none;stroke:#0b1521;stroke-width:3.29157;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+        <path
+           id="path3156"
+           d="m 181.76846,74.564003 -17.89251,14.53268 -23.85668,-14.53268 17.89251,-14.53268 23.85668,14.53268"
+           style="fill:#729fcf;stroke:#0b1521;stroke-width:3.29157;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" />
+      </g>
+      <path
+         style="fill:#cc0000;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+         d="M 34,15 44,5 v 6 c 0,0 17,0 17,24 0,20 -17,20 -17,20 v 6 L 34,51 44,41 v 6 C 44,47 54,47 54,35 54,19 44,19 44,19 v 6 z"
+         id="path3820-6-0" />
+      <rect
+         transform="translate(-19.586948,-2.6850777)"
+         y="16"
+         x="36"
+         height="15.685078"
+         width="5"
+         id="rect3848-9"
+         style="fill:#888a85;fill-opacity:1;stroke:none;stroke-width:0.885581" />
+      <path
+         transform="matrix(-0.89381012,0,0,0.64358296,101.13974,3.5349373)"
+         d="m 99.26795,15.196153 -14.5359,0 L 92,2.6076946 Z"
+         id="path3855-1"
+         style="fill:#888a85;fill-opacity:1;stroke:none" />
+      <rect
+         transform="translate(-19.586948,-2.6850777)"
+         y="16"
+         x="35.992332"
+         height="16.685078"
+         width="4"
+         id="rect3848-3-2"
+         style="fill:#888a85;stroke:#000000;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         transform="matrix(-0.82554287,0,0,0.64358296,94.355322,3.5349373)"
+         d="m 99.26795,15.196153 -14.5359,0 L 92,2.6076946 Z"
+         id="path3855-5-7"
+         style="fill:#888a85;stroke:#000000;stroke-width:2.74383;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <rect
+         transform="translate(-19.586948,-2.6850777)"
+         y="14.499998"
+         x="36.992332"
+         height="2.7"
+         width="2"
+         id="rect3899-0"
+         style="fill:#888a85;stroke:none" />
+      <path
+         style="fill:none;stroke:#ef2929;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="M 43.867204,7.9504952 35.626466,16.208292"
+         id="path3840" />
+      <path
+         style="fill:none;stroke:#ef2929;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 43.84881,44.007343 -8.189337,8.149421"
+         id="path3840-7" />
+      <path
+         style="fill:none;stroke:#ef2929;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 45,13 c -3,0 -3,-1 -3,-3"
+         id="path3932" />
+      <path
+         style="fill:none;stroke:#0b1521;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+         d="M 34,15 44,5 v 6 c 0,0 17,0 17,24 0,20 -17,20 -17,20 v 6 L 34,51 44,41 v 6 C 44,47 54,47 54,35 54,19 44,19 44,19 v 6 z"
+         id="path3820-6" />
+      <path
+         style="fill:none;stroke:url(#linearGradient3930);stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 44,49 c 0,0 12,0 12,-15"
+         id="path3912" />
+      <path
+         style="fill:none;stroke:url(#linearGradient3922);stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 44,13 c 0,0 15,0 15,21"
+         id="path3914" />
+      <path
+         style="fill:none;stroke:#ef2929;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 45,49 c -3,0 -3,-1 -3,-3"
+         id="path3932-2" />
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
Part Reverse Shape command does not have icon for the FreeCAD UI (Part WB).

This commit adds SVG file with icon for this command. Also, it makes the necessary changes on Command.cpp and Part.qrc files.

The new SVG icon follows the FreeCAD Artwork Guidelines and were saved as Plain SVG format.

The icon designs keep the style of the existing icons in the Part Workbench:
https://wiki.freecadweb.org/Part_Module

The discussion with the request can be found in the UX/UI Design FreeCAD Forum:
https://forum.freecadweb.org/viewtopic.php?f=34&t=44278&hilit=bitacovir