### PR TITLE
Draft: Improve make_sketch and geometric related functions

### DIFF
--- a/src/Mod/Draft/DraftGeomUtils.py
+++ b/src/Mod/Draft/DraftGeomUtils.py
@@ -68,11 +68,16 @@ from draftgeoutils.general import (precision,
 from draftgeoutils.geometry import (findPerpendicular,
                                     findDistance,
                                     getSplineNormal,
+                                    get_spline_normal,
                                     getNormal,
+                                    get_normal,
                                     getRotation,
                                     isPlanar,
+                                    is_planar,
                                     calculatePlacement,
-                                    mirror)
+                                    mirror,
+                                    are_coplanar,
+                                    is_straight_line)
 
 from draftgeoutils.edges import (findEdge,
                                  orientEdge,

--- a/src/Mod/Draft/draftgeoutils/edges.py
+++ b/src/Mod/Draft/draftgeoutils/edges.py
@@ -111,15 +111,27 @@ def isSameLine(e1, e2):
     return False
 
 
-def isLine(bspline):
+def is_line(bspline):
     """Return True if the given BSpline curve is a straight line."""
-    step = bspline.LastParameter/10
-    b = bspline.tangent(0)
 
-    for i in range(10):
-        if bspline.tangent(i * step) != b:
-            return False
-    return True
+# previous implementation may fail for a multipole striaght spline due
+# a second order error in tolerance, wich introduce a difference of 1e-14
+# in the values of the tangents. Also, may fail on a periodic spline.
+#    step = bspline.LastParameter/10
+#    b = bspline.tangent(0)
+#
+#    for i in range(10):
+#        if bspline.tangent(i * step) != b:
+#            return False
+
+    start_point = bspline.StartPoint
+    end_point = bspline.EndPoint
+    dist_start_end = end_point.distanceToPoint(start_point)
+    if (dist_start_end == bspline.length()) < 1e-7:
+        return True
+
+    return False
+
 
 
 def invert(shape):
@@ -208,5 +220,9 @@ def getTangent(edge, from_point=None):
         return v1.cross(edge.Curve.Axis)
 
     return None
+
+# compatibility layer
+
+isLine = is_line
 
 ## @}

--- a/src/Mod/Draft/draftgeoutils/offsets.py
+++ b/src/Mod/Draft/draftgeoutils/offsets.py
@@ -32,7 +32,7 @@ import FreeCAD as App
 import DraftVecUtils
 
 from draftgeoutils.general import geomType, vec
-from draftgeoutils.geometry import getNormal
+from draftgeoutils.geometry import get_normal
 from draftgeoutils.wires import isReallyClosed
 from draftgeoutils.intersections import wiresIntersect, connect
 
@@ -223,7 +223,10 @@ def offsetWire(wire, dvec, bind=False, occ=False,
     if normal:
         norm = normal
     else:
-        norm = getNormal(wire)  # norm = Vector(0, 0, 1)
+        norm = get_normal(wire)  # norm = Vector(0, 0, 1)
+        # for backward compatibility with previous getNormal implementation
+        if norm == None:
+            norm = App.Vector(0, 0, 1)
 
     closed = isReallyClosed(wire)
     nedges = []

--- a/src/Mod/Draft/draftgeoutils/wires.py
+++ b/src/Mod/Draft/draftgeoutils/wires.py
@@ -29,11 +29,12 @@
 import math
 import lazy_loader.lazy_loader as lz
 
+import FreeCAD as App
 import DraftVecUtils
 import WorkingPlane
 
 from draftgeoutils.general import geomType, vec, precision
-from draftgeoutils.geometry import getNormal
+from draftgeoutils.geometry import get_normal
 from draftgeoutils.edges import findMidpoint, isLine
 
 # Delay import of module until first use because it is heavy
@@ -157,9 +158,10 @@ def findWiresOld(edges):
 
 def flattenWire(wire):
     """Force a wire to get completely flat along its normal."""
-    n = getNormal(wire)
-    if not n:
-        return
+    n = get_normal(wire)
+    # for backward compatibility with previous getNormal implementation
+    if n == None:
+        n = App.Vector(0, 0, 1)
 
     o = wire.Vertexes[0].Point
     plane = WorkingPlane.plane()

--- a/src/Mod/Draft/draftguitools/gui_draft2sketch.py
+++ b/src/Mod/Draft/draftguitools/gui_draft2sketch.py
@@ -36,7 +36,6 @@ into several individual Draft objects.
 ## \addtogroup draftguitools
 # @{
 from PySide.QtCore import QT_TRANSLATE_NOOP
-
 import FreeCADGui as Gui
 import Draft_rc
 import draftguitools.gui_base_original as gui_base_original
@@ -90,7 +89,8 @@ class Draft2Sketch(gui_base_original.Modifier):
         for obj in sel:
             if obj.isDerivedFrom("Sketcher::SketchObject"):
                 allDraft = False
-            elif obj.isDerivedFrom("Part::Part2DObjectPython"):
+            elif (obj.isDerivedFrom("Part::Part2DObjectPython")
+                  or obj.isDerivedFrom("Part::Feature")):
                 allSketches = False
             else:
                 allDraft = False
@@ -141,12 +141,13 @@ class Draft2Sketch(gui_base_original.Modifier):
 
                 if obj.isDerivedFrom("Sketcher::SketchObject"):
                     _cmd_list.append("obj" + str(n) + " = " + _cmd_df)
-                elif obj.isDerivedFrom("Part::Part2DObjectPython"):
+                elif (obj.isDerivedFrom("Part::Part2DObjectPython")
+                      or obj.isDerivedFrom("Part::Feature")):
                     _cmd_list.append("obj" + str(n) + " = " + _cmd_sk)
-                elif obj.isDerivedFrom("Part::Feature"):
-                    # if (len(obj.Shape.Wires) == 1
-                    #     or len(obj.Shape.Edges) == 1):
-                    _cmd_list.append("obj" + str(n) + " = " + _cmd_sk)
+                #elif obj.isDerivedFrom("Part::Feature"):
+                #    # if (len(obj.Shape.Wires) == 1
+                #    #     or len(obj.Shape.Edges) == 1):
+                #    _cmd_list.append("obj" + str(n) + " = " + _cmd_sk)
                 n += 1
             _cmd_list.append('FreeCAD.ActiveDocument.recompute()')
             self.commit(translate("draft", "Convert Draft/Sketch"),

--- a/src/Mod/Draft/draftobjects/patharray.py
+++ b/src/Mod/Draft/draftobjects/patharray.py
@@ -444,7 +444,10 @@ def placements_on_path(shapeRotation, pathwire, count, xlate, align,
     Each copy will be distributed evenly.
     """
     closedpath = DraftGeomUtils.isReallyClosed(pathwire)
-    normal = DraftGeomUtils.getNormal(pathwire)
+    normal = DraftGeomUtils.get_normal(pathwire)
+    # for backward compatibility with previous getNormal implementation
+    if normal == None:
+        normal = App.Vector(0, 0, 1)
 
     if forceNormal and normalOverride:
         normal = normalOverride


### PR DESCRIPTION
Motivated by https://tracker.freecadweb.org/view.php?id=4416

Now the draft2sketch operation works more correctly on custom planes other than XY.
The previous implementation had the following drawbacks:
Fails to check coplanarity.
Fails with three collinear points wires and doesn't convert isolated points.
Sometimes, shapes in unexpected location, as reflected or rotated.
Mixed conversion between planes.
Only first piece is converted for bezier curves.
Splines and bezier curves are projected to xy plane instead of being converted.

The previous functions isLine and getSplineNormal may fail in symetrics splines or straight splines with multiple control points.
In fact, the bug reported is related to the latter.

Also geometrical functions are modified to use the Part.Shape.findPlane method and to counteract the fact that shape.findPlane method defines a single plane and normal for straight wires (but not for vertex and straight edges) thus creating privileged coordinated systems.
For example, findPlane assign to a straight wire in the plane XY the normal (0,0,1) when instead it should be undefined.

see https://forum.freecadweb.org/viewtopic.php?f=23&t=51084