### PR TITLE
Path: Pocket_Shape - Improved fixes for FinalDepth and rotational issues

### DIFF
--- a/src/Mod/Path/PathScripts/PathAreaOp.py
+++ b/src/Mod/Path/PathScripts/PathAreaOp.py
@@ -383,10 +383,10 @@ class ObjectOp(PathOp.ObjectOp):
             if PathLog.getLevel(PathLog.thisModule()) == 4:
                 self.visualAxis()
 
-        # Set axial feed rates based upon horizontal feed rates
-        safeCircum = 2 * math.pi * obj.SafeHeight.Value
-        self.axialFeed = 360 / safeCircum * self.horizFeed # pylint: disable=attribute-defined-outside-init
-        self.axialRapid = 360 / safeCircum * self.horizRapid # pylint: disable=attribute-defined-outside-init
+            # Set axial feed rates based upon horizontal feed rates
+            safeCircum = 2 * math.pi * obj.SafeHeight.Value
+            self.axialFeed = 360 / safeCircum * self.horizFeed # pylint: disable=attribute-defined-outside-init
+            self.axialRapid = 360 / safeCircum * self.horizRapid # pylint: disable=attribute-defined-outside-init
 
         # Initiate depthparams and calculate operation heights for rotational operation
         self.depthparams = self._customDepthParams(obj, obj.StartDepth.Value, obj.FinalDepth.Value)

--- a/src/Mod/Path/PathScripts/PathAreaOp.py
+++ b/src/Mod/Path/PathScripts/PathAreaOp.py
@@ -322,14 +322,8 @@ class ObjectOp(PathOp.ObjectOp):
                 paths.extend(pp.Commands)
                 PathLog.debug('pp: {}, end vector: {}'.format(pp, end_vector))
 
-        self.endVector = end_vector # pylint: disable=attribute-defined-outside-init
-
+        self.endVector = end_vector
         simobj = None
-        if getsim:
-            areaParams['ToolRadius'] = self.radius - self.radius * .005
-            area.setParams(**areaParams)
-            sec = area.makeSections(mode=0, project=False, heights=heights)[-1].getShape()
-            simobj = sec.extrude(FreeCAD.Vector(0, 0, baseobject.BoundBox.ZMax))
 
         return paths, simobj
 

--- a/src/Mod/Path/PathScripts/PathPocketShape.py
+++ b/src/Mod/Path/PathScripts/PathPocketShape.py
@@ -350,7 +350,7 @@ class ObjectPocket(PathPocketBase.ObjectPocket):
                 subsList = o[1]
                 angle = o[2]
                 axis = o[3]
-                stock = o[4]
+                # stock = o[4]
 
                 for sub in subsList:
                     if 'Face' in sub:
@@ -539,10 +539,10 @@ class ObjectPocket(PathPocketBase.ObjectPocket):
                 return (False, 0, 0)
             else:
                 tmpWire = FreeCAD.ActiveDocument.addObject('Part::Feature', wireName).Shape = wr
-                tmpWire = FreeCAD.ActiveDocument.getObject(wireName)
-                tmpExt = FreeCAD.ActiveDocument.addObject('Part::Extrusion', extName)
+                tmpWireObj = FreeCAD.ActiveDocument.getObject(wireName)
+                tmpExtObj = FreeCAD.ActiveDocument.addObject('Part::Extrusion', extName)
                 tmpExt = FreeCAD.ActiveDocument.getObject(extName)
-                tmpExt.Base = tmpWire
+                tmpExt.Base = tmpWireObj
                 tmpExt.DirMode = "Normal"
                 tmpExt.DirLink = None
                 tmpExt.LengthFwd = 10.0
@@ -555,8 +555,8 @@ class ObjectPocket(PathPocketBase.ObjectPocket):
 
                 tmpExt.recompute()
                 tmpExt.purgeTouched()
-                tmpWire.purgeTouched()
-                return (True, tmpWire, tmpExt)
+                tmpWireObj.purgeTouched()
+                return (True, tmpWireObj, tmpExt)
 
         def roundValue(precision, val):
             # Convert VALxe-15 numbers to zero
@@ -705,7 +705,7 @@ class ObjectPocket(PathPocketBase.ObjectPocket):
                     if FreeCAD.ActiveDocument.getObject(fName):
                         FreeCAD.ActiveDocument.removeObject(fName)
 
-                    tmpFace = FreeCAD.ActiveDocument.addObject('Part::Feature', fName).Shape = mFF
+                    tmpFaceObj = FreeCAD.ActiveDocument.addObject('Part::Feature', fName).Shape = mFF
                     tmpFace = FreeCAD.ActiveDocument.getObject(fName)
                     tmpFace.purgeTouched()
 

--- a/src/Mod/Path/PathScripts/PathPocketShape.py
+++ b/src/Mod/Path/PathScripts/PathPocketShape.py
@@ -321,6 +321,7 @@ class ObjectPocket(PathPocketBase.ObjectPocket):
         PathLog.track()
         PathLog.debug("----- areaOpShapes() in PathPocketShape.py")
 
+        self.isDebug = True if PathLog.getLevel(PathLog.thisModule()) == 4 else False
         baseSubsTuples = []
         subCount = 0
         allTuples = []
@@ -426,8 +427,6 @@ class ObjectPocket(PathPocketBase.ObjectPocket):
                     msg += translate('Path', "\n<br>Bottom of pocket might be non-planar and/or not normal to spindle axis.")
                     msg += translate('Path', "\n<br>\n<br><i>3D pocket bottom is NOT available in this operation</i>.")
                     PathLog.warning(msg)
-                    # title = translate('Path', 'Depth Warning')
-                    # self.guiMessage(title, msg, False)
                 else:
                     PathLog.error(translate("Path", "Failed to create a planar face from edges in {}.".format(sub)))
 
@@ -614,15 +613,11 @@ class ObjectPocket(PathPocketBase.ObjectPocket):
                         if PathGeom.isRoughly(face.Area, 0):
                             msg = translate('PathPocket', 'Vertical faces do not form a loop - ignoring')
                             PathLog.error(msg)
-                            # title = translate("Path", "Face Selection Warning")
-                            # self.guiMessage(title, msg, True)
                         else:
                             face.translate(FreeCAD.Vector(0, 0, vFinDep - face.BoundBox.ZMin))
                             self.horiz.append(face)
                             msg = translate('Path', 'Verify final depth of pocket shaped by vertical faces.')
                             PathLog.warning(msg)
-                            # title = translate('Path', 'Depth Warning')
-                            # self.guiMessage(title, msg, False)
 
                 # add faces for extensions
                 self.exts = [] # pylint: disable=attribute-defined-outside-init
@@ -632,10 +627,6 @@ class ObjectPocket(PathPocketBase.ObjectPocket):
                         face = Part.Face(wire)
                         self.horiz.append(face)
                         self.exts.append(face)
-
-                # move all horizontal faces to FinalDepth
-                # for f in self.horiz:
-                #     f.translate(FreeCAD.Vector(0, 0, obj.FinalDepth.Value - f.BoundBox.ZMin))
 
                 # check all faces and see if they are touching/overlapping and combine those into a compound
                 self.horizontal = [] # pylint: disable=attribute-defined-outside-init
@@ -909,6 +900,13 @@ class ObjectPocket(PathPocketBase.ObjectPocket):
                 FreeCAD.ActiveDocument.removeObject(tmpNm)
 
         return (go, norm, surf)
+
+    # Method to add temporary debug object
+    def _addDebugObject(self, objName, objShape):
+        if self.isDebug:
+            O = FreeCAD.ActiveDocument.addObject('Part::Feature', 'debug_' + objName)
+            O.Shape = objShape
+            O.purgeTouched()
 
 
 def SetupProperties():


### PR DESCRIPTION
It seems a group of recent FinalDepth and rotational issues were sharing a common set of code errors.  This PR attempts to address them collectively.  I have tested models submitted in the following forum threads pertaining to Pocket_Shape and this PR correctly pockets each model presented with an error.

- [pocket path below selected plane.](https://forum.freecadweb.org/viewtopic.php?f=15&t=50493)
- [1.5mm stepdown issue](https://forum.freecadweb.org/viewtopic.php?f=15&t=50453)
- [Pocket path generated only on face depth if object is reversed or origin moved](https://forum.freecadweb.org/viewtopic.php?f=15&t=49513)
- [[RESOLVED] Path Pocket generating wrong code](https://forum.freecadweb.org/viewtopic.php?f=15&t=50263)
- [Ticket #4411 - Can only generate pocket once for this shape, then it fails.](https://forum.freecadweb.org/viewtopic.php?f=15&t=49035)
- [tool capabilities of 3d surface?](https://forum.freecadweb.org/viewtopic.php?f=15&t=50570) (rotationally indexed pocket)

This PR includes some light organization of the rotational analysis code in the `areaOpShapes()` method, shortening it and making it a little easier to follow.  This organization includes relocating the affected code into independent methods.
Additional organization would be beneficial to get the module into a better state of readability in general since it has undergone major changes due to rotational integration over the past year or so.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
