### PR TITLE
PATH: 32bit build bugfix - Using python type conversion to return voronoi element color

### DIFF
--- a/src/Mod/Path/App/VoronoiCellPyImp.cpp
+++ b/src/Mod/Path/App/VoronoiCellPyImp.cpp
@@ -123,7 +123,7 @@ Py::Long VoronoiCellPy::getColor(void) const {
   VoronoiCell *c = getVoronoiCellPtr();
   if (c->isBound()) {
     Voronoi::color_type color = c->ptr->color() & Voronoi::ColorMask;
-    return Py::Long(color);
+    return Py::Long(PyLong_FromSize_t(color));
   }
   return Py::Long(0);
 }

--- a/src/Mod/Path/App/VoronoiEdgePyImp.cpp
+++ b/src/Mod/Path/App/VoronoiEdgePyImp.cpp
@@ -142,7 +142,7 @@ Py::Long VoronoiEdgePy::getColor(void) const {
   VoronoiEdge *e = getVoronoiEdgePtr();
   if (e->isBound()) {
     Voronoi::color_type color = e->ptr->color() & Voronoi::ColorMask;
-    return Py::Long(color);
+    return Py::Long(PyLong_FromSize_t(color));
   }
   return Py::Long(0);
 }

--- a/src/Mod/Path/App/VoronoiVertexPyImp.cpp
+++ b/src/Mod/Path/App/VoronoiVertexPyImp.cpp
@@ -125,7 +125,7 @@ Py::Long VoronoiVertexPy::getColor(void) const {
   VoronoiVertex *v = getVoronoiVertexPtr();
   if (v->isBound()) {
     Voronoi::color_type color = v->ptr->color() & Voronoi::ColorMask;
-    return Py::Long(color);
+    return Py::Long(PyLong_FromSize_t(color));
   }
   return Py::Long(0);
 }


### PR DESCRIPTION
Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
