### PR TITLE
Part: use uIso() and vIso() methods from base Surface object

### DIFF
--- a/src/Mod/Part/App/BSplineSurfacePy.xml
+++ b/src/Mod/Part/App/BSplineSurfacePy.xml
@@ -668,16 +668,6 @@
 				</UserDocu>
 			</Documentation>
 		</Methode>
-        <Methode Name="uIso" Const="true">
-			<Documentation>
-				<UserDocu>Builds the U isoparametric B-Spline curve of this B-Spline surface</UserDocu>
-			</Documentation>
-		</Methode>
-        <Methode Name="vIso" Const="true">
-			<Documentation>
-				<UserDocu>Builds the V isoparametric B-Spline curve of this B-Spline surface</UserDocu>
-			</Documentation>
-		</Methode>
 		<Methode Name="reparametrize" Const="true">
 			<Documentation>
 				<UserDocu>Returns a reparametrized copy of this surface</UserDocu>

--- a/src/Mod/Part/App/BSplineSurfacePyImp.cpp
+++ b/src/Mod/Part/App/BSplineSurfacePyImp.cpp
@@ -1109,42 +1109,6 @@ PyObject* BSplineSurfacePy::exchangeUV(PyObject *args)
     Py_Return;
 }
 
-PyObject* BSplineSurfacePy::uIso(PyObject * args)
-{
-    double u;
-    if (!PyArg_ParseTuple(args, "d", &u))
-        return 0;
-
-    try {
-        Handle(Geom_BSplineSurface) surf = Handle(Geom_BSplineSurface)::DownCast
-            (getGeometryPtr()->handle());
-        Handle(Geom_Curve) c = surf->UIso(u);
-        return new BSplineCurvePy(new GeomBSplineCurve(Handle(Geom_BSplineCurve)::DownCast(c)));
-    }
-    catch (Standard_Failure& e) {
-        PyErr_SetString(PartExceptionOCCError, e.GetMessageString());
-        return 0;
-    }
-}
-
-PyObject* BSplineSurfacePy::vIso(PyObject * args)
-{
-    double v;
-    if (!PyArg_ParseTuple(args, "d", &v))
-        return 0;
-
-    try {
-        Handle(Geom_BSplineSurface) surf = Handle(Geom_BSplineSurface)::DownCast
-            (getGeometryPtr()->handle());
-        Handle(Geom_Curve) c = surf->VIso(v);
-        return new BSplineCurvePy(new GeomBSplineCurve(Handle(Geom_BSplineCurve)::DownCast(c)));
-    }
-    catch (Standard_Failure& e) {
-        PyErr_SetString(PartExceptionOCCError, e.GetMessageString());
-        return 0;
-    }
-}
-
 PyObject* BSplineSurfacePy::reparametrize(PyObject * args)
 {
     int u,v;

--- a/src/Mod/Part/App/BezierSurfacePy.xml
+++ b/src/Mod/Part/App/BezierSurfacePy.xml
@@ -308,15 +308,5 @@
 				</UserDocu>
 			</Documentation>
 		</Methode>
-        <Methode Name="uIso" Const="true">
-			<Documentation>
-				<UserDocu>Builds the U isoparametric Bezier curve of this Bezier surface</UserDocu>
-			</Documentation>
-		</Methode>
-        <Methode Name="vIso" Const="true">
-			<Documentation>
-				<UserDocu>Builds the V isoparametric Bezier curve of this Bezier surface</UserDocu>
-			</Documentation>
-		</Methode>
 	</PythonExport>
 </GenerateModel>

--- a/src/Mod/Part/App/BezierSurfacePyImp.cpp
+++ b/src/Mod/Part/App/BezierSurfacePyImp.cpp
@@ -672,41 +672,6 @@ PyObject* BezierSurfacePy::exchangeUV(PyObject *args)
     }
 }
 
-PyObject* BezierSurfacePy::uIso(PyObject * args)
-{
-    double u;
-    if (!PyArg_ParseTuple(args, "d", &u))
-        return 0;
-
-    try {
-        Handle(Geom_BezierSurface) surf = Handle(Geom_BezierSurface)::DownCast
-            (getGeometryPtr()->handle());
-        Handle(Geom_Curve) c = surf->UIso(u);
-        return new BezierCurvePy(new GeomBezierCurve(Handle(Geom_BezierCurve)::DownCast(c)));
-    }
-    catch (Standard_Failure& e) {
-        PyErr_SetString(PartExceptionOCCError, e.GetMessageString());
-        return 0;
-    }
-}
-
-PyObject* BezierSurfacePy::vIso(PyObject * args)
-{
-    double v;
-    if (!PyArg_ParseTuple(args, "d", &v))
-        return 0;
-
-    try {
-        Handle(Geom_BezierSurface) surf = Handle(Geom_BezierSurface)::DownCast
-            (getGeometryPtr()->handle());
-        Handle(Geom_Curve) c = surf->VIso(v);
-        return new BezierCurvePy(new GeomBezierCurve(Handle(Geom_BezierCurve)::DownCast(c)));
-    }
-    catch (Standard_Failure& e) {
-        PyErr_SetString(PartExceptionOCCError, e.GetMessageString());
-        return 0;
-    }
-}
 Py::Long BezierSurfacePy::getUDegree(void) const
 {
     Handle(Geom_BezierSurface) surf = Handle(Geom_BezierSurface)::DownCast

--- a/src/Mod/Part/App/ConePy.xml
+++ b/src/Mod/Part/App/ConePy.xml
@@ -71,15 +71,5 @@
 			</Documentation>
 			<Parameter Name="Axis" Type="Object"/>
 		</Attribute>
-        <Methode Name="uIso" Const="true">
-			<Documentation>
-				<UserDocu>Builds the U isoparametric circle of this cone</UserDocu>
-			</Documentation>
-		</Methode>
-        <Methode Name="vIso" Const="true">
-			<Documentation>
-				<UserDocu>Builds the V isoparametric circle of this cone</UserDocu>
-			</Documentation>
-		</Methode>
 	</PythonExport>
 </GenerateModel>

--- a/src/Mod/Part/App/ConePyImp.cpp
+++ b/src/Mod/Part/App/ConePyImp.cpp
@@ -151,46 +151,6 @@ int ConePy::PyInit(PyObject* args, PyObject* kwds)
     return -1;
 }
 
-PyObject* ConePy::uIso(PyObject * args)
-{
-    double u;
-    if (!PyArg_ParseTuple(args, "d", &u))
-        return 0;
-
-    try {
-        Handle(Geom_ConicalSurface) cone = Handle(Geom_ConicalSurface)::DownCast
-            (getGeomConePtr()->handle());
-        Handle(Geom_Line) c = Handle(Geom_Line)::DownCast(cone->UIso(u));
-        GeomLine* line = new GeomLine();
-        Handle(Geom_Line) this_curv = Handle(Geom_Line)::DownCast
-            (line->handle());
-        this_curv->SetLin(c->Lin());
-        return new LinePy(line);
-    }
-    catch (Standard_Failure& e) {
-        PyErr_SetString(PartExceptionOCCError, e.GetMessageString());
-        return 0;
-    }
-}
-
-PyObject* ConePy::vIso(PyObject * args)
-{
-    double v;
-    if (!PyArg_ParseTuple(args, "d", &v))
-        return 0;
-
-    try {
-        Handle(Geom_ConicalSurface) cone = Handle(Geom_ConicalSurface)::DownCast
-            (getGeomConePtr()->handle());
-        Handle(Geom_Curve) c = cone->VIso(v);
-        return new CirclePy(new GeomCircle(Handle(Geom_Circle)::DownCast(c)));
-    }
-    catch (Standard_Failure& e) {
-        PyErr_SetString(PartExceptionOCCError, e.GetMessageString());
-        return 0;
-    }
-}
-
 Py::Object ConePy::getApex(void) const
 {
     Handle(Geom_ConicalSurface) s = Handle(Geom_ConicalSurface)::DownCast

--- a/src/Mod/Part/App/CylinderPy.xml
+++ b/src/Mod/Part/App/CylinderPy.xml
@@ -49,15 +49,5 @@
 			</Documentation>
 			<Parameter Name="Axis" Type="Object"/>
 		</Attribute>
-        <Methode Name="uIso" Const="true">
-			<Documentation>
-				<UserDocu>Builds the U isoparametric circle of this cylinder</UserDocu>
-			</Documentation>
-		</Methode>
-        <Methode Name="vIso" Const="true">
-			<Documentation>
-				<UserDocu>Builds the V isoparametric circle of this cylinder</UserDocu>
-			</Documentation>
-		</Methode>
 	</PythonExport>
 </GenerateModel>

--- a/src/Mod/Part/App/CylinderPyImp.cpp
+++ b/src/Mod/Part/App/CylinderPyImp.cpp
@@ -157,59 +157,6 @@ int CylinderPy::PyInit(PyObject* args, PyObject* kwds)
     return -1;
 }
 
-PyObject* CylinderPy::uIso(PyObject * args)
-{
-    double v;
-    if (!PyArg_ParseTuple(args, "d", &v))
-        return 0;
-
-    try {
-        Handle(Geom_CylindricalSurface) cyl = Handle(Geom_CylindricalSurface)::DownCast
-            (getGeomCylinderPtr()->handle());
-        Handle(Geom_Curve) c = cyl->UIso(v);
-        if (!Handle(Geom_Line)::DownCast(c).IsNull()) {
-            GeomLine* line = new GeomLine();
-            Handle(Geom_Line) this_curv = Handle(Geom_Line)::DownCast
-                (line->handle());
-            this_curv->SetLin(Handle(Geom_Line)::DownCast(c)->Lin());
-            return new LinePy(line);
-        }
-
-        PyErr_SetString(PyExc_NotImplementedError, "this type of conical curve is not implemented");
-        return 0;
-    }
-    catch (Standard_Failure& e) {
-        PyErr_SetString(PartExceptionOCCError, e.GetMessageString());
-        return 0;
-    }
-}
-
-PyObject* CylinderPy::vIso(PyObject * args)
-{
-    double v;
-    if (!PyArg_ParseTuple(args, "d", &v))
-        return 0;
-
-    try {
-        Handle(Geom_CylindricalSurface) cyl = Handle(Geom_CylindricalSurface)::DownCast
-            (getGeomCylinderPtr()->handle());
-        Handle(Geom_Curve) c = cyl->VIso(v);
-        if (!Handle(Geom_Circle)::DownCast(c).IsNull()) {
-            return new CirclePy(new GeomCircle(Handle(Geom_Circle)::DownCast(c)));
-        }
-        if (!Handle(Geom_Ellipse)::DownCast(c).IsNull()) {
-            return new EllipsePy(new GeomEllipse(Handle(Geom_Ellipse)::DownCast(c)));
-        }
-
-        PyErr_SetString(PyExc_NotImplementedError, "this type of conical curve is not implemented");
-        return 0;
-    }
-    catch (Standard_Failure& e) {
-        PyErr_SetString(PartExceptionOCCError, e.GetMessageString());
-        return 0;
-    }
-}
-
 Py::Float CylinderPy::getRadius(void) const
 {
     Handle(Geom_CylindricalSurface) cyl = Handle(Geom_CylindricalSurface)::DownCast

--- a/src/Mod/Part/App/GeometrySurfacePyImp.cpp
+++ b/src/Mod/Part/App/GeometrySurfacePyImp.cpp
@@ -75,54 +75,6 @@
 #include <Mod/Part/App/TopoShapeFacePy.h>
 
 namespace Part {
-const Py::Object makeGeometryCurvePy(const Handle(Geom_Curve)& c)
-{
-    if (c->IsKind(STANDARD_TYPE(Geom_Circle))) {
-        Handle(Geom_Circle) circ = Handle(Geom_Circle)::DownCast(c);
-        return Py::asObject(new CirclePy(new GeomCircle(circ)));
-    }
-    else if (c->IsKind(STANDARD_TYPE(Geom_Ellipse))) {
-        Handle(Geom_Ellipse) ell = Handle(Geom_Ellipse)::DownCast(c);
-        return Py::asObject(new EllipsePy(new GeomEllipse(ell)));
-    }
-    else if (c->IsKind(STANDARD_TYPE(Geom_Hyperbola))) {
-        Handle(Geom_Hyperbola) hyp = Handle(Geom_Hyperbola)::DownCast(c);
-        return Py::asObject(new HyperbolaPy(new GeomHyperbola(hyp)));
-    }
-    else if (c->IsKind(STANDARD_TYPE(Geom_Line))) {
-        Handle(Geom_Line) lin = Handle(Geom_Line)::DownCast(c);
-        return Py::asObject(new LinePy(new GeomLine(lin)));
-    }
-    else if (c->IsKind(STANDARD_TYPE(Geom_OffsetCurve))) {
-        Handle(Geom_OffsetCurve) oc = Handle(Geom_OffsetCurve)::DownCast(c);
-        return Py::asObject(new OffsetCurvePy(new GeomOffsetCurve(oc)));
-    }
-    else if (c->IsKind(STANDARD_TYPE(Geom_Parabola))) {
-        Handle(Geom_Parabola) par = Handle(Geom_Parabola)::DownCast(c);
-        return Py::asObject(new ParabolaPy(new GeomParabola(par)));
-    }
-    else if (c->IsKind(STANDARD_TYPE(Geom_TrimmedCurve))) {
-        Handle(Geom_TrimmedCurve) trc = Handle(Geom_TrimmedCurve)::DownCast(c);
-        return Py::asObject(new GeometryCurvePy(new GeomTrimmedCurve(trc)));
-    }
-    /*else if (c->IsKind(STANDARD_TYPE(Geom_BoundedCurve))) {
-        Handle(Geom_BoundedCurve) bc = Handle(Geom_BoundedCurve)::DownCast(c);
-        return Py::asObject(new GeometryCurvePy(new GeomBoundedCurve(bc)));
-    }*/
-    else if (c->IsKind(STANDARD_TYPE(Geom_BezierCurve))) {
-        Handle(Geom_BezierCurve) bezier = Handle(Geom_BezierCurve)::DownCast(c);
-        return Py::asObject(new BezierCurvePy(new GeomBezierCurve(bezier)));
-    }
-    else if (c->IsKind(STANDARD_TYPE(Geom_BSplineCurve))) {
-        Handle(Geom_BSplineCurve) bspline = Handle(Geom_BSplineCurve)::DownCast(c);
-        return Py::asObject(new BSplineCurvePy(new GeomBSplineCurve(bspline)));
-    }
-
-    std::string err = "Unhandled curve type ";
-    err += c->DynamicType()->Name();
-    throw Py::TypeError(err);
-}
-
 const Py::Object makeTrimmedCurvePy(const Handle(Geom_Curve)& c, double f,double l)
 {
     if (c->IsKind(STANDARD_TYPE(Geom_Circle))) {
@@ -221,6 +173,53 @@ const Py::Object makeTrimmedCurvePy(const Handle(Geom_Curve)& c, double f,double
         Handle(Geom_BoundedCurve) bc = Handle(Geom_BoundedCurve)::DownCast(c);
         return Py::asObject(new GeometryCurvePy(new GeomBoundedCurve(bc)));
     }*/
+
+    std::string err = "Unhandled curve type ";
+    err += c->DynamicType()->Name();
+    throw Py::TypeError(err);
+}
+
+const Py::Object makeGeometryCurvePy(const Handle(Geom_Curve)& c)
+{
+    if (c->IsKind(STANDARD_TYPE(Geom_Circle))) {
+        Handle(Geom_Circle) circ = Handle(Geom_Circle)::DownCast(c);
+        return Py::asObject(new CirclePy(new GeomCircle(circ)));
+    }
+    else if (c->IsKind(STANDARD_TYPE(Geom_Ellipse))) {
+        Handle(Geom_Ellipse) ell = Handle(Geom_Ellipse)::DownCast(c);
+        return Py::asObject(new EllipsePy(new GeomEllipse(ell)));
+    }
+    else if (c->IsKind(STANDARD_TYPE(Geom_Hyperbola))) {
+        Handle(Geom_Hyperbola) hyp = Handle(Geom_Hyperbola)::DownCast(c);
+        return Py::asObject(new HyperbolaPy(new GeomHyperbola(hyp)));
+    }
+    else if (c->IsKind(STANDARD_TYPE(Geom_Line))) {
+        Handle(Geom_Line) lin = Handle(Geom_Line)::DownCast(c);
+        return Py::asObject(new LinePy(new GeomLine(lin)));
+    }
+    else if (c->IsKind(STANDARD_TYPE(Geom_OffsetCurve))) {
+        Handle(Geom_OffsetCurve) oc = Handle(Geom_OffsetCurve)::DownCast(c);
+        return Py::asObject(new OffsetCurvePy(new GeomOffsetCurve(oc)));
+    }
+    else if (c->IsKind(STANDARD_TYPE(Geom_Parabola))) {
+        Handle(Geom_Parabola) par = Handle(Geom_Parabola)::DownCast(c);
+        return Py::asObject(new ParabolaPy(new GeomParabola(par)));
+    }
+    else if (c->IsKind(STANDARD_TYPE(Geom_TrimmedCurve))) {
+        return makeTrimmedCurvePy(c, c->FirstParameter(), c->LastParameter());
+    }
+    /*else if (c->IsKind(STANDARD_TYPE(Geom_BoundedCurve))) {
+        Handle(Geom_BoundedCurve) bc = Handle(Geom_BoundedCurve)::DownCast(c);
+        return Py::asObject(new GeometryCurvePy(new GeomBoundedCurve(bc)));
+    }*/
+    else if (c->IsKind(STANDARD_TYPE(Geom_BezierCurve))) {
+        Handle(Geom_BezierCurve) bezier = Handle(Geom_BezierCurve)::DownCast(c);
+        return Py::asObject(new BezierCurvePy(new GeomBezierCurve(bezier)));
+    }
+    else if (c->IsKind(STANDARD_TYPE(Geom_BSplineCurve))) {
+        Handle(Geom_BSplineCurve) bspline = Handle(Geom_BSplineCurve)::DownCast(c);
+        return Py::asObject(new BSplineCurvePy(new GeomBSplineCurve(bspline)));
+    }
 
     std::string err = "Unhandled curve type ";
     err += c->DynamicType()->Name();

--- a/src/Mod/Part/App/PlanePy.xml
+++ b/src/Mod/Part/App/PlanePy.xml
@@ -47,15 +47,5 @@ Part.Plane(A,B,C,D)
       </Documentation>
       <Parameter Name="Axis" Type="Object"/>
     </Attribute>
-    <Methode Name="uIso" Const="true">
-      <Documentation>
-        <UserDocu>Builds the U isoparametric line of this plane</UserDocu>
-       </Documentation>
-    </Methode>
-    <Methode Name="vIso" Const="true">
-      <Documentation>
-        <UserDocu>Builds the V isoparametric line of this plane</UserDocu>
-      </Documentation>
-    </Methode>
   </PythonExport>
 </GenerateModel>

--- a/src/Mod/Part/App/PlanePyImp.cpp
+++ b/src/Mod/Part/App/PlanePyImp.cpp
@@ -255,50 +255,6 @@ void PlanePy::setAxis(Py::Object arg)
     }
 }
 
-PyObject* PlanePy::uIso(PyObject * args)
-{
-    double u;
-    if (!PyArg_ParseTuple(args, "d", &u))
-        return 0;
-
-    try {
-        Handle(Geom_Plane) plane = Handle(Geom_Plane)::DownCast
-            (getGeomPlanePtr()->handle());
-        Handle(Geom_Line) c = Handle(Geom_Line)::DownCast(plane->UIso(u));
-        GeomLine* line = new GeomLine();
-        Handle(Geom_Line) this_curv = Handle(Geom_Line)::DownCast
-            (line->handle());
-        this_curv->SetLin(c->Lin());
-        return new LinePy(line);
-    }
-    catch (Standard_Failure& e) {
-        PyErr_SetString(PartExceptionOCCError, e.GetMessageString());
-        return 0;
-    }
-}
-
-PyObject* PlanePy::vIso(PyObject * args)
-{
-    double v;
-    if (!PyArg_ParseTuple(args, "d", &v))
-        return 0;
-
-    try {
-        Handle(Geom_Plane) plane = Handle(Geom_Plane)::DownCast
-            (getGeomPlanePtr()->handle());
-        Handle(Geom_Line) c = Handle(Geom_Line)::DownCast(plane->VIso(v));
-        GeomLine* line = new GeomLine();
-        Handle(Geom_Line) this_curv = Handle(Geom_Line)::DownCast
-            (line->handle());
-        this_curv->SetLin(c->Lin());
-        return new LinePy(line);
-    }
-    catch (Standard_Failure& e) {
-        PyErr_SetString(PartExceptionOCCError, e.GetMessageString());
-        return 0;
-    }
-}
-
 PyObject *PlanePy::getCustomAttributes(const char* /*attr*/) const
 {
     return 0;

--- a/src/Mod/Part/App/RectangularTrimmedSurfacePy.xml
+++ b/src/Mod/Part/App/RectangularTrimmedSurfacePy.xml
@@ -25,15 +25,5 @@ The trimmed surface is built from a copy of the basis surface. Therefore, when t
 is modified the trimmed surface is not changed. Consequently, the trimmed surface does not
 necessarily have the same orientation as the basis surface.</UserDocu>
 		</Documentation>
-        <Methode Name="uIso" Const="true">
-			<Documentation>
-				<UserDocu>Builds the U isoparametric curve</UserDocu>
-			</Documentation>
-		</Methode>
-        <Methode Name="vIso" Const="true">
-			<Documentation>
-				<UserDocu>Builds the V isoparametric curve</UserDocu>
-			</Documentation>
-		</Methode>
 	</PythonExport>
 </GenerateModel>

--- a/src/Mod/Part/App/RectangularTrimmedSurfacePyImp.cpp
+++ b/src/Mod/Part/App/RectangularTrimmedSurfacePyImp.cpp
@@ -86,58 +86,6 @@ int RectangularTrimmedSurfacePy::PyInit(PyObject* args, PyObject* /*kwd*/)
     return -1;
 }
 
-PyObject* RectangularTrimmedSurfacePy::uIso(PyObject * args)
-{
-    double v;
-    if (!PyArg_ParseTuple(args, "d", &v))
-        return 0;
-
-    try {
-        Handle(Geom_Surface) surf = Handle(Geom_Surface)::DownCast
-            (getGeometryPtr()->handle());
-        Handle(Geom_Curve) c = surf->UIso(v);
-        if (c->IsKind(STANDARD_TYPE(Geom_TrimmedCurve))) {
-            Handle(Geom_TrimmedCurve) aCurve = Handle(Geom_TrimmedCurve)::DownCast(c);
-            return new GeometryCurvePy(new GeomTrimmedCurve(aCurve));
-        }
-
-        PyErr_Format(PyExc_NotImplementedError, "Iso curve is of type '%s'",
-            c->DynamicType()->Name());
-        return 0;
-    }
-    catch (Standard_Failure& e) {
-
-        PyErr_SetString(PartExceptionOCCError, e.GetMessageString());
-        return 0;
-    }
-}
-
-PyObject* RectangularTrimmedSurfacePy::vIso(PyObject * args)
-{
-    double v;
-    if (!PyArg_ParseTuple(args, "d", &v))
-        return 0;
-
-    try {
-        Handle(Geom_Surface) surf = Handle(Geom_Surface)::DownCast
-            (getGeometryPtr()->handle());
-        Handle(Geom_Curve) c = surf->VIso(v);
-        if (c->IsKind(STANDARD_TYPE(Geom_TrimmedCurve))) {
-            Handle(Geom_TrimmedCurve) aCurve = Handle(Geom_TrimmedCurve)::DownCast(c);
-            return new GeometryCurvePy(new GeomTrimmedCurve(aCurve));
-        }
-
-        PyErr_Format(PyExc_NotImplementedError, "Iso curve is of type '%s'",
-            c->DynamicType()->Name());
-        return 0;
-    }
-    catch (Standard_Failure& e) {
-
-        PyErr_SetString(PartExceptionOCCError, e.GetMessageString());
-        return 0;
-    }
-}
-
 PyObject *RectangularTrimmedSurfacePy::getCustomAttributes(const char* /*attr*/) const
 {
     return 0;

--- a/src/Mod/Part/App/SpherePy.xml
+++ b/src/Mod/Part/App/SpherePy.xml
@@ -45,18 +45,5 @@
 			</Documentation>
 			<Parameter Name="Axis" Type="Object"/>
 		</Attribute>
-        <Methode Name="uIso" Const="true">
-			<Documentation>
-				<UserDocu>
-					Builds the U isoparametric circle of this sphere
-				</UserDocu>
-			</Documentation>
-		</Methode>
-        <Methode Name="vIso" Const="true">
-			<Documentation>
-				<UserDocu>Builds the V isoparametric circle of this sphere 
-where V must be in the range [-Pi/2,Pi/2]</UserDocu>
-			</Documentation>
-		</Methode>
 	</PythonExport>
 </GenerateModel>

--- a/src/Mod/Part/App/SpherePyImp.cpp
+++ b/src/Mod/Part/App/SpherePyImp.cpp
@@ -181,16 +181,6 @@ void SpherePy::setAxis(Py::Object arg)
     }
 }
 
-PyObject *SpherePy::uIso(PyObject *args)
-{
-    return GeometrySurfacePy::uIso(args);
-}
-
-PyObject *SpherePy::vIso(PyObject *args)
-{
-    return GeometrySurfacePy::vIso(args);
-}
-
 PyObject *SpherePy::getCustomAttributes(const char* /*attr*/) const
 {
     return 0;

--- a/src/Mod/Part/App/ToroidPy.xml
+++ b/src/Mod/Part/App/ToroidPy.xml
@@ -51,15 +51,5 @@
 			</Documentation>
 			<Parameter Name="Volume" Type="Float"/>
 		</Attribute>
-        <Methode Name="uIso" Const="true">
-			<Documentation>
-				<UserDocu>Builds the U isoparametric circle of this toroid</UserDocu>
-			</Documentation>
-		</Methode>
-        <Methode Name="vIso" Const="true">
-			<Documentation>
-				<UserDocu>Builds the V isoparametric circle of this toroid</UserDocu>
-			</Documentation>
-		</Methode>
 	</PythonExport>
 </GenerateModel>

--- a/src/Mod/Part/App/ToroidPyImp.cpp
+++ b/src/Mod/Part/App/ToroidPyImp.cpp
@@ -66,44 +66,6 @@ int ToroidPy::PyInit(PyObject* args, PyObject* /*kwd*/)
     return -1;
 }
 
-PyObject* ToroidPy::uIso(PyObject * args)
-{
-    double u;
-    if (!PyArg_ParseTuple(args, "d", &u))
-        return 0;
-
-    try {
-        Handle(Geom_ToroidalSurface) torus = Handle(Geom_ToroidalSurface)::DownCast
-            (getGeomToroidPtr()->handle());
-        Handle(Geom_Circle) c = Handle(Geom_Circle)::DownCast(torus->UIso(u));
-        return new CirclePy(new GeomCircle(c));
-    }
-    catch (Standard_Failure& e) {
-
-        PyErr_SetString(PartExceptionOCCError, e.GetMessageString());
-        return 0;
-    }
-}
-
-PyObject* ToroidPy::vIso(PyObject * args)
-{
-    double v;
-    if (!PyArg_ParseTuple(args, "d", &v))
-        return 0;
-
-    try {
-        Handle(Geom_ToroidalSurface) torus = Handle(Geom_ToroidalSurface)::DownCast
-            (getGeomToroidPtr()->handle());
-        Handle(Geom_Circle) c = Handle(Geom_Circle)::DownCast(torus->VIso(v));
-        return new CirclePy(new GeomCircle(c));
-    }
-    catch (Standard_Failure& e) {
-
-        PyErr_SetString(PartExceptionOCCError, e.GetMessageString());
-        return 0;
-    }
-}
-
 Py::Float ToroidPy::getMajorRadius(void) const
 {
     Handle(Geom_ToroidalSurface) torus = Handle(Geom_ToroidalSurface)::DownCast


### PR DESCRIPTION
Following PR #3845, remove other overridden uIso() and vIso() methods.
I treated [RectangularTrimmedSurface](https://github.com/FreeCAD/FreeCAD/pull/3845#issuecomment-689447967) in a separate commit, to allow a revert, but IMHO, after code inspection, I think it is safe to include it too.


Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
