### PR TITLE
Part: activate Part_ColorPerFace in the menu and toolbar

### DIFF
--- a/src/Mod/Part/Gui/Command.cpp
+++ b/src/Mod/Part/Gui/Command.cpp
@@ -2158,9 +2158,18 @@ CmdColorPerFace::CmdColorPerFace()
     sAppModule    = "Part";
     sGroup        = QT_TR_NOOP("Part");
     sMenuText     = QT_TR_NOOP("Color per face");
-    sToolTipText  = QT_TR_NOOP("Set color per face");
+    sToolTipText  = QT_TR_NOOP("Set the color of each individual face "
+                               "of the selected object.\n"
+                               "\n"
+                               "At the moment, this command only works "
+                               "with objects which have not reimplemented\n"
+                               "their 'edit modes'; this means, it works "
+                               "with Part and PartDesign created objects,\n"
+                               "but not with most Draft or Arch objects. "
+                               "See issues #0477 and #1954 in the tracker.");
     sStatusTip    = sToolTipText;
     sWhatsThis    = "Part_ColorPerFace";
+    sPixmap       = "Part_ColorFace";
 }
 
 void CmdColorPerFace::activated(int iMsg)

--- a/src/Mod/Part/Gui/Resources/Part.qrc
+++ b/src/Mod/Part/Gui/Resources/Part.qrc
@@ -62,6 +62,7 @@
     <qresource>
         <file>icons/tools/Part_Attachment.svg</file>
         <file>icons/tools/Part_Chamfer.svg</file>
+        <file>icons/tools/Part_ColorFace.svg</file>
         <file>icons/tools/Part_Element_Copy.svg</file>
         <file>icons/tools/Part_Extrude.svg</file>
         <file>icons/tools/Part_Fillet.svg</file>

--- a/src/Mod/Part/Gui/Resources/icons/tools/Part_ColorFace.svg
+++ b/src/Mod/Part/Gui/Resources/icons/tools/Part_ColorFace.svg
@@ -1,0 +1,249 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   version="1.1"
+   id="svg2980"
+   height="64px"
+   width="64px">
+  <title
+     id="title1193">Part_ColorFace</title>
+  <defs
+     id="defs2982">
+    <linearGradient
+       id="linearGradient3794">
+      <stop
+         id="stop3796"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         id="stop3798"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3864">
+      <stop
+         style="stop-color:#71b2f8;stop-opacity:1;"
+         offset="0"
+         id="stop3866" />
+      <stop
+         style="stop-color:#002795;stop-opacity:1;"
+         offset="1"
+         id="stop3868" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="21.31134"
+       x2="17.328547"
+       y1="55.717518"
+       x1="22.116516"
+       id="linearGradient3773"
+       xlink:href="#linearGradient3767"
+       gradientTransform="translate(0,-4)" />
+    <linearGradient
+       id="linearGradient3767">
+      <stop
+         id="stop3769"
+         offset="0"
+         style="stop-color:#3465a4;stop-opacity:1" />
+      <stop
+         id="stop3771"
+         offset="1"
+         style="stop-color:#729fcf;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="21.83742"
+       x2="47.502235"
+       y1="51.179787"
+       x1="53.896763"
+       id="linearGradient3783"
+       xlink:href="#linearGradient3777"
+       gradientTransform="translate(0,-4)" />
+    <linearGradient
+       id="linearGradient3777">
+      <stop
+         id="stop3779"
+         offset="0"
+         style="stop-color:#204a87;stop-opacity:1" />
+      <stop
+         id="stop3781"
+         offset="1"
+         style="stop-color:#3465a4;stop-opacity:1" />
+    </linearGradient>
+    <radialGradient
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.93348213,-2.2905276e-8,0,0.28687573,0.06651751,32.090592)"
+       r="41"
+       fy="45"
+       fx="1"
+       cy="45"
+       cx="1"
+       id="radialGradient3800"
+       xlink:href="#linearGradient3794" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="21.83742"
+       x2="47.502235"
+       y1="51.179787"
+       x1="53.896763"
+       id="linearGradient3783-3"
+       xlink:href="#linearGradient3777-6"
+       gradientTransform="translate(72,0)" />
+    <linearGradient
+       id="linearGradient3777-6">
+      <stop
+         id="stop3779-7"
+         offset="0"
+         style="stop-color:#c4a000;stop-opacity:1" />
+      <stop
+         id="stop3781-5"
+         offset="1"
+         style="stop-color:#edd400;stop-opacity:1" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#linearGradient3377"
+       id="radialGradient3692"
+       cx="45.883327"
+       cy="28.869568"
+       fx="45.883327"
+       fy="28.869568"
+       r="19.467436"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-0.23443224,0.23443198)" />
+    <linearGradient
+       id="linearGradient3377">
+      <stop
+         id="stop3379"
+         offset="0"
+         style="stop-color:#faff2b;stop-opacity:1;" />
+      <stop
+         id="stop3381"
+         offset="1"
+         style="stop-color:#ffaa00;stop-opacity:1;" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#linearGradient3377"
+       id="radialGradient6412"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.67067175,0,0,0.64145918,-63.380792,0.83845403)"
+       cx="45.883327"
+       cy="28.869568"
+       fx="45.883327"
+       fy="28.869568"
+       r="19.467436" />
+    <linearGradient
+       id="linearGradient3036">
+      <stop
+         id="stop3038"
+         offset="0"
+         style="stop-color:#ef2929;stop-opacity:1" />
+      <stop
+         id="stop3040"
+         offset="1"
+         style="stop-color:#a40000;stop-opacity:1" />
+    </linearGradient>
+  </defs>
+  <metadata
+     id="metadata2985">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>Part_ColorFace</dc:title>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>[vocx]</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:date>2020-10-05</dc:date>
+        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>FreeCAD</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:identifier>FreeCAD/src/Mod/Part/Gui/Resources/icons/Part_ColorFace.svg</dc:identifier>
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>FreeCAD LGPL2+</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <cc:license
+           rdf:resource="http://creativecommons.org/licenses/by-sa/4.0/">https://www.gnu.org/copyleft/lesser.html</cc:license>
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title>[agryson] Alexander Gryson, [wmayer]</dc:title>
+          </cc:Agent>
+        </dc:contributor>
+        <dc:description>Based on the 'Tree_Part' icon, the tree faces of the cube are each of a different color, one blue, one yellow, and the other red.</dc:description>
+        <dc:subject>
+          <rdf:Bag>
+            <rdf:li>Cube</rdf:li>
+            <rdf:li>colors</rdf:li>
+            <rdf:li>blue</rdf:li>
+            <rdf:li>yellow</rdf:li>
+            <rdf:li>red</rdf:li>
+          </rdf:Bag>
+        </dc:subject>
+      </cc:Work>
+      <cc:License
+         rdf:about="http://creativecommons.org/licenses/by-sa/4.0/">
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Reproduction" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Distribution" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Notice" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Attribution" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#DerivativeWorks" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#ShareAlike" />
+      </cc:License>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1">
+    <path
+       id="path2993"
+       d="M 3,13 37,19 61,11 31,7 z"
+       style="fill:#ef2929;stroke:#0b1521;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1;fill-opacity:1" />
+    <path
+       id="path2995"
+       d="M 61,11 61,47 37,57 37,19 z"
+       style="fill:url(#linearGradient3783);fill-opacity:1;stroke:#0b1521;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1" />
+    <path
+       style="fill:url(#linearGradient3773);fill-opacity:1;fill-rule:evenodd;stroke:#0b1521;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       d="M 3,13 37,19 37,57 3,51 z"
+       id="path3825" />
+    <path
+       id="path3765"
+       d="m 5,15.42772 0.00867,33.919116 30.008671,5.268799 -0.0087,-33.933614 z"
+       style="fill:none;stroke:#729fcf;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       id="path3775"
+       d="m 39.01243,20.433833 -0.01226,33.535301 20.001105,-8.300993 3.6e-4,-31.867363 z"
+       style="fill:none;stroke:#3465a4;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <g
+       transform="translate(-71.997618,-3.9896317)"
+       id="g5368">
+      <path
+         style="fill:url(#linearGradient3783-3);fill-opacity:1;stroke:#302b00;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1"
+         d="m 133,15 0,36 -24,10 0,-38 z"
+         id="path2995-3" />
+      <path
+         style="fill:none;stroke:#edd400;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 111.01243,24.433833 -0.0123,33.535301 20.0011,-8.300993 3.6e-4,-31.867363 z"
+         id="path3775-5" />
+    </g>
+  </g>
+</svg>

--- a/src/Mod/Part/Gui/Workbench.cpp
+++ b/src/Mod/Part/Gui/Workbench.cpp
@@ -158,7 +158,16 @@ Gui::MenuItem* Workbench::setupMenuBar() const
              << "Part_Measure_Toggle_Delta";
 
     // leave this for 0.14 until #0000477 is fixed
-#if 0
+
+    // According to #0477 and #1954
+    // `Part_ColorPerFace` does not work with objects that reimplement
+    // their edit modes, meaning it may work with Part and PartDesign
+    // created objects but not with Draft and Arch objects.
+    // However, it does not make much sense to keep it hidden;
+    // having it available in the interface will allow more people
+    // to use it, and maybe somebody will be able to investigate
+    // and fix the issue.
+#if 1
     Gui::MenuItem* view = root->findItem("&View");
     if (view) {
         Gui::MenuItem* appr = view->findItem("Std_RandomColor");
@@ -199,7 +208,8 @@ Gui::ToolBarItem* Workbench::setupToolBars() const
           << "Part_Sweep"
           << "Part_CompOffset"
           << "Part_Thickness"
-          << "Part_ProjectionOnSurface";
+          << "Part_ProjectionOnSurface"
+          << "Part_ColorPerFace";  // See issues #0477 and #1954 in the tracker
 
     Gui::ToolBarItem* boolop = new Gui::ToolBarItem(root);
     boolop->setCommand("Boolean");


### PR DESCRIPTION
According to the source this command was deactivated until issue [#0477](https://tracker.freecadweb.org/view.php?id=477) and hence [#1954](https://tracker.freecadweb.org/view.php?id=1954) could be solved. However, since those issues haven't been addressed the command has remained hidden for a long time.

This command does not work with objects that reimplement their edit modes, meaning that it may work with Part and PartDesign created objects but not with Draft and Arch objects.

The command is added to the standard `View` menu, and to the `Part tools` toolbar so that it is no longer hidden. The limitations of the command can be described in the documentation, and then somebody else can help solve the problem with the edit modes.

A new icon for the command is also provided.

See [Artwork_Part](https://wiki.freecadweb.org/Artwork_Part).

---

The wiki page currently is [Part_FaceColors](https://wiki.freecadweb.org/Part_FaceColors). This describes a command that is launched from the context menu, right click, but if the command is made accessible from the main menu and toolbar, then it can be referenced properly in the documentation. The wiki page would have to be renamed as well to `Part_ColorPerFace`, or the command can be renamed if necessary to match the current page name.

---

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists