### PR TITLE
[PD] fix wording for skew prisms

### DIFF
--- a/src/Mod/Part/App/PrimitiveFeature.cpp
+++ b/src/Mod/Part/App/PrimitiveFeature.cpp
@@ -564,12 +564,12 @@ Prism::Prism(void)
     ADD_PROPERTY_TYPE(Polygon, (6.0), "Prism", App::Prop_None, "Number of sides in the polygon, of the prism");
     ADD_PROPERTY_TYPE(Circumradius, (2.0), "Prism", App::Prop_None, "Circumradius (centre to vertex) of the polygon, of the prism");
     ADD_PROPERTY_TYPE(Height, (10.0f), "Prism", App::Prop_None, "The height of the prism");
-    ADD_PROPERTY_TYPE(FirstSkew, (0.0f), "Prism", App::Prop_None, "Angle in first direction");
-    ADD_PROPERTY_TYPE(SecondSkew, (0.0f), "Prism", App::Prop_None, "Angle in second direction");
+    ADD_PROPERTY_TYPE(FirstAngle, (0.0f), "Prism", App::Prop_None, "Angle in first direction");
+    ADD_PROPERTY_TYPE(SecondAngle, (0.0f), "Prism", App::Prop_None, "Angle in second direction");
     Polygon.setConstraints(&polygonRange);
     static const App::PropertyQuantityConstraint::Constraints angleConstraint = { -89.99999, 89.99999, 1.0 };
-    FirstSkew.setConstraints(&angleConstraint);
-    SecondSkew.setConstraints(&angleConstraint);
+    FirstAngle.setConstraints(&angleConstraint);
+    SecondAngle.setConstraints(&angleConstraint);
 }
 
 short Prism::mustExecute() const
@@ -580,9 +580,9 @@ short Prism::mustExecute() const
         return 1;
     if (Height.isTouched())
         return 1;
-    if (FirstSkew.isTouched())
+    if (FirstAngle.isTouched())
         return 1;
-    if (SecondSkew.isTouched())
+    if (SecondAngle.isTouched())
         return 1;
     return Primitive::mustExecute();
 }
@@ -611,10 +611,10 @@ App::DocumentObjectExecReturn *Prism::execute(void)
         }
         mkPoly.Add(gp_Pnt(v.x,v.y,v.z));
         BRepBuilderAPI_MakeFace mkFace(mkPoly.Wire());
-        // the direction vector for the prism is the height for z and the skew
+        // the direction vector for the prism is the height for z and the given angle
         BRepPrimAPI_MakePrism mkPrism(mkFace.Face(),
-            gp_Vec(Height.getValue() * tan(Base::toRadians<double>(FirstSkew.getValue())),
-                   Height.getValue() * tan(Base::toRadians<double>(SecondSkew.getValue())),
+            gp_Vec(Height.getValue() * tan(Base::toRadians<double>(FirstAngle.getValue())),
+                   Height.getValue() * tan(Base::toRadians<double>(SecondAngle.getValue())),
                    Height.getValue()));
         this->Shape.setValue(mkPrism.Shape());
     }

--- a/src/Mod/Part/App/PrimitiveFeature.h
+++ b/src/Mod/Part/App/PrimitiveFeature.h
@@ -209,8 +209,8 @@ public:
     App::PropertyIntegerConstraint Polygon;
     App::PropertyLength Circumradius;
     App::PropertyLength Height;
-    App::PropertyAngle FirstSkew;
-    App::PropertyAngle SecondSkew;
+    App::PropertyAngle FirstAngle;
+    App::PropertyAngle SecondAngle;
 
     /** @name methods override feature */
     //@{

--- a/src/Mod/Part/Gui/DlgPrimitives.cpp
+++ b/src/Mod/Part/Gui/DlgPrimitives.cpp
@@ -501,8 +501,8 @@ void DlgPrimitives::createPrimitive(const QString& placement)
                 "App.ActiveDocument.%1.Polygon=%2\n"
                 "App.ActiveDocument.%1.Circumradius=%3\n"
                 "App.ActiveDocument.%1.Height=%4\n"
-                "App.ActiveDocument.%1.FirstSkew=%5\n"
-                "App.ActiveDocument.%1.SecondSkew=%6\n"
+                "App.ActiveDocument.%1.FirstAngle=%5\n"
+                "App.ActiveDocument.%1.SecondAngle=%6\n"
                 "App.ActiveDocument.%1.Placement=%7\n"
                 "App.ActiveDocument.%1.Label='%8'\n")
                 .arg(name)

--- a/src/Mod/PartDesign/App/FeaturePrimitive.cpp
+++ b/src/Mod/PartDesign/App/FeaturePrimitive.cpp
@@ -535,11 +535,11 @@ Prism::Prism()
     ADD_PROPERTY_TYPE(Polygon, (6.0), "Prism", App::Prop_None, "Number of sides in the polygon, of the prism");
     ADD_PROPERTY_TYPE(Circumradius, (2.0), "Prism", App::Prop_None, "Circumradius (centre to vertex) of the polygon, of the prism");
     ADD_PROPERTY_TYPE(Height, (10.0f), "Prism", App::Prop_None, "The height of the prism");
-    ADD_PROPERTY_TYPE(FirstSkew, (0.0f), "Prism", App::Prop_None, "Angle in first direction");
-    ADD_PROPERTY_TYPE(SecondSkew, (0.0f), "Prism", App::Prop_None, "Angle in second direction");
+    ADD_PROPERTY_TYPE(FirstAngle, (0.0f), "Prism", App::Prop_None, "Angle in first direction");
+    ADD_PROPERTY_TYPE(SecondAngle, (0.0f), "Prism", App::Prop_None, "Angle in second direction");
     static const App::PropertyQuantityConstraint::Constraints angleConstraint = { -89.99999, 89.99999, 1.0 };
-    FirstSkew.setConstraints(&angleConstraint);
-    SecondSkew.setConstraints(&angleConstraint);
+    FirstAngle.setConstraints(&angleConstraint);
+    SecondAngle.setConstraints(&angleConstraint);
 
     primitiveType = FeaturePrimitive::Prism;
 }
@@ -568,10 +568,10 @@ App::DocumentObjectExecReturn* Prism::execute(void)
         }
         mkPoly.Add(gp_Pnt(v.x,v.y,v.z));
         BRepBuilderAPI_MakeFace mkFace(mkPoly.Wire());
-        // the direction vector for the prism is the height for z and the skew
+        // the direction vector for the prism is the height for z and the given angle
         BRepPrimAPI_MakePrism mkPrism(mkFace.Face(),
-            gp_Vec(Height.getValue() * tan(Base::toRadians<double>(FirstSkew.getValue())),
-                   Height.getValue() * tan(Base::toRadians<double>(SecondSkew.getValue())),
+            gp_Vec(Height.getValue() * tan(Base::toRadians<double>(FirstAngle.getValue())),
+                   Height.getValue() * tan(Base::toRadians<double>(SecondAngle.getValue())),
                    Height.getValue()));
         return FeaturePrimitive::execute(mkPrism.Shape());
     }
@@ -590,9 +590,9 @@ short int Prism::mustExecute() const
         return 1;
     if (Height.isTouched())
         return 1;
-    if (FirstSkew.isTouched())
+    if (FirstAngle.isTouched())
         return 1;
-    if (SecondSkew.isTouched())
+    if (SecondAngle.isTouched())
         return 1;
 
     return FeaturePrimitive::mustExecute();

--- a/src/Mod/PartDesign/App/FeaturePrimitive.h
+++ b/src/Mod/PartDesign/App/FeaturePrimitive.h
@@ -318,8 +318,8 @@ public:
     App::PropertyIntegerConstraint Polygon;
     App::PropertyLength Circumradius;
     App::PropertyLength Height;
-    App::PropertyAngle FirstSkew;
-    App::PropertyAngle SecondSkew;
+    App::PropertyAngle FirstAngle;
+    App::PropertyAngle SecondAngle;
     
     /** @name methods override feature */
     //@{

--- a/src/Mod/PartDesign/Gui/TaskPrimitiveParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskPrimitiveParameters.cpp
@@ -192,10 +192,10 @@ TaskBoxPrimitives::TaskBoxPrimitives(ViewProviderPrimitive* vp, QWidget* parent)
             ui->prismCircumradius->bind(static_cast<PartDesign::Prism*>(vp->getObject())->Circumradius);
             ui->prismHeight->setValue(static_cast<PartDesign::Prism*>(vp->getObject())->Height.getValue());
             ui->prismHeight->bind(static_cast<PartDesign::Prism*>(vp->getObject())->Height);
-            ui->prismXSkew->setValue(static_cast<PartDesign::Prism*>(vp->getObject())->FirstSkew.getValue());
-            ui->prismXSkew->bind(static_cast<PartDesign::Prism*>(vp->getObject())->FirstSkew);
-            ui->prismYSkew->setValue(static_cast<PartDesign::Prism*>(vp->getObject())->SecondSkew.getValue());
-            ui->prismYSkew->bind(static_cast<PartDesign::Prism*>(vp->getObject())->SecondSkew);
+            ui->prismXSkew->setValue(static_cast<PartDesign::Prism*>(vp->getObject())->FirstAngle.getValue());
+            ui->prismXSkew->bind(static_cast<PartDesign::Prism*>(vp->getObject())->FirstAngle);
+            ui->prismYSkew->setValue(static_cast<PartDesign::Prism*>(vp->getObject())->SecondAngle.getValue());
+            ui->prismYSkew->bind(static_cast<PartDesign::Prism*>(vp->getObject())->SecondAngle);
             ui->prismCircumradius->setMaximum(INT_MAX);
             ui->prismCircumradius->setMinimum(0.0);
             ui->prismHeight->setMaximum(INT_MAX);
@@ -531,14 +531,14 @@ void TaskBoxPrimitives::onPrismXSkewChanged(double v) {
     // we must assure that if the user incremented from e.g. 85 degree with the
     // spin buttons he does not end at 90.0 but 89.9999 which is shown rounded to 90 degree
     if ((v < 90.0) && (v > -90.0)) {
-        sph->FirstSkew.setValue(v);
+        sph->FirstAngle.setValue(v);
     }
     else {
         if (v == 90.0)
-            sph->FirstSkew.setValue(89.99999);
+            sph->FirstAngle.setValue(89.99999);
         else if (v == -90.0)
-            sph->FirstSkew.setValue(-89.99999);
-        ui->prismXSkew->setValue(sph->FirstSkew.getQuantityValue());
+            sph->FirstAngle.setValue(-89.99999);
+        ui->prismXSkew->setValue(sph->FirstAngle.getQuantityValue());
     }
     vp->getObject()->getDocument()->recomputeFeature(vp->getObject());
 }
@@ -548,14 +548,14 @@ void TaskBoxPrimitives::onPrismYSkewChanged(double v) {
     // we must assure that if the user incremented from e.g. 85 degree with the
     // spin buttons he does not end at 90.0 but 89.9999 which is shown rounded to 90 degree
     if ((v < 90.0) && (v > -90.0)) {
-        sph->SecondSkew.setValue(v);
+        sph->SecondAngle.setValue(v);
     }
     else {
         if (v == 90.0)
-            sph->SecondSkew.setValue(89.99999);
+            sph->SecondAngle.setValue(89.99999);
         else if (v == -90.0)
-            sph->SecondSkew.setValue(-89.99999);
-        ui->prismYSkew->setValue(sph->SecondSkew.getQuantityValue());
+            sph->SecondAngle.setValue(-89.99999);
+        ui->prismYSkew->setValue(sph->SecondAngle.getQuantityValue());
     }
     vp->getObject()->getDocument()->recomputeFeature(vp->getObject());
 }
@@ -733,8 +733,8 @@ void  TaskBoxPrimitives::setPrimitive(App::DocumentObject *obj)
                     "%1.Polygon=%2\n"
                     "%1.Circumradius=%3\n"
                     "%1.Height=%4\n"
-                    "%1.FirstSkew=%5\n"
-                    "%1.SecondSkew=%6\n")
+                    "%1.FirstAngle=%5\n"
+                    "%1.SecondAngle=%6\n")
                     .arg(name)
                     .arg(ui->prismPolygon->value())
                     .arg(ui->prismCircumradius->value().getValue(), 0, 'f', Base::UnitsApi::getDecimals())


### PR DESCRIPTION
the UI and the property is not consistent. In the dialog we use the term angle upon user feedback while the property still has the name "skew" in it.
I simply forgot this change in my PR that implemented skew prisms.

This is now corrected by this PR.