### PR TITLE
[Sketcher] Changes to drawing of constraint icons.

### DIFF
--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -3198,8 +3198,7 @@ void ViewProviderSketch::drawConstraintIcons()
 void ViewProviderSketch::combineConstraintIcons(IconQueue iconQueue)
 {
     // getScaleFactor gives us a ratio of pixels per some kind of real units
-    // (Translation: this number is somewhat made-up.)
-    float maxDistSquared = pow(0.05 * getScaleFactor(), 2);
+    float maxDistSquared = pow(getScaleFactor(), 2);
 
     // There's room for optimisation here; we could reuse the combined icons...
     edit->combinedConstrBoxes.clear();
@@ -3219,8 +3218,9 @@ void ViewProviderSketch::combineConstraintIcons(IconQueue iconQueue)
                 bool addedToGroup = false;
 
                 for(IconQueue::iterator j = thisGroup.begin();
-                    j != thisGroup.end(); ++j)
-                    if(i->position.equals(j->position, maxDistSquared) && (*i).type != QString::fromLatin1("small/Constraint_Symmetric_sm")) {
+                    j != thisGroup.end(); ++j) {
+                    float distSquared = pow(i->position[0]-j->position[0],2) + pow(i->position[1]-j->position[1],2);
+                    if(distSquared <= maxDistSquared && (*i).type != QString::fromLatin1("small/Constraint_Symmetric_sm")) {
                         // Found an icon in iconQueue that's close enough to
                         // a member of thisGroup, so move it into thisGroup
                         thisGroup.push_back(*i);
@@ -3228,6 +3228,7 @@ void ViewProviderSketch::combineConstraintIcons(IconQueue iconQueue)
                         addedToGroup = true;
                         break;
                     }
+                }
 
                 if(addedToGroup) {
                     if(i == iconQueue.end())
@@ -3253,17 +3254,13 @@ void ViewProviderSketch::combineConstraintIcons(IconQueue iconQueue)
 
 void ViewProviderSketch::drawMergedConstraintIcons(IconQueue iconQueue)
 {
-    SbVec3f avPos(0, 0, 0);
     for(IconQueue::iterator i = iconQueue.begin(); i != iconQueue.end(); ++i) {
         clearCoinImage(i->destination);
-        avPos = avPos + i->position;
     }
-    avPos = avPos/iconQueue.size();
 
     QImage compositeIcon;
-    float closest = FLT_MAX;  // Closest distance between avPos and any icon
-    SoImage *thisDest = 0;
-    SoInfo *thisInfo = 0;
+    SoImage *thisDest = iconQueue[0].destination;
+    SoInfo *thisInfo = iconQueue[0].infoPtr;
 
     // Tracks all constraint IDs that are combined into this icon
     QString idString;
@@ -3299,23 +3296,11 @@ void ViewProviderSketch::drawMergedConstraintIcons(IconQueue iconQueue)
             idString.append(QString::fromLatin1(","));
         idString.append(QString::number(i->constraintId));
 
-        if((avPos - i->position).length() < closest) {
-            thisDest = i->destination;
-            thisInfo = i->infoPtr;
-            closest = (avPos - i->position).length();
-        }
-
         i = iconQueue.erase(i);
         while(i != iconQueue.end()) {
             if(i->type != thisType) {
                 ++i;
                 continue;
-            }
-
-            if((avPos - i->position).length() < closest) {
-                thisDest = i->destination;
-                thisInfo = i->infoPtr;
-                closest = (avPos - i->position).length();
             }
 
             labels.append(i->label);


### PR DESCRIPTION
* Change the formula to calculate maximum distance for merging of constraint icons.
* Ignore z coordinate while calculating the distance between icons. It is irrelevant but can slightly differ between icons.
* Choose first icon from the group of nearby icons as a location of the composite icon, instead of choosing icon closest to the average position. Fixes jittering of the icon while one of the constraints is moved. See [forum thread](https://forum.freecadweb.org/viewtopic.php?f=17&t=51165) for more detailed description.

- [x] Branch rebased on latest master `git pull --rebase upstream master`
- [x] Unit tests confirmed to pass by running `./bin/FreeCAD --run-test 0`
- [x] Commit message is [well-written](https://chris.beams.io/posts/git-commit/)
- [ ] Commit message includes `issue #<id>` or `fixes #<id>` where `<id>` is the [associated MantisBT](https://freecadweb.org/wiki/tracker#GitHub_and_MantisBT) issue id if one exists
