### PR TITLE
Part: improve tooltip of measure commands

### DIFF
--- a/src/Mod/Part/Gui/Command.cpp
+++ b/src/Mod/Part/Gui/Command.cpp
@@ -2197,7 +2197,9 @@ CmdMeasureLinear::CmdMeasureLinear()
     sAppModule    = "Part";
     sGroup        = QT_TR_NOOP("Part");
     sMenuText     = QT_TR_NOOP("Measure Linear");
-    sToolTipText  = QT_TR_NOOP("Measure Linear");
+    sToolTipText  = QT_TR_NOOP("Measure the linear distance between two points;\n"
+                               "if edges or faces are picked, it will measure\n"
+                               "between two vertices of them.");
     sWhatsThis    = "Part_Measure_Linear";
     sStatusTip    = sToolTipText;
     sPixmap       = "Part_Measure_Linear";
@@ -2226,7 +2228,7 @@ CmdMeasureAngular::CmdMeasureAngular()
     sAppModule    = "Part";
     sGroup        = QT_TR_NOOP("Part");
     sMenuText     = QT_TR_NOOP("Measure Angular");
-    sToolTipText  = QT_TR_NOOP("Measure Angular");
+    sToolTipText  = QT_TR_NOOP("Measure the angle between two edges.");
     sWhatsThis    = "Part_Measure_Angular";
     sStatusTip    = sToolTipText;
     sPixmap       = "Part_Measure_Angular";
@@ -2255,7 +2257,8 @@ CmdMeasureRefresh::CmdMeasureRefresh()
     sAppModule    = "Part";
     sGroup        = QT_TR_NOOP("Part");
     sMenuText     = QT_TR_NOOP("Refresh");
-    sToolTipText  = QT_TR_NOOP("Refresh");
+    sToolTipText  = QT_TR_NOOP("Recalculate the dimensions\n"
+                               "if the measured points have moved.");
     sWhatsThis    = "Part_Measure_Refresh";
     sStatusTip    = sToolTipText;
     sPixmap       = "Part_Measure_Refresh";
@@ -2284,7 +2287,7 @@ CmdMeasureClearAll::CmdMeasureClearAll()
     sAppModule    = "Part";
     sGroup        = QT_TR_NOOP("Part");
     sMenuText     = QT_TR_NOOP("Clear All");
-    sToolTipText  = QT_TR_NOOP("Clear All");
+    sToolTipText  = QT_TR_NOOP("Clear all dimensions from the screen.");
     sWhatsThis    = "Part_Measure_Clear_All";
     sStatusTip    = sToolTipText;
     sPixmap       = "Part_Measure_Clear_All";
@@ -2313,7 +2316,9 @@ CmdMeasureToggleAll::CmdMeasureToggleAll()
     sAppModule    = "Part";
     sGroup        = QT_TR_NOOP("Part");
     sMenuText     = QT_TR_NOOP("Toggle All");
-    sToolTipText  = QT_TR_NOOP("Toggle All");
+    sToolTipText  = QT_TR_NOOP("Toggle on and off "
+                               "all currently visible dimensions,\n"
+                               "direct, orthogonal, and angular.");
     sWhatsThis    = "Part_Measure_Toggle_All";
     sStatusTip    = sToolTipText;
     sPixmap       = "Part_Measure_Toggle_All";
@@ -2349,7 +2354,8 @@ CmdMeasureToggle3d::CmdMeasureToggle3d()
     sGroup        = QT_TR_NOOP("Part");
     sMenuText     = QT_TR_NOOP("Toggle 3D");
     sToolTipText  = QT_TR_NOOP("Toggle on and off "
-                               "the dimensions on the 3D view");
+                               "all direct dimensions,\n"
+                               "including angular.");
     sWhatsThis    = "Part_Measure_Toggle_3D";
     sStatusTip    = sToolTipText;
     sPixmap       = "Part_Measure_Toggle_3D";
@@ -2378,7 +2384,10 @@ CmdMeasureToggleDelta::CmdMeasureToggleDelta()
     sAppModule    = "Part";
     sGroup        = QT_TR_NOOP("Part");
     sMenuText     = QT_TR_NOOP("Toggle Delta");
-    sToolTipText  = QT_TR_NOOP("Toggle Delta");
+    sToolTipText  = QT_TR_NOOP("Toggle on and off "
+                               "all orthogonal dimensions,\n"
+                               "meaning that a direct dimension will be decomposed\n"
+                               "into its X, Y, and Z components.");
     sWhatsThis    = "Part_Measure_Toggle_Delta";
     sStatusTip    = sToolTipText;
     sPixmap       = "Part_Measure_Toggle_Delta";

--- a/src/Mod/Part/Gui/TaskDimension.cpp
+++ b/src/Mod/Part/Gui/TaskDimension.cpp
@@ -861,14 +861,14 @@ bool PartGui::evaluateAngularPreSelection(VectorAdapter &vector1Out, VectorAdapt
       TopoDS_Vertex currentVertex = TopoDS::Vertex(shape);
       if (!lastVertex.IsNull())
       {
-	//need something here for 0 length vector.
-	//create a point half way between to vertices.
-	adapters.emplace_back(currentVertex, lastVertex);
-	lastVertex = TopoDS_Vertex();
+        //need something here for 0 length vector.
+        //create a point half way between to vertices.
+        adapters.emplace_back(currentVertex, lastVertex);
+        lastVertex = TopoDS_Vertex();
       }
       else
       {
-	lastVertex = currentVertex;
+        lastVertex = currentVertex;
       }
       continue;
     }
@@ -906,10 +906,10 @@ bool PartGui::evaluateAngularPreSelection(VectorAdapter &vector1Out, VectorAdapt
       double lastDistance = (lastPoint - pickPoint).Magnitude();
       if (lastDistance > firstDistance)
       {
-	if (edge.Orientation() == TopAbs_FORWARD)
-	  edge.Orientation(TopAbs_REVERSED);
-	else
-	  edge.Orientation(TopAbs_FORWARD);
+        if (edge.Orientation() == TopAbs_FORWARD)
+          edge.Orientation(TopAbs_REVERSED);
+        else
+          edge.Orientation(TopAbs_FORWARD);
       }
       adapters.emplace_back(edge, pickPoint);
       continue;
@@ -1007,9 +1007,9 @@ void PartGui::goDimensionAngularNoTask(const VectorAdapter &vector1Adapter, cons
     if (xAxis.IsParallel(vector1, Precision::Angular()))
     {
       if (!xAxis.IsParallel(gp_Vec(0.0, 0.0, 1.0), Precision::Angular()))
-	zAxis = gp_Vec(0.0, 0.0, 1.0);
+        zAxis = gp_Vec(0.0, 0.0, 1.0);
       else
-	zAxis = gp_Vec(0.0, 1.0, 0.0);
+        zAxis = gp_Vec(0.0, 1.0, 0.0);
     }
     else
       zAxis = xAxis.Crossed(vector1).Normalized();
@@ -1139,8 +1139,8 @@ PartGui::DimensionAngular::DimensionAngular()
     SO_NODE_ADD_FIELD(dColor, (1.0, 0.0, 0.0));//dimension color.
     SO_NODE_ADD_FIELD(matrix, (1.0, 0.0, 0.0, 0.0,
                                0.0, 1.0, 0.0, 0.0,
-			       0.0, 0.0, 1.0, 0.0,
-			       0.0, 0.0, 0.0, 1.0));
+                               0.0, 0.0, 1.0, 0.0,
+                               0.0, 0.0, 0.0, 1.0));
 }
 
 PartGui::DimensionAngular::~DimensionAngular()
@@ -1454,21 +1454,21 @@ PartGui::DimensionControl::DimensionControl(QWidget* parent): QWidget(parent)
   this->setLayout(commandLayout);
 
   resetButton = new QPushButton(Gui::BitmapFactory().pixmap("Part_Measure_Linear"),
-				QObject::tr("Reset Dialog"), this);
+                                QObject::tr("Reset selection"), this);
   commandLayout->addWidget(resetButton);
 
   QPushButton *toggle3dButton = new QPushButton(Gui::BitmapFactory().pixmap("Part_Measure_Toggle_3D"),
-						QObject::tr("Toggle 3D"), this);
+                                                QObject::tr("Toggle direct dimensions"), this);
   QObject::connect(toggle3dButton, SIGNAL(clicked(bool)), this, SLOT(toggle3dSlot(bool)));
   commandLayout->addWidget(toggle3dButton);
 
   QPushButton *toggleDeltaButton = new QPushButton(Gui::BitmapFactory().pixmap("Part_Measure_Toggle_Delta"),
-						QObject::tr("Toggle Delta"), this);
+                                                   QObject::tr("Toggle orthogonal dimensions"), this);
   QObject::connect(toggleDeltaButton, SIGNAL(clicked(bool)), this, SLOT(toggleDeltaSlot(bool)));
   commandLayout->addWidget(toggleDeltaButton);
 
   QPushButton *clearAllButton = new QPushButton(Gui::BitmapFactory().pixmap("Part_Measure_Clear_All"),
-						QObject::tr("Clear All"), this);
+                                                QObject::tr("Clear all dimensions"), this);
   QObject::connect(clearAllButton, SIGNAL(clicked(bool)), this, SLOT(clearAllSlot(bool)));
   commandLayout->addWidget(clearAllButton);
 }
@@ -1524,29 +1524,29 @@ void PartGui::TaskMeasureAngular::onSelectionChanged(const Gui::SelectionChanges
     {
       if (shape.ShapeType() == TopAbs_VERTEX)
       {
-	//if we have previous selection it should be only one vertex.
-	if (selections1.selections.size() > 1)
-	  selections1.selections.clear();
-	else if(selections1.selections.size() == 1)
-	{
-	  //make sure it is a vertex.
-	  if (selections1.selections.at(0).shapeType != DimSelections::Vertex)
-	    selections1.selections.clear();
-	}
+        //if we have previous selection it should be only one vertex.
+        if (selections1.selections.size() > 1)
+            selections1.selections.clear();
+        else if(selections1.selections.size() == 1)
+        {
+          //make sure it is a vertex.
+          if (selections1.selections.at(0).shapeType != DimSelections::Vertex)
+              selections1.selections.clear();
+        }
 
-	newSelection.shapeType = DimSelections::Vertex;
-	selections1.selections.push_back(newSelection);
-	if (selections1.selections.size() == 1)
-	  return;
-	//here we should have 2 vertices, but will check to make sure.
-	assert(selections1.selections.size() == 2);
-	assert(selections1.selections.at(0).shapeType == DimSelections::Vertex);
-	assert(selections1.selections.at(1).shapeType == DimSelections::Vertex);
-
-	QTimer::singleShot(0, this, SLOT(selectionClearDelayedSlot()));
-	stepped->getButton(1)->setEnabled(true);
-	stepped->getButton(1)->setChecked(true);
-	return;
+        newSelection.shapeType = DimSelections::Vertex;
+        selections1.selections.push_back(newSelection);
+        if (selections1.selections.size() == 1)
+            return;
+        //here we should have 2 vertices, but will check to make sure.
+        assert(selections1.selections.size() == 2);
+        assert(selections1.selections.at(0).shapeType == DimSelections::Vertex);
+        assert(selections1.selections.at(1).shapeType == DimSelections::Vertex);
+        
+        QTimer::singleShot(0, this, SLOT(selectionClearDelayedSlot()));
+        stepped->getButton(1)->setEnabled(true);
+        stepped->getButton(1)->setChecked(true);
+        return;
       }
 
       //here there should only be one in the selections container. so just clear it.
@@ -1554,14 +1554,14 @@ void PartGui::TaskMeasureAngular::onSelectionChanged(const Gui::SelectionChanges
 
       if (shape.ShapeType() == TopAbs_EDGE)
       {
-	newSelection.shapeType = DimSelections::Edge;
-	selections1.selections. push_back(newSelection);
+        newSelection.shapeType = DimSelections::Edge;
+        selections1.selections. push_back(newSelection);
       }
 
       if (shape.ShapeType() == TopAbs_FACE)
       {
-	newSelection.shapeType = DimSelections::Face;
-	selections1.selections.push_back(newSelection);
+        newSelection.shapeType = DimSelections::Face;
+        selections1.selections.push_back(newSelection);
       }
 
       QTimer::singleShot(0, this, SLOT(selectionClearDelayedSlot()));
@@ -1576,45 +1576,45 @@ void PartGui::TaskMeasureAngular::onSelectionChanged(const Gui::SelectionChanges
     {
       if (shape.ShapeType() == TopAbs_VERTEX)
       {
-	//if we have previous selection it should be only one vertex.
-	if (selections2.selections.size() > 1)
-	  selections2.selections.clear();
-	else if(selections2.selections.size() == 1)
-	{
-	  //make sure it is a vertex.
-	  if (selections2.selections.at(0).shapeType != DimSelections::Vertex)
-	    selections2.selections.clear();
-	}
+        //if we have previous selection it should be only one vertex.
+        if (selections2.selections.size() > 1)
+          selections2.selections.clear();
+        else if(selections2.selections.size() == 1)
+        {
+          //make sure it is a vertex.
+          if (selections2.selections.at(0).shapeType != DimSelections::Vertex)
+            selections2.selections.clear();
+        }
 
-	newSelection.shapeType = DimSelections::Vertex;
-	selections2.selections.push_back(newSelection);
-	if (selections2.selections.size() == 1)
-	  return;
-	//here we should have 2 vertices, but will check to make sure.
-	assert(selections2.selections.size() == 2);
-	assert(selections2.selections.at(0).shapeType == DimSelections::Vertex);
-	assert(selections2.selections.at(1).shapeType == DimSelections::Vertex);
+        newSelection.shapeType = DimSelections::Vertex;
+        selections2.selections.push_back(newSelection);
+        if (selections2.selections.size() == 1)
+          return;
+        //here we should have 2 vertices, but will check to make sure.
+        assert(selections2.selections.size() == 2);
+        assert(selections2.selections.at(0).shapeType == DimSelections::Vertex);
+        assert(selections2.selections.at(1).shapeType == DimSelections::Vertex);
 
-	buildDimension();
-	clearSelection();
-	QTimer::singleShot(0, this, SLOT(selectionClearDelayedSlot()));
-	stepped->getButton(0)->setChecked(true);
-	stepped->getButton(1)->setEnabled(false);
-	return;
+        buildDimension();
+        clearSelection();
+        QTimer::singleShot(0, this, SLOT(selectionClearDelayedSlot()));
+        stepped->getButton(0)->setChecked(true);
+        stepped->getButton(1)->setEnabled(false);
+        return;
       }
       //vertices have to be selected in succession. if we get here,clear temp selection.
       selections2.selections.clear();
 
       if (shape.ShapeType() == TopAbs_EDGE)
       {
-	newSelection.shapeType = DimSelections::Edge;
-	selections2.selections. push_back(newSelection);
+        newSelection.shapeType = DimSelections::Edge;
+        selections2.selections. push_back(newSelection);
       }
 
       if (shape.ShapeType() == TopAbs_FACE)
       {
-	newSelection.shapeType = DimSelections::Face;
-	selections2.selections.push_back(newSelection);
+        newSelection.shapeType = DimSelections::Face;
+        selections2.selections.push_back(newSelection);
       }
 
       buildDimension();
@@ -1676,7 +1676,7 @@ PartGui::VectorAdapter PartGui::TaskMeasureAngular::buildAdapter(const PartGui::
     {
       TopoDS_Shape faceShape;
       if (!getShapeFromStrings(faceShape, current.documentName, current.objectName, current.subObjectName,&mat))
-	return VectorAdapter();
+        return VectorAdapter();
 
       TopoDS_Face face = TopoDS::Face(faceShape);
       Base::Vector3d v(current.x,current.y,current.z);
@@ -1719,7 +1719,7 @@ void PartGui::TaskMeasureAngular::buildDimension(const DimSelections &sel1, cons
     return;
   }
   auto doc = App::GetApplication().getActiveDocument();
-  if(doc) 
+  if(doc)
     _Measures[doc->getName()].emplace_back(sel1,sel2,false);
   goDimensionAngularNoTask(adapt1, adapt2);
 }


### PR DESCRIPTION
Improve the tooltips of `Part_Measure_Linear`, `Part_Measure_Angular`, `Part_Measure_Refresh`, `Part_Measure_Clear_All`, `Part_Measure_Toggle_All`, `Part_Measure_Toggle_3D`, `Part_Measure_Toggle_Delta`.

See also, [Move or remove "View_Measure_Toggle_All" and "View_Measure_Clear_All"](https://forum.freecadweb.org/viewtopic.php?f=10&t=51075).

Also update the text of the buttons in the `TaskDimension` task panel.

Remove tabs in the source code, as there was a mix of tabs and spaces. Further cleaning is necessary as the indentation is inconsistent and mostly 2 spaces instead of 4 spaces.

---

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists