### PR TITLE
[Pending][PartDesign] Hole countersink for metric

### DIFF
--- a/src/Mod/PartDesign/App/FeatureHole.cpp
+++ b/src/Mod/PartDesign/App/FeatureHole.cpp
@@ -626,150 +626,83 @@ void Hole::onChanged(const App::Property *prop)
             }
             Threaded.setValue(0);
         }
-        else if ( type == "ISOMetricProfile" ) {
-            ThreadSize.setEnums(ThreadSize_ISOmetric_Enums);
-            ThreadClass.setEnums(ThreadClass_ISOmetric_Enums);
-            HoleCutType.setEnums(HoleCutType_ISOmetric_Enums);
-            Threaded.setReadOnly(false);
-            ThreadSize.setReadOnly(false);
-            // thread class and direction are only sensible if threaded
-            // fit only sensible if not threaded
-            ThreadFit.setReadOnly(Threaded.getValue());
-            ThreadClass.setReadOnly(!Threaded.getValue());
-            Diameter.setReadOnly(true);
-
-            if (holeCutType == "None") {
-                HoleCutDiameter.setReadOnly(true);
-                HoleCutDepth.setReadOnly(true);
-                HoleCutCountersinkAngle.setReadOnly(true);
-            }
-            else if (holeCutType == "Counterbore") {
-                HoleCutDiameter.setReadOnly(true);
-                HoleCutDepth.setReadOnly(false);
-                HoleCutCountersinkAngle.setReadOnly(true);
-
-            }
-            else if (holeCutType == "Countersink") {
-                HoleCutDiameter.setReadOnly(false);
-                HoleCutDepth.setReadOnly(true);
-                HoleCutCountersinkAngle.setReadOnly(true);
-            }
-        }
-        else if ( type == "ISOMetricFineProfile" ) {
-            ThreadSize.setEnums(ThreadSize_ISOmetricfine_Enums);
-            ThreadClass.setEnums(ThreadClass_ISOmetricfine_Enums);
-            HoleCutType.setEnums(HoleCutType_ISOmetricfine_Enums);
-            Threaded.setReadOnly(false);
-            ThreadSize.setReadOnly(false);
-            // thread class and direction are only sensible if threaded
-            // fit only sensible if not threaded
-            ThreadFit.setReadOnly(Threaded.getValue());
-            ThreadClass.setReadOnly(!Threaded.getValue());
-            Diameter.setReadOnly(true);
-
-            if (holeCutType == "None") {
-                HoleCutDiameter.setReadOnly(true);
-                HoleCutDepth.setReadOnly(true);
-                HoleCutCountersinkAngle.setReadOnly(true);
-            }
-            else if (holeCutType == "Counterbore") {
-                HoleCutDiameter.setReadOnly(true);
-                HoleCutDepth.setReadOnly(false);
-                HoleCutCountersinkAngle.setReadOnly(true);
-
-            }
-            else if (holeCutType == "Countersink") {
-                HoleCutDiameter.setReadOnly(false);
-                HoleCutDepth.setReadOnly(true);
-                HoleCutCountersinkAngle.setReadOnly(true);
-            }
-        }
-        else if ( type == "UNC" ) {
-            ThreadSize.setEnums(ThreadSize_UNC_Enums);
-            ThreadClass.setEnums(ThreadClass_UNC_Enums);
-            HoleCutType.setEnums(HoleCutType_UNC_Enums);
-            Threaded.setReadOnly(false);
-            ThreadSize.setReadOnly(false);
-            // thread class and direction are only sensible if threaded
-            // fit only sensible if not threaded
-            ThreadFit.setReadOnly(Threaded.getValue());
-            ThreadClass.setReadOnly(!Threaded.getValue());
-            Diameter.setReadOnly(true);
-
-            if (holeCutType == "None") {
-                HoleCutDiameter.setReadOnly(true);
-                HoleCutDepth.setReadOnly(true);
-                HoleCutCountersinkAngle.setReadOnly(true);
-            }
-            else if (holeCutType == "Counterbore") {
-                HoleCutDiameter.setReadOnly(false);
-                HoleCutDepth.setReadOnly(false);
-                HoleCutCountersinkAngle.setReadOnly(true);
-
-            }
-            else if (holeCutType == "Countersink") {
-                HoleCutDiameter.setReadOnly(false);
-                HoleCutDepth.setReadOnly(true);
-                HoleCutCountersinkAngle.setReadOnly(false);
-            }
-        }
-        else if ( type == "UNF" ) {
-            ThreadSize.setEnums(ThreadSize_UNF_Enums);
-            ThreadClass.setEnums(ThreadClass_UNF_Enums);
-            HoleCutType.setEnums(HoleCutType_UNF_Enums);
-            Threaded.setReadOnly(false);
-            ThreadSize.setReadOnly(false);
-            // thread class and direction are only sensible if threaded
-            // fit only sensible if not threaded
-            ThreadFit.setReadOnly(Threaded.getValue());
-            ThreadClass.setReadOnly(!Threaded.getValue());
-            Diameter.setReadOnly(true);
-
-            if (holeCutType == "None") {
-                HoleCutDiameter.setReadOnly(true);
-                HoleCutDepth.setReadOnly(true);
-                HoleCutCountersinkAngle.setReadOnly(true);
-            }
-            else if (holeCutType == "Counterbore") {
-                HoleCutDiameter.setReadOnly(false);
-                HoleCutDepth.setReadOnly(false);
-                HoleCutCountersinkAngle.setReadOnly(true);
-
-            }
-            else if (holeCutType == "Countersink") {
-                HoleCutDiameter.setReadOnly(false);
-                HoleCutDepth.setReadOnly(true);
-                HoleCutCountersinkAngle.setReadOnly(false);
-            }
-        }
-        else if ( type == "UNEF" ) {
-            ThreadSize.setEnums(ThreadSize_UNEF_Enums);
-            ThreadClass.setEnums(ThreadClass_UNEF_Enums);
-            HoleCutType.setEnums(HoleCutType_UNEF_Enums);
-            Threaded.setReadOnly(false);
-            ThreadSize.setReadOnly(false);
-            // thread class and direction are only sensible if threaded
-            // fit only sensible if not threaded
-            ThreadFit.setReadOnly(Threaded.getValue());
-            ThreadClass.setReadOnly(!Threaded.getValue());;
-            Diameter.setReadOnly(true);
-
-            if (holeCutType == "None") {
-                HoleCutDiameter.setReadOnly(true);
-                HoleCutDepth.setReadOnly(true);
-                HoleCutCountersinkAngle.setReadOnly(true);
-            }
-            else if (holeCutType == "Counterbore") {
-                HoleCutDiameter.setReadOnly(false);
-                HoleCutDepth.setReadOnly(false);
-                HoleCutCountersinkAngle.setReadOnly(true);
-
-            }
-            else if (holeCutType == "Countersink") {
-                HoleCutDiameter.setReadOnly(false);
-                HoleCutDepth.setReadOnly(true);
-                HoleCutCountersinkAngle.setReadOnly(false);
-            }
+        else {
+	        if ( type == "ISOMetricProfile" ) {
+		        ThreadSize.setEnums(ThreadSize_ISOmetric_Enums);
+		        ThreadClass.setEnums(ThreadClass_ISOmetric_Enums);
+		        HoleCutType.setEnums(HoleCutType_ISOmetric_Enums);
+		        Threaded.setReadOnly(false);
+		        ThreadSize.setReadOnly(false);
+		        // thread class and direction are only sensible if threaded
+		        // fit only sensible if not threaded
+		        ThreadFit.setReadOnly(Threaded.getValue());
+		        ThreadClass.setReadOnly(!Threaded.getValue());
+		        Diameter.setReadOnly(true);
+	        }
+	        else if ( type == "ISOMetricFineProfile" ) {
+		        ThreadSize.setEnums(ThreadSize_ISOmetricfine_Enums);
+		        ThreadClass.setEnums(ThreadClass_ISOmetricfine_Enums);
+		        HoleCutType.setEnums(HoleCutType_ISOmetricfine_Enums);
+		        Threaded.setReadOnly(false);
+		        ThreadSize.setReadOnly(false);
+		        // thread class and direction are only sensible if threaded
+		        // fit only sensible if not threaded
+		        ThreadFit.setReadOnly(Threaded.getValue());
+		        ThreadClass.setReadOnly(!Threaded.getValue());
+		        Diameter.setReadOnly(true);
+	        }
+	        else if ( type == "UNC" ) {
+		        ThreadSize.setEnums(ThreadSize_UNC_Enums);
+		        ThreadClass.setEnums(ThreadClass_UNC_Enums);
+		        HoleCutType.setEnums(HoleCutType_UNC_Enums);
+		        Threaded.setReadOnly(false);
+		        ThreadSize.setReadOnly(false);
+		        // thread class and direction are only sensible if threaded
+		        // fit only sensible if not threaded
+		        ThreadFit.setReadOnly(Threaded.getValue());
+		        ThreadClass.setReadOnly(!Threaded.getValue());
+		        Diameter.setReadOnly(true);
+	        }
+	        else if ( type == "UNF" ) {
+		        ThreadSize.setEnums(ThreadSize_UNF_Enums);
+		        ThreadClass.setEnums(ThreadClass_UNF_Enums);
+		        HoleCutType.setEnums(HoleCutType_UNF_Enums);
+		        Threaded.setReadOnly(false);
+		        ThreadSize.setReadOnly(false);
+		        // thread class and direction are only sensible if threaded
+		        // fit only sensible if not threaded
+		        ThreadFit.setReadOnly(Threaded.getValue());
+		        ThreadClass.setReadOnly(!Threaded.getValue());
+		        Diameter.setReadOnly(true);
+	        }
+	        else if ( type == "UNEF" ) {
+		        ThreadSize.setEnums(ThreadSize_UNEF_Enums);
+		        ThreadClass.setEnums(ThreadClass_UNEF_Enums);
+		        HoleCutType.setEnums(HoleCutType_UNEF_Enums);
+		        Threaded.setReadOnly(false);
+		        ThreadSize.setReadOnly(false);
+		        // thread class and direction are only sensible if threaded
+		        // fit only sensible if not threaded
+		        ThreadFit.setReadOnly(Threaded.getValue());
+		        ThreadClass.setReadOnly(!Threaded.getValue());;
+		        Diameter.setReadOnly(true);
+	        }
+	        if (holeCutType == "None") {
+		        HoleCutDiameter.setReadOnly(true);
+		        HoleCutDepth.setReadOnly(true);
+		        HoleCutCountersinkAngle.setReadOnly(true);
+	        }
+	        else if (holeCutType == "Counterbore") {
+		        HoleCutDiameter.setReadOnly(false);
+		        HoleCutDepth.setReadOnly(false);
+		        HoleCutCountersinkAngle.setReadOnly(true);
+		        
+	        }
+	        else if (holeCutType == "Countersink") {
+		        HoleCutDiameter.setReadOnly(false);
+		        HoleCutDepth.setReadOnly(true);
+		        HoleCutCountersinkAngle.setReadOnly(false);
+	        }
         }
 
         if (type == "ISOMetricProfile" || type == "ISOMetricFineProfile")


### PR DESCRIPTION
fix a problem with counterbore and countersink in PartDesign Hole feature.

It was not possible to custom define counterbores or countersinks if a
metric thread hole was selected.

Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [ ] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [ ] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---
