### PR TITLE
@arijeetbaruah moved 'Pick Radius' from 'Color' to '3D View' fixes #0004147

### DIFF
--- a/src/Gui/DlgSettings3DView.ui
+++ b/src/Gui/DlgSettings3DView.ui
@@ -310,7 +310,7 @@ but slower response to any scene changes.</string>
              <property name="toolTip">
                <string>
                  Area for picking elements in 3D view.
-                 Larger value eases to pick things, but can make small features impossible to select.
+Larger value eases to pick things, but can make small features impossible to select.
                </string>
              </property>
              <property name="inputMethodHints">

--- a/src/Gui/DlgSettings3DView.ui
+++ b/src/Gui/DlgSettings3DView.ui
@@ -292,14 +292,58 @@ but slower response to any scene changes.</string>
           </property>
          </widget>
         </item>
-        <item row="4" column="0">
+         <item row="4" column="0">
+           <widget class="QLabel" name="spinPickRadiusLabel">
+             <property name="text">
+               <string>Pick radius (px):</string>
+             </property>
+           </widget>
+         </item>
+         <item row="4" column="4">
+           <widget class="Gui::PrefDoubleSpinBox" name="spinPickRadius">
+             <property name="minimumSize">
+               <size>
+                 <width>120</width>
+                 <height>0</height>
+               </size>
+             </property>
+             <property name="toolTip">
+               <string>
+                 Area for picking elements in 3D view.
+                 Larger value eases to pick things, but can make small features impossible to select.
+               </string>
+             </property>
+             <property name="inputMethodHints">
+               <set>Qt::ImhPreferNumbers</set>
+             </property>
+             <property name="decimals">
+               <number>1</number>
+             </property>
+             <property name="minimum">
+               <double>0.500000000000000</double>
+             </property>
+             <property name="maximum">
+               <double>200.000000000000000</double>
+             </property>
+             <property name="value">
+               <double>5.000000000000000</double>
+             </property>
+             <property name="prefEntry" stdset="0">
+               <cstring>PickRadius</cstring>
+             </property>
+             <property name="prefPath" stdset="0">
+               <cstring>View</cstring>
+             </property>
+           </widget>
+         </item>
+        <item row="5" column="0">
          <widget class="QLabel" name="textLabel1">
           <property name="text">
            <string>Eye to eye distance for stereo modes</string>
           </property>
          </widget>
         </item>
-        <item row="4" column="4">
+        <item row="5" column="4">
          <widget class="Gui::PrefDoubleSpinBox" name="FloatSpinBox_EyeDistance">
           <property name="minimumSize">
            <size>
@@ -335,7 +379,7 @@ bounding box size of the 3D object that is currently displayed. </string>
           </property>
          </widget>
         </item>
-        <item row="5" column="0">
+        <item row="6" column="0">
          <widget class="Gui::PrefCheckBox" name="checkBoxBacklight">
           <property name="toolTip">
            <string>Backlight is enabled with the defined color</string>
@@ -351,7 +395,7 @@ bounding box size of the 3D object that is currently displayed. </string>
           </property>
          </widget>
         </item>
-        <item row="5" column="1">
+        <item row="6" column="1">
          <widget class="Gui::PrefColorButton" name="backlightColor">
           <property name="enabled">
            <bool>false</bool>
@@ -374,7 +418,7 @@ bounding box size of the 3D object that is currently displayed. </string>
           </property>
          </widget>
         </item>
-        <item row="5" column="2">
+        <item row="6" column="2">
          <spacer name="horizontalSpacer">
           <property name="orientation">
            <enum>Qt::Horizontal</enum>
@@ -387,7 +431,7 @@ bounding box size of the 3D object that is currently displayed. </string>
           </property>
          </spacer>
         </item>
-        <item row="5" column="3">
+        <item row="6" column="3">
          <widget class="QLabel" name="backlightLabel">
           <property name="enabled">
            <bool>false</bool>
@@ -403,7 +447,7 @@ bounding box size of the 3D object that is currently displayed. </string>
           </property>
          </widget>
         </item>
-        <item row="5" column="4">
+        <item row="6" column="4">
          <widget class="Gui::PrefSlider" name="sliderIntensity">
           <property name="enabled">
            <bool>false</bool>

--- a/src/Gui/DlgSettings3DView.ui
+++ b/src/Gui/DlgSettings3DView.ui
@@ -308,8 +308,7 @@ but slower response to any scene changes.</string>
                </size>
              </property>
              <property name="toolTip">
-               <string>
-                 Area for picking elements in 3D view.
+               <string>Area for picking elements in 3D view.
 Larger value eases to pick things, but can make small features impossible to select.
                </string>
              </property>

--- a/src/Gui/DlgSettings3DViewImp.cpp
+++ b/src/Gui/DlgSettings3DViewImp.cpp
@@ -92,6 +92,7 @@ void DlgSettings3DViewImp::saveSettings()
     ui->CheckBox_ShowAxisCross->onSave();
     ui->CheckBox_WbByTab->onSave();
     ui->CheckBox_ShowFPS->onSave();
+    ui->spinPickRadius->onSave();
     ui->CheckBox_useVBO->onSave();
     ui->FloatSpinBox_EyeDistance->onSave();
     ui->checkBoxBacklight->onSave();
@@ -107,6 +108,7 @@ void DlgSettings3DViewImp::loadSettings()
     ui->CheckBox_ShowAxisCross->onRestore();
     ui->CheckBox_WbByTab->onRestore();
     ui->CheckBox_ShowFPS->onRestore();
+    ui->spinPickRadius->onRestore();
     ui->CheckBox_useVBO->onRestore();
     ui->FloatSpinBox_EyeDistance->onRestore();
     ui->checkBoxBacklight->onRestore();

--- a/src/Gui/DlgSettingsViewColor.cpp
+++ b/src/Gui/DlgSettingsViewColor.cpp
@@ -68,7 +68,7 @@ void DlgSettingsViewColor::saveSettings()
     ui->checkBoxSelection->onSave();
     ui->HighlightColor->onSave();
     ui->SelectionColor->onSave();
-    ui->spinPickRadius->onSave();
+    //ui->spinPickRadius->onSave();
     ui->TreeEditColor->onSave();
     ui->TreeActiveColor->onSave();
 }
@@ -86,7 +86,7 @@ void DlgSettingsViewColor::loadSettings()
     ui->checkBoxSelection->onRestore();
     ui->HighlightColor->onRestore();
     ui->SelectionColor->onRestore();
-    ui->spinPickRadius->onRestore();
+    //ui->spinPickRadius->onRestore();
     ui->TreeEditColor->onRestore();
     ui->TreeActiveColor->onRestore();
 }

--- a/src/Gui/DlgSettingsViewColor.cpp
+++ b/src/Gui/DlgSettingsViewColor.cpp
@@ -68,7 +68,6 @@ void DlgSettingsViewColor::saveSettings()
     ui->checkBoxSelection->onSave();
     ui->HighlightColor->onSave();
     ui->SelectionColor->onSave();
-    //ui->spinPickRadius->onSave();
     ui->TreeEditColor->onSave();
     ui->TreeActiveColor->onSave();
 }
@@ -86,7 +85,6 @@ void DlgSettingsViewColor::loadSettings()
     ui->checkBoxSelection->onRestore();
     ui->HighlightColor->onRestore();
     ui->SelectionColor->onRestore();
-    //ui->spinPickRadius->onRestore();
     ui->TreeEditColor->onRestore();
     ui->TreeActiveColor->onRestore();
 }

--- a/src/Gui/DlgSettingsViewColor.ui
+++ b/src/Gui/DlgSettingsViewColor.ui
@@ -176,42 +176,6 @@
           </property>
          </widget>
         </item>
-        <item row="2" column="0">
-         <widget class="QLabel" name="label">
-          <property name="text">
-           <string>Pick radius (px):</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="1">
-         <widget class="Gui::PrefDoubleSpinBox" name="spinPickRadius">
-          <property name="toolTip">
-           <string>Area for picking elements in 3D view.
-Larger value eases to pick things, but can make small features impossible to select.</string>
-          </property>
-          <property name="inputMethodHints">
-           <set>Qt::ImhPreferNumbers</set>
-          </property>
-          <property name="decimals">
-           <number>1</number>
-          </property>
-          <property name="minimum">
-           <double>0.500000000000000</double>
-          </property>
-          <property name="maximum">
-           <double>200.000000000000000</double>
-          </property>
-          <property name="value">
-           <double>5.000000000000000</double>
-          </property>
-          <property name="prefEntry" stdset="0">
-           <cstring>PickRadius</cstring>
-          </property>
-          <property name="prefPath" stdset="0">
-           <cstring>View</cstring>
-          </property>
-         </widget>
-        </item>
        </layout>
       </item>
      </layout>


### PR DESCRIPTION
Screencast showing where Pick Radius is located in the m Preferences https://i.imgur.com/N7MFELX.mp4

This is not a 'Color' issue. It's a mouse-related issue.

Case arguing for change:
https://forum.freecadweb.org/viewtopic.php?f=8&t=39650&p=336939#p336932
https://forum.freecadweb.org/viewtopic.php?f=3&t=39161

Forum thread to poll the community for the desired location => https://forum.freecadweb.org/viewtopic.php?f=8&t=39655