### PR TITLE
[Gui] Remove initial hardcoded styling of taskview and taskheader

### DIFF
--- a/src/Gui/QSint/actionpanel/actiongroup.cpp
+++ b/src/Gui/QSint/actionpanel/actiongroup.cpp
@@ -67,7 +67,6 @@ void ActionGroup::setScheme(ActionPanelScheme *pointer)
 {
   myScheme = pointer;
   myHeader->setScheme(pointer);
-  myGroup->setScheme(pointer);
   update();
 }
 

--- a/src/Gui/QSint/actionpanel/taskgroup_p.cpp
+++ b/src/Gui/QSint/actionpanel/taskgroup_p.cpp
@@ -23,25 +23,12 @@ TaskGroup::TaskGroup(QWidget *parent, bool hasHeader)
     setProperty("class", "content");
     setProperty("header", hasHeader ? "true" : "false");
 
-    setScheme(ActionPanelScheme::defaultScheme());
-
     QVBoxLayout *vbl = new QVBoxLayout();
     vbl->setMargin(4);
     vbl->setSpacing(0);
     setLayout(vbl);
 
     setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Maximum);
-}
-
-void TaskGroup::setScheme(ActionPanelScheme *scheme)
-{
-  if (scheme) {
-    myScheme = scheme;
-
-    setStyleSheet(myScheme->actionStyle);
-
-    update();
-  }
 }
 
 bool TaskGroup::addActionLabel(ActionLabel *label, bool addToLayout, bool addStretch)

--- a/src/Gui/QSint/actionpanel/taskgroup_p.h
+++ b/src/Gui/QSint/actionpanel/taskgroup_p.h
@@ -26,8 +26,6 @@ class TaskGroup : public QFrame
 public:
   TaskGroup(QWidget *parent, bool hasHeader = false);
 
-  void setScheme(ActionPanelScheme *scheme);
-
   inline QBoxLayout* groupLayout()
   {
     return (QBoxLayout*)layout();

--- a/src/Gui/QSint/actionpanel/taskheader_p.cpp
+++ b/src/Gui/QSint/actionpanel/taskheader_p.cpp
@@ -111,7 +111,7 @@ bool TaskHeader::eventFilter(QObject *obj, QEvent *event)
 }
 
 void TaskHeader::setScheme(ActionPanelScheme *scheme)
-{  
+{
   if (scheme) {
     myScheme = scheme;
     //myLabelScheme = &(scheme->headerLabelScheme);
@@ -125,7 +125,6 @@ void TaskHeader::setScheme(ActionPanelScheme *scheme)
 
     update();
   }
-  
 }
 
 void TaskHeader::paintEvent ( QPaintEvent * event )

--- a/src/Gui/QSint/actionpanel/taskheader_p.cpp
+++ b/src/Gui/QSint/actionpanel/taskheader_p.cpp
@@ -111,11 +111,10 @@ bool TaskHeader::eventFilter(QObject *obj, QEvent *event)
 }
 
 void TaskHeader::setScheme(ActionPanelScheme *scheme)
-{
+{  
   if (scheme) {
     myScheme = scheme;
     //myLabelScheme = &(scheme->headerLabelScheme);
-    setStyleSheet(myScheme->actionStyle);
 
     if (myExpandable) {
       //setCursor(myLabelScheme->cursorOver ? Qt::PointingHandCursor : cursor());
@@ -126,6 +125,7 @@ void TaskHeader::setScheme(ActionPanelScheme *scheme)
 
     update();
   }
+  
 }
 
 void TaskHeader::paintEvent ( QPaintEvent * event )


### PR DESCRIPTION
Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [X] Branch rebased on latest master `git pull --rebase upstream master`
- [X] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [X] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists 

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---

When the taskview is drawn for the first time without changing the workbench (like having PartDesign or Robot as your launch workbench) it would be drawn with hardcoded styling from the original Qsint stuff.
![Before](https://user-images.githubusercontent.com/39636046/94914768-f322e080-04ab-11eb-98f1-fef227c718f3.png)

The colors would be correct when switching between workbenches or re-applying a stylesheet.

Removing all calls of setStylesSheet() for the initial draw of taskheader and taskview makes it load with the correct styling:
![After](https://user-images.githubusercontent.com/39636046/94914917-37ae7c00-04ac-11eb-838b-f9bdfeaa21a4.png)

I was able to completely delete the TaskGroup::setScheme method, which only set the stylesheet, but the TaskHeader::setScheme method is still required as FreeCAD does not load with it removed, so only the setStyleSheet() call was removed here. I would have liked to remove all hardcoded initial stylings but right now i can't get it to work. 

I could not find an existing issue ticket for this.