### PR TITLE
Draft: fix mismatch of arguments in get_dxf function

### DIFF
--- a/src/Mod/Draft/draftfunctions/dxf.py
+++ b/src/Mod/Draft/draftfunctions/dxf.py
@@ -134,10 +134,10 @@ def get_dxf(obj, direction=None):
 
 
 def getDXF(obj,
-           projection=None):
+           direction=None):
     """Return DXF string of the object. DEPRECATED. Use 'get_dxf'."""
     utils.use_instead("get_dxf")
     return get_dxf(obj,
-                   projection=projection)
+                   direction=direction)
 
 ## @}


### PR DESCRIPTION
The name of the argument in the old function doesn't match the new function which would cause an error. However, it's hard to trigger this problem because this code is essentially not used any more.

Found by LGTM: [Draft WB LGTM Analysis](https://forum.freecadweb.org/viewtopic.php?f=23&t=50946)

---

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists