### PR TITLE
Fixed bug: In `Draft.get_clone_base` function.

### DIFF
--- a/src/Mod/Draft/draftutils/utils.py
+++ b/src/Mod/Draft/draftutils/utils.py
@@ -526,7 +526,7 @@ def is_clone(obj, objtype, recursive=False):
 isClone = is_clone
 
 
-def get_clone_base(obj, strict=False):
+def get_clone_base(obj, strict=False, recursive=True):
     """Return the object cloned by this object, if any.
 
     Parameters
@@ -538,6 +538,13 @@ def get_clone_base(obj, strict=False):
         It defaults to `False`.
         If it is `True`, and this object is not a clone,
         this function will return `False`.
+
+    recursive: bool, optional
+        It defaults to `True`
+        If it is `True`, it call recursively to itself to
+        get base object and if it is `False` then it just
+        return base object, not call recursively to find
+        base object.
 
     Returns
     -------
@@ -556,11 +563,14 @@ def get_clone_base(obj, strict=False):
         It will return `False` if `obj` is not a clone,
         and `strict` is `True`.
     """
-    if hasattr(obj, "CloneOf"):
-        if obj.CloneOf:
+    if hasattr(obj, "CloneOf") and obj.CloneOf:
+        if recursive:
             return get_clone_base(obj.CloneOf)
+        return obj.CloneOf
     if get_type(obj) == "Clone" and obj.Objects:
-        return get_clone_base(obj.Objects[0])
+        if recursive:
+            return get_clone_base(obj.Objects[0])
+        return obj.Objects[0]
     if strict:
         return False
     return obj

--- a/src/Mod/Draft/draftutils/utils.py
+++ b/src/Mod/Draft/draftutils/utils.py
@@ -560,7 +560,7 @@ def get_clone_base(obj, strict=False):
         if obj.CloneOf:
             return get_clone_base(obj.CloneOf)
     if get_type(obj) == "Clone" and obj.Objects:
-        return obj.Objects[0]
+        return get_clone_base(obj.Objects[0])
     if strict:
         return False
     return obj


### PR DESCRIPTION
**Bug detail:** When we have clone object that is clone of clone another object, then in export IFC file object are displaced because `Draft.get_clone_base` not return correct base object.

```python
>>> Draft.get_clone_base(App.ActiveDocument.Clone).Label
'Base'
>>> Draft.get_clone_base(App.ActiveDocument.Clone001).Label
'CloneOfBase'  # Should also return `Base`

# After fix:
>>> Draft.get_clone_base(App.ActiveDocument.Clone).Label
'Base'
>>> Draft.get_clone_base(App.ActiveDocument.Clone001).Label
'Base'
```

### FreeCAD model
![image](https://user-images.githubusercontent.com/10414959/93898152-858aed80-fd10-11ea-9a9b-24a064501768.png)

### Before bug fix
![image](https://user-images.githubusercontent.com/10414959/93899465-f7b00200-fd11-11ea-8b89-827aca8b6a4d.png)

### After bug fix
![image](https://user-images.githubusercontent.com/10414959/93899534-0eeeef80-fd12-11ea-80e7-3d0ebe8a1ded.png)

[bug.zip](https://github.com/FreeCAD/FreeCAD/files/5262407/bug.zip)
