### PR TITLE
[PartDesign Hole] added iso 4762

### DIFF
--- a/src/Mod/PartDesign/App/FeatureHole.h
+++ b/src/Mod/PartDesign/App/FeatureHole.h
@@ -129,6 +129,33 @@ private:
     static const char* ThreadSize_UNEF_Enums[];
     static const char* ThreadClass_UNEF_Enums[];
 
+    /* Counter-xxx */
+    struct CounterDimension {
+        double thread;
+        double diameter;
+        double depth;
+    };
+
+    class CounterDimensionBase {
+        const CounterDimension *data;
+    public:
+        CounterDimensionBase(const CounterDimension *d) : data{ d } { }
+        const CounterDimension &get(double t) {
+            const CounterDimension *i;
+            for(i = data; i->thread; ++i) {
+                if (t == i->thread) break;
+            }
+            return *i;
+        }
+    };
+
+    static const CounterDimension iso4762_data[];
+    CounterDimensionBase iso4762;
+    static const CounterDimension iso4762_7089_data[];
+    CounterDimensionBase iso4762_7089;
+    static const CounterDimension din7984_data[];
+    CounterDimensionBase din7984;
+
     void updateHoleCutParams();
     void updateDiameterParam();
 };


### PR DESCRIPTION
added added counterbore definitions.

added conterbores for metric coarse.
    · ISO 4762
    · ISO 4762 with ISO 7089 washers
    · DIN 7984

https://forum.freecadweb.org/viewtopic.php?f=13&t=50978&p=437974

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
