### PR TITLE
Draft: fix loading of arrays and workbench tools

### DIFF
--- a/src/Mod/Draft/draftguitools/gui_arrays.py
+++ b/src/Mod/Draft/draftguitools/gui_arrays.py
@@ -55,7 +55,7 @@ class ArrayGroup:
         return ("Draft_OrthoArray",
                 "Draft_PolarArray", "Draft_CircularArray",
                 "Draft_PathArray", "Draft_PathLinkArray",
-                "Draft_PointArray", "Draft_PointLinkArray")
+                "Draft_PointArray", "Draft_PointLinkArray",
                 "Draft_PathTwistedArray", "Draft_PathTwistedLinkArray")
 
     def GetResources(self):


### PR DESCRIPTION
The previous request #3815 contains a conflict that produces a Python syntax error (wrong indentation and non-matching parenthesis), which makes the Draft Workbench fail when loading the Draft Array commands and the rest of the commands. This request fixes the issue.

Forum thread: [freecad-daily PPA - startup failure - indent in gui_arrays.py](https://forum.freecadweb.org/viewtopic.php?f=3&t=50420)

---

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists