### PR TITLE
[PD] fix 2 hole dialog bugs

### DIFF
--- a/src/Mod/PartDesign/Gui/TaskHoleParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskHoleParameters.cpp
@@ -604,17 +604,17 @@ void TaskHoleParameters::onSelectionChanged(const Gui::SelectionChanges& msg)
     Q_UNUSED(msg)
 }
 
-bool   TaskHoleParameters::getThreaded() const
+bool TaskHoleParameters::getThreaded() const
 {
     return ui->Threaded->isChecked();
 }
 
-long   TaskHoleParameters::getThreadType() const
+long TaskHoleParameters::getThreadType() const
 {
     return ui->ThreadType->currentIndex();
 }
 
-long   TaskHoleParameters::getThreadSize() const
+long TaskHoleParameters::getThreadSize() const
 {
     if ( ui->ThreadSize->currentIndex() == -1 )
         return 0;
@@ -622,7 +622,7 @@ long   TaskHoleParameters::getThreadSize() const
         return ui->ThreadSize->currentIndex();
 }
 
-long   TaskHoleParameters::getThreadClass() const
+long TaskHoleParameters::getThreadClass() const
 {
     if ( ui->ThreadSize->currentIndex() == -1 )
         return 0;
@@ -632,10 +632,9 @@ long   TaskHoleParameters::getThreadClass() const
 
 long TaskHoleParameters::getThreadFit() const
 {
-    if (ui->Threaded->isChecked())
-        return ui->ThreadFit->currentIndex();
-    else
-        return 0;
+    // the fit is independent if the hole is threaded or not
+    // since an unthreaded hole for a screw can also have a close fit
+    return ui->ThreadFit->currentIndex();
 }
 
 Base::Quantity TaskHoleParameters::getDiameter() const
@@ -643,12 +642,15 @@ Base::Quantity TaskHoleParameters::getDiameter() const
     return ui->Diameter->value();
 }
 
-bool   TaskHoleParameters::getThreadDirection() const
+long TaskHoleParameters::getThreadDirection() const
 {
-    return ui->directionRightHand->isChecked();
+    if (ui->directionRightHand->isChecked())
+        return 0;
+    else
+        return 1;
 }
 
-long   TaskHoleParameters::getHoleCutType() const
+long TaskHoleParameters::getHoleCutType() const
 {
     if (ui->HoleCutType->currentIndex() == -1)
         return 0;
@@ -671,7 +673,7 @@ Base::Quantity TaskHoleParameters::getHoleCutCountersinkAngle() const
     return ui->HoleCutCountersinkAngle->value();
 }
 
-long   TaskHoleParameters::getDepthType() const
+long TaskHoleParameters::getDepthType() const
 {
     return ui->DepthType->currentIndex();
 }
@@ -681,7 +683,7 @@ Base::Quantity TaskHoleParameters::getDepth() const
     return ui->Depth->value();
 }
 
-long   TaskHoleParameters::getDrillPoint() const
+long TaskHoleParameters::getDrillPoint() const
 {
     if ( ui->drillPointFlat->isChecked() )
         return 0;
@@ -696,7 +698,7 @@ Base::Quantity TaskHoleParameters::getDrillPointAngle() const
     return ui->DrillPointAngle->value();
 }
 
-bool   TaskHoleParameters::getTapered() const
+bool TaskHoleParameters::getTapered() const
 {
     return ui->Tapered->isChecked();
 }

--- a/src/Mod/PartDesign/Gui/TaskHoleParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskHoleParameters.h
@@ -67,7 +67,7 @@ public:
     long   getThreadClass() const;
     long   getThreadFit() const;
     Base::Quantity getDiameter() const;
-    bool   getThreadDirection() const;
+    long   getThreadDirection() const;
     long   getHoleCutType() const;
     Base::Quantity getHoleCutDiameter() const;
     Base::Quantity getHoleCutDepth() const;

--- a/src/Mod/PartDesign/Gui/TaskHoleParameters.ui
+++ b/src/Mod/PartDesign/Gui/TaskHoleParameters.ui
@@ -7,79 +7,62 @@
     <x>0</x>
     <y>0</y>
     <width>356</width>
-    <height>660</height>
+    <height>583</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Task Hole Parameters</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="11" column="5" colspan="2">
-    <widget class="Gui::PrefQuantitySpinBox" name="Diameter" native="true">
+   <item row="10" column="2" colspan="5">
+    <widget class="QComboBox" name="ThreadFit">
+     <item>
+      <property name="text">
+       <string>Standard fit</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Close fit</string>
+      </property>
+     </item>
+    </widget>
+   </item>
+   <item row="17" column="2" colspan="2">
+    <widget class="QLabel" name="label_10">
+     <property name="text">
+      <string>Countersink angle</string>
+     </property>
+    </widget>
+   </item>
+   <item row="11" column="2">
+    <widget class="QComboBox" name="ThreadClass"/>
+   </item>
+   <item row="6" column="3" colspan="4">
+    <widget class="Gui::PrefQuantitySpinBox" name="ThreadCutOffInner">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
      <property name="unit" stdset="0">
       <string notr="true">mm</string>
      </property>
     </widget>
    </item>
-   <item row="14" column="0">
-    <widget class="QLabel" name="label">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
+   <item row="1" column="2" colspan="5">
+    <widget class="QComboBox" name="ThreadType"/>
+   </item>
+   <item row="10" column="0" colspan="2">
+    <widget class="QLabel" name="label_3">
      <property name="text">
-      <string>Type</string>
+      <string>Fit</string>
      </property>
     </widget>
    </item>
-   <item row="15" column="2" colspan="2">
-    <widget class="QLabel" name="label_11">
-     <property name="text">
-      <string>Diameter</string>
-     </property>
-    </widget>
-   </item>
-   <item row="16" column="2" colspan="2">
-    <widget class="QLabel" name="label_12">
-     <property name="text">
-      <string>Depth</string>
-     </property>
-    </widget>
-   </item>
-   <item row="6" column="2">
-    <widget class="QLabel" name="label_CutoffInner">
+   <item row="4" column="3" colspan="4">
+    <widget class="Gui::PrefQuantitySpinBox" name="ThreadPitch">
      <property name="enabled">
       <bool>false</bool>
      </property>
-     <property name="text">
-      <string>Cutoff inner</string>
-     </property>
-    </widget>
-   </item>
-   <item row="11" column="0" colspan="2">
-    <widget class="QLabel" name="label_5">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string>Class</string>
-     </property>
-    </widget>
-   </item>
-   <item row="21" column="0" colspan="2">
-    <widget class="QCheckBox" name="Tapered">
-     <property name="text">
-      <string>Tapered</string>
-     </property>
-    </widget>
-   </item>
-   <item row="12" column="5" colspan="2">
-    <widget class="Gui::PrefQuantitySpinBox" name="Depth" native="true">
      <property name="unit" stdset="0">
       <string notr="true">mm</string>
      </property>
@@ -101,32 +84,12 @@
      </property>
     </widget>
    </item>
-   <item row="14" column="2" colspan="5">
-    <widget class="QComboBox" name="HoleCutType"/>
-   </item>
-   <item row="10" column="0" colspan="2">
-    <widget class="QLabel" name="label_3">
+   <item row="2" column="2" colspan="5">
+    <widget class="QCheckBox" name="Threaded">
      <property name="text">
-      <string>Fit</string>
+      <string>Threaded</string>
      </property>
     </widget>
-   </item>
-   <item row="16" column="4" colspan="3">
-    <widget class="Gui::PrefQuantitySpinBox" name="HoleCutDepth" native="true">
-     <property name="unit" stdset="0">
-      <string notr="true">mm</string>
-     </property>
-    </widget>
-   </item>
-   <item row="15" column="4" colspan="3">
-    <widget class="Gui::PrefQuantitySpinBox" name="HoleCutDiameter" native="true">
-     <property name="unit" stdset="0">
-      <string notr="true">mm</string>
-     </property>
-    </widget>
-   </item>
-   <item row="9" column="2" colspan="5">
-    <widget class="QComboBox" name="ThreadSize"/>
    </item>
    <item row="19" column="2" colspan="5">
     <widget class="QWidget" name="widget_2" native="true">
@@ -175,7 +138,7 @@
          </widget>
         </item>
         <item>
-         <widget class="Gui::PrefQuantitySpinBox" name="DrillPointAngle" native="true">
+         <widget class="Gui::PrefQuantitySpinBox" name="DrillPointAngle">
           <property name="unit" stdset="0">
            <string notr="true">deg</string>
           </property>
@@ -186,6 +149,119 @@
      </layout>
     </widget>
    </item>
+   <item row="14" column="2" colspan="5">
+    <widget class="QComboBox" name="HoleCutType"/>
+   </item>
+   <item row="7" column="3" colspan="4">
+    <widget class="Gui::PrefQuantitySpinBox" name="ThreadCutOffOuter">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="unit" stdset="0">
+      <string notr="true">mm</string>
+     </property>
+    </widget>
+   </item>
+   <item row="20" column="0" colspan="7">
+    <widget class="QLabel" name="label_16">
+     <property name="text">
+      <string>&lt;b&gt;Misc&lt;/b&gt;</string>
+     </property>
+    </widget>
+   </item>
+   <item row="11" column="0" colspan="2">
+    <widget class="QLabel" name="label_5">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>Class</string>
+     </property>
+    </widget>
+   </item>
+   <item row="21" column="5">
+    <widget class="QCheckBox" name="Reversed">
+     <property name="text">
+      <string>Reversed</string>
+     </property>
+    </widget>
+   </item>
+   <item row="9" column="0">
+    <widget class="QLabel" name="label_4">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>Size</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0" colspan="2">
+    <widget class="QLabel" name="label_2">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>Profile</string>
+     </property>
+    </widget>
+   </item>
+   <item row="15" column="2" colspan="2">
+    <widget class="QLabel" name="label_11">
+     <property name="text">
+      <string>Diameter</string>
+     </property>
+    </widget>
+   </item>
+   <item row="11" column="3" colspan="2">
+    <widget class="QLabel" name="label_7">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>Diameter</string>
+     </property>
+    </widget>
+   </item>
+   <item row="15" column="4" colspan="3">
+    <widget class="Gui::PrefQuantitySpinBox" name="HoleCutDiameter">
+     <property name="unit" stdset="0">
+      <string notr="true">mm</string>
+     </property>
+    </widget>
+   </item>
+   <item row="12" column="0" colspan="2">
+    <widget class="QLabel" name="label_6">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>Depth</string>
+     </property>
+    </widget>
+   </item>
+   <item row="16" column="4" colspan="3">
+    <widget class="Gui::PrefQuantitySpinBox" name="HoleCutDepth">
+     <property name="unit" stdset="0">
+      <string notr="true">mm</string>
+     </property>
+    </widget>
+   </item>
    <item row="4" column="2">
     <widget class="QLabel" name="label_Pitch">
      <property name="enabled">
@@ -193,6 +269,13 @@
      </property>
      <property name="text">
       <string>Pitch</string>
+     </property>
+    </widget>
+   </item>
+   <item row="13" column="0" colspan="7">
+    <widget class="QLabel" name="label_14">
+     <property name="text">
+      <string>&lt;b&gt;Hole cut&lt;/b&gt;</string>
      </property>
     </widget>
    </item>
@@ -231,112 +314,10 @@
      </layout>
     </widget>
    </item>
-   <item row="3" column="2" colspan="5">
-    <widget class="QCheckBox" name="ModelActualThread">
-     <property name="enabled">
-      <bool>false</bool>
-     </property>
-     <property name="text">
-      <string>Model actual thread</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="2" colspan="5">
-    <widget class="QCheckBox" name="Threaded">
-     <property name="text">
-      <string>Threaded</string>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="2">
-    <widget class="QLabel" name="label_Angle">
-     <property name="enabled">
-      <bool>false</bool>
-     </property>
-     <property name="text">
-      <string>Angle</string>
-     </property>
-    </widget>
-   </item>
-   <item row="22" column="2">
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="1" column="0" colspan="2">
-    <widget class="QLabel" name="label_2">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string>Profile</string>
-     </property>
-    </widget>
-   </item>
-   <item row="11" column="2">
-    <widget class="QComboBox" name="ThreadClass"/>
-   </item>
-   <item row="17" column="2" colspan="2">
-    <widget class="QLabel" name="label_10">
-     <property name="text">
-      <string>Countersink angle</string>
-     </property>
-    </widget>
-   </item>
-   <item row="19" column="0" colspan="2">
-    <widget class="QLabel" name="label_15">
-     <property name="text">
-      <string>Type</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-     </property>
-    </widget>
-   </item>
-   <item row="11" column="3" colspan="2">
-    <widget class="QLabel" name="label_7">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string>Diameter</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="2" colspan="5">
-    <widget class="QComboBox" name="ThreadType"/>
-   </item>
-   <item row="12" column="0" colspan="2">
-    <widget class="QLabel" name="label_6">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
+   <item row="16" column="2" colspan="2">
+    <widget class="QLabel" name="label_12">
      <property name="text">
       <string>Depth</string>
-     </property>
-    </widget>
-   </item>
-   <item row="17" column="4" colspan="3">
-    <widget class="Gui::PrefQuantitySpinBox" name="HoleCutCountersinkAngle" native="true">
-     <property name="unit" stdset="0">
-      <string notr="true">deg</string>
      </property>
     </widget>
    </item>
@@ -360,83 +341,6 @@
      </item>
     </widget>
    </item>
-   <item row="9" column="0">
-    <widget class="QLabel" name="label_4">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string>Size</string>
-     </property>
-    </widget>
-   </item>
-   <item row="10" column="2" colspan="5">
-    <widget class="QComboBox" name="ThreadFit">
-     <item>
-      <property name="text">
-       <string>Standard fit</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>Close fit</string>
-      </property>
-     </item>
-    </widget>
-   </item>
-   <item row="7" column="2">
-    <widget class="QLabel" name="label_CutoffOuter">
-     <property name="enabled">
-      <bool>false</bool>
-     </property>
-     <property name="text">
-      <string>Cutoff outer</string>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="3" colspan="4">
-    <widget class="Gui::PrefQuantitySpinBox" name="ThreadPitch" native="true">
-     <property name="enabled">
-      <bool>false</bool>
-     </property>
-     <property name="unit" stdset="0">
-      <string notr="true">mm</string>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="3" colspan="4">
-    <widget class="Gui::PrefQuantitySpinBox" name="ThreadAngle" native="true">
-     <property name="enabled">
-      <bool>false</bool>
-     </property>
-     <property name="unit" stdset="0">
-      <string notr="true">deg</string>
-     </property>
-    </widget>
-   </item>
-   <item row="6" column="3" colspan="4">
-    <widget class="Gui::PrefQuantitySpinBox" name="ThreadCutOffInner" native="true">
-     <property name="enabled">
-      <bool>false</bool>
-     </property>
-     <property name="unit" stdset="0">
-      <string notr="true">mm</string>
-     </property>
-    </widget>
-   </item>
-   <item row="7" column="3" colspan="4">
-    <widget class="Gui::PrefQuantitySpinBox" name="ThreadCutOffOuter" native="true">
-     <property name="enabled">
-      <bool>false</bool>
-     </property>
-     <property name="unit" stdset="0">
-      <string notr="true">mm</string>
-     </property>
-    </widget>
-   </item>
    <item row="18" column="0" colspan="7">
     <widget class="QLabel" name="label_9">
      <property name="sizePolicy">
@@ -453,17 +357,63 @@
      </property>
     </widget>
    </item>
-   <item row="20" column="0" colspan="7">
-    <widget class="QLabel" name="label_16">
+   <item row="6" column="2">
+    <widget class="QLabel" name="label_CutoffInner">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
      <property name="text">
-      <string>&lt;b&gt;Misc&lt;/b&gt;</string>
+      <string>Cutoff inner</string>
      </property>
     </widget>
    </item>
-   <item row="13" column="0" colspan="7">
-    <widget class="QLabel" name="label_14">
+   <item row="5" column="2">
+    <widget class="QLabel" name="label_Angle">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
      <property name="text">
-      <string>&lt;b&gt;Hole cut&lt;/b&gt;</string>
+      <string>Angle</string>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="2">
+    <widget class="QLabel" name="label_CutoffOuter">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="text">
+      <string>Cutoff outer</string>
+     </property>
+    </widget>
+   </item>
+   <item row="9" column="2" colspan="5">
+    <widget class="QComboBox" name="ThreadSize"/>
+   </item>
+   <item row="21" column="0" colspan="2">
+    <widget class="QCheckBox" name="Tapered">
+     <property name="text">
+      <string>Tapered</string>
+     </property>
+    </widget>
+   </item>
+   <item row="11" column="5" colspan="2">
+    <widget class="Gui::PrefQuantitySpinBox" name="Diameter">
+     <property name="unit" stdset="0">
+      <string notr="true">mm</string>
+     </property>
+    </widget>
+   </item>
+   <item row="14" column="0">
+    <widget class="QLabel" name="label">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>Type</string>
      </property>
     </widget>
    </item>
@@ -474,17 +424,54 @@
      </property>
     </widget>
    </item>
+   <item row="3" column="2" colspan="5">
+    <widget class="QCheckBox" name="ModelActualThread">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="text">
+      <string>Model actual thread</string>
+     </property>
+    </widget>
+   </item>
    <item row="21" column="2" colspan="2">
-    <widget class="Gui::PrefQuantitySpinBox" name="TaperedAngle" native="true">
+    <widget class="Gui::PrefQuantitySpinBox" name="TaperedAngle">
      <property name="unit" stdset="0">
       <string notr="true">deg</string>
      </property>
     </widget>
    </item>
-   <item row="21" column="5">
-    <widget class="QCheckBox" name="Reversed">
+   <item row="5" column="3" colspan="4">
+    <widget class="Gui::PrefQuantitySpinBox" name="ThreadAngle">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="unit" stdset="0">
+      <string notr="true">deg</string>
+     </property>
+    </widget>
+   </item>
+   <item row="19" column="0" colspan="2">
+    <widget class="QLabel" name="label_15">
      <property name="text">
-      <string>Reversed</string>
+      <string>Type</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+     </property>
+    </widget>
+   </item>
+   <item row="17" column="4" colspan="3">
+    <widget class="Gui::PrefQuantitySpinBox" name="HoleCutCountersinkAngle">
+     <property name="unit" stdset="0">
+      <string notr="true">deg</string>
+     </property>
+    </widget>
+   </item>
+   <item row="12" column="5" colspan="2">
+    <widget class="Gui::PrefQuantitySpinBox" name="Depth">
+     <property name="unit" stdset="0">
+      <string notr="true">mm</string>
      </property>
     </widget>
    </item>
@@ -492,8 +479,13 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>Gui::PrefQuantitySpinBox</class>
+   <class>Gui::QuantitySpinBox</class>
    <extends>QWidget</extends>
+   <header>Gui/QuantitySpinBox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>Gui::PrefQuantitySpinBox</class>
+   <extends>Gui::QuantitySpinBox</extends>
    <header>Gui/PrefWidgets.h</header>
   </customwidget>
  </customwidgets>


### PR DESCRIPTION
- 1. reported here: https://forum.freecadweb.org/viewtopic.php?p=432936#p432851
also unthreaded holes can have a close or standard fit

- 2. reported here: https://forum.freecadweb.org/viewtopic.php?p=432936#p432944
the thread direction is always left. The reason is that this property is an enum but the dialog returns a bool.

- also fix an UI issue with the spin boxes (automatically found and repaired by Qt's designer, thus the many changes in the UI file)
- also remove a superfluous spacer from the UI file