### PR TITLE
[PD] initialize hole dialog properly

### DIFF
--- a/src/Mod/PartDesign/App/FeatureHole.cpp
+++ b/src/Mod/PartDesign/App/FeatureHole.cpp
@@ -468,7 +468,7 @@ Hole::Hole()
     ThreadDirection.setEnums(ThreadDirectionEnums);
 
     ADD_PROPERTY_TYPE(HoleCutType, ((long)0), "Hole", App::Prop_None, "Head cut type");
-    HoleCutType.setEnums(HoleCutType_None_Enums);
+    HoleCutType.setEnums(HoleCutType_ISOmetric_Enums);
 
     ADD_PROPERTY_TYPE(HoleCutDiameter, (0.0), "Hole", App::Prop_None, "Head cut diameter");
 

--- a/src/Mod/PartDesign/Gui/TaskHoleParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskHoleParameters.cpp
@@ -76,6 +76,56 @@ TaskHoleParameters::TaskHoleParameters(ViewProviderHole *HoleView, QWidget *pare
     ui->ThreadType->addItem(tr("UTS fine profile"));
     ui->ThreadType->addItem(tr("UTS extra fine profile"));
 
+    // read values from the hole properties
+    PartDesign::Hole* pcHole = static_cast<PartDesign::Hole*>(vp->getObject());
+    ui->Threaded->setChecked(pcHole->Threaded.getValue());
+    ui->ModelActualThread->setChecked(pcHole->ModelActualThread.getValue());
+    ui->ThreadPitch->setValue(pcHole->ThreadPitch.getValue());
+    ui->ThreadAngle->setValue(pcHole->ThreadAngle.getValue());
+    ui->ThreadCutOffInner->setValue(pcHole->ThreadCutOffInner.getValue());
+    ui->ThreadCutOffOuter->setValue(pcHole->ThreadCutOffOuter.getValue());
+    ui->ThreadType->setCurrentIndex(pcHole->ThreadType.getValue());
+    ui->ThreadSize->clear();
+    const char** cursor = pcHole->ThreadSize.getEnums();
+    while (*cursor) {
+        ui->ThreadSize->addItem(tr(*cursor));
+        ++cursor;
+    }
+    ui->ThreadSize->setCurrentIndex(pcHole->ThreadSize.getValue());
+    ui->ThreadClass->clear();
+    cursor = pcHole->ThreadClass.getEnums();
+    while (*cursor) {
+        ui->ThreadClass->addItem(tr(*cursor));
+        ++cursor;
+    }
+    ui->ThreadClass->setCurrentIndex(pcHole->ThreadClass.getValue());
+    ui->ThreadFit->setCurrentIndex(pcHole->ThreadFit.getValue());
+    ui->Diameter->setValue(pcHole->Diameter.getValue());
+    if (pcHole->ThreadDirection.getValue() == 0L)
+        ui->directionRightHand->setChecked(true);
+    else
+        ui->directionLeftHand->setChecked(true);
+    ui->HoleCutType->clear();
+    cursor = pcHole->HoleCutType.getEnums();
+    while (*cursor) {
+        ui->HoleCutType->addItem(tr(*cursor));
+        ++cursor;
+    }
+    ui->HoleCutType->setCurrentIndex(pcHole->HoleCutType.getValue());
+    ui->HoleCutDiameter->setValue(pcHole->HoleCutDiameter.getValue());
+    ui->HoleCutDepth->setValue(pcHole->HoleCutDepth.getValue());
+    ui->HoleCutCountersinkAngle->setValue(pcHole->HoleCutCountersinkAngle.getValue());
+    ui->DepthType->setCurrentIndex(pcHole->DepthType.getValue());
+    ui->Depth->setValue(pcHole->Depth.getValue());
+    if (pcHole->DrillPoint.getValue() == 0L)
+        ui->drillPointFlat->setChecked(true);
+    else
+        ui->drillPointAngled->setChecked(true);
+    ui->DrillPointAngle->setValue(pcHole->DrillPointAngle.getValue());
+    ui->Tapered->setChecked(pcHole->ModelActualThread.getValue());
+    ui->TaperedAngle->setValue(pcHole->TaperedAngle.getValue());
+    ui->Reversed->setChecked(pcHole->Reversed.getValue());
+
     connect(ui->Threaded, SIGNAL(clicked(bool)), this, SLOT(threadedChanged()));
     connect(ui->ThreadType, SIGNAL(currentIndexChanged(int)), this, SLOT(threadTypeChanged(int)));
     connect(ui->ModelActualThread, SIGNAL(clicked(bool)), this, SLOT(modelActualThreadChanged()));
@@ -101,14 +151,6 @@ TaskHoleParameters::TaskHoleParameters(ViewProviderHole *HoleView, QWidget *pare
     connect(ui->Tapered, SIGNAL(clicked(bool)), this, SLOT(taperedChanged()));
     connect(ui->Reversed, SIGNAL(clicked(bool)), this, SLOT(reversedChanged()));
     connect(ui->TaperedAngle, SIGNAL(valueChanged(double)), this, SLOT(taperedAngleChanged(double)));
-
-    PartDesign::Hole* pcHole = static_cast<PartDesign::Hole*>(vp->getObject());
-
-    pcHole->updateProps();
-
-    ui->Reversed->blockSignals(true);
-    ui->Reversed->setChecked(pcHole->Reversed.getValue());
-    ui->Reversed->blockSignals(false);
 
     vp->show();
 
@@ -410,7 +452,7 @@ void TaskHoleParameters::changedObject(const App::Document&, const App::Property
 
         ui->ThreadSize->blockSignals(true);
         ui->ThreadSize->clear();
-        const char ** cursor = pcHole->ThreadSize.getEnums();
+        const char** cursor = pcHole->ThreadSize.getEnums();
         while (*cursor) {
             ui->ThreadSize->addItem(tr(*cursor));
             ++cursor;


### PR DESCRIPTION
as described in https://forum.freecadweb.org/viewtopic.php?f=3&t=50611, the task dialog should just read out the parameters on initialization and not invoke automatically change actions.

This PR also fixes a bug that opening a document with a cheesehead hole leads to an error about an invalid index. The reason is that we access the hole cut type before we set its enums. Thus initialize the cut type with all possible enums since, if necessary, the reduced enum set will be set later on parsing the file.