### PR TITLE
Fix various typos [skip-ci]

### DIFF
--- a/src/Base/ParameterPy.cpp
+++ b/src/Base/ParameterPy.cpp
@@ -272,9 +272,9 @@ Py::Object ParameterGrpPy::getGroup(const Py::Tuple& args)
     // get the Handle of the wanted group
     Base::Reference<ParameterGrp> handle = _cParamGrp->GetGroup(pstr);
     if (handle.isValid()) {
-        // crate a python wrapper class
+        // create a python wrapper class
         ParameterGrpPy *pcParamGrp = new ParameterGrpPy(handle);
-        // increment the reff count
+        // increment the ref count
         return Py::asObject(pcParamGrp);
     }
     else {

--- a/src/Gui/Stylesheets/Behave-dark.qss
+++ b/src/Gui/Stylesheets/Behave-dark.qss
@@ -62,7 +62,7 @@ If you would like to change the overall look/style of the theme, just find and r
 BEHAVE DARK APPROVED COLORS
 ============================================================================================================
 
-2C333D //dark blue background (Ligher background if you ask me)
+2C333D //dark blue background (Lighter background if you ask me)
 909FB5 //light grey caret
 D2D8E1 //light grey foreground
 434D5B //darker blue "invisibles" or "selection"

--- a/src/Mod/Part/App/GeomPlate/BuildPlateSurfacePy.xml
+++ b/src/Mod/Part/App/GeomPlate/BuildPlateSurfacePy.xml
@@ -95,17 +95,17 @@
     </Methode>
     <Methode Name="G0Error" Const="true">
       <Documentation>
-        <UserDocu>Returns the max distance betwen the result and the constraints</UserDocu>
+        <UserDocu>Returns the max distance between the result and the constraints</UserDocu>
       </Documentation>
     </Methode>
     <Methode Name="G1Error" Const="true">
       <Documentation>
-        <UserDocu>Returns the max angle betwen the result and the constraints</UserDocu>
+        <UserDocu>Returns the max angle between the result and the constraints</UserDocu>
       </Documentation>
     </Methode>
     <Methode Name="G2Error" Const="true">
       <Documentation>
-        <UserDocu>Returns the max difference of curvature betwen the result and the constraints</UserDocu>
+        <UserDocu>Returns the max difference of curvature between the result and the constraints</UserDocu>
       </Documentation>
     </Methode>
   </PythonExport>

--- a/src/Mod/Path/App/VoronoiEdgePy.xml
+++ b/src/Mod/Path/App/VoronoiEdgePy.xml
@@ -42,25 +42,25 @@
         </Attribute>
         <Attribute Name="Next" ReadOnly="true">
             <Documentation>
-                <UserDocu>CCW next edge whithin voronoi cell</UserDocu>
+                <UserDocu>CCW next edge within voronoi cell</UserDocu>
             </Documentation>
             <Parameter Name="Next" Type="Object"/>
         </Attribute>
         <Attribute Name="Prev" ReadOnly="true">
             <Documentation>
-                <UserDocu>CCW previous edge whithin voronoi cell</UserDocu>
+                <UserDocu>CCW previous edge within voronoi cell</UserDocu>
             </Documentation>
             <Parameter Name="Prev" Type="Object"/>
         </Attribute>
         <Attribute Name="RotNext" ReadOnly="true">
             <Documentation>
-                <UserDocu>Rotated CCW next edge whithin voronoi cell</UserDocu>
+                <UserDocu>Rotated CCW next edge within voronoi cell</UserDocu>
             </Documentation>
             <Parameter Name="RotNext" Type="Object"/>
         </Attribute>
         <Attribute Name="RotPrev" ReadOnly="true">
             <Documentation>
-                <UserDocu>Rotated CCW previous edge whithin voronoi cell</UserDocu>
+                <UserDocu>Rotated CCW previous edge within voronoi cell</UserDocu>
             </Documentation>
             <Parameter Name="RotPrev" Type="Object"/>
         </Attribute>

--- a/src/Mod/Path/App/VoronoiEdgePyImp.cpp
+++ b/src/Mod/Path/App/VoronoiEdgePyImp.cpp
@@ -359,7 +359,7 @@ PyObject* VoronoiEdgePy::toGeom(PyObject *args)
       // parabolic curve, which is always formed by a point and an edge
       Voronoi::point_type   point   = e->ptr->cell()->contains_point() ? e->dia->retrievePoint(e->ptr->cell())  : e->dia->retrievePoint(e->ptr->twin()->cell());
       Voronoi::segment_type segment = e->ptr->cell()->contains_point() ? e->dia->retrieveSegment(e->ptr->twin()->cell()) : e->dia->retrieveSegment(e->ptr->cell());
-      // the location is the mid point betwenn the normal on the segment through point
+      // the location is the mid point between the normal on the segment through point
       // this is only the mid point of the segment if the parabola is symmetric
       Voronoi::point_type loc;
       {

--- a/src/Mod/Path/PathScripts/PathVcarve.py
+++ b/src/Mod/Path/PathScripts/PathVcarve.py
@@ -54,7 +54,7 @@ else:
     PathLog.setLevel(PathLog.Level.INFO, PathLog.thisModule())
 
 
-# Qt tanslation handling
+# Qt translation handling
 def translate(context, text, disambig=None):
     return QtCore.QCoreApplication.translate(context, text, disambig)
 

--- a/src/Mod/Surface/Gui/Resources/icons/Surface_Sections.svg
+++ b/src/Mod/Surface/Gui/Resources/icons/Surface_Sections.svg
@@ -2789,7 +2789,7 @@
             <rdf:li>edges</rdf:li>
           </rdf:Bag>
         </dc:subject>
-        <dc:description>A purple surface made with several highlighted red edges whic represent transversal sections of the surface.</dc:description>
+        <dc:description>A purple surface made with several highlighted red edges which represent transversal sections of the surface.</dc:description>
       </cc:Work>
       <cc:License
          rdf:about="http://creativecommons.org/licenses/by-sa/4.0/">

--- a/vagrant/etc/matplotlibrc
+++ b/vagrant/etc/matplotlibrc
@@ -406,7 +406,7 @@ backend      : TkAgg
 #savefig.format      : png      # png, ps, pdf, svg
 #savefig.bbox        : standard # 'tight' or 'standard'.
                                 # 'tight' is incompatible with pipe-based animation
-                                # backends but will workd with temporary file based ones:
+                                # backends but will work with temporary file based ones:
                                 # e.g. setting animation.writer to ffmpeg will not work,
                                 # use ffmpeg_file instead
 #savefig.pad_inches  : 0.1      # Padding to be used when bbox is set to 'tight'


### PR DESCRIPTION
Found via `codespell v2.0.dev0`  
```
codespell -q 3 -L aci,ake,aline,alle,alledges,alocation,als,ang,anid,ba,beginn,behaviour,bloaded,byteorder,calculater,cancelled,cancelling,cas,cascade,centimetre,childs,colour,colours,commen,connexion,currenty,dof,doubleclick,dum,eiter,elemente,ende,feld,finde,findf,freez,hist,iff,indicies,initialisation,initialise,initialised,initialises,initialisiert,ist,kilometre,lod,mantatory,methode,metres,millimetre,modell,nd,noe,normale,normaly,nto,numer,oder,orgin,orginx,orginy,ot,pard,pres,programm,que,recurrance,rougly,seperator,serie,sinc,strack,substraction,te,thist,thru,tread,uint,unter,vertexes,wallthickness,whitespaces -S ./.git,*.po,*.ts,./ChangeLog.txt,./src/3rdParty,./src/Mod/Assembly/App/opendcm,./src/CXX,./src/zipios++,./src/Base/swig*,./src/Mod/Robot/App/kdl_cp,./src/Mod/Import/App/SCL,./src/WindowsInstaller,./src/Doc/FreeCAD.uml
```