### PR TITLE
Arch: consider DraftText objects in the section plane for compatibility

### DIFF
--- a/src/Mod/Arch/ArchSectionPlane.py
+++ b/src/Mod/Arch/ArchSectionPlane.py
@@ -368,7 +368,7 @@ def getSVG(source,
     for o in objs:
         if Draft.getType(o) == "Space":
             spaces.append(o)
-        elif Draft.getType(o) in ["AngularDimension","LinearDimension","Annotation","Label","Text"]:
+        elif Draft.getType(o) in ["AngularDimension","LinearDimension","Annotation","Label","Text", "DraftText"]:
             if isOriented(o,cutplane):
                 drafts.append(o)
         elif o.isDerivedFrom("Part::Part2DObject"):

--- a/src/Mod/Draft/draftobjects/draft_annotation.py
+++ b/src/Mod/Draft/draftobjects/draft_annotation.py
@@ -131,13 +131,13 @@ class DraftAnnotation(object):
                 # the 'DraftText' type was changed to 'Text' type
                 if state["Type"] == "DraftText":
                     state["Type"] = "Text"
-                    _info = "migrate 'DraftText' type to 'Text'"
+                    _info = "migrated 'DraftText' type to 'Text'"
                     _wrn("v0.19, " + _tr(_info))
                 self.Type = state["Type"]
             else:
                 if state == "DraftText":
                     state = "Text"
-                    _info = "migrate 'DraftText' type to 'Text'"
+                    _info = "migrated 'DraftText' type to 'Text'"
                     _wrn("v0.19, " + _tr(_info))
                 self.Type = state
 


### PR DESCRIPTION
By looking at this recent commit 69fa329223, I realized the older `'DraftText'` objects are not handled by the Arch SectionPlane.

After the reorganization of the Draft Workbench, the `'DraftText'` objects are now of Proxy.Type `'Text'`. In the `DraftAnnotation` class the `__setstate__` method was defined to automatically migrate the Type.

The `Arch SectionPlane` only handles `'Text'` objects. If for some reason there is still an old `'DraftText'` object which has not been migrated to the new Type, it won't be found. This is corrected by adding `'DraftText'` to the list of objects to process.

---

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists