### PR TITLE
Spreadsheet: fixes issue #4429; Move the aliases before other content of cells

### DIFF
--- a/src/Mod/Spreadsheet/App/PropertySheet.h
+++ b/src/Mod/Spreadsheet/App/PropertySheet.h
@@ -98,7 +98,7 @@ public:
 
     void setSpans(App::CellAddress address, int rows, int columns);
 
-    void clear(App::CellAddress address);
+    void clear(App::CellAddress address, bool toClearAlias=true);
 
     void clear();
 
@@ -125,8 +125,6 @@ public:
     void clearDirty() { dirty.clear(); purgeTouched(); }
 
     bool isDirty() const { return dirty.size() > 0; }
-
-    void moveCell(App::CellAddress currPos, App::CellAddress newPos, std::map<App::ObjectIdentifier, App::ObjectIdentifier> &renames);
 
     void pasteCells(const std::map<App::CellAddress, std::string> &cells, int rowOffset, int colOffset);
 
@@ -215,6 +213,12 @@ private:
 
     /*! Owner of this property */
     Sheet * owner;
+
+    void clearAlias(App::CellAddress address);
+
+    void moveAlias(App::CellAddress currPos, App::CellAddress newPos);
+
+    void moveCell(App::CellAddress currPos, App::CellAddress newPos, std::map<App::ObjectIdentifier, App::ObjectIdentifier> &renames);
 
     /*
      * Cell dependency tracking

--- a/src/Mod/Spreadsheet/TestSpreadsheet.py
+++ b/src/Mod/Spreadsheet/TestSpreadsheet.py
@@ -1017,6 +1017,57 @@ class SpreadsheetCases(unittest.TestCase):
         self.doc.recompute()
         self.assertEqual(sheet.get('C1'), Units.Quantity('3 mm'))
 
+    def testInsertRowsAlias(self):
+        """ Regression test for issue 4429; insert rows to sheet with aliases"""
+        sheet = self.doc.addObject('Spreadsheet::Sheet','Spreadsheet')
+        sheet.set('A3', '1')
+        sheet.setAlias('A3', 'alias1')
+        sheet.set('A4', '=alias1 + 1')
+        sheet.setAlias('A4', 'alias2')
+        sheet.set('A5', '=alias2 + 1')
+        self.doc.recompute()
+        sheet.insertRows('1', 1)
+        self.doc.recompute()
+        self.assertEqual(sheet.A6, 3)
+
+    def testInsertColumnsAlias(self):
+        """ Regression test for issue 4429; insert columns to sheet with aliases"""
+        sheet = self.doc.addObject('Spreadsheet::Sheet','Spreadsheet')
+        sheet.set('C1', '1')
+        sheet.setAlias('C1', 'alias1')
+        sheet.set('D1', '=alias1 + 1')
+        sheet.setAlias('D1', 'alias2')
+        sheet.set('E1', '=alias2 + 1')
+        self.doc.recompute()
+        sheet.insertColumns('A', 1)
+        self.doc.recompute()
+        self.assertEqual(sheet.F1, 3)
+
+    def testRemoveRowsAlias(self):
+        """ Regression test for issue 4429; remove rows from sheet with aliases"""
+        sheet = self.doc.addObject('Spreadsheet::Sheet','Spreadsheet')
+        sheet.set('A3', '1')
+        sheet.setAlias('A3', 'alias1')
+        sheet.set('A5', '=alias1 + 1')
+        sheet.setAlias('A5', 'alias2')
+        sheet.set('A4', '=alias2 + 1')
+        self.doc.recompute()
+        sheet.removeRows('1', 1)
+        self.doc.recompute()
+        self.assertEqual(sheet.A3, 3)
+
+    def testRemoveColumnsAlias(self):
+        """ Regression test for issue 4429; remove columns from sheet with aliases"""
+        sheet = self.doc.addObject('Spreadsheet::Sheet','Spreadsheet')
+        sheet.set('C1', '1')
+        sheet.setAlias('C1', 'alias1')
+        sheet.set('E1', '=alias1 + 1')
+        sheet.setAlias('E1', 'alias2')
+        sheet.set('D1', '=alias2 + 1')
+        self.doc.recompute()
+        sheet.removeColumns('A', 1)
+        self.doc.recompute()
+        self.assertEqual(sheet.C1, 3)
 
     def tearDown(self):
         #closing doc


### PR DESCRIPTION
Move the aliases before other content of cells

When a user performs insert rows, remove rows, insert columns, or
remove rows, we need to move multiple cells as a batch. The cells are
moved sequentially. For each cell, its dependent alias positions are
looked up and dependencies are added.  However, those cells with
aliases may be moved later in the batch. Thus the earlier dependencies
become wrong. This commit fixes this bug by moving all the aliases
before moving the cells. Unit tests are added to for this bug.

fixes issue #4429

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [*] Branch rebased on latest master `git pull --rebase upstream master`
- [*] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [*] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [*] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
