### PR TITLE
Clean up unnecessary double namespace definition

### DIFF
--- a/src/Gui/FileDialog.cpp
+++ b/src/Gui/FileDialog.cpp
@@ -50,7 +50,6 @@
 
 using namespace Gui;
 
-namespace Gui {
 bool dontUseNativeDialog()
 {
 #if defined(USE_QT_FILEDIALOG)
@@ -63,7 +62,6 @@ bool dontUseNativeDialog()
           GetGroup("BaseApp")->GetGroup("Preferences")->GetGroup("Dialog");
     notNativeDialog = group->GetBool("DontUseNativeDialog", notNativeDialog);
     return notNativeDialog;
-}
 }
 
 /* TRANSLATOR Gui::FileDialog */


### PR DESCRIPTION
Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [X] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [X] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---

`namespace Gui {...}` was assigned right after `using namespace Gui` which seems unnecessary.