### PR TITLE
Draft: method to get the bounding box of objects that don't have a Shape

### DIFF
--- a/src/Mod/Draft/Draft.py
+++ b/src/Mod/Draft/Draft.py
@@ -112,7 +112,8 @@ from draftutils.gui_utils import (get3DView,
                                   get_selection_ex,
                                   select,
                                   loadTexture,
-                                  load_texture)
+                                  load_texture,
+                                  get_bbox)
 
 from draftutils.gui_utils import (dim_symbol,
                                   dimSymbol,

--- a/src/Mod/Draft/importSVG.py
+++ b/src/Mod/Draft/importSVG.py
@@ -1810,21 +1810,28 @@ def export(exportList, filename):
 
     # Determine the size of the page by adding the bounding boxes
     # of all shapes
-    bb = None
-    for ob in exportList:
-        if ob.isDerivedFrom("Part::Feature"):
-            if bb:
-                bb.add(ob.Shape.BoundBox)
-            else:
-                bb = ob.Shape.BoundBox
-    if bb:
-        minx = bb.XMin
-        maxx = bb.XMax
-        miny = bb.YMin
-        maxy = bb.YMax
-    else:
-        _err("The export list contains no shape")
+    bb = FreeCAD.BoundBox()
+    for obj in exportList:
+        if (hasattr(obj, "Shape")
+                and obj.Shape
+                and obj.Shape.BoundBox.isValid()):
+            bb.add(obj.Shape.BoundBox)
+        else:
+            # if Draft.get_type(obj) in ("Text", "LinearDimension", ...)
+            _wrn("'{}': no Shape, "
+                 "calculate manual bounding box".format(obj.Label))
+            bb.add(Draft.get_bbox(obj))
+
+    if not bb.isValid():
+        _err(translate("ImportSVG",
+                       "The export list contains no object "
+                       "with a valid bounding box"))
         return
+
+    minx = bb.XMin
+    maxx = bb.XMax
+    miny = bb.YMin
+    maxy = bb.YMax
 
     if svg_export_style == 0:
         # translated-style exports get a bit of a margin
@@ -1860,6 +1867,7 @@ def export(exportList, filename):
         # We need the negative Y here because SVG is upside down, and we
         # flip the sketch right-way up with a scale later
         svg.write(' viewBox="%f %f %f %f"' % (minx, -maxy, sizex, sizey))
+
     svg.write(' xmlns="http://www.w3.org/2000/svg" version="1.1"')
     svg.write('>\n')
 
@@ -1876,6 +1884,7 @@ def export(exportList, filename):
         else:
             # raw-style exports do not translate the sketch
             svg.write('<g id="%s" transform="scale(1,-1)">\n' % ob.Name)
+
         svg.write(Draft.get_svg(ob))
         _label_enc = str(ob.Label.encode('utf8'))
         _label = _label_enc.replace('<', '&lt;').replace('>', '&gt;')


### PR DESCRIPTION
Normally the bounding box is taken from `Shape.BoundBox`. Certain objects don't have a `Shape`, like `App::FeaturePython` such as Draft Dimension and Draft Text, so the bounding box is calculated from the corresponding viewprovider, that is, from `ViewObject.RootNode`. This new function, `Draft.get_bbox`, only works in GUI mode.

In `importSVG.export` the bounding box of each exported object is used to determine the size of the SVG page. Using `get_bbox`, now Draft Dimensions and Draft Text are also included in this calculation.

---

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists