### PR TITLE
Part: change command name Part_MakeTube to Part_Tube

### DIFF
--- a/src/Mod/Part/BasicShapes/Shapes.py
+++ b/src/Mod/Part/BasicShapes/Shapes.py
@@ -79,14 +79,14 @@ if FreeCAD.GuiUp:
             return None
 
 
-    class _CommandMakeTube:
-        "Make tube command"
+    class CommandTube:
+        """Command for creating Tube."""
         def GetResources(self):
-            return {'MenuText': Qt.QT_TRANSLATE_NOOP("Part_MakeTube","Create tube"),
+            return {'MenuText': Qt.QT_TRANSLATE_NOOP("Part_Tube","Create tube"),
                     'Accel': "",
                     'CmdType': "AlterDoc:Alter3DView:AlterSelection",
-                    'Pixmap'  : ":/icons/Part_Tube.svg",
-                    'ToolTip': Qt.QT_TRANSLATE_NOOP("Part_MakeTube","Creates a tube")}
+                    'Pixmap': ":/icons/Part_Tube.svg",
+                    'ToolTip': Qt.QT_TRANSLATE_NOOP("Part_Tube","Creates a tube")}
         
         def Activated(self):
             FreeCAD.ActiveDocument.openTransaction("Create tube")
@@ -100,4 +100,4 @@ if FreeCAD.GuiUp:
             return not FreeCAD.ActiveDocument is None
 
 
-    FreeCADGui.addCommand('Part_MakeTube',_CommandMakeTube())
+    FreeCADGui.addCommand('Part_Tube', CommandTube())

--- a/src/Mod/Part/Gui/Workbench.cpp
+++ b/src/Mod/Part/Gui/Workbench.cpp
@@ -70,7 +70,7 @@ Gui::MenuItem* Workbench::setupMenuBar() const
           << "Part_Cone"
           << "Part_Torus"
           << "Separator"
-          << "Part_MakeTube";
+          << "Part_Tube";
 
     Gui::MenuItem* copy = new Gui::MenuItem;
     copy->setCommand("Create a copy");
@@ -183,7 +183,7 @@ Gui::ToolBarItem* Workbench::setupToolBars() const
             << "Part_Sphere"
             << "Part_Cone"
             << "Part_Torus"
-            << "Part_MakeTube"
+            << "Part_Tube"
             << "Part_Primitives"
             << "Part_Builder";
 


### PR DESCRIPTION
This follows the style of the other Part commands which don't have the word `Make` just the name of the noun, `Box`, `Cylinder`,
`Sphere`, etc.

---

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists