### PR TITLE
Part: clean up Python files of the workbench

### DIFF
--- a/src/Mod/Part/AttachmentEditor/Commands.py
+++ b/src/Mod/Part/AttachmentEditor/Commands.py
@@ -103,3 +103,4 @@ if App.GuiUp:
     import FreeCADGui as Gui
     command_instance = CommandEditAttachment()
     Gui.addCommand('Part_EditAttachment', command_instance)
+

--- a/src/Mod/Part/AttachmentEditor/FrozenClass.py
+++ b/src/Mod/Part/AttachmentEditor/FrozenClass.py
@@ -34,3 +34,4 @@ class FrozenClass(object):
 
     def _unfreeze(self):
         self.__isfrozen = False
+

--- a/src/Mod/Part/AttachmentEditor/TaskAttachmentEditor.py
+++ b/src/Mod/Part/AttachmentEditor/TaskAttachmentEditor.py
@@ -611,3 +611,4 @@ class AttachmentEditorTaskPanel(FrozenClass):
         Gui.Selection.removeObserver(self)
         if self.tv:
             self.tv.restore()
+

--- a/src/Mod/Part/BOPTools/GeneralFuseResult.py
+++ b/src/Mod/Part/BOPTools/GeneralFuseResult.py
@@ -40,18 +40,27 @@ def myCustomFusionRoutine(list_of_shapes):
     ... (use attributes and methods of ao) ..."""
 
     def __define_attributes(self):
-        self.gfa_return = None #stores the data returned by generalFuse, supplied to class constructor
+        # stores the data returned by generalFuse, supplied to class constructor
+        self.gfa_return = None 
 
-        self.pieces = None #pieces that resulted from intersetion routine. List of shapes (non-decorated).
-        self._piece_to_index = {} # key = decorated shape. Value = index (int) into self.pieces
+        # pieces that resulted from intersetion routine. List of shapes (non-decorated).
+        self.pieces = None
+        # key = decorated shape. Value = index (int) into self.pieces
+        self._piece_to_index = {}
 
-        self.source_shapes = [] # list of shapes that was supplied to generalFuse (plus the self-shape). List of shapes (non-decorated)
-        self._source_to_index = {} # key = decorated shape. Value = index (int) into self.source_shapes
+        # list of shapes that was supplied to generalFuse (plus the self-shape). List of shapes (non-decorated)
+        self.source_shapes = []
+        # key = decorated shape. Value = index (int) into self.source_shapes
+        self._source_to_index = {}
 
-        self._pieces_of_source = [] #list of pieces (indexes) generated from a source shape, by index of source shape. List of lists of ints.
-        self._sources_of_piece = [] #list of source shapes (indexes) the piece came from, by index of piece. List of lists of ints.
+        #list of pieces (indexes) generated from a source shape, by index of source shape. List of lists of ints.
+        self._pieces_of_source = []
+        #list of source shapes (indexes) the piece came from, by index of piece. List of lists of ints.
+        self._sources_of_piece = []
 
-        self._element_to_source = {} #dictionary for finding, which source shapes did an element of pieces come from. key = HashableShape (element). Value = set of ints
+        # dictionary for finding, which source shapes did an element of pieces come from.
+        # key = HashableShape (element). Value = set of ints
+        self._element_to_source = {} 
 
         self._freeze()
 
@@ -138,7 +147,8 @@ def myCustomFusionRoutine(list_of_shapes):
             for iSource in range(len(map)):
                 if len(map[iSource]) == 0:
                     import FreeCAD as App
-                    App.Console.PrintWarning("Map entry {num} is empty. Source-to-piece correspondence information is probably incomplete.".format(num= iSource))
+                    App.Console.PrintWarning("Map entry {num} is empty. "
+                                             "Source-to-piece correspondence information is probably incomplete.".format(num=iSource))
 
         self._pieces_of_source = [[] for i in range(len(self.source_shapes))]
         self._sources_of_piece = [[] for i in range(len(self.pieces))]
@@ -311,7 +321,8 @@ def myCustomFusionRoutine(list_of_shapes):
             #can't split the shape
             return [shape]
 
-        # for each joint, test if all bits it's connected to are from same number of sources. If not, this is a joint for splitting
+        # for each joint, test if all bits it's connected to are from same number of sources.
+        # If not, this is a joint for splitting
         # FIXME: this is slow, and maybe can be optimized
         splits = []
         for joint in joint_extractor(shape):
@@ -372,7 +383,9 @@ class GeneralFuseReturnBuilder(FrozenClass):
     "GeneralFuseReturnBuilder: utility class used by splitAggregates to build fake return of generalFuse, for re-parsing."
     def __define_attributes(self):
         self.pieces = []
-        self._piece_to_index = {} # key = hasher_class(shape). Value = (index_into_self_dot_pieces, shape). Note that GeneralFuseResult uses this item directly.
+        # key = hasher_class(shape). Value = (index_into_self_dot_pieces, shape).
+        # Note that GeneralFuseResult uses this item directly.
+        self._piece_to_index = {}
 
         self._pieces_from_source = [] #list of list of ints
         self.source_shapes = []

--- a/src/Mod/Part/BOPTools/JoinAPI.py
+++ b/src/Mod/Part/BOPTools/JoinAPI.py
@@ -32,7 +32,8 @@ from .GeneralFuseResult import GeneralFuseResult
 from .Utils import compoundLeaves
 
 def shapeOfMaxSize(list_of_shapes):
-    """shapeOfMaxSize(list_of_shapes): finds the shape that has the largest mass in the list and returns it. The shapes in the list must be of same dimension."""
+    """shapeOfMaxSize(list_of_shapes): finds the shape that has the largest "
+    "mass in the list and returns it. The shapes in the list must be of same dimension."""
     #first, check if shapes can be compared by size
     ShapeMerge.dimensionOfShapes(list_of_shapes)
 

--- a/src/Mod/Part/BOPTools/JoinFeatures.py
+++ b/src/Mod/Part/BOPTools/JoinFeatures.py
@@ -20,7 +20,7 @@
 # *                                                                         *
 # ***************************************************************************/
 
-__title__="BOPTools.JoinFeatures module"
+__title__ = "BOPTools.JoinFeatures module"
 __author__ = "DeepSOIC"
 __url__ = "http://www.freecadweb.org"
 __doc__ = "Implementation of document objects (features) for connect, ebmed and cutout operations."
@@ -32,11 +32,11 @@ import Part
 if FreeCAD.GuiUp:
     import FreeCADGui
     from PySide import QtCore, QtGui
-    # -------------------------- common stuff --------------------------------------------------
-    
-    #-------------------------- translation-related code ----------------------------------------
-    #Thanks, yorik! (see forum thread "A new Part tool is being born... JoinFeatures!"
-    #http://forum.freecadweb.org/viewtopic.php?f=22&t=11112&start=30#p90239 )
+# -------------------------- common stuff -------------------------------------
+
+# -------------------------- translation-related code -------------------------
+# Thanks, yorik! (see forum thread "A new Part tool is being born... JoinFeatures!"
+# http://forum.freecadweb.org/viewtopic.php?f=22&t=11112&start=30#p90239 )
     
     try:
         _fromUtf8 = QtCore.QString.fromUtf8
@@ -53,18 +53,20 @@ if FreeCAD.GuiUp:
 else:
     def _translate(context, text, disambig):
         return text
-    #--------------------------/translation-related code ----------------------------------------
+# --------------------------/translation-related code -------------------------
 
 
 def getParamRefine():
     return FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/Part/Boolean").GetBool("RefineModel")
 
+
 def cmdCreateJoinFeature(name, mode):
-    "cmdCreateJoinFeature(name, mode): generalized implementation of GUI commands."
+    """cmdCreateJoinFeature(name, mode): generalized implementation of GUI commands."""
     sel = FreeCADGui.Selection.getSelectionEx()
+
     FreeCAD.ActiveDocument.openTransaction("Create "+mode)
     FreeCADGui.addModule("BOPTools.JoinFeatures")
-    FreeCADGui.doCommand("j = BOPTools.JoinFeatures.make{mode}(name = '{name}')".format(mode= mode, name= name))
+    FreeCADGui.doCommand("j = BOPTools.JoinFeatures.make{mode}(name='{name}')".format(mode=mode, name=name))
     if mode == "Embed" or mode == "Cutout":
         FreeCADGui.doCommand("j.Base = App.ActiveDocument."+sel[0].Object.Name)
         FreeCADGui.doCommand("j.Tool = App.ActiveDocument."+sel[1].Object.Name)
@@ -73,7 +75,7 @@ def cmdCreateJoinFeature(name, mode):
            sel= "["  +  ", ".join(["App.ActiveDocument."+so.Object.Name for so in sel])  +  "]"
            ))
     else:
-        raise ValueError("cmdCreateJoinFeature: Unexpected mode {mode}".format(mode= repr(mode)))
+        raise ValueError("cmdCreateJoinFeature: Unexpected mode {mode}".format(mode=repr(mode)))
 
     try:
         FreeCADGui.doCommand("j.Proxy.execute(j)")
@@ -81,13 +83,16 @@ def cmdCreateJoinFeature(name, mode):
     except Exception as err:
         mb = QtGui.QMessageBox()
         mb.setIcon(mb.Icon.Warning)
-        mb.setText(_translate("Part_JoinFeatures","Computing the result failed with an error: \n\n{err}\n\n Click 'Continue' to create the feature anyway, or 'Abort' to cancel.", None)
-                   .format(err= str(err)))
+        mb.setText(_translate("Part_JoinFeatures",
+                              "Computing the result failed with an error:\n\n"
+                              "{err}\n\n"
+                              "Click 'Continue' to create the feature anyway, or 'Abort' to cancel.", None)
+                   .format(err=str(err)))
         mb.setWindowTitle(_translate("Part_JoinFeatures","Bad selection", None))
         btnAbort = mb.addButton(QtGui.QMessageBox.StandardButton.Abort)
-        btnOK = mb.addButton(_translate("Part_JoinFeatures","Continue",None), QtGui.QMessageBox.ButtonRole.ActionRole)
+        btnOK = mb.addButton(_translate("Part_JoinFeatures","Continue",None),
+                             QtGui.QMessageBox.ButtonRole.ActionRole)
         mb.setDefaultButton(btnOK)
-
         mb.exec_()
 
         if mb.clickedButton() is btnAbort:
@@ -99,12 +104,13 @@ def cmdCreateJoinFeature(name, mode):
 
     FreeCAD.ActiveDocument.commitTransaction()
 
+
 def getIconPath(icon_dot_svg):
     return icon_dot_svg
 
-# -------------------------- /common stuff --------------------------------------------------
+# -------------------------- /common stuff ------------------------------------
 
-# -------------------------- Connect --------------------------------------------------
+# -------------------------- Connect ------------------------------------------
 
 def makeConnect(name):
     '''makeConnect(name): makes an Connect object.'''
@@ -114,13 +120,18 @@ def makeConnect(name):
         ViewProviderConnect(obj.ViewObject)
     return obj
 
+
 class FeatureConnect:
-    "The PartJoinFeature object"
+    """The PartJoinFeature object."""
+
     def __init__(self,obj):
         obj.addProperty("App::PropertyLinkList","Objects","Connect","Object to be connectded.")
-        obj.addProperty("App::PropertyBool","Refine","Connect","True = refine resulting shape. False = output as is.")
+        obj.addProperty("App::PropertyBool","Refine","Connect",
+                        "True = refine resulting shape. False = output as is.")
         obj.Refine = getParamRefine()
-        obj.addProperty("App::PropertyLength","Tolerance","Connect","Tolerance when intersecting (fuzzy value). In addition to tolerances of the shapes.")
+        obj.addProperty("App::PropertyLength","Tolerance","Connect",
+                        "Tolerance when intersecting (fuzzy value). "
+                        "In addition to tolerances of the shapes.")
 
         obj.Proxy = self
         self.Type = "FeatureConnect"
@@ -133,7 +144,7 @@ class FeatureConnect:
 
 
 class ViewProviderConnect:
-    "A View Provider for the Part Connect feature"
+    """A View Provider for the Part Connect feature."""
 
     def __init__(self,vobj):
         vobj.Proxy = self
@@ -179,20 +190,23 @@ class ViewProviderConnect:
 
 
 class CommandConnect:
-    "Command to create Connect feature"
+    """Command to create Connect feature."""
+
     def GetResources(self):
-        return {'Pixmap'  : getIconPath("Part_JoinConnect.svg"),
+        return {'Pixmap': getIconPath("Part_JoinConnect.svg"),
                 'MenuText': QtCore.QT_TRANSLATE_NOOP("Part_JoinConnect","Connect objects"),
                 'Accel': "",
-                'ToolTip': QtCore.QT_TRANSLATE_NOOP("Part_JoinConnect","Fuses objects, taking care to preserve voids.")}
+                'ToolTip': QtCore.QT_TRANSLATE_NOOP("Part_JoinConnect",
+                                                    "Fuses objects, taking care to preserve voids.")}
 
     def Activated(self):
-        if len(FreeCADGui.Selection.getSelectionEx()) >= 1 :
-            cmdCreateJoinFeature(name = "Connect", mode = "Connect")
+        if len(FreeCADGui.Selection.getSelectionEx()) >= 1:
+            cmdCreateJoinFeature(name="Connect", mode="Connect")
         else:
             mb = QtGui.QMessageBox()
             mb.setIcon(mb.Icon.Warning)
-            mb.setText(_translate("Part_JoinFeatures", "Select at least two objects, or one or more compounds, first!", None))
+            mb.setText(_translate("Part_JoinFeatures",
+                                  "Select at least two objects, or one or more compounds", None))
             mb.setWindowTitle(_translate("Part_JoinFeatures","Bad selection", None))
             mb.exec_()
 
@@ -202,10 +216,10 @@ class CommandConnect:
         else:
             return False
 
-# -------------------------- /Connect --------------------------------------------------
+# -------------------------- /Connect -----------------------------------------
 
 
-# -------------------------- Embed --------------------------------------------------
+# -------------------------- Embed --------------------------------------------
 
 
 def makeEmbed(name):
@@ -216,14 +230,19 @@ def makeEmbed(name):
         ViewProviderEmbed(obj.ViewObject)
     return obj
 
+
 class FeatureEmbed:
-    "The Part Embed object"
+    """The Part Embed object."""
+
     def __init__(self,obj):
         obj.addProperty("App::PropertyLink","Base","Embed","Object to embed into.")
         obj.addProperty("App::PropertyLink","Tool","Embed","Object to be embedded.")
-        obj.addProperty("App::PropertyBool","Refine","Embed","True = refine resulting shape. False = output as is.")
+        obj.addProperty("App::PropertyBool","Refine","Embed",
+                        "True = refine resulting shape. False = output as is.")
         obj.Refine = getParamRefine()
-        obj.addProperty("App::PropertyLength","Tolerance","Embed","Tolerance when intersecting (fuzzy value). In addition to tolerances of the shapes.")
+        obj.addProperty("App::PropertyLength","Tolerance","Embed",
+                        "Tolerance when intersecting (fuzzy value). "
+                        "In addition to tolerances of the shapes.")
 
         obj.Proxy = self
         self.Type = "FeatureEmbed"
@@ -236,7 +255,7 @@ class FeatureEmbed:
 
 
 class ViewProviderEmbed:
-    "A View Provider for the Part Embed feature"
+    """A View Provider for the Part Embed feature."""
 
     def __init__(self,vobj):
         vobj.Proxy = self
@@ -265,24 +284,28 @@ class ViewProviderEmbed:
             FreeCAD.Console.PrintError("Error in onDelete: " + str(err))
         return True
 
+
 class CommandEmbed:
-    "Command to create Part Embed feature"
+    """Command to create Part Embed feature."""
+
     def GetResources(self):
-        return {'Pixmap'  : getIconPath("Part_JoinEmbed.svg"),
+        return {'Pixmap': getIconPath("Part_JoinEmbed.svg"),
                 'MenuText': QtCore.QT_TRANSLATE_NOOP("Part_JoinEmbed","Embed object"),
                 'Accel': "",
-                'ToolTip': QtCore.QT_TRANSLATE_NOOP("Part_JoinEmbed","Fuses one object into another, taking care to preserve voids.")}
+                'ToolTip': QtCore.QT_TRANSLATE_NOOP("Part_JoinEmbed",
+                                                    "Fuses one object into another, taking care to preserve voids.")}
 
     def Activated(self):
-        if len(FreeCADGui.Selection.getSelectionEx()) == 2 :
+        if len(FreeCADGui.Selection.getSelectionEx()) == 2:
             cmdCreateJoinFeature(name = "Embed", mode = "Embed")
         else:
             mb = QtGui.QMessageBox()
             mb.setIcon(mb.Icon.Warning)
-            mb.setText(_translate("Part_JoinFeatures","Select base object, then the object to embed, and invoke this tool.", None))
+            mb.setText(_translate("Part_JoinFeatures",
+                                  "Select base object, then the object to embed, "
+                                  "and then invoke this tool.", None))
             mb.setWindowTitle(_translate("Part_JoinFeatures","Bad selection", None))
             mb.exec_()
-
 
     def IsActive(self):
         if FreeCAD.ActiveDocument:
@@ -290,11 +313,10 @@ class CommandEmbed:
         else:
             return False
 
-# -------------------------- /Embed --------------------------------------------------
+# -------------------------- /Embed -------------------------------------------
 
 
-
-# -------------------------- Cutout --------------------------------------------------
+# -------------------------- Cutout -------------------------------------------
 
 def makeCutout(name):
     '''makeCutout(name): makes an Cutout object.'''
@@ -304,14 +326,18 @@ def makeCutout(name):
         ViewProviderCutout(obj.ViewObject)
     return obj
 
+
 class FeatureCutout:
-    "The Part Cutout object"
+    """The Part Cutout object."""
+
     def __init__(self,obj):
         obj.addProperty("App::PropertyLink","Base","Cutout","Object to be cut.")
         obj.addProperty("App::PropertyLink","Tool","Cutout","Object to make cutout for.")
-        obj.addProperty("App::PropertyBool","Refine","Cutout","True = refine resulting shape. False = output as is.")
+        obj.addProperty("App::PropertyBool","Refine","Cutout",
+                        "True = refine resulting shape. False = output as is.")
         obj.Refine = getParamRefine()
-        obj.addProperty("App::PropertyLength","Tolerance","Cutout","Tolerance when intersecting (fuzzy value). In addition to tolerances of the shapes.")
+        obj.addProperty("App::PropertyLength","Tolerance","Cutout",
+                        "Tolerance when intersecting (fuzzy value). In addition to tolerances of the shapes.")
 
         obj.Proxy = self
         self.Type = "FeatureCutout"
@@ -324,7 +350,7 @@ class FeatureCutout:
 
 
 class ViewProviderCutout:
-    "A View Provider for the Part Cutout feature"
+    """A View Provider for the Part Cutout feature."""
 
     def __init__(self,vobj):
         vobj.Proxy = self
@@ -355,20 +381,25 @@ class ViewProviderCutout:
 
 
 class CommandCutout:
-    "Command to create PartJoinFeature in Cutout mode"
+    """Command to create PartJoinFeature in Cutout mode."""
+
     def GetResources(self):
-        return {'Pixmap'  : getIconPath("Part_JoinCutout.svg"),
+        return {'Pixmap': getIconPath("Part_JoinCutout.svg"),
                 'MenuText': QtCore.QT_TRANSLATE_NOOP("Part_JoinCutout","Cutout for object"),
                 'Accel': "",
-                'ToolTip': QtCore.QT_TRANSLATE_NOOP("Part_JoinCutout","Makes a cutout in one object to fit another object.")}
+                'ToolTip': QtCore.QT_TRANSLATE_NOOP("Part_JoinCutout",
+                                                    "Makes a cutout in one object to fit another object.")}
 
     def Activated(self):
-        if len(FreeCADGui.Selection.getSelectionEx()) == 2 :
-            cmdCreateJoinFeature(name = "Cutout", mode = "Cutout")
+        if len(FreeCADGui.Selection.getSelectionEx()) == 2:
+            cmdCreateJoinFeature(name="Cutout", mode="Cutout")
         else:
             mb = QtGui.QMessageBox()
             mb.setIcon(mb.Icon.Warning)
-            mb.setText(_translate("Part_JoinFeatures","Select the object to make a cutout in, then the object that should fit into the cutout, and invoke this tool.", None))
+            mb.setText(_translate("Part_JoinFeatures",
+                                  "Select the object to make a cutout in, "
+                                  "then the object that should fit into the cutout, "
+                                  "and then invoke this tool.", None))
             mb.setWindowTitle(_translate("Part_JoinFeatures","Bad selection", None))
             mb.exec_()
 
@@ -378,9 +409,9 @@ class CommandCutout:
         else:
             return False
 
-# -------------------------- /Cutout --------------------------------------------------
+# -------------------------- /Cutout ------------------------------------------
 
 def addCommands():
-    FreeCADGui.addCommand('Part_JoinCutout',CommandCutout())
-    FreeCADGui.addCommand('Part_JoinEmbed',CommandEmbed())
-    FreeCADGui.addCommand('Part_JoinConnect',CommandConnect())
+    FreeCADGui.addCommand('Part_JoinCutout', CommandCutout())
+    FreeCADGui.addCommand('Part_JoinEmbed', CommandEmbed())
+    FreeCADGui.addCommand('Part_JoinConnect', CommandConnect())

--- a/src/Mod/Part/BOPTools/SplitFeatures.py
+++ b/src/Mod/Part/BOPTools/SplitFeatures.py
@@ -33,9 +33,9 @@ if FreeCAD.GuiUp:
     import FreeCADGui
     from PySide import QtCore, QtGui
 
-#-------------------------- translation-related code ----------------------------------------
-#(see forum thread "A new Part tool is being born... JoinFeatures!"
-#http://forum.freecadweb.org/viewtopic.php?f=22&t=11112&start=30#p90239 )
+# -------------------------- translation-related code -------------------------
+# See forum thread "A new Part tool is being born... JoinFeatures!"
+# http://forum.freecadweb.org/viewtopic.php?f=22&t=11112&start=30#p90239
     try:
         _fromUtf8 = QtCore.QString.fromUtf8
     except Exception:
@@ -48,30 +48,38 @@ if FreeCAD.GuiUp:
     except AttributeError:
         def _translate(context, text, disambig):
             return QtGui.QApplication.translate(context, text, disambig)
-#--------------------------/translation-related code ----------------------------------------
+#--------------------------/translation-related code --------------------------
+
 
 def getIconPath(icon_dot_svg):
     return icon_dot_svg
 
-# -------------------------- /common stuff --------------------------------------------------
+# -------------------------- /common stuff ------------------------------------
 
-# -------------------------- BooleanFragments --------------------------------------------------
+# -------------------------- BooleanFragments ---------------------------------
 
 def makeBooleanFragments(name):
     '''makeBooleanFragments(name): makes an BooleanFragments object.'''
-    obj = FreeCAD.ActiveDocument.addObject("Part::FeaturePython",name)
+    obj = FreeCAD.ActiveDocument.addObject("Part::FeaturePython", name)
     FeatureBooleanFragments(obj)
     if FreeCAD.GuiUp:
         ViewProviderBooleanFragments(obj.ViewObject)
     return obj
 
+
 class FeatureBooleanFragments:
-    "The BooleanFragments feature object"
+    """The BooleanFragments feature object."""
+
     def __init__(self,obj):
         obj.addProperty("App::PropertyLinkList","Objects","BooleanFragments","Object to compute intersections between.")
-        obj.addProperty("App::PropertyEnumeration","Mode","BooleanFragments","Standard: wires, shells, compsolids remain in one piece. Split: wires, shells, compsolids are split. CompSolid: make compsolid from solid fragments.")
+        obj.addProperty("App::PropertyEnumeration","Mode","BooleanFragments",
+                        "- Standard: wires, shells, compsolids remain in one piece.\n"
+                        "- Split: wires, shells, compsolids are split.\n"
+                        "- CompSolid: make compsolid from solid fragments.")
         obj.Mode = ["Standard", "Split", "CompSolid"]
-        obj.addProperty("App::PropertyLength","Tolerance","BooleanFragments","Tolerance when intersecting (fuzzy value). In addition to tolerances of the shapes.")
+        obj.addProperty("App::PropertyLength","Tolerance","BooleanFragments",
+                        "Tolerance when intersecting (fuzzy value). "
+                        "In addition to tolerances of the shapes.")
 
         obj.Proxy = self
         self.Type = "FeatureBooleanFragments"
@@ -81,12 +89,12 @@ class FeatureBooleanFragments:
         if len(shapes) == 1 and shapes[0].ShapeType == "Compound":
             shapes = shapes[0].childShapes()
         if len(shapes) < 2:
-            raise ValueError("At least two shapes are needed for computing boolean fragments. Got only {num}.".format(num= len(shapes)))
+            raise ValueError("At least two shapes are needed for computing boolean fragments. Got only {num}.".format(num=len(shapes)))
         selfobj.Shape = SplitAPI.booleanFragments(shapes, selfobj.Mode, selfobj.Tolerance)
 
 
 class ViewProviderBooleanFragments:
-    "A View Provider for the Part BooleanFragments feature"
+    """A View Provider for the Part BooleanFragments feature."""
 
     def __init__(self,vobj):
         vobj.Proxy = self
@@ -130,13 +138,14 @@ class ViewProviderBooleanFragments:
     def dropObject(self, selfvp, incoming_object):
         self.Object.Objects = self.Object.Objects + [incoming_object]
 
+
 def cmdCreateBooleanFragmentsFeature(name, mode):
     """cmdCreateBooleanFragmentsFeature(name, mode): implementation of GUI command to create
     BooleanFragments feature (GFA). Mode can be "Standard", "Split", or "CompSolid"."""
     sel = FreeCADGui.Selection.getSelectionEx()
     FreeCAD.ActiveDocument.openTransaction("Create Boolean Fragments")
     FreeCADGui.addModule("BOPTools.SplitFeatures")
-    FreeCADGui.doCommand("j = BOPTools.SplitFeatures.makeBooleanFragments(name= '{name}')".format(name= name))
+    FreeCADGui.doCommand("j = BOPTools.SplitFeatures.makeBooleanFragments(name='{name}')".format(name=name))
     FreeCADGui.doCommand("j.Objects = {sel}".format(
        sel= "["  +  ", ".join(["App.ActiveDocument."+so.Object.Name for so in sel])  +  "]"
        ))
@@ -148,11 +157,15 @@ def cmdCreateBooleanFragmentsFeature(name, mode):
     except Exception as err:
         mb = QtGui.QMessageBox()
         mb.setIcon(mb.Icon.Warning)
-        mb.setText(_translate("Part_SplitFeatures","Computing the result failed with an error: \n\n{err}\n\nClick 'Continue' to create the feature anyway, or 'Abort' to cancel.", None)
-                   .format(err= str(err)))
+        mb.setText(_translate("Part_SplitFeatures",
+                              "Computing the result failed with an error:\n\n"
+                              "{err}\n\n"
+                              "Click 'Continue' to create the feature anyway, or 'Abort' to cancel.", None)
+                   .format(err=str(err)))
         mb.setWindowTitle(_translate("Part_SplitFeatures","Bad selection", None))
         btnAbort = mb.addButton(QtGui.QMessageBox.StandardButton.Abort)
-        btnOK = mb.addButton(_translate("Part_SplitFeatures","Continue",None), QtGui.QMessageBox.ButtonRole.ActionRole)
+        btnOK = mb.addButton(_translate("Part_SplitFeatures","Continue",None),
+                             QtGui.QMessageBox.ButtonRole.ActionRole)
         mb.setDefaultButton(btnOK)
 
         mb.exec_()
@@ -166,21 +179,31 @@ def cmdCreateBooleanFragmentsFeature(name, mode):
 
     FreeCAD.ActiveDocument.commitTransaction()
 
+
 class CommandBooleanFragments:
-    "Command to create BooleanFragments feature"
+    """Command to create BooleanFragments feature."""
+
     def GetResources(self):
-        return {'Pixmap'  : getIconPath("Part_BooleanFragments.svg"),
-                'MenuText': QtCore.QT_TRANSLATE_NOOP("Part_SplitFeatures","Boolean Fragments"),
+        return {'Pixmap': getIconPath("Part_BooleanFragments.svg"),
+                'MenuText': QtCore.QT_TRANSLATE_NOOP("Part_SplitFeatures","Boolean fragments"),
                 'Accel': "",
-                'ToolTip': QtCore.QT_TRANSLATE_NOOP("Part_SplitFeatures","Split objects where they intersect")}
+                'ToolTip': QtCore.QT_TRANSLATE_NOOP("Part_SplitFeatures",
+                                                    "Create a 'Boolean Fragments' object from two or more selected objects,\n"
+                                                    "or from the shapes inside a compound.\n"
+                                                    "This is a boolean union which is then sliced at the intersections\n"
+                                                    "of the original shapes.\n"
+                                                    "A 'Compound Filter' can be used to extract the individual slices.")}
 
     def Activated(self):
-        if len(FreeCADGui.Selection.getSelectionEx()) >= 1 :
-            cmdCreateBooleanFragmentsFeature(name= "BooleanFragments", mode= "Standard")
+        if len(FreeCADGui.Selection.getSelectionEx()) >= 1:
+            cmdCreateBooleanFragmentsFeature(name="BooleanFragments", mode="Standard")
         else:
             mb = QtGui.QMessageBox()
             mb.setIcon(mb.Icon.Warning)
-            mb.setText(_translate("Part_SplitFeatures", "Select at least two objects, or one or more compounds, first! If only one compound is selected, the compounded shapes will be intersected between each other (otherwise, compounds with self-intersections are invalid).", None))
+            mb.setText(_translate("Part_SplitFeatures",
+                                  "Select at least two objects, or one or more compounds. "
+                                  "If only one compound is selected, the compounded shapes will be intersected between each other "
+                                  "(otherwise, compounds with self-intersections are invalid).", None))
             mb.setWindowTitle(_translate("Part_SplitFeatures","Bad selection", None))
             mb.exec_()
 
@@ -190,9 +213,9 @@ class CommandBooleanFragments:
         else:
             return False
 
-# -------------------------- /BooleanFragments --------------------------------------------------
+# -------------------------- /BooleanFragments --------------------------------
 
-# -------------------------- Slice --------------------------------------------------
+# -------------------------- Slice --------------------------------------------
 
 def makeSlice(name):
     '''makeSlice(name): makes an Slice object.'''
@@ -202,14 +225,21 @@ def makeSlice(name):
         ViewProviderSlice(obj.ViewObject)
     return obj
 
+
 class FeatureSlice:
-    "The Slice feature object"
+    """The Slice feature object."""
+
     def __init__(self,obj):
         obj.addProperty("App::PropertyLink","Base","Slice","Object to be sliced.")
         obj.addProperty("App::PropertyLinkList","Tools","Slice","Objects that slice.")
-        obj.addProperty("App::PropertyEnumeration","Mode","Slice","Standard: wires, shells, compsolids remain in one piece. Split: wires, shells, compsolids are split. CompSolid: make compsolid from solid fragments.")
+        obj.addProperty("App::PropertyEnumeration","Mode","Slice",
+                        "- Standard: wires, shells, compsolids remain in one piece.\n"
+                        "- Split: wires, shells, compsolids are split.\n"
+                        "- CompSolid: make compsolid from solid fragments.")
         obj.Mode = ["Standard", "Split", "CompSolid"]
-        obj.addProperty("App::PropertyLength","Tolerance","Slice","Tolerance when intersecting (fuzzy value). In addition to tolerances of the shapes.")
+        obj.addProperty("App::PropertyLength","Tolerance","Slice",
+                        "Tolerance when intersecting (fuzzy value). "
+                        "In addition to tolerances of the shapes.")
 
         obj.Proxy = self
         self.Type = "FeatureSlice"
@@ -217,11 +247,14 @@ class FeatureSlice:
     def execute(self,selfobj):
         if len(selfobj.Tools) < 1:
             raise ValueError("No slicing objects supplied!")
-        selfobj.Shape = SplitAPI.slice(selfobj.Base.Shape, [obj.Shape for obj in selfobj.Tools], selfobj.Mode, selfobj.Tolerance)
+        selfobj.Shape = SplitAPI.slice(selfobj.Base.Shape,
+                                       [obj.Shape for obj in selfobj.Tools],
+                                       selfobj.Mode,
+                                       selfobj.Tolerance)
 
 
 class ViewProviderSlice:
-    "A View Provider for the Part Slice feature"
+    """A View Provider for the Part Slice feature."""
 
     def __init__(self,vobj):
         vobj.Proxy = self
@@ -250,13 +283,13 @@ class ViewProviderSlice:
             FreeCAD.Console.PrintError("Error in onDelete: " + str(err))
         return True
 
-def cmdCreateSliceFeature(name, mode, transaction= True):
+def cmdCreateSliceFeature(name, mode, transaction=True):
     """cmdCreateSliceFeature(name, mode): implementation of GUI command to create
     Slice feature. Mode can be "Standard", "Split", or "CompSolid"."""
     sel = FreeCADGui.Selection.getSelectionEx()
     if transaction: FreeCAD.ActiveDocument.openTransaction("Create Slice")
     FreeCADGui.addModule("BOPTools.SplitFeatures")
-    FreeCADGui.doCommand("f = BOPTools.SplitFeatures.makeSlice(name= '{name}')".format(name= name))
+    FreeCADGui.doCommand("f = BOPTools.SplitFeatures.makeSlice(name='{name}')".format(name=name))
     FreeCADGui.doCommand("f.Base = {sel}[0]\n"
                          "f.Tools = {sel}[1:]".format(
        sel= "["  +  ", ".join(["App.ActiveDocument."+so.Object.Name for so in sel])  +  "]"
@@ -269,11 +302,15 @@ def cmdCreateSliceFeature(name, mode, transaction= True):
     except Exception as err:
         mb = QtGui.QMessageBox()
         mb.setIcon(mb.Icon.Warning)
-        mb.setText(_translate("Part_SplitFeatures","Computing the result failed with an error: \n\n{err}\n\nClick 'Continue' to create the feature anyway, or 'Abort' to cancel.", None)
-                   .format(err= str(err)))
+        mb.setText(_translate("Part_SplitFeatures",
+                              "Computing the result failed with an error:\n\n"
+                              "{err}\n\n"
+                              "Click 'Continue' to create the feature anyway, or 'Abort' to cancel.", None)
+                   .format(err=str(err)))
         mb.setWindowTitle(_translate("Part_SplitFeatures","Bad selection", None))
         btnAbort = mb.addButton(QtGui.QMessageBox.StandardButton.Abort)
-        btnOK = mb.addButton(_translate("Part_SplitFeatures","Continue",None), QtGui.QMessageBox.ButtonRole.ActionRole)
+        btnOK = mb.addButton(_translate("Part_SplitFeatures","Continue",None),
+                             QtGui.QMessageBox.ButtonRole.ActionRole)
         mb.setDefaultButton(btnOK)
 
         mb.exec_()
@@ -290,7 +327,7 @@ def cmdCreateSliceFeature(name, mode, transaction= True):
 
 def cmdSliceApart():
     FreeCAD.ActiveDocument.openTransaction("Slice apart")
-    made = cmdCreateSliceFeature(name= "Slice", mode= "Split", transaction= False)
+    made = cmdCreateSliceFeature(name="Slice", mode="Split", transaction=False)
     
     if made:
         FreeCADGui.addModule("CompoundTools.Explode")
@@ -300,23 +337,30 @@ def cmdSliceApart():
         FreeCADGui.doCommand("App.ActiveDocument.recompute()")
     else:
         FreeCAD.ActiveDocument.abortTransaction()
-        
+
 
 class CommandSlice:
-    "Command to create Slice feature"
+    """Command to create Slice feature."""
+
     def GetResources(self):
-        return {'Pixmap'  : getIconPath("Part_Slice.svg"),
+        return {'Pixmap': getIconPath("Part_Slice.svg"),
                 'MenuText': QtCore.QT_TRANSLATE_NOOP("Part_SplitFeatures","Slice to compound"),
                 'Accel': "",
-                'ToolTip': QtCore.QT_TRANSLATE_NOOP("Part_SplitFeatures","Split object by intersections with other objects, and pack the pieces into a compound.")}
+                'ToolTip': QtCore.QT_TRANSLATE_NOOP("Part_SplitFeatures",
+                                                    "Slice a selected object by using other objects as cutting tools.\n"
+                                                    "The resulting pieces will be stored in a compound.\n"
+                                                    "A 'Compound Filter' can be used to extract the individual slices.")}
 
     def Activated(self):
-        if len(FreeCADGui.Selection.getSelectionEx()) > 1 :
-            cmdCreateSliceFeature(name= "Slice", mode= "Split")
+        if len(FreeCADGui.Selection.getSelectionEx()) > 1:
+            cmdCreateSliceFeature(name="Slice", mode="Split")
         else:
             mb = QtGui.QMessageBox()
             mb.setIcon(mb.Icon.Warning)
-            mb.setText(_translate("Part_SplitFeatures", "Select at least two objects, first! First one is the object to be sliced; the rest are objects to slice with.", None))
+            mb.setText(_translate("Part_SplitFeatures",
+                                  "Select at least two objects. "
+                                  "The first one is the object to be sliced; "
+                                  "the rest are objects to slice with.", None))
             mb.setWindowTitle(_translate("Part_SplitFeatures","Bad selection", None))
             mb.exec_()
 
@@ -326,21 +370,28 @@ class CommandSlice:
         else:
             return False
 
+
 class CommandSliceApart:
-    "Command to create exploded Slice feature"
+    """Command to create exploded Slice feature."""
+
     def GetResources(self):
-        return {'Pixmap'  : getIconPath("Part_SliceApart.svg"),
+        return {'Pixmap': getIconPath("Part_SliceApart.svg"),
                 'MenuText': QtCore.QT_TRANSLATE_NOOP("Part_SplitFeatures","Slice apart"),
                 'Accel': "",
-                'ToolTip': QtCore.QT_TRANSLATE_NOOP("Part_SplitFeatures","Split object by intersections with other objects.")}
+                'ToolTip': QtCore.QT_TRANSLATE_NOOP("Part_SplitFeatures",
+                                                    "Slice a selected object by other objects, and split it apart.\n"
+                                                    "It will create a 'Compound Filter' for each slice.")}
 
     def Activated(self):
-        if len(FreeCADGui.Selection.getSelectionEx()) > 1 :
+        if len(FreeCADGui.Selection.getSelectionEx()) > 1:
             cmdSliceApart()
         else:
             mb = QtGui.QMessageBox()
             mb.setIcon(mb.Icon.Warning)
-            mb.setText(_translate("Part_SplitFeatures", "Select at least two objects, first! First one is the object to be sliced; the rest are objects to slice with.", None))
+            mb.setText(_translate("Part_SplitFeatures",
+                                  "Select at least two objects. "
+                                  "The first one is the object to be sliced; "
+                                  "the rest are objects to slice with.", None))
             mb.setWindowTitle(_translate("Part_SplitFeatures","Bad selection", None))
             mb.exec_()
 
@@ -350,9 +401,9 @@ class CommandSliceApart:
         else:
             return False
 
-# -------------------------- /Slice --------------------------------------------------
+# -------------------------- /Slice -------------------------------------------
 
-# -------------------------- XOR --------------------------------------------------
+# -------------------------- XOR ----------------------------------------------
 
 def makeXOR(name):
     '''makeXOR(name): makes an XOR object.'''
@@ -362,11 +413,15 @@ def makeXOR(name):
         ViewProviderXOR(obj.ViewObject)
     return obj
 
+
 class FeatureXOR:
-    "The XOR feature object"
+    """The XOR feature object."""
+
     def __init__(self,obj):
         obj.addProperty("App::PropertyLinkList","Objects","XOR","Object to compute intersections between.")
-        obj.addProperty("App::PropertyLength","Tolerance","XOR","Tolerance when intersecting (fuzzy value). In addition to tolerances of the shapes.")
+        obj.addProperty("App::PropertyLength","Tolerance","XOR",
+                        "Tolerance when intersecting (fuzzy value). "
+                        "In addition to tolerances of the shapes.")
 
         obj.Proxy = self
         self.Type = "FeatureXOR"
@@ -376,12 +431,12 @@ class FeatureXOR:
         if len(shapes) == 1 and shapes[0].ShapeType == "Compound":
             shapes = shapes[0].childShapes()
         if len(shapes) < 2:
-            raise ValueError("At least two shapes are needed for computing XOR. Got only {num}.".format(num= len(shapes)))
+            raise ValueError("At least two shapes are needed for computing XOR. Got only {num}.".format(num=len(shapes)))
         selfobj.Shape = SplitAPI.xor(shapes, selfobj.Tolerance)
 
 
 class ViewProviderXOR:
-    "A View Provider for the Part XOR feature"
+    """A View Provider for the Part XOR feature."""
 
     def __init__(self,vobj):
         vobj.Proxy = self
@@ -425,13 +480,14 @@ class ViewProviderXOR:
     def dropObject(self, selfvp, incoming_object):
         self.Object.Objects = self.Object.Objects + [incoming_object]
 
+
 def cmdCreateXORFeature(name):
     """cmdCreateXORFeature(name): implementation of GUI command to create
     XOR feature (GFA). Mode can be "Standard", "Split", or "CompSolid"."""
     sel = FreeCADGui.Selection.getSelectionEx()
     FreeCAD.ActiveDocument.openTransaction("Create Boolean XOR")
     FreeCADGui.addModule("BOPTools.SplitFeatures")
-    FreeCADGui.doCommand("j = BOPTools.SplitFeatures.makeXOR(name= '{name}')".format(name= name))
+    FreeCADGui.doCommand("j = BOPTools.SplitFeatures.makeXOR(name='{name}')".format(name=name))
     FreeCADGui.doCommand("j.Objects = {sel}".format(
        sel= "["  +  ", ".join(["App.ActiveDocument."+so.Object.Name for so in sel])  +  "]"
        ))
@@ -442,11 +498,15 @@ def cmdCreateXORFeature(name):
     except Exception as err:
         mb = QtGui.QMessageBox()
         mb.setIcon(mb.Icon.Warning)
-        mb.setText(_translate("Part_SplitFeatures","Computing the result failed with an error: \n\n{err}\n\nClick 'Continue' to create the feature anyway, or 'Abort' to cancel.", None)
-                   .format(err= str(err)))
+        mb.setText(_translate("Part_SplitFeatures",
+                              "Computing the result failed with an error:\n\n"
+                              "{err}\n\n"
+                              "Click 'Continue' to create the feature anyway, or 'Abort' to cancel.", None)
+                   .format(err=str(err)))
         mb.setWindowTitle(_translate("Part_SplitFeatures","Bad selection", None))
         btnAbort = mb.addButton(QtGui.QMessageBox.StandardButton.Abort)
-        btnOK = mb.addButton(_translate("Part_SplitFeatures","Continue",None), QtGui.QMessageBox.ButtonRole.ActionRole)
+        btnOK = mb.addButton(_translate("Part_SplitFeatures","Continue",None),
+                             QtGui.QMessageBox.ButtonRole.ActionRole)
         mb.setDefaultButton(btnOK)
 
         mb.exec_()
@@ -460,21 +520,30 @@ def cmdCreateXORFeature(name):
 
     FreeCAD.ActiveDocument.commitTransaction()
 
+
 class CommandXOR:
-    "Command to create XOR feature"
+    """Command to create XOR feature."""
+
     def GetResources(self):
-        return {'Pixmap'  : getIconPath("Part_XOR.svg"),
+        return {'Pixmap': getIconPath("Part_XOR.svg"),
                 'MenuText': QtCore.QT_TRANSLATE_NOOP("Part_SplitFeatures","Boolean XOR"),
                 'Accel': "",
-                'ToolTip': QtCore.QT_TRANSLATE_NOOP("Part_SplitFeatures","Remove intersection fragments")}
+                'ToolTip': QtCore.QT_TRANSLATE_NOOP("Part_SplitFeatures",
+                                                    "Perform an 'exclusive OR' boolean operation with two or more selected objects,\n"
+                                                    "or with the shapes inside a compound.\n"
+                                                    "This means the overlapping volumes of the shapes will be removed.\n"
+                                                    "A 'Compound Filter' can be used to extract the remaining pieces.")}
 
     def Activated(self):
-        if len(FreeCADGui.Selection.getSelectionEx()) >= 1 :
-            cmdCreateXORFeature(name= "XOR")
+        if len(FreeCADGui.Selection.getSelectionEx()) >= 1:
+            cmdCreateXORFeature(name="XOR")
         else:
             mb = QtGui.QMessageBox()
             mb.setIcon(mb.Icon.Warning)
-            mb.setText(_translate("Part_SplitFeatures", "Select at least two objects, or one or more compounds, first! If only one compound is selected, the compounded shapes will be intersected between each other (otherwise, compounds with self-intersections are invalid).", None))
+            mb.setText(_translate("Part_SplitFeatures",
+                                  "Select at least two objects, or one or more compounds. "
+                                  "If only one compound is selected, the compounded shapes will be intersected between each other "
+                                  "(otherwise, compounds with self-intersections are invalid).", None))
             mb.setWindowTitle(_translate("Part_SplitFeatures","Bad selection", None))
             mb.exec_()
 
@@ -484,7 +553,7 @@ class CommandXOR:
         else:
             return False
 
-# -------------------------- /XOR --------------------------------------------------
+# -------------------------- /XOR ---------------------------------------------
 
 def addCommands():
     FreeCADGui.addCommand('Part_BooleanFragments',CommandBooleanFragments())

--- a/src/Mod/Part/CompoundTools/CompoundFilter.py
+++ b/src/Mod/Part/CompoundTools/CompoundFilter.py
@@ -34,7 +34,8 @@ import sys
 if sys.version_info.major >= 3:
     xrange = range
 
-# OCC's Precision::Confusion; should have taken this from FreeCAD but haven't found; unlikely to ever change (DeepSOIC)
+# OCC's Precision::Confusion; should have taken this from FreeCAD
+# but haven't found; unlikely to ever change (DeepSOIC)
 DistConfusion = 1e-7
 ParaConfusion = 1e-8
 
@@ -54,38 +55,55 @@ def makeCompoundFilter(name, into_group = None):
 
 
 class _CompoundFilter:
-    "The CompoundFilter object"
+    """The CompoundFilter object."""
+
     def __init__(self, obj):
         obj.addProperty("App::PropertyLink", "Base", "CompoundFilter", "Compound to be filtered")
 
-        obj.addProperty("App::PropertyEnumeration", "FilterType", "CompoundFilter", "")
-        obj.FilterType = ['bypass', 'specific items', 'collision-pass', 'window-volume', 'window-area', 'window-length', 'window-distance']
+        obj.addProperty("App::PropertyEnumeration",
+                        "FilterType",
+                        "CompoundFilter",
+                        "Type of filter method to use; some of these methods "
+                        "require, or are affected by, a 'Stencil' object.")
+        obj.FilterType = ['bypass', 'specific items', 'collision-pass',
+                          'window-volume', 'window-area', 'window-length',
+                          'window-distance']
         obj.FilterType = 'bypass'
 
         # properties controlling "specific items" mode
-        obj.addProperty("App::PropertyString", "items", "CompoundFilter", "list of indexes of childs to be returned (like this: 1;4;8:10).")
+        obj.addProperty("App::PropertyString", "items", "CompoundFilter",
+                        "Indices of the pieces to be returned.\n"
+                        "These are numbers separated by a semicolon, '1;3;5'.\n"
+                        "A range can also be provided using a colon, '1;4;8:10'.")
 
-        obj.addProperty("App::PropertyLink", "Stencil", "CompoundFilter", "Object that defines filtering")
+        obj.addProperty("App::PropertyLink", "Stencil", "CompoundFilter",
+                        "Object that defines filtering")
 
-        obj.addProperty("App::PropertyFloat", "WindowFrom", "CompoundFilter", "Value of threshold, expressed as a percentage of maximum value.")
+        obj.addProperty("App::PropertyFloat", "WindowFrom", "CompoundFilter",
+                        "Value of threshold, expressed as a percentage of maximum value.")
         obj.WindowFrom = 80.0
-        obj.addProperty("App::PropertyFloat", "WindowTo", "CompoundFilter", "Value of threshold, expressed as a percentage of maximum value.")
+        obj.addProperty("App::PropertyFloat", "WindowTo", "CompoundFilter",
+                        "Value of threshold, expressed as a percentage of maximum value.")
         obj.WindowTo = 100.0
 
-        obj.addProperty("App::PropertyFloat", "OverrideMaxVal", "CompoundFilter", "Volume threshold, expressed as percentage of the volume of largest child")
+        obj.addProperty("App::PropertyFloat", "OverrideMaxVal", "CompoundFilter",
+                        "Volume threshold, expressed as percentage of the volume of largest child")
         obj.OverrideMaxVal = 0
 
-        obj.addProperty("App::PropertyBool", "Invert", "CompoundFilter", "Output shapes that are rejected by filter, instead")
+        obj.addProperty("App::PropertyBool", "Invert", "CompoundFilter",
+                        "Output shapes that are rejected by the filter, instead")
         obj.Invert = False
 
         self.Type = "CompoundFilter"
         obj.Proxy = self
 
     def execute(self, obj):
-        # When operating on the object, it is to be treated as a lattice object. If False, treat as a regular shape.'''
+        # When operating on the object, it is to be treated as a lattice object.
+        # If False, treat as a regular shape.
         if hasattr(obj, "isLattice"):
             if 'On' in obj.isLattice:
-                print(obj.Name + " A generic shape is expected, but an array of placements was supplied. It will be treated as a generic shape.\n")
+                print(obj.Name + " A generic shape is expected, but an array of placements was supplied. "
+                      "It will be treated as a generic shape.\n")
 
         rst = []  # variable to receive the final list of shapes
         shps = obj.Base.Shape.childShapes()
@@ -94,16 +112,28 @@ class _CompoundFilter:
         elif obj.FilterType == 'specific items':
             rst = []
             flags = [False] * len(shps)
+            if not obj.items:
+                raise ValueError("The 'items' property must have a number to use this filter: '{}'".format(obj.FilterType))
             ranges = obj.items.split(';')
             for r in ranges:
                 r_v = r.split(':')
                 if len(r_v) == 1:
-                    i = int(r_v[0])
-                    rst.append(shps[i])
+                    try:
+                        i = int(r_v[0])
+                    except ValueError:
+                        raise ValueError("Make sure the 'item' does not have spaces; "
+                                         "a semicolon (;) can only appear between two numbers; "
+                                         "filter: '{}'".format(obj.FilterType))
+                    try:
+                        rst.append(shps[i])
+                    except IndexError:
+                        raise ValueError("Item index '{}' is out of range for this filter: '{}'".format(i, obj.FilterType))
                     flags[i] = True
                 elif len(r_v) == 2 or len(r_v) == 3:
                     if len(r_v) == 2:
-                        r_v.append("")  # fix issue #1: instead of checking length here and there, simply add the missing field =) (DeepSOIC)
+                        # fix issue #1: instead of checking length
+                        # here and there, simply add the missing field =) (DeepSOIC)
+                        r_v.append("")
                     ifrom = None if len(r_v[0].strip()) == 0 else int(r_v[0])
                     ito = None if len(r_v[1].strip()) == 0 else int(r_v[1])
                     istep = None if len(r_v[2].strip()) == 0 else int(r_v[2])
@@ -111,19 +141,23 @@ class _CompoundFilter:
                     for b in flags[ifrom:ito:istep]:
                         b = True
                 else:
-                    raise ValueError('index range cannot be parsed:' + r)
+                    raise ValueError("index range cannot be parsed: '{}'".format(r))
             if obj.Invert:
                 rst = []
                 for i in xrange(0, len(shps)):
                     if not flags[i]:
                         rst.append(shps[i])
         elif obj.FilterType == 'collision-pass':
+            if not obj.Stencil:
+                raise ValueError("A 'Stencil' object must be set to use this filter: '{}'".format(obj.FilterType))
+
             stencil = obj.Stencil.Shape
             for s in shps:
                 d = s.distToShape(stencil)
                 if bool(d[0] < DistConfusion) ^ bool(obj.Invert):
                     rst.append(s)
-        elif obj.FilterType == 'window-volume' or obj.FilterType == 'window-area' or obj.FilterType == 'window-length' or obj.FilterType == 'window-distance':
+        elif obj.FilterType in ('window-volume', 'window-area',
+                                'window-length', 'window-distance'):
             vals = [0.0] * len(shps)
             for i in xrange(0, len(shps)):
                 if obj.FilterType == 'window-volume':
@@ -133,6 +167,8 @@ class _CompoundFilter:
                 elif obj.FilterType == 'window-length':
                     vals[i] = shps[i].Length
                 elif obj.FilterType == 'window-distance':
+                    if not obj.Stencil:
+                        raise ValueError("A 'Stencil' object must be set to use this filter: '{}'".format(obj.FilterType))
                     vals[i] = shps[i].distToShape(obj.Stencil.Shape)[0]
 
             maxval = max(vals)
@@ -153,7 +189,7 @@ class _CompoundFilter:
                 if bool(vals[i] >= valFrom and vals[i] <= valTo) ^ obj.Invert:
                     rst.append(shps[i])
         else:
-            raise ValueError('Filter mode not implemented:' + obj.FilterType)
+            raise ValueError("Filter mode not implemented: '{}'".format(obj.FilterType))
 
         if len(rst) == 0:
             scale = 1.0
@@ -163,7 +199,9 @@ class _CompoundFilter:
                 scale = 1.0
             print(scale)
             obj.Shape = getNullShapeShape(scale)
-            raise ValueError('Nothing passes through the filter')  # Feeding empty compounds to FreeCAD seems to cause rendering issues, otherwise it would have been a good idea to output nothing.
+            # Feeding empty compounds to FreeCAD seems to cause rendering issues,
+            # otherwise it would have been a good idea to output nothing.
+            raise ValueError('Nothing passes through the filter')
 
         if len(rst) > 1:
             obj.Shape = Part.makeCompound(rst)
@@ -177,11 +215,15 @@ class _CompoundFilter:
 
 
 class _ViewProviderCompoundFilter:
-    "A View Provider for the CompoundFilter object"
+    """A View Provider for the CompoundFilter object."""
 
     def __init__(self, vobj):
         vobj.Proxy = self
-        vobj.addProperty("App::PropertyBool", "DontUnhideOnDelete", "CompoundFilter", "When this object is deleted, Base and Stencil are unhidden. This flag stops it from happening.")
+        vobj.addProperty("App::PropertyBool",
+                         "DontUnhideOnDelete",
+                         "CompoundFilter",
+                         "When this object is deleted, Base and Stencil are unhidden. "
+                         "This flag stops it from happening.")
         vobj.setEditorMode("DontUnhideOnDelete", 2)  # set hidden
 
     def getIcon(self):
@@ -203,7 +245,8 @@ class _ViewProviderCompoundFilter:
             children.append(self.Object.Stencil)
         return children
 
-    def onDelete(self, feature, subelements):  # subelements is a tuple of strings
+    def onDelete(self, feature, subelements):
+        """subelements is a tuple of strings."""
         if not self.ViewObject.DontUnhideOnDelete:
             try:
                 if self.Object.Base:
@@ -221,23 +264,35 @@ class _ViewProviderCompoundFilter:
         return True
 
 
-# helper
 def getNullShapeShape(scale=1.0):
-    """obtains a shape intended ad a placeholder in case null shape was produced by an operation"""
-
+    """Obtains a shape intended as a placeholder in case null shape was produced by an operation"""
     # read shape from file, if not done this before
+
     global _nullShapeShape
-    if not _nullShapeShape:
+    try:
+        # TODO: check this, and possibly remove this code
+        # vocx: this doesn't work at all.
+        # What is `empty-shape.brep`? An empty shape that is imported
+        # from a BREP file? Why do we need it? What does it contain?
+        # It does not even exist.
+        # The simplest way to return a `Null` shape is with `Part.Shape`.
+        if not _nullShapeShape:
+            _nullShapeShape = Part.Shape()
+            import os
+            shapePath = os.path.join(os.path.dirname(__file__),
+                                     "shapes", "empty-shape.brep")
+            f = open(shapePath)
+            _nullShapeShape.importBrep(f)
+            f.close()
+    except NameError:
         _nullShapeShape = Part.Shape()
-        import os
-        shapePath = os.path.dirname(__file__) + os.path.sep + "shapes" + os.path.sep + "empty-shape.brep"
-        f = open(shapePath)
-        _nullShapeShape.importBrep(f)
-        f.close()
 
     # scale the shape
     ret = _nullShapeShape
     if scale != 1.0:
         ret = _nullShapeShape.copy()
+
+        # In the past the software would crash trying to scale a Null shape
         ret.scale(scale)
 
+    return ret

--- a/src/Mod/Part/CompoundTools/Explode.py
+++ b/src/Mod/Part/CompoundTools/Explode.py
@@ -23,3 +23,4 @@ def explodeCompound(compound_obj, b_group = None):
         cf.ViewObject.DontUnhideOnDelete = True
         features_created.append(cf)
     return (group, features_created)
+

--- a/src/Mod/Part/CompoundTools/_CommandCompoundFilter.py
+++ b/src/Mod/Part/CompoundTools/_CommandCompoundFilter.py
@@ -56,7 +56,13 @@ class _CommandCompoundFilter:
         return {'Pixmap': "Part_CompoundFilter",
                 'MenuText': QtCore.QT_TRANSLATE_NOOP("Part_CompoundFilter", "Compound Filter"),
                 'Accel': "",
-                'ToolTip': QtCore.QT_TRANSLATE_NOOP("Part_CompoundFilter", "Compound Filter: remove some childs from a compound")}
+                'ToolTip': QtCore.QT_TRANSLATE_NOOP("Part_CompoundFilter",
+                                                    "Filter out objects from a selected compound "
+                                                    "by characteristics like volume,\n"
+                                                    "area, or length, or by choosing specific items.\n"
+                                                    "If a second object is selected, it will be used "
+                                                    "as reference, for example,\n"
+                                                    "for collision or distance filtering.")}
 
     def Activated(self):
         if len(FreeCADGui.Selection.getSelection()) == 1 or len(FreeCADGui.Selection.getSelection()) == 2:
@@ -64,7 +70,10 @@ class _CommandCompoundFilter:
         else:
             mb = QtGui.QMessageBox()
             mb.setIcon(mb.Icon.Warning)
-            mb.setText(_translate("Part_CompoundFilter", "Select a shape that is a compound, first! Second selected item (optional) will be treated as a stencil.", None))
+            mb.setText(_translate("Part_CompoundFilter",
+                                  "First select a shape that is a compound. "
+                                  "If a second object is selected (optional) "
+                                  "it will be treated as a stencil.", None))
             mb.setWindowTitle(_translate("Part_CompoundFilter", "Bad selection", None))
             mb.exec_()
 

--- a/src/Mod/Part/CompoundTools/_CommandExplodeCompound.py
+++ b/src/Mod/Part/CompoundTools/_CommandExplodeCompound.py
@@ -55,7 +55,9 @@ class _CommandExplodeCompound:
         return {'Pixmap': "Part_ExplodeCompound",
                 'MenuText': QtCore.QT_TRANSLATE_NOOP("Part_ExplodeCompound", "Explode compound"),
                 'Accel': "",
-                'ToolTip': QtCore.QT_TRANSLATE_NOOP("Part_ExplodeCompound", "Explode compound: split up a list of shapes into separate objects")}
+                'ToolTip': QtCore.QT_TRANSLATE_NOOP("Part_ExplodeCompound",
+                                                    "Split up a compound of shapes into separate objects.\n"
+                                                    "It will create a 'Compound Filter' for each shape.")}
 
     def Activated(self):
         if len(FreeCADGui.Selection.getSelection()) == 1:
@@ -63,7 +65,7 @@ class _CommandExplodeCompound:
         else:
             mb = QtGui.QMessageBox()
             mb.setIcon(mb.Icon.Warning)
-            mb.setText(_translate("Part_ExplodeCompound", "Select a shape that is a compound, first!", None))
+            mb.setText(_translate("Part_ExplodeCompound", "First select a shape that is a compound.", None))
             mb.setWindowTitle(_translate("Part_ExplodeCompound", "Bad selection", None))
             mb.exec_()
 

--- a/src/Mod/Part/Gui/Resources/icons/booleans/Part_CompoundFilter.svg
+++ b/src/Mod/Part/Gui/Resources/icons/booleans/Part_CompoundFilter.svg
@@ -1,6 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-
 <svg
    xmlns:dc="http://purl.org/dc/elements/1.1/"
    xmlns:cc="http://creativecommons.org/ns#"
@@ -8,86 +6,285 @@
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="64px"
-   height="64px"
-   id="svg2568"
-   sodipodi:version="0.32"
-   inkscape:version="0.48.4 r9939"
-   sodipodi:docname="Part_CompoundFilter.svg"
-   inkscape:output_extension="org.inkscape.output.svg.inkscape"
    version="1.1"
-   inkscape:export-filename="/home/user/Downloads/cad/mystuff/icons/Part/mystuff/Part_Compound_5_32px.png"
-   inkscape:export-xdpi="45"
-   inkscape:export-ydpi="45">
+   id="svg2568"
+   height="64px"
+   width="64px">
+  <title
+     id="title895">Part_CompoundFilter</title>
   <defs
      id="defs2570">
     <linearGradient
        id="linearGradient3864">
       <stop
-         id="stop3866"
+         style="stop-color:#71b2f8;stop-opacity:1;"
          offset="0"
-         style="stop-color:#71b2f8;stop-opacity:1;" />
+         id="stop3866" />
       <stop
-         id="stop3868"
+         style="stop-color:#002795;stop-opacity:1;"
          offset="1"
-         style="stop-color:#002795;stop-opacity:1;" />
+         id="stop3868" />
     </linearGradient>
-    <inkscape:perspective
-       sodipodi:type="inkscape:persp3d"
-       inkscape:vp_x="0 : 32 : 1"
-       inkscape:vp_y="0 : 1000 : 0"
-       inkscape:vp_z="64 : 32 : 1"
-       inkscape:persp3d-origin="32 : 21.333333 : 1"
-       id="perspective2576" />
     <linearGradient
        id="linearGradient3377">
       <stop
-         id="stop3379"
+         style="stop-color:#71b2f8;stop-opacity:1;"
          offset="0"
-         style="stop-color:#71b2f8;stop-opacity:1;" />
+         id="stop3379" />
       <stop
-         id="stop3381"
+         style="stop-color:#002795;stop-opacity:1;"
          offset="1"
-         style="stop-color:#002795;stop-opacity:1;" />
+         id="stop3381" />
     </linearGradient>
     <linearGradient
        id="linearGradient3023">
       <stop
-         id="stop3025"
+         style="stop-color:#71b2f8;stop-opacity:1;"
          offset="0"
-         style="stop-color:#71b2f8;stop-opacity:1;" />
+         id="stop3025" />
       <stop
-         id="stop3027"
+         style="stop-color:#002795;stop-opacity:1;"
          offset="1"
-         style="stop-color:#002795;stop-opacity:1;" />
+         id="stop3027" />
     </linearGradient>
     <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3377"
+       gradientUnits="userSpaceOnUse"
+       r="19.467436"
+       fy="28.869568"
+       fx="45.883327"
+       cy="28.869568"
+       cx="45.883327"
        id="radialGradient3692"
+       xlink:href="#linearGradient3377" />
+    <linearGradient
+       id="linearGradient3030">
+      <stop
+         style="stop-color:#71b2f8;stop-opacity:1;"
+         offset="0"
+         id="stop3032" />
+      <stop
+         style="stop-color:#002795;stop-opacity:1;"
+         offset="1"
+         id="stop3034" />
+    </linearGradient>
+    <radialGradient
+       r="19.467436"
+       fy="81.869568"
+       fx="148.88333"
+       cy="81.869568"
+       cx="148.88333"
+       gradientTransform="matrix(0.98773287,-0.06324662,0.02642229,1.230404,-216.68819,-80.013158)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3837"
+       xlink:href="#linearGradient3377" />
+    <radialGradient
+       r="19.467436"
+       fy="97.369568"
+       fx="135.38333"
+       cy="97.369568"
+       cx="135.38333"
+       gradientTransform="matrix(0.69474204,0.27707782,-0.32964185,2.4645588,-139.05338,-247.09727)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3839"
+       xlink:href="#linearGradient3377" />
+    <radialGradient
+       r="19.467436"
+       fy="28.869568"
+       fx="45.883327"
+       cy="28.869568"
+       cx="45.883327"
+       gradientTransform="matrix(0.71303129,0,0,1.2312496,-173.62652,-89.498759)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3841"
+       xlink:href="#linearGradient3377" />
+    <linearGradient
+       id="linearGradient3794">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop3796" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop3798" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(0,-4)"
+       xlink:href="#linearGradient3767"
+       id="linearGradient3773"
+       x1="22.116516"
+       y1="55.717518"
+       x2="17.328547"
+       y2="21.31134"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3767">
+      <stop
+         style="stop-color:#3465a4;stop-opacity:1"
+         offset="0"
+         id="stop3769" />
+      <stop
+         style="stop-color:#729fcf;stop-opacity:1"
+         offset="1"
+         id="stop3771" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(0,-4)"
+       xlink:href="#linearGradient3777"
+       id="linearGradient3783"
+       x1="53.896763"
+       y1="51.179787"
+       x2="47.502235"
+       y2="21.83742"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3777">
+      <stop
+         style="stop-color:#204a87;stop-opacity:1"
+         offset="0"
+         id="stop3779" />
+      <stop
+         style="stop-color:#3465a4;stop-opacity:1"
+         offset="1"
+         id="stop3781" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#linearGradient3794"
+       id="radialGradient3800"
+       cx="1"
+       cy="45"
+       fx="1"
+       fy="45"
+       r="41"
+       gradientTransform="matrix(0.93348213,-2.2905276e-8,0,0.28687573,0.06651751,32.090592)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       gradientTransform="matrix(0.54576533,0,0,1,0.478854,-2.5327864)"
+       xlink:href="#linearGradient3777"
+       id="linearGradient3783-3"
+       x1="52.258991"
+       y1="44.532787"
+       x2="46.762123"
+       y2="27.532787"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       gradientTransform="matrix(0.54576533,0,0,1,-13.236968,4.1776016)"
+       xlink:href="#linearGradient3777"
+       id="linearGradient3783-3-3"
+       x1="37.079983"
+       y1="43.822399"
+       x2="48.247574"
+       y2="30.922165"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="48.5"
+       x2="29.084745"
+       y1="52.5"
+       x1="33"
+       id="linearGradient845"
+       xlink:href="#linearGradient3777" />
+    <radialGradient
+       xlink:href="#linearGradient3864"
+       id="radialGradient3692-0"
        cx="45.883327"
        cy="28.869568"
        fx="45.883327"
        fy="28.869568"
        r="19.467436"
        gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       xlink:href="#linearGradient3864"
+       id="radialGradient3837-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.98773287,-0.06324662,0.02642229,1.230404,-216.68819,-80.013158)"
+       cx="148.88333"
+       cy="81.869568"
+       fx="148.88333"
+       fy="81.869568"
+       r="19.467436" />
+    <radialGradient
+       xlink:href="#linearGradient3864"
+       id="radialGradient3839-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.69474204,0.27707782,-0.32964185,2.4645588,-139.05338,-247.09727)"
+       cx="135.38333"
+       cy="97.369568"
+       fx="135.38333"
+       fy="97.369568"
+       r="19.467436" />
+    <radialGradient
+       xlink:href="#linearGradient3864"
+       id="radialGradient3841-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.71303129,0,0,1.2312496,-173.62652,-89.498759)"
+       cx="45.883327"
+       cy="28.869568"
+       fx="45.883327"
+       fy="28.869568"
+       r="19.467436" />
+    <radialGradient
+       xlink:href="#linearGradient3864"
+       id="radialGradient3804-2"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.98773287,-0.06324662,0.02642229,1.230404,-216.68819,-80.013158)"
+       cx="148.88333"
+       cy="81.869568"
+       fx="148.88333"
+       fy="81.869568"
+       r="19.467436" />
+    <radialGradient
+       xlink:href="#linearGradient3864"
+       id="radialGradient3806-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.69474204,0.27707782,-0.32964185,2.4645588,-139.05338,-247.09727)"
+       cx="135.38333"
+       cy="97.369568"
+       fx="135.38333"
+       fy="97.369568"
+       r="19.467436" />
+    <radialGradient
+       xlink:href="#linearGradient3864"
+       id="radialGradient3808-1"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.71303129,0,0,1.2312496,-173.62652,-89.498759)"
+       cx="45.883327"
+       cy="28.869568"
+       fx="45.883327"
+       fy="28.869568"
+       r="19.467436" />
     <linearGradient
-       id="linearGradient3030">
+       xlink:href="#linearGradient4287"
+       id="linearGradient4293"
+       x1="25.559771"
+       y1="48.403759"
+       x2="31.477535"
+       y2="52.710686"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient4287">
       <stop
-         id="stop3032"
+         id="stop4289"
          offset="0"
-         style="stop-color:#71b2f8;stop-opacity:1;" />
+         style="stop-color:#f87c71;stop-opacity:1;" />
       <stop
-         id="stop3034"
+         id="stop4291"
          offset="1"
-         style="stop-color:#002795;stop-opacity:1;" />
+         style="stop-color:#ff0000;stop-opacity:1;" />
     </linearGradient>
     <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3377"
-       id="radialGradient3837"
+       xlink:href="#linearGradient4287"
+       id="radialGradient4285"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.54355955,-0.69959567,1.0924249,-0.61410558,95.667642,203.16161)"
+       cx="112.7718"
+       cy="66.255531"
+       fx="112.7718"
+       fy="66.255531"
+       r="19.467436" />
+    <radialGradient
+       xlink:href="#linearGradient3864"
+       id="radialGradient3098"
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(0.98773287,-0.06324662,0.02642229,1.230404,-216.68819,-80.013158)"
        cx="148.88333"
@@ -96,9 +293,8 @@
        fy="81.869568"
        r="19.467436" />
     <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3377"
-       id="radialGradient3839"
+       xlink:href="#linearGradient3864"
+       id="radialGradient3100"
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(0.69474204,0.27707782,-0.32964185,2.4645588,-139.05338,-247.09727)"
        cx="135.38333"
@@ -107,9 +303,8 @@
        fy="97.369568"
        r="19.467436" />
     <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3377"
-       id="radialGradient3841"
+       xlink:href="#linearGradient3864"
+       id="radialGradient3102"
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(0.71303129,0,0,1.2312496,-173.62652,-89.498759)"
        cx="45.883327"
@@ -117,10 +312,39 @@
        fx="45.883327"
        fy="28.869568"
        r="19.467436" />
+    <linearGradient
+       xlink:href="#linearGradient3994-3"
+       id="linearGradient4000-2"
+       x1="62.000004"
+       y1="34"
+       x2="52"
+       y2="34"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect"
+       gradientTransform="matrix(0.87648555,0,0,1.1068128,0.81760416,1.3277733)" />
+    <linearGradient
+       id="linearGradient3994-3">
+      <stop
+         style="stop-color:#a40000;stop-opacity:1"
+         offset="0"
+         id="stop3996-7" />
+      <stop
+         style="stop-color:#ef2929;stop-opacity:1"
+         offset="1"
+         id="stop3998-5" />
+    </linearGradient>
     <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3377"
-       id="radialGradient3804"
+       xlink:href="#linearGradient3864"
+       id="radialGradient3692-7"
+       cx="45.883327"
+       cy="28.869568"
+       fx="45.883327"
+       fy="28.869568"
+       r="19.467436"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       xlink:href="#linearGradient3864"
+       id="radialGradient3837-5"
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(0.98773287,-0.06324662,0.02642229,1.230404,-216.68819,-80.013158)"
        cx="148.88333"
@@ -129,9 +353,8 @@
        fy="81.869568"
        r="19.467436" />
     <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3377"
-       id="radialGradient3806"
+       xlink:href="#linearGradient3864"
+       id="radialGradient3839-03"
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(0.69474204,0.27707782,-0.32964185,2.4645588,-139.05338,-247.09727)"
        cx="135.38333"
@@ -140,9 +363,8 @@
        fy="97.369568"
        r="19.467436" />
     <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3377"
-       id="radialGradient3808"
+       xlink:href="#linearGradient3864"
+       id="radialGradient3841-61"
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(0.71303129,0,0,1.2312496,-173.62652,-89.498759)"
        cx="45.883327"
@@ -150,26 +372,95 @@
        fx="45.883327"
        fy="28.869568"
        r="19.467436" />
+    <radialGradient
+       xlink:href="#linearGradient3864"
+       id="radialGradient3804-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.98773287,-0.06324662,0.02642229,1.230404,-216.68819,-80.013158)"
+       cx="148.88333"
+       cy="81.869568"
+       fx="148.88333"
+       fy="81.869568"
+       r="19.467436" />
+    <radialGradient
+       xlink:href="#linearGradient3864"
+       id="radialGradient3806-63"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.69474204,0.27707782,-0.32964185,2.4645588,-139.05338,-247.09727)"
+       cx="135.38333"
+       cy="97.369568"
+       fx="135.38333"
+       fy="97.369568"
+       r="19.467436" />
+    <radialGradient
+       xlink:href="#linearGradient3864"
+       id="radialGradient3808-2"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.71303129,0,0,1.2312496,-173.62652,-89.498759)"
+       cx="45.883327"
+       cy="28.869568"
+       fx="45.883327"
+       fy="28.869568"
+       r="19.467436" />
+    <radialGradient
+       xlink:href="#linearGradient4287"
+       id="radialGradient4285-1"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.54355955,-0.69959567,1.0924249,-0.61410558,95.667642,203.16161)"
+       cx="112.7718"
+       cy="66.255531"
+       fx="112.7718"
+       fy="66.255531"
+       r="19.467436" />
+    <radialGradient
+       xlink:href="#linearGradient3864"
+       id="radialGradient3098-5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.98773287,-0.06324662,0.02642229,1.230404,-216.68819,-80.013158)"
+       cx="148.88333"
+       cy="81.869568"
+       fx="148.88333"
+       fy="81.869568"
+       r="19.467436" />
+    <radialGradient
+       xlink:href="#linearGradient3864"
+       id="radialGradient3100-5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.69474204,0.27707782,-0.32964185,2.4645588,-139.05338,-247.09727)"
+       cx="135.38333"
+       cy="97.369568"
+       fx="135.38333"
+       fy="97.369568"
+       r="19.467436" />
+    <radialGradient
+       xlink:href="#linearGradient3864"
+       id="radialGradient3102-4"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.71303129,0,0,1.2312496,-173.62652,-89.498759)"
+       cx="45.883327"
+       cy="28.869568"
+       fx="45.883327"
+       fy="28.869568"
+       r="19.467436" />
+    <linearGradient
+       y2="21.83742"
+       x2="47.502235"
+       y1="51.179787"
+       x1="53.896763"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient1905"
+       xlink:href="#linearGradient3777" />
+    <linearGradient
+       y2="21.31134"
+       x2="17.328547"
+       y1="55.717518"
+       x1="22.116516"
+       gradientTransform="translate(0,-4)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient1907"
+       xlink:href="#linearGradient3767" />
   </defs>
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageopacity="0.0"
-     inkscape:pageshadow="2"
-     inkscape:zoom="7.7781746"
-     inkscape:cx="-30.316014"
-     inkscape:cy="34.632737"
-     inkscape:current-layer="layer1"
-     showgrid="true"
-     inkscape:document-units="px"
-     inkscape:grid-bbox="true"
-     inkscape:window-width="1920"
-     inkscape:window-height="990"
-     inkscape:window-x="-11"
-     inkscape:window-y="-11"
-     inkscape:window-maximized="1" />
   <metadata
      id="metadata2573">
     <rdf:RDF>
@@ -178,104 +469,118 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
+        <dc:title>Part_CompoundFilter</dc:title>
+        <cc:license
+           rdf:resource="http://creativecommons.org/licenses/by-sa/4.0/" />
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title>Bernd Hahnebach</dc:title>
+          </cc:Agent>
+        </dc:contributor>
+        <dc:date>2020-10-08</dc:date>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>[vocx]</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>CC-BY-SA 4.0</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title>FreeCAD</dc:title>
+          </cc:Agent>
+        </dc:publisher>
+        <dc:identifier>FreeCAD/src/Mod/Part/Gui/Resources/icons/Part_CompoundFilter.svg</dc:identifier>
+        <dc:relation>http://www.freecadweb.org/wiki/index.php?title=Artwork</dc:relation>
+        <dc:subject>
+          <rdf:Bag>
+            <rdf:li>Cube</rdf:li>
+            <rdf:li>component</rdf:li>
+            <rdf:li>funnel</rdf:li>
+          </rdf:Bag>
+        </dc:subject>
+        <dc:description>Based on the 'Part_Compound' icon, a cube is superimposed on a funnel, indicating that it is being filtered.</dc:description>
       </cc:Work>
+      <cc:License
+         rdf:about="http://creativecommons.org/licenses/by-sa/4.0/">
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Reproduction" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Distribution" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Notice" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Attribution" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#DerivativeWorks" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#ShareAlike" />
+      </cc:License>
     </rdf:RDF>
   </metadata>
   <g
-     id="layer1"
-     inkscape:label="Layer 1"
-     inkscape:groupmode="layer">
+     id="layer1">
+    <path
+       id="path1628"
+       d="m 4,27 h 6 v 6.126833 L 54,33 v -6 h 6 V 39 L 44,48 V 60 H 20 V 48 L 4,39 Z"
+       style="fill:#9b3535;fill-opacity:1;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       style="fill:#ff8080;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 10,33 h 44 v 5 L 40,46 V 60.5 H 24 V 46 L 10,38 Z"
+       id="path1926" />
     <g
-       id="g3029"
-       transform="translate(-0.25712974,3.8569461)">
-      <path
-         sodipodi:nodetypes="ccccccsssc"
-         inkscape:connector-curvature="0"
-         id="path3024"
-         d="M 8.0995866,33.144431 23.141676,43.815315 23.27024,56.414672 c 0.476565,4.113068 20.356105,3.171267 20.31325,0.514259 L 43.454925,43.94388 59.782662,32.630171 c 1.324085,-0.591322 3.447335,-3.332971 0,-4.49977 C 51.04293,25.172316 42.049495,24.538764 32.398346,24.65915 21.342168,24.797061 7.9710214,27.616141 7.9710214,27.616141 c -3.625473,1.563215 -6.5941112,2.651976 0.1285652,5.52829 z"
-         style="fill:#ff8080;stroke:none" />
-      <path
-         d="m 61.968266,30.316004 c 0,2.982185 -12.893542,5.399724 -28.798531,5.399724 -15.904989,0 -28.7985306,-2.417539 -28.7985306,-5.399724 0,-2.982186 12.8935416,-5.399725 28.7985306,-5.399725 15.904989,0 28.798531,2.417539 28.798531,5.399725 z"
-         sodipodi:ry="5.3997245"
-         sodipodi:rx="28.798531"
-         sodipodi:cy="30.316004"
-         sodipodi:cx="33.169735"
-         id="path3012"
-         style="fill:#000000;fill-opacity:0.20415225;stroke:#000000;stroke-width:1.41732287;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
-         sodipodi:type="arc" />
-      <path
-         inkscape:connector-curvature="0"
-         id="path3014"
-         d="m 61.196878,31.344523 -17.741952,12.470793 0,12.727922"
-         style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
-      <use
-         height="64"
-         width="64"
-         transform="matrix(-1,0,0,1,66.468037,0)"
-         id="use3016"
-         xlink:href="#path3014"
-         y="0"
-         x="0" />
-      <path
-         sodipodi:nodetypes="cc"
-         inkscape:connector-curvature="0"
-         id="path3018"
-         d="m 23.141676,56.157543 c 0.0046,4.178769 19.985257,4.725403 20.31325,0"
-         style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
-      <use
-         height="64"
-         width="64"
-         transform="translate(0,-12.985052)"
-         id="use3022"
-         xlink:href="#path3018"
-         y="0"
-         x="0" />
-    </g>
-    <g
-       id="g3049"
-       style="stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none"
-       transform="matrix(1.4762131,0,0,1.0076494,-1.6458556,-22.340833)">
-      <path
-         sodipodi:nodetypes="cccc"
-         inkscape:connector-curvature="0"
-         id="path3045"
-         d="m 10.351377,24.493827 -5.6980057,0 0,25.925926 5.6980057,0"
-         style="fill:none;stroke:#000000;stroke-width:1.63983715;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
-      <use
-         height="64"
-         width="64"
-         transform="matrix(-1,0,0,1,47.081698,0)"
-         id="use3047"
-         xlink:href="#path3045"
-         y="0"
-         x="0"
-         style="stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none" />
-    </g>
-    <g
-       id="g3798"
-       transform="matrix(1.566393,0,0,1.566393,-35.857152,-16.961636)">
+       transform="translate(-0.51898211,0.20824558)"
+       id="g972">
       <g
-         id="g3843"
-         transform="matrix(0.57659255,0,0,0.32499812,79.277735,9.6499853)">
+         transform="matrix(0.56155482,0,0,0.56000041,15.316722,1.0813807)"
+         id="g3004-2"
+         style="stroke-width:1.41834235">
         <path
-           style="fill:url(#radialGradient3804);fill-opacity:1;fill-rule:evenodd;stroke:#000137;stroke-width:1.31598008;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-           d="m -65.878042,4.7970936 -12.866966,10.1036774 21.744289,5.108296 0.30338,44.045609 11.486763,-13.03934 0.410614,-42.3363302 z"
-           id="path3845"
-           sodipodi:nodetypes="ccccccc"
-           inkscape:connector-curvature="0" />
+           id="path2993-5"
+           d="M 3,13 37,19 61,11 31,7 Z"
+           style="fill:#729fcf;stroke:#0b1521;stroke-width:3.56647968;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1" />
         <path
-           style="fill:url(#radialGradient3806);fill-opacity:1;fill-rule:evenodd;stroke:#000137;stroke-width:1.31598008;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-           d="m -78.552461,15.155385 21.896364,4.143912 0,44.912523 -22.192265,-6.236008 0.295901,-42.820427 z"
-           id="path3847"
-           sodipodi:nodetypes="ccccc"
-           inkscape:connector-curvature="0" />
+           id="path2995-4"
+           d="M 61,11 V 47 L 37,57 V 19 Z"
+           style="fill:url(#linearGradient1905);fill-opacity:1;stroke:#0b1521;stroke-width:3.56647968;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1" />
         <path
-           style="fill:url(#radialGradient3808);fill-opacity:1;fill-rule:evenodd;stroke:#000137;stroke-width:1.31598008;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-           d="M -56.822875,19.354658 -44.896728,9.001326"
-           id="path3849"
-           inkscape:connector-curvature="0" />
+           style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1907);fill-opacity:1;fill-rule:evenodd;stroke:#0b1521;stroke-width:3.56647968;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+           d="m 3,13 34,6 V 57 L 3,51 Z"
+           id="path3825-8-7" />
+        <path
+           id="path3765-4"
+           d="M 6.5163202,16.664167 V 48.360572 L 33.494986,52.824855 V 22.021306 Z"
+           style="fill:none;stroke:#729fcf;stroke-width:3.56647968;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+        <path
+           id="path3775-4"
+           d="M 40.618066,22.021306 V 52.824855 L 57.713459,44.789146 V 15.324882 Z"
+           style="fill:none;stroke:#3465a4;stroke-width:3.56647968;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
       </g>
+      <g
+         style="stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none"
+         id="g3827-0"
+         transform="matrix(1.4922477,0,0,1.7510489,3.0560174,-38.889889)">
+        <path
+           id="path3045-7"
+           d="M 10.351377,25.636 H 4.6533713 v 16.561502 h 5.6980057"
+           style="fill:none;stroke:#ffffff;stroke-width:4.33040428;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.8565401" />
+        <path
+           style="fill:none;stroke:#000000;stroke-width:1.2372582;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           d="M 10.351377,25.636 H 4.6533713 v 16.561502 h 5.6980057"
+           id="path3825-86" />
+      </g>
+      <use
+         style="stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none"
+         height="64"
+         width="64"
+         transform="matrix(-1,0,0,1,65,-0.39756403)"
+         id="use3831-8"
+         xlink:href="#g3827-0"
+         y="0"
+         x="0" />
     </g>
   </g>
 </svg>

--- a/src/Mod/Part/InitGui.py
+++ b/src/Mod/Part/InitGui.py
@@ -1,40 +1,40 @@
-# Part gui init module
-# (c) 2003 Juergen Riegel
-#
-# Gathering all the information to start FreeCAD
-# This is the second one of three init scripts, the third one
-# runs when the gui is up
+# ***************************************************************************
+# *   Copyright (c) 2002 Juergen Riegel <juergen.riegel@web.de>             *
+# *                                                                         *
+# *   This file is part of the FreeCAD CAx development system.              *
+# *                                                                         *
+# *   This program is free software; you can redistribute it and/or modify  *
+# *   it under the terms of the GNU Lesser General Public License (LGPL)    *
+# *   as published by the Free Software Foundation; either version 2 of     *
+# *   the License, or (at your option) any later version.                   *
+# *   for detail see the LICENCE text file.                                 *
+# *                                                                         *
+# *   FreeCAD is distributed in the hope that it will be useful,            *
+# *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+# *   GNU Lesser General Public License for more details.                   *
+# *                                                                         *
+# *   You should have received a copy of the GNU Library General Public     *
+# *   License along with FreeCAD; if not, write to the Free Software        *
+# *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
+# *   USA                                                                   *
+# *                                                                         *
+# ***************************************************************************
+"""Initialization of the Part Workbench graphical interface."""
 
-#***************************************************************************
-#*   (c) Juergen Riegel (juergen.riegel@web.de) 2002                       *
-#*                                                                         *
-#*   This file is part of the FreeCAD CAx development system.              *
-#*                                                                         *
-#*   This program is free software; you can redistribute it and/or modify  *
-#*   it under the terms of the GNU Lesser General Public License (LGPL)    *
-#*   as published by the Free Software Foundation; either version 2 of     *
-#*   the License, or (at your option) any later version.                   *
-#*   for detail see the LICENCE text file.                                 *
-#*                                                                         *
-#*   FreeCAD is distributed in the hope that it will be useful,            *
-#*   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
-#*   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
-#*   GNU Lesser General Public License for more details.                   *
-#*                                                                         *
-#*   You should have received a copy of the GNU Library General Public     *
-#*   License along with FreeCAD; if not, write to the Free Software        *
-#*   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
-#*   USA                                                                   *
-#*                                                                         *
-#*   Juergen Riegel 2002                                                   *
-#***************************************************************************/
+import FreeCAD as App
+import FreeCADGui as Gui
+import os
 
 
+class PartWorkbench(Gui.Workbench):
+    """Part workbench object."""
 
-class PartWorkbench ( Workbench ):
-    "Part workbench object"
     def __init__(self):
-        self.__class__.Icon = FreeCAD.getResourceDir() + "Mod/Part/Resources/icons/PartWorkbench.svg"
+        self.__class__.Icon = os.path.join(App.getResourceDir(),
+                                           "Mod", "Part",
+                                           "Resources", "icons",
+                                           "PartWorkbench.svg")
         self.__class__.MenuText = "Part"
         self.__class__.ToolTip = "Part workbench"
 
@@ -45,14 +45,15 @@ class PartWorkbench ( Workbench ):
         try:
             import BasicShapes.Shapes
         except ImportError as err:
-            FreeCAD.Console.PrintError("Features from BasicShapes package cannot be loaded. {err}\n".format(err= str(err)))
+            App.Console.PrintError("'BasicShapes' package cannot be loaded. "
+                                   "{err}\n".format(err=str(err)))
 
         try:
             import CompoundTools._CommandCompoundFilter
             import CompoundTools._CommandExplodeCompound
         except ImportError as err:
-            FreeCAD.Console.PrintError("Features from CompoundTools package cannot be loaded. {err}\n".format(err= str(err)))
-
+            App.Console.PrintError("'CompoundTools' package cannot be loaded. "
+                                   "{err}\n".format(err=str(err)))
 
         try:
             bop = __import__("BOPTools")
@@ -60,11 +61,13 @@ class PartWorkbench ( Workbench ):
             bop.addCommands()
             PartGui.BOPTools = bop
         except Exception as err:
-            FreeCAD.Console.PrintError("Features from BOPTools package cannot be loaded. {err}\n".format(err= str(err)))        
+            App.Console.PrintError("'BOPTools' package cannot be loaded. "
+                                   "{err}\n".format(err=str(err)))
 
     def GetClassName(self):
         return "PartGui::Workbench"
 
+
 Gui.addWorkbench(PartWorkbench())
 
-FreeCAD.__unit_test__ += [ "TestPartGui" ]
+App.__unit_test__ += ["TestPartGui"]


### PR DESCRIPTION
Several edits to the Python modules.
* Add empty line to the end of Python files.
* Clean up `InitGui.py`.
* Clean up spacing for the compound tools, `CompoundFilter`, `ExplodedCompound`, boolean tools `BooleanFragments`, `Slice to compound`, `Slice apart`, `Boolean XOR`, and join tools `JoinConnect`, `JoinEmbed`, `JoinCutout`.
* Update icon `Part_CompoundFilter.svg` to follow better our Artwork guidelines, line thickness, highlights.
* Many long lines (150 characters) are broken into smaller 80 to 100 character lines.
* Revise and clean up the docstrings of the commands, functions, and property tooltips.
* For the `CompoundFilter` object various checks are added in case the object doesn't have the correct values for the properties (`Stencil` and `items`) for a given filter (`collision-pass`, `window-distance`, `specific items`). Raise a `ValueError` in case a bad value is used.
* Fix the `getNullShapeShape` function to return a simple, empty `Part.Shape`. I'm not sure this function does anything useful, perhaps it should be removed completely.

---

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists