### PR TITLE
Path: add missing postprocessor to CMakeLists

### DIFF
--- a/src/Mod/Path/CMakeLists.txt
+++ b/src/Mod/Path/CMakeLists.txt
@@ -142,6 +142,7 @@ SET(PathScripts_post_SRCS
     PathScripts/post/jtech_post.py
     PathScripts/post/linuxcnc_post.py
     PathScripts/post/mach3_mach4_post.py
+    PathScripts/post/nccad_post.py
     PathScripts/post/opensbp_post.py
     PathScripts/post/opensbp_pre.py
     PathScripts/post/philips_post.py

--- a/src/Mod/Path/CMakeLists.txt
+++ b/src/Mod/Path/CMakeLists.txt
@@ -86,8 +86,8 @@ SET(PathScripts_SRCS
     PathScripts/PathPreferences.py
     PathScripts/PathPreferencesPathDressup.py
     PathScripts/PathPreferencesPathJob.py
-	PathScripts/PathProbe.py
-	PathScripts/PathProbeGui.py
+    PathScripts/PathProbe.py
+    PathScripts/PathProbeGui.py
     PathScripts/PathProfile.py
     PathScripts/PathProfileContour.py
     PathScripts/PathProfileContourGui.py
@@ -152,27 +152,27 @@ SET(PathScripts_post_SRCS
 )
 
 SET(Tools_Bit_SRCS
-  Tools/Bit/t1.fctb
-  Tools/Bit/t2.fctb
-  Tools/Bit/t3.fctb
-  Tools/Bit/t4.fctb
-  Tools/Bit/t5.fctb
-  Tools/Bit/t6.fctb
-  Tools/Bit/t7.fctb
-  Tools/Bit/t8.fctb
-  Tools/Bit/t9.fctb
+    Tools/Bit/t1.fctb
+    Tools/Bit/t2.fctb
+    Tools/Bit/t3.fctb
+    Tools/Bit/t4.fctb
+    Tools/Bit/t5.fctb
+    Tools/Bit/t6.fctb
+    Tools/Bit/t7.fctb
+    Tools/Bit/t8.fctb
+    Tools/Bit/t9.fctb
 )
 
 SET(Tools_Library_SRCS
-  Tools/Library/endmills.fctl
+    Tools/Library/endmills.fctl
 )
 
 SET(Tools_Shape_SRCS
-  Tools/Shape/ballend.fcstd
-  Tools/Shape/bullnose.fcstd
-  Tools/Shape/drill.fcstd
-  Tools/Shape/endmill.fcstd
-  Tools/Shape/v-bit.fcstd
+    Tools/Shape/ballend.fcstd
+    Tools/Shape/bullnose.fcstd
+    Tools/Shape/drill.fcstd
+    Tools/Shape/endmill.fcstd
+    Tools/Shape/v-bit.fcstd
 )
 
 SET(PathTests_SRCS

--- a/src/Mod/Path/PathScripts/post/nccad_post.py
+++ b/src/Mod/Path/PathScripts/post/nccad_post.py
@@ -1,34 +1,34 @@
-# *********************************************************************************************
-# *   Copyright (c) 2019/2020 Rene 'Renne' Bartsch, B.Sc. Informatics <rene@bartschnet.de>    *
-# *                                                                                           *
-# *   This file is part of the FreeCAD CAx development system.                                *
-# *                                                                                           *
-# *   This program is free software; you can redistribute it and/or modify                    *
-# *   it under the terms of the GNU Lesser General Public License (LGPL)                      *
-# *   as published by the Free Software Foundation; either version 2 of                       *
-# *   the License, or (at your option) any later version.                                     *
-# *   for detail see the LICENCE text file.                                                   *
-# *                                                                                           *
-# *   FreeCAD is distributed in the hope that it will be useful,                              *
-# *   but WITHOUT ANY WARRANTY; without even the implied warranty of                          *
-# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the                           *
-# *   GNU Lesser General Public License for more details.                                     *
-# *                                                                                           *
-# *   You should have received a copy of the GNU Library General Public                       *
-# *   License along with FreeCAD; if not, write to the Free Software                          *
-# *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307                    *
-# *   USA                                                                                     *
-# *                                                                                           *
-# ********************************************************************************************/
-import FreeCAD
-import PathScripts
+# *****************************************************************************
+# *   Copyright (c) 2020 Rene Bartsch, B.Sc. Informatics <rene@bartschnet.de> *
+# *                                                                           *
+# *   This file is part of the FreeCAD CAx development system.                *
+# *                                                                           *
+# *   This program is free software; you can redistribute it and/or modify    *
+# *   it under the terms of the GNU Lesser General Public License (LGPL)      *
+# *   as published by the Free Software Foundation; either version 2 of       *
+# *   the License, or (at your option) any later version.                     *
+# *   for detail see the LICENCE text file.                                   *
+# *                                                                           *
+# *   FreeCAD is distributed in the hope that it will be useful,              *
+# *   but WITHOUT ANY WARRANTY; without even the implied warranty of          *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the           *
+# *   GNU Lesser General Public License for more details.                     *
+# *                                                                           *
+# *   You should have received a copy of the GNU Library General Public       *
+# *   License along with FreeCAD; if not, write to the Free Software          *
+# *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307    *
+# *   USA                                                                     *
+# *                                                                           *
+# ****************************************************************************/
+"""Postprocessor to output real GCode for Max Computer GmbH nccad9."""
+import FreeCAD as App
 from PathScripts import PostUtils
 import datetime
 
 
-TOOLTIP='''
+TOOLTIP = '''
 This is a postprocessor file for the Path workbench. It is used to take
-a pseudo-gcode fragment outputted by a Path object and output real GCode
+a pseudo-gcode fragment output by a Path object and output real GCode
 suitable for the Max Computer GmbH nccad9 Computer Numeric Control.
 
 Supported features:
@@ -37,7 +37,11 @@ Supported features:
 - manual tool change with tool number as comment
 - spindle speed as comment
 
-!!! gCode files must use the suffix .knc !!!'''
+!!! gCode files must use the suffix .knc !!!
+
+import nccad_post
+nccad_post.export([object], "/path/to/file.knc", "")
+'''
 
 
 MACHINE_NAME = '''Max Computer GmbH nccad9 MCS/KOSY'''
@@ -57,60 +61,69 @@ POSTAMBLE = '''G77      ; Move to release position
 M10 O6.0 ; Stop spindle'''
 
 
-# gCode header with information about CAD-software, post-processor and date/time
+# gCode header with information about CAD-software, post-processor
+# and date/time
 HEADER = ''';Exported by FreeCAD
 ;Post Processor: {}
 ;CAM file: {}
 ;Output Time: {}
-'''.format(__name__, FreeCAD.ActiveDocument.FileName, str(datetime.datetime.now()))
+'''.format(__name__, App.ActiveDocument.FileName, str(datetime.datetime.now()))
 
 
 def export(objectslist, filename, argstring):
+    """Export the list of objects into a filename.
 
-  gcode = HEADER
+    Parameters
+    ----------
+    objectslists: list
+        List of objects.
 
-  for obj in objectslist:
+    filename: str
+        Name of the output file ending in `'.knc'`.
+    """
+    gcode = HEADER
 
-    for command in obj.Path.Commands:
+    for obj in objectslist:
+        for command in obj.Path.Commands:
+            # Manipulate tool change commands
+            if 'M6' == command.Name:
+                gcode += TOOL_CHANGE.replace('TOOL',
+                                             str(int(command.Parameters['T'])))
+            elif 'M3' == command.Name:
+                # Convert spindle speed (rpm) command to comment
+                gcode += ('M01 Set spindle speed to '
+                          + str(int(command.Parameters['S']))
+                          + ' rounds per minute')
+            else:
+                # Add other commands
+                gcode += command.Name
 
-      # Manipulate tool change commands
-      if 'M6' == command.Name:
-        gcode += TOOL_CHANGE.replace('TOOL', str(int(command.Parameters['T'])))
+                # Loop through command parameters
+                for parameter, value in command.Parameters.items():
+                    # Multiply F parameter value by 10,
+                    # FreeCAD = mm/s, nccad = 1/10 mm/s
+                    if 'F' == parameter:
+                        value *= 10
+                    # Add command parameters and values and round float
+                    # as nccad9 does not support exponents
+                    gcode += ' ' + parameter + str(round(value, 5))
 
-      # Convert spindle speed (rpm) command to comment
-      elif 'M3' == command.Name:
-        gcode += 'M01 Set spindle speed to ' + str(int(command.Parameters['S'])) + ' rounds per minute'
+            gcode += '\n'
 
-      # Add other commands
-      else:
-        gcode += command.Name
+    gcode += POSTAMBLE + '\n'
 
-        # Loop through command parameters
-        for parameter, value in command.Parameters.items():
+    # Open editor window
+    if App.GuiUp:
+        dia = PostUtils.GCodeEditorDialog()
+        dia.editor.setText(gcode)
+        result = dia.exec_()
+        if result:
+            gcode = dia.editor.toPlainText()
 
-          # Multiply F parameter value by 10 (FreeCAD = mm/s, nccad = 1/10 mm/s)
-          if 'F' == parameter:
-            value *= 10
+    # Save to file
+    if filename != '-':
+        gfile = open(filename, "w")
+        gfile.write(gcode)
+        gfile.close()
 
-          # Add command parameters and values and round float as nccad9 does not support exponents
-          gcode += ' ' + parameter + str(round(value, 5))
-
-      gcode += '\n'
-
-  gcode += POSTAMBLE + '\n'
-
-  # Open editor window
-  if FreeCAD.GuiUp:
-    dia = PostUtils.GCodeEditorDialog()
-    dia.editor.setText(gcode)
-    result = dia.exec_()
-    if result:
-      gcode = dia.editor.toPlainText()
-
-  # Save to file
-  if filename != '-':
-    gfile = open(filename, "w")
-    gfile.write(gcode)
-    gfile.close()
-
-  return filename
+    return filename


### PR DESCRIPTION
The file in #2876 was not added to the `CMakeLists.txt`, so it wasn't installed when compilation occurs.

---

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists