### PR TITLE
Fix "Random color" not random - Seed randomizer on application init

### DIFF
--- a/src/App/Application.cpp
+++ b/src/App/Application.cpp
@@ -2127,6 +2127,9 @@ void Application::initApplication(void)
     catch (const Base::Exception& e) {
         e.ReportException();
     }
+    
+    // seed randomizer
+    srand(time(0));
 }
 
 std::list<std::string> Application::getCmdLineFiles()


### PR DESCRIPTION
Thank you for creating a pull request to contribute to FreeCAD! To ease integration, please confirm the following:

- [X] Branch rebased on latest master `git pull --rebase upstream master`
- [ ] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [X] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists

And please remember to update the Wiki with the features added or changed once this PR is merged.  
**Note**: If you don't have wiki access, then please mention your contribution on the [0.19 Changelog Forum Thread](https://forum.freecadweb.org/viewtopic.php?f=10&t=34586).

---

The "Random color" command was producing the same sequence of colors every startup, so the first object i colored in a new file would always be barf green, then light brown, then another green. This happened because `srand()` was never called before the `rand()` calls in the random color command.
As `rand()` is used in more places we should seed the randomizer on application startup.