### PR TITLE
Include Inventor/SbByteBuffer.h in QuarterWidget.cpp.

### DIFF
--- a/src/Gui/Quarter/QuarterWidget.cpp
+++ b/src/Gui/Quarter/QuarterWidget.cpp
@@ -71,6 +71,10 @@
 #include <QOpenGLDebugLogger>
 #endif
 
+#if COIN_MAJOR_VERSION >= 4
+#include <Inventor/SbByteBuffer.h>
+#endif
+
 #include <Inventor/SbViewportRegion.h>
 #include <Inventor/system/gl.h>
 #include <Inventor/events/SoEvents.h>


### PR DESCRIPTION
This allows compilation with the latest Coin3D library revision. While the latest version of Coin3D hasn't been released yet, it supports Wayland. As such, with this change, compiling FreeCAD with the latest Coin3D enables functional Wayland support.