### PR TITLE
Show: add argument to NotAContainerError class constructor

### DIFF
--- a/src/Mod/Show/Containers.py
+++ b/src/Mod/Show/Containers.py
@@ -255,7 +255,7 @@ def VisGroupChain(feat):
 class ContainerError(RuntimeError):
     pass
 class NotAContainerError(ContainerError):
-    def __init__(self):
-        ContainerError.__init__(self, u"{obj} is not recognized as container".format(obj.Name))
+    def __init__(self, name="None"):
+        ContainerError.__init__(self, "'{}' is not recognized as container".format(name))
 class ContainerTreeError(ContainerError):
     pass


### PR DESCRIPTION
The class `NotAContainerError` is used as an exception. Where it is used it is initialized with an argument, but the definition didn't accept one; now we accept an argument in the constructor.

Reported by LGTM: [Mod/Show/Containers.py LGTM alert](https://forum.freecadweb.org/viewtopic.php?f=8&t=50961)

---

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
