### PR TITLE
Path: Profile - Fix rotation error and remove FinalDepth limit

### DIFF
--- a/src/Mod/Path/PathScripts/PathProfile.py
+++ b/src/Mod/Path/PathScripts/PathProfile.py
@@ -570,9 +570,13 @@ class ObjectProfile(PathAreaOp.ObjectOp):
                     angle -= 180.0
 
             if rtn is True:
-                PathLog.debug(translate("Path", "Face appears misaligned after initial rotation."))
-                if obj.InverseAngle is False:
-                    if obj.AttemptInverseAngle is True:
+                PathLog.debug(translate("Path", "Face appears misaligned after initial rotation."))                    
+                if obj.AttemptInverseAngle is True:
+                    PathLog.debug(translate("Path", "Applying inverse angle automatically."))
+                    (clnBase, clnStock, angle) = self.applyInverseAngle(obj, clnBase, clnStock, axis, angle)
+                else:
+                    if obj.InverseAngle:
+                        PathLog.debug(translate("Path", "Applying inverse angle manually."))
                         (clnBase, clnStock, angle) = self.applyInverseAngle(obj, clnBase, clnStock, axis, angle)
                     else:
                         msg = translate("Path", "Consider toggling the 'InverseAngle' property and recomputing.")

--- a/src/Mod/Path/PathScripts/PathProfile.py
+++ b/src/Mod/Path/PathScripts/PathProfile.py
@@ -482,7 +482,7 @@ class ObjectProfile(PathAreaOp.ObjectOp):
                         for shape in faces:
                             finalDep = obj.FinalDepth.Value
                             custDepthparams = self.depthparams
-
+                            self._addDebugObject('Rotation_Indiv_Shp', shape)
                             if obj.Side == 'Inside':
                                 if finalDep < shape.BoundBox.ZMin:
                                     # Recalculate depthparams
@@ -557,13 +557,16 @@ class ObjectProfile(PathAreaOp.ObjectOp):
         (norm, surf) = self.getFaceNormAndSurf(shape)
         (rtn, angle, axis, praInfo) = self.faceRotationAnalysis(obj, norm, surf) # pylint: disable=unused-variable
         PathLog.debug("initial faceRotationAnalysis: {}".format(praInfo))
+
         if rtn is True:
+            # Rotational alignment is suggested from analysis
             (clnBase, angle, clnStock, tag) = self.applyRotationalAnalysis(obj, base, angle, axis, subCount)
             # Verify faces are correctly oriented - InverseAngle might be necessary
             faceIA = getattr(clnBase.Shape, sub)
             (norm, surf) = self.getFaceNormAndSurf(faceIA)
             (rtn, praAngle, praAxis, praInfo2) = self.faceRotationAnalysis(obj, norm, surf) # pylint: disable=unused-variable
             PathLog.debug("follow-up faceRotationAnalysis: {}".format(praInfo2))
+            PathLog.debug("praAngle: {}".format(praAngle))
 
             if abs(praAngle) == 180.0:
                 rtn = False

--- a/src/Mod/Path/PathScripts/PathProfile.py
+++ b/src/Mod/Path/PathScripts/PathProfile.py
@@ -483,11 +483,6 @@ class ObjectProfile(PathAreaOp.ObjectOp):
                             finalDep = obj.FinalDepth.Value
                             custDepthparams = self.depthparams
                             self._addDebugObject('Rotation_Indiv_Shp', shape)
-                            if obj.Side == 'Inside':
-                                if finalDep < shape.BoundBox.ZMin:
-                                    # Recalculate depthparams
-                                    finalDep = shape.BoundBox.ZMin
-                                    custDepthparams = self._customDepthParams(obj, strDep + 0.5, finalDep)
 
                             if self.expandProfile:
                                 shapeEnv = self._getExpandedProfileEnvelope(obj, shape, False, obj.StartDepth.Value, finalDep)


### PR DESCRIPTION
This PR fixes a rotational usage error discovered while troubleshooting recent Pocket_Shape errrors.  It also removed the FinalDepth limitation imposed that is requested to be removed in the forum at [Profiling below depth of face](https://forum.freecadweb.org/viewtopic.php?f=15&t=50341)
I added a comment and a couple debug items.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
