### PR TITLE
Big update to remove deprecation warning from Qt 5.15.0

### DIFF
--- a/src/Gui/CommandView.cpp
+++ b/src/Gui/CommandView.cpp
@@ -1799,7 +1799,7 @@ void StdViewScreenShot::activated(int iMsg)
                 selFilter = filter.last();
         }
 
-        FileOptionsDialog fd(getMainWindow(), 0);
+        FileOptionsDialog fd(getMainWindow(), Qt::WindowFlags());
         fd.setFileMode(QFileDialog::AnyFile);
         fd.setAcceptMode(QFileDialog::AcceptSave);
         fd.setWindowTitle(QObject::tr("Save picture"));

--- a/src/Gui/DemoMode.h
+++ b/src/Gui/DemoMode.h
@@ -44,7 +44,7 @@ class GuiExport DemoMode : public QDialog
     Q_OBJECT
 
 public:
-    DemoMode(QWidget* parent = 0, Qt::WindowFlags fl = 0);
+    DemoMode(QWidget* parent = 0, Qt::WindowFlags fl = Qt::WindowFlags());
     ~DemoMode();
 
     void accept();

--- a/src/Gui/DlgActivateWindowImp.h
+++ b/src/Gui/DlgActivateWindowImp.h
@@ -40,7 +40,7 @@ class DlgActivateWindowImp : public QDialog
     Q_OBJECT
 
 public:
-    DlgActivateWindowImp(QWidget* parent = 0, Qt::WindowFlags fl = 0);
+    DlgActivateWindowImp(QWidget* parent = 0, Qt::WindowFlags fl = Qt::WindowFlags());
     ~DlgActivateWindowImp();
 
 protected:

--- a/src/Gui/DlgCustomizeImp.h
+++ b/src/Gui/DlgCustomizeImp.h
@@ -51,7 +51,7 @@ class DlgCustomizeImp : public QDialog
     Q_OBJECT
 
 public:
-    DlgCustomizeImp(QWidget* parent = 0, Qt::WindowFlags fl = 0);
+    DlgCustomizeImp(QWidget* parent = 0, Qt::WindowFlags fl = Qt::WindowFlags());
     ~DlgCustomizeImp();
 
     static void addPage(const char* className);

--- a/src/Gui/DlgDisplayPropertiesImp.h
+++ b/src/Gui/DlgDisplayPropertiesImp.h
@@ -56,7 +56,7 @@ class DlgDisplayPropertiesImp : public QDialog,
     Q_OBJECT
 
 public:
-    DlgDisplayPropertiesImp(bool floating, QWidget* parent = nullptr, Qt::WindowFlags fl = 0);
+    DlgDisplayPropertiesImp(bool floating, QWidget* parent = nullptr, Qt::WindowFlags fl = Qt::WindowFlags());
     ~DlgDisplayPropertiesImp();
     /// Observer message from the Selection
     void OnChange(Gui::SelectionSingleton::SubjectType &rCaller,

--- a/src/Gui/DlgEditFileIncludePropertyExternal.h
+++ b/src/Gui/DlgEditFileIncludePropertyExternal.h
@@ -39,7 +39,7 @@ class GuiExport DlgEditFileIncludePropertyExternal : public DlgRunExternal
     Q_OBJECT
 
 public:
-    DlgEditFileIncludePropertyExternal( App::PropertyFileIncluded& Prop, QWidget* parent = 0, Qt::WindowFlags fl = 0 );
+    DlgEditFileIncludePropertyExternal( App::PropertyFileIncluded& Prop, QWidget* parent = 0, Qt::WindowFlags fl = Qt::WindowFlags() );
     virtual ~DlgEditFileIncludePropertyExternal();
 
     int Do(void);

--- a/src/Gui/DlgMacroExecuteImp.h
+++ b/src/Gui/DlgMacroExecuteImp.h
@@ -44,7 +44,7 @@ class DlgMacroExecuteImp : public QDialog, public Gui::WindowParameter
     Q_OBJECT
 
 public:
-    DlgMacroExecuteImp( QWidget* parent = 0, Qt::WindowFlags fl = 0 );
+    DlgMacroExecuteImp( QWidget* parent = 0, Qt::WindowFlags fl =  Qt::WindowFlags() );
     ~DlgMacroExecuteImp();
 
     void accept();

--- a/src/Gui/DlgMacroRecordImp.h
+++ b/src/Gui/DlgMacroRecordImp.h
@@ -43,7 +43,7 @@ class DlgMacroRecordImp : public QDialog, public Gui::WindowParameter
     Q_OBJECT
 
 public:
-    DlgMacroRecordImp( QWidget* parent = 0, Qt::WindowFlags fl = 0 );
+    DlgMacroRecordImp( QWidget* parent = 0, Qt::WindowFlags fl = Qt::WindowFlags() );
     virtual ~DlgMacroRecordImp();
 
 protected Q_SLOTS:

--- a/src/Gui/DlgMaterialPropertiesImp.h
+++ b/src/Gui/DlgMaterialPropertiesImp.h
@@ -39,7 +39,7 @@ class DlgMaterialPropertiesImp : public QDialog
     Q_OBJECT
 
 public:
-    DlgMaterialPropertiesImp(const std::string& mat, QWidget* parent = 0, Qt::WindowFlags fl = 0);
+    DlgMaterialPropertiesImp(const std::string& mat, QWidget* parent = 0, Qt::WindowFlags fl = Qt::WindowFlags());
     ~DlgMaterialPropertiesImp();
     void setViewProviders(const std::vector<Gui::ViewProvider*>&);
     QColor diffuseColor() const;

--- a/src/Gui/DlgObjectSelection.h
+++ b/src/Gui/DlgObjectSelection.h
@@ -33,7 +33,7 @@ class GuiExport DlgObjectSelection : public QDialog
 
 public:
     DlgObjectSelection(const std::vector<App::DocumentObject*> &objs, 
-            QWidget* parent = 0, Qt::WindowFlags fl = 0);
+            QWidget* parent = 0, Qt::WindowFlags fl = Qt::WindowFlags());
     ~DlgObjectSelection();
 
     std::vector<App::DocumentObject*> getSelections() const;

--- a/src/Gui/DlgParameterImp.h
+++ b/src/Gui/DlgParameterImp.h
@@ -46,7 +46,7 @@ class GuiExport DlgParameterImp : public QDialog
     Q_OBJECT
 
 public:
-    DlgParameterImp( QWidget* parent = 0, Qt::WindowFlags fl = 0 );
+    DlgParameterImp( QWidget* parent = 0, Qt::WindowFlags fl = Qt::WindowFlags() );
     ~DlgParameterImp();
 
     void accept();

--- a/src/Gui/DlgPreferencesImp.h
+++ b/src/Gui/DlgPreferencesImp.h
@@ -112,7 +112,7 @@ public:
     static void addPage(const std::string& className, const std::string& group);
     static void removePage(const std::string& className, const std::string& group);
 
-    DlgPreferencesImp(QWidget* parent = 0, Qt::WindowFlags fl = 0);
+    DlgPreferencesImp(QWidget* parent = 0, Qt::WindowFlags fl = Qt::WindowFlags());
     ~DlgPreferencesImp();
 
     void accept();

--- a/src/Gui/DlgProjectInformationImp.h
+++ b/src/Gui/DlgProjectInformationImp.h
@@ -40,7 +40,7 @@ class DlgProjectInformationImp : public QDialog
     Q_OBJECT
 
 public:
-    DlgProjectInformationImp(App::Document* doc, QWidget* parent = 0, Qt::WindowFlags fl = 0);
+    DlgProjectInformationImp(App::Document* doc, QWidget* parent = 0, Qt::WindowFlags fl = Qt::WindowFlags());
     ~DlgProjectInformationImp();
     void accept();
 

--- a/src/Gui/DlgProjectUtility.h
+++ b/src/Gui/DlgProjectUtility.h
@@ -35,7 +35,7 @@ class DlgProjectUtility : public QDialog
     Q_OBJECT
 
 public:
-    DlgProjectUtility(QWidget* parent = 0, Qt::WindowFlags fl = 0);
+    DlgProjectUtility(QWidget* parent = 0, Qt::WindowFlags fl = Qt::WindowFlags());
     ~DlgProjectUtility();
 
 private Q_SLOTS:

--- a/src/Gui/DlgRunExternal.h
+++ b/src/Gui/DlgRunExternal.h
@@ -41,7 +41,7 @@ class GuiExport DlgRunExternal : public QDialog
     Q_OBJECT
 
 public:
-    DlgRunExternal(QWidget* parent = 0, Qt::WindowFlags fl = 0);
+    DlgRunExternal(QWidget* parent = 0, Qt::WindowFlags fl = Qt::WindowFlags());
     virtual ~DlgRunExternal();
 
     int Do(void);

--- a/src/Gui/DlgSettingsColorGradientImp.h
+++ b/src/Gui/DlgSettingsColorGradientImp.h
@@ -44,7 +44,7 @@ class DlgSettingsColorGradientImp : public QDialog
     Q_OBJECT
 
 public:
-    DlgSettingsColorGradientImp( QWidget* parent = 0, Qt::WindowFlags fl = 0 );
+    DlgSettingsColorGradientImp( QWidget* parent = 0, Qt::WindowFlags fl = Qt::WindowFlags() );
     ~DlgSettingsColorGradientImp();
 
     void accept();

--- a/src/Gui/DlgUnitsCalculatorImp.h
+++ b/src/Gui/DlgUnitsCalculatorImp.h
@@ -42,7 +42,7 @@ class DlgUnitsCalculator : public QDialog
     Q_OBJECT
 
 public:
-    DlgUnitsCalculator(QWidget* parent = 0, Qt::WindowFlags fl = 0);
+    DlgUnitsCalculator(QWidget* parent = 0, Qt::WindowFlags fl = Qt::WindowFlags());
     ~DlgUnitsCalculator();
 
 protected:

--- a/src/Gui/DocumentModel.cpp
+++ b/src/Gui/DocumentModel.cpp
@@ -628,7 +628,7 @@ Qt::ItemFlags DocumentModel::flags(const QModelIndex &index) const
     //    return Qt::ItemIsEnabled;
     //return QAbstractItemModel::flags(index);
     if (!index.isValid())
-        return 0;
+        return Qt::ItemFlags();
     return static_cast<DocumentModelIndex*>(index.internalPointer())->flags();
 }
 

--- a/src/Gui/EditorView.cpp
+++ b/src/Gui/EditorView.cpp
@@ -79,7 +79,7 @@ public:
  *  name 'name'.
  */
 EditorView::EditorView(QPlainTextEdit* editor, QWidget* parent)
-    : MDIView(0,parent,0), WindowParameter( "Editor" )
+    : MDIView(0,parent,Qt::WindowFlags()), WindowParameter( "Editor" )
 {
     d = new EditorViewP;
     d->lock = false;

--- a/src/Gui/FileDialog.h
+++ b/src/Gui/FileDialog.h
@@ -49,13 +49,13 @@ class GuiExport FileDialog : public QFileDialog
 
 public:
     static QString getOpenFileName( QWidget * parent = 0, const QString & caption = QString(), const QString & dir = QString(), 
-                                    const QString & filter = QString(), QString * selectedFilter = 0, Options options = 0 );
+                                    const QString & filter = QString(), QString * selectedFilter = 0, Options options = Options() );
     static QString getSaveFileName( QWidget * parent = 0, const QString & caption = QString(), const QString & dir = QString(), 
-                                    const QString & filter = QString(), QString * selectedFilter = 0, Options options = 0 );
+                                    const QString & filter = QString(), QString * selectedFilter = 0, Options options = Options() );
     static QString getExistingDirectory( QWidget * parent = 0, const QString & caption = QString(), const QString & dir = QString(), 
                                          Options options = ShowDirsOnly );
     static QStringList getOpenFileNames( QWidget * parent = 0, const QString & caption = QString(), const QString & dir = QString(),
-                                         const QString & filter = QString(), QString * selectedFilter = 0, Options options = 0 );
+                                         const QString & filter = QString(), QString * selectedFilter = 0, Options options = Options() );
 
     /*! Return the last directory a file was read from or saved to. */
     static QString getWorkingDirectory();

--- a/src/Gui/InputVector.h
+++ b/src/Gui/InputVector.h
@@ -83,7 +83,7 @@ class GuiExport LocationDialog : public QDialog
     Q_OBJECT
 
 protected:
-    LocationDialog(QWidget* parent = 0, Qt::WindowFlags fl = 0);
+    LocationDialog(QWidget* parent = 0, Qt::WindowFlags fl = Qt::WindowFlags());
     virtual ~LocationDialog();
 
 protected:
@@ -116,7 +116,7 @@ template <class Ui>
 class LocationDialogUi : public LocationDialog, public Ui
 {
 public:
-    LocationDialogUi(QWidget* parent = 0, Qt::WindowFlags fl = 0)  : LocationDialog(parent, fl)
+    LocationDialogUi(QWidget* parent = 0, Qt::WindowFlags fl = Qt::WindowFlags())  : LocationDialog(parent, fl)
     {
         this->setupUi(this);
         this->retranslate();
@@ -366,7 +366,7 @@ template <class Ui>
 class LocationDialogImp : public LocationDialog
 {
 public:
-    LocationDialogImp(QWidget* parent = 0, Qt::WindowFlags fl = 0)
+    LocationDialogImp(QWidget* parent = 0, Qt::WindowFlags fl = Qt::WindowFlags())
       : LocationDialog(parent, fl), ui(this)
     {
     }
@@ -556,7 +556,7 @@ class GuiExport LocationDialogUiImp : public LocationDialog
 {
 public:
     template<class T>
-    LocationDialogUiImp(T* t, QWidget* parent = 0, Qt::WindowFlags fl = 0)
+    LocationDialogUiImp(T* t, QWidget* parent = 0, Qt::WindowFlags fl =  Qt::WindowFlags())
       : LocationDialog(parent, fl), ui(new LocationImpUi<T>(t))
     {
         std::shared_ptr<T> uit = boost::any_cast< std::shared_ptr<T> >(ui->get());

--- a/src/Gui/MDIView.h
+++ b/src/Gui/MDIView.h
@@ -62,7 +62,7 @@ public:
      * the view will attach to the active document. Be aware, there isn't
      * always an active document.
      */
-    MDIView(Gui::Document* pcDocument, QWidget* parent, Qt::WindowFlags wflags=0);
+    MDIView(Gui::Document* pcDocument, QWidget* parent, Qt::WindowFlags wflags=Qt::WindowFlags());
     /** View destructor
      * Detach the view from the document, if attached.
      */

--- a/src/Gui/ManualAlignment.cpp
+++ b/src/Gui/ManualAlignment.cpp
@@ -369,7 +369,7 @@ class AlignmentView : public Gui::AbstractSplitView
 public:
     QLabel* myLabel;
 
-    AlignmentView(Gui::Document* pcDocument, QWidget* parent, Qt::WindowFlags wflags=0)
+    AlignmentView(Gui::Document* pcDocument, QWidget* parent, Qt::WindowFlags wflags=Qt::WindowFlags())
         : AbstractSplitView(pcDocument, parent, wflags)
     {
         //anti-aliasing settings

--- a/src/Gui/Placement.h
+++ b/src/Gui/Placement.h
@@ -45,7 +45,7 @@ class GuiExport Placement : public Gui::LocationDialog
     Q_OBJECT
 
 public:
-    Placement(QWidget* parent = 0, Qt::WindowFlags fl = 0);
+    Placement(QWidget* parent = 0, Qt::WindowFlags fl = Qt::WindowFlags());
     ~Placement();
     void accept();
     void reject();
@@ -116,7 +116,7 @@ class GuiExport DockablePlacement : public Placement
     Q_OBJECT
 
 public:
-    DockablePlacement(QWidget* parent = 0, Qt::WindowFlags fl = 0);
+    DockablePlacement(QWidget* parent = 0, Qt::WindowFlags fl = Qt::WindowFlags());
     ~DockablePlacement();
 
     void accept();

--- a/src/Gui/QSint/actionpanel/actionbox.h
+++ b/src/Gui/QSint/actionpanel/actionbox.h
@@ -182,7 +182,7 @@ public:
     void setIcon(const QPixmap & icon);
     /** Returns icon of the ActionBox.
       */
-    inline const QPixmap* icon() const { return iconLabel->pixmap(); }
+    inline QPixmap icon() { return iconLabel->pixmap(Qt::ReturnByValue); }
 
     /** Returns header item of the ActionBox.
       */

--- a/src/Gui/QSint/actionpanel/actionbox.h
+++ b/src/Gui/QSint/actionpanel/actionbox.h
@@ -182,7 +182,7 @@ public:
     void setIcon(const QPixmap & icon);
     /** Returns icon of the ActionBox.
       */
-    inline QPixmap icon() { return iconLabel->pixmap(Qt::ReturnByValue); }
+    inline const QPixmap* icon() const { return iconLabel->pixmap(); }
 
     /** Returns header item of the ActionBox.
       */

--- a/src/Gui/QSint/actionpanel/taskheader_p.cpp
+++ b/src/Gui/QSint/actionpanel/taskheader_p.cpp
@@ -264,7 +264,7 @@ void TaskHeader::keyPressEvent ( QKeyEvent * event )
   {
     case Qt::Key_Down:
     {
-      QKeyEvent ke(QEvent::KeyPress, Qt::Key_Tab, 0);
+      QKeyEvent ke(QEvent::KeyPress, Qt::Key_Tab,0 );
       QApplication::sendEvent(this, &ke);
       return;
     }

--- a/src/Gui/Quarter/QuarterWidget.cpp
+++ b/src/Gui/Quarter/QuarterWidget.cpp
@@ -154,7 +154,7 @@ class CustomGLWidget : public QOpenGLWidget {
 public:
     QSurfaceFormat myFormat;
 
-    CustomGLWidget(const QSurfaceFormat& format, QWidget* parent = 0, const QOpenGLWidget* shareWidget = 0, Qt::WindowFlags f = 0)
+    CustomGLWidget(const QSurfaceFormat& format, QWidget* parent = 0, const QOpenGLWidget* shareWidget = 0, Qt::WindowFlags f = Qt::WindowFlags())
      : QOpenGLWidget(parent, f), myFormat(format)
     {
         Q_UNUSED(shareWidget);

--- a/src/Gui/Quarter/QuarterWidget.h
+++ b/src/Gui/Quarter/QuarterWidget.h
@@ -81,9 +81,9 @@ class QUARTER_DLL_API QuarterWidget : public QGraphicsView {
 
 
 public:
-  explicit QuarterWidget(QWidget * parent = 0, const QtGLWidget * sharewidget = 0, Qt::WindowFlags f = 0);
-  explicit QuarterWidget(QtGLContext * context, QWidget * parent = 0, const QtGLWidget * sharewidget = 0, Qt::WindowFlags f = 0);
-  explicit QuarterWidget(const QtGLFormat & format, QWidget * parent = 0, const QtGLWidget * shareWidget = 0, Qt::WindowFlags f = 0);
+  explicit QuarterWidget(QWidget * parent = 0, const QtGLWidget * sharewidget = 0, Qt::WindowFlags f = Qt::WindowFlags());
+  explicit QuarterWidget(QtGLContext * context, QWidget * parent = 0, const QtGLWidget * sharewidget = 0, Qt::WindowFlags f = Qt::WindowFlags());
+  explicit QuarterWidget(const QtGLFormat & format, QWidget * parent = 0, const QtGLWidget * shareWidget = 0, Qt::WindowFlags f = Qt::WindowFlags());
   virtual ~QuarterWidget();
 
   enum TransparencyType {

--- a/src/Gui/Quarter/SoQTQuarterAdaptor.h
+++ b/src/Gui/Quarter/SoQTQuarterAdaptor.h
@@ -47,9 +47,9 @@ typedef void SoQTQuarterAdaptorCB(void* data, SoQTQuarterAdaptor* viewer);
 class QUARTER_DLL_API SoQTQuarterAdaptor :  public QuarterWidget {
 
 public:
-    explicit SoQTQuarterAdaptor(QWidget* parent = 0, const QtGLWidget* sharewidget = 0, Qt::WindowFlags f = 0);
-    explicit SoQTQuarterAdaptor(const QtGLFormat& format, QWidget* parent = 0, const QtGLWidget* shareWidget = 0, Qt::WindowFlags f = 0);
-    explicit SoQTQuarterAdaptor(QtGLContext* context, QWidget* parent = 0, const QtGLWidget* sharewidget = 0, Qt::WindowFlags f = 0);
+    explicit SoQTQuarterAdaptor(QWidget* parent = 0, const QtGLWidget* sharewidget = 0, Qt::WindowFlags f = Qt::WindowFlags());
+    explicit SoQTQuarterAdaptor(const QtGLFormat& format, QWidget* parent = 0, const QtGLWidget* shareWidget = 0, Qt::WindowFlags f = Qt::WindowFlags());
+    explicit SoQTQuarterAdaptor(QtGLContext* context, QWidget* parent = 0, const QtGLWidget* sharewidget = 0, Qt::WindowFlags f = Qt::WindowFlags());
     virtual ~SoQTQuarterAdaptor();
 
     //the functions available in soqtviewer but missing in quarter

--- a/src/Gui/SceneInspector.h
+++ b/src/Gui/SceneInspector.h
@@ -71,7 +71,7 @@ class DlgInspector : public QDialog
     Q_OBJECT
 
 public:
-    DlgInspector(QWidget* parent = 0, Qt::WindowFlags fl = 0);
+    DlgInspector(QWidget* parent = 0, Qt::WindowFlags fl = Qt::WindowFlags());
     ~DlgInspector();
 
     void setDocument(Gui::Document* doc);

--- a/src/Gui/Splashscreen.cpp
+++ b/src/Gui/Splashscreen.cpp
@@ -826,7 +826,7 @@ void AboutDialog::on_copyButton_clicked()
 /* TRANSLATOR Gui::LicenseView */
 
 LicenseView::LicenseView(QWidget* parent)
-    : MDIView(0,parent,0)
+    : MDIView(0,parent,Qt::WindowFlags())
 {
     browser = new QTextBrowser(this);
     browser->setOpenExternalLinks(true);

--- a/src/Gui/Splashscreen.h
+++ b/src/Gui/Splashscreen.h
@@ -42,7 +42,7 @@ class SplashScreen : public QSplashScreen
     Q_OBJECT
 
 public:
-    SplashScreen(  const QPixmap & pixmap = QPixmap ( ), Qt::WindowFlags f = 0 );
+    SplashScreen(  const QPixmap & pixmap = QPixmap ( ), Qt::WindowFlags f = Qt::WindowFlags() );
     ~SplashScreen();
 
 protected:

--- a/src/Gui/SplitView3DInventor.h
+++ b/src/Gui/SplitView3DInventor.h
@@ -42,7 +42,7 @@ class GuiExport AbstractSplitView : public MDIView, public ParameterGrp::Observe
     TYPESYSTEM_HEADER();
 
 public:
-    AbstractSplitView(Gui::Document* pcDocument, QWidget* parent, Qt::WindowFlags wflags=0);
+    AbstractSplitView(Gui::Document* pcDocument, QWidget* parent, Qt::WindowFlags wflags=Qt::WindowFlags());
     ~AbstractSplitView();
 
     virtual const char *getName(void) const;
@@ -109,7 +109,7 @@ class GuiExport SplitView3DInventor : public AbstractSplitView
     TYPESYSTEM_HEADER();
 
 public:
-    SplitView3DInventor(int views, Gui::Document* pcDocument, QWidget* parent, Qt::WindowFlags wflags=0);
+    SplitView3DInventor(int views, Gui::Document* pcDocument, QWidget* parent, Qt::WindowFlags wflags=Qt::WindowFlags());
     ~SplitView3DInventor();
 };
 

--- a/src/Gui/TextureMapping.h
+++ b/src/Gui/TextureMapping.h
@@ -39,7 +39,7 @@ class GuiExport TextureMapping : public QDialog
     Q_OBJECT
 
 public:
-    TextureMapping(QWidget* parent = 0, Qt::WindowFlags fl = 0);
+    TextureMapping(QWidget* parent = 0, Qt::WindowFlags fl = Qt::WindowFlags());
     ~TextureMapping();
     void accept();
     void reject();

--- a/src/Gui/Transform.h
+++ b/src/Gui/Transform.h
@@ -71,7 +71,7 @@ class GuiExport Transform : public Gui::LocationDialog
     Q_OBJECT
 
 public:
-    Transform(QWidget* parent = 0, Qt::WindowFlags fl = 0);
+    Transform(QWidget* parent = 0, Qt::WindowFlags fl = Qt::WindowFlags());
     ~Transform();
     void accept();
     void reject();

--- a/src/Gui/View3DInventor.h
+++ b/src/Gui/View3DInventor.h
@@ -68,7 +68,7 @@ class GuiExport View3DInventor : public MDIView, public ParameterGrp::ObserverTy
     TYPESYSTEM_HEADER();
 
 public:
-    View3DInventor(Gui::Document* pcDocument, QWidget* parent, const QtGLWidget* sharewidget = 0, Qt::WindowFlags wflags=0);
+    View3DInventor(Gui::Document* pcDocument, QWidget* parent, const QtGLWidget* sharewidget = 0, Qt::WindowFlags wflags=Qt::WindowFlags());
     ~View3DInventor();
 
     /// Message handler

--- a/src/Gui/Widgets.h
+++ b/src/Gui/Widgets.h
@@ -179,7 +179,7 @@ class GuiExport CheckListDialog : public QDialog
   Q_OBJECT
 
 public:
-  CheckListDialog( QWidget* parent = 0, Qt::WindowFlags fl = 0 );
+  CheckListDialog( QWidget* parent = 0, Qt::WindowFlags fl = Qt::WindowFlags() );
   ~CheckListDialog();
 
   void setCheckableItems( const QStringList& items );
@@ -260,7 +260,7 @@ class GuiExport UrlLabel : public QLabel
   Q_PROPERTY( QString  url    READ url   WRITE setUrl)
 
 public:
-  UrlLabel ( QWidget * parent = 0, Qt::WindowFlags f = 0 );
+  UrlLabel ( QWidget * parent = 0, Qt::WindowFlags f = Qt::WindowFlags() );
   virtual ~UrlLabel();
 
   QString url() const;

--- a/src/Mod/Drawing/Gui/DrawingView.cpp
+++ b/src/Mod/Drawing/Gui/DrawingView.cpp
@@ -463,7 +463,7 @@ void DrawingView::onRelabel(Gui::Document *pDoc)
 
 void DrawingView::printPdf()
 {
-    Gui::FileOptionsDialog dlg(this, 0);
+    Gui::FileOptionsDialog dlg(this, Qt::WindowFlags());
     dlg.setFileMode(QFileDialog::AnyFile);
     dlg.setAcceptMode(QFileDialog::AcceptSave);
     dlg.setWindowTitle(tr("Export PDF"));

--- a/src/Mod/Image/Gui/OpenGLImageBox.h
+++ b/src/Mod/Image/Gui/OpenGLImageBox.h
@@ -37,7 +37,7 @@ class ImageGuiExport GLImageBox : public QOpenGLWidget
 
 public:
 
-    GLImageBox(QWidget * parent = 0, Qt::WindowFlags f = 0);
+    GLImageBox(QWidget * parent = 0, Qt::WindowFlags f = Qt::WindowFlags());
     ~GLImageBox();
 
     Image::ImageBase *getImageBasePtr() { return &_image; }

--- a/src/Mod/Inspection/Gui/VisualInspection.h
+++ b/src/Mod/Inspection/Gui/VisualInspection.h
@@ -37,7 +37,7 @@ class VisualInspection : public QDialog
     Q_OBJECT
 
 public:
-    VisualInspection(QWidget* parent = 0, Qt::WindowFlags fl = 0);
+    VisualInspection(QWidget* parent = 0, Qt::WindowFlags fl = Qt::WindowFlags());
   ~ VisualInspection();
 
     void accept();

--- a/src/Mod/Mesh/Gui/DlgDecimating.h
+++ b/src/Mod/Mesh/Gui/DlgDecimating.h
@@ -36,7 +36,7 @@ class DlgDecimating : public QWidget
     Q_OBJECT
 
 public:
-    DlgDecimating(QWidget* parent = 0, Qt::WindowFlags fl = 0);
+    DlgDecimating(QWidget* parent = 0, Qt::WindowFlags fl = Qt::WindowFlags());
     ~DlgDecimating();
     void setNumberOfTriangles(int);
     double tolerance() const;

--- a/src/Mod/Mesh/Gui/DlgEvaluateMeshImp.h
+++ b/src/Mod/Mesh/Gui/DlgEvaluateMeshImp.h
@@ -68,7 +68,7 @@ class DlgEvaluateMeshImp : public QDialog, public App::DocumentObserver
     Q_OBJECT
 
 public:
-    DlgEvaluateMeshImp(QWidget* parent = 0, Qt::WindowFlags fl = 0);
+    DlgEvaluateMeshImp(QWidget* parent = 0, Qt::WindowFlags fl = Qt::WindowFlags());
     ~DlgEvaluateMeshImp();
 
     void setMesh(Mesh::Feature*);
@@ -146,7 +146,7 @@ class DockEvaluateMeshImp : public DlgEvaluateMeshImp
     Q_OBJECT
 
 protected:
-    DockEvaluateMeshImp( QWidget* parent = 0, Qt::WindowFlags fl = 0 );
+    DockEvaluateMeshImp( QWidget* parent = 0, Qt::WindowFlags fl = Qt::WindowFlags() );
     ~DockEvaluateMeshImp();
     void closeEvent(QCloseEvent* e);
 

--- a/src/Mod/Mesh/Gui/DlgEvaluateSettings.h
+++ b/src/Mod/Mesh/Gui/DlgEvaluateSettings.h
@@ -38,7 +38,7 @@ class DlgEvaluateSettings : public QDialog
     Q_OBJECT
 
 public:
-    DlgEvaluateSettings(QWidget* parent = 0, Qt::WindowFlags fl = 0);
+    DlgEvaluateSettings(QWidget* parent = 0, Qt::WindowFlags fl = Qt::WindowFlags());
     ~DlgEvaluateSettings();
 
     void setNonmanifoldPointsChecked(bool);

--- a/src/Mod/Mesh/Gui/DlgRegularSolidImp.h
+++ b/src/Mod/Mesh/Gui/DlgRegularSolidImp.h
@@ -34,7 +34,7 @@ class DlgRegularSolidImp : public QDialog
     Q_OBJECT
 
 public:
-    DlgRegularSolidImp(QWidget* parent = 0, Qt::WindowFlags fl = 0);
+    DlgRegularSolidImp(QWidget* parent = 0, Qt::WindowFlags fl = Qt::WindowFlags());
     ~DlgRegularSolidImp();
 
 public Q_SLOTS:

--- a/src/Mod/Mesh/Gui/DlgSmoothing.h
+++ b/src/Mod/Mesh/Gui/DlgSmoothing.h
@@ -73,7 +73,7 @@ class MeshGuiExport SmoothingDialog : public QDialog
     Q_OBJECT
 
 public:
-    SmoothingDialog(QWidget* parent = 0, Qt::WindowFlags fl = 0);
+    SmoothingDialog(QWidget* parent = 0, Qt::WindowFlags fl = Qt::WindowFlags());
     ~SmoothingDialog();
 
     int iterations() const

--- a/src/Mod/Mesh/Gui/RemeshGmsh.h
+++ b/src/Mod/Mesh/Gui/RemeshGmsh.h
@@ -52,7 +52,7 @@ class MeshGuiExport GmshWidget : public QWidget
     Q_OBJECT
 
 public:
-    GmshWidget(QWidget* parent = 0, Qt::WindowFlags fl = 0);
+    GmshWidget(QWidget* parent = 0, Qt::WindowFlags fl = Qt::WindowFlags());
     ~GmshWidget();
     void accept();
     void reject();
@@ -90,7 +90,7 @@ class MeshGuiExport RemeshGmsh : public GmshWidget
     Q_OBJECT
 
 public:
-    RemeshGmsh(Mesh::Feature* mesh, QWidget* parent = 0, Qt::WindowFlags fl = 0);
+    RemeshGmsh(Mesh::Feature* mesh, QWidget* parent = 0, Qt::WindowFlags fl = Qt::WindowFlags());
     ~RemeshGmsh();
 
 protected:

--- a/src/Mod/Mesh/Gui/RemoveComponents.h
+++ b/src/Mod/Mesh/Gui/RemoveComponents.h
@@ -42,7 +42,7 @@ class MeshGuiExport RemoveComponents : public QWidget
     Q_OBJECT
 
 public:
-    RemoveComponents(QWidget* parent = 0, Qt::WindowFlags fl = 0);
+    RemoveComponents(QWidget* parent = 0, Qt::WindowFlags fl = Qt::WindowFlags());
     ~RemoveComponents();
     void reject();
     void deleteSelection();
@@ -78,7 +78,7 @@ class MeshGuiExport RemoveComponentsDialog : public QDialog
     Q_OBJECT
 
 public:
-    RemoveComponentsDialog(QWidget* parent = 0, Qt::WindowFlags fl = 0);
+    RemoveComponentsDialog(QWidget* parent = 0, Qt::WindowFlags fl = Qt::WindowFlags());
     ~RemoveComponentsDialog();
     void reject();
 

--- a/src/Mod/Mesh/Gui/Segmentation.h
+++ b/src/Mod/Mesh/Gui/Segmentation.h
@@ -37,7 +37,7 @@ class Ui_Segmentation;
 class MeshGuiExport Segmentation : public QWidget
 {
 public:
-    Segmentation(Mesh::Feature* mesh, QWidget* parent = 0, Qt::WindowFlags fl = 0);
+    Segmentation(Mesh::Feature* mesh, QWidget* parent = 0, Qt::WindowFlags fl = Qt::WindowFlags());
     ~Segmentation();
     void accept();
 

--- a/src/Mod/Mesh/Gui/SegmentationBestFit.h
+++ b/src/Mod/Mesh/Gui/SegmentationBestFit.h
@@ -82,7 +82,7 @@ class MeshGuiExport SegmentationBestFit : public QWidget
     Q_OBJECT
 
 public:
-    SegmentationBestFit(Mesh::Feature* mesh, QWidget* parent = 0, Qt::WindowFlags fl = 0);
+    SegmentationBestFit(Mesh::Feature* mesh, QWidget* parent = 0, Qt::WindowFlags fl = Qt::WindowFlags());
     ~SegmentationBestFit();
     void accept();
 

--- a/src/Mod/MeshPart/Gui/CrossSections.h
+++ b/src/Mod/MeshPart/Gui/CrossSections.h
@@ -44,7 +44,7 @@ class CrossSections : public QDialog
     enum Plane { XY, XZ, YZ };
 
 public:
-    CrossSections(const Base::BoundBox3d& bb, QWidget* parent = 0, Qt::WindowFlags fl = 0);
+    CrossSections(const Base::BoundBox3d& bb, QWidget* parent = 0, Qt::WindowFlags fl = Qt::WindowFlags());
     ~CrossSections();
     void accept();
     void apply();

--- a/src/Mod/MeshPart/Gui/Tessellation.h
+++ b/src/Mod/MeshPart/Gui/Tessellation.h
@@ -47,7 +47,7 @@ class Mesh2ShapeGmsh : public MeshGui::GmshWidget
     Q_OBJECT
 
 public:
-    Mesh2ShapeGmsh(QWidget* parent = 0, Qt::WindowFlags fl = 0);
+    Mesh2ShapeGmsh(QWidget* parent = 0, Qt::WindowFlags fl = Qt::WindowFlags());
     ~Mesh2ShapeGmsh();
 
     void process(App::Document* doc, const std::list<App::SubObjectT>&);

--- a/src/Mod/Part/Gui/CrossSections.h
+++ b/src/Mod/Part/Gui/CrossSections.h
@@ -44,7 +44,7 @@ class CrossSections : public QDialog
     enum Plane { XY, XZ, YZ };
 
 public:
-    CrossSections(const Base::BoundBox3d& bb, QWidget* parent = 0, Qt::WindowFlags fl = 0);
+    CrossSections(const Base::BoundBox3d& bb, QWidget* parent = 0, Qt::WindowFlags fl = Qt::WindowFlags());
     ~CrossSections();
     void accept();
     void apply();

--- a/src/Mod/Part/Gui/DlgExtrusion.h
+++ b/src/Mod/Part/Gui/DlgExtrusion.h
@@ -39,7 +39,7 @@ class DlgExtrusion : public QDialog, public Gui::SelectionObserver
     Q_OBJECT
 
 public:
-    DlgExtrusion(QWidget* parent = 0, Qt::WindowFlags fl = 0);
+    DlgExtrusion(QWidget* parent = 0, Qt::WindowFlags fl = Qt::WindowFlags());
     ~DlgExtrusion();
     void accept();
     void apply();

--- a/src/Mod/Part/Gui/DlgFilletEdges.h
+++ b/src/Mod/Part/Gui/DlgFilletEdges.h
@@ -81,7 +81,7 @@ class DlgFilletEdges : public QWidget, public Gui::SelectionObserver
 public:
     enum FilletType { FILLET, CHAMFER };
 
-    DlgFilletEdges(FilletType type, Part::FilletBase*, QWidget* parent = 0, Qt::WindowFlags fl = 0);
+    DlgFilletEdges(FilletType type, Part::FilletBase*, QWidget* parent = 0, Qt::WindowFlags fl = Qt::WindowFlags());
     ~DlgFilletEdges();
     bool accept();
 
@@ -121,7 +121,7 @@ class FilletEdgesDialog : public QDialog
     Q_OBJECT
 
 public:
-    FilletEdgesDialog(DlgFilletEdges::FilletType type, Part::FilletBase* fillet, QWidget* parent = 0, Qt::WindowFlags fl = 0);
+    FilletEdgesDialog(DlgFilletEdges::FilletType type, Part::FilletBase* fillet, QWidget* parent = 0, Qt::WindowFlags fl = Qt::WindowFlags());
     ~FilletEdgesDialog();
     void accept();
 
@@ -134,7 +134,7 @@ class DlgChamferEdges : public DlgFilletEdges
     Q_OBJECT
 
 public:
-    DlgChamferEdges(Part::FilletBase*, QWidget* parent = 0, Qt::WindowFlags fl = 0);
+    DlgChamferEdges(Part::FilletBase*, QWidget* parent = 0, Qt::WindowFlags fl = Qt::WindowFlags());
     ~DlgChamferEdges();
 
 protected:

--- a/src/Mod/Part/Gui/DlgPartBoxImp.h
+++ b/src/Mod/Part/Gui/DlgPartBoxImp.h
@@ -34,7 +34,7 @@ class DlgPartBoxImp : public Gui::LocationDialogUiImp
     Q_OBJECT
 
 public:
-    DlgPartBoxImp(QWidget* parent = 0, Qt::WindowFlags fl = 0);
+    DlgPartBoxImp(QWidget* parent = 0, Qt::WindowFlags fl = Qt::WindowFlags());
     ~DlgPartBoxImp();
 };
 

--- a/src/Mod/Part/Gui/DlgPartCylinderImp.h
+++ b/src/Mod/Part/Gui/DlgPartCylinderImp.h
@@ -34,7 +34,7 @@ class DlgPartCylinderImp : public Gui::LocationDialogUiImp
     Q_OBJECT
 
 public:
-    DlgPartCylinderImp(QWidget* parent = 0, Qt::WindowFlags fl = 0);
+    DlgPartCylinderImp(QWidget* parent = 0, Qt::WindowFlags fl = Qt::WindowFlags());
     ~DlgPartCylinderImp();
 
     double getRadius() const;

--- a/src/Mod/Part/Gui/DlgPartImportIgesImp.h
+++ b/src/Mod/Part/Gui/DlgPartImportIgesImp.h
@@ -33,7 +33,7 @@ class DlgPartImportIgesImp : public QDialog
     Q_OBJECT
 
 public:
-  DlgPartImportIgesImp( QWidget* parent = 0, Qt::WindowFlags fl = 0 );
+  DlgPartImportIgesImp( QWidget* parent = 0, Qt::WindowFlags fl = Qt::WindowFlags() );
   ~DlgPartImportIgesImp();
 
 public Q_SLOTS:

--- a/src/Mod/Part/Gui/DlgPartImportStepImp.h
+++ b/src/Mod/Part/Gui/DlgPartImportStepImp.h
@@ -34,7 +34,7 @@ class DlgPartImportStepImp : public QDialog
     Q_OBJECT
 
 public:
-  DlgPartImportStepImp( QWidget* parent = 0, Qt::WindowFlags fl = 0 );
+  DlgPartImportStepImp( QWidget* parent = 0, Qt::WindowFlags fl = Qt::WindowFlags() );
   ~DlgPartImportStepImp();
 
 public Q_SLOTS:

--- a/src/Mod/Part/Gui/DlgRevolution.h
+++ b/src/Mod/Part/Gui/DlgRevolution.h
@@ -36,7 +36,7 @@ class DlgRevolution : public QDialog, public Gui::SelectionObserver
     Q_OBJECT
 
 public:
-    DlgRevolution(QWidget* parent = 0, Qt::WindowFlags fl = 0);
+    DlgRevolution(QWidget* parent = 0, Qt::WindowFlags fl = Qt::WindowFlags());
     ~DlgRevolution();
     void accept();
 

--- a/src/Mod/Points/Gui/DlgPointsReadImp.h
+++ b/src/Mod/Points/Gui/DlgPointsReadImp.h
@@ -38,7 +38,7 @@ class DlgPointsReadImp : public QDialog
   Q_OBJECT
 
 public:
-  DlgPointsReadImp(const char *FileName, QWidget* parent = nullptr, Qt::WindowFlags fl = 0 );
+  DlgPointsReadImp(const char *FileName, QWidget* parent = nullptr, Qt::WindowFlags fl = Qt::WindowFlags() );
   ~DlgPointsReadImp();
 
 private:

--- a/src/Mod/ReverseEngineering/Gui/Segmentation.h
+++ b/src/Mod/ReverseEngineering/Gui/Segmentation.h
@@ -41,7 +41,7 @@ class Segmentation : public QWidget
     Q_OBJECT
 
 public:
-    Segmentation(Mesh::Feature* mesh, QWidget* parent = 0, Qt::WindowFlags fl = 0);
+    Segmentation(Mesh::Feature* mesh, QWidget* parent = 0, Qt::WindowFlags fl = Qt::WindowFlags());
     ~Segmentation();
     void accept();
 

--- a/src/Mod/ReverseEngineering/Gui/SegmentationManual.h
+++ b/src/Mod/ReverseEngineering/Gui/SegmentationManual.h
@@ -43,7 +43,7 @@ class SegmentationManual : public QWidget
     Q_OBJECT
 
 public:
-    SegmentationManual(QWidget* parent = 0, Qt::WindowFlags fl = 0);
+    SegmentationManual(QWidget* parent = 0, Qt::WindowFlags fl = Qt::WindowFlags());
     ~SegmentationManual();
     void reject();
     void createSegment();

--- a/src/Mod/Start/Gui/Workbench.cpp
+++ b/src/Mod/Start/Gui/Workbench.cpp
@@ -85,35 +85,35 @@ void StartGui::Workbench::loadStartPage()
         std::string escapedstr = Base::Tools::escapedUnicodeFromUtf8(utf8Title);
         QByteArray cmd;
         QTextStream str(&cmd);
-        str << "import WebGui,sys,Start" << endl;
-        str << "from StartPage import StartPage" << endl;
+        str << "import WebGui,sys,Start" << Qt::endl;
+        str << "from StartPage import StartPage" << Qt::endl;
         str << endl;
-        str << "class WebPage(object):" << endl;
-        str << "    def __init__(self):" << endl;
-        str << "        self.browser=WebGui.openBrowserWindow(u'" << escapedstr.c_str() << "')" << endl;
+        str << "class WebPage(object):" << Qt::endl;
+        str << "    def __init__(self):" << Qt::endl;
+        str << "        self.browser=WebGui.openBrowserWindow(u'" << escapedstr.c_str() << "')" << Qt::endl;
 #if defined(FC_OS_WIN32)
-        str << "        self.browser.setHtml(StartPage.handle(), App.getResourceDir() + 'Mod/Start/StartPage/')" << endl;
+        str << "        self.browser.setHtml(StartPage.handle(), App.getResourceDir() + 'Mod/Start/StartPage/')" << Qt::endl;
 #else
-        str << "        self.browser.setHtml(StartPage.handle(), 'file://' + App.getResourceDir() + 'Mod/Start/StartPage/')" << endl;
+        str << "        self.browser.setHtml(StartPage.handle(), 'file://' + App.getResourceDir() + 'Mod/Start/StartPage/')" << Qt::endl;
 #endif
-        str << "    def onChange(self, par, reason):" << endl;
-        str << "        if reason == 'RecentFiles':" << endl;
+        str << "    def onChange(self, par, reason):" << Qt::endl;
+        str << "        if reason == 'RecentFiles':" << Qt::endl;
 #if defined(FC_OS_WIN32)
-        str << "            self.browser.setHtml(StartPage.handle(), App.getResourceDir() + 'Mod/Start/StartPage/')" << endl;
+        str << "            self.browser.setHtml(StartPage.handle(), App.getResourceDir() + 'Mod/Start/StartPage/')" << Qt::endl;
 #else
-        str << "            self.browser.setHtml(StartPage.handle(), 'file://' + App.getResourceDir() + 'Mod/Start/StartPage/')" << endl;
+        str << "            self.browser.setHtml(StartPage.handle(), 'file://' + App.getResourceDir() + 'Mod/Start/StartPage/')" << Qt::endl;
 #endif
+        str << Qt::endl;
+        str << "class WebView(object):" << Qt::endl;
+        str << "    def __init__(self):" << Qt::endl;
+        str << "        self.pargrp = FreeCAD.ParamGet('User parameter:BaseApp/Preferences/RecentFiles')" << Qt::endl;
+        str << "        self.webPage = WebPage()" << Qt::endl;
+        str << "        self.pargrp.Attach(self.webPage)" << Qt::endl;
+        str << "    def __del__(self):" << Qt::endl;
+        str << "        self.pargrp.Detach(self.webPage)" << Qt::endl;
         str << endl;
-        str << "class WebView(object):" << endl;
-        str << "    def __init__(self):" << endl;
-        str << "        self.pargrp = FreeCAD.ParamGet('User parameter:BaseApp/Preferences/RecentFiles')" << endl;
-        str << "        self.webPage = WebPage()" << endl;
-        str << "        self.pargrp.Attach(self.webPage)" << endl;
-        str << "    def __del__(self):" << endl;
-        str << "        self.pargrp.Detach(self.webPage)" << endl;
-        str << endl;
-        str << "webView=WebView()" << endl;
-        str << "StartPage.checkPostOpenStartPage()" << endl;
+        str << "webView=WebView()" << Qt::endl;
+        str << "StartPage.checkPostOpenStartPage()" << Qt::endl;
 
         Base::Interpreter().runString(cmd);
         // Gui::Command::runCommand(Gui::Command::Gui, cmd);

--- a/src/Mod/Start/Gui/Workbench.cpp
+++ b/src/Mod/Start/Gui/Workbench.cpp
@@ -85,35 +85,35 @@ void StartGui::Workbench::loadStartPage()
         std::string escapedstr = Base::Tools::escapedUnicodeFromUtf8(utf8Title);
         QByteArray cmd;
         QTextStream str(&cmd);
-        str << "import WebGui,sys,Start" << Qt::endl;
-        str << "from StartPage import StartPage" << Qt::endl;
+        str << "import WebGui,sys,Start" << endl;
+        str << "from StartPage import StartPage" << endl;
         str << endl;
-        str << "class WebPage(object):" << Qt::endl;
-        str << "    def __init__(self):" << Qt::endl;
-        str << "        self.browser=WebGui.openBrowserWindow(u'" << escapedstr.c_str() << "')" << Qt::endl;
+        str << "class WebPage(object):" << endl;
+        str << "    def __init__(self):" << endl;
+        str << "        self.browser=WebGui.openBrowserWindow(u'" << escapedstr.c_str() << "')" << endl;
 #if defined(FC_OS_WIN32)
-        str << "        self.browser.setHtml(StartPage.handle(), App.getResourceDir() + 'Mod/Start/StartPage/')" << Qt::endl;
+        str << "        self.browser.setHtml(StartPage.handle(), App.getResourceDir() + 'Mod/Start/StartPage/')" << endl;
 #else
-        str << "        self.browser.setHtml(StartPage.handle(), 'file://' + App.getResourceDir() + 'Mod/Start/StartPage/')" << Qt::endl;
+        str << "        self.browser.setHtml(StartPage.handle(), 'file://' + App.getResourceDir() + 'Mod/Start/StartPage/')" << endl;
 #endif
-        str << "    def onChange(self, par, reason):" << Qt::endl;
-        str << "        if reason == 'RecentFiles':" << Qt::endl;
+        str << "    def onChange(self, par, reason):" << endl;
+        str << "        if reason == 'RecentFiles':" << endl;
 #if defined(FC_OS_WIN32)
-        str << "            self.browser.setHtml(StartPage.handle(), App.getResourceDir() + 'Mod/Start/StartPage/')" << Qt::endl;
+        str << "            self.browser.setHtml(StartPage.handle(), App.getResourceDir() + 'Mod/Start/StartPage/')" << endl;
 #else
-        str << "            self.browser.setHtml(StartPage.handle(), 'file://' + App.getResourceDir() + 'Mod/Start/StartPage/')" << Qt::endl;
+        str << "            self.browser.setHtml(StartPage.handle(), 'file://' + App.getResourceDir() + 'Mod/Start/StartPage/')" << endl;
 #endif
-        str << Qt::endl;
-        str << "class WebView(object):" << Qt::endl;
-        str << "    def __init__(self):" << Qt::endl;
-        str << "        self.pargrp = FreeCAD.ParamGet('User parameter:BaseApp/Preferences/RecentFiles')" << Qt::endl;
-        str << "        self.webPage = WebPage()" << Qt::endl;
-        str << "        self.pargrp.Attach(self.webPage)" << Qt::endl;
-        str << "    def __del__(self):" << Qt::endl;
-        str << "        self.pargrp.Detach(self.webPage)" << Qt::endl;
         str << endl;
-        str << "webView=WebView()" << Qt::endl;
-        str << "StartPage.checkPostOpenStartPage()" << Qt::endl;
+        str << "class WebView(object):" << endl;
+        str << "    def __init__(self):" << endl;
+        str << "        self.pargrp = FreeCAD.ParamGet('User parameter:BaseApp/Preferences/RecentFiles')" << endl;
+        str << "        self.webPage = WebPage()" << endl;
+        str << "        self.pargrp.Attach(self.webPage)" << endl;
+        str << "    def __del__(self):" << endl;
+        str << "        self.pargrp.Detach(self.webPage)" << endl;
+        str << endl;
+        str << "webView=WebView()" << endl;
+        str << "StartPage.checkPostOpenStartPage()" << endl;
 
         Base::Interpreter().runString(cmd);
         // Gui::Command::runCommand(Gui::Command::Gui, cmd);

--- a/src/Mod/Test/Gui/UnitTestImp.h
+++ b/src/Mod/Test/Gui/UnitTestImp.h
@@ -60,7 +60,7 @@ public:
     static bool hasInstance();
 
 protected:
-    UnitTestDialog(QWidget* parent = 0, Qt::WindowFlags f = 0);
+    UnitTestDialog(QWidget* parent = 0, Qt::WindowFlags f = Qt::WindowFlags());
     ~UnitTestDialog();
     void setProgressColor(const QColor& col);
 

--- a/src/Mod/Web/Gui/BrowserView.cpp
+++ b/src/Mod/Web/Gui/BrowserView.cpp
@@ -380,7 +380,7 @@ void WebView::triggerContextMenuAction(int id)
  *  name 'name'.
  */
 BrowserView::BrowserView(QWidget* parent)
-    : MDIView(0,parent,0),
+    : MDIView(0,parent,Qt::WindowFlags()),
       WindowParameter( "Browser" ),
       isLoading(false)
 {


### PR DESCRIPTION
That is needed on MacOS build as travis log is bigger than 50k lines
which breaks travis rules
And by the way deprecations are real
All file contains the same modification replace 0 to Qt::WindowFlags() when needed
as the class needs to be instantiated

Signed-off-by: vejmarie <jmverdun3@gmail.com>

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
