### PR TITLE
Conda doesn't export functions to subshells

### DIFF
--- a/build_unix_dev_conda.sh
+++ b/build_unix_dev_conda.sh
@@ -52,10 +52,12 @@ if [[ "${CONDA_DEFAULT_ENV}" =~ "${FCENV}" ]]; then
   echo "Already in env"
 elif [[ -z "${CONDA_DEFAULT_ENV}" ]]; then
   echo "Not in conda env... activating"
+  eval "$(conda shell.bash hook)"
   conda activate ${FCENV}
 else
   # Assume we are in some other env.
   echo "In ${CONDA_DEFAULT_ENV}, attempting switch to ${FCENV}"
+  eval "$(conda shell.bash hook)"
   conda deactivate
   conda activate ${FCENV}
 fi


### PR DESCRIPTION
build_unix_dev_conda.sh fails to activate the freecad_dev
environment. This is issue #7980 on the conda github. This has
one of the suggested work arounds added.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [x] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
